### PR TITLE
feat(conversation): route send_message to team runtime when team_id set (W3-D16b)

### DIFF
--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -876,6 +876,25 @@ impl ConversationService {
                 AppError::NotFound(format!("Conversation {conversation_id} not found"))
             })?;
 
+        // Route to the team runtime when this conversation belongs to a team
+        // and a router is injected. The solo-chat pipeline below is left
+        // untouched. When `team_id` is set but no router has been wired
+        // (startup ordering, or a build without the team crate), log a
+        // warning and fall back to the solo path so legacy conversations
+        // keep working — graceful degradation per §17.2.
+        if let Some(team_id) = extract_team_id(&row.extra) {
+            if let Some(router) = self.team_router() {
+                return router
+                    .route_agent_message(&row.id, &req.content, false)
+                    .await;
+            }
+            warn!(
+                conversation_id = %row.id,
+                team_id = %team_id,
+                "team_router not injected; falling back to solo-chat path"
+            );
+        }
+
         // Short-circuit for legacy Gemini conversations: the dedicated Gemini
         // runtime has been removed, so we cannot build an agent for this row.
         // Emit CONVERSATION_ARCHIVED (HTTP 410 Gone) without touching the
@@ -1364,6 +1383,25 @@ fn legacy_cron_trigger_to_artifact(
         created_at: row.created_at,
         updated_at: row.created_at,
     })
+}
+
+/// Extract a non-empty `team_id` from a serialized `extra` JSON string.
+///
+/// Accepts both `team_id` and legacy `teamId` keys. Returns `None` when
+/// the JSON is invalid, the key is absent, or the value is not a
+/// non-empty string — so the caller can cleanly distinguish "belongs to
+/// a team" from "solo conversation".
+fn extract_team_id(extra: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(extra).ok()?;
+    let raw = value
+        .get("team_id")
+        .or_else(|| value.get("teamId"))
+        .and_then(|v| v.as_str())?;
+    if raw.is_empty() {
+        None
+    } else {
+        Some(raw.to_owned())
+    }
 }
 
 /// Merge `patch` into `base` (top-level key overwrite).

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -174,6 +174,14 @@ impl IConversationRepository for MockRepo {
         Ok(vec![])
     }
 
+    async fn list_by_team_id(
+        &self,
+        _user_id: &str,
+        _team_id: &str,
+    ) -> Result<Vec<ConversationRow>, aionui_db::DbError> {
+        Ok(vec![])
+    }
+
     async fn list_associated(
         &self,
         _user_id: &str,
@@ -2388,6 +2396,159 @@ async fn list_backfills_mixed_rows() {
         .unwrap();
     let extras: Vec<_> = resp.items.iter().map(|c| c.extra.clone()).collect();
     assert!(extras.iter().any(|e| e["skills"] == json!(["cron", "pdf"])));
+}
+
+// ── send_message team route-fork tests (W3-D16b) ────────────────
+
+/// Captures calls to `route_agent_message` so tests can assert the fork
+/// dispatched to the team runtime instead of the solo-chat pipeline.
+struct RecordingTeamRouter {
+    calls: Mutex<Vec<(String, String, bool)>>,
+}
+
+impl RecordingTeamRouter {
+    fn new() -> Self {
+        Self {
+            calls: Mutex::new(vec![]),
+        }
+    }
+
+    fn take_calls(&self) -> Vec<(String, String, bool)> {
+        std::mem::take(&mut self.calls.lock().unwrap())
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::traits::ITeamMessageRouter for RecordingTeamRouter {
+    async fn route_agent_message(
+        &self,
+        conversation_id: &str,
+        content: &str,
+        silent: bool,
+    ) -> Result<(), AppError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push((conversation_id.to_owned(), content.to_owned(), silent));
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn send_message_without_team_id_takes_solo_path() {
+    // No team_id in extra → must NOT call the injected router; user
+    // message still lands in repo via the solo pipeline.
+    let (svc, _broadcaster, repo, _default_task_mgr) = make_service();
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
+
+    let router = Arc::new(RecordingTeamRouter::new());
+    svc.set_team_router(Some(router.clone()));
+
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr)
+        .await
+        .unwrap();
+
+    assert!(
+        router.take_calls().is_empty(),
+        "router must not be called for solo conversations"
+    );
+    let messages = repo
+        .get_messages(&conv.id, 1, 20, SortOrder::Asc)
+        .await
+        .unwrap()
+        .items;
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.msg_id.as_deref() == Some("msg-1")),
+        "solo path must still persist the user message"
+    );
+}
+
+#[tokio::test]
+async fn send_message_with_team_id_delegates_to_router() {
+    // extra.team_id present + router injected → forward to router and
+    // short-circuit the solo pipeline (no user message persisted, no
+    // status flip to running).
+    let (svc, _broadcaster, repo, _default_task_mgr) = make_service();
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
+
+    let router = Arc::new(RecordingTeamRouter::new());
+    svc.set_team_router(Some(router.clone()));
+
+    let create_req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "model": { "provider_id": "p1", "model": "m1" },
+        "extra": { "workspace": "/project", "team_id": "team-42" }
+    }))
+    .unwrap();
+    let conv = svc.create("user_1", create_req).await.unwrap();
+
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr)
+        .await
+        .unwrap();
+
+    let calls = router.take_calls();
+    assert_eq!(calls.len(), 1, "router must receive exactly one call");
+    assert_eq!(calls[0].0, conv.id);
+    assert_eq!(calls[0].1, "Hello");
+    assert!(!calls[0].2, "silent must default to false");
+
+    // Solo-pipeline side effects must be skipped.
+    let messages = repo
+        .get_messages(&conv.id, 1, 20, SortOrder::Asc)
+        .await
+        .unwrap()
+        .items;
+    assert!(
+        messages.is_empty(),
+        "team route must not double-persist user messages via the solo path"
+    );
+    let row = repo.get(&conv.id).await.unwrap().unwrap();
+    assert_ne!(
+        row.status.as_deref(),
+        Some("running"),
+        "team route must not flip conversation status via solo-path side effects"
+    );
+}
+
+#[tokio::test]
+async fn send_message_with_team_id_but_no_router_falls_back_to_solo() {
+    // extra.team_id present but router None (startup ordering / no team
+    // crate) → graceful degradation into solo pipeline.
+    let (svc, _broadcaster, repo, _default_task_mgr) = make_service();
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
+
+    // Explicitly clear any router (defensive; constructor already None).
+    svc.set_team_router(None);
+
+    let create_req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "model": { "provider_id": "p1", "model": "m1" },
+        "extra": { "workspace": "/project", "team_id": "team-99" }
+    }))
+    .unwrap();
+    let conv = svc.create("user_1", create_req).await.unwrap();
+
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr)
+        .await
+        .unwrap();
+
+    // Without a router, the solo pipeline must still run so the message
+    // isn't silently lost.
+    let messages = repo
+        .get_messages(&conv.id, 1, 20, SortOrder::Asc)
+        .await
+        .unwrap()
+        .items;
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.msg_id.as_deref() == Some("msg-1")),
+        "fallback path must persist the user message"
+    );
 }
 
 #[tokio::test]

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -831,6 +831,13 @@ mod tests {
         ) -> Result<Vec<aionui_db::models::ConversationRow>, DbError> {
             Ok(vec![])
         }
+        async fn list_by_team_id(
+            &self,
+            _user_id: &str,
+            _team_id: &str,
+        ) -> Result<Vec<aionui_db::models::ConversationRow>, DbError> {
+            Ok(vec![])
+        }
         async fn list_associated(
             &self,
             _user_id: &str,
@@ -957,6 +964,13 @@ mod tests {
             &self,
             _user_id: &str,
             _cron_job_id: &str,
+        ) -> Result<Vec<aionui_db::models::ConversationRow>, DbError> {
+            Ok(vec![])
+        }
+        async fn list_by_team_id(
+            &self,
+            _user_id: &str,
+            _team_id: &str,
         ) -> Result<Vec<aionui_db::models::ConversationRow>, DbError> {
             Ok(vec![])
         }


### PR DESCRIPTION
## Summary

- `ConversationService::send_message` now checks the conversation's `extra.team_id` after the user/ownership guard. When the id is non-empty **and** an `ITeamMessageRouter` has been injected (wired in the upcoming W3-D16c), the call is forwarded to `router.route_agent_message(conv_id, content, silent=false)` and the solo-chat pipeline is short-circuited.
- When `team_id` is set but no router is wired yet (startup ordering, or a build without the team crate), we log a `tracing::warn!` and fall back to the solo path — graceful degradation per §17.2 so existing team rows keep working without a router.
- Solo conversations are untouched: the fork is gated on both `team_id.is_some()` **and** `team_router.is_some()`, so no solo-path behavior changes for rows without `team_id`.
- Adds no-op `list_by_team_id` stubs to the three test fakes already living in this crate (`MockRepo`, `NoopRepo`, `RecordingRepo`) so the `IConversationRepository` trait (extended in D13a) compiles here again. Non-behavioral drift fix.

Contract reference: [interface-contracts.md §17.2](../docs/teams/phase1/interface-contracts.md#172-send_message-路由分叉)

Dependencies: built on top of W3-D16a (trait + field already on `feat/team-wave3`).

## Test plan

- [x] `cargo test -p aionui-conversation --lib` — 113/113 passed, including 3 new tests
  - `send_message_without_team_id_takes_solo_path` — router injected but no team_id → router never called, solo message persisted
  - `send_message_with_team_id_delegates_to_router` — router receives `(conv_id, "Hello", false)`; solo side-effects (user message row, status flip to `running`) are skipped
  - `send_message_with_team_id_but_no_router_falls_back_to_solo` — router cleared, team_id set → solo pipeline runs and persists the user message
- [x] `cargo clippy -p aionui-conversation` — clean on `service.rs`; remaining warnings are pre-existing baseline issues on `feat/team-wave3` (unused `task_mgr` rebinds in legacy tests, `useless_conversion` in `make_service_with_resolver`, etc.) — untouched by this PR
- [x] `cargo build -p aionui-conversation` — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)