### PR TITLE
fix(channel): normalize yolo mode to backend-specific full-auto mode

### DIFF
--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -53,15 +53,18 @@ fn normalize_requested_mode(backend: AcpBackend, mode: &str) -> String {
         return String::new();
     }
 
+    // "yolo" / "yoloNoSandbox" are generic full-auto identifiers used by
+    // channel and cron flows. Map them to whatever the specific backend
+    // actually calls its permissive mode (e.g. `bypassPermissions` for
+    // Claude, `full-access` for Codex, `yolo` for Gemini/Qwen).
+    if matches!(trimmed, "yolo" | "yoloNoSandbox") {
+        return backend.full_auto_mode_id().to_owned();
+    }
+
     match backend {
-        // Codex ACP now reports native mode ids (`read-only`, `auto`,
-        // `full-access`) while existing AionUi flows still persist the legacy
-        // semantic ids (`default`, `autoEdit`, `yolo`, `yoloNoSandbox`).
-        // Cron reuses the persisted value directly, so normalize it before
-        // comparing or calling `session/set_mode`.
+        // Codex also has legacy `default`/`autoEdit` that need mapping.
         AcpBackend::Codex => match trimmed {
             "default" | "autoEdit" => "auto".to_owned(),
-            "yolo" | "yoloNoSandbox" => "full-access".to_owned(),
             other => other.to_owned(),
         },
         _ => trimmed.to_owned(),
@@ -915,6 +918,26 @@ mod tests {
         assert_eq!(
             normalize_requested_mode(AcpBackend::Claude, "bypassPermissions"),
             "bypassPermissions"
+        );
+        assert_eq!(
+            normalize_requested_mode(AcpBackend::Claude, "yolo"),
+            "bypassPermissions"
+        );
+        assert_eq!(
+            normalize_requested_mode(AcpBackend::Claude, "yoloNoSandbox"),
+            "bypassPermissions"
+        );
+        assert_eq!(
+            normalize_requested_mode(AcpBackend::Opencode, "yolo"),
+            "build"
+        );
+        assert_eq!(
+            normalize_requested_mode(AcpBackend::Cursor, "yolo"),
+            "agent"
+        );
+        assert_eq!(
+            normalize_requested_mode(AcpBackend::Gemini, "yolo"),
+            "yolo"
         );
     }
 }

--- a/crates/aionui-common/src/enums.rs
+++ b/crates/aionui-common/src/enums.rs
@@ -280,7 +280,7 @@ impl AcpBackend {
     /// conversation without depending on a live ACP runtime snapshot.
     pub fn full_auto_mode_id(&self) -> &'static str {
         match self {
-            AcpBackend::Claude => "bypassPermissions",
+            AcpBackend::Claude | AcpBackend::Codebuddy => "bypassPermissions",
             AcpBackend::Codex => "full-access",
             AcpBackend::Opencode => "build",
             AcpBackend::Cursor => "agent",
@@ -723,6 +723,10 @@ mod tests {
     #[test]
     fn acp_backend_full_auto_mode_id_matches_backend_capabilities() {
         assert_eq!(AcpBackend::Claude.full_auto_mode_id(), "bypassPermissions");
+        assert_eq!(
+            AcpBackend::Codebuddy.full_auto_mode_id(),
+            "bypassPermissions"
+        );
         assert_eq!(AcpBackend::Codex.full_auto_mode_id(), "full-access");
         assert_eq!(AcpBackend::Opencode.full_auto_mode_id(), "build");
         assert_eq!(AcpBackend::Cursor.full_auto_mode_id(), "agent");


### PR DESCRIPTION
## Summary

- Channel/cron flows use generic `"yolo"` as session_mode, but Claude and CodeBuddy ACP agents only recognize `"bypassPermissions"`. This caused `session/set_mode` to fail with "Invalid Mode", blocking the entire prompt flow and leaving Telegram messages stuck in "Thinking..." forever.
- `normalize_requested_mode` now maps `"yolo"`/`"yoloNoSandbox"` to `backend.full_auto_mode_id()` for all ACP backends, not just Codex.
- Added `Codebuddy` to the `"bypassPermissions"` group in `full_auto_mode_id()`.

## Test plan

- [x] Unit tests pass for `normalize_requested_mode` (Claude, Codex, Opencode, Cursor, Gemini)
- [x] Unit tests pass for `full_auto_mode_id` (Codebuddy added)
- [ ] Manual: send message via Telegram channel with Claude backend → should receive reply
- [ ] Manual: send message via Telegram channel with CodeBuddy backend → should receive reply