### PR TITLE
fix(cron): accept 5-field Unix cron expressions on create/update

### DIFF
--- a/crates/aionui-conversation/src/skill_resolver.rs
+++ b/crates/aionui-conversation/src/skill_resolver.rs
@@ -5,7 +5,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use aionui_extension::ResolvedAgentSkill;
+pub use aionui_extension::ResolvedAgentSkill;
 use async_trait::async_trait;
 
 #[async_trait]

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -771,6 +771,22 @@ mod tests {
             async fn auto_inject_names(&self) -> Vec<String> {
                 Vec::new()
             }
+
+            async fn resolve_skills(
+                &self,
+                _names: &[String],
+            ) -> Vec<aionui_conversation::skill_resolver::ResolvedAgentSkill> {
+                Vec::new()
+            }
+
+            async fn link_workspace_skills(
+                &self,
+                _workspace: &std::path::Path,
+                _rel_dirs: &[&str],
+                _skills: &[aionui_conversation::skill_resolver::ResolvedAgentSkill],
+            ) -> usize {
+                0
+            }
         }
 
         let stub_broadcaster: Arc<dyn aionui_realtime::EventBroadcaster> =

--- a/crates/aionui-cron/src/scheduler.rs
+++ b/crates/aionui-cron/src/scheduler.rs
@@ -15,8 +15,23 @@ use crate::types::{CronJob, CronSchedule};
 // Schedule validation
 // ---------------------------------------------------------------------------
 
+/// Normalize a cron expression so both 5-field (standard Unix) and 6-field
+/// (seconds-prefixed, as required by the `cron` crate) forms are accepted.
+/// A 5-field expression is promoted by prepending `0 ` for the seconds field.
+pub(crate) fn normalize_cron_expr(expr: &str) -> String {
+    let trimmed = expr.trim();
+    let field_count = trimmed.split_whitespace().count();
+    if field_count == 5 {
+        format!("0 {trimmed}")
+    } else {
+        trimmed.to_owned()
+    }
+}
+
 pub fn validate_cron_expression(expr: &str) -> Result<Schedule, CronError> {
-    Schedule::from_str(expr).map_err(|e| CronError::InvalidCronExpression(format!("{expr}: {e}")))
+    let normalized = normalize_cron_expr(expr);
+    Schedule::from_str(&normalized)
+        .map_err(|e| CronError::InvalidCronExpression(format!("{expr}: {e}")))
 }
 
 pub fn validate_timezone(tz: &str) -> Result<chrono_tz::Tz, CronError> {
@@ -42,7 +57,8 @@ pub fn compute_next_run(schedule: &CronSchedule, now: TimestampMs) -> Option<Tim
 }
 
 fn compute_cron_next_run(expr: &str, tz: Option<&str>, now: TimestampMs) -> Option<TimestampMs> {
-    let schedule = Schedule::from_str(expr).ok()?;
+    let normalized = normalize_cron_expr(expr);
+    let schedule = Schedule::from_str(&normalized).ok()?;
 
     if let Some(tz_str) = tz {
         let tz_parsed: chrono_tz::Tz = tz_str.parse().ok()?;
@@ -422,9 +438,33 @@ mod tests {
     }
 
     #[test]
+    fn validate_cron_expression_accepts_five_field_unix_form() {
+        // Standard 5-field Unix cron (minute hour day month dow) — must be
+        // auto-normalized to the 6-field form the `cron` crate requires.
+        assert!(validate_cron_expression("0 9 * * *").is_ok());
+        assert!(validate_cron_expression("30 14 * * MON-FRI").is_ok());
+        assert!(validate_cron_expression("0 10 * * WED").is_ok());
+        assert!(validate_cron_expression("0 * * * *").is_ok());
+    }
+
+    #[test]
     fn validate_cron_expression_invalid() {
         assert!(validate_cron_expression("not a cron").is_err());
         assert!(validate_cron_expression("").is_err());
+    }
+
+    #[test]
+    fn normalize_cron_expr_leaves_six_field_alone() {
+        assert_eq!(normalize_cron_expr("0 0 9 * * *"), "0 0 9 * * *");
+    }
+
+    #[test]
+    fn normalize_cron_expr_promotes_five_field() {
+        assert_eq!(normalize_cron_expr("0 9 * * *"), "0 0 9 * * *");
+        assert_eq!(
+            normalize_cron_expr("  30 14 * * MON-FRI  "),
+            "0 30 14 * * MON-FRI"
+        );
     }
 
     #[test]

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -225,6 +225,22 @@ async fn setup() -> (CronService, Arc<dyn ICronRepository>, Arc<MockBroadcaster>
         async fn auto_inject_names(&self) -> Vec<String> {
             Vec::new()
         }
+
+        async fn resolve_skills(
+            &self,
+            _names: &[String],
+        ) -> Vec<aionui_conversation::skill_resolver::ResolvedAgentSkill> {
+            Vec::new()
+        }
+
+        async fn link_workspace_skills(
+            &self,
+            _workspace: &std::path::Path,
+            _rel_dirs: &[&str],
+            _skills: &[aionui_conversation::skill_resolver::ResolvedAgentSkill],
+        ) -> usize {
+            0
+        }
     }
 
     let stub_conv_repo: Arc<dyn IConversationRepository> = Arc::new(StubConvRepo);


### PR DESCRIPTION
## Summary

- Normalize 5-field Unix cron (`minute hour dom mon dow`) to the 6-field form required by `cron = 0.15` by prepending `0 ` as the seconds field. Both 5- and 6-field forms now validate and schedule correctly.
- Fix pre-existing breakage in `StubSkillResolver` (cron executor unit tests + cron service integration tests) so `cargo test -p aionui-cron` runs; re-export `ResolvedAgentSkill` from `aionui-conversation` for downstream stubs.

## Why

AionUi frontend's `CreateTaskDialog` emits standard 5-field Unix cron (e.g. `0 9 * * *`). On edit, `PUT /api/cron/jobs/:id` went through `validate_schedule` → `Schedule::from_str` and consistently failed with:

```
Bad request: 0 9 * * *: 0 9 * * *
         ^
```

This is `CronError::InvalidCronExpression(format!("{expr}: {e}"))` concatenated with the `cron` crate's own echo of the expression — the field count simply didn't match what the crate expects.

## Test plan

- [x] `cargo test -p aionui-cron` — 126 unit + 35 integration tests pass, including 4 new tests covering the 5-field forms (`0 9 * * *`, `30 14 * * MON-FRI`, `0 10 * * WED`, `0 * * * *`) and `normalize_cron_expr`.
- [x] `cargo check --workspace` — clean.
- [ ] Manual: edit an existing task in AionUi, save — confirm no 400.