### PR TITLE
feat(team): emit team.agent.shutdown on shutdown_approved (W5-D30a-2)

### DIFF
--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -116,8 +116,8 @@ pub use system::{
 pub use team::{
     AddAgentRequest, CreateTeamRequest, RenameAgentRequest, RenameTeamRequest, SendAgentMessageRequest,
     SendTeamMessageRequest, TeamAgentInput, TeamAgentRemovedPayload, TeamAgentRenamedPayload, TeamAgentResponse,
-    TeamAgentSpawnedPayload, TeamAgentStatusPayload, TeamListResponse, TeamMcpPhase, TeamMcpStatusPayload,
-    TeamResponse, TeammateMessagePayload,
+    TeamAgentShutdownPayload, TeamAgentSpawnedPayload, TeamAgentStatusPayload, TeamListResponse, TeamMcpPhase,
+    TeamMcpStatusPayload, TeamResponse, TeammateMessagePayload,
 };
 pub use team_mcp::TeamMcpStdioConfig;
 pub use websocket::WebSocketMessage;

--- a/crates/aionui-api-types/src/team.rs
+++ b/crates/aionui-api-types/src/team.rs
@@ -167,6 +167,19 @@ pub struct TeamAgentRenamedPayload {
     pub name: String,
 }
 
+/// Payload for `team.agent.shutdown` WebSocket event.
+///
+/// Pushed when a teammate acknowledges a Lead-initiated shutdown by
+/// replying `shutdown_approved`. The acknowledging teammate is identified
+/// by `slot_id`; `remove_agent` (and the accompanying
+/// `team.agent.removed` event) follows asynchronously once the agent
+/// process is actually killed and state is cleared.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TeamAgentShutdownPayload {
+    pub team_id: String,
+    pub slot_id: String,
+}
+
 /// Lifecycle phases of the per-team MCP stdio bridge + ACP session.
 ///
 /// Emitted by the MCP supervisor whenever a teammate slot transitions
@@ -641,6 +654,19 @@ mod tests {
         };
         let json = serde_json::to_string(&payload).unwrap();
         let parsed: TeamAgentRenamedPayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, payload);
+    }
+
+    #[test]
+    fn team_agent_shutdown_payload_roundtrip() {
+        let payload = TeamAgentShutdownPayload {
+            team_id: "t1".into(),
+            slot_id: "s2".into(),
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["team_id"], "t1");
+        assert_eq!(json["slot_id"], "s2");
+        let parsed: TeamAgentShutdownPayload = serde_json::from_value(json).unwrap();
         assert_eq!(parsed, payload);
     }
 

--- a/crates/aionui-team/src/events.rs
+++ b/crates/aionui-team/src/events.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use aionui_api_types::{
-    TeamAgentRemovedPayload, TeamAgentRenamedPayload, TeamAgentSpawnedPayload, TeamAgentStatusPayload, WebSocketMessage,
+    TeamAgentRemovedPayload, TeamAgentRenamedPayload, TeamAgentShutdownPayload, TeamAgentSpawnedPayload,
+    TeamAgentStatusPayload, WebSocketMessage,
 };
 use aionui_realtime::EventBroadcaster;
 
@@ -58,6 +59,22 @@ impl TeamEventEmitter {
         self.broadcaster.broadcast(event);
     }
 
+    /// Emit `team.agent.shutdown` to signal that the named teammate has
+    /// acknowledged a Lead-initiated shutdown request. The actual removal
+    /// (and `team.agent.removed`) follows once the agent process is killed
+    /// and scheduler state is cleared.
+    pub fn broadcast_agent_shutdown(&self, slot_id: &str) {
+        let payload = TeamAgentShutdownPayload {
+            team_id: self.team_id.clone(),
+            slot_id: slot_id.to_owned(),
+        };
+        let event = WebSocketMessage::new(
+            "team.agent.shutdown",
+            serde_json::to_value(payload).expect("serialize shutdown payload"),
+        );
+        self.broadcaster.broadcast(event);
+    }
+
     pub fn broadcast_agent_renamed(&self, slot_id: &str, name: &str) {
         let payload = TeamAgentRenamedPayload {
             team_id: self.team_id.clone(),
@@ -77,7 +94,8 @@ mod tests {
     use super::*;
     use crate::types::TeammateRole;
     use aionui_api_types::{
-        TeamAgentRemovedPayload, TeamAgentRenamedPayload, TeamAgentSpawnedPayload, TeamAgentStatusPayload,
+        TeamAgentRemovedPayload, TeamAgentRenamedPayload, TeamAgentShutdownPayload, TeamAgentSpawnedPayload,
+        TeamAgentStatusPayload,
     };
 
     struct RecordingBroadcaster {
@@ -163,6 +181,20 @@ mod tests {
         let payload: TeamAgentRemovedPayload = serde_json::from_value(events[0].data.clone()).unwrap();
         assert_eq!(payload.team_id, "team-1");
         assert_eq!(payload.slot_id, "slot-3");
+    }
+
+    #[test]
+    fn shutdown_event_has_correct_shape() {
+        let (emitter, bc) = make_emitter();
+        emitter.broadcast_agent_shutdown("slot-9");
+
+        let events = bc.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].name, "team.agent.shutdown");
+
+        let payload: TeamAgentShutdownPayload = serde_json::from_value(events[0].data.clone()).unwrap();
+        assert_eq!(payload.team_id, "team-1");
+        assert_eq!(payload.slot_id, "slot-9");
     }
 
     #[test]

--- a/crates/aionui-team/src/mcp/server.rs
+++ b/crates/aionui-team/src/mcp/server.rs
@@ -391,8 +391,8 @@ async fn exec_send_message(args: &Value, scheduler: &TeammateManager, caller_slo
 
     let trimmed = input.message.trim();
     if trimmed == "shutdown_approved" {
-        // W5-D30a-2 will wire the real approval handling; this stub intercepts the sentinel so it never reaches the recipient.
         debug!(from = caller_slot_id, "shutdown_approved intercepted");
+        scheduler.notify_shutdown_acknowledged(caller_slot_id);
         return Ok(json!({"status": "shutdown_approved_received"}).to_string());
     }
     if trimmed.starts_with("shutdown_rejected:") {

--- a/crates/aionui-team/src/scheduler.rs
+++ b/crates/aionui-team/src/scheduler.rs
@@ -454,6 +454,19 @@ impl TeammateManager {
         Ok(())
     }
 
+    /// Announce that a teammate has acknowledged a Lead-initiated shutdown
+    /// request (returned `shutdown_approved` via `team_send_message`).
+    ///
+    /// This is the first signal the frontend receives; actual removal
+    /// (process kill, state cleanup, `team.agent.removed`) is driven
+    /// separately by `remove_agent` once the orchestration layer decides to
+    /// tear the slot down. Broadcast is best-effort and does not mutate
+    /// scheduler state on its own.
+    pub fn notify_shutdown_acknowledged(&self, slot_id: &str) {
+        self.events.broadcast_agent_shutdown(slot_id);
+        debug!(team_id = %self.team_id, slot_id, "agent shutdown acknowledged");
+    }
+
     /// Clear all scheduler-side state associated with a removed agent.
     ///
     /// Drops three independent entries so nothing survives to affect the
@@ -1151,6 +1164,34 @@ mod tests {
             .collect();
         assert_eq!(removed_events.len(), 1);
         assert_eq!(removed_events[0].data["slot_id"], "worker-2");
+    }
+
+    #[tokio::test]
+    async fn notify_shutdown_acknowledged_broadcasts_shutdown_event() {
+        let agents = make_team_agents();
+        let (mgr, bc) = make_manager(&agents);
+
+        mgr.notify_shutdown_acknowledged("worker-2");
+
+        let shutdown_events: Vec<_> = bc
+            .events()
+            .into_iter()
+            .filter(|e| e.name == "team.agent.shutdown")
+            .collect();
+        assert_eq!(shutdown_events.len(), 1);
+        assert_eq!(shutdown_events[0].data["slot_id"], "worker-2");
+        assert_eq!(shutdown_events[0].data["team_id"], mgr.team_id);
+    }
+
+    #[tokio::test]
+    async fn notify_shutdown_acknowledged_does_not_remove_slot() {
+        let agents = make_team_agents();
+        let (mgr, _) = make_manager(&agents);
+        let before = mgr.list_agents().await.len();
+
+        mgr.notify_shutdown_acknowledged("worker-2");
+
+        assert_eq!(mgr.list_agents().await.len(), before);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- When a teammate returns `shutdown_approved` via `team_send_message`, emit a new `team.agent.shutdown` WebSocket event so the frontend can surface the acknowledgement before the slot is actually torn down.
- Add `TeamAgentShutdownPayload { team_id, slot_id }` to `aionui-api-types`, mirroring `TeamAgentRemovedPayload`.
- Add `TeamEventEmitter::broadcast_agent_shutdown` and a thin scheduler entry point `TeammateManager::notify_shutdown_acknowledged` to match the existing event emission pattern (`broadcast_agent_removed` / `notify_shutdown_acknowledged` is state-free; actual removal + `team.agent.removed` still comes later).

## Event contract

- Name: `team.agent.shutdown` (three-segment, consistent with `team.agent.removed` / `team.agent.spawned`).
- Payload: `{ team_id, slot_id }` where `slot_id` is the teammate that acknowledged shutdown (the `caller_slot_id` of the `team_send_message` call).

## Test plan

- [x] `cargo test -p aionui-api-types` passes (incl. new `team_agent_shutdown_payload_roundtrip`).
- [x] `cargo test -p aionui-team --lib -- scheduler::tests::notify_shutdown events::tests::shutdown` — all 3 new tests pass.
- [x] `cargo fmt -p aionui-api-types -p aionui-team -- --check` clean.
- [x] `cargo clippy -p aionui-api-types -- -D warnings` clean. (`aionui-team` still shows two pre-existing unused-variable warnings at `mcp/server.rs:568` and `:623` inside the HTTP MCP fallback loop — unchanged on this branch, tracked as existing debt.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)