### PR TITLE
feat(team): handle_aion_create_team handler (W5-D26b-2)

### DIFF
--- a/crates/aionui-team/src/guide/handlers.rs
+++ b/crates/aionui-team/src/guide/handlers.rs
@@ -1,4 +1,20 @@
-use serde_json::Value;
+use aionui_api_types::{CreateTeamRequest, TeamAgentInput, TeamResponse};
+use aionui_common::AppError;
+use serde_json::{Value, json};
+use tracing::info;
+
+use crate::service::TeamSessionService;
+
+/// User ID used when the Guide MCP spawns a team on behalf of a solo agent.
+/// Backend is single-tenant today; revisit when multi-tenant lands.
+const MCP_SPAWN_USER_ID: &str = "system_default_user";
+
+/// Default role string when the Guide spawns the lead agent.
+const LEAD_ROLE: &str = "lead";
+
+/// Default model passed to the lead agent when the caller does not specify;
+/// empty string defers to the backend's own default routing.
+const DEFAULT_LEAD_MODEL: &str = "";
 
 #[derive(Debug, Clone)]
 pub struct CreateTeamParams {
@@ -37,6 +53,83 @@ pub fn parse_create_team_args(args: &Value, caller_workspace: Option<&str>) -> R
         name,
         workspace,
     })
+}
+
+/// Build the `CreateTeamRequest` sent to `TeamSessionService::create_team`
+/// from parsed `aion_create_team` args.
+///
+/// The lead agent inherits the caller's backend and a default role of
+/// `"lead"`; `TeamSessionService::create_team` promotes the first agent in
+/// the vector to the team lead regardless of the `role` string value.
+///
+/// # TODO (W3-D15b)
+/// Once `TeamAgentInput::conversation_id` lands on this branch (PR #71),
+/// pass `Some(caller_conversation_id)` so the lead reuses the solo agent's
+/// existing conversation instead of spawning a fresh one. Until then,
+/// `caller_conversation_id` is accepted for signature stability and logged
+/// for traceability.
+pub fn build_create_team_request(params: &CreateTeamParams, backend: &str) -> CreateTeamRequest {
+    let lead = TeamAgentInput {
+        name: params.name.clone(),
+        role: LEAD_ROLE.to_owned(),
+        backend: backend.to_owned(),
+        model: DEFAULT_LEAD_MODEL.to_owned(),
+        custom_agent_id: None,
+    };
+    CreateTeamRequest {
+        name: params.name.clone(),
+        agents: vec![lead],
+    }
+}
+
+/// Shape the MCP tool response returned to the calling agent once the team
+/// has been persisted.
+///
+/// The `next_step` copy is lifted from the AionUi reference bridge so an
+/// upstream LLM seeing the result recognises that the frontend has already
+/// surfaced the new team and it should terminate its current turn rather
+/// than continue operating in the solo conversation.
+pub fn format_create_team_response(team: &TeamResponse) -> Value {
+    let lead_agent = team.agents.iter().find(|a| a.role == LEAD_ROLE);
+    json!({
+        "team_id": team.id,
+        "name": team.name,
+        "route": format!("/team/{}", team.id),
+        "lead_agent": lead_agent.map(|a| json!({
+            "slot_id": a.slot_id,
+            "name": a.name,
+            "conversation_id": a.conversation_id,
+        })),
+        "status": "team_created",
+        "next_step": "The team page has been opened automatically. End your turn now.",
+    })
+}
+
+/// MCP handler for the `aion_create_team` tool.
+///
+/// Parses args, constructs the service request, persists the team, and
+/// returns a structured JSON payload for the calling agent.
+pub async fn handle_aion_create_team(
+    service: &TeamSessionService,
+    args: &Value,
+    backend: &str,
+    caller_conversation_id: &str,
+) -> Result<Value, AppError> {
+    // Solo agents today only ever invoke the Guide with their own workspace
+    // in their conversation.extra; we do not yet propagate it through the
+    // bridge, so caller_workspace is `None` until W5-D27 lands.
+    let params = parse_create_team_args(args, None).map_err(AppError::BadRequest)?;
+
+    info!(
+        team_name = %params.name,
+        caller_conversation_id = %caller_conversation_id,
+        backend = %backend,
+        "aion_create_team invoked"
+    );
+
+    let req = build_create_team_request(&params, backend);
+    let team = service.create_team(MCP_SPAWN_USER_ID, req).await?;
+    Ok(format_create_team_response(&team))
 }
 
 #[cfg(test)]
@@ -123,5 +216,117 @@ mod tests {
         });
         let params = parse_create_team_args(&args, Some("/caller/ws")).unwrap();
         assert_eq!(params.workspace, "/caller/ws");
+    }
+
+    // -----------------------------------------------------------------------
+    // build_create_team_request
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_request_uses_parsed_name_for_team_and_lead() {
+        let params = CreateTeamParams {
+            summary: "draft the onboarding flow".into(),
+            name: "onboarding-flow".into(),
+            workspace: ".".into(),
+        };
+        let req = build_create_team_request(&params, "claude");
+        assert_eq!(req.name, "onboarding-flow");
+        assert_eq!(req.agents.len(), 1);
+        assert_eq!(req.agents[0].name, "onboarding-flow");
+    }
+
+    #[test]
+    fn build_request_lead_inherits_caller_backend() {
+        let params = CreateTeamParams {
+            summary: "x".into(),
+            name: "alpha".into(),
+            workspace: ".".into(),
+        };
+        let req = build_create_team_request(&params, "codex");
+        assert_eq!(req.agents[0].backend, "codex");
+        // The service promotes agents[0] to Lead regardless of the role
+        // string, but we still emit "lead" here for consistency with the
+        // REST contract and to make the intent obvious in persisted rows.
+        assert_eq!(req.agents[0].role, "lead");
+    }
+
+    #[test]
+    fn build_request_lead_has_no_custom_agent_id() {
+        let params = CreateTeamParams {
+            summary: "x".into(),
+            name: "alpha".into(),
+            workspace: ".".into(),
+        };
+        let req = build_create_team_request(&params, "claude");
+        assert!(req.agents[0].custom_agent_id.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // format_create_team_response
+    // -----------------------------------------------------------------------
+
+    fn sample_team_response(with_lead: bool) -> TeamResponse {
+        use aionui_api_types::TeamAgentResponse;
+        let mut agents = vec![];
+        if with_lead {
+            agents.push(TeamAgentResponse {
+                slot_id: "slot-lead".into(),
+                name: "alpha".into(),
+                role: "lead".into(),
+                conversation_id: "conv-lead".into(),
+                backend: "claude".into(),
+                model: "".into(),
+                custom_agent_id: None,
+                status: None,
+            });
+        }
+        TeamResponse {
+            id: "team-123".into(),
+            name: "alpha".into(),
+            agents,
+            lead_agent_id: if with_lead { Some("slot-lead".into()) } else { None },
+            created_at: 1_700_000_000_000,
+            updated_at: 1_700_000_000_000,
+        }
+    }
+
+    #[test]
+    fn response_carries_team_id_name_route_and_status() {
+        let team = sample_team_response(true);
+        let out = format_create_team_response(&team);
+        assert_eq!(out["team_id"], "team-123");
+        assert_eq!(out["name"], "alpha");
+        assert_eq!(out["route"], "/team/team-123");
+        assert_eq!(out["status"], "team_created");
+    }
+
+    #[test]
+    fn response_next_step_instructs_agent_to_end_turn() {
+        let team = sample_team_response(true);
+        let out = format_create_team_response(&team);
+        let next = out["next_step"].as_str().unwrap_or_default();
+        assert!(
+            next.contains("End your turn"),
+            "next_step must steer the calling agent to stop; got: {next}"
+        );
+    }
+
+    #[test]
+    fn response_lead_agent_echoes_service_assigned_slot() {
+        let team = sample_team_response(true);
+        let out = format_create_team_response(&team);
+        assert_eq!(out["lead_agent"]["slot_id"], "slot-lead");
+        assert_eq!(out["lead_agent"]["conversation_id"], "conv-lead");
+        assert_eq!(out["lead_agent"]["name"], "alpha");
+    }
+
+    #[test]
+    fn response_lead_agent_is_null_when_service_returns_no_agents() {
+        // Defensive: should never happen because create_team rejects empty
+        // agent lists, but lock the shape so callers receive an explicit
+        // null rather than a field-missing shape drift.
+        let team = sample_team_response(false);
+        let out = format_create_team_response(&team);
+        assert!(out["lead_agent"].is_null());
     }
 }

--- a/crates/aionui-team/src/guide/mod.rs
+++ b/crates/aionui-team/src/guide/mod.rs
@@ -2,4 +2,7 @@
 pub mod capability;
 pub mod handlers;
 
-pub use handlers::{CreateTeamParams, parse_create_team_args};
+pub use handlers::{
+    CreateTeamParams, build_create_team_request, format_create_team_response, handle_aion_create_team,
+    parse_create_team_args,
+};


### PR DESCRIPTION
## Summary

Implements `handle_aion_create_team` in `aionui-team/src/guide/handlers.rs` per [interface-contracts.md §27.2.1](../blob/feat/team-wave4-5/docs/teams/phase1/interface-contracts.md#272-handle_aion_create_team) and [modules.md §W5-D26b-2](../blob/feat/team-wave4-5/docs/teams/phase1/modules.md).

- `handle_aion_create_team(service, args, backend, caller_conversation_id)` — parses args with D26b-1's `parse_create_team_args`, builds a single-lead `CreateTeamRequest`, calls `service.create_team(MCP_SPAWN_USER_ID, req)`, and returns the agreed JSON shape (`team_id`, `name`, `route`, `lead_agent`, `status`, `next_step`).
- `build_create_team_request` / `format_create_team_response` extracted as pure helpers so the request construction and response shaping are unit-testable.
- `MCP_SPAWN_USER_ID = "system_default_user"` + lead role copy lifted from AionUi reference (`getCreateTeamToolDescription()`).

## Stacked on D26b-1

Base is `w5-d26b1/create-team-args` (PR #100). PR target is `feat/team-wave4-5` per task.

## Known gap (explicitly deferred)

Caller conversation reuse (W3-D15b) needs `TeamAgentInput.conversation_id: Option<String>`. PR #71 added that field to `api-types` on `feat/team-wave4-5`, **but the D26b-1 stack base does not include #71**. The handler accepts `caller_conversation_id` and logs it via `tracing::info`; the field-level wire-up is a TODO that lights up naturally when this branch rebases on wave4-5 tip. This path matches the in-flight W5 slicing pattern (see mnemo `wave45_missing_w3d14a`).

## Test plan

7 new unit tests in `guide::handlers::tests`:
- `build_request_uses_parsed_name_for_team_and_lead`
- `build_request_lead_inherits_caller_backend`
- `build_request_lead_has_no_custom_agent_id`
- `response_carries_team_id_name_route_and_status`
- `response_next_step_instructs_agent_to_end_turn` — locks the end-your-turn copy so the calling LLM stops driving the solo conversation.
- `response_lead_agent_echoes_service_assigned_slot`
- `response_lead_agent_is_null_when_service_returns_no_agents`

- [x] `cargo fmt -p aionui-team -- --check` clean
- [x] `cargo build -p aionui-team` clean (pre-existing `mcp/server.rs` `unused_variables` warnings documented in mnemo `main_clippy_debt_wave4`; not caused by this PR — verified by running clippy on untouched base)
- [x] `cargo test -p aionui-team --lib guide::` — 23 passed including 7 new

Orchestrator-level test (`handle_aion_create_team` end-to-end) is deferred to an integration suite because `TeamSessionService::create_team` auto-calls `ensure_session`, which fails on this base (mnemo `ensure_session_baseline_break`). D26d's WS event integration test or the D26 e2e smoke will cover the orchestrator seam once the baseline session path is working again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)