### PR TITLE
refactor(ai-agent): narrow visibility batch 2 — types & translate internals

### DIFF
--- a/crates/aionui-ai-agent/src/manager/aionrs.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs.rs
@@ -35,7 +35,7 @@ pub struct AionrsAgentManager {
 }
 
 impl AionrsAgentManager {
-    pub async fn new(
+    pub(crate) async fn new(
         conversation_id: String,
         workspace: String,
         config_extra: AionrsResolvedConfig,

--- a/crates/aionui-ai-agent/src/protocol/events/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/events/mod.rs
@@ -18,7 +18,7 @@ pub use tool_call::{
     AcpToolCallSessionUpdateKind, AcpToolCallStatus, AcpToolCallTextBlock, AcpToolCallTextBlockType,
     AcpToolCallUpdateData, ToolCallEventData, ToolCallStatus, ToolGroupEntry,
 };
-pub use translate::{permission_request_to_event_data, session_notification_to_events};
+pub(crate) use translate::{permission_request_to_event_data, session_notification_to_events};
 
 /// Events emitted by an Agent during a message processing turn.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/aionui-ai-agent/src/protocol/events/translate.rs
+++ b/crates/aionui-ai-agent/src/protocol/events/translate.rs
@@ -18,7 +18,7 @@ use super::tool_call::{
 use super::{AgentStreamEvent, TextEventData};
 
 /// Convert an SDK [`SessionNotification`] into zero or more [`AgentStreamEvent`]s.
-pub fn session_notification_to_events(notif: &SessionNotification) -> Vec<AgentStreamEvent> {
+pub(crate) fn session_notification_to_events(notif: &SessionNotification) -> Vec<AgentStreamEvent> {
     let session_id = notif.session_id.to_string();
     let mut events = Vec::new();
 
@@ -138,7 +138,7 @@ pub fn session_notification_to_events(notif: &SessionNotification) -> Vec<AgentS
     events
 }
 
-pub fn permission_request_to_event_data(request: &RequestPermissionRequest) -> AcpPermissionEventData {
+pub(crate) fn permission_request_to_event_data(request: &RequestPermissionRequest) -> AcpPermissionEventData {
     AcpPermissionEventData::Request(AcpPermissionRequestData {
         session_id: request.session_id.to_string(),
         tool_call: map_permission_tool_call(&request.tool_call),

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -37,14 +37,14 @@ pub struct BuildTaskOptions {
 
 /// Provider-specific compat overrides resolved in the factory.
 #[derive(Debug, Clone, Default)]
-pub struct AionrsCompatOverrides {
+pub(crate) struct AionrsCompatOverrides {
     pub max_tokens_field: Option<String>,
     pub api_path: Option<String>,
 }
 
 /// Fully resolved Aionrs configuration passed to the agent manager.
 #[derive(Debug, Clone)]
-pub struct AionrsResolvedConfig {
+pub(crate) struct AionrsResolvedConfig {
     /// LLM provider name (anthropic, openai, bedrock, vertex).
     pub provider: String,
     /// Decrypted API key.


### PR DESCRIPTION
## Summary
- `AionrsResolvedConfig` / `AionrsCompatOverrides` in `types.rs` → `pub(crate)`
- `session_notification_to_events` / `permission_request_to_event_data` in `translate.rs` → `pub(crate)`
- Re-export in `events/mod.rs` → `pub(crate) use`
- `AionrsAgentManager::new` → `pub(crate)` (cascade fix for private-interfaces lint)

All targets verified to have zero references outside `aionui-ai-agent`. Continues the visibility narrowing plan (mnemo #1179, batch 2).

## Verification
- `cargo clippy -p aionui-ai-agent -- -D warnings` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

## Test plan
- [ ] CI passes (clippy, fmt, tests)
- [ ] No downstream compile errors (confirmed via workspace clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)