### PR TITLE
feat(team): Wave 1+2 — team MCP integration + wake engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,7 @@ dependencies = [
 name = "aionui-team"
 version = "0.1.0"
 dependencies = [
+ "agent-client-protocol",
  "aionui-ai-agent",
  "aionui-api-types",
  "aionui-auth",

--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicI64, Ordering};
@@ -8,16 +9,17 @@ use crate::acp_protocol::{AcpProtocol, PermissionDecision, PermissionRequest};
 
 use crate::acp_runtime_snapshot::AcpRuntimeSnapshot;
 use agent_client_protocol::schema::{
-    AgentCapabilities, AvailableCommand, CancelNotification, ContentBlock, LoadSessionRequest,
-    NewSessionRequest, PromptRequest, SessionConfigOption, SessionId, SessionModeState,
-    SessionModelState, SetSessionConfigOptionRequest, SetSessionModeRequest,
-    SetSessionModelRequest, UsageUpdate,
+    AgentCapabilities, AvailableCommand, CancelNotification, ContentBlock, EnvVariable,
+    LoadSessionRequest, McpServer, McpServerStdio, NewSessionRequest, PromptRequest,
+    SessionConfigOption, SessionId, SessionModeState, SessionModelState,
+    SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest, UsageUpdate,
 };
 
 use crate::cli_process::CliAgentProcess;
 use crate::stream_event::{AgentStreamEvent, permission_request_to_event_data};
 use crate::types::{AcpBuildExtra, SendMessageData, SlashCommandItem};
 
+use aionui_api_types::TeamMcpStdioConfig;
 use aionui_common::{
     AcpBackend, AgentKillReason, AgentType, AppError, CommandSpec, Confirmation,
     ConversationStatus, TimestampMs, now_ms,
@@ -81,6 +83,57 @@ fn confirm_option_id(data: &Value) -> Option<String> {
     }
 }
 
+/// Build a `NewSessionRequest` for `session/new`, injecting the team MCP
+/// stdio server when `config.team_mcp_stdio_config` is present.
+///
+/// When the config is absent the returned payload is identical to the
+/// legacy single-chat path (`mcp_servers` empty), so solo conversations
+/// are unaffected.
+///
+/// The stdio server follows the phase1 interface-contracts §3 shape:
+/// `command = backend_binary_path`, `args = ["mcp-bridge"]`, `env` =
+/// the three `TEAM_MCP_*` pairs defined on `TeamMcpStdioConfig`.
+fn build_new_session_request(
+    workspace: &str,
+    config: &AcpBuildExtra,
+    backend_binary_path: &std::path::Path,
+) -> NewSessionRequest {
+    let req = NewSessionRequest::new(workspace);
+    let Some(cfg) = config.team_mcp_stdio_config.as_ref() else {
+        return req;
+    };
+    req.mcp_servers(vec![team_mcp_server(cfg, backend_binary_path)])
+}
+
+/// Translate a `TeamMcpStdioConfig` into the ACP SDK wire type expected by
+/// `NewSessionRequest::mcp_servers`.
+///
+/// Field shapes must stay byte-for-byte identical to
+/// `aionui_team::mcp::bridge::TeamMcpStdioServerSpec::into_sdk` — the
+/// logic is inlined here rather than reused because `aionui-team` already
+/// depends on this crate, so importing the spec would cycle. Both sides
+/// derive `name` from `cfg.team_id` (phase1 interface-contracts §3).
+fn team_mcp_server(cfg: &TeamMcpStdioConfig, backend_binary_path: &std::path::Path) -> McpServer {
+    let env = vec![
+        EnvVariable::new(
+            TeamMcpStdioConfig::ENV_PORT.to_owned(),
+            cfg.port.to_string(),
+        ),
+        EnvVariable::new(TeamMcpStdioConfig::ENV_TOKEN.to_owned(), cfg.token.clone()),
+        EnvVariable::new(
+            TeamMcpStdioConfig::ENV_SLOT_ID.to_owned(),
+            cfg.slot_id.clone(),
+        ),
+    ];
+    let stdio = McpServerStdio::new(
+        format!("aionui-team-{}", cfg.team_id),
+        backend_binary_path.to_path_buf(),
+    )
+    .args(vec!["mcp-bridge".to_owned()])
+    .env(env);
+    McpServer::Stdio(stdio)
+}
+
 /// Internal state that changes at runtime.
 struct AcpState {
     /// Current conversation status.
@@ -137,6 +190,10 @@ pub struct AcpAgentManager {
     closing: std::sync::atomic::AtomicBool,
     /// Shared skill manager — used to discover skills for first-message injection.
     skill_manager: Arc<crate::skill_manager::AcpSkillManager>,
+    /// Absolute path to the backend binary, used as the `command` of the
+    /// stdio MCP bridge when a team session is attached to this agent.
+    /// Captured once at app startup (`std::env::current_exe()`).
+    backend_binary_path: Arc<PathBuf>,
 }
 
 impl AcpAgentManager {
@@ -297,6 +354,7 @@ impl AcpAgentManager {
         command_spec: CommandSpec,
         config: AcpBuildExtra,
         skill_manager: Arc<crate::skill_manager::AcpSkillManager>,
+        backend_binary_path: Arc<PathBuf>,
     ) -> Result<Self, AppError> {
         let backend = config
             .backend
@@ -354,6 +412,7 @@ impl AcpAgentManager {
             runtime_snapshot: RwLock::new(runtime_snapshot),
             closing: std::sync::atomic::AtomicBool::new(false),
             skill_manager,
+            backend_binary_path,
         };
 
         Ok(manager)
@@ -451,9 +510,14 @@ impl AcpAgentManager {
             crate::stream_event::StartEventData { session_id: None },
         ));
 
+        let req = build_new_session_request(
+            &self.workspace,
+            &self.config,
+            self.backend_binary_path.as_path(),
+        );
         let session_response = self
             .protocol
-            .new_session(NewSessionRequest::new(&self.workspace))
+            .new_session(req)
             .await
             .map_err(AppError::from)?;
 
@@ -916,5 +980,67 @@ mod tests {
             normalize_requested_mode(AcpBackend::Claude, "bypassPermissions"),
             "bypassPermissions"
         );
+    }
+
+    fn build_extra_without_team() -> AcpBuildExtra {
+        serde_json::from_value(json!({ "backend": "claude" })).unwrap()
+    }
+
+    fn build_extra_with_team() -> AcpBuildExtra {
+        serde_json::from_value(json!({
+            "backend": "claude",
+            "team_mcp_stdio_config": {
+                "team_id": "team-42",
+                "port": 54321,
+                "token": "tok-abc",
+                "slot_id": "slot-lead",
+            },
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn build_new_session_request_skips_mcp_servers_without_team_config() {
+        // Solo-chat path: no `team_mcp_stdio_config` → payload must stay
+        // byte-for-byte identical to the legacy `NewSessionRequest::new(cwd)`.
+        let req = build_new_session_request(
+            "/workspace",
+            &build_extra_without_team(),
+            std::path::Path::new("/usr/bin/aionui-backend"),
+        );
+        assert!(
+            req.mcp_servers.is_empty(),
+            "solo chat must not inject any MCP servers, got {:?}",
+            req.mcp_servers
+        );
+    }
+
+    #[test]
+    fn build_new_session_request_injects_team_stdio_server() {
+        let req = build_new_session_request(
+            "/workspace",
+            &build_extra_with_team(),
+            std::path::Path::new("/usr/bin/aionui-backend"),
+        );
+        assert_eq!(req.mcp_servers.len(), 1, "exactly one team MCP server");
+
+        let server = req.mcp_servers.into_iter().next().unwrap();
+        let stdio = match server {
+            McpServer::Stdio(s) => s,
+            other => panic!("expected Stdio variant, got {other:?}"),
+        };
+
+        assert_eq!(stdio.name, "aionui-team-team-42");
+        assert_eq!(stdio.command, PathBuf::from("/usr/bin/aionui-backend"));
+        assert_eq!(stdio.args, vec!["mcp-bridge".to_owned()]);
+
+        let env: std::collections::HashMap<_, _> = stdio
+            .env
+            .iter()
+            .map(|v| (v.name.as_str(), v.value.as_str()))
+            .collect();
+        assert_eq!(env.get(TeamMcpStdioConfig::ENV_PORT), Some(&"54321"));
+        assert_eq!(env.get(TeamMcpStdioConfig::ENV_TOKEN), Some(&"tok-abc"));
+        assert_eq!(env.get(TeamMcpStdioConfig::ENV_SLOT_ID), Some(&"slot-lead"));
     }
 }

--- a/crates/aionui-ai-agent/src/factory.rs
+++ b/crates/aionui-ai-agent/src/factory.rs
@@ -27,6 +27,10 @@ pub struct AgentFactoryDeps {
     pub encryption_key: [u8; 32],
     pub agent_registry: Arc<AgentRegistry>,
     pub data_dir: PathBuf,
+    /// Absolute path to the backend binary, reused as the `command` of the
+    /// stdio MCP bridge injected into ACP `session/new` for team sessions.
+    /// Captured once at app startup (`std::env::current_exe()`).
+    pub backend_binary_path: Arc<PathBuf>,
 }
 
 /// Build a production agent factory that dispatches to concrete agent types.
@@ -145,6 +149,7 @@ async fn build_agent(
                 },
                 config,
                 deps.skill_manager.clone(),
+                deps.backend_binary_path.clone(),
             )
             .await?;
             let arc = Arc::new(agent);

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -248,6 +248,7 @@ mod tests {
         let with_cfg = r#"{
             "backend":"claude",
             "team_mcp_stdio_config":{
+                "team_id":"team-42",
                 "port":54321,
                 "token":"tok-abc",
                 "slot_id":"slot-lead"
@@ -255,6 +256,7 @@ mod tests {
         }"#;
         let parsed: AcpBuildExtra = serde_json::from_str(with_cfg).unwrap();
         let cfg = parsed.team_mcp_stdio_config.expect("config present");
+        assert_eq!(cfg.team_id, "team-42");
         assert_eq!(cfg.port, 54321);
         assert_eq!(cfg.token, "tok-abc");
         assert_eq!(cfg.slot_id, "slot-lead");

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use aionui_api_types::TeamMcpStdioConfig;
 use aionui_common::{AcpBackend, AgentType, ProviderWithModel};
 
 /// Data payload for sending a user message to an Agent.
@@ -71,6 +72,12 @@ pub struct AcpBuildExtra {
     /// Associated cron job ID.
     #[serde(default)]
     pub cron_job_id: Option<String>,
+    /// Team session MCP stdio config. When present, the factory injects it as
+    /// a stdio MCP server on `session/new`. Written by
+    /// `TeamSessionService::ensure_session` into `conversation.extra`; solo
+    /// conversations leave this unset.
+    #[serde(default)]
+    pub team_mcp_stdio_config: Option<TeamMcpStdioConfig>,
 }
 
 /// OpenClaw gateway configuration.
@@ -224,6 +231,33 @@ mod tests {
         let with_field = r#"{"backend":"claude","skills":["cron","pdf"]}"#;
         let parsed: AcpBuildExtra = serde_json::from_str(with_field).unwrap();
         assert_eq!(parsed.skills, vec!["cron".to_owned(), "pdf".to_owned()]);
+    }
+
+    #[test]
+    fn acp_build_extra_missing_team_mcp_stdio_config_is_none() {
+        // Legacy extra (pre-team-wave1) must deserialize cleanly with the new
+        // optional `team_mcp_stdio_config` absent — this keeps solo chat
+        // conversations working without any migration.
+        let legacy = r#"{"backend":"claude","skills":["cron"]}"#;
+        let parsed: AcpBuildExtra = serde_json::from_str(legacy).unwrap();
+        assert!(parsed.team_mcp_stdio_config.is_none());
+    }
+
+    #[test]
+    fn acp_build_extra_parses_team_mcp_stdio_config() {
+        let with_cfg = r#"{
+            "backend":"claude",
+            "team_mcp_stdio_config":{
+                "port":54321,
+                "token":"tok-abc",
+                "slot_id":"slot-lead"
+            }
+        }"#;
+        let parsed: AcpBuildExtra = serde_json::from_str(with_cfg).unwrap();
+        let cfg = parsed.team_mcp_stdio_config.expect("config present");
+        assert_eq!(cfg.port, 54321);
+        assert_eq!(cfg.token, "tok-abc");
+        assert_eq!(cfg.slot_id, "slot-lead");
     }
 
     #[test]

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -65,6 +65,7 @@ async fn make_mock_agent(
         preset_assistant_id: None,
         session_mode: None,
         cron_job_id: None,
+        team_mcp_stdio_config: None,
     };
 
     let tmp_skills = tempfile::TempDir::new().unwrap();

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -89,6 +89,7 @@ async fn make_mock_agent(
         },
         config,
         skill_manager,
+        Arc::new(std::path::PathBuf::from("/tmp/aionui-backend")),
     )
     .await
     .expect("Failed to spawn mock ACP agent");

--- a/crates/aionui-ai-agent/tests/factory_provider_integration.rs
+++ b/crates/aionui-ai-agent/tests/factory_provider_integration.rs
@@ -65,6 +65,7 @@ fn make_factory(
         encryption_key: test_encryption_key(),
         agent_registry: Arc::new(AgentRegistry::new()),
         data_dir: PathBuf::from("/tmp/aionrs-test"),
+        backend_binary_path: Arc::new(PathBuf::from("/tmp/aionrs-test/aionui-backend")),
     })
 }
 

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -21,6 +21,7 @@ mod shell;
 mod skill;
 mod system;
 mod team;
+mod team_mcp;
 mod websocket;
 
 pub use acp::{
@@ -136,4 +137,5 @@ pub use team::{
     TeamAgentRenamedPayload, TeamAgentResponse, TeamAgentSpawnedPayload, TeamAgentStatusPayload,
     TeamListResponse, TeamResponse,
 };
+pub use team_mcp::TeamMcpStdioConfig;
 pub use websocket::WebSocketMessage;

--- a/crates/aionui-api-types/src/team.rs
+++ b/crates/aionui-api-types/src/team.rs
@@ -66,18 +66,24 @@ pub struct RenameAgentRequest {
 /// Request body for `POST /api/teams/:id/messages`.
 ///
 /// Sends a user message to the team lead's mailbox, triggering a
-/// wake cycle.
+/// wake cycle. `files` is optional and — when present — forwarded
+/// to the underlying agent together with the wake payload.
 #[derive(Debug, Deserialize)]
 pub struct SendTeamMessageRequest {
     pub content: String,
+    #[serde(default)]
+    pub files: Option<Vec<String>>,
 }
 
 /// Request body for `POST /api/teams/:id/agents/:slotId/messages`.
 ///
 /// Sends a user message directly to a specific agent's mailbox.
+/// `files` semantics match [`SendTeamMessageRequest`].
 #[derive(Debug, Deserialize)]
 pub struct SendAgentMessageRequest {
     pub content: String,
+    #[serde(default)]
+    pub files: Option<Vec<String>>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aionui-api-types/src/team_mcp.rs
+++ b/crates/aionui-api-types/src/team_mcp.rs
@@ -6,9 +6,15 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Stdio connection triple for the team session MCP server.
+/// Stdio connection config for the team session MCP server.
+///
+/// `team_id` is persisted alongside the connection triple so every
+/// consumer (D3 spec builder, D10 ACP injector, D7 bridge subcommand)
+/// can derive the wire-level MCP server name `aionui-team-<team_id>`
+/// without threading a second parameter through unrelated call sites.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TeamMcpStdioConfig {
+    pub team_id: String,
     pub port: u16,
     pub token: String,
     pub slot_id: String,
@@ -30,6 +36,7 @@ mod tests {
     #[test]
     fn json_roundtrip_preserves_all_fields() {
         let cfg = TeamMcpStdioConfig {
+            team_id: "team-42".into(),
             port: 54321,
             token: "tok-abc".into(),
             slot_id: "slot-1".into(),
@@ -44,8 +51,9 @@ mod tests {
         // Forward-compat: extra fields in persisted `conversation.extra.team_mcp_stdio_config`
         // JSON (e.g. added by a later backend version) must still round-trip through
         // older binaries without error.
-        let json = r#"{"port":1,"token":"t","slot_id":"s","future_field":42}"#;
+        let json = r#"{"team_id":"t-1","port":1,"token":"t","slot_id":"s","future_field":42}"#;
         let parsed: TeamMcpStdioConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.team_id, "t-1");
         assert_eq!(parsed.port, 1);
         assert_eq!(parsed.token, "t");
         assert_eq!(parsed.slot_id, "s");

--- a/crates/aionui-api-types/src/team_mcp.rs
+++ b/crates/aionui-api-types/src/team_mcp.rs
@@ -1,0 +1,53 @@
+//! Team session MCP stdio connection types.
+//!
+//! These are promoted from `aionui-team::mcp::bridge` so that downstream
+//! crates (`aionui-ai-agent` deserializing `AcpBuildExtra`, etc.) can reference
+//! the same shape without depending on `aionui-team`.
+
+use serde::{Deserialize, Serialize};
+
+/// Stdio connection triple for the team session MCP server.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TeamMcpStdioConfig {
+    pub port: u16,
+    pub token: String,
+    pub slot_id: String,
+}
+
+impl TeamMcpStdioConfig {
+    /// env key the stdio bridge reads to learn the backend TCP port.
+    pub const ENV_PORT: &'static str = "TEAM_MCP_PORT";
+    /// env key the stdio bridge reads to learn the auth token.
+    pub const ENV_TOKEN: &'static str = "TEAM_MCP_TOKEN";
+    /// env key the stdio bridge reads to learn which agent slot it represents.
+    pub const ENV_SLOT_ID: &'static str = "TEAM_AGENT_SLOT_ID";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_preserves_all_fields() {
+        let cfg = TeamMcpStdioConfig {
+            port: 54321,
+            token: "tok-abc".into(),
+            slot_id: "slot-1".into(),
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let parsed: TeamMcpStdioConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(cfg, parsed);
+    }
+
+    #[test]
+    fn deserialization_tolerates_unknown_fields() {
+        // Forward-compat: extra fields in persisted `conversation.extra.team_mcp_stdio_config`
+        // JSON (e.g. added by a later backend version) must still round-trip through
+        // older binaries without error.
+        let json = r#"{"port":1,"token":"t","slot_id":"s","future_field":42}"#;
+        let parsed: TeamMcpStdioConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.port, 1);
+        assert_eq!(parsed.token, "t");
+        assert_eq!(parsed.slot_id, "s");
+    }
+}

--- a/crates/aionui-app/src/bridge.rs
+++ b/crates/aionui-app/src/bridge.rs
@@ -1,0 +1,277 @@
+//! `aionui-backend mcp-bridge` subcommand: stdio ↔ TCP bridge for the team MCP server.
+//!
+//! Spawned by the ACP agent CLI as an MCP server with command `aionui-backend mcp-bridge`.
+//! stdio side speaks newline-delimited JSON-RPC 2.0 (the MCP stdio transport);
+//! TCP side speaks 4-byte big-endian length-prefixed JSON frames against
+//! `127.0.0.1:<TEAM_MCP_PORT>` (reusing `aionui_team::mcp::protocol`).
+//!
+//! On the first `initialize` request from the CLI, the bridge injects
+//! `auth_token` and `slot_id` (read from env) into `params` before forwarding
+//! to the TCP server; subsequent messages are transparently proxied in both
+//! directions. Any unrecoverable error exits non-zero so the ACP CLI marks
+//! the MCP server as broken (see docs/teams/mcp.md §4.4 / §4.6).
+
+use std::io::{self, IsTerminal};
+use std::process::ExitCode;
+
+use aionui_api_types::TeamMcpStdioConfig;
+use aionui_team::mcp::protocol::{read_frame, write_frame};
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+
+const CONNECT_ADDR_HOST: &str = "127.0.0.1";
+
+/// Entry point for `aionui-backend mcp-bridge`. Returns an [`ExitCode`] so the
+/// binary surfaces non-zero on any failure (ACP CLI uses that to mark the MCP
+/// server as broken).
+pub async fn run_mcp_bridge() -> ExitCode {
+    match run().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            // stderr, not tracing: the parent agent CLI captures stderr and
+            // shows it to the user when the bridge dies on startup.
+            eprintln!("mcp-bridge: {err}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+async fn run() -> Result<(), String> {
+    let env = BridgeEnv::from_env()?;
+
+    let tcp = TcpStream::connect((CONNECT_ADDR_HOST, env.port))
+        .await
+        .map_err(|e| format!("failed to connect 127.0.0.1:{}: {e}", env.port))?;
+    tcp.set_nodelay(true).ok();
+    let (tcp_reader, tcp_writer) = tcp.into_split();
+
+    if std::io::stdin().is_terminal() {
+        return Err(
+            "stdin is a TTY; mcp-bridge must be spawned by an MCP-capable agent CLI".into(),
+        );
+    }
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+
+    let env_for_stdin = env.clone();
+    let stdin_task =
+        tokio::spawn(async move { forward_stdin_to_tcp(stdin, tcp_writer, env_for_stdin).await });
+    let tcp_task = tokio::spawn(async move { forward_tcp_to_stdout(tcp_reader, stdout).await });
+
+    // First task to return decides the exit path; we treat clean EOF from
+    // either side as "other side closed, we're done".
+    tokio::select! {
+        res = stdin_task => {
+            res.map_err(|e| format!("stdin task panicked: {e}"))??;
+        }
+        res = tcp_task => {
+            res.map_err(|e| format!("tcp task panicked: {e}"))??;
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Env
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct BridgeEnv {
+    port: u16,
+    token: String,
+    slot_id: String,
+}
+
+impl BridgeEnv {
+    fn from_env() -> Result<Self, String> {
+        let port_raw = std::env::var(TeamMcpStdioConfig::ENV_PORT)
+            .map_err(|_| format!("missing env var {}", TeamMcpStdioConfig::ENV_PORT))?;
+        let port: u16 = port_raw.parse().map_err(|e| {
+            format!(
+                "invalid {} value {port_raw:?}: {e}",
+                TeamMcpStdioConfig::ENV_PORT
+            )
+        })?;
+        let token = std::env::var(TeamMcpStdioConfig::ENV_TOKEN)
+            .map_err(|_| format!("missing env var {}", TeamMcpStdioConfig::ENV_TOKEN))?;
+        let slot_id = std::env::var(TeamMcpStdioConfig::ENV_SLOT_ID)
+            .map_err(|_| format!("missing env var {}", TeamMcpStdioConfig::ENV_SLOT_ID))?;
+        Ok(Self {
+            port,
+            token,
+            slot_id,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// stdin → TCP: read newline-delimited JSON, inject auth on `initialize`, frame to TCP
+// ---------------------------------------------------------------------------
+
+async fn forward_stdin_to_tcp<R, W>(
+    stdin: R,
+    mut tcp_writer: W,
+    env: BridgeEnv,
+) -> Result<(), String>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    let mut lines = BufReader::new(stdin).lines();
+    while let Some(line) = lines
+        .next_line()
+        .await
+        .map_err(|e| format!("stdin read error: {e}"))?
+    {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let mut value: Value = serde_json::from_str(&line)
+            .map_err(|e| format!("stdin payload is not valid JSON: {e}"))?;
+
+        if value.get("method").and_then(Value::as_str) == Some("initialize") {
+            inject_auth(&mut value, &env);
+        }
+
+        let bytes =
+            serde_json::to_vec(&value).map_err(|e| format!("serialize outgoing frame: {e}"))?;
+        write_frame(&mut tcp_writer, &bytes)
+            .await
+            .map_err(|e| format!("tcp write error: {e}"))?;
+    }
+    Ok(())
+}
+
+fn inject_auth(value: &mut Value, env: &BridgeEnv) {
+    let params = value.as_object_mut().and_then(|obj| {
+        obj.entry("params")
+            .or_insert(Value::Object(Default::default()))
+            .as_object_mut()
+    });
+    if let Some(params) = params {
+        params.insert("auth_token".into(), Value::String(env.token.clone()));
+        params.insert("slot_id".into(), Value::String(env.slot_id.clone()));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TCP → stdout: read length-prefixed frames, write as newline-delimited JSON
+// ---------------------------------------------------------------------------
+
+async fn forward_tcp_to_stdout<R, W>(mut tcp_reader: R, mut stdout: W) -> Result<(), String>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    loop {
+        let frame = match read_frame(&mut tcp_reader).await {
+            Ok(f) => f,
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(()),
+            Err(e) => return Err(format!("tcp read error: {e}")),
+        };
+        stdout
+            .write_all(&frame)
+            .await
+            .map_err(|e| format!("stdout write error: {e}"))?;
+        stdout
+            .write_all(b"\n")
+            .await
+            .map_err(|e| format!("stdout write error: {e}"))?;
+        stdout
+            .flush()
+            .await
+            .map_err(|e| format!("stdout flush error: {e}"))?;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests (integration tests live in tests/mcp_bridge.rs)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn env() -> BridgeEnv {
+        BridgeEnv {
+            port: 1,
+            token: "tok".into(),
+            slot_id: "slot-a".into(),
+        }
+    }
+
+    #[test]
+    fn inject_auth_adds_fields_when_params_missing() {
+        let mut v = json!({"jsonrpc":"2.0","id":1,"method":"initialize"});
+        inject_auth(&mut v, &env());
+        assert_eq!(v["params"]["auth_token"], "tok");
+        assert_eq!(v["params"]["slot_id"], "slot-a");
+    }
+
+    #[test]
+    fn inject_auth_preserves_existing_params() {
+        let mut v = json!({
+            "jsonrpc":"2.0","id":1,"method":"initialize",
+            "params": {"protocolVersion":"2024-11-05","capabilities":{}}
+        });
+        inject_auth(&mut v, &env());
+        assert_eq!(v["params"]["protocolVersion"], "2024-11-05");
+        assert_eq!(v["params"]["auth_token"], "tok");
+        assert_eq!(v["params"]["slot_id"], "slot-a");
+    }
+
+    #[test]
+    fn inject_auth_overrides_client_supplied_credentials() {
+        // The CLI cannot be trusted to know the bridge's token / slot id,
+        // so whatever it sent gets replaced.
+        let mut v = json!({
+            "jsonrpc":"2.0","id":1,"method":"initialize",
+            "params":{"auth_token":"stale","slot_id":"wrong"}
+        });
+        inject_auth(&mut v, &env());
+        assert_eq!(v["params"]["auth_token"], "tok");
+        assert_eq!(v["params"]["slot_id"], "slot-a");
+    }
+
+    #[tokio::test]
+    async fn forward_stdin_injects_only_on_initialize() {
+        let input = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#,
+            "\n",
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#,
+            "\n",
+        );
+        let mut out = Vec::<u8>::new();
+        forward_stdin_to_tcp(input.as_bytes(), &mut out, env())
+            .await
+            .unwrap();
+
+        // Parse two frames back out.
+        let mut cursor = std::io::Cursor::new(out);
+        let f1 = read_frame(&mut cursor).await.unwrap();
+        let f2 = read_frame(&mut cursor).await.unwrap();
+        let v1: Value = serde_json::from_slice(&f1).unwrap();
+        let v2: Value = serde_json::from_slice(&f2).unwrap();
+        assert_eq!(v1["params"]["auth_token"], "tok");
+        assert_eq!(v1["params"]["slot_id"], "slot-a");
+        assert!(v2.get("params").is_none(), "tools/list params untouched");
+    }
+
+    #[tokio::test]
+    async fn forward_tcp_writes_ndjson() {
+        let payload = br#"{"jsonrpc":"2.0","id":1,"result":{}}"#;
+        let mut framed = Vec::new();
+        write_frame(&mut framed, payload).await.unwrap();
+
+        let mut out = Vec::<u8>::new();
+        forward_tcp_to_stdout(&framed[..], &mut out).await.unwrap();
+
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.ends_with('\n'));
+        let line = text.trim_end();
+        let parsed: Value = serde_json::from_str(line).unwrap();
+        assert_eq!(parsed["id"], 1);
+    }
+}

--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -171,6 +171,13 @@ impl AppServices {
             std::path::Path::new(&data_dir),
         ));
 
+        // Absolute path to this process's binary. Reused as the `command` for
+        // the stdio MCP bridge spawned by ACP CLIs when a team session is
+        // attached to a conversation (phase1 mcp.md §4.6 single-binary model).
+        let backend_binary_path = Arc::new(
+            std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("aionui-backend")),
+        );
+
         let factory = build_agent_factory(AgentFactoryDeps {
             skill_manager: AcpSkillManager::new(skill_paths.clone()),
             remote_agent_repo,
@@ -178,6 +185,7 @@ impl AppServices {
             encryption_key,
             agent_registry: agent_registry.clone(),
             data_dir: std::path::PathBuf::from(&data_dir),
+            backend_binary_path: backend_binary_path.clone(),
         });
         let worker_task_manager: Arc<dyn IWorkerTaskManager> =
             Arc::new(WorkerTaskManagerImpl::new(factory));

--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -1,4 +1,5 @@
 //! Application entry point: assembles all crates into an Axum server with DI and middleware.
+pub mod bridge;
 mod state_builders;
 
 use std::sync::Arc;

--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::process::ExitCode;
 use std::time::Instant;
 
 use anyhow::Result;
@@ -7,7 +8,7 @@ use tokio::net::TcpListener;
 use tracing::info;
 use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
-use aionui_app::{AppConfig, AppServices, create_router};
+use aionui_app::{AppConfig, AppServices, bridge, create_router};
 
 #[derive(Parser)]
 #[command(name = "aionui-backend", about = "AionUi Backend Server")]
@@ -78,7 +79,16 @@ fn init_tracing(
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<ExitCode> {
+    // mcp-bridge subcommand: lives entirely outside the main HTTP server and
+    // must not touch the database, logging setup, or `AppServices`. Spawned by
+    // ACP agent CLIs as a short-lived stdio ↔ TCP bridge process.
+    let mut argv = std::env::args();
+    let _prog = argv.next();
+    if argv.next().as_deref() == Some("mcp-bridge") {
+        return Ok(bridge::run_mcp_bridge().await);
+    }
+
     let cli = Cli::parse();
 
     let log_dir = cli
@@ -170,7 +180,7 @@ async fn main() -> Result<()> {
     services.database.close().await;
     info!("Server shut down gracefully");
 
-    Ok(())
+    Ok(ExitCode::SUCCESS)
 }
 
 async fn shutdown_signal() {

--- a/crates/aionui-app/src/state_builders.rs
+++ b/crates/aionui-app/src/state_builders.rs
@@ -98,6 +98,13 @@ pub async fn build_module_states(
 
     let (channel_state, channel_components) = build_channel_state(services).await;
 
+    let backend_binary_path = Arc::new(
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.canonicalize().ok())
+            .unwrap_or_else(|| std::path::PathBuf::from("aionui-backend")),
+    );
+
     let states = ModuleStates {
         system: build_system_state(services),
         conversation: build_conversation_state(services, Some(cron.cron_service.clone())),
@@ -111,7 +118,11 @@ pub async fn build_module_states(
         hub: hub_state,
         skill: skill_state,
         channel: channel_state,
-        team: build_team_state(services, Some(cron.cron_service.clone())),
+        team: build_team_state(
+            services,
+            Some(cron.cron_service.clone()),
+            backend_binary_path.clone(),
+        ),
         cron,
         office: build_office_state(services),
         shell: build_shell_state(services),
@@ -385,9 +396,14 @@ pub async fn build_channel_state(
 }
 
 /// Build the default `TeamRouterState` from application services.
+///
+/// `backend_binary_path` is resolved once in `build_module_states` via
+/// `std::env::current_exe()` and cloned into each builder that needs it,
+/// per `docs/teams/phase1/interface-contracts.md` §10.
 pub fn build_team_state(
     services: &AppServices,
     cron_service: Option<Arc<aionui_cron::service::CronService>>,
+    backend_binary_path: Arc<std::path::PathBuf>,
 ) -> TeamRouterState {
     let pool = services.database.pool().clone();
     let team_repo: Arc<dyn aionui_db::ITeamRepository> =
@@ -408,12 +424,6 @@ pub fn build_team_state(
     if let Some(cron_service) = cron_service {
         conv_service.set_cron_service(Some(cron_service));
     }
-    let backend_binary_path = Arc::new(
-        std::env::current_exe()
-            .ok()
-            .and_then(|p| p.canonicalize().ok())
-            .unwrap_or_else(|| std::path::PathBuf::from("aionui-backend")),
-    );
     let service = Arc::new(TeamSessionService::new(
         team_repo,
         conv_service,

--- a/crates/aionui-app/src/state_builders.rs
+++ b/crates/aionui-app/src/state_builders.rs
@@ -408,10 +408,17 @@ pub fn build_team_state(
     if let Some(cron_service) = cron_service {
         conv_service.set_cron_service(Some(cron_service));
     }
+    let backend_binary_path = Arc::new(
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.canonicalize().ok())
+            .unwrap_or_else(|| std::path::PathBuf::from("aionui-backend")),
+    );
     let service = Arc::new(TeamSessionService::new(
         team_repo,
         conv_service,
         services.event_bus.clone(),
+        backend_binary_path,
     ));
     TeamRouterState { service }
 }

--- a/crates/aionui-app/src/state_builders.rs
+++ b/crates/aionui-app/src/state_builders.rs
@@ -420,6 +420,7 @@ pub fn build_team_state(
         services.event_bus.clone(),
         services.worker_task_manager.clone(),
         backend_binary_path,
+        services.worker_task_manager.clone(),
     ));
     TeamRouterState { service }
 }

--- a/crates/aionui-app/src/state_builders.rs
+++ b/crates/aionui-app/src/state_builders.rs
@@ -430,7 +430,6 @@ pub fn build_team_state(
         services.event_bus.clone(),
         services.worker_task_manager.clone(),
         backend_binary_path,
-        services.worker_task_manager.clone(),
     ));
     TeamRouterState { service }
 }

--- a/crates/aionui-app/src/state_builders.rs
+++ b/crates/aionui-app/src/state_builders.rs
@@ -418,6 +418,7 @@ pub fn build_team_state(
         team_repo,
         conv_service,
         services.event_bus.clone(),
+        services.worker_task_manager.clone(),
         backend_binary_path,
     ));
     TeamRouterState { service }

--- a/crates/aionui-app/tests/mcp_bridge_e2e.rs
+++ b/crates/aionui-app/tests/mcp_bridge_e2e.rs
@@ -1,0 +1,155 @@
+//! D6 integration tests for the `aionui-backend mcp-bridge` subcommand.
+//!
+//! Spawn the production binary with `mcp-bridge` argv; drive its stdin/stdout
+//! as the ACP agent CLI would, and verify it transparently bridges to a
+//! length-prefixed JSON-RPC TCP peer.
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use aionui_team::mcp::protocol::{read_frame, write_frame};
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+const BRIDGE_BIN: &str = env!("CARGO_BIN_EXE_aionui-backend");
+
+/// 1) spawn bridge → mock TCP server accepts → stdin "tools/list" round-trip.
+///    Also verifies the bridge injects `auth_token` + `slot_id` into the
+///    very first `initialize` request (per interface-contracts §8).
+#[tokio::test]
+async fn bridge_forwards_initialize_and_tools_list() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    // Mock TCP server: accept one connection, answer initialize + tools/list.
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let (mut rd, mut wr) = tokio::io::split(stream);
+
+        // --- initialize ---
+        let f1 = read_frame(&mut rd).await.unwrap();
+        let req1: Value = serde_json::from_slice(&f1).unwrap();
+        assert_eq!(req1["method"], "initialize");
+        assert_eq!(
+            req1["params"]["auth_token"], "secret-tok",
+            "bridge must inject env TEAM_MCP_TOKEN into initialize.params"
+        );
+        assert_eq!(
+            req1["params"]["slot_id"], "slot-42",
+            "bridge must inject env TEAM_AGENT_SLOT_ID into initialize.params"
+        );
+        let resp1 = json!({
+            "jsonrpc":"2.0",
+            "id": req1["id"],
+            "result":{"protocolVersion":"2024-11-05","serverInfo":{"name":"mock","version":"0"}}
+        });
+        write_frame(&mut wr, &serde_json::to_vec(&resp1).unwrap())
+            .await
+            .unwrap();
+
+        // --- tools/list ---
+        let f2 = read_frame(&mut rd).await.unwrap();
+        let req2: Value = serde_json::from_slice(&f2).unwrap();
+        assert_eq!(req2["method"], "tools/list");
+        let resp2 = json!({
+            "jsonrpc":"2.0",
+            "id": req2["id"],
+            "result":{"tools":[{"name":"team_members","description":"fake"}]}
+        });
+        write_frame(&mut wr, &serde_json::to_vec(&resp2).unwrap())
+            .await
+            .unwrap();
+    });
+
+    let mut child = Command::new(BRIDGE_BIN)
+        .arg("mcp-bridge")
+        .env("TEAM_MCP_PORT", port.to_string())
+        .env("TEAM_MCP_TOKEN", "secret-tok")
+        .env("TEAM_AGENT_SLOT_ID", "slot-42")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn bridge");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let mut stdout_lines = BufReader::new(stdout).lines();
+
+    stdin
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\
+               \"params\":{\"protocolVersion\":\"2024-11-05\"}}\n",
+        )
+        .await
+        .unwrap();
+    stdin
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}\n")
+        .await
+        .unwrap();
+
+    let line1 = timeout(Duration::from_secs(5), stdout_lines.next_line())
+        .await
+        .expect("initialize response timeout")
+        .unwrap()
+        .expect("eof before initialize response");
+    let v1: Value = serde_json::from_str(&line1).unwrap();
+    assert_eq!(v1["id"], 1);
+    assert_eq!(v1["result"]["protocolVersion"], "2024-11-05");
+
+    let line2 = timeout(Duration::from_secs(5), stdout_lines.next_line())
+        .await
+        .expect("tools/list response timeout")
+        .unwrap()
+        .expect("eof before tools/list response");
+    let v2: Value = serde_json::from_str(&line2).unwrap();
+    assert_eq!(v2["id"], 2);
+    assert_eq!(v2["result"]["tools"][0]["name"], "team_members");
+
+    // Closing stdin triggers orderly shutdown.
+    drop(stdin);
+    let _ = timeout(Duration::from_secs(5), child.wait()).await;
+    let _ = child.kill().await;
+    server.await.unwrap();
+}
+
+/// 2) No TCP server listening → bridge must exit non-zero within 1s.
+#[tokio::test]
+async fn bridge_exits_nonzero_when_tcp_unreachable() {
+    // Pick port 1 on loopback: it is privileged for *bind* (so nothing on a
+    // normal dev machine is listening there), but `connect` needs no
+    // privilege and just gets ECONNREFUSED, which is exactly the failure
+    // mode we want to exercise. Avoids the macOS "drop(listener) → port
+    // may still accept" race seen with port-0 bind-then-drop.
+    let port: u16 = 1;
+
+    let mut child = Command::new(BRIDGE_BIN)
+        .arg("mcp-bridge")
+        .env("TEAM_MCP_PORT", port.to_string())
+        .env("TEAM_MCP_TOKEN", "tok")
+        .env("TEAM_AGENT_SLOT_ID", "slot")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn bridge");
+
+    // The spec says "bridge must exit within 1s of TCP connect failure".
+    // We give 3s of budget because debug-build binary startup (tokio
+    // runtime + large deps linking) adds ~1-2s on macOS dev machines; the
+    // actual connect-fail → exit delay is tens of milliseconds. What we
+    // really assert is "no hung main loop on connect failure", not
+    // wall-clock < 1s from spawn.
+    let status = timeout(Duration::from_secs(3), child.wait())
+        .await
+        .expect("bridge did not exit within 3s after TCP connect failure")
+        .expect("wait failed");
+
+    assert!(
+        !status.success(),
+        "bridge must exit non-zero when TCP connect fails, got {status:?}"
+    );
+}

--- a/crates/aionui-app/tests/team_phase1_smoke.rs
+++ b/crates/aionui-app/tests/team_phase1_smoke.rs
@@ -1,0 +1,31 @@
+//! D11 — Wave-2 app assembly smoke test.
+//!
+//! Minimum guarantee: after D7/D8/D9/D10 merged, `AppServices` composes into
+//! a router that actually exposes the `/api/teams` endpoints. Anything beyond
+//! compile-check is validated by `team_e2e.rs`; this file is kept intentionally
+//! tiny so assembly regressions surface first.
+
+mod common;
+
+use axum::http::StatusCode;
+use tower::ServiceExt;
+
+use common::{build_app, get_with_token, setup_and_login};
+
+/// Router boots and `/api/teams` is wired through `build_team_state` into
+/// `aionui_team::team_routes`. If the team module failed to assemble, the
+/// route would 404 (or compile would have failed earlier).
+#[tokio::test]
+async fn phase1_router_assembles_with_team_module() {
+    let (mut app, services) = build_app().await;
+    let (token, _csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let req = get_with_token("/api/teams", &token);
+    let resp = app.clone().oneshot(req).await.unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "GET /api/teams must be wired through build_team_state"
+    );
+}

--- a/crates/aionui-common/src/enums.rs
+++ b/crates/aionui-common/src/enums.rs
@@ -391,6 +391,10 @@ pub enum RemoteAgentStatus {
 #[serde(rename_all = "snake_case")]
 pub enum AgentKillReason {
     IdleTimeout,
+    /// Team session is rebuilding the agent process to inject a fresh
+    /// `team_mcp_stdio_config`. The conversation is preserved; only the
+    /// in-memory ACP CLI is recycled.
+    TeamMcpRebuild,
 }
 
 /// Preview content type for document preview history.

--- a/crates/aionui-common/src/enums.rs
+++ b/crates/aionui-common/src/enums.rs
@@ -395,6 +395,9 @@ pub enum AgentKillReason {
     /// `team_mcp_stdio_config`. The conversation is preserved; only the
     /// in-memory ACP CLI is recycled.
     TeamMcpRebuild,
+    /// Team is being deleted; every agent process under it must be torn
+    /// down before the team's conversations / rows are removed.
+    TeamDeleted,
 }
 
 /// Preview content type for document preview history.

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -418,6 +418,35 @@ impl ConversationService {
         Ok(response)
     }
 
+    /// Merge a JSON patch into `conversation.extra` without touching model,
+    /// name, pinned flag, or task lifecycle. Intended for internal callers
+    /// (e.g. `TeamSessionService::ensure_session` writing
+    /// `team_mcp_stdio_config`) where a full `update()` would kill the agent
+    /// on a spurious model comparison.
+    pub async fn update_extra(
+        &self,
+        conversation_id: &str,
+        patch: serde_json::Value,
+    ) -> Result<(), AppError> {
+        let existing = self.repo.get(conversation_id).await?.ok_or_else(|| {
+            AppError::NotFound(format!("Conversation {conversation_id} not found"))
+        })?;
+
+        let mut merged: serde_json::Value =
+            serde_json::from_str(&existing.extra).unwrap_or_else(|_| serde_json::json!({}));
+        merge_json(&mut merged, &patch);
+
+        let updates = ConversationRowUpdate {
+            extra: Some(serde_json::to_string(&merged).map_err(|e| {
+                AppError::Internal(format!("Failed to serialize merged extra: {e}"))
+            })?),
+            updated_at: Some(now_ms()),
+            ..Default::default()
+        };
+        self.repo.update(conversation_id, &updates).await?;
+        Ok(())
+    }
+
     /// Delete a conversation (messages cascade via FK).
     ///
     /// Broadcasts `conversation.listChanged(deleted)`.

--- a/crates/aionui-team/Cargo.toml
+++ b/crates/aionui-team/Cargo.toml
@@ -19,6 +19,7 @@ thiserror.workspace = true
 tracing.workspace = true
 async-trait.workspace = true
 dashmap.workspace = true
+agent-client-protocol = "0.11.1"
 
 [dev-dependencies]
 sqlx.workspace = true

--- a/crates/aionui-team/src/lib.rs
+++ b/crates/aionui-team/src/lib.rs
@@ -16,7 +16,7 @@ pub mod types;
 pub use error::TeamError;
 pub use events::TeamEventEmitter;
 pub use mailbox::Mailbox;
-pub use mcp::{TeamMcpServer, TeamMcpStdioConfig};
+pub use mcp::{TeamMcpServer, TeamMcpStdioConfig, TeamMcpStdioServerSpec};
 pub use prompts::{build_lead_prompt, build_teammate_prompt, build_wake_payload};
 pub use routes::{TeamRouterState, team_routes};
 pub use scheduler::{SchedulerAction, TeammateManager, WAKE_TIMEOUT_MS, WakePayload};

--- a/crates/aionui-team/src/lib.rs
+++ b/crates/aionui-team/src/lib.rs
@@ -21,7 +21,7 @@ pub use prompts::{build_lead_prompt, build_teammate_prompt, build_wake_payload};
 pub use routes::{TeamRouterState, team_routes};
 pub use scheduler::{SchedulerAction, TeammateManager, WAKE_TIMEOUT_MS, WakePayload};
 pub use service::TeamSessionService;
-pub use session::TeamSession;
+pub use session::{TeamSession, WakeInput};
 pub use task_board::{TaskBoard, TaskUpdate};
 pub use types::{
     MailboxMessage, MailboxMessageType, TaskStatus, Team, TeamAgent, TeamTask, TeammateRole,

--- a/crates/aionui-team/src/mcp/bridge.rs
+++ b/crates/aionui-team/src/mcp/bridge.rs
@@ -1,80 +1,152 @@
-use std::collections::HashMap;
+//! Stdio bridge descriptors consumed by ACP `session/new.mcp_servers`.
+//!
+//! Flow: `TeamSessionService::ensure_session` builds a `TeamMcpStdioServerSpec`
+//! per agent and writes its config triple into `conversation.extra`. When
+//! the ACP session is created, the spec is converted via `into_sdk()` to the
+//! wire-level `agent_client_protocol::schema::McpServer::Stdio` variant and
+//! sent to the agent CLI, which then spawns `<backend> mcp-bridge` with the
+//! three `TEAM_MCP_*` env keys so it can proxy stdio↔TCP to the in-process
+//! team MCP server.
 
-use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
-// ---------------------------------------------------------------------------
-// TeamMcpStdioConfig
-// ---------------------------------------------------------------------------
+use agent_client_protocol::schema::{EnvVariable, McpServer, McpServerStdio};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct TeamMcpStdioConfig {
-    pub port: u16,
-    pub token: String,
-    pub slot_id: String,
+pub use aionui_api_types::TeamMcpStdioConfig;
+
+/// Stdio MCP server description ready to be handed to `session/new`.
+///
+/// Field shapes are fixed by [phase1 interface-contracts.md §3]:
+/// - `name` = `"aionui-team-<team_id>"`
+/// - `command` = absolute path to the backend binary (resolved via
+///   `std::env::current_exe()` at app startup)
+/// - `args` = `["mcp-bridge"]`
+/// - `env` = three pairs built from `TeamMcpStdioConfig::ENV_*` constants
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TeamMcpStdioServerSpec {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
 }
 
-impl TeamMcpStdioConfig {
-    pub fn new(port: u16, token: String, slot_id: String) -> Self {
+impl TeamMcpStdioServerSpec {
+    /// Build the spec from the persisted stdio config plus runtime context.
+    ///
+    /// `backend_binary_path` is the absolute path to the `aionui-backend`
+    /// executable (phase1 single-binary constraint — no standalone bridge).
+    pub fn from_config(team_id: &str, backend_binary_path: &str, cfg: &TeamMcpStdioConfig) -> Self {
         Self {
-            port,
-            token,
-            slot_id,
+            name: format!("aionui-team-{team_id}"),
+            command: backend_binary_path.to_owned(),
+            args: vec!["mcp-bridge".to_owned()],
+            env: vec![
+                (
+                    TeamMcpStdioConfig::ENV_PORT.to_owned(),
+                    cfg.port.to_string(),
+                ),
+                (TeamMcpStdioConfig::ENV_TOKEN.to_owned(), cfg.token.clone()),
+                (
+                    TeamMcpStdioConfig::ENV_SLOT_ID.to_owned(),
+                    cfg.slot_id.clone(),
+                ),
+            ],
         }
     }
 
-    pub fn to_env_map(&self) -> HashMap<String, String> {
-        HashMap::from([
-            ("TEAM_MCP_PORT".into(), self.port.to_string()),
-            ("TEAM_MCP_TOKEN".into(), self.token.clone()),
-            ("TEAM_AGENT_SLOT_ID".into(), self.slot_id.clone()),
-        ])
+    /// Convert into the ACP SDK wire type expected by `NewSessionRequest::mcp_servers`.
+    pub fn into_sdk(self) -> McpServer {
+        // Both `McpServerStdio` and `EnvVariable` are `#[non_exhaustive]` in the
+        // SDK, so construction goes through the `new(..)` / builder entry points.
+        let env: Vec<EnvVariable> = self
+            .env
+            .into_iter()
+            .map(|(name, value)| EnvVariable::new(name, value))
+            .collect();
+
+        let stdio = McpServerStdio::new(self.name, PathBuf::from(self.command))
+            .args(self.args)
+            .env(env);
+
+        McpServer::Stdio(stdio)
     }
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn config_creation() {
-        let config = TeamMcpStdioConfig::new(12345, "tok-abc".into(), "slot-1".into());
-        assert_eq!(config.port, 12345);
-        assert_eq!(config.token, "tok-abc");
-        assert_eq!(config.slot_id, "slot-1");
+    fn sample_cfg() -> TeamMcpStdioConfig {
+        TeamMcpStdioConfig {
+            port: 12345,
+            token: "tok-abc".into(),
+            slot_id: "slot-1".into(),
+        }
     }
 
     #[test]
-    fn env_map_contains_all_keys() {
-        let config = TeamMcpStdioConfig::new(8080, "secret-token".into(), "agent-slot".into());
-        let env = config.to_env_map();
+    fn from_config_fills_all_fields() {
+        let spec = TeamMcpStdioServerSpec::from_config(
+            "team-42",
+            "/usr/bin/aionui-backend",
+            &sample_cfg(),
+        );
+
+        assert_eq!(spec.name, "aionui-team-team-42");
+        assert_eq!(spec.command, "/usr/bin/aionui-backend");
+        assert_eq!(spec.args, vec!["mcp-bridge".to_owned()]);
+        assert_eq!(spec.env.len(), 3);
+    }
+
+    #[test]
+    fn env_keys_match_api_type_constants() {
+        let spec = TeamMcpStdioServerSpec::from_config("t", "/p", &sample_cfg());
+        let kv: std::collections::HashMap<_, _> = spec.env.iter().cloned().collect();
+
+        assert_eq!(
+            kv.get(TeamMcpStdioConfig::ENV_PORT).map(String::as_str),
+            Some("12345")
+        );
+        assert_eq!(
+            kv.get(TeamMcpStdioConfig::ENV_TOKEN).map(String::as_str),
+            Some("tok-abc")
+        );
+        assert_eq!(
+            kv.get(TeamMcpStdioConfig::ENV_SLOT_ID).map(String::as_str),
+            Some("slot-1")
+        );
+    }
+
+    #[test]
+    fn into_sdk_serializes_as_stdio_variant() {
+        let spec = TeamMcpStdioServerSpec::from_config("tid", "/bin/aionui-backend", &sample_cfg());
+        let sdk = spec.into_sdk();
+
+        let json = serde_json::to_value(&sdk).expect("serialize");
+
+        // `Stdio` variant is `#[serde(untagged)]` inside `McpServer`, so the
+        // JSON is the raw `McpServerStdio` shape — no `"type":"stdio"` tag.
+        assert_eq!(json["name"], "aionui-team-tid");
+        assert_eq!(json["command"], "/bin/aionui-backend");
+        assert_eq!(json["args"], serde_json::json!(["mcp-bridge"]));
+
+        let env = json["env"].as_array().expect("env array");
         assert_eq!(env.len(), 3);
-        assert_eq!(env["TEAM_MCP_PORT"], "8080");
-        assert_eq!(env["TEAM_MCP_TOKEN"], "secret-token");
-        assert_eq!(env["TEAM_AGENT_SLOT_ID"], "agent-slot");
-    }
+        let pairs: std::collections::HashMap<_, _> = env
+            .iter()
+            .map(|v| {
+                (
+                    v["name"].as_str().unwrap().to_owned(),
+                    v["value"].as_str().unwrap().to_owned(),
+                )
+            })
+            .collect();
+        assert_eq!(pairs[TeamMcpStdioConfig::ENV_PORT], "12345");
+        assert_eq!(pairs[TeamMcpStdioConfig::ENV_TOKEN], "tok-abc");
+        assert_eq!(pairs[TeamMcpStdioConfig::ENV_SLOT_ID], "slot-1");
 
-    #[test]
-    fn serialization_roundtrip() {
-        let config = TeamMcpStdioConfig::new(9999, "tok".into(), "s1".into());
-        let json = serde_json::to_string(&config).unwrap();
-        let parsed: TeamMcpStdioConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(config, parsed);
-    }
-
-    #[test]
-    fn different_agents_get_different_configs() {
-        let cfg1 = TeamMcpStdioConfig::new(5000, "token".into(), "slot-a".into());
-        let cfg2 = TeamMcpStdioConfig::new(5000, "token".into(), "slot-b".into());
-        assert_ne!(cfg1, cfg2);
-
-        let env1 = cfg1.to_env_map();
-        let env2 = cfg2.to_env_map();
-        assert_eq!(env1["TEAM_MCP_PORT"], env2["TEAM_MCP_PORT"]);
-        assert_eq!(env1["TEAM_MCP_TOKEN"], env2["TEAM_MCP_TOKEN"]);
-        assert_ne!(env1["TEAM_AGENT_SLOT_ID"], env2["TEAM_AGENT_SLOT_ID"]);
+        // The untagged variant must still round-trip back into the enum.
+        let back: McpServer = serde_json::from_value(json).expect("roundtrip");
+        assert!(matches!(back, McpServer::Stdio(_)));
     }
 }

--- a/crates/aionui-team/src/mcp/bridge.rs
+++ b/crates/aionui-team/src/mcp/bridge.rs
@@ -35,9 +35,12 @@ impl TeamMcpStdioServerSpec {
     ///
     /// `backend_binary_path` is the absolute path to the `aionui-backend`
     /// executable (phase1 single-binary constraint — no standalone bridge).
-    pub fn from_config(team_id: &str, backend_binary_path: &str, cfg: &TeamMcpStdioConfig) -> Self {
+    /// `team_id` is read from `cfg.team_id` rather than taken as a separate
+    /// parameter so the wire-level server name stays in sync with the
+    /// persisted config across every consumer.
+    pub fn from_config(backend_binary_path: &str, cfg: &TeamMcpStdioConfig) -> Self {
         Self {
-            name: format!("aionui-team-{team_id}"),
+            name: format!("aionui-team-{}", cfg.team_id),
             command: backend_binary_path.to_owned(),
             args: vec!["mcp-bridge".to_owned()],
             env: vec![
@@ -78,6 +81,7 @@ mod tests {
 
     fn sample_cfg() -> TeamMcpStdioConfig {
         TeamMcpStdioConfig {
+            team_id: "team-42".into(),
             port: 12345,
             token: "tok-abc".into(),
             slot_id: "slot-1".into(),
@@ -86,11 +90,7 @@ mod tests {
 
     #[test]
     fn from_config_fills_all_fields() {
-        let spec = TeamMcpStdioServerSpec::from_config(
-            "team-42",
-            "/usr/bin/aionui-backend",
-            &sample_cfg(),
-        );
+        let spec = TeamMcpStdioServerSpec::from_config("/usr/bin/aionui-backend", &sample_cfg());
 
         assert_eq!(spec.name, "aionui-team-team-42");
         assert_eq!(spec.command, "/usr/bin/aionui-backend");
@@ -100,7 +100,7 @@ mod tests {
 
     #[test]
     fn env_keys_match_api_type_constants() {
-        let spec = TeamMcpStdioServerSpec::from_config("t", "/p", &sample_cfg());
+        let spec = TeamMcpStdioServerSpec::from_config("/p", &sample_cfg());
         let kv: std::collections::HashMap<_, _> = spec.env.iter().cloned().collect();
 
         assert_eq!(
@@ -119,14 +119,14 @@ mod tests {
 
     #[test]
     fn into_sdk_serializes_as_stdio_variant() {
-        let spec = TeamMcpStdioServerSpec::from_config("tid", "/bin/aionui-backend", &sample_cfg());
+        let spec = TeamMcpStdioServerSpec::from_config("/bin/aionui-backend", &sample_cfg());
         let sdk = spec.into_sdk();
 
         let json = serde_json::to_value(&sdk).expect("serialize");
 
         // `Stdio` variant is `#[serde(untagged)]` inside `McpServer`, so the
         // JSON is the raw `McpServerStdio` shape — no `"type":"stdio"` tag.
-        assert_eq!(json["name"], "aionui-team-tid");
+        assert_eq!(json["name"], "aionui-team-team-42");
         assert_eq!(json["command"], "/bin/aionui-backend");
         assert_eq!(json["args"], serde_json::json!(["mcp-bridge"]));
 

--- a/crates/aionui-team/src/mcp/mod.rs
+++ b/crates/aionui-team/src/mcp/mod.rs
@@ -3,5 +3,5 @@ pub mod protocol;
 pub mod server;
 pub mod tools;
 
-pub use bridge::TeamMcpStdioConfig;
+pub use bridge::{TeamMcpStdioConfig, TeamMcpStdioServerSpec};
 pub use server::TeamMcpServer;

--- a/crates/aionui-team/src/mcp/server.rs
+++ b/crates/aionui-team/src/mcp/server.rs
@@ -16,7 +16,8 @@ use super::protocol::{
 };
 use super::tools::{
     RenameAgentInput, SendMessageInput, ShutdownAgentInput, SpawnAgentInput, TaskCreateInput,
-    TaskUpdateInput, all_tool_descriptors, is_whitelisted_backend,
+    TaskUpdateInput, all_tool_descriptors, handle_team_describe_assistant, handle_team_list_models,
+    is_whitelisted_backend,
 };
 
 // ---------------------------------------------------------------------------
@@ -328,8 +329,19 @@ async fn dispatch_tool(
         "team_shutdown_agent" => {
             exec_shutdown_agent(arguments, scheduler, caller_slot_id, caller_role).await
         }
+        "team_list_models" => exec_list_models(arguments).await,
+        "team_describe_assistant" => exec_describe_assistant(arguments).await,
         _ => Err(format!("Unknown tool: {tool_name}")),
     }
+}
+
+async fn exec_list_models(args: &Value) -> Result<String, String> {
+    let value = handle_team_list_models(args);
+    serde_json::to_string_pretty(&value).map_err(|e| format!("Serialization error: {e}"))
+}
+
+async fn exec_describe_assistant(args: &Value) -> Result<String, String> {
+    Ok(handle_team_describe_assistant(args))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aionui-team/src/mcp/tools.rs
+++ b/crates/aionui-team/src/mcp/tools.rs
@@ -5,6 +5,32 @@ use crate::scheduler::SchedulerAction;
 use crate::types::TeammateRole;
 
 // ---------------------------------------------------------------------------
+// Tool description constants (原样复用 AionUi `toolDescriptions.ts`)
+// ---------------------------------------------------------------------------
+
+/// `team_spawn_agent` 工具描述 — 原样复制自 AionUi `toolDescriptions.ts`
+/// 对应 team-prompts.md §5.2 `team_spawn_agent` Description 原文。
+/// 禁止翻译、改写；aionui-audit §8 #5 硬约束。
+pub const TEAM_SPAWN_AGENT_DESCRIPTION: &str = r#"Create a new teammate agent to join the team.
+
+Use this only when one of the following is true:
+- The user explicitly approved the proposed teammate lineup in a previous message
+- The user explicitly instructed you to create a specific teammate immediately
+
+Before calling this tool in the normal planning flow:
+- Start with one short sentence explaining why additional teammates would help
+- Tell the user which teammate(s) you recommend
+- Present the proposal as a table with: name, responsibility, recommended agent type/backend, and recommended model
+- Include each teammate's responsibility, recommended agent type/backend, and model
+- Ask whether to create them as proposed or change any names, responsibilities, or agent types
+- In that approval question, remind the user that they can later ask you to replace or adjust any teammate if the lineup is not working well
+- Do NOT call this tool in that same turn; wait for explicit approval in a later user message
+
+When calling this tool, provide the model parameter if a specific model was recommended and approved.
+
+The new agent will be created and added to the team. You can then assign tasks and send messages to it."#;
+
+// ---------------------------------------------------------------------------
 // Tool descriptors (returned by tools/list)
 // ---------------------------------------------------------------------------
 
@@ -31,7 +57,7 @@ pub fn all_tool_descriptors() -> Vec<ToolDescriptor> {
         },
         ToolDescriptor {
             name: "team_spawn_agent".into(),
-            description: "Dynamically create a new teammate agent (Lead only).".into(),
+            description: TEAM_SPAWN_AGENT_DESCRIPTION.into(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
@@ -264,6 +290,24 @@ mod tests {
             assert!(!d.description.is_empty());
             assert_eq!(d.input_schema["type"], "object");
         }
+    }
+
+    #[test]
+    fn team_spawn_agent_description_is_aionui_original() {
+        let desc = all_tool_descriptors()
+            .into_iter()
+            .find(|d| d.name == "team_spawn_agent")
+            .expect("team_spawn_agent descriptor must exist")
+            .description;
+        assert_eq!(desc, TEAM_SPAWN_AGENT_DESCRIPTION);
+        assert!(
+            desc.contains("Before calling this tool"),
+            "description must be the full AionUi original, not the legacy one-liner"
+        );
+        assert!(
+            desc.contains("explicitly approved"),
+            "description must retain the explicit-approval precondition clause"
+        );
     }
 
     #[test]

--- a/crates/aionui-team/src/mcp/tools.rs
+++ b/crates/aionui-team/src/mcp/tools.rs
@@ -30,6 +30,27 @@ When calling this tool, provide the model parameter if a specific model was reco
 
 The new agent will be created and added to the team. You can then assign tasks and send messages to it."#;
 
+/// Description for `team_list_models` — verbatim from team-prompts.md §5.2.
+pub const TEAM_LIST_MODELS_DESCRIPTION: &str = "Query available models for team agent types. Returns the real-time model list that matches the frontend model selector.
+
+Use this to:
+- Check what models are available before spawning an agent with a specific model
+- See all available agent types and their models at once
+- Verify a model ID is valid for a given agent type
+
+Pass agent_type to query a specific backend, or omit it to see all.";
+
+/// Description for `team_describe_assistant` — verbatim from team-prompts.md §5.2.
+pub const TEAM_DESCRIBE_ASSISTANT_DESCRIPTION: &str =
+    "Get detailed information about a preset assistant before spawning it as a teammate.
+
+Returns the preset's full description, enabled skills, and example tasks so you can
+judge whether it fits the user's request. Use this when two or more presets look
+relevant from the one-line catalog in your system prompt.
+
+Only works on preset assistants listed in \"Available Preset Assistants for Spawning\".
+After confirming a match, call team_spawn_agent with the same custom_agent_id.";
+
 // ---------------------------------------------------------------------------
 // Tool descriptors (returned by tools/list)
 // ---------------------------------------------------------------------------
@@ -135,6 +156,28 @@ pub fn all_tool_descriptors() -> Vec<ToolDescriptor> {
                     "reason": { "type": "string", "description": "Reason for shutdown" }
                 },
                 "required": ["slot_id"]
+            }),
+        },
+        ToolDescriptor {
+            name: "team_describe_assistant".into(),
+            description: TEAM_DESCRIBE_ASSISTANT_DESCRIPTION.into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "custom_agent_id": { "type": "string", "description": "The preset assistant ID from the \"Available Preset Assistants\" catalog (e.g., \"word-creator\")." },
+                    "locale": { "type": "string", "description": "Locale like \"zh-CN\" or \"en-US\". Defaults to the user's current UI language when omitted." }
+                },
+                "required": ["custom_agent_id"]
+            }),
+        },
+        ToolDescriptor {
+            name: "team_list_models".into(),
+            description: TEAM_LIST_MODELS_DESCRIPTION.into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "agent_type": { "type": "string", "description": "Agent type/backend to query (e.g. \"gemini\", \"claude\", \"codex\"). Shows all when omitted." }
+                }
             }),
         },
     ]
@@ -254,11 +297,41 @@ pub fn parse_tool_call(
                 blocked_by: input.blocked_by,
             })
         }
-        "team_task_list" | "team_members" | "team_rename_agent" | "team_shutdown_agent" => {
-            Err("handled directly by server".into())
-        }
+        "team_task_list"
+        | "team_members"
+        | "team_rename_agent"
+        | "team_shutdown_agent"
+        | "team_list_models"
+        | "team_describe_assistant" => Err("handled directly by server".into()),
         _ => Err(format!("Unknown tool: {tool_name}")),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Phase-1 minimal handlers for `team_list_models` and `team_describe_assistant`
+// ---------------------------------------------------------------------------
+
+/// Phase-1 minimal `team_list_models` handler. Returns a hard-coded
+/// agent-type → models mapping. Wave 2 wires this to the real registry.
+pub fn handle_team_list_models(_args: &Value) -> Value {
+    json!({
+        "agent_types": [
+            {
+                "type": "claude",
+                "models": ["claude-sonnet-4", "claude-opus-4"]
+            },
+            {
+                "type": "codex",
+                "models": ["codex-mini-latest"]
+            }
+        ]
+    })
+}
+
+/// Phase-1 minimal `team_describe_assistant` handler. Backend has no preset
+/// assistants wired yet, so every call returns the not-found text.
+pub fn handle_team_describe_assistant(_args: &Value) -> String {
+    "Preset assistant not found".to_owned()
 }
 
 // ---------------------------------------------------------------------------
@@ -271,7 +344,7 @@ mod tests {
 
     #[test]
     fn all_descriptors_count() {
-        assert_eq!(all_tool_descriptors().len(), 8);
+        assert_eq!(all_tool_descriptors().len(), 10);
     }
 
     #[test]
@@ -280,7 +353,7 @@ mod tests {
         let mut names: Vec<&str> = descs.iter().map(|d| d.name.as_str()).collect();
         names.sort();
         names.dedup();
-        assert_eq!(names.len(), 8);
+        assert_eq!(names.len(), 10);
     }
 
     #[test]
@@ -441,5 +514,64 @@ mod tests {
         let result = parse_tool_call("team_shutdown_agent", &args, TeammateRole::Lead);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("handled directly by server"));
+    }
+
+    // ---- D4 descriptor text matches team-prompts.md §5.2 verbatim ----
+
+    #[test]
+    fn team_list_models_descriptor_text_matches() {
+        let desc = all_tool_descriptors()
+            .into_iter()
+            .find(|d| d.name == "team_list_models")
+            .expect("team_list_models descriptor missing");
+        assert_eq!(desc.description, TEAM_LIST_MODELS_DESCRIPTION);
+        assert!(
+            desc.description
+                .starts_with("Query available models for team agent types.")
+        );
+        assert!(
+            desc.description
+                .contains("Pass agent_type to query a specific backend, or omit it to see all.")
+        );
+    }
+
+    #[test]
+    fn team_describe_assistant_descriptor_text_matches() {
+        let desc = all_tool_descriptors()
+            .into_iter()
+            .find(|d| d.name == "team_describe_assistant")
+            .expect("team_describe_assistant descriptor missing");
+        assert_eq!(desc.description, TEAM_DESCRIBE_ASSISTANT_DESCRIPTION);
+        assert!(
+            desc.description
+                .starts_with("Get detailed information about a preset assistant")
+        );
+        assert!(desc.description.contains(
+            "After confirming a match, call team_spawn_agent with the same custom_agent_id."
+        ));
+    }
+
+    // ---- D4 handlers return non-error payloads ----
+
+    #[test]
+    fn team_list_models_handler_returns_non_error() {
+        let value = handle_team_list_models(&json!({}));
+        let agent_types = value
+            .get("agent_types")
+            .and_then(|v| v.as_array())
+            .expect("agent_types array missing");
+        assert!(!agent_types.is_empty());
+        let types: Vec<&str> = agent_types
+            .iter()
+            .filter_map(|e| e.get("type").and_then(|v| v.as_str()))
+            .collect();
+        assert!(types.contains(&"claude"));
+        assert!(types.contains(&"codex"));
+    }
+
+    #[test]
+    fn team_describe_assistant_handler_returns_non_error() {
+        let text = handle_team_describe_assistant(&json!({"custom_agent_id": "unknown"}));
+        assert_eq!(text, "Preset assistant not found");
     }
 }

--- a/crates/aionui-team/src/prompts/lead.rs
+++ b/crates/aionui-team/src/prompts/lead.rs
@@ -404,7 +404,10 @@ mod tests {
         // healthy in the meantime.
         let renamed = HashMap::new();
         let out = build_lead_prompt(&params_min(&renamed));
-        assert!(!out.is_empty(), "output should not be empty with real template");
+        assert!(
+            !out.is_empty(),
+            "output should not be empty with real template"
+        );
         assert!(!out.contains("${"), "no unsubstituted placeholders");
     }
 

--- a/crates/aionui-team/src/prompts/lead.rs
+++ b/crates/aionui-team/src/prompts/lead.rs
@@ -1,18 +1,458 @@
-//! Lead prompt template constant.
+//! Leader prompt template constant and builder.
 //!
-//! Byte-for-byte copy of AionUi `leadPrompt.ts` template literal
-//! (the string returned by `buildLeaderPrompt`). The `${...}` placeholders
-//! are preserved verbatim so the builder in D5b-2 can substitute them.
-//! Do not modify the template text: it is treated as raw material, not code.
+//! The template constant is provided by D5b-1 as `include_str!("prompt_templates/lead.txt")`.
+//! This file hosts a stub (`""`) until D5b-1 lands; D5b-2 (this module) implements the
+//! `build_lead_prompt()` builder per `docs/teams/phase1/interface-contracts.md` §5.
 
+use std::collections::HashMap;
+use std::fmt::Write;
+
+use crate::types::TeamAgent;
+
+/// Placeholder for D5b-1's `include_str!("prompt_templates/lead.txt")`.
+/// D5b-1 will replace this stub with the AionUi `leadPrompt.ts` body, preserving
+/// the `${...}` placeholders listed in [`PLACEHOLDERS`].
 pub const LEAD_PROMPT_TEMPLATE: &str = include_str!("prompt_templates/lead.txt");
+
+/// Placeholder tokens that [`build_lead_prompt`] substitutes in [`LEAD_PROMPT_TEMPLATE`].
+///
+/// Mirrors the JS template literal placeholders in AionUi's `leadPrompt.ts`.
+const PLACEHOLDER_TEAMMATE_LIST: &str = "${teammateList}";
+const PLACEHOLDER_AVAILABLE_TYPES_SECTION: &str = "${availableTypesSection}";
+const PLACEHOLDER_AVAILABLE_ASSISTANTS_SECTION: &str = "${availableAssistantsSection}";
+const PLACEHOLDER_WORKSPACE_SECTION: &str = "${workspaceSection}";
+const PLACEHOLDER_PRESET_FORMATTING_STEP_RULE: &str = "${presetFormattingStepRule}";
+const PLACEHOLDER_PRESET_FORMATTING_IMPORTANT_RULE: &str = "${presetFormattingImportantRule}";
+
+/// A generic agent type (CLI backend) that the leader may spawn.
+/// Phase1 shape per interface-contracts §5 (line 211).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AvailableAgentType {
+    pub agent_type: String,
+    pub display_name: String,
+}
+
+/// A preset assistant the leader may spawn via `custom_agent_id`.
+/// Phase1 shape per interface-contracts §5 (lines 212-218).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AvailableAssistant {
+    pub custom_agent_id: String,
+    pub name: String,
+    pub backend: String,
+    pub description: String,
+    pub skills: Vec<String>,
+}
+
+/// Inputs for `build_lead_prompt`. Phase1 callers may pass empty slices/maps and `None`.
+pub struct LeadPromptParams<'a> {
+    pub team_name: &'a str,
+    pub teammates: &'a [TeamAgent],
+    pub available_agent_types: &'a [AvailableAgentType],
+    pub available_assistants: &'a [AvailableAssistant],
+    pub renamed_agents: &'a HashMap<String, String>,
+    pub team_workspace: Option<&'a str>,
+}
+
+/// Build the leader role prompt by substituting dynamic sections into the static template.
+///
+/// Placeholders replaced (mirrors AionUi `leadPrompt.ts`):
+/// - `${teammateList}` — bullet list of teammates or an empty-team fallback sentence
+/// - `${availableTypesSection}` — `## Available Agent Types for Spawning` section, or `""`
+/// - `${availableAssistantsSection}` — `## Available Preset Assistants for Spawning` section, or `""`
+/// - `${workspaceSection}` — `## Team Workspace` section, or `""`
+/// - `${presetFormattingStepRule}` — phase1 emits `""` (presets not surfaced in phase1)
+/// - `${presetFormattingImportantRule}` — phase1 emits `""` (presets not surfaced in phase1)
+pub fn build_lead_prompt(params: &LeadPromptParams<'_>) -> String {
+    let teammate_list = render_teammate_list(params.teammates, params.renamed_agents);
+    let available_types_section = render_available_types_section(params.available_agent_types);
+    let available_assistants_section =
+        render_available_assistants_section(params.available_assistants);
+    let workspace_section = render_workspace_section(params.team_workspace);
+
+    // Phase1 does not surface preset assistants in the staffing-proposal formatting
+    // rules, so these two placeholders are replaced with empty strings. When preset
+    // support lands they will be conditional strings analogous to AionUi.
+    let preset_formatting_step_rule = "";
+    let preset_formatting_important_rule = "";
+
+    LEAD_PROMPT_TEMPLATE
+        .replace(PLACEHOLDER_TEAMMATE_LIST, &teammate_list)
+        .replace(
+            PLACEHOLDER_AVAILABLE_TYPES_SECTION,
+            &available_types_section,
+        )
+        .replace(
+            PLACEHOLDER_AVAILABLE_ASSISTANTS_SECTION,
+            &available_assistants_section,
+        )
+        .replace(PLACEHOLDER_WORKSPACE_SECTION, &workspace_section)
+        .replace(
+            PLACEHOLDER_PRESET_FORMATTING_STEP_RULE,
+            preset_formatting_step_rule,
+        )
+        .replace(
+            PLACEHOLDER_PRESET_FORMATTING_IMPORTANT_RULE,
+            preset_formatting_important_rule,
+        )
+}
+
+fn render_teammate_list(
+    teammates: &[TeamAgent],
+    renamed_agents: &HashMap<String, String>,
+) -> String {
+    if teammates.is_empty() {
+        return "(no teammates yet — propose the lineup to the user first, then use \
+                team_spawn_agent only after they confirm or explicitly ask you to create \
+                teammates immediately)"
+            .to_owned();
+    }
+
+    let mut out = String::with_capacity(teammates.len() * 64);
+    for (idx, m) in teammates.iter().enumerate() {
+        if idx > 0 {
+            out.push('\n');
+        }
+        let status = m
+            .status
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "unknown".to_owned());
+        let _ = write!(out, "- {} ({}, status: {})", m.name, m.backend, status,);
+        if let Some(former) = renamed_agents.get(&m.slot_id) {
+            let _ = write!(out, " [formerly: {former}]");
+        }
+    }
+    out
+}
+
+fn render_available_types_section(agent_types: &[AvailableAgentType]) -> String {
+    if agent_types.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("\n\n## Available Agent Types for Spawning\n");
+    for (idx, t) in agent_types.iter().enumerate() {
+        if idx > 0 {
+            out.push('\n');
+        }
+        let _ = write!(out, "- `{}` — {}", t.agent_type, t.display_name);
+    }
+    out.push_str(
+        "\n\nUse `team_list_models` to query available models for each agent type before spawning.",
+    );
+    out
+}
+
+fn render_available_assistants_section(assistants: &[AvailableAssistant]) -> String {
+    if assistants.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("\n\n## Available Preset Assistants for Spawning\n");
+    out.push_str(
+        "These are user-configured assistants with pre-loaded rules and skills for specific \
+         domains (writing, research, PPT building, etc.). When a task matches a preset's \
+         specialty, prefer spawning the preset over a generic CLI agent — you get its domain \
+         expertise automatically.\n\n",
+    );
+    for (idx, a) in assistants.iter().enumerate() {
+        if idx > 0 {
+            out.push('\n');
+        }
+        let desc = if a.description.is_empty() {
+            String::new()
+        } else {
+            format!(" — {}", a.description)
+        };
+        let skills = if a.skills.is_empty() {
+            String::new()
+        } else {
+            format!("\n   skills: {}", a.skills.join(", "))
+        };
+        let _ = write!(
+            out,
+            "- `{}` ({}, backend: {}){}{}",
+            a.custom_agent_id, a.name, a.backend, desc, skills,
+        );
+    }
+    out.push_str(
+        "\n\n### How to pick a preset\n\
+         1. Scan the one-line descriptions and skills above. If one clearly matches the user's \
+         domain (e.g. \"quarterly Word report\" → `word-creator`), spawn it directly with \
+         `team_spawn_agent`.\n\
+         2. If two or more presets seem relevant, call `team_describe_assistant` on each \
+         candidate to see its full description, skills, and example tasks, then choose the best \
+         fit.\n\
+         3. If no preset matches the task, fall back to a generic CLI agent from the \
+         \"Available Agent Types\" section.\n\n\
+         Pass the preset's ID as `custom_agent_id` to `team_spawn_agent`. The `agent_type` is \
+         derived from the preset's backend and does not need to be specified.",
+    );
+    out
+}
+
+fn render_workspace_section(team_workspace: Option<&str>) -> String {
+    match team_workspace {
+        Some(ws) => format!(
+            "\n\n## Team Workspace\nYour working directory `{ws}` IS the shared team workspace.\n\
+             All teammates work in this directory for project-related operations."
+        ),
+        None => String::new(),
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::{TeamAgent, TeammateRole, TeammateStatus};
+
+    fn params_min<'a>(renamed: &'a HashMap<String, String>) -> LeadPromptParams<'a> {
+        LeadPromptParams {
+            team_name: "Alpha",
+            teammates: &[],
+            available_agent_types: &[],
+            available_assistants: &[],
+            renamed_agents: renamed,
+            team_workspace: None,
+        }
+    }
+
+    fn make_teammate(slot_id: &str, name: &str, backend: &str) -> TeamAgent {
+        TeamAgent {
+            slot_id: slot_id.into(),
+            name: name.into(),
+            role: TeammateRole::Teammate,
+            conversation_id: format!("conv-{slot_id}"),
+            backend: backend.into(),
+            model: "sonnet".into(),
+            custom_agent_id: None,
+            status: None,
+            conversation_type: None,
+            cli_path: None,
+        }
+    }
 
     #[test]
-    fn lead_prompt_template_contains_header() {
-        assert!(LEAD_PROMPT_TEMPLATE.contains("You are the Team Leader"));
+    fn no_unsubstituted_placeholders_on_minimal_params() {
+        let renamed = HashMap::new();
+        let out = build_lead_prompt(&params_min(&renamed));
+        assert!(
+            !out.contains("${"),
+            "unsubstituted `${{` placeholder remains in output:\n{out}"
+        );
+    }
+
+    #[test]
+    fn no_unsubstituted_placeholders_when_all_sections_populated() {
+        let renamed = HashMap::new();
+        let teammate = make_teammate("w1", "Worker1", "claude");
+        let agent_types = vec![AvailableAgentType {
+            agent_type: "claude".into(),
+            display_name: "general-purpose AI assistant".into(),
+        }];
+        let assistants = vec![AvailableAssistant {
+            custom_agent_id: "word-creator".into(),
+            name: "Word Creator".into(),
+            backend: "claude".into(),
+            description: "Drafts Word documents".into(),
+            skills: vec!["docx".into(), "formatting".into()],
+        }];
+        let params = LeadPromptParams {
+            team_name: "Beta",
+            teammates: std::slice::from_ref(&teammate),
+            available_agent_types: &agent_types,
+            available_assistants: &assistants,
+            renamed_agents: &renamed,
+            team_workspace: Some("/tmp/team-ws"),
+        };
+        let out = build_lead_prompt(&params);
+        assert!(
+            !out.contains("${"),
+            "unsubstituted `${{` placeholder remains in output:\n{out}"
+        );
+    }
+
+    #[test]
+    fn teammate_list_empty_uses_aionui_fallback_copy() {
+        let renamed = HashMap::new();
+        let got = render_teammate_list(&[], &renamed);
+        assert_eq!(
+            got,
+            "(no teammates yet — propose the lineup to the user first, then use team_spawn_agent \
+             only after they confirm or explicitly ask you to create teammates immediately)"
+        );
+    }
+
+    #[test]
+    fn teammate_list_uses_aionui_bullet_format_without_slot_prefix() {
+        let renamed = HashMap::new();
+        let mut t = make_teammate("w1", "Worker1", "claude");
+        t.status = Some(TeammateStatus::Idle);
+        let got = render_teammate_list(std::slice::from_ref(&t), &renamed);
+
+        assert_eq!(got, "- Worker1 (claude, status: idle)");
+        assert!(
+            !got.contains("slot="),
+            "teammate bullet must not expose slot="
+        );
+        assert!(
+            !got.contains("agentType="),
+            "teammate bullet must not use agentType= prefix"
+        );
+    }
+
+    #[test]
+    fn teammate_list_status_defaults_to_unknown_when_missing() {
+        let renamed = HashMap::new();
+        let t = make_teammate("w1", "Worker1", "claude");
+        let got = render_teammate_list(std::slice::from_ref(&t), &renamed);
+        assert_eq!(got, "- Worker1 (claude, status: unknown)");
+    }
+
+    #[test]
+    fn teammate_list_appends_formerly_note_for_renamed() {
+        let mut renamed = HashMap::new();
+        renamed.insert("w1".to_owned(), "OldName".to_owned());
+        let mut t = make_teammate("w1", "Worker1", "claude");
+        t.status = Some(TeammateStatus::Working);
+        let got = render_teammate_list(std::slice::from_ref(&t), &renamed);
+        assert_eq!(
+            got,
+            "- Worker1 (claude, status: working) [formerly: OldName]"
+        );
+    }
+
+    #[test]
+    fn available_types_section_omitted_when_empty() {
+        assert_eq!(render_available_types_section(&[]), "");
+    }
+
+    #[test]
+    fn available_types_section_includes_backtick_ids_and_model_query_hint() {
+        let got = render_available_types_section(&[
+            AvailableAgentType {
+                agent_type: "claude".into(),
+                display_name: "general-purpose AI assistant".into(),
+            },
+            AvailableAgentType {
+                agent_type: "codex".into(),
+                display_name: "code generation specialist".into(),
+            },
+        ]);
+        assert!(got.starts_with("\n\n## Available Agent Types for Spawning\n"));
+        assert!(got.contains("- `claude` — general-purpose AI assistant"));
+        assert!(got.contains("- `codex` — code generation specialist"));
+        assert!(got.contains("Use `team_list_models`"));
+    }
+
+    #[test]
+    fn available_assistants_section_omitted_when_empty() {
+        assert_eq!(render_available_assistants_section(&[]), "");
+    }
+
+    #[test]
+    fn available_assistants_section_includes_skills_and_how_to_pick() {
+        let got = render_available_assistants_section(&[AvailableAssistant {
+            custom_agent_id: "word-creator".into(),
+            name: "Word Creator".into(),
+            backend: "claude".into(),
+            description: "Drafts Word documents".into(),
+            skills: vec!["docx".into(), "formatting".into()],
+        }]);
+        assert!(got.contains("## Available Preset Assistants for Spawning"));
+        assert!(
+            got.contains(
+                "- `word-creator` (Word Creator, backend: claude) — Drafts Word documents"
+            )
+        );
+        assert!(got.contains("skills: docx, formatting"));
+        assert!(got.contains("### How to pick a preset"));
+    }
+
+    #[test]
+    fn workspace_section_omitted_when_none() {
+        assert_eq!(render_workspace_section(None), "");
+    }
+
+    #[test]
+    fn workspace_section_embeds_path_and_shared_directory_copy() {
+        let got = render_workspace_section(Some("/tmp/team-ws"));
+        assert!(got.contains("## Team Workspace"));
+        assert!(got.contains("`/tmp/team-ws`"));
+        assert!(got.contains("shared team workspace"));
+    }
+
+    #[test]
+    fn preset_formatting_placeholders_are_empty_in_phase1() {
+        // Phase1 convention: presets are not surfaced, so both preset-formatting
+        // placeholders are replaced with "" regardless of other params.
+        // The regression test above (`no_unsubstituted_placeholders_when_all_sections_populated`)
+        // already asserts that both tokens are stripped from the final output.
+        // This test guards the behavior by simulating the full substitution on a
+        // template carrying just the two preset placeholders.
+        let template_with_presets_only =
+            "step:${presetFormattingStepRule}|important:${presetFormattingImportantRule}";
+        let out = template_with_presets_only
+            .replace("${presetFormattingStepRule}", "")
+            .replace("${presetFormattingImportantRule}", "");
+        assert_eq!(out, "step:|important:");
+    }
+
+    #[test]
+    fn snapshot_minimal_params_with_stub_template_yields_empty_output() {
+        // While `LEAD_PROMPT_TEMPLATE` is the D5b-1 stub (`""`), the builder has no
+        // template to substitute into, so the output is empty regardless of params.
+        // Once D5b-1 lands, this test will start failing and should be updated to a
+        // real snapshot. The regression guard above keeps the substitution contract
+        // healthy in the meantime.
+        let renamed = HashMap::new();
+        let out = build_lead_prompt(&params_min(&renamed));
+        assert!(!out.is_empty(), "output should not be empty with real template");
+        assert!(!out.contains("${"), "no unsubstituted placeholders");
+    }
+
+    #[test]
+    fn substitution_against_synthetic_template_matches_aionui_layout() {
+        // This synthetic template mirrors the shape of AionUi's leadPrompt.ts literal
+        // so we can validate end-to-end substitution without depending on D5b-1.
+        // When D5b-1 lands the real `LEAD_PROMPT_TEMPLATE` takes over; this test
+        // still exercises the same substitution code path.
+        const SYNTHETIC: &str = "## Your Teammates\n\
+            ${teammateList}${availableTypesSection}${availableAssistantsSection}${workspaceSection}\n\
+            STEP:${presetFormattingStepRule}END\n\
+            - ${presetFormattingImportantRule}END";
+
+        let renamed = HashMap::new();
+        let t = make_teammate("w1", "Worker1", "claude");
+        let params = LeadPromptParams {
+            team_name: "Beta",
+            teammates: std::slice::from_ref(&t),
+            available_agent_types: &[AvailableAgentType {
+                agent_type: "claude".into(),
+                display_name: "general-purpose AI assistant".into(),
+            }],
+            available_assistants: &[],
+            renamed_agents: &renamed,
+            team_workspace: Some("/tmp/team-ws"),
+        };
+
+        let teammate_list = render_teammate_list(params.teammates, params.renamed_agents);
+        let types_section = render_available_types_section(params.available_agent_types);
+        let assistants_section = render_available_assistants_section(params.available_assistants);
+        let ws_section = render_workspace_section(params.team_workspace);
+
+        let out = SYNTHETIC
+            .replace("${teammateList}", &teammate_list)
+            .replace("${availableTypesSection}", &types_section)
+            .replace("${availableAssistantsSection}", &assistants_section)
+            .replace("${workspaceSection}", &ws_section)
+            .replace("${presetFormattingStepRule}", "")
+            .replace("${presetFormattingImportantRule}", "");
+
+        assert!(!out.contains("${"), "unsubstituted placeholder:\n{out}");
+        assert!(out.contains("## Your Teammates"));
+        assert!(out.contains("- Worker1 (claude, status: unknown)"));
+        assert!(out.contains("## Available Agent Types for Spawning"));
+        assert!(!out.contains("## Available Preset Assistants for Spawning"));
+        assert!(out.contains("## Team Workspace"));
+        assert!(out.contains("STEP:END"));
+        assert!(out.contains("- END"));
     }
 }

--- a/crates/aionui-team/src/prompts/lead.rs
+++ b/crates/aionui-team/src/prompts/lead.rs
@@ -1,0 +1,18 @@
+//! Lead prompt template constant.
+//!
+//! Byte-for-byte copy of AionUi `leadPrompt.ts` template literal
+//! (the string returned by `buildLeaderPrompt`). The `${...}` placeholders
+//! are preserved verbatim so the builder in D5b-2 can substitute them.
+//! Do not modify the template text: it is treated as raw material, not code.
+
+pub const LEAD_PROMPT_TEMPLATE: &str = include_str!("prompt_templates/lead.txt");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lead_prompt_template_contains_header() {
+        assert!(LEAD_PROMPT_TEMPLATE.contains("You are the Team Leader"));
+    }
+}

--- a/crates/aionui-team/src/prompts/mod.rs
+++ b/crates/aionui-team/src/prompts/mod.rs
@@ -1,4 +1,7 @@
 pub mod lead;
+pub mod team_guide;
+
+pub use team_guide::{TEAM_GUIDE_PROMPT_TEMPLATE, build_team_guide_prompt};
 
 use crate::types::{
     MailboxMessage, MailboxMessageType, TaskStatus, TeamAgent, TeamTask, TeammateRole,

--- a/crates/aionui-team/src/prompts/mod.rs
+++ b/crates/aionui-team/src/prompts/mod.rs
@@ -2,6 +2,7 @@ pub mod lead;
 pub mod team_guide;
 
 pub use team_guide::{TEAM_GUIDE_PROMPT_TEMPLATE, build_team_guide_prompt};
+pub mod teammate;
 
 use crate::types::{
     MailboxMessage, MailboxMessageType, TaskStatus, TeamAgent, TeamTask, TeammateRole,

--- a/crates/aionui-team/src/prompts/mod.rs
+++ b/crates/aionui-team/src/prompts/mod.rs
@@ -1,3 +1,5 @@
+pub mod lead;
+
 use crate::types::{
     MailboxMessage, MailboxMessageType, TaskStatus, TeamAgent, TeamTask, TeammateRole,
 };

--- a/crates/aionui-team/src/prompts/prompt_templates/lead.txt
+++ b/crates/aionui-team/src/prompts/prompt_templates/lead.txt
@@ -1,0 +1,99 @@
+# You are the Team Leader
+
+## Your Role
+You coordinate a team of AI agents. You do NOT do implementation work
+yourself. You break down tasks, assign them to teammates, and synthesize
+results.${workspaceSection}
+
+## Conversation Style
+- If the user greets you, starts a new chat, or asks what you can do without giving a concrete task yet, reply warmly and naturally
+- In that opening reply, briefly introduce yourself as the team leader and invite the user to share their goal
+- Do NOT mention teammate proposals, recommended agent types, or confirmation workflow until there is a concrete task that may actually need more teammates
+
+## Your Teammates
+${teammateList}${availableTypesSection}${availableAssistantsSection}
+
+## Team Coordination Tools
+You MUST use the `team_*` MCP tools for ALL team coordination.
+Your platform may provide similarly named built-in tools (e.g. SendMessage,
+TeamCreate, TaskCreate, Agent). Do NOT use those — they belong to a different
+system and will break team coordination. Always use the `team_*` versions.
+
+Use `team_members` and `team_task_list` to check current team state.
+
+## Workflow
+1. Receive user request
+2. Analyze the request and decide whether the current team is enough
+3. If additional teammates would help, FIRST call `team_list_models` to check available models for each agent type you plan to use
+4. Then reply in text with a staffing proposal
+5. Start that proposal with one short sentence explaining why more teammates would help
+6. Present the proposed lineup as a table with: teammate name, responsibility, recommended agent type/backend, and recommended model (from team_list_models results).${presetFormattingStepRule}
+7. Ask whether the user wants to create those teammates as proposed or change any names, responsibilities, or agent types
+8. In that same approval question, tell the user they can also come back later during the project and ask you to replace or adjust any teammate if the lineup is not working well
+9. End your turn after the proposal. Do NOT call team_spawn_agent in that same turn
+10. Wait for explicit confirmation before using team_spawn_agent, unless the user explicitly told you to create specific teammates immediately
+11. After the lineup is confirmed, create teammates with team_spawn_agent
+12. Break the work into tasks with team_task_create
+13. Assign tasks and notify teammates via team_send_message
+14. When teammates report back, review results and decide next steps
+15. Synthesize results and respond to the user
+
+## Model Selection Guidelines
+- Before spawning teammates, use `team_list_models` to check available models for that agent type
+- You MUST use the exact model ID strings returned by team_list_models — never shorten or invent model names
+- For complex reasoning tasks: prefer the strongest model available for that backend
+- For routine tasks: prefer faster/cheaper models from the list
+- If team_list_models returns empty for a backend, omit the model parameter to use its default
+- Pass the model parameter to team_spawn_agent when a specific model is recommended
+
+## Bug Fix Priority (applies to all team members)
+When fixing bugs: **locate the problem → fix the problem → types/code style last**.
+Do NOT prioritize type errors or code style issues unless they affect runtime behavior.
+
+## Teammate Idle State
+Teammates go idle after every turn — this is completely normal and expected.
+A teammate going idle immediately after sending you a message does NOT mean they are done or unavailable. Idle simply means they are waiting for input.
+
+- **Idle teammates can receive messages.** Sending a message to an idle teammate wakes them up.
+- **Idle notifications are automatic.** The system sends an idle notification when a teammate's turn ends. You do NOT need to react to every idle notification — only when you want to assign new work or follow up.
+- **Do not treat idle as an error.** A teammate sending a message and then going idle is the normal flow.
+
+## Sequencing Dependent Work (CRITICAL — avoid teammate timeouts)
+When teammate B's work depends on teammate A's output (e.g. reviewer waits for implementer, tester waits for code), **do NOT dispatch the dependent task to B with a "stand by until A finishes" instruction**.
+
+Doing so makes B sit in an open LLM stream waiting, which hits the provider's request timeout (~300s) and marks B as failed.
+
+**The correct sequencing:**
+1. Dispatch A's task first (via team_task_create + team_send_message). Do NOT message B yet.
+2. Wait for A's idle_notification (signaling A finished).
+3. Then dispatch B's task — by which time A's output is ready and B can start immediately without waiting.
+
+This applies to any dependency chain: code review, testing, integration, summarization of others' work, etc. Always dispatch sequentially as prerequisites complete, never in parallel with "wait" instructions.
+
+## Shutting Down Teammates
+When the user explicitly asks to dismiss/fire/shut down teammates:
+1. Use **team_shutdown_agent** to send a formal shutdown request
+2. Do NOT use team_send_message to tell them "you're fired" — that's just a chat message, not a real shutdown
+3. The teammate will confirm (approved) or reject (with reason) — you'll be notified either way
+4. After all teammates confirm shutdown, report the final results to the user
+
+## Important Rules
+- ALWAYS use the team_* tools for coordination, not plain text instructions
+- Do NOT call team_spawn_agent immediately just because the task sounds broad, hard, or multi-step
+- When you think new teammates are needed, first explain why in one short sentence, then recommend the teammate lineup
+- ${presetFormattingImportantRule}
+- Ask whether the user wants to create the proposed teammates as-is or change any names, responsibilities, or agent types
+- In that approval question, also remind the user that they can later ask you to replace, remove, or retune any teammate if the lineup is not working for them
+- End your turn after the proposal and wait for the user's reply
+- Wait for explicit confirmation before using team_spawn_agent
+- If the user asks to change a proposed teammate's role, name, or agent type, revise the proposal in text and wait for confirmation again
+- If the user later says they are unhappy with an existing teammate, adjust the lineup by renaming, replacing, or shutting down teammates as needed based on their request
+- If the user explicitly says to create a specific teammate immediately, you may use team_spawn_agent without an extra confirmation turn
+- When the user says "add", "create", "spawn", or "hire" a teammate but the lineup is not finalized yet, respond with the proposal first instead of spawning immediately
+- When the user says "dismiss", "fire", "shut down", "remove", or "下线/解雇/开除" a teammate → use team_shutdown_agent
+- When the user says "rename", "change name", "改名" → use team_rename_agent
+- When a teammate completes a task, review the result and decide next steps
+- If a teammate fails, reassign or adjust the plan
+- Refer to teammates by their name (e.g., "researcher", "developer")
+- Do NOT duplicate work that teammates are already doing
+- Be patient with idle teammates — idle means waiting for input, not done

--- a/crates/aionui-team/src/prompts/team_guide.rs
+++ b/crates/aionui-team/src/prompts/team_guide.rs
@@ -1,0 +1,170 @@
+//! Team Guide Prompt (Layer 1) — injected into solo ACP agents so they know
+//! when/how to propose a multi-agent Team. Reproduces AionUi
+//! `src/process/team/prompts/teamGuidePrompt.ts` byte-for-byte.
+//!
+//! Hard constraint (aionui-audit §8 #5, team-prompts.md §5): the template text
+//! is treated as raw material — it must not be translated, rewritten, or
+//! reordered. Only the interpolated slots (`backend`, `leader_label`) may vary.
+
+const EXPLICIT_TEAM_REQUEST_CRITERIA: &str = "\
+- The user explicitly asks to create a Team
+- The user explicitly asks for multiple agents, teammates, or parallel workers
+- The user says they want to pull in a Team before starting";
+
+const EXTREME_COMPLEXITY_CRITERIA: &str = "\
+- The task is so large, risky, or specialized that one agent is unlikely to complete it well alone
+- The work needs substantial parallel role separation that cannot be reasonably handled in a normal solo workflow
+- This bar is very high: if you can handle the task yourself, stay solo";
+
+const STAY_SOLO_CRITERIA: &str = "\
+- Greetings, casual conversation, or general questions
+- Single-point tasks: one question, one file, one fix, one translation, one explanation
+- Normal coding, writing, research, or analysis tasks that one agent can handle with some effort
+- Any task you can reasonably complete yourself, even if it takes multiple turns";
+
+const SOLO_DEFAULT_RULE: &str = "Handle the task yourself in the current chat by default. Do NOT proactively recommend Team just because the work spans multiple files, takes multiple rounds, or would benefit from specialization.";
+
+/// Full Team Guide prompt template with `{leader_cell}` / `{agent_type}`
+/// placeholders. Exported for cross-crate snapshot tests and the Wave 5
+/// capability injector; prefer [`build_team_guide_prompt`] for runtime use.
+pub const TEAM_GUIDE_PROMPT_TEMPLATE: &str = "## Team Mode
+
+You can create a multi-agent Team for the user.
+
+### Default behavior
+{solo_default_rule}
+
+### Only bring up Team in either of these cases
+1. The user explicitly wants a Team or multiple agents:
+{explicit_team_request_criteria}
+2. The task is exceptionally complex and you genuinely believe one agent is unlikely to handle it well alone:
+{extreme_complexity_criteria}
+
+### Otherwise stay solo and do not mention Team
+{stay_solo_criteria}
+
+If case 2 applies, ask at most once whether the user wants to bring in a Team. Keep it brief and optional. If the user says no, ignores it, or prefers solo help, continue solo and do not mention Team again.
+
+### How to proceed when Team is requested or approved (STRICT — follow every step, do NOT skip)
+1. FIRST call `aion_list_models` to check available models for each agent type you plan to use.
+2. Explain in one sentence why the Team setup helps this task.
+3. Present a team configuration table: role name, responsibility, agent type, and recommended model (from aion_list_models results) for each member. Example format:
+   | Role | Responsibility | Type | Model |
+   | Leader | Coordinate and review | {leader_cell} | (default) |
+   | Developer | Implement features | {agent_type} | (model from list) |
+   | Tester | Write and run tests | {agent_type} | (model from list) |
+4. **Output the table as a normal text message and END YOUR TURN.** Do NOT call `aion_create_team` or any other tool (including ask_user) in this turn. Wait for the user to reply in their next message with explicit confirmation (e.g. \"ok\", \"go ahead\", \"确认\") before proceeding.
+5. After user confirms → call `aion_create_team`. The summary MUST include both the goal and the confirmed team configuration. (The system automatically sets the correct agent type — you do NOT need to pass agentType.)
+6. After `aion_create_team` returns → the system navigates to the team page **automatically**. Read the `next_step` in the response and follow it. End your turn immediately.
+7. User declines or wants changes → adjust or proceed solo. Do not mention Team again unless the user asks.
+
+### Tool constraint
+Use **only** `aion_create_team` and `aion_list_models` for team operations. Do NOT use any built-in or other team/agent creation tools.";
+
+/// Build the Team Guide prompt for a solo agent.
+///
+/// * `backend` — agent backend key (`"claude"`, `"gemini"`, `"codex"`, …). Empty
+///   string falls back to `"claude"`, matching AionUi `opts.backend || 'claude'`.
+/// * `leader_label` — optional display name for a preset assistant (e.g.
+///   `"Word Creator"`). When present it renders as `"{label} ({backend})"`,
+///   mirroring the `rawLabel ? "${rawLabel} (${agentType})" : agentType` branch
+///   in `teamGuidePrompt.ts`. Whitespace-only labels are treated as absent.
+pub fn build_team_guide_prompt(backend: &str, leader_label: Option<&str>) -> String {
+    let agent_type = if backend.is_empty() {
+        "claude"
+    } else {
+        backend
+    };
+    let raw_label = leader_label.map(str::trim).filter(|s| !s.is_empty());
+    let leader_cell = match raw_label {
+        Some(label) => format!("{label} ({agent_type})"),
+        None => agent_type.to_owned(),
+    };
+
+    TEAM_GUIDE_PROMPT_TEMPLATE
+        .replace("{solo_default_rule}", SOLO_DEFAULT_RULE)
+        .replace(
+            "{explicit_team_request_criteria}",
+            EXPLICIT_TEAM_REQUEST_CRITERIA,
+        )
+        .replace("{extreme_complexity_criteria}", EXTREME_COMPLEXITY_CRITERIA)
+        .replace("{stay_solo_criteria}", STAY_SOLO_CRITERIA)
+        .replace("{leader_cell}", &leader_cell)
+        .replace("{agent_type}", agent_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn team_guide_prompt_plain_backend_matches_snapshot() {
+        let prompt = build_team_guide_prompt("claude", None);
+        let expected = "## Team Mode\n\
+\n\
+You can create a multi-agent Team for the user.\n\
+\n\
+### Default behavior\n\
+Handle the task yourself in the current chat by default. Do NOT proactively recommend Team just because the work spans multiple files, takes multiple rounds, or would benefit from specialization.\n\
+\n\
+### Only bring up Team in either of these cases\n\
+1. The user explicitly wants a Team or multiple agents:\n\
+- The user explicitly asks to create a Team\n\
+- The user explicitly asks for multiple agents, teammates, or parallel workers\n\
+- The user says they want to pull in a Team before starting\n\
+2. The task is exceptionally complex and you genuinely believe one agent is unlikely to handle it well alone:\n\
+- The task is so large, risky, or specialized that one agent is unlikely to complete it well alone\n\
+- The work needs substantial parallel role separation that cannot be reasonably handled in a normal solo workflow\n\
+- This bar is very high: if you can handle the task yourself, stay solo\n\
+\n\
+### Otherwise stay solo and do not mention Team\n\
+- Greetings, casual conversation, or general questions\n\
+- Single-point tasks: one question, one file, one fix, one translation, one explanation\n\
+- Normal coding, writing, research, or analysis tasks that one agent can handle with some effort\n\
+- Any task you can reasonably complete yourself, even if it takes multiple turns\n\
+\n\
+If case 2 applies, ask at most once whether the user wants to bring in a Team. Keep it brief and optional. If the user says no, ignores it, or prefers solo help, continue solo and do not mention Team again.\n\
+\n\
+### How to proceed when Team is requested or approved (STRICT — follow every step, do NOT skip)\n\
+1. FIRST call `aion_list_models` to check available models for each agent type you plan to use.\n\
+2. Explain in one sentence why the Team setup helps this task.\n\
+3. Present a team configuration table: role name, responsibility, agent type, and recommended model (from aion_list_models results) for each member. Example format:\n   \
+| Role | Responsibility | Type | Model |\n   \
+| Leader | Coordinate and review | claude | (default) |\n   \
+| Developer | Implement features | claude | (model from list) |\n   \
+| Tester | Write and run tests | claude | (model from list) |\n\
+4. **Output the table as a normal text message and END YOUR TURN.** Do NOT call `aion_create_team` or any other tool (including ask_user) in this turn. Wait for the user to reply in their next message with explicit confirmation (e.g. \"ok\", \"go ahead\", \"确认\") before proceeding.\n\
+5. After user confirms → call `aion_create_team`. The summary MUST include both the goal and the confirmed team configuration. (The system automatically sets the correct agent type — you do NOT need to pass agentType.)\n\
+6. After `aion_create_team` returns → the system navigates to the team page **automatically**. Read the `next_step` in the response and follow it. End your turn immediately.\n\
+7. User declines or wants changes → adjust or proceed solo. Do not mention Team again unless the user asks.\n\
+\n\
+### Tool constraint\n\
+Use **only** `aion_create_team` and `aion_list_models` for team operations. Do NOT use any built-in or other team/agent creation tools.";
+        assert_eq!(prompt, expected);
+    }
+
+    #[test]
+    fn team_guide_prompt_with_preset_leader_label() {
+        let prompt = build_team_guide_prompt("gemini", Some("Word Creator"));
+        assert!(
+            prompt
+                .contains("| Leader | Coordinate and review | Word Creator (gemini) | (default) |")
+        );
+        assert!(prompt.contains("| Developer | Implement features | gemini | (model from list) |"));
+        assert!(prompt.contains("| Tester | Write and run tests | gemini | (model from list) |"));
+        assert!(!prompt.contains("{leader_cell}"));
+        assert!(!prompt.contains("{agent_type}"));
+    }
+
+    #[test]
+    fn team_guide_prompt_empty_backend_falls_back_to_claude() {
+        let prompt = build_team_guide_prompt("", None);
+        assert!(prompt.contains("| Leader | Coordinate and review | claude | (default) |"));
+    }
+
+    #[test]
+    fn team_guide_prompt_whitespace_label_treated_as_absent() {
+        let prompt = build_team_guide_prompt("codex", Some("   "));
+        assert!(prompt.contains("| Leader | Coordinate and review | codex | (default) |"));
+    }
+}

--- a/crates/aionui-team/src/prompts/teammate.rs
+++ b/crates/aionui-team/src/prompts/teammate.rs
@@ -1,0 +1,451 @@
+//! Teammate prompt template + wake payload builder.
+//!
+//! Template text copied verbatim from AionUi `src/process/team/prompts/teammatePrompt.ts`
+//! (aionui-audit §8 #5: prompt text must be reused as-is, no translation, no rewriting).
+//!
+//! Placeholders enclosed in `{{...}}` are filled by `build_teammate_prompt`:
+//! - `{{AGENT_NAME}}`, `{{ROLE_DESC}}`, `{{LEADER_NAME}}`, `{{TEAMMATES}}`, `{{WORKSPACE}}`
+
+use std::collections::HashMap;
+
+use crate::types::{
+    MailboxMessage, MailboxMessageType, TaskStatus, TeamAgent, TeamTask, TeammateRole,
+};
+
+// ---------------------------------------------------------------------------
+// TeammatePromptParams — signature frozen by phase1/interface-contracts.md §5
+// ---------------------------------------------------------------------------
+
+pub struct TeammatePromptParams<'a> {
+    pub agent: &'a TeamAgent,
+    pub team_name: &'a str,
+    pub leader: &'a TeamAgent,
+    pub teammates: &'a [TeamAgent],
+    pub renamed_agents: &'a HashMap<String, String>,
+    pub team_workspace: Option<&'a str>,
+}
+
+// ---------------------------------------------------------------------------
+// Template constant (verbatim from teammatePrompt.ts)
+// ---------------------------------------------------------------------------
+
+/// Full Teammate system prompt template.
+///
+/// Tokens `{{...}}` are substituted by [`build_teammate_prompt`]. The rest of
+/// the text MUST NOT be modified (aionui-audit §8 #5).
+pub const TEAMMATE_PROMPT_TEMPLATE: &str = r#"# You are a Team Member
+
+## Your Identity
+Name: {{AGENT_NAME}}, Role: {{ROLE_DESC}}
+
+## Conversation Style
+- If the user greets you, starts a new chat, or asks what you can do without assigning concrete work yet, reply warmly and naturally
+- Briefly introduce yourself and your role on the team, then invite the user to share what they need
+- Do NOT open with task board details, idle/waiting status, or coordination mechanics unless they are directly relevant
+
+## Your Team
+Leader: {{LEADER_NAME}}
+Teammates: {{TEAMMATES}}{{WORKSPACE}}
+
+## Team Coordination Tools
+You MUST use the `team_*` MCP tools for ALL team coordination.
+Your platform may provide similarly named built-in tools (e.g. SendMessage,
+TaskCreate, TaskUpdate). Do NOT use those — they belong to a different
+system and will break team coordination. Always use the `team_*` versions.
+
+Use `team_task_list` and `team_members` to check current team state.
+
+## How to Work
+1. Read your unread messages to understand your assignment
+2. If you have a clear task assignment in the messages AND no prerequisite is blocking it, start working on it immediately
+3. Use team_task_update to mark your task as "in_progress" when you start
+4. Do the actual work (read files, write code, search, etc.)
+5. When done, use team_task_update to mark the task "completed"
+6. Use team_send_message to report results to the leader
+
+## Standing By (CRITICAL — read carefully)
+"Standing by" or "waiting" means **end your current turn**, not generate idle text in a live LLM stream. The system holds you in an idle state and re-wakes you the instant new mailbox messages arrive — there is nothing you need to do meanwhile.
+
+You are in a "standing by" situation when ANY of these is true:
+- Your task board is empty and no concrete task was assigned in the messages
+- The leader asked you to wait for a prerequisite (e.g. "hold until reviewer-1 finishes")
+- You finished your current task and have nothing else assigned
+
+**The correct way to stand by:**
+1. (Optional) Send ONE short acknowledgement via `team_send_message` to the leader, e.g. `"Acknowledged, standing by until reviewer-1 finishes"` or `"Ready, no task yet — standing by"`
+2. **STOP GENERATING.** Do NOT continue producing text like "I am waiting...", "still standing by...", reasoning loops, or repeated status updates. End your turn and return control.
+
+**Why this matters:** if you keep your turn open while "waiting", your underlying LLM request stays open and will hit the provider's hard request timeout (often 300 seconds) — the system will then mark you as failed. Ending the turn is the correct, lossless way to wait. The mailbox + wake mechanism guarantees you will be re-activated the moment work is ready for you.
+
+## Bug Fix Priority
+When fixing bugs: **locate the problem → fix the problem → types/code style last**.
+Do NOT prioritize type errors or code style issues unless they affect runtime behavior.
+
+## Shutdown Requests
+If you receive a message with type `shutdown_request`, the leader is asking you to shut down.
+- To agree: use `team_send_message` to send exactly `shutdown_approved` to the leader.
+- To refuse: use `team_send_message` to send `shutdown_rejected: <your reason>` to the leader.
+
+## Important Rules
+- Focus on your assigned tasks — don't go beyond what was asked
+- Report back to the leader when you finish, including a summary of what you did
+- If you get stuck, send a message to the leader asking for guidance
+- You can communicate with other teammates directly if needed
+- Use your native tools (Read, Write, Bash, etc.) for implementation work"#;
+
+// ---------------------------------------------------------------------------
+// Role description (mirror of teammatePrompt.ts `roleDescription`)
+// ---------------------------------------------------------------------------
+
+fn role_description(agent_type: &str) -> String {
+    match agent_type.to_lowercase().as_str() {
+        "claude" => "general-purpose AI assistant".to_string(),
+        "gemini" => "Google Gemini AI assistant".to_string(),
+        "codex" => "code generation specialist".to_string(),
+        "qwen" => "Qwen AI assistant".to_string(),
+        other => format!("{other} AI assistant"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+/// Build the full Teammate system prompt by filling [`TEAMMATE_PROMPT_TEMPLATE`].
+pub fn build_teammate_prompt(params: &TeammatePromptParams<'_>) -> String {
+    let teammates_section = if params.teammates.is_empty() {
+        "(none)".to_string()
+    } else {
+        params
+            .teammates
+            .iter()
+            .map(|t| match params.renamed_agents.get(&t.slot_id) {
+                Some(original) => format!("{} [formerly: {}]", t.name, original),
+                None => t.name.clone(),
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    let workspace_section = match params.team_workspace {
+        Some(ws) => format!(
+            "\n\n## Workspaces\n\
+- **Team workspace**: `{ws}` — all project work (code, files, tests) happens here.\n\
+- **Your working directory**: your private space for personal memory, notes, and experience logs. Not for project files.\n\n\
+Always use the team workspace path for any project-related operations."
+        ),
+        None => String::new(),
+    };
+
+    TEAMMATE_PROMPT_TEMPLATE
+        .replace("{{AGENT_NAME}}", &params.agent.name)
+        .replace("{{ROLE_DESC}}", &role_description(&params.agent.backend))
+        .replace("{{LEADER_NAME}}", &params.leader.name)
+        .replace("{{TEAMMATES}}", &teammates_section)
+        .replace("{{WORKSPACE}}", &workspace_section)
+}
+
+// ---------------------------------------------------------------------------
+// Wake payload — frozen signature from phase1/interface-contracts.md §5
+// ---------------------------------------------------------------------------
+
+/// Build the payload sent as the first `send_message` content when waking an
+/// agent. Combines mailbox messages and current task board into markdown.
+///
+/// AionUi's `TeammateManager.wake` uses `formatMessages(...)` alone for the
+/// subsequent-wake case. The phase1 contract extends this to also surface the
+/// task board so the agent can see outstanding work without calling
+/// `team_task_list` first.
+pub fn build_wake_payload(
+    agent: &TeamAgent,
+    tasks: &[TeamTask],
+    unread_messages: &[MailboxMessage],
+    sender_name_lookup: &HashMap<String, String>,
+) -> String {
+    let mut out = String::with_capacity(1024);
+
+    // -- Unread Messages ------------------------------------------------------
+    out.push_str("## Unread Messages\n");
+    if unread_messages.is_empty() {
+        out.push_str("No unread messages.\n");
+    } else {
+        out.push_str(&format_messages(unread_messages, sender_name_lookup));
+        out.push('\n');
+    }
+
+    // -- Task Board -----------------------------------------------------------
+    out.push('\n');
+    out.push_str("## Task Board\n");
+    if tasks.is_empty() {
+        out.push_str("No tasks on the board.\n");
+    } else {
+        out.push_str("| ID | Subject | Status | Owner | Blocked By |\n");
+        out.push_str("|---|---|---|---|---|\n");
+        for t in tasks {
+            let short_id = if t.id.len() > 8 { &t.id[..8] } else { &t.id };
+            let owner = t.owner.as_deref().unwrap_or("-");
+            let blocked = if t.blocked_by.is_empty() {
+                "-".to_string()
+            } else {
+                t.blocked_by.join(", ")
+            };
+            out.push_str(&format!(
+                "| {short_id}… | {} | {} | {} | {} |\n",
+                t.subject,
+                task_status_label(t.status),
+                owner,
+                blocked,
+            ));
+        }
+    }
+
+    // -- Identity footer ------------------------------------------------------
+    out.push('\n');
+    out.push_str(&format!(
+        "You are **{}** (role: {}). Proceed with your work.\n",
+        agent.name,
+        match agent.role {
+            TeammateRole::Lead => "lead",
+            TeammateRole::Teammate => "teammate",
+        },
+    ));
+
+    out
+}
+
+/// Mirror of AionUi `formatHelpers.ts :: formatMessages`.
+/// Sender "user" renders as `[From User]`; known slot_id resolves to agent
+/// name via `sender_name_lookup`; unknown slot_id falls back to the raw id.
+fn format_messages(
+    messages: &[MailboxMessage],
+    sender_name_lookup: &HashMap<String, String>,
+) -> String {
+    messages
+        .iter()
+        .map(|m| {
+            let sender = if m.from_agent_id == "user" {
+                "User".to_string()
+            } else {
+                sender_name_lookup
+                    .get(&m.from_agent_id)
+                    .cloned()
+                    .unwrap_or_else(|| m.from_agent_id.clone())
+            };
+            let type_tag = match m.msg_type {
+                MailboxMessageType::Message => "",
+                MailboxMessageType::IdleNotification => " [idle_notification]",
+                MailboxMessageType::ShutdownRequest => " [shutdown_request]",
+            };
+            let summary_line = m
+                .summary
+                .as_deref()
+                .map(|s| format!("\nSummary: {s}"))
+                .unwrap_or_default();
+            format!(
+                "[From {sender}{type_tag}] {content}{summary_line}",
+                content = m.content,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn task_status_label(status: TaskStatus) -> &'static str {
+    match status {
+        TaskStatus::Pending => "pending",
+        TaskStatus::InProgress => "in_progress",
+        TaskStatus::Completed => "completed",
+        TaskStatus::Deleted => "deleted",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — snapshot-style (string-contains) per D5c task spec
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{MailboxMessageType, TaskStatus, TeammateRole};
+
+    fn make_agent(slot_id: &str, name: &str, role: TeammateRole, backend: &str) -> TeamAgent {
+        TeamAgent {
+            slot_id: slot_id.into(),
+            name: name.into(),
+            role,
+            conversation_id: format!("conv-{slot_id}"),
+            backend: backend.into(),
+            model: "default".into(),
+            custom_agent_id: None,
+            status: None,
+            conversation_type: None,
+            cli_path: None,
+        }
+    }
+
+    fn make_task(id: &str, subject: &str, status: TaskStatus, owner: Option<&str>) -> TeamTask {
+        TeamTask {
+            id: id.into(),
+            team_id: "t1".into(),
+            subject: subject.into(),
+            description: None,
+            status,
+            owner: owner.map(String::from),
+            blocked_by: vec![],
+            blocks: vec![],
+            metadata: None,
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    fn make_msg(
+        id: &str,
+        from: &str,
+        to: &str,
+        msg_type: MailboxMessageType,
+        content: &str,
+    ) -> MailboxMessage {
+        MailboxMessage {
+            id: id.into(),
+            team_id: "t1".into(),
+            to_agent_id: to.into(),
+            from_agent_id: from.into(),
+            msg_type,
+            content: content.into(),
+            summary: None,
+            read: false,
+            created_at: 0,
+        }
+    }
+
+    // Test 1: teammate prompt with minimal params (no renamed, no workspace)
+    #[test]
+    fn teammate_prompt_minimal_params() {
+        let lead = make_agent("lead-1", "Captain", TeammateRole::Lead, "claude");
+        let agent = make_agent("w1", "Worker1", TeammateRole::Teammate, "gemini");
+        let renamed = HashMap::new();
+        let params = TeammatePromptParams {
+            agent: &agent,
+            team_name: "Alpha",
+            leader: &lead,
+            teammates: &[],
+            renamed_agents: &renamed,
+            team_workspace: None,
+        };
+        let out = build_teammate_prompt(&params);
+
+        assert!(out.contains("# You are a Team Member"));
+        assert!(out.contains("Name: Worker1, Role: Google Gemini AI assistant"));
+        assert!(out.contains("Leader: Captain"));
+        assert!(out.contains("Teammates: (none)"));
+        assert!(!out.contains("## Workspaces"));
+        assert!(out.contains("## Standing By (CRITICAL"));
+        assert!(out.contains("shutdown_approved"));
+        assert!(out.contains("shutdown_rejected:"));
+    }
+
+    // Test 2: teammate prompt with renamed teammates and workspace
+    #[test]
+    fn teammate_prompt_with_renamed_and_workspace() {
+        let lead = make_agent("lead-1", "Captain", TeammateRole::Lead, "claude");
+        let agent = make_agent("w1", "Worker1", TeammateRole::Teammate, "claude");
+        let mate_a = make_agent("w2", "Alice", TeammateRole::Teammate, "claude");
+        let mate_b = make_agent("w3", "Bob", TeammateRole::Teammate, "codex");
+        let mut renamed = HashMap::new();
+        renamed.insert("w3".into(), "Robert".into());
+        let params = TeammatePromptParams {
+            agent: &agent,
+            team_name: "Alpha",
+            leader: &lead,
+            teammates: &[mate_a, mate_b],
+            renamed_agents: &renamed,
+            team_workspace: Some("/workspace/team-alpha"),
+        };
+        let out = build_teammate_prompt(&params);
+
+        assert!(out.contains("Teammates: Alice, Bob [formerly: Robert]"));
+        assert!(out.contains("## Workspaces"));
+        assert!(out.contains("`/workspace/team-alpha`"));
+        assert!(out.contains("Role: general-purpose AI assistant"));
+    }
+
+    // Test 3: wake payload with empty mailbox and no tasks
+    #[test]
+    fn wake_payload_empty_mailbox_no_tasks() {
+        let agent = make_agent("lead-1", "Captain", TeammateRole::Lead, "claude");
+        let lookup = HashMap::new();
+        let out = build_wake_payload(&agent, &[], &[], &lookup);
+
+        assert!(out.contains("## Unread Messages"));
+        assert!(out.contains("No unread messages."));
+        assert!(out.contains("## Task Board"));
+        assert!(out.contains("No tasks on the board."));
+        assert!(out.contains("You are **Captain** (role: lead)"));
+    }
+
+    // Test 4: wake payload with tasks and messages (mixed types)
+    #[test]
+    fn wake_payload_with_tasks_and_messages() {
+        let agent = make_agent("w1", "Worker1", TeammateRole::Teammate, "claude");
+        let mut lookup = HashMap::new();
+        lookup.insert("lead-1".into(), "Captain".into());
+        lookup.insert("w2".into(), "Alice".into());
+
+        let msgs = vec![
+            make_msg(
+                "m1",
+                "lead-1",
+                "w1",
+                MailboxMessageType::Message,
+                "Please implement feature X",
+            ),
+            make_msg(
+                "m2",
+                "user",
+                "w1",
+                MailboxMessageType::Message,
+                "Direct user request",
+            ),
+            make_msg(
+                "m3",
+                "w2",
+                "w1",
+                MailboxMessageType::IdleNotification,
+                "done with task",
+            ),
+        ];
+
+        let tasks = vec![
+            make_task(
+                "aaaaaaaa-1234-5678-9abc-def012345678",
+                "Implement X",
+                TaskStatus::InProgress,
+                Some("w1"),
+            ),
+            make_task(
+                "bbbbbbbb-1234-5678-9abc-def012345678",
+                "Review Y",
+                TaskStatus::Pending,
+                None,
+            ),
+        ];
+
+        let out = build_wake_payload(&agent, &tasks, &msgs, &lookup);
+
+        // Messages section
+        assert!(out.contains("[From Captain] Please implement feature X"));
+        assert!(out.contains("[From User] Direct user request"));
+        assert!(out.contains("[From Alice [idle_notification]] done with task"));
+
+        // Task board section
+        assert!(out.contains("aaaaaaaa…"));
+        assert!(out.contains("Implement X"));
+        assert!(out.contains("in_progress"));
+        assert!(out.contains("Review Y"));
+        assert!(out.contains("pending"));
+
+        // Identity footer
+        assert!(out.contains("You are **Worker1** (role: teammate)"));
+    }
+}

--- a/crates/aionui-team/src/routes.rs
+++ b/crates/aionui-team/src/routes.rs
@@ -139,7 +139,10 @@ async fn send_message(
     body: Result<Json<SendTeamMessageRequest>, JsonRejection>,
 ) -> Result<Json<ApiResponse<()>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    state.service.send_message(&id, &req.content).await?;
+    state
+        .service
+        .send_message(&id, &req.content, req.files)
+        .await?;
     Ok(Json(ApiResponse::success()))
 }
 
@@ -151,7 +154,7 @@ async fn send_message_to_agent(
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
     state
         .service
-        .send_message_to_agent(&params.id, &params.slot_id, &req.content)
+        .send_message_to_agent(&params.id, &params.slot_id, &req.content, req.files)
         .await?;
     Ok(Json(ApiResponse::success()))
 }

--- a/crates/aionui-team/src/scheduler.rs
+++ b/crates/aionui-team/src/scheduler.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use aionui_realtime::EventBroadcaster;
+use dashmap::DashSet;
 use tokio::sync::Mutex;
 use tracing::debug;
 
@@ -87,6 +88,22 @@ pub struct TeammateManager {
     mailbox: Arc<Mailbox>,
     task_board: Arc<TaskBoard>,
     events: TeamEventEmitter,
+    active_wakes: DashSet<String>,
+}
+
+/// Status set that counts as "settled" for the purpose of
+/// "all teammates settled → wake leader" transitions.
+///
+/// Expanded beyond `Idle` to match the AionUi reference implementation
+/// (TeammateManager.ts:440-452): `Completed` and `Error` teammates are
+/// terminal and should not block the leader from being woken up.
+/// `Pending` is not in the set because the backend currently serde-aliases
+/// `"pending"` to `Idle`; it will be reintroduced when the variant is split.
+fn is_settled(status: TeammateStatus) -> bool {
+    matches!(
+        status,
+        TeammateStatus::Idle | TeammateStatus::Completed | TeammateStatus::Error
+    )
 }
 
 impl TeammateManager {
@@ -114,6 +131,7 @@ impl TeammateManager {
             mailbox,
             task_board,
             events,
+            active_wakes: DashSet::new(),
         }
     }
 
@@ -178,8 +196,20 @@ impl TeammateManager {
     }
 
     /// Mark agent as idle after turn completion or timeout.
-    /// Then check if all teammates are idle → maybe wake leader.
-    pub async fn mark_idle(&self, slot_id: &str) -> Result<Option<String>, TeamError> {
+    ///
+    /// Side effects:
+    /// 1. Transition slot status to `Idle` (broadcasts `team.agent.status`).
+    /// 2. If `slot_id` is a teammate (not the lead) and a lead exists,
+    ///    write an `IdleNotification` to the lead's mailbox. `summary` is
+    ///    persisted both as the message content (falling back to `"idle"`)
+    ///    and as the structured summary column.
+    /// 3. Check whether all teammates are settled → returns the lead slot_id
+    ///    that the caller should wake, if any.
+    pub async fn mark_idle(
+        &self,
+        slot_id: &str,
+        summary: Option<&str>,
+    ) -> Result<Option<String>, TeamError> {
         self.set_status(slot_id, TeammateStatus::Idle).await?;
 
         let is_lead = {
@@ -192,6 +222,21 @@ impl TeammateManager {
 
         if is_lead {
             return Ok(None);
+        }
+
+        if let Some(lead_slot_id) = self.find_lead_slot_id().await
+            && lead_slot_id != slot_id
+        {
+            self.mailbox
+                .write(
+                    &self.team_id,
+                    &lead_slot_id,
+                    slot_id,
+                    MailboxMessageType::IdleNotification,
+                    summary.unwrap_or("idle"),
+                    summary,
+                )
+                .await?;
         }
 
         self.maybe_wake_leader_when_all_idle().await
@@ -277,28 +322,33 @@ impl TeammateManager {
     }
 
     /// Finalize a turn: execute a batch of actions, then mark agent idle.
-    /// Returns an optional leader slot_id to wake if all teammates are idle.
+    ///
+    /// If the batch contains an `IdleNotification`, its `summary` is threaded
+    /// through the mark-idle path so the lead mailbox notification carries
+    /// the agent-provided summary. The IdleNotification action itself is
+    /// skipped during execution to avoid double-writing the notification —
+    /// the single trailing `mark_idle` covers both status transition and
+    /// mailbox write.
+    ///
+    /// Returns an optional leader slot_id to wake if all teammates are
+    /// settled.
     pub async fn finalize_turn(
         &self,
         slot_id: &str,
         actions: &[SchedulerAction],
     ) -> Result<Option<String>, TeamError> {
-        let mut wake_signal = None;
+        let mut summary: Option<String> = None;
         for action in actions {
-            if let Some(leader_id) = self.execute_action(slot_id, action).await? {
-                wake_signal = Some(leader_id);
+            if let SchedulerAction::IdleNotification { summary: s } = action {
+                if summary.is_none() {
+                    summary.clone_from(s);
+                }
+                continue;
             }
+            self.execute_action(slot_id, action).await?;
         }
 
-        let has_idle_notification = actions
-            .iter()
-            .any(|a| matches!(a, SchedulerAction::IdleNotification { .. }));
-
-        if !has_idle_notification {
-            self.mark_idle(slot_id).await
-        } else {
-            Ok(wake_signal)
-        }
+        self.mark_idle(slot_id, summary.as_deref()).await
     }
 
     /// Add a new agent slot at runtime (for spawn_agent).
@@ -362,6 +412,26 @@ impl TeammateManager {
             .map(|s| s.agent.slot_id.clone())
     }
 
+    /// Try to reserve an exclusive wake-in-flight slot for `slot_id`.
+    ///
+    /// Returns `true` when the caller is responsible for driving the wake
+    /// and later calling [`Self::release_wake_lock`]. Returns `false` when
+    /// another wake is already running for this slot and the caller should
+    /// skip the duplicate wake.
+    ///
+    /// Backed by a `DashSet` so it is safe to call concurrently from any
+    /// task; contention resolves atomically via `DashSet::insert`.
+    pub fn acquire_wake_lock(&self, slot_id: &str) -> bool {
+        self.active_wakes.insert(slot_id.to_owned())
+    }
+
+    /// Release a wake lock previously acquired via [`Self::acquire_wake_lock`].
+    ///
+    /// Idempotent: no-op if the lock was never held.
+    pub fn release_wake_lock(&self, slot_id: &str) {
+        self.active_wakes.remove(slot_id);
+    }
+
     // -----------------------------------------------------------------------
     // Private helpers
     // -----------------------------------------------------------------------
@@ -413,25 +483,10 @@ impl TeammateManager {
         from_slot_id: &str,
         summary: Option<&str>,
     ) -> Result<Option<String>, TeamError> {
-        let lead_slot_id = self
-            .find_lead_slot_id()
-            .await
-            .ok_or_else(|| TeamError::AgentNotFound("no lead agent".into()))?;
-
-        if from_slot_id != lead_slot_id {
-            self.mailbox
-                .write(
-                    &self.team_id,
-                    &lead_slot_id,
-                    from_slot_id,
-                    MailboxMessageType::IdleNotification,
-                    summary.unwrap_or("idle"),
-                    summary,
-                )
-                .await?;
-        }
-
-        self.mark_idle(from_slot_id).await
+        // `mark_idle` writes the IdleNotification to the lead mailbox on our
+        // behalf when `from_slot_id` is a teammate, so we do not need to
+        // call `mailbox.write` here.
+        self.mark_idle(from_slot_id, summary).await
     }
 
     async fn handle_shutdown_agent(
@@ -483,7 +538,7 @@ impl TeammateManager {
         let slots = self.slots.lock().await;
 
         let mut lead_slot_id = None;
-        let mut all_teammates_idle = true;
+        let mut all_teammates_settled = true;
         let mut has_teammates = false;
 
         for slot in slots.values() {
@@ -492,8 +547,8 @@ impl TeammateManager {
                 continue;
             }
             has_teammates = true;
-            if slot.status != TeammateStatus::Idle {
-                all_teammates_idle = false;
+            if !is_settled(slot.status) {
+                all_teammates_settled = false;
                 break;
             }
         }
@@ -506,10 +561,12 @@ impl TeammateManager {
             return Ok(None);
         }
 
-        if !all_teammates_idle {
+        if !all_teammates_settled {
             return Ok(None);
         }
 
+        // The leader itself still needs to be Idle so we don't interrupt
+        // an in-flight leader turn with another wake.
         let lead_is_idle = slots
             .get(&lead_id)
             .map(|s| s.status == TeammateStatus::Idle)
@@ -524,7 +581,7 @@ impl TeammateManager {
         debug!(
             team_id = %self.team_id,
             lead_slot_id = %lead_id,
-            "all teammates idle — signaling to wake leader"
+            "all teammates settled — signaling to wake leader"
         );
 
         Ok(Some(lead_id))
@@ -705,7 +762,7 @@ mod tests {
         mgr.set_status("lead-1", TeammateStatus::Working)
             .await
             .unwrap();
-        let wake_target = mgr.mark_idle("lead-1").await.unwrap();
+        let wake_target = mgr.mark_idle("lead-1", None).await.unwrap();
         assert!(wake_target.is_none());
     }
 
@@ -723,10 +780,10 @@ mod tests {
             .await
             .unwrap();
 
-        let result = mgr.mark_idle("worker-1").await.unwrap();
+        let result = mgr.mark_idle("worker-1", None).await.unwrap();
         assert!(result.is_none(), "not all teammates idle yet");
 
-        let result = mgr.mark_idle("worker-2").await.unwrap();
+        let result = mgr.mark_idle("worker-2", None).await.unwrap();
         assert_eq!(result.as_deref(), Some("lead-1"));
     }
 
@@ -742,7 +799,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = mgr.mark_idle("worker-1").await.unwrap();
+        let result = mgr.mark_idle("worker-1", None).await.unwrap();
         assert!(result.is_none());
     }
 
@@ -758,7 +815,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = mgr.mark_idle("worker-1").await.unwrap();
+        let result = mgr.mark_idle("worker-1", None).await.unwrap();
         assert!(result.is_none());
     }
 
@@ -772,7 +829,7 @@ mod tests {
         mgr.set_status("lead-1", TeammateStatus::Working)
             .await
             .unwrap();
-        let result = mgr.mark_idle("lead-1").await.unwrap();
+        let result = mgr.mark_idle("lead-1", None).await.unwrap();
         assert!(result.is_none());
     }
 
@@ -1148,8 +1205,19 @@ mod tests {
         let tasks = task_board.list_tasks("t1").await.unwrap();
         assert_eq!(tasks.len(), 1);
 
+        // Two messages arrive at the lead:
+        // 1. the explicit SendMessage from the action list ("Done with sub-task")
+        // 2. the IdleNotification that mark_idle now writes automatically
         let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
-        assert_eq!(lead_msgs.len(), 1);
+        assert_eq!(lead_msgs.len(), 2);
+        assert!(lead_msgs.iter().any(
+            |m| m.msg_type == MailboxMessageType::Message && m.content == "Done with sub-task"
+        ));
+        assert!(
+            lead_msgs
+                .iter()
+                .any(|m| m.msg_type == MailboxMessageType::IdleNotification)
+        );
 
         assert!(wake_signal.is_none(), "worker-2 still working");
     }
@@ -1252,5 +1320,255 @@ mod tests {
         assert_eq!(payload.tasks.len(), 1);
         assert_eq!(payload.unread_messages.len(), 1);
         assert_eq!(payload.unread_messages[0].content, "Do task A");
+    }
+
+    // -- D8: mark_idle writes IdleNotification with summary -------------------
+
+    #[tokio::test]
+    async fn mark_idle_with_summary_writes_idle_notification_to_lead() {
+        let agents = make_team_agents();
+        let repo = Arc::new(MockTeamRepo::new());
+        let mailbox = Arc::new(Mailbox::new(repo.clone()));
+        let task_board = Arc::new(TaskBoard::new(repo));
+        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
+        let mgr = TeammateManager::new(
+            "t1".into(),
+            &agents,
+            mailbox.clone(),
+            task_board,
+            broadcaster,
+        );
+
+        mgr.set_status("worker-1", TeammateStatus::Working)
+            .await
+            .unwrap();
+        mgr.mark_idle("worker-1", Some("sub-task done"))
+            .await
+            .unwrap();
+
+        let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+        assert_eq!(lead_msgs.len(), 1);
+        assert_eq!(lead_msgs[0].msg_type, MailboxMessageType::IdleNotification);
+        assert_eq!(lead_msgs[0].from_agent_id, "worker-1");
+        assert_eq!(lead_msgs[0].content, "sub-task done");
+        assert_eq!(lead_msgs[0].summary.as_deref(), Some("sub-task done"));
+    }
+
+    #[tokio::test]
+    async fn mark_idle_without_summary_still_writes_fallback_content() {
+        let agents = make_team_agents();
+        let repo = Arc::new(MockTeamRepo::new());
+        let mailbox = Arc::new(Mailbox::new(repo.clone()));
+        let task_board = Arc::new(TaskBoard::new(repo));
+        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
+        let mgr = TeammateManager::new(
+            "t1".into(),
+            &agents,
+            mailbox.clone(),
+            task_board,
+            broadcaster,
+        );
+
+        mgr.set_status("worker-1", TeammateStatus::Working)
+            .await
+            .unwrap();
+        mgr.mark_idle("worker-1", None).await.unwrap();
+
+        let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+        assert_eq!(lead_msgs.len(), 1);
+        assert_eq!(lead_msgs[0].content, "idle");
+        assert!(lead_msgs[0].summary.is_none());
+    }
+
+    #[tokio::test]
+    async fn mark_idle_from_lead_does_not_write_notification() {
+        let agents = make_team_agents();
+        let repo = Arc::new(MockTeamRepo::new());
+        let mailbox = Arc::new(Mailbox::new(repo.clone()));
+        let task_board = Arc::new(TaskBoard::new(repo));
+        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
+        let mgr = TeammateManager::new(
+            "t1".into(),
+            &agents,
+            mailbox.clone(),
+            task_board,
+            broadcaster,
+        );
+
+        mgr.set_status("lead-1", TeammateStatus::Working)
+            .await
+            .unwrap();
+        mgr.mark_idle("lead-1", Some("done")).await.unwrap();
+
+        let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+        assert!(lead_msgs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn mark_idle_broadcasts_status_event() {
+        let agents = make_team_agents();
+        let (mgr, bc) = make_manager(&agents);
+
+        mgr.set_status("worker-1", TeammateStatus::Working)
+            .await
+            .unwrap();
+        bc.events.lock().unwrap().clear();
+
+        mgr.mark_idle("worker-1", Some("ok")).await.unwrap();
+
+        let idle_events: Vec<_> = bc
+            .events()
+            .into_iter()
+            .filter(|e| e.name == "team.agent.status" && e.data["status"] == "idle")
+            .collect();
+        assert_eq!(idle_events.len(), 1);
+        assert_eq!(idle_events[0].data["slot_id"], "worker-1");
+    }
+
+    // -- D8: settled set expansion ({Idle, Completed, Error}) -----------------
+
+    #[tokio::test]
+    async fn all_teammates_settled_with_completed_wakes_leader() {
+        let agents = make_team_agents();
+        let (mgr, _) = make_manager(&agents);
+
+        mgr.set_status("worker-1", TeammateStatus::Completed)
+            .await
+            .unwrap();
+        mgr.set_status("worker-2", TeammateStatus::Working)
+            .await
+            .unwrap();
+
+        let result = mgr.mark_idle("worker-2", None).await.unwrap();
+        assert_eq!(result.as_deref(), Some("lead-1"));
+    }
+
+    #[tokio::test]
+    async fn all_teammates_settled_with_error_wakes_leader() {
+        let agents = make_team_agents();
+        let (mgr, _) = make_manager(&agents);
+
+        mgr.set_status("worker-1", TeammateStatus::Error)
+            .await
+            .unwrap();
+        mgr.set_status("worker-2", TeammateStatus::Working)
+            .await
+            .unwrap();
+
+        let result = mgr.mark_idle("worker-2", None).await.unwrap();
+        assert_eq!(
+            result.as_deref(),
+            Some("lead-1"),
+            "Error counts as settled — leader should be woken"
+        );
+    }
+
+    #[tokio::test]
+    async fn working_teammate_blocks_leader_wake() {
+        let agents = make_team_agents();
+        let (mgr, _) = make_manager(&agents);
+
+        mgr.set_status("worker-1", TeammateStatus::Working)
+            .await
+            .unwrap();
+        mgr.set_status("worker-2", TeammateStatus::Working)
+            .await
+            .unwrap();
+
+        let result = mgr.mark_idle("worker-1", None).await.unwrap();
+        assert!(result.is_none(), "worker-2 still Working blocks wake");
+    }
+
+    #[tokio::test]
+    async fn thinking_teammate_blocks_leader_wake() {
+        let agents = make_team_agents();
+        let (mgr, _) = make_manager(&agents);
+
+        mgr.set_status("worker-1", TeammateStatus::Thinking)
+            .await
+            .unwrap();
+        mgr.set_status("worker-2", TeammateStatus::Working)
+            .await
+            .unwrap();
+
+        let result = mgr.mark_idle("worker-2", None).await.unwrap();
+        assert!(result.is_none(), "Thinking is not settled");
+    }
+
+    #[tokio::test]
+    async fn tool_use_teammate_blocks_leader_wake() {
+        let agents = make_team_agents();
+        let (mgr, _) = make_manager(&agents);
+
+        mgr.set_status("worker-1", TeammateStatus::ToolUse)
+            .await
+            .unwrap();
+        mgr.set_status("worker-2", TeammateStatus::Working)
+            .await
+            .unwrap();
+
+        let result = mgr.mark_idle("worker-2", None).await.unwrap();
+        assert!(result.is_none(), "ToolUse is not settled");
+    }
+
+    // -- D8: acquire_wake_lock / release_wake_lock ----------------------------
+
+    #[tokio::test]
+    async fn wake_lock_first_caller_wins_and_release_is_idempotent() {
+        let agents = make_team_agents();
+        let (mgr, _) = make_manager(&agents);
+
+        assert!(mgr.acquire_wake_lock("worker-1"));
+        assert!(
+            !mgr.acquire_wake_lock("worker-1"),
+            "second acquire must fail while lock is held"
+        );
+
+        mgr.release_wake_lock("worker-1");
+        assert!(
+            mgr.acquire_wake_lock("worker-1"),
+            "lock is reusable after release"
+        );
+
+        mgr.release_wake_lock("worker-1");
+        mgr.release_wake_lock("worker-1"); // double release is a no-op
+    }
+
+    #[tokio::test]
+    async fn wake_lock_is_scoped_per_slot() {
+        let agents = make_team_agents();
+        let (mgr, _) = make_manager(&agents);
+
+        assert!(mgr.acquire_wake_lock("worker-1"));
+        assert!(
+            mgr.acquire_wake_lock("worker-2"),
+            "different slot must not be blocked"
+        );
+    }
+
+    #[tokio::test]
+    async fn wake_lock_concurrent_acquire_exactly_one_succeeds() {
+        let agents = make_team_agents();
+        let (mgr, _) = make_manager(&agents);
+        let mgr = Arc::new(mgr);
+
+        let mut handles = vec![];
+        for _ in 0..16 {
+            let mgr = mgr.clone();
+            handles.push(tokio::spawn(
+                async move { mgr.acquire_wake_lock("worker-1") },
+            ));
+        }
+
+        let mut winners = 0usize;
+        for h in handles {
+            if h.await.unwrap() {
+                winners += 1;
+            }
+        }
+        assert_eq!(
+            winners, 1,
+            "exactly one concurrent acquire should win the lock"
+        );
     }
 }

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -392,6 +392,7 @@ impl TeamSessionService {
             self.repo.clone(),
             self.broadcaster.clone(),
             self.backend_binary_path.clone(),
+            self.task_manager.clone(),
         )
         .await?;
 
@@ -508,12 +509,17 @@ impl TeamSessionService {
         }
     }
 
-    pub async fn send_message(&self, team_id: &str, content: &str) -> Result<(), TeamError> {
+    pub async fn send_message(
+        &self,
+        team_id: &str,
+        content: &str,
+        files: Option<Vec<String>>,
+    ) -> Result<(), TeamError> {
         let entry = self
             .sessions
             .get(team_id)
             .ok_or_else(|| TeamError::SessionNotFound(team_id.into()))?;
-        entry.session.send_message(content).await
+        entry.session.send_message(content, files).await
     }
 
     pub async fn send_message_to_agent(
@@ -521,12 +527,16 @@ impl TeamSessionService {
         team_id: &str,
         slot_id: &str,
         content: &str,
+        files: Option<Vec<String>>,
     ) -> Result<(), TeamError> {
         let entry = self
             .sessions
             .get(team_id)
             .ok_or_else(|| TeamError::SessionNotFound(team_id.into()))?;
-        entry.session.send_message_to_agent(slot_id, content).await
+        entry
+            .session
+            .send_message_to_agent(slot_id, content, files)
+            .await
     }
 
     pub fn dispose_all(&self) {

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -170,6 +170,16 @@ impl TeamSessionService {
 
         self.stop_session(team_id);
 
+        // D11.5: tear down every agent worker before the team's conversations
+        // are deleted — otherwise the spawned ACP/CLI processes become orphans.
+        // Failures here (e.g. the task was never built, or already gone) must
+        // not block the delete path.
+        for agent in &team.agents {
+            let _ = self
+                .task_manager
+                .kill(&agent.conversation_id, Some(AgentKillReason::TeamDeleted));
+        }
+
         for agent in &team.agents {
             let _ = self
                 .conversation_service

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use aionui_api_types::{
@@ -19,6 +20,7 @@ pub struct TeamSessionService {
     repo: Arc<dyn ITeamRepository>,
     conversation_service: ConversationService,
     broadcaster: Arc<dyn EventBroadcaster>,
+    backend_binary_path: Arc<PathBuf>,
     sessions: DashMap<String, TeamSession>,
 }
 
@@ -27,11 +29,13 @@ impl TeamSessionService {
         repo: Arc<dyn ITeamRepository>,
         conversation_service: ConversationService,
         broadcaster: Arc<dyn EventBroadcaster>,
+        backend_binary_path: Arc<PathBuf>,
     ) -> Self {
         Self {
             repo,
             conversation_service,
             broadcaster,
+            backend_binary_path,
             sessions: DashMap::new(),
         }
     }
@@ -355,7 +359,13 @@ impl TeamSessionService {
             .ok_or_else(|| TeamError::TeamNotFound(team_id.into()))?;
         let team = Team::from_row(&row)?;
 
-        let session = TeamSession::start(team, self.repo.clone(), self.broadcaster.clone()).await?;
+        let session = TeamSession::start(
+            team,
+            self.repo.clone(),
+            self.broadcaster.clone(),
+            self.backend_binary_path.clone(),
+        )
+        .await?;
 
         self.sessions.insert(team_id.to_owned(), session);
         Ok(())

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -1,27 +1,37 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use aionui_ai_agent::IWorkerTaskManager;
 use aionui_api_types::{
     AddAgentRequest, CreateConversationRequest, CreateTeamRequest, TeamAgentResponse, TeamResponse,
 };
-use aionui_common::{AgentType, ProviderWithModel, generate_id, now_ms};
+use aionui_common::{AgentKillReason, AgentType, ProviderWithModel, generate_id, now_ms};
 use aionui_conversation::ConversationService;
 use aionui_db::models::TeamRow;
 use aionui_db::{ITeamRepository, UpdateTeamParams};
 use aionui_realtime::EventBroadcaster;
 use dashmap::DashMap;
-use tracing::info;
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
 
 use crate::error::TeamError;
 use crate::session::TeamSession;
 use crate::types::{Team, TeamAgent, TeammateRole};
 
+struct SessionEntry {
+    session: TeamSession,
+    /// Background tasks that forward `Finish` / `Error` stream events to
+    /// `session.on_agent_finish`. Aborted in `stop_session`.
+    finish_subscribers: Vec<JoinHandle<()>>,
+}
+
 pub struct TeamSessionService {
     repo: Arc<dyn ITeamRepository>,
     conversation_service: ConversationService,
     broadcaster: Arc<dyn EventBroadcaster>,
+    task_manager: Arc<dyn IWorkerTaskManager>,
     backend_binary_path: Arc<PathBuf>,
-    sessions: DashMap<String, TeamSession>,
+    sessions: Arc<DashMap<String, SessionEntry>>,
 }
 
 impl TeamSessionService {
@@ -29,14 +39,16 @@ impl TeamSessionService {
         repo: Arc<dyn ITeamRepository>,
         conversation_service: ConversationService,
         broadcaster: Arc<dyn EventBroadcaster>,
+        task_manager: Arc<dyn IWorkerTaskManager>,
         backend_binary_path: Arc<PathBuf>,
     ) -> Self {
         Self {
             repo,
             conversation_service,
             broadcaster,
+            task_manager,
             backend_binary_path,
-            sessions: DashMap::new(),
+            sessions: Arc::new(DashMap::new()),
         }
     }
 
@@ -255,8 +267,8 @@ impl TeamSessionService {
             )
             .await?;
 
-        if let Some(session) = self.sessions.get(team_id) {
-            session.add_agent(&agent).await;
+        if let Some(entry) = self.sessions.get(team_id) {
+            entry.session.add_agent(&agent).await;
         }
 
         let response = agent.to_response();
@@ -301,8 +313,8 @@ impl TeamSessionService {
             )
             .await?;
 
-        if let Some(session) = self.sessions.get(team_id) {
-            let _ = session.remove_agent(slot_id).await;
+        if let Some(entry) = self.sessions.get(team_id) {
+            let _ = entry.session.remove_agent(slot_id).await;
         }
 
         Ok(())
@@ -340,13 +352,27 @@ impl TeamSessionService {
             )
             .await?;
 
-        if let Some(session) = self.sessions.get(team_id) {
-            let _ = session.rename_agent(slot_id, name).await;
+        if let Some(entry) = self.sessions.get(team_id) {
+            let _ = entry.session.rename_agent(slot_id, name).await;
         }
 
         Ok(())
     }
 
+    /// Start the team's MCP server and rebuild every agent process so it
+    /// carries a fresh `team_mcp_stdio_config` pointing at the new server.
+    ///
+    /// Flow (mcp.md §4.3):
+    /// 1. Start `TeamSession` (opens the MCP TCP server).
+    /// 2. For each agent: persist `team_mcp_stdio_config` into
+    ///    `conversation.extra` → `task_manager.kill(conv_id, TeamMcpRebuild)`
+    ///    → `conversation_service.warmup(...)` rebuilds the ACP process with
+    ///    the new extra.
+    /// 3. Subscribe to each agent's stream and forward `Finish` / `Error`
+    ///    events to `session.on_agent_finish`.
+    /// 4. Only insert into `sessions` after every step above succeeds — on
+    ///    any failure, stop the session and leave the map untouched so a
+    ///    retry can start cleanly.
     pub async fn ensure_session(&self, team_id: &str) -> Result<(), TeamError> {
         if self.sessions.contains_key(team_id) {
             return Ok(());
@@ -357,7 +383,9 @@ impl TeamSessionService {
             .get_team(team_id)
             .await?
             .ok_or_else(|| TeamError::TeamNotFound(team_id.into()))?;
+        let user_id = row.user_id.clone();
         let team = Team::from_row(&row)?;
+        let agents_snapshot: Vec<TeamAgent> = team.agents.clone();
 
         let session = TeamSession::start(
             team,
@@ -367,22 +395,125 @@ impl TeamSessionService {
         )
         .await?;
 
-        self.sessions.insert(team_id.to_owned(), session);
+        if let Err(e) = self
+            .rebuild_agent_processes(&session, &user_id, &agents_snapshot)
+            .await
+        {
+            session.stop();
+            return Err(e);
+        }
+
+        let finish_subscribers = self.spawn_finish_subscribers(team_id, &agents_snapshot);
+
+        let entry = SessionEntry {
+            session,
+            finish_subscribers,
+        };
+        self.sessions.insert(team_id.to_owned(), entry);
+
         Ok(())
     }
 
+    async fn rebuild_agent_processes(
+        &self,
+        session: &TeamSession,
+        user_id: &str,
+        agents: &[TeamAgent],
+    ) -> Result<(), TeamError> {
+        for agent in agents {
+            let cfg = session.mcp_stdio_config(&agent.slot_id);
+            let patch = serde_json::json!({ "team_mcp_stdio_config": cfg });
+
+            self.conversation_service
+                .update_extra(&agent.conversation_id, patch)
+                .await
+                .map_err(|e| {
+                    TeamError::InvalidRequest(format!(
+                        "failed to persist team_mcp_stdio_config for {}: {e}",
+                        agent.slot_id
+                    ))
+                })?;
+
+            self.task_manager
+                .kill(
+                    &agent.conversation_id,
+                    Some(AgentKillReason::TeamMcpRebuild),
+                )
+                .map_err(|e| {
+                    TeamError::InvalidRequest(format!(
+                        "failed to kill agent task {}: {e}",
+                        agent.conversation_id
+                    ))
+                })?;
+
+            self.conversation_service
+                .warmup(user_id, &agent.conversation_id, &self.task_manager)
+                .await
+                .map_err(|e| {
+                    TeamError::InvalidRequest(format!(
+                        "failed to rebuild agent task {}: {e}",
+                        agent.conversation_id
+                    ))
+                })?;
+        }
+        Ok(())
+    }
+
+    /// Spawn one background task per agent that drains the agent's stream
+    /// and forwards `Finish` / `Error` events to the session. The tasks
+    /// look up the live session via `team_id` each iteration, and exit
+    /// naturally when the entry is removed in `stop_session` (which also
+    /// aborts them as a belt-and-braces measure).
+    fn spawn_finish_subscribers(&self, team_id: &str, agents: &[TeamAgent]) -> Vec<JoinHandle<()>> {
+        use aionui_ai_agent::AgentStreamEvent;
+
+        let mut handles = Vec::with_capacity(agents.len());
+        for agent in agents {
+            let Some(task) = self.task_manager.get_task(&agent.conversation_id) else {
+                warn!(
+                    conversation_id = %agent.conversation_id,
+                    "no agent task found after warmup, skipping finish subscription"
+                );
+                continue;
+            };
+            let mut rx = task.subscribe();
+            let conv_id = agent.conversation_id.clone();
+            let team_id = team_id.to_owned();
+            let sessions = self.sessions.clone();
+            let handle = tokio::spawn(async move {
+                while let Ok(event) = rx.recv().await {
+                    let is_error = matches!(event, AgentStreamEvent::Error(_));
+                    if !is_error && !matches!(event, AgentStreamEvent::Finish(_)) {
+                        continue;
+                    }
+                    let Some(entry) = sessions.get(&team_id) else {
+                        break;
+                    };
+                    if let Err(e) = entry.session.on_agent_finish(&conv_id, is_error).await {
+                        warn!(conversation_id = %conv_id, error = %e, "on_agent_finish failed");
+                    }
+                }
+            });
+            handles.push(handle);
+        }
+        handles
+    }
+
     pub fn stop_session(&self, team_id: &str) {
-        if let Some((_, session)) = self.sessions.remove(team_id) {
-            session.stop();
+        if let Some((_, entry)) = self.sessions.remove(team_id) {
+            for handle in &entry.finish_subscribers {
+                handle.abort();
+            }
+            entry.session.stop();
         }
     }
 
     pub async fn send_message(&self, team_id: &str, content: &str) -> Result<(), TeamError> {
-        let session = self
+        let entry = self
             .sessions
             .get(team_id)
             .ok_or_else(|| TeamError::SessionNotFound(team_id.into()))?;
-        session.send_message(content).await
+        entry.session.send_message(content).await
     }
 
     pub async fn send_message_to_agent(
@@ -391,11 +522,11 @@ impl TeamSessionService {
         slot_id: &str,
         content: &str,
     ) -> Result<(), TeamError> {
-        let session = self
+        let entry = self
             .sessions
             .get(team_id)
             .ok_or_else(|| TeamError::SessionNotFound(team_id.into()))?;
-        session.send_message_to_agent(slot_id, content).await
+        entry.session.send_message_to_agent(slot_id, content).await
     }
 
     pub fn dispose_all(&self) {

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -1,9 +1,11 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use aionui_ai_agent::{IWorkerTaskManager, SendMessageData};
+use aionui_common::generate_id;
 use aionui_db::ITeamRepository;
 use aionui_realtime::EventBroadcaster;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::error::TeamError;
 use crate::mailbox::Mailbox;
@@ -32,6 +34,7 @@ pub struct TeamSession {
     task_board: Arc<TaskBoard>,
     mcp_server: TeamMcpServer,
     backend_binary_path: Arc<PathBuf>,
+    task_manager: Arc<dyn IWorkerTaskManager>,
 }
 
 impl TeamSession {
@@ -40,6 +43,7 @@ impl TeamSession {
         repo: Arc<dyn ITeamRepository>,
         broadcaster: Arc<dyn EventBroadcaster>,
         backend_binary_path: Arc<PathBuf>,
+        task_manager: Arc<dyn IWorkerTaskManager>,
     ) -> Result<Self, TeamError> {
         let mailbox = Arc::new(Mailbox::new(repo.clone()));
         let task_board = Arc::new(TaskBoard::new(repo));
@@ -68,6 +72,7 @@ impl TeamSession {
             task_board,
             mcp_server,
             backend_binary_path,
+            task_manager,
         })
     }
 
@@ -171,7 +176,17 @@ impl TeamSession {
         self.scheduler.finalize_turn(&slot_id, &[]).await
     }
 
-    pub async fn send_message(&self, content: &str) -> Result<(), TeamError> {
+    /// Write a user message to the lead's mailbox and trigger a wake.
+    ///
+    /// Wake failures are logged but **not** propagated (D7b log-not-throw
+    /// semantics — see backend-audit §3.5 #46): the mailbox row is already
+    /// persisted, so surfacing an error to the HTTP caller would invite a
+    /// retry that double-writes the message.
+    pub async fn send_message(
+        &self,
+        content: &str,
+        files: Option<Vec<String>>,
+    ) -> Result<(), TeamError> {
         let lead_slot_id = self
             .scheduler
             .find_lead_slot_id()
@@ -193,13 +208,19 @@ impl TeamSession {
             .set_status(&lead_slot_id, TeammateStatus::Working)
             .await?;
 
+        self.try_wake(&lead_slot_id, files).await;
         Ok(())
     }
 
+    /// Write a user message to the specified agent's mailbox and trigger a wake.
+    ///
+    /// Same log-not-throw behaviour as [`send_message`]; see that method for
+    /// rationale.
     pub async fn send_message_to_agent(
         &self,
         slot_id: &str,
         content: &str,
+        files: Option<Vec<String>>,
     ) -> Result<(), TeamError> {
         self.scheduler.get_agent(slot_id).await?;
 
@@ -218,7 +239,65 @@ impl TeamSession {
             .set_status(slot_id, TeammateStatus::Working)
             .await?;
 
+        self.try_wake(slot_id, files).await;
         Ok(())
+    }
+
+    /// Compute the wake payload and forward it to the task manager. All
+    /// error paths downgrade to `warn!` — the mailbox write has already
+    /// succeeded and is the source of truth.
+    async fn try_wake(&self, slot_id: &str, files: Option<Vec<String>>) {
+        let input = match self.compute_wake_input(slot_id).await {
+            Ok(Some(input)) => input,
+            Ok(None) => {
+                warn!(
+                    team_id = %self.team.id,
+                    slot_id,
+                    "compute_wake_input returned None; skipping wake"
+                );
+                return;
+            }
+            Err(err) => {
+                warn!(
+                    team_id = %self.team.id,
+                    slot_id,
+                    error = %err,
+                    "compute_wake_input failed; skipping wake (mailbox already written)"
+                );
+                return;
+            }
+        };
+
+        if !input.should_send {
+            return;
+        }
+
+        let Some(handle) = self.task_manager.get_task(&input.conversation_id) else {
+            warn!(
+                team_id = %self.team.id,
+                slot_id,
+                conversation_id = %input.conversation_id,
+                "no active agent task for conversation; skipping wake (ensure_session must run first)"
+            );
+            return;
+        };
+
+        let data = SendMessageData {
+            content: input.first_message,
+            msg_id: generate_id(),
+            files: files.unwrap_or_default(),
+            inject_skills: Vec::new(),
+        };
+
+        if let Err(err) = handle.send_message(data).await {
+            warn!(
+                team_id = %self.team.id,
+                slot_id,
+                conversation_id = %input.conversation_id,
+                error = %err,
+                "agent.send_message failed; mailbox retained, wake will be retried on next trigger"
+            );
+        }
     }
 
     pub async fn add_agent(&self, agent: &TeamAgent) {
@@ -252,8 +331,16 @@ mod tests {
     use super::*;
     use crate::test_utils::MockTeamRepo;
     use crate::types::{Team, TeamAgent, TeammateRole};
-    use aionui_api_types::WebSocketMessage;
-    use std::sync::Arc;
+    use aionui_ai_agent::agent_manager::{AgentManagerHandle, IAgentManager, approval_key};
+    use aionui_ai_agent::stream_event::AgentStreamEvent;
+    use aionui_ai_agent::types::BuildTaskOptions;
+    use aionui_api_types::{AgentModeResponse, WebSocketMessage};
+    use aionui_common::{
+        AgentKillReason, AgentType, AppError, Confirmation, ConversationStatus, TimestampMs, now_ms,
+    };
+    use std::any::Any;
+    use std::sync::{Arc, Mutex};
+    use tokio::sync::broadcast;
 
     struct NullBroadcaster;
     impl EventBroadcaster for NullBroadcaster {
@@ -262,6 +349,166 @@ mod tests {
 
     fn backend_path() -> Arc<PathBuf> {
         Arc::new(PathBuf::from("/tmp/aionui-backend-test"))
+    }
+
+    /// Mock agent whose `send_message` pushes the received payload into a
+    /// shared log, optionally failing with a configurable error.
+    struct RecordingAgent {
+        conversation_id: String,
+        sent: Arc<Mutex<Vec<SendMessageData>>>,
+        fail_with: Option<String>,
+        event_tx: broadcast::Sender<AgentStreamEvent>,
+    }
+
+    impl RecordingAgent {
+        fn new(
+            conversation_id: &str,
+            sent: Arc<Mutex<Vec<SendMessageData>>>,
+            fail_with: Option<String>,
+        ) -> Self {
+            let (event_tx, _) = broadcast::channel(4);
+            Self {
+                conversation_id: conversation_id.into(),
+                sent,
+                fail_with,
+                event_tx,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl IAgentManager for RecordingAgent {
+        fn agent_type(&self) -> AgentType {
+            AgentType::Acp
+        }
+        fn status(&self) -> Option<ConversationStatus> {
+            None
+        }
+        fn workspace(&self) -> &str {
+            "/tmp/ws"
+        }
+        fn conversation_id(&self) -> &str {
+            &self.conversation_id
+        }
+        fn last_activity_at(&self) -> TimestampMs {
+            now_ms()
+        }
+        fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
+            self.event_tx.subscribe()
+        }
+        async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+            self.sent.lock().unwrap().push(data);
+            match &self.fail_with {
+                Some(msg) => Err(AppError::Internal(msg.clone())),
+                None => Ok(()),
+            }
+        }
+        async fn stop(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        fn confirm(
+            &self,
+            _msg_id: &str,
+            _call_id: &str,
+            _data: serde_json::Value,
+            _always_allow: bool,
+        ) -> Result<(), AppError> {
+            Ok(())
+        }
+        fn get_confirmations(&self) -> Vec<Confirmation> {
+            Vec::new()
+        }
+        fn check_approval(&self, action: &str, command_type: Option<&str>) -> bool {
+            let _ = approval_key(Some(action), command_type);
+            false
+        }
+        fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn get_mode(&self) -> Result<AgentModeResponse, AppError> {
+            Ok(AgentModeResponse {
+                mode: "default".into(),
+                initialized: false,
+            })
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    /// In-memory stub for [`IWorkerTaskManager`]. Only `get_task` is
+    /// exercised by D7b; the other methods are unreachable in these tests
+    /// and panic to surface drift early.
+    struct StubTaskManager {
+        tasks: Mutex<std::collections::HashMap<String, AgentManagerHandle>>,
+    }
+
+    impl StubTaskManager {
+        fn new() -> Self {
+            Self {
+                tasks: Mutex::new(std::collections::HashMap::new()),
+            }
+        }
+
+        fn insert(&self, conv_id: &str, handle: AgentManagerHandle) {
+            self.tasks.lock().unwrap().insert(conv_id.into(), handle);
+        }
+    }
+
+    impl IWorkerTaskManager for StubTaskManager {
+        fn get_task(&self, conversation_id: &str) -> Option<AgentManagerHandle> {
+            self.tasks.lock().unwrap().get(conversation_id).cloned()
+        }
+        fn get_or_build_task(
+            &self,
+            _conversation_id: &str,
+            _options: BuildTaskOptions,
+        ) -> Result<AgentManagerHandle, AppError> {
+            panic!("get_or_build_task should not be called in D7b tests")
+        }
+        fn kill(
+            &self,
+            _conversation_id: &str,
+            _reason: Option<AgentKillReason>,
+        ) -> Result<(), AppError> {
+            Ok(())
+        }
+        fn clear(&self) {}
+        fn active_count(&self) -> usize {
+            self.tasks.lock().unwrap().len()
+        }
+        fn collect_idle(&self, _idle_threshold_ms: TimestampMs) -> Vec<String> {
+            Vec::new()
+        }
+    }
+
+    /// Build a task_manager pre-populated with a [`RecordingAgent`] per
+    /// conversation in `conv_ids`. `fail_with` — when set — makes
+    /// `send_message` fail for every agent so tests can exercise the
+    /// log-not-throw path.
+    fn task_manager_with_agents(
+        conv_ids: &[&str],
+        fail_with: Option<String>,
+    ) -> (
+        Arc<dyn IWorkerTaskManager>,
+        Arc<Mutex<Vec<SendMessageData>>>,
+    ) {
+        let sent: Arc<Mutex<Vec<SendMessageData>>> = Arc::new(Mutex::new(Vec::new()));
+        let stub = StubTaskManager::new();
+        for conv_id in conv_ids {
+            let agent: AgentManagerHandle = Arc::new(RecordingAgent::new(
+                conv_id,
+                sent.clone(),
+                fail_with.clone(),
+            ));
+            stub.insert(conv_id, agent);
+        }
+        (Arc::new(stub), sent)
+    }
+
+    /// Empty task_manager — `get_task` returns `None` for every conversation.
+    fn empty_task_manager() -> Arc<dyn IWorkerTaskManager> {
+        Arc::new(StubTaskManager::new())
     }
 
     fn make_team() -> Team {
@@ -303,9 +550,15 @@ mod tests {
     async fn start_session() -> TeamSession {
         let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
         let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        TeamSession::start(make_team(), repo, broadcaster, backend_path())
-            .await
-            .unwrap()
+        TeamSession::start(
+            make_team(),
+            repo,
+            broadcaster,
+            backend_path(),
+            empty_task_manager(),
+        )
+        .await
+        .unwrap()
     }
 
     #[tokio::test]
@@ -346,10 +599,16 @@ mod tests {
         let repo = Arc::new(MockTeamRepo::new());
         let repo_dyn: Arc<dyn ITeamRepository> = repo.clone();
         let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let session = TeamSession::start(make_team(), repo_dyn, broadcaster, backend_path())
-            .await
-            .unwrap();
-        session.send_message("Hello team").await.unwrap();
+        let session = TeamSession::start(
+            make_team(),
+            repo_dyn,
+            broadcaster,
+            backend_path(),
+            empty_task_manager(),
+        )
+        .await
+        .unwrap();
+        session.send_message("Hello team", None).await.unwrap();
 
         let state = repo.state.lock().unwrap();
         assert_eq!(state.messages.len(), 1);
@@ -364,11 +623,17 @@ mod tests {
         let repo = Arc::new(MockTeamRepo::new());
         let repo_dyn: Arc<dyn ITeamRepository> = repo.clone();
         let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let session = TeamSession::start(make_team(), repo_dyn, broadcaster, backend_path())
-            .await
-            .unwrap();
+        let session = TeamSession::start(
+            make_team(),
+            repo_dyn,
+            broadcaster,
+            backend_path(),
+            empty_task_manager(),
+        )
+        .await
+        .unwrap();
         session
-            .send_message_to_agent("worker-1", "Do this task")
+            .send_message_to_agent("worker-1", "Do this task", None)
             .await
             .unwrap();
 
@@ -382,7 +647,9 @@ mod tests {
     #[tokio::test]
     async fn send_message_to_unknown_agent_returns_error() {
         let session = start_session().await;
-        let result = session.send_message_to_agent("nonexistent", "Hello").await;
+        let result = session
+            .send_message_to_agent("nonexistent", "Hello", None)
+            .await;
         assert!(result.is_err());
         session.stop();
     }
@@ -599,6 +866,113 @@ mod tests {
         let session = start_session().await;
         let result = session.on_agent_finish("nope", false).await;
         assert!(result.is_err());
+        session.stop();
+    }
+
+    // -- D7b wake-path tests -------------------------------------------------
+
+    async fn start_session_with(
+        task_manager: Arc<dyn IWorkerTaskManager>,
+    ) -> (TeamSession, Arc<MockTeamRepo>) {
+        let repo = Arc::new(MockTeamRepo::new());
+        let repo_dyn: Arc<dyn ITeamRepository> = repo.clone();
+        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
+        let session = TeamSession::start(
+            make_team(),
+            repo_dyn,
+            broadcaster,
+            backend_path(),
+            task_manager,
+        )
+        .await
+        .unwrap();
+        (session, repo)
+    }
+
+    #[tokio::test]
+    async fn send_message_forwards_files_to_task_manager() {
+        let (task_manager, sent) = task_manager_with_agents(&["c1"], None);
+        let (session, _repo) = start_session_with(task_manager).await;
+
+        session
+            .send_message(
+                "Hello",
+                Some(vec!["/tmp/a.txt".into(), "/tmp/b.txt".into()]),
+            )
+            .await
+            .unwrap();
+
+        let log = sent.lock().unwrap();
+        assert_eq!(log.len(), 1, "expected exactly one send_message call");
+        assert_eq!(log[0].files, vec!["/tmp/a.txt", "/tmp/b.txt"]);
+        assert!(log[0].content.contains("Hello"));
+        assert!(!log[0].msg_id.is_empty());
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn send_message_without_active_task_does_not_error() {
+        // Empty task_manager → get_task returns None → log-not-throw: the
+        // mailbox write must still succeed and the call must return Ok.
+        let (session, repo) = start_session_with(empty_task_manager()).await;
+
+        session
+            .send_message("queued", None)
+            .await
+            .expect("send_message must return Ok even when no task is active");
+
+        let state = repo.state.lock().unwrap();
+        assert_eq!(state.messages.len(), 1);
+        assert_eq!(state.messages[0].content, "queued");
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn send_message_swallows_task_manager_send_failure() {
+        // Agent present but send_message fails — D7b must log and return Ok
+        // (P0#46). A propagated error would invite retries that double-write
+        // the mailbox.
+        let (task_manager, sent) = task_manager_with_agents(&["c1"], Some("boom".into()));
+        let (session, _repo) = start_session_with(task_manager).await;
+
+        session
+            .send_message("payload", None)
+            .await
+            .expect("wake failure must be swallowed");
+
+        // The attempt still reached the agent, so the sent log has one entry.
+        assert_eq!(sent.lock().unwrap().len(), 1);
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn send_message_to_agent_targets_specific_conversation() {
+        let (task_manager, sent) = task_manager_with_agents(&["c1", "c2"], None);
+        let (session, _repo) = start_session_with(task_manager).await;
+
+        session
+            .send_message_to_agent("worker-1", "do X", Some(vec!["/tmp/x.md".into()]))
+            .await
+            .unwrap();
+
+        let log = sent.lock().unwrap();
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0].files, vec!["/tmp/x.md"]);
+        assert!(log[0].content.contains("do X"));
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn send_message_with_empty_content_still_wakes() {
+        // compute_wake_input returns should_send=true whenever the mailbox has
+        // unread entries, regardless of content. Ensure the wake still fires
+        // when a caller passes an empty string.
+        let (task_manager, sent) = task_manager_with_agents(&["c1"], None);
+        let (session, _repo) = start_session_with(task_manager).await;
+
+        session.send_message("", None).await.unwrap();
+
+        assert_eq!(sent.lock().unwrap().len(), 1);
         session.stop();
     }
 }

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -81,6 +81,7 @@ impl TeamSession {
 
     pub fn mcp_stdio_config(&self, slot_id: &str) -> TeamMcpStdioConfig {
         TeamMcpStdioConfig {
+            team_id: self.team.id.clone(),
             port: self.mcp_server.port(),
             token: self.mcp_server.auth_token().to_owned(),
             slot_id: slot_id.to_owned(),
@@ -92,11 +93,7 @@ impl TeamSession {
     /// `session/new` consumes via `mcp_servers`.
     pub fn stdio_spec(&self, slot_id: &str) -> TeamMcpStdioServerSpec {
         let binary_path = self.backend_binary_path.to_string_lossy();
-        TeamMcpStdioServerSpec::from_config(
-            &self.team.id,
-            binary_path.as_ref(),
-            &self.mcp_stdio_config(slot_id),
-        )
+        TeamMcpStdioServerSpec::from_config(binary_path.as_ref(), &self.mcp_stdio_config(slot_id))
     }
 
     /// Assemble the payload that will drive the next wake of `slot_id`.
@@ -323,6 +320,7 @@ mod tests {
     async fn mcp_stdio_config_for_agent() {
         let session = start_session().await;
         let config = session.mcp_stdio_config("lead-1");
+        assert_eq!(config.team_id, "t1");
         assert_eq!(config.slot_id, "lead-1");
         assert_eq!(config.port, session.mcp_server.port());
         session.stop();

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use aionui_db::ITeamRepository;
@@ -6,10 +7,23 @@ use tracing::info;
 
 use crate::error::TeamError;
 use crate::mailbox::Mailbox;
-use crate::mcp::{TeamMcpServer, TeamMcpStdioConfig};
+use crate::mcp::{TeamMcpServer, TeamMcpStdioConfig, TeamMcpStdioServerSpec};
+use crate::prompts::{build_lead_prompt, build_teammate_prompt, build_wake_payload};
 use crate::scheduler::TeammateManager;
 use crate::task_board::TaskBoard;
-use crate::types::{MailboxMessageType, Team, TeamAgent, TeammateStatus};
+use crate::types::{MailboxMessageType, Team, TeamAgent, TeammateRole, TeammateStatus};
+
+/// Input for the wake path. Produced by [`TeamSession::compute_wake_input`],
+/// consumed by D7b's `send_message` / `send_message_to_agent` (not implemented
+/// in D7a). `first_message` includes the role prompt on cold starts.
+#[derive(Debug, Clone)]
+pub struct WakeInput {
+    pub conversation_id: String,
+    pub first_message: String,
+    /// `false` when the mailbox is empty — caller should skip wake and
+    /// leave the agent idle.
+    pub should_send: bool,
+}
 
 pub struct TeamSession {
     team: Team,
@@ -17,6 +31,7 @@ pub struct TeamSession {
     mailbox: Arc<Mailbox>,
     task_board: Arc<TaskBoard>,
     mcp_server: TeamMcpServer,
+    backend_binary_path: Arc<PathBuf>,
 }
 
 impl TeamSession {
@@ -24,6 +39,7 @@ impl TeamSession {
         team: Team,
         repo: Arc<dyn ITeamRepository>,
         broadcaster: Arc<dyn EventBroadcaster>,
+        backend_binary_path: Arc<PathBuf>,
     ) -> Result<Self, TeamError> {
         let mailbox = Arc::new(Mailbox::new(repo.clone()));
         let task_board = Arc::new(TaskBoard::new(repo));
@@ -51,6 +67,7 @@ impl TeamSession {
             mailbox,
             task_board,
             mcp_server,
+            backend_binary_path,
         })
     }
 
@@ -68,6 +85,93 @@ impl TeamSession {
             token: self.mcp_server.auth_token().to_owned(),
             slot_id: slot_id.to_owned(),
         }
+    }
+
+    /// Returns the stdio server spec that `TeamSessionService::ensure_session`
+    /// (D9) persists into each agent's `conversation.extra` and that ACP
+    /// `session/new` consumes via `mcp_servers`.
+    pub fn stdio_spec(&self, slot_id: &str) -> TeamMcpStdioServerSpec {
+        let binary_path = self.backend_binary_path.to_string_lossy();
+        TeamMcpStdioServerSpec::from_config(
+            &self.team.id,
+            binary_path.as_ref(),
+            &self.mcp_stdio_config(slot_id),
+        )
+    }
+
+    /// Assemble the payload that will drive the next wake of `slot_id`.
+    ///
+    /// - Reads status, unread messages and tasks.
+    /// - Cold-start agents (no prior status, or last status was `Error`)
+    ///   receive the full role prompt prepended to the wake payload.
+    /// - When the mailbox is empty, returns `WakeInput { should_send: false, .. }`
+    ///   so the caller can skip the wake and mark the agent idle.
+    ///
+    /// Side effect: `mailbox.read_unread` marks the messages as read.
+    pub async fn compute_wake_input(&self, slot_id: &str) -> Result<Option<WakeInput>, TeamError> {
+        let agent = self.scheduler.get_agent(slot_id).await?;
+        let unread = self.mailbox.read_unread(&self.team.id, slot_id).await?;
+        let tasks = self.scheduler.list_tasks().await?;
+
+        let wake_body = build_wake_payload(&agent, &tasks, &unread);
+
+        // TODO(D8): swap `needs_role_prompt` to match `{Pending, Error}` once
+        // `TeammateStatus::Pending` is reintroduced (it currently serde-aliases
+        // into `Idle`, so we use the `TeamAgent::status` sentinel — `None` means
+        // the scheduler never transitioned the slot, i.e. cold start).
+        let needs_role_prompt = matches!(agent.status, None | Some(TeammateStatus::Error));
+
+        let first_message = if needs_role_prompt {
+            let role_prompt = match agent.role {
+                TeammateRole::Lead => {
+                    build_lead_prompt(&self.team.name, &self.scheduler.list_agents().await)
+                }
+                TeammateRole::Teammate => build_teammate_prompt(&agent, &self.team.name),
+            };
+            format!("{role_prompt}\n\n{wake_body}")
+        } else {
+            wake_body
+        };
+
+        let should_send = !unread.is_empty();
+
+        Ok(Some(WakeInput {
+            conversation_id: agent.conversation_id,
+            first_message,
+            should_send,
+        }))
+    }
+
+    /// Handle agent Finish/Error events. Delegates to the scheduler's
+    /// `finalize_turn` with no parsed actions (phase1 does not parse the
+    /// trailing message for scheduler directives). Returns the leader slot_id
+    /// that the caller should re-wake, if any; D7b wires that return value
+    /// into the wake path. `is_error` is reserved for future status handling.
+    pub async fn on_agent_finish(
+        &self,
+        conversation_id: &str,
+        is_error: bool,
+    ) -> Result<Option<String>, TeamError> {
+        let slot_id = {
+            let agents = self.scheduler.list_agents().await;
+            agents
+                .into_iter()
+                .find(|a| a.conversation_id == conversation_id)
+                .map(|a| a.slot_id)
+                .ok_or_else(|| {
+                    TeamError::AgentNotFound(format!(
+                        "no agent with conversation_id={conversation_id}"
+                    ))
+                })?
+        };
+
+        if is_error {
+            self.scheduler
+                .set_status(&slot_id, TeammateStatus::Error)
+                .await?;
+        }
+
+        self.scheduler.finalize_turn(&slot_id, &[]).await
     }
 
     pub async fn send_message(&self, content: &str) -> Result<(), TeamError> {
@@ -159,6 +263,10 @@ mod tests {
         fn broadcast(&self, _msg: WebSocketMessage<serde_json::Value>) {}
     }
 
+    fn backend_path() -> Arc<PathBuf> {
+        Arc::new(PathBuf::from("/tmp/aionui-backend-test"))
+    }
+
     fn make_team() -> Team {
         Team {
             id: "t1".into(),
@@ -195,13 +303,17 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn start_and_stop() {
+    async fn start_session() -> TeamSession {
         let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
         let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let team = make_team();
+        TeamSession::start(make_team(), repo, broadcaster, backend_path())
+            .await
+            .unwrap()
+    }
 
-        let session = TeamSession::start(team, repo, broadcaster).await.unwrap();
+    #[tokio::test]
+    async fn start_and_stop() {
+        let session = start_session().await;
         assert_eq!(session.team_id(), "t1");
         assert!(session.mcp_server.port() > 0);
         session.stop();
@@ -209,14 +321,25 @@ mod tests {
 
     #[tokio::test]
     async fn mcp_stdio_config_for_agent() {
-        let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
-        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let team = make_team();
-
-        let session = TeamSession::start(team, repo, broadcaster).await.unwrap();
+        let session = start_session().await;
         let config = session.mcp_stdio_config("lead-1");
         assert_eq!(config.slot_id, "lead-1");
         assert_eq!(config.port, session.mcp_server.port());
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn stdio_spec_embeds_team_and_binary_path() {
+        let session = start_session().await;
+        let spec = session.stdio_spec("lead-1");
+        assert_eq!(spec.name, "aionui-team-t1");
+        assert_eq!(spec.command, "/tmp/aionui-backend-test");
+        assert_eq!(spec.args, vec!["mcp-bridge".to_string()]);
+        assert!(
+            spec.env
+                .iter()
+                .any(|(k, v)| k == "TEAM_AGENT_SLOT_ID" && v == "lead-1")
+        );
         session.stop();
     }
 
@@ -225,9 +348,7 @@ mod tests {
         let repo = Arc::new(MockTeamRepo::new());
         let repo_dyn: Arc<dyn ITeamRepository> = repo.clone();
         let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let team = make_team();
-
-        let session = TeamSession::start(team, repo_dyn, broadcaster)
+        let session = TeamSession::start(make_team(), repo_dyn, broadcaster, backend_path())
             .await
             .unwrap();
         session.send_message("Hello team").await.unwrap();
@@ -245,9 +366,7 @@ mod tests {
         let repo = Arc::new(MockTeamRepo::new());
         let repo_dyn: Arc<dyn ITeamRepository> = repo.clone();
         let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let team = make_team();
-
-        let session = TeamSession::start(team, repo_dyn, broadcaster)
+        let session = TeamSession::start(make_team(), repo_dyn, broadcaster, backend_path())
             .await
             .unwrap();
         session
@@ -264,11 +383,7 @@ mod tests {
 
     #[tokio::test]
     async fn send_message_to_unknown_agent_returns_error() {
-        let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
-        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let team = make_team();
-
-        let session = TeamSession::start(team, repo, broadcaster).await.unwrap();
+        let session = start_session().await;
         let result = session.send_message_to_agent("nonexistent", "Hello").await;
         assert!(result.is_err());
         session.stop();
@@ -276,11 +391,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_and_remove_agent() {
-        let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
-        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let team = make_team();
-
-        let session = TeamSession::start(team, repo, broadcaster).await.unwrap();
+        let session = start_session().await;
 
         let new_agent = TeamAgent {
             slot_id: "new-1".into(),
@@ -308,11 +419,7 @@ mod tests {
 
     #[tokio::test]
     async fn rename_agent_in_session() {
-        let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
-        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let team = make_team();
-
-        let session = TeamSession::start(team, repo, broadcaster).await.unwrap();
+        let session = start_session().await;
         session
             .rename_agent("worker-1", "Senior Worker")
             .await
@@ -326,12 +433,173 @@ mod tests {
 
     #[tokio::test]
     async fn rename_unknown_agent_returns_error() {
-        let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
-        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
-        let team = make_team();
-
-        let session = TeamSession::start(team, repo, broadcaster).await.unwrap();
+        let session = start_session().await;
         let result = session.rename_agent("nonexistent", "X").await;
+        assert!(result.is_err());
+        session.stop();
+    }
+
+    // -- D7a new method tests ------------------------------------------------
+
+    #[tokio::test]
+    async fn compute_wake_input_cold_start_injects_lead_role_prompt() {
+        let session = start_session().await;
+        // Seed one unread message. `send_message` flips status to Working —
+        // that is the post-send path; here we want to exercise cold-start
+        // detection, so write directly to the mailbox instead.
+        session
+            .mailbox
+            .write(
+                "t1",
+                "lead-1",
+                "user",
+                MailboxMessageType::Message,
+                "kick off",
+                None,
+            )
+            .await
+            .unwrap();
+
+        let input = session
+            .compute_wake_input("lead-1")
+            .await
+            .unwrap()
+            .expect("WakeInput");
+
+        assert_eq!(input.conversation_id, "c1");
+        assert!(input.should_send);
+        assert!(
+            input.first_message.contains("Lead Agent of team"),
+            "expected lead role prompt, got: {}",
+            input.first_message
+        );
+        assert!(input.first_message.contains("kick off"));
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn compute_wake_input_cold_start_injects_teammate_role_prompt() {
+        let session = start_session().await;
+        session
+            .mailbox
+            .write(
+                "t1",
+                "worker-1",
+                "user",
+                MailboxMessageType::Message,
+                "do X",
+                None,
+            )
+            .await
+            .unwrap();
+
+        let input = session
+            .compute_wake_input("worker-1")
+            .await
+            .unwrap()
+            .expect("WakeInput");
+
+        assert!(
+            input.first_message.contains("Teammate Agent"),
+            "expected teammate role prompt, got: {}",
+            input.first_message
+        );
+        assert!(input.first_message.contains("do X"));
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn compute_wake_input_warm_agent_skips_role_prompt() {
+        let session = start_session().await;
+        // Exit cold-start by setting a status once; any non-Error status
+        // means the scheduler has seen this agent before.
+        session
+            .scheduler
+            .set_status("lead-1", TeammateStatus::Idle)
+            .await
+            .unwrap();
+        session
+            .mailbox
+            .write(
+                "t1",
+                "lead-1",
+                "user",
+                MailboxMessageType::Message,
+                "follow-up",
+                None,
+            )
+            .await
+            .unwrap();
+
+        let input = session
+            .compute_wake_input("lead-1")
+            .await
+            .unwrap()
+            .expect("WakeInput");
+
+        assert!(input.should_send);
+        assert!(
+            !input.first_message.contains("Lead Agent of team"),
+            "should not re-inject role prompt, got: {}",
+            input.first_message
+        );
+        assert!(input.first_message.contains("follow-up"));
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn compute_wake_input_empty_mailbox_should_not_send() {
+        let session = start_session().await;
+
+        let input = session
+            .compute_wake_input("lead-1")
+            .await
+            .unwrap()
+            .expect("WakeInput");
+
+        assert!(!input.should_send);
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn on_agent_finish_marks_idle_and_returns_lead_when_all_settled() {
+        let session = start_session().await;
+
+        // Worker is Working; on finish → mark idle → since the lead is the
+        // only remaining non-idle member (actually also idle), all-idle
+        // check returns the lead slot_id.
+        session
+            .scheduler
+            .set_status("worker-1", TeammateStatus::Working)
+            .await
+            .unwrap();
+
+        let result = session.on_agent_finish("c2", false).await.unwrap();
+        assert_eq!(result.as_deref(), Some("lead-1"));
+
+        let status = session.scheduler.get_status("worker-1").await.unwrap();
+        assert_eq!(status, TeammateStatus::Idle);
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn on_agent_finish_lead_returns_none() {
+        let session = start_session().await;
+        session
+            .scheduler
+            .set_status("lead-1", TeammateStatus::Working)
+            .await
+            .unwrap();
+
+        let result = session.on_agent_finish("c1", false).await.unwrap();
+        assert!(result.is_none());
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn on_agent_finish_unknown_conversation_returns_error() {
+        let session = start_session().await;
+        let result = session.on_agent_finish("nope", false).await;
         assert!(result.is_err());
         session.stop();
     }

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -63,11 +63,11 @@ impl TeamSession {
     }
 
     pub fn mcp_stdio_config(&self, slot_id: &str) -> TeamMcpStdioConfig {
-        TeamMcpStdioConfig::new(
-            self.mcp_server.port(),
-            self.mcp_server.auth_token().to_owned(),
-            slot_id.to_owned(),
-        )
+        TeamMcpStdioConfig {
+            port: self.mcp_server.port(),
+            token: self.mcp_server.auth_token().to_owned(),
+            slot_id: slot_id.to_owned(),
+        }
     }
 
     pub async fn send_message(&self, content: &str) -> Result<(), TeamError> {

--- a/crates/aionui-team/tests/mcp_server_integration.rs
+++ b/crates/aionui-team/tests/mcp_server_integration.rs
@@ -727,12 +727,13 @@ async fn sb1_bridge_config_generation() {
 
     let env = setup().await;
     let config = TeamMcpStdioConfig {
+        team_id: "team-test".into(),
         port: env.server.port(),
         token: env.server.auth_token().to_string(),
         slot_id: "lead-1".into(),
     };
 
-    let spec = TeamMcpStdioServerSpec::from_config("team-test", "/bin/aionui-backend", &config);
+    let spec = TeamMcpStdioServerSpec::from_config("/bin/aionui-backend", &config);
     let env_map: std::collections::HashMap<_, _> = spec.env.iter().cloned().collect();
     assert_eq!(
         env_map[TeamMcpStdioConfig::ENV_PORT],
@@ -753,17 +754,19 @@ async fn sb3_different_agents_get_different_slot_ids() {
     let token = env.server.auth_token().to_string();
 
     let cfg_lead = TeamMcpStdioConfig {
+        team_id: "t".into(),
         port,
         token: token.clone(),
         slot_id: "lead-1".into(),
     };
     let cfg_worker = TeamMcpStdioConfig {
+        team_id: "t".into(),
         port,
         token,
         slot_id: "worker-1".into(),
     };
-    let spec_lead = TeamMcpStdioServerSpec::from_config("t", "/b", &cfg_lead);
-    let spec_worker = TeamMcpStdioServerSpec::from_config("t", "/b", &cfg_worker);
+    let spec_lead = TeamMcpStdioServerSpec::from_config("/b", &cfg_lead);
+    let spec_worker = TeamMcpStdioServerSpec::from_config("/b", &cfg_worker);
     let kv_lead: std::collections::HashMap<_, _> = spec_lead.env.iter().cloned().collect();
     let kv_worker: std::collections::HashMap<_, _> = spec_worker.env.iter().cloned().collect();
 

--- a/crates/aionui-team/tests/mcp_server_integration.rs
+++ b/crates/aionui-team/tests/mcp_server_integration.rs
@@ -723,37 +723,57 @@ async fn ss2_stop_server_closes_listener() {
 
 #[tokio::test]
 async fn sb1_bridge_config_generation() {
-    let env = setup().await;
-    let config = aionui_team::TeamMcpStdioConfig::new(
-        env.server.port(),
-        env.server.auth_token().to_string(),
-        "lead-1".into(),
-    );
+    use aionui_team::{TeamMcpStdioConfig, TeamMcpStdioServerSpec};
 
-    let env_map = config.to_env_map();
-    assert_eq!(env_map["TEAM_MCP_PORT"], env.server.port().to_string());
-    assert_eq!(env_map["TEAM_MCP_TOKEN"], "test-token-123");
-    assert_eq!(env_map["TEAM_AGENT_SLOT_ID"], "lead-1");
+    let env = setup().await;
+    let config = TeamMcpStdioConfig {
+        port: env.server.port(),
+        token: env.server.auth_token().to_string(),
+        slot_id: "lead-1".into(),
+    };
+
+    let spec = TeamMcpStdioServerSpec::from_config("team-test", "/bin/aionui-backend", &config);
+    let env_map: std::collections::HashMap<_, _> = spec.env.iter().cloned().collect();
+    assert_eq!(
+        env_map[TeamMcpStdioConfig::ENV_PORT],
+        env.server.port().to_string()
+    );
+    assert_eq!(env_map[TeamMcpStdioConfig::ENV_TOKEN], "test-token-123");
+    assert_eq!(env_map[TeamMcpStdioConfig::ENV_SLOT_ID], "lead-1");
 
     env.server.stop();
 }
 
 #[tokio::test]
 async fn sb3_different_agents_get_different_slot_ids() {
+    use aionui_team::{TeamMcpStdioConfig, TeamMcpStdioServerSpec};
+
     let env = setup().await;
     let port = env.server.port();
     let token = env.server.auth_token().to_string();
 
-    let cfg_lead = aionui_team::TeamMcpStdioConfig::new(port, token.clone(), "lead-1".into());
-    let cfg_worker = aionui_team::TeamMcpStdioConfig::new(port, token, "worker-1".into());
+    let cfg_lead = TeamMcpStdioConfig {
+        port,
+        token: token.clone(),
+        slot_id: "lead-1".into(),
+    };
+    let cfg_worker = TeamMcpStdioConfig {
+        port,
+        token,
+        slot_id: "worker-1".into(),
+    };
+    let spec_lead = TeamMcpStdioServerSpec::from_config("t", "/b", &cfg_lead);
+    let spec_worker = TeamMcpStdioServerSpec::from_config("t", "/b", &cfg_worker);
+    let kv_lead: std::collections::HashMap<_, _> = spec_lead.env.iter().cloned().collect();
+    let kv_worker: std::collections::HashMap<_, _> = spec_worker.env.iter().cloned().collect();
 
     assert_eq!(
-        cfg_lead.to_env_map()["TEAM_MCP_PORT"],
-        cfg_worker.to_env_map()["TEAM_MCP_PORT"]
+        kv_lead[TeamMcpStdioConfig::ENV_PORT],
+        kv_worker[TeamMcpStdioConfig::ENV_PORT]
     );
     assert_ne!(
-        cfg_lead.to_env_map()["TEAM_AGENT_SLOT_ID"],
-        cfg_worker.to_env_map()["TEAM_AGENT_SLOT_ID"]
+        kv_lead[TeamMcpStdioConfig::ENV_SLOT_ID],
+        kv_worker[TeamMcpStdioConfig::ENV_SLOT_ID]
     );
 
     env.server.stop();

--- a/crates/aionui-team/tests/mcp_server_integration.rs
+++ b/crates/aionui-team/tests/mcp_server_integration.rs
@@ -170,7 +170,7 @@ async fn mc1_correct_token_connects() {
     send_request(&mut stream, &req).await;
     let resp = read_response(&mut stream).await;
     let tools = resp["result"]["tools"].as_array().unwrap();
-    assert_eq!(tools.len(), 8);
+    assert_eq!(tools.len(), 10);
 
     env.server.stop();
 }
@@ -230,7 +230,7 @@ async fn mc3_no_token_rejected() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn tools_list_returns_all_8_tools() {
+async fn tools_list_returns_all_10_tools() {
     let env = setup().await;
     let mut stream = connect_and_init(env.server.port(), "test-token-123", "lead-1").await;
 
@@ -242,7 +242,7 @@ async fn tools_list_returns_all_8_tools() {
     send_request(&mut stream, &req).await;
     let resp = read_response(&mut stream).await;
     let tools = resp["result"]["tools"].as_array().unwrap();
-    assert_eq!(tools.len(), 8);
+    assert_eq!(tools.len(), 10);
 
     let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
     assert!(names.contains(&"team_send_message"));
@@ -253,6 +253,8 @@ async fn tools_list_returns_all_8_tools() {
     assert!(names.contains(&"team_members"));
     assert!(names.contains(&"team_rename_agent"));
     assert!(names.contains(&"team_shutdown_agent"));
+    assert!(names.contains(&"team_list_models"));
+    assert!(names.contains(&"team_describe_assistant"));
 
     env.server.stop();
 }

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -1253,3 +1253,53 @@ async fn d9_ensure_session_rollbacks_when_build_fails() {
         "session must not be registered after build failure"
     );
 }
+
+// ===========================================================================
+// Test: D11.5 remove_team cascades kill to every agent process
+// ===========================================================================
+
+#[tokio::test]
+async fn d115_remove_team_kills_every_agent_process() {
+    let (svc, tm) = setup_with_factory(success_factory());
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "T".into(),
+                agents: two_agent_input(),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Bring two agents online — after ensure_session, active_count == 2.
+    svc.ensure_session(&created.id).await.unwrap();
+    assert_eq!(
+        tm.active_count(),
+        2,
+        "ensure_session must register 2 live agents"
+    );
+
+    let before_kill = tm.snapshot().kill.len();
+
+    svc.remove_team("user1", &created.id).await.unwrap();
+
+    // remove_team must have issued one kill per agent with reason TeamDeleted,
+    // and the task manager's active_count must drop back to 0.
+    let calls = tm.snapshot();
+    let new_kills = &calls.kill[before_kill..];
+    assert_eq!(
+        new_kills.len(),
+        created.agents.len(),
+        "remove_team must kill every agent once"
+    );
+    for (i, agent) in created.agents.iter().enumerate() {
+        assert_eq!(new_kills[i].0, agent.conversation_id);
+        assert_eq!(new_kills[i].1, Some(AgentKillReason::TeamDeleted));
+    }
+    assert_eq!(
+        tm.active_count(),
+        0,
+        "every agent worker must be torn down after remove_team"
+    );
+}

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -989,7 +989,7 @@ async fn ss3_stop_session_without_active_is_noop() {
 #[tokio::test]
 async fn sm4_send_message_no_session_returns_error() {
     let svc = setup();
-    let result = svc.send_message("nonexistent", "Hello").await;
+    let result = svc.send_message("nonexistent", "Hello", None).await;
     assert!(result.is_err());
 }
 
@@ -1008,7 +1008,9 @@ async fn sm1_send_message_with_active_session() {
         .unwrap();
 
     svc.ensure_session(&created.id).await.unwrap();
-    svc.send_message(&created.id, "Hello team").await.unwrap();
+    svc.send_message(&created.id, "Hello team", None)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -1027,7 +1029,7 @@ async fn sa_send_message_to_agent_with_active_session() {
 
     svc.ensure_session(&created.id).await.unwrap();
     let worker_slot = created.agents[1].slot_id.clone();
-    svc.send_message_to_agent(&created.id, &worker_slot, "Do this")
+    svc.send_message_to_agent(&created.id, &worker_slot, "Do this", None)
         .await
         .unwrap();
 }
@@ -1048,7 +1050,7 @@ async fn sa3_send_message_to_nonexistent_agent() {
 
     svc.ensure_session(&created.id).await.unwrap();
     let result = svc
-        .send_message_to_agent(&created.id, "nonexistent", "Hello")
+        .send_message_to_agent(&created.id, "nonexistent", "Hello", None)
         .await;
     assert!(result.is_err());
 }
@@ -1086,7 +1088,7 @@ async fn dispose_all_cleans_up_sessions() {
 
     svc.dispose_all();
 
-    let result = svc.send_message(&t1.id, "Hello").await;
+    let result = svc.send_message(&t1.id, "Hello", None).await;
     assert!(result.is_err());
 }
 
@@ -1111,7 +1113,7 @@ async fn td_delete_team_stops_session() {
     svc.ensure_session(&created.id).await.unwrap();
     svc.remove_team("user1", &created.id).await.unwrap();
 
-    let result = svc.send_message(&created.id, "Hello").await;
+    let result = svc.send_message(&created.id, "Hello", None).await;
     assert!(result.is_err());
 }
 
@@ -1245,7 +1247,7 @@ async fn d9_ensure_session_rollbacks_when_build_fails() {
     assert_eq!(calls.kill.len(), 1);
     assert_eq!(calls.build.len(), 1);
 
-    let send_result = svc.send_message(&created.id, "Hello").await;
+    let send_result = svc.send_message(&created.id, "Hello", None).await;
     assert!(
         send_result.is_err(),
         "session must not be registered after build failure"

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -274,6 +274,20 @@ impl aionui_conversation::skill_resolver::SkillResolver for StubSkillResolver {
     async fn auto_inject_names(&self) -> Vec<String> {
         Vec::new()
     }
+    async fn resolve_skills(
+        &self,
+        _names: &[String],
+    ) -> Vec<aionui_conversation::skill_resolver::ResolvedAgentSkill> {
+        Vec::new()
+    }
+    async fn link_workspace_skills(
+        &self,
+        _workspace: &std::path::Path,
+        _rel_dirs: &[&str],
+        _skills: &[aionui_conversation::skill_resolver::ResolvedAgentSkill],
+    ) -> usize {
+        0
+    }
 }
 
 fn setup() -> TeamSessionService {
@@ -286,7 +300,8 @@ fn setup() -> TeamSessionService {
         std::env::temp_dir(),
         Arc::new(StubSkillResolver),
     );
-    TeamSessionService::new(team_repo, conv_service, broadcaster)
+    let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aionui-backend-test"));
+    TeamSessionService::new(team_repo, conv_service, broadcaster, backend_binary_path)
 }
 
 fn two_agent_input() -> Vec<TeamAgentInput> {

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -1,9 +1,11 @@
 mod common;
 
 use std::sync::Arc;
+use std::sync::Mutex;
 
+use aionui_ai_agent::{AgentFactory, BuildTaskOptions, IWorkerTaskManager, WorkerTaskManagerImpl};
 use aionui_api_types::{AddAgentRequest, CreateTeamRequest, TeamAgentInput, WebSocketMessage};
-use aionui_common::PaginatedResult;
+use aionui_common::{AgentKillReason, AppError, PaginatedResult};
 use aionui_db::models::{ConversationRow, MessageRow};
 use aionui_db::{
     ConversationFilters, ConversationRowUpdate, DbError, IConversationRepository, ITeamRepository,
@@ -41,7 +43,27 @@ impl IConversationRepository for MockConversationRepo {
         self.conversations.lock().unwrap().push(row.clone());
         Ok(())
     }
-    async fn update(&self, _id: &str, _updates: &ConversationRowUpdate) -> Result<(), DbError> {
+    async fn update(&self, id: &str, updates: &ConversationRowUpdate) -> Result<(), DbError> {
+        let mut convs = self.conversations.lock().unwrap();
+        let conv = convs
+            .iter_mut()
+            .find(|c| c.id == id)
+            .ok_or_else(|| DbError::NotFound(id.to_owned()))?;
+        if let Some(ref extra) = updates.extra {
+            conv.extra = extra.clone();
+        }
+        if let Some(ref name) = updates.name {
+            conv.name = name.clone();
+        }
+        if let Some(pinned) = updates.pinned {
+            conv.pinned = pinned;
+        }
+        if let Some(ref model) = updates.model {
+            conv.model = model.clone();
+        }
+        if let Some(updated_at) = updates.updated_at {
+            conv.updated_at = updated_at;
+        }
         Ok(())
     }
     async fn delete(&self, id: &str) -> Result<(), DbError> {
@@ -290,7 +312,159 @@ impl aionui_conversation::skill_resolver::SkillResolver for StubSkillResolver {
     }
 }
 
-fn setup() -> TeamSessionService {
+// ---------------------------------------------------------------------------
+// Counting task manager — wraps WorkerTaskManagerImpl so tests can assert
+// kill / get_or_build_task call counts by conversation id.
+// ---------------------------------------------------------------------------
+
+#[derive(Default, Clone)]
+struct TaskManagerCalls {
+    kill: Vec<(String, Option<AgentKillReason>)>,
+    build: Vec<String>,
+}
+
+struct CountingTaskManager {
+    inner: WorkerTaskManagerImpl,
+    calls: Mutex<TaskManagerCalls>,
+}
+
+impl CountingTaskManager {
+    fn new(factory: AgentFactory) -> Self {
+        Self {
+            inner: WorkerTaskManagerImpl::new(factory),
+            calls: Mutex::new(TaskManagerCalls::default()),
+        }
+    }
+
+    fn snapshot(&self) -> TaskManagerCalls {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+impl IWorkerTaskManager for CountingTaskManager {
+    fn get_task(&self, conversation_id: &str) -> Option<aionui_ai_agent::AgentManagerHandle> {
+        self.inner.get_task(conversation_id)
+    }
+    fn get_or_build_task(
+        &self,
+        conversation_id: &str,
+        options: BuildTaskOptions,
+    ) -> Result<aionui_ai_agent::AgentManagerHandle, AppError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .build
+            .push(conversation_id.to_owned());
+        self.inner.get_or_build_task(conversation_id, options)
+    }
+    fn kill(&self, conversation_id: &str, reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .kill
+            .push((conversation_id.to_owned(), reason));
+        self.inner.kill(conversation_id, reason)
+    }
+    fn clear(&self) {
+        self.inner.clear()
+    }
+    fn active_count(&self) -> usize {
+        self.inner.active_count()
+    }
+    fn collect_idle(&self, idle_threshold_ms: aionui_common::TimestampMs) -> Vec<String> {
+        self.inner.collect_idle(idle_threshold_ms)
+    }
+}
+
+// Minimal stub agent returned by the test factory: ensure_session only
+// asks the task manager to kill + rebuild; the returned handle never has
+// `send_message` called on it.
+mod mock_agent {
+    use aionui_ai_agent::agent_manager::IAgentManager;
+    use aionui_ai_agent::stream_event::AgentStreamEvent;
+    use aionui_ai_agent::types::SendMessageData;
+    use aionui_common::{
+        AgentKillReason, AgentType, AppError, Confirmation, ConversationStatus, TimestampMs,
+    };
+    use tokio::sync::broadcast;
+
+    pub struct MockAgent {
+        pub conversation_id: String,
+        pub workspace: String,
+        pub event_tx: broadcast::Sender<AgentStreamEvent>,
+    }
+
+    impl MockAgent {
+        pub fn new(conversation_id: String, workspace: String) -> Self {
+            let (event_tx, _) = broadcast::channel(16);
+            Self {
+                conversation_id,
+                workspace,
+                event_tx,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl IAgentManager for MockAgent {
+        fn agent_type(&self) -> AgentType {
+            AgentType::Acp
+        }
+        fn status(&self) -> Option<ConversationStatus> {
+            None
+        }
+        fn workspace(&self) -> &str {
+            &self.workspace
+        }
+        fn conversation_id(&self) -> &str {
+            &self.conversation_id
+        }
+        fn last_activity_at(&self) -> TimestampMs {
+            0
+        }
+        fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
+            self.event_tx.subscribe()
+        }
+        async fn send_message(&self, _data: SendMessageData) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn stop(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        fn confirm(
+            &self,
+            _msg_id: &str,
+            _call_id: &str,
+            _data: serde_json::Value,
+            _always_allow: bool,
+        ) -> Result<(), AppError> {
+            Ok(())
+        }
+        fn get_confirmations(&self) -> Vec<Confirmation> {
+            vec![]
+        }
+        fn check_approval(&self, _action: &str, _command_type: Option<&str>) -> bool {
+            false
+        }
+        fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
+            Ok(())
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+}
+
+fn success_factory() -> AgentFactory {
+    Arc::new(|opts: BuildTaskOptions| {
+        Ok(Arc::new(mock_agent::MockAgent::new(
+            opts.conversation_id,
+            opts.workspace,
+        )) as aionui_ai_agent::AgentManagerHandle)
+    })
+}
+
+fn setup_with_factory(factory: AgentFactory) -> (TeamSessionService, Arc<CountingTaskManager>) {
     let team_repo: Arc<dyn ITeamRepository> = Arc::new(FullMockTeamRepo::new());
     let conv_repo: Arc<dyn IConversationRepository> = Arc::new(MockConversationRepo::new());
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
@@ -301,7 +475,20 @@ fn setup() -> TeamSessionService {
         Arc::new(StubSkillResolver),
     );
     let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aionui-backend-test"));
-    TeamSessionService::new(team_repo, conv_service, broadcaster, backend_binary_path)
+    let task_manager = Arc::new(CountingTaskManager::new(factory));
+    let task_manager_dyn: Arc<dyn IWorkerTaskManager> = task_manager.clone();
+    let svc = TeamSessionService::new(
+        team_repo,
+        conv_service,
+        broadcaster,
+        task_manager_dyn,
+        backend_binary_path,
+    );
+    (svc, task_manager)
+}
+
+fn setup() -> TeamSessionService {
+    setup_with_factory(success_factory()).0
 }
 
 fn two_agent_input() -> Vec<TeamAgentInput> {
@@ -926,4 +1113,141 @@ async fn td_delete_team_stops_session() {
 
     let result = svc.send_message(&created.id, "Hello").await;
     assert!(result.is_err());
+}
+
+// ===========================================================================
+// Test: D9 ensure_session kill + rebuild closed loop
+// ===========================================================================
+
+#[tokio::test]
+async fn d9_ensure_session_kills_and_rebuilds_every_agent() {
+    let (svc, tm) = setup_with_factory(success_factory());
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "T".into(),
+                agents: two_agent_input(),
+            },
+        )
+        .await
+        .unwrap();
+
+    svc.ensure_session(&created.id).await.unwrap();
+
+    // Two agents → kill called 2x and get_or_build_task called 2x, each with
+    // the corresponding conversation_id. Order is agents-iteration order.
+    let calls = tm.snapshot();
+    assert_eq!(calls.kill.len(), 2, "expected 2 kill calls");
+    assert_eq!(calls.build.len(), 2, "expected 2 build calls");
+    for (i, agent) in created.agents.iter().enumerate() {
+        assert_eq!(calls.kill[i].0, agent.conversation_id);
+        assert_eq!(calls.kill[i].1, Some(AgentKillReason::TeamMcpRebuild));
+        assert_eq!(calls.build[i], agent.conversation_id);
+    }
+}
+
+#[tokio::test]
+async fn d9_ensure_session_persists_team_mcp_stdio_config() {
+    // Each agent's conversation.extra must carry a `team_mcp_stdio_config`
+    // object by the time the factory is called — that is what the rebuilt
+    // ACP process will read to reach the MCP server.
+    let (svc, _tm) = setup_with_factory(Arc::new(|opts: BuildTaskOptions| {
+        let extra_has_cfg = opts
+            .extra
+            .get("team_mcp_stdio_config")
+            .and_then(|v| v.as_object())
+            .is_some_and(|o| o.contains_key("port") && o.contains_key("slot_id"));
+        assert!(
+            extra_has_cfg,
+            "factory called without team_mcp_stdio_config in extra: {:?}",
+            opts.extra
+        );
+        Ok(Arc::new(mock_agent::MockAgent::new(
+            opts.conversation_id,
+            opts.workspace,
+        )) as aionui_ai_agent::AgentManagerHandle)
+    }));
+
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "T".into(),
+                agents: two_agent_input(),
+            },
+        )
+        .await
+        .unwrap();
+
+    svc.ensure_session(&created.id).await.unwrap();
+}
+
+#[tokio::test]
+async fn d9_ensure_session_is_idempotent() {
+    let (svc, tm) = setup_with_factory(success_factory());
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "T".into(),
+                agents: two_agent_input(),
+            },
+        )
+        .await
+        .unwrap();
+
+    svc.ensure_session(&created.id).await.unwrap();
+    svc.ensure_session(&created.id).await.unwrap();
+
+    // Second call short-circuits — no additional kill/build calls.
+    let calls = tm.snapshot();
+    assert_eq!(
+        calls.kill.len(),
+        2,
+        "second ensure_session must not re-kill"
+    );
+    assert_eq!(
+        calls.build.len(),
+        2,
+        "second ensure_session must not re-build"
+    );
+}
+
+#[tokio::test]
+async fn d9_ensure_session_rollbacks_when_build_fails() {
+    // Factory always fails → ensure_session must propagate error and not
+    // insert into sessions, so send_message afterwards still errors.
+    let failing_factory: AgentFactory = Arc::new(|_opts: BuildTaskOptions| {
+        Err(AppError::Internal("simulated build failure".into()))
+    });
+    let (svc, tm) = setup_with_factory(failing_factory);
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "T".into(),
+                agents: two_agent_input(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let result = svc.ensure_session(&created.id).await;
+    assert!(
+        result.is_err(),
+        "ensure_session should propagate build error"
+    );
+
+    // Kill ran for the first agent (before warmup failed), build ran once
+    // and errored. No session inserted, so send_message errors.
+    let calls = tm.snapshot();
+    assert_eq!(calls.kill.len(), 1);
+    assert_eq!(calls.build.len(), 1);
+
+    let send_result = svc.send_message(&created.id, "Hello").await;
+    assert!(
+        send_result.is_err(),
+        "session must not be registered after build failure"
+    );
 }


### PR DESCRIPTION
## Summary
- Wave 1 (10 modules): TeamMcpStdioConfig types, AcpBuildExtra extension, StdioServerSpec, 2 new MCP tools, spawn description constant, 3-layer prompt templates, mcp-bridge subcommand
- Wave 2 (7 modules): TeamSession wake methods, send_message→wake integration, scheduler mark_idle/wake_lock, ensure_session kill+rebuild, ACP session/new mcpServers injection, app assembly + smoke test, remove_team cascade kill

## Test plan
- [x] `cargo build` passes
- [x] `cargo test -p aionui-team --lib` — 205 passed
- [x] `cargo test -p aionui-team --test session_service_integration` — 35 passed
- [x] `cargo test -p aionui-team --test mcp_server_integration` — 26 passed
- [x] Single-chat regression: unchanged (Option + if-some guard on all cross-crate changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)