### PR TITLE
feat(ai-agent): add sort_order to agent catalog

### DIFF
--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -1139,6 +1139,7 @@ mod tests {
             native_skills_dirs: None,
             behavior_policy: BehaviorPolicy::default(),
             yolo_id: yolo_id.map(ToOwned::to_owned),
+            sort_order: 3130,
             handshake: AgentHandshake::default(),
         }
     }

--- a/crates/aionui-ai-agent/src/agent_registry.rs
+++ b/crates/aionui-ai-agent/src/agent_registry.rs
@@ -172,7 +172,8 @@ impl AgentRegistry {
     }
 
     /// Every enabled, installed row whose `agent_type` matches,
-    /// sorted by id. See [`Self::list_all`] for the filter semantics.
+    /// sorted by `sort_order`. See [`Self::list_all`] for the filter
+    /// semantics.
     pub async fn list_by_agent_type(&self, agent_type: AgentType) -> Vec<AgentMetadata> {
         let guard = self.by_id.read().await;
         let mut rows: Vec<AgentMetadata> = guard
@@ -180,7 +181,7 @@ impl AgentRegistry {
             .filter(|m| m.agent_type == agent_type && is_visible(m))
             .cloned()
             .collect();
-        rows.sort_by(|a, b| a.id.cmp(&b.id));
+        rows.sort_by(|a, b| a.sort_order.cmp(&b.sort_order).then_with(|| a.name.cmp(&b.name)));
         rows
     }
 
@@ -191,13 +192,16 @@ impl AgentRegistry {
     /// would otherwise render unusable vendor chips that fail the
     /// moment the user tries to spawn them.
     pub async fn list_all(&self) -> Vec<AgentMetadata> {
-        self.by_id
+        let mut rows: Vec<AgentMetadata> = self
+            .by_id
             .read()
             .await
             .values()
             .filter(|m| is_visible(m))
             .cloned()
-            .collect()
+            .collect();
+        rows.sort_by(|a, b| a.sort_order.cmp(&b.sort_order).then_with(|| a.name.cmp(&b.name)));
+        rows
     }
 
     /// Unfiltered snapshot — used by internal paths that legitimately
@@ -205,7 +209,9 @@ impl AgentRegistry {
     /// "manage agents" surface). Keep external API handlers on
     /// [`Self::list_all`].
     pub async fn list_all_including_hidden(&self) -> Vec<AgentMetadata> {
-        self.by_id.read().await.values().cloned().collect()
+        let mut rows: Vec<AgentMetadata> = self.by_id.read().await.values().cloned().collect();
+        rows.sort_by(|a, b| a.sort_order.cmp(&b.sort_order).then_with(|| a.name.cmp(&b.name)));
+        rows
     }
 }
 
@@ -259,6 +265,7 @@ fn decode_row(row: AgentMetadataRow) -> Option<AgentMetadata> {
         native_skills_dirs,
         behavior_policy,
         yolo_id: row.yolo_id,
+        sort_order: row.sort_order,
         handshake,
     };
 
@@ -456,6 +463,7 @@ mod tests {
         let count = |t: AgentType| all.iter().filter(|m| m.agent_type == t).count();
         assert_eq!(count(AgentType::Acp), 17);
         assert_eq!(count(AgentType::Nanobot), 1);
+        assert_eq!(count(AgentType::OpenclawGateway), 1);
         assert_eq!(count(AgentType::Aionrs), 1);
     }
 

--- a/crates/aionui-api-types/src/agent_discovery.rs
+++ b/crates/aionui-api-types/src/agent_discovery.rs
@@ -147,6 +147,10 @@ pub struct AgentMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub yolo_id: Option<String>,
 
+    /// Display ordering key — smaller values appear first. The range
+    /// scheme is documented in `007_agent_metadata_sort_order.sql`.
+    pub sort_order: i64,
+
     #[serde(default)]
     pub handshake: AgentHandshake,
 }
@@ -193,6 +197,7 @@ mod tests {
             native_skills_dirs: None,
             behavior_policy: BehaviorPolicy::default(),
             yolo_id: None,
+            sort_order: 3100,
             handshake: AgentHandshake::default(),
         };
         let v = serde_json::to_value(&meta).unwrap();
@@ -214,6 +219,7 @@ mod tests {
             "agent_source": "custom",
             "enabled": true,
             "available": false,
+            "sort_order": 1100,
         });
         let meta: AgentMetadata = serde_json::from_value(payload).unwrap();
         assert_eq!(meta.agent_type, AgentType::Acp);

--- a/crates/aionui-db/migrations/006_agent_metadata.sql
+++ b/crates/aionui-db/migrations/006_agent_metadata.sql
@@ -1,8 +1,8 @@
 -- Agent metadata catalog.
 --
 -- Replaces the static `AcpBackend` enum and becomes the single source of
--- truth for how each agent is spawned. Seeds the 17 ACP vendors plus the
--- three non-ACP built-ins (nanobot, openclaw-gateway, aionrs).
+-- truth for how each agent is spawned. Seeds the 17 ACP vendors, two
+-- non-ACP builtins (nanobot, openclaw-gateway), and one internal (aionrs).
 --
 -- Row semantics:
 --   command             Program-name form that the adapter resolves via `which()`
@@ -260,7 +260,7 @@ VALUES
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000);
 
--- ── Seed: non-ACP internals (agent_source='internal') ────────────────
+-- ── Seed: non-ACP builtins + internal ─────────────────────────────────
 
 INSERT OR IGNORE INTO agent_metadata
     (id, icon, name, name_i18n, description, description_i18n,
@@ -271,7 +271,7 @@ INSERT OR IGNORE INTO agent_metadata
      created_at, updated_at)
 VALUES
     ('fb1083a5', NULL, 'Nanobot', NULL, NULL, NULL,
-     NULL, 'nanobot', 'internal',
+     NULL, 'nanobot', 'builtin',
      '{"binary_name":"nanobot"}',
      1, 'nanobot', '["--experimental-acp"]', '[]',
      NULL,
@@ -281,7 +281,7 @@ VALUES
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 
     ('f9f61666', NULL, 'OpenClaw Gateway', NULL, NULL, NULL,
-     NULL, 'openclaw-gateway', 'internal',
+     NULL, 'openclaw-gateway', 'builtin',
      '{"binary_name":"openclaw"}',
      1, 'openclaw', '[]', '[]',
      NULL,

--- a/crates/aionui-db/migrations/007_agent_metadata_sort_order.sql
+++ b/crates/aionui-db/migrations/007_agent_metadata_sort_order.sql
@@ -1,0 +1,40 @@
+-- Add sort_order column to agent_metadata for deterministic display ordering.
+--
+-- The value is a plain integer: smaller = higher in the list. The scheme
+-- reserves ranges by agent_source so future custom / extension rows slot
+-- in naturally:
+--
+--   100–199   internal   (aionrs = 100)
+--   1000–1999 custom     (future)
+--   2000–2999 extension  (future)
+--   3000–3999 builtin    (ACP vendors, openclaw, nanobot)
+--
+-- Within builtin ACP, backend priority:
+--   claude = 3100, codex = 3110, gemini = 3120, others = 3130
+-- Special non-ACP builtins:
+--   openclaw = 3900, nanobot = 3990
+
+ALTER TABLE agent_metadata ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 1000;
+
+-- ── Backfill sort_order for seed rows ────────────────────────────────
+
+-- internal: aionrs
+UPDATE agent_metadata SET sort_order = 100 WHERE agent_type = 'aionrs' AND agent_source = 'internal';
+
+-- builtin ACP: claude highest, then codex, gemini, rest
+UPDATE agent_metadata SET sort_order = 3100 WHERE agent_source = 'builtin' AND agent_type = 'acp' AND backend = 'claude';
+UPDATE agent_metadata SET sort_order = 3110 WHERE agent_source = 'builtin' AND agent_type = 'acp' AND backend = 'codex';
+UPDATE agent_metadata SET sort_order = 3120 WHERE agent_source = 'builtin' AND agent_type = 'acp' AND backend = 'gemini';
+UPDATE agent_metadata SET sort_order = 3130 WHERE agent_source = 'builtin' AND agent_type = 'acp' AND backend NOT IN ('claude', 'codex', 'gemini');
+
+-- ── Fix agent_source for openclaw and nanobot ────────────────────────
+-- These were incorrectly seeded as 'internal'; they should be 'builtin'.
+
+UPDATE agent_metadata SET agent_source = 'builtin' WHERE agent_type = 'openclaw-gateway';
+UPDATE agent_metadata SET agent_source = 'builtin' WHERE agent_type = 'nanobot';
+
+-- Now assign their sort_order (after source correction).
+UPDATE agent_metadata SET sort_order = 3900 WHERE agent_type = 'openclaw-gateway' AND agent_source = 'builtin';
+UPDATE agent_metadata SET sort_order = 3990 WHERE agent_type = 'nanobot' AND agent_source = 'builtin';
+
+CREATE INDEX IF NOT EXISTS idx_agent_metadata_sort_order ON agent_metadata(sort_order);

--- a/crates/aionui-db/src/models/agent_metadata.rs
+++ b/crates/aionui-db/src/models/agent_metadata.rs
@@ -44,6 +44,10 @@ pub struct AgentMetadataRow {
     pub available_models: Option<String>,
     pub available_commands: Option<String>,
 
+    /// Display ordering key — smaller values appear first. See the
+    /// `007_agent_metadata_sort_order` migration for the range scheme.
+    pub sort_order: i64,
+
     pub created_at: TimestampMs,
     pub updated_at: TimestampMs,
 }
@@ -77,6 +81,7 @@ pub struct UpsertAgentMetadataParams<'a> {
     pub available_modes: Option<&'a str>,
     pub available_models: Option<&'a str>,
     pub available_commands: Option<&'a str>,
+    pub sort_order: i64,
 }
 
 /// Partial update applied after an ACP initialize/authenticate handshake.

--- a/crates/aionui-db/src/repository/sqlite_agent_metadata.rs
+++ b/crates/aionui-db/src/repository/sqlite_agent_metadata.rs
@@ -22,7 +22,7 @@ impl SqliteAgentMetadataRepository {
 impl IAgentMetadataRepository for SqliteAgentMetadataRepository {
     async fn list_all(&self) -> Result<Vec<AgentMetadataRow>, DbError> {
         let rows =
-            sqlx::query_as::<_, AgentMetadataRow>("SELECT * FROM agent_metadata ORDER BY created_at ASC, id ASC")
+            sqlx::query_as::<_, AgentMetadataRow>("SELECT * FROM agent_metadata ORDER BY sort_order ASC, name ASC")
                 .fetch_all(&self.pool)
                 .await?;
         Ok(rows)
@@ -54,7 +54,7 @@ impl IAgentMetadataRepository for SqliteAgentMetadataRepository {
         let row = sqlx::query_as::<_, AgentMetadataRow>(
             "SELECT * FROM agent_metadata \
              WHERE agent_source = 'builtin' AND backend = ? \
-             ORDER BY created_at ASC, id ASC LIMIT 1",
+             ORDER BY sort_order ASC, name ASC LIMIT 1",
         )
         .bind(backend)
         .fetch_optional(&self.pool)
@@ -73,8 +73,8 @@ impl IAgentMetadataRepository for SqliteAgentMetadataRepository {
                  behavior_policy, yolo_id, \
                  agent_capabilities, auth_methods, config_options, \
                  available_modes, available_models, available_commands, \
-                 created_at, updated_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+                 sort_order, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
              ON CONFLICT(id) DO UPDATE SET \
                 icon = excluded.icon, \
                 name = excluded.name, \
@@ -98,6 +98,7 @@ impl IAgentMetadataRepository for SqliteAgentMetadataRepository {
                 available_modes = excluded.available_modes, \
                 available_models = excluded.available_models, \
                 available_commands = excluded.available_commands, \
+                sort_order = excluded.sort_order, \
                 updated_at = excluded.updated_at",
         )
         .bind(params.id)
@@ -123,6 +124,7 @@ impl IAgentMetadataRepository for SqliteAgentMetadataRepository {
         .bind(params.available_modes)
         .bind(params.available_models)
         .bind(params.available_commands)
+        .bind(params.sort_order)
         .bind(now)
         .bind(now)
         .execute(&self.pool)
@@ -245,6 +247,7 @@ mod tests {
             available_modes: None,
             available_models: None,
             available_commands: None,
+            sort_order: 1100,
         }
     }
 
@@ -252,12 +255,18 @@ mod tests {
     async fn seed_rows_populated_after_migrations() {
         let (repo, _db) = setup().await;
         let rows = repo.list_all().await.unwrap();
-        // 17 ACP vendors + 3 internal agents = 20.
+        // 17 ACP vendors + 2 non-ACP builtins + 1 internal = 20.
         assert_eq!(rows.len(), 20);
         assert!(rows.iter().any(|r| r.name == "Claude" && r.agent_source == "builtin"));
         assert!(
             rows.iter()
                 .any(|r| r.name == "Aion CLI" && r.agent_source == "internal")
+        );
+        // Nanobot and OpenClaw are builtin (not internal).
+        assert!(rows.iter().any(|r| r.name == "Nanobot" && r.agent_source == "builtin"));
+        assert!(
+            rows.iter()
+                .any(|r| r.name == "OpenClaw Gateway" && r.agent_source == "builtin")
         );
     }
 


### PR DESCRIPTION
## Summary
- Add `sort_order` column to `agent_metadata` with a ranged scheme (internal / custom / extension / builtin) so display ordering survives seed re-runs and future extension rows slot in naturally
- Reclassify `nanobot` and `openclaw-gateway` from `internal` to `builtin`; `internal` is reserved for `aionrs`
- Sort `AgentRegistry` listings by `sort_order` then `name` instead of id/insertion order

## Test plan
- [x] `cargo test -p aionui-db`
- [x] `cargo test -p aionui-ai-agent`
- [x] `cargo test -p aionui-api-types`
- [ ] Manual: confirm Claude / Codex / Gemini appear first in the agent picker, followed by other ACP vendors, then OpenClaw and Nanobot