### PR TITLE
test(team): ratify spawn_agent WS emit ordering (W5-D29d-1)

### DIFF
--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -523,6 +523,29 @@ mod tests {
         fn broadcast(&self, _msg: WebSocketMessage<serde_json::Value>) {}
     }
 
+    /// RecordingBroadcaster used by the D29d-1 ratification test below to
+    /// assert that `team.agent.spawned` is *not* emitted on failed spawns.
+    #[derive(Default)]
+    struct RecordingBroadcaster {
+        events: Mutex<Vec<WebSocketMessage<serde_json::Value>>>,
+    }
+
+    impl RecordingBroadcaster {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn names(&self) -> Vec<String> {
+            self.events.lock().unwrap().iter().map(|e| e.name.clone()).collect()
+        }
+    }
+
+    impl EventBroadcaster for RecordingBroadcaster {
+        fn broadcast(&self, msg: WebSocketMessage<serde_json::Value>) {
+            self.events.lock().unwrap().push(msg);
+        }
+    }
+
     fn backend_path() -> Arc<PathBuf> {
         Arc::new(PathBuf::from("/tmp/aionui-backend-test"))
     }
@@ -1223,6 +1246,26 @@ mod tests {
         .unwrap()
     }
 
+    async fn start_session_with_recorder(backend: &str) -> (TeamSession, Arc<RecordingBroadcaster>) {
+        let mut team = make_team();
+        team.agents[0].backend = backend.to_string();
+        let repo: Arc<dyn ITeamRepository> = Arc::new(MockTeamRepo::new());
+        let recorder = Arc::new(RecordingBroadcaster::new());
+        let broadcaster: Arc<dyn EventBroadcaster> = recorder.clone();
+        let session = TeamSession::start(
+            team,
+            repo,
+            broadcaster,
+            backend_path(),
+            empty_task_manager(),
+            "user-test".into(),
+            Weak::<TeamSessionService>::new(),
+        )
+        .await
+        .unwrap();
+        (session, recorder)
+    }
+
     fn spawn_req(agent_type: Option<&str>) -> SpawnAgentRequest {
         SpawnAgentRequest {
             name: "Helper".into(),
@@ -1352,6 +1395,49 @@ mod tests {
         assert!(
             matches!(&err, TeamError::InvalidRequest(msg) if msg.contains("empty")),
             "expected InvalidRequest about empty name, got {err:?}"
+        );
+        session.stop();
+    }
+
+    // -- W5-D29d-1 ratification: spawn emit-order contract ------------------
+    //
+    // The success-path emission of `team.agent.spawned` is exercised by
+    // `scheduler::tests::add_agent_broadcasts_spawned_event` — `spawn_agent`
+    // reaches that emission via `scheduler.add_agent(&new_agent)` after
+    // `persist_spawned_agent` returns. This ratification test locks the
+    // *ordering* half of the contract: the event must NOT be published
+    // before the DB step succeeds. If a future refactor hoists broadcast
+    // above the persist/add_agent boundary (so the frontend sees a spawned
+    // agent that never persisted), this test regresses.
+
+    #[tokio::test]
+    async fn spawn_agent_does_not_emit_before_db_step() {
+        let (session, recorder) = start_session_with_recorder("claude").await;
+        let err = session
+            .spawn_agent("lead-1", spawn_req(Some("claude")))
+            .await
+            .expect_err("unit test has no service wire; spawn stops at DB step");
+        assert_reached_db_step(err);
+        assert!(
+            !recorder.names().iter().any(|n| n == "team.agent.spawned"),
+            "team.agent.spawned must not be emitted when spawn fails before add_agent; saw {:?}",
+            recorder.names()
+        );
+        session.stop();
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_does_not_emit_on_guard_rejection() {
+        let (session, recorder) = start_session_with_recorder("claude").await;
+        let err = session
+            .spawn_agent("worker-1", spawn_req(Some("claude")))
+            .await
+            .expect_err("non-lead caller must be rejected");
+        assert!(matches!(&err, TeamError::LeaderOnly(what) if what == "spawn_agent"));
+        assert!(
+            !recorder.names().iter().any(|n| n == "team.agent.spawned"),
+            "team.agent.spawned must not be emitted when guard rejects the caller; saw {:?}",
+            recorder.names()
         );
         session.stop();
     }


### PR DESCRIPTION
## Summary

\`team.agent.spawned\` is already emitted end-to-end today: \`TeamSession::spawn_agent\` calls \`scheduler.add_agent(&new_agent)\` after \`persist_spawned_agent\` returns, and \`Scheduler::add_agent\` broadcasts the event (landed alongside W5-D29b in #121). The success-path emission is covered by \`scheduler::tests::add_agent_broadcasts_spawned_event\` plus \`events::tests::spawned_event_has_correct_shape\` / \`prompts_events_integration::we2_agent_spawned_event\`.

What was missing: a test locking the **ordering** half of the contract. This PR adds two negative-path tests on \`TeamSession::spawn_agent\`:

- \`spawn_agent_does_not_emit_before_db_step\` — when validation passes but the DB step is unreachable (no \`TeamSessionService\` wire in unit tests), no \`team.agent.spawned\` may be published.
- \`spawn_agent_does_not_emit_on_guard_rejection\` — when the non-lead caller guard rejects the request, no \`team.agent.spawned\` may be published.

If a future refactor hoists broadcast above the persist/add_agent boundary (so the frontend sees a spawned agent that never persisted), these tests regress.

Payload shape follows \`frontend-guide.md\` §WS Events: \`{ team_id, agent: TeamAgentResponse }\` — the richer \`agent\` object was already in \`TeamAgentSpawnedPayload\` (api-types).

## Test plan

- [x] \`cargo fmt -p aionui-team -p aionui-api-types -- --check\` clean
- [x] \`cargo clippy -p aionui-team --lib\` — only pre-existing \`mcp/server.rs\` \`unused_variables\` warnings (memory: \`project_main_clippy_debt_wave4.md\`), nothing new
- [x] \`cargo test -p aionui-team --lib spawn_agent\` — 15 pass (13 pre-existing + 2 new)
- [x] \`cargo test -p aionui-team --lib\` — 295 pass, 1 pre-existing flake \`mcp_stdio_config_for_agent\` (noted in PR #121 body; unrelated)

## Out of scope

- Exposing a \`spawn_agent\` entrypoint on \`TeamSessionService\` so \`session_service_integration\` can lock the full-wire success path end-to-end — belongs to W5-D29e.
- \`cargo clippy -p aionui-team -- -D warnings\` fails on 2 pre-existing lib warnings in \`mcp/server.rs\`; fixing that is unrelated baseline debt.