### PR TITLE
feat(cron): finish backend migration runtime flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,7 @@ dependencies = [
  "dashmap",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -92,6 +92,8 @@ pub struct AcpAgentManager {
     backend: AcpBackend,
     /// Build configuration (preset context, enabled/excluded skills, session mode, …).
     config: AcpBuildExtra,
+    /// Preferred session mode to apply on the next session initialization.
+    preferred_mode: RwLock<Option<String>>,
     /// Underlying CLI process (for lifecycle management: kill, is_running).
     process: Arc<CliAgentProcess>,
     /// ACP protocol handle (SDK connection).
@@ -122,6 +124,50 @@ impl AcpAgentManager {
     pub async fn modes(&self) -> Option<SessionModeState> {
         let snapshot = self.runtime_snapshot.read().await;
         snapshot.modes().cloned()
+    }
+
+    async fn preferred_mode(&self) -> Option<String> {
+        self.preferred_mode
+            .read()
+            .await
+            .clone()
+            .filter(|mode| !mode.is_empty())
+    }
+
+    async fn update_cached_mode(&self, mode: &str) {
+        let mut snapshot = self.runtime_snapshot.write().await;
+        if let Some(modes) = snapshot.modes().cloned() {
+            snapshot.set_modes(SessionModeState::new(
+                mode.to_owned(),
+                modes.available_modes,
+            ));
+        }
+    }
+
+    async fn apply_preferred_mode(&self, session_id: &str) -> Result<(), AppError> {
+        let Some(mode) = self.preferred_mode().await else {
+            return Ok(());
+        };
+
+        let current_mode = {
+            let snapshot = self.runtime_snapshot.read().await;
+            snapshot.current_mode_id()
+        };
+
+        if current_mode.as_deref() == Some(mode.as_str()) {
+            return Ok(());
+        }
+
+        self.protocol
+            .set_mode(SetSessionModeRequest::new(
+                SessionId::new(session_id),
+                mode.clone(),
+            ))
+            .await
+            .map_err(AppError::from)?;
+
+        self.update_cached_mode(&mode).await;
+        Ok(())
     }
 
     async fn _set_modes(&self, mode: &str) -> Result<(), AppError> {
@@ -264,6 +310,7 @@ impl AcpAgentManager {
             workspace,
             is_custom_workspace,
             backend,
+            preferred_mode: RwLock::new(config.session_mode.clone()),
             config,
             process: Arc::new(process),
             protocol,
@@ -403,6 +450,8 @@ impl AcpAgentManager {
             let mut state = self.state.write().await;
             state.session_id = Some(sid.clone());
         }
+
+        self.apply_preferred_mode(&sid).await?;
 
         // Inject first-message prefix (preset context + skills index).
         // Backends with native skill discovery (e.g. Claude via .claude/skills/)
@@ -725,27 +774,35 @@ impl crate::agent_manager::IAgentManager for AcpAgentManager {
     }
 
     async fn get_mode(&self) -> Result<aionui_api_types::AgentModeResponse, AppError> {
+        let preferred_mode = self.preferred_mode().await;
         Ok(aionui_api_types::AgentModeResponse {
             mode: self
                 .modes()
                 .await
                 .map(|modes| modes.current_mode_id.to_string())
-                .or_else(|| self.config.session_mode.clone())
+                .or(preferred_mode)
                 .unwrap_or_else(|| "default".to_owned()),
             initialized: self.session_id().await.is_some(),
         })
     }
 
     async fn set_mode(&self, mode: &str) -> Result<(), AppError> {
-        let sid = self.require_session_id().await?;
-        self.protocol
-            .set_mode(SetSessionModeRequest::new(
-                SessionId::new(sid),
-                mode.to_owned(),
-            ))
-            .await
-            .map_err(AppError::from)
-            .map(|_| ())
+        let session_id = self.state.read().await.session_id.clone();
+
+        if let Some(sid) = session_id {
+            self.protocol
+                .set_mode(SetSessionModeRequest::new(
+                    SessionId::new(sid),
+                    mode.to_owned(),
+                ))
+                .await
+                .map_err(AppError::from)?;
+            self.update_cached_mode(mode).await;
+        }
+
+        let mut preferred_mode = self.preferred_mode.write().await;
+        *preferred_mode = Some(mode.to_owned());
+        Ok(())
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -47,6 +47,27 @@ impl SessionResumeStrategy {
     }
 }
 
+fn normalize_requested_mode(backend: AcpBackend, mode: &str) -> String {
+    let trimmed = mode.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    match backend {
+        // Codex ACP now reports native mode ids (`read-only`, `auto`,
+        // `full-access`) while existing AionUi flows still persist the legacy
+        // semantic ids (`default`, `autoEdit`, `yolo`, `yoloNoSandbox`).
+        // Cron reuses the persisted value directly, so normalize it before
+        // comparing or calling `session/set_mode`.
+        AcpBackend::Codex => match trimmed {
+            "default" | "autoEdit" => "auto".to_owned(),
+            "yolo" | "yoloNoSandbox" => "full-access".to_owned(),
+            other => other.to_owned(),
+        },
+        _ => trimmed.to_owned(),
+    }
+}
+
 fn confirm_option_id(data: &Value) -> Option<String> {
     match data {
         Value::String(v) => Some(v.clone()),
@@ -148,25 +169,31 @@ impl AcpAgentManager {
         let Some(mode) = self.preferred_mode().await else {
             return Ok(());
         };
+        let normalized_mode = normalize_requested_mode(self.backend, &mode);
+        if normalized_mode.is_empty() {
+            return Ok(());
+        }
 
         let current_mode = {
             let snapshot = self.runtime_snapshot.read().await;
             snapshot.current_mode_id()
         };
 
-        if current_mode.as_deref() == Some(mode.as_str()) {
+        if current_mode.as_deref() == Some(normalized_mode.as_str()) {
             return Ok(());
         }
 
         self.protocol
             .set_mode(SetSessionModeRequest::new(
                 SessionId::new(session_id),
-                mode.clone(),
+                normalized_mode.clone(),
             ))
             .await
             .map_err(AppError::from)?;
 
-        self.update_cached_mode(&mode).await;
+        self.update_cached_mode(&normalized_mode).await;
+        let mut preferred_mode = self.preferred_mode.write().await;
+        *preferred_mode = Some(normalized_mode);
         Ok(())
     }
 
@@ -774,34 +801,42 @@ impl crate::agent_manager::IAgentManager for AcpAgentManager {
     }
 
     async fn get_mode(&self) -> Result<aionui_api_types::AgentModeResponse, AppError> {
-        let preferred_mode = self.preferred_mode().await;
+        let preferred_mode = self
+            .preferred_mode()
+            .await
+            .map(|mode| normalize_requested_mode(self.backend, &mode))
+            .filter(|mode| !mode.is_empty());
         Ok(aionui_api_types::AgentModeResponse {
             mode: self
                 .modes()
                 .await
                 .map(|modes| modes.current_mode_id.to_string())
                 .or(preferred_mode)
-                .unwrap_or_else(|| "default".to_owned()),
+                .unwrap_or_else(|| normalize_requested_mode(self.backend, "default")),
             initialized: self.session_id().await.is_some(),
         })
     }
 
     async fn set_mode(&self, mode: &str) -> Result<(), AppError> {
+        let normalized_mode = normalize_requested_mode(self.backend, mode);
+        if normalized_mode.is_empty() {
+            return Ok(());
+        }
         let session_id = self.state.read().await.session_id.clone();
 
         if let Some(sid) = session_id {
             self.protocol
                 .set_mode(SetSessionModeRequest::new(
                     SessionId::new(sid),
-                    mode.to_owned(),
+                    normalized_mode.clone(),
                 ))
                 .await
                 .map_err(AppError::from)?;
-            self.update_cached_mode(mode).await;
+            self.update_cached_mode(&normalized_mode).await;
         }
 
         let mut preferred_mode = self.preferred_mode.write().await;
-        *preferred_mode = Some(mode.to_owned());
+        *preferred_mode = Some(normalized_mode);
         Ok(())
     }
 
@@ -852,6 +887,34 @@ mod tests {
         assert_eq!(
             confirm_option_id(&json!({ "value": "allow_always" })).as_deref(),
             Some("allow_always")
+        );
+    }
+
+    #[test]
+    fn normalize_requested_mode_maps_legacy_codex_modes() {
+        assert_eq!(
+            normalize_requested_mode(AcpBackend::Codex, "default"),
+            "auto"
+        );
+        assert_eq!(
+            normalize_requested_mode(AcpBackend::Codex, "autoEdit"),
+            "auto"
+        );
+        assert_eq!(
+            normalize_requested_mode(AcpBackend::Codex, "yolo"),
+            "full-access"
+        );
+        assert_eq!(
+            normalize_requested_mode(AcpBackend::Codex, "yoloNoSandbox"),
+            "full-access"
+        );
+        assert_eq!(
+            normalize_requested_mode(AcpBackend::Codex, "read-only"),
+            "read-only"
+        );
+        assert_eq!(
+            normalize_requested_mode(AcpBackend::Claude, "bypassPermissions"),
+            "bypassPermissions"
         );
     }
 }

--- a/crates/aionui-ai-agent/src/auxiliary_routes.rs
+++ b/crates/aionui-ai-agent/src/auxiliary_routes.rs
@@ -6,11 +6,11 @@ use axum::extract::{Extension, Json, Path, Query, State};
 use axum::routing::{get, post};
 
 use crate::acp_agent::AcpAgentManager;
-use agent_client_protocol::schema::{AgentCapabilities, SessionConfigOption, UsageUpdate};
 use crate::agent_manager::AgentManagerHandle;
 use crate::openclaw::OpenClawAgentManager;
 use crate::task_manager::IWorkerTaskManager;
 use crate::types::SlashCommandItem;
+use agent_client_protocol::schema::{AgentCapabilities, SessionConfigOption, UsageUpdate};
 use aionui_api_types::{
     AgentModeResponse, ApiResponse, GetModelInfoResponse, ModelInfoEntry, ModelInfoPayload,
     SetConfigOptionRequest, SetConfigOptionsRequest, SetModeRequest, SetModelRequest,

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -50,9 +50,9 @@ pub use connection_test_service::ConnectionTestService;
 pub use factory::{AgentFactoryDeps, build_agent_factory};
 pub use idle_scanner::start_idle_scanner;
 pub use middleware::{
-    CronCommand, CronCommandResult, CronCreateParams, ICronService, MessageMiddleware,
-    MiddlewareResult, detect_cron_commands, has_cron_commands, strip_cron_commands,
-    strip_think_tags,
+    CronCommand, CronCommandResult, CronCreateParams, CronUpdateParams, ICronService,
+    MessageMiddleware, MiddlewareResult, detect_cron_commands, has_cron_commands,
+    strip_cron_commands, strip_think_tags,
 };
 pub use nanobot_agent::NanobotAgentManager;
 pub use openclaw::OpenClawAgentManager;

--- a/crates/aionui-ai-agent/src/middleware.rs
+++ b/crates/aionui-ai-agent/src/middleware.rs
@@ -29,6 +29,12 @@ static CRON_CREATE_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?s)\[CRON_CREATE\]\s*(.*?)\s*\[/CRON_CREATE\]").expect("valid cron-create regex")
 });
 
+/// Regex for `[CRON_UPDATE: <id>]...[/CRON_UPDATE]` blocks (dot-all).
+static CRON_UPDATE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?s)\[CRON_UPDATE:\s*([^\]]+)\]\s*(.*?)\s*\[/CRON_UPDATE\]")
+        .expect("valid cron-update regex")
+});
+
 /// Regex for `[CRON_LIST]`.
 static CRON_LIST_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\[CRON_LIST\]").expect("valid cron-list regex"));
@@ -41,6 +47,7 @@ static CRON_DELETE_RE: LazyLock<Regex> =
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CronCommand {
     Create(CronCreateParams),
+    Update(CronUpdateParams),
     List,
     Delete(String),
 }
@@ -48,6 +55,16 @@ pub enum CronCommand {
 /// Parameters for a cron-create command.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CronCreateParams {
+    pub name: String,
+    pub schedule: String,
+    pub schedule_description: String,
+    pub message: String,
+}
+
+/// Parameters for a cron-update command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CronUpdateParams {
+    pub job_id: String,
     pub name: String,
     pub schedule: String,
     pub schedule_description: String,
@@ -63,6 +80,15 @@ pub fn detect_cron_commands(text: &str) -> Vec<CronCommand> {
             && let Some(params) = parse_cron_create_body(body.as_str())
         {
             commands.push(CronCommand::Create(params));
+        }
+    }
+
+    for cap in CRON_UPDATE_RE.captures_iter(text) {
+        if let (Some(job_id_match), Some(body)) = (cap.get(1), cap.get(2))
+            && let Some(params) =
+                parse_cron_update_body(job_id_match.as_str().trim(), body.as_str())
+        {
+            commands.push(CronCommand::Update(params));
         }
     }
 
@@ -84,15 +110,27 @@ pub fn detect_cron_commands(text: &str) -> Vec<CronCommand> {
 
 /// Quick check: does the text contain any cron commands?
 pub fn has_cron_commands(text: &str) -> bool {
-    CRON_CREATE_RE.is_match(text) || CRON_LIST_RE.is_match(text) || CRON_DELETE_RE.is_match(text)
+    CRON_CREATE_RE.is_match(text)
+        || CRON_UPDATE_RE.is_match(text)
+        || CRON_LIST_RE.is_match(text)
+        || CRON_DELETE_RE.is_match(text)
 }
 
 /// Strip all cron command tags from text, returning cleaned content.
 pub fn strip_cron_commands(text: &str) -> String {
     let result = CRON_CREATE_RE.replace_all(text, "");
+    let result = CRON_UPDATE_RE.replace_all(&result, "");
     let result = CRON_LIST_RE.replace_all(&result, "");
     let result = CRON_DELETE_RE.replace_all(&result, "");
     result.into_owned()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CronCommandFields {
+    name: Option<String>,
+    schedule: Option<String>,
+    schedule_description: Option<String>,
+    message: Option<String>,
 }
 
 /// Parse the body of a `[CRON_CREATE]...[/CRON_CREATE]` block.
@@ -104,7 +142,7 @@ pub fn strip_cron_commands(text: &str) -> String {
 /// schedule_description: <human-readable>
 /// message: <prompt text>
 /// ```
-fn parse_cron_create_body(body: &str) -> Option<CronCreateParams> {
+fn parse_cron_command_body(body: &str) -> Option<CronCommandFields> {
     let mut name = None;
     let mut schedule = None;
     let mut schedule_description = None;
@@ -123,11 +161,36 @@ fn parse_cron_create_body(body: &str) -> Option<CronCreateParams> {
         }
     }
 
+    Some(CronCommandFields {
+        name,
+        schedule,
+        schedule_description,
+        message,
+    })
+}
+
+fn parse_cron_create_body(body: &str) -> Option<CronCreateParams> {
+    let fields = parse_cron_command_body(body)?;
     Some(CronCreateParams {
-        name: name.unwrap_or_default(),
-        schedule: schedule?,
-        schedule_description: schedule_description.unwrap_or_default(),
-        message: message.unwrap_or_default(),
+        name: fields.name.unwrap_or_default(),
+        schedule: fields.schedule?,
+        schedule_description: fields.schedule_description.unwrap_or_default(),
+        message: fields.message.unwrap_or_default(),
+    })
+}
+
+fn parse_cron_update_body(job_id: &str, body: &str) -> Option<CronUpdateParams> {
+    if job_id.is_empty() {
+        return None;
+    }
+
+    let fields = parse_cron_command_body(body)?;
+    Some(CronUpdateParams {
+        job_id: job_id.to_string(),
+        name: fields.name?,
+        schedule: fields.schedule?,
+        schedule_description: fields.schedule_description?,
+        message: fields.message?,
     })
 }
 
@@ -156,8 +219,17 @@ pub trait ICronService: Send + Sync {
         params: &CronCreateParams,
     ) -> CronCommandResult;
 
-    /// List cron jobs. Returns a formatted text response.
-    async fn list_jobs(&self, user_id: &str) -> CronCommandResult;
+    /// Update an existing cron job.
+    async fn update_job(
+        &self,
+        user_id: &str,
+        conversation_id: &str,
+        params: &CronUpdateParams,
+    ) -> CronCommandResult;
+
+    /// List cron jobs for the current conversation scope.
+    /// Returns a formatted text response.
+    async fn list_jobs(&self, user_id: &str, conversation_id: &str) -> CronCommandResult;
 
     /// Delete a cron job by ID.
     async fn delete_job(&self, user_id: &str, job_id: &str) -> CronCommandResult;
@@ -252,7 +324,12 @@ impl MessageMiddleware {
                         .create_job(user_id, conversation_id, params)
                         .await
                 }
-                CronCommand::List => cron_service.list_jobs(user_id).await,
+                CronCommand::Update(params) => {
+                    cron_service
+                        .update_job(user_id, conversation_id, params)
+                        .await
+                }
+                CronCommand::List => cron_service.list_jobs(user_id, conversation_id).await,
                 CronCommand::Delete(id) => cron_service.delete_job(user_id, id).await,
             };
 
@@ -364,6 +441,23 @@ mod tests {
     }
 
     #[test]
+    fn detect_cron_update_command() {
+        let input = "[CRON_UPDATE: job-123]\nname: Updated Job\nschedule: 0 10 * * *\nschedule_description: Daily at 10am\nmessage: Updated instructions\n[/CRON_UPDATE]";
+        let commands = detect_cron_commands(input);
+        assert_eq!(commands.len(), 1);
+        match &commands[0] {
+            CronCommand::Update(params) => {
+                assert_eq!(params.job_id, "job-123");
+                assert_eq!(params.name, "Updated Job");
+                assert_eq!(params.schedule, "0 10 * * *");
+                assert_eq!(params.schedule_description, "Daily at 10am");
+                assert_eq!(params.message, "Updated instructions");
+            }
+            _ => panic!("Expected CronCommand::Update"),
+        }
+    }
+
+    #[test]
     fn detect_cron_delete_command() {
         let input = "[CRON_DELETE: job-123]";
         let commands = detect_cron_commands(input);
@@ -373,12 +467,13 @@ mod tests {
 
     #[test]
     fn detect_mixed_cron_commands() {
-        let input = "I'll manage your crons.\n[CRON_CREATE]\nname: test\nschedule: * * * * *\nschedule_description: every minute\nmessage: ping\n[/CRON_CREATE]\nAlso listing: [CRON_LIST]\nAnd deleting: [CRON_DELETE: old-job]";
+        let input = "I'll manage your crons.\n[CRON_CREATE]\nname: test\nschedule: * * * * *\nschedule_description: every minute\nmessage: ping\n[/CRON_CREATE]\nUpdate too: [CRON_UPDATE: existing-job]\nname: updated\nschedule: 0 * * * *\nschedule_description: hourly\nmessage: pong\n[/CRON_UPDATE]\nAlso listing: [CRON_LIST]\nAnd deleting: [CRON_DELETE: old-job]";
         let commands = detect_cron_commands(input);
-        assert_eq!(commands.len(), 3);
+        assert_eq!(commands.len(), 4);
         assert!(matches!(&commands[0], CronCommand::Create(_)));
-        assert_eq!(commands[1], CronCommand::List);
-        assert_eq!(commands[2], CronCommand::Delete("old-job".to_string()));
+        assert!(matches!(&commands[1], CronCommand::Update(_)));
+        assert_eq!(commands[2], CronCommand::List);
+        assert_eq!(commands[3], CronCommand::Delete("old-job".to_string()));
     }
 
     #[test]
@@ -404,6 +499,9 @@ mod tests {
         assert!(has_cron_commands("[CRON_LIST]"));
         assert!(has_cron_commands("[CRON_DELETE: x]"));
         assert!(has_cron_commands(
+            "[CRON_UPDATE: x]\nschedule: *\n[/CRON_UPDATE]"
+        ));
+        assert!(has_cron_commands(
             "[CRON_CREATE]\nschedule: *\n[/CRON_CREATE]"
         ));
     }
@@ -420,7 +518,7 @@ mod tests {
 
     #[test]
     fn strip_cron_commands_all_types() {
-        let input = "Before [CRON_LIST] middle [CRON_DELETE: abc] after [CRON_CREATE]\nname: t\nschedule: *\n[/CRON_CREATE] end";
+        let input = "Before [CRON_LIST] middle [CRON_DELETE: abc] after [CRON_CREATE]\nname: t\nschedule: *\n[/CRON_CREATE] and [CRON_UPDATE: abc]\nname: t2\nschedule: 0 * * * *\n[/CRON_UPDATE] end";
         let stripped = strip_cron_commands(input);
         assert!(!stripped.contains("[CRON_"));
         assert!(stripped.contains("Before"));
@@ -464,6 +562,29 @@ mod tests {
     }
 
     #[test]
+    fn parse_cron_update_body_full() {
+        let body = "name: Updated\nschedule: 0 9 * * *\nschedule_description: Daily 9am\nmessage: Run tests";
+        let params = parse_cron_update_body("job-7", body).unwrap();
+        assert_eq!(params.job_id, "job-7");
+        assert_eq!(params.name, "Updated");
+        assert_eq!(params.schedule, "0 9 * * *");
+        assert_eq!(params.schedule_description, "Daily 9am");
+        assert_eq!(params.message, "Run tests");
+    }
+
+    #[test]
+    fn parse_cron_update_body_requires_job_id() {
+        let body = "name: Updated\nschedule: 0 9 * * *";
+        assert!(parse_cron_update_body("", body).is_none());
+    }
+
+    #[test]
+    fn parse_cron_update_body_requires_all_fields() {
+        let body = "name: Updated\nschedule: 0 9 * * *\nmessage: Run tests";
+        assert!(parse_cron_update_body("job-7", body).is_none());
+    }
+
+    #[test]
     fn parse_cron_create_body_schedule_description_before_schedule() {
         // schedule_description should match before schedule due to prefix ordering
         let body = "schedule_description: desc first\nschedule: 0 * * * *\nname: test";
@@ -492,7 +613,19 @@ mod tests {
             }
         }
 
-        async fn list_jobs(&self, _user_id: &str) -> CronCommandResult {
+        async fn update_job(
+            &self,
+            _user_id: &str,
+            _conversation_id: &str,
+            params: &CronUpdateParams,
+        ) -> CronCommandResult {
+            CronCommandResult {
+                success: true,
+                message: format!("Updated cron job '{}'", params.job_id),
+            }
+        }
+
+        async fn list_jobs(&self, _user_id: &str, _conversation_id: &str) -> CronCommandResult {
             CronCommandResult {
                 success: true,
                 message: "No cron jobs found".to_string(),
@@ -531,6 +664,17 @@ mod tests {
         assert!(result.display_message.is_some());
         assert_eq!(result.system_responses.len(), 1);
         assert!(result.system_responses[0].contains("Created cron job"));
+    }
+
+    #[tokio::test]
+    async fn middleware_processes_cron_update() {
+        let mw = MessageMiddleware::new(Some(Box::new(MockCronService)));
+        let input = "Updated it. [CRON_UPDATE: job-99]\nname: daily\nschedule: 0 10 * * *\nschedule_description: Daily\nmessage: run\n[/CRON_UPDATE]";
+        let result = mw.process(input, "user1", "conv1").await;
+        assert!(!result.message.contains("[CRON_UPDATE"));
+        assert!(result.display_message.is_some());
+        assert_eq!(result.system_responses.len(), 1);
+        assert!(result.system_responses[0].contains("Updated cron job 'job-99'"));
     }
 
     #[tokio::test]

--- a/crates/aionui-ai-agent/tests/middleware_integration.rs
+++ b/crates/aionui-ai-agent/tests/middleware_integration.rs
@@ -6,8 +6,9 @@
 //! - MessageMiddleware pipeline end-to-end
 
 use aionui_ai_agent::{
-    CronCommand, CronCommandResult, CronCreateParams, ICronService, MessageMiddleware,
-    detect_cron_commands, has_cron_commands, strip_cron_commands, strip_think_tags,
+    CronCommand, CronCommandResult, CronCreateParams, CronUpdateParams, ICronService,
+    MessageMiddleware, detect_cron_commands, has_cron_commands, strip_cron_commands,
+    strip_think_tags,
 };
 use async_trait::async_trait;
 
@@ -98,6 +99,23 @@ fn detect_cron_list() {
 }
 
 #[test]
+fn detect_cron_update_with_all_fields() {
+    let input = "[CRON_UPDATE: job-456]\nname: 更新后的任务\nschedule: 0 10 * * MON\nschedule_description: 每周一上午 10 点\nmessage: 请发送更新后的提醒\n[/CRON_UPDATE]";
+    let commands = detect_cron_commands(input);
+    assert_eq!(commands.len(), 1);
+    match &commands[0] {
+        CronCommand::Update(params) => {
+            assert_eq!(params.job_id, "job-456");
+            assert_eq!(params.name, "更新后的任务");
+            assert_eq!(params.schedule, "0 10 * * MON");
+            assert_eq!(params.schedule_description, "每周一上午 10 点");
+            assert_eq!(params.message, "请发送更新后的提醒");
+        }
+        _ => panic!("Expected Update"),
+    }
+}
+
+#[test]
 fn detect_cron_delete_with_id() {
     let input = "[CRON_DELETE: job-123]";
     let commands = detect_cron_commands(input);
@@ -107,12 +125,13 @@ fn detect_cron_delete_with_id() {
 
 #[test]
 fn detect_mixed_content_with_cron() {
-    let input = "Here's what I did:\n\n[CRON_CREATE]\nname: cleanup\nschedule: 0 0 * * *\nschedule_description: daily midnight\nmessage: clean old files\n[/CRON_CREATE]\n\nAlso check: [CRON_LIST]\n\nAnd remove old one: [CRON_DELETE: old-123]";
+    let input = "Here's what I did:\n\n[CRON_CREATE]\nname: cleanup\nschedule: 0 0 * * *\nschedule_description: daily midnight\nmessage: clean old files\n[/CRON_CREATE]\n\nThen updated one:\n[CRON_UPDATE: job-22]\nname: cleanup-v2\nschedule: 0 1 * * *\nschedule_description: daily 1am\nmessage: clean old files carefully\n[/CRON_UPDATE]\n\nAlso check: [CRON_LIST]\n\nAnd remove old one: [CRON_DELETE: old-123]";
     let commands = detect_cron_commands(input);
-    assert_eq!(commands.len(), 3);
+    assert_eq!(commands.len(), 4);
     assert!(matches!(&commands[0], CronCommand::Create(_)));
-    assert_eq!(commands[1], CronCommand::List);
-    assert_eq!(commands[2], CronCommand::Delete("old-123".to_string()));
+    assert!(matches!(&commands[1], CronCommand::Update(_)));
+    assert_eq!(commands[2], CronCommand::List);
+    assert_eq!(commands[3], CronCommand::Delete("old-123".to_string()));
 }
 
 #[test]
@@ -126,6 +145,9 @@ fn has_cron_detects_all_types() {
     assert!(has_cron_commands(
         "[CRON_CREATE]\nschedule: *\n[/CRON_CREATE]"
     ));
+    assert!(has_cron_commands(
+        "[CRON_UPDATE: job-1]\nschedule: *\n[/CRON_UPDATE]"
+    ));
     assert!(has_cron_commands("[CRON_LIST]"));
     assert!(has_cron_commands("[CRON_DELETE: x]"));
     assert!(!has_cron_commands("nothing here"));
@@ -133,7 +155,7 @@ fn has_cron_detects_all_types() {
 
 #[test]
 fn strip_cron_removes_all_types_preserves_text() {
-    let input = "Before\n[CRON_CREATE]\nname: t\nschedule: *\n[/CRON_CREATE]\nMiddle [CRON_LIST] After [CRON_DELETE: x] End";
+    let input = "Before\n[CRON_CREATE]\nname: t\nschedule: *\n[/CRON_CREATE]\nMiddle [CRON_LIST] After [CRON_DELETE: x] Between [CRON_UPDATE: id-7]\nname: t2\nschedule: 0 * * * *\n[/CRON_UPDATE] End";
     let stripped = strip_cron_commands(input);
     assert!(!stripped.contains("[CRON_"));
     assert!(stripped.contains("Before"));
@@ -195,10 +217,28 @@ impl ICronService for TrackingCronService {
         }
     }
 
-    async fn list_jobs(&self, _user_id: &str) -> CronCommandResult {
+    async fn update_job(
+        &self,
+        _user_id: &str,
+        conversation_id: &str,
+        params: &CronUpdateParams,
+    ) -> CronCommandResult {
         CronCommandResult {
             success: true,
-            message: "Active jobs: daily-check (0 9 * * *)".to_string(),
+            message: format!(
+                "Job '{}' updated in conversation '{}'",
+                params.job_id, conversation_id
+            ),
+        }
+    }
+
+    async fn list_jobs(&self, _user_id: &str, conversation_id: &str) -> CronCommandResult {
+        CronCommandResult {
+            success: true,
+            message: format!(
+                "Active jobs for '{}': daily-check (0 9 * * *)",
+                conversation_id
+            ),
         }
     }
 
@@ -227,7 +267,19 @@ impl ICronService for FailingCronService {
         }
     }
 
-    async fn list_jobs(&self, _user_id: &str) -> CronCommandResult {
+    async fn update_job(
+        &self,
+        _user_id: &str,
+        _conversation_id: &str,
+        _params: &CronUpdateParams,
+    ) -> CronCommandResult {
+        CronCommandResult {
+            success: false,
+            message: "Update rejected".to_string(),
+        }
+    }
+
+    async fn list_jobs(&self, _user_id: &str, _conversation_id: &str) -> CronCommandResult {
         CronCommandResult {
             success: false,
             message: "Service unavailable".to_string(),
@@ -280,7 +332,19 @@ async fn middleware_executes_cron_list() {
 
     assert!(!result.message.contains("[CRON_LIST]"));
     assert_eq!(result.system_responses.len(), 1);
-    assert!(result.system_responses[0].contains("Active jobs"));
+    assert!(result.system_responses[0].contains("Active jobs for 'c1'"));
+}
+
+#[tokio::test]
+async fn middleware_executes_cron_update() {
+    let mw = MessageMiddleware::new(Some(Box::new(TrackingCronService)));
+    let input = "Updating it now. [CRON_UPDATE: job-42]\nname: renamed\nschedule: 0 8 * * *\nschedule_description: Daily at 8am\nmessage: New prompt\n[/CRON_UPDATE]";
+    let result = mw.process(input, "u1", "c1").await;
+
+    assert!(!result.message.contains("[CRON_UPDATE"));
+    assert_eq!(result.system_responses.len(), 1);
+    assert!(result.system_responses[0].contains("job-42"));
+    assert!(result.system_responses[0].contains("c1"));
 }
 
 #[tokio::test]
@@ -297,12 +361,12 @@ async fn middleware_executes_cron_delete() {
 #[tokio::test]
 async fn middleware_handles_cron_failure() {
     let mw = MessageMiddleware::new(Some(Box::new(FailingCronService)));
-    let input = "[CRON_DELETE: x]";
+    let input = "[CRON_UPDATE: x]\nname: renamed\nschedule: 0 8 * * *\nschedule_description: Daily at 8am\nmessage: New prompt\n[/CRON_UPDATE]";
     let result = mw.process(input, "u1", "c1").await;
 
     assert_eq!(result.system_responses.len(), 1);
     assert!(result.system_responses[0].contains("System Error"));
-    assert!(result.system_responses[0].contains("Permission denied"));
+    assert!(result.system_responses[0].contains("Update rejected"));
 }
 
 #[tokio::test]
@@ -335,8 +399,8 @@ async fn middleware_combined_think_tags_and_cron_commands() {
 #[tokio::test]
 async fn middleware_multiple_cron_commands_all_executed() {
     let mw = MessageMiddleware::new(Some(Box::new(TrackingCronService)));
-    let input = "[CRON_CREATE]\nname: job1\nschedule: 0 * * * *\n[/CRON_CREATE] and [CRON_LIST] and [CRON_DELETE: old]";
+    let input = "[CRON_CREATE]\nname: job1\nschedule: 0 * * * *\n[/CRON_CREATE] and [CRON_UPDATE: old]\nname: job2\nschedule: 0 1 * * *\nschedule_description: daily 1am\nmessage: New prompt\n[/CRON_UPDATE] and [CRON_LIST] and [CRON_DELETE: old]";
     let result = mw.process(input, "u1", "c1").await;
 
-    assert_eq!(result.system_responses.len(), 3);
+    assert_eq!(result.system_responses.len(), 4);
 }

--- a/crates/aionui-api-types/src/conversation.rs
+++ b/crates/aionui-api-types/src/conversation.rs
@@ -46,6 +46,8 @@ pub struct SendMessageRequest {
     pub files: Vec<String>,
     #[serde(default)]
     pub inject_skills: Vec<String>,
+    #[serde(default)]
+    pub hidden: bool,
 }
 
 // ── Query types ────────────────────────────────────────────────────
@@ -66,6 +68,12 @@ pub struct ListMessagesQuery {
     pub page: Option<u32>,
     pub page_size: Option<u32>,
     pub order: Option<String>,
+}
+
+/// Body for `PATCH /api/conversations/:id/artifacts/:artifact_id`.
+#[derive(Debug, Deserialize)]
+pub struct UpdateConversationArtifactRequest {
+    pub status: ConversationArtifactStatus,
 }
 
 /// Query parameters for `GET /api/messages/search`.
@@ -114,6 +122,40 @@ pub struct MessageResponse {
 
 /// Paginated list of messages.
 pub type MessageListResponse = PaginatedResult<MessageResponse>;
+
+/// Artifact kind discriminant for conversation-bound UI artifacts.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConversationArtifactKind {
+    CronTrigger,
+    SkillSuggest,
+}
+
+/// Durable artifact state exposed to the client.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConversationArtifactStatus {
+    Active,
+    Pending,
+    Dismissed,
+    Saved,
+}
+
+/// Artifact object returned by conversation artifact APIs and websocket events.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ConversationArtifactResponse {
+    pub id: String,
+    pub conversation_id: String,
+    pub cron_job_id: Option<String>,
+    pub kind: ConversationArtifactKind,
+    pub status: ConversationArtifactStatus,
+    pub payload: serde_json::Value,
+    pub created_at: TimestampMs,
+    pub updated_at: TimestampMs,
+}
+
+/// List of conversation artifacts for a single conversation.
+pub type ConversationArtifactListResponse = Vec<ConversationArtifactResponse>;
 
 /// A single item from cross-conversation message search.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -243,6 +285,13 @@ mod tests {
         assert!(req.pinned.is_none());
         assert!(req.model.is_none());
         assert!(req.extra.is_none());
+    }
+
+    #[test]
+    fn deserialize_update_artifact_request() {
+        let raw = json!({ "status": "dismissed" });
+        let req: UpdateConversationArtifactRequest = serde_json::from_value(raw).unwrap();
+        assert_eq!(req.status, ConversationArtifactStatus::Dismissed);
     }
 
     // ── CloneConversationRequest ────────────────────────────────────
@@ -507,13 +556,15 @@ mod tests {
             "content": "Review this code",
             "msg_id": "msg-001",
             "files": ["/tmp/a.rs"],
-            "inject_skills": ["security-review"]
+            "inject_skills": ["security-review"],
+            "hidden": true
         });
         let req: SendMessageRequest = serde_json::from_value(raw).unwrap();
         assert_eq!(req.content, "Review this code");
         assert_eq!(req.msg_id, "msg-001");
         assert_eq!(req.files, vec!["/tmp/a.rs"]);
         assert_eq!(req.inject_skills, vec!["security-review"]);
+        assert!(req.hidden);
     }
 
     #[test]
@@ -524,6 +575,7 @@ mod tests {
         assert_eq!(req.msg_id, "m1");
         assert!(req.files.is_empty());
         assert!(req.inject_skills.is_empty());
+        assert!(!req.hidden);
     }
 
     #[test]
@@ -595,5 +647,29 @@ mod tests {
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["items"][0]["message_id"], "m1");
         assert_eq!(json["total"], 1);
+    }
+
+    #[test]
+    fn serialize_conversation_artifact_response() {
+        let artifact = ConversationArtifactResponse {
+            id: "conv_1:skill_suggest:cron_1".into(),
+            conversation_id: "conv_1".into(),
+            cron_job_id: Some("cron_1".into()),
+            kind: ConversationArtifactKind::SkillSuggest,
+            status: ConversationArtifactStatus::Active,
+            payload: json!({
+                "cron_job_id": "cron_1",
+                "name": "daily-report",
+                "description": "Daily report",
+                "skillContent": "---\nname: daily-report\n---\nUse it.",
+            }),
+            created_at: 1000,
+            updated_at: 2000,
+        };
+
+        let raw = serde_json::to_value(&artifact).unwrap();
+        assert_eq!(raw["kind"], "skill_suggest");
+        assert_eq!(raw["status"], "active");
+        assert_eq!(raw["payload"]["name"], "daily-report");
     }
 }

--- a/crates/aionui-api-types/src/cron.rs
+++ b/crates/aionui-api-types/src/cron.rs
@@ -108,6 +108,8 @@ pub struct CronJobStateDto {
 pub struct CronJobResponse {
     pub id: String,
     pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     pub enabled: bool,
     pub schedule: CronScheduleDto,
     pub target: CronJobTargetDto,
@@ -122,6 +124,8 @@ pub struct CronJobResponse {
 #[derive(Debug, Clone, Deserialize)]
 pub struct CreateCronJobRequest {
     pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
     pub schedule: CronScheduleDto,
     #[serde(default)]
     pub prompt: Option<String>,
@@ -142,6 +146,8 @@ pub struct CreateCronJobRequest {
 pub struct UpdateCronJobRequest {
     #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
     #[serde(default)]
     pub enabled: Option<bool>,
     #[serde(default)]
@@ -441,6 +447,7 @@ mod tests {
         CronJobResponse {
             id: "cron_abc".into(),
             name: "Daily report".into(),
+            description: Some("Daily report description".into()),
             enabled: true,
             schedule: CronScheduleDto::Cron {
                 expr: "0 0 9 * * *".into(),
@@ -522,6 +529,7 @@ mod tests {
         let resp = CronJobResponse {
             id: "cron_min".into(),
             name: "Ping".into(),
+            description: None,
             enabled: false,
             schedule: CronScheduleDto::Every {
                 every_ms: 60000,

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -52,10 +52,12 @@ pub use confirmation::{
 };
 pub use connection_test::TestBedrockConnectionRequest;
 pub use conversation::{
-    CloneConversationRequest, ConversationListResponse, ConversationResponse,
-    CreateConversationRequest, ListConversationsQuery, ListMessagesQuery, MessageListResponse,
-    MessageResponse, MessageSearchItem, MessageSearchResponse, SearchMessagesQuery,
-    SendMessageRequest, UpdateConversationRequest,
+    CloneConversationRequest, ConversationArtifactKind, ConversationArtifactListResponse,
+    ConversationArtifactResponse, ConversationArtifactStatus, ConversationListResponse,
+    ConversationResponse, CreateConversationRequest, ListConversationsQuery, ListMessagesQuery,
+    MessageListResponse, MessageResponse, MessageSearchItem, MessageSearchResponse,
+    SearchMessagesQuery, SendMessageRequest, UpdateConversationArtifactRequest,
+    UpdateConversationRequest,
 };
 pub use cron::{
     CreateCronJobRequest, CronAgentConfigDto, CronJobExecutedEvent, CronJobMetadataDto,

--- a/crates/aionui-app/src/state_builders.rs
+++ b/crates/aionui-app/src/state_builders.rs
@@ -73,6 +73,8 @@ pub(crate) async fn resolve_extension_agents(registry: &ExtensionRegistry) -> Ve
 pub async fn build_module_states(services: &AppServices) -> ModuleStates {
     let (ext_state, hub_state, mut skill_state) = build_extension_states(services).await;
     let assistant = build_assistant_state(services, ext_state.registry.clone());
+    let cron = build_cron_state(services);
+    cron.cron_service.init().await;
 
     let extensions = resolve_extension_agents(&ext_state.registry).await;
     services.agent_registry.initialize(extensions, vec![]).await;
@@ -82,7 +84,7 @@ pub async fn build_module_states(services: &AppServices) -> ModuleStates {
 
     ModuleStates {
         system: build_system_state(services),
-        conversation: build_conversation_state(services),
+        conversation: build_conversation_state(services, Some(cron.cron_service.clone())),
         remote_agent: build_remote_agent_state(services),
         acp: build_acp_state(services),
         connection_test: build_connection_test_state(),
@@ -93,8 +95,8 @@ pub async fn build_module_states(services: &AppServices) -> ModuleStates {
         hub: hub_state,
         skill: skill_state,
         channel: build_channel_state(services),
-        team: build_team_state(services),
-        cron: build_cron_state(services),
+        team: build_team_state(services, Some(cron.cron_service.clone())),
+        cron,
         office: build_office_state(services),
         shell: build_shell_state(services),
         assistant,
@@ -153,7 +155,10 @@ pub fn build_system_state(services: &AppServices) -> SystemRouterState {
 }
 
 /// Build the default `ConversationRouterState` from application services.
-pub fn build_conversation_state(services: &AppServices) -> ConversationRouterState {
+pub fn build_conversation_state(
+    services: &AppServices,
+    cron_service: Option<Arc<aionui_cron::service::CronService>>,
+) -> ConversationRouterState {
     let pool = services.database.pool().clone();
     let repo = Arc::new(SqliteConversationRepository::new(pool));
     let skill_resolver = Arc::new(
@@ -161,13 +166,17 @@ pub fn build_conversation_state(services: &AppServices) -> ConversationRouterSta
             services.skill_paths.clone(),
         ),
     );
+    let conversation_service = ConversationService::new_with_workspace_root(
+        repo,
+        services.event_bus.clone(),
+        std::path::PathBuf::from(&services.data_dir),
+        skill_resolver,
+    );
+    if let Some(cron_service) = cron_service {
+        conversation_service.set_cron_service(Some(cron_service));
+    }
     ConversationRouterState {
-        conversation_service: ConversationService::new_with_workspace_root(
-            repo,
-            services.event_bus.clone(),
-            std::path::PathBuf::from(&services.data_dir),
-            skill_resolver,
-        ),
+        conversation_service,
         worker_task_manager: services.worker_task_manager.clone(),
     }
 }
@@ -292,7 +301,10 @@ pub fn build_channel_state(services: &AppServices) -> ChannelRouterState {
 }
 
 /// Build the default `TeamRouterState` from application services.
-pub fn build_team_state(services: &AppServices) -> TeamRouterState {
+pub fn build_team_state(
+    services: &AppServices,
+    cron_service: Option<Arc<aionui_cron::service::CronService>>,
+) -> TeamRouterState {
     let pool = services.database.pool().clone();
     let team_repo: Arc<dyn aionui_db::ITeamRepository> =
         Arc::new(aionui_db::SqliteTeamRepository::new(pool.clone()));
@@ -309,6 +321,9 @@ pub fn build_team_state(services: &AppServices) -> TeamRouterState {
         std::path::PathBuf::from(&services.data_dir),
         skill_resolver,
     );
+    if let Some(cron_service) = cron_service {
+        conv_service.set_cron_service(Some(cron_service));
+    }
     let service = Arc::new(TeamSessionService::new(
         team_repo,
         conv_service,
@@ -343,6 +358,8 @@ pub fn build_cron_state(services: &AppServices) -> CronRouterState {
         conv_repo,
         Arc::new(conv_service.clone()),
         busy_guard,
+        std::path::PathBuf::from(&services.data_dir),
+        services.event_bus.clone(),
     ));
 
     let tick_service_ref: Arc<CronServiceTickRef> = Arc::new(CronServiceTickRef::default());
@@ -360,7 +377,11 @@ pub fn build_cron_state(services: &AppServices) -> CronRouterState {
 
     let emitter = CronEventEmitter::new(services.event_bus.clone());
     let cron_service = Arc::new(aionui_cron::service::CronService::new(
-        cron_repo, scheduler, executor, emitter,
+        cron_repo,
+        scheduler,
+        executor,
+        emitter,
+        std::path::PathBuf::from(&services.data_dir),
     ));
 
     tick_service_ref

--- a/crates/aionui-app/tests/assistants_e2e.rs
+++ b/crates/aionui-app/tests/assistants_e2e.rs
@@ -175,6 +175,7 @@ async fn fixture() -> Fixture {
     let skill_paths = SkillPaths {
         data_dir: ext_data_dir.clone(),
         user_skills_dir: ext_data_dir.join("skills"),
+        cron_skills_dir: ext_data_dir.join("cron").join("skills"),
         builtin_skills_dir: ext_data_dir.join("builtin-skills"),
         builtin_rules_dir: ext_data_dir.join("builtin-rules"),
         assistant_rules_dir: user_data_dir.join("assistant-rules"),

--- a/crates/aionui-app/tests/common/mod.rs
+++ b/crates/aionui-app/tests/common/mod.rs
@@ -36,6 +36,7 @@ pub async fn build_app_with_skill_paths(
     let paths = SkillPaths {
         data_dir: root.to_path_buf(),
         user_skills_dir: root.join("skills"),
+        cron_skills_dir: root.join("cron").join("skills"),
         builtin_skills_dir: builtin_dir.clone(),
         builtin_rules_dir: root.join("builtin-rules"),
         assistant_rules_dir: root.join("assistant-rules"),

--- a/crates/aionui-app/tests/cron_e2e.rs
+++ b/crates/aionui-app/tests/cron_e2e.rs
@@ -1,7 +1,7 @@
 //! E2E tests for cron job HTTP endpoints.
 //!
 //! Covers test-plan items: CJ-1..CJ-12, SK-1..SK-6, SC-3..SC-8, AU-1..AU-2,
-//! RN-2 (run-now nonexistent).
+//! RN-1..RN-2.
 //! Items requiring real AI execution (RN-1, EV-*, SR-*, OC-*, CD-*) are tested
 //! at the service integration level in `aionui-cron/tests/service_integration.rs`.
 
@@ -88,6 +88,7 @@ async fn au2_unauthenticated_all_endpoints() {
         ("GET", "/api/cron/jobs"),
         ("GET", "/api/cron/jobs/cron_test"),
         ("GET", "/api/cron/jobs/cron_test/skill"),
+        ("DELETE", "/api/cron/jobs/cron_test/skill"),
     ];
 
     for (method, uri) in endpoints {
@@ -380,6 +381,47 @@ async fn cj12_delete_nonexistent() {
 // ── RN-2: Run now nonexistent ────────────────────────────────────────
 
 #[tokio::test]
+async fn rn1_run_now_returns_conversation_id_for_new_conversation_job() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let create_conv_req = json_with_token(
+        "POST",
+        "/api/conversations",
+        json!({
+            "type": "acp",
+            "name": "Run Now Source",
+            "model": { "provider_id": "p1", "model": "claude-sonnet-4-20250514" },
+            "extra": { "workspace": "/project" }
+        }),
+        &token,
+        &csrf,
+    );
+    let create_conv_resp = app.clone().oneshot(create_conv_req).await.unwrap();
+    assert_eq!(create_conv_resp.status(), StatusCode::CREATED);
+    let created_conv = body_json(create_conv_resp).await;
+    let conversation_id = created_conv["data"]["id"].as_str().unwrap();
+
+    let mut body = create_job_body("Run Now Job");
+    body["conversation_id"] = json!(conversation_id);
+    let created = create_job(&mut app, &token, &csrf, body).await;
+    let job_id = created["id"].as_str().unwrap();
+
+    let req = json_with_token(
+        "POST",
+        &format!("/api/cron/jobs/{job_id}/run"),
+        json!({}),
+        &token,
+        &csrf,
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = body_json(resp).await;
+    assert_eq!(body["data"]["conversation_id"], json!(conversation_id));
+}
+
+#[tokio::test]
 async fn rn2_run_now_nonexistent() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
@@ -529,6 +571,50 @@ async fn sk6_save_skill_nonexistent() {
         &token,
         &csrf,
     );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// ── SK-7: Delete existing skill ──────────────────────────────────────
+
+#[tokio::test]
+async fn sk7_delete_skill() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let created = create_job(&mut app, &token, &csrf, create_job_body("Delete Skill Job")).await;
+    let job_id = created["id"].as_str().unwrap();
+
+    let save_req = json_with_token(
+        "POST",
+        &format!("/api/cron/jobs/{job_id}/skill"),
+        json!({"content": "---\nname: delete-me\n---\nContent"}),
+        &token,
+        &csrf,
+    );
+    let save_resp = app.clone().oneshot(save_req).await.unwrap();
+    assert_eq!(save_resp.status(), StatusCode::OK);
+
+    let delete_req = delete_with_token(&format!("/api/cron/jobs/{job_id}/skill"), &token, &csrf);
+    let delete_resp = app.clone().oneshot(delete_req).await.unwrap();
+    assert_eq!(delete_resp.status(), StatusCode::OK);
+
+    let has_req = get_with_token(&format!("/api/cron/jobs/{job_id}/skill"), &token);
+    let has_resp = app.oneshot(has_req).await.unwrap();
+    assert_eq!(has_resp.status(), StatusCode::OK);
+
+    let json = body_json(has_resp).await;
+    assert_eq!(json["data"]["has_skill"], false);
+}
+
+// ── SK-8: Delete skill for nonexistent job ───────────────────────────
+
+#[tokio::test]
+async fn sk8_delete_skill_nonexistent() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let req = delete_with_token("/api/cron/jobs/cron_nonexistent/skill", &token, &csrf);
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }

--- a/crates/aionui-app/tests/message_e2e.rs
+++ b/crates/aionui-app/tests/message_e2e.rs
@@ -62,6 +62,16 @@ async fn insert_message(
         .unwrap();
 }
 
+async fn upsert_artifact(
+    services: &aionui_app::AppServices,
+    artifact: aionui_db::ConversationArtifactRow,
+) {
+    let repo = aionui_db::SqliteConversationRepository::new(services.database.pool().clone());
+    aionui_db::IConversationRepository::upsert_artifact(&repo, &artifact)
+        .await
+        .unwrap();
+}
+
 // ── T8: Message list ──────────────────────────────────────────────────
 
 #[tokio::test]
@@ -199,6 +209,126 @@ async fn t8_6_messages_requires_auth() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn t8_7_messages_exclude_legacy_cron_rows() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+    let conv_id = create_conversation(&mut app, &token, &csrf, "Legacy Filter").await;
+
+    insert_message(&services, &conv_id, "msg-text", "Visible", 1000).await;
+
+    let repo = aionui_db::SqliteConversationRepository::new(services.database.pool().clone());
+    for (id, ty, content) in [
+        (
+            "legacy-cron",
+            "cron_trigger",
+            json!({
+                "cron_job_id": "cron_1",
+                "cron_job_name": "Daily",
+                "triggered_at": 2000
+            }),
+        ),
+        (
+            "legacy-skill",
+            "skill_suggest",
+            json!({
+                "cron_job_id": "cron_1",
+                "name": "daily-report",
+                "description": "Daily report",
+                "skillContent": "---\nname: daily-report\n---\nUse it."
+            }),
+        ),
+    ] {
+        let msg = aionui_db::models::MessageRow {
+            id: id.into(),
+            conversation_id: conv_id.clone(),
+            msg_id: None,
+            r#type: ty.into(),
+            content: content.to_string(),
+            position: Some("center".into()),
+            status: Some("finish".into()),
+            hidden: false,
+            created_at: 2000,
+        };
+        aionui_db::IConversationRepository::insert_message(&repo, &msg)
+            .await
+            .unwrap();
+    }
+
+    let resp = app
+        .oneshot(get_with_token(
+            &format!("/api/conversations/{conv_id}/messages"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let json = body_json(resp).await;
+    let items = json["data"]["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(json["data"]["total"], 1);
+    assert_eq!(items[0]["type"], "text");
+    assert_eq!(items[0]["content"]["content"], "Visible");
+}
+
+#[tokio::test]
+async fn t8_8_artifacts_list_and_patch_status() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+    let conv_id = create_conversation(&mut app, &token, &csrf, "Artifacts").await;
+    let artifact_id = format!("{conv_id}:skill_suggest:cron_1");
+
+    upsert_artifact(
+        &services,
+        aionui_db::ConversationArtifactRow {
+            id: artifact_id.clone(),
+            conversation_id: conv_id.clone(),
+            cron_job_id: Some("cron_1".into()),
+            kind: "skill_suggest".into(),
+            status: "active".into(),
+            payload: json!({
+                "cron_job_id": "cron_1",
+                "name": "daily-report",
+                "description": "Daily report",
+                "skillContent": "---\nname: daily-report\n---\nUse it."
+            })
+            .to_string(),
+            created_at: 1000,
+            updated_at: 1000,
+        },
+    )
+    .await;
+
+    let resp = app
+        .clone()
+        .oneshot(get_with_token(
+            &format!("/api/conversations/{conv_id}/artifacts"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    let items = json["data"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["id"], artifact_id);
+    assert_eq!(items[0]["kind"], "skill_suggest");
+    assert_eq!(items[0]["status"], "active");
+
+    let patch_req = common::json_with_token(
+        "PATCH",
+        &format!("/api/conversations/{conv_id}/artifacts/{artifact_id}"),
+        json!({ "status": "dismissed" }),
+        &token,
+        &csrf,
+    );
+    let patch_resp = app.oneshot(patch_req).await.unwrap();
+    assert_eq!(patch_resp.status(), StatusCode::OK);
+    let patch_json = body_json(patch_resp).await;
+    assert_eq!(patch_json["data"]["status"], "dismissed");
 }
 
 // ── T9: Message search ────────────────────────────────────────────────

--- a/crates/aionui-app/tests/skills_builtin_e2e.rs
+++ b/crates/aionui-app/tests/skills_builtin_e2e.rs
@@ -71,6 +71,7 @@ async fn fixture_embedded() -> Fixture {
     let skill_paths = SkillPaths {
         data_dir: data_dir.clone(),
         user_skills_dir: data_dir.join("skills"),
+        cron_skills_dir: data_dir.join("cron").join("skills"),
         builtin_skills_dir: data_dir.join("builtin-skills"),
         builtin_rules_dir: data_dir.join("builtin-rules"),
         assistant_rules_dir: data_dir.join("assistant-rules"),

--- a/crates/aionui-channel/src/message_service.rs
+++ b/crates/aionui-channel/src/message_service.rs
@@ -69,6 +69,7 @@ impl ChannelMessageService {
             msg_id: msg_id.clone(),
             files: vec![],
             inject_skills: vec![],
+            hidden: false,
         };
 
         // Use a fixed user_id for channel messages (they're system-level)

--- a/crates/aionui-conversation/src/convert.rs
+++ b/crates/aionui-conversation/src/convert.rs
@@ -1,13 +1,14 @@
 use std::path::Path;
 
-use aionui_api_types::{ConversationResponse, MessageResponse, MessageSearchItem};
+use aionui_api_types::{
+    ConversationArtifactResponse, ConversationResponse, MessageResponse, MessageSearchItem,
+};
 use aionui_common::{
     AgentType, AppError, ConversationSource, ConversationStatus, MessagePosition, MessageStatus,
     MessageType, ProviderWithModel,
 };
 use aionui_db::MessageSearchRow;
-use aionui_db::models::ConversationRow;
-use aionui_db::models::MessageRow;
+use aionui_db::models::{ConversationArtifactRow, ConversationRow, MessageRow};
 
 /// Convert a database row into an API response DTO.
 ///
@@ -161,6 +162,27 @@ pub fn row_to_message_response(row: MessageRow) -> Result<MessageResponse, AppEr
         status,
         hidden: row.hidden,
         created_at: row.created_at,
+    })
+}
+
+/// Convert an artifact database row into an API response DTO.
+pub fn row_to_artifact_response(
+    row: ConversationArtifactRow,
+) -> Result<ConversationArtifactResponse, AppError> {
+    let kind = string_to_enum(&row.kind)?;
+    let status = string_to_enum(&row.status)?;
+    let payload: serde_json::Value = serde_json::from_str(&row.payload)
+        .map_err(|e| AppError::Internal(format!("Invalid artifact payload JSON: {e}")))?;
+
+    Ok(ConversationArtifactResponse {
+        id: row.id,
+        conversation_id: row.conversation_id,
+        cron_job_id: row.cron_job_id,
+        kind,
+        status,
+        payload,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
     })
 }
 

--- a/crates/aionui-conversation/src/convert.rs
+++ b/crates/aionui-conversation/src/convert.rs
@@ -53,7 +53,6 @@ pub fn row_to_response_with_extra(
         );
     }
 
-
     let agent_type: AgentType = string_to_enum(&row.r#type)?;
     let status: ConversationStatus = match row.status.as_deref() {
         None | Some("") => ConversationStatus::Finished,

--- a/crates/aionui-conversation/src/routes.rs
+++ b/crates/aionui-conversation/src/routes.rs
@@ -2,13 +2,15 @@ use axum::Router;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{Extension, Json, Path, Query, State};
 use axum::http::StatusCode;
-use axum::routing::{get, post};
+use axum::routing::{get, patch, post};
 
 use aionui_api_types::{
     ApiResponse, ApprovalCheckQuery, ApprovalCheckResponse, CloneConversationRequest,
-    ConfirmRequest, ConfirmationListResponse, ConversationListResponse, ConversationResponse,
+    ConfirmRequest, ConfirmationListResponse, ConversationArtifactListResponse,
+    ConversationArtifactResponse, ConversationListResponse, ConversationResponse,
     CreateConversationRequest, ListConversationsQuery, ListMessagesQuery, MessageListResponse,
-    MessageSearchResponse, SearchMessagesQuery, SendMessageRequest, UpdateConversationRequest,
+    MessageSearchResponse, SearchMessagesQuery, SendMessageRequest,
+    UpdateConversationArtifactRequest, UpdateConversationRequest,
 };
 use aionui_auth::CurrentUser;
 use aionui_common::AppError;
@@ -32,6 +34,11 @@ pub fn conversation_routes(state: ConversationRouterState) -> Router {
         .route(
             "/api/conversations/{id}/messages",
             get(list_messages).post(send_message),
+        )
+        .route("/api/conversations/{id}/artifacts", get(list_artifacts))
+        .route(
+            "/api/conversations/{id}/artifacts/{artifactId}",
+            patch(update_artifact),
         )
         .route("/api/conversations/{id}/stop", post(stop_stream))
         .route("/api/conversations/{id}/warmup", post(warmup))
@@ -164,6 +171,39 @@ async fn send_message(
         .send_message(&user.id, &id, req, &state.worker_task_manager)
         .await?;
     Ok((StatusCode::ACCEPTED, Json(ApiResponse::success())))
+}
+
+async fn list_artifacts(
+    State(state): State<ConversationRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+) -> Result<Json<ApiResponse<ConversationArtifactListResponse>>, AppError> {
+    let result = state
+        .conversation_service
+        .list_artifacts(&user.id, &id)
+        .await?;
+    Ok(Json(ApiResponse::ok(result)))
+}
+
+#[derive(serde::Deserialize)]
+struct ArtifactPathParams {
+    id: String,
+    #[serde(rename = "artifactId")]
+    artifact_id: String,
+}
+
+async fn update_artifact(
+    State(state): State<ConversationRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    Path(params): Path<ArtifactPathParams>,
+    body: Result<Json<UpdateConversationArtifactRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<ConversationArtifactResponse>>, AppError> {
+    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
+    let artifact = state
+        .conversation_service
+        .update_artifact(&user.id, &params.id, &params.artifact_id, req)
+        .await?;
+    Ok(Json(ApiResponse::ok(artifact)))
 }
 
 async fn stop_stream(

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -3,22 +3,24 @@ use std::sync::Arc;
 use aionui_ai_agent::{BuildTaskOptions, ICronService, IWorkerTaskManager, SendMessageData};
 use aionui_api_types::{
     ApprovalCheckResponse, CloneConversationRequest, ConfirmRequest, ConfirmationListResponse,
-    ConversationListResponse, ConversationResponse, CreateConversationRequest,
-    ListConversationsQuery, ListMessagesQuery, MessageListResponse, MessageResponse,
-    MessageSearchResponse, SearchMessagesQuery, SendMessageRequest, UpdateConversationRequest,
-    WebSocketMessage,
+    ConversationArtifactKind, ConversationArtifactListResponse, ConversationArtifactResponse,
+    ConversationArtifactStatus, ConversationListResponse, ConversationResponse,
+    CreateConversationRequest, ListConversationsQuery, ListMessagesQuery, MessageListResponse,
+    MessageResponse, MessageSearchResponse, SearchMessagesQuery, SendMessageRequest,
+    UpdateConversationArtifactRequest, UpdateConversationRequest, WebSocketMessage,
 };
 use aionui_common::{
     AcpBackend, AgentType, AppError, ConversationSource, ConversationStatus, PaginatedResult,
     generate_id, generate_short_id, now_ms,
 };
+use aionui_db::models::MessageRow;
 use aionui_db::{ConversationFilters, ConversationRowUpdate, IConversationRepository, SortOrder};
 use aionui_realtime::EventBroadcaster;
 use tracing::{debug, info, warn};
 
 use crate::convert::{
-    row_to_message_response, row_to_response, row_to_response_with_extra, search_row_to_item,
-    string_to_enum,
+    row_to_artifact_response, row_to_message_response, row_to_response, row_to_response_with_extra,
+    search_row_to_item, string_to_enum,
 };
 use crate::skill_resolver::SkillResolver;
 use crate::stream_relay::StreamRelay;
@@ -516,6 +518,7 @@ impl ConversationService {
 
         // Delete all messages
         self.repo.delete_messages_by_conversation(id).await?;
+        self.repo.delete_artifacts_by_conversation(id).await?;
 
         // Reset status to pending
         let now = now_ms();
@@ -592,6 +595,84 @@ impl ConversationService {
             total: result.total,
             has_more: result.has_more,
         })
+    }
+
+    /// List artifacts for a conversation with durable status state.
+    pub async fn list_artifacts(
+        &self,
+        user_id: &str,
+        conversation_id: &str,
+    ) -> Result<ConversationArtifactListResponse, AppError> {
+        self.repo
+            .get(conversation_id)
+            .await?
+            .filter(|r| r.user_id == user_id)
+            .ok_or_else(|| {
+                AppError::NotFound(format!("Conversation {conversation_id} not found"))
+            })?;
+
+        let mut items = self
+            .repo
+            .list_artifacts(conversation_id)
+            .await?
+            .into_iter()
+            .map(row_to_artifact_response)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut legacy_items = self
+            .repo
+            .list_legacy_cron_trigger_messages(conversation_id)
+            .await?
+            .into_iter()
+            .filter_map(|row| legacy_cron_trigger_to_artifact(row).ok())
+            .collect::<Vec<_>>();
+
+        items.append(&mut legacy_items);
+        items.sort_by(|left, right| {
+            left.created_at
+                .cmp(&right.created_at)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+
+        Ok(items)
+    }
+
+    /// Update the durable status of a conversation artifact and broadcast the upsert.
+    pub async fn update_artifact(
+        &self,
+        user_id: &str,
+        conversation_id: &str,
+        artifact_id: &str,
+        req: UpdateConversationArtifactRequest,
+    ) -> Result<ConversationArtifactResponse, AppError> {
+        self.repo
+            .get(conversation_id)
+            .await?
+            .filter(|r| r.user_id == user_id)
+            .ok_or_else(|| {
+                AppError::NotFound(format!("Conversation {conversation_id} not found"))
+            })?;
+
+        let status = serde_json::to_value(req.status)
+            .ok()
+            .and_then(|value| value.as_str().map(str::to_owned))
+            .ok_or_else(|| AppError::Internal("Failed to serialize artifact status".into()))?;
+
+        let row = self
+            .repo
+            .update_artifact_status(conversation_id, artifact_id, &status, now_ms())
+            .await?
+            .ok_or_else(|| AppError::NotFound(format!("Artifact {artifact_id} not found")))?;
+
+        let response = row_to_artifact_response(row)?;
+        self.broadcaster.broadcast(WebSocketMessage::new(
+            "conversation.artifact",
+            serde_json::to_value(&response).map_err(|e| {
+                AppError::Internal(format!("Failed to serialize artifact event: {e}"))
+            })?,
+        ));
+
+        Ok(response)
     }
 
     /// Search messages across all conversations for the user.
@@ -781,7 +862,7 @@ impl ConversationService {
             content: serde_json::json!({ "content": req.content }).to_string(),
             position: Some("right".into()),
             status: Some("finish".into()),
-            hidden: false,
+            hidden: req.hidden,
             created_at: now_ms(),
         };
         self.repo.insert_message(&user_msg).await?;
@@ -840,7 +921,8 @@ impl ConversationService {
 
                 let rx = agent.subscribe();
                 let send_agent = Arc::clone(&agent);
-                let send_task = tokio::spawn(async move { send_agent.send_message(current_send).await });
+                let send_task =
+                    tokio::spawn(async move { send_agent.send_message(current_send).await });
                 let outcome = relay.run(rx).await;
 
                 match send_task.await {
@@ -1210,6 +1292,30 @@ async fn persist_session_key(
             "Persisted session key to conversation.extra"
         );
     }
+}
+
+fn legacy_cron_trigger_to_artifact(
+    row: MessageRow,
+) -> Result<ConversationArtifactResponse, AppError> {
+    let payload: serde_json::Value = serde_json::from_str(&row.content).map_err(|e| {
+        AppError::Internal(format!("Invalid legacy cron trigger payload JSON: {e}"))
+    })?;
+    let cron_job_id = payload
+        .get("cron_job_id")
+        .or_else(|| payload.get("cronJobId"))
+        .and_then(|value| value.as_str())
+        .map(ToOwned::to_owned);
+
+    Ok(ConversationArtifactResponse {
+        id: format!("legacy-cron-trigger:{}", row.id),
+        conversation_id: row.conversation_id,
+        cron_job_id,
+        kind: ConversationArtifactKind::CronTrigger,
+        status: ConversationArtifactStatus::Active,
+        payload,
+        created_at: row.created_at,
+        updated_at: row.created_at,
+    })
 }
 
 /// Merge `patch` into `base` (top-level key overwrite).

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use aionui_ai_agent::{BuildTaskOptions, IWorkerTaskManager, SendMessageData};
+use aionui_ai_agent::{BuildTaskOptions, ICronService, IWorkerTaskManager, SendMessageData};
 use aionui_api_types::{
     ApprovalCheckResponse, CloneConversationRequest, ConfirmRequest, ConfirmationListResponse,
     ConversationListResponse, ConversationResponse, CreateConversationRequest,
@@ -23,6 +23,8 @@ use crate::convert::{
 use crate::skill_resolver::SkillResolver;
 use crate::stream_relay::StreamRelay;
 
+const MAX_CRON_CONTINUATIONS_PER_TURN: usize = 4;
+
 #[async_trait::async_trait]
 pub trait OnConversationDelete: Send + Sync {
     async fn on_conversation_deleted(&self, conversation_id: &str);
@@ -35,6 +37,7 @@ pub struct ConversationService {
     delete_hooks: Vec<Arc<dyn OnConversationDelete>>,
     workspace_root: std::path::PathBuf,
     skill_resolver: Arc<dyn SkillResolver>,
+    cron_service: Arc<std::sync::RwLock<Option<Arc<dyn ICronService>>>>,
 }
 
 impl ConversationService {
@@ -49,6 +52,7 @@ impl ConversationService {
             delete_hooks: Vec::new(),
             workspace_root: std::path::PathBuf::from("data"),
             skill_resolver,
+            cron_service: Arc::new(std::sync::RwLock::new(None)),
         }
     }
 
@@ -64,6 +68,7 @@ impl ConversationService {
             delete_hooks: Vec::new(),
             workspace_root,
             skill_resolver,
+            cron_service: Arc::new(std::sync::RwLock::new(None)),
         }
     }
 
@@ -79,6 +84,13 @@ impl ConversationService {
             delete_hooks,
             workspace_root: std::path::PathBuf::from("data"),
             skill_resolver,
+            cron_service: Arc::new(std::sync::RwLock::new(None)),
+        }
+    }
+
+    pub fn set_cron_service(&self, cron_service: Option<Arc<dyn ICronService>>) {
+        if let Ok(mut guard) = self.cron_service.write() {
+            *guard = cron_service;
         }
     }
 
@@ -466,11 +478,25 @@ impl ConversationService {
             let mut merged = source_extra;
             merge_json(&mut merged, &create_req.extra);
 
-            // Handle cronJobId migration
-            if req.migrate_cron != Some(true)
-                && let Some(obj) = merged.as_object_mut()
-            {
-                obj.remove("cronJobId");
+            // Handle cron job binding migration across both legacy and new keys.
+            if let Some(obj) = merged.as_object_mut() {
+                if req.migrate_cron == Some(true) {
+                    let cron_job_id = obj
+                        .get("cron_job_id")
+                        .and_then(|value| value.as_str())
+                        .or_else(|| obj.get("cronJobId").and_then(|value| value.as_str()))
+                        .map(ToOwned::to_owned);
+                    if let Some(cron_job_id) = cron_job_id {
+                        obj.insert(
+                            "cron_job_id".into(),
+                            serde_json::Value::String(cron_job_id.clone()),
+                        );
+                        obj.insert("cronJobId".into(), serde_json::Value::String(cron_job_id));
+                    }
+                } else {
+                    obj.remove("cron_job_id");
+                    obj.remove("cronJobId");
+                }
             }
 
             create_req.extra = merged;
@@ -778,20 +804,6 @@ impl ConversationService {
         };
         self.repo.update(conversation_id, &update).await?;
 
-        // Subscribe to agent events before sending (no events lost)
-        let rx = agent.subscribe();
-
-        // Spawn background relay BEFORE sending — prompt() blocks until the
-        // agent turn completes, so the relay must already be running to
-        // consume streaming events as they arrive.
-        let relay = StreamRelay::new(
-            conversation_id.to_owned(),
-            generate_id(),
-            Arc::clone(&self.repo),
-            Arc::clone(&self.broadcaster),
-        );
-        tokio::spawn(relay.run(rx));
-
         // Send message to the agent in a background task.
         // prompt() blocks until the PromptResponse arrives (turn completed),
         // but the HTTP handler should return 202 immediately.
@@ -804,13 +816,70 @@ impl ConversationService {
         };
         let conv_id = conversation_id.to_owned();
         let repo = Arc::clone(&self.repo);
+        let broadcaster = Arc::clone(&self.broadcaster);
+        let cron_service = self.current_cron_service();
+        let user_id_owned = user_id.to_owned();
         tokio::spawn(async move {
-            if let Err(e) = agent.send_message(send_data).await {
-                tracing::error!(conversation_id = %conv_id, error = %e, "Agent send_message failed");
+            let mut pending_send = Some(send_data);
+            let mut continuation_count = 0usize;
+
+            loop {
+                let Some(current_send) = pending_send.take() else {
+                    break;
+                };
+
+                let relay = StreamRelay::new(
+                    conv_id.clone(),
+                    generate_id(),
+                    user_id_owned.clone(),
+                    Arc::clone(&repo),
+                    Arc::clone(&broadcaster),
+                    cron_service.clone(),
+                )
+                .with_turn_completion(false);
+
+                let rx = agent.subscribe();
+                let send_agent = Arc::clone(&agent);
+                let send_task = tokio::spawn(async move { send_agent.send_message(current_send).await });
+                let outcome = relay.run(rx).await;
+
+                match send_task.await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => {
+                        tracing::error!(conversation_id = %conv_id, error = %e, "Agent send_message failed");
+                    }
+                    Err(e) => {
+                        tracing::error!(conversation_id = %conv_id, error = %e, "Agent send task join failed");
+                    }
+                }
+
+                if let Some(session_key) = agent.get_session_key() {
+                    persist_session_key(&repo, &conv_id, &session_key).await;
+                }
+
+                if outcome.system_responses.is_empty() {
+                    break;
+                }
+
+                if continuation_count >= MAX_CRON_CONTINUATIONS_PER_TURN {
+                    warn!(
+                        conversation_id = %conv_id,
+                        max = MAX_CRON_CONTINUATIONS_PER_TURN,
+                        "Reached cron continuation limit; ending turn early"
+                    );
+                    break;
+                }
+
+                continuation_count += 1;
+                pending_send = Some(SendMessageData {
+                    content: outcome.system_responses.join("\n"),
+                    msg_id: generate_id(),
+                    files: vec![],
+                    inject_skills: vec![],
+                });
             }
-            if let Some(session_key) = agent.get_session_key() {
-                persist_session_key(&repo, &conv_id, &session_key).await;
-            }
+
+            StreamRelay::complete_conversation(&repo, &broadcaster, &conv_id).await;
         });
 
         info!(conversation_id, msg_id = %msg_id_log, "Message dispatched, stream relay started");
@@ -971,13 +1040,21 @@ impl ConversationService {
         self.broadcaster.broadcast(event);
     }
 
+    fn current_cron_service(&self) -> Option<Arc<dyn ICronService>> {
+        match self.cron_service.read() {
+            Ok(guard) => guard.as_ref().map(Arc::clone),
+            Err(_) => None,
+        }
+    }
+
     /// Backfill `extra.skills` if the row predates the snapshot model.
     /// Persists the mutation asynchronously; failures are logged and
     /// swallowed so a read path never 500s because of a backfill write
     /// failure.
     async fn backfill_extra_inplace(&self, conversation_id: &str, extra: &mut serde_json::Value) {
         let auto_inject = self.skill_resolver.auto_inject_names().await;
-        let mutated = crate::skill_snapshot::backfill_skills_if_missing(extra, &auto_inject);
+        let mut mutated = crate::skill_snapshot::backfill_skills_if_missing(extra, &auto_inject);
+        mutated |= backfill_cron_job_id_alias(extra);
         if !mutated {
             return;
         }
@@ -1004,6 +1081,37 @@ impl ConversationService {
             );
         }
     }
+}
+
+fn backfill_cron_job_id_alias(extra: &mut serde_json::Value) -> bool {
+    let Some(obj) = extra.as_object_mut() else {
+        return false;
+    };
+
+    let cron_job_id = obj
+        .get("cron_job_id")
+        .and_then(|value| value.as_str())
+        .or_else(|| obj.get("cronJobId").and_then(|value| value.as_str()))
+        .map(ToOwned::to_owned);
+
+    let Some(cron_job_id) = cron_job_id else {
+        return false;
+    };
+
+    let mut mutated = false;
+    if obj.get("cron_job_id").and_then(|value| value.as_str()) != Some(cron_job_id.as_str()) {
+        obj.insert(
+            "cron_job_id".into(),
+            serde_json::Value::String(cron_job_id.clone()),
+        );
+        mutated = true;
+    }
+    if obj.get("cronJobId").and_then(|value| value.as_str()) != Some(cron_job_id.as_str()) {
+        obj.insert("cronJobId".into(), serde_json::Value::String(cron_job_id));
+        mutated = true;
+    }
+
+    mutated
 }
 
 // ── Helpers ────────────────────────────────────────────────────────

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1,8 +1,11 @@
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
-use aionui_ai_agent::IWorkerTaskManager;
+use aionui_ai_agent::{
+    CronCommandResult, CronCreateParams, CronUpdateParams, ICronService, IWorkerTaskManager,
+};
 use aionui_ai_agent::agent_manager::{AgentManagerHandle, IAgentManager};
-use aionui_ai_agent::stream_event::AgentStreamEvent;
+use aionui_ai_agent::stream_event::{AgentStreamEvent, FinishEventData, TextEventData};
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
 use aionui_api_types::{
     CloneConversationRequest, CreateConversationRequest, ListConversationsQuery,
@@ -791,6 +794,7 @@ async fn clone_strips_cron_job_id_by_default() {
 
     // cronJobId should not be carried over
     assert!(cloned.extra.get("cronJobId").is_none());
+    assert!(cloned.extra.get("cron_job_id").is_none());
 }
 
 #[tokio::test]
@@ -818,6 +822,35 @@ async fn clone_with_migrate_cron_preserves_cron_job_id() {
     let cloned = svc.clone_create("user_1", clone_req).await.unwrap();
 
     assert_eq!(cloned.extra["cronJobId"], "cron_1");
+    assert_eq!(cloned.extra["cron_job_id"], "cron_1");
+}
+
+#[tokio::test]
+async fn clone_with_migrate_cron_preserves_snake_case_cron_job_id() {
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
+
+    let source_req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "model": { "provider_id": "p1", "model": "m1" },
+        "extra": { "workspace": "/p", "cron_job_id": "cron_2" }
+    }))
+    .unwrap();
+    let source = svc.create("user_1", source_req).await.unwrap();
+
+    let clone_req: CloneConversationRequest = serde_json::from_value(json!({
+        "source_conversation_id": source.id,
+        "conversation": {
+            "type": "acp",
+            "model": { "provider_id": "p1", "model": "m1" },
+            "extra": {}
+        },
+        "migrate_cron": true
+    }))
+    .unwrap();
+    let cloned = svc.clone_create("user_1", clone_req).await.unwrap();
+
+    assert_eq!(cloned.extra["cronJobId"], "cron_2");
+    assert_eq!(cloned.extra["cron_job_id"], "cron_2");
 }
 
 // ── Reset tests ───────────────────────────────────────────────────
@@ -1133,6 +1166,143 @@ impl IWorkerTaskManager for MockTaskManagerWithWorkspace {
     }
 }
 
+struct ScriptedAgent {
+    conversation_id: String,
+    event_tx: broadcast::Sender<AgentStreamEvent>,
+    scripts: Mutex<VecDeque<Vec<AgentStreamEvent>>>,
+    sent_contents: Mutex<Vec<String>>,
+}
+
+impl ScriptedAgent {
+    fn new(conversation_id: &str, scripts: Vec<Vec<AgentStreamEvent>>) -> Self {
+        let (event_tx, _) = broadcast::channel(64);
+        Self {
+            conversation_id: conversation_id.to_owned(),
+            event_tx,
+            scripts: Mutex::new(VecDeque::from(scripts)),
+            sent_contents: Mutex::new(vec![]),
+        }
+    }
+
+    fn sent_contents(&self) -> Vec<String> {
+        self.sent_contents.lock().unwrap().clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl IAgentManager for ScriptedAgent {
+    fn agent_type(&self) -> AgentType {
+        AgentType::Acp
+    }
+
+    fn status(&self) -> Option<ConversationStatus> {
+        Some(ConversationStatus::Finished)
+    }
+
+    fn workspace(&self) -> &str {
+        "/tmp/test"
+    }
+
+    fn conversation_id(&self) -> &str {
+        &self.conversation_id
+    }
+
+    fn last_activity_at(&self) -> TimestampMs {
+        0
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
+        self.event_tx.subscribe()
+    }
+
+    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+        self.sent_contents.lock().unwrap().push(data.content);
+        let script = self
+            .scripts
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or_else(|| vec![AgentStreamEvent::Finish(FinishEventData::default())]);
+        for event in script {
+            let _ = self.event_tx.send(event);
+        }
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+
+    fn confirm(
+        &self,
+        _msg_id: &str,
+        _call_id: &str,
+        _data: serde_json::Value,
+        _always_allow: bool,
+    ) -> Result<(), AppError> {
+        Ok(())
+    }
+
+    fn get_confirmations(&self) -> Vec<Confirmation> {
+        vec![]
+    }
+
+    fn check_approval(&self, _action: &str, _command_type: Option<&str>) -> bool {
+        false
+    }
+
+    fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        Ok(())
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+struct MockCronContinuationService;
+
+#[async_trait::async_trait]
+impl ICronService for MockCronContinuationService {
+    async fn create_job(
+        &self,
+        _user_id: &str,
+        _conversation_id: &str,
+        params: &CronCreateParams,
+    ) -> CronCommandResult {
+        CronCommandResult {
+            success: true,
+            message: format!("Created cron job '{}'", params.name),
+        }
+    }
+
+    async fn update_job(
+        &self,
+        _user_id: &str,
+        _conversation_id: &str,
+        _params: &CronUpdateParams,
+    ) -> CronCommandResult {
+        CronCommandResult {
+            success: true,
+            message: "Updated cron job".into(),
+        }
+    }
+
+    async fn list_jobs(&self, _user_id: &str, _conversation_id: &str) -> CronCommandResult {
+        CronCommandResult {
+            success: true,
+            message: "No scheduled tasks".into(),
+        }
+    }
+
+    async fn delete_job(&self, _user_id: &str, _job_id: &str) -> CronCommandResult {
+        CronCommandResult {
+            success: true,
+            message: "Deleted cron job".into(),
+        }
+    }
+}
+
 // ── send_message tests ──────────────────────────────────────────
 
 fn make_send_req() -> SendMessageRequest {
@@ -1274,6 +1444,74 @@ async fn send_message_persists_factory_resolved_workspace() {
     // Verify the workspace was written back.
     let updated = svc.get("user_1", &conv.id).await.unwrap();
     assert_eq!(updated.extra["workspace"], auto_workspace);
+}
+
+#[tokio::test]
+async fn send_message_continues_cron_system_responses() {
+    let (svc, broadcaster, _repo, _default_task_mgr) = make_service();
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let scripted_agent = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![
+            vec![
+                AgentStreamEvent::Text(TextEventData {
+                    content: "I'll check. [CRON_LIST]".into(),
+                }),
+                AgentStreamEvent::Finish(FinishEventData::default()),
+            ],
+            vec![
+                AgentStreamEvent::Text(TextEventData {
+                    content: "[CRON_CREATE]\nname: Daily Greeting\nschedule: 0 9 * * *\nschedule_description: Daily at 9:00 AM\nmessage: Say good morning\n[/CRON_CREATE]".into(),
+                }),
+                AgentStreamEvent::Finish(FinishEventData::default()),
+            ],
+            vec![
+                AgentStreamEvent::Text(TextEventData {
+                    content: "Done. The task is scheduled.".into(),
+                }),
+                AgentStreamEvent::Finish(FinishEventData::default()),
+            ],
+        ],
+    ));
+    task_mgr.insert_agent(&conv.id, scripted_agent.clone());
+    svc.set_cron_service(Some(Arc::new(MockCronContinuationService)));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    let req: SendMessageRequest = serde_json::from_value(json!({
+        "content": "Create the task now",
+        "msg_id": "msg-1"
+    }))
+    .unwrap();
+
+    svc.send_message("user_1", &conv.id, req, &task_mgr_dyn)
+        .await
+        .unwrap();
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if scripted_agent.sent_contents().len() >= 3 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .unwrap();
+
+    let sends = scripted_agent.sent_contents();
+    assert_eq!(sends.len(), 3);
+    assert_eq!(sends[0], "Create the task now");
+    assert_eq!(sends[1], "[System: No scheduled tasks]");
+    assert_eq!(sends[2], "[System: Created cron job 'Daily Greeting']");
+
+    let finished = svc.get("user_1", &conv.id).await.unwrap();
+    assert_eq!(finished.status, ConversationStatus::Finished);
+
+    let events = broadcaster.take_events();
+    let turn_completed = events.iter().filter(|evt| evt.name == "turn.completed").count();
+    assert_eq!(turn_completed, 1);
 }
 
 // ── stop_stream tests ───────────────────────────────────────────

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1,12 +1,13 @@
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
-use aionui_ai_agent::{
-    CronCommandResult, CronCreateParams, CronUpdateParams, ICronService, IWorkerTaskManager,
-};
 use aionui_ai_agent::agent_manager::{AgentManagerHandle, IAgentManager};
 use aionui_ai_agent::stream_event::{AgentStreamEvent, FinishEventData, TextEventData};
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
+use aionui_ai_agent::{
+    CronCommandResult, CronCreateParams, CronUpdateParams, ICronService, IWorkerTaskManager,
+};
+use aionui_api_types::ConversationArtifactKind;
 use aionui_api_types::{
     CloneConversationRequest, CreateConversationRequest, ListConversationsQuery,
     SearchMessagesQuery, SendMessageRequest, UpdateConversationRequest, WebSocketMessage,
@@ -15,7 +16,7 @@ use aionui_common::{
     AgentKillReason, AgentType, AppError, Confirmation, ConversationSource, ConversationStatus,
     PaginatedResult, TimestampMs,
 };
-use aionui_db::models::{ConversationRow, MessageRow};
+use aionui_db::models::{ConversationArtifactRow, ConversationRow, MessageRow};
 use aionui_db::{
     ConversationFilters, ConversationRowUpdate, IConversationRepository, MessageRowUpdate,
     MessageSearchRow, SortOrder,
@@ -55,12 +56,16 @@ impl EventBroadcaster for MockBroadcaster {
 
 struct MockRepo {
     rows: Mutex<Vec<ConversationRow>>,
+    messages: Mutex<Vec<MessageRow>>,
+    artifacts: Mutex<Vec<ConversationArtifactRow>>,
 }
 
 impl MockRepo {
     fn new() -> Self {
         Self {
             rows: Mutex::new(vec![]),
+            messages: Mutex::new(vec![]),
+            artifacts: Mutex::new(vec![]),
         }
     }
 }
@@ -179,44 +184,90 @@ impl IConversationRepository for MockRepo {
 
     async fn get_messages(
         &self,
-        _conv_id: &str,
-        _page: u32,
-        _page_size: u32,
-        _order: SortOrder,
+        conv_id: &str,
+        page: u32,
+        page_size: u32,
+        order: SortOrder,
     ) -> Result<PaginatedResult<MessageRow>, aionui_db::DbError> {
+        let messages = self.messages.lock().unwrap();
+        let mut matched: Vec<_> = messages
+            .iter()
+            .filter(|message| message.conversation_id == conv_id)
+            .cloned()
+            .collect();
+        matched.sort_by_key(|message| message.created_at);
+        if matches!(order, SortOrder::Desc) {
+            matched.reverse();
+        }
+
+        let start = page.saturating_sub(1) as usize * page_size as usize;
+        let end = (start + page_size as usize).min(matched.len());
+        let items = if start < matched.len() {
+            matched[start..end].to_vec()
+        } else {
+            Vec::new()
+        };
         Ok(PaginatedResult {
-            items: vec![],
-            total: 0,
-            has_more: false,
+            items,
+            total: matched.len() as u64,
+            has_more: end < matched.len(),
         })
     }
 
-    async fn insert_message(&self, _message: &MessageRow) -> Result<(), aionui_db::DbError> {
+    async fn insert_message(&self, message: &MessageRow) -> Result<(), aionui_db::DbError> {
+        self.messages.lock().unwrap().push(message.clone());
         Ok(())
     }
 
     async fn update_message(
         &self,
-        _id: &str,
-        _updates: &MessageRowUpdate,
+        id: &str,
+        updates: &MessageRowUpdate,
     ) -> Result<(), aionui_db::DbError> {
+        let mut messages = self.messages.lock().unwrap();
+        let message = messages
+            .iter_mut()
+            .find(|message| message.id == id)
+            .ok_or_else(|| aionui_db::DbError::NotFound(format!("Message {id}")))?;
+
+        if let Some(content) = &updates.content {
+            message.content = content.clone();
+        }
+        if let Some(status) = &updates.status {
+            message.status = status.clone();
+        }
+        if let Some(hidden) = updates.hidden {
+            message.hidden = hidden;
+        }
         Ok(())
     }
 
     async fn delete_messages_by_conversation(
         &self,
-        _conv_id: &str,
+        conv_id: &str,
     ) -> Result<(), aionui_db::DbError> {
+        self.messages
+            .lock()
+            .unwrap()
+            .retain(|message| message.conversation_id != conv_id);
         Ok(())
     }
 
     async fn get_message_by_msg_id(
         &self,
-        _conv_id: &str,
-        _msg_id: &str,
-        _msg_type: &str,
+        conv_id: &str,
+        msg_id: &str,
+        msg_type: &str,
     ) -> Result<Option<MessageRow>, aionui_db::DbError> {
-        Ok(None)
+        let messages = self.messages.lock().unwrap();
+        Ok(messages
+            .iter()
+            .find(|message| {
+                message.conversation_id == conv_id
+                    && message.msg_id.as_deref() == Some(msg_id)
+                    && message.r#type == msg_type
+            })
+            .cloned())
     }
 
     async fn search_messages(
@@ -231,6 +282,112 @@ impl IConversationRepository for MockRepo {
             total: 0,
             has_more: false,
         })
+    }
+
+    async fn list_artifacts(
+        &self,
+        conversation_id: &str,
+    ) -> Result<Vec<ConversationArtifactRow>, aionui_db::DbError> {
+        Ok(self
+            .artifacts
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|artifact| artifact.conversation_id == conversation_id)
+            .cloned()
+            .collect())
+    }
+
+    async fn get_artifact(
+        &self,
+        conversation_id: &str,
+        artifact_id: &str,
+    ) -> Result<Option<ConversationArtifactRow>, aionui_db::DbError> {
+        Ok(self
+            .artifacts
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|artifact| {
+                artifact.conversation_id == conversation_id && artifact.id == artifact_id
+            })
+            .cloned())
+    }
+
+    async fn upsert_artifact(
+        &self,
+        artifact: &ConversationArtifactRow,
+    ) -> Result<ConversationArtifactRow, aionui_db::DbError> {
+        let mut artifacts = self.artifacts.lock().unwrap();
+        if let Some(existing) = artifacts.iter_mut().find(|row| row.id == artifact.id) {
+            *existing = artifact.clone();
+            return Ok(existing.clone());
+        }
+        artifacts.push(artifact.clone());
+        Ok(artifact.clone())
+    }
+
+    async fn update_artifact_status(
+        &self,
+        conversation_id: &str,
+        artifact_id: &str,
+        status: &str,
+        updated_at: TimestampMs,
+    ) -> Result<Option<ConversationArtifactRow>, aionui_db::DbError> {
+        let mut artifacts = self.artifacts.lock().unwrap();
+        let Some(existing) = artifacts.iter_mut().find(|artifact| {
+            artifact.conversation_id == conversation_id && artifact.id == artifact_id
+        }) else {
+            return Ok(None);
+        };
+        existing.status = status.to_owned();
+        existing.updated_at = updated_at;
+        Ok(Some(existing.clone()))
+    }
+
+    async fn mark_skill_suggest_artifacts_saved(
+        &self,
+        cron_job_id: &str,
+        updated_at: TimestampMs,
+    ) -> Result<Vec<ConversationArtifactRow>, aionui_db::DbError> {
+        let mut artifacts = self.artifacts.lock().unwrap();
+        let mut updated = Vec::new();
+        for artifact in artifacts
+            .iter_mut()
+            .filter(|artifact| artifact.cron_job_id.as_deref() == Some(cron_job_id))
+        {
+            artifact.status = "saved".into();
+            artifact.updated_at = updated_at;
+            updated.push(artifact.clone());
+        }
+        Ok(updated)
+    }
+
+    async fn delete_artifacts_by_conversation(
+        &self,
+        conversation_id: &str,
+    ) -> Result<(), aionui_db::DbError> {
+        self.artifacts
+            .lock()
+            .unwrap()
+            .retain(|artifact| artifact.conversation_id != conversation_id);
+        Ok(())
+    }
+
+    async fn list_legacy_cron_trigger_messages(
+        &self,
+        conversation_id: &str,
+    ) -> Result<Vec<MessageRow>, aionui_db::DbError> {
+        Ok(self
+            .messages
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|message| {
+                message.conversation_id == conversation_id && message.r#type == "cron_trigger"
+            })
+            .cloned()
+            .collect())
     }
 }
 
@@ -867,6 +1024,60 @@ async fn reset_sets_status_to_pending() {
 }
 
 #[tokio::test]
+async fn reset_clears_conversation_artifacts() {
+    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+    repo.upsert_artifact(&ConversationArtifactRow {
+        id: format!("{}:skill_suggest:cron_1", conv.id),
+        conversation_id: conv.id.clone(),
+        cron_job_id: Some("cron_1".into()),
+        kind: "skill_suggest".into(),
+        status: "pending".into(),
+        payload: json!({ "cron_job_id": "cron_1", "name": "daily-report" }).to_string(),
+        created_at: 1000,
+        updated_at: 1000,
+    })
+    .await
+    .unwrap();
+
+    svc.reset("user_1", &conv.id).await.unwrap();
+
+    let artifacts = repo.list_artifacts(&conv.id).await.unwrap();
+    assert!(artifacts.is_empty());
+}
+
+#[tokio::test]
+async fn list_artifacts_includes_legacy_cron_trigger_messages() {
+    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+    repo.insert_message(&MessageRow {
+        id: "legacy-msg-1".into(),
+        conversation_id: conv.id.clone(),
+        msg_id: Some("legacy-trigger-1".into()),
+        r#type: "cron_trigger".into(),
+        content: json!({
+            "cron_job_id": "cron_1",
+            "cron_job_name": "Daily Report",
+            "triggered_at": 1234
+        })
+        .to_string(),
+        position: Some("center".into()),
+        status: Some("finish".into()),
+        hidden: false,
+        created_at: 1234,
+    })
+    .await
+    .unwrap();
+
+    let artifacts = svc.list_artifacts("user_1", &conv.id).await.unwrap();
+
+    assert_eq!(artifacts.len(), 1);
+    assert_eq!(artifacts[0].kind, ConversationArtifactKind::CronTrigger);
+    assert_eq!(artifacts[0].payload["cron_job_id"], "cron_1");
+    assert_eq!(artifacts[0].payload["cron_job_name"], "Daily Report");
+}
+
+#[tokio::test]
 async fn reset_not_found() {
     let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     let err = svc.reset("user_1", "no-such-id").await.unwrap_err();
@@ -1327,6 +1538,35 @@ async fn send_message_returns_accepted() {
 }
 
 #[tokio::test]
+async fn send_message_persists_hidden_user_message_when_requested() {
+    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
+
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+    let req: SendMessageRequest = serde_json::from_value(json!({
+        "content": "Hidden cron prompt",
+        "msg_id": "msg-hidden",
+        "hidden": true
+    }))
+    .unwrap();
+
+    svc.send_message("user_1", &conv.id, req, &task_mgr)
+        .await
+        .unwrap();
+
+    let messages = repo
+        .get_messages(&conv.id, 1, 20, SortOrder::Asc)
+        .await
+        .unwrap()
+        .items;
+    let user_message = messages
+        .iter()
+        .find(|message| message.msg_id.as_deref() == Some("msg-hidden"))
+        .expect("hidden user message should be persisted");
+    assert!(user_message.hidden);
+}
+
+#[tokio::test]
 async fn send_message_empty_content_returns_bad_request() {
     let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
@@ -1510,7 +1750,10 @@ async fn send_message_continues_cron_system_responses() {
     assert_eq!(finished.status, ConversationStatus::Finished);
 
     let events = broadcaster.take_events();
-    let turn_completed = events.iter().filter(|evt| evt.name == "turn.completed").count();
+    let turn_completed = events
+        .iter()
+        .filter(|evt| evt.name == "turn.completed")
+        .count();
     assert_eq!(turn_completed, 1);
 }
 

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use aionui_ai_agent::AgentStreamEvent;
+use aionui_ai_agent::{AgentStreamEvent, ICronService, MessageMiddleware, MiddlewareResult};
 use aionui_api_types::WebSocketMessage;
-use aionui_common::{ConversationStatus, generate_id, now_ms};
+use aionui_common::{generate_id, now_ms};
 use aionui_db::IConversationRepository;
 use aionui_db::models::MessageRow;
 use aionui_realtime::EventBroadcaster;
@@ -13,6 +13,12 @@ use tracing::{debug, error, info, warn};
 /// Number of text chunks to accumulate before flushing to the database.
 const FLUSH_INTERVAL: u32 = 20;
 
+/// Result returned after a relay turn has fully drained and finalized.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RelayOutcome {
+    pub system_responses: Vec<String>,
+}
+
 /// Relays agent stream events to WebSocket and persists messages.
 ///
 /// This struct is created for each `send_message` call and runs as a
@@ -20,27 +26,40 @@ const FLUSH_INTERVAL: u32 = 20;
 pub struct StreamRelay {
     conversation_id: String,
     assistant_msg_id: String,
+    user_id: String,
     repo: Arc<dyn IConversationRepository>,
     broadcaster: Arc<dyn EventBroadcaster>,
+    cron_service: Option<Arc<dyn ICronService>>,
+    complete_turn: bool,
 }
 
 impl StreamRelay {
     pub fn new(
         conversation_id: String,
         assistant_msg_id: String,
+        user_id: String,
         repo: Arc<dyn IConversationRepository>,
         broadcaster: Arc<dyn EventBroadcaster>,
+        cron_service: Option<Arc<dyn ICronService>>,
     ) -> Self {
         Self {
             conversation_id,
             assistant_msg_id,
+            user_id,
             repo,
             broadcaster,
+            cron_service,
+            complete_turn: true,
         }
     }
 
+    pub fn with_turn_completion(mut self, enabled: bool) -> Self {
+        self.complete_turn = enabled;
+        self
+    }
+
     /// Run the relay loop. Consumes `self` and runs until the agent stream ends.
-    pub async fn run(self, mut rx: broadcast::Receiver<AgentStreamEvent>) {
+    pub async fn run(self, mut rx: broadcast::Receiver<AgentStreamEvent>) -> RelayOutcome {
         let started_at = now_ms();
         info!(
             conversation_id = %self.conversation_id,
@@ -97,9 +116,16 @@ impl StreamRelay {
                         }
                         self.persist_thinking(&thinking_buffer, thinking_started_at)
                             .await;
-                        self.finalize(&text_buffer, &record_created, &event).await;
-                        self.send_turn_completed(&event);
-                        break;
+                        let outcome = self.finalize(&text_buffer, &record_created, &event).await;
+                        if self.complete_turn {
+                            Self::complete_conversation(
+                                &self.repo,
+                                &self.broadcaster,
+                                &self.conversation_id,
+                            )
+                            .await;
+                        }
+                        break outcome;
                     }
                 }
                 Err(broadcast::error::RecvError::Closed) => {
@@ -116,16 +142,24 @@ impl StreamRelay {
                     self.persist_thinking(&thinking_buffer, thinking_started_at)
                         .await;
                     // Channel closed without finish/error — still finalize
-                    self.finalize(
-                        &text_buffer,
-                        &record_created,
-                        &AgentStreamEvent::Finish(
-                            aionui_ai_agent::stream_event::FinishEventData::default(),
-                        ),
-                    )
-                    .await;
-                    self.send_turn_completed_status("finished");
-                    break;
+                    let outcome = self
+                        .finalize(
+                            &text_buffer,
+                            &record_created,
+                            &AgentStreamEvent::Finish(
+                                aionui_ai_agent::stream_event::FinishEventData::default(),
+                            ),
+                        )
+                        .await;
+                    if self.complete_turn {
+                        Self::complete_conversation(
+                            &self.repo,
+                            &self.broadcaster,
+                            &self.conversation_id,
+                        )
+                        .await;
+                    }
+                    break outcome;
                 }
                 Err(broadcast::error::RecvError::Lagged(n)) => {
                     warn!(
@@ -156,8 +190,7 @@ impl StreamRelay {
             "hidden": false,
         });
 
-        let msg = WebSocketMessage::new("message.stream", payload);
-        self.broadcaster.broadcast(msg);
+        self.broadcast_stream_payload(payload);
     }
 
     /// Flush accumulated text to the database (create or update).
@@ -201,43 +234,62 @@ impl StreamRelay {
     }
 
     /// Finalize the assistant message on stream end.
-    async fn finalize(&self, text: &str, record_created: &bool, event: &AgentStreamEvent) {
+    async fn finalize(
+        &self,
+        text: &str,
+        record_created: &bool,
+        event: &AgentStreamEvent,
+    ) -> RelayOutcome {
+        let mut outcome = RelayOutcome::default();
         let status = match event {
             AgentStreamEvent::Error(_) => "error",
             _ => "finish",
         };
 
         if !text.is_empty() {
-            let content = json!({ "content": text }).to_string();
-            if *record_created {
-                let update = aionui_db::MessageRowUpdate {
-                    content: Some(content),
-                    status: Some(Some(status.to_owned())),
-                    hidden: None,
-                };
-                if let Err(e) = self
-                    .repo
-                    .update_message(&self.assistant_msg_id, &update)
-                    .await
-                {
-                    error!(error = %e, "Failed to finalize streaming message");
+            let processed = self.process_final_text(text).await;
+            let final_text = processed.message.trim().to_owned();
+            let hidden = final_text.is_empty();
+            let content = json!({ "content": final_text }).to_string();
+
+            if *record_created || !hidden {
+                if *record_created {
+                    let update = aionui_db::MessageRowUpdate {
+                        content: Some(content),
+                        status: Some(Some(status.to_owned())),
+                        hidden: Some(hidden),
+                    };
+                    if let Err(e) = self
+                        .repo
+                        .update_message(&self.assistant_msg_id, &update)
+                        .await
+                    {
+                        error!(error = %e, "Failed to finalize streaming message");
+                    }
+                } else {
+                    let row = MessageRow {
+                        id: self.assistant_msg_id.clone(),
+                        conversation_id: self.conversation_id.clone(),
+                        msg_id: None,
+                        r#type: "text".into(),
+                        content,
+                        position: Some("left".into()),
+                        status: Some(status.to_owned()),
+                        hidden,
+                        created_at: now_ms(),
+                    };
+                    if let Err(e) = self.repo.insert_message(&row).await {
+                        error!(error = %e, "Failed to create final message");
+                    }
                 }
-            } else {
-                let row = MessageRow {
-                    id: self.assistant_msg_id.clone(),
-                    conversation_id: self.conversation_id.clone(),
-                    msg_id: None,
-                    r#type: "text".into(),
-                    content,
-                    position: Some("left".into()),
-                    status: Some(status.to_owned()),
-                    hidden: false,
-                    created_at: now_ms(),
-                };
-                if let Err(e) = self.repo.insert_message(&row).await {
-                    error!(error = %e, "Failed to create final message");
+
+                if processed.message != text || hidden {
+                    self.send_final_text_override(&processed.message, hidden);
                 }
             }
+
+            self.send_system_responses(&processed.system_responses);
+            outcome.system_responses = processed.system_responses;
         } else if let AgentStreamEvent::Error(data) = event {
             // No text accumulated but got an error — store error as tips message
             let content = json!({ "content": data.message, "type": "error" }).to_string();
@@ -257,9 +309,7 @@ impl StreamRelay {
             }
         }
 
-        // Update conversation status — all terminal events resolve to Finished
-        self.update_conversation_status(ConversationStatus::Finished)
-            .await;
+        outcome
     }
 
     /// Persist accumulated thinking content as a message in the database.
@@ -301,46 +351,72 @@ impl StreamRelay {
         self.forward_to_websocket(&thinking_done);
     }
 
-    /// Send a `turn.completed` WebSocket event.
-    fn send_turn_completed(&self, _event: &AgentStreamEvent) {
-        // All terminal events resolve to "finished" status
-        self.send_turn_completed_status("finished");
+    async fn process_final_text(&self, text: &str) -> MiddlewareResult {
+        let middleware = MessageMiddleware::new(self.cron_service.as_ref().map(|service| {
+            Box::new(SharedCronService(Arc::clone(service))) as Box<dyn ICronService>
+        }));
+
+        middleware
+            .process(text, &self.user_id, &self.conversation_id)
+            .await
     }
 
-    fn send_turn_completed_status(&self, status: &str) {
-        let can_send = status == "finished";
-        let payload = json!({
+    fn send_final_text_override(&self, text: &str, hidden: bool) {
+        self.broadcast_stream_payload(json!({
             "conversation_id": self.conversation_id,
-            "session_id": self.conversation_id,
-            "status": status,
-            "canSendMessage": can_send,
+            "msg_id": self.assistant_msg_id,
+            "type": "content",
+            "data": { "content": text },
+            "hidden": hidden,
+            "replace": true,
+        }));
+    }
+
+    fn send_system_responses(&self, responses: &[String]) {
+        for response in responses {
+            self.broadcast_stream_payload(json!({
+                "conversation_id": self.conversation_id,
+                "msg_id": generate_id(),
+                "type": "system",
+                "data": response,
+                "hidden": true,
+            }));
+        }
+    }
+
+    fn broadcast_stream_payload(&self, payload: serde_json::Value) {
+        let msg = WebSocketMessage::new("message.stream", payload);
+        self.broadcaster.broadcast(msg);
+    }
+
+    pub async fn complete_conversation(
+        repo: &Arc<dyn IConversationRepository>,
+        broadcaster: &Arc<dyn EventBroadcaster>,
+        conversation_id: &str,
+    ) {
+        let update = aionui_db::ConversationRowUpdate {
+            status: Some("finished".to_owned()),
+            updated_at: Some(now_ms()),
+            ..Default::default()
+        };
+        if let Err(e) = repo.update(conversation_id, &update).await {
+            error!(error = %e, "Failed to update conversation status");
+        }
+
+        let payload = json!({
+            "conversation_id": conversation_id,
+            "session_id": conversation_id,
+            "status": "finished",
+            "canSendMessage": true,
         });
         let msg = WebSocketMessage::new("turn.completed", payload);
-        self.broadcaster.broadcast(msg);
+        broadcaster.broadcast(msg);
 
         debug!(
-            conversation_id = %self.conversation_id,
-            status,
+            conversation_id,
+            status = "finished",
             "Turn completed"
         );
-    }
-
-    /// Update the conversation status in the database.
-    async fn update_conversation_status(&self, status: ConversationStatus) {
-        let status_str = serde_json::to_value(status)
-            .ok()
-            .and_then(|v| v.as_str().map(|s| s.to_owned()));
-
-        if let Some(status_str) = status_str {
-            let update = aionui_db::ConversationRowUpdate {
-                status: Some(status_str),
-                updated_at: Some(now_ms()),
-                ..Default::default()
-            };
-            if let Err(e) = self.repo.update(&self.conversation_id, &update).await {
-                error!(error = %e, "Failed to update conversation status");
-            }
-        }
     }
 
     fn is_terminal(&self, event: &AgentStreamEvent) -> bool {
@@ -348,6 +424,41 @@ impl StreamRelay {
             event,
             AgentStreamEvent::Finish(_) | AgentStreamEvent::Error(_)
         )
+    }
+}
+
+struct SharedCronService(Arc<dyn ICronService>);
+
+#[async_trait::async_trait]
+impl ICronService for SharedCronService {
+    async fn create_job(
+        &self,
+        user_id: &str,
+        conversation_id: &str,
+        params: &aionui_ai_agent::CronCreateParams,
+    ) -> aionui_ai_agent::CronCommandResult {
+        self.0.create_job(user_id, conversation_id, params).await
+    }
+
+    async fn update_job(
+        &self,
+        user_id: &str,
+        conversation_id: &str,
+        params: &aionui_ai_agent::CronUpdateParams,
+    ) -> aionui_ai_agent::CronCommandResult {
+        self.0.update_job(user_id, conversation_id, params).await
+    }
+
+    async fn list_jobs(
+        &self,
+        user_id: &str,
+        conversation_id: &str,
+    ) -> aionui_ai_agent::CronCommandResult {
+        self.0.list_jobs(user_id, conversation_id).await
+    }
+
+    async fn delete_job(&self, user_id: &str, job_id: &str) -> aionui_ai_agent::CronCommandResult {
+        self.0.delete_job(user_id, job_id).await
     }
 }
 
@@ -403,7 +514,14 @@ mod tests {
         let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
         let (tx, _) = broadcast::channel(64);
 
-        let relay = StreamRelay::new("conv-1".into(), "asst-1".into(), repo.clone(), bus.clone());
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+            None,
+        );
 
         let rx = tx.subscribe();
 
@@ -419,7 +537,8 @@ mod tests {
         tx.send(AgentStreamEvent::Finish(FinishEventData::default()))
             .unwrap();
 
-        relay.run(rx).await;
+        let outcome = relay.run(rx).await;
+        assert!(outcome.system_responses.is_empty());
 
         // Should have inserted a message with accumulated text
         let inserts = repo.take_inserts();
@@ -440,7 +559,14 @@ mod tests {
         let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
         let (tx, _) = broadcast::channel(64);
 
-        let relay = StreamRelay::new("conv-1".into(), "asst-1".into(), repo.clone(), bus.clone());
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+            None,
+        );
 
         let rx = tx.subscribe();
 
@@ -450,7 +576,8 @@ mod tests {
         }))
         .unwrap();
 
-        relay.run(rx).await;
+        let outcome = relay.run(rx).await;
+        assert!(outcome.system_responses.is_empty());
 
         let inserts = repo.take_inserts();
         assert_eq!(inserts.len(), 1);
@@ -469,7 +596,14 @@ mod tests {
         let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
         let (tx, _) = broadcast::channel(64);
 
-        let relay = StreamRelay::new("conv-1".into(), "asst-1".into(), repo.clone(), bus.clone());
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+            None,
+        );
 
         let rx = tx.subscribe();
 
@@ -480,7 +614,8 @@ mod tests {
         .unwrap();
         drop(tx);
 
-        relay.run(rx).await;
+        let outcome = relay.run(rx).await;
+        assert!(outcome.system_responses.is_empty());
 
         // Should still persist the partial text
         let inserts = repo.take_inserts();
@@ -495,7 +630,14 @@ mod tests {
         let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
         let (tx, _) = broadcast::channel(64);
 
-        let relay = StreamRelay::new("conv-1".into(), "asst-1".into(), repo.clone(), bus.clone());
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+            None,
+        );
 
         // Subscribe to the bus before relay runs
         let mut ws_rx = bus.subscribe();
@@ -504,7 +646,8 @@ mod tests {
         tx.send(AgentStreamEvent::Finish(FinishEventData::default()))
             .unwrap();
 
-        relay.run(rx).await;
+        let outcome = relay.run(rx).await;
+        assert!(outcome.system_responses.is_empty());
 
         // Collect WebSocket events
         let mut ws_events = vec![];
@@ -522,15 +665,118 @@ mod tests {
         assert_eq!(data["canSendMessage"], true);
     }
 
+    #[tokio::test]
+    async fn run_finalizes_with_cleaned_replacement_event() {
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let (tx, _) = broadcast::channel(64);
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+            Some(Arc::new(MockCronService)),
+        );
+
+        let mut ws_rx = bus.subscribe();
+        let rx = tx.subscribe();
+        tx.send(AgentStreamEvent::Text(TextEventData {
+            content: "Hello [CRON_LIST]".into(),
+        }))
+        .unwrap();
+        tx.send(AgentStreamEvent::Finish(FinishEventData::default()))
+            .unwrap();
+
+        let outcome = relay.run(rx).await;
+        assert_eq!(outcome.system_responses, vec!["[System: listed]".to_string()]);
+
+        let inserts = repo.take_inserts();
+        assert_eq!(inserts.len(), 1);
+        let content: serde_json::Value = serde_json::from_str(&inserts[0].content).unwrap();
+        assert_eq!(content["content"].as_str().map(str::trim), Some("Hello"));
+
+        let mut ws_events = vec![];
+        while let Ok(evt) = ws_rx.try_recv() {
+            ws_events.push(evt);
+        }
+
+        let replacement = ws_events.iter().find(|evt| {
+            evt.name == "message.stream"
+                && evt.data["type"] == "content"
+                && evt.data["replace"] == true
+        });
+        assert!(replacement.is_some());
+        assert_eq!(
+            replacement.unwrap().data["data"]["content"]
+                .as_str()
+                .map(str::trim),
+            Some("Hello")
+        );
+    }
+
     // ── Helpers ──────────────────────────────────────────────────
 
     fn make_relay() -> StreamRelay {
         let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(16));
-        StreamRelay {
-            conversation_id: "conv-1".into(),
-            assistant_msg_id: "msg-1".into(),
-            repo: Arc::new(NoopRepo),
-            broadcaster: bus,
+        StreamRelay::new(
+            "conv-1".into(),
+            "msg-1".into(),
+            "user-1".into(),
+            Arc::new(NoopRepo),
+            bus,
+            None,
+        )
+    }
+
+    struct MockCronService;
+
+    #[async_trait::async_trait]
+    impl ICronService for MockCronService {
+        async fn create_job(
+            &self,
+            _user_id: &str,
+            _conversation_id: &str,
+            _params: &aionui_ai_agent::CronCreateParams,
+        ) -> aionui_ai_agent::CronCommandResult {
+            aionui_ai_agent::CronCommandResult {
+                success: true,
+                message: "created".into(),
+            }
+        }
+
+        async fn update_job(
+            &self,
+            _user_id: &str,
+            _conversation_id: &str,
+            _params: &aionui_ai_agent::CronUpdateParams,
+        ) -> aionui_ai_agent::CronCommandResult {
+            aionui_ai_agent::CronCommandResult {
+                success: true,
+                message: "updated".into(),
+            }
+        }
+
+        async fn list_jobs(
+            &self,
+            _user_id: &str,
+            _conversation_id: &str,
+        ) -> aionui_ai_agent::CronCommandResult {
+            aionui_ai_agent::CronCommandResult {
+                success: true,
+                message: "listed".into(),
+            }
+        }
+
+        async fn delete_job(
+            &self,
+            _user_id: &str,
+            _job_id: &str,
+        ) -> aionui_ai_agent::CronCommandResult {
+            aionui_ai_agent::CronCommandResult {
+                success: true,
+                message: "deleted".into(),
+            }
         }
     }
 

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -412,11 +412,7 @@ impl StreamRelay {
         let msg = WebSocketMessage::new("turn.completed", payload);
         broadcaster.broadcast(msg);
 
-        debug!(
-            conversation_id,
-            status = "finished",
-            "Turn completed"
-        );
+        debug!(conversation_id, status = "finished", "Turn completed");
     }
 
     fn is_terminal(&self, event: &AgentStreamEvent) -> bool {
@@ -689,7 +685,10 @@ mod tests {
             .unwrap();
 
         let outcome = relay.run(rx).await;
-        assert_eq!(outcome.system_responses, vec!["[System: listed]".to_string()]);
+        assert_eq!(
+            outcome.system_responses,
+            vec!["[System: listed]".to_string()]
+        );
 
         let inserts = repo.take_inserts();
         assert_eq!(inserts.len(), 1);

--- a/crates/aionui-conversation/tests/conversation_crud.rs
+++ b/crates/aionui-conversation/tests/conversation_crud.rs
@@ -71,10 +71,7 @@ impl SkillResolver for EmptySkillResolver {
         Vec::new()
     }
 
-    async fn resolve_skills(
-        &self,
-        _names: &[String],
-    ) -> Vec<aionui_extension::ResolvedAgentSkill> {
+    async fn resolve_skills(&self, _names: &[String]) -> Vec<aionui_extension::ResolvedAgentSkill> {
         Vec::new()
     }
 

--- a/crates/aionui-conversation/tests/conversation_extended.rs
+++ b/crates/aionui-conversation/tests/conversation_extended.rs
@@ -41,10 +41,7 @@ impl SkillResolver for EmptySkillResolver {
         Vec::new()
     }
 
-    async fn resolve_skills(
-        &self,
-        _names: &[String],
-    ) -> Vec<aionui_extension::ResolvedAgentSkill> {
+    async fn resolve_skills(&self, _names: &[String]) -> Vec<aionui_extension::ResolvedAgentSkill> {
         Vec::new()
     }
 

--- a/crates/aionui-cron/Cargo.toml
+++ b/crates/aionui-cron/Cargo.toml
@@ -26,3 +26,4 @@ async-trait.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+tempfile.workspace = true

--- a/crates/aionui-cron/src/artifacts.rs
+++ b/crates/aionui-cron/src/artifacts.rs
@@ -1,0 +1,165 @@
+use std::sync::Arc;
+
+use aionui_api_types::{ConversationArtifactResponse, WebSocketMessage};
+use aionui_common::generate_id;
+use aionui_db::ConversationArtifactRow;
+use aionui_realtime::EventBroadcaster;
+use serde::de::DeserializeOwned;
+use serde_json::json;
+
+use crate::error::CronError;
+use crate::types::CronJob;
+
+pub(crate) fn build_cron_trigger_artifact(
+    conversation_id: &str,
+    job: &CronJob,
+    created_at: i64,
+) -> ConversationArtifactRow {
+    let id = format!("{conversation_id}:cron_trigger:{}", generate_id());
+    let payload = json!({
+        "cron_job_id": job.id,
+        "cron_job_name": job.name,
+        "triggered_at": created_at,
+    });
+
+    ConversationArtifactRow {
+        id,
+        conversation_id: conversation_id.to_owned(),
+        cron_job_id: Some(job.id.clone()),
+        kind: "cron_trigger".into(),
+        status: "active".into(),
+        payload: payload.to_string(),
+        created_at,
+        updated_at: created_at,
+    }
+}
+
+pub(crate) fn build_skill_suggest_artifact(
+    conversation_id: &str,
+    job_id: &str,
+    name: &str,
+    description: &str,
+    skill_content: &str,
+    now: i64,
+) -> ConversationArtifactRow {
+    let id = format!("{conversation_id}:skill_suggest:{job_id}");
+    let payload = json!({
+        "cron_job_id": job_id,
+        "name": name,
+        "description": description,
+        "skillContent": skill_content,
+    });
+
+    ConversationArtifactRow {
+        id,
+        conversation_id: conversation_id.to_owned(),
+        cron_job_id: Some(job_id.to_owned()),
+        kind: "skill_suggest".into(),
+        status: "pending".into(),
+        payload: payload.to_string(),
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+pub(crate) fn artifact_response_from_row(
+    row: &ConversationArtifactRow,
+) -> Result<ConversationArtifactResponse, CronError> {
+    Ok(ConversationArtifactResponse {
+        id: row.id.clone(),
+        conversation_id: row.conversation_id.clone(),
+        cron_job_id: row.cron_job_id.clone(),
+        kind: parse_enum(&row.kind)?,
+        status: parse_enum(&row.status)?,
+        payload: serde_json::from_str(&row.payload)
+            .map_err(|e| CronError::Scheduler(format!("invalid artifact payload JSON: {e}")))?,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    })
+}
+
+pub(crate) fn broadcast_artifact(
+    broadcaster: &Arc<dyn EventBroadcaster>,
+    row: &ConversationArtifactRow,
+) -> Result<(), CronError> {
+    let payload = serde_json::to_value(artifact_response_from_row(row)?)
+        .map_err(|e| CronError::Scheduler(format!("failed to serialize artifact event: {e}")))?;
+    broadcaster.broadcast(WebSocketMessage::new("conversation.artifact", payload));
+    Ok(())
+}
+
+fn parse_enum<T: DeserializeOwned>(value: &str) -> Result<T, CronError> {
+    serde_json::from_value(serde_json::Value::String(value.to_owned()))
+        .map_err(|e| CronError::Scheduler(format!("invalid artifact enum value '{value}': {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{CreatedBy, CronJob, CronSchedule, ExecutionMode};
+
+    fn sample_job() -> CronJob {
+        CronJob {
+            id: "cron_1".into(),
+            name: "Daily Report".into(),
+            enabled: true,
+            schedule: CronSchedule::Every {
+                every_ms: 60_000,
+                description: None,
+            },
+            message: "Run".into(),
+            execution_mode: ExecutionMode::NewConversation,
+            agent_config: None,
+            conversation_id: "conv_1".into(),
+            conversation_title: None,
+            agent_type: "acp".into(),
+            created_by: CreatedBy::User,
+            skill_content: None,
+            description: None,
+            created_at: 1000,
+            updated_at: 1000,
+            next_run_at: Some(2000),
+            last_run_at: None,
+            last_status: None,
+            last_error: None,
+            run_count: 0,
+            retry_count: 0,
+            max_retries: 3,
+        }
+    }
+
+    #[test]
+    fn builds_skill_suggest_response() {
+        let row = build_skill_suggest_artifact(
+            "conv_1",
+            "cron_1",
+            "daily-report",
+            "Daily report",
+            "---\nname: daily-report\n---\nUse it.",
+            1234,
+        );
+
+        let response = artifact_response_from_row(&row).unwrap();
+        assert_eq!(
+            response.kind,
+            aionui_api_types::ConversationArtifactKind::SkillSuggest
+        );
+        assert_eq!(
+            response.status,
+            aionui_api_types::ConversationArtifactStatus::Pending
+        );
+        assert_eq!(response.payload["name"], "daily-report");
+    }
+
+    #[test]
+    fn builds_cron_trigger_payload() {
+        let row = build_cron_trigger_artifact("conv_1", &sample_job(), 1234);
+        let response = artifact_response_from_row(&row).unwrap();
+        assert_eq!(
+            response.kind,
+            aionui_api_types::ConversationArtifactKind::CronTrigger
+        );
+        assert_eq!(response.payload["cron_job_id"], "cron_1");
+        assert_eq!(response.payload["cron_job_name"], "Daily Report");
+    }
+}

--- a/crates/aionui-cron/src/events.rs
+++ b/crates/aionui-cron/src/events.rs
@@ -3,9 +3,12 @@ use std::sync::Arc;
 use aionui_api_types::{
     CronJobExecutedEvent, CronJobRemovedPayload, CronJobResponse, WebSocketMessage,
 };
+use aionui_common::generate_id;
 use aionui_realtime::EventBroadcaster;
+use serde_json::json;
 use tracing::error;
 
+#[derive(Clone)]
 pub struct CronEventEmitter {
     broadcaster: Arc<dyn EventBroadcaster>,
 }
@@ -16,16 +19,16 @@ impl CronEventEmitter {
     }
 
     pub fn emit_job_created(&self, job: &CronJobResponse) {
-        self.broadcast("cron.jobCreated", job);
+        self.broadcast("cron.job-created", job);
     }
 
     pub fn emit_job_updated(&self, job: &CronJobResponse) {
-        self.broadcast("cron.jobUpdated", job);
+        self.broadcast("cron.job-updated", job);
     }
 
     pub fn emit_job_removed(&self, job_id: &str) {
         self.broadcast(
-            "cron.jobRemoved",
+            "cron.job-removed",
             &CronJobRemovedPayload {
                 job_id: job_id.to_owned(),
             },
@@ -34,13 +37,28 @@ impl CronEventEmitter {
 
     pub fn emit_job_executed(&self, job_id: &str, status: &str, err: Option<&str>) {
         self.broadcast(
-            "cron.jobExecuted",
+            "cron.job-executed",
             &CronJobExecutedEvent {
                 job_id: job_id.to_owned(),
                 status: status.to_owned(),
                 error: err.map(|s| s.to_owned()),
             },
         );
+    }
+
+    pub fn emit_conversation_tips(&self, conversation_id: &str, content: &str, tip_type: &str) {
+        let payload = json!({
+            "conversation_id": conversation_id,
+            "msg_id": generate_id(),
+            "type": "tips",
+            "data": {
+                "content": content,
+                "type": tip_type,
+            },
+            "hidden": false,
+        });
+        self.broadcaster
+            .broadcast(WebSocketMessage::new("message.stream", payload));
     }
 
     fn broadcast<T: serde::Serialize>(&self, event_name: &str, payload: &T) {
@@ -96,6 +114,7 @@ mod tests {
         CronJobResponse {
             id: "cron_123".into(),
             name: "Test Job".into(),
+            description: Some("Test description".into()),
             enabled: true,
             schedule: CronScheduleDto::Every {
                 every_ms: 60000,
@@ -136,7 +155,7 @@ mod tests {
 
         let events = bc.events();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].name, "cron.jobCreated");
+        assert_eq!(events[0].name, "cron.job-created");
 
         let parsed: CronJobResponse = serde_json::from_value(events[0].data.clone()).unwrap();
         assert_eq!(parsed.id, "cron_123");
@@ -151,7 +170,7 @@ mod tests {
 
         let events = bc.events();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].name, "cron.jobUpdated");
+        assert_eq!(events[0].name, "cron.job-updated");
 
         let parsed: CronJobResponse = serde_json::from_value(events[0].data.clone()).unwrap();
         assert_eq!(parsed.id, "cron_123");
@@ -164,7 +183,7 @@ mod tests {
 
         let events = bc.events();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].name, "cron.jobRemoved");
+        assert_eq!(events[0].name, "cron.job-removed");
 
         let parsed: CronJobRemovedPayload = serde_json::from_value(events[0].data.clone()).unwrap();
         assert_eq!(parsed.job_id, "cron_456");
@@ -177,7 +196,7 @@ mod tests {
 
         let events = bc.events();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].name, "cron.jobExecuted");
+        assert_eq!(events[0].name, "cron.job-executed");
 
         let parsed: CronJobExecutedEvent = serde_json::from_value(events[0].data.clone()).unwrap();
         assert_eq!(parsed.job_id, "cron_789");
@@ -219,9 +238,9 @@ mod tests {
 
         let events = bc.events();
         assert_eq!(events.len(), 4);
-        assert_eq!(events[0].name, "cron.jobCreated");
-        assert_eq!(events[1].name, "cron.jobUpdated");
-        assert_eq!(events[2].name, "cron.jobRemoved");
-        assert_eq!(events[3].name, "cron.jobExecuted");
+        assert_eq!(events[0].name, "cron.job-created");
+        assert_eq!(events[1].name, "cron.job-updated");
+        assert_eq!(events[2].name, "cron.job-removed");
+        assert_eq!(events[3].name, "cron.job-executed");
     }
 }

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use aionui_ai_agent::task_manager::IWorkerTaskManager;
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
 use aionui_ai_agent::{AgentStreamEvent, IAgentManager};
-use aionui_api_types::{CreateConversationRequest, SendMessageRequest, WebSocketMessage};
+use aionui_api_types::{CreateConversationRequest, SendMessageRequest};
 use aionui_common::{AgentType, ProviderWithModel, generate_id, now_ms};
 use aionui_conversation::ConversationService;
 use aionui_db::models::MessageRow;
@@ -15,6 +15,7 @@ use tokio::sync::broadcast;
 use tokio::time::timeout;
 use tracing::{error, info, warn};
 
+use crate::artifacts::{broadcast_artifact, build_cron_trigger_artifact};
 use crate::busy_guard::CronBusyGuard;
 use crate::error::CronError;
 use crate::prompt::{
@@ -572,6 +573,7 @@ impl JobExecutor {
             msg_id,
             files: vec![],
             inject_skills: skill_names.clone(),
+            hidden: true,
         };
 
         match self
@@ -580,15 +582,20 @@ impl JobExecutor {
             .await
         {
             Ok(()) => {
-                if let Err(e) = self.insert_cron_trigger_message(conversation_id, job).await {
+                if let Err(e) = self
+                    .upsert_cron_trigger_artifact(conversation_id, job)
+                    .await
+                {
                     warn!(
                         job_id = %job.id,
                         conversation_id,
                         error = %e,
-                        "Failed to persist/broadcast cron trigger message"
+                        "Failed to persist/broadcast cron trigger artifact"
                     );
                 }
-                if saved_skill.is_none() {
+                if saved_skill.is_none()
+                    && matches!(job.execution_mode, ExecutionMode::NewConversation)
+                {
                     self.spawn_skill_suggest_flow(
                         Arc::clone(&agent),
                         terminal_rx,
@@ -596,7 +603,7 @@ impl JobExecutor {
                         job.id.clone(),
                         job.name.clone(),
                         agent.workspace().to_owned(),
-                        matches!(job.execution_mode, ExecutionMode::Existing),
+                        false,
                         skill_names.clone(),
                     );
                 }
@@ -640,46 +647,33 @@ impl JobExecutor {
         Ok(row.user_id)
     }
 
-    async fn insert_cron_trigger_message(
+    async fn upsert_cron_trigger_artifact(
         &self,
         conversation_id: &str,
         job: &CronJob,
     ) -> Result<(), CronError> {
         let created_at = now_ms();
-        let msg_id = generate_id();
-        let content = serde_json::json!({
-            "cron_job_id": job.id,
-            "cron_job_name": job.name,
-            "triggered_at": created_at,
-        });
+        let row = build_cron_trigger_artifact(conversation_id, job, created_at);
+        let row = self
+            .conversation_repo
+            .upsert_artifact(&row)
+            .await
+            .map_err(CronError::Database)?;
+        broadcast_artifact(&self.broadcaster, &row)?;
 
-        let row = MessageRow {
-            id: generate_id(),
-            conversation_id: conversation_id.to_owned(),
-            msg_id: Some(msg_id.clone()),
-            r#type: "cron_trigger".into(),
-            content: content.to_string(),
-            position: Some("center".into()),
-            status: Some("finish".into()),
-            hidden: false,
-            created_at,
-        };
+        Ok(())
+    }
 
-        self.conversation_repo
-            .insert_message(&row)
+    pub async fn mark_skill_suggest_artifacts_saved(&self, job_id: &str) -> Result<(), CronError> {
+        let rows = self
+            .conversation_repo
+            .mark_skill_suggest_artifacts_saved(job_id, now_ms())
             .await
             .map_err(CronError::Database)?;
 
-        self.broadcaster.broadcast(WebSocketMessage::new(
-            "message.stream",
-            serde_json::json!({
-                "conversation_id": conversation_id,
-                "msg_id": msg_id,
-                "type": "cron_trigger",
-                "data": content,
-                "hidden": false,
-            }),
-        ));
+        for row in rows {
+            broadcast_artifact(&self.broadcaster, &row)?;
+        }
 
         Ok(())
     }
@@ -813,7 +807,8 @@ impl JobExecutor {
             ExecutionMode::NewConversation => Vec::new(),
         };
 
-        if let Some(saved_skill) = saved_skill
+        if matches!(job.execution_mode, ExecutionMode::NewConversation)
+            && let Some(saved_skill) = saved_skill
             && !skills.iter().any(|name| name == &saved_skill.name)
         {
             skills.push(saved_skill.name.clone());
@@ -940,6 +935,25 @@ fn resolve_model(job: &CronJob) -> ProviderWithModel {
     }
 }
 
+fn infer_acp_backend(job: &CronJob) -> Option<String> {
+    if let Some(config) = &job.agent_config
+        && !config.backend.trim().is_empty()
+    {
+        return Some(config.backend.clone());
+    }
+
+    let agent_type = job.agent_type.trim();
+    if serde_json::from_value::<aionui_common::AcpBackend>(serde_json::Value::String(
+        agent_type.to_owned(),
+    ))
+    .is_ok()
+    {
+        return Some(agent_type.to_owned());
+    }
+
+    None
+}
+
 fn build_task_extra(job: &CronJob, skills: &[String]) -> serde_json::Value {
     let mut extra = serde_json::Map::new();
     extra.insert(
@@ -963,11 +977,11 @@ fn build_task_extra(job: &CronJob, skills: &[String]) -> serde_json::Value {
         );
     }
 
+    if let Some(backend) = infer_acp_backend(job) {
+        extra.insert("backend".to_owned(), serde_json::Value::String(backend));
+    }
+
     if let Some(config) = &job.agent_config {
-        extra.insert(
-            "backend".to_owned(),
-            serde_json::Value::String(config.backend.clone()),
-        );
         if let Some(cli_path) = &config.cli_path {
             extra.insert(
                 "cli_path".to_owned(),
@@ -1008,13 +1022,7 @@ fn build_prompt(job: &CronJob, saved_skill: Option<&SavedSkillContext>) -> Strin
 
     match job.execution_mode {
         ExecutionMode::Existing => {
-            let mut prompt =
-                build_existing_conversation_prompt(&job.name, &schedule_desc, &job.message);
-            if let Some(saved_skill) = saved_skill {
-                prompt.push_str("\n\n---\n\n## Skill Instructions\n\n");
-                prompt.push_str(&saved_skill.raw_content);
-            }
-            prompt
+            build_existing_conversation_prompt(&job.name, &schedule_desc, &job.message)
         }
         ExecutionMode::NewConversation => {
             if saved_skill.is_some() {
@@ -1061,11 +1069,11 @@ fn build_conversation_extra(
         );
     }
 
+    if let Some(backend) = infer_acp_backend(job) {
+        extra.insert("backend".to_owned(), serde_json::Value::String(backend));
+    }
+
     if let Some(config) = &job.agent_config {
-        extra.insert(
-            "backend".to_owned(),
-            serde_json::Value::String(config.backend.clone()),
-        );
         if let Some(cli_path) = &config.cli_path {
             extra.insert(
                 "cli_path".to_owned(),
@@ -1193,12 +1201,14 @@ mod tests {
     use super::*;
     use crate::types::{CreatedBy, CronAgentConfig, CronSchedule};
     use aionui_ai_agent::agent_manager::AgentManagerHandle;
+    use aionui_ai_agent::stream_event::FinishEventData;
     use aionui_api_types::{AgentModeResponse, WebSocketMessage};
     use aionui_common::{
         AgentKillReason, Confirmation, ConversationStatus, PaginatedResult, TimestampMs,
     };
     use aionui_db::{
-        ConversationFilters, ConversationRowUpdate, MessageRowUpdate, MessageSearchRow, SortOrder,
+        ConversationArtifactRow, ConversationFilters, ConversationRowUpdate, MessageRowUpdate,
+        MessageSearchRow, SortOrder,
     };
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
@@ -1327,7 +1337,7 @@ mod tests {
     }
 
     #[test]
-    fn build_prompt_existing_mode_with_skill_appends_inline_instructions() {
+    fn build_prompt_existing_mode_with_skill_does_not_append_saved_skill() {
         let job = sample_job();
         let prompt = build_prompt(
             &job,
@@ -1337,8 +1347,8 @@ mod tests {
             }),
         );
         assert!(prompt.contains("[Scheduled Task Execution]"));
-        assert!(prompt.contains("## Skill Instructions"));
-        assert!(prompt.contains("Do X"));
+        assert!(!prompt.contains("## Skill Instructions"));
+        assert!(!prompt.contains("Do X"));
     }
 
     #[test]
@@ -1473,6 +1483,17 @@ mod tests {
     }
 
     #[test]
+    fn build_task_extra_falls_back_to_agent_type_for_acp_backend() {
+        let job = CronJob {
+            agent_type: "claude".into(),
+            agent_config: None,
+            ..sample_job()
+        };
+        let extra = build_task_extra(&job, &[]);
+        assert_eq!(extra["backend"], "claude");
+    }
+
+    #[test]
     fn build_conversation_extra_without_saved_skill_excludes_cron_auto_inject_only() {
         let job = CronJob {
             execution_mode: ExecutionMode::NewConversation,
@@ -1522,6 +1543,20 @@ mod tests {
         let extra = build_conversation_extra(&job, None);
 
         assert_eq!(extra["workspace"], "/home/user/project");
+    }
+
+    #[test]
+    fn build_conversation_extra_falls_back_to_agent_type_for_acp_backend() {
+        let job = CronJob {
+            execution_mode: ExecutionMode::NewConversation,
+            agent_type: "claude".into(),
+            agent_config: None,
+            ..sample_job()
+        };
+
+        let extra = build_conversation_extra(&job, None);
+
+        assert_eq!(extra["backend"], "claude");
     }
 
     // -- execution_result display ---------------------------------------------
@@ -1711,6 +1746,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_inner_existing_with_saved_skill_keeps_saved_skill_out_of_prompt_and_turn() {
+        let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
+        let executor = make_executor_with_agent(agent.clone() as AgentManagerHandle);
+        let job = sample_job();
+        let saved_skill = SavedSkillContext {
+            name: "cron-cron_test1".into(),
+            raw_content: "---\nname: test\ndescription: desc\n---\nDo X".into(),
+        };
+
+        let result = executor
+            .execute_inner(&job, "conv_1", Some(&saved_skill))
+            .await;
+
+        assert_eq!(
+            result,
+            ExecutionResult::Success {
+                conversation_id: "conv_1".into()
+            }
+        );
+        wait_for_agent_send(&agent, 1).await;
+        let sent_messages = agent.sent_messages().await;
+        assert_eq!(sent_messages.len(), 1);
+        assert!(!sent_messages[0].content.contains("## Skill Instructions"));
+        assert!(!sent_messages[0].content.contains("Do X"));
+        assert!(sent_messages[0].inject_skills.is_empty());
+    }
+
+    #[tokio::test]
+    async fn execute_inner_existing_without_saved_skill_does_not_send_skill_suggest_follow_up() {
+        let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
+        let executor = make_executor_with_agent(agent.clone() as AgentManagerHandle);
+        let job = sample_job();
+
+        let result = executor.execute_inner(&job, "conv_1", None).await;
+
+        assert_eq!(
+            result,
+            ExecutionResult::Success {
+                conversation_id: "conv_1".into()
+            }
+        );
+        wait_for_agent_send(&agent, 1).await;
+
+        let _ = agent
+            .event_tx
+            .send(AgentStreamEvent::Finish(FinishEventData::default()));
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(
+            agent.send_calls(),
+            1,
+            "existing-mode cron should not send a follow-up SKILL_SUGGEST prompt"
+        );
+    }
+
+    #[tokio::test]
     async fn execute_inner_uses_conversation_workspace_when_job_workspace_missing() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
         let task_manager = Arc::new(RecordingTaskManager::new(
@@ -1813,11 +1906,12 @@ mod tests {
             .find(|message| message.position.as_deref() == Some("right"))
             .expect("cron execution should insert a right-side prompt message");
         assert_eq!(right_message.r#type, "text");
+        assert!(right_message.hidden);
         assert!(right_message.content.contains("SKILL_SUGGEST.md"));
     }
 
     #[tokio::test]
-    async fn execute_inner_inserts_cron_trigger_message_and_broadcasts_event() {
+    async fn execute_inner_upserts_cron_trigger_artifact_and_broadcasts_event() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
         let task_manager = Arc::new(RecordingTaskManager::new(
             agent.clone() as AgentManagerHandle
@@ -1848,29 +1942,31 @@ mod tests {
         wait_for_agent_send(&agent, 1).await;
 
         let messages = repo.inserted_messages();
-        let trigger_message = messages
-            .iter()
-            .find(|message| message.r#type == "cron_trigger")
-            .expect("cron execution should insert a cron trigger message");
-        assert_eq!(trigger_message.position.as_deref(), Some("center"));
-        let trigger_content: serde_json::Value =
-            serde_json::from_str(&trigger_message.content).expect("valid trigger payload");
-        assert_eq!(trigger_content["cron_job_id"], "cron_test1");
-        assert_eq!(trigger_content["cron_job_name"], "Test Job");
-        assert!(trigger_content["triggered_at"].as_i64().is_some());
+        assert!(
+            messages
+                .iter()
+                .all(|message| message.r#type != "cron_trigger"),
+            "cron execution should no longer persist cron trigger as a message"
+        );
 
         let events = broadcaster.events();
         let trigger_event = events
             .iter()
             .find(|event| {
-                event["name"] == "message.stream" && event["data"]["type"] == "cron_trigger"
+                event["name"] == "conversation.artifact" && event["data"]["kind"] == "cron_trigger"
             })
-            .expect("cron execution should broadcast cron trigger event");
+            .expect("cron execution should broadcast cron trigger artifact");
         assert_eq!(trigger_event["data"]["conversation_id"], "conv_1");
-        assert_eq!(trigger_event["data"]["data"]["cron_job_id"], "cron_test1");
-        assert_eq!(trigger_event["data"]["data"]["cron_job_name"], "Test Job");
+        assert_eq!(
+            trigger_event["data"]["payload"]["cron_job_id"],
+            "cron_test1"
+        );
+        assert_eq!(
+            trigger_event["data"]["payload"]["cron_job_name"],
+            "Test Job"
+        );
         assert!(
-            trigger_event["data"]["data"]["triggered_at"]
+            trigger_event["data"]["payload"]["triggered_at"]
                 .as_i64()
                 .is_some()
         );
@@ -2442,6 +2538,7 @@ mod tests {
         row: aionui_db::models::ConversationRow,
         updates: Mutex<Vec<ConversationRowUpdate>>,
         inserted_messages: Mutex<Vec<aionui_db::models::MessageRow>>,
+        artifacts: Mutex<Vec<ConversationArtifactRow>>,
     }
 
     impl MissingWorkspaceConversationRepo {
@@ -2464,6 +2561,7 @@ mod tests {
                 },
                 updates: Mutex::new(Vec::new()),
                 inserted_messages: Mutex::new(Vec::new()),
+                artifacts: Mutex::new(Vec::new()),
             }
         }
 
@@ -2645,6 +2743,19 @@ mod tests {
                 total: 0,
                 has_more: false,
             })
+        }
+
+        async fn upsert_artifact(
+            &self,
+            artifact: &ConversationArtifactRow,
+        ) -> Result<ConversationArtifactRow, aionui_db::DbError> {
+            let mut artifacts = self.artifacts.lock().unwrap();
+            if let Some(existing) = artifacts.iter_mut().find(|row| row.id == artifact.id) {
+                *existing = artifact.clone();
+                return Ok(existing.clone());
+            }
+            artifacts.push(artifact.clone());
+            Ok(artifact.clone())
         }
     }
 

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -1,19 +1,36 @@
+use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use aionui_ai_agent::task_manager::IWorkerTaskManager;
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
-use aionui_api_types::CreateConversationRequest;
-use aionui_common::{AgentType, ProviderWithModel, generate_id};
+use aionui_ai_agent::{AgentStreamEvent, IAgentManager};
+use aionui_api_types::{CreateConversationRequest, SendMessageRequest, WebSocketMessage};
+use aionui_common::{AgentType, ProviderWithModel, generate_id, now_ms};
 use aionui_conversation::ConversationService;
-use aionui_db::IConversationRepository;
+use aionui_db::models::MessageRow;
+use aionui_db::{ConversationRowUpdate, IConversationRepository};
+use aionui_realtime::EventBroadcaster;
+use tokio::sync::broadcast;
+use tokio::time::timeout;
 use tracing::{error, info, warn};
 
 use crate::busy_guard::CronBusyGuard;
 use crate::error::CronError;
+use crate::prompt::{
+    build_existing_conversation_prompt, build_new_conversation_prompt_with_skill_suggest,
+    build_new_conversation_with_skill_prompt, build_skill_suggest_prompt,
+};
+use crate::skill_file::{
+    cron_skill_name, read_skill_content, write_raw_skill_file, write_skill_file,
+};
+use crate::skill_suggest::SkillSuggestDetector;
 use crate::types::{CronJob, ExecutionMode};
 
 pub const RETRY_INTERVAL_MS: u64 = 30_000;
 pub const MAX_RETRIES_DEFAULT: i64 = 3;
+const SYSTEM_DEFAULT_USER_ID: &str = "system_default_user";
+const SKILL_SUGGEST_TERMINAL_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExecutionResult {
@@ -23,11 +40,20 @@ pub enum ExecutionResult {
     Error { message: String },
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedExecution {
+    pub conversation_id: String,
+    saved_skill: Option<SavedSkillContext>,
+}
+
 pub struct JobExecutor {
     task_manager: Arc<dyn IWorkerTaskManager>,
     conversation_repo: Arc<dyn IConversationRepository>,
     conversation_service: Arc<ConversationService>,
     busy_guard: Arc<CronBusyGuard>,
+    data_dir: PathBuf,
+    broadcaster: Arc<dyn EventBroadcaster>,
+    skill_suggest_detector: SkillSuggestDetector,
 }
 
 impl JobExecutor {
@@ -36,12 +62,22 @@ impl JobExecutor {
         conversation_repo: Arc<dyn IConversationRepository>,
         conversation_service: Arc<ConversationService>,
         busy_guard: Arc<CronBusyGuard>,
+        data_dir: PathBuf,
+        broadcaster: Arc<dyn EventBroadcaster>,
     ) -> Self {
+        let skill_suggest_detector = SkillSuggestDetector::new(
+            Arc::clone(&broadcaster),
+            conversation_repo.clone(),
+            data_dir.clone(),
+        );
         Self {
             task_manager,
             conversation_repo,
             conversation_service,
             busy_guard,
+            data_dir,
+            broadcaster,
+            skill_suggest_detector,
         }
     }
 
@@ -52,20 +88,33 @@ impl JobExecutor {
             return self.handle_busy(job);
         }
 
-        let target_conversation_id = match self.resolve_conversation(job).await {
-            Ok(id) => id,
+        let saved_skill = match self.prepare_saved_skill(job).await {
+            Ok(skill) => skill,
             Err(e) => {
-                error!(job_id = %job.id, error = %e, "Failed to resolve conversation");
+                error!(job_id = %job.id, error = %e, "Failed to prepare saved cron skill");
                 return ExecutionResult::Error {
                     message: e.to_string(),
                 };
             }
         };
 
+        let target_conversation_id =
+            match self.resolve_conversation(job, saved_skill.as_ref()).await {
+                Ok(id) => id,
+                Err(e) => {
+                    error!(job_id = %job.id, error = %e, "Failed to resolve conversation");
+                    return ExecutionResult::Error {
+                        message: e.to_string(),
+                    };
+                }
+            };
+
         self.busy_guard
             .set_processing(&target_conversation_id, true);
 
-        let result = self.execute_inner(job, &target_conversation_id).await;
+        let result = self
+            .execute_inner(job, &target_conversation_id, saved_skill.as_ref())
+            .await;
 
         self.busy_guard
             .set_processing(&target_conversation_id, false);
@@ -73,30 +122,223 @@ impl JobExecutor {
         result
     }
 
-    pub async fn execute_run_now(&self, job: &CronJob) -> ExecutionResult {
-        let target_conversation_id = match self.resolve_conversation(job).await {
-            Ok(id) => id,
-            Err(e) => {
-                error!(job_id = %job.id, error = %e, "Failed to resolve conversation for run-now");
-                return ExecutionResult::Error {
-                    message: e.to_string(),
-                };
+    pub(crate) async fn prepare_run_now(
+        &self,
+        job: &CronJob,
+    ) -> Result<PreparedExecution, CronError> {
+        let saved_skill = match self.prepare_saved_skill(job).await {
+            Ok(skill) => skill,
+            Err(err) => {
+                error!(
+                    job_id = %job.id,
+                    error = %err,
+                    "Failed to prepare saved cron skill for run-now"
+                );
+                return Err(err);
             }
         };
 
-        self.busy_guard
-            .set_processing(&target_conversation_id, true);
+        let conversation_id = self.resolve_conversation(job, saved_skill.as_ref()).await?;
 
-        let result = self.execute_inner(job, &target_conversation_id).await;
+        Ok(PreparedExecution {
+            conversation_id,
+            saved_skill,
+        })
+    }
+
+    pub(crate) async fn execute_prepared(
+        &self,
+        job: &CronJob,
+        prepared: PreparedExecution,
+    ) -> ExecutionResult {
+        self.busy_guard
+            .set_processing(&prepared.conversation_id, true);
+
+        let result = self
+            .execute_inner(
+                job,
+                &prepared.conversation_id,
+                prepared.saved_skill.as_ref(),
+            )
+            .await;
 
         self.busy_guard
-            .set_processing(&target_conversation_id, false);
+            .set_processing(&prepared.conversation_id, false);
 
         result
     }
 
     pub fn busy_guard(&self) -> &CronBusyGuard {
         &self.busy_guard
+    }
+
+    pub async fn conversation_exists(&self, conversation_id: &str) -> Result<bool, CronError> {
+        let row = self
+            .conversation_repo
+            .get(conversation_id)
+            .await
+            .map_err(CronError::Database)?;
+        Ok(row.is_some())
+    }
+
+    pub async fn get_conversation_row(
+        &self,
+        conversation_id: &str,
+    ) -> Result<Option<aionui_db::models::ConversationRow>, CronError> {
+        self.conversation_repo
+            .get(conversation_id)
+            .await
+            .map_err(CronError::Database)
+    }
+
+    pub async fn insert_tips_message(
+        &self,
+        conversation_id: &str,
+        content: &str,
+        tip_type: &str,
+    ) -> Result<(), CronError> {
+        let row = MessageRow {
+            id: generate_id(),
+            conversation_id: conversation_id.to_owned(),
+            msg_id: None,
+            r#type: "tips".into(),
+            content: serde_json::json!({
+                "content": content,
+                "type": tip_type,
+            })
+            .to_string(),
+            position: Some("center".into()),
+            status: Some("finish".into()),
+            hidden: false,
+            created_at: aionui_common::now_ms(),
+        };
+
+        self.conversation_repo
+            .insert_message(&row)
+            .await
+            .map_err(CronError::Database)
+    }
+
+    pub async fn bind_cron_job_to_conversation(
+        &self,
+        conversation_id: &str,
+        cron_job_id: &str,
+    ) -> Result<(), CronError> {
+        let Some(row) = self.get_conversation_row(conversation_id).await? else {
+            return Ok(());
+        };
+
+        let mut extra: serde_json::Value =
+            serde_json::from_str(&row.extra).unwrap_or_else(|_| serde_json::json!({}));
+        let Some(obj) = extra.as_object_mut() else {
+            extra = serde_json::json!({});
+            extra.as_object_mut().expect("json object").insert(
+                "cron_job_id".to_owned(),
+                serde_json::Value::String(cron_job_id.to_owned()),
+            );
+            extra.as_object_mut().expect("json object").insert(
+                "cronJobId".to_owned(),
+                serde_json::Value::String(cron_job_id.to_owned()),
+            );
+            let update = ConversationRowUpdate {
+                extra: Some(extra.to_string()),
+                updated_at: Some(now_ms()),
+                ..Default::default()
+            };
+            return self
+                .conversation_repo
+                .update(conversation_id, &update)
+                .await
+                .map_err(CronError::Database);
+        };
+
+        let current = obj
+            .get("cron_job_id")
+            .and_then(|value| value.as_str())
+            .or_else(|| obj.get("cronJobId").and_then(|value| value.as_str()));
+
+        if current == Some(cron_job_id) {
+            return Ok(());
+        }
+
+        obj.insert(
+            "cron_job_id".to_owned(),
+            serde_json::Value::String(cron_job_id.to_owned()),
+        );
+        obj.insert(
+            "cronJobId".to_owned(),
+            serde_json::Value::String(cron_job_id.to_owned()),
+        );
+
+        let update = ConversationRowUpdate {
+            extra: Some(extra.to_string()),
+            updated_at: Some(now_ms()),
+            ..Default::default()
+        };
+        self.conversation_repo
+            .update(conversation_id, &update)
+            .await
+            .map_err(CronError::Database)
+    }
+
+    pub async fn persist_workspace_if_missing(
+        &self,
+        conversation_id: &str,
+        resolved_workspace: &str,
+    ) -> Result<(), CronError> {
+        let resolved_workspace = resolved_workspace.trim();
+        if resolved_workspace.is_empty() {
+            return Ok(());
+        }
+
+        let Some(row) = self.get_conversation_row(conversation_id).await? else {
+            return Ok(());
+        };
+
+        let mut extra: serde_json::Value =
+            serde_json::from_str(&row.extra).unwrap_or_else(|_| serde_json::json!({}));
+        let Some(obj) = extra.as_object_mut() else {
+            extra = serde_json::json!({});
+            extra.as_object_mut().expect("json object").insert(
+                "workspace".to_owned(),
+                serde_json::Value::String(resolved_workspace.to_owned()),
+            );
+            let update = ConversationRowUpdate {
+                extra: Some(extra.to_string()),
+                updated_at: Some(now_ms()),
+                ..Default::default()
+            };
+            return self
+                .conversation_repo
+                .update(conversation_id, &update)
+                .await
+                .map_err(CronError::Database);
+        };
+
+        let current_workspace = obj
+            .get("workspace")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .unwrap_or_default();
+
+        if !current_workspace.is_empty() {
+            return Ok(());
+        }
+
+        obj.insert(
+            "workspace".to_owned(),
+            serde_json::Value::String(resolved_workspace.to_owned()),
+        );
+
+        let update = ConversationRowUpdate {
+            extra: Some(extra.to_string()),
+            updated_at: Some(now_ms()),
+            ..Default::default()
+        };
+        self.conversation_repo
+            .update(conversation_id, &update)
+            .await
+            .map_err(CronError::Database)
     }
 }
 
@@ -124,24 +366,23 @@ impl JobExecutor {
         ExecutionResult::Retrying { attempt }
     }
 
-    async fn resolve_conversation(&self, job: &CronJob) -> Result<String, CronError> {
+    async fn resolve_conversation(
+        &self,
+        job: &CronJob,
+        saved_skill: Option<&SavedSkillContext>,
+    ) -> Result<String, CronError> {
         match job.execution_mode {
             ExecutionMode::Existing => {
                 self.verify_conversation_exists(&job.conversation_id)
                     .await?;
                 Ok(job.conversation_id.clone())
             }
-            ExecutionMode::NewConversation => self.create_new_conversation(job).await,
+            ExecutionMode::NewConversation => self.create_new_conversation(job, saved_skill).await,
         }
     }
 
     async fn verify_conversation_exists(&self, conversation_id: &str) -> Result<(), CronError> {
-        let exists = self
-            .conversation_repo
-            .get(conversation_id)
-            .await
-            .map_err(CronError::Database)?;
-        if exists.is_none() {
+        if !self.conversation_exists(conversation_id).await? {
             return Err(CronError::Scheduler(format!(
                 "conversation {conversation_id} not found"
             )));
@@ -149,13 +390,16 @@ impl JobExecutor {
         Ok(())
     }
 
-    async fn create_new_conversation(&self, job: &CronJob) -> Result<String, CronError> {
+    async fn create_new_conversation(
+        &self,
+        job: &CronJob,
+        saved_skill: Option<&SavedSkillContext>,
+    ) -> Result<String, CronError> {
         let agent_type = parse_agent_type(&job.agent_type);
         let model = resolve_model(job);
+        let user_id = self.resolve_conversation_owner_user_id(job).await?;
 
-        let extra = serde_json::json!({
-            "cronJobId": job.id,
-        });
+        let extra = build_conversation_extra(job, saved_skill);
 
         let req = CreateConversationRequest {
             r#type: agent_type,
@@ -168,9 +412,29 @@ impl JobExecutor {
 
         let response = self
             .conversation_service
-            .create("cron", req)
+            .create(&user_id, req)
             .await
             .map_err(|e| CronError::Scheduler(format!("create conversation: {e}")))?;
+
+        let response_workspace = response
+            .extra
+            .get("workspace")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .unwrap_or_default();
+
+        if response_workspace.is_empty() {
+            let fallback_workspace =
+                default_temp_workspace_path(&self.data_dir, &agent_type, job, &response.id);
+            std::fs::create_dir_all(&fallback_workspace).map_err(|err| {
+                CronError::Scheduler(format!(
+                    "create fallback cron workspace {}: {err}",
+                    fallback_workspace.display()
+                ))
+            })?;
+            self.persist_workspace_if_missing(&response.id, &fallback_workspace.to_string_lossy())
+                .await?;
+        }
 
         info!(
             job_id = %job.id,
@@ -181,16 +445,54 @@ impl JobExecutor {
         Ok(response.id)
     }
 
-    async fn execute_inner(&self, job: &CronJob, conversation_id: &str) -> ExecutionResult {
+    async fn resolve_conversation_owner_user_id(&self, job: &CronJob) -> Result<String, CronError> {
+        if !job.conversation_id.trim().is_empty()
+            && let Some(row) = self.get_conversation_row(&job.conversation_id).await?
+            && !row.user_id.trim().is_empty()
+        {
+            return Ok(row.user_id);
+        }
+
+        Ok(SYSTEM_DEFAULT_USER_ID.to_owned())
+    }
+
+    async fn execute_inner(
+        &self,
+        job: &CronJob,
+        conversation_id: &str,
+        saved_skill: Option<&SavedSkillContext>,
+    ) -> ExecutionResult {
         let agent_type = parse_agent_type(&job.agent_type);
         let model = resolve_model(job);
-        let workspace = job
-            .agent_config
-            .as_ref()
-            .and_then(|c| c.workspace.clone())
-            .unwrap_or_default();
+        let workspace = match self.resolve_execution_workspace(job, conversation_id).await {
+            Ok(workspace) => workspace,
+            Err(e) => {
+                error!(
+                    job_id = %job.id,
+                    conversation_id,
+                    error = %e,
+                    "Failed to resolve cron execution workspace"
+                );
+                return ExecutionResult::Error {
+                    message: e.to_string(),
+                };
+            }
+        };
 
-        let build_extra = build_task_extra(job);
+        let skill_names = match self
+            .resolve_task_skill_names(job, conversation_id, saved_skill)
+            .await
+        {
+            Ok(names) => names,
+            Err(e) => {
+                error!(job_id = %job.id, error = %e, "Failed to resolve task skills");
+                return ExecutionResult::Error {
+                    message: e.to_string(),
+                };
+            }
+        };
+        let build_extra = build_task_extra(job, &skill_names);
+        let requested_workspace_missing = workspace.trim().is_empty();
 
         let options = BuildTaskOptions {
             agent_type,
@@ -217,18 +519,87 @@ impl JobExecutor {
             }
         };
 
-        let prompt = build_prompt(job);
-        let msg_id = generate_id();
+        if requested_workspace_missing
+            && let Err(e) = self
+                .persist_workspace_if_missing(conversation_id, agent.workspace())
+                .await
+        {
+            error!(
+                job_id = %job.id,
+                conversation_id,
+                error = %e,
+                "Failed to persist resolved cron workspace back to conversation"
+            );
+            return ExecutionResult::Error {
+                message: e.to_string(),
+            };
+        }
 
-        let send_data = SendMessageData {
+        if let Err(e) = self.ensure_agent_session_mode(job, &agent).await {
+            error!(
+                job_id = %job.id,
+                conversation_id,
+                error = %e,
+                "Failed to apply cron session mode"
+            );
+            return ExecutionResult::Error {
+                message: e.to_string(),
+            };
+        }
+
+        let prompt = build_prompt(job, saved_skill);
+        let msg_id = generate_id();
+        let terminal_rx = agent.subscribe();
+        let user_id = match self
+            .resolve_target_conversation_user_id(conversation_id)
+            .await
+        {
+            Ok(user_id) => user_id,
+            Err(e) => {
+                error!(
+                    job_id = %job.id,
+                    conversation_id,
+                    error = %e,
+                    "Failed to resolve cron conversation owner before dispatch"
+                );
+                return ExecutionResult::Error {
+                    message: e.to_string(),
+                };
+            }
+        };
+        let send_req = SendMessageRequest {
             content: prompt,
             msg_id,
             files: vec![],
-            inject_skills: vec![],
+            inject_skills: skill_names.clone(),
         };
 
-        match agent.send_message(send_data).await {
+        match self
+            .conversation_service
+            .send_message(&user_id, conversation_id, send_req, &self.task_manager)
+            .await
+        {
             Ok(()) => {
+                if let Err(e) = self.insert_cron_trigger_message(conversation_id, job).await {
+                    warn!(
+                        job_id = %job.id,
+                        conversation_id,
+                        error = %e,
+                        "Failed to persist/broadcast cron trigger message"
+                    );
+                }
+                if saved_skill.is_none() {
+                    self.spawn_skill_suggest_flow(
+                        Arc::clone(&agent),
+                        terminal_rx,
+                        conversation_id.to_owned(),
+                        job.id.clone(),
+                        job.name.clone(),
+                        agent.workspace().to_owned(),
+                        matches!(job.execution_mode, ExecutionMode::Existing),
+                        skill_names.clone(),
+                    );
+                }
                 info!(
                     job_id = %job.id,
                     conversation_id,
@@ -251,9 +622,301 @@ impl JobExecutor {
             }
         }
     }
+
+    async fn resolve_target_conversation_user_id(
+        &self,
+        conversation_id: &str,
+    ) -> Result<String, CronError> {
+        let Some(row) = self.get_conversation_row(conversation_id).await? else {
+            return Err(CronError::Scheduler(format!(
+                "conversation {conversation_id} not found"
+            )));
+        };
+
+        if row.user_id.trim().is_empty() {
+            return Ok(SYSTEM_DEFAULT_USER_ID.to_owned());
+        }
+
+        Ok(row.user_id)
+    }
+
+    async fn insert_cron_trigger_message(
+        &self,
+        conversation_id: &str,
+        job: &CronJob,
+    ) -> Result<(), CronError> {
+        let created_at = now_ms();
+        let msg_id = generate_id();
+        let content = serde_json::json!({
+            "cron_job_id": job.id,
+            "cron_job_name": job.name,
+            "triggered_at": created_at,
+        });
+
+        let row = MessageRow {
+            id: generate_id(),
+            conversation_id: conversation_id.to_owned(),
+            msg_id: Some(msg_id.clone()),
+            r#type: "cron_trigger".into(),
+            content: content.to_string(),
+            position: Some("center".into()),
+            status: Some("finish".into()),
+            hidden: false,
+            created_at,
+        };
+
+        self.conversation_repo
+            .insert_message(&row)
+            .await
+            .map_err(CronError::Database)?;
+
+        self.broadcaster.broadcast(WebSocketMessage::new(
+            "message.stream",
+            serde_json::json!({
+                "conversation_id": conversation_id,
+                "msg_id": msg_id,
+                "type": "cron_trigger",
+                "data": content,
+                "hidden": false,
+            }),
+        ));
+
+        Ok(())
+    }
+
+    async fn resolve_execution_workspace(
+        &self,
+        job: &CronJob,
+        conversation_id: &str,
+    ) -> Result<String, CronError> {
+        if let Some(workspace) = job
+            .agent_config
+            .as_ref()
+            .and_then(|config| config.workspace.as_deref())
+            .map(str::trim)
+            .filter(|workspace| !workspace.is_empty())
+        {
+            return Ok(workspace.to_owned());
+        }
+
+        let Some(row) = self.get_conversation_row(conversation_id).await? else {
+            return Ok(String::new());
+        };
+
+        let extra = serde_json::from_str::<serde_json::Value>(&row.extra).unwrap_or_default();
+        Ok(extra
+            .get("workspace")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|workspace| !workspace.is_empty())
+            .unwrap_or_default()
+            .to_owned())
+    }
+
+    fn spawn_skill_suggest_flow(
+        &self,
+        agent: Arc<dyn aionui_ai_agent::IAgentManager>,
+        main_rx: broadcast::Receiver<AgentStreamEvent>,
+        conversation_id: String,
+        job_id: String,
+        job_name: String,
+        workspace: String,
+        needs_follow_up: bool,
+        skill_names: Vec<String>,
+    ) {
+        let detector = self.skill_suggest_detector.clone();
+
+        tokio::spawn(async move {
+            if !wait_for_terminal_event(main_rx).await {
+                warn!(
+                    conversation_id,
+                    job_id,
+                    "Timed out waiting for cron turn completion before skill suggestion check"
+                );
+                return;
+            }
+
+            if needs_follow_up {
+                let follow_up_rx = agent.subscribe();
+                let follow_up = SendMessageData {
+                    content: build_skill_suggest_prompt(&job_name),
+                    msg_id: generate_id(),
+                    files: vec![],
+                    inject_skills: skill_names,
+                };
+
+                if let Err(err) = agent.send_message(follow_up).await {
+                    warn!(
+                        conversation_id,
+                        job_id,
+                        error = %err,
+                        "Failed to send cron skill suggestion follow-up prompt"
+                    );
+                    return;
+                }
+
+                if !wait_for_terminal_event(follow_up_rx).await {
+                    warn!(
+                        conversation_id,
+                        job_id, "Timed out waiting for cron skill suggestion follow-up completion"
+                    );
+                    return;
+                }
+            }
+
+            detector.schedule_check(conversation_id, job_id, workspace);
+        });
+    }
+
+    async fn prepare_saved_skill(
+        &self,
+        job: &CronJob,
+    ) -> Result<Option<SavedSkillContext>, CronError> {
+        if let Some(raw_content) = read_skill_content(&self.data_dir, &job.id).await?
+            && !raw_content.trim().is_empty()
+        {
+            return Ok(Some(SavedSkillContext {
+                name: cron_skill_name(&job.id)?,
+                raw_content,
+            }));
+        }
+
+        let legacy_content = job
+            .skill_content
+            .as_deref()
+            .map(str::trim)
+            .filter(|content| !content.is_empty());
+
+        let Some(legacy_content) = legacy_content else {
+            return Ok(None);
+        };
+
+        persist_legacy_skill_file(&self.data_dir, job, legacy_content).await?;
+        let raw_content = read_skill_content(&self.data_dir, &job.id)
+            .await?
+            .unwrap_or_else(|| legacy_content.to_owned());
+
+        Ok(Some(SavedSkillContext {
+            name: cron_skill_name(&job.id)?,
+            raw_content,
+        }))
+    }
+
+    async fn resolve_task_skill_names(
+        &self,
+        job: &CronJob,
+        conversation_id: &str,
+        saved_skill: Option<&SavedSkillContext>,
+    ) -> Result<Vec<String>, CronError> {
+        let mut skills = match job.execution_mode {
+            ExecutionMode::Existing => self.load_conversation_skill_names(conversation_id).await?,
+            ExecutionMode::NewConversation => Vec::new(),
+        };
+
+        if let Some(saved_skill) = saved_skill
+            && !skills.iter().any(|name| name == &saved_skill.name)
+        {
+            skills.push(saved_skill.name.clone());
+        }
+
+        Ok(skills)
+    }
+
+    async fn ensure_agent_session_mode(
+        &self,
+        job: &CronJob,
+        agent: &Arc<dyn IAgentManager>,
+    ) -> Result<(), CronError> {
+        let Some(desired_mode) = job
+            .agent_config
+            .as_ref()
+            .and_then(|config| config.mode.as_deref())
+            .map(str::trim)
+            .filter(|mode| !mode.is_empty())
+        else {
+            return Ok(());
+        };
+
+        let current_mode = agent
+            .get_mode()
+            .await
+            .map_err(|e| CronError::Scheduler(format!("get session mode: {e}")))?;
+
+        if current_mode.mode == desired_mode {
+            return Ok(());
+        }
+
+        agent.set_mode(desired_mode).await.map_err(|e| {
+            CronError::Scheduler(format!("set session mode to {desired_mode}: {e}"))
+        })?;
+
+        info!(
+            conversation_id = %agent.conversation_id(),
+            from_mode = %current_mode.mode,
+            to_mode = desired_mode,
+            initialized = current_mode.initialized,
+            "Applied cron session mode before execution"
+        );
+
+        Ok(())
+    }
+
+    async fn load_conversation_skill_names(
+        &self,
+        conversation_id: &str,
+    ) -> Result<Vec<String>, CronError> {
+        let Some(row) = self
+            .conversation_repo
+            .get(conversation_id)
+            .await
+            .map_err(CronError::Database)?
+        else {
+            return Ok(Vec::new());
+        };
+
+        let Ok(extra) = serde_json::from_str::<serde_json::Value>(&row.extra) else {
+            return Ok(Vec::new());
+        };
+
+        Ok(extra
+            .get("skills")
+            .and_then(|value| value.as_array())
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|item| item.as_str().map(ToOwned::to_owned))
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
+}
+
+async fn wait_for_terminal_event(mut rx: broadcast::Receiver<AgentStreamEvent>) -> bool {
+    let fut = async move {
+        loop {
+            match rx.recv().await {
+                Ok(AgentStreamEvent::Finish(_)) | Ok(AgentStreamEvent::Error(_)) => return true,
+                Ok(_) => continue,
+                Err(broadcast::error::RecvError::Closed) => return true,
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+            }
+        }
+    };
+
+    timeout(SKILL_SUGGEST_TERMINAL_TIMEOUT, fut)
+        .await
+        .unwrap_or(false)
 }
 
 fn parse_agent_type(agent_type_str: &str) -> AgentType {
+    if serde_json::from_value::<aionui_common::AcpBackend>(serde_json::Value::String(
+        agent_type_str.to_owned(),
+    ))
+    .is_ok()
+    {
+        return AgentType::Acp;
+    }
+
     serde_json::from_value(serde_json::Value::String(agent_type_str.to_owned()))
         .unwrap_or(AgentType::Acp)
 }
@@ -277,12 +940,28 @@ fn resolve_model(job: &CronJob) -> ProviderWithModel {
     }
 }
 
-fn build_task_extra(job: &CronJob) -> serde_json::Value {
+fn build_task_extra(job: &CronJob, skills: &[String]) -> serde_json::Value {
     let mut extra = serde_json::Map::new();
+    extra.insert(
+        "cron_job_id".to_owned(),
+        serde_json::Value::String(job.id.clone()),
+    );
     extra.insert(
         "cronJobId".to_owned(),
         serde_json::Value::String(job.id.clone()),
     );
+    if !skills.is_empty() {
+        extra.insert(
+            "skills".to_owned(),
+            serde_json::Value::Array(
+                skills
+                    .iter()
+                    .cloned()
+                    .map(serde_json::Value::String)
+                    .collect(),
+            ),
+        );
+    }
 
     if let Some(config) = &job.agent_config {
         extra.insert(
@@ -291,25 +970,31 @@ fn build_task_extra(job: &CronJob) -> serde_json::Value {
         );
         if let Some(cli_path) = &config.cli_path {
             extra.insert(
-                "cliPath".to_owned(),
+                "cli_path".to_owned(),
                 serde_json::Value::String(cli_path.clone()),
             );
         }
         if !config.name.is_empty() {
             extra.insert(
-                "agentName".to_owned(),
+                "agent_name".to_owned(),
                 serde_json::Value::String(config.name.clone()),
             );
         }
         if let Some(custom_agent_id) = &config.custom_agent_id {
             extra.insert(
-                "customAgentId".to_owned(),
+                "custom_agent_id".to_owned(),
                 serde_json::Value::String(custom_agent_id.clone()),
             );
+            if config.is_preset.unwrap_or(false) {
+                extra.insert(
+                    "preset_assistant_id".to_owned(),
+                    serde_json::Value::String(custom_agent_id.clone()),
+                );
+            }
         }
         if let Some(mode) = &config.mode {
             extra.insert(
-                "sessionMode".to_owned(),
+                "session_mode".to_owned(),
                 serde_json::Value::String(mode.clone()),
             );
         }
@@ -318,15 +1003,188 @@ fn build_task_extra(job: &CronJob) -> serde_json::Value {
     serde_json::Value::Object(extra)
 }
 
-fn build_prompt(job: &CronJob) -> String {
-    match (&job.execution_mode, &job.skill_content) {
-        (ExecutionMode::NewConversation, Some(skill)) if !skill.is_empty() => {
-            format!(
-                "{}\n\n---\n\n## Skill Instructions\n\n{}",
-                job.message, skill
-            )
+fn build_prompt(job: &CronJob, saved_skill: Option<&SavedSkillContext>) -> String {
+    let schedule_desc = schedule_description_text(&job.schedule);
+
+    match job.execution_mode {
+        ExecutionMode::Existing => {
+            let mut prompt =
+                build_existing_conversation_prompt(&job.name, &schedule_desc, &job.message);
+            if let Some(saved_skill) = saved_skill {
+                prompt.push_str("\n\n---\n\n## Skill Instructions\n\n");
+                prompt.push_str(&saved_skill.raw_content);
+            }
+            prompt
         }
-        _ => job.message.clone(),
+        ExecutionMode::NewConversation => {
+            if saved_skill.is_some() {
+                build_new_conversation_with_skill_prompt(&job.name, &job.message)
+            } else {
+                build_new_conversation_prompt_with_skill_suggest(
+                    &job.name,
+                    &schedule_desc,
+                    &job.message,
+                )
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SavedSkillContext {
+    name: String,
+    raw_content: String,
+}
+
+fn build_conversation_extra(
+    job: &CronJob,
+    saved_skill: Option<&SavedSkillContext>,
+) -> serde_json::Value {
+    let mut extra = serde_json::Map::new();
+    extra.insert(
+        "cron_job_id".to_owned(),
+        serde_json::Value::String(job.id.clone()),
+    );
+    extra.insert(
+        "cronJobId".to_owned(),
+        serde_json::Value::String(job.id.clone()),
+    );
+    extra.insert(
+        "exclude_auto_inject_skills".to_owned(),
+        serde_json::Value::Array(vec![serde_json::Value::String("cron".to_owned())]),
+    );
+
+    if let Some(saved_skill) = saved_skill {
+        extra.insert(
+            "preset_enabled_skills".to_owned(),
+            serde_json::Value::Array(vec![serde_json::Value::String(saved_skill.name.clone())]),
+        );
+    }
+
+    if let Some(config) = &job.agent_config {
+        extra.insert(
+            "backend".to_owned(),
+            serde_json::Value::String(config.backend.clone()),
+        );
+        if let Some(cli_path) = &config.cli_path {
+            extra.insert(
+                "cli_path".to_owned(),
+                serde_json::Value::String(cli_path.clone()),
+            );
+        }
+        if !config.name.is_empty() {
+            extra.insert(
+                "agent_name".to_owned(),
+                serde_json::Value::String(config.name.clone()),
+            );
+        }
+        if let Some(custom_agent_id) = &config.custom_agent_id {
+            extra.insert(
+                "custom_agent_id".to_owned(),
+                serde_json::Value::String(custom_agent_id.clone()),
+            );
+            if config.is_preset.unwrap_or(false) {
+                extra.insert(
+                    "preset_assistant_id".to_owned(),
+                    serde_json::Value::String(custom_agent_id.clone()),
+                );
+            }
+        }
+        if let Some(mode) = &config.mode {
+            extra.insert(
+                "session_mode".to_owned(),
+                serde_json::Value::String(mode.clone()),
+            );
+        }
+        if let Some(workspace) = &config.workspace
+            && !workspace.trim().is_empty()
+        {
+            extra.insert(
+                "workspace".to_owned(),
+                serde_json::Value::String(workspace.clone()),
+            );
+        }
+    }
+
+    serde_json::Value::Object(extra)
+}
+
+fn schedule_description_text(schedule: &crate::types::CronSchedule) -> String {
+    match schedule {
+        crate::types::CronSchedule::At { at_ms, description } => {
+            description.clone().unwrap_or_else(|| format!("At {at_ms}"))
+        }
+        crate::types::CronSchedule::Every {
+            every_ms,
+            description,
+        } => description
+            .clone()
+            .unwrap_or_else(|| format!("Every {every_ms} ms")),
+        crate::types::CronSchedule::Cron {
+            expr,
+            tz,
+            description,
+        } => description.clone().unwrap_or_else(|| match tz {
+            Some(tz) => format!("{expr} ({tz})"),
+            None => expr.clone(),
+        }),
+    }
+}
+
+fn default_temp_workspace_path(
+    data_dir: &std::path::Path,
+    agent_type: &AgentType,
+    job: &CronJob,
+    conversation_id: &str,
+) -> std::path::PathBuf {
+    let label = if *agent_type == AgentType::Acp {
+        job.agent_config
+            .as_ref()
+            .map(|config| config.backend.trim())
+            .filter(|backend| !backend.is_empty())
+            .unwrap_or("acp")
+            .to_owned()
+    } else {
+        agent_type.serde_name().to_owned()
+    };
+
+    data_dir
+        .join("conversations")
+        .join(format!("{label}-temp-{conversation_id}"))
+}
+
+fn schedule_description_ref(schedule: &crate::types::CronSchedule) -> Option<&str> {
+    match schedule {
+        crate::types::CronSchedule::At { description, .. }
+        | crate::types::CronSchedule::Every { description, .. }
+        | crate::types::CronSchedule::Cron { description, .. } => description.as_deref(),
+    }
+}
+
+async fn persist_legacy_skill_file(
+    data_dir: &PathBuf,
+    job: &CronJob,
+    raw_content: &str,
+) -> Result<(), CronError> {
+    match write_raw_skill_file(data_dir, &job.id, raw_content).await {
+        Ok(_) => Ok(()),
+        Err(CronError::InvalidSkillContent(_)) => {
+            let description = job
+                .description
+                .clone()
+                .unwrap_or_else(|| format!("Saved cron skill for {}", job.name));
+            write_skill_file(
+                data_dir,
+                &job.id,
+                &job.name,
+                &description,
+                raw_content.trim(),
+                schedule_description_ref(&job.schedule),
+            )
+            .await
+            .map(|_| ())
+        }
+        Err(err) => Err(err),
     }
 }
 
@@ -334,6 +1192,17 @@ fn build_prompt(job: &CronJob) -> String {
 mod tests {
     use super::*;
     use crate::types::{CreatedBy, CronAgentConfig, CronSchedule};
+    use aionui_ai_agent::agent_manager::AgentManagerHandle;
+    use aionui_api_types::{AgentModeResponse, WebSocketMessage};
+    use aionui_common::{
+        AgentKillReason, Confirmation, ConversationStatus, PaginatedResult, TimestampMs,
+    };
+    use aionui_db::{
+        ConversationFilters, ConversationRowUpdate, MessageRowUpdate, MessageSearchRow, SortOrder,
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use tokio::sync::{RwLock, broadcast};
 
     fn sample_job() -> CronJob {
         CronJob {
@@ -374,6 +1243,19 @@ mod tests {
             retry_count: 0,
             max_retries: 3,
         }
+    }
+
+    async fn wait_for_agent_send(agent: &RecordingAgent, expected_calls: usize) {
+        timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if agent.send_calls() >= expected_calls {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("agent send should complete");
     }
 
     // -- handle_busy tests ---------------------------------------------------
@@ -439,31 +1321,41 @@ mod tests {
     #[test]
     fn build_prompt_existing_mode_no_skill() {
         let job = sample_job();
-        let prompt = build_prompt(&job);
-        assert_eq!(prompt, "do something");
+        let prompt = build_prompt(&job, None);
+        assert!(prompt.contains("[Scheduled Task Execution]"));
+        assert!(prompt.contains("Task instruction:\ndo something"));
     }
 
     #[test]
-    fn build_prompt_existing_mode_with_skill_ignores_skill() {
-        let job = CronJob {
-            skill_content: Some("skill content".into()),
-            ..sample_job()
-        };
-        let prompt = build_prompt(&job);
-        assert_eq!(prompt, "do something");
+    fn build_prompt_existing_mode_with_skill_appends_inline_instructions() {
+        let job = sample_job();
+        let prompt = build_prompt(
+            &job,
+            Some(&SavedSkillContext {
+                name: "cron-cron_test1".into(),
+                raw_content: "---\nname: test\ndescription: desc\n---\nDo X".into(),
+            }),
+        );
+        assert!(prompt.contains("[Scheduled Task Execution]"));
+        assert!(prompt.contains("## Skill Instructions"));
+        assert!(prompt.contains("Do X"));
     }
 
     #[test]
     fn build_prompt_new_conv_with_skill() {
         let job = CronJob {
             execution_mode: ExecutionMode::NewConversation,
-            skill_content: Some("---\nname: test\n---\nDo X".into()),
             ..sample_job()
         };
-        let prompt = build_prompt(&job);
+        let prompt = build_prompt(
+            &job,
+            Some(&SavedSkillContext {
+                name: "cron-cron_test1".into(),
+                raw_content: "---\nname: test\ndescription: desc\n---\nDo X".into(),
+            }),
+        );
+        assert!(prompt.contains("A skill file with detailed instructions has been loaded"));
         assert!(prompt.contains("do something"));
-        assert!(prompt.contains("Skill Instructions"));
-        assert!(prompt.contains("Do X"));
     }
 
     #[test]
@@ -472,19 +1364,18 @@ mod tests {
             execution_mode: ExecutionMode::NewConversation,
             ..sample_job()
         };
-        let prompt = build_prompt(&job);
-        assert_eq!(prompt, "do something");
+        let prompt = build_prompt(&job, None);
+        assert!(prompt.contains("create a file named \"SKILL_SUGGEST.md\""));
     }
 
     #[test]
     fn build_prompt_new_conv_empty_skill() {
         let job = CronJob {
             execution_mode: ExecutionMode::NewConversation,
-            skill_content: Some(String::new()),
             ..sample_job()
         };
-        let prompt = build_prompt(&job);
-        assert_eq!(prompt, "do something");
+        let prompt = build_prompt(&job, None);
+        assert!(prompt.contains("SKILL_SUGGEST.md"));
     }
 
     // -- parse_agent_type tests -----------------------------------------------
@@ -493,6 +1384,14 @@ mod tests {
     fn parse_agent_type_known_types() {
         assert_eq!(parse_agent_type("acp"), AgentType::Acp);
         assert_eq!(parse_agent_type("nanobot"), AgentType::Nanobot);
+    }
+
+    #[test]
+    fn parse_agent_type_acp_backend_aliases_to_acp() {
+        assert_eq!(parse_agent_type("claude"), AgentType::Acp);
+        assert_eq!(parse_agent_type("gemini"), AgentType::Acp);
+        assert_eq!(parse_agent_type("qwen"), AgentType::Acp);
+        assert_eq!(parse_agent_type("codex"), AgentType::Acp);
     }
 
     #[test]
@@ -548,17 +1447,18 @@ mod tests {
     #[test]
     fn build_task_extra_includes_cron_job_id() {
         let job = sample_job();
-        let extra = build_task_extra(&job);
-        assert_eq!(extra["cronJobId"], "cron_test1");
+        let extra = build_task_extra(&job, &[]);
+        assert_eq!(extra["cron_job_id"], "cron_test1");
     }
 
     #[test]
     fn build_task_extra_with_config_fields() {
         let job = sample_job();
-        let extra = build_task_extra(&job);
+        let extra = build_task_extra(&job, &["cron-cron_test1".into()]);
         assert_eq!(extra["backend"], "acp");
-        assert_eq!(extra["cliPath"], "/usr/bin/claude");
-        assert_eq!(extra["agentName"], "Claude");
+        assert_eq!(extra["cli_path"], "/usr/bin/claude");
+        assert_eq!(extra["agent_name"], "Claude");
+        assert_eq!(extra["skills"], serde_json::json!(["cron-cron_test1"]));
     }
 
     #[test]
@@ -567,9 +1467,61 @@ mod tests {
             agent_config: None,
             ..sample_job()
         };
-        let extra = build_task_extra(&job);
-        assert_eq!(extra["cronJobId"], "cron_test1");
+        let extra = build_task_extra(&job, &[]);
+        assert_eq!(extra["cron_job_id"], "cron_test1");
         assert!(extra.get("backend").is_none());
+    }
+
+    #[test]
+    fn build_conversation_extra_without_saved_skill_excludes_cron_auto_inject_only() {
+        let job = CronJob {
+            execution_mode: ExecutionMode::NewConversation,
+            ..sample_job()
+        };
+
+        let extra = build_conversation_extra(&job, None);
+
+        assert_eq!(extra["cron_job_id"], "cron_test1");
+        assert_eq!(
+            extra["exclude_auto_inject_skills"],
+            serde_json::json!(["cron"])
+        );
+        assert!(extra.get("preset_enabled_skills").is_none());
+    }
+
+    #[test]
+    fn build_conversation_extra_with_saved_skill_enables_preset_skill() {
+        let job = CronJob {
+            execution_mode: ExecutionMode::NewConversation,
+            ..sample_job()
+        };
+        let saved_skill = SavedSkillContext {
+            name: "cron-cron_test1".into(),
+            raw_content: "---\nname: test\ndescription: desc\n---\nDo X".into(),
+        };
+
+        let extra = build_conversation_extra(&job, Some(&saved_skill));
+
+        assert_eq!(
+            extra["exclude_auto_inject_skills"],
+            serde_json::json!(["cron"])
+        );
+        assert_eq!(
+            extra["preset_enabled_skills"],
+            serde_json::json!(["cron-cron_test1"])
+        );
+    }
+
+    #[test]
+    fn build_conversation_extra_preserves_agent_workspace() {
+        let job = CronJob {
+            execution_mode: ExecutionMode::NewConversation,
+            ..sample_job()
+        };
+
+        let extra = build_conversation_extra(&job, None);
+
+        assert_eq!(extra["workspace"], "/home/user/project");
     }
 
     // -- execution_result display ---------------------------------------------
@@ -602,17 +1554,331 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn execute_inner_applies_desired_session_mode_before_sending() {
+        let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
+        let executor = make_executor_with_agent(agent.clone() as AgentManagerHandle);
+        let mut job = sample_job();
+        job.agent_config.as_mut().unwrap().mode = Some("yolo".into());
+
+        let result = executor.execute_inner(&job, "conv_1", None).await;
+
+        assert_eq!(
+            result,
+            ExecutionResult::Success {
+                conversation_id: "conv_1".into()
+            }
+        );
+        wait_for_agent_send(&agent, 1).await;
+        assert_eq!(agent.mode().await, "yolo");
+        assert_eq!(agent.set_mode_calls(), 1);
+        assert_eq!(agent.send_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn execute_inner_applies_mode_even_for_uninitialized_agent() {
+        let agent = Arc::new(RecordingAgent::new("conv_1", "default", false));
+        let executor = make_executor_with_agent(agent.clone() as AgentManagerHandle);
+        let mut job = sample_job();
+        job.agent_config.as_mut().unwrap().mode = Some("yolo".into());
+
+        let result = executor.execute_inner(&job, "conv_1", None).await;
+
+        assert_eq!(
+            result,
+            ExecutionResult::Success {
+                conversation_id: "conv_1".into()
+            }
+        );
+        wait_for_agent_send(&agent, 1).await;
+        assert_eq!(agent.mode().await, "yolo");
+        assert_eq!(agent.set_mode_calls(), 1);
+        assert_eq!(agent.send_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn execute_inner_skips_mode_update_when_already_matching() {
+        let agent = Arc::new(RecordingAgent::new("conv_1", "yolo", true));
+        let executor = make_executor_with_agent(agent.clone() as AgentManagerHandle);
+        let mut job = sample_job();
+        job.agent_config.as_mut().unwrap().mode = Some("yolo".into());
+
+        let result = executor.execute_inner(&job, "conv_1", None).await;
+
+        assert_eq!(
+            result,
+            ExecutionResult::Success {
+                conversation_id: "conv_1".into()
+            }
+        );
+        wait_for_agent_send(&agent, 1).await;
+        assert_eq!(agent.mode().await, "yolo");
+        assert_eq!(agent.set_mode_calls(), 0);
+        assert_eq!(agent.send_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn execute_inner_new_conversation_without_saved_skill_requests_skill_suggest() {
+        let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
+        let task_manager = Arc::new(RecordingTaskManager::new(
+            agent.clone() as AgentManagerHandle
+        ));
+        let executor = make_executor_with_task_manager(task_manager.clone());
+        let job = CronJob {
+            execution_mode: ExecutionMode::NewConversation,
+            ..sample_job()
+        };
+
+        let result = executor.execute_inner(&job, "conv_1", None).await;
+
+        assert_eq!(
+            result,
+            ExecutionResult::Success {
+                conversation_id: "conv_1".into()
+            }
+        );
+        wait_for_agent_send(&agent, 1).await;
+        let sent_messages = agent.sent_messages().await;
+        assert_eq!(sent_messages.len(), 1);
+        assert!(
+            sent_messages[0]
+                .content
+                .contains("create a file named \"SKILL_SUGGEST.md\"")
+        );
+        assert!(sent_messages[0].inject_skills.is_empty());
+
+        let options = task_manager
+            .last_options()
+            .expect("task manager should capture build options");
+        assert!(
+            options
+                .extra
+                .get("skills")
+                .and_then(|value| value.as_array())
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_inner_new_conversation_with_saved_skill_injects_saved_skill() {
+        let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
+        let task_manager = Arc::new(RecordingTaskManager::new(
+            agent.clone() as AgentManagerHandle
+        ));
+        let executor = make_executor_with_task_manager(task_manager.clone());
+        let job = CronJob {
+            execution_mode: ExecutionMode::NewConversation,
+            ..sample_job()
+        };
+        let saved_skill = SavedSkillContext {
+            name: "cron-cron_test1".into(),
+            raw_content: "---\nname: test\ndescription: desc\n---\nDo X".into(),
+        };
+
+        let result = executor
+            .execute_inner(&job, "conv_1", Some(&saved_skill))
+            .await;
+
+        assert_eq!(
+            result,
+            ExecutionResult::Success {
+                conversation_id: "conv_1".into()
+            }
+        );
+        wait_for_agent_send(&agent, 1).await;
+        let sent_messages = agent.sent_messages().await;
+        assert_eq!(sent_messages.len(), 1);
+        assert!(
+            sent_messages[0]
+                .content
+                .contains("A skill file with detailed instructions has been loaded")
+        );
+        assert!(!sent_messages[0].content.contains("SKILL_SUGGEST.md"));
+        assert_eq!(
+            sent_messages[0].inject_skills,
+            vec!["cron-cron_test1".to_owned()]
+        );
+
+        let options = task_manager
+            .recorded_options()
+            .into_iter()
+            .next()
+            .expect("task manager should capture build options");
+        assert_eq!(
+            options.extra["skills"],
+            serde_json::json!(["cron-cron_test1"])
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_inner_uses_conversation_workspace_when_job_workspace_missing() {
+        let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
+        let task_manager = Arc::new(RecordingTaskManager::new(
+            agent.clone() as AgentManagerHandle
+        ));
+        let executor = make_executor_with_task_manager(task_manager.clone());
+        let mut job = CronJob {
+            execution_mode: ExecutionMode::NewConversation,
+            ..sample_job()
+        };
+        job.agent_config.as_mut().unwrap().workspace = None;
+
+        let result = executor.execute_inner(&job, "conv_1", None).await;
+
+        assert_eq!(
+            result,
+            ExecutionResult::Success {
+                conversation_id: "conv_1".into()
+            }
+        );
+        wait_for_agent_send(&agent, 1).await;
+        let options = task_manager
+            .last_options()
+            .expect("task manager should capture build options");
+        assert_eq!(options.workspace, "/tmp/existing-conversation-workspace");
+    }
+
+    #[tokio::test]
+    async fn execute_inner_persists_agent_workspace_when_conversation_workspace_missing() {
+        let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
+        let task_manager = Arc::new(RecordingTaskManager::new(
+            agent.clone() as AgentManagerHandle
+        ));
+        let repo = Arc::new(MissingWorkspaceConversationRepo::new(
+            "conv_1",
+            serde_json::json!({}),
+        ));
+        let executor = make_executor_with_task_manager_and_repo(task_manager.clone(), repo.clone());
+        let mut job = CronJob {
+            execution_mode: ExecutionMode::NewConversation,
+            ..sample_job()
+        };
+        job.agent_config.as_mut().unwrap().workspace = None;
+
+        let result = executor.execute_inner(&job, "conv_1", None).await;
+
+        assert_eq!(
+            result,
+            ExecutionResult::Success {
+                conversation_id: "conv_1".into()
+            }
+        );
+        wait_for_agent_send(&agent, 1).await;
+        let options = task_manager
+            .last_options()
+            .expect("task manager should capture build options");
+        assert_eq!(options.workspace, "");
+
+        let update = repo
+            .last_update_with_extra()
+            .expect("conversation workspace should be persisted");
+        let extra = update.extra.expect("workspace update should write extra");
+        let value: serde_json::Value = serde_json::from_str(&extra).expect("valid extra json");
+        assert_eq!(value["workspace"], "/tmp/cron-test");
+    }
+
+    #[tokio::test]
+    async fn execute_inner_inserts_right_side_user_message_for_cron_prompt() {
+        let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
+        let task_manager = Arc::new(RecordingTaskManager::new(
+            agent.clone() as AgentManagerHandle
+        ));
+        let repo = Arc::new(MissingWorkspaceConversationRepo::new(
+            "conv_1",
+            serde_json::json!({ "workspace": "/tmp/existing-conversation-workspace" }),
+        ));
+        let executor = make_executor_with_task_manager_and_repo(task_manager, repo.clone());
+        let job = CronJob {
+            execution_mode: ExecutionMode::NewConversation,
+            ..sample_job()
+        };
+
+        let result = executor.execute_inner(&job, "conv_1", None).await;
+
+        assert_eq!(
+            result,
+            ExecutionResult::Success {
+                conversation_id: "conv_1".into()
+            }
+        );
+        wait_for_agent_send(&agent, 1).await;
+
+        let messages = repo.inserted_messages();
+        assert!(
+            !messages.is_empty(),
+            "cron execution should insert a user message"
+        );
+        let right_message = messages
+            .iter()
+            .find(|message| message.position.as_deref() == Some("right"))
+            .expect("cron execution should insert a right-side prompt message");
+        assert_eq!(right_message.r#type, "text");
+        assert!(right_message.content.contains("SKILL_SUGGEST.md"));
+    }
+
+    #[tokio::test]
+    async fn execute_inner_inserts_cron_trigger_message_and_broadcasts_event() {
+        let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
+        let task_manager = Arc::new(RecordingTaskManager::new(
+            agent.clone() as AgentManagerHandle
+        ));
+        let repo = Arc::new(MissingWorkspaceConversationRepo::new(
+            "conv_1",
+            serde_json::json!({ "workspace": "/tmp/existing-conversation-workspace" }),
+        ));
+        let broadcaster = Arc::new(RecordingBroadcaster::new());
+        let executor = make_executor_with_task_manager_repo_and_broadcaster(
+            task_manager,
+            repo.clone(),
+            broadcaster.clone(),
+        );
+        let job = CronJob {
+            execution_mode: ExecutionMode::NewConversation,
+            ..sample_job()
+        };
+
+        let result = executor.execute_inner(&job, "conv_1", None).await;
+
+        assert_eq!(
+            result,
+            ExecutionResult::Success {
+                conversation_id: "conv_1".into()
+            }
+        );
+        wait_for_agent_send(&agent, 1).await;
+
+        let messages = repo.inserted_messages();
+        let trigger_message = messages
+            .iter()
+            .find(|message| message.r#type == "cron_trigger")
+            .expect("cron execution should insert a cron trigger message");
+        assert_eq!(trigger_message.position.as_deref(), Some("center"));
+        let trigger_content: serde_json::Value =
+            serde_json::from_str(&trigger_message.content).expect("valid trigger payload");
+        assert_eq!(trigger_content["cron_job_id"], "cron_test1");
+        assert_eq!(trigger_content["cron_job_name"], "Test Job");
+        assert!(trigger_content["triggered_at"].as_i64().is_some());
+
+        let events = broadcaster.events();
+        let trigger_event = events
+            .iter()
+            .find(|event| {
+                event["name"] == "message.stream" && event["data"]["type"] == "cron_trigger"
+            })
+            .expect("cron execution should broadcast cron trigger event");
+        assert_eq!(trigger_event["data"]["conversation_id"], "conv_1");
+        assert_eq!(trigger_event["data"]["data"]["cron_job_id"], "cron_test1");
+        assert_eq!(trigger_event["data"]["data"]["cron_job_name"], "Test Job");
+        assert!(
+            trigger_event["data"]["data"]["triggered_at"]
+                .as_i64()
+                .is_some()
+        );
+    }
+
     // -- helper ---------------------------------------------------------------
 
     fn make_executor_for_busy_tests(guard: Arc<CronBusyGuard>) -> JobExecutor {
-        use aionui_ai_agent::agent_manager::AgentManagerHandle;
-        use aionui_api_types::WebSocketMessage;
-        use aionui_common::PaginatedResult;
-        use aionui_db::{
-            ConversationFilters, ConversationRowUpdate, MessageRowUpdate, MessageSearchRow,
-            SortOrder,
-        };
-
         struct StubTaskManager;
         impl IWorkerTaskManager for StubTaskManager {
             fn get_task(&self, _: &str) -> Option<AgentManagerHandle> {
@@ -799,6 +2065,649 @@ mod tests {
             Arc::new(StubSkillResolver),
         ));
 
-        JobExecutor::new(Arc::new(StubTaskManager), stub_repo, conv_service, guard)
+        JobExecutor::new(
+            Arc::new(StubTaskManager),
+            stub_repo,
+            conv_service,
+            guard,
+            std::env::temp_dir(),
+            Arc::new(StubBroadcaster),
+        )
+    }
+
+    struct RecordingAgent {
+        conversation_id: String,
+        workspace: String,
+        event_tx: broadcast::Sender<AgentStreamEvent>,
+        mode: RwLock<String>,
+        sent_messages: RwLock<Vec<SendMessageData>>,
+        initialized: bool,
+        set_mode_calls: AtomicUsize,
+        send_calls: AtomicUsize,
+    }
+
+    impl RecordingAgent {
+        fn new(conversation_id: &str, mode: &str, initialized: bool) -> Self {
+            let (event_tx, _) = broadcast::channel(16);
+            Self {
+                conversation_id: conversation_id.to_owned(),
+                workspace: "/tmp/cron-test".to_owned(),
+                event_tx,
+                mode: RwLock::new(mode.to_owned()),
+                sent_messages: RwLock::new(Vec::new()),
+                initialized,
+                set_mode_calls: AtomicUsize::new(0),
+                send_calls: AtomicUsize::new(0),
+            }
+        }
+
+        async fn mode(&self) -> String {
+            self.mode.read().await.clone()
+        }
+
+        fn set_mode_calls(&self) -> usize {
+            self.set_mode_calls.load(Ordering::Relaxed)
+        }
+
+        fn send_calls(&self) -> usize {
+            self.send_calls.load(Ordering::Relaxed)
+        }
+
+        async fn sent_messages(&self) -> Vec<SendMessageData> {
+            self.sent_messages.read().await.clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl IAgentManager for RecordingAgent {
+        fn agent_type(&self) -> AgentType {
+            AgentType::Acp
+        }
+
+        fn status(&self) -> Option<ConversationStatus> {
+            Some(ConversationStatus::Pending)
+        }
+
+        fn workspace(&self) -> &str {
+            &self.workspace
+        }
+
+        fn conversation_id(&self) -> &str {
+            &self.conversation_id
+        }
+
+        fn last_activity_at(&self) -> TimestampMs {
+            0
+        }
+
+        fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
+            self.event_tx.subscribe()
+        }
+
+        async fn send_message(&self, data: SendMessageData) -> Result<(), aionui_common::AppError> {
+            self.send_calls.fetch_add(1, Ordering::Relaxed);
+            self.sent_messages.write().await.push(data);
+            Ok(())
+        }
+
+        async fn stop(&self) -> Result<(), aionui_common::AppError> {
+            Ok(())
+        }
+
+        fn confirm(
+            &self,
+            _msg_id: &str,
+            _call_id: &str,
+            _data: serde_json::Value,
+            _always_allow: bool,
+        ) -> Result<(), aionui_common::AppError> {
+            Ok(())
+        }
+
+        fn get_confirmations(&self) -> Vec<Confirmation> {
+            Vec::new()
+        }
+
+        fn check_approval(&self, _action: &str, _command_type: Option<&str>) -> bool {
+            false
+        }
+
+        fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), aionui_common::AppError> {
+            Ok(())
+        }
+
+        async fn get_mode(&self) -> Result<AgentModeResponse, aionui_common::AppError> {
+            Ok(AgentModeResponse {
+                mode: self.mode().await,
+                initialized: self.initialized,
+            })
+        }
+
+        async fn set_mode(&self, mode: &str) -> Result<(), aionui_common::AppError> {
+            self.set_mode_calls.fetch_add(1, Ordering::Relaxed);
+            let mut guard = self.mode.write().await;
+            *guard = mode.to_owned();
+            Ok(())
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    struct FixedTaskManager {
+        agent: AgentManagerHandle,
+    }
+
+    impl IWorkerTaskManager for FixedTaskManager {
+        fn get_task(&self, _conversation_id: &str) -> Option<AgentManagerHandle> {
+            Some(Arc::clone(&self.agent))
+        }
+
+        fn get_or_build_task(
+            &self,
+            _conversation_id: &str,
+            _options: BuildTaskOptions,
+        ) -> Result<AgentManagerHandle, aionui_common::AppError> {
+            Ok(Arc::clone(&self.agent))
+        }
+
+        fn kill(
+            &self,
+            _conversation_id: &str,
+            _reason: Option<AgentKillReason>,
+        ) -> Result<(), aionui_common::AppError> {
+            Ok(())
+        }
+
+        fn clear(&self) {}
+
+        fn active_count(&self) -> usize {
+            1
+        }
+
+        fn collect_idle(&self, _idle_threshold_ms: TimestampMs) -> Vec<String> {
+            Vec::new()
+        }
+    }
+
+    struct RecordingTaskManager {
+        agent: AgentManagerHandle,
+        options: Mutex<Vec<BuildTaskOptions>>,
+    }
+
+    impl RecordingTaskManager {
+        fn new(agent: AgentManagerHandle) -> Self {
+            Self {
+                agent,
+                options: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn last_options(&self) -> Option<BuildTaskOptions> {
+            self.options
+                .lock()
+                .ok()
+                .and_then(|items| items.last().cloned())
+        }
+
+        fn recorded_options(&self) -> Vec<BuildTaskOptions> {
+            self.options
+                .lock()
+                .map(|items| items.clone())
+                .unwrap_or_default()
+        }
+    }
+
+    impl IWorkerTaskManager for RecordingTaskManager {
+        fn get_task(&self, _conversation_id: &str) -> Option<AgentManagerHandle> {
+            Some(Arc::clone(&self.agent))
+        }
+
+        fn get_or_build_task(
+            &self,
+            _conversation_id: &str,
+            options: BuildTaskOptions,
+        ) -> Result<AgentManagerHandle, aionui_common::AppError> {
+            self.options.lock().unwrap().push(options);
+            Ok(Arc::clone(&self.agent))
+        }
+
+        fn kill(
+            &self,
+            _conversation_id: &str,
+            _reason: Option<AgentKillReason>,
+        ) -> Result<(), aionui_common::AppError> {
+            Ok(())
+        }
+
+        fn clear(&self) {}
+
+        fn active_count(&self) -> usize {
+            1
+        }
+
+        fn collect_idle(&self, _idle_threshold_ms: TimestampMs) -> Vec<String> {
+            Vec::new()
+        }
+    }
+
+    struct ExistingConversationRepo;
+
+    #[async_trait::async_trait]
+    impl IConversationRepository for ExistingConversationRepo {
+        async fn get(
+            &self,
+            id: &str,
+        ) -> Result<Option<aionui_db::models::ConversationRow>, aionui_db::DbError> {
+            Ok(Some(aionui_db::models::ConversationRow {
+                id: id.to_owned(),
+                user_id: "cron".into(),
+                name: "Cron Conversation".into(),
+                r#type: "acp".into(),
+                extra: serde_json::json!({
+                    "workspace": "/tmp/existing-conversation-workspace"
+                })
+                .to_string(),
+                model: None,
+                status: Some("finished".into()),
+                source: None,
+                channel_chat_id: None,
+                pinned: false,
+                pinned_at: None,
+                created_at: 0,
+                updated_at: 0,
+            }))
+        }
+
+        async fn create(
+            &self,
+            _row: &aionui_db::models::ConversationRow,
+        ) -> Result<(), aionui_db::DbError> {
+            Ok(())
+        }
+
+        async fn update(
+            &self,
+            _id: &str,
+            _updates: &ConversationRowUpdate,
+        ) -> Result<(), aionui_db::DbError> {
+            Ok(())
+        }
+
+        async fn delete(&self, _id: &str) -> Result<(), aionui_db::DbError> {
+            Ok(())
+        }
+
+        async fn list_paginated(
+            &self,
+            _user_id: &str,
+            _filters: &ConversationFilters,
+        ) -> Result<PaginatedResult<aionui_db::models::ConversationRow>, aionui_db::DbError>
+        {
+            Ok(PaginatedResult {
+                items: vec![],
+                total: 0,
+                has_more: false,
+            })
+        }
+
+        async fn find_by_source_and_chat(
+            &self,
+            _user_id: &str,
+            _source: &str,
+            _chat_id: &str,
+            _agent_type: &str,
+        ) -> Result<Option<aionui_db::models::ConversationRow>, aionui_db::DbError> {
+            Ok(None)
+        }
+
+        async fn list_by_cron_job(
+            &self,
+            _user_id: &str,
+            _cron_job_id: &str,
+        ) -> Result<Vec<aionui_db::models::ConversationRow>, aionui_db::DbError> {
+            Ok(vec![])
+        }
+
+        async fn list_associated(
+            &self,
+            _user_id: &str,
+            _conversation_id: &str,
+        ) -> Result<Vec<aionui_db::models::ConversationRow>, aionui_db::DbError> {
+            Ok(vec![])
+        }
+
+        async fn get_messages(
+            &self,
+            _conv_id: &str,
+            _page: u32,
+            _page_size: u32,
+            _order: SortOrder,
+        ) -> Result<PaginatedResult<aionui_db::models::MessageRow>, aionui_db::DbError> {
+            Ok(PaginatedResult {
+                items: vec![],
+                total: 0,
+                has_more: false,
+            })
+        }
+
+        async fn insert_message(
+            &self,
+            _message: &aionui_db::models::MessageRow,
+        ) -> Result<(), aionui_db::DbError> {
+            Ok(())
+        }
+
+        async fn update_message(
+            &self,
+            _id: &str,
+            _updates: &MessageRowUpdate,
+        ) -> Result<(), aionui_db::DbError> {
+            Ok(())
+        }
+
+        async fn delete_messages_by_conversation(
+            &self,
+            _conv_id: &str,
+        ) -> Result<(), aionui_db::DbError> {
+            Ok(())
+        }
+
+        async fn get_message_by_msg_id(
+            &self,
+            _conv_id: &str,
+            _msg_id: &str,
+            _msg_type: &str,
+        ) -> Result<Option<aionui_db::models::MessageRow>, aionui_db::DbError> {
+            Ok(None)
+        }
+
+        async fn search_messages(
+            &self,
+            _user_id: &str,
+            _keyword: &str,
+            _page: u32,
+            _page_size: u32,
+        ) -> Result<PaginatedResult<MessageSearchRow>, aionui_db::DbError> {
+            Ok(PaginatedResult {
+                items: vec![],
+                total: 0,
+                has_more: false,
+            })
+        }
+    }
+
+    struct MissingWorkspaceConversationRepo {
+        row: aionui_db::models::ConversationRow,
+        updates: Mutex<Vec<ConversationRowUpdate>>,
+        inserted_messages: Mutex<Vec<aionui_db::models::MessageRow>>,
+    }
+
+    impl MissingWorkspaceConversationRepo {
+        fn new(conversation_id: &str, extra: serde_json::Value) -> Self {
+            Self {
+                row: aionui_db::models::ConversationRow {
+                    id: conversation_id.to_owned(),
+                    user_id: "cron".into(),
+                    name: "Cron Conversation".into(),
+                    r#type: "acp".into(),
+                    extra: extra.to_string(),
+                    model: None,
+                    status: Some("finished".into()),
+                    source: None,
+                    channel_chat_id: None,
+                    pinned: false,
+                    pinned_at: None,
+                    created_at: 0,
+                    updated_at: 0,
+                },
+                updates: Mutex::new(Vec::new()),
+                inserted_messages: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn last_update_with_extra(&self) -> Option<ConversationRowUpdate> {
+            self.updates.lock().ok().and_then(|items| {
+                items
+                    .iter()
+                    .rev()
+                    .find(|update| update.extra.is_some())
+                    .cloned()
+            })
+        }
+
+        fn inserted_messages(&self) -> Vec<aionui_db::models::MessageRow> {
+            self.inserted_messages
+                .lock()
+                .map(|items| items.clone())
+                .unwrap_or_default()
+        }
+    }
+
+    struct RecordingBroadcaster {
+        events: Mutex<Vec<serde_json::Value>>,
+    }
+
+    impl RecordingBroadcaster {
+        fn new() -> Self {
+            Self {
+                events: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn events(&self) -> Vec<serde_json::Value> {
+            self.events
+                .lock()
+                .map(|items| items.clone())
+                .unwrap_or_default()
+        }
+    }
+
+    impl aionui_realtime::EventBroadcaster for RecordingBroadcaster {
+        fn broadcast(&self, event: WebSocketMessage<serde_json::Value>) {
+            self.events.lock().unwrap().push(serde_json::json!({
+                "name": event.name,
+                "data": event.data,
+            }));
+        }
+    }
+
+    struct StubBroadcaster;
+
+    impl aionui_realtime::EventBroadcaster for StubBroadcaster {
+        fn broadcast(&self, _: WebSocketMessage<serde_json::Value>) {}
+    }
+
+    #[async_trait::async_trait]
+    impl IConversationRepository for MissingWorkspaceConversationRepo {
+        async fn get(
+            &self,
+            _id: &str,
+        ) -> Result<Option<aionui_db::models::ConversationRow>, aionui_db::DbError> {
+            Ok(Some(self.row.clone()))
+        }
+
+        async fn create(
+            &self,
+            _row: &aionui_db::models::ConversationRow,
+        ) -> Result<(), aionui_db::DbError> {
+            Ok(())
+        }
+
+        async fn update(
+            &self,
+            _id: &str,
+            updates: &ConversationRowUpdate,
+        ) -> Result<(), aionui_db::DbError> {
+            self.updates.lock().unwrap().push(updates.clone());
+            Ok(())
+        }
+
+        async fn delete(&self, _id: &str) -> Result<(), aionui_db::DbError> {
+            Ok(())
+        }
+
+        async fn list_paginated(
+            &self,
+            _user_id: &str,
+            _filters: &ConversationFilters,
+        ) -> Result<PaginatedResult<aionui_db::models::ConversationRow>, aionui_db::DbError>
+        {
+            Ok(PaginatedResult {
+                items: vec![],
+                total: 0,
+                has_more: false,
+            })
+        }
+
+        async fn find_by_source_and_chat(
+            &self,
+            _user_id: &str,
+            _source: &str,
+            _chat_id: &str,
+            _agent_type: &str,
+        ) -> Result<Option<aionui_db::models::ConversationRow>, aionui_db::DbError> {
+            Ok(None)
+        }
+
+        async fn list_by_cron_job(
+            &self,
+            _user_id: &str,
+            _cron_job_id: &str,
+        ) -> Result<Vec<aionui_db::models::ConversationRow>, aionui_db::DbError> {
+            Ok(vec![])
+        }
+
+        async fn list_associated(
+            &self,
+            _user_id: &str,
+            _conversation_id: &str,
+        ) -> Result<Vec<aionui_db::models::ConversationRow>, aionui_db::DbError> {
+            Ok(vec![])
+        }
+
+        async fn get_messages(
+            &self,
+            _conv_id: &str,
+            _page: u32,
+            _page_size: u32,
+            _order: SortOrder,
+        ) -> Result<PaginatedResult<aionui_db::models::MessageRow>, aionui_db::DbError> {
+            Ok(PaginatedResult {
+                items: vec![],
+                total: 0,
+                has_more: false,
+            })
+        }
+
+        async fn insert_message(
+            &self,
+            message: &aionui_db::models::MessageRow,
+        ) -> Result<(), aionui_db::DbError> {
+            self.inserted_messages.lock().unwrap().push(message.clone());
+            Ok(())
+        }
+
+        async fn update_message(
+            &self,
+            _id: &str,
+            _updates: &MessageRowUpdate,
+        ) -> Result<(), aionui_db::DbError> {
+            Ok(())
+        }
+
+        async fn delete_messages_by_conversation(
+            &self,
+            _conv_id: &str,
+        ) -> Result<(), aionui_db::DbError> {
+            Ok(())
+        }
+
+        async fn get_message_by_msg_id(
+            &self,
+            _conv_id: &str,
+            _msg_id: &str,
+            _msg_type: &str,
+        ) -> Result<Option<aionui_db::models::MessageRow>, aionui_db::DbError> {
+            Ok(None)
+        }
+
+        async fn search_messages(
+            &self,
+            _user_id: &str,
+            _keyword: &str,
+            _page: u32,
+            _page_size: u32,
+        ) -> Result<PaginatedResult<MessageSearchRow>, aionui_db::DbError> {
+            Ok(PaginatedResult {
+                items: vec![],
+                total: 0,
+                has_more: false,
+            })
+        }
+    }
+
+    fn make_executor_with_agent(agent: AgentManagerHandle) -> JobExecutor {
+        make_executor_with_task_manager(Arc::new(FixedTaskManager { agent }))
+    }
+
+    fn make_executor_with_task_manager(task_manager: Arc<dyn IWorkerTaskManager>) -> JobExecutor {
+        make_executor_with_task_manager_and_repo(task_manager, Arc::new(ExistingConversationRepo))
+    }
+
+    fn make_executor_with_task_manager_and_repo(
+        task_manager: Arc<dyn IWorkerTaskManager>,
+        repo: Arc<dyn IConversationRepository>,
+    ) -> JobExecutor {
+        let broadcaster: Arc<dyn aionui_realtime::EventBroadcaster> = Arc::new(StubBroadcaster);
+        make_executor_with_task_manager_repo_and_broadcaster(task_manager, repo, broadcaster)
+    }
+
+    fn make_executor_with_task_manager_repo_and_broadcaster(
+        task_manager: Arc<dyn IWorkerTaskManager>,
+        repo: Arc<dyn IConversationRepository>,
+        broadcaster: Arc<dyn aionui_realtime::EventBroadcaster>,
+    ) -> JobExecutor {
+        struct StubSkillResolver;
+
+        #[async_trait::async_trait]
+        impl aionui_conversation::skill_resolver::SkillResolver for StubSkillResolver {
+            async fn auto_inject_names(&self) -> Vec<String> {
+                Vec::new()
+            }
+
+            async fn resolve_skills(
+                &self,
+                _names: &[String],
+            ) -> Vec<aionui_conversation::skill_resolver::ResolvedAgentSkill> {
+                Vec::new()
+            }
+
+            async fn link_workspace_skills(
+                &self,
+                _workspace: &std::path::Path,
+                _rel_dirs: &[&str],
+                _skills: &[aionui_conversation::skill_resolver::ResolvedAgentSkill],
+            ) -> usize {
+                0
+            }
+        }
+
+        let conversation_service = Arc::new(ConversationService::new_with_workspace_root(
+            Arc::clone(&repo),
+            Arc::clone(&broadcaster),
+            std::env::temp_dir(),
+            Arc::new(StubSkillResolver),
+        ));
+
+        JobExecutor::new(
+            task_manager,
+            repo,
+            conversation_service,
+            Arc::new(CronBusyGuard::new()),
+            std::env::temp_dir(),
+            broadcaster,
+        )
     }
 }

--- a/crates/aionui-cron/src/lib.rs
+++ b/crates/aionui-cron/src/lib.rs
@@ -3,9 +3,12 @@ pub mod busy_guard;
 pub mod error;
 pub mod events;
 pub mod executor;
+pub mod prompt;
 pub mod routes;
 pub mod scheduler;
 pub mod service;
+pub mod skill_file;
+pub mod skill_suggest;
 pub mod state;
 pub mod types;
 

--- a/crates/aionui-cron/src/lib.rs
+++ b/crates/aionui-cron/src/lib.rs
@@ -1,4 +1,5 @@
 //! Scheduled job engine: cron scheduler, executor, and lifecycle event emitter.
+mod artifacts;
 pub mod busy_guard;
 pub mod error;
 pub mod events;

--- a/crates/aionui-cron/src/prompt.rs
+++ b/crates/aionui-cron/src/prompt.rs
@@ -1,0 +1,53 @@
+/// The fixed filename agents write skill suggestions to in the workspace root.
+pub const SKILL_SUGGEST_FILENAME: &str = "SKILL_SUGGEST.md";
+
+/// New-conversation mode, first run (no saved skill yet).
+pub fn build_new_conversation_prompt(
+    task_name: &str,
+    schedule_desc: &str,
+    user_prompt: &str,
+) -> String {
+    format!(
+        "[Scheduled Task Context]\nTask: {task_name}\nSchedule: {schedule_desc}\n\nRules:\n1. Execute the task directly — do NOT ask clarifying questions.\n2. Focus on producing useful, actionable output.\n3. If the task requires external data (news, weather, etc.), search for the latest information.\n[/Scheduled Task Context]\n\n{user_prompt}"
+    )
+}
+
+/// New-conversation mode without a saved skill for agents that need the
+/// `SKILL_SUGGEST.md` request inline.
+pub fn build_new_conversation_prompt_with_skill_suggest(
+    task_name: &str,
+    schedule_desc: &str,
+    user_prompt: &str,
+) -> String {
+    format!(
+        "[Scheduled Task Context]\nTask: {task_name}\nSchedule: {schedule_desc}\n\nRules:\n1. Execute the task directly — do NOT ask clarifying questions.\n2. Focus on producing useful, actionable output.\n3. If the task requires external data (news, weather, etc.), search for the latest information.\n4. After completing the task above, create a file named \"{SKILL_SUGGEST_FILENAME}\" in the current working directory (see instructions at the end).\n[/Scheduled Task Context]\n\n{user_prompt}\n\n---\n\n[Post-Task] After you have fully completed the task above, create a file named \"{SKILL_SUGGEST_FILENAME}\" in the current working directory to help future runs stay consistent. The file should follow this format:\n\n```markdown\n---\nname: <short kebab-case name, e.g. daily-greeting>\ndescription: <one-line description of what this task does>\n---\n\n<Instructions capturing the pattern you used: output format, tone, sources checked, steps taken, quality criteria. Use concrete details from this execution, not placeholders.>\n```\n\nIf you think the task is too simple or one-off to benefit from a skill file, you can skip this step."
+    )
+}
+
+/// New-conversation mode with an existing saved skill already linked into the
+/// agent workspace.
+pub fn build_new_conversation_with_skill_prompt(task_name: &str, user_prompt: &str) -> String {
+    format!(
+        "[Scheduled Task Context]\nTask: {task_name}\n\nThis is a scheduled task execution. A skill file with detailed instructions has been loaded\ninto your workspace. You MUST read and follow the skill instructions precisely.\n\nRules:\n1. Execute the task directly — do NOT ask clarifying questions.\n2. Follow the output format, tone, sources, and steps defined in the skill.\n3. If the task requires external data (news, weather, etc.), search for the latest information.\n[/Scheduled Task Context]\n\n{user_prompt}"
+    )
+}
+
+/// Existing-conversation mode: wrap the raw task text so the model treats it as
+/// an automatic task instruction rather than as user chat.
+pub fn build_existing_conversation_prompt(
+    task_name: &str,
+    schedule_desc: &str,
+    user_prompt: &str,
+) -> String {
+    format!(
+        "[Scheduled Task Execution]\nTask: {task_name}\nSchedule: {schedule_desc}\n\nThis message is NOT a conversation from the user — it is a scheduled task triggered automatically.\nThe text below is a TASK INSTRUCTION that you must execute, not something the user is saying to you.\n\nRules:\n1. Treat the instruction as a command to perform, not as a chat message to respond to.\n2. Execute it directly — do NOT ask clarifying questions.\n3. If the task requires external data (news, weather, etc.), search for the latest information.\n\nTask instruction:\n{user_prompt}"
+    )
+}
+
+/// Follow-up request asking the agent to write `SKILL_SUGGEST.md` after it has
+/// already completed the recurring task.
+pub fn build_skill_suggest_prompt(task_name: &str) -> String {
+    format!(
+        "The task \"{task_name}\" is a recurring scheduled task. Based on what you just did, please create a file named \"{SKILL_SUGGEST_FILENAME}\" in the current working directory to help future runs stay consistent.\n\nThe file should follow this format:\n\n```markdown\n---\nname: <short kebab-case name, e.g. daily-greeting>\ndescription: <one-line description of what this task does>\n---\n\n<Instructions capturing the pattern you used: output format, tone, sources checked, steps taken, quality criteria. Use concrete details from this execution, not placeholders.>\n```\n\nIf you think the task is too simple or one-off to benefit from a skill file, you can skip this."
+    )
+}

--- a/crates/aionui-cron/src/routes.rs
+++ b/crates/aionui-cron/src/routes.rs
@@ -1,7 +1,7 @@
 use axum::Router;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{Extension, Json, Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::routing::{get, post};
 
 use aionui_api_types::{
@@ -22,11 +22,15 @@ pub fn cron_routes(state: CronRouterState) -> Router {
             get(get_job).put(update_job).delete(delete_job),
         )
         .route("/api/cron/jobs/{id}/run", post(run_now))
+        .route("/api/cron/internal/system-resume", post(system_resume))
         .route(
             "/api/cron/jobs/{id}/conversations",
             get(list_conversations_by_cron_job),
         )
-        .route("/api/cron/jobs/{id}/skill", get(has_skill).post(save_skill))
+        .route(
+            "/api/cron/jobs/{id}/skill",
+            get(has_skill).post(save_skill).delete(delete_skill),
+        )
         .with_state(state)
 }
 
@@ -89,6 +93,22 @@ async fn run_now(
     Ok(Json(ApiResponse::ok(resp)))
 }
 
+async fn system_resume(
+    State(state): State<CronRouterState>,
+    headers: HeaderMap,
+) -> Result<Json<ApiResponse<()>>, AppError> {
+    let is_internal = headers
+        .get("x-aionui-internal")
+        .and_then(|value| value.to_str().ok())
+        == Some("1");
+    if !is_internal {
+        return Err(AppError::Forbidden("internal route".into()));
+    }
+
+    state.cron_service.handle_system_resume().await;
+    Ok(Json(ApiResponse::success()))
+}
+
 async fn save_skill(
     State(state): State<CronRouterState>,
     Extension(_user): Extension<CurrentUser>,
@@ -119,4 +139,13 @@ async fn has_skill(
 ) -> Result<Json<ApiResponse<HasSkillResponse>>, AppError> {
     let resp = state.cron_service.has_skill(&id).await?;
     Ok(Json(ApiResponse::ok(resp)))
+}
+
+async fn delete_skill(
+    State(state): State<CronRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+) -> Result<Json<ApiResponse<()>>, AppError> {
+    state.cron_service.delete_skill(&id).await?;
+    Ok(Json(ApiResponse::success()))
 }

--- a/crates/aionui-cron/src/scheduler.rs
+++ b/crates/aionui-cron/src/scheduler.rs
@@ -88,6 +88,9 @@ pub fn validate_schedule(schedule: &CronSchedule) -> Result<(), CronError> {
             Ok(())
         }
         CronSchedule::Cron { expr, tz, .. } => {
+            if expr.trim().is_empty() {
+                return Ok(());
+            }
             validate_cron_expression(expr)?;
             if let Some(tz_str) = tz {
                 validate_timezone(tz_str)?;
@@ -394,6 +397,17 @@ mod tests {
             description: None,
         };
         assert!(validate_schedule(&s).is_ok());
+    }
+
+    #[test]
+    fn validate_cron_empty_expr_is_manual_only() {
+        let s = CronSchedule::Cron {
+            expr: String::new(),
+            tz: None,
+            description: Some("manual".into()),
+        };
+        assert!(validate_schedule(&s).is_ok());
+        assert_eq!(compute_next_run(&s, 1000), None);
     }
 
     #[test]

--- a/crates/aionui-cron/src/service.rs
+++ b/crates/aionui-cron/src/service.rs
@@ -381,6 +381,9 @@ impl CronService {
             ..Default::default()
         };
         self.repo.update(job_id, &params).await?;
+        self.executor
+            .mark_skill_suggest_artifacts_saved(job_id)
+            .await?;
 
         info!(job_id, "Skill content saved");
         Ok(())

--- a/crates/aionui-cron/src/service.rs
+++ b/crates/aionui-cron/src/service.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -5,7 +6,7 @@ use aionui_api_types::{
     CreateCronJobRequest, CronJobResponse, CronScheduleDto, HasSkillResponse, ListCronJobsQuery,
     RunNowResponse, SaveCronSkillRequest, UpdateCronJobRequest,
 };
-use aionui_common::{generate_prefixed_id, now_ms};
+use aionui_common::{ProviderWithModel, generate_prefixed_id, now_ms};
 use aionui_db::{ICronRepository, UpdateCronJobParams};
 use tracing::{error, info, warn};
 
@@ -14,6 +15,9 @@ use crate::events::CronEventEmitter;
 use crate::error::CronError;
 use crate::executor::{ExecutionResult, JobExecutor, RETRY_INTERVAL_MS};
 use crate::scheduler::{CronScheduler, compute_next_run, validate_schedule};
+use crate::skill_file::{
+    delete_skill_file, has_skill_file, write_raw_skill_file, write_skill_file,
+};
 use crate::types::{
     CreatedBy, CronAgentConfig, CronJob, CronSchedule, ExecutionMode, cron_job_from_row,
     cron_job_to_response, cron_job_to_row, schedule_from_dto,
@@ -32,11 +36,13 @@ const PLACEHOLDER_PATTERNS: &[&str] = &[
     "put your",
 ];
 
+#[derive(Clone)]
 pub struct CronService {
     repo: Arc<dyn ICronRepository>,
     scheduler: Arc<CronScheduler>,
     executor: Arc<JobExecutor>,
     emitter: CronEventEmitter,
+    data_dir: PathBuf,
 }
 
 impl CronService {
@@ -45,12 +51,14 @@ impl CronService {
         scheduler: Arc<CronScheduler>,
         executor: Arc<JobExecutor>,
         emitter: CronEventEmitter,
+        data_dir: PathBuf,
     ) -> Self {
         Self {
             repo,
             scheduler,
             executor,
             emitter,
+            data_dir,
         }
     }
 
@@ -95,7 +103,7 @@ impl CronService {
             agent_type: req.agent_type,
             created_by,
             skill_content: None,
-            description: None,
+            description: req.description,
             created_at: now,
             updated_at: now,
             next_run_at,
@@ -109,6 +117,7 @@ impl CronService {
 
         let row = cron_job_to_row(&job)?;
         self.repo.insert(&row).await?;
+        self.bind_existing_conversation_if_needed(&job).await;
         self.scheduler.schedule_job(&job);
         self.emitter.emit_job_created(&cron_job_to_response(&job));
 
@@ -130,6 +139,9 @@ impl CronService {
 
         if let Some(name) = &req.name {
             job.name = name.clone();
+        }
+        if let Some(description) = &req.description {
+            job.description = Some(description.clone());
         }
         if let Some(enabled) = req.enabled {
             job.enabled = enabled;
@@ -175,6 +187,7 @@ impl CronService {
         let params = build_update_params(&job, &req);
         self.repo.update(job_id, &params).await?;
 
+        self.bind_existing_conversation_if_needed(&job).await;
         self.scheduler.reschedule_job(&job);
         self.emitter.emit_job_updated(&cron_job_to_response(&job));
 
@@ -184,6 +197,9 @@ impl CronService {
 
     pub async fn remove_job(&self, job_id: &str) -> Result<(), CronError> {
         self.scheduler.cancel_job(job_id);
+        if let Err(err) = delete_skill_file(&self.data_dir, job_id).await {
+            warn!(job_id, error = %err, "Failed to delete cron skill file during job removal");
+        }
         self.repo.delete(job_id).await?;
         self.emitter.emit_job_removed(job_id);
         info!(job_id, "Cron job removed");
@@ -303,9 +319,15 @@ impl CronService {
             if let Some(next_run) = job.next_run_at
                 && next_run < now
             {
-                info!(job_id = %job.id, "Resume: missed job, executing immediately");
-                let result = self.executor.execute(&job).await;
-                self.handle_execution_result(job, result).await;
+                info!(
+                    job_id = %job.id,
+                    conversation_id = %job.conversation_id,
+                    "Resume: missed job detected, marking missed without auto-execution"
+                );
+                self.record_missed_execution(&job).await;
+                self.insert_missed_job_tips(&job).await;
+                self.reschedule_after_missed(&job).await;
+                self.emitter.emit_job_executed(&job.id, "missed", None);
                 continue;
             }
 
@@ -322,24 +344,17 @@ impl CronService {
             .await?
             .ok_or_else(|| CronError::JobNotFound(job_id.to_owned()))?;
         let job = cron_job_from_row(row)?;
+        let prepared = self.executor.prepare_run_now(&job).await?;
+        let conversation_id = prepared.conversation_id.clone();
+        let service = self.clone();
+        let job_id = job.id.clone();
 
-        let result = self.executor.execute_run_now(&job).await;
+        tokio::spawn(async move {
+            let result = service.executor.execute_prepared(&job, prepared).await;
+            service.handle_run_now_result(&job_id, result).await;
+        });
 
-        match result {
-            ExecutionResult::Success { conversation_id } => {
-                self.update_job_after_success(job_id, &conversation_id)
-                    .await;
-                self.emitter.emit_job_executed(job_id, "ok", None);
-                Ok(RunNowResponse { conversation_id })
-            }
-            ExecutionResult::Error { message } => {
-                self.update_job_after_error(job_id, &message).await;
-                self.emitter
-                    .emit_job_executed(job_id, "error", Some(&message));
-                Err(CronError::Scheduler(message))
-            }
-            _ => Err(CronError::Scheduler("unexpected execution result".into())),
-        }
+        Ok(RunNowResponse { conversation_id })
     }
 
     // -----------------------------------------------------------------------
@@ -351,12 +366,15 @@ impl CronService {
         job_id: &str,
         req: SaveCronSkillRequest,
     ) -> Result<(), CronError> {
-        self.repo
+        let row = self
+            .repo
             .get_by_id(job_id)
             .await?
             .ok_or_else(|| CronError::JobNotFound(job_id.to_owned()))?;
 
-        validate_skill_content(&req.content)?;
+        validate_skill_body_content(&req.content)?;
+        let job = cron_job_from_row(row)?;
+        persist_skill_file(&self.data_dir, &job, &req.content).await?;
 
         let params = UpdateCronJobParams {
             skill_content: Some(Some(req.content)),
@@ -375,7 +393,11 @@ impl CronService {
             .await?
             .ok_or_else(|| CronError::JobNotFound(job_id.to_owned()))?;
 
-        let has_skill = row.skill_content.as_ref().is_some_and(|s| !s.is_empty());
+        let has_skill = has_skill_file(&self.data_dir, job_id).await?
+            || row
+                .skill_content
+                .as_ref()
+                .is_some_and(|s| !s.trim().is_empty());
 
         Ok(HasSkillResponse { has_skill })
     }
@@ -385,6 +407,8 @@ impl CronService {
             .get_by_id(job_id)
             .await?
             .ok_or_else(|| CronError::JobNotFound(job_id.to_owned()))?;
+
+        delete_skill_file(&self.data_dir, job_id).await?;
 
         let params = UpdateCronJobParams {
             skill_content: Some(None),
@@ -404,19 +428,50 @@ impl CronService {
         cron_job_to_response(job)
     }
 
+    async fn bind_existing_conversation_if_needed(&self, job: &CronJob) {
+        if !matches!(job.execution_mode, ExecutionMode::Existing)
+            || job.conversation_id.trim().is_empty()
+        {
+            return;
+        }
+
+        if let Err(err) = self
+            .executor
+            .bind_cron_job_to_conversation(&job.conversation_id, &job.id)
+            .await
+        {
+            warn!(
+                conversation_id = %job.conversation_id,
+                job_id = %job.id,
+                error = %err,
+                "Failed to bind existing-conversation cron job to conversation"
+            );
+        }
+    }
+
     async fn is_orphan(&self, job: &CronJob) -> bool {
-        match self.executor.busy_guard().is_busy(&job.conversation_id) {
-            true => false,
-            false => {
-                // Check if conversation still exists via repo
-                // The executor holds a conversation_repo reference but we
-                // use the cron repo's list_by_conversation as a proxy isn't right.
-                // We re-verify by attempting tick-level check — for init we
-                // just check the job's conversation existence.
-                // Since we don't have direct conversation_repo access here,
-                // delegate orphan detection to a simple heuristic: if the
-                // conversation_id is empty, it's an orphan.
-                job.conversation_id.is_empty()
+        if self.executor.busy_guard().is_busy(&job.conversation_id) {
+            return false;
+        }
+
+        if job.conversation_id.trim().is_empty() {
+            return true;
+        }
+
+        match self
+            .executor
+            .conversation_exists(&job.conversation_id)
+            .await
+        {
+            Ok(exists) => !exists,
+            Err(err) => {
+                warn!(
+                    job_id = %job.id,
+                    conversation_id = %job.conversation_id,
+                    error = %err,
+                    "Failed to verify cron conversation during orphan cleanup"
+                );
+                false
             }
         }
     }
@@ -458,6 +513,49 @@ impl CronService {
                 self.reschedule_after_execution(&job).await;
                 self.emitter
                     .emit_job_executed(job_id, "error", Some(&message));
+            }
+        }
+    }
+
+    async fn handle_run_now_result(&self, job_id: &str, result: ExecutionResult) {
+        match result {
+            ExecutionResult::Success { conversation_id } => {
+                self.update_job_after_success(job_id, &conversation_id)
+                    .await;
+                self.emitter.emit_job_executed(job_id, "ok", None);
+            }
+            ExecutionResult::Error { message } => {
+                self.update_job_after_error(job_id, &message).await;
+                self.emitter
+                    .emit_job_executed(job_id, "error", Some(&message));
+            }
+            ExecutionResult::Retrying { attempt } => {
+                let params = UpdateCronJobParams {
+                    retry_count: Some(attempt),
+                    ..Default::default()
+                };
+                if let Err(err) = self.repo.update(job_id, &params).await {
+                    error!(
+                        job_id,
+                        error = %err,
+                        "Failed to update run-now retry count"
+                    );
+                }
+            }
+            ExecutionResult::Skipped => {
+                let params = UpdateCronJobParams {
+                    last_status: Some(Some("skipped".into())),
+                    retry_count: Some(0),
+                    ..Default::default()
+                };
+                if let Err(err) = self.repo.update(job_id, &params).await {
+                    error!(
+                        job_id,
+                        error = %err,
+                        "Failed to update run-now skipped status"
+                    );
+                }
+                self.emitter.emit_job_executed(job_id, "skipped", None);
             }
         }
     }
@@ -549,6 +647,92 @@ impl CronService {
         self.scheduler.reschedule_job(&updated);
     }
 
+    async fn record_missed_execution(&self, job: &CronJob) {
+        let params = UpdateCronJobParams {
+            last_status: Some(Some("missed".into())),
+            last_error: Some(None),
+            retry_count: Some(0),
+            ..Default::default()
+        };
+        if let Err(err) = self.repo.update(&job.id, &params).await {
+            error!(
+                job_id = %job.id,
+                error = %err,
+                "Failed to mark cron job as missed"
+            );
+        }
+    }
+
+    async fn insert_missed_job_tips(&self, job: &CronJob) {
+        if job.conversation_id.trim().is_empty() {
+            return;
+        }
+
+        let content = format!(
+            "Scheduled task \"{}\" was missed while the system was unavailable. It was not run automatically.",
+            job.name
+        );
+
+        match self
+            .executor
+            .insert_tips_message(&job.conversation_id, &content, "warning")
+            .await
+        {
+            Ok(()) => {
+                self.emitter
+                    .emit_conversation_tips(&job.conversation_id, &content, "warning")
+            }
+            Err(err) => {
+                warn!(
+                    job_id = %job.id,
+                    conversation_id = %job.conversation_id,
+                    error = %err,
+                    "Failed to persist missed-job tips message"
+                );
+            }
+        }
+    }
+
+    async fn reschedule_after_missed(&self, job: &CronJob) {
+        let is_at = matches!(job.schedule, CronSchedule::At { .. });
+        if is_at {
+            let params = UpdateCronJobParams {
+                enabled: Some(false),
+                next_run_at: Some(None),
+                ..Default::default()
+            };
+            if let Err(err) = self.repo.update(&job.id, &params).await {
+                error!(
+                    job_id = %job.id,
+                    error = %err,
+                    "Failed to disable missed at-type job"
+                );
+            }
+            self.scheduler.cancel_job(&job.id);
+            return;
+        }
+
+        let next = compute_next_run(&job.schedule, now_ms());
+        let params = UpdateCronJobParams {
+            next_run_at: Some(next),
+            ..Default::default()
+        };
+        if let Err(err) = self.repo.update(&job.id, &params).await {
+            error!(
+                job_id = %job.id,
+                error = %err,
+                "Failed to reschedule missed cron job"
+            );
+            return;
+        }
+
+        let updated = CronJob {
+            next_run_at: next,
+            ..job.clone()
+        };
+        self.scheduler.reschedule_job(&updated);
+    }
+
     fn schedule_retry(&self, job_id: &str, _attempt: i64) {
         let next_run = now_ms() + RETRY_INTERVAL_MS as i64;
         let retry_job = CronJob {
@@ -636,24 +820,61 @@ impl aionui_ai_agent::middleware::ICronService for CronService {
             description: Some(params.schedule_description.clone()),
         };
 
+        let (agent_type, conversation_title, agent_config) = match self
+            .executor
+            .get_conversation_row(conversation_id)
+            .await
+        {
+            Ok(Some(row)) => {
+                let title = Some(row.name.clone());
+                let (agent_type, agent_config) = build_agent_config_from_conversation(&row);
+                (agent_type, title, agent_config)
+            }
+            Ok(None) => ("acp".to_owned(), None, None),
+            Err(err) => {
+                warn!(
+                    conversation_id,
+                    error = %err,
+                    "Failed to load conversation context for cron create; falling back to defaults"
+                );
+                ("acp".to_owned(), None, None)
+            }
+        };
+
         let req = CreateCronJobRequest {
             name: params.name.clone(),
+            description: None,
             schedule: schedule_dto,
             prompt: None,
             message: Some(params.message.clone()),
             conversation_id: conversation_id.to_owned(),
-            conversation_title: None,
-            agent_type: "acp".to_owned(),
+            conversation_title,
+            agent_type,
             created_by: "agent".to_owned(),
             execution_mode: Some("existing".to_owned()),
-            agent_config: None,
+            agent_config,
         };
 
         match self.add_job(req).await {
-            Ok(job) => aionui_ai_agent::middleware::CronCommandResult {
-                success: true,
-                message: format!("Created cron job '{}' ({})", job.name, job.id),
-            },
+            Ok(job) => {
+                if let Err(err) = self
+                    .executor
+                    .bind_cron_job_to_conversation(conversation_id, &job.id)
+                    .await
+                {
+                    warn!(
+                        conversation_id,
+                        job_id = %job.id,
+                        error = %err,
+                        "Cron job created but failed to bind conversation to job"
+                    );
+                }
+
+                aionui_ai_agent::middleware::CronCommandResult {
+                    success: true,
+                    message: format!("Created cron job '{}' ({})", job.name, job.id),
+                }
+            }
             Err(e) => aionui_ai_agent::middleware::CronCommandResult {
                 success: false,
                 message: e.to_string(),
@@ -661,14 +882,72 @@ impl aionui_ai_agent::middleware::ICronService for CronService {
         }
     }
 
-    async fn list_jobs(&self, _user_id: &str) -> aionui_ai_agent::middleware::CronCommandResult {
-        let query = ListCronJobsQuery::default();
+    async fn update_job(
+        &self,
+        _user_id: &str,
+        conversation_id: &str,
+        params: &aionui_ai_agent::middleware::CronUpdateParams,
+    ) -> aionui_ai_agent::middleware::CronCommandResult {
+        let req = UpdateCronJobRequest {
+            name: Some(params.name.clone()),
+            description: None,
+            enabled: None,
+            schedule: Some(CronScheduleDto::Cron {
+                expr: params.schedule.clone(),
+                tz: None,
+                description: Some(params.schedule_description.clone()),
+            }),
+            message: Some(params.message.clone()),
+            execution_mode: None,
+            agent_config: None,
+            conversation_title: None,
+            max_retries: None,
+        };
+
+        match self.update_job(&params.job_id, req).await {
+            Ok(job) => {
+                if let Err(err) = self
+                    .executor
+                    .bind_cron_job_to_conversation(conversation_id, &job.id)
+                    .await
+                {
+                    warn!(
+                        conversation_id,
+                        job_id = %job.id,
+                        error = %err,
+                        "Cron job updated but failed to bind conversation to job"
+                    );
+                }
+
+                aionui_ai_agent::middleware::CronCommandResult {
+                    success: true,
+                    message: format!("Updated cron job '{}' ({})", job.name, job.id),
+                }
+            }
+            Err(e) => aionui_ai_agent::middleware::CronCommandResult {
+                success: false,
+                message: e.to_string(),
+            },
+        }
+    }
+
+    async fn list_jobs(
+        &self,
+        _user_id: &str,
+        conversation_id: &str,
+    ) -> aionui_ai_agent::middleware::CronCommandResult {
+        let query = ListCronJobsQuery {
+            conversation_id: Some(conversation_id.to_owned()),
+        };
         match self.list_jobs(&query).await {
             Ok(jobs) => {
                 if jobs.is_empty() {
                     return aionui_ai_agent::middleware::CronCommandResult {
                         success: true,
-                        message: "No cron jobs found.".into(),
+                        message: format!(
+                            "No cron jobs found for conversation '{}'.",
+                            conversation_id
+                        ),
                     };
                 }
 
@@ -682,7 +961,12 @@ impl aionui_ai_agent::middleware::ICronService for CronService {
 
                 aionui_ai_agent::middleware::CronCommandResult {
                     success: true,
-                    message: format!("Found {} cron job(s):\n{}", jobs.len(), lines.join("\n")),
+                    message: format!(
+                        "Found {} cron job(s) for conversation '{}':\n{}",
+                        jobs.len(),
+                        conversation_id,
+                        lines.join("\n")
+                    ),
                 }
             }
             Err(e) => aionui_ai_agent::middleware::CronCommandResult {
@@ -710,6 +994,117 @@ impl aionui_ai_agent::middleware::ICronService for CronService {
     }
 }
 
+fn build_agent_config_from_conversation(
+    row: &aionui_db::models::ConversationRow,
+) -> (String, Option<aionui_api_types::CronAgentConfigDto>) {
+    let extra = serde_json::from_str::<serde_json::Value>(&row.extra)
+        .unwrap_or_else(|_| serde_json::json!({}));
+    let model = parse_provider_with_model_loose(row.model.as_deref());
+
+    let backend = if row.r#type == "aionrs" {
+        model
+            .as_ref()
+            .map(|value| value.provider_id.clone())
+            .filter(|value| !value.is_empty())
+            .or_else(|| get_string(&extra, &["backend"]))
+            .unwrap_or_else(|| "aionrs".to_owned())
+    } else {
+        get_string(&extra, &["backend"])
+            .or_else(|| {
+                model
+                    .as_ref()
+                    .map(|value| value.provider_id.clone())
+                    .filter(|value| !value.is_empty())
+            })
+            .unwrap_or_else(|| row.r#type.clone())
+    };
+
+    let preset_assistant_id = get_string(&extra, &["preset_assistant_id", "presetAssistantId"]);
+    let custom_agent_id =
+        get_string(&extra, &["custom_agent_id", "customAgentId"]).or(preset_assistant_id.clone());
+    let is_preset = preset_assistant_id.as_ref().map(|_| true);
+    let preset_agent_type = if preset_assistant_id.is_some() {
+        Some(backend.clone())
+    } else {
+        None
+    };
+
+    let agent_config = aionui_api_types::CronAgentConfigDto {
+        backend,
+        name: get_string(&extra, &["agent_name", "agentName"]).unwrap_or_else(|| row.name.clone()),
+        cli_path: get_string(&extra, &["cli_path", "cliPath"]).or_else(|| {
+            extra
+                .get("gateway")
+                .and_then(|gateway| gateway.get("cli_path").or_else(|| gateway.get("cliPath")))
+                .and_then(|value| value.as_str())
+                .map(ToOwned::to_owned)
+        }),
+        is_preset,
+        custom_agent_id,
+        preset_agent_type,
+        mode: get_string(&extra, &["session_mode", "sessionMode"]),
+        model_id: get_string(&extra, &["current_model_id", "currentModelId"]).or_else(|| {
+            model.as_ref().and_then(|value| {
+                value
+                    .use_model
+                    .clone()
+                    .or_else(|| (!value.model.is_empty()).then(|| value.model.clone()))
+            })
+        }),
+        config_options: None,
+        workspace: get_string(&extra, &["workspace"]),
+    };
+
+    (row.r#type.clone(), Some(agent_config))
+}
+
+fn get_string(extra: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    keys.iter().find_map(|key| {
+        extra
+            .get(*key)
+            .and_then(|value| value.as_str())
+            .map(ToOwned::to_owned)
+            .filter(|value| !value.is_empty())
+    })
+}
+
+fn parse_provider_with_model_loose(model_json: Option<&str>) -> Option<ProviderWithModel> {
+    let raw = model_json?;
+
+    if let Ok(model) = serde_json::from_str::<ProviderWithModel>(raw) {
+        return Some(model);
+    }
+
+    let value = serde_json::from_str::<serde_json::Value>(raw).ok()?;
+    let provider_id = value
+        .get("provider_id")
+        .or_else(|| value.get("providerId"))
+        .or_else(|| value.get("id"))
+        .and_then(|item| item.as_str())
+        .unwrap_or_default()
+        .to_owned();
+    let model = value
+        .get("model")
+        .and_then(|item| item.as_str())
+        .unwrap_or_default()
+        .to_owned();
+    let use_model = value
+        .get("use_model")
+        .or_else(|| value.get("useModel"))
+        .and_then(|item| item.as_str())
+        .map(ToOwned::to_owned);
+
+    if provider_id.is_empty() {
+        return None;
+    }
+
+    Some(ProviderWithModel {
+        provider_id,
+        model,
+        use_model,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Free functions
 // ---------------------------------------------------------------------------
@@ -721,7 +1116,7 @@ fn parse_execution_mode(mode: Option<&str>) -> Result<ExecutionMode, CronError> 
     }
 }
 
-fn validate_skill_content(content: &str) -> Result<(), CronError> {
+fn validate_skill_body_content(content: &str) -> Result<(), CronError> {
     let trimmed = content.trim();
 
     if trimmed.is_empty() {
@@ -740,6 +1135,41 @@ fn validate_skill_content(content: &str) -> Result<(), CronError> {
     }
 
     Ok(())
+}
+
+fn schedule_description(schedule: &CronSchedule) -> Option<&str> {
+    match schedule {
+        CronSchedule::At { description, .. }
+        | CronSchedule::Every { description, .. }
+        | CronSchedule::Cron { description, .. } => description.as_deref(),
+    }
+}
+
+async fn persist_skill_file(
+    data_dir: &PathBuf,
+    job: &CronJob,
+    raw_content: &str,
+) -> Result<(), CronError> {
+    match write_raw_skill_file(data_dir, &job.id, raw_content).await {
+        Ok(_) => Ok(()),
+        Err(CronError::InvalidSkillContent(_)) => {
+            let description = job
+                .description
+                .clone()
+                .unwrap_or_else(|| format!("Saved cron skill for {}", job.name));
+            write_skill_file(
+                data_dir,
+                &job.id,
+                &job.name,
+                &description,
+                raw_content.trim(),
+                schedule_description(&job.schedule),
+            )
+            .await
+            .map(|_| ())
+        }
+        Err(err) => Err(err),
+    }
 }
 
 fn build_update_params(job: &CronJob, req: &UpdateCronJobRequest) -> UpdateCronJobParams {
@@ -781,7 +1211,7 @@ fn build_update_params(job: &CronJob, req: &UpdateCronJobRequest) -> UpdateCronJ
         conversation_title: req.conversation_title.as_ref().map(|t| Some(t.clone())),
         agent_type: None,
         skill_content: None,
-        description: None,
+        description: req.description.as_ref().map(|value| Some(value.clone())),
         next_run_at: if req.schedule.is_some() || req.enabled.is_some() {
             Some(job.next_run_at)
         } else {
@@ -835,46 +1265,46 @@ fn schedule_to_row_fields(
 mod tests {
     use super::*;
 
-    // -- validate_skill_content -----------------------------------------------
+    // -- validate_skill_body_content -------------------------------------------
 
     #[test]
     fn validate_skill_empty_content() {
-        let err = validate_skill_content("").unwrap_err();
+        let err = validate_skill_body_content("").unwrap_err();
         assert!(matches!(err, CronError::InvalidSkillContent(_)));
     }
 
     #[test]
     fn validate_skill_whitespace_only() {
-        let err = validate_skill_content("   \n  ").unwrap_err();
+        let err = validate_skill_body_content("   \n  ").unwrap_err();
         assert!(matches!(err, CronError::InvalidSkillContent(_)));
     }
 
     #[test]
     fn validate_skill_placeholder_todo() {
-        let err = validate_skill_content("TODO: fill in later").unwrap_err();
+        let err = validate_skill_body_content("TODO: fill in later").unwrap_err();
         assert!(matches!(err, CronError::InvalidSkillContent(_)));
     }
 
     #[test]
     fn validate_skill_placeholder_fill_in() {
-        let err = validate_skill_content("Fill in your instructions here").unwrap_err();
+        let err = validate_skill_body_content("Fill in your instructions here").unwrap_err();
         assert!(matches!(err, CronError::InvalidSkillContent(_)));
     }
 
     #[test]
     fn validate_skill_placeholder_replace() {
-        let err = validate_skill_content("Replace this with your skill").unwrap_err();
+        let err = validate_skill_body_content("Replace this with your skill").unwrap_err();
         assert!(matches!(err, CronError::InvalidSkillContent(_)));
     }
 
     #[test]
     fn validate_skill_valid_content() {
-        assert!(validate_skill_content("---\nname: test\n---\nDo something useful").is_ok());
+        assert!(validate_skill_body_content("---\nname: test\n---\nDo something useful").is_ok());
     }
 
     #[test]
     fn validate_skill_valid_short() {
-        assert!(validate_skill_content("Run daily report").is_ok());
+        assert!(validate_skill_body_content("Run daily report").is_ok());
     }
 
     // -- parse_execution_mode -------------------------------------------------
@@ -943,6 +1373,7 @@ mod tests {
         let job = sample_job();
         let req = UpdateCronJobRequest {
             name: Some("New Name".into()),
+            description: None,
             enabled: None,
             schedule: None,
             message: None,
@@ -971,6 +1402,7 @@ mod tests {
         };
         let req = UpdateCronJobRequest {
             name: None,
+            description: None,
             enabled: None,
             schedule: Some(CronScheduleDto::Cron {
                 expr: "0 0 9 * * *".into(),
@@ -994,6 +1426,7 @@ mod tests {
         let job = sample_job();
         let req = UpdateCronJobRequest {
             name: None,
+            description: None,
             enabled: Some(false),
             schedule: None,
             message: None,
@@ -1005,6 +1438,30 @@ mod tests {
         let params = build_update_params(&job, &req);
         assert_eq!(params.enabled, Some(false));
         assert!(params.next_run_at.is_some());
+    }
+
+    #[test]
+    fn build_update_params_description_only() {
+        let job = sample_job();
+        let req = UpdateCronJobRequest {
+            name: None,
+            description: Some("Updated description".into()),
+            enabled: None,
+            schedule: None,
+            message: None,
+            execution_mode: None,
+            agent_config: None,
+            conversation_title: None,
+            max_retries: None,
+        };
+        let params = build_update_params(&job, &req);
+        assert_eq!(
+            params
+                .description
+                .as_ref()
+                .and_then(|value| value.as_deref()),
+            Some("Updated description")
+        );
     }
 
     // -- schedule_to_row_fields -----------------------------------------------

--- a/crates/aionui-cron/src/skill_file.rs
+++ b/crates/aionui-cron/src/skill_file.rs
@@ -1,0 +1,311 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tokio::fs;
+
+use crate::error::CronError;
+
+pub const CRON_SKILLS_REL_DIR: &str = "cron/skills";
+pub const CRON_SKILL_DIR_PREFIX: &str = "cron-";
+pub const SKILL_FILE_NAME: &str = "SKILL.md";
+
+const PLACEHOLDER_PATTERNS: &[&str] = &[
+    "skill-name",
+    "one-line description",
+    "your-skill-name",
+    "your skill name",
+    "description of",
+];
+const PLACEHOLDER_BODY_PATTERNS: &[&str] = &[
+    "(full skill.md body",
+    "full skill.md body",
+    "(clear instructions for executing this task",
+    "<full instructions: output format, tone, sources to check",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedSkillContent {
+    pub name: String,
+    pub description: String,
+    pub body: String,
+}
+
+pub fn cron_skill_name(job_id: &str) -> Result<String, CronError> {
+    validate_job_id(job_id)?;
+    Ok(format!("{CRON_SKILL_DIR_PREFIX}{job_id}"))
+}
+
+pub fn cron_skill_dir(data_dir: &Path, job_id: &str) -> Result<PathBuf, CronError> {
+    Ok(data_dir
+        .join(CRON_SKILLS_REL_DIR)
+        .join(cron_skill_name(job_id)?))
+}
+
+pub fn cron_skill_file_path(data_dir: &Path, job_id: &str) -> Result<PathBuf, CronError> {
+    Ok(cron_skill_dir(data_dir, job_id)?.join(SKILL_FILE_NAME))
+}
+
+pub fn build_skill_content(
+    name: &str,
+    description: &str,
+    prompt: &str,
+    schedule_description: Option<&str>,
+) -> String {
+    let sanitized_desc = description
+        .replace("\r\n", "\n")
+        .replace('\r', "\n")
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let mut lines = vec![
+        "---".to_owned(),
+        format!("name: {name}"),
+        format!("description: {sanitized_desc}"),
+        "---".to_owned(),
+        String::new(),
+        format!("This is a scheduled task: **{name}**"),
+    ];
+
+    if let Some(schedule_description) = schedule_description {
+        lines.push(format!("Schedule: {schedule_description}"));
+    }
+
+    lines.extend([
+        String::new(),
+        "## Instructions".to_owned(),
+        String::new(),
+        "You are executing a scheduled task. Follow the instructions below directly.".to_owned(),
+        "Do NOT ask clarifying questions — just execute the task and produce the result."
+            .to_owned(),
+        String::new(),
+        prompt.to_owned(),
+    ]);
+
+    lines.join("\n")
+}
+
+pub fn parse_skill_content(content: &str) -> Result<ParsedSkillContent, CronError> {
+    let (name, description, body) = parse_frontmatter(content)?;
+    let prompt = extract_prompt_from_body(&body);
+    Ok(ParsedSkillContent {
+        name,
+        description,
+        body: prompt,
+    })
+}
+
+pub fn validate_skill_content(content: &str) -> Result<ParsedSkillContent, CronError> {
+    let (name, description, body) = parse_frontmatter(content)?;
+    let trimmed_body = body.trim();
+    if trimmed_body.is_empty() {
+        return Err(CronError::InvalidSkillContent(
+            "skill file body cannot be empty".into(),
+        ));
+    }
+    if is_placeholder(&name, PLACEHOLDER_PATTERNS) {
+        return Err(CronError::InvalidSkillContent(
+            "skill name looks like a template placeholder".into(),
+        ));
+    }
+    if is_placeholder(&description, PLACEHOLDER_PATTERNS) {
+        return Err(CronError::InvalidSkillContent(
+            "skill description looks like a template placeholder".into(),
+        ));
+    }
+    if is_placeholder(trimmed_body, PLACEHOLDER_BODY_PATTERNS) {
+        return Err(CronError::InvalidSkillContent(
+            "skill body looks like a template placeholder".into(),
+        ));
+    }
+
+    Ok(ParsedSkillContent {
+        name,
+        description,
+        body: trimmed_body.to_owned(),
+    })
+}
+
+pub fn content_hash(content: &str) -> String {
+    let normalized = normalize_for_hash(content);
+    let mut hasher = DefaultHasher::new();
+    normalized.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+pub async fn write_skill_file(
+    data_dir: &Path,
+    job_id: &str,
+    name: &str,
+    description: &str,
+    prompt: &str,
+    schedule_description: Option<&str>,
+) -> Result<PathBuf, CronError> {
+    let content = build_skill_content(name, description, prompt, schedule_description);
+    write_raw_skill_file(data_dir, job_id, &content).await
+}
+
+pub async fn write_raw_skill_file(
+    data_dir: &Path,
+    job_id: &str,
+    raw_content: &str,
+) -> Result<PathBuf, CronError> {
+    validate_skill_content(raw_content)?;
+
+    let dir = cron_skill_dir(data_dir, job_id)?;
+    let file_path = dir.join(SKILL_FILE_NAME);
+    fs::create_dir_all(&dir)
+        .await
+        .map_err(|err| CronError::InvalidSkillContent(err.to_string()))?;
+
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let temp_path = dir.join(format!(
+        "{SKILL_FILE_NAME}.tmp-{}-{nonce}",
+        std::process::id()
+    ));
+
+    fs::write(&temp_path, raw_content)
+        .await
+        .map_err(|err| CronError::InvalidSkillContent(err.to_string()))?;
+    fs::rename(&temp_path, &file_path)
+        .await
+        .map_err(|err| CronError::InvalidSkillContent(err.to_string()))?;
+
+    Ok(file_path)
+}
+
+pub async fn read_skill_content(
+    data_dir: &Path,
+    job_id: &str,
+) -> Result<Option<String>, CronError> {
+    let file_path = cron_skill_file_path(data_dir, job_id)?;
+    match fs::read_to_string(file_path).await {
+        Ok(content) => Ok(Some(content)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(CronError::InvalidSkillContent(err.to_string())),
+    }
+}
+
+pub async fn has_skill_file(data_dir: &Path, job_id: &str) -> Result<bool, CronError> {
+    let file_path = cron_skill_file_path(data_dir, job_id)?;
+    match fs::metadata(file_path).await {
+        Ok(metadata) => Ok(metadata.is_file()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(CronError::InvalidSkillContent(err.to_string())),
+    }
+}
+
+pub async fn delete_skill_file(data_dir: &Path, job_id: &str) -> Result<(), CronError> {
+    let dir = cron_skill_dir(data_dir, job_id)?;
+    match fs::remove_dir_all(dir).await {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(CronError::InvalidSkillContent(err.to_string())),
+    }
+}
+
+fn validate_job_id(job_id: &str) -> Result<(), CronError> {
+    if job_id.is_empty() || job_id.contains('/') || job_id.contains('\\') || job_id.contains("..") {
+        return Err(CronError::InvalidSkillContent(format!(
+            "invalid cron job id: {job_id}"
+        )));
+    }
+    Ok(())
+}
+
+fn parse_frontmatter(content: &str) -> Result<(String, String, String), CronError> {
+    let normalized = content.replace("\r\n", "\n").replace('\r', "\n");
+    let mut lines = normalized.lines();
+    if lines.next() != Some("---") {
+        return Err(CronError::InvalidSkillContent(
+            "skill file must start with YAML frontmatter".into(),
+        ));
+    }
+
+    let mut frontmatter = Vec::new();
+    let mut found_end = false;
+    for line in &mut lines {
+        if line == "---" {
+            found_end = true;
+            break;
+        }
+        frontmatter.push(line);
+    }
+    if !found_end {
+        return Err(CronError::InvalidSkillContent(
+            "skill file is missing the closing frontmatter delimiter".into(),
+        ));
+    }
+
+    let name = frontmatter
+        .iter()
+        .find_map(|line| line.strip_prefix("name:"))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| CronError::InvalidSkillContent("missing skill name".into()))?
+        .to_owned();
+    let description = frontmatter
+        .iter()
+        .find_map(|line| line.strip_prefix("description:"))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| CronError::InvalidSkillContent("missing skill description".into()))?
+        .to_owned();
+
+    let mut body_lines: Vec<&str> = lines.collect();
+    while matches!(body_lines.first(), Some(line) if line.is_empty()) {
+        body_lines.remove(0);
+    }
+    let body = body_lines.join("\n");
+    Ok((name, description, body))
+}
+
+fn extract_prompt_from_body(body: &str) -> String {
+    let instructions_idx = match body.find("## Instructions") {
+        Some(idx) => idx,
+        None => return body.trim_end().to_owned(),
+    };
+
+    let after_heading = &body[instructions_idx..];
+    let lines: Vec<&str> = after_heading.split('\n').collect();
+    let mut start_idx = lines.len();
+    for (idx, line) in lines.iter().enumerate().skip(1) {
+        let trimmed = line.trim();
+        if trimmed.is_empty()
+            || trimmed.starts_with("You are executing")
+            || trimmed.starts_with("Do NOT ask")
+        {
+            continue;
+        }
+        start_idx = idx;
+        break;
+    }
+
+    if start_idx >= lines.len() {
+        return String::new();
+    }
+
+    lines[start_idx..].join("\n").trim_end().to_owned()
+}
+
+fn is_placeholder(value: &str, patterns: &[&str]) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    patterns
+        .iter()
+        .any(|pattern| normalized.starts_with(pattern))
+}
+
+fn normalize_for_hash(content: &str) -> String {
+    content
+        .replace("\r\n", "\n")
+        .replace('\r', "\n")
+        .trim()
+        .to_owned()
+}

--- a/crates/aionui-cron/src/skill_suggest.rs
+++ b/crates/aionui-cron/src/skill_suggest.rs
@@ -1,0 +1,365 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use aionui_api_types::WebSocketMessage;
+use aionui_common::{generate_id, now_ms};
+use aionui_db::IConversationRepository;
+use aionui_db::models::MessageRow;
+use aionui_realtime::EventBroadcaster;
+use serde_json::json;
+use tokio::fs;
+use tokio::time::sleep;
+use tracing::{debug, warn};
+
+use crate::error::CronError;
+use crate::prompt::SKILL_SUGGEST_FILENAME;
+use crate::skill_file::{content_hash, has_skill_file, validate_skill_content};
+
+const RETRY_DELAYS_MS: [u64; 3] = [1000, 2000, 3000];
+
+#[derive(Clone)]
+pub struct SkillSuggestDetector {
+    broadcaster: Arc<dyn EventBroadcaster>,
+    conversation_repo: Arc<dyn IConversationRepository>,
+    data_dir: PathBuf,
+    last_hash_by_job: Arc<Mutex<HashMap<String, String>>>,
+}
+
+impl SkillSuggestDetector {
+    pub fn new(
+        broadcaster: Arc<dyn EventBroadcaster>,
+        conversation_repo: Arc<dyn IConversationRepository>,
+        data_dir: PathBuf,
+    ) -> Self {
+        Self {
+            broadcaster,
+            conversation_repo,
+            data_dir,
+            last_hash_by_job: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn schedule_check(&self, conversation_id: String, job_id: String, workspace: String) {
+        let detector = self.clone();
+        tokio::spawn(async move {
+            detector
+                .check_with_retry(&conversation_id, &job_id, &workspace)
+                .await;
+        });
+    }
+
+    async fn check_with_retry(&self, conversation_id: &str, job_id: &str, workspace: &str) {
+        for delay_ms in RETRY_DELAYS_MS {
+            sleep(Duration::from_millis(delay_ms)).await;
+            match self
+                .check_and_emit(conversation_id, job_id, workspace)
+                .await
+            {
+                Ok(true) => return,
+                Ok(false) => continue,
+                Err(err) => {
+                    warn!(
+                        conversation_id,
+                        job_id,
+                        error = %err,
+                        "Failed checking SKILL_SUGGEST.md"
+                    );
+                }
+            }
+        }
+    }
+
+    async fn check_and_emit(
+        &self,
+        conversation_id: &str,
+        job_id: &str,
+        workspace: &str,
+    ) -> Result<bool, CronError> {
+        if workspace.trim().is_empty() {
+            return Ok(false);
+        }
+
+        if has_skill_file(&self.data_dir, job_id).await? {
+            self.clear_last_hash(job_id);
+            return Ok(true);
+        }
+
+        let file_path = Path::new(workspace).join(SKILL_SUGGEST_FILENAME);
+        let content = match fs::read_to_string(&file_path).await {
+            Ok(content) => content,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(err) => {
+                return Err(CronError::InvalidSkillContent(err.to_string()));
+            }
+        };
+
+        if content.trim().is_empty() {
+            return Ok(false);
+        }
+
+        let validated = match validate_skill_content(&content) {
+            Ok(validated) => validated,
+            Err(_) => return Ok(false),
+        };
+
+        let hash = content_hash(&content);
+        if self.last_hash(job_id).as_deref() == Some(hash.as_str()) {
+            return Ok(true);
+        }
+
+        self.set_last_hash(job_id, hash);
+        self.emit(
+            conversation_id,
+            job_id,
+            &validated.name,
+            &validated.description,
+            &content,
+        )
+        .await;
+        Ok(true)
+    }
+
+    async fn emit(
+        &self,
+        conversation_id: &str,
+        job_id: &str,
+        name: &str,
+        description: &str,
+        skill_content: &str,
+    ) {
+        let msg_id = generate_id();
+        self.persist_and_broadcast(
+            conversation_id,
+            job_id,
+            name,
+            description,
+            skill_content,
+            &msg_id,
+        )
+        .await;
+    }
+
+    async fn persist_and_broadcast(
+        &self,
+        conversation_id: &str,
+        job_id: &str,
+        name: &str,
+        description: &str,
+        skill_content: &str,
+        msg_id: &str,
+    ) {
+        let content = json!({
+            "cron_job_id": job_id,
+            "name": name,
+            "description": description,
+            "skillContent": skill_content,
+        });
+
+        let row = MessageRow {
+            id: generate_id(),
+            conversation_id: conversation_id.to_owned(),
+            msg_id: Some(msg_id.to_owned()),
+            r#type: "skill_suggest".into(),
+            content: content.to_string(),
+            position: Some("center".into()),
+            status: Some("finish".into()),
+            hidden: false,
+            created_at: now_ms(),
+        };
+
+        if let Err(err) = self.conversation_repo.insert_message(&row).await {
+            warn!(
+                conversation_id,
+                job_id,
+                error = %err,
+                "Failed persisting cron skill suggestion message"
+            );
+        }
+
+        let payload = json!({
+            "conversation_id": conversation_id,
+            "msg_id": msg_id,
+            "type": "skill_suggest",
+            "data": {
+                "cron_job_id": job_id,
+                "name": name,
+                "description": description,
+                "skill_content": skill_content,
+            },
+            "hidden": false,
+        });
+
+        self.broadcaster
+            .broadcast(WebSocketMessage::new("message.stream", payload));
+        debug!(conversation_id, job_id, "Broadcasted cron skill suggestion");
+    }
+
+    fn last_hash(&self, job_id: &str) -> Option<String> {
+        self.last_hash_by_job
+            .lock()
+            .ok()
+            .and_then(|hashes| hashes.get(job_id).cloned())
+    }
+
+    fn set_last_hash(&self, job_id: &str, hash: String) {
+        if let Ok(mut hashes) = self.last_hash_by_job.lock() {
+            hashes.insert(job_id.to_owned(), hash);
+        }
+    }
+
+    fn clear_last_hash(&self, job_id: &str) {
+        if let Ok(mut hashes) = self.last_hash_by_job.lock() {
+            hashes.remove(job_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aionui_db::models::ConversationRow;
+    use aionui_db::{SortOrder, SqliteConversationRepository, init_database_memory};
+    use aionui_realtime::BroadcastEventBus;
+    use tempfile::tempdir;
+
+    fn make_conversation(id: &str) -> ConversationRow {
+        ConversationRow {
+            id: id.into(),
+            user_id: "system_default_user".into(),
+            name: "Cron Conversation".into(),
+            r#type: "acp".into(),
+            extra: "{}".into(),
+            model: None,
+            status: Some("finished".into()),
+            source: Some("aionui".into()),
+            channel_chat_id: None,
+            pinned: false,
+            pinned_at: None,
+            created_at: now_ms(),
+            updated_at: now_ms(),
+        }
+    }
+
+    #[tokio::test]
+    async fn emits_skill_suggest_when_file_is_valid() {
+        let temp = tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        tokio::fs::write(
+            workspace.join(SKILL_SUGGEST_FILENAME),
+            "---\nname: daily-report\ndescription: Daily report\n---\n\nCheck sources.\n",
+        )
+        .await
+        .unwrap();
+
+        let db = init_database_memory().await.unwrap();
+        let repo: Arc<dyn IConversationRepository> =
+            Arc::new(SqliteConversationRepository::new(db.pool().clone()));
+        repo.create(&make_conversation("conv-1")).await.unwrap();
+
+        let bus = Arc::new(BroadcastEventBus::new(16));
+        let detector =
+            SkillSuggestDetector::new(bus.clone(), repo.clone(), temp.path().to_path_buf());
+        let mut rx = bus.subscribe();
+
+        let emitted = detector
+            .check_and_emit("conv-1", "cron-1", &workspace.to_string_lossy())
+            .await
+            .unwrap();
+
+        assert!(emitted);
+        let msg = rx.try_recv().unwrap();
+        assert_eq!(msg.name, "message.stream");
+        assert_eq!(msg.data["type"], "skill_suggest");
+        assert_eq!(msg.data["data"]["cron_job_id"], "cron-1");
+        assert_eq!(msg.data["data"]["name"], "daily-report");
+
+        let rows = repo
+            .get_messages("conv-1", 1, 50, SortOrder::Asc)
+            .await
+            .unwrap();
+        assert_eq!(rows.items.len(), 1);
+        assert_eq!(rows.items[0].r#type, "skill_suggest");
+        assert_eq!(rows.items[0].position.as_deref(), Some("center"));
+        assert!(rows.items[0].content.contains("\"skillContent\""));
+    }
+
+    #[tokio::test]
+    async fn suppresses_duplicate_skill_suggest_content() {
+        let temp = tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        tokio::fs::write(
+            workspace.join(SKILL_SUGGEST_FILENAME),
+            "---\nname: daily-report\ndescription: Daily report\n---\n\nCheck sources.\n",
+        )
+        .await
+        .unwrap();
+
+        let db = init_database_memory().await.unwrap();
+        let repo: Arc<dyn IConversationRepository> =
+            Arc::new(SqliteConversationRepository::new(db.pool().clone()));
+        repo.create(&make_conversation("conv-1")).await.unwrap();
+        repo.create(&make_conversation("conv-2")).await.unwrap();
+
+        let bus = Arc::new(BroadcastEventBus::new(16));
+        let detector = SkillSuggestDetector::new(bus.clone(), repo, temp.path().to_path_buf());
+        let mut rx = bus.subscribe();
+
+        assert!(
+            detector
+                .check_and_emit("conv-1", "cron-1", &workspace.to_string_lossy())
+                .await
+                .unwrap()
+        );
+        assert!(rx.try_recv().is_ok());
+
+        assert!(
+            detector
+                .check_and_emit("conv-2", "cron-1", &workspace.to_string_lossy())
+                .await
+                .unwrap()
+        );
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn suppresses_skill_suggest_when_saved_skill_exists() {
+        let temp = tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        tokio::fs::write(
+            workspace.join(SKILL_SUGGEST_FILENAME),
+            "---\nname: daily-report\ndescription: Daily report\n---\n\nCheck sources.\n",
+        )
+        .await
+        .unwrap();
+        let skill_dir = temp.path().join("cron/skills/cron-cron-1");
+        tokio::fs::create_dir_all(&skill_dir).await.unwrap();
+        tokio::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: saved-skill\ndescription: Saved skill\n---\n\nDo the task.\n",
+        )
+        .await
+        .unwrap();
+
+        let db = init_database_memory().await.unwrap();
+        let repo: Arc<dyn IConversationRepository> =
+            Arc::new(SqliteConversationRepository::new(db.pool().clone()));
+        repo.create(&make_conversation("conv-1")).await.unwrap();
+
+        let bus = Arc::new(BroadcastEventBus::new(16));
+        let detector = SkillSuggestDetector::new(bus.clone(), repo, temp.path().to_path_buf());
+        let mut rx = bus.subscribe();
+
+        let emitted = detector
+            .check_and_emit("conv-1", "cron-1", &workspace.to_string_lossy())
+            .await
+            .unwrap();
+
+        assert!(emitted);
+        assert!(rx.try_recv().is_err());
+    }
+}

--- a/crates/aionui-cron/src/skill_suggest.rs
+++ b/crates/aionui-cron/src/skill_suggest.rs
@@ -3,16 +3,14 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use aionui_api_types::WebSocketMessage;
-use aionui_common::{generate_id, now_ms};
+use aionui_common::now_ms;
 use aionui_db::IConversationRepository;
-use aionui_db::models::MessageRow;
 use aionui_realtime::EventBroadcaster;
-use serde_json::json;
 use tokio::fs;
 use tokio::time::sleep;
 use tracing::{debug, warn};
 
+use crate::artifacts::{broadcast_artifact, build_skill_suggest_artifact};
 use crate::error::CronError;
 use crate::prompt::SKILL_SUGGEST_FILENAME;
 use crate::skill_file::{content_hash, has_skill_file, validate_skill_content};
@@ -129,16 +127,8 @@ impl SkillSuggestDetector {
         description: &str,
         skill_content: &str,
     ) {
-        let msg_id = generate_id();
-        self.persist_and_broadcast(
-            conversation_id,
-            job_id,
-            name,
-            description,
-            skill_content,
-            &msg_id,
-        )
-        .await;
+        self.persist_and_broadcast(conversation_id, job_id, name, description, skill_content)
+            .await;
     }
 
     async fn persist_and_broadcast(
@@ -148,52 +138,42 @@ impl SkillSuggestDetector {
         name: &str,
         description: &str,
         skill_content: &str,
-        msg_id: &str,
     ) {
-        let content = json!({
-            "cron_job_id": job_id,
-            "name": name,
-            "description": description,
-            "skillContent": skill_content,
-        });
+        let row = build_skill_suggest_artifact(
+            conversation_id,
+            job_id,
+            name,
+            description,
+            skill_content,
+            now_ms(),
+        );
 
-        let row = MessageRow {
-            id: generate_id(),
-            conversation_id: conversation_id.to_owned(),
-            msg_id: Some(msg_id.to_owned()),
-            r#type: "skill_suggest".into(),
-            content: content.to_string(),
-            position: Some("center".into()),
-            status: Some("finish".into()),
-            hidden: false,
-            created_at: now_ms(),
+        let row = match self.conversation_repo.upsert_artifact(&row).await {
+            Ok(row) => row,
+            Err(err) => {
+                warn!(
+                    conversation_id,
+                    job_id,
+                    error = %err,
+                    "Failed persisting cron skill suggestion artifact"
+                );
+                return;
+            }
         };
 
-        if let Err(err) = self.conversation_repo.insert_message(&row).await {
+        if let Err(err) = broadcast_artifact(&self.broadcaster, &row) {
             warn!(
                 conversation_id,
                 job_id,
                 error = %err,
-                "Failed persisting cron skill suggestion message"
+                "Failed broadcasting cron skill suggestion artifact"
             );
+            return;
         }
-
-        let payload = json!({
-            "conversation_id": conversation_id,
-            "msg_id": msg_id,
-            "type": "skill_suggest",
-            "data": {
-                "cron_job_id": job_id,
-                "name": name,
-                "description": description,
-                "skill_content": skill_content,
-            },
-            "hidden": false,
-        });
-
-        self.broadcaster
-            .broadcast(WebSocketMessage::new("message.stream", payload));
-        debug!(conversation_id, job_id, "Broadcasted cron skill suggestion");
+        debug!(
+            conversation_id,
+            job_id, "Broadcasted cron skill suggestion artifact"
+        );
     }
 
     fn last_hash(&self, job_id: &str) -> Option<String> {
@@ -220,7 +200,7 @@ impl SkillSuggestDetector {
 mod tests {
     use super::*;
     use aionui_db::models::ConversationRow;
-    use aionui_db::{SortOrder, SqliteConversationRepository, init_database_memory};
+    use aionui_db::{SqliteConversationRepository, init_database_memory};
     use aionui_realtime::BroadcastEventBus;
     use tempfile::tempdir;
 
@@ -271,19 +251,17 @@ mod tests {
 
         assert!(emitted);
         let msg = rx.try_recv().unwrap();
-        assert_eq!(msg.name, "message.stream");
-        assert_eq!(msg.data["type"], "skill_suggest");
-        assert_eq!(msg.data["data"]["cron_job_id"], "cron-1");
-        assert_eq!(msg.data["data"]["name"], "daily-report");
+        assert_eq!(msg.name, "conversation.artifact");
+        assert_eq!(msg.data["kind"], "skill_suggest");
+        assert_eq!(msg.data["status"], "pending");
+        assert_eq!(msg.data["payload"]["cron_job_id"], "cron-1");
+        assert_eq!(msg.data["payload"]["name"], "daily-report");
 
-        let rows = repo
-            .get_messages("conv-1", 1, 50, SortOrder::Asc)
-            .await
-            .unwrap();
-        assert_eq!(rows.items.len(), 1);
-        assert_eq!(rows.items[0].r#type, "skill_suggest");
-        assert_eq!(rows.items[0].position.as_deref(), Some("center"));
-        assert!(rows.items[0].content.contains("\"skillContent\""));
+        let rows = repo.list_artifacts("conv-1").await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].kind, "skill_suggest");
+        assert_eq!(rows[0].status, "pending");
+        assert!(rows[0].payload.contains("\"skillContent\""));
     }
 
     #[tokio::test]

--- a/crates/aionui-cron/src/types.rs
+++ b/crates/aionui-cron/src/types.rs
@@ -383,6 +383,7 @@ pub fn cron_job_to_response(job: &CronJob) -> CronJobResponse {
     CronJobResponse {
         id: job.id.clone(),
         name: job.name.clone(),
+        description: job.description.clone(),
         enabled: job.enabled,
         schedule,
         target: CronJobTargetDto {

--- a/crates/aionui-cron/tests/prompt_test.rs
+++ b/crates/aionui-cron/tests/prompt_test.rs
@@ -1,0 +1,62 @@
+use aionui_cron::prompt::{
+    SKILL_SUGGEST_FILENAME, build_existing_conversation_prompt, build_new_conversation_prompt,
+    build_new_conversation_prompt_with_skill_suggest, build_new_conversation_with_skill_prompt,
+    build_skill_suggest_prompt,
+};
+
+#[test]
+fn build_new_conversation_prompt_matches_frontend_copy() {
+    let prompt = build_new_conversation_prompt("Daily Report", "Every day at 9am", "Summarize it.");
+    assert_eq!(
+        prompt,
+        "[Scheduled Task Context]\nTask: Daily Report\nSchedule: Every day at 9am\n\nRules:\n1. Execute the task directly — do NOT ask clarifying questions.\n2. Focus on producing useful, actionable output.\n3. If the task requires external data (news, weather, etc.), search for the latest information.\n[/Scheduled Task Context]\n\nSummarize it."
+    );
+}
+
+#[test]
+fn build_new_conversation_prompt_with_skill_suggest_includes_follow_up_block() {
+    let prompt = build_new_conversation_prompt_with_skill_suggest(
+        "Daily Report",
+        "Every day at 9am",
+        "Summarize it.",
+    );
+    assert!(prompt.contains(&format!("create a file named \"{SKILL_SUGGEST_FILENAME}\"")));
+    assert!(prompt.contains("short kebab-case name"));
+    assert!(
+        prompt.contains(
+            "If you think the task is too simple or one-off to benefit from a skill file"
+        )
+    );
+}
+
+#[test]
+fn build_new_conversation_with_skill_prompt_matches_frontend_copy() {
+    let prompt = build_new_conversation_with_skill_prompt("Daily Report", "Summarize it.");
+    assert_eq!(
+        prompt,
+        "[Scheduled Task Context]\nTask: Daily Report\n\nThis is a scheduled task execution. A skill file with detailed instructions has been loaded\ninto your workspace. You MUST read and follow the skill instructions precisely.\n\nRules:\n1. Execute the task directly — do NOT ask clarifying questions.\n2. Follow the output format, tone, sources, and steps defined in the skill.\n3. If the task requires external data (news, weather, etc.), search for the latest information.\n[/Scheduled Task Context]\n\nSummarize it."
+    );
+}
+
+#[test]
+fn build_existing_conversation_prompt_matches_frontend_copy() {
+    let prompt =
+        build_existing_conversation_prompt("Daily Report", "Every day at 9am", "Summarize it.");
+    assert_eq!(
+        prompt,
+        "[Scheduled Task Execution]\nTask: Daily Report\nSchedule: Every day at 9am\n\nThis message is NOT a conversation from the user — it is a scheduled task triggered automatically.\nThe text below is a TASK INSTRUCTION that you must execute, not something the user is saying to you.\n\nRules:\n1. Treat the instruction as a command to perform, not as a chat message to respond to.\n2. Execute it directly — do NOT ask clarifying questions.\n3. If the task requires external data (news, weather, etc.), search for the latest information.\n\nTask instruction:\nSummarize it."
+    );
+}
+
+#[test]
+fn build_skill_suggest_prompt_matches_frontend_copy() {
+    let prompt = build_skill_suggest_prompt("Daily Report");
+    assert!(prompt.starts_with(
+        "The task \"Daily Report\" is a recurring scheduled task. Based on what you just did,"
+    ));
+    assert!(prompt.contains("```markdown"));
+    assert!(prompt.contains("Use concrete details from this execution, not placeholders."));
+    assert!(prompt.ends_with(
+        "If you think the task is too simple or one-off to benefit from a skill file, you can skip this."
+    ));
+}

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -7,10 +7,11 @@
 //! Covers test-plan items: CJ-1..CJ-12, SK-1..SK-7, SC-1..SC-8,
 //! OC-1, SR-1, ICronService trait integration.
 
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use aionui_ai_agent::agent_manager::AgentManagerHandle;
-use aionui_ai_agent::middleware::CronCreateParams;
+use aionui_ai_agent::middleware::{CronCreateParams, CronUpdateParams};
 use aionui_ai_agent::types::BuildTaskOptions;
 use aionui_api_types::{
     CreateCronJobRequest, CronScheduleDto, ListCronJobsQuery, SaveCronSkillRequest,
@@ -21,6 +22,7 @@ use aionui_conversation::ConversationService;
 use aionui_db::{
     ConversationFilters, ConversationRowUpdate, IConversationRepository, ICronRepository,
     MessageRowUpdate, MessageSearchRow, SortOrder, SqliteCronRepository, init_database_memory,
+    models::MessageRow,
 };
 use aionui_realtime::EventBroadcaster;
 
@@ -29,6 +31,7 @@ use aionui_cron::events::CronEventEmitter;
 use aionui_cron::executor::JobExecutor;
 use aionui_cron::scheduler::CronScheduler;
 use aionui_cron::service::CronService;
+use aionui_cron::types::JobStatus;
 
 // ── Test infrastructure ────────────────────────────────────────────
 
@@ -84,41 +87,130 @@ impl aionui_ai_agent::task_manager::IWorkerTaskManager for StubTaskManager {
     }
 }
 
-struct StubConvRepo;
+struct StubConvRepo {
+    messages: Mutex<Vec<MessageRow>>,
+    rows: Mutex<HashMap<String, aionui_db::models::ConversationRow>>,
+}
+
+impl StubConvRepo {
+    fn new() -> Self {
+        Self {
+            messages: Mutex::new(Vec::new()),
+            rows: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn take_messages(&self) -> Vec<MessageRow> {
+        let mut guard = self.messages.lock().unwrap();
+        std::mem::take(&mut *guard)
+    }
+}
 
 #[async_trait::async_trait]
 impl IConversationRepository for StubConvRepo {
     async fn get(
         &self,
-        _id: &str,
+        id: &str,
     ) -> Result<Option<aionui_db::models::ConversationRow>, aionui_db::DbError> {
-        Ok(Some(aionui_db::models::ConversationRow {
-            id: "conv_stub".into(),
-            user_id: "u1".into(),
-            name: "stub".into(),
-            r#type: "default".into(),
-            model: None,
-            status: Some("active".into()),
-            source: None,
-            channel_chat_id: None,
-            extra: "{}".into(),
-            pinned: false,
-            pinned_at: None,
-            created_at: 1000,
-            updated_at: 1000,
-        }))
+        let mut rows = self.rows.lock().unwrap();
+
+        if let Some(existing) = rows.get(id) {
+            return Ok(Some(existing.clone()));
+        }
+        if id.starts_with("missing") {
+            return Ok(None);
+        }
+
+        let row = if id == "conv_mode" {
+            aionui_db::models::ConversationRow {
+                id: id.into(),
+                user_id: "u1".into(),
+                name: "Gemini Chat".into(),
+                r#type: "acp".into(),
+                model: Some(
+                    serde_json::json!({
+                        "provider_id": "gemini",
+                        "model": "gemini-2.5-pro",
+                        "use_model": "gemini-2.5-pro"
+                    })
+                    .to_string(),
+                ),
+                status: Some("active".into()),
+                source: None,
+                channel_chat_id: None,
+                extra: serde_json::json!({
+                    "backend": "gemini",
+                    "agent_name": "Gemini",
+                    "workspace": "/tmp/gemini-workspace",
+                    "session_mode": "yolo",
+                    "current_model_id": "gemini-2.5-pro"
+                })
+                .to_string(),
+                pinned: false,
+                pinned_at: None,
+                created_at: 1000,
+                updated_at: 1000,
+            }
+        } else {
+            aionui_db::models::ConversationRow {
+                id: id.into(),
+                user_id: "u1".into(),
+                name: "stub".into(),
+                r#type: "default".into(),
+                model: None,
+                status: Some("active".into()),
+                source: None,
+                channel_chat_id: None,
+                extra: "{}".into(),
+                pinned: false,
+                pinned_at: None,
+                created_at: 1000,
+                updated_at: 1000,
+            }
+        };
+
+        rows.insert(id.to_owned(), row.clone());
+        Ok(Some(row))
     }
     async fn create(
         &self,
-        _row: &aionui_db::models::ConversationRow,
+        row: &aionui_db::models::ConversationRow,
     ) -> Result<(), aionui_db::DbError> {
+        self.rows
+            .lock()
+            .unwrap()
+            .insert(row.id.clone(), row.clone());
         Ok(())
     }
     async fn update(
         &self,
-        _id: &str,
-        _updates: &ConversationRowUpdate,
+        id: &str,
+        updates: &ConversationRowUpdate,
     ) -> Result<(), aionui_db::DbError> {
+        let mut rows = self.rows.lock().unwrap();
+        let row = rows
+            .entry(id.to_owned())
+            .or_insert_with(|| aionui_db::models::ConversationRow {
+                id: id.to_owned(),
+                user_id: "u1".into(),
+                name: "stub".into(),
+                r#type: "default".into(),
+                model: None,
+                status: Some("active".into()),
+                source: None,
+                channel_chat_id: None,
+                extra: "{}".into(),
+                pinned: false,
+                pinned_at: None,
+                created_at: 1000,
+                updated_at: 1000,
+            });
+        if let Some(extra) = &updates.extra {
+            row.extra = extra.clone();
+        }
+        if let Some(updated_at) = updates.updated_at {
+            row.updated_at = updated_at;
+        }
         Ok(())
     }
     async fn delete(&self, _id: &str) -> Result<(), aionui_db::DbError> {
@@ -147,9 +239,23 @@ impl IConversationRepository for StubConvRepo {
     async fn list_by_cron_job(
         &self,
         _user_id: &str,
-        _cron_job_id: &str,
+        cron_job_id: &str,
     ) -> Result<Vec<aionui_db::models::ConversationRow>, aionui_db::DbError> {
-        Ok(vec![])
+        let rows = self.rows.lock().unwrap();
+        Ok(rows
+            .values()
+            .filter(|row| {
+                let parsed = serde_json::from_str::<serde_json::Value>(&row.extra).ok();
+                let bound = parsed.as_ref().and_then(|extra| {
+                    extra
+                        .get("cron_job_id")
+                        .and_then(|value| value.as_str())
+                        .or_else(|| extra.get("cronJobId").and_then(|value| value.as_str()))
+                });
+                bound == Some(cron_job_id)
+            })
+            .cloned()
+            .collect())
     }
     async fn list_associated(
         &self,
@@ -173,8 +279,9 @@ impl IConversationRepository for StubConvRepo {
     }
     async fn insert_message(
         &self,
-        _message: &aionui_db::models::MessageRow,
+        message: &aionui_db::models::MessageRow,
     ) -> Result<(), aionui_db::DbError> {
+        self.messages.lock().unwrap().push(message.clone());
         Ok(())
     }
     async fn update_message(
@@ -214,10 +321,22 @@ impl IConversationRepository for StubConvRepo {
 }
 
 async fn setup() -> (CronService, Arc<dyn ICronRepository>, Arc<MockBroadcaster>) {
+    let (svc, repo, bc, _) = setup_with_conv_repo().await;
+    (svc, repo, bc)
+}
+
+async fn setup_with_conv_repo() -> (
+    CronService,
+    Arc<dyn ICronRepository>,
+    Arc<MockBroadcaster>,
+    Arc<StubConvRepo>,
+) {
     let db = init_database_memory().await.unwrap();
     let pool = db.pool().clone();
     let cron_repo: Arc<dyn ICronRepository> = Arc::new(SqliteCronRepository::new(pool));
     let bc = Arc::new(MockBroadcaster::new());
+    let data_dir = std::env::temp_dir().join(format!("aionui-cron-test-{}", now_ms()));
+    std::fs::create_dir_all(&data_dir).unwrap();
 
     struct StubSkillResolver;
     #[async_trait::async_trait]
@@ -243,9 +362,10 @@ async fn setup() -> (CronService, Arc<dyn ICronRepository>, Arc<MockBroadcaster>
         }
     }
 
-    let stub_conv_repo: Arc<dyn IConversationRepository> = Arc::new(StubConvRepo);
+    let stub_conv_repo = Arc::new(StubConvRepo::new());
+    let stub_conv_repo_trait: Arc<dyn IConversationRepository> = stub_conv_repo.clone();
     let conv_service = Arc::new(ConversationService::new_with_workspace_root(
-        Arc::clone(&stub_conv_repo),
+        Arc::clone(&stub_conv_repo_trait),
         bc.clone() as Arc<dyn EventBroadcaster>,
         std::env::temp_dir(),
         Arc::new(StubSkillResolver),
@@ -253,23 +373,26 @@ async fn setup() -> (CronService, Arc<dyn ICronRepository>, Arc<MockBroadcaster>
     let busy_guard = Arc::new(CronBusyGuard::new());
     let executor = Arc::new(JobExecutor::new(
         Arc::new(StubTaskManager),
-        stub_conv_repo,
+        stub_conv_repo_trait,
         conv_service,
         busy_guard,
+        data_dir.clone(),
+        bc.clone() as Arc<dyn EventBroadcaster>,
     ));
 
     let scheduler = Arc::new(CronScheduler::new(Arc::new(|_| {})));
 
     let emitter = CronEventEmitter::new(bc.clone() as Arc<dyn EventBroadcaster>);
-    let svc = CronService::new(cron_repo.clone(), scheduler, executor, emitter);
+    let svc = CronService::new(cron_repo.clone(), scheduler, executor, emitter, data_dir);
 
     std::mem::forget(db);
-    (svc, cron_repo, bc)
+    (svc, cron_repo, bc, stub_conv_repo)
 }
 
 fn make_create_req(name: &str, schedule: CronScheduleDto) -> CreateCronJobRequest {
     CreateCronJobRequest {
         name: name.into(),
+        description: Some("test description".into()),
         schedule,
         prompt: None,
         message: Some("test message".into()),
@@ -321,7 +444,7 @@ async fn cj1_create_cron_job() {
 
     let events = bc.take_events();
     assert_eq!(events.len(), 1);
-    assert_eq!(events[0].name, "cron.jobCreated");
+    assert_eq!(events[0].name, "cron.job-created");
 }
 
 // ── CJ-2: Create three schedule types ──────────────────────────────
@@ -415,6 +538,25 @@ async fn cj7_list_by_conversation() {
     assert_eq!(jobs.len(), 2);
 }
 
+#[tokio::test]
+async fn cj7b_add_job_binds_existing_conversation_to_job() {
+    let (svc, _, _, conv_repo) = setup_with_conv_repo().await;
+
+    let mut req = make_create_req("Bound Existing Conversation", every_60s());
+    req.conversation_id = "conv_existing_bind".into();
+
+    let job = svc.add_job(req).await.unwrap();
+
+    let bound = conv_repo.get("conv_existing_bind").await.unwrap().unwrap();
+    let extra: serde_json::Value = serde_json::from_str(&bound.extra).unwrap();
+    assert_eq!(extra["cron_job_id"], job.id);
+    assert_eq!(extra["cronJobId"], job.id);
+
+    let linked = conv_repo.list_by_cron_job("user_1", &job.id).await.unwrap();
+    assert_eq!(linked.len(), 1);
+    assert_eq!(linked[0].id, "conv_existing_bind");
+}
+
 // ── CJ-8: Update job ──────────────────────────────────────────────
 
 #[tokio::test]
@@ -428,6 +570,7 @@ async fn cj8_update_job() {
 
     let req = UpdateCronJobRequest {
         name: Some("Updated Name".into()),
+        description: Some("Updated description".into()),
         enabled: Some(false),
         schedule: None,
         message: None,
@@ -439,12 +582,13 @@ async fn cj8_update_job() {
 
     let updated = svc.update_job(&created.id, req).await.unwrap();
     assert_eq!(updated.name, "Updated Name");
+    assert_eq!(updated.description.as_deref(), Some("Updated description"));
     assert!(!updated.enabled);
     assert!(updated.updated_at >= created.created_at);
 
     let events = bc.take_events();
     assert_eq!(events.len(), 1);
-    assert_eq!(events[0].name, "cron.jobUpdated");
+    assert_eq!(events[0].name, "cron.job-updated");
 }
 
 // ── CJ-9: Update schedule type ────────────────────────────────────
@@ -459,6 +603,7 @@ async fn cj9_update_schedule_type() {
 
     let req = UpdateCronJobRequest {
         name: None,
+        description: None,
         enabled: None,
         schedule: Some(cron_every_5min()),
         message: None,
@@ -483,6 +628,7 @@ async fn cj10_update_nonexistent() {
     let (svc, _, _) = setup().await;
     let req = UpdateCronJobRequest {
         name: Some("x".into()),
+        description: None,
         enabled: None,
         schedule: None,
         message: None,
@@ -513,7 +659,7 @@ async fn cj11_delete_job() {
 
     let events = bc.take_events();
     assert_eq!(events.len(), 1);
-    assert_eq!(events[0].name, "cron.jobRemoved");
+    assert_eq!(events[0].name, "cron.job-removed");
 }
 
 // ── CJ-12: Delete nonexistent ─────────────────────────────────────
@@ -781,6 +927,27 @@ async fn oc1_init_cleans_orphans() {
     assert!(found.is_ok());
 }
 
+#[tokio::test]
+async fn oc2_init_cleans_jobs_with_missing_conversation() {
+    let (svc, _repo, _) = setup().await;
+
+    let mut missing_req = make_create_req("Missing Conversation", every_60s());
+    missing_req.conversation_id = "missing-conv-1".into();
+    let missing = svc.add_job(missing_req).await.unwrap();
+
+    let mut normal_req = make_create_req("Existing Conversation", every_60s());
+    normal_req.conversation_id = "conv-existing".into();
+    let normal = svc.add_job(normal_req).await.unwrap();
+
+    svc.init().await;
+
+    let err = svc.get_job(&missing.id).await;
+    assert!(err.is_err());
+
+    let found = svc.get_job(&normal.id).await;
+    assert!(found.is_ok());
+}
+
 // ── Delete skill explicitly ───────────────────────────────────────
 
 #[tokio::test]
@@ -809,7 +976,7 @@ async fn delete_skill_clears_content() {
 
 #[tokio::test]
 async fn icron_service_create_job() {
-    let (svc, _, _) = setup().await;
+    let (svc, _, _, conv_repo) = setup_with_conv_repo().await;
 
     use aionui_ai_agent::middleware::ICronService;
 
@@ -823,6 +990,52 @@ async fn icron_service_create_job() {
     let result = ICronService::create_job(&svc, "user_1", "conv_1", &params).await;
     assert!(result.success);
     assert!(result.message.contains("Agent Job"));
+
+    let bound = conv_repo.get("conv_1").await.unwrap().unwrap();
+    let extra: serde_json::Value = serde_json::from_str(&bound.extra).unwrap();
+    let bound_job_id = extra
+        .get("cron_job_id")
+        .and_then(|value| value.as_str())
+        .or_else(|| extra.get("cronJobId").and_then(|value| value.as_str()));
+    assert!(bound_job_id.is_some());
+}
+
+#[tokio::test]
+async fn icron_service_create_job_inherits_conversation_mode_and_backend() {
+    let (svc, _, _) = setup().await;
+
+    use aionui_ai_agent::middleware::ICronService;
+
+    let params = CronCreateParams {
+        name: "Agent Job".into(),
+        schedule: "0 */10 * * * *".into(),
+        schedule_description: "every 10 min".into(),
+        message: "do agent work".into(),
+    };
+
+    let result = ICronService::create_job(&svc, "user_1", "conv_mode", &params).await;
+    assert!(result.success);
+
+    let jobs = svc
+        .list_jobs(&ListCronJobsQuery {
+            conversation_id: Some("conv_mode".into()),
+        })
+        .await
+        .unwrap();
+    assert_eq!(jobs.len(), 1);
+
+    let job = &jobs[0];
+    let config = job
+        .agent_config
+        .as_ref()
+        .expect("agent config should be copied");
+    assert_eq!(job.agent_type, "acp");
+    assert_eq!(job.conversation_title.as_deref(), Some("Gemini Chat"));
+    assert_eq!(config.backend, "gemini");
+    assert_eq!(config.name, "Gemini");
+    assert_eq!(config.mode.as_deref(), Some("yolo"));
+    assert_eq!(config.model_id.as_deref(), Some("gemini-2.5-pro"));
+    assert_eq!(config.workspace.as_deref(), Some("/tmp/gemini-workspace"));
 }
 
 // ── ICronService trait: list ───────────────────────────────────────
@@ -833,18 +1046,61 @@ async fn icron_service_list_jobs() {
 
     use aionui_ai_agent::middleware::ICronService;
 
-    let result = ICronService::list_jobs(&svc, "user_1").await;
+    let result = ICronService::list_jobs(&svc, "user_1", "conv_1").await;
     assert!(result.success);
-    assert!(result.message.contains("No cron jobs found"));
+    assert!(
+        result
+            .message
+            .contains("No cron jobs found for conversation 'conv_1'")
+    );
 
-    svc.add_job(make_create_req("Listed Job", every_60s()))
+    let mut req = make_create_req("Listed Job", every_60s());
+    req.conversation_id = "conv_1".into();
+    svc.add_job(req).await.unwrap();
+
+    let result = ICronService::list_jobs(&svc, "user_1", "conv_1").await;
+    assert!(result.success);
+    assert!(
+        result
+            .message
+            .contains("1 cron job(s) for conversation 'conv_1'")
+    );
+    assert!(result.message.contains("Listed Job"));
+}
+
+// ── ICronService trait: update ─────────────────────────────────────
+
+#[tokio::test]
+async fn icron_service_update_job() {
+    let (svc, _, _, conv_repo) = setup_with_conv_repo().await;
+
+    use aionui_ai_agent::middleware::ICronService;
+
+    let job = svc
+        .add_job(make_create_req("Update Via Trait", every_60s()))
         .await
         .unwrap();
 
-    let result = ICronService::list_jobs(&svc, "user_1").await;
+    let params = CronUpdateParams {
+        job_id: job.id.clone(),
+        name: "Updated Via Trait".into(),
+        schedule: "0 */10 * * * *".into(),
+        schedule_description: "every 10 min".into(),
+        message: "do updated work".into(),
+    };
+
+    let result = ICronService::update_job(&svc, "user_1", "conv_1", &params).await;
     assert!(result.success);
-    assert!(result.message.contains("1 cron job(s)"));
-    assert!(result.message.contains("Listed Job"));
+    assert!(result.message.contains("Updated Via Trait"));
+
+    let bound = conv_repo.get("conv_1").await.unwrap().unwrap();
+    let extra: serde_json::Value = serde_json::from_str(&bound.extra).unwrap();
+    assert_eq!(extra["cron_job_id"], job.id);
+    assert_eq!(extra["cronJobId"], job.id);
+
+    let linked = conv_repo.list_by_cron_job("user_1", &job.id).await.unwrap();
+    assert_eq!(linked.len(), 1);
+    assert_eq!(linked[0].id, "conv_1");
 }
 
 // ── ICronService trait: delete ─────────────────────────────────────
@@ -880,6 +1136,7 @@ async fn update_max_retries() {
 
     let req = UpdateCronJobRequest {
         name: None,
+        description: None,
         enabled: None,
         schedule: None,
         message: None,
@@ -930,7 +1187,7 @@ async fn sc2_at_type_past_timestamp() {
 
 #[tokio::test]
 async fn sr1_system_resume_missed_job() {
-    let (svc, repo, bc) = setup().await;
+    let (svc, repo, bc, conv_repo) = setup_with_conv_repo().await;
 
     let req = make_create_req("Resume Job", every_60s());
     let job = svc.add_job(req).await.unwrap();
@@ -947,16 +1204,39 @@ async fn sr1_system_resume_missed_job() {
 
     let updated = svc.get_job(&job.id).await.unwrap();
     assert!(
-        updated.last_run_at.is_some(),
-        "missed job should have been executed (last_run_at set)"
+        updated.last_run_at.is_none(),
+        "missed job should not be auto-executed on resume"
     );
+    assert_eq!(updated.last_status, Some(JobStatus::Missed));
     assert!(
         updated.next_run_at.is_some(),
-        "job should be rescheduled after execution"
+        "job should be rescheduled after being marked missed"
     );
     assert!(
         updated.next_run_at.unwrap() > now_ms() - 2000,
         "next_run_at should be in the future"
+    );
+
+    let messages = conv_repo.take_messages();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].r#type, "tips");
+    assert!(messages[0].content.contains("Resume Job"));
+    assert!(messages[0].content.contains("not run automatically"));
+
+    let events = bc.take_events();
+    assert!(
+        events
+            .iter()
+            .any(|event| { event.name == "cron.job-executed" && event.data["status"] == "missed" }),
+        "resume should emit a missed execution event"
+    );
+    assert!(
+        events.iter().any(|event| {
+            event.name == "message.stream"
+                && event.data["type"] == "tips"
+                && event.data["conversation_id"] == "conv_1"
+        }),
+        "resume should emit a tips websocket message"
     );
 }
 
@@ -991,7 +1271,7 @@ async fn cd1_cascade_delete_by_conversation() {
     let events = bc.take_events();
     let removed_events: Vec<_> = events
         .iter()
-        .filter(|e| e.name == "cron.jobRemoved")
+        .filter(|e| e.name == "cron.job-removed")
         .collect();
     assert_eq!(removed_events.len(), 2, "should emit 2 removed events");
 }
@@ -1038,5 +1318,5 @@ async fn cd3_on_conversation_delete_trait() {
 
     let events = bc.take_events();
     assert_eq!(events.len(), 1);
-    assert_eq!(events[0].name, "cron.jobRemoved");
+    assert_eq!(events[0].name, "cron.job-removed");
 }

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -89,6 +89,7 @@ impl aionui_ai_agent::task_manager::IWorkerTaskManager for StubTaskManager {
 
 struct StubConvRepo {
     messages: Mutex<Vec<MessageRow>>,
+    artifacts: Mutex<Vec<aionui_db::ConversationArtifactRow>>,
     rows: Mutex<HashMap<String, aionui_db::models::ConversationRow>>,
 }
 
@@ -96,6 +97,7 @@ impl StubConvRepo {
     fn new() -> Self {
         Self {
             messages: Mutex::new(Vec::new()),
+            artifacts: Mutex::new(Vec::new()),
             rows: Mutex::new(HashMap::new()),
         }
     }
@@ -103,6 +105,19 @@ impl StubConvRepo {
     fn take_messages(&self) -> Vec<MessageRow> {
         let mut guard = self.messages.lock().unwrap();
         std::mem::take(&mut *guard)
+    }
+
+    fn upsert_artifact_row(&self, artifact: aionui_db::ConversationArtifactRow) {
+        let mut guard = self.artifacts.lock().unwrap();
+        if let Some(existing) = guard.iter_mut().find(|row| row.id == artifact.id) {
+            *existing = artifact;
+        } else {
+            guard.push(artifact);
+        }
+    }
+
+    fn artifacts(&self) -> Vec<aionui_db::ConversationArtifactRow> {
+        self.artifacts.lock().unwrap().clone()
     }
 }
 
@@ -317,6 +332,75 @@ impl IConversationRepository for StubConvRepo {
             total: 0,
             has_more: false,
         })
+    }
+    async fn list_artifacts(
+        &self,
+        conversation_id: &str,
+    ) -> Result<Vec<aionui_db::ConversationArtifactRow>, aionui_db::DbError> {
+        Ok(self
+            .artifacts
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|row| row.conversation_id == conversation_id)
+            .cloned()
+            .collect())
+    }
+    async fn get_artifact(
+        &self,
+        conversation_id: &str,
+        artifact_id: &str,
+    ) -> Result<Option<aionui_db::ConversationArtifactRow>, aionui_db::DbError> {
+        Ok(self
+            .artifacts
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|row| row.conversation_id == conversation_id && row.id == artifact_id)
+            .cloned())
+    }
+    async fn upsert_artifact(
+        &self,
+        artifact: &aionui_db::ConversationArtifactRow,
+    ) -> Result<aionui_db::ConversationArtifactRow, aionui_db::DbError> {
+        self.upsert_artifact_row(artifact.clone());
+        Ok(artifact.clone())
+    }
+    async fn update_artifact_status(
+        &self,
+        conversation_id: &str,
+        artifact_id: &str,
+        status: &str,
+        updated_at: TimestampMs,
+    ) -> Result<Option<aionui_db::ConversationArtifactRow>, aionui_db::DbError> {
+        let mut guard = self.artifacts.lock().unwrap();
+        let Some(existing) = guard
+            .iter_mut()
+            .find(|row| row.conversation_id == conversation_id && row.id == artifact_id)
+        else {
+            return Ok(None);
+        };
+        existing.status = status.to_string();
+        existing.updated_at = updated_at;
+        Ok(Some(existing.clone()))
+    }
+    async fn mark_skill_suggest_artifacts_saved(
+        &self,
+        cron_job_id: &str,
+        updated_at: TimestampMs,
+    ) -> Result<Vec<aionui_db::ConversationArtifactRow>, aionui_db::DbError> {
+        let mut guard = self.artifacts.lock().unwrap();
+        let mut updated = Vec::new();
+        for artifact in guard.iter_mut() {
+            if artifact.kind == "skill_suggest"
+                && artifact.cron_job_id.as_deref() == Some(cron_job_id)
+            {
+                artifact.status = "saved".into();
+                artifact.updated_at = updated_at;
+                updated.push(artifact.clone());
+            }
+        }
+        Ok(updated)
     }
 }
 
@@ -688,6 +772,56 @@ async fn sk1_save_skill() {
         content: "---\nname: test\ndescription: test skill\n---\nDo something".into(),
     };
     svc.save_skill(&job.id, req).await.unwrap();
+}
+
+#[tokio::test]
+async fn sk1_1_save_skill_marks_related_skill_suggest_artifacts_saved() {
+    let (svc, _, bc, conv_repo) = setup_with_conv_repo().await;
+    let job = svc
+        .add_job(make_create_req("Skill Artifact Job", every_60s()))
+        .await
+        .unwrap();
+
+    conv_repo.upsert_artifact_row(aionui_db::ConversationArtifactRow {
+        id: format!("conv_1:skill_suggest:{}", job.id),
+        conversation_id: "conv_1".into(),
+        cron_job_id: Some(job.id.clone()),
+        kind: "skill_suggest".into(),
+        status: "active".into(),
+        payload: serde_json::json!({
+            "cron_job_id": job.id,
+            "name": "daily-report",
+            "description": "Daily report",
+            "skillContent": "---\nname: daily-report\n---\nUse it."
+        })
+        .to_string(),
+        created_at: 1000,
+        updated_at: 1000,
+    });
+
+    svc.save_skill(
+        &job.id,
+        SaveCronSkillRequest {
+            content: "---\nname: daily-report\ndescription: Daily report\n---\nUse it.".into(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let artifacts = conv_repo.artifacts();
+    assert_eq!(artifacts.len(), 1);
+    assert_eq!(artifacts[0].status, "saved");
+
+    let events = bc.take_events();
+    let saved_event = events
+        .iter()
+        .find(|event| {
+            event.name == "conversation.artifact"
+                && event.data["id"] == artifacts[0].id
+                && event.data["status"] == "saved"
+        })
+        .expect("save_skill should broadcast saved artifact upsert");
+    assert_eq!(saved_event.data["conversation_id"], "conv_1");
 }
 
 // ── SK-2: Has skill (true) ────────────────────────────────────────

--- a/crates/aionui-cron/tests/skill_file_test.rs
+++ b/crates/aionui-cron/tests/skill_file_test.rs
@@ -1,0 +1,133 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use aionui_cron::skill_file::{
+    ParsedSkillContent, build_skill_content, content_hash, cron_skill_dir, cron_skill_file_path,
+    parse_skill_content, read_skill_content, validate_skill_content, write_raw_skill_file,
+    write_skill_file,
+};
+
+fn unique_temp_dir(label: &str) -> std::path::PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "aionui-cron-{label}-{}-{nanos}",
+        std::process::id()
+    ))
+}
+
+#[test]
+fn build_skill_content_matches_frontend_shape() {
+    let content = build_skill_content(
+        "Daily Report",
+        "Line 1\nLine 2\r\nLine 3",
+        "Run report",
+        Some("Every day at 9am"),
+    );
+
+    assert!(content.contains("name: Daily Report"));
+    assert!(content.contains("description: Line 1 Line 2 Line 3"));
+    assert!(content.contains("This is a scheduled task: **Daily Report**"));
+    assert!(content.contains("Schedule: Every day at 9am"));
+    assert!(content.contains("## Instructions"));
+    assert!(content.ends_with("Run report"));
+}
+
+#[test]
+fn parse_skill_content_roundtrips_built_files() {
+    let built = build_skill_content("My Job", "My Description", "First\n\nSecond", None);
+    let parsed = parse_skill_content(&built).unwrap();
+    assert_eq!(
+        parsed,
+        ParsedSkillContent {
+            name: "My Job".into(),
+            description: "My Description".into(),
+            body: "First\n\nSecond".into(),
+        }
+    );
+}
+
+#[test]
+fn parse_skill_content_skips_blank_lines_after_frontmatter() {
+    let parsed =
+        parse_skill_content("---\nname: Test\ndescription: Desc\n---\n\n\nPrompt").unwrap();
+    assert_eq!(parsed.body, "Prompt");
+}
+
+#[test]
+fn parse_skill_content_handles_empty_body() {
+    let parsed = parse_skill_content("---\nname: Test\ndescription: Desc\n---\n\n").unwrap();
+    assert_eq!(parsed.body, "");
+}
+
+#[test]
+fn validate_skill_content_rejects_placeholders() {
+    let err = validate_skill_content(
+        "---\nname: skill-name\ndescription: Real description\n---\n\nReal body",
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("template placeholder"));
+}
+
+#[test]
+fn content_hash_normalizes_line_endings_and_edges() {
+    let a = content_hash("---\nname: Test\ndescription: Desc\n---\n\nBody\n");
+    let b = content_hash("---\r\nname: Test\r\ndescription: Desc\r\n---\r\n\r\nBody");
+    let c = content_hash("  ---\nname: Test\ndescription: Desc\n---\n\nBody  ");
+    assert_eq!(a, b);
+    assert_eq!(a, c);
+}
+
+#[tokio::test]
+async fn write_read_and_resolve_skill_file_paths() {
+    let base = unique_temp_dir("write-read");
+    std::fs::create_dir_all(&base).unwrap();
+
+    let file_path = write_skill_file(
+        &base,
+        "job-123",
+        "Daily Report",
+        "Generate daily report",
+        "Run report",
+        Some("Every day at 9am"),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        cron_skill_dir(&base, "job-123").unwrap(),
+        base.join("cron").join("skills").join("cron-job-123")
+    );
+    assert_eq!(file_path, cron_skill_file_path(&base, "job-123").unwrap());
+
+    let raw = read_skill_content(&base, "job-123").await.unwrap().unwrap();
+    let parsed = parse_skill_content(&raw).unwrap();
+    assert_eq!(parsed.name, "Daily Report");
+    assert_eq!(parsed.description, "Generate daily report");
+    assert_eq!(parsed.body, "Run report");
+
+    std::fs::remove_dir_all(&base).unwrap();
+}
+
+#[tokio::test]
+async fn write_raw_skill_file_validates_before_writing() {
+    let base = unique_temp_dir("write-raw");
+    std::fs::create_dir_all(&base).unwrap();
+
+    let err = write_raw_skill_file(&base, "job-456", "not valid")
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("skill file must start with YAML frontmatter")
+    );
+    assert!(
+        read_skill_content(&base, "job-456")
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    std::fs::remove_dir_all(&base).unwrap();
+}

--- a/crates/aionui-db/migrations/004_conversation_artifacts.sql
+++ b/crates/aionui-db/migrations/004_conversation_artifacts.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS conversation_artifacts (
+    id              TEXT PRIMARY KEY NOT NULL,
+    conversation_id TEXT    NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    cron_job_id     TEXT,
+    kind            TEXT    NOT NULL
+                            CHECK(kind IN ('cron_trigger', 'skill_suggest')),
+    status          TEXT    NOT NULL DEFAULT 'active'
+                            CHECK(status IN ('active', 'pending', 'dismissed', 'saved')),
+    payload         TEXT    NOT NULL DEFAULT '{}',
+    created_at      INTEGER NOT NULL,
+    updated_at      INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversation_artifacts_conversation_id
+    ON conversation_artifacts(conversation_id);
+CREATE INDEX IF NOT EXISTS idx_conversation_artifacts_created_at
+    ON conversation_artifacts(created_at);
+CREATE INDEX IF NOT EXISTS idx_conversation_artifacts_conversation_created
+    ON conversation_artifacts(conversation_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_conversation_artifacts_cron_job
+    ON conversation_artifacts(cron_job_id);
+CREATE INDEX IF NOT EXISTS idx_conversation_artifacts_kind_status
+    ON conversation_artifacts(kind, status);

--- a/crates/aionui-db/src/lib.rs
+++ b/crates/aionui-db/src/lib.rs
@@ -7,8 +7,8 @@ mod repository;
 pub use database::{Database, init_database, init_database_memory};
 pub use error::DbError;
 pub use models::{
-    AssistantOverrideRow, AssistantRow, CreateAssistantParams, UpdateAssistantParams,
-    UpsertOverrideParams,
+    AssistantOverrideRow, AssistantRow, ConversationArtifactRow, CreateAssistantParams,
+    UpdateAssistantParams, UpsertOverrideParams,
 };
 pub use repository::channel::UpdatePluginStatusParams;
 pub use repository::conversation::{

--- a/crates/aionui-db/src/models/conversation_artifact.rs
+++ b/crates/aionui-db/src/models/conversation_artifact.rs
@@ -1,0 +1,15 @@
+use aionui_common::TimestampMs;
+use serde::{Deserialize, Serialize};
+
+/// Row mapping for the `conversation_artifacts` table.
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct ConversationArtifactRow {
+    pub id: String,
+    pub conversation_id: String,
+    pub cron_job_id: Option<String>,
+    pub kind: String,
+    pub status: String,
+    pub payload: String,
+    pub created_at: TimestampMs,
+    pub updated_at: TimestampMs,
+}

--- a/crates/aionui-db/src/models/mod.rs
+++ b/crates/aionui-db/src/models/mod.rs
@@ -3,6 +3,7 @@ mod assistant;
 mod channel;
 mod client_preference;
 mod conversation;
+mod conversation_artifact;
 mod cron_job;
 mod mcp_server;
 mod message;
@@ -21,6 +22,7 @@ pub use assistant::{
 pub use channel::{AssistantSessionRow, AssistantUserRow, ChannelPluginRow, PairingCodeRow};
 pub use client_preference::ClientPreference;
 pub use conversation::ConversationRow;
+pub use conversation_artifact::ConversationArtifactRow;
 pub use cron_job::CronJobRow;
 pub use mcp_server::McpServerRow;
 pub use message::MessageRow;

--- a/crates/aionui-db/src/repository/conversation.rs
+++ b/crates/aionui-db/src/repository/conversation.rs
@@ -2,7 +2,7 @@ use aionui_common::{PaginatedResult, TimestampMs};
 use serde::{Deserialize, Serialize};
 
 use crate::error::DbError;
-use crate::models::{ConversationRow, MessageRow};
+use crate::models::{ConversationArtifactRow, ConversationRow, MessageRow};
 
 /// Conversation + message data access abstraction.
 ///
@@ -97,6 +97,68 @@ pub trait IConversationRepository: Send + Sync {
         page: u32,
         page_size: u32,
     ) -> Result<PaginatedResult<MessageSearchRow>, DbError>;
+
+    /// Returns persisted conversation artifacts ordered by `created_at`.
+    async fn list_artifacts(
+        &self,
+        _conversation_id: &str,
+    ) -> Result<Vec<ConversationArtifactRow>, DbError> {
+        Ok(Vec::new())
+    }
+
+    /// Returns a conversation artifact by ID scoped to a conversation.
+    async fn get_artifact(
+        &self,
+        _conversation_id: &str,
+        _artifact_id: &str,
+    ) -> Result<Option<ConversationArtifactRow>, DbError> {
+        Ok(None)
+    }
+
+    /// Inserts or updates a conversation artifact by primary key.
+    async fn upsert_artifact(
+        &self,
+        artifact: &ConversationArtifactRow,
+    ) -> Result<ConversationArtifactRow, DbError> {
+        Ok(artifact.clone())
+    }
+
+    /// Updates artifact status and returns the updated row if found.
+    async fn update_artifact_status(
+        &self,
+        _conversation_id: &str,
+        _artifact_id: &str,
+        _status: &str,
+        _updated_at: TimestampMs,
+    ) -> Result<Option<ConversationArtifactRow>, DbError> {
+        Ok(None)
+    }
+
+    /// Marks all skill suggestion artifacts for a cron job as saved.
+    async fn mark_skill_suggest_artifacts_saved(
+        &self,
+        _cron_job_id: &str,
+        _updated_at: TimestampMs,
+    ) -> Result<Vec<ConversationArtifactRow>, DbError> {
+        Ok(Vec::new())
+    }
+
+    /// Deletes all artifacts belonging to a conversation.
+    async fn delete_artifacts_by_conversation(
+        &self,
+        _conversation_id: &str,
+    ) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    /// Returns legacy persisted cron trigger rows so callers can synthesize
+    /// artifact cards for historical conversations created before artifact migration.
+    async fn list_legacy_cron_trigger_messages(
+        &self,
+        _conversation_id: &str,
+    ) -> Result<Vec<MessageRow>, DbError> {
+        Ok(Vec::new())
+    }
 }
 
 // ── Supporting types ────────────────────────────────────────────────

--- a/crates/aionui-db/src/repository/sqlite_conversation.rs
+++ b/crates/aionui-db/src/repository/sqlite_conversation.rs
@@ -3,7 +3,7 @@ use sqlx::SqlitePool;
 use aionui_common::PaginatedResult;
 
 use crate::error::DbError;
-use crate::models::{ConversationRow, MessageRow};
+use crate::models::{ConversationArtifactRow, ConversationRow, MessageRow};
 use crate::repository::conversation::{
     ConversationFilters, ConversationRowUpdate, IConversationRepository, MessageRowUpdate,
     MessageSearchRow, SortOrder,
@@ -296,16 +296,20 @@ impl IConversationRepository for SqliteConversationRepository {
         let offset = (effective_page - 1) * effective_size;
         let fetch_limit = effective_size + 1;
 
-        let count_row: (i64,) =
-            sqlx::query_as("SELECT COUNT(*) FROM messages WHERE conversation_id = ?")
-                .bind(conv_id)
-                .fetch_one(&self.pool)
-                .await?;
+        let count_row: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM messages \
+                 WHERE conversation_id = ? \
+                   AND type NOT IN ('cron_trigger', 'skill_suggest')",
+        )
+        .bind(conv_id)
+        .fetch_one(&self.pool)
+        .await?;
         let total = count_row.0 as u64;
 
         let sql = format!(
             "SELECT * FROM messages \
              WHERE conversation_id = ? \
+               AND type NOT IN ('cron_trigger', 'skill_suggest') \
              ORDER BY created_at {}, id {} \
              LIMIT ? OFFSET ?",
             order.as_sql(),
@@ -477,6 +481,153 @@ impl IConversationRepository for SqliteConversationRepository {
             total,
             has_more,
         })
+    }
+
+    async fn list_artifacts(
+        &self,
+        conversation_id: &str,
+    ) -> Result<Vec<ConversationArtifactRow>, DbError> {
+        let rows = sqlx::query_as::<_, ConversationArtifactRow>(
+            "SELECT * FROM conversation_artifacts \
+             WHERE conversation_id = ? \
+             ORDER BY created_at ASC, id ASC",
+        )
+        .bind(conversation_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    async fn get_artifact(
+        &self,
+        conversation_id: &str,
+        artifact_id: &str,
+    ) -> Result<Option<ConversationArtifactRow>, DbError> {
+        let row = sqlx::query_as::<_, ConversationArtifactRow>(
+            "SELECT * FROM conversation_artifacts WHERE conversation_id = ? AND id = ?",
+        )
+        .bind(conversation_id)
+        .bind(artifact_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    async fn upsert_artifact(
+        &self,
+        artifact: &ConversationArtifactRow,
+    ) -> Result<ConversationArtifactRow, DbError> {
+        sqlx::query(
+            "INSERT INTO conversation_artifacts \
+                (id, conversation_id, cron_job_id, kind, status, payload, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?) \
+             ON CONFLICT(id) DO UPDATE SET \
+                conversation_id = excluded.conversation_id, \
+                cron_job_id = excluded.cron_job_id, \
+                kind = excluded.kind, \
+                status = excluded.status, \
+                payload = excluded.payload, \
+                updated_at = excluded.updated_at",
+        )
+        .bind(&artifact.id)
+        .bind(&artifact.conversation_id)
+        .bind(&artifact.cron_job_id)
+        .bind(&artifact.kind)
+        .bind(&artifact.status)
+        .bind(&artifact.payload)
+        .bind(artifact.created_at)
+        .bind(artifact.updated_at)
+        .execute(&self.pool)
+        .await?;
+
+        self.get_artifact(&artifact.conversation_id, &artifact.id)
+            .await?
+            .ok_or_else(|| {
+                DbError::Init(format!(
+                    "upsert artifact did not produce row for id '{}'",
+                    artifact.id
+                ))
+            })
+    }
+
+    async fn update_artifact_status(
+        &self,
+        conversation_id: &str,
+        artifact_id: &str,
+        status: &str,
+        updated_at: i64,
+    ) -> Result<Option<ConversationArtifactRow>, DbError> {
+        let result = sqlx::query(
+            "UPDATE conversation_artifacts \
+             SET status = ?, updated_at = ? \
+             WHERE conversation_id = ? AND id = ?",
+        )
+        .bind(status)
+        .bind(updated_at)
+        .bind(conversation_id)
+        .bind(artifact_id)
+        .execute(&self.pool)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Ok(None);
+        }
+
+        self.get_artifact(conversation_id, artifact_id).await
+    }
+
+    async fn mark_skill_suggest_artifacts_saved(
+        &self,
+        cron_job_id: &str,
+        updated_at: i64,
+    ) -> Result<Vec<ConversationArtifactRow>, DbError> {
+        sqlx::query(
+            "UPDATE conversation_artifacts \
+             SET status = 'saved', updated_at = ? \
+             WHERE kind = 'skill_suggest' AND cron_job_id = ? AND status != 'saved'",
+        )
+        .bind(updated_at)
+        .bind(cron_job_id)
+        .execute(&self.pool)
+        .await?;
+
+        let rows = sqlx::query_as::<_, ConversationArtifactRow>(
+            "SELECT * FROM conversation_artifacts \
+             WHERE kind = 'skill_suggest' AND cron_job_id = ? \
+             ORDER BY created_at ASC, id ASC",
+        )
+        .bind(cron_job_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    async fn delete_artifacts_by_conversation(&self, conversation_id: &str) -> Result<(), DbError> {
+        sqlx::query("DELETE FROM conversation_artifacts WHERE conversation_id = ?")
+            .bind(conversation_id)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn list_legacy_cron_trigger_messages(
+        &self,
+        conversation_id: &str,
+    ) -> Result<Vec<MessageRow>, DbError> {
+        let rows = sqlx::query_as::<_, MessageRow>(
+            "SELECT * FROM messages \
+             WHERE conversation_id = ? AND type = 'cron_trigger' \
+             ORDER BY created_at ASC, id ASC",
+        )
+        .bind(conversation_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
     }
 }
 

--- a/crates/aionui-db/src/repository/sqlite_conversation.rs
+++ b/crates/aionui-db/src/repository/sqlite_conversation.rs
@@ -224,10 +224,12 @@ impl IConversationRepository for SqliteConversationRepository {
     ) -> Result<Vec<ConversationRow>, DbError> {
         let rows = sqlx::query_as::<_, ConversationRow>(
             "SELECT * FROM conversations \
-             WHERE user_id = ? AND json_extract(extra, '$.cronJobId') = ? \
+             WHERE user_id = ? \
+             AND (json_extract(extra, '$.cronJobId') = ? OR json_extract(extra, '$.cron_job_id') = ?) \
              ORDER BY updated_at DESC",
         )
         .bind(user_id)
+        .bind(cron_job_id)
         .bind(cron_job_id)
         .fetch_all(&self.pool)
         .await?;
@@ -531,7 +533,11 @@ fn append_filter_conditions(
         binds.push(BindValue::Str(source.clone()));
     }
     if let Some(ref cron_job_id) = filters.cron_job_id {
-        where_parts.push("json_extract(c.extra, '$.cronJobId') = ?".to_string());
+        where_parts.push(
+            "(json_extract(c.extra, '$.cronJobId') = ? OR json_extract(c.extra, '$.cron_job_id') = ?)"
+                .to_string(),
+        );
+        binds.push(BindValue::Str(cron_job_id.clone()));
         binds.push(BindValue::Str(cron_job_id.clone()));
     }
     if let Some(pinned) = filters.pinned {

--- a/crates/aionui-db/tests/conversation_repository.rs
+++ b/crates/aionui-db/tests/conversation_repository.rs
@@ -46,6 +46,25 @@ fn make_message(conv_id: &str, content: &str) -> MessageRow {
     }
 }
 
+fn make_artifact(conv_id: &str, artifact_id: &str) -> aionui_db::ConversationArtifactRow {
+    aionui_db::ConversationArtifactRow {
+        id: artifact_id.to_string(),
+        conversation_id: conv_id.to_string(),
+        cron_job_id: Some("cron_1".to_string()),
+        kind: "skill_suggest".to_string(),
+        status: "pending".to_string(),
+        payload: serde_json::json!({
+            "cron_job_id": "cron_1",
+            "name": "daily-report",
+            "description": "Daily report",
+            "skillContent": "---\nname: daily-report\n---\nUse it."
+        })
+        .to_string(),
+        created_at: 1000,
+        updated_at: 1000,
+    }
+}
+
 // ── Conversation CRUD ───────────────────────────────────────────────
 
 #[tokio::test]
@@ -691,6 +710,128 @@ async fn update_extra_replaces_json() {
 
     let found = repo.get(&conv.id).await.unwrap().unwrap();
     assert_eq!(found.extra, r#"{"workspace":"/new","flag":true}"#);
+}
+
+#[tokio::test]
+async fn get_messages_excludes_legacy_cron_and_skill_suggest_rows() {
+    let (repo, _db) = setup().await;
+    let conv = make_conversation("message-filter");
+    repo.create(&conv).await.unwrap();
+
+    repo.insert_message(&make_message(&conv.id, "visible"))
+        .await
+        .unwrap();
+
+    for (id, ty) in [
+        ("legacy-cron", "cron_trigger"),
+        ("legacy-skill", "skill_suggest"),
+    ] {
+        repo.insert_message(&MessageRow {
+            id: id.into(),
+            conversation_id: conv.id.clone(),
+            msg_id: None,
+            r#type: ty.into(),
+            content: "{}".into(),
+            position: Some("center".into()),
+            status: Some("finish".into()),
+            hidden: false,
+            created_at: 2000,
+        })
+        .await
+        .unwrap();
+    }
+
+    let rows = repo
+        .get_messages(&conv.id, 1, 50, SortOrder::Asc)
+        .await
+        .unwrap();
+    assert_eq!(rows.total, 1);
+    assert_eq!(rows.items.len(), 1);
+    assert_eq!(rows.items[0].r#type, "text");
+}
+
+#[tokio::test]
+async fn list_legacy_cron_trigger_messages_returns_only_trigger_rows() {
+    let (repo, _db) = setup().await;
+    let conv = make_conversation("legacy-cron-trigger");
+    repo.create(&conv).await.unwrap();
+
+    repo.insert_message(&MessageRow {
+        id: aionui_common::generate_prefixed_id("msg"),
+        conversation_id: conv.id.clone(),
+        msg_id: Some("legacy-trigger".into()),
+        r#type: "cron_trigger".into(),
+        content: r#"{"cron_job_id":"cron_1","cron_job_name":"Daily Report"}"#.into(),
+        position: Some("center".into()),
+        status: Some("finish".into()),
+        hidden: false,
+        created_at: 1000,
+    })
+    .await
+    .unwrap();
+    repo.insert_message(&make_message(&conv.id, "plain text"))
+        .await
+        .unwrap();
+
+    let rows = repo
+        .list_legacy_cron_trigger_messages(&conv.id)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].r#type, "cron_trigger");
+}
+
+#[tokio::test]
+async fn artifact_upsert_list_and_mark_saved() {
+    let (repo, _db) = setup().await;
+    let conv = make_conversation("artifact-row");
+    repo.create(&conv).await.unwrap();
+
+    let artifact_id = format!("{}:skill_suggest:cron_1", conv.id);
+    let inserted = repo
+        .upsert_artifact(&make_artifact(&conv.id, &artifact_id))
+        .await
+        .unwrap();
+    assert_eq!(inserted.status, "pending");
+
+    let listed = repo.list_artifacts(&conv.id).await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].id, artifact_id);
+
+    let dismissed = repo
+        .update_artifact_status(&conv.id, &artifact_id, "dismissed", 2000)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(dismissed.status, "dismissed");
+    assert_eq!(dismissed.updated_at, 2000);
+
+    let saved = repo
+        .mark_skill_suggest_artifacts_saved("cron_1", 3000)
+        .await
+        .unwrap();
+    assert_eq!(saved.len(), 1);
+    assert_eq!(saved[0].status, "saved");
+    assert_eq!(saved[0].updated_at, 3000);
+}
+
+#[tokio::test]
+async fn delete_artifacts_by_conversation_removes_rows() {
+    let (repo, _db) = setup().await;
+    let conv = make_conversation("artifact-delete");
+    repo.create(&conv).await.unwrap();
+
+    let artifact_id = format!("{}:skill_suggest:cron_1", conv.id);
+    repo.upsert_artifact(&make_artifact(&conv.id, &artifact_id))
+        .await
+        .unwrap();
+
+    repo.delete_artifacts_by_conversation(&conv.id)
+        .await
+        .unwrap();
+
+    let listed = repo.list_artifacts(&conv.id).await.unwrap();
+    assert!(listed.is_empty());
 }
 
 // ── User isolation ──────────────────────────────────────────────────

--- a/crates/aionui-db/tests/conversation_repository.rs
+++ b/crates/aionui-db/tests/conversation_repository.rs
@@ -259,6 +259,30 @@ async fn filter_by_cron_job_id() {
     assert_eq!(result.items[0].id, c1.id);
 }
 
+#[tokio::test]
+async fn filter_by_cron_job_id_accepts_snake_case_extra() {
+    let (repo, _db) = setup().await;
+
+    let mut c1 = make_conversation("cron-snake");
+    c1.extra = r#"{"cron_job_id":"cron_123","workspace":"/p"}"#.to_string();
+    repo.create(&c1).await.unwrap();
+
+    let result = repo
+        .list_paginated(
+            USER_ID,
+            &ConversationFilters {
+                cron_job_id: Some("cron_123".to_string()),
+                limit: 20,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.items.len(), 1);
+    assert_eq!(result.items[0].id, c1.id);
+}
+
 // ── Extended queries ────────────────────────────────────────────────
 
 #[tokio::test]
@@ -294,6 +318,22 @@ async fn list_by_cron_job_returns_matching() {
     let mut c3 = make_conversation("cron3");
     c3.extra = r#"{"cronJobId":"job_y","workspace":"/c"}"#.to_string();
     repo.create(&c3).await.unwrap();
+
+    let result = repo.list_by_cron_job(USER_ID, "job_x").await.unwrap();
+    assert_eq!(result.len(), 2);
+}
+
+#[tokio::test]
+async fn list_by_cron_job_accepts_mixed_key_formats() {
+    let (repo, _db) = setup().await;
+
+    let mut c1 = make_conversation("cron-old");
+    c1.extra = r#"{"cronJobId":"job_x","workspace":"/a"}"#.to_string();
+    repo.create(&c1).await.unwrap();
+
+    let mut c2 = make_conversation("cron-new");
+    c2.extra = r#"{"cron_job_id":"job_x","workspace":"/b"}"#.to_string();
+    repo.create(&c2).await.unwrap();
 
     let result = repo.list_by_cron_job(USER_ID, "job_x").await.unwrap();
     assert_eq!(result.len(), 2);

--- a/crates/aionui-extension/src/constants.rs
+++ b/crates/aionui-extension/src/constants.rs
@@ -55,6 +55,9 @@ pub const RESERVED_ROUTE_PREFIXES: &[&str] = &["/api/", "/auth/", "/ws/"];
 /// Default subdirectory name for user-created skills.
 pub const SKILLS_DIR_NAME: &str = "skills";
 
+/// Default subdirectory name for per-job cron skills under the data dir.
+pub const CRON_SKILLS_DIR_NAME: &str = "cron/skills";
+
 /// Default subdirectory name for built-in skills.
 pub const BUILTIN_SKILLS_DIR_NAME: &str = "builtin-skills";
 

--- a/crates/aionui-extension/src/skill_routes.rs
+++ b/crates/aionui-extension/src/skill_routes.rs
@@ -555,6 +555,7 @@ mod tests {
         let paths = SkillPaths {
             data_dir: tmp.path().to_path_buf(),
             user_skills_dir: tmp.path().join("skills"),
+            cron_skills_dir: tmp.path().join("cron").join("skills"),
             builtin_skills_dir: tmp.path().join("builtin-skills"),
             builtin_rules_dir: tmp.path().join("builtin-rules"),
             assistant_rules_dir: tmp.path().join("assistant-rules"),

--- a/crates/aionui-extension/src/skill_service.rs
+++ b/crates/aionui-extension/src/skill_service.rs
@@ -5,7 +5,8 @@ use tracing::{debug, warn};
 
 use crate::constants::{
     ASSISTANT_RULES_DIR_NAME, ASSISTANT_SKILLS_DIR_NAME, BUILTIN_AUTO_SKILLS_SUBDIR,
-    BUILTIN_RULES_DIR_NAME, COMMON_SKILL_DIRS, SKILL_MANIFEST_FILE, SKILLS_DIR_NAME,
+    BUILTIN_RULES_DIR_NAME, COMMON_SKILL_DIRS, CRON_SKILLS_DIR_NAME, SKILL_MANIFEST_FILE,
+    SKILLS_DIR_NAME,
 };
 use crate::error::ExtensionError;
 
@@ -46,6 +47,8 @@ pub struct SkillPaths {
     pub data_dir: PathBuf,
     /// User-created skills directory (~/.aionui/skills/).
     pub user_skills_dir: PathBuf,
+    /// Per-job cron skills directory (~/.aionui/cron/skills/).
+    pub cron_skills_dir: PathBuf,
     /// Built-in skills directory on disk. Always set.
     /// Points to `{data_dir}/builtin-skills/` in production (populated at
     /// startup by `startup_materialize::materialize_if_needed`) or
@@ -82,6 +85,7 @@ pub fn resolve_skill_paths(app_resource_dir: &Path, data_dir: &Path) -> SkillPat
     SkillPaths {
         data_dir: data_dir.to_path_buf(),
         user_skills_dir: data_dir.join(SKILLS_DIR_NAME),
+        cron_skills_dir: data_dir.join(CRON_SKILLS_DIR_NAME),
         builtin_skills_dir,
         builtin_rules_dir: app_resource_dir.join(BUILTIN_RULES_DIR_NAME),
         assistant_rules_dir: data_dir.join(ASSISTANT_RULES_DIR_NAME),
@@ -575,6 +579,7 @@ pub struct ResolvedAgentSkill {
 /// 1. `{builtin_skills_dir}/{name}/` — top-level opt-in builtin.
 /// 2. `{builtin_skills_dir}/auto-inject/{name}/` — auto-inject builtin.
 /// 3. `{user_skills_dir}/{name}/` — user-created custom skill.
+/// 4. `{cron_skills_dir}/{name}/` — per-job cron skill.
 ///
 /// No files are copied and no per-conversation directory is created —
 /// the backend just hands the absolute source paths back to the caller,
@@ -700,6 +705,10 @@ fn resolve_skill_source_path(paths: &SkillPaths, name: &str) -> Option<PathBuf> 
     let user = paths.user_skills_dir.join(name);
     if user.is_dir() {
         return Some(user);
+    }
+    let cron = paths.cron_skills_dir.join(name);
+    if cron.is_dir() {
+        return Some(cron);
     }
     None
 }
@@ -1154,6 +1163,7 @@ mod tests {
         let paths = SkillPaths {
             data_dir: tmp.path().to_path_buf(),
             user_skills_dir: tmp.path().join(SKILLS_DIR_NAME),
+            cron_skills_dir: tmp.path().join(CRON_SKILLS_DIR_NAME),
             builtin_skills_dir: tmp.path().join(crate::constants::BUILTIN_SKILLS_DIR_NAME),
             builtin_rules_dir: rules_dir,
             assistant_rules_dir: tmp.path().join(ASSISTANT_RULES_DIR_NAME),
@@ -1662,6 +1672,7 @@ mod tests {
         SkillPaths {
             data_dir: base.to_path_buf(),
             user_skills_dir: base.join(SKILLS_DIR_NAME),
+            cron_skills_dir: base.join(CRON_SKILLS_DIR_NAME),
             builtin_skills_dir: base.join(crate::constants::BUILTIN_SKILLS_DIR_NAME),
             builtin_rules_dir: base.join(BUILTIN_RULES_DIR_NAME),
             assistant_rules_dir: base.join(ASSISTANT_RULES_DIR_NAME),

--- a/crates/aionui-extension/tests/assistant_dispatch_test.rs
+++ b/crates/aionui-extension/tests/assistant_dispatch_test.rs
@@ -142,6 +142,7 @@ async fn router_with_dispatcher(dispatcher: Arc<FakeDispatcher>) -> axum::Router
     let paths = SkillPaths {
         data_dir: root.clone(),
         user_skills_dir: root.join("skills"),
+        cron_skills_dir: root.join("cron").join("skills"),
         builtin_skills_dir: root.join("builtin-skills"),
         builtin_rules_dir: root.join("builtin-rules"),
         assistant_rules_dir: root.join("assistant-rules"),

--- a/crates/aionui-extension/tests/cron_skill_resolve_test.rs
+++ b/crates/aionui-extension/tests/cron_skill_resolve_test.rs
@@ -1,0 +1,49 @@
+use aionui_extension::{resolve_skill_paths, skill_service};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn unique_temp_dir(label: &str) -> std::path::PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "aionui-extension-{label}-{}-{nanos}",
+        std::process::id()
+    ))
+}
+
+#[tokio::test]
+async fn resolve_skill_paths_includes_cron_skills_dir() {
+    let base = unique_temp_dir("cron-paths");
+    std::fs::create_dir_all(&base).unwrap();
+
+    let paths = resolve_skill_paths(&base, &base);
+    assert_eq!(paths.cron_skills_dir, base.join("cron").join("skills"));
+
+    std::fs::remove_dir_all(&base).unwrap();
+}
+
+#[tokio::test]
+async fn materialize_resolves_saved_cron_skill() {
+    let base = unique_temp_dir("cron-materialize");
+    let skill_dir = base.join("cron").join("skills").join("cron-job-123");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: cron-job-123\ndescription: Saved cron skill\n---\nUse the saved steps.",
+    )
+    .unwrap();
+
+    let paths = resolve_skill_paths(&base, &base);
+    let resolved =
+        skill_service::materialize_skills_for_agent(&paths, "conv-1", &["cron-job-123".to_owned()])
+            .await
+            .unwrap();
+
+    assert_eq!(resolved.len(), 1);
+    assert_eq!(resolved[0].name, "cron-job-123");
+    assert_eq!(resolved[0].source_path, skill_dir);
+    assert!(resolved[0].source_path.join("SKILL.md").exists());
+
+    std::fs::remove_dir_all(&base).unwrap();
+}

--- a/crates/aionui-extension/tests/skill_integration_test.rs
+++ b/crates/aionui-extension/tests/skill_integration_test.rs
@@ -26,6 +26,7 @@ fn make_paths(base: &Path) -> SkillPaths {
     SkillPaths {
         data_dir: base.to_path_buf(),
         user_skills_dir: base.join("skills"),
+        cron_skills_dir: base.join("cron").join("skills"),
         builtin_skills_dir: base.join("builtin-skills"),
         builtin_rules_dir: base.join("builtin-rules"),
         assistant_rules_dir: base.join("assistant-rules"),


### PR DESCRIPTION
## Summary
- finish the backend cron migration runtime: API parity, runtime middleware wiring, run-now conversation creation, skill storage, skill suggestion detection, and websocket delivery
- add backend-owned `cron_trigger` insertion/broadcasting plus conversation binding for existing-conversation jobs created through REST
- cover the migration with cron unit, integration, middleware, and app e2e tests

## Handoff Doc
- `AionUi/docs/backend-migration/plans/2026-04-28-cron-backend-migration-plan.md`

## Validation
- `cargo fmt --check -p aionui-cron`
- `cargo test -p aionui-cron --lib -- --nocapture`
- `cargo test -p aionui-cron --test service_integration -- --nocapture`
- `cargo test -p aionui-app --test cron_e2e -- --nocapture`
- `cargo test -p aionui-ai-agent middleware -- --nocapture`

## Notes
- saved cron skills are persisted under `data_dir/cron/skills/cron-<job_id>/SKILL.md`
- `run_now` now creates/returns a conversation with workspace + user-message insertion through the normal conversation service path
- existing-conversation jobs created from REST now bind `conversation.extra.cron_job_id` so scheduled-detail history and associations remain intact
