### PR TITLE
feat(team/mcp): use AionUi original text for team_spawn_agent description

### DIFF
--- a/crates/aionui-team/src/mcp/tools.rs
+++ b/crates/aionui-team/src/mcp/tools.rs
@@ -5,6 +5,32 @@ use crate::scheduler::SchedulerAction;
 use crate::types::TeammateRole;
 
 // ---------------------------------------------------------------------------
+// Tool description constants (原样复用 AionUi `toolDescriptions.ts`)
+// ---------------------------------------------------------------------------
+
+/// `team_spawn_agent` 工具描述 — 原样复制自 AionUi `toolDescriptions.ts`
+/// 对应 team-prompts.md §5.2 `team_spawn_agent` Description 原文。
+/// 禁止翻译、改写；aionui-audit §8 #5 硬约束。
+pub const TEAM_SPAWN_AGENT_DESCRIPTION: &str = r#"Create a new teammate agent to join the team.
+
+Use this only when one of the following is true:
+- The user explicitly approved the proposed teammate lineup in a previous message
+- The user explicitly instructed you to create a specific teammate immediately
+
+Before calling this tool in the normal planning flow:
+- Start with one short sentence explaining why additional teammates would help
+- Tell the user which teammate(s) you recommend
+- Present the proposal as a table with: name, responsibility, recommended agent type/backend, and recommended model
+- Include each teammate's responsibility, recommended agent type/backend, and model
+- Ask whether to create them as proposed or change any names, responsibilities, or agent types
+- In that approval question, remind the user that they can later ask you to replace or adjust any teammate if the lineup is not working well
+- Do NOT call this tool in that same turn; wait for explicit approval in a later user message
+
+When calling this tool, provide the model parameter if a specific model was recommended and approved.
+
+The new agent will be created and added to the team. You can then assign tasks and send messages to it."#;
+
+// ---------------------------------------------------------------------------
 // Tool descriptors (returned by tools/list)
 // ---------------------------------------------------------------------------
 
@@ -31,7 +57,7 @@ pub fn all_tool_descriptors() -> Vec<ToolDescriptor> {
         },
         ToolDescriptor {
             name: "team_spawn_agent".into(),
-            description: "Dynamically create a new teammate agent (Lead only).".into(),
+            description: TEAM_SPAWN_AGENT_DESCRIPTION.into(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -264,6 +290,24 @@ mod tests {
             assert!(!d.description.is_empty());
             assert_eq!(d.input_schema["type"], "object");
         }
+    }
+
+    #[test]
+    fn team_spawn_agent_description_is_aionui_original() {
+        let desc = all_tool_descriptors()
+            .into_iter()
+            .find(|d| d.name == "team_spawn_agent")
+            .expect("team_spawn_agent descriptor must exist")
+            .description;
+        assert_eq!(desc, TEAM_SPAWN_AGENT_DESCRIPTION);
+        assert!(
+            desc.contains("Before calling this tool"),
+            "description must be the full AionUi original, not the legacy one-liner"
+        );
+        assert!(
+            desc.contains("explicitly approved"),
+            "description must retain the explicit-approval precondition clause"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

模块 **D4b** — 把 `team_spawn_agent` 工具描述从极简一句话换成 AionUi `toolDescriptions.ts` 原文。

- 新增常量 `pub const TEAM_SPAWN_AGENT_DESCRIPTION` — 原样复制 `docs/teams/team-prompts.md §5.2 team_spawn_agent` 的 Description（禁翻译、禁改写）
- `team_spawn_agent` descriptor 的 `description` 字段改引该常量
- 新增 1 条单元测试 `team_spawn_agent_description_is_aionui_original`：
  - 断言 descriptor description 等于常量
  - 断言包含 `"Before calling this tool"` 和 `"explicitly approved"`（§5.2 原文独有词组，确认不是极简版）

## Why

backend-audit §3.5 #48 标 **P0**、aionui-audit §8 #5 硬约束：后端原描述 `"Dynamically create a new teammate agent (Lead only)."` 遗漏了"先征求用户同意再 spawn"的行为契约，会导致 leader agent 绕过审批直接拉人，产生非预期 teammate。

## Test plan

- [x] `cargo test -p aionui-team --lib` — 155 passed（新增 1 条，原有 154 条全绿）
- [x] `cargo clippy -p aionui-team --lib -- -D warnings` — 零告警
- [x] `cargo fmt -p aionui-team --check` — 格式通过
- [ ] 与 D5b-1（leader prompt 模板）集成后验证 leader agent 实际行为

## 关键词说明

task 原要求测试检查 `"PRECONDITIONS"`，但 team-prompts.md §5.2 team_spawn_agent 原文并不含该词（`PRECONDITIONS` 在 §5.1 `aion_create_team` 里）。已与 team lead 确认改为 `"Before calling this tool"` / `"explicitly approved"`（§5.2 独有独有词组）。

## 规格符合

- 代码新增 45 行（40 行预算，多出 5 行为 3 行文档注释 + 2 行分隔符注释）
- 文件：`crates/aionui-team/src/mcp/tools.rs`

Refs: `docs/teams/phase1/modules.md` §D4b · `docs/teams/phase1/backend-audit.md` §3.5 #48 · `docs/teams/phase1/aionui-audit.md` §8 #5