### PR TITLE
feat(team): reuse existing conversation in create_team (W3-D15b)

### DIFF
--- a/crates/aionui-team/src/error.rs
+++ b/crates/aionui-team/src/error.rs
@@ -8,6 +8,9 @@ pub enum TeamError {
     #[error("Agent not found: {0}")]
     AgentNotFound(String),
 
+    #[error("Conversation not found: {0}")]
+    ConversationNotFound(String),
+
     #[error("Task not found: {0}")]
     TaskNotFound(String),
 
@@ -32,6 +35,7 @@ impl From<TeamError> for AppError {
         match err {
             TeamError::TeamNotFound(msg) => AppError::NotFound(msg),
             TeamError::AgentNotFound(msg) => AppError::NotFound(msg),
+            TeamError::ConversationNotFound(msg) => AppError::NotFound(msg),
             TeamError::TaskNotFound(msg) => AppError::NotFound(msg),
             TeamError::InvalidRequest(msg) => AppError::BadRequest(msg),
             TeamError::SessionNotFound(msg) => AppError::NotFound(msg),
@@ -62,6 +66,12 @@ mod tests {
     fn task_not_found_maps_to_app_not_found() {
         let err: AppError = TeamError::TaskNotFound("tk-1".into()).into();
         assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    #[test]
+    fn conversation_not_found_maps_to_app_not_found() {
+        let err: AppError = TeamError::ConversationNotFound("c1".into()).into();
+        assert!(matches!(err, AppError::NotFound(msg) if msg == "c1"));
     }
 
     #[test]

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -76,31 +76,39 @@ impl TeamSessionService {
             };
 
             let agent_type = parse_agent_type(&input.backend)?;
-            let conv_req = CreateConversationRequest {
-                r#type: agent_type,
-                name: Some(input.name.clone()),
-                model: Some(ProviderWithModel {
-                    provider_id: input.backend.clone(),
-                    model: input.model.clone(),
-                    use_model: None,
-                }),
-                source: None,
-                channel_chat_id: None,
-                extra: serde_json::json!({ "teamId": team_id }),
+            let conversation_id = match &input.conversation_id {
+                Some(existing_id) => {
+                    self.reuse_conversation_for_team(user_id, existing_id, &team_id)
+                        .await?
+                }
+                None => {
+                    let conv_req = CreateConversationRequest {
+                        r#type: agent_type,
+                        name: Some(input.name.clone()),
+                        model: Some(ProviderWithModel {
+                            provider_id: input.backend.clone(),
+                            model: input.model.clone(),
+                            use_model: None,
+                        }),
+                        source: None,
+                        channel_chat_id: None,
+                        extra: serde_json::json!({ "teamId": team_id }),
+                    };
+                    self.conversation_service
+                        .create(user_id, conv_req)
+                        .await
+                        .map_err(|e| {
+                            TeamError::InvalidRequest(format!("failed to create conversation: {e}"))
+                        })?
+                        .id
+                }
             };
-            let conv = self
-                .conversation_service
-                .create(user_id, conv_req)
-                .await
-                .map_err(|e| {
-                    TeamError::InvalidRequest(format!("failed to create conversation: {e}"))
-                })?;
 
             agents.push(TeamAgent {
                 slot_id,
                 name: input.name.clone(),
                 role,
-                conversation_id: conv.id,
+                conversation_id,
                 backend: input.backend.clone(),
                 model: input.model.clone(),
                 custom_agent_id: input.custom_agent_id.clone(),
@@ -138,6 +146,44 @@ impl TeamSessionService {
 
         info!(team_id = %team.id, "Team created");
         Ok(team.to_response())
+    }
+
+    /// Reuse an existing solo conversation as a team agent's conversation.
+    ///
+    /// Validates ownership (via `ConversationService::get`, which returns
+    /// `NotFound` when the conv belongs to another user), then rejects convs
+    /// already bound to a different team. On success merges `teamId` into
+    /// `conversation.extra` and returns the conversation id.
+    async fn reuse_conversation_for_team(
+        &self,
+        user_id: &str,
+        conversation_id: &str,
+        team_id: &str,
+    ) -> Result<String, TeamError> {
+        let existing = self
+            .conversation_service
+            .get(user_id, conversation_id)
+            .await
+            .map_err(|_| TeamError::ConversationNotFound(conversation_id.into()))?;
+
+        if let Some(bound) = existing.extra.get("teamId").and_then(|v| v.as_str())
+            && bound != team_id
+        {
+            return Err(TeamError::InvalidRequest(format!(
+                "conversation {conversation_id} already belongs to another team"
+            )));
+        }
+
+        self.conversation_service
+            .update_extra(conversation_id, serde_json::json!({ "teamId": team_id }))
+            .await
+            .map_err(|e| {
+                TeamError::InvalidRequest(format!(
+                    "failed to update conversation extra for {conversation_id}: {e}"
+                ))
+            })?;
+
+        Ok(conversation_id.to_owned())
     }
 
     pub async fn list_teams(&self, user_id: &str) -> Result<Vec<TeamResponse>, TeamError> {

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -31,6 +31,38 @@ impl MockConversationRepo {
             conversations: std::sync::Mutex::new(Vec::new()),
         }
     }
+
+    /// Pre-seed a conversation row; used by reuse tests.
+    fn insert_raw(&self, row: ConversationRow) {
+        self.conversations.lock().unwrap().push(row);
+    }
+
+    fn find_extra(&self, id: &str) -> Option<String> {
+        self.conversations
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|c| c.id == id)
+            .map(|c| c.extra.clone())
+    }
+}
+
+fn stub_conversation_row(id: &str, user_id: &str, extra: serde_json::Value) -> ConversationRow {
+    ConversationRow {
+        id: id.into(),
+        user_id: user_id.into(),
+        name: "solo".into(),
+        r#type: "acp".into(),
+        extra: extra.to_string(),
+        model: Some(serde_json::json!({ "provider_id": "acp", "model": "claude" }).to_string()),
+        status: None,
+        source: None,
+        channel_chat_id: None,
+        pinned: false,
+        pinned_at: None,
+        created_at: 0,
+        updated_at: 0,
+    }
 }
 
 #[async_trait::async_trait]
@@ -94,6 +126,13 @@ impl IConversationRepository for MockConversationRepo {
         &self,
         _user_id: &str,
         _cron_job_id: &str,
+    ) -> Result<Vec<ConversationRow>, DbError> {
+        Ok(vec![])
+    }
+    async fn list_by_team_id(
+        &self,
+        _user_id: &str,
+        _team_id: &str,
     ) -> Result<Vec<ConversationRow>, DbError> {
         Ok(vec![])
     }
@@ -472,11 +511,23 @@ fn success_factory() -> AgentFactory {
 }
 
 fn setup_with_factory(factory: AgentFactory) -> (TeamSessionService, Arc<CountingTaskManager>) {
+    let (svc, task_manager, _) = setup_with_factory_and_conv_repo(factory);
+    (svc, task_manager)
+}
+
+fn setup_with_factory_and_conv_repo(
+    factory: AgentFactory,
+) -> (
+    TeamSessionService,
+    Arc<CountingTaskManager>,
+    Arc<MockConversationRepo>,
+) {
     let team_repo: Arc<dyn ITeamRepository> = Arc::new(FullMockTeamRepo::new());
-    let conv_repo: Arc<dyn IConversationRepository> = Arc::new(MockConversationRepo::new());
+    let conv_repo = Arc::new(MockConversationRepo::new());
+    let conv_repo_dyn: Arc<dyn IConversationRepository> = conv_repo.clone();
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
     let conv_service = ConversationService::new_with_workspace_root(
-        conv_repo,
+        conv_repo_dyn,
         broadcaster.clone(),
         std::env::temp_dir(),
         Arc::new(StubSkillResolver),
@@ -491,7 +542,7 @@ fn setup_with_factory(factory: AgentFactory) -> (TeamSessionService, Arc<Countin
         task_manager_dyn,
         backend_binary_path,
     );
-    (svc, task_manager)
+    (svc, task_manager, conv_repo)
 }
 
 fn setup() -> TeamSessionService {
@@ -1386,4 +1437,123 @@ async fn d115_remove_team_kills_every_agent_process() {
         0,
         "every agent worker must be torn down after remove_team"
     );
+}
+
+// ===========================================================================
+// Test: W3-D15b — create_team conversation reuse
+// ===========================================================================
+
+fn agent_with_conv(conv_id: Option<&str>) -> TeamAgentInput {
+    TeamAgentInput {
+        name: "Lead".into(),
+        role: "lead".into(),
+        backend: "acp".into(),
+        model: "claude".into(),
+        custom_agent_id: None,
+        conversation_id: conv_id.map(str::to_owned),
+    }
+}
+
+#[tokio::test]
+async fn d15b_reuses_existing_conversation_and_stamps_team_id() {
+    let (svc, _, conv_repo) = setup_with_factory_and_conv_repo(success_factory());
+    conv_repo.insert_raw(stub_conversation_row(
+        "conv-existing",
+        "user1",
+        serde_json::json!({}),
+    ));
+    let count_before = conv_repo.conversations.lock().unwrap().len();
+
+    let resp = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "Reuse".into(),
+                agents: vec![agent_with_conv(Some("conv-existing"))],
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.agents[0].conversation_id, "conv-existing");
+
+    let count_after = conv_repo.conversations.lock().unwrap().len();
+    assert_eq!(
+        count_after, count_before,
+        "reuse path must not create a new conversation"
+    );
+
+    let extra = conv_repo.find_extra("conv-existing").unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&extra).unwrap();
+    assert_eq!(parsed["teamId"].as_str(), Some(resp.id.as_str()));
+}
+
+#[tokio::test]
+async fn d15b_missing_conversation_returns_not_found() {
+    let (svc, _, _) = setup_with_factory_and_conv_repo(success_factory());
+
+    let err = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "Missing".into(),
+                agents: vec![agent_with_conv(Some("conv-does-not-exist"))],
+            },
+        )
+        .await
+        .unwrap_err();
+
+    let app_err: aionui_common::AppError = err.into();
+    assert!(matches!(app_err, aionui_common::AppError::NotFound(_)));
+}
+
+#[tokio::test]
+async fn d15b_conversation_owned_by_other_user_returns_not_found() {
+    let (svc, _, conv_repo) = setup_with_factory_and_conv_repo(success_factory());
+    conv_repo.insert_raw(stub_conversation_row(
+        "conv-other",
+        "user2",
+        serde_json::json!({}),
+    ));
+
+    let err = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "Cross".into(),
+                agents: vec![agent_with_conv(Some("conv-other"))],
+            },
+        )
+        .await
+        .unwrap_err();
+
+    let app_err: aionui_common::AppError = err.into();
+    assert!(
+        matches!(app_err, aionui_common::AppError::NotFound(_)),
+        "cross-user reuse must masquerade as NotFound to avoid leaking existence"
+    );
+}
+
+#[tokio::test]
+async fn d15b_conversation_already_in_another_team_returns_bad_request() {
+    let (svc, _, conv_repo) = setup_with_factory_and_conv_repo(success_factory());
+    conv_repo.insert_raw(stub_conversation_row(
+        "conv-taken",
+        "user1",
+        serde_json::json!({ "teamId": "team-other" }),
+    ));
+
+    let err = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "Conflict".into(),
+                agents: vec![agent_with_conv(Some("conv-taken"))],
+            },
+        )
+        .await
+        .unwrap_err();
+
+    let app_err: aionui_common::AppError = err.into();
+    assert!(matches!(app_err, aionui_common::AppError::BadRequest(_)));
 }


### PR DESCRIPTION
## Summary

Implements W3-D15b — reuse of a solo conversation when `TeamAgentInput.conversation_id` is non-empty inside `TeamSessionService::create_team`.

- When `conversation_id: Some(id)` → validate ownership, reject conflict, stamp `extra.teamId`, and reuse the conversation (no new conversation row).
- When `conversation_id: None` → original create path is unchanged.
- Cross-user access masquerades as `NotFound` (existence is not leaked).
- `extra.teamId` already bound to a different team → `BadRequest`.

Depends on W3-D15a (`TeamAgentInput.conversation_id` field) already merged on `feat/team-wave3` (#71).

Spec: [interface-contracts §16.2](../blob/feat/team-wave3/docs/teams/phase1/interface-contracts.md#162-create_team-复用分支).

## Test plan

- [x] `cargo test -p aionui-team --test session_service_integration` — 42 tests pass, including 4 new D15b cases:
  - `d15b_reuses_existing_conversation_and_stamps_team_id`
  - `d15b_missing_conversation_returns_not_found`
  - `d15b_conversation_owned_by_other_user_returns_not_found`
  - `d15b_conversation_already_in_another_team_returns_bad_request`
- [x] `cargo test -p aionui-team --lib` — 212 unit tests pass (incl. new `conversation_not_found_maps_to_app_not_found`).
- [x] `cargo clippy -p aionui-team --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -p aionui-team --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)