### PR TITLE
feat(team): W5-D26c handle_aion_list_models handler

### DIFF
--- a/crates/aionui-team/src/guide/handlers.rs
+++ b/crates/aionui-team/src/guide/handlers.rs
@@ -1,4 +1,14 @@
-use serde_json::Value;
+//! Tool handlers for the Guide MCP server (`aion_*` tools) and argument
+//! parsing for lead-facing create-team flows.
+//!
+//! Guide tools run in the agent's own MCP client and expose "meta" operations
+//! that help the agent reason about team composition (list available models,
+//! create a team, describe a preset). They are distinct from the in-team
+//! `team_*` tools exposed by `mcp::server`.
+
+use serde_json::{Value, json};
+
+use crate::mcp::tools::handle_team_list_models;
 
 #[derive(Debug, Clone)]
 pub struct CreateTeamParams {
@@ -39,10 +49,31 @@ pub fn parse_create_team_args(args: &Value, caller_workspace: Option<&str>) -> R
     })
 }
 
+/// Handle the `aion_list_models` tool call.
+///
+/// Returns available backend × model combinations the agent can pick from when
+/// planning a team. The Guide advertises everything the user could reasonably
+/// select; the per-backend security whitelist enforced by
+/// `aion_create_team` / `team_spawn_agent` is a separate concern.
+///
+/// Claude + Codex entries are sourced verbatim from the project-wide
+/// `handle_team_list_models` so Guide and in-team tools stay in lockstep.
+/// Gemini is appended here because Guide surfaces every frontend-visible
+/// option regardless of the spawn whitelist.
+pub fn handle_aion_list_models() -> Value {
+    let mut base = handle_team_list_models(&Value::Null);
+    if let Some(agent_types) = base.get_mut("agent_types").and_then(Value::as_array_mut) {
+        agent_types.push(json!({
+            "type": "gemini",
+            "models": ["gemini-2.5-pro", "gemini-2.5-flash"]
+        }));
+    }
+    base
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
 
     #[test]
     fn errors_when_summary_missing() {
@@ -123,5 +154,46 @@ mod tests {
         });
         let params = parse_create_team_args(&args, Some("/caller/ws")).unwrap();
         assert_eq!(params.workspace, "/caller/ws");
+    }
+
+    #[test]
+    fn returns_agent_types_array() {
+        let value = handle_aion_list_models();
+        let types = value
+            .get("agent_types")
+            .and_then(Value::as_array)
+            .expect("agent_types must be an array");
+        let names: Vec<&str> = types.iter().filter_map(|t| t.get("type")?.as_str()).collect();
+        assert!(names.contains(&"claude"));
+        assert!(names.contains(&"codex"));
+        assert!(names.contains(&"gemini"));
+    }
+
+    #[test]
+    fn every_entry_has_models_list() {
+        let value = handle_aion_list_models();
+        for entry in value["agent_types"].as_array().unwrap() {
+            let models = entry["models"].as_array().expect("models must be array");
+            assert!(!models.is_empty(), "models list must not be empty");
+            assert!(entry["type"].as_str().map(|s| !s.is_empty()).unwrap_or(false));
+        }
+    }
+
+    #[test]
+    fn reuses_team_list_models_for_claude_and_codex() {
+        let guide = handle_aion_list_models();
+        let team = handle_team_list_models(&Value::Null);
+        for backend in ["claude", "codex"] {
+            let guide_entry = find_entry(&guide, backend).expect("guide entry present");
+            let team_entry = find_entry(&team, backend).expect("team entry present");
+            assert_eq!(guide_entry["models"], team_entry["models"]);
+        }
+    }
+
+    fn find_entry<'a>(value: &'a Value, backend: &str) -> Option<&'a Value> {
+        value["agent_types"]
+            .as_array()?
+            .iter()
+            .find(|entry| entry["type"].as_str() == Some(backend))
     }
 }

--- a/crates/aionui-team/src/guide/mod.rs
+++ b/crates/aionui-team/src/guide/mod.rs
@@ -1,13 +1,17 @@
 //! Team Guide module — capability descriptor, lead-facing tool arg parsing,
-//! and Guide MCP server.
+//! `aion_*` MCP tool handlers, and Guide MCP server.
 //!
 //! The Guide MCP server is injected into single-chat agents to expose
 //! `aion_create_team` / `aion_list_models` tools. Independent from the
 //! per-team `TeamMcpServer`.
+//!
+//! Current tool set:
+//! - `aion_create_team` — build a new team from a natural-language summary
+//! - `aion_list_models` — enumerate backend × model options
 
 pub mod capability;
 pub mod handlers;
 pub mod server;
 
-pub use handlers::{CreateTeamParams, parse_create_team_args};
+pub use handlers::{CreateTeamParams, handle_aion_list_models, parse_create_team_args};
 pub use server::GuideMcpServer;

--- a/crates/aionui-team/src/lib.rs
+++ b/crates/aionui-team/src/lib.rs
@@ -18,7 +18,7 @@ pub mod types;
 pub use crash_detection::{CrashReason, detect_crash, is_rate_limited};
 pub use error::TeamError;
 pub use events::TeamEventEmitter;
-pub use guide::GuideMcpServer;
+pub use guide::{GuideMcpServer, handle_aion_list_models};
 pub use mailbox::Mailbox;
 pub use mcp::{TeamMcpServer, TeamMcpStdioConfig, TeamMcpStdioServerSpec};
 pub use prompts::{build_lead_prompt, build_teammate_prompt, build_wake_payload};


### PR DESCRIPTION
## Summary
- New `guide` module (`crates/aionui-team/src/guide/`) with `handle_aion_list_models` for the Guide MCP server.
- Reuses `handle_team_list_models` for claude/codex so Guide and in-team tools stay in lockstep; appends gemini because Guide surfaces every frontend-selectable backend while spawn whitelists remain at `aion_create_team` / `team_spawn_agent`.
- Module registered in `crates/aionui-team/src/lib.rs` and re-exported as `aionui_team::handle_aion_list_models`.

## Test plan
- [x] `cargo test -p aionui-team --lib guide` — 3 new tests pass (agent_types array, non-empty models per entry, claude/codex parity with team_list_models).
- [x] `cargo check -p aionui-team` clean (pre-existing unused warnings only).
- [x] `cargo fmt -p aionui-team -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)