### PR TITLE
refactor(ai-agent): ACP aggregate state cleanup + observed-state persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -573,3 +573,4 @@ data/
 .graphify_python
 .graphify_detect.json
 graphify-out/
+.graphify_*

--- a/crates/aionui-ai-agent/src/agent_task.rs
+++ b/crates/aionui-ai-agent/src/agent_task.rs
@@ -100,7 +100,7 @@ pub trait IMockAgent: IAgentTask {
     fn get_session_key(&self) -> Option<String> {
         None
     }
-    async fn get_mode(&self) -> Result<aionui_api_types::AgentModeResponse, AppError> {
+    async fn mode(&self) -> Result<aionui_api_types::AgentModeResponse, AppError> {
         Ok(aionui_api_types::AgentModeResponse {
             mode: "default".into(),
             initialized: false,
@@ -279,14 +279,14 @@ impl AgentInstance {
     /// so cron / UI can skip mode reconciliation.
     pub async fn get_mode(&self) -> Result<aionui_api_types::AgentModeResponse, AppError> {
         match self {
-            Self::Acp(m) => m.get_mode().await,
-            Self::Aionrs(m) => m.get_mode().await,
+            Self::Acp(m) => m.mode().await,
+            Self::Aionrs(m) => m.mode().await,
             Self::OpenClaw(_) | Self::Nanobot(_) | Self::Remote(_) => Ok(aionui_api_types::AgentModeResponse {
                 mode: "default".into(),
                 initialized: false,
             }),
             #[cfg(any(test, feature = "test-support"))]
-            Self::Mock(m) => m.get_mode().await,
+            Self::Mock(m) => m.mode().await,
         }
     }
 

--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -1,15 +1,14 @@
 use std::sync::Arc;
 
-use aionui_api_types::AcpBuildExtra;
-use aionui_common::{AppError, CommandSpec};
-use tracing::{debug, info};
-
 use crate::agent_task::AgentInstance;
 use crate::factory::AgentFactoryDeps;
 use crate::factory::acp_assembler::{WorkspaceInfo, assemble_acp_params};
 use crate::factory::context::FactoryContext;
 use crate::manager::acp::{AcpAgentManager, CatalogForwarder};
 use crate::types::BuildTaskOptions;
+use aionui_api_types::AcpBuildExtra;
+use aionui_common::{AppError, CommandSpec};
+use tracing::{debug, info};
 
 pub(super) async fn build(
     deps: Arc<AgentFactoryDeps>,
@@ -61,36 +60,42 @@ pub(super) async fn build(
     // never had a command (e.g. remote-only). Either way the
     // caller needs to see a BadRequest, not a confusing
     // spawn-time error.
-    let command = meta
-        .resolved_command
-        .clone()
-        .ok_or_else(|| AppError::BadRequest(format!("Agent '{}' CLI not found in PATH", meta.name)))?;
-    let args = meta.args.clone();
-    let env = meta
-        .env
-        .iter()
-        .map(|e| aionui_common::EnvVar {
-            name: e.name.clone(),
-            value: e.value.clone(),
-        })
-        .collect();
+    let (command, args, env, cwd) = (
+        meta.resolved_command
+            .clone()
+            .ok_or_else(|| AppError::BadRequest(format!("Agent '{}' CLI not found in PATH", meta.name)))?,
+        meta.args.clone(),
+        meta.env
+            .iter()
+            .map(|e| aionui_common::EnvVar {
+                name: e.name.clone(),
+                value: e.value.clone(),
+            })
+            .collect(),
+        Some(ctx.workspace.clone()),
+    );
     let command_spec = CommandSpec {
         command,
         args,
         env,
-        cwd: Some(ctx.workspace.clone()),
+        cwd,
     };
+    let session_snapshot = deps.acp_agent_service.load_snapshot_state(&ctx.conversation_id).await;
 
-    let params = Arc::new(assemble_acp_params(
-        ctx.conversation_id.clone(),
-        WorkspaceInfo {
-            path: ctx.workspace,
-            is_custom: ctx.is_custom_workspace,
-        },
-        meta,
-        command_spec,
-        config,
-    ));
+    let params = Arc::new(
+        assemble_acp_params(
+            ctx.conversation_id.clone(),
+            WorkspaceInfo {
+                path: ctx.workspace,
+                is_custom: ctx.is_custom_workspace,
+            },
+            meta,
+            command_spec,
+            config,
+            session_snapshot,
+        )
+        .await,
+    );
 
     let skill_mgr = deps.skill_manager.clone();
     let catalog_tx = deps.agent_registry.catalog_sender();
@@ -106,12 +111,10 @@ pub(super) async fn build(
         catalog_tx,
     );
 
-    // Seed the aggregate with persisted runtime choices and
-    // (if present) the CLI-assigned session id, so the first
-    // turn after a task rebuild takes the resume path.
-    if let Some(state) = deps.acp_agent_service.load_snapshot_state(&ctx.conversation_id).await {
-        arc.preload_snapshot(state).await;
-    }
+    // Desired (mode/model/config) are seeded from `params.session_snapshot`
+    // inside `AcpAgentManager::new`. The CLI-assigned session id is still
+    // loaded here so the first turn after a task rebuild takes the resume
+    // path.
     if let Some(sid) = deps.acp_agent_service.load_session_id(&ctx.conversation_id).await {
         arc.restore_session_id(sid).await;
     }

--- a/crates/aionui-ai-agent/src/factory/acp_assembler.rs
+++ b/crates/aionui-ai-agent/src/factory/acp_assembler.rs
@@ -1,9 +1,9 @@
+use crate::capability::team_guide_prompt;
+use crate::shared_kernel::PersistedSessionState;
 use agent_client_protocol::schema::{EnvVariable, McpServer, McpServerStdio, NewSessionRequest};
+use aionui_api_types::AgentMetadata;
 use aionui_api_types::{AcpBuildExtra, GuideMcpConfig, TeamMcpStdioConfig};
 use aionui_common::CommandSpec;
-
-use crate::capability::team_guide_prompt;
-use aionui_api_types::AgentMetadata;
 
 /// Backends for which solo conversations receive the Guide MCP server.
 const TEAM_CAPABLE_BACKENDS: &[&str] = &["claude", "codex", "gemini", "aionrs", "codebuddy"];
@@ -30,6 +30,7 @@ pub struct AcpSessionParams {
     pub config: AcpBuildExtra,
     pub mcp_servers: Vec<McpServer>,
     pub preset_context: Option<String>,
+    pub session_snapshot: Option<PersistedSessionState>,
 }
 
 impl AcpSessionParams {
@@ -49,12 +50,13 @@ impl AcpSessionParams {
 /// This front-loads all decision logic that was previously scattered across
 /// `build_new_session_request`, `compose_preset_context_with_team_guide`,
 /// and the factory's ACP match arm.
-pub fn assemble_acp_params(
+pub async fn assemble_acp_params(
     conversation_id: String,
     workspace: WorkspaceInfo,
     metadata: AgentMetadata,
     command_spec: CommandSpec,
     config: AcpBuildExtra,
+    session_snapshot: Option<PersistedSessionState>,
 ) -> AcpSessionParams {
     let mcp_servers = resolve_mcp_servers(&config, &conversation_id);
     let preset_context = compose_preset_context(
@@ -71,6 +73,7 @@ pub fn assemble_acp_params(
         config,
         mcp_servers,
         preset_context,
+        session_snapshot,
     }
 }
 

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -9,7 +9,7 @@ use crate::registry::CatalogSender;
 use crate::shared_kernel::{ModeId, ModelId, SessionId as DomainSessionId};
 use crate::types::SendMessageData;
 use agent_client_protocol::schema::{
-    AgentCapabilities, AvailableCommand, CancelNotification, SessionConfigOption, SessionId, SessionModeState,
+    AgentCapabilities, AuthMethod, AvailableCommand, CancelNotification, SessionConfigOption, SessionId,
     SessionModelState, SessionNotification, SetSessionConfigOptionRequest, SetSessionModeRequest,
     SetSessionModelRequest, UsageUpdate,
 };
@@ -83,193 +83,12 @@ pub struct AcpAgentManager {
     session_lock: Mutex<()>,
     /// Routes permission requests from the protocol layer to the user
     /// and back. Owns the receiver channel, pending map, and closing flag.
-    permission_router: Arc<PermissionRouter>,
+    pub(super) permission_router: Arc<PermissionRouter>,
     /// Shared skill manager — used to discover skills for first-message injection.
     pub(super) skill_manager: Arc<AcpSkillManager>,
     /// Domain event sender — session aggregate events are forwarded here
     /// for the persistence consumer (`AcpSessionSyncService`).
     pub(super) domain_event_tx: mpsc::Sender<AcpSessionEvent>,
-}
-
-impl AcpAgentManager {
-    /// Current session mode state. Reading a cached session is infallible.
-    pub async fn modes(&self) -> Option<SessionModeState> {
-        self.session.read().await.modes().cloned()
-    }
-
-    async fn desired_mode(&self) -> Option<String> {
-        self.session
-            .read()
-            .await
-            .desired_mode()
-            .map(ToOwned::to_owned)
-            .filter(|mode| !mode.is_empty())
-    }
-
-    /// Execute reconcile actions produced by `AcpSession::plan_reconcile`.
-    ///
-    /// Compares the aggregate's desired state against what the CLI has
-    /// reported as current, then issues the minimal set of SDK calls
-    /// (set_mode, set_config_option) to bring the CLI into alignment.
-    /// Best-effort: individual failures are logged but do not abort.
-    pub(super) async fn reconcile_session(&self, session_id: &str) {
-        use crate::manager::acp::ReconcileAction;
-
-        let actions = {
-            let session = self.session.read().await;
-            session.plan_reconcile()
-        };
-
-        for action in actions {
-            match action {
-                ReconcileAction::SetMode { mode } => {
-                    let normalized = normalize_requested_mode(&self.params.metadata, mode.as_str());
-                    if normalized.is_empty() {
-                        continue;
-                    }
-                    if let Err(e) = self
-                        .protocol
-                        .set_mode(SetSessionModeRequest::new(
-                            SessionId::new(session_id),
-                            normalized.clone(),
-                        ))
-                        .await
-                    {
-                        error!(
-                            conversation_id = %self.params.conversation_id,
-                            mode_id = %normalized,
-                            error = %e,
-                            "reconcile_session: set_mode failed"
-                        );
-                        continue;
-                    }
-                    // SDK does not push a notification after a successful
-                    // set_mode — sync observed/advertised ourselves so the
-                    // next plan_reconcile is a no-op.
-                    let mut session = self.session.write().await;
-                    session.apply_observed_mode(ModeId::new(normalized));
-                    self.commit_session_changes(&mut session).await;
-                }
-                ReconcileAction::SetModel { model } => {
-                    if let Err(e) = self
-                        .protocol
-                        .set_model(SetSessionModelRequest::new(
-                            SessionId::new(session_id),
-                            model.as_str().to_owned(),
-                        ))
-                        .await
-                    {
-                        error!(
-                            conversation_id = %self.params.conversation_id,
-                            model_id = %model,
-                            error = %e,
-                            "reconcile_session: set_model failed"
-                        );
-                        continue;
-                    }
-                    // SDK does not push a CurrentModelUpdate notification —
-                    // sync observed/advertised ourselves.
-                    let mut session = self.session.write().await;
-                    session.apply_observed_model(model);
-                    self.commit_session_changes(&mut session).await;
-                }
-                ReconcileAction::SetConfigOption { key, value } => {
-                    if let Err(err) = self
-                        .protocol
-                        .set_config_option(SetSessionConfigOptionRequest::new(
-                            SessionId::new(session_id),
-                            key.as_str().to_owned(),
-                            value.as_str().to_owned(),
-                        ))
-                        .await
-                    {
-                        info!(
-                            config_id = %key,
-                            desired = %value,
-                            error = %err,
-                            "reconcile_session: set_config_option failed; skipping"
-                        );
-                        continue;
-                    }
-                    // Sync observed ourselves so the next plan_reconcile
-                    // does not replay this action. CLI does not push a
-                    // config-update notification after set_config_option.
-                    let mut session = self.session.write().await;
-                    session.apply_observed_config(key, value);
-                    self.commit_session_changes(&mut session).await;
-                }
-            }
-        }
-    }
-
-    /// Cached model info from the ACP backend, if any has been received.
-    pub async fn model_info(&self) -> Option<SessionModelState> {
-        self.session.read().await.model_info().cloned()
-    }
-
-    /// Set the model for the current session.
-    ///
-    /// Mirrors `set_mode`: writes user intent into the aggregate's Desired
-    /// layer, then delegates to `reconcile_session` for the SDK call.
-    /// `reconcile_session` is the sole call-site of `protocol.set_model` —
-    /// it also handles the observed sync since the CLI does not emit a
-    /// CurrentModelUpdate notification after `session/set_model`.
-    pub async fn set_model_info(&self, model_id: &str) -> Result<(), AppError> {
-        let session_id = self.session.read().await.session_id().map(ToOwned::to_owned);
-
-        {
-            let mut session = self.session.write().await;
-            session.set_desired_model(ModelId::new(model_id));
-            self.commit_session_changes(&mut session).await;
-        }
-
-        if let Some(sid) = session_id {
-            self.reconcile_session(&sid).await;
-        } else {
-            return Err(AppError::BadRequest("No active session".into()));
-        }
-        Ok(())
-    }
-
-    /// Cached session configuration options.
-    pub async fn config_options(&self) -> Vec<SessionConfigOption> {
-        self.session
-            .read()
-            .await
-            .config_options()
-            .map(<[SessionConfigOption]>::to_vec)
-            .unwrap_or_default()
-    }
-
-    /// Set a session configuration option.
-    pub async fn set_config_option(&self, config_id: &str, value: &str) -> Result<(), AppError> {
-        let sid = self.require_session_id().await?;
-
-        self.protocol
-            .set_config_option(SetSessionConfigOptionRequest::new(
-                SessionId::new(sid),
-                config_id.to_owned(),
-                value.to_owned(),
-            ))
-            .await
-            .map_err(AppError::from)
-            .map(|_| ())
-    }
-
-    /// Cached context usage info from the ACP backend.
-    pub async fn usage(&self) -> Option<UsageUpdate> {
-        self.session.read().await.context_usage().cloned()
-    }
-
-    /// Agent capabilities captured during the ACP initialize handshake.
-    pub async fn agent_capabilities(&self) -> Option<AgentCapabilities> {
-        self.session.read().await.agent_capabilities().cloned()
-    }
-
-    /// Cached available commands from the ACP backend.
-    pub async fn available_commands(&self) -> Option<Vec<AvailableCommand>> {
-        self.session.read().await.available_commands().map(|c| c.to_vec())
-    }
 }
 
 impl AcpAgentManager {
@@ -383,21 +202,284 @@ impl AcpAgentManager {
 
         Ok((manager, domain_event_rx, notification_rx))
     }
+}
 
-    /// Start the permission handler loop. Must be called after the manager
-    /// is wrapped in Arc. Delegates to `PermissionRouter::start`.
-    pub fn start_permission_handler(self: &Arc<Self>) {
-        self.permission_router.start(self.runtime.clone());
-    }
+impl AcpAgentManager {
+    /// Execute reconcile actions produced by `AcpSession::plan_reconcile`.
+    ///
+    /// Compares the aggregate's desired state against what the CLI has
+    /// reported as current, then issues the minimal set of SDK calls
+    /// (set_mode, set_config_option) to bring the CLI into alignment.
+    /// Best-effort: individual failures are logged but do not abort.
+    pub(super) async fn reconcile_session(&self, session_id: &str) {
+        use crate::manager::acp::ReconcileAction;
 
-    /// Drain pending domain events from the session aggregate and
-    /// forward them to the persistence consumer via the mpsc channel.
-    pub(super) async fn commit_session_changes(&self, session: &mut AcpSession) {
-        for event in session.drain_events() {
-            let _ = self.domain_event_tx.send(event).await;
+        let actions = {
+            let session = self.session.read().await;
+            session.plan_reconcile()
+        };
+
+        for action in actions {
+            match action {
+                ReconcileAction::SetMode { mode } => {
+                    let normalized = normalize_requested_mode(&self.params.metadata, mode.as_str());
+                    if normalized.is_empty() {
+                        continue;
+                    }
+                    if let Err(e) = self
+                        .protocol
+                        .set_mode(SetSessionModeRequest::new(
+                            SessionId::new(session_id),
+                            normalized.clone(),
+                        ))
+                        .await
+                    {
+                        error!(
+                            conversation_id = %self.params.conversation_id,
+                            mode_id = %normalized,
+                            error = %e,
+                            "reconcile_session: set_mode failed"
+                        );
+                        continue;
+                    }
+                    // SDK does not push a notification after a successful
+                    // set_mode — sync observed/advertised ourselves so the
+                    // next plan_reconcile is a no-op.
+                    let mut session = self.session.write().await;
+                    session.apply_observed_mode(ModeId::new(normalized));
+                    self.commit_session_changes(&mut session).await;
+                }
+                ReconcileAction::SetModel { model } => {
+                    if let Err(e) = self
+                        .protocol
+                        .set_model(SetSessionModelRequest::new(
+                            SessionId::new(session_id),
+                            model.as_str().to_owned(),
+                        ))
+                        .await
+                    {
+                        error!(
+                            conversation_id = %self.params.conversation_id,
+                            model_id = %model,
+                            error = %e,
+                            "reconcile_session: set_model failed"
+                        );
+                        continue;
+                    }
+                    // SDK does not push a CurrentModelUpdate notification —
+                    // sync observed/advertised ourselves.
+                    let mut session = self.session.write().await;
+                    session.apply_observed_model(model);
+                    self.commit_session_changes(&mut session).await;
+                }
+                ReconcileAction::SetConfigOption { key, value } => {
+                    if let Err(err) = self
+                        .protocol
+                        .set_config_option(SetSessionConfigOptionRequest::new(
+                            SessionId::new(session_id),
+                            key.as_str().to_owned(),
+                            value.as_str().to_owned(),
+                        ))
+                        .await
+                    {
+                        info!(
+                            config_id = %key,
+                            desired = %value,
+                            error = %err,
+                            "reconcile_session: set_config_option failed; skipping"
+                        );
+                        continue;
+                    }
+                    // Sync observed ourselves so the next plan_reconcile
+                    // does not replay this action. CLI does not push a
+                    // config-update notification after set_config_option.
+                    let mut session = self.session.write().await;
+                    session.apply_observed_config(key, value);
+                    self.commit_session_changes(&mut session).await;
+                }
+            }
         }
     }
+}
 
+impl AcpAgentManager {
+    pub async fn mode(&self) -> Result<aionui_api_types::AgentModeResponse, AppError> {
+        let desired = self
+            .session
+            .read()
+            .await
+            .desired_mode()
+            .map(|mode| normalize_requested_mode(&self.params.metadata, mode))
+            .filter(|mode| !mode.is_empty());
+        Ok(aionui_api_types::AgentModeResponse {
+            mode: self
+                .session
+                .read()
+                .await
+                .modes()
+                .map(|modes| modes.current_mode_id.to_string())
+                .or(desired)
+                .unwrap_or_else(|| normalize_requested_mode(&self.params.metadata, "default")),
+            initialized: self.session_id().await.is_some(),
+        })
+    }
+
+    /// Cached model info from the ACP backend, if any has been received.
+    pub async fn model(&self) -> Option<SessionModelState> {
+        self.session.read().await.model_info().cloned()
+    }
+
+    /// Cached session configuration options.
+    pub async fn config_options(&self) -> Vec<SessionConfigOption> {
+        self.session
+            .read()
+            .await
+            .config_options()
+            .map(<[SessionConfigOption]>::to_vec)
+            .unwrap_or_default()
+    }
+
+    /// Cached context usage info from the ACP backend.
+    pub async fn usage(&self) -> Option<UsageUpdate> {
+        self.session.read().await.context_usage().cloned()
+    }
+
+    /// Authentication methods captured during the ACP initialize handshake.
+    pub async fn auth_methods(&self) -> Option<Vec<AuthMethod>> {
+        self.session.read().await.auth_methods().map(|methods| methods.to_vec())
+    }
+
+    /// Agent capabilities captured during the ACP initialize handshake.
+    pub async fn agent_capabilities(&self) -> Option<AgentCapabilities> {
+        self.session.read().await.agent_capabilities().cloned()
+    }
+
+    /// Cached available commands from the ACP backend.
+    pub async fn available_commands(&self) -> Option<Vec<AvailableCommand>> {
+        self.session.read().await.available_commands().map(|c| c.to_vec())
+    }
+
+    /// Set the mode for the current session.
+    pub async fn set_mode(&self, mode: &str) -> Result<(), AppError> {
+        let normalized_mode = normalize_requested_mode(&self.params.metadata, mode);
+        if normalized_mode.is_empty() {
+            return Ok(());
+        }
+        let session_id = self.session.read().await.session_id().map(ToOwned::to_owned);
+
+        // Write desired — the aggregate root's legitimate intent write-point.
+        {
+            let mut session = self.session.write().await;
+            session.set_desired_mode(ModeId::new(&normalized_mode));
+            self.commit_session_changes(&mut session).await;
+        }
+
+        // If a session is open, reconcile to the CLI. `reconcile_session`
+        // is the sole call-site of `protocol.set_mode` and the sole
+        // observed/advertised write-point — on success it calls
+        // `apply_observed_mode`, which syncs both layers and emits
+        // `ObservedModeSynced`. `get_mode()` reflects the change as soon
+        // as the SDK call returns.
+        if let Some(sid) = session_id {
+            self.reconcile_session(&sid).await;
+        }
+        Ok(())
+    }
+
+    /// Set the model for the current session.
+    ///
+    /// Mirrors `set_mode`: writes user intent into the aggregate's Desired
+    /// layer, then delegates to `reconcile_session` for the SDK call.
+    /// `reconcile_session` is the sole call-site of `protocol.set_model` —
+    /// it also handles the observed sync since the CLI does not emit a
+    /// CurrentModelUpdate notification after `session/set_model`.
+    pub async fn set_model(&self, model_id: &str) -> Result<(), AppError> {
+        let session_id = self.session.read().await.session_id().map(ToOwned::to_owned);
+
+        {
+            let mut session = self.session.write().await;
+            session.set_desired_model(ModelId::new(model_id));
+            self.commit_session_changes(&mut session).await;
+        }
+
+        if let Some(sid) = session_id {
+            self.reconcile_session(&sid).await;
+        } else {
+            return Err(AppError::BadRequest("No active session".into()));
+        }
+        Ok(())
+    }
+
+    /// Set a session configuration option.
+    pub async fn set_config_option(&self, config_id: &str, value: &str) -> Result<(), AppError> {
+        let sid = self.require_session_id().await?;
+
+        self.protocol
+            .set_config_option(SetSessionConfigOptionRequest::new(
+                SessionId::new(sid),
+                config_id.to_owned(),
+                value.to_owned(),
+            ))
+            .await
+            .map_err(AppError::from)
+            .map(|_| ())
+    }
+
+    /// Return available slash commands from the session aggregate.
+    pub async fn load_slash_commands(&self) -> Result<Vec<SlashCommandItem>, AppError> {
+        let session = self.session.read().await;
+        let items = session
+            .available_commands()
+            .map(|cmds| {
+                cmds.iter()
+                    .map(|c| SlashCommandItem {
+                        command: c.name.clone(),
+                        description: c.description.clone(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(items)
+    }
+}
+
+impl AcpAgentManager {
+    /// Current ACP session ID, if a session has been established.
+    pub async fn session_id(&self) -> Option<String> {
+        self.session.read().await.session_id().map(ToOwned::to_owned)
+    }
+
+    /// Restore a previously persisted session_id (e.g. from DB on task rebuild).
+    /// Enables resume path on next send_message instead of creating a fresh session.
+    ///
+    /// Deliberately leaves `opened = false`: the CLI child process is
+    /// brand new and still needs `session/load` (or claude-meta-resume) to
+    /// re-attach to the persisted session before the next prompt. Subsequent
+    /// turns — once the resume handshake has run — take the short path.
+    pub async fn restore_session_id(&self, sid: String) {
+        let mut session = self.session.write().await;
+        session.set_session_id(DomainSessionId::new(sid));
+        // Discarded — the session_id already came from DB, no need to re-persist.
+        session.drain_events();
+    }
+
+    /// Vendor label this session was spawned as (e.g. "claude"), if any.
+    pub fn backend(&self) -> Option<&str> {
+        self.params.metadata.backend.as_deref()
+    }
+
+    /// Agent metadata id this session was spawned from.
+    pub fn agent_metadata_id(&self) -> &str {
+        &self.params.metadata.id
+    }
+
+    /// Whether the configured agent supports side questions.
+    pub fn supports_side_question(&self) -> bool {
+        self.params.metadata.behavior_policy.supports_side_question
+    }
+}
+
+impl AcpAgentManager {
     /// Initialize or resume a session, then send the user message.
     ///
     /// Three paths:
@@ -443,57 +525,6 @@ impl AcpAgentManager {
         self.runtime.transition_to(ConversationStatus::Running);
 
         Ok(())
-    }
-
-    /// Return available slash commands from the session aggregate.
-    pub async fn load_slash_commands(&self) -> Result<Vec<SlashCommandItem>, AppError> {
-        let session = self.session.read().await;
-        let items = session
-            .available_commands()
-            .map(|cmds| {
-                cmds.iter()
-                    .map(|c| SlashCommandItem {
-                        command: c.name.clone(),
-                        description: c.description.clone(),
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-        Ok(items)
-    }
-
-    /// Current ACP session ID, if a session has been established.
-    pub async fn session_id(&self) -> Option<String> {
-        self.session.read().await.session_id().map(ToOwned::to_owned)
-    }
-
-    /// Restore a previously persisted session_id (e.g. from DB on task rebuild).
-    /// Enables resume path on next send_message instead of creating a fresh session.
-    ///
-    /// Deliberately leaves `opened = false`: the CLI child process is
-    /// brand new and still needs `session/load` (or claude-meta-resume) to
-    /// re-attach to the persisted session before the next prompt. Subsequent
-    /// turns — once the resume handshake has run — take the short path.
-    pub async fn restore_session_id(&self, sid: String) {
-        let mut session = self.session.write().await;
-        session.assign_session_id(DomainSessionId::new(sid));
-        // Discarded — the session_id already came from DB, no need to re-persist.
-        session.drain_events();
-    }
-
-    /// Vendor label this session was spawned as (e.g. "claude"), if any.
-    pub fn backend(&self) -> Option<&str> {
-        self.params.metadata.backend.as_deref()
-    }
-
-    /// Agent metadata id this session was spawned from.
-    pub fn agent_metadata_id(&self) -> &str {
-        &self.params.metadata.id
-    }
-
-    /// Whether the configured agent supports side questions.
-    pub fn supports_side_question(&self) -> bool {
-        self.params.metadata.behavior_policy.supports_side_question
     }
 
     /// Whether the agent supports `session/load` — read from the ACP
@@ -675,49 +706,6 @@ impl AcpAgentManager {
     /// every tool request round-trips through the CLI.
     pub fn check_approval(&self, _action: &str, _command_type: Option<&str>) -> bool {
         false
-    }
-
-    pub async fn get_mode(&self) -> Result<aionui_api_types::AgentModeResponse, AppError> {
-        let desired = self
-            .desired_mode()
-            .await
-            .map(|mode| normalize_requested_mode(&self.params.metadata, &mode))
-            .filter(|mode| !mode.is_empty());
-        Ok(aionui_api_types::AgentModeResponse {
-            mode: self
-                .modes()
-                .await
-                .map(|modes| modes.current_mode_id.to_string())
-                .or(desired)
-                .unwrap_or_else(|| normalize_requested_mode(&self.params.metadata, "default")),
-            initialized: self.session_id().await.is_some(),
-        })
-    }
-
-    pub async fn set_mode(&self, mode: &str) -> Result<(), AppError> {
-        let normalized_mode = normalize_requested_mode(&self.params.metadata, mode);
-        if normalized_mode.is_empty() {
-            return Ok(());
-        }
-        let session_id = self.session.read().await.session_id().map(ToOwned::to_owned);
-
-        // Write desired — the aggregate root's legitimate intent write-point.
-        {
-            let mut session = self.session.write().await;
-            session.set_desired_mode(ModeId::new(&normalized_mode));
-            self.commit_session_changes(&mut session).await;
-        }
-
-        // If a session is open, reconcile to the CLI. `reconcile_session`
-        // is the sole call-site of `protocol.set_mode` and the sole
-        // observed/advertised write-point — on success it calls
-        // `apply_observed_mode`, which syncs both layers and emits
-        // `ObservedModeSynced`. `get_mode()` reflects the change as soon
-        // as the SDK call returns.
-        if let Some(sid) = session_id {
-            self.reconcile_session(&sid).await;
-        }
-        Ok(())
     }
 }
 

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -2,7 +2,7 @@ use crate::agent_runtime::AgentRuntime;
 use crate::capability::cli_process::CliAgentProcess;
 use crate::capability::skill_manager::AcpSkillManager;
 use crate::factory::acp_assembler::AcpSessionParams;
-use crate::manager::acp::{AcpSession, AcpSessionEvent, PermissionRouter, PersistedSessionState};
+use crate::manager::acp::{AcpSession, AcpSessionEvent, PermissionRouter};
 use crate::protocol::acp::AcpProtocol;
 use crate::protocol::events::AgentStreamEvent;
 use crate::registry::CatalogSender;
@@ -18,7 +18,6 @@ use aionui_common::{
     AgentKillReason, AgentType, AppError, Confirmation, ConversationStatus, TimestampMs, normalize_keys_to_snake_case,
 };
 use serde_json::Value;
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, RwLock, broadcast, mpsc};
@@ -107,11 +106,6 @@ impl AcpAgentManager {
             .filter(|mode| !mode.is_empty())
     }
 
-    async fn update_cached_mode(&self, mode: &str) {
-        let mut session = self.session.write().await;
-        session.apply_partial_mode_update(ModeId::new(mode));
-    }
-
     /// Execute reconcile actions produced by `AcpSession::plan_reconcile`.
     ///
     /// Compares the aggregate's desired state against what the CLI has
@@ -149,9 +143,35 @@ impl AcpAgentManager {
                         );
                         continue;
                     }
-                    self.update_cached_mode(&normalized).await;
+                    // SDK does not push a notification after a successful
+                    // set_mode — sync observed/advertised ourselves so the
+                    // next plan_reconcile is a no-op.
                     let mut session = self.session.write().await;
                     session.apply_observed_mode(ModeId::new(normalized));
+                    self.commit_session_changes(&mut session).await;
+                }
+                ReconcileAction::SetModel { model } => {
+                    if let Err(e) = self
+                        .protocol
+                        .set_model(SetSessionModelRequest::new(
+                            SessionId::new(session_id),
+                            model.as_str().to_owned(),
+                        ))
+                        .await
+                    {
+                        error!(
+                            conversation_id = %self.params.conversation_id,
+                            model_id = %model,
+                            error = %e,
+                            "reconcile_session: set_model failed"
+                        );
+                        continue;
+                    }
+                    // SDK does not push a CurrentModelUpdate notification —
+                    // sync observed/advertised ourselves.
+                    let mut session = self.session.write().await;
+                    session.apply_observed_model(model);
+                    self.commit_session_changes(&mut session).await;
                 }
                 ReconcileAction::SetConfigOption { key, value } => {
                     if let Err(err) = self
@@ -169,7 +189,14 @@ impl AcpAgentManager {
                             error = %err,
                             "reconcile_session: set_config_option failed; skipping"
                         );
+                        continue;
                     }
+                    // Sync observed ourselves so the next plan_reconcile
+                    // does not replay this action. CLI does not push a
+                    // config-update notification after set_config_option.
+                    let mut session = self.session.write().await;
+                    session.apply_observed_config(key, value);
+                    self.commit_session_changes(&mut session).await;
                 }
             }
         }
@@ -181,21 +208,26 @@ impl AcpAgentManager {
     }
 
     /// Set the model for the current session.
+    ///
+    /// Mirrors `set_mode`: writes user intent into the aggregate's Desired
+    /// layer, then delegates to `reconcile_session` for the SDK call.
+    /// `reconcile_session` is the sole call-site of `protocol.set_model` —
+    /// it also handles the observed sync since the CLI does not emit a
+    /// CurrentModelUpdate notification after `session/set_model`.
     pub async fn set_model_info(&self, model_id: &str) -> Result<(), AppError> {
-        let sid = self.require_session_id().await?;
+        let session_id = self.session.read().await.session_id().map(ToOwned::to_owned);
 
-        self.protocol
-            .set_model(SetSessionModelRequest::new(SessionId::new(sid), model_id.to_owned()))
-            .await
-            .map_err(AppError::from)?;
-
-        // Update the session immediately since SDK does not send a
-        // CurrentModelUpdate notification for model changes.
         {
             let mut session = self.session.write().await;
-            session.update_current_model(ModelId::new(model_id));
+            session.set_desired_model(ModelId::new(model_id));
+            self.commit_session_changes(&mut session).await;
         }
 
+        if let Some(sid) = session_id {
+            self.reconcile_session(&sid).await;
+        } else {
+            return Err(AppError::BadRequest("No active session".into()));
+        }
         Ok(())
     }
 
@@ -277,7 +309,6 @@ impl AcpAgentManager {
         // events that were broadcast for the UI (e.g. from emit_snapshot_events).
         let (notification_tx, notification_rx) = mpsc::channel::<SessionNotification>(256);
 
-        // Connect via ACP SDK — executes initialize handshake
         let protocol = AcpProtocol::connect(stdin, stdout, runtime.event_sender(), permission_tx, notification_tx)
             .await
             .map_err(|e| {
@@ -289,11 +320,6 @@ impl AcpAgentManager {
                 AppError::from(e)
             })?;
 
-        // Push the static handshake payloads (agent_capabilities +
-        // auth_methods) through the catalog sync channel. Session-driven
-        // fields — modes, models, config_options, commands — flow
-        // through the `CatalogForwarder` the factory spawns after
-        // construction.
         let init_handshake = AgentHandshake {
             agent_capabilities: protocol.agent_capabilities().and_then(|c| sdk_to_snake_value(&c)),
             auth_methods: protocol.auth_methods().and_then(|m| sdk_to_snake_value(&m)),
@@ -303,14 +329,37 @@ impl AcpAgentManager {
             catalog_tx.send_partial(params.metadata.id.clone(), init_handshake);
         }
 
-        let initial_mode = params
-            .config
-            .session_mode
-            .as_ref()
-            .map(|m| normalize_requested_mode(&params.metadata, m))
+        let snapshot = params.session_snapshot.as_ref();
+
+        // Prefer the last-persisted mode; for brand-new conversations
+        // fall back to `AcpBuildExtra::session_mode` so the first turn
+        // still honours the caller's choice.
+        let initial_mode = snapshot
+            .and_then(|s| s.current_mode_id.as_ref())
+            .map(|m| normalize_requested_mode(&params.metadata, m.as_str()))
+            .or_else(|| {
+                params
+                    .config
+                    .session_mode
+                    .as_ref()
+                    .map(|m| normalize_requested_mode(&params.metadata, m))
+            })
             .filter(|m| !m.is_empty())
             .map(ModeId::new);
-        let mut session = AcpSession::new(initial_mode, HashMap::new());
+
+        let initial_model = snapshot.and_then(|s| s.current_model_id.clone());
+        let initial_config = snapshot.map(|s| s.config_selections.clone()).unwrap_or_default();
+
+        let mut session = AcpSession::new(initial_mode, initial_model, initial_config);
+        // Seed the observed/advertised layers (observed mode/model, cached
+        // context_usage) from the persisted snapshot. Desired fields are
+        // already populated via `AcpSession::new`.
+        if let Some(snapshot) = snapshot {
+            session.preload_persisted(snapshot);
+            // Preload did not come from the user this turn — drain so the
+            // persistence consumer doesn't echo the DB back into itself.
+            session.drain_events();
+        }
         if let Some(agent_capabilities) = protocol.agent_capabilities() {
             session.apply_advertised_capabilities(agent_capabilities);
         }
@@ -347,26 +396,6 @@ impl AcpAgentManager {
         for event in session.drain_events() {
             let _ = self.domain_event_tx.send(event).await;
         }
-    }
-
-    /// Seed the session aggregate with the user's last choices. Called
-    /// by `ConversationService` on resume paths, before dispatching
-    /// `send_message`. `None` fields are ignored — the CLI's
-    /// `session/load` response fills in whatever the preload omits.
-    pub async fn preload_snapshot(&self, state: PersistedSessionState) {
-        let mut session = self.session.write().await;
-        session.preload_persisted(&state);
-        if let Some(mode) = &state.current_mode_id {
-            let normalized = normalize_requested_mode(&self.params.metadata, mode.as_str());
-            if !normalized.is_empty() {
-                session.set_desired_mode(ModeId::new(normalized));
-            }
-        }
-        for (key, value) in &state.config_selections {
-            session.set_desired_config(key.clone(), value.clone());
-        }
-        // Preload events are discarded — the DB already has these values.
-        session.drain_events();
     }
 
     /// Initialize or resume a session, then send the user message.
@@ -679,15 +708,12 @@ impl AcpAgentManager {
             self.commit_session_changes(&mut session).await;
         }
 
-        // Optimistically update advertised.modes.current_mode_id so get_mode()
-        // reflects the user's choice immediately. reconcile_session pushes the
-        // actual SDK call; the advertised state is then confirmed (or corrected)
-        // when the CLI's next SessionNotification arrives via event_tracker.
-        self.update_cached_mode(&normalized_mode).await;
-
-        // If a session is open, reconcile to the CLI. After this change, this is
-        // the SOLE call-site of `protocol.set_mode` in the crate — the aggregate
-        // root's reconcile path owns SDK alignment end-to-end.
+        // If a session is open, reconcile to the CLI. `reconcile_session`
+        // is the sole call-site of `protocol.set_mode` and the sole
+        // observed/advertised write-point — on success it calls
+        // `apply_observed_mode`, which syncs both layers and emits
+        // `ObservedModeSynced`. `get_mode()` reflects the change as soon
+        // as the SDK call returns.
         if let Some(sid) = session_id {
             self.reconcile_session(&sid).await;
         }

--- a/crates/aionui-ai-agent/src/manager/acp/event_tracker.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/event_tracker.rs
@@ -1,4 +1,4 @@
-use crate::manager::acp::AcpAgentManager;
+use crate::manager::acp::{AcpAgentManager, AcpSession};
 use crate::protocol::events::AgentStreamEvent;
 use crate::shared_kernel::ModeId;
 use agent_client_protocol::schema::{
@@ -78,9 +78,24 @@ impl AcpAgentManager {
                 if let Ok(update) = serde_json::from_value::<UsageUpdate>(value.clone()) {
                     let mut s = self.session.write().await;
                     s.apply_context_usage(update);
+                    self.commit_session_changes(&mut s).await;
                 }
             }
             _ => {}
+        }
+    }
+
+    /// Start the permission handler loop. Must be called after the manager
+    /// is wrapped in Arc. Delegates to `PermissionRouter::start`.
+    pub fn start_permission_handler(self: &Arc<Self>) {
+        self.permission_router.start(self.runtime.clone());
+    }
+
+    /// Drain pending domain events from the session aggregate and
+    /// forward them to the persistence consumer via the mpsc channel.
+    pub(super) async fn commit_session_changes(&self, session: &mut AcpSession) {
+        for event in session.drain_events() {
+            let _ = self.domain_event_tx.send(event).await;
         }
     }
 }
@@ -135,20 +150,28 @@ mod tests {
     }
 
     #[test]
-    fn apply_advertised_modes_does_not_produce_pending_events() {
-        // apply_advertised_modes writes to `advertised` and `observed.mode_id`
-        // but does NOT push to `pending_events` (unlike apply_observed_mode).
-        // This is intentional: the advertised layer is not tracked as a domain
-        // event. Verify this so we know what the old tracker loop was NOT doing.
+    fn apply_advertised_modes_emits_observed_synced_when_observed_changes() {
+        // `apply_advertised_modes` writes the CLI's advertised snapshot,
+        // which also moves `observed.mode_id` to `current_mode_id`. When
+        // that shifts the observed value, one `ObservedModeSynced` event
+        // is emitted so the persistence consumer writes the new value to
+        // `session_config.runtime`. Re-applying with the same current id
+        // is a no-op.
         let mut session = AcpSession::new(None, None, Default::default());
         let modes = SessionModeState::new("plan".to_owned(), vec![]);
-        session.apply_advertised_modes(modes);
+        session.apply_advertised_modes(modes.clone());
         let events = session.drain_events();
+        assert_eq!(events.len(), 1);
         assert_eq!(
-            events.len(),
-            0,
-            "apply_advertised_modes must not produce pending domain events, got: {events:?}"
+            events[0],
+            AcpSessionEvent::ObservedModeSynced {
+                mode: ModeId::new("plan")
+            }
         );
+
+        // Idempotent re-apply: same current id — no new event.
+        session.apply_advertised_modes(modes);
+        assert_eq!(session.drain_events().len(), 0);
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/manager/acp/event_tracker.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/event_tracker.rs
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn apply_observed_mode_emits_exactly_one_event() {
-        let mut session = AcpSession::new(None, Default::default());
+        let mut session = AcpSession::new(None, None, Default::default());
 
         // First apply: should emit one event
         session.apply_observed_mode(ModeId::new("plan"));
@@ -140,7 +140,7 @@ mod tests {
         // but does NOT push to `pending_events` (unlike apply_observed_mode).
         // This is intentional: the advertised layer is not tracked as a domain
         // event. Verify this so we know what the old tracker loop was NOT doing.
-        let mut session = AcpSession::new(None, Default::default());
+        let mut session = AcpSession::new(None, None, Default::default());
         let modes = SessionModeState::new("plan".to_owned(), vec![]);
         session.apply_advertised_modes(modes);
         let events = session.drain_events();
@@ -153,7 +153,7 @@ mod tests {
 
     #[test]
     fn apply_observed_model_emits_exactly_one_event_then_idempotent() {
-        let mut session = AcpSession::new(None, Default::default());
+        let mut session = AcpSession::new(None, None, Default::default());
 
         session.apply_observed_model(ModelId::new("claude-3-5-sonnet"));
         let events = session.drain_events();

--- a/crates/aionui-ai-agent/src/manager/acp/events.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/events.rs
@@ -7,6 +7,11 @@ use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId, SessionId};
 /// These capture *intent* changes (user wants mode X) and *observation*
 /// arrivals (CLI reported mode Y) separately — persistence consumers can
 /// decide which to write to DB without re-interpreting UI stream events.
+///
+/// `context_usage_json` travels as a pre-serialised string so the event
+/// type can keep `Eq` (SDK's `UsageUpdate` only derives `PartialEq`) and
+/// so the persistence consumer can forward it to the DB without another
+/// round-trip through serde.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AcpSessionEvent {
     SessionOpened,
@@ -30,6 +35,9 @@ pub enum AcpSessionEvent {
     },
     ObservedConfigSynced {
         selections: HashMap<ConfigKey, ConfigValue>,
+    },
+    ObservedContextUsageChanged {
+        usage_json: String,
     },
 }
 

--- a/crates/aionui-ai-agent/src/manager/acp/events.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/events.rs
@@ -9,12 +9,15 @@ use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId, SessionId};
 /// decide which to write to DB without re-interpreting UI stream events.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AcpSessionEvent {
+    SessionOpened,
     SessionAssigned {
         session_id: SessionId,
     },
-    SessionOpened,
     DesiredModeChanged {
         mode: ModeId,
+    },
+    DesiredModelChanged {
+        model: ModelId,
     },
     DesiredConfigChanged {
         selections: HashMap<ConfigKey, ConfigValue>,
@@ -24,6 +27,9 @@ pub enum AcpSessionEvent {
     },
     ObservedModelSynced {
         model: ModelId,
+    },
+    ObservedConfigSynced {
+        selections: HashMap<ConfigKey, ConfigValue>,
     },
 }
 

--- a/crates/aionui-ai-agent/src/manager/acp/mod.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/mod.rs
@@ -13,4 +13,4 @@ pub use catalog_forwarder::CatalogForwarder;
 pub use events::AcpSessionEvent;
 pub use permission_router::PermissionRouter;
 pub use reconcile::ReconcileAction;
-pub use session::{AcpSession, PersistedSessionState};
+pub use session::AcpSession;

--- a/crates/aionui-ai-agent/src/manager/acp/reconcile.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/reconcile.rs
@@ -1,4 +1,4 @@
-use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId};
+use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId};
 
 /// Actions the session driver must execute to align CLI state with user intent.
 ///
@@ -7,6 +7,7 @@ use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReconcileAction {
     SetMode { mode: ModeId },
+    SetModel { model: ModelId },
     SetConfigOption { key: ConfigKey, value: ConfigValue },
 }
 

--- a/crates/aionui-ai-agent/src/manager/acp/session.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session.rs
@@ -78,7 +78,7 @@ impl AcpSession {
     }
 }
 
-// ─── Getters ───────────────────────────────────────────────────────
+// ─── Session Id and Session Opened ───────────────────────────────────────────────────────
 impl AcpSession {
     pub fn session_id(&self) -> Option<&str> {
         self.session_id.as_ref().map(SessionId::as_str)
@@ -88,12 +88,33 @@ impl AcpSession {
         self.session_id.as_ref()
     }
 
+    /// Assign (or restore) a session ID. Idempotent: re-assigning the same
+    /// ID is a no-op. Assigning a *different* ID after one is already set
+    /// is an invariant violation (the aggregate must be recreated).
+    pub fn set_session_id(&mut self, sid: SessionId) {
+        if let Some(existing) = &self.session_id {
+            debug_assert_eq!(existing, &sid, "session_id reassignment attempted");
+            return;
+        }
+        self.session_id = Some(sid.clone());
+        self.pending_events
+            .push(AcpSessionEvent::SessionAssigned { session_id: sid });
+    }
+
     pub fn is_opened(&self) -> bool {
         self.opened
     }
+
+    /// Mark the session as opened with the CLI (first turn handshake complete).
+    pub fn mark_opened(&mut self) {
+        if !self.opened {
+            self.opened = true;
+            self.pending_events.push(AcpSessionEvent::SessionOpened);
+        }
+    }
 }
 
-// ─── Getters desired ───────────────────────────────────────────────────────
+// ─── Getters Setters desired ───────────────────────────────────────────────────────
 impl AcpSession {
     pub fn desired_mode(&self) -> Option<&str> {
         self.desired.mode_id.as_ref().map(ModeId::as_str)
@@ -113,6 +134,53 @@ impl AcpSession {
 
     pub fn desired_config_selections(&self) -> &HashMap<ConfigKey, ConfigValue> {
         &self.desired.config_selections
+    }
+
+    /// Set the user's desired mode. Emits `DesiredModeChanged` if the
+    /// value actually changed. When advertised modes are known, the mode
+    /// must be in the list (otherwise the call is a no-op).
+    pub fn set_desired_mode(&mut self, mode: ModeId) -> bool {
+        if mode.as_str().is_empty() {
+            return false;
+        }
+        if !self.is_mode_valid(mode.as_str()) {
+            return false;
+        }
+        if self.desired.mode_id.as_ref() == Some(&mode) {
+            return false;
+        }
+        self.desired.mode_id = Some(mode.clone());
+        self.pending_events.push(AcpSessionEvent::DesiredModeChanged { mode });
+        true
+    }
+
+    /// Set the user's desired model. Emits `DesiredModelChanged` if the
+    /// value actually changed. When advertised models are known, the model
+    /// must be in the list (otherwise the call is a no-op).
+    pub fn set_desired_model(&mut self, model: ModelId) -> bool {
+        if model.as_str().is_empty() {
+            return false;
+        }
+        if !self.is_model_valid(model.as_str()) {
+            return false;
+        }
+        if self.desired.model_id.as_ref() == Some(&model) {
+            return false;
+        }
+        self.desired.model_id = Some(model.clone());
+        self.pending_events.push(AcpSessionEvent::DesiredModelChanged { model });
+        true
+    }
+
+    /// Set a user's desired config selection.
+    pub fn set_desired_config(&mut self, key: ConfigKey, value: ConfigValue) {
+        let changed = self.desired.config_selections.get(&key) != Some(&value);
+        self.desired.config_selections.insert(key, value);
+        if changed {
+            let selections = self.desired.config_selections.clone();
+            self.pending_events
+                .push(AcpSessionEvent::DesiredConfigChanged { selections });
+        }
     }
 }
 
@@ -174,77 +242,6 @@ impl AcpSession {
     }
 }
 
-// ─── Commands (mutate + emit events) ───────────────────────────────
-impl AcpSession {
-    /// Assign (or restore) a session ID. Idempotent: re-assigning the same
-    /// ID is a no-op. Assigning a *different* ID after one is already set
-    /// is an invariant violation (the aggregate must be recreated).
-    pub fn assign_session_id(&mut self, sid: SessionId) {
-        if let Some(existing) = &self.session_id {
-            debug_assert_eq!(existing, &sid, "session_id reassignment attempted");
-            return;
-        }
-        self.session_id = Some(sid.clone());
-        self.pending_events
-            .push(AcpSessionEvent::SessionAssigned { session_id: sid });
-    }
-
-    /// Mark the session as opened with the CLI (first turn handshake complete).
-    pub fn mark_opened(&mut self) {
-        if !self.opened {
-            self.opened = true;
-            self.pending_events.push(AcpSessionEvent::SessionOpened);
-        }
-    }
-
-    /// Set the user's desired mode. Emits `DesiredModeChanged` if the
-    /// value actually changed. When advertised modes are known, the mode
-    /// must be in the list (otherwise the call is a no-op).
-    pub fn set_desired_mode(&mut self, mode: ModeId) -> bool {
-        if mode.as_str().is_empty() {
-            return false;
-        }
-        if !self.is_mode_valid(mode.as_str()) {
-            return false;
-        }
-        if self.desired.mode_id.as_ref() == Some(&mode) {
-            return false;
-        }
-        self.desired.mode_id = Some(mode.clone());
-        self.pending_events.push(AcpSessionEvent::DesiredModeChanged { mode });
-        true
-    }
-
-    /// Set the user's desired model. Emits `DesiredModelChanged` if the
-    /// value actually changed. When advertised models are known, the model
-    /// must be in the list (otherwise the call is a no-op).
-    pub fn set_desired_model(&mut self, model: ModelId) -> bool {
-        if model.as_str().is_empty() {
-            return false;
-        }
-        if !self.is_model_valid(model.as_str()) {
-            return false;
-        }
-        if self.desired.model_id.as_ref() == Some(&model) {
-            return false;
-        }
-        self.desired.model_id = Some(model.clone());
-        self.pending_events.push(AcpSessionEvent::DesiredModelChanged { model });
-        true
-    }
-
-    /// Set a user's desired config selection.
-    pub fn set_desired_config(&mut self, key: ConfigKey, value: ConfigValue) {
-        let changed = self.desired.config_selections.get(&key) != Some(&value);
-        self.desired.config_selections.insert(key, value);
-        if changed {
-            let selections = self.desired.config_selections.clone();
-            self.pending_events
-                .push(AcpSessionEvent::DesiredConfigChanged { selections });
-        }
-    }
-}
-
 // ─── Observations (from CLI responses/notifications) ───────────────
 impl AcpSession {
     /// Record the CLI's current mode. Updates both `observed.mode_id` and
@@ -299,13 +296,25 @@ impl AcpSession {
     }
 
     pub fn apply_advertised_modes(&mut self, modes: SessionModeState) {
-        self.observed.mode_id = Some(ModeId::new(modes.current_mode_id.to_string()));
+        let new_id = ModeId::new(modes.current_mode_id.to_string());
+        let changed = self.observed.mode_id.as_ref() != Some(&new_id);
+        self.observed.mode_id = Some(new_id.clone());
         self.advertised.modes = Some(modes);
+        if changed {
+            self.pending_events
+                .push(AcpSessionEvent::ObservedModeSynced { mode: new_id });
+        }
     }
 
     pub fn apply_advertised_models(&mut self, models: SessionModelState) {
-        self.observed.model_id = Some(ModelId::new(models.current_model_id.to_string()));
+        let new_id = ModelId::new(models.current_model_id.to_string());
+        let changed = self.observed.model_id.as_ref() != Some(&new_id);
+        self.observed.model_id = Some(new_id.clone());
         self.advertised.models = Some(models);
+        if changed {
+            self.pending_events
+                .push(AcpSessionEvent::ObservedModelSynced { model: new_id });
+        }
     }
 
     pub fn apply_advertised_config_options(&mut self, options: Vec<SessionConfigOption>) {
@@ -339,8 +348,18 @@ impl AcpSession {
         self.advertised.available_commands = Some(commands);
     }
 
+    /// Record the CLI's latest context usage. Diff-driven: emits
+    /// `ObservedContextUsageChanged` only when the usage payload differs
+    /// from what we last cached, so the persistence consumer can debounce
+    /// a stream of token updates into one DB write per turn.
     pub fn apply_context_usage(&mut self, usage: UsageUpdate) {
-        self.advertised.context_usage = Some(usage);
+        let changed = self.advertised.context_usage.as_ref() != Some(&usage);
+        self.advertised.context_usage = Some(usage.clone());
+        if changed {
+            let usage_json = serde_json::to_string(&usage).unwrap_or_default();
+            self.pending_events
+                .push(AcpSessionEvent::ObservedContextUsageChanged { usage_json });
+        }
     }
 }
 
@@ -449,7 +468,7 @@ mod tests {
     #[test]
     fn assign_session_id_emits_event() {
         let mut session = make_session();
-        session.assign_session_id(SessionId::new("sess-1"));
+        session.set_session_id(SessionId::new("sess-1"));
         assert_eq!(session.session_id(), Some("sess-1"));
         let events = session.drain_events();
         assert_eq!(events.len(), 1);
@@ -464,9 +483,9 @@ mod tests {
     #[test]
     fn assign_session_id_is_idempotent() {
         let mut session = make_session();
-        session.assign_session_id(SessionId::new("sess-1"));
+        session.set_session_id(SessionId::new("sess-1"));
         session.drain_events();
-        session.assign_session_id(SessionId::new("sess-1"));
+        session.set_session_id(SessionId::new("sess-1"));
         assert!(session.drain_events().is_empty());
     }
 
@@ -687,7 +706,7 @@ mod tests {
     #[test]
     fn drain_events_clears_buffer() {
         let mut session = make_session();
-        session.assign_session_id(SessionId::new("s1"));
+        session.set_session_id(SessionId::new("s1"));
         session.mark_opened();
         assert_eq!(session.drain_events().len(), 2);
         assert!(session.drain_events().is_empty());

--- a/crates/aionui-ai-agent/src/manager/acp/session.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session.rs
@@ -7,25 +7,13 @@ use agent_client_protocol::schema::{
 
 use super::events::AcpSessionEvent;
 use super::reconcile::ReconcileAction;
-use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId, SessionId};
-
-/// Decoded per-session runtime state loaded from `acp_session.session_config.runtime`.
-///
-/// Only carries the user's last *choices* — the enumerations of what
-/// the agent supports (mode list, model list, config schema) come from
-/// the CLI's session response after initialization.
-#[derive(Debug, Clone, Default)]
-pub struct PersistedSessionState {
-    pub current_mode_id: Option<ModeId>,
-    pub current_model_id: Option<ModelId>,
-    pub config_selections: HashMap<ConfigKey, ConfigValue>,
-    pub context_usage: Option<UsageUpdate>,
-}
+use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId, PersistedSessionState, SessionId};
 
 /// What the user wants the session to be (intent).
 #[derive(Debug, Clone, Default)]
 struct Desired {
     mode_id: Option<ModeId>,
+    model_id: Option<ModelId>,
     config_selections: HashMap<ConfigKey, ConfigValue>,
 }
 
@@ -70,12 +58,17 @@ pub struct AcpSession {
 }
 
 impl AcpSession {
-    pub fn new(initial_mode: Option<ModeId>, config_selections: HashMap<ConfigKey, ConfigValue>) -> Self {
+    pub fn new(
+        initial_mode: Option<ModeId>,
+        initial_model: Option<ModelId>,
+        config_selections: HashMap<ConfigKey, ConfigValue>,
+    ) -> Self {
         Self {
             session_id: None,
             opened: false,
             desired: Desired {
                 mode_id: initial_mode,
+                model_id: initial_model,
                 config_selections,
             },
             observed: Observed::default(),
@@ -83,9 +76,10 @@ impl AcpSession {
             pending_events: Vec::new(),
         }
     }
+}
 
-    // ─── Getters ───────────────────────────────────────────────────────
-
+// ─── Getters ───────────────────────────────────────────────────────
+impl AcpSession {
     pub fn session_id(&self) -> Option<&str> {
         self.session_id.as_ref().map(SessionId::as_str)
     }
@@ -97,7 +91,10 @@ impl AcpSession {
     pub fn is_opened(&self) -> bool {
         self.opened
     }
+}
 
+// ─── Getters desired ───────────────────────────────────────────────────────
+impl AcpSession {
     pub fn desired_mode(&self) -> Option<&str> {
         self.desired.mode_id.as_ref().map(ModeId::as_str)
     }
@@ -106,6 +103,21 @@ impl AcpSession {
         self.desired.mode_id.as_ref()
     }
 
+    pub fn desired_model(&self) -> Option<&str> {
+        self.desired.model_id.as_ref().map(ModelId::as_str)
+    }
+
+    pub fn desired_model_id(&self) -> Option<&ModelId> {
+        self.desired.model_id.as_ref()
+    }
+
+    pub fn desired_config_selections(&self) -> &HashMap<ConfigKey, ConfigValue> {
+        &self.desired.config_selections
+    }
+}
+
+// ─── Getters observed ───────────────────────────────────────────────────────
+impl AcpSession {
     pub fn observed_mode(&self) -> Option<&str> {
         self.observed.mode_id.as_ref().map(ModeId::as_str)
     }
@@ -121,11 +133,10 @@ impl AcpSession {
     pub fn observed_model_id(&self) -> Option<&ModelId> {
         self.observed.model_id.as_ref()
     }
+}
 
-    pub fn config_selections(&self) -> &HashMap<ConfigKey, ConfigValue> {
-        &self.desired.config_selections
-    }
-
+// ─── Getters advertised ───────────────────────────────────────────────────────
+impl AcpSession {
     pub fn modes(&self) -> Option<&SessionModeState> {
         self.advertised.modes.as_ref()
     }
@@ -158,8 +169,13 @@ impl AcpSession {
         self.advertised.modes.as_ref().map(|m| m.current_mode_id.to_string())
     }
 
-    // ─── Commands (mutate + emit events) ───────────────────────────────
+    pub fn current_model_id(&self) -> Option<String> {
+        self.advertised.models.as_ref().map(|m| m.current_model_id.to_string())
+    }
+}
 
+// ─── Commands (mutate + emit events) ───────────────────────────────
+impl AcpSession {
     /// Assign (or restore) a session ID. Idempotent: re-assigning the same
     /// ID is a no-op. Assigning a *different* ID after one is already set
     /// is an invariant violation (the aggregate must be recreated).
@@ -199,6 +215,24 @@ impl AcpSession {
         true
     }
 
+    /// Set the user's desired model. Emits `DesiredModelChanged` if the
+    /// value actually changed. When advertised models are known, the model
+    /// must be in the list (otherwise the call is a no-op).
+    pub fn set_desired_model(&mut self, model: ModelId) -> bool {
+        if model.as_str().is_empty() {
+            return false;
+        }
+        if !self.is_model_valid(model.as_str()) {
+            return false;
+        }
+        if self.desired.model_id.as_ref() == Some(&model) {
+            return false;
+        }
+        self.desired.model_id = Some(model.clone());
+        self.pending_events.push(AcpSessionEvent::DesiredModelChanged { model });
+        true
+    }
+
     /// Set a user's desired config selection.
     pub fn set_desired_config(&mut self, key: ConfigKey, value: ConfigValue) {
         let changed = self.desired.config_selections.get(&key) != Some(&value);
@@ -209,22 +243,58 @@ impl AcpSession {
                 .push(AcpSessionEvent::DesiredConfigChanged { selections });
         }
     }
+}
 
-    // ─── Observations (from CLI responses/notifications) ───────────────
-
+// ─── Observations (from CLI responses/notifications) ───────────────
+impl AcpSession {
+    /// Record the CLI's current mode. Updates both `observed.mode_id` and
+    /// the `advertised.modes.current_mode_id` (available_modes preserved);
+    /// emits `ObservedModeSynced` when the value actually changed.
     pub fn apply_observed_mode(&mut self, mode: ModeId) {
         let changed = self.observed.mode_id.as_ref() != Some(&mode);
         self.observed.mode_id = Some(mode.clone());
+        let available = self
+            .advertised
+            .modes
+            .as_ref()
+            .map(|m| m.available_modes.clone())
+            .unwrap_or_default();
+        self.advertised.modes = Some(SessionModeState::new(mode.as_str().to_owned(), available));
         if changed {
             self.pending_events.push(AcpSessionEvent::ObservedModeSynced { mode });
         }
     }
 
+    /// Record the CLI's current model. Updates both `observed.model_id` and
+    /// the `advertised.models.current_model_id` (available_models preserved);
+    /// emits `ObservedModelSynced` when the value actually changed.
     pub fn apply_observed_model(&mut self, model: ModelId) {
         let changed = self.observed.model_id.as_ref() != Some(&model);
         self.observed.model_id = Some(model.clone());
+        let available = self
+            .advertised
+            .models
+            .as_ref()
+            .map(|m| m.available_models.clone())
+            .unwrap_or_default();
+        self.advertised.models = Some(SessionModelState::new(model.as_str().to_owned(), available));
         if changed {
             self.pending_events.push(AcpSessionEvent::ObservedModelSynced { model });
+        }
+    }
+
+    /// Record the CLI's current value for a single config option. Mirrors
+    /// `apply_observed_mode/model`: diff-driven, emits `ObservedConfigSynced`
+    /// with the full selection map when the value actually changed. Used by
+    /// the reconcile loop after a successful `set_config_option` so
+    /// `plan_reconcile` treats the drift as resolved.
+    pub fn apply_observed_config(&mut self, key: ConfigKey, value: ConfigValue) {
+        let changed = self.observed.config_current.get(&key) != Some(&value);
+        self.observed.config_current.insert(key, value);
+        if changed {
+            let selections = self.observed.config_current.clone();
+            self.pending_events
+                .push(AcpSessionEvent::ObservedConfigSynced { selections });
         }
     }
 
@@ -239,14 +309,22 @@ impl AcpSession {
     }
 
     pub fn apply_advertised_config_options(&mut self, options: Vec<SessionConfigOption>) {
+        let mut changed = false;
         for opt in &options {
             if let Some(current) = extract_config_current_value(&opt.kind) {
-                self.observed
-                    .config_current
-                    .insert(ConfigKey::new(opt.id.to_string()), ConfigValue::new(current));
+                let key = ConfigKey::new(opt.id.to_string());
+                let value = ConfigValue::new(current);
+                if self.observed.config_current.insert(key, value.clone()).as_ref() != Some(&value) {
+                    changed = true;
+                }
             }
         }
         self.advertised.config_options = Some(options);
+        if changed {
+            let selections = self.observed.config_current.clone();
+            self.pending_events
+                .push(AcpSessionEvent::ObservedConfigSynced { selections });
+        }
     }
 
     pub fn apply_advertised_capabilities(&mut self, caps: AgentCapabilities) {
@@ -264,17 +342,9 @@ impl AcpSession {
     pub fn apply_context_usage(&mut self, usage: UsageUpdate) {
         self.advertised.context_usage = Some(usage);
     }
+}
 
-    /// Update the model's current_model_id in place without replacing
-    /// the available models list. Used after a successful `set_model` call.
-    pub fn update_current_model(&mut self, model: ModelId) {
-        if let Some(info) = &self.advertised.models {
-            let updated = SessionModelState::new(model.as_str().to_owned(), info.available_models.clone());
-            self.advertised.models = Some(updated);
-        }
-        self.observed.model_id = Some(model);
-    }
-
+impl AcpSession {
     /// Seed the aggregate with persisted user choices from DB.
     /// Called on resume paths before the CLI session/load response arrives.
     pub fn preload_persisted(&mut self, state: &PersistedSessionState) {
@@ -293,20 +363,10 @@ impl AcpSession {
             self.advertised.context_usage = Some(usage.clone());
         }
     }
+}
 
-    /// Apply a partial mode update (only currentModeId changed, keep available_modes).
-    pub fn apply_partial_mode_update(&mut self, current_mode: ModeId) {
-        if let Some(existing) = &self.advertised.modes {
-            let available = existing.available_modes.clone();
-            self.advertised.modes = Some(SessionModeState::new(current_mode.as_str().to_owned(), available));
-        } else {
-            self.advertised.modes = Some(SessionModeState::new(current_mode.as_str().to_owned(), Vec::new()));
-        }
-        self.observed.mode_id = Some(current_mode);
-    }
-
-    // ─── Reconcile ─────────────────────────────────────────────────────
-
+// ─── Reconcile ─────────────────────────────────────────────────────
+impl AcpSession {
     /// Produce a list of actions needed to align CLI state with user intent.
     /// Pure function — no side effects. The driver executes the actions.
     pub fn plan_reconcile(&self) -> Vec<ReconcileAction> {
@@ -317,6 +377,14 @@ impl AcpSession {
         {
             actions.push(ReconcileAction::SetMode {
                 mode: desired_mode.clone(),
+            });
+        }
+
+        if let Some(desired_model) = &self.desired.model_id
+            && self.observed.model_id.as_ref() != Some(desired_model)
+        {
+            actions.push(ReconcileAction::SetModel {
+                model: desired_model.clone(),
             });
         }
 
@@ -348,6 +416,17 @@ impl AcpSession {
             Some(modes) => modes.available_modes.iter().any(|m| m.id.0.as_ref() == mode_id),
         }
     }
+
+    fn is_model_valid(&self, model_id: &str) -> bool {
+        match &self.advertised.models {
+            None => true,
+            Some(models) if models.available_models.is_empty() => true,
+            Some(models) => models
+                .available_models
+                .iter()
+                .any(|m| m.model_id.0.as_ref() == model_id),
+        }
+    }
 }
 
 fn extract_config_current_value(kind: &SessionConfigKind) -> Option<String> {
@@ -364,7 +443,7 @@ mod tests {
     use super::*;
 
     fn make_session() -> AcpSession {
-        AcpSession::new(Some(ModeId::new("default")), HashMap::new())
+        AcpSession::new(Some(ModeId::new("default")), None, HashMap::new())
     }
 
     #[test]
@@ -460,6 +539,99 @@ mod tests {
     }
 
     #[test]
+    fn apply_observed_mode_syncs_advertised_current_without_losing_available() {
+        use agent_client_protocol::schema::SessionMode;
+        let mut session = make_session();
+        session.apply_advertised_modes(SessionModeState::new(
+            "default",
+            vec![SessionMode::new("default", "Default"), SessionMode::new("plan", "Plan")],
+        ));
+        session.drain_events();
+
+        session.apply_observed_mode(ModeId::new("plan"));
+
+        assert_eq!(session.observed_mode(), Some("plan"));
+        assert_eq!(session.current_mode_id().as_deref(), Some("plan"));
+        let modes = session.modes().expect("modes present");
+        assert_eq!(modes.available_modes.len(), 2, "available_modes must be preserved");
+    }
+
+    #[test]
+    fn apply_observed_model_syncs_advertised_current_without_losing_available() {
+        use agent_client_protocol::schema::ModelInfo;
+        let mut session = make_session();
+        session.apply_advertised_models(SessionModelState::new(
+            "claude-sonnet-4",
+            vec![
+                ModelInfo::new("claude-sonnet-4", "Sonnet 4"),
+                ModelInfo::new("claude-opus-4", "Opus 4"),
+            ],
+        ));
+        session.drain_events();
+
+        session.apply_observed_model(ModelId::new("claude-opus-4"));
+
+        assert_eq!(session.observed_model(), Some("claude-opus-4"));
+        assert_eq!(session.current_model_id().as_deref(), Some("claude-opus-4"));
+        let models = session.model_info().expect("models present");
+        assert_eq!(models.available_models.len(), 2, "available_models must be preserved");
+    }
+
+    #[test]
+    fn apply_observed_mode_creates_advertised_when_empty() {
+        let mut session = make_session();
+        session.apply_observed_mode(ModeId::new("plan"));
+        assert_eq!(session.current_mode_id().as_deref(), Some("plan"));
+    }
+
+    #[test]
+    fn apply_observed_model_creates_advertised_when_empty() {
+        let mut session = make_session();
+        session.apply_observed_model(ModelId::new("claude-opus-4"));
+        assert_eq!(session.current_model_id().as_deref(), Some("claude-opus-4"));
+    }
+
+    #[test]
+    fn apply_observed_config_emits_on_change_and_is_idempotent() {
+        let mut session = make_session();
+        session.apply_observed_config(ConfigKey::new("reasoning"), ConfigValue::new("high"));
+        let events = session.drain_events();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AcpSessionEvent::ObservedConfigSynced { selections } => {
+                assert_eq!(
+                    selections.get(&ConfigKey::new("reasoning")),
+                    Some(&ConfigValue::new("high"))
+                );
+            }
+            other => panic!("expected ObservedConfigSynced, got {other:?}"),
+        }
+
+        // Idempotent repeat: no new event.
+        session.apply_observed_config(ConfigKey::new("reasoning"), ConfigValue::new("high"));
+        assert!(session.drain_events().is_empty());
+    }
+
+    #[test]
+    fn apply_observed_config_closes_plan_reconcile_drift() {
+        let mut session = AcpSession::new(None, None, HashMap::new());
+        session.set_desired_config(ConfigKey::new("reasoning"), ConfigValue::new("high"));
+        assert_eq!(
+            session.plan_reconcile(),
+            vec![ReconcileAction::SetConfigOption {
+                key: ConfigKey::new("reasoning"),
+                value: ConfigValue::new("high"),
+            }]
+        );
+
+        session.apply_observed_config(ConfigKey::new("reasoning"), ConfigValue::new("high"));
+        assert!(
+            session.plan_reconcile().is_empty(),
+            "plan_reconcile must be a no-op once observed catches up to desired",
+        );
+    }
+
+    #[test]
     fn plan_reconcile_detects_mode_drift() {
         let mut session = make_session();
         session.set_desired_mode(ModeId::new("plan"));
@@ -483,7 +655,7 @@ mod tests {
 
     #[test]
     fn plan_reconcile_detects_config_drift() {
-        let mut session = AcpSession::new(None, HashMap::new());
+        let mut session = AcpSession::new(None, None, HashMap::new());
         session.set_desired_config(ConfigKey::new("reasoning"), ConfigValue::new("high"));
         let actions = session.plan_reconcile();
         assert_eq!(
@@ -497,7 +669,7 @@ mod tests {
 
     #[test]
     fn plan_reconcile_config_aligned_when_observed_matches() {
-        let mut session = AcpSession::new(None, HashMap::new());
+        let mut session = AcpSession::new(None, None, HashMap::new());
         session.set_desired_config(ConfigKey::new("reasoning"), ConfigValue::new("high"));
 
         session.apply_advertised_config_options(vec![SessionConfigOption::select(
@@ -537,12 +709,150 @@ mod tests {
     }
 
     #[test]
+    fn set_desired_model_emits_when_changed() {
+        let mut session = make_session();
+        assert!(session.set_desired_model(ModelId::new("claude-sonnet-4")));
+        assert_eq!(session.desired_model(), Some("claude-sonnet-4"));
+        let events = session.drain_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0],
+            AcpSessionEvent::DesiredModelChanged {
+                model: ModelId::new("claude-sonnet-4"),
+            }
+        );
+    }
+
+    #[test]
+    fn set_desired_model_rejects_empty() {
+        let mut session = make_session();
+        assert!(!session.set_desired_model(ModelId::new("")));
+        assert!(session.drain_events().is_empty());
+    }
+
+    #[test]
+    fn set_desired_model_no_op_when_unchanged() {
+        let mut session = make_session();
+        session.set_desired_model(ModelId::new("claude-sonnet-4"));
+        session.drain_events();
+        assert!(!session.set_desired_model(ModelId::new("claude-sonnet-4")));
+        assert!(session.drain_events().is_empty());
+    }
+
+    #[test]
+    fn set_desired_model_validates_against_advertised() {
+        use agent_client_protocol::schema::ModelInfo;
+        let mut session = make_session();
+        session.apply_advertised_models(SessionModelState::new(
+            "claude-sonnet-4",
+            vec![
+                ModelInfo::new("claude-sonnet-4", "Sonnet 4"),
+                ModelInfo::new("claude-opus-4", "Opus 4"),
+            ],
+        ));
+        assert!(session.set_desired_model(ModelId::new("claude-opus-4")));
+        assert!(!session.set_desired_model(ModelId::new("nonexistent")));
+    }
+
+    #[test]
+    fn set_desired_model_allows_any_when_advertised_empty() {
+        let mut session = make_session();
+        assert!(session.set_desired_model(ModelId::new("anything")));
+    }
+
+    #[test]
+    fn apply_observed_model_does_not_change_desired_model() {
+        let mut session = make_session();
+        session.set_desired_model(ModelId::new("claude-opus-4"));
+        session.drain_events();
+        session.apply_observed_model(ModelId::new("claude-sonnet-4"));
+        assert_eq!(session.desired_model(), Some("claude-opus-4"));
+        assert_eq!(session.observed_model(), Some("claude-sonnet-4"));
+    }
+
+    #[test]
+    fn plan_reconcile_detects_model_drift() {
+        let mut session = AcpSession::new(None, None, HashMap::new());
+        session.set_desired_model(ModelId::new("claude-opus-4"));
+        session.apply_observed_model(ModelId::new("claude-sonnet-4"));
+        let actions = session.plan_reconcile();
+        assert_eq!(
+            actions,
+            vec![ReconcileAction::SetModel {
+                model: ModelId::new("claude-opus-4"),
+            }]
+        );
+    }
+
+    #[test]
+    fn plan_reconcile_model_aligned_when_observed_matches() {
+        let mut session = AcpSession::new(None, None, HashMap::new());
+        session.set_desired_model(ModelId::new("claude-opus-4"));
+        session.apply_observed_model(ModelId::new("claude-opus-4"));
+        assert!(session.plan_reconcile().is_empty());
+    }
+
+    #[test]
+    fn new_with_initial_model_sets_desired_model() {
+        let session = AcpSession::new(None, Some(ModelId::new("claude-opus-4")), HashMap::new());
+        assert_eq!(session.desired_model(), Some("claude-opus-4"));
+    }
+
+    #[test]
+    fn apply_advertised_config_options_emits_observed_config_synced_on_change() {
+        let mut session = AcpSession::new(None, None, HashMap::new());
+        session.apply_advertised_config_options(vec![SessionConfigOption::select(
+            "reasoning",
+            "Reasoning",
+            "high",
+            vec![
+                SessionConfigSelectOption::new("low", "Low"),
+                SessionConfigSelectOption::new("high", "High"),
+            ],
+        )]);
+        let events = session.drain_events();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AcpSessionEvent::ObservedConfigSynced { selections } => {
+                assert_eq!(
+                    selections.get(&ConfigKey::new("reasoning")),
+                    Some(&ConfigValue::new("high"))
+                );
+            }
+            other => panic!("expected ObservedConfigSynced, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_advertised_config_options_idempotent_when_unchanged() {
+        let mut session = AcpSession::new(None, None, HashMap::new());
+        let options = vec![SessionConfigOption::select(
+            "reasoning",
+            "Reasoning",
+            "high",
+            vec![
+                SessionConfigSelectOption::new("low", "Low"),
+                SessionConfigSelectOption::new("high", "High"),
+            ],
+        )];
+        session.apply_advertised_config_options(options.clone());
+        session.drain_events();
+
+        session.apply_advertised_config_options(options);
+        let events = session.drain_events();
+        assert!(
+            events.is_empty(),
+            "no ObservedConfigSynced when observed unchanged, got {events:?}"
+        );
+    }
+
+    #[test]
     fn set_desired_mode_plus_plan_reconcile_produces_set_mode_action() {
         // This test documents the Stage 4 invariant: the manager's set_mode
         // should only (a) call set_desired_mode on the aggregate and (b) delegate
         // to plan_reconcile for the SDK call. Plan_reconcile should emit
         // ReconcileAction::SetMode when desired and observed diverge.
-        let mut session = AcpSession::new(None, Default::default());
+        let mut session = AcpSession::new(None, None, Default::default());
         session.apply_advertised_modes(SessionModeState::new(
             "default".to_owned(),
             vec![SessionMode::new("default", "Default"), SessionMode::new("plan", "Plan")],

--- a/crates/aionui-ai-agent/src/manager/acp/session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session_flow.rs
@@ -43,7 +43,7 @@ impl AcpAgentManager {
             if let Some(config_options) = session_response.config_options {
                 session.apply_advertised_config_options(config_options);
             }
-            session.assign_session_id(DomainSessionId::new(sid.clone()));
+            session.set_session_id(DomainSessionId::new(sid.clone()));
             self.commit_session_changes(&mut session).await;
         }
         self.emit_snapshot_events().await;
@@ -138,7 +138,7 @@ impl AcpAgentManager {
                     if let Some(config_options) = session_response.config_options {
                         session.apply_advertised_config_options(config_options);
                     }
-                    session.assign_session_id(DomainSessionId::new(new_sid.clone()));
+                    session.set_session_id(DomainSessionId::new(new_sid.clone()));
                     self.commit_session_changes(&mut session).await;
                 }
                 self.emit_snapshot_events().await;
@@ -190,7 +190,7 @@ impl AcpAgentManager {
         if let Some(sid) = session_id {
             {
                 let mut session = self.session.write().await;
-                session.assign_session_id(DomainSessionId::new(sid));
+                session.set_session_id(DomainSessionId::new(sid));
                 self.commit_session_changes(&mut session).await;
             }
             self.reconcile_session(sid).await;

--- a/crates/aionui-ai-agent/src/manager/acp/session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session_flow.rs
@@ -88,10 +88,10 @@ impl AcpAgentManager {
 
     /// Resume an existing session and send a message.
     ///
-    /// Assumes `preload_snapshot` has already been called by the
-    /// caller (conversation service) on resume paths — the session
-    /// aggregate may therefore already carry `current_mode_id` / `current_model_id`
-    /// from `acp_session.session_config.runtime`. When the CLI's
+    /// The session aggregate is seeded during `AcpAgentManager::new`
+    /// from `params.session_snapshot` — on resume paths it already
+    /// carries `current_mode_id` / `current_model_id` from
+    /// `acp_session.session_config.runtime`. When the CLI's
     /// `session/load` response arrives, we merge it in but keep the
     /// preloaded `current_*` values because they reflect the user's
     /// last explicit choice; the CLI's own `current_*` is only used

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -68,8 +68,8 @@ impl AionrsAgentManager {
             project_dir: Some(PathBuf::from(&workspace)),
         };
 
-        let mut config = Config::resolve(&cli_args)
-            .map_err(|e| AppError::Internal(format!("Config resolve failed: {e}")))?;
+        let mut config =
+            Config::resolve(&cli_args).map_err(|e| AppError::Internal(format!("Config resolve failed: {e}")))?;
 
         // Backend-specific overrides
         config.session.enabled = true;
@@ -282,7 +282,7 @@ impl AionrsAgentManager {
         self.approval_manager.is_auto_approved(action)
     }
 
-    pub async fn get_mode(&self) -> Result<AgentModeResponse, AppError> {
+    pub async fn mode(&self) -> Result<AgentModeResponse, AppError> {
         Ok(AgentModeResponse {
             mode: self.approval_manager.current_mode(),
             initialized: true,

--- a/crates/aionui-ai-agent/src/persistence/acp_session_sync.rs
+++ b/crates/aionui-ai-agent/src/persistence/acp_session_sync.rs
@@ -1,9 +1,15 @@
 //! Per-session persistence consumer driven by domain events.
 //!
 //! Subscribes to `mpsc::Receiver<AcpSessionEvent>` (not the UI broadcast)
-//! and writes user *intent* changes to `acp_session.session_config.runtime`.
-//! This eliminates the previous anti-pattern of reverse-engineering desired
-//! state from CLI observation events (`currentModeId` in `AcpModeInfo`).
+//! and writes CLI-observed state to `acp_session.session_config.runtime`.
+//!
+//! The consumer listens to `Observed*` events (mode, model, config,
+//! context_usage). The `session_config.runtime` columns record what the
+//! session last had — i.e. what resume needs to restore — which is by
+//! definition observation-shaped, not intent-shaped. Desired events are
+//! kept inside the aggregate for reconcile/UI broadcast only; they are
+//! intentionally not persisted so that an invalid user pick (which the
+//! CLI rejects) does not leave stale desired values in the DB.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -152,11 +158,15 @@ impl PendingUpdate {
 
     fn merge_from_domain_event(&mut self, event: &AcpSessionEvent) -> bool {
         match event {
-            AcpSessionEvent::DesiredModeChanged { mode } => {
+            AcpSessionEvent::ObservedModeSynced { mode } => {
                 self.current_mode_id = Some(Some(mode.as_str().to_owned()));
                 true
             }
-            AcpSessionEvent::DesiredConfigChanged { selections } => {
+            AcpSessionEvent::ObservedModelSynced { model } => {
+                self.current_model_id = Some(Some(model.as_str().to_owned()));
+                true
+            }
+            AcpSessionEvent::ObservedConfigSynced { selections } => {
                 let string_map: HashMap<String, String> = selections
                     .iter()
                     .map(|(k, v)| (k.as_str().to_owned(), v.as_str().to_owned()))
@@ -165,8 +175,8 @@ impl PendingUpdate {
                 self.config_selections_json = Some(Some(json));
                 true
             }
-            AcpSessionEvent::DesiredModelChanged { model } => {
-                self.current_model_id = Some(Some(model.as_str().to_owned()));
+            AcpSessionEvent::ObservedContextUsageChanged { usage_json } => {
+                self.context_usage_json = Some(Some(usage_json.clone()));
                 true
             }
             _ => false,
@@ -294,7 +304,7 @@ mod tests {
         assert_eq!(state.current_mode_id.as_deref(), Some("plan"));
     }
 
-    /// Domain event DesiredModeChanged flushes after debounce.
+    /// Domain event ObservedModeSynced flushes after debounce.
     #[tokio::test(flavor = "current_thread")]
     async fn domain_event_flushes_after_debounce() {
         let (_svc, repo) = setup().await;
@@ -303,7 +313,7 @@ mod tests {
         let cid = "conv-1".to_owned();
         tokio::spawn(domain_event_consumer(cid, rx, repo.clone()));
 
-        tx.send(AcpSessionEvent::DesiredModeChanged { mode: "plan".into() })
+        tx.send(AcpSessionEvent::ObservedModeSynced { mode: "plan".into() })
             .await
             .unwrap();
 
@@ -326,7 +336,7 @@ mod tests {
         tokio::spawn(domain_event_consumer(cid, rx, repo.clone()));
 
         for label in ["code", "plan", "ask"] {
-            tx.send(AcpSessionEvent::DesiredModeChanged { mode: label.into() })
+            tx.send(AcpSessionEvent::ObservedModeSynced { mode: label.into() })
                 .await
                 .unwrap();
             sleep(Duration::from_millis(100)).await;
@@ -362,7 +372,7 @@ mod tests {
         let cid = "conv-1".to_owned();
         tokio::spawn(domain_event_consumer(cid, rx, repo.clone()));
 
-        tx.send(AcpSessionEvent::DesiredModeChanged { mode: "plan".into() })
+        tx.send(AcpSessionEvent::ObservedModeSynced { mode: "plan".into() })
             .await
             .unwrap();
         drop(tx);
@@ -376,30 +386,13 @@ mod tests {
         );
     }
 
-    /// DesiredModelChanged drives current_model_id persistence (mirrors
-    /// DesiredModeChanged). ObservedModelSynced must NOT write the DB —
-    /// persistence only reflects user intent, never CLI observation.
+    /// ObservedModelSynced drives current_model_id persistence (mirrors
+    /// ObservedModeSynced). DesiredModelChanged must NOT write the DB —
+    /// the DB stores what the CLI actually ran with, not what the user
+    /// asked for (an invalid desired value the CLI rejects must not
+    /// leave a stale row).
     #[tokio::test(flavor = "current_thread")]
-    async fn desired_model_changed_persists_current_model_id() {
-        let (_svc, repo) = setup().await;
-        let (tx, rx) = mpsc::channel(64);
-
-        let cid = "conv-1".to_owned();
-        tokio::spawn(domain_event_consumer(cid, rx, repo.clone()));
-
-        tx.send(AcpSessionEvent::DesiredModelChanged {
-            model: "claude-opus-4".into(),
-        })
-        .await
-        .unwrap();
-
-        sleep(Duration::from_millis(700)).await;
-        let state = repo.load_runtime_state("conv-1").await.unwrap().unwrap();
-        assert_eq!(state.current_model_id.as_deref(), Some("claude-opus-4"));
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn observed_model_synced_does_not_persist() {
+    async fn observed_model_synced_persists_current_model_id() {
         let (_svc, repo) = setup().await;
         let (tx, rx) = mpsc::channel(64);
 
@@ -414,14 +407,58 @@ mod tests {
 
         sleep(Duration::from_millis(700)).await;
         let state = repo.load_runtime_state("conv-1").await.unwrap().unwrap();
+        assert_eq!(state.current_model_id.as_deref(), Some("claude-opus-4"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn desired_model_changed_does_not_persist() {
+        let (_svc, repo) = setup().await;
+        let (tx, rx) = mpsc::channel(64);
+
+        let cid = "conv-1".to_owned();
+        tokio::spawn(domain_event_consumer(cid, rx, repo.clone()));
+
+        tx.send(AcpSessionEvent::DesiredModelChanged {
+            model: "claude-opus-4".into(),
+        })
+        .await
+        .unwrap();
+
+        sleep(Duration::from_millis(700)).await;
+        let state = repo.load_runtime_state("conv-1").await.unwrap().unwrap();
         assert!(
             state.current_model_id.is_none(),
-            "ObservedModelSynced is UI-only; persistence must only come from DesiredModelChanged",
+            "DesiredModelChanged is reconcile/UI-only; persistence only follows Observed*",
         );
     }
 
+    /// ObservedContextUsageChanged persists the usage blob so resume
+    /// paths can preload `advertised.context_usage` before the CLI's
+    /// first notification arrives.
+    #[tokio::test(flavor = "current_thread")]
+    async fn observed_context_usage_persists() {
+        let (_svc, repo) = setup().await;
+        let (tx, rx) = mpsc::channel(64);
+
+        let cid = "conv-1".to_owned();
+        tokio::spawn(domain_event_consumer(cid, rx, repo.clone()));
+
+        tx.send(AcpSessionEvent::ObservedContextUsageChanged {
+            usage_json: r#"{"used":12345,"size":200000}"#.to_owned(),
+        })
+        .await
+        .unwrap();
+
+        sleep(Duration::from_millis(700)).await;
+        let state = repo.load_runtime_state("conv-1").await.unwrap().unwrap();
+        let raw = state.context_usage_json.expect("usage must be persisted");
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(parsed["used"], 12345);
+        assert_eq!(parsed["size"], 200000);
+    }
+
     /// SessionAssigned must write the session_id immediately, bypassing
-    /// the debounce window used for desired-state updates.
+    /// the debounce window used for runtime-state updates.
     #[tokio::test(flavor = "current_thread")]
     async fn session_assigned_writes_session_id_immediately() {
         let (_svc, repo) = setup().await;

--- a/crates/aionui-ai-agent/src/persistence/acp_session_sync.rs
+++ b/crates/aionui-ai-agent/src/persistence/acp_session_sync.rs
@@ -15,9 +15,8 @@ use tokio::task::JoinHandle;
 use tokio::time::sleep_until;
 use tracing::{debug, warn};
 
-use crate::manager::acp::PersistedSessionState as SnapshotPersistedState;
 use crate::manager::acp::events::AcpSessionEvent;
-use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId};
+use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId, PersistedSessionState};
 
 const DEBOUNCE_WINDOW: Duration = Duration::from_millis(500);
 
@@ -56,7 +55,7 @@ impl AcpSessionSyncService {
     /// aggregate's value-object shape. Returns `None` when the row does
     /// not exist or the JSON payload is empty. Errors are logged and
     /// swallowed so the caller can proceed with a fresh session.
-    pub async fn load_snapshot_state(&self, conversation_id: &str) -> Option<SnapshotPersistedState> {
+    pub async fn load_snapshot_state(&self, conversation_id: &str) -> Option<PersistedSessionState> {
         let row = match self.repo.load_runtime_state(conversation_id).await {
             Ok(Some(row)) => row,
             Ok(None) => return None,
@@ -70,7 +69,7 @@ impl AcpSessionSyncService {
             }
         };
 
-        let mut state = SnapshotPersistedState {
+        let mut state = PersistedSessionState {
             current_mode_id: row.current_mode_id.map(ModeId::new),
             current_model_id: row.current_model_id.map(ModelId::new),
             ..Default::default()
@@ -166,7 +165,7 @@ impl PendingUpdate {
                 self.config_selections_json = Some(Some(json));
                 true
             }
-            AcpSessionEvent::ObservedModelSynced { model } => {
+            AcpSessionEvent::DesiredModelChanged { model } => {
                 self.current_model_id = Some(Some(model.as_str().to_owned()));
                 true
             }
@@ -374,6 +373,50 @@ mod tests {
             state.current_mode_id.as_deref(),
             Some("plan"),
             "pending update must flush on channel close"
+        );
+    }
+
+    /// DesiredModelChanged drives current_model_id persistence (mirrors
+    /// DesiredModeChanged). ObservedModelSynced must NOT write the DB —
+    /// persistence only reflects user intent, never CLI observation.
+    #[tokio::test(flavor = "current_thread")]
+    async fn desired_model_changed_persists_current_model_id() {
+        let (_svc, repo) = setup().await;
+        let (tx, rx) = mpsc::channel(64);
+
+        let cid = "conv-1".to_owned();
+        tokio::spawn(domain_event_consumer(cid, rx, repo.clone()));
+
+        tx.send(AcpSessionEvent::DesiredModelChanged {
+            model: "claude-opus-4".into(),
+        })
+        .await
+        .unwrap();
+
+        sleep(Duration::from_millis(700)).await;
+        let state = repo.load_runtime_state("conv-1").await.unwrap().unwrap();
+        assert_eq!(state.current_model_id.as_deref(), Some("claude-opus-4"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn observed_model_synced_does_not_persist() {
+        let (_svc, repo) = setup().await;
+        let (tx, rx) = mpsc::channel(64);
+
+        let cid = "conv-1".to_owned();
+        tokio::spawn(domain_event_consumer(cid, rx, repo.clone()));
+
+        tx.send(AcpSessionEvent::ObservedModelSynced {
+            model: "claude-opus-4".into(),
+        })
+        .await
+        .unwrap();
+
+        sleep(Duration::from_millis(700)).await;
+        let state = repo.load_runtime_state("conv-1").await.unwrap().unwrap();
+        assert!(
+            state.current_model_id.is_none(),
+            "ObservedModelSynced is UI-only; persistence must only come from DesiredModelChanged",
         );
     }
 

--- a/crates/aionui-ai-agent/src/service.rs
+++ b/crates/aionui-ai-agent/src/service.rs
@@ -77,7 +77,7 @@ impl AgentService {
                 "Model info is only available for ACP agents".into(),
             ));
         };
-        let sdk_model = acp.model_info().await;
+        let sdk_model = acp.model().await;
         let model_info = sdk_model.map(map_sdk_model_to_payload);
         Ok(GetModelInfoResponse { model_info })
     }
@@ -92,7 +92,7 @@ impl AgentService {
                 "Model switching is not supported for this agent type".into(),
             ));
         };
-        acp.set_model_info(&req.model_id).await
+        acp.set_model(&req.model_id).await
     }
 
     pub async fn get_config(

--- a/crates/aionui-ai-agent/src/shared_kernel/mod.rs
+++ b/crates/aionui-ai-agent/src/shared_kernel/mod.rs
@@ -1,5 +1,7 @@
 pub mod approval;
 pub mod ids;
+pub mod snapshot;
 
 pub use approval::approval_key;
 pub use ids::*;
+pub use snapshot::PersistedSessionState;

--- a/crates/aionui-ai-agent/src/shared_kernel/snapshot.rs
+++ b/crates/aionui-ai-agent/src/shared_kernel/snapshot.rs
@@ -1,0 +1,23 @@
+use std::collections::HashMap;
+
+use agent_client_protocol::schema::UsageUpdate;
+
+use super::{ConfigKey, ConfigValue, ModeId, ModelId};
+
+/// Decoded per-session runtime state loaded from `acp_session.session_config.runtime`.
+///
+/// Only carries the user's last *choices* — the enumerations of what
+/// the agent supports (mode list, model list, config schema) come from
+/// the CLI's session response after initialization.
+///
+/// Shared between the factory (seeds `AcpSessionParams`), the aggregate
+/// root (`AcpSession::preload_persisted`), and the persistence consumer
+/// (`AcpSessionSyncService::load_snapshot_state`), so it lives in
+/// `shared_kernel` rather than any of those layers.
+#[derive(Debug, Clone, Default)]
+pub struct PersistedSessionState {
+    pub current_mode_id: Option<ModeId>,
+    pub current_model_id: Option<ModelId>,
+    pub config_selections: HashMap<ConfigKey, ConfigValue>,
+    pub context_usage: Option<UsageUpdate>,
+}

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -299,7 +299,7 @@ async fn acp_agent_model_info_captured() {
 
     wait_for_event(&mut rx, |e| matches!(e, AgentStreamEvent::AcpModelInfo(_))).await;
 
-    let info = agent.model_info().await;
+    let info = agent.model().await;
     assert!(info.is_some(), "Model info should be captured");
     let info = info.unwrap();
     assert_eq!(&*info.current_model_id.0, "claude-sonnet-4");

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -88,21 +88,25 @@ async fn make_mock_agent(script: &str, backend: &str) -> (Arc<AcpAgentManager>, 
         .expect("seeded backend row must exist");
     let catalog_tx = registry.catalog_sender();
 
-    let params = Arc::new(assemble_acp_params(
-        "test-conv-1".into(),
-        WorkspaceInfo {
-            path: "/tmp".into(),
-            is_custom: true,
-        },
-        metadata,
-        aionui_common::CommandSpec {
-            command: script_path.into(),
-            args: vec![],
-            env: vec![],
-            cwd: None,
-        },
-        config,
-    ));
+    let params = Arc::new(
+        assemble_acp_params(
+            "test-conv-1".into(),
+            WorkspaceInfo {
+                path: "/tmp".into(),
+                is_custom: true,
+            },
+            metadata,
+            aionui_common::CommandSpec {
+                command: script_path.into(),
+                args: vec![],
+                env: vec![],
+                cwd: None,
+            },
+            config,
+            None,
+        )
+        .await,
+    );
 
     let (manager, _, _) = AcpAgentManager::new(params, skill_manager, &catalog_tx)
         .await

--- a/crates/aionui-ai-agent/tests/acp_module_surface.rs
+++ b/crates/aionui-ai-agent/tests/acp_module_surface.rs
@@ -8,9 +8,7 @@
 //! moved function bodies and by the stage's new targeted tests.
 #![allow(dead_code, unused_imports)]
 
-use aionui_ai_agent::manager::acp::{
-    AcpSession, AcpSessionEvent, CatalogForwarder, PermissionRouter, ReconcileAction,
-};
+use aionui_ai_agent::manager::acp::{AcpSession, AcpSessionEvent, CatalogForwarder, PermissionRouter, ReconcileAction};
 use aionui_ai_agent::shared_kernel::PersistedSessionState;
 
 fn _surface_probe() {

--- a/crates/aionui-ai-agent/tests/acp_module_surface.rs
+++ b/crates/aionui-ai-agent/tests/acp_module_surface.rs
@@ -9,8 +9,9 @@
 #![allow(dead_code, unused_imports)]
 
 use aionui_ai_agent::manager::acp::{
-    AcpSession, AcpSessionEvent, CatalogForwarder, PermissionRouter, PersistedSessionState, ReconcileAction,
+    AcpSession, AcpSessionEvent, CatalogForwarder, PermissionRouter, ReconcileAction,
 };
+use aionui_ai_agent::shared_kernel::PersistedSessionState;
 
 fn _surface_probe() {
     let _ = std::any::type_name::<AcpSession>();

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -2114,7 +2114,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl IMockAgent for RecordingAgent {
-        async fn get_mode(&self) -> Result<AgentModeResponse, aionui_common::AppError> {
+        async fn mode(&self) -> Result<AgentModeResponse, aionui_common::AppError> {
             Ok(AgentModeResponse {
                 mode: self.mode().await,
                 initialized: self.initialized,

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -1004,7 +1004,7 @@ mod tests {
             let _ = approval_key(Some(action), command_type);
             false
         }
-        async fn get_mode(&self) -> Result<AgentModeResponse, AppError> {
+        async fn mode(&self) -> Result<AgentModeResponse, AppError> {
             Ok(AgentModeResponse {
                 mode: "default".into(),
                 initialized: false,

--- a/crates/aionui-team/tests/e2e_team_flow.rs
+++ b/crates/aionui-team/tests/e2e_team_flow.rs
@@ -172,7 +172,7 @@ impl IMockAgent for RecordingAgent {
     fn confirm(&self, _: &str, _: &str, _: Value, _: bool) -> Result<(), AppError> {
         Ok(())
     }
-    async fn get_mode(&self) -> Result<AgentModeResponse, AppError> {
+    async fn mode(&self) -> Result<AgentModeResponse, AppError> {
         Ok(AgentModeResponse {
             mode: "default".to_owned(),
             initialized: false,


### PR DESCRIPTION
## Summary

- Reshape `AcpSession` into symmetric desired/observed/advertised layers with event-sourced mutations, so intent writes and CLI observations no longer fight for the same fields
- Switch `session_config.runtime` persistence from `Desired*` to `Observed*` events — the DB now records what the CLI actually ran with, and invalid user picks rejected by the CLI no longer leave stale runtime rows
- Add `ObservedContextUsageChanged` + `preload_persisted` so resume can restore the cached usage blob before the CLI's first notification, and emit `ObservedModeSynced`/`ObservedModelSynced` from `apply_advertised_*`
- Align agent accessors: `get_mode` → `mode`, `model_info` → `model`, `set_model_info` → `set_model`, `assign_session_id` → `set_session_id`; add `set_mode`, `auth_methods`, `load_slash_commands` on `AcpAgentManager`
- Move `AcpAgentManager::new` into `agent.rs` and regroup `AcpSession` impl blocks by concern (session id, desired, observed)

## Test plan

- [ ] `cargo test -p aionui-ai-agent`
- [ ] `cargo test -p aionui-cron -p aionui-team`
- [ ] `cargo clippy -p aionui-ai-agent -p aionui-cron -p aionui-team -- -D warnings`
- [ ] Manual: open an ACP conversation, switch mode + model, reload — verify persisted runtime reflects observed values and resume preloads usage/mode/model without flicker