### PR TITLE
feat(runtime): enhance PATH at startup for all downstream spawn sites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,21 @@ The bun version is pinned in
 `[package.metadata.aionui-runtime] bun_version = "..."`. Upgrading bun is
 a one-line change — no source edits required.
 
+### Startup PATH Enhancement
+
+`fn main()` calls `aionui_runtime::enhance_process_path()` **before** the
+tokio runtime starts, so every downstream `which::which(...)` and
+`Command::new(...)` — including the existing spawn sites across the
+workspace — inherits an enriched `PATH`. Three layers are merged in priority
+order: bundled bun directory → platform extra bins (`~/.bun/bin`,
+`~/.cargo/bin`, `~/.local/bin`, Windows `%APPDATA%\npm`, Git, Scoop, …) →
+current PATH → login-shell `$PATH` (Unix, 3 s timeout). The call is
+`unsafe` because Rust 2024 requires a single-threaded precondition for
+`env::set_var`; `main()` runs this as its very first statement to
+satisfy the invariant. A `startup: PATH ready path_segments=… path_len=…`
+info log confirms the enhancement at each run (no full PATH content is
+logged at `info` level).
+
 ### Pushing Code
 
 Always use `just push` instead of `git push`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "aionui-mcp",
  "aionui-office",
  "aionui-realtime",
+ "aionui-runtime",
  "aionui-shell",
  "aionui-system",
  "aionui-team",
@@ -682,6 +683,7 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 0.8.23",
  "tracing",
+ "wait-timeout",
  "which",
  "zip",
  "zstd",
@@ -5926,6 +5928,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/crates/aionui-app/Cargo.toml
+++ b/crates/aionui-app/Cargo.toml
@@ -33,6 +33,7 @@ aionui-channel.workspace = true
 aionui-team.workspace = true
 aionui-cron.workspace = true
 aionui-assistant.workspace = true
+aionui-runtime.workspace = true
 axum.workspace = true
 dirs.workspace = true
 tokio.workspace = true

--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -77,8 +77,17 @@ fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> tracing_appender::no
     guard
 }
 
-#[tokio::main]
-async fn main() -> Result<ExitCode> {
+fn main() -> Result<ExitCode> {
+    // SAFETY: called before any worker thread exists (including the tokio
+    // runtime constructed below). Rust 2024 requires `unsafe` for
+    // `std::env::set_var` invoked inside `enhance_process_path`.
+    let merged_path = unsafe { aionui_runtime::enhance_process_path() };
+
+    let runtime = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
+    runtime.block_on(async_main(merged_path))
+}
+
+async fn async_main(merged_path: String) -> Result<ExitCode> {
     // mcp-bridge / mcp-guide-stdio subcommands: live entirely outside the main
     // HTTP server and must not touch the database, logging setup, or `AppServices`.
     let mut argv = std::env::args();
@@ -94,6 +103,12 @@ async fn main() -> Result<ExitCode> {
 
     let log_dir = cli.log_dir.unwrap_or_else(|| Path::new(&cli.data_dir).join("logs"));
     let _log_guard = init_tracing(&log_dir, cli.log_level.as_deref());
+
+    tracing::info!(
+        path_segments = merged_path.split(if cfg!(windows) { ';' } else { ':' }).count(),
+        path_len = merged_path.len(),
+        "startup: PATH ready"
+    );
 
     let config = AppConfig {
         host: cli.host,

--- a/crates/aionui-runtime/Cargo.toml
+++ b/crates/aionui-runtime/Cargo.toml
@@ -32,3 +32,6 @@ tempfile.workspace = true
 zstd.workspace = true
 sha2.workspace = true
 hex.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+wait-timeout = "0.2"

--- a/crates/aionui-runtime/src/lib.rs
+++ b/crates/aionui-runtime/src/lib.rs
@@ -9,8 +9,10 @@ mod cache;
 mod embed;
 mod extract;
 mod resolver;
+mod shell_env;
 
 pub use resolver::{ResolveError, bun_bin_dir, resolve_bun};
+pub use shell_env::enhance_process_path;
 
 #[cfg(test)]
 #[path = "../build_support.rs"]

--- a/crates/aionui-runtime/src/shell_env.rs
+++ b/crates/aionui-runtime/src/shell_env.rs
@@ -1,0 +1,344 @@
+//! Startup-time PATH enhancement.
+//!
+//! Call [`enhance_process_path`] from `main()` **before any worker thread
+//! is spawned** (including the tokio runtime). It rewrites
+//! `std::env::var("PATH")` to include:
+//!
+//! 1. The bundled bun directory (highest priority).
+//! 2. Platform extra bins (`~/.bun/bin`, `~/.cargo/bin`, etc.).
+//! 3. The current `PATH` (inherited from the launching process).
+//! 4. The login-shell `PATH` (Unix only, 3s timeout) — fixes
+//!    launchd / Finder / systemd-service starts.
+//!
+//! After this runs, all downstream `which::which(...)` and
+//! `Command::new(...)` calls see the enhanced PATH with zero further
+//! wiring.
+
+use std::path::{Path, PathBuf};
+
+/// Enhance the current process's `PATH`. Returns the merged PATH string
+/// for logging/debugging.
+///
+/// # Safety
+///
+/// Must be called **before** any other thread exists (including the
+/// tokio runtime). Internally calls `std::env::set_var` which is
+/// `unsafe` on Rust 2024.
+pub unsafe fn enhance_process_path() -> String {
+    let current = std::env::var("PATH").unwrap_or_default();
+    let login = login_shell_path();
+    let extras = platform_extra_bins();
+    let bun_dir = crate::bun_bin_dir();
+
+    let merged = merge_paths(bun_dir.as_deref(), &extras, &current, login.as_deref());
+
+    if merged == current {
+        tracing::warn!("PATH enhancement produced no changes; continuing with inherited PATH");
+    } else {
+        tracing::info!(
+            login = login.is_some(),
+            extra_bin_count = extras.len(),
+            bun_bundled = bun_dir.is_some(),
+            original_len = current.len(),
+            merged_len = merged.len(),
+            "PATH enhanced at startup"
+        );
+    }
+
+    // SAFETY: caller guarantees single-threaded precondition.
+    unsafe {
+        std::env::set_var("PATH", &merged);
+    }
+    merged
+}
+
+// Placeholder helpers — filled in by later tasks.
+
+fn merge_paths(bun_dir: Option<&Path>, extras: &[PathBuf], current: &str, login: Option<&str>) -> String {
+    // Order: bun_dir, extras, current, login. First-occurrence wins.
+    // `env::split_paths` and `env::join_paths` honour the OS-specific
+    // separator (':' on Unix, ';' on Windows) and handle quoting.
+    let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+    let mut parts: Vec<PathBuf> = Vec::new();
+
+    let mut push = |p: PathBuf| {
+        if p.as_os_str().is_empty() {
+            return;
+        }
+        if seen.insert(p.clone()) {
+            parts.push(p);
+        }
+    };
+
+    if let Some(p) = bun_dir {
+        push(p.to_path_buf());
+    }
+    for p in extras {
+        push(p.clone());
+    }
+    for p in std::env::split_paths(current) {
+        push(p);
+    }
+    if let Some(l) = login {
+        for p in std::env::split_paths(l) {
+            push(p);
+        }
+    }
+
+    std::env::join_paths(&parts)
+        .map(|os| os.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+fn platform_extra_bins() -> Vec<PathBuf> {
+    platform_extra_bins_at(dirs::home_dir().as_deref())
+}
+
+fn platform_extra_bins_at(home: Option<&Path>) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    let mut push_if_dir = |p: PathBuf| {
+        if p.is_dir() {
+            out.push(p);
+        }
+    };
+
+    if let Some(h) = home {
+        push_if_dir(h.join(".bun").join("bin"));
+        push_if_dir(h.join(".cargo").join("bin"));
+        push_if_dir(h.join("go").join("bin"));
+        push_if_dir(h.join(".deno").join("bin"));
+        push_if_dir(h.join(".local").join("bin"));
+        push_if_dir(h.join(".volta").join("bin"));
+    }
+
+    #[cfg(windows)]
+    {
+        if let Ok(appdata) = std::env::var("APPDATA") {
+            push_if_dir(PathBuf::from(&appdata).join("npm"));
+        }
+        if let Ok(local) = std::env::var("LOCALAPPDATA") {
+            push_if_dir(PathBuf::from(&local).join("pnpm"));
+            push_if_dir(PathBuf::from(&local).join("fnm_multishells"));
+        }
+        if let Ok(pf) = std::env::var("ProgramFiles") {
+            push_if_dir(PathBuf::from(&pf).join("Git").join("cmd"));
+            push_if_dir(PathBuf::from(&pf).join("Git").join("bin"));
+            push_if_dir(PathBuf::from(&pf).join("nodejs"));
+        }
+        if let Ok(scoop) = std::env::var("SCOOP") {
+            push_if_dir(PathBuf::from(&scoop).join("shims"));
+        } else if let Some(h) = home {
+            push_if_dir(h.join("scoop").join("shims"));
+        }
+    }
+
+    out
+}
+
+#[cfg(unix)]
+fn login_shell_path() -> Option<String> {
+    use std::io::Read;
+    use std::process::{Command, Stdio};
+    use std::time::Duration;
+    use wait_timeout::ChildExt;
+
+    let shell = std::env::var("SHELL").ok()?;
+    if !Path::new(&shell).is_absolute() {
+        tracing::debug!(%shell, "SHELL is not absolute, skipping login shell probe");
+        return None;
+    }
+
+    let mut child = match Command::new(&shell)
+        .args(["-l", "-c", "printf %s \"$PATH\""])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::debug!(%shell, error = %e, "login shell spawn failed");
+            return None;
+        }
+    };
+
+    // Take stdout handle before waiting to prevent pipe-buffer deadlock.
+    // If the PATH string is long enough to fill the pipe buffer, the child
+    // will block on write while we block on wait — causing a deadlock and
+    // the 3s timeout to fire. Reading stdout first drains the buffer.
+    let mut stdout_handle = child.stdout.take()?;
+    let mut stdout = String::new();
+    stdout_handle.read_to_string(&mut stdout).ok()?;
+
+    let status = match child.wait_timeout(Duration::from_secs(3)) {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            tracing::warn!("login shell PATH probe timed out after 3s");
+            return None;
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "login shell wait_timeout errored");
+            return None;
+        }
+    };
+
+    if !status.success() {
+        tracing::debug!(?status, "login shell exited non-zero");
+        return None;
+    }
+
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(not(unix))]
+fn login_shell_path() -> Option<String> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sep() -> &'static str {
+        if cfg!(windows) { ";" } else { ":" }
+    }
+
+    #[test]
+    fn merge_paths_dedupes_preserve_order() {
+        let s = sep();
+        let current = format!("/a{s}/b{s}/c");
+        let login = format!("/b{s}/d");
+        let extras: Vec<PathBuf> = vec![PathBuf::from("/e")];
+
+        let result = merge_paths(None, &extras, &current, Some(&login));
+        let parts: Vec<&str> = result.split(s).collect();
+
+        assert_eq!(parts, vec!["/e", "/a", "/b", "/c", "/d"]);
+    }
+
+    #[test]
+    fn merge_paths_with_bun_dir_at_front() {
+        let s = sep();
+        let current = format!("/a{s}/b");
+        let bun = PathBuf::from("/bun");
+
+        let result = merge_paths(Some(&bun), &[], &current, None);
+        let parts: Vec<&str> = result.split(s).collect();
+
+        assert_eq!(parts, vec!["/bun", "/a", "/b"]);
+    }
+
+    #[test]
+    fn merge_paths_drops_empty_segments() {
+        let s = sep();
+        let current = format!("{s}/a{s}{s}/b{s}");
+
+        let result = merge_paths(None, &[], &current, None);
+        let parts: Vec<&str> = result.split(s).collect();
+
+        assert_eq!(parts, vec!["/a", "/b"]);
+    }
+
+    #[test]
+    fn merge_paths_all_optional_none() {
+        let result = merge_paths(None, &[], "", None);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn merge_paths_bun_dir_deduplicates_if_already_in_current() {
+        let s = sep();
+        let current = format!("/bun{s}/a");
+        let bun = PathBuf::from("/bun");
+
+        let result = merge_paths(Some(&bun), &[], &current, None);
+        let parts: Vec<&str> = result.split(s).collect();
+
+        // /bun appears first (from bun_dir), then /a from current.
+        // Second /bun (inside current) is dedup'd.
+        assert_eq!(parts, vec!["/bun", "/a"]);
+    }
+
+    #[test]
+    fn platform_extra_bins_at_filters_nonexistent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+
+        // 构造少量"存在"的 bin 目录，其他 candidate 仍会被 platform_extra_bins_at
+        // 检查但应被过滤掉。
+        std::fs::create_dir_all(home.join(".bun/bin")).unwrap();
+        std::fs::create_dir_all(home.join(".cargo/bin")).unwrap();
+
+        let bins = platform_extra_bins_at(Some(home));
+
+        // 至少这两个应出现
+        assert!(
+            bins.iter().any(|p| p.ends_with(".bun/bin")),
+            "expected ~/.bun/bin in result"
+        );
+        assert!(
+            bins.iter().any(|p| p.ends_with(".cargo/bin")),
+            "expected ~/.cargo/bin in result"
+        );
+
+        // 没创建的目录不应出现
+        assert!(!bins.iter().any(|p| p.ends_with("go/bin")));
+        assert!(!bins.iter().any(|p| p.ends_with(".deno/bin")));
+    }
+
+    #[test]
+    fn platform_extra_bins_at_handles_no_home() {
+        let bins = platform_extra_bins_at(None);
+        // 没 home 时，Unix 返回空；Windows 可能仍从 env 读到 APPDATA 等——两种都可接受。
+        // 只验证不 panic。
+        let _ = bins;
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn login_shell_path_returns_none_without_shell_var() {
+        // SAFETY: single-threaded test process.
+        unsafe {
+            std::env::remove_var("SHELL");
+        }
+        let result = login_shell_path();
+        assert!(result.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn login_shell_path_rejects_relative_shell() {
+        // SAFETY: single-threaded test process.
+        unsafe {
+            std::env::set_var("SHELL", "sh");
+        }
+        let result = login_shell_path();
+        assert!(result.is_none());
+        unsafe {
+            std::env::remove_var("SHELL");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn login_shell_path_roundtrip_with_sh() {
+        // SAFETY: single-threaded test process.
+        unsafe {
+            std::env::set_var("SHELL", "/bin/sh");
+        }
+        let result = login_shell_path();
+        assert!(result.is_some(), "login shell probe should return Some");
+        let path = result.unwrap();
+        assert!(!path.is_empty(), "login shell PATH should not be empty");
+        unsafe {
+            std::env::remove_var("SHELL");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- 新增 \`aionui-runtime::shell_env::enhance_process_path()\` — 启动最早位置（tokio runtime 构造之前）调用一次，合并三层 PATH：**bundled bun 目录 → 平台 extra bins (\`~/.bun/bin\`, \`~/.cargo/bin\`, \`~/.local/bin\`, Windows \`%APPDATA%\\npm\`, Git, Scoop, …) → 当前 PATH → login-shell \$PATH (Unix, 3s 超时)**。之后所有下游 \`which::which(...)\` / \`Command::new(...)\` 自动受益。
- 修复 v2 后端"从 launchd / Finder / Windows 快捷方式 / systemd service 启动时 PATH 几乎为空"的问题——这正是 v1 \`shellEnv.ts\` 解决的 pain point，v2 到目前为止完全没覆盖。
- \`aionui-app\` 从 \`#[tokio::main]\` 改为手动构造 runtime，以满足 Rust 2024 \`env::set_var\` 的单线程前置条件。功能上等价于原 macro 展开（\`new_multi_thread().enable_all()\`）。
- 合并使用 \`std::env::split_paths\` / \`join_paths\` 处理跨平台分隔符与 PathBuf 去重。Login shell 探测避免 pipe buffer 死锁（先 read 后 wait）。
- tracing init 之后补一条结构化 \`startup: PATH ready path_segments=N path_len=M\` info 日志（不含完整 PATH 内容，避免泄漏用户目录）。

**23 个现有 \`Command::new\` / \`which::which\` 调用点未改动**——它们通过 \`env::var(\"PATH\")\` 继承自动受益。

## Test plan

- [x] \`cargo test -p aionui-runtime\` 全绿（29 unit + 2 integration；新增 10 个 shell_env 测试）
- [x] \`cargo test -p aionui-app --lib\` 全绿（12 passed）
- [x] \`cargo clippy -p aionui-runtime -p aionui-app -- -D warnings\` 无警告
- [x] \`cargo fmt --all -- --check\` 通过
- [x] Smoke: \`AIONUI_LOG_LEVEL=info ./aionui-backend --data-dir /tmp/smoke\` 打印 \`startup: PATH ready path_segments=31 path_len=1323\`
- [ ] 手工验证: \`SHELL=/bin/false cargo run\` 应在 3s 内打 warn（login shell 超时）

## Design & Plan

- Spec: \`docs/superpowers/specs/2026-05-08-startup-path-enhance-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-08-startup-path-enhance.md\`

## Follow-up

后续 PR (per Plan §Non-Goals / Follow-up)：

- **PR B**: \`aionui-runtime::spawn::Builder\` —— kill_on_drop + env 清理 + bun dir 前置；迁移 \`aionui-ai-agent\` spawn 站点
- **PR C+**: 逐 crate 迁移 \`aionui-mcp\` / \`aionui-office\` / \`aionui-extension\` / \`aionui-shell\` 到 Spawn Builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)