### PR TITLE
feat(team): W4-D23 per-team add_agent_locks (agents list race fix)

### DIFF
--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -32,6 +32,10 @@ pub struct TeamSessionService {
     task_manager: Arc<dyn IWorkerTaskManager>,
     backend_binary_path: Arc<PathBuf>,
     sessions: Arc<DashMap<String, SessionEntry>>,
+    /// Per-team mutex serializing `add_agent` so concurrent callers cannot
+    /// read-modify-write the `agents` JSON with stale state (last-writer-wins
+    /// would otherwise drop entries).
+    add_agent_locks: Arc<DashMap<String, Arc<tokio::sync::Mutex<()>>>>,
 }
 
 impl TeamSessionService {
@@ -49,6 +53,7 @@ impl TeamSessionService {
             task_manager,
             backend_binary_path,
             sessions: Arc::new(DashMap::new()),
+            add_agent_locks: Arc::new(DashMap::new()),
         }
     }
 
@@ -202,6 +207,10 @@ impl TeamSessionService {
         self.repo.delete_tasks_by_team(team_id).await?;
         self.repo.delete_team(team_id).await?;
 
+        // Drop the per-team add_agent lock so the DashMap entry does not leak
+        // across team lifecycles (W4-D23).
+        self.add_agent_locks.remove(team_id);
+
         info!(team_id = %team_id, "Team removed");
         Ok(())
     }
@@ -231,6 +240,13 @@ impl TeamSessionService {
         team_id: &str,
         req: AddAgentRequest,
     ) -> Result<TeamAgentResponse, TeamError> {
+        let lock = self
+            .add_agent_locks
+            .entry(team_id.to_owned())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone();
+        let _guard = lock.lock().await;
+
         let row = self
             .repo
             .get_team(team_id)

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -1258,6 +1258,86 @@ async fn d9_ensure_session_rollbacks_when_build_fails() {
 // Test: D11.5 remove_team cascades kill to every agent process
 // ===========================================================================
 
+// ===========================================================================
+// Test: W4-D23 add_agent_locks — per-team serialization prevents last-writer-
+// wins when two tasks race on add_agent.
+// ===========================================================================
+
+#[tokio::test]
+async fn w4_d23_concurrent_add_agent_preserves_every_insertion() {
+    // Two concurrent add_agent calls on the same team must both be persisted
+    // (no silent drop from unsynchronized read-modify-write on the agents
+    // JSON blob).
+    let svc = Arc::new(setup());
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "T".into(),
+                agents: vec![TeamAgentInput {
+                    name: "Lead".into(),
+                    role: "lead".into(),
+                    backend: "acp".into(),
+                    model: "claude".into(),
+                    custom_agent_id: None,
+                }],
+            },
+        )
+        .await
+        .unwrap();
+
+    let svc_a = svc.clone();
+    let team_id_a = created.id.clone();
+    let task_a = tokio::spawn(async move {
+        svc_a
+            .add_agent(
+                "user1",
+                &team_id_a,
+                AddAgentRequest {
+                    name: "WorkerA".into(),
+                    role: "teammate".into(),
+                    backend: "acp".into(),
+                    model: "claude".into(),
+                    custom_agent_id: None,
+                },
+            )
+            .await
+    });
+
+    let svc_b = svc.clone();
+    let team_id_b = created.id.clone();
+    let task_b = tokio::spawn(async move {
+        svc_b
+            .add_agent(
+                "user1",
+                &team_id_b,
+                AddAgentRequest {
+                    name: "WorkerB".into(),
+                    role: "teammate".into(),
+                    backend: "acp".into(),
+                    model: "claude".into(),
+                    custom_agent_id: None,
+                },
+            )
+            .await
+    });
+
+    let (a, b) = tokio::join!(task_a, task_b);
+    a.unwrap().unwrap();
+    b.unwrap().unwrap();
+
+    let got = svc.get_team(&created.id).await.unwrap();
+    assert_eq!(
+        got.agents.len(),
+        3,
+        "both concurrent add_agent calls must be persisted (1 lead + 2 workers)"
+    );
+    let names: std::collections::HashSet<_> = got.agents.iter().map(|a| a.name.clone()).collect();
+    assert!(names.contains("Lead"));
+    assert!(names.contains("WorkerA"));
+    assert!(names.contains("WorkerB"));
+}
+
 #[tokio::test]
 async fn d115_remove_team_kills_every_agent_process() {
     let (svc, tm) = setup_with_factory(success_factory());


### PR DESCRIPTION
## Summary
- Adds a per-team `tokio::sync::Mutex` (`add_agent_locks: DashMap<String, Arc<Mutex<()>>>`) on `TeamSessionService` and acquires it at the entry of `add_agent`.
- Without this lock, two concurrent `add_agent` calls on the same team can both read the current `agents` JSON, mutate independent copies, and overwrite each other (last-writer-wins), silently dropping one insertion.
- `remove_team` removes the lock entry to prevent `DashMap` leak across team lifecycles.
- Does not change any logic inside `add_agent` — only serializes entry.

## Scope
- `crates/aionui-team/src/service.rs` — +16 lines (field, init, lock acquire, lock cleanup).
- `crates/aionui-team/tests/session_service_integration.rs` — +80 lines: one concurrency test spawning two tokio tasks that race `add_agent` on the same team, asserting both insertions persist.

## Test plan
- [x] `cargo build -p aionui-team` passes.
- [x] `cargo test -p aionui-team --lib` — 205 lib tests pass.
- [x] `cargo test -p aionui-team --test session_service_integration w4_d23_concurrent_add_agent_preserves_every_insertion` passes.
- [x] `cargo clippy -p aionui-team --all-targets -- -D warnings` — no warnings.
- [x] `cargo fmt -p aionui-team -- --check` — clean.
- Pre-existing failure `d9_ensure_session_rollbacks_when_build_fails` also fails on `main` at 1ba599b — not introduced by this PR.

## Doc reference
- `docs/teams/phase1/modules.md` §W4-D23
- `docs/teams/phase1/interface-contracts.md` §25

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>