### PR TITLE
W5-D29a-1: SpawnAgentRequest type + spawn_agent skeleton

### DIFF
--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -27,6 +27,16 @@ pub struct WakeInput {
     pub should_send: bool,
 }
 
+/// Input for [`TeamSession::spawn_agent`]. Populated by the lead agent when
+/// it calls the `spawn_agent` MCP tool.
+#[derive(Debug, Clone)]
+pub struct SpawnAgentRequest {
+    pub name: String,
+    pub agent_type: Option<String>,
+    pub custom_agent_id: Option<String>,
+    pub model: Option<String>,
+}
+
 pub struct TeamSession {
     team: Team,
     scheduler: Arc<TeammateManager>,
@@ -307,6 +317,10 @@ impl TeamSession {
 
     pub async fn rename_agent(&self, slot_id: &str, new_name: &str) -> Result<(), TeamError> {
         self.scheduler.rename_agent(slot_id, new_name).await
+    }
+
+    pub async fn spawn_agent(&self, _caller_slot_id: &str, _req: SpawnAgentRequest) -> Result<TeamAgent, TeamError> {
+        todo!("W5-D29a-2..D29d will fill in the implementation")
     }
 
     pub fn stop(&self) {


### PR DESCRIPTION
## Summary
- Add `SpawnAgentRequest` struct to `crates/aionui-team/src/session.rs`
- Add `TeamSession::spawn_agent(&self, caller_slot_id, req) -> Result<TeamAgent, TeamError>` skeleton gated with `todo!()`
- Later slices `W5-D29a-2..D29d` will fill in the implementation (agent allocation, ensure_session, mailbox seeding, etc.)

## Scope
Intentionally minimal: type + method signature only. No behavior change; the method panics if called.

## Test plan
- [x] `cargo check -p aionui-team` — green
- [x] `cargo test -p aionui-team --lib` — 225 pass, 1 pre-existing flake (`session::tests::mcp_stdio_config_for_agent`, port race) unrelated to this change; reproduced on main without the diff.
- [x] No test exercises `spawn_agent` directly, so `todo!()` is never triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)