### PR TITLE
feat(team): normalize + uniqueness check in spawn_agent (W5-D29a-3)

### DIFF
--- a/crates/aionui-team/src/lib.rs
+++ b/crates/aionui-team/src/lib.rs
@@ -21,7 +21,9 @@ pub use mailbox::Mailbox;
 pub use mcp::{TeamMcpServer, TeamMcpStdioConfig, TeamMcpStdioServerSpec};
 pub use prompts::{build_lead_prompt, build_teammate_prompt, build_wake_payload};
 pub use routes::{TeamRouterState, team_routes};
-pub use scheduler::{SchedulerAction, TeammateManager, WAKE_TIMEOUT_MS, WakePayload, format_crash_testament};
+pub use scheduler::{
+    SchedulerAction, TeammateManager, WAKE_TIMEOUT_MS, WakePayload, format_crash_testament, normalize_name,
+};
 pub use service::TeamSessionService;
 pub use session::{TeamSession, WakeInput};
 pub use task_board::{TaskBoard, TaskUpdate};

--- a/crates/aionui-team/src/scheduler.rs
+++ b/crates/aionui-team/src/scheduler.rs
@@ -19,6 +19,24 @@ pub const WAKE_TIMEOUT_MS: u64 = 60_000;
 const FINALIZE_DEDUP_WINDOW: Duration = Duration::from_secs(5);
 
 // ---------------------------------------------------------------------------
+// normalize_name — canonical form for agent-name conflict checks
+// ---------------------------------------------------------------------------
+
+/// Normalize an agent name to its canonical form for conflict detection.
+///
+/// Rules (see interface-contracts §15.1):
+/// 1. Trim leading/trailing whitespace.
+/// 2. Drop control characters (`char::is_control`).
+/// 3. Lowercase (Unicode-aware via `to_lowercase`).
+pub fn normalize_name(name: &str) -> String {
+    name.trim()
+        .chars()
+        .filter(|c| !c.is_control())
+        .collect::<String>()
+        .to_lowercase()
+}
+
+// ---------------------------------------------------------------------------
 // SchedulerAction — actions parsed from an agent's turn response
 // ---------------------------------------------------------------------------
 
@@ -697,6 +715,35 @@ mod tests {
     use super::*;
     use crate::test_utils::MockTeamRepo;
     use aionui_api_types::WebSocketMessage;
+
+    // -----------------------------------------------------------------
+    // normalize_name — §15.1 contract
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn normalize_name_trims_outer_whitespace() {
+        assert_eq!(normalize_name("  Alice  "), "alice");
+        assert_eq!(normalize_name("\tBob\n"), "bob");
+    }
+
+    #[test]
+    fn normalize_name_lowercases_ascii_and_unicode() {
+        assert_eq!(normalize_name("ALICE"), "alice");
+        assert_eq!(normalize_name("Crème"), "crème");
+    }
+
+    #[test]
+    fn normalize_name_filters_control_characters() {
+        // Null + bell in the middle + outer whitespace.
+        assert_eq!(normalize_name("  Ali\x00ce\x07 "), "alice");
+    }
+
+    #[test]
+    fn normalize_name_collides_on_case_and_whitespace() {
+        // Conflict-detection invariant: two inputs that only differ by
+        // surrounding whitespace / case must normalize to the same string.
+        assert_eq!(normalize_name("  Leader  "), normalize_name("leader"));
+    }
 
     struct RecordingBroadcaster {
         events: std::sync::Mutex<Vec<WebSocketMessage<serde_json::Value>>>,

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -11,7 +11,7 @@ use crate::error::TeamError;
 use crate::mailbox::Mailbox;
 use crate::mcp::{TeamMcpServer, TeamMcpStdioConfig, TeamMcpStdioServerSpec};
 use crate::prompts::{build_lead_prompt, build_teammate_prompt, build_wake_payload};
-use crate::scheduler::TeammateManager;
+use crate::scheduler::{TeammateManager, normalize_name};
 use crate::task_board::TaskBoard;
 use crate::types::{MailboxMessageType, Team, TeamAgent, TeammateRole, TeammateStatus};
 
@@ -328,8 +328,21 @@ impl TeamSession {
             return Err(TeamError::LeaderOnly("spawn_agent".into()));
         }
 
+        // Step 2: normalize the requested name + uniqueness check against
+        // existing agents. See interface-contracts §15.1 for the rules.
+        let normalized = normalize_name(&req.name);
+        if normalized.is_empty() {
+            return Err(TeamError::InvalidRequest(
+                "agent name cannot be empty after normalization".into(),
+            ));
+        }
+        let existing = self.scheduler.list_agents().await;
+        if existing.iter().any(|a| normalize_name(&a.name) == normalized) {
+            return Err(TeamError::InvalidRequest(format!("agent name conflict: {normalized}")));
+        }
+
         let _ = req;
-        todo!("W5-D29a-3..D29d will fill in the remaining spawn steps")
+        todo!("W5-D29a-4..D29d will fill in the remaining spawn steps")
     }
 
     pub fn stop(&self) {
@@ -713,14 +726,59 @@ mod tests {
         session.stop();
     }
 
-    // Lead caller is expected to pass the guard and hit the todo!() for
-    // subsequent slices (W5-D29a-3..D29d). This pins that the guard does not
-    // over-reject a legitimate Lead caller.
+    // Lead caller is expected to pass the caller guard and the name check
+    // (sample_spawn_req uses "Helper", which does not collide) and hit the
+    // todo!() for subsequent slices (W5-D29a-4..D29d). This pins that the
+    // guards do not over-reject a legitimate Lead caller.
     #[tokio::test]
-    #[should_panic(expected = "W5-D29a-3..D29d")]
+    #[should_panic(expected = "W5-D29a-4..D29d")]
     async fn spawn_agent_lead_caller_passes_guard() {
         let session = start_session().await;
         let _ = session.spawn_agent("lead-1", sample_spawn_req()).await;
+    }
+
+    // -- W5-D29a-3: spawn_agent name normalize + uniqueness ------------------
+
+    #[tokio::test]
+    async fn spawn_agent_rejects_empty_name_after_normalization() {
+        let session = start_session().await;
+        // All-whitespace + control chars normalizes to empty.
+        let req = SpawnAgentRequest {
+            name: "  \t\n  ".into(),
+            agent_type: None,
+            custom_agent_id: None,
+            model: None,
+        };
+        let result = session.spawn_agent("lead-1", req).await;
+        match result {
+            Err(TeamError::InvalidRequest(msg)) => {
+                assert!(msg.contains("empty"), "unexpected message: {msg}");
+            }
+            other => panic!("expected InvalidRequest, got {other:?}"),
+        }
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_rejects_name_colliding_with_existing_agent() {
+        let session = start_session().await;
+        // `make_team()` already seeded an agent named "Worker". Any variant
+        // that normalizes to "worker" must be rejected.
+        let req = SpawnAgentRequest {
+            name: "  WORKER\t".into(),
+            agent_type: None,
+            custom_agent_id: None,
+            model: None,
+        };
+        let result = session.spawn_agent("lead-1", req).await;
+        match result {
+            Err(TeamError::InvalidRequest(msg)) => {
+                assert!(msg.contains("conflict"), "unexpected message: {msg}");
+                assert!(msg.contains("worker"), "expected normalized name in message: {msg}");
+            }
+            other => panic!("expected InvalidRequest, got {other:?}"),
+        }
+        session.stop();
     }
 
     // -- D7a new method tests ------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds step 2 of `TeamSession::spawn_agent` on top of W5-D29a-2's caller guard: normalize `req.name`, reject when empty after normalization or when it collides with an existing agent's normalized name. Both failures surface as `TeamError::InvalidRequest` (→ `BadRequest`).
- Inlines `scheduler::normalize_name` + its 4 §15.1 contract unit tests (originally PR #66 / W3-D14a — not on `feat/team-wave4-5`). Re-exported from `aionui-team::lib` for reuse by rename conflict check + future D29 sub-tasks.
- Updates D29a-2's `#[should_panic]` sentinel from `"W5-D29a-3..D29d"` to `"W5-D29a-4..D29d"` since step 2 is no longer stubbed.

## Base note
- Branched off `origin/w5-d29a2/spawn-caller-check` (D29a-2), not `w5-d29a1`, so the caller guard already sits in the method when my step-2 guard lands after it. When D29a-2 merges into `feat/team-wave4-5`, this PR will rebase to a one-commit diff.

## Test plan
- [x] `cargo check -p aionui-team` — clean (only pre-existing `mcp/server.rs` warnings on this line).
- [x] `cargo fmt -p aionui-team -- --check` — clean.
- [x] `cargo clippy -p aionui-team -- -D warnings` — clean.
- [x] `cargo test -p aionui-team --lib -- scheduler::tests::normalize_name session::tests::spawn_agent` — 9/9 pass, including the 2 new `spawn_agent_rejects_*` cases and D29a-2's `spawn_agent_lead_caller_passes_guard` with the updated sentinel.
- [x] Full `cargo test -p aionui-team --lib`: 235 pass / 1 pre-existing flake (`session::tests::mcp_stdio_config_for_agent` — known port race, not touched by this PR).