### PR TITLE
fix: auto-assign workspace on conversation create

### DIFF
--- a/crates/aionui-ai-agent/src/auxiliary_routes.rs
+++ b/crates/aionui-ai-agent/src/auxiliary_routes.rs
@@ -8,6 +8,7 @@ use axum::routing::{get, post};
 use aionui_api_types::{AgentModeResponse, ApiResponse, SetModeRequest};
 use aionui_auth::CurrentUser;
 use aionui_common::{AgentType, AppError};
+use aionui_db::IConversationRepository;
 use serde::{Deserialize, Serialize};
 
 use crate::acp_agent::AcpAgentManager;
@@ -20,6 +21,7 @@ use crate::types::SlashCommandItem;
 #[derive(Clone)]
 pub struct AuxiliaryRouterState {
     pub worker_task_manager: Arc<dyn IWorkerTaskManager>,
+    pub conversation_repo: Arc<dyn IConversationRepository>,
 }
 
 /// Build the auxiliary routes router.
@@ -118,6 +120,9 @@ const MAX_DIR_DEPTH: usize = 10;
 /// GET /api/conversations/:id/workspace
 ///
 /// Browse the workspace directory associated with a conversation.
+///
+/// Reads the workspace path from `conversation.extra.workspace` in the
+/// database so it works before any agent session has been started.
 async fn browse_workspace(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
@@ -128,11 +133,29 @@ async fn browse_workspace(
         return Err(AppError::BadRequest("path must not be empty".into()));
     }
 
-    let handle = get_task(&state, &id)?;
-    let workspace = handle.workspace();
+    let row = state
+        .conversation_repo
+        .get(&id)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to load conversation: {e}")))?
+        .ok_or_else(|| AppError::NotFound(format!("Conversation '{id}' not found")))?;
+
+    let extra: serde_json::Value = serde_json::from_str(&row.extra)
+        .map_err(|e| AppError::Internal(format!("Invalid extra JSON: {e}")))?;
+    let workspace = extra
+        .get("workspace")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_owned();
+    if workspace.is_empty() {
+        return Err(AppError::BadRequest(
+            "Conversation has no workspace assigned".into(),
+        ));
+    }
 
     // Resolve the browsed path relative to the workspace root
-    let base = std::path::Path::new(workspace);
+    let base = std::path::Path::new(&workspace);
     let browse_path = base.join(query.path.trim_start_matches('/'));
 
     // Security: ensure the resolved path is within the workspace

--- a/crates/aionui-ai-agent/src/factory.rs
+++ b/crates/aionui-ai-agent/src/factory.rs
@@ -62,16 +62,16 @@ async fn build_agent(
                     .get("backend")
                     .and_then(|v| serde_json::from_value::<AcpBackend>(v.clone()).ok());
                 match backend {
-                    Some(b) => format!("acp-{}", b.display_name()).to_lowercase(),
+                    Some(b) => b.display_name().to_lowercase(),
                     None => "acp".to_string(),
                 }
             }
-            other => format!("{other:?}").to_lowercase(),
+            other => match other {
+                AgentType::OpenclawGateway => "openclaw".to_string(),
+                t => format!("{t:?}").to_lowercase(),
+            },
         };
-        let dir = deps
-            .data_dir
-            .join("tmp")
-            .join(format!("{label}-temp-{}", now_ms()));
+        let dir = deps.data_dir.join(format!("{label}-temp-{}", now_ms()));
         std::fs::create_dir_all(&dir)
             .map_err(|e| AppError::Internal(format!("Failed to create temp workspace: {e}")))?;
         dir.to_string_lossy().into_owned()

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -48,9 +48,6 @@ pub struct AcpBuildExtra {
     /// Path to the CLI executable (resolved from registry when `agent_id` is set).
     #[serde(default)]
     pub cli_path: Option<String>,
-    /// Whether the user picked a custom workspace path.
-    #[serde(default)]
-    pub custom_workspace: bool,
     /// Agent name within the ACP backend.
     #[serde(default)]
     pub agent_name: Option<String>,
@@ -94,9 +91,6 @@ pub struct OpenClawBuildExtra {
     /// Agent name.
     #[serde(default)]
     pub agent_name: Option<String>,
-    /// Whether the user picked a custom workspace path.
-    #[serde(default)]
-    pub custom_workspace: bool,
     /// OpenClaw gateway configuration.
     pub gateway: OpenClawGatewayConfig,
     /// Skills to enable.

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -58,7 +58,6 @@ async fn make_mock_agent(
         agent_id: None,
         backend: Some(backend),
         cli_path: Some(script_path.to_string_lossy().into_owned()),
-        custom_workspace: false,
         agent_name: None,
         custom_agent_id: None,
         preset_context: None,

--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -435,7 +435,11 @@ pub fn build_conversation_state(services: &AppServices) -> ConversationRouterSta
     let pool = services.database.pool().clone();
     let repo = Arc::new(SqliteConversationRepository::new(pool));
     ConversationRouterState {
-        conversation_service: ConversationService::new(repo, services.event_bus.clone()),
+        conversation_service: ConversationService::new_with_workspace_root(
+            repo,
+            services.event_bus.clone(),
+            std::path::PathBuf::from(&services.data_dir),
+        ),
         worker_task_manager: services.worker_task_manager.clone(),
     }
 }
@@ -563,7 +567,11 @@ pub fn build_team_state(services: &AppServices) -> TeamRouterState {
         Arc::new(aionui_db::SqliteTeamRepository::new(pool.clone()));
     let conv_repo: Arc<dyn aionui_db::IConversationRepository> =
         Arc::new(SqliteConversationRepository::new(pool));
-    let conv_service = ConversationService::new(conv_repo, services.event_bus.clone());
+    let conv_service = ConversationService::new_with_workspace_root(
+        conv_repo,
+        services.event_bus.clone(),
+        std::path::PathBuf::from(&services.data_dir),
+    );
     let service = Arc::new(TeamSessionService::new(
         team_repo,
         conv_service,
@@ -580,7 +588,11 @@ pub fn build_cron_state(services: &AppServices) -> CronRouterState {
 
     let conv_repo: Arc<dyn aionui_db::IConversationRepository> =
         Arc::new(SqliteConversationRepository::new(pool));
-    let conv_service = ConversationService::new(conv_repo.clone(), services.event_bus.clone());
+    let conv_service = ConversationService::new_with_workspace_root(
+        conv_repo.clone(),
+        services.event_bus.clone(),
+        std::path::PathBuf::from(&services.data_dir),
+    );
 
     let busy_guard = Arc::new(aionui_cron::busy_guard::CronBusyGuard::new());
     let executor = Arc::new(aionui_cron::executor::JobExecutor::new(

--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -470,8 +470,11 @@ pub fn build_connection_test_state() -> ConnectionTestRouterState {
 
 /// Build the default `AuxiliaryRouterState` from application services.
 pub fn build_auxiliary_state(services: &AppServices) -> AuxiliaryRouterState {
+    let pool = services.database.pool().clone();
+    let conversation_repo = Arc::new(SqliteConversationRepository::new(pool));
     AuxiliaryRouterState {
         worker_task_manager: services.worker_task_manager.clone(),
+        conversation_repo,
     }
 }
 

--- a/crates/aionui-app/tests/auxiliary_e2e.rs
+++ b/crates/aionui-app/tests/auxiliary_e2e.rs
@@ -22,6 +22,39 @@ fn create_conv_body(name: &str, agent_type: &str) -> serde_json::Value {
     })
 }
 
+fn create_conv_body_with_workspace(
+    name: &str,
+    agent_type: &str,
+    workspace: &str,
+) -> serde_json::Value {
+    json!({
+        "type": agent_type,
+        "name": name,
+        "model": { "provider_id": "p1", "model": "m1" },
+        "extra": { "workspace": workspace }
+    })
+}
+
+async fn create_conversation_with_workspace(
+    app: &mut axum::Router,
+    token: &str,
+    csrf: &str,
+    name: &str,
+    agent_type: &str,
+    workspace: &str,
+) -> String {
+    let req = common::json_with_token(
+        "POST",
+        "/api/conversations",
+        create_conv_body_with_workspace(name, agent_type, workspace),
+        token,
+        csrf,
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let json = common::body_json(resp).await;
+    json["data"]["id"].as_str().unwrap().to_owned()
+}
+
 async fn create_conversation(
     app: &mut axum::Router,
     token: &str,
@@ -66,14 +99,41 @@ async fn workspace_browse_requires_auth() {
 async fn workspace_browse_no_active_task() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "user1", "pass123").await;
-    let conv_id = create_conversation(&mut app, &token, &csrf, "Test Conv", "acp").await;
+
+    // Seed a real workspace on disk so the handler can canonicalize it.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    std::fs::write(tmp.path().join("src/lib.rs"), b"// hi").unwrap();
+
+    let ws = tmp.path().to_string_lossy().into_owned();
+    let conv_id =
+        create_conversation_with_workspace(&mut app, &token, &csrf, "Test Conv", "acp", &ws)
+            .await;
 
     let req = get_with_token(
         &format!("/api/conversations/{conv_id}/workspace?path=/src"),
         &token,
     );
     let resp = app.oneshot(req).await.unwrap();
-    // No active agent task → 404
+    // Workspace comes from DB; no active agent required.
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    let entries = json["data"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["name"], "lib.rs");
+    assert_eq!(entries[0]["type"], "file");
+}
+
+#[tokio::test]
+async fn workspace_browse_conversation_not_found() {
+    let (mut app, services) = build_app().await;
+    let (token, _csrf) = setup_and_login(&mut app, &services, "user1", "pass123").await;
+
+    let req = get_with_token(
+        "/api/conversations/does-not-exist/workspace?path=/src",
+        &token,
+    );
+    let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -31,6 +31,7 @@ pub struct ConversationService {
     repo: Arc<dyn IConversationRepository>,
     broadcaster: Arc<dyn EventBroadcaster>,
     delete_hooks: Vec<Arc<dyn OnConversationDelete>>,
+    workspace_root: std::path::PathBuf,
 }
 
 impl ConversationService {
@@ -42,6 +43,20 @@ impl ConversationService {
             repo,
             broadcaster,
             delete_hooks: Vec::new(),
+            workspace_root: std::path::PathBuf::from("data"),
+        }
+    }
+
+    pub fn new_with_workspace_root(
+        repo: Arc<dyn IConversationRepository>,
+        broadcaster: Arc<dyn EventBroadcaster>,
+        workspace_root: std::path::PathBuf,
+    ) -> Self {
+        Self {
+            repo,
+            broadcaster,
+            delete_hooks: Vec::new(),
+            workspace_root,
         }
     }
 
@@ -54,6 +69,7 @@ impl ConversationService {
             repo,
             broadcaster,
             delete_hooks,
+            workspace_root: std::path::PathBuf::from("data"),
         }
     }
 
@@ -70,12 +86,20 @@ impl ConversationService {
         let now = now_ms();
         let source = req.source.unwrap_or(ConversationSource::Aionui);
 
+        let mut extra = req.extra;
+        if extra.get("workspace").and_then(|v| v.as_str()).unwrap_or("").is_empty() {
+            let ws_path = self.workspace_root.join("workspaces").join(&id);
+            std::fs::create_dir_all(&ws_path)
+                .map_err(|e| AppError::Internal(format!("Failed to create workspace: {e}")))?;
+            extra["workspace"] = serde_json::Value::String(ws_path.to_string_lossy().into_owned());
+        }
+
         let row = aionui_db::models::ConversationRow {
             id: id.clone(),
             user_id: user_id.to_owned(),
             name: req.name.unwrap_or_default(),
             r#type: enum_to_db(&req.r#type)?,
-            extra: serde_json::to_string(&req.extra)
+            extra: serde_json::to_string(&extra)
                 .map_err(|e| AppError::Internal(format!("Failed to serialize extra: {e}")))?,
             model: req
                 .model

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -88,7 +88,14 @@ impl ConversationService {
 
         let mut extra = req.extra;
         if extra.get("workspace").and_then(|v| v.as_str()).unwrap_or("").is_empty() {
-            let ws_path = self.workspace_root.join("workspaces").join(&id);
+            let agent_type_label = match req.r#type {
+                aionui_common::AgentType::Acp => "acp".to_owned(),
+                ref t => format!("{:?}", t).to_lowercase(),
+            };
+            let ws_path = self
+                .workspace_root
+                .join("tmp")
+                .join(format!("{}-temp-{}", agent_type_label, now));
             std::fs::create_dir_all(&ws_path)
                 .map_err(|e| AppError::Internal(format!("Failed to create workspace: {e}")))?;
             extra["workspace"] = serde_json::Value::String(ws_path.to_string_lossy().into_owned());

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -94,12 +94,20 @@ impl ConversationService {
             .is_empty()
         {
             let agent_type_label = match req.r#type {
-                aionui_common::AgentType::Acp => "acp".to_owned(),
+                aionui_common::AgentType::Acp => {
+                    let backend = extra.get("backend").and_then(|v| {
+                        serde_json::from_value::<aionui_common::AcpBackend>(v.clone()).ok()
+                    });
+                    match backend {
+                        Some(b) => b.display_name().to_lowercase(),
+                        None => "acp".to_owned(),
+                    }
+                }
+                aionui_common::AgentType::OpenclawGateway => "openclaw".to_owned(),
                 ref t => format!("{:?}", t).to_lowercase(),
             };
             let ws_path = self
                 .workspace_root
-                .join("tmp")
                 .join(format!("{}-temp-{}", agent_type_label, now));
             std::fs::create_dir_all(&ws_path)
                 .map_err(|e| AppError::Internal(format!("Failed to create workspace: {e}")))?;

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -87,7 +87,12 @@ impl ConversationService {
         let source = req.source.unwrap_or(ConversationSource::Aionui);
 
         let mut extra = req.extra;
-        if extra.get("workspace").and_then(|v| v.as_str()).unwrap_or("").is_empty() {
+        if extra
+            .get("workspace")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .is_empty()
+        {
             let agent_type_label = match req.r#type {
                 aionui_common::AgentType::Acp => "acp".to_owned(),
                 ref t => format!("{:?}", t).to_lowercase(),
@@ -628,7 +633,13 @@ impl ConversationService {
 
         // Build task options from conversation row
         let build_opts = self.build_task_options(&row)?;
+        let stored_workspace = build_opts.workspace.clone();
         let agent = task_manager.get_or_build_task(conversation_id, build_opts)?;
+
+        // If the factory resolved a different workspace (e.g. auto-created temp
+        // dir for a legacy conversation with empty workspace), persist it back.
+        self.maybe_persist_workspace(conversation_id, &stored_workspace, agent.workspace())
+            .await?;
 
         // Update conversation status to running
         let update = ConversationRowUpdate {
@@ -719,7 +730,12 @@ impl ConversationService {
             })?;
 
         let build_opts = self.build_task_options(&row)?;
-        let _agent = task_manager.get_or_build_task(conversation_id, build_opts)?;
+        let stored_workspace = build_opts.workspace.clone();
+        let agent = task_manager.get_or_build_task(conversation_id, build_opts)?;
+
+        // Persist auto-resolved workspace if factory picked a different path.
+        self.maybe_persist_workspace(conversation_id, &stored_workspace, agent.workspace())
+            .await?;
 
         debug!(conversation_id, "Agent warmed up");
         Ok(())
@@ -761,6 +777,49 @@ impl ConversationService {
             conversation_id: row.id.clone(),
             extra,
         })
+    }
+
+    /// Write the resolved workspace back to `conversation.extra.workspace` when
+    /// the factory picked a different (auto-generated) path than what was stored.
+    ///
+    /// This handles legacy conversations whose `extra.workspace` was empty:
+    /// the factory creates a temp dir at task-build time, and we persist that
+    /// path here so the frontend can display the workspace panel correctly.
+    async fn maybe_persist_workspace(
+        &self,
+        conversation_id: &str,
+        stored_workspace: &str,
+        resolved_workspace: &str,
+    ) -> Result<(), AppError> {
+        if resolved_workspace.is_empty() || resolved_workspace == stored_workspace {
+            return Ok(());
+        }
+
+        // Fetch latest extra, merge the resolved workspace path in, and persist.
+        let row = self.repo.get(conversation_id).await?.ok_or_else(|| {
+            AppError::Internal("Conversation vanished during workspace sync".into())
+        })?;
+
+        let mut extra: serde_json::Value =
+            serde_json::from_str(&row.extra).unwrap_or_else(|_| serde_json::json!({}));
+        extra["workspace"] = serde_json::Value::String(resolved_workspace.to_owned());
+
+        let extra_json = serde_json::to_string(&extra)
+            .map_err(|e| AppError::Internal(format!("Failed to serialize extra: {e}")))?;
+
+        let update = ConversationRowUpdate {
+            extra: Some(extra_json),
+            updated_at: Some(now_ms()),
+            ..Default::default()
+        };
+        self.repo.update(conversation_id, &update).await?;
+
+        debug!(
+            conversation_id,
+            workspace = resolved_workspace,
+            "Persisted auto-resolved workspace to conversation.extra"
+        );
+        Ok(())
     }
 
     /// Broadcast a `conversation.listChanged` WebSocket event.

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1211,7 +1211,7 @@ async fn send_message_persists_factory_resolved_workspace() {
     // Factory resolves a *different* temp dir (simulating legacy-conv fallback).
     // After send_message, conversation.extra.workspace must match what the
     // agent reports.
-    let (svc, _broadcaster, repo) = make_service();
+    let (svc, _broadcaster, repo, _default_task_mgr) = make_service();
     let auto_workspace = "/tmp/factory-resolved";
     let task_mgr: Arc<dyn IWorkerTaskManager> =
         Arc::new(MockTaskManagerWithWorkspace::new(auto_workspace));

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -240,7 +240,11 @@ fn make_service() -> (
 ) {
     let repo = Arc::new(MockRepo::new());
     let broadcaster = Arc::new(MockBroadcaster::new());
-    let svc = ConversationService::new(repo.clone(), broadcaster.clone());
+    let svc = ConversationService::new_with_workspace_root(
+        repo.clone(),
+        broadcaster.clone(),
+        std::path::PathBuf::from(std::env::temp_dir()),
+    );
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
     (svc, broadcaster, repo, task_mgr)
 }

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -872,6 +872,8 @@ struct MockAgent {
     stopped: Mutex<bool>,
     confirmations: Mutex<Vec<Confirmation>>,
     approval_memory: Mutex<std::collections::HashMap<String, bool>>,
+    /// Optional workspace override; falls back to "/tmp/test" when `None`.
+    workspace_override: Option<String>,
 }
 
 impl MockAgent {
@@ -883,6 +885,7 @@ impl MockAgent {
             stopped: Mutex::new(false),
             confirmations: Mutex::new(vec![]),
             approval_memory: Mutex::new(std::collections::HashMap::new()),
+            workspace_override: None,
         }
     }
 
@@ -894,6 +897,7 @@ impl MockAgent {
             stopped: Mutex::new(false),
             confirmations: Mutex::new(confirmations),
             approval_memory: Mutex::new(std::collections::HashMap::new()),
+            workspace_override: None,
         }
     }
 }
@@ -907,7 +911,7 @@ impl IAgentManager for MockAgent {
         None
     }
     fn workspace(&self) -> &str {
-        "/tmp/test"
+        self.workspace_override.as_deref().unwrap_or("/tmp/test")
     }
     fn conversation_id(&self) -> &str {
         &self.conversation_id
@@ -1011,6 +1015,65 @@ impl IWorkerTaskManager for MockTaskManager {
         let agent: AgentManagerHandle = Arc::new(MockAgent::new(conversation_id));
         agents.insert(conversation_id.to_owned(), agent.clone());
         Ok(agent)
+    }
+
+    fn kill(
+        &self,
+        conversation_id: &str,
+        _reason: Option<AgentKillReason>,
+    ) -> Result<(), AppError> {
+        self.agents.lock().unwrap().remove(conversation_id);
+        Ok(())
+    }
+
+    fn clear(&self) {
+        self.agents.lock().unwrap().clear();
+    }
+
+    fn active_count(&self) -> usize {
+        self.agents.lock().unwrap().len()
+    }
+
+    fn collect_idle(&self, _idle_threshold_ms: TimestampMs) -> Vec<String> {
+        vec![]
+    }
+}
+
+/// A variant of MockTaskManager that always builds agents with a specific workspace.
+struct MockTaskManagerWithWorkspace {
+    workspace: String,
+    agents: Mutex<std::collections::HashMap<String, AgentManagerHandle>>,
+}
+
+impl MockTaskManagerWithWorkspace {
+    fn new(workspace: &str) -> Self {
+        Self {
+            workspace: workspace.to_owned(),
+            agents: Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+}
+
+impl IWorkerTaskManager for MockTaskManagerWithWorkspace {
+    fn get_task(&self, conversation_id: &str) -> Option<AgentManagerHandle> {
+        self.agents.lock().unwrap().get(conversation_id).cloned()
+    }
+
+    fn get_or_build_task(
+        &self,
+        conversation_id: &str,
+        _options: BuildTaskOptions,
+    ) -> Result<AgentManagerHandle, AppError> {
+        let workspace = self.workspace.clone();
+        let mut agents = self.agents.lock().unwrap();
+        if let Some(existing) = agents.get(conversation_id) {
+            return Ok(existing.clone());
+        }
+        let mut agent = MockAgent::new(conversation_id);
+        agent.workspace_override = Some(workspace);
+        let handle: AgentManagerHandle = Arc::new(agent);
+        agents.insert(conversation_id.to_owned(), handle.clone());
+        Ok(handle)
     }
 
     fn kill(
@@ -1140,6 +1203,42 @@ async fn send_message_running_conversation_returns_conflict() {
         .await
         .unwrap_err();
     assert!(matches!(err, AppError::Conflict(_)));
+}
+
+#[tokio::test]
+async fn send_message_persists_factory_resolved_workspace() {
+    // Conversation created with no workspace → create() auto-assigns one.
+    // Factory resolves a *different* temp dir (simulating legacy-conv fallback).
+    // After send_message, conversation.extra.workspace must match what the
+    // agent reports.
+    let (svc, _broadcaster, repo) = make_service();
+    let auto_workspace = "/tmp/factory-resolved";
+    let task_mgr: Arc<dyn IWorkerTaskManager> =
+        Arc::new(MockTaskManagerWithWorkspace::new(auto_workspace));
+
+    // Create a conversation with an empty workspace to simulate legacy case.
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "model": { "provider_id": "p1", "model": "m1" },
+        "extra": {}
+    }))
+    .unwrap();
+    let conv = svc.create("user_1", req).await.unwrap();
+
+    // Inject an empty workspace directly into the repo to mimic legacy state.
+    let empty_ws_update = ConversationRowUpdate {
+        extra: Some(r#"{"workspace":""}"#.to_owned()),
+        ..Default::default()
+    };
+    repo.update(&conv.id, &empty_ws_update).await.unwrap();
+
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr)
+        .await
+        .unwrap();
+
+    // Verify the workspace was written back.
+    let updated = svc.get("user_1", &conv.id).await.unwrap();
+    assert_eq!(updated.extra["workspace"], auto_workspace);
 }
 
 // ── stop_stream tests ───────────────────────────────────────────

--- a/crates/aionui-conversation/tests/conversation_crud.rs
+++ b/crates/aionui-conversation/tests/conversation_crud.rs
@@ -70,7 +70,11 @@ async fn setup() -> (
     let db = init_database_memory().await.unwrap();
     let repo = Arc::new(SqliteConversationRepository::new(db.pool().clone()));
     let broadcaster = Arc::new(TestBroadcaster::new());
-    let svc = ConversationService::new(repo, broadcaster.clone());
+    let svc = ConversationService::new_with_workspace_root(
+        repo,
+        broadcaster.clone(),
+        std::env::temp_dir(),
+    );
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(NoopTaskManager);
     (svc, broadcaster, task_mgr)
 }

--- a/crates/aionui-conversation/tests/conversation_extended.rs
+++ b/crates/aionui-conversation/tests/conversation_extended.rs
@@ -40,7 +40,11 @@ async fn setup() -> (
     let db = init_database_memory().await.unwrap();
     let repo = Arc::new(SqliteConversationRepository::new(db.pool().clone()));
     let broadcaster = Arc::new(TestBroadcaster::new());
-    let svc = ConversationService::new(repo.clone(), broadcaster.clone());
+    let svc = ConversationService::new_with_workspace_root(
+        repo.clone(),
+        broadcaster.clone(),
+        std::env::temp_dir(),
+    );
     (svc, repo, broadcaster)
 }
 

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -768,9 +768,10 @@ mod tests {
         let stub_broadcaster: Arc<dyn aionui_realtime::EventBroadcaster> =
             Arc::new(StubBroadcaster);
         let stub_repo: Arc<dyn IConversationRepository> = Arc::new(StubConvRepo);
-        let conv_service = Arc::new(ConversationService::new(
+        let conv_service = Arc::new(ConversationService::new_with_workspace_root(
             Arc::clone(&stub_repo),
             stub_broadcaster,
+            std::env::temp_dir(),
         ));
 
         JobExecutor::new(Arc::new(StubTaskManager), stub_repo, conv_service, guard)

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -220,9 +220,10 @@ async fn setup() -> (CronService, Arc<dyn ICronRepository>, Arc<MockBroadcaster>
     let bc = Arc::new(MockBroadcaster::new());
 
     let stub_conv_repo: Arc<dyn IConversationRepository> = Arc::new(StubConvRepo);
-    let conv_service = Arc::new(ConversationService::new(
+    let conv_service = Arc::new(ConversationService::new_with_workspace_root(
         Arc::clone(&stub_conv_repo),
         bc.clone() as Arc<dyn EventBroadcaster>,
+        std::env::temp_dir(),
     ));
     let busy_guard = Arc::new(CronBusyGuard::new());
     let executor = Arc::new(JobExecutor::new(

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -272,7 +272,11 @@ fn setup() -> TeamSessionService {
     let team_repo: Arc<dyn ITeamRepository> = Arc::new(FullMockTeamRepo::new());
     let conv_repo: Arc<dyn IConversationRepository> = Arc::new(MockConversationRepo::new());
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-    let conv_service = ConversationService::new(conv_repo, broadcaster.clone());
+    let conv_service = ConversationService::new_with_workspace_root(
+        conv_repo,
+        broadcaster.clone(),
+        std::env::temp_dir(),
+    );
     TeamSessionService::new(team_repo, conv_service, broadcaster)
 }
 


### PR DESCRIPTION
## 问题

Conversation 创建时 `extra.workspace` 字段为空，前端工作区面板无法渲染。另外 `GET /api/conversations/{id}/workspace` 文件树浏览端点要求 active agent session，用户选择工作区但未发消息时返回 404。

## 解决方案

1. **ConversationService.create()** 自动注入 workspace 路径：`{data_dir}/{backend}-temp-{timestamp}`（如 `claude-temp-1234567890`），格式与原 AionUi 一致
2. **factory.rs 运行后回写**：agent 启动时通过 `maybe_persist_workspace()` 将实际路径写回 DB
3. **browse_workspace** 从 `conversation.extra.workspace` 读路径，不再依赖 active agent session

## 顺带清理

移除 `AcpBuildExtra`、`GeminiBuildExtra`、`OpenClawBuildExtra` 中未被使用的 `custom_workspace` 死字段。

## 变更范围

- `crates/aionui-conversation/src/service.rs` — workspace 自动注入 + maybe_persist_workspace
- `crates/aionui-ai-agent/src/factory.rs` — 路径格式对齐原 AionUi
- `crates/aionui-ai-agent/src/auxiliary_routes.rs` — browse_workspace 不依赖 active agent
- `crates/aionui-ai-agent/src/types.rs` — 移除死字段

## Test plan

- [x] `cargo test --workspace` 通过
- [x] curl 验证：无 active agent 时 GET /api/conversations/{id}/workspace 返回 200 + 文件列表
- [x] 前端工作区面板能正确渲染

🤖 Generated with [Claude Code](https://claude.com/claude-code)