### PR TITLE
refactor(aionrs): use Config::resolve() for consistent config loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,8 +105,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.19"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.19#bd31c5ff0ed5aadf1cf970cda783a821144ea4f6"
+version = "0.1.20"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.20#3f63840cd3228004fa810cce6716476eb1ce2e62"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -134,8 +134,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.19"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.19#bd31c5ff0ed5aadf1cf970cda783a821144ea4f6"
+version = "0.1.20"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.20#3f63840cd3228004fa810cce6716476eb1ce2e62"
 dependencies = [
  "regex",
  "serde",
@@ -144,8 +144,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.19"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.19#bd31c5ff0ed5aadf1cf970cda783a821144ea4f6"
+version = "0.1.20"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.20#3f63840cd3228004fa810cce6716476eb1ce2e62"
 dependencies = [
  "aion-compact",
  "aion-types",
@@ -164,8 +164,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.19"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.19#bd31c5ff0ed5aadf1cf970cda783a821144ea4f6"
+version = "0.1.20"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.20#3f63840cd3228004fa810cce6716476eb1ce2e62"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -184,8 +184,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.19"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.19#bd31c5ff0ed5aadf1cf970cda783a821144ea4f6"
+version = "0.1.20"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.20#3f63840cd3228004fa810cce6716476eb1ce2e62"
 dependencies = [
  "aion-config",
  "chrono",
@@ -197,8 +197,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.19"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.19#bd31c5ff0ed5aadf1cf970cda783a821144ea4f6"
+version = "0.1.20"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.20#3f63840cd3228004fa810cce6716476eb1ce2e62"
 dependencies = [
  "aion-types",
  "serde",
@@ -209,8 +209,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.19"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.19#bd31c5ff0ed5aadf1cf970cda783a821144ea4f6"
+version = "0.1.20"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.20#3f63840cd3228004fa810cce6716476eb1ce2e62"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -236,8 +236,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.19"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.19#bd31c5ff0ed5aadf1cf970cda783a821144ea4f6"
+version = "0.1.20"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.20#3f63840cd3228004fa810cce6716476eb1ce2e62"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -261,8 +261,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.19"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.19#bd31c5ff0ed5aadf1cf970cda783a821144ea4f6"
+version = "0.1.20"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.20#3f63840cd3228004fa810cce6716476eb1ce2e62"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -280,8 +280,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.19"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.19#bd31c5ff0ed5aadf1cf970cda783a821144ea4f6"
+version = "0.1.20"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.20#3f63840cd3228004fa810cce6716476eb1ce2e62"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6619,7 +6619,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.19#bd31c5ff0ed5aadf1cf970cda783a821144ea4f6"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.20#3f63840cd3228004fa810cce6716476eb1ce2e62"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.19" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.19" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.19" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.19" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.19" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.20" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.20" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.20" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.20" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.20" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -1,11 +1,11 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use aion_agent::bootstrap::AgentBootstrap;
 use aion_agent::engine::AgentEngine;
 use aion_agent::output::OutputSink;
 use aion_agent::session::Session;
-use aion_config::compat::ProviderCompat;
-use aion_config::config::{Config, ProviderType, SessionConfig};
+use aion_config::config::{CliArgs, Config};
 use aion_mcp::manager::McpManager;
 use aion_protocol::commands::SessionMode;
 use aion_protocol::{ToolApprovalManager, ToolApprovalResult};
@@ -55,60 +55,35 @@ impl AionrsAgentManager {
         let runtime = AgentRuntime::new(conversation_id.clone(), workspace.clone(), 128);
         let sink: Arc<dyn OutputSink> = Arc::new(BackendOutputSink::new(runtime.event_sender()));
 
-        let provider_type = match config_extra.provider.as_str() {
-            "openai" => ProviderType::OpenAI,
-            "bedrock" => ProviderType::Bedrock,
-            "vertex" => ProviderType::Vertex,
-            _ => ProviderType::Anthropic,
+        let cli_args = CliArgs {
+            provider: Some(config_extra.provider.clone()),
+            api_key: Some(config_extra.api_key.clone()),
+            base_url: config_extra.base_url.clone(),
+            model: Some(config_extra.model.clone()),
+            max_tokens: Some(config_extra.max_tokens),
+            max_turns: config_extra.max_turns,
+            system_prompt: config_extra.system_prompt.clone(),
+            profile: None,
+            auto_approve: config_extra.session_mode.as_deref() == Some("yolo"),
+            project_dir: Some(PathBuf::from(&workspace)),
         };
 
-        let mut compat = match provider_type {
-            ProviderType::OpenAI => ProviderCompat::openai_defaults(),
-            ProviderType::Bedrock => ProviderCompat::bedrock_defaults(),
-            ProviderType::Anthropic | ProviderType::Vertex => ProviderCompat::anthropic_defaults(),
-        };
+        let mut config = Config::resolve(&cli_args)
+            .map_err(|e| AppError::Internal(format!("Config resolve failed: {e}")))?;
+
+        // Backend-specific overrides
+        config.session.enabled = true;
+        config.session.directory = config_extra.session_directory.to_string_lossy().into_owned();
+
         if let Some(field) = config_extra.compat_overrides.max_tokens_field {
-            compat.max_tokens_field = Some(field);
+            config.compat.max_tokens_field = Some(field);
         }
         if let Some(path) = config_extra.compat_overrides.api_path {
-            compat.api_path = Some(path);
+            config.compat.api_path = Some(path);
         }
 
-        let prompt_caching = matches!(
-            provider_type,
-            ProviderType::Anthropic | ProviderType::Bedrock | ProviderType::Vertex
-        );
-
         let is_resume = resume_session.is_some();
-        let provider_label = config_extra.provider.clone();
-
-        let config = Config {
-            provider_label: provider_label.clone(),
-            provider: provider_type,
-            api_key: config_extra.api_key,
-            base_url: config_extra.base_url.unwrap_or_default(),
-            model: config_extra.model,
-            max_tokens: config_extra.max_tokens,
-            max_turns: config_extra.max_turns,
-            system_prompt: config_extra.system_prompt,
-            thinking: None,
-            prompt_caching,
-            compat,
-            tools: Default::default(),
-            session: SessionConfig {
-                enabled: true,
-                directory: config_extra.session_directory.to_string_lossy().into_owned(),
-                ..Default::default()
-            },
-            compact: Default::default(),
-            plan: Default::default(),
-            file_cache: Default::default(),
-            hooks: Default::default(),
-            bedrock: None,
-            vertex: None,
-            mcp: Default::default(),
-            debug: Default::default(),
-        };
+        let provider_label = config.provider_label.clone();
 
         let mut bootstrap = AgentBootstrap::new(config, &workspace, sink);
         if let Some(session) = resume_session {


### PR DESCRIPTION
## Summary

- Bump aionrs dependencies to v0.1.20 (includes new `project_dir` field on `CliArgs`)
- Replace manual `Config` struct construction in `AionrsAgentManager` with `Config::resolve(&CliArgs)`, passing user workspace as `project_dir`
- Backend now loads the same config files (global `config.toml` + project `.aionrs.toml`) as the subprocess CLI mode, achieving behavior parity

## Test plan

- [x] `cargo clippy -p aionui-ai-agent -- -D warnings` passes
- [x] `cargo test -p aionui-ai-agent` — 12 tests pass
- [x] Full workspace: 5378 tests pass via `just push`
- [x] Local E2E: verified config.toml and .aionrs.toml are loaded correctly at runtime