### PR TITLE
feat(team): ensure_session kill + rebuild closed loop (D9)

### DIFF
--- a/crates/aionui-app/src/state_builders.rs
+++ b/crates/aionui-app/src/state_builders.rs
@@ -418,6 +418,7 @@ pub fn build_team_state(
         team_repo,
         conv_service,
         services.event_bus.clone(),
+        services.worker_task_manager.clone(),
         backend_binary_path,
     ));
     TeamRouterState { service }

--- a/crates/aionui-common/src/enums.rs
+++ b/crates/aionui-common/src/enums.rs
@@ -391,6 +391,10 @@ pub enum RemoteAgentStatus {
 #[serde(rename_all = "snake_case")]
 pub enum AgentKillReason {
     IdleTimeout,
+    /// Team session is rebuilding the agent process to inject a fresh
+    /// `team_mcp_stdio_config`. The conversation is preserved; only the
+    /// in-memory ACP CLI is recycled.
+    TeamMcpRebuild,
 }
 
 /// Preview content type for document preview history.

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -418,6 +418,35 @@ impl ConversationService {
         Ok(response)
     }
 
+    /// Merge a JSON patch into `conversation.extra` without touching model,
+    /// name, pinned flag, or task lifecycle. Intended for internal callers
+    /// (e.g. `TeamSessionService::ensure_session` writing
+    /// `team_mcp_stdio_config`) where a full `update()` would kill the agent
+    /// on a spurious model comparison.
+    pub async fn update_extra(
+        &self,
+        conversation_id: &str,
+        patch: serde_json::Value,
+    ) -> Result<(), AppError> {
+        let existing = self.repo.get(conversation_id).await?.ok_or_else(|| {
+            AppError::NotFound(format!("Conversation {conversation_id} not found"))
+        })?;
+
+        let mut merged: serde_json::Value =
+            serde_json::from_str(&existing.extra).unwrap_or_else(|_| serde_json::json!({}));
+        merge_json(&mut merged, &patch);
+
+        let updates = ConversationRowUpdate {
+            extra: Some(serde_json::to_string(&merged).map_err(|e| {
+                AppError::Internal(format!("Failed to serialize merged extra: {e}"))
+            })?),
+            updated_at: Some(now_ms()),
+            ..Default::default()
+        };
+        self.repo.update(conversation_id, &updates).await?;
+        Ok(())
+    }
+
     /// Delete a conversation (messages cascade via FK).
     ///
     /// Broadcasts `conversation.listChanged(deleted)`.

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -1,27 +1,37 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use aionui_ai_agent::IWorkerTaskManager;
 use aionui_api_types::{
     AddAgentRequest, CreateConversationRequest, CreateTeamRequest, TeamAgentResponse, TeamResponse,
 };
-use aionui_common::{AgentType, ProviderWithModel, generate_id, now_ms};
+use aionui_common::{AgentKillReason, AgentType, ProviderWithModel, generate_id, now_ms};
 use aionui_conversation::ConversationService;
 use aionui_db::models::TeamRow;
 use aionui_db::{ITeamRepository, UpdateTeamParams};
 use aionui_realtime::EventBroadcaster;
 use dashmap::DashMap;
-use tracing::info;
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
 
 use crate::error::TeamError;
 use crate::session::TeamSession;
 use crate::types::{Team, TeamAgent, TeammateRole};
 
+struct SessionEntry {
+    session: TeamSession,
+    /// Background tasks that forward `Finish` / `Error` stream events to
+    /// `session.on_agent_finish`. Aborted in `stop_session`.
+    finish_subscribers: Vec<JoinHandle<()>>,
+}
+
 pub struct TeamSessionService {
     repo: Arc<dyn ITeamRepository>,
     conversation_service: ConversationService,
     broadcaster: Arc<dyn EventBroadcaster>,
+    task_manager: Arc<dyn IWorkerTaskManager>,
     backend_binary_path: Arc<PathBuf>,
-    sessions: DashMap<String, TeamSession>,
+    sessions: Arc<DashMap<String, SessionEntry>>,
 }
 
 impl TeamSessionService {
@@ -29,14 +39,16 @@ impl TeamSessionService {
         repo: Arc<dyn ITeamRepository>,
         conversation_service: ConversationService,
         broadcaster: Arc<dyn EventBroadcaster>,
+        task_manager: Arc<dyn IWorkerTaskManager>,
         backend_binary_path: Arc<PathBuf>,
     ) -> Self {
         Self {
             repo,
             conversation_service,
             broadcaster,
+            task_manager,
             backend_binary_path,
-            sessions: DashMap::new(),
+            sessions: Arc::new(DashMap::new()),
         }
     }
 
@@ -255,8 +267,8 @@ impl TeamSessionService {
             )
             .await?;
 
-        if let Some(session) = self.sessions.get(team_id) {
-            session.add_agent(&agent).await;
+        if let Some(entry) = self.sessions.get(team_id) {
+            entry.session.add_agent(&agent).await;
         }
 
         let response = agent.to_response();
@@ -301,8 +313,8 @@ impl TeamSessionService {
             )
             .await?;
 
-        if let Some(session) = self.sessions.get(team_id) {
-            let _ = session.remove_agent(slot_id).await;
+        if let Some(entry) = self.sessions.get(team_id) {
+            let _ = entry.session.remove_agent(slot_id).await;
         }
 
         Ok(())
@@ -340,13 +352,27 @@ impl TeamSessionService {
             )
             .await?;
 
-        if let Some(session) = self.sessions.get(team_id) {
-            let _ = session.rename_agent(slot_id, name).await;
+        if let Some(entry) = self.sessions.get(team_id) {
+            let _ = entry.session.rename_agent(slot_id, name).await;
         }
 
         Ok(())
     }
 
+    /// Start the team's MCP server and rebuild every agent process so it
+    /// carries a fresh `team_mcp_stdio_config` pointing at the new server.
+    ///
+    /// Flow (mcp.md §4.3):
+    /// 1. Start `TeamSession` (opens the MCP TCP server).
+    /// 2. For each agent: persist `team_mcp_stdio_config` into
+    ///    `conversation.extra` → `task_manager.kill(conv_id, TeamMcpRebuild)`
+    ///    → `conversation_service.warmup(...)` rebuilds the ACP process with
+    ///    the new extra.
+    /// 3. Subscribe to each agent's stream and forward `Finish` / `Error`
+    ///    events to `session.on_agent_finish`.
+    /// 4. Only insert into `sessions` after every step above succeeds — on
+    ///    any failure, stop the session and leave the map untouched so a
+    ///    retry can start cleanly.
     pub async fn ensure_session(&self, team_id: &str) -> Result<(), TeamError> {
         if self.sessions.contains_key(team_id) {
             return Ok(());
@@ -357,7 +383,9 @@ impl TeamSessionService {
             .get_team(team_id)
             .await?
             .ok_or_else(|| TeamError::TeamNotFound(team_id.into()))?;
+        let user_id = row.user_id.clone();
         let team = Team::from_row(&row)?;
+        let agents_snapshot: Vec<TeamAgent> = team.agents.clone();
 
         let session = TeamSession::start(
             team,
@@ -367,22 +395,125 @@ impl TeamSessionService {
         )
         .await?;
 
-        self.sessions.insert(team_id.to_owned(), session);
+        if let Err(e) = self
+            .rebuild_agent_processes(&session, &user_id, &agents_snapshot)
+            .await
+        {
+            session.stop();
+            return Err(e);
+        }
+
+        let finish_subscribers = self.spawn_finish_subscribers(team_id, &agents_snapshot);
+
+        let entry = SessionEntry {
+            session,
+            finish_subscribers,
+        };
+        self.sessions.insert(team_id.to_owned(), entry);
+
         Ok(())
     }
 
+    async fn rebuild_agent_processes(
+        &self,
+        session: &TeamSession,
+        user_id: &str,
+        agents: &[TeamAgent],
+    ) -> Result<(), TeamError> {
+        for agent in agents {
+            let cfg = session.mcp_stdio_config(&agent.slot_id);
+            let patch = serde_json::json!({ "team_mcp_stdio_config": cfg });
+
+            self.conversation_service
+                .update_extra(&agent.conversation_id, patch)
+                .await
+                .map_err(|e| {
+                    TeamError::InvalidRequest(format!(
+                        "failed to persist team_mcp_stdio_config for {}: {e}",
+                        agent.slot_id
+                    ))
+                })?;
+
+            self.task_manager
+                .kill(
+                    &agent.conversation_id,
+                    Some(AgentKillReason::TeamMcpRebuild),
+                )
+                .map_err(|e| {
+                    TeamError::InvalidRequest(format!(
+                        "failed to kill agent task {}: {e}",
+                        agent.conversation_id
+                    ))
+                })?;
+
+            self.conversation_service
+                .warmup(user_id, &agent.conversation_id, &self.task_manager)
+                .await
+                .map_err(|e| {
+                    TeamError::InvalidRequest(format!(
+                        "failed to rebuild agent task {}: {e}",
+                        agent.conversation_id
+                    ))
+                })?;
+        }
+        Ok(())
+    }
+
+    /// Spawn one background task per agent that drains the agent's stream
+    /// and forwards `Finish` / `Error` events to the session. The tasks
+    /// look up the live session via `team_id` each iteration, and exit
+    /// naturally when the entry is removed in `stop_session` (which also
+    /// aborts them as a belt-and-braces measure).
+    fn spawn_finish_subscribers(&self, team_id: &str, agents: &[TeamAgent]) -> Vec<JoinHandle<()>> {
+        use aionui_ai_agent::AgentStreamEvent;
+
+        let mut handles = Vec::with_capacity(agents.len());
+        for agent in agents {
+            let Some(task) = self.task_manager.get_task(&agent.conversation_id) else {
+                warn!(
+                    conversation_id = %agent.conversation_id,
+                    "no agent task found after warmup, skipping finish subscription"
+                );
+                continue;
+            };
+            let mut rx = task.subscribe();
+            let conv_id = agent.conversation_id.clone();
+            let team_id = team_id.to_owned();
+            let sessions = self.sessions.clone();
+            let handle = tokio::spawn(async move {
+                while let Ok(event) = rx.recv().await {
+                    let is_error = matches!(event, AgentStreamEvent::Error(_));
+                    if !is_error && !matches!(event, AgentStreamEvent::Finish(_)) {
+                        continue;
+                    }
+                    let Some(entry) = sessions.get(&team_id) else {
+                        break;
+                    };
+                    if let Err(e) = entry.session.on_agent_finish(&conv_id, is_error).await {
+                        warn!(conversation_id = %conv_id, error = %e, "on_agent_finish failed");
+                    }
+                }
+            });
+            handles.push(handle);
+        }
+        handles
+    }
+
     pub fn stop_session(&self, team_id: &str) {
-        if let Some((_, session)) = self.sessions.remove(team_id) {
-            session.stop();
+        if let Some((_, entry)) = self.sessions.remove(team_id) {
+            for handle in &entry.finish_subscribers {
+                handle.abort();
+            }
+            entry.session.stop();
         }
     }
 
     pub async fn send_message(&self, team_id: &str, content: &str) -> Result<(), TeamError> {
-        let session = self
+        let entry = self
             .sessions
             .get(team_id)
             .ok_or_else(|| TeamError::SessionNotFound(team_id.into()))?;
-        session.send_message(content).await
+        entry.session.send_message(content).await
     }
 
     pub async fn send_message_to_agent(
@@ -391,11 +522,11 @@ impl TeamSessionService {
         slot_id: &str,
         content: &str,
     ) -> Result<(), TeamError> {
-        let session = self
+        let entry = self
             .sessions
             .get(team_id)
             .ok_or_else(|| TeamError::SessionNotFound(team_id.into()))?;
-        session.send_message_to_agent(slot_id, content).await
+        entry.session.send_message_to_agent(slot_id, content).await
     }
 
     pub fn dispose_all(&self) {

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -1,9 +1,11 @@
 mod common;
 
 use std::sync::Arc;
+use std::sync::Mutex;
 
+use aionui_ai_agent::{AgentFactory, BuildTaskOptions, IWorkerTaskManager, WorkerTaskManagerImpl};
 use aionui_api_types::{AddAgentRequest, CreateTeamRequest, TeamAgentInput, WebSocketMessage};
-use aionui_common::PaginatedResult;
+use aionui_common::{AgentKillReason, AppError, PaginatedResult};
 use aionui_db::models::{ConversationRow, MessageRow};
 use aionui_db::{
     ConversationFilters, ConversationRowUpdate, DbError, IConversationRepository, ITeamRepository,
@@ -41,7 +43,27 @@ impl IConversationRepository for MockConversationRepo {
         self.conversations.lock().unwrap().push(row.clone());
         Ok(())
     }
-    async fn update(&self, _id: &str, _updates: &ConversationRowUpdate) -> Result<(), DbError> {
+    async fn update(&self, id: &str, updates: &ConversationRowUpdate) -> Result<(), DbError> {
+        let mut convs = self.conversations.lock().unwrap();
+        let conv = convs
+            .iter_mut()
+            .find(|c| c.id == id)
+            .ok_or_else(|| DbError::NotFound(id.to_owned()))?;
+        if let Some(ref extra) = updates.extra {
+            conv.extra = extra.clone();
+        }
+        if let Some(ref name) = updates.name {
+            conv.name = name.clone();
+        }
+        if let Some(pinned) = updates.pinned {
+            conv.pinned = pinned;
+        }
+        if let Some(ref model) = updates.model {
+            conv.model = model.clone();
+        }
+        if let Some(updated_at) = updates.updated_at {
+            conv.updated_at = updated_at;
+        }
         Ok(())
     }
     async fn delete(&self, id: &str) -> Result<(), DbError> {
@@ -290,7 +312,159 @@ impl aionui_conversation::skill_resolver::SkillResolver for StubSkillResolver {
     }
 }
 
-fn setup() -> TeamSessionService {
+// ---------------------------------------------------------------------------
+// Counting task manager — wraps WorkerTaskManagerImpl so tests can assert
+// kill / get_or_build_task call counts by conversation id.
+// ---------------------------------------------------------------------------
+
+#[derive(Default, Clone)]
+struct TaskManagerCalls {
+    kill: Vec<(String, Option<AgentKillReason>)>,
+    build: Vec<String>,
+}
+
+struct CountingTaskManager {
+    inner: WorkerTaskManagerImpl,
+    calls: Mutex<TaskManagerCalls>,
+}
+
+impl CountingTaskManager {
+    fn new(factory: AgentFactory) -> Self {
+        Self {
+            inner: WorkerTaskManagerImpl::new(factory),
+            calls: Mutex::new(TaskManagerCalls::default()),
+        }
+    }
+
+    fn snapshot(&self) -> TaskManagerCalls {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+impl IWorkerTaskManager for CountingTaskManager {
+    fn get_task(&self, conversation_id: &str) -> Option<aionui_ai_agent::AgentManagerHandle> {
+        self.inner.get_task(conversation_id)
+    }
+    fn get_or_build_task(
+        &self,
+        conversation_id: &str,
+        options: BuildTaskOptions,
+    ) -> Result<aionui_ai_agent::AgentManagerHandle, AppError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .build
+            .push(conversation_id.to_owned());
+        self.inner.get_or_build_task(conversation_id, options)
+    }
+    fn kill(&self, conversation_id: &str, reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .kill
+            .push((conversation_id.to_owned(), reason));
+        self.inner.kill(conversation_id, reason)
+    }
+    fn clear(&self) {
+        self.inner.clear()
+    }
+    fn active_count(&self) -> usize {
+        self.inner.active_count()
+    }
+    fn collect_idle(&self, idle_threshold_ms: aionui_common::TimestampMs) -> Vec<String> {
+        self.inner.collect_idle(idle_threshold_ms)
+    }
+}
+
+// Minimal stub agent returned by the test factory: ensure_session only
+// asks the task manager to kill + rebuild; the returned handle never has
+// `send_message` called on it.
+mod mock_agent {
+    use aionui_ai_agent::agent_manager::IAgentManager;
+    use aionui_ai_agent::stream_event::AgentStreamEvent;
+    use aionui_ai_agent::types::SendMessageData;
+    use aionui_common::{
+        AgentKillReason, AgentType, AppError, Confirmation, ConversationStatus, TimestampMs,
+    };
+    use tokio::sync::broadcast;
+
+    pub struct MockAgent {
+        pub conversation_id: String,
+        pub workspace: String,
+        pub event_tx: broadcast::Sender<AgentStreamEvent>,
+    }
+
+    impl MockAgent {
+        pub fn new(conversation_id: String, workspace: String) -> Self {
+            let (event_tx, _) = broadcast::channel(16);
+            Self {
+                conversation_id,
+                workspace,
+                event_tx,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl IAgentManager for MockAgent {
+        fn agent_type(&self) -> AgentType {
+            AgentType::Acp
+        }
+        fn status(&self) -> Option<ConversationStatus> {
+            None
+        }
+        fn workspace(&self) -> &str {
+            &self.workspace
+        }
+        fn conversation_id(&self) -> &str {
+            &self.conversation_id
+        }
+        fn last_activity_at(&self) -> TimestampMs {
+            0
+        }
+        fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
+            self.event_tx.subscribe()
+        }
+        async fn send_message(&self, _data: SendMessageData) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn stop(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        fn confirm(
+            &self,
+            _msg_id: &str,
+            _call_id: &str,
+            _data: serde_json::Value,
+            _always_allow: bool,
+        ) -> Result<(), AppError> {
+            Ok(())
+        }
+        fn get_confirmations(&self) -> Vec<Confirmation> {
+            vec![]
+        }
+        fn check_approval(&self, _action: &str, _command_type: Option<&str>) -> bool {
+            false
+        }
+        fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
+            Ok(())
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+}
+
+fn success_factory() -> AgentFactory {
+    Arc::new(|opts: BuildTaskOptions| {
+        Ok(Arc::new(mock_agent::MockAgent::new(
+            opts.conversation_id,
+            opts.workspace,
+        )) as aionui_ai_agent::AgentManagerHandle)
+    })
+}
+
+fn setup_with_factory(factory: AgentFactory) -> (TeamSessionService, Arc<CountingTaskManager>) {
     let team_repo: Arc<dyn ITeamRepository> = Arc::new(FullMockTeamRepo::new());
     let conv_repo: Arc<dyn IConversationRepository> = Arc::new(MockConversationRepo::new());
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
@@ -301,7 +475,20 @@ fn setup() -> TeamSessionService {
         Arc::new(StubSkillResolver),
     );
     let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aionui-backend-test"));
-    TeamSessionService::new(team_repo, conv_service, broadcaster, backend_binary_path)
+    let task_manager = Arc::new(CountingTaskManager::new(factory));
+    let task_manager_dyn: Arc<dyn IWorkerTaskManager> = task_manager.clone();
+    let svc = TeamSessionService::new(
+        team_repo,
+        conv_service,
+        broadcaster,
+        task_manager_dyn,
+        backend_binary_path,
+    );
+    (svc, task_manager)
+}
+
+fn setup() -> TeamSessionService {
+    setup_with_factory(success_factory()).0
 }
 
 fn two_agent_input() -> Vec<TeamAgentInput> {
@@ -926,4 +1113,141 @@ async fn td_delete_team_stops_session() {
 
     let result = svc.send_message(&created.id, "Hello").await;
     assert!(result.is_err());
+}
+
+// ===========================================================================
+// Test: D9 ensure_session kill + rebuild closed loop
+// ===========================================================================
+
+#[tokio::test]
+async fn d9_ensure_session_kills_and_rebuilds_every_agent() {
+    let (svc, tm) = setup_with_factory(success_factory());
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "T".into(),
+                agents: two_agent_input(),
+            },
+        )
+        .await
+        .unwrap();
+
+    svc.ensure_session(&created.id).await.unwrap();
+
+    // Two agents → kill called 2x and get_or_build_task called 2x, each with
+    // the corresponding conversation_id. Order is agents-iteration order.
+    let calls = tm.snapshot();
+    assert_eq!(calls.kill.len(), 2, "expected 2 kill calls");
+    assert_eq!(calls.build.len(), 2, "expected 2 build calls");
+    for (i, agent) in created.agents.iter().enumerate() {
+        assert_eq!(calls.kill[i].0, agent.conversation_id);
+        assert_eq!(calls.kill[i].1, Some(AgentKillReason::TeamMcpRebuild));
+        assert_eq!(calls.build[i], agent.conversation_id);
+    }
+}
+
+#[tokio::test]
+async fn d9_ensure_session_persists_team_mcp_stdio_config() {
+    // Each agent's conversation.extra must carry a `team_mcp_stdio_config`
+    // object by the time the factory is called — that is what the rebuilt
+    // ACP process will read to reach the MCP server.
+    let (svc, _tm) = setup_with_factory(Arc::new(|opts: BuildTaskOptions| {
+        let extra_has_cfg = opts
+            .extra
+            .get("team_mcp_stdio_config")
+            .and_then(|v| v.as_object())
+            .is_some_and(|o| o.contains_key("port") && o.contains_key("slot_id"));
+        assert!(
+            extra_has_cfg,
+            "factory called without team_mcp_stdio_config in extra: {:?}",
+            opts.extra
+        );
+        Ok(Arc::new(mock_agent::MockAgent::new(
+            opts.conversation_id,
+            opts.workspace,
+        )) as aionui_ai_agent::AgentManagerHandle)
+    }));
+
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "T".into(),
+                agents: two_agent_input(),
+            },
+        )
+        .await
+        .unwrap();
+
+    svc.ensure_session(&created.id).await.unwrap();
+}
+
+#[tokio::test]
+async fn d9_ensure_session_is_idempotent() {
+    let (svc, tm) = setup_with_factory(success_factory());
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "T".into(),
+                agents: two_agent_input(),
+            },
+        )
+        .await
+        .unwrap();
+
+    svc.ensure_session(&created.id).await.unwrap();
+    svc.ensure_session(&created.id).await.unwrap();
+
+    // Second call short-circuits — no additional kill/build calls.
+    let calls = tm.snapshot();
+    assert_eq!(
+        calls.kill.len(),
+        2,
+        "second ensure_session must not re-kill"
+    );
+    assert_eq!(
+        calls.build.len(),
+        2,
+        "second ensure_session must not re-build"
+    );
+}
+
+#[tokio::test]
+async fn d9_ensure_session_rollbacks_when_build_fails() {
+    // Factory always fails → ensure_session must propagate error and not
+    // insert into sessions, so send_message afterwards still errors.
+    let failing_factory: AgentFactory = Arc::new(|_opts: BuildTaskOptions| {
+        Err(AppError::Internal("simulated build failure".into()))
+    });
+    let (svc, tm) = setup_with_factory(failing_factory);
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "T".into(),
+                agents: two_agent_input(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let result = svc.ensure_session(&created.id).await;
+    assert!(
+        result.is_err(),
+        "ensure_session should propagate build error"
+    );
+
+    // Kill ran for the first agent (before warmup failed), build ran once
+    // and errored. No session inserted, so send_message errors.
+    let calls = tm.snapshot();
+    assert_eq!(calls.kill.len(), 1);
+    assert_eq!(calls.build.len(), 1);
+
+    let send_result = svc.send_message(&created.id, "Hello").await;
+    assert!(
+        send_result.is_err(),
+        "session must not be registered after build failure"
+    );
 }


### PR DESCRIPTION
## Summary
- Implements **D9** from `docs/teams/phase1/modules.md` — `TeamSessionService::ensure_session` now closes the kill + rebuild loop so agent processes pick up the fresh `team_mcp_stdio_config` (mcp.md §4.3).
- Adds `AgentKillReason::TeamMcpRebuild` and a new `ConversationService::update_extra(conv_id, patch)` helper (full `update()` would spuriously kill the agent via its model-changed check).
- 4 new integration tests using a counting `IWorkerTaskManager` on top of the real `WorkerTaskManagerImpl`; 30 pre-existing tests still pass (34 total).

## Changes
- `aionui-team/src/service.rs`: `TeamSessionService` gains `task_manager: Arc<dyn IWorkerTaskManager>`; sessions map is now `Arc<DashMap<String, SessionEntry>>` holding both the session and the finish-subscriber join handles. `ensure_session` iterates agents with `update_extra → kill(TeamMcpRebuild) → warmup` and spawns one `Finish`/`Error` subscriber per agent that calls `session.on_agent_finish` (D7a method).
- `aionui-common/src/enums.rs`: new `AgentKillReason::TeamMcpRebuild` variant.
- `aionui-conversation/src/service.rs`: new `update_extra(conv_id, patch)` that merges JSON into `conversation.extra` without touching model / name / task lifecycle.
- `aionui-app/src/state_builders.rs`: pass `services.worker_task_manager` into `TeamSessionService::new`.

## Test plan
- [x] `cargo test -p aionui-team --test session_service_integration` (34/34 pass, including 4 new `d9_*` tests)
- [x] `cargo clippy -p aionui-team --tests -- -D warnings`
- [x] `rustfmt --check` on all modified files
- [x] `cargo build -p aionui-app` succeeds

## Refs
- `docs/teams/phase1/modules.md` §D9
- `docs/teams/phase1/interface-contracts.md` §9
- `docs/teams/mcp.md` §4.3 (Agent process restart mechanism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)