### PR TITLE
refactor: restructure AGENTS.md to prevent premature full-test runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,9 +163,9 @@ Prohibited:
 > - Do NOT run `cargo test --workspace` at the start of a task.
 >
 > ⚠️ **Performance:**
+> - `cargo clippy --workspace` takes several minutes — use `run_in_background: true`.
 > - `cargo test --workspace` takes 10+ minutes. MUST use `run_in_background: true` when calling via Bash tool, otherwise it will timeout.
-> - `cargo clippy --workspace` also takes several minutes — use `run_in_background: true`.
-> - `cargo test -p aionui-<crate>` and `cargo clippy -p aionui-<crate>` typically complete in under 1 minute.
+> - `cargo clippy -p aionui-<crate>` and `cargo test -p aionui-<crate>` typically complete in under 1 minute.
 
 ### During Development (fast feedback loop)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,14 +177,15 @@ cargo clippy -p aionui-<crate> -- -D warnings         # Lint the crate you chang
 ### Before Commit (affected crates)
 
 ```bash
-cargo test -p aionui-<crate1> -p aionui-<crate2>     # Test all affected crates
-cargo fmt --all -- --check                             # Format check
+cargo fmt --all -- --check                                                      # Format gate (instant)
+cargo clippy -p aionui-<crate1> -p aionui-<crate2> -- -D warnings              # Lint affected crates
+cargo test -p aionui-<crate1> -p aionui-<crate2>                               # Test affected crates
 ```
 
 ### Final Verification (run in background, 10+ min)
 
 ```bash
-cargo test --workspace                                 # Full test suite
+cargo fmt --all -- --check                             # Format gate (instant)
 cargo clippy --workspace -- -D warnings                # Full lint
-cargo fmt --all                                        # Format
+cargo test --workspace                                 # Full test suite
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ Prohibited:
 > ⚠️ **When to run what:**
 > - During development: only test the crate you're working on → `cargo test -p aionui-<crate>`
 > - After implementation complete: full verification → `cargo test --workspace`
-> - Do NOT run `cargo test --workspace` at the start of a task or after creating a worktree.
+> - Do NOT run `cargo test --workspace` at the start of a task.
 >
 > ⚠️ **Performance:**
 > - `cargo test --workspace` takes 10+ minutes. MUST use `run_in_background: true` when calling via Bash tool, otherwise it will timeout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,19 +2,6 @@
 
 Project-specific rules and conventions for AI assistants and contributors.
 
-## Build & Test
-
-```bash
-cargo build                          # Build (debug)
-cargo build --release                # Build (release)
-cargo test --workspace               # Run all tests
-cargo clippy --workspace -- -D warnings  # Lint (warnings = errors)
-cargo fmt --all                      # Format
-cargo fmt --all -- --check           # Format check (CI enforces this)
-```
-
-Binary name: `aionui-backend` (produced by `crates/aionui-app`).
-
 ## Architecture
 
 Cargo workspace with 17 crates under `crates/`. Dependencies flow downward:
@@ -29,64 +16,7 @@ Cargo workspace with 17 crates under `crates/`. Dependencies flow downward:
 
 Never introduce circular dependencies or upward references.
 
-## Test Organization
-
-| Location | What goes there |
-|----------|----------------|
-| Inline `#[cfg(test)]` in each `.rs` file | Unit tests for that module's internals |
-| `crates/<crate>/tests/` | Integration / E2E tests for that crate |
-
-## Code Style
-
-- Rust 2024 edition, stable toolchain
-- `cargo clippy` must pass without warnings
-- `cargo fmt` must pass
-- Comments in English, commit messages in English
-- Each `.rs` file follows single responsibility — one module, one concern
-- Max 1000 lines per `.rs` file; split into submodules when approaching the limit
-
-## Route Map
-
-| Prefix | Crate | Auth |
-|--------|-------|------|
-| `POST /login`, `/api/auth/*` | aionui-auth | Public (rate-limited) |
-| `POST /logout`, `/api/auth/user`, `/api/auth/change-password`, `/api/ws-token` | aionui-auth | Yes |
-| `/api/conversations/*`, `/api/messages/*` | aionui-conversation | Yes |
-| `/api/agents`, `/api/agents/refresh`, `/api/agents/test` | aionui-ai-agent | Yes |
-| `/api/acp/*`, `/api/conversations/{id}/acp/*` | aionui-ai-agent | Yes |
-| `/api/bedrock/*`, `/api/gemini/*` | aionui-ai-agent | Yes |
-| `/api/conversations/{id}/workspace`, `/api/conversations/{id}/side-question`, `/api/conversations/{id}/slash-commands`, `/api/conversations/{id}/reload-context` | aionui-ai-agent | Yes |
-| `/api/remote-agents/*` | aionui-ai-agent | Yes |
-| `/api/settings/*`, `/api/providers/*`, `/api/system/*` | aionui-system | Yes |
-| `/api/fs/*` | aionui-file | Yes |
-| `/api/mcp/*` | aionui-mcp | Yes |
-| `/api/extensions/*`, `/api/hub/*`, `/api/skills/*` | aionui-extension | Yes |
-| `/api/channel/*` | aionui-channel | Yes |
-| `/api/teams/*` | aionui-team | Yes |
-| `/api/cron/*` | aionui-cron | Yes |
-| `/api/word-preview/*`, `/api/excel-preview/*`, `/api/ppt-preview/*`, `/api/preview-history/*`, `/api/star-office/*`, `/api/document/*` | aionui-office | Yes |
-| `/api/ppt-proxy/*`, `/api/office-watch-proxy/*` | aionui-office | Public (iframe) |
-| `/api/shell/*`, `/api/stt` | aionui-shell | Yes |
-| `/ws` | aionui-realtime | Token callback |
-| `/health` | aionui-app | Public |
-
-## Quick Recipes
-
-**Add endpoint to existing crate:**
-1. Request/response types → `aionui-api-types/src/{domain}.rs`
-2. Handler function → `crates/aionui-{domain}/src/routes.rs`
-3. Business logic → `crates/aionui-{domain}/src/service.rs`
-4. Register route in `domain_routes()` function
-5. Add test → `crates/aionui-{domain}/tests/` or `crates/aionui-app/tests/`
-
-**Add migration:**
-1. Next number → `ls crates/aionui-db/migrations/`
-2. Create `NNN_descriptive_name.sql` with `IF NOT EXISTS`
-
-**Add WebSocket event:**
-1. Event type → `aionui-api-types`
-2. Emit via `event_bus.broadcast()` in service
-3. Naming: `domain.camelCaseAction`
+Binary name: `aionui-backend` (produced by `crates/aionui-app`).
 
 ## Architecture Rules
 
@@ -146,16 +76,72 @@ Every domain crate must follow:
 - Error responses must not leak internal details
 - Secrets must never be hardcoded
 
-### Testing
+## Route Map
 
-- Unit tests: `#[cfg(test)]` inline in corresponding `.rs` files
-- Integration tests: `crates/<crate>/tests/` directory
-- E2E tests: `crates/aionui-app/tests/`
+| Prefix | Crate | Auth |
+|--------|-------|------|
+| `POST /login`, `/api/auth/*` | aionui-auth | Public (rate-limited) |
+| `POST /logout`, `/api/auth/user`, `/api/auth/change-password`, `/api/ws-token` | aionui-auth | Yes |
+| `/api/conversations/*`, `/api/messages/*` | aionui-conversation | Yes |
+| `/api/agents`, `/api/agents/refresh`, `/api/agents/test` | aionui-ai-agent | Yes |
+| `/api/acp/*`, `/api/conversations/{id}/acp/*` | aionui-ai-agent | Yes |
+| `/api/bedrock/*`, `/api/gemini/*` | aionui-ai-agent | Yes |
+| `/api/conversations/{id}/workspace`, `/api/conversations/{id}/side-question`, `/api/conversations/{id}/slash-commands`, `/api/conversations/{id}/reload-context` | aionui-ai-agent | Yes |
+| `/api/remote-agents/*` | aionui-ai-agent | Yes |
+| `/api/settings/*`, `/api/providers/*`, `/api/system/*` | aionui-system | Yes |
+| `/api/fs/*` | aionui-file | Yes |
+| `/api/mcp/*` | aionui-mcp | Yes |
+| `/api/extensions/*`, `/api/hub/*`, `/api/skills/*` | aionui-extension | Yes |
+| `/api/channel/*` | aionui-channel | Yes |
+| `/api/teams/*` | aionui-team | Yes |
+| `/api/cron/*` | aionui-cron | Yes |
+| `/api/word-preview/*`, `/api/excel-preview/*`, `/api/ppt-preview/*`, `/api/preview-history/*`, `/api/star-office/*`, `/api/document/*` | aionui-office | Yes |
+| `/api/ppt-proxy/*`, `/api/office-watch-proxy/*` | aionui-office | Public (iframe) |
+| `/api/shell/*`, `/api/stt` | aionui-shell | Yes |
+| `/ws` | aionui-realtime | Token callback |
+| `/health` | aionui-app | Public |
+
+## Code Style
+
+- Rust 2024 edition, stable toolchain
+- `cargo clippy` must pass without warnings
+- `cargo fmt` must pass
+- Comments in English, commit messages in English
+- Each `.rs` file follows single responsibility — one module, one concern
+- Max 1000 lines per `.rs` file; split into submodules when approaching the limit
+
+## Quick Recipes
+
+**Add endpoint to existing crate:**
+1. Request/response types → `aionui-api-types/src/{domain}.rs`
+2. Handler function → `crates/aionui-{domain}/src/routes.rs`
+3. Business logic → `crates/aionui-{domain}/src/service.rs`
+4. Register route in `domain_routes()` function
+5. Add test → `crates/aionui-{domain}/tests/` or `crates/aionui-app/tests/`
+
+**Add migration:**
+1. Next number → `ls crates/aionui-db/migrations/`
+2. Create `NNN_descriptive_name.sql` with `IF NOT EXISTS`
+
+**Add WebSocket event:**
+1. Event type → `aionui-api-types`
+2. Emit via `event_bus.broadcast()` in service
+3. Naming: `domain.camelCaseAction`
+
+## Test Organization
+
+| Location | What goes there |
+|----------|----------------|
+| Inline `#[cfg(test)]` in each `.rs` file | Unit tests for that module's internals |
+| `crates/<crate>/tests/` | Integration / E2E tests for that crate |
+
+### Testing Rules
+
 - Database tests use `init_database_memory()`
 - Prefer real in-memory DB over mocks; mock only to isolate unneeded dependencies
 - New features must include tests
 
-#### Test Failure Handling
+### Test Failure Handling
 
 When a test fails, do NOT modify the test to make it pass. First determine:
 
@@ -168,3 +154,37 @@ When a test fails, do NOT modify the test to make it pass. First determine:
 Prohibited:
 - ❌ Deleting failing tests to "fix" the problem
 - ❌ Weakening specific assertions to vague ones (e.g., `assert_eq!(status, 201)` → `assert!(status.is_success())`)
+
+## Verification Strategy
+
+> ⚠️ **When to run what:**
+> - During development: only test the crate you're working on → `cargo test -p aionui-<crate>`
+> - After implementation complete: full verification → `cargo test --workspace`
+> - Do NOT run `cargo test --workspace` at the start of a task or after creating a worktree.
+>
+> ⚠️ **Performance:**
+> - `cargo test --workspace` takes 10+ minutes. MUST use `run_in_background: true` when calling via Bash tool, otherwise it will timeout.
+> - `cargo clippy --workspace` also takes several minutes — use `run_in_background: true`.
+> - `cargo test -p aionui-<crate>` and `cargo clippy -p aionui-<crate>` typically complete in under 1 minute.
+
+### During Development (fast feedback loop)
+
+```bash
+cargo test -p aionui-<crate>                          # Test the crate you changed
+cargo clippy -p aionui-<crate> -- -D warnings         # Lint the crate you changed
+```
+
+### Before Commit (affected crates)
+
+```bash
+cargo test -p aionui-<crate1> -p aionui-<crate2>     # Test all affected crates
+cargo fmt --all -- --check                             # Format check
+```
+
+### Final Verification (run in background, 10+ min)
+
+```bash
+cargo test --workspace                                 # Full test suite
+cargo clippy --workspace -- -D warnings                # Full lint
+cargo fmt --all                                        # Format
+```


### PR DESCRIPTION
## Summary

- **删除 `Build & Test` 首章节**：原先命令平铺列在文件开头，导致 agent 进入项目后习惯性先跑 `cargo test --workspace` 全量测试（10+ 分钟）
- **章节重排**：Architecture → Rules → Route Map → Code Style → Quick Recipes → Test Organization → Verification Strategy，"理解"在前，"执行"在后
- **新增 `Verification Strategy`**：分三阶段验证（开发期单 crate → 提交前受影响 crate → 最终全量验证），统一按 `fmt → clippy → test` 快到慢排列
- **添加 Performance 警告**：workspace 级命令需要 `run_in_background: true`，避免 Bash tool timeout

## Test plan

- [ ] 新会话中创建 worktree 后，确认 agent 不再自动跑 `cargo test --workspace`
- [ ] 开发阶段 agent 使用 `cargo test -p aionui-<crate>` 而非全量测试
- [ ] Final Verification 阶段 agent 使用 `run_in_background: true`