### PR TITLE
feat(team): TeamMcpStdioServerSpec with ACP SDK conversion (Wave1 D3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,7 @@ dependencies = [
 name = "aionui-team"
 version = "0.1.0"
 dependencies = [
+ "agent-client-protocol",
  "aionui-ai-agent",
  "aionui-api-types",
  "aionui-auth",

--- a/crates/aionui-team/Cargo.toml
+++ b/crates/aionui-team/Cargo.toml
@@ -19,6 +19,7 @@ thiserror.workspace = true
 tracing.workspace = true
 async-trait.workspace = true
 dashmap.workspace = true
+agent-client-protocol = "0.11.1"
 
 [dev-dependencies]
 sqlx.workspace = true

--- a/crates/aionui-team/src/lib.rs
+++ b/crates/aionui-team/src/lib.rs
@@ -16,7 +16,7 @@ pub mod types;
 pub use error::TeamError;
 pub use events::TeamEventEmitter;
 pub use mailbox::Mailbox;
-pub use mcp::{TeamMcpServer, TeamMcpStdioConfig};
+pub use mcp::{TeamMcpServer, TeamMcpStdioConfig, TeamMcpStdioServerSpec};
 pub use prompts::{build_lead_prompt, build_teammate_prompt, build_wake_payload};
 pub use routes::{TeamRouterState, team_routes};
 pub use scheduler::{SchedulerAction, TeammateManager, WAKE_TIMEOUT_MS, WakePayload};

--- a/crates/aionui-team/src/mcp/bridge.rs
+++ b/crates/aionui-team/src/mcp/bridge.rs
@@ -1,80 +1,152 @@
-use std::collections::HashMap;
+//! Stdio bridge descriptors consumed by ACP `session/new.mcp_servers`.
+//!
+//! Flow: `TeamSessionService::ensure_session` builds a `TeamMcpStdioServerSpec`
+//! per agent and writes its config triple into `conversation.extra`. When
+//! the ACP session is created, the spec is converted via `into_sdk()` to the
+//! wire-level `agent_client_protocol::schema::McpServer::Stdio` variant and
+//! sent to the agent CLI, which then spawns `<backend> mcp-bridge` with the
+//! three `TEAM_MCP_*` env keys so it can proxy stdio↔TCP to the in-process
+//! team MCP server.
 
-use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
-// ---------------------------------------------------------------------------
-// TeamMcpStdioConfig
-// ---------------------------------------------------------------------------
+use agent_client_protocol::schema::{EnvVariable, McpServer, McpServerStdio};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct TeamMcpStdioConfig {
-    pub port: u16,
-    pub token: String,
-    pub slot_id: String,
+pub use aionui_api_types::TeamMcpStdioConfig;
+
+/// Stdio MCP server description ready to be handed to `session/new`.
+///
+/// Field shapes are fixed by [phase1 interface-contracts.md §3]:
+/// - `name` = `"aionui-team-<team_id>"`
+/// - `command` = absolute path to the backend binary (resolved via
+///   `std::env::current_exe()` at app startup)
+/// - `args` = `["mcp-bridge"]`
+/// - `env` = three pairs built from `TeamMcpStdioConfig::ENV_*` constants
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TeamMcpStdioServerSpec {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
 }
 
-impl TeamMcpStdioConfig {
-    pub fn new(port: u16, token: String, slot_id: String) -> Self {
+impl TeamMcpStdioServerSpec {
+    /// Build the spec from the persisted stdio config plus runtime context.
+    ///
+    /// `backend_binary_path` is the absolute path to the `aionui-backend`
+    /// executable (phase1 single-binary constraint — no standalone bridge).
+    pub fn from_config(team_id: &str, backend_binary_path: &str, cfg: &TeamMcpStdioConfig) -> Self {
         Self {
-            port,
-            token,
-            slot_id,
+            name: format!("aionui-team-{team_id}"),
+            command: backend_binary_path.to_owned(),
+            args: vec!["mcp-bridge".to_owned()],
+            env: vec![
+                (
+                    TeamMcpStdioConfig::ENV_PORT.to_owned(),
+                    cfg.port.to_string(),
+                ),
+                (TeamMcpStdioConfig::ENV_TOKEN.to_owned(), cfg.token.clone()),
+                (
+                    TeamMcpStdioConfig::ENV_SLOT_ID.to_owned(),
+                    cfg.slot_id.clone(),
+                ),
+            ],
         }
     }
 
-    pub fn to_env_map(&self) -> HashMap<String, String> {
-        HashMap::from([
-            ("TEAM_MCP_PORT".into(), self.port.to_string()),
-            ("TEAM_MCP_TOKEN".into(), self.token.clone()),
-            ("TEAM_AGENT_SLOT_ID".into(), self.slot_id.clone()),
-        ])
+    /// Convert into the ACP SDK wire type expected by `NewSessionRequest::mcp_servers`.
+    pub fn into_sdk(self) -> McpServer {
+        // Both `McpServerStdio` and `EnvVariable` are `#[non_exhaustive]` in the
+        // SDK, so construction goes through the `new(..)` / builder entry points.
+        let env: Vec<EnvVariable> = self
+            .env
+            .into_iter()
+            .map(|(name, value)| EnvVariable::new(name, value))
+            .collect();
+
+        let stdio = McpServerStdio::new(self.name, PathBuf::from(self.command))
+            .args(self.args)
+            .env(env);
+
+        McpServer::Stdio(stdio)
     }
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn config_creation() {
-        let config = TeamMcpStdioConfig::new(12345, "tok-abc".into(), "slot-1".into());
-        assert_eq!(config.port, 12345);
-        assert_eq!(config.token, "tok-abc");
-        assert_eq!(config.slot_id, "slot-1");
+    fn sample_cfg() -> TeamMcpStdioConfig {
+        TeamMcpStdioConfig {
+            port: 12345,
+            token: "tok-abc".into(),
+            slot_id: "slot-1".into(),
+        }
     }
 
     #[test]
-    fn env_map_contains_all_keys() {
-        let config = TeamMcpStdioConfig::new(8080, "secret-token".into(), "agent-slot".into());
-        let env = config.to_env_map();
+    fn from_config_fills_all_fields() {
+        let spec = TeamMcpStdioServerSpec::from_config(
+            "team-42",
+            "/usr/bin/aionui-backend",
+            &sample_cfg(),
+        );
+
+        assert_eq!(spec.name, "aionui-team-team-42");
+        assert_eq!(spec.command, "/usr/bin/aionui-backend");
+        assert_eq!(spec.args, vec!["mcp-bridge".to_owned()]);
+        assert_eq!(spec.env.len(), 3);
+    }
+
+    #[test]
+    fn env_keys_match_api_type_constants() {
+        let spec = TeamMcpStdioServerSpec::from_config("t", "/p", &sample_cfg());
+        let kv: std::collections::HashMap<_, _> = spec.env.iter().cloned().collect();
+
+        assert_eq!(
+            kv.get(TeamMcpStdioConfig::ENV_PORT).map(String::as_str),
+            Some("12345")
+        );
+        assert_eq!(
+            kv.get(TeamMcpStdioConfig::ENV_TOKEN).map(String::as_str),
+            Some("tok-abc")
+        );
+        assert_eq!(
+            kv.get(TeamMcpStdioConfig::ENV_SLOT_ID).map(String::as_str),
+            Some("slot-1")
+        );
+    }
+
+    #[test]
+    fn into_sdk_serializes_as_stdio_variant() {
+        let spec = TeamMcpStdioServerSpec::from_config("tid", "/bin/aionui-backend", &sample_cfg());
+        let sdk = spec.into_sdk();
+
+        let json = serde_json::to_value(&sdk).expect("serialize");
+
+        // `Stdio` variant is `#[serde(untagged)]` inside `McpServer`, so the
+        // JSON is the raw `McpServerStdio` shape — no `"type":"stdio"` tag.
+        assert_eq!(json["name"], "aionui-team-tid");
+        assert_eq!(json["command"], "/bin/aionui-backend");
+        assert_eq!(json["args"], serde_json::json!(["mcp-bridge"]));
+
+        let env = json["env"].as_array().expect("env array");
         assert_eq!(env.len(), 3);
-        assert_eq!(env["TEAM_MCP_PORT"], "8080");
-        assert_eq!(env["TEAM_MCP_TOKEN"], "secret-token");
-        assert_eq!(env["TEAM_AGENT_SLOT_ID"], "agent-slot");
-    }
+        let pairs: std::collections::HashMap<_, _> = env
+            .iter()
+            .map(|v| {
+                (
+                    v["name"].as_str().unwrap().to_owned(),
+                    v["value"].as_str().unwrap().to_owned(),
+                )
+            })
+            .collect();
+        assert_eq!(pairs[TeamMcpStdioConfig::ENV_PORT], "12345");
+        assert_eq!(pairs[TeamMcpStdioConfig::ENV_TOKEN], "tok-abc");
+        assert_eq!(pairs[TeamMcpStdioConfig::ENV_SLOT_ID], "slot-1");
 
-    #[test]
-    fn serialization_roundtrip() {
-        let config = TeamMcpStdioConfig::new(9999, "tok".into(), "s1".into());
-        let json = serde_json::to_string(&config).unwrap();
-        let parsed: TeamMcpStdioConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(config, parsed);
-    }
-
-    #[test]
-    fn different_agents_get_different_configs() {
-        let cfg1 = TeamMcpStdioConfig::new(5000, "token".into(), "slot-a".into());
-        let cfg2 = TeamMcpStdioConfig::new(5000, "token".into(), "slot-b".into());
-        assert_ne!(cfg1, cfg2);
-
-        let env1 = cfg1.to_env_map();
-        let env2 = cfg2.to_env_map();
-        assert_eq!(env1["TEAM_MCP_PORT"], env2["TEAM_MCP_PORT"]);
-        assert_eq!(env1["TEAM_MCP_TOKEN"], env2["TEAM_MCP_TOKEN"]);
-        assert_ne!(env1["TEAM_AGENT_SLOT_ID"], env2["TEAM_AGENT_SLOT_ID"]);
+        // The untagged variant must still round-trip back into the enum.
+        let back: McpServer = serde_json::from_value(json).expect("roundtrip");
+        assert!(matches!(back, McpServer::Stdio(_)));
     }
 }

--- a/crates/aionui-team/src/mcp/mod.rs
+++ b/crates/aionui-team/src/mcp/mod.rs
@@ -3,5 +3,5 @@ pub mod protocol;
 pub mod server;
 pub mod tools;
 
-pub use bridge::TeamMcpStdioConfig;
+pub use bridge::{TeamMcpStdioConfig, TeamMcpStdioServerSpec};
 pub use server::TeamMcpServer;

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -63,11 +63,11 @@ impl TeamSession {
     }
 
     pub fn mcp_stdio_config(&self, slot_id: &str) -> TeamMcpStdioConfig {
-        TeamMcpStdioConfig::new(
-            self.mcp_server.port(),
-            self.mcp_server.auth_token().to_owned(),
-            slot_id.to_owned(),
-        )
+        TeamMcpStdioConfig {
+            port: self.mcp_server.port(),
+            token: self.mcp_server.auth_token().to_owned(),
+            slot_id: slot_id.to_owned(),
+        }
     }
 
     pub async fn send_message(&self, content: &str) -> Result<(), TeamError> {

--- a/crates/aionui-team/tests/mcp_server_integration.rs
+++ b/crates/aionui-team/tests/mcp_server_integration.rs
@@ -723,37 +723,57 @@ async fn ss2_stop_server_closes_listener() {
 
 #[tokio::test]
 async fn sb1_bridge_config_generation() {
-    let env = setup().await;
-    let config = aionui_team::TeamMcpStdioConfig::new(
-        env.server.port(),
-        env.server.auth_token().to_string(),
-        "lead-1".into(),
-    );
+    use aionui_team::{TeamMcpStdioConfig, TeamMcpStdioServerSpec};
 
-    let env_map = config.to_env_map();
-    assert_eq!(env_map["TEAM_MCP_PORT"], env.server.port().to_string());
-    assert_eq!(env_map["TEAM_MCP_TOKEN"], "test-token-123");
-    assert_eq!(env_map["TEAM_AGENT_SLOT_ID"], "lead-1");
+    let env = setup().await;
+    let config = TeamMcpStdioConfig {
+        port: env.server.port(),
+        token: env.server.auth_token().to_string(),
+        slot_id: "lead-1".into(),
+    };
+
+    let spec = TeamMcpStdioServerSpec::from_config("team-test", "/bin/aionui-backend", &config);
+    let env_map: std::collections::HashMap<_, _> = spec.env.iter().cloned().collect();
+    assert_eq!(
+        env_map[TeamMcpStdioConfig::ENV_PORT],
+        env.server.port().to_string()
+    );
+    assert_eq!(env_map[TeamMcpStdioConfig::ENV_TOKEN], "test-token-123");
+    assert_eq!(env_map[TeamMcpStdioConfig::ENV_SLOT_ID], "lead-1");
 
     env.server.stop();
 }
 
 #[tokio::test]
 async fn sb3_different_agents_get_different_slot_ids() {
+    use aionui_team::{TeamMcpStdioConfig, TeamMcpStdioServerSpec};
+
     let env = setup().await;
     let port = env.server.port();
     let token = env.server.auth_token().to_string();
 
-    let cfg_lead = aionui_team::TeamMcpStdioConfig::new(port, token.clone(), "lead-1".into());
-    let cfg_worker = aionui_team::TeamMcpStdioConfig::new(port, token, "worker-1".into());
+    let cfg_lead = TeamMcpStdioConfig {
+        port,
+        token: token.clone(),
+        slot_id: "lead-1".into(),
+    };
+    let cfg_worker = TeamMcpStdioConfig {
+        port,
+        token,
+        slot_id: "worker-1".into(),
+    };
+    let spec_lead = TeamMcpStdioServerSpec::from_config("t", "/b", &cfg_lead);
+    let spec_worker = TeamMcpStdioServerSpec::from_config("t", "/b", &cfg_worker);
+    let kv_lead: std::collections::HashMap<_, _> = spec_lead.env.iter().cloned().collect();
+    let kv_worker: std::collections::HashMap<_, _> = spec_worker.env.iter().cloned().collect();
 
     assert_eq!(
-        cfg_lead.to_env_map()["TEAM_MCP_PORT"],
-        cfg_worker.to_env_map()["TEAM_MCP_PORT"]
+        kv_lead[TeamMcpStdioConfig::ENV_PORT],
+        kv_worker[TeamMcpStdioConfig::ENV_PORT]
     );
     assert_ne!(
-        cfg_lead.to_env_map()["TEAM_AGENT_SLOT_ID"],
-        cfg_worker.to_env_map()["TEAM_AGENT_SLOT_ID"]
+        kv_lead[TeamMcpStdioConfig::ENV_SLOT_ID],
+        kv_worker[TeamMcpStdioConfig::ENV_SLOT_ID]
     );
 
     env.server.stop();


### PR DESCRIPTION
## Summary

Phase1 Wave 1 module **D3**. Produces the stdio MCP server descriptor
that `session/new.mcp_servers` needs in order to attach the team MCP
server to each agent's ACP CLI.

- `TeamMcpStdioServerSpec::from_config(team_id, backend_binary_path, cfg)`
  builds `{name, command, args, env}` from the D1
  `TeamMcpStdioConfig` triple; env uses `TeamMcpStdioConfig::ENV_*`.
- `TeamMcpStdioServerSpec::into_sdk()` converts to
  `agent_client_protocol::schema::McpServer::Stdio`, constructed through
  the SDK's `McpServerStdio::new(..)` / `EnvVariable::new(..)` builders
  (both types are `#[non_exhaustive]`).
- `bridge.rs` now re-exports `pub use aionui_api_types::TeamMcpStdioConfig`
  (D1 merged in #46). `session.rs` + integration tests adjusted to the
  new struct surface.

## Interface contract

Matches [phase1 interface-contracts.md §3](../docs/teams/phase1/interface-contracts.md#3-aionui-teammcpbridge-新增serverspecwave-1--模块-d3)
exactly: `name = "aionui-team-<team_id>"`, `command = backend_binary_path`,
`args = ["mcp-bridge"]`, three env pairs from `ENV_*` constants.

## Test plan

- [x] `cargo test -p aionui-team --lib` — 152 pass (incl. 3 new
      `mcp::bridge::tests::*`)
- [x] `cargo test -p aionui-team --test mcp_server_integration` — 26 pass
      (sb1 / sb3 refactored to use `TeamMcpStdioServerSpec`)
- [x] `cargo clippy -p aionui-team --lib -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean on changed files

## Pre-existing issue (not in scope)

`tests/session_service_integration.rs:273` (`StubSkillResolver`) fails
to compile on `feat/team-wave1` because commit 7af338f extended
`SkillResolver` with `resolve_skills` / `link_workspace_skills`. This is
unrelated to D3 and left for whichever module owns that test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)