### PR TITLE
feat: add generic /api/conversations/{id}/mode endpoint

### DIFF
--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -426,15 +426,15 @@ impl AcpAgentManager {
 
     // -- ACP-specific extended methods (beyond IAgentManager) --
 
-    /// Get the current session mode.
-    pub async fn get_mode(&self) -> Result<Value, AppError> {
+    /// Query the ACP backend for current session mode.
+    pub async fn acp_get_mode(&self) -> Result<Value, AppError> {
         // With the SDK, mode info arrives via session update events.
         // We return a placeholder — the actual mode is tracked internally.
         Ok(json!({ "sent": true }))
     }
 
-    /// Set the session mode.
-    pub async fn set_mode(&self, mode: &str) -> Result<(), AppError> {
+    /// Set the session mode via ACP protocol.
+    pub async fn acp_set_mode(&self, mode: &str) -> Result<(), AppError> {
         let sid = self
             .state
             .read()
@@ -652,6 +652,18 @@ impl crate::agent_manager::IAgentManager for AcpAgentManager {
         });
 
         Ok(())
+    }
+
+    async fn get_mode(&self) -> Result<aionui_api_types::AgentModeResponse, AppError> {
+        self.acp_get_mode().await?;
+        Ok(aionui_api_types::AgentModeResponse {
+            mode: String::new(),
+            initialized: self.session_id().await.is_some(),
+        })
+    }
+
+    async fn set_mode(&self, mode: &str) -> Result<(), AppError> {
+        self.acp_set_mode(mode).await
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/crates/aionui-ai-agent/src/acp_routes.rs
+++ b/crates/aionui-ai-agent/src/acp_routes.rs
@@ -6,9 +6,8 @@ use axum::extract::{Extension, Json, Path, State};
 use axum::routing::{get, post, put};
 
 use aionui_api_types::{
-    AcpEnvResponse, AcpHealthCheckRequest, AcpHealthCheckResponse, AcpModeResponse, ApiResponse,
-    DetectCliRequest, DetectCliResponse, ProbeModelRequest, SetConfigOptionRequest, SetModeRequest,
-    SetModelRequest,
+    AcpEnvResponse, AcpHealthCheckRequest, AcpHealthCheckResponse, ApiResponse, DetectCliRequest,
+    DetectCliResponse, ProbeModelRequest, SetConfigOptionRequest, SetModelRequest,
 };
 use aionui_auth::CurrentUser;
 use aionui_common::{AgentType, AppError};
@@ -37,10 +36,6 @@ pub fn acp_routes(state: AcpRouterState) -> Router {
         .route("/api/acp/env", get(get_env))
         .route("/api/acp/probe-model", post(probe_model))
         // Per-conversation ACP session routes
-        .route(
-            "/api/conversations/{id}/acp/mode",
-            get(get_mode).put(set_mode),
-        )
         .route(
             "/api/conversations/{id}/acp/model",
             get(get_model).put(set_model),
@@ -136,37 +131,6 @@ async fn probe_model(
 }
 
 // ── Per-conversation ACP session routes ──────────────────────────
-
-async fn get_mode(
-    State(state): State<AcpRouterState>,
-    Extension(_user): Extension<CurrentUser>,
-    Path(id): Path<String>,
-) -> Result<Json<ApiResponse<AcpModeResponse>>, AppError> {
-    let handle = require_acp_task(&state, &id)?;
-    let acp = downcast_acp(&handle)?;
-    acp.get_mode().await?;
-    // The actual mode is returned via the event stream; provide best-effort sync state
-    Ok(Json(ApiResponse::ok(AcpModeResponse {
-        mode: String::new(),
-        initialized: acp.session_id().await.is_some(),
-    })))
-}
-
-async fn set_mode(
-    State(state): State<AcpRouterState>,
-    Extension(_user): Extension<CurrentUser>,
-    Path(id): Path<String>,
-    body: Result<Json<SetModeRequest>, JsonRejection>,
-) -> Result<Json<ApiResponse<()>>, AppError> {
-    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    if req.mode.trim().is_empty() {
-        return Err(AppError::BadRequest("mode must not be empty".into()));
-    }
-    let handle = require_acp_task(&state, &id)?;
-    let acp = downcast_acp(&handle)?;
-    acp.set_mode(&req.mode).await?;
-    Ok(Json(ApiResponse::success()))
-}
 
 async fn get_model(
     State(state): State<AcpRouterState>,

--- a/crates/aionui-ai-agent/src/agent_manager.rs
+++ b/crates/aionui-ai-agent/src/agent_manager.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
+use aionui_api_types::AgentModeResponse;
 use aionui_common::{
     AgentKillReason, AgentType, AppError, Confirmation, ConversationStatus, TimestampMs,
 };
@@ -73,6 +74,23 @@ pub trait IAgentManager: Send + Sync {
     /// - `reason: Some(IdleTimeout)` — idle cleanup
     /// - `reason: None` — explicit user/system kill
     fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError>;
+
+    /// Get the current session mode.
+    /// Default: returns "default" with initialized=false.
+    async fn get_mode(&self) -> Result<AgentModeResponse, AppError> {
+        Ok(AgentModeResponse {
+            mode: "default".into(),
+            initialized: false,
+        })
+    }
+
+    /// Set the session mode.
+    /// Default: returns error (unsupported).
+    async fn set_mode(&self, _mode: &str) -> Result<(), AppError> {
+        Err(AppError::BadRequest(
+            "Mode switching is not supported for this agent type".into(),
+        ))
+    }
 
     /// Downcast helper for accessing type-specific extensions.
     ///

--- a/crates/aionui-ai-agent/src/aionrs_agent.rs
+++ b/crates/aionui-ai-agent/src/aionrs_agent.rs
@@ -9,6 +9,8 @@ use aion_config::compat::ProviderCompat;
 use aion_config::config::{Config, ProviderType, SessionConfig};
 use aion_mcp::manager::McpManager;
 use aion_protocol::ToolApprovalManager;
+use aion_protocol::commands::SessionMode;
+use aionui_api_types::AgentModeResponse;
 use aionui_common::{
     AgentKillReason, AgentType, AppError, Confirmation, ConversationStatus, TimestampMs, now_ms,
 };
@@ -129,6 +131,16 @@ impl AionrsAgentManager {
         }
 
         let approval_manager = Arc::new(ToolApprovalManager::new());
+
+        if let Some(mode_str) = &config_extra.session_mode {
+            let mode = parse_session_mode(mode_str);
+            approval_manager.set_mode(mode);
+            info!(
+                conversation_id = %conversation_id,
+                session_mode = mode_str,
+                "Aionrs initial session mode applied"
+            );
+        }
 
         Ok(Self {
             conversation_id,
@@ -291,8 +303,35 @@ impl IAgentManager for AionrsAgentManager {
         Ok(())
     }
 
+    async fn get_mode(&self) -> Result<AgentModeResponse, AppError> {
+        Ok(AgentModeResponse {
+            mode: self.approval_manager.current_mode(),
+            initialized: true,
+        })
+    }
+
+    async fn set_mode(&self, mode: &str) -> Result<(), AppError> {
+        let prev = self.approval_manager.current_mode();
+        self.approval_manager.set_mode(parse_session_mode(mode));
+        info!(
+            conversation_id = %self.conversation_id,
+            from = prev,
+            to = mode,
+            "Aionrs session mode switched"
+        );
+        Ok(())
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+fn parse_session_mode(s: &str) -> SessionMode {
+    match s {
+        "auto_edit" => SessionMode::AutoEdit,
+        "yolo" => SessionMode::Yolo,
+        _ => SessionMode::Default,
     }
 }
 
@@ -311,6 +350,7 @@ mod tests {
             max_turns: None,
             compat_overrides: Default::default(),
             session_directory: std::env::temp_dir().join("aionrs-test-sessions"),
+            session_mode: None,
         }
     }
 

--- a/crates/aionui-ai-agent/src/auxiliary_routes.rs
+++ b/crates/aionui-ai-agent/src/auxiliary_routes.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
 use axum::Router;
+use axum::extract::rejection::JsonRejection;
 use axum::extract::{Extension, Json, Path, Query, State};
 use axum::routing::{get, post};
 
-use aionui_api_types::ApiResponse;
+use aionui_api_types::{AgentModeResponse, ApiResponse, SetModeRequest};
 use aionui_auth::CurrentUser;
 use aionui_common::{AgentType, AppError};
 use serde::{Deserialize, Serialize};
@@ -35,10 +36,47 @@ pub fn auxiliary_routes(state: AuxiliaryRouterState) -> Router {
             get(get_slash_commands),
         )
         .route(
+            "/api/conversations/{id}/mode",
+            get(get_agent_mode).put(set_agent_mode),
+        )
+        .route(
             "/api/conversations/{id}/openclaw/runtime",
             get(get_openclaw_runtime),
         )
         .with_state(state)
+}
+
+// ── Generic mode endpoints ────────────────────────────────────────
+
+async fn get_agent_mode(
+    State(state): State<AuxiliaryRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+) -> Result<Json<ApiResponse<AgentModeResponse>>, AppError> {
+    let handle = state
+        .worker_task_manager
+        .get_task(&id)
+        .ok_or_else(|| AppError::NotFound(format!("No active agent for conversation '{id}'")))?;
+    let resp = handle.get_mode().await?;
+    Ok(Json(ApiResponse::ok(resp)))
+}
+
+async fn set_agent_mode(
+    State(state): State<AuxiliaryRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+    body: Result<Json<SetModeRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<()>>, AppError> {
+    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
+    if req.mode.trim().is_empty() {
+        return Err(AppError::BadRequest("mode must not be empty".into()));
+    }
+    let handle = state
+        .worker_task_manager
+        .get_task(&id)
+        .ok_or_else(|| AppError::NotFound(format!("No active agent for conversation '{id}'")))?;
+    handle.set_mode(&req.mode).await?;
+    Ok(Json(ApiResponse::success()))
 }
 
 // ── Request / Response types ───────────────────────────────────────

--- a/crates/aionui-ai-agent/src/factory.rs
+++ b/crates/aionui-ai-agent/src/factory.rs
@@ -279,6 +279,7 @@ async fn build_agent(
                 max_turns: overrides.max_turns,
                 compat_overrides,
                 session_directory,
+                session_mode: overrides.session_mode,
             };
 
             let agent =

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -171,6 +171,9 @@ pub struct AionrsBuildExtra {
     /// Max agentic turns.
     #[serde(default)]
     pub max_turns: Option<usize>,
+    /// Session mode (default, auto_edit, yolo).
+    #[serde(default)]
+    pub session_mode: Option<String>,
 }
 
 /// Provider-specific compat overrides resolved in the factory.
@@ -206,6 +209,8 @@ pub struct AionrsResolvedConfig {
     pub compat_overrides: AionrsCompatOverrides,
     /// Directory for aionrs session persistence files.
     pub session_directory: PathBuf,
+    /// Session mode (default, auto_edit, yolo).
+    pub session_mode: Option<String>,
 }
 
 fn default_aionrs_max_tokens() -> u32 {

--- a/crates/aionui-ai-agent/tests/agent_types_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_types_integration.rs
@@ -118,6 +118,7 @@ fn make_aionrs_config() -> AionrsResolvedConfig {
         max_turns: None,
         compat_overrides: Default::default(),
         session_directory: std::env::temp_dir().join("aionrs-test-sessions"),
+        session_mode: None,
     }
 }
 

--- a/crates/aionui-api-types/src/acp.rs
+++ b/crates/aionui-api-types/src/acp.rs
@@ -39,14 +39,14 @@ pub struct AcpEnvResponse {
     pub env: HashMap<String, String>,
 }
 
-/// Response for ACP session mode.
+/// Response for agent session mode.
 #[derive(Debug, Serialize)]
-pub struct AcpModeResponse {
+pub struct AgentModeResponse {
     pub mode: String,
     pub initialized: bool,
 }
 
-/// Request body for setting ACP session mode.
+/// Request body for setting session mode.
 #[derive(Debug, Deserialize)]
 pub struct SetModeRequest {
     pub mode: String,

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -24,7 +24,7 @@ mod team;
 mod websocket;
 
 pub use acp::{
-    AcpEnvResponse, AcpHealthCheckRequest, AcpHealthCheckResponse, AcpModeResponse,
+    AcpEnvResponse, AcpHealthCheckRequest, AcpHealthCheckResponse, AgentModeResponse,
     DetectCliRequest, DetectCliResponse, ProbeModelRequest, SetConfigOptionRequest, SetModeRequest,
     SetModelRequest, TestCustomAgentRequest, TestCustomAgentResponse,
 };


### PR DESCRIPTION
## Summary

- Replace ACP-only `/api/conversations/{id}/acp/mode` with generic `/api/conversations/{id}/mode` that works across all agent types
- Add `get_mode`/`set_mode` to `IAgentManager` trait with default implementations — unsupported agent types return a clear error
- Implement aionrs mode support: wire `session_mode` from conversation `extra` through factory so initial mode is applied at creation; runtime switching via `ToolApprovalManager` (default / auto_edit / yolo)
- ACP mode behavior unchanged — trait methods delegate to existing ACP protocol

## Changes

| File | What |
|------|------|
| `aionui-api-types/src/acp.rs` | `AcpModeResponse` → `AgentModeResponse` |
| `aionui-ai-agent/src/agent_manager.rs` | `get_mode`/`set_mode` on `IAgentManager` trait |
| `aionui-ai-agent/src/types.rs` | `session_mode` field on `AionrsBuildExtra` + `AionrsResolvedConfig` |
| `aionui-ai-agent/src/factory.rs` | Pass `session_mode` through to config |
| `aionui-ai-agent/src/aionrs_agent.rs` | Apply initial mode, implement trait, add logging |
| `aionui-ai-agent/src/acp_agent.rs` | Implement trait delegating to ACP protocol |
| `aionui-ai-agent/src/auxiliary_routes.rs` | New generic `/api/conversations/{id}/mode` endpoint |
| `aionui-ai-agent/src/acp_routes.rs` | Remove `/api/conversations/{id}/acp/mode` route |

## Test plan

- [ ] `cargo test -p aionui-api-types -p aionui-ai-agent` passes (20 + 15 tests)
- [ ] `cargo clippy --workspace` passes with zero warnings
- [ ] Create aionrs conversation → switch mode → verify log "Aionrs session mode switched"
- [ ] Create ACP conversation → switch mode → verify no regression
- [ ] Frontend uses `/mode` path (requires paired frontend change in AionUi)