### PR TITLE
feat(team): integrate finalized_turns dedup into on_agent_finish (W4-D19b)

### DIFF
--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -154,6 +154,12 @@ impl TeamSession {
         conversation_id: &str,
         is_error: bool,
     ) -> Result<Option<String>, TeamError> {
+        // Dedup: skip if another finish event already claimed this conversation
+        // within the 5-second window (W4-D19a).
+        if !self.scheduler.begin_finalize(conversation_id) {
+            return Ok(None);
+        }
+
         let slot_id = {
             let agents = self.scheduler.list_agents().await;
             agents
@@ -173,7 +179,16 @@ impl TeamSession {
                 .await?;
         }
 
-        self.scheduler.finalize_turn(&slot_id, &[]).await
+        let wake_target = self.scheduler.finalize_turn(&slot_id, &[]).await?;
+
+        // Clear the dedup window once finalize succeeded — the next legitimate
+        // finish event (after the re-woken agent completes) must be allowed
+        // through.
+        if wake_target.is_some() {
+            self.scheduler.clear_finalized_turn(conversation_id);
+        }
+
+        Ok(wake_target)
     }
 
     /// Write a user message to the lead's mailbox and trigger a wake.


### PR DESCRIPTION
## Summary

- Add `begin_finalize` dedup guard at the start of `on_agent_finish` to reject duplicate finish events within the 5-second window introduced by W4-D19a
- Call `clear_finalized_turn` after `finalize_turn` succeeds with a wake target, so the dedup window is released before the next agent cycle

## Test plan

- [x] Existing `on_agent_finish_marks_idle_and_returns_lead_when_all_settled` passes (first call to `begin_finalize` returns true)
- [x] Existing `on_agent_finish_lead_returns_none` passes
- [x] Existing `on_agent_finish_unknown_conversation_returns_error` passes
- [x] `cargo test -p aionui-team --lib session::tests::on_agent_finish` — all 3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)