### PR TITLE
refactor: separate agent management routes from ACP routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Never introduce circular dependencies or upward references.
 | `POST /login`, `/api/auth/*` | aionui-auth | Public (rate-limited) |
 | `POST /logout`, `/api/auth/user`, `/api/auth/change-password`, `/api/ws-token` | aionui-auth | Yes |
 | `/api/conversations/*`, `/api/messages/*` | aionui-conversation | Yes |
+| `/api/agents`, `/api/agents/refresh`, `/api/agents/test` | aionui-ai-agent | Yes |
 | `/api/acp/*`, `/api/conversations/{id}/acp/*` | aionui-ai-agent | Yes |
 | `/api/bedrock/*`, `/api/gemini/*` | aionui-ai-agent | Yes |
 | `/api/conversations/{id}/workspace`, `/api/conversations/{id}/side-question`, `/api/conversations/{id}/slash-commands`, `/api/conversations/{id}/reload-context` | aionui-ai-agent | Yes |

--- a/crates/aionui-ai-agent/src/acp_routes.rs
+++ b/crates/aionui-ai-agent/src/acp_routes.rs
@@ -6,9 +6,9 @@ use axum::extract::{Extension, Json, Path, State};
 use axum::routing::{get, post, put};
 
 use aionui_api_types::{
-    AcpAgentInfo, AcpEnvResponse, AcpHealthCheckRequest, AcpHealthCheckResponse, AcpModeResponse,
-    ApiResponse, DetectCliRequest, DetectCliResponse, ProbeModelRequest, SetConfigOptionRequest,
-    SetModeRequest, SetModelRequest, TestCustomAgentRequest, TestCustomAgentResponse,
+    AcpEnvResponse, AcpHealthCheckRequest, AcpHealthCheckResponse, AcpModeResponse, ApiResponse,
+    DetectCliRequest, DetectCliResponse, ProbeModelRequest, SetConfigOptionRequest, SetModeRequest,
+    SetModelRequest,
 };
 use aionui_auth::CurrentUser;
 use aionui_common::{AgentType, AppError};
@@ -16,7 +16,6 @@ use aionui_common::{AgentType, AppError};
 use crate::acp_agent::AcpAgentManager;
 use crate::acp_service;
 use crate::agent_manager::AgentManagerHandle;
-use crate::agent_registry::AgentRegistry;
 use crate::task_manager::IWorkerTaskManager;
 use crate::types::{AcpModelInfo, AcpSessionConfigOption};
 
@@ -24,7 +23,6 @@ use crate::types::{AcpModelInfo, AcpSessionConfigOption};
 #[derive(Clone)]
 pub struct AcpRouterState {
     pub worker_task_manager: Arc<dyn IWorkerTaskManager>,
-    pub agent_registry: Arc<AgentRegistry>,
 }
 
 /// Build the ACP management router.
@@ -35,9 +33,6 @@ pub fn acp_routes(state: AcpRouterState) -> Router {
     Router::new()
         // Global ACP management routes
         .route("/api/acp/detect-cli", post(detect_cli))
-        .route("/api/acp/agents", get(list_agents))
-        .route("/api/acp/agents/refresh", post(refresh_agents))
-        .route("/api/acp/agents/test", post(test_custom_agent))
         .route("/api/acp/health-check", post(health_check))
         .route("/api/acp/env", get(get_env))
         .route("/api/acp/probe-model", post(probe_model))
@@ -101,35 +96,6 @@ async fn detect_cli(
 ) -> Result<Json<ApiResponse<DetectCliResponse>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
     let result = acp_service::detect_cli(req.backend);
-    Ok(Json(ApiResponse::ok(result)))
-}
-
-async fn list_agents(
-    State(state): State<AcpRouterState>,
-    Extension(_user): Extension<CurrentUser>,
-) -> Result<Json<ApiResponse<Vec<AcpAgentInfo>>>, AppError> {
-    let agents = state.agent_registry.get_all().await;
-    let infos: Vec<AcpAgentInfo> = agents.into_iter().map(Into::into).collect();
-    Ok(Json(ApiResponse::ok(infos)))
-}
-
-async fn refresh_agents(
-    State(state): State<AcpRouterState>,
-    Extension(_user): Extension<CurrentUser>,
-) -> Result<Json<ApiResponse<Vec<AcpAgentInfo>>>, AppError> {
-    state.agent_registry.refresh_builtins().await;
-    let agents = state.agent_registry.get_all().await;
-    let infos: Vec<AcpAgentInfo> = agents.into_iter().map(Into::into).collect();
-    Ok(Json(ApiResponse::ok(infos)))
-}
-
-async fn test_custom_agent(
-    State(_state): State<AcpRouterState>,
-    Extension(_user): Extension<CurrentUser>,
-    body: Result<Json<TestCustomAgentRequest>, JsonRejection>,
-) -> Result<Json<ApiResponse<TestCustomAgentResponse>>, AppError> {
-    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    let result = acp_service::test_custom_agent(&req.command, &req.acp_args, &req.env)?;
     Ok(Json(ApiResponse::ok(result)))
 }
 

--- a/crates/aionui-ai-agent/src/agent_routes.rs
+++ b/crates/aionui-ai-agent/src/agent_routes.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use axum::Router;
+use axum::extract::rejection::JsonRejection;
+use axum::extract::{Extension, Json, State};
+use axum::routing::{get, post};
+
+use aionui_api_types::{AgentInfo, ApiResponse, TestCustomAgentRequest, TestCustomAgentResponse};
+use aionui_auth::CurrentUser;
+use aionui_common::AppError;
+
+use crate::acp_service;
+use crate::agent_registry::AgentRegistry;
+
+#[derive(Clone)]
+pub struct AgentRouterState {
+    pub agent_registry: Arc<AgentRegistry>,
+}
+
+pub fn agent_routes(state: AgentRouterState) -> Router {
+    Router::new()
+        .route("/api/agents", get(list_agents))
+        .route("/api/agents/refresh", post(refresh_agents))
+        .route("/api/agents/test", post(test_custom_agent))
+        .with_state(state)
+}
+
+async fn list_agents(
+    State(state): State<AgentRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+) -> Result<Json<ApiResponse<Vec<AgentInfo>>>, AppError> {
+    let agents = state.agent_registry.get_all().await;
+    let infos: Vec<AgentInfo> = agents.into_iter().map(Into::into).collect();
+    Ok(Json(ApiResponse::ok(infos)))
+}
+
+async fn refresh_agents(
+    State(state): State<AgentRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+) -> Result<Json<ApiResponse<Vec<AgentInfo>>>, AppError> {
+    state.agent_registry.refresh_builtins().await;
+    let agents = state.agent_registry.get_all().await;
+    let infos: Vec<AgentInfo> = agents.into_iter().map(Into::into).collect();
+    Ok(Json(ApiResponse::ok(infos)))
+}
+
+async fn test_custom_agent(
+    State(_state): State<AgentRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    body: Result<Json<TestCustomAgentRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<TestCustomAgentResponse>>, AppError> {
+    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
+    let result = acp_service::test_custom_agent(&req.command, &req.acp_args, &req.env)?;
+    Ok(Json(ApiResponse::ok(result)))
+}

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -6,6 +6,7 @@ pub mod acp_routes;
 pub mod acp_service;
 pub mod agent_manager;
 pub mod agent_registry;
+pub mod agent_routes;
 pub mod aionrs_agent;
 pub mod api_client;
 pub mod auxiliary_routes;
@@ -31,6 +32,7 @@ pub use acp_agent::AcpAgentManager;
 pub use acp_routes::{AcpRouterState, acp_routes};
 pub use agent_manager::{AgentManagerHandle, IAgentManager, approval_key};
 pub use agent_registry::AgentRegistry;
+pub use agent_routes::{AgentRouterState, agent_routes};
 pub use aionrs_agent::AionrsAgentManager;
 pub use api_client::{
     AnthropicRotatingClient, ApiClientError, ApiKeyManager, ApiKeyStatus, ClientOptions,

--- a/crates/aionui-api-types/src/acp.rs
+++ b/crates/aionui-api-types/src/acp.rs
@@ -17,28 +17,6 @@ pub struct DetectCliResponse {
     pub path: Option<String>,
 }
 
-/// Information about an available ACP agent (public API shape).
-#[derive(Debug, Clone, Serialize)]
-pub struct AcpAgentInfo {
-    pub id: String,
-    pub name: String,
-    pub backend: AcpBackend,
-    pub available: bool,
-    pub source: crate::AgentSource,
-}
-
-impl From<crate::DetectedAgent> for AcpAgentInfo {
-    fn from(a: crate::DetectedAgent) -> Self {
-        Self {
-            id: a.id,
-            name: a.name,
-            backend: a.backend,
-            available: a.available,
-            source: a.source,
-        }
-    }
-}
-
 /// Request body for ACP health check.
 #[derive(Debug, Deserialize)]
 pub struct AcpHealthCheckRequest {
@@ -134,22 +112,6 @@ mod tests {
         let resp = DetectCliResponse { path: None };
         let json = serde_json::to_value(&resp).unwrap();
         assert!(json.get("path").is_none());
-    }
-
-    #[test]
-    fn acp_agent_info_serde() {
-        let info = AcpAgentInfo {
-            id: "claude".into(),
-            name: "Claude".into(),
-            backend: AcpBackend::Claude,
-            available: true,
-            source: crate::AgentSource::Builtin,
-        };
-        let json = serde_json::to_value(&info).unwrap();
-        assert_eq!(json["id"], "claude");
-        assert_eq!(json["backend"], "claude");
-        assert_eq!(json["available"], true);
-        assert_eq!(json["source"], "builtin");
     }
 
     #[test]

--- a/crates/aionui-api-types/src/agent.rs
+++ b/crates/aionui-api-types/src/agent.rs
@@ -1,0 +1,63 @@
+use aionui_common::AcpBackend;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentInfo {
+    pub id: String,
+    pub name: String,
+    pub backend: AcpBackend,
+    pub available: bool,
+    pub source: crate::AgentSource,
+}
+
+impl From<crate::DetectedAgent> for AgentInfo {
+    fn from(a: crate::DetectedAgent) -> Self {
+        Self {
+            id: a.id,
+            name: a.name,
+            backend: a.backend,
+            available: a.available,
+            source: a.source,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_info_from_detected() {
+        let detected = crate::DetectedAgent {
+            id: "abc123".into(),
+            name: "Claude".into(),
+            backend: AcpBackend::Claude,
+            available: true,
+            source: crate::AgentSource::Builtin,
+            command: Some("/usr/bin/claude".into()),
+            args: vec!["--experimental-acp".into()],
+            env: vec![],
+        };
+        let info = AgentInfo::from(detected);
+        assert_eq!(info.id, "abc123");
+        assert_eq!(info.name, "Claude");
+        assert_eq!(info.backend, AcpBackend::Claude);
+        assert!(info.available);
+        assert_eq!(info.source, crate::AgentSource::Builtin);
+    }
+
+    #[test]
+    fn agent_info_serde() {
+        let info = AgentInfo {
+            id: "aionrs".into(),
+            name: "Aion CLI".into(),
+            backend: AcpBackend::Aionrs,
+            available: true,
+            source: crate::AgentSource::Internal,
+        };
+        let json = serde_json::to_value(&info).unwrap();
+        assert_eq!(json["id"], "aionrs");
+        assert_eq!(json["backend"], "aionrs");
+        assert_eq!(json["source"], "internal");
+    }
+}

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -1,5 +1,6 @@
 //! All HTTP request/response DTOs shared across the API surface.
 mod acp;
+mod agent;
 mod agent_discovery;
 mod auth;
 mod channel;
@@ -22,10 +23,11 @@ mod team;
 mod websocket;
 
 pub use acp::{
-    AcpAgentInfo, AcpEnvResponse, AcpHealthCheckRequest, AcpHealthCheckResponse, AcpModeResponse,
+    AcpEnvResponse, AcpHealthCheckRequest, AcpHealthCheckResponse, AcpModeResponse,
     DetectCliRequest, DetectCliResponse, ProbeModelRequest, SetConfigOptionRequest, SetModeRequest,
     SetModelRequest, TestCustomAgentRequest, TestCustomAgentResponse,
 };
+pub use agent::AgentInfo;
 pub use agent_discovery::{AgentSource, DetectedAgent, EnvVar};
 pub use auth::{
     AuthStatusResponse, ChangePasswordRequest, LoginRequest, LoginResponse, PublicUser,

--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -10,10 +10,10 @@ use sha2::{Digest, Sha256};
 use tower_http::cors::{Any, CorsLayer};
 
 use aionui_ai_agent::{
-    AcpRouterState, AcpSkillManager, AgentFactoryDeps, AgentRegistry, AuxiliaryRouterState,
-    ConnectionTestRouterState, ConnectionTestService, IWorkerTaskManager, RemoteAgentRouterState,
-    RemoteAgentService, WorkerTaskManagerImpl, acp_routes, auxiliary_routes, build_agent_factory,
-    connection_test_routes, remote_agent_routes,
+    AcpRouterState, AcpSkillManager, AgentFactoryDeps, AgentRegistry, AgentRouterState,
+    AuxiliaryRouterState, ConnectionTestRouterState, ConnectionTestService, IWorkerTaskManager,
+    RemoteAgentRouterState, RemoteAgentService, WorkerTaskManagerImpl, acp_routes, agent_routes,
+    auxiliary_routes, build_agent_factory, connection_test_routes, remote_agent_routes,
 };
 use aionui_api_types::{AgentSource, DetectedAgent, EnvVar};
 use aionui_auth::{
@@ -224,6 +224,7 @@ pub struct ModuleStates {
     pub cron: CronRouterState,
     pub office: OfficeRouterState,
     pub shell: ShellRouterState,
+    pub agent: AgentRouterState,
 }
 
 /// Convert extension-contributed ACP adapters into `DetectedAgent` values.
@@ -279,6 +280,9 @@ pub async fn build_module_states(services: &AppServices) -> ModuleStates {
         cron: build_cron_state(services),
         office: build_office_state(services),
         shell: build_shell_state(services),
+        agent: AgentRouterState {
+            agent_registry: services.agent_registry.clone(),
+        },
     }
 }
 
@@ -358,7 +362,6 @@ pub fn build_remote_agent_state(services: &AppServices) -> RemoteAgentRouterStat
 pub fn build_acp_state(services: &AppServices) -> AcpRouterState {
     AcpRouterState {
         worker_task_manager: services.worker_task_manager.clone(),
-        agent_registry: services.agent_registry.clone(),
     }
 }
 
@@ -698,6 +701,10 @@ pub fn create_router_with_all_state(
     let acp_authenticated = acp_routes(states.acp)
         .route_layer(from_fn_with_state(auth_mw_state.clone(), auth_middleware));
 
+    // Unified agent listing/refresh/test routes protected by auth middleware
+    let agent_authenticated = agent_routes(states.agent)
+        .route_layer(from_fn_with_state(auth_mw_state.clone(), auth_middleware));
+
     // Connection test routes (Bedrock, Gemini) protected by auth middleware
     let connection_test_authenticated = connection_test_routes(states.connection_test)
         .route_layer(from_fn_with_state(auth_mw_state.clone(), auth_middleware));
@@ -765,6 +772,7 @@ pub fn create_router_with_all_state(
         .merge(conversation_authenticated)
         .merge(remote_agent_authenticated)
         .merge(acp_authenticated)
+        .merge(agent_authenticated)
         .merge(connection_test_authenticated)
         .merge(auxiliary_authenticated)
         .merge(file_authenticated)

--- a/crates/aionui-app/tests/acp_e2e.rs
+++ b/crates/aionui-app/tests/acp_e2e.rs
@@ -89,7 +89,7 @@ async fn list_agents_returns_array() {
     let (mut app, services) = build_app().await;
     let (token, _csrf) = setup_and_login(&mut app, &services, "user1", "pass123").await;
 
-    let req = get_with_token("/api/acp/agents", &token);
+    let req = get_with_token("/api/agents", &token);
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
 
@@ -105,7 +105,7 @@ async fn refresh_agents_returns_array() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "user1", "pass123").await;
 
-    let req = json_with_token("POST", "/api/acp/agents/refresh", json!({}), &token, &csrf);
+    let req = json_with_token("POST", "/api/agents/refresh", json!({}), &token, &csrf);
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
 
@@ -121,7 +121,7 @@ async fn test_custom_agent_nonexistent_command() {
 
     let req = json_with_token(
         "POST",
-        "/api/acp/agents/test",
+        "/api/agents/test",
         json!({ "command": "/nonexistent/path/to/agent" }),
         &token,
         &csrf,


### PR DESCRIPTION
## Summary

- Move `GET /api/acp/agents`, `POST /api/acp/agents/refresh`, `POST /api/acp/agents/test` to `/api/agents`, `/api/agents/refresh`, `/api/agents/test`
- Replace `AcpAgentInfo` with `AgentInfo` (typed fields: `AcpBackend` + `AgentSource`)
- New `agent_routes.rs` with dedicated `AgentRouterState` owning `AgentRegistry`
- `AcpRouterState` no longer depends on `AgentRegistry` — ACP routes now only handle protocol operations
- Update E2E tests and route map documentation

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test --workspace` passes
- [ ] `GET /api/agents` returns all agents (internal + builtin + extension + custom)
- [ ] `POST /api/agents/refresh` refreshes builtins and returns updated list
- [ ] `POST /api/agents/test` validates custom agent command
- [ ] Old `/api/acp/agents*` paths return 404