### PR TITLE
refactor(ai-agent): PR #7b-6 aggregate cleanup (value objects, domain events, CatalogForwarder)

### DIFF
--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -109,46 +109,6 @@ fn sdk_to_snake_value<T: serde::Serialize>(value: &T) -> Option<Value> {
     Some(v)
 }
 
-/// Project an `AgentStreamEvent` onto the subset of `AgentHandshake`
-/// fields the catalog cares about. Returns `None` for unrelated
-/// events — the forwarder filters on that.
-///
-/// Event payloads may arrive here either already snake_case (from
-/// `emit_snapshot_events`) or camelCase (from `SessionUpdate::*`
-/// translation in `stream_event.rs`). We re-normalise unconditionally
-/// so the persisted handshake blob is uniform; `camel_to_snake` is
-/// idempotent on snake_case input.
-fn catalog_partial_from_event(event: &AgentStreamEvent) -> Option<AgentHandshake> {
-    fn snake(mut v: Value) -> Value {
-        normalize_keys_to_snake_case(&mut v);
-        v
-    }
-    match event {
-        AgentStreamEvent::AcpModeInfo(v) => Some(AgentHandshake {
-            available_modes: Some(snake(v.clone())),
-            ..Default::default()
-        }),
-        AgentStreamEvent::AcpModelInfo(v) => Some(AgentHandshake {
-            available_models: Some(snake(v.clone())),
-            ..Default::default()
-        }),
-        AgentStreamEvent::AcpConfigOption(v) => Some(AgentHandshake {
-            config_options: Some(snake(v.clone())),
-            ..Default::default()
-        }),
-        AgentStreamEvent::AvailableCommands(data) => {
-            // `AvailableCommand` is an ACP SDK struct — normalise on
-            // the way into the catalog so the stored blob is snake_case.
-            let cmds = sdk_to_snake_value(&data.commands)?;
-            Some(AgentHandshake {
-                available_commands: Some(cmds),
-                ..Default::default()
-            })
-        }
-        _ => None,
-    }
-}
-
 /// Manages a single ACP Agent instance.
 ///
 /// ACP is the most complex agent type, supporting 20+ CLI sub-backends
@@ -348,8 +308,8 @@ impl AcpAgentManager {
     /// `params` is the pre-computed, immutable session bundle assembled by
     /// `assemble_acp_params` in the factory layer. `catalog_tx` is the
     /// MPSC sender used for the one-shot initialize handshake write;
-    /// session-driven fields flow through the forwarder started via
-    /// `start_catalog_sync`.
+    /// session-driven fields flow through the `CatalogForwarder` the
+    /// factory spawns after construction.
     pub async fn new(
         params: Arc<AcpSessionParams>,
         skill_manager: Arc<AcpSkillManager>,
@@ -383,7 +343,8 @@ impl AcpAgentManager {
         // Push the static handshake payloads (agent_capabilities +
         // auth_methods) through the catalog sync channel. Session-driven
         // fields — modes, models, config_options, commands — flow
-        // through the forwarder started in `start_catalog_sync`.
+        // through the `CatalogForwarder` the factory spawns after
+        // construction.
         let init_handshake = AgentHandshake {
             agent_capabilities: protocol.agent_capabilities().and_then(|c| sdk_to_snake_value(&c)),
             auth_methods: protocol.auth_methods().and_then(|m| sdk_to_snake_value(&m)),
@@ -489,33 +450,6 @@ impl AcpAgentManager {
             }
             _ => {}
         }
-    }
-
-    /// Forward session-driven ACP events into the catalog sync channel
-    /// so the `agent_metadata` row stays in sync with what the CLI is
-    /// actually reporting. Runs as a subscriber on this manager's
-    /// broadcast bus; the registry owns the single consumer that drains
-    /// the resulting MPSC.
-    ///
-    /// `catalog_tx` is passed in rather than stored on the manager — the
-    /// spawned task is the sole consumer of the sender for session-driven
-    /// updates after initialization.
-    pub fn start_catalog_sync(self: &Arc<Self>, catalog_tx: CatalogSender) {
-        let id = self.params.metadata.id.clone();
-        let mut rx = self.event_tx.subscribe();
-        tokio::spawn(async move {
-            loop {
-                match rx.recv().await {
-                    Ok(event) => {
-                        if let Some(partial) = catalog_partial_from_event(&event) {
-                            catalog_tx.send_partial(id.clone(), partial);
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Closed) => break,
-                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
-                }
-            }
-        });
     }
 
     /// Drain pending domain events from the session aggregate and
@@ -1316,29 +1250,5 @@ mod tests {
     fn normalize_requested_mode_trims_and_returns_empty_for_blank() {
         let meta = metadata_with_yolo_id(Some("full-access"));
         assert_eq!(normalize_requested_mode(&meta, "   "), "");
-    }
-
-    /// Each session-driven event projects onto exactly one handshake
-    /// field. Unrelated events produce `None` so the forwarder sends
-    /// nothing for them.
-    #[test]
-    fn catalog_partial_covers_session_fields() {
-        let modes = catalog_partial_from_event(&AgentStreamEvent::AcpModeInfo(json!({"x": 1})))
-            .expect("mode event must project");
-        assert_eq!(modes.available_modes, Some(json!({"x": 1})));
-        assert!(modes.available_models.is_none());
-
-        let models =
-            catalog_partial_from_event(&AgentStreamEvent::AcpModelInfo(json!([1]))).expect("model event must project");
-        assert_eq!(models.available_models, Some(json!([1])));
-
-        let cfg = catalog_partial_from_event(&AgentStreamEvent::AcpConfigOption(json!([
-            {"id":"mode"}
-        ])))
-        .expect("config event must project");
-        assert_eq!(cfg.config_options, Some(json!([{"id":"mode"}])));
-
-        // An unrelated event emits no update.
-        assert!(catalog_partial_from_event(&AgentStreamEvent::Start(StartEventData { session_id: None })).is_none());
     }
 }

--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -5,6 +5,7 @@ use crate::cli_process::CliAgentProcess;
 use crate::factory::acp_assembler::AcpSessionParams;
 use crate::first_message_injector::{InjectionConfig, inject_first_message_prefix};
 use crate::manager::acp::{AcpSession, AcpSessionEvent, PermissionRouter, PersistedSessionState};
+use crate::shared_kernel::{ModeId, ModelId, SessionId as DomainSessionId};
 use crate::skill_manager::AcpSkillManager;
 use crate::stream_event::{
     AgentStreamEvent, AvailableCommandsEventData, FinishEventData, SessionAssignedEventData, StartEventData,
@@ -209,7 +210,7 @@ impl AcpAgentManager {
 
     async fn update_cached_mode(&self, mode: &str) {
         let mut session = self.session.write().await;
-        session.apply_partial_mode_update(mode);
+        session.apply_partial_mode_update(ModeId::new(mode));
     }
 
     /// Execute reconcile actions produced by `AcpSession::plan_reconcile`.
@@ -228,8 +229,8 @@ impl AcpAgentManager {
 
         for action in actions {
             match action {
-                ReconcileAction::SetMode { mode_id } => {
-                    let normalized = normalize_requested_mode(&self.params.metadata, mode_id.as_str());
+                ReconcileAction::SetMode { mode } => {
+                    let normalized = normalize_requested_mode(&self.params.metadata, mode.as_str());
                     if normalized.is_empty() {
                         continue;
                     }
@@ -251,23 +252,21 @@ impl AcpAgentManager {
                     }
                     self.update_cached_mode(&normalized).await;
                     let mut session = self.session.write().await;
-                    session.apply_observed_mode(&normalized);
+                    session.apply_observed_mode(ModeId::new(normalized));
                 }
-                ReconcileAction::SetConfigOption { config_id, value } => {
-                    let cid_str = config_id.into_inner();
-                    let val_str = value.into_inner();
+                ReconcileAction::SetConfigOption { key, value } => {
                     if let Err(err) = self
                         .protocol
                         .set_config_option(SetSessionConfigOptionRequest::new(
                             SessionId::new(session_id),
-                            cid_str.clone(),
-                            val_str.clone(),
+                            key.as_str().to_owned(),
+                            value.as_str().to_owned(),
                         ))
                         .await
                     {
                         info!(
-                            config_id = %cid_str,
-                            desired = %val_str,
+                            config_id = %key,
+                            desired = %value,
                             error = %err,
                             "reconcile_session: set_config_option failed; skipping"
                         );
@@ -295,7 +294,7 @@ impl AcpAgentManager {
         // CurrentModelUpdate notification for model changes.
         {
             let mut session = self.session.write().await;
-            session.update_current_model(model_id);
+            session.update_current_model(ModelId::new(model_id));
         }
 
         Ok(())
@@ -399,7 +398,8 @@ impl AcpAgentManager {
             .session_mode
             .as_ref()
             .map(|m| normalize_requested_mode(&params.metadata, m))
-            .filter(|m| !m.is_empty());
+            .filter(|m| !m.is_empty())
+            .map(ModeId::new);
         let mut session = AcpSession::new(initial_mode, HashMap::new());
         if let Some(agent_capabilities) = protocol.agent_capabilities() {
             session.apply_advertised_capabilities(agent_capabilities);
@@ -463,7 +463,7 @@ impl AcpAgentManager {
                     self.commit_session_changes(&mut s).await;
                 } else if let Some(current_id) = value.get("currentModeId").and_then(|v: &Value| v.as_str()) {
                     let mut s = self.session.write().await;
-                    s.apply_observed_mode(current_id);
+                    s.apply_observed_mode(ModeId::new(current_id));
                     self.commit_session_changes(&mut s).await;
                 }
             }
@@ -533,14 +533,14 @@ impl AcpAgentManager {
     pub async fn preload_snapshot(&self, state: PersistedSessionState) {
         let mut session = self.session.write().await;
         session.preload_persisted(&state);
-        if let Some(mode_id) = &state.current_mode_id {
-            let normalized = normalize_requested_mode(&self.params.metadata, mode_id);
+        if let Some(mode) = &state.current_mode_id {
+            let normalized = normalize_requested_mode(&self.params.metadata, mode.as_str());
             if !normalized.is_empty() {
-                session.set_desired_mode(normalized);
+                session.set_desired_mode(ModeId::new(normalized));
             }
         }
-        for (config_id, value) in &state.config_selections {
-            session.set_desired_config(config_id.clone(), value.clone());
+        for (key, value) in &state.config_selections {
+            session.set_desired_config(key.clone(), value.clone());
         }
         // Preload events are discarded — the DB already has these values.
         session.drain_events();
@@ -624,7 +624,7 @@ impl AcpAgentManager {
             if let Some(config_options) = session_response.config_options {
                 session.apply_advertised_config_options(config_options);
             }
-            session.assign_session_id(sid.clone());
+            session.assign_session_id(DomainSessionId::new(sid.clone()));
             self.commit_session_changes(&mut session).await;
         }
         self.emit_snapshot_events().await;
@@ -717,7 +717,7 @@ impl AcpAgentManager {
                     if let Some(config_options) = session_response.config_options {
                         session.apply_advertised_config_options(config_options);
                     }
-                    session.assign_session_id(new_sid.clone());
+                    session.assign_session_id(DomainSessionId::new(new_sid.clone()));
                     self.commit_session_changes(&mut session).await;
                 }
                 self.emit_snapshot_events().await;
@@ -769,7 +769,7 @@ impl AcpAgentManager {
         if let Some(sid) = session_id {
             {
                 let mut session = self.session.write().await;
-                session.assign_session_id(sid.to_owned());
+                session.assign_session_id(DomainSessionId::new(sid));
                 self.commit_session_changes(&mut session).await;
             }
             self.reconcile_session(sid).await;
@@ -892,7 +892,7 @@ impl AcpAgentManager {
     /// turns — once the resume handshake has run — take the short path.
     pub async fn restore_session_id(&self, sid: String) {
         let mut session = self.session.write().await;
-        session.assign_session_id(sid);
+        session.assign_session_id(DomainSessionId::new(sid));
         // Discarded — the session_id already came from DB, no need to re-persist.
         session.drain_events();
     }
@@ -1109,11 +1109,11 @@ impl IAgentManager for AcpAgentManager {
                 .map_err(AppError::from)?;
             self.update_cached_mode(&normalized_mode).await;
             let mut session = self.session.write().await;
-            session.apply_observed_mode(&normalized_mode);
+            session.apply_observed_mode(ModeId::new(&normalized_mode));
         }
 
         let mut session = self.session.write().await;
-        session.set_desired_mode(normalized_mode);
+        session.set_desired_mode(ModeId::new(normalized_mode));
         self.commit_session_changes(&mut session).await;
         Ok(())
     }

--- a/crates/aionui-ai-agent/src/factory/mod.rs
+++ b/crates/aionui-ai-agent/src/factory/mod.rs
@@ -12,7 +12,7 @@ use tracing::{debug, info, warn};
 use crate::agent_manager::AgentManagerHandle;
 use crate::agent_registry::AgentRegistry;
 use crate::factory::acp_assembler::{WorkspaceInfo, assemble_acp_params};
-use crate::manager::acp::AcpSessionSyncService;
+use crate::manager::acp::{AcpSessionSyncService, CatalogForwarder};
 use crate::manager::remote::RemoteAgentConfig;
 use crate::skill_manager::AcpSkillManager;
 use crate::task_manager::AgentFactory;
@@ -172,7 +172,11 @@ async fn build_agent(deps: Arc<AgentFactoryDeps>, options: BuildTaskOptions) -> 
             let arc = Arc::new(agent);
             arc.start_permission_handler();
             arc.start_session_event_tracker();
-            arc.start_catalog_sync(catalog_tx);
+            CatalogForwarder::spawn(
+                arc.agent_metadata_id().to_owned(),
+                crate::IAgentManager::subscribe(arc.as_ref()),
+                catalog_tx,
+            );
 
             // Seed the aggregate with persisted runtime choices and
             // (if present) the CLI-assigned session id, so the first

--- a/crates/aionui-ai-agent/src/factory/mod.rs
+++ b/crates/aionui-ai-agent/src/factory/mod.rs
@@ -173,14 +173,23 @@ async fn build_agent(deps: Arc<AgentFactoryDeps>, options: BuildTaskOptions) -> 
             arc.start_permission_handler();
             arc.start_session_event_tracker();
             arc.start_catalog_sync(catalog_tx);
+
+            // Seed the aggregate with persisted runtime choices and
+            // (if present) the CLI-assigned session id, so the first
+            // turn after a task rebuild takes the resume path.
+            if let Some(state) = deps.acp_agent_service.load_snapshot_state(&conversation_id).await {
+                arc.preload_snapshot(state).await;
+            }
+            if let Some(sid) = deps.acp_agent_service.load_session_id(&conversation_id).await {
+                arc.restore_session_id(sid).await;
+            }
+
             let handle: AgentManagerHandle = arc.clone();
 
             // Hand the service the domain event receiver so it can
             // persist user intent changes without reverse-engineering
             // them from CLI observations.
-            deps.acp_agent_service
-                .attach(conversation_id, handle.clone(), domain_rx)
-                .await;
+            deps.acp_agent_service.attach(conversation_id, domain_rx).await;
 
             Ok(handle)
         }

--- a/crates/aionui-ai-agent/src/manager/acp/catalog_forwarder.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/catalog_forwarder.rs
@@ -1,0 +1,122 @@
+//! Forwards ACP session events to the catalog sync channel.
+//!
+//! Subscribes to the manager's stream event broadcast and projects
+//! capability-advertising events (modes, models, commands, capabilities,
+//! auth methods) into `AgentHandshake` partials that the registry's
+//! catalog consumer writes to `agent_metadata`.
+
+use aionui_api_types::AgentHandshake;
+use aionui_common::normalize_keys_to_snake_case;
+use serde_json::Value;
+use tokio::sync::broadcast;
+use tokio::task::JoinHandle;
+use tracing::debug;
+
+use crate::agent_registry::CatalogSender;
+use crate::stream_event::AgentStreamEvent;
+
+/// Subscriber that projects session-driven ACP events into the
+/// `agent_metadata` catalog so the stored handshake blob stays in sync
+/// with what the CLI is actually advertising.
+///
+/// One task per `AcpAgentManager`; the task exits automatically when
+/// the broadcast channel closes (i.e. the manager is dropped).
+pub struct CatalogForwarder;
+
+impl CatalogForwarder {
+    /// Spawn the forwarder task. The returned handle is not normally
+    /// awaited — callers drop it and rely on the broadcast channel
+    /// closing to terminate the task.
+    pub fn spawn(
+        agent_id: String,
+        mut event_rx: broadcast::Receiver<AgentStreamEvent>,
+        catalog_tx: CatalogSender,
+    ) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            loop {
+                match event_rx.recv().await {
+                    Ok(event) => {
+                        if let Some(partial) = catalog_partial_from_event(&event) {
+                            catalog_tx.send_partial(agent_id.clone(), partial);
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                }
+            }
+            debug!(agent_id, "CatalogForwarder exiting");
+        })
+    }
+}
+
+/// Project an `AgentStreamEvent` onto the subset of `AgentHandshake`
+/// fields the catalog cares about. Returns `None` for unrelated
+/// events — the forwarder filters on that.
+///
+/// Event payloads may arrive here either already snake_case (from
+/// `emit_snapshot_events`) or camelCase (from `SessionUpdate::*`
+/// translation in `stream_event.rs`). We re-normalise unconditionally
+/// so the persisted handshake blob is uniform; `camel_to_snake` is
+/// idempotent on snake_case input.
+fn catalog_partial_from_event(event: &AgentStreamEvent) -> Option<AgentHandshake> {
+    fn snake(mut v: Value) -> Value {
+        normalize_keys_to_snake_case(&mut v);
+        v
+    }
+    match event {
+        AgentStreamEvent::AcpModeInfo(v) => Some(AgentHandshake {
+            available_modes: Some(snake(v.clone())),
+            ..Default::default()
+        }),
+        AgentStreamEvent::AcpModelInfo(v) => Some(AgentHandshake {
+            available_models: Some(snake(v.clone())),
+            ..Default::default()
+        }),
+        AgentStreamEvent::AcpConfigOption(v) => Some(AgentHandshake {
+            config_options: Some(snake(v.clone())),
+            ..Default::default()
+        }),
+        AgentStreamEvent::AvailableCommands(data) => {
+            // `AvailableCommand` is an ACP SDK struct — normalise on
+            // the way into the catalog so the stored blob is snake_case.
+            let mut cmds = serde_json::to_value(&data.commands).ok()?;
+            normalize_keys_to_snake_case(&mut cmds);
+            Some(AgentHandshake {
+                available_commands: Some(cmds),
+                ..Default::default()
+            })
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stream_event::StartEventData;
+    use serde_json::json;
+
+    /// Each session-driven event projects onto exactly one handshake
+    /// field. Unrelated events produce `None` so the forwarder sends
+    /// nothing for them.
+    #[test]
+    fn catalog_partial_covers_session_fields() {
+        let modes = catalog_partial_from_event(&AgentStreamEvent::AcpModeInfo(json!({"x": 1})))
+            .expect("mode event must project");
+        assert_eq!(modes.available_modes, Some(json!({"x": 1})));
+        assert!(modes.available_models.is_none());
+
+        let models =
+            catalog_partial_from_event(&AgentStreamEvent::AcpModelInfo(json!([1]))).expect("model event must project");
+        assert_eq!(models.available_models, Some(json!([1])));
+
+        let cfg = catalog_partial_from_event(&AgentStreamEvent::AcpConfigOption(json!([
+            {"id":"mode"}
+        ])))
+        .expect("config event must project");
+        assert_eq!(cfg.config_options, Some(json!([{"id":"mode"}])));
+
+        // An unrelated event emits no update.
+        assert!(catalog_partial_from_event(&AgentStreamEvent::Start(StartEventData { session_id: None })).is_none());
+    }
+}

--- a/crates/aionui-ai-agent/src/manager/acp/events.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/events.rs
@@ -14,16 +14,16 @@ pub enum AcpSessionEvent {
     },
     SessionOpened,
     DesiredModeChanged {
-        mode_id: ModeId,
+        mode: ModeId,
     },
     DesiredConfigChanged {
         selections: HashMap<ConfigKey, ConfigValue>,
     },
     ObservedModeSynced {
-        mode_id: ModeId,
+        mode: ModeId,
     },
     ObservedModelSynced {
-        model_id: ModelId,
+        model: ModelId,
     },
 }
 
@@ -45,7 +45,7 @@ mod tests {
     #[test]
     fn event_debug_format() {
         let e = AcpSessionEvent::DesiredModeChanged {
-            mode_id: ModeId::new("plan"),
+            mode: ModeId::new("plan"),
         };
         let dbg = format!("{e:?}");
         assert!(dbg.contains("plan"));

--- a/crates/aionui-ai-agent/src/manager/acp/mod.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/mod.rs
@@ -1,9 +1,11 @@
+pub mod catalog_forwarder;
 pub mod events;
 pub mod permission_router;
 pub mod reconcile;
 pub mod session;
 pub mod session_sync;
 
+pub use catalog_forwarder::CatalogForwarder;
 pub use events::AcpSessionEvent;
 pub use permission_router::PermissionRouter;
 pub use reconcile::ReconcileAction;

--- a/crates/aionui-ai-agent/src/manager/acp/reconcile.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/reconcile.rs
@@ -6,8 +6,8 @@ use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId};
 /// desired vs observed and returns a list of idempotent, order-independent ops.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReconcileAction {
-    SetMode { mode_id: ModeId },
-    SetConfigOption { config_id: ConfigKey, value: ConfigValue },
+    SetMode { mode: ModeId },
+    SetConfigOption { key: ConfigKey, value: ConfigValue },
 }
 
 #[cfg(test)]
@@ -17,10 +17,10 @@ mod tests {
     #[test]
     fn reconcile_action_equality() {
         let a = ReconcileAction::SetMode {
-            mode_id: ModeId::new("plan"),
+            mode: ModeId::new("plan"),
         };
         let b = ReconcileAction::SetMode {
-            mode_id: ModeId::new("plan"),
+            mode: ModeId::new("plan"),
         };
         assert_eq!(a, b);
     }

--- a/crates/aionui-ai-agent/src/manager/acp/session.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session.rs
@@ -16,25 +16,25 @@ use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId, SessionId};
 /// the CLI's session response after initialization.
 #[derive(Debug, Clone, Default)]
 pub struct PersistedSessionState {
-    pub current_mode_id: Option<String>,
-    pub current_model_id: Option<String>,
-    pub config_selections: HashMap<String, String>,
+    pub current_mode_id: Option<ModeId>,
+    pub current_model_id: Option<ModelId>,
+    pub config_selections: HashMap<ConfigKey, ConfigValue>,
     pub context_usage: Option<UsageUpdate>,
 }
 
 /// What the user wants the session to be (intent).
 #[derive(Debug, Clone, Default)]
 struct Desired {
-    mode_id: Option<String>,
-    config_selections: HashMap<String, String>,
+    mode_id: Option<ModeId>,
+    config_selections: HashMap<ConfigKey, ConfigValue>,
 }
 
 /// What the CLI last reported (ground truth from the backend).
 #[derive(Debug, Clone, Default)]
 struct Observed {
-    mode_id: Option<String>,
-    model_id: Option<String>,
-    config_current: HashMap<String, String>,
+    mode_id: Option<ModeId>,
+    model_id: Option<ModelId>,
+    config_current: HashMap<ConfigKey, ConfigValue>,
 }
 
 /// What the CLI advertises as available options.
@@ -61,7 +61,7 @@ struct Advertised {
 /// events (collected in `pending_events` and drained by the driver).
 #[derive(Debug, Clone)]
 pub struct AcpSession {
-    session_id: Option<String>,
+    session_id: Option<SessionId>,
     opened: bool,
     desired: Desired,
     observed: Observed,
@@ -70,7 +70,7 @@ pub struct AcpSession {
 }
 
 impl AcpSession {
-    pub fn new(initial_mode: Option<String>, config_selections: HashMap<String, String>) -> Self {
+    pub fn new(initial_mode: Option<ModeId>, config_selections: HashMap<ConfigKey, ConfigValue>) -> Self {
         Self {
             session_id: None,
             opened: false,
@@ -87,7 +87,11 @@ impl AcpSession {
     // ─── Getters ───────────────────────────────────────────────────────
 
     pub fn session_id(&self) -> Option<&str> {
-        self.session_id.as_deref()
+        self.session_id.as_ref().map(SessionId::as_str)
+    }
+
+    pub fn session_id_vo(&self) -> Option<&SessionId> {
+        self.session_id.as_ref()
     }
 
     pub fn is_opened(&self) -> bool {
@@ -95,18 +99,30 @@ impl AcpSession {
     }
 
     pub fn desired_mode(&self) -> Option<&str> {
-        self.desired.mode_id.as_deref()
+        self.desired.mode_id.as_ref().map(ModeId::as_str)
+    }
+
+    pub fn desired_mode_id(&self) -> Option<&ModeId> {
+        self.desired.mode_id.as_ref()
     }
 
     pub fn observed_mode(&self) -> Option<&str> {
-        self.observed.mode_id.as_deref()
+        self.observed.mode_id.as_ref().map(ModeId::as_str)
+    }
+
+    pub fn observed_mode_id(&self) -> Option<&ModeId> {
+        self.observed.mode_id.as_ref()
     }
 
     pub fn observed_model(&self) -> Option<&str> {
-        self.observed.model_id.as_deref()
+        self.observed.model_id.as_ref().map(ModelId::as_str)
     }
 
-    pub fn config_selections(&self) -> &HashMap<String, String> {
+    pub fn observed_model_id(&self) -> Option<&ModelId> {
+        self.observed.model_id.as_ref()
+    }
+
+    pub fn config_selections(&self) -> &HashMap<ConfigKey, ConfigValue> {
         &self.desired.config_selections
     }
 
@@ -147,15 +163,14 @@ impl AcpSession {
     /// Assign (or restore) a session ID. Idempotent: re-assigning the same
     /// ID is a no-op. Assigning a *different* ID after one is already set
     /// is an invariant violation (the aggregate must be recreated).
-    pub fn assign_session_id(&mut self, sid: String) {
+    pub fn assign_session_id(&mut self, sid: SessionId) {
         if let Some(existing) = &self.session_id {
             debug_assert_eq!(existing, &sid, "session_id reassignment attempted");
             return;
         }
         self.session_id = Some(sid.clone());
-        self.pending_events.push(AcpSessionEvent::SessionAssigned {
-            session_id: SessionId::new(sid),
-        });
+        self.pending_events
+            .push(AcpSessionEvent::SessionAssigned { session_id: sid });
     }
 
     /// Mark the session as opened with the CLI (first turn handshake complete).
@@ -169,34 +184,27 @@ impl AcpSession {
     /// Set the user's desired mode. Emits `DesiredModeChanged` if the
     /// value actually changed. When advertised modes are known, the mode
     /// must be in the list (otherwise the call is a no-op).
-    pub fn set_desired_mode(&mut self, mode_id: String) -> bool {
-        if mode_id.is_empty() {
+    pub fn set_desired_mode(&mut self, mode: ModeId) -> bool {
+        if mode.as_str().is_empty() {
             return false;
         }
-        if !self.is_mode_valid(&mode_id) {
+        if !self.is_mode_valid(mode.as_str()) {
             return false;
         }
-        if self.desired.mode_id.as_deref() == Some(&mode_id) {
+        if self.desired.mode_id.as_ref() == Some(&mode) {
             return false;
         }
-        self.desired.mode_id = Some(mode_id.clone());
-        self.pending_events.push(AcpSessionEvent::DesiredModeChanged {
-            mode_id: ModeId::new(mode_id),
-        });
+        self.desired.mode_id = Some(mode.clone());
+        self.pending_events.push(AcpSessionEvent::DesiredModeChanged { mode });
         true
     }
 
     /// Set a user's desired config selection.
-    pub fn set_desired_config(&mut self, config_id: String, value: String) {
-        let changed = self.desired.config_selections.get(&config_id) != Some(&value);
-        self.desired.config_selections.insert(config_id, value);
+    pub fn set_desired_config(&mut self, key: ConfigKey, value: ConfigValue) {
+        let changed = self.desired.config_selections.get(&key) != Some(&value);
+        self.desired.config_selections.insert(key, value);
         if changed {
-            let selections = self
-                .desired
-                .config_selections
-                .iter()
-                .map(|(k, v)| (ConfigKey::new(k), ConfigValue::new(v)))
-                .collect();
+            let selections = self.desired.config_selections.clone();
             self.pending_events
                 .push(AcpSessionEvent::DesiredConfigChanged { selections });
         }
@@ -204,40 +212,38 @@ impl AcpSession {
 
     // ─── Observations (from CLI responses/notifications) ───────────────
 
-    pub fn apply_observed_mode(&mut self, mode_id: &str) {
-        let changed = self.observed.mode_id.as_deref() != Some(mode_id);
-        self.observed.mode_id = Some(mode_id.to_owned());
+    pub fn apply_observed_mode(&mut self, mode: ModeId) {
+        let changed = self.observed.mode_id.as_ref() != Some(&mode);
+        self.observed.mode_id = Some(mode.clone());
         if changed {
-            self.pending_events.push(AcpSessionEvent::ObservedModeSynced {
-                mode_id: ModeId::new(mode_id),
-            });
+            self.pending_events.push(AcpSessionEvent::ObservedModeSynced { mode });
         }
     }
 
-    pub fn apply_observed_model(&mut self, model_id: &str) {
-        let changed = self.observed.model_id.as_deref() != Some(model_id);
-        self.observed.model_id = Some(model_id.to_owned());
+    pub fn apply_observed_model(&mut self, model: ModelId) {
+        let changed = self.observed.model_id.as_ref() != Some(&model);
+        self.observed.model_id = Some(model.clone());
         if changed {
-            self.pending_events.push(AcpSessionEvent::ObservedModelSynced {
-                model_id: ModelId::new(model_id),
-            });
+            self.pending_events.push(AcpSessionEvent::ObservedModelSynced { model });
         }
     }
 
     pub fn apply_advertised_modes(&mut self, modes: SessionModeState) {
-        self.observed.mode_id = Some(modes.current_mode_id.to_string());
+        self.observed.mode_id = Some(ModeId::new(modes.current_mode_id.to_string()));
         self.advertised.modes = Some(modes);
     }
 
     pub fn apply_advertised_models(&mut self, models: SessionModelState) {
-        self.observed.model_id = Some(models.current_model_id.to_string());
+        self.observed.model_id = Some(ModelId::new(models.current_model_id.to_string()));
         self.advertised.models = Some(models);
     }
 
     pub fn apply_advertised_config_options(&mut self, options: Vec<SessionConfigOption>) {
         for opt in &options {
             if let Some(current) = extract_config_current_value(&opt.kind) {
-                self.observed.config_current.insert(opt.id.to_string(), current);
+                self.observed
+                    .config_current
+                    .insert(ConfigKey::new(opt.id.to_string()), ConfigValue::new(current));
             }
         }
         self.advertised.config_options = Some(options);
@@ -261,24 +267,24 @@ impl AcpSession {
 
     /// Update the model's current_model_id in place without replacing
     /// the available models list. Used after a successful `set_model` call.
-    pub fn update_current_model(&mut self, model_id: &str) {
+    pub fn update_current_model(&mut self, model: ModelId) {
         if let Some(info) = &self.advertised.models {
-            let updated = SessionModelState::new(model_id.to_owned(), info.available_models.clone());
+            let updated = SessionModelState::new(model.as_str().to_owned(), info.available_models.clone());
             self.advertised.models = Some(updated);
         }
-        self.observed.model_id = Some(model_id.to_owned());
+        self.observed.model_id = Some(model);
     }
 
     /// Seed the aggregate with persisted user choices from DB.
     /// Called on resume paths before the CLI session/load response arrives.
     pub fn preload_persisted(&mut self, state: &PersistedSessionState) {
-        if let Some(mode_id) = &state.current_mode_id {
-            self.advertised.modes = Some(SessionModeState::new(mode_id.clone(), Vec::new()));
-            self.observed.mode_id = Some(mode_id.clone());
+        if let Some(mode) = &state.current_mode_id {
+            self.advertised.modes = Some(SessionModeState::new(mode.as_str().to_owned(), Vec::new()));
+            self.observed.mode_id = Some(mode.clone());
         }
-        if let Some(model_id) = &state.current_model_id {
-            self.advertised.models = Some(SessionModelState::new(model_id.clone(), Vec::new()));
-            self.observed.model_id = Some(model_id.clone());
+        if let Some(model) = &state.current_model_id {
+            self.advertised.models = Some(SessionModelState::new(model.as_str().to_owned(), Vec::new()));
+            self.observed.model_id = Some(model.clone());
         }
         if !state.config_selections.is_empty() {
             self.observed.config_current = state.config_selections.clone();
@@ -289,14 +295,14 @@ impl AcpSession {
     }
 
     /// Apply a partial mode update (only currentModeId changed, keep available_modes).
-    pub fn apply_partial_mode_update(&mut self, current_mode_id: &str) {
+    pub fn apply_partial_mode_update(&mut self, current_mode: ModeId) {
         if let Some(existing) = &self.advertised.modes {
             let available = existing.available_modes.clone();
-            self.advertised.modes = Some(SessionModeState::new(current_mode_id.to_owned(), available));
+            self.advertised.modes = Some(SessionModeState::new(current_mode.as_str().to_owned(), available));
         } else {
-            self.advertised.modes = Some(SessionModeState::new(current_mode_id.to_owned(), Vec::new()));
+            self.advertised.modes = Some(SessionModeState::new(current_mode.as_str().to_owned(), Vec::new()));
         }
-        self.observed.mode_id = Some(current_mode_id.to_owned());
+        self.observed.mode_id = Some(current_mode);
     }
 
     // ─── Reconcile ─────────────────────────────────────────────────────
@@ -307,18 +313,18 @@ impl AcpSession {
         let mut actions = Vec::new();
 
         if let Some(desired_mode) = &self.desired.mode_id
-            && self.observed.mode_id.as_deref() != Some(desired_mode)
+            && self.observed.mode_id.as_ref() != Some(desired_mode)
         {
             actions.push(ReconcileAction::SetMode {
-                mode_id: ModeId::new(desired_mode),
+                mode: desired_mode.clone(),
             });
         }
 
-        for (config_id, desired_value) in &self.desired.config_selections {
-            if self.observed.config_current.get(config_id) != Some(desired_value) {
+        for (key, desired_value) in &self.desired.config_selections {
+            if self.observed.config_current.get(key) != Some(desired_value) {
                 actions.push(ReconcileAction::SetConfigOption {
-                    config_id: ConfigKey::new(config_id),
-                    value: ConfigValue::new(desired_value),
+                    key: key.clone(),
+                    value: desired_value.clone(),
                 });
             }
         }
@@ -358,20 +364,20 @@ mod tests {
     use super::*;
 
     fn make_session() -> AcpSession {
-        AcpSession::new(Some("default".into()), HashMap::new())
+        AcpSession::new(Some(ModeId::new("default")), HashMap::new())
     }
 
     #[test]
     fn assign_session_id_emits_event() {
         let mut session = make_session();
-        session.assign_session_id("sess-1".into());
+        session.assign_session_id(SessionId::new("sess-1"));
         assert_eq!(session.session_id(), Some("sess-1"));
         let events = session.drain_events();
         assert_eq!(events.len(), 1);
         assert_eq!(
             events[0],
             AcpSessionEvent::SessionAssigned {
-                session_id: "sess-1".into()
+                session_id: SessionId::new("sess-1"),
             }
         );
     }
@@ -379,9 +385,9 @@ mod tests {
     #[test]
     fn assign_session_id_is_idempotent() {
         let mut session = make_session();
-        session.assign_session_id("sess-1".into());
+        session.assign_session_id(SessionId::new("sess-1"));
         session.drain_events();
-        session.assign_session_id("sess-1".into());
+        session.assign_session_id(SessionId::new("sess-1"));
         assert!(session.drain_events().is_empty());
     }
 
@@ -399,28 +405,30 @@ mod tests {
     #[test]
     fn set_desired_mode_emits_when_changed() {
         let mut session = make_session();
-        assert!(session.set_desired_mode("plan".into()));
+        assert!(session.set_desired_mode(ModeId::new("plan")));
         assert_eq!(session.desired_mode(), Some("plan"));
         let events = session.drain_events();
         assert_eq!(
             events[0],
-            AcpSessionEvent::DesiredModeChanged { mode_id: "plan".into() }
+            AcpSessionEvent::DesiredModeChanged {
+                mode: ModeId::new("plan"),
+            }
         );
     }
 
     #[test]
     fn set_desired_mode_rejects_empty() {
         let mut session = make_session();
-        assert!(!session.set_desired_mode(String::new()));
+        assert!(!session.set_desired_mode(ModeId::new("")));
         assert!(session.drain_events().is_empty());
     }
 
     #[test]
     fn set_desired_mode_no_op_when_unchanged() {
         let mut session = make_session();
-        session.set_desired_mode("plan".into());
+        session.set_desired_mode(ModeId::new("plan"));
         session.drain_events();
-        assert!(!session.set_desired_mode("plan".into()));
+        assert!(!session.set_desired_mode(ModeId::new("plan")));
         assert!(session.drain_events().is_empty());
     }
 
@@ -431,22 +439,22 @@ mod tests {
             "code",
             vec![SessionMode::new("code", "Code"), SessionMode::new("plan", "Plan")],
         ));
-        assert!(session.set_desired_mode("plan".into()));
-        assert!(!session.set_desired_mode("nonexistent".into()));
+        assert!(session.set_desired_mode(ModeId::new("plan")));
+        assert!(!session.set_desired_mode(ModeId::new("nonexistent")));
     }
 
     #[test]
     fn set_desired_mode_allows_any_when_advertised_empty() {
         let mut session = make_session();
-        assert!(session.set_desired_mode("anything".into()));
+        assert!(session.set_desired_mode(ModeId::new("anything")));
     }
 
     #[test]
     fn apply_observed_mode_does_not_change_desired() {
         let mut session = make_session();
-        session.set_desired_mode("plan".into());
+        session.set_desired_mode(ModeId::new("plan"));
         session.drain_events();
-        session.apply_observed_mode("code");
+        session.apply_observed_mode(ModeId::new("code"));
         assert_eq!(session.desired_mode(), Some("plan"));
         assert_eq!(session.observed_mode(), Some("code"));
     }
@@ -454,30 +462,35 @@ mod tests {
     #[test]
     fn plan_reconcile_detects_mode_drift() {
         let mut session = make_session();
-        session.set_desired_mode("plan".into());
-        session.apply_observed_mode("default");
+        session.set_desired_mode(ModeId::new("plan"));
+        session.apply_observed_mode(ModeId::new("default"));
         let actions = session.plan_reconcile();
-        assert_eq!(actions, vec![ReconcileAction::SetMode { mode_id: "plan".into() }]);
+        assert_eq!(
+            actions,
+            vec![ReconcileAction::SetMode {
+                mode: ModeId::new("plan"),
+            }]
+        );
     }
 
     #[test]
     fn plan_reconcile_empty_when_aligned() {
         let mut session = make_session();
-        session.set_desired_mode("plan".into());
-        session.apply_observed_mode("plan");
+        session.set_desired_mode(ModeId::new("plan"));
+        session.apply_observed_mode(ModeId::new("plan"));
         assert!(session.plan_reconcile().is_empty());
     }
 
     #[test]
     fn plan_reconcile_detects_config_drift() {
         let mut session = AcpSession::new(None, HashMap::new());
-        session.set_desired_config("reasoning".into(), "high".into());
+        session.set_desired_config(ConfigKey::new("reasoning"), ConfigValue::new("high"));
         let actions = session.plan_reconcile();
         assert_eq!(
             actions,
             vec![ReconcileAction::SetConfigOption {
-                config_id: "reasoning".into(),
-                value: "high".into(),
+                key: ConfigKey::new("reasoning"),
+                value: ConfigValue::new("high"),
             }]
         );
     }
@@ -485,7 +498,7 @@ mod tests {
     #[test]
     fn plan_reconcile_config_aligned_when_observed_matches() {
         let mut session = AcpSession::new(None, HashMap::new());
-        session.set_desired_config("reasoning".into(), "high".into());
+        session.set_desired_config(ConfigKey::new("reasoning"), ConfigValue::new("high"));
 
         session.apply_advertised_config_options(vec![SessionConfigOption::select(
             "reasoning",
@@ -502,7 +515,7 @@ mod tests {
     #[test]
     fn drain_events_clears_buffer() {
         let mut session = make_session();
-        session.assign_session_id("s1".into());
+        session.assign_session_id(SessionId::new("s1"));
         session.mark_opened();
         assert_eq!(session.drain_events().len(), 2);
         assert!(session.drain_events().is_empty());

--- a/crates/aionui-ai-agent/src/manager/acp/session_sync.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session_sync.rs
@@ -19,6 +19,7 @@ use crate::acp_agent::AcpAgentManager;
 use crate::agent_manager::AgentManagerHandle;
 use crate::manager::acp::PersistedSessionState as SnapshotPersistedState;
 use crate::manager::acp::events::AcpSessionEvent;
+use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId};
 use crate::stream_event::AgentStreamEvent;
 
 const DEBOUNCE_WINDOW: Duration = Duration::from_millis(500);
@@ -109,14 +110,17 @@ impl AcpSessionSyncService {
         };
 
         let mut state = SnapshotPersistedState {
-            current_mode_id: row.current_mode_id,
-            current_model_id: row.current_model_id,
+            current_mode_id: row.current_mode_id.map(ModeId::new),
+            current_model_id: row.current_model_id.map(ModelId::new),
             ..Default::default()
         };
         if let Some(raw) = row.config_selections_json
-            && let Ok(map) = serde_json::from_str(&raw)
+            && let Ok(map) = serde_json::from_str::<HashMap<String, String>>(&raw)
         {
-            state.config_selections = map;
+            state.config_selections = map
+                .into_iter()
+                .map(|(k, v)| (ConfigKey::new(k), ConfigValue::new(v)))
+                .collect();
         }
         if let Some(raw) = row.context_usage_json
             && let Ok(usage) = serde_json::from_str(&raw)
@@ -155,8 +159,8 @@ impl PendingUpdate {
 
     fn merge_from_domain_event(&mut self, event: &AcpSessionEvent) -> bool {
         match event {
-            AcpSessionEvent::DesiredModeChanged { mode_id } => {
-                self.current_mode_id = Some(Some(mode_id.as_str().to_owned()));
+            AcpSessionEvent::DesiredModeChanged { mode } => {
+                self.current_mode_id = Some(Some(mode.as_str().to_owned()));
                 true
             }
             AcpSessionEvent::DesiredConfigChanged { selections } => {
@@ -168,8 +172,8 @@ impl PendingUpdate {
                 self.config_selections_json = Some(Some(json));
                 true
             }
-            AcpSessionEvent::ObservedModelSynced { model_id } => {
-                self.current_model_id = Some(Some(model_id.as_str().to_owned()));
+            AcpSessionEvent::ObservedModelSynced { model } => {
+                self.current_model_id = Some(Some(model.as_str().to_owned()));
                 true
             }
             _ => false,
@@ -321,7 +325,7 @@ mod tests {
         let cid = "conv-1".to_owned();
         tokio::spawn(domain_event_consumer(cid, rx, repo.clone()));
 
-        tx.send(AcpSessionEvent::DesiredModeChanged { mode_id: "plan".into() })
+        tx.send(AcpSessionEvent::DesiredModeChanged { mode: "plan".into() })
             .await
             .unwrap();
 
@@ -344,7 +348,7 @@ mod tests {
         tokio::spawn(domain_event_consumer(cid, rx, repo.clone()));
 
         for label in ["code", "plan", "ask"] {
-            tx.send(AcpSessionEvent::DesiredModeChanged { mode_id: label.into() })
+            tx.send(AcpSessionEvent::DesiredModeChanged { mode: label.into() })
                 .await
                 .unwrap();
             sleep(Duration::from_millis(100)).await;
@@ -380,7 +384,7 @@ mod tests {
         let cid = "conv-1".to_owned();
         tokio::spawn(domain_event_consumer(cid, rx, repo.clone()));
 
-        tx.send(AcpSessionEvent::DesiredModeChanged { mode_id: "plan".into() })
+        tx.send(AcpSessionEvent::DesiredModeChanged { mode: "plan".into() })
             .await
             .unwrap();
         drop(tx);

--- a/crates/aionui-ai-agent/src/manager/acp/session_sync.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session_sync.rs
@@ -15,12 +15,9 @@ use tokio::task::JoinHandle;
 use tokio::time::sleep_until;
 use tracing::{debug, warn};
 
-use crate::acp_agent::AcpAgentManager;
-use crate::agent_manager::AgentManagerHandle;
 use crate::manager::acp::PersistedSessionState as SnapshotPersistedState;
 use crate::manager::acp::events::AcpSessionEvent;
 use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId};
-use crate::stream_event::AgentStreamEvent;
 
 const DEBOUNCE_WINDOW: Duration = Duration::from_millis(500);
 
@@ -55,47 +52,11 @@ impl AcpSessionSyncService {
         }
     }
 
-    /// Wire a newly-constructed manager into the service:
-    ///
-    /// 1. Load persisted runtime state and seed the manager's session.
-    /// 2. Spawn a per-conversation consumer task that subscribes to the
-    ///    manager's domain event channel and writes intent changes to DB.
-    pub async fn attach(
-        &self,
-        conversation_id: String,
-        handle: AgentManagerHandle,
-        domain_rx: mpsc::Receiver<AcpSessionEvent>,
-    ) {
-        if let Some(acp) = handle.as_any().downcast_ref::<AcpAgentManager>() {
-            if let Some(state) = self.load_snapshot_state(&conversation_id).await {
-                acp.preload_snapshot(state).await;
-            }
-            if let Ok(Some(row)) = self.repo.get(&conversation_id).await
-                && let Some(sid) = row.session_id
-            {
-                acp.restore_session_id(sid).await;
-            }
-        }
-
-        // Spawn domain-event consumer (replaces broadcast-based consumer).
-        let repo = self.repo.clone();
-        let cid = conversation_id.clone();
-        let task = tokio::spawn(domain_event_consumer(cid, domain_rx, repo));
-
-        // Also spawn broadcast consumer for session_id assignment which
-        // fires through the existing AgentStreamEvent::SessionAssigned path.
-        let rx = handle.subscribe();
-        let repo2 = self.repo.clone();
-        let cid2 = conversation_id.clone();
-        tokio::spawn(session_id_consumer(cid2, rx, repo2));
-
-        let mut guard = self.active.write().await;
-        if let Some(prev) = guard.insert(conversation_id, task) {
-            prev.abort();
-        }
-    }
-
-    async fn load_snapshot_state(&self, conversation_id: &str) -> Option<SnapshotPersistedState> {
+    /// Read the decoded per-session runtime state, mapped into the
+    /// aggregate's value-object shape. Returns `None` when the row does
+    /// not exist or the JSON payload is empty. Errors are logged and
+    /// swallowed so the caller can proceed with a fresh session.
+    pub async fn load_snapshot_state(&self, conversation_id: &str) -> Option<SnapshotPersistedState> {
         let row = match self.repo.load_runtime_state(conversation_id).await {
             Ok(Some(row)) => row,
             Ok(None) => return None,
@@ -128,6 +89,39 @@ impl AcpSessionSyncService {
             state.context_usage = Some(usage);
         }
         Some(state)
+    }
+
+    /// Read the persisted CLI-assigned session id, if any.
+    /// Used by the factory on resume paths to seed the aggregate before
+    /// the first prompt.
+    pub async fn load_session_id(&self, conversation_id: &str) -> Option<String> {
+        match self.repo.get(conversation_id).await {
+            Ok(Some(row)) => row.session_id,
+            Ok(None) => None,
+            Err(err) => {
+                warn!(
+                    conversation_id,
+                    error = %err,
+                    "load_session_id: repository failed"
+                );
+                None
+            }
+        }
+    }
+
+    /// Take ownership of the manager's domain event receiver and spawn
+    /// the per-conversation persistence consumer. Lifetime of the
+    /// spawned task is tied to the sender being dropped when the manager
+    /// is destroyed.
+    pub async fn attach(&self, conversation_id: String, domain_rx: mpsc::Receiver<AcpSessionEvent>) {
+        let repo = self.repo.clone();
+        let cid = conversation_id.clone();
+        let task = tokio::spawn(domain_event_consumer(cid, domain_rx, repo));
+
+        let mut guard = self.active.write().await;
+        if let Some(prev) = guard.insert(conversation_id, task) {
+            prev.abort();
+        }
     }
 }
 
@@ -183,6 +177,10 @@ impl PendingUpdate {
 
 /// Consume domain events from the session aggregate and persist user
 /// intent changes with a debounce window.
+///
+/// `SessionAssigned` bypasses the debounce: the CLI-issued id must be
+/// written immediately so the next turn can take the resume path even
+/// if the process crashes before any other event fires.
 async fn domain_event_consumer(
     conversation_id: String,
     mut rx: mpsc::Receiver<AcpSessionEvent>,
@@ -209,6 +207,21 @@ async fn domain_event_consumer(
 
         match recv {
             Some(event) => {
+                if let AcpSessionEvent::SessionAssigned { session_id } = &event {
+                    match repo.update_session_id(&conversation_id, session_id.as_str()).await {
+                        Ok(true) => {}
+                        Ok(false) => debug!(
+                            conversation_id,
+                            "session-sync: acp_session row missing; session_id not written"
+                        ),
+                        Err(err) => warn!(
+                            conversation_id,
+                            error = %err,
+                            "session-sync: update_session_id failed"
+                        ),
+                    }
+                    continue;
+                }
                 if pending.merge_from_domain_event(&event) {
                     flush_at = Some(Instant::now() + DEBOUNCE_WINDOW);
                 }
@@ -218,41 +231,6 @@ async fn domain_event_consumer(
                 debug!(conversation_id, "session-sync domain consumer exiting");
                 return;
             }
-        }
-    }
-}
-
-/// Lightweight consumer that only handles session_id assignment from the
-/// broadcast stream. This event fires exactly once per conversation when
-/// the CLI responds to `session/new`.
-async fn session_id_consumer(
-    conversation_id: String,
-    mut rx: tokio::sync::broadcast::Receiver<AgentStreamEvent>,
-    repo: Arc<dyn IAcpSessionRepository>,
-) {
-    loop {
-        match rx.recv().await {
-            Ok(AgentStreamEvent::SessionAssigned(data)) => {
-                match repo.update_session_id(&conversation_id, &data.session_id).await {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        debug!(
-                            conversation_id,
-                            "session-sync: acp_session row missing; session_id not written"
-                        );
-                    }
-                    Err(err) => {
-                        warn!(
-                            conversation_id,
-                            error = %err,
-                            "session-sync: update_session_id failed"
-                        );
-                    }
-                }
-            }
-            Ok(_) => continue,
-            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
-            Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
         }
     }
 }
@@ -281,6 +259,7 @@ async fn flush(repo: &Arc<dyn IAcpSessionRepository>, conversation_id: &str, pen
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shared_kernel::SessionId;
     use aionui_db::{CreateAcpSessionParams, SqliteAcpSessionRepository, init_database_memory};
     use tokio::time::sleep;
 
@@ -396,5 +375,28 @@ mod tests {
             Some("plan"),
             "pending update must flush on channel close"
         );
+    }
+
+    /// SessionAssigned must write the session_id immediately, bypassing
+    /// the debounce window used for desired-state updates.
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_assigned_writes_session_id_immediately() {
+        let (_svc, repo) = setup().await;
+        let (tx, rx) = mpsc::channel(64);
+
+        let cid = "conv-1".to_owned();
+        tokio::spawn(domain_event_consumer(cid, rx, repo.clone()));
+
+        tx.send(AcpSessionEvent::SessionAssigned {
+            session_id: SessionId::new("sess-42"),
+        })
+        .await
+        .unwrap();
+
+        // Well under the debounce window — the event must have already
+        // been written.
+        sleep(Duration::from_millis(100)).await;
+        let row = repo.get("conv-1").await.unwrap().unwrap();
+        assert_eq!(row.session_id.as_deref(), Some("sess-42"));
     }
 }


### PR DESCRIPTION
## Summary

三个 commit 收尾聚合化改造（详见 `tmp/05-migration-plan.md` 的 PR #7b-6 段）：

- **6a** `refactor(ai-agent): use newtype value objects inside AcpSession aggregate`
  `ModeId`/`ModelId`/`SessionId`/`ConfigKey`/`ConfigValue` 正式渗入 `AcpSession`
  内部字段和命令 API。路由入口处做一次 `String → newtype` 转换。
- **6b** `refactor(ai-agent): route SessionAssigned through domain events, remove sync downcast`
  `AcpSessionSyncService` 通过 `AcpSessionEvent::SessionAssigned` 持久化
  session_id，删除 `session_id_consumer` + 消除 `as_any().downcast_ref`。
  `preload_snapshot` / `restore_session_id` 的职责上移到 factory。
- **6c** `refactor(ai-agent): extract CatalogForwarder into dedicated module`
  把 `start_catalog_sync` + `catalog_partial_from_event` 搬到
  `manager/acp/catalog_forwarder.rs`。订阅源保持 `AgentStreamEvent`
  不变（升级到 `AcpSessionEvent` 留给后续 DDD 演进）。

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace -- -D warnings`
- [ ] `cargo test -p aionui-ai-agent`
- [ ] `cargo test -p aionui-app`
- [ ] 场景 A：新建 ACP 会话 → DB `acp_session.session_id` 被写入
- [ ] 场景 B：idle 回收后重连 → preload + restore 在 factory 构造时完成
- [ ] 场景 C：CLI session/update → 聚合不污染 desired，DB 保持不变