### PR TITLE
feat(team): add is_rate_limited stream-event classifier (W4-D21)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,7 @@ dependencies = [
  "async-trait",
  "axum",
  "dashmap",
+ "regex",
  "serde",
  "serde_json",
  "sqlx",

--- a/crates/aionui-team/Cargo.toml
+++ b/crates/aionui-team/Cargo.toml
@@ -19,6 +19,7 @@ thiserror.workspace = true
 tracing.workspace = true
 async-trait.workspace = true
 dashmap.workspace = true
+regex.workspace = true
 agent-client-protocol = "0.11.1"
 
 [dev-dependencies]

--- a/crates/aionui-team/src/crash_detection.rs
+++ b/crates/aionui-team/src/crash_detection.rs
@@ -1,0 +1,63 @@
+//! Classify fatal agent stream events into recoverable (rate-limited) vs crash.
+//!
+//! Paired with W4-D20a `detect_crash`. Rate-limit errors are surfaced as
+//! `TeammateStatus::Failed` without going through crash recovery (no kill,
+//! no testament) — see interface-contracts §23.
+
+use aionui_ai_agent::stream_event::AgentStreamEvent;
+use regex::Regex;
+use std::sync::OnceLock;
+
+fn rate_limit_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r"(?i)429|rate.?limit|quota|too many requests")
+            .expect("rate-limit regex must compile")
+    })
+}
+
+/// Returns true when an [`AgentStreamEvent::Error`] message looks like an
+/// upstream rate-limit / quota response.
+pub fn is_rate_limited(event: &AgentStreamEvent) -> bool {
+    match event {
+        AgentStreamEvent::Error(data) => rate_limit_regex().is_match(&data.message),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aionui_ai_agent::stream_event::{ErrorEventData, StartEventData};
+
+    fn error_event(message: &str) -> AgentStreamEvent {
+        AgentStreamEvent::Error(ErrorEventData {
+            message: message.to_string(),
+            code: None,
+        })
+    }
+
+    #[test]
+    fn http_429_is_rate_limited() {
+        assert!(is_rate_limited(&error_event("HTTP 429 Too Many Requests")));
+    }
+
+    #[test]
+    fn rate_limit_phrase_is_rate_limited() {
+        assert!(is_rate_limited(&error_event(
+            "Anthropic API: rate limit exceeded, retry later"
+        )));
+    }
+
+    #[test]
+    fn plain_error_is_not_rate_limited() {
+        assert!(!is_rate_limited(&error_event("syntax error at line 42")));
+    }
+
+    #[test]
+    fn non_error_event_is_not_rate_limited() {
+        assert!(!is_rate_limited(&AgentStreamEvent::Start(
+            StartEventData::default()
+        )));
+    }
+}

--- a/crates/aionui-team/src/lib.rs
+++ b/crates/aionui-team/src/lib.rs
@@ -1,4 +1,5 @@
 //! Multi-agent team sessions with role-based prompts, task board, mailbox, and scheduling.
+pub mod crash_detection;
 pub mod error;
 pub mod events;
 pub mod mailbox;
@@ -13,6 +14,7 @@ pub mod task_board;
 pub(crate) mod test_utils;
 pub mod types;
 
+pub use crash_detection::is_rate_limited;
 pub use error::TeamError;
 pub use events::TeamEventEmitter;
 pub use mailbox::Mailbox;


### PR DESCRIPTION
## Summary

- Add `aionui_team::crash_detection::is_rate_limited(&AgentStreamEvent) -> bool`, a pure regex-based classifier that detects HTTP 429 / rate-limit / quota / \"too many requests\" responses in `AgentStreamEvent::Error` messages.
- Wire the new `crash_detection` module into `aionui-team`'s `lib.rs` and add `regex` as a direct dependency (already a workspace dep).
- Per [interface-contracts §23](../docs/teams/phase1/interface-contracts.md#23-429--rate-limit-识别), rate-limited errors are meant to be handled as `TeammateStatus::Failed` without entering crash recovery (no kill, no testament). This PR delivers only the detection primitive; call-site integration in `on_agent_finish` lives in the downstream task.

## Module

- Task: W4-D21 — 429 / rate-limit 识别
- Doc: `docs/teams/phase1/modules.md` §W4-D21
- Depends on: W4-D20a (parallel; module placed next to future `detect_crash`)

## Test plan

- [x] `cargo test -p aionui-team --lib crash_detection` — 4 new unit tests pass:
  - `http_429_is_rate_limited`
  - `rate_limit_phrase_is_rate_limited`
  - `plain_error_is_not_rate_limited`
  - `non_error_event_is_not_rate_limited`
- [x] `cargo clippy -p aionui-team --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)