### PR TITLE
chore: sync Cargo.lock after aionui-realtime dependency removal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,6 @@ dependencies = [
  "aionui-common",
  "aionui-db",
  "aionui-extension",
- "aionui-realtime",
  "aionui-system",
  "async-trait",
  "axum",


### PR DESCRIPTION
Stage 10 PR #177 removed `aionui-realtime` from `crates/aionui-ai-agent/Cargo.toml` but did not regenerate Cargo.lock. Running `cargo build` (or `just build`) locally immediately re-syncs it, leaving every contributor with a spurious one-line diff.

This PR carries that lockfile update into main. Diff is literally one line — removing the `aionui-realtime` entry from the `aionui-ai-agent` dependency list in Cargo.lock.

## Test plan

- [x] `cargo build --release` — clean, finishes in 0.73s (no new compilation needed)
- [x] no source changes, no behaviour changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)