### PR TITLE
refactor: agent type-aware detection with separated AgentType logic

### DIFF
--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -699,7 +699,7 @@ mod tests {
         assert_eq!(yolo_mode_value(AcpBackend::IFlow), Some("yolo"));
         assert_eq!(yolo_mode_value(AcpBackend::Kiro), None);
         assert_eq!(yolo_mode_value(AcpBackend::Gemini), None);
-        assert_eq!(yolo_mode_value(AcpBackend::Custom), None);
+        assert_eq!(yolo_mode_value(AcpBackend::Goose), None);
     }
 
     // ── approval_key tests ────────────────────────────────────────────

--- a/crates/aionui-ai-agent/src/acp_service.rs
+++ b/crates/aionui-ai-agent/src/acp_service.rs
@@ -84,13 +84,13 @@ mod tests {
 
     #[test]
     fn detect_cli_non_cli_backend_returns_none() {
-        let resp = detect_cli(AcpBackend::Custom);
+        let resp = detect_cli(AcpBackend::Gemini);
         assert!(resp.path.is_none());
     }
 
     #[test]
     fn health_check_non_cli_backend() {
-        let resp = health_check(AcpBackend::Custom);
+        let resp = health_check(AcpBackend::Gemini);
         assert!(!resp.available);
         assert!(resp.error.is_some());
     }

--- a/crates/aionui-ai-agent/src/agent_registry.rs
+++ b/crates/aionui-ai-agent/src/agent_registry.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use aionui_api_types::{AgentSource, DetectedAgent};
-use aionui_common::AcpBackend;
+use aionui_common::{AcpBackend, AgentType};
 use tokio::sync::RwLock;
 use tracing::{debug, info};
 
@@ -81,9 +81,10 @@ impl AgentRegistry {
 
     fn detect_internal_agent() -> DetectedAgent {
         DetectedAgent {
-            id: AcpBackend::Aionrs.id(),
+            id: AgentType::Aionrs.id(),
             name: "Aion CLI".into(),
-            backend: AcpBackend::Aionrs,
+            agent_type: AgentType::Aionrs,
+            backend: None,
             available: true,
             source: AgentSource::Internal,
             command: None,
@@ -92,20 +93,28 @@ impl AgentRegistry {
         }
     }
 
+    /// Detect all builtin agents by scanning the system PATH.
+    ///
+    /// Each AgentType has its own detection logic — ACP backends are detected
+    /// via CLI_BACKENDS, while other agent types have dedicated detectors.
     fn detect_builtin_agents() -> Vec<DetectedAgent> {
-        // TODO: 改成使用打包进应用的 bundled bun，而不是 PATH 里的 bun。
-        // 目前还不清楚如何从 Rust 侧获取 bundled bun 的路径。
+        let mut agents = Self::detect_acp_agents();
+        agents.extend(Self::detect_openclaw());
+        agents.extend(Self::detect_nanobot());
+        agents
+    }
+
+    fn detect_acp_agents() -> Vec<DetectedAgent> {
+        // TODO: use bundled bun instead of PATH bun.
         let bun_path = which::which("bun").ok();
 
         AcpBackend::CLI_BACKENDS
             .iter()
             .filter_map(|&backend| {
                 if let Some(bridge_pkg) = backend.bridge_package() {
-                    // Bridge-based backend: needs bun/npx to run the bridge package
                     let bun = bun_path.as_ref()?;
                     let bun_cmd = bun.to_string_lossy().into_owned();
 
-                    // Also check that the native CLI exists (indicates the tool is installed)
                     if let Some(binary) = backend.cli_binary_name() {
                         which::which(binary).ok()?;
                     }
@@ -124,7 +133,8 @@ impl AgentRegistry {
                     Some(DetectedAgent {
                         id: backend.id(),
                         name: backend.display_name().into(),
-                        backend,
+                        agent_type: AgentType::Acp,
+                        backend: Some(backend),
                         available: true,
                         source: AgentSource::Builtin,
                         command: Some(bun_cmd),
@@ -132,7 +142,6 @@ impl AgentRegistry {
                         env: vec![],
                     })
                 } else {
-                    // Direct CLI backend: native binary + ACP args
                     let binary = backend.cli_binary_name()?;
                     let path = which::which(binary).ok()?;
                     let command = path.to_string_lossy().into_owned();
@@ -143,7 +152,8 @@ impl AgentRegistry {
                     Some(DetectedAgent {
                         id: backend.id(),
                         name: backend.display_name().into(),
-                        backend,
+                        agent_type: AgentType::Acp,
+                        backend: Some(backend),
                         available: true,
                         source: AgentSource::Builtin,
                         command: Some(command),
@@ -153,6 +163,44 @@ impl AgentRegistry {
                 }
             })
             .collect()
+    }
+
+    fn detect_openclaw() -> Option<DetectedAgent> {
+        let path = which::which("openclaw").ok()?;
+        let command = path.to_string_lossy().into_owned();
+
+        debug!(%command, "Detected OpenClaw Gateway agent");
+
+        Some(DetectedAgent {
+            id: AgentType::OpenclawGateway.id(),
+            name: "OpenClaw Gateway".into(),
+            agent_type: AgentType::OpenclawGateway,
+            backend: None,
+            available: true,
+            source: AgentSource::Builtin,
+            command: Some(command),
+            args: vec![],
+            env: vec![],
+        })
+    }
+
+    fn detect_nanobot() -> Option<DetectedAgent> {
+        let path = which::which("nanobot").ok()?;
+        let command = path.to_string_lossy().into_owned();
+
+        debug!(%command, "Detected Nanobot agent");
+
+        Some(DetectedAgent {
+            id: AgentType::Nanobot.id(),
+            name: "Nanobot".into(),
+            agent_type: AgentType::Nanobot,
+            backend: None,
+            available: true,
+            source: AgentSource::Builtin,
+            command: Some(command),
+            args: vec!["--experimental-acp".to_owned()],
+            env: vec![],
+        })
     }
 
     /// Merge all sources with priority: Custom > Extension > Builtin > Internal.
@@ -172,14 +220,18 @@ impl AgentRegistry {
 
     /// Deduplicate agents. First occurrence wins (priority order preserved by caller).
     /// Custom and Extension agents use their `id` as dedup key (multiple custom agents
-    /// can share the same backend). Builtin/Internal dedup by backend.
+    /// can share the same backend). Builtin/Internal dedup by backend (for ACP) or
+    /// agent_type (for non-ACP).
     fn deduplicate(agents: Vec<DetectedAgent>) -> Vec<DetectedAgent> {
         let mut seen = HashSet::new();
         let mut result = Vec::new();
         for agent in agents {
             let key = match agent.source {
                 AgentSource::Custom | AgentSource::Extension => agent.id.clone(),
-                _ => format!("{:?}", agent.backend),
+                _ => match agent.backend {
+                    Some(b) => format!("acp:{b:?}"),
+                    None => format!("type:{:?}", agent.agent_type),
+                },
             };
             if seen.insert(key) {
                 result.push(agent);
@@ -193,11 +245,26 @@ impl AgentRegistry {
 mod tests {
     use super::*;
 
-    fn make_agent(id: &str, backend: AcpBackend, source: AgentSource) -> DetectedAgent {
+    fn make_acp_agent(id: &str, backend: AcpBackend, source: AgentSource) -> DetectedAgent {
         DetectedAgent {
             id: id.into(),
             name: id.into(),
-            backend,
+            agent_type: AgentType::Acp,
+            backend: Some(backend),
+            available: true,
+            source,
+            command: None,
+            args: vec![],
+            env: vec![],
+        }
+    }
+
+    fn make_typed_agent(id: &str, agent_type: AgentType, source: AgentSource) -> DetectedAgent {
+        DetectedAgent {
+            id: id.into(),
+            name: id.into(),
+            agent_type,
+            backend: None,
             available: true,
             source,
             command: None,
@@ -208,12 +275,12 @@ mod tests {
 
     #[test]
     fn merge_priority_custom_over_builtin() {
-        let customs = vec![make_agent(
+        let customs = vec![make_acp_agent(
             "custom:claude",
             AcpBackend::Claude,
             AgentSource::Custom,
         )];
-        let builtins = vec![make_agent(
+        let builtins = vec![make_acp_agent(
             "builtin-claude",
             AcpBackend::Claude,
             AgentSource::Builtin,
@@ -226,13 +293,13 @@ mod tests {
     #[test]
     fn merge_deduplicates_same_backend_builtins() {
         let builtins = vec![
-            make_agent("a", AcpBackend::Claude, AgentSource::Builtin),
-            make_agent("b", AcpBackend::Claude, AgentSource::Builtin),
+            make_acp_agent("a", AcpBackend::Claude, AgentSource::Builtin),
+            make_acp_agent("b", AcpBackend::Claude, AgentSource::Builtin),
         ];
         let merged = AgentRegistry::merge(vec![], vec![], builtins, vec![]);
         let claude_count = merged
             .iter()
-            .filter(|a| a.backend == AcpBackend::Claude && a.source == AgentSource::Builtin)
+            .filter(|a| a.backend == Some(AcpBackend::Claude) && a.source == AgentSource::Builtin)
             .count();
         assert_eq!(claude_count, 1);
         assert_eq!(merged[0].id, "a");
@@ -240,12 +307,12 @@ mod tests {
 
     #[test]
     fn merge_keeps_internal_at_end() {
-        let internals = vec![make_agent(
+        let internals = vec![make_typed_agent(
             "aionrs",
-            AcpBackend::Aionrs,
+            AgentType::Aionrs,
             AgentSource::Internal,
         )];
-        let builtins = vec![make_agent(
+        let builtins = vec![make_acp_agent(
             "claude",
             AcpBackend::Claude,
             AgentSource::Builtin,
@@ -254,12 +321,25 @@ mod tests {
         assert_eq!(merged.last().unwrap().source, AgentSource::Internal);
     }
 
+    #[test]
+    fn dedup_non_acp_by_agent_type() {
+        let agents = vec![
+            make_typed_agent("oc1", AgentType::OpenclawGateway, AgentSource::Builtin),
+            make_typed_agent("oc2", AgentType::OpenclawGateway, AgentSource::Builtin),
+        ];
+        let deduped = AgentRegistry::deduplicate(agents);
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].id, "oc1");
+    }
+
     #[tokio::test]
     async fn registry_initialize_and_get_all() {
         let registry = AgentRegistry::new();
         registry.initialize(vec![], vec![]).await;
         let agents = registry.get_all().await;
-        assert!(agents.iter().any(|a| a.backend == AcpBackend::Aionrs));
+        assert!(agents
+            .iter()
+            .any(|a| a.agent_type == AgentType::Aionrs));
     }
 
     #[tokio::test]
@@ -276,9 +356,9 @@ mod tests {
             0
         );
 
-        let customs = vec![make_agent(
+        let customs = vec![make_acp_agent(
             "custom:test",
-            AcpBackend::Custom,
+            AcpBackend::Claude,
             AgentSource::Custom,
         )];
         registry.refresh_customs(customs).await;

--- a/crates/aionui-ai-agent/src/agent_registry.rs
+++ b/crates/aionui-ai-agent/src/agent_registry.rs
@@ -337,9 +337,7 @@ mod tests {
         let registry = AgentRegistry::new();
         registry.initialize(vec![], vec![]).await;
         let agents = registry.get_all().await;
-        assert!(agents
-            .iter()
-            .any(|a| a.agent_type == AgentType::Aionrs));
+        assert!(agents.iter().any(|a| a.agent_type == AgentType::Aionrs));
     }
 
     #[tokio::test]

--- a/crates/aionui-ai-agent/src/factory.rs
+++ b/crates/aionui-ai-agent/src/factory.rs
@@ -54,11 +54,10 @@ async fn build_agent(
 ) -> Result<AgentManagerHandle, AppError> {
     let conversation_id = options.conversation_id.clone();
     let workspace = if options.workspace.is_empty() {
-        let dir = deps.data_dir.join("tmp").join(format!(
-            "{:?}-temp-{}",
-            options.agent_type,
-            now_ms()
-        ));
+        let dir =
+            deps.data_dir
+                .join("tmp")
+                .join(format!("{:?}-temp-{}", options.agent_type, now_ms()));
         std::fs::create_dir_all(&dir)
             .map_err(|e| AppError::Internal(format!("Failed to create temp workspace: {e}")))?;
         dir.to_string_lossy().into_owned()

--- a/crates/aionui-ai-agent/src/factory.rs
+++ b/crates/aionui-ai-agent/src/factory.rs
@@ -84,7 +84,7 @@ async fn build_agent(
             if let Some(ref detected) = detected
                 && config.backend.is_none()
             {
-                config.backend = Some(detected.backend);
+                config.backend = detected.backend;
             }
 
             let (spawn_command, spawn_args) = match detected {

--- a/crates/aionui-api-types/src/agent.rs
+++ b/crates/aionui-api-types/src/agent.rs
@@ -1,11 +1,13 @@
-use aionui_common::AcpBackend;
+use aionui_common::{AcpBackend, AgentType};
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct AgentInfo {
     pub id: String,
     pub name: String,
-    pub backend: AcpBackend,
+    pub agent_type: AgentType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backend: Option<AcpBackend>,
     pub available: bool,
     pub source: crate::AgentSource,
 }
@@ -15,6 +17,7 @@ impl From<crate::DetectedAgent> for AgentInfo {
         Self {
             id: a.id,
             name: a.name,
+            agent_type: a.agent_type,
             backend: a.backend,
             available: a.available,
             source: a.source,
@@ -31,7 +34,8 @@ mod tests {
         let detected = crate::DetectedAgent {
             id: "abc123".into(),
             name: "Claude".into(),
-            backend: AcpBackend::Claude,
+            agent_type: AgentType::Acp,
+            backend: Some(AcpBackend::Claude),
             available: true,
             source: crate::AgentSource::Builtin,
             command: Some("/usr/bin/claude".into()),
@@ -41,23 +45,40 @@ mod tests {
         let info = AgentInfo::from(detected);
         assert_eq!(info.id, "abc123");
         assert_eq!(info.name, "Claude");
-        assert_eq!(info.backend, AcpBackend::Claude);
+        assert_eq!(info.agent_type, AgentType::Acp);
+        assert_eq!(info.backend, Some(AcpBackend::Claude));
         assert!(info.available);
         assert_eq!(info.source, crate::AgentSource::Builtin);
     }
 
     #[test]
-    fn agent_info_serde() {
+    fn agent_info_serde_acp() {
+        let info = AgentInfo {
+            id: "abc123".into(),
+            name: "Claude".into(),
+            agent_type: AgentType::Acp,
+            backend: Some(AcpBackend::Claude),
+            available: true,
+            source: crate::AgentSource::Builtin,
+        };
+        let json = serde_json::to_value(&info).unwrap();
+        assert_eq!(json["agent_type"], "acp");
+        assert_eq!(json["backend"], "claude");
+    }
+
+    #[test]
+    fn agent_info_serde_non_acp() {
         let info = AgentInfo {
             id: "aionrs".into(),
             name: "Aion CLI".into(),
-            backend: AcpBackend::Aionrs,
+            agent_type: AgentType::Aionrs,
+            backend: None,
             available: true,
             source: crate::AgentSource::Internal,
         };
         let json = serde_json::to_value(&info).unwrap();
-        assert_eq!(json["id"], "aionrs");
-        assert_eq!(json["backend"], "aionrs");
+        assert_eq!(json["agent_type"], "aionrs");
+        assert!(json.get("backend").is_none());
         assert_eq!(json["source"], "internal");
     }
 }

--- a/crates/aionui-api-types/src/agent_discovery.rs
+++ b/crates/aionui-api-types/src/agent_discovery.rs
@@ -1,4 +1,4 @@
-use aionui_common::AcpBackend;
+use aionui_common::{AcpBackend, AgentType};
 use serde::{Deserialize, Serialize};
 
 /// How an agent was discovered.
@@ -23,7 +23,9 @@ pub struct EnvVar {
 pub struct DetectedAgent {
     pub id: String,
     pub name: String,
-    pub backend: AcpBackend,
+    pub agent_type: AgentType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backend: Option<AcpBackend>,
     pub available: bool,
     pub source: AgentSource,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -60,7 +62,8 @@ mod tests {
         let agent = DetectedAgent {
             id: "abc12345".into(),
             name: "Claude".into(),
-            backend: AcpBackend::Claude,
+            agent_type: AgentType::Acp,
+            backend: Some(AcpBackend::Claude),
             available: true,
             source: AgentSource::Builtin,
             command: None,
@@ -69,6 +72,8 @@ mod tests {
         };
         let json = serde_json::to_value(&agent).unwrap();
         assert_eq!(json["id"], "abc12345");
+        assert_eq!(json["agent_type"], "acp");
+        assert_eq!(json["backend"], "claude");
         assert_eq!(json["source"], "builtin");
         assert!(json.get("command").is_none());
         assert!(json.get("args").is_none());
@@ -80,6 +85,7 @@ mod tests {
         let json = json!({
             "id": "ext123",
             "name": "MyAgent",
+            "agent_type": "acp",
             "backend": "claude",
             "available": true,
             "source": "extension",
@@ -87,9 +93,29 @@ mod tests {
             "env": [{"name": "FOO", "value": "bar"}]
         });
         let agent: DetectedAgent = serde_json::from_value(json).unwrap();
+        assert_eq!(agent.agent_type, AgentType::Acp);
+        assert_eq!(agent.backend, Some(AcpBackend::Claude));
         assert_eq!(agent.source, AgentSource::Extension);
         assert_eq!(agent.command.as_deref(), Some("/usr/bin/my-cli"));
         assert_eq!(agent.env.len(), 1);
         assert_eq!(agent.env[0].name, "FOO");
+    }
+
+    #[test]
+    fn detected_agent_without_backend() {
+        let agent = DetectedAgent {
+            id: "oc123".into(),
+            name: "OpenClaw Gateway".into(),
+            agent_type: AgentType::OpenclawGateway,
+            backend: None,
+            available: true,
+            source: AgentSource::Builtin,
+            command: Some("/usr/bin/openclaw".into()),
+            args: vec![],
+            env: vec![],
+        };
+        let json = serde_json::to_value(&agent).unwrap();
+        assert_eq!(json["agent_type"], "openclaw-gateway");
+        assert!(json.get("backend").is_none());
     }
 }

--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -24,7 +24,7 @@ use aionui_auth::{
 #[cfg(feature = "weixin")]
 use aionui_channel::weixin_login_route;
 use aionui_channel::{ChannelRouterState, channel_routes};
-use aionui_common::AcpBackend;
+use aionui_common::AgentType;
 use aionui_conversation::{ConversationRouterState, ConversationService, conversation_routes};
 use aionui_cron::{CronEventEmitter, CronRouterState, cron_routes};
 use aionui_db::{
@@ -242,7 +242,8 @@ async fn resolve_extension_agents(registry: &ExtensionRegistry) -> Vec<DetectedA
         .map(|a| DetectedAgent {
             id: a.id,
             name: a.name,
-            backend: AcpBackend::Custom,
+            agent_type: AgentType::Acp,
+            backend: None,
             available: true,
             source: AgentSource::Extension,
             command: a.default_cli_path.or(a.cli_command),

--- a/crates/aionui-app/tests/acp_e2e.rs
+++ b/crates/aionui-app/tests/acp_e2e.rs
@@ -68,11 +68,11 @@ async fn detect_cli_non_cli_backend_returns_no_path() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "user1", "pass123").await;
 
-    // "custom" backend has no CLI binary
+    // "gemini" backend has no CLI binary name (returns None)
     let req = json_with_token(
         "POST",
         "/api/acp/detect-cli",
-        json!({ "backend": "custom" }),
+        json!({ "backend": "gemini" }),
         &token,
         &csrf,
     );
@@ -97,7 +97,7 @@ async fn list_agents_returns_array() {
     assert_eq!(body["success"], true);
     assert!(body["data"].is_array());
     let agents = body["data"].as_array().unwrap();
-    assert!(agents.iter().any(|a| a["backend"] == "aionrs"));
+    assert!(agents.iter().any(|a| a["agent_type"] == "aionrs"));
 }
 
 #[tokio::test]
@@ -161,7 +161,7 @@ async fn health_check_non_cli_backend() {
     let req = json_with_token(
         "POST",
         "/api/acp/health-check",
-        json!({ "backend": "custom" }),
+        json!({ "backend": "gemini" }),
         &token,
         &csrf,
     );

--- a/crates/aionui-common/src/enums.rs
+++ b/crates/aionui-common/src/enums.rs
@@ -359,7 +359,10 @@ mod tests {
 
     #[test]
     fn test_agent_type_display_names() {
-        assert_eq!(AgentType::OpenclawGateway.display_name(), "OpenClaw Gateway");
+        assert_eq!(
+            AgentType::OpenclawGateway.display_name(),
+            "OpenClaw Gateway"
+        );
         assert_eq!(AgentType::Aionrs.display_name(), "Aion CLI");
         assert_eq!(AgentType::Nanobot.display_name(), "Nanobot");
         assert_eq!(AgentType::Gemini.display_name(), "Gemini");

--- a/crates/aionui-common/src/enums.rs
+++ b/crates/aionui-common/src/enums.rs
@@ -63,17 +63,11 @@ pub enum AcpBackend {
     Opencode,
     Copilot,
     Qoder,
-    #[serde(rename = "openclaw-gateway")]
-    OpenclawGateway,
     Vibe,
-    Nanobot,
     Cursor,
     Kiro,
     Hermes,
     Snow,
-    Remote,
-    Aionrs,
-    Custom,
 }
 
 impl AcpBackend {
@@ -93,7 +87,6 @@ impl AcpBackend {
         AcpBackend::Kimi,
         AcpBackend::Qoder,
         AcpBackend::Vibe,
-        AcpBackend::Nanobot,
         AcpBackend::Hermes,
         AcpBackend::Snow,
     ];
@@ -114,15 +107,9 @@ impl AcpBackend {
             AcpBackend::Kimi => Some("kimi"),
             AcpBackend::Qoder => Some("qoder"),
             AcpBackend::Vibe => Some("vibe"),
-            AcpBackend::Nanobot => Some("nanobot"),
             AcpBackend::Hermes => Some("hermes"),
             AcpBackend::Snow => Some("snow"),
-            AcpBackend::IFlow
-            | AcpBackend::Gemini
-            | AcpBackend::OpenclawGateway
-            | AcpBackend::Remote
-            | AcpBackend::Aionrs
-            | AcpBackend::Custom => None,
+            AcpBackend::IFlow | AcpBackend::Gemini => None,
         }
     }
 
@@ -147,16 +134,11 @@ impl AcpBackend {
             AcpBackend::Opencode => "OpenCode",
             AcpBackend::Copilot => "Copilot",
             AcpBackend::Qoder => "Qoder",
-            AcpBackend::OpenclawGateway => "OpenClaw Gateway",
             AcpBackend::Vibe => "Vibe",
-            AcpBackend::Nanobot => "Nanobot",
             AcpBackend::Cursor => "Cursor",
             AcpBackend::Kiro => "Kiro",
             AcpBackend::Hermes => "Hermes",
             AcpBackend::Snow => "Snow",
-            AcpBackend::Remote => "Remote",
-            AcpBackend::Aionrs => "Aionrs",
-            AcpBackend::Custom => "Custom",
         }
     }
 
@@ -205,9 +187,8 @@ impl AcpBackend {
             AcpBackend::Hermes => Some(&["acp"]),
             AcpBackend::Snow => Some(&["--acp"]),
             AcpBackend::Qwen => Some(&["--acp"]),
-            AcpBackend::Nanobot => Some(&["--experimental-acp"]),
             // Non-CLI backends
-            _ => None,
+            AcpBackend::IFlow | AcpBackend::Gemini => None,
         }
     }
 }
@@ -451,7 +432,6 @@ mod tests {
             (AcpBackend::Claude, "claude"),
             (AcpBackend::Codebuddy, "codebuddy"),
             (AcpBackend::Opencode, "opencode"),
-            (AcpBackend::OpenclawGateway, "openclaw-gateway"),
             (AcpBackend::Hermes, "hermes"),
             (AcpBackend::Snow, "snow"),
         ];
@@ -560,10 +540,6 @@ mod tests {
     fn test_acp_backend_cli_binary_name_none() {
         assert_eq!(AcpBackend::IFlow.cli_binary_name(), None);
         assert_eq!(AcpBackend::Gemini.cli_binary_name(), None);
-        assert_eq!(AcpBackend::OpenclawGateway.cli_binary_name(), None);
-        assert_eq!(AcpBackend::Remote.cli_binary_name(), None);
-        assert_eq!(AcpBackend::Aionrs.cli_binary_name(), None);
-        assert_eq!(AcpBackend::Custom.cli_binary_name(), None);
     }
 
     #[test]
@@ -572,10 +548,6 @@ mod tests {
         assert_eq!(AcpBackend::IFlow.display_name(), "iFlow");
         assert_eq!(AcpBackend::Codebuddy.display_name(), "CodeBuddy");
         assert_eq!(AcpBackend::Opencode.display_name(), "OpenCode");
-        assert_eq!(
-            AcpBackend::OpenclawGateway.display_name(),
-            "OpenClaw Gateway"
-        );
     }
 
     #[test]

--- a/crates/aionui-common/src/enums.rs
+++ b/crates/aionui-common/src/enums.rs
@@ -15,6 +15,36 @@ pub enum AgentType {
     Aionrs,
 }
 
+impl AgentType {
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            AgentType::Gemini => "Gemini",
+            AgentType::Acp => "ACP",
+            AgentType::OpenclawGateway => "OpenClaw Gateway",
+            AgentType::Nanobot => "Nanobot",
+            AgentType::Remote => "Remote",
+            AgentType::Aionrs => "Aion CLI",
+        }
+    }
+
+    pub fn serde_name(&self) -> &'static str {
+        match self {
+            AgentType::Gemini => "gemini",
+            AgentType::Acp => "acp",
+            AgentType::OpenclawGateway => "openclaw-gateway",
+            AgentType::Nanobot => "nanobot",
+            AgentType::Remote => "remote",
+            AgentType::Aionrs => "aionrs",
+        }
+    }
+
+    pub fn id(&self) -> String {
+        let hash = fnv1a_hex8(self.serde_name().as_bytes());
+        // SAFETY: fnv1a_hex8 only produces ASCII hex digits
+        unsafe { std::str::from_utf8_unchecked(&hash) }.into()
+    }
+}
+
 /// ACP sub-backend identifier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -345,6 +375,41 @@ pub enum McpServerStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_agent_type_display_names() {
+        assert_eq!(AgentType::OpenclawGateway.display_name(), "OpenClaw Gateway");
+        assert_eq!(AgentType::Aionrs.display_name(), "Aion CLI");
+        assert_eq!(AgentType::Nanobot.display_name(), "Nanobot");
+        assert_eq!(AgentType::Gemini.display_name(), "Gemini");
+        assert_eq!(AgentType::Remote.display_name(), "Remote");
+        assert_eq!(AgentType::Acp.display_name(), "ACP");
+    }
+
+    #[test]
+    fn test_agent_type_id_stability() {
+        let id = AgentType::Aionrs.id();
+        assert_eq!(id.len(), 8);
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(AgentType::Aionrs.id(), AgentType::Aionrs.id());
+    }
+
+    #[test]
+    fn test_agent_type_id_unique_per_variant() {
+        let ids: Vec<String> = [
+            AgentType::Gemini,
+            AgentType::Acp,
+            AgentType::OpenclawGateway,
+            AgentType::Nanobot,
+            AgentType::Remote,
+            AgentType::Aionrs,
+        ]
+        .iter()
+        .map(|t| t.id())
+        .collect();
+        let unique: std::collections::HashSet<&String> = ids.iter().collect();
+        assert_eq!(unique.len(), ids.len());
+    }
 
     #[test]
     fn test_agent_type_serde_roundtrip() {

--- a/crates/aionui-common/src/lib.rs
+++ b/crates/aionui-common/src/lib.rs
@@ -16,7 +16,9 @@ pub use enums::{
     PreviewContentType, ProtocolType, RemoteAgentAuthType, RemoteAgentProtocol, RemoteAgentStatus,
 };
 pub use error::AppError;
-pub use id::{fnv1a_hex8, generate_id, generate_id_with_length, generate_prefixed_id, generate_short_id};
+pub use id::{
+    fnv1a_hex8, generate_id, generate_id_with_length, generate_prefixed_id, generate_short_id,
+};
 pub use pagination::PaginatedResult;
 pub use timestamp::{TimestampMs, now_ms};
 pub use types::{Confirmation, ConfirmationOption, ProviderWithModel, UpdateType, VersionInfo};

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -79,7 +79,8 @@ impl StreamRelay {
                         if has_thinking {
                             self.send_thinking_done();
                         }
-                        self.persist_thinking(&thinking_buffer, thinking_started_at).await;
+                        self.persist_thinking(&thinking_buffer, thinking_started_at)
+                            .await;
                         self.finalize(&text_buffer, &record_created, &event).await;
                         self.send_turn_completed(&event);
                         break;
@@ -89,7 +90,8 @@ impl StreamRelay {
                     if has_thinking {
                         self.send_thinking_done();
                     }
-                    self.persist_thinking(&thinking_buffer, thinking_started_at).await;
+                    self.persist_thinking(&thinking_buffer, thinking_started_at)
+                        .await;
                     // Channel closed without finish/error — still finalize
                     self.finalize(
                         &text_buffer,
@@ -307,14 +309,13 @@ impl StreamRelay {
 
     /// Send a `thinking` event with `status: "done"` to close the thinking UI.
     fn send_thinking_done(&self) {
-        let thinking_done = AgentStreamEvent::Thinking(
-            aionui_ai_agent::stream_event::ThinkingEventData {
+        let thinking_done =
+            AgentStreamEvent::Thinking(aionui_ai_agent::stream_event::ThinkingEventData {
                 content: String::new(),
                 subject: None,
                 duration: None,
                 status: Some("done".into()),
-            },
-        );
+            });
         self.forward_to_websocket(&thinking_done);
     }
 


### PR DESCRIPTION
## Summary

- `DetectedAgent` 新增 `agent_type: AgentType` 字段，`backend` 改为 `Option<AcpBackend>`（仅 ACP agent 有值）
- 从 `AcpBackend` 枚举移除 5 个非 ACP 变体（OpenclawGateway、Nanobot、Remote、Aionrs、Custom），使其回归 "ACP sub-backend" 纯粹语义
- 按 `AgentType` 拆分检测逻辑：`detect_acp_agents()`、`detect_openclaw()`、`detect_nanobot()` 各自独立
- `/api/agents` 响应现在携带 `agent_type` 字段，与前端 `DetectedAgentKind` 概念对齐
- 修复 openclaw-gateway 无法被发现的问题（之前不在 `CLI_BACKENDS` 中，现在有独立检测函数）

## Motivation

之前所有 agent 都被建模为 `AcpBackend` 的变体，但 `AgentType` 才是顶层分类。`openclaw-gateway`、`nanobot` 等独立 agent 类型不应该挤在 ACP 体系里。这导致 `openclaw-gateway` 因为没有 `cli_binary_name()` 而无法被检测到。

## Breaking Changes

- `DetectedAgent.backend` 从 `AcpBackend` 改为 `Option<AcpBackend>`
- `AgentInfo` 新增 `agent_type` 字段，`backend` 变为可选
- `AcpBackend` 枚举移除了 `OpenclawGateway`、`Nanobot`、`Remote`、`Aionrs`、`Custom` 变体
- 前端需适配 `/api/agents` 新响应结构（新增 `agent_type`，`backend` 可能缺失）

## Test plan

- [x] `cargo fmt --all -- --check` 通过
- [x] `cargo clippy --workspace -- -D warnings` 零警告
- [x] `cargo test --workspace` 全量通过
- [ ] 前端联调验证 `/api/agents` 返回包含 `agent_type` 字段
- [ ] 验证 openclaw-gateway 在安装了 `openclaw` CLI 的环境中出现在 agent 列表