### PR TITLE
feat(ai-agent): populate yolo_id for third-party agents + smart build cache

### DIFF
--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -1195,7 +1195,7 @@ mod tests {
         // Cursor → agent.
         let cursor_like = metadata_with_yolo_id(Some("agent"));
         assert_eq!(normalize_requested_mode(&cursor_like, "yolo"), "agent");
-        // Gemini / Qwen / … have no yolo equivalent; alias flows through.
+        // When a row has no yolo_id the alias flows through unchanged.
         let gemini_like = metadata_with_yolo_id(None);
         assert_eq!(normalize_requested_mode(&gemini_like, "yolo"), "yolo");
     }

--- a/crates/aionui-db/migrations/006_agent_metadata.sql
+++ b/crates/aionui-db/migrations/006_agent_metadata.sql
@@ -113,7 +113,7 @@ VALUES
      1, 'gemini', '["--experimental-acp"]', '[]',
      '[".gemini/skills"]',
      '{"supports_side_question":false}',
-     NULL,
+     'yolo',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 
@@ -123,7 +123,7 @@ VALUES
      1, 'qwen', '["--acp"]', '[]',
      '[".qwen/skills"]',
      '{"supports_side_question":false}',
-     NULL,
+     'yolo',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 
@@ -146,7 +146,7 @@ VALUES
      1, 'droid', '["exec","--output-format","acp"]', '[]',
      '[".factory/skills"]',
      '{"supports_side_question":false}',
-     NULL,
+     'yolo',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 
@@ -156,7 +156,7 @@ VALUES
      1, 'goose', '["acp"]', '[]',
      '[".goose/skills"]',
      '{"supports_side_question":false}',
-     NULL,
+     'yolo',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 
@@ -166,7 +166,7 @@ VALUES
      1, 'auggie', '["--acp"]', '[]',
      NULL,
      '{"supports_side_question":false}',
-     NULL,
+     'yolo',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 
@@ -176,7 +176,7 @@ VALUES
      1, 'kimi', '["acp"]', '[]',
      '[".kimi/skills"]',
      '{"supports_side_question":false}',
-     NULL,
+     'yolo',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 
@@ -186,7 +186,7 @@ VALUES
      1, 'opencode', '["acp"]', '[]',
      '[".opencode/skills"]',
      '{"supports_side_question":false}',
-     NULL,
+     'build',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 
@@ -196,7 +196,7 @@ VALUES
      1, 'copilot', '["--acp","--stdio"]', '[]',
      NULL,
      '{"supports_side_question":false}',
-     NULL,
+     'yolo',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 
@@ -206,7 +206,7 @@ VALUES
      1, 'qoder', '["--acp"]', '[]',
      NULL,
      '{"supports_side_question":false}',
-     NULL,
+     'yolo',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 
@@ -216,7 +216,7 @@ VALUES
      1, 'vibe', '[]', '[]',
      '[".vibe/skills"]',
      '{"supports_side_question":false}',
-     NULL,
+     'yolo',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 
@@ -226,7 +226,7 @@ VALUES
      1, 'cursor', '["acp"]', '[]',
      '[".cursor/skills"]',
      '{"supports_side_question":false}',
-     NULL,
+     'agent',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 
@@ -236,7 +236,7 @@ VALUES
      1, 'kiro', '["acp"]', '[]',
      NULL,
      '{"supports_side_question":false}',
-     NULL,
+     'yolo',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 
@@ -246,7 +246,7 @@ VALUES
      1, 'hermes', '["acp"]', '[]',
      NULL,
      '{"supports_side_question":false}',
-     NULL,
+     'yolo',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 
@@ -256,7 +256,7 @@ VALUES
      1, 'snow', '["--acp"]', '[]',
      NULL,
      '{"supports_side_question":false}',
-     NULL,
+     'yolo',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000);
 
@@ -276,7 +276,7 @@ VALUES
      1, 'nanobot', '["--experimental-acp"]', '[]',
      NULL,
      '{}',
-     NULL,
+     'yolo',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 
@@ -286,7 +286,7 @@ VALUES
      1, 'openclaw', '[]', '[]',
      NULL,
      '{}',
-     NULL,
+     'yolo',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000),
 
@@ -296,6 +296,6 @@ VALUES
      1, NULL, '[]', '[]',
      '[".aionrs/skills"]',
      '{}',
-     NULL,
+     'yolo',
      NULL, NULL, NULL, NULL, NULL, NULL,
      unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000);

--- a/justfile
+++ b/justfile
@@ -3,14 +3,54 @@ default:
     @just --list
 
 # Build in release mode and install to ~/.cargo/bin
-build: lint fmt
+# Use `just build --force` to skip cache check
+build *FLAGS: lint fmt
+    #!/usr/bin/env bash
+    set -euo pipefail
     cargo build --release
-    cp target/release/aionui-backend ~/.cargo/bin/
-    codesign --force --sign - ~/.cargo/bin/aionui-backend
+    new_sum=$(shasum -a 256 target/release/aionui-backend | cut -d' ' -f1)
+    force=false
+    for flag in {{FLAGS}}; do
+        if [[ "$flag" == "--force" || "$flag" == "-f" ]]; then
+            force=true
+        fi
+    done
+    old_sum=""
+    if [[ -f target/.build-sum ]] && [[ "$force" == "false" ]]; then
+        old_sum=$(cat target/.build-sum)
+    fi
+    if [[ "$new_sum" == "$old_sum" ]]; then
+        echo -e "\n⏭️  Binary unchanged — skipping install (sha256: ${new_sum:0:16}…)"
+    else
+        cp target/release/aionui-backend ~/.cargo/bin/
+        codesign --force --sign - ~/.cargo/bin/aionui-backend
+        echo "$new_sum" > target/.build-sum
+        echo -e "\n✅ Build complete — sha256: ${new_sum:0:16}…"
+    fi
 
 # Build in debug mode
-build-debug:
+# Use `just build-debug --force` to skip cache check
+build-debug *FLAGS:
+    #!/usr/bin/env bash
+    set -euo pipefail
     cargo build
+    new_sum=$(shasum -a 256 target/debug/aionui-backend | cut -d' ' -f1)
+    force=false
+    for flag in {{FLAGS}}; do
+        if [[ "$flag" == "--force" || "$flag" == "-f" ]]; then
+            force=true
+        fi
+    done
+    old_sum=""
+    if [[ -f target/.build-debug-sum ]] && [[ "$force" == "false" ]]; then
+        old_sum=$(cat target/.build-debug-sum)
+    fi
+    if [[ "$new_sum" == "$old_sum" ]]; then
+        echo -e "\n⏭️  Debug binary unchanged (sha256: ${new_sum:0:16}…)"
+    else
+        echo "$new_sum" > target/.build-debug-sum
+        echo -e "\n✅ Debug build complete — sha256: ${new_sum:0:16}…"
+    fi
 
 # Run all tests
 test:


### PR DESCRIPTION
## Summary

- 为所有第三方 agent 填充 `yolo_id` 字段，建立模式别名映射关系
- 更新测试注释，更准确描述 `yolo_id` 的语义
- 为 `just build` 和 `just build-debug` 添加基于 SHA256 的智能缓存，避免不必要的 install/codesign 操作

## Changes

### Agent Metadata (006_agent_metadata.sql)
- **Gemini, Qwen, Droid, Goose, Auggie, Kimi, Copilot, Qoder, Vibe, Kiro, Hermes, Snow, Nanobot, OpenClaw, AionRS**: `yolo_id` → `"yolo"`
- **Cursor**: `yolo_id` → `"agent"`
- **CodeBuddy**: `yolo_id` → `"bypassPermissions"`
- **OpenCode**: `yolo_id` → `"build"`

这些映射使得用户在使用模式别名（如 `yolo`）时，能够正确路由到对应 agent 的实际模式。

### Test Comment (acp_agent.rs)
更新注释从 "Gemini / Qwen / … have no yolo equivalent" 改为 "When a row has no yolo_id the alias flows through unchanged"，更准确描述了 fallback 行为。

### Justfile
为 `build` 和 `build-debug` recipe 添加 SHA256 缓存检查：
- 构建后计算二进制文件的 SHA256 hash
- 与上次构建的 hash 比对
- 仅在 hash 变化时执行 `cp` + `codesign`
- 支持 `--force` / `-f` 强制跳过缓存

## Test plan

- [x] `cargo test -p aionui-ai-agent` 通过
- [x] `cargo test -p aionui-db` 通过
- [x] 验证 `just build` 在二进制未变化时跳过 install
- [x] 验证 `just build --force` 强制执行 install

🤖 Generated with [Claude Code](https://claude.com/claude-code)