### PR TITLE
fix: propagate custom_workspace flag via DB extra instead of path heuristic

### DIFF
--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -325,7 +325,7 @@ impl AcpAgentManager {
                 enabled_skills: &self.config.enabled_skills,
                 exclude_builtin_skills: &self.config.exclude_builtin_skills,
                 native_skill_support: self.backend.native_skills_dirs().is_some(),
-                custom_workspace: !self.workspace.contains("-temp-"),
+                custom_workspace: self.config.custom_workspace,
             },
         )
         .await;

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -72,6 +72,7 @@ pub struct AcpBuildExtra {
     /// Associated cron job ID.
     #[serde(default)]
     pub cron_job_id: Option<String>,
+    /// Whether the workspace was explicitly provided by the user (vs. auto-created).
     #[serde(default)]
     pub custom_workspace: bool,
 }
@@ -214,6 +215,7 @@ mod tests {
         let legacy = r#"{"backend":"claude"}"#;
         let parsed: AcpBuildExtra = serde_json::from_str(legacy).unwrap();
         assert!(parsed.exclude_builtin_skills.is_empty());
+        assert!(!parsed.custom_workspace);
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -72,6 +72,8 @@ pub struct AcpBuildExtra {
     /// Associated cron job ID.
     #[serde(default)]
     pub cron_job_id: Option<String>,
+    #[serde(default)]
+    pub custom_workspace: bool,
 }
 
 /// OpenClaw gateway configuration.

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -66,6 +66,7 @@ async fn make_mock_agent(
         preset_assistant_id: None,
         session_mode: None,
         cron_job_id: None,
+        custom_workspace: false,
     };
 
     let tmp_skills = tempfile::TempDir::new().unwrap();

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -87,6 +87,9 @@ impl ConversationService {
         let source = req.source.unwrap_or(ConversationSource::Aionui);
 
         let mut extra = req.extra;
+        if !extra.is_object() {
+            extra = serde_json::Value::Object(serde_json::Map::new());
+        }
         let user_provided_workspace = !extra
             .get("workspace")
             .and_then(|v| v.as_str())

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -87,12 +87,12 @@ impl ConversationService {
         let source = req.source.unwrap_or(ConversationSource::Aionui);
 
         let mut extra = req.extra;
-        if extra
+        let user_provided_workspace = !extra
             .get("workspace")
             .and_then(|v| v.as_str())
             .unwrap_or("")
-            .is_empty()
-        {
+            .is_empty();
+        if !user_provided_workspace {
             let agent_type_label = match req.r#type {
                 aionui_common::AgentType::Acp => {
                     let backend = extra.get("backend").and_then(|v| {
@@ -112,6 +112,12 @@ impl ConversationService {
             std::fs::create_dir_all(&ws_path)
                 .map_err(|e| AppError::Internal(format!("Failed to create workspace: {e}")))?;
             extra["workspace"] = serde_json::Value::String(ws_path.to_string_lossy().into_owned());
+        }
+        if let Some(obj) = extra.as_object_mut() {
+            obj.insert(
+                "custom_workspace".to_owned(),
+                serde_json::Value::Bool(user_provided_workspace),
+            );
         }
 
         let row = aionui_db::models::ConversationRow {

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -318,6 +318,63 @@ async fn create_stores_model_as_json() {
     assert_eq!(model.model, "m1");
 }
 
+// ── custom_workspace tests ────────────────────────────────────────
+
+#[tokio::test]
+async fn create_with_user_provided_workspace_sets_custom_workspace_true() {
+    let (svc, _, _, _) = make_service();
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "model": { "provider_id": "p1", "model": "m1" },
+        "extra": { "workspace": "/my/project" }
+    }))
+    .unwrap();
+    let resp = svc.create("user_1", req).await.unwrap();
+    assert_eq!(resp.extra["custom_workspace"], true);
+    assert_eq!(resp.extra["workspace"], "/my/project");
+}
+
+#[tokio::test]
+async fn create_without_workspace_sets_custom_workspace_false_and_auto_creates_dir() {
+    let (svc, _, _, _) = make_service();
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "model": { "provider_id": "p1", "model": "m1" },
+        "extra": {}
+    }))
+    .unwrap();
+    let resp = svc.create("user_1", req).await.unwrap();
+    assert_eq!(resp.extra["custom_workspace"], false);
+    assert!(resp.extra["workspace"].as_str().unwrap().contains("-temp-"));
+}
+
+#[tokio::test]
+async fn create_with_non_object_extra_normalizes_to_object() {
+    let (svc, _, _, _) = make_service();
+    // extra is a string instead of an object — should be normalized, not panic or silently drop
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "model": { "provider_id": "p1", "model": "m1" },
+        "extra": {}
+    }))
+    .unwrap();
+    // The API type enforces object, so we test the normalization path via a manual extra mutation
+    // by directly constructing a request with a non-object extra value
+    let mut raw: serde_json::Value = json!({
+        "type": "acp",
+        "model": { "provider_id": "p1", "model": "m1" },
+        "extra": null
+    });
+    // Patch the extra field to be non-object
+    raw["extra"] = serde_json::Value::Bool(false);
+    // Since CreateConversationRequest.extra is Value, this will deserialize fine
+    if let Ok(patched_req) = serde_json::from_value::<CreateConversationRequest>(raw) {
+        let resp = svc.create("user_1", patched_req).await.unwrap();
+        // custom_workspace must be written — it must not be silently dropped
+        assert!(resp.extra.get("custom_workspace").is_some());
+    }
+}
+
 // ── Get tests ──────────────────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- `AcpBuildExtra.custom_workspace` was deleted in PR #11, causing `acp_agent.rs` to use `!self.workspace.contains("-temp-")` as a brittle heuristic
- `ConversationService.create()` now writes `custom_workspace` into the conversation's `extra` JSON: `true` if user explicitly provided a workspace path, `false` if auto-generated
- `AcpBuildExtra` gets the field back with `#[serde(default)]` for backward compatibility
- `acp_agent.rs` reads `self.config.custom_workspace` instead of guessing from the path string

## Test plan

- [ ] `cargo test --workspace` passes (2 pre-existing E2E failures in `acp_e2e.rs` are unrelated to this change — they also fail on clean `main`)
- [ ] Existing `custom_workspace_forces_heavy_even_when_native_supported` test still passes
- [ ] Existing `acp_build_extra_backcompat_no_new_fields` backcompat test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)