### PR TITLE
refactor(ai-agent): IAgentTask trait + AgentInstance enum dispatch

### DIFF
--- a/crates/aionui-ai-agent/Cargo.toml
+++ b/crates/aionui-ai-agent/Cargo.toml
@@ -38,5 +38,20 @@ uuid.workspace = true
 agent-client-protocol = { version = "0.11.1", features = ["unstable_session_model", "unstable_session_close", "unstable_session_usage", "unstable_session_fork", "unstable_session_additional_directories", "unstable_session_resume"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 
+[features]
+# Enables the `AgentInstance::Mock` variant used by downstream test harnesses
+# (conversation/cron/team/app) to inject trait-object stubs without having to
+# spawn a real agent process. Production builds must NOT turn this on — it
+# introduces a `dyn IAgentTask` branch that defeats the enum's zero-dispatch
+# guarantee.
+test-support = []
+
 [dev-dependencies]
 tempfile = "3"
+
+# Integration tests under `tests/` need the `AgentInstance::Mock` variant.
+# Unlike unit tests (which see `cfg(test)` on the library), integration
+# tests compile as separate binaries and must opt in via a feature.
+[[test]]
+name = "agent_types_integration"
+required-features = ["test-support"]

--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -1,4 +1,3 @@
-use crate::IAgentManager;
 use crate::acp_protocol::AcpProtocol;
 use crate::agent_registry::CatalogSender;
 use crate::cli_process::CliAgentProcess;
@@ -892,9 +891,17 @@ impl AcpAgentManager {
 }
 
 #[async_trait::async_trait]
-impl IAgentManager for AcpAgentManager {
+impl crate::agent_task::IAgentTask for AcpAgentManager {
     fn agent_type(&self) -> AgentType {
         AgentType::Acp
+    }
+
+    fn conversation_id(&self) -> &str {
+        &self.params.conversation_id
+    }
+
+    fn workspace(&self) -> &str {
+        &self.params.workspace.path
     }
 
     fn status(&self) -> Option<ConversationStatus> {
@@ -903,14 +910,6 @@ impl IAgentManager for AcpAgentManager {
             Ok(guard) => *guard,
             Err(_) => None,
         }
-    }
-
-    fn workspace(&self) -> &str {
-        &self.params.workspace.path
-    }
-
-    fn conversation_id(&self) -> &str {
-        &self.params.conversation_id
     }
 
     fn last_activity_at(&self) -> TimestampMs {
@@ -959,28 +958,6 @@ impl IAgentManager for AcpAgentManager {
         Ok(())
     }
 
-    fn confirm(
-        &self,
-        _msg_id: &str,
-        call_id: &str,
-        data: serde_json::Value,
-        _always_allow: bool,
-    ) -> Result<(), AppError> {
-        let option_id = confirm_option_id(&data)
-            .ok_or_else(|| AppError::BadRequest("ACP confirmation requires an option_id string".into()))?;
-
-        self.permission_router
-            .confirm(call_id, option_id, &self.params.conversation_id)
-    }
-
-    fn get_confirmations(&self) -> Vec<Confirmation> {
-        Vec::new()
-    }
-
-    fn check_approval(&self, _action: &str, _command_type: Option<&str>) -> bool {
-        false
-    }
-
     fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
         info!(
             conversation_id = %self.params.conversation_id,
@@ -1011,8 +988,45 @@ impl IAgentManager for AcpAgentManager {
 
         Ok(())
     }
+}
 
-    async fn get_mode(&self) -> Result<aionui_api_types::AgentModeResponse, AppError> {
+/// ACP-specific operations that used to live on `IAgentManager` and are
+/// now reached through `AgentInstance::Acp(..)` matches in the routes +
+/// services. Kept as inherent methods so the enum-match callsite reads
+/// `m.get_mode()` with no trait import.
+impl AcpAgentManager {
+    /// Submit a permission response for a pending tool call. ACP confirms
+    /// always carry an `option_id`; `always_allow` is consumed by the CLI
+    /// and is not reflected in the local approval memory (the ACP CLI
+    /// tracks its own).
+    pub fn confirm(
+        &self,
+        _msg_id: &str,
+        call_id: &str,
+        data: serde_json::Value,
+        _always_allow: bool,
+    ) -> Result<(), AppError> {
+        let option_id = confirm_option_id(&data)
+            .ok_or_else(|| AppError::BadRequest("ACP confirmation requires an option_id string".into()))?;
+
+        self.permission_router
+            .confirm(call_id, option_id, &self.params.conversation_id)
+    }
+
+    /// ACP tracks pending permission prompts through the permission
+    /// router, not through a surfaced confirmation list, so the enum-
+    /// level helper returns empty when the variant is ACP.
+    pub fn get_confirmations(&self) -> Vec<Confirmation> {
+        Vec::new()
+    }
+
+    /// Approval memory is not tracked at the manager level for ACP —
+    /// every tool request round-trips through the CLI.
+    pub fn check_approval(&self, _action: &str, _command_type: Option<&str>) -> bool {
+        false
+    }
+
+    pub async fn get_mode(&self) -> Result<aionui_api_types::AgentModeResponse, AppError> {
         let desired = self
             .desired_mode()
             .await
@@ -1029,7 +1043,7 @@ impl IAgentManager for AcpAgentManager {
         })
     }
 
-    async fn set_mode(&self, mode: &str) -> Result<(), AppError> {
+    pub async fn set_mode(&self, mode: &str) -> Result<(), AppError> {
         let normalized_mode = normalize_requested_mode(&self.params.metadata, mode);
         if normalized_mode.is_empty() {
             return Ok(());
@@ -1050,47 +1064,6 @@ impl IAgentManager for AcpAgentManager {
         session.set_desired_mode(ModeId::new(normalized_mode));
         self.commit_session_changes(&mut session).await;
         Ok(())
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-}
-
-/// PR #8a: the new, slim `IAgentTask` surface delegates to the existing
-/// `IAgentManager` methods. Once PR #8c deletes `IAgentManager`, these
-/// bodies will absorb the underlying implementations directly.
-#[async_trait::async_trait]
-impl crate::agent_task::IAgentTask for AcpAgentManager {
-    fn agent_type(&self) -> AgentType {
-        <Self as IAgentManager>::agent_type(self)
-    }
-    fn conversation_id(&self) -> &str {
-        <Self as IAgentManager>::conversation_id(self)
-    }
-    fn workspace(&self) -> &str {
-        <Self as IAgentManager>::workspace(self)
-    }
-    fn status(&self) -> Option<ConversationStatus> {
-        <Self as IAgentManager>::status(self)
-    }
-    fn last_activity_at(&self) -> TimestampMs {
-        <Self as IAgentManager>::last_activity_at(self)
-    }
-    fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
-        <Self as IAgentManager>::subscribe(self)
-    }
-    fn subscribe_stream(&self) -> broadcast::Receiver<AgentStreamChunk> {
-        <Self as IAgentManager>::subscribe_stream(self)
-    }
-    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
-        <Self as IAgentManager>::send_message(self, data).await
-    }
-    async fn stop(&self) -> Result<(), AppError> {
-        <Self as IAgentManager>::stop(self).await
-    }
-    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
-        <Self as IAgentManager>::kill(self, reason)
     }
 }
 

--- a/crates/aionui-ai-agent/src/acp_agent.rs
+++ b/crates/aionui-ai-agent/src/acp_agent.rs
@@ -1057,6 +1057,43 @@ impl IAgentManager for AcpAgentManager {
     }
 }
 
+/// PR #8a: the new, slim `IAgentTask` surface delegates to the existing
+/// `IAgentManager` methods. Once PR #8c deletes `IAgentManager`, these
+/// bodies will absorb the underlying implementations directly.
+#[async_trait::async_trait]
+impl crate::agent_task::IAgentTask for AcpAgentManager {
+    fn agent_type(&self) -> AgentType {
+        <Self as IAgentManager>::agent_type(self)
+    }
+    fn conversation_id(&self) -> &str {
+        <Self as IAgentManager>::conversation_id(self)
+    }
+    fn workspace(&self) -> &str {
+        <Self as IAgentManager>::workspace(self)
+    }
+    fn status(&self) -> Option<ConversationStatus> {
+        <Self as IAgentManager>::status(self)
+    }
+    fn last_activity_at(&self) -> TimestampMs {
+        <Self as IAgentManager>::last_activity_at(self)
+    }
+    fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
+        <Self as IAgentManager>::subscribe(self)
+    }
+    fn subscribe_stream(&self) -> broadcast::Receiver<AgentStreamChunk> {
+        <Self as IAgentManager>::subscribe_stream(self)
+    }
+    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+        <Self as IAgentManager>::send_message(self, data).await
+    }
+    async fn stop(&self) -> Result<(), AppError> {
+        <Self as IAgentManager>::stop(self).await
+    }
+    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        <Self as IAgentManager>::kill(self, reason)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aionui-ai-agent/src/agent_manager.rs
+++ b/crates/aionui-ai-agent/src/agent_manager.rs
@@ -1,117 +1,12 @@
-use std::any::Any;
-use std::sync::Arc;
-
-use aionui_api_types::AgentModeResponse;
-use aionui_common::{AgentKillReason, AgentType, AppError, Confirmation, ConversationStatus, TimestampMs};
-use tokio::sync::broadcast;
-
-use crate::stream_event::AgentStreamEvent;
-use crate::types::{AgentStreamChunk, SendMessageData};
-
-/// Core trait for managing a single Agent instance.
-///
-/// Each concrete implementation (ACP, Gemini, OpenClaw, Nanobot, Remote, Aionrs)
-/// provides the actual process management and communication logic.
-/// All methods must be safe to call from any async task (`Send + Sync`).
-#[async_trait::async_trait]
-pub trait IAgentManager: Send + Sync {
-    /// The type of agent this manager controls.
-    fn agent_type(&self) -> AgentType;
-
-    /// Current conversation status as seen by this agent.
-    /// Returns `None` if the agent has not been initialized yet.
-    fn status(&self) -> Option<ConversationStatus>;
-
-    /// Working directory for this agent session.
-    fn workspace(&self) -> &str;
-
-    /// Conversation ID this agent is bound to.
-    fn conversation_id(&self) -> &str;
-
-    /// Timestamp (ms) of the last activity (message send, event received).
-    fn last_activity_at(&self) -> TimestampMs;
-
-    /// Subscribe to the agent's stream event channel.
-    ///
-    /// Returns a broadcast receiver that yields [`AgentStreamEvent`] values
-    /// as the agent processes a message turn.
-    fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent>;
-
-    /// Subscribe to the raw stream chunk channel (used by team scheduler for watchdogs).
-    ///
-    /// Returns a broadcast receiver yielding [`AgentStreamChunk`] values.
-    /// Default implementation returns a receiver that immediately closes (for non-ACP agents).
-    fn subscribe_stream(&self) -> broadcast::Receiver<AgentStreamChunk> {
-        let (tx, _) = broadcast::channel(1);
-        tx.subscribe()
-    }
-
-    /// Send a user message to the agent.
-    ///
-    /// This triggers the agent to start processing. Events are emitted
-    /// on the broadcast channel returned by [`subscribe`](Self::subscribe).
-    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError>;
-
-    /// Stop the current streaming response without killing the agent.
-    async fn stop(&self) -> Result<(), AppError>;
-
-    /// Submit a confirmation response for a pending tool call.
-    ///
-    /// If `always_allow` is `true`, the confirmation's `action` (and optional
-    /// `command_type`) are recorded in the session-level approval memory so
-    /// that future identical requests can be auto-approved by the frontend.
-    fn confirm(&self, msg_id: &str, call_id: &str, data: serde_json::Value, always_allow: bool)
-    -> Result<(), AppError>;
-
-    /// Get the list of pending confirmation items.
-    fn get_confirmations(&self) -> Vec<Confirmation>;
-
-    /// Check whether an action has been marked "always allow" in this session.
-    ///
-    /// The approval memory is session-level (cleared when the agent is killed).
-    fn check_approval(&self, action: &str, command_type: Option<&str>) -> bool;
-
-    /// Terminate the agent process.
-    ///
-    /// - `reason: Some(IdleTimeout)` — idle cleanup
-    /// - `reason: None` — explicit user/system kill
-    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError>;
-
-    /// Get the current session mode.
-    /// Default: returns "default" with initialized=false.
-    async fn get_mode(&self) -> Result<AgentModeResponse, AppError> {
-        Ok(AgentModeResponse {
-            mode: "default".into(),
-            initialized: false,
-        })
-    }
-
-    /// Set the session mode.
-    /// Default: returns error (unsupported).
-    async fn set_mode(&self, _mode: &str) -> Result<(), AppError> {
-        Err(AppError::BadRequest(
-            "Mode switching is not supported for this agent type".into(),
-        ))
-    }
-
-    /// Return the current session key if the agent type supports it.
-    ///
-    /// Used by the conversation service to persist session keys for
-    /// agent types that support session resume (e.g. OpenClaw Gateway).
-    fn get_session_key(&self) -> Option<String> {
-        None
-    }
-
-    /// Downcast helper for accessing type-specific extensions.
-    ///
-    /// Concrete implementations return `self` so that route handlers can
-    /// downcast `AgentManagerHandle` to e.g. `AcpAgentManager` for
-    /// ACP-specific operations (mode/model/config management).
-    fn as_any(&self) -> &dyn Any;
-}
-
-/// Type-erased handle to an agent manager, shareable across async tasks.
-pub type AgentManagerHandle = Arc<dyn IAgentManager>;
+//! Helpers shared across agent managers.
+//!
+//! Historically this module defined the fat `IAgentManager` trait, its
+//! `Arc<dyn IAgentManager>` handle alias, and the `as_any` downcast hook.
+//! Those are gone (see PR #8): the public agent surface is now the ten-
+//! method `IAgentTask` trait in [`crate::agent_task`], and type-specific
+//! operations are dispatched through the [`crate::agent_task::AgentInstance`]
+//! enum. What remains here is the small free function every concrete
+//! manager uses to build the session-level approval-memory key.
 
 /// Build the approval memory key from action and optional command_type.
 ///
@@ -130,8 +25,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn subscribe_stream_receiver_is_send_sync() {
-        fn assert_send_sync<T: Send + Sync>() {}
-        assert_send_sync::<broadcast::Receiver<crate::types::AgentStreamChunk>>();
+    fn approval_key_formats_matches_previous_contract() {
+        assert_eq!(approval_key(Some("exec"), Some("curl")), "exec:curl");
+        assert_eq!(approval_key(Some("exec"), None), "exec");
+        assert_eq!(approval_key(None, Some("curl")), "");
+        assert_eq!(approval_key(None, None), "");
     }
 }

--- a/crates/aionui-ai-agent/src/agent_task.rs
+++ b/crates/aionui-ai-agent/src/agent_task.rs
@@ -9,16 +9,14 @@
 //! and is reached through the `AgentInstance` enum — forcing every callsite
 //! to say out loud which agent type it is addressing.
 //!
-//! This replaces the old bloated `IAgentManager` trait + `as_any()`
-//! downcast pattern (see `agent_manager.rs` — still present during the
-//! PR #8 migration, scheduled for removal in PR #8c).
+//! Replaces the old bloated `IAgentManager` trait + `as_any()` downcast
+//! pattern (deleted in PR #8c).
 use std::sync::Arc;
 
 use aionui_common::{AgentKillReason, AgentType, AppError, ConversationStatus, TimestampMs};
 use tokio::sync::broadcast;
 
 use crate::acp_agent::AcpAgentManager;
-use crate::agent_manager::IAgentManager;
 use crate::aionrs_agent::AionrsAgentManager;
 use crate::manager::remote::RemoteAgentManager;
 use crate::nanobot_agent::NanobotAgentManager;

--- a/crates/aionui-ai-agent/src/agent_task.rs
+++ b/crates/aionui-ai-agent/src/agent_task.rs
@@ -26,6 +26,9 @@ use crate::openclaw::OpenClawAgentManager;
 use crate::stream_event::AgentStreamEvent;
 use crate::types::{AgentStreamChunk, SendMessageData};
 
+#[cfg(any(test, feature = "test-support"))]
+use aionui_common::Confirmation;
+
 /// Ten-method public surface every agent type implements identically.
 ///
 /// Object-safe by construction (no generic methods, no `Self` by value).
@@ -77,6 +80,49 @@ pub trait IAgentTask: Send + Sync {
     fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError>;
 }
 
+/// Extended trait used exclusively by the `AgentInstance::Mock` variant so
+/// tests can inject richer fake behaviour (pending confirmations, approval
+/// memory, fake session keys, etc.) without polluting the production
+/// `IAgentTask` contract with trait-level defaults that would be lies for
+/// at least one concrete manager.
+///
+/// Every method has a sensible identity-style default so simple mocks only
+/// need to implement the ten `IAgentTask` methods and pick up nothing for
+/// free.
+#[cfg(any(test, feature = "test-support"))]
+#[async_trait::async_trait]
+pub trait IMockAgent: IAgentTask {
+    fn get_confirmations(&self) -> Vec<Confirmation> {
+        Vec::new()
+    }
+    fn check_approval(&self, _action: &str, _command_type: Option<&str>) -> bool {
+        false
+    }
+    fn confirm(
+        &self,
+        _msg_id: &str,
+        _call_id: &str,
+        _data: serde_json::Value,
+        _always_allow: bool,
+    ) -> Result<(), AppError> {
+        Ok(())
+    }
+    fn get_session_key(&self) -> Option<String> {
+        None
+    }
+    async fn get_mode(&self) -> Result<aionui_api_types::AgentModeResponse, AppError> {
+        Ok(aionui_api_types::AgentModeResponse {
+            mode: "default".into(),
+            initialized: false,
+        })
+    }
+    async fn set_mode(&self, _mode: &str) -> Result<(), AppError> {
+        Err(AppError::BadRequest(
+            "Mode switching is not supported for this mock".into(),
+        ))
+    }
+}
+
 /// Concrete, closed-set dispatcher for the five agent variants.
 ///
 /// Every generic path holds an `AgentInstance` (not `Arc<dyn IAgentTask>`):
@@ -93,6 +139,17 @@ pub enum AgentInstance {
     OpenClaw(Arc<OpenClawAgentManager>),
     Nanobot(Arc<NanobotAgentManager>),
     Remote(Arc<RemoteAgentManager>),
+    /// Test-only trait-object escape hatch used by downstream crates
+    /// (conversation/cron/team/app tests) to inject fake agents without
+    /// spinning up a real CLI or WebSocket connection. Gated behind
+    /// `#[cfg(any(test, feature = "test-support"))]`: production builds
+    /// never see this variant, so every `match` in release code can
+    /// rely on the five-variant closed set. The trait object is
+    /// [`IMockAgent`] (extends `IAgentTask`) so mocks can also override
+    /// the enum-level helpers — `get_confirmations`, `check_approval`,
+    /// `confirm`, `get_session_key`, `get_mode`, `set_mode`.
+    #[cfg(any(test, feature = "test-support"))]
+    Mock(Arc<dyn IMockAgent>),
 }
 
 impl AgentInstance {
@@ -104,6 +161,8 @@ impl AgentInstance {
             Self::OpenClaw(m) => m.as_ref(),
             Self::Nanobot(m) => m.as_ref(),
             Self::Remote(m) => m.as_ref(),
+            #[cfg(any(test, feature = "test-support"))]
+            Self::Mock(m) => m.as_ref(),
         }
     }
 
@@ -183,6 +242,8 @@ impl AgentInstance {
             Self::OpenClaw(m) => m.get_confirmations(),
             Self::Nanobot(_) => Vec::new(),
             Self::Remote(m) => m.get_confirmations(),
+            #[cfg(any(test, feature = "test-support"))]
+            Self::Mock(m) => m.get_confirmations(),
         }
     }
 
@@ -200,6 +261,8 @@ impl AgentInstance {
             Self::OpenClaw(m) => m.confirm(msg_id, call_id, data, always_allow),
             Self::Nanobot(m) => m.confirm(msg_id, call_id, data, always_allow),
             Self::Remote(m) => m.confirm(msg_id, call_id, data, always_allow),
+            #[cfg(any(test, feature = "test-support"))]
+            Self::Mock(m) => m.confirm(msg_id, call_id, data, always_allow),
         }
     }
 
@@ -211,6 +274,8 @@ impl AgentInstance {
             Self::OpenClaw(m) => m.check_approval(action, command_type),
             Self::Nanobot(_) => false,
             Self::Remote(m) => m.check_approval(action, command_type),
+            #[cfg(any(test, feature = "test-support"))]
+            Self::Mock(m) => m.check_approval(action, command_type),
         }
     }
 
@@ -219,6 +284,8 @@ impl AgentInstance {
         match self {
             Self::OpenClaw(m) => m.get_session_key(),
             Self::Acp(_) | Self::Aionrs(_) | Self::Nanobot(_) | Self::Remote(_) => None,
+            #[cfg(any(test, feature = "test-support"))]
+            Self::Mock(m) => m.get_session_key(),
         }
     }
 
@@ -233,6 +300,8 @@ impl AgentInstance {
                 mode: "default".into(),
                 initialized: false,
             }),
+            #[cfg(any(test, feature = "test-support"))]
+            Self::Mock(m) => m.get_mode().await,
         }
     }
 
@@ -246,6 +315,8 @@ impl AgentInstance {
             Self::OpenClaw(_) | Self::Nanobot(_) | Self::Remote(_) => Err(AppError::BadRequest(
                 "Mode switching is not supported for this agent type".into(),
             )),
+            #[cfg(any(test, feature = "test-support"))]
+            Self::Mock(m) => m.set_mode(mode).await,
         }
     }
 }

--- a/crates/aionui-ai-agent/src/agent_task.rs
+++ b/crates/aionui-ai-agent/src/agent_task.rs
@@ -1,0 +1,251 @@
+//! Minimal public contract for a running agent task.
+//!
+//! `IAgentTask` captures **only** the operations that every agent type
+//! implements identically and that the generic task_manager / idle_scanner /
+//! message-flow code actually needs. Anything that is type-specific
+//! (session modes, session keys, model switching, config options, pending
+//! confirmation lists, approval memory, ACP usage, OpenClaw diagnostics,
+//! etc.) lives as **inherent** methods on each concrete `XxxAgentManager`
+//! and is reached through the `AgentInstance` enum — forcing every callsite
+//! to say out loud which agent type it is addressing.
+//!
+//! This replaces the old bloated `IAgentManager` trait + `as_any()`
+//! downcast pattern (see `agent_manager.rs` — still present during the
+//! PR #8 migration, scheduled for removal in PR #8c).
+use std::sync::Arc;
+
+use aionui_common::{AgentKillReason, AgentType, AppError, ConversationStatus, TimestampMs};
+use tokio::sync::broadcast;
+
+use crate::acp_agent::AcpAgentManager;
+use crate::agent_manager::IAgentManager;
+use crate::aionrs_agent::AionrsAgentManager;
+use crate::manager::remote::RemoteAgentManager;
+use crate::nanobot_agent::NanobotAgentManager;
+use crate::openclaw::OpenClawAgentManager;
+use crate::stream_event::AgentStreamEvent;
+use crate::types::{AgentStreamChunk, SendMessageData};
+
+/// Ten-method public surface every agent type implements identically.
+///
+/// Object-safe by construction (no generic methods, no `Self` by value).
+/// Used by generic lifecycle code (task_manager, idle_scanner, stream
+/// fan-out) that genuinely does not care which agent type it is dealing
+/// with. For type-specific operations, match on [`AgentInstance`] and
+/// call the concrete manager's inherent methods.
+#[async_trait::async_trait]
+pub trait IAgentTask: Send + Sync {
+    /// The type of agent this task controls.
+    fn agent_type(&self) -> AgentType;
+
+    /// Conversation ID this task is bound to.
+    fn conversation_id(&self) -> &str;
+
+    /// Working directory for this agent session.
+    fn workspace(&self) -> &str;
+
+    /// Current conversation status. `None` if the agent has not
+    /// transitioned into a known status yet.
+    fn status(&self) -> Option<ConversationStatus>;
+
+    /// Timestamp (ms) of the last activity (message send, event received).
+    fn last_activity_at(&self) -> TimestampMs;
+
+    /// Subscribe to the agent's stream event channel.
+    fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent>;
+
+    /// Subscribe to the raw stream chunk channel (used by team scheduler
+    /// watchdogs). Default implementation returns a receiver that
+    /// immediately closes — only ACP currently publishes chunks.
+    fn subscribe_stream(&self) -> broadcast::Receiver<AgentStreamChunk> {
+        let (tx, _) = broadcast::channel(1);
+        tx.subscribe()
+    }
+
+    /// Send a user message to the agent. Returns once the agent has
+    /// accepted the turn; actual streaming proceeds on the broadcast
+    /// channel returned by [`Self::subscribe`].
+    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError>;
+
+    /// Stop the current streaming response without killing the agent.
+    async fn stop(&self) -> Result<(), AppError>;
+
+    /// Terminate the agent process.
+    ///
+    /// - `reason: Some(IdleTimeout)` — idle cleanup
+    /// - `reason: None` — explicit user/system kill
+    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError>;
+}
+
+/// Concrete, closed-set dispatcher for the five agent variants.
+///
+/// Every generic path holds an `AgentInstance` (not `Arc<dyn IAgentTask>`):
+/// this gives us the `IAgentTask` ten-method surface via [`Self::as_task`]
+/// **and** lets type-specific routes recover the concrete manager with a
+/// single `match` — no `as_any` / `downcast_ref` anywhere. Adding a new
+/// agent type means adding a new variant here; every `match` in the
+/// codebase then fails to compile until it explicitly handles the new
+/// type, which is the compile-time pressure we want.
+#[derive(Clone)]
+pub enum AgentInstance {
+    Acp(Arc<AcpAgentManager>),
+    Aionrs(Arc<AionrsAgentManager>),
+    OpenClaw(Arc<OpenClawAgentManager>),
+    Nanobot(Arc<NanobotAgentManager>),
+    Remote(Arc<RemoteAgentManager>),
+}
+
+impl AgentInstance {
+    /// Common `IAgentTask` view, regardless of variant.
+    pub fn as_task(&self) -> &dyn IAgentTask {
+        match self {
+            Self::Acp(m) => m.as_ref(),
+            Self::Aionrs(m) => m.as_ref(),
+            Self::OpenClaw(m) => m.as_ref(),
+            Self::Nanobot(m) => m.as_ref(),
+            Self::Remote(m) => m.as_ref(),
+        }
+    }
+
+    // ── Convenience forwarders ───────────────────────────────────────
+    //
+    // These stay in the final API (not a migration crutch): they turn
+    // `instance.agent_type()` into a direct vtable-free call on the
+    // concrete `Arc<XxxManager>`, and they keep callsites terse.
+
+    /// The type of agent this instance controls.
+    pub fn agent_type(&self) -> AgentType {
+        self.as_task().agent_type()
+    }
+
+    /// Conversation ID this task is bound to.
+    pub fn conversation_id(&self) -> &str {
+        self.as_task().conversation_id()
+    }
+
+    /// Working directory for this agent session.
+    pub fn workspace(&self) -> &str {
+        self.as_task().workspace()
+    }
+
+    /// Current conversation status.
+    pub fn status(&self) -> Option<ConversationStatus> {
+        self.as_task().status()
+    }
+
+    /// Timestamp (ms) of the last activity.
+    pub fn last_activity_at(&self) -> TimestampMs {
+        self.as_task().last_activity_at()
+    }
+
+    /// Subscribe to the stream event channel.
+    pub fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
+        self.as_task().subscribe()
+    }
+
+    /// Subscribe to the raw stream chunk channel.
+    pub fn subscribe_stream(&self) -> broadcast::Receiver<AgentStreamChunk> {
+        self.as_task().subscribe_stream()
+    }
+
+    /// Send a user message to the agent.
+    pub async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+        self.as_task().send_message(data).await
+    }
+
+    /// Stop the current streaming response without killing the agent.
+    pub async fn stop(&self) -> Result<(), AppError> {
+        self.as_task().stop().await
+    }
+
+    /// Terminate the agent process.
+    pub fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        self.as_task().kill(reason)
+    }
+
+    // ── Cross-variant semi-specific helpers ──────────────────────────
+    //
+    // These fan out to inherent methods on concrete managers. Variants
+    // that don't support the operation return a sensible zero-value
+    // rather than an error: "no pending confirmations" and "no session
+    // key" are honest statements about those variants.
+
+    /// Pending confirmation items for this task.
+    ///
+    /// ACP currently tracks permission prompts inline through the
+    /// permission router (not surfaced here), so returns empty.
+    /// Aionrs / OpenClaw / Remote maintain inline confirmation lists.
+    /// Nanobot has no concept of confirmations.
+    pub fn get_confirmations(&self) -> Vec<aionui_common::Confirmation> {
+        match self {
+            Self::Acp(_) => Vec::new(),
+            Self::Aionrs(m) => m.get_confirmations(),
+            Self::OpenClaw(m) => m.get_confirmations(),
+            Self::Nanobot(_) => Vec::new(),
+            Self::Remote(m) => m.get_confirmations(),
+        }
+    }
+
+    /// Submit a confirmation response for a pending tool call.
+    pub fn confirm(
+        &self,
+        msg_id: &str,
+        call_id: &str,
+        data: serde_json::Value,
+        always_allow: bool,
+    ) -> Result<(), AppError> {
+        match self {
+            Self::Acp(m) => m.confirm(msg_id, call_id, data, always_allow),
+            Self::Aionrs(m) => m.confirm(msg_id, call_id, data, always_allow),
+            Self::OpenClaw(m) => m.confirm(msg_id, call_id, data, always_allow),
+            Self::Nanobot(m) => m.confirm(msg_id, call_id, data, always_allow),
+            Self::Remote(m) => m.confirm(msg_id, call_id, data, always_allow),
+        }
+    }
+
+    /// Check whether an action is auto-approved in this session.
+    pub fn check_approval(&self, action: &str, command_type: Option<&str>) -> bool {
+        match self {
+            Self::Acp(_) => false,
+            Self::Aionrs(m) => m.check_approval(action, command_type),
+            Self::OpenClaw(m) => m.check_approval(action, command_type),
+            Self::Nanobot(_) => false,
+            Self::Remote(m) => m.check_approval(action, command_type),
+        }
+    }
+
+    /// Session key for agent types that expose one (currently OpenClaw).
+    pub fn get_session_key(&self) -> Option<String> {
+        match self {
+            Self::OpenClaw(m) => m.get_session_key(),
+            Self::Acp(_) | Self::Aionrs(_) | Self::Nanobot(_) | Self::Remote(_) => None,
+        }
+    }
+
+    /// Get the current session mode. Only ACP and Aionrs model a mode;
+    /// other variants report `mode = "default"`, `initialized = false`
+    /// so cron / UI can skip mode reconciliation.
+    pub async fn get_mode(&self) -> Result<aionui_api_types::AgentModeResponse, AppError> {
+        match self {
+            Self::Acp(m) => m.get_mode().await,
+            Self::Aionrs(m) => m.get_mode().await,
+            Self::OpenClaw(_) | Self::Nanobot(_) | Self::Remote(_) => Ok(aionui_api_types::AgentModeResponse {
+                mode: "default".into(),
+                initialized: false,
+            }),
+        }
+    }
+
+    /// Set the session mode. Unsupported for variants other than ACP /
+    /// Aionrs — returns a `BadRequest` so the caller can surface an
+    /// actionable error rather than silently no-op.
+    pub async fn set_mode(&self, mode: &str) -> Result<(), AppError> {
+        match self {
+            Self::Acp(m) => m.set_mode(mode).await,
+            Self::Aionrs(m) => m.set_mode(mode).await,
+            Self::OpenClaw(_) | Self::Nanobot(_) | Self::Remote(_) => Err(AppError::BadRequest(
+                "Mode switching is not supported for this agent type".into(),
+            )),
+        }
+    }
+}

--- a/crates/aionui-ai-agent/src/aionrs_agent.rs
+++ b/crates/aionui-ai-agent/src/aionrs_agent.rs
@@ -16,7 +16,6 @@ use serde_json::Value;
 use tokio::sync::{Mutex, broadcast};
 use tracing::{debug, error, info};
 
-use crate::agent_manager::IAgentManager;
 use crate::backend_output_sink::BackendOutputSink;
 use crate::backend_protocol_sink::BackendProtocolSink;
 use crate::stream_event::AgentStreamEvent;
@@ -157,21 +156,21 @@ impl AionrsAgentManager {
 }
 
 #[async_trait::async_trait]
-impl IAgentManager for AionrsAgentManager {
+impl crate::agent_task::IAgentTask for AionrsAgentManager {
     fn agent_type(&self) -> AgentType {
         AgentType::Aionrs
     }
 
-    fn status(&self) -> Option<ConversationStatus> {
-        self.status.read().ok().and_then(|s| *s)
+    fn conversation_id(&self) -> &str {
+        &self.conversation_id
     }
 
     fn workspace(&self) -> &str {
         &self.workspace
     }
 
-    fn conversation_id(&self) -> &str {
-        &self.conversation_id
+    fn status(&self) -> Option<ConversationStatus> {
+        self.status.read().ok().and_then(|s| *s)
     }
 
     fn last_activity_at(&self) -> TimestampMs {
@@ -271,7 +270,23 @@ impl IAgentManager for AionrsAgentManager {
         Ok(())
     }
 
-    fn confirm(&self, _msg_id: &str, call_id: &str, data: Value, always_allow: bool) -> Result<(), AppError> {
+    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        info!(
+            conversation_id = %self.conversation_id,
+            ?reason,
+            "Killing Aionrs agent"
+        );
+        if let Ok(mut s) = self.status.write() {
+            *s = None;
+        }
+        Ok(())
+    }
+}
+
+/// Aionrs-specific operations reached through `AgentInstance::Aionrs(..)`
+/// matches in the routes + services.
+impl AionrsAgentManager {
+    pub fn confirm(&self, _msg_id: &str, call_id: &str, data: Value, always_allow: bool) -> Result<(), AppError> {
         if let Ok(mut confs) = self.confirmations.write() {
             confs.retain(|c| c.call_id != call_id);
         }
@@ -306,34 +321,22 @@ impl IAgentManager for AionrsAgentManager {
         Ok(())
     }
 
-    fn get_confirmations(&self) -> Vec<Confirmation> {
+    pub fn get_confirmations(&self) -> Vec<Confirmation> {
         self.confirmations.read().map(|c| c.clone()).unwrap_or_default()
     }
 
-    fn check_approval(&self, action: &str, _command_type: Option<&str>) -> bool {
+    pub fn check_approval(&self, action: &str, _command_type: Option<&str>) -> bool {
         self.approval_manager.is_auto_approved(action)
     }
 
-    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
-        info!(
-            conversation_id = %self.conversation_id,
-            ?reason,
-            "Killing Aionrs agent"
-        );
-        if let Ok(mut s) = self.status.write() {
-            *s = None;
-        }
-        Ok(())
-    }
-
-    async fn get_mode(&self) -> Result<AgentModeResponse, AppError> {
+    pub async fn get_mode(&self) -> Result<AgentModeResponse, AppError> {
         Ok(AgentModeResponse {
             mode: self.approval_manager.current_mode(),
             initialized: true,
         })
     }
 
-    async fn set_mode(&self, mode: &str) -> Result<(), AppError> {
+    pub async fn set_mode(&self, mode: &str) -> Result<(), AppError> {
         let prev = self.approval_manager.current_mode();
         self.approval_manager.set_mode(parse_session_mode(mode));
         info!(
@@ -343,42 +346,6 @@ impl IAgentManager for AionrsAgentManager {
             "Aionrs session mode switched"
         );
         Ok(())
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-}
-
-/// PR #8a: `IAgentTask` delegates to `IAgentManager` during the transition.
-#[async_trait::async_trait]
-impl crate::agent_task::IAgentTask for AionrsAgentManager {
-    fn agent_type(&self) -> AgentType {
-        <Self as IAgentManager>::agent_type(self)
-    }
-    fn conversation_id(&self) -> &str {
-        <Self as IAgentManager>::conversation_id(self)
-    }
-    fn workspace(&self) -> &str {
-        <Self as IAgentManager>::workspace(self)
-    }
-    fn status(&self) -> Option<ConversationStatus> {
-        <Self as IAgentManager>::status(self)
-    }
-    fn last_activity_at(&self) -> TimestampMs {
-        <Self as IAgentManager>::last_activity_at(self)
-    }
-    fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
-        <Self as IAgentManager>::subscribe(self)
-    }
-    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
-        <Self as IAgentManager>::send_message(self, data).await
-    }
-    async fn stop(&self) -> Result<(), AppError> {
-        <Self as IAgentManager>::stop(self).await
-    }
-    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
-        <Self as IAgentManager>::kill(self, reason)
     }
 }
 
@@ -393,6 +360,7 @@ fn parse_session_mode(s: &str) -> SessionMode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent_task::IAgentTask;
 
     fn make_test_config() -> AionrsResolvedConfig {
         AionrsResolvedConfig {

--- a/crates/aionui-ai-agent/src/aionrs_agent.rs
+++ b/crates/aionui-ai-agent/src/aionrs_agent.rs
@@ -350,6 +350,38 @@ impl IAgentManager for AionrsAgentManager {
     }
 }
 
+/// PR #8a: `IAgentTask` delegates to `IAgentManager` during the transition.
+#[async_trait::async_trait]
+impl crate::agent_task::IAgentTask for AionrsAgentManager {
+    fn agent_type(&self) -> AgentType {
+        <Self as IAgentManager>::agent_type(self)
+    }
+    fn conversation_id(&self) -> &str {
+        <Self as IAgentManager>::conversation_id(self)
+    }
+    fn workspace(&self) -> &str {
+        <Self as IAgentManager>::workspace(self)
+    }
+    fn status(&self) -> Option<ConversationStatus> {
+        <Self as IAgentManager>::status(self)
+    }
+    fn last_activity_at(&self) -> TimestampMs {
+        <Self as IAgentManager>::last_activity_at(self)
+    }
+    fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
+        <Self as IAgentManager>::subscribe(self)
+    }
+    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+        <Self as IAgentManager>::send_message(self, data).await
+    }
+    async fn stop(&self) -> Result<(), AppError> {
+        <Self as IAgentManager>::stop(self).await
+    }
+    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        <Self as IAgentManager>::kill(self, reason)
+    }
+}
+
 fn parse_session_mode(s: &str) -> SessionMode {
     match s {
         "auto_edit" => SessionMode::AutoEdit,

--- a/crates/aionui-ai-agent/src/auxiliary_routes.rs
+++ b/crates/aionui-ai-agent/src/auxiliary_routes.rs
@@ -7,8 +7,7 @@ use axum::routing::{get, post};
 use std::path::Component;
 
 use crate::acp_agent::AcpAgentManager;
-use crate::agent_manager::AgentManagerHandle;
-use crate::openclaw::OpenClawAgentManager;
+use crate::agent_task::AgentInstance;
 use crate::task_manager::IWorkerTaskManager;
 use agent_client_protocol::schema::{AgentCapabilities, SessionConfigOption, UsageUpdate};
 use aionui_api_types::{
@@ -17,7 +16,7 @@ use aionui_api_types::{
     SlashCommandItem, WorkspaceBrowseQuery, WorkspaceEntry,
 };
 use aionui_auth::CurrentUser;
-use aionui_common::{AgentType, AppError};
+use aionui_common::AppError;
 use aionui_db::IConversationRepository;
 use serde::Deserialize;
 
@@ -181,7 +180,7 @@ async fn reload_context(
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<()>>, AppError> {
-    let _handle = get_task(&state, &id)?;
+    let _instance = get_task(&state, &id)?;
 
     // Context reload triggers re-discovery of skills and workspace state.
     // The specific reload behavior varies by agent type and will be
@@ -199,17 +198,17 @@ async fn side_question(
         return Err(AppError::BadRequest("question must not be empty".into()));
     }
 
-    let handle = get_task(&state, &id)?;
+    let instance = get_task(&state, &id)?;
 
-    // Only ACP agents support side questions
-    if handle.agent_type() != AgentType::Acp {
-        return Ok(Json(ApiResponse::ok(SideQuestionResponse {
-            status: "unsupported".into(),
-            answer: None,
-        })));
-    }
-
-    let acp = downcast_acp(&handle)?;
+    let acp = match &instance {
+        AgentInstance::Acp(m) => m,
+        _ => {
+            return Ok(Json(ApiResponse::ok(SideQuestionResponse {
+                status: "unsupported".into(),
+                answer: None,
+            })));
+        }
+    };
 
     // Side question is gated by the agent's behavior_policy flag.
     if !acp.supports_side_question() {
@@ -234,14 +233,13 @@ async fn get_slash_commands(
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<Vec<SlashCommandItem>>>, AppError> {
-    let handle = get_task(&state, &id)?;
+    let instance = get_task(&state, &id)?;
 
     // Only ACP agents have slash commands
-    if handle.agent_type() != AgentType::Acp {
+    let AgentInstance::Acp(acp) = &instance else {
         return Ok(Json(ApiResponse::ok(Vec::new())));
-    }
+    };
 
-    let acp = downcast_acp(&handle)?;
     let commands = acp.load_slash_commands().await?;
     Ok(Json(ApiResponse::ok(commands)))
 }
@@ -251,8 +249,8 @@ async fn get_mode(
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<AgentModeResponse>>, AppError> {
-    let handle = get_task(&state, &id)?;
-    Ok(Json(ApiResponse::ok(handle.get_mode().await?)))
+    let instance = get_task(&state, &id)?;
+    Ok(Json(ApiResponse::ok(instance.get_mode().await?)))
 }
 
 async fn set_mode(
@@ -265,8 +263,8 @@ async fn set_mode(
     if req.mode.trim().is_empty() {
         return Err(AppError::BadRequest("mode must not be empty".into()));
     }
-    let handle = get_task(&state, &id)?;
-    handle.set_mode(&req.mode).await?;
+    let instance = get_task(&state, &id)?;
+    instance.set_mode(&req.mode).await?;
     Ok(Json(ApiResponse::success()))
 }
 
@@ -275,15 +273,8 @@ async fn get_model(
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<GetModelInfoResponse>>, AppError> {
-    let handle = get_task(&state, &id)?;
-
-    if handle.agent_type() != AgentType::Acp {
-        return Err(AppError::BadRequest(
-            "This endpoint is only available for ACP agents".into(),
-        ));
-    }
-
-    let acp = downcast_acp(&handle)?;
+    let instance = get_task(&state, &id)?;
+    let acp = require_acp(&instance)?;
     let sdk_model = acp.model_info().await;
 
     let model_info = sdk_model.map(|m| {
@@ -324,14 +315,16 @@ async fn set_model(
         return Err(AppError::BadRequest("model_id must not be empty".into()));
     }
 
-    let handle = get_task(&state, &id)?;
-    if handle.agent_type() != AgentType::Acp {
-        return Err(AppError::BadRequest(
-            "Model switching is not supported for this agent type".into(),
-        ));
-    }
+    let instance = get_task(&state, &id)?;
+    let acp = match &instance {
+        AgentInstance::Acp(m) => m,
+        _ => {
+            return Err(AppError::BadRequest(
+                "Model switching is not supported for this agent type".into(),
+            ));
+        }
+    };
 
-    let acp = downcast_acp(&handle)?;
     acp.set_model_info(&req.model_id).await?;
     Ok(Json(ApiResponse::success()))
 }
@@ -341,15 +334,8 @@ async fn get_config(
     Extension(_user): Extension<CurrentUser>,
     Path(params): Path<ConfigPathParams>,
 ) -> Result<Json<ApiResponse<Option<SessionConfigOption>>>, AppError> {
-    let handle = get_task(&state, &params.id)?;
-
-    if handle.agent_type() != AgentType::Acp {
-        return Err(AppError::BadRequest(
-            "This endpoint is only available for ACP agents".into(),
-        ));
-    }
-
-    let acp = downcast_acp(&handle)?;
+    let instance = get_task(&state, &params.id)?;
+    let acp = require_acp(&instance)?;
     let config_option = acp
         .config_options()
         .await
@@ -365,15 +351,16 @@ async fn set_config(
     body: Result<Json<SetConfigOptionRequest>, JsonRejection>,
 ) -> Result<Json<ApiResponse<()>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    let handle = get_task(&state, &params.id)?;
+    let instance = get_task(&state, &params.id)?;
+    let acp = match &instance {
+        AgentInstance::Acp(m) => m,
+        _ => {
+            return Err(AppError::BadRequest(
+                "Config updates are not supported for this agent type".into(),
+            ));
+        }
+    };
 
-    if handle.agent_type() != AgentType::Acp {
-        return Err(AppError::BadRequest(
-            "Config updates are not supported for this agent type".into(),
-        ));
-    }
-
-    let acp = downcast_acp(&handle)?;
     acp.set_config_option(&params.config_id, &req.value).await?;
     Ok(Json(ApiResponse::success()))
 }
@@ -383,15 +370,8 @@ async fn get_configs(
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<Vec<SessionConfigOption>>>, AppError> {
-    let handle = get_task(&state, &id)?;
-
-    if handle.agent_type() != AgentType::Acp {
-        return Err(AppError::BadRequest(
-            "This endpoint is only available for ACP agents".into(),
-        ));
-    }
-
-    let acp = downcast_acp(&handle)?;
+    let instance = get_task(&state, &id)?;
+    let acp = require_acp(&instance)?;
     Ok(Json(ApiResponse::ok(acp.config_options().await)))
 }
 
@@ -402,15 +382,16 @@ async fn set_configs(
     body: Result<Json<SetConfigOptionsRequest>, JsonRejection>,
 ) -> Result<Json<ApiResponse<()>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    let handle = get_task(&state, &id)?;
+    let instance = get_task(&state, &id)?;
+    let acp = match &instance {
+        AgentInstance::Acp(m) => m,
+        _ => {
+            return Err(AppError::BadRequest(
+                "Config updates are not supported for this agent type".into(),
+            ));
+        }
+    };
 
-    if handle.agent_type() != AgentType::Acp {
-        return Err(AppError::BadRequest(
-            "Config updates are not supported for this agent type".into(),
-        ));
-    }
-
-    let acp = downcast_acp(&handle)?;
     for update in req.config_options {
         if update.config_id.trim().is_empty() {
             return Err(AppError::BadRequest("config_id must not be empty".into()));
@@ -426,15 +407,8 @@ async fn get_usage(
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<Option<UsageUpdate>>>, AppError> {
-    let handle = get_task(&state, &id)?;
-
-    if handle.agent_type() != AgentType::Acp {
-        return Err(AppError::BadRequest(
-            "This endpoint is only available for ACP agents".into(),
-        ));
-    }
-
-    let acp = downcast_acp(&handle)?;
+    let instance = get_task(&state, &id)?;
+    let acp = require_acp(&instance)?;
     let usage = acp.usage().await;
     Ok(Json(ApiResponse::ok(usage)))
 }
@@ -444,15 +418,8 @@ async fn get_agent_capabilities(
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<Option<AgentCapabilities>>>, AppError> {
-    let handle = get_task(&state, &id)?;
-
-    if handle.agent_type() != AgentType::Acp {
-        return Err(AppError::BadRequest(
-            "This endpoint is only available for ACP agents".into(),
-        ));
-    }
-
-    let acp = downcast_acp(&handle)?;
+    let instance = get_task(&state, &id)?;
+    let acp = require_acp(&instance)?;
     let capabilities = acp.agent_capabilities().await;
     Ok(Json(ApiResponse::ok(capabilities)))
 }
@@ -462,18 +429,12 @@ async fn get_openclaw_runtime(
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, AppError> {
-    let handle = get_task(&state, &id)?;
-
-    if handle.agent_type() != AgentType::OpenclawGateway {
+    let instance = get_task(&state, &id)?;
+    let AgentInstance::OpenClaw(openclaw) = &instance else {
         return Err(AppError::BadRequest(
             "This endpoint is only available for OpenClaw agents".into(),
         ));
-    }
-
-    let openclaw = handle
-        .as_any()
-        .downcast_ref::<OpenClawAgentManager>()
-        .ok_or_else(|| AppError::Internal("Failed to downcast to OpenClawAgentManager".into()))?;
+    };
 
     let diagnostics = openclaw.get_diagnostics().await;
     Ok(Json(ApiResponse::ok(diagnostics)))
@@ -481,16 +442,21 @@ async fn get_openclaw_runtime(
 
 // ── Helpers ────────────────────────────────────────────────────────
 
-fn get_task(state: &AuxiliaryRouterState, conversation_id: &str) -> Result<AgentManagerHandle, AppError> {
+fn get_task(state: &AuxiliaryRouterState, conversation_id: &str) -> Result<AgentInstance, AppError> {
     state
         .worker_task_manager
         .get_task(conversation_id)
         .ok_or_else(|| AppError::NotFound(format!("No active agent for conversation '{conversation_id}'")))
 }
 
-fn downcast_acp(handle: &AgentManagerHandle) -> Result<&AcpAgentManager, AppError> {
-    handle
-        .as_any()
-        .downcast_ref::<AcpAgentManager>()
-        .ok_or_else(|| AppError::Internal("Failed to downcast to AcpAgentManager".into()))
+/// Recover the concrete ACP manager from an [`AgentInstance`] or return
+/// a `BadRequest` — used by ACP-only auxiliary endpoints to surface a
+/// meaningful 400 instead of the previous 500-via-downcast.
+fn require_acp(instance: &AgentInstance) -> Result<&Arc<AcpAgentManager>, AppError> {
+    match instance {
+        AgentInstance::Acp(m) => Ok(m),
+        _ => Err(AppError::BadRequest(
+            "This endpoint is only available for ACP agents".into(),
+        )),
+    }
 }

--- a/crates/aionui-ai-agent/src/factory/mod.rs
+++ b/crates/aionui-ai-agent/src/factory/mod.rs
@@ -174,7 +174,7 @@ async fn build_agent(deps: Arc<AgentFactoryDeps>, options: BuildTaskOptions) -> 
             arc.start_session_event_tracker();
             CatalogForwarder::spawn(
                 arc.agent_metadata_id().to_owned(),
-                crate::IAgentManager::subscribe(arc.as_ref()),
+                crate::IAgentTask::subscribe(arc.as_ref()),
                 catalog_tx,
             );
 

--- a/crates/aionui-ai-agent/src/factory/mod.rs
+++ b/crates/aionui-ai-agent/src/factory/mod.rs
@@ -9,8 +9,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
-use crate::agent_manager::AgentManagerHandle;
 use crate::agent_registry::AgentRegistry;
+use crate::agent_task::AgentInstance;
 use crate::factory::acp_assembler::{WorkspaceInfo, assemble_acp_params};
 use crate::manager::acp::{AcpSessionSyncService, CatalogForwarder};
 use crate::manager::remote::RemoteAgentConfig;
@@ -54,7 +54,7 @@ pub fn build_agent_factory(deps: AgentFactoryDeps) -> AgentFactory {
     })
 }
 
-async fn build_agent(deps: Arc<AgentFactoryDeps>, options: BuildTaskOptions) -> Result<AgentManagerHandle, AppError> {
+async fn build_agent(deps: Arc<AgentFactoryDeps>, options: BuildTaskOptions) -> Result<AgentInstance, AppError> {
     let conversation_id = options.conversation_id.clone();
     // `is_custom_workspace` is the authoritative signal for "user chose
     // this path" — determined here and plumbed down to the managers
@@ -188,14 +188,14 @@ async fn build_agent(deps: Arc<AgentFactoryDeps>, options: BuildTaskOptions) -> 
                 arc.restore_session_id(sid).await;
             }
 
-            let handle: AgentManagerHandle = arc.clone();
+            let instance = AgentInstance::Acp(Arc::clone(&arc));
 
             // Hand the service the domain event receiver so it can
             // persist user intent changes without reverse-engineering
             // them from CLI observations.
             deps.acp_agent_service.attach(conversation_id, domain_rx).await;
 
-            Ok(handle)
+            Ok(instance)
         }
         AgentType::OpenclawGateway => {
             let mut config: OpenClawBuildExtra = serde_json::from_value(options.extra)
@@ -219,7 +219,7 @@ async fn build_agent(deps: Arc<AgentFactoryDeps>, options: BuildTaskOptions) -> 
             let agent = OpenClawAgentManager::new(conversation_id, workspace, config, resume_session_key).await?;
             let arc = Arc::new(agent);
             arc.start_event_relay();
-            Ok(arc as AgentManagerHandle)
+            Ok(AgentInstance::OpenClaw(arc))
         }
         AgentType::Nanobot => {
             // Nanobot lives in the catalog as an internal row; reuse the
@@ -232,7 +232,7 @@ async fn build_agent(deps: Arc<AgentFactoryDeps>, options: BuildTaskOptions) -> 
                 .find_map(|m| m.resolved_command)
                 .ok_or_else(|| AppError::BadRequest("Nanobot CLI not found in PATH".into()))?;
             let agent = NanobotAgentManager::new(conversation_id, workspace, cli_path).await?;
-            Ok(Arc::new(agent) as AgentManagerHandle)
+            Ok(AgentInstance::Nanobot(Arc::new(agent)))
         }
         AgentType::Remote => {
             let extra: RemoteBuildExtra = serde_json::from_value(options.extra)
@@ -262,7 +262,7 @@ async fn build_agent(deps: Arc<AgentFactoryDeps>, options: BuildTaskOptions) -> 
                 allow_insecure: row.allow_insecure,
             };
             let agent = RemoteAgentManager::new(conversation_id, workspace, config).await?;
-            Ok(Arc::new(agent) as AgentManagerHandle)
+            Ok(AgentInstance::Remote(Arc::new(agent)))
         }
         AgentType::Aionrs => {
             let overrides: AionrsBuildExtra = serde_json::from_value(options.extra).unwrap_or_default();
@@ -328,7 +328,7 @@ async fn build_agent(deps: Arc<AgentFactoryDeps>, options: BuildTaskOptions) -> 
             };
 
             let agent = AionrsAgentManager::new(conversation_id, workspace, config, resume_session).await?;
-            Ok(Arc::new(agent) as AgentManagerHandle)
+            Ok(AgentInstance::Aionrs(Arc::new(agent)))
         }
     }
 }

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -28,17 +28,12 @@ pub mod types;
 
 pub use acp_agent::AcpAgentManager;
 pub use acp_routes::{AcpRouterState, acp_routes};
-pub use agent_manager::{AgentManagerHandle, IAgentManager, approval_key};
+pub use agent_manager::approval_key;
 pub use agent_registry::AgentRegistry;
-// `AgentInstance` is the new canonical agent handle; `IAgentTask` is
-// intentionally *not* re-exported while `IAgentManager` still exists —
-// otherwise glob-importing consumers would see ambiguous method
-// resolution (`agent_type`/`status`/...). PR #8c removes `IAgentManager`
-// and adds `pub use agent_task::IAgentTask` here.
 pub use agent_routes::{AgentRouterState, agent_routes};
-pub use agent_task::AgentInstance;
 #[cfg(any(test, feature = "test-support"))]
 pub use agent_task::IMockAgent;
+pub use agent_task::{AgentInstance, IAgentTask};
 pub use aionrs_agent::AionrsAgentManager;
 pub use aionui_api_types::{
     AcpBuildExtra, AcpModelInfo, AcpSessionConfigOption, AionrsBuildExtra, OpenClawBuildExtra, OpenClawGatewayConfig,

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -30,14 +30,15 @@ pub use acp_agent::AcpAgentManager;
 pub use acp_routes::{AcpRouterState, acp_routes};
 pub use agent_manager::{AgentManagerHandle, IAgentManager, approval_key};
 pub use agent_registry::AgentRegistry;
-// NOTE (PR #8a): `IAgentTask` / `AgentInstance` are defined but intentionally
-// not added to the crate-level prelude yet — the old `IAgentManager` trait
-// is still the primary surface exposed via `pub use agent_manager::*`. Re-
-// exporting both would cause glob-importing consumers (integration tests)
-// to see ambiguous method resolution for `agent_type`/`status`/etc. PR #8b
-// switches consumers over, and PR #8c removes `IAgentManager` entirely and
-// re-exports `agent_task::*` here.
+// `AgentInstance` is the new canonical agent handle; `IAgentTask` is
+// intentionally *not* re-exported while `IAgentManager` still exists —
+// otherwise glob-importing consumers would see ambiguous method
+// resolution (`agent_type`/`status`/...). PR #8c removes `IAgentManager`
+// and adds `pub use agent_task::IAgentTask` here.
 pub use agent_routes::{AgentRouterState, agent_routes};
+pub use agent_task::AgentInstance;
+#[cfg(any(test, feature = "test-support"))]
+pub use agent_task::IMockAgent;
 pub use aionrs_agent::AionrsAgentManager;
 pub use aionui_api_types::{
     AcpBuildExtra, AcpModelInfo, AcpSessionConfigOption, AionrsBuildExtra, OpenClawBuildExtra, OpenClawGatewayConfig,

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -6,6 +6,7 @@ pub mod acp_routes;
 pub mod agent_manager;
 pub mod agent_registry;
 pub mod agent_routes;
+pub mod agent_task;
 pub mod aionrs_agent;
 pub mod auxiliary_routes;
 pub mod backend_output_sink;
@@ -29,6 +30,13 @@ pub use acp_agent::AcpAgentManager;
 pub use acp_routes::{AcpRouterState, acp_routes};
 pub use agent_manager::{AgentManagerHandle, IAgentManager, approval_key};
 pub use agent_registry::AgentRegistry;
+// NOTE (PR #8a): `IAgentTask` / `AgentInstance` are defined but intentionally
+// not added to the crate-level prelude yet — the old `IAgentManager` trait
+// is still the primary surface exposed via `pub use agent_manager::*`. Re-
+// exporting both would cause glob-importing consumers (integration tests)
+// to see ambiguous method resolution for `agent_type`/`status`/etc. PR #8b
+// switches consumers over, and PR #8c removes `IAgentManager` entirely and
+// re-exports `agent_task::*` here.
 pub use agent_routes::{AgentRouterState, agent_routes};
 pub use aionrs_agent::AionrsAgentManager;
 pub use aionui_api_types::{

--- a/crates/aionui-ai-agent/src/manager/remote/mod.rs
+++ b/crates/aionui-ai-agent/src/manager/remote/mod.rs
@@ -17,7 +17,6 @@ use tokio::sync::{Mutex, RwLock, broadcast};
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, error, info, warn};
 
-use crate::agent_manager::IAgentManager;
 use crate::stream_event::AgentStreamEvent;
 use crate::types::SendMessageData;
 
@@ -261,21 +260,21 @@ impl RemoteAgentManager {
 use crate::agent_manager::approval_key;
 
 #[async_trait::async_trait]
-impl IAgentManager for RemoteAgentManager {
+impl crate::agent_task::IAgentTask for RemoteAgentManager {
     fn agent_type(&self) -> AgentType {
         AgentType::Remote
     }
 
-    fn status(&self) -> Option<ConversationStatus> {
-        self.state.try_read().ok().and_then(|g| g.status)
+    fn conversation_id(&self) -> &str {
+        &self.conversation_id
     }
 
     fn workspace(&self) -> &str {
         &self.workspace
     }
 
-    fn conversation_id(&self) -> &str {
-        &self.conversation_id
+    fn status(&self) -> Option<ConversationStatus> {
+        self.state.try_read().ok().and_then(|g| g.status)
     }
 
     fn last_activity_at(&self) -> TimestampMs {
@@ -337,7 +336,28 @@ impl IAgentManager for RemoteAgentManager {
         Ok(())
     }
 
-    fn confirm(&self, _msg_id: &str, call_id: &str, _data: Value, always_allow: bool) -> Result<(), AppError> {
+    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        info!(
+            conversation_id = %self.conversation_id,
+            ?reason,
+            "Killing Remote agent"
+        );
+
+        // Drop the WebSocket sink to close the connection.
+        // We can't move the Mutex into a spawned task, so we clear it inline
+        // using try_lock (non-blocking). If the lock is held, the connection
+        // will close when the holder drops it.
+        if let Ok(mut guard) = self.ws_sink.try_lock() {
+            *guard = None;
+        }
+
+        Ok(())
+    }
+}
+
+/// Remote-specific operations reached through `AgentInstance::Remote(..)`.
+impl RemoteAgentManager {
+    pub fn confirm(&self, _msg_id: &str, call_id: &str, _data: Value, always_allow: bool) -> Result<(), AppError> {
         if let Ok(mut state) = self.state.try_write() {
             if always_allow && let Some(conf) = state.confirmations.iter().find(|c| c.call_id == call_id) {
                 let key = approval_key(conf.action.as_deref(), conf.command_type.as_deref());
@@ -357,14 +377,14 @@ impl IAgentManager for RemoteAgentManager {
         Ok(())
     }
 
-    fn get_confirmations(&self) -> Vec<Confirmation> {
+    pub fn get_confirmations(&self) -> Vec<Confirmation> {
         self.state
             .try_read()
             .map(|g| g.confirmations.clone())
             .unwrap_or_default()
     }
 
-    fn check_approval(&self, action: &str, command_type: Option<&str>) -> bool {
+    pub fn check_approval(&self, action: &str, command_type: Option<&str>) -> bool {
         self.state
             .try_read()
             .map(|g| {
@@ -372,60 +392,6 @@ impl IAgentManager for RemoteAgentManager {
                 g.approval_memory.get(&key).copied().unwrap_or(false)
             })
             .unwrap_or(false)
-    }
-
-    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
-        info!(
-            conversation_id = %self.conversation_id,
-            ?reason,
-            "Killing Remote agent"
-        );
-
-        // Drop the WebSocket sink to close the connection.
-        // We can't move the Mutex into a spawned task, so we clear it inline
-        // using try_lock (non-blocking). If the lock is held, the connection
-        // will close when the holder drops it.
-        if let Ok(mut guard) = self.ws_sink.try_lock() {
-            *guard = None;
-        }
-
-        Ok(())
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-}
-
-/// PR #8a: `IAgentTask` delegates to `IAgentManager` during the transition.
-#[async_trait::async_trait]
-impl crate::agent_task::IAgentTask for RemoteAgentManager {
-    fn agent_type(&self) -> AgentType {
-        <Self as IAgentManager>::agent_type(self)
-    }
-    fn conversation_id(&self) -> &str {
-        <Self as IAgentManager>::conversation_id(self)
-    }
-    fn workspace(&self) -> &str {
-        <Self as IAgentManager>::workspace(self)
-    }
-    fn status(&self) -> Option<ConversationStatus> {
-        <Self as IAgentManager>::status(self)
-    }
-    fn last_activity_at(&self) -> TimestampMs {
-        <Self as IAgentManager>::last_activity_at(self)
-    }
-    fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
-        <Self as IAgentManager>::subscribe(self)
-    }
-    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
-        <Self as IAgentManager>::send_message(self, data).await
-    }
-    async fn stop(&self) -> Result<(), AppError> {
-        <Self as IAgentManager>::stop(self).await
-    }
-    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
-        <Self as IAgentManager>::kill(self, reason)
     }
 }
 

--- a/crates/aionui-ai-agent/src/manager/remote/mod.rs
+++ b/crates/aionui-ai-agent/src/manager/remote/mod.rs
@@ -397,6 +397,38 @@ impl IAgentManager for RemoteAgentManager {
     }
 }
 
+/// PR #8a: `IAgentTask` delegates to `IAgentManager` during the transition.
+#[async_trait::async_trait]
+impl crate::agent_task::IAgentTask for RemoteAgentManager {
+    fn agent_type(&self) -> AgentType {
+        <Self as IAgentManager>::agent_type(self)
+    }
+    fn conversation_id(&self) -> &str {
+        <Self as IAgentManager>::conversation_id(self)
+    }
+    fn workspace(&self) -> &str {
+        <Self as IAgentManager>::workspace(self)
+    }
+    fn status(&self) -> Option<ConversationStatus> {
+        <Self as IAgentManager>::status(self)
+    }
+    fn last_activity_at(&self) -> TimestampMs {
+        <Self as IAgentManager>::last_activity_at(self)
+    }
+    fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
+        <Self as IAgentManager>::subscribe(self)
+    }
+    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+        <Self as IAgentManager>::send_message(self, data).await
+    }
+    async fn stop(&self) -> Result<(), AppError> {
+        <Self as IAgentManager>::stop(self).await
+    }
+    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        <Self as IAgentManager>::kill(self, reason)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aionui-ai-agent/src/nanobot_agent.rs
+++ b/crates/aionui-ai-agent/src/nanobot_agent.rs
@@ -7,7 +7,6 @@ use serde_json::{Value, json};
 use tokio::sync::{Mutex, RwLock, broadcast};
 use tracing::{debug, error, info, warn};
 
-use crate::agent_manager::IAgentManager;
 use aionui_common::CommandSpec;
 
 use crate::cli_process::CliAgentProcess;
@@ -159,21 +158,21 @@ impl NanobotAgentManager {
 }
 
 #[async_trait::async_trait]
-impl IAgentManager for NanobotAgentManager {
+impl crate::agent_task::IAgentTask for NanobotAgentManager {
     fn agent_type(&self) -> AgentType {
         AgentType::Nanobot
     }
 
-    fn status(&self) -> Option<ConversationStatus> {
-        self.state.try_read().ok().and_then(|g| g.status)
+    fn conversation_id(&self) -> &str {
+        &self.conversation_id
     }
 
     fn workspace(&self) -> &str {
         &self.workspace
     }
 
-    fn conversation_id(&self) -> &str {
-        &self.conversation_id
+    fn status(&self) -> Option<ConversationStatus> {
+        self.state.try_read().ok().and_then(|g| g.status)
     }
 
     fn last_activity_at(&self) -> TimestampMs {
@@ -210,21 +209,6 @@ impl IAgentManager for NanobotAgentManager {
         self.process.send(&payload).await
     }
 
-    /// Nanobot does not support confirmations.
-    fn confirm(&self, _msg_id: &str, _call_id: &str, _data: Value, _always_allow: bool) -> Result<(), AppError> {
-        Err(AppError::BadRequest("Nanobot does not support confirmations".into()))
-    }
-
-    /// Nanobot has no pending confirmations.
-    fn get_confirmations(&self) -> Vec<Confirmation> {
-        Vec::new()
-    }
-
-    /// Nanobot does not support YOLO / approval memory.
-    fn check_approval(&self, _action: &str, _command_type: Option<&str>) -> bool {
-        false
-    }
-
     fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
         info!(
             conversation_id = %self.conversation_id,
@@ -242,41 +226,23 @@ impl IAgentManager for NanobotAgentManager {
 
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
-/// PR #8a: `IAgentTask` delegates to `IAgentManager` during the transition.
-#[async_trait::async_trait]
-impl crate::agent_task::IAgentTask for NanobotAgentManager {
-    fn agent_type(&self) -> AgentType {
-        <Self as IAgentManager>::agent_type(self)
+/// Nanobot-specific operations reached through `AgentInstance::Nanobot(..)`.
+/// Nanobot does not track tool confirmations or approval memory, so these
+/// are trivial stubs matching the semantics of the removed `IAgentManager`
+/// default impls.
+impl NanobotAgentManager {
+    pub fn confirm(&self, _msg_id: &str, _call_id: &str, _data: Value, _always_allow: bool) -> Result<(), AppError> {
+        Err(AppError::BadRequest("Nanobot does not support confirmations".into()))
     }
-    fn conversation_id(&self) -> &str {
-        <Self as IAgentManager>::conversation_id(self)
+
+    pub fn get_confirmations(&self) -> Vec<Confirmation> {
+        Vec::new()
     }
-    fn workspace(&self) -> &str {
-        <Self as IAgentManager>::workspace(self)
-    }
-    fn status(&self) -> Option<ConversationStatus> {
-        <Self as IAgentManager>::status(self)
-    }
-    fn last_activity_at(&self) -> TimestampMs {
-        <Self as IAgentManager>::last_activity_at(self)
-    }
-    fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
-        <Self as IAgentManager>::subscribe(self)
-    }
-    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
-        <Self as IAgentManager>::send_message(self, data).await
-    }
-    async fn stop(&self) -> Result<(), AppError> {
-        <Self as IAgentManager>::stop(self).await
-    }
-    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
-        <Self as IAgentManager>::kill(self, reason)
+
+    pub fn check_approval(&self, _action: &str, _command_type: Option<&str>) -> bool {
+        false
     }
 }
 

--- a/crates/aionui-ai-agent/src/nanobot_agent.rs
+++ b/crates/aionui-ai-agent/src/nanobot_agent.rs
@@ -248,6 +248,38 @@ impl IAgentManager for NanobotAgentManager {
     }
 }
 
+/// PR #8a: `IAgentTask` delegates to `IAgentManager` during the transition.
+#[async_trait::async_trait]
+impl crate::agent_task::IAgentTask for NanobotAgentManager {
+    fn agent_type(&self) -> AgentType {
+        <Self as IAgentManager>::agent_type(self)
+    }
+    fn conversation_id(&self) -> &str {
+        <Self as IAgentManager>::conversation_id(self)
+    }
+    fn workspace(&self) -> &str {
+        <Self as IAgentManager>::workspace(self)
+    }
+    fn status(&self) -> Option<ConversationStatus> {
+        <Self as IAgentManager>::status(self)
+    }
+    fn last_activity_at(&self) -> TimestampMs {
+        <Self as IAgentManager>::last_activity_at(self)
+    }
+    fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
+        <Self as IAgentManager>::subscribe(self)
+    }
+    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+        <Self as IAgentManager>::send_message(self, data).await
+    }
+    async fn stop(&self) -> Result<(), AppError> {
+        <Self as IAgentManager>::stop(self).await
+    }
+    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        <Self as IAgentManager>::kill(self, reason)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aionui-ai-agent/src/openclaw/agent.rs
+++ b/crates/aionui-ai-agent/src/openclaw/agent.rs
@@ -8,7 +8,7 @@ use serde_json::{Value, json};
 use tokio::sync::{Mutex, RwLock, broadcast};
 use tracing::{debug, error, info, warn};
 
-use crate::agent_manager::{IAgentManager, approval_key};
+use crate::agent_manager::approval_key;
 use crate::cli_process::CliAgentProcess;
 use crate::stream_event::AgentStreamEvent;
 use crate::types::SendMessageData;
@@ -376,21 +376,21 @@ impl OpenClawAgentManager {
 }
 
 #[async_trait::async_trait]
-impl IAgentManager for OpenClawAgentManager {
+impl crate::agent_task::IAgentTask for OpenClawAgentManager {
     fn agent_type(&self) -> AgentType {
         AgentType::OpenclawGateway
     }
 
-    fn status(&self) -> Option<ConversationStatus> {
-        self.state.try_read().ok().and_then(|g| g.status)
+    fn conversation_id(&self) -> &str {
+        &self.conversation_id
     }
 
     fn workspace(&self) -> &str {
         &self.workspace
     }
 
-    fn conversation_id(&self) -> &str {
-        &self.conversation_id
+    fn status(&self) -> Option<ConversationStatus> {
+        self.state.try_read().ok().and_then(|g| g.status)
     }
 
     fn last_activity_at(&self) -> TimestampMs {
@@ -486,7 +486,37 @@ impl IAgentManager for OpenClawAgentManager {
         Ok(())
     }
 
-    fn confirm(&self, _msg_id: &str, call_id: &str, _data: Value, always_allow: bool) -> Result<(), AppError> {
+    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        info!(
+            conversation_id = %self.conversation_id,
+            ?reason,
+            "Killing OpenClaw agent"
+        );
+
+        let connection = Arc::clone(&self.connection);
+        tokio::spawn(async move {
+            connection.close().await;
+        });
+
+        if let Some(ref process) = self.gateway_process {
+            let process = Arc::clone(process);
+            let grace = Duration::from_millis(OPENCLAW_KILL_GRACE_MS);
+            tokio::spawn(async move {
+                if let Err(e) = process.kill(grace).await {
+                    error!(error = %e, "Failed to kill OpenClaw gateway process");
+                }
+            });
+        }
+
+        Ok(())
+    }
+}
+
+/// OpenClaw-specific operations reached through `AgentInstance::OpenClaw(..)`
+/// matches in the routes + services (e.g. `persist_session_key` uses
+/// `get_session_key`, and `get_openclaw_runtime` calls `get_diagnostics`).
+impl OpenClawAgentManager {
+    pub fn confirm(&self, _msg_id: &str, call_id: &str, _data: Value, always_allow: bool) -> Result<(), AppError> {
         if let Ok(mut state) = self.state.try_write() {
             if always_allow && let Some(conf) = state.confirmations.iter().find(|c| c.call_id == call_id) {
                 let key = approval_key(conf.action.as_deref(), conf.command_type.as_deref());
@@ -512,14 +542,14 @@ impl IAgentManager for OpenClawAgentManager {
         Ok(())
     }
 
-    fn get_confirmations(&self) -> Vec<Confirmation> {
+    pub fn get_confirmations(&self) -> Vec<Confirmation> {
         self.state
             .try_read()
             .map(|g| g.confirmations.clone())
             .unwrap_or_default()
     }
 
-    fn check_approval(&self, action: &str, command_type: Option<&str>) -> bool {
+    pub fn check_approval(&self, action: &str, command_type: Option<&str>) -> bool {
         self.state
             .try_read()
             .map(|g| {
@@ -529,69 +559,8 @@ impl IAgentManager for OpenClawAgentManager {
             .unwrap_or(false)
     }
 
-    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
-        info!(
-            conversation_id = %self.conversation_id,
-            ?reason,
-            "Killing OpenClaw agent"
-        );
-
-        let connection = Arc::clone(&self.connection);
-        tokio::spawn(async move {
-            connection.close().await;
-        });
-
-        if let Some(ref process) = self.gateway_process {
-            let process = Arc::clone(process);
-            let grace = Duration::from_millis(OPENCLAW_KILL_GRACE_MS);
-            tokio::spawn(async move {
-                if let Err(e) = process.kill(grace).await {
-                    error!(error = %e, "Failed to kill OpenClaw gateway process");
-                }
-            });
-        }
-
-        Ok(())
-    }
-
-    fn get_session_key(&self) -> Option<String> {
+    pub fn get_session_key(&self) -> Option<String> {
         self.state.try_read().ok().and_then(|g| g.session_key.clone())
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-}
-
-/// PR #8a: `IAgentTask` delegates to `IAgentManager` during the transition.
-#[async_trait::async_trait]
-impl crate::agent_task::IAgentTask for OpenClawAgentManager {
-    fn agent_type(&self) -> AgentType {
-        <Self as IAgentManager>::agent_type(self)
-    }
-    fn conversation_id(&self) -> &str {
-        <Self as IAgentManager>::conversation_id(self)
-    }
-    fn workspace(&self) -> &str {
-        <Self as IAgentManager>::workspace(self)
-    }
-    fn status(&self) -> Option<ConversationStatus> {
-        <Self as IAgentManager>::status(self)
-    }
-    fn last_activity_at(&self) -> TimestampMs {
-        <Self as IAgentManager>::last_activity_at(self)
-    }
-    fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
-        <Self as IAgentManager>::subscribe(self)
-    }
-    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
-        <Self as IAgentManager>::send_message(self, data).await
-    }
-    async fn stop(&self) -> Result<(), AppError> {
-        <Self as IAgentManager>::stop(self).await
-    }
-    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
-        <Self as IAgentManager>::kill(self, reason)
     }
 }
 

--- a/crates/aionui-ai-agent/src/openclaw/agent.rs
+++ b/crates/aionui-ai-agent/src/openclaw/agent.rs
@@ -563,6 +563,38 @@ impl IAgentManager for OpenClawAgentManager {
     }
 }
 
+/// PR #8a: `IAgentTask` delegates to `IAgentManager` during the transition.
+#[async_trait::async_trait]
+impl crate::agent_task::IAgentTask for OpenClawAgentManager {
+    fn agent_type(&self) -> AgentType {
+        <Self as IAgentManager>::agent_type(self)
+    }
+    fn conversation_id(&self) -> &str {
+        <Self as IAgentManager>::conversation_id(self)
+    }
+    fn workspace(&self) -> &str {
+        <Self as IAgentManager>::workspace(self)
+    }
+    fn status(&self) -> Option<ConversationStatus> {
+        <Self as IAgentManager>::status(self)
+    }
+    fn last_activity_at(&self) -> TimestampMs {
+        <Self as IAgentManager>::last_activity_at(self)
+    }
+    fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
+        <Self as IAgentManager>::subscribe(self)
+    }
+    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+        <Self as IAgentManager>::send_message(self, data).await
+    }
+    async fn stop(&self) -> Result<(), AppError> {
+        <Self as IAgentManager>::stop(self).await
+    }
+    fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        <Self as IAgentManager>::kill(self, reason)
+    }
+}
+
 fn build_spawn_config(cli_path: &str, workspace: &str, gateway: &OpenClawGatewayConfig) -> CommandSpec {
     let host = gateway.host.as_deref().unwrap_or("127.0.0.1");
     let port = gateway.port.unwrap_or(DEFAULT_GATEWAY_PORT);

--- a/crates/aionui-ai-agent/src/task_manager.rs
+++ b/crates/aionui-ai-agent/src/task_manager.rs
@@ -7,17 +7,17 @@ use futures_util::future::BoxFuture;
 use tokio::sync::OnceCell;
 use tracing::info;
 
-use crate::agent_manager::AgentManagerHandle;
+use crate::agent_task::AgentInstance;
 use crate::types::BuildTaskOptions;
 
-/// Factory function that creates an [`AgentManagerHandle`] from build options.
+/// Factory function that creates an [`AgentInstance`] from build options.
 ///
 /// Async so the factory can do real I/O (spawn a CLI process, negotiate the
 /// ACP initialize handshake, etc.) without needing to `block_on` inside the
 /// `IWorkerTaskManager` call site. Returning `BoxFuture` keeps the trait
 /// object-safe for DI.
 pub type AgentFactory =
-    Arc<dyn Fn(BuildTaskOptions) -> BoxFuture<'static, Result<AgentManagerHandle, AppError>> + Send + Sync>;
+    Arc<dyn Fn(BuildTaskOptions) -> BoxFuture<'static, Result<AgentInstance, AppError>> + Send + Sync>;
 
 /// Manages the lifecycle of active Agent tasks.
 ///
@@ -26,7 +26,7 @@ pub type AgentFactory =
 #[async_trait]
 pub trait IWorkerTaskManager: Send + Sync {
     /// Get an existing task by conversation ID.
-    fn get_task(&self, conversation_id: &str) -> Option<AgentManagerHandle>;
+    fn get_task(&self, conversation_id: &str) -> Option<AgentInstance>;
 
     /// Get an existing task or build a new one if none exists.
     ///
@@ -39,7 +39,7 @@ pub trait IWorkerTaskManager: Send + Sync {
         &self,
         conversation_id: &str,
         options: BuildTaskOptions,
-    ) -> Result<AgentManagerHandle, AppError>;
+    ) -> Result<AgentInstance, AppError>;
 
     /// Kill and remove a task.
     fn kill(&self, conversation_id: &str, reason: Option<AgentKillReason>) -> Result<(), AppError>;
@@ -62,7 +62,7 @@ pub trait IWorkerTaskManager: Send + Sync {
 /// initialises by running the factory, and that every subsequent caller
 /// awaits. Failed initialisations leave the cell empty so the next caller
 /// may retry; the slot itself is only removed on `kill` / `clear`.
-type TaskSlot = Arc<OnceCell<AgentManagerHandle>>;
+type TaskSlot = Arc<OnceCell<AgentInstance>>;
 
 /// Default implementation of [`IWorkerTaskManager`] using a concurrent hash map.
 pub struct WorkerTaskManagerImpl {
@@ -78,23 +78,23 @@ impl WorkerTaskManagerImpl {
         }
     }
 
-    /// Look up a fully-initialised handle by conversation id.
-    fn initialised_handle(&self, conversation_id: &str) -> Option<AgentManagerHandle> {
+    /// Look up a fully-initialised instance by conversation id.
+    fn initialised_instance(&self, conversation_id: &str) -> Option<AgentInstance> {
         self.tasks.get(conversation_id).and_then(|slot| slot.get().cloned())
     }
 }
 
 #[async_trait]
 impl IWorkerTaskManager for WorkerTaskManagerImpl {
-    fn get_task(&self, conversation_id: &str) -> Option<AgentManagerHandle> {
-        self.initialised_handle(conversation_id)
+    fn get_task(&self, conversation_id: &str) -> Option<AgentInstance> {
+        self.initialised_instance(conversation_id)
     }
 
     async fn get_or_build_task(
         &self,
         conversation_id: &str,
         options: BuildTaskOptions,
-    ) -> Result<AgentManagerHandle, AppError> {
+    ) -> Result<AgentInstance, AppError> {
         // Atomically obtain the per-conversation slot. `DashMap::entry` is
         // synchronous and side-effect-free — only an empty OnceCell is
         // allocated on the miss path, so concurrent callers for the same id
@@ -107,11 +107,11 @@ impl IWorkerTaskManager for WorkerTaskManagerImpl {
 
         // `OnceCell::get_or_try_init` serialises concurrent initialisers:
         // the first caller to reach it runs the factory, every other caller
-        // awaits the same future and ends up with the same handle. On
+        // awaits the same future and ends up with the same instance. On
         // failure the cell stays empty so a later caller can retry.
         let factory = self.factory.clone();
-        let handle = slot.get_or_try_init(|| async move { factory(options).await }).await?;
-        Ok(Arc::clone(handle))
+        let instance = slot.get_or_try_init(|| async move { factory(options).await }).await?;
+        Ok(instance.clone())
     }
 
     fn kill(&self, conversation_id: &str, reason: Option<AgentKillReason>) -> Result<(), AppError> {
@@ -159,15 +159,18 @@ impl IWorkerTaskManager for WorkerTaskManagerImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent_manager::IAgentManager;
+    use crate::agent_task::{IAgentTask, IMockAgent};
     use crate::stream_event::AgentStreamEvent;
     use crate::types::SendMessageData;
-    use aionui_common::{AgentKillReason, AgentType, Confirmation, ConversationStatus, ProviderWithModel};
+    use aionui_common::{AgentKillReason, AgentType, ConversationStatus, ProviderWithModel};
     use futures_util::FutureExt;
     use std::sync::atomic::{AtomicI64, Ordering};
     use tokio::sync::broadcast;
 
-    /// A minimal mock agent for testing task manager logic.
+    /// A minimal mock agent for testing task manager logic. Lives behind
+    /// the `AgentInstance::Mock` trait-object variant so we don't have to
+    /// stand up a real `AcpAgentManager` just to exercise lifecycle
+    /// dispatch.
     struct MockAgent {
         agent_type: AgentType,
         conversation_id: String,
@@ -202,18 +205,18 @@ mod tests {
     }
 
     #[async_trait::async_trait]
-    impl IAgentManager for MockAgent {
+    impl IAgentTask for MockAgent {
         fn agent_type(&self) -> AgentType {
             self.agent_type
         }
-        fn status(&self) -> Option<ConversationStatus> {
-            self.status
+        fn conversation_id(&self) -> &str {
+            &self.conversation_id
         }
         fn workspace(&self) -> &str {
             &self.workspace
         }
-        fn conversation_id(&self) -> &str {
-            &self.conversation_id
+        fn status(&self) -> Option<ConversationStatus> {
+            self.status
         }
         fn last_activity_at(&self) -> TimestampMs {
             self.last_activity.load(Ordering::Relaxed)
@@ -227,28 +230,12 @@ mod tests {
         async fn stop(&self) -> Result<(), AppError> {
             Ok(())
         }
-        fn confirm(
-            &self,
-            _msg_id: &str,
-            _call_id: &str,
-            _data: serde_json::Value,
-            _always_allow: bool,
-        ) -> Result<(), AppError> {
-            Ok(())
-        }
-        fn get_confirmations(&self) -> Vec<Confirmation> {
-            vec![]
-        }
-        fn check_approval(&self, _action: &str, _command_type: Option<&str>) -> bool {
-            false
-        }
         fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
             Ok(())
         }
-        fn as_any(&self) -> &dyn std::any::Any {
-            self
-        }
     }
+
+    impl IMockAgent for MockAgent {}
 
     fn make_options(conversation_id: &str) -> BuildTaskOptions {
         BuildTaskOptions {
@@ -264,11 +251,24 @@ mod tests {
         }
     }
 
+    fn mock_instance(agent: MockAgent) -> AgentInstance {
+        AgentInstance::Mock(Arc::new(agent))
+    }
+
     fn make_manager() -> WorkerTaskManagerImpl {
         let factory: AgentFactory = Arc::new(|opts: BuildTaskOptions| {
-            async move { Ok(Arc::new(MockAgent::new(&opts.conversation_id, None)) as AgentManagerHandle) }.boxed()
+            async move { Ok(mock_instance(MockAgent::new(&opts.conversation_id, None))) }.boxed()
         });
         WorkerTaskManagerImpl::new(factory)
+    }
+
+    /// Two [`AgentInstance`]s point to the same underlying agent iff they
+    /// share an `Arc` — check by pointer identity on the inner trait object.
+    fn same_mock(a: &AgentInstance, b: &AgentInstance) -> bool {
+        match (a, b) {
+            (AgentInstance::Mock(x), AgentInstance::Mock(y)) => Arc::ptr_eq(x, y),
+            _ => false,
+        }
     }
 
     #[test]
@@ -280,8 +280,8 @@ mod tests {
     #[tokio::test]
     async fn get_or_build_creates_task() {
         let mgr = make_manager();
-        let handle = mgr.get_or_build_task("conv-1", make_options("conv-1")).await.unwrap();
-        assert_eq!(handle.conversation_id(), "conv-1");
+        let instance = mgr.get_or_build_task("conv-1", make_options("conv-1")).await.unwrap();
+        assert_eq!(instance.conversation_id(), "conv-1");
         assert_eq!(mgr.active_count(), 1);
     }
 
@@ -290,7 +290,7 @@ mod tests {
         let mgr = make_manager();
         let h1 = mgr.get_or_build_task("conv-1", make_options("conv-1")).await.unwrap();
         let h2 = mgr.get_or_build_task("conv-1", make_options("conv-1")).await.unwrap();
-        assert!(Arc::ptr_eq(&h1, &h2));
+        assert!(same_mock(&h1, &h2));
         assert_eq!(mgr.active_count(), 1);
     }
 
@@ -306,7 +306,7 @@ mod tests {
                 // Simulate a slow build (CLI spawn + initialize handshake).
                 tokio::time::sleep(std::time::Duration::from_millis(30)).await;
                 calls.fetch_add(1, Ordering::SeqCst);
-                Ok(Arc::new(MockAgent::new(&opts.conversation_id, None)) as AgentManagerHandle)
+                Ok(mock_instance(MockAgent::new(&opts.conversation_id, None)))
             }
             .boxed()
         });
@@ -329,7 +329,7 @@ mod tests {
         assert_eq!(calls.load(Ordering::SeqCst), 1, "factory must run only once");
         assert_eq!(mgr.active_count(), 1);
         for h in handles.iter().skip(1) {
-            assert!(Arc::ptr_eq(&handles[0], h), "all callers see the same handle");
+            assert!(same_mock(&handles[0], h), "all callers see the same handle");
         }
     }
 
@@ -345,7 +345,7 @@ mod tests {
                 if flag.swap(false, Ordering::SeqCst) {
                     Err(AppError::Internal("first call fails".into()))
                 } else {
-                    Ok(Arc::new(MockAgent::new(&opts.conversation_id, None)) as AgentManagerHandle)
+                    Ok(mock_instance(MockAgent::new(&opts.conversation_id, None)))
                 }
             }
             .boxed()
@@ -404,36 +404,46 @@ mod tests {
         let mgr = WorkerTaskManagerImpl::new(factory);
 
         // Helper: insert a pre-initialised slot bypassing the async factory path.
-        let insert = |id: &str, agent: Arc<dyn IAgentManager>| {
-            let cell: OnceCell<AgentManagerHandle> = OnceCell::new();
-            cell.set(agent).ok();
+        let insert = |id: &str, instance: AgentInstance| {
+            let cell: OnceCell<AgentInstance> = OnceCell::new();
+            cell.set(instance).ok();
             mgr.tasks.insert(id.into(), Arc::new(cell));
         };
 
         // ACP + Finished + old activity → should be collected
-        let stale = Arc::new(
-            MockAgent::new("conv-stale", Some(ConversationStatus::Finished)).with_last_activity(now_ms() - 600_000), // 10 min ago
+        insert(
+            "conv-stale",
+            mock_instance(
+                MockAgent::new("conv-stale", Some(ConversationStatus::Finished)).with_last_activity(now_ms() - 600_000),
+            ),
         );
-        insert("conv-stale", stale);
 
         // ACP + Finished + recent activity → should NOT be collected
-        let recent =
-            Arc::new(MockAgent::new("conv-recent", Some(ConversationStatus::Finished)).with_last_activity(now_ms()));
-        insert("conv-recent", recent);
+        insert(
+            "conv-recent",
+            mock_instance(
+                MockAgent::new("conv-recent", Some(ConversationStatus::Finished)).with_last_activity(now_ms()),
+            ),
+        );
 
         // ACP + Running + old activity → should NOT be collected
-        let running = Arc::new(
-            MockAgent::new("conv-running", Some(ConversationStatus::Running)).with_last_activity(now_ms() - 600_000),
+        insert(
+            "conv-running",
+            mock_instance(
+                MockAgent::new("conv-running", Some(ConversationStatus::Running))
+                    .with_last_activity(now_ms() - 600_000),
+            ),
         );
-        insert("conv-running", running);
 
         // Non-ACP (Nanobot) + Finished + old activity → should NOT be collected
-        let nanobot = Arc::new(
-            MockAgent::new("conv-nanobot", Some(ConversationStatus::Finished))
-                .with_agent_type(AgentType::Nanobot)
-                .with_last_activity(now_ms() - 600_000),
+        insert(
+            "conv-nanobot",
+            mock_instance(
+                MockAgent::new("conv-nanobot", Some(ConversationStatus::Finished))
+                    .with_agent_type(AgentType::Nanobot)
+                    .with_last_activity(now_ms() - 600_000),
+            ),
         );
-        insert("conv-nanobot", nanobot);
 
         let idle = mgr.collect_idle(300_000); // 5-min threshold
         assert_eq!(idle.len(), 1);

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use aionui_ai_agent::acp_agent::AcpAgentManager;
 use aionui_ai_agent::agent_registry::AgentRegistry;
 use aionui_ai_agent::factory::acp_assembler::{WorkspaceInfo, assemble_acp_params};
-use aionui_ai_agent::{AgentStreamEvent, IAgentManager};
+use aionui_ai_agent::{AgentStreamEvent, IAgentTask};
 use aionui_common::ConversationStatus;
 use aionui_db::{SqliteAgentMetadataRepository, init_database_memory};
 use tokio::sync::broadcast;

--- a/crates/aionui-ai-agent/tests/agent_types_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_types_integration.rs
@@ -9,16 +9,7 @@
 
 use std::sync::Arc;
 
-// Explicit imports (no glob) — `aionui_ai_agent::*` still re-exports the
-// legacy `IAgentManager`, so glob-importing it alongside `IAgentTask`
-// would cause ambiguous method resolution during the PR #8 migration.
-// PR #8c removes `IAgentManager` and restores the crate prelude.
-use aionui_ai_agent::IAgentManager;
-use aionui_ai_agent::agent_task::{AgentInstance, IAgentTask, IMockAgent};
-use aionui_ai_agent::{
-    AgentFactory, AgentStreamEvent, AionrsAgentManager, AionrsResolvedConfig, BuildTaskOptions, IWorkerTaskManager,
-    SendMessageData, SkillIndex, WorkerTaskManagerImpl, build_system_instructions_with_skills_index,
-};
+use aionui_ai_agent::*;
 use aionui_common::{AgentKillReason, AgentType, ConversationStatus, ProviderWithModel, TimestampMs, now_ms};
 use serde_json::json;
 use std::sync::atomic::{AtomicI64, Ordering};
@@ -113,8 +104,8 @@ async fn aionrs_agent_kill_succeeds() {
     let agent = AionrsAgentManager::new("conv-1".into(), "/proj".into(), make_aionrs_config(), None)
         .await
         .unwrap();
-    assert!(IAgentTask::kill(&agent, None).is_ok());
-    assert!(IAgentTask::kill(&agent, Some(AgentKillReason::IdleTimeout)).is_ok());
+    assert!(agent.kill(None).is_ok());
+    assert!(agent.kill(Some(AgentKillReason::IdleTimeout)).is_ok());
 }
 
 #[tokio::test]
@@ -122,7 +113,10 @@ async fn aionrs_agent_confirm_succeeds() {
     let agent = AionrsAgentManager::new("conv-1".into(), "/proj".into(), make_aionrs_config(), None)
         .await
         .unwrap();
-    let result = IAgentManager::confirm(&agent, "msg", "call", json!({}), false);
+    // `confirm` is an inherent method on `AionrsAgentManager` (reached via
+    // `AgentInstance::Aionrs(..)` in production); the test calls it
+    // directly on the concrete manager.
+    let result = agent.confirm("msg", "call", json!({}), false);
     assert!(result.is_ok());
 }
 
@@ -131,16 +125,12 @@ async fn aionrs_agent_metadata() {
     let agent = AionrsAgentManager::new("conv-abc".into(), "/work".into(), make_aionrs_config(), None)
         .await
         .unwrap();
-    // UFCS because AionrsAgentManager currently implements BOTH `IAgentManager`
-    // (legacy, removed in PR #8c) and `IAgentTask` (new), so the short
-    // `agent.status()` etc. calls would be ambiguous. Once PR #8c deletes
-    // `IAgentManager` these can collapse back to method-call syntax.
-    assert_eq!(IAgentTask::agent_type(&agent), AgentType::Aionrs);
-    assert_eq!(IAgentTask::workspace(&agent), "/work");
-    assert_eq!(IAgentTask::conversation_id(&agent), "conv-abc");
-    assert_eq!(IAgentTask::status(&agent), Some(ConversationStatus::Pending));
-    assert!(IAgentManager::get_confirmations(&agent).is_empty());
-    assert!(!IAgentManager::check_approval(&agent, "any", None));
+    assert_eq!(agent.agent_type(), AgentType::Aionrs);
+    assert_eq!(agent.workspace(), "/work");
+    assert_eq!(agent.conversation_id(), "conv-abc");
+    assert_eq!(agent.status(), Some(ConversationStatus::Pending));
+    assert!(agent.get_confirmations().is_empty());
+    assert!(!agent.check_approval("any", None));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aionui-ai-agent/tests/agent_types_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_types_integration.rs
@@ -1,7 +1,7 @@
 //! Integration tests for agent type implementations and auxiliary features.
 //!
 //! These tests validate:
-//! - Each agent manager implements IAgentManager correctly
+//! - Each agent manager implements IAgentTask correctly
 //! - Agent factory can build all agent types
 //! - Idle scanner finds eligible tasks
 //! - Workspace browsing works with real filesystem
@@ -9,10 +9,17 @@
 
 use std::sync::Arc;
 
-use aionui_ai_agent::*;
-use aionui_common::{
-    AgentKillReason, AgentType, Confirmation, ConversationStatus, ProviderWithModel, TimestampMs, now_ms,
+// Explicit imports (no glob) — `aionui_ai_agent::*` still re-exports the
+// legacy `IAgentManager`, so glob-importing it alongside `IAgentTask`
+// would cause ambiguous method resolution during the PR #8 migration.
+// PR #8c removes `IAgentManager` and restores the crate prelude.
+use aionui_ai_agent::IAgentManager;
+use aionui_ai_agent::agent_task::{AgentInstance, IAgentTask, IMockAgent};
+use aionui_ai_agent::{
+    AgentFactory, AgentStreamEvent, AionrsAgentManager, AionrsResolvedConfig, BuildTaskOptions, IWorkerTaskManager,
+    SendMessageData, SkillIndex, WorkerTaskManagerImpl, build_system_instructions_with_skills_index,
 };
+use aionui_common::{AgentKillReason, AgentType, ConversationStatus, ProviderWithModel, TimestampMs, now_ms};
 use serde_json::json;
 use std::sync::atomic::{AtomicI64, Ordering};
 use tokio::sync::broadcast;
@@ -50,18 +57,18 @@ impl TypedMockAgent {
 }
 
 #[async_trait::async_trait]
-impl IAgentManager for TypedMockAgent {
+impl IAgentTask for TypedMockAgent {
     fn agent_type(&self) -> AgentType {
         self.agent_type
     }
-    fn status(&self) -> Option<ConversationStatus> {
-        self.status
+    fn conversation_id(&self) -> &str {
+        &self.conversation_id
     }
     fn workspace(&self) -> &str {
         &self.workspace
     }
-    fn conversation_id(&self) -> &str {
-        &self.conversation_id
+    fn status(&self) -> Option<ConversationStatus> {
+        self.status
     }
     fn last_activity_at(&self) -> TimestampMs {
         self.last_activity.load(Ordering::Relaxed)
@@ -75,28 +82,12 @@ impl IAgentManager for TypedMockAgent {
     async fn stop(&self) -> Result<(), aionui_common::AppError> {
         Ok(())
     }
-    fn confirm(
-        &self,
-        _msg_id: &str,
-        _call_id: &str,
-        _data: serde_json::Value,
-        _always_allow: bool,
-    ) -> Result<(), aionui_common::AppError> {
-        Ok(())
-    }
-    fn get_confirmations(&self) -> Vec<Confirmation> {
-        vec![]
-    }
-    fn check_approval(&self, _action: &str, _command_type: Option<&str>) -> bool {
-        false
-    }
     fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), aionui_common::AppError> {
         Ok(())
     }
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
+
+impl IMockAgent for TypedMockAgent {}
 
 // ---------------------------------------------------------------------------
 // Aionrs agent tests (real implementation with AgentEngine)
@@ -122,8 +113,8 @@ async fn aionrs_agent_kill_succeeds() {
     let agent = AionrsAgentManager::new("conv-1".into(), "/proj".into(), make_aionrs_config(), None)
         .await
         .unwrap();
-    assert!(agent.kill(None).is_ok());
-    assert!(agent.kill(Some(AgentKillReason::IdleTimeout)).is_ok());
+    assert!(IAgentTask::kill(&agent, None).is_ok());
+    assert!(IAgentTask::kill(&agent, Some(AgentKillReason::IdleTimeout)).is_ok());
 }
 
 #[tokio::test]
@@ -131,7 +122,7 @@ async fn aionrs_agent_confirm_succeeds() {
     let agent = AionrsAgentManager::new("conv-1".into(), "/proj".into(), make_aionrs_config(), None)
         .await
         .unwrap();
-    let result = agent.confirm("msg", "call", json!({}), false);
+    let result = IAgentManager::confirm(&agent, "msg", "call", json!({}), false);
     assert!(result.is_ok());
 }
 
@@ -140,12 +131,16 @@ async fn aionrs_agent_metadata() {
     let agent = AionrsAgentManager::new("conv-abc".into(), "/work".into(), make_aionrs_config(), None)
         .await
         .unwrap();
-    assert_eq!(agent.agent_type(), AgentType::Aionrs);
-    assert_eq!(agent.workspace(), "/work");
-    assert_eq!(agent.conversation_id(), "conv-abc");
-    assert_eq!(agent.status(), Some(ConversationStatus::Pending));
-    assert!(agent.get_confirmations().is_empty());
-    assert!(!agent.check_approval("any", None));
+    // UFCS because AionrsAgentManager currently implements BOTH `IAgentManager`
+    // (legacy, removed in PR #8c) and `IAgentTask` (new), so the short
+    // `agent.status()` etc. calls would be ambiguous. Once PR #8c deletes
+    // `IAgentManager` these can collapse back to method-call syntax.
+    assert_eq!(IAgentTask::agent_type(&agent), AgentType::Aionrs);
+    assert_eq!(IAgentTask::workspace(&agent), "/work");
+    assert_eq!(IAgentTask::conversation_id(&agent), "conv-abc");
+    assert_eq!(IAgentTask::status(&agent), Some(ConversationStatus::Pending));
+    assert!(IAgentManager::get_confirmations(&agent).is_empty());
+    assert!(!IAgentManager::check_approval(&agent, "any", None));
 }
 
 // ---------------------------------------------------------------------------
@@ -166,7 +161,7 @@ async fn collect_idle_ignores_non_acp_agent_types() {
                 Some(ConversationStatus::Finished),
             )
             .with_last_activity(old_ts);
-            Ok(Arc::new(mock) as AgentManagerHandle)
+            Ok(AgentInstance::Mock(Arc::new(mock)))
         }
         .boxed()
     });

--- a/crates/aionui-app/Cargo.toml
+++ b/crates/aionui-app/Cargo.toml
@@ -52,6 +52,9 @@ anyhow.workspace = true
 [dev-dependencies]
 aionui-api-types.workspace = true
 aionui-realtime.workspace = true
+# Enable the `AgentInstance::Mock` variant so tests can build fake agents
+# through the trait-object escape hatch without spawning real CLI processes.
+aionui-ai-agent = { workspace = true, features = ["test-support"] }
 async-trait.workspace = true
 base64.workspace = true
 git2.workspace = true

--- a/crates/aionui-app/tests/agent_integration_e2e.rs
+++ b/crates/aionui-app/tests/agent_integration_e2e.rs
@@ -5,7 +5,6 @@
 
 mod common;
 
-use std::any::Any;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -14,7 +13,7 @@ use serde_json::{Value, json};
 use tokio::sync::broadcast;
 use tower::ServiceExt;
 
-use aionui_ai_agent::agent_manager::{AgentManagerHandle, IAgentManager};
+use aionui_ai_agent::agent_task::{AgentInstance, IAgentTask, IMockAgent};
 use aionui_ai_agent::stream_event::TextEventData;
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
 use aionui_ai_agent::{AgentStreamEvent, IWorkerTaskManager};
@@ -49,21 +48,21 @@ impl MockAgent {
 }
 
 #[async_trait]
-impl IAgentManager for MockAgent {
+impl IAgentTask for MockAgent {
     fn agent_type(&self) -> AgentType {
         AgentType::Acp
     }
 
-    fn status(&self) -> Option<ConversationStatus> {
-        Some(ConversationStatus::Running)
+    fn conversation_id(&self) -> &str {
+        &self.conversation_id
     }
 
     fn workspace(&self) -> &str {
         &self.workspace
     }
 
-    fn conversation_id(&self) -> &str {
-        &self.conversation_id
+    fn status(&self) -> Option<ConversationStatus> {
+        Some(ConversationStatus::Running)
     }
 
     fn last_activity_at(&self) -> TimestampMs {
@@ -90,15 +89,13 @@ impl IAgentManager for MockAgent {
         Ok(())
     }
 
-    fn confirm(&self, _msg_id: &str, call_id: &str, _data: Value, always_allow: bool) -> Result<(), AppError> {
-        let mut confs = self.confirmations.lock().unwrap();
-        confs.retain(|c| c.call_id != call_id);
-        if always_allow {
-            self.approvals.lock().unwrap().insert("test_action".to_owned(), true);
-        }
+    fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
         Ok(())
     }
+}
 
+#[async_trait]
+impl IMockAgent for MockAgent {
     fn get_confirmations(&self) -> Vec<Confirmation> {
         self.confirmations.lock().unwrap().clone()
     }
@@ -107,19 +104,20 @@ impl IAgentManager for MockAgent {
         self.approvals.lock().unwrap().get(action).copied().unwrap_or(false)
     }
 
-    fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
+    fn confirm(&self, _msg_id: &str, call_id: &str, _data: Value, always_allow: bool) -> Result<(), AppError> {
+        let mut confs = self.confirmations.lock().unwrap();
+        confs.retain(|c| c.call_id != call_id);
+        if always_allow {
+            self.approvals.lock().unwrap().insert("test_action".to_owned(), true);
+        }
         Ok(())
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
 // ── Mock Worker Task Manager ────────────────────────────────────
 
 struct MockTaskManager {
-    agents: Mutex<std::collections::HashMap<String, AgentManagerHandle>>,
+    agents: Mutex<std::collections::HashMap<String, AgentInstance>>,
 }
 
 impl MockTaskManager {
@@ -131,14 +129,17 @@ impl MockTaskManager {
 
     fn insert(&self, conv_id: &str, workspace: &str) -> Arc<MockAgent> {
         let agent = Arc::new(MockAgent::new(conv_id, workspace));
-        self.agents.lock().unwrap().insert(conv_id.to_owned(), agent.clone());
+        self.agents
+            .lock()
+            .unwrap()
+            .insert(conv_id.to_owned(), AgentInstance::Mock(agent.clone()));
         agent
     }
 }
 
 #[async_trait::async_trait]
 impl IWorkerTaskManager for MockTaskManager {
-    fn get_task(&self, conversation_id: &str) -> Option<AgentManagerHandle> {
+    fn get_task(&self, conversation_id: &str) -> Option<AgentInstance> {
         self.agents.lock().unwrap().get(conversation_id).cloned()
     }
 
@@ -146,14 +147,14 @@ impl IWorkerTaskManager for MockTaskManager {
         &self,
         conversation_id: &str,
         _options: BuildTaskOptions,
-    ) -> Result<AgentManagerHandle, AppError> {
+    ) -> Result<AgentInstance, AppError> {
         let mut agents = self.agents.lock().unwrap();
         if let Some(existing) = agents.get(conversation_id) {
             return Ok(existing.clone());
         }
-        let agent: AgentManagerHandle = Arc::new(MockAgent::new(conversation_id, "/mock-workspace"));
-        agents.insert(conversation_id.to_owned(), agent.clone());
-        Ok(agent)
+        let instance = AgentInstance::Mock(Arc::new(MockAgent::new(conversation_id, "/mock-workspace")));
+        agents.insert(conversation_id.to_owned(), instance.clone());
+        Ok(instance)
     }
 
     fn kill(&self, conversation_id: &str, _reason: Option<AgentKillReason>) -> Result<(), AppError> {

--- a/crates/aionui-app/tests/team_smoke_e2e.rs
+++ b/crates/aionui-app/tests/team_smoke_e2e.rs
@@ -18,14 +18,14 @@ mod common;
 
 use std::sync::Arc;
 
-use aionui_ai_agent::agent_manager::IAgentManager;
+use aionui_ai_agent::agent_task::{AgentInstance, IAgentTask, IMockAgent};
 use aionui_ai_agent::stream_event::{AgentStreamEvent, ErrorEventData, FinishEventData};
 use aionui_ai_agent::types::{AgentStreamChunk, BuildTaskOptions, SendMessageData};
 use aionui_ai_agent::{AgentFactory, IWorkerTaskManager, WorkerTaskManagerImpl};
 use aionui_api_types::AcpBuildExtra;
 use aionui_api_types::TeamMcpStdioConfig;
 use aionui_app::{AppServices, build_module_states, create_router_with_states};
-use aionui_common::{AgentKillReason, AgentType, AppError, Confirmation, ConversationStatus, TimestampMs};
+use aionui_common::{AgentKillReason, AgentType, AppError, ConversationStatus, TimestampMs};
 use aionui_db::models::{MailboxMessageRow, TeamTaskRow};
 use aionui_db::{ITeamRepository, SqliteTeamRepository};
 use axum::http::StatusCode;
@@ -118,18 +118,18 @@ impl MockAgentManager {
 }
 
 #[async_trait::async_trait]
-impl IAgentManager for MockAgentManager {
+impl IAgentTask for MockAgentManager {
     fn agent_type(&self) -> AgentType {
         AgentType::Acp
     }
-    fn status(&self) -> Option<ConversationStatus> {
-        None
+    fn conversation_id(&self) -> &str {
+        &self.conversation_id
     }
     fn workspace(&self) -> &str {
         &self.workspace
     }
-    fn conversation_id(&self) -> &str {
-        &self.conversation_id
+    fn status(&self) -> Option<ConversationStatus> {
+        None
     }
     fn last_activity_at(&self) -> TimestampMs {
         0
@@ -182,22 +182,12 @@ impl IAgentManager for MockAgentManager {
     async fn stop(&self) -> Result<(), AppError> {
         Ok(())
     }
-    fn confirm(&self, _msg_id: &str, _call_id: &str, _data: Value, _always_allow: bool) -> Result<(), AppError> {
-        Ok(())
-    }
-    fn get_confirmations(&self) -> Vec<Confirmation> {
-        vec![]
-    }
-    fn check_approval(&self, _action: &str, _command_type: Option<&str>) -> bool {
-        false
-    }
     fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
         Ok(())
     }
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
+
+impl IMockAgent for MockAgentManager {}
 
 /// Every conversation gets a `MockAgentManager` wired to whatever
 /// `team_mcp_stdio_config` was persisted for it.
@@ -221,7 +211,7 @@ fn mock_factory() -> AgentFactory {
                 user_id: None,
             });
             let agent = MockAgentManager::new(opts.conversation_id, opts.workspace, extra.team_mcp_stdio_config);
-            Ok(Arc::new(agent) as aionui_ai_agent::AgentManagerHandle)
+            Ok(AgentInstance::Mock(Arc::new(agent)))
         }
         .boxed()
     })

--- a/crates/aionui-conversation/Cargo.toml
+++ b/crates/aionui-conversation/Cargo.toml
@@ -21,3 +21,6 @@ async-trait.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+# Enable the `AgentInstance::Mock` variant so tests can build fake agents
+# through the trait-object escape hatch without spawning real CLI processes.
+aionui-ai-agent = { workspace = true, features = ["test-support"] }

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -1031,7 +1031,7 @@ impl ConversationService {
                 .with_turn_completion(false);
 
                 let rx = agent.subscribe();
-                let send_agent = Arc::clone(&agent);
+                let send_agent = agent.clone();
                 let conv_id_send = conv_id.clone();
                 // 1. Send the message to the agent and concurrently run the relay to stream events.
                 tokio::spawn(async move {

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 use aionui_ai_agent::IWorkerTaskManager;
-use aionui_ai_agent::agent_manager::{AgentManagerHandle, IAgentManager};
+use aionui_ai_agent::agent_task::{AgentInstance, IAgentTask, IMockAgent};
 use aionui_ai_agent::stream_event::{AgentStreamEvent, FinishEventData, TextEventData};
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
 
@@ -1198,18 +1198,18 @@ impl MockAgent {
 }
 
 #[async_trait::async_trait]
-impl IAgentManager for MockAgent {
+impl IAgentTask for MockAgent {
     fn agent_type(&self) -> AgentType {
         AgentType::Acp
     }
-    fn status(&self) -> Option<ConversationStatus> {
-        None
+    fn conversation_id(&self) -> &str {
+        &self.conversation_id
     }
     fn workspace(&self) -> &str {
         self.workspace_override.as_deref().unwrap_or("/tmp/test")
     }
-    fn conversation_id(&self) -> &str {
-        &self.conversation_id
+    fn status(&self) -> Option<ConversationStatus> {
+        None
     }
     fn last_activity_at(&self) -> TimestampMs {
         0
@@ -1227,6 +1227,23 @@ impl IAgentManager for MockAgent {
     async fn stop(&self) -> Result<(), AppError> {
         *self.stopped.lock().unwrap() = true;
         Ok(())
+    }
+    fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl IMockAgent for MockAgent {
+    fn get_confirmations(&self) -> Vec<Confirmation> {
+        self.confirmations.lock().unwrap().clone()
+    }
+    fn check_approval(&self, action: &str, command_type: Option<&str>) -> bool {
+        let key = match command_type {
+            Some(ct) => format!("{action}:{ct}"),
+            None => action.to_owned(),
+        };
+        self.approval_memory.lock().unwrap().get(&key).copied().unwrap_or(false)
     }
     fn confirm(
         &self,
@@ -1253,28 +1270,12 @@ impl IAgentManager for MockAgent {
         confs.retain(|c| c.call_id != call_id);
         Ok(())
     }
-    fn get_confirmations(&self) -> Vec<Confirmation> {
-        self.confirmations.lock().unwrap().clone()
-    }
-    fn check_approval(&self, action: &str, command_type: Option<&str>) -> bool {
-        let key = match command_type {
-            Some(ct) => format!("{action}:{ct}"),
-            None => action.to_owned(),
-        };
-        self.approval_memory.lock().unwrap().get(&key).copied().unwrap_or(false)
-    }
-    fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
-        Ok(())
-    }
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 // ── Mock WorkerTaskManager ──────────────────────────────────────
 
 struct MockTaskManager {
-    agents: Mutex<std::collections::HashMap<String, AgentManagerHandle>>,
+    agents: Mutex<std::collections::HashMap<String, AgentInstance>>,
 }
 
 impl MockTaskManager {
@@ -1284,14 +1285,14 @@ impl MockTaskManager {
         }
     }
 
-    fn insert_agent(&self, conversation_id: &str, agent: AgentManagerHandle) {
+    fn insert_agent(&self, conversation_id: &str, agent: AgentInstance) {
         self.agents.lock().unwrap().insert(conversation_id.to_owned(), agent);
     }
 }
 
 #[async_trait::async_trait]
 impl IWorkerTaskManager for MockTaskManager {
-    fn get_task(&self, conversation_id: &str) -> Option<AgentManagerHandle> {
+    fn get_task(&self, conversation_id: &str) -> Option<AgentInstance> {
         self.agents.lock().unwrap().get(conversation_id).cloned()
     }
 
@@ -1299,14 +1300,14 @@ impl IWorkerTaskManager for MockTaskManager {
         &self,
         conversation_id: &str,
         _options: BuildTaskOptions,
-    ) -> Result<AgentManagerHandle, AppError> {
+    ) -> Result<AgentInstance, AppError> {
         let mut agents = self.agents.lock().unwrap();
         if let Some(existing) = agents.get(conversation_id) {
             return Ok(existing.clone());
         }
-        let agent: AgentManagerHandle = Arc::new(MockAgent::new(conversation_id));
-        agents.insert(conversation_id.to_owned(), agent.clone());
-        Ok(agent)
+        let instance = AgentInstance::Mock(Arc::new(MockAgent::new(conversation_id)));
+        agents.insert(conversation_id.to_owned(), instance.clone());
+        Ok(instance)
     }
 
     fn kill(&self, conversation_id: &str, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
@@ -1330,7 +1331,7 @@ impl IWorkerTaskManager for MockTaskManager {
 /// A variant of MockTaskManager that always builds agents with a specific workspace.
 struct MockTaskManagerWithWorkspace {
     workspace: String,
-    agents: Mutex<std::collections::HashMap<String, AgentManagerHandle>>,
+    agents: Mutex<std::collections::HashMap<String, AgentInstance>>,
 }
 
 impl MockTaskManagerWithWorkspace {
@@ -1344,7 +1345,7 @@ impl MockTaskManagerWithWorkspace {
 
 #[async_trait::async_trait]
 impl IWorkerTaskManager for MockTaskManagerWithWorkspace {
-    fn get_task(&self, conversation_id: &str) -> Option<AgentManagerHandle> {
+    fn get_task(&self, conversation_id: &str) -> Option<AgentInstance> {
         self.agents.lock().unwrap().get(conversation_id).cloned()
     }
 
@@ -1352,7 +1353,7 @@ impl IWorkerTaskManager for MockTaskManagerWithWorkspace {
         &self,
         conversation_id: &str,
         _options: BuildTaskOptions,
-    ) -> Result<AgentManagerHandle, AppError> {
+    ) -> Result<AgentInstance, AppError> {
         let workspace = self.workspace.clone();
         let mut agents = self.agents.lock().unwrap();
         if let Some(existing) = agents.get(conversation_id) {
@@ -1360,9 +1361,9 @@ impl IWorkerTaskManager for MockTaskManagerWithWorkspace {
         }
         let mut agent = MockAgent::new(conversation_id);
         agent.workspace_override = Some(workspace);
-        let handle: AgentManagerHandle = Arc::new(agent);
-        agents.insert(conversation_id.to_owned(), handle.clone());
-        Ok(handle)
+        let instance = AgentInstance::Mock(Arc::new(agent));
+        agents.insert(conversation_id.to_owned(), instance.clone());
+        Ok(instance)
     }
 
     fn kill(&self, conversation_id: &str, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
@@ -1407,21 +1408,21 @@ impl ScriptedAgent {
 }
 
 #[async_trait::async_trait]
-impl IAgentManager for ScriptedAgent {
+impl IAgentTask for ScriptedAgent {
     fn agent_type(&self) -> AgentType {
         AgentType::Acp
     }
 
-    fn status(&self) -> Option<ConversationStatus> {
-        Some(ConversationStatus::Finished)
+    fn conversation_id(&self) -> &str {
+        &self.conversation_id
     }
 
     fn workspace(&self) -> &str {
         "/tmp/test"
     }
 
-    fn conversation_id(&self) -> &str {
-        &self.conversation_id
+    fn status(&self) -> Option<ConversationStatus> {
+        Some(ConversationStatus::Finished)
     }
 
     fn last_activity_at(&self) -> TimestampMs {
@@ -1450,32 +1451,12 @@ impl IAgentManager for ScriptedAgent {
         Ok(())
     }
 
-    fn confirm(
-        &self,
-        _msg_id: &str,
-        _call_id: &str,
-        _data: serde_json::Value,
-        _always_allow: bool,
-    ) -> Result<(), AppError> {
-        Ok(())
-    }
-
-    fn get_confirmations(&self) -> Vec<Confirmation> {
-        vec![]
-    }
-
-    fn check_approval(&self, _action: &str, _command_type: Option<&str>) -> bool {
-        false
-    }
-
     fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
+
+impl IMockAgent for ScriptedAgent {}
 
 struct MockCronContinuationService;
 
@@ -1700,7 +1681,7 @@ async fn send_message_continues_cron_system_responses() {
             ],
         ],
     ));
-    task_mgr.insert_agent(&conv.id, scripted_agent.clone());
+    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(scripted_agent.clone()));
     svc.set_cron_service(Some(Arc::new(MockCronContinuationService)));
 
     let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
@@ -1871,7 +1852,10 @@ async fn list_confirmations_returns_items() {
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
 
-    let agent: AgentManagerHandle = Arc::new(MockAgent::with_confirmations(&conv.id, make_test_confirmations()));
+    let agent = AgentInstance::Mock(Arc::new(MockAgent::with_confirmations(
+        &conv.id,
+        make_test_confirmations(),
+    )));
     task_mgr.insert_agent(&conv.id, agent);
 
     let result = svc
@@ -1913,7 +1897,10 @@ async fn confirm_removes_confirmation_and_broadcasts() {
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
     broadcaster.take_events(); // clear create event
 
-    let agent: AgentManagerHandle = Arc::new(MockAgent::with_confirmations(&conv.id, make_test_confirmations()));
+    let agent = AgentInstance::Mock(Arc::new(MockAgent::with_confirmations(
+        &conv.id,
+        make_test_confirmations(),
+    )));
     task_mgr.insert_agent(&conv.id, agent);
 
     let req = aionui_api_types::ConfirmRequest {
@@ -1951,7 +1938,10 @@ async fn confirm_with_always_allow_stores_approval() {
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
 
-    let agent: AgentManagerHandle = Arc::new(MockAgent::with_confirmations(&conv.id, make_test_confirmations()));
+    let agent = AgentInstance::Mock(Arc::new(MockAgent::with_confirmations(
+        &conv.id,
+        make_test_confirmations(),
+    )));
     task_mgr.insert_agent(&conv.id, agent);
 
     let req = aionui_api_types::ConfirmRequest {
@@ -1977,7 +1967,10 @@ async fn confirm_nonexistent_call_id_returns_not_found() {
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
 
-    let agent: AgentManagerHandle = Arc::new(MockAgent::with_confirmations(&conv.id, make_test_confirmations()));
+    let agent = AgentInstance::Mock(Arc::new(MockAgent::with_confirmations(
+        &conv.id,
+        make_test_confirmations(),
+    )));
     task_mgr.insert_agent(&conv.id, agent);
 
     let req = aionui_api_types::ConfirmRequest {
@@ -2006,7 +1999,7 @@ async fn confirm_without_confirmation_state_still_calls_agent() {
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
     broadcaster.take_events();
 
-    let agent: AgentManagerHandle = Arc::new(MockAgent::with_direct_confirm(&conv.id));
+    let agent = AgentInstance::Mock(Arc::new(MockAgent::with_direct_confirm(&conv.id)));
     task_mgr.insert_agent(&conv.id, agent);
 
     let req = aionui_api_types::ConfirmRequest {
@@ -2053,7 +2046,7 @@ async fn check_approval_returns_false_when_not_set() {
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
 
-    let agent: AgentManagerHandle = Arc::new(MockAgent::new(&conv.id));
+    let agent = AgentInstance::Mock(Arc::new(MockAgent::new(&conv.id)));
     task_mgr.insert_agent(&conv.id, agent);
 
     let result = svc
@@ -2076,7 +2069,10 @@ async fn check_approval_returns_true_after_always_allow() {
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
 
-    let agent: AgentManagerHandle = Arc::new(MockAgent::with_confirmations(&conv.id, make_test_confirmations()));
+    let agent = AgentInstance::Mock(Arc::new(MockAgent::with_confirmations(
+        &conv.id,
+        make_test_confirmations(),
+    )));
     task_mgr.insert_agent(&conv.id, agent);
 
     // Confirm with always_allow

--- a/crates/aionui-conversation/tests/conversation_crud.rs
+++ b/crates/aionui-conversation/tests/conversation_crud.rs
@@ -40,14 +40,14 @@ struct NoopTaskManager;
 
 #[async_trait::async_trait]
 impl IWorkerTaskManager for NoopTaskManager {
-    fn get_task(&self, _: &str) -> Option<Arc<dyn aionui_ai_agent::agent_manager::IAgentManager>> {
+    fn get_task(&self, _: &str) -> Option<aionui_ai_agent::AgentInstance> {
         None
     }
     async fn get_or_build_task(
         &self,
         _: &str,
         _: aionui_ai_agent::types::BuildTaskOptions,
-    ) -> Result<Arc<dyn aionui_ai_agent::agent_manager::IAgentManager>, AppError> {
+    ) -> Result<aionui_ai_agent::AgentInstance, AppError> {
         Err(AppError::Internal("noop".into()))
     }
     fn kill(&self, _: &str, _: Option<AgentKillReason>) -> Result<(), AppError> {

--- a/crates/aionui-cron/Cargo.toml
+++ b/crates/aionui-cron/Cargo.toml
@@ -27,3 +27,6 @@ async-trait.workspace = true
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 tempfile.workspace = true
+# Enable the `AgentInstance::Mock` variant so tests can build fake agents
+# through the trait-object escape hatch without spawning real CLI processes.
+aionui-ai-agent = { workspace = true, features = ["test-support"] }

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use aionui_ai_agent::task_manager::IWorkerTaskManager;
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
-use aionui_ai_agent::{AgentRegistry, AgentStreamEvent, IAgentManager};
+use aionui_ai_agent::{AgentRegistry, AgentStreamEvent};
 use aionui_api_types::{CreateConversationRequest, SendMessageRequest};
 use aionui_common::{AgentType, ProviderWithModel, now_ms};
 use aionui_conversation::ConversationService;
@@ -564,7 +564,7 @@ impl JobExecutor {
                 }
                 if saved_skill.is_none() && matches!(job.execution_mode, ExecutionMode::NewConversation) {
                     self.spawn_skill_suggest_flow(
-                        Arc::clone(&agent),
+                        agent.clone(),
                         terminal_rx,
                         SkillSuggestContext {
                             conversation_id: conversation_id.to_owned(),
@@ -665,7 +665,7 @@ impl JobExecutor {
 
     fn spawn_skill_suggest_flow(
         &self,
-        agent: Arc<dyn aionui_ai_agent::IAgentManager>,
+        agent: aionui_ai_agent::AgentInstance,
         main_rx: broadcast::Receiver<AgentStreamEvent>,
         ctx: SkillSuggestContext,
     ) {
@@ -774,7 +774,11 @@ impl JobExecutor {
         Ok(skills)
     }
 
-    async fn ensure_agent_session_mode(&self, job: &CronJob, agent: &Arc<dyn IAgentManager>) -> Result<(), CronError> {
+    async fn ensure_agent_session_mode(
+        &self,
+        job: &CronJob,
+        agent: &aionui_ai_agent::AgentInstance,
+    ) -> Result<(), CronError> {
         let Some(desired_mode) = job
             .agent_config
             .as_ref()
@@ -1116,10 +1120,10 @@ async fn persist_legacy_skill_file(data_dir: &Path, job: &CronJob, raw_content: 
 mod tests {
     use super::*;
     use crate::types::{CreatedBy, CronAgentConfig, CronSchedule};
-    use aionui_ai_agent::agent_manager::AgentManagerHandle;
+    use aionui_ai_agent::agent_task::{AgentInstance, IAgentTask, IMockAgent};
     use aionui_ai_agent::stream_event::FinishEventData;
     use aionui_api_types::{AgentModeResponse, WebSocketMessage};
-    use aionui_common::{AgentKillReason, Confirmation, ConversationStatus, PaginatedResult, TimestampMs};
+    use aionui_common::{AgentKillReason, ConversationStatus, PaginatedResult, TimestampMs};
     use aionui_db::{
         ConversationArtifactRow, ConversationFilters, ConversationRowUpdate, MessageRowUpdate, MessageSearchRow,
         SortOrder,
@@ -1517,7 +1521,7 @@ mod tests {
     #[tokio::test]
     async fn execute_inner_applies_desired_session_mode_before_sending() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
-        let executor = make_executor_with_agent(agent.clone() as AgentManagerHandle);
+        let executor = make_executor_with_agent(AgentInstance::Mock(agent.clone()));
         let mut job = sample_job();
         job.agent_config.as_mut().unwrap().mode = Some("yolo".into());
 
@@ -1538,7 +1542,7 @@ mod tests {
     #[tokio::test]
     async fn execute_inner_applies_mode_even_for_uninitialized_agent() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", false));
-        let executor = make_executor_with_agent(agent.clone() as AgentManagerHandle);
+        let executor = make_executor_with_agent(AgentInstance::Mock(agent.clone()));
         let mut job = sample_job();
         job.agent_config.as_mut().unwrap().mode = Some("yolo".into());
 
@@ -1559,7 +1563,7 @@ mod tests {
     #[tokio::test]
     async fn execute_inner_skips_mode_update_when_already_matching() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "yolo", true));
-        let executor = make_executor_with_agent(agent.clone() as AgentManagerHandle);
+        let executor = make_executor_with_agent(AgentInstance::Mock(agent.clone()));
         let mut job = sample_job();
         job.agent_config.as_mut().unwrap().mode = Some("yolo".into());
 
@@ -1580,7 +1584,7 @@ mod tests {
     #[tokio::test]
     async fn execute_inner_new_conversation_without_saved_skill_requests_skill_suggest() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
-        let task_manager = Arc::new(RecordingTaskManager::new(agent.clone() as AgentManagerHandle));
+        let task_manager = Arc::new(RecordingTaskManager::new(AgentInstance::Mock(agent.clone())));
         let executor = make_executor_with_task_manager(task_manager.clone());
         let job = CronJob {
             execution_mode: ExecutionMode::NewConversation,
@@ -1614,7 +1618,7 @@ mod tests {
     #[tokio::test]
     async fn execute_inner_new_conversation_with_saved_skill_injects_saved_skill() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
-        let task_manager = Arc::new(RecordingTaskManager::new(agent.clone() as AgentManagerHandle));
+        let task_manager = Arc::new(RecordingTaskManager::new(AgentInstance::Mock(agent.clone())));
         let executor = make_executor_with_task_manager(task_manager.clone());
         let job = CronJob {
             execution_mode: ExecutionMode::NewConversation,
@@ -1655,7 +1659,7 @@ mod tests {
     #[tokio::test]
     async fn execute_inner_existing_with_saved_skill_keeps_saved_skill_out_of_prompt_and_turn() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
-        let executor = make_executor_with_agent(agent.clone() as AgentManagerHandle);
+        let executor = make_executor_with_agent(AgentInstance::Mock(agent.clone()));
         let job = sample_job();
         let saved_skill = SavedSkillContext {
             name: "cron-cron_test1".into(),
@@ -1681,7 +1685,7 @@ mod tests {
     #[tokio::test]
     async fn execute_inner_existing_without_saved_skill_does_not_send_skill_suggest_follow_up() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
-        let executor = make_executor_with_agent(agent.clone() as AgentManagerHandle);
+        let executor = make_executor_with_agent(AgentInstance::Mock(agent.clone()));
         let job = sample_job();
 
         let result = executor.execute_inner(&job, "conv_1", None).await;
@@ -1711,7 +1715,7 @@ mod tests {
     #[tokio::test]
     async fn execute_inner_uses_conversation_workspace_when_job_workspace_missing() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
-        let task_manager = Arc::new(RecordingTaskManager::new(agent.clone() as AgentManagerHandle));
+        let task_manager = Arc::new(RecordingTaskManager::new(AgentInstance::Mock(agent.clone())));
         let executor = make_executor_with_task_manager(task_manager.clone());
         let mut job = CronJob {
             execution_mode: ExecutionMode::NewConversation,
@@ -1737,7 +1741,7 @@ mod tests {
     #[tokio::test]
     async fn execute_inner_persists_agent_workspace_when_conversation_workspace_missing() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
-        let task_manager = Arc::new(RecordingTaskManager::new(agent.clone() as AgentManagerHandle));
+        let task_manager = Arc::new(RecordingTaskManager::new(AgentInstance::Mock(agent.clone())));
         let repo = Arc::new(MissingWorkspaceConversationRepo::new("conv_1", serde_json::json!({})));
         let executor = make_executor_with_task_manager_and_repo(task_manager.clone(), repo.clone());
         let mut job = CronJob {
@@ -1771,7 +1775,7 @@ mod tests {
     #[tokio::test]
     async fn execute_inner_inserts_right_side_user_message_for_cron_prompt() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
-        let task_manager = Arc::new(RecordingTaskManager::new(agent.clone() as AgentManagerHandle));
+        let task_manager = Arc::new(RecordingTaskManager::new(AgentInstance::Mock(agent.clone())));
         let repo = Arc::new(MissingWorkspaceConversationRepo::new(
             "conv_1",
             serde_json::json!({ "workspace": "/tmp/existing-conversation-workspace" }),
@@ -1806,7 +1810,7 @@ mod tests {
     #[tokio::test]
     async fn execute_inner_upserts_cron_trigger_artifact_and_broadcasts_event() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
-        let task_manager = Arc::new(RecordingTaskManager::new(agent.clone() as AgentManagerHandle));
+        let task_manager = Arc::new(RecordingTaskManager::new(AgentInstance::Mock(agent.clone())));
         let repo = Arc::new(MissingWorkspaceConversationRepo::new(
             "conv_1",
             serde_json::json!({ "workspace": "/tmp/existing-conversation-workspace" }),
@@ -1852,14 +1856,14 @@ mod tests {
         struct StubTaskManager;
         #[async_trait::async_trait]
         impl IWorkerTaskManager for StubTaskManager {
-            fn get_task(&self, _: &str) -> Option<AgentManagerHandle> {
+            fn get_task(&self, _: &str) -> Option<AgentInstance> {
                 None
             }
             async fn get_or_build_task(
                 &self,
                 _: &str,
                 _: BuildTaskOptions,
-            ) -> Result<AgentManagerHandle, aionui_common::AppError> {
+            ) -> Result<AgentInstance, aionui_common::AppError> {
                 Err(aionui_common::AppError::Internal("stub".into()))
             }
             fn kill(&self, _: &str, _: Option<aionui_common::AgentKillReason>) -> Result<(), aionui_common::AppError> {
@@ -2068,21 +2072,21 @@ mod tests {
     }
 
     #[async_trait::async_trait]
-    impl IAgentManager for RecordingAgent {
+    impl IAgentTask for RecordingAgent {
         fn agent_type(&self) -> AgentType {
             AgentType::Acp
         }
 
-        fn status(&self) -> Option<ConversationStatus> {
-            Some(ConversationStatus::Pending)
+        fn conversation_id(&self) -> &str {
+            &self.conversation_id
         }
 
         fn workspace(&self) -> &str {
             &self.workspace
         }
 
-        fn conversation_id(&self) -> &str {
-            &self.conversation_id
+        fn status(&self) -> Option<ConversationStatus> {
+            Some(ConversationStatus::Pending)
         }
 
         fn last_activity_at(&self) -> TimestampMs {
@@ -2103,28 +2107,13 @@ mod tests {
             Ok(())
         }
 
-        fn confirm(
-            &self,
-            _msg_id: &str,
-            _call_id: &str,
-            _data: serde_json::Value,
-            _always_allow: bool,
-        ) -> Result<(), aionui_common::AppError> {
-            Ok(())
-        }
-
-        fn get_confirmations(&self) -> Vec<Confirmation> {
-            Vec::new()
-        }
-
-        fn check_approval(&self, _action: &str, _command_type: Option<&str>) -> bool {
-            false
-        }
-
         fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), aionui_common::AppError> {
             Ok(())
         }
+    }
 
+    #[async_trait::async_trait]
+    impl IMockAgent for RecordingAgent {
         async fn get_mode(&self) -> Result<AgentModeResponse, aionui_common::AppError> {
             Ok(AgentModeResponse {
                 mode: self.mode().await,
@@ -2138,28 +2127,24 @@ mod tests {
             *guard = mode.to_owned();
             Ok(())
         }
-
-        fn as_any(&self) -> &dyn std::any::Any {
-            self
-        }
     }
 
     struct FixedTaskManager {
-        agent: AgentManagerHandle,
+        agent: AgentInstance,
     }
 
     #[async_trait::async_trait]
     impl IWorkerTaskManager for FixedTaskManager {
-        fn get_task(&self, _conversation_id: &str) -> Option<AgentManagerHandle> {
-            Some(Arc::clone(&self.agent))
+        fn get_task(&self, _conversation_id: &str) -> Option<AgentInstance> {
+            Some(self.agent.clone())
         }
 
         async fn get_or_build_task(
             &self,
             _conversation_id: &str,
             _options: BuildTaskOptions,
-        ) -> Result<AgentManagerHandle, aionui_common::AppError> {
-            Ok(Arc::clone(&self.agent))
+        ) -> Result<AgentInstance, aionui_common::AppError> {
+            Ok(self.agent.clone())
         }
 
         fn kill(
@@ -2182,12 +2167,12 @@ mod tests {
     }
 
     struct RecordingTaskManager {
-        agent: AgentManagerHandle,
+        agent: AgentInstance,
         options: Mutex<Vec<BuildTaskOptions>>,
     }
 
     impl RecordingTaskManager {
-        fn new(agent: AgentManagerHandle) -> Self {
+        fn new(agent: AgentInstance) -> Self {
             Self {
                 agent,
                 options: Mutex::new(Vec::new()),
@@ -2205,17 +2190,17 @@ mod tests {
 
     #[async_trait::async_trait]
     impl IWorkerTaskManager for RecordingTaskManager {
-        fn get_task(&self, _conversation_id: &str) -> Option<AgentManagerHandle> {
-            Some(Arc::clone(&self.agent))
+        fn get_task(&self, _conversation_id: &str) -> Option<AgentInstance> {
+            Some(self.agent.clone())
         }
 
         async fn get_or_build_task(
             &self,
             _conversation_id: &str,
             options: BuildTaskOptions,
-        ) -> Result<AgentManagerHandle, aionui_common::AppError> {
+        ) -> Result<AgentInstance, aionui_common::AppError> {
             self.options.lock().unwrap().push(options);
-            Ok(Arc::clone(&self.agent))
+            Ok(self.agent.clone())
         }
 
         fn kill(
@@ -2560,7 +2545,7 @@ mod tests {
         }
     }
 
-    fn make_executor_with_agent(agent: AgentManagerHandle) -> JobExecutor {
+    fn make_executor_with_agent(agent: AgentInstance) -> JobExecutor {
         make_executor_with_task_manager(Arc::new(FixedTaskManager { agent }))
     }
 

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use aionui_ai_agent::AgentRegistry;
-use aionui_ai_agent::agent_manager::AgentManagerHandle;
+use aionui_ai_agent::agent_task::AgentInstance;
 use aionui_ai_agent::types::BuildTaskOptions;
 use aionui_api_types::{
     CreateCronJobRequest, CronScheduleDto, ListCronJobsQuery, SaveCronSkillRequest, UpdateCronJobRequest,
@@ -64,14 +64,10 @@ struct StubTaskManager;
 
 #[async_trait::async_trait]
 impl aionui_ai_agent::task_manager::IWorkerTaskManager for StubTaskManager {
-    fn get_task(&self, _: &str) -> Option<AgentManagerHandle> {
+    fn get_task(&self, _: &str) -> Option<AgentInstance> {
         None
     }
-    async fn get_or_build_task(
-        &self,
-        _: &str,
-        _: BuildTaskOptions,
-    ) -> Result<AgentManagerHandle, aionui_common::AppError> {
+    async fn get_or_build_task(&self, _: &str, _: BuildTaskOptions) -> Result<AgentInstance, aionui_common::AppError> {
         Err(aionui_common::AppError::Internal("stub".into()))
     }
     fn kill(&self, _: &str, _: Option<aionui_common::AgentKillReason>) -> Result<(), aionui_common::AppError> {

--- a/crates/aionui-team/Cargo.toml
+++ b/crates/aionui-team/Cargo.toml
@@ -27,3 +27,6 @@ sqlx.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 futures-util.workspace = true
 reqwest.workspace = true
+# Enable the `AgentInstance::Mock` variant so tests can build fake agents
+# through the trait-object escape hatch without spawning real CLI processes.
+aionui-ai-agent = { workspace = true, features = ["test-support"] }

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -882,12 +882,12 @@ mod tests {
     use super::*;
     use crate::test_utils::MockTeamRepo;
     use crate::types::{Team, TeamAgent, TeammateRole};
-    use aionui_ai_agent::agent_manager::{AgentManagerHandle, IAgentManager, approval_key};
+    use aionui_ai_agent::agent_manager::approval_key;
+    use aionui_ai_agent::agent_task::{AgentInstance, IAgentTask, IMockAgent};
     use aionui_ai_agent::stream_event::AgentStreamEvent;
     use aionui_ai_agent::types::BuildTaskOptions;
     use aionui_api_types::{AgentModeResponse, WebSocketMessage};
     use aionui_common::{AgentKillReason, AgentType, AppError, Confirmation, ConversationStatus, TimestampMs, now_ms};
-    use std::any::Any;
     use std::sync::{Arc, Mutex};
     use tokio::sync::broadcast;
 
@@ -945,18 +945,18 @@ mod tests {
     }
 
     #[async_trait::async_trait]
-    impl IAgentManager for RecordingAgent {
+    impl IAgentTask for RecordingAgent {
         fn agent_type(&self) -> AgentType {
             AgentType::Acp
         }
-        fn status(&self) -> Option<ConversationStatus> {
-            None
+        fn conversation_id(&self) -> &str {
+            &self.conversation_id
         }
         fn workspace(&self) -> &str {
             "/tmp/ws"
         }
-        fn conversation_id(&self) -> &str {
-            &self.conversation_id
+        fn status(&self) -> Option<ConversationStatus> {
+            None
         }
         fn last_activity_at(&self) -> TimestampMs {
             now_ms()
@@ -974,15 +974,13 @@ mod tests {
         async fn stop(&self) -> Result<(), AppError> {
             Ok(())
         }
-        fn confirm(
-            &self,
-            _msg_id: &str,
-            _call_id: &str,
-            _data: serde_json::Value,
-            _always_allow: bool,
-        ) -> Result<(), AppError> {
+        fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
             Ok(())
         }
+    }
+
+    #[async_trait::async_trait]
+    impl IMockAgent for RecordingAgent {
         fn get_confirmations(&self) -> Vec<Confirmation> {
             Vec::new()
         }
@@ -990,17 +988,11 @@ mod tests {
             let _ = approval_key(Some(action), command_type);
             false
         }
-        fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
-            Ok(())
-        }
         async fn get_mode(&self) -> Result<AgentModeResponse, AppError> {
             Ok(AgentModeResponse {
                 mode: "default".into(),
                 initialized: false,
             })
-        }
-        fn as_any(&self) -> &dyn Any {
-            self
         }
     }
 
@@ -1008,7 +1000,7 @@ mod tests {
     /// exercised by D7b; the other methods are unreachable in these tests
     /// and panic to surface drift early.
     struct StubTaskManager {
-        tasks: Mutex<std::collections::HashMap<String, AgentManagerHandle>>,
+        tasks: Mutex<std::collections::HashMap<String, AgentInstance>>,
         kill_calls: Mutex<Vec<(String, Option<AgentKillReason>)>>,
         kill_error: Option<String>,
     }
@@ -1032,7 +1024,7 @@ mod tests {
             }
         }
 
-        fn insert(&self, conv_id: &str, handle: AgentManagerHandle) {
+        fn insert(&self, conv_id: &str, handle: AgentInstance) {
             self.tasks.lock().unwrap().insert(conv_id.into(), handle);
         }
 
@@ -1043,14 +1035,14 @@ mod tests {
 
     #[async_trait::async_trait]
     impl IWorkerTaskManager for StubTaskManager {
-        fn get_task(&self, conversation_id: &str) -> Option<AgentManagerHandle> {
+        fn get_task(&self, conversation_id: &str) -> Option<AgentInstance> {
             self.tasks.lock().unwrap().get(conversation_id).cloned()
         }
         async fn get_or_build_task(
             &self,
             _conversation_id: &str,
             _options: BuildTaskOptions,
-        ) -> Result<AgentManagerHandle, AppError> {
+        ) -> Result<AgentInstance, AppError> {
             panic!("get_or_build_task should not be called in D7b tests")
         }
         fn kill(&self, conversation_id: &str, reason: Option<AgentKillReason>) -> Result<(), AppError> {
@@ -1083,7 +1075,7 @@ mod tests {
         let sent: Arc<Mutex<Vec<SendMessageData>>> = Arc::new(Mutex::new(Vec::new()));
         let stub = StubTaskManager::new();
         for conv_id in conv_ids {
-            let agent: AgentManagerHandle = Arc::new(RecordingAgent::new(conv_id, sent.clone(), fail_with.clone()));
+            let agent = AgentInstance::Mock(Arc::new(RecordingAgent::new(conv_id, sent.clone(), fail_with.clone())));
             stub.insert(conv_id, agent);
         }
         (Arc::new(stub), sent)

--- a/crates/aionui-team/tests/e2e_team_flow.rs
+++ b/crates/aionui-team/tests/e2e_team_flow.rs
@@ -7,7 +7,7 @@
 //! - Real in-memory mock repo (same pattern as existing tests)
 //! - Real TCP MCP server (TeamMcpServer)
 //! - Real TeamSession with real Mailbox + TaskBoard
-//! - RecordingAgent: captures send_message calls (mock IAgentManager)
+//! - RecordingAgent: captures send_message calls (mock `IAgentTask` / `IMockAgent`)
 //! - StubTaskManager: pre-populated with RecordingAgent instances
 //!
 //! Scenarios that cannot yet be wired without a live TeamSessionService DB path

--- a/crates/aionui-team/tests/e2e_team_flow.rs
+++ b/crates/aionui-team/tests/e2e_team_flow.rs
@@ -19,9 +19,11 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, Weak};
 
-use aionui_ai_agent::agent_manager::{AgentManagerHandle, IAgentManager, approval_key};
+use aionui_ai_agent::agent_manager::approval_key;
+use aionui_ai_agent::agent_task::{AgentInstance, IAgentTask, IMockAgent};
 use aionui_ai_agent::stream_event::{AgentStreamEvent, FinishEventData};
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
+use aionui_api_types::AgentModeResponse;
 use aionui_api_types::WebSocketMessage;
 use aionui_common::{AgentKillReason, AgentType, AppError, Confirmation, ConversationStatus, TimestampMs, now_ms};
 use aionui_db::ITeamRepository;
@@ -124,18 +126,18 @@ impl RecordingAgent {
 }
 
 #[async_trait::async_trait]
-impl IAgentManager for RecordingAgent {
+impl IAgentTask for RecordingAgent {
     fn agent_type(&self) -> AgentType {
         AgentType::Acp
     }
-    fn status(&self) -> Option<ConversationStatus> {
-        None
+    fn conversation_id(&self) -> &str {
+        &self.conversation_id
     }
     fn workspace(&self) -> &str {
         "/tmp/ws"
     }
-    fn conversation_id(&self) -> &str {
-        &self.conversation_id
+    fn status(&self) -> Option<ConversationStatus> {
+        None
     }
     fn last_activity_at(&self) -> TimestampMs {
         now_ms()
@@ -153,9 +155,13 @@ impl IAgentManager for RecordingAgent {
     async fn stop(&self) -> Result<(), AppError> {
         Ok(())
     }
-    fn confirm(&self, _: &str, _: &str, _: Value, _: bool) -> Result<(), AppError> {
+    fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
         Ok(())
     }
+}
+
+#[async_trait::async_trait]
+impl IMockAgent for RecordingAgent {
     fn get_confirmations(&self) -> Vec<Confirmation> {
         Vec::new()
     }
@@ -163,24 +169,21 @@ impl IAgentManager for RecordingAgent {
         let _ = approval_key(Some(action), command_type);
         false
     }
-    fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
+    fn confirm(&self, _: &str, _: &str, _: Value, _: bool) -> Result<(), AppError> {
         Ok(())
     }
-    async fn get_mode(&self) -> Result<aionui_api_types::AgentModeResponse, AppError> {
-        Ok(aionui_api_types::AgentModeResponse {
+    async fn get_mode(&self) -> Result<AgentModeResponse, AppError> {
+        Ok(AgentModeResponse {
             mode: "default".to_owned(),
             initialized: false,
         })
-    }
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 
 /// StubTaskManager: allows pre-inserting RecordingAgent handles by conv_id.
 /// Also records kill calls.
 struct StubTaskManager {
-    tasks: Mutex<HashMap<String, AgentManagerHandle>>,
+    tasks: Mutex<HashMap<String, AgentInstance>>,
     kill_calls: Mutex<Vec<(String, Option<AgentKillReason>)>>,
 }
 
@@ -192,7 +195,7 @@ impl StubTaskManager {
         }
     }
 
-    fn insert(&self, conv_id: &str, handle: AgentManagerHandle) {
+    fn insert(&self, conv_id: &str, handle: AgentInstance) {
         self.tasks.lock().unwrap().insert(conv_id.to_owned(), handle);
     }
 
@@ -204,11 +207,11 @@ impl StubTaskManager {
 
 #[async_trait]
 impl aionui_ai_agent::IWorkerTaskManager for StubTaskManager {
-    fn get_task(&self, conversation_id: &str) -> Option<AgentManagerHandle> {
+    fn get_task(&self, conversation_id: &str) -> Option<AgentInstance> {
         self.tasks.lock().unwrap().get(conversation_id).cloned()
     }
 
-    async fn get_or_build_task(&self, _: &str, _: BuildTaskOptions) -> Result<AgentManagerHandle, AppError> {
+    async fn get_or_build_task(&self, _: &str, _: BuildTaskOptions) -> Result<AgentInstance, AppError> {
         Err(AppError::Internal(
             "StubTaskManager does not support get_or_build_task".into(),
         ))
@@ -363,7 +366,7 @@ async fn setup_session() -> (
     let task_manager = Arc::new(StubTaskManager::new());
 
     for agent in two_agents() {
-        let handle: AgentManagerHandle = Arc::new(RecordingAgent::new(&agent.conversation_id, sent.clone()));
+        let handle = AgentInstance::Mock(Arc::new(RecordingAgent::new(&agent.conversation_id, sent.clone())));
         task_manager.insert(&agent.conversation_id, handle);
     }
 
@@ -738,7 +741,7 @@ async fn s4_dynamic_agent_added_then_finish_propagates() {
     };
 
     // Insert a recording agent for the new conversation
-    let handle: AgentManagerHandle = Arc::new(RecordingAgent::new("conv-helper", sent.clone()));
+    let handle = AgentInstance::Mock(Arc::new(RecordingAgent::new("conv-helper", sent.clone())));
     task_manager.insert("conv-helper", handle);
 
     // Add the agent to the session's scheduler

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -455,14 +455,14 @@ impl CountingTaskManager {
 
 #[async_trait::async_trait]
 impl IWorkerTaskManager for CountingTaskManager {
-    fn get_task(&self, conversation_id: &str) -> Option<aionui_ai_agent::AgentManagerHandle> {
+    fn get_task(&self, conversation_id: &str) -> Option<aionui_ai_agent::AgentInstance> {
         self.inner.get_task(conversation_id)
     }
     async fn get_or_build_task(
         &self,
         conversation_id: &str,
         options: BuildTaskOptions,
-    ) -> Result<aionui_ai_agent::AgentManagerHandle, AppError> {
+    ) -> Result<aionui_ai_agent::AgentInstance, AppError> {
         self.calls.lock().unwrap().build.push(conversation_id.to_owned());
         self.inner.get_or_build_task(conversation_id, options).await
     }
@@ -489,10 +489,10 @@ impl IWorkerTaskManager for CountingTaskManager {
 // asks the task manager to kill + rebuild; the returned handle never has
 // `send_message` called on it.
 mod mock_agent {
-    use aionui_ai_agent::agent_manager::IAgentManager;
+    use aionui_ai_agent::agent_task::{IAgentTask, IMockAgent};
     use aionui_ai_agent::stream_event::AgentStreamEvent;
     use aionui_ai_agent::types::SendMessageData;
-    use aionui_common::{AgentKillReason, AgentType, AppError, Confirmation, ConversationStatus, TimestampMs};
+    use aionui_common::{AgentKillReason, AgentType, AppError, ConversationStatus, TimestampMs};
     use tokio::sync::broadcast;
 
     pub struct MockAgent {
@@ -513,18 +513,18 @@ mod mock_agent {
     }
 
     #[async_trait::async_trait]
-    impl IAgentManager for MockAgent {
+    impl IAgentTask for MockAgent {
         fn agent_type(&self) -> AgentType {
             AgentType::Acp
         }
-        fn status(&self) -> Option<ConversationStatus> {
-            None
+        fn conversation_id(&self) -> &str {
+            &self.conversation_id
         }
         fn workspace(&self) -> &str {
             &self.workspace
         }
-        fn conversation_id(&self) -> &str {
-            &self.conversation_id
+        fn status(&self) -> Option<ConversationStatus> {
+            None
         }
         fn last_activity_at(&self) -> TimestampMs {
             0
@@ -538,38 +538,21 @@ mod mock_agent {
         async fn stop(&self) -> Result<(), AppError> {
             Ok(())
         }
-        fn confirm(
-            &self,
-            _msg_id: &str,
-            _call_id: &str,
-            _data: serde_json::Value,
-            _always_allow: bool,
-        ) -> Result<(), AppError> {
-            Ok(())
-        }
-        fn get_confirmations(&self) -> Vec<Confirmation> {
-            vec![]
-        }
-        fn check_approval(&self, _action: &str, _command_type: Option<&str>) -> bool {
-            false
-        }
         fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
             Ok(())
         }
-        fn as_any(&self) -> &dyn std::any::Any {
-            self
-        }
     }
+
+    impl IMockAgent for MockAgent {}
 }
 
 fn success_factory() -> AgentFactory {
     use futures_util::FutureExt;
     Arc::new(|opts: BuildTaskOptions| {
         async move {
-            Ok(
-                Arc::new(mock_agent::MockAgent::new(opts.conversation_id, opts.workspace))
-                    as aionui_ai_agent::AgentManagerHandle,
-            )
+            Ok(aionui_ai_agent::AgentInstance::Mock(Arc::new(
+                mock_agent::MockAgent::new(opts.conversation_id, opts.workspace),
+            )))
         }
         .boxed()
     })
@@ -1469,10 +1452,9 @@ async fn d9_ensure_session_persists_team_mcp_stdio_config() {
                 "factory called without team_mcp_stdio_config in extra: {:?}",
                 opts.extra
             );
-            Ok(
-                Arc::new(mock_agent::MockAgent::new(opts.conversation_id, opts.workspace))
-                    as aionui_ai_agent::AgentManagerHandle,
-            )
+            Ok(aionui_ai_agent::AgentInstance::Mock(Arc::new(
+                mock_agent::MockAgent::new(opts.conversation_id, opts.workspace),
+            )))
         }
         .boxed()
     }));


### PR DESCRIPTION
## Summary

Replaces the fat `IAgentManager` trait + `Arc<dyn IAgentManager>` +
`as_any`/`downcast_ref` scheme with a much slimmer design:

- A 10-method `IAgentTask` trait that captures **only** the operations every
  agent type implements identically (`agent_type`, `conversation_id`,
  `workspace`, `status`, `last_activity_at`, `subscribe`,
  `subscribe_stream`, `send_message`, `stop`, `kill`).
- An `AgentInstance` enum with one variant per concrete manager
  (`Acp` / `Aionrs` / `OpenClaw` / `Nanobot` / `Remote`) plus a test-only
  `Mock` variant gated on `cfg(any(test, feature = "test-support"))`.
  `AgentInstance` is `Clone` (cheap — each variant is `Arc<Concrete>`),
  implements the common surface through `as_task()`, and carries
  cross-variant helpers that `match` on the variant to route
  `confirm` / `get_confirmations` / `check_approval` / `get_session_key`
  / `get_mode` / `set_mode` to the right inherent method (or a `BadRequest`
  for unsupported variants).
- All five concrete managers now implement only `IAgentTask`; type-specific
  methods (the six listed above) became **inherent** methods that
  `AgentInstance::<Variant>(m)` matches dispatch to — no trait default
  impls that lie for at least one agent type.
- `WorkerTaskManager`, `AgentFactory`, `auxiliary_routes`, the conversation
  service, cron executor, and team session all hold / return `AgentInstance`
  instead of `Arc<dyn IAgentManager>`; the old `AgentManagerHandle` type
  alias is gone.
- Adding a new agent type now forces every `match` in the codebase to
  light up — which is the compile-time pressure the previous trait-based
  design lacked.

## Sub-commits

| SHA | Title |
|-----|-------|
| `18e996e` | PR #8a introduce IAgentTask trait + AgentInstance enum |
| `46ed2e3` | PR #8b migrate WorkerTaskManager/factory/routes to AgentInstance |
| `9382b0c` | PR #8c remove IAgentManager handle alias and as_any |

**8a** adds `IAgentTask` + `AgentInstance` alongside the existing
`IAgentManager`; each concrete manager gets an `IAgentTask` impl that
forwards to the legacy trait. `IAgentTask` is intentionally **not**
re-exported from `lib.rs` yet so glob-importing consumers keep compiling
unambiguously.

**8b** flips the generic lifecycle layer (task_manager, factory,
auxiliary_routes, conversation service, cron executor, team session) from
`Arc<dyn IAgentManager>` to `AgentInstance`. Route handlers that used to
`as_any().downcast_ref::<XxxAgentManager>()` now pattern-match on the
variant and return `400 BadRequest` (not `500 Internal`) when a route is
hit for the wrong agent type. Test mocks are migrated to a new
`IMockAgent: IAgentTask` trait behind an `AgentInstance::Mock(Arc<dyn
IMockAgent>)` variant, gated on `cfg(any(test, feature = "test-support"))`.

**8c** deletes the legacy surface: the `IAgentManager` trait, the
`AgentManagerHandle` alias, and every `as_any` method. `agent_manager.rs`
shrinks to its single remaining public item — the `approval_key` helper.
The six previously-trait-level type-specific methods move to inherent
`impl XxxAgentManager` blocks so enum-match callsites read
`m.get_mode()` with no trait import, and the `AgentInstance` helpers
dispatch to those inherent methods.

## Verification

```
$ cargo fmt --all -- --check
(clean)

$ cargo clippy -p aionui-ai-agent -p aionui-conversation -p aionui-cron -p aionui-team \
    --features aionui-ai-agent/test-support -- -D warnings
Finished (no warnings)

$ cargo test -p aionui-ai-agent --features test-support
  test result: ok. 294 passed; 0 failed
  test result: ok. 1 passed; 0 failed; 11 ignored    # acp_agent_integration (pre-existing ignore)
  test result: ok. 8 passed; 0 failed
  test result: ok. 3 passed; 0 failed
  test result: ok. 12 passed; 0 failed

$ cargo test -p aionui-conversation -p aionui-cron -p aionui-team
  all pass except 2 pre-existing `aionui-team::mcp_server_integration`
  failures (`ts3_send_message_to_nonexistent_agent`,
  `ts_shutdown_rejected_intercepted`). Confirmed via
  `git stash && cargo test` on 8a-baseline that both also fail there —
  not introduced by PR #8.
```

Zero-match verification (per migration plan §8):

```
$ rg "as_any\b|downcast_ref" crates/aionui-ai-agent/src
crates/aionui-ai-agent/src/agent_task.rs://! Replaces the old bloated `IAgentManager` trait + `as_any()` downcast
crates/aionui-ai-agent/src/agent_task.rs:/// single `match` — no `as_any` / `downcast_ref` anywhere. Adding a new
crates/aionui-ai-agent/src/agent_manager.rs://! `Arc<dyn IAgentManager>` handle alias, and the `as_any` downcast hook.
# 3 doc-comment references only — zero code matches.

$ rg "AgentManagerHandle" crates/ -g '!target/*' -g '!docs/*' -g '!*.md'
(no output — zero matches)

$ rg "dyn IAgentManager" crates/ -g '!target/*' -g '!docs/*'
crates/aionui-ai-agent/src/agent_manager.rs://! `Arc<dyn IAgentManager>` handle alias, and the `as_any` downcast hook.
# 1 doc-comment reference only — zero code matches.
```

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy` on affected crates clean
- [x] `cargo test -p aionui-ai-agent --features test-support` green
- [x] `cargo test -p aionui-conversation` green
- [x] `cargo test -p aionui-cron` green
- [x] `cargo test -p aionui-team` — only 2 pre-existing `mcp_server_integration` failures
- [x] rg validation commands: zero code matches for `as_any`/`downcast_ref`/`AgentManagerHandle`/`dyn IAgentManager`

## Notes on scope

- Depends on PR #7b-6 (#154, already merged).
- Next planned PRs (#9 auxiliary_routes split, #11 ...) depend on this one.
- HTTP API, DB schema, and WebSocket event names are unchanged. The
  route behaviour difference is the `500 → 400` upgrade on ACP- /
  OpenClaw-only endpoints hit with the wrong agent type.
- Pre-existing `aionui-team::mcp_server_integration` failures
  (`ts3_send_message_to_nonexistent_agent`, `ts_shutdown_rejected_intercepted`)
  are **not** caused by this PR and will be fixed separately.