### PR TITLE
fix: kill cached agent task when conversation model changes

### DIFF
--- a/crates/aionui-ai-agent/src/aionrs_agent.rs
+++ b/crates/aionui-ai-agent/src/aionrs_agent.rs
@@ -340,9 +340,10 @@ mod tests {
 
     #[tokio::test]
     async fn stop_emits_finish_event_and_sets_status() {
-        let agent = AionrsAgentManager::new("conv-stop".into(), "/project".into(), make_test_config())
-            .await
-            .unwrap();
+        let agent =
+            AionrsAgentManager::new("conv-stop".into(), "/project".into(), make_test_config())
+                .await
+                .unwrap();
         let mut rx = agent.subscribe();
 
         agent.stop().await.unwrap();
@@ -363,9 +364,10 @@ mod tests {
 
     #[tokio::test]
     async fn event_tx_can_send_error_and_finish() {
-        let agent = AionrsAgentManager::new("conv-err".into(), "/project".into(), make_test_config())
-            .await
-            .unwrap();
+        let agent =
+            AionrsAgentManager::new("conv-err".into(), "/project".into(), make_test_config())
+                .await
+                .unwrap();
         let mut rx = agent.subscribe();
 
         let _ = agent.event_tx.send(AgentStreamEvent::Error(

--- a/crates/aionui-ai-agent/src/factory.rs
+++ b/crates/aionui-ai-agent/src/factory.rs
@@ -10,8 +10,8 @@ use crate::remote_agent::RemoteAgentConfig;
 use crate::skill_manager::AcpSkillManager;
 use crate::task_manager::AgentFactory;
 use crate::types::{
-    AcpBuildExtra, AionrsBuildExtra, AionrsCompatOverrides, AionrsResolvedConfig,
-    BuildTaskOptions, GeminiBuildExtra, OpenClawBuildExtra, RemoteBuildExtra,
+    AcpBuildExtra, AionrsBuildExtra, AionrsCompatOverrides, AionrsResolvedConfig, BuildTaskOptions,
+    GeminiBuildExtra, OpenClawBuildExtra, RemoteBuildExtra,
 };
 use crate::{
     AcpAgentManager, AionrsAgentManager, GeminiAgentManager, NanobotAgentManager,
@@ -237,11 +237,8 @@ async fn build_agent(
                 .unwrap_or(&options.model.model)
                 .to_owned();
 
-            let provider = map_aionrs_provider(
-                &row.platform,
-                &model_id,
-                row.model_protocols.as_deref(),
-            );
+            let provider =
+                map_aionrs_provider(&row.platform, &model_id, row.model_protocols.as_deref());
 
             let (base_url, compat_overrides) =
                 resolve_aionrs_url_and_compat(&row.platform, &row.base_url, &provider);
@@ -268,11 +265,7 @@ async fn build_agent(
 /// Mirrors the frontend `src/process/agent/aionrs/envBuilder.ts` mapping.
 /// For `new-api` platform, per-model protocol overrides from `model_protocols`
 /// JSON take precedence.
-fn map_aionrs_provider(
-    platform: &str,
-    model_id: &str,
-    model_protocols: Option<&str>,
-) -> String {
+fn map_aionrs_provider(platform: &str, model_id: &str, model_protocols: Option<&str>) -> String {
     if platform == "new-api"
         && let Some(protocols_json) = model_protocols
         && let Ok(map) =
@@ -385,7 +378,10 @@ mod tests {
     #[test]
     fn map_aionrs_provider_custom_and_others_default_to_openai() {
         assert_eq!(map_aionrs_provider("custom", "gpt-4o", None), "openai");
-        assert_eq!(map_aionrs_provider("gemini", "gemini-2.5-pro", None), "openai");
+        assert_eq!(
+            map_aionrs_provider("gemini", "gemini-2.5-pro", None),
+            "openai"
+        );
         assert_eq!(map_aionrs_provider("new-api", "m", None), "openai");
         assert_eq!(map_aionrs_provider("unknown", "m", None), "openai");
     }
@@ -437,23 +433,20 @@ mod tests {
 
     #[test]
     fn resolve_openai_official_sets_max_completion_tokens() {
-        let (base_url, compat) = resolve_aionrs_url_and_compat(
-            "custom",
-            "https://api.openai.com/v1",
-            "openai",
-        );
+        let (base_url, compat) =
+            resolve_aionrs_url_and_compat("custom", "https://api.openai.com/v1", "openai");
         assert_eq!(base_url.as_deref(), Some("https://api.openai.com"));
-        assert_eq!(compat.max_tokens_field.as_deref(), Some("max_completion_tokens"));
+        assert_eq!(
+            compat.max_tokens_field.as_deref(),
+            Some("max_completion_tokens")
+        );
         assert!(compat.api_path.is_none());
     }
 
     #[test]
     fn resolve_non_openai_keeps_default_max_tokens() {
-        let (base_url, compat) = resolve_aionrs_url_and_compat(
-            "custom",
-            "https://api.deepseek.com/v1",
-            "openai",
-        );
+        let (base_url, compat) =
+            resolve_aionrs_url_and_compat("custom", "https://api.deepseek.com/v1", "openai");
         assert_eq!(base_url.as_deref(), Some("https://api.deepseek.com"));
         assert!(compat.max_tokens_field.is_none());
     }
@@ -475,11 +468,8 @@ mod tests {
 
     #[test]
     fn resolve_anthropic_no_compat_overrides() {
-        let (base_url, compat) = resolve_aionrs_url_and_compat(
-            "anthropic",
-            "https://api.anthropic.com",
-            "anthropic",
-        );
+        let (base_url, compat) =
+            resolve_aionrs_url_and_compat("anthropic", "https://api.anthropic.com", "anthropic");
         assert_eq!(base_url.as_deref(), Some("https://api.anthropic.com"));
         assert!(compat.max_tokens_field.is_none());
         assert!(compat.api_path.is_none());

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -65,8 +65,7 @@ pub use skill_manager::{
 pub use stream_event::AgentStreamEvent;
 pub use task_manager::{AgentFactory, IWorkerTaskManager, WorkerTaskManagerImpl};
 pub use types::{
-    AcpBuildExtra, AcpModelInfo, AcpSessionConfigOption, AionrsBuildExtra,
-    AionrsCompatOverrides, AionrsResolvedConfig, BuildTaskOptions, GeminiBuildExtra,
-    OpenClawBuildExtra, OpenClawGatewayConfig, RemoteBuildExtra, SendMessageData,
-    SlashCommandItem,
+    AcpBuildExtra, AcpModelInfo, AcpSessionConfigOption, AionrsBuildExtra, AionrsCompatOverrides,
+    AionrsResolvedConfig, BuildTaskOptions, GeminiBuildExtra, OpenClawBuildExtra,
+    OpenClawGatewayConfig, RemoteBuildExtra, SendMessageData, SlashCommandItem,
 };

--- a/crates/aionui-conversation/src/routes.rs
+++ b/crates/aionui-conversation/src/routes.rs
@@ -104,7 +104,7 @@ async fn update(
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
     let conversation = state
         .conversation_service
-        .update(&user.id, &id, req)
+        .update(&user.id, &id, req, &state.worker_task_manager)
         .await?;
     Ok(Json(ApiResponse::ok(conversation)))
 }

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -154,6 +154,7 @@ impl ConversationService {
         user_id: &str,
         id: &str,
         req: UpdateConversationRequest,
+        task_manager: &Arc<dyn IWorkerTaskManager>,
     ) -> Result<ConversationResponse, AppError> {
         let existing = self
             .repo
@@ -179,6 +180,11 @@ impl ConversationService {
         // Handle pinned_at: set timestamp on pin, clear on unpin
         let pinned_at = req.pinned.map(|p| if p { Some(now) } else { None });
 
+        let model_changed = req.model.as_ref().is_some_and(|new_model| {
+            let new_json = serde_json::to_string(new_model).unwrap_or_default();
+            existing.model.as_deref() != Some(new_json.as_str())
+        });
+
         let model_json = req
             .model
             .as_ref()
@@ -200,6 +206,10 @@ impl ConversationService {
         };
 
         self.repo.update(id, &updates).await?;
+
+        if model_changed {
+            let _ = task_manager.kill(id, None);
+        }
 
         // Re-fetch to return the updated version
         let updated = self

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -232,11 +232,17 @@ impl IConversationRepository for MockRepo {
 
 // ── Helpers ────────────────────────────────────────────────────────
 
-fn make_service() -> (ConversationService, Arc<MockBroadcaster>, Arc<MockRepo>) {
+fn make_service() -> (
+    ConversationService,
+    Arc<MockBroadcaster>,
+    Arc<MockRepo>,
+    Arc<dyn IWorkerTaskManager>,
+) {
     let repo = Arc::new(MockRepo::new());
     let broadcaster = Arc::new(MockBroadcaster::new());
     let svc = ConversationService::new(repo.clone(), broadcaster.clone());
-    (svc, broadcaster, repo)
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
+    (svc, broadcaster, repo, task_mgr)
 }
 
 fn make_create_req() -> CreateConversationRequest {
@@ -252,7 +258,7 @@ fn make_create_req() -> CreateConversationRequest {
 
 #[tokio::test]
 async fn create_returns_conversation_with_defaults() {
-    let (svc, broadcaster, _repo) = make_service();
+    let (svc, broadcaster, _repo, _task_mgr) = make_service();
 
     let resp = svc.create("user_1", make_create_req()).await.unwrap();
 
@@ -277,7 +283,7 @@ async fn create_returns_conversation_with_defaults() {
 
 #[tokio::test]
 async fn create_with_custom_name_and_source() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
 
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "acp",
@@ -299,7 +305,7 @@ async fn create_with_custom_name_and_source() {
 
 #[tokio::test]
 async fn create_stores_model_as_json() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
 
     let resp = svc.create("user_1", make_create_req()).await.unwrap();
 
@@ -312,7 +318,7 @@ async fn create_stores_model_as_json() {
 
 #[tokio::test]
 async fn get_existing_conversation() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     let created = svc.create("user_1", make_create_req()).await.unwrap();
 
     let fetched = svc.get("user_1", &created.id).await.unwrap();
@@ -322,7 +328,7 @@ async fn get_existing_conversation() {
 
 #[tokio::test]
 async fn get_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     let err = svc.get("user_1", "non-existent").await.unwrap_err();
     assert!(matches!(err, AppError::NotFound(_)));
 }
@@ -331,7 +337,7 @@ async fn get_not_found() {
 
 #[tokio::test]
 async fn list_empty() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     let result = svc
         .list("user_1", ListConversationsQuery::default())
         .await
@@ -343,7 +349,7 @@ async fn list_empty() {
 
 #[tokio::test]
 async fn list_returns_created_conversations() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     svc.create("user_1", make_create_req()).await.unwrap();
     svc.create("user_1", make_create_req()).await.unwrap();
 
@@ -357,7 +363,7 @@ async fn list_returns_created_conversations() {
 
 #[tokio::test]
 async fn list_filters_by_user() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     svc.create("user_1", make_create_req()).await.unwrap();
     svc.create("user_2", make_create_req()).await.unwrap();
 
@@ -370,7 +376,7 @@ async fn list_filters_by_user() {
 
 #[tokio::test]
 async fn list_with_source_filter() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     svc.create("user_1", make_create_req()).await.unwrap();
 
     let telegram_req: CreateConversationRequest = serde_json::from_value(json!({
@@ -393,14 +399,16 @@ async fn list_with_source_filter() {
 
 #[tokio::test]
 async fn list_with_pinned_filter() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
     svc.create("user_1", make_create_req()).await.unwrap();
 
     // Pin the first one
     let update_req: UpdateConversationRequest =
         serde_json::from_value(json!({ "pinned": true })).unwrap();
-    svc.update("user_1", &conv.id, update_req).await.unwrap();
+    svc.update("user_1", &conv.id, update_req, &task_mgr)
+        .await
+        .unwrap();
 
     let query = ListConversationsQuery {
         pinned: Some(true),
@@ -415,13 +423,16 @@ async fn list_with_pinned_filter() {
 
 #[tokio::test]
 async fn update_name() {
-    let (svc, broadcaster, _repo) = make_service();
+    let (svc, broadcaster, _repo, task_mgr) = make_service();
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
     broadcaster.take_events(); // clear create event
 
     let req: UpdateConversationRequest =
         serde_json::from_value(json!({ "name": "New Name" })).unwrap();
-    let updated = svc.update("user_1", &conv.id, req).await.unwrap();
+    let updated = svc
+        .update("user_1", &conv.id, req, &task_mgr)
+        .await
+        .unwrap();
 
     assert_eq!(updated.name, "New Name");
     assert!(updated.modified_at >= conv.modified_at);
@@ -433,39 +444,48 @@ async fn update_name() {
 
 #[tokio::test]
 async fn update_pin() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
     assert!(!conv.pinned);
 
     let req: UpdateConversationRequest = serde_json::from_value(json!({ "pinned": true })).unwrap();
-    let updated = svc.update("user_1", &conv.id, req).await.unwrap();
+    let updated = svc
+        .update("user_1", &conv.id, req, &task_mgr)
+        .await
+        .unwrap();
     assert!(updated.pinned);
     assert!(updated.pinned_at.is_some());
 }
 
 #[tokio::test]
 async fn update_unpin_clears_pinned_at() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
 
     // Pin first
     let pin_req: UpdateConversationRequest =
         serde_json::from_value(json!({ "pinned": true })).unwrap();
-    let pinned = svc.update("user_1", &conv.id, pin_req).await.unwrap();
+    let pinned = svc
+        .update("user_1", &conv.id, pin_req, &task_mgr)
+        .await
+        .unwrap();
     assert!(pinned.pinned);
     assert!(pinned.pinned_at.is_some());
 
     // Unpin
     let unpin_req: UpdateConversationRequest =
         serde_json::from_value(json!({ "pinned": false })).unwrap();
-    let unpinned = svc.update("user_1", &conv.id, unpin_req).await.unwrap();
+    let unpinned = svc
+        .update("user_1", &conv.id, unpin_req, &task_mgr)
+        .await
+        .unwrap();
     assert!(!unpinned.pinned);
     assert!(unpinned.pinned_at.is_none());
 }
 
 #[tokio::test]
 async fn update_extra_merge() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
 
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "gemini",
@@ -478,7 +498,10 @@ async fn update_extra_merge() {
     // Update only workspace — contextFileName should be preserved
     let update_req: UpdateConversationRequest =
         serde_json::from_value(json!({ "extra": { "workspace": "/new" } })).unwrap();
-    let updated = svc.update("user_1", &conv.id, update_req).await.unwrap();
+    let updated = svc
+        .update("user_1", &conv.id, update_req, &task_mgr)
+        .await
+        .unwrap();
 
     assert_eq!(updated.extra["workspace"], "/new");
     assert_eq!(updated.extra["contextFileName"], "ctx.md");
@@ -486,14 +509,17 @@ async fn update_extra_merge() {
 
 #[tokio::test]
 async fn update_model() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
 
     let req: UpdateConversationRequest = serde_json::from_value(json!({
         "model": { "provider_id": "p2", "model": "new-model" }
     }))
     .unwrap();
-    let updated = svc.update("user_1", &conv.id, req).await.unwrap();
+    let updated = svc
+        .update("user_1", &conv.id, req, &task_mgr)
+        .await
+        .unwrap();
 
     let model = updated.model.unwrap();
     assert_eq!(model.provider_id, "p2");
@@ -502,9 +528,12 @@ async fn update_model() {
 
 #[tokio::test]
 async fn update_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let req: UpdateConversationRequest = serde_json::from_value(json!({ "name": "x" })).unwrap();
-    let err = svc.update("user_1", "non-existent", req).await.unwrap_err();
+    let err = svc
+        .update("user_1", "non-existent", req, &task_mgr)
+        .await
+        .unwrap_err();
     assert!(matches!(err, AppError::NotFound(_)));
 }
 
@@ -512,7 +541,7 @@ async fn update_not_found() {
 
 #[tokio::test]
 async fn delete_conversation() {
-    let (svc, broadcaster, _repo) = make_service();
+    let (svc, broadcaster, _repo, _task_mgr) = make_service();
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
     broadcaster.take_events();
 
@@ -531,7 +560,7 @@ async fn delete_conversation() {
 
 #[tokio::test]
 async fn delete_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     let err = svc.delete("user_1", "non-existent").await.unwrap_err();
     assert!(matches!(err, AppError::NotFound(_)));
 }
@@ -540,7 +569,7 @@ async fn delete_not_found() {
 
 #[tokio::test]
 async fn broadcast_includes_source_on_delete() {
-    let (svc, broadcaster, _repo) = make_service();
+    let (svc, broadcaster, _repo, _task_mgr) = make_service();
 
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "gemini",
@@ -559,7 +588,7 @@ async fn broadcast_includes_source_on_delete() {
 
 #[tokio::test]
 async fn all_crud_operations_broadcast() {
-    let (svc, broadcaster, _repo) = make_service();
+    let (svc, broadcaster, _repo, task_mgr) = make_service();
 
     // Create
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -568,7 +597,9 @@ async fn all_crud_operations_broadcast() {
 
     // Update
     let req: UpdateConversationRequest = serde_json::from_value(json!({ "name": "x" })).unwrap();
-    svc.update("user_1", &conv.id, req).await.unwrap();
+    svc.update("user_1", &conv.id, req, &task_mgr)
+        .await
+        .unwrap();
     let events = broadcaster.take_events();
     assert_eq!(events[0].data["action"], "updated");
 
@@ -582,7 +613,7 @@ async fn all_crud_operations_broadcast() {
 
 #[tokio::test]
 async fn get_wrong_user_returns_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
 
     let err = svc.get("user_2", &conv.id).await.unwrap_err();
@@ -591,12 +622,15 @@ async fn get_wrong_user_returns_not_found() {
 
 #[tokio::test]
 async fn update_wrong_user_returns_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
 
     let req: UpdateConversationRequest =
         serde_json::from_value(json!({ "name": "hacked" })).unwrap();
-    let err = svc.update("user_2", &conv.id, req).await.unwrap_err();
+    let err = svc
+        .update("user_2", &conv.id, req, &task_mgr)
+        .await
+        .unwrap_err();
     assert!(matches!(err, AppError::NotFound(_)));
 
     // Original should be unchanged
@@ -606,7 +640,7 @@ async fn update_wrong_user_returns_not_found() {
 
 #[tokio::test]
 async fn delete_wrong_user_returns_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
 
     let err = svc.delete("user_2", &conv.id).await.unwrap_err();
@@ -621,7 +655,7 @@ async fn delete_wrong_user_returns_not_found() {
 
 #[tokio::test]
 async fn clone_without_source_creates_new() {
-    let (svc, broadcaster, _repo) = make_service();
+    let (svc, broadcaster, _repo, _task_mgr) = make_service();
 
     let req: CloneConversationRequest = serde_json::from_value(json!({
         "conversation": {
@@ -644,7 +678,7 @@ async fn clone_without_source_creates_new() {
 
 #[tokio::test]
 async fn clone_from_source_inherits_config() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
 
     // Create source with name and extra
     let source_req: CreateConversationRequest = serde_json::from_value(json!({
@@ -679,7 +713,7 @@ async fn clone_from_source_inherits_config() {
 
 #[tokio::test]
 async fn clone_source_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
 
     let req: CloneConversationRequest = serde_json::from_value(json!({
         "source_conversation_id": "no-such-id",
@@ -697,7 +731,7 @@ async fn clone_source_not_found() {
 
 #[tokio::test]
 async fn clone_source_wrong_user() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
 
     let source = svc.create("user_1", make_create_req()).await.unwrap();
 
@@ -717,7 +751,7 @@ async fn clone_source_wrong_user() {
 
 #[tokio::test]
 async fn clone_strips_cron_job_id_by_default() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
 
     let source_req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "gemini",
@@ -744,7 +778,7 @@ async fn clone_strips_cron_job_id_by_default() {
 
 #[tokio::test]
 async fn clone_with_migrate_cron_preserves_cron_job_id() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
 
     let source_req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "gemini",
@@ -773,7 +807,7 @@ async fn clone_with_migrate_cron_preserves_cron_job_id() {
 
 #[tokio::test]
 async fn reset_sets_status_to_pending() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
 
     svc.reset("user_1", &conv.id).await.unwrap();
@@ -784,14 +818,14 @@ async fn reset_sets_status_to_pending() {
 
 #[tokio::test]
 async fn reset_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     let err = svc.reset("user_1", "no-such-id").await.unwrap_err();
     assert!(matches!(err, AppError::NotFound(_)));
 }
 
 #[tokio::test]
 async fn reset_wrong_user() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
 
     let err = svc.reset("user_2", &conv.id).await.unwrap_err();
@@ -802,7 +836,7 @@ async fn reset_wrong_user() {
 
 #[tokio::test]
 async fn search_messages_empty_keyword_returns_bad_request() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
 
     let query = SearchMessagesQuery {
         keyword: "".into(),
@@ -815,7 +849,7 @@ async fn search_messages_empty_keyword_returns_bad_request() {
 
 #[tokio::test]
 async fn search_messages_whitespace_keyword_returns_bad_request() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
 
     let query = SearchMessagesQuery {
         keyword: "   ".into(),
@@ -1009,7 +1043,7 @@ fn make_send_req() -> SendMessageRequest {
 
 #[tokio::test]
 async fn send_message_returns_accepted() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1022,7 +1056,7 @@ async fn send_message_returns_accepted() {
 
 #[tokio::test]
 async fn send_message_empty_content_returns_bad_request() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1041,7 +1075,7 @@ async fn send_message_empty_content_returns_bad_request() {
 
 #[tokio::test]
 async fn send_message_whitespace_content_returns_bad_request() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1060,7 +1094,7 @@ async fn send_message_whitespace_content_returns_bad_request() {
 
 #[tokio::test]
 async fn send_message_conversation_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let err = svc
@@ -1072,7 +1106,7 @@ async fn send_message_conversation_not_found() {
 
 #[tokio::test]
 async fn send_message_wrong_user_returns_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1085,7 +1119,7 @@ async fn send_message_wrong_user_returns_not_found() {
 
 #[tokio::test]
 async fn send_message_running_conversation_returns_conflict() {
-    let (svc, _broadcaster, repo) = make_service();
+    let (svc, _broadcaster, repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1108,7 +1142,7 @@ async fn send_message_running_conversation_returns_conflict() {
 
 #[tokio::test]
 async fn stop_stream_with_active_agent() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1136,7 +1170,7 @@ async fn stop_stream_with_active_agent() {
 
 #[tokio::test]
 async fn stop_stream_conversation_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let err = svc
@@ -1148,7 +1182,7 @@ async fn stop_stream_conversation_not_found() {
 
 #[tokio::test]
 async fn stop_stream_no_active_agent_returns_conflict() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1162,7 +1196,7 @@ async fn stop_stream_no_active_agent_returns_conflict() {
 
 #[tokio::test]
 async fn stop_stream_wrong_user_returns_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1177,7 +1211,7 @@ async fn stop_stream_wrong_user_returns_not_found() {
 
 #[tokio::test]
 async fn warmup_creates_agent_task() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1197,7 +1231,7 @@ async fn warmup_creates_agent_task() {
 
 #[tokio::test]
 async fn warmup_conversation_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let err = svc
@@ -1209,7 +1243,7 @@ async fn warmup_conversation_not_found() {
 
 #[tokio::test]
 async fn warmup_wrong_user_returns_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1244,7 +1278,7 @@ fn make_test_confirmations() -> Vec<Confirmation> {
 
 #[tokio::test]
 async fn list_confirmations_empty_when_no_agent() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1257,7 +1291,7 @@ async fn list_confirmations_empty_when_no_agent() {
 
 #[tokio::test]
 async fn list_confirmations_returns_items() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1283,7 +1317,7 @@ async fn list_confirmations_returns_items() {
 
 #[tokio::test]
 async fn list_confirmations_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let err = svc
@@ -1295,7 +1329,7 @@ async fn list_confirmations_not_found() {
 
 #[tokio::test]
 async fn list_confirmations_wrong_user() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1308,7 +1342,7 @@ async fn list_confirmations_wrong_user() {
 
 #[tokio::test]
 async fn confirm_removes_confirmation_and_broadcasts() {
-    let (svc, broadcaster, _repo) = make_service();
+    let (svc, broadcaster, _repo, task_mgr) = make_service();
     let task_mgr = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1350,7 +1384,7 @@ async fn confirm_removes_confirmation_and_broadcasts() {
 
 #[tokio::test]
 async fn confirm_with_always_allow_stores_approval() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1379,7 +1413,7 @@ async fn confirm_with_always_allow_stores_approval() {
 
 #[tokio::test]
 async fn confirm_nonexistent_call_id_returns_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1410,7 +1444,7 @@ async fn confirm_nonexistent_call_id_returns_not_found() {
 
 #[tokio::test]
 async fn confirm_no_agent_returns_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1429,7 +1463,7 @@ async fn confirm_no_agent_returns_not_found() {
 
 #[tokio::test]
 async fn check_approval_returns_false_when_not_set() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1452,7 +1486,7 @@ async fn check_approval_returns_false_when_not_set() {
 
 #[tokio::test]
 async fn check_approval_returns_true_after_always_allow() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1484,7 +1518,7 @@ async fn check_approval_returns_true_after_always_allow() {
 
 #[tokio::test]
 async fn check_approval_returns_false_when_no_agent() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
@@ -1498,7 +1532,7 @@ async fn check_approval_returns_false_when_no_agent() {
 
 #[tokio::test]
 async fn check_approval_not_found() {
-    let (svc, _broadcaster, _repo) = make_service();
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let err = svc

--- a/crates/aionui-conversation/tests/conversation_crud.rs
+++ b/crates/aionui-conversation/tests/conversation_crud.rs
@@ -1,9 +1,12 @@
 use std::sync::Arc;
 
+use aionui_ai_agent::IWorkerTaskManager;
 use aionui_api_types::{
     CreateConversationRequest, ListConversationsQuery, UpdateConversationRequest, WebSocketMessage,
 };
-use aionui_common::{AgentType, ConversationSource, ConversationStatus};
+use aionui_common::{
+    AgentKillReason, AgentType, AppError, ConversationSource, ConversationStatus, TimestampMs,
+};
 use aionui_conversation::ConversationService;
 use aionui_db::{SqliteConversationRepository, init_database_memory};
 use aionui_realtime::EventBroadcaster;
@@ -34,12 +37,42 @@ impl EventBroadcaster for TestBroadcaster {
     }
 }
 
-async fn setup() -> (ConversationService, Arc<TestBroadcaster>) {
+struct NoopTaskManager;
+
+impl IWorkerTaskManager for NoopTaskManager {
+    fn get_task(&self, _: &str) -> Option<Arc<dyn aionui_ai_agent::agent_manager::IAgentManager>> {
+        None
+    }
+    fn get_or_build_task(
+        &self,
+        _: &str,
+        _: aionui_ai_agent::types::BuildTaskOptions,
+    ) -> Result<Arc<dyn aionui_ai_agent::agent_manager::IAgentManager>, AppError> {
+        Err(AppError::Internal("noop".into()))
+    }
+    fn kill(&self, _: &str, _: Option<AgentKillReason>) -> Result<(), AppError> {
+        Ok(())
+    }
+    fn clear(&self) {}
+    fn active_count(&self) -> usize {
+        0
+    }
+    fn collect_idle(&self, _: TimestampMs) -> Vec<String> {
+        vec![]
+    }
+}
+
+async fn setup() -> (
+    ConversationService,
+    Arc<TestBroadcaster>,
+    Arc<dyn IWorkerTaskManager>,
+) {
     let db = init_database_memory().await.unwrap();
     let repo = Arc::new(SqliteConversationRepository::new(db.pool().clone()));
     let broadcaster = Arc::new(TestBroadcaster::new());
     let svc = ConversationService::new(repo, broadcaster.clone());
-    (svc, broadcaster)
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(NoopTaskManager);
+    (svc, broadcaster, task_mgr)
 }
 
 const USER_ID: &str = "system_default_user";
@@ -57,7 +90,7 @@ fn make_create_req() -> CreateConversationRequest {
 
 #[tokio::test]
 async fn t1_1_create_with_defaults() {
-    let (svc, broadcaster) = setup().await;
+    let (svc, broadcaster, _task_mgr) = setup().await;
 
     let resp = svc.create(USER_ID, make_create_req()).await.unwrap();
 
@@ -87,7 +120,7 @@ async fn t1_1_create_with_defaults() {
 
 #[tokio::test]
 async fn t1_2_create_each_agent_type() {
-    let (svc, _) = setup().await;
+    let (svc, _, _task_mgr) = setup().await;
 
     let types = vec![
         ("gemini", AgentType::Gemini),
@@ -112,7 +145,7 @@ async fn t1_2_create_each_agent_type() {
 
 #[tokio::test]
 async fn t1_3_create_with_optional_fields() {
-    let (svc, _) = setup().await;
+    let (svc, _, _task_mgr) = setup().await;
 
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "gemini",
@@ -134,7 +167,7 @@ async fn t1_3_create_with_optional_fields() {
 
 #[tokio::test]
 async fn t2_1_list_empty() {
-    let (svc, _) = setup().await;
+    let (svc, _, _task_mgr) = setup().await;
     let result = svc
         .list(USER_ID, ListConversationsQuery::default())
         .await
@@ -146,7 +179,7 @@ async fn t2_1_list_empty() {
 
 #[tokio::test]
 async fn t2_2_list_basic() {
-    let (svc, _) = setup().await;
+    let (svc, _, _task_mgr) = setup().await;
     for _ in 0..3 {
         svc.create(USER_ID, make_create_req()).await.unwrap();
     }
@@ -161,7 +194,7 @@ async fn t2_2_list_basic() {
 
 #[tokio::test]
 async fn t2_3_cursor_pagination() {
-    let (svc, _) = setup().await;
+    let (svc, _, _task_mgr) = setup().await;
     for _ in 0..5 {
         svc.create(USER_ID, make_create_req()).await.unwrap();
     }
@@ -212,7 +245,7 @@ async fn t2_3_cursor_pagination() {
 
 #[tokio::test]
 async fn t2_4_source_filter() {
-    let (svc, _) = setup().await;
+    let (svc, _, _task_mgr) = setup().await;
 
     // 2 aionui + 1 telegram
     svc.create(USER_ID, make_create_req()).await.unwrap();
@@ -238,7 +271,7 @@ async fn t2_4_source_filter() {
 
 #[tokio::test]
 async fn t2_5_pinned_filter() {
-    let (svc, _) = setup().await;
+    let (svc, _, task_mgr) = setup().await;
 
     let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
     svc.create(USER_ID, make_create_req()).await.unwrap();
@@ -246,7 +279,9 @@ async fn t2_5_pinned_filter() {
     // Pin one
     let pin_req: UpdateConversationRequest =
         serde_json::from_value(json!({ "pinned": true })).unwrap();
-    svc.update(USER_ID, &conv.id, pin_req).await.unwrap();
+    svc.update(USER_ID, &conv.id, pin_req, &task_mgr)
+        .await
+        .unwrap();
 
     let query = ListConversationsQuery {
         pinned: Some(true),
@@ -261,7 +296,7 @@ async fn t2_5_pinned_filter() {
 
 #[tokio::test]
 async fn t3_1_get_existing() {
-    let (svc, _) = setup().await;
+    let (svc, _, _task_mgr) = setup().await;
     let created = svc.create(USER_ID, make_create_req()).await.unwrap();
 
     let fetched = svc.get(USER_ID, &created.id).await.unwrap();
@@ -273,7 +308,7 @@ async fn t3_1_get_existing() {
 
 #[tokio::test]
 async fn t3_2_get_not_found() {
-    let (svc, _) = setup().await;
+    let (svc, _, _task_mgr) = setup().await;
     let err = svc.get(USER_ID, "non-existent-uuid").await.unwrap_err();
     assert!(matches!(err, aionui_common::AppError::NotFound(_)));
 }
@@ -282,13 +317,13 @@ async fn t3_2_get_not_found() {
 
 #[tokio::test]
 async fn t4_1_update_name() {
-    let (svc, broadcaster) = setup().await;
+    let (svc, broadcaster, task_mgr) = setup().await;
     let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
     broadcaster.take_events();
 
     let req: UpdateConversationRequest =
         serde_json::from_value(json!({ "name": "New Name" })).unwrap();
-    let updated = svc.update(USER_ID, &conv.id, req).await.unwrap();
+    let updated = svc.update(USER_ID, &conv.id, req, &task_mgr).await.unwrap();
 
     assert_eq!(updated.name, "New Name");
     assert!(updated.modified_at >= conv.modified_at);
@@ -300,11 +335,11 @@ async fn t4_1_update_name() {
 
 #[tokio::test]
 async fn t4_2_pin_conversation() {
-    let (svc, _) = setup().await;
+    let (svc, _, task_mgr) = setup().await;
     let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
 
     let req: UpdateConversationRequest = serde_json::from_value(json!({ "pinned": true })).unwrap();
-    let updated = svc.update(USER_ID, &conv.id, req).await.unwrap();
+    let updated = svc.update(USER_ID, &conv.id, req, &task_mgr).await.unwrap();
 
     assert!(updated.pinned);
     assert!(updated.pinned_at.is_some());
@@ -312,25 +347,28 @@ async fn t4_2_pin_conversation() {
 
 #[tokio::test]
 async fn t4_3_unpin_clears_pinned_at() {
-    let (svc, _) = setup().await;
+    let (svc, _, task_mgr) = setup().await;
     let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
 
     // Pin
     let pin: UpdateConversationRequest = serde_json::from_value(json!({ "pinned": true })).unwrap();
-    let pinned = svc.update(USER_ID, &conv.id, pin).await.unwrap();
+    let pinned = svc.update(USER_ID, &conv.id, pin, &task_mgr).await.unwrap();
     assert!(pinned.pinned_at.is_some());
 
     // Unpin
     let unpin: UpdateConversationRequest =
         serde_json::from_value(json!({ "pinned": false })).unwrap();
-    let unpinned = svc.update(USER_ID, &conv.id, unpin).await.unwrap();
+    let unpinned = svc
+        .update(USER_ID, &conv.id, unpin, &task_mgr)
+        .await
+        .unwrap();
     assert!(!unpinned.pinned);
     assert!(unpinned.pinned_at.is_none());
 }
 
 #[tokio::test]
 async fn t4_4_extra_merge_preserves_existing_keys() {
-    let (svc, _) = setup().await;
+    let (svc, _, task_mgr) = setup().await;
 
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "gemini",
@@ -343,7 +381,10 @@ async fn t4_4_extra_merge_preserves_existing_keys() {
     // Update only workspace
     let update_req: UpdateConversationRequest =
         serde_json::from_value(json!({ "extra": { "workspace": "/new" } })).unwrap();
-    let updated = svc.update(USER_ID, &conv.id, update_req).await.unwrap();
+    let updated = svc
+        .update(USER_ID, &conv.id, update_req, &task_mgr)
+        .await
+        .unwrap();
 
     assert_eq!(updated.extra["workspace"], "/new");
     assert_eq!(updated.extra["contextFileName"], "ctx.md");
@@ -351,14 +392,14 @@ async fn t4_4_extra_merge_preserves_existing_keys() {
 
 #[tokio::test]
 async fn t4_5_update_model() {
-    let (svc, _) = setup().await;
+    let (svc, _, task_mgr) = setup().await;
     let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
 
     let req: UpdateConversationRequest = serde_json::from_value(json!({
         "model": { "provider_id": "p2", "model": "new-model" }
     }))
     .unwrap();
-    let updated = svc.update(USER_ID, &conv.id, req).await.unwrap();
+    let updated = svc.update(USER_ID, &conv.id, req, &task_mgr).await.unwrap();
 
     let model = updated.model.unwrap();
     assert_eq!(model.provider_id, "p2");
@@ -367,9 +408,12 @@ async fn t4_5_update_model() {
 
 #[tokio::test]
 async fn t4_6_update_not_found() {
-    let (svc, _) = setup().await;
+    let (svc, _, task_mgr) = setup().await;
     let req: UpdateConversationRequest = serde_json::from_value(json!({ "name": "x" })).unwrap();
-    let err = svc.update(USER_ID, "non-existent", req).await.unwrap_err();
+    let err = svc
+        .update(USER_ID, "non-existent", req, &task_mgr)
+        .await
+        .unwrap_err();
     assert!(matches!(err, aionui_common::AppError::NotFound(_)));
 }
 
@@ -377,7 +421,7 @@ async fn t4_6_update_not_found() {
 
 #[tokio::test]
 async fn t5_1_delete_conversation() {
-    let (svc, broadcaster) = setup().await;
+    let (svc, broadcaster, _task_mgr) = setup().await;
     let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
     broadcaster.take_events();
 
@@ -396,7 +440,7 @@ async fn t5_1_delete_conversation() {
 
 #[tokio::test]
 async fn t5_2_delete_then_get_returns_404() {
-    let (svc, _) = setup().await;
+    let (svc, _, _task_mgr) = setup().await;
     let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
 
     svc.delete(USER_ID, &conv.id).await.unwrap();
@@ -406,7 +450,7 @@ async fn t5_2_delete_then_get_returns_404() {
 
 #[tokio::test]
 async fn t5_3_delete_not_found() {
-    let (svc, _) = setup().await;
+    let (svc, _, _task_mgr) = setup().await;
     let err = svc.delete(USER_ID, "non-existent").await.unwrap_err();
     assert!(matches!(err, aionui_common::AppError::NotFound(_)));
 }
@@ -415,7 +459,7 @@ async fn t5_3_delete_not_found() {
 
 #[tokio::test]
 async fn t11_1_create_broadcasts_created() {
-    let (svc, broadcaster) = setup().await;
+    let (svc, broadcaster, _task_mgr) = setup().await;
     let resp = svc.create(USER_ID, make_create_req()).await.unwrap();
 
     let events = broadcaster.take_events();
@@ -427,12 +471,12 @@ async fn t11_1_create_broadcasts_created() {
 
 #[tokio::test]
 async fn t11_2_update_broadcasts_updated() {
-    let (svc, broadcaster) = setup().await;
+    let (svc, broadcaster, task_mgr) = setup().await;
     let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
     broadcaster.take_events();
 
     let req: UpdateConversationRequest = serde_json::from_value(json!({ "name": "x" })).unwrap();
-    svc.update(USER_ID, &conv.id, req).await.unwrap();
+    svc.update(USER_ID, &conv.id, req, &task_mgr).await.unwrap();
 
     let events = broadcaster.take_events();
     assert_eq!(events[0].data["action"], "updated");
@@ -440,7 +484,7 @@ async fn t11_2_update_broadcasts_updated() {
 
 #[tokio::test]
 async fn t11_3_delete_broadcasts_deleted() {
-    let (svc, broadcaster) = setup().await;
+    let (svc, broadcaster, _task_mgr) = setup().await;
     let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
     broadcaster.take_events();
 
@@ -454,7 +498,7 @@ async fn t11_3_delete_broadcasts_deleted() {
 
 #[tokio::test]
 async fn t12_1_long_name() {
-    let (svc, _) = setup().await;
+    let (svc, _, _task_mgr) = setup().await;
     let long_name = "x".repeat(1000);
 
     let req: CreateConversationRequest = serde_json::from_value(json!({
@@ -470,7 +514,7 @@ async fn t12_1_long_name() {
 
 #[tokio::test]
 async fn t12_2_large_extra_json() {
-    let (svc, _) = setup().await;
+    let (svc, _, _task_mgr) = setup().await;
 
     let large_extra = json!({
         "workspace": "/project",
@@ -497,7 +541,7 @@ async fn t12_2_large_extra_json() {
 
 #[tokio::test]
 async fn t12_3_concurrent_creates() {
-    let (svc, _) = setup().await;
+    let (svc, _, _task_mgr) = setup().await;
 
     let mut handles = vec![];
     for _ in 0..10 {
@@ -522,7 +566,7 @@ async fn t12_3_concurrent_creates() {
 
 #[tokio::test]
 async fn full_lifecycle_create_get_update_delete() {
-    let (svc, broadcaster) = setup().await;
+    let (svc, broadcaster, task_mgr) = setup().await;
 
     // Create
     let created = svc.create(USER_ID, make_create_req()).await.unwrap();
@@ -539,7 +583,10 @@ async fn full_lifecycle_create_get_update_delete() {
         "extra": { "workspace": "/updated" }
     }))
     .unwrap();
-    let updated = svc.update(USER_ID, &created.id, update_req).await.unwrap();
+    let updated = svc
+        .update(USER_ID, &created.id, update_req, &task_mgr)
+        .await
+        .unwrap();
     assert_eq!(updated.name, "Updated");
     assert!(updated.pinned);
     assert_eq!(updated.extra["workspace"], "/updated");


### PR DESCRIPTION
## Summary

- 修复会话中切换模型后，AI 仍然使用旧模型回复的问题
- 根因：`ConversationService::update()` 更新了数据库中的 model 字段，但 `WorkerTaskManager` 的 DashMap 中缓存的旧 agent task 未被清除，`get_or_build_task()` 命中缓存直接返回旧 agent
- 修复：在 `update()` 中检测 model 字段变更，调用 `task_manager.kill()` 驱逐缓存，下次发消息时用新模型重建 agent

## Changes

- `service.rs` — `update()` 新增 `task_manager` 参数，model 变更时调用 `kill()` 清除缓存
- `routes.rs` — handler 传入 `state.worker_task_manager`
- `service_test.rs` / `conversation_crud.rs` — 测试适配新签名

## Test plan

- [x] `cargo clippy -p aionui-conversation -- -D warnings` 零警告
- [x] `cargo clippy -p aionui-app -- -D warnings` 零警告（全量编译通过）
- [x] `cargo test -p aionui-conversation` 131 个测试全部通过
- [ ] 手动验证：创建会话 → 发消息 → 切换模型 → 再发消息确认使用新模型