### PR TITLE
refactor(ai-agent): consolidate ACP runtime snapshot and session routes

### DIFF
--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -4,16 +4,15 @@ use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::Duration;
 
-use crate::acp_protocol::{
-    AcpProtocol, CancelNotification, ContentBlock, LoadSessionRequest, NewSessionRequest,
-    PermissionDecision, PermissionRequest, PromptRequest, SessionId, SetSessionConfigOptionRequest,
-    SetSessionModeRequest, SetSessionModelRequest,
-};
-use crate::acp_runtime_snapshot::AcpRuntimeSnapshot;
+use crate::acp_protocol::{AcpProtocol, PermissionDecision, PermissionRequest};
 
-use crate::acp_runtime_snapshot::{
-    AgentCapabilities, SessionConfigOption, SessionModelState, UsageUpdate,
+use crate::acp_runtime_snapshot::AcpRuntimeSnapshot;
+use agent_client_protocol::schema::{
+    AgentCapabilities, CancelNotification, ContentBlock, LoadSessionRequest, NewSessionRequest,
+    PromptRequest, SessionConfigOption, SessionId, SessionModeState, SessionModelState,
+    SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest, UsageUpdate,
 };
+
 use crate::cli_process::CliAgentProcess;
 use crate::stream_event::{AgentStreamEvent, permission_request_to_event_data};
 use crate::types::{AcpBuildExtra, SendMessageData};
@@ -114,6 +113,94 @@ pub struct AcpAgentManager {
     closing: std::sync::atomic::AtomicBool,
     /// Shared skill manager — used to discover skills for first-message injection.
     skill_manager: Arc<crate::skill_manager::AcpSkillManager>,
+}
+
+impl AcpAgentManager {
+    /// Current session mode id. Falls back to the configured session mode,
+    /// then to `"default"`. Reading a cached snapshot is infallible.
+    pub async fn modes(&self) -> Option<SessionModeState> {
+        let snapshot = self.runtime_snapshot.read().await;
+        snapshot.modes().cloned()
+    }
+
+    async fn _set_modes(&self, mode: &str) -> Result<(), AppError> {
+        let sid = self.require_session_id().await?;
+        self.protocol
+            .set_mode(SetSessionModeRequest::new(
+                SessionId::new(sid),
+                mode.to_owned(),
+            ))
+            .await
+            .map_err(AppError::from)
+            .map(|_| ())
+    }
+
+    /// Cached model info from the ACP backend, if any has been received.
+    pub async fn model_info(&self) -> Option<SessionModelState> {
+        let snapshot = self.runtime_snapshot.read().await;
+        snapshot.model_info().cloned()
+    }
+
+    /// Set the model for the current session.
+    pub async fn set_model_info(&self, model_id: &str) -> Result<(), AppError> {
+        let sid = self.require_session_id().await?;
+
+        self.protocol
+            .set_model(SetSessionModelRequest::new(
+                SessionId::new(sid),
+                model_id.to_owned(),
+            ))
+            .await
+            .map_err(AppError::from)?;
+
+        // Update the snapshot immediately since SDK does not send a
+        // CurrentModelUpdate notification for model changes.
+        {
+            let mut snapshot = self.runtime_snapshot.write().await;
+            if let Some(info) = snapshot.model_info().cloned() {
+                let updated = SessionModelState::new(model_id.to_owned(), info.available_models);
+                snapshot.set_model_info(updated);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Cached session configuration options.
+    pub async fn config_options(&self) -> Vec<SessionConfigOption> {
+        let snapshot = self.runtime_snapshot.read().await;
+        snapshot
+            .config_options()
+            .map(<[SessionConfigOption]>::to_vec)
+            .unwrap_or_default()
+    }
+
+    /// Set a session configuration option.
+    pub async fn set_config_option(&self, config_id: &str, value: &str) -> Result<(), AppError> {
+        let sid = self.require_session_id().await?;
+
+        self.protocol
+            .set_config_option(SetSessionConfigOptionRequest::new(
+                SessionId::new(sid),
+                config_id.to_owned(),
+                value.to_owned(),
+            ))
+            .await
+            .map_err(AppError::from)
+            .map(|_| ())
+    }
+
+    /// Agent capabilities captured during the ACP initialize handshake.
+    pub async fn agent_capabilities(&self) -> Option<AgentCapabilities> {
+        let snapshot = self.runtime_snapshot.read().await;
+        snapshot.agent_capabilities().cloned()
+    }
+
+    /// Cached context usage info from the ACP backend.
+    pub async fn usage(&self) -> Option<UsageUpdate> {
+        let snapshot = self.runtime_snapshot.read().await;
+        snapshot.context_usage().cloned()
+    }
 }
 
 impl AcpAgentManager {
@@ -280,13 +367,28 @@ impl AcpAgentManager {
             crate::stream_event::StartEventData { session_id: None },
         ));
 
-        let session_id = self
+        let session_response = self
             .protocol
             .new_session(NewSessionRequest::new(&self.workspace))
             .await
             .map_err(AppError::from)?;
 
-        let sid = session_id.to_string();
+        let sid = session_response.session_id.to_string();
+
+        // Populate the runtime snapshot from the session response
+        {
+            let mut snapshot = self.runtime_snapshot.write().await;
+            if let Some(models) = session_response.models {
+                snapshot.set_model_info(models);
+            }
+            if let Some(modes) = session_response.modes {
+                snapshot.set_modes(modes);
+            }
+            if let Some(config_options) = session_response.config_options {
+                snapshot.set_config_options(config_options);
+            }
+        }
+        self.emit_snapshot_events().await;
         {
             let mut state = self.state.write().await;
             state.session_id = Some(sid.clone());
@@ -343,14 +445,28 @@ impl AcpAgentManager {
         if strategy == SessionResumeStrategy::SessionLoad
             && let Some(sid) = session_id
         {
-            self.protocol
+            let resp = self
+                .protocol
                 .load_session(LoadSessionRequest::new(
                     SessionId::new(sid),
                     &self.workspace,
                 ))
                 .await
                 .map_err(AppError::from)?;
+
+            let mut snapshot = self.runtime_snapshot.write().await;
+            if let Some(models) = resp.models {
+                snapshot.set_model_info(models);
+            }
+            if let Some(modes) = resp.modes {
+                snapshot.set_modes(modes);
+            }
+            if let Some(config_options) = resp.config_options {
+                snapshot.set_config_options(config_options);
+            }
         }
+
+        self.emit_snapshot_events().await;
 
         self.prompt_existing_session(data, session_id).await
     }
@@ -389,69 +505,47 @@ impl AcpAgentManager {
         Ok(())
     }
 
-    // -- ACP-specific extended methods (beyond IAgentManager) --
+    /// Emit model/mode/config events from the current snapshot so the frontend
+    /// receives the initial session state via WebSocket immediately after
+    /// session creation or load.
+    async fn emit_snapshot_events(&self) {
+        use aionui_api_types::{ModelInfoEntry, ModelInfoPayload};
 
-    /// Current session mode id. Falls back to the configured session mode,
-    /// then to `"default"`. Reading a cached snapshot is infallible.
-    pub async fn mode_id(&self) -> String {
         let snapshot = self.runtime_snapshot.read().await;
-        snapshot
-            .current_mode_id()
-            .or_else(|| self.config.session_mode.clone())
-            .unwrap_or_else(|| "default".to_owned())
-    }
-
-    /// Cached model info from the ACP backend, if any has been received.
-    pub async fn model_info(&self) -> Option<SessionModelState> {
-        let snapshot = self.runtime_snapshot.read().await;
-        snapshot.model_info().cloned()
-    }
-
-    /// Cached session configuration options.
-    pub async fn config_options(&self) -> Vec<SessionConfigOption> {
-        let snapshot = self.runtime_snapshot.read().await;
-        snapshot
-            .config_options()
-            .map(<[SessionConfigOption]>::to_vec)
-            .unwrap_or_default()
-    }
-
-    /// Agent capabilities captured during the ACP initialize handshake.
-    pub async fn agent_capabilities(&self) -> Option<AgentCapabilities> {
-        let snapshot = self.runtime_snapshot.read().await;
-        snapshot.agent_capabilities().cloned()
-    }
-
-    /// Cached context usage info from the ACP backend.
-    pub async fn usage(&self) -> Option<UsageUpdate> {
-        let snapshot = self.runtime_snapshot.read().await;
-        snapshot.context_usage().cloned()
-    }
-    /// Set the model for the current session.
-    pub async fn set_model(&self, model_id: &str) -> Result<(), AppError> {
-        let sid = self.require_session_id().await?;
-
-        self.protocol
-            .set_model(SetSessionModelRequest::new(
-                SessionId::new(sid),
-                model_id.to_owned(),
-            ))
-            .await
-            .map_err(AppError::from)
-    }
-
-    /// Set a session configuration option.
-    pub async fn set_config_option(&self, config_id: &str, value: &str) -> Result<(), AppError> {
-        let sid = self.require_session_id().await?;
-
-        self.protocol
-            .set_config_option(SetSessionConfigOptionRequest::new(
-                SessionId::new(sid),
-                config_id.to_owned(),
-                value.to_owned(),
-            ))
-            .await
-            .map_err(AppError::from)
+        if let Some(models) = snapshot.model_info() {
+            let current_id = models.current_model_id.to_string();
+            let available: Vec<ModelInfoEntry> = models
+                .available_models
+                .iter()
+                .map(|am| ModelInfoEntry {
+                    id: am.model_id.to_string(),
+                    label: am.name.clone(),
+                })
+                .collect();
+            let current_label = available
+                .iter()
+                .find(|e| e.id == current_id)
+                .map(|e| e.label.clone())
+                .unwrap_or_else(|| current_id.clone());
+            let payload = ModelInfoPayload {
+                current_model_id: Some(current_id),
+                current_model_label: Some(current_label),
+                available_models: available,
+            };
+            if let Ok(v) = serde_json::to_value(&payload) {
+                let _ = self.event_tx.send(AgentStreamEvent::AcpModelInfo(v));
+            }
+        }
+        if let Some(modes) = snapshot.modes()
+            && let Ok(v) = serde_json::to_value(modes)
+        {
+            let _ = self.event_tx.send(AgentStreamEvent::AcpModeInfo(v));
+        }
+        if let Some(config_options) = snapshot.config_options()
+            && let Ok(v) = serde_json::to_value(config_options)
+        {
+            let _ = self.event_tx.send(AgentStreamEvent::AcpConfigOption(v));
+        }
     }
 
     /// Request the ACP backend to load available slash commands.
@@ -605,7 +699,12 @@ impl crate::agent_manager::IAgentManager for AcpAgentManager {
 
     async fn get_mode(&self) -> Result<aionui_api_types::AgentModeResponse, AppError> {
         Ok(aionui_api_types::AgentModeResponse {
-            mode: self.mode_id().await,
+            mode: self
+                .modes()
+                .await
+                .map(|modes| modes.current_mode_id.to_string())
+                .or_else(|| self.config.session_mode.clone())
+                .unwrap_or_else(|| "default".to_owned()),
             initialized: self.session_id().await.is_some(),
         })
     }
@@ -619,6 +718,7 @@ impl crate::agent_manager::IAgentManager for AcpAgentManager {
             ))
             .await
             .map_err(AppError::from)
+            .map(|_| ())
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -4,22 +4,27 @@ use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::Duration;
 
-use aionui_common::{
-    AcpBackend, AgentKillReason, AgentType, AppError, CommandSpec, Confirmation,
-    ConversationStatus, TimestampMs, now_ms,
-};
-use serde_json::{Value, json};
-use tokio::sync::{Mutex, RwLock, broadcast, mpsc, oneshot};
-use tracing::{debug, error, info};
-
 use crate::acp_protocol::{
     AcpProtocol, CancelNotification, ContentBlock, LoadSessionRequest, NewSessionRequest,
     PermissionDecision, PermissionRequest, PromptRequest, SessionId, SetSessionConfigOptionRequest,
     SetSessionModeRequest, SetSessionModelRequest,
 };
+use crate::acp_runtime_snapshot::AcpRuntimeSnapshot;
+
+use crate::acp_runtime_snapshot::{
+    AgentCapabilities, SessionConfigOption, SessionModelState, UsageUpdate,
+};
 use crate::cli_process::CliAgentProcess;
 use crate::stream_event::{AgentStreamEvent, permission_request_to_event_data};
-use crate::types::{AcpBuildExtra, AcpModelInfo, SendMessageData};
+use crate::types::{AcpBuildExtra, SendMessageData};
+
+use aionui_common::{
+    AcpBackend, AgentKillReason, AgentType, AppError, CommandSpec, Confirmation,
+    ConversationStatus, TimestampMs, now_ms,
+};
+use serde_json::Value;
+use tokio::sync::{Mutex, RwLock, broadcast, mpsc, oneshot};
+use tracing::{debug, error, info};
 
 /// Grace period before force-killing an ACP process (ms).
 const ACP_KILL_GRACE_MS: u64 = 500;
@@ -61,8 +66,6 @@ struct AcpState {
     status: Option<ConversationStatus>,
     /// Active session ID (set after session/new or session/load).
     session_id: Option<String>,
-    /// Model info from ACP backend.
-    model_info: Option<AcpModelInfo>,
     /// Whether this session has sent at least one message.
     has_messages: bool,
 }
@@ -105,6 +108,8 @@ pub struct AcpAgentManager {
     permission_rx: Mutex<mpsc::Receiver<PermissionRequest>>,
     /// Pending ACP permission responders keyed by tool call ID.
     pending_permissions: StdMutex<HashMap<String, oneshot::Sender<PermissionDecision>>>,
+    /// Runtime ACP session snapshot used by getters.
+    runtime_snapshot: RwLock<AcpRuntimeSnapshot>,
     /// Whether a graceful shutdown is in progress.
     closing: std::sync::atomic::AtomicBool,
     /// Shared skill manager — used to discover skills for first-message injection.
@@ -152,6 +157,11 @@ impl AcpAgentManager {
                 AppError::from(e)
             })?;
 
+        let mut runtime_snapshot = AcpRuntimeSnapshot::default();
+        if let Some(agent_capabilities) = protocol.agent_capabilities() {
+            runtime_snapshot.set_agent_capabilities(agent_capabilities);
+        }
+
         let manager = Self {
             conversation_id,
             workspace,
@@ -164,13 +174,13 @@ impl AcpAgentManager {
             state: RwLock::new(AcpState {
                 status: None,
                 session_id: None,
-                model_info: None,
                 has_messages: false,
             }),
             last_activity: AtomicI64::new(now_ms()),
             session_lock: Mutex::new(()),
             permission_rx: Mutex::new(permission_rx),
             pending_permissions: StdMutex::new(HashMap::new()),
+            runtime_snapshot: RwLock::new(runtime_snapshot),
             closing: std::sync::atomic::AtomicBool::new(false),
             skill_manager,
         };
@@ -186,35 +196,51 @@ impl AcpAgentManager {
     /// responses routed through the `confirm()` method.
     pub fn start_permission_handler(self: &Arc<Self>) {
         let this = Arc::clone(self);
-        tokio::spawn(async move { this.run_permission_handler().await });
+        tokio::spawn(async move {
+            let mut rx = this.permission_rx.lock().await;
+
+            while let Some(perm_req) = rx.recv().await {
+                this.last_activity.store(now_ms(), Ordering::Relaxed);
+
+                let call_id = perm_req.request.tool_call.tool_call_id.to_string();
+
+                let mut pending = this.pending_permissions.lock().unwrap();
+                if let Some(previous) = pending.insert(call_id.clone(), perm_req.response_tx) {
+                    let _ = previous.send(PermissionDecision::Cancelled);
+                }
+                drop(pending);
+
+                let permission_event = permission_request_to_event_data(&perm_req.request);
+
+                if this
+                    .event_tx
+                    .send(AgentStreamEvent::AcpPermission(permission_event))
+                    .is_err()
+                    && let Some(response_tx) =
+                        this.pending_permissions.lock().unwrap().remove(&call_id)
+                {
+                    let _ = response_tx.send(PermissionDecision::Cancelled);
+                }
+            }
+        });
     }
 
-    /// Run the permission handler loop.
-    async fn run_permission_handler(self: Arc<Self>) {
-        let mut rx = self.permission_rx.lock().await;
-
-        while let Some(perm_req) = rx.recv().await {
-            self.last_activity.store(now_ms(), Ordering::Relaxed);
-
-            let call_id = perm_req.request.tool_call.tool_call_id.to_string();
-
-            let mut pending = self.pending_permissions.lock().unwrap();
-            if let Some(previous) = pending.insert(call_id.clone(), perm_req.response_tx) {
-                let _ = previous.send(PermissionDecision::Cancelled);
+    /// Start the runtime snapshot tracker loop.
+    pub fn start_runtime_snapshot_tracker(self: &Arc<Self>) {
+        let this = Arc::clone(self);
+        tokio::spawn(async move {
+            let mut rx = this.event_tx.subscribe();
+            loop {
+                match rx.recv().await {
+                    Ok(event) => {
+                        let mut snapshot = this.runtime_snapshot.write().await;
+                        snapshot.apply_event(&event);
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                }
             }
-            drop(pending);
-
-            let permission_event = permission_request_to_event_data(&perm_req.request);
-
-            if self
-                .event_tx
-                .send(AgentStreamEvent::AcpPermission(permission_event))
-                .is_err()
-                && let Some(response_tx) = self.pending_permissions.lock().unwrap().remove(&call_id)
-            {
-                let _ = response_tx.send(PermissionDecision::Cancelled);
-            }
-        }
+        });
     }
 
     /// Initialize or resume a session, then send the user message.
@@ -365,47 +391,45 @@ impl AcpAgentManager {
 
     // -- ACP-specific extended methods (beyond IAgentManager) --
 
-    /// Query the ACP backend for current session mode.
-    pub async fn acp_get_mode(&self) -> Result<Value, AppError> {
-        // With the SDK, mode info arrives via session update events.
-        // We return a placeholder — the actual mode is tracked internally.
-        Ok(json!({ "sent": true }))
+    /// Current session mode id. Falls back to the configured session mode,
+    /// then to `"default"`. Reading a cached snapshot is infallible.
+    pub async fn mode_id(&self) -> String {
+        let snapshot = self.runtime_snapshot.read().await;
+        snapshot
+            .current_mode_id()
+            .or_else(|| self.config.session_mode.clone())
+            .unwrap_or_else(|| "default".to_owned())
     }
 
-    /// Set the session mode via ACP protocol.
-    pub async fn acp_set_mode(&self, mode: &str) -> Result<(), AppError> {
-        let sid = self
-            .state
-            .read()
-            .await
-            .session_id
-            .clone()
-            .ok_or_else(|| AppError::BadRequest("No active session".into()))?;
-
-        self.protocol
-            .set_mode(SetSessionModeRequest::new(
-                SessionId::new(sid),
-                mode.to_owned(),
-            ))
-            .await
-            .map_err(AppError::from)
+    /// Cached model info from the ACP backend, if any has been received.
+    pub async fn model_info(&self) -> Option<SessionModelState> {
+        let snapshot = self.runtime_snapshot.read().await;
+        snapshot.model_info().cloned()
     }
 
-    /// Get model info from the ACP backend.
-    pub async fn get_model_info(&self) -> Option<AcpModelInfo> {
-        let state = self.state.read().await;
-        state.model_info.clone()
+    /// Cached session configuration options.
+    pub async fn config_options(&self) -> Vec<SessionConfigOption> {
+        let snapshot = self.runtime_snapshot.read().await;
+        snapshot
+            .config_options()
+            .map(<[SessionConfigOption]>::to_vec)
+            .unwrap_or_default()
     }
 
+    /// Agent capabilities captured during the ACP initialize handshake.
+    pub async fn agent_capabilities(&self) -> Option<AgentCapabilities> {
+        let snapshot = self.runtime_snapshot.read().await;
+        snapshot.agent_capabilities().cloned()
+    }
+
+    /// Cached context usage info from the ACP backend.
+    pub async fn usage(&self) -> Option<UsageUpdate> {
+        let snapshot = self.runtime_snapshot.read().await;
+        snapshot.context_usage().cloned()
+    }
     /// Set the model for the current session.
     pub async fn set_model(&self, model_id: &str) -> Result<(), AppError> {
-        let sid = self
-            .state
-            .read()
-            .await
-            .session_id
-            .clone()
-            .ok_or_else(|| AppError::BadRequest("No active session".into()))?;
+        let sid = self.require_session_id().await?;
 
         self.protocol
             .set_model(SetSessionModelRequest::new(
@@ -416,21 +440,9 @@ impl AcpAgentManager {
             .map_err(AppError::from)
     }
 
-    /// Get the session configuration options.
-    pub async fn get_config_options(&self) -> Result<(), AppError> {
-        // Config options arrive via session update events.
-        Ok(())
-    }
-
     /// Set a session configuration option.
     pub async fn set_config_option(&self, config_id: &str, value: &str) -> Result<(), AppError> {
-        let sid = self
-            .state
-            .read()
-            .await
-            .session_id
-            .clone()
-            .ok_or_else(|| AppError::BadRequest("No active session".into()))?;
+        let sid = self.require_session_id().await?;
 
         self.protocol
             .set_config_option(SetSessionConfigOptionRequest::new(
@@ -442,21 +454,31 @@ impl AcpAgentManager {
             .map_err(AppError::from)
     }
 
-    /// Load available slash commands from the ACP backend.
+    /// Request the ACP backend to load available slash commands.
+    ///
+    /// Results arrive asynchronously via `AvailableCommandsUpdate` events.
     pub async fn load_slash_commands(&self) -> Result<(), AppError> {
-        // Slash commands arrive via AvailableCommandsUpdate events.
         Ok(())
     }
 
-    /// Get the session ID.
+    /// Current ACP session ID, if a session has been established.
     pub async fn session_id(&self) -> Option<String> {
-        let state = self.state.read().await;
-        state.session_id.clone()
+        self.state.read().await.session_id.clone()
     }
 
-    /// Get the ACP backend type.
+    /// ACP sub-backend (Claude, Codex, …).
     pub fn backend(&self) -> AcpBackend {
         self.backend
+    }
+
+    /// Return the active session id or a `BadRequest` error.
+    async fn require_session_id(&self) -> Result<String, AppError> {
+        self.state
+            .read()
+            .await
+            .session_id
+            .clone()
+            .ok_or_else(|| AppError::BadRequest("No active session".into()))
     }
 }
 
@@ -582,15 +604,21 @@ impl crate::agent_manager::IAgentManager for AcpAgentManager {
     }
 
     async fn get_mode(&self) -> Result<aionui_api_types::AgentModeResponse, AppError> {
-        self.acp_get_mode().await?;
         Ok(aionui_api_types::AgentModeResponse {
-            mode: String::new(),
+            mode: self.mode_id().await,
             initialized: self.session_id().await.is_some(),
         })
     }
 
     async fn set_mode(&self, mode: &str) -> Result<(), AppError> {
-        self.acp_set_mode(mode).await
+        let sid = self.require_session_id().await?;
+        self.protocol
+            .set_mode(SetSessionModeRequest::new(
+                SessionId::new(sid),
+                mode.to_owned(),
+            ))
+            .await
+            .map_err(AppError::from)
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -601,6 +629,7 @@ impl crate::agent_manager::IAgentManager for AcpAgentManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn session_resume_strategy_for_backends() {

--- a/crates/aionui-ai-agent/src/acp_protocol.rs
+++ b/crates/aionui-ai-agent/src/acp_protocol.rs
@@ -12,9 +12,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
 use agent_client_protocol::schema::{
-    ClientNotification, ClientRequest, InitializeRequest, ProtocolVersion,
-    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
-    SelectedPermissionOutcome, SessionNotification,
+    AGENT_METHOD_NAMES, AuthenticateResponse, ClientNotification, ClientRequest,
+    CloseSessionResponse, ExtResponse, ForkSessionResponse, InitializeRequest, LoadSessionResponse,
+    PromptResponse, ProtocolVersion, RequestPermissionOutcome, RequestPermissionRequest,
+    RequestPermissionResponse, ResumeSessionResponse, SelectedPermissionOutcome,
+    SessionNotification, SetSessionConfigOptionResponse, SetSessionModeResponse,
+    SetSessionModelResponse,
 };
 use agent_client_protocol::{
     Agent, ByteStreams, Client, ConnectionTo, on_receive_notification, on_receive_request,
@@ -30,10 +33,11 @@ use crate::stream_event::{self, AgentStreamEvent};
 
 // Re-export SDK types used in public method signatures.
 pub use agent_client_protocol::schema::{
-    AuthenticateRequest, CancelNotification, CloseSessionRequest, ContentBlock, ExtNotification,
-    ExtRequest, ForkSessionRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse,
-    LoadSessionRequest, McpServer, Meta, NewSessionRequest, PromptRequest, ResumeSessionRequest,
-    SessionId, SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest,
+    AgentCapabilities, AuthenticateRequest, CancelNotification, CloseSessionRequest, ContentBlock,
+    ExtNotification, ExtRequest, ForkSessionRequest, InitializeResponse, ListSessionsRequest,
+    ListSessionsResponse, LoadSessionRequest, McpServer, Meta, NewSessionRequest,
+    NewSessionResponse, PromptRequest, ResumeSessionRequest, SessionId,
+    SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest,
 };
 
 /// Type alias to shorten `agent_client_protocol::Responder<RequestPermissionResponse>`.
@@ -58,60 +62,78 @@ pub enum PermissionDecision {
     Cancelled,
 }
 
+/// Commands constructed by SDK callbacks and dispatched to handle agent→client messages.
+///
+/// Mirrors [`AcpClientCommand`] for the reverse direction. Each callback
+/// builds the appropriate variant and calls [`dispatch_agent_command`].
+enum AcpAgentCommand {
+    /// Agent sent a session update notification (streaming chunks, tool calls, etc.).
+    SessionUpdate {
+        notification: SessionNotification,
+        reply_tx: broadcast::Sender<AgentStreamEvent>,
+    },
+    /// Agent requests permission from the user before performing an action.
+    RequestPermission {
+        request: RequestPermissionRequest,
+        responder: PermissionResponder,
+        reply_tx: mpsc::Sender<PermissionRequest>,
+    },
+}
+
 // ── Internal command protocol ────────────────────────────────────────────
 
 /// Commands sent from `AcpProtocol` methods to the SDK event loop.
-enum AcpCommand {
+enum AcpClientCommand {
     NewSession {
         req: NewSessionRequest,
-        reply: oneshot::Sender<Result<SessionId, AcpError>>,
+        reply_tx: oneshot::Sender<Result<NewSessionResponse, AcpError>>,
     },
     LoadSession {
         req: LoadSessionRequest,
-        reply: oneshot::Sender<Result<(), AcpError>>,
+        reply_tx: oneshot::Sender<Result<LoadSessionResponse, AcpError>>,
     },
     ForkSession {
         req: ForkSessionRequest,
-        reply: oneshot::Sender<Result<SessionId, AcpError>>,
+        reply_tx: oneshot::Sender<Result<ForkSessionResponse, AcpError>>,
     },
     ResumeSession {
         req: ResumeSessionRequest,
-        reply: oneshot::Sender<Result<(), AcpError>>,
+        reply_tx: oneshot::Sender<Result<ResumeSessionResponse, AcpError>>,
     },
     CloseSession {
         req: CloseSessionRequest,
-        reply: oneshot::Sender<Result<(), AcpError>>,
+        reply_tx: oneshot::Sender<Result<CloseSessionResponse, AcpError>>,
     },
     Prompt {
         req: PromptRequest,
-        reply: oneshot::Sender<Result<(), AcpError>>,
+        reply_tx: oneshot::Sender<Result<PromptResponse, AcpError>>,
     },
     Cancel {
         notification: CancelNotification,
     },
     SetMode {
         req: SetSessionModeRequest,
-        reply: oneshot::Sender<Result<(), AcpError>>,
+        reply_tx: oneshot::Sender<Result<SetSessionModeResponse, AcpError>>,
     },
     SetModel {
         req: SetSessionModelRequest,
-        reply: oneshot::Sender<Result<(), AcpError>>,
+        reply_tx: oneshot::Sender<Result<SetSessionModelResponse, AcpError>>,
     },
     SetConfigOption {
         req: SetSessionConfigOptionRequest,
-        reply: oneshot::Sender<Result<(), AcpError>>,
+        reply_tx: oneshot::Sender<Result<SetSessionConfigOptionResponse, AcpError>>,
     },
     ListSessions {
         req: ListSessionsRequest,
-        reply: oneshot::Sender<Result<ListSessionsResponse, AcpError>>,
+        reply_tx: oneshot::Sender<Result<ListSessionsResponse, AcpError>>,
     },
     Authenticate {
         req: AuthenticateRequest,
-        reply: oneshot::Sender<Result<(), AcpError>>,
+        reply_tx: oneshot::Sender<Result<AuthenticateResponse, AcpError>>,
     },
     ExtMethod {
         req: ExtRequest,
-        reply: oneshot::Sender<Result<serde_json::Value, AcpError>>,
+        reply_tx: oneshot::Sender<Result<ExtResponse, AcpError>>,
     },
     ExtNotify {
         notification: ExtNotification,
@@ -126,7 +148,7 @@ pub struct AcpProtocol {
     /// Background task handle (SDK transport + routing).
     _bg_task: JoinHandle<()>,
     /// Command sender to the SDK event loop.
-    cmd_tx: mpsc::Sender<AcpCommand>,
+    cmd_tx: mpsc::Sender<AcpClientCommand>,
     /// Whether the SDK connection is still alive.
     alive: Arc<AtomicBool>,
     /// Cached initialize response from the ACP handshake.
@@ -150,7 +172,7 @@ impl AcpProtocol {
         let initialize_response = Arc::new(RwLock::new(None));
 
         // Command channel: external methods → SDK event loop
-        let (cmd_tx, cmd_rx) = mpsc::channel::<AcpCommand>(32);
+        let (cmd_tx, cmd_rx) = mpsc::channel::<AcpClientCommand>(32);
 
         // Signal that init completed successfully
         let (init_tx, init_rx) = oneshot::channel::<Result<InitializeResponse, AcpError>>();
@@ -193,48 +215,81 @@ impl AcpProtocol {
         self.initialize_response.read().unwrap().clone()
     }
 
-    pub fn agent_capabilities(&self) -> Option<agent_client_protocol::schema::AgentCapabilities> {
+    pub fn agent_capabilities(&self) -> Option<AgentCapabilities> {
         self.initialize_response()
             .map(|response| response.agent_capabilities)
     }
 
     /// Create a new ACP session.
-    pub async fn new_session(&self, req: NewSessionRequest) -> Result<SessionId, AcpError> {
-        self.send_cmd(|reply| AcpCommand::NewSession { req, reply })
-            .await
+    pub async fn new_session(
+        &self,
+        req: NewSessionRequest,
+    ) -> Result<NewSessionResponse, AcpError> {
+        self.send_cmd(|reply| AcpClientCommand::NewSession {
+            req,
+            reply_tx: reply,
+        })
+        .await
     }
 
     /// Load (resume) an existing ACP session.
-    pub async fn load_session(&self, req: LoadSessionRequest) -> Result<(), AcpError> {
-        self.send_cmd(|reply| AcpCommand::LoadSession { req, reply })
-            .await
+    pub async fn load_session(
+        &self,
+        req: LoadSessionRequest,
+    ) -> Result<LoadSessionResponse, AcpError> {
+        self.send_cmd(|reply| AcpClientCommand::LoadSession {
+            req,
+            reply_tx: reply,
+        })
+        .await
     }
 
     /// Fork an existing ACP session into a new session.
-    pub async fn fork_session(&self, req: ForkSessionRequest) -> Result<SessionId, AcpError> {
-        self.send_cmd(|reply| AcpCommand::ForkSession { req, reply })
-            .await
+    pub async fn fork_session(
+        &self,
+        req: ForkSessionRequest,
+    ) -> Result<ForkSessionResponse, AcpError> {
+        self.send_cmd(|reply| AcpClientCommand::ForkSession {
+            req,
+            reply_tx: reply,
+        })
+        .await
     }
 
     /// Resume an existing ACP session.
-    pub async fn resume_session(&self, req: ResumeSessionRequest) -> Result<(), AcpError> {
-        self.send_cmd(|reply| AcpCommand::ResumeSession { req, reply })
-            .await
+    pub async fn resume_session(
+        &self,
+        req: ResumeSessionRequest,
+    ) -> Result<ResumeSessionResponse, AcpError> {
+        self.send_cmd(|reply| AcpClientCommand::ResumeSession {
+            req,
+            reply_tx: reply,
+        })
+        .await
     }
 
     /// Close an ACP session.
-    pub async fn close_session(&self, req: CloseSessionRequest) -> Result<(), AcpError> {
-        self.send_cmd(|reply| AcpCommand::CloseSession { req, reply })
-            .await
+    pub async fn close_session(
+        &self,
+        req: CloseSessionRequest,
+    ) -> Result<CloseSessionResponse, AcpError> {
+        self.send_cmd(|reply| AcpClientCommand::CloseSession {
+            req,
+            reply_tx: reply,
+        })
+        .await
     }
 
     /// Send a prompt to the agent in an active session.
     ///
     /// Blocks until the agent returns a `PromptResponse` (turn completed).
     /// Streaming events arrive via the `event_tx` broadcast channel.
-    pub async fn prompt(&self, req: PromptRequest) -> Result<(), AcpError> {
-        self.send_cmd(|reply| AcpCommand::Prompt { req, reply })
-            .await
+    pub async fn prompt(&self, req: PromptRequest) -> Result<PromptResponse, AcpError> {
+        self.send_cmd(|reply| AcpClientCommand::Prompt {
+            req,
+            reply_tx: reply,
+        })
+        .await
     }
 
     /// Cancel the current prompt in a session (fire-and-forget notification).
@@ -242,28 +297,45 @@ impl AcpProtocol {
         if !self.is_connected() {
             return;
         }
-        let _ = self.cmd_tx.try_send(AcpCommand::Cancel { notification });
+        let _ = self
+            .cmd_tx
+            .try_send(AcpClientCommand::Cancel { notification });
     }
 
     /// Set the session mode.
-    pub async fn set_mode(&self, req: SetSessionModeRequest) -> Result<(), AcpError> {
-        self.send_cmd(|reply| AcpCommand::SetMode { req, reply })
-            .await
+    pub async fn set_mode(
+        &self,
+        req: SetSessionModeRequest,
+    ) -> Result<SetSessionModeResponse, AcpError> {
+        self.send_cmd(|reply| AcpClientCommand::SetMode {
+            req,
+            reply_tx: reply,
+        })
+        .await
     }
 
     /// Set the session model.
-    pub async fn set_model(&self, req: SetSessionModelRequest) -> Result<(), AcpError> {
-        self.send_cmd(|reply| AcpCommand::SetModel { req, reply })
-            .await
+    pub async fn set_model(
+        &self,
+        req: SetSessionModelRequest,
+    ) -> Result<SetSessionModelResponse, AcpError> {
+        self.send_cmd(|reply| AcpClientCommand::SetModel {
+            req,
+            reply_tx: reply,
+        })
+        .await
     }
 
     /// Set a session config option.
     pub async fn set_config_option(
         &self,
         req: SetSessionConfigOptionRequest,
-    ) -> Result<(), AcpError> {
-        self.send_cmd(|reply| AcpCommand::SetConfigOption { req, reply })
-            .await
+    ) -> Result<SetSessionConfigOptionResponse, AcpError> {
+        self.send_cmd(|reply| AcpClientCommand::SetConfigOption {
+            req,
+            reply_tx: reply,
+        })
+        .await
     }
 
     /// List sessions, optionally filtered by working directory.
@@ -271,22 +343,34 @@ impl AcpProtocol {
         &self,
         req: ListSessionsRequest,
     ) -> Result<ListSessionsResponse, AcpError> {
-        self.send_cmd(|reply| AcpCommand::ListSessions { req, reply })
-            .await
+        self.send_cmd(|reply| AcpClientCommand::ListSessions {
+            req,
+            reply_tx: reply,
+        })
+        .await
     }
 
     /// Authenticate with the agent using a previously advertised auth method.
-    pub async fn authenticate(&self, req: AuthenticateRequest) -> Result<(), AcpError> {
-        self.send_cmd(|reply| AcpCommand::Authenticate { req, reply })
-            .await
+    pub async fn authenticate(
+        &self,
+        req: AuthenticateRequest,
+    ) -> Result<AuthenticateResponse, AcpError> {
+        self.send_cmd(|reply| AcpClientCommand::Authenticate {
+            req,
+            reply_tx: reply,
+        })
+        .await
     }
 
     /// Send an extension request (method name must start with `_`).
     ///
     /// Returns the raw JSON response value from the agent.
-    pub async fn ext_request(&self, req: ExtRequest) -> Result<serde_json::Value, AcpError> {
-        self.send_cmd(|reply| AcpCommand::ExtMethod { req, reply })
-            .await
+    pub async fn ext_request(&self, req: ExtRequest) -> Result<ExtResponse, AcpError> {
+        self.send_cmd(|reply| AcpClientCommand::ExtMethod {
+            req,
+            reply_tx: reply,
+        })
+        .await
     }
 
     /// Send an extension notification (fire-and-forget, method name must start with `_`).
@@ -294,7 +378,9 @@ impl AcpProtocol {
         if !self.is_connected() {
             return;
         }
-        let _ = self.cmd_tx.try_send(AcpCommand::ExtNotify { notification });
+        let _ = self
+            .cmd_tx
+            .try_send(AcpClientCommand::ExtNotify { notification });
     }
 
     /// Check whether the SDK connection is still alive.
@@ -307,7 +393,7 @@ impl AcpProtocol {
     /// Send a command to the SDK event loop and wait for the reply.
     async fn send_cmd<T>(
         &self,
-        build: impl FnOnce(oneshot::Sender<Result<T, AcpError>>) -> AcpCommand,
+        build: impl FnOnce(oneshot::Sender<Result<T, AcpError>>) -> AcpClientCommand,
     ) -> Result<T, AcpError> {
         self.ensure_connected()?;
         let (tx, rx) = oneshot::channel();
@@ -361,7 +447,7 @@ async fn run_sdk_event_loop(
     stdout: ChildStdout,
     event_tx: broadcast::Sender<AgentStreamEvent>,
     permission_tx: mpsc::Sender<PermissionRequest>,
-    cmd_rx: mpsc::Receiver<AcpCommand>,
+    cmd_rx: mpsc::Receiver<AcpClientCommand>,
     init_tx: oneshot::Sender<Result<InitializeResponse, AcpError>>,
     alive: Arc<AtomicBool>,
 ) {
@@ -371,14 +457,12 @@ async fn run_sdk_event_loop(
         .builder()
         .on_receive_notification(
             {
-                let event_tx = event_tx.clone();
                 async move |notification: SessionNotification, _cx: ConnectionTo<Agent>| {
-                    log_incoming("session/update", &json_str(&notification));
-
-                    let events = stream_event::session_notification_to_events(&notification);
-                    for event in events {
-                        let _ = event_tx.send(event);
-                    }
+                    let cmd = AcpAgentCommand::SessionUpdate {
+                        notification,
+                        reply_tx: event_tx.clone(),
+                    };
+                    dispatch_agent_command(cmd).await;
                     Ok(())
                 }
             },
@@ -386,42 +470,16 @@ async fn run_sdk_event_loop(
         )
         .on_receive_request(
             {
-                let permission_tx = permission_tx.clone();
                 async move |request: RequestPermissionRequest,
                             responder: PermissionResponder,
                             _cx: ConnectionTo<Agent>| {
-                    log_incoming("session/request_permission", &json_str(&request));
-
-                    let (resp_tx, resp_rx) = oneshot::channel();
-
-                    let perm_req = PermissionRequest {
+                    let cmd = AcpAgentCommand::RequestPermission {
                         request,
-                        response_tx: resp_tx,
+                        responder,
+                        reply_tx: permission_tx.clone(),
                     };
-
-                    if permission_tx.send(perm_req).await.is_err() {
-                        warn!("Permission channel closed, cancelling request");
-                        return responder.respond(RequestPermissionResponse::new(
-                            RequestPermissionOutcome::Cancelled,
-                        ));
-                    }
-
-                    match resp_rx.await {
-                        Ok(PermissionDecision::Selected { option_id }) => {
-                            let respond =
-                                RequestPermissionResponse::new(RequestPermissionOutcome::Selected(
-                                    SelectedPermissionOutcome::new(option_id),
-                                ));
-                            log_outgoing("session/request_permission", &json_str(&respond));
-                            responder.respond(respond)
-                        }
-                        Ok(PermissionDecision::Cancelled) | Err(_) => {
-                            let respond =
-                                RequestPermissionResponse::new(RequestPermissionOutcome::Cancelled);
-                            log_outgoing("session/request_permission", &json_str(&respond));
-                            responder.respond(respond)
-                        }
-                    }
+                    dispatch_agent_command(cmd).await;
+                    Ok(())
                 }
             },
             on_receive_request!(),
@@ -435,7 +493,7 @@ async fn run_sdk_event_loop(
 
                 // Command loop: process requests from AcpProtocol methods
                 while let Some(cmd) = cmd_rx.recv().await {
-                    dispatch_command(&connection, cmd).await;
+                    dispatch_client_command(&connection, cmd).await;
                 }
 
                 debug!("ACP command channel closed, connection ending");
@@ -453,96 +511,171 @@ async fn run_sdk_event_loop(
     }
 }
 
-/// Dispatch a single [`AcpCommand`] over the connection.
-async fn dispatch_command(connection: &ConnectionTo<Agent>, cmd: AcpCommand) {
+/// Dispatch a single [`AcpClientCommand`] over the connection.
+///
+/// Mirrored by [`dispatch_agent_command`] for the reverse direction.
+async fn dispatch_client_command(connection: &ConnectionTo<Agent>, cmd: AcpClientCommand) {
     match cmd {
-        AcpCommand::NewSession { req, reply } => {
+        AcpClientCommand::NewSession {
+            req,
+            reply_tx: reply,
+        } => {
+            let _ = reply.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_new).await);
+        }
+        AcpClientCommand::ForkSession {
+            req,
+            reply_tx: reply,
+        } => {
+            let _ =
+                reply.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_fork).await);
+        }
+        AcpClientCommand::LoadSession {
+            req,
+            reply_tx: reply,
+        } => {
+            let _ =
+                reply.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_load).await);
+        }
+        AcpClientCommand::ResumeSession {
+            req,
+            reply_tx: reply,
+        } => {
+            let _ =
+                reply.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_resume).await);
+        }
+        AcpClientCommand::CloseSession {
+            req,
+            reply_tx: reply,
+        } => {
+            let _ =
+                reply.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_close).await);
+        }
+        AcpClientCommand::Prompt {
+            req,
+            reply_tx: reply,
+        } => {
+            let _ =
+                reply.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_prompt).await);
+        }
+        AcpClientCommand::SetMode {
+            req,
+            reply_tx: reply,
+        } => {
+            let _ = reply
+                .send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_set_mode).await);
+        }
+        AcpClientCommand::SetModel {
+            req,
+            reply_tx: reply,
+        } => {
+            let _ = reply
+                .send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_set_model).await);
+        }
+        AcpClientCommand::SetConfigOption {
+            req,
+            reply_tx: reply,
+        } => {
             let _ = reply.send(
-                send_and_log(connection, req, "session/new")
-                    .await
-                    .map(|r| r.session_id),
+                send_and_log(
+                    connection,
+                    req,
+                    AGENT_METHOD_NAMES.session_set_config_option,
+                )
+                .await,
             );
         }
-        AcpCommand::ForkSession { req, reply } => {
-            let _ = reply.send(
-                send_and_log(connection, req, "session/fork")
-                    .await
-                    .map(|r| r.session_id),
-            );
-        }
-        AcpCommand::LoadSession { req, reply } => {
-            let _ = reply.send(
-                send_and_log(connection, req, "session/load")
-                    .await
-                    .map(|_| ()),
-            );
-        }
-        AcpCommand::ResumeSession { req, reply } => {
-            let _ = reply.send(
-                send_and_log(connection, req, "session/resume")
-                    .await
-                    .map(|_| ()),
-            );
-        }
-        AcpCommand::CloseSession { req, reply } => {
-            let _ = reply.send(
-                send_and_log(connection, req, "session/close")
-                    .await
-                    .map(|_| ()),
-            );
-        }
-        AcpCommand::Prompt { req, reply } => {
-            let _ = reply.send(
-                send_and_log(connection, req, "session/prompt")
-                    .await
-                    .map(|_| ()),
-            );
-        }
-        AcpCommand::SetMode { req, reply } => {
-            let _ = reply.send(
-                send_and_log(connection, req, "session/set_mode")
-                    .await
-                    .map(|_| ()),
-            );
-        }
-        AcpCommand::SetModel { req, reply } => {
-            let _ = reply.send(
-                send_and_log(connection, req, "session/set_model")
-                    .await
-                    .map(|_| ()),
-            );
-        }
-        AcpCommand::SetConfigOption { req, reply } => {
-            let _ = reply.send(
-                send_and_log(connection, req, "session/set_config_option")
-                    .await
-                    .map(|_| ()),
-            );
-        }
-        AcpCommand::Cancel { notification } => {
-            log_notify("session/cancel", &json_str(&notification));
+        AcpClientCommand::Cancel { notification } => {
+            log_notify(AGENT_METHOD_NAMES.session_cancel, &json_str(&notification));
             let _ = connection.send_notification(notification);
         }
-        AcpCommand::ListSessions { req, reply } => {
-            let _ = reply.send(send_and_log(connection, req, "session/list").await);
+        AcpClientCommand::ListSessions {
+            req,
+            reply_tx: reply,
+        } => {
+            let _ =
+                reply.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_list).await);
         }
-        AcpCommand::Authenticate { req, reply } => {
-            let _ = reply.send(
-                send_and_log(connection, req, "authenticate")
-                    .await
-                    .map(|_| ()),
-            );
+        AcpClientCommand::Authenticate {
+            req,
+            reply_tx: reply,
+        } => {
+            let _ =
+                reply.send(send_and_log(connection, req, AGENT_METHOD_NAMES.authenticate).await);
         }
-        AcpCommand::ExtMethod { req, reply } => {
+        AcpClientCommand::ExtMethod {
+            req,
+            reply_tx: reply,
+        } => {
             let method = format!("_{}", req.method);
             let wrapped = ClientRequest::ExtMethodRequest(req);
-            let _ = reply.send(send_and_log(connection, wrapped, &method).await);
+            let result = send_and_log(connection, wrapped, &method).await;
+            let _ = reply.send(result.and_then(|v| {
+                let raw =
+                    serde_json::value::to_raw_value(&v).map_err(|e| AcpError::AgentInternal {
+                        message: format!("Failed to convert ext response: {e}"),
+                        code: -32603,
+                    })?;
+                Ok(ExtResponse::new(raw.into()))
+            }));
         }
-        AcpCommand::ExtNotify { notification } => {
+        AcpClientCommand::ExtNotify { notification } => {
             let method = format!("_{}", notification.method);
             log_notify(&method, &json_str(&notification));
             let wrapped = ClientNotification::ExtNotification(notification);
             let _ = connection.send_notification(wrapped);
+        }
+    }
+}
+
+/// Dispatch a single [`AcpAgentCommand`] (agent → client direction).
+///
+/// Mirrors [`dispatch_client_command`] for the client → agent direction.
+async fn dispatch_agent_command(cmd: AcpAgentCommand) {
+    match cmd {
+        AcpAgentCommand::SessionUpdate {
+            notification,
+            reply_tx,
+        } => {
+            log_incoming("session/update", &json_str(&notification));
+
+            let events = stream_event::session_notification_to_events(&notification);
+            for event in events {
+                let _ = reply_tx.send(event);
+            }
+        }
+        AcpAgentCommand::RequestPermission {
+            request,
+            responder,
+            reply_tx,
+        } => {
+            log_incoming("session/request_permission", &json_str(&request));
+
+            let (resp_tx, resp_rx) = oneshot::channel();
+
+            let perm_req = PermissionRequest {
+                request,
+                response_tx: resp_tx,
+            };
+
+            if reply_tx.send(perm_req).await.is_err() {
+                warn!("Permission channel closed, cancelling request");
+                let _ = responder.respond(RequestPermissionResponse::new(
+                    RequestPermissionOutcome::Cancelled,
+                ));
+                return;
+            }
+
+            let response = match resp_rx.await {
+                Ok(PermissionDecision::Selected { option_id }) => RequestPermissionResponse::new(
+                    RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(option_id)),
+                ),
+                Ok(PermissionDecision::Cancelled) | Err(_) => {
+                    RequestPermissionResponse::new(RequestPermissionOutcome::Cancelled)
+                }
+            };
+
+            log_outgoing("session/request_permission", &json_str(&response));
+            let _ = responder.respond(response);
         }
     }
 }
@@ -561,9 +694,9 @@ where
     Req::Response: serde::Serialize + std::fmt::Debug,
 {
     log_request(method, &json_str(&req));
-    let raw = connection.send_request(req).block_task().await;
-    log_response(method, &json_or_err(&raw));
-    raw.map_err(|e| AcpError::from_sdk(e, method))
+    let rsp = connection.send_request(req).block_task().await;
+    log_response(method, &json_or_err(&rsp));
+    rsp.map_err(|e| AcpError::from_sdk(e, method))
 }
 
 /// Serialize a value to a compact JSON string, falling back to Debug on failure.

--- a/crates/aionui-ai-agent/src/acp_protocol.rs
+++ b/crates/aionui-ai-agent/src/acp_protocol.rs
@@ -8,8 +8,8 @@
 //! running inside `connect_with`. This is required because `block_task()` only
 //! works within the `connect_with` closure's execution context.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
 
 use agent_client_protocol::schema::{
     ClientNotification, ClientRequest, InitializeRequest, ProtocolVersion,
@@ -31,9 +31,9 @@ use crate::stream_event::{self, AgentStreamEvent};
 // Re-export SDK types used in public method signatures.
 pub use agent_client_protocol::schema::{
     AuthenticateRequest, CancelNotification, CloseSessionRequest, ContentBlock, ExtNotification,
-    ExtRequest, ForkSessionRequest, ListSessionsRequest, ListSessionsResponse, LoadSessionRequest,
-    McpServer, Meta, NewSessionRequest, PromptRequest, ResumeSessionRequest, SessionId,
-    SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest,
+    ExtRequest, ForkSessionRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse,
+    LoadSessionRequest, McpServer, Meta, NewSessionRequest, PromptRequest, ResumeSessionRequest,
+    SessionId, SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest,
 };
 
 /// Type alias to shorten `agent_client_protocol::Responder<RequestPermissionResponse>`.
@@ -129,6 +129,8 @@ pub struct AcpProtocol {
     cmd_tx: mpsc::Sender<AcpCommand>,
     /// Whether the SDK connection is still alive.
     alive: Arc<AtomicBool>,
+    /// Cached initialize response from the ACP handshake.
+    initialize_response: Arc<RwLock<Option<InitializeResponse>>>,
 }
 
 impl AcpProtocol {
@@ -145,12 +147,13 @@ impl AcpProtocol {
     ) -> Result<Self, AcpError> {
         let alive = Arc::new(AtomicBool::new(true));
         let alive_clone = Arc::clone(&alive);
+        let initialize_response = Arc::new(RwLock::new(None));
 
         // Command channel: external methods → SDK event loop
         let (cmd_tx, cmd_rx) = mpsc::channel::<AcpCommand>(32);
 
         // Signal that init completed successfully
-        let (init_tx, init_rx) = oneshot::channel::<Result<(), AcpError>>();
+        let (init_tx, init_rx) = oneshot::channel::<Result<InitializeResponse, AcpError>>();
 
         let _bg_task = tokio::spawn(run_sdk_event_loop(
             stdin,
@@ -175,13 +178,24 @@ impl AcpProtocol {
                     stderr: "Init channel dropped".into(),
                 })?;
 
-        init_result?;
+        let init_response = init_result?;
+        *initialize_response.write().unwrap() = Some(init_response);
 
         Ok(Self {
             cmd_tx,
             _bg_task,
             alive,
+            initialize_response,
         })
+    }
+
+    pub fn initialize_response(&self) -> Option<InitializeResponse> {
+        self.initialize_response.read().unwrap().clone()
+    }
+
+    pub fn agent_capabilities(&self) -> Option<agent_client_protocol::schema::AgentCapabilities> {
+        self.initialize_response()
+            .map(|response| response.agent_capabilities)
     }
 
     /// Create a new ACP session.
@@ -320,7 +334,7 @@ impl AcpProtocol {
 /// Returns `Err(())` when the handshake failed (the caller should bail out).
 async fn execute_initialize(
     connection: &ConnectionTo<Agent>,
-    init_tx: oneshot::Sender<Result<(), AcpError>>,
+    init_tx: oneshot::Sender<Result<InitializeResponse, AcpError>>,
 ) -> Result<(), ()> {
     let req = InitializeRequest::new(ProtocolVersion::LATEST);
     log_request("initialize", &json_str(&req));
@@ -332,7 +346,7 @@ async fn execute_initialize(
         let _ = init_tx.send(Err(AcpError::from_sdk(e, "initialize")));
         return Err(());
     }
-    let _ = init_tx.send(Ok(()));
+    let _ = init_tx.send(raw.map_err(|e| AcpError::from_sdk(e, "initialize")));
     Ok(())
 }
 
@@ -348,7 +362,7 @@ async fn run_sdk_event_loop(
     event_tx: broadcast::Sender<AgentStreamEvent>,
     permission_tx: mpsc::Sender<PermissionRequest>,
     cmd_rx: mpsc::Receiver<AcpCommand>,
-    init_tx: oneshot::Sender<Result<(), AcpError>>,
+    init_tx: oneshot::Sender<Result<InitializeResponse, AcpError>>,
     alive: Arc<AtomicBool>,
 ) {
     let transport = ByteStreams::new(stdin.compat_write(), stdout.compat());

--- a/crates/aionui-ai-agent/src/acp_routes.rs
+++ b/crates/aionui-ai-agent/src/acp_routes.rs
@@ -2,21 +2,19 @@ use std::sync::Arc;
 
 use axum::Router;
 use axum::extract::rejection::JsonRejection;
-use axum::extract::{Extension, Json, Path, State};
-use axum::routing::{get, post, put};
+use axum::extract::{Extension, Json, State};
+use axum::routing::{get, post};
 
 use aionui_api_types::{
     AcpEnvResponse, AcpHealthCheckRequest, AcpHealthCheckResponse, ApiResponse, DetectCliRequest,
-    DetectCliResponse, ProbeModelRequest, SetConfigOptionRequest, SetModelRequest,
+    DetectCliResponse, ProbeModelRequest,
 };
 use aionui_auth::CurrentUser;
-use aionui_common::{AgentType, AppError};
+use aionui_common::AppError;
 
-use crate::acp_agent::AcpAgentManager;
 use crate::acp_service;
-use crate::agent_manager::AgentManagerHandle;
 use crate::task_manager::IWorkerTaskManager;
-use crate::types::{AcpModelInfo, AcpSessionConfigOption};
+use crate::types::AcpModelInfo;
 
 /// Router state for ACP management routes.
 #[derive(Clone)]
@@ -26,7 +24,7 @@ pub struct AcpRouterState {
 
 /// Build the ACP management router.
 ///
-/// Includes both global ACP routes and per-conversation session routes.
+/// Includes global ACP routes.
 /// All routes require authentication (applied by the caller).
 pub fn acp_routes(state: AcpRouterState) -> Router {
     Router::new()
@@ -35,51 +33,7 @@ pub fn acp_routes(state: AcpRouterState) -> Router {
         .route("/api/acp/health-check", post(health_check))
         .route("/api/acp/env", get(get_env))
         .route("/api/acp/probe-model", post(probe_model))
-        // Per-conversation ACP session routes
-        .route(
-            "/api/conversations/{id}/acp/model",
-            get(get_model).put(set_model),
-        )
-        .route("/api/conversations/{id}/acp/config", get(get_config))
-        .route(
-            "/api/conversations/{id}/acp/config/{configId}",
-            put(set_config_option),
-        )
         .with_state(state)
-}
-
-/// Get the active ACP agent task for a conversation.
-///
-/// Returns the handle (keeping the Arc alive) so callers can downcast.
-/// Returns `NotFound` if no active task exists, `BadRequest` if not ACP.
-fn require_acp_task(
-    state: &AcpRouterState,
-    conversation_id: &str,
-) -> Result<AgentManagerHandle, AppError> {
-    let handle = state
-        .worker_task_manager
-        .get_task(conversation_id)
-        .ok_or_else(|| {
-            AppError::NotFound(format!(
-                "No active agent for conversation '{conversation_id}'"
-            ))
-        })?;
-
-    if handle.agent_type() != AgentType::Acp {
-        return Err(AppError::BadRequest(
-            "This operation is only available for ACP agents".into(),
-        ));
-    }
-
-    Ok(handle)
-}
-
-/// Downcast an `AgentManagerHandle` to `&AcpAgentManager`.
-fn downcast_acp(handle: &AgentManagerHandle) -> Result<&AcpAgentManager, AppError> {
-    handle
-        .as_any()
-        .downcast_ref::<AcpAgentManager>()
-        .ok_or_else(|| AppError::Internal("Failed to downcast agent to AcpAgentManager".into()))
 }
 
 // ── Global ACP routes ────────────────────────────────────────────
@@ -128,65 +82,4 @@ async fn probe_model(
     }
     // Full model probing will be wired when integrated with real ACP sessions (6.15)
     Ok(Json(ApiResponse::ok(None)))
-}
-
-// ── Per-conversation ACP session routes ──────────────────────────
-
-async fn get_model(
-    State(state): State<AcpRouterState>,
-    Extension(_user): Extension<CurrentUser>,
-    Path(id): Path<String>,
-) -> Result<Json<ApiResponse<Option<AcpModelInfo>>>, AppError> {
-    let handle = require_acp_task(&state, &id)?;
-    let acp = downcast_acp(&handle)?;
-    let info = acp.get_model_info().await;
-    Ok(Json(ApiResponse::ok(info)))
-}
-
-async fn set_model(
-    State(state): State<AcpRouterState>,
-    Extension(_user): Extension<CurrentUser>,
-    Path(id): Path<String>,
-    body: Result<Json<SetModelRequest>, JsonRejection>,
-) -> Result<Json<ApiResponse<()>>, AppError> {
-    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    if req.model_id.trim().is_empty() {
-        return Err(AppError::BadRequest("modelId must not be empty".into()));
-    }
-    let handle = require_acp_task(&state, &id)?;
-    let acp = downcast_acp(&handle)?;
-    acp.set_model(&req.model_id).await?;
-    Ok(Json(ApiResponse::success()))
-}
-
-async fn get_config(
-    State(state): State<AcpRouterState>,
-    Extension(_user): Extension<CurrentUser>,
-    Path(id): Path<String>,
-) -> Result<Json<ApiResponse<Vec<AcpSessionConfigOption>>>, AppError> {
-    let handle = require_acp_task(&state, &id)?;
-    let acp = downcast_acp(&handle)?;
-    acp.get_config_options().await?;
-    // Config options arrive via event stream; return empty for sync response
-    Ok(Json(ApiResponse::ok(Vec::new())))
-}
-
-#[derive(serde::Deserialize)]
-struct ConfigPathParams {
-    id: String,
-    #[serde(rename = "configId")]
-    config_id: String,
-}
-
-async fn set_config_option(
-    State(state): State<AcpRouterState>,
-    Extension(_user): Extension<CurrentUser>,
-    Path(params): Path<ConfigPathParams>,
-    body: Result<Json<SetConfigOptionRequest>, JsonRejection>,
-) -> Result<Json<ApiResponse<()>>, AppError> {
-    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    let handle = require_acp_task(&state, &params.id)?;
-    let acp = downcast_acp(&handle)?;
-    acp.set_config_option(&params.config_id, &req.value).await?;
-    Ok(Json(ApiResponse::success()))
 }

--- a/crates/aionui-ai-agent/src/acp_runtime_snapshot.rs
+++ b/crates/aionui-ai-agent/src/acp_runtime_snapshot.rs
@@ -2,7 +2,6 @@ use crate::stream_event::AgentStreamEvent;
 pub use agent_client_protocol::schema::{
     AgentCapabilities, SessionConfigOption, SessionModeState, SessionModelState, UsageUpdate,
 };
-use agent_client_protocol::schema::{ConfigOptionUpdate, CurrentModeUpdate};
 
 #[derive(Debug, Clone, Default)]
 pub struct AcpRuntimeSnapshot {
@@ -29,6 +28,7 @@ impl AcpRuntimeSnapshot {
     pub fn agent_capabilities(&self) -> Option<&AgentCapabilities> {
         self.agent_capabilities.as_ref()
     }
+
     pub fn set_modes(&mut self, modes: SessionModeState) {
         self.modes = Some(modes);
     }
@@ -48,23 +48,25 @@ impl AcpRuntimeSnapshot {
     pub fn apply_event(&mut self, event: &AgentStreamEvent) {
         match event {
             AgentStreamEvent::AcpModeInfo(value) => {
-                if let Ok(update) = serde_json::from_value::<CurrentModeUpdate>(value.clone()) {
-                    self.apply_mode_update(update);
-                }
-            }
-            AgentStreamEvent::AcpConfigOption(value) => {
-                if let Ok(update) = serde_json::from_value::<ConfigOptionUpdate>(value.clone()) {
-                    self.apply_config_update(update);
+                if let Ok(update) = serde_json::from_value::<SessionModeState>(value.clone()) {
+                    self.modes = Some(update);
                 }
             }
             AgentStreamEvent::AcpModelInfo(value) => {
-                if let Ok(model_info) = serde_json::from_value::<SessionModelState>(value.clone()) {
-                    self.model_info = Some(model_info);
+                if let Ok(update) = serde_json::from_value::<SessionModelState>(value.clone()) {
+                    self.model_info = Some(update);
+                }
+            }
+            AgentStreamEvent::AcpConfigOption(value) => {
+                if let Ok(update) =
+                    serde_json::from_value::<Vec<SessionConfigOption>>(value.clone())
+                {
+                    self.config_options = Some(update);
                 }
             }
             AgentStreamEvent::AcpContextUsage(value) => {
-                if let Ok(usage) = serde_json::from_value::<UsageUpdate>(value.clone()) {
-                    self.context_usage = Some(usage);
+                if let Ok(update) = serde_json::from_value::<UsageUpdate>(value.clone()) {
+                    self.context_usage = Some(update);
                 }
             }
             _ => {}
@@ -76,33 +78,13 @@ impl AcpRuntimeSnapshot {
             .as_ref()
             .map(|modes| modes.current_mode_id.to_string())
     }
-
-    fn apply_mode_update(&mut self, update: CurrentModeUpdate) {
-        match &mut self.modes {
-            Some(modes) => {
-                modes.current_mode_id = update.current_mode_id;
-                if update.meta.is_some() {
-                    modes.meta = update.meta;
-                }
-            }
-            None => {
-                self.modes = Some(
-                    SessionModeState::new(update.current_mode_id, Vec::new()).meta(update.meta),
-                );
-            }
-        }
-    }
-
-    fn apply_config_update(&mut self, update: ConfigOptionUpdate) {
-        self.config_options = Some(update.config_options);
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use agent_client_protocol::schema::{
-        ConfigOptionUpdate, ModelInfo, SessionConfigOption, SessionConfigSelectOption, SessionMode,
-        SessionModeState, SessionModelState, UsageUpdate,
+        ModelInfo, SessionConfigOption, SessionConfigSelectOption, SessionMode, SessionModeState,
+        SessionModelState, UsageUpdate,
     };
     use serde_json::json;
 
@@ -142,12 +124,14 @@ mod tests {
     #[test]
     fn applies_config_update_into_sdk_config_options() {
         let mut snapshot = AcpRuntimeSnapshot::default();
-        snapshot.apply_config_update(ConfigOptionUpdate::new(vec![SessionConfigOption::select(
-            "mode",
-            "Mode",
-            "code",
-            vec![SessionConfigSelectOption::new("code", "Code")],
-        )]));
+        snapshot.apply_event(&AgentStreamEvent::AcpConfigOption(json!([
+            SessionConfigOption::select(
+                "mode",
+                "Mode",
+                "code",
+                vec![SessionConfigSelectOption::new("code", "Code")],
+            )
+        ])));
 
         let config_options = snapshot
             .config_options()

--- a/crates/aionui-ai-agent/src/acp_runtime_snapshot.rs
+++ b/crates/aionui-ai-agent/src/acp_runtime_snapshot.rs
@@ -1,0 +1,184 @@
+use crate::stream_event::AgentStreamEvent;
+pub use agent_client_protocol::schema::{
+    AgentCapabilities, SessionConfigOption, SessionModeState, SessionModelState, UsageUpdate,
+};
+use agent_client_protocol::schema::{ConfigOptionUpdate, CurrentModeUpdate};
+
+#[derive(Debug, Clone, Default)]
+pub struct AcpRuntimeSnapshot {
+    agent_capabilities: Option<AgentCapabilities>,
+    modes: Option<SessionModeState>,
+    model_info: Option<SessionModelState>,
+    config_options: Option<Vec<SessionConfigOption>>,
+    context_usage: Option<UsageUpdate>,
+}
+
+impl AcpRuntimeSnapshot {
+    pub fn modes(&self) -> Option<&SessionModeState> {
+        self.modes.as_ref()
+    }
+    pub fn model_info(&self) -> Option<&SessionModelState> {
+        self.model_info.as_ref()
+    }
+    pub fn config_options(&self) -> Option<&[SessionConfigOption]> {
+        self.config_options.as_deref()
+    }
+    pub fn context_usage(&self) -> Option<&UsageUpdate> {
+        self.context_usage.as_ref()
+    }
+    pub fn agent_capabilities(&self) -> Option<&AgentCapabilities> {
+        self.agent_capabilities.as_ref()
+    }
+    pub fn set_modes(&mut self, modes: SessionModeState) {
+        self.modes = Some(modes);
+    }
+    pub fn set_model_info(&mut self, model_info: SessionModelState) {
+        self.model_info = Some(model_info);
+    }
+    pub fn set_config_options(&mut self, config_options: Vec<SessionConfigOption>) {
+        self.config_options = Some(config_options);
+    }
+    pub fn set_context_usage(&mut self, context_usage: UsageUpdate) {
+        self.context_usage = Some(context_usage);
+    }
+    pub fn set_agent_capabilities(&mut self, agent_capabilities: AgentCapabilities) {
+        self.agent_capabilities = Some(agent_capabilities);
+    }
+
+    pub fn apply_event(&mut self, event: &AgentStreamEvent) {
+        match event {
+            AgentStreamEvent::AcpModeInfo(value) => {
+                if let Ok(update) = serde_json::from_value::<CurrentModeUpdate>(value.clone()) {
+                    self.apply_mode_update(update);
+                }
+            }
+            AgentStreamEvent::AcpConfigOption(value) => {
+                if let Ok(update) = serde_json::from_value::<ConfigOptionUpdate>(value.clone()) {
+                    self.apply_config_update(update);
+                }
+            }
+            AgentStreamEvent::AcpModelInfo(value) => {
+                if let Ok(model_info) = serde_json::from_value::<SessionModelState>(value.clone()) {
+                    self.model_info = Some(model_info);
+                }
+            }
+            AgentStreamEvent::AcpContextUsage(value) => {
+                if let Ok(usage) = serde_json::from_value::<UsageUpdate>(value.clone()) {
+                    self.context_usage = Some(usage);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub fn current_mode_id(&self) -> Option<String> {
+        self.modes
+            .as_ref()
+            .map(|modes| modes.current_mode_id.to_string())
+    }
+
+    fn apply_mode_update(&mut self, update: CurrentModeUpdate) {
+        match &mut self.modes {
+            Some(modes) => {
+                modes.current_mode_id = update.current_mode_id;
+                if update.meta.is_some() {
+                    modes.meta = update.meta;
+                }
+            }
+            None => {
+                self.modes = Some(
+                    SessionModeState::new(update.current_mode_id, Vec::new()).meta(update.meta),
+                );
+            }
+        }
+    }
+
+    fn apply_config_update(&mut self, update: ConfigOptionUpdate) {
+        self.config_options = Some(update.config_options);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use agent_client_protocol::schema::{
+        ConfigOptionUpdate, ModelInfo, SessionConfigOption, SessionConfigSelectOption, SessionMode,
+        SessionModeState, SessionModelState, UsageUpdate,
+    };
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn stores_agent_capabilities() {
+        let mut snapshot = AcpRuntimeSnapshot::default();
+        snapshot.set_agent_capabilities(AgentCapabilities::new().load_session(true));
+
+        let caps = snapshot
+            .agent_capabilities()
+            .expect("agent capabilities should be cached");
+        assert!(caps.load_session);
+    }
+
+    #[test]
+    fn applies_mode_update_into_session_mode_state() {
+        let mut snapshot = AcpRuntimeSnapshot::default();
+        snapshot.set_modes(SessionModeState::new(
+            "code",
+            vec![
+                SessionMode::new("code", "Code"),
+                SessionMode::new("plan", "Plan"),
+            ],
+        ));
+
+        snapshot.apply_event(&AgentStreamEvent::AcpModeInfo(json!({
+            "currentModeId": "plan"
+        })));
+
+        let modes = snapshot.modes().expect("modes should exist");
+        assert_eq!(modes.current_mode_id.to_string(), "plan");
+        assert_eq!(modes.available_modes.len(), 2);
+    }
+
+    #[test]
+    fn applies_config_update_into_sdk_config_options() {
+        let mut snapshot = AcpRuntimeSnapshot::default();
+        snapshot.apply_config_update(ConfigOptionUpdate::new(vec![SessionConfigOption::select(
+            "mode",
+            "Mode",
+            "code",
+            vec![SessionConfigSelectOption::new("code", "Code")],
+        )]));
+
+        let config_options = snapshot
+            .config_options()
+            .expect("config options should be cached");
+        assert_eq!(config_options.len(), 1);
+        assert_eq!(config_options[0].name, "Mode");
+    }
+
+    #[test]
+    fn stores_model_info_and_usage() {
+        let mut snapshot = AcpRuntimeSnapshot::default();
+        snapshot.set_model_info(SessionModelState::new(
+            "claude-sonnet-4",
+            vec![ModelInfo::new("claude-sonnet-4", "Claude Sonnet 4")],
+        ));
+        snapshot.set_context_usage(UsageUpdate::new(1024, 8192));
+
+        assert_eq!(
+            snapshot
+                .model_info()
+                .expect("model info should be cached")
+                .current_model_id
+                .to_string(),
+            "claude-sonnet-4"
+        );
+        assert_eq!(
+            snapshot
+                .context_usage()
+                .expect("usage should be cached")
+                .used,
+            1024
+        );
+    }
+}

--- a/crates/aionui-ai-agent/src/auxiliary_routes.rs
+++ b/crates/aionui-ai-agent/src/auxiliary_routes.rs
@@ -6,23 +6,20 @@ use axum::extract::{Extension, Json, Path, Query, State};
 use axum::routing::{get, post};
 
 use crate::acp_agent::AcpAgentManager;
-use crate::acp_runtime_snapshot::{
-    AgentCapabilities, SessionConfigOption, SessionModelState, UsageUpdate,
-};
+use crate::acp_runtime_snapshot::{AgentCapabilities, SessionConfigOption, UsageUpdate};
 use crate::agent_manager::AgentManagerHandle;
 use crate::openclaw::OpenClawAgentManager;
 use crate::task_manager::IWorkerTaskManager;
 use crate::types::SlashCommandItem;
 use aionui_api_types::{
-    AgentModeResponse, ApiResponse, SetConfigOptionRequest, SetConfigOptionsRequest,
-    SetModeRequest, SetModelRequest, SideQuestionRequest, SideQuestionResponse,
-    WorkspaceBrowseQuery, WorkspaceEntry,
+    AgentModeResponse, ApiResponse, GetModelInfoResponse, ModelInfoEntry, ModelInfoPayload,
+    SetConfigOptionRequest, SetConfigOptionsRequest, SetModeRequest, SetModelRequest,
+    SideQuestionRequest, SideQuestionResponse, WorkspaceBrowseQuery, WorkspaceEntry,
 };
 use aionui_auth::CurrentUser;
 use aionui_common::{AgentType, AppError};
 use aionui_db::IConversationRepository;
 use serde::Deserialize;
-use tracing::debug;
 
 /// Router state for auxiliary conversation routes.
 #[derive(Clone)]
@@ -289,7 +286,7 @@ async fn get_model(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
-) -> Result<Json<ApiResponse<Option<SessionModelState>>>, AppError> {
+) -> Result<Json<ApiResponse<GetModelInfoResponse>>, AppError> {
     let handle = get_task(&state, &id)?;
 
     if handle.agent_type() != AgentType::Acp {
@@ -299,9 +296,33 @@ async fn get_model(
     }
 
     let acp = downcast_acp(&handle)?;
-    let resp = acp.model_info().await;
-    debug!("Current ACP model info for conversation {id}: {resp:?}");
-    Ok(Json(ApiResponse::ok(resp)))
+    let sdk_model = acp.model_info().await;
+
+    let model_info = sdk_model.map(|m| {
+        let available: Vec<ModelInfoEntry> = m
+            .available_models
+            .iter()
+            .map(|am| ModelInfoEntry {
+                id: am.model_id.to_string(),
+                label: am.name.clone(),
+            })
+            .collect();
+
+        let current_id = m.current_model_id.to_string();
+        let current_label = available
+            .iter()
+            .find(|e| e.id == current_id)
+            .map(|e| e.label.clone())
+            .unwrap_or_else(|| current_id.clone());
+
+        ModelInfoPayload {
+            current_model_id: Some(current_id),
+            current_model_label: Some(current_label),
+            available_models: available,
+        }
+    });
+
+    Ok(Json(ApiResponse::ok(GetModelInfoResponse { model_info })))
 }
 
 async fn set_model(
@@ -323,7 +344,7 @@ async fn set_model(
     }
 
     let acp = downcast_acp(&handle)?;
-    acp.set_model(&req.model_id).await?;
+    acp.set_model_info(&req.model_id).await?;
     Ok(Json(ApiResponse::success()))
 }
 

--- a/crates/aionui-ai-agent/src/auxiliary_routes.rs
+++ b/crates/aionui-ai-agent/src/auxiliary_routes.rs
@@ -39,34 +39,28 @@ pub fn auxiliary_routes(state: AuxiliaryRouterState) -> Router {
             "/api/conversations/{id}/reload-context",
             post(reload_context),
         )
+        .route("/api/conversations/{id}/side-question", post(side_question))
         .route(
-            "/api/conversations/{id}/acp/side-question",
-            post(acp_side_question),
+            "/api/conversations/{id}/slash-commands",
+            get(get_slash_commands),
+        )
+        .route("/api/conversations/{id}/mode", get(get_mode).put(set_mode))
+        .route(
+            "/api/conversations/{id}/model",
+            get(get_model).put(set_model),
         )
         .route(
-            "/api/conversations/{id}/acp/slash-commands",
-            get(get_acp_slash_commands),
+            "/api/conversations/{id}/config",
+            get(get_configs).put(set_configs),
         )
         .route(
-            "/api/conversations/{id}/acp/mode",
-            get(get_acp_mode).put(set_acp_mode),
+            "/api/conversations/{id}/config/{configId}",
+            get(get_config).put(set_config),
         )
+        .route("/api/conversations/{id}/usage", get(get_usage))
         .route(
-            "/api/conversations/{id}/acp/model",
-            get(get_acp_model).put(set_acp_model),
-        )
-        .route(
-            "/api/conversations/{id}/acp/config",
-            get(get_acp_config_options).put(set_acp_config_options),
-        )
-        .route(
-            "/api/conversations/{id}/acp/config/{configId}",
-            get(get_acp_config_option).put(set_acp_config_option),
-        )
-        .route("/api/conversations/{id}/acp/usage", get(get_acp_usage))
-        .route(
-            "/api/conversations/{id}/acp/agent-capabilities",
-            get(get_acp_agent_capabilities),
+            "/api/conversations/{id}/agent-capabilities",
+            get(get_agent_capabilities),
         )
         .route(
             "/api/conversations/{id}/openclaw/runtime",
@@ -205,7 +199,7 @@ async fn reload_context(
     Ok(Json(ApiResponse::success()))
 }
 
-async fn acp_side_question(
+async fn side_question(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
@@ -246,7 +240,7 @@ async fn acp_side_question(
     })))
 }
 
-async fn get_acp_slash_commands(
+async fn get_slash_commands(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
@@ -267,23 +261,16 @@ async fn get_acp_slash_commands(
     Ok(Json(ApiResponse::ok(Vec::new())))
 }
 
-async fn get_acp_mode(
+async fn get_mode(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<AgentModeResponse>>, AppError> {
     let handle = get_task(&state, &id)?;
-
-    if handle.agent_type() != AgentType::Acp {
-        return Err(AppError::BadRequest(
-            "This endpoint is only available for ACP agents".into(),
-        ));
-    }
-
     Ok(Json(ApiResponse::ok(handle.get_mode().await?)))
 }
 
-async fn set_acp_mode(
+async fn set_mode(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
@@ -294,16 +281,11 @@ async fn set_acp_mode(
         return Err(AppError::BadRequest("mode must not be empty".into()));
     }
     let handle = get_task(&state, &id)?;
-    if handle.agent_type() != AgentType::Acp {
-        return Err(AppError::BadRequest(
-            "This endpoint is only available for ACP agents".into(),
-        ));
-    }
     handle.set_mode(&req.mode).await?;
     Ok(Json(ApiResponse::success()))
 }
 
-async fn get_acp_model(
+async fn get_model(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
@@ -322,7 +304,7 @@ async fn get_acp_model(
     Ok(Json(ApiResponse::ok(resp)))
 }
 
-async fn set_acp_model(
+async fn set_model(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
@@ -345,7 +327,7 @@ async fn set_acp_model(
     Ok(Json(ApiResponse::success()))
 }
 
-async fn get_acp_config_option(
+async fn get_config(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(params): Path<ConfigPathParams>,
@@ -367,7 +349,7 @@ async fn get_acp_config_option(
     Ok(Json(ApiResponse::ok(config_option)))
 }
 
-async fn set_acp_config_option(
+async fn set_config(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(params): Path<ConfigPathParams>,
@@ -387,7 +369,7 @@ async fn set_acp_config_option(
     Ok(Json(ApiResponse::success()))
 }
 
-async fn get_acp_config_options(
+async fn get_configs(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
@@ -404,7 +386,7 @@ async fn get_acp_config_options(
     Ok(Json(ApiResponse::ok(acp.config_options().await)))
 }
 
-async fn set_acp_config_options(
+async fn set_configs(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
@@ -431,7 +413,7 @@ async fn set_acp_config_options(
     Ok(Json(ApiResponse::success()))
 }
 
-async fn get_acp_usage(
+async fn get_usage(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
@@ -449,7 +431,7 @@ async fn get_acp_usage(
     Ok(Json(ApiResponse::ok(usage)))
 }
 
-async fn get_acp_agent_capabilities(
+async fn get_agent_capabilities(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,

--- a/crates/aionui-ai-agent/src/auxiliary_routes.rs
+++ b/crates/aionui-ai-agent/src/auxiliary_routes.rs
@@ -5,17 +5,24 @@ use axum::extract::rejection::JsonRejection;
 use axum::extract::{Extension, Json, Path, Query, State};
 use axum::routing::{get, post};
 
-use aionui_api_types::{AgentModeResponse, ApiResponse, SetModeRequest};
-use aionui_auth::CurrentUser;
-use aionui_common::{AgentType, AppError};
-use aionui_db::IConversationRepository;
-use serde::{Deserialize, Serialize};
-
 use crate::acp_agent::AcpAgentManager;
+use crate::acp_runtime_snapshot::{
+    AgentCapabilities, SessionConfigOption, SessionModelState, UsageUpdate,
+};
 use crate::agent_manager::AgentManagerHandle;
 use crate::openclaw::OpenClawAgentManager;
 use crate::task_manager::IWorkerTaskManager;
 use crate::types::SlashCommandItem;
+use aionui_api_types::{
+    AgentModeResponse, ApiResponse, SetConfigOptionRequest, SetConfigOptionsRequest,
+    SetModeRequest, SetModelRequest, SideQuestionRequest, SideQuestionResponse,
+    WorkspaceBrowseQuery, WorkspaceEntry,
+};
+use aionui_auth::CurrentUser;
+use aionui_common::{AgentType, AppError};
+use aionui_db::IConversationRepository;
+use serde::Deserialize;
+use tracing::debug;
 
 /// Router state for auxiliary conversation routes.
 #[derive(Clone)]
@@ -28,18 +35,38 @@ pub struct AuxiliaryRouterState {
 pub fn auxiliary_routes(state: AuxiliaryRouterState) -> Router {
     Router::new()
         .route("/api/conversations/{id}/workspace", get(browse_workspace))
-        .route("/api/conversations/{id}/side-question", post(side_question))
         .route(
             "/api/conversations/{id}/reload-context",
             post(reload_context),
         )
         .route(
-            "/api/conversations/{id}/slash-commands",
-            get(get_slash_commands),
+            "/api/conversations/{id}/acp/side-question",
+            post(acp_side_question),
         )
         .route(
-            "/api/conversations/{id}/mode",
-            get(get_agent_mode).put(set_agent_mode),
+            "/api/conversations/{id}/acp/slash-commands",
+            get(get_acp_slash_commands),
+        )
+        .route(
+            "/api/conversations/{id}/acp/mode",
+            get(get_acp_mode).put(set_acp_mode),
+        )
+        .route(
+            "/api/conversations/{id}/acp/model",
+            get(get_acp_model).put(set_acp_model),
+        )
+        .route(
+            "/api/conversations/{id}/acp/config",
+            get(get_acp_config_options).put(set_acp_config_options),
+        )
+        .route(
+            "/api/conversations/{id}/acp/config/{configId}",
+            get(get_acp_config_option).put(set_acp_config_option),
+        )
+        .route("/api/conversations/{id}/acp/usage", get(get_acp_usage))
+        .route(
+            "/api/conversations/{id}/acp/agent-capabilities",
+            get(get_acp_agent_capabilities),
         )
         .route(
             "/api/conversations/{id}/openclaw/runtime",
@@ -48,68 +75,11 @@ pub fn auxiliary_routes(state: AuxiliaryRouterState) -> Router {
         .with_state(state)
 }
 
-// ── Generic mode endpoints ────────────────────────────────────────
-
-async fn get_agent_mode(
-    State(state): State<AuxiliaryRouterState>,
-    Extension(_user): Extension<CurrentUser>,
-    Path(id): Path<String>,
-) -> Result<Json<ApiResponse<AgentModeResponse>>, AppError> {
-    let handle = state
-        .worker_task_manager
-        .get_task(&id)
-        .ok_or_else(|| AppError::NotFound(format!("No active agent for conversation '{id}'")))?;
-    let resp = handle.get_mode().await?;
-    Ok(Json(ApiResponse::ok(resp)))
-}
-
-async fn set_agent_mode(
-    State(state): State<AuxiliaryRouterState>,
-    Extension(_user): Extension<CurrentUser>,
-    Path(id): Path<String>,
-    body: Result<Json<SetModeRequest>, JsonRejection>,
-) -> Result<Json<ApiResponse<()>>, AppError> {
-    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    if req.mode.trim().is_empty() {
-        return Err(AppError::BadRequest("mode must not be empty".into()));
-    }
-    let handle = state
-        .worker_task_manager
-        .get_task(&id)
-        .ok_or_else(|| AppError::NotFound(format!("No active agent for conversation '{id}'")))?;
-    handle.set_mode(&req.mode).await?;
-    Ok(Json(ApiResponse::success()))
-}
-
-// ── Request / Response types ───────────────────────────────────────
-
-/// Query parameters for workspace browse.
 #[derive(Debug, Deserialize)]
-pub struct WorkspaceBrowseQuery {
-    pub path: String,
-    pub search: Option<String>,
-}
-
-/// A file or directory entry in the workspace.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DirOrFile {
-    pub name: String,
-    #[serde(rename = "type")]
-    pub entry_type: String,
-}
-
-/// Request body for side question.
-#[derive(Debug, Deserialize)]
-pub struct SideQuestionRequest {
-    pub question: String,
-}
-
-/// Response for side question.
-#[derive(Debug, Serialize)]
-pub struct SideQuestionResponse {
-    pub status: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub answer: Option<String>,
+struct ConfigPathParams {
+    id: String,
+    #[serde(rename = "configId")]
+    config_id: String,
 }
 
 // ── Max depth for workspace traversal ──────────────────────────────
@@ -117,18 +87,12 @@ const MAX_DIR_DEPTH: usize = 10;
 
 // ── Route handlers ─────────────────────────────────────────────────
 
-/// GET /api/conversations/:id/workspace
-///
-/// Browse the workspace directory associated with a conversation.
-///
-/// Reads the workspace path from `conversation.extra.workspace` in the
-/// database so it works before any agent session has been started.
 async fn browse_workspace(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
     Query(query): Query<WorkspaceBrowseQuery>,
-) -> Result<Json<ApiResponse<Vec<DirOrFile>>>, AppError> {
+) -> Result<Json<ApiResponse<Vec<WorkspaceEntry>>>, AppError> {
     if query.path.trim().is_empty() {
         return Err(AppError::BadRequest("path must not be empty".into()));
     }
@@ -209,7 +173,7 @@ async fn browse_workspace(
             "file"
         };
 
-        entries.push(DirOrFile {
+        entries.push(WorkspaceEntry {
             name,
             entry_type: entry_type.into(),
         });
@@ -228,11 +192,20 @@ async fn browse_workspace(
     Ok(Json(ApiResponse::ok(entries)))
 }
 
-/// POST /api/conversations/:id/side-question
-///
-/// Ask a side question without interrupting the main conversation.
-/// Only supported for ACP Claude backend.
-async fn side_question(
+async fn reload_context(
+    State(state): State<AuxiliaryRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+) -> Result<Json<ApiResponse<()>>, AppError> {
+    let _handle = get_task(&state, &id)?;
+
+    // Context reload triggers re-discovery of skills and workspace state.
+    // The specific reload behavior varies by agent type and will be
+    // fully integrated in Phase 6.15. For now, acknowledge the request.
+    Ok(Json(ApiResponse::success()))
+}
+
+async fn acp_side_question(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
@@ -252,10 +225,7 @@ async fn side_question(
         })));
     }
 
-    let acp = handle
-        .as_any()
-        .downcast_ref::<AcpAgentManager>()
-        .ok_or_else(|| AppError::Internal("Failed to downcast to AcpAgentManager".into()))?;
+    let acp = downcast_acp(&handle)?;
 
     // Check if the backend is Claude (side question is only supported for Claude)
     let backend = acp.backend();
@@ -276,26 +246,7 @@ async fn side_question(
     })))
 }
 
-/// POST /api/conversations/:id/reload-context
-///
-/// Reload the session context (skills, workspace state, etc.).
-async fn reload_context(
-    State(state): State<AuxiliaryRouterState>,
-    Extension(_user): Extension<CurrentUser>,
-    Path(id): Path<String>,
-) -> Result<Json<ApiResponse<()>>, AppError> {
-    let _handle = get_task(&state, &id)?;
-
-    // Context reload triggers re-discovery of skills and workspace state.
-    // The specific reload behavior varies by agent type and will be
-    // fully integrated in Phase 6.15. For now, acknowledge the request.
-    Ok(Json(ApiResponse::success()))
-}
-
-/// GET /api/conversations/:id/slash-commands
-///
-/// Get the list of available slash commands for the conversation.
-async fn get_slash_commands(
+async fn get_acp_slash_commands(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
@@ -307,12 +258,7 @@ async fn get_slash_commands(
         return Ok(Json(ApiResponse::ok(Vec::new())));
     }
 
-    let acp = handle
-        .as_any()
-        .downcast_ref::<AcpAgentManager>()
-        .ok_or_else(|| AppError::Internal("Failed to downcast to AcpAgentManager".into()))?;
-
-    // Trigger the CLI to send slash commands via the event stream
+    let acp = downcast_acp(&handle)?;
     acp.load_slash_commands().await?;
 
     // Slash commands arrive asynchronously via the event stream.
@@ -321,9 +267,206 @@ async fn get_slash_commands(
     Ok(Json(ApiResponse::ok(Vec::new())))
 }
 
-/// GET /api/conversations/:id/openclaw/runtime
-///
-/// Get OpenClaw runtime diagnostic information.
+async fn get_acp_mode(
+    State(state): State<AuxiliaryRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+) -> Result<Json<ApiResponse<AgentModeResponse>>, AppError> {
+    let handle = get_task(&state, &id)?;
+
+    if handle.agent_type() != AgentType::Acp {
+        return Err(AppError::BadRequest(
+            "This endpoint is only available for ACP agents".into(),
+        ));
+    }
+
+    Ok(Json(ApiResponse::ok(handle.get_mode().await?)))
+}
+
+async fn set_acp_mode(
+    State(state): State<AuxiliaryRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+    body: Result<Json<SetModeRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<()>>, AppError> {
+    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
+    if req.mode.trim().is_empty() {
+        return Err(AppError::BadRequest("mode must not be empty".into()));
+    }
+    let handle = get_task(&state, &id)?;
+    if handle.agent_type() != AgentType::Acp {
+        return Err(AppError::BadRequest(
+            "This endpoint is only available for ACP agents".into(),
+        ));
+    }
+    handle.set_mode(&req.mode).await?;
+    Ok(Json(ApiResponse::success()))
+}
+
+async fn get_acp_model(
+    State(state): State<AuxiliaryRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+) -> Result<Json<ApiResponse<Option<SessionModelState>>>, AppError> {
+    let handle = get_task(&state, &id)?;
+
+    if handle.agent_type() != AgentType::Acp {
+        return Err(AppError::BadRequest(
+            "This endpoint is only available for ACP agents".into(),
+        ));
+    }
+
+    let acp = downcast_acp(&handle)?;
+    let resp = acp.model_info().await;
+    debug!("Current ACP model info for conversation {id}: {resp:?}");
+    Ok(Json(ApiResponse::ok(resp)))
+}
+
+async fn set_acp_model(
+    State(state): State<AuxiliaryRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+    body: Result<Json<SetModelRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<()>>, AppError> {
+    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
+    if req.model_id.trim().is_empty() {
+        return Err(AppError::BadRequest("model_id must not be empty".into()));
+    }
+
+    let handle = get_task(&state, &id)?;
+    if handle.agent_type() != AgentType::Acp {
+        return Err(AppError::BadRequest(
+            "Model switching is not supported for this agent type".into(),
+        ));
+    }
+
+    let acp = downcast_acp(&handle)?;
+    acp.set_model(&req.model_id).await?;
+    Ok(Json(ApiResponse::success()))
+}
+
+async fn get_acp_config_option(
+    State(state): State<AuxiliaryRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(params): Path<ConfigPathParams>,
+) -> Result<Json<ApiResponse<Option<SessionConfigOption>>>, AppError> {
+    let handle = get_task(&state, &params.id)?;
+
+    if handle.agent_type() != AgentType::Acp {
+        return Err(AppError::BadRequest(
+            "This endpoint is only available for ACP agents".into(),
+        ));
+    }
+
+    let acp = downcast_acp(&handle)?;
+    let config_option = acp
+        .config_options()
+        .await
+        .into_iter()
+        .find(|opt| *opt.id.0 == *params.config_id);
+    Ok(Json(ApiResponse::ok(config_option)))
+}
+
+async fn set_acp_config_option(
+    State(state): State<AuxiliaryRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(params): Path<ConfigPathParams>,
+    body: Result<Json<SetConfigOptionRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<()>>, AppError> {
+    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
+    let handle = get_task(&state, &params.id)?;
+
+    if handle.agent_type() != AgentType::Acp {
+        return Err(AppError::BadRequest(
+            "Config updates are not supported for this agent type".into(),
+        ));
+    }
+
+    let acp = downcast_acp(&handle)?;
+    acp.set_config_option(&params.config_id, &req.value).await?;
+    Ok(Json(ApiResponse::success()))
+}
+
+async fn get_acp_config_options(
+    State(state): State<AuxiliaryRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+) -> Result<Json<ApiResponse<Vec<SessionConfigOption>>>, AppError> {
+    let handle = get_task(&state, &id)?;
+
+    if handle.agent_type() != AgentType::Acp {
+        return Err(AppError::BadRequest(
+            "This endpoint is only available for ACP agents".into(),
+        ));
+    }
+
+    let acp = downcast_acp(&handle)?;
+    Ok(Json(ApiResponse::ok(acp.config_options().await)))
+}
+
+async fn set_acp_config_options(
+    State(state): State<AuxiliaryRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+    body: Result<Json<SetConfigOptionsRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<()>>, AppError> {
+    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
+    let handle = get_task(&state, &id)?;
+
+    if handle.agent_type() != AgentType::Acp {
+        return Err(AppError::BadRequest(
+            "Config updates are not supported for this agent type".into(),
+        ));
+    }
+
+    let acp = downcast_acp(&handle)?;
+    for update in req.config_options {
+        if update.config_id.trim().is_empty() {
+            return Err(AppError::BadRequest("config_id must not be empty".into()));
+        }
+        acp.set_config_option(&update.config_id, &update.value)
+            .await?;
+    }
+
+    Ok(Json(ApiResponse::success()))
+}
+
+async fn get_acp_usage(
+    State(state): State<AuxiliaryRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+) -> Result<Json<ApiResponse<Option<UsageUpdate>>>, AppError> {
+    let handle = get_task(&state, &id)?;
+
+    if handle.agent_type() != AgentType::Acp {
+        return Err(AppError::BadRequest(
+            "This endpoint is only available for ACP agents".into(),
+        ));
+    }
+
+    let acp = downcast_acp(&handle)?;
+    let usage = acp.usage().await;
+    Ok(Json(ApiResponse::ok(usage)))
+}
+
+async fn get_acp_agent_capabilities(
+    State(state): State<AuxiliaryRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+) -> Result<Json<ApiResponse<Option<AgentCapabilities>>>, AppError> {
+    let handle = get_task(&state, &id)?;
+
+    if handle.agent_type() != AgentType::Acp {
+        return Err(AppError::BadRequest(
+            "This endpoint is only available for ACP agents".into(),
+        ));
+    }
+
+    let acp = downcast_acp(&handle)?;
+    let capabilities = acp.agent_capabilities().await;
+    Ok(Json(ApiResponse::ok(capabilities)))
+}
+
 async fn get_openclaw_runtime(
     State(state): State<AuxiliaryRouterState>,
     Extension(_user): Extension<CurrentUser>,
@@ -360,4 +503,11 @@ fn get_task(
                 "No active agent for conversation '{conversation_id}'"
             ))
         })
+}
+
+fn downcast_acp(handle: &AgentManagerHandle) -> Result<&AcpAgentManager, AppError> {
+    handle
+        .as_any()
+        .downcast_ref::<AcpAgentManager>()
+        .ok_or_else(|| AppError::Internal("Failed to downcast to AcpAgentManager".into()))
 }

--- a/crates/aionui-ai-agent/src/factory.rs
+++ b/crates/aionui-ai-agent/src/factory.rs
@@ -149,6 +149,7 @@ async fn build_agent(
             .await?;
             let arc = Arc::new(agent);
             arc.start_permission_handler();
+            arc.start_runtime_snapshot_tracker();
             Ok(arc as AgentManagerHandle)
         }
         AgentType::OpenclawGateway => {

--- a/crates/aionui-ai-agent/src/first_message_injector.rs
+++ b/crates/aionui-ai-agent/src/first_message_injector.rs
@@ -59,11 +59,7 @@ pub async fn inject_first_message_prefix(
 mod tests {
     use super::*;
     use aionui_extension::{BUILTIN_SKILLS_ENV_VAR, resolve_skill_paths};
-    use std::sync::Mutex;
     use tempfile::TempDir;
-
-    /// `BUILTIN_SKILLS_ENV_VAR` is process-global; serialize tests that set it.
-    static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
     fn test_mgr(base: &std::path::Path) -> Arc<AcpSkillManager> {
         let paths = Arc::new(resolve_skill_paths(base, base));
@@ -72,14 +68,13 @@ mod tests {
 
     /// Point the embedded corpus at an empty dir so tests don't pick up
     /// real auto-inject builtin skills.
-    struct EmptyBuiltinGuard(std::sync::MutexGuard<'static, ()>);
+    struct EmptyBuiltinGuard;
     impl EmptyBuiltinGuard {
         fn new(empty_path: &std::path::Path) -> Self {
-            let g = ENV_MUTEX.lock().unwrap();
             unsafe {
                 std::env::set_var(BUILTIN_SKILLS_ENV_VAR, empty_path);
             }
-            Self(g)
+            Self
         }
     }
     impl Drop for EmptyBuiltinGuard {

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -3,6 +3,7 @@ pub mod acp_agent;
 pub mod acp_error;
 pub mod acp_protocol;
 pub mod acp_routes;
+pub mod acp_runtime_snapshot;
 pub mod acp_service;
 pub mod agent_manager;
 pub mod agent_registry;

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -146,6 +146,7 @@ fn event_type_name(event: &AgentStreamEvent) -> &'static str {
         AgentStreamEvent::Thinking(_) => "Thinking",
         AgentStreamEvent::Plan(_) => "Plan",
         AgentStreamEvent::Permission(_) => "Permission",
+        AgentStreamEvent::AcpPermission(_) => "AcpPermission",
         AgentStreamEvent::AcpToolCall(_) => "AcpToolCall",
         AgentStreamEvent::AvailableCommands(_) => "AvailableCommands",
         AgentStreamEvent::SkillSuggest(_) => "SkillSuggest",
@@ -280,19 +281,19 @@ async fn acp_agent_error_event_sets_finished() {
 async fn acp_agent_model_info_captured() {
     let _guard = serial();
     let (agent, mut rx) = make_mock_agent(
-        r#"echo '{"type":"acp_model_info","data":{"model_id":"claude-sonnet-4","model_name":"Claude Sonnet 4","provider":"anthropic"}}' && sleep 0.5"#,
+        r#"echo '{"type":"acp_model_info","data":{"current_model_id":"claude-sonnet-4","current_model_label":"Claude Sonnet 4","available_models":[{"id":"claude-sonnet-4","label":"Claude Sonnet 4"},{"id":"claude-opus-4","label":"Claude Opus 4"}],"can_switch":true,"source":"models","source_detail":"acp-models"}}' && sleep 0.5"#,
         AcpBackend::Claude,
     )
     .await;
 
     wait_for_event(&mut rx, |e| matches!(e, AgentStreamEvent::AcpModelInfo(_))).await;
 
-    let info = agent.get_model_info().await;
+    let info = agent.model_info().await;
     assert!(info.is_some(), "Model info should be captured");
     let info = info.unwrap();
-    assert_eq!(info.model_id, "claude-sonnet-4");
-    assert_eq!(info.model_name, Some("Claude Sonnet 4".into()));
-    assert_eq!(info.provider, Some("anthropic".into()));
+    assert_eq!(&*info.current_model_id.0, "claude-sonnet-4");
+    assert_eq!(info.available_models.len(), 2);
+    assert_eq!(info.available_models[0].name, "Claude Sonnet 4");
 
     agent.kill(None).unwrap();
 }

--- a/crates/aionui-api-types/src/acp.rs
+++ b/crates/aionui-api-types/src/acp.rs
@@ -58,6 +58,30 @@ pub struct SetModelRequest {
     pub model_id: String,
 }
 
+/// A single available model entry in the frontend-facing model info response.
+#[derive(Debug, Clone, Serialize)]
+pub struct ModelInfoEntry {
+    pub id: String,
+    pub label: String,
+}
+
+/// Frontend-compatible model info response.
+///
+/// Maps from the SDK's camelCase `SessionModelState` to the snake_case
+/// `AcpModelInfo` format the renderer expects.
+#[derive(Debug, Serialize)]
+pub struct GetModelInfoResponse {
+    pub model_info: Option<ModelInfoPayload>,
+}
+
+/// Inner model info payload matching the frontend's `AcpModelInfo` type.
+#[derive(Debug, Clone, Serialize)]
+pub struct ModelInfoPayload {
+    pub current_model_id: Option<String>,
+    pub current_model_label: Option<String>,
+    pub available_models: Vec<ModelInfoEntry>,
+}
+
 /// Request body for probing model information.
 #[derive(Debug, Deserialize)]
 pub struct ProbeModelRequest {

--- a/crates/aionui-api-types/src/acp.rs
+++ b/crates/aionui-api-types/src/acp.rs
@@ -70,6 +70,20 @@ pub struct SetConfigOptionRequest {
     pub value: String,
 }
 
+/// A single session config option update.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SessionConfigOptionUpdate {
+    pub config_id: String,
+    pub value: String,
+}
+
+/// Request body for setting multiple ACP config options.
+#[derive(Debug, Deserialize)]
+pub struct SetConfigOptionsRequest {
+    #[serde(default)]
+    pub config_options: Vec<SessionConfigOptionUpdate>,
+}
+
 /// Request body for testing a custom ACP agent.
 #[derive(Debug, Deserialize)]
 pub struct TestCustomAgentRequest {
@@ -84,6 +98,36 @@ pub struct TestCustomAgentRequest {
 #[derive(Debug, Serialize)]
 pub struct TestCustomAgentResponse {
     pub step: String,
+}
+
+/// Query parameters for workspace browse.
+#[derive(Debug, Deserialize)]
+pub struct WorkspaceBrowseQuery {
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub search: Option<String>,
+}
+
+/// A file or directory entry in the workspace browse response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceEntry {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub entry_type: String,
+}
+
+/// Request body for side question.
+#[derive(Debug, Deserialize)]
+pub struct SideQuestionRequest {
+    pub question: String,
+}
+
+/// Response for side question.
+#[derive(Debug, Serialize)]
+pub struct SideQuestionResponse {
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub answer: Option<String>,
 }
 
 #[cfg(test)]
@@ -158,6 +202,20 @@ mod tests {
         let json = json!({ "value": "dark" });
         let req: SetConfigOptionRequest = serde_json::from_value(json).unwrap();
         assert_eq!(req.value, "dark");
+    }
+
+    #[test]
+    fn set_config_options_request_serde() {
+        let json = json!({
+            "config_options": [
+                { "config_id": "model", "value": "claude-sonnet-4" },
+                { "config_id": "reasoning", "value": "high" }
+            ]
+        });
+        let req: SetConfigOptionsRequest = serde_json::from_value(json).unwrap();
+        assert_eq!(req.config_options.len(), 2);
+        assert_eq!(req.config_options[0].config_id, "model");
+        assert_eq!(req.config_options[1].value, "high");
     }
 
     #[test]

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -25,10 +25,10 @@ mod websocket;
 
 pub use acp::{
     AcpEnvResponse, AcpHealthCheckRequest, AcpHealthCheckResponse, AgentModeResponse,
-    DetectCliRequest, DetectCliResponse, ProbeModelRequest, SessionConfigOptionUpdate,
-    SetConfigOptionRequest, SetConfigOptionsRequest, SetModeRequest, SetModelRequest,
-    SideQuestionRequest, SideQuestionResponse, TestCustomAgentRequest, TestCustomAgentResponse,
-    WorkspaceBrowseQuery, WorkspaceEntry,
+    DetectCliRequest, DetectCliResponse, GetModelInfoResponse, ModelInfoEntry, ModelInfoPayload,
+    ProbeModelRequest, SessionConfigOptionUpdate, SetConfigOptionRequest, SetConfigOptionsRequest,
+    SetModeRequest, SetModelRequest, SideQuestionRequest, SideQuestionResponse,
+    TestCustomAgentRequest, TestCustomAgentResponse, WorkspaceBrowseQuery, WorkspaceEntry,
 };
 pub use agent::AgentInfo;
 pub use agent_discovery::{AgentSource, DetectedAgent, EnvVar};

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -25,8 +25,10 @@ mod websocket;
 
 pub use acp::{
     AcpEnvResponse, AcpHealthCheckRequest, AcpHealthCheckResponse, AgentModeResponse,
-    DetectCliRequest, DetectCliResponse, ProbeModelRequest, SetConfigOptionRequest, SetModeRequest,
-    SetModelRequest, TestCustomAgentRequest, TestCustomAgentResponse,
+    DetectCliRequest, DetectCliResponse, ProbeModelRequest, SessionConfigOptionUpdate,
+    SetConfigOptionRequest, SetConfigOptionsRequest, SetModeRequest, SetModelRequest,
+    SideQuestionRequest, SideQuestionResponse, TestCustomAgentRequest, TestCustomAgentResponse,
+    WorkspaceBrowseQuery, WorkspaceEntry,
 };
 pub use agent::AgentInfo;
 pub use agent_discovery::{AgentSource, DetectedAgent, EnvVar};


### PR DESCRIPTION
## Summary

- Consolidate per-conversation ACP session routes via a single `AcpRuntimeSnapshot` so caller-facing state (modes, model info, config options, capabilities, usage) is read from one cache instead of ad-hoc fields
- Populate the snapshot from `new_session` / `load_session` responses and emit initial model/mode/config events to WebSocket clients immediately after session create/load — frontend no longer has to wait for the first SDK notification
- Split `AcpCommand` into `AcpClientCommand` (client → agent) and `AcpAgentCommand` (agent → client) for symmetric bidirectional dispatch; return full SDK response types from `AcpProtocol` methods
- Add frontend-compatible `GetModelInfoResponse` / `ModelInfoPayload` / `ModelInfoEntry` and convert camelCase SDK model state to snake_case in the `get_model` route
- Drop the `/acp` prefix from per-conversation routes so ACP-only endpoints live under `/api/conversations/{id}/...` consistently with other domains

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy -p aionui-ai-agent -p aionui-api-types -- -D warnings`
- [ ] `cargo test -p aionui-ai-agent -p aionui-api-types`
- [ ] Manual: create a new ACP conversation and verify model/mode/config info appears on the client before the first message
- [ ] Manual: reload a conversation and verify snapshot state is rehydrated from `load_session` response

🤖 Generated with [Claude Code](https://claude.com/claude-code)