### PR TITLE
test(team): lock in renamed_agents rendering in lead/teammate prompts (W3-D14c)

### DIFF
--- a/crates/aionui-team/src/prompts/lead.rs
+++ b/crates/aionui-team/src/prompts/lead.rs
@@ -320,6 +320,37 @@ mod tests {
     }
 
     #[test]
+    fn build_lead_prompt_renders_formerly_note_in_full_output() {
+        // End-to-end: the `[formerly: X]` annotation must survive template
+        // substitution and appear verbatim in the final lead prompt text.
+        let mut renamed = HashMap::new();
+        renamed.insert("w2".to_owned(), "OldAlice".to_owned());
+        let mut a = make_teammate("w1", "Bob", "claude");
+        a.status = Some(TeammateStatus::Idle);
+        let mut b = make_teammate("w2", "Alice", "codex");
+        b.status = Some(TeammateStatus::Working);
+        let teammates = vec![a, b];
+        let params = LeadPromptParams {
+            team_name: "Alpha",
+            teammates: &teammates,
+            available_agent_types: &[],
+            available_assistants: &[],
+            renamed_agents: &renamed,
+            team_workspace: None,
+        };
+        let out = build_lead_prompt(&params);
+        assert!(
+            out.contains("- Alice (codex, status: working) [formerly: OldAlice]"),
+            "renamed teammate bullet missing in final prompt:\n{out}"
+        );
+        assert!(
+            out.contains("- Bob (claude, status: idle)")
+                && !out.contains("Bob (claude, status: idle) [formerly:"),
+            "non-renamed teammate must not carry [formerly: ...] suffix:\n{out}"
+        );
+    }
+
+    #[test]
     fn available_types_section_omitted_when_empty() {
         assert_eq!(render_available_types_section(&[]), "");
     }

--- a/crates/aionui-team/src/prompts/teammate.rs
+++ b/crates/aionui-team/src/prompts/teammate.rs
@@ -370,6 +370,36 @@ mod tests {
         assert!(out.contains("Role: general-purpose AI assistant"));
     }
 
+    #[test]
+    fn teammate_prompt_lists_multiple_renamed_agents_with_formerly_note() {
+        // When several teammates carry former names, each entry must receive
+        // its own `[formerly: X]` suffix in the comma-joined list.
+        let lead = make_agent("lead-1", "Captain", TeammateRole::Lead, "claude");
+        let agent = make_agent("w1", "Worker1", TeammateRole::Teammate, "claude");
+        let mate_a = make_agent("w2", "Alice", TeammateRole::Teammate, "claude");
+        let mate_b = make_agent("w3", "Bob", TeammateRole::Teammate, "codex");
+        let mate_c = make_agent("w4", "Carol", TeammateRole::Teammate, "gemini");
+        let mut renamed = HashMap::new();
+        renamed.insert("w2".into(), "OldAlice".into());
+        renamed.insert("w4".into(), "OldCarol".into());
+        let params = TeammatePromptParams {
+            agent: &agent,
+            team_name: "Alpha",
+            leader: &lead,
+            teammates: &[mate_a, mate_b, mate_c],
+            renamed_agents: &renamed,
+            team_workspace: None,
+        };
+        let out = build_teammate_prompt(&params);
+
+        assert!(
+            out.contains(
+                "Teammates: Alice [formerly: OldAlice], Bob, Carol [formerly: OldCarol]"
+            ),
+            "teammate list must annotate both renamed agents and leave Bob untouched:\n{out}"
+        );
+    }
+
     // Test 3: wake payload with empty mailbox and no tasks
     #[test]
     fn wake_payload_empty_mailbox_no_tasks() {


### PR DESCRIPTION
## Summary

Task **W3-D14c** — Prompt builder reads `renamed_agents` to render `[formerly: X]` annotations in leader / teammate prompts.

**Result: already implemented by D5b-2 and D5c.** Both `build_lead_prompt` (`crates/aionui-team/src/prompts/lead.rs`) and `build_teammate_prompt` (`crates/aionui-team/src/prompts/teammate.rs`) already read `params.renamed_agents` and append ` [formerly: {old_name}]` to matching teammates. Unit-level tests for the renderers were already present.

Per task spec ("if already implemented, just verify + add tests to confirm"), this PR adds two end-to-end regression tests at the builder level to lock the feature in:

- `lead.rs :: build_lead_prompt_renders_formerly_note_in_full_output` — drives the full template substitution and asserts the `[formerly: X]` suffix appears in the final prompt text; negative assertion that non-renamed teammates stay unannotated.
- `teammate.rs :: teammate_prompt_lists_multiple_renamed_agents_with_formerly_note` — covers multiple renamed teammates in the comma-joined `Teammates:` list, confirming each renamed entry gets its own `[formerly: X]` suffix while untouched names remain plain.

No production code changed. +61 lines of tests, 0 lines deleted.

## Test plan

- [x] `cargo test -p aionui-team --lib` — 217 passed, 0 failed
- [x] `cargo test -p aionui-team --lib prompts` — 41 passed (the 2 new cases included)
- [x] `cargo clippy -p aionui-team --lib -- -D warnings` — clean
- [ ] (Out of scope for D14c) `session_service_integration` has a pre-existing duplicate `list_by_team_id` definition in a test mock vs. the new D14b trait method — tracked independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)