### PR TITLE
refactor(ai-agent): narrow capability module to pub(crate) (batch 3)

### DIFF
--- a/crates/aionui-ai-agent/src/capability/cli_process.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process.rs
@@ -38,6 +38,7 @@ pub struct CliAgentProcess {
     /// OS-level process ID.
     pid: u32,
     /// Broadcast sender for parsed stdout events (legacy mode only).
+    #[allow(dead_code)] // Part of the complete CliProcess API; used in legacy mode via subscribe()
     event_tx: broadcast::Sender<serde_json::Value>,
     /// Watch channel that transitions from `None` → `Some(ExitStatus)` on exit.
     exit_rx: watch::Receiver<Option<ExitStatus>>,
@@ -45,6 +46,7 @@ pub struct CliAgentProcess {
     /// Take this via [`take_initial_receiver`] to guarantee no events are lost.
     initial_rx: InitialReceiver,
     /// Stderr ring buffer for diagnostics.
+    #[allow(dead_code)] // Read via take_stderr(); part of diagnostics API for startup crash reporting
     stderr_buffer: Arc<Mutex<String>>,
     /// Handle to the stdout reader task (legacy mode, for cleanup).
     _stdout_handle: Option<Arc<tokio::task::JoinHandle<()>>>,
@@ -382,6 +384,7 @@ impl CliAgentProcess {
     ///
     /// Returns a broadcast receiver that yields raw `serde_json::Value` events
     /// as they are parsed from the subprocess stdout.
+    #[allow(dead_code)] // Complete CliProcess API for legacy-mode event subscription
     pub fn subscribe(&self) -> broadcast::Receiver<serde_json::Value> {
         self.event_tx.subscribe()
     }
@@ -435,21 +438,25 @@ impl CliAgentProcess {
     }
 
     /// Check whether the subprocess is still running.
+    #[allow(dead_code)] // Complete CliProcess lifecycle API
     pub fn is_running(&self) -> bool {
         self.exit_rx.borrow().is_none()
     }
 
     /// Get the exit status if the process has exited.
+    #[allow(dead_code)] // Complete CliProcess lifecycle API
     pub fn exit_status(&self) -> Option<ExitStatus> {
         *self.exit_rx.borrow()
     }
 
     /// Get the OS process ID.
+    #[allow(dead_code)] // Complete CliProcess lifecycle API
     pub fn pid(&self) -> u32 {
         self.pid
     }
 
     /// Wait for the process to exit (blocks until exit or cancellation).
+    #[allow(dead_code)] // Complete CliProcess lifecycle API
     pub async fn wait_for_exit(&self) -> Option<ExitStatus> {
         let mut rx = self.exit_rx.clone();
         // If already exited, return immediately
@@ -466,6 +473,7 @@ impl CliAgentProcess {
     /// Returns the last [`STDERR_BUFFER_MAX`] bytes of stderr output.
     /// Used for error diagnostics in `AcpError::StartupCrash` and
     /// `AcpError::Disconnected`.
+    #[allow(dead_code)] // Diagnostics API for startup crash and disconnect error reporting
     pub async fn take_stderr(&self) -> String {
         let mut buf = self.stderr_buffer.lock().await;
         std::mem::take(&mut *buf)

--- a/crates/aionui-ai-agent/src/capability/mod.rs
+++ b/crates/aionui-ai-agent/src/capability/mod.rs
@@ -4,9 +4,9 @@
 //! skill indexing, backend output/protocol sinks, first-message injection,
 //! solo-team guide prompts) that any agent implementation can compose.
 
-pub mod backend_output_sink;
-pub mod backend_protocol_sink;
-pub mod cli_process;
-pub mod first_message_injector;
-pub mod skill_manager;
-pub mod team_guide_prompt;
+pub(crate) mod backend_output_sink;
+pub(crate) mod backend_protocol_sink;
+pub(crate) mod cli_process;
+pub(crate) mod first_message_injector;
+pub(crate) mod skill_manager;
+pub(crate) mod team_guide_prompt;

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -1,6 +1,6 @@
 //! AI agent lifecycle, worker task dispatch, and skill management.
 pub mod agent_task;
-pub mod capability;
+pub(crate) mod capability;
 pub mod factory;
 pub mod idle_scanner;
 pub mod manager;
@@ -19,7 +19,11 @@ pub use aionui_api_types::{
     AcpBuildExtra, AcpModelInfo, AcpSessionConfigOption, AionrsBuildExtra, OpenClawBuildExtra, OpenClawGatewayConfig,
     RemoteBuildExtra, SlashCommandItem,
 };
-pub use capability::skill_manager::AcpSkillManager;
+pub use capability::skill_manager::{
+    AcpSkillManager, SkillDefinition, SkillIndex, build_skills_index_text, build_system_instructions,
+    build_system_instructions_with_skills_index, detect_skill_load_request, prepare_first_message,
+    prepare_first_message_with_skills_index,
+};
 pub use factory::{AgentFactoryDeps, build_agent_factory};
 pub use idle_scanner::start_idle_scanner;
 pub use manager::remote::{RemoteAgentRouterState, RemoteAgentService, remote_agent_routes};

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -75,7 +75,7 @@ async fn make_mock_agent(script: &str, backend: &str) -> (Arc<AcpAgentManager>, 
         tmp_skills.path(),
         tmp_skills.path(),
     ));
-    let skill_manager = aionui_ai_agent::capability::skill_manager::AcpSkillManager::new(skill_paths);
+    let skill_manager = aionui_ai_agent::AcpSkillManager::new(skill_paths);
 
     let db = init_database_memory().await.unwrap();
     let repo = Arc::new(SqliteAgentMetadataRepository::new(db.pool().clone()));

--- a/crates/aionui-ai-agent/tests/agent_types_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_types_integration.rs
@@ -9,11 +9,11 @@
 
 use std::sync::Arc;
 
-use aionui_ai_agent::capability::skill_manager::{SkillIndex, build_system_instructions_with_skills_index};
 use aionui_ai_agent::manager::aionrs::AionrsAgentManager;
 use aionui_ai_agent::task_manager::AgentFactory;
 use aionui_ai_agent::types::{AionrsResolvedConfig, BuildTaskOptions, SendMessageData};
 use aionui_ai_agent::*;
+use aionui_ai_agent::{SkillIndex, build_system_instructions_with_skills_index};
 use aionui_common::{AgentKillReason, AgentType, ConversationStatus, ProviderWithModel, TimestampMs, now_ms};
 use serde_json::json;
 use std::sync::atomic::{AtomicI64, Ordering};

--- a/crates/aionui-ai-agent/tests/factory_provider_integration.rs
+++ b/crates/aionui-ai-agent/tests/factory_provider_integration.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use aionui_ai_agent::AcpSessionSyncService;
-use aionui_ai_agent::capability::skill_manager::AcpSkillManager;
+use aionui_ai_agent::AcpSkillManager;
 use aionui_ai_agent::factory::{AgentFactoryDeps, build_agent_factory};
 use aionui_ai_agent::registry::AgentRegistry;
 use aionui_ai_agent::types::BuildTaskOptions;

--- a/crates/aionui-ai-agent/tests/skill_manager_integration.rs
+++ b/crates/aionui-ai-agent/tests/skill_manager_integration.rs
@@ -11,7 +11,7 @@
 use std::fs;
 use std::sync::{Arc, Mutex};
 
-use aionui_ai_agent::capability::skill_manager::{
+use aionui_ai_agent::{
     AcpSkillManager, build_skills_index_text, build_system_instructions, detect_skill_load_request,
     prepare_first_message, prepare_first_message_with_skills_index,
 };
@@ -189,11 +189,11 @@ async fn discover_skills_respects_exclude_builtin() {
 #[test]
 fn build_index_text_contains_load_protocol() {
     let skills = vec![
-        aionui_ai_agent::capability::skill_manager::SkillIndex {
+        aionui_ai_agent::SkillIndex {
             name: "security".into(),
             description: "Security review".into(),
         },
-        aionui_ai_agent::capability::skill_manager::SkillIndex {
+        aionui_ai_agent::SkillIndex {
             name: "tdd".into(),
             description: "Test-driven development".into(),
         },
@@ -243,7 +243,7 @@ fn detect_load_skill_handles_whitespace() {
 
 #[test]
 fn system_instructions_with_loaded_skills() {
-    let skills = vec![aionui_ai_agent::capability::skill_manager::SkillDefinition {
+    let skills = vec![aionui_ai_agent::SkillDefinition {
         name: "helper".into(),
         description: "A helper".into(),
         location: std::path::PathBuf::new(),
@@ -260,7 +260,7 @@ fn system_instructions_with_loaded_skills() {
 
 #[test]
 fn first_message_with_skills_index_for_acp() {
-    let skills = vec![aionui_ai_agent::capability::skill_manager::SkillIndex {
+    let skills = vec![aionui_ai_agent::SkillIndex {
         name: "review".into(),
         description: "Code review".into(),
     }];
@@ -274,7 +274,7 @@ fn first_message_with_skills_index_for_acp() {
 
 #[test]
 fn first_message_with_full_skills_for_gemini() {
-    let skills = vec![aionui_ai_agent::capability::skill_manager::SkillDefinition {
+    let skills = vec![aionui_ai_agent::SkillDefinition {
         name: "debug".into(),
         description: "Debug".into(),
         location: std::path::PathBuf::new(),

--- a/crates/aionui-app/tests/common/mod.rs
+++ b/crates/aionui-app/tests/common/mod.rs
@@ -7,8 +7,8 @@ use http_body_util::BodyExt;
 use tower::ServiceExt;
 use wiremock::MockServer;
 
+use aionui_ai_agent::{AgentInstance, IAgentTask, IMockAgent, WorkerTaskManagerImpl};
 use aionui_app::{AppServices, build_module_states, create_router, create_router_with_states};
-use aionui_ai_agent::{AgentInstance, IMockAgent, IAgentTask, WorkerTaskManagerImpl};
 use aionui_extension::{ExternalPathsManager, SkillPaths, SkillRouterState};
 use aionui_file::FileService;
 use aionui_system::VersionCheckService;
@@ -117,7 +117,10 @@ pub async fn build_app_with_mock_agents() -> (axum::Router, AppServices) {
     });
     let wtm: std::sync::Arc<dyn aionui_ai_agent::IWorkerTaskManager> =
         std::sync::Arc::new(WorkerTaskManagerImpl::new(factory));
-    let services = AppServices::from_database(db).await.unwrap().with_worker_task_manager(wtm);
+    let services = AppServices::from_database(db)
+        .await
+        .unwrap()
+        .with_worker_task_manager(wtm);
     let router = create_router(&services).await;
     (router, services)
 }

--- a/crates/aionui-app/tests/team_e2e.rs
+++ b/crates/aionui-app/tests/team_e2e.rs
@@ -4,7 +4,10 @@ use axum::http::StatusCode;
 use serde_json::json;
 use tower::ServiceExt;
 
-use common::{body_json, build_app, build_app_with_mock_agents, delete_with_token, get_with_token, json_with_token, setup_and_login};
+use common::{
+    body_json, build_app, build_app_with_mock_agents, delete_with_token, get_with_token, json_with_token,
+    setup_and_login,
+};
 
 fn two_agent_body() -> serde_json::Value {
     json!({


### PR DESCRIPTION
## Summary
- `capability` module and all submodules narrowed to `pub(crate)`
- Skill manager public API re-exported from crate root (`AcpSkillManager`, `SkillDefinition`, `SkillIndex`, helper functions)
- Integration tests updated to use crate root imports instead of deep `capability::skill_manager::` paths
- `#[allow(dead_code)]` with rationale comments added to `CliProcess` fields/methods that become unused within crate boundary (complete subprocess lifecycle API, not yet wired to all code paths)

Continues visibility narrowing plan (mnemo #1179/#1180, batch 3). Zero external crate impact confirmed via `cargo clippy --workspace`.

## Verification
- `cargo clippy -p aionui-ai-agent -- -D warnings` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

## Test plan
- [ ] CI passes (clippy, fmt, tests)
- [ ] No downstream compile errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)