### PR TITLE
feat(ai-agent): replace hardcoded agent list with AgentRegistry

### DIFF
--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -132,9 +132,15 @@ impl AcpAgentManager {
         workspace: String,
         config: AcpBuildExtra,
     ) -> Result<Self, AppError> {
-        let backend = config.backend;
+        let backend = config
+            .backend
+            .ok_or_else(|| AppError::BadRequest("ACP backend is required".into()))?;
+        let cli_path = config
+            .cli_path
+            .as_deref()
+            .ok_or_else(|| AppError::BadRequest("CLI path is required for ACP agent".into()))?;
 
-        let spawn_config = Self::build_spawn_config(&config.cli_path, &workspace, &config);
+        let spawn_config = Self::build_spawn_config(cli_path, &workspace, &config);
         let process = CliAgentProcess::spawn(spawn_config).await?;
 
         // Take the pre-subscribed receiver (created before background tasks start)
@@ -764,8 +770,9 @@ mod tests {
     #[test]
     fn build_spawn_config_basic() {
         let config = AcpBuildExtra {
-            backend: AcpBackend::Claude,
-            cli_path: "/usr/bin/claude".into(),
+            agent_id: None,
+            backend: Some(AcpBackend::Claude),
+            cli_path: Some("/usr/bin/claude".into()),
             custom_workspace: false,
             agent_name: None,
             custom_agent_id: None,
@@ -784,8 +791,9 @@ mod tests {
     #[test]
     fn build_spawn_config_with_agent_name() {
         let config = AcpBuildExtra {
-            backend: AcpBackend::Claude,
-            cli_path: "/usr/bin/claude".into(),
+            agent_id: None,
+            backend: Some(AcpBackend::Claude),
+            cli_path: Some("/usr/bin/claude".into()),
             custom_workspace: false,
             agent_name: Some("security-reviewer".into()),
             custom_agent_id: None,
@@ -802,8 +810,9 @@ mod tests {
     #[test]
     fn build_spawn_config_with_custom_agent_id() {
         let config = AcpBuildExtra {
-            backend: AcpBackend::Custom,
-            cli_path: "/usr/bin/custom-agent".into(),
+            agent_id: None,
+            backend: Some(AcpBackend::Custom),
+            cli_path: Some("/usr/bin/custom-agent".into()),
             custom_workspace: true,
             agent_name: None,
             custom_agent_id: Some("my-agent-123".into()),

--- a/crates/aionui-ai-agent/src/acp_routes.rs
+++ b/crates/aionui-ai-agent/src/acp_routes.rs
@@ -16,6 +16,7 @@ use aionui_common::{AgentType, AppError};
 use crate::acp_agent::AcpAgentManager;
 use crate::acp_service;
 use crate::agent_manager::AgentManagerHandle;
+use crate::agent_registry::AgentRegistry;
 use crate::task_manager::IWorkerTaskManager;
 use crate::types::{AcpModelInfo, AcpSessionConfigOption};
 
@@ -23,6 +24,7 @@ use crate::types::{AcpModelInfo, AcpSessionConfigOption};
 #[derive(Clone)]
 pub struct AcpRouterState {
     pub worker_task_manager: Arc<dyn IWorkerTaskManager>,
+    pub agent_registry: Arc<AgentRegistry>,
 }
 
 /// Build the ACP management router.
@@ -103,20 +105,22 @@ async fn detect_cli(
 }
 
 async fn list_agents(
-    State(_state): State<AcpRouterState>,
+    State(state): State<AcpRouterState>,
     Extension(_user): Extension<CurrentUser>,
 ) -> Result<Json<ApiResponse<Vec<AcpAgentInfo>>>, AppError> {
-    let agents = acp_service::get_available_agents();
-    Ok(Json(ApiResponse::ok(agents)))
+    let agents = state.agent_registry.get_all().await;
+    let infos: Vec<AcpAgentInfo> = agents.into_iter().map(Into::into).collect();
+    Ok(Json(ApiResponse::ok(infos)))
 }
 
 async fn refresh_agents(
-    State(_state): State<AcpRouterState>,
+    State(state): State<AcpRouterState>,
     Extension(_user): Extension<CurrentUser>,
 ) -> Result<Json<ApiResponse<Vec<AcpAgentInfo>>>, AppError> {
-    // Re-scan available agents (semantically a refresh of the cached list)
-    let agents = acp_service::get_available_agents();
-    Ok(Json(ApiResponse::ok(agents)))
+    state.agent_registry.refresh_builtins().await;
+    let agents = state.agent_registry.get_all().await;
+    let infos: Vec<AcpAgentInfo> = agents.into_iter().map(Into::into).collect();
+    Ok(Json(ApiResponse::ok(infos)))
 }
 
 async fn test_custom_agent(

--- a/crates/aionui-ai-agent/src/acp_service.rs
+++ b/crates/aionui-ai-agent/src/acp_service.rs
@@ -2,102 +2,14 @@ use std::collections::HashMap;
 use std::time::Instant;
 
 use aionui_api_types::{
-    AcpAgentInfo, AcpEnvResponse, AcpHealthCheckResponse, DetectCliResponse,
-    TestCustomAgentResponse,
+    AcpEnvResponse, AcpHealthCheckResponse, DetectCliResponse, TestCustomAgentResponse,
 };
 use aionui_common::{AcpBackend, AppError};
 use tracing::debug;
 
-/// Known ACP backend CLI binary names.
-///
-/// Returns the expected executable name for a given ACP backend,
-/// or `None` for backends that don't have a standalone CLI.
-fn cli_binary_name(backend: AcpBackend) -> Option<&'static str> {
-    match backend {
-        AcpBackend::Claude => Some("claude"),
-        AcpBackend::Qwen => Some("qwen"),
-        AcpBackend::Codex => Some("codex"),
-        AcpBackend::Codebuddy => Some("codebuddy"),
-        AcpBackend::Kiro => Some("kiro"),
-        AcpBackend::Opencode => Some("opencode"),
-        AcpBackend::Copilot => Some("copilot"),
-        AcpBackend::Goose => Some("goose"),
-        AcpBackend::Cursor => Some("cursor"),
-        AcpBackend::Droid => Some("droid"),
-        AcpBackend::Auggie => Some("auggie"),
-        AcpBackend::Kimi => Some("kimi"),
-        AcpBackend::Qoder => Some("qoder"),
-        AcpBackend::Vibe => Some("vibe"),
-        AcpBackend::Nanobot => Some("nanobot"),
-        AcpBackend::Hermes => Some("hermes"),
-        AcpBackend::Snow => Some("snow"),
-        // These backends don't have a direct CLI to detect
-        AcpBackend::IFlow => None,
-        AcpBackend::Gemini => None,
-        AcpBackend::OpenclawGateway => None,
-        AcpBackend::Remote => None,
-        AcpBackend::Aionrs => None,
-        AcpBackend::Custom => None,
-    }
-}
-
-/// Predefined list of known ACP agents.
-fn known_agents() -> Vec<AcpAgentInfo> {
-    vec![
-        AcpAgentInfo {
-            id: "claude".into(),
-            name: "Claude".into(),
-            backend: AcpBackend::Claude,
-            available: false,
-        },
-        AcpAgentInfo {
-            id: "codex".into(),
-            name: "Codex".into(),
-            backend: AcpBackend::Codex,
-            available: false,
-        },
-        AcpAgentInfo {
-            id: "codebuddy".into(),
-            name: "CodeBuddy".into(),
-            backend: AcpBackend::Codebuddy,
-            available: false,
-        },
-        AcpAgentInfo {
-            id: "qwen".into(),
-            name: "Qwen".into(),
-            backend: AcpBackend::Qwen,
-            available: false,
-        },
-        AcpAgentInfo {
-            id: "kiro".into(),
-            name: "Kiro".into(),
-            backend: AcpBackend::Kiro,
-            available: false,
-        },
-        AcpAgentInfo {
-            id: "opencode".into(),
-            name: "OpenCode".into(),
-            backend: AcpBackend::Opencode,
-            available: false,
-        },
-        AcpAgentInfo {
-            id: "copilot".into(),
-            name: "Copilot".into(),
-            backend: AcpBackend::Copilot,
-            available: false,
-        },
-        AcpAgentInfo {
-            id: "goose".into(),
-            name: "Goose".into(),
-            backend: AcpBackend::Goose,
-            available: false,
-        },
-    ]
-}
-
 /// Detect the CLI path for a given ACP backend using PATH lookup.
 pub fn detect_cli(backend: AcpBackend) -> DetectCliResponse {
-    let binary = match cli_binary_name(backend) {
+    let binary = match backend.cli_binary_name() {
         Some(name) => name,
         None => return DetectCliResponse { path: None },
     };
@@ -110,26 +22,13 @@ pub fn detect_cli(backend: AcpBackend) -> DetectCliResponse {
     DetectCliResponse { path }
 }
 
-/// Get the list of available ACP agents, checking CLI availability.
-pub fn get_available_agents() -> Vec<AcpAgentInfo> {
-    known_agents()
-        .into_iter()
-        .map(|mut agent| {
-            if let Some(binary) = cli_binary_name(agent.backend) {
-                agent.available = which::which(binary).is_ok();
-            }
-            agent
-        })
-        .collect()
-}
-
 /// Perform a health check for an ACP backend.
 ///
 /// Checks CLI availability and measures detection latency.
 pub fn health_check(backend: AcpBackend) -> AcpHealthCheckResponse {
     let start = Instant::now();
 
-    let binary = match cli_binary_name(backend) {
+    let binary = match backend.cli_binary_name() {
         Some(name) => name,
         None => {
             return AcpHealthCheckResponse {
@@ -185,24 +84,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cli_binary_name_known_backends() {
-        assert_eq!(cli_binary_name(AcpBackend::Claude), Some("claude"));
-        assert_eq!(cli_binary_name(AcpBackend::Qwen), Some("qwen"));
-        assert_eq!(cli_binary_name(AcpBackend::Codex), Some("codex"));
-        assert_eq!(cli_binary_name(AcpBackend::Codebuddy), Some("codebuddy"));
-        assert_eq!(cli_binary_name(AcpBackend::Kiro), Some("kiro"));
-    }
-
-    #[test]
-    fn cli_binary_name_returns_none_for_non_cli_backends() {
-        assert_eq!(cli_binary_name(AcpBackend::IFlow), None);
-        assert_eq!(cli_binary_name(AcpBackend::Gemini), None);
-        assert_eq!(cli_binary_name(AcpBackend::Custom), None);
-        assert_eq!(cli_binary_name(AcpBackend::Remote), None);
-        assert_eq!(cli_binary_name(AcpBackend::Aionrs), None);
-    }
-
-    #[test]
     fn detect_cli_non_cli_backend_returns_none() {
         let resp = detect_cli(AcpBackend::Custom);
         assert!(resp.path.is_none());
@@ -218,27 +99,7 @@ mod tests {
     #[test]
     fn get_env_returns_at_least_path() {
         let resp = get_env();
-        // PATH should generally be available in any environment
         assert!(resp.env.contains_key("PATH") || resp.env.contains_key("HOME"));
-    }
-
-    #[test]
-    fn get_available_agents_returns_known_list() {
-        let agents = get_available_agents();
-        assert!(!agents.is_empty());
-        // Claude should be in the list
-        assert!(agents.iter().any(|a| a.id == "claude"));
-    }
-
-    #[test]
-    fn known_agents_list_is_complete() {
-        let agents = known_agents();
-        let ids: Vec<&str> = agents.iter().map(|a| a.id.as_str()).collect();
-        assert!(ids.contains(&"claude"));
-        assert!(ids.contains(&"codex"));
-        assert!(ids.contains(&"codebuddy"));
-        assert!(ids.contains(&"qwen"));
-        assert!(ids.contains(&"kiro"));
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/agent_registry.rs
+++ b/crates/aionui-ai-agent/src/agent_registry.rs
@@ -1,0 +1,251 @@
+use std::collections::HashSet;
+
+use aionui_api_types::{AgentSource, DetectedAgent};
+use aionui_common::AcpBackend;
+use tokio::sync::RwLock;
+use tracing::{debug, info};
+
+pub struct AgentRegistry {
+    agents: RwLock<Vec<DetectedAgent>>,
+}
+
+impl Default for AgentRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AgentRegistry {
+    pub fn new() -> Self {
+        Self {
+            agents: RwLock::new(Vec::new()),
+        }
+    }
+
+    /// Run builtin detection + merge injected agents, then populate the registry.
+    pub async fn initialize(&self, extensions: Vec<DetectedAgent>, customs: Vec<DetectedAgent>) {
+        let internal = Self::detect_internal_agent();
+        let builtins = Self::detect_builtin_agents();
+
+        let merged = Self::merge(customs, extensions, builtins, vec![internal]);
+
+        info!(
+            count = merged.len(),
+            names = %merged.iter().map(|a| a.name.as_str()).collect::<Vec<_>>().join(", "),
+            "Agent registry initialized"
+        );
+
+        *self.agents.write().await = merged;
+    }
+
+    pub async fn get_all(&self) -> Vec<DetectedAgent> {
+        self.agents.read().await.clone()
+    }
+
+    pub async fn get_by_id(&self, id: &str) -> Option<DetectedAgent> {
+        self.agents.read().await.iter().find(|a| a.id == id).cloned()
+    }
+
+    /// Re-scan builtin agents only (PATH may have changed).
+    pub async fn refresh_builtins(&self) {
+        let mut agents = self.agents.write().await;
+        agents.retain(|a| a.source != AgentSource::Builtin);
+        let builtins = Self::detect_builtin_agents();
+        let mut merged = std::mem::take(&mut *agents);
+        merged.extend(builtins);
+        *agents = Self::deduplicate(merged);
+    }
+
+    /// Replace extension-contributed agents.
+    pub async fn refresh_extensions(&self, extensions: Vec<DetectedAgent>) {
+        let mut agents = self.agents.write().await;
+        agents.retain(|a| a.source != AgentSource::Extension);
+        let mut merged = std::mem::take(&mut *agents);
+        merged.extend(extensions);
+        *agents = Self::deduplicate(merged);
+    }
+
+    /// Replace custom agents.
+    pub async fn refresh_customs(&self, customs: Vec<DetectedAgent>) {
+        let mut agents = self.agents.write().await;
+        agents.retain(|a| a.source != AgentSource::Custom);
+        let mut merged = std::mem::take(&mut *agents);
+        merged.extend(customs);
+        *agents = Self::deduplicate(merged);
+    }
+
+    fn detect_internal_agent() -> DetectedAgent {
+        DetectedAgent {
+            id: AcpBackend::Aionrs.id(),
+            name: "Aion CLI".into(),
+            backend: AcpBackend::Aionrs,
+            available: true,
+            source: AgentSource::Internal,
+            command: None,
+            args: vec![],
+            env: vec![],
+        }
+    }
+
+    fn detect_builtin_agents() -> Vec<DetectedAgent> {
+        AcpBackend::CLI_BACKENDS
+            .iter()
+            .filter_map(|&backend| {
+                let binary = backend.cli_binary_name()?;
+                let path = which::which(binary).ok()?;
+                let command = path.to_string_lossy().into_owned();
+
+                debug!(backend = ?backend, %command, "Detected builtin agent");
+
+                Some(DetectedAgent {
+                    id: backend.id(),
+                    name: backend.display_name().into(),
+                    backend,
+                    available: true,
+                    source: AgentSource::Builtin,
+                    command: Some(command),
+                    args: vec![],
+                    env: vec![],
+                })
+            })
+            .collect()
+    }
+
+    /// Merge all sources with priority: Custom > Extension > Builtin > Internal.
+    fn merge(
+        customs: Vec<DetectedAgent>,
+        extensions: Vec<DetectedAgent>,
+        builtins: Vec<DetectedAgent>,
+        internals: Vec<DetectedAgent>,
+    ) -> Vec<DetectedAgent> {
+        let mut all = Vec::new();
+        all.extend(customs);
+        all.extend(extensions);
+        all.extend(builtins);
+        all.extend(internals);
+        Self::deduplicate(all)
+    }
+
+    /// Deduplicate agents. First occurrence wins (priority order preserved by caller).
+    /// Custom and Extension agents use their `id` as dedup key (multiple custom agents
+    /// can share the same backend). Builtin/Internal dedup by backend.
+    fn deduplicate(agents: Vec<DetectedAgent>) -> Vec<DetectedAgent> {
+        let mut seen = HashSet::new();
+        let mut result = Vec::new();
+        for agent in agents {
+            let key = match agent.source {
+                AgentSource::Custom | AgentSource::Extension => agent.id.clone(),
+                _ => format!("{:?}", agent.backend),
+            };
+            if seen.insert(key) {
+                result.push(agent);
+            }
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_agent(id: &str, backend: AcpBackend, source: AgentSource) -> DetectedAgent {
+        DetectedAgent {
+            id: id.into(),
+            name: id.into(),
+            backend,
+            available: true,
+            source,
+            command: None,
+            args: vec![],
+            env: vec![],
+        }
+    }
+
+    #[test]
+    fn merge_priority_custom_over_builtin() {
+        let customs = vec![make_agent(
+            "custom:claude",
+            AcpBackend::Claude,
+            AgentSource::Custom,
+        )];
+        let builtins = vec![make_agent(
+            "builtin-claude",
+            AcpBackend::Claude,
+            AgentSource::Builtin,
+        )];
+        let merged = AgentRegistry::merge(customs, vec![], builtins, vec![]);
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].source, AgentSource::Custom);
+    }
+
+    #[test]
+    fn merge_deduplicates_same_backend_builtins() {
+        let builtins = vec![
+            make_agent("a", AcpBackend::Claude, AgentSource::Builtin),
+            make_agent("b", AcpBackend::Claude, AgentSource::Builtin),
+        ];
+        let merged = AgentRegistry::merge(vec![], vec![], builtins, vec![]);
+        let claude_count = merged
+            .iter()
+            .filter(|a| a.backend == AcpBackend::Claude && a.source == AgentSource::Builtin)
+            .count();
+        assert_eq!(claude_count, 1);
+        assert_eq!(merged[0].id, "a");
+    }
+
+    #[test]
+    fn merge_keeps_internal_at_end() {
+        let internals = vec![make_agent(
+            "aionrs",
+            AcpBackend::Aionrs,
+            AgentSource::Internal,
+        )];
+        let builtins = vec![make_agent(
+            "claude",
+            AcpBackend::Claude,
+            AgentSource::Builtin,
+        )];
+        let merged = AgentRegistry::merge(vec![], vec![], builtins, internals);
+        assert_eq!(merged.last().unwrap().source, AgentSource::Internal);
+    }
+
+    #[tokio::test]
+    async fn registry_initialize_and_get_all() {
+        let registry = AgentRegistry::new();
+        registry.initialize(vec![], vec![]).await;
+        let agents = registry.get_all().await;
+        assert!(agents.iter().any(|a| a.backend == AcpBackend::Aionrs));
+    }
+
+    #[tokio::test]
+    async fn registry_refresh_customs() {
+        let registry = AgentRegistry::new();
+        registry.initialize(vec![], vec![]).await;
+
+        let before = registry.get_all().await;
+        assert_eq!(
+            before
+                .iter()
+                .filter(|a| a.source == AgentSource::Custom)
+                .count(),
+            0
+        );
+
+        let customs = vec![make_agent(
+            "custom:test",
+            AcpBackend::Custom,
+            AgentSource::Custom,
+        )];
+        registry.refresh_customs(customs).await;
+
+        let after = registry.get_all().await;
+        assert_eq!(
+            after
+                .iter()
+                .filter(|a| a.source == AgentSource::Custom)
+                .count(),
+            1
+        );
+    }
+}

--- a/crates/aionui-ai-agent/src/factory.rs
+++ b/crates/aionui-ai-agent/src/factory.rs
@@ -5,6 +5,7 @@ use aionui_db::IRemoteAgentRepository;
 use tracing::warn;
 
 use crate::agent_manager::AgentManagerHandle;
+use crate::agent_registry::AgentRegistry;
 use crate::remote_agent::RemoteAgentConfig;
 use crate::skill_manager::AcpSkillManager;
 use crate::task_manager::AgentFactory;
@@ -22,6 +23,7 @@ pub struct AgentFactoryDeps {
     pub skill_manager: Arc<AcpSkillManager>,
     pub remote_agent_repo: Arc<dyn IRemoteAgentRepository>,
     pub encryption_key: [u8; 32],
+    pub agent_registry: Arc<AgentRegistry>,
 }
 
 /// Build a production agent factory that dispatches to concrete agent types.
@@ -53,8 +55,25 @@ async fn build_agent(
 
     match options.agent_type {
         AgentType::Acp => {
-            let config: AcpBuildExtra = serde_json::from_value(options.extra)
+            let mut config: AcpBuildExtra = serde_json::from_value(options.extra)
                 .map_err(|e| AppError::BadRequest(format!("Invalid ACP build options: {e}")))?;
+
+            if let Some(ref agent_id) = config.agent_id {
+                let detected = deps
+                    .agent_registry
+                    .get_by_id(agent_id)
+                    .await
+                    .ok_or_else(|| {
+                        AppError::BadRequest(format!("Agent '{agent_id}' not found in registry"))
+                    })?;
+                if config.backend.is_none() {
+                    config.backend = Some(detected.backend);
+                }
+                if config.cli_path.is_none() {
+                    config.cli_path = detected.command;
+                }
+            }
+
             let agent = AcpAgentManager::new(conversation_id, workspace, config).await?;
             Ok(Arc::new(agent))
         }

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -3,6 +3,7 @@ pub mod acp_agent;
 pub mod acp_routes;
 pub mod acp_service;
 pub mod agent_manager;
+pub mod agent_registry;
 pub mod aionrs_agent;
 pub mod api_client;
 pub mod auxiliary_routes;
@@ -27,6 +28,7 @@ pub mod types;
 pub use acp_agent::AcpAgentManager;
 pub use acp_routes::{AcpRouterState, acp_routes};
 pub use agent_manager::{AgentManagerHandle, IAgentManager, approval_key};
+pub use agent_registry::AgentRegistry;
 pub use aionrs_agent::AionrsAgentManager;
 pub use api_client::{
     AnthropicRotatingClient, ApiClientError, ApiKeyManager, ApiKeyStatus, ClientOptions,

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -36,10 +36,16 @@ pub struct BuildTaskOptions {
 /// ACP-specific fields extracted from `extra` in [`BuildTaskOptions`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AcpBuildExtra {
+    /// Agent registry ID. When provided, `backend`/`cli_path` are resolved
+    /// from the registry and need not be supplied by the caller.
+    #[serde(default)]
+    pub agent_id: Option<String>,
     /// ACP sub-backend identifier.
-    pub backend: AcpBackend,
-    /// Path to the CLI executable.
-    pub cli_path: String,
+    #[serde(default)]
+    pub backend: Option<AcpBackend>,
+    /// Path to the CLI executable (resolved from registry when `agent_id` is set).
+    #[serde(default)]
+    pub cli_path: Option<String>,
     /// Whether the user picked a custom workspace path.
     #[serde(default)]
     pub custom_workspace: bool,

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -48,8 +48,9 @@ async fn make_mock_agent(
     }
 
     let config = aionui_ai_agent::AcpBuildExtra {
-        backend,
-        cli_path: script_path.to_string_lossy().into_owned(),
+        agent_id: None,
+        backend: Some(backend),
+        cli_path: Some(script_path.to_string_lossy().into_owned()),
         custom_workspace: false,
         agent_name: None,
         custom_agent_id: None,

--- a/crates/aionui-api-types/src/acp.rs
+++ b/crates/aionui-api-types/src/acp.rs
@@ -17,13 +17,26 @@ pub struct DetectCliResponse {
     pub path: Option<String>,
 }
 
-/// Information about an available ACP agent.
+/// Information about an available ACP agent (public API shape).
 #[derive(Debug, Clone, Serialize)]
 pub struct AcpAgentInfo {
     pub id: String,
     pub name: String,
     pub backend: AcpBackend,
     pub available: bool,
+    pub source: crate::AgentSource,
+}
+
+impl From<crate::DetectedAgent> for AcpAgentInfo {
+    fn from(a: crate::DetectedAgent) -> Self {
+        Self {
+            id: a.id,
+            name: a.name,
+            backend: a.backend,
+            available: a.available,
+            source: a.source,
+        }
+    }
 }
 
 /// Request body for ACP health check.
@@ -130,11 +143,13 @@ mod tests {
             name: "Claude".into(),
             backend: AcpBackend::Claude,
             available: true,
+            source: crate::AgentSource::Builtin,
         };
         let json = serde_json::to_value(&info).unwrap();
         assert_eq!(json["id"], "claude");
         assert_eq!(json["backend"], "claude");
         assert_eq!(json["available"], true);
+        assert_eq!(json["source"], "builtin");
     }
 
     #[test]

--- a/crates/aionui-api-types/src/agent_discovery.rs
+++ b/crates/aionui-api-types/src/agent_discovery.rs
@@ -1,0 +1,95 @@
+use aionui_common::AcpBackend;
+use serde::{Deserialize, Serialize};
+
+/// How an agent was discovered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentSource {
+    Internal,
+    Builtin,
+    Extension,
+    Custom,
+}
+
+/// A name=value environment variable pair.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnvVar {
+    pub name: String,
+    pub value: String,
+}
+
+/// A discovered agent from any source.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DetectedAgent {
+    pub id: String,
+    pub name: String,
+    pub backend: AcpBackend,
+    pub available: bool,
+    pub source: AgentSource,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<EnvVar>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn agent_source_serde_roundtrip() {
+        let cases = [
+            (AgentSource::Internal, "internal"),
+            (AgentSource::Builtin, "builtin"),
+            (AgentSource::Extension, "extension"),
+            (AgentSource::Custom, "custom"),
+        ];
+        for (variant, expected) in cases {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, format!("\"{expected}\""));
+            let parsed: AgentSource = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, variant);
+        }
+    }
+
+    #[test]
+    fn detected_agent_serialization_skips_empty_fields() {
+        let agent = DetectedAgent {
+            id: "abc12345".into(),
+            name: "Claude".into(),
+            backend: AcpBackend::Claude,
+            available: true,
+            source: AgentSource::Builtin,
+            command: None,
+            args: vec![],
+            env: vec![],
+        };
+        let json = serde_json::to_value(&agent).unwrap();
+        assert_eq!(json["id"], "abc12345");
+        assert_eq!(json["source"], "builtin");
+        assert!(json.get("command").is_none());
+        assert!(json.get("args").is_none());
+        assert!(json.get("env").is_none());
+    }
+
+    #[test]
+    fn detected_agent_deserialization() {
+        let json = json!({
+            "id": "ext123",
+            "name": "MyAgent",
+            "backend": "claude",
+            "available": true,
+            "source": "extension",
+            "command": "/usr/bin/my-cli",
+            "env": [{"name": "FOO", "value": "bar"}]
+        });
+        let agent: DetectedAgent = serde_json::from_value(json).unwrap();
+        assert_eq!(agent.source, AgentSource::Extension);
+        assert_eq!(agent.command.as_deref(), Some("/usr/bin/my-cli"));
+        assert_eq!(agent.env.len(), 1);
+        assert_eq!(agent.env[0].name, "FOO");
+    }
+}

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -1,5 +1,6 @@
 //! All HTTP request/response DTOs shared across the API surface.
 mod acp;
+mod agent_discovery;
 mod auth;
 mod channel;
 mod confirmation;
@@ -25,6 +26,7 @@ pub use acp::{
     DetectCliRequest, DetectCliResponse, ProbeModelRequest, SetConfigOptionRequest, SetModeRequest,
     SetModelRequest, TestCustomAgentRequest, TestCustomAgentResponse,
 };
+pub use agent_discovery::{AgentSource, DetectedAgent, EnvVar};
 pub use auth::{
     AuthStatusResponse, ChangePasswordRequest, LoginRequest, LoginResponse, PublicUser,
     QrLoginRequest, RefreshResponse, RefreshTokenRequest, UserInfoResponse, WsTokenResponse,

--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -10,11 +10,12 @@ use sha2::{Digest, Sha256};
 use tower_http::cors::{Any, CorsLayer};
 
 use aionui_ai_agent::{
-    AcpRouterState, AcpSkillManager, AgentFactoryDeps, AuxiliaryRouterState,
+    AcpRouterState, AcpSkillManager, AgentFactoryDeps, AgentRegistry, AuxiliaryRouterState,
     ConnectionTestRouterState, ConnectionTestService, IWorkerTaskManager, RemoteAgentRouterState,
     RemoteAgentService, WorkerTaskManagerImpl, acp_routes, auxiliary_routes, build_agent_factory,
     connection_test_routes, remote_agent_routes,
 };
+use aionui_api_types::{AgentSource, DetectedAgent, EnvVar};
 use aionui_auth::{
     AuthRouterState, AuthState, CookieConfig, JwtService, QrTokenStore, auth_middleware,
     auth_routes, csrf_middleware, extract_token_from_ws_headers, resolve_jwt_secret,
@@ -23,6 +24,7 @@ use aionui_auth::{
 #[cfg(feature = "weixin")]
 use aionui_channel::weixin_login_route;
 use aionui_channel::{ChannelRouterState, channel_routes};
+use aionui_common::AcpBackend;
 use aionui_conversation::{ConversationRouterState, ConversationService, conversation_routes};
 use aionui_cron::{CronEventEmitter, CronRouterState, cron_routes};
 use aionui_db::{
@@ -99,6 +101,7 @@ pub struct AppServices {
     pub ws_manager: Arc<WebSocketManager>,
     pub event_bus: Arc<BroadcastEventBus>,
     pub worker_task_manager: Arc<dyn IWorkerTaskManager>,
+    pub agent_registry: Arc<AgentRegistry>,
     /// Raw JWT secret string, used to derive encryption keys.
     pub jwt_secret_raw: String,
     pub data_dir: String,
@@ -156,10 +159,12 @@ impl AppServices {
 
         let encryption_key = derive_encryption_key(&secret);
         let remote_agent_repo = Arc::new(SqliteRemoteAgentRepository::new(database.pool().clone()));
+        let agent_registry = Arc::new(AgentRegistry::new());
         let factory = build_agent_factory(AgentFactoryDeps {
             skill_manager: AcpSkillManager::new(),
             remote_agent_repo,
             encryption_key,
+            agent_registry: agent_registry.clone(),
         });
         let worker_task_manager: Arc<dyn IWorkerTaskManager> =
             Arc::new(WorkerTaskManagerImpl::new(factory));
@@ -173,6 +178,7 @@ impl AppServices {
             ws_manager: Arc::new(WebSocketManager::new()),
             event_bus: Arc::new(BroadcastEventBus::new(256)),
             worker_task_manager,
+            agent_registry,
             jwt_secret_raw: secret,
             data_dir,
             local,
@@ -220,9 +226,42 @@ pub struct ModuleStates {
     pub shell: ShellRouterState,
 }
 
+/// Convert extension-contributed ACP adapters into `DetectedAgent` values.
+async fn resolve_extension_agents(registry: &ExtensionRegistry) -> Vec<DetectedAgent> {
+    registry
+        .get_acp_adapters()
+        .await
+        .into_iter()
+        .filter(|a| {
+            a.connection_type
+                .as_deref()
+                .is_none_or(|ct| ct == "cli" || ct == "stdio")
+        })
+        .map(|a| DetectedAgent {
+            id: a.id,
+            name: a.name,
+            backend: AcpBackend::Custom,
+            available: true,
+            source: AgentSource::Extension,
+            command: a.default_cli_path.or(a.cli_command),
+            args: a.acp_args,
+            env: a
+                .env
+                .into_iter()
+                .map(|(k, v)| EnvVar { name: k, value: v })
+                .collect(),
+        })
+        .collect()
+}
+
 /// Build all default `ModuleStates` from application services.
 pub async fn build_module_states(services: &AppServices) -> ModuleStates {
     let (ext_state, hub_state, skill_state) = build_extension_states(services).await;
+
+    let extensions = resolve_extension_agents(&ext_state.registry).await;
+    // TODO: load custom agent configs from settings/DB and convert to DetectedAgent
+    services.agent_registry.initialize(extensions, vec![]).await;
+
     ModuleStates {
         system: build_system_state(services),
         conversation: build_conversation_state(services),
@@ -309,6 +348,7 @@ pub fn build_remote_agent_state(services: &AppServices) -> RemoteAgentRouterStat
 pub fn build_acp_state(services: &AppServices) -> AcpRouterState {
     AcpRouterState {
         worker_task_manager: services.worker_task_manager.clone(),
+        agent_registry: services.agent_registry.clone(),
     }
 }
 

--- a/crates/aionui-app/tests/acp_e2e.rs
+++ b/crates/aionui-app/tests/acp_e2e.rs
@@ -96,9 +96,8 @@ async fn list_agents_returns_array() {
     let body = body_json(resp).await;
     assert_eq!(body["success"], true);
     assert!(body["data"].is_array());
-    // Should contain at least known agents like "claude"
     let agents = body["data"].as_array().unwrap();
-    assert!(agents.iter().any(|a| a["id"] == "claude"));
+    assert!(agents.iter().any(|a| a["backend"] == "aionrs"));
 }
 
 #[tokio::test]

--- a/crates/aionui-common/src/enums.rs
+++ b/crates/aionui-common/src/enums.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::id::fnv1a_hex8;
+
 /// Type of AI agent backend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -42,6 +44,91 @@ pub enum AcpBackend {
     Remote,
     Aionrs,
     Custom,
+}
+
+impl AcpBackend {
+    /// All backends that have a detectable CLI binary.
+    pub const CLI_BACKENDS: &[AcpBackend] = &[
+        AcpBackend::Claude,
+        AcpBackend::Qwen,
+        AcpBackend::Codex,
+        AcpBackend::Codebuddy,
+        AcpBackend::Kiro,
+        AcpBackend::Opencode,
+        AcpBackend::Copilot,
+        AcpBackend::Goose,
+        AcpBackend::Cursor,
+        AcpBackend::Droid,
+        AcpBackend::Auggie,
+        AcpBackend::Kimi,
+        AcpBackend::Qoder,
+        AcpBackend::Vibe,
+        AcpBackend::Nanobot,
+        AcpBackend::Hermes,
+        AcpBackend::Snow,
+    ];
+
+    pub fn cli_binary_name(&self) -> Option<&'static str> {
+        match self {
+            AcpBackend::Claude => Some("claude"),
+            AcpBackend::Qwen => Some("qwen"),
+            AcpBackend::Codex => Some("codex"),
+            AcpBackend::Codebuddy => Some("codebuddy"),
+            AcpBackend::Kiro => Some("kiro"),
+            AcpBackend::Opencode => Some("opencode"),
+            AcpBackend::Copilot => Some("copilot"),
+            AcpBackend::Goose => Some("goose"),
+            AcpBackend::Cursor => Some("cursor"),
+            AcpBackend::Droid => Some("droid"),
+            AcpBackend::Auggie => Some("auggie"),
+            AcpBackend::Kimi => Some("kimi"),
+            AcpBackend::Qoder => Some("qoder"),
+            AcpBackend::Vibe => Some("vibe"),
+            AcpBackend::Nanobot => Some("nanobot"),
+            AcpBackend::Hermes => Some("hermes"),
+            AcpBackend::Snow => Some("snow"),
+            AcpBackend::IFlow
+            | AcpBackend::Gemini
+            | AcpBackend::OpenclawGateway
+            | AcpBackend::Remote
+            | AcpBackend::Aionrs
+            | AcpBackend::Custom => None,
+        }
+    }
+
+    pub fn id(&self) -> String {
+        let hash = fnv1a_hex8(self.display_name().as_bytes());
+        // SAFETY: fnv1a_hex8 only produces ASCII hex digits
+        unsafe { std::str::from_utf8_unchecked(&hash) }.into()
+    }
+
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            AcpBackend::Claude => "Claude",
+            AcpBackend::Gemini => "Gemini",
+            AcpBackend::Qwen => "Qwen",
+            AcpBackend::IFlow => "iFlow",
+            AcpBackend::Codex => "Codex",
+            AcpBackend::Codebuddy => "CodeBuddy",
+            AcpBackend::Droid => "Droid",
+            AcpBackend::Goose => "Goose",
+            AcpBackend::Auggie => "Auggie",
+            AcpBackend::Kimi => "Kimi",
+            AcpBackend::Opencode => "OpenCode",
+            AcpBackend::Copilot => "Copilot",
+            AcpBackend::Qoder => "Qoder",
+            AcpBackend::OpenclawGateway => "OpenClaw Gateway",
+            AcpBackend::Vibe => "Vibe",
+            AcpBackend::Nanobot => "Nanobot",
+            AcpBackend::Cursor => "Cursor",
+            AcpBackend::Kiro => "Kiro",
+            AcpBackend::Hermes => "Hermes",
+            AcpBackend::Snow => "Snow",
+            AcpBackend::Remote => "Remote",
+            AcpBackend::Aionrs => "Aionrs",
+            AcpBackend::Custom => "Custom",
+        }
+    }
 }
 
 /// Runtime status of a conversation.
@@ -340,5 +427,63 @@ mod tests {
             let parsed: McpServerStatus = serde_json::from_str(&json).unwrap();
             assert_eq!(parsed, variant, "deserialize {expected_json}");
         }
+    }
+
+    #[test]
+    fn test_acp_backend_cli_binary_name_known() {
+        assert_eq!(AcpBackend::Claude.cli_binary_name(), Some("claude"));
+        assert_eq!(AcpBackend::Qwen.cli_binary_name(), Some("qwen"));
+        assert_eq!(AcpBackend::Codex.cli_binary_name(), Some("codex"));
+        assert_eq!(AcpBackend::Kiro.cli_binary_name(), Some("kiro"));
+        assert_eq!(AcpBackend::Goose.cli_binary_name(), Some("goose"));
+        assert_eq!(AcpBackend::Cursor.cli_binary_name(), Some("cursor"));
+        assert_eq!(AcpBackend::Snow.cli_binary_name(), Some("snow"));
+    }
+
+    #[test]
+    fn test_acp_backend_cli_binary_name_none() {
+        assert_eq!(AcpBackend::IFlow.cli_binary_name(), None);
+        assert_eq!(AcpBackend::Gemini.cli_binary_name(), None);
+        assert_eq!(AcpBackend::OpenclawGateway.cli_binary_name(), None);
+        assert_eq!(AcpBackend::Remote.cli_binary_name(), None);
+        assert_eq!(AcpBackend::Aionrs.cli_binary_name(), None);
+        assert_eq!(AcpBackend::Custom.cli_binary_name(), None);
+    }
+
+    #[test]
+    fn test_acp_backend_display_name() {
+        assert_eq!(AcpBackend::Claude.display_name(), "Claude");
+        assert_eq!(AcpBackend::IFlow.display_name(), "iFlow");
+        assert_eq!(AcpBackend::Codebuddy.display_name(), "CodeBuddy");
+        assert_eq!(AcpBackend::Opencode.display_name(), "OpenCode");
+        assert_eq!(
+            AcpBackend::OpenclawGateway.display_name(),
+            "OpenClaw Gateway"
+        );
+    }
+
+    #[test]
+    fn test_acp_backend_cli_backends_only_contains_some() {
+        for backend in AcpBackend::CLI_BACKENDS {
+            assert!(
+                backend.cli_binary_name().is_some(),
+                "{backend:?} is in CLI_BACKENDS but cli_binary_name() returns None"
+            );
+        }
+    }
+
+    #[test]
+    fn test_acp_backend_id_deterministic() {
+        let a = AcpBackend::Claude.id();
+        let b = AcpBackend::Claude.id();
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 8);
+    }
+
+    #[test]
+    fn test_acp_backend_id_unique_per_variant() {
+        let claude_id = AcpBackend::Claude.id();
+        let codex_id = AcpBackend::Codex.id();
+        assert_ne!(claude_id, codex_id);
     }
 }

--- a/crates/aionui-common/src/id.rs
+++ b/crates/aionui-common/src/id.rs
@@ -1,5 +1,30 @@
 use uuid::Uuid;
 
+/// FNV-1a hash producing an 8-character lowercase hex string at compile time.
+pub const fn fnv1a_hex8(input: &[u8]) -> [u8; 8] {
+    const BASIS: u32 = 0x811c_9dc5;
+    const PRIME: u32 = 0x0100_0193;
+    const HEX: [u8; 16] = *b"0123456789abcdef";
+
+    let mut hash = BASIS;
+    let mut i = 0;
+    while i < input.len() {
+        hash ^= input[i] as u32;
+        hash = hash.wrapping_mul(PRIME);
+        i += 1;
+    }
+
+    let mut out = [0u8; 8];
+    let mut j = 0;
+    while j < 4 {
+        let byte = (hash >> (24 - j * 8)) as u8;
+        out[j * 2] = HEX[(byte >> 4) as usize];
+        out[j * 2 + 1] = HEX[(byte & 0x0f) as usize];
+        j += 1;
+    }
+    out
+}
+
 /// Generate a time-ordered globally unique ID (UUID v7).
 pub fn generate_id() -> String {
     Uuid::now_v7().to_string()
@@ -54,5 +79,28 @@ mod tests {
         let prefix = "a".repeat(1000);
         let id = generate_prefixed_id(&prefix);
         assert!(id.starts_with(&prefix));
+    }
+
+    #[test]
+    fn test_fnv1a_hex8_deterministic() {
+        let a = fnv1a_hex8(b"claude");
+        let b = fnv1a_hex8(b"claude");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_fnv1a_hex8_different_inputs() {
+        let a = fnv1a_hex8(b"claude");
+        let b = fnv1a_hex8(b"codex");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_fnv1a_hex8_length() {
+        let hash = fnv1a_hex8(b"test");
+        assert_eq!(hash.len(), 8);
+        for byte in &hash {
+            assert!(byte.is_ascii_hexdigit());
+        }
     }
 }

--- a/crates/aionui-common/src/lib.rs
+++ b/crates/aionui-common/src/lib.rs
@@ -16,7 +16,7 @@ pub use enums::{
     PreviewContentType, ProtocolType, RemoteAgentAuthType, RemoteAgentProtocol, RemoteAgentStatus,
 };
 pub use error::AppError;
-pub use id::{generate_id, generate_prefixed_id};
+pub use id::{fnv1a_hex8, generate_id, generate_prefixed_id};
 pub use pagination::PaginatedResult;
 pub use timestamp::{TimestampMs, now_ms};
 pub use types::{Confirmation, ConfirmationOption, ProviderWithModel, UpdateType, VersionInfo};


### PR DESCRIPTION
## Summary
- Replace hardcoded `known_agents()` with `AgentRegistry` supporting 4-source discovery (internal, builtin, extension, custom)
- Add `AcpBackend` methods (`id()`, `cli_binary_name()`, `display_name()`, `CLI_BACKENDS`) and `fnv1a_hex8` hash for deterministic agent IDs
- Factory resolves agent by registry ID — frontend only needs to pass `agent_id` to create sessions, no more `cli_path`
- API returns `AcpAgentInfo` (id, name, backend, available, source) without exposing internal fields (command, args, env)

## Test plan
- [ ] `cargo test -p aionui-ai-agent -p aionui-app -p aionui-api-types` — all pass
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Verify agent list via `GET /api/acp/agents` returns new shape with `source` field
- [ ] Create single-chat conversation with `agent_id` — backend resolves cli_path from registry