### PR TITLE
refactor(ai-agent): split openclaw/agent.rs into submodules (Stage 9.3, M5)

### DIFF
--- a/crates/aionui-ai-agent/src/manager/openclaw/agent/confirmations.rs
+++ b/crates/aionui-ai-agent/src/manager/openclaw/agent/confirmations.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+
+use aionui_common::{AppError, Confirmation};
+use serde_json::{Value, json};
+use tracing::warn;
+
+use crate::shared_kernel::approval_key;
+
+use super::OpenClawAgentManager;
+
+/// OpenClaw-specific operations reached through `AgentInstance::OpenClaw(..)`
+/// matches in the routes + services (e.g. `persist_session_key` uses
+/// `get_session_key`, and `get_openclaw_runtime` calls `get_diagnostics`).
+impl OpenClawAgentManager {
+    pub fn confirm(&self, _msg_id: &str, call_id: &str, _data: Value, always_allow: bool) -> Result<(), AppError> {
+        if let Ok(mut state) = self.state.try_write() {
+            if always_allow && let Some(conf) = state.confirmations.iter().find(|c| c.call_id == call_id) {
+                let key = approval_key(conf.action.as_deref(), conf.command_type.as_deref());
+                state.approval_memory.insert(key, true);
+            }
+            state.confirmations.retain(|c| c.call_id != call_id);
+        }
+
+        let connection = Arc::clone(&self.connection);
+        let call_id = call_id.to_owned();
+        let option_id = if always_allow { "allow_always" } else { "allow_once" };
+        let option_id = option_id.to_owned();
+        tokio::spawn(async move {
+            let params = json!({
+                "requestId": call_id,
+                "optionId": option_id,
+            });
+            if let Err(e) = connection.request::<Value>("exec.approval.respond", params).await {
+                warn!(error = %e, "Failed to send OpenClaw approval response");
+            }
+        });
+
+        Ok(())
+    }
+
+    pub fn get_confirmations(&self) -> Vec<Confirmation> {
+        self.state
+            .try_read()
+            .map(|g| g.confirmations.clone())
+            .unwrap_or_default()
+    }
+
+    pub fn check_approval(&self, action: &str, command_type: Option<&str>) -> bool {
+        self.state
+            .try_read()
+            .map(|g| {
+                let key = approval_key(Some(action), command_type);
+                g.approval_memory.get(&key).copied().unwrap_or(false)
+            })
+            .unwrap_or(false)
+    }
+
+    pub fn get_session_key(&self) -> Option<String> {
+        self.state.try_read().ok().and_then(|g| g.session_key.clone())
+    }
+}

--- a/crates/aionui-ai-agent/src/manager/openclaw/agent/mod.rs
+++ b/crates/aionui-ai-agent/src/manager/openclaw/agent/mod.rs
@@ -10,9 +10,8 @@ use tracing::{debug, error, info, warn};
 use crate::agent_runtime::AgentRuntime;
 use crate::capability::cli_process::CliAgentProcess;
 use crate::protocol::events::AgentStreamEvent;
-use crate::shared_kernel::approval_key;
 use crate::types::SendMessageData;
-use aionui_api_types::{OpenClawBuildExtra, OpenClawGatewayConfig};
+use aionui_api_types::OpenClawBuildExtra;
 
 use super::config::load_openclaw_config;
 use super::connection::{AuthConfig, OpenClawConnection};
@@ -23,28 +22,31 @@ use super::protocol::{
     SessionsResolveResponse, normalize_ws_url,
 };
 
-use aionui_common::{CommandSpec, EnvVar};
+mod confirmations;
+mod spawn_helpers;
+
+use spawn_helpers::{build_spawn_config, is_port_listening, wait_for_gateway_ready};
 
 pub const DEFAULT_GATEWAY_PORT: u16 = 18789;
 
 const OPENCLAW_KILL_GRACE_MS: u64 = 1000;
-const GATEWAY_READY_TIMEOUT: Duration = Duration::from_secs(10);
-const GATEWAY_READY_POLL_INTERVAL: Duration = Duration::from_millis(200);
+pub(super) const GATEWAY_READY_TIMEOUT: Duration = Duration::from_secs(10);
+pub(super) const GATEWAY_READY_POLL_INTERVAL: Duration = Duration::from_millis(200);
 const STOP_FINISH_FALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
 
-struct OpenClawState {
-    session_key: Option<String>,
-    confirmations: Vec<Confirmation>,
-    has_messages: bool,
-    approval_memory: HashMap<String, bool>,
+pub(super) struct OpenClawState {
+    pub(super) session_key: Option<String>,
+    pub(super) confirmations: Vec<Confirmation>,
+    pub(super) has_messages: bool,
+    pub(super) approval_memory: HashMap<String, bool>,
 }
 
 pub struct OpenClawAgentManager {
     runtime: AgentRuntime,
     config: OpenClawBuildExtra,
     gateway_process: Option<Arc<CliAgentProcess>>,
-    connection: Arc<OpenClawConnection>,
-    state: Arc<RwLock<OpenClawState>>,
+    pub(super) connection: Arc<OpenClawConnection>,
+    pub(super) state: Arc<RwLock<OpenClawState>>,
     text_state: Mutex<TextFallbackState>,
 }
 
@@ -483,166 +485,5 @@ impl crate::agent_task::IAgentTask for OpenClawAgentManager {
         }
 
         Ok(())
-    }
-}
-
-/// OpenClaw-specific operations reached through `AgentInstance::OpenClaw(..)`
-/// matches in the routes + services (e.g. `persist_session_key` uses
-/// `get_session_key`, and `get_openclaw_runtime` calls `get_diagnostics`).
-impl OpenClawAgentManager {
-    pub fn confirm(&self, _msg_id: &str, call_id: &str, _data: Value, always_allow: bool) -> Result<(), AppError> {
-        if let Ok(mut state) = self.state.try_write() {
-            if always_allow && let Some(conf) = state.confirmations.iter().find(|c| c.call_id == call_id) {
-                let key = approval_key(conf.action.as_deref(), conf.command_type.as_deref());
-                state.approval_memory.insert(key, true);
-            }
-            state.confirmations.retain(|c| c.call_id != call_id);
-        }
-
-        let connection = Arc::clone(&self.connection);
-        let call_id = call_id.to_owned();
-        let option_id = if always_allow { "allow_always" } else { "allow_once" };
-        let option_id = option_id.to_owned();
-        tokio::spawn(async move {
-            let params = json!({
-                "requestId": call_id,
-                "optionId": option_id,
-            });
-            if let Err(e) = connection.request::<Value>("exec.approval.respond", params).await {
-                warn!(error = %e, "Failed to send OpenClaw approval response");
-            }
-        });
-
-        Ok(())
-    }
-
-    pub fn get_confirmations(&self) -> Vec<Confirmation> {
-        self.state
-            .try_read()
-            .map(|g| g.confirmations.clone())
-            .unwrap_or_default()
-    }
-
-    pub fn check_approval(&self, action: &str, command_type: Option<&str>) -> bool {
-        self.state
-            .try_read()
-            .map(|g| {
-                let key = approval_key(Some(action), command_type);
-                g.approval_memory.get(&key).copied().unwrap_or(false)
-            })
-            .unwrap_or(false)
-    }
-
-    pub fn get_session_key(&self) -> Option<String> {
-        self.state.try_read().ok().and_then(|g| g.session_key.clone())
-    }
-}
-
-fn build_spawn_config(cli_path: &str, workspace: &str, gateway: &OpenClawGatewayConfig) -> CommandSpec {
-    let host = gateway.host.as_deref().unwrap_or("127.0.0.1");
-    let port = gateway.port.unwrap_or(DEFAULT_GATEWAY_PORT);
-
-    let mut env = vec![
-        EnvVar {
-            name: "OPENCLAW_GATEWAY_HOST".into(),
-            value: host.to_owned(),
-        },
-        EnvVar {
-            name: "OPENCLAW_GATEWAY_PORT".into(),
-            value: port.to_string(),
-        },
-    ];
-
-    if let Some(ref token) = gateway.token {
-        env.push(EnvVar {
-            name: "OPENCLAW_GATEWAY_TOKEN".into(),
-            value: token.clone(),
-        });
-    }
-    if let Some(ref password) = gateway.password {
-        env.push(EnvVar {
-            name: "OPENCLAW_GATEWAY_PASSWORD".into(),
-            value: password.clone(),
-        });
-    }
-
-    CommandSpec {
-        command: cli_path.into(),
-        args: vec!["gateway".into(), "--port".into(), port.to_string()],
-        env,
-        cwd: Some(workspace.to_owned()),
-    }
-}
-
-async fn is_port_listening(host: &str, port: u16) -> bool {
-    tokio::net::TcpStream::connect((host, port)).await.is_ok()
-}
-
-async fn wait_for_gateway_ready(host: &str, port: u16) -> Result<(), AppError> {
-    let start = tokio::time::Instant::now();
-    while start.elapsed() < GATEWAY_READY_TIMEOUT {
-        if is_port_listening(host, port).await {
-            return Ok(());
-        }
-        tokio::time::sleep(GATEWAY_READY_POLL_INTERVAL).await;
-    }
-    Err(AppError::Internal(format!(
-        "OpenClaw gateway did not become ready on {host}:{port} within {}s",
-        GATEWAY_READY_TIMEOUT.as_secs()
-    )))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn default_gateway_port_is_18789() {
-        assert_eq!(DEFAULT_GATEWAY_PORT, 18789);
-    }
-
-    fn env_val<'a>(config: &'a CommandSpec, name: &str) -> Option<&'a str> {
-        config.env.iter().find(|e| e.name == name).map(|e| e.value.as_str())
-    }
-
-    #[test]
-    fn build_spawn_config_with_defaults() {
-        let gateway = OpenClawGatewayConfig {
-            host: None,
-            port: None,
-            token: None,
-            password: None,
-            use_external_gateway: false,
-            cli_path: Some("/usr/bin/openclaw".into()),
-        };
-        let config = build_spawn_config("/usr/bin/openclaw", "/proj", &gateway);
-        assert_eq!(config.command.to_str().unwrap(), "/usr/bin/openclaw");
-        assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_HOST").unwrap(), "127.0.0.1");
-        assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_PORT").unwrap(), "18789");
-        assert!(env_val(&config, "OPENCLAW_GATEWAY_TOKEN").is_none());
-    }
-
-    #[test]
-    fn build_spawn_config_with_custom_gateway() {
-        let gateway = OpenClawGatewayConfig {
-            host: Some("remote.host".into()),
-            port: Some(9999),
-            token: Some("secret".into()),
-            password: Some("pass".into()),
-            use_external_gateway: true,
-            cli_path: Some("/usr/bin/openclaw".into()),
-        };
-        let config = build_spawn_config("/usr/bin/openclaw", "/proj", &gateway);
-        assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_HOST").unwrap(), "remote.host");
-        assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_PORT").unwrap(), "9999");
-        assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_TOKEN").unwrap(), "secret");
-        assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_PASSWORD").unwrap(), "pass");
-    }
-
-    #[test]
-    fn approval_key_formats_correctly() {
-        assert_eq!(approval_key(Some("edit"), Some("file")), "edit:file");
-        assert_eq!(approval_key(Some("edit"), None), "edit");
-        assert_eq!(approval_key(None, None), "");
     }
 }

--- a/crates/aionui-ai-agent/src/manager/openclaw/agent/spawn_helpers.rs
+++ b/crates/aionui-ai-agent/src/manager/openclaw/agent/spawn_helpers.rs
@@ -1,0 +1,114 @@
+use aionui_api_types::OpenClawGatewayConfig;
+use aionui_common::{AppError, CommandSpec, EnvVar};
+
+use super::{DEFAULT_GATEWAY_PORT, GATEWAY_READY_POLL_INTERVAL, GATEWAY_READY_TIMEOUT};
+
+pub(super) fn build_spawn_config(cli_path: &str, workspace: &str, gateway: &OpenClawGatewayConfig) -> CommandSpec {
+    let host = gateway.host.as_deref().unwrap_or("127.0.0.1");
+    let port = gateway.port.unwrap_or(DEFAULT_GATEWAY_PORT);
+
+    let mut env = vec![
+        EnvVar {
+            name: "OPENCLAW_GATEWAY_HOST".into(),
+            value: host.to_owned(),
+        },
+        EnvVar {
+            name: "OPENCLAW_GATEWAY_PORT".into(),
+            value: port.to_string(),
+        },
+    ];
+
+    if let Some(ref token) = gateway.token {
+        env.push(EnvVar {
+            name: "OPENCLAW_GATEWAY_TOKEN".into(),
+            value: token.clone(),
+        });
+    }
+    if let Some(ref password) = gateway.password {
+        env.push(EnvVar {
+            name: "OPENCLAW_GATEWAY_PASSWORD".into(),
+            value: password.clone(),
+        });
+    }
+
+    CommandSpec {
+        command: cli_path.into(),
+        args: vec!["gateway".into(), "--port".into(), port.to_string()],
+        env,
+        cwd: Some(workspace.to_owned()),
+    }
+}
+
+pub(super) async fn is_port_listening(host: &str, port: u16) -> bool {
+    tokio::net::TcpStream::connect((host, port)).await.is_ok()
+}
+
+pub(super) async fn wait_for_gateway_ready(host: &str, port: u16) -> Result<(), AppError> {
+    let start = tokio::time::Instant::now();
+    while start.elapsed() < GATEWAY_READY_TIMEOUT {
+        if is_port_listening(host, port).await {
+            return Ok(());
+        }
+        tokio::time::sleep(GATEWAY_READY_POLL_INTERVAL).await;
+    }
+    Err(AppError::Internal(format!(
+        "OpenClaw gateway did not become ready on {host}:{port} within {}s",
+        GATEWAY_READY_TIMEOUT.as_secs()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared_kernel::approval_key;
+
+    #[test]
+    fn default_gateway_port_is_18789() {
+        assert_eq!(DEFAULT_GATEWAY_PORT, 18789);
+    }
+
+    fn env_val<'a>(config: &'a CommandSpec, name: &str) -> Option<&'a str> {
+        config.env.iter().find(|e| e.name == name).map(|e| e.value.as_str())
+    }
+
+    #[test]
+    fn build_spawn_config_with_defaults() {
+        let gateway = OpenClawGatewayConfig {
+            host: None,
+            port: None,
+            token: None,
+            password: None,
+            use_external_gateway: false,
+            cli_path: Some("/usr/bin/openclaw".into()),
+        };
+        let config = build_spawn_config("/usr/bin/openclaw", "/proj", &gateway);
+        assert_eq!(config.command.to_str().unwrap(), "/usr/bin/openclaw");
+        assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_HOST").unwrap(), "127.0.0.1");
+        assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_PORT").unwrap(), "18789");
+        assert!(env_val(&config, "OPENCLAW_GATEWAY_TOKEN").is_none());
+    }
+
+    #[test]
+    fn build_spawn_config_with_custom_gateway() {
+        let gateway = OpenClawGatewayConfig {
+            host: Some("remote.host".into()),
+            port: Some(9999),
+            token: Some("secret".into()),
+            password: Some("pass".into()),
+            use_external_gateway: true,
+            cli_path: Some("/usr/bin/openclaw".into()),
+        };
+        let config = build_spawn_config("/usr/bin/openclaw", "/proj", &gateway);
+        assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_HOST").unwrap(), "remote.host");
+        assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_PORT").unwrap(), "9999");
+        assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_TOKEN").unwrap(), "secret");
+        assert_eq!(env_val(&config, "OPENCLAW_GATEWAY_PASSWORD").unwrap(), "pass");
+    }
+
+    #[test]
+    fn approval_key_formats_correctly() {
+        assert_eq!(approval_key(Some("edit"), Some("file")), "edit:file");
+        assert_eq!(approval_key(Some("edit"), None), "edit");
+        assert_eq!(approval_key(None, None), "");
+    }
+}


### PR DESCRIPTION
## Summary

Preventive split of `crates/aionui-ai-agent/src/manager/openclaw/agent.rs` (648 lines) per Stage 9 of the aionui-ai-agent refactor plan (`docs/superpowers/plans/2026-05-07-aionui-ai-agent-refactor.md`). Completes the Stage 9 split trilogy (cli_process → skill_manager → openclaw/agent).

New layout under `manager/openclaw/agent/`:

| File | Lines | Responsibility |
|---|---|---|
| `mod.rs` | 489 | Constants + `OpenClawState` + `OpenClawAgentManager` struct + core impl (new, event relay, send pipeline, resolve_session, diagnostics) + `IAgentTask` impl |
| `confirmations.rs` | 61 | `OpenClawAgentManager::confirm` / `get_confirmations` / `check_approval` / `get_session_key` — the m2-related approval/confirmation helpers |
| `spawn_helpers.rs` | 114 | Free fns `build_spawn_config`, `is_port_listening`, `wait_for_gateway_ready` + tests |

Public path `crate::manager::openclaw::agent::OpenClawAgentManager` is unchanged — `OpenClawAgentManager` lives in `agent/mod.rs` and is reached the same way.

**Note on `mod.rs` at 489 lines:** The spec's soft ≤ 400 guideline conflicts with the explicit content layout (core impl + `IAgentTask` impl must stay together per the plan). Further splitting would require either extracting helper methods (violates "pure file move" invariant) or moving the `IAgentTask` impl to its own file (fragments a single trait's surface). Accepted the 489-line mod.rs — well within the 1000-line hard cap.

## Review invariants (spec §9 "Pure file move")

- **Byte-level body preservation.** Function bodies unchanged. Only deltas: (1) `use super::...` added where sub-files need access; (2) visibility widened to `pub(super)` for items now crossing file boundaries:
  - `OpenClawState` fields (used by `confirmations.rs`)
  - `OpenClawAgentManager::{connection, state}` (used by `confirmations.rs`)
  - `GATEWAY_READY_TIMEOUT`, `GATEWAY_READY_POLL_INTERVAL` (used by `spawn_helpers.rs`)
  - Free fns `build_spawn_config`, `is_port_listening`, `wait_for_gateway_ready` (called from `mod.rs::new`)
- **No unrelated edits.** `git diff --stat 0fe499c..HEAD` only touches `manager/openclaw/agent/*` paths.
- **All tests preserved.** 4 tests (`default_gateway_port_is_18789`, `build_spawn_config_with_defaults`, `build_spawn_config_with_custom_gateway`, `approval_key_formats_correctly`) moved intact into `spawn_helpers.rs`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p aionui-ai-agent -- -D warnings`
- [x] `cargo test -p aionui-ai-agent --lib` — 298 passed
- [ ] Full workspace clippy + test (not run; out of scope for single-crate preventive split)

Pre-existing compile failure in `tests/acp_agent_integration.rs` (same class as the documented `agent_types_integration` upstream breakage) is unrelated to this PR.

## Stage 9 status

This completes Stage 9 of the plan:
- ✅ Stage 9.1: `cli_process.rs` split (#179)
- ✅ Stage 9.2: `skill_manager.rs` split (#180)
- ✅ Stage 9.3: `openclaw/agent.rs` split (this PR)