### PR TITLE
feat(extension): materialize builtin skills to disk at startup

### DIFF
--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -98,6 +98,25 @@ async fn main() -> Result<()> {
         config.database_path().display()
     );
     let database = aionui_db::init_database(&config.database_path()).await?;
+
+    // Materialize the embedded builtin-skills corpus to disk before any
+    // service can read from it. Gated by a .version file so this is a
+    // no-op on subsequent starts with the same binary. When
+    // `AIONUI_BUILTIN_SKILLS_PATH` is set, skip materialization — the
+    // override path is the source of truth in that mode.
+    if std::env::var(aionui_extension::BUILTIN_SKILLS_ENV_VAR)
+        .map(|v| v.is_empty())
+        .unwrap_or(true)
+    {
+        aionui_extension::materialize_if_needed(
+            Path::new(&config.data_dir),
+            aionui_extension::builtin_skills_corpus(),
+            env!("CARGO_PKG_VERSION"),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to materialize builtin skills: {e}"))?;
+    }
+
     let services =
         AppServices::from_database_with_data_dir(database, config.data_dir.clone(), config.local)
             .await?;

--- a/crates/aionui-app/tests/assistants_e2e.rs
+++ b/crates/aionui-app/tests/assistants_e2e.rs
@@ -175,7 +175,7 @@ async fn fixture() -> Fixture {
     let skill_paths = SkillPaths {
         data_dir: ext_data_dir.clone(),
         user_skills_dir: ext_data_dir.join("skills"),
-        builtin_skills_dir: Some(ext_data_dir.join("builtin-skills")),
+        builtin_skills_dir: ext_data_dir.join("builtin-skills"),
         builtin_rules_dir: ext_data_dir.join("builtin-rules"),
         assistant_rules_dir: user_data_dir.join("assistant-rules"),
         assistant_skills_dir: user_data_dir.join("assistant-skills"),

--- a/crates/aionui-app/tests/common/mod.rs
+++ b/crates/aionui-app/tests/common/mod.rs
@@ -36,7 +36,7 @@ pub async fn build_app_with_skill_paths(
     let paths = SkillPaths {
         data_dir: root.to_path_buf(),
         user_skills_dir: root.join("skills"),
-        builtin_skills_dir: Some(builtin_dir.clone()),
+        builtin_skills_dir: builtin_dir.clone(),
         builtin_rules_dir: root.join("builtin-rules"),
         assistant_rules_dir: root.join("assistant-rules"),
         assistant_skills_dir: root.join("assistant-skills"),

--- a/crates/aionui-app/tests/extension_e2e.rs
+++ b/crates/aionui-app/tests/extension_e2e.rs
@@ -528,11 +528,7 @@ async fn sk2_read_builtin_skill_happy_path_returns_file_content() {
     let (token, csrf) = setup_and_login(&mut app, &services, "user1", "pass1").await;
 
     std::fs::write(
-        paths
-            .builtin_skills_dir
-            .as_ref()
-            .expect("disk override set in build_app_with_skill_paths")
-            .join("cowork-skills.md"),
+        paths.builtin_skills_dir.join("cowork-skills.md"),
         "## Cowork skills\n\n- git\n- bash\n",
     )
     .unwrap();
@@ -691,11 +687,7 @@ async fn sl1_list_skills_tags_builtin_and_custom_with_source_field() {
     let (mut app, services, paths) = build_app_with_skill_paths(tmp.path()).await;
     let (token, _csrf) = setup_and_login(&mut app, &services, "user1", "pass1").await;
 
-    let builtin_dir = paths
-        .builtin_skills_dir
-        .as_ref()
-        .expect("disk override set by helper")
-        .clone();
+    let builtin_dir = paths.builtin_skills_dir.clone();
     write_skill(&builtin_dir, "review", "Built-in review skill");
     write_skill(&paths.user_skills_dir, "my-skill", "A user-imported skill");
 
@@ -734,11 +726,7 @@ async fn sl2_list_skills_user_custom_overrides_builtin() {
     let (mut app, services, paths) = build_app_with_skill_paths(tmp.path()).await;
     let (token, _csrf) = setup_and_login(&mut app, &services, "user1", "pass1").await;
 
-    let builtin_dir = paths
-        .builtin_skills_dir
-        .as_ref()
-        .expect("disk override set by helper")
-        .clone();
+    let builtin_dir = paths.builtin_skills_dir.clone();
     write_skill(&builtin_dir, "review", "Built-in review");
     write_skill(&paths.user_skills_dir, "review", "Custom review override");
 
@@ -782,11 +770,7 @@ async fn ba1_auto_skills_lists_underscore_builtin_entries() {
     let (mut app, services, paths) = build_app_with_skill_paths(tmp.path()).await;
     let (token, _csrf) = setup_and_login(&mut app, &services, "user1", "pass1").await;
 
-    let builtin_dir = paths
-        .builtin_skills_dir
-        .as_ref()
-        .expect("disk override set by helper")
-        .clone();
+    let builtin_dir = paths.builtin_skills_dir.clone();
     let auto_dir = builtin_dir.join("auto-inject");
     write_skill(&auto_dir, "cron", "Schedule recurring tasks");
     write_skill(&auto_dir, "skill-creator", "Scaffold a new skill");

--- a/crates/aionui-app/tests/skills_builtin_e2e.rs
+++ b/crates/aionui-app/tests/skills_builtin_e2e.rs
@@ -31,10 +31,9 @@ struct Fixture {
     _tmp: TempDir,
 }
 
-/// Build an app whose skill state uses the embedded built-in corpus
-/// (no `AIONUI_BUILTIN_SKILLS_PATH` override) and a fresh temp data
-/// directory. `write_skill` can still seed user skills under
-/// `{data_dir}/skills/`.
+/// Build an app whose skill state points at a freshly materialized
+/// builtin-skills tree rooted at a temp `data_dir`. `write_skill` can
+/// still seed user skills under `{data_dir}/skills/`.
 async fn fixture_embedded() -> Fixture {
     // Ensure no env override interferes.
     // SAFETY: tests in this file may mutate this env var across async
@@ -49,6 +48,16 @@ async fn fixture_embedded() -> Fixture {
     let tmp = TempDir::new().unwrap();
     let data_dir = tmp.path().to_path_buf();
 
+    // Materialize the embedded corpus onto the temp data dir so the
+    // per-test router can read it just like production would.
+    aionui_extension::materialize_if_needed(
+        &data_dir,
+        aionui_extension::builtin_skills_corpus(),
+        "test-fixture",
+    )
+    .await
+    .expect("failed to materialize embedded builtin skills for test fixture");
+
     let db = init_database_memory().await.unwrap();
     let services =
         aionui_app::AppServices::from_database_with_data_dir(db, "data".to_string(), false)
@@ -62,7 +71,7 @@ async fn fixture_embedded() -> Fixture {
     let skill_paths = SkillPaths {
         data_dir: data_dir.clone(),
         user_skills_dir: data_dir.join("skills"),
-        builtin_skills_dir: None, // embedded corpus
+        builtin_skills_dir: data_dir.join("builtin-skills"),
         builtin_rules_dir: data_dir.join("builtin-rules"),
         assistant_rules_dir: data_dir.join("assistant-rules"),
         assistant_skills_dir: data_dir.join("assistant-skills"),

--- a/crates/aionui-app/tests/skills_builtin_e2e.rs
+++ b/crates/aionui-app/tests/skills_builtin_e2e.rs
@@ -272,13 +272,14 @@ async fn list_skills_builtin_entries_carry_relative_location() {
                 assert!(rel.ends_with("/SKILL.md"));
                 let loc = item["location"].as_str().unwrap();
                 assert!(
-                    loc.contains("builtin-skills-view"),
-                    "builtin location should live under view dir: {loc}"
+                    loc.contains("builtin-skills"),
+                    "builtin location should live under builtin-skills dir: {loc}"
                 );
-                // View is materialized lazily; SKILL.md must now exist.
+                // The builtin-skills tree is materialized at startup, so
+                // SKILL.md must already exist on disk.
                 assert!(
                     std::path::Path::new(loc).exists(),
-                    "view file missing on disk: {loc}"
+                    "builtin skill file missing on disk: {loc}"
                 );
             }
             "custom" => {

--- a/crates/aionui-app/tests/startup_smoke.rs
+++ b/crates/aionui-app/tests/startup_smoke.rs
@@ -48,11 +48,9 @@ async fn version_bump_triggers_rewrite() {
     )
     .await
     .unwrap();
-    assert!(
-        second,
-        "version change should trigger a fresh materialize"
-    );
+    assert!(second, "version change should trigger a fresh materialize");
 
-    let version = std::fs::read_to_string(data_dir.join("builtin-skills").join(".version")).unwrap();
+    let version =
+        std::fs::read_to_string(data_dir.join("builtin-skills").join(".version")).unwrap();
     assert_eq!(version, "test-2.0.0");
 }

--- a/crates/aionui-app/tests/startup_smoke.rs
+++ b/crates/aionui-app/tests/startup_smoke.rs
@@ -1,0 +1,58 @@
+//! Smoke test: starting the app twice with the same binary version
+//! should be a no-op on the second run (version gate skips rewrite).
+
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn second_start_with_same_version_is_noop() {
+    let tmp = TempDir::new().unwrap();
+    let data_dir = tmp.path();
+
+    let first = aionui_extension::materialize_if_needed(
+        data_dir,
+        aionui_extension::builtin_skills_corpus(),
+        "test-1.0.0",
+    )
+    .await
+    .unwrap();
+    assert!(first, "first call should materialize");
+
+    let second = aionui_extension::materialize_if_needed(
+        data_dir,
+        aionui_extension::builtin_skills_corpus(),
+        "test-1.0.0",
+    )
+    .await
+    .unwrap();
+    assert!(!second, "second call with same version should skip");
+}
+
+#[tokio::test]
+async fn version_bump_triggers_rewrite() {
+    let tmp = TempDir::new().unwrap();
+    let data_dir = tmp.path();
+
+    let first = aionui_extension::materialize_if_needed(
+        data_dir,
+        aionui_extension::builtin_skills_corpus(),
+        "test-1.0.0",
+    )
+    .await
+    .unwrap();
+    assert!(first);
+
+    let second = aionui_extension::materialize_if_needed(
+        data_dir,
+        aionui_extension::builtin_skills_corpus(),
+        "test-2.0.0",
+    )
+    .await
+    .unwrap();
+    assert!(
+        second,
+        "version change should trigger a fresh materialize"
+    );
+
+    let version = std::fs::read_to_string(data_dir.join("builtin-skills").join(".version")).unwrap();
+    assert_eq!(version, "test-2.0.0");
+}

--- a/crates/aionui-extension/src/constants.rs
+++ b/crates/aionui-extension/src/constants.rs
@@ -68,12 +68,6 @@ pub const BUILTIN_RULES_DIR_NAME: &str = "builtin-rules";
 /// `include_dir!`).
 pub const BUILTIN_AUTO_SKILLS_SUBDIR: &str = "auto-inject";
 
-/// Subdirectory under `data_dir` where the lazily materialized built-in
-/// skills "view" lives. Consumers (e.g. SkillsHubSettings export-symlink
-/// flow) need a real on-disk source path, even though the canonical
-/// corpus is embedded in the binary. See `skill_service::list_skills`.
-pub const BUILTIN_SKILLS_VIEW_SUBDIR: &str = "builtin-skills-view";
-
 /// Subdirectory under `data_dir` where per-conversation materialized
 /// skill directories are written for the gemini agent.
 pub const AGENT_SKILLS_SUBDIR: &str = "agent-skills";

--- a/crates/aionui-extension/src/lib.rs
+++ b/crates/aionui-extension/src/lib.rs
@@ -50,11 +50,12 @@ pub use routes::{ExtensionRouterState, extension_routes};
 pub use skill_routes::{SkillRouterState, skill_routes};
 pub use skill_service::{
     BUILTIN_SKILLS_ENV_VAR, BuiltinAutoSkillItem, ExternalSkillSource, NamedPath, ScannedSkill,
-    SkillListItem, SkillPaths, SkillSource, cleanup_agent_skills, cleanup_orphan_agent_skills,
-    delete_skill, detect_and_count_external_skills, detect_common_skill_paths,
-    export_skill_with_symlink, get_skill_paths, import_skill, import_skill_with_symlink,
-    list_available_skills, list_builtin_auto_skills, materialize_skills_for_agent,
-    read_builtin_rule, read_builtin_skill, read_skill_info, resolve_skill_paths, scan_for_skills,
+    SkillListItem, SkillPaths, SkillSource, builtin_skills_corpus, cleanup_agent_skills,
+    cleanup_orphan_agent_skills, delete_skill, detect_and_count_external_skills,
+    detect_common_skill_paths, export_skill_with_symlink, get_skill_paths, import_skill,
+    import_skill_with_symlink, list_available_skills, list_builtin_auto_skills,
+    materialize_skills_for_agent, read_builtin_rule, read_builtin_skill, read_skill_info,
+    resolve_skill_paths, scan_for_skills,
 };
 pub use skill_service::{
     delete_assistant_rule, delete_assistant_skill, read_assistant_rule, read_assistant_skill,

--- a/crates/aionui-extension/src/lib.rs
+++ b/crates/aionui-extension/src/lib.rs
@@ -17,6 +17,7 @@ pub mod resolvers;
 pub mod routes;
 pub mod skill_routes;
 pub mod skill_service;
+pub mod startup_materialize;
 pub mod state;
 pub mod template;
 pub mod types;
@@ -36,6 +37,7 @@ pub use registry::{ExtensionRegistry, ExtensionSummary};
 pub use resolvers::{
     resolve_all_contributions, resolve_extension_contributions, resolve_i18n_for_all,
 };
+pub use startup_materialize::materialize_if_needed;
 pub use state::{ExtensionStateStore, load_states_from_file, save_states_to_file};
 pub use template::{resolve_env_map, resolve_env_templates, resolve_file_reference};
 pub use types::*;

--- a/crates/aionui-extension/src/skill_routes.rs
+++ b/crates/aionui-extension/src/skill_routes.rs
@@ -568,7 +568,7 @@ mod tests {
         let paths = SkillPaths {
             data_dir: tmp.path().to_path_buf(),
             user_skills_dir: tmp.path().join("skills"),
-            builtin_skills_dir: Some(tmp.path().join("builtin-skills")),
+            builtin_skills_dir: tmp.path().join("builtin-skills"),
             builtin_rules_dir: tmp.path().join("builtin-rules"),
             assistant_rules_dir: tmp.path().join("assistant-rules"),
             assistant_skills_dir: tmp.path().join("assistant-skills"),

--- a/crates/aionui-extension/src/skill_service.rs
+++ b/crates/aionui-extension/src/skill_service.rs
@@ -24,27 +24,34 @@ static BUILTIN_SKILLS: Dir<'static> =
 /// [`resolve_skill_paths`] when building [`SkillPaths`].
 pub const BUILTIN_SKILLS_ENV_VAR: &str = "AIONUI_BUILTIN_SKILLS_PATH";
 
+/// Expose the embedded builtin skills corpus for startup
+/// materialization. Consumers outside this crate should not depend on
+/// `include_dir` directly.
+pub fn builtin_skills_corpus() -> &'static Dir<'static> {
+    &BUILTIN_SKILLS
+}
+
 // ---------------------------------------------------------------------------
 // Skill paths resolution
 // ---------------------------------------------------------------------------
 
 /// Resolved base directories for skill and rule management.
 ///
-/// `builtin_skills_dir` is `Some(path)` only when the
-/// `AIONUI_BUILTIN_SKILLS_PATH` env var points at an on-disk corpus, or
-/// when tests construct the struct directly. In normal production use it
-/// is `None` and the embedded [`BUILTIN_SKILLS`] corpus is consulted
-/// instead.
+/// `builtin_skills_dir` always points at a real on-disk directory.
+/// In production it resolves to `{data_dir}/builtin-skills/`, populated
+/// at startup by [`crate::startup_materialize::materialize_if_needed`].
+/// In dev/test it can be redirected via [`BUILTIN_SKILLS_ENV_VAR`].
 #[derive(Debug, Clone)]
 pub struct SkillPaths {
     /// Root data directory (~/.aionui/).
     pub data_dir: PathBuf,
     /// User-created skills directory (~/.aionui/skills/).
     pub user_skills_dir: PathBuf,
-    /// Built-in skills directory on disk. `None` means "use the embedded
-    /// corpus"; `Some(path)` means "read from disk" (env override or
-    /// test fixture).
-    pub builtin_skills_dir: Option<PathBuf>,
+    /// Built-in skills directory on disk. Always set.
+    /// Points to `{data_dir}/builtin-skills/` in production (populated at
+    /// startup by `startup_materialize::materialize_if_needed`) or
+    /// wherever [`BUILTIN_SKILLS_ENV_VAR`] points in dev mode.
+    pub builtin_skills_dir: PathBuf,
     /// Built-in rules directory (app bundle resource).
     pub builtin_rules_dir: PathBuf,
     /// Assistant-level rules directory (~/.aionui/assistant-rules/).
@@ -58,18 +65,19 @@ pub struct SkillPaths {
 /// `app_resource_dir` is the application's bundled resource directory
 /// (e.g. the binary's parent or a configured resource path); only
 /// `builtin_rules_dir` is still derived from it — built-in skills live
-/// embedded in the binary unless overridden via
-/// [`BUILTIN_SKILLS_ENV_VAR`].
+/// under `data_dir` (materialized at startup from the embedded corpus)
+/// unless redirected via [`BUILTIN_SKILLS_ENV_VAR`].
 ///
 /// `data_dir` is the user-level data root (e.g. `~/.aionui/`) and
 /// determines where user skills, assistant resources, the built-in
-/// skills "view" (`{data_dir}/builtin-skills-view/`), and per-agent
+/// skills tree (`{data_dir}/builtin-skills/`), and per-agent
 /// materialized skill dirs (`{data_dir}/agent-skills/`) live.
 pub fn resolve_skill_paths(app_resource_dir: &Path, data_dir: &Path) -> SkillPaths {
     let builtin_skills_dir = std::env::var(BUILTIN_SKILLS_ENV_VAR)
         .ok()
         .filter(|s| !s.is_empty())
-        .map(PathBuf::from);
+        .map(PathBuf::from)
+        .unwrap_or_else(|| data_dir.join(crate::constants::BUILTIN_SKILLS_DIR_NAME));
 
     SkillPaths {
         data_dir: data_dir.to_path_buf(),
@@ -106,25 +114,16 @@ pub async fn read_builtin_rule(
 /// exist (preserves the legacy graceful-degradation contract consumed by
 /// the renderer).
 ///
-/// When `paths.builtin_skills_dir` is `Some`, reads from that on-disk
-/// directory; otherwise consults the embedded corpus. Rejects
-/// `..`-style traversal regardless of source.
+/// Reads from `paths.builtin_skills_dir`, which is always populated at
+/// startup by [`crate::startup_materialize::materialize_if_needed`].
+/// Rejects `..`-style traversal.
 pub async fn read_builtin_skill(
     paths: &SkillPaths,
     file_name: &str,
 ) -> Result<String, ExtensionError> {
     validate_builtin_skill_path(file_name)?;
-
-    if let Some(dir) = &paths.builtin_skills_dir {
-        let file_path = dir.join(file_name);
-        return read_file_or_empty(&file_path).await;
-    }
-
-    Ok(BUILTIN_SKILLS
-        .get_file(file_name)
-        .and_then(|f| f.contents_utf8())
-        .map(|s| s.to_string())
-        .unwrap_or_default())
+    let file_path = paths.builtin_skills_dir.join(file_name);
+    read_file_or_empty(&file_path).await
 }
 
 // ---------------------------------------------------------------------------
@@ -273,10 +272,8 @@ pub async fn list_available_skills(
 /// Emit a [`SkillListItem`] for every built-in skill (both auto-inject
 /// and opt-in), materializing the on-disk view lazily.
 async fn list_builtin_skills(paths: &SkillPaths) -> Vec<SkillListItem> {
-    if let Some(dir) = &paths.builtin_skills_dir {
-        return list_builtin_skills_from_disk(paths, dir).await;
-    }
-    list_builtin_skills_from_embedded(paths).await
+    let dir = paths.builtin_skills_dir.clone();
+    list_builtin_skills_from_disk(paths, &dir).await
 }
 
 async fn list_builtin_skills_from_disk(paths: &SkillPaths, dir: &Path) -> Vec<SkillListItem> {
@@ -288,8 +285,16 @@ async fn list_builtin_skills_from_disk(paths: &SkillPaths, dir: &Path) -> Vec<Sk
             if s.name == BUILTIN_AUTO_SKILLS_SUBDIR {
                 continue;
             }
-            let rel = format!("{}/{SKILL_MANIFEST_FILE}", s.name);
-            let location = materialize_builtin_view_from_disk(paths, dir, &s.name).await;
+            // Use the on-disk directory name (basename of scanned path)
+            // rather than the frontmatter name, so the view lookup hits
+            // the real filesystem layout when the two disagree.
+            let dir_name = Path::new(&s.path)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(&s.name)
+                .to_string();
+            let rel = format!("{dir_name}/{SKILL_MANIFEST_FILE}");
+            let location = materialize_builtin_view_from_disk(paths, dir, &dir_name).await;
             items.push(SkillListItem {
                 name: s.name,
                 description: s.description,
@@ -305,11 +310,13 @@ async fn list_builtin_skills_from_disk(paths: &SkillPaths, dir: &Path) -> Vec<Sk
     let auto_dir = dir.join(BUILTIN_AUTO_SKILLS_SUBDIR);
     if let Ok(auto) = scan_skill_dirs(&auto_dir).await {
         for s in auto {
-            let rel = format!(
-                "{BUILTIN_AUTO_SKILLS_SUBDIR}/{}/{SKILL_MANIFEST_FILE}",
-                s.name
-            );
-            let location = materialize_builtin_view_from_disk(paths, dir, &s.name).await;
+            let dir_name = Path::new(&s.path)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(&s.name)
+                .to_string();
+            let rel = format!("{BUILTIN_AUTO_SKILLS_SUBDIR}/{dir_name}/{SKILL_MANIFEST_FILE}");
+            let location = materialize_builtin_view_from_disk(paths, dir, &dir_name).await;
             items.push(SkillListItem {
                 name: s.name,
                 description: s.description,
@@ -324,6 +331,7 @@ async fn list_builtin_skills_from_disk(paths: &SkillPaths, dir: &Path) -> Vec<Sk
     items
 }
 
+#[allow(dead_code)]
 async fn list_builtin_skills_from_embedded(paths: &SkillPaths) -> Vec<SkillListItem> {
     let mut items = Vec::new();
 
@@ -396,6 +404,7 @@ async fn list_builtin_skills_from_embedded(paths: &SkillPaths) -> Vec<SkillListI
     items
 }
 
+#[allow(dead_code)]
 fn read_embedded_skill_meta(skill_rel: &str) -> Option<(String, String)> {
     let file = BUILTIN_SKILLS.get_file(skill_rel)?;
     let content = file.contents_utf8()?;
@@ -515,20 +524,14 @@ pub struct BuiltinAutoSkillItem {
 
 /// List built-in skills that are auto-injected into every assistant.
 ///
-/// Reads from the embedded corpus under `auto-inject/`, or from
-/// `{builtin_skills_dir}/auto-inject/` when a disk override is in
-/// effect. A missing `auto-inject/` directory yields an empty list,
-/// matching the graceful-degradation semantics used elsewhere in this
-/// module.
+/// Reads from `{paths.builtin_skills_dir}/auto-inject/`. A missing
+/// `auto-inject/` directory yields an empty list, matching the
+/// graceful-degradation semantics used elsewhere in this module.
 pub async fn list_builtin_auto_skills(
     paths: &SkillPaths,
 ) -> Result<Vec<BuiltinAutoSkillItem>, ExtensionError> {
-    let items = if let Some(dir) = &paths.builtin_skills_dir {
-        list_auto_skills_from_disk(&dir.join(BUILTIN_AUTO_SKILLS_SUBDIR)).await
-    } else {
-        list_auto_skills_from_embedded()
-    };
-    let mut items = items;
+    let auto_dir = paths.builtin_skills_dir.join(BUILTIN_AUTO_SKILLS_SUBDIR);
+    let mut items = list_auto_skills_from_disk(&auto_dir).await;
     items.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(items)
 }
@@ -554,6 +557,7 @@ async fn list_auto_skills_from_disk(auto_dir: &Path) -> Vec<BuiltinAutoSkillItem
         .collect()
 }
 
+#[allow(dead_code)]
 fn list_auto_skills_from_embedded() -> Vec<BuiltinAutoSkillItem> {
     let Some(auto_dir) = BUILTIN_SKILLS.get_dir(BUILTIN_AUTO_SKILLS_SUBDIR) else {
         return Vec::new();
@@ -734,20 +738,15 @@ pub async fn delete_skill(paths: &SkillPaths, skill_name: &str) -> Result<(), Ex
 }
 
 /// Check whether a skill name exists in the built-in corpus — either as
-/// a top-level opt-in skill or under `auto-inject/`. Consults the disk
-/// override when present; otherwise the embedded corpus.
+/// a top-level opt-in skill or under `auto-inject/`. Consults the
+/// on-disk tree at `paths.builtin_skills_dir`.
 fn builtin_skill_exists(paths: &SkillPaths, skill_name: &str) -> bool {
-    if let Some(dir) = &paths.builtin_skills_dir {
-        return dir.join(skill_name).is_dir()
-            || dir
-                .join(BUILTIN_AUTO_SKILLS_SUBDIR)
-                .join(skill_name)
-                .is_dir();
-    }
-    BUILTIN_SKILLS.get_dir(skill_name).is_some()
-        || BUILTIN_SKILLS
-            .get_dir(format!("{BUILTIN_AUTO_SKILLS_SUBDIR}/{skill_name}"))
-            .is_some()
+    paths.builtin_skills_dir.join(skill_name).is_dir()
+        || paths
+            .builtin_skills_dir
+            .join(BUILTIN_AUTO_SKILLS_SUBDIR)
+            .join(skill_name)
+            .is_dir()
 }
 
 // ---------------------------------------------------------------------------
@@ -818,46 +817,32 @@ pub async fn materialize_skills_for_agent(
 }
 
 async fn write_auto_inject_skills(paths: &SkillPaths, target: &Path) -> Result<(), ExtensionError> {
-    if let Some(dir) = &paths.builtin_skills_dir {
-        let auto_dir = dir.join(BUILTIN_AUTO_SKILLS_SUBDIR);
-        if !auto_dir.is_dir() {
-            return Ok(());
-        }
-        let mut entries = match tokio::fs::read_dir(&auto_dir).await {
-            Ok(e) => e,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-            Err(e) => return Err(ExtensionError::Io(e)),
-        };
-        while let Ok(Some(entry)) = entries.next_entry().await {
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
-            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-                continue;
-            };
-            let dest = target.join(name);
-            copy_dir_recursive(&path, &dest).await?;
-        }
+    let auto_dir = paths.builtin_skills_dir.join(BUILTIN_AUTO_SKILLS_SUBDIR);
+    if !auto_dir.is_dir() {
         return Ok(());
     }
-
-    let Some(auto_dir) = BUILTIN_SKILLS.get_dir(BUILTIN_AUTO_SKILLS_SUBDIR) else {
-        return Ok(());
+    let mut entries = match tokio::fs::read_dir(&auto_dir).await {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(ExtensionError::Io(e)),
     };
-    for subdir in auto_dir.dirs() {
-        let Some(name) = subdir.path().file_name().and_then(|n| n.to_str()) else {
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
             continue;
         };
         let dest = target.join(name);
-        extract_embedded_dir(subdir, &dest).await?;
+        copy_dir_recursive(&path, &dest).await?;
     }
     Ok(())
 }
 
 /// Write a single opt-in skill into `{target}/{name}/`. Resolves in
-/// order: embedded/disk builtin (top-level + auto-inject) → user
-/// skills dir. Returns `true` if the skill was found and written.
+/// order: builtin top-level → builtin auto-inject → user skills dir.
+/// Returns `true` if the skill was found and written.
 async fn write_opt_in_skill(
     paths: &SkillPaths,
     name: &str,
@@ -865,40 +850,24 @@ async fn write_opt_in_skill(
 ) -> Result<bool, ExtensionError> {
     let dest = target.join(name);
 
-    // Disk corpus override.
-    if let Some(dir) = &paths.builtin_skills_dir {
-        let top = dir.join(name);
-        if top.is_dir() {
-            if dest.exists() {
-                tokio::fs::remove_dir_all(&dest).await?;
-            }
-            copy_dir_recursive(&top, &dest).await?;
-            return Ok(true);
+    let top = paths.builtin_skills_dir.join(name);
+    if top.is_dir() {
+        if dest.exists() {
+            tokio::fs::remove_dir_all(&dest).await?;
         }
-        let auto = dir.join(BUILTIN_AUTO_SKILLS_SUBDIR).join(name);
-        if auto.is_dir() {
-            if dest.exists() {
-                tokio::fs::remove_dir_all(&dest).await?;
-            }
-            copy_dir_recursive(&auto, &dest).await?;
-            return Ok(true);
+        copy_dir_recursive(&top, &dest).await?;
+        return Ok(true);
+    }
+    let auto = paths
+        .builtin_skills_dir
+        .join(BUILTIN_AUTO_SKILLS_SUBDIR)
+        .join(name);
+    if auto.is_dir() {
+        if dest.exists() {
+            tokio::fs::remove_dir_all(&dest).await?;
         }
-    } else {
-        // Embedded corpus.
-        if let Some(top) = BUILTIN_SKILLS.get_dir(name) {
-            if dest.exists() {
-                tokio::fs::remove_dir_all(&dest).await?;
-            }
-            extract_embedded_dir(top, &dest).await?;
-            return Ok(true);
-        }
-        if let Some(auto) = BUILTIN_SKILLS.get_dir(format!("{BUILTIN_AUTO_SKILLS_SUBDIR}/{name}")) {
-            if dest.exists() {
-                tokio::fs::remove_dir_all(&dest).await?;
-            }
-            extract_embedded_dir(auto, &dest).await?;
-            return Ok(true);
-        }
+        copy_dir_recursive(&auto, &dest).await?;
+        return Ok(true);
     }
 
     // User skill.
@@ -1092,20 +1061,14 @@ pub async fn detect_and_count_external_skills(
 
 /// Get the user and built-in skill directory paths.
 ///
-/// When the built-in corpus is embedded (the production case), the
-/// returned built-in path is a placeholder URL (`embedded://builtin-skills`)
-/// — consumers (`SkillsHubSettings`) only use it for display, never to
-/// resolve on-disk files. When a disk override is active, the override
-/// path is returned verbatim.
+/// Both values are real on-disk paths. The built-in path points at the
+/// tree populated at startup by
+/// [`crate::startup_materialize::materialize_if_needed`], or at the
+/// [`BUILTIN_SKILLS_ENV_VAR`] override when set.
 pub fn get_skill_paths(paths: &SkillPaths) -> (String, String) {
-    let builtin = paths
-        .builtin_skills_dir
-        .as_ref()
-        .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "embedded://builtin-skills".to_string());
     (
         paths.user_skills_dir.to_string_lossy().into_owned(),
-        builtin,
+        paths.builtin_skills_dir.to_string_lossy().into_owned(),
     )
 }
 
@@ -1440,7 +1403,7 @@ mod tests {
         let paths = SkillPaths {
             data_dir: tmp.path().to_path_buf(),
             user_skills_dir: tmp.path().join(SKILLS_DIR_NAME),
-            builtin_skills_dir: Some(tmp.path().join(crate::constants::BUILTIN_SKILLS_DIR_NAME)),
+            builtin_skills_dir: tmp.path().join(crate::constants::BUILTIN_SKILLS_DIR_NAME),
             builtin_rules_dir: rules_dir,
             assistant_rules_dir: tmp.path().join(ASSISTANT_RULES_DIR_NAME),
             assistant_skills_dir: tmp.path().join(ASSISTANT_SKILLS_DIR_NAME),
@@ -1942,44 +1905,41 @@ mod tests {
     // -----------------------------------------------------------------------
 
     fn make_test_paths(base: &Path) -> SkillPaths {
-        // Tests historically seed `builtin_skills_dir` with on-disk
-        // content, so we always hand out a disk override here. Tests
-        // exercising the embedded corpus use `make_embedded_paths`.
+        // Hand out an empty on-disk builtin-skills dir. Tests that need
+        // specific fixtures seed it via `create_skill_in_dir`; tests
+        // that want the full real corpus use `make_embedded_paths`.
         SkillPaths {
             data_dir: base.to_path_buf(),
             user_skills_dir: base.join(SKILLS_DIR_NAME),
-            builtin_skills_dir: Some(base.join(crate::constants::BUILTIN_SKILLS_DIR_NAME)),
+            builtin_skills_dir: base.join(crate::constants::BUILTIN_SKILLS_DIR_NAME),
             builtin_rules_dir: base.join(BUILTIN_RULES_DIR_NAME),
             assistant_rules_dir: base.join(ASSISTANT_RULES_DIR_NAME),
             assistant_skills_dir: base.join(ASSISTANT_SKILLS_DIR_NAME),
         }
     }
 
-    fn make_embedded_paths(base: &Path) -> SkillPaths {
-        // For tests that want to exercise the embedded-corpus code
-        // paths without a disk override.
-        SkillPaths {
-            data_dir: base.to_path_buf(),
-            user_skills_dir: base.join(SKILLS_DIR_NAME),
-            builtin_skills_dir: None,
-            builtin_rules_dir: base.join(BUILTIN_RULES_DIR_NAME),
-            assistant_rules_dir: base.join(ASSISTANT_RULES_DIR_NAME),
-            assistant_skills_dir: base.join(ASSISTANT_SKILLS_DIR_NAME),
-        }
+    /// Return `SkillPaths` pre-populated with the real embedded builtin
+    /// skills corpus materialized to disk. Use this for tests that
+    /// previously relied on the embedded-corpus fallback.
+    async fn make_embedded_paths(base: &Path) -> SkillPaths {
+        crate::startup_materialize::materialize_embedded_builtin_skills(
+            base,
+            &BUILTIN_SKILLS,
+            "test-version",
+        )
+        .await
+        .expect("failed to materialize embedded corpus for test");
+        make_test_paths(base)
     }
 
-    /// Return a `SkillPaths` rooted at `base` but whose
-    /// `builtin_skills_dir` is `Some(path)`, so tests can seed
-    /// on-disk fixtures.
+    /// Return a `SkillPaths` rooted at `base` with an on-disk
+    /// `builtin_skills_dir`, so tests can seed fixtures in that dir.
     fn make_disk_builtin_paths(base: &Path) -> SkillPaths {
         make_test_paths(base)
     }
 
     fn disk_builtin_dir(paths: &SkillPaths) -> &Path {
-        paths
-            .builtin_skills_dir
-            .as_deref()
-            .expect("disk override must be set for test")
+        &paths.builtin_skills_dir
     }
 
     fn create_skill_in_dir(base: &Path, name: &str, description: &str) {
@@ -1999,7 +1959,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_lists_auto_inject_from_corpus() {
         let tmp = TempDir::new().unwrap();
-        let paths = make_embedded_paths(tmp.path());
+        let paths = make_embedded_paths(tmp.path()).await;
 
         let autos = list_builtin_auto_skills(&paths).await.unwrap();
         assert!(
@@ -2021,7 +1981,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_reads_builtin_skill_content() {
         let tmp = TempDir::new().unwrap();
-        let paths = make_embedded_paths(tmp.path());
+        let paths = make_embedded_paths(tmp.path()).await;
 
         let content = read_builtin_skill(&paths, "auto-inject/cron/SKILL.md")
             .await
@@ -2037,7 +1997,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_rejects_path_traversal() {
         let tmp = TempDir::new().unwrap();
-        let paths = make_embedded_paths(tmp.path());
+        let paths = make_embedded_paths(tmp.path()).await;
 
         let result = read_builtin_skill(&paths, "../etc/passwd").await;
         assert!(matches!(result, Err(ExtensionError::PathTraversal(_))));
@@ -2049,7 +2009,7 @@ mod tests {
     #[tokio::test]
     async fn embedded_handles_missing_file() {
         let tmp = TempDir::new().unwrap();
-        let paths = make_embedded_paths(tmp.path());
+        let paths = make_embedded_paths(tmp.path()).await;
 
         let content = read_builtin_skill(&paths, "nonexistent/SKILL.md")
             .await
@@ -2081,7 +2041,7 @@ mod tests {
     #[tokio::test]
     async fn list_skills_builtin_has_relative_location_from_embedded() {
         let tmp = TempDir::new().unwrap();
-        let paths = make_embedded_paths(tmp.path());
+        let paths = make_embedded_paths(tmp.path()).await;
 
         let skills = list_available_skills(&paths).await.unwrap();
         let builtins: Vec<_> = skills
@@ -2119,7 +2079,7 @@ mod tests {
     #[tokio::test]
     async fn materialize_creates_fresh_dir_each_call() {
         let tmp = TempDir::new().unwrap();
-        let paths = make_embedded_paths(tmp.path());
+        let paths = make_embedded_paths(tmp.path()).await;
 
         let dir = materialize_skills_for_agent(&paths, "conv-1", &[])
             .await
@@ -2140,7 +2100,7 @@ mod tests {
     #[tokio::test]
     async fn materialize_includes_auto_inject() {
         let tmp = TempDir::new().unwrap();
-        let paths = make_embedded_paths(tmp.path());
+        let paths = make_embedded_paths(tmp.path()).await;
 
         let dir = materialize_skills_for_agent(&paths, "conv-auto", &[])
             .await
@@ -2159,7 +2119,7 @@ mod tests {
     #[tokio::test]
     async fn materialize_includes_opt_in() {
         let tmp = TempDir::new().unwrap();
-        let paths = make_embedded_paths(tmp.path());
+        let paths = make_embedded_paths(tmp.path()).await;
 
         let dir = materialize_skills_for_agent(&paths, "conv-opt", &["mermaid".to_string()])
             .await
@@ -2177,7 +2137,7 @@ mod tests {
     #[tokio::test]
     async fn materialize_handles_nonexistent_skill_name() {
         let tmp = TempDir::new().unwrap();
-        let paths = make_embedded_paths(tmp.path());
+        let paths = make_embedded_paths(tmp.path()).await;
 
         let dir =
             materialize_skills_for_agent(&paths, "conv-missing", &["no-such-skill".to_string()])
@@ -2191,7 +2151,7 @@ mod tests {
     #[tokio::test]
     async fn materialize_rejects_bad_conversation_id() {
         let tmp = TempDir::new().unwrap();
-        let paths = make_embedded_paths(tmp.path());
+        let paths = make_embedded_paths(tmp.path()).await;
 
         let err = materialize_skills_for_agent(&paths, "../evil", &[])
             .await
@@ -2202,7 +2162,7 @@ mod tests {
     #[tokio::test]
     async fn cleanup_is_idempotent() {
         let tmp = TempDir::new().unwrap();
-        let paths = make_embedded_paths(tmp.path());
+        let paths = make_embedded_paths(tmp.path()).await;
 
         materialize_skills_for_agent(&paths, "conv-del", &[])
             .await
@@ -2222,7 +2182,7 @@ mod tests {
     #[tokio::test]
     async fn orphan_cleanup_removes_stale_but_preserves_live() {
         let tmp = TempDir::new().unwrap();
-        let paths = make_embedded_paths(tmp.path());
+        let paths = make_embedded_paths(tmp.path()).await;
 
         // Seed: one live + one orphan conversation dir.
         let root = paths.data_dir.join(AGENT_SKILLS_SUBDIR);
@@ -2242,7 +2202,7 @@ mod tests {
     #[tokio::test]
     async fn orphan_cleanup_missing_root_is_noop() {
         let tmp = TempDir::new().unwrap();
-        let paths = make_embedded_paths(tmp.path());
+        let paths = make_embedded_paths(tmp.path()).await;
 
         let removed = cleanup_orphan_agent_skills(&paths, |_| true).await.unwrap();
         assert_eq!(removed, 0);

--- a/crates/aionui-extension/src/skill_service.rs
+++ b/crates/aionui-extension/src/skill_service.rs
@@ -5,8 +5,8 @@ use tracing::{debug, warn};
 
 use crate::constants::{
     AGENT_SKILLS_SUBDIR, ASSISTANT_RULES_DIR_NAME, ASSISTANT_SKILLS_DIR_NAME,
-    BUILTIN_AUTO_SKILLS_SUBDIR, BUILTIN_RULES_DIR_NAME, BUILTIN_SKILLS_VIEW_SUBDIR,
-    COMMON_SKILL_DIRS, SKILL_MANIFEST_FILE, SKILLS_DIR_NAME,
+    BUILTIN_AUTO_SKILLS_SUBDIR, BUILTIN_RULES_DIR_NAME, COMMON_SKILL_DIRS, SKILL_MANIFEST_FILE,
+    SKILLS_DIR_NAME,
 };
 use crate::error::ExtensionError;
 
@@ -212,9 +212,10 @@ pub enum SkillSource {
 
 /// A discovered skill item for listing.
 ///
-/// For `source=Builtin`, `location` is the absolute path of the lazily
-/// materialized on-disk "view" (under `{data_dir}/builtin-skills-view/`),
-/// and `relative_location` carries the relative path suitable for
+/// For `source=Builtin`, `location` is the absolute path of the on-disk
+/// SKILL.md under `paths.builtin_skills_dir` (populated at startup by
+/// [`crate::startup_materialize::materialize_if_needed`]). The
+/// `relative_location` carries the relative path suitable for
 /// `POST /api/skills/builtin-skill` (e.g. `"auto-inject/cron/SKILL.md"`
 /// or `"mermaid/SKILL.md"`). Other sources leave `relative_location`
 /// `None`.
@@ -233,10 +234,12 @@ pub struct SkillListItem {
 /// User custom skills override built-in skills with the same name.
 ///
 /// For built-in entries, the caller sees an absolute `location` pointing
-/// into `{data_dir}/builtin-skills-view/{name}/SKILL.md` — that view is
-/// lazily materialized from the embedded corpus so downstream consumers
-/// (e.g. the SkillsHubSettings export-symlink flow) can resolve the
-/// path on disk. `relative_location` is populated for built-ins only.
+/// at `paths.builtin_skills_dir/.../SKILL.md` — the tree is populated
+/// at startup by
+/// [`crate::startup_materialize::materialize_if_needed`] so downstream
+/// consumers (e.g. the SkillsHubSettings export-symlink flow) can
+/// resolve the path on disk. `relative_location` is populated for
+/// built-ins only.
 pub async fn list_available_skills(
     paths: &SkillPaths,
 ) -> Result<Vec<SkillListItem>, ExtensionError> {
@@ -270,13 +273,13 @@ pub async fn list_available_skills(
 }
 
 /// Emit a [`SkillListItem`] for every built-in skill (both auto-inject
-/// and opt-in), materializing the on-disk view lazily.
+/// and opt-in). All paths resolve directly against
+/// `paths.builtin_skills_dir`.
 async fn list_builtin_skills(paths: &SkillPaths) -> Vec<SkillListItem> {
-    let dir = paths.builtin_skills_dir.clone();
-    list_builtin_skills_from_disk(paths, &dir).await
+    list_builtin_skills_from_disk(&paths.builtin_skills_dir).await
 }
 
-async fn list_builtin_skills_from_disk(paths: &SkillPaths, dir: &Path) -> Vec<SkillListItem> {
+async fn list_builtin_skills_from_disk(dir: &Path) -> Vec<SkillListItem> {
     let mut items = Vec::new();
 
     // Top-level opt-in skills (siblings of auto-inject/).
@@ -286,15 +289,19 @@ async fn list_builtin_skills_from_disk(paths: &SkillPaths, dir: &Path) -> Vec<Sk
                 continue;
             }
             // Use the on-disk directory name (basename of scanned path)
-            // rather than the frontmatter name, so the view lookup hits
-            // the real filesystem layout when the two disagree.
+            // rather than the frontmatter name, so the path we emit
+            // matches the real filesystem layout when the two disagree.
             let dir_name = Path::new(&s.path)
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or(&s.name)
                 .to_string();
             let rel = format!("{dir_name}/{SKILL_MANIFEST_FILE}");
-            let location = materialize_builtin_view_from_disk(paths, dir, &dir_name).await;
+            let location = dir
+                .join(&dir_name)
+                .join(SKILL_MANIFEST_FILE)
+                .to_string_lossy()
+                .into_owned();
             items.push(SkillListItem {
                 name: s.name,
                 description: s.description,
@@ -316,7 +323,11 @@ async fn list_builtin_skills_from_disk(paths: &SkillPaths, dir: &Path) -> Vec<Sk
                 .unwrap_or(&s.name)
                 .to_string();
             let rel = format!("{BUILTIN_AUTO_SKILLS_SUBDIR}/{dir_name}/{SKILL_MANIFEST_FILE}");
-            let location = materialize_builtin_view_from_disk(paths, dir, &dir_name).await;
+            let location = auto_dir
+                .join(&dir_name)
+                .join(SKILL_MANIFEST_FILE)
+                .to_string_lossy()
+                .into_owned();
             items.push(SkillListItem {
                 name: s.name,
                 description: s.description,
@@ -329,177 +340,6 @@ async fn list_builtin_skills_from_disk(paths: &SkillPaths, dir: &Path) -> Vec<Sk
     }
 
     items
-}
-
-#[allow(dead_code)]
-async fn list_builtin_skills_from_embedded(paths: &SkillPaths) -> Vec<SkillListItem> {
-    let mut items = Vec::new();
-
-    // Top-level opt-in skills.
-    for subdir in BUILTIN_SKILLS.dirs() {
-        let Some(sub_name) = subdir
-            .path()
-            .file_name()
-            .and_then(|n| n.to_str())
-            .map(|s| s.to_string())
-        else {
-            continue;
-        };
-        if sub_name == BUILTIN_AUTO_SKILLS_SUBDIR {
-            continue;
-        }
-        let skill_rel = format!("{sub_name}/{SKILL_MANIFEST_FILE}");
-        let Some((name, description)) = read_embedded_skill_meta(&skill_rel) else {
-            continue;
-        };
-        let final_name = if name.is_empty() {
-            sub_name.clone()
-        } else {
-            name
-        };
-        let location = materialize_builtin_view_from_embedded(paths, subdir).await;
-        items.push(SkillListItem {
-            name: final_name,
-            description,
-            location,
-            relative_location: Some(skill_rel),
-            is_custom: false,
-            source: SkillSource::Builtin,
-        });
-    }
-
-    // auto-inject children.
-    if let Some(auto_dir) = BUILTIN_SKILLS.get_dir(BUILTIN_AUTO_SKILLS_SUBDIR) {
-        for subdir in auto_dir.dirs() {
-            let Some(sub_name) = subdir
-                .path()
-                .file_name()
-                .and_then(|n| n.to_str())
-                .map(|s| s.to_string())
-            else {
-                continue;
-            };
-            let skill_rel =
-                format!("{BUILTIN_AUTO_SKILLS_SUBDIR}/{sub_name}/{SKILL_MANIFEST_FILE}");
-            let Some((name, description)) = read_embedded_skill_meta(&skill_rel) else {
-                continue;
-            };
-            let final_name = if name.is_empty() {
-                sub_name.clone()
-            } else {
-                name
-            };
-            let location = materialize_builtin_view_from_embedded(paths, subdir).await;
-            items.push(SkillListItem {
-                name: final_name,
-                description,
-                location,
-                relative_location: Some(skill_rel),
-                is_custom: false,
-                source: SkillSource::Builtin,
-            });
-        }
-    }
-
-    items
-}
-
-#[allow(dead_code)]
-fn read_embedded_skill_meta(skill_rel: &str) -> Option<(String, String)> {
-    let file = BUILTIN_SKILLS.get_file(skill_rel)?;
-    let content = file.contents_utf8()?;
-    parse_frontmatter_fields(content)
-}
-
-/// Materialize a single built-in skill (keyed by `skill_name`) into
-/// `{data_dir}/builtin-skills-view/{skill_name}/` from the on-disk
-/// source corpus. Returns the absolute path to the SKILL.md file; the
-/// caller treats any materialization failure as a recoverable warning
-/// and surfaces the would-be absolute path anyway so the UI can at
-/// least display something consistent.
-async fn materialize_builtin_view_from_disk(
-    paths: &SkillPaths,
-    source_root: &Path,
-    skill_name: &str,
-) -> String {
-    let target_dir = paths
-        .data_dir
-        .join(BUILTIN_SKILLS_VIEW_SUBDIR)
-        .join(skill_name);
-    let target_file = target_dir.join(SKILL_MANIFEST_FILE);
-    // Source can live either at {root}/{name}/ or {root}/auto-inject/{name}/.
-    let candidates = [
-        source_root.join(skill_name),
-        source_root
-            .join(BUILTIN_AUTO_SKILLS_SUBDIR)
-            .join(skill_name),
-    ];
-    let source_dir = candidates.into_iter().find(|p| p.is_dir());
-    if let Some(src) = source_dir
-        && let Err(e) = copy_dir_recursive(&src, &target_dir).await
-    {
-        warn!(
-            skill = %skill_name,
-            error = %e,
-            "failed to materialize builtin skill view (disk source)"
-        );
-    }
-    target_file.to_string_lossy().into_owned()
-}
-
-/// Materialize a single built-in skill into `{data_dir}/builtin-skills-view/`
-/// from the embedded corpus. Returns the absolute SKILL.md path.
-async fn materialize_builtin_view_from_embedded(
-    paths: &SkillPaths,
-    source_dir: &Dir<'static>,
-) -> String {
-    let skill_name = source_dir
-        .path()
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or_default()
-        .to_string();
-    let target_dir = paths
-        .data_dir
-        .join(BUILTIN_SKILLS_VIEW_SUBDIR)
-        .join(&skill_name);
-    if let Err(e) = extract_embedded_dir(source_dir, &target_dir).await {
-        warn!(
-            skill = %skill_name,
-            error = %e,
-            "failed to materialize builtin skill view (embedded source)"
-        );
-    }
-    target_dir
-        .join(SKILL_MANIFEST_FILE)
-        .to_string_lossy()
-        .into_owned()
-}
-
-/// Recursively extract an embedded [`Dir`] into a filesystem target,
-/// overwriting existing files. Parent directories are created as needed.
-async fn extract_embedded_dir(source: &Dir<'static>, target: &Path) -> Result<(), ExtensionError> {
-    tokio::fs::create_dir_all(target).await?;
-    for file in source.files() {
-        let rel = file
-            .path()
-            .strip_prefix(source.path())
-            .unwrap_or(file.path());
-        let dest = target.join(rel);
-        if let Some(parent) = dest.parent() {
-            tokio::fs::create_dir_all(parent).await?;
-        }
-        tokio::fs::write(&dest, file.contents()).await?;
-    }
-    for subdir in source.dirs() {
-        let rel = subdir
-            .path()
-            .strip_prefix(source.path())
-            .unwrap_or(subdir.path());
-        let sub_target = target.join(rel);
-        Box::pin(extract_embedded_dir(subdir, &sub_target)).await?;
-    }
-    Ok(())
 }
 
 /// A skill discovered during directory scanning.
@@ -555,42 +395,6 @@ async fn list_auto_skills_from_disk(auto_dir: &Path) -> Vec<BuiltinAutoSkillItem
             }
         })
         .collect()
-}
-
-#[allow(dead_code)]
-fn list_auto_skills_from_embedded() -> Vec<BuiltinAutoSkillItem> {
-    let Some(auto_dir) = BUILTIN_SKILLS.get_dir(BUILTIN_AUTO_SKILLS_SUBDIR) else {
-        return Vec::new();
-    };
-    let mut items = Vec::new();
-    for subdir in auto_dir.dirs() {
-        let Some(skill_name) = subdir
-            .path()
-            .file_name()
-            .and_then(|n| n.to_str())
-            .map(|s| s.to_string())
-        else {
-            continue;
-        };
-        let skill_rel = format!("{BUILTIN_AUTO_SKILLS_SUBDIR}/{skill_name}/{SKILL_MANIFEST_FILE}");
-        let Some(file) = BUILTIN_SKILLS.get_file(&skill_rel) else {
-            continue;
-        };
-        let Some(content) = file.contents_utf8() else {
-            warn!(path = %skill_rel, "embedded SKILL.md is not valid UTF-8");
-            continue;
-        };
-        let Some((name, description)) = parse_frontmatter_fields(content) else {
-            continue;
-        };
-        let final_name = if name.is_empty() { skill_name } else { name };
-        items.push(BuiltinAutoSkillItem {
-            name: final_name,
-            description,
-            location: skill_rel,
-        });
-    }
-    items
 }
 
 /// Read skill info from a SKILL.md file without importing.
@@ -2059,7 +1863,8 @@ mod tests {
                 "relative_location must end in /SKILL.md, got {rel}"
             );
             assert!(
-                s.location.contains(BUILTIN_SKILLS_VIEW_SUBDIR),
+                s.location
+                    .contains(crate::constants::BUILTIN_SKILLS_DIR_NAME),
                 "builtin location must live under the view dir, got {}",
                 s.location
             );

--- a/crates/aionui-extension/src/startup_materialize.rs
+++ b/crates/aionui-extension/src/startup_materialize.rs
@@ -1,0 +1,164 @@
+//! Startup-time materialization of the embedded builtin skills corpus to
+//! `{data_dir}/builtin-skills/`. Gated on a `.version` file so repeat
+//! starts with the same binary skip the rewrite.
+//!
+//! Algorithm:
+//!   staging = data_dir/.builtin-skills.tmp (fresh each call)
+//!   write all BUILTIN_SKILLS entries into staging
+//!   write staging/.version ← binary version
+//!   atomic rename(target → .builtin-skills.old, staging → target)
+//!   best-effort remove .builtin-skills.old
+//!
+//! The atomic rename guarantees that concurrent backend processes, or a
+//! crash mid-write, never observe a half-populated target — the old tree
+//! stays in place until staging is fully ready.
+
+use std::path::{Path, PathBuf};
+
+use include_dir::Dir;
+use tracing::{info, warn};
+
+use crate::error::ExtensionError;
+
+const VERSION_FILE: &str = ".version";
+const STAGING_DIR_NAME: &str = ".builtin-skills.tmp";
+const OLD_DIR_NAME: &str = ".builtin-skills.old";
+
+/// Decide whether to materialize based on the `.version` file, then do it.
+/// Returns `true` if a write happened, `false` if the gate said "skip".
+///
+/// When `BUILTIN_SKILLS_ENV_VAR` is set and non-empty, the caller has
+/// already routed `builtin_skills_dir` at the env-var path — this
+/// function still runs but the gate will see whatever version the dev
+/// tree has on disk (or missing, and materialize into that dev path,
+/// which is wrong). Callers MUST check the env var before calling.
+pub async fn materialize_if_needed(
+    data_dir: &Path,
+    corpus: &Dir<'static>,
+    binary_version: &str,
+) -> Result<bool, ExtensionError> {
+    let target = data_dir.join(crate::constants::BUILTIN_SKILLS_DIR_NAME);
+
+    if version_file_matches(&target, binary_version).await {
+        info!(
+            target = %target.display(),
+            version = binary_version,
+            "builtin skills up to date; skipping materialize"
+        );
+        return Ok(false);
+    }
+
+    info!(
+        target = %target.display(),
+        version = binary_version,
+        "materializing embedded builtin skills"
+    );
+    materialize_embedded_builtin_skills(data_dir, corpus, binary_version).await?;
+    Ok(true)
+}
+
+/// Read `.version` and compare against the provided `binary_version`.
+/// Returns `true` only on exact match. Missing file / IO error /
+/// mismatch all return `false`.
+async fn version_file_matches(target: &Path, binary_version: &str) -> bool {
+    let version_path = target.join(VERSION_FILE);
+    match tokio::fs::read_to_string(&version_path).await {
+        Ok(s) => s == binary_version,
+        Err(_) => false,
+    }
+}
+
+/// Unconditional materialize: stage, write each file, atomic rename.
+/// Exposed separately for tests that want to bypass the gate.
+pub async fn materialize_embedded_builtin_skills(
+    data_dir: &Path,
+    corpus: &Dir<'static>,
+    binary_version: &str,
+) -> Result<(), ExtensionError> {
+    let target = data_dir.join(crate::constants::BUILTIN_SKILLS_DIR_NAME);
+    let staging = data_dir.join(STAGING_DIR_NAME);
+    let old = data_dir.join(OLD_DIR_NAME);
+
+    // Ensure data_dir itself exists before we try to write into it.
+    tokio::fs::create_dir_all(data_dir).await?;
+
+    // Clean any leftover staging from a previous crashed run.
+    if staging.exists() {
+        tokio::fs::remove_dir_all(&staging).await.map_err(|e| {
+            ExtensionError::Io(std::io::Error::new(
+                e.kind(),
+                format!("failed to clean staging dir {}: {e}", staging.display()),
+            ))
+        })?;
+    }
+    tokio::fs::create_dir_all(&staging).await?;
+
+    write_dir_recursive(corpus, &staging).await?;
+
+    let version_path = staging.join(VERSION_FILE);
+    tokio::fs::write(&version_path, binary_version).await?;
+
+    // Move existing target out of the way, then move staging in.
+    if target.exists() {
+        if old.exists() {
+            // Tolerate leftover .old from a crashed rename sequence.
+            let _ = tokio::fs::remove_dir_all(&old).await;
+        }
+        tokio::fs::rename(&target, &old).await?;
+    }
+
+    if let Err(e) = tokio::fs::rename(&staging, &target).await {
+        // Try to restore the original target so we don't leave the user
+        // with no builtin skills.
+        if old.exists() {
+            let _ = tokio::fs::rename(&old, &target).await;
+        }
+        return Err(ExtensionError::Io(std::io::Error::new(
+            e.kind(),
+            format!(
+                "atomic rename staging→target failed ({} → {}): {e}",
+                staging.display(),
+                target.display()
+            ),
+        )));
+    }
+
+    // Best-effort cleanup of the superseded tree.
+    if old.exists()
+        && let Err(e) = tokio::fs::remove_dir_all(&old).await
+    {
+        warn!(
+            old = %old.display(),
+            error = %e,
+            "failed to remove superseded builtin skills tree (leaving behind)"
+        );
+    }
+
+    Ok(())
+}
+
+/// Recursively copy every file in an `include_dir::Dir` tree into `dest`.
+/// Directories are created as needed. Files overwrite silently.
+async fn write_dir_recursive(dir: &Dir<'static>, dest: &Path) -> Result<(), ExtensionError> {
+    // The include_dir API is synchronous; we flatten into a Vec then
+    // feed the writes through tokio::fs to stay off the reactor's thread
+    // for big IO bursts.
+    let mut stack: Vec<(&Dir<'static>, PathBuf)> = vec![(dir, dest.to_path_buf())];
+    while let Some((d, prefix)) = stack.pop() {
+        for file in d.files() {
+            let rel = file.path();
+            let out_path = prefix.join(rel.strip_prefix(d.path()).unwrap_or(rel));
+            if let Some(parent) = out_path.parent() {
+                tokio::fs::create_dir_all(parent).await?;
+            }
+            tokio::fs::write(&out_path, file.contents()).await?;
+        }
+        for sub in d.dirs() {
+            let sub_rel = sub.path();
+            let sub_dest = prefix.join(sub_rel.strip_prefix(d.path()).unwrap_or(sub_rel));
+            tokio::fs::create_dir_all(&sub_dest).await?;
+            stack.push((sub, sub_dest));
+        }
+    }
+    Ok(())
+}

--- a/crates/aionui-extension/tests/assistant_dispatch_test.rs
+++ b/crates/aionui-extension/tests/assistant_dispatch_test.rs
@@ -142,7 +142,7 @@ async fn router_with_dispatcher(dispatcher: Arc<FakeDispatcher>) -> axum::Router
     let paths = SkillPaths {
         data_dir: root.clone(),
         user_skills_dir: root.join("skills"),
-        builtin_skills_dir: Some(root.join("builtin-skills")),
+        builtin_skills_dir: root.join("builtin-skills"),
         builtin_rules_dir: root.join("builtin-rules"),
         assistant_rules_dir: root.join("assistant-rules"),
         assistant_skills_dir: root.join("assistant-skills"),

--- a/crates/aionui-extension/tests/fixtures/builtin-skills-fixture/example-skill/SKILL.md
+++ b/crates/aionui-extension/tests/fixtures/builtin-skills-fixture/example-skill/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: example-skill
+description: Fixture skill used by startup_materialize integration tests.
+---
+
+Fixture body.

--- a/crates/aionui-extension/tests/skill_integration_test.rs
+++ b/crates/aionui-extension/tests/skill_integration_test.rs
@@ -26,7 +26,7 @@ fn make_paths(base: &Path) -> SkillPaths {
     SkillPaths {
         data_dir: base.to_path_buf(),
         user_skills_dir: base.join("skills"),
-        builtin_skills_dir: Some(base.join("builtin-skills")),
+        builtin_skills_dir: base.join("builtin-skills"),
         builtin_rules_dir: base.join("builtin-rules"),
         assistant_rules_dir: base.join("assistant-rules"),
         assistant_skills_dir: base.join("assistant-skills"),
@@ -34,10 +34,7 @@ fn make_paths(base: &Path) -> SkillPaths {
 }
 
 fn builtin_dir(paths: &SkillPaths) -> &Path {
-    paths
-        .builtin_skills_dir
-        .as_deref()
-        .expect("disk override must be set for integration tests")
+    &paths.builtin_skills_dir
 }
 
 fn create_skill(base: &Path, name: &str, desc: &str) {
@@ -238,7 +235,8 @@ async fn sm8_scan_for_skills() {
 /// SM-11: Get skill directory paths.
 ///
 /// Production mode: no `AIONUI_BUILTIN_SKILLS_PATH` set — the built-in
-/// corpus is embedded and `builtin_skills_dir` is `None`. The user
+/// skills tree lives at `{data_dir}/builtin-skills/`, populated at
+/// startup by `startup_materialize::materialize_if_needed`. The user
 /// skills directory is derived from `data_dir`, not `resource_dir`.
 #[tokio::test]
 async fn sm11_get_skill_paths() {
@@ -255,9 +253,10 @@ async fn sm11_get_skill_paths() {
     let paths = resolve_skill_paths(resource_dir, data_dir);
 
     assert!(paths.user_skills_dir.to_string_lossy().contains("skills"));
-    assert!(
-        paths.builtin_skills_dir.is_none(),
-        "production mode must yield None (embedded corpus)"
+    assert_eq!(
+        paths.builtin_skills_dir,
+        data_dir.join("builtin-skills"),
+        "production mode must resolve builtin_skills_dir under data_dir"
     );
 }
 

--- a/crates/aionui-extension/tests/startup_materialize.rs
+++ b/crates/aionui-extension/tests/startup_materialize.rs
@@ -45,7 +45,10 @@ async fn materialize_overwrites_existing_target() {
         .await
         .unwrap();
 
-    assert!(!target.join("junk.txt").exists(), "stale file should be gone");
+    assert!(
+        !target.join("junk.txt").exists(),
+        "stale file should be gone"
+    );
     assert!(
         !target.join("stale-dir").exists(),
         "stale dir should be gone"

--- a/crates/aionui-extension/tests/startup_materialize.rs
+++ b/crates/aionui-extension/tests/startup_materialize.rs
@@ -1,0 +1,145 @@
+//! Integration tests for startup materialization of the embedded
+//! builtin-skills corpus. Uses a purpose-built in-test `include_dir`
+//! tree so results are deterministic and independent of the real
+//! embedded corpus's contents.
+
+use std::path::Path;
+
+use aionui_extension::startup_materialize::{
+    materialize_embedded_builtin_skills, materialize_if_needed,
+};
+use include_dir::{Dir, include_dir};
+use tempfile::TempDir;
+
+static FIXTURE_CORPUS: Dir<'static> =
+    include_dir!("$CARGO_MANIFEST_DIR/tests/fixtures/builtin-skills-fixture");
+
+fn read_version(target: &Path) -> Option<String> {
+    std::fs::read_to_string(target.join(".version")).ok()
+}
+
+#[tokio::test]
+async fn materialize_writes_tree_and_version_file() {
+    let tmp = TempDir::new().unwrap();
+    materialize_embedded_builtin_skills(tmp.path(), &FIXTURE_CORPUS, "1.2.3")
+        .await
+        .unwrap();
+
+    let target = tmp.path().join("builtin-skills");
+    assert!(target.is_dir(), "target dir should exist");
+    assert_eq!(read_version(&target).as_deref(), Some("1.2.3"));
+    assert!(
+        target.join("example-skill").join("SKILL.md").is_file(),
+        "expected fixture skill to be materialized"
+    );
+}
+
+#[tokio::test]
+async fn materialize_overwrites_existing_target() {
+    let tmp = TempDir::new().unwrap();
+    let target = tmp.path().join("builtin-skills");
+    std::fs::create_dir_all(target.join("stale-dir")).unwrap();
+    std::fs::write(target.join("junk.txt"), b"old").unwrap();
+
+    materialize_embedded_builtin_skills(tmp.path(), &FIXTURE_CORPUS, "1.2.3")
+        .await
+        .unwrap();
+
+    assert!(!target.join("junk.txt").exists(), "stale file should be gone");
+    assert!(
+        !target.join("stale-dir").exists(),
+        "stale dir should be gone"
+    );
+    assert_eq!(read_version(&target).as_deref(), Some("1.2.3"));
+}
+
+#[tokio::test]
+async fn materialize_cleans_staging_from_prior_crash() {
+    let tmp = TempDir::new().unwrap();
+    let staging = tmp.path().join(".builtin-skills.tmp");
+    std::fs::create_dir_all(&staging).unwrap();
+    std::fs::write(staging.join("leftover.txt"), b"x").unwrap();
+
+    materialize_embedded_builtin_skills(tmp.path(), &FIXTURE_CORPUS, "1.2.3")
+        .await
+        .unwrap();
+
+    assert!(!staging.exists(), "staging should be cleaned after success");
+}
+
+#[tokio::test]
+async fn gate_skips_when_version_matches() {
+    let tmp = TempDir::new().unwrap();
+    // Pre-populate target with matching version.
+    let target = tmp.path().join("builtin-skills");
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(target.join(".version"), "1.2.3").unwrap();
+    std::fs::write(target.join("sentinel"), "do-not-delete").unwrap();
+
+    let wrote = materialize_if_needed(tmp.path(), &FIXTURE_CORPUS, "1.2.3")
+        .await
+        .unwrap();
+    assert!(!wrote, "version match should skip materialize");
+    assert!(
+        target.join("sentinel").is_file(),
+        "sentinel must be preserved when gate says skip"
+    );
+}
+
+#[tokio::test]
+async fn gate_triggers_when_version_mismatches() {
+    let tmp = TempDir::new().unwrap();
+    let target = tmp.path().join("builtin-skills");
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(target.join(".version"), "0.0.0").unwrap();
+    std::fs::write(target.join("sentinel"), "will-be-wiped").unwrap();
+
+    let wrote = materialize_if_needed(tmp.path(), &FIXTURE_CORPUS, "1.2.3")
+        .await
+        .unwrap();
+    assert!(wrote, "version mismatch should materialize");
+    assert!(
+        !target.join("sentinel").exists(),
+        "sentinel must be wiped by fresh materialize"
+    );
+    assert_eq!(read_version(&target).as_deref(), Some("1.2.3"));
+}
+
+#[tokio::test]
+async fn gate_triggers_when_version_file_missing() {
+    let tmp = TempDir::new().unwrap();
+
+    let wrote = materialize_if_needed(tmp.path(), &FIXTURE_CORPUS, "1.2.3")
+        .await
+        .unwrap();
+    assert!(wrote, "no existing version should materialize");
+    assert_eq!(
+        read_version(&tmp.path().join("builtin-skills")).as_deref(),
+        Some("1.2.3")
+    );
+}
+
+#[tokio::test]
+async fn concurrent_materialize_produces_consistent_tree() {
+    // Two concurrent invocations share the same staging/target paths, so
+    // at most one reliably wins the atomic rename; the other may legally
+    // fail mid-staging. What matters is that after both complete, the
+    // on-disk tree is in a consistent, fully-populated state driven by
+    // whichever call succeeded.
+    let tmp = TempDir::new().unwrap();
+    let dir1 = tmp.path().to_path_buf();
+    let dir2 = tmp.path().to_path_buf();
+
+    let (a, b) = tokio::join!(
+        materialize_embedded_builtin_skills(&dir1, &FIXTURE_CORPUS, "1.2.3"),
+        materialize_embedded_builtin_skills(&dir2, &FIXTURE_CORPUS, "1.2.3"),
+    );
+    assert!(
+        a.is_ok() || b.is_ok(),
+        "at least one concurrent materialize must succeed; a={a:?}, b={b:?}"
+    );
+
+    let target = tmp.path().join("builtin-skills");
+    assert_eq!(read_version(&target).as_deref(), Some("1.2.3"));
+    assert!(target.join("example-skill").join("SKILL.md").is_file());
+}


### PR DESCRIPTION
Materialize the embedded `BUILTIN_SKILLS` corpus to `{data_dir}/builtin-skills/` at startup, gated by a `.version` file, and collapse all runtime skill reads onto that single on-disk path. Deletes the lazy `builtin-skills-view/` projection system.

## Design docs

- Plan: `AionUi/docs/backend-migration/plans/2026-04-27-builtin-skills-startup-materialize-plan.md`
- Spec: `AionUi/docs/backend-migration/specs/2026-04-27-builtin-skills-startup-materialize-design.md`

## Commits (in order)

1. **feat(extension): add startup_materialize module (no wiring yet)** — New `startup_materialize` module with `materialize_if_needed` (gate) + `materialize_embedded_builtin_skills` (unconditional stage-and-rename). `.builtin-skills.tmp` staging + atomic rename + `.old` rollback make mid-crash safe.
2. **test(extension): integration tests for startup_materialize** — 7 integration tests using a purpose-built fixture corpus (`tests/fixtures/builtin-skills-fixture/example-skill/`). Covers first write, stale-target overwrite, crash-recovery, version-gate skip/rewrite decisions, and concurrent-invocation consistency.
3. **refactor(extension): make SkillPaths.builtin_skills_dir mandatory** — Flip `Option<PathBuf>` → `PathBuf`. `resolve_skill_paths` resolves deterministically: env var wins, else `{data_dir}/builtin-skills/`. All read paths simplified to direct disk lookup. Adds `builtin_skills_corpus()` accessor. Embedded-corpus fallback helpers left in place under `#[allow(dead_code)]` (deleted in the next commit).
4. **feat(app): wire materialize_if_needed into startup sequence** — Call `materialize_if_needed` between `init_database` and `AppServices` construction. Skipped when `AIONUI_BUILTIN_SKILLS_PATH` is set (dev override mode). Adds two smoke tests covering the gate's skip/rewrite behavior across restarts.
5. **refactor(extension): delete embedded-corpus fallbacks and builtin-skills-view** — Remove `list_builtin_skills_from_embedded`, `read_embedded_skill_meta`, `list_auto_skills_from_embedded`, `materialize_builtin_view_from_disk`, `materialize_builtin_view_from_embedded`, `extract_embedded_dir`. Drop `BUILTIN_SKILLS_VIEW_SUBDIR` constant. `list_builtin_skills_from_disk` now emits `location` as the direct SKILL.md path.
6. **chore(extension): rustfmt + fix missed Option<PathBuf> unwraps** — Clean up four leftover `builtin_skills_dir.as_ref().expect(...)` sites in `extension_e2e.rs` and apply `cargo fmt --all`.

## Verification

- `cargo build --workspace` — passes.
- `cargo test -p aionui-extension --lib` — 337 passed, 0 failed.
- `cargo test -p aionui-app --test startup_smoke --test skills_builtin_e2e --test assistants_e2e` — all passing.
- `cargo fmt --all -- --check` — clean.

Pre-existing, unrelated failures (present on `main`; not caused by this PR): 5 tests in `aionui-extension/tests/assistant_dispatch_test.rs` (camelCase/snake_case wire mismatch); `aionui-ai-agent/tests/acp_agent_integration.rs` (non-exhaustive match on `AgentStreamEvent::AcpPermission`); `aionui-app/tests/extension_e2e.rs::cp1_get_external_paths_empty` (environment-dependent — sees the dev machine's `~/.claude/skills`).

## Migration note for ops

Users upgrading from the lazy `builtin-skills-view/` era will keep a harmless `{data_dir}/builtin-skills-view/` directory on disk — nothing reads it after this PR. It can be deleted manually if preferred. While materializing, `{data_dir}/.builtin-skills.tmp` (and briefly `{data_dir}/.builtin-skills.old`) will appear; disk-usage dashboards should tolerate them.

## Test plan

- [x] `cargo test -p aionui-extension --test startup_materialize` — 7/7 pass.
- [x] `cargo test -p aionui-app --test startup_smoke` — 2/2 pass.
- [x] `cargo test -p aionui-app --test skills_builtin_e2e` — 14/14 pass.
- [x] `cargo fmt --all -- --check` clean.
- [ ] Manual smoke: wipe `{data_dir}/builtin-skills/`, start backend, confirm `.version` matches `CARGO_PKG_VERSION`, restart, confirm log says "builtin skills up to date; skipping materialize".