### PR TITLE
refactor(ai-agent): Stage 10 cleanup — drop realtime dep, deprecate dead event variants, make aionrs Drop explicit

### DIFF
--- a/crates/aionui-ai-agent/Cargo.toml
+++ b/crates/aionui-ai-agent/Cargo.toml
@@ -10,7 +10,6 @@ aionui-common.workspace = true
 aionui-db.workspace = true
 aionui-extension.workspace = true
 aionui-api-types.workspace = true
-aionui-realtime.workspace = true
 aionui-system.workspace = true
 axum.workspace = true
 base64.workspace = true

--- a/crates/aionui-ai-agent/src/manager/aionrs.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs.rs
@@ -24,10 +24,25 @@ use crate::types::{AionrsResolvedConfig, SendMessageData};
 pub struct AionrsAgentManager {
     runtime: AgentRuntime,
     engine: Mutex<AgentEngine>,
-    #[allow(dead_code)] // held for Arc drop cleanup on agent destruction
+    /// Holds `Arc<McpManager>` instances alive for the duration of this agent's
+    /// lifetime. The managers are not accessed after construction — they exist
+    /// solely so their underlying MCP connections outlive the engine's event
+    /// loop. Rust drops them here, in field-declaration order, after `engine`
+    /// and `runtime` are dropped. See the explicit `Drop` impl below.
+    #[allow(dead_code)] // intentional: lifetime-extension only; see Drop impl
     mcp_managers: Vec<Arc<McpManager>>,
     approval_manager: Arc<ToolApprovalManager>,
     confirmations: Arc<std::sync::RwLock<Vec<Confirmation>>>,
+}
+
+impl Drop for AionrsAgentManager {
+    fn drop(&mut self) {
+        // McpManagers are held alive by the `mcp_managers` field specifically
+        // so they outlive the agent's event loop. No explicit cleanup is needed
+        // here — the Arc drop path releases each McpManager's underlying MCP
+        // connection. This impl exists to document the intentional Drop-order
+        // semantics rather than as a lint escape hatch.
+    }
 }
 
 impl AionrsAgentManager {

--- a/crates/aionui-ai-agent/src/protocol/events/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/events/mod.rs
@@ -51,7 +51,15 @@ pub enum AgentStreamEvent {
     AvailableCommands(AvailableCommandsEventData),
     Finish(FinishEventData),
     Error(ErrorEventData),
+    /// DEPRECATED: no producer in the backend. Retained for wire-format
+    /// compatibility — removing it would change the `AgentStreamEvent`
+    /// serde tag set visible to the frontend. Safe to delete once the
+    /// frontend is confirmed not to depend on `type: "system"` messages.
     System(serde_json::Value),
+    /// DEPRECATED: no producer in the backend. Retained for wire-format
+    /// compatibility — removing it would change the `AgentStreamEvent`
+    /// serde tag set visible to the frontend. Safe to delete once the
+    /// frontend is confirmed not to depend on `type: "request_trace"` messages.
     RequestTrace(serde_json::Value),
     SessionAssigned(SessionAssignedEventData),
 }


### PR DESCRIPTION
## Summary

Stage 10 of the `aionui-ai-agent` refactor plan. After the seven preceding stages, the §15 Definition-of-Done checklist was run to identify remaining cleanup. This PR addresses three small, independent items surfaced by that scan. A follow-up PR will handle the remaining items (documented below).

### Included

1. **Drop `aionui-realtime` dependency** (target §15). Verified zero source uses:
   ```
   $ grep -rn 'aionui_realtime\|aionui-realtime' crates/aionui-ai-agent/src/
   (empty)
   ```
   The line was a historical leftover. Removed from `Cargo.toml`.

2. **Deprecate `AgentStreamEvent::System(Value)` and `AgentStreamEvent::RequestTrace(Value)`** (review.md §m2). Both variants have zero producers in the backend — only defined + matched as no-op in `aionui-channel`. Rather than deleting them (which would change the wire-format tag set visible to the frontend), mark deprecated with comments mirroring the treatment of `Permission(Value)` in Stage 5. Safe to delete in a coordinated cross-repo PR once the frontend is confirmed not to rely on them.

3. **Make `aionrs.rs::mcp_managers` Drop semantics explicit** (review.md §m5). Previous code had `#[allow(dead_code)] // held for Arc drop cleanup`. The `#[allow]` is unavoidable (rustc's `dead_code` lint doesn't see through Drop), but the comment now explicitly says \"lifetime extension\" and cross-references an explicit `impl Drop`. Intent is now readable.

### §15 DoD scan — full results

| Item | Status | Notes |
|---|---|---|
| 1 lib.rs only pub use | ✓ | 38 lines |
| 2 use axum only in routes | ✓ | |
| 3 service.rs sole business layer | ✓ | 419 lines |
| 4 no file > 1000 lines | ✓ | max = 808 (`cli_process.rs`) |
| 5 manager/*/agent.rs ≤ 500 | ⚠ | `acp/agent.rs` = 718, `openclaw/agent.rs` = 648 (Stage 9 deferred) |
| 6 Permission no producer | ✓ | |
| 7 managers compose AgentRuntime | ✓ | all 5 |
| 9 AcpAgentManager ≤ 9 fields | ✓ | exactly 9 |
| 10 AgentStreamChunk removed | ✓ | already in upstream |
| 11 protocol.set_mode single call site | ✓ | only reconcile_session |
| 12 event_tracker no self-subscribe | ✓ | Stage 3 |
| 13 factory per-agent | ✓ | build_agent = 15 lines |
| 16 aionui-realtime dropped | ✓ | **this PR** |
| 18 No Policy | ✓ | |

### Not in this PR (deferred to follow-up)

- **cli_process / skill_manager / openclaw-agent preventive splits** (review.md §M5, plan Stage 9). None exceed 1000 yet; the largest is 808.
- **`browse_workspace` relocation** to `aionui-conversation` (target §5). Would need cross-crate move — best as a standalone PR.
- **`manager/*/agent.rs` ≤ 500 tightening** (target §15 item 5). Requires finding natural single-responsibility seams in `acp/agent.rs` (718) and `openclaw/agent.rs` (648); neither seam is obvious from the current code. Deferred until a subsequent change needs to touch them.
- **`side_question` / `reload_context` implement-or-delete decision** (review.md §m7). Still placeholder service methods returning static stubs. Needs product input.
- **Full deletion of `Permission(Value)` / `System(Value)` / `RequestTrace(Value)` variants**. Needs coordinated frontend PR to confirm it doesn't consume those tags.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p aionui-ai-agent -p aionui-app -p aionui-channel -- -D warnings` — zero warnings
- [x] `cargo test -p aionui-ai-agent --lib` — 298 passing
- [x] `cargo test -p aionui-app --lib` — 12 passing
- [x] `just build` — release binary built, signed, installed

## Refactor plan status

7 of 10 stages complete on main after this PR merges:

- ✅ Stage 1 — split acp/agent.rs (#169)
- ✅ Stage 2 — introduce AgentService (#171)
- ✅ Stage 3 — break event-tracker self-loop (#172)
- ✅ Stage 4 — route set_mode through reconcile (#173)
- ✅ Stage 5 — migrate permission producers (#174)
- ✅ Stage 6 — AgentStreamChunk removal (#161, already merged)
- ✅ Stage 7 — AgentRuntime + m1 fix (#175)
- ✅ Stage 8 — split factory::build_agent (#176)
- ⏭ Stage 9 — deferred (no file over red line)
- 🟡 Stage 10 — this PR (first pass); full completion needs the deferred items above

🤖 Generated with [Claude Code](https://claude.com/claude-code)