### PR TITLE
feat(db): safe database migration via copy-then-migrate

### DIFF
--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -663,7 +663,7 @@ mod tests {
         };
         assert_eq!(
             config.database_path(),
-            std::path::PathBuf::from("/tmp/aionui/aionui.db")
+            std::path::PathBuf::from("/tmp/aionui/aionui-backend.db")
         );
     }
 

--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -71,7 +71,7 @@ impl AppConfig {
 
     /// Path to the SQLite database file.
     pub fn database_path(&self) -> std::path::PathBuf {
-        std::path::Path::new(&self.data_dir).join("aionui.db")
+        std::path::Path::new(&self.data_dir).join("aionui-backend.db")
     }
 }
 

--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -106,8 +106,10 @@ async fn main() -> Result<ExitCode> {
     let boot = Instant::now();
 
     // Initialize database and all services
-    info!("Initializing database at {}", config.database_path().display());
-    let database = aionui_db::init_database(&config.database_path()).await?;
+    let db_path = config.database_path();
+    aionui_db::maybe_copy_legacy_database(&db_path)?;
+    info!("Initializing database at {}", db_path.display());
+    let database = aionui_db::init_database(&db_path).await?;
     info!(elapsed_ms = boot.elapsed().as_millis(), "startup: database initialized");
 
     // Materialize the embedded builtin-skills corpus to disk before any

--- a/crates/aionui-db/src/database.rs
+++ b/crates/aionui-db/src/database.rs
@@ -83,6 +83,32 @@ pub async fn init_database_memory() -> Result<Database, DbError> {
     Ok(Database { pool })
 }
 
+/// Copy the legacy `aionui.db` to the new target path if the target does not exist.
+///
+/// This enables safe upgrades: the old database remains untouched and the backend
+/// operates exclusively on the copy. The copy is atomic (write to `.tmp`, then rename)
+/// so a crash mid-copy leaves no half-written target file.
+pub fn maybe_copy_legacy_database(target: &Path) -> Result<(), DbError> {
+    if target.exists() {
+        return Ok(());
+    }
+
+    let legacy = target.with_file_name("aionui.db");
+    if !legacy.exists() {
+        return Ok(());
+    }
+
+    let tmp = target.with_extension("db.tmp");
+    std::fs::copy(&legacy, &tmp).map_err(|e| DbError::Init(format!("Failed to copy legacy database: {e}")))?;
+    std::fs::rename(&tmp, target).map_err(|e| DbError::Init(format!("Failed to rename temp database: {e}")))?;
+
+    let _ = std::fs::remove_file(target.with_extension("db-wal"));
+    let _ = std::fs::remove_file(target.with_extension("db-shm"));
+
+    info!("Copied legacy database {} -> {}", legacy.display(), target.display());
+    Ok(())
+}
+
 async fn try_init_file(path: &Path) -> Result<Database, DbError> {
     let opts = SqliteConnectOptions::new()
         .filename(path)

--- a/crates/aionui-db/src/lib.rs
+++ b/crates/aionui-db/src/lib.rs
@@ -4,7 +4,7 @@ mod error;
 pub mod models;
 mod repository;
 
-pub use database::{Database, init_database, init_database_memory};
+pub use database::{Database, init_database, init_database_memory, maybe_copy_legacy_database};
 pub use error::DbError;
 pub use models::{
     AgentMetadataRow, AssistantOverrideRow, AssistantRow, ConversationArtifactRow, CreateAssistantParams,

--- a/crates/aionui-db/tests/db_lifecycle.rs
+++ b/crates/aionui-db/tests/db_lifecycle.rs
@@ -339,3 +339,44 @@ fn copy_legacy_overwrites_leftover_tmp() {
     let content = std::fs::read(&target).unwrap();
     assert_eq!(content, b"real data");
 }
+
+#[tokio::test]
+async fn copy_legacy_then_init_database_works() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("aionui-backend.db");
+    let legacy = dir.path().join("aionui.db");
+
+    let legacy_db = init_database(&legacy).await.unwrap();
+    sqlx::query(
+        "INSERT INTO users (id, username, password_hash, created_at, updated_at) \
+         VALUES ('test_user', 'alice', 'hash', 1000, 1000)",
+    )
+    .execute(legacy_db.pool())
+    .await
+    .unwrap();
+    sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+        .execute(legacy_db.pool())
+        .await
+        .unwrap();
+    legacy_db.close().await;
+
+    maybe_copy_legacy_database(&target).unwrap();
+
+    let db = init_database(&target).await.unwrap();
+
+    let row = sqlx::query("SELECT username FROM users WHERE id = 'test_user'")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(row.get::<String, _>("username"), "alice");
+
+    let legacy_db2 = init_database(&legacy).await.unwrap();
+    let row2 = sqlx::query("SELECT username FROM users WHERE id = 'test_user'")
+        .fetch_one(legacy_db2.pool())
+        .await
+        .unwrap();
+    assert_eq!(row2.get::<String, _>("username"), "alice");
+
+    db.close().await;
+    legacy_db2.close().await;
+}

--- a/crates/aionui-db/tests/db_lifecycle.rs
+++ b/crates/aionui-db/tests/db_lifecycle.rs
@@ -303,7 +303,10 @@ fn copy_legacy_copies_when_target_missing() {
     assert_eq!(content, b"legacy database content", "content should match legacy");
 
     let legacy_content = std::fs::read(&legacy).unwrap();
-    assert_eq!(legacy_content, b"legacy database content", "legacy must not be modified");
+    assert_eq!(
+        legacy_content, b"legacy database content",
+        "legacy must not be modified"
+    );
 }
 
 #[test]
@@ -318,8 +321,14 @@ fn copy_legacy_removes_wal_sidecars() {
 
     maybe_copy_legacy_database(&target).unwrap();
 
-    assert!(!target.with_extension("db-wal").exists(), "WAL sidecar should be removed");
-    assert!(!target.with_extension("db-shm").exists(), "SHM sidecar should be removed");
+    assert!(
+        !target.with_extension("db-wal").exists(),
+        "WAL sidecar should be removed"
+    );
+    assert!(
+        !target.with_extension("db-shm").exists(),
+        "SHM sidecar should be removed"
+    );
 }
 
 #[test]

--- a/crates/aionui-db/tests/db_lifecycle.rs
+++ b/crates/aionui-db/tests/db_lifecycle.rs
@@ -1,4 +1,4 @@
-use aionui_db::{init_database, init_database_memory};
+use aionui_db::{init_database, init_database_memory, maybe_copy_legacy_database};
 use sqlx::Row;
 
 // -- T1.1 Initialization --
@@ -260,4 +260,82 @@ async fn creates_parent_directories() {
     let db = init_database(&path).await.unwrap();
     assert!(path.exists(), "database file should be created in nested directory");
     db.close().await;
+}
+
+// -- Legacy database copy --
+
+#[test]
+fn copy_legacy_noop_when_no_legacy_db() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("aionui-backend.db");
+
+    maybe_copy_legacy_database(&target).unwrap();
+    assert!(!target.exists(), "target should not be created when no legacy db");
+}
+
+#[test]
+fn copy_legacy_noop_when_target_exists() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("aionui-backend.db");
+    let legacy = dir.path().join("aionui.db");
+
+    std::fs::write(&legacy, b"legacy data").unwrap();
+    std::fs::write(&target, b"existing target").unwrap();
+
+    maybe_copy_legacy_database(&target).unwrap();
+
+    let content = std::fs::read(&target).unwrap();
+    assert_eq!(content, b"existing target", "existing target must not be overwritten");
+}
+
+#[test]
+fn copy_legacy_copies_when_target_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("aionui-backend.db");
+    let legacy = dir.path().join("aionui.db");
+
+    std::fs::write(&legacy, b"legacy database content").unwrap();
+
+    maybe_copy_legacy_database(&target).unwrap();
+
+    assert!(target.exists(), "target should be created");
+    let content = std::fs::read(&target).unwrap();
+    assert_eq!(content, b"legacy database content", "content should match legacy");
+
+    let legacy_content = std::fs::read(&legacy).unwrap();
+    assert_eq!(legacy_content, b"legacy database content", "legacy must not be modified");
+}
+
+#[test]
+fn copy_legacy_removes_wal_sidecars() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("aionui-backend.db");
+    let legacy = dir.path().join("aionui.db");
+
+    std::fs::write(&legacy, b"legacy data").unwrap();
+    std::fs::write(target.with_extension("db-wal"), b"wal").unwrap();
+    std::fs::write(target.with_extension("db-shm"), b"shm").unwrap();
+
+    maybe_copy_legacy_database(&target).unwrap();
+
+    assert!(!target.with_extension("db-wal").exists(), "WAL sidecar should be removed");
+    assert!(!target.with_extension("db-shm").exists(), "SHM sidecar should be removed");
+}
+
+#[test]
+fn copy_legacy_overwrites_leftover_tmp() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("aionui-backend.db");
+    let legacy = dir.path().join("aionui.db");
+    let tmp = target.with_extension("db.tmp");
+
+    std::fs::write(&legacy, b"real data").unwrap();
+    std::fs::write(&tmp, b"leftover from crash").unwrap();
+
+    maybe_copy_legacy_database(&target).unwrap();
+
+    assert!(target.exists(), "target should be created");
+    assert!(!tmp.exists(), "tmp file should be cleaned up via rename");
+    let content = std::fs::read(&target).unwrap();
+    assert_eq!(content, b"real data");
 }


### PR DESCRIPTION
## Summary

- Add `maybe_copy_legacy_database()` that atomically copies `aionui.db` → `aionui-backend.db` on first run (write to `.tmp`, then rename)
- Change `database_path()` to use `aionui-backend.db` as the new database filename
- Call `maybe_copy_legacy_database` in `main.rs` before `init_database`, so old Electron users get a safe upgrade without touching the original file

## Test Plan

- [x] Unit tests: no-op when no legacy db, no-op when target exists, copies when target missing, removes WAL sidecars, handles leftover `.tmp`
- [x] Integration test: copy real legacy db → init_database runs migrations → data preserved
- [x] Full workspace: 5363 tests passed via `just push`