### PR TITLE
feat(api-types): D1 TeamMcpStdioConfig + env keys in team_mcp module

### DIFF
--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -21,6 +21,7 @@ mod shell;
 mod skill;
 mod system;
 mod team;
+mod team_mcp;
 mod websocket;
 
 pub use acp::{
@@ -136,4 +137,5 @@ pub use team::{
     TeamAgentRenamedPayload, TeamAgentResponse, TeamAgentSpawnedPayload, TeamAgentStatusPayload,
     TeamListResponse, TeamResponse,
 };
+pub use team_mcp::TeamMcpStdioConfig;
 pub use websocket::WebSocketMessage;

--- a/crates/aionui-api-types/src/team_mcp.rs
+++ b/crates/aionui-api-types/src/team_mcp.rs
@@ -1,0 +1,53 @@
+//! Team session MCP stdio connection types.
+//!
+//! These are promoted from `aionui-team::mcp::bridge` so that downstream
+//! crates (`aionui-ai-agent` deserializing `AcpBuildExtra`, etc.) can reference
+//! the same shape without depending on `aionui-team`.
+
+use serde::{Deserialize, Serialize};
+
+/// Stdio connection triple for the team session MCP server.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TeamMcpStdioConfig {
+    pub port: u16,
+    pub token: String,
+    pub slot_id: String,
+}
+
+impl TeamMcpStdioConfig {
+    /// env key the stdio bridge reads to learn the backend TCP port.
+    pub const ENV_PORT: &'static str = "TEAM_MCP_PORT";
+    /// env key the stdio bridge reads to learn the auth token.
+    pub const ENV_TOKEN: &'static str = "TEAM_MCP_TOKEN";
+    /// env key the stdio bridge reads to learn which agent slot it represents.
+    pub const ENV_SLOT_ID: &'static str = "TEAM_AGENT_SLOT_ID";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_preserves_all_fields() {
+        let cfg = TeamMcpStdioConfig {
+            port: 54321,
+            token: "tok-abc".into(),
+            slot_id: "slot-1".into(),
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let parsed: TeamMcpStdioConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(cfg, parsed);
+    }
+
+    #[test]
+    fn deserialization_tolerates_unknown_fields() {
+        // Forward-compat: extra fields in persisted `conversation.extra.team_mcp_stdio_config`
+        // JSON (e.g. added by a later backend version) must still round-trip through
+        // older binaries without error.
+        let json = r#"{"port":1,"token":"t","slot_id":"s","future_field":42}"#;
+        let parsed: TeamMcpStdioConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.port, 1);
+        assert_eq!(parsed.token, "t");
+        assert_eq!(parsed.slot_id, "s");
+    }
+}


### PR DESCRIPTION
## Summary

Wave 1 module **D1** — promotes `TeamMcpStdioConfig` (port/token/slot_id) and the three env-key constants (`TEAM_MCP_PORT`, `TEAM_MCP_TOKEN`, `TEAM_AGENT_SLOT_ID`) into `aionui-api-types::team_mcp`. This is the "type seed" that unblocks D2 / D3 / D6 in Wave 1.

Strictly follows [interface-contracts.md §1](../docs/teams/phase1/interface-contracts.md):

- struct derives `Debug, Clone, PartialEq, Eq, Serialize, Deserialize`
- fields are `snake_case`: `port: u16`, `token: String`, `slot_id: String`
- associated consts `ENV_PORT` / `ENV_TOKEN` / `ENV_SLOT_ID` match the bridge stdio env names
- `lib.rs` adds `mod team_mcp;` and `pub use team_mcp::TeamMcpStdioConfig;`
- zero new deps (only `serde`, already present)

The existing `aionui-team::mcp::bridge::TeamMcpStdioConfig` is left untouched — D3 will switch it to `pub use aionui_api_types::TeamMcpStdioConfig;`.

## Files changed

- **new** `crates/aionui-api-types/src/team_mcp.rs` (53 lines, including 2 tests)
- `crates/aionui-api-types/src/lib.rs` (+2 lines: `mod team_mcp;` + `pub use`)

## Test plan

- [x] `cargo test -p aionui-api-types` — 2 new tests pass (`json_roundtrip_preserves_all_fields`, `deserialization_tolerates_unknown_fields`), 0 regressions
- [x] `cargo clippy -p aionui-api-types -- -D warnings` — clean
- [x] `cargo fmt -p aionui-api-types -- --check` — clean (workspace-wide fmt issues exist on `feat/team-wave1` baseline but are unrelated to this PR)

## Follow-ups (out of scope)

- D2 will add `team_mcp_stdio_config: Option<TeamMcpStdioConfig>` to `AcpBuildExtra` using the new `pub use` path.
- D3 will rewrite `aionui-team::mcp::bridge::TeamMcpStdioConfig` as a re-export and add `TeamMcpStdioServerSpec`.
- D6 will read the three env-key constants from `aionui_api_types::TeamMcpStdioConfig::ENV_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)