### PR TITLE
fix: ignore OpenClaw lifecycle events to prevent duplicate status messages

### DIFF
--- a/crates/aionui-ai-agent/src/openclaw/event_mapper.rs
+++ b/crates/aionui-ai-agent/src/openclaw/event_mapper.rs
@@ -3,8 +3,8 @@ use tracing::debug;
 
 use super::protocol::{AgentEvent, ApprovalRequestEvent, ChatEvent, ChatEventState, EventFrame};
 use crate::stream_event::{
-    AgentStatusEventData, AgentStreamEvent, ErrorEventData, FinishEventData, StartEventData,
-    TextEventData, ThinkingEventData, ToolCallEventData, ToolCallStatus,
+    AgentStreamEvent, ErrorEventData, FinishEventData, StartEventData, TextEventData,
+    ThinkingEventData, ToolCallEventData, ToolCallStatus,
 };
 
 #[derive(Default)]
@@ -184,17 +184,8 @@ fn map_agent_event(
             }
             vec![]
         }
-        "lifecycle" => {
-            if data.get("phase").and_then(|v| v.as_str()) == Some("start") {
-                return vec![AgentStreamEvent::AgentStatus(AgentStatusEventData {
-                    backend: "openclaw-gateway".into(),
-                    status: "session_active".into(),
-                    agent_name: None,
-                    session_id: agent_evt.session_key,
-                })];
-            }
-            vec![]
-        }
+        // Turn lifecycle is driven by chat.state events (final/aborted/error)
+        "lifecycle" => vec![],
         _ => {
             debug!(stream = stream, "Unhandled agent event stream");
             vec![]


### PR DESCRIPTION
## Summary

- OpenClaw Gateway sends a `lifecycle` event with `phase: "start"` on every `chat.send`, which was incorrectly mapped to `AgentStatus(session_active)` — causing a new "会话活跃中" status banner to appear on every message turn
- The pre-separation codebase (`src/process/agent/openclaw/index.ts`) intentionally ignored lifecycle events with `// Intentionally ignored — turn lifecycle is driven by chat.state events`
- Aligned the backend event mapper with that behavior: lifecycle events now return empty `vec![]`

## Test plan

- [x] `cargo clippy -p aionui-ai-agent -- -D warnings` passes
- [x] `cargo test -p aionui-ai-agent` passes (12/12)
- [ ] Manual: send multiple messages in an OpenClaw Gateway conversation — verify only one "会话活跃中" banner appears (on initial connection), not one per message