### PR TITLE
feat(team): remove_team cascades kill to every agent process (D11.5)

### DIFF
--- a/crates/aionui-common/src/enums.rs
+++ b/crates/aionui-common/src/enums.rs
@@ -395,6 +395,9 @@ pub enum AgentKillReason {
     /// `team_mcp_stdio_config`. The conversation is preserved; only the
     /// in-memory ACP CLI is recycled.
     TeamMcpRebuild,
+    /// Team is being deleted; every agent process under it must be torn
+    /// down before the team's conversations / rows are removed.
+    TeamDeleted,
 }
 
 /// Preview content type for document preview history.

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -170,6 +170,16 @@ impl TeamSessionService {
 
         self.stop_session(team_id);
 
+        // D11.5: tear down every agent worker before the team's conversations
+        // are deleted — otherwise the spawned ACP/CLI processes become orphans.
+        // Failures here (e.g. the task was never built, or already gone) must
+        // not block the delete path.
+        for agent in &team.agents {
+            let _ = self
+                .task_manager
+                .kill(&agent.conversation_id, Some(AgentKillReason::TeamDeleted));
+        }
+
         for agent in &team.agents {
             let _ = self
                 .conversation_service

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -1253,3 +1253,53 @@ async fn d9_ensure_session_rollbacks_when_build_fails() {
         "session must not be registered after build failure"
     );
 }
+
+// ===========================================================================
+// Test: D11.5 remove_team cascades kill to every agent process
+// ===========================================================================
+
+#[tokio::test]
+async fn d115_remove_team_kills_every_agent_process() {
+    let (svc, tm) = setup_with_factory(success_factory());
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "T".into(),
+                agents: two_agent_input(),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Bring two agents online — after ensure_session, active_count == 2.
+    svc.ensure_session(&created.id).await.unwrap();
+    assert_eq!(
+        tm.active_count(),
+        2,
+        "ensure_session must register 2 live agents"
+    );
+
+    let before_kill = tm.snapshot().kill.len();
+
+    svc.remove_team("user1", &created.id).await.unwrap();
+
+    // remove_team must have issued one kill per agent with reason TeamDeleted,
+    // and the task manager's active_count must drop back to 0.
+    let calls = tm.snapshot();
+    let new_kills = &calls.kill[before_kill..];
+    assert_eq!(
+        new_kills.len(),
+        created.agents.len(),
+        "remove_team must kill every agent once"
+    );
+    for (i, agent) in created.agents.iter().enumerate() {
+        assert_eq!(new_kills[i].0, agent.conversation_id);
+        assert_eq!(new_kills[i].1, Some(AgentKillReason::TeamDeleted));
+    }
+    assert_eq!(
+        tm.active_count(),
+        0,
+        "every agent worker must be torn down after remove_team"
+    );
+}


### PR DESCRIPTION
## 背景

删除 team 时 `remove_team` 只做了 `stop_session` + 删 conversation 行，**没有 kill agent 进程**。结果 agent 的 ACP/CLI 子进程在 team 删除后继续跑，task_manager 也不再认得它们——变成孤儿。

参考：
- [modules.md §D11.5](/Users/zhuqingyu/.superset/projects/aionui-backend/docs/teams/phase1/modules.md#d115--remove_team-级联-kill-agent-进程)（P0 补漏）
- [interface-contracts.md §12.5](/Users/zhuqingyu/.superset/projects/aionui-backend/docs/teams/phase1/interface-contracts.md#125-remove_team-级联-kill-agent-进程wave-2--模块-d115)
- backend-audit §3.5 #47 标 **P0**

## 改动

**`crates/aionui-common/src/enums.rs`** · 给 `AgentKillReason` 加 `TeamDeleted` variant，和 `IdleTimeout` / `TeamMcpRebuild` 区分开，方便日志/监控追因。

**`crates/aionui-team/src/service.rs`** · `remove_team` 在 `stop_session` 之后、delete conversations 之前遍历 `team.agents` 调 `task_manager.kill(conv_id, Some(AgentKillReason::TeamDeleted))`。
- kill 失败（已经不在了/从未 build 过）用 `let _ =` 吞掉——不能因为 worker 已经挂了就阻塞 team 删除路径

**测试** · `crates/aionui-team/tests/session_service_integration.rs` 加 1 条集成 `d115_remove_team_kills_every_agent_process`：
- 建 team（2 agent）→ `ensure_session` → 断言 `active_count == 2`
- `remove_team` → 断言 2 次 kill 都带 `TeamDeleted`、conversation_id 对上
- 断言 `active_count == 0`

## 测试

```
cargo test -p aionui-team --test session_service_integration
# 35 passed; 0 failed
cargo clippy -p aionui-common -p aionui-team --tests -- -D warnings
# clean
```

`mcp_server_integration.rs` 的 2 个 "tools 8→10" 失败是 feat/team-wave1 基线既有问题（D4 补了 2 个 tool 但 server 测试未同步更新），与本 PR 无关。

## LoC

3 文件 +63 行，预估 40 行，超 23 行主要是测试样板（ensure_session + 2 agent 搭建）。

## 依赖

- ✅ D7a (team session methods) · D7b (send_message wake) · D8 (scheduler) · D9 (ensure_session + TeamSessionService 持有 task_manager) · D10 已全部合并
- ⏳ W3-D12c (remove_team 归属校验) — 独立路径，各自进展