### PR TITLE
feat(ai-agent): inject solo Team Guide prompt into first ACP message (W5-D28b)

### DIFF
--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -13,6 +13,7 @@ use crate::agent_registry::CatalogSender;
 use crate::cli_process::CliAgentProcess;
 use crate::skill_manager::AcpSkillManager;
 use crate::stream_event::{AgentStreamEvent, permission_request_to_event_data};
+use crate::team_guide_prompt;
 use crate::types::{AcpBuildExtra, AgentStreamChunk, SendMessageData, SlashCommandItem};
 use agent_client_protocol::schema::{
     AgentCapabilities, AvailableCommand, CancelNotification, ContentBlock, HttpHeader, LoadSessionRequest, McpServer,
@@ -86,6 +87,48 @@ fn confirm_option_id(data: &Value) -> Option<String> {
             .and_then(Value::as_str)
             .map(ToOwned::to_owned),
         _ => None,
+    }
+}
+
+/// Compose the first-message preset context for a solo ACP agent, optionally
+/// prepending the Team Guide prompt (W5-D28b).
+///
+/// The guide is injected iff **both** conditions hold:
+/// 1. The session is not already part of a team (`team_mcp_stdio_config`
+///    absent on [`AcpBuildExtra`]) — in-team agents receive a different
+///    coordination prompt via their team MCP bridge, and must not be told to
+///    propose a fresh team from inside one.
+/// 2. The backend is on the solo-guide whitelist (see
+///    [`team_guide_prompt::is_solo_team_guide_backend`]). Unknown backends
+///    receive no guide, matching AionUi's `opts.backend`-gated solo
+///    injection.
+///
+/// When the guide is added it is appended after any pre-existing
+/// `preset_context` so user-configured rules still take precedence at the
+/// top of the `[Assistant Rules]` block assembled by
+/// [`crate::first_message_injector::inject_first_message_prefix`].
+fn compose_preset_context_with_team_guide(
+    base_preset_context: Option<&str>,
+    backend: Option<&str>,
+    has_team_session: bool,
+) -> Option<String> {
+    let base = base_preset_context
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned);
+
+    if has_team_session {
+        return base;
+    }
+    let backend_key = backend.unwrap_or_default();
+    if !team_guide_prompt::is_solo_team_guide_backend(backend_key) {
+        return base;
+    }
+
+    let guide = team_guide_prompt::build_solo_team_guide_prompt(backend_key);
+    match base {
+        Some(ctx) => Some(format!("{ctx}\n\n{guide}")),
+        None => Some(guide),
     }
 }
 
@@ -710,11 +753,23 @@ impl AcpAgentManager {
         // Backends with native skill discovery (e.g. Claude via .claude/skills/)
         // only need preset_context here; others get the full [Assistant Rules]
         // block with a skills index.
+        //
+        // Before handing off, (W5-D28b) prepend the solo Team Guide prompt to
+        // `preset_context` when this agent is *not* part of a team and the
+        // backend is on the solo-guide whitelist. Agents inside a team
+        // (non-empty `team_mcp_stdio_config`) are deliberately excluded —
+        // they coordinate through the team MCP bridge and must not receive
+        // the "propose a team" prompt.
+        let composed_preset_context = compose_preset_context_with_team_guide(
+            self.config.preset_context.as_deref(),
+            self.backend(),
+            self.config.team_mcp_stdio_config.is_some(),
+        );
         let injected_content = crate::first_message_injector::inject_first_message_prefix(
             &data.content,
             &self.skill_manager,
             crate::first_message_injector::InjectionConfig {
-                preset_context: self.config.preset_context.as_deref(),
+                preset_context: composed_preset_context.as_deref(),
                 skills: &self.config.skills,
                 native_skill_support: self.native_skill_support(),
                 // Whether the user chose this workspace — determined at
@@ -1331,6 +1386,67 @@ mod tests {
     fn normalize_requested_mode_trims_and_returns_empty_for_blank() {
         let meta = metadata_with_yolo_id(Some("full-access"));
         assert_eq!(normalize_requested_mode(&meta, "   "), "");
+    }
+
+    const TEAM_GUIDE_MARKER: &str = "## Team Mode";
+
+    #[test]
+    fn compose_preset_context_injects_team_guide_for_solo_whitelisted_backend() {
+        let out = compose_preset_context_with_team_guide(None, Some("claude"), false).expect("guide must be injected");
+        assert!(
+            out.contains(TEAM_GUIDE_MARKER),
+            "solo whitelisted backend must receive Team Guide prompt, got: {out}"
+        );
+    }
+
+    #[test]
+    fn compose_preset_context_preserves_base_context_before_team_guide() {
+        let base = "User rule: always respond in English.";
+        let out =
+            compose_preset_context_with_team_guide(Some(base), Some("gemini"), false).expect("guide must be injected");
+        let guide_idx = out.find(TEAM_GUIDE_MARKER).expect("team guide present");
+        let base_idx = out.find(base).expect("base rule present");
+        assert!(
+            base_idx < guide_idx,
+            "base preset_context must come before the Team Guide so user rules stay at the top of [Assistant Rules]"
+        );
+    }
+
+    #[test]
+    fn compose_preset_context_skips_team_guide_when_already_in_team() {
+        // Agent bound to a team: `team_mcp_stdio_config` present ⇒
+        // `has_team_session = true`. Must NOT inject the Team Guide prompt.
+        let out = compose_preset_context_with_team_guide(None, Some("claude"), true);
+        assert!(out.is_none(), "in-team agent must not receive Team Guide, got: {out:?}");
+
+        let with_base = compose_preset_context_with_team_guide(Some("Keep responses short."), Some("claude"), true)
+            .expect("base context must pass through");
+        assert!(
+            !with_base.contains(TEAM_GUIDE_MARKER),
+            "in-team agent must not receive Team Guide even when base context exists"
+        );
+        assert!(with_base.contains("Keep responses short."));
+    }
+
+    #[test]
+    fn compose_preset_context_skips_team_guide_for_unknown_backend() {
+        // Solo agent, but backend not on the whitelist: pass base context
+        // through (possibly `None`) without adding the Team Guide.
+        assert!(compose_preset_context_with_team_guide(None, Some("qwen"), false).is_none());
+        assert!(compose_preset_context_with_team_guide(None, None, false).is_none());
+
+        let with_base = compose_preset_context_with_team_guide(Some("Existing rule."), Some("qwen"), false)
+            .expect("base context must pass through unchanged");
+        assert_eq!(with_base, "Existing rule.");
+    }
+
+    #[test]
+    fn compose_preset_context_treats_blank_base_as_absent() {
+        // Whitespace-only base context should be treated as "none" so we
+        // don't leak "\n\n" prefixes into the injected Team Guide.
+        let out = compose_preset_context_with_team_guide(Some("   \n\t"), Some("claude"), false)
+            .expect("guide must still be injected");
+        assert!(out.starts_with("## Team Mode"));
     }
 
     /// Each session-driven event projects onto exactly one handshake

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -29,6 +29,7 @@ pub mod remote_agent_service;
 pub mod skill_manager;
 pub mod stream_event;
 pub mod task_manager;
+mod team_guide_prompt;
 pub mod types;
 
 pub use acp_agent::AcpAgentManager;

--- a/crates/aionui-ai-agent/src/team_guide_prompt.rs
+++ b/crates/aionui-ai-agent/src/team_guide_prompt.rs
@@ -1,0 +1,197 @@
+//! Solo-agent Team Guide prompt (Layer 1) — teaches a solo ACP agent when and
+//! how to propose a multi-agent Team to the user.
+//!
+//! This is a local copy of the prompt owned by `aionui_team::prompts::team_guide`
+//! (see `crates/aionui-team/src/prompts/team_guide.rs`). We duplicate rather
+//! than import because `aionui-team` depends on `aionui-ai-agent`, so the
+//! reverse direction would create a dependency cycle. Future work may sink
+//! this prompt into `aionui-common` and have both crates re-export; until
+//! then, **keep this file byte-for-byte in sync with the team-side template**
+//! — it ships to the LLM and must match AionUi's
+//! `src/process/team/prompts/teamGuidePrompt.ts` exactly (aionui-audit §8 #5).
+//!
+//! Unlike the team-side helper, this module only exposes the solo branch
+//! (`leader_label = None`). The preset-assistant label branch does not apply
+//! to Wave 5 solo-agent injection.
+
+/// Vendor backends for which the solo Team Guide prompt is injected. Matches
+/// `TEAM_CAPABLE_BACKENDS` in `crates/aionui-team/src/guide/capability.rs` at
+/// the time of W5-D28b. Kept as a local copy to avoid a crate-dependency
+/// cycle (see module docs); when a new backend is whitelisted for team
+/// membership it must be added in **both** places.
+const TEAM_GUIDE_CAPABLE_BACKENDS: &[&str] = &["claude", "codex", "gemini", "aionrs"];
+
+const EXPLICIT_TEAM_REQUEST_CRITERIA: &str = "\
+- The user explicitly asks to create a Team
+- The user explicitly asks for multiple agents, teammates, or parallel workers
+- The user says they want to pull in a Team before starting";
+
+const EXTREME_COMPLEXITY_CRITERIA: &str = "\
+- The task is so large, risky, or specialized that one agent is unlikely to complete it well alone
+- The work needs substantial parallel role separation that cannot be reasonably handled in a normal solo workflow
+- This bar is very high: if you can handle the task yourself, stay solo";
+
+const STAY_SOLO_CRITERIA: &str = "\
+- Greetings, casual conversation, or general questions
+- Single-point tasks: one question, one file, one fix, one translation, one explanation
+- Normal coding, writing, research, or analysis tasks that one agent can handle with some effort
+- Any task you can reasonably complete yourself, even if it takes multiple turns";
+
+const SOLO_DEFAULT_RULE: &str = "Handle the task yourself in the current chat by default. Do NOT proactively recommend Team just because the work spans multiple files, takes multiple rounds, or would benefit from specialization.";
+
+const TEAM_GUIDE_PROMPT_TEMPLATE: &str = "## Team Mode
+
+You can create a multi-agent Team for the user.
+
+### Default behavior
+{solo_default_rule}
+
+### Only bring up Team in either of these cases
+1. The user explicitly wants a Team or multiple agents:
+{explicit_team_request_criteria}
+2. The task is exceptionally complex and you genuinely believe one agent is unlikely to handle it well alone:
+{extreme_complexity_criteria}
+
+### Otherwise stay solo and do not mention Team
+{stay_solo_criteria}
+
+If case 2 applies, ask at most once whether the user wants to bring in a Team. Keep it brief and optional. If the user says no, ignores it, or prefers solo help, continue solo and do not mention Team again.
+
+### How to proceed when Team is requested or approved (STRICT — follow every step, do NOT skip)
+1. FIRST call `aion_list_models` to check available models for each agent type you plan to use.
+2. Explain in one sentence why the Team setup helps this task.
+3. Present a team configuration table: role name, responsibility, agent type, and recommended model (from aion_list_models results) for each member. Example format:
+   | Role | Responsibility | Type | Model |
+   | Leader | Coordinate and review | {leader_cell} | (default) |
+   | Developer | Implement features | {agent_type} | (model from list) |
+   | Tester | Write and run tests | {agent_type} | (model from list) |
+4. **Output the table as a normal text message and END YOUR TURN.** Do NOT call `aion_create_team` or any other tool (including ask_user) in this turn. Wait for the user to reply in their next message with explicit confirmation (e.g. \"ok\", \"go ahead\", \"确认\") before proceeding.
+5. After user confirms → call `aion_create_team`. The summary MUST include both the goal and the confirmed team configuration. (The system automatically sets the correct agent type — you do NOT need to pass agentType.)
+6. After `aion_create_team` returns → the system navigates to the team page **automatically**. Read the `next_step` in the response and follow it. End your turn immediately.
+7. User declines or wants changes → adjust or proceed solo. Do not mention Team again unless the user asks.
+
+### Tool constraint
+Use **only** `aion_create_team` and `aion_list_models` for team operations. Do NOT use any built-in or other team/agent creation tools.";
+
+/// Return `true` iff the given backend is a known team-capable backend. An
+/// empty or unrecognized backend returns `false`; solo agents with unknown
+/// backends do not receive the Team Guide prompt.
+///
+/// The `mcp_stdio_capable` dynamic escape hatch that `aionui_team` exposes is
+/// intentionally omitted here — at session/new time in the factory we have
+/// no general way to probe MCP capability across all 20+ vendor CLIs, and
+/// the team-audit authority (aionui-audit §8) only requires the whitelist
+/// to gate prompt injection. Extend this list in lockstep with
+/// `aionui_team::guide::capability::TEAM_CAPABLE_BACKENDS` if the policy
+/// changes.
+pub(crate) fn is_solo_team_guide_backend(backend: &str) -> bool {
+    TEAM_GUIDE_CAPABLE_BACKENDS.contains(&backend)
+}
+
+/// Build the Team Guide prompt for a solo agent with the given backend label.
+/// An empty `backend` falls back to `"claude"`, matching AionUi's
+/// `opts.backend || 'claude'` and the team-side helper.
+pub(crate) fn build_solo_team_guide_prompt(backend: &str) -> String {
+    let agent_type = if backend.is_empty() { "claude" } else { backend };
+    TEAM_GUIDE_PROMPT_TEMPLATE
+        .replace("{solo_default_rule}", SOLO_DEFAULT_RULE)
+        .replace("{explicit_team_request_criteria}", EXPLICIT_TEAM_REQUEST_CRITERIA)
+        .replace("{extreme_complexity_criteria}", EXTREME_COMPLEXITY_CRITERIA)
+        .replace("{stay_solo_criteria}", STAY_SOLO_CRITERIA)
+        .replace("{leader_cell}", agent_type)
+        .replace("{agent_type}", agent_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_solo_team_guide_backend_allows_known_vendors() {
+        assert!(is_solo_team_guide_backend("claude"));
+        assert!(is_solo_team_guide_backend("codex"));
+        assert!(is_solo_team_guide_backend("gemini"));
+        assert!(is_solo_team_guide_backend("aionrs"));
+    }
+
+    #[test]
+    fn is_solo_team_guide_backend_rejects_unknown_and_empty() {
+        assert!(!is_solo_team_guide_backend(""));
+        assert!(!is_solo_team_guide_backend("qwen"));
+        assert!(!is_solo_team_guide_backend("Claude")); // case-sensitive
+    }
+
+    #[test]
+    fn build_solo_team_guide_prompt_resolves_all_placeholders() {
+        let prompt = build_solo_team_guide_prompt("claude");
+        assert!(!prompt.contains("{solo_default_rule}"));
+        assert!(!prompt.contains("{explicit_team_request_criteria}"));
+        assert!(!prompt.contains("{extreme_complexity_criteria}"));
+        assert!(!prompt.contains("{stay_solo_criteria}"));
+        assert!(!prompt.contains("{leader_cell}"));
+        assert!(!prompt.contains("{agent_type}"));
+    }
+
+    #[test]
+    fn build_solo_team_guide_prompt_renders_leader_row_with_backend() {
+        let prompt = build_solo_team_guide_prompt("gemini");
+        assert!(prompt.contains("| Leader | Coordinate and review | gemini | (default) |"));
+        assert!(prompt.contains("| Developer | Implement features | gemini | (model from list) |"));
+    }
+
+    #[test]
+    fn build_solo_team_guide_prompt_empty_backend_falls_back_to_claude() {
+        let prompt = build_solo_team_guide_prompt("");
+        assert!(prompt.contains("| Leader | Coordinate and review | claude | (default) |"));
+    }
+
+    #[test]
+    fn snapshot_matches_team_crate_verbatim() {
+        // Byte-for-byte equality with the canonical prompt in
+        // `aionui-team/src/prompts/team_guide.rs`. If this test fails, one
+        // side has drifted — update **both** files (and the AionUi TS
+        // source in lockstep) rather than patching this assertion.
+        let prompt = build_solo_team_guide_prompt("claude");
+        let expected = "## Team Mode\n\
+\n\
+You can create a multi-agent Team for the user.\n\
+\n\
+### Default behavior\n\
+Handle the task yourself in the current chat by default. Do NOT proactively recommend Team just because the work spans multiple files, takes multiple rounds, or would benefit from specialization.\n\
+\n\
+### Only bring up Team in either of these cases\n\
+1. The user explicitly wants a Team or multiple agents:\n\
+- The user explicitly asks to create a Team\n\
+- The user explicitly asks for multiple agents, teammates, or parallel workers\n\
+- The user says they want to pull in a Team before starting\n\
+2. The task is exceptionally complex and you genuinely believe one agent is unlikely to handle it well alone:\n\
+- The task is so large, risky, or specialized that one agent is unlikely to complete it well alone\n\
+- The work needs substantial parallel role separation that cannot be reasonably handled in a normal solo workflow\n\
+- This bar is very high: if you can handle the task yourself, stay solo\n\
+\n\
+### Otherwise stay solo and do not mention Team\n\
+- Greetings, casual conversation, or general questions\n\
+- Single-point tasks: one question, one file, one fix, one translation, one explanation\n\
+- Normal coding, writing, research, or analysis tasks that one agent can handle with some effort\n\
+- Any task you can reasonably complete yourself, even if it takes multiple turns\n\
+\n\
+If case 2 applies, ask at most once whether the user wants to bring in a Team. Keep it brief and optional. If the user says no, ignores it, or prefers solo help, continue solo and do not mention Team again.\n\
+\n\
+### How to proceed when Team is requested or approved (STRICT — follow every step, do NOT skip)\n\
+1. FIRST call `aion_list_models` to check available models for each agent type you plan to use.\n\
+2. Explain in one sentence why the Team setup helps this task.\n\
+3. Present a team configuration table: role name, responsibility, agent type, and recommended model (from aion_list_models results) for each member. Example format:\n   \
+| Role | Responsibility | Type | Model |\n   \
+| Leader | Coordinate and review | claude | (default) |\n   \
+| Developer | Implement features | claude | (model from list) |\n   \
+| Tester | Write and run tests | claude | (model from list) |\n\
+4. **Output the table as a normal text message and END YOUR TURN.** Do NOT call `aion_create_team` or any other tool (including ask_user) in this turn. Wait for the user to reply in their next message with explicit confirmation (e.g. \"ok\", \"go ahead\", \"确认\") before proceeding.\n\
+5. After user confirms → call `aion_create_team`. The summary MUST include both the goal and the confirmed team configuration. (The system automatically sets the correct agent type — you do NOT need to pass agentType.)\n\
+6. After `aion_create_team` returns → the system navigates to the team page **automatically**. Read the `next_step` in the response and follow it. End your turn immediately.\n\
+7. User declines or wants changes → adjust or proceed solo. Do not mention Team again unless the user asks.\n\
+\n\
+### Tool constraint\n\
+Use **only** `aion_create_team` and `aion_list_models` for team operations. Do NOT use any built-in or other team/agent creation tools.";
+        assert_eq!(prompt, expected);
+    }
+}


### PR DESCRIPTION
## Summary

Wire the Team Guide prompt (Layer 1) into solo ACP agents so they know when and how to propose a multi-agent Team. Part of Wave 5 (W5-D28b).

- **Injection site:** `session_new_and_prompt` in `crates/aionui-ai-agent/src/acp_agent.rs` composes the solo Team Guide prompt into `preset_context` **before** it is handed to `inject_first_message_prefix`. The guide surfaces to the LLM inside the existing `[Assistant Rules]` block on the first `session/new` prompt — ACP itself has no separate `instructions`/`system_prompt` field.
- **Mutual-exclusion guard:** `team_mcp_stdio_config.is_none() && is_solo_team_guide_backend(backend)`. Agents already bound to a team receive a different coordination prompt via their team MCP bridge and must not be told to propose a fresh team from inside one.
- **Whitelist:** `claude / codex / gemini / aionrs` (matches `aionui_team::guide::capability::TEAM_CAPABLE_BACKENDS` at the time of W5-D28a). Unknown backends receive no guide.
- **Prompt text:** a new crate-local `team_guide_prompt` module carries a byte-for-byte copy of the canonical template owned by `aionui-team/src/prompts/team_guide.rs`. `aionui-team` already depends on `aionui-ai-agent`, so importing the team-side helper would cycle. A snapshot test asserts the two copies stay identical — CI will catch any drift. Future work may sink the prompt into `aionui-common` and have both crates re-export; not done here to keep the slice small and avoid cross-slice conflicts.

## Testing

- `cargo check -p aionui-ai-agent` — clean.
- `cargo test -p aionui-ai-agent --lib` — 11 new tests pass:
  - `team_guide_prompt::tests::*` (6): whitelist membership, placeholder resolution, backend fallback, byte-for-byte snapshot parity with the team-side template.
  - `acp_agent::tests::compose_preset_context_*` (5): guide injected for solo whitelisted, skipped for in-team, skipped for unknown backend, base `preset_context` stays at the top, blank base treated as absent.
- `cargo clippy -p aionui-ai-agent --lib -- -D warnings` — clean.
- `cargo fmt -p aionui-ai-agent --check` — clean.

### Pre-existing issues out of scope for this PR

- `acp_agent::tests::build_new_session_request_injects_team_stdio_server` was already failing on `origin/feat/team-wave4-5` before this branch: commit `6c334a9 feat(team): switch MCP injection from stdio to HTTP transport` flipped the implementation from `McpServer::Stdio` to `McpServer::Http` but did not update the assertion. Not touched here.
- `cargo clippy -p aionui-ai-agent --all-targets` flags `await_holding_lock` in `tests/acp_agent_integration.rs` — also pre-existing, unrelated to this change.

## Test plan

- [x] New snapshot test locks the two prompt copies together (drift = CI fail).
- [x] Solo + claude → guide present.
- [x] Solo + unknown backend → guide absent.
- [x] In-team (has `team_mcp_stdio_config`) → guide absent, base context passes through.
- [x] Base `preset_context` stays above guide in the composed string so user-configured rules keep priority.
- [ ] Manual verification on a real Claude CLI session (not runnable in CI — needs backend binary and live API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)