### PR TITLE
feat(ai-agent): add AgentStreamChunk enum (W4-D25a)

### DIFF
--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -67,7 +67,7 @@ pub use skill_manager::{
 pub use stream_event::AgentStreamEvent;
 pub use task_manager::{AgentFactory, IWorkerTaskManager, WorkerTaskManagerImpl};
 pub use types::{
-    AcpBuildExtra, AcpModelInfo, AcpSessionConfigOption, AionrsBuildExtra, AionrsCompatOverrides,
-    AionrsResolvedConfig, BuildTaskOptions, OpenClawBuildExtra, OpenClawGatewayConfig,
-    RemoteBuildExtra, SendMessageData, SlashCommandItem,
+    AcpBuildExtra, AcpModelInfo, AcpSessionConfigOption, AgentStreamChunk, AionrsBuildExtra,
+    AionrsCompatOverrides, AionrsResolvedConfig, BuildTaskOptions, OpenClawBuildExtra,
+    OpenClawGatewayConfig, RemoteBuildExtra, SendMessageData, SlashCommandItem,
 };

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -213,6 +213,33 @@ pub struct SlashCommandItem {
     pub description: String,
 }
 
+/// Unified stream chunk published on the per-session broadcast channel.
+///
+/// Emitted by `AgentManagerHandle` implementations at every stream event so
+/// downstream subscribers (wake timeout watchdog, crash detector) can observe
+/// agent progress without intercepting the existing frontend event pipeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AgentStreamChunk {
+    Text {
+        text: String,
+    },
+    ToolUse {
+        tool_name: String,
+        input: serde_json::Value,
+    },
+    Thought {
+        content: String,
+    },
+    Finish {
+        agent_crash: bool,
+        stop_reason: Option<String>,
+    },
+    Error {
+        message: String,
+    },
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -359,6 +386,77 @@ mod tests {
         assert!(extra.system_prompt.is_none());
         assert_eq!(extra.max_tokens, 8192);
         assert!(extra.max_turns.is_none());
+    }
+
+    #[test]
+    fn agent_stream_chunk_all_variants_serde_roundtrip() {
+        let cases = vec![
+            AgentStreamChunk::Text {
+                text: "hello".into(),
+            },
+            AgentStreamChunk::ToolUse {
+                tool_name: "read_file".into(),
+                input: json!({ "path": "/tmp/a.txt" }),
+            },
+            AgentStreamChunk::Thought {
+                content: "analyzing".into(),
+            },
+            AgentStreamChunk::Finish {
+                agent_crash: false,
+                stop_reason: Some("end_turn".into()),
+            },
+            AgentStreamChunk::Error {
+                message: "timeout".into(),
+            },
+        ];
+        for chunk in cases {
+            let json = serde_json::to_value(&chunk).unwrap();
+            let parsed: AgentStreamChunk = serde_json::from_value(json).unwrap();
+            match (chunk, parsed) {
+                (AgentStreamChunk::Text { text: a }, AgentStreamChunk::Text { text: b }) => {
+                    assert_eq!(a, b);
+                }
+                (
+                    AgentStreamChunk::ToolUse {
+                        tool_name: a1,
+                        input: a2,
+                    },
+                    AgentStreamChunk::ToolUse {
+                        tool_name: b1,
+                        input: b2,
+                    },
+                ) => {
+                    assert_eq!(a1, b1);
+                    assert_eq!(a2, b2);
+                }
+                (
+                    AgentStreamChunk::Thought { content: a },
+                    AgentStreamChunk::Thought { content: b },
+                ) => {
+                    assert_eq!(a, b);
+                }
+                (
+                    AgentStreamChunk::Finish {
+                        agent_crash: a1,
+                        stop_reason: a2,
+                    },
+                    AgentStreamChunk::Finish {
+                        agent_crash: b1,
+                        stop_reason: b2,
+                    },
+                ) => {
+                    assert_eq!(a1, b1);
+                    assert_eq!(a2, b2);
+                }
+                (
+                    AgentStreamChunk::Error { message: a },
+                    AgentStreamChunk::Error { message: b },
+                ) => {
+                    assert_eq!(a, b);
+                }
+                _ => panic!("variant mismatch after roundtrip"),
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- 按 [interface-contracts.md §19.1](../blob/main/docs/teams/phase1/interface-contracts.md#19-agentstream-chunk-订阅底座wave-4--模块-w4-d25) 在 `crates/aionui-ai-agent/src/types.rs` 新增 `AgentStreamChunk` enum：`Text` / `ToolUse` / `Thought` / `Finish { agent_crash, stop_reason }` / `Error { message }`
- 仅类型定义，不含 emit 点、不含 trait 方法、不改任何现有 stream 处理逻辑
- 为 wave 4 的 wake timeout watchdog（W4-D18）、crash detector（W4-D20）、broadcast 底座（W4-D25b/c）提供共用类型

## Scope

- 新增 enum：`+78` lines in `types.rs`
- `pub use` 一条：`lib.rs`
- 新增测试 1 条：`agent_stream_chunk_all_variants_serde_roundtrip` — 5 个 variant 全部 JSON roundtrip
- 不引入新依赖

## 依赖关系

- 无上游依赖
- 下游：W4-D25b（subscribe_stream trait 方法）、W4-D25c（broadcast 注入）、W4-D18、W4-D20

## Test plan

- [x] `cargo test -p aionui-ai-agent --lib types::` — 14 passed
- [x] `cargo clippy -p aionui-ai-agent --lib -- -D warnings` — clean
- [x] `rustfmt --check crates/aionui-ai-agent/src/{types,lib}.rs` — clean
- 注：`cargo clippy -p aionui-ai-agent --all-targets` 在 integration tests 里存在 22 个已有 lint 错误（`await_holding_lock` 等），与本 PR 无关，在 main 上同样存在。

## 任务来源

- [docs/teams/phase1/modules.md §W4-D25a](../blob/main/docs/teams/phase1/modules.md) L591-L600
- [docs/teams/phase1/interface-contracts.md §19.1](../blob/main/docs/teams/phase1/interface-contracts.md) L857-L912