### PR TITLE
feat: aionrs session resume on conversation re-entry

### DIFF
--- a/crates/aionui-ai-agent/src/aionrs_agent.rs
+++ b/crates/aionui-ai-agent/src/aionrs_agent.rs
@@ -85,7 +85,10 @@ impl AionrsAgentManager {
             tools: Default::default(),
             session: SessionConfig {
                 enabled: true,
-                directory: config_extra.session_directory.to_string_lossy().into_owned(),
+                directory: config_extra
+                    .session_directory
+                    .to_string_lossy()
+                    .into_owned(),
                 ..Default::default()
             },
             compact: Default::default(),
@@ -115,16 +118,14 @@ impl AionrsAgentManager {
             .map_err(|e| AppError::Internal(format!("Agent bootstrap failed: {e}")))?;
 
         let mut engine = result.engine;
-        if !is_resume {
-            if let Err(e) =
-                engine.init_session(&provider_label, &workspace, Some(&conversation_id))
-            {
-                error!(
-                    conversation_id = %conversation_id,
-                    error = %e,
-                    "Failed to init session, continuing without persistence"
-                );
-            }
+        if !is_resume
+            && let Err(e) = engine.init_session(&provider_label, &workspace, Some(&conversation_id))
+        {
+            error!(
+                conversation_id = %conversation_id,
+                error = %e,
+                "Failed to init session, continuing without persistence"
+            );
         }
 
         let approval_manager = Arc::new(ToolApprovalManager::new());

--- a/crates/aionui-ai-agent/src/aionrs_agent.rs
+++ b/crates/aionui-ai-agent/src/aionrs_agent.rs
@@ -4,8 +4,9 @@ use std::sync::{Arc, RwLock};
 use aion_agent::bootstrap::AgentBootstrap;
 use aion_agent::engine::AgentEngine;
 use aion_agent::output::OutputSink;
+use aion_agent::session::Session;
 use aion_config::compat::ProviderCompat;
-use aion_config::config::{Config, ProviderType};
+use aion_config::config::{Config, ProviderType, SessionConfig};
 use aion_mcp::manager::McpManager;
 use aion_protocol::ToolApprovalManager;
 use aionui_common::{
@@ -37,6 +38,7 @@ impl AionrsAgentManager {
         conversation_id: String,
         workspace: String,
         config_extra: AionrsResolvedConfig,
+        resume_session: Option<Session>,
     ) -> Result<Self, AppError> {
         let (event_tx, _) = broadcast::channel(128);
         let sink: Arc<dyn OutputSink> = Arc::new(BackendOutputSink::new(event_tx.clone()));
@@ -65,8 +67,11 @@ impl AionrsAgentManager {
             ProviderType::Anthropic | ProviderType::Bedrock | ProviderType::Vertex
         );
 
+        let is_resume = resume_session.is_some();
+        let provider_label = config_extra.provider.clone();
+
         let config = Config {
-            provider_label: config_extra.provider.clone(),
+            provider_label: provider_label.clone(),
             provider: provider_type,
             api_key: config_extra.api_key,
             base_url: config_extra.base_url.unwrap_or_default(),
@@ -78,7 +83,11 @@ impl AionrsAgentManager {
             prompt_caching,
             compat,
             tools: Default::default(),
-            session: Default::default(),
+            session: SessionConfig {
+                enabled: true,
+                directory: config_extra.session_directory.to_string_lossy().into_owned(),
+                ..Default::default()
+            },
             compact: Default::default(),
             plan: Default::default(),
             file_cache: Default::default(),
@@ -89,10 +98,34 @@ impl AionrsAgentManager {
             debug: Default::default(),
         };
 
-        let result = AgentBootstrap::new(config, &workspace, sink)
+        let mut bootstrap = AgentBootstrap::new(config, &workspace, sink);
+        if let Some(session) = resume_session {
+            info!(
+                conversation_id = %conversation_id,
+                session_id = %session.id,
+                message_count = session.messages.len(),
+                "Resuming aionrs session"
+            );
+            bootstrap = bootstrap.resume(session);
+        }
+
+        let result = bootstrap
             .build()
             .await
             .map_err(|e| AppError::Internal(format!("Agent bootstrap failed: {e}")))?;
+
+        let mut engine = result.engine;
+        if !is_resume {
+            if let Err(e) =
+                engine.init_session(&provider_label, &workspace, Some(&conversation_id))
+            {
+                error!(
+                    conversation_id = %conversation_id,
+                    error = %e,
+                    "Failed to init session, continuing without persistence"
+                );
+            }
+        }
 
         let approval_manager = Arc::new(ToolApprovalManager::new());
 
@@ -101,7 +134,7 @@ impl AionrsAgentManager {
             workspace,
             event_tx,
             last_activity: AtomicI64::new(now_ms()),
-            engine: Mutex::new(result.engine),
+            engine: Mutex::new(engine),
             mcp_managers: result.mcp_managers,
             status: RwLock::new(Some(ConversationStatus::Pending)),
             approval_manager,
@@ -276,14 +309,16 @@ mod tests {
             max_tokens: 4096,
             max_turns: None,
             compat_overrides: Default::default(),
+            session_directory: std::env::temp_dir().join("aionrs-test-sessions"),
         }
     }
 
     #[tokio::test]
     async fn aionrs_agent_returns_correct_type() {
-        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config())
-            .await
-            .unwrap();
+        let agent =
+            AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config(), None)
+                .await
+                .unwrap();
         assert_eq!(agent.agent_type(), AgentType::Aionrs);
         assert_eq!(agent.workspace(), "/project");
         assert_eq!(agent.conversation_id(), "conv-1");
@@ -291,59 +326,69 @@ mod tests {
 
     #[tokio::test]
     async fn aionrs_agent_initial_status_is_pending() {
-        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config())
-            .await
-            .unwrap();
+        let agent =
+            AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config(), None)
+                .await
+                .unwrap();
         assert_eq!(agent.status(), Some(ConversationStatus::Pending));
     }
 
     #[tokio::test]
     async fn aionrs_agent_subscribe_returns_receiver() {
-        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config())
-            .await
-            .unwrap();
+        let agent =
+            AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config(), None)
+                .await
+                .unwrap();
         let _rx = agent.subscribe();
     }
 
     #[tokio::test]
     async fn aionrs_agent_kill_succeeds() {
-        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config())
-            .await
-            .unwrap();
+        let agent =
+            AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config(), None)
+                .await
+                .unwrap();
         assert!(agent.kill(None).is_ok());
         assert_eq!(agent.status(), None);
     }
 
     #[tokio::test]
     async fn aionrs_agent_kill_with_reason_succeeds() {
-        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config())
-            .await
-            .unwrap();
+        let agent =
+            AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config(), None)
+                .await
+                .unwrap();
         assert!(agent.kill(Some(AgentKillReason::IdleTimeout)).is_ok());
     }
 
     #[tokio::test]
     async fn aionrs_agent_confirmations_initially_empty() {
-        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config())
-            .await
-            .unwrap();
+        let agent =
+            AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config(), None)
+                .await
+                .unwrap();
         assert!(agent.get_confirmations().is_empty());
     }
 
     #[tokio::test]
     async fn aionrs_agent_check_approval_returns_false_by_default() {
-        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config())
-            .await
-            .unwrap();
+        let agent =
+            AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config(), None)
+                .await
+                .unwrap();
         assert!(!agent.check_approval("any_action", None));
     }
 
     #[tokio::test]
     async fn stop_emits_finish_event_and_sets_status() {
-        let agent =
-            AionrsAgentManager::new("conv-stop".into(), "/project".into(), make_test_config())
-                .await
-                .unwrap();
+        let agent = AionrsAgentManager::new(
+            "conv-stop".into(),
+            "/project".into(),
+            make_test_config(),
+            None,
+        )
+        .await
+        .unwrap();
         let mut rx = agent.subscribe();
 
         agent.stop().await.unwrap();
@@ -364,10 +409,14 @@ mod tests {
 
     #[tokio::test]
     async fn event_tx_can_send_error_and_finish() {
-        let agent =
-            AionrsAgentManager::new("conv-err".into(), "/project".into(), make_test_config())
-                .await
-                .unwrap();
+        let agent = AionrsAgentManager::new(
+            "conv-err".into(),
+            "/project".into(),
+            make_test_config(),
+            None,
+        )
+        .await
+        .unwrap();
         let mut rx = agent.subscribe();
 
         let _ = agent.event_tx.send(AgentStreamEvent::Error(

--- a/crates/aionui-ai-agent/src/factory.rs
+++ b/crates/aionui-ai-agent/src/factory.rs
@@ -1,8 +1,9 @@
+use aion_agent::session::SessionManager;
 use aionui_common::{AcpBackend, AgentType, AppError, CommandSpec, now_ms};
 use aionui_db::{IProviderRepository, IRemoteAgentRepository};
 use std::path::PathBuf;
 use std::sync::Arc;
-use tracing::warn;
+use tracing::{debug, info, warn};
 
 use crate::agent_manager::AgentManagerHandle;
 use crate::agent_registry::AgentRegistry;
@@ -243,6 +244,31 @@ async fn build_agent(
             let (base_url, compat_overrides) =
                 resolve_aionrs_url_and_compat(&row.platform, &row.base_url, &provider);
 
+            let session_directory = deps.data_dir.join("aionrs-sessions");
+
+            let resume_session = {
+                let session_mgr = SessionManager::new(session_directory.clone(), 100);
+                match session_mgr.load(&conversation_id) {
+                    Ok(session) => {
+                        info!(
+                            conversation_id = %conversation_id,
+                            session_id = %session.id,
+                            message_count = session.messages.len(),
+                            "Loaded existing aionrs session for resume"
+                        );
+                        Some(session)
+                    }
+                    Err(e) => {
+                        debug!(
+                            conversation_id = %conversation_id,
+                            error = %e,
+                            "No existing aionrs session found, starting fresh"
+                        );
+                        None
+                    }
+                }
+            };
+
             let config = AionrsResolvedConfig {
                 provider,
                 api_key,
@@ -252,9 +278,11 @@ async fn build_agent(
                 max_tokens: overrides.max_tokens,
                 max_turns: overrides.max_turns,
                 compat_overrides,
+                session_directory,
             };
 
-            let agent = AionrsAgentManager::new(conversation_id, workspace, config).await?;
+            let agent =
+                AionrsAgentManager::new(conversation_id, workspace, config, resume_session).await?;
             Ok(Arc::new(agent) as AgentManagerHandle)
         }
     }

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use serde::{Deserialize, Serialize};
 
 use aionui_common::{AcpBackend, AgentType, ProviderWithModel};
@@ -202,6 +204,8 @@ pub struct AionrsResolvedConfig {
     pub max_turns: Option<usize>,
     /// Provider-specific compat overrides.
     pub compat_overrides: AionrsCompatOverrides,
+    /// Directory for aionrs session persistence files.
+    pub session_directory: PathBuf,
 }
 
 fn default_aionrs_max_tokens() -> u32 {

--- a/crates/aionui-ai-agent/tests/agent_types_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_types_integration.rs
@@ -117,32 +117,36 @@ fn make_aionrs_config() -> AionrsResolvedConfig {
         max_tokens: 4096,
         max_turns: None,
         compat_overrides: Default::default(),
+        session_directory: std::env::temp_dir().join("aionrs-test-sessions"),
     }
 }
 
 #[tokio::test]
 async fn aionrs_agent_kill_succeeds() {
-    let agent = AionrsAgentManager::new("conv-1".into(), "/proj".into(), make_aionrs_config())
-        .await
-        .unwrap();
+    let agent =
+        AionrsAgentManager::new("conv-1".into(), "/proj".into(), make_aionrs_config(), None)
+            .await
+            .unwrap();
     assert!(agent.kill(None).is_ok());
     assert!(agent.kill(Some(AgentKillReason::IdleTimeout)).is_ok());
 }
 
 #[tokio::test]
 async fn aionrs_agent_confirm_succeeds() {
-    let agent = AionrsAgentManager::new("conv-1".into(), "/proj".into(), make_aionrs_config())
-        .await
-        .unwrap();
+    let agent =
+        AionrsAgentManager::new("conv-1".into(), "/proj".into(), make_aionrs_config(), None)
+            .await
+            .unwrap();
     let result = agent.confirm("msg", "call", json!({}), false);
     assert!(result.is_ok());
 }
 
 #[tokio::test]
 async fn aionrs_agent_metadata() {
-    let agent = AionrsAgentManager::new("conv-abc".into(), "/work".into(), make_aionrs_config())
-        .await
-        .unwrap();
+    let agent =
+        AionrsAgentManager::new("conv-abc".into(), "/work".into(), make_aionrs_config(), None)
+            .await
+            .unwrap();
     assert_eq!(agent.agent_type(), AgentType::Aionrs);
     assert_eq!(agent.workspace(), "/work");
     assert_eq!(agent.conversation_id(), "conv-abc");

--- a/crates/aionui-ai-agent/tests/agent_types_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_types_integration.rs
@@ -143,10 +143,14 @@ async fn aionrs_agent_confirm_succeeds() {
 
 #[tokio::test]
 async fn aionrs_agent_metadata() {
-    let agent =
-        AionrsAgentManager::new("conv-abc".into(), "/work".into(), make_aionrs_config(), None)
-            .await
-            .unwrap();
+    let agent = AionrsAgentManager::new(
+        "conv-abc".into(),
+        "/work".into(),
+        make_aionrs_config(),
+        None,
+    )
+    .await
+    .unwrap();
     assert_eq!(agent.agent_type(), AgentType::Aionrs);
     assert_eq!(agent.workspace(), "/work");
     assert_eq!(agent.conversation_id(), "conv-abc");


### PR DESCRIPTION
## Summary

- 重新进入已有 aionrs 会话时，自动从磁盘加载 session 文件恢复历史消息上下文，使 AI 能延续之前的对话
- `AionrsResolvedConfig` 新增 `session_directory` 字段，指定 session 持久化目录
- `AionrsAgentManager::new()` 新增 `resume_session: Option<Session>` 参数，通过 `AgentBootstrap.resume()` 恢复会话
- Factory 的 Aionrs 分支在构建 agent 前使用 `SessionManager::load(conversation_id)` 尝试加载已有 session，加载失败则静默降级为新会话

## Changed files

- `crates/aionui-ai-agent/src/types.rs` — `AionrsResolvedConfig` 增加 `session_directory: PathBuf`
- `crates/aionui-ai-agent/src/aionrs_agent.rs` — 支持 resume session 参数，配置 `SessionConfig`，分支处理 resume vs 新建
- `crates/aionui-ai-agent/src/factory.rs` — Aionrs 分支加载 session 文件，传递给 agent manager
- `crates/aionui-ai-agent/tests/agent_types_integration.rs` — 更新集成测试适配新接口

## Test plan

- [x] `cargo test -p aionui-ai-agent` — 348 passed, 0 failed
- [x] `cargo clippy --workspace -- -D warnings` — 通过
- [x] `cargo fmt --all -- --check` — 通过
- [x] `cargo test --workspace` — 无新增失败（10 个 `extension_e2e` 失败为 main 已有问题）