### PR TITLE
feat(team/mcp): D4 — add team_list_models and team_describe_assistant tools

### DIFF
--- a/crates/aionui-team/src/mcp/server.rs
+++ b/crates/aionui-team/src/mcp/server.rs
@@ -16,7 +16,8 @@ use super::protocol::{
 };
 use super::tools::{
     RenameAgentInput, SendMessageInput, ShutdownAgentInput, SpawnAgentInput, TaskCreateInput,
-    TaskUpdateInput, all_tool_descriptors, is_whitelisted_backend,
+    TaskUpdateInput, all_tool_descriptors, handle_team_describe_assistant, handle_team_list_models,
+    is_whitelisted_backend,
 };
 
 // ---------------------------------------------------------------------------
@@ -328,8 +329,19 @@ async fn dispatch_tool(
         "team_shutdown_agent" => {
             exec_shutdown_agent(arguments, scheduler, caller_slot_id, caller_role).await
         }
+        "team_list_models" => exec_list_models(arguments).await,
+        "team_describe_assistant" => exec_describe_assistant(arguments).await,
         _ => Err(format!("Unknown tool: {tool_name}")),
     }
+}
+
+async fn exec_list_models(args: &Value) -> Result<String, String> {
+    let value = handle_team_list_models(args);
+    serde_json::to_string_pretty(&value).map_err(|e| format!("Serialization error: {e}"))
+}
+
+async fn exec_describe_assistant(args: &Value) -> Result<String, String> {
+    Ok(handle_team_describe_assistant(args))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aionui-team/src/mcp/tools.rs
+++ b/crates/aionui-team/src/mcp/tools.rs
@@ -30,6 +30,27 @@ When calling this tool, provide the model parameter if a specific model was reco
 
 The new agent will be created and added to the team. You can then assign tasks and send messages to it."#;
 
+/// Description for `team_list_models` — verbatim from team-prompts.md §5.2.
+pub const TEAM_LIST_MODELS_DESCRIPTION: &str = "Query available models for team agent types. Returns the real-time model list that matches the frontend model selector.
+
+Use this to:
+- Check what models are available before spawning an agent with a specific model
+- See all available agent types and their models at once
+- Verify a model ID is valid for a given agent type
+
+Pass agent_type to query a specific backend, or omit it to see all.";
+
+/// Description for `team_describe_assistant` — verbatim from team-prompts.md §5.2.
+pub const TEAM_DESCRIBE_ASSISTANT_DESCRIPTION: &str =
+    "Get detailed information about a preset assistant before spawning it as a teammate.
+
+Returns the preset's full description, enabled skills, and example tasks so you can
+judge whether it fits the user's request. Use this when two or more presets look
+relevant from the one-line catalog in your system prompt.
+
+Only works on preset assistants listed in \"Available Preset Assistants for Spawning\".
+After confirming a match, call team_spawn_agent with the same custom_agent_id.";
+
 // ---------------------------------------------------------------------------
 // Tool descriptors (returned by tools/list)
 // ---------------------------------------------------------------------------
@@ -135,6 +156,28 @@ pub fn all_tool_descriptors() -> Vec<ToolDescriptor> {
                     "reason": { "type": "string", "description": "Reason for shutdown" }
                 },
                 "required": ["slot_id"]
+            }),
+        },
+        ToolDescriptor {
+            name: "team_describe_assistant".into(),
+            description: TEAM_DESCRIBE_ASSISTANT_DESCRIPTION.into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "custom_agent_id": { "type": "string", "description": "The preset assistant ID from the \"Available Preset Assistants\" catalog (e.g., \"word-creator\")." },
+                    "locale": { "type": "string", "description": "Locale like \"zh-CN\" or \"en-US\". Defaults to the user's current UI language when omitted." }
+                },
+                "required": ["custom_agent_id"]
+            }),
+        },
+        ToolDescriptor {
+            name: "team_list_models".into(),
+            description: TEAM_LIST_MODELS_DESCRIPTION.into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "agent_type": { "type": "string", "description": "Agent type/backend to query (e.g. \"gemini\", \"claude\", \"codex\"). Shows all when omitted." }
+                }
             }),
         },
     ]
@@ -254,11 +297,41 @@ pub fn parse_tool_call(
                 blocked_by: input.blocked_by,
             })
         }
-        "team_task_list" | "team_members" | "team_rename_agent" | "team_shutdown_agent" => {
-            Err("handled directly by server".into())
-        }
+        "team_task_list"
+        | "team_members"
+        | "team_rename_agent"
+        | "team_shutdown_agent"
+        | "team_list_models"
+        | "team_describe_assistant" => Err("handled directly by server".into()),
         _ => Err(format!("Unknown tool: {tool_name}")),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Phase-1 minimal handlers for `team_list_models` and `team_describe_assistant`
+// ---------------------------------------------------------------------------
+
+/// Phase-1 minimal `team_list_models` handler. Returns a hard-coded
+/// agent-type → models mapping. Wave 2 wires this to the real registry.
+pub fn handle_team_list_models(_args: &Value) -> Value {
+    json!({
+        "agent_types": [
+            {
+                "type": "claude",
+                "models": ["claude-sonnet-4", "claude-opus-4"]
+            },
+            {
+                "type": "codex",
+                "models": ["codex-mini-latest"]
+            }
+        ]
+    })
+}
+
+/// Phase-1 minimal `team_describe_assistant` handler. Backend has no preset
+/// assistants wired yet, so every call returns the not-found text.
+pub fn handle_team_describe_assistant(_args: &Value) -> String {
+    "Preset assistant not found".to_owned()
 }
 
 // ---------------------------------------------------------------------------
@@ -271,7 +344,7 @@ mod tests {
 
     #[test]
     fn all_descriptors_count() {
-        assert_eq!(all_tool_descriptors().len(), 8);
+        assert_eq!(all_tool_descriptors().len(), 10);
     }
 
     #[test]
@@ -280,7 +353,7 @@ mod tests {
         let mut names: Vec<&str> = descs.iter().map(|d| d.name.as_str()).collect();
         names.sort();
         names.dedup();
-        assert_eq!(names.len(), 8);
+        assert_eq!(names.len(), 10);
     }
 
     #[test]
@@ -441,5 +514,64 @@ mod tests {
         let result = parse_tool_call("team_shutdown_agent", &args, TeammateRole::Lead);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("handled directly by server"));
+    }
+
+    // ---- D4 descriptor text matches team-prompts.md §5.2 verbatim ----
+
+    #[test]
+    fn team_list_models_descriptor_text_matches() {
+        let desc = all_tool_descriptors()
+            .into_iter()
+            .find(|d| d.name == "team_list_models")
+            .expect("team_list_models descriptor missing");
+        assert_eq!(desc.description, TEAM_LIST_MODELS_DESCRIPTION);
+        assert!(
+            desc.description
+                .starts_with("Query available models for team agent types.")
+        );
+        assert!(
+            desc.description
+                .contains("Pass agent_type to query a specific backend, or omit it to see all.")
+        );
+    }
+
+    #[test]
+    fn team_describe_assistant_descriptor_text_matches() {
+        let desc = all_tool_descriptors()
+            .into_iter()
+            .find(|d| d.name == "team_describe_assistant")
+            .expect("team_describe_assistant descriptor missing");
+        assert_eq!(desc.description, TEAM_DESCRIBE_ASSISTANT_DESCRIPTION);
+        assert!(
+            desc.description
+                .starts_with("Get detailed information about a preset assistant")
+        );
+        assert!(desc.description.contains(
+            "After confirming a match, call team_spawn_agent with the same custom_agent_id."
+        ));
+    }
+
+    // ---- D4 handlers return non-error payloads ----
+
+    #[test]
+    fn team_list_models_handler_returns_non_error() {
+        let value = handle_team_list_models(&json!({}));
+        let agent_types = value
+            .get("agent_types")
+            .and_then(|v| v.as_array())
+            .expect("agent_types array missing");
+        assert!(!agent_types.is_empty());
+        let types: Vec<&str> = agent_types
+            .iter()
+            .filter_map(|e| e.get("type").and_then(|v| v.as_str()))
+            .collect();
+        assert!(types.contains(&"claude"));
+        assert!(types.contains(&"codex"));
+    }
+
+    #[test]
+    fn team_describe_assistant_handler_returns_non_error() {
+        let text = handle_team_describe_assistant(&json!({"custom_agent_id": "unknown"}));
+        assert_eq!(text, "Preset assistant not found");
     }
 }


### PR DESCRIPTION
## Summary

- 在 `aionui-team::mcp::tools` 新增 2 个 `ToolDescriptor`：`team_list_models` 与 `team_describe_assistant`，description 原样复用 `docs/teams/team-prompts.md` §5.2 的英文原文（AionUi audit §8 #5 硬约束）
- 在 `mcp/server.rs` dispatch 新增 2 个分支，调用 phase-1 最小 handler
- Phase-1 handler：
  - `team_list_models` 返回固定 JSON `{agent_types:[{type:"claude",models:["claude-sonnet-4","claude-opus-4"]},{type:"codex",models:["codex-mini-latest"]}]}`
  - `team_describe_assistant` 统一返回 `"Preset assistant not found"`（后端暂无 preset registry）
- 4 条单元测试：2 个 descriptor 文本匹配原文；2 个 handler 返回非 isError

Wave 2 会接入真实 agent registry 和 preset assistants 配置。

## Scope

只改动 2 个文件，共 +154/-6：
- `crates/aionui-team/src/mcp/tools.rs`
- `crates/aionui-team/src/mcp/server.rs`

## Test plan

- [x] `cargo test -p aionui-team --lib`：157 passed / 0 failed（含 4 条 D4 新测试）
- [x] `cargo clippy -p aionui-team --lib -- -D warnings` 干净
- [x] `cargo fmt --all -- --check` 通过
- [ ] `cargo test -p aionui-team`（含 integration）在基线 feat/team-wave1 上就编译失败——`tests/session_service_integration.rs` 的 `StubSkillResolver` 没实现 `SkillResolver::resolve_skills` / `link_workspace_skills`，这是 feat/team-wave1 自带的问题（commit 7af338f 改 trait 后没更新这个 stub），与 D4 无关

Ref: `docs/teams/phase1/modules.md` D4, `docs/teams/phase1/interface-contracts.md` §4.