### PR TITLE
feat(team): spawn_agent backend whitelist check (W5-D29a-4)

### DIFF
--- a/crates/aionui-team/src/error.rs
+++ b/crates/aionui-team/src/error.rs
@@ -23,6 +23,9 @@ pub enum TeamError {
     #[error("Blocked task not found: {0}")]
     BlockedTaskNotFound(String),
 
+    #[error("Backend not allowed: {0}")]
+    BackendNotAllowed(String),
+
     #[error("{0}")]
     Database(#[from] aionui_db::DbError),
 
@@ -40,6 +43,7 @@ impl From<TeamError> for AppError {
             TeamError::LeaderOnly(msg) => AppError::Forbidden(msg),
             TeamError::SessionNotFound(msg) => AppError::NotFound(msg),
             TeamError::BlockedTaskNotFound(msg) => AppError::BadRequest(msg),
+            TeamError::BackendNotAllowed(msg) => AppError::BadRequest(msg),
             TeamError::Database(db_err) => AppError::from(db_err),
             TeamError::Json(e) => AppError::Internal(format!("JSON error: {e}")),
         }
@@ -90,6 +94,12 @@ mod tests {
     fn blocked_task_not_found_maps_to_bad_request() {
         let err: AppError = TeamError::BlockedTaskNotFound("tk-x".into()).into();
         assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn backend_not_allowed_maps_to_bad_request() {
+        let err: AppError = TeamError::BackendNotAllowed("gemini".into()).into();
+        assert!(matches!(err, AppError::BadRequest(msg) if msg == "gemini"));
     }
 
     #[test]

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -341,6 +341,18 @@ impl TeamSession {
             return Err(TeamError::InvalidRequest(format!("agent name conflict: {normalized}")));
         }
 
+        // Step 3: backend whitelist — inherit caller's backend when the
+        // request does not specify, otherwise validate against the allowed set.
+        const SPAWN_BACKEND_WHITELIST: &[&str] = &["claude", "codex"];
+        let backend = req
+            .agent_type
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .unwrap_or(caller.backend.as_str());
+        if !SPAWN_BACKEND_WHITELIST.contains(&backend) {
+            return Err(TeamError::BackendNotAllowed(backend.to_owned()));
+        }
+
         let _ = req;
         todo!("W5-D29a-4..D29d will fill in the remaining spawn steps")
     }
@@ -1006,6 +1018,78 @@ mod tests {
         session.send_message("", None).await.unwrap();
 
         assert_eq!(sent.lock().unwrap().len(), 1);
+        session.stop();
+    }
+
+    async fn start_session_with_lead_backend(backend: &str) -> TeamSession {
+        let mut team = make_team();
+        team.agents[0].backend = backend.to_string();
+        let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
+        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
+        TeamSession::start(team, repo, broadcaster, backend_path(), empty_task_manager())
+            .await
+            .unwrap()
+    }
+
+    fn spawn_req(agent_type: Option<&str>) -> SpawnAgentRequest {
+        SpawnAgentRequest {
+            name: "Helper".into(),
+            agent_type: agent_type.map(str::to_owned),
+            custom_agent_id: None,
+            model: None,
+        }
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "W5-D29a")]
+    async fn spawn_agent_accepts_claude_backend() {
+        let session = start_session_with_lead_backend("claude").await;
+        let _ = session.spawn_agent("lead-1", spawn_req(Some("claude"))).await;
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "W5-D29a")]
+    async fn spawn_agent_accepts_codex_backend() {
+        let session = start_session_with_lead_backend("claude").await;
+        let _ = session.spawn_agent("lead-1", spawn_req(Some("codex"))).await;
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_rejects_unknown_backend() {
+        let session = start_session_with_lead_backend("claude").await;
+        let err = session
+            .spawn_agent("lead-1", spawn_req(Some("unknown_backend")))
+            .await
+            .expect_err("unknown backend must be rejected");
+        assert!(
+            matches!(&err, TeamError::BackendNotAllowed(b) if b == "unknown_backend"),
+            "expected BackendNotAllowed(\"unknown_backend\"), got {err:?}"
+        );
+        session.stop();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "W5-D29a")]
+    async fn spawn_agent_inherits_caller_backend_when_unspecified() {
+        // No agent_type on the request -> must fall back to the caller's
+        // backend ("claude"), which passes the whitelist and reaches todo!().
+        let session = start_session_with_lead_backend("claude").await;
+        let _ = session.spawn_agent("lead-1", spawn_req(None)).await;
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_rejects_when_inherited_backend_not_whitelisted() {
+        // Caller's backend is "acp" (not whitelisted). With no explicit
+        // agent_type, the inherited backend must be rejected.
+        let session = start_session_with_lead_backend("acp").await;
+        let err = session
+            .spawn_agent("lead-1", spawn_req(None))
+            .await
+            .expect_err("non-whitelisted inherited backend must be rejected");
+        assert!(
+            matches!(&err, TeamError::BackendNotAllowed(b) if b == "acp"),
+            "expected BackendNotAllowed(\"acp\"), got {err:?}"
+        );
         session.stop();
     }
 }


### PR DESCRIPTION
## Summary
- Add backend whitelist check (`claude`, `codex`) in `TeamSession::spawn_agent`
- Inherit caller's backend when `SpawnAgentRequest.agent_type` is None or empty
- Return `TeamError::BackendNotAllowed` for non-whitelisted backends (maps to `AppError::BadRequest`)

Base branch: `w5-d29a1/spawn-request-type` (PR #98). Will auto-collapse into `feat/team-wave4-5` as upstream merges.

## Test plan
- [x] `cargo check -p aionui-team` clean
- [x] Unit tests — 5 new spawn_agent tests + 1 new error mapping test, all pass
- [x] Explicit backend "claude" and "codex" pass whitelist (reach `todo!()` as designed — asserted via `#[should_panic]`)
- [x] Explicit backend "unknown_backend" → `BackendNotAllowed("unknown_backend")`
- [x] Missing `agent_type` + caller backend "claude" → inherits "claude", passes whitelist
- [x] Missing `agent_type` + caller backend "acp" → `BackendNotAllowed("acp")`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>