### PR TITLE
refactor(ai-agent): ACP state management enhancements

### DIFF
--- a/crates/aionui-ai-agent/src/capability/cli_process/spawn_sdk.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/spawn_sdk.rs
@@ -30,7 +30,7 @@ impl CliAgentProcess {
         if let Some(ref cwd) = config.cwd {
             cmd.current_dir(cwd);
         }
-
+        debug!("Spawning CLI process (SDK mode) with command: {:?}", &cmd);
         let mut child: Child = cmd.spawn().map_err(|e| {
             error!(command = %config.command.display(), error = %e, "Failed to spawn CLI process");
             AppError::Internal(format!(

--- a/crates/aionui-ai-agent/src/protocol/events/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/events/mod.rs
@@ -34,10 +34,6 @@ pub enum AgentStreamEvent {
     AgentStatus(AgentStatusEventData),
     Thinking(ThinkingEventData),
     Plan(PlanEventData),
-    // DEPRECATED: Use AcpPermission(AcpPermissionEventData::Confirmation(..)) instead.
-    // This variant remains only for wire-format compatibility with the frontend;
-    // no production code should emit it after Stage 5 (see review.md §B3, target §7.5).
-    // Removing it is a coordinated cross-repo change.
     Permission(serde_json::Value),
     AcpPermission(AcpPermissionEventData),
     SkillSuggest(SkillSuggestEventData),
@@ -51,15 +47,7 @@ pub enum AgentStreamEvent {
     AvailableCommands(AvailableCommandsEventData),
     Finish(FinishEventData),
     Error(ErrorEventData),
-    /// DEPRECATED: no producer in the backend. Retained for wire-format
-    /// compatibility — removing it would change the `AgentStreamEvent`
-    /// serde tag set visible to the frontend. Safe to delete once the
-    /// frontend is confirmed not to depend on `type: "system"` messages.
     System(serde_json::Value),
-    /// DEPRECATED: no producer in the backend. Retained for wire-format
-    /// compatibility — removing it would change the `AgentStreamEvent`
-    /// serde tag set visible to the frontend. Safe to delete once the
-    /// frontend is confirmed not to depend on `type: "request_trace"` messages.
     RequestTrace(serde_json::Value),
     SessionAssigned(SessionAssignedEventData),
 }

--- a/crates/aionui-runtime/build.rs
+++ b/crates/aionui-runtime/build.rs
@@ -60,7 +60,7 @@ fn main() {
     // Step 1: ensure decompressed bun is cached.
     if !bun_exe_path.is_file() {
         let url = build_support::download_url(&version, &asset);
-        println!("cargo:warning=Downloading {url}");
+        println!("cargo:info=Downloading {url}");
         let zip_path = cache_root.join(&asset);
         download(&url, &zip_path);
         unzip_bun(&zip_path, &cache_root, build_support::bun_exe_name(&target));

--- a/crates/aionui-runtime/src/spawn.rs
+++ b/crates/aionui-runtime/src/spawn.rs
@@ -39,8 +39,16 @@ enum Mode {
 
 pub struct Builder {
     inner: Command,
-    #[allow(dead_code)] // kept for future diagnostics / debug impl
     mode: Mode,
+}
+
+impl std::fmt::Debug for Builder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Builder")
+            .field("mode", &self.mode)
+            .field("command", self.inner.as_std())
+            .finish()
+    }
 }
 
 impl Builder {

--- a/crates/aionui-system/src/provider.rs
+++ b/crates/aionui-system/src/provider.rs
@@ -185,9 +185,22 @@ fn validate_create_request(req: &CreateProviderRequest) -> Result<(), AppError> 
     if req.name.trim().is_empty() {
         return Err(AppError::BadRequest("name is required".into()));
     }
-    validate_base_url(&req.base_url)?;
-    if req.api_key.trim().is_empty() {
-        return Err(AppError::BadRequest("apiKey is required".into()));
+    // Bedrock auths via bedrock_config (IAM profile / static keys) rather than
+    // an HTTP endpoint + bearer key, so baseUrl and apiKey may be empty.
+    if req.platform == "bedrock" {
+        if req.bedrock_config.is_none() {
+            return Err(AppError::BadRequest(
+                "bedrockConfig is required for bedrock platform".into(),
+            ));
+        }
+        if !req.base_url.trim().is_empty() {
+            validate_base_url(&req.base_url)?;
+        }
+    } else {
+        validate_base_url(&req.base_url)?;
+        if req.api_key.trim().is_empty() {
+            return Err(AppError::BadRequest("apiKey is required".into()));
+        }
     }
     Ok(())
 }
@@ -365,6 +378,38 @@ mod tests {
     #[test]
     fn validate_create_valid() {
         assert!(validate_create_request(&sample_create_request()).is_ok());
+    }
+
+    #[test]
+    fn validate_create_bedrock_allows_empty_base_url_and_api_key() {
+        let req = CreateProviderRequest {
+            platform: "bedrock".into(),
+            name: "AWS Bedrock".into(),
+            base_url: "".into(),
+            api_key: "".into(),
+            bedrock_config: Some(aionui_api_types::BedrockConfig {
+                auth_method: aionui_api_types::BedrockAuthMethod::Profile,
+                region: "us-west-2".into(),
+                profile: Some("ai".into()),
+                access_key_id: None,
+                secret_access_key: None,
+            }),
+            ..sample_create_request()
+        };
+        assert!(validate_create_request(&req).is_ok());
+    }
+
+    #[test]
+    fn validate_create_bedrock_requires_bedrock_config() {
+        let req = CreateProviderRequest {
+            platform: "bedrock".into(),
+            name: "AWS Bedrock".into(),
+            base_url: "".into(),
+            api_key: "".into(),
+            bedrock_config: None,
+            ..sample_create_request()
+        };
+        assert!(validate_create_request(&req).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Refactor ACP state management and session persistence architecture
- Improve runtime diagnostics and subprocess spawning infrastructure
- Clean up deprecated protocol documentation
- Fix Bedrock provider validation to allow IAM-based authentication
- Migrate database filename and add safe upgrade path

## Key Changes

### ACP State Management
- Centralize runtime state in `AcpRuntimeSnapshot` for consistent resume/new paths
- Persist user-selected configuration via `session_config` field
- Clean up overlapping state holders in `AcpAgentManager`
- Improve event tracking and reconciliation logic

### Runtime Infrastructure
- Add `aionui_runtime::Builder` for subprocess spawning with consistent policies
- Enhance `PATH` at startup to include bundled bun and platform-specific bins
- Migrate ai-agent, mcp, office, extension, and shell spawns to use Builder
- Improve spawn diagnostics with structured logging

### Database Migration
- Change database filename from `aionui.db` to `aionui-backend.db`
- Add `maybe_copy_legacy_database` for safe upgrade path on first run
- Add integration tests for copy-then-migrate flow

### Provider Validation
- Fix Bedrock provider validation to allow empty `baseUrl`/`apiKey` when using IAM authentication
- Require `bedrockConfig` for Bedrock platform
- Add test coverage for Bedrock validation scenarios

### Protocol Cleanup
- Remove obsolete deprecation comments from `AgentStreamEvent` variants
- Clean up documentation for wire-format compatibility variants

## Test Plan

- [x] All existing tests pass (`cargo test --workspace`)
- [x] New database migration tests verify copy behavior
- [x] Bedrock provider validation tests cover IAM auth scenarios
- [x] ACP integration tests validate state persistence
- [x] Manual testing of ACP session resume/new flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)