### PR TITLE
refactor(ai-agent): split skill_manager into submodules (Stage 9.2, M5)

### DIFF
--- a/crates/aionui-ai-agent/src/capability/skill_manager/mod.rs
+++ b/crates/aionui-ai-agent/src/capability/skill_manager/mod.rs
@@ -6,6 +6,9 @@ use regex::Regex;
 use tokio::sync::RwLock;
 use tracing::{debug, warn};
 
+mod prompt_builder;
+pub use prompt_builder::*;
+
 static LOAD_SKILL_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\[LOAD_SKILL:\s*([^\]]+)\]").expect("valid regex"));
 
@@ -267,28 +270,6 @@ impl AcpSkillManager {
     }
 }
 
-/// Build a formatted text block listing available skills for injection.
-///
-/// The output includes skill names with descriptions and instructions
-/// on how to request loading via `[LOAD_SKILL: name]`.
-pub fn build_skills_index_text(skills: &[SkillIndex]) -> String {
-    if skills.is_empty() {
-        return String::new();
-    }
-
-    let mut lines = Vec::with_capacity(skills.len() + 4);
-    lines.push("## Available Skills".to_string());
-    lines.push(String::new());
-    lines.push("To load a skill, include `[LOAD_SKILL: skill-name]` in your response.".to_string());
-    lines.push(String::new());
-
-    for skill in skills {
-        lines.push(format!("- **{}**: {}", skill.name, skill.description));
-    }
-
-    lines.join("\n")
-}
-
 /// Detect `[LOAD_SKILL: ...]` requests in agent output content.
 ///
 /// Returns a list of requested skill names.
@@ -298,101 +279,6 @@ pub fn detect_skill_load_request(content: &str) -> Vec<String> {
         .filter_map(|cap| cap.get(1).map(|m| m.as_str().trim().to_string()))
         .filter(|name| !name.is_empty())
         .collect()
-}
-
-/// Build system instructions text with full skill content (for Gemini).
-pub fn build_system_instructions(base_instructions: &str, skills: &[SkillDefinition]) -> String {
-    if skills.is_empty() {
-        return base_instructions.to_string();
-    }
-
-    let mut parts = vec![base_instructions.to_string()];
-
-    for skill in skills {
-        if let Some(body) = &skill.body {
-            parts.push(format!("\n## Skill: {}\n\n{}", skill.name, body));
-        }
-    }
-
-    parts.join("\n")
-}
-
-/// Prepare the first message with skills index prefix (for ACP/Codex).
-///
-/// Prepends `[Assistant Rules]` block with skill index to the user content.
-pub fn prepare_first_message_with_skills_index(
-    content: &str,
-    skills: &[SkillIndex],
-    preset_context: Option<&str>,
-) -> String {
-    let mut parts = Vec::new();
-
-    let index_text = build_skills_index_text(skills);
-    let has_rules = !index_text.is_empty() || preset_context.is_some();
-
-    if has_rules {
-        parts.push("[Assistant Rules]".to_string());
-
-        if let Some(ctx) = preset_context
-            && !ctx.is_empty()
-        {
-            parts.push(ctx.to_string());
-        }
-
-        if !index_text.is_empty() {
-            parts.push(index_text);
-        }
-
-        parts.push("[/Assistant Rules]".to_string());
-        parts.push(String::new());
-    }
-
-    parts.push(content.to_string());
-    parts.join("\n")
-}
-
-/// Build system instructions with skills index only (for Gemini index-only mode).
-///
-/// Unlike [`build_system_instructions`] which injects full skill bodies,
-/// this variant injects only the skill index (name + description) and
-/// the `[LOAD_SKILL]` protocol, allowing the agent to request full content on demand.
-pub fn build_system_instructions_with_skills_index(base_instructions: &str, skills: &[SkillIndex]) -> String {
-    let index_text = build_skills_index_text(skills);
-    if index_text.is_empty() {
-        return base_instructions.to_string();
-    }
-
-    format!("{base_instructions}\n\n{index_text}")
-}
-
-/// Prepare the first message with full skill content (for Gemini).
-///
-/// Prepends `[Assistant Rules]` block with complete skill bodies.
-pub fn prepare_first_message(content: &str, skills: &[SkillDefinition], preset_context: Option<&str>) -> String {
-    let mut parts = Vec::new();
-    let has_rules = !skills.is_empty() || preset_context.is_some();
-
-    if has_rules {
-        parts.push("[Assistant Rules]".to_string());
-
-        if let Some(ctx) = preset_context
-            && !ctx.is_empty()
-        {
-            parts.push(ctx.to_string());
-        }
-
-        for skill in skills {
-            if let Some(body) = &skill.body {
-                parts.push(format!("## Skill: {}\n\n{}", skill.name, body));
-            }
-        }
-
-        parts.push("[/Assistant Rules]".to_string());
-        parts.push(String::new());
-    }
-
-    parts.push(content.to_string());
-    parts.join("\n")
 }
 
 // ---------------------------------------------------------------------------
@@ -506,149 +392,6 @@ mod tests {
         let content = "[LOAD_SKILL:  ]";
         let skills = detect_skill_load_request(content);
         assert!(skills.is_empty());
-    }
-
-    // -----------------------------------------------------------------------
-    // Skills index text
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn build_skills_index_text_empty() {
-        assert!(build_skills_index_text(&[]).is_empty());
-    }
-
-    #[test]
-    fn build_skills_index_text_with_skills() {
-        let skills = vec![
-            SkillIndex {
-                name: "review".into(),
-                description: "Code review".into(),
-            },
-            SkillIndex {
-                name: "debug".into(),
-                description: "Debugging helper".into(),
-            },
-        ];
-        let text = build_skills_index_text(&skills);
-        assert!(text.contains("## Available Skills"));
-        assert!(text.contains("[LOAD_SKILL: skill-name]"));
-        assert!(text.contains("- **review**: Code review"));
-        assert!(text.contains("- **debug**: Debugging helper"));
-    }
-
-    // -----------------------------------------------------------------------
-    // First message preparation
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn prepare_first_message_with_index_no_skills() {
-        let result = prepare_first_message_with_skills_index("Hello", &[], None);
-        assert_eq!(result, "Hello");
-    }
-
-    #[test]
-    fn prepare_first_message_with_index_and_context() {
-        let skills = vec![SkillIndex {
-            name: "test".into(),
-            description: "Testing".into(),
-        }];
-        let result = prepare_first_message_with_skills_index("Hello", &skills, Some("Be concise."));
-        assert!(result.contains("[Assistant Rules]"));
-        assert!(result.contains("Be concise."));
-        assert!(result.contains("- **test**: Testing"));
-        assert!(result.contains("[/Assistant Rules]"));
-        assert!(result.ends_with("Hello"));
-    }
-
-    #[test]
-    fn prepare_first_message_with_full_skills() {
-        let skills = vec![SkillDefinition {
-            name: "review".into(),
-            description: "Review".into(),
-            location: PathBuf::new(),
-            source: aionui_extension::SkillSource::Custom,
-            relative_location: None,
-            body: Some("Full review instructions here.".into()),
-        }];
-        let result = prepare_first_message("Hello", &skills, None);
-        assert!(result.contains("[Assistant Rules]"));
-        assert!(result.contains("## Skill: review"));
-        assert!(result.contains("Full review instructions here."));
-        assert!(result.contains("[/Assistant Rules]"));
-        assert!(result.ends_with("Hello"));
-    }
-
-    #[test]
-    fn prepare_first_message_no_skills_no_context() {
-        let result = prepare_first_message("Hello", &[], None);
-        assert_eq!(result, "Hello");
-    }
-
-    #[test]
-    fn prepare_first_message_context_only() {
-        let result = prepare_first_message_with_skills_index("Hello", &[], Some("Rules here."));
-        assert!(result.contains("[Assistant Rules]"));
-        assert!(result.contains("Rules here."));
-        assert!(result.ends_with("Hello"));
-    }
-
-    // -----------------------------------------------------------------------
-    // System instructions builder
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn build_system_instructions_no_skills() {
-        let result = build_system_instructions("Base prompt", &[]);
-        assert_eq!(result, "Base prompt");
-    }
-
-    #[test]
-    fn build_system_instructions_with_skills() {
-        let skills = vec![SkillDefinition {
-            name: "helper".into(),
-            description: "A helper".into(),
-            location: PathBuf::new(),
-            source: aionui_extension::SkillSource::Custom,
-            relative_location: None,
-            body: Some("Helper body content.".into()),
-        }];
-        let result = build_system_instructions("Base prompt", &skills);
-        assert!(result.starts_with("Base prompt"));
-        assert!(result.contains("## Skill: helper"));
-        assert!(result.contains("Helper body content."));
-    }
-
-    #[test]
-    fn build_system_instructions_with_skills_index_no_skills() {
-        let result = build_system_instructions_with_skills_index("Base prompt", &[]);
-        assert_eq!(result, "Base prompt");
-    }
-
-    #[test]
-    fn build_system_instructions_with_skills_index_includes_index() {
-        let skills = vec![SkillIndex {
-            name: "helper".into(),
-            description: "A helper skill".into(),
-        }];
-        let result = build_system_instructions_with_skills_index("Base prompt", &skills);
-        assert!(result.starts_with("Base prompt"));
-        assert!(result.contains("## Available Skills"));
-        assert!(result.contains("- **helper**: A helper skill"));
-        assert!(result.contains("[LOAD_SKILL: skill-name]"));
-    }
-
-    #[test]
-    fn build_system_instructions_skips_unloaded_skills() {
-        let skills = vec![SkillDefinition {
-            name: "unloaded".into(),
-            description: "Not loaded".into(),
-            location: PathBuf::new(),
-            source: aionui_extension::SkillSource::Custom,
-            relative_location: None,
-            body: None,
-        }];
-        let result = build_system_instructions("Base", &skills);
-        assert_eq!(result, "Base");
     }
 
     // -----------------------------------------------------------------------

--- a/crates/aionui-ai-agent/src/capability/skill_manager/prompt_builder.rs
+++ b/crates/aionui-ai-agent/src/capability/skill_manager/prompt_builder.rs
@@ -1,0 +1,267 @@
+use super::{SkillDefinition, SkillIndex};
+
+/// Build a formatted text block listing available skills for injection.
+///
+/// The output includes skill names with descriptions and instructions
+/// on how to request loading via `[LOAD_SKILL: name]`.
+pub fn build_skills_index_text(skills: &[SkillIndex]) -> String {
+    if skills.is_empty() {
+        return String::new();
+    }
+
+    let mut lines = Vec::with_capacity(skills.len() + 4);
+    lines.push("## Available Skills".to_string());
+    lines.push(String::new());
+    lines.push("To load a skill, include `[LOAD_SKILL: skill-name]` in your response.".to_string());
+    lines.push(String::new());
+
+    for skill in skills {
+        lines.push(format!("- **{}**: {}", skill.name, skill.description));
+    }
+
+    lines.join("\n")
+}
+
+/// Build system instructions text with full skill content (for Gemini).
+pub fn build_system_instructions(base_instructions: &str, skills: &[SkillDefinition]) -> String {
+    if skills.is_empty() {
+        return base_instructions.to_string();
+    }
+
+    let mut parts = vec![base_instructions.to_string()];
+
+    for skill in skills {
+        if let Some(body) = &skill.body {
+            parts.push(format!("\n## Skill: {}\n\n{}", skill.name, body));
+        }
+    }
+
+    parts.join("\n")
+}
+
+/// Prepare the first message with skills index prefix (for ACP/Codex).
+///
+/// Prepends `[Assistant Rules]` block with skill index to the user content.
+pub fn prepare_first_message_with_skills_index(
+    content: &str,
+    skills: &[SkillIndex],
+    preset_context: Option<&str>,
+) -> String {
+    let mut parts = Vec::new();
+
+    let index_text = build_skills_index_text(skills);
+    let has_rules = !index_text.is_empty() || preset_context.is_some();
+
+    if has_rules {
+        parts.push("[Assistant Rules]".to_string());
+
+        if let Some(ctx) = preset_context
+            && !ctx.is_empty()
+        {
+            parts.push(ctx.to_string());
+        }
+
+        if !index_text.is_empty() {
+            parts.push(index_text);
+        }
+
+        parts.push("[/Assistant Rules]".to_string());
+        parts.push(String::new());
+    }
+
+    parts.push(content.to_string());
+    parts.join("\n")
+}
+
+/// Build system instructions with skills index only (for Gemini index-only mode).
+///
+/// Unlike [`build_system_instructions`] which injects full skill bodies,
+/// this variant injects only the skill index (name + description) and
+/// the `[LOAD_SKILL]` protocol, allowing the agent to request full content on demand.
+pub fn build_system_instructions_with_skills_index(base_instructions: &str, skills: &[SkillIndex]) -> String {
+    let index_text = build_skills_index_text(skills);
+    if index_text.is_empty() {
+        return base_instructions.to_string();
+    }
+
+    format!("{base_instructions}\n\n{index_text}")
+}
+
+/// Prepare the first message with full skill content (for Gemini).
+///
+/// Prepends `[Assistant Rules]` block with complete skill bodies.
+pub fn prepare_first_message(content: &str, skills: &[SkillDefinition], preset_context: Option<&str>) -> String {
+    let mut parts = Vec::new();
+    let has_rules = !skills.is_empty() || preset_context.is_some();
+
+    if has_rules {
+        parts.push("[Assistant Rules]".to_string());
+
+        if let Some(ctx) = preset_context
+            && !ctx.is_empty()
+        {
+            parts.push(ctx.to_string());
+        }
+
+        for skill in skills {
+            if let Some(body) = &skill.body {
+                parts.push(format!("## Skill: {}\n\n{}", skill.name, body));
+            }
+        }
+
+        parts.push("[/Assistant Rules]".to_string());
+        parts.push(String::new());
+    }
+
+    parts.push(content.to_string());
+    parts.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // -----------------------------------------------------------------------
+    // Skills index text
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_skills_index_text_empty() {
+        assert!(build_skills_index_text(&[]).is_empty());
+    }
+
+    #[test]
+    fn build_skills_index_text_with_skills() {
+        let skills = vec![
+            SkillIndex {
+                name: "review".into(),
+                description: "Code review".into(),
+            },
+            SkillIndex {
+                name: "debug".into(),
+                description: "Debugging helper".into(),
+            },
+        ];
+        let text = build_skills_index_text(&skills);
+        assert!(text.contains("## Available Skills"));
+        assert!(text.contains("[LOAD_SKILL: skill-name]"));
+        assert!(text.contains("- **review**: Code review"));
+        assert!(text.contains("- **debug**: Debugging helper"));
+    }
+
+    // -----------------------------------------------------------------------
+    // First message preparation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn prepare_first_message_with_index_no_skills() {
+        let result = prepare_first_message_with_skills_index("Hello", &[], None);
+        assert_eq!(result, "Hello");
+    }
+
+    #[test]
+    fn prepare_first_message_with_index_and_context() {
+        let skills = vec![SkillIndex {
+            name: "test".into(),
+            description: "Testing".into(),
+        }];
+        let result = prepare_first_message_with_skills_index("Hello", &skills, Some("Be concise."));
+        assert!(result.contains("[Assistant Rules]"));
+        assert!(result.contains("Be concise."));
+        assert!(result.contains("- **test**: Testing"));
+        assert!(result.contains("[/Assistant Rules]"));
+        assert!(result.ends_with("Hello"));
+    }
+
+    #[test]
+    fn prepare_first_message_with_full_skills() {
+        let skills = vec![SkillDefinition {
+            name: "review".into(),
+            description: "Review".into(),
+            location: PathBuf::new(),
+            source: aionui_extension::SkillSource::Custom,
+            relative_location: None,
+            body: Some("Full review instructions here.".into()),
+        }];
+        let result = prepare_first_message("Hello", &skills, None);
+        assert!(result.contains("[Assistant Rules]"));
+        assert!(result.contains("## Skill: review"));
+        assert!(result.contains("Full review instructions here."));
+        assert!(result.contains("[/Assistant Rules]"));
+        assert!(result.ends_with("Hello"));
+    }
+
+    #[test]
+    fn prepare_first_message_no_skills_no_context() {
+        let result = prepare_first_message("Hello", &[], None);
+        assert_eq!(result, "Hello");
+    }
+
+    #[test]
+    fn prepare_first_message_context_only() {
+        let result = prepare_first_message_with_skills_index("Hello", &[], Some("Rules here."));
+        assert!(result.contains("[Assistant Rules]"));
+        assert!(result.contains("Rules here."));
+        assert!(result.ends_with("Hello"));
+    }
+
+    // -----------------------------------------------------------------------
+    // System instructions builder
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_system_instructions_no_skills() {
+        let result = build_system_instructions("Base prompt", &[]);
+        assert_eq!(result, "Base prompt");
+    }
+
+    #[test]
+    fn build_system_instructions_with_skills() {
+        let skills = vec![SkillDefinition {
+            name: "helper".into(),
+            description: "A helper".into(),
+            location: PathBuf::new(),
+            source: aionui_extension::SkillSource::Custom,
+            relative_location: None,
+            body: Some("Helper body content.".into()),
+        }];
+        let result = build_system_instructions("Base prompt", &skills);
+        assert!(result.starts_with("Base prompt"));
+        assert!(result.contains("## Skill: helper"));
+        assert!(result.contains("Helper body content."));
+    }
+
+    #[test]
+    fn build_system_instructions_with_skills_index_no_skills() {
+        let result = build_system_instructions_with_skills_index("Base prompt", &[]);
+        assert_eq!(result, "Base prompt");
+    }
+
+    #[test]
+    fn build_system_instructions_with_skills_index_includes_index() {
+        let skills = vec![SkillIndex {
+            name: "helper".into(),
+            description: "A helper skill".into(),
+        }];
+        let result = build_system_instructions_with_skills_index("Base prompt", &skills);
+        assert!(result.starts_with("Base prompt"));
+        assert!(result.contains("## Available Skills"));
+        assert!(result.contains("- **helper**: A helper skill"));
+        assert!(result.contains("[LOAD_SKILL: skill-name]"));
+    }
+
+    #[test]
+    fn build_system_instructions_skips_unloaded_skills() {
+        let skills = vec![SkillDefinition {
+            name: "unloaded".into(),
+            description: "Not loaded".into(),
+            location: PathBuf::new(),
+            source: aionui_extension::SkillSource::Custom,
+            relative_location: None,
+            body: None,
+        }];
+        let result = build_system_instructions("Base", &skills);
+        assert_eq!(result, "Base");
+    }
+}


### PR DESCRIPTION
## Summary

Preventive split of `crates/aionui-ai-agent/src/capability/skill_manager.rs` (672 lines) per Stage 9 of the aionui-ai-agent refactor plan (`docs/superpowers/plans/2026-05-07-aionui-ai-agent-refactor.md`). Approaching the 1000-line ceiling — split along the natural seam of *discovery/lifecycle* vs *pure prompt construction*.

New layout under `skill_manager/`:

| File | Lines | Responsibility |
|---|---|---|
| `mod.rs` | 415 | `AcpSkillManager` struct + discovery impl (new, discover_skills, discover_by_names, get_skills_index, get_skill, is_discovered), `SkillDefinition` / `SkillIndex` types, `LOAD_SKILL_RE`, `detect_skill_load_request`, `extract_body`, and tests for all of the above |
| `prompt_builder.rs` | 267 | Pure functions: `build_skills_index_text`, `build_system_instructions`, `build_system_instructions_with_skills_index`, `prepare_first_message`, `prepare_first_message_with_skills_index`, plus tests |

Public API unchanged — `prompt_builder` re-exported via `pub use prompt_builder::*;` in `mod.rs`, so existing call sites (`first_message_injector.rs`, `manager/acp/agent.rs`, `factory/mod.rs`, `lib.rs`) keep their imports.

**Note on `mod.rs` at 415 lines:** 15 lines over the 400 soft guideline but well within the 1000-line hard limit. Content is cohesive (discovery + detection + struct definitions + their tests); further splitting would fragment tightly-coupled logic. Documented here rather than silently deviating from the plan.

## Review invariants (spec §9 "Pure file move")

- **Byte-level body preservation.** Function bodies (including test bodies) moved without modification. Only changes: `use super::{SkillIndex, SkillDefinition};` added to `prompt_builder.rs`.
- **No unrelated edits.** `git diff --stat 00fe2e4..HEAD` only touches `skill_manager/*` paths.
- **All 26 tests preserved.** 11 tests in mod.rs (new + skill_definition + extract_body×3 + detect×5 + get_skill_unknown) + 12 tests in prompt_builder.rs (index_text×2 + prepare×5 + system_instructions×5) + 3 Git-detected as rename-rewrites of existing.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p aionui-ai-agent -- -D warnings`
- [x] `cargo test -p aionui-ai-agent --lib` — 298 passed
- [ ] Full workspace clippy + test (not run; out of scope for single-crate preventive split)

## Out of scope

Stage 9.3 (openclaw/agent.rs split) will land as a separate PR.