### PR TITLE
refactor(ai-agent): create temp workspace under data-dir

### DIFF
--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -118,20 +118,6 @@ impl AcpAgentManager {
             .backend
             .ok_or_else(|| AppError::BadRequest("ACP backend is required".into()))?;
 
-        // Workspace fallback: create temp directory if empty
-        let workspace = if workspace.is_empty() {
-            let dir = std::env::temp_dir().join(format!(
-                "{}-temp-{}",
-                backend.cli_binary_name().unwrap_or("acp"),
-                now_ms()
-            ));
-            std::fs::create_dir_all(&dir)
-                .map_err(|e| AppError::Internal(format!("Failed to create temp workspace: {e}")))?;
-            dir.to_string_lossy().into_owned()
-        } else {
-            workspace
-        };
-
         let process = CliAgentProcess::spawn_for_sdk(CliSpawnConfig {
             command: spawn_command,
             args: spawn_args,

--- a/crates/aionui-ai-agent/src/factory.rs
+++ b/crates/aionui-ai-agent/src/factory.rs
@@ -1,6 +1,7 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
-use aionui_common::{AgentType, AppError};
+use aionui_common::{AgentType, AppError, now_ms};
 use aionui_db::IRemoteAgentRepository;
 use tracing::warn;
 
@@ -24,6 +25,7 @@ pub struct AgentFactoryDeps {
     pub remote_agent_repo: Arc<dyn IRemoteAgentRepository>,
     pub encryption_key: [u8; 32],
     pub agent_registry: Arc<AgentRegistry>,
+    pub data_dir: PathBuf,
 }
 
 /// Build a production agent factory that dispatches to concrete agent types.
@@ -51,7 +53,18 @@ async fn build_agent(
     options: BuildTaskOptions,
 ) -> Result<AgentManagerHandle, AppError> {
     let conversation_id = options.conversation_id.clone();
-    let workspace = options.workspace.clone();
+    let workspace = if options.workspace.is_empty() {
+        let dir = deps.data_dir.join("tmp").join(format!(
+            "{:?}-temp-{}",
+            options.agent_type,
+            now_ms()
+        ));
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| AppError::Internal(format!("Failed to create temp workspace: {e}")))?;
+        dir.to_string_lossy().into_owned()
+    } else {
+        options.workspace.clone()
+    };
 
     match options.agent_type {
         AgentType::Acp => {

--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -165,6 +165,7 @@ impl AppServices {
             remote_agent_repo,
             encryption_key,
             agent_registry: agent_registry.clone(),
+            data_dir: std::path::PathBuf::from(&data_dir),
         });
         let worker_task_manager: Arc<dyn IWorkerTaskManager> =
             Arc::new(WorkerTaskManagerImpl::new(factory));

--- a/crates/aionui-common/src/id.rs
+++ b/crates/aionui-common/src/id.rs
@@ -32,7 +32,7 @@ pub const fn fnv1a_hex8(input: &[u8]) -> [u8; 8] {
 pub fn generate_id_with_length(length: Option<usize>) -> String {
     match length {
         Some(len) if len < 36 => {
-            let num_bytes = (len + 1) / 2;
+            let num_bytes = len.div_ceil(2);
             let mut buf = vec![0u8; num_bytes];
             getrandom::getrandom(&mut buf).expect("getrandom failed");
             let hex: String = buf.iter().map(|b| format!("{b:02x}")).collect();


### PR DESCRIPTION
## Summary
- Move workspace fallback logic from `AcpAgentManager::new()` into the shared `build_agent()` factory, so all agent types use the same fallback
- Temp workspace now created under `data_dir/tmp/` instead of `std::env::temp_dir()`, keeping application data self-contained
- `AgentFactoryDeps` gains a `data_dir: PathBuf` field, injected from `AppServices`

## Test plan
- [ ] Verify agent creation with empty workspace uses `data_dir/tmp/` path
- [ ] Verify agent creation with non-empty workspace is unchanged
- [ ] `cargo build` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)