### PR TITLE
feat(team): intercept shutdown_approved/rejected in team_send_message (W5-D30a-1)

### DIFF
--- a/crates/aionui-team/src/mcp/server.rs
+++ b/crates/aionui-team/src/mcp/server.rs
@@ -348,6 +348,18 @@ async fn exec_describe_assistant(args: &Value) -> Result<String, String> {
 async fn exec_send_message(args: &Value, scheduler: &TeammateManager, caller_slot_id: &str) -> Result<String, String> {
     let input: SendMessageInput = serde_json::from_value(args.clone()).map_err(|e| format!("Invalid params: {e}"))?;
 
+    let trimmed = input.message.trim();
+    if trimmed == "shutdown_approved" {
+        // W5-D30a-2 will wire the real approval handling; this stub intercepts the sentinel so it never reaches the recipient.
+        debug!(from = caller_slot_id, "shutdown_approved intercepted");
+        return Ok(json!({"status": "shutdown_approved_received"}).to_string());
+    }
+    if trimmed.starts_with("shutdown_rejected:") {
+        // W5-D30b will wire the real rejection handling; this stub intercepts the sentinel so it never reaches the recipient.
+        debug!(from = caller_slot_id, "shutdown_rejected intercepted");
+        return Ok(json!({"status": "shutdown_rejected_received"}).to_string());
+    }
+
     let action = crate::scheduler::SchedulerAction::SendMessage {
         to: input.to.clone(),
         message: input.message,

--- a/crates/aionui-team/tests/mcp_server_integration.rs
+++ b/crates/aionui-team/tests/mcp_server_integration.rs
@@ -313,6 +313,70 @@ async fn ts3_send_message_to_nonexistent_agent() {
     env.server.stop();
 }
 
+#[tokio::test]
+async fn ts_shutdown_approved_intercepted() {
+    let env = setup().await;
+    let mut stream = connect_and_init(env.server.port(), "test-token-123", "worker-1").await;
+
+    let resp = call_tool(
+        &mut stream,
+        2,
+        "team_send_message",
+        json!({"to": "lead-1", "message": "shutdown_approved"}),
+    )
+    .await;
+
+    assert!(!is_error_response(&resp));
+    let text = extract_text(&resp);
+    let payload: Value = serde_json::from_str(&text).expect("interception payload is JSON");
+    assert_eq!(payload["status"], "shutdown_approved_received");
+
+    env.server.stop();
+}
+
+#[tokio::test]
+async fn ts_shutdown_rejected_intercepted() {
+    let env = setup().await;
+    let mut stream = connect_and_init(env.server.port(), "test-token-123", "worker-1").await;
+
+    let resp = call_tool(
+        &mut stream,
+        2,
+        "team_send_message",
+        json!({"to": "lead-1", "message": "shutdown_rejected: still finishing task"}),
+    )
+    .await;
+
+    assert!(!is_error_response(&resp));
+    let text = extract_text(&resp);
+    let payload: Value = serde_json::from_str(&text).expect("interception payload is JSON");
+    assert_eq!(payload["status"], "shutdown_rejected_received");
+
+    env.server.stop();
+}
+
+#[tokio::test]
+async fn ts_regular_message_not_intercepted() {
+    let env = setup().await;
+    let mut stream = connect_and_init(env.server.port(), "test-token-123", "worker-1").await;
+
+    let resp = call_tool(
+        &mut stream,
+        2,
+        "team_send_message",
+        json!({"to": "lead-1", "message": "just a normal update"}),
+    )
+    .await;
+
+    assert!(!is_error_response(&resp));
+    let text = extract_text(&resp);
+    assert!(text.contains("lead-1"));
+    assert!(!text.contains("shutdown_approved_received"));
+    assert!(!text.contains("shutdown_rejected_received"));
+
+    env.server.stop();
+}
+
 // ---------------------------------------------------------------------------
 // Tests: team_spawn_agent (SP-1, SP-2, SP-3)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add sentinel-string interception in `exec_send_message`: `shutdown_approved` and `shutdown_rejected: <reason>` short-circuit the send, return a JSON-stringified status payload, and emit a `debug!` trace.
- Both branches are explicit placeholders; wiring the real approved/rejected handling is left to follow-up tickets W5-D30a-2 and W5-D30b respectively.

## Why
Teammates reply to a shutdown request with exactly `shutdown_approved` or `shutdown_rejected: <reason>` (see `crates/aionui-team/src/prompts/teammate.rs`). Without interception those strings would reach the recipient's mailbox and read like a normal message. This PR closes that gap with a cheap content check — behaviour parity with mocks, real semantics to land next.

## Test plan
- [x] `cargo test -p aionui-team --test mcp_server_integration` — 29 passing, including three new tests:
  - `ts_shutdown_approved_intercepted` — asserts `{"status":"shutdown_approved_received"}` payload
  - `ts_shutdown_rejected_intercepted` — asserts `{"status":"shutdown_rejected_received"}` payload
  - `ts_regular_message_not_intercepted` — ordinary content still goes through `SendMessage`
- [x] `cargo clippy -p aionui-team --no-deps --tests -- -D warnings` — clean for this change; the two `unused_variables` warnings inside the unrelated `http_mcp_loop` (server.rs:515 / 570) are pre-existing on `origin/main` (verified by stash-and-rerun).
- [x] `cargo test -p aionui-team --lib` — 225/226 passing; the single unrelated failure `session::tests::mcp_stdio_config_for_agent` is pre-existing on `origin/main` (port mismatch between server and config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)