### PR TITLE
feat(app): add mcp-bridge subcommand for stdio ↔ TCP team MCP bridge (D6)

### DIFF
--- a/crates/aionui-app/src/bridge.rs
+++ b/crates/aionui-app/src/bridge.rs
@@ -1,0 +1,277 @@
+//! `aionui-backend mcp-bridge` subcommand: stdio ↔ TCP bridge for the team MCP server.
+//!
+//! Spawned by the ACP agent CLI as an MCP server with command `aionui-backend mcp-bridge`.
+//! stdio side speaks newline-delimited JSON-RPC 2.0 (the MCP stdio transport);
+//! TCP side speaks 4-byte big-endian length-prefixed JSON frames against
+//! `127.0.0.1:<TEAM_MCP_PORT>` (reusing `aionui_team::mcp::protocol`).
+//!
+//! On the first `initialize` request from the CLI, the bridge injects
+//! `auth_token` and `slot_id` (read from env) into `params` before forwarding
+//! to the TCP server; subsequent messages are transparently proxied in both
+//! directions. Any unrecoverable error exits non-zero so the ACP CLI marks
+//! the MCP server as broken (see docs/teams/mcp.md §4.4 / §4.6).
+
+use std::io::{self, IsTerminal};
+use std::process::ExitCode;
+
+use aionui_api_types::TeamMcpStdioConfig;
+use aionui_team::mcp::protocol::{read_frame, write_frame};
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+
+const CONNECT_ADDR_HOST: &str = "127.0.0.1";
+
+/// Entry point for `aionui-backend mcp-bridge`. Returns an [`ExitCode`] so the
+/// binary surfaces non-zero on any failure (ACP CLI uses that to mark the MCP
+/// server as broken).
+pub async fn run_mcp_bridge() -> ExitCode {
+    match run().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            // stderr, not tracing: the parent agent CLI captures stderr and
+            // shows it to the user when the bridge dies on startup.
+            eprintln!("mcp-bridge: {err}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+async fn run() -> Result<(), String> {
+    let env = BridgeEnv::from_env()?;
+
+    let tcp = TcpStream::connect((CONNECT_ADDR_HOST, env.port))
+        .await
+        .map_err(|e| format!("failed to connect 127.0.0.1:{}: {e}", env.port))?;
+    tcp.set_nodelay(true).ok();
+    let (tcp_reader, tcp_writer) = tcp.into_split();
+
+    if std::io::stdin().is_terminal() {
+        return Err(
+            "stdin is a TTY; mcp-bridge must be spawned by an MCP-capable agent CLI".into(),
+        );
+    }
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+
+    let env_for_stdin = env.clone();
+    let stdin_task =
+        tokio::spawn(async move { forward_stdin_to_tcp(stdin, tcp_writer, env_for_stdin).await });
+    let tcp_task = tokio::spawn(async move { forward_tcp_to_stdout(tcp_reader, stdout).await });
+
+    // First task to return decides the exit path; we treat clean EOF from
+    // either side as "other side closed, we're done".
+    tokio::select! {
+        res = stdin_task => {
+            res.map_err(|e| format!("stdin task panicked: {e}"))??;
+        }
+        res = tcp_task => {
+            res.map_err(|e| format!("tcp task panicked: {e}"))??;
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Env
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct BridgeEnv {
+    port: u16,
+    token: String,
+    slot_id: String,
+}
+
+impl BridgeEnv {
+    fn from_env() -> Result<Self, String> {
+        let port_raw = std::env::var(TeamMcpStdioConfig::ENV_PORT)
+            .map_err(|_| format!("missing env var {}", TeamMcpStdioConfig::ENV_PORT))?;
+        let port: u16 = port_raw.parse().map_err(|e| {
+            format!(
+                "invalid {} value {port_raw:?}: {e}",
+                TeamMcpStdioConfig::ENV_PORT
+            )
+        })?;
+        let token = std::env::var(TeamMcpStdioConfig::ENV_TOKEN)
+            .map_err(|_| format!("missing env var {}", TeamMcpStdioConfig::ENV_TOKEN))?;
+        let slot_id = std::env::var(TeamMcpStdioConfig::ENV_SLOT_ID)
+            .map_err(|_| format!("missing env var {}", TeamMcpStdioConfig::ENV_SLOT_ID))?;
+        Ok(Self {
+            port,
+            token,
+            slot_id,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// stdin → TCP: read newline-delimited JSON, inject auth on `initialize`, frame to TCP
+// ---------------------------------------------------------------------------
+
+async fn forward_stdin_to_tcp<R, W>(
+    stdin: R,
+    mut tcp_writer: W,
+    env: BridgeEnv,
+) -> Result<(), String>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    let mut lines = BufReader::new(stdin).lines();
+    while let Some(line) = lines
+        .next_line()
+        .await
+        .map_err(|e| format!("stdin read error: {e}"))?
+    {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let mut value: Value = serde_json::from_str(&line)
+            .map_err(|e| format!("stdin payload is not valid JSON: {e}"))?;
+
+        if value.get("method").and_then(Value::as_str) == Some("initialize") {
+            inject_auth(&mut value, &env);
+        }
+
+        let bytes =
+            serde_json::to_vec(&value).map_err(|e| format!("serialize outgoing frame: {e}"))?;
+        write_frame(&mut tcp_writer, &bytes)
+            .await
+            .map_err(|e| format!("tcp write error: {e}"))?;
+    }
+    Ok(())
+}
+
+fn inject_auth(value: &mut Value, env: &BridgeEnv) {
+    let params = value.as_object_mut().and_then(|obj| {
+        obj.entry("params")
+            .or_insert(Value::Object(Default::default()))
+            .as_object_mut()
+    });
+    if let Some(params) = params {
+        params.insert("auth_token".into(), Value::String(env.token.clone()));
+        params.insert("slot_id".into(), Value::String(env.slot_id.clone()));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TCP → stdout: read length-prefixed frames, write as newline-delimited JSON
+// ---------------------------------------------------------------------------
+
+async fn forward_tcp_to_stdout<R, W>(mut tcp_reader: R, mut stdout: W) -> Result<(), String>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    loop {
+        let frame = match read_frame(&mut tcp_reader).await {
+            Ok(f) => f,
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(()),
+            Err(e) => return Err(format!("tcp read error: {e}")),
+        };
+        stdout
+            .write_all(&frame)
+            .await
+            .map_err(|e| format!("stdout write error: {e}"))?;
+        stdout
+            .write_all(b"\n")
+            .await
+            .map_err(|e| format!("stdout write error: {e}"))?;
+        stdout
+            .flush()
+            .await
+            .map_err(|e| format!("stdout flush error: {e}"))?;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests (integration tests live in tests/mcp_bridge.rs)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn env() -> BridgeEnv {
+        BridgeEnv {
+            port: 1,
+            token: "tok".into(),
+            slot_id: "slot-a".into(),
+        }
+    }
+
+    #[test]
+    fn inject_auth_adds_fields_when_params_missing() {
+        let mut v = json!({"jsonrpc":"2.0","id":1,"method":"initialize"});
+        inject_auth(&mut v, &env());
+        assert_eq!(v["params"]["auth_token"], "tok");
+        assert_eq!(v["params"]["slot_id"], "slot-a");
+    }
+
+    #[test]
+    fn inject_auth_preserves_existing_params() {
+        let mut v = json!({
+            "jsonrpc":"2.0","id":1,"method":"initialize",
+            "params": {"protocolVersion":"2024-11-05","capabilities":{}}
+        });
+        inject_auth(&mut v, &env());
+        assert_eq!(v["params"]["protocolVersion"], "2024-11-05");
+        assert_eq!(v["params"]["auth_token"], "tok");
+        assert_eq!(v["params"]["slot_id"], "slot-a");
+    }
+
+    #[test]
+    fn inject_auth_overrides_client_supplied_credentials() {
+        // The CLI cannot be trusted to know the bridge's token / slot id,
+        // so whatever it sent gets replaced.
+        let mut v = json!({
+            "jsonrpc":"2.0","id":1,"method":"initialize",
+            "params":{"auth_token":"stale","slot_id":"wrong"}
+        });
+        inject_auth(&mut v, &env());
+        assert_eq!(v["params"]["auth_token"], "tok");
+        assert_eq!(v["params"]["slot_id"], "slot-a");
+    }
+
+    #[tokio::test]
+    async fn forward_stdin_injects_only_on_initialize() {
+        let input = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#,
+            "\n",
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#,
+            "\n",
+        );
+        let mut out = Vec::<u8>::new();
+        forward_stdin_to_tcp(input.as_bytes(), &mut out, env())
+            .await
+            .unwrap();
+
+        // Parse two frames back out.
+        let mut cursor = std::io::Cursor::new(out);
+        let f1 = read_frame(&mut cursor).await.unwrap();
+        let f2 = read_frame(&mut cursor).await.unwrap();
+        let v1: Value = serde_json::from_slice(&f1).unwrap();
+        let v2: Value = serde_json::from_slice(&f2).unwrap();
+        assert_eq!(v1["params"]["auth_token"], "tok");
+        assert_eq!(v1["params"]["slot_id"], "slot-a");
+        assert!(v2.get("params").is_none(), "tools/list params untouched");
+    }
+
+    #[tokio::test]
+    async fn forward_tcp_writes_ndjson() {
+        let payload = br#"{"jsonrpc":"2.0","id":1,"result":{}}"#;
+        let mut framed = Vec::new();
+        write_frame(&mut framed, payload).await.unwrap();
+
+        let mut out = Vec::<u8>::new();
+        forward_tcp_to_stdout(&framed[..], &mut out).await.unwrap();
+
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.ends_with('\n'));
+        let line = text.trim_end();
+        let parsed: Value = serde_json::from_str(line).unwrap();
+        assert_eq!(parsed["id"], 1);
+    }
+}

--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -1,4 +1,5 @@
 //! Application entry point: assembles all crates into an Axum server with DI and middleware.
+pub mod bridge;
 mod state_builders;
 
 use std::sync::Arc;

--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::process::ExitCode;
 use std::time::Instant;
 
 use anyhow::Result;
@@ -7,7 +8,7 @@ use tokio::net::TcpListener;
 use tracing::info;
 use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
-use aionui_app::{AppConfig, AppServices, create_router};
+use aionui_app::{AppConfig, AppServices, bridge, create_router};
 
 #[derive(Parser)]
 #[command(name = "aionui-backend", about = "AionUi Backend Server")]
@@ -78,7 +79,16 @@ fn init_tracing(
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<ExitCode> {
+    // mcp-bridge subcommand: lives entirely outside the main HTTP server and
+    // must not touch the database, logging setup, or `AppServices`. Spawned by
+    // ACP agent CLIs as a short-lived stdio ↔ TCP bridge process.
+    let mut argv = std::env::args();
+    let _prog = argv.next();
+    if argv.next().as_deref() == Some("mcp-bridge") {
+        return Ok(bridge::run_mcp_bridge().await);
+    }
+
     let cli = Cli::parse();
 
     let log_dir = cli
@@ -170,7 +180,7 @@ async fn main() -> Result<()> {
     services.database.close().await;
     info!("Server shut down gracefully");
 
-    Ok(())
+    Ok(ExitCode::SUCCESS)
 }
 
 async fn shutdown_signal() {

--- a/crates/aionui-app/tests/mcp_bridge_e2e.rs
+++ b/crates/aionui-app/tests/mcp_bridge_e2e.rs
@@ -1,0 +1,155 @@
+//! D6 integration tests for the `aionui-backend mcp-bridge` subcommand.
+//!
+//! Spawn the production binary with `mcp-bridge` argv; drive its stdin/stdout
+//! as the ACP agent CLI would, and verify it transparently bridges to a
+//! length-prefixed JSON-RPC TCP peer.
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use aionui_team::mcp::protocol::{read_frame, write_frame};
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+const BRIDGE_BIN: &str = env!("CARGO_BIN_EXE_aionui-backend");
+
+/// 1) spawn bridge → mock TCP server accepts → stdin "tools/list" round-trip.
+///    Also verifies the bridge injects `auth_token` + `slot_id` into the
+///    very first `initialize` request (per interface-contracts §8).
+#[tokio::test]
+async fn bridge_forwards_initialize_and_tools_list() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    // Mock TCP server: accept one connection, answer initialize + tools/list.
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let (mut rd, mut wr) = tokio::io::split(stream);
+
+        // --- initialize ---
+        let f1 = read_frame(&mut rd).await.unwrap();
+        let req1: Value = serde_json::from_slice(&f1).unwrap();
+        assert_eq!(req1["method"], "initialize");
+        assert_eq!(
+            req1["params"]["auth_token"], "secret-tok",
+            "bridge must inject env TEAM_MCP_TOKEN into initialize.params"
+        );
+        assert_eq!(
+            req1["params"]["slot_id"], "slot-42",
+            "bridge must inject env TEAM_AGENT_SLOT_ID into initialize.params"
+        );
+        let resp1 = json!({
+            "jsonrpc":"2.0",
+            "id": req1["id"],
+            "result":{"protocolVersion":"2024-11-05","serverInfo":{"name":"mock","version":"0"}}
+        });
+        write_frame(&mut wr, &serde_json::to_vec(&resp1).unwrap())
+            .await
+            .unwrap();
+
+        // --- tools/list ---
+        let f2 = read_frame(&mut rd).await.unwrap();
+        let req2: Value = serde_json::from_slice(&f2).unwrap();
+        assert_eq!(req2["method"], "tools/list");
+        let resp2 = json!({
+            "jsonrpc":"2.0",
+            "id": req2["id"],
+            "result":{"tools":[{"name":"team_members","description":"fake"}]}
+        });
+        write_frame(&mut wr, &serde_json::to_vec(&resp2).unwrap())
+            .await
+            .unwrap();
+    });
+
+    let mut child = Command::new(BRIDGE_BIN)
+        .arg("mcp-bridge")
+        .env("TEAM_MCP_PORT", port.to_string())
+        .env("TEAM_MCP_TOKEN", "secret-tok")
+        .env("TEAM_AGENT_SLOT_ID", "slot-42")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn bridge");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let mut stdout_lines = BufReader::new(stdout).lines();
+
+    stdin
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\
+               \"params\":{\"protocolVersion\":\"2024-11-05\"}}\n",
+        )
+        .await
+        .unwrap();
+    stdin
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}\n")
+        .await
+        .unwrap();
+
+    let line1 = timeout(Duration::from_secs(5), stdout_lines.next_line())
+        .await
+        .expect("initialize response timeout")
+        .unwrap()
+        .expect("eof before initialize response");
+    let v1: Value = serde_json::from_str(&line1).unwrap();
+    assert_eq!(v1["id"], 1);
+    assert_eq!(v1["result"]["protocolVersion"], "2024-11-05");
+
+    let line2 = timeout(Duration::from_secs(5), stdout_lines.next_line())
+        .await
+        .expect("tools/list response timeout")
+        .unwrap()
+        .expect("eof before tools/list response");
+    let v2: Value = serde_json::from_str(&line2).unwrap();
+    assert_eq!(v2["id"], 2);
+    assert_eq!(v2["result"]["tools"][0]["name"], "team_members");
+
+    // Closing stdin triggers orderly shutdown.
+    drop(stdin);
+    let _ = timeout(Duration::from_secs(5), child.wait()).await;
+    let _ = child.kill().await;
+    server.await.unwrap();
+}
+
+/// 2) No TCP server listening → bridge must exit non-zero within 1s.
+#[tokio::test]
+async fn bridge_exits_nonzero_when_tcp_unreachable() {
+    // Pick port 1 on loopback: it is privileged for *bind* (so nothing on a
+    // normal dev machine is listening there), but `connect` needs no
+    // privilege and just gets ECONNREFUSED, which is exactly the failure
+    // mode we want to exercise. Avoids the macOS "drop(listener) → port
+    // may still accept" race seen with port-0 bind-then-drop.
+    let port: u16 = 1;
+
+    let mut child = Command::new(BRIDGE_BIN)
+        .arg("mcp-bridge")
+        .env("TEAM_MCP_PORT", port.to_string())
+        .env("TEAM_MCP_TOKEN", "tok")
+        .env("TEAM_AGENT_SLOT_ID", "slot")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn bridge");
+
+    // The spec says "bridge must exit within 1s of TCP connect failure".
+    // We give 3s of budget because debug-build binary startup (tokio
+    // runtime + large deps linking) adds ~1-2s on macOS dev machines; the
+    // actual connect-fail → exit delay is tens of milliseconds. What we
+    // really assert is "no hung main loop on connect failure", not
+    // wall-clock < 1s from spawn.
+    let status = timeout(Duration::from_secs(3), child.wait())
+        .await
+        .expect("bridge did not exit within 3s after TCP connect failure")
+        .expect("wait failed");
+
+    assert!(
+        !status.success(),
+        "bridge must exit non-zero when TCP connect fails, got {status:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements Wave 1 module **D6** — `aionui-backend mcp-bridge` subcommand that ACP agent CLIs spawn as their MCP server, bridging stdio JSON-RPC ↔ TCP length-prefixed JSON to the existing `TeamMcpServer` inside `aionui-team`.

- **New file**: `crates/aionui-app/src/bridge.rs` — env parsing, TCP connect, two one-way forwarders (stdin→TCP and TCP→stdout), with `auth_token` / `slot_id` injection into the first `initialize` request.
- **Modified**: `crates/aionui-app/src/main.rs` — argv gate at the very top of `main()` so `aionui-backend mcp-bridge` never touches the database, logging, or `AppServices`; the normal server path is unaffected.
- **Modified**: `crates/aionui-app/src/lib.rs` — `pub mod bridge;`.
- **New tests**: `crates/aionui-app/tests/mcp_bridge_e2e.rs` — 2 integration tests (see below) plus 5 unit tests inside `bridge.rs`.

Env constants come from `aionui_api_types::TeamMcpStdioConfig::{ENV_PORT, ENV_TOKEN, ENV_SLOT_ID}` (landed in D1 #46). TCP frames use `aionui_team::mcp::protocol::{read_frame, write_frame}` — no new protocol code.

### Design notes

- **stdio format** is newline-delimited JSON (standard MCP stdio transport used by Claude Code / Codex / rmcp). No `Content-Length` headers.
- **Auth injection** replaces whatever the CLI sent in `initialize.params.auth_token` / `.slot_id`. The CLI cannot be trusted to know these — they come from env set by the backend that spawned it.
- **Error policy**: any unrecoverable error (missing env, TCP connect fail, malformed stdin JSON, TCP EOF mid-session) prints to stderr and exits 1, so the ACP CLI marks this MCP server as broken (docs/teams/mcp.md §4.4 stability guarantee #3). Clean TCP EOF exits 0.
- **mcp_ready notification** is phase1-deferred per interface-contracts.md §8 (AionUi's `waitForMcpReady` already graceful-resolves on timeout per aionui-audit §8 #11). W4-D24c will add it.

### LoC

- `bridge.rs`: 274 lines (≈180 LoC of production code + unit tests and rustdoc).
- `mcp_bridge_e2e.rs`: 155 lines.

## Test plan

- [x] `cargo build -p aionui-app` — clean
- [x] `cargo test -p aionui-app --lib` — all 10 tests pass (5 new bridge unit tests)
- [x] `cargo test -p aionui-app --test mcp_bridge_e2e` — both integration tests pass:
  - `bridge_forwards_initialize_and_tools_list`: spawns the real binary, drives stdin, asserts the mock TCP server sees `auth_token`/`slot_id` injected and that `tools/list` responses reach stdout as NDJSON.
  - `bridge_exits_nonzero_when_tcp_unreachable`: connects to `127.0.0.1:1` (privileged bind, so nothing listens; `connect` just gets ECONNREFUSED), asserts non-zero exit within 3s wall-clock from spawn — spec's "1s from connect failure" is well below that, the extra budget is just the debug-build startup cost.
- [x] `cargo clippy -p aionui-app --lib --bin aionui-backend --test mcp_bridge_e2e` — no new warnings from any D6 file. Pre-existing warnings in `aionui-cron` and `tests/file_e2e.rs` are unrelated to this PR.
- [x] `rustfmt --check` on `bridge.rs` and `mcp_bridge_e2e.rs` — clean.
- [x] Manual smoke: `TEAM_MCP_PORT=1 TEAM_MCP_TOKEN=tok TEAM_AGENT_SLOT_ID=slot ./target/debug/aionui-backend mcp-bridge < /dev/null` exits 1 immediately with `Connection refused`.
- [x] Manual smoke: running `aionui-backend` with no args still enters the normal HTTP server path (argv branch only fires for the literal `mcp-bridge` first arg).

Refs: docs/teams/phase1/modules.md §D6, docs/teams/phase1/interface-contracts.md §8, docs/teams/mcp.md §4.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)