### PR TITLE
feat: add file logging with dual-layer tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5618,6 +5618,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5627,12 +5637,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ anyhow = "1"
 # Logging
 tracing = "0.1"
 tracing-appender = "0.2"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "registry"] }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aionui-ai-agent/src/cli_process.rs
+++ b/crates/aionui-ai-agent/src/cli_process.rs
@@ -81,7 +81,8 @@ impl CliAgentProcess {
             error!(command = %config.command.display(), error = %e, "Failed to spawn CLI process");
             AppError::Internal(format!(
                 "Failed to spawn CLI process '{}': {}",
-                config.command.display(), e
+                config.command.display(),
+                e
             ))
         })?;
 
@@ -210,7 +211,8 @@ impl CliAgentProcess {
             error!(command = %config.command.display(), error = %e, "Failed to spawn CLI process");
             AppError::Internal(format!(
                 "Failed to spawn CLI process '{}': {}",
-                config.command.display(), e
+                config.command.display(),
+                e
             ))
         })?;
 
@@ -635,7 +637,10 @@ mod tests {
                 "-c".into(),
                 "echo \"{\\\"val\\\":\\\"$MY_TEST_VAR\\\"}\"".into(),
             ],
-            env: vec![EnvVar { name: "MY_TEST_VAR".into(), value: "hello_env".into() }],
+            env: vec![EnvVar {
+                name: "MY_TEST_VAR".into(),
+                value: "hello_env".into(),
+            }],
             cwd: Some("/tmp".into()),
         };
         let proc = CliAgentProcess::spawn(config).await.unwrap();

--- a/crates/aionui-ai-agent/src/openclaw_agent.rs
+++ b/crates/aionui-ai-agent/src/openclaw_agent.rs
@@ -100,15 +100,27 @@ impl OpenClawAgentManager {
         let port = gateway.port.unwrap_or(DEFAULT_GATEWAY_PORT);
 
         let mut env = vec![
-            EnvVar { name: "OPENCLAW_GATEWAY_HOST".into(), value: host.to_owned() },
-            EnvVar { name: "OPENCLAW_GATEWAY_PORT".into(), value: port.to_string() },
+            EnvVar {
+                name: "OPENCLAW_GATEWAY_HOST".into(),
+                value: host.to_owned(),
+            },
+            EnvVar {
+                name: "OPENCLAW_GATEWAY_PORT".into(),
+                value: port.to_string(),
+            },
         ];
 
         if let Some(ref token) = gateway.token {
-            env.push(EnvVar { name: "OPENCLAW_GATEWAY_TOKEN".into(), value: token.clone() });
+            env.push(EnvVar {
+                name: "OPENCLAW_GATEWAY_TOKEN".into(),
+                value: token.clone(),
+            });
         }
         if let Some(ref password) = gateway.password {
-            env.push(EnvVar { name: "OPENCLAW_GATEWAY_PASSWORD".into(), value: password.clone() });
+            env.push(EnvVar {
+                name: "OPENCLAW_GATEWAY_PASSWORD".into(),
+                value: password.clone(),
+            });
         }
 
         CommandSpec {
@@ -398,7 +410,11 @@ mod tests {
     }
 
     fn env_val<'a>(config: &'a CommandSpec, name: &str) -> Option<&'a str> {
-        config.env.iter().find(|e| e.name == name).map(|e| e.value.as_str())
+        config
+            .env
+            .iter()
+            .find(|e| e.name == name)
+            .map(|e| e.value.as_str())
     }
 
     #[test]
@@ -414,7 +430,10 @@ mod tests {
         let config =
             OpenClawAgentManager::build_spawn_config("/usr/bin/openclaw", "/proj", &gateway);
         assert_eq!(config.command.to_str().unwrap(), "/usr/bin/openclaw");
-        assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_HOST").unwrap(), "127.0.0.1");
+        assert_eq!(
+            env_val(&config, "OPENCLAW_GATEWAY_HOST").unwrap(),
+            "127.0.0.1"
+        );
         assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_PORT").unwrap(), "18789");
         assert!(env_val(&config, "OPENCLAW_GATEWAY_TOKEN").is_none());
     }
@@ -431,10 +450,19 @@ mod tests {
         };
         let config =
             OpenClawAgentManager::build_spawn_config("/usr/bin/openclaw", "/proj", &gateway);
-        assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_HOST").unwrap(), "remote.host");
+        assert_eq!(
+            env_val(&config, "OPENCLAW_GATEWAY_HOST").unwrap(),
+            "remote.host"
+        );
         assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_PORT").unwrap(), "9999");
-        assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_TOKEN").unwrap(), "secret");
-        assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_PASSWORD").unwrap(), "pass");
+        assert_eq!(
+            env_val(&config, "OPENCLAW_GATEWAY_TOKEN").unwrap(),
+            "secret"
+        );
+        assert_eq!(
+            env_val(&config, "OPENCLAW_GATEWAY_PASSWORD").unwrap(),
+            "pass"
+        );
     }
 
     #[test]

--- a/crates/aionui-api-types/src/agent.rs
+++ b/crates/aionui-api-types/src/agent.rs
@@ -40,7 +40,10 @@ mod tests {
             source: crate::AgentSource::Builtin,
             command: Some("/usr/bin/claude".into()),
             args: vec!["--experimental-acp".into()],
-            env: vec![crate::EnvVar { name: "FOO".into(), value: "bar".into() }],
+            env: vec![crate::EnvVar {
+                name: "FOO".into(),
+                value: "bar".into(),
+            }],
         };
         let info = AgentInfo::from(detected);
         assert_eq!(info.id, "abc123");

--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -16,7 +16,6 @@ use aionui_ai_agent::{
     auxiliary_routes, build_agent_factory, connection_test_routes, remote_agent_routes,
 };
 use aionui_api_types::{AgentSource, DetectedAgent};
-use aionui_common::EnvVar;
 use aionui_assistant::{
     AssistantRouterState, AssistantService, BuiltinAssistantRegistry, assistant_routes,
 };
@@ -29,14 +28,14 @@ use aionui_auth::{
 use aionui_channel::weixin_login_route;
 use aionui_channel::{ChannelRouterState, channel_routes};
 use aionui_common::AgentType;
+use aionui_common::EnvVar;
 use aionui_conversation::{ConversationRouterState, ConversationService, conversation_routes};
 use aionui_cron::{CronEventEmitter, CronRouterState, cron_routes};
 use aionui_db::{
     Database, IAssistantOverrideRepository, IAssistantRepository, IUserRepository,
-    SqliteAssistantOverrideRepository,
-    SqliteAssistantRepository, SqliteClientPreferenceRepository, SqliteConversationRepository,
-    SqliteProviderRepository, SqliteRemoteAgentRepository, SqliteSettingsRepository,
-    SqliteUserRepository,
+    SqliteAssistantOverrideRepository, SqliteAssistantRepository, SqliteClientPreferenceRepository,
+    SqliteConversationRepository, SqliteProviderRepository, SqliteRemoteAgentRepository,
+    SqliteSettingsRepository, SqliteUserRepository,
 };
 use aionui_extension::{
     AssistantRuleDispatcher, ExtensionRegistry, ExtensionRouterState, ExtensionStateStore,

--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -32,32 +32,23 @@ struct Cli {
     log_dir: Option<PathBuf>,
 
     /// Log level filter (e.g. "info", "debug", "info,aionui_mcp=trace").
-    /// Overridden by RUST_LOG env var when set.
     #[arg(long)]
     log_level: Option<String>,
 }
 
 fn init_tracing(
     log_dir: &Path,
-    log_level: Option<String>,
+    log_level: Option<&str>,
 ) -> tracing_appender::non_blocking::WorkerGuard {
     let default_filter =
         "info,aionui_ai_agent=debug,aionui_conversation=debug,aionui_realtime=debug";
 
-    let make_filter = |fallback: &str| {
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-            log_level
-                .as_deref()
-                .map(EnvFilter::new)
-                .unwrap_or_else(|| fallback.into())
-        })
-    };
-
     std::fs::create_dir_all(log_dir).expect("failed to create log directory");
 
+    let console_filter = EnvFilter::new(log_level.unwrap_or("info"));
     let console_layer = fmt::layer()
         .with_target(true)
-        .with_filter(make_filter("info"));
+        .with_filter(console_filter);
 
     let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
         .rotation(tracing_appender::rolling::Rotation::DAILY)
@@ -67,12 +58,13 @@ fn init_tracing(
         .expect("failed to create log file appender");
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
+    let file_filter = EnvFilter::new(log_level.unwrap_or(default_filter));
     let file_layer = fmt::layer()
         .json()
         .with_writer(non_blocking)
         .with_ansi(false)
         .with_target(true)
-        .with_filter(make_filter(default_filter));
+        .with_filter(file_filter);
 
     tracing_subscriber::registry()
         .with(console_layer)
@@ -89,7 +81,7 @@ async fn main() -> Result<()> {
     let log_dir = cli
         .log_dir
         .unwrap_or_else(|| Path::new(&cli.data_dir).join("logs"));
-    let _log_guard = init_tracing(&log_dir, cli.log_level);
+    let _log_guard = init_tracing(&log_dir, cli.log_level.as_deref());
 
     let config = AppConfig {
         host: cli.host,

--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -1,13 +1,10 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use clap::Parser;
 use tokio::net::TcpListener;
 use tracing::info;
-use tracing_subscriber::Layer;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::EnvFilter;
+use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 use aionui_app::{AppConfig, AppServices, create_router};
 
@@ -30,71 +27,52 @@ struct Cli {
     #[arg(long)]
     local: bool,
 
-    /// Directory for log files. When set, logs are written to rolling daily
-    /// files under this directory. Without this, logs go to stderr only.
+    /// Directory for log files. Defaults to {data-dir}/logs/.
     #[arg(long)]
     log_dir: Option<PathBuf>,
-
-    /// Log level filter (e.g. "warn", "info", "debug", "info,aionui_ai_agent=debug").
-    /// Defaults to "warn" when no log directory is set, "info" when one is.
-    #[arg(long)]
-    log_level: Option<String>,
 }
 
-fn init_tracing(log_dir: Option<PathBuf>, log_level: Option<String>) -> Option<tracing_appender::non_blocking::WorkerGuard> {
-    let default_level = if log_dir.is_some() { "info" } else { "warn" };
-    let filter_str = log_level.unwrap_or_else(|| default_level.to_owned());
+fn init_tracing(log_dir: &Path) -> tracing_appender::non_blocking::WorkerGuard {
+    let default_filter =
+        "info,aionui_ai_agent=debug,aionui_conversation=debug,aionui_realtime=debug";
 
-    let make_filter = |s: &str| EnvFilter::try_new(s).unwrap_or_else(|_| EnvFilter::new(default_level));
+    std::fs::create_dir_all(log_dir).expect("failed to create log directory");
 
-    match log_dir {
-        Some(dir) => {
-            let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
-                .rotation(tracing_appender::rolling::Rotation::DAILY)
-                .filename_prefix("backend")
-                .filename_suffix("log")
-                .build(&dir)
-                .expect("failed to create log file appender");
-            let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+    let console_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into());
+    let console_layer = fmt::layer().with_target(true).with_filter(console_filter);
 
-            tracing_subscriber::registry()
-                .with(
-                    tracing_subscriber::fmt::layer()
-                        .with_writer(non_blocking)
-                        .with_ansi(false)
-                        .with_target(true)
-                        .with_filter(make_filter(&filter_str)),
-                )
-                .with(
-                    tracing_subscriber::fmt::layer()
-                        .with_writer(std::io::stderr)
-                        .with_target(true)
-                        .with_filter(EnvFilter::new("warn")),
-                )
-                .init();
+    let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
+        .rotation(tracing_appender::rolling::Rotation::DAILY)
+        .filename_prefix("backend")
+        .filename_suffix("log")
+        .build(log_dir)
+        .expect("failed to create log file appender");
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
-            Some(guard)
-        }
-        None => {
-            tracing_subscriber::registry()
-                .with(
-                    tracing_subscriber::fmt::layer()
-                        .with_writer(std::io::stderr)
-                        .with_target(true)
-                        .with_filter(make_filter(&filter_str)),
-                )
-                .init();
+    let file_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| default_filter.into());
+    let file_layer = fmt::layer()
+        .json()
+        .with_writer(non_blocking)
+        .with_ansi(false)
+        .with_target(true)
+        .with_filter(file_filter);
 
-            None
-        }
-    }
+    tracing_subscriber::registry()
+        .with(console_layer)
+        .with(file_layer)
+        .init();
+
+    guard
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    let _log_guard = init_tracing(cli.log_dir, cli.log_level);
+    let log_dir = cli
+        .log_dir
+        .unwrap_or_else(|| Path::new(&cli.data_dir).join("logs"));
+    let _log_guard = init_tracing(&log_dir);
 
     let config = AppConfig {
         host: cli.host,

--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -30,16 +30,34 @@ struct Cli {
     /// Directory for log files. Defaults to {data-dir}/logs/.
     #[arg(long)]
     log_dir: Option<PathBuf>,
+
+    /// Log level filter (e.g. "info", "debug", "info,aionui_mcp=trace").
+    /// Overridden by RUST_LOG env var when set.
+    #[arg(long)]
+    log_level: Option<String>,
 }
 
-fn init_tracing(log_dir: &Path) -> tracing_appender::non_blocking::WorkerGuard {
+fn init_tracing(
+    log_dir: &Path,
+    log_level: Option<String>,
+) -> tracing_appender::non_blocking::WorkerGuard {
     let default_filter =
         "info,aionui_ai_agent=debug,aionui_conversation=debug,aionui_realtime=debug";
 
+    let make_filter = |fallback: &str| {
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+            log_level
+                .as_deref()
+                .map(EnvFilter::new)
+                .unwrap_or_else(|| fallback.into())
+        })
+    };
+
     std::fs::create_dir_all(log_dir).expect("failed to create log directory");
 
-    let console_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into());
-    let console_layer = fmt::layer().with_target(true).with_filter(console_filter);
+    let console_layer = fmt::layer()
+        .with_target(true)
+        .with_filter(make_filter("info"));
 
     let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
         .rotation(tracing_appender::rolling::Rotation::DAILY)
@@ -49,13 +67,12 @@ fn init_tracing(log_dir: &Path) -> tracing_appender::non_blocking::WorkerGuard {
         .expect("failed to create log file appender");
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
-    let file_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| default_filter.into());
     let file_layer = fmt::layer()
         .json()
         .with_writer(non_blocking)
         .with_ansi(false)
         .with_target(true)
-        .with_filter(file_filter);
+        .with_filter(make_filter(default_filter));
 
     tracing_subscriber::registry()
         .with(console_layer)
@@ -72,7 +89,7 @@ async fn main() -> Result<()> {
     let log_dir = cli
         .log_dir
         .unwrap_or_else(|| Path::new(&cli.data_dir).join("logs"));
-    let _log_guard = init_tracing(&log_dir);
+    let _log_guard = init_tracing(&log_dir, cli.log_level);
 
     let config = AppConfig {
         host: cli.host,

--- a/crates/aionui-common/src/lib.rs
+++ b/crates/aionui-common/src/lib.rs
@@ -22,5 +22,6 @@ pub use id::{
 pub use pagination::PaginatedResult;
 pub use timestamp::{TimestampMs, now_ms};
 pub use types::{
-    CommandSpec, Confirmation, ConfirmationOption, EnvVar, ProviderWithModel, UpdateType, VersionInfo,
+    CommandSpec, Confirmation, ConfirmationOption, EnvVar, ProviderWithModel, UpdateType,
+    VersionInfo,
 };


### PR DESCRIPTION
## Summary

基于 PR #13 的 tracing-appender 基础设施，按讨论确定的设计方案进行调整：

- **Console layer**: stdout, info+, 人类可读格式（给 Electron 和终端用）
- **File layer**: JSON 结构化, debug+, non_blocking 异步写入, 按日滚动
- `--log-dir` 默认 `{data-dir}/logs/`，后端始终写文件日志，不依赖前端
- `--log-level` 作为唯一的日志级别控制入口，去掉 `RUST_LOG` 环境变量支持
- 为 `tracing-subscriber` 添加 `json` 和 `registry` features
- 附带修复 PR #14 引入的 `cargo fmt` 格式问题

## 设计文档

`docs/superpowers/specs/2026-04-25-file-logging-design.md`

## Test Plan

- [x] `cargo check -p aionui-app` 编译通过
- [x] `cargo clippy -p aionui-app -- -D warnings` 无 warning
- [x] `cargo fmt --all -- --check` 格式通过
- [x] 验证默认 `{data-dir}/logs/` 目录自动创建并写入 JSON 日志
- [x] 验证自定义 `--log-dir` 参数工作正常
- [x] 验证控制台 stdout 只输出 info+ 人类可读日志
- [x] 验证文件日志为 NDJSON 格式，包含 timestamp/level/target/fields
- [x] 验证 `--log-level` 可覆盖默认级别