### PR TITLE
feat(ai-agent): add team_mcp_stdio_config to AcpBuildExtra (D2)

### DIFF
--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use aionui_api_types::TeamMcpStdioConfig;
 use aionui_common::{AcpBackend, AgentType, ProviderWithModel};
 
 /// Data payload for sending a user message to an Agent.
@@ -71,6 +72,12 @@ pub struct AcpBuildExtra {
     /// Associated cron job ID.
     #[serde(default)]
     pub cron_job_id: Option<String>,
+    /// Team session MCP stdio config. When present, the factory injects it as
+    /// a stdio MCP server on `session/new`. Written by
+    /// `TeamSessionService::ensure_session` into `conversation.extra`; solo
+    /// conversations leave this unset.
+    #[serde(default)]
+    pub team_mcp_stdio_config: Option<TeamMcpStdioConfig>,
 }
 
 /// OpenClaw gateway configuration.
@@ -224,6 +231,33 @@ mod tests {
         let with_field = r#"{"backend":"claude","skills":["cron","pdf"]}"#;
         let parsed: AcpBuildExtra = serde_json::from_str(with_field).unwrap();
         assert_eq!(parsed.skills, vec!["cron".to_owned(), "pdf".to_owned()]);
+    }
+
+    #[test]
+    fn acp_build_extra_missing_team_mcp_stdio_config_is_none() {
+        // Legacy extra (pre-team-wave1) must deserialize cleanly with the new
+        // optional `team_mcp_stdio_config` absent — this keeps solo chat
+        // conversations working without any migration.
+        let legacy = r#"{"backend":"claude","skills":["cron"]}"#;
+        let parsed: AcpBuildExtra = serde_json::from_str(legacy).unwrap();
+        assert!(parsed.team_mcp_stdio_config.is_none());
+    }
+
+    #[test]
+    fn acp_build_extra_parses_team_mcp_stdio_config() {
+        let with_cfg = r#"{
+            "backend":"claude",
+            "team_mcp_stdio_config":{
+                "port":54321,
+                "token":"tok-abc",
+                "slot_id":"slot-lead"
+            }
+        }"#;
+        let parsed: AcpBuildExtra = serde_json::from_str(with_cfg).unwrap();
+        let cfg = parsed.team_mcp_stdio_config.expect("config present");
+        assert_eq!(cfg.port, 54321);
+        assert_eq!(cfg.token, "tok-abc");
+        assert_eq!(cfg.slot_id, "slot-lead");
     }
 
     #[test]

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -65,6 +65,7 @@ async fn make_mock_agent(
         preset_assistant_id: None,
         session_mode: None,
         cron_job_id: None,
+        team_mcp_stdio_config: None,
     };
 
     let tmp_skills = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- Adds optional `team_mcp_stdio_config: Option<TeamMcpStdioConfig>` to `AcpBuildExtra` (`crates/aionui-ai-agent/src/types.rs`). When present, the ACP factory will inject a team session MCP server on `session/new`.
- Reuses `aionui_api_types::TeamMcpStdioConfig` from D1 (#46, already merged on this branch) instead of a local stub — no duplicate type.
- `#[serde(default)]` + `Option` keeps legacy `conversation.extra` payloads backward-compatible; solo chat unaffected (no migration).
- Updates the one existing struct literal in `tests/acp_agent_integration.rs` to include the new field (`None`).

Refs: `docs/teams/phase1/interface-contracts.md` §2 (module D2), `docs/teams/phase1/modules.md` §D2.

## Test plan

- [x] `cargo test -p aionui-ai-agent` — 2 new tests pass, all pre-existing types tests still pass. (One unrelated pre-existing flake `acp_runtime_snapshot::tests::applies_mode_update_into_session_mode_state` fails identically on `feat/team-wave1` base — not touched by this PR.)
- [x] `cargo clippy -p aionui-ai-agent -- -D warnings` — clean.
- [x] `cargo fmt -p aionui-ai-agent -- --check` — clean.

New unit tests (both in `crates/aionui-ai-agent/src/types.rs`):
- `acp_build_extra_missing_team_mcp_stdio_config_is_none` — legacy JSON (`{"backend":"claude","skills":["cron"]}`) deserializes with `team_mcp_stdio_config == None`.
- `acp_build_extra_parses_team_mcp_stdio_config` — full JSON with nested `{port, token, slot_id}` round-trips correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)