### PR TITLE
refactor(ai-agent): rename IAgentTask::stop → cancel workspace-wide

### DIFF
--- a/crates/aionui-ai-agent/src/agent_task.rs
+++ b/crates/aionui-ai-agent/src/agent_task.rs
@@ -61,7 +61,7 @@ pub trait IAgentTask: Send + Sync {
     async fn send_message(&self, data: SendMessageData) -> Result<(), AppError>;
 
     /// Stop the current streaming response without killing the agent.
-    async fn stop(&self) -> Result<(), AppError>;
+    async fn cancel(&self) -> Result<(), AppError>;
 
     /// Terminate the agent process.
     ///
@@ -197,9 +197,9 @@ impl AgentInstance {
         self.as_task().send_message(data).await
     }
 
-    /// Stop the current streaming response without killing the agent.
-    pub async fn stop(&self) -> Result<(), AppError> {
-        self.as_task().stop().await
+    /// Cancel the current streaming response without killing the agent.
+    pub async fn cancel(&self) -> Result<(), AppError> {
+        self.as_task().cancel().await
     }
 
     /// Terminate the agent process.

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -556,7 +556,7 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
         result
     }
 
-    async fn stop(&self) -> Result<(), AppError> {
+    async fn cancel(&self) -> Result<(), AppError> {
         let session_id = self.session.read().await.session_id().map(ToOwned::to_owned);
         if let Some(sid) = session_id {
             self.protocol.cancel(CancelNotification::new(SessionId::new(sid)));

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -234,7 +234,7 @@ impl crate::agent_task::IAgentTask for AionrsAgentManager {
         }
     }
 
-    async fn stop(&self) -> Result<(), AppError> {
+    async fn cancel(&self) -> Result<(), AppError> {
         info!(
             conversation_id = %self.runtime.conversation_id(),
             "Aionrs stop requested"
@@ -422,7 +422,7 @@ mod tests {
             .unwrap();
         let mut rx = agent.subscribe();
 
-        agent.stop().await.unwrap();
+        agent.cancel().await.unwrap();
 
         assert_eq!(agent.status(), Some(ConversationStatus::Finished));
 

--- a/crates/aionui-ai-agent/src/manager/nanobot/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/nanobot/agent.rs
@@ -193,7 +193,7 @@ impl crate::agent_task::IAgentTask for NanobotAgentManager {
         self.process.send(&payload).await
     }
 
-    async fn stop(&self) -> Result<(), AppError> {
+    async fn cancel(&self) -> Result<(), AppError> {
         let payload = json!({ "type": "stop.stream", "data": {} });
         self.process.send(&payload).await
     }

--- a/crates/aionui-ai-agent/src/manager/openclaw/agent/mod.rs
+++ b/crates/aionui-ai-agent/src/manager/openclaw/agent/mod.rs
@@ -423,7 +423,7 @@ impl crate::agent_task::IAgentTask for OpenClawAgentManager {
         result
     }
 
-    async fn stop(&self) -> Result<(), AppError> {
+    async fn cancel(&self) -> Result<(), AppError> {
         let session_key = self.state.read().await.session_key.clone();
         if let Some(ref key) = session_key {
             let params = ChatAbortParams {

--- a/crates/aionui-ai-agent/src/manager/remote/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/remote/agent.rs
@@ -314,7 +314,7 @@ impl crate::agent_task::IAgentTask for RemoteAgentManager {
         }
     }
 
-    async fn stop(&self) -> Result<(), AppError> {
+    async fn cancel(&self) -> Result<(), AppError> {
         let payload = json!({ "type": "session/cancel", "data": {} });
         self.ws_send(&payload).await?;
 

--- a/crates/aionui-ai-agent/src/task_manager.rs
+++ b/crates/aionui-ai-agent/src/task_manager.rs
@@ -227,7 +227,7 @@ mod tests {
         async fn send_message(&self, _data: SendMessageData) -> Result<(), AppError> {
             Ok(())
         }
-        async fn stop(&self) -> Result<(), AppError> {
+        async fn cancel(&self) -> Result<(), AppError> {
             Ok(())
         }
         fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -104,7 +104,7 @@ async fn make_mock_agent(script: &str, backend: &str) -> (Arc<AcpAgentManager>, 
         config,
     ));
 
-    let (manager, _domain_rx) = AcpAgentManager::new(params, skill_manager, &catalog_tx)
+    let (manager, _, _) = AcpAgentManager::new(params, skill_manager, &catalog_tx)
         .await
         .expect("Failed to spawn mock ACP agent");
 

--- a/crates/aionui-ai-agent/tests/agent_types_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_types_integration.rs
@@ -74,7 +74,7 @@ impl IAgentTask for TypedMockAgent {
     async fn send_message(&self, _data: SendMessageData) -> Result<(), aionui_common::AppError> {
         Ok(())
     }
-    async fn stop(&self) -> Result<(), aionui_common::AppError> {
+    async fn cancel(&self) -> Result<(), aionui_common::AppError> {
         Ok(())
     }
     fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), aionui_common::AppError> {

--- a/crates/aionui-app/tests/agent_integration_e2e.rs
+++ b/crates/aionui-app/tests/agent_integration_e2e.rs
@@ -85,7 +85,7 @@ impl IAgentTask for MockAgent {
         Ok(())
     }
 
-    async fn stop(&self) -> Result<(), AppError> {
+    async fn cancel(&self) -> Result<(), AppError> {
         Ok(())
     }
 

--- a/crates/aionui-app/tests/common/mod.rs
+++ b/crates/aionui-app/tests/common/mod.rs
@@ -156,7 +156,7 @@ impl IAgentTask for NoopMockAgent {
     ) -> Result<(), aionui_common::AppError> {
         Ok(())
     }
-    async fn stop(&self) -> Result<(), aionui_common::AppError> {
+    async fn cancel(&self) -> Result<(), aionui_common::AppError> {
         Ok(())
     }
     fn kill(&self, _reason: Option<aionui_common::AgentKillReason>) -> Result<(), aionui_common::AppError> {

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -1133,9 +1133,9 @@ impl ConversationService {
             .get_task(conversation_id)
             .ok_or_else(|| AppError::Conflict("No active agent for this conversation".into()))?;
 
-        agent.stop().await?;
+        agent.cancel().await?;
 
-        info!(conversation_id, "Stream stopped");
+        info!(conversation_id, "Stream canceled");
         Ok(())
     }
 

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1224,7 +1224,7 @@ impl IAgentTask for MockAgent {
         ));
         Ok(())
     }
-    async fn stop(&self) -> Result<(), AppError> {
+    async fn cancel(&self) -> Result<(), AppError> {
         *self.stopped.lock().unwrap() = true;
         Ok(())
     }
@@ -1447,7 +1447,7 @@ impl IAgentTask for ScriptedAgent {
         Ok(())
     }
 
-    async fn stop(&self) -> Result<(), AppError> {
+    async fn cancel(&self) -> Result<(), AppError> {
         Ok(())
     }
 

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -2103,7 +2103,7 @@ mod tests {
             Ok(())
         }
 
-        async fn stop(&self) -> Result<(), aionui_common::AppError> {
+        async fn cancel(&self) -> Result<(), aionui_common::AppError> {
             Ok(())
         }
 

--- a/crates/aionui-team/src/scheduler/tests.rs
+++ b/crates/aionui-team/src/scheduler/tests.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use aionui_ai_agent::AgentStreamEvent;
-use aionui_ai_agent::protocol::events::{ErrorEventData, FinishEventData, TextEventData};
+use aionui_ai_agent::protocol::events::{FinishEventData, TextEventData};
 use aionui_api_types::WebSocketMessage;
 use aionui_realtime::EventBroadcaster;
 use dashmap::DashMap;

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -987,7 +987,7 @@ mod tests {
                 None => Ok(()),
             }
         }
-        async fn stop(&self) -> Result<(), AppError> {
+        async fn cancel(&self) -> Result<(), AppError> {
             Ok(())
         }
         fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {

--- a/crates/aionui-team/tests/e2e_team_flow.rs
+++ b/crates/aionui-team/tests/e2e_team_flow.rs
@@ -152,7 +152,7 @@ impl IAgentTask for RecordingAgent {
             None => Ok(()),
         }
     }
-    async fn stop(&self) -> Result<(), AppError> {
+    async fn cancel(&self) -> Result<(), AppError> {
         Ok(())
     }
     fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -537,7 +537,7 @@ mod mock_agent {
         async fn send_message(&self, _data: SendMessageData) -> Result<(), AppError> {
             Ok(())
         }
-        async fn stop(&self) -> Result<(), AppError> {
+        async fn cancel(&self) -> Result<(), AppError> {
             Ok(())
         }
         fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {


### PR DESCRIPTION
## Summary

Rename `IAgentTask::stop` → `IAgentTask::cancel` across all managers and all call sites.

**Why:** the semantic of the method is 'cancel the in-flight streaming response without killing the agent process'. `stop` was ambiguous and could be confused with `kill` / terminate. `cancel` reads accurately and aligns with the ACP SDK's own `CancelNotification`.

## Scope

- `IAgentTask` trait — method renamed
- `AgentInstance::stop` → `AgentInstance::cancel`
- All five concrete managers renamed: acp, aionrs, nanobot, openclaw, remote
- `task_manager` call site follows the rename
- Callers in `aionui-conversation`, `aionui-cron`, `aionui-team`, `aionui-app` test + integration test suites all updated
- `acp_agent_integration.rs` also follows the upstream `AcpAgentManager::new` return-tuple shape (3-tuple since M3 event-tracker split)
- `scheduler/tests.rs`: drops now-unused `ErrorEventData` import

18 files, 24 insertions / 24 deletions — pure rename, no behavior change.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test -p aionui-ai-agent --lib` — 298 passed
- [x] `cargo test -p aionui-ai-agent --test acp_agent_integration` — 1 passed, 11 ignored (mock-backed, as before)