### PR TITLE
fix(cron): force full-auto mode for generated jobs

### DIFF
--- a/crates/aionui-common/src/enums.rs
+++ b/crates/aionui-common/src/enums.rs
@@ -77,6 +77,23 @@ impl AgentType {
             | AgentType::Gemini => None,
         }
     }
+
+    /// Canonical full-auto session mode id for this agent type.
+    ///
+    /// ACP agents need backend-specific mode ids, while other agent types
+    /// currently converge on the permissive `yolo` mode.
+    pub fn full_auto_mode_id(&self, backend: Option<AcpBackend>) -> &'static str {
+        match self {
+            AgentType::Acp => backend
+                .map(|backend| backend.full_auto_mode_id())
+                .unwrap_or("yolo"),
+            AgentType::Aionrs
+            | AgentType::Gemini
+            | AgentType::OpenclawGateway
+            | AgentType::Nanobot
+            | AgentType::Remote => "yolo",
+        }
+    }
 }
 
 /// ACP sub-backend identifier.
@@ -253,6 +270,21 @@ impl AcpBackend {
             | AcpBackend::Hermes
             | AcpBackend::Snow
             | AcpBackend::Auggie => None,
+        }
+    }
+
+    /// Canonical full-auto session mode id for this ACP backend.
+    ///
+    /// This mirrors the frontend `getFullAutoMode()` mapping and is used by
+    /// backend flows that need to materialize a new cron job from an existing
+    /// conversation without depending on a live ACP runtime snapshot.
+    pub fn full_auto_mode_id(&self) -> &'static str {
+        match self {
+            AcpBackend::Claude => "bypassPermissions",
+            AcpBackend::Codex => "full-access",
+            AcpBackend::Opencode => "build",
+            AcpBackend::Cursor => "agent",
+            _ => "yolo",
         }
     }
 }
@@ -686,5 +718,25 @@ mod tests {
         assert_eq!(AcpBackend::Gemini.args(), Some(&["--experimental-acp"][..]));
         // Gemini is a direct-CLI backend, no bridge
         assert_eq!(AcpBackend::Gemini.bridge_package(), None);
+    }
+
+    #[test]
+    fn acp_backend_full_auto_mode_id_matches_backend_capabilities() {
+        assert_eq!(AcpBackend::Claude.full_auto_mode_id(), "bypassPermissions");
+        assert_eq!(AcpBackend::Codex.full_auto_mode_id(), "full-access");
+        assert_eq!(AcpBackend::Opencode.full_auto_mode_id(), "build");
+        assert_eq!(AcpBackend::Cursor.full_auto_mode_id(), "agent");
+        assert_eq!(AcpBackend::Gemini.full_auto_mode_id(), "yolo");
+        assert_eq!(AcpBackend::Qwen.full_auto_mode_id(), "yolo");
+    }
+
+    #[test]
+    fn agent_type_full_auto_mode_id_supports_non_acp_agents() {
+        assert_eq!(
+            AgentType::Acp.full_auto_mode_id(Some(AcpBackend::Codex)),
+            "full-access"
+        );
+        assert_eq!(AgentType::Aionrs.full_auto_mode_id(None), "yolo");
+        assert_eq!(AgentType::Remote.full_auto_mode_id(None), "yolo");
     }
 }

--- a/crates/aionui-cron/src/service.rs
+++ b/crates/aionui-cron/src/service.rs
@@ -6,7 +6,7 @@ use aionui_api_types::{
     CreateCronJobRequest, CronJobResponse, CronScheduleDto, HasSkillResponse, ListCronJobsQuery,
     RunNowResponse, SaveCronSkillRequest, UpdateCronJobRequest,
 };
-use aionui_common::{ProviderWithModel, generate_prefixed_id, now_ms};
+use aionui_common::{AcpBackend, AgentType, ProviderWithModel, generate_prefixed_id, now_ms};
 use aionui_db::{ICronRepository, UpdateCronJobParams};
 use tracing::{error, info, warn};
 
@@ -1032,7 +1032,14 @@ fn build_agent_config_from_conversation(
         None
     };
 
-    let full_auto_mode = cron_full_auto_mode_for_backend(&backend);
+    let agent_type_enum =
+        serde_json::from_value::<AgentType>(serde_json::Value::String(row.r#type.clone())).ok();
+    let backend_enum =
+        serde_json::from_value::<AcpBackend>(serde_json::Value::String(backend.clone())).ok();
+    let full_auto_mode = agent_type_enum
+        .unwrap_or(AgentType::Acp)
+        .full_auto_mode_id(backend_enum)
+        .to_owned();
     let agent_config = aionui_api_types::CronAgentConfigDto {
         backend,
         name: get_string(&extra, &["agent_name", "agentName"]).unwrap_or_else(|| row.name.clone()),
@@ -1061,17 +1068,6 @@ fn build_agent_config_from_conversation(
 
     (row.r#type.clone(), Some(agent_config))
 }
-
-fn cron_full_auto_mode_for_backend(backend: &str) -> String {
-    match backend.trim() {
-        "claude" => "bypassPermissions".to_owned(),
-        "codex" => "full-access".to_owned(),
-        "opencode" => "build".to_owned(),
-        "cursor" => "agent".to_owned(),
-        _ => "yolo".to_owned(),
-    }
-}
-
 fn get_string(extra: &serde_json::Value, keys: &[&str]) -> Option<String> {
     keys.iter().find_map(|key| {
         extra

--- a/crates/aionui-cron/src/service.rs
+++ b/crates/aionui-cron/src/service.rs
@@ -1032,6 +1032,7 @@ fn build_agent_config_from_conversation(
         None
     };
 
+    let full_auto_mode = cron_full_auto_mode_for_backend(&backend);
     let agent_config = aionui_api_types::CronAgentConfigDto {
         backend,
         name: get_string(&extra, &["agent_name", "agentName"]).unwrap_or_else(|| row.name.clone()),
@@ -1045,7 +1046,7 @@ fn build_agent_config_from_conversation(
         is_preset,
         custom_agent_id,
         preset_agent_type,
-        mode: get_string(&extra, &["session_mode", "sessionMode"]),
+        mode: Some(full_auto_mode),
         model_id: get_string(&extra, &["current_model_id", "currentModelId"]).or_else(|| {
             model.as_ref().and_then(|value| {
                 value
@@ -1059,6 +1060,16 @@ fn build_agent_config_from_conversation(
     };
 
     (row.r#type.clone(), Some(agent_config))
+}
+
+fn cron_full_auto_mode_for_backend(backend: &str) -> String {
+    match backend.trim() {
+        "claude" => "bypassPermissions".to_owned(),
+        "codex" => "full-access".to_owned(),
+        "opencode" => "build".to_owned(),
+        "cursor" => "agent".to_owned(),
+        _ => "yolo".to_owned(),
+    }
 }
 
 fn get_string(extra: &serde_json::Value, keys: &[&str]) -> Option<String> {

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -256,6 +256,36 @@ impl IConversationRepository for StubConvRepo {
                 created_at: 1000,
                 updated_at: 1000,
             }
+        } else if id == "conv_mode_aionrs" {
+            aionui_db::models::ConversationRow {
+                id: id.into(),
+                user_id: "u1".into(),
+                name: "Aionrs Chat".into(),
+                r#type: "aionrs".into(),
+                model: Some(
+                    serde_json::json!({
+                        "provider_id": "anthropic",
+                        "model": "claude-sonnet-4-20250514",
+                        "use_model": "claude-sonnet-4-20250514"
+                    })
+                    .to_string(),
+                ),
+                status: Some("active".into()),
+                source: None,
+                channel_chat_id: None,
+                extra: serde_json::json!({
+                    "backend": "anthropic",
+                    "agent_name": "Aion CLI",
+                    "workspace": "/tmp/aionrs-workspace",
+                    "session_mode": "default",
+                    "current_model_id": "claude-sonnet-4-20250514"
+                })
+                .to_string(),
+                pinned: false,
+                pinned_at: None,
+                created_at: 1000,
+                updated_at: 1000,
+            }
         } else {
             aionui_db::models::ConversationRow {
                 id: id.into(),
@@ -1284,6 +1314,9 @@ async fn icron_service_create_job_forces_full_auto_mode_for_generated_crons() {
     let claude = ICronService::create_job(&svc, "user_1", "conv_mode_claude", &params).await;
     assert!(claude.success);
 
+    let aionrs = ICronService::create_job(&svc, "user_1", "conv_mode_aionrs", &params).await;
+    assert!(aionrs.success);
+
     let gemini_jobs = svc
         .list_jobs(&ListCronJobsQuery {
             conversation_id: Some("conv_mode_default".into()),
@@ -1324,6 +1357,20 @@ async fn icron_service_create_job_forces_full_auto_mode_for_generated_crons() {
             .as_ref()
             .and_then(|config| config.mode.as_deref()),
         Some("bypassPermissions")
+    );
+
+    let aionrs_jobs = svc
+        .list_jobs(&ListCronJobsQuery {
+            conversation_id: Some("conv_mode_aionrs".into()),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        aionrs_jobs[0]
+            .agent_config
+            .as_ref()
+            .and_then(|config| config.mode.as_deref()),
+        Some("yolo")
     );
 }
 

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -166,6 +166,96 @@ impl IConversationRepository for StubConvRepo {
                 created_at: 1000,
                 updated_at: 1000,
             }
+        } else if id == "conv_mode_default" {
+            aionui_db::models::ConversationRow {
+                id: id.into(),
+                user_id: "u1".into(),
+                name: "Gemini Default Chat".into(),
+                r#type: "acp".into(),
+                model: Some(
+                    serde_json::json!({
+                        "provider_id": "gemini",
+                        "model": "gemini-2.5-pro",
+                        "use_model": "gemini-2.5-pro"
+                    })
+                    .to_string(),
+                ),
+                status: Some("active".into()),
+                source: None,
+                channel_chat_id: None,
+                extra: serde_json::json!({
+                    "backend": "gemini",
+                    "agent_name": "Gemini",
+                    "workspace": "/tmp/gemini-default-workspace",
+                    "session_mode": "default",
+                    "current_model_id": "gemini-2.5-pro"
+                })
+                .to_string(),
+                pinned: false,
+                pinned_at: None,
+                created_at: 1000,
+                updated_at: 1000,
+            }
+        } else if id == "conv_mode_codex" {
+            aionui_db::models::ConversationRow {
+                id: id.into(),
+                user_id: "u1".into(),
+                name: "Codex Chat".into(),
+                r#type: "acp".into(),
+                model: Some(
+                    serde_json::json!({
+                        "provider_id": "codex",
+                        "model": "gpt-5-codex",
+                        "use_model": "gpt-5-codex"
+                    })
+                    .to_string(),
+                ),
+                status: Some("active".into()),
+                source: None,
+                channel_chat_id: None,
+                extra: serde_json::json!({
+                    "backend": "codex",
+                    "agent_name": "Codex",
+                    "workspace": "/tmp/codex-workspace",
+                    "session_mode": "default",
+                    "current_model_id": "gpt-5-codex"
+                })
+                .to_string(),
+                pinned: false,
+                pinned_at: None,
+                created_at: 1000,
+                updated_at: 1000,
+            }
+        } else if id == "conv_mode_claude" {
+            aionui_db::models::ConversationRow {
+                id: id.into(),
+                user_id: "u1".into(),
+                name: "Claude Chat".into(),
+                r#type: "acp".into(),
+                model: Some(
+                    serde_json::json!({
+                        "provider_id": "claude",
+                        "model": "claude-sonnet-4-20250514",
+                        "use_model": "claude-sonnet-4-20250514"
+                    })
+                    .to_string(),
+                ),
+                status: Some("active".into()),
+                source: None,
+                channel_chat_id: None,
+                extra: serde_json::json!({
+                    "backend": "claude",
+                    "agent_name": "Claude",
+                    "workspace": "/tmp/claude-workspace",
+                    "session_mode": "default",
+                    "current_model_id": "claude-sonnet-4-20250514"
+                })
+                .to_string(),
+                pinned: false,
+                pinned_at: None,
+                created_at: 1000,
+                updated_at: 1000,
+            }
         } else {
             aionui_db::models::ConversationRow {
                 id: id.into(),
@@ -1170,6 +1260,71 @@ async fn icron_service_create_job_inherits_conversation_mode_and_backend() {
     assert_eq!(config.mode.as_deref(), Some("yolo"));
     assert_eq!(config.model_id.as_deref(), Some("gemini-2.5-pro"));
     assert_eq!(config.workspace.as_deref(), Some("/tmp/gemini-workspace"));
+}
+
+#[tokio::test]
+async fn icron_service_create_job_forces_full_auto_mode_for_generated_crons() {
+    let (svc, _, _) = setup().await;
+
+    use aionui_ai_agent::middleware::ICronService;
+
+    let params = CronCreateParams {
+        name: "Generated Agent Job".into(),
+        schedule: "0 */10 * * * *".into(),
+        schedule_description: "every 10 min".into(),
+        message: "do agent work".into(),
+    };
+
+    let gemini = ICronService::create_job(&svc, "user_1", "conv_mode_default", &params).await;
+    assert!(gemini.success);
+
+    let codex = ICronService::create_job(&svc, "user_1", "conv_mode_codex", &params).await;
+    assert!(codex.success);
+
+    let claude = ICronService::create_job(&svc, "user_1", "conv_mode_claude", &params).await;
+    assert!(claude.success);
+
+    let gemini_jobs = svc
+        .list_jobs(&ListCronJobsQuery {
+            conversation_id: Some("conv_mode_default".into()),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        gemini_jobs[0]
+            .agent_config
+            .as_ref()
+            .and_then(|config| config.mode.as_deref()),
+        Some("yolo")
+    );
+
+    let codex_jobs = svc
+        .list_jobs(&ListCronJobsQuery {
+            conversation_id: Some("conv_mode_codex".into()),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        codex_jobs[0]
+            .agent_config
+            .as_ref()
+            .and_then(|config| config.mode.as_deref()),
+        Some("full-access")
+    );
+
+    let claude_jobs = svc
+        .list_jobs(&ListCronJobsQuery {
+            conversation_id: Some("conv_mode_claude".into()),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        claude_jobs[0]
+            .agent_config
+            .as_ref()
+            .and_then(|config| config.mode.as_deref()),
+        Some("bypassPermissions")
+    );
 }
 
 // ── ICronService trait: list ───────────────────────────────────────


### PR DESCRIPTION
## Summary

- force conversation-generated cron jobs onto each agent's frontend-defined full-auto mode instead of inheriting the current chat mode
- move the mode mapping into shared backend agent metadata so ACP and non-ACP agents stay aligned with AionUi mode semantics
- cover the new mode mapping and generated-job behavior with targeted cron service integration tests

## Test plan

- [x] `cargo fmt --check -p aionui-common -p aionui-cron`
- [x] `cargo test -p aionui-common agent_type_full_auto_mode_id_supports_non_acp_agents -- --nocapture`
- [x] `cargo test -p aionui-cron icron_service_create_job_forces_full_auto_mode_for_generated_crons -- --nocapture`
- [x] `cargo test -p aionui-cron icron_service_create_job_inherits_conversation_mode_and_backend -- --nocapture`