### PR TITLE
fix(conversation): send thinking_done before terminal event in stream relay

### DIFF
--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -81,8 +81,6 @@ impl StreamRelay {
         loop {
             match rx.recv().await {
                 Ok(event) => {
-                    self.forward_to_websocket(&event);
-
                     match &event {
                         AgentStreamEvent::Thinking(data) => {
                             has_thinking = true;
@@ -92,8 +90,10 @@ impl StreamRelay {
                                 }
                                 thinking_buffer.push_str(&data.content);
                             }
+                            self.forward_to_websocket(&event);
                         }
                         AgentStreamEvent::Text(data) => {
+                            self.forward_to_websocket(&event);
                             text_buffer.push_str(&data.content);
                             flush_counter += 1;
                             if flush_counter >= FLUSH_INTERVAL {
@@ -115,9 +115,14 @@ impl StreamRelay {
                                 text_len = text_buffer.len(),
                                 "StreamRelay received terminal event"
                             );
+                            // Send thinking_done BEFORE the terminal event so the
+                            // frontend receives it while still in "running" state.
+                            // Otherwise the thinking_done arriving after finish
+                            // re-activates the processing indicator.
                             if has_thinking {
                                 self.send_thinking_done();
                             }
+                            self.forward_to_websocket(&event);
                             self.persist_thinking(&thinking_buffer, thinking_started_at).await;
                             let outcome = self.finalize(&text_buffer, &record_created, &event).await;
                             if self.complete_turn {
@@ -125,7 +130,9 @@ impl StreamRelay {
                             }
                             break outcome;
                         }
-                        _ => {}
+                        _ => {
+                            self.forward_to_websocket(&event);
+                        }
                     }
                 }
                 Err(broadcast::error::RecvError::Closed) => {


### PR DESCRIPTION
## Summary

- Fix the "正在处理中" (processing) indicator getting stuck after AI response completes when using models with thinking support (e.g. deepseek-v4-flash) through aionrs
- Root cause: `send_thinking_done()` was called AFTER `forward_to_websocket(Finish)`, so the frontend received finish → set `streamRunning=false`, then received thinking_done → re-activated `streamRunning=true` with no subsequent event to clear it
- Reorder event emission: thinking_done is now sent before the terminal event, ensuring correct state transitions on the frontend

## Test plan

- [ ] Start a conversation using deepseek model via aionrs
- [ ] Send a message and wait for response to complete
- [ ] Verify "正在处理中" indicator disappears after response finishes
- [ ] Test with other thinking-capable models (Claude with extended thinking)
- [ ] Test non-thinking models still work correctly (no regression)
- [ ] Verify `cargo test -p aionui-conversation` passes