### PR TITLE
feat(team): TeamSession new methods (D7a) — stdio_spec / compute_wake_input / on_agent_finish

### DIFF
--- a/crates/aionui-app/src/state_builders.rs
+++ b/crates/aionui-app/src/state_builders.rs
@@ -408,10 +408,17 @@ pub fn build_team_state(
     if let Some(cron_service) = cron_service {
         conv_service.set_cron_service(Some(cron_service));
     }
+    let backend_binary_path = Arc::new(
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.canonicalize().ok())
+            .unwrap_or_else(|| std::path::PathBuf::from("aionui-backend")),
+    );
     let service = Arc::new(TeamSessionService::new(
         team_repo,
         conv_service,
         services.event_bus.clone(),
+        backend_binary_path,
     ));
     TeamRouterState { service }
 }

--- a/crates/aionui-team/src/lib.rs
+++ b/crates/aionui-team/src/lib.rs
@@ -21,7 +21,7 @@ pub use prompts::{build_lead_prompt, build_teammate_prompt, build_wake_payload};
 pub use routes::{TeamRouterState, team_routes};
 pub use scheduler::{SchedulerAction, TeammateManager, WAKE_TIMEOUT_MS, WakePayload};
 pub use service::TeamSessionService;
-pub use session::TeamSession;
+pub use session::{TeamSession, WakeInput};
 pub use task_board::{TaskBoard, TaskUpdate};
 pub use types::{
     MailboxMessage, MailboxMessageType, TaskStatus, Team, TeamAgent, TeamTask, TeammateRole,

--- a/crates/aionui-team/src/prompts/lead.rs
+++ b/crates/aionui-team/src/prompts/lead.rs
@@ -404,7 +404,10 @@ mod tests {
         // healthy in the meantime.
         let renamed = HashMap::new();
         let out = build_lead_prompt(&params_min(&renamed));
-        assert!(!out.is_empty(), "output should not be empty with real template");
+        assert!(
+            !out.is_empty(),
+            "output should not be empty with real template"
+        );
         assert!(!out.contains("${"), "no unsubstituted placeholders");
     }
 

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use aionui_api_types::{
@@ -19,6 +20,7 @@ pub struct TeamSessionService {
     repo: Arc<dyn ITeamRepository>,
     conversation_service: ConversationService,
     broadcaster: Arc<dyn EventBroadcaster>,
+    backend_binary_path: Arc<PathBuf>,
     sessions: DashMap<String, TeamSession>,
 }
 
@@ -27,11 +29,13 @@ impl TeamSessionService {
         repo: Arc<dyn ITeamRepository>,
         conversation_service: ConversationService,
         broadcaster: Arc<dyn EventBroadcaster>,
+        backend_binary_path: Arc<PathBuf>,
     ) -> Self {
         Self {
             repo,
             conversation_service,
             broadcaster,
+            backend_binary_path,
             sessions: DashMap::new(),
         }
     }
@@ -355,7 +359,13 @@ impl TeamSessionService {
             .ok_or_else(|| TeamError::TeamNotFound(team_id.into()))?;
         let team = Team::from_row(&row)?;
 
-        let session = TeamSession::start(team, self.repo.clone(), self.broadcaster.clone()).await?;
+        let session = TeamSession::start(
+            team,
+            self.repo.clone(),
+            self.broadcaster.clone(),
+            self.backend_binary_path.clone(),
+        )
+        .await?;
 
         self.sessions.insert(team_id.to_owned(), session);
         Ok(())

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use aionui_db::ITeamRepository;
@@ -6,10 +7,23 @@ use tracing::info;
 
 use crate::error::TeamError;
 use crate::mailbox::Mailbox;
-use crate::mcp::{TeamMcpServer, TeamMcpStdioConfig};
+use crate::mcp::{TeamMcpServer, TeamMcpStdioConfig, TeamMcpStdioServerSpec};
+use crate::prompts::{build_lead_prompt, build_teammate_prompt, build_wake_payload};
 use crate::scheduler::TeammateManager;
 use crate::task_board::TaskBoard;
-use crate::types::{MailboxMessageType, Team, TeamAgent, TeammateStatus};
+use crate::types::{MailboxMessageType, Team, TeamAgent, TeammateRole, TeammateStatus};
+
+/// Input for the wake path. Produced by [`TeamSession::compute_wake_input`],
+/// consumed by D7b's `send_message` / `send_message_to_agent` (not implemented
+/// in D7a). `first_message` includes the role prompt on cold starts.
+#[derive(Debug, Clone)]
+pub struct WakeInput {
+    pub conversation_id: String,
+    pub first_message: String,
+    /// `false` when the mailbox is empty — caller should skip wake and
+    /// leave the agent idle.
+    pub should_send: bool,
+}
 
 pub struct TeamSession {
     team: Team,
@@ -17,6 +31,7 @@ pub struct TeamSession {
     mailbox: Arc<Mailbox>,
     task_board: Arc<TaskBoard>,
     mcp_server: TeamMcpServer,
+    backend_binary_path: Arc<PathBuf>,
 }
 
 impl TeamSession {
@@ -24,6 +39,7 @@ impl TeamSession {
         team: Team,
         repo: Arc<dyn ITeamRepository>,
         broadcaster: Arc<dyn EventBroadcaster>,
+        backend_binary_path: Arc<PathBuf>,
     ) -> Result<Self, TeamError> {
         let mailbox = Arc::new(Mailbox::new(repo.clone()));
         let task_board = Arc::new(TaskBoard::new(repo));
@@ -51,6 +67,7 @@ impl TeamSession {
             mailbox,
             task_board,
             mcp_server,
+            backend_binary_path,
         })
     }
 
@@ -68,6 +85,93 @@ impl TeamSession {
             token: self.mcp_server.auth_token().to_owned(),
             slot_id: slot_id.to_owned(),
         }
+    }
+
+    /// Returns the stdio server spec that `TeamSessionService::ensure_session`
+    /// (D9) persists into each agent's `conversation.extra` and that ACP
+    /// `session/new` consumes via `mcp_servers`.
+    pub fn stdio_spec(&self, slot_id: &str) -> TeamMcpStdioServerSpec {
+        let binary_path = self.backend_binary_path.to_string_lossy();
+        TeamMcpStdioServerSpec::from_config(
+            &self.team.id,
+            binary_path.as_ref(),
+            &self.mcp_stdio_config(slot_id),
+        )
+    }
+
+    /// Assemble the payload that will drive the next wake of `slot_id`.
+    ///
+    /// - Reads status, unread messages and tasks.
+    /// - Cold-start agents (no prior status, or last status was `Error`)
+    ///   receive the full role prompt prepended to the wake payload.
+    /// - When the mailbox is empty, returns `WakeInput { should_send: false, .. }`
+    ///   so the caller can skip the wake and mark the agent idle.
+    ///
+    /// Side effect: `mailbox.read_unread` marks the messages as read.
+    pub async fn compute_wake_input(&self, slot_id: &str) -> Result<Option<WakeInput>, TeamError> {
+        let agent = self.scheduler.get_agent(slot_id).await?;
+        let unread = self.mailbox.read_unread(&self.team.id, slot_id).await?;
+        let tasks = self.scheduler.list_tasks().await?;
+
+        let wake_body = build_wake_payload(&agent, &tasks, &unread);
+
+        // TODO(D8): swap `needs_role_prompt` to match `{Pending, Error}` once
+        // `TeammateStatus::Pending` is reintroduced (it currently serde-aliases
+        // into `Idle`, so we use the `TeamAgent::status` sentinel — `None` means
+        // the scheduler never transitioned the slot, i.e. cold start).
+        let needs_role_prompt = matches!(agent.status, None | Some(TeammateStatus::Error));
+
+        let first_message = if needs_role_prompt {
+            let role_prompt = match agent.role {
+                TeammateRole::Lead => {
+                    build_lead_prompt(&self.team.name, &self.scheduler.list_agents().await)
+                }
+                TeammateRole::Teammate => build_teammate_prompt(&agent, &self.team.name),
+            };
+            format!("{role_prompt}\n\n{wake_body}")
+        } else {
+            wake_body
+        };
+
+        let should_send = !unread.is_empty();
+
+        Ok(Some(WakeInput {
+            conversation_id: agent.conversation_id,
+            first_message,
+            should_send,
+        }))
+    }
+
+    /// Handle agent Finish/Error events. Delegates to the scheduler's
+    /// `finalize_turn` with no parsed actions (phase1 does not parse the
+    /// trailing message for scheduler directives). Returns the leader slot_id
+    /// that the caller should re-wake, if any; D7b wires that return value
+    /// into the wake path. `is_error` is reserved for future status handling.
+    pub async fn on_agent_finish(
+        &self,
+        conversation_id: &str,
+        is_error: bool,
+    ) -> Result<Option<String>, TeamError> {
+        let slot_id = {
+            let agents = self.scheduler.list_agents().await;
+            agents
+                .into_iter()
+                .find(|a| a.conversation_id == conversation_id)
+                .map(|a| a.slot_id)
+                .ok_or_else(|| {
+                    TeamError::AgentNotFound(format!(
+                        "no agent with conversation_id={conversation_id}"
+                    ))
+                })?
+        };
+
+        if is_error {
+            self.scheduler
+                .set_status(&slot_id, TeammateStatus::Error)
+                .await?;
+        }
+
+        self.scheduler.finalize_turn(&slot_id, &[]).await
     }
 
     pub async fn send_message(&self, content: &str) -> Result<(), TeamError> {
@@ -159,6 +263,10 @@ mod tests {
         fn broadcast(&self, _msg: WebSocketMessage<serde_json::Value>) {}
     }
 
+    fn backend_path() -> Arc<PathBuf> {
+        Arc::new(PathBuf::from("/tmp/aionui-backend-test"))
+    }
+
     fn make_team() -> Team {
         Team {
             id: "t1".into(),
@@ -195,13 +303,17 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn start_and_stop() {
+    async fn start_session() -> TeamSession {
         let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
         let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let team = make_team();
+        TeamSession::start(make_team(), repo, broadcaster, backend_path())
+            .await
+            .unwrap()
+    }
 
-        let session = TeamSession::start(team, repo, broadcaster).await.unwrap();
+    #[tokio::test]
+    async fn start_and_stop() {
+        let session = start_session().await;
         assert_eq!(session.team_id(), "t1");
         assert!(session.mcp_server.port() > 0);
         session.stop();
@@ -209,14 +321,25 @@ mod tests {
 
     #[tokio::test]
     async fn mcp_stdio_config_for_agent() {
-        let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
-        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let team = make_team();
-
-        let session = TeamSession::start(team, repo, broadcaster).await.unwrap();
+        let session = start_session().await;
         let config = session.mcp_stdio_config("lead-1");
         assert_eq!(config.slot_id, "lead-1");
         assert_eq!(config.port, session.mcp_server.port());
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn stdio_spec_embeds_team_and_binary_path() {
+        let session = start_session().await;
+        let spec = session.stdio_spec("lead-1");
+        assert_eq!(spec.name, "aionui-team-t1");
+        assert_eq!(spec.command, "/tmp/aionui-backend-test");
+        assert_eq!(spec.args, vec!["mcp-bridge".to_string()]);
+        assert!(
+            spec.env
+                .iter()
+                .any(|(k, v)| k == "TEAM_AGENT_SLOT_ID" && v == "lead-1")
+        );
         session.stop();
     }
 
@@ -225,9 +348,7 @@ mod tests {
         let repo = Arc::new(MockTeamRepo::new());
         let repo_dyn: Arc<dyn ITeamRepository> = repo.clone();
         let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let team = make_team();
-
-        let session = TeamSession::start(team, repo_dyn, broadcaster)
+        let session = TeamSession::start(make_team(), repo_dyn, broadcaster, backend_path())
             .await
             .unwrap();
         session.send_message("Hello team").await.unwrap();
@@ -245,9 +366,7 @@ mod tests {
         let repo = Arc::new(MockTeamRepo::new());
         let repo_dyn: Arc<dyn ITeamRepository> = repo.clone();
         let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let team = make_team();
-
-        let session = TeamSession::start(team, repo_dyn, broadcaster)
+        let session = TeamSession::start(make_team(), repo_dyn, broadcaster, backend_path())
             .await
             .unwrap();
         session
@@ -264,11 +383,7 @@ mod tests {
 
     #[tokio::test]
     async fn send_message_to_unknown_agent_returns_error() {
-        let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
-        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let team = make_team();
-
-        let session = TeamSession::start(team, repo, broadcaster).await.unwrap();
+        let session = start_session().await;
         let result = session.send_message_to_agent("nonexistent", "Hello").await;
         assert!(result.is_err());
         session.stop();
@@ -276,11 +391,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_and_remove_agent() {
-        let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
-        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let team = make_team();
-
-        let session = TeamSession::start(team, repo, broadcaster).await.unwrap();
+        let session = start_session().await;
 
         let new_agent = TeamAgent {
             slot_id: "new-1".into(),
@@ -308,11 +419,7 @@ mod tests {
 
     #[tokio::test]
     async fn rename_agent_in_session() {
-        let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
-        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let team = make_team();
-
-        let session = TeamSession::start(team, repo, broadcaster).await.unwrap();
+        let session = start_session().await;
         session
             .rename_agent("worker-1", "Senior Worker")
             .await
@@ -326,12 +433,173 @@ mod tests {
 
     #[tokio::test]
     async fn rename_unknown_agent_returns_error() {
-        let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
-        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let team = make_team();
-
-        let session = TeamSession::start(team, repo, broadcaster).await.unwrap();
+        let session = start_session().await;
         let result = session.rename_agent("nonexistent", "X").await;
+        assert!(result.is_err());
+        session.stop();
+    }
+
+    // -- D7a new method tests ------------------------------------------------
+
+    #[tokio::test]
+    async fn compute_wake_input_cold_start_injects_lead_role_prompt() {
+        let session = start_session().await;
+        // Seed one unread message. `send_message` flips status to Working —
+        // that is the post-send path; here we want to exercise cold-start
+        // detection, so write directly to the mailbox instead.
+        session
+            .mailbox
+            .write(
+                "t1",
+                "lead-1",
+                "user",
+                MailboxMessageType::Message,
+                "kick off",
+                None,
+            )
+            .await
+            .unwrap();
+
+        let input = session
+            .compute_wake_input("lead-1")
+            .await
+            .unwrap()
+            .expect("WakeInput");
+
+        assert_eq!(input.conversation_id, "c1");
+        assert!(input.should_send);
+        assert!(
+            input.first_message.contains("Lead Agent of team"),
+            "expected lead role prompt, got: {}",
+            input.first_message
+        );
+        assert!(input.first_message.contains("kick off"));
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn compute_wake_input_cold_start_injects_teammate_role_prompt() {
+        let session = start_session().await;
+        session
+            .mailbox
+            .write(
+                "t1",
+                "worker-1",
+                "user",
+                MailboxMessageType::Message,
+                "do X",
+                None,
+            )
+            .await
+            .unwrap();
+
+        let input = session
+            .compute_wake_input("worker-1")
+            .await
+            .unwrap()
+            .expect("WakeInput");
+
+        assert!(
+            input.first_message.contains("Teammate Agent"),
+            "expected teammate role prompt, got: {}",
+            input.first_message
+        );
+        assert!(input.first_message.contains("do X"));
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn compute_wake_input_warm_agent_skips_role_prompt() {
+        let session = start_session().await;
+        // Exit cold-start by setting a status once; any non-Error status
+        // means the scheduler has seen this agent before.
+        session
+            .scheduler
+            .set_status("lead-1", TeammateStatus::Idle)
+            .await
+            .unwrap();
+        session
+            .mailbox
+            .write(
+                "t1",
+                "lead-1",
+                "user",
+                MailboxMessageType::Message,
+                "follow-up",
+                None,
+            )
+            .await
+            .unwrap();
+
+        let input = session
+            .compute_wake_input("lead-1")
+            .await
+            .unwrap()
+            .expect("WakeInput");
+
+        assert!(input.should_send);
+        assert!(
+            !input.first_message.contains("Lead Agent of team"),
+            "should not re-inject role prompt, got: {}",
+            input.first_message
+        );
+        assert!(input.first_message.contains("follow-up"));
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn compute_wake_input_empty_mailbox_should_not_send() {
+        let session = start_session().await;
+
+        let input = session
+            .compute_wake_input("lead-1")
+            .await
+            .unwrap()
+            .expect("WakeInput");
+
+        assert!(!input.should_send);
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn on_agent_finish_marks_idle_and_returns_lead_when_all_settled() {
+        let session = start_session().await;
+
+        // Worker is Working; on finish → mark idle → since the lead is the
+        // only remaining non-idle member (actually also idle), all-idle
+        // check returns the lead slot_id.
+        session
+            .scheduler
+            .set_status("worker-1", TeammateStatus::Working)
+            .await
+            .unwrap();
+
+        let result = session.on_agent_finish("c2", false).await.unwrap();
+        assert_eq!(result.as_deref(), Some("lead-1"));
+
+        let status = session.scheduler.get_status("worker-1").await.unwrap();
+        assert_eq!(status, TeammateStatus::Idle);
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn on_agent_finish_lead_returns_none() {
+        let session = start_session().await;
+        session
+            .scheduler
+            .set_status("lead-1", TeammateStatus::Working)
+            .await
+            .unwrap();
+
+        let result = session.on_agent_finish("c1", false).await.unwrap();
+        assert!(result.is_none());
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn on_agent_finish_unknown_conversation_returns_error() {
+        let session = start_session().await;
+        let result = session.on_agent_finish("nope", false).await;
         assert!(result.is_err());
         session.stop();
     }

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -274,6 +274,20 @@ impl aionui_conversation::skill_resolver::SkillResolver for StubSkillResolver {
     async fn auto_inject_names(&self) -> Vec<String> {
         Vec::new()
     }
+    async fn resolve_skills(
+        &self,
+        _names: &[String],
+    ) -> Vec<aionui_conversation::skill_resolver::ResolvedAgentSkill> {
+        Vec::new()
+    }
+    async fn link_workspace_skills(
+        &self,
+        _workspace: &std::path::Path,
+        _rel_dirs: &[&str],
+        _skills: &[aionui_conversation::skill_resolver::ResolvedAgentSkill],
+    ) -> usize {
+        0
+    }
 }
 
 fn setup() -> TeamSessionService {
@@ -286,7 +300,8 @@ fn setup() -> TeamSessionService {
         std::env::temp_dir(),
         Arc::new(StubSkillResolver),
     );
-    TeamSessionService::new(team_repo, conv_service, broadcaster)
+    let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aionui-backend-test"));
+    TeamSessionService::new(team_repo, conv_service, broadcaster, backend_binary_path)
 }
 
 fn two_agent_input() -> Vec<TeamAgentInput> {


### PR DESCRIPTION
## Summary

Wave 2 module **D7a**. Adds three pure new methods on `TeamSession`
without touching the existing `send_message` / `send_message_to_agent`
paths (D7b wires those later per the split in `docs/teams/phase1/modules.md`).

- `stdio_spec(slot_id) -> TeamMcpStdioServerSpec` — thin wrapper over
  `TeamMcpStdioServerSpec::from_config(team_id, backend_binary_path, mcp_stdio_config(slot_id))`
  using a new `backend_binary_path: Arc<PathBuf>` field on `TeamSession`.
  `TeamSession::start()` signature gains that argument; callers updated
  (`TeamSessionService::new` / integration test / `state_builders`).
- `compute_wake_input(slot_id) -> Result<Option<WakeInput>, TeamError>`
  reads `agent`, `unread_messages` (via `mailbox.read_unread`), and
  `tasks`, then builds the wake body via `build_wake_payload`. Cold-start
  agents (`agent.status == None`, i.e. the scheduler has never
  transitioned the slot) and agents last seen as `Error` get the
  lead/teammate role prompt prepended to `first_message`. Returns
  `WakeInput { should_send: false, .. }` when the mailbox is empty so the
  caller can skip the wake and mark idle. A `TODO(D8)` notes the
  `Pending` variant reintroduction will let us tighten the check to
  `{Pending, Error}`.
- `on_agent_finish(conversation_id, is_error)` looks up the owning
  `slot_id`, flips status to `Error` when `is_error`, and delegates to
  `scheduler.finalize_turn(slot_id, &[])` — phase1 does not parse
  trailing actions. Returns the `Option<String>` lead_slot_id that D7b
  will feed back into the wake path.
- New `WakeInput` DTO re-exported from `aionui_team::`.

## Test plan

- [x] `cargo build -p aionui-team -p aionui-app` — passes.
- [x] `cargo test -p aionui-team --lib session::tests` — 16/16 pass
      (including 7 new tests for D7a).
- [x] `cargo test -p aionui-team --test session_service_integration` —
      30/30 pass.
- [x] `cargo clippy -p aionui-team --all-targets -- -D warnings` — clean.
- [x] `cargo fmt` clean on touched files.

### D7a-specific tests (all pass)
- `stdio_spec_embeds_team_and_binary_path`
- `compute_wake_input_cold_start_injects_lead_role_prompt`
- `compute_wake_input_cold_start_injects_teammate_role_prompt`
- `compute_wake_input_warm_agent_skips_role_prompt`
- `compute_wake_input_empty_mailbox_should_not_send`
- `on_agent_finish_marks_idle_and_returns_lead_when_all_settled`
- `on_agent_finish_lead_returns_none`
- `on_agent_finish_unknown_conversation_returns_error`

### Known pre-existing baseline failures (NOT caused by D7a)
- `tests/mcp_server_integration.rs::mc1_correct_token_connects`
- `tests/mcp_server_integration.rs::tools_list_returns_all_8_tools` —
  expects 8 tools but D4/D4b added 2 more; needs a separate fix.
- Fmt diffs in unrelated files (`aionui-app/src/main.rs`, `aionui-channel/src/message_service.rs`).

Also included: one-line fill-in for the pre-existing `SkillResolver`
stub in the integration test (trait drift made the test file fail to
compile on the base branch); added `resolve_skills` + `link_workspace_skills`
no-op impls so the test binary builds.

## Notes for downstream waves

- **D7b** will consume `compute_wake_input` inside `send_message` /
  `send_message_to_agent` and handle the `should_send=false` skip + the
  log-not-throw semantics for wake failures.
- **D8** will reintroduce `TeammateStatus::Pending`; tighten the
  `needs_role_prompt` match arm to `{Pending, Error}` at that point.
- **D9** will thread a real `backend_binary_path` into
  `TeamSessionService::new` (today it comes from
  `std::env::current_exe()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)