### PR TITLE
fix(acp): re-apply preferred mode on session resume

### DIFF
--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -940,6 +940,19 @@ impl AcpAgentManager {
                 state.session_id = Some(new_sid.clone());
                 drop(state);
 
+                // Re-apply the user's preferred mode: the CLI resets
+                // `currentModeId` to its own default on every resume
+                // handshake (Claude meta-resume rebuilds the session), so
+                // without this the mode the user had set (e.g.
+                // `bypassPermissions`) silently downgrades to `default`
+                // and the CLI starts prompting for permissions again.
+                if let Err(e) = self.apply_preferred_mode(&new_sid).await {
+                    tracing::error!(
+                        conversation_id = %self.conversation_id,
+                        error = %e,
+                        "failed to re-apply preferred mode after meta-resume"
+                    );
+                }
                 self.apply_preferred_config_selections(&new_sid).await;
                 return self.prompt_existing_session(data, Some(&new_sid)).await;
             }
@@ -982,6 +995,17 @@ impl AcpAgentManager {
         self.emit_snapshot_events().await;
 
         if let Some(sid) = session_id {
+            // Same reasoning as the Claude meta-resume branch above:
+            // `session/load` returns the CLI's own `currentModeId`
+            // (usually `default`), so re-apply the user's preferred
+            // mode before prompting.
+            if let Err(e) = self.apply_preferred_mode(sid).await {
+                tracing::error!(
+                    conversation_id = %self.conversation_id,
+                    error = %e,
+                    "failed to re-apply preferred mode after session/load"
+                );
+            }
             self.apply_preferred_config_selections(sid).await;
         }
 


### PR DESCRIPTION
## Summary

- After `session/load` (Codex etc.) or the Claude meta-resume handshake, the CLI resets `currentModeId` to its own default, so a user who had selected `bypassPermissions` silently dropped back to `default` on every turn after a task rebuild — causing the CLI to start prompting for permissions again.
- `session_resume_and_send` already re-applied `config_options` but not the session mode. Added `apply_preferred_mode` calls right after both resume branches, mirroring the existing `session_new_and_prompt` path. Failures log but do not block the prompt.

## Test plan

- [ ] `cargo test -p aionui-ai-agent --lib` passes (pre-existing failures unrelated to this change)
- [ ] `cargo clippy -p aionui-ai-agent -- -D warnings` clean
- [ ] Manual: new Claude conversation with mode set to `bypassPermissions`, send first message → observe `session/set_mode → bypassPermissions` in logs; send second message → resume path triggers `session/new` with `_meta.claudeCode.options.resume`, followed by another `session/set_mode → bypassPermissions`; CLI should not emit `session/request_permission` for Write / MCP tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)