### PR TITLE
feat(team): enforce user_id ownership on get_team/remove_team (W3-D12b+D12c)

### DIFF
--- a/crates/aionui-team/src/routes.rs
+++ b/crates/aionui-team/src/routes.rs
@@ -66,9 +66,10 @@ async fn list_teams(
 
 async fn get_team(
     State(state): State<TeamRouterState>,
+    Extension(user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<TeamResponse>>, AppError> {
-    let team = state.service.get_team(&id).await?;
+    let team = state.service.get_team(&user.id, &id).await?;
     Ok(Json(ApiResponse::ok(team)))
 }
 

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -150,12 +150,15 @@ impl TeamSessionService {
         Ok(teams)
     }
 
-    pub async fn get_team(&self, team_id: &str) -> Result<TeamResponse, TeamError> {
+    pub async fn get_team(&self, user_id: &str, team_id: &str) -> Result<TeamResponse, TeamError> {
         let row = self
             .repo
             .get_team(team_id)
             .await?
             .ok_or_else(|| TeamError::TeamNotFound(team_id.into()))?;
+        if row.user_id != user_id {
+            return Err(TeamError::TeamNotFound(team_id.into()));
+        }
         let team = Team::from_row(&row)?;
         Ok(team.to_response())
     }
@@ -166,6 +169,9 @@ impl TeamSessionService {
             .get_team(team_id)
             .await?
             .ok_or_else(|| TeamError::TeamNotFound(team_id.into()))?;
+        if row.user_id != user_id {
+            return Err(TeamError::TeamNotFound(team_id.into()));
+        }
         let team = Team::from_row(&row)?;
 
         self.stop_session(team_id);

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -682,7 +682,7 @@ async fn tg1_get_existing_team() {
         .await
         .unwrap();
 
-    let got = svc.get_team(&created.id).await.unwrap();
+    let got = svc.get_team("user1", &created.id).await.unwrap();
     assert_eq!(got.id, created.id);
     assert_eq!(got.name, "Alpha");
     assert_eq!(got.agents.len(), 2);
@@ -691,7 +691,7 @@ async fn tg1_get_existing_team() {
 #[tokio::test]
 async fn tg2_get_nonexistent_returns_error() {
     let svc = setup();
-    let result = svc.get_team("nonexistent").await;
+    let result = svc.get_team("user1", "nonexistent").await;
     assert!(result.is_err());
 }
 
@@ -723,6 +723,46 @@ async fn td6_delete_nonexistent_returns_error() {
     assert!(result.is_err());
 }
 
+#[tokio::test]
+async fn tg3_get_team_other_user_returns_not_found() {
+    let svc = setup();
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "Alpha".into(),
+                agents: two_agent_input(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let err = svc.get_team("user2", &created.id).await.unwrap_err();
+    assert!(matches!(err, aionui_team::TeamError::TeamNotFound(_)));
+}
+
+#[tokio::test]
+async fn td7_remove_team_other_user_returns_not_found() {
+    let svc = setup();
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "Alpha".into(),
+                agents: two_agent_input(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let err = svc.remove_team("user2", &created.id).await.unwrap_err();
+    assert!(matches!(err, aionui_team::TeamError::TeamNotFound(_)));
+
+    // Team should still exist
+    let got = svc.get_team("user1", &created.id).await.unwrap();
+    assert_eq!(got.id, created.id);
+}
+
 // -- Rename team --------------------------------------------------------------
 
 #[tokio::test]
@@ -740,7 +780,7 @@ async fn tr1_rename_existing_team() {
         .unwrap();
 
     svc.rename_team(&created.id, "New Name").await.unwrap();
-    let got = svc.get_team(&created.id).await.unwrap();
+    let got = svc.get_team("user1", &created.id).await.unwrap();
     assert_eq!(got.name, "New Name");
 }
 
@@ -794,7 +834,7 @@ async fn aa1_add_agent_to_team() {
     assert_eq!(agent.role, "teammate");
     assert!(!agent.conversation_id.is_empty());
 
-    let got = svc.get_team(&created.id).await.unwrap();
+    let got = svc.get_team("user1", &created.id).await.unwrap();
     assert_eq!(got.agents.len(), 2);
 }
 
@@ -836,7 +876,7 @@ async fn ar1_remove_agent_from_team() {
         .await
         .unwrap();
 
-    let got = svc.get_team(&created.id).await.unwrap();
+    let got = svc.get_team("user1", &created.id).await.unwrap();
     assert_eq!(got.agents.len(), 1);
     assert!(got.agents.iter().all(|a| a.slot_id != worker_slot));
 }
@@ -878,7 +918,7 @@ async fn an1_rename_agent() {
         .await
         .unwrap();
 
-    let got = svc.get_team(&created.id).await.unwrap();
+    let got = svc.get_team("user1", &created.id).await.unwrap();
     let agent = got.agents.iter().find(|a| a.slot_id == slot_id).unwrap();
     assert_eq!(agent.name, "Senior Worker");
 }


### PR DESCRIPTION
## Summary

- `get_team(team_id)` → `get_team(user_id, team_id)`: fetch row, compare `row.user_id == user_id`, return `TeamNotFound` on mismatch — prevents cross-user team reads.
- `remove_team(user_id, team_id)`: same ownership check *before* any side effects (session stop → agent kill → conversation delete → mailbox/task cleanup → row delete), so a foreign user cannot tear down another user's team or leak its existence via the delete path.
- Route handler `get_team` now takes `Extension<CurrentUser>` and threads `user.id` into the service call (parity with `remove_team`).

## Why NotFound (not Forbidden)

Using `TeamNotFound` on a cross-user hit keeps the same status/shape as a truly missing team, avoiding information disclosure (existence of another user's team id).

## Test plan

- [x] New: `tg3_get_team_other_user_returns_not_found` — user2 calling `get_team` on user1's team → `TeamNotFound`
- [x] New: `td7_remove_team_other_user_returns_not_found` — user2 calling `remove_team` on user1's team → `TeamNotFound`, and team still accessible via user1
- [x] Existing `get_team` integration tests updated to pass owning `user_id`
- [x] `cargo test -p aionui-team` — 205 unit + 37 integration tests pass
- [x] `cargo clippy -p aionui-team --all-targets -- -D warnings` — clean
- [x] `cargo build --workspace` — clean

## Scope

~30 LOC, as estimated. D12b + D12c merged because both land in the same method pattern (fetch row → ownership check → proceed).