### PR TITLE
refactor(ai-agent): move BuildExtra types to aionui-api-types

### DIFF
--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -11,13 +11,14 @@ use crate::stream_event::{
     permission_request_to_event_data,
 };
 use crate::team_guide_prompt;
-use crate::types::{AcpBuildExtra, AgentStreamChunk, SendMessageData, SlashCommandItem};
+use crate::types::{AgentStreamChunk, SendMessageData};
 use agent_client_protocol::schema::{
     AgentCapabilities, AvailableCommand, CancelNotification, ContentBlock, EnvVariable, LoadSessionRequest, McpServer,
     McpServerStdio, NewSessionRequest, PromptRequest, SessionConfigKind, SessionConfigOption, SessionId,
     SessionModeState, SessionModelState, SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest,
     UsageUpdate,
 };
+use aionui_api_types::{AcpBuildExtra, SlashCommandItem};
 use aionui_api_types::{AgentHandshake, AgentMetadata};
 use aionui_api_types::{GuideMcpConfig, TeamMcpStdioConfig};
 use aionui_common::{

--- a/crates/aionui-ai-agent/src/acp_routes.rs
+++ b/crates/aionui-ai-agent/src/acp_routes.rs
@@ -15,7 +15,7 @@ use aionui_common::AppError;
 use crate::acp_agent_service;
 use crate::agent_registry::AgentRegistry;
 use crate::task_manager::IWorkerTaskManager;
-use crate::types::AcpModelInfo;
+use aionui_api_types::AcpModelInfo;
 
 /// Router state for ACP management routes.
 #[derive(Clone)]

--- a/crates/aionui-ai-agent/src/auxiliary_routes.rs
+++ b/crates/aionui-ai-agent/src/auxiliary_routes.rs
@@ -10,12 +10,11 @@ use crate::acp_agent::AcpAgentManager;
 use crate::agent_manager::AgentManagerHandle;
 use crate::openclaw::OpenClawAgentManager;
 use crate::task_manager::IWorkerTaskManager;
-use crate::types::SlashCommandItem;
 use agent_client_protocol::schema::{AgentCapabilities, SessionConfigOption, UsageUpdate};
 use aionui_api_types::{
     AgentModeResponse, ApiResponse, GetModelInfoResponse, ModelInfoEntry, ModelInfoPayload, SetConfigOptionRequest,
     SetConfigOptionsRequest, SetModeRequest, SetModelRequest, SideQuestionRequest, SideQuestionResponse,
-    WorkspaceBrowseQuery, WorkspaceEntry,
+    SlashCommandItem, WorkspaceBrowseQuery, WorkspaceEntry,
 };
 use aionui_auth::CurrentUser;
 use aionui_common::{AgentType, AppError};

--- a/crates/aionui-ai-agent/src/factory.rs
+++ b/crates/aionui-ai-agent/src/factory.rs
@@ -1,5 +1,5 @@
 use aion_agent::session::SessionManager;
-use aionui_api_types::GuideMcpConfig;
+use aionui_api_types::{AcpBuildExtra, AionrsBuildExtra, GuideMcpConfig, OpenClawBuildExtra, RemoteBuildExtra};
 use aionui_common::{AgentType, AppError, CommandSpec};
 use aionui_db::{IProviderRepository, IRemoteAgentRepository};
 use futures_util::FutureExt;
@@ -13,10 +13,7 @@ use crate::agent_registry::AgentRegistry;
 use crate::manager::remote::RemoteAgentConfig;
 use crate::skill_manager::AcpSkillManager;
 use crate::task_manager::AgentFactory;
-use crate::types::{
-    AcpBuildExtra, AionrsBuildExtra, AionrsCompatOverrides, AionrsResolvedConfig, BuildTaskOptions, OpenClawBuildExtra,
-    RemoteBuildExtra,
-};
+use crate::types::{AionrsCompatOverrides, AionrsResolvedConfig, BuildTaskOptions};
 use crate::{AcpAgentManager, AionrsAgentManager, NanobotAgentManager, OpenClawAgentManager, RemoteAgentManager};
 
 /// Dependencies needed by the agent factory to construct agents.

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -32,6 +32,10 @@ pub use agent_manager::{AgentManagerHandle, IAgentManager, approval_key};
 pub use agent_registry::AgentRegistry;
 pub use agent_routes::{AgentRouterState, agent_routes};
 pub use aionrs_agent::AionrsAgentManager;
+pub use aionui_api_types::{
+    AcpBuildExtra, AcpModelInfo, AcpSessionConfigOption, AionrsBuildExtra, OpenClawBuildExtra, OpenClawGatewayConfig,
+    RemoteBuildExtra, SlashCommandItem,
+};
 pub use auxiliary_routes::{AuxiliaryRouterState, auxiliary_routes};
 pub use backend_output_sink::BackendOutputSink;
 pub use backend_protocol_sink::BackendProtocolSink;
@@ -50,8 +54,4 @@ pub use skill_manager::{
 };
 pub use stream_event::AgentStreamEvent;
 pub use task_manager::{AgentFactory, IWorkerTaskManager, WorkerTaskManagerImpl};
-pub use types::{
-    AcpBuildExtra, AcpModelInfo, AcpSessionConfigOption, AgentStreamChunk, AionrsBuildExtra, AionrsCompatOverrides,
-    AionrsResolvedConfig, BuildTaskOptions, OpenClawBuildExtra, OpenClawGatewayConfig, RemoteBuildExtra,
-    SendMessageData, SlashCommandItem,
-};
+pub use types::{AgentStreamChunk, AionrsCompatOverrides, AionrsResolvedConfig, BuildTaskOptions, SendMessageData};

--- a/crates/aionui-ai-agent/src/openclaw/agent.rs
+++ b/crates/aionui-ai-agent/src/openclaw/agent.rs
@@ -11,7 +11,8 @@ use tracing::{debug, error, info, warn};
 use crate::agent_manager::{IAgentManager, approval_key};
 use crate::cli_process::CliAgentProcess;
 use crate::stream_event::AgentStreamEvent;
-use crate::types::{OpenClawBuildExtra, OpenClawGatewayConfig, SendMessageData};
+use crate::types::SendMessageData;
+use aionui_api_types::{OpenClawBuildExtra, OpenClawGatewayConfig};
 
 use super::config::load_openclaw_config;
 use super::connection::{AuthConfig, OpenClawConnection};

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-use aionui_api_types::{GuideMcpConfig, TeamMcpStdioConfig};
 use aionui_common::{AgentType, ProviderWithModel};
 
 /// Data payload for sending a user message to an Agent.
@@ -36,130 +35,7 @@ pub struct BuildTaskOptions {
     pub extra: serde_json::Value,
 }
 
-/// ACP-specific fields extracted from `extra` in [`BuildTaskOptions`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AcpBuildExtra {
-    /// Agent registry ID. When provided, `backend`/`cli_path` are resolved
-    /// from the registry and need not be supplied by the caller.
-    #[serde(default)]
-    pub agent_id: Option<String>,
-    /// Vendor label (e.g. "claude"). When present without `agent_id`, the
-    /// factory looks up the first builtin row matching this label.
-    #[serde(default)]
-    pub backend: Option<String>,
-    /// Path to the CLI executable (resolved from registry when `agent_id` is set).
-    #[serde(default)]
-    pub cli_path: Option<String>,
-    /// Agent name within the ACP backend.
-    #[serde(default)]
-    pub agent_name: Option<String>,
-    /// Custom agent ID (for user-defined agents).
-    #[serde(default)]
-    pub custom_agent_id: Option<String>,
-    /// Preset context to inject.
-    #[serde(default)]
-    pub preset_context: Option<String>,
-    /// Resolved skill snapshot for the session. Populated from
-    /// `conversation.extra.skills` by the factory. No runtime filtering —
-    /// what the caller sends is what the agent sees.
-    #[serde(default)]
-    pub skills: Vec<String>,
-    /// Preset assistant ID.
-    #[serde(default)]
-    pub preset_assistant_id: Option<String>,
-    /// Session mode override.
-    #[serde(default)]
-    pub session_mode: Option<String>,
-    /// Associated cron job ID.
-    #[serde(default)]
-    pub cron_job_id: Option<String>,
-    /// Team session MCP stdio config. When present, the factory injects it as
-    /// a stdio MCP server on `session/new`. Written by
-    /// `TeamSessionService::ensure_session` into `conversation.extra`; solo
-    /// conversations leave this unset.
-    #[serde(default)]
-    pub team_mcp_stdio_config: Option<TeamMcpStdioConfig>,
-    /// Guide MCP stdio config for solo team-capable sessions.
-    /// When present alongside a team-capable `backend` and no `team_mcp_stdio_config`,
-    /// `build_new_session_request` injects the Guide as a stdio MCP server.
-    #[serde(default)]
-    pub guide_mcp_config: Option<GuideMcpConfig>,
-    /// Owner user_id — passed to the Guide MCP bridge so `aion_create_team`
-    /// can associate the new team with the correct user.
-    #[serde(default)]
-    pub user_id: Option<String>,
-}
-
-/// OpenClaw gateway configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct OpenClawGatewayConfig {
-    pub host: Option<String>,
-    pub port: Option<u16>,
-    pub token: Option<String>,
-    pub password: Option<String>,
-    #[serde(default)]
-    pub use_external_gateway: bool,
-    pub cli_path: Option<String>,
-}
-
-/// OpenClaw-specific fields extracted from `extra` in [`BuildTaskOptions`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OpenClawBuildExtra {
-    /// Optional downstream AI backend (informational only).
-    #[serde(default)]
-    pub backend: Option<String>,
-    /// Agent name.
-    #[serde(default)]
-    pub agent_name: Option<String>,
-    /// OpenClaw gateway configuration.
-    #[serde(default)]
-    pub gateway: OpenClawGatewayConfig,
-    /// Resolved skill snapshot for the session. Populated from
-    /// `conversation.extra.skills` by the factory.
-    #[serde(default)]
-    pub skills: Vec<String>,
-    /// Preset assistant ID.
-    #[serde(default)]
-    pub preset_assistant_id: Option<String>,
-    /// Associated cron job ID.
-    #[serde(default)]
-    pub cron_job_id: Option<String>,
-    /// Persisted session key for resume (from conversation.extra.sessionKey).
-    #[serde(default, rename = "sessionKey")]
-    pub session_key: Option<String>,
-}
-
-/// Remote agent-specific fields extracted from `extra` in [`BuildTaskOptions`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RemoteBuildExtra {
-    /// Remote agent configuration ID.
-    pub remote_agent_id: String,
-}
-
-/// Aionrs-specific fields extracted from `extra` in [`BuildTaskOptions`].
-///
-/// Provider credentials (provider name, api_key, model) are resolved from
-/// the providers table in the factory — they are NOT expected in `extra`.
-/// This struct only carries optional overrides the caller may supply.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct AionrsBuildExtra {
-    /// System prompt override.
-    #[serde(default)]
-    pub system_prompt: Option<String>,
-    /// Max tokens per response.
-    #[serde(default = "default_aionrs_max_tokens")]
-    pub max_tokens: u32,
-    /// Max agentic turns.
-    #[serde(default)]
-    pub max_turns: Option<usize>,
-    /// Session mode (default, auto_edit, yolo).
-    #[serde(default)]
-    pub session_mode: Option<String>,
-}
-
 /// Provider-specific compat overrides resolved in the factory.
-///
-/// These are merged on top of the provider defaults in the agent manager.
 #[derive(Debug, Clone, Default)]
 pub struct AionrsCompatOverrides {
     pub max_tokens_field: Option<String>,
@@ -167,9 +43,6 @@ pub struct AionrsCompatOverrides {
 }
 
 /// Fully resolved Aionrs configuration passed to the agent manager.
-///
-/// Constructed in the factory by combining provider DB data with
-/// optional overrides from [`AionrsBuildExtra`].
 #[derive(Debug, Clone)]
 pub struct AionrsResolvedConfig {
     /// LLM provider name (anthropic, openai, bedrock, vertex).
@@ -194,40 +67,7 @@ pub struct AionrsResolvedConfig {
     pub session_mode: Option<String>,
 }
 
-fn default_aionrs_max_tokens() -> u32 {
-    8192
-}
-
-/// ACP model information returned by the ACP backend.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AcpModelInfo {
-    pub model_id: String,
-    pub model_name: Option<String>,
-    pub provider: Option<String>,
-}
-
-/// ACP session configuration option.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AcpSessionConfigOption {
-    pub config_id: String,
-    pub label: String,
-    pub value: String,
-    /// Possible values; `None` means free-form input.
-    pub options: Option<Vec<String>>,
-}
-
-/// A slash command item available in a conversation session.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SlashCommandItem {
-    pub command: String,
-    pub description: String,
-}
-
 /// Unified stream chunk published on the per-session broadcast channel.
-///
-/// Emitted by `AgentManagerHandle` implementations at every stream event so
-/// downstream subscribers (wake timeout watchdog, crash detector) can observe
-/// agent progress without intercepting the existing frontend event pipeline.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AgentStreamChunk {
@@ -253,11 +93,13 @@ pub enum AgentStreamChunk {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aionui_api_types::{
+        AcpBuildExtra, AcpModelInfo, AcpSessionConfigOption, OpenClawGatewayConfig, SlashCommandItem,
+    };
     use serde_json::json;
 
     #[test]
     fn acp_build_extra_accepts_payload_without_skills() {
-        // Legacy payloads without skills should still deserialize.
         let legacy = r#"{"backend":"claude"}"#;
         let parsed: AcpBuildExtra = serde_json::from_str(legacy).unwrap();
         assert!(parsed.skills.is_empty());
@@ -272,9 +114,6 @@ mod tests {
 
     #[test]
     fn acp_build_extra_missing_team_mcp_stdio_config_is_none() {
-        // Legacy extra (pre-team-wave1) must deserialize cleanly with the new
-        // optional `team_mcp_stdio_config` absent — this keeps solo chat
-        // conversations working without any migration.
         let legacy = r#"{"backend":"claude","skills":["cron"]}"#;
         let parsed: AcpBuildExtra = serde_json::from_str(legacy).unwrap();
         assert!(parsed.team_mcp_stdio_config.is_none());

--- a/crates/aionui-api-types/src/agent_build_extra.rs
+++ b/crates/aionui-api-types/src/agent_build_extra.rs
@@ -1,0 +1,112 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{GuideMcpConfig, TeamMcpStdioConfig};
+
+/// ACP-specific fields extracted from `extra` in build task options.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcpBuildExtra {
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    #[serde(default)]
+    pub backend: Option<String>,
+    #[serde(default)]
+    pub cli_path: Option<String>,
+    #[serde(default)]
+    pub agent_name: Option<String>,
+    #[serde(default)]
+    pub custom_agent_id: Option<String>,
+    #[serde(default)]
+    pub preset_context: Option<String>,
+    #[serde(default)]
+    pub skills: Vec<String>,
+    #[serde(default)]
+    pub preset_assistant_id: Option<String>,
+    #[serde(default)]
+    pub session_mode: Option<String>,
+    #[serde(default)]
+    pub cron_job_id: Option<String>,
+    #[serde(default)]
+    pub team_mcp_stdio_config: Option<TeamMcpStdioConfig>,
+    #[serde(default)]
+    pub guide_mcp_config: Option<GuideMcpConfig>,
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// OpenClaw gateway configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct OpenClawGatewayConfig {
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub token: Option<String>,
+    pub password: Option<String>,
+    #[serde(default)]
+    pub use_external_gateway: bool,
+    pub cli_path: Option<String>,
+}
+
+/// OpenClaw-specific fields extracted from `extra` in build task options.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenClawBuildExtra {
+    #[serde(default)]
+    pub backend: Option<String>,
+    #[serde(default)]
+    pub agent_name: Option<String>,
+    #[serde(default)]
+    pub gateway: OpenClawGatewayConfig,
+    #[serde(default)]
+    pub skills: Vec<String>,
+    #[serde(default)]
+    pub preset_assistant_id: Option<String>,
+    #[serde(default)]
+    pub cron_job_id: Option<String>,
+    #[serde(default, rename = "sessionKey")]
+    pub session_key: Option<String>,
+}
+
+/// Remote agent-specific fields extracted from `extra` in build task options.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemoteBuildExtra {
+    pub remote_agent_id: String,
+}
+
+/// Aionrs-specific fields extracted from `extra` in build task options.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AionrsBuildExtra {
+    #[serde(default)]
+    pub system_prompt: Option<String>,
+    #[serde(default = "default_aionrs_max_tokens")]
+    pub max_tokens: u32,
+    #[serde(default)]
+    pub max_turns: Option<usize>,
+    #[serde(default)]
+    pub session_mode: Option<String>,
+}
+
+fn default_aionrs_max_tokens() -> u32 {
+    8192
+}
+
+/// ACP model information returned by the ACP backend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcpModelInfo {
+    pub model_id: String,
+    pub model_name: Option<String>,
+    pub provider: Option<String>,
+}
+
+/// ACP session configuration option.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcpSessionConfigOption {
+    pub config_id: String,
+    pub label: String,
+    pub value: String,
+    pub options: Option<Vec<String>>,
+}
+
+/// A slash command item available in a conversation session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlashCommandItem {
+    pub command: String,
+    pub description: String,
+}

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -1,5 +1,6 @@
 //! All HTTP request/response DTOs shared across the API surface.
 mod acp;
+mod agent_build_extra;
 mod agent_discovery;
 mod assistant;
 mod auth;
@@ -29,6 +30,10 @@ pub use acp::{
     SessionConfigOptionUpdate, SetConfigOptionRequest, SetConfigOptionsRequest, SetModeRequest, SetModelRequest,
     SideQuestionRequest, SideQuestionResponse, TestCustomAgentRequest, TestCustomAgentResponse, WorkspaceBrowseQuery,
     WorkspaceEntry,
+};
+pub use agent_build_extra::{
+    AcpBuildExtra, AcpModelInfo, AcpSessionConfigOption, AionrsBuildExtra, OpenClawBuildExtra, OpenClawGatewayConfig,
+    RemoteBuildExtra, SlashCommandItem,
 };
 pub use agent_discovery::{AgentEnvEntry, AgentHandshake, AgentMetadata, AgentSource, AgentSourceInfo, BehaviorPolicy};
 pub use assistant::{

--- a/crates/aionui-app/tests/team_smoke_e2e.rs
+++ b/crates/aionui-app/tests/team_smoke_e2e.rs
@@ -20,8 +20,9 @@ use std::sync::Arc;
 
 use aionui_ai_agent::agent_manager::IAgentManager;
 use aionui_ai_agent::stream_event::{AgentStreamEvent, ErrorEventData, FinishEventData};
-use aionui_ai_agent::types::{AcpBuildExtra, AgentStreamChunk, BuildTaskOptions, SendMessageData};
+use aionui_ai_agent::types::{AgentStreamChunk, BuildTaskOptions, SendMessageData};
 use aionui_ai_agent::{AgentFactory, IWorkerTaskManager, WorkerTaskManagerImpl};
+use aionui_api_types::AcpBuildExtra;
 use aionui_api_types::TeamMcpStdioConfig;
 use aionui_app::{AppServices, build_module_states, create_router_with_states};
 use aionui_common::{AgentKillReason, AgentType, AppError, Confirmation, ConversationStatus, TimestampMs};


### PR DESCRIPTION
## Summary
- Move `AcpBuildExtra`, `OpenClawBuildExtra`, `OpenClawGatewayConfig`, `RemoteBuildExtra`, `AionrsBuildExtra`, `AcpModelInfo`, `AcpSessionConfigOption`, `SlashCommandItem` to `aionui-api-types/src/agent_build_extra.rs`
- Keep `AgentStreamChunk`, `BuildTaskOptions`, `SendMessageData`, `AionrsResolvedConfig`, `AionrsCompatOverrides` in `aionui-ai-agent/src/types.rs`
- Re-export moved types from `aionui-ai-agent` for downstream compatibility
- Update internal imports to reference `aionui_api_types` directly