### PR TITLE
feat(ai-agent): wire AgentStreamChunk emits through ACP dispatch (W4-D25c-2)

### DIFF
--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -16,8 +16,8 @@ use crate::stream_event::{AgentStreamEvent, permission_request_to_event_data};
 use crate::types::{AcpBuildExtra, AgentStreamChunk, SendMessageData, SlashCommandItem};
 use agent_client_protocol::schema::{
     AgentCapabilities, AvailableCommand, CancelNotification, ContentBlock, HttpHeader, LoadSessionRequest, McpServer,
-    McpServerHttp, NewSessionRequest, PromptRequest, SessionConfigOption, SessionId, SessionModeState, SessionModelState,
-    SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest, UsageUpdate,
+    McpServerHttp, NewSessionRequest, PromptRequest, SessionConfigOption, SessionId, SessionModeState,
+    SessionModelState, SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest, UsageUpdate,
 };
 use aionui_api_types::{AgentHandshake, AgentMetadata};
 
@@ -478,7 +478,7 @@ impl AcpAgentManager {
         let (permission_tx, permission_rx) = mpsc::channel(32);
 
         // Connect via ACP SDK — executes initialize handshake
-        let protocol = AcpProtocol::connect(stdin, stdout, event_tx.clone(), permission_tx)
+        let protocol = AcpProtocol::connect(stdin, stdout, event_tx.clone(), stream_tx.clone(), permission_tx)
             .await
             .map_err(|e| {
                 error!(
@@ -1000,7 +1000,26 @@ impl crate::agent_manager::IAgentManager for AcpAgentManager {
 
     async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
         self.last_activity.store(now_ms(), Ordering::Relaxed);
-        self.ensure_session_and_send(&data).await
+
+        // Drive the session, then emit a terminal chunk so subscribers
+        // (wake timeout watchdog, crash detector) always see a Finish or
+        // Error at the end of every turn — matching the contract documented
+        // on `AgentStreamChunk`.
+        let result = self.ensure_session_and_send(&data).await;
+        match &result {
+            Ok(()) => {
+                let _ = self.stream_tx.send(AgentStreamChunk::Finish {
+                    agent_crash: false,
+                    stop_reason: None,
+                });
+            }
+            Err(err) => {
+                let _ = self.stream_tx.send(AgentStreamChunk::Error {
+                    message: err.to_string(),
+                });
+            }
+        }
+        result
     }
 
     async fn stop(&self) -> Result<(), AppError> {

--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -13,11 +13,11 @@ use crate::agent_registry::CatalogSender;
 use crate::cli_process::CliAgentProcess;
 use crate::skill_manager::AcpSkillManager;
 use crate::stream_event::{AgentStreamEvent, permission_request_to_event_data};
-use crate::types::{AcpBuildExtra, SendMessageData, SlashCommandItem};
+use crate::types::{AcpBuildExtra, AgentStreamChunk, SendMessageData, SlashCommandItem};
 use agent_client_protocol::schema::{
-    AgentCapabilities, AvailableCommand, CancelNotification, ContentBlock, EnvVariable, HttpHeader, LoadSessionRequest,
-    McpServer, McpServerHttp, NewSessionRequest, PromptRequest, SessionConfigOption, SessionId, SessionModeState,
-    SessionModelState, SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest, UsageUpdate,
+    AgentCapabilities, AvailableCommand, CancelNotification, ContentBlock, HttpHeader, LoadSessionRequest, McpServer,
+    McpServerHttp, NewSessionRequest, PromptRequest, SessionConfigOption, SessionId, SessionModeState, SessionModelState,
+    SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest, UsageUpdate,
 };
 use aionui_api_types::{AgentHandshake, AgentMetadata};
 
@@ -228,6 +228,11 @@ pub struct AcpAgentManager {
     protocol: AcpProtocol,
     /// Typed event broadcast channel.
     event_tx: broadcast::Sender<AgentStreamEvent>,
+    /// Raw stream chunk broadcast channel consumed by the team scheduler's
+    /// wake-timeout watchdog. Emission points are wired up in W4-D25c-2;
+    /// this channel exists from D25c-1 onward so `subscribe_stream` can
+    /// hand out live receivers regardless of whether emitters are active.
+    stream_tx: broadcast::Sender<AgentStreamChunk>,
     /// Mutable runtime state.
     state: RwLock<AcpState>,
     /// Timestamp of last activity (atomic for lock-free reads).
@@ -469,6 +474,7 @@ impl AcpAgentManager {
             .ok_or_else(|| AppError::Internal("Failed to take stdio from CLI process".into()))?;
 
         let (event_tx, _) = broadcast::channel(256);
+        let (stream_tx, _) = broadcast::channel(256);
         let (permission_tx, permission_rx) = mpsc::channel(32);
 
         // Connect via ACP SDK — executes initialize handshake
@@ -515,6 +521,7 @@ impl AcpAgentManager {
             process: Arc::new(process),
             protocol,
             event_tx,
+            stream_tx,
             state: RwLock::new(AcpState {
                 status: None,
                 session_id: None,
@@ -987,6 +994,10 @@ impl crate::agent_manager::IAgentManager for AcpAgentManager {
         self.event_tx.subscribe()
     }
 
+    fn subscribe_stream(&self) -> broadcast::Receiver<AgentStreamChunk> {
+        self.stream_tx.subscribe()
+    }
+
     async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
         self.last_activity.store(now_ms(), Ordering::Relaxed);
         self.ensure_session_and_send(&data).await
@@ -1117,6 +1128,19 @@ impl crate::agent_manager::IAgentManager for AcpAgentManager {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// The stream channel powering [`AcpAgentManager::subscribe_stream`] is
+    /// created identically to the one inside `new()` — capacity 256 and
+    /// the `AgentStreamChunk` element type. Subscribing before any emit
+    /// yields a live receiver that observes `TryRecvError::Empty`. Once
+    /// D25c-2 wires up emitters, existing subscribers will begin seeing
+    /// chunks; the empty-on-idle contract stays intact.
+    #[test]
+    fn stream_channel_yields_live_receiver_that_is_initially_empty() {
+        let (tx, _) = broadcast::channel::<AgentStreamChunk>(256);
+        let mut rx = tx.subscribe();
+        assert!(matches!(rx.try_recv(), Err(broadcast::error::TryRecvError::Empty)));
+    }
 
     #[test]
     fn confirm_option_id_accepts_string_or_object() {

--- a/crates/aionui-ai-agent/src/acp_protocol.rs
+++ b/crates/aionui-ai-agent/src/acp_protocol.rs
@@ -27,6 +27,7 @@ use tracing::{debug, warn};
 
 use crate::acp_error::AcpError;
 use crate::stream_event::{self, AgentStreamEvent};
+use crate::types::AgentStreamChunk;
 
 use agent_client_protocol::schema::{
     AgentCapabilities, AuthMethod, AuthenticateRequest, CancelNotification, CloseSessionRequest, ExtNotification,
@@ -65,6 +66,7 @@ enum AcpAgentCommand {
     SessionUpdate {
         notification: SessionNotification,
         event_tx: broadcast::Sender<AgentStreamEvent>,
+        stream_tx: broadcast::Sender<AgentStreamChunk>,
     },
     /// Agent requests permission from the user before performing an action.
     RequestPermission {
@@ -159,6 +161,7 @@ impl AcpProtocol {
         stdin: ChildStdin,
         stdout: ChildStdout,
         event_tx: broadcast::Sender<AgentStreamEvent>,
+        stream_tx: broadcast::Sender<AgentStreamChunk>,
         permission_tx: mpsc::Sender<PermissionRequest>,
     ) -> Result<Self, AcpError> {
         let alive = Arc::new(AtomicBool::new(true));
@@ -175,6 +178,7 @@ impl AcpProtocol {
             stdin,
             stdout,
             event_tx,
+            stream_tx,
             permission_tx,
             init_tx,
             clicmd_rx,
@@ -368,10 +372,12 @@ async fn execute_initialize(
 ///
 /// This is the top-level future spawned as the background task in
 /// [`AcpProtocol::connect`].
+#[allow(clippy::too_many_arguments)]
 async fn run_sdk_event_loop(
     stdin: ChildStdin,
     stdout: ChildStdout,
     event_tx: broadcast::Sender<AgentStreamEvent>,
+    stream_tx: broadcast::Sender<AgentStreamChunk>,
     permission_tx: mpsc::Sender<PermissionRequest>,
     init_tx: oneshot::Sender<Result<InitializeResponse, AcpError>>,
     clicmd_rx: mpsc::Receiver<AcpClientCommand>,
@@ -387,6 +393,7 @@ async fn run_sdk_event_loop(
                     let cmd = AcpAgentCommand::SessionUpdate {
                         notification,
                         event_tx: event_tx.clone(),
+                        stream_tx: stream_tx.clone(),
                     };
                     dispatch_agent_command(cmd).await;
                     Ok(())
@@ -505,12 +512,25 @@ async fn dispatch_client_command(connection: &ConnectionTo<Agent>, cmd: AcpClien
 /// Mirrors [`dispatch_client_command`] for the client → agent direction.
 async fn dispatch_agent_command(cmd: AcpAgentCommand) {
     match cmd {
-        AcpAgentCommand::SessionUpdate { notification, event_tx } => {
+        AcpAgentCommand::SessionUpdate {
+            notification,
+            event_tx,
+            stream_tx,
+        } => {
             log_incoming("session/update", &json_str(&notification));
 
             let events = stream_event::session_notification_to_events(&notification);
             for event in events {
                 let _ = event_tx.send(event);
+            }
+
+            // Parallel projection onto the AgentStreamChunk broadcast channel.
+            // Subscribers (wake timeout watchdog, crash detector) only care
+            // about message/thought/tool-call chunks; handshake-like updates
+            // are filtered out inside `session_notification_to_chunks`.
+            let chunks = stream_event::session_notification_to_chunks(&notification);
+            for chunk in chunks {
+                let _ = stream_tx.send(chunk);
             }
         }
         AcpAgentCommand::RequestPermission {

--- a/crates/aionui-ai-agent/src/stream_event.rs
+++ b/crates/aionui-ai-agent/src/stream_event.rs
@@ -9,6 +9,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::debug;
 
+use crate::types::AgentStreamChunk;
+
 /// Events emitted by an Agent during a message processing turn.
 ///
 /// These are parsed from Agent stdout (line-delimited JSON) and forwarded
@@ -553,6 +555,57 @@ pub fn session_notification_to_events(notif: &SessionNotification) -> Vec<AgentS
     events
 }
 
+/// Convert an SDK [`SessionNotification`] into zero or more [`AgentStreamChunk`]s.
+///
+/// Parallel projection of [`session_notification_to_events`] onto the smaller
+/// [`AgentStreamChunk`] enum consumed by `subscribe_stream()`. Only message/
+/// thought/tool-call updates are projected — handshake-like updates
+/// (mode/model/config/session-info/usage/plan) are skipped since they are not
+/// useful for the wake-timeout watchdog or crash detector that subscribe to
+/// this stream.
+pub fn session_notification_to_chunks(notif: &SessionNotification) -> Vec<AgentStreamChunk> {
+    let mut chunks = Vec::new();
+
+    match &notif.update {
+        SessionUpdate::AgentMessageChunk(chunk) => {
+            if let ContentBlock::Text(text) = &chunk.content {
+                chunks.push(AgentStreamChunk::Text {
+                    text: text.text.clone(),
+                });
+            }
+        }
+        SessionUpdate::AgentThoughtChunk(chunk) => {
+            if let ContentBlock::Text(text) = &chunk.content {
+                chunks.push(AgentStreamChunk::Thought {
+                    content: text.text.clone(),
+                });
+            }
+        }
+        SessionUpdate::ToolCall(tc) => {
+            chunks.push(AgentStreamChunk::ToolUse {
+                tool_name: tc.title.clone(),
+                input: tc.raw_input.clone().unwrap_or(Value::Null),
+            });
+        }
+        SessionUpdate::ToolCallUpdate(tcu) => {
+            // Only emit ToolUse on updates that carry a fresh raw_input —
+            // status-only updates (e.g. Completed with no new input) would
+            // duplicate earlier emits without adding signal for the
+            // watchdog.
+            if let Some(raw_input) = tcu.fields.raw_input.clone() {
+                let tool_name = tcu.fields.title.clone().unwrap_or_default();
+                chunks.push(AgentStreamChunk::ToolUse {
+                    tool_name,
+                    input: raw_input,
+                });
+            }
+        }
+        _ => {}
+    }
+
+    chunks
+}
+
 fn map_sdk_tool_status(sdk: &SdkToolCallStatus) -> AcpToolCallStatus {
     match sdk {
         SdkToolCallStatus::Pending => AcpToolCallStatus::Pending,
@@ -667,9 +720,9 @@ fn map_tool_call_locations(locations: &[SdkToolCallLocation]) -> Option<Vec<AcpT
 mod tests {
     use super::*;
     use agent_client_protocol::schema::{
-        PermissionOption, PermissionOptionKind as SdkPermissionOptionKind, SessionNotification, SessionUpdate,
-        ToolCall as SdkToolCall, ToolCallStatus as SdkToolCallStatus, ToolCallUpdate as SdkToolCallUpdate,
-        ToolCallUpdateFields, ToolKind as SdkToolKind,
+        ContentBlock, ContentChunk, PermissionOption, PermissionOptionKind as SdkPermissionOptionKind,
+        SessionNotification, SessionUpdate, ToolCall as SdkToolCall, ToolCallStatus as SdkToolCallStatus,
+        ToolCallUpdate as SdkToolCallUpdate, ToolCallUpdateFields, ToolKind as SdkToolKind,
     };
     use serde_json::json;
 
@@ -905,5 +958,106 @@ mod tests {
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["type"], "thinking");
         assert_eq!(json["data"]["duration"], 1500);
+    }
+
+    // ── session_notification_to_chunks projection tests ──────────────────────
+
+    #[test]
+    fn agent_message_chunk_maps_to_text_chunk() {
+        let notif = SessionNotification::new(
+            "sess-1",
+            SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::from("hello world"))),
+        );
+        let chunks = session_notification_to_chunks(&notif);
+        assert_eq!(chunks.len(), 1);
+        match &chunks[0] {
+            AgentStreamChunk::Text { text } => assert_eq!(text, "hello world"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_thought_chunk_maps_to_thought_chunk() {
+        let notif = SessionNotification::new(
+            "sess-1",
+            SessionUpdate::AgentThoughtChunk(ContentChunk::new(ContentBlock::from("thinking..."))),
+        );
+        let chunks = session_notification_to_chunks(&notif);
+        assert_eq!(chunks.len(), 1);
+        match &chunks[0] {
+            AgentStreamChunk::Thought { content } => assert_eq!(content, "thinking..."),
+            other => panic!("expected Thought, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_call_maps_to_tool_use_chunk() {
+        let notif = SessionNotification::new(
+            "sess-1",
+            SessionUpdate::ToolCall(
+                SdkToolCall::new("tool-1", "read_file")
+                    .kind(SdkToolKind::Read)
+                    .status(SdkToolCallStatus::Pending)
+                    .raw_input(json!({ "path": "/tmp/a.txt" })),
+            ),
+        );
+        let chunks = session_notification_to_chunks(&notif);
+        assert_eq!(chunks.len(), 1);
+        match &chunks[0] {
+            AgentStreamChunk::ToolUse { tool_name, input } => {
+                assert_eq!(tool_name, "read_file");
+                assert_eq!(input["path"], "/tmp/a.txt");
+            }
+            other => panic!("expected ToolUse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_call_update_without_raw_input_is_skipped() {
+        // Status-only updates should not produce a ToolUse chunk — they'd
+        // duplicate earlier emits without adding signal for the watchdog.
+        let notif = SessionNotification::new(
+            "sess-1",
+            SessionUpdate::ToolCallUpdate(SdkToolCallUpdate::new(
+                "tool-1",
+                ToolCallUpdateFields::new().status(SdkToolCallStatus::Completed),
+            )),
+        );
+        let chunks = session_notification_to_chunks(&notif);
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn tool_call_update_with_raw_input_emits_tool_use() {
+        let notif = SessionNotification::new(
+            "sess-1",
+            SessionUpdate::ToolCallUpdate(SdkToolCallUpdate::new(
+                "tool-1",
+                ToolCallUpdateFields::new()
+                    .title("search")
+                    .raw_input(json!({ "q": "foo" })),
+            )),
+        );
+        let chunks = session_notification_to_chunks(&notif);
+        assert_eq!(chunks.len(), 1);
+        match &chunks[0] {
+            AgentStreamChunk::ToolUse { tool_name, input } => {
+                assert_eq!(tool_name, "search");
+                assert_eq!(input["q"], "foo");
+            }
+            other => panic!("expected ToolUse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_update_does_not_produce_chunks() {
+        // Handshake-like updates (plan/mode/model/config/session-info/usage)
+        // should not surface on the subscribe_stream channel.
+        let notif = SessionNotification::new(
+            "sess-1",
+            SessionUpdate::CurrentModeUpdate(agent_client_protocol::schema::CurrentModeUpdate::new("normal")),
+        );
+        let chunks = session_notification_to_chunks(&notif);
+        assert!(chunks.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

W4-D25c-2: wires producers for the `stream_tx` broadcast channel added in
W4-D25c-1 (PR #93). Before this change, `subscribe_stream()` existed but
had no emitters — subscribers would never observe any `AgentStreamChunk`.
After this change, the wake-timeout watchdog and crash detector can
observe agent progress in real time.

## Design note — scope differs from task brief

The task brief said "inject `stream_tx.send` in acp_agent.rs at every
chunk handling point." In reality, `acp_agent.rs` only emits control
events (`Start` / `Finish` / `SessionAssigned` / snapshot). The real
Text / Thought / ToolCall chunks come from
`acp_protocol.rs::dispatch_agent_command` via
`session_notification_to_events`. Emitting only in `acp_agent.rs` would
leave `Text` / `ToolUse` / `Thought` permanently empty.

Aligned with lead before commit: stream_tx is threaded through
`AcpProtocol::connect` → `run_sdk_event_loop` → the `on_receive_notification`
callback → `AcpAgentCommand::SessionUpdate { stream_tx }` →
`dispatch_agent_command`, which forks both an `AgentStreamEvent` (via
existing projection) and an `AgentStreamChunk` (via new
`session_notification_to_chunks`).

## Changes

- **acp_protocol.rs**: `connect` / `run_sdk_event_loop` /
  `AcpAgentCommand::SessionUpdate` gain `stream_tx: broadcast::Sender<AgentStreamChunk>`.
  `dispatch_agent_command` forwards each projected chunk.
- **stream_event.rs**: new `session_notification_to_chunks` maps SDK
  variants (`AgentMessageChunk` → `Text`, `AgentThoughtChunk` → `Thought`,
  `ToolCall`/`ToolCallUpdate` → `ToolUse`). Handshake-like updates
  (mode/model/config/session-info/usage/plan) are filtered out —
  they're not useful signal for the watchdog/crash subscribers.
- **acp_agent.rs**: `send_message` emits a terminal chunk per turn:
  `Ok → Finish { agent_crash: false, stop_reason: None }`,
  `Err → Error { message }`. Guarantees every turn produces an end
  marker even when the CLI doesn't emit a final text chunk.

## Tests (5 new unit tests in stream_event.rs)

- `agent_message_chunk_maps_to_text_chunk`
- `agent_thought_chunk_maps_to_thought_chunk`
- `tool_call_maps_to_tool_use_chunk`
- `tool_call_update_without_raw_input_is_skipped`
- `tool_call_update_with_raw_input_emits_tool_use`
- `plan_update_does_not_produce_chunks`

## Test plan

- [x] `cargo clippy -p aionui-ai-agent -- -D warnings` clean
- [x] `cargo test -p aionui-ai-agent --lib` — 368 pass, 1 pre-existing
  failure (`build_new_session_request_injects_team_stdio_server`,
  unrelated: post-6c334a9 HTTP MCP switch, test still destructures
  `McpServer::Stdio`).
- [x] 5 new unit tests all pass
- [ ] Integration coverage: existing `acp_agent_integration.rs` tests are
  `#[ignore]` since the ACP SDK transition — needs a follow-up with a
  real JSON-RPC mock responder. Out of scope here.

## Pre-existing issues (not touched)

- `acp_agent::tests::build_new_session_request_injects_team_stdio_server`
  still expects `Stdio` variant after 6c334a9 switched team MCP to HTTP.
  Fix belongs to the HTTP-switch PR, not here.
- Integration tests under `tests/` hold `MutexGuard` across `await`
  (clippy `await_holding_lock`). Only surfaces under `--tests`; the
  acceptance criteria spec uses `cargo clippy -p aionui-ai-agent -- -D warnings`
  which is clean.

## Base branch

Targets `feat/team-wave4-5`. Built on top of `w4-d25c1/broadcast-channel`
(PR #93). If PR #93 merges first, this should rebase cleanly onto the
resulting state of `feat/team-wave4-5`.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>