### PR TITLE
fix(db): normalize legacy camelCase JSON data to snake_case

### DIFF
--- a/crates/aionui-db/migrations/009_teams_agents_normalize.sql
+++ b/crates/aionui-db/migrations/009_teams_agents_normalize.sql
@@ -1,0 +1,40 @@
+-- Migration 009: Normalize teams.agents JSON from camelCase to snake_case
+--
+-- Old TypeScript backend stored team agents with camelCase field names:
+--   slotId, conversationId, agentType, agentName, conversationType, cliPath
+-- New Rust backend expects snake_case:
+--   slot_id, conversation_id, backend, name, conversation_type, cli_path
+--
+-- This migration converts all existing agents JSON in-place using SQLite JSON
+-- functions. COALESCE handles both old (camelCase) and already-new (snake_case)
+-- data, making the migration idempotent.
+
+-- Step 1: Add version tracking column for future migrations
+ALTER TABLE teams ADD COLUMN agents_version TEXT NOT NULL DEFAULT '1.0.0';
+
+-- Step 2: Transform non-empty agents arrays
+UPDATE teams
+SET agents = (
+    SELECT json_group_array(
+        json_object(
+            'slot_id',           COALESCE(json_extract(j.value, '$.slotId'), json_extract(j.value, '$.slot_id'), ''),
+            'name',              COALESCE(json_extract(j.value, '$.agentName'), json_extract(j.value, '$.name'), ''),
+            'role',              CASE json_extract(j.value, '$.role')
+                                   WHEN 'leader' THEN 'lead'
+                                   ELSE COALESCE(json_extract(j.value, '$.role'), 'teammate')
+                                 END,
+            'conversation_id',   COALESCE(json_extract(j.value, '$.conversationId'), json_extract(j.value, '$.conversation_id'), ''),
+            'backend',           COALESCE(json_extract(j.value, '$.agentType'), json_extract(j.value, '$.backend'), ''),
+            'model',             COALESCE(json_extract(j.value, '$.model'), ''),
+            'status',            json_extract(j.value, '$.status'),
+            'conversation_type', COALESCE(json_extract(j.value, '$.conversationType'), json_extract(j.value, '$.conversation_type')),
+            'cli_path',          COALESCE(json_extract(j.value, '$.cliPath'), json_extract(j.value, '$.cli_path')),
+            'custom_agent_id',   COALESCE(json_extract(j.value, '$.customAgentId'), json_extract(j.value, '$.custom_agent_id'))
+        )
+    ) FROM json_each(teams.agents) AS j
+),
+agents_version = '1.0.1'
+WHERE agents != '[]';
+
+-- Step 3: Mark empty arrays as already compliant
+UPDATE teams SET agents_version = '1.0.1' WHERE agents = '[]';

--- a/crates/aionui-db/migrations/010_conversations_extra_normalize.sql
+++ b/crates/aionui-db/migrations/010_conversations_extra_normalize.sql
@@ -1,0 +1,95 @@
+-- Migration 010: Normalize conversations.extra JSON keys from camelCase to snake_case
+--
+-- Old TypeScript backend stored conversation metadata with camelCase keys:
+--   agentName, cliPath, currentModelId, sessionMode, customWorkspace,
+--   defaultFiles, cachedConfigOptions, loadedSkills, lastContextLimit,
+--   lastTokenUsage, acpSessionConversationId, acpSessionId, acpSessionUpdatedAt
+--
+-- New Rust backend uses snake_case. This migration renames keys that are simple
+-- renames (same data structure, just different key name).
+--
+-- NOT migrated here (structural changes needed, handled by code-layer aliases):
+--   - teamMcpStdioConfig (structure changed: old=spawn config, new=TCP config)
+--   - cachedConfigOptions, loadedSkills, lastTokenUsage (runtime caches, stale)
+
+-- Rename agentName → agent_name (where agentName exists and agent_name doesn't)
+UPDATE conversations
+SET extra = json_set(json_remove(extra, '$.agentName'), '$.agent_name', json_extract(extra, '$.agentName'))
+WHERE json_extract(extra, '$.agentName') IS NOT NULL
+  AND json_extract(extra, '$.agent_name') IS NULL;
+
+-- Rename cliPath → cli_path
+UPDATE conversations
+SET extra = json_set(json_remove(extra, '$.cliPath'), '$.cli_path', json_extract(extra, '$.cliPath'))
+WHERE json_extract(extra, '$.cliPath') IS NOT NULL
+  AND json_extract(extra, '$.cli_path') IS NULL;
+
+-- Rename currentModelId → current_model_id
+UPDATE conversations
+SET extra = json_set(json_remove(extra, '$.currentModelId'), '$.current_model_id', json_extract(extra, '$.currentModelId'))
+WHERE json_extract(extra, '$.currentModelId') IS NOT NULL
+  AND json_extract(extra, '$.current_model_id') IS NULL;
+
+-- Rename sessionMode → session_mode
+UPDATE conversations
+SET extra = json_set(json_remove(extra, '$.sessionMode'), '$.session_mode', json_extract(extra, '$.sessionMode'))
+WHERE json_extract(extra, '$.sessionMode') IS NOT NULL
+  AND json_extract(extra, '$.session_mode') IS NULL;
+
+-- Rename customWorkspace → custom_workspace
+UPDATE conversations
+SET extra = json_set(json_remove(extra, '$.customWorkspace'), '$.custom_workspace', json_extract(extra, '$.customWorkspace'))
+WHERE json_extract(extra, '$.customWorkspace') IS NOT NULL
+  AND json_extract(extra, '$.custom_workspace') IS NULL;
+
+-- Rename defaultFiles → default_files
+UPDATE conversations
+SET extra = json_set(json_remove(extra, '$.defaultFiles'), '$.default_files', json_extract(extra, '$.defaultFiles'))
+WHERE json_extract(extra, '$.defaultFiles') IS NOT NULL
+  AND json_extract(extra, '$.default_files') IS NULL;
+
+-- Rename acpSessionConversationId → acp_session_conversation_id
+UPDATE conversations
+SET extra = json_set(json_remove(extra, '$.acpSessionConversationId'), '$.acp_session_conversation_id', json_extract(extra, '$.acpSessionConversationId'))
+WHERE json_extract(extra, '$.acpSessionConversationId') IS NOT NULL;
+
+-- Rename acpSessionId → acp_session_id
+UPDATE conversations
+SET extra = json_set(json_remove(extra, '$.acpSessionId'), '$.acp_session_id', json_extract(extra, '$.acpSessionId'))
+WHERE json_extract(extra, '$.acpSessionId') IS NOT NULL;
+
+-- Rename acpSessionUpdatedAt → acp_session_updated_at
+UPDATE conversations
+SET extra = json_set(json_remove(extra, '$.acpSessionUpdatedAt'), '$.acp_session_updated_at', json_extract(extra, '$.acpSessionUpdatedAt'))
+WHERE json_extract(extra, '$.acpSessionUpdatedAt') IS NOT NULL;
+
+-- Normalize teamId → ensure both teamId and team_id exist for transition period
+-- (Guide server reads teamId, frontend reads team_id; keep both until code is unified)
+UPDATE conversations
+SET extra = json_set(extra, '$.team_id', json_extract(extra, '$.teamId'))
+WHERE json_extract(extra, '$.teamId') IS NOT NULL
+  AND json_extract(extra, '$.team_id') IS NULL;
+
+-- Rename customAgentId → custom_agent_id
+UPDATE conversations
+SET extra = json_set(json_remove(extra, '$.customAgentId'), '$.custom_agent_id', json_extract(extra, '$.customAgentId'))
+WHERE json_extract(extra, '$.customAgentId') IS NOT NULL
+  AND json_extract(extra, '$.custom_agent_id') IS NULL;
+
+-- Clean up stale runtime caches that are no longer meaningful after upgrade
+-- (These are session-specific caches that won't be valid after a restart anyway)
+UPDATE conversations
+SET extra = json_remove(extra, '$.cachedConfigOptions', '$.loadedSkills', '$.lastContextLimit', '$.lastTokenUsage')
+WHERE json_extract(extra, '$.cachedConfigOptions') IS NOT NULL
+   OR json_extract(extra, '$.loadedSkills') IS NOT NULL;
+
+-- Rename teamMcpStdioConfig → mark as legacy (don't remove, code handles gracefully)
+-- The old format {command, args, env} is structurally incompatible with new {binary_path, port, token}
+-- Team session restore already handles missing/invalid config by creating a new session
+UPDATE conversations
+SET extra = json_set(
+    json_remove(extra, '$.teamMcpStdioConfig'),
+    '$.legacy_team_mcp_stdio_config', json_extract(extra, '$.teamMcpStdioConfig')
+)
+WHERE json_extract(extra, '$.teamMcpStdioConfig') IS NOT NULL
+  AND json_extract(extra, '$.team_mcp_stdio_config') IS NULL;

--- a/crates/aionui-db/src/models/team.rs
+++ b/crates/aionui-db/src/models/team.rs
@@ -15,6 +15,7 @@ pub struct TeamRow {
     pub agents: String,
     pub lead_agent_id: Option<String>,
     pub session_mode: Option<String>,
+    pub agents_version: String,
     pub created_at: TimestampMs,
     pub updated_at: TimestampMs,
 }
@@ -78,6 +79,7 @@ mod tests {
             agents: "[]".into(),
             lead_agent_id: None,
             session_mode: None,
+            agents_version: "1.0.1".into(),
             created_at: 0,
             updated_at: 0,
         };

--- a/crates/aionui-db/src/repository/sqlite_team.rs
+++ b/crates/aionui-db/src/repository/sqlite_team.rs
@@ -23,8 +23,8 @@ impl ITeamRepository for SqliteTeamRepository {
 
     async fn create_team(&self, row: &TeamRow) -> Result<(), DbError> {
         sqlx::query(
-            "INSERT INTO teams (id, user_id, name, workspace, workspace_mode, agents, lead_agent_id, session_mode, created_at, updated_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO teams (id, user_id, name, workspace, workspace_mode, agents, lead_agent_id, session_mode, agents_version, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&row.id)
         .bind(&row.user_id)
@@ -34,6 +34,7 @@ impl ITeamRepository for SqliteTeamRepository {
         .bind(&row.agents)
         .bind(&row.lead_agent_id)
         .bind(&row.session_mode)
+        .bind(&row.agents_version)
         .bind(row.created_at)
         .bind(row.updated_at)
         .execute(&self.pool)

--- a/crates/aionui-db/tests/team_repository.rs
+++ b/crates/aionui-db/tests/team_repository.rs
@@ -31,9 +31,12 @@ fn make_team(id: &str, name: &str) -> TeamRow {
         name: name.into(),
         workspace: String::new(),
         workspace_mode: "shared".into(),
-        agents: r#"[{"slotId":"a1","name":"Lead","role":"lead"}]"#.into(),
+        agents:
+            r#"[{"slot_id":"a1","name":"Lead","role":"lead","conversation_id":"conv-1","backend":"claude","model":""}]"#
+                .into(),
         lead_agent_id: Some("a1".into()),
         session_mode: None,
+        agents_version: "1.0.1".into(),
         created_at: now,
         updated_at: now,
     }

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -224,6 +224,7 @@ impl TeamSessionService {
             agents: agents_json,
             lead_agent_id: lead_agent_id.clone(),
             session_mode: None,
+            agents_version: "1.0.1".into(),
             created_at: now,
             updated_at: now,
         };
@@ -259,8 +260,17 @@ impl TeamSessionService {
         let rows = self.repo.list_teams().await?;
         let mut teams = Vec::with_capacity(rows.len());
         for row in &rows {
-            let team = Team::from_row(row)?;
-            teams.push(self.build_team_response(&team).await?);
+            match Team::from_row(row) {
+                Ok(team) => match self.build_team_response(&team).await {
+                    Ok(resp) => teams.push(resp),
+                    Err(e) => {
+                        tracing::warn!(team_id = %row.id, error = %e, "skipping team with build error");
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(team_id = %row.id, error = %e, "skipping team with invalid agents JSON");
+                }
+            }
         }
         Ok(teams)
     }

--- a/crates/aionui-team/src/types.rs
+++ b/crates/aionui-team/src/types.rs
@@ -87,23 +87,24 @@ impl TeammateStatus {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TeamAgent {
-    #[serde(default)]
+    #[serde(default, alias = "slotId")]
     pub slot_id: String,
     #[serde(alias = "agentName")]
     pub name: String,
     pub role: TeammateRole,
+    #[serde(alias = "conversationId")]
     pub conversation_id: String,
     #[serde(alias = "agentType")]
     pub backend: String,
     #[serde(default)]
     pub model: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "customAgentId")]
     pub custom_agent_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<TeammateStatus>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "conversationType")]
     pub conversation_type: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "cliPath")]
     pub cli_path: Option<String>,
 }
 
@@ -616,6 +617,7 @@ mod tests {
             agents: agents_json,
             lead_agent_id: Some("s1".into()),
             session_mode: None,
+            agents_version: "1.0.1".into(),
             created_at: 1000,
             updated_at: 2000,
         };
@@ -668,10 +670,32 @@ mod tests {
             agents: "not-json".into(),
             lead_agent_id: None,
             session_mode: None,
+            agents_version: "1.0.1".into(),
             created_at: 0,
             updated_at: 0,
         };
         assert!(Team::from_row(&row).is_err());
+    }
+
+    #[test]
+    fn team_agent_deserialize_old_camelcase_format() {
+        let raw = serde_json::json!({
+            "slotId": "slot-abc",
+            "conversationId": "conv-123",
+            "role": "leader",
+            "status": "pending",
+            "agentType": "claude",
+            "agentName": "Leader",
+            "conversationType": "acp",
+            "cliPath": "claude"
+        });
+        let agent: TeamAgent = serde_json::from_value(raw).unwrap();
+        assert_eq!(agent.slot_id, "slot-abc");
+        assert_eq!(agent.conversation_id, "conv-123");
+        assert_eq!(agent.name, "Leader");
+        assert_eq!(agent.backend, "claude");
+        assert_eq!(agent.conversation_type.as_deref(), Some("acp"));
+        assert_eq!(agent.cli_path.as_deref(), Some("claude"));
     }
 
     // -- MailboxMessage from_row ----------------------------------------------


### PR DESCRIPTION
## Summary

- **Migration 009**: Normalizes `teams.agents` JSON from old camelCase format (`agentName`, `conversationId`, `agentType`) to snake_case (`name`, `conversation_id`, `backend`). Adds `agents_version` column for tracking.
- **Migration 010**: Normalizes `conversations.extra` JSON keys (10+ camelCase → snake_case), cleans stale runtime caches, moves incompatible `teamMcpStdioConfig` to legacy key.
- **Graceful degradation**: `list_teams()` now skips rows with invalid JSON instead of returning 500 for all teams.
- **Serde aliases**: `TeamAgent` struct accepts both old camelCase and new snake_case keys as a safety net.

## Problem

Old TypeScript backend stored JSON fields in camelCase. New Rust backend expects snake_case → `serde_json::from_str()` fails → `GET /api/teams` returns HTTP 500 when **any** old team data exists, making the entire team list invisible in the frontend.

## Test plan

- [x] All 311 aionui-team tests pass
- [x] All 20 aionui-db tests pass
- [x] Tested migrations on real production data copy
- [x] Verified camelCase deserialization with dedicated test
- [x] Confirmed frontend team list renders correctly after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)