### PR TITLE
fix(conversation): compute thinking duration in send_thinking_done

### DIFF
--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -120,7 +120,7 @@ impl StreamRelay {
                             // Otherwise the thinking_done arriving after finish
                             // re-activates the processing indicator.
                             if has_thinking {
-                                self.send_thinking_done();
+                                self.send_thinking_done(thinking_started_at);
                             }
                             self.forward_to_websocket(&event);
                             self.persist_thinking(&thinking_buffer, thinking_started_at).await;
@@ -144,7 +144,7 @@ impl StreamRelay {
                         "StreamRelay channel closed without terminal event"
                     );
                     if has_thinking {
-                        self.send_thinking_done();
+                        self.send_thinking_done(thinking_started_at);
                     }
                     self.persist_thinking(&thinking_buffer, thinking_started_at).await;
                     // Channel closed without finish/error — still finalize
@@ -312,9 +312,11 @@ impl StreamRelay {
         if thinking_buffer.is_empty() {
             return;
         }
+        let duration_ms = started_at.map(|t| (now_ms() - t).max(0));
         let content = json!({
             "content": thinking_buffer,
             "status": "done",
+            "duration_ms": duration_ms,
         })
         .to_string();
         let row = MessageRow {
@@ -334,11 +336,12 @@ impl StreamRelay {
     }
 
     /// Send a `thinking` event with `status: "done"` to close the thinking UI.
-    fn send_thinking_done(&self) {
+    fn send_thinking_done(&self, started_at: Option<i64>) {
+        let duration = started_at.map(|t| (now_ms() - t).max(0) as u64);
         let thinking_done = AgentStreamEvent::Thinking(ThinkingEventData {
             content: String::new(),
             subject: None,
-            duration: None,
+            duration,
             status: Some("done".into()),
         });
         self.forward_to_websocket(&thinking_done);


### PR DESCRIPTION
## Summary

- `send_thinking_done()` previously hardcoded `duration: None`, causing frontend to display "0s" for all completed thinking blocks
- Now accepts `thinking_started_at` parameter and computes elapsed milliseconds
- Also persists `duration_ms` in the thinking message content JSON so history loads can display correct thinking time

## Root Cause

`stream_relay.rs:337` — `send_thinking_done()` never received the `thinking_started_at` timestamp that was already being tracked in `consume()` (line 76, 89). The field was always serialized as `null`, which the frontend rendered as 0s.

## Changes

Single file: `crates/aionui-conversation/src/stream_relay.rs` (+7, -4)

## Test plan

- [x] `cargo test -p aionui-conversation` — 29 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build --release` — success
- [ ] Manual verification: send a message, observe thinking duration displays correct seconds instead of 0s

🤖 Generated with [Claude Code](https://claude.com/claude-code)