### PR TITLE
fix(team): scope list_teams to current user (W3-D12a)

### DIFF
--- a/crates/aionui-db/src/repository/sqlite_team.rs
+++ b/crates/aionui-db/src/repository/sqlite_team.rs
@@ -41,10 +41,13 @@ impl ITeamRepository for SqliteTeamRepository {
         Ok(())
     }
 
-    async fn list_teams(&self) -> Result<Vec<TeamRow>, DbError> {
-        let rows = sqlx::query_as::<_, TeamRow>("SELECT * FROM teams ORDER BY created_at ASC")
-            .fetch_all(&self.pool)
-            .await?;
+    async fn list_teams(&self, user_id: &str) -> Result<Vec<TeamRow>, DbError> {
+        let rows = sqlx::query_as::<_, TeamRow>(
+            "SELECT * FROM teams WHERE user_id = ? ORDER BY created_at ASC",
+        )
+        .bind(user_id)
+        .fetch_all(&self.pool)
+        .await?;
         Ok(rows)
     }
 

--- a/crates/aionui-db/src/repository/team.rs
+++ b/crates/aionui-db/src/repository/team.rs
@@ -31,8 +31,8 @@ pub trait ITeamRepository: Send + Sync {
     /// Inserts a new team record.
     async fn create_team(&self, row: &TeamRow) -> Result<(), DbError>;
 
-    /// Returns all teams ordered by creation time ascending.
-    async fn list_teams(&self) -> Result<Vec<TeamRow>, DbError>;
+    /// Returns all teams owned by `user_id` ordered by creation time ascending.
+    async fn list_teams(&self, user_id: &str) -> Result<Vec<TeamRow>, DbError>;
 
     /// Returns a single team by id, or `None` if not found.
     async fn get_team(&self, team_id: &str) -> Result<Option<TeamRow>, DbError>;

--- a/crates/aionui-db/tests/team_repository.rs
+++ b/crates/aionui-db/tests/team_repository.rs
@@ -102,7 +102,7 @@ async fn get_nonexistent_team_returns_none() {
 #[tokio::test]
 async fn list_teams_empty() {
     let (repo, _db) = repo().await;
-    let teams = repo.list_teams().await.unwrap();
+    let teams = repo.list_teams("system_default_user").await.unwrap();
     assert!(teams.is_empty());
 }
 
@@ -112,10 +112,50 @@ async fn list_teams_multiple() {
     repo.create_team(&make_team("t1", "Alpha")).await.unwrap();
     repo.create_team(&make_team("t2", "Beta")).await.unwrap();
 
-    let teams = repo.list_teams().await.unwrap();
+    let teams = repo.list_teams("system_default_user").await.unwrap();
     assert_eq!(teams.len(), 2);
     assert_eq!(teams[0].id, "t1");
     assert_eq!(teams[1].id, "t2");
+}
+
+#[tokio::test]
+async fn list_teams_filters_by_user_id() {
+    let (repo, _db) = repo().await;
+    let now = now_ms();
+    let team_a = TeamRow {
+        id: "ta".into(),
+        user_id: "userA".into(),
+        name: "A-team".into(),
+        workspace: String::new(),
+        workspace_mode: "shared".into(),
+        agents: r#"[{"slotId":"a1","name":"Lead","role":"lead"}]"#.into(),
+        lead_agent_id: Some("a1".into()),
+        session_mode: None,
+        created_at: now,
+        updated_at: now,
+    };
+    let team_b = TeamRow {
+        id: "tb".into(),
+        user_id: "userB".into(),
+        name: "B-team".into(),
+        workspace: String::new(),
+        workspace_mode: "shared".into(),
+        agents: r#"[{"slotId":"a1","name":"Lead","role":"lead"}]"#.into(),
+        lead_agent_id: Some("a1".into()),
+        session_mode: None,
+        created_at: now,
+        updated_at: now,
+    };
+    repo.create_team(&team_a).await.unwrap();
+    repo.create_team(&team_b).await.unwrap();
+
+    let list_a = repo.list_teams("userA").await.unwrap();
+    assert_eq!(list_a.len(), 1);
+    assert_eq!(list_a[0].id, "ta");
+
+    let list_b = repo.list_teams("userB").await.unwrap();
+    assert_eq!(list_b.len(), 1);
+    assert_eq!(list_b[0].id, "tb");
 }
 
 #[tokio::test]

--- a/crates/aionui-team/src/routes.rs
+++ b/crates/aionui-team/src/routes.rs
@@ -59,8 +59,9 @@ async fn create_team(
 
 async fn list_teams(
     State(state): State<TeamRouterState>,
+    Extension(user): Extension<CurrentUser>,
 ) -> Result<Json<ApiResponse<TeamListResponse>>, AppError> {
-    let teams = state.service.list_teams().await?;
+    let teams = state.service.list_teams(&user.id).await?;
     Ok(Json(ApiResponse::ok(teams)))
 }
 

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -140,8 +140,8 @@ impl TeamSessionService {
         Ok(team.to_response())
     }
 
-    pub async fn list_teams(&self) -> Result<Vec<TeamResponse>, TeamError> {
-        let rows = self.repo.list_teams().await?;
+    pub async fn list_teams(&self, user_id: &str) -> Result<Vec<TeamResponse>, TeamError> {
+        let rows = self.repo.list_teams(user_id).await?;
         let mut teams = Vec::with_capacity(rows.len());
         for row in &rows {
             let team = Team::from_row(row)?;

--- a/crates/aionui-team/src/test_utils.rs
+++ b/crates/aionui-team/src/test_utils.rs
@@ -28,7 +28,7 @@ impl ITeamRepository for MockTeamRepo {
     async fn create_team(&self, _row: &TeamRow) -> Result<(), DbError> {
         Ok(())
     }
-    async fn list_teams(&self) -> Result<Vec<TeamRow>, DbError> {
+    async fn list_teams(&self, _user_id: &str) -> Result<Vec<TeamRow>, DbError> {
         Ok(vec![])
     }
     async fn get_team(&self, _id: &str) -> Result<Option<TeamRow>, DbError> {

--- a/crates/aionui-team/tests/common/mod.rs
+++ b/crates/aionui-team/tests/common/mod.rs
@@ -26,7 +26,7 @@ impl ITeamRepository for MockTeamRepo {
     async fn create_team(&self, _row: &TeamRow) -> Result<(), DbError> {
         Ok(())
     }
-    async fn list_teams(&self) -> Result<Vec<TeamRow>, DbError> {
+    async fn list_teams(&self, _user_id: &str) -> Result<Vec<TeamRow>, DbError> {
         Ok(vec![])
     }
     async fn get_team(&self, _id: &str) -> Result<Option<TeamRow>, DbError> {

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -182,8 +182,15 @@ impl ITeamRepository for FullMockTeamRepo {
         self.teams.lock().unwrap().push(row.clone());
         Ok(())
     }
-    async fn list_teams(&self) -> Result<Vec<aionui_db::models::TeamRow>, DbError> {
-        Ok(self.teams.lock().unwrap().clone())
+    async fn list_teams(&self, user_id: &str) -> Result<Vec<aionui_db::models::TeamRow>, DbError> {
+        Ok(self
+            .teams
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|t| t.user_id == user_id)
+            .cloned()
+            .collect())
     }
     async fn get_team(&self, id: &str) -> Result<Option<aionui_db::models::TeamRow>, DbError> {
         Ok(self
@@ -636,7 +643,7 @@ async fn tc3_each_agent_has_conversation_id() {
 #[tokio::test]
 async fn tl1_empty_list() {
     let svc = setup();
-    let list = svc.list_teams().await.unwrap();
+    let list = svc.list_teams("user1").await.unwrap();
     assert!(list.is_empty());
 }
 
@@ -662,8 +669,39 @@ async fn tl2_list_multiple_teams() {
     .await
     .unwrap();
 
-    let list = svc.list_teams().await.unwrap();
+    let list = svc.list_teams("user1").await.unwrap();
     assert_eq!(list.len(), 2);
+}
+
+#[tokio::test]
+async fn tl3_list_is_user_scoped() {
+    let svc = setup();
+    svc.create_team(
+        "userA",
+        CreateTeamRequest {
+            name: "A-team".into(),
+            agents: two_agent_input(),
+        },
+    )
+    .await
+    .unwrap();
+    svc.create_team(
+        "userB",
+        CreateTeamRequest {
+            name: "B-team".into(),
+            agents: two_agent_input(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let list_a = svc.list_teams("userA").await.unwrap();
+    assert_eq!(list_a.len(), 1);
+    assert_eq!(list_a[0].name, "A-team");
+
+    let list_b = svc.list_teams("userB").await.unwrap();
+    assert_eq!(list_b.len(), 1);
+    assert_eq!(list_b[0].name, "B-team");
 }
 
 // -- Get team -----------------------------------------------------------------
@@ -712,7 +750,7 @@ async fn td1_delete_existing_team() {
         .unwrap();
 
     svc.remove_team("user1", &created.id).await.unwrap();
-    let list = svc.list_teams().await.unwrap();
+    let list = svc.list_teams("user1").await.unwrap();
     assert!(list.is_empty());
 }
 


### PR DESCRIPTION
## Summary

Fixes backend-audit bug #5: any logged-in user could see every other user's teams through `GET /api/teams` because `ITeamRepository::list_teams` returned every row and `TeamSessionService::list_teams` had no `user_id` parameter.

- `ITeamRepository::list_teams(user_id: &str)` — trait signature now requires a user id
- `SqliteTeamRepository::list_teams` — SQL filters with `WHERE user_id = ? ORDER BY created_at ASC`
- `TeamSessionService::list_teams(user_id: &str)` — propagates the id to the repo
- `list_teams` handler — reads `user.id` from `Extension<CurrentUser>` and forwards it
- Mocks (`test_utils`, `tests/common`, `FullMockTeamRepo` in integration) updated for the new signature

## Test plan

- [x] `cargo test -p aionui-db --test team_repository` — 35 passed (new `list_teams_filters_by_user_id` asserts userA only sees A's team)
- [x] `cargo test -p aionui-team --lib` — 205 passed
- [x] `cargo test -p aionui-team --test session_service_integration` — 36 passed (new `tl3_list_is_user_scoped` verifies cross-user isolation at the service layer)
- [x] `cargo clippy -p aionui-db -p aionui-team --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean on touched files

Refs: `docs/teams/phase1/modules.md` W3-D12a, `docs/teams/phase1/interface-contracts.md` §13.1