### PR TITLE
fix(ai-agent): channel conversations hang with CodeBuddy due to missing yolo_id

### DIFF
--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -685,7 +685,13 @@ impl AcpAgentManager {
                 session_id: sid.clone(),
             }));
 
-        self.apply_preferred_mode(&sid).await?;
+        if let Err(e) = self.apply_preferred_mode(&sid).await {
+            tracing::warn!(
+                conversation_id = %self.conversation_id,
+                error = %e,
+                "failed to apply preferred mode, continuing with default"
+            );
+        }
         self.apply_preferred_config_selections(&sid).await;
 
         // Inject first-message prefix (preset context + skills index).

--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -686,7 +686,7 @@ impl AcpAgentManager {
             }));
 
         if let Err(e) = self.apply_preferred_mode(&sid).await {
-            tracing::warn!(
+            tracing::error!(
                 conversation_id = %self.conversation_id,
                 error = %e,
                 "failed to apply preferred mode, continuing with default"

--- a/crates/aionui-db/migrations/006_agent_metadata.sql
+++ b/crates/aionui-db/migrations/006_agent_metadata.sql
@@ -136,7 +136,7 @@ VALUES
      '[]',
      '[".codebuddy/skills"]',
      '{"supports_side_question":false}',
-     NULL,
+     'bypassPermissions',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 


### PR DESCRIPTION
## Summary

- CodeBuddy channel 对话（Telegram 等）卡在 "Thinking..." 永远无响应
- 根因：CodeBuddy 的 `yolo_id` 为 NULL，channel 发送 `session/set_mode("yolo")` 被 backend 拒绝，错误通过 `?` 中断了整个 `session_new_and_prompt`，`session/prompt` 从未发送
- 修复：seed data 添加 `yolo_id = 'bypassPermissions'`；将 `apply_preferred_mode` 失败降级为 warn 而非硬错误

## Changes

- `crates/aionui-db/migrations/006_agent_metadata.sql` — CodeBuddy seed row 设置 `yolo_id = 'bypassPermissions'`
- `crates/aionui-ai-agent/src/acp_agent.rs` — `apply_preferred_mode` 错误不再中断消息投递，改为 warn 日志

## Test plan

- [ ] 已有实例需手动 `UPDATE agent_metadata SET yolo_id = 'bypassPermissions' WHERE id = '8b20fd41';`
- [ ] 通过 Telegram channel 向 CodeBuddy agent 发送消息，验证回复正常
- [ ] 验证单聊 CodeBuddy 仍正常工作
- [ ] `cargo clippy -p aionui-ai-agent -- -D warnings` 通过