### PR TITLE
W5-D28a: is_team_capable_backend pure fn + whitelist

### DIFF
--- a/crates/aionui-team/src/guide/capability.rs
+++ b/crates/aionui-team/src/guide/capability.rs
@@ -1,0 +1,32 @@
+pub const TEAM_CAPABLE_BACKENDS: &[&str] = &["claude", "codex", "gemini", "aionrs"];
+
+pub fn is_team_capable_backend(backend: &str, mcp_stdio_capable: bool) -> bool {
+    TEAM_CAPABLE_BACKENDS.contains(&backend) || mcp_stdio_capable
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn whitelist_backend_is_capable_regardless_of_mcp_flag() {
+        assert!(is_team_capable_backend("claude", false));
+        assert!(is_team_capable_backend("claude", true));
+        assert!(is_team_capable_backend("codex", false));
+        assert!(is_team_capable_backend("gemini", false));
+        assert!(is_team_capable_backend("aionrs", false));
+    }
+
+    #[test]
+    fn non_whitelist_backend_with_mcp_stdio_is_capable() {
+        assert!(is_team_capable_backend("custom", true));
+        assert!(is_team_capable_backend("unknown-backend", true));
+    }
+
+    #[test]
+    fn non_whitelist_backend_without_mcp_stdio_is_not_capable() {
+        assert!(!is_team_capable_backend("custom", false));
+        assert!(!is_team_capable_backend("", false));
+        assert!(!is_team_capable_backend("Claude", false));
+    }
+}

--- a/crates/aionui-team/src/guide/mod.rs
+++ b/crates/aionui-team/src/guide/mod.rs
@@ -1,0 +1,1 @@
+pub mod capability;

--- a/crates/aionui-team/src/lib.rs
+++ b/crates/aionui-team/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod crash_detection;
 pub mod error;
 pub mod events;
+pub mod guide;
 pub mod mailbox;
 pub mod mcp;
 pub mod prompts;


### PR DESCRIPTION
## Summary

- Add `crates/aionui-team/src/guide/capability.rs` with `TEAM_CAPABLE_BACKENDS` constant (`claude`, `codex`, `gemini`, `aionrs`) and pure fn `is_team_capable_backend(backend, mcp_stdio_capable)` returning `true` when the backend is on the whitelist OR advertises MCP stdio capability.
- Register new `guide` module via `guide/mod.rs` and `pub mod guide;` in `crates/aionui-team/src/lib.rs`.
- Pure function, no IO, no state — ready to be consumed by downstream team-spawn gating logic (W5-D28b/c).

## Test plan

- [x] `cargo test -p aionui-team --lib guide::capability` — 3/3 pass
  - `whitelist_backend_is_capable_regardless_of_mcp_flag`
  - `non_whitelist_backend_with_mcp_stdio_is_capable`
  - `non_whitelist_backend_without_mcp_stdio_is_not_capable`
- [x] `cargo clippy -p aionui-team -- -D warnings` clean on new files (pre-existing warnings in `mcp/server.rs` are out of scope for this task)

Branch: `w5-d28a/team-capable` from `main` → targeting `feat/team-wave4-5`.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>