### PR TITLE
feat(team): broadcast team.mcpStatus on TCP bind (W5-D31b-1)

### DIFF
--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -116,7 +116,8 @@ pub use system::{
 pub use team::{
     AddAgentRequest, CreateTeamRequest, RenameAgentRequest, RenameTeamRequest, SendAgentMessageRequest,
     SendTeamMessageRequest, TeamAgentInput, TeamAgentRemovedPayload, TeamAgentRenamedPayload, TeamAgentResponse,
-    TeamAgentSpawnedPayload, TeamAgentStatusPayload, TeamListResponse, TeamResponse,
+    TeamAgentSpawnedPayload, TeamAgentStatusPayload, TeamListResponse, TeamMcpPhase, TeamMcpStatusPayload,
+    TeamResponse, TeammateMessagePayload,
 };
 pub use team_mcp::TeamMcpStdioConfig;
 pub use websocket::WebSocketMessage;

--- a/crates/aionui-api-types/src/team.rs
+++ b/crates/aionui-api-types/src/team.rs
@@ -167,6 +167,58 @@ pub struct TeamAgentRenamedPayload {
     pub name: String,
 }
 
+/// Lifecycle phases of the per-team MCP stdio bridge + ACP session.
+///
+/// Emitted by the MCP supervisor whenever a teammate slot transitions
+/// through its bring-up / degraded / ready states so the frontend can
+/// surface actionable status for each agent.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum TeamMcpPhase {
+    TcpReady,
+    TcpError,
+    SessionInjecting,
+    SessionReady,
+    SessionError,
+    LoadFailed,
+    Degraded,
+    ConfigWriteFailed,
+    McpToolsWaiting,
+    McpToolsReady,
+}
+
+/// Payload for `team.mcp.status` WebSocket event.
+///
+/// Pushed whenever a teammate's MCP bridge or ACP session transitions to
+/// a new [`TeamMcpPhase`]. Optional fields carry phase-specific detail:
+/// `port` for TCP bring-up, `server_count` for tool readiness, `error`
+/// for failure phases.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamMcpStatusPayload {
+    pub team_id: String,
+    pub slot_id: String,
+    pub phase: TeamMcpPhase,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Payload for `team.teammate.message` WebSocket event.
+///
+/// Pushed when a teammate sends a message to another agent within the
+/// team; identifies both the sender (`from_slot_id` / `from_name`) and
+/// the conversation the message belongs to.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeammateMessagePayload {
+    pub conversation_id: String,
+    pub content: String,
+    pub from_slot_id: String,
+    pub from_name: String,
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -627,5 +679,119 @@ mod tests {
         assert_eq!(team.id, "team-1");
         assert_eq!(team.lead_agent_id.as_deref(), Some("s1"));
         assert_eq!(team.created_at, 1000);
+    }
+
+    // -- F. TeamMcpPhase serde roundtrip --------------------------------------
+
+    fn assert_phase_roundtrip(phase: TeamMcpPhase, wire: &str) {
+        let json = serde_json::to_value(&phase).unwrap();
+        assert_eq!(json, serde_json::Value::String(wire.into()));
+        let parsed: TeamMcpPhase = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, phase);
+    }
+
+    #[test]
+    fn team_mcp_phase_tcp_ready_roundtrip() {
+        assert_phase_roundtrip(TeamMcpPhase::TcpReady, "tcp_ready");
+    }
+
+    #[test]
+    fn team_mcp_phase_tcp_error_roundtrip() {
+        assert_phase_roundtrip(TeamMcpPhase::TcpError, "tcp_error");
+    }
+
+    #[test]
+    fn team_mcp_phase_session_injecting_roundtrip() {
+        assert_phase_roundtrip(TeamMcpPhase::SessionInjecting, "session_injecting");
+    }
+
+    #[test]
+    fn team_mcp_phase_session_ready_roundtrip() {
+        assert_phase_roundtrip(TeamMcpPhase::SessionReady, "session_ready");
+    }
+
+    #[test]
+    fn team_mcp_phase_session_error_roundtrip() {
+        assert_phase_roundtrip(TeamMcpPhase::SessionError, "session_error");
+    }
+
+    #[test]
+    fn team_mcp_phase_load_failed_roundtrip() {
+        assert_phase_roundtrip(TeamMcpPhase::LoadFailed, "load_failed");
+    }
+
+    #[test]
+    fn team_mcp_phase_degraded_roundtrip() {
+        assert_phase_roundtrip(TeamMcpPhase::Degraded, "degraded");
+    }
+
+    #[test]
+    fn team_mcp_phase_config_write_failed_roundtrip() {
+        assert_phase_roundtrip(TeamMcpPhase::ConfigWriteFailed, "config_write_failed");
+    }
+
+    #[test]
+    fn team_mcp_phase_mcp_tools_waiting_roundtrip() {
+        assert_phase_roundtrip(TeamMcpPhase::McpToolsWaiting, "mcp_tools_waiting");
+    }
+
+    #[test]
+    fn team_mcp_phase_mcp_tools_ready_roundtrip() {
+        assert_phase_roundtrip(TeamMcpPhase::McpToolsReady, "mcp_tools_ready");
+    }
+
+    // -- G. TeamMcpStatusPayload & TeammateMessagePayload ---------------------
+
+    #[test]
+    fn serialize_team_mcp_status_payload_all_fields_present() {
+        let payload = TeamMcpStatusPayload {
+            team_id: "team-1".into(),
+            slot_id: "slot-2".into(),
+            phase: TeamMcpPhase::SessionReady,
+            port: Some(54321),
+            server_count: Some(7),
+            error: Some("boom".into()),
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["team_id"], "team-1");
+        assert_eq!(json["slot_id"], "slot-2");
+        assert_eq!(json["phase"], "session_ready");
+        assert_eq!(json["port"], 54321);
+        assert_eq!(json["server_count"], 7);
+        assert_eq!(json["error"], "boom");
+    }
+
+    #[test]
+    fn serialize_team_mcp_status_payload_optional_fields_omitted() {
+        let payload = TeamMcpStatusPayload {
+            team_id: "team-1".into(),
+            slot_id: "slot-2".into(),
+            phase: TeamMcpPhase::TcpReady,
+            port: None,
+            server_count: None,
+            error: None,
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["team_id"], "team-1");
+        assert_eq!(json["slot_id"], "slot-2");
+        assert_eq!(json["phase"], "tcp_ready");
+        assert!(json.get("port").is_none());
+        assert!(json.get("server_count").is_none());
+        assert!(json.get("error").is_none());
+    }
+
+    #[test]
+    fn serialize_teammate_message_payload_all_fields_present() {
+        let payload = TeammateMessagePayload {
+            conversation_id: "conv-9".into(),
+            content: "ping".into(),
+            from_slot_id: "slot-1".into(),
+            from_name: "Lead".into(),
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["conversation_id"], "conv-9");
+        assert_eq!(json["content"], "ping");
+        assert_eq!(json["from_slot_id"], "slot-1");
+        assert_eq!(json["from_name"], "Lead");
     }
 }

--- a/crates/aionui-team/src/mcp/server.rs
+++ b/crates/aionui-team/src/mcp/server.rs
@@ -1,6 +1,8 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use aionui_api_types::{TeamMcpPhase, TeamMcpStatusPayload, WebSocketMessage};
+use aionui_realtime::EventBroadcaster;
 use serde_json::{Value, json};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::watch;
@@ -31,13 +33,44 @@ pub struct TeamMcpServer {
 }
 
 impl TeamMcpServer {
-    pub async fn start(auth_token: String, scheduler: Arc<TeammateManager>) -> Result<Self, TeamError> {
-        let listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .map_err(|e| TeamError::InvalidRequest(format!("Failed to bind TCP: {e}")))?;
+    pub async fn start(
+        auth_token: String,
+        scheduler: Arc<TeammateManager>,
+        team_id: String,
+        broadcaster: Arc<dyn EventBroadcaster>,
+    ) -> Result<Self, TeamError> {
+        let listener = match TcpListener::bind("127.0.0.1:0").await {
+            Ok(l) => l,
+            Err(e) => {
+                broadcast_mcp_status(
+                    broadcaster.as_ref(),
+                    TeamMcpStatusPayload {
+                        team_id: team_id.clone(),
+                        slot_id: String::new(),
+                        phase: TeamMcpPhase::TcpError,
+                        port: None,
+                        server_count: None,
+                        error: Some(e.to_string()),
+                    },
+                );
+                return Err(TeamError::InvalidRequest(format!("Failed to bind TCP: {e}")));
+            }
+        };
         let addr = listener
             .local_addr()
             .map_err(|e| TeamError::InvalidRequest(format!("Failed to get local addr: {e}")))?;
+
+        broadcast_mcp_status(
+            broadcaster.as_ref(),
+            TeamMcpStatusPayload {
+                team_id: team_id.clone(),
+                slot_id: String::new(),
+                phase: TeamMcpPhase::TcpReady,
+                port: Some(addr.port()),
+                server_count: None,
+                error: None,
+            },
+        );
 
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
@@ -93,6 +126,14 @@ impl Drop for TeamMcpServer {
     fn drop(&mut self) {
         let _ = self.shutdown_tx.send(true);
     }
+}
+
+fn broadcast_mcp_status(broadcaster: &dyn EventBroadcaster, payload: TeamMcpStatusPayload) {
+    let event = WebSocketMessage::new(
+        "team.mcpStatus",
+        serde_json::to_value(payload).expect("serialize mcp status payload"),
+    );
+    broadcaster.broadcast(event);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -53,11 +53,11 @@ impl TeamSession {
             &team.agents,
             mailbox.clone(),
             task_board.clone(),
-            broadcaster,
+            broadcaster.clone(),
         ));
 
         let auth_token = aionui_common::generate_id();
-        let mcp_server = TeamMcpServer::start(auth_token, scheduler.clone()).await?;
+        let mcp_server = TeamMcpServer::start(auth_token, scheduler.clone(), team.id.clone(), broadcaster).await?;
 
         info!(
             team_id = %team.id,

--- a/crates/aionui-team/tests/mcp_server_integration.rs
+++ b/crates/aionui-team/tests/mcp_server_integration.rs
@@ -24,6 +24,10 @@ impl RecordingBroadcaster {
             events: std::sync::Mutex::new(vec![]),
         }
     }
+
+    fn events(&self) -> Vec<WebSocketMessage<Value>> {
+        self.events.lock().unwrap().clone()
+    }
 }
 
 impl EventBroadcaster for RecordingBroadcaster {
@@ -68,25 +72,33 @@ fn make_agents() -> Vec<TeamAgent> {
 struct TestEnv {
     server: TeamMcpServer,
     _repo: Arc<MockTeamRepo>,
+    broadcaster: Arc<RecordingBroadcaster>,
 }
 
 async fn setup() -> TestEnv {
     let repo = Arc::new(MockTeamRepo::new());
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo.clone()));
-    let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
+    let recorder = Arc::new(RecordingBroadcaster::new());
+    let broadcaster: Arc<dyn EventBroadcaster> = recorder.clone();
     let agents = make_agents();
     let scheduler = Arc::new(TeammateManager::new(
         "team-1".into(),
         &agents,
         mailbox,
         task_board,
-        broadcaster,
+        broadcaster.clone(),
     ));
 
-    let server = TeamMcpServer::start("test-token-123".into(), scheduler).await.unwrap();
+    let server = TeamMcpServer::start("test-token-123".into(), scheduler, "team-1".into(), broadcaster)
+        .await
+        .unwrap();
 
-    TestEnv { server, _repo: repo }
+    TestEnv {
+        server,
+        _repo: repo,
+        broadcaster: recorder,
+    }
 }
 
 async fn connect_and_init(port: u16, token: &str, slot_id: &str) -> TcpStream {
@@ -734,6 +746,37 @@ async fn sb3_different_agents_get_different_slot_ids() {
         kv_lead[TeamMcpStdioConfig::ENV_SLOT_ID],
         kv_worker[TeamMcpStdioConfig::ENV_SLOT_ID]
     );
+}
+
+// ---------------------------------------------------------------------------
+// Tests: mcpStatus broadcast (W5-D31b-1)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn mcp_status_tcp_ready_is_broadcast_on_successful_bind() {
+    use aionui_api_types::{TeamMcpPhase, TeamMcpStatusPayload};
+
+    let env = setup().await;
+    let port = env.server.port();
+
+    let events = env.broadcaster.events();
+    let status_events: Vec<_> = events.iter().filter(|e| e.name == "team.mcpStatus").collect();
+    assert_eq!(
+        status_events.len(),
+        1,
+        "expected exactly one team.mcpStatus event after bind, got {}",
+        status_events.len()
+    );
+
+    let payload: TeamMcpStatusPayload = serde_json::from_value(status_events[0].data.clone()).unwrap();
+    assert_eq!(payload.team_id, "team-1");
+    assert_eq!(payload.slot_id, "");
+    assert!(matches!(payload.phase, TeamMcpPhase::TcpReady));
+    assert_eq!(payload.port, Some(port));
+    assert!(payload.server_count.is_none());
+    assert!(payload.error.is_none());
+
+    env.server.stop();
 
     env.server.stop();
 }


### PR DESCRIPTION
## Summary

W5-D31b-1 — `team.mcpStatus` WebSocket broadcast at the TCP layer.

- `TeamMcpServer::start` now takes `team_id` and `Arc<dyn EventBroadcaster>` and emits a `team.mcpStatus` event immediately after the TCP `TcpListener::bind("127.0.0.1:0")` returns, using `TeamMcpPhase::TcpReady` with the bound port.
- On bind failure, emits the same event with `TeamMcpPhase::TcpError` and `error = Some(e.to_string())` before returning the `TeamError` upstream.
- `slot_id` is left empty per the task spec (TCP bring-up is server-level, not slot-specific).
- HTTP bind broadcast is intentionally out of scope for this slice (TCP layer only, per the task brief).

## Wiring

- `TeamSession::start` clones its existing broadcaster and passes it alongside `team.id` into `TeamMcpServer::start`.
- `mcp_server_integration` test setup exposes the `RecordingBroadcaster` via `TestEnv` so new test `mcp_status_tcp_ready_is_broadcast_on_successful_bind` can assert the event shape end-to-end.

## Base

- Branched from `w5-d31a/mcp-phase-types` (PR #96) because `TeamMcpPhase` / `TeamMcpStatusPayload` land there and haven't reached `main` or `feat/team-wave4-5` yet.
- PR target is `feat/team-wave4-5` per team-lead instructions; merge order is D31a first.

## Test plan

- [x] `cargo check -p aionui-team` clean (only pre-existing warnings on main)
- [x] `cargo test -p aionui-team --test mcp_server_integration` — all 27 tests pass, including new `mcp_status_tcp_ready_is_broadcast_on_successful_bind`
- [x] Pre-existing `cargo clippy` warnings in `aionui-ai-agent` / `aionui-team` not introduced by this PR (confirmed on w5-d31a baseline)
- Note: `session::tests::mcp_stdio_config_for_agent` is already failing on `w5-d31a` baseline (unrelated port race, recorded in memory #24); not regressed by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)