### PR TITLE
fix(aionrs): second message stuck in processing state

### DIFF
--- a/crates/aionui-ai-agent/src/agent_runtime.rs
+++ b/crates/aionui-ai-agent/src/agent_runtime.rs
@@ -93,6 +93,14 @@ impl AgentRuntime {
         *guard = Some(status);
     }
 
+    /// Force-reset the status so a new turn can emit Finish again.
+    /// Only intended for multi-turn agents (e.g. aionrs) where the same
+    /// runtime instance handles successive user messages.
+    pub fn reset_for_new_turn(&self, status: ConversationStatus) {
+        let mut guard = self.status.write().unwrap_or_else(|e| e.into_inner());
+        *guard = Some(status);
+    }
+
     pub fn emit(&self, event: AgentStreamEvent) {
         let _ = self.event_tx.send(event);
     }

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -68,8 +68,8 @@ impl AionrsAgentManager {
             project_dir: Some(PathBuf::from(&workspace)),
         };
 
-        let mut config = Config::resolve(&cli_args)
-            .map_err(|e| AppError::Internal(format!("Config resolve failed: {e}")))?;
+        let mut config =
+            Config::resolve(&cli_args).map_err(|e| AppError::Internal(format!("Config resolve failed: {e}")))?;
 
         // Backend-specific overrides
         config.session.enabled = true;
@@ -173,7 +173,7 @@ impl crate::agent_task::IAgentTask for AionrsAgentManager {
             "Aionrs send_message started"
         );
         self.runtime.bump_activity();
-        self.runtime.transition_to(ConversationStatus::Running);
+        self.runtime.reset_for_new_turn(ConversationStatus::Running);
 
         let mut engine = self.engine.lock().await;
         let result = engine.run(&data.content, &data.msg_id).await;


### PR DESCRIPTION
## Summary

- Aionrs 对话中发送第二条消息后，前端永远卡在"正在处理中"状态
- 根因：`AgentRuntime` 重构 (#175) 将 `Finished` 设计为 absorbing state，`emit_finish()` 在已 Finished 时是 no-op。但 aionrs 多轮复用同一个 runtime 实例，第一轮完成后 status 锁死在 Finished，第二轮的 `emit_finish` 不再发送事件，`StreamRelay` 永远收不到终止信号
- 修复：添加 `AgentRuntime::reset_for_new_turn()` 方法，在 aionrs `send_message` 开始时强制重置状态为 Running，使后续 `emit_finish` 正常工作

## Test plan

- [x] `cargo clippy -p aionui-ai-agent -- -D warnings` 通过
- [x] `cargo test -p aionui-ai-agent` 318 tests 全部通过
- [x] `cargo test -p aionui-conversation` 227 tests 全部通过
- [ ] 手动验证：aionrs 对话中连续发送多条消息，每条消息完成后状态正确切换为 finished