### PR TITLE
feat(team): add McpReadyNotification protocol type (W4-D24a)

### DIFF
--- a/crates/aionui-team/src/mcp/protocol.rs
+++ b/crates/aionui-team/src/mcp/protocol.rs
@@ -122,6 +122,38 @@ pub async fn write_response<W: AsyncWriteExt + Unpin>(
 }
 
 // ---------------------------------------------------------------------------
+// MCP ready notification (W4-D24a)
+//
+// Bridge 在 TCP connect + initialize 成功后 fire-and-forget 发送一帧通知给
+// TeamMcpServer，声明对应 slot 已就绪。扁平结构（非 JSON-RPC），格式：
+//   { "type": "mcp_ready", "slot_id": "...", "auth_token": "..." }
+// 事实来源：docs/teams/phase1/aionui-audit.md §3.1 "MCP ready 握手"
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpReadyNotification {
+    pub r#type: String,
+    pub slot_id: String,
+    pub auth_token: String,
+}
+
+impl McpReadyNotification {
+    pub const TYPE: &'static str = "mcp_ready";
+
+    pub fn new(slot_id: impl Into<String>, auth_token: impl Into<String>) -> Self {
+        Self {
+            r#type: Self::TYPE.to_string(),
+            slot_id: slot_id.into(),
+            auth_token: auth_token.into(),
+        }
+    }
+
+    pub fn is_mcp_ready(json: &serde_json::Value) -> bool {
+        json.get("type").and_then(|v| v.as_str()) == Some(Self::TYPE)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -237,5 +269,39 @@ mod tests {
         let mut cursor = std::io::Cursor::new(buf);
         let read_back = read_frame(&mut cursor).await.unwrap();
         assert!(read_back.is_empty());
+    }
+
+    #[test]
+    fn mcp_ready_notification_roundtrip() {
+        let original = McpReadyNotification::new("slot-123", "token-abc");
+        let json = serde_json::to_string(&original).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["type"], "mcp_ready");
+        assert_eq!(value["slot_id"], "slot-123");
+        assert_eq!(value["auth_token"], "token-abc");
+
+        let parsed: McpReadyNotification = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.r#type, "mcp_ready");
+        assert_eq!(parsed.slot_id, "slot-123");
+        assert_eq!(parsed.auth_token, "token-abc");
+    }
+
+    #[test]
+    fn mcp_ready_notification_is_mcp_ready() {
+        let positive = serde_json::json!({
+            "type": "mcp_ready",
+            "slot_id": "s",
+            "auth_token": "t"
+        });
+        assert!(McpReadyNotification::is_mcp_ready(&positive));
+
+        let wrong_type = serde_json::json!({ "type": "other" });
+        assert!(!McpReadyNotification::is_mcp_ready(&wrong_type));
+
+        let missing_type = serde_json::json!({ "slot_id": "s" });
+        assert!(!McpReadyNotification::is_mcp_ready(&missing_type));
+
+        let non_object = serde_json::json!("mcp_ready");
+        assert!(!McpReadyNotification::is_mcp_ready(&non_object));
     }
 }


### PR DESCRIPTION
## Summary

- 定义 `McpReadyNotification` 结构与 `is_mcp_ready` 判定辅助方法
- 用于 stdio bridge 在 TCP connect + initialize 成功后 fire-and-forget 的就绪通知帧
- 扁平格式：\`{ \"type\": \"mcp_ready\", \"slot_id\": \"...\", \"auth_token\": \"...\" }\`

事实来源：[docs/teams/phase1/aionui-audit.md §3.1 \"MCP ready 握手\"](../blob/main/docs/teams/phase1/aionui-audit.md#31-能力清单)

模块规约：[docs/teams/phase1/modules.md W4-D24a](../blob/main/docs/teams/phase1/modules.md)

## Test plan

- [x] \`cargo test -p aionui-team --lib mcp::protocol\` — 12 passed（新增 2 条：roundtrip + is_mcp_ready）
- [x] \`cargo clippy -p aionui-team --lib -- -D warnings\` — clean
- [x] \`cargo fmt -p aionui-team -- --check\` — clean