### PR TITLE
feat(team): kill agent process on remove_agent (W5-D30d-1)

### DIFF
--- a/crates/aionui-team/src/scheduler.rs
+++ b/crates/aionui-team/src/scheduler.rs
@@ -442,16 +442,24 @@ impl TeammateManager {
     /// re-spawn (or a stale callback from the killed agent task) cannot be
     /// blocked by leftover wake locks, wake timeouts, or finalize-dedup
     /// entries. See [`Self::clear_agent_state`] for the state inventory.
-    pub async fn remove_agent(&self, slot_id: &str) -> Result<(), TeamError> {
+    ///
+    /// Returns the removed slot's `conversation_id` so the session layer can
+    /// terminate the underlying worker process via
+    /// `IWorkerTaskManager::kill` (W5-D30d-1). The scheduler does not own the
+    /// task manager, mirroring the delegation pattern used by
+    /// [`Self::handle_agent_crash`]: cross-crate side effects are handed back
+    /// to the session.
+    pub async fn remove_agent(&self, slot_id: &str) -> Result<Option<String>, TeamError> {
         let mut slots = self.slots.lock().await;
         let removed = slots
             .remove(slot_id)
             .ok_or_else(|| TeamError::AgentNotFound(slot_id.to_owned()))?;
+        let conversation_id = removed.agent.conversation_id.clone();
         drop(slots);
-        self.clear_agent_state(slot_id, &removed.agent.conversation_id);
+        self.clear_agent_state(slot_id, &conversation_id);
         self.events.broadcast_agent_removed(slot_id);
         debug!(team_id = %self.team_id, slot_id, "agent removed from scheduler");
-        Ok(())
+        Ok(Some(conversation_id))
     }
 
     /// Clear all scheduler-side state associated with a removed agent.
@@ -1139,7 +1147,8 @@ mod tests {
         let agents = make_team_agents();
         let (mgr, bc) = make_manager(&agents);
 
-        mgr.remove_agent("worker-2").await.unwrap();
+        let conv_id = mgr.remove_agent("worker-2").await.unwrap();
+        assert_eq!(conv_id.as_deref(), Some("conv-worker-2"));
 
         let all = mgr.list_agents().await;
         assert_eq!(all.len(), 2);

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use aionui_ai_agent::{IWorkerTaskManager, SendMessageData};
-use aionui_common::generate_id;
+use aionui_common::{AgentKillReason, generate_id};
 use aionui_db::ITeamRepository;
 use aionui_realtime::EventBroadcaster;
 use tracing::{info, warn};
@@ -312,7 +312,19 @@ impl TeamSession {
     }
 
     pub async fn remove_agent(&self, slot_id: &str) -> Result<(), TeamError> {
-        self.scheduler.remove_agent(slot_id).await
+        let conversation_id = self.scheduler.remove_agent(slot_id).await?;
+        if let Some(conv_id) = conversation_id
+            && let Err(e) = self.task_manager.kill(&conv_id, Some(AgentKillReason::TeamDeleted))
+        {
+            warn!(
+                team_id = %self.team.id,
+                slot_id,
+                conversation_id = %conv_id,
+                error = %e,
+                "remove_agent: task_manager.kill failed (non-fatal)"
+            );
+        }
+        Ok(())
     }
 
     pub async fn rename_agent(&self, slot_id: &str, new_name: &str) -> Result<(), TeamError> {
@@ -468,17 +480,35 @@ mod tests {
     /// and panic to surface drift early.
     struct StubTaskManager {
         tasks: Mutex<std::collections::HashMap<String, AgentManagerHandle>>,
+        kill_calls: Mutex<Vec<(String, Option<AgentKillReason>)>>,
+        kill_error: Option<String>,
     }
 
     impl StubTaskManager {
         fn new() -> Self {
             Self {
                 tasks: Mutex::new(std::collections::HashMap::new()),
+                kill_calls: Mutex::new(Vec::new()),
+                kill_error: None,
+            }
+        }
+
+        /// Build a stub whose `kill` always fails with `AppError::NotFound` so
+        /// tests can exercise the non-fatal kill branch in `remove_agent`.
+        fn with_kill_error(msg: &str) -> Self {
+            Self {
+                tasks: Mutex::new(std::collections::HashMap::new()),
+                kill_calls: Mutex::new(Vec::new()),
+                kill_error: Some(msg.to_owned()),
             }
         }
 
         fn insert(&self, conv_id: &str, handle: AgentManagerHandle) {
             self.tasks.lock().unwrap().insert(conv_id.into(), handle);
+        }
+
+        fn kill_calls(&self) -> Vec<(String, Option<AgentKillReason>)> {
+            self.kill_calls.lock().unwrap().clone()
         }
     }
 
@@ -493,7 +523,14 @@ mod tests {
         ) -> Result<AgentManagerHandle, AppError> {
             panic!("get_or_build_task should not be called in D7b tests")
         }
-        fn kill(&self, _conversation_id: &str, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        fn kill(&self, conversation_id: &str, reason: Option<AgentKillReason>) -> Result<(), AppError> {
+            self.kill_calls
+                .lock()
+                .unwrap()
+                .push((conversation_id.to_owned(), reason));
+            if let Some(msg) = &self.kill_error {
+                return Err(AppError::NotFound(msg.clone()));
+            }
             Ok(())
         }
         fn clear(&self) {}
@@ -671,6 +708,50 @@ mod tests {
         let agents = session.scheduler.list_agents().await;
         assert_eq!(agents.len(), 2);
 
+        session.stop();
+    }
+
+    // -- W5-D30d-1: remove_agent kills the agent process ---------------------
+
+    #[tokio::test]
+    async fn remove_agent_calls_task_manager_kill() {
+        let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
+        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
+        let stub = Arc::new(StubTaskManager::new());
+        let stub_dyn: Arc<dyn IWorkerTaskManager> = stub.clone();
+        let session = TeamSession::start(make_team(), repo, broadcaster, backend_path(), stub_dyn)
+            .await
+            .unwrap();
+
+        session.remove_agent("worker-1").await.unwrap();
+
+        let calls = stub.kill_calls();
+        assert_eq!(calls.len(), 1, "kill invoked exactly once");
+        assert_eq!(calls[0].0, "c2", "kill targets removed slot's conversation_id");
+        assert!(
+            matches!(calls[0].1, Some(AgentKillReason::TeamDeleted)),
+            "kill reason carries AgentKillReason"
+        );
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn remove_agent_is_non_fatal_when_kill_fails() {
+        let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
+        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
+        let stub = Arc::new(StubTaskManager::with_kill_error("task not found"));
+        let stub_dyn: Arc<dyn IWorkerTaskManager> = stub.clone();
+        let session = TeamSession::start(make_team(), repo, broadcaster, backend_path(), stub_dyn)
+            .await
+            .unwrap();
+
+        // kill returns Err(AppError::NotFound) but remove_agent must still
+        // succeed — NotFound means the worker already died, which is OK.
+        session.remove_agent("worker-1").await.unwrap();
+
+        let agents = session.scheduler.list_agents().await;
+        assert_eq!(agents.len(), 1, "slot still removed even after kill failure");
+        assert_eq!(stub.kill_calls().len(), 1);
         session.stop();
     }
 


### PR DESCRIPTION
## Summary

`scheduler.remove_agent` now returns the removed slot's `conversation_id` and `session.remove_agent` uses it to call `IWorkerTaskManager::kill`. This closes the gap where removing an agent left the ACP/CLI worker process orphaned (the D11.5 `remove_team` path already does this; W5-D30d-1 lifts the same behavior into single-agent removal).

## Why this shape

- `TeammateManager` does not own the task manager — that is held by `TeamSession`. Rather than plumbing `Arc<dyn IWorkerTaskManager>` into the scheduler for one call site, `remove_agent` returns the `conversation_id` and lets `TeamSession` drive the kill. This mirrors `handle_agent_crash` (W4-D20b-2), which returns an `Option<String>` so the session layer owns all cross-crate side effects.
- `AgentKillReason::Shutdown` (from `interface-contracts` §31.4.1) does **not** exist in `aionui-common`. This PR uses `TeamDeleted` as the closest existing variant. Introducing a new `Shutdown` variant is a foundation-crate change that warrants its own module/impact assessment.
- `kill` failures are logged at `warn!` only — the contract explicitly says NotFound means the worker already died and should be treated as success.

## Test plan

- [x] `cargo test -p aionui-team --lib` — 227 passed. New cases:
  - `scheduler::tests::remove_agent_broadcasts_removed_event` updated to assert returned `Some(conversation_id)`.
  - `session::tests::remove_agent_calls_task_manager_kill` — verifies `kill` is called once with the right `conv_id` and `AgentKillReason`.
  - `session::tests::remove_agent_is_non_fatal_when_kill_fails` — verifies `remove_agent` still returns `Ok(())` when `kill` returns `AppError::NotFound`.
  - Pre-existing `mcp_stdio_config_for_agent` flake (port-allocation race, unrelated to this PR) is skipped; re-run with `--skip mcp_stdio_config_for_agent` shows clean pass.
- [x] `cargo clippy -p aionui-team --all-targets` — no new warnings (3 pre-existing `aionui-ai-agent` + `mcp/server.rs` warnings untouched).
- [x] `cargo fmt -p aionui-team --check` — clean.

## Contract notes (for the lead)

Sent a message earlier flagging the contract/impl divergence (`Shutdown` variant missing, scheduler doesn't own `task_manager`). Going with the lightest shape that honors the contract's **intent** ("kill the worker; treat missing worker as OK; don't fail remove_agent on kill error"). If you want the strict `Shutdown` variant + task-manager down-push, that's a separate enum change + architecture PR.