### PR TITLE
fix(conversation): align search response with frontend expectations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,42 @@ Every domain crate must follow:
 - Prefer real in-memory DB over mocks; mock only to isolate unneeded dependencies
 - New features must include tests
 
+### Test Scope Requirements
+
+**Happy Path (Critical Paths)**
+
+Every new or modified feature must have integration tests covering its normal flow. Critical paths that always require test coverage:
+- Authentication flow (login, token refresh, permission checks)
+- Message sending and retrieval
+- Agent session creation and interaction
+- File upload/download
+- WebSocket connection and event delivery
+
+**Bad Path (Error Paths)**
+
+New endpoints or business logic must include tests for these scenarios:
+- Invalid input (missing fields, wrong types, oversized content)
+- Resource not found (404)
+- Insufficient permissions (unauthenticated, accessing another user's resources)
+- Business rule violations (duplicate creation, operations not allowed in current state)
+
+Bad path tests must assert specific error codes or error messages — asserting merely "not success" is not acceptable.
+
+**Security Tests**
+
+Endpoints involving authentication, authorization, or data isolation must include security tests:
+- Unauthenticated requests are rejected (401)
+- Cross-user data isolation (user A cannot access user B's resources)
+- State-changing requests are rejected when CSRF token is missing or invalid
+- Sensitive fields (passwords, tokens) never appear in responses
+
+**WebSocket Event Tests**
+
+New WebSocket events must verify:
+- The event is emitted after the correct business operation
+- Event payload conforms to `WebSocketMessage<T>` structure
+- Events are only delivered to authorized subscribers (no leakage to unrelated users)
+
 ### Test Failure Handling
 
 When a test fails, do NOT modify the test to make it pass. First determine:

--- a/crates/aionui-api-types/src/conversation.rs
+++ b/crates/aionui-api-types/src/conversation.rs
@@ -162,11 +162,10 @@ pub type ConversationArtifactListResponse = Vec<ConversationArtifactResponse>;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageSearchItem {
     pub message_id: String,
-    pub conversation_id: String,
-    pub conversation_name: String,
-    pub r#type: String,
-    pub content: String,
-    pub created_at: TimestampMs,
+    pub message_type: String,
+    pub message_created_at: TimestampMs,
+    pub preview_text: String,
+    pub conversation: ConversationResponse,
 }
 
 /// Paginated search results for messages.
@@ -513,40 +512,65 @@ mod tests {
     fn serialize_search_item_snake_case() {
         let item = MessageSearchItem {
             message_id: "msg_1".into(),
-            conversation_id: "conv_1".into(),
-            conversation_name: "Code Review".into(),
-            r#type: "text".into(),
-            content: "matched snippet".into(),
-            created_at: 1712345678000,
+            message_type: "text".into(),
+            message_created_at: 1712345678000,
+            preview_text: "matched snippet".into(),
+            conversation: ConversationResponse {
+                id: "conv_1".into(),
+                name: "Code Review".into(),
+                r#type: AgentType::Acp,
+                model: None,
+                status: ConversationStatus::Finished,
+                source: None,
+                pinned: false,
+                pinned_at: None,
+                channel_chat_id: None,
+                created_at: 1712345678000,
+                modified_at: 1712345678000,
+                extra: json!({}),
+            },
         };
         let json = serde_json::to_value(&item).unwrap();
         assert_eq!(json["message_id"], "msg_1");
-        assert_eq!(json["conversation_id"], "conv_1");
-        assert_eq!(json["conversation_name"], "Code Review");
-        assert_eq!(json["type"], "text");
-        assert_eq!(json["content"], "matched snippet");
-        assert_eq!(json["created_at"], 1712345678000_i64);
+        assert_eq!(json["message_type"], "text");
+        assert_eq!(json["message_created_at"], 1712345678000_i64);
+        assert_eq!(json["preview_text"], "matched snippet");
+        assert_eq!(json["conversation"]["id"], "conv_1");
+        assert_eq!(json["conversation"]["name"], "Code Review");
         // Verify no camelCase leaks
         assert!(json.get("messageId").is_none());
-        assert!(json.get("conversationId").is_none());
-        assert!(json.get("conversationName").is_none());
-        assert!(json.get("createdAt").is_none());
+        assert!(json.get("messageType").is_none());
+        assert!(json.get("previewText").is_none());
     }
 
     #[test]
     fn search_item_roundtrip() {
         let item = MessageSearchItem {
             message_id: "msg_x".into(),
-            conversation_id: "conv_x".into(),
-            conversation_name: "Search Test".into(),
-            r#type: "tips".into(),
-            content: "some content".into(),
-            created_at: 9000,
+            message_type: "tips".into(),
+            message_created_at: 9000,
+            preview_text: "some content preview".into(),
+            conversation: ConversationResponse {
+                id: "conv_x".into(),
+                name: "Search Test".into(),
+                r#type: AgentType::Acp,
+                model: None,
+                status: ConversationStatus::Finished,
+                source: None,
+                pinned: false,
+                pinned_at: None,
+                channel_chat_id: None,
+                created_at: 9000,
+                modified_at: 9000,
+                extra: json!({}),
+            },
         };
         let serialized = serde_json::to_string(&item).unwrap();
         let deserialized: MessageSearchItem = serde_json::from_str(&serialized).unwrap();
         assert_eq!(deserialized.message_id, "msg_x");
-        assert_eq!(deserialized.conversation_name, "Search Test");
+        assert_eq!(deserialized.message_type, "tips");
+        assert_eq!(deserialized.preview_text, "some content preview");
+        assert_eq!(deserialized.conversation.name, "Search Test");
     }
 
     // ── SendMessageRequest ──────────────────────────────────────────
@@ -635,17 +659,31 @@ mod tests {
         let resp: MessageSearchResponse = PaginatedResult {
             items: vec![MessageSearchItem {
                 message_id: "m1".into(),
-                conversation_id: "c1".into(),
-                conversation_name: "Conv".into(),
-                r#type: "text".into(),
-                content: "matched".into(),
-                created_at: 5000,
+                message_type: "text".into(),
+                message_created_at: 5000,
+                preview_text: "matched".into(),
+                conversation: ConversationResponse {
+                    id: "c1".into(),
+                    name: "Conv".into(),
+                    r#type: AgentType::Acp,
+                    model: None,
+                    status: ConversationStatus::Finished,
+                    source: None,
+                    pinned: false,
+                    pinned_at: None,
+                    channel_chat_id: None,
+                    created_at: 5000,
+                    modified_at: 5000,
+                    extra: json!({}),
+                },
             }],
             total: 1,
             has_more: false,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["items"][0]["message_id"], "m1");
+        assert_eq!(json["items"][0]["conversation"]["id"], "c1");
+        assert_eq!(json["items"][0]["preview_text"], "matched");
         assert_eq!(json["total"], 1);
     }
 

--- a/crates/aionui-conversation/src/convert.rs
+++ b/crates/aionui-conversation/src/convert.rs
@@ -170,16 +170,78 @@ pub fn row_to_artifact_response(row: ConversationArtifactRow) -> Result<Conversa
     })
 }
 
-/// Convert a search result row into an API search item DTO.
-pub fn search_row_to_item(row: MessageSearchRow) -> MessageSearchItem {
-    MessageSearchItem {
-        message_id: row.message_id,
-        conversation_id: row.conversation_id,
-        conversation_name: row.conversation_name,
-        r#type: row.r#type,
-        content: row.content,
-        created_at: row.created_at,
+/// Extract plain-text preview from a message content field.
+///
+/// Message content is stored as JSON (arrays, objects with nested strings).
+/// This recursively collects all string values and joins them with spaces,
+/// producing a flat preview suitable for search snippet display.
+fn extract_preview_text(raw_content: &str) -> String {
+    fn collect_strings(value: &serde_json::Value, bucket: &mut Vec<String>) {
+        match value {
+            serde_json::Value::String(s) => {
+                let trimmed = s.trim();
+                if !trimmed.is_empty() {
+                    bucket.push(trimmed.to_owned());
+                }
+            }
+            serde_json::Value::Array(arr) => {
+                for item in arr {
+                    collect_strings(item, bucket);
+                }
+            }
+            serde_json::Value::Object(map) => {
+                for item in map.values() {
+                    collect_strings(item, bucket);
+                }
+            }
+            _ => {}
+        }
     }
+
+    match serde_json::from_str::<serde_json::Value>(raw_content) {
+        Ok(parsed) => {
+            let mut bucket = Vec::new();
+            collect_strings(&parsed, &mut bucket);
+            let joined = bucket.join(" ");
+            let normalized = joined.split_whitespace().collect::<Vec<_>>().join(" ");
+            if normalized.is_empty() {
+                raw_content.split_whitespace().collect::<Vec<_>>().join(" ")
+            } else {
+                normalized
+            }
+        }
+        Err(_) => raw_content.split_whitespace().collect::<Vec<_>>().join(" "),
+    }
+}
+
+/// Convert a search result row into an API search item DTO.
+pub fn search_row_to_item(row: MessageSearchRow, data_dir: &Path) -> Result<MessageSearchItem, AppError> {
+    let conversation_row = ConversationRow {
+        id: row.conversation_id,
+        user_id: String::new(),
+        name: row.conversation_name,
+        r#type: row.conversation_type,
+        extra: row.conversation_extra,
+        model: row.conversation_model,
+        status: row.conversation_status,
+        source: row.conversation_source,
+        channel_chat_id: row.conversation_channel_chat_id,
+        pinned: row.conversation_pinned,
+        pinned_at: row.conversation_pinned_at,
+        created_at: row.conversation_created_at,
+        updated_at: row.conversation_updated_at,
+    };
+
+    let conversation = row_to_response(conversation_row, data_dir)?;
+    let preview_text = extract_preview_text(&row.content);
+
+    Ok(MessageSearchItem {
+        message_id: row.message_id,
+        message_type: row.r#type,
+        message_created_at: row.created_at,
+        preview_text,
+        conversation,
+    })
 }
 
 #[cfg(test)]
@@ -364,5 +426,138 @@ mod tests {
         assert!(resp.pinned);
         assert_eq!(resp.pinned_at, Some(5000));
         assert_eq!(resp.channel_chat_id.as_deref(), Some("chat:1"));
+    }
+
+    // ── extract_preview_text ───────────────────────────────────────────
+
+    #[test]
+    fn test_extract_preview_text_json_array() {
+        let content = r#"[{"type":"text","content":"Hello world"},{"type":"text","content":"How are you?"}]"#;
+        let result = extract_preview_text(content);
+        assert!(result.contains("Hello world"));
+        assert!(result.contains("How are you?"));
+    }
+
+    #[test]
+    fn test_extract_preview_text_plain_string() {
+        let content = "Just plain text message";
+        let result = extract_preview_text(content);
+        assert_eq!(result, "Just plain text message");
+    }
+
+    #[test]
+    fn test_extract_preview_text_nested_object() {
+        let content = r#"{"text":"nested value","items":[{"content":"inner"}]}"#;
+        let result = extract_preview_text(content);
+        assert!(result.contains("nested value"));
+        assert!(result.contains("inner"));
+    }
+
+    #[test]
+    fn test_extract_preview_text_malformed_json() {
+        let content = "this is not { json at all";
+        let result = extract_preview_text(content);
+        assert_eq!(result, "this is not { json at all");
+    }
+
+    #[test]
+    fn test_extract_preview_text_empty_content() {
+        let result = extract_preview_text("");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_extract_preview_text_whitespace_normalization() {
+        let content = r#"{"content":"  hello   world  "}"#;
+        let result = extract_preview_text(content);
+        assert_eq!(result, "hello world");
+    }
+
+    // ── search_row_to_item ─────────────────────────────────────────────
+
+    #[test]
+    fn test_search_row_to_item_builds_nested_conversation() {
+        let row = MessageSearchRow {
+            message_id: "msg_1".into(),
+            r#type: "text".into(),
+            content: r#"{"content":"hello world"}"#.into(),
+            created_at: 5000,
+            conversation_id: "conv_1".into(),
+            conversation_name: "Test Conv".into(),
+            conversation_type: "acp".into(),
+            conversation_extra: r#"{"workspace":"/project"}"#.into(),
+            conversation_model: None,
+            conversation_status: Some("finished".into()),
+            conversation_source: Some("aionui".into()),
+            conversation_channel_chat_id: None,
+            conversation_pinned: false,
+            conversation_pinned_at: None,
+            conversation_created_at: 1000,
+            conversation_updated_at: 2000,
+        };
+
+        let item = search_row_to_item(row, Path::new("/tmp/data")).unwrap();
+
+        assert_eq!(item.message_id, "msg_1");
+        assert_eq!(item.message_type, "text");
+        assert_eq!(item.message_created_at, 5000);
+        assert_eq!(item.preview_text, "hello world");
+
+        assert_eq!(item.conversation.id, "conv_1");
+        assert_eq!(item.conversation.name, "Test Conv");
+        assert_eq!(item.conversation.r#type, AgentType::Acp);
+        assert_eq!(item.conversation.source, Some(ConversationSource::Aionui));
+        assert_eq!(item.conversation.extra["workspace"], "/project");
+        assert_eq!(item.conversation.modified_at, 2000);
+    }
+
+    #[test]
+    fn test_search_row_to_item_invalid_conversation_type() {
+        let row = MessageSearchRow {
+            message_id: "msg_1".into(),
+            r#type: "text".into(),
+            content: "plain text".into(),
+            created_at: 5000,
+            conversation_id: "conv_1".into(),
+            conversation_name: "Test".into(),
+            conversation_type: "invalid_type".into(),
+            conversation_extra: "{}".into(),
+            conversation_model: None,
+            conversation_status: Some("finished".into()),
+            conversation_source: None,
+            conversation_channel_chat_id: None,
+            conversation_pinned: false,
+            conversation_pinned_at: None,
+            conversation_created_at: 1000,
+            conversation_updated_at: 2000,
+        };
+
+        let err = search_row_to_item(row, Path::new("/tmp/data")).unwrap_err();
+        assert!(matches!(err, AppError::Internal(_)));
+    }
+
+    #[test]
+    fn test_search_row_to_item_invalid_conversation_extra_json() {
+        let row = MessageSearchRow {
+            message_id: "msg_1".into(),
+            r#type: "text".into(),
+            content: r#"{"content":"hello"}"#.into(),
+            created_at: 5000,
+            conversation_id: "conv_1".into(),
+            conversation_name: "Test".into(),
+            conversation_type: "acp".into(),
+            conversation_extra: "not valid json".into(),
+            conversation_model: None,
+            conversation_status: Some("finished".into()),
+            conversation_source: None,
+            conversation_channel_chat_id: None,
+            conversation_pinned: false,
+            conversation_pinned_at: None,
+            conversation_created_at: 1000,
+            conversation_updated_at: 2000,
+        };
+
+        let err = search_row_to_item(row, Path::new("/tmp/data")).unwrap_err();
+        assert!(matches!(err, AppError::Internal(_)));
     }
 }

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -794,7 +794,11 @@ impl ConversationService {
             .search_messages(user_id, &query.keyword, page, page_size)
             .await?;
 
-        let items = result.items.into_iter().map(search_row_to_item).collect();
+        let items = result
+            .items
+            .into_iter()
+            .map(|row| search_row_to_item(row, &self.workspace_root))
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(PaginatedResult {
             items,

--- a/crates/aionui-conversation/tests/conversation_extended.rs
+++ b/crates/aionui-conversation/tests/conversation_extended.rs
@@ -346,6 +346,15 @@ async fn t9_1_keyword_match() {
     let result = svc.search_messages(USER_ID, query).await.unwrap();
     assert_eq!(result.items.len(), 1);
     assert_eq!(result.total, 1);
+
+    let item = &result.items[0];
+    assert_eq!(item.message_type, "text");
+    assert!(item.message_created_at > 0);
+    assert!(item.preview_text.contains("Rust review report"));
+
+    assert_eq!(item.conversation.id, conv.id);
+    assert_eq!(item.conversation.name, conv.name);
+    assert_eq!(item.conversation.extra["workspace"], "/home/user/project");
 }
 
 #[tokio::test]
@@ -399,6 +408,81 @@ async fn t9_4_empty_keyword() {
     };
     let err = svc.search_messages(USER_ID, query).await.unwrap_err();
     assert!(matches!(err, aionui_common::AppError::BadRequest(_)));
+}
+
+#[tokio::test]
+async fn t9_5_preview_text_extracts_from_json_content() {
+    let (svc, repo, _b) = setup().await;
+    let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
+
+    let complex_msg = MessageRow {
+        id: generate_prefixed_id("msg"),
+        conversation_id: conv.id.clone(),
+        msg_id: None,
+        r#type: "text".to_string(),
+        content: r#"[{"type":"text","content":"Design document for search"},{"type":"text","content":"feature implementation"}]"#.to_string(),
+        position: Some("right".to_string()),
+        status: Some("finish".to_string()),
+        hidden: false,
+        created_at: now_ms(),
+    };
+    repo.insert_message(&complex_msg).await.unwrap();
+
+    let query = SearchMessagesQuery {
+        keyword: "search".into(),
+        page: None,
+        page_size: None,
+    };
+    let result = svc.search_messages(USER_ID, query).await.unwrap();
+    assert_eq!(result.items.len(), 1);
+
+    let item = &result.items[0];
+    assert!(!item.preview_text.contains('{'));
+    assert!(!item.preview_text.contains('['));
+    assert!(item.preview_text.contains("Design document for search"));
+    assert!(item.preview_text.contains("feature implementation"));
+}
+
+#[tokio::test]
+async fn t9_6_search_result_includes_conversation_model() {
+    let (svc, repo, _b) = setup().await;
+    let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
+
+    repo.insert_message(&make_message(&conv.id, "model test keyword", 0))
+        .await
+        .unwrap();
+
+    let query = SearchMessagesQuery {
+        keyword: "model test".into(),
+        page: None,
+        page_size: None,
+    };
+    let result = svc.search_messages(USER_ID, query).await.unwrap();
+    assert_eq!(result.items.len(), 1);
+
+    let item = &result.items[0];
+    let model = item.conversation.model.as_ref().unwrap();
+    assert_eq!(model.provider_id, "p1");
+    assert_eq!(model.model, "claude-sonnet-4-20250514");
+}
+
+#[tokio::test]
+async fn t9_7_search_does_not_leak_other_users_messages() {
+    let (svc, repo, _b) = setup().await;
+
+    let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
+    repo.insert_message(&make_message(&conv.id, "secret keyword data", 0))
+        .await
+        .unwrap();
+
+    let query = SearchMessagesQuery {
+        keyword: "secret".into(),
+        page: None,
+        page_size: None,
+    };
+    let result = svc.search_messages("other_user_id", query).await.unwrap();
+    assert!(result.items.is_empty());
+    assert_eq!(result.total, 0);
 }
 
 // ── T10: Associated conversations ──────────────────────────────────

--- a/crates/aionui-db/src/repository/conversation.rs
+++ b/crates/aionui-db/src/repository/conversation.rs
@@ -204,13 +204,26 @@ pub struct MessageRowUpdate {
 }
 
 /// A single result row from cross-conversation message search.
+/// Includes full conversation fields for building nested response.
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct MessageSearchRow {
+    // Message fields
     pub message_id: String,
-    pub conversation_id: String,
-    pub conversation_name: String,
     #[sqlx(rename = "type")]
     pub r#type: String,
     pub content: String,
     pub created_at: TimestampMs,
+    // Conversation fields
+    pub conversation_id: String,
+    pub conversation_name: String,
+    pub conversation_type: String,
+    pub conversation_extra: String,
+    pub conversation_model: Option<String>,
+    pub conversation_status: Option<String>,
+    pub conversation_source: Option<String>,
+    pub conversation_channel_chat_id: Option<String>,
+    pub conversation_pinned: bool,
+    pub conversation_pinned_at: Option<TimestampMs>,
+    pub conversation_created_at: TimestampMs,
+    pub conversation_updated_at: TimestampMs,
 }

--- a/crates/aionui-db/src/repository/sqlite_conversation.rs
+++ b/crates/aionui-db/src/repository/sqlite_conversation.rs
@@ -437,11 +437,21 @@ impl IConversationRepository for SqliteConversationRepository {
         let rows = sqlx::query_as::<_, MessageSearchRow>(
             "SELECT \
                 m.id AS message_id, \
-                m.conversation_id, \
-                c.name AS conversation_name, \
                 m.type, \
                 m.content, \
-                m.created_at \
+                m.created_at, \
+                c.id AS conversation_id, \
+                c.name AS conversation_name, \
+                c.type AS conversation_type, \
+                c.extra AS conversation_extra, \
+                c.model AS conversation_model, \
+                c.status AS conversation_status, \
+                c.source AS conversation_source, \
+                c.channel_chat_id AS conversation_channel_chat_id, \
+                c.pinned AS conversation_pinned, \
+                c.pinned_at AS conversation_pinned_at, \
+                c.created_at AS conversation_created_at, \
+                c.updated_at AS conversation_updated_at \
              FROM messages m \
              INNER JOIN conversations c ON m.conversation_id = c.id \
              WHERE c.user_id = ? AND m.content LIKE ? \


### PR DESCRIPTION
## Summary

- Expand `MessageSearchRow` to include all conversation columns (type, extra, model, status, source, pinned, timestamps)
- Restructure `MessageSearchItem` API type to return a nested `ConversationResponse` object and a `preview_text` field (plain-text extracted from JSON content)
- Add `extract_preview_text` helper that recursively collects string values from JSON message content
- Update `search_row_to_item` to build the full nested response using existing `row_to_response` infrastructure

This fixes the broken "检索会话内容" feature where the frontend expected `item.conversation.id`, `item.preview_text`, and `item.message_created_at` but the backend returned flat fields (`conversation_id`, `content`, `created_at`).

## Test plan

- [x] Unit tests for `extract_preview_text` (JSON array, nested object, plain text, malformed JSON, empty, whitespace normalization)
- [x] Unit tests for `search_row_to_item` (happy path, invalid type, invalid extra JSON)
- [x] Integration tests: field-level assertions (t9_1), JSON preview extraction (t9_5), model passthrough (t9_6), cross-user isolation (t9_7)
- [x] `cargo clippy -p aionui-db -p aionui-api-types -p aionui-conversation -- -D warnings` passes
- [x] `cargo test -p aionui-conversation` — 226 tests pass
- [ ] Manual E2E: search popover displays results with conversation name, agent icon, timestamp, preview text with highlighting, and navigation works