### PR TITLE
refactor(ai-agent): ACP concurrency + single-flight task builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,7 @@ dependencies = [
  "async-trait",
  "axum",
  "dashmap",
+ "futures-util",
  "regex",
  "serde",
  "serde_json",

--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -239,8 +239,19 @@ struct AcpState {
     status: Option<ConversationStatus>,
     /// Active session ID (set after session/new or session/load).
     session_id: Option<String>,
-    /// Whether this session has sent at least one message.
-    has_messages: bool,
+    /// Whether **this `AcpAgentManager` instance** has opened the session with
+    /// the CLI — either through `session/new` (first turn) or through
+    /// `session/load` / claude-meta-resume (recovering a persisted id). Once
+    /// set, subsequent turns in the same process go through the short-path
+    /// `prompt_existing_session` instead of re-loading.
+    ///
+    /// This is NOT the same as "the conversation has prior messages in the
+    /// DB" — a task rebuild (idle cleanup, crash recovery, etc.) starts
+    /// with `session_opened = false` even when a persisted `session_id`
+    /// has already been restored, because the CLI child process is brand
+    /// new and still needs the load/resume handshake on its very first
+    /// prompt after rebuild.
+    session_opened: bool,
 }
 
 /// Serialize an external value (typically an ACP SDK struct that emits
@@ -622,7 +633,7 @@ impl AcpAgentManager {
             state: RwLock::new(AcpState {
                 status: None,
                 session_id: None,
-                has_messages: false,
+                session_opened: false,
             }),
             last_activity: AtomicI64::new(now_ms()),
             session_lock: Mutex::new(()),
@@ -725,28 +736,44 @@ impl AcpAgentManager {
     }
 
     /// Initialize or resume a session, then send the user message.
+    ///
+    /// Three paths:
+    /// 1. **No session_id at all** → `session/new` + first prompt.
+    /// 2. **Have session_id but this instance has not yet opened it with the
+    ///    CLI** → `session/load` (or claude-meta-resume) + prompt. This
+    ///    happens on the first turn after a task rebuild or after
+    ///    `restore_session_id` seeded the id from the DB.
+    /// 3. **Session already opened by this instance** → plain `prompt`. No
+    ///    `session/load` — the CLI child process still owns the session in
+    ///    memory, re-loading every turn would both waste a round-trip and
+    ///    (on some backends) reset config options.
     async fn ensure_session_and_send(&self, data: &SendMessageData) -> Result<(), AppError> {
         let _lock = self.session_lock.lock().await;
 
         let state = self.state.read().await;
-        let has_session = state.session_id.is_some();
         let session_id = state.session_id.clone();
-        let has_messages = state.has_messages;
+        let session_opened = state.session_opened;
         drop(state);
 
-        if !has_session && !has_messages {
-            // First message — create new session then prompt
-            self.session_new_and_prompt(data).await?;
-        } else if has_session && has_messages {
-            // Existing session — resume strategy depends on backend
-            self.session_resume_and_send(data, session_id.as_deref()).await?;
-        } else {
-            // Session exists but no previous messages — just prompt
-            self.prompt_existing_session(data, session_id.as_deref()).await?;
+        match (session_id.as_deref(), session_opened) {
+            (None, _) => {
+                // Path 1: first turn in a brand-new conversation.
+                self.session_new_and_prompt(data).await?;
+            }
+            (Some(sid), false) => {
+                // Path 2: we have a persisted id but this process has not
+                // opened it with the CLI yet. Needs backend-appropriate
+                // resume handshake before the prompt.
+                self.session_resume_and_send(data, Some(sid)).await?;
+            }
+            (Some(sid), true) => {
+                // Path 3: session is live with the CLI; just prompt.
+                self.prompt_existing_session(data, Some(sid)).await?;
+            }
         }
 
         let mut state = self.state.write().await;
-        state.has_messages = true;
+        state.session_opened = true;
         state.status = Some(ConversationStatus::Running);
 
         Ok(())
@@ -1068,10 +1095,15 @@ impl AcpAgentManager {
 
     /// Restore a previously persisted session_id (e.g. from DB on task rebuild).
     /// Enables resume path on next send_message instead of creating a fresh session.
+    ///
+    /// Deliberately leaves `session_opened = false`: the CLI child process is
+    /// brand new and still needs `session/load` (or claude-meta-resume) to
+    /// re-attach to the persisted session before the next prompt. Subsequent
+    /// turns — once the resume handshake has run — take the short path.
     pub async fn restore_session_id(&self, sid: String) {
         let mut state = self.state.write().await;
         state.session_id = Some(sid);
-        state.has_messages = true;
+        state.session_opened = false;
     }
 
     /// Vendor label this session was spawned as (e.g. "claude"), if any.

--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -13,13 +13,13 @@ use crate::stream_event::{
 use crate::team_guide_prompt;
 use crate::types::{AcpBuildExtra, AgentStreamChunk, SendMessageData, SlashCommandItem};
 use agent_client_protocol::schema::{
-    AgentCapabilities, AvailableCommand, CancelNotification, ContentBlock, EnvVariable,
-    LoadSessionRequest, McpServer, McpServerStdio, NewSessionRequest, PromptRequest,
-    SessionConfigKind, SessionConfigOption, SessionId, SessionModeState, SessionModelState,
-    SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest, UsageUpdate,
+    AgentCapabilities, AvailableCommand, CancelNotification, ContentBlock, EnvVariable, LoadSessionRequest, McpServer,
+    McpServerStdio, NewSessionRequest, PromptRequest, SessionConfigKind, SessionConfigOption, SessionId,
+    SessionModeState, SessionModelState, SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest,
+    UsageUpdate,
 };
-use aionui_api_types::{GuideMcpConfig, TeamMcpStdioConfig};
 use aionui_api_types::{AgentHandshake, AgentMetadata};
+use aionui_api_types::{GuideMcpConfig, TeamMcpStdioConfig};
 use aionui_common::{
     AgentKillReason, AgentType, AppError, CommandSpec, Confirmation, ConversationStatus, TimestampMs,
     normalize_keys_to_snake_case, now_ms,
@@ -190,7 +190,10 @@ fn build_new_session_request(workspace: &str, config: &AcpBuildExtra) -> NewSess
     }
     // Solo: inject Guide MCP stdio server for team-capable backends
     if let Some(guide_cfg) = config.guide_mcp_config.as_ref()
-        && config.backend.as_deref().map_or(false, |b| TEAM_CAPABLE_BACKENDS.contains(&b))
+        && config
+            .backend
+            .as_deref()
+            .is_some_and(|b| TEAM_CAPABLE_BACKENDS.contains(&b))
     {
         return req.mcp_servers(vec![guide_mcp_server(guide_cfg, config)]);
     }
@@ -222,10 +225,7 @@ fn guide_mcp_server(cfg: &GuideMcpConfig, extra: &AcpBuildExtra) -> McpServer {
     let env = vec![
         EnvVariable::new("AION_MCP_PORT".to_owned(), cfg.port.to_string()),
         EnvVariable::new("AION_MCP_TOKEN".to_owned(), cfg.token.clone()),
-        EnvVariable::new(
-            "AION_MCP_BACKEND".to_owned(),
-            extra.backend.clone().unwrap_or_default(),
-        ),
+        EnvVariable::new("AION_MCP_BACKEND".to_owned(), extra.backend.clone().unwrap_or_default()),
     ];
     let stdio = McpServerStdio::new("aionui-team-guide", &cfg.binary_path)
         .args(vec!["mcp-guide-stdio".to_owned()])

--- a/crates/aionui-ai-agent/src/acp_agent_service.rs
+++ b/crates/aionui-ai-agent/src/acp_agent_service.rs
@@ -200,10 +200,10 @@ impl AcpAgentService {
                 acp.preload_snapshot(state).await;
             }
             // Restore session_id from DB so resume path works after restart
-            if let Ok(Some(row)) = self.repo.get(&conversation_id).await {
-                if let Some(sid) = row.session_id {
-                    acp.restore_session_id(sid).await;
-                }
+            if let Ok(Some(row)) = self.repo.get(&conversation_id).await
+                && let Some(sid) = row.session_id
+            {
+                acp.restore_session_id(sid).await;
             }
         }
 

--- a/crates/aionui-ai-agent/src/acp_protocol.rs
+++ b/crates/aionui-ai-agent/src/acp_protocol.rs
@@ -1,12 +1,26 @@
 //! ACP protocol layer: SDK integration for JSON-RPC communication.
 //!
 //! This module owns the `agent-client-protocol` SDK connection. It provides
-//! typed async methods for all ACP operations and routes incoming agent
-//! notifications/requests to the appropriate channels.
+//! typed async methods for all ACP operations (wrappers around the SDK's
+//! `send_request` / `send_notification`) plus dedicated handlers for the
+//! notifications and permission requests the CLI sends back.
 //!
-//! All requests are dispatched through a command channel to the SDK event loop
-//! running inside `connect_with`. This is required because `block_task()` only
-//! works within the `connect_with` closure's execution context.
+//! # Concurrency model
+//!
+//! We follow the SDK's documented best practice (see
+//! `jsonrpc::Builder` "Event Loop and Concurrency" and
+//! `jsonrpc::SentRequest::block_task` doc comments): `connect_with` runs the
+//! SDK background actors on a dedicated tokio task; its `main_fn` completes
+//! the `initialize` handshake, hands the resulting [`ConnectionTo<Agent>`] out
+//! to this struct, and then parks on a shutdown oneshot until
+//! [`AcpProtocol`] is dropped. The connection handle is `Clone + Send` and
+//! is used directly by every method — outgoing requests / notifications go
+//! through the SDK's own outgoing actor, so they are naturally concurrent.
+//! No hand-rolled command channel is involved.
+//!
+//! This is what makes `session/cancel` preempt an in-flight `session/prompt`:
+//! both requests are just `send_request` / `send_notification` calls on the
+//! shared connection, each awaited in its own caller task.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
@@ -18,10 +32,11 @@ use agent_client_protocol::schema::{
     SelectedPermissionOutcome, SessionNotification, SetSessionConfigOptionResponse, SetSessionModeResponse,
     SetSessionModelResponse,
 };
-use agent_client_protocol::{Agent, ByteStreams, Client, ConnectionTo, on_receive_notification, on_receive_request};
+use agent_client_protocol::{
+    Agent, ByteStreams, Client, ConnectionTo, Responder, on_receive_notification, on_receive_request,
+};
 use tokio::process::{ChildStdin, ChildStdout};
 use tokio::sync::{broadcast, mpsc, oneshot};
-use tokio::task::JoinHandle;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use tracing::{debug, warn};
 
@@ -35,8 +50,6 @@ use agent_client_protocol::schema::{
     NewSessionRequest, NewSessionResponse, PromptRequest, ResumeSessionRequest, SetSessionConfigOptionRequest,
     SetSessionModeRequest, SetSessionModelRequest,
 };
-
-type PermissionResponder = agent_client_protocol::Responder<RequestPermissionResponse>;
 
 /// Timeout for the ACP initialize handshake (seconds).
 const INIT_TIMEOUT_SECS: u64 = 30;
@@ -57,95 +70,21 @@ pub enum PermissionDecision {
     Cancelled,
 }
 
-/// Commands constructed by SDK callbacks and dispatched to handle agent→client messages.
-///
-/// Mirrors [`AcpClientCommand`] for the reverse direction. Each callback
-/// builds the appropriate variant and calls [`dispatch_agent_command`].
-enum AcpAgentCommand {
-    /// Agent sent a session update notification (streaming chunks, tool calls, etc.).
-    SessionUpdate {
-        notification: SessionNotification,
-        event_tx: broadcast::Sender<AgentStreamEvent>,
-        stream_tx: broadcast::Sender<AgentStreamChunk>,
-    },
-    /// Agent requests permission from the user before performing an action.
-    RequestPermission {
-        request: RequestPermissionRequest,
-        responder: PermissionResponder,
-        event_tx: mpsc::Sender<PermissionRequest>,
-    },
-}
-
-// ── Internal command protocol ────────────────────────────────────────────
-
-/// Commands sent from `AcpProtocol` methods to the SDK event loop.
-enum AcpClientCommand {
-    NewSession {
-        req: NewSessionRequest,
-        event_tx: oneshot::Sender<Result<NewSessionResponse, AcpError>>,
-    },
-    LoadSession {
-        req: LoadSessionRequest,
-        event_tx: oneshot::Sender<Result<LoadSessionResponse, AcpError>>,
-    },
-    ForkSession {
-        req: ForkSessionRequest,
-        event_tx: oneshot::Sender<Result<ForkSessionResponse, AcpError>>,
-    },
-    ResumeSession {
-        req: ResumeSessionRequest,
-        event_tx: oneshot::Sender<Result<ResumeSessionResponse, AcpError>>,
-    },
-    CloseSession {
-        req: CloseSessionRequest,
-        event_tx: oneshot::Sender<Result<CloseSessionResponse, AcpError>>,
-    },
-    Prompt {
-        req: PromptRequest,
-        event_tx: oneshot::Sender<Result<PromptResponse, AcpError>>,
-    },
-    Cancel {
-        notification: CancelNotification,
-    },
-    SetMode {
-        req: SetSessionModeRequest,
-        event_tx: oneshot::Sender<Result<SetSessionModeResponse, AcpError>>,
-    },
-    SetModel {
-        req: SetSessionModelRequest,
-        event_tx: oneshot::Sender<Result<SetSessionModelResponse, AcpError>>,
-    },
-    SetConfigOption {
-        req: SetSessionConfigOptionRequest,
-        event_tx: oneshot::Sender<Result<SetSessionConfigOptionResponse, AcpError>>,
-    },
-    ListSessions {
-        req: ListSessionsRequest,
-        event_tx: oneshot::Sender<Result<ListSessionsResponse, AcpError>>,
-    },
-    Authenticate {
-        req: AuthenticateRequest,
-        event_tx: oneshot::Sender<Result<AuthenticateResponse, AcpError>>,
-    },
-    ExtMethod {
-        req: ExtRequest,
-        event_tx: oneshot::Sender<Result<ExtResponse, AcpError>>,
-    },
-    ExtNotify {
-        notification: ExtNotification,
-    },
-}
-
 /// ACP protocol handle: wraps the SDK connection and provides typed operations.
 ///
-/// All methods send commands to the SDK event loop via a channel. The event
-/// loop runs inside `connect_with` where `block_task()` is safe to use.
+/// All request methods are thin wrappers over `connection.send_request(...)
+/// .block_task().await` — safe because each caller runs in its own tokio
+/// task, separate from the SDK background actors spawned by `connect_with`.
 pub struct AcpProtocol {
-    /// Background task handle (SDK transport + routing).
-    _bg_task: JoinHandle<()>,
-    /// Command sender to the SDK event loop.
-    cmd_tx: mpsc::Sender<AcpClientCommand>,
-    /// Whether the SDK connection is still alive.
+    /// SDK connection handle. Cheap to clone (channel senders only) and
+    /// shared by every method. Kept alive by the background task parked
+    /// on `shutdown_rx` in `connect_with`'s `main_fn`.
+    connection: ConnectionTo<Agent>,
+    /// Signal dropped on `Drop` to make `main_fn` return, which in turn
+    /// lets the SDK background actors shut down cleanly.
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    /// Flipped to `false` when the background task exits. Used by
+    /// [`Self::is_connected`] as a fast synchronous check.
     alive: Arc<AtomicBool>,
     /// Cached initialize response from the ACP handshake.
     initialize_response: Arc<RwLock<Option<InitializeResponse>>>,
@@ -165,28 +104,32 @@ impl AcpProtocol {
         permission_tx: mpsc::Sender<PermissionRequest>,
     ) -> Result<Self, AcpError> {
         let alive = Arc::new(AtomicBool::new(true));
-        let alive_clone = Arc::clone(&alive);
-        let initialize_response = Arc::new(RwLock::new(None));
 
-        // Command channel: external methods → SDK event loop
-        let (clicmd_tx, clicmd_rx) = mpsc::channel::<AcpClientCommand>(32);
-
-        // Signal that init completed successfully
+        // Signals from the background task:
+        // - `init_tx`: initialize handshake result (with possible SDK error)
+        // - `ready_tx`: connection handle once init succeeded; if init fails
+        //   this oneshot is dropped and the caller observes `NotConnected`
         let (init_tx, init_rx) = oneshot::channel::<Result<InitializeResponse, AcpError>>();
+        let (ready_tx, ready_rx) = oneshot::channel::<ConnectionTo<Agent>>();
 
-        let _bg_task = tokio::spawn(run_sdk_event_loop(
+        // Signal from us → background task telling `main_fn` to return,
+        // which triggers a clean SDK shutdown.
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+        tokio::spawn(run_sdk_background(
             stdin,
             stdout,
             event_tx,
             stream_tx,
             permission_tx,
             init_tx,
-            clicmd_rx,
-            alive_clone,
+            ready_tx,
+            shutdown_rx,
+            Arc::clone(&alive),
         ));
 
-        // Wait for init to complete with timeout
-        let init_result = tokio::time::timeout(std::time::Duration::from_secs(INIT_TIMEOUT_SECS), init_rx)
+        // Wait for init to complete with timeout.
+        let init_response = tokio::time::timeout(std::time::Duration::from_secs(INIT_TIMEOUT_SECS), init_rx)
             .await
             .map_err(|_| AcpError::InitTimeout {
                 timeout_secs: INIT_TIMEOUT_SECS,
@@ -195,16 +138,16 @@ impl AcpProtocol {
                 exit_code: None,
                 signal: None,
                 stderr: "Init channel dropped".into(),
-            })?;
+            })??;
 
-        let init_response = init_result?;
-        *initialize_response.write().unwrap() = Some(init_response);
+        // `ready_rx` should resolve almost immediately after init_tx fires.
+        let connection = ready_rx.await.map_err(|_| AcpError::NotConnected)?;
 
         Ok(Self {
-            cmd_tx: clicmd_tx,
-            _bg_task,
+            connection,
+            shutdown_tx: Some(shutdown_tx),
             alive,
-            initialize_response,
+            initialize_response: Arc::new(RwLock::new(Some(init_response))),
         })
     }
 
@@ -222,32 +165,27 @@ impl AcpProtocol {
 
     /// Create a new ACP session.
     pub async fn new_session(&self, req: NewSessionRequest) -> Result<NewSessionResponse, AcpError> {
-        self.send_cmd(|event_tx| AcpClientCommand::NewSession { req, event_tx })
-            .await
+        self.send_request(req, AGENT_METHOD_NAMES.session_new).await
     }
 
     /// Load (resume) an existing ACP session.
     pub async fn load_session(&self, req: LoadSessionRequest) -> Result<LoadSessionResponse, AcpError> {
-        self.send_cmd(|event_tx| AcpClientCommand::LoadSession { req, event_tx })
-            .await
+        self.send_request(req, AGENT_METHOD_NAMES.session_load).await
     }
 
     /// Fork an existing ACP session into a new session.
     pub async fn fork_session(&self, req: ForkSessionRequest) -> Result<ForkSessionResponse, AcpError> {
-        self.send_cmd(|event_tx| AcpClientCommand::ForkSession { req, event_tx })
-            .await
+        self.send_request(req, AGENT_METHOD_NAMES.session_fork).await
     }
 
     /// Resume an existing ACP session.
     pub async fn resume_session(&self, req: ResumeSessionRequest) -> Result<ResumeSessionResponse, AcpError> {
-        self.send_cmd(|event_tx| AcpClientCommand::ResumeSession { req, event_tx })
-            .await
+        self.send_request(req, AGENT_METHOD_NAMES.session_resume).await
     }
 
     /// Close an ACP session.
     pub async fn close_session(&self, req: CloseSessionRequest) -> Result<CloseSessionResponse, AcpError> {
-        self.send_cmd(|event_tx| AcpClientCommand::CloseSession { req, event_tx })
-            .await
+        self.send_request(req, AGENT_METHOD_NAMES.session_close).await
     }
 
     /// Send a prompt to the agent in an active session.
@@ -255,8 +193,7 @@ impl AcpProtocol {
     /// Blocks until the agent returns a `PromptResponse` (turn completed).
     /// Streaming events arrive via the `event_tx` broadcast channel.
     pub async fn prompt(&self, req: PromptRequest) -> Result<PromptResponse, AcpError> {
-        self.send_cmd(|event_tx| AcpClientCommand::Prompt { req, event_tx })
-            .await
+        self.send_request(req, AGENT_METHOD_NAMES.session_prompt).await
     }
 
     /// Cancel the current prompt in a session (fire-and-forget notification).
@@ -264,19 +201,18 @@ impl AcpProtocol {
         if !self.is_connected() {
             return;
         }
-        let _ = self.cmd_tx.try_send(AcpClientCommand::Cancel { notification });
+        log_notify(AGENT_METHOD_NAMES.session_cancel, &json_str(&notification));
+        let _ = self.connection.send_notification(notification);
     }
 
     /// Set the session mode.
     pub async fn set_mode(&self, req: SetSessionModeRequest) -> Result<SetSessionModeResponse, AcpError> {
-        self.send_cmd(|event_tx| AcpClientCommand::SetMode { req, event_tx })
-            .await
+        self.send_request(req, AGENT_METHOD_NAMES.session_set_mode).await
     }
 
     /// Set the session model.
     pub async fn set_model(&self, req: SetSessionModelRequest) -> Result<SetSessionModelResponse, AcpError> {
-        self.send_cmd(|event_tx| AcpClientCommand::SetModel { req, event_tx })
-            .await
+        self.send_request(req, AGENT_METHOD_NAMES.session_set_model).await
     }
 
     /// Set a session config option.
@@ -284,28 +220,33 @@ impl AcpProtocol {
         &self,
         req: SetSessionConfigOptionRequest,
     ) -> Result<SetSessionConfigOptionResponse, AcpError> {
-        self.send_cmd(|event_tx| AcpClientCommand::SetConfigOption { req, event_tx })
+        self.send_request(req, AGENT_METHOD_NAMES.session_set_config_option)
             .await
     }
 
     /// List sessions, optionally filtered by working directory.
     pub async fn list_sessions(&self, req: ListSessionsRequest) -> Result<ListSessionsResponse, AcpError> {
-        self.send_cmd(|event_tx| AcpClientCommand::ListSessions { req, event_tx })
-            .await
+        self.send_request(req, AGENT_METHOD_NAMES.session_list).await
     }
 
     /// Authenticate with the agent using a previously advertised auth method.
     pub async fn authenticate(&self, req: AuthenticateRequest) -> Result<AuthenticateResponse, AcpError> {
-        self.send_cmd(|event_tx| AcpClientCommand::Authenticate { req, event_tx })
-            .await
+        self.send_request(req, AGENT_METHOD_NAMES.authenticate).await
     }
 
     /// Send an extension request (method name must start with `_`).
     ///
     /// Returns the raw JSON response value from the agent.
     pub async fn ext_request(&self, req: ExtRequest) -> Result<ExtResponse, AcpError> {
-        self.send_cmd(|event_tx| AcpClientCommand::ExtMethod { req, event_tx })
-            .await
+        self.ensure_connected()?;
+        let method = format!("_{}", req.method);
+        let wrapped = ClientRequest::ExtMethodRequest(req);
+        let value = self.send_request(wrapped, &method).await?;
+        let raw = serde_json::value::to_raw_value(&value).map_err(|e| AcpError::AgentInternal {
+            message: format!("Failed to convert ext response: {e}"),
+            code: -32603,
+        })?;
+        Ok(ExtResponse::new(raw.into()))
     }
 
     /// Send an extension notification (fire-and-forget, method name must start with `_`).
@@ -313,7 +254,10 @@ impl AcpProtocol {
         if !self.is_connected() {
             return;
         }
-        let _ = self.cmd_tx.try_send(AcpClientCommand::ExtNotify { notification });
+        let method = format!("_{}", notification.method);
+        log_notify(&method, &json_str(&notification));
+        let wrapped = ClientNotification::ExtNotification(notification);
+        let _ = self.connection.send_notification(wrapped);
     }
 
     /// Check whether the SDK connection is still alive.
@@ -323,15 +267,17 @@ impl AcpProtocol {
 
     // ── Private helpers ──────────────────────────────────────────────────
 
-    /// Send a command to the SDK event loop and wait for the reply.
-    async fn send_cmd<T>(
-        &self,
-        build: impl FnOnce(oneshot::Sender<Result<T, AcpError>>) -> AcpClientCommand,
-    ) -> Result<T, AcpError> {
+    /// Shared request path: connectivity check, structured logging, SDK call.
+    async fn send_request<Req>(&self, req: Req, method: &str) -> Result<Req::Response, AcpError>
+    where
+        Req: agent_client_protocol::JsonRpcRequest + serde::Serialize + std::fmt::Debug,
+        Req::Response: serde::Serialize + std::fmt::Debug + Send,
+    {
         self.ensure_connected()?;
-        let (tx, rx) = oneshot::channel();
-        self.cmd_tx.send(build(tx)).await.map_err(|_| AcpError::NotConnected)?;
-        rx.await.map_err(|_| AcpError::NotConnected)?
+        log_request(method, &json_str(&req));
+        let rsp = self.connection.send_request(req).block_task().await;
+        log_response(method, &json_or_err(&rsp));
+        rsp.map_err(|e| AcpError::from_sdk(e, method))
     }
 
     /// Return `Err(NotConnected)` if the connection is dead.
@@ -344,58 +290,47 @@ impl AcpProtocol {
     }
 }
 
-/// Execute the ACP initialize handshake over the given connection.
-///
-/// Sends `InitializeRequest` and signals success/failure via `init_tx`.
-/// Returns `Err(())` when the handshake failed (the caller should bail out).
-async fn execute_initialize(
-    connection: &ConnectionTo<Agent>,
-    init_tx: oneshot::Sender<Result<InitializeResponse, AcpError>>,
-) -> Result<(), ()> {
-    let req = InitializeRequest::new(ProtocolVersion::LATEST);
-    log_request("initialize", &json_str(&req));
-
-    let raw = connection.send_request(req).block_task().await;
-    log_response("initialize", &json_or_err(&raw));
-
-    if let Err(e) = raw {
-        let _ = init_tx.send(Err(AcpError::from_sdk(e, "initialize")));
-        return Err(());
+impl Drop for AcpProtocol {
+    fn drop(&mut self) {
+        // Releasing the oneshot wakes `main_fn` in the background task, which
+        // returns, which drives SDK shutdown. The bg_task joins naturally
+        // (we don't await it here — Drop can't be async; the task is
+        // `tokio::spawn`ed, so it gets cleaned up by the runtime).
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
     }
-    let _ = init_tx.send(raw.map_err(|e| AcpError::from_sdk(e, "initialize")));
-    Ok(())
 }
 
-/// Run the SDK event loop: build the client, connect transport, handle
-/// notifications/requests, execute the initialize handshake, then process
-/// commands until the channel closes.
-///
-/// This is the top-level future spawned as the background task in
-/// [`AcpProtocol::connect`].
+/// Run the SDK `connect_with` future: register notification/request
+/// handlers, execute the initialize handshake, publish the connection
+/// handle, then park on the shutdown signal until [`AcpProtocol`] is dropped.
 #[allow(clippy::too_many_arguments)]
-async fn run_sdk_event_loop(
+async fn run_sdk_background(
     stdin: ChildStdin,
     stdout: ChildStdout,
     event_tx: broadcast::Sender<AgentStreamEvent>,
     stream_tx: broadcast::Sender<AgentStreamChunk>,
     permission_tx: mpsc::Sender<PermissionRequest>,
     init_tx: oneshot::Sender<Result<InitializeResponse, AcpError>>,
-    clicmd_rx: mpsc::Receiver<AcpClientCommand>,
+    ready_tx: oneshot::Sender<ConnectionTo<Agent>>,
+    shutdown_rx: oneshot::Receiver<()>,
     alive: Arc<AtomicBool>,
 ) {
     let transport = ByteStreams::new(stdin.compat_write(), stdout.compat());
+
+    // `init_tx` / `ready_tx` are consumed inside the main_fn closure; wrap
+    // them in Option so we can .take() without moving out of captured state.
+    let mut init_tx = Some(init_tx);
+    let mut ready_tx = Some(ready_tx);
+    let mut shutdown_rx = Some(shutdown_rx);
 
     let result = Client
         .builder()
         .on_receive_notification(
             {
                 async move |notification: SessionNotification, _cx: ConnectionTo<Agent>| {
-                    let cmd = AcpAgentCommand::SessionUpdate {
-                        notification,
-                        event_tx: event_tx.clone(),
-                        stream_tx: stream_tx.clone(),
-                    };
-                    dispatch_agent_command(cmd).await;
+                    handle_session_notification(notification, &event_tx, &stream_tx).await;
                     Ok(())
                 }
             },
@@ -403,39 +338,56 @@ async fn run_sdk_event_loop(
         )
         .on_receive_request(
             {
-                async move |request: RequestPermissionRequest,
-                            responder: PermissionResponder,
-                            _cx: ConnectionTo<Agent>| {
-                    let cmd = AcpAgentCommand::RequestPermission {
-                        request,
-                        responder,
-                        event_tx: permission_tx.clone(),
-                    };
-                    dispatch_agent_command(cmd).await;
+                async move |request: RequestPermissionRequest, responder, _cx| {
+                    handle_permission_request(request, responder, &permission_tx).await;
                     Ok(())
                 }
             },
             on_receive_request!(),
         )
-        .connect_with(transport, {
-            let mut cmd_rx = clicmd_rx;
-            move |connection: ConnectionTo<Agent>| async move {
-                if let Err(()) = execute_initialize(&connection, init_tx).await {
+        .connect_with(transport, async move |connection: ConnectionTo<Agent>| {
+            // Step 1 — initialize handshake. main_fn is the canonical place
+            // to call `block_task` (see SDK `connect_with` doc example).
+            let init_result = {
+                let req = InitializeRequest::new(ProtocolVersion::LATEST);
+                log_request("initialize", &json_str(&req));
+                let raw = connection.send_request(req).block_task().await;
+                log_response("initialize", &json_or_err(&raw));
+                raw.map_err(|e| AcpError::from_sdk(e, "initialize"))
+            };
+
+            let Some(tx) = init_tx.take() else {
+                return Ok(());
+            };
+            match init_result {
+                Ok(resp) => {
+                    let _ = tx.send(Ok(resp));
+                }
+                Err(err) => {
+                    let _ = tx.send(Err(err));
+                    // init failure: let main_fn return so SDK cleans up.
                     return Ok(());
                 }
-
-                // Command loop: process requests from AcpProtocol methods
-                while let Some(cmd) = cmd_rx.recv().await {
-                    dispatch_client_command(&connection, cmd).await;
-                }
-
-                debug!("ACP command channel closed, connection ending");
-                Ok(())
             }
+
+            // Step 2 — publish the connection handle so the outer
+            // AcpProtocol can start issuing requests.
+            if let Some(tx) = ready_tx.take()
+                && tx.send(connection).is_err()
+            {
+                // Owner dropped before we became ready — nothing more to do.
+                return Ok(());
+            }
+
+            // Step 3 — keep the connection alive until AcpProtocol::drop
+            // releases the shutdown oneshot.
+            if let Some(rx) = shutdown_rx.take() {
+                let _ = rx.await;
+            }
+            Ok(())
         })
         .await;
 
-    // Mark connection as dead
     alive.store(false, Ordering::Release);
 
     match result {
@@ -444,161 +396,57 @@ async fn run_sdk_event_loop(
     }
 }
 
-/// Dispatch a single [`AcpClientCommand`] over the connection.
-///
-/// Mirrored by [`dispatch_agent_command`] for the reverse direction.
-async fn dispatch_client_command(connection: &ConnectionTo<Agent>, cmd: AcpClientCommand) {
-    match cmd {
-        AcpClientCommand::NewSession { req, event_tx } => {
-            let _ = event_tx.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_new).await);
-        }
-        AcpClientCommand::ForkSession { req, event_tx } => {
-            let _ = event_tx.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_fork).await);
-        }
-        AcpClientCommand::LoadSession { req, event_tx } => {
-            let _ = event_tx.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_load).await);
-        }
-        AcpClientCommand::ResumeSession { req, event_tx } => {
-            let _ = event_tx.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_resume).await);
-        }
-        AcpClientCommand::CloseSession { req, event_tx } => {
-            let _ = event_tx.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_close).await);
-        }
-        AcpClientCommand::Prompt { req, event_tx } => {
-            // Run the prompt on a dedicated SDK task so the dispatch loop can
-            // keep processing commands (most importantly `Cancel`) while the
-            // CLI is still streaming the turn. Awaiting `send_and_log` here
-            // directly would block every other command until the turn ends,
-            // which is exactly what made `stop` not interrupt live turns —
-            // the `session/cancel` notification was only dispatched after
-            // the prompt response arrived.
-            let connection_for_task = connection.clone();
-            if let Err(err) = connection.spawn(async move {
-                let result = send_and_log(&connection_for_task, req, AGENT_METHOD_NAMES.session_prompt).await;
-                let _ = event_tx.send(result);
-                Ok(())
-            }) {
-                // Spawn can only fail when the SDK is shutting down. In that
-                // case `event_tx` was consumed by the closure, so the caller
-                // will observe `AcpError::NotConnected` via the dropped
-                // oneshot — which is the correct signal.
-                warn!(error = %err, "Failed to spawn ACP prompt task");
-            }
-        }
-        AcpClientCommand::SetMode { req, event_tx } => {
-            let _ = event_tx.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_set_mode).await);
-        }
-        AcpClientCommand::SetModel { req, event_tx } => {
-            let _ = event_tx.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_set_model).await);
-        }
-        AcpClientCommand::SetConfigOption { req, event_tx } => {
-            let _ = event_tx.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_set_config_option).await);
-        }
-        AcpClientCommand::Cancel { notification } => {
-            log_notify(AGENT_METHOD_NAMES.session_cancel, &json_str(&notification));
-            let _ = connection.send_notification(notification);
-        }
-        AcpClientCommand::ListSessions { req, event_tx } => {
-            let _ = event_tx.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_list).await);
-        }
-        AcpClientCommand::Authenticate { req, event_tx } => {
-            let _ = event_tx.send(send_and_log(connection, req, AGENT_METHOD_NAMES.authenticate).await);
-        }
-        AcpClientCommand::ExtMethod { req, event_tx } => {
-            let method = format!("_{}", req.method);
-            let wrapped = ClientRequest::ExtMethodRequest(req);
-            let result = send_and_log(connection, wrapped, &method).await;
-            let _ = event_tx.send(result.and_then(|v| {
-                let raw = serde_json::value::to_raw_value(&v).map_err(|e| AcpError::AgentInternal {
-                    message: format!("Failed to convert ext response: {e}"),
-                    code: -32603,
-                })?;
-                Ok(ExtResponse::new(raw.into()))
-            }));
-        }
-        AcpClientCommand::ExtNotify { notification } => {
-            let method = format!("_{}", notification.method);
-            log_notify(&method, &json_str(&notification));
-            let wrapped = ClientNotification::ExtNotification(notification);
-            let _ = connection.send_notification(wrapped);
-        }
+/// Fan out a CLI session notification to the event/stream broadcast channels.
+async fn handle_session_notification(
+    notification: SessionNotification,
+    event_tx: &broadcast::Sender<AgentStreamEvent>,
+    stream_tx: &broadcast::Sender<AgentStreamChunk>,
+) {
+    log_incoming("session/update", &json_str(&notification));
+
+    let events = stream_event::session_notification_to_events(&notification);
+    for event in events {
+        let _ = event_tx.send(event);
+    }
+
+    // Parallel projection onto the AgentStreamChunk broadcast channel.
+    // Subscribers (wake timeout watchdog, crash detector) only care about
+    // message / thought / tool-call chunks; handshake-like updates are
+    // filtered out inside `session_notification_to_chunks`.
+    let chunks = stream_event::session_notification_to_chunks(&notification);
+    for chunk in chunks {
+        let _ = stream_tx.send(chunk);
     }
 }
 
-/// Dispatch a single [`AcpAgentCommand`] (agent → client direction).
-///
-/// Mirrors [`dispatch_client_command`] for the client → agent direction.
-async fn dispatch_agent_command(cmd: AcpAgentCommand) {
-    match cmd {
-        AcpAgentCommand::SessionUpdate {
-            notification,
-            event_tx,
-            stream_tx,
-        } => {
-            log_incoming("session/update", &json_str(&notification));
+/// Relay a CLI permission request to the pending-permission channel and
+/// forward the user's decision back to the SDK responder.
+async fn handle_permission_request(
+    request: RequestPermissionRequest,
+    responder: Responder<RequestPermissionResponse>,
+    event_tx: &mpsc::Sender<PermissionRequest>,
+) {
+    log_incoming("session/request_permission", &json_str(&request));
 
-            let events = stream_event::session_notification_to_events(&notification);
-            for event in events {
-                let _ = event_tx.send(event);
-            }
+    let (response_tx, response_rx) = oneshot::channel();
 
-            // Parallel projection onto the AgentStreamChunk broadcast channel.
-            // Subscribers (wake timeout watchdog, crash detector) only care
-            // about message/thought/tool-call chunks; handshake-like updates
-            // are filtered out inside `session_notification_to_chunks`.
-            let chunks = stream_event::session_notification_to_chunks(&notification);
-            for chunk in chunks {
-                let _ = stream_tx.send(chunk);
-            }
-        }
-        AcpAgentCommand::RequestPermission {
-            request,
-            responder,
-            event_tx,
-        } => {
-            log_incoming("session/request_permission", &json_str(&request));
-
-            let (resp_tx, resp_rx) = oneshot::channel();
-
-            let perm_req = PermissionRequest {
-                request,
-                response_tx: resp_tx,
-            };
-
-            if event_tx.send(perm_req).await.is_err() {
-                warn!("Permission channel closed, cancelling request");
-                let _ = responder.respond(RequestPermissionResponse::new(RequestPermissionOutcome::Cancelled));
-                return;
-            }
-
-            let response = match resp_rx.await {
-                Ok(PermissionDecision::Selected { option_id }) => RequestPermissionResponse::new(
-                    RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(option_id)),
-                ),
-                Ok(PermissionDecision::Cancelled) | Err(_) => {
-                    RequestPermissionResponse::new(RequestPermissionOutcome::Cancelled)
-                }
-            };
-
-            log_outgoing("session/request_permission", &json_str(&response));
-            let _ = responder.respond(response);
-        }
+    if event_tx.send(PermissionRequest { request, response_tx }).await.is_err() {
+        warn!("Permission channel closed, cancelling request");
+        let _ = responder.respond(RequestPermissionResponse::new(RequestPermissionOutcome::Cancelled));
+        return;
     }
-}
 
-/// Send an SDK request over the connection, logging the request and response JSON.
-///
-/// The `method` string is used for log labels and as error context for
-/// [`AcpError::from_sdk`].
-async fn send_and_log<Req>(connection: &ConnectionTo<Agent>, req: Req, method: &str) -> Result<Req::Response, AcpError>
-where
-    Req: agent_client_protocol::JsonRpcRequest + serde::Serialize + std::fmt::Debug,
-    Req::Response: serde::Serialize + std::fmt::Debug,
-{
-    log_request(method, &json_str(&req));
-    let rsp = connection.send_request(req).block_task().await;
-    log_response(method, &json_or_err(&rsp));
-    rsp.map_err(|e| AcpError::from_sdk(e, method))
+    let response = match response_rx.await {
+        Ok(PermissionDecision::Selected { option_id }) => RequestPermissionResponse::new(
+            RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(option_id)),
+        ),
+        Ok(PermissionDecision::Cancelled) | Err(_) => {
+            RequestPermissionResponse::new(RequestPermissionOutcome::Cancelled)
+        }
+    };
+
+    log_outgoing("session/request_permission", &json_str(&response));
+    let _ = responder.respond(response);
 }
 
 /// Serialize a value to a compact JSON string, falling back to Debug on failure.
@@ -616,27 +464,27 @@ fn json_or_err<T: serde::Serialize + std::fmt::Debug, E: std::fmt::Debug>(result
 
 /// Log an outgoing ACP request (`→`).
 fn log_request(method: &str, body: &str) {
-    debug!("[ACP] {method}\n → {body}");
+    debug!("[ACP] {method} ->\n -> {body}");
 }
 
 /// Log an incoming ACP response (`←`).
 fn log_response(method: &str, body: &str) {
-    debug!("[ACP] {method}\n ← {body}");
+    debug!("[ACP] {method} <-\n <- {body}");
 }
 
 /// Log a fire-and-forget notification (`⚡`).
 fn log_notify(method: &str, body: &str) {
-    debug!("[ACP] {method}\n ⚡ {body}");
+    debug!("[ACP] {method} ⚡⚡\n ⚡⚡ {body}");
 }
 
 /// Log an incoming agent notification/request (`←`).
 fn log_incoming(method: &str, body: &str) {
-    debug!("[ACP] {method}\n ← {body}");
+    debug!("[ACP] {method} <-\n <- {body}");
 }
 
 /// Log an outgoing agent notification/request (`→`).
 fn log_outgoing(method: &str, body: &str) {
-    debug!("[ACP] {method}\n → {body}");
+    debug!("[ACP] {method} ->\n -> {body}");
 }
 
 impl std::fmt::Debug for AcpProtocol {

--- a/crates/aionui-ai-agent/src/acp_protocol.rs
+++ b/crates/aionui-ai-agent/src/acp_protocol.rs
@@ -465,7 +465,25 @@ async fn dispatch_client_command(connection: &ConnectionTo<Agent>, cmd: AcpClien
             let _ = event_tx.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_close).await);
         }
         AcpClientCommand::Prompt { req, event_tx } => {
-            let _ = event_tx.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_prompt).await);
+            // Run the prompt on a dedicated SDK task so the dispatch loop can
+            // keep processing commands (most importantly `Cancel`) while the
+            // CLI is still streaming the turn. Awaiting `send_and_log` here
+            // directly would block every other command until the turn ends,
+            // which is exactly what made `stop` not interrupt live turns —
+            // the `session/cancel` notification was only dispatched after
+            // the prompt response arrived.
+            let connection_for_task = connection.clone();
+            if let Err(err) = connection.spawn(async move {
+                let result = send_and_log(&connection_for_task, req, AGENT_METHOD_NAMES.session_prompt).await;
+                let _ = event_tx.send(result);
+                Ok(())
+            }) {
+                // Spawn can only fail when the SDK is shutting down. In that
+                // case `event_tx` was consumed by the closure, so the caller
+                // will observe `AcpError::NotConnected` via the dropped
+                // oneshot — which is the correct signal.
+                warn!(error = %err, "Failed to spawn ACP prompt task");
+            }
         }
         AcpClientCommand::SetMode { req, event_tx } => {
             let _ = event_tx.send(send_and_log(connection, req, AGENT_METHOD_NAMES.session_set_mode).await);

--- a/crates/aionui-ai-agent/src/factory.rs
+++ b/crates/aionui-ai-agent/src/factory.rs
@@ -2,6 +2,7 @@ use aion_agent::session::SessionManager;
 use aionui_api_types::GuideMcpConfig;
 use aionui_common::{AgentType, AppError, CommandSpec};
 use aionui_db::{IProviderRepository, IRemoteAgentRepository};
+use futures_util::FutureExt;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
@@ -39,21 +40,17 @@ pub struct AgentFactoryDeps {
 
 /// Build a production agent factory that dispatches to concrete agent types.
 ///
-/// The factory bridges the synchronous `AgentFactory` signature to async agent
-/// constructors. Uses a scoped thread + `Handle::block_on` so it works on both
-/// multi-threaded and single-threaded (test) tokio runtimes.
+/// [`AgentFactory`] is async: the returned `BoxFuture` is driven by
+/// [`crate::task_manager::IWorkerTaskManager::get_or_build_task`] on whatever
+/// runtime is currently polling it. This lets us spawn CLI processes and
+/// await ACP handshakes directly, without the scoped-thread + `block_on`
+/// bridge the old sync-factory version needed.
 pub fn build_agent_factory(deps: AgentFactoryDeps) -> AgentFactory {
     let deps = Arc::new(deps);
 
     Arc::new(move |options: BuildTaskOptions| {
         let deps = deps.clone();
-        let handle = tokio::runtime::Handle::current();
-
-        std::thread::scope(|s| {
-            s.spawn(|| handle.block_on(build_agent(deps, options)))
-                .join()
-                .map_err(|_| AppError::Internal("Agent construction panicked".into()))?
-        })
+        async move { build_agent(deps, options).await }.boxed()
     })
 }
 

--- a/crates/aionui-ai-agent/src/factory.rs
+++ b/crates/aionui-ai-agent/src/factory.rs
@@ -112,7 +112,10 @@ async fn build_agent(deps: Arc<AgentFactoryDeps>, options: BuildTaskOptions) -> 
             if config.team_mcp_stdio_config.is_some() {
                 debug!(conversation_id, "guide_mcp: skipped: has team_mcp");
             } else if config.guide_mcp_config.is_some() {
-                debug!(conversation_id, "guide_mcp: skipped: caller already set guide_mcp_config");
+                debug!(
+                    conversation_id,
+                    "guide_mcp: skipped: caller already set guide_mcp_config"
+                );
             } else if deps.guide_mcp_config.is_none() {
                 debug!(conversation_id, "guide_mcp: skipped: guide server not running");
             } else {

--- a/crates/aionui-ai-agent/src/task_manager.rs
+++ b/crates/aionui-ai-agent/src/task_manager.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
 use aionui_common::{AgentKillReason, AgentType, AppError, ConversationStatus, TimestampMs, now_ms};
+use async_trait::async_trait;
 use dashmap::DashMap;
+use futures_util::future::BoxFuture;
+use tokio::sync::OnceCell;
 use tracing::info;
 
 use crate::agent_manager::AgentManagerHandle;
@@ -9,20 +12,30 @@ use crate::types::BuildTaskOptions;
 
 /// Factory function that creates an [`AgentManagerHandle`] from build options.
 ///
-/// This is provided at DI time by the application layer, which knows
-/// how to construct each agent type (ACP, Gemini, etc.).
-pub type AgentFactory = Arc<dyn Fn(BuildTaskOptions) -> Result<AgentManagerHandle, AppError> + Send + Sync>;
+/// Async so the factory can do real I/O (spawn a CLI process, negotiate the
+/// ACP initialize handshake, etc.) without needing to `block_on` inside the
+/// `IWorkerTaskManager` call site. Returning `BoxFuture` keeps the trait
+/// object-safe for DI.
+pub type AgentFactory =
+    Arc<dyn Fn(BuildTaskOptions) -> BoxFuture<'static, Result<AgentManagerHandle, AppError>> + Send + Sync>;
 
 /// Manages the lifecycle of active Agent tasks.
 ///
 /// Each conversation has at most one active task (keyed by conversation ID).
 /// The trait is object-safe for dependency injection.
+#[async_trait]
 pub trait IWorkerTaskManager: Send + Sync {
     /// Get an existing task by conversation ID.
     fn get_task(&self, conversation_id: &str) -> Option<AgentManagerHandle>;
 
     /// Get an existing task or build a new one if none exists.
-    fn get_or_build_task(
+    ///
+    /// Concurrent callers with the same `conversation_id` block on a shared
+    /// [`OnceCell`] so the factory runs at most once per conversation —
+    /// avoiding the race where two concurrent HTTP requests (e.g.
+    /// `/messages` + `/warmup`) would each spawn their own CLI process and
+    /// ACP connection, with one of them leaking.
+    async fn get_or_build_task(
         &self,
         conversation_id: &str,
         options: BuildTaskOptions,
@@ -45,9 +58,15 @@ pub trait IWorkerTaskManager: Send + Sync {
     fn collect_idle(&self, idle_threshold_ms: TimestampMs) -> Vec<String>;
 }
 
+/// Per-conversation slot: an [`OnceCell`] that the first concurrent caller
+/// initialises by running the factory, and that every subsequent caller
+/// awaits. Failed initialisations leave the cell empty so the next caller
+/// may retry; the slot itself is only removed on `kill` / `clear`.
+type TaskSlot = Arc<OnceCell<AgentManagerHandle>>;
+
 /// Default implementation of [`IWorkerTaskManager`] using a concurrent hash map.
 pub struct WorkerTaskManagerImpl {
-    tasks: DashMap<String, AgentManagerHandle>,
+    tasks: DashMap<String, TaskSlot>,
     factory: AgentFactory,
 }
 
@@ -58,36 +77,49 @@ impl WorkerTaskManagerImpl {
             factory,
         }
     }
+
+    /// Look up a fully-initialised handle by conversation id.
+    fn initialised_handle(&self, conversation_id: &str) -> Option<AgentManagerHandle> {
+        self.tasks.get(conversation_id).and_then(|slot| slot.get().cloned())
+    }
 }
 
+#[async_trait]
 impl IWorkerTaskManager for WorkerTaskManagerImpl {
     fn get_task(&self, conversation_id: &str) -> Option<AgentManagerHandle> {
-        self.tasks.get(conversation_id).map(|r| Arc::clone(&r))
+        self.initialised_handle(conversation_id)
     }
 
-    fn get_or_build_task(
+    async fn get_or_build_task(
         &self,
         conversation_id: &str,
         options: BuildTaskOptions,
     ) -> Result<AgentManagerHandle, AppError> {
-        // Fast path: task already exists
-        if let Some(existing) = self.tasks.get(conversation_id) {
-            return Ok(Arc::clone(&existing));
-        }
+        // Atomically obtain the per-conversation slot. `DashMap::entry` is
+        // synchronous and side-effect-free — only an empty OnceCell is
+        // allocated on the miss path, so concurrent callers for the same id
+        // all end up holding the same `Arc<OnceCell>`.
+        let slot: TaskSlot = self
+            .tasks
+            .entry(conversation_id.to_owned())
+            .or_insert_with(|| Arc::new(OnceCell::new()))
+            .clone();
 
-        // Build a new task
-        let handle = (self.factory)(options)?;
-
-        // Use entry API to avoid TOCTOU race — if another thread inserted
-        // between our get and this point, use the existing one.
-        let entry = self.tasks.entry(conversation_id.to_owned()).or_insert(handle);
-        Ok(Arc::clone(&entry))
+        // `OnceCell::get_or_try_init` serialises concurrent initialisers:
+        // the first caller to reach it runs the factory, every other caller
+        // awaits the same future and ends up with the same handle. On
+        // failure the cell stays empty so a later caller can retry.
+        let factory = self.factory.clone();
+        let handle = slot.get_or_try_init(|| async move { factory(options).await }).await?;
+        Ok(Arc::clone(handle))
     }
 
     fn kill(&self, conversation_id: &str, reason: Option<AgentKillReason>) -> Result<(), AppError> {
-        if let Some((id, agent)) = self.tasks.remove(conversation_id) {
+        if let Some((id, slot)) = self.tasks.remove(conversation_id) {
             info!(conversation_id = %id, ?reason, "Killing agent task");
-            agent.kill(reason)?;
+            if let Some(agent) = slot.get() {
+                agent.kill(reason)?;
+            }
         }
         Ok(())
     }
@@ -95,29 +127,31 @@ impl IWorkerTaskManager for WorkerTaskManagerImpl {
     fn clear(&self) {
         let keys: Vec<String> = self.tasks.iter().map(|r| r.key().clone()).collect();
         for key in keys {
-            if let Some((id, agent)) = self.tasks.remove(&key) {
+            if let Some((id, slot)) = self.tasks.remove(&key) {
                 info!(conversation_id = %id, "Clearing agent task");
-                let _ = agent.kill(None);
+                if let Some(agent) = slot.get() {
+                    let _ = agent.kill(None);
+                }
             }
         }
     }
 
     fn active_count(&self) -> usize {
-        self.tasks.len()
+        self.tasks.iter().filter(|entry| entry.value().get().is_some()).count()
     }
 
     fn collect_idle(&self, idle_threshold_ms: TimestampMs) -> Vec<String> {
         let now = now_ms();
         self.tasks
             .iter()
-            .filter(|entry| {
-                let agent = entry.value();
+            .filter_map(|entry| {
+                let agent = entry.value().get()?;
                 // Only ACP agents participate in idle cleanup per API Spec
-                agent.agent_type() == AgentType::Acp
+                (agent.agent_type() == AgentType::Acp
                     && agent.status() == Some(ConversationStatus::Finished)
-                    && (now - agent.last_activity_at()) > idle_threshold_ms
+                    && (now - agent.last_activity_at()) > idle_threshold_ms)
+                    .then(|| entry.key().clone())
             })
-            .map(|entry| entry.key().clone())
             .collect()
     }
 }
@@ -129,6 +163,7 @@ mod tests {
     use crate::stream_event::AgentStreamEvent;
     use crate::types::SendMessageData;
     use aionui_common::{AgentKillReason, AgentType, Confirmation, ConversationStatus, ProviderWithModel};
+    use futures_util::FutureExt;
     use std::sync::atomic::{AtomicI64, Ordering};
     use tokio::sync::broadcast;
 
@@ -231,7 +266,7 @@ mod tests {
 
     fn make_manager() -> WorkerTaskManagerImpl {
         let factory: AgentFactory = Arc::new(|opts: BuildTaskOptions| {
-            Ok(Arc::new(MockAgent::new(&opts.conversation_id, None)) as AgentManagerHandle)
+            async move { Ok(Arc::new(MockAgent::new(&opts.conversation_id, None)) as AgentManagerHandle) }.boxed()
         });
         WorkerTaskManagerImpl::new(factory)
     }
@@ -242,36 +277,102 @@ mod tests {
         assert!(mgr.get_task("nonexistent").is_none());
     }
 
-    #[test]
-    fn get_or_build_creates_task() {
+    #[tokio::test]
+    async fn get_or_build_creates_task() {
         let mgr = make_manager();
-        let handle = mgr.get_or_build_task("conv-1", make_options("conv-1")).unwrap();
+        let handle = mgr.get_or_build_task("conv-1", make_options("conv-1")).await.unwrap();
         assert_eq!(handle.conversation_id(), "conv-1");
         assert_eq!(mgr.active_count(), 1);
     }
 
-    #[test]
-    fn get_or_build_returns_existing() {
+    #[tokio::test]
+    async fn get_or_build_returns_existing() {
         let mgr = make_manager();
-        let h1 = mgr.get_or_build_task("conv-1", make_options("conv-1")).unwrap();
-        let h2 = mgr.get_or_build_task("conv-1", make_options("conv-1")).unwrap();
+        let h1 = mgr.get_or_build_task("conv-1", make_options("conv-1")).await.unwrap();
+        let h2 = mgr.get_or_build_task("conv-1", make_options("conv-1")).await.unwrap();
         assert!(Arc::ptr_eq(&h1, &h2));
         assert_eq!(mgr.active_count(), 1);
     }
 
-    #[test]
-    fn get_task_finds_existing() {
+    #[tokio::test]
+    async fn get_or_build_is_single_flight_under_concurrency() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_factory = Arc::clone(&calls);
+        let factory: AgentFactory = Arc::new(move |opts: BuildTaskOptions| {
+            let calls = Arc::clone(&calls_for_factory);
+            async move {
+                // Simulate a slow build (CLI spawn + initialize handshake).
+                tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(Arc::new(MockAgent::new(&opts.conversation_id, None)) as AgentManagerHandle)
+            }
+            .boxed()
+        });
+        let mgr = Arc::new(WorkerTaskManagerImpl::new(factory));
+
+        // Ten concurrent callers all racing on the same conversation id.
+        let mut joins = Vec::new();
+        for _ in 0..10 {
+            let mgr = Arc::clone(&mgr);
+            joins.push(tokio::spawn(async move {
+                mgr.get_or_build_task("conv-race", make_options("conv-race")).await
+            }));
+        }
+        let handles: Vec<_> = futures_util::future::join_all(joins)
+            .await
+            .into_iter()
+            .map(|r| r.unwrap().unwrap())
+            .collect();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "factory must run only once");
+        assert_eq!(mgr.active_count(), 1);
+        for h in handles.iter().skip(1) {
+            assert!(Arc::ptr_eq(&handles[0], h), "all callers see the same handle");
+        }
+    }
+
+    #[tokio::test]
+    async fn get_or_build_retries_after_failure() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let fail_next = Arc::new(AtomicBool::new(true));
+        let flag = Arc::clone(&fail_next);
+        let factory: AgentFactory = Arc::new(move |opts: BuildTaskOptions| {
+            let flag = Arc::clone(&flag);
+            async move {
+                if flag.swap(false, Ordering::SeqCst) {
+                    Err(AppError::Internal("first call fails".into()))
+                } else {
+                    Ok(Arc::new(MockAgent::new(&opts.conversation_id, None)) as AgentManagerHandle)
+                }
+            }
+            .boxed()
+        });
+        let mgr = WorkerTaskManagerImpl::new(factory);
+
+        // First call fails, slot stays empty.
+        assert!(mgr.get_or_build_task("conv-1", make_options("conv-1")).await.is_err());
+        // Second call retries and succeeds.
+        let h = mgr.get_or_build_task("conv-1", make_options("conv-1")).await.unwrap();
+        assert_eq!(h.conversation_id(), "conv-1");
+        assert_eq!(mgr.active_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn get_task_finds_existing() {
         let mgr = make_manager();
-        mgr.get_or_build_task("conv-1", make_options("conv-1")).unwrap();
+        mgr.get_or_build_task("conv-1", make_options("conv-1")).await.unwrap();
         let handle = mgr.get_task("conv-1");
         assert!(handle.is_some());
         assert_eq!(handle.unwrap().conversation_id(), "conv-1");
     }
 
-    #[test]
-    fn kill_removes_task() {
+    #[tokio::test]
+    async fn kill_removes_task() {
         let mgr = make_manager();
-        mgr.get_or_build_task("conv-1", make_options("conv-1")).unwrap();
+        mgr.get_or_build_task("conv-1", make_options("conv-1")).await.unwrap();
         assert_eq!(mgr.active_count(), 1);
 
         mgr.kill("conv-1", Some(AgentKillReason::IdleTimeout)).unwrap();
@@ -281,15 +382,16 @@ mod tests {
 
     #[test]
     fn kill_nonexistent_is_ok() {
-        let mgr = make_manager();
+        let factory: AgentFactory = Arc::new(|_| async { unreachable!() }.boxed());
+        let mgr = WorkerTaskManagerImpl::new(factory);
         assert!(mgr.kill("nothing", None).is_ok());
     }
 
-    #[test]
-    fn clear_removes_all() {
+    #[tokio::test]
+    async fn clear_removes_all() {
         let mgr = make_manager();
-        mgr.get_or_build_task("conv-1", make_options("conv-1")).unwrap();
-        mgr.get_or_build_task("conv-2", make_options("conv-2")).unwrap();
+        mgr.get_or_build_task("conv-1", make_options("conv-1")).await.unwrap();
+        mgr.get_or_build_task("conv-2", make_options("conv-2")).await.unwrap();
         assert_eq!(mgr.active_count(), 2);
 
         mgr.clear();
@@ -298,27 +400,32 @@ mod tests {
 
     #[test]
     fn collect_idle_finds_finished_and_stale_acp_tasks() {
-        let mgr = WorkerTaskManagerImpl {
-            tasks: DashMap::new(),
-            factory: Arc::new(|_| unreachable!()),
+        let factory: AgentFactory = Arc::new(|_| async { unreachable!() }.boxed());
+        let mgr = WorkerTaskManagerImpl::new(factory);
+
+        // Helper: insert a pre-initialised slot bypassing the async factory path.
+        let insert = |id: &str, agent: Arc<dyn IAgentManager>| {
+            let cell: OnceCell<AgentManagerHandle> = OnceCell::new();
+            cell.set(agent).ok();
+            mgr.tasks.insert(id.into(), Arc::new(cell));
         };
 
         // ACP + Finished + old activity → should be collected
         let stale = Arc::new(
             MockAgent::new("conv-stale", Some(ConversationStatus::Finished)).with_last_activity(now_ms() - 600_000), // 10 min ago
         );
-        mgr.tasks.insert("conv-stale".into(), stale);
+        insert("conv-stale", stale);
 
         // ACP + Finished + recent activity → should NOT be collected
         let recent =
             Arc::new(MockAgent::new("conv-recent", Some(ConversationStatus::Finished)).with_last_activity(now_ms()));
-        mgr.tasks.insert("conv-recent".into(), recent);
+        insert("conv-recent", recent);
 
         // ACP + Running + old activity → should NOT be collected
         let running = Arc::new(
             MockAgent::new("conv-running", Some(ConversationStatus::Running)).with_last_activity(now_ms() - 600_000),
         );
-        mgr.tasks.insert("conv-running".into(), running);
+        insert("conv-running", running);
 
         // Non-ACP (Nanobot) + Finished + old activity → should NOT be collected
         let nanobot = Arc::new(
@@ -326,7 +433,7 @@ mod tests {
                 .with_agent_type(AgentType::Nanobot)
                 .with_last_activity(now_ms() - 600_000),
         );
-        mgr.tasks.insert("conv-nanobot".into(), nanobot);
+        insert("conv-nanobot", nanobot);
 
         let idle = mgr.collect_idle(300_000); // 5-min threshold
         assert_eq!(idle.len(), 1);

--- a/crates/aionui-ai-agent/tests/agent_types_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_types_integration.rs
@@ -152,19 +152,23 @@ async fn aionrs_agent_metadata() {
 // Idle scanner: collect_idle only finds ACP tasks
 // ---------------------------------------------------------------------------
 
-#[test]
-fn collect_idle_ignores_non_acp_agent_types() {
+#[tokio::test]
+async fn collect_idle_ignores_non_acp_agent_types() {
+    use futures_util::FutureExt;
     let old_ts = now_ms() - 600_000; // 10 min ago
 
     // Build a factory that creates typed mocks (all finished + old)
     let factory: AgentFactory = Arc::new(move |opts: BuildTaskOptions| {
-        let mock = TypedMockAgent::new(
-            opts.agent_type,
-            &opts.conversation_id,
-            Some(ConversationStatus::Finished),
-        )
-        .with_last_activity(old_ts);
-        Ok(Arc::new(mock) as AgentManagerHandle)
+        async move {
+            let mock = TypedMockAgent::new(
+                opts.agent_type,
+                &opts.conversation_id,
+                Some(ConversationStatus::Finished),
+            )
+            .with_last_activity(old_ts);
+            Ok(Arc::new(mock) as AgentManagerHandle)
+        }
+        .boxed()
     });
     let mgr = WorkerTaskManagerImpl::new(factory);
 
@@ -181,12 +185,16 @@ fn collect_idle_ignores_non_acp_agent_types() {
     };
 
     mgr.get_or_build_task("nanobot-1", make_opts(AgentType::Nanobot, "nanobot-1"))
+        .await
         .unwrap();
     mgr.get_or_build_task("openclaw-1", make_opts(AgentType::OpenclawGateway, "openclaw-1"))
+        .await
         .unwrap();
     mgr.get_or_build_task("acp-1", make_opts(AgentType::Acp, "acp-1"))
+        .await
         .unwrap();
     mgr.get_or_build_task("remote-1", make_opts(AgentType::Remote, "remote-1"))
+        .await
         .unwrap();
 
     assert_eq!(mgr.active_count(), 4);

--- a/crates/aionui-ai-agent/tests/factory_provider_integration.rs
+++ b/crates/aionui-ai-agent/tests/factory_provider_integration.rs
@@ -94,7 +94,7 @@ async fn aionrs_factory_returns_error_for_missing_provider() {
         extra: serde_json::json!({}),
     };
 
-    let result = factory(options);
+    let result = factory(options).await;
     match result {
         Ok(_) => panic!("Expected error for missing provider, got Ok"),
         Err(e) => {
@@ -125,7 +125,7 @@ async fn aionrs_factory_resolves_provider_from_db() {
         extra: serde_json::json!({ "max_tokens": 2048 }),
     };
 
-    let result = factory(options);
+    let result = factory(options).await;
     assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
 }
 
@@ -147,6 +147,6 @@ async fn aionrs_factory_respects_use_model_override() {
         extra: serde_json::json!({}),
     };
 
-    let result = factory(options);
+    let result = factory(options).await;
     assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
 }

--- a/crates/aionui-app/src/guide_stdio.rs
+++ b/crates/aionui-app/src/guide_stdio.rs
@@ -41,9 +41,7 @@ pub async fn run_guide_stdio() -> ExitCode {
     let backend = std::env::var("AION_MCP_BACKEND").unwrap_or_default();
     let conversation_id = std::env::var("AION_MCP_CONVERSATION_ID").unwrap_or_default();
 
-    eprintln!(
-        "[mcp-guide-stdio] Started OK. PORT={port}, BACKEND={backend}, CONV_ID={conversation_id}"
-    );
+    eprintln!("[mcp-guide-stdio] Started OK. PORT={port}, BACKEND={backend}, CONV_ID={conversation_id}");
 
     let server = GuideServer {
         port: port.parse().unwrap_or(0),
@@ -99,26 +97,37 @@ struct ListModelsParams {
     agent_type: Option<String>,
 }
 
-
 #[tool_router(server_handler)]
 impl GuideServer {
-    #[tool(name = "aion_create_team", description = "Create a multi-agent Team. Only call after user explicitly confirms team configuration.")]
+    #[tool(
+        name = "aion_create_team",
+        description = "Create a multi-agent Team. Only call after user explicitly confirms team configuration."
+    )]
     async fn create_team(&self, Parameters(params): Parameters<CreateTeamParams>) -> String {
         eprintln!("[mcp-guide-stdio] tools/call: aion_create_team");
-        self.forward_tool("aion_create_team", &serde_json::json!({
-            "summary": params.summary,
-            "name": params.name,
-            "workspace": params.workspace,
-        }))
+        self.forward_tool(
+            "aion_create_team",
+            &serde_json::json!({
+                "summary": params.summary,
+                "name": params.name,
+                "workspace": params.workspace,
+            }),
+        )
         .await
     }
 
-    #[tool(name = "aion_list_models", description = "Query available models for team agent types. Pass agent_type to filter, or omit to see all.")]
+    #[tool(
+        name = "aion_list_models",
+        description = "Query available models for team agent types. Pass agent_type to filter, or omit to see all."
+    )]
     async fn list_models(&self, Parameters(params): Parameters<ListModelsParams>) -> String {
         eprintln!("[mcp-guide-stdio] tools/call: aion_list_models");
-        self.forward_tool("aion_list_models", &serde_json::json!({
-            "agent_type": params.agent_type,
-        }))
+        self.forward_tool(
+            "aion_list_models",
+            &serde_json::json!({
+                "agent_type": params.agent_type,
+            }),
+        )
         .await
     }
 }
@@ -134,7 +143,8 @@ impl GuideServer {
         });
 
         eprintln!("[mcp-guide-stdio] HTTP POST {url}");
-        match self.http_client
+        match self
+            .http_client
             .post(&url)
             .header("Authorization", format!("Bearer {}", self.token))
             .json(&body)

--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -1,8 +1,8 @@
 //! Application entry point: assembles all crates into an Axum server with DI and middleware.
 pub mod bridge;
 pub mod guide_stdio;
-pub mod team_stdio;
 mod state_builders;
+pub mod team_stdio;
 
 use std::sync::Arc;
 
@@ -20,6 +20,7 @@ use aionui_ai_agent::{
     AuxiliaryRouterState, ConnectionTestRouterState, IWorkerTaskManager, RemoteAgentRouterState, WorkerTaskManagerImpl,
     acp_routes, agent_routes, auxiliary_routes, build_agent_factory, connection_test_routes, remote_agent_routes,
 };
+use aionui_api_types::GuideMcpConfig;
 use aionui_assistant::{AssistantRouterState, assistant_routes};
 use aionui_auth::{
     AuthRouterState, AuthState, CookieConfig, JwtService, QrTokenStore, auth_middleware, auth_routes, csrf_middleware,
@@ -44,7 +45,6 @@ use aionui_realtime::{BroadcastEventBus, WebSocketManager, WsHandlerState, ws_up
 use aionui_shell::{ShellRouterState, shell_routes};
 use aionui_system::{SystemRouterState, system_routes};
 use aionui_team::{GuideMcpServer, TeamRouterState, team_routes};
-use aionui_api_types::GuideMcpConfig;
 
 pub use state_builders::{
     ChannelOrchestratorComponents, build_assistant_state, build_extension_states, build_module_states, build_ws_state,
@@ -373,7 +373,9 @@ pub async fn create_router(services: &AppServices) -> Router {
     let (states, channel_components) = build_module_states(services).await;
 
     // Wire TeamSessionService into Guide MCP server now that both are available.
-    services.inject_guide_service(Arc::downgrade(&states.team.service)).await;
+    services
+        .inject_guide_service(Arc::downgrade(&states.team.service))
+        .await;
 
     // Start channel orchestrator (message loop)
     tokio::spawn(

--- a/crates/aionui-app/src/team_stdio.rs
+++ b/crates/aionui-app/src/team_stdio.rs
@@ -217,7 +217,10 @@ impl TeamStdioServer {
 
     #[tool(name = "team_task_create", description = "Create a new task on the team task board.")]
     async fn task_create(&self, Parameters(params): Parameters<TaskCreateParams>) -> String {
-        eprintln!("[mcp-team-stdio] tools/call: team_task_create subject={}", params.subject);
+        eprintln!(
+            "[mcp-team-stdio] tools/call: team_task_create subject={}",
+            params.subject
+        );
         self.forward_to_tcp(
             "team_task_create",
             &serde_json::json!({
@@ -230,9 +233,15 @@ impl TeamStdioServer {
         .await
     }
 
-    #[tool(name = "team_task_update", description = "Update an existing task on the team task board.")]
+    #[tool(
+        name = "team_task_update",
+        description = "Update an existing task on the team task board."
+    )]
     async fn task_update(&self, Parameters(params): Parameters<TaskUpdateParams>) -> String {
-        eprintln!("[mcp-team-stdio] tools/call: team_task_update task_id={}", params.task_id);
+        eprintln!(
+            "[mcp-team-stdio] tools/call: team_task_update task_id={}",
+            params.task_id
+        );
         self.forward_to_tcp(
             "team_task_update",
             &serde_json::json!({
@@ -252,7 +261,10 @@ impl TeamStdioServer {
         self.forward_to_tcp("team_task_list", &serde_json::json!({})).await
     }
 
-    #[tool(name = "team_members", description = "List all team members with their roles and current status.")]
+    #[tool(
+        name = "team_members",
+        description = "List all team members with their roles and current status."
+    )]
     async fn members(&self) -> String {
         eprintln!("[mcp-team-stdio] tools/call: team_members");
         self.forward_to_tcp("team_members", &serde_json::json!({})).await
@@ -260,7 +272,10 @@ impl TeamStdioServer {
 
     #[tool(name = "team_rename_agent", description = "Rename a team member.")]
     async fn rename_agent(&self, Parameters(params): Parameters<RenameAgentParams>) -> String {
-        eprintln!("[mcp-team-stdio] tools/call: team_rename_agent slot_id={}", params.slot_id);
+        eprintln!(
+            "[mcp-team-stdio] tools/call: team_rename_agent slot_id={}",
+            params.slot_id
+        );
         self.forward_to_tcp(
             "team_rename_agent",
             &serde_json::json!({ "slot_id": params.slot_id, "new_name": params.new_name }),
@@ -273,7 +288,10 @@ impl TeamStdioServer {
         description = "Initiate shutdown of a teammate (Lead only). Sends a shutdown_request to the target agent."
     )]
     async fn shutdown_agent(&self, Parameters(params): Parameters<ShutdownAgentParams>) -> String {
-        eprintln!("[mcp-team-stdio] tools/call: team_shutdown_agent slot_id={}", params.slot_id);
+        eprintln!(
+            "[mcp-team-stdio] tools/call: team_shutdown_agent slot_id={}",
+            params.slot_id
+        );
         self.forward_to_tcp(
             "team_shutdown_agent",
             &serde_json::json!({ "slot_id": params.slot_id, "reason": params.reason }),
@@ -287,8 +305,11 @@ impl TeamStdioServer {
     )]
     async fn list_models(&self, Parameters(params): Parameters<ListModelsParams>) -> String {
         eprintln!("[mcp-team-stdio] tools/call: team_list_models");
-        self.forward_to_tcp("team_list_models", &serde_json::json!({ "agent_type": params.agent_type }))
-            .await
+        self.forward_to_tcp(
+            "team_list_models",
+            &serde_json::json!({ "agent_type": params.agent_type }),
+        )
+        .await
     }
 
     #[tool(
@@ -296,7 +317,10 @@ impl TeamStdioServer {
         description = "Get detailed information about a preset assistant before spawning it as a teammate.\n\nReturns the preset's full description, enabled skills, and example tasks so you can\njudge whether it fits the user's request. Use this when two or more presets look\nrelevant from the one-line catalog in your system prompt.\n\nOnly works on preset assistants listed in \"Available Preset Assistants for Spawning\".\nAfter confirming a match, call team_spawn_agent with the same custom_agent_id."
     )]
     async fn describe_assistant(&self, Parameters(params): Parameters<DescribeAssistantParams>) -> String {
-        eprintln!("[mcp-team-stdio] tools/call: team_describe_assistant id={}", params.custom_agent_id);
+        eprintln!(
+            "[mcp-team-stdio] tools/call: team_describe_assistant id={}",
+            params.custom_agent_id
+        );
         self.forward_to_tcp(
             "team_describe_assistant",
             &serde_json::json!({ "custom_agent_id": params.custom_agent_id }),

--- a/crates/aionui-app/tests/agent_integration_e2e.rs
+++ b/crates/aionui-app/tests/agent_integration_e2e.rs
@@ -136,12 +136,13 @@ impl MockTaskManager {
     }
 }
 
+#[async_trait::async_trait]
 impl IWorkerTaskManager for MockTaskManager {
     fn get_task(&self, conversation_id: &str) -> Option<AgentManagerHandle> {
         self.agents.lock().unwrap().get(conversation_id).cloned()
     }
 
-    fn get_or_build_task(
+    async fn get_or_build_task(
         &self,
         conversation_id: &str,
         _options: BuildTaskOptions,

--- a/crates/aionui-app/tests/team_smoke_e2e.rs
+++ b/crates/aionui-app/tests/team_smoke_e2e.rs
@@ -201,23 +201,27 @@ impl IAgentManager for MockAgentManager {
 /// Every conversation gets a `MockAgentManager` wired to whatever
 /// `team_mcp_stdio_config` was persisted for it.
 fn mock_factory() -> AgentFactory {
+    use futures_util::FutureExt;
     Arc::new(|opts: BuildTaskOptions| {
-        let extra: AcpBuildExtra = serde_json::from_value(opts.extra.clone()).unwrap_or_else(|_| AcpBuildExtra {
-            agent_id: None,
-            backend: None,
-            cli_path: None,
-            agent_name: None,
-            custom_agent_id: None,
-            preset_context: None,
-            skills: vec![],
-            preset_assistant_id: None,
-            session_mode: None,
-            cron_job_id: None,
-            team_mcp_stdio_config: None,
-            guide_mcp_config: None,
-        });
-        let agent = MockAgentManager::new(opts.conversation_id, opts.workspace, extra.team_mcp_stdio_config);
-        Ok(Arc::new(agent) as aionui_ai_agent::AgentManagerHandle)
+        async move {
+            let extra: AcpBuildExtra = serde_json::from_value(opts.extra.clone()).unwrap_or_else(|_| AcpBuildExtra {
+                agent_id: None,
+                backend: None,
+                cli_path: None,
+                agent_name: None,
+                custom_agent_id: None,
+                preset_context: None,
+                skills: vec![],
+                preset_assistant_id: None,
+                session_mode: None,
+                cron_job_id: None,
+                team_mcp_stdio_config: None,
+                guide_mcp_config: None,
+            });
+            let agent = MockAgentManager::new(opts.conversation_id, opts.workspace, extra.team_mcp_stdio_config);
+            Ok(Arc::new(agent) as aionui_ai_agent::AgentManagerHandle)
+        }
+        .boxed()
     })
 }
 

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -962,7 +962,7 @@ impl ConversationService {
         // Build task options from conversation row
         let build_opts = self.build_task_options(&row)?;
         let stored_workspace = build_opts.workspace.clone();
-        let agent = task_manager.get_or_build_task(conversation_id, build_opts)?;
+        let agent = task_manager.get_or_build_task(conversation_id, build_opts).await?;
 
         // If the factory resolved a different workspace (e.g. auto-created temp
         // dir for a legacy conversation with empty workspace), persist it back.
@@ -1137,7 +1137,7 @@ impl ConversationService {
 
         let build_opts = self.build_task_options(&row)?;
         let stored_workspace = build_opts.workspace.clone();
-        let agent = task_manager.get_or_build_task(conversation_id, build_opts)?;
+        let agent = task_manager.get_or_build_task(conversation_id, build_opts).await?;
 
         // Persist auto-resolved workspace if factory picked a different path.
         self.maybe_persist_workspace(conversation_id, &stored_workspace, agent.workspace())

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -1077,8 +1077,8 @@ impl ConversationService {
         self.repo.insert_message(row).await?;
 
         let msg_id = row.msg_id.clone().unwrap_or_else(|| row.id.clone());
-        let content_value: serde_json::Value = serde_json::from_str(&row.content)
-            .unwrap_or_else(|_| serde_json::Value::String(row.content.clone()));
+        let content_value: serde_json::Value =
+            serde_json::from_str(&row.content).unwrap_or_else(|_| serde_json::Value::String(row.content.clone()));
         let payload = serde_json::json!({
             "conversation_id": row.conversation_id,
             "msg_id": msg_id,

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1287,12 +1287,13 @@ impl MockTaskManager {
     }
 }
 
+#[async_trait::async_trait]
 impl IWorkerTaskManager for MockTaskManager {
     fn get_task(&self, conversation_id: &str) -> Option<AgentManagerHandle> {
         self.agents.lock().unwrap().get(conversation_id).cloned()
     }
 
-    fn get_or_build_task(
+    async fn get_or_build_task(
         &self,
         conversation_id: &str,
         _options: BuildTaskOptions,
@@ -1339,12 +1340,13 @@ impl MockTaskManagerWithWorkspace {
     }
 }
 
+#[async_trait::async_trait]
 impl IWorkerTaskManager for MockTaskManagerWithWorkspace {
     fn get_task(&self, conversation_id: &str) -> Option<AgentManagerHandle> {
         self.agents.lock().unwrap().get(conversation_id).cloned()
     }
 
-    fn get_or_build_task(
+    async fn get_or_build_task(
         &self,
         conversation_id: &str,
         _options: BuildTaskOptions,

--- a/crates/aionui-conversation/tests/conversation_crud.rs
+++ b/crates/aionui-conversation/tests/conversation_crud.rs
@@ -38,11 +38,12 @@ impl EventBroadcaster for TestBroadcaster {
 
 struct NoopTaskManager;
 
+#[async_trait::async_trait]
 impl IWorkerTaskManager for NoopTaskManager {
     fn get_task(&self, _: &str) -> Option<Arc<dyn aionui_ai_agent::agent_manager::IAgentManager>> {
         None
     }
-    fn get_or_build_task(
+    async fn get_or_build_task(
         &self,
         _: &str,
         _: aionui_ai_agent::types::BuildTaskOptions,

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -489,7 +489,7 @@ impl JobExecutor {
             extra: build_extra,
         };
 
-        let agent = match self.task_manager.get_or_build_task(conversation_id, options) {
+        let agent = match self.task_manager.get_or_build_task(conversation_id, options).await {
             Ok(handle) => handle,
             Err(e) => {
                 error!(
@@ -1850,11 +1850,12 @@ mod tests {
 
     fn make_executor_for_busy_tests(guard: Arc<CronBusyGuard>) -> JobExecutor {
         struct StubTaskManager;
+        #[async_trait::async_trait]
         impl IWorkerTaskManager for StubTaskManager {
             fn get_task(&self, _: &str) -> Option<AgentManagerHandle> {
                 None
             }
-            fn get_or_build_task(
+            async fn get_or_build_task(
                 &self,
                 _: &str,
                 _: BuildTaskOptions,
@@ -2147,12 +2148,13 @@ mod tests {
         agent: AgentManagerHandle,
     }
 
+    #[async_trait::async_trait]
     impl IWorkerTaskManager for FixedTaskManager {
         fn get_task(&self, _conversation_id: &str) -> Option<AgentManagerHandle> {
             Some(Arc::clone(&self.agent))
         }
 
-        fn get_or_build_task(
+        async fn get_or_build_task(
             &self,
             _conversation_id: &str,
             _options: BuildTaskOptions,
@@ -2201,12 +2203,13 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl IWorkerTaskManager for RecordingTaskManager {
         fn get_task(&self, _conversation_id: &str) -> Option<AgentManagerHandle> {
             Some(Arc::clone(&self.agent))
         }
 
-        fn get_or_build_task(
+        async fn get_or_build_task(
             &self,
             _conversation_id: &str,
             options: BuildTaskOptions,

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -62,11 +62,16 @@ impl EventBroadcaster for MockBroadcaster {
 
 struct StubTaskManager;
 
+#[async_trait::async_trait]
 impl aionui_ai_agent::task_manager::IWorkerTaskManager for StubTaskManager {
     fn get_task(&self, _: &str) -> Option<AgentManagerHandle> {
         None
     }
-    fn get_or_build_task(&self, _: &str, _: BuildTaskOptions) -> Result<AgentManagerHandle, aionui_common::AppError> {
+    async fn get_or_build_task(
+        &self,
+        _: &str,
+        _: BuildTaskOptions,
+    ) -> Result<AgentManagerHandle, aionui_common::AppError> {
         Err(aionui_common::AppError::Internal("stub".into()))
     }
     fn kill(&self, _: &str, _: Option<aionui_common::AgentKillReason>) -> Result<(), aionui_common::AppError> {

--- a/crates/aionui-extension/src/manifest.rs
+++ b/crates/aionui-extension/src/manifest.rs
@@ -239,10 +239,10 @@ fn normalize_mcp_server(value: &mut Value) {
         return;
     };
 
-    if !obj.contains_key("id") {
-        if let Some(Value::String(name)) = obj.get("name") {
-            obj.insert("id".into(), Value::String(name.clone()));
-        }
+    if !obj.contains_key("id")
+        && let Some(Value::String(name)) = obj.get("name")
+    {
+        obj.insert("id".into(), Value::String(name.clone()));
     }
 }
 
@@ -374,13 +374,7 @@ fn normalize_webui(value: &mut Value) {
             .get("urlPrefix")
             .or_else(|| asset_obj.get("url_prefix"))
             .and_then(Value::as_str)
-            .map(|prefix| {
-                prefix
-                    .trim_matches('/')
-                    .replace('/', "-")
-                    .replace('.', "-")
-                    .replace('_', "-")
-            })
+            .map(|prefix| prefix.trim_matches('/').replace(['/', '.', '_'], "-"))
             .filter(|value| !value.is_empty())
             .unwrap_or_else(|| format!("legacy-webui-assets-{index}"));
 

--- a/crates/aionui-team/Cargo.toml
+++ b/crates/aionui-team/Cargo.toml
@@ -25,3 +25,4 @@ agent-client-protocol = "0.11.1"
 [dev-dependencies]
 sqlx.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
+futures-util.workspace = true

--- a/crates/aionui-team/src/guide/server.rs
+++ b/crates/aionui-team/src/guide/server.rs
@@ -29,7 +29,12 @@ impl GuideMcpServer {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let service_slot: Arc<RwLock<Weak<TeamSessionService>>> = Arc::new(RwLock::new(Weak::new()));
 
-        tokio::spawn(accept_loop(listener, auth_token.clone(), shutdown_rx, service_slot.clone()));
+        tokio::spawn(accept_loop(
+            listener,
+            auth_token.clone(),
+            shutdown_rx,
+            service_slot.clone(),
+        ));
 
         debug!(http_port = http_addr.port(), "Guide MCP Server started");
 
@@ -78,8 +83,8 @@ async fn handle_aion_create_team(
     args: &serde_json::Value,
     service: Arc<RwLock<Weak<TeamSessionService>>>,
 ) -> serde_json::Value {
-    use aionui_api_types::{CreateTeamRequest, TeamAgentInput};
     use crate::guide::handlers::parse_create_team_args;
+    use aionui_api_types::{CreateTeamRequest, TeamAgentInput};
 
     let svc = match service.read().await.upgrade() {
         Some(s) => s,

--- a/crates/aionui-team/src/mcp/server.rs
+++ b/crates/aionui-team/src/mcp/server.rs
@@ -395,7 +395,9 @@ async fn handle_tools_call(
 
     match &result {
         Ok(_) => info!(team_id = %team_id, tool = %tool_name, caller = %caller_slot_id, "MCP tool call succeeded"),
-        Err(e) => warn!(team_id = %team_id, tool = %tool_name, caller = %caller_slot_id, error = %e, "MCP tool call failed"),
+        Err(e) => {
+            warn!(team_id = %team_id, tool = %tool_name, caller = %caller_slot_id, error = %e, "MCP tool call failed")
+        }
     }
 
     match result {
@@ -494,7 +496,10 @@ async fn exec_send_message(
     // Wake target agent(s) so they process the new mailbox message.
     if let Some(svc) = service.upgrade() {
         let targets = if input.to == "*" {
-            scheduler.list_agents().await.iter()
+            scheduler
+                .list_agents()
+                .await
+                .iter()
                 .filter(|a| a.slot_id != caller_slot_id)
                 .map(|a| a.slot_id.clone())
                 .collect::<Vec<_>>()

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -662,15 +662,14 @@ impl TeamSessionService {
         };
 
         // Ensure the agent task exists (mirrors AionUi's getOrBuildTask).
-        if self.task_manager.get_task(&conv_id).is_none() {
-            if let Err(e) = self
+        if self.task_manager.get_task(&conv_id).is_none()
+            && let Err(e) = self
                 .conversation_service
                 .warmup(&user_id, &conv_id, &self.task_manager)
                 .await
-            {
-                warn!(team_id, slot_id, conversation_id = %conv_id, error = %e, "warmup in wake failed");
-                return Ok(());
-            }
+        {
+            warn!(team_id, slot_id, conversation_id = %conv_id, error = %e, "warmup in wake failed");
+            return Ok(());
         }
 
         let task_mgr = self.task_manager.clone();

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -530,7 +530,9 @@ impl TeamSessionService {
                 return Err(TeamError::InvalidRequest(msg));
             }
 
-            let _ = self.task_manager.kill(&agent.conversation_id, Some(AgentKillReason::TeamMcpRebuild));
+            let _ = self
+                .task_manager
+                .kill(&agent.conversation_id, Some(AgentKillReason::TeamMcpRebuild));
 
             if let Err(e) = self
                 .conversation_service
@@ -638,7 +640,11 @@ impl TeamSessionService {
             .sessions
             .get(team_id)
             .ok_or_else(|| TeamError::SessionNotFound(team_id.into()))?;
-        entry.session.scheduler().set_status(slot_id, crate::types::TeammateStatus::Working).await?;
+        entry
+            .session
+            .scheduler()
+            .set_status(slot_id, crate::types::TeammateStatus::Working)
+            .await?;
         let input = entry.session.compute_wake_input(slot_id).await;
 
         if let Ok(Some(ref i)) = input
@@ -673,7 +679,9 @@ impl TeamSessionService {
                 Ok(Some(i)) if i.should_send => i,
                 _ => return,
             };
-            let Some(handle) = task_mgr.get_task(&input.conversation_id) else { return };
+            let Some(handle) = task_mgr.get_task(&input.conversation_id) else {
+                return;
+            };
             let data = aionui_ai_agent::SendMessageData {
                 content: input.first_message,
                 msg_id: aionui_common::generate_id(),

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -420,7 +420,9 @@ impl TeamSession {
                 continue;
             }
             let sender = agents.iter().find(|a| a.slot_id == msg.from_agent_id);
-            let sender_name = sender.map(|a| a.name.clone()).unwrap_or_else(|| msg.from_agent_id.clone());
+            let sender_name = sender
+                .map(|a| a.name.clone())
+                .unwrap_or_else(|| msg.from_agent_id.clone());
             let sender_backend = sender.map(|a| a.backend.clone());
             let sender_conv_id = sender.map(|a| a.conversation_id.clone());
             let display_content = if total > 1 {
@@ -1239,7 +1241,14 @@ mod tests {
         let session = start_session().await;
         session
             .mailbox
-            .write("t1", "worker-1", "lead-1", MailboxMessageType::Message, "from lead", None)
+            .write(
+                "t1",
+                "worker-1",
+                "lead-1",
+                MailboxMessageType::Message,
+                "from lead",
+                None,
+            )
             .await
             .unwrap();
         session
@@ -1282,7 +1291,14 @@ mod tests {
         let session = start_session().await;
         session
             .mailbox
-            .write("t1", "lead-1", "worker-1", MailboxMessageType::Message, "lead-gets-this", None)
+            .write(
+                "t1",
+                "lead-1",
+                "worker-1",
+                MailboxMessageType::Message,
+                "lead-gets-this",
+                None,
+            )
             .await
             .unwrap();
 

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -823,11 +823,12 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl IWorkerTaskManager for StubTaskManager {
         fn get_task(&self, conversation_id: &str) -> Option<AgentManagerHandle> {
             self.tasks.lock().unwrap().get(conversation_id).cloned()
         }
-        fn get_or_build_task(
+        async fn get_or_build_task(
             &self,
             _conversation_id: &str,
             _options: BuildTaskOptions,

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -338,21 +338,20 @@ impl TeamSession {
             h
         } else {
             // Task missing — warmup to create it (mirrors AionUi's getOrBuildTask).
-            if let Some(svc) = self.service.upgrade() {
-                if let Err(e) = svc
+            if let Some(svc) = self.service.upgrade()
+                && let Err(e) = svc
                     .conversation_service_ref()
                     .warmup(&self.user_id, &input.conversation_id, &self.task_manager)
                     .await
-                {
-                    warn!(
-                        team_id = %self.team.id,
-                        slot_id,
-                        conversation_id = %input.conversation_id,
-                        error = %e,
-                        "warmup in try_wake failed; skipping wake"
-                    );
-                    return;
-                }
+            {
+                warn!(
+                    team_id = %self.team.id,
+                    slot_id,
+                    conversation_id = %input.conversation_id,
+                    error = %e,
+                    "warmup in try_wake failed; skipping wake"
+                );
+                return;
             }
             let Some(h) = self.task_manager.get_task(&input.conversation_id) else {
                 warn!(

--- a/crates/aionui-team/tests/prompts_events_integration.rs
+++ b/crates/aionui-team/tests/prompts_events_integration.rs
@@ -115,7 +115,10 @@ fn lp2_lead_prompt_contains_tool_descriptions() {
 fn lp3_lead_prompt_contains_task_management_guidance() {
     let prompt = build_lead_prompt("Gamma", &[], &default_agent_types());
 
-    assert!(prompt.contains("Break the work into tasks"), "missing decompose guidance");
+    assert!(
+        prompt.contains("Break the work into tasks"),
+        "missing decompose guidance"
+    );
     assert!(prompt.contains("Assign tasks"), "missing assign guidance");
     assert!(prompt.contains("dependency"), "missing dependency guidance");
     assert!(

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -410,17 +410,18 @@ impl CountingTaskManager {
     }
 }
 
+#[async_trait::async_trait]
 impl IWorkerTaskManager for CountingTaskManager {
     fn get_task(&self, conversation_id: &str) -> Option<aionui_ai_agent::AgentManagerHandle> {
         self.inner.get_task(conversation_id)
     }
-    fn get_or_build_task(
+    async fn get_or_build_task(
         &self,
         conversation_id: &str,
         options: BuildTaskOptions,
     ) -> Result<aionui_ai_agent::AgentManagerHandle, AppError> {
         self.calls.lock().unwrap().build.push(conversation_id.to_owned());
-        self.inner.get_or_build_task(conversation_id, options)
+        self.inner.get_or_build_task(conversation_id, options).await
     }
     fn kill(&self, conversation_id: &str, reason: Option<AgentKillReason>) -> Result<(), AppError> {
         self.calls
@@ -519,11 +520,15 @@ mod mock_agent {
 }
 
 fn success_factory() -> AgentFactory {
+    use futures_util::FutureExt;
     Arc::new(|opts: BuildTaskOptions| {
-        Ok(
-            Arc::new(mock_agent::MockAgent::new(opts.conversation_id, opts.workspace))
-                as aionui_ai_agent::AgentManagerHandle,
-        )
+        async move {
+            Ok(
+                Arc::new(mock_agent::MockAgent::new(opts.conversation_id, opts.workspace))
+                    as aionui_ai_agent::AgentManagerHandle,
+            )
+        }
+        .boxed()
     })
 }
 
@@ -1268,21 +1273,25 @@ async fn d9_ensure_session_persists_team_mcp_stdio_config() {
     // Each agent's conversation.extra must carry a `team_mcp_stdio_config`
     // object by the time the factory is called — that is what the rebuilt
     // ACP process will read to reach the MCP server.
+    use futures_util::FutureExt;
     let (svc, _tm) = setup_with_factory(Arc::new(|opts: BuildTaskOptions| {
-        let extra_has_cfg = opts
-            .extra
-            .get("team_mcp_stdio_config")
-            .and_then(|v| v.as_object())
-            .is_some_and(|o| o.contains_key("port") && o.contains_key("slot_id"));
-        assert!(
-            extra_has_cfg,
-            "factory called without team_mcp_stdio_config in extra: {:?}",
-            opts.extra
-        );
-        Ok(
-            Arc::new(mock_agent::MockAgent::new(opts.conversation_id, opts.workspace))
-                as aionui_ai_agent::AgentManagerHandle,
-        )
+        async move {
+            let extra_has_cfg = opts
+                .extra
+                .get("team_mcp_stdio_config")
+                .and_then(|v| v.as_object())
+                .is_some_and(|o| o.contains_key("port") && o.contains_key("slot_id"));
+            assert!(
+                extra_has_cfg,
+                "factory called without team_mcp_stdio_config in extra: {:?}",
+                opts.extra
+            );
+            Ok(
+                Arc::new(mock_agent::MockAgent::new(opts.conversation_id, opts.workspace))
+                    as aionui_ai_agent::AgentManagerHandle,
+            )
+        }
+        .boxed()
     }));
 
     let created = svc
@@ -1326,8 +1335,10 @@ async fn d9_ensure_session_is_idempotent() {
 async fn d9_ensure_session_rollbacks_when_build_fails() {
     // Factory always fails → ensure_session must propagate error and not
     // insert into sessions, so send_message afterwards still errors.
-    let failing_factory: AgentFactory =
-        Arc::new(|_opts: BuildTaskOptions| Err(AppError::Internal("simulated build failure".into())));
+    use futures_util::FutureExt;
+    let failing_factory: AgentFactory = Arc::new(|_opts: BuildTaskOptions| {
+        async move { Err(AppError::Internal("simulated build failure".into())) }.boxed()
+    });
     let (svc, tm) = setup_with_factory(failing_factory);
     let created = svc
         .create_team(

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 
 # Build in release mode and install to ~/.cargo/bin
 # Use `just build --force` to skip cache check
-build *FLAGS: lint fmt
+build *FLAGS: lint-fix fmt
     #!/usr/bin/env bash
     set -euo pipefail
     cargo build --release
@@ -59,6 +59,9 @@ test:
 # Lint (warnings = errors)
 lint:
     cargo clippy --workspace -- -D warnings
+
+lint-fix:
+    cargo clippy --workspace --fix --allow-dirty --allow-staged
 
 # Format code
 fmt:


### PR DESCRIPTION
## Summary

- **`fix(ai-agent): unblock ACP dispatch loop during streaming prompts`** — Spawn `session/prompt` on a dedicated SDK task so the dispatch loop keeps servicing commands while the turn streams. Previously `session/cancel` couldn't interrupt a live turn because it was queued behind the awaited prompt response.
- **`refactor(ai-agent): simplify ACP concurrency and serialize task builds`** — Drop the custom `AcpProtocol` command channel + dispatch loop; hold `ConnectionTo<Agent>` directly and call `send_request` / `send_notification` per the SDK's documented concurrency model. Use a oneshot shutdown signal + Drop to tear down the SDK `main_fn` cleanly.
- **`refactor(ai-agent): async single-flight task builds`** — Make `AgentFactory` and `IWorkerTaskManager::get_or_build_task` async (`BoxFuture`) so factories can await CLI spawns and ACP handshakes directly (drops the scoped-thread + `block_on` bridge). Serialize concurrent builds per `conversation_id` via `Arc<OnceCell<AgentManagerHandle>>`, preventing duplicate CLI processes when two requests race on the same conversation; failed builds leave the slot empty so later callers can retry. Rename `AcpState::has_messages` to `session_opened` with clearer semantics: tracks whether this `AcpAgentManager` instance has opened the CLI session (so `restore_session_id` leaves it false, forcing a resume handshake on the next prompt after rebuild).
- **`chore: apply cargo fmt + clippy --fix across upstream-merged code`** — Format gate and clippy lints weren't enforced on recent `origin/main` merges, leaving 20+ fmt violations and several clippy suggestions (nested if-let → let-chain, `map_or(false, ..)` → `is_some_and(..)`, chained `.replace` → `.replace([...])`).

## Notes

- Updates all `IWorkerTaskManager` implementors, factory call sites, and tests for the new async signature; adds single-flight + retry-after-failure tests.
- The fmt/clippy commit is a pure cleanup of code that landed via other PRs without fmt/clippy enforcement — no behavior change.

## Test plan

- [x] `cargo check -p aionui-app --tests` green
- [x] `cargo test -p aionui-ai-agent -p aionui-team -p aionui-conversation` passes (3 pre-existing failures in `types::tests::acp_build_extra_parses_team_mcp_stdio_config` et al. are inherited from `origin/main` 3f8886b — `TeamMcpStdioConfig` gained a required `binary_path` field but the test fixtures weren't updated)
- [ ] Solo conversation: streaming prompt + cancel mid-stream (verify cancel unblocks the turn)
- [ ] Concurrent `/messages` + `/warmup` on the same conversation (verify only one CLI spawns)
- [ ] Team session restore: task rebuild preserves context via session/new + resume