### PR TITLE
fix(channel): enable lark and dingtalk plugins

### DIFF
--- a/crates/aionui-app/Cargo.toml
+++ b/crates/aionui-app/Cargo.toml
@@ -8,7 +8,10 @@ name = "aionui-backend"
 path = "src/main.rs"
 
 [features]
-default = ["weixin"]
+default = ["telegram", "lark", "dingtalk", "weixin"]
+telegram = ["aionui-channel/telegram"]
+lark = ["aionui-channel/lark"]
+dingtalk = ["aionui-channel/dingtalk"]
 weixin = ["aionui-channel/weixin"]
 
 [dependencies]

--- a/crates/aionui-channel/Cargo.toml
+++ b/crates/aionui-channel/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [features]
-default = ["telegram"]
+default = []
 telegram = ["dep:reqwest"]
 lark = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures-util"]
 dingtalk = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures-util"]


### PR DESCRIPTION
## Summary

- Lark "测试并连接" 报错 `Invalid plugin type: No implementation for lark`，原因是 lark/dingtalk 的 feature flag 从未在 aionui-app 中转发，导致插件代码未编译进二进制
- 将所有插件 feature 选择统一到 aionui-app（Composition 层），aionui-channel 的 default 设为空，符合 AGENTS.md 的分层架构规范

## Test plan

- [x] `cargo check -p aionui-app` 编译通过
- [x] `cargo test -p aionui-channel --all-features` 15 个测试全部通过
- [ ] 启动后端，在设置页面配置 Lark app id/secret，点击"测试并连接"验证不再报错