### PR TITLE
refactor(ai-agent): migrate permission producers to AcpPermission (Stage 5 / B3)

### DIFF
--- a/crates/aionui-ai-agent/src/capability/backend_protocol_sink.rs
+++ b/crates/aionui-ai-agent/src/capability/backend_protocol_sink.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 use tokio::sync::broadcast;
 use tracing::debug;
 
-use crate::protocol::events::{AgentStreamEvent, ToolCallEventData, ToolCallStatus};
+use crate::protocol::events::{AcpPermissionEventData, AgentStreamEvent, ToolCallEventData, ToolCallStatus};
 
 /// Implements `ProtocolEmitter` for the aionui-backend context.
 ///
@@ -70,13 +70,16 @@ impl ProtocolEmitter for BackendProtocolSink {
                     confs.push(confirmation.clone());
                 }
 
-                let json_val = serde_json::to_value(&confirmation).unwrap_or_default();
-                let _ = self.event_tx.send(AgentStreamEvent::Permission(json_val));
+                let _ = self
+                    .event_tx
+                    .send(AgentStreamEvent::AcpPermission(AcpPermissionEventData::Confirmation(
+                        confirmation.clone(),
+                    )));
 
                 debug!(
                     call_id,
                     tool_name = %tool.name,
-                    "BackendProtocolSink: emitted Permission event"
+                    "BackendProtocolSink: emitted AcpPermission(Confirmation) event"
                 );
             }
 
@@ -136,11 +139,11 @@ mod tests {
 
         let received = rx.try_recv().unwrap();
         match received {
-            AgentStreamEvent::Permission(data) => {
-                assert_eq!(data["call_id"], "c1");
-                assert!(data["options"].as_array().unwrap().len() >= 3);
+            AgentStreamEvent::AcpPermission(AcpPermissionEventData::Confirmation(conf)) => {
+                assert_eq!(conf.call_id, "c1");
+                assert!(conf.options.len() >= 3);
             }
-            other => panic!("Expected Permission, got {:?}", other),
+            other => panic!("Expected AcpPermission(Confirmation), got {:?}", other),
         }
 
         let stored = confs.read().unwrap();

--- a/crates/aionui-ai-agent/src/manager/openclaw/event_mapper.rs
+++ b/crates/aionui-ai-agent/src/manager/openclaw/event_mapper.rs
@@ -1,10 +1,11 @@
+use aionui_common::Confirmation;
 use serde_json::Value;
 use tracing::debug;
 
 use super::protocol::{AgentEvent, ApprovalRequestEvent, ChatEvent, ChatEventState, EventFrame};
 use crate::protocol::events::{
-    AgentStreamEvent, ErrorEventData, FinishEventData, StartEventData, TextEventData, ThinkingEventData,
-    ToolCallEventData, ToolCallStatus,
+    AcpPermissionEventData, AgentStreamEvent, ErrorEventData, FinishEventData, StartEventData, TextEventData,
+    ThinkingEventData, ToolCallEventData, ToolCallStatus,
 };
 
 #[derive(Default)]
@@ -220,18 +221,22 @@ fn map_approval_event(event: &EventFrame) -> Vec<AgentStreamEvent> {
     let tool_call = approval.tool_call.as_ref();
     let call_id = tool_call
         .and_then(|tc| tc.tool_call_id.as_deref())
-        .unwrap_or(&approval.request_id);
-    let action = tool_call.and_then(|tc| tc.title.as_deref()).unwrap_or("unknown");
-    let command_type = tool_call.and_then(|tc| tc.kind.as_deref());
+        .unwrap_or(&approval.request_id)
+        .to_owned();
 
-    let confirmation = serde_json::json!({
-        "call_id": call_id,
-        "action": action,
-        "command_type": command_type,
-        "request_id": approval.request_id,
-    });
+    let confirmation = Confirmation {
+        id: approval.request_id.clone(),
+        call_id,
+        title: tool_call.and_then(|tc| tc.title.clone()),
+        action: tool_call.and_then(|tc| tc.title.clone()),
+        description: String::new(),
+        command_type: tool_call.and_then(|tc| tc.kind.as_deref()).map(ToOwned::to_owned),
+        options: Vec::new(),
+    };
 
-    vec![AgentStreamEvent::Permission(confirmation)]
+    vec![AgentStreamEvent::AcpPermission(AcpPermissionEventData::Confirmation(
+        confirmation,
+    ))]
 }
 
 fn compute_text_delta(message: &Option<Value>, accumulated: &mut String) -> Option<String> {
@@ -482,12 +487,12 @@ mod tests {
         let events = map_openclaw_event(&event, &mut state, None);
 
         assert_eq!(events.len(), 1);
-        if let AgentStreamEvent::Permission(v) = &events[0] {
-            assert_eq!(v["call_id"], "tc-1");
-            assert_eq!(v["action"], "bash");
-            assert_eq!(v["request_id"], "req-1");
+        if let AgentStreamEvent::AcpPermission(AcpPermissionEventData::Confirmation(conf)) = &events[0] {
+            assert_eq!(conf.call_id, "tc-1");
+            assert_eq!(conf.action, Some("bash".to_owned()));
+            assert_eq!(conf.id, "req-1");
         } else {
-            panic!("Expected Permission");
+            panic!("Expected AcpPermission(Confirmation)");
         }
     }
 

--- a/crates/aionui-ai-agent/src/protocol/events/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/events/mod.rs
@@ -34,6 +34,10 @@ pub enum AgentStreamEvent {
     AgentStatus(AgentStatusEventData),
     Thinking(ThinkingEventData),
     Plan(PlanEventData),
+    // DEPRECATED: Use AcpPermission(AcpPermissionEventData::Confirmation(..)) instead.
+    // This variant remains only for wire-format compatibility with the frontend;
+    // no production code should emit it after Stage 5 (see review.md §B3, target §7.5).
+    // Removing it is a coordinated cross-repo change.
     Permission(serde_json::Value),
     AcpPermission(AcpPermissionEventData),
     SkillSuggest(SkillSuggestEventData),


### PR DESCRIPTION
## Summary

Stage 5 of the `aionui-ai-agent` refactor plan. Fixes review.md §B3 (truth-source split): two variants carried the same semantic for pending tool-call confirmations — `AgentStreamEvent::Permission(Value)` (weakly typed, aionrs + openclaw) and `AgentStreamEvent::AcpPermission(..)` (structured, ACP + Remote). This PR migrates the two `Permission` producers onto `AcpPermission(AcpPermissionEventData::Confirmation(..))`, which uses the already-existing `Confirmation` variant designed exactly for this legacy shape.

### Scope decision: keep the variant, delete the producers

`AgentStreamEvent::Permission` serializes to `type: \"permission\"` on the WebSocket. The frontend consumes `type=permission` and a backend-only variant removal would break the wire contract. This PR therefore:

- Migrates both producers (aionrs / openclaw) to `AcpPermission(Confirmation(..))` — done
- Keeps `Permission(Value)` variant defined, with a comment marking it deprecated and pointing at the cutover path — done
- Leaves `aionui-channel::message_service`'s defensive match arm untouched — so any stale emission (from old caches or unknown future consumers) still gets handled as a no-op

Full variant removal remains as a future coordinated cross-repo change.

### DoD check

```bash
$ grep -rn 'AgentStreamEvent::Permission(' crates/aionui-ai-agent/src/
# zero producer hits — only the variant definition
```

After this PR, no code in `crates/aionui-ai-agent/src/` emits `AgentStreamEvent::Permission(..)`.

## Files changed

- `crates/aionui-ai-agent/src/capability/backend_protocol_sink.rs` — aionrs producer + inline test
- `crates/aionui-ai-agent/src/manager/openclaw/event_mapper.rs` — openclaw producer + structured `Confirmation` construction + test
- `crates/aionui-ai-agent/src/protocol/events/mod.rs` — deprecation comment on the variant

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p aionui-ai-agent -p aionui-app -p aionui-channel -- -D warnings` — zero warnings
- [x] `cargo test -p aionui-ai-agent --lib` — 292 passing
- [x] `cargo test -p aionui-app --lib` — 12 passing
- [x] `just build` — release binary built, signed, installed
- [x] DoD grep: zero `Permission(..)` producers in ai-agent

## Not in this PR

- Frontend switch-over to consume `type=acp_permission` as canonical
- Physical removal of `AgentStreamEvent::Permission` variant (depends on above)
- Stage 6 (M6 — AgentStreamChunk deletion) is already complete upstream (#161)
- Stage 7 (M1 — AgentRuntime) is next

🤖 Generated with [Claude Code](https://claude.com/claude-code)