### PR TITLE
feat(team): add GuideMcpServer skeleton (W5-D26a)

### DIFF
--- a/crates/aionui-team/src/guide/mod.rs
+++ b/crates/aionui-team/src/guide/mod.rs
@@ -1,5 +1,13 @@
-//! Team guide module: capability descriptor + lead-facing MCP tool argument parsing.
+//! Team Guide module — capability descriptor, lead-facing tool arg parsing,
+//! and Guide MCP server.
+//!
+//! The Guide MCP server is injected into single-chat agents to expose
+//! `aion_create_team` / `aion_list_models` tools. Independent from the
+//! per-team `TeamMcpServer`.
+
 pub mod capability;
 pub mod handlers;
+pub mod server;
 
 pub use handlers::{CreateTeamParams, parse_create_team_args};
+pub use server::GuideMcpServer;

--- a/crates/aionui-team/src/guide/server.rs
+++ b/crates/aionui-team/src/guide/server.rs
@@ -1,0 +1,138 @@
+use std::net::SocketAddr;
+
+use aionui_common::generate_id;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tracing::debug;
+
+pub struct GuideMcpServer {
+    http_addr: SocketAddr,
+    auth_token: String,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+}
+
+impl GuideMcpServer {
+    pub async fn start() -> Result<Self, String> {
+        let auth_token = generate_id();
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .map_err(|e| format!("Failed to bind guide MCP HTTP listener: {e}"))?;
+        let http_addr = listener
+            .local_addr()
+            .map_err(|e| format!("Failed to read guide MCP local addr: {e}"))?;
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+        tokio::spawn(accept_loop(listener, shutdown_rx));
+
+        debug!(http_port = http_addr.port(), "Guide MCP Server started");
+
+        Ok(Self {
+            http_addr,
+            auth_token,
+            shutdown_tx: Some(shutdown_tx),
+        })
+    }
+
+    pub fn http_port(&self) -> u16 {
+        self.http_addr.port()
+    }
+
+    pub fn http_addr(&self) -> SocketAddr {
+        self.http_addr
+    }
+
+    pub fn auth_token(&self) -> &str {
+        &self.auth_token
+    }
+
+    pub fn stop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+            debug!(http_port = self.http_addr.port(), "Guide MCP Server stop requested");
+        }
+    }
+}
+
+impl Drop for GuideMcpServer {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+async fn accept_loop(listener: TcpListener, mut shutdown_rx: oneshot::Receiver<()>) {
+    loop {
+        tokio::select! {
+            _ = &mut shutdown_rx => {
+                debug!("Guide MCP Server shutting down");
+                break;
+            }
+            accept = listener.accept() => {
+                // D26b/c will plug in JSON-RPC / HTTP dispatch for
+                // aion_create_team + aion_list_models. For the skeleton we
+                // accept and immediately drop the connection.
+                if let Ok((stream, _peer)) = accept {
+                    drop(stream);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::io::AsyncReadExt;
+    use tokio::net::TcpStream;
+    use tokio::time::timeout;
+
+    #[tokio::test]
+    async fn start_returns_positive_port_and_token() {
+        let server = GuideMcpServer::start().await.expect("start should succeed");
+        assert!(server.http_port() > 0, "http_port should be assigned");
+        assert!(!server.auth_token().is_empty(), "auth_token should be generated");
+    }
+
+    #[tokio::test]
+    async fn each_start_uses_a_fresh_auth_token() {
+        let a = GuideMcpServer::start().await.unwrap();
+        let b = GuideMcpServer::start().await.unwrap();
+        assert_ne!(a.auth_token(), b.auth_token());
+    }
+
+    #[tokio::test]
+    async fn stop_closes_the_listener() {
+        let mut server = GuideMcpServer::start().await.unwrap();
+        let port = server.http_port();
+        server.stop();
+
+        // Give the accept loop a moment to observe the shutdown signal.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Either the connect is refused outright, or it succeeds but the
+        // listener-less port yields an immediate EOF on read. Both are
+        // acceptable evidence that the server is no longer serving.
+        match timeout(Duration::from_millis(200), TcpStream::connect(("127.0.0.1", port))).await {
+            Ok(Ok(mut stream)) => {
+                let mut buf = [0u8; 1];
+                let read = timeout(Duration::from_millis(200), stream.read(&mut buf)).await;
+                match read {
+                    Ok(Ok(0)) => { /* EOF — expected */ }
+                    Ok(Err(_)) => { /* connection error — expected */ }
+                    Ok(Ok(_)) => panic!("unexpected data from stopped server"),
+                    Err(_) => panic!("server still reading after stop"),
+                }
+            }
+            Ok(Err(_)) => { /* connection refused — expected */ }
+            Err(_) => panic!("connect timed out (expected refuse or EOF)"),
+        }
+    }
+
+    #[tokio::test]
+    async fn stop_is_idempotent() {
+        let mut server = GuideMcpServer::start().await.unwrap();
+        server.stop();
+        server.stop();
+    }
+}

--- a/crates/aionui-team/src/lib.rs
+++ b/crates/aionui-team/src/lib.rs
@@ -18,6 +18,7 @@ pub mod types;
 pub use crash_detection::{CrashReason, detect_crash, is_rate_limited};
 pub use error::TeamError;
 pub use events::TeamEventEmitter;
+pub use guide::GuideMcpServer;
 pub use mailbox::Mailbox;
 pub use mcp::{TeamMcpServer, TeamMcpStdioConfig, TeamMcpStdioServerSpec};
 pub use prompts::{build_lead_prompt, build_teammate_prompt, build_wake_payload};


### PR DESCRIPTION
## Summary

- Adds `crates/aionui-team/src/guide/server.rs` with the `GuideMcpServer` skeleton: `start` (binds `127.0.0.1:0` HTTP listener, generates auth token via `aionui_common::generate_id()`), `http_port` / `http_addr` / `auth_token` getters, `stop` (idempotent oneshot signal), and `Drop`.
- Registers `pub mod guide;` in `crates/aionui-team/src/lib.rs` and re-exports `GuideMcpServer`.
- Accept loop is a placeholder (accepts and drops the stream); JSON-RPC dispatch for `aion_create_team` / `aion_list_models` lands in W5-D26b / D26c.

## Scope deviation (flagged with lead, approved)

- Task card referenced `uuid::Uuid::new_v4()` for the auth token, but `uuid` is not a workspace dep for `aionui-team` and the existing `TeamMcpServer` caller (`session.rs:39`) uses `aionui_common::generate_id()` (UUID v7). Used `generate_id()` to keep the two MCP servers consistent. No new crate dependency added.

## Test plan

- [x] `cargo test -p aionui-team guide:: --lib` — 4 passed (`start_returns_positive_port_and_token`, `each_start_uses_a_fresh_auth_token`, `stop_closes_the_listener`, `stop_is_idempotent`)
- [x] `cargo check -p aionui-team` — clean (no new warnings)
- [x] `cargo fmt -p aionui-team -- --check` — clean

## Notes

- Pre-existing clippy `-D warnings` failures in `crates/aionui-team/src/mcp/server.rs:515` (`token` unused) and `:570` (`slot_id` unused) exist on `main` from the W4 HTTP transport switch and are out of scope for D26a.