### PR TITLE
fix(channel/dingtalk): fix WebSocket Stream protocol and AI Card streaming

### DIFF
--- a/crates/aionui-channel/src/plugins/dingtalk/api.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/api.rs
@@ -176,18 +176,18 @@ impl DingtalkApi {
             .map_err(|e| ChannelError::ConnectionFailed(format!("DingTalk stream registration failed: {e}")))?;
 
         let status = raw_resp.status();
-        let body_text = raw_resp
-            .text()
-            .await
-            .map_err(|e| ChannelError::ConnectionFailed(format!("DingTalk stream registration read body failed: {e}")))?;
+        let body_text = raw_resp.text().await.map_err(|e| {
+            ChannelError::ConnectionFailed(format!("DingTalk stream registration read body failed: {e}"))
+        })?;
 
         debug!(status = %status, body_len = body_text.len(), "DingTalk stream registration response received");
 
-        let resp: RegisterStreamResponse = serde_json::from_str(&body_text)
-            .map_err(|e| ChannelError::ConnectionFailed(format!(
+        let resp: RegisterStreamResponse = serde_json::from_str(&body_text).map_err(|e| {
+            ChannelError::ConnectionFailed(format!(
                 "DingTalk stream registration parse failed: {e}, body: {}",
                 &body_text[..body_text.len().min(200)]
-            )))?;
+            ))
+        })?;
 
         Ok(resp)
     }

--- a/crates/aionui-channel/src/plugins/dingtalk/api.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/api.rs
@@ -294,7 +294,12 @@ impl DingtalkApi {
         request: &SendRobotMessageRequest,
     ) -> Result<SendRobotMessageResponse, ChannelError> {
         let token = self.get_token().await?;
-        let url = format!("{DINGTALK_API_BASE}/v1.0/robot/oToMessages/batchSend");
+
+        let url = if request.open_conversation_id.is_some() {
+            format!("{DINGTALK_API_BASE}/v1.0/robot/groupMessages/send")
+        } else {
+            format!("{DINGTALK_API_BASE}/v1.0/robot/oToMessages/batchSend")
+        };
 
         let resp: SendRobotMessageResponse = self
             .client

--- a/crates/aionui-channel/src/plugins/dingtalk/api.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/api.rs
@@ -139,12 +139,21 @@ impl DingtalkApi {
     }
 
     /// Register for WebSocket Stream and get the connection endpoint.
+    ///
+    /// Note: This endpoint uses clientId/clientSecret in the request body,
+    /// NOT the access token header. The Accept header is required to get
+    /// JSON instead of XML.
     pub async fn register_stream(&self) -> Result<RegisterStreamResponse, ChannelError> {
         let url = format!("{DINGTALK_API_BASE}/v1.0/gateway/connections/open");
-        let token = self.get_token().await?;
 
         let body = RegisterStreamRequest {
+            client_id: self.client_id.clone(),
+            client_secret: self.client_secret.clone(),
             subscriptions: vec![
+                StreamSubscription {
+                    sub_type: "EVENT".into(),
+                    topic: "*".into(),
+                },
                 StreamSubscription {
                     sub_type: "CALLBACK".into(),
                     topic: "/v1.0/im/bot/messages/get".into(),
@@ -154,19 +163,31 @@ impl DingtalkApi {
                     topic: "/v1.0/card/instances/callback".into(),
                 },
             ],
+            ua: Some("aionui-backend".into()),
         };
 
-        let resp: RegisterStreamResponse = self
+        let raw_resp = self
             .client
             .post(&url)
-            .header("x-acs-dingtalk-access-token", &token)
+            .header("Accept", "application/json")
             .json(&body)
             .send()
             .await
-            .map_err(|e| ChannelError::ConnectionFailed(format!("DingTalk stream registration failed: {e}")))?
-            .json()
+            .map_err(|e| ChannelError::ConnectionFailed(format!("DingTalk stream registration failed: {e}")))?;
+
+        let status = raw_resp.status();
+        let body_text = raw_resp
+            .text()
             .await
-            .map_err(|e| ChannelError::ConnectionFailed(format!("DingTalk stream registration parse failed: {e}")))?;
+            .map_err(|e| ChannelError::ConnectionFailed(format!("DingTalk stream registration read body failed: {e}")))?;
+
+        debug!(status = %status, body_len = body_text.len(), "DingTalk stream registration response received");
+
+        let resp: RegisterStreamResponse = serde_json::from_str(&body_text)
+            .map_err(|e| ChannelError::ConnectionFailed(format!(
+                "DingTalk stream registration parse failed: {e}, body: {}",
+                &body_text[..body_text.len().min(200)]
+            )))?;
 
         Ok(resp)
     }

--- a/crates/aionui-channel/src/plugins/dingtalk/plugin.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/plugin.rs
@@ -1078,11 +1078,7 @@ mod tests {
             "data": "{}"
         });
 
-        let result = handle_stream_frame(
-            &ping_frame.to_string(),
-            &msg_tx,
-            &confirm_tx,
-        ).await;
+        let result = handle_stream_frame(&ping_frame.to_string(), &msg_tx, &confirm_tx).await;
 
         assert!(result.is_some(), "SYSTEM ping should return an ack");
         let ack = result.unwrap();
@@ -1101,11 +1097,7 @@ mod tests {
             "data": "{\"code\":200,\"message\":\"OK\"}"
         });
 
-        let result = handle_stream_frame(
-            &connected_frame.to_string(),
-            &msg_tx,
-            &confirm_tx,
-        ).await;
+        let result = handle_stream_frame(&connected_frame.to_string(), &msg_tx, &confirm_tx).await;
 
         assert!(result.is_none(), "Non-ping SYSTEM frames should not return ack");
     }
@@ -1135,11 +1127,7 @@ mod tests {
             }).to_string()
         });
 
-        let result = handle_stream_frame(
-            &callback_frame.to_string(),
-            &msg_tx,
-            &confirm_tx,
-        ).await;
+        let result = handle_stream_frame(&callback_frame.to_string(), &msg_tx, &confirm_tx).await;
 
         assert!(result.is_some());
         let ack = result.unwrap();
@@ -1173,11 +1161,7 @@ mod tests {
             }).to_string()
         });
 
-        let result = handle_stream_frame(
-            &card_frame.to_string(),
-            &msg_tx,
-            &confirm_tx,
-        ).await;
+        let result = handle_stream_frame(&card_frame.to_string(), &msg_tx, &confirm_tx).await;
 
         assert!(result.is_some());
 

--- a/crates/aionui-channel/src/plugins/dingtalk/plugin.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/plugin.rs
@@ -1110,6 +1110,82 @@ mod tests {
         assert!(result.is_none(), "Non-ping SYSTEM frames should not return ack");
     }
 
+    // -- handle_stream_frame: CALLBACK flow ---------------------------------
+
+    #[tokio::test]
+    async fn handle_stream_frame_callback_emits_message() {
+        let (msg_tx, mut msg_rx) = tokio::sync::mpsc::channel(16);
+        let (confirm_tx, _confirm_rx) = tokio::sync::mpsc::channel(16);
+
+        let callback_frame = serde_json::json!({
+            "type": "CALLBACK",
+            "headers": {
+                "contentType": "application/json",
+                "messageId": "cb_msg_001",
+                "topic": "/v1.0/im/bot/messages/get"
+            },
+            "data": serde_json::json!({
+                "msgId": "dt_msg_123",
+                "msgtype": "text",
+                "text": { "content": "hello bot" },
+                "senderStaffId": "staff_abc",
+                "senderNick": "Alice",
+                "conversationType": "1",
+                "createAt": 1700000000000_i64
+            }).to_string()
+        });
+
+        let result = handle_stream_frame(
+            &callback_frame.to_string(),
+            &msg_tx,
+            &confirm_tx,
+        ).await;
+
+        assert!(result.is_some());
+        let ack = result.unwrap();
+        assert_eq!(ack.code, 200);
+        assert_eq!(ack.headers.message_id, "cb_msg_001");
+
+        let msg = msg_rx.try_recv().unwrap();
+        assert_eq!(msg.id, "dt_msg_123");
+        assert_eq!(msg.chat_id, "user:staff_abc");
+        assert_eq!(msg.content.text, "hello bot");
+        assert_eq!(msg.user.display_name, "Alice");
+        assert_eq!(msg.platform, PluginType::Dingtalk);
+    }
+
+    #[tokio::test]
+    async fn handle_stream_frame_card_action_emits_confirm() {
+        let (msg_tx, _msg_rx) = tokio::sync::mpsc::channel(16);
+        let (confirm_tx, mut confirm_rx) = tokio::sync::mpsc::channel(16);
+
+        let card_frame = serde_json::json!({
+            "type": "CALLBACK",
+            "headers": {
+                "contentType": "application/json",
+                "messageId": "cb_card_001",
+                "topic": "/v1.0/card/instances/callback"
+            },
+            "data": serde_json::json!({
+                "userId": "user_xyz",
+                "openConversationId": "",
+                "content": r#"{"action":"chat:system.confirm:callId=call_123,value=yes"}"#
+            }).to_string()
+        });
+
+        let result = handle_stream_frame(
+            &card_frame.to_string(),
+            &msg_tx,
+            &confirm_tx,
+        ).await;
+
+        assert!(result.is_some());
+
+        let (call_id, value) = confirm_rx.try_recv().unwrap();
+        assert_eq!(call_id, "call_123");
+        assert_eq!(value, "yes");
+    }
+
     // -- DingtalkPlugin constructor -----------------------------------------
 
     #[test]

--- a/crates/aionui-channel/src/plugins/dingtalk/plugin.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/plugin.rs
@@ -29,7 +29,7 @@ const MAX_RECONNECT_ATTEMPTS: u32 = 10;
 const MAX_RECONNECT_DELAY: Duration = Duration::from_secs(30);
 
 /// DingTalk standard AI card template ID.
-const AI_CARD_TEMPLATE_ID: &str = "StandardCard";
+const AI_CARD_TEMPLATE_ID: &str = "382e4302-551d-4880-bf29-a30acfab2e71.schema";
 
 /// DingTalk platform plugin.
 ///
@@ -322,8 +322,8 @@ async fn send_via_open_api(api: &Arc<DingtalkApi>, chat_id: &str, text: &str) ->
     let (is_group, raw_id) = decode_chat_id(chat_id);
 
     let req = SendRobotMessageRequest {
-        msg_key: "sampleText".into(),
-        msg_param: serde_json::json!({ "content": text }).to_string(),
+        msg_key: "sampleMarkdown".into(),
+        msg_param: serde_json::json!({ "title": "Message", "text": text }).to_string(),
         robot_code: api.client_id().to_string(),
         open_conversation_id: if is_group { Some(raw_id.to_string()) } else { None },
         user_ids: if !is_group {
@@ -611,7 +611,11 @@ async fn handle_bot_message(data_str: &str, message_tx: &mpsc::Sender<UnifiedInc
         .or(cb.sender_id.as_deref())
         .unwrap_or("unknown");
 
-    let chat_id = encode_chat_id(cb.conversation_id.as_deref(), sender_staff_id);
+    let chat_id = encode_chat_id(
+        cb.conversation_type.as_deref(),
+        cb.conversation_id.as_deref(),
+        sender_staff_id,
+    );
 
     let user = UnifiedUser {
         id: sender_staff_id.to_string(),

--- a/crates/aionui-channel/src/plugins/dingtalk/plugin.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/plugin.rs
@@ -391,6 +391,7 @@ async fn ws_stream_loop(
         let stream_info = match api.register_stream().await {
             Ok(info) => {
                 consecutive_errors = 0;
+                info!(endpoint = %info.endpoint, "DingTalk stream registered successfully");
                 info
             }
             Err(e) => {
@@ -410,7 +411,7 @@ async fn ws_stream_loop(
 
         let ws_url = format!("{}?ticket={}", stream_info.endpoint, stream_info.ticket);
 
-        debug!(url = %ws_url, "Connecting to DingTalk WebSocket Stream");
+        info!(url = %ws_url, "Connecting to DingTalk WebSocket Stream");
 
         match connect_and_listen(&ws_url, &message_tx, &confirm_tx, &mut shutdown_rx).await {
             Ok(()) => {
@@ -592,10 +593,17 @@ async fn handle_bot_message(data_str: &str, message_tx: &mpsc::Sender<UnifiedInc
     let cb: BotMessageCallback = match serde_json::from_str(data_str) {
         Ok(c) => c,
         Err(e) => {
-            warn!(error = %e, "Failed to parse DingTalk bot message");
+            warn!(error = %e, raw = %&data_str[..data_str.len().min(200)], "Failed to parse DingTalk bot message");
             return;
         }
     };
+
+    debug!(
+        msg_id = cb.msg_id.as_deref().unwrap_or(""),
+        sender = cb.sender_nick.as_deref().unwrap_or(""),
+        msgtype = cb.msgtype.as_deref().unwrap_or(""),
+        "DingTalk bot message received"
+    );
 
     let sender_staff_id = cb
         .sender_staff_id
@@ -648,6 +656,11 @@ async fn handle_card_action(
             return;
         }
     };
+
+    debug!(
+        user_id = cb.user_id.as_deref().unwrap_or(""),
+        "DingTalk card action received"
+    );
 
     // Extract action string from content field
     let action_str = cb

--- a/crates/aionui-channel/src/plugins/dingtalk/plugin.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/plugin.rs
@@ -524,16 +524,34 @@ async fn handle_stream_frame(
 
     match frame.frame_type.as_str() {
         "SYSTEM" => {
-            if let Some(ref data_str) = frame.data
-                && let Ok(sys) = serde_json::from_str::<SystemEvent>(data_str)
-            {
-                debug!(
-                    code = sys.code,
-                    message = sys.message.as_deref().unwrap_or(""),
-                    "DingTalk system event"
-                );
+            let topic = frame.headers.topic.as_deref().unwrap_or("");
+            match topic {
+                "ping" => {
+                    debug!("DingTalk system ping received, sending pong");
+                    Some(StreamAck {
+                        code: 200,
+                        headers: super::types::AckHeaders {
+                            content_type: "application/json".into(),
+                            message_id: message_id.clone(),
+                        },
+                        message: "OK".into(),
+                        data: frame.data.unwrap_or_else(|| "{}".into()),
+                    })
+                }
+                _ => {
+                    if let Some(ref data_str) = frame.data
+                        && let Ok(sys) = serde_json::from_str::<SystemEvent>(data_str)
+                    {
+                        debug!(
+                            code = sys.code,
+                            message = sys.message.as_deref().unwrap_or(""),
+                            topic,
+                            "DingTalk system event"
+                        );
+                    }
+                    None
+                }
             }
-            None
         }
         "CALLBACK" => {
             let topic = frame.headers.topic.as_deref().unwrap_or("");
@@ -750,7 +768,7 @@ fn build_ack(message_id: &str) -> StreamAck {
             message_id: message_id.to_string(),
         },
         message: "OK".into(),
-        data: "{}".into(),
+        data: r#"{"response":"SUCCESS"}"#.into(),
     }
 }
 
@@ -953,6 +971,16 @@ mod tests {
         assert_eq!(ack.code, 200);
         assert_eq!(ack.headers.message_id, "msg_123");
         assert_eq!(ack.message, "OK");
+        assert_eq!(ack.data, r#"{"response":"SUCCESS"}"#);
+    }
+
+    #[test]
+    fn build_ack_data_contains_response_success() {
+        let ack = build_ack("msg_456");
+        assert_eq!(ack.code, 200);
+        assert_eq!(ack.headers.message_id, "msg_456");
+        let data: serde_json::Value = serde_json::from_str(&ack.data).unwrap();
+        assert_eq!(data["response"], "SUCCESS");
     }
 
     // -- build_card_param_map for update (empty text, buttons only) ----------
@@ -1018,6 +1046,55 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("not initialized"), "expected init error: {err}");
+    }
+
+    // -- handle_stream_frame: SYSTEM ping -----------------------------------
+
+    #[tokio::test]
+    async fn handle_stream_frame_system_ping_returns_ack() {
+        let (msg_tx, _msg_rx) = tokio::sync::mpsc::channel(16);
+        let (confirm_tx, _confirm_rx) = tokio::sync::mpsc::channel(16);
+
+        let ping_frame = serde_json::json!({
+            "type": "SYSTEM",
+            "headers": {
+                "contentType": "application/json",
+                "messageId": "ping_001",
+                "topic": "ping"
+            },
+            "data": "{}"
+        });
+
+        let result = handle_stream_frame(
+            &ping_frame.to_string(),
+            &msg_tx,
+            &confirm_tx,
+        ).await;
+
+        assert!(result.is_some(), "SYSTEM ping should return an ack");
+        let ack = result.unwrap();
+        assert_eq!(ack.code, 200);
+        assert_eq!(ack.headers.message_id, "ping_001");
+    }
+
+    #[tokio::test]
+    async fn handle_stream_frame_system_connected_returns_none() {
+        let (msg_tx, _msg_rx) = tokio::sync::mpsc::channel(16);
+        let (confirm_tx, _confirm_rx) = tokio::sync::mpsc::channel(16);
+
+        let connected_frame = serde_json::json!({
+            "type": "SYSTEM",
+            "headers": { "topic": "CONNECTED" },
+            "data": "{\"code\":200,\"message\":\"OK\"}"
+        });
+
+        let result = handle_stream_frame(
+            &connected_frame.to_string(),
+            &msg_tx,
+            &confirm_tx,
+        ).await;
+
+        assert!(result.is_none(), "Non-ping SYSTEM frames should not return ack");
     }
 
     // -- DingtalkPlugin constructor -----------------------------------------

--- a/crates/aionui-channel/src/plugins/dingtalk/plugin.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/plugin.rs
@@ -17,9 +17,9 @@ use crate::types::{
 use super::api::DingtalkApi;
 use super::types::{
     BotMessageCallback, CardActionCallback, CardData, CreateCardInstanceRequest, DeliverCardRequest,
-    ImGroupDeliverModel, ImRobotDeliverModel, SendRobotMessageRequest, StreamAck, StreamFrame, StreamingWriteRequest,
-    SystemEvent, UpdateCardRequest, build_open_space_id, decode_chat_id, encode_chat_id, format_dingtalk_callback,
-    parse_dingtalk_callback,
+    ImGroupDeliverModel, ImRobotDeliverModel, SendRobotMessageRequest, SpaceModel, StreamAck, StreamFrame,
+    StreamingWriteRequest, SystemEvent, UpdateCardRequest, build_open_space_id, decode_chat_id, encode_chat_id,
+    format_dingtalk_callback, parse_dingtalk_callback,
 };
 
 /// Maximum reconnect attempts before giving up.
@@ -200,20 +200,22 @@ impl ChannelPlugin for DingtalkPlugin {
         // Presence of buttons signals the final message in a streaming sequence.
         let is_final = message.buttons.is_some();
 
-        // AI Card streaming write
+        // AI Card streaming write (always send full content, not deltas)
         let req = StreamingWriteRequest {
             out_track_id: message_id.to_string(),
-            key: "content".into(),
-            content: text,
-            is_eof: is_final,
-            is_last: is_final,
+            key: "msgContent".into(),
+            content: text.clone(),
+            is_full: true,
+            is_finalize: is_final,
+            is_error: false,
+            guid: generate_guid(),
         };
 
         api.streaming_write(&req).await?;
 
-        // When finalizing, update the card with button actions.
-        if let Some(ref button_rows) = message.buttons {
-            let card_param_map = build_card_param_map("", Some(button_rows));
+        // When finalizing, update the card status to FINISHED.
+        if is_final {
+            let card_param_map = build_final_card_param_map(&text, message.buttons.as_deref());
             let update_req = UpdateCardRequest {
                 out_track_id: message_id.to_string(),
                 card_data: CardData {
@@ -252,49 +254,39 @@ impl ChannelPlugin for DingtalkPlugin {
 // ---------------------------------------------------------------------------
 
 /// Send a message via AI Card (create + deliver).
+///
+/// The initial "Thinking..." state is implied by the streaming card template.
+/// Returns the `outTrackId` which is used as the message ID for subsequent streaming writes.
 async fn send_via_ai_card(
     api: &Arc<DingtalkApi>,
     chat_id: &str,
-    text: &str,
-    buttons: Option<&[Vec<crate::types::ActionButton>]>,
+    _text: &str,
+    _buttons: Option<&[Vec<crate::types::ActionButton>]>,
 ) -> Result<String, ChannelError> {
     let (is_group, _) = decode_chat_id(chat_id);
 
-    let card_param_map = build_card_param_map(text, buttons);
+    let out_track_id = generate_out_track_id();
 
     let create_req = CreateCardInstanceRequest {
         card_template_id: AI_CARD_TEMPLATE_ID.into(),
+        out_track_id: out_track_id.clone(),
+        callback_type: "STREAM".into(),
         card_data: CardData {
-            card_param_map: Some(card_param_map),
+            card_param_map: Some(serde_json::json!({})),
         },
-        im_group_open_deliver_model: if is_group {
-            Some(ImGroupDeliverModel {
-                robot_code: api.client_id().to_string(),
-            })
-        } else {
-            None
-        },
-        im_robot_open_deliver_model: if !is_group {
-            Some(ImRobotDeliverModel {
-                robot_code: api.client_id().to_string(),
-            })
-        } else {
-            None
-        },
+        im_group_open_space_model: Some(SpaceModel { support_forward: true }),
+        im_robot_open_space_model: Some(SpaceModel { support_forward: true }),
     };
 
-    let create_resp = api.create_card_instance(&create_req).await?;
-    let card_id = create_resp
-        .result
-        .and_then(|r| r.out_track_id)
-        .ok_or_else(|| ChannelError::MessageSendFailed("DingTalk card create returned no outTrackId".into()))?;
+    api.create_card_instance(&create_req).await?;
 
     // Deliver the card
     let open_space_id = build_open_space_id(chat_id);
 
     let deliver_req = DeliverCardRequest {
-        out_track_id: card_id.clone(),
+        out_track_id: out_track_id.clone(),
         open_space_id,
+        user_id_type: 1,
         im_group_open_deliver_model: if is_group {
             Some(ImGroupDeliverModel {
                 robot_code: api.client_id().to_string(),
@@ -304,7 +296,7 @@ async fn send_via_ai_card(
         },
         im_robot_open_deliver_model: if !is_group {
             Some(ImRobotDeliverModel {
-                robot_code: api.client_id().to_string(),
+                space_type: "IM_ROBOT".into(),
             })
         } else {
             None
@@ -313,8 +305,8 @@ async fn send_via_ai_card(
 
     api.deliver_card(&deliver_req).await?;
 
-    debug!(card_id = %card_id, "DingTalk AI Card delivered");
-    Ok(card_id)
+    debug!(card_id = %out_track_id, "DingTalk AI Card delivered");
+    Ok(out_track_id)
 }
 
 /// Send a message via DingTalk Open API (fallback).
@@ -340,10 +332,13 @@ async fn send_via_open_api(api: &Arc<DingtalkApi>, chat_id: &str, text: &str) ->
     Ok(msg_id)
 }
 
-/// Build the card_param_map for an AI Card.
-fn build_card_param_map(text: &str, buttons: Option<&[Vec<crate::types::ActionButton>]>) -> serde_json::Value {
+/// Build the card_param_map for finalizing an AI Card (status = FINISHED).
+fn build_final_card_param_map(text: &str, buttons: Option<&[Vec<crate::types::ActionButton>]>) -> serde_json::Value {
     let mut map = serde_json::json!({
-        "content": text
+        "flowStatus": "3",
+        "msgContent": text,
+        "staticMsgContent": "",
+        "sys_full_json_obj": serde_json::json!({"order": ["msgContent"]}).to_string(),
     });
 
     if let Some(button_rows) = buttons {
@@ -363,6 +358,32 @@ fn build_card_param_map(text: &str, buttons: Option<&[Vec<crate::types::ActionBu
     }
 
     map
+}
+
+/// Generate a unique outTrackId for AI Card instances.
+fn generate_out_track_id() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("aion_{}_{}", ts, seq)
+}
+
+/// Generate a unique GUID for streaming write operations.
+fn generate_guid() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{}_{}", ts, seq)
 }
 
 // ---------------------------------------------------------------------------
@@ -956,25 +977,27 @@ mod tests {
         assert!(text.contains("Unsupported"));
     }
 
-    // -- build_card_param_map -----------------------------------------------
+    // -- build_final_card_param_map -------------------------------------------
 
     #[test]
-    fn build_card_param_map_text_only() {
-        let map = build_card_param_map("Hello", None);
-        assert_eq!(map["content"], "Hello");
+    fn build_final_card_param_map_text_only() {
+        let map = build_final_card_param_map("Hello", None);
+        assert_eq!(map["flowStatus"], "3");
+        assert_eq!(map["msgContent"], "Hello");
         assert!(map.get("actions").is_none());
     }
 
     #[test]
-    fn build_card_param_map_with_buttons() {
+    fn build_final_card_param_map_with_buttons() {
         use crate::types::ActionButton;
         let buttons = vec![vec![ActionButton {
             label: "Yes".into(),
             action: "system.confirm".into(),
             params: None,
         }]];
-        let map = build_card_param_map("Choose:", Some(&buttons));
-        assert_eq!(map["content"], "Choose:");
+        let map = build_final_card_param_map("Choose:", Some(&buttons));
+        assert_eq!(map["flowStatus"], "3");
+        assert_eq!(map["msgContent"], "Choose:");
         let actions = map["actions"].as_array().unwrap();
         assert_eq!(actions[0]["label"], "Yes");
         assert!(actions[0]["action"].as_str().unwrap().contains("system.confirm"));
@@ -1000,18 +1023,19 @@ mod tests {
         assert_eq!(data["response"], "SUCCESS");
     }
 
-    // -- build_card_param_map for update (empty text, buttons only) ----------
+    // -- build_final_card_param_map for update (empty text, buttons only) ----
 
     #[test]
-    fn build_card_param_map_empty_text_with_buttons() {
+    fn build_final_card_param_map_empty_text_with_buttons() {
         use crate::types::ActionButton;
         let buttons = vec![vec![ActionButton {
             label: "Confirm".into(),
             action: "system.confirm".into(),
             params: None,
         }]];
-        let map = build_card_param_map("", Some(&buttons));
-        assert_eq!(map["content"], "");
+        let map = build_final_card_param_map("", Some(&buttons));
+        assert_eq!(map["flowStatus"], "3");
+        assert_eq!(map["msgContent"], "");
         let actions = map["actions"].as_array().unwrap();
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0]["label"], "Confirm");

--- a/crates/aionui-channel/src/plugins/dingtalk/plugin.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/plugin.rs
@@ -172,11 +172,14 @@ impl ChannelPlugin for DingtalkPlugin {
 
         let text = truncate_message(message.text.as_deref().unwrap_or(""), DINGTALK_MESSAGE_LIMIT);
 
-        // Try AI Card first
-        match send_via_ai_card(api, chat_id, &text, message.buttons.as_deref()).await {
-            Ok(card_id) => return Ok(card_id),
-            Err(e) => {
-                warn!(error = %e, "AI Card send failed, falling back to Open API");
+        // Only use AI Card for streaming (messages without buttons).
+        // Messages with buttons are one-shot and should go via Open API.
+        if message.buttons.is_none() {
+            match send_via_ai_card(api, chat_id).await {
+                Ok(card_id) => return Ok(card_id),
+                Err(e) => {
+                    warn!(error = %e, "AI Card send failed, falling back to Open API");
+                }
             }
         }
 
@@ -253,16 +256,10 @@ impl ChannelPlugin for DingtalkPlugin {
 // AI Card operations
 // ---------------------------------------------------------------------------
 
-/// Send a message via AI Card (create + deliver).
+/// Create an empty AI Card for streaming (create + deliver + set INPUTING).
 ///
-/// The initial "Thinking..." state is implied by the streaming card template.
 /// Returns the `outTrackId` which is used as the message ID for subsequent streaming writes.
-async fn send_via_ai_card(
-    api: &Arc<DingtalkApi>,
-    chat_id: &str,
-    _text: &str,
-    _buttons: Option<&[Vec<crate::types::ActionButton>]>,
-) -> Result<String, ChannelError> {
+async fn send_via_ai_card(api: &Arc<DingtalkApi>, chat_id: &str) -> Result<String, ChannelError> {
     let (is_group, _) = decode_chat_id(chat_id);
 
     let out_track_id = generate_out_track_id();
@@ -304,6 +301,20 @@ async fn send_via_ai_card(
     };
 
     api.deliver_card(&deliver_req).await?;
+
+    // Transition card to INPUTING state so streaming writes are accepted.
+    let inputing_req = UpdateCardRequest {
+        out_track_id: out_track_id.clone(),
+        card_data: CardData {
+            card_param_map: Some(serde_json::json!({
+                "flowStatus": "2",
+                "msgContent": "",
+                "staticMsgContent": "",
+                "sys_full_json_obj": serde_json::json!({"order": ["msgContent"]}).to_string(),
+            })),
+        },
+    };
+    api.update_card(&inputing_req).await?;
 
     debug!(card_id = %out_track_id, "DingTalk AI Card delivered");
     Ok(out_track_id)

--- a/crates/aionui-channel/src/plugins/dingtalk/types.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/types.rs
@@ -509,11 +509,21 @@ pub(crate) fn parse_dingtalk_callback(data: &str) -> Option<ParsedCallback> {
 
 /// Encode a chat ID for DingTalk.
 ///
-/// - Private chat: `user:{staffId}`
-/// - Group chat: `group:{conversationId}`
-pub(crate) fn encode_chat_id(conversation_id: Option<&str>, sender_staff_id: &str) -> String {
-    match conversation_id {
-        Some(cid) if !cid.is_empty() => format!("group:{cid}"),
+/// - Private chat (`conversationType == "1"`): `user:{staffId}`
+/// - Group chat (`conversationType == "2"`): `group:{conversationId}`
+///
+/// DingTalk sends a `conversationId` for BOTH private and group chats,
+/// so we must rely on `conversationType` to distinguish them.
+pub(crate) fn encode_chat_id(
+    conversation_type: Option<&str>,
+    conversation_id: Option<&str>,
+    sender_staff_id: &str,
+) -> String {
+    match conversation_type {
+        Some("2") => {
+            let cid = conversation_id.unwrap_or("");
+            format!("group:{cid}")
+        }
         _ => format!("user:{sender_staff_id}"),
     }
 }
@@ -931,19 +941,19 @@ mod tests {
 
     #[test]
     fn encode_chat_id_group() {
-        let result = encode_chat_id(Some("conv_123"), "staff_1");
+        let result = encode_chat_id(Some("2"), Some("conv_123"), "staff_1");
         assert_eq!(result, "group:conv_123");
     }
 
     #[test]
     fn encode_chat_id_private() {
-        let result = encode_chat_id(None, "staff_1");
+        let result = encode_chat_id(Some("1"), Some("cid_private_xyz"), "staff_1");
         assert_eq!(result, "user:staff_1");
     }
 
     #[test]
-    fn encode_chat_id_empty_conversation() {
-        let result = encode_chat_id(Some(""), "staff_1");
+    fn encode_chat_id_no_conversation_type() {
+        let result = encode_chat_id(None, Some("cid_whatever"), "staff_1");
         assert_eq!(result, "user:staff_1");
     }
 

--- a/crates/aionui-channel/src/plugins/dingtalk/types.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/types.rs
@@ -46,10 +46,17 @@ pub(crate) struct RobotInfoResponse {
 // ---------------------------------------------------------------------------
 
 /// Request body for registering a WebSocket Stream connection.
+///
+/// Note: This endpoint uses clientId/clientSecret directly in the body,
+/// NOT the access token header used by other DingTalk APIs.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct RegisterStreamRequest {
+    pub client_id: String,
+    pub client_secret: String,
     pub subscriptions: Vec<StreamSubscription>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ua: Option<String>,
 }
 
 /// A subscription entry for stream registration.
@@ -749,14 +756,46 @@ mod tests {
     #[test]
     fn register_stream_request_serializes() {
         let req = RegisterStreamRequest {
+            client_id: "key_1".into(),
+            client_secret: "secret_1".into(),
             subscriptions: vec![StreamSubscription {
-                sub_type: "EVENT".into(),
+                sub_type: "CALLBACK".into(),
                 topic: "/v1.0/im/bot/messages/get".into(),
             }],
+            ua: None,
         };
         let json = serde_json::to_value(&req).unwrap();
-        assert_eq!(json["subscriptions"][0]["type"], "EVENT");
+        assert_eq!(json["clientId"], "key_1");
+        assert_eq!(json["clientSecret"], "secret_1");
+        assert_eq!(json["subscriptions"][0]["type"], "CALLBACK");
         assert_eq!(json["subscriptions"][0]["topic"], "/v1.0/im/bot/messages/get");
+        assert!(json.get("ua").is_none());
+    }
+
+    #[test]
+    fn register_stream_request_includes_credentials() {
+        let req = RegisterStreamRequest {
+            client_id: "my_client_id".into(),
+            client_secret: "my_secret".into(),
+            subscriptions: vec![
+                StreamSubscription {
+                    sub_type: "EVENT".into(),
+                    topic: "*".into(),
+                },
+                StreamSubscription {
+                    sub_type: "CALLBACK".into(),
+                    topic: "/v1.0/im/bot/messages/get".into(),
+                },
+            ],
+            ua: Some("aionui-backend".into()),
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["clientId"], "my_client_id");
+        assert_eq!(json["clientSecret"], "my_secret");
+        assert_eq!(json["ua"], "aionui-backend");
+        assert_eq!(json["subscriptions"][0]["type"], "EVENT");
+        assert_eq!(json["subscriptions"][0]["topic"], "*");
+        assert_eq!(json["subscriptions"][1]["type"], "CALLBACK");
     }
 
     #[test]

--- a/crates/aionui-channel/src/plugins/dingtalk/types.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/types.rs
@@ -247,16 +247,20 @@ pub(crate) struct CardPrivateData {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct CreateCardInstanceRequest {
-    /// Card template ID (use "StandardCard" for AI streaming cards).
+    /// Card template ID.
     pub card_template_id: String,
-    /// Card data (markdown content, buttons, etc.).
+    /// Client-generated tracking ID for the card instance.
+    pub out_track_id: String,
+    /// Callback type — must be "STREAM" for streaming cards.
+    pub callback_type: String,
+    /// Card data (initially empty for streaming cards).
     pub card_data: CardData,
-    /// IM group setting for card delivery.
+    /// IM group space model (for group chats).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub im_group_open_deliver_model: Option<ImGroupDeliverModel>,
-    /// IM robot setting for card delivery.
+    pub im_group_open_space_model: Option<SpaceModel>,
+    /// IM robot space model (for single chats).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub im_robot_open_deliver_model: Option<ImRobotDeliverModel>,
+    pub im_robot_open_space_model: Option<SpaceModel>,
 }
 
 /// Card data containing dynamic fields.
@@ -266,6 +270,13 @@ pub(crate) struct CardData {
     /// Content body for the card (markdown).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub card_param_map: Option<serde_json::Value>,
+}
+
+/// Space model for card creation (supportForward flag).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SpaceModel {
+    pub support_forward: bool,
 }
 
 /// IM group delivery settings.
@@ -280,8 +291,8 @@ pub(crate) struct ImGroupDeliverModel {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ImRobotDeliverModel {
-    /// Robot code (App Key).
-    pub robot_code: String,
+    /// Space type for robot delivery.
+    pub space_type: String,
 }
 
 /// Response from creating an AI Card instance.
@@ -291,18 +302,6 @@ pub(crate) struct CreateCardInstanceResponse {
     /// Whether the request succeeded.
     #[serde(default)]
     pub success: Option<bool>,
-    /// Result containing the card instance ID.
-    #[serde(default)]
-    pub result: Option<CardInstanceResult>,
-}
-
-/// Result payload from card instance creation.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct CardInstanceResult {
-    /// The created card instance ID.
-    #[serde(default)]
-    pub out_track_id: Option<String>,
 }
 
 /// Request to deliver a card instance to a chat.
@@ -313,6 +312,8 @@ pub(crate) struct DeliverCardRequest {
     pub out_track_id: String,
     /// Open space ID: `dtv1.card//IM_ROBOT.userId` or `dtv1.card//IM_GROUP.conversationId`.
     pub open_space_id: String,
+    /// User ID type (1 = staffId).
+    pub user_id_type: u8,
     /// IM group delivery model (for group chats).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub im_group_open_deliver_model: Option<ImGroupDeliverModel>,
@@ -338,14 +339,18 @@ pub(crate) struct DeliverCardResponse {
 pub(crate) struct StreamingWriteRequest {
     /// Card instance ID.
     pub out_track_id: String,
-    /// Streaming content key.
+    /// Streaming content key (use "msgContent" for AI Card streaming).
     pub key: String,
-    /// Content to append.
+    /// Content to write.
     pub content: String,
-    /// Whether this is the final write (marks card as complete).
-    pub is_eof: bool,
-    /// Whether this is the final write for this key.
-    pub is_last: bool,
+    /// Whether this is a full replacement (true) or append (false).
+    pub is_full: bool,
+    /// Whether this is the final write (marks card streaming as complete).
+    pub is_finalize: bool,
+    /// Whether this is an error state.
+    pub is_error: bool,
+    /// Unique identifier for this write operation.
+    pub guid: String,
 }
 
 /// Response from streaming write.
@@ -720,7 +725,6 @@ mod tests {
         });
         let resp: CreateCardInstanceResponse = serde_json::from_value(raw).unwrap();
         assert_eq!(resp.success, Some(true));
-        assert_eq!(resp.result.unwrap().out_track_id.as_deref(), Some("card_inst_1"));
     }
 
     // -- DeliverCardResponse --------------------------------------------------
@@ -828,36 +832,42 @@ mod tests {
     #[test]
     fn create_card_instance_request_serializes() {
         let req = CreateCardInstanceRequest {
-            card_template_id: "StandardCard".into(),
+            card_template_id: "382e4302-551d-4880-bf29-a30acfab2e71.schema".into(),
+            out_track_id: "aion_123_0".into(),
+            callback_type: "STREAM".into(),
             card_data: CardData {
-                card_param_map: Some(json!({"content": "Hello"})),
+                card_param_map: Some(json!({})),
             },
-            im_group_open_deliver_model: None,
-            im_robot_open_deliver_model: Some(ImRobotDeliverModel {
-                robot_code: "app_key_1".into(),
-            }),
+            im_group_open_space_model: Some(SpaceModel { support_forward: true }),
+            im_robot_open_space_model: Some(SpaceModel { support_forward: true }),
         };
         let json = serde_json::to_value(&req).unwrap();
-        assert_eq!(json["cardTemplateId"], "StandardCard");
-        assert_eq!(json["cardData"]["cardParamMap"]["content"], "Hello");
-        assert!(json.get("imGroupOpenDeliverModel").is_none());
-        assert_eq!(json["imRobotOpenDeliverModel"]["robotCode"], "app_key_1");
+        assert_eq!(json["cardTemplateId"], "382e4302-551d-4880-bf29-a30acfab2e71.schema");
+        assert_eq!(json["outTrackId"], "aion_123_0");
+        assert_eq!(json["callbackType"], "STREAM");
+        assert_eq!(json["imGroupOpenSpaceModel"]["supportForward"], true);
+        assert_eq!(json["imRobotOpenSpaceModel"]["supportForward"], true);
     }
 
     #[test]
     fn streaming_write_request_serializes() {
         let req = StreamingWriteRequest {
             out_track_id: "card_1".into(),
-            key: "content".into(),
+            key: "msgContent".into(),
             content: "chunk text".into(),
-            is_eof: false,
-            is_last: false,
+            is_full: true,
+            is_finalize: false,
+            is_error: false,
+            guid: "123_abc".into(),
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["outTrackId"], "card_1");
-        assert_eq!(json["key"], "content");
+        assert_eq!(json["key"], "msgContent");
         assert_eq!(json["content"], "chunk text");
-        assert_eq!(json["isEof"], false);
+        assert_eq!(json["isFull"], true);
+        assert_eq!(json["isFinalize"], false);
+        assert_eq!(json["isError"], false);
+        assert_eq!(json["guid"], "123_abc");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix DingTalk WebSocket Stream registration to use body credentials (clientId/clientSecret) instead of access token header
- Fix ACK data format and handle SYSTEM ping frames for connection keep-alive
- Fix chat_id encoding to use `conversationType` field instead of `conversationId` presence
- Fix AI Card streaming protocol: correct template ID, outTrackId generation, callbackType=STREAM, INPUTING state transition, msgContent key
- Fix Open API message format: use sampleMarkdown with split endpoints for group/single chat
- Skip AI Card for one-shot messages (pairing, errors) — send via Open API directly
- Add structured logging for connection lifecycle and unit tests for callback message flow

## Test plan

- [x] Unit tests pass (557 tests in aionui-channel)
- [x] Clippy passes with no warnings
- [x] Manual test: DingTalk pairing flow works (pairing code sent via Open API)
- [x] Manual test: AI Card streaming shows content and finalizes correctly
- [ ] Verify group chat scenario works correctly