### PR TITLE
test(ai-agent): add user_id field to AgentOptions in tests

### DIFF
--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -66,6 +66,7 @@ async fn make_mock_agent(script: &str, backend: &str) -> (Arc<AcpAgentManager>, 
         cron_job_id: None,
         team_mcp_stdio_config: None,
         guide_mcp_config: None,
+        user_id: None,
     };
 
     let tmp_skills = tempfile::TempDir::new().unwrap();

--- a/crates/aionui-app/tests/team_smoke_e2e.rs
+++ b/crates/aionui-app/tests/team_smoke_e2e.rs
@@ -217,6 +217,7 @@ fn mock_factory() -> AgentFactory {
                 cron_job_id: None,
                 team_mcp_stdio_config: None,
                 guide_mcp_config: None,
+                user_id: None,
             });
             let agent = MockAgentManager::new(opts.conversation_id, opts.workspace, extra.team_mcp_stdio_config);
             Ok(Arc::new(agent) as aionui_ai_agent::AgentManagerHandle)


### PR DESCRIPTION
## Summary
- 在测试文件中为 `AgentOptions` 结构体添加 `user_id: None` 字段初始化
- 修复了由于 `AgentOptions` 结构体新增 `user_id` 字段导致的测试编译错误

## Test plan
- [x] 运行 `cargo test -p aionui-ai-agent` 确保 acp_agent_integration 测试通过
- [x] 运行 `cargo test -p aionui-app` 确保 team_smoke_e2e 测试通过
- [x] 运行 `cargo clippy --workspace` 确保无警告
