### PR TITLE
chore: pin Rust toolchain to 1.95.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- Add `rust-toolchain.toml` to pin project Rust version to 1.95.0
- Ensures all contributors use the same toolchain with `rustfmt` and `clippy` components

## Test plan

- [ ] `rustup show` confirms 1.95.0 is active when entering the project directory
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --workspace` passes