### PR TITLE
fix: handle empty path in office proxy routes (ppt/word/excel preview 404)

### DIFF
--- a/crates/aionui-app/tests/office_e2e.rs
+++ b/crates/aionui-app/tests/office_e2e.rs
@@ -532,11 +532,7 @@ async fn ppt_proxy_root_path_returns_non_404() {
     let req = get_request("/api/ppt-proxy/19999");
     let resp = app.oneshot(req).await.unwrap();
 
-    assert_ne!(
-        resp.status(),
-        StatusCode::NOT_FOUND,
-        "root path must hit the proxy handler, not 404"
-    );
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test]
@@ -546,11 +542,7 @@ async fn office_watch_proxy_root_path_returns_non_404() {
     let req = get_request("/api/office-watch-proxy/19999");
     let resp = app.oneshot(req).await.unwrap();
 
-    assert_ne!(
-        resp.status(),
-        StatusCode::NOT_FOUND,
-        "root path must hit the proxy handler, not 404"
-    );
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
 // ── Test utilities ──────────────────────────────────────────────────

--- a/crates/aionui-app/tests/office_e2e.rs
+++ b/crates/aionui-app/tests/office_e2e.rs
@@ -523,6 +523,36 @@ async fn rp4_office_watch_proxy_ssrf_inactive_port() {
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
+// ── RP-root: proxy root path (no trailing path segment) ─────────────
+
+#[tokio::test]
+async fn ppt_proxy_root_path_returns_non_404() {
+    let (app, _services, _tmp) = build_office_app().await;
+
+    let req = get_request("/api/ppt-proxy/19999");
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_ne!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "root path must hit the proxy handler, not 404"
+    );
+}
+
+#[tokio::test]
+async fn office_watch_proxy_root_path_returns_non_404() {
+    let (app, _services, _tmp) = build_office_app().await;
+
+    let req = get_request("/api/office-watch-proxy/19999");
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_ne!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "root path must hit the proxy handler, not 404"
+    );
+}
+
 // ── Test utilities ──────────────────────────────────────────────────
 
 fn create_test_xlsx(path: &std::path::Path) {

--- a/crates/aionui-office/src/routes.rs
+++ b/crates/aionui-office/src/routes.rs
@@ -225,15 +225,6 @@ async fn office_watch_proxy(
     headers: HeaderMap,
 ) -> Result<Response, AppError> {
     let path = params.path.as_deref().unwrap_or("/");
-    watch_proxy_forward(state, params.port, path, &headers).await
-}
-
-async fn watch_proxy_forward(
-    state: OfficeRouterState,
-    port: u16,
-    path: &str,
-    headers: &HeaderMap,
-) -> Result<Response, AppError> {
     let request_headers: Vec<(String, String)> = headers
         .iter()
         .filter_map(|(k, v)| {
@@ -245,7 +236,7 @@ async fn watch_proxy_forward(
 
     let proxy_resp = state
         .proxy_service
-        .forward_watch(port, path, &request_headers)
+        .forward_watch(params.port, path, &request_headers)
         .await?;
 
     let status =

--- a/crates/aionui-office/src/routes.rs
+++ b/crates/aionui-office/src/routes.rs
@@ -37,12 +37,20 @@ pub fn office_routes(state: OfficeRouterState) -> Router {
 
 pub fn office_proxy_routes(state: OfficeRouterState) -> Router {
     Router::new()
+        .route("/api/ppt-proxy/{port}", get(ppt_proxy))
         .route("/api/ppt-proxy/{port}/{*path}", get(ppt_proxy))
+        .route("/api/office-watch-proxy/{port}", get(office_watch_proxy))
         .route(
             "/api/office-watch-proxy/{port}/{*path}",
             get(office_watch_proxy),
         )
         .with_state(state)
+}
+
+#[derive(serde::Deserialize)]
+struct ProxyPortPath {
+    port: u16,
+    path: Option<String>,
 }
 
 // -- Preview start/stop handlers ------------------------------------------
@@ -204,16 +212,27 @@ async fn convert_document(
 
 async fn ppt_proxy(
     State(state): State<OfficeRouterState>,
-    Path((port, path)): Path<(u16, String)>,
+    Path(params): Path<ProxyPortPath>,
     headers: HeaderMap,
 ) -> Result<Response, AppError> {
-    proxy_forward(state, port, &path, DocType::Ppt, &headers).await
+    let path = params.path.as_deref().unwrap_or("/");
+    proxy_forward(state, params.port, path, DocType::Ppt, &headers).await
 }
 
 async fn office_watch_proxy(
     State(state): State<OfficeRouterState>,
-    Path((port, path)): Path<(u16, String)>,
+    Path(params): Path<ProxyPortPath>,
     headers: HeaderMap,
+) -> Result<Response, AppError> {
+    let path = params.path.as_deref().unwrap_or("/");
+    watch_proxy_forward(state, params.port, path, &headers).await
+}
+
+async fn watch_proxy_forward(
+    state: OfficeRouterState,
+    port: u16,
+    path: &str,
+    headers: &HeaderMap,
 ) -> Result<Response, AppError> {
     let request_headers: Vec<(String, String)> = headers
         .iter()
@@ -226,7 +245,7 @@ async fn office_watch_proxy(
 
     let proxy_resp = state
         .proxy_service
-        .forward_watch(port, &path, &request_headers)
+        .forward_watch(port, path, &request_headers)
         .await?;
 
     let status =


### PR DESCRIPTION
## Summary

- `/api/ppt-proxy/{port}/` and `/api/office-watch-proxy/{port}/` returned 404 because axum's `{*path}` wildcard does not match empty strings
- Affects all three document types: PPT, Word, Excel preview
- Fix: register root routes (`/{port}`) alongside wildcard routes, both pointing to the same handler
- Changed `Path<(u16, String)>` extractor to `Path<ProxyPortPath>` with `path: Option<String>`, defaulting to `"/"` when absent
- Handler count stays at 2 — no duplication introduced

## Test plan

- [x] `ppt_proxy_root_path_returns_non_404` — `GET /api/ppt-proxy/{port}` returns 403 (not 404), confirming route is matched
- [x] `office_watch_proxy_root_path_returns_non_404` — same for watch proxy
- [x] All 19 existing office E2E tests still pass
- [x] `cargo clippy -D warnings` passes
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)