### PR TITLE
feat(team): normalize_name pure function (W3-D14a)

### DIFF
--- a/crates/aionui-team/src/lib.rs
+++ b/crates/aionui-team/src/lib.rs
@@ -19,7 +19,9 @@ pub use mailbox::Mailbox;
 pub use mcp::{TeamMcpServer, TeamMcpStdioConfig, TeamMcpStdioServerSpec};
 pub use prompts::{build_lead_prompt, build_teammate_prompt, build_wake_payload};
 pub use routes::{TeamRouterState, team_routes};
-pub use scheduler::{SchedulerAction, TeammateManager, WAKE_TIMEOUT_MS, WakePayload};
+pub use scheduler::{
+    SchedulerAction, TeammateManager, WAKE_TIMEOUT_MS, WakePayload, normalize_name,
+};
 pub use service::TeamSessionService;
 pub use session::{TeamSession, WakeInput};
 pub use task_board::{TaskBoard, TaskUpdate};

--- a/crates/aionui-team/src/scheduler.rs
+++ b/crates/aionui-team/src/scheduler.rs
@@ -17,6 +17,24 @@ use crate::types::{
 pub const WAKE_TIMEOUT_MS: u64 = 60_000;
 
 // ---------------------------------------------------------------------------
+// normalize_name — canonical form for agent-name conflict checks
+// ---------------------------------------------------------------------------
+
+/// Normalize an agent name to its canonical form for conflict detection.
+///
+/// Rules (see interface-contracts §15.1):
+/// 1. Trim leading/trailing whitespace.
+/// 2. Drop control characters (`char::is_control`).
+/// 3. Lowercase (Unicode-aware via `to_lowercase`).
+pub fn normalize_name(name: &str) -> String {
+    name.trim()
+        .chars()
+        .filter(|c| !c.is_control())
+        .collect::<String>()
+        .to_lowercase()
+}
+
+// ---------------------------------------------------------------------------
 // SchedulerAction — actions parsed from an agent's turn response
 // ---------------------------------------------------------------------------
 
@@ -597,6 +615,35 @@ mod tests {
     use super::*;
     use crate::test_utils::MockTeamRepo;
     use aionui_api_types::WebSocketMessage;
+
+    // -----------------------------------------------------------------
+    // normalize_name — §15.1 contract
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn normalize_name_trims_outer_whitespace() {
+        assert_eq!(normalize_name("  Alice  "), "alice");
+        assert_eq!(normalize_name("\tBob\n"), "bob");
+    }
+
+    #[test]
+    fn normalize_name_lowercases_ascii_and_unicode() {
+        assert_eq!(normalize_name("ALICE"), "alice");
+        assert_eq!(normalize_name("Crème"), "crème");
+    }
+
+    #[test]
+    fn normalize_name_filters_control_characters() {
+        // Null + bell in the middle + outer whitespace.
+        assert_eq!(normalize_name("  Ali\x00ce\x07 "), "alice");
+    }
+
+    #[test]
+    fn normalize_name_collides_on_case_and_whitespace() {
+        // Conflict-detection invariant: two inputs that only differ by
+        // surrounding whitespace / case must normalize to the same string.
+        assert_eq!(normalize_name("  Leader  "), normalize_name("leader"));
+    }
 
     struct RecordingBroadcaster {
         events: std::sync::Mutex<Vec<WebSocketMessage<serde_json::Value>>>,


### PR DESCRIPTION
## Summary
- 按 [interface-contracts §15.1](../blob/feat/team-wave3/docs/teams/phase1/interface-contracts.md) 实现 `normalize_name` 纯函数：`trim + filter is_control + to_lowercase`
- 暴露在 `aionui_team::normalize_name`，供 W3-D14b (`rename_agent` 冲突检测) 与 W5-D29a-3 (`spawn_agent` 校验) 复用
- 零依赖、无副作用；约 15 行实现 + 4 条单元测试，整 diff 50 行

## 契约对齐
- 规则严格按 §15.1 代码块：`trim → filter(!c.is_control()) → to_lowercase`
- 无长度截断（契约未要求；如未来需要，在 W3-D14b 或独立模块加）

## Test plan
- [x] `cargo test -p aionui-team --lib normalize_name` → 4 passed
  - `normalize_name_trims_outer_whitespace`
  - `normalize_name_lowercases_ascii_and_unicode`
  - `normalize_name_filters_control_characters`
  - `normalize_name_collides_on_case_and_whitespace` (冲突检测不变量)
- [x] `cargo clippy -p aionui-team --lib --tests -- -D warnings` → 无警告
- [x] `cargo fmt -p aionui-team -- --check` → 干净

## 相关任务
- Blocks: W3-D14b (`rename_agent` 冲突 + renamed_agents)、W5-D29a-3 (spawn 名字冲突校验)
- 模块定义: [docs/teams/phase1/modules.md#w3-d14a](../blob/feat/team-wave3/docs/teams/phase1/modules.md)