### PR TITLE
fix(test): repair broken E2E tests for message search and team session

### DIFF
--- a/crates/aionui-app/tests/common/mod.rs
+++ b/crates/aionui-app/tests/common/mod.rs
@@ -8,6 +8,7 @@ use tower::ServiceExt;
 use wiremock::MockServer;
 
 use aionui_app::{AppServices, build_module_states, create_router, create_router_with_states};
+use aionui_ai_agent::{AgentInstance, IMockAgent, IAgentTask, WorkerTaskManagerImpl};
 use aionui_extension::{ExternalPathsManager, SkillPaths, SkillRouterState};
 use aionui_file::FileService;
 use aionui_system::VersionCheckService;
@@ -94,6 +95,74 @@ pub async fn build_app_with_mock_version(
     let router = create_router_with_states(&services, states);
     (router, services)
 }
+
+/// Build app with a mock worker task manager that returns noop agents.
+///
+/// Use for tests that exercise session/warmup paths (team ensure_session,
+/// send_message) where spawning a real CLI process is not feasible.
+pub async fn build_app_with_mock_agents() -> (axum::Router, AppServices) {
+    let db = aionui_db::init_database_memory().await.unwrap();
+    let factory: std::sync::Arc<
+        dyn Fn(
+                aionui_ai_agent::types::BuildTaskOptions,
+            ) -> futures_util::future::BoxFuture<'static, Result<AgentInstance, aionui_common::AppError>>
+            + Send
+            + Sync,
+    > = std::sync::Arc::new(|opts| {
+        Box::pin(async move {
+            Ok(AgentInstance::Mock(std::sync::Arc::new(NoopMockAgent {
+                conversation_id: opts.conversation_id,
+            })))
+        })
+    });
+    let wtm: std::sync::Arc<dyn aionui_ai_agent::IWorkerTaskManager> =
+        std::sync::Arc::new(WorkerTaskManagerImpl::new(factory));
+    let services = AppServices::from_database(db).await.unwrap().with_worker_task_manager(wtm);
+    let router = create_router(&services).await;
+    (router, services)
+}
+
+struct NoopMockAgent {
+    conversation_id: String,
+}
+
+#[async_trait::async_trait]
+impl IAgentTask for NoopMockAgent {
+    fn agent_type(&self) -> aionui_common::AgentType {
+        aionui_common::AgentType::Acp
+    }
+    fn conversation_id(&self) -> &str {
+        &self.conversation_id
+    }
+    fn workspace(&self) -> &str {
+        "/tmp/test"
+    }
+    fn status(&self) -> Option<aionui_common::ConversationStatus> {
+        None
+    }
+    fn last_activity_at(&self) -> aionui_common::TimestampMs {
+        aionui_common::now_ms()
+    }
+    fn subscribe(&self) -> tokio::sync::broadcast::Receiver<aionui_ai_agent::AgentStreamEvent> {
+        let (tx, _) = tokio::sync::broadcast::channel(1);
+        tx.subscribe()
+    }
+    async fn send_message(
+        &self,
+        _data: aionui_ai_agent::types::SendMessageData,
+    ) -> Result<(), aionui_common::AppError> {
+        Ok(())
+    }
+    async fn stop(&self) -> Result<(), aionui_common::AppError> {
+        Ok(())
+    }
+    fn kill(&self, _reason: Option<aionui_common::AgentKillReason>) -> Result<(), aionui_common::AppError> {
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl IMockAgent for NoopMockAgent {}
 
 pub async fn body_json(resp: axum::response::Response) -> serde_json::Value {
     let bytes = resp.into_body().collect().await.unwrap().to_bytes();

--- a/crates/aionui-app/tests/message_e2e.rs
+++ b/crates/aionui-app/tests/message_e2e.rs
@@ -333,7 +333,7 @@ async fn t9_1_search_keyword_match() {
     let json = body_json(resp).await;
     let items = json["data"]["items"].as_array().unwrap();
     assert_eq!(items.len(), 1);
-    assert_eq!(items[0]["conversation_name"], "Search Conv");
+    assert_eq!(items[0]["conversation"]["name"], "Search Conv");
 }
 
 #[tokio::test]

--- a/crates/aionui-app/tests/team_e2e.rs
+++ b/crates/aionui-app/tests/team_e2e.rs
@@ -4,7 +4,7 @@ use axum::http::StatusCode;
 use serde_json::json;
 use tower::ServiceExt;
 
-use common::{body_json, build_app, delete_with_token, get_with_token, json_with_token, setup_and_login};
+use common::{body_json, build_app, build_app_with_mock_agents, delete_with_token, get_with_token, json_with_token, setup_and_login};
 
 fn two_agent_body() -> serde_json::Value {
     json!({
@@ -522,7 +522,7 @@ async fn an3_rename_nonexistent_agent() {
 // ES-1: Ensure session
 #[tokio::test]
 async fn es1_ensure_session() {
-    let (mut app, services) = build_app().await;
+    let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
     let data = create_team(&mut app, &token, &csrf).await;
@@ -542,7 +542,7 @@ async fn es1_ensure_session() {
 // ES-2: Ensure session is idempotent
 #[tokio::test]
 async fn es2_ensure_session_idempotent() {
-    let (mut app, services) = build_app().await;
+    let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
     let data = create_team(&mut app, &token, &csrf).await;
@@ -583,7 +583,7 @@ async fn es3_ensure_session_nonexistent() {
 // SS-1: Stop session
 #[tokio::test]
 async fn ss1_stop_session() {
-    let (mut app, services) = build_app().await;
+    let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
     let data = create_team(&mut app, &token, &csrf).await;
@@ -624,7 +624,7 @@ async fn ss3_stop_session_noop() {
 // SM-1: Send message with active session
 #[tokio::test]
 async fn sm1_send_message_with_session() {
-    let (mut app, services) = build_app().await;
+    let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
     let data = create_team(&mut app, &token, &csrf).await;
@@ -691,7 +691,7 @@ async fn sm5_send_message_missing_content() {
 // SA-1: Send message to specific agent
 #[tokio::test]
 async fn sa1_send_message_to_agent() {
-    let (mut app, services) = build_app().await;
+    let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
     let data = create_team(&mut app, &token, &csrf).await;
@@ -726,7 +726,7 @@ async fn sa1_send_message_to_agent() {
 // Full CRUD lifecycle
 #[tokio::test]
 async fn full_team_lifecycle() {
-    let (mut app, services) = build_app().await;
+    let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
     // Create


### PR DESCRIPTION
## Summary

- **message_e2e**: 修复搜索断言，使用嵌套的 `conversation.name` 字段（对应 `MessageSearchItem` 在 4d5812f 中的结构变更）
- **team_e2e**: 注入 mock worker task manager，避免 session 相关测试尝试在测试环境中启动真实 CLI 进程
- **common**: 新增 `build_app_with_mock_agents()` 辅助函数和 `NoopMockAgent` 实现

## Test plan

- [x] `cargo test -p aionui-app` 全量 E2E 测试通过
- [ ] CI 全量 `cargo test --workspace` 通过