### PR TITLE
feat: enrich tool call rendering data and fix duplicate events

### DIFF
--- a/crates/aionui-ai-agent/src/backend_output_sink.rs
+++ b/crates/aionui-ai-agent/src/backend_output_sink.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
 use aion_agent::output::OutputSink;
 use tokio::sync::broadcast;
 use uuid::Uuid;
@@ -9,11 +12,15 @@ use crate::stream_event::{
 
 pub struct BackendOutputSink {
     event_tx: broadcast::Sender<AgentStreamEvent>,
+    active_calls: Mutex<HashMap<String, String>>,
 }
 
 impl BackendOutputSink {
     pub fn new(event_tx: broadcast::Sender<AgentStreamEvent>) -> Self {
-        Self { event_tx }
+        Self {
+            event_tx,
+            active_calls: Mutex::new(HashMap::new()),
+        }
     }
 }
 
@@ -36,32 +43,56 @@ impl OutputSink for BackendOutputSink {
     }
 
     fn emit_tool_call(&self, name: &str, input: &str) {
-        let args =
+        let parsed_input =
             serde_json::from_str(input).unwrap_or(serde_json::Value::String(input.to_owned()));
         let call_id = format!("aionrs-{}", Uuid::now_v7());
+
+        self.active_calls
+            .lock()
+            .unwrap()
+            .insert(name.to_owned(), call_id.clone());
+
         let _ = self
             .event_tx
             .send(AgentStreamEvent::ToolCall(ToolCallEventData {
                 call_id,
                 name: name.to_owned(),
-                args,
+                args: parsed_input.clone(),
                 status: ToolCallStatus::Running,
+                input: Some(parsed_input),
+                output: None,
+                description: None,
             }));
     }
 
-    fn emit_tool_result(&self, name: &str, is_error: bool, _content: &str) {
+    fn emit_tool_result(&self, name: &str, is_error: bool, content: &str) {
         let status = if is_error {
             ToolCallStatus::Error
         } else {
             ToolCallStatus::Completed
         };
+
+        let call_id = self
+            .active_calls
+            .lock()
+            .unwrap()
+            .remove(name)
+            .unwrap_or_default();
+
         let _ = self
             .event_tx
             .send(AgentStreamEvent::ToolCall(ToolCallEventData {
-                call_id: String::new(),
+                call_id,
                 name: name.to_owned(),
                 args: serde_json::Value::Null,
                 status,
+                input: None,
+                output: if content.is_empty() {
+                    None
+                } else {
+                    Some(content.to_owned())
+                },
+                description: None,
             }));
     }
 
@@ -219,6 +250,58 @@ mod tests {
                 assert_eq!(data.tip_type, TipType::Success);
             }
             other => panic!("Expected Tips, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn emit_tool_call_carries_input() {
+        let (sink, mut rx) = make_sink();
+        sink.emit_tool_call("Glob", r#"{"pattern":"**/*.rs"}"#);
+        let event = rx.try_recv().unwrap();
+        match event {
+            AgentStreamEvent::ToolCall(data) => {
+                assert_eq!(data.name, "Glob");
+                assert_eq!(data.status, ToolCallStatus::Running);
+                assert!(data.input.is_some());
+                assert_eq!(data.input.unwrap()["pattern"], "**/*.rs");
+            }
+            other => panic!("Expected ToolCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn emit_tool_result_carries_output_and_matching_call_id() {
+        let (sink, mut rx) = make_sink();
+        sink.emit_tool_call("Glob", r#"{"pattern":"**/*.rs"}"#);
+        let start_event = rx.try_recv().unwrap();
+        let start_call_id = match &start_event {
+            AgentStreamEvent::ToolCall(data) => data.call_id.clone(),
+            _ => panic!("Expected ToolCall"),
+        };
+
+        sink.emit_tool_result("Glob", false, "src/main.rs\nsrc/lib.rs");
+        let event = rx.try_recv().unwrap();
+        match event {
+            AgentStreamEvent::ToolCall(data) => {
+                assert_eq!(data.name, "Glob");
+                assert_eq!(data.status, ToolCallStatus::Completed);
+                assert_eq!(data.call_id, start_call_id);
+                assert_eq!(data.output.as_deref(), Some("src/main.rs\nsrc/lib.rs"));
+            }
+            other => panic!("Expected ToolCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn emit_tool_result_empty_content_omits_output() {
+        let (sink, mut rx) = make_sink();
+        sink.emit_tool_result("Glob", false, "");
+        let event = rx.try_recv().unwrap();
+        match event {
+            AgentStreamEvent::ToolCall(data) => {
+                assert!(data.output.is_none());
+            }
+            other => panic!("Expected ToolCall, got {:?}", other),
         }
     }
 

--- a/crates/aionui-ai-agent/src/backend_protocol_sink.rs
+++ b/crates/aionui-ai-agent/src/backend_protocol_sink.rs
@@ -93,19 +93,6 @@ impl ProtocolEmitter for BackendProtocolSink {
                 );
             }
 
-            ProtocolEvent::ToolRunning {
-                call_id, tool_name, ..
-            } => {
-                let _ = self
-                    .event_tx
-                    .send(AgentStreamEvent::ToolCall(ToolCallEventData {
-                        call_id: call_id.clone(),
-                        name: tool_name.clone(),
-                        args: serde_json::Value::Null,
-                        status: ToolCallStatus::Running,
-                    }));
-            }
-
             ProtocolEvent::ToolCancelled {
                 call_id, reason, ..
             } => {
@@ -120,6 +107,9 @@ impl ProtocolEmitter for BackendProtocolSink {
                         name: format!("cancelled: {reason}"),
                         args: serde_json::Value::Null,
                         status: ToolCallStatus::Error,
+                        input: None,
+                        output: None,
+                        description: None,
                     }));
             }
 
@@ -176,7 +166,7 @@ mod tests {
     }
 
     #[test]
-    fn tool_running_emits_tool_call_event() {
+    fn tool_running_is_ignored() {
         let (sink, mut rx, _) = make_sink();
         let event = ProtocolEvent::ToolRunning {
             msg_id: "m1".into(),
@@ -185,16 +175,7 @@ mod tests {
         };
 
         sink.emit(&event).unwrap();
-
-        let received = rx.try_recv().unwrap();
-        match received {
-            AgentStreamEvent::ToolCall(data) => {
-                assert_eq!(data.call_id, "c1");
-                assert_eq!(data.name, "Write");
-                assert_eq!(data.status, ToolCallStatus::Running);
-            }
-            other => panic!("Expected ToolCall, got {:?}", other),
-        }
+        assert!(rx.try_recv().is_err());
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/openclaw/event_mapper.rs
+++ b/crates/aionui-ai-agent/src/openclaw/event_mapper.rs
@@ -223,6 +223,9 @@ fn map_tool_event(data: &Value) -> Vec<AgentStreamEvent> {
         name,
         args,
         status,
+        input: None,
+        output: None,
+        description: None,
     })]
 }
 

--- a/crates/aionui-ai-agent/src/stream_event.rs
+++ b/crates/aionui-ai-agent/src/stream_event.rs
@@ -115,6 +115,12 @@ pub struct ToolCallEventData {
     #[serde(default)]
     pub args: serde_json::Value,
     pub status: ToolCallStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -692,11 +698,49 @@ mod tests {
             name: "read_file".into(),
             args: json!({ "path": "/tmp/a.txt" }),
             status: ToolCallStatus::Running,
+            input: None,
+            output: None,
+            description: None,
         });
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["type"], "tool_call");
         assert_eq!(json["data"]["call_id"], "call-1");
         assert_eq!(json["data"]["status"], "running");
+    }
+
+    #[test]
+    fn tool_call_event_includes_enriched_fields() {
+        let event = AgentStreamEvent::ToolCall(ToolCallEventData {
+            call_id: "call-1".into(),
+            name: "Glob".into(),
+            args: json!({}),
+            status: ToolCallStatus::Completed,
+            input: Some(json!({ "pattern": "**/*.rs" })),
+            output: Some("src/main.rs\nsrc/lib.rs".into()),
+            description: Some("Search for Rust files".into()),
+        });
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "tool_call");
+        assert_eq!(json["data"]["input"]["pattern"], "**/*.rs");
+        assert_eq!(json["data"]["output"], "src/main.rs\nsrc/lib.rs");
+        assert_eq!(json["data"]["description"], "Search for Rust files");
+    }
+
+    #[test]
+    fn tool_call_event_omits_none_fields() {
+        let event = AgentStreamEvent::ToolCall(ToolCallEventData {
+            call_id: "call-1".into(),
+            name: "Glob".into(),
+            args: json!({}),
+            status: ToolCallStatus::Running,
+            input: None,
+            output: None,
+            description: None,
+        });
+        let json = serde_json::to_value(&event).unwrap();
+        assert!(json["data"].get("input").is_none());
+        assert!(json["data"].get("output").is_none());
+        assert!(json["data"].get("description").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Enrich `ToolCallEventData` with `input`, `output`, `description` fields so the frontend can render non-ACP tool calls (aionrs, nanobot) with the same card-style UI as ACP agents
- `BackendOutputSink` now carries parsed input/output and maintains consistent `call_id` pairing between tool start and result events
- Fix duplicate tool_call events: remove `ToolRunning` handler from `BackendProtocolSink` — display events are `OutputSink`'s responsibility, `ProtocolSink` should only handle the approval flow (`ToolRequest`/`ToolCancelled`)

## Test plan
- [x] `cargo test -p aionui-ai-agent` — all tests pass
- [x] `cargo clippy -p aionui-ai-agent -- -D warnings` — no warnings
- [ ] Manual test: aionrs agent shows single tool entry per call in View Steps (no duplicates)
- [ ] Manual test: ACP agent tool rendering unchanged (no regression)