### PR TITLE
feat(team): clear scheduler state on remove_agent (W5-D30d-2)

### DIFF
--- a/crates/aionui-team/src/scheduler.rs
+++ b/crates/aionui-team/src/scheduler.rs
@@ -406,15 +406,38 @@ impl TeammateManager {
     }
 
     /// Remove an agent slot at runtime.
+    ///
+    /// Also clears any scheduler-side state tied to the slot so a later
+    /// re-spawn (or a stale callback from the killed agent task) cannot be
+    /// blocked by leftover wake locks, wake timeouts, or finalize-dedup
+    /// entries. See [`Self::clear_agent_state`] for the state inventory.
     pub async fn remove_agent(&self, slot_id: &str) -> Result<(), TeamError> {
         let mut slots = self.slots.lock().await;
-        slots
+        let removed = slots
             .remove(slot_id)
             .ok_or_else(|| TeamError::AgentNotFound(slot_id.to_owned()))?;
         drop(slots);
+        self.clear_agent_state(slot_id, &removed.agent.conversation_id);
         self.events.broadcast_agent_removed(slot_id);
         debug!(team_id = %self.team_id, slot_id, "agent removed from scheduler");
         Ok(())
+    }
+
+    /// Clear all scheduler-side state associated with a removed agent.
+    ///
+    /// Drops three independent entries so nothing survives to affect the
+    /// slot's next life (re-spawn with the same id, or a sibling slot that
+    /// shares the same conversation):
+    /// * `active_wakes` — W4-D18a wake-in-flight lock
+    /// * `wake_timeouts` — W4-D18b-1 per-slot wake watchdog task
+    /// * `finalized_turns` — W4-D19a Finish/Error dedup window (keyed by
+    ///   `conversation_id`, not `slot_id`)
+    ///
+    /// Idempotent: every underlying call tolerates missing entries.
+    pub fn clear_agent_state(&self, slot_id: &str, conversation_id: &str) {
+        self.active_wakes.remove(slot_id);
+        self.clear_wake_timeout(slot_id);
+        self.finalized_turns.remove(conversation_id);
     }
 
     /// Rename an agent slot.
@@ -948,6 +971,48 @@ mod tests {
 
         let result = mgr.remove_agent("ghost").await;
         assert!(matches!(result, Err(TeamError::AgentNotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn remove_agent_clears_wake_lock_timeout_and_finalize_dedup() {
+        let agents = make_team_agents();
+        let (mgr, _) = make_manager(&agents);
+        let conv_id = "conv-worker-2"; // matches make_agent("worker-2")
+
+        // Populate all three state stores for worker-2.
+        assert!(mgr.acquire_wake_lock("worker-2"));
+        let handle = tokio::spawn(async { tokio::time::sleep(Duration::from_secs(999)).await });
+        mgr.wake_timeouts.insert("worker-2".into(), handle);
+        assert!(mgr.begin_finalize(conv_id));
+
+        mgr.remove_agent("worker-2").await.unwrap();
+
+        assert!(
+            !mgr.active_wakes.contains("worker-2"),
+            "active_wakes must not retain a removed slot"
+        );
+        assert!(
+            mgr.wake_timeouts.get("worker-2").is_none(),
+            "wake_timeouts must not retain a removed slot"
+        );
+        assert!(
+            mgr.finalized_turns.get(conv_id).is_none(),
+            "finalized_turns must not retain the removed slot's conversation_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_agent_clear_state_is_idempotent() {
+        // clear_agent_state tolerates missing entries — calling it on a slot
+        // that never populated any of the three stores is a no-op, not a panic.
+        let agents = make_team_agents();
+        let (mgr, _) = make_manager(&agents);
+
+        mgr.remove_agent("worker-1").await.unwrap();
+
+        assert!(!mgr.active_wakes.contains("worker-1"));
+        assert!(mgr.wake_timeouts.get("worker-1").is_none());
+        assert!(mgr.finalized_turns.get("conv-worker-1").is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Add `clear_agent_state(slot_id, conversation_id)` helper on `TeammateManager`
- `remove_agent` now drops the slot's `active_wakes` entry, cancels any pending `wake_timeouts` task, and purges the `finalized_turns` dedup entry keyed by `conversation_id`
- Without this, a stale wake lock or lingering finalize-dedup entry from the killed slot could block a later re-spawn (or a sibling reusing the same conversation)

## Why three stores

| Store | Key | Risk if not cleared |
|---|---|---|
| `active_wakes` (W4-D18a) | `slot_id` | next wake for a re-spawned slot is dropped as "already in flight" |
| `wake_timeouts` (W4-D18b-1) | `slot_id` | orphan `JoinHandle` lingers; spurious late callback |
| `finalized_turns` (W4-D19a) | `conversation_id` | next turn's Finish is dedup-swallowed for up to 5s |

## Test plan

- [x] `cargo test -p aionui-team --lib remove_agent` — all 4 tests pass (incl. 2 new)
  - `remove_agent_clears_wake_lock_timeout_and_finalize_dedup` — populate all three stores, remove, assert all empty
  - `remove_agent_clear_state_is_idempotent` — remove on a fresh slot with nothing populated, no panic
- [x] `cargo fmt -p aionui-team --check` clean
- [x] `cargo clippy -p aionui-team --lib --tests` — no new warnings (pre-existing main debt only: `EnvVariable` in aionui-ai-agent, two `unused variable` in `mcp/server.rs`)

## Relation to D30d-1

D30d-1 adds `task_manager.kill(conversation_id, ...)` to `remove_agent` for OS-level cleanup. D30d-2 (this PR) complements it with scheduler-side cleanup. The two land independently; ordering inside `remove_agent` — state clear runs right after the slot is dropped, so merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)