### PR TITLE
refactor(ai-agent): break event-tracker self-loop (Stage 3 / M3)

### DIFF
--- a/crates/aionui-ai-agent/src/factory/mod.rs
+++ b/crates/aionui-ai-agent/src/factory/mod.rs
@@ -171,11 +171,11 @@ async fn build_agent(deps: Arc<AgentFactoryDeps>, options: BuildTaskOptions) -> 
             let skill_mgr = deps.skill_manager.clone();
             let catalog_tx = deps.agent_registry.catalog_sender();
 
-            let (agent, domain_rx) = AcpAgentManager::new(params, skill_mgr, &catalog_tx).await?;
+            let (agent, domain_rx, notification_rx) = AcpAgentManager::new(params, skill_mgr, &catalog_tx).await?;
 
             let arc = Arc::new(agent);
             arc.start_permission_handler();
-            arc.start_session_event_tracker();
+            arc.start_session_event_tracker(notification_rx);
             CatalogForwarder::spawn(
                 arc.agent_metadata_id().to_owned(),
                 crate::IAgentTask::subscribe(arc.as_ref()),

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -9,7 +9,8 @@ use crate::shared_kernel::{ModeId, ModelId, SessionId as DomainSessionId};
 use crate::types::SendMessageData;
 use agent_client_protocol::schema::{
     AgentCapabilities, AvailableCommand, CancelNotification, SessionConfigOption, SessionId, SessionModeState,
-    SessionModelState, SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest, UsageUpdate,
+    SessionModelState, SessionNotification, SetSessionConfigOptionRequest, SetSessionModeRequest,
+    SetSessionModelRequest, UsageUpdate,
 };
 use aionui_api_types::{AgentHandshake, SlashCommandItem};
 use aionui_common::{
@@ -253,7 +254,14 @@ impl AcpAgentManager {
         params: Arc<AcpSessionParams>,
         skill_manager: Arc<AcpSkillManager>,
         catalog_tx: &CatalogSender,
-    ) -> Result<(Self, mpsc::Receiver<AcpSessionEvent>), AppError> {
+    ) -> Result<
+        (
+            Self,
+            mpsc::Receiver<AcpSessionEvent>,
+            mpsc::Receiver<SessionNotification>,
+        ),
+        AppError,
+    > {
         let process = CliAgentProcess::spawn_for_sdk(params.command_spec.clone()).await?;
 
         // Take raw stdio for the SDK transport
@@ -265,9 +273,13 @@ impl AcpAgentManager {
         let (event_tx, _) = broadcast::channel(256);
         let (permission_tx, permission_rx) = mpsc::channel(32);
         let (domain_event_tx, domain_event_rx) = mpsc::channel(256);
+        // Dedicated channel for raw SDK SessionNotifications → session tracker.
+        // This channel is separate from event_tx so the tracker never re-applies
+        // events that were broadcast for the UI (e.g. from emit_snapshot_events).
+        let (notification_tx, notification_rx) = mpsc::channel::<SessionNotification>(256);
 
         // Connect via ACP SDK — executes initialize handshake
-        let protocol = AcpProtocol::connect(stdin, stdout, event_tx.clone(), permission_tx)
+        let protocol = AcpProtocol::connect(stdin, stdout, event_tx.clone(), permission_tx, notification_tx)
             .await
             .map_err(|e| {
                 error!(
@@ -323,7 +335,7 @@ impl AcpAgentManager {
             domain_event_tx,
         };
 
-        Ok((manager, domain_event_rx))
+        Ok((manager, domain_event_rx, notification_rx))
     }
 
     /// Start the permission handler loop. Must be called after the manager

--- a/crates/aionui-ai-agent/src/manager/acp/event_tracker.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/event_tracker.rs
@@ -1,27 +1,48 @@
 use crate::manager::acp::AcpAgentManager;
 use crate::protocol::events::AgentStreamEvent;
 use crate::shared_kernel::ModeId;
-use agent_client_protocol::schema::{SessionConfigOption, SessionModeState, SessionModelState, UsageUpdate};
+use agent_client_protocol::schema::{
+    SessionConfigOption, SessionModeState, SessionModelState, SessionNotification, UsageUpdate,
+};
 use serde_json::Value;
 use std::sync::Arc;
-use tokio::sync::broadcast;
+use tokio::sync::mpsc;
 
 impl AcpAgentManager {
-    /// Start the session event tracker loop.
-    pub fn start_session_event_tracker(self: &Arc<Self>) {
+    /// Consume SDK session/update notifications and apply their effects to
+    /// the AcpSession aggregate.
+    ///
+    /// This is the **sole** writer of observed/advertised session state from
+    /// the CLI side (target.md §7.2). It intentionally consumes a dedicated
+    /// mpsc receiver — NOT a subscription to `event_tx` — to keep the "SDK
+    /// notification → session" flow single-directional. Anything else that
+    /// emits `AgentStreamEvent::Acp*` on `event_tx` (e.g. session_flow's
+    /// `emit_snapshot_events` broadcasting initial UI state) does NOT feed
+    /// back into the session.
+    ///
+    /// Invariant: `emit_snapshot_events` broadcasts on `event_tx` for UI
+    /// initial state, but its events are NOT delivered to this tracker —
+    /// the reflexive loop has been removed. This is intentional: the session
+    /// aggregate is only updated from raw SDK `SessionNotification`s, never
+    /// from re-broadcast AgentStreamEvents.
+    pub fn start_session_event_tracker(self: &Arc<Self>, mut notification_rx: mpsc::Receiver<SessionNotification>) {
         let this = Arc::clone(self);
         tokio::spawn(async move {
-            let mut rx = this.event_tx.subscribe();
-            loop {
-                match rx.recv().await {
-                    Ok(event) => {
-                        this.apply_event_to_session(&event).await;
-                    }
-                    Err(broadcast::error::RecvError::Closed) => break,
-                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
-                }
+            while let Some(notif) = notification_rx.recv().await {
+                this.apply_notification_to_session(&notif).await;
             }
         });
+    }
+
+    async fn apply_notification_to_session(&self, notif: &SessionNotification) {
+        // Translate the SDK notification into AgentStreamEvent shapes, then
+        // dispatch through the existing apply logic.
+        // A future Stage 3b can collapse this round-trip to consume SessionUpdate
+        // directly, avoiding the JSON serialization step.
+        let events = crate::protocol::events::session_notification_to_events(notif);
+        for event in events {
+            self.apply_event_to_session(&event).await;
+        }
     }
 
     /// Mirror a stream event into the `AcpSession` aggregate's observed/advertised
@@ -61,5 +82,143 @@ impl AcpAgentManager {
             }
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manager::acp::events::AcpSessionEvent;
+    use crate::manager::acp::session::AcpSession;
+    use crate::shared_kernel::{ModeId, ModelId};
+    use agent_client_protocol::schema::SessionModeState;
+
+    // ── Test 1 ──────────────────────────────────────────────────────────────
+    //
+    // Verify that a single `apply_observed_mode` call on AcpSession produces
+    // exactly one `ObservedModeSynced` event, and calling it again with the
+    // same value produces no additional event (idempotent).
+    //
+    // This test documents what the old tracker loop was doing: re-applying
+    // the same events that `emit_snapshot_events` already put on the broadcast.
+    // The re-application was idempotent (hence "masking" the bug), but it was
+    // still a redundant write. The new architecture avoids the issue entirely by
+    // only consuming raw SDK SessionNotifications, not broadcast events.
+
+    #[test]
+    fn apply_observed_mode_emits_exactly_one_event() {
+        let mut session = AcpSession::new(None, Default::default());
+
+        // First apply: should emit one event
+        session.apply_observed_mode(ModeId::new("plan"));
+        let events = session.drain_events();
+        assert_eq!(
+            events.len(),
+            1,
+            "expected exactly one ObservedModeSynced event, got: {events:?}"
+        );
+        assert_eq!(
+            events[0],
+            AcpSessionEvent::ObservedModeSynced {
+                mode: ModeId::new("plan")
+            }
+        );
+
+        // Second apply with same value: idempotent — no additional event
+        session.apply_observed_mode(ModeId::new("plan"));
+        let events2 = session.drain_events();
+        assert_eq!(
+            events2.len(),
+            0,
+            "idempotent re-apply should produce no new events, got: {events2:?}"
+        );
+    }
+
+    #[test]
+    fn apply_advertised_modes_does_not_produce_pending_events() {
+        // apply_advertised_modes writes to `advertised` and `observed.mode_id`
+        // but does NOT push to `pending_events` (unlike apply_observed_mode).
+        // This is intentional: the advertised layer is not tracked as a domain
+        // event. Verify this so we know what the old tracker loop was NOT doing.
+        let mut session = AcpSession::new(None, Default::default());
+        let modes = SessionModeState::new("plan".to_owned(), vec![]);
+        session.apply_advertised_modes(modes);
+        let events = session.drain_events();
+        assert_eq!(
+            events.len(),
+            0,
+            "apply_advertised_modes must not produce pending domain events, got: {events:?}"
+        );
+    }
+
+    #[test]
+    fn apply_observed_model_emits_exactly_one_event_then_idempotent() {
+        let mut session = AcpSession::new(None, Default::default());
+
+        session.apply_observed_model(ModelId::new("claude-3-5-sonnet"));
+        let events = session.drain_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0],
+            AcpSessionEvent::ObservedModelSynced {
+                model: ModelId::new("claude-3-5-sonnet")
+            }
+        );
+
+        // Idempotent second write
+        session.apply_observed_model(ModelId::new("claude-3-5-sonnet"));
+        let events2 = session.drain_events();
+        assert_eq!(events2.len(), 0);
+    }
+
+    // ── Test 2 ──────────────────────────────────────────────────────────────
+    //
+    // Compile-time signature guard: start_session_event_tracker must accept
+    // an mpsc::Receiver<SessionNotification>. If the implementation regresses
+    // to internally subscribing to event_tx, the FnOnce bound below ensures
+    // the code still won't compile without an explicit receiver parameter.
+
+    #[tokio::test]
+    async fn tracker_signature_accepts_notification_receiver() {
+        // This is a compile-only guard. We verify that the function has
+        // the expected signature via type inference — if the signature
+        // changes to take no arguments, this won't compile.
+        fn _assert_method_exists(_: impl Fn(&Arc<AcpAgentManager>, mpsc::Receiver<SessionNotification>)) {}
+
+        _assert_method_exists(|m, rx| {
+            m.start_session_event_tracker(rx);
+        });
+    }
+
+    // ── Test 3 ──────────────────────────────────────────────────────────────
+    //
+    // Architectural invariant test: events broadcast on event_tx are NOT
+    // re-applied to the session by the tracker.
+    //
+    // We verify this by constructing the two channels independently and
+    // confirming they are decoupled: sending on event_tx does not cause
+    // anything to arrive on notification_rx.
+    #[tokio::test]
+    async fn event_tx_broadcast_does_not_feed_notification_rx() {
+        use crate::protocol::events::AgentStreamEvent;
+        use tokio::sync::broadcast;
+
+        let (event_tx, _event_rx) = broadcast::channel::<AgentStreamEvent>(8);
+        let (notification_tx, mut notification_rx) = mpsc::channel::<SessionNotification>(8);
+
+        // Simulate what emit_snapshot_events does: broadcast on event_tx
+        let _ = event_tx.send(AgentStreamEvent::AcpModeInfo(
+            serde_json::json!({"currentModeId": "plan"}),
+        ));
+
+        // Drop the notification sender so the receiver's try_recv terminates
+        drop(notification_tx);
+
+        // The notification_rx should be empty — no SessionNotification was
+        // sent merely because event_tx received an AcpModeInfo event.
+        assert!(
+            notification_rx.recv().await.is_none(),
+            "notification_rx must not receive events that were broadcast on event_tx"
+        );
     }
 }

--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -101,6 +101,7 @@ impl AcpProtocol {
         stdout: ChildStdout,
         event_tx: broadcast::Sender<AgentStreamEvent>,
         permission_tx: mpsc::Sender<PermissionRequest>,
+        notification_tx: mpsc::Sender<SessionNotification>,
     ) -> Result<Self, AcpError> {
         let alive = Arc::new(AtomicBool::new(true));
 
@@ -120,6 +121,7 @@ impl AcpProtocol {
             stdout,
             event_tx,
             permission_tx,
+            notification_tx,
             init_tx,
             ready_tx,
             shutdown_rx,
@@ -309,6 +311,7 @@ async fn run_sdk_background(
     stdout: ChildStdout,
     event_tx: broadcast::Sender<AgentStreamEvent>,
     permission_tx: mpsc::Sender<PermissionRequest>,
+    notification_tx: mpsc::Sender<SessionNotification>,
     init_tx: oneshot::Sender<Result<InitializeResponse, AcpError>>,
     ready_tx: oneshot::Sender<ConnectionTo<Agent>>,
     shutdown_rx: oneshot::Receiver<()>,
@@ -326,7 +329,15 @@ async fn run_sdk_background(
         .builder()
         .on_receive_notification(
             {
+                let event_tx = event_tx.clone();
+                let notification_tx = notification_tx.clone();
                 async move |notification: SessionNotification, _cx: ConnectionTo<Agent>| {
+                    // Fan out the raw SDK notification to the manager's apply-loop
+                    // FIRST, so session state is consistent by the time the UI
+                    // event hits the broadcast channel. Swallow send errors — if
+                    // the manager has dropped the receiver, session consistency
+                    // is moot anyway (we're on our way down).
+                    let _ = notification_tx.send(notification.clone()).await;
                     handle_session_notification(notification, &event_tx).await;
                     Ok(())
                 }


### PR DESCRIPTION
## Summary

Stage 3 of the `aionui-ai-agent` refactor plan. First **behavioural** change in the sequence — fixes review.md §M3 (reflexive loop): the CLI-side path for writing `AcpSession` observed/advertised state is now SDK notifications ONLY, not a subscription that reads back its own `event_tx` broadcasts.

### Before

```
SDK session/update notif
  → protocol::acp::handle_session_notification
  → event_tx.send(AgentStreamEvent::Acp*)       [for UI]
      │
      └─→ start_session_event_tracker (subscribed to event_tx)
            └─→ apply_event_to_session → session.apply_*()   [for session]
```

Entangled with `session_flow::emit_snapshot_events` — which also broadcasts the same variants on `event_tx` (for the UI's initial state), causing those broadcasts to be *re-applied* to the session. Idempotent writes, hence invisible bug, but architecturally the two write paths were impossible to reason about separately.

### After

```
SDK session/update notif
  → protocol::acp::handle_session_notification
      ├─→ notification_tx.send(notif.clone())    [dedicated mpsc → manager]
      │     └─→ start_session_event_tracker (consumes notification_rx)
      │           └─→ apply_event_to_session → session.apply_*()
      └─→ event_tx.send(AgentStreamEvent::Acp*)  [broadcast for UI]
            └─→ StreamRelay / CatalogForwarder / team scheduler etc. (external only)
```

`emit_snapshot_events` still broadcasts on `event_tx` for UI initial state, but its events are NOT consumed by the tracker — they never feed back into the session. Target §7.2 invariant restored.

### Implementation

1. `AcpProtocol::connect` gains `notification_tx: mpsc::Sender<SessionNotification>`.
2. The `on_receive_notification` closure fans out: send on `notification_tx` FIRST (so session is consistent before the UI event lands), then call the existing `handle_session_notification` path for `event_tx`.
3. `AcpAgentManager::new` creates the channel and returns `(Self, domain_rx, notification_rx)` — `notification_rx` is **not** stored on the manager (AGENTS.md high-priority rule compliance).
4. `start_session_event_tracker` now takes `notification_rx` as an arg and consumes it directly. Internally it still goes through `AgentStreamEvent` shapes (via `session_notification_to_events`) + existing `apply_event_to_session` — so the JSON round-trip remains for now. A later Stage 3b can collapse it to consume `SessionUpdate` structurally if desired.

### Tests

Added 5 new first-principles tests in `event_tracker.rs` (not relying on existing tests, per the user's guidance that existing tests may encode the bug):

- `apply_observed_mode_emits_exactly_one_event` — one write = one domain event; idempotent re-apply produces none.
- `apply_advertised_modes_does_not_produce_pending_events` — documents the layer distinction.
- `apply_observed_model_emits_exactly_one_event_then_idempotent` — same for model.
- `tracker_signature_accepts_notification_receiver` — compile-time signature guard; if anyone regresses the tracker to subscribe on `event_tx` internally, this won't type-check.
- `event_tx_broadcast_does_not_feed_notification_rx` — weak-but-documentary invariant that the two channels are constructed independently. Real behavioural invariant would need a full manager mock; weak test + comment is the pragmatic call.

No pre-existing tests modified. All 286 existing + 5 new = 291 passing.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p aionui-ai-agent -p aionui-app -- -D warnings` — zero warnings
- [x] `cargo test -p aionui-ai-agent --lib` — 291 passing (286 existing + 5 new)
- [x] `cargo test -p aionui-app --lib` — 12 passing
- [x] `just build` — release binary built, signed, installed
- [x] Independent spec-review agent ran 11 structural checks: all pass

## Files changed

- `crates/aionui-ai-agent/src/protocol/acp.rs` — `AcpProtocol::connect` signature, notification fan-out
- `crates/aionui-ai-agent/src/manager/acp/agent.rs` — new channel in `AcpAgentManager::new`, updated return tuple
- `crates/aionui-ai-agent/src/manager/acp/event_tracker.rs` — tracker rewritten to consume `notification_rx`, new tests
- `crates/aionui-ai-agent/src/factory/mod.rs` — 3-tuple destructure, new arg to `start_session_event_tracker`

## Not in this PR

- Stage 3b (optional): collapse the JSON round-trip in `apply_event_to_session` → consume `SessionUpdate` directly.
- Stage 4 (M2): route `set_mode` through `reconcile_session` — next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)