### PR TITLE
feat(db): add IConversationRepository::list_by_team_id (W3-D13a)

### DIFF
--- a/crates/aionui-db/src/repository/conversation.rs
+++ b/crates/aionui-db/src/repository/conversation.rs
@@ -53,6 +53,13 @@ pub trait IConversationRepository: Send + Sync {
         cron_job_id: &str,
     ) -> Result<Vec<ConversationRow>, DbError>;
 
+    /// Lists conversations whose `extra.teamId` matches, scoped to a user.
+    async fn list_by_team_id(
+        &self,
+        user_id: &str,
+        team_id: &str,
+    ) -> Result<Vec<ConversationRow>, DbError>;
+
     /// Lists conversations sharing the same `extra.workspace` value.
     /// The conversation identified by `conversation_id` is excluded.
     async fn list_associated(

--- a/crates/aionui-db/src/repository/sqlite_conversation.rs
+++ b/crates/aionui-db/src/repository/sqlite_conversation.rs
@@ -237,6 +237,25 @@ impl IConversationRepository for SqliteConversationRepository {
         Ok(rows)
     }
 
+    async fn list_by_team_id(
+        &self,
+        user_id: &str,
+        team_id: &str,
+    ) -> Result<Vec<ConversationRow>, DbError> {
+        let rows = sqlx::query_as::<_, ConversationRow>(
+            "SELECT * FROM conversations \
+             WHERE user_id = ? \
+             AND json_extract(extra, '$.teamId') = ? \
+             ORDER BY updated_at DESC",
+        )
+        .bind(user_id)
+        .bind(team_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
     async fn list_associated(
         &self,
         user_id: &str,
@@ -1167,6 +1186,79 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn list_by_team_id_filters_by_team_and_user() {
+        let (repo, db) = setup().await;
+
+        let mut c1 = sample_conversation(SYSTEM_USER_ID);
+        c1.extra = r#"{"teamId":"team_1","workspace":"/a"}"#.to_string();
+        repo.create(&c1).await.unwrap();
+
+        let mut c2 = sample_conversation(SYSTEM_USER_ID);
+        c2.extra = r#"{"teamId":"team_1","workspace":"/b"}"#.to_string();
+        repo.create(&c2).await.unwrap();
+
+        let mut c3 = sample_conversation(SYSTEM_USER_ID);
+        c3.extra = r#"{"workspace":"/c"}"#.to_string();
+        repo.create(&c3).await.unwrap();
+
+        // Insert a second user and a conversation belonging to that user in the
+        // same team — must not leak across users.
+        let now = aionui_common::now_ms();
+        sqlx::query(
+            "INSERT INTO users (id, username, password_hash, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind("other_user")
+        .bind("other")
+        .bind("h")
+        .bind(now)
+        .bind(now)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let mut c4 = sample_conversation("other_user");
+        c4.extra = r#"{"teamId":"team_1","workspace":"/d"}"#.to_string();
+        repo.create(&c4).await.unwrap();
+
+        let result = repo
+            .list_by_team_id(SYSTEM_USER_ID, "team_1")
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 2);
+        assert!(result.iter().all(|r| r.user_id == SYSTEM_USER_ID));
+    }
+
+    #[tokio::test]
+    async fn list_by_team_id_other_user_does_not_match() {
+        let (repo, db) = setup().await;
+
+        let now = aionui_common::now_ms();
+        sqlx::query(
+            "INSERT INTO users (id, username, password_hash, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind("other_user")
+        .bind("other")
+        .bind("h")
+        .bind(now)
+        .bind(now)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let mut c = sample_conversation("other_user");
+        c.extra = r#"{"teamId":"team_1"}"#.to_string();
+        repo.create(&c).await.unwrap();
+
+        let result = repo
+            .list_by_team_id(SYSTEM_USER_ID, "team_1")
+            .await
+            .unwrap();
+        assert!(result.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

W3-D13a — add `IConversationRepository::list_by_team_id(user_id, team_id)`, a user-scoped query for conversations belonging to a given team. This is the data-layer seed for Wave 3 team self-repair (D13b/D13c): when a team row has empty `agents`, D13c needs to pull its conversations and let D13b reconstruct the agent list.

- New trait method on `IConversationRepository`, returning `Vec<ConversationRow>`, `DbError` (matches the conventions of `list_by_cron_job` / `list_associated`).
- SQLite impl uses `WHERE user_id = ? AND json_extract(extra, '$.teamId') = ? ORDER BY updated_at DESC`.
- 2 unit tests for the contract cases (positive hit + cross-user isolation).

## Notes on conventions

- **`user_id` first, then `team_id`** — aligns with the existing `list_by_xxx(user_id, …)` shape in this trait. `interface-contracts.md §14.1` currently documents `(team_id, user_id)`; the code here follows the trait convention.
- **JSON key is camelCase `teamId`** — matches what `aionui-team/service.rs:89,244` actually writes into `extra`. `interface-contracts.md §14.1` says `$.team_id`, which doesn't match the persisted shape. Flagging for a follow-up doc fix rather than changing the code; the SQL has to match what's on disk.
- **`DbError`, not `AppError`** — consistent with all other methods on this trait.

## Test plan

- [x] `cargo test -p aionui-db` — 216 passed (including the 2 new cases)
- [x] `cargo clippy -p aionui-db --tests -- -D warnings` — clean
- [x] `cargo fmt -p aionui-db -- --check` — clean
- [ ] Reviewer to confirm SQL path `$.teamId` matches live DB rows (it does as of `feat/team-wave3`; calling out because the interface contract doc disagrees)

Module spec: `docs/teams/phase1/modules.md` → `W3-D13a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)