### PR TITLE
feat(team): impl ITeamMessageRouter on TeamSessionService (W3-D16c)

### DIFF
--- a/crates/aionui-app/src/state_builders.rs
+++ b/crates/aionui-app/src/state_builders.rs
@@ -132,6 +132,18 @@ pub async fn build_module_states(
         },
     };
 
+    // W3-D16c: wire the team session service as the ConversationService's
+    // team router so solo-chat `send_message` on a team-owned conversation is
+    // forwarded into the team runtime (§17.3). Must happen after both states
+    // are built; the set is a no-op until here because build_conversation_state
+    // initializes the router slot to None.
+    states
+        .conversation
+        .conversation_service
+        .set_team_router(Some(
+            states.team.service.clone() as Arc<dyn aionui_conversation::ITeamMessageRouter>
+        ));
+
     (states, channel_components)
 }
 

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -876,6 +876,25 @@ impl ConversationService {
                 AppError::NotFound(format!("Conversation {conversation_id} not found"))
             })?;
 
+        // Route to the team runtime when this conversation belongs to a team
+        // and a router is injected. The solo-chat pipeline below is left
+        // untouched. When `team_id` is set but no router has been wired
+        // (startup ordering, or a build without the team crate), log a
+        // warning and fall back to the solo path so legacy conversations
+        // keep working — graceful degradation per §17.2.
+        if let Some(team_id) = extract_team_id(&row.extra) {
+            if let Some(router) = self.team_router() {
+                return router
+                    .route_agent_message(&row.id, &req.content, false)
+                    .await;
+            }
+            warn!(
+                conversation_id = %row.id,
+                team_id = %team_id,
+                "team_router not injected; falling back to solo-chat path"
+            );
+        }
+
         // Short-circuit for legacy Gemini conversations: the dedicated Gemini
         // runtime has been removed, so we cannot build an agent for this row.
         // Emit CONVERSATION_ARCHIVED (HTTP 410 Gone) without touching the
@@ -1364,6 +1383,25 @@ fn legacy_cron_trigger_to_artifact(
         created_at: row.created_at,
         updated_at: row.created_at,
     })
+}
+
+/// Extract a non-empty `team_id` from a serialized `extra` JSON string.
+///
+/// Accepts both `team_id` and legacy `teamId` keys. Returns `None` when
+/// the JSON is invalid, the key is absent, or the value is not a
+/// non-empty string — so the caller can cleanly distinguish "belongs to
+/// a team" from "solo conversation".
+fn extract_team_id(extra: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(extra).ok()?;
+    let raw = value
+        .get("team_id")
+        .or_else(|| value.get("teamId"))
+        .and_then(|v| v.as_str())?;
+    if raw.is_empty() {
+        None
+    } else {
+        Some(raw.to_owned())
+    }
 }
 
 /// Merge `patch` into `base` (top-level key overwrite).

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -174,6 +174,14 @@ impl IConversationRepository for MockRepo {
         Ok(vec![])
     }
 
+    async fn list_by_team_id(
+        &self,
+        _user_id: &str,
+        _team_id: &str,
+    ) -> Result<Vec<ConversationRow>, aionui_db::DbError> {
+        Ok(vec![])
+    }
+
     async fn list_associated(
         &self,
         _user_id: &str,
@@ -2388,6 +2396,159 @@ async fn list_backfills_mixed_rows() {
         .unwrap();
     let extras: Vec<_> = resp.items.iter().map(|c| c.extra.clone()).collect();
     assert!(extras.iter().any(|e| e["skills"] == json!(["cron", "pdf"])));
+}
+
+// ── send_message team route-fork tests (W3-D16b) ────────────────
+
+/// Captures calls to `route_agent_message` so tests can assert the fork
+/// dispatched to the team runtime instead of the solo-chat pipeline.
+struct RecordingTeamRouter {
+    calls: Mutex<Vec<(String, String, bool)>>,
+}
+
+impl RecordingTeamRouter {
+    fn new() -> Self {
+        Self {
+            calls: Mutex::new(vec![]),
+        }
+    }
+
+    fn take_calls(&self) -> Vec<(String, String, bool)> {
+        std::mem::take(&mut self.calls.lock().unwrap())
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::traits::ITeamMessageRouter for RecordingTeamRouter {
+    async fn route_agent_message(
+        &self,
+        conversation_id: &str,
+        content: &str,
+        silent: bool,
+    ) -> Result<(), AppError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push((conversation_id.to_owned(), content.to_owned(), silent));
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn send_message_without_team_id_takes_solo_path() {
+    // No team_id in extra → must NOT call the injected router; user
+    // message still lands in repo via the solo pipeline.
+    let (svc, _broadcaster, repo, _default_task_mgr) = make_service();
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
+
+    let router = Arc::new(RecordingTeamRouter::new());
+    svc.set_team_router(Some(router.clone()));
+
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr)
+        .await
+        .unwrap();
+
+    assert!(
+        router.take_calls().is_empty(),
+        "router must not be called for solo conversations"
+    );
+    let messages = repo
+        .get_messages(&conv.id, 1, 20, SortOrder::Asc)
+        .await
+        .unwrap()
+        .items;
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.msg_id.as_deref() == Some("msg-1")),
+        "solo path must still persist the user message"
+    );
+}
+
+#[tokio::test]
+async fn send_message_with_team_id_delegates_to_router() {
+    // extra.team_id present + router injected → forward to router and
+    // short-circuit the solo pipeline (no user message persisted, no
+    // status flip to running).
+    let (svc, _broadcaster, repo, _default_task_mgr) = make_service();
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
+
+    let router = Arc::new(RecordingTeamRouter::new());
+    svc.set_team_router(Some(router.clone()));
+
+    let create_req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "model": { "provider_id": "p1", "model": "m1" },
+        "extra": { "workspace": "/project", "team_id": "team-42" }
+    }))
+    .unwrap();
+    let conv = svc.create("user_1", create_req).await.unwrap();
+
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr)
+        .await
+        .unwrap();
+
+    let calls = router.take_calls();
+    assert_eq!(calls.len(), 1, "router must receive exactly one call");
+    assert_eq!(calls[0].0, conv.id);
+    assert_eq!(calls[0].1, "Hello");
+    assert!(!calls[0].2, "silent must default to false");
+
+    // Solo-pipeline side effects must be skipped.
+    let messages = repo
+        .get_messages(&conv.id, 1, 20, SortOrder::Asc)
+        .await
+        .unwrap()
+        .items;
+    assert!(
+        messages.is_empty(),
+        "team route must not double-persist user messages via the solo path"
+    );
+    let row = repo.get(&conv.id).await.unwrap().unwrap();
+    assert_ne!(
+        row.status.as_deref(),
+        Some("running"),
+        "team route must not flip conversation status via solo-path side effects"
+    );
+}
+
+#[tokio::test]
+async fn send_message_with_team_id_but_no_router_falls_back_to_solo() {
+    // extra.team_id present but router None (startup ordering / no team
+    // crate) → graceful degradation into solo pipeline.
+    let (svc, _broadcaster, repo, _default_task_mgr) = make_service();
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
+
+    // Explicitly clear any router (defensive; constructor already None).
+    svc.set_team_router(None);
+
+    let create_req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "model": { "provider_id": "p1", "model": "m1" },
+        "extra": { "workspace": "/project", "team_id": "team-99" }
+    }))
+    .unwrap();
+    let conv = svc.create("user_1", create_req).await.unwrap();
+
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr)
+        .await
+        .unwrap();
+
+    // Without a router, the solo pipeline must still run so the message
+    // isn't silently lost.
+    let messages = repo
+        .get_messages(&conv.id, 1, 20, SortOrder::Asc)
+        .await
+        .unwrap()
+        .items;
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.msg_id.as_deref() == Some("msg-1")),
+        "fallback path must persist the user message"
+    );
 }
 
 #[tokio::test]

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -831,6 +831,13 @@ mod tests {
         ) -> Result<Vec<aionui_db::models::ConversationRow>, DbError> {
             Ok(vec![])
         }
+        async fn list_by_team_id(
+            &self,
+            _user_id: &str,
+            _team_id: &str,
+        ) -> Result<Vec<aionui_db::models::ConversationRow>, DbError> {
+            Ok(vec![])
+        }
         async fn list_associated(
             &self,
             _user_id: &str,
@@ -957,6 +964,13 @@ mod tests {
             &self,
             _user_id: &str,
             _cron_job_id: &str,
+        ) -> Result<Vec<aionui_db::models::ConversationRow>, DbError> {
+            Ok(vec![])
+        }
+        async fn list_by_team_id(
+            &self,
+            _user_id: &str,
+            _team_id: &str,
         ) -> Result<Vec<aionui_db::models::ConversationRow>, DbError> {
             Ok(vec![])
         }

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -5,11 +5,12 @@ use aionui_ai_agent::IWorkerTaskManager;
 use aionui_api_types::{
     AddAgentRequest, CreateConversationRequest, CreateTeamRequest, TeamAgentResponse, TeamResponse,
 };
-use aionui_common::{AgentKillReason, AgentType, ProviderWithModel, generate_id, now_ms};
-use aionui_conversation::ConversationService;
+use aionui_common::{AgentKillReason, AgentType, AppError, ProviderWithModel, generate_id, now_ms};
+use aionui_conversation::{ConversationService, ITeamMessageRouter};
 use aionui_db::models::TeamRow;
 use aionui_db::{ITeamRepository, UpdateTeamParams};
 use aionui_realtime::EventBroadcaster;
+use async_trait::async_trait;
 use dashmap::DashMap;
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
@@ -565,6 +566,59 @@ impl TeamSessionService {
             self.stop_session(&key);
         }
         info!("All team sessions disposed");
+    }
+
+    /// Locate the (team_id, slot_id) pair that owns a given conversation.
+    ///
+    /// Phase1 walks every live session's agent roster — cheap at the current
+    /// scale (≤ dozens of sessions × ≤ dozens of agents) and keeps the data
+    /// flow one-directional (no reverse index to invalidate when agents are
+    /// added, removed, or renamed).
+    async fn locate_agent_by_conversation(
+        &self,
+        conversation_id: &str,
+    ) -> Option<(String, String)> {
+        for entry in self.sessions.iter() {
+            let team_id = entry.key().clone();
+            let agents = entry.session.scheduler().list_agents().await;
+            if let Some(agent) = agents
+                .into_iter()
+                .find(|a| a.conversation_id == conversation_id)
+            {
+                return Some((team_id, agent.slot_id));
+            }
+        }
+        None
+    }
+}
+
+#[async_trait]
+impl ITeamMessageRouter for TeamSessionService {
+    /// Route a solo-chat `send_message` into the team runtime by locating the
+    /// conversation's owning session and slot, then deferring to
+    /// [`Self::send_message_to_agent`].
+    ///
+    /// `silent` is accepted for forward compatibility with the team prompt
+    /// pipeline but is unused in phase1 — the mailbox contract currently has
+    /// no "silent" variant, so every routed message is a normal user message.
+    async fn route_agent_message(
+        &self,
+        conversation_id: &str,
+        content: &str,
+        _silent: bool,
+    ) -> Result<(), AppError> {
+        let (team_id, slot_id) = self
+            .locate_agent_by_conversation(conversation_id)
+            .await
+            .ok_or_else(|| {
+                AppError::NotFound(format!(
+                    "no live team session owns conversation {conversation_id}"
+                ))
+            })?;
+
+        self.send_message_to_agent(&team_id, &slot_id, content, None)
+            .await
+            .map_err(Into::into)
     }
 }
 

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -13,7 +13,7 @@ use aionui_db::{
 };
 use aionui_realtime::EventBroadcaster;
 
-use aionui_conversation::ConversationService;
+use aionui_conversation::{ConversationService, ITeamMessageRouter};
 use aionui_team::TeamSessionService;
 use common::MockTeamRepo;
 
@@ -101,6 +101,13 @@ impl IConversationRepository for MockConversationRepo {
         &self,
         _user_id: &str,
         _conversation_id: &str,
+    ) -> Result<Vec<ConversationRow>, DbError> {
+        Ok(vec![])
+    }
+    async fn list_by_team_id(
+        &self,
+        _user_id: &str,
+        _team_id: &str,
     ) -> Result<Vec<ConversationRow>, DbError> {
         Ok(vec![])
     }
@@ -1385,5 +1392,29 @@ async fn d115_remove_team_kills_every_agent_process() {
         tm.active_count(),
         0,
         "every agent worker must be torn down after remove_team"
+    );
+}
+
+// ===========================================================================
+// W3-D16c: ITeamMessageRouter impl
+// ===========================================================================
+
+/// When a conversation does not belong to any live team session, the router
+/// must surface `AppError::NotFound` rather than silently succeeding or
+/// panicking — ConversationService relies on this signal to distinguish
+/// "truly unknown" from "known but team runtime unavailable".
+#[tokio::test]
+async fn route_agent_message_unknown_conversation_returns_not_found() {
+    let svc = setup();
+    let router: &dyn ITeamMessageRouter = &svc;
+
+    let err = router
+        .route_agent_message("conv-does-not-exist", "hello", false)
+        .await
+        .expect_err("routing an unknown conversation must fail");
+
+    assert!(
+        matches!(err, AppError::NotFound(ref msg) if msg.contains("conv-does-not-exist")),
+        "expected NotFound carrying the conversation id, got: {err:?}"
     );
 }


### PR DESCRIPTION
## Summary

- `TeamSessionService` 实现 `ITeamMessageRouter`：按 `conversation_id` 遍历 live sessions 的 agent 名单反查 `(team_id, slot_id)`，委托给已有的 `send_message_to_agent`；未命中返 `AppError::NotFound`。
- 在 `build_module_states` 把 team service 注入到 `ConversationService::set_team_router`，闭合 W3-D16b 的路由分叉（§17.3）。
- `silent` 参数保留 trait 签名但在 phase1 不生效（mailbox 目前无 silent 变体）。
- 顺手补齐 `aionui-team` 集成测试 mock 的 `IConversationRepository::list_by_team_id`（D13a 引入的 trait 方法）。

## 依赖

基于 `w3-d16b/conv-route-fork`（包含 W3-D16a trait 定义 + W3-D16b send_message 分叉逻辑）。

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p aionui-team` — 337 条全绿，含新增 `route_agent_message_unknown_conversation_returns_not_found`
- [x] `cargo clippy -p aionui-team --lib --tests -- -D warnings`
- [x] `rustfmt --check` 仅改动 3 个文件
- 注：`cargo clippy -p aionui-app` 有 3 条 pre-existing 错误（全在 `aionui-cron`，与本 PR 无关）

🤖 Generated with [Claude Code](https://claude.com/claude-code)