### PR TITLE
W3-D16a: ITeamMessageRouter trait + injection point

### DIFF
--- a/crates/aionui-conversation/src/lib.rs
+++ b/crates/aionui-conversation/src/lib.rs
@@ -6,10 +6,12 @@ pub mod skill_resolver;
 pub mod skill_snapshot;
 pub mod state;
 pub mod stream_relay;
+pub mod traits;
 
 pub use routes::conversation_routes;
 pub use service::{ConversationService, OnConversationDelete};
 pub use state::ConversationRouterState;
+pub use traits::ITeamMessageRouter;
 
 #[cfg(test)]
 #[path = "service_test.rs"]

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -24,6 +24,7 @@ use crate::convert::{
 };
 use crate::skill_resolver::SkillResolver;
 use crate::stream_relay::StreamRelay;
+use crate::traits::ITeamMessageRouter;
 
 const MAX_CRON_CONTINUATIONS_PER_TURN: usize = 4;
 
@@ -40,6 +41,7 @@ pub struct ConversationService {
     workspace_root: std::path::PathBuf,
     skill_resolver: Arc<dyn SkillResolver>,
     cron_service: Arc<std::sync::RwLock<Option<Arc<dyn ICronService>>>>,
+    team_router: Arc<std::sync::RwLock<Option<Arc<dyn ITeamMessageRouter>>>>,
 }
 
 impl ConversationService {
@@ -55,6 +57,7 @@ impl ConversationService {
             workspace_root: std::path::PathBuf::from("data"),
             skill_resolver,
             cron_service: Arc::new(std::sync::RwLock::new(None)),
+            team_router: Arc::new(std::sync::RwLock::new(None)),
         }
     }
 
@@ -71,6 +74,7 @@ impl ConversationService {
             workspace_root,
             skill_resolver,
             cron_service: Arc::new(std::sync::RwLock::new(None)),
+            team_router: Arc::new(std::sync::RwLock::new(None)),
         }
     }
 
@@ -87,6 +91,7 @@ impl ConversationService {
             workspace_root: std::path::PathBuf::from("data"),
             skill_resolver,
             cron_service: Arc::new(std::sync::RwLock::new(None)),
+            team_router: Arc::new(std::sync::RwLock::new(None)),
         }
     }
 
@@ -94,6 +99,20 @@ impl ConversationService {
         if let Ok(mut guard) = self.cron_service.write() {
             *guard = cron_service;
         }
+    }
+
+    /// Inject the team-message router. Called by `build_app_services` once
+    /// `TeamSessionService` is constructed (W3-D16c). When `None`, routing
+    /// falls back to the single-chat path.
+    pub fn set_team_router(&self, team_router: Option<Arc<dyn ITeamMessageRouter>>) {
+        if let Ok(mut guard) = self.team_router.write() {
+            *guard = team_router;
+        }
+    }
+
+    /// Snapshot of the currently injected team router, if any.
+    pub fn team_router(&self) -> Option<Arc<dyn ITeamMessageRouter>> {
+        self.team_router.read().ok().and_then(|g| g.clone())
     }
 
     /// Create a new conversation.

--- a/crates/aionui-conversation/src/traits.rs
+++ b/crates/aionui-conversation/src/traits.rs
@@ -1,0 +1,56 @@
+use aionui_common::AppError;
+use async_trait::async_trait;
+
+/// Routes a single-chat message to the team runtime when the target
+/// conversation belongs to a team.
+///
+/// Defined here (instead of in `aionui-team`) so `aionui-conversation` can
+/// depend only on the trait and avoid a reverse dependency on the team crate.
+#[async_trait]
+pub trait ITeamMessageRouter: Send + Sync {
+    /// Called by `ConversationService::send_message` after detecting that
+    /// the conversation's `extra.team_id` is non-empty.
+    ///
+    /// Implementations resolve `conversation_id` back to a slot on the team
+    /// session and forward the message to that agent.
+    async fn route_agent_message(
+        &self,
+        conversation_id: &str,
+        content: &str,
+        silent: bool,
+    ) -> Result<(), AppError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    // Compile-time check: `ITeamMessageRouter` must be object-safe so the
+    // service can hold `Arc<dyn ITeamMessageRouter>`.
+    #[allow(dead_code)]
+    fn _assert_object_safe(_: Arc<dyn ITeamMessageRouter>) {}
+
+    struct NoopRouter;
+
+    #[async_trait]
+    impl ITeamMessageRouter for NoopRouter {
+        async fn route_agent_message(
+            &self,
+            _conversation_id: &str,
+            _content: &str,
+            _silent: bool,
+        ) -> Result<(), AppError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn trait_is_object_safe_and_callable() {
+        let router: Arc<dyn ITeamMessageRouter> = Arc::new(NoopRouter);
+        router
+            .route_agent_message("conv-1", "hello", false)
+            .await
+            .unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

- 在 `aionui-conversation` 里新增 `ITeamMessageRouter` trait（`crates/aionui-conversation/src/traits.rs`），带一个 async 方法 `route_agent_message(conversation_id, content, silent)`。trait 放在 conversation crate 内，避免 conversation 反向依赖 team crate。
- `ConversationService` 加 `team_router: Arc<RwLock<Option<Arc<dyn ITeamMessageRouter>>>>` 字段 + `set_team_router` setter + `team_router()` snapshot getter。默认 `None` 行为等价旧构造。模式与既有 `cron_service` 一致，便于 D16c 在 app-assembly 时 post-construction 注入。
- 一条编译 + 运行期测试：确认 trait object-safe（`Arc<dyn ITeamMessageRouter>` 可构造），可 `.route_agent_message()`。

纯声明工作，不含路由分叉逻辑（D16b）或 impl/装配（D16c）。

参考：
- `docs/teams/phase1/modules.md` W3-D16a
- `docs/teams/phase1/interface-contracts.md` §17.1

## Test plan
- [x] `cargo build -p aionui-conversation` 通过
- [x] `cargo test -p aionui-conversation --lib traits::` 1 passed（object-safe + callable）
- [x] `cargo clippy -p aionui-conversation --lib -- -D warnings` 无 warning（service_test.rs 里的 clippy 报错是 feat/team-wave3 基线上 pre-existing 的，与本 PR 无关）
- [x] `cargo fmt -p aionui-conversation -- --check` 通过