### PR TITLE
feat(conversation): freeze skills snapshot in extra.skills at create time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,7 @@ dependencies = [
  "aionui-auth",
  "aionui-common",
  "aionui-db",
+ "aionui-extension",
  "aionui-realtime",
  "async-trait",
  "axum",

--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -266,8 +266,9 @@ impl AcpAgentManager {
             &self.skill_manager,
             crate::first_message_injector::InjectionConfig {
                 preset_context: self.config.preset_context.as_deref(),
-                enabled_skills: &self.config.enabled_skills,
-                exclude_builtin_skills: &self.config.exclude_builtin_skills,
+                enabled_skills: &[],
+                exclude_builtin_skills: &[],
+                skills: &self.config.skills,
                 native_skill_support: self.backend.native_skills_dirs().is_some(),
                 custom_workspace: !self.workspace.contains("-temp-"),
             },

--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -266,8 +266,6 @@ impl AcpAgentManager {
             &self.skill_manager,
             crate::first_message_injector::InjectionConfig {
                 preset_context: self.config.preset_context.as_deref(),
-                enabled_skills: &[],
-                exclude_builtin_skills: &[],
                 skills: &self.config.skills,
                 native_skill_support: self.backend.native_skills_dirs().is_some(),
                 custom_workspace: !self.workspace.contains("-temp-"),

--- a/crates/aionui-ai-agent/src/first_message_injector.rs
+++ b/crates/aionui-ai-agent/src/first_message_injector.rs
@@ -13,12 +13,7 @@ use crate::skill_manager::{AcpSkillManager, prepare_first_message_with_skills_in
 pub struct InjectionConfig<'a> {
     /// Preset context (assistant-level system prompt injection).
     pub preset_context: Option<&'a str>,
-    /// Skills the user explicitly enabled for this session.
-    pub enabled_skills: &'a [String],
-    /// Builtin auto-inject skills the user disabled.
-    pub exclude_builtin_skills: &'a [String],
-    /// Resolved skill snapshot (superset of enabled/exclude filtering).
-    /// Task 7 replaces the two fields above with this one.
+    /// Resolved skill names (snapshot from `conversation.extra.skills`).
     pub skills: &'a [String],
     /// True iff the agent's native CLI reads skills from the workspace
     /// without needing prompt injection. Derived by callers from
@@ -34,8 +29,8 @@ pub struct InjectionConfig<'a> {
 /// - If `native_skill_support && !custom_workspace`: **light mode** — only
 ///   `preset_context` prepended as an `[Assistant Rules]` block (if present).
 ///   The native CLI handles skill discovery via workspace symlinks.
-/// - Else: **heavy mode** — `preset_context` + skills index injected via
-///   `prepare_first_message_with_skills_index`.
+/// - Else: **heavy mode** — `preset_context` + resolved skills index
+///   injected via `prepare_first_message_with_skills_index`.
 pub async fn inject_first_message_prefix(
     content: &str,
     manager: &Arc<AcpSkillManager>,
@@ -44,35 +39,20 @@ pub async fn inject_first_message_prefix(
     let use_native = config.native_skill_support && !config.custom_workspace;
 
     if use_native {
-        // Light mode: only preset_context, no skill discovery
-        match config.preset_context {
+        return match config.preset_context {
             Some(ctx) if !ctx.is_empty() => {
                 format!("[Assistant Rules]\n{ctx}\n[/Assistant Rules]\n\n{content}")
             }
             _ => content.to_string(),
-        }
-    } else {
-        // Heavy mode: discover skills then inject index
-        let enabled = if config.enabled_skills.is_empty() {
-            None
-        } else {
-            Some(config.enabled_skills)
         };
-        let exclude = if config.exclude_builtin_skills.is_empty() {
-            None
-        } else {
-            Some(config.exclude_builtin_skills)
-        };
-
-        let skills = manager.discover_skills(enabled, exclude).await;
-
-        let has_context = config.preset_context.is_some_and(|s| !s.is_empty());
-        if skills.is_empty() && !has_context {
-            return content.to_string();
-        }
-
-        prepare_first_message_with_skills_index(content, &skills, config.preset_context)
     }
+
+    let skills = manager.discover_by_names(config.skills).await;
+    let has_context = config.preset_context.is_some_and(|s| !s.is_empty());
+    if skills.is_empty() && !has_context {
+        return content.to_string();
+    }
+    prepare_first_message_with_skills_index(content, &skills, config.preset_context)
 }
 
 #[cfg(test)]
@@ -120,8 +100,6 @@ mod tests {
             &mgr,
             InjectionConfig {
                 preset_context: Some("Be concise."),
-                enabled_skills: &[],
-                exclude_builtin_skills: &[],
                 skills: &[],
                 native_skill_support: true,
                 custom_workspace: false,
@@ -144,8 +122,6 @@ mod tests {
             &mgr,
             InjectionConfig {
                 preset_context: None,
-                enabled_skills: &[],
-                exclude_builtin_skills: &[],
                 skills: &[],
                 native_skill_support: true,
                 custom_workspace: false,
@@ -166,8 +142,6 @@ mod tests {
             &mgr,
             InjectionConfig {
                 preset_context: None,
-                enabled_skills: &[],
-                exclude_builtin_skills: &[],
                 skills: &[],
                 native_skill_support: false,
                 custom_workspace: false,
@@ -188,8 +162,6 @@ mod tests {
             &mgr,
             InjectionConfig {
                 preset_context: Some("Rule 1."),
-                enabled_skills: &[],
-                exclude_builtin_skills: &[],
                 skills: &[],
                 native_skill_support: false,
                 custom_workspace: false,
@@ -203,6 +175,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn heavy_mode_with_resolved_skills_injects_index() {
+        // Set up a builtin skills dir with two skills; pass only one in `skills`.
+        let tmp = TempDir::new().unwrap();
+        let auto = tmp.path().join("auto-inject");
+        std::fs::create_dir_all(auto.join("cron")).unwrap();
+        std::fs::write(
+            auto.join("cron").join("SKILL.md"),
+            "---\nname: cron\ndescription: Schedule stuff\n---\nBody.",
+        )
+        .unwrap();
+        std::fs::create_dir_all(auto.join("pdf")).unwrap();
+        std::fs::write(
+            auto.join("pdf").join("SKILL.md"),
+            "---\nname: pdf\ndescription: Render PDFs\n---\nBody.",
+        )
+        .unwrap();
+        let _guard = EmptyBuiltinGuard::new(tmp.path());
+        let mgr = test_mgr(tmp.path());
+
+        let out = inject_first_message_prefix(
+            "Hello",
+            &mgr,
+            InjectionConfig {
+                preset_context: None,
+                skills: &["cron".to_owned()],
+                native_skill_support: false,
+                custom_workspace: false,
+            },
+        )
+        .await;
+        assert!(out.contains("cron"));
+        assert!(!out.contains("pdf"));
+        assert!(out.ends_with("Hello"));
+    }
+
+    #[tokio::test]
     async fn custom_workspace_forces_heavy_even_when_native_supported() {
         let tmp = TempDir::new().unwrap();
         let _guard = EmptyBuiltinGuard::new(tmp.path());
@@ -213,8 +221,6 @@ mod tests {
             &mgr,
             InjectionConfig {
                 preset_context: Some("Custom rule"),
-                enabled_skills: &[],
-                exclude_builtin_skills: &[],
                 skills: &[],
                 native_skill_support: true,
                 custom_workspace: true, // <-- overrides native

--- a/crates/aionui-ai-agent/src/first_message_injector.rs
+++ b/crates/aionui-ai-agent/src/first_message_injector.rs
@@ -17,6 +17,9 @@ pub struct InjectionConfig<'a> {
     pub enabled_skills: &'a [String],
     /// Builtin auto-inject skills the user disabled.
     pub exclude_builtin_skills: &'a [String],
+    /// Resolved skill snapshot (superset of enabled/exclude filtering).
+    /// Task 7 replaces the two fields above with this one.
+    pub skills: &'a [String],
     /// True iff the agent's native CLI reads skills from the workspace
     /// without needing prompt injection. Derived by callers from
     /// `AcpBackend::native_skills_dirs().is_some()` for ACP, or hardcoded
@@ -119,6 +122,7 @@ mod tests {
                 preset_context: Some("Be concise."),
                 enabled_skills: &[],
                 exclude_builtin_skills: &[],
+                skills: &[],
                 native_skill_support: true,
                 custom_workspace: false,
             },
@@ -142,6 +146,7 @@ mod tests {
                 preset_context: None,
                 enabled_skills: &[],
                 exclude_builtin_skills: &[],
+                skills: &[],
                 native_skill_support: true,
                 custom_workspace: false,
             },
@@ -163,6 +168,7 @@ mod tests {
                 preset_context: None,
                 enabled_skills: &[],
                 exclude_builtin_skills: &[],
+                skills: &[],
                 native_skill_support: false,
                 custom_workspace: false,
             },
@@ -184,6 +190,7 @@ mod tests {
                 preset_context: Some("Rule 1."),
                 enabled_skills: &[],
                 exclude_builtin_skills: &[],
+                skills: &[],
                 native_skill_support: false,
                 custom_workspace: false,
             },
@@ -208,6 +215,7 @@ mod tests {
                 preset_context: Some("Custom rule"),
                 enabled_skills: &[],
                 exclude_builtin_skills: &[],
+                skills: &[],
                 native_skill_support: true,
                 custom_workspace: true, // <-- overrides native
             },

--- a/crates/aionui-ai-agent/src/skill_manager.rs
+++ b/crates/aionui-ai-agent/src/skill_manager.rs
@@ -136,6 +136,56 @@ impl AcpSkillManager {
         index
     }
 
+    /// Populate the cache with only the named skills (no filtering by
+    /// auto-inject/opt-in). Returns the resulting index. Used by the
+    /// snapshot-driven first-message injector.
+    pub async fn discover_by_names(&self, names: &[String]) -> Vec<SkillIndex> {
+        // Always reset state so repeated calls produce a deterministic cache.
+        if names.is_empty() {
+            let mut cache = self.cache.write().await;
+            cache.clear();
+            let mut discovered = self.discovered.write().await;
+            *discovered = true;
+            return Vec::new();
+        }
+        let items = match aionui_extension::list_available_skills(&self.paths).await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(error = %e, "discover_by_names: list_available_skills failed");
+                Vec::new()
+            }
+        };
+
+        let wanted: std::collections::HashSet<&String> = names.iter().collect();
+        let mut cache = self.cache.write().await;
+        cache.clear();
+        for item in items {
+            if !wanted.contains(&item.name) {
+                continue;
+            }
+            cache.insert(
+                item.name.clone(),
+                SkillDefinition {
+                    name: item.name.clone(),
+                    description: item.description.clone(),
+                    location: std::path::PathBuf::from(&item.location),
+                    source: item.source,
+                    relative_location: item.relative_location.clone(),
+                    body: None,
+                },
+            );
+        }
+        let mut discovered = self.discovered.write().await;
+        *discovered = true;
+        cache
+            .values()
+            .map(|d| SkillIndex {
+                name: d.name.clone(),
+                description: d.description.clone(),
+            })
+            .collect()
+    }
+
     /// Return the current skill index without re-scanning.
     pub async fn get_skills_index(&self) -> Vec<SkillIndex> {
         let cache = self.cache.read().await;

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -57,12 +57,11 @@ pub struct AcpBuildExtra {
     /// Preset context to inject.
     #[serde(default)]
     pub preset_context: Option<String>,
-    /// Skills to enable for this session.
+    /// Resolved skill snapshot for the session. Populated from
+    /// `conversation.extra.skills` by the factory. No runtime filtering —
+    /// what the caller sends is what the agent sees.
     #[serde(default)]
-    pub enabled_skills: Vec<String>,
-    /// Builtin auto-inject skills to exclude from this session.
-    #[serde(default)]
-    pub exclude_builtin_skills: Vec<String>,
+    pub skills: Vec<String>,
     /// Preset assistant ID.
     #[serde(default)]
     pub preset_assistant_id: Option<String>,
@@ -96,9 +95,10 @@ pub struct OpenClawBuildExtra {
     pub agent_name: Option<String>,
     /// OpenClaw gateway configuration.
     pub gateway: OpenClawGatewayConfig,
-    /// Skills to enable.
+    /// Resolved skill snapshot for the session. Populated from
+    /// `conversation.extra.skills` by the factory.
     #[serde(default)]
-    pub enabled_skills: Vec<String>,
+    pub skills: Vec<String>,
     /// Preset assistant ID.
     #[serde(default)]
     pub preset_assistant_id: Option<String>,
@@ -207,18 +207,18 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn acp_build_extra_backcompat_no_new_fields() {
-        // Legacy payloads without exclude_builtin_skills should still deserialize
+    fn acp_build_extra_accepts_payload_without_skills() {
+        // Legacy payloads without skills should still deserialize.
         let legacy = r#"{"backend":"claude"}"#;
         let parsed: AcpBuildExtra = serde_json::from_str(legacy).unwrap();
-        assert!(parsed.exclude_builtin_skills.is_empty());
+        assert!(parsed.skills.is_empty());
     }
 
     #[test]
-    fn acp_build_extra_accepts_exclude_builtin_skills() {
-        let with_field = r#"{"backend":"claude","exclude_builtin_skills":["cron"]}"#;
+    fn acp_build_extra_accepts_skills() {
+        let with_field = r#"{"backend":"claude","skills":["cron","pdf"]}"#;
         let parsed: AcpBuildExtra = serde_json::from_str(with_field).unwrap();
-        assert_eq!(parsed.exclude_builtin_skills, vec!["cron"]);
+        assert_eq!(parsed.skills, vec!["cron".to_owned(), "pdf".to_owned()]);
     }
 
     #[test]

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -61,8 +61,7 @@ async fn make_mock_agent(
         agent_name: None,
         custom_agent_id: None,
         preset_context: None,
-        enabled_skills: vec![],
-        exclude_builtin_skills: vec![],
+        skills: vec![],
         preset_assistant_id: None,
         session_mode: None,
         cron_job_id: None,
@@ -158,7 +157,18 @@ fn event_type_name(event: &AgentStreamEvent) -> &'static str {
         AgentStreamEvent::System(_) => "System",
         AgentStreamEvent::RequestTrace(_) => "RequestTrace",
         AgentStreamEvent::SlashCommandsUpdated(_) => "SlashCommandsUpdated",
+        AgentStreamEvent::AcpPermission(_) => "AcpPermission",
     }
+}
+
+#[test]
+fn acp_build_extra_populates_skills_from_extra_json() {
+    let json = serde_json::json!({
+        "backend": "claude",
+        "skills": ["cron", "pdf"],
+    });
+    let extra: aionui_ai_agent::AcpBuildExtra = serde_json::from_value(json).unwrap();
+    assert_eq!(extra.skills, vec!["cron".to_owned(), "pdf".to_owned()]);
 }
 
 // -- Tests --

--- a/crates/aionui-api-types/src/skill.rs
+++ b/crates/aionui-api-types/src/skill.rs
@@ -172,11 +172,16 @@ pub struct ReadBuiltinResourceRequest {
 }
 
 /// Request body for `POST /api/skills/materialize-for-agent`.
+///
+/// Callers pass the resolved skill snapshot (see
+/// `conversation.extra.skills`). For backwards compatibility with pre-
+/// snapshot clients that still emit `enabled_skills`, the alias below
+/// accepts either spelling; remove the alias after the frontend PR lands.
 #[derive(Debug, Clone, Deserialize)]
 pub struct MaterializeSkillsRequest {
     pub conversation_id: String,
-    #[serde(default)]
-    pub enabled_skills: Vec<String>,
+    #[serde(default, alias = "enabled_skills")]
+    pub skills: Vec<String>,
 }
 
 /// Response for `POST /api/skills/materialize-for-agent`.
@@ -271,18 +276,28 @@ mod tests {
     fn test_materialize_request_roundtrip() {
         let raw = json!({
             "conversation_id": "conv-abc",
-            "enabled_skills": ["mermaid", "pdf"],
+            "skills": ["mermaid", "pdf"],
         });
         let req: MaterializeSkillsRequest = serde_json::from_value(raw).unwrap();
         assert_eq!(req.conversation_id, "conv-abc");
-        assert_eq!(req.enabled_skills, vec!["mermaid", "pdf"]);
+        assert_eq!(req.skills, vec!["mermaid", "pdf"]);
+    }
+
+    #[test]
+    fn test_materialize_request_accepts_legacy_enabled_skills_alias() {
+        let raw = json!({
+            "conversation_id": "conv-abc",
+            "enabled_skills": ["pdf"],
+        });
+        let req: MaterializeSkillsRequest = serde_json::from_value(raw).unwrap();
+        assert_eq!(req.skills, vec!["pdf"]);
     }
 
     #[test]
     fn test_materialize_request_default_enabled() {
         let raw = json!({"conversation_id": "conv-abc"});
         let req: MaterializeSkillsRequest = serde_json::from_value(raw).unwrap();
-        assert!(req.enabled_skills.is_empty());
+        assert!(req.skills.is_empty());
     }
 
     #[test]

--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -97,6 +97,9 @@ pub struct AppServices {
     pub data_dir: String,
     /// When `true`, skip JWT authentication and use a fixed default user.
     pub local: bool,
+    /// Resolved skill paths. Shared with the `ConversationService` for
+    /// snapshot resolution at create time.
+    pub skill_paths: Arc<aionui_extension::SkillPaths>,
 }
 
 impl AppServices {
@@ -190,6 +193,7 @@ impl AppServices {
             jwt_secret_raw: secret,
             data_dir,
             local,
+            skill_paths,
         })
     }
 }

--- a/crates/aionui-app/src/state_builders.rs
+++ b/crates/aionui-app/src/state_builders.rs
@@ -186,11 +186,17 @@ pub fn build_system_state(services: &AppServices) -> SystemRouterState {
 pub fn build_conversation_state(services: &AppServices) -> ConversationRouterState {
     let pool = services.database.pool().clone();
     let repo = Arc::new(SqliteConversationRepository::new(pool));
+    let skill_resolver = Arc::new(
+        aionui_conversation::skill_resolver::ExtensionSkillResolver::new(
+            services.skill_paths.clone(),
+        ),
+    );
     ConversationRouterState {
         conversation_service: ConversationService::new_with_workspace_root(
             repo,
             services.event_bus.clone(),
             std::path::PathBuf::from(&services.data_dir),
+            skill_resolver,
         ),
         worker_task_manager: services.worker_task_manager.clone(),
     }
@@ -322,10 +328,16 @@ pub fn build_team_state(services: &AppServices) -> TeamRouterState {
         Arc::new(aionui_db::SqliteTeamRepository::new(pool.clone()));
     let conv_repo: Arc<dyn aionui_db::IConversationRepository> =
         Arc::new(SqliteConversationRepository::new(pool));
+    let skill_resolver = Arc::new(
+        aionui_conversation::skill_resolver::ExtensionSkillResolver::new(
+            services.skill_paths.clone(),
+        ),
+    );
     let conv_service = ConversationService::new_with_workspace_root(
         conv_repo,
         services.event_bus.clone(),
         std::path::PathBuf::from(&services.data_dir),
+        skill_resolver,
     );
     let service = Arc::new(TeamSessionService::new(
         team_repo,
@@ -343,10 +355,16 @@ pub fn build_cron_state(services: &AppServices) -> CronRouterState {
 
     let conv_repo: Arc<dyn aionui_db::IConversationRepository> =
         Arc::new(SqliteConversationRepository::new(pool));
+    let skill_resolver = Arc::new(
+        aionui_conversation::skill_resolver::ExtensionSkillResolver::new(
+            services.skill_paths.clone(),
+        ),
+    );
     let conv_service = ConversationService::new_with_workspace_root(
         conv_repo.clone(),
         services.event_bus.clone(),
         std::path::PathBuf::from(&services.data_dir),
+        skill_resolver,
     );
 
     let busy_guard = Arc::new(aionui_cron::busy_guard::CronBusyGuard::new());

--- a/crates/aionui-app/tests/skills_builtin_e2e.rs
+++ b/crates/aionui-app/tests/skills_builtin_e2e.rs
@@ -290,7 +290,10 @@ async fn list_skills_builtin_entries_carry_relative_location() {
 // ===========================================================================
 
 #[tokio::test]
-async fn materialize_for_agent_writes_auto_inject_flat() {
+async fn materialize_for_agent_writes_named_skill_flat() {
+    // Post-snapshot contract: `materialize-for-agent` does NOT implicitly
+    // include auto-inject. Callers pass the fully resolved snapshot;
+    // naming an auto-inject skill produces a flat `{name}/SKILL.md` entry.
     let fx = fixture_embedded().await;
 
     let resp = fx
@@ -301,7 +304,7 @@ async fn materialize_for_agent_writes_auto_inject_flat() {
             "/api/skills/materialize-for-agent",
             json!({
                 "conversation_id": "conv-happy",
-                "enabled_skills": [],
+                "skills": ["cron"],
             }),
             &fx.token,
             &fx.csrf,
@@ -316,7 +319,7 @@ async fn materialize_for_agent_writes_auto_inject_flat() {
     assert!(dir.is_dir(), "agent-skills dir must exist: {dir_path}");
     assert!(
         dir.join("cron").join("SKILL.md").exists(),
-        "cron auto-inject not materialized at {dir_path}/cron/SKILL.md",
+        "cron skill not materialized at {dir_path}/cron/SKILL.md",
     );
     // Flat layout — no `auto-inject` wrapper remains.
     assert!(

--- a/crates/aionui-conversation/Cargo.toml
+++ b/crates/aionui-conversation/Cargo.toml
@@ -10,6 +10,7 @@ aionui-api-types.workspace = true
 aionui-realtime.workspace = true
 aionui-auth.workspace = true
 aionui-ai-agent.workspace = true
+aionui-extension.workspace = true
 axum.workspace = true
 tokio.workspace = true
 serde.workspace = true

--- a/crates/aionui-conversation/src/convert.rs
+++ b/crates/aionui-conversation/src/convert.rs
@@ -11,6 +11,18 @@ use aionui_db::models::MessageRow;
 ///
 /// Parses string enum fields and JSON text fields back into typed values.
 pub fn row_to_response(row: ConversationRow) -> Result<ConversationResponse, AppError> {
+    let extra: serde_json::Value = serde_json::from_str(&row.extra)
+        .map_err(|e| AppError::Internal(format!("Invalid extra JSON: {e}")))?;
+    row_to_response_with_extra(row, extra)
+}
+
+/// Same as [`row_to_response`] but takes a pre-parsed `extra` value. Used
+/// by callers that need to mutate `extra` (e.g. lazy `skills` backfill)
+/// before building the response DTO.
+pub fn row_to_response_with_extra(
+    row: ConversationRow,
+    extra: serde_json::Value,
+) -> Result<ConversationResponse, AppError> {
     let agent_type: AgentType = string_to_enum(&row.r#type)?;
     let status: ConversationStatus = match row.status.as_deref() {
         None | Some("") => ConversationStatus::Finished,
@@ -25,9 +37,6 @@ pub fn row_to_response(row: ConversationRow) -> Result<ConversationResponse, App
         .as_deref()
         .map(parse_provider_with_model)
         .transpose()?;
-
-    let extra: serde_json::Value = serde_json::from_str(&row.extra)
-        .map_err(|e| AppError::Internal(format!("Invalid extra JSON: {e}")))?;
 
     Ok(ConversationResponse {
         id: row.id,

--- a/crates/aionui-conversation/src/lib.rs
+++ b/crates/aionui-conversation/src/lib.rs
@@ -2,6 +2,7 @@
 mod convert;
 pub mod routes;
 pub mod service;
+pub mod skill_snapshot;
 pub mod state;
 pub mod stream_relay;
 

--- a/crates/aionui-conversation/src/lib.rs
+++ b/crates/aionui-conversation/src/lib.rs
@@ -2,6 +2,7 @@
 mod convert;
 pub mod routes;
 pub mod service;
+pub mod skill_resolver;
 pub mod skill_snapshot;
 pub mod state;
 pub mod stream_relay;

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -933,11 +933,7 @@ impl ConversationService {
     /// Persists the mutation asynchronously; failures are logged and
     /// swallowed so a read path never 500s because of a backfill write
     /// failure.
-    async fn backfill_extra_inplace(
-        &self,
-        conversation_id: &str,
-        extra: &mut serde_json::Value,
-    ) {
+    async fn backfill_extra_inplace(&self, conversation_id: &str, extra: &mut serde_json::Value) {
         let auto_inject = self.skill_resolver.auto_inject_names().await;
         let mutated = crate::skill_snapshot::backfill_skills_if_missing(extra, &auto_inject);
         if !mutated {

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -297,6 +297,17 @@ impl ConversationService {
             .filter(|r| r.user_id == user_id)
             .ok_or_else(|| AppError::NotFound(format!("Conversation {id} not found")))?;
 
+        // Snapshot invariant: once written at create time, `extra.skills`
+        // must not be re-shaped by PATCH. The frontend must clone the
+        // conversation to produce a new snapshot.
+        if let Some(incoming) = &req.extra
+            && incoming.get("skills").is_some()
+        {
+            return Err(AppError::BadRequest(
+                "extra.skills is immutable post-creation".into(),
+            ));
+        }
+
         let now = now_ms();
 
         // Merge extra if provided

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -122,6 +122,60 @@ impl ConversationService {
             extra["workspace"] = serde_json::Value::String(ws_path.to_string_lossy().into_owned());
         }
 
+        // Consume transient skill-shaping inputs and freeze the initial
+        // `skills` snapshot into `extra.skills`. These request-only fields
+        // must not land in the stored row. Legacy names (`enabled_skills`,
+        // `exclude_builtin_skills`) are accepted as aliases so that
+        // `clone_create` — which merges a source conversation's legacy
+        // `extra` into the new request — keeps working on pre-snapshot rows
+        // until every legacy row has been backfilled (§7.1).
+        fn take_string_array(
+            obj: &mut serde_json::Map<String, serde_json::Value>,
+            keys: &[&str],
+        ) -> Vec<String> {
+            for key in keys {
+                if let Some(v) = obj.remove(*key)
+                    && let Ok(arr) = serde_json::from_value::<Vec<String>>(v)
+                {
+                    return arr;
+                }
+            }
+            Vec::new()
+        }
+
+        let (preset_enabled, exclude_auto_inject) = match extra.as_object_mut() {
+            Some(obj) => {
+                let preset = take_string_array(obj, &["preset_enabled_skills", "enabled_skills"]);
+                let exclude = take_string_array(
+                    obj,
+                    &["exclude_auto_inject_skills", "exclude_builtin_skills"],
+                );
+                // Strip the stale cache field if a clone copied it in.
+                obj.remove("loaded_skills");
+                (preset, exclude)
+            }
+            None => (Vec::new(), Vec::new()),
+        };
+
+        let auto_inject_names = self.skill_resolver.auto_inject_names().await;
+        let initial_skills = crate::skill_snapshot::compute_initial_skills(
+            &auto_inject_names,
+            &preset_enabled,
+            &exclude_auto_inject,
+        );
+
+        if let Some(obj) = extra.as_object_mut() {
+            obj.insert(
+                "skills".to_owned(),
+                serde_json::Value::Array(
+                    initial_skills
+                        .into_iter()
+                        .map(serde_json::Value::String)
+                        .collect(),
+                ),
+            );
+        }
+
         let row = aionui_db::models::ConversationRow {
             id: id.clone(),
             user_id: user_id.to_owned(),

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -19,6 +19,7 @@ use tracing::{debug, info, warn};
 use crate::convert::{
     row_to_message_response, row_to_response, search_row_to_item, string_to_enum,
 };
+use crate::skill_resolver::SkillResolver;
 use crate::stream_relay::StreamRelay;
 
 #[async_trait::async_trait]
@@ -32,18 +33,21 @@ pub struct ConversationService {
     broadcaster: Arc<dyn EventBroadcaster>,
     delete_hooks: Vec<Arc<dyn OnConversationDelete>>,
     workspace_root: std::path::PathBuf,
+    skill_resolver: Arc<dyn SkillResolver>,
 }
 
 impl ConversationService {
     pub fn new(
         repo: Arc<dyn IConversationRepository>,
         broadcaster: Arc<dyn EventBroadcaster>,
+        skill_resolver: Arc<dyn SkillResolver>,
     ) -> Self {
         Self {
             repo,
             broadcaster,
             delete_hooks: Vec::new(),
             workspace_root: std::path::PathBuf::from("data"),
+            skill_resolver,
         }
     }
 
@@ -51,12 +55,14 @@ impl ConversationService {
         repo: Arc<dyn IConversationRepository>,
         broadcaster: Arc<dyn EventBroadcaster>,
         workspace_root: std::path::PathBuf,
+        skill_resolver: Arc<dyn SkillResolver>,
     ) -> Self {
         Self {
             repo,
             broadcaster,
             delete_hooks: Vec::new(),
             workspace_root,
+            skill_resolver,
         }
     }
 
@@ -64,12 +70,14 @@ impl ConversationService {
         repo: Arc<dyn IConversationRepository>,
         broadcaster: Arc<dyn EventBroadcaster>,
         delete_hooks: Vec<Arc<dyn OnConversationDelete>>,
+        skill_resolver: Arc<dyn SkillResolver>,
     ) -> Self {
         Self {
             repo,
             broadcaster,
             delete_hooks,
             workspace_root: std::path::PathBuf::from("data"),
+            skill_resolver,
         }
     }
 

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -17,7 +17,8 @@ use aionui_realtime::EventBroadcaster;
 use tracing::{debug, info, warn};
 
 use crate::convert::{
-    row_to_message_response, row_to_response, search_row_to_item, string_to_enum,
+    row_to_message_response, row_to_response, row_to_response_with_extra, search_row_to_item,
+    string_to_enum,
 };
 use crate::skill_resolver::SkillResolver;
 use crate::stream_relay::StreamRelay;
@@ -218,7 +219,11 @@ impl ConversationService {
             .await?
             .filter(|r| r.user_id == user_id)
             .ok_or_else(|| AppError::NotFound(format!("Conversation {id} not found")))?;
-        row_to_response(row)
+
+        let mut extra: serde_json::Value = serde_json::from_str(&row.extra)
+            .map_err(|e| AppError::Internal(format!("Invalid extra JSON: {e}")))?;
+        self.backfill_extra_inplace(&row.id, &mut extra).await;
+        row_to_response_with_extra(row, extra)
     }
 
     /// List conversations with cursor-based pagination and optional filters.
@@ -241,24 +246,30 @@ impl ConversationService {
         // (e.g. an abandoned agent_type='gemini' conversation post-migration)
         // must not take down the whole listing. Skip-and-log is the
         // explicit resilience contract from the Gemini→ACP migration spec.
-        let items = result
-            .items
-            .into_iter()
-            .filter_map(|row| {
-                let row_id = row.id.clone();
-                match row_to_response(row) {
-                    Ok(resp) => Some(resp),
-                    Err(err) => {
-                        warn!(
-                            conversation_id = %row_id,
-                            error = %err,
-                            "Skipping unreadable conversation row in list"
-                        );
-                        None
-                    }
+        let mut items = Vec::with_capacity(result.items.len());
+        for row in result.items {
+            let row_id = row.id.clone();
+            let mut extra: serde_json::Value = match serde_json::from_str(&row.extra) {
+                Ok(v) => v,
+                Err(err) => {
+                    warn!(
+                        conversation_id = %row_id,
+                        error = %err,
+                        "Skipping unreadable conversation row in list"
+                    );
+                    continue;
                 }
-            })
-            .collect();
+            };
+            self.backfill_extra_inplace(&row_id, &mut extra).await;
+            match row_to_response_with_extra(row, extra) {
+                Ok(resp) => items.push(resp),
+                Err(err) => warn!(
+                    conversation_id = %row_id,
+                    error = %err,
+                    "Skipping unreadable conversation row in list"
+                ),
+            }
+        }
 
         Ok(PaginatedResult {
             items,
@@ -905,6 +916,44 @@ impl ConversationService {
         });
         let event = WebSocketMessage::new("conversation.listChanged", payload);
         self.broadcaster.broadcast(event);
+    }
+
+    /// Backfill `extra.skills` if the row predates the snapshot model.
+    /// Persists the mutation asynchronously; failures are logged and
+    /// swallowed so a read path never 500s because of a backfill write
+    /// failure.
+    async fn backfill_extra_inplace(
+        &self,
+        conversation_id: &str,
+        extra: &mut serde_json::Value,
+    ) {
+        let auto_inject = self.skill_resolver.auto_inject_names().await;
+        let mutated = crate::skill_snapshot::backfill_skills_if_missing(extra, &auto_inject);
+        if !mutated {
+            return;
+        }
+        let serialized = match serde_json::to_string(extra) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(
+                    conversation_id,
+                    error = %e,
+                    "backfill serialize failed; returning in-memory value"
+                );
+                return;
+            }
+        };
+        let update = ConversationRowUpdate {
+            extra: Some(serialized),
+            ..Default::default()
+        };
+        if let Err(e) = self.repo.update(conversation_id, &update).await {
+            warn!(
+                conversation_id,
+                error = %e,
+                "backfill persist failed; returning in-memory value"
+            );
+        }
     }
 }
 

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1752,6 +1752,55 @@ async fn create_writes_empty_skills_when_no_auto_inject_and_no_preset() {
 }
 
 #[tokio::test]
+async fn update_rejects_extra_skills() {
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
+
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "extra": { "workspace": "/project", "backend": "claude" },
+    }))
+    .unwrap();
+    let resp = svc.create("u", req).await.unwrap();
+
+    let update_req: UpdateConversationRequest = serde_json::from_value(json!({
+        "extra": { "skills": ["cron"] },
+    }))
+    .unwrap();
+    let err = svc
+        .update("u", &resp.id, update_req, &task_mgr)
+        .await
+        .unwrap_err();
+
+    match err {
+        AppError::BadRequest(msg) => assert!(msg.contains("skills"), "msg = {msg:?}"),
+        other => panic!("expected BadRequest, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn update_allows_other_extra_fields() {
+    let (svc, _broadcaster, _repo, task_mgr) = make_service();
+
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "extra": { "workspace": "/project", "backend": "claude" },
+    }))
+    .unwrap();
+    let resp = svc.create("u", req).await.unwrap();
+
+    let update_req: UpdateConversationRequest = serde_json::from_value(json!({
+        "extra": { "current_model_id": "claude-3-5-sonnet" },
+    }))
+    .unwrap();
+    let updated = svc
+        .update("u", &resp.id, update_req, &task_mgr)
+        .await
+        .unwrap();
+
+    assert_eq!(updated.extra["current_model_id"], "claude-3-5-sonnet");
+}
+
+#[tokio::test]
 async fn get_backfills_legacy_row_and_persists() {
     let resolver = Arc::new(FixedSkillResolver {
         names: vec!["cron".into(), "todo-tracker".into()],

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1901,7 +1901,10 @@ async fn list_backfills_mixed_rows() {
     repo.create(&legacy).await.unwrap();
     repo.create(&modern).await.unwrap();
 
-    let resp = svc.list("u", ListConversationsQuery::default()).await.unwrap();
+    let resp = svc
+        .list("u", ListConversationsQuery::default())
+        .await
+        .unwrap();
     let extras: Vec<_> = resp.items.iter().map(|c| c.extra.clone()).collect();
     assert!(extras.iter().any(|e| e["skills"] == json!(["cron", "pdf"])));
 }

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1708,3 +1708,75 @@ async fn check_approval_not_found() {
         .unwrap_err();
     assert!(matches!(err, AppError::NotFound(_)));
 }
+
+// ── Skill snapshot tests ───────────────────────────────────────────
+
+#[tokio::test]
+async fn create_writes_extra_skills_from_auto_inject_and_preset() {
+    let resolver = Arc::new(FixedSkillResolver {
+        names: vec!["cron".into(), "todo-tracker".into()],
+    });
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service_with_resolver(resolver);
+
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "name": "t",
+        "extra": {
+            "workspace": "/project",
+            "backend": "claude",
+            "preset_enabled_skills": ["pdf", "cron"],
+            "exclude_auto_inject_skills": ["todo-tracker"],
+        },
+    }))
+    .unwrap();
+    let resp = svc.create("user-1", req).await.unwrap();
+
+    assert_eq!(resp.extra["skills"], json!(["cron", "pdf"]));
+    assert!(resp.extra.get("preset_enabled_skills").is_none());
+    assert!(resp.extra.get("exclude_auto_inject_skills").is_none());
+}
+
+#[tokio::test]
+async fn create_writes_empty_skills_when_no_auto_inject_and_no_preset() {
+    let resolver = Arc::new(FixedSkillResolver { names: vec![] });
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service_with_resolver(resolver);
+
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "extra": { "workspace": "/project", "backend": "claude" },
+    }))
+    .unwrap();
+    let resp = svc.create("user-1", req).await.unwrap();
+
+    assert_eq!(resp.extra["skills"], json!([]));
+}
+
+#[tokio::test]
+async fn create_honors_legacy_alias_fields_from_clone_merge() {
+    let resolver = Arc::new(FixedSkillResolver {
+        names: vec!["cron".into()],
+    });
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service_with_resolver(resolver);
+
+    // Legacy-shaped extra — what clone_create might merge in from an
+    // unmigrated source conversation.
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "extra": {
+            "workspace": "/project",
+            "backend": "claude",
+            "enabled_skills": ["pdf"],
+            "exclude_builtin_skills": ["cron"],
+            "loaded_skills": [{"name": "cron", "description": "stale"}],
+        },
+    }))
+    .unwrap();
+    let resp = svc.create("u", req).await.unwrap();
+
+    // Legacy enabled_skills ["pdf"] surfaces as preset; legacy exclude drops
+    // cron; snapshot = {} ∪ ["pdf"] = ["pdf"].
+    assert_eq!(resp.extra["skills"], json!(["pdf"]));
+    assert!(resp.extra.get("enabled_skills").is_none());
+    assert!(resp.extra.get("exclude_builtin_skills").is_none());
+    assert!(resp.extra.get("loaded_skills").is_none());
+}

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -22,6 +22,7 @@ use serde_json::json;
 use tokio::sync::broadcast;
 
 use crate::service::ConversationService;
+use crate::skill_resolver::FixedSkillResolver;
 
 // ── Mock EventBroadcaster ──────────────────────────────────────────
 
@@ -238,12 +239,24 @@ fn make_service() -> (
     Arc<MockRepo>,
     Arc<dyn IWorkerTaskManager>,
 ) {
+    make_service_with_resolver(Arc::new(FixedSkillResolver { names: vec![] }))
+}
+
+fn make_service_with_resolver(
+    skill_resolver: Arc<dyn crate::skill_resolver::SkillResolver>,
+) -> (
+    ConversationService,
+    Arc<MockBroadcaster>,
+    Arc<MockRepo>,
+    Arc<dyn IWorkerTaskManager>,
+) {
     let repo = Arc::new(MockRepo::new());
     let broadcaster = Arc::new(MockBroadcaster::new());
     let svc = ConversationService::new_with_workspace_root(
         repo.clone(),
         broadcaster.clone(),
         std::path::PathBuf::from(std::env::temp_dir()),
+        skill_resolver,
     );
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
     (svc, broadcaster, repo, task_mgr)

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1752,6 +1752,112 @@ async fn create_writes_empty_skills_when_no_auto_inject_and_no_preset() {
 }
 
 #[tokio::test]
+async fn get_backfills_legacy_row_and_persists() {
+    let resolver = Arc::new(FixedSkillResolver {
+        names: vec!["cron".into(), "todo-tracker".into()],
+    });
+    let (svc, _broadcaster, repo, _task_mgr) = make_service_with_resolver(resolver);
+
+    // Seed a legacy row directly via the repo — simulates a pre-migration
+    // conversation that the service has never touched.
+    let legacy_row = ConversationRow {
+        id: "legacy-1".into(),
+        user_id: "user-1".into(),
+        name: "legacy".into(),
+        r#type: "acp".into(),
+        extra: serde_json::to_string(&json!({
+            "workspace": "/tmp/x",
+            "enabled_skills": ["pdf"],
+            "exclude_builtin_skills": ["todo-tracker"],
+            "loaded_skills": [{"name": "cron", "description": "stale"}],
+        }))
+        .unwrap(),
+        model: None,
+        status: Some("finished".into()),
+        source: Some("aionui".into()),
+        channel_chat_id: None,
+        pinned: false,
+        pinned_at: None,
+        created_at: 0,
+        updated_at: 0,
+    };
+    repo.create(&legacy_row).await.unwrap();
+
+    let resp = svc.get("user-1", "legacy-1").await.unwrap();
+    assert_eq!(resp.extra["skills"], json!(["cron", "pdf"]));
+    assert!(resp.extra.get("enabled_skills").is_none());
+    assert!(resp.extra.get("exclude_builtin_skills").is_none());
+    assert!(resp.extra.get("loaded_skills").is_none());
+
+    // Second read returns the same result.
+    let resp2 = svc.get("user-1", "legacy-1").await.unwrap();
+    assert_eq!(resp2.extra["skills"], json!(["cron", "pdf"]));
+
+    // Verify the row on disk was persisted with the new shape.
+    let persisted = repo.get("legacy-1").await.unwrap().unwrap();
+    let persisted_extra: serde_json::Value = serde_json::from_str(&persisted.extra).unwrap();
+    assert_eq!(persisted_extra["skills"], json!(["cron", "pdf"]));
+    assert!(persisted_extra.get("enabled_skills").is_none());
+    assert!(persisted_extra.get("exclude_builtin_skills").is_none());
+    assert!(persisted_extra.get("loaded_skills").is_none());
+}
+
+#[tokio::test]
+async fn list_backfills_mixed_rows() {
+    let resolver = Arc::new(FixedSkillResolver {
+        names: vec!["cron".into()],
+    });
+    let (svc, _broadcaster, repo, _task_mgr) = make_service_with_resolver(resolver);
+
+    // Row 1: legacy (needs backfill).
+    let legacy = ConversationRow {
+        id: "a".into(),
+        user_id: "u".into(),
+        name: "a".into(),
+        r#type: "acp".into(),
+        extra: serde_json::to_string(&json!({
+            "workspace": "/tmp/a",
+            "enabled_skills": ["pdf"],
+        }))
+        .unwrap(),
+        model: None,
+        status: None,
+        source: None,
+        channel_chat_id: None,
+        pinned: false,
+        pinned_at: None,
+        created_at: 1,
+        updated_at: 1,
+    };
+    // Row 2: already migrated.
+    let modern = ConversationRow {
+        id: "b".into(),
+        user_id: "u".into(),
+        name: "b".into(),
+        r#type: "acp".into(),
+        extra: serde_json::to_string(&json!({
+            "workspace": "/tmp/b",
+            "skills": ["cron", "pdf"],
+        }))
+        .unwrap(),
+        model: None,
+        status: None,
+        source: None,
+        channel_chat_id: None,
+        pinned: false,
+        pinned_at: None,
+        created_at: 2,
+        updated_at: 2,
+    };
+    repo.create(&legacy).await.unwrap();
+    repo.create(&modern).await.unwrap();
+
+    let resp = svc.list("u", ListConversationsQuery::default()).await.unwrap();
+    let extras: Vec<_> = resp.items.iter().map(|c| c.extra.clone()).collect();
+    assert!(extras.iter().any(|e| e["skills"] == json!(["cron", "pdf"])));
+}
+
+#[tokio::test]
 async fn create_honors_legacy_alias_fields_from_clone_merge() {
     let resolver = Arc::new(FixedSkillResolver {
         names: vec!["cron".into()],

--- a/crates/aionui-conversation/src/skill_resolver.rs
+++ b/crates/aionui-conversation/src/skill_resolver.rs
@@ -1,0 +1,58 @@
+//! Abstraction over "what are the auto-inject skill names right now?" so
+//! `ConversationService` can compute the initial snapshot without forcing
+//! every test setup to stand up a real `SkillPaths`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait SkillResolver: Send + Sync {
+    /// Returns the sorted list of auto-inject builtin skill names currently
+    /// available on this installation.
+    async fn auto_inject_names(&self) -> Vec<String>;
+}
+
+/// Production adapter backed by `aionui_extension::skill_service`.
+pub struct ExtensionSkillResolver {
+    paths: Arc<aionui_extension::SkillPaths>,
+}
+
+impl ExtensionSkillResolver {
+    pub fn new(paths: Arc<aionui_extension::SkillPaths>) -> Self {
+        Self { paths }
+    }
+}
+
+#[async_trait]
+impl SkillResolver for ExtensionSkillResolver {
+    async fn auto_inject_names(&self) -> Vec<String> {
+        match aionui_extension::list_builtin_auto_skills(&self.paths).await {
+            Ok(items) => {
+                let mut names: Vec<String> = items.into_iter().map(|i| i.name).collect();
+                names.sort();
+                names
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "auto_inject_names: list_builtin_auto_skills failed, falling back to empty"
+                );
+                Vec::new()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub struct FixedSkillResolver {
+    pub names: Vec<String>,
+}
+
+#[cfg(test)]
+#[async_trait]
+impl SkillResolver for FixedSkillResolver {
+    async fn auto_inject_names(&self) -> Vec<String> {
+        self.names.clone()
+    }
+}

--- a/crates/aionui-conversation/src/skill_snapshot.rs
+++ b/crates/aionui-conversation/src/skill_snapshot.rs
@@ -92,8 +92,7 @@ mod tests {
     fn compute_initial_exclude_does_not_affect_preset_opt_in() {
         // User excluded cron from auto-inject, but the preset still added it
         // explicitly — preset wins.
-        let skills =
-            compute_initial_skills(&["cron".into()], &["cron".into()], &["cron".into()]);
+        let skills = compute_initial_skills(&["cron".into()], &["cron".into()], &["cron".into()]);
         assert_eq!(skills, vec!["cron"]);
     }
 

--- a/crates/aionui-conversation/src/skill_snapshot.rs
+++ b/crates/aionui-conversation/src/skill_snapshot.rs
@@ -1,0 +1,145 @@
+//! Pure helpers that compute `conversation.extra.skills` values. No I/O here
+//! — callers (e.g. `ConversationService::create`) fetch the auto-inject name
+//! set up-front and pass it in. This keeps unit tests deterministic and keeps
+//! `aionui-conversation` from taking a hard dep on `aionui-extension` beyond
+//! the `SkillResolver` trait.
+
+use serde_json::Value;
+
+/// Compute the initial `skills` snapshot for a brand-new conversation.
+///
+/// Formula: `(auto_inject − exclude_auto_inject) ∪ preset_enabled`,
+/// sorted ascending, deduplicated.
+pub fn compute_initial_skills(
+    auto_inject: &[String],
+    preset_enabled: &[String],
+    exclude_auto_inject: &[String],
+) -> Vec<String> {
+    let excluded: std::collections::HashSet<&String> = exclude_auto_inject.iter().collect();
+    let mut out: std::collections::BTreeSet<String> = auto_inject
+        .iter()
+        .filter(|n| !excluded.contains(n))
+        .cloned()
+        .collect();
+    for name in preset_enabled {
+        out.insert(name.clone());
+    }
+    out.into_iter().collect()
+}
+
+/// Mutate `extra` in place to add a `skills` array derived from legacy
+/// fields if absent. Returns `true` when a mutation happened (caller
+/// persists the row). Strips the legacy fields whether or not `skills`
+/// was already present, so a single pass cleans up partial rows too.
+///
+/// Legacy formula: `(auto_inject_now − extra.exclude_builtin_skills) ∪
+/// extra.enabled_skills`.
+pub fn backfill_skills_if_missing(extra: &mut Value, auto_inject_now: &[String]) -> bool {
+    let Some(obj) = extra.as_object_mut() else {
+        return false;
+    };
+
+    let legacy_enabled = take_string_array(obj, "enabled_skills");
+    let legacy_excluded = take_string_array(obj, "exclude_builtin_skills");
+    let legacy_loaded = obj.remove("loaded_skills");
+    let had_legacy =
+        !legacy_enabled.is_empty() || !legacy_excluded.is_empty() || legacy_loaded.is_some();
+
+    let needs_compute = !obj.contains_key("skills");
+    if needs_compute {
+        let computed = compute_initial_skills(auto_inject_now, &legacy_enabled, &legacy_excluded);
+        obj.insert(
+            "skills".to_owned(),
+            Value::Array(computed.into_iter().map(Value::String).collect()),
+        );
+    }
+
+    needs_compute || had_legacy
+}
+
+fn take_string_array(obj: &mut serde_json::Map<String, Value>, key: &str) -> Vec<String> {
+    obj.remove(key)
+        .and_then(|v| serde_json::from_value::<Vec<String>>(v).ok())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn compute_initial_union_dedup_sort() {
+        let skills = compute_initial_skills(
+            &["cron".into(), "todo-tracker".into()],
+            &["pdf".into(), "cron".into()],
+            &[],
+        );
+        assert_eq!(skills, vec!["cron", "pdf", "todo-tracker"]);
+    }
+
+    #[test]
+    fn compute_initial_applies_exclude() {
+        let skills = compute_initial_skills(
+            &["cron".into(), "todo-tracker".into()],
+            &[],
+            &["cron".into()],
+        );
+        assert_eq!(skills, vec!["todo-tracker"]);
+    }
+
+    #[test]
+    fn compute_initial_exclude_does_not_affect_preset_opt_in() {
+        // User excluded cron from auto-inject, but the preset still added it
+        // explicitly — preset wins.
+        let skills =
+            compute_initial_skills(&["cron".into()], &["cron".into()], &["cron".into()]);
+        assert_eq!(skills, vec!["cron"]);
+    }
+
+    #[test]
+    fn backfill_writes_skills_and_strips_legacy() {
+        let mut extra = json!({
+            "workspace": "/tmp/foo",
+            "enabled_skills": ["pdf"],
+            "exclude_builtin_skills": ["cron"],
+            "loaded_skills": [{"name": "cron", "description": "old cache"}],
+        });
+        let mutated =
+            backfill_skills_if_missing(&mut extra, &["cron".into(), "todo-tracker".into()]);
+        assert!(mutated);
+        assert_eq!(extra["skills"], json!(["pdf", "todo-tracker"]));
+        assert!(extra.get("enabled_skills").is_none());
+        assert!(extra.get("exclude_builtin_skills").is_none());
+        assert!(extra.get("loaded_skills").is_none());
+    }
+
+    #[test]
+    fn backfill_noop_when_skills_present_and_no_legacy() {
+        let mut extra = json!({
+            "skills": ["cron"],
+            "workspace": "/tmp/foo",
+        });
+        let mutated = backfill_skills_if_missing(&mut extra, &["cron".into()]);
+        assert!(!mutated);
+        assert_eq!(extra["skills"], json!(["cron"]));
+    }
+
+    #[test]
+    fn backfill_strips_legacy_even_when_skills_already_present() {
+        let mut extra = json!({
+            "skills": ["cron"],
+            "loaded_skills": [{"name": "cron", "description": "stale"}],
+        });
+        let mutated = backfill_skills_if_missing(&mut extra, &[]);
+        assert!(mutated);
+        assert!(extra.get("loaded_skills").is_none());
+    }
+
+    #[test]
+    fn backfill_ignores_non_object_extra() {
+        let mut extra = json!(null);
+        let mutated = backfill_skills_if_missing(&mut extra, &["cron".into()]);
+        assert!(!mutated);
+    }
+}

--- a/crates/aionui-conversation/tests/conversation_crud.rs
+++ b/crates/aionui-conversation/tests/conversation_crud.rs
@@ -8,6 +8,7 @@ use aionui_common::{
     AgentKillReason, AgentType, AppError, ConversationSource, ConversationStatus, TimestampMs,
 };
 use aionui_conversation::ConversationService;
+use aionui_conversation::skill_resolver::SkillResolver;
 use aionui_db::{SqliteConversationRepository, init_database_memory};
 use aionui_realtime::EventBroadcaster;
 use serde_json::json;
@@ -62,6 +63,15 @@ impl IWorkerTaskManager for NoopTaskManager {
     }
 }
 
+struct EmptySkillResolver;
+
+#[async_trait::async_trait]
+impl SkillResolver for EmptySkillResolver {
+    async fn auto_inject_names(&self) -> Vec<String> {
+        Vec::new()
+    }
+}
+
 async fn setup() -> (
     ConversationService,
     Arc<TestBroadcaster>,
@@ -74,6 +84,7 @@ async fn setup() -> (
         repo,
         broadcaster.clone(),
         std::env::temp_dir(),
+        Arc::new(EmptySkillResolver),
     );
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(NoopTaskManager);
     (svc, broadcaster, task_mgr)

--- a/crates/aionui-conversation/tests/conversation_extended.rs
+++ b/crates/aionui-conversation/tests/conversation_extended.rs
@@ -6,6 +6,7 @@ use aionui_api_types::{
 };
 use aionui_common::{ConversationStatus, generate_prefixed_id, now_ms};
 use aionui_conversation::ConversationService;
+use aionui_conversation::skill_resolver::SkillResolver;
 use aionui_db::models::MessageRow;
 use aionui_db::{IConversationRepository, SqliteConversationRepository, init_database_memory};
 use aionui_realtime::EventBroadcaster;
@@ -32,6 +33,15 @@ impl EventBroadcaster for TestBroadcaster {
     }
 }
 
+struct EmptySkillResolver;
+
+#[async_trait::async_trait]
+impl SkillResolver for EmptySkillResolver {
+    async fn auto_inject_names(&self) -> Vec<String> {
+        Vec::new()
+    }
+}
+
 async fn setup() -> (
     ConversationService,
     Arc<SqliteConversationRepository>,
@@ -44,6 +54,7 @@ async fn setup() -> (
         repo.clone(),
         broadcaster.clone(),
         std::env::temp_dir(),
+        Arc::new(EmptySkillResolver),
     );
     (svc, repo, broadcaster)
 }

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -765,6 +765,14 @@ mod tests {
             fn broadcast(&self, _: WebSocketMessage<serde_json::Value>) {}
         }
 
+        struct StubSkillResolver;
+        #[async_trait::async_trait]
+        impl aionui_conversation::skill_resolver::SkillResolver for StubSkillResolver {
+            async fn auto_inject_names(&self) -> Vec<String> {
+                Vec::new()
+            }
+        }
+
         let stub_broadcaster: Arc<dyn aionui_realtime::EventBroadcaster> =
             Arc::new(StubBroadcaster);
         let stub_repo: Arc<dyn IConversationRepository> = Arc::new(StubConvRepo);
@@ -772,6 +780,7 @@ mod tests {
             Arc::clone(&stub_repo),
             stub_broadcaster,
             std::env::temp_dir(),
+            Arc::new(StubSkillResolver),
         ));
 
         JobExecutor::new(Arc::new(StubTaskManager), stub_repo, conv_service, guard)

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -219,11 +219,20 @@ async fn setup() -> (CronService, Arc<dyn ICronRepository>, Arc<MockBroadcaster>
     let cron_repo: Arc<dyn ICronRepository> = Arc::new(SqliteCronRepository::new(pool));
     let bc = Arc::new(MockBroadcaster::new());
 
+    struct StubSkillResolver;
+    #[async_trait::async_trait]
+    impl aionui_conversation::skill_resolver::SkillResolver for StubSkillResolver {
+        async fn auto_inject_names(&self) -> Vec<String> {
+            Vec::new()
+        }
+    }
+
     let stub_conv_repo: Arc<dyn IConversationRepository> = Arc::new(StubConvRepo);
     let conv_service = Arc::new(ConversationService::new_with_workspace_root(
         Arc::clone(&stub_conv_repo),
         bc.clone() as Arc<dyn EventBroadcaster>,
         std::env::temp_dir(),
+        Arc::new(StubSkillResolver),
     ));
     let busy_guard = Arc::new(CronBusyGuard::new());
     let executor = Arc::new(JobExecutor::new(

--- a/crates/aionui-extension/src/skill_routes.rs
+++ b/crates/aionui-extension/src/skill_routes.rs
@@ -335,7 +335,7 @@ async fn materialize_for_agent(
     let dir = skill_service::materialize_skills_for_agent(
         &state.skill_paths,
         &req.conversation_id,
-        &req.enabled_skills,
+        &req.skills,
     )
     .await?;
     Ok(Json(ApiResponse::ok(MaterializeSkillsResponse {

--- a/crates/aionui-extension/src/skill_service.rs
+++ b/crates/aionui-extension/src/skill_service.rs
@@ -2105,10 +2105,9 @@ mod tests {
             "auto-inject must NOT be implicit anymore"
         );
 
-        let named =
-            materialize_skills_for_agent(&paths, "conv-named", &["cron".to_owned()])
-                .await
-                .unwrap();
+        let named = materialize_skills_for_agent(&paths, "conv-named", &["cron".to_owned()])
+            .await
+            .unwrap();
         assert!(
             named.join("cron").join(SKILL_MANIFEST_FILE).exists(),
             "named auto-inject skill not materialized"

--- a/crates/aionui-extension/src/skill_service.rs
+++ b/crates/aionui-extension/src/skill_service.rs
@@ -754,8 +754,8 @@ fn builtin_skill_exists(paths: &SkillPaths, skill_name: &str) -> bool {
 // D2. Per-agent skill materialization
 // ---------------------------------------------------------------------------
 
-/// Materialize built-in and selected opt-in skills into a per-conversation
-/// directory under `{data_dir}/agent-skills/{conversation_id}/`.
+/// Materialize the listed skills into a per-conversation directory
+/// under `{data_dir}/agent-skills/{conversation_id}/`.
 ///
 /// Layout is flat: every skill lands at `{target}/{name}/SKILL.md`,
 /// regardless of whether it originated from the `auto-inject/` subtree
@@ -763,18 +763,16 @@ fn builtin_skill_exists(paths: &SkillPaths, skill_name: &str) -> bool {
 /// directory is flattened away because gemini CLI's `--extensions`
 /// loader expects one skill per subdir.
 ///
-/// Order of precedence (later writes overwrite earlier ones, with a
-/// warning logged on collision):
-/// 1. All auto-inject skills
-/// 2. User opt-in skills listed in `enabled_skills` (embedded / disk / user / extension)
-///
-/// Unknown names in `enabled_skills` are silently skipped — a warning is
-/// emitted but the operation still returns success. Returns the
-/// absolute path of the target directory.
+/// Callers pass the fully resolved snapshot — this function does NOT
+/// implicitly include auto-inject; the caller (e.g. the
+/// `ConversationService::create` snapshot) is the source of truth.
+/// Unknown names are silently skipped — a warning is emitted but the
+/// operation still returns success. Returns the absolute path of the
+/// target directory.
 pub async fn materialize_skills_for_agent(
     paths: &SkillPaths,
     conversation_id: &str,
-    enabled_skills: &[String],
+    skills: &[String],
 ) -> Result<PathBuf, ExtensionError> {
     validate_filename(conversation_id)?;
 
@@ -790,75 +788,27 @@ pub async fn materialize_skills_for_agent(
     }
     tokio::fs::create_dir_all(&target).await?;
 
-    // 1. Auto-inject (always).
-    write_auto_inject_skills(paths, &target).await?;
-
-    // 2. Opt-in enabled skills.
-    for name in enabled_skills {
+    for name in skills {
         if name.is_empty() {
             continue;
         }
         if name.contains('/') || name.contains('\\') || name.contains("..") {
-            warn!(skill = %name, "skipping enabled skill with invalid name");
+            warn!(skill = %name, "skipping skill with invalid name");
             continue;
         }
-        if target.join(name).exists() {
-            warn!(
-                skill = %name,
-                "enabled skill overlaps auto-inject name; opt-in copy wins"
-            );
-        }
-        let wrote = write_opt_in_skill(paths, name, &target).await?;
+        let wrote = write_skill_by_name(paths, name, &target).await?;
         if !wrote {
-            warn!(skill = %name, "enabled skill not found in any source");
+            warn!(skill = %name, "skill not found in any source");
         }
     }
 
     Ok(target)
 }
 
-async fn write_auto_inject_skills(paths: &SkillPaths, target: &Path) -> Result<(), ExtensionError> {
-    if let Some(dir) = &paths.builtin_skills_dir {
-        let auto_dir = dir.join(BUILTIN_AUTO_SKILLS_SUBDIR);
-        if !auto_dir.is_dir() {
-            return Ok(());
-        }
-        let mut entries = match tokio::fs::read_dir(&auto_dir).await {
-            Ok(e) => e,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-            Err(e) => return Err(ExtensionError::Io(e)),
-        };
-        while let Ok(Some(entry)) = entries.next_entry().await {
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
-            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-                continue;
-            };
-            let dest = target.join(name);
-            copy_dir_recursive(&path, &dest).await?;
-        }
-        return Ok(());
-    }
-
-    let Some(auto_dir) = BUILTIN_SKILLS.get_dir(BUILTIN_AUTO_SKILLS_SUBDIR) else {
-        return Ok(());
-    };
-    for subdir in auto_dir.dirs() {
-        let Some(name) = subdir.path().file_name().and_then(|n| n.to_str()) else {
-            continue;
-        };
-        let dest = target.join(name);
-        extract_embedded_dir(subdir, &dest).await?;
-    }
-    Ok(())
-}
-
-/// Write a single opt-in skill into `{target}/{name}/`. Resolves in
+/// Write a single named skill into `{target}/{name}/`. Resolves in
 /// order: embedded/disk builtin (top-level + auto-inject) → user
 /// skills dir. Returns `true` if the skill was found and written.
-async fn write_opt_in_skill(
+async fn write_skill_by_name(
     paths: &SkillPaths,
     name: &str,
     target: &Path,
@@ -2138,20 +2088,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn materialize_includes_auto_inject() {
+    async fn materialize_resolves_auto_inject_skill_by_name() {
+        // Auto-inject skills are now only materialized when the caller
+        // names them explicitly (see `ConversationService::create`
+        // snapshot). Passing `&[]` yields an empty dir; passing a known
+        // auto-inject name (e.g. "cron") writes it at the flat layout.
         let tmp = TempDir::new().unwrap();
         let paths = make_embedded_paths(tmp.path());
 
-        let dir = materialize_skills_for_agent(&paths, "conv-auto", &[])
+        let empty = materialize_skills_for_agent(&paths, "conv-empty", &[])
             .await
             .unwrap();
-        // At least one auto-inject skill (cron) lands flat under dir/{name}/SKILL.md.
+        assert!(empty.is_dir());
         assert!(
-            dir.join("cron").join(SKILL_MANIFEST_FILE).exists(),
-            "auto-inject cron skill not materialized"
+            !empty.join("cron").exists(),
+            "auto-inject must NOT be implicit anymore"
+        );
+
+        let named =
+            materialize_skills_for_agent(&paths, "conv-named", &["cron".to_owned()])
+                .await
+                .unwrap();
+        assert!(
+            named.join("cron").join(SKILL_MANIFEST_FILE).exists(),
+            "named auto-inject skill not materialized"
         );
         assert!(
-            !dir.join(BUILTIN_AUTO_SKILLS_SUBDIR).exists(),
+            !named.join(BUILTIN_AUTO_SKILLS_SUBDIR).exists(),
             "auto-inject/ wrapper should be flattened away; layout is flat"
         );
     }
@@ -2183,7 +2146,7 @@ mod tests {
             materialize_skills_for_agent(&paths, "conv-missing", &["no-such-skill".to_string()])
                 .await
                 .unwrap();
-        // Unknown name silently skipped; auto-inject still present.
+        // Unknown name is silently skipped; the dir exists but stays empty.
         assert!(dir.is_dir());
         assert!(!dir.join("no-such-skill").exists());
     }

--- a/crates/aionui-extension/tests/skill_service_materialize.rs
+++ b/crates/aionui-extension/tests/skill_service_materialize.rs
@@ -32,16 +32,15 @@ async fn materialize_writes_only_listed_skills() {
     }
     let paths = resolve_skill_paths(tmp.path(), tmp.path());
 
-    let dir = skill_service::materialize_skills_for_agent(
-        &paths,
-        "conv-1",
-        &["cron".to_owned()],
-    )
-    .await
-    .unwrap();
+    let dir = skill_service::materialize_skills_for_agent(&paths, "conv-1", &["cron".to_owned()])
+        .await
+        .unwrap();
 
     assert!(dir.join("cron").join("SKILL.md").exists());
-    assert!(!dir.join("todo").exists(), "todo should not be materialized");
+    assert!(
+        !dir.join("todo").exists(),
+        "todo should not be materialized"
+    );
 
     unsafe {
         std::env::remove_var(aionui_extension::BUILTIN_SKILLS_ENV_VAR);

--- a/crates/aionui-extension/tests/skill_service_materialize.rs
+++ b/crates/aionui-extension/tests/skill_service_materialize.rs
@@ -1,0 +1,49 @@
+use aionui_extension::{resolve_skill_paths, skill_service};
+use tempfile::TempDir;
+
+/// `BUILTIN_SKILLS_ENV_VAR` is process-global; this test mutates it, so
+/// it must not run in parallel with other `skill_service` tests that
+/// touch the same env var. Vitest-style serialization inside a single
+/// test is sufficient here.
+#[tokio::test]
+async fn materialize_writes_only_listed_skills() {
+    let tmp = TempDir::new().unwrap();
+    // Stage two builtin auto-inject skills on disk.
+    let auto_dir = tmp.path().join("builtin-skills").join("auto-inject");
+    std::fs::create_dir_all(auto_dir.join("cron")).unwrap();
+    std::fs::write(
+        auto_dir.join("cron").join("SKILL.md"),
+        "---\nname: cron\ndescription: \n---",
+    )
+    .unwrap();
+    std::fs::create_dir_all(auto_dir.join("todo")).unwrap();
+    std::fs::write(
+        auto_dir.join("todo").join("SKILL.md"),
+        "---\nname: todo\ndescription: \n---",
+    )
+    .unwrap();
+
+    // SAFETY: single-threaded test harness.
+    unsafe {
+        std::env::set_var(
+            aionui_extension::BUILTIN_SKILLS_ENV_VAR,
+            tmp.path().join("builtin-skills"),
+        );
+    }
+    let paths = resolve_skill_paths(tmp.path(), tmp.path());
+
+    let dir = skill_service::materialize_skills_for_agent(
+        &paths,
+        "conv-1",
+        &["cron".to_owned()],
+    )
+    .await
+    .unwrap();
+
+    assert!(dir.join("cron").join("SKILL.md").exists());
+    assert!(!dir.join("todo").exists(), "todo should not be materialized");
+
+    unsafe {
+        std::env::remove_var(aionui_extension::BUILTIN_SKILLS_ENV_VAR);
+    }
+}

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -268,6 +268,14 @@ impl ITeamRepository for FullMockTeamRepo {
 // Helpers
 // ---------------------------------------------------------------------------
 
+struct StubSkillResolver;
+#[async_trait::async_trait]
+impl aionui_conversation::skill_resolver::SkillResolver for StubSkillResolver {
+    async fn auto_inject_names(&self) -> Vec<String> {
+        Vec::new()
+    }
+}
+
 fn setup() -> TeamSessionService {
     let team_repo: Arc<dyn ITeamRepository> = Arc::new(FullMockTeamRepo::new());
     let conv_repo: Arc<dyn IConversationRepository> = Arc::new(MockConversationRepo::new());
@@ -276,6 +284,7 @@ fn setup() -> TeamSessionService {
         conv_repo,
         broadcaster.clone(),
         std::env::temp_dir(),
+        Arc::new(StubSkillResolver),
     );
     TeamSessionService::new(team_repo, conv_service, broadcaster)
 }


### PR DESCRIPTION
## Summary

Implements Plan B (backend half) of the conversation skills snapshot migration. Freezes `conversation.extra.skills: string[]` at create time and drops the runtime `enabled_skills + exclude_builtin_skills` model from the agent-facing pipeline.

- `ConversationService::create` consumes `preset_enabled_skills` + `exclude_auto_inject_skills` (with legacy `enabled_skills` / `exclude_builtin_skills` accepted as aliases so `clone_create` keeps working on pre-migration rows), resolves the auto-inject name set via a new `SkillResolver` trait, and persists the sorted, deduplicated union into `extra.skills`.
- `ConversationService::get` / `list` lazily backfill pre-migration rows — compute `skills` from legacy fields + current auto-inject names, strip `enabled_skills` / `exclude_builtin_skills` / `loaded_skills`, and persist the new shape.
- `ConversationService::update` rejects `extra.skills` with `BadRequest` (immutable post-creation).
- `AcpBuildExtra` / `OpenClawBuildExtra` replace the pair of fields with a single `skills: Vec<String>` that flows in from `conversation.extra.skills`.
- `first_message_injector::InjectionConfig` now takes a resolved `skills: &[String]`; `AcpSkillManager` gains `discover_by_names`.
- `POST /api/skills/materialize-for-agent` takes `skills` (with `enabled_skills` alias for one release) and no longer implicitly includes auto-inject — the caller is the source of truth.

## Plan & spec

- Plan: `docs/backend-migration/plans/2026-04-27-conversation-skills-snapshot-backend-plan.md`
- Spec: `docs/backend-migration/specs/2026-04-27-conversation-skills-snapshot-design.md`

## Commits

1. `feat(conversation): add skill_snapshot helpers for create/backfill` — pure `compute_initial_skills` + `backfill_skills_if_missing` with 7 unit tests.
2. `feat(conversation): add SkillResolver trait + extension-backed impl` — abstraction + production adapter.
3. `feat(conversation): inject SkillResolver into ConversationService` — thread dependency through constructors and every call site (app, cron, team, tests).
4. `feat(conversation): write extra.skills snapshot at conversation create time` — consume transient fields, resolve snapshot, strip legacy + `loaded_skills`.
5. `feat(conversation): lazy-backfill extra.skills on get and list` — persist migration through normal reads.
6. `refactor(ai-agent): rename AcpBuildExtra fields to skills; keep injector compat shim` — transition step keeping the injector compiling.
7. `refactor(ai-agent): first-message injector takes resolved skills list` — final injector shape + `discover_by_names`.
8. `test(ai-agent): verify skills snapshot populates AcpBuildExtra` — wire-format round-trip.
9. `refactor(extension): materialize-for-agent takes resolved skills list` — renamed field with legacy alias, dropped auto-inject layering.
10. `feat(conversation): reject PATCH of extra.skills (immutable post-creation)` — snapshot invariant.
11. `chore: update e2e test for snapshot contract and cargo fmt` — match new materialize contract + fmt.

## Relationship to Plan A

Plan A (builtin-skills startup materialize, PR #32) and this PR are independent and can merge in either order. This branch was built against `origin/main` and does not assume Plan A's `SkillPaths.builtin_skills_dir: PathBuf` change (it still uses `Option<PathBuf>`).

## Test plan

- [x] `cargo test -p aionui-conversation skill_snapshot --lib` — 7 snapshot helper tests
- [x] `cargo test -p aionui-conversation` — full conversation suite (100 lib + 26 + 21 integration tests)
- [x] `cargo test -p aionui-ai-agent --lib` — 266 tests including new `heavy_mode_with_resolved_skills_injects_index`
- [x] `cargo test -p aionui-api-types` — materialize round-trip + legacy alias acceptance
- [x] `cargo test -p aionui-extension --test skill_service_materialize` — new test verifying no implicit auto-inject
- [x] `cargo test --workspace --all-features --no-fail-fast` — green except for pre-existing failures (see below)
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p aionui-conversation -p aionui-extension -p aionui-ai-agent -p aionui-api-types -p aionui-app --lib -- -D warnings` — clean on my crates

### Pre-existing failures (not this PR)

All of these fail on `origin/main` with the same errors — not introduced here:

- `aionui-extension::tests::assistant_dispatch_test::*` — 5 camelCase wire-format mismatches.
- `aionui-app::extension_e2e::cp1_get_external_paths_empty` — environment-dependent (asserts 0 external paths but finds 27 on dev machines).
- `aionui-realtime::tests::handler_integration` clippy warnings (`redundant_locals`, `let_and_return`).
- `aionui-api-types` test-target clippy warnings (`bool_assert_comparison`, `len_zero`).
- `aionui-extension::registry_test` clippy `collapsible_if`.

The production-code clippy lint is clean on every crate I touched.