### PR TITLE
feat(team): handle shutdown_rejected:<reason> in team_send_message (W5-D30b)

### DIFF
--- a/crates/aionui-team/src/mcp/server.rs
+++ b/crates/aionui-team/src/mcp/server.rs
@@ -395,10 +395,18 @@ async fn exec_send_message(args: &Value, scheduler: &TeammateManager, caller_slo
         debug!(from = caller_slot_id, "shutdown_approved intercepted");
         return Ok(json!({"status": "shutdown_approved_received"}).to_string());
     }
-    if trimmed.starts_with("shutdown_rejected:") {
-        // W5-D30b will wire the real rejection handling; this stub intercepts the sentinel so it never reaches the recipient.
-        debug!(from = caller_slot_id, "shutdown_rejected intercepted");
-        return Ok(json!({"status": "shutdown_rejected_received"}).to_string());
+    // Reason: a teammate replying to a shutdown request with
+    // `shutdown_rejected: <reason>` is a protocol sentinel, not a normal
+    // message. Divert it to a leader-directed notification and return without
+    // removing the agent — the teammate keeps running.
+    if let Some(rest) = trimmed.strip_prefix("shutdown_rejected:") {
+        let reason = rest.trim();
+        scheduler
+            .notify_shutdown_rejected(caller_slot_id, reason)
+            .await
+            .map_err(|e| e.to_string())?;
+        debug!(from = caller_slot_id, reason, "shutdown_rejected handled");
+        return Ok(format!("shutdown_rejected: {reason}"));
     }
 
     let action = crate::scheduler::SchedulerAction::SendMessage {

--- a/crates/aionui-team/src/scheduler.rs
+++ b/crates/aionui-team/src/scheduler.rs
@@ -797,6 +797,38 @@ impl TeammateManager {
         Ok(())
     }
 
+    /// Notify the leader that a teammate declined a shutdown request.
+    ///
+    /// Called when `team_send_message` intercepts a `shutdown_rejected: <reason>`
+    /// payload. The teammate continues to run; the lead receives a mailbox
+    /// message describing who refused and why. No-op when no lead exists or
+    /// when the sender is the lead itself.
+    pub async fn notify_shutdown_rejected(&self, from_slot_id: &str, reason: &str) -> Result<(), TeamError> {
+        let Some(lead_slot_id) = self.find_lead_slot_id().await else {
+            return Ok(());
+        };
+        if lead_slot_id == from_slot_id {
+            return Ok(());
+        }
+        let agent_name = self
+            .get_agent(from_slot_id)
+            .await
+            .map(|a| a.name)
+            .unwrap_or_else(|_| from_slot_id.to_owned());
+        let content = format!("Teammate '{agent_name}' declined shutdown: {reason}");
+        self.mailbox
+            .write(
+                &self.team_id,
+                &lead_slot_id,
+                from_slot_id,
+                MailboxMessageType::Message,
+                &content,
+                None,
+            )
+            .await?;
+        Ok(())
+    }
+
     async fn handle_send_message(&self, from_slot_id: &str, to: &str, message: &str) -> Result<(), TeamError> {
         if to == "*" {
             let slots = self.slots.lock().await;
@@ -2505,5 +2537,66 @@ mod tests {
 
         let msgs2 = mailbox.read_unread("t1", "worker-2").await.unwrap();
         assert!(msgs2.is_empty());
+    }
+
+    // -- W5-D30b: notify_shutdown_rejected -------------------------------------
+
+    #[tokio::test]
+    async fn notify_shutdown_rejected_delivers_to_lead_mailbox() {
+        let agents = make_team_agents();
+        let repo = Arc::new(MockTeamRepo::new());
+        let mailbox = Arc::new(Mailbox::new(repo.clone()));
+        let task_board = Arc::new(TaskBoard::new(repo));
+        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
+        let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+
+        mgr.notify_shutdown_rejected("worker-1", "still working on task X")
+            .await
+            .unwrap();
+
+        let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+        assert_eq!(lead_msgs.len(), 1);
+        assert_eq!(lead_msgs[0].from_agent_id, "worker-1");
+        assert!(lead_msgs[0].content.contains("Worker1"));
+        assert!(lead_msgs[0].content.contains("declined shutdown"));
+        assert!(lead_msgs[0].content.contains("still working on task X"));
+
+        // Agent was not removed
+        assert!(mgr.get_agent("worker-1").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn notify_shutdown_rejected_noop_when_no_lead() {
+        let agents = vec![
+            make_agent("worker-1", "Worker1", TeammateRole::Teammate),
+            make_agent("worker-2", "Worker2", TeammateRole::Teammate),
+        ];
+        let repo = Arc::new(MockTeamRepo::new());
+        let mailbox = Arc::new(Mailbox::new(repo.clone()));
+        let task_board = Arc::new(TaskBoard::new(repo));
+        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
+        let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+
+        mgr.notify_shutdown_rejected("worker-1", "busy").await.unwrap();
+
+        let msgs1 = mailbox.read_unread("t1", "worker-1").await.unwrap();
+        let msgs2 = mailbox.read_unread("t1", "worker-2").await.unwrap();
+        assert!(msgs1.is_empty());
+        assert!(msgs2.is_empty());
+    }
+
+    #[tokio::test]
+    async fn notify_shutdown_rejected_noop_when_sender_is_lead() {
+        let agents = make_team_agents();
+        let repo = Arc::new(MockTeamRepo::new());
+        let mailbox = Arc::new(Mailbox::new(repo.clone()));
+        let task_board = Arc::new(TaskBoard::new(repo));
+        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
+        let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+
+        mgr.notify_shutdown_rejected("lead-1", "irrelevant").await.unwrap();
+
+        let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+        assert!(lead_msgs.is_empty());
     }
 }

--- a/crates/aionui-team/tests/mcp_server_integration.rs
+++ b/crates/aionui-team/tests/mcp_server_integration.rs
@@ -844,3 +844,111 @@ async fn mcp_status_tcp_ready_is_broadcast_on_successful_bind() {
 
     env.server.stop();
 }
+
+// ---------------------------------------------------------------------------
+// Tests: W5-D30b — shutdown_rejected detection in team_send_message
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tsr1_shutdown_rejected_notifies_lead_and_preserves_agent() {
+    let env = setup().await;
+    let mut stream = connect_and_init(env.server.port(), "test-token-123", "worker-1").await;
+
+    let resp = call_tool(
+        &mut stream,
+        2,
+        "team_send_message",
+        json!({"to": "lead-1", "message": "shutdown_rejected: still working"}),
+    )
+    .await;
+
+    assert!(!is_error_response(&resp));
+    let text = extract_text(&resp);
+    assert!(
+        text.contains("shutdown_rejected"),
+        "response should echo the sentinel, got: {text}"
+    );
+    assert!(
+        text.contains("still working"),
+        "response should echo the reason, got: {text}"
+    );
+
+    // Leader mailbox contains the notification, worker did not receive a
+    // literal copy of the sentinel.
+    let state = env._repo.state.lock().unwrap();
+    let lead_msgs: Vec<_> = state.messages.iter().filter(|m| m.to_agent_id == "lead-1").collect();
+    assert_eq!(lead_msgs.len(), 1, "expected exactly one message to lead");
+    assert_eq!(lead_msgs[0].from_agent_id, "worker-1");
+    assert!(lead_msgs[0].content.contains("Worker"));
+    assert!(lead_msgs[0].content.contains("declined shutdown"));
+    assert!(lead_msgs[0].content.contains("still working"));
+
+    let lead_self_msgs: Vec<_> = state
+        .messages
+        .iter()
+        .filter(|m| m.to_agent_id == "lead-1" && m.content == "shutdown_rejected: still working")
+        .collect();
+    assert!(
+        lead_self_msgs.is_empty(),
+        "raw sentinel must not be delivered as a normal message"
+    );
+    drop(state);
+
+    env.server.stop();
+}
+
+#[tokio::test]
+async fn tsr2_shutdown_rejected_with_whitespace_reason() {
+    let env = setup().await;
+    let mut stream = connect_and_init(env.server.port(), "test-token-123", "worker-1").await;
+
+    let resp = call_tool(
+        &mut stream,
+        2,
+        "team_send_message",
+        json!({"to": "lead-1", "message": "  shutdown_rejected:   need more time  "}),
+    )
+    .await;
+
+    assert!(!is_error_response(&resp));
+
+    let state = env._repo.state.lock().unwrap();
+    let lead_msgs: Vec<_> = state.messages.iter().filter(|m| m.to_agent_id == "lead-1").collect();
+    assert_eq!(lead_msgs.len(), 1);
+    // Reason is trimmed before inclusion in the notification.
+    assert!(lead_msgs[0].content.contains("need more time"));
+    assert!(!lead_msgs[0].content.contains("  need more time  "));
+    drop(state);
+
+    env.server.stop();
+}
+
+#[tokio::test]
+async fn tsr3_send_message_without_sentinel_still_routes_normally() {
+    let env = setup().await;
+    let mut stream = connect_and_init(env.server.port(), "test-token-123", "worker-1").await;
+
+    let resp = call_tool(
+        &mut stream,
+        2,
+        "team_send_message",
+        json!({"to": "lead-1", "message": "regular update"}),
+    )
+    .await;
+
+    assert!(!is_error_response(&resp));
+    let text = extract_text(&resp);
+    assert!(text.contains("Message sent"));
+
+    // The literal message lands in the lead mailbox unchanged.
+    let state = env._repo.state.lock().unwrap();
+    let lead_msg = state
+        .messages
+        .iter()
+        .find(|m| m.to_agent_id == "lead-1")
+        .expect("message should be delivered");
+    assert_eq!(lead_msg.content, "regular update");
+    drop(state);
+
+    env.server.stop();
+}


### PR DESCRIPTION
## Summary
- `exec_send_message` intercepts `shutdown_rejected: <reason>` sentinels from a teammate and routes them to the leader's mailbox instead of delivering them as plain messages.
- Adds `TeammateManager::notify_shutdown_rejected`, mirroring `write_crash_testament` — looks up the lead, no-ops when no lead is present or when the sender is the lead, otherwise writes `Teammate '<name>' declined shutdown: <reason>`.
- The teammate is **not** removed; a rejection means the agent chose to keep working.

## Why
Teammates are instructed via `prompts/teammate.rs` to reply to a shutdown request with either `shutdown_approved` or `shutdown_rejected: <reason>`. Without this interception the sentinel would land in the leader mailbox verbatim, forcing the LLM to parse it. This change normalises it into a first-class notification.

## Tests
- `crates/aionui-team/src/scheduler.rs` — 3 unit tests on `notify_shutdown_rejected`
  - delivers formatted message to the lead mailbox (happy path)
  - no-op when the team has no lead
  - no-op when the sender is the lead itself
- `crates/aionui-team/tests/mcp_server_integration.rs` — 3 TCP-level tests
  - `tsr1` — worker rejects; lead mailbox has the notification, raw sentinel not delivered
  - `tsr2` — whitespace around the reason is trimmed
  - `tsr3` — regular `team_send_message` still routes normally (regression guard)

## Test plan
- [x] `cargo fmt -p aionui-team --check` — clean
- [x] `cargo test -p aionui-team --lib scheduler::tests::notify_shutdown` — 3/3 pass
- [x] `cargo test -p aionui-team --test mcp_server_integration` — 29/29 pass
- [x] `cargo test -p aionui-team --lib` — 228 pass, 1 pre-existing failure (`session::tests::mcp_stdio_config_for_agent`) unrelated to this change — tracked in mnemo `project_main_clippy_debt_wave4.md`
- [x] `cargo clippy -p aionui-team --lib --tests --no-deps -- -D warnings` — only pre-existing warnings in `http_mcp_loop` (lines 529, 584) remain, same as on `origin/main`

## Related
- Builds on the stub from `w5-d30a1/shutdown-detect` (W5-D30a-1) which intercepts both sentinels with placeholders. When D30a-1 merges first, this PR will need a trivial conflict resolution in `exec_send_message` (the placeholder block is replaced by the real handler).
- `w5-d30a2/shutdown-approved` will follow the same pattern for the approval path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)