### PR TITLE
fix(backend-migration): handle symlinked skill directories

### DIFF
--- a/crates/aionui-ai-agent/src/auxiliary_routes.rs
+++ b/crates/aionui-ai-agent/src/auxiliary_routes.rs
@@ -4,6 +4,7 @@ use axum::Router;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{Extension, Json, Path, Query, State};
 use axum::routing::{get, post};
+use std::path::Component;
 
 use crate::acp_agent::AcpAgentManager;
 use crate::agent_manager::AgentManagerHandle;
@@ -92,28 +93,42 @@ async fn browse_workspace(
         return Err(AppError::BadRequest("Conversation has no workspace assigned".into()));
     }
 
+    let relative_path = query.path.trim_start_matches('/');
+    let relative_path_obj = std::path::Path::new(relative_path);
+    if relative_path_obj
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(AppError::BadRequest(
+            "Path traversal outside workspace is not allowed".into(),
+        ));
+    }
+
     // Resolve the browsed path relative to the workspace root
     let base = std::path::Path::new(&workspace);
-    let browse_path = base.join(query.path.trim_start_matches('/'));
+    let browse_path = if relative_path.is_empty() {
+        base.to_path_buf()
+    } else {
+        base.join(relative_path_obj)
+    };
 
-    // Security: ensure the resolved path is within the workspace
+    // Security: reject direct traversal outside the workspace root, but allow
+    // symlinked directories mounted inside the workspace (e.g. native skill
+    // dirs that point at the builtin skills corpus under data-dir).
     let canonical_base = base
         .canonicalize()
         .map_err(|e| AppError::Internal(format!("Failed to resolve workspace path: {e}")))?;
     let canonical_browse = browse_path
         .canonicalize()
         .map_err(|_| AppError::NotFound("Directory not found".into()))?;
-    if !canonical_browse.starts_with(&canonical_base) {
+    if !browse_path.starts_with(base) && !canonical_browse.starts_with(&canonical_base) {
         return Err(AppError::BadRequest(
             "Path traversal outside workspace is not allowed".into(),
         ));
     }
 
     // Check depth limit
-    let relative = canonical_browse
-        .strip_prefix(&canonical_base)
-        .unwrap_or(&canonical_browse);
-    let depth = relative.components().count();
+    let depth = relative_path_obj.components().count();
     if depth > MAX_DIR_DEPTH {
         return Err(AppError::BadRequest(format!(
             "Directory depth exceeds maximum of {MAX_DIR_DEPTH}"
@@ -136,12 +151,12 @@ async fn browse_workspace(
             continue;
         }
 
-        let file_type = entry
-            .file_type()
+        let entry_path = entry.path();
+        let metadata = tokio::fs::metadata(&entry_path)
             .await
-            .map_err(|e| AppError::Internal(format!("Failed to read file type: {e}")))?;
+            .map_err(|e| AppError::Internal(format!("Failed to read entry metadata: {e}")))?;
 
-        let entry_type = if file_type.is_dir() { "directory" } else { "file" };
+        let entry_type = if metadata.is_dir() { "directory" } else { "file" };
 
         entries.push(WorkspaceEntry {
             name,

--- a/crates/aionui-app/tests/auxiliary_e2e.rs
+++ b/crates/aionui-app/tests/auxiliary_e2e.rs
@@ -81,7 +81,7 @@ async fn workspace_browse_requires_auth() {
         .uri("/api/conversations/test-conv/workspace?path=/src")
         .body(axum::body::Body::empty())
         .unwrap();
-    let resp = app.oneshot(req).await.unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
@@ -99,7 +99,7 @@ async fn workspace_browse_no_active_task() {
     let conv_id = create_conversation_with_workspace(&mut app, &token, &csrf, "Test Conv", "acp", &ws).await;
 
     let req = get_with_token(&format!("/api/conversations/{conv_id}/workspace?path=/src"), &token);
-    let resp = app.oneshot(req).await.unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
     // Workspace comes from DB; no active agent required.
     assert_eq!(resp.status(), StatusCode::OK);
     let json = body_json(resp).await;
@@ -128,6 +128,57 @@ async fn workspace_browse_empty_path() {
     let resp = app.oneshot(req).await.unwrap();
     // Empty path should return 400 (validated before agent lookup)
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn workspace_browse_treats_symlinked_skill_dir_as_directory() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "user1", "pass123").await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace = tmp.path().join("workspace");
+    let builtin = tmp.path().join("builtin-skills/auto-inject/aionui-skills");
+    std::fs::create_dir_all(workspace.join(".claude/skills")).unwrap();
+    std::fs::create_dir_all(&builtin).unwrap();
+    std::fs::write(builtin.join("SKILL.md"), b"---\ndescription: test\n---\nbody").unwrap();
+    std::os::unix::fs::symlink(&builtin, workspace.join(".claude/skills/aionui-skills")).unwrap();
+
+    let ws = workspace.to_string_lossy().into_owned();
+    let conv_id = create_conversation_with_workspace(&mut app, &token, &csrf, "Test Conv", "acp", &ws).await;
+
+    let req = get_with_token(
+        &format!("/api/conversations/{conv_id}/workspace?path=/.claude/skills"),
+        &token,
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let json = body_json(resp).await;
+    let entries = json["data"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry["name"] == "aionui-skills" && entry["type"] == "directory"),
+        "symlinked skill dir should stay visible as directory: {entries:?}"
+    );
+
+    let req = get_with_token(
+        &format!("/api/conversations/{conv_id}/workspace?path=/.claude/skills/aionui-skills"),
+        &token,
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let json = body_json(resp).await;
+    let entries = json["data"].as_array().unwrap();
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry["name"] == "SKILL.md" && entry["type"] == "file"),
+        "symlinked skill dir should remain browsable: {entries:?}"
+    );
 }
 
 // ── 9.2 Side question ───────────────────────────────────────────

--- a/crates/aionui-app/tests/common/mod.rs
+++ b/crates/aionui-app/tests/common/mod.rs
@@ -73,14 +73,11 @@ pub async fn build_app_with_noop_opener() -> (axum::Router, AppServices) {
     (router, services)
 }
 
-pub async fn build_app_with_file_roots(
-    allowed_roots: Vec<std::path::PathBuf>,
-) -> (axum::Router, AppServices) {
+pub async fn build_app_with_file_roots(allowed_roots: Vec<std::path::PathBuf>) -> (axum::Router, AppServices) {
     let db = aionui_db::init_database_memory().await.unwrap();
     let services = AppServices::from_database(db).await.unwrap();
     let (mut states, _) = build_module_states(&services).await;
-    states.file.file_service =
-        std::sync::Arc::new(FileService::new(services.event_bus.clone(), allowed_roots));
+    states.file.file_service = std::sync::Arc::new(FileService::new(services.event_bus.clone(), allowed_roots));
     let router = create_router_with_states(&services, states);
     (router, services)
 }

--- a/crates/aionui-file/src/service.rs
+++ b/crates/aionui-file/src/service.rs
@@ -13,9 +13,7 @@ use aionui_api_types::WebSocketMessage;
 use aionui_common::AppError;
 use aionui_realtime::EventBroadcaster;
 
-use crate::path_safety::{
-    has_traversal, validate_path, validate_path_for_write, validate_path_with_extra_root,
-};
+use crate::path_safety::{has_traversal, validate_path, validate_path_for_write, validate_path_with_extra_root};
 use crate::types::{
     ContentUpdateEvent, ContentUpdateOperation, CopyResult, DirOrFile, FileMetadata, WorkspaceFlatFile, ZipEntry,
 };
@@ -230,12 +228,20 @@ fn list_workspace_files_sync(root: &Path) -> Result<Vec<WorkspaceFlatFile>, AppE
             }
         };
 
-        // Skip directories — only include files
-        if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(true) {
+        let path = entry.path();
+        let metadata = match std::fs::metadata(path) {
+            Ok(metadata) => metadata,
+            Err(e) => {
+                warn!(path = %path.display(), error = %e, "skipping unreadable workspace entry");
+                continue;
+            }
+        };
+
+        // Skip real directories and symlinks that resolve to directories.
+        if metadata.is_dir() {
             continue;
         }
 
-        let path = entry.path();
         let name = path
             .file_name()
             .map(|n| n.to_string_lossy().into_owned())
@@ -280,6 +286,13 @@ fn validate_file_for_read(path: &Path) -> Result<Option<()>, AppError> {
             "file '{}' exceeds 256 MB limit ({} bytes)",
             path.display(),
             metadata.len()
+        )));
+    }
+
+    if metadata.is_dir() {
+        return Err(AppError::BadRequest(format!(
+            "path '{}' is a directory; expected a file",
+            path.display()
         )));
     }
 
@@ -578,11 +591,7 @@ impl crate::traits::IFileService for FileService {
         Ok(files)
     }
 
-    async fn get_file_metadata(
-        &self,
-        path: &str,
-        extra_root: Option<&Path>,
-    ) -> Result<FileMetadata, AppError> {
+    async fn get_file_metadata(&self, path: &str, extra_root: Option<&Path>) -> Result<FileMetadata, AppError> {
         let roots = self.allowed_roots_refs();
         let canonical = validate_path_with_extra_root(path, &roots, extra_root)?;
 
@@ -595,11 +604,7 @@ impl crate::traits::IFileService for FileService {
 
     // -- File read/write (task 7.4) --
 
-    async fn read_file(
-        &self,
-        path: &str,
-        extra_root: Option<&Path>,
-    ) -> Result<Option<String>, AppError> {
+    async fn read_file(&self, path: &str, extra_root: Option<&Path>) -> Result<Option<String>, AppError> {
         if has_traversal(path) {
             return Err(AppError::BadRequest(format!(
                 "path '{}' contains invalid traversal patterns",
@@ -612,14 +617,11 @@ impl crate::traits::IFileService for FileService {
             Ok(c) => c,
             Err(err) => {
                 if matches!(err, AppError::BadRequest(_))
-                    && validate_path_for_write(path, &self.allowed_roots_with_extra(extra_root))
-                        .is_ok()
+                    && validate_path_for_write(path, &self.allowed_roots_with_extra(extra_root)).is_ok()
                 {
                     return Ok(None);
                 }
-                if matches!(err, AppError::BadRequest(_))
-                    && self.path_uses_allowed_root(Path::new(path), extra_root)
-                {
+                if matches!(err, AppError::BadRequest(_)) && self.path_uses_allowed_root(Path::new(path), extra_root) {
                     return Ok(None);
                 }
                 return Err(err);
@@ -631,11 +633,7 @@ impl crate::traits::IFileService for FileService {
             .map_err(|e| AppError::Internal(format!("read file task failed: {e}")))?
     }
 
-    async fn read_file_buffer(
-        &self,
-        path: &str,
-        extra_root: Option<&Path>,
-    ) -> Result<Option<Vec<u8>>, AppError> {
+    async fn read_file_buffer(&self, path: &str, extra_root: Option<&Path>) -> Result<Option<Vec<u8>>, AppError> {
         if has_traversal(path) {
             return Err(AppError::BadRequest(format!(
                 "path '{}' contains invalid traversal patterns",
@@ -648,14 +646,11 @@ impl crate::traits::IFileService for FileService {
             Ok(c) => c,
             Err(err) => {
                 if matches!(err, AppError::BadRequest(_))
-                    && validate_path_for_write(path, &self.allowed_roots_with_extra(extra_root))
-                        .is_ok()
+                    && validate_path_for_write(path, &self.allowed_roots_with_extra(extra_root)).is_ok()
                 {
                     return Ok(None);
                 }
-                if matches!(err, AppError::BadRequest(_))
-                    && self.path_uses_allowed_root(Path::new(path), extra_root)
-                {
+                if matches!(err, AppError::BadRequest(_)) && self.path_uses_allowed_root(Path::new(path), extra_root) {
                     return Ok(None);
                 }
                 return Err(err);
@@ -872,11 +867,7 @@ impl crate::traits::IFileService for FileService {
         .map_err(|e| AppError::Internal(format!("create temp file task failed: {e}")))?
     }
 
-    async fn get_image_base64(
-        &self,
-        path: &str,
-        extra_root: Option<&Path>,
-    ) -> Result<String, AppError> {
+    async fn get_image_base64(&self, path: &str, extra_root: Option<&Path>) -> Result<String, AppError> {
         if has_traversal(path) {
             return Err(AppError::BadRequest(format!(
                 "path '{}' contains invalid traversal patterns",
@@ -1123,6 +1114,26 @@ mod tests {
         assert_eq!(main_file.relative_path, "src/main.rs");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn list_workspace_files_sync_skips_directory_symlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("builtin-skills/auto-inject/aionui-skills");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(skill_dir.join("SKILL.md"), "---\ndescription: test\n---\nbody").unwrap();
+
+        let workspace = dir.path().join("workspace/.claude/skills");
+        fs::create_dir_all(&workspace).unwrap();
+        std::os::unix::fs::symlink(&skill_dir, workspace.join("aionui-skills")).unwrap();
+
+        let files = list_workspace_files_sync(&dir.path().join("workspace")).unwrap();
+
+        assert!(
+            files.iter().all(|f| f.name != "aionui-skills"),
+            "directory symlink should not be surfaced as a file: {files:?}"
+        );
+    }
+
     #[test]
     fn get_file_metadata_sync_text_file() {
         let dir = tempfile::tempdir().unwrap();
@@ -1218,6 +1229,17 @@ mod tests {
 
         let result = read_file_sync(&fake).unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn read_file_sync_rejects_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let folder = dir.path().join("subdir");
+        fs::create_dir(&folder).unwrap();
+
+        let err = read_file_sync(&folder).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+        assert!(err.to_string().contains("is a directory"));
     }
 
     // -- validate_file_for_read tests --

--- a/crates/aionui-file/tests/directory_browsing.rs
+++ b/crates/aionui-file/tests/directory_browsing.rs
@@ -230,6 +230,30 @@ async fn list_workspace_files_relative_paths() {
     assert_eq!(helper.relative_path, "src/utils/helper.ts");
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn list_workspace_files_skips_directory_symlinks() {
+    let dir = tempfile::tempdir().unwrap();
+    let skill_dir = dir.path().join("builtin-skills/auto-inject/aionui-skills");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), "---\ndescription: test\n---\nbody").unwrap();
+
+    let workspace_skills_dir = dir.path().join("workspace/.claude/skills");
+    fs::create_dir_all(&workspace_skills_dir).unwrap();
+    std::os::unix::fs::symlink(&skill_dir, workspace_skills_dir.join("aionui-skills")).unwrap();
+
+    let svc = make_service(dir.path().join("workspace").as_path());
+    let files = svc
+        .list_workspace_files(dir.path().join("workspace").to_str().unwrap())
+        .await
+        .unwrap();
+
+    assert!(
+        files.iter().all(|file| file.name != "aionui-skills"),
+        "directory symlink should not be surfaced as a file: {files:?}"
+    );
+}
+
 // -----------------------------------------------------------------------
 // getFileMetadata
 // -----------------------------------------------------------------------
@@ -241,10 +265,7 @@ async fn get_file_metadata_text_file() {
     fs::write(&file, "hello world").unwrap();
 
     let svc = make_service(dir.path());
-    let meta = svc
-        .get_file_metadata(file.to_str().unwrap(), None)
-        .await
-        .unwrap();
+    let meta = svc.get_file_metadata(file.to_str().unwrap(), None).await.unwrap();
 
     assert_eq!(meta.name, "hello.txt");
     assert_eq!(meta.size, 11);
@@ -260,10 +281,7 @@ async fn get_file_metadata_image() {
     fs::write(&png, [0x89, 0x50, 0x4E, 0x47]).unwrap();
 
     let svc = make_service(dir.path());
-    let meta = svc
-        .get_file_metadata(png.to_str().unwrap(), None)
-        .await
-        .unwrap();
+    let meta = svc.get_file_metadata(png.to_str().unwrap(), None).await.unwrap();
 
     assert_eq!(meta.mime_type, "image/png");
 }
@@ -275,10 +293,7 @@ async fn get_file_metadata_directory() {
     fs::create_dir(&sub).unwrap();
 
     let svc = make_service(dir.path());
-    let meta = svc
-        .get_file_metadata(sub.to_str().unwrap(), None)
-        .await
-        .unwrap();
+    let meta = svc.get_file_metadata(sub.to_str().unwrap(), None).await.unwrap();
 
     assert!(meta.is_directory);
     assert_eq!(meta.mime_type, "inode/directory");
@@ -316,10 +331,7 @@ async fn get_file_metadata_json_file() {
     fs::write(&file, r#"{"key":"value"}"#).unwrap();
 
     let svc = make_service(dir.path());
-    let meta = svc
-        .get_file_metadata(file.to_str().unwrap(), None)
-        .await
-        .unwrap();
+    let meta = svc.get_file_metadata(file.to_str().unwrap(), None).await.unwrap();
 
     assert_eq!(meta.mime_type, "application/json");
 }

--- a/crates/aionui-file/tests/file_read_write.rs
+++ b/crates/aionui-file/tests/file_read_write.rs
@@ -153,10 +153,7 @@ async fn read_file_rejects_outside_sandbox_without_workspace() {
     fs::write(&file, "secret").unwrap();
 
     let svc = make_service(sandbox.path());
-    let err = svc
-        .read_file(file.to_str().unwrap(), None)
-        .await
-        .unwrap_err();
+    let err = svc.read_file(file.to_str().unwrap(), None).await.unwrap_err();
 
     assert!(matches!(err, aionui_common::AppError::Forbidden(_)));
     assert_eq!(err.error_code(), "PATH_OUTSIDE_SANDBOX");
@@ -168,12 +165,22 @@ async fn read_file_returns_none_for_missing_file_in_sandbox() {
     let missing = sandbox.path().join("missing.txt");
 
     let svc = make_service(sandbox.path());
-    let result = svc
-        .read_file(missing.to_str().unwrap(), None)
-        .await
-        .unwrap();
+    let result = svc.read_file(missing.to_str().unwrap(), None).await.unwrap();
 
     assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn read_file_rejects_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let folder = dir.path().join("aionui-skills");
+    fs::create_dir(&folder).unwrap();
+
+    let svc = make_service(dir.path());
+    let err = svc.read_file(folder.to_str().unwrap(), None).await.unwrap_err();
+
+    assert!(matches!(err, aionui_common::AppError::BadRequest(_)));
+    assert!(err.to_string().contains("is a directory"));
 }
 
 #[tokio::test]
@@ -220,10 +227,7 @@ async fn read_file_buffer_normal() {
     fs::write(&file, &data).unwrap();
 
     let svc = make_service(dir.path());
-    let result = svc
-        .read_file_buffer(file.to_str().unwrap(), None)
-        .await
-        .unwrap();
+    let result = svc.read_file_buffer(file.to_str().unwrap(), None).await.unwrap();
 
     assert_eq!(result.as_deref(), Some(data.as_slice()));
 }
@@ -234,10 +238,7 @@ async fn read_file_buffer_nonexistent_returns_none() {
     let fake = dir.path().join("missing.bin");
 
     let svc = make_service(dir.path());
-    let result = svc
-        .read_file_buffer(fake.to_str().unwrap(), None)
-        .await
-        .unwrap();
+    let result = svc.read_file_buffer(fake.to_str().unwrap(), None).await.unwrap();
 
     assert!(result.is_none());
 }
@@ -428,10 +429,7 @@ async fn read_buffer_after_write_roundtrip() {
 
     svc.write_file(file.to_str().unwrap(), &data, ws).await.unwrap();
 
-    let read_result = svc
-        .read_file_buffer(file.to_str().unwrap(), None)
-        .await
-        .unwrap();
+    let read_result = svc.read_file_buffer(file.to_str().unwrap(), None).await.unwrap();
     assert_eq!(read_result.as_deref(), Some(data.as_slice()));
 }
 


### PR DESCRIPTION
## Summary
- keep symlinked skill directories browsable in conversation workspace trees
- hide directory symlinks from flat workspace file listings so they are not treated as files
- return a clear bad-request error when file read APIs receive a directory path

## Verification
- cargo test -p aionui-file
- cargo test -p aionui-app --test auxiliary_e2e

## Notes
- follow-up after #125 merged to main
- addresses symlinked skill directory handling in preview/workspace flows
