### PR TITLE
refactor(ai-agent): narrow protocol internals visibility (batch 1)

### DIFF
--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -89,7 +89,7 @@ pub struct AcpProtocol {
     initialize_response: Arc<RwLock<Option<InitializeResponse>>>,
 }
 
-#[allow(dead_code)]
+#[allow(dead_code)] // Full ACP method set; some methods await wiring (fork, close, list, auth, ext).
 impl AcpProtocol {
     /// Connect to a running CLI process and execute the ACP initialize handshake.
     ///

--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -89,6 +89,7 @@ pub struct AcpProtocol {
     initialize_response: Arc<RwLock<Option<InitializeResponse>>>,
 }
 
+#[allow(dead_code)]
 impl AcpProtocol {
     /// Connect to a running CLI process and execute the ACP initialize handshake.
     ///

--- a/crates/aionui-ai-agent/src/protocol/cli_detect.rs
+++ b/crates/aionui-ai-agent/src/protocol/cli_detect.rs
@@ -14,7 +14,7 @@ use crate::registry::AgentRegistry;
 ///
 /// Resolves the vendor label to the first `builtin` row in the metadata
 /// catalog, then checks that the row's spawn command is on `$PATH`.
-pub async fn detect_cli(registry: &Arc<AgentRegistry>, backend: &str) -> DetectCliResponse {
+pub(crate) async fn detect_cli(registry: &Arc<AgentRegistry>, backend: &str) -> DetectCliResponse {
     let Some(meta) = registry.find_builtin_by_backend(backend).await else {
         return DetectCliResponse { path: None };
     };
@@ -27,7 +27,7 @@ pub async fn detect_cli(registry: &Arc<AgentRegistry>, backend: &str) -> DetectC
 /// Perform a health check for an ACP backend.
 ///
 /// Checks CLI availability and measures detection latency.
-pub async fn health_check(registry: &Arc<AgentRegistry>, backend: &str) -> AcpHealthCheckResponse {
+pub(crate) async fn health_check(registry: &Arc<AgentRegistry>, backend: &str) -> AcpHealthCheckResponse {
     let start = Instant::now();
 
     let Some(meta) = registry.find_builtin_by_backend(backend).await else {
@@ -59,7 +59,7 @@ fn probe_command(meta: &AgentMetadata) -> Option<String> {
 }
 
 /// Get relevant environment variables for ACP operations.
-pub fn get_env() -> AcpEnvResponse {
+pub(crate) fn get_env() -> AcpEnvResponse {
     let keys = ["PATH", "HOME", "USER", "SHELL", "LANG", "TERM"];
     let env: HashMap<String, String> = keys
         .iter()
@@ -70,7 +70,7 @@ pub fn get_env() -> AcpEnvResponse {
 }
 
 /// Test a custom ACP agent by verifying the command exists.
-pub fn test_custom_agent(
+pub(crate) fn test_custom_agent(
     command: &str,
     _acp_args: &[String],
     _env: &HashMap<String, String>,

--- a/crates/aionui-ai-agent/src/protocol/error.rs
+++ b/crates/aionui-ai-agent/src/protocol/error.rs
@@ -6,7 +6,7 @@ use aionui_common::AppError;
 /// This error is internal to the `aionui-ai-agent` crate. External callers
 /// see it only after conversion to [`AppError`] via the `From` impl.
 #[derive(Debug, thiserror::Error)]
-#[allow(dead_code)]
+#[allow(dead_code)] // Variants constructed as error paths mature; kept for complete ACP error model.
 pub(crate) enum AcpError {
     // ── Process lifecycle ──────────────────────────────────────────
     /// CLI binary not found or not executable.
@@ -62,7 +62,7 @@ pub(crate) enum AcpError {
 
 impl AcpError {
     /// Whether the caller may retry the operation.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Will be used once retry logic is wired into the send path.
     pub(crate) fn is_retryable(&self) -> bool {
         matches!(
             self,

--- a/crates/aionui-ai-agent/src/protocol/error.rs
+++ b/crates/aionui-ai-agent/src/protocol/error.rs
@@ -6,7 +6,8 @@ use aionui_common::AppError;
 /// This error is internal to the `aionui-ai-agent` crate. External callers
 /// see it only after conversion to [`AppError`] via the `From` impl.
 #[derive(Debug, thiserror::Error)]
-pub enum AcpError {
+#[allow(dead_code)]
+pub(crate) enum AcpError {
     // ── Process lifecycle ──────────────────────────────────────────
     /// CLI binary not found or not executable.
     #[error("Failed to spawn agent process: {message}")]
@@ -61,7 +62,8 @@ pub enum AcpError {
 
 impl AcpError {
     /// Whether the caller may retry the operation.
-    pub fn is_retryable(&self) -> bool {
+    #[allow(dead_code)]
+    pub(crate) fn is_retryable(&self) -> bool {
         matches!(
             self,
             AcpError::SpawnFailed { .. }

--- a/crates/aionui-ai-agent/src/protocol/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/mod.rs
@@ -1,7 +1,4 @@
-pub mod acp;
-pub mod cli_detect;
-pub mod error;
+pub(crate) mod acp;
+pub(crate) mod cli_detect;
+pub(crate) mod error;
 pub mod events;
-
-pub use acp::AcpProtocol;
-pub use error::AcpError;


### PR DESCRIPTION
## Summary

- Restrict `protocol::acp`, `protocol::cli_detect`, and `protocol::error` submodules to `pub(crate)` visibility
- Remove unused re-exports (`AcpProtocol`, `AcpError`) from `protocol/mod.rs`
- Narrow `detect_cli`, `health_check`, `get_env`, `test_custom_agent` functions to `pub(crate)`
- Narrow `AcpError` enum and `is_retryable()` method to `pub(crate)`

This is batch 1 (zero-risk) of the visibility narrowing effort. Only internal types/functions that have no external consumers are affected. The public API surface (`AgentStreamEvent`, event data types via `protocol::events`) remains unchanged.

## Context

Follow-up to PR #161 (stream_tx removal). The goal is to use Rust's visibility system to enforce that external crates interact with `aionui-ai-agent` only through its trait interface, preventing future "creative" but incorrect coupling.

## Test plan

- [x] `cargo clippy -p aionui-ai-agent -- -D warnings` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Zero external import paths affected (verified via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)