### PR TITLE
feat(team): reject shutdown_agent when target is team lead (W5-D30c)

### DIFF
--- a/crates/aionui-team/src/scheduler.rs
+++ b/crates/aionui-team/src/scheduler.rs
@@ -611,8 +611,11 @@ impl TeammateManager {
 
         {
             let slots = self.slots.lock().await;
-            if !slots.contains_key(target_slot_id) {
-                return Err(TeamError::AgentNotFound(target_slot_id.to_owned()));
+            let target = slots
+                .get(target_slot_id)
+                .ok_or_else(|| TeamError::AgentNotFound(target_slot_id.to_owned()))?;
+            if target.agent.role == TeammateRole::Lead {
+                return Err(TeamError::InvalidRequest("cannot shutdown the team lead".into()));
             }
         }
 
@@ -1146,6 +1149,52 @@ mod tests {
         };
         let result = mgr.execute_action("worker-1", &action).await;
         assert!(matches!(result, Err(TeamError::InvalidRequest(_))));
+    }
+
+    #[tokio::test]
+    async fn lead_cannot_shutdown_lead() {
+        let agents = make_team_agents();
+        let repo = Arc::new(MockTeamRepo::new());
+        let mailbox = Arc::new(Mailbox::new(repo.clone()));
+        let task_board = Arc::new(TaskBoard::new(repo));
+        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
+        let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+
+        let action = SchedulerAction::ShutdownAgent {
+            slot_id: "lead-1".into(),
+            reason: Some("trying to shutdown self".into()),
+        };
+        let result = mgr.execute_action("lead-1", &action).await;
+        assert!(
+            matches!(&result, Err(TeamError::InvalidRequest(msg)) if msg.contains("lead")),
+            "lead shutting down lead must be rejected, got {result:?}"
+        );
+
+        // No ShutdownRequest message should have been written to the lead's mailbox.
+        let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+        assert!(lead_msgs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn lead_can_shutdown_worker() {
+        // Positive-path sanity check that the new target-role guard does not
+        // regress the normal shutdown flow.
+        let agents = make_team_agents();
+        let repo = Arc::new(MockTeamRepo::new());
+        let mailbox = Arc::new(Mailbox::new(repo.clone()));
+        let task_board = Arc::new(TaskBoard::new(repo));
+        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
+        let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+
+        let action = SchedulerAction::ShutdownAgent {
+            slot_id: "worker-1".into(),
+            reason: Some("not needed".into()),
+        };
+        mgr.execute_action("lead-1", &action).await.unwrap();
+
+        let msgs = mailbox.read_unread("t1", "worker-1").await.unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].msg_type, MailboxMessageType::ShutdownRequest);
     }
 
     // -- execute_action: RenameAgent -----------------------------------------


### PR DESCRIPTION
## Summary

`handle_shutdown_agent` already refused callers whose role was not `Lead`, but nothing stopped the lead from shutting itself down (or a second lead, if one ever existed). This adds a target-role check after the existence lookup so the action fails with `InvalidRequest("cannot shutdown the team lead")` and no `ShutdownRequest` is written.

- Reuses `TeamError::InvalidRequest` for symmetry with the existing caller-role guard — no new error variant needed.
- The check runs under the same `slots` read lock as the existence lookup, so no extra round-trip.

## Test plan

- [x] `cargo fmt -p aionui-team --check`
- [x] `cargo test -p aionui-team --lib scheduler::tests` — 53/53 pass, including the new `lead_cannot_shutdown_lead` and `lead_can_shutdown_worker`
- [x] Manual trace-through of both branches (existence miss vs lead-target) to confirm lock is released before returning

### Out of scope (pre-existing on `origin/main`)

- `cargo clippy -p aionui-team -- -D warnings` still fails on two unused bindings in `crates/aionui-team/src/mcp/server.rs` (`token` at L515, `slot_id` at L570). Not introduced by this PR — confirmed present on `origin/main@0cf96d1`. Belongs to the MCP-server wave.
- `session::tests::mcp_stdio_config_for_agent` is a flaky port-collision test on `origin/main`; untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)