### PR TITLE
feat(team): add conversation_id to TeamAgentInput (W3-D15a)

### DIFF
--- a/crates/aionui-api-types/src/team.rs
+++ b/crates/aionui-api-types/src/team.rs
@@ -17,6 +17,10 @@ pub struct TeamAgentInput {
     pub model: String,
     #[serde(default)]
     pub custom_agent_id: Option<String>,
+    /// Reuse an existing 1:1 conversation as this agent's conversation.
+    /// When `None`, a new conversation is created by the service.
+    #[serde(default)]
+    pub conversation_id: Option<String>,
 }
 
 /// Request body for `POST /api/teams`.
@@ -206,8 +210,38 @@ mod tests {
         assert_eq!(req.agents[0].backend, "acp");
         assert_eq!(req.agents[0].model, "claude");
         assert_eq!(req.agents[0].custom_agent_id.as_deref(), Some("agent-x"));
+        assert!(req.agents[0].conversation_id.is_none());
         assert_eq!(req.agents[1].name, "Worker");
         assert!(req.agents[1].custom_agent_id.is_none());
+        assert!(req.agents[1].conversation_id.is_none());
+    }
+
+    #[test]
+    fn deserialize_create_team_request_with_agent_conversation_id() {
+        let raw = json!({
+            "name": "Team Reuse",
+            "agents": [
+                {
+                    "name": "Lead",
+                    "role": "lead",
+                    "backend": "acp",
+                    "model": "claude",
+                    "conversation_id": "conv-existing"
+                },
+                {
+                    "name": "Worker",
+                    "role": "teammate",
+                    "backend": "acp",
+                    "model": "claude"
+                }
+            ]
+        });
+        let req: CreateTeamRequest = serde_json::from_value(raw).unwrap();
+        assert_eq!(
+            req.agents[0].conversation_id.as_deref(),
+            Some("conv-existing"),
+        );
+        assert!(req.agents[1].conversation_id.is_none());
     }
 
     #[test]

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -499,6 +499,7 @@ fn two_agent_input() -> Vec<TeamAgentInput> {
             backend: "acp".into(),
             model: "claude".into(),
             custom_agent_id: None,
+            conversation_id: None,
         },
         TeamAgentInput {
             name: "Worker".into(),
@@ -506,6 +507,7 @@ fn two_agent_input() -> Vec<TeamAgentInput> {
             backend: "acp".into(),
             model: "claude".into(),
             custom_agent_id: None,
+            conversation_id: None,
         },
     ]
 }
@@ -550,6 +552,7 @@ async fn tc2_create_single_agent_team() {
                     backend: "acp".into(),
                     model: "claude".into(),
                     custom_agent_id: None,
+                    conversation_id: None,
                 }],
             },
         )
@@ -575,6 +578,7 @@ async fn tc4_first_agent_is_lead() {
                         backend: "acp".into(),
                         model: "claude".into(),
                         custom_agent_id: None,
+                        conversation_id: None,
                     },
                     TeamAgentInput {
                         name: "B".into(),
@@ -582,6 +586,7 @@ async fn tc4_first_agent_is_lead() {
                         backend: "acp".into(),
                         model: "claude".into(),
                         custom_agent_id: None,
+                        conversation_id: None,
                     },
                 ],
             },
@@ -769,6 +774,7 @@ async fn aa1_add_agent_to_team() {
                     backend: "acp".into(),
                     model: "claude".into(),
                     custom_agent_id: None,
+                    conversation_id: None,
                 }],
             },
         )


### PR DESCRIPTION
## Summary

- 在 `TeamAgentInput` 新增可选字段 `#[serde(default)] pub conversation_id: Option<String>`，为 `CreateTeamRequest.agents` 承载「单聊 → 建团 conversation 复用」准备。
- 纯类型扩展，零业务逻辑 — service 端的复用分支由 W3-D15b 实现。
- 契约来源：`docs/teams/phase1/interface-contracts.md` §16.1（文档里写作 `CreateAgentRequest`，与代码中 `TeamAgentInput` 指同一结构：\"Input for a single agent when creating a team or adding an agent\"）。

## Changes

- `crates/aionui-api-types/src/team.rs`
  - `TeamAgentInput` 加 `conversation_id: Option<String>` (`#[serde(default)]`)
  - 扩展既有 `deserialize_create_team_request_full` 断言字段默认 `None`
  - 新增 `deserialize_create_team_request_with_agent_conversation_id`：有/无字段反序列化均可
- `crates/aionui-team/tests/session_service_integration.rs`
  - 6 处 struct literal 补 `conversation_id: None`（Rust 新字段必须显式填，行为不变）

## Test plan

- [x] `cargo test -p aionui-api-types` — 全通过（含新增测试）
- [x] `cargo test -p aionui-team --test session_service_integration` — 35/35 通过
- [x] `cargo clippy -p aionui-api-types --lib` — 无 warning
- [x] `cargo clippy -p aionui-team --tests` — 无 warning
- [x] `cargo fmt -p aionui-api-types -p aionui-team -- --check` — 通过
- [x] `cargo check --workspace --tests` — 全部编译通过

## Scope

- 仅类型扩展，不涉及 service/routes/db
- `AddAgentRequest` 不在本次范围（D15a 描述只覆盖 `CreateTeamRequest.agents`；若后续需要加给 `AddAgentRequest`，走独立任务）