### PR TITLE
test(team): strengthen remove_agent coverage (W5-D30d-3)

### DIFF
--- a/crates/aionui-team/src/scheduler.rs
+++ b/crates/aionui-team/src/scheduler.rs
@@ -1259,6 +1259,22 @@ mod tests {
 
         let all = mgr.list_agents().await;
         assert_eq!(all.len(), 2);
+        assert!(
+            all.iter().all(|a| a.slot_id != "worker-2"),
+            "list_agents must not contain the removed slot_id"
+        );
+        assert!(
+            all.iter().any(|a| a.slot_id == "lead-1") && all.iter().any(|a| a.slot_id == "worker-1"),
+            "list_agents must retain every slot that was not removed"
+        );
+
+        assert!(
+            matches!(
+                mgr.get_agent("worker-2").await,
+                Err(TeamError::AgentNotFound(ref s)) if s == "worker-2"
+            ),
+            "get_agent on a removed slot must return AgentNotFound"
+        );
 
         let removed_events: Vec<_> = bc
             .events()
@@ -1331,6 +1347,30 @@ mod tests {
         assert!(
             mgr.finalized_turns.get(conv_id).is_none(),
             "finalized_turns must not retain the removed slot's conversation_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_agent_twice_second_call_is_noop_and_no_extra_broadcast() {
+        let agents = make_team_agents();
+        let (mgr, bc) = make_manager(&agents);
+
+        mgr.remove_agent("worker-2").await.unwrap();
+        let second = mgr.remove_agent("worker-2").await;
+        assert!(
+            matches!(second, Err(TeamError::AgentNotFound(ref s)) if s == "worker-2"),
+            "second remove of the same slot must fail with AgentNotFound"
+        );
+
+        let removed_events: Vec<_> = bc
+            .events()
+            .into_iter()
+            .filter(|e| e.name == "team.agent.removed")
+            .collect();
+        assert_eq!(
+            removed_events.len(),
+            1,
+            "failed second remove must not emit another team.agent.removed"
         );
     }
 


### PR DESCRIPTION
## Summary

W5-D30d-3 — `remove_agent` slots-remove + WS broadcast locked down with test strengthening (no functional change).

**Context:** On `origin/main` `0cf96d1` the `remove_agent` method already performed `slots.remove(slot_id)` and `broadcast_agent_removed` (landed before D30d). D30d-1 (#104) and D30d-2 (#105) subsequently added `task_manager.kill` at the session layer and `clear_agent_state` at the scheduler layer. This PR is the final D30d slice: lock down the slots-remove + WS-emit contract with test coverage.

## Changes

`crates/aionui-team/src/scheduler.rs` — three new assertions, zero production-code changes:

1. `remove_agent_broadcasts_removed_event` (existing test) extended so:
   - `list_agents` after remove must not contain the removed `slot_id` (precise match, not just `len` decrement).
   - `list_agents` still contains every other slot (`lead-1`, `worker-1`) — guards against bulk-remove regressions.
   - `get_agent(removed_slot)` returns `Err(TeamError::AgentNotFound)` with the right slot id payload.

2. `remove_agent_twice_second_call_is_noop_and_no_extra_broadcast` (new test):
   - Calling `remove_agent` twice on the same slot: second call returns `AgentNotFound`.
   - Only one `team.agent.removed` event is broadcast (the failed second call must not re-emit).

## Naming decision

Event name stays `team.agent.removed` (existing 3-segment kebab). `AGENTS.md` flags 3-segment names as legacy but allows them for existing events; renaming to `team.agentRemoved` would be a cross-crate contract change affecting the frontend and was explicitly out of scope (confirmed with team-lead: option A only).

## Test plan

- [x] `cargo test -p aionui-team --lib scheduler::tests::remove_` — 3 passed
- [x] `cargo test -p aionui-team --lib scheduler::tests` — 52 passed
- [x] `cargo clippy -p aionui-team --lib --tests --no-deps` — no new warnings (3 pre-existing on main: `EnvVariable`, 2× `mcp/server.rs` unused vars)
- [x] `cargo fmt --package aionui-team -- --check` — clean
- [ ] Note: `session::tests::mcp_stdio_config_for_agent` fails on `main` HEAD (TCP vs HTTP port) — unrelated pre-existing debt, see memory `project_main_clippy_debt_wave4.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)