### PR TITLE
feat: use AgentBootstrap for consistent aionrs engine initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,8 +105,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.15"
-source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.15#4a25b305ea319a407584d504aed97625ff2fbc4d"
+version = "0.1.16"
+source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.16#c5a849d1e7acc800a5bb778329bcdd894de91195"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -134,8 +134,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.15"
-source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.15#4a25b305ea319a407584d504aed97625ff2fbc4d"
+version = "0.1.16"
+source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.16#c5a849d1e7acc800a5bb778329bcdd894de91195"
 dependencies = [
  "regex",
  "serde",
@@ -144,8 +144,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.15"
-source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.15#4a25b305ea319a407584d504aed97625ff2fbc4d"
+version = "0.1.16"
+source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.16#c5a849d1e7acc800a5bb778329bcdd894de91195"
 dependencies = [
  "aion-compact",
  "aion-types",
@@ -164,8 +164,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.15"
-source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.15#4a25b305ea319a407584d504aed97625ff2fbc4d"
+version = "0.1.16"
+source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.16#c5a849d1e7acc800a5bb778329bcdd894de91195"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -184,8 +184,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.15"
-source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.15#4a25b305ea319a407584d504aed97625ff2fbc4d"
+version = "0.1.16"
+source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.16#c5a849d1e7acc800a5bb778329bcdd894de91195"
 dependencies = [
  "aion-config",
  "chrono",
@@ -197,8 +197,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.15"
-source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.15#4a25b305ea319a407584d504aed97625ff2fbc4d"
+version = "0.1.16"
+source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.16#c5a849d1e7acc800a5bb778329bcdd894de91195"
 dependencies = [
  "aion-types",
  "serde",
@@ -209,8 +209,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.15"
-source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.15#4a25b305ea319a407584d504aed97625ff2fbc4d"
+version = "0.1.16"
+source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.16#c5a849d1e7acc800a5bb778329bcdd894de91195"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -236,8 +236,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.15"
-source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.15#4a25b305ea319a407584d504aed97625ff2fbc4d"
+version = "0.1.16"
+source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.16#c5a849d1e7acc800a5bb778329bcdd894de91195"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -261,8 +261,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.15"
-source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.15#4a25b305ea319a407584d504aed97625ff2fbc4d"
+version = "0.1.16"
+source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.16#c5a849d1e7acc800a5bb778329bcdd894de91195"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -280,8 +280,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.15"
-source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.15#4a25b305ea319a407584d504aed97625ff2fbc4d"
+version = "0.1.16"
+source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.16#c5a849d1e7acc800a5bb778329bcdd894de91195"
 dependencies = [
  "async-trait",
  "chrono",
@@ -296,8 +296,8 @@ dependencies = [
  "agent-client-protocol",
  "aion-agent",
  "aion-config",
+ "aion-mcp",
  "aion-protocol",
- "aion-tools",
  "aion-types",
  "aionui-api-types",
  "aionui-auth",
@@ -6513,7 +6513,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.15#4a25b305ea319a407584d504aed97625ff2fbc4d"
+source = "git+ssh://git@github.com/iOfficeAI/aionrs.git?tag=v0.1.16#c5a849d1e7acc800a5bb778329bcdd894de91195"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,11 +48,11 @@ aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
 # Aionrs agent engine (external git dependency)
-aion-agent = { git = "ssh://git@github.com/iOfficeAI/aionrs.git", tag = "v0.1.15" }
-aion-types = { git = "ssh://git@github.com/iOfficeAI/aionrs.git", tag = "v0.1.15" }
-aion-protocol = { git = "ssh://git@github.com/iOfficeAI/aionrs.git", tag = "v0.1.15" }
-aion-config = { git = "ssh://git@github.com/iOfficeAI/aionrs.git", tag = "v0.1.15" }
-aion-tools = { git = "ssh://git@github.com/iOfficeAI/aionrs.git", tag = "v0.1.15" }
+aion-agent = { git = "ssh://git@github.com/iOfficeAI/aionrs.git", tag = "v0.1.16" }
+aion-types = { git = "ssh://git@github.com/iOfficeAI/aionrs.git", tag = "v0.1.16" }
+aion-protocol = { git = "ssh://git@github.com/iOfficeAI/aionrs.git", tag = "v0.1.16" }
+aion-config = { git = "ssh://git@github.com/iOfficeAI/aionrs.git", tag = "v0.1.16" }
+aion-mcp = { git = "ssh://git@github.com/iOfficeAI/aionrs.git", tag = "v0.1.16" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }

--- a/crates/aionui-ai-agent/Cargo.toml
+++ b/crates/aionui-ai-agent/Cargo.toml
@@ -33,7 +33,7 @@ aion-agent.workspace = true
 aion-types.workspace = true
 aion-protocol.workspace = true
 aion-config.workspace = true
-aion-tools.workspace = true
+aion-mcp.workspace = true
 uuid.workspace = true
 agent-client-protocol = { version = "0.11.1", features = ["unstable_session_model", "unstable_session_close", "unstable_session_usage", "unstable_session_fork", "unstable_session_additional_directories", "unstable_session_resume"] }
 tokio-util = { version = "0.7", features = ["compat"] }

--- a/crates/aionui-ai-agent/src/aionrs_agent.rs
+++ b/crates/aionui-ai-agent/src/aionrs_agent.rs
@@ -1,24 +1,19 @@
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::{Arc, RwLock};
 
+use aion_agent::bootstrap::AgentBootstrap;
 use aion_agent::engine::AgentEngine;
 use aion_agent::output::OutputSink;
 use aion_config::compat::ProviderCompat;
 use aion_config::config::{Config, ProviderType};
+use aion_mcp::manager::McpManager;
 use aion_protocol::ToolApprovalManager;
-use aion_tools::bash::BashTool;
-use aion_tools::edit::EditTool;
-use aion_tools::glob::GlobTool;
-use aion_tools::grep::GrepTool;
-use aion_tools::read::ReadTool;
-use aion_tools::registry::ToolRegistry;
-use aion_tools::write::WriteTool;
 use aionui_common::{
     AgentKillReason, AgentType, AppError, Confirmation, ConversationStatus, TimestampMs, now_ms,
 };
 use serde_json::Value;
 use tokio::sync::{Mutex, broadcast};
-use tracing::{debug, info, error};
+use tracing::{debug, error, info};
 
 use crate::agent_manager::IAgentManager;
 use crate::backend_output_sink::BackendOutputSink;
@@ -31,16 +26,18 @@ pub struct AionrsAgentManager {
     pub(crate) event_tx: broadcast::Sender<AgentStreamEvent>,
     last_activity: AtomicI64,
     engine: Mutex<AgentEngine>,
+    #[allow(dead_code)] // held for Arc drop cleanup on agent destruction
+    mcp_managers: Vec<Arc<McpManager>>,
     status: RwLock<Option<ConversationStatus>>,
     approval_manager: Arc<ToolApprovalManager>,
 }
 
 impl AionrsAgentManager {
-    pub fn new(
+    pub async fn new(
         conversation_id: String,
         workspace: String,
         config_extra: AionrsResolvedConfig,
-    ) -> Self {
+    ) -> Result<Self, AppError> {
         let (event_tx, _) = broadcast::channel(128);
         let sink: Arc<dyn OutputSink> = Arc::new(BackendOutputSink::new(event_tx.clone()));
 
@@ -92,26 +89,23 @@ impl AionrsAgentManager {
             debug: Default::default(),
         };
 
-        let mut registry = ToolRegistry::new();
-        registry.register(Box::new(ReadTool::new(None)));
-        registry.register(Box::new(WriteTool::new(None)));
-        registry.register(Box::new(EditTool::new(None)));
-        registry.register(Box::new(BashTool));
-        registry.register(Box::new(GrepTool));
-        registry.register(Box::new(GlobTool));
+        let result = AgentBootstrap::new(config, &workspace, sink)
+            .build()
+            .await
+            .map_err(|e| AppError::Internal(format!("Agent bootstrap failed: {e}")))?;
 
-        let engine = AgentEngine::new(config, registry, sink);
         let approval_manager = Arc::new(ToolApprovalManager::new());
 
-        Self {
+        Ok(Self {
             conversation_id,
             workspace,
             event_tx,
             last_activity: AtomicI64::new(now_ms()),
-            engine: Mutex::new(engine),
+            engine: Mutex::new(result.engine),
+            mcp_managers: result.mcp_managers,
             status: RwLock::new(Some(ConversationStatus::Pending)),
             approval_manager,
-        }
+        })
     }
 }
 
@@ -285,55 +279,70 @@ mod tests {
         }
     }
 
-    #[test]
-    fn aionrs_agent_returns_correct_type() {
-        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config());
+    #[tokio::test]
+    async fn aionrs_agent_returns_correct_type() {
+        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config())
+            .await
+            .unwrap();
         assert_eq!(agent.agent_type(), AgentType::Aionrs);
         assert_eq!(agent.workspace(), "/project");
         assert_eq!(agent.conversation_id(), "conv-1");
     }
 
-    #[test]
-    fn aionrs_agent_initial_status_is_pending() {
-        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config());
+    #[tokio::test]
+    async fn aionrs_agent_initial_status_is_pending() {
+        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config())
+            .await
+            .unwrap();
         assert_eq!(agent.status(), Some(ConversationStatus::Pending));
     }
 
-    #[test]
-    fn aionrs_agent_subscribe_returns_receiver() {
-        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config());
+    #[tokio::test]
+    async fn aionrs_agent_subscribe_returns_receiver() {
+        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config())
+            .await
+            .unwrap();
         let _rx = agent.subscribe();
     }
 
-    #[test]
-    fn aionrs_agent_kill_succeeds() {
-        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config());
+    #[tokio::test]
+    async fn aionrs_agent_kill_succeeds() {
+        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config())
+            .await
+            .unwrap();
         assert!(agent.kill(None).is_ok());
         assert_eq!(agent.status(), None);
     }
 
-    #[test]
-    fn aionrs_agent_kill_with_reason_succeeds() {
-        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config());
+    #[tokio::test]
+    async fn aionrs_agent_kill_with_reason_succeeds() {
+        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config())
+            .await
+            .unwrap();
         assert!(agent.kill(Some(AgentKillReason::IdleTimeout)).is_ok());
     }
 
-    #[test]
-    fn aionrs_agent_confirmations_initially_empty() {
-        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config());
+    #[tokio::test]
+    async fn aionrs_agent_confirmations_initially_empty() {
+        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config())
+            .await
+            .unwrap();
         assert!(agent.get_confirmations().is_empty());
     }
 
-    #[test]
-    fn aionrs_agent_check_approval_returns_false_by_default() {
-        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config());
+    #[tokio::test]
+    async fn aionrs_agent_check_approval_returns_false_by_default() {
+        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config())
+            .await
+            .unwrap();
         assert!(!agent.check_approval("any_action", None));
     }
 
     #[tokio::test]
     async fn stop_emits_finish_event_and_sets_status() {
-        let agent =
-            AionrsAgentManager::new("conv-stop".into(), "/project".into(), make_test_config());
+        let agent = AionrsAgentManager::new("conv-stop".into(), "/project".into(), make_test_config())
+            .await
+            .unwrap();
         let mut rx = agent.subscribe();
 
         agent.stop().await.unwrap();
@@ -352,10 +361,11 @@ mod tests {
         }
     }
 
-    #[test]
-    fn event_tx_can_send_error_and_finish() {
-        let agent =
-            AionrsAgentManager::new("conv-err".into(), "/project".into(), make_test_config());
+    #[tokio::test]
+    async fn event_tx_can_send_error_and_finish() {
+        let agent = AionrsAgentManager::new("conv-err".into(), "/project".into(), make_test_config())
+            .await
+            .unwrap();
         let mut rx = agent.subscribe();
 
         let _ = agent.event_tx.send(AgentStreamEvent::Error(

--- a/crates/aionui-ai-agent/src/factory.rs
+++ b/crates/aionui-ai-agent/src/factory.rs
@@ -257,7 +257,7 @@ async fn build_agent(
                 compat_overrides,
             };
 
-            let agent = AionrsAgentManager::new(conversation_id, workspace, config);
+            let agent = AionrsAgentManager::new(conversation_id, workspace, config).await?;
             Ok(Arc::new(agent) as AgentManagerHandle)
         }
     }

--- a/crates/aionui-ai-agent/tests/agent_types_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_types_integration.rs
@@ -120,23 +120,29 @@ fn make_aionrs_config() -> AionrsResolvedConfig {
     }
 }
 
-#[test]
-fn aionrs_agent_kill_succeeds() {
-    let agent = AionrsAgentManager::new("conv-1".into(), "/proj".into(), make_aionrs_config());
+#[tokio::test]
+async fn aionrs_agent_kill_succeeds() {
+    let agent = AionrsAgentManager::new("conv-1".into(), "/proj".into(), make_aionrs_config())
+        .await
+        .unwrap();
     assert!(agent.kill(None).is_ok());
     assert!(agent.kill(Some(AgentKillReason::IdleTimeout)).is_ok());
 }
 
-#[test]
-fn aionrs_agent_confirm_succeeds() {
-    let agent = AionrsAgentManager::new("conv-1".into(), "/proj".into(), make_aionrs_config());
+#[tokio::test]
+async fn aionrs_agent_confirm_succeeds() {
+    let agent = AionrsAgentManager::new("conv-1".into(), "/proj".into(), make_aionrs_config())
+        .await
+        .unwrap();
     let result = agent.confirm("msg", "call", json!({}), false);
     assert!(result.is_ok());
 }
 
-#[test]
-fn aionrs_agent_metadata() {
-    let agent = AionrsAgentManager::new("conv-abc".into(), "/work".into(), make_aionrs_config());
+#[tokio::test]
+async fn aionrs_agent_metadata() {
+    let agent = AionrsAgentManager::new("conv-abc".into(), "/work".into(), make_aionrs_config())
+        .await
+        .unwrap();
     assert_eq!(agent.agent_type(), AgentType::Aionrs);
     assert_eq!(agent.workspace(), "/work");
     assert_eq!(agent.conversation_id(), "conv-abc");


### PR DESCRIPTION
## Summary

- Replace manual 6-tool registration with `AgentBootstrap.build()` from aion-agent v0.1.16, giving the backend the same initialization pipeline as the aionrs CLI
- Backend now automatically gets: model identity in system prompt, tool guidance, AGENTS.md loading, skills, MCP, SpawnTool, PlanMode, ToolSearch, file cache
- Upgrade aionrs dependency from v0.1.15 to v0.1.16 (includes [iOfficeAI/aionrs#73](https://github.com/iOfficeAI/aionrs/pull/73))

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | aionrs deps v0.1.15 → v0.1.16, replace `aion-tools` with `aion-mcp` |
| `crates/aionui-ai-agent/Cargo.toml` | `aion-tools` → `aion-mcp` |
| `crates/aionui-ai-agent/src/aionrs_agent.rs` | Replace manual tool registration with `AgentBootstrap`, `new()` is now async |
| `crates/aionui-ai-agent/src/factory.rs` | Add `.await?` to `AionrsAgentManager::new()` call |
| `crates/aionui-ai-agent/tests/agent_types_integration.rs` | Update tests for async `new()` |

## Motivation

The backend was constructing `AgentEngine` directly with only 6 basic tools, bypassing `build_system_prompt()`. This caused the model to not know its own identity (e.g. answering "I don't know which model I am" when asked). The aionrs CLI didn't have this issue because it ran the full initialization pipeline. Now both paths use the same `AgentBootstrap` builder.

## Test plan

- [x] `cargo build -p aionui-ai-agent` compiles with zero warnings
- [x] `cargo test -p aionui-ai-agent` — all 362 tests pass
- [ ] Manual smoke test: ask the model "你是哪个模型?" and verify it correctly identifies itself