### PR TITLE
feat(app): configurable logging with --log-dir and --log-level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "wiremock",
 ]
@@ -1734,6 +1735,15 @@ dependencies = [
  "chrono",
  "once_cell",
  "winnow 0.6.26",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -5141,6 +5151,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5554,6 +5570,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ anyhow = "1"
 
 # Logging
 tracing = "0.1"
+tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # CLI

--- a/crates/aionui-app/Cargo.toml
+++ b/crates/aionui-app/Cargo.toml
@@ -35,6 +35,7 @@ tokio.workspace = true
 tower.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
+tracing-appender.workspace = true
 tracing-subscriber.workspace = true
 clap.workspace = true
 serde.workspace = true

--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -1,7 +1,13 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use clap::Parser;
 use tokio::net::TcpListener;
 use tracing::info;
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::EnvFilter;
 
 use aionui_app::{AppConfig, AppServices, create_router};
 
@@ -23,24 +29,72 @@ struct Cli {
     /// Run in local embedded mode (skip authentication, use system_default_user).
     #[arg(long)]
     local: bool,
+
+    /// Directory for log files. When set, logs are written to rolling daily
+    /// files under this directory. Without this, logs go to stderr only.
+    #[arg(long)]
+    log_dir: Option<PathBuf>,
+
+    /// Log level filter (e.g. "warn", "info", "debug", "info,aionui_ai_agent=debug").
+    /// Defaults to "warn" when no log directory is set, "info" when one is.
+    #[arg(long)]
+    log_level: Option<String>,
 }
 
-fn init_tracing() {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                "info,aionui_ai_agent=debug,aionui_conversation=debug,aionui_realtime=debug".into()
-            }),
-        )
-        .with_target(true)
-        .init();
+fn init_tracing(log_dir: Option<PathBuf>, log_level: Option<String>) -> Option<tracing_appender::non_blocking::WorkerGuard> {
+    let default_level = if log_dir.is_some() { "info" } else { "warn" };
+    let filter_str = log_level.unwrap_or_else(|| default_level.to_owned());
+
+    let make_filter = |s: &str| EnvFilter::try_new(s).unwrap_or_else(|_| EnvFilter::new(default_level));
+
+    match log_dir {
+        Some(dir) => {
+            let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
+                .rotation(tracing_appender::rolling::Rotation::DAILY)
+                .filename_prefix("backend")
+                .filename_suffix("log")
+                .build(&dir)
+                .expect("failed to create log file appender");
+            let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+
+            tracing_subscriber::registry()
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .with_writer(non_blocking)
+                        .with_ansi(false)
+                        .with_target(true)
+                        .with_filter(make_filter(&filter_str)),
+                )
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .with_writer(std::io::stderr)
+                        .with_target(true)
+                        .with_filter(EnvFilter::new("warn")),
+                )
+                .init();
+
+            Some(guard)
+        }
+        None => {
+            tracing_subscriber::registry()
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .with_writer(std::io::stderr)
+                        .with_target(true)
+                        .with_filter(make_filter(&filter_str)),
+                )
+                .init();
+
+            None
+        }
+    }
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    init_tracing();
+    let _log_guard = init_tracing(cli.log_dir, cli.log_level);
 
     let config = AppConfig {
         host: cli.host,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2024"
+style_edition = "2024"


### PR DESCRIPTION
## Summary
- Add `--log-dir` and `--log-level` CLI options for flexible logging configuration
- When `--log-dir` is set: rolling daily log files + stderr (warn only)
- When no `--log-dir`: stderr-only mode, defaults to warn level
- `AIONUI_LOG_DIR` env var reserved for sysinfo reporting only (not for triggering file logging)

## Test plan
- [ ] Verify `--log-dir /tmp/logs --log-level debug` writes rolling daily log files
- [ ] Verify stderr-only mode (no `--log-dir`) defaults to warn level
- [ ] `cargo test -p aionui-app` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)