### PR TITLE
feat(team): gate spawn_agent with caller role==Lead (W5-D29a-2)

### DIFF
--- a/crates/aionui-team/src/error.rs
+++ b/crates/aionui-team/src/error.rs
@@ -14,6 +14,9 @@ pub enum TeamError {
     #[error("Invalid request: {0}")]
     InvalidRequest(String),
 
+    #[error("Leader-only action: {0}")]
+    LeaderOnly(String),
+
     #[error("Session not found: {0}")]
     SessionNotFound(String),
 
@@ -34,6 +37,7 @@ impl From<TeamError> for AppError {
             TeamError::AgentNotFound(msg) => AppError::NotFound(msg),
             TeamError::TaskNotFound(msg) => AppError::NotFound(msg),
             TeamError::InvalidRequest(msg) => AppError::BadRequest(msg),
+            TeamError::LeaderOnly(msg) => AppError::Forbidden(msg),
             TeamError::SessionNotFound(msg) => AppError::NotFound(msg),
             TeamError::BlockedTaskNotFound(msg) => AppError::BadRequest(msg),
             TeamError::Database(db_err) => AppError::from(db_err),
@@ -68,6 +72,12 @@ mod tests {
     fn invalid_request_maps_to_bad_request() {
         let err: AppError = TeamError::InvalidRequest("empty agents".into()).into();
         assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn leader_only_maps_to_forbidden() {
+        let err: AppError = TeamError::LeaderOnly("spawn_agent".into()).into();
+        assert!(matches!(err, AppError::Forbidden(msg) if msg == "spawn_agent"));
     }
 
     #[test]

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -27,6 +27,16 @@ pub struct WakeInput {
     pub should_send: bool,
 }
 
+/// Input for [`TeamSession::spawn_agent`]. Populated by the lead agent when
+/// it calls the `spawn_agent` MCP tool.
+#[derive(Debug, Clone)]
+pub struct SpawnAgentRequest {
+    pub name: String,
+    pub agent_type: Option<String>,
+    pub custom_agent_id: Option<String>,
+    pub model: Option<String>,
+}
+
 pub struct TeamSession {
     team: Team,
     scheduler: Arc<TeammateManager>,
@@ -307,6 +317,10 @@ impl TeamSession {
 
     pub async fn rename_agent(&self, slot_id: &str, new_name: &str) -> Result<(), TeamError> {
         self.scheduler.rename_agent(slot_id, new_name).await
+    }
+
+    pub async fn spawn_agent(&self, _caller_slot_id: &str, _req: SpawnAgentRequest) -> Result<TeamAgent, TeamError> {
+        todo!("W5-D29a-2..D29d will fill in the implementation")
     }
 
     pub fn stop(&self) {

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -319,8 +319,17 @@ impl TeamSession {
         self.scheduler.rename_agent(slot_id, new_name).await
     }
 
-    pub async fn spawn_agent(&self, _caller_slot_id: &str, _req: SpawnAgentRequest) -> Result<TeamAgent, TeamError> {
-        todo!("W5-D29a-2..D29d will fill in the implementation")
+    pub async fn spawn_agent(&self, caller_slot_id: &str, req: SpawnAgentRequest) -> Result<TeamAgent, TeamError> {
+        // Step 1: caller must be a Lead. The MCP dispatch layer also gates
+        // this, but spawn_agent is exposed on TeamSession so any call site
+        // (including future direct service callers) must re-check.
+        let caller = self.scheduler.get_agent(caller_slot_id).await?;
+        if caller.role != TeammateRole::Lead {
+            return Err(TeamError::LeaderOnly("spawn_agent".into()));
+        }
+
+        let _ = req;
+        todo!("W5-D29a-3..D29d will fill in the remaining spawn steps")
     }
 
     pub fn stop(&self) {
@@ -669,6 +678,49 @@ mod tests {
         let result = session.rename_agent("nonexistent", "X").await;
         assert!(result.is_err());
         session.stop();
+    }
+
+    // -- W5-D29a-2: spawn_agent caller guard --------------------------------
+
+    fn sample_spawn_req() -> SpawnAgentRequest {
+        SpawnAgentRequest {
+            name: "Helper".into(),
+            agent_type: None,
+            custom_agent_id: None,
+            model: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_rejects_non_lead_caller() {
+        let session = start_session().await;
+        let result = session.spawn_agent("worker-1", sample_spawn_req()).await;
+        assert!(
+            matches!(&result, Err(TeamError::LeaderOnly(msg)) if msg == "spawn_agent"),
+            "non-lead caller must be rejected with LeaderOnly, got {result:?}"
+        );
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_rejects_unknown_caller() {
+        let session = start_session().await;
+        let result = session.spawn_agent("nonexistent", sample_spawn_req()).await;
+        assert!(
+            matches!(&result, Err(TeamError::AgentNotFound(_))),
+            "unknown caller must surface AgentNotFound, got {result:?}"
+        );
+        session.stop();
+    }
+
+    // Lead caller is expected to pass the guard and hit the todo!() for
+    // subsequent slices (W5-D29a-3..D29d). This pins that the guard does not
+    // over-reject a legitimate Lead caller.
+    #[tokio::test]
+    #[should_panic(expected = "W5-D29a-3..D29d")]
+    async fn spawn_agent_lead_caller_passes_guard() {
+        let session = start_session().await;
+        let _ = session.spawn_agent("lead-1", sample_spawn_req()).await;
     }
 
     // -- D7a new method tests ------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `TeamError::LeaderOnly(String)` mapped to `AppError::Forbidden` (403).
- Replace `TeamSession::spawn_agent`'s body with the first validation step: look up the caller through the scheduler and reject with `LeaderOnly(\"spawn_agent\")` when `role != Lead`. Remainder of the method is still gated by `todo!(\"W5-D29a-3..D29d\")`.
- Based on `w5-d29a1/spawn-request-type` (PR #98); targets `feat/team-wave4-5`.

## Test plan

- [x] `cargo check -p aionui-team`
- [x] `cargo fmt -p aionui-team -- --check`
- [x] `cargo clippy -p aionui-team --lib --tests` — no new warnings (pre-existing baseline in `mcp/server.rs:515,570` and `aionui-ai-agent` untouched)
- [x] `cargo test -p aionui-team --lib session::` — 3 new tests pass: `spawn_agent_rejects_non_lead_caller`, `spawn_agent_rejects_unknown_caller`, `spawn_agent_lead_caller_passes_guard` (#[should_panic] pins the happy path reaches `todo!()`). The `mcp_stdio_config_for_agent` port-race flake is pre-existing main debt, unrelated.
- [x] `cargo test -p aionui-team --lib error::` — `leader_only_maps_to_forbidden` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)