### PR TITLE
refactor(ai-agent): ACP manager construction phase split

### DIFF
--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -100,7 +100,7 @@ pub(super) async fn build(
     let skill_mgr = deps.skill_manager.clone();
     let catalog_tx = deps.agent_registry.catalog_sender();
 
-    let (agent, domain_rx, notification_rx) = AcpAgentManager::new(params, skill_mgr, &catalog_tx).await?;
+    let (agent, domain_rx, notification_rx) = AcpAgentManager::build(params, skill_mgr, &catalog_tx).await?;
 
     let arc = Arc::new(agent);
     arc.start_permission_handler();

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -61,11 +61,13 @@ pub(super) fn sdk_to_snake_value<T: serde::Serialize>(value: &T) -> Option<Value
 pub struct AcpAgentManager {
     /// Pre-computed, immutable session parameters assembled by the factory.
     pub(super) params: Arc<AcpSessionParams>,
+
     /// Session aggregate root — owns desired/observed/advertised state.
     /// Single in-memory source of truth for session lifecycle, modes,
     /// models, config, and all runtime data previously split across
     /// `AcpRuntimeSnapshot` and `AcpState`.
     pub(super) session: RwLock<AcpSession>,
+
     /// Shared runtime holding status, last_activity, and the event
     /// broadcast channel. `pub(super)` so sibling modules (session_flow,
     /// event_tracker) can call `self.runtime.emit(...)` directly.
@@ -75,20 +77,26 @@ pub struct AcpAgentManager {
     /// `emit_finish` / `emit_error` are idempotent in the Finished
     /// absorbing state — multiple calls are safe.
     pub(super) runtime: AgentRuntime,
-    /// Underlying CLI process (for lifecycle management: kill, is_running).
-    process: Arc<CliAgentProcess>,
+
     /// ACP protocol handle (SDK connection).
     pub(super) protocol: AcpProtocol,
-    /// Mutex for serializing session operations (new/load/send).
-    session_lock: Mutex<()>,
+
     /// Routes permission requests from the protocol layer to the user
     /// and back. Owns the receiver channel, pending map, and closing flag.
     pub(super) permission_router: Arc<PermissionRouter>,
+
     /// Shared skill manager — used to discover skills for first-message injection.
     pub(super) skill_manager: Arc<AcpSkillManager>,
+
     /// Domain event sender — session aggregate events are forwarded here
     /// for the persistence consumer (`AcpSessionSyncService`).
     pub(super) domain_event_tx: mpsc::Sender<AcpSessionEvent>,
+
+    /// Underlying CLI process (for lifecycle management: kill, is_running).
+    process: Arc<CliAgentProcess>,
+
+    /// Mutex for serializing session operations (new/load/send).
+    session_lock: Mutex<()>,
 }
 
 impl AcpAgentManager {
@@ -100,7 +108,7 @@ impl AcpAgentManager {
     /// MPSC sender used for the one-shot initialize handshake write;
     /// session-driven fields flow through the `CatalogForwarder` the
     /// factory spawns after construction.
-    pub async fn new(
+    pub async fn build(
         params: Arc<AcpSessionParams>,
         skill_manager: Arc<AcpSkillManager>,
         catalog_tx: &CatalogSender,
@@ -112,21 +120,35 @@ impl AcpAgentManager {
         ),
         AppError,
     > {
-        let process = CliAgentProcess::spawn_for_sdk(params.command_spec.clone()).await?;
+        let (this, domain_event_rx, notification_rx) = AcpAgentManager::new(params, skill_manager).await?;
+        this.init(catalog_tx).await;
+        Ok((this, domain_event_rx, notification_rx))
+    }
 
-        // Take raw stdio for the SDK transport
+    async fn new(
+        params: Arc<AcpSessionParams>,
+        skill_manager: Arc<AcpSkillManager>,
+    ) -> Result<
+        (
+            Self,
+            mpsc::Receiver<AcpSessionEvent>,
+            mpsc::Receiver<SessionNotification>,
+        ),
+        AppError,
+    > {
+        let process = CliAgentProcess::spawn_for_sdk(params.command_spec.clone()).await?;
         let (stdin, stdout) = process
             .take_stdio()
             .await
             .ok_or_else(|| AppError::Internal("Failed to take stdio from CLI process".into()))?;
 
-        let runtime = AgentRuntime::new(params.conversation_id.clone(), params.workspace.path.clone(), 256);
-        let (permission_tx, permission_rx) = mpsc::channel(32);
-        let (domain_event_tx, domain_event_rx) = mpsc::channel(256);
         // Dedicated channel for raw SDK SessionNotifications → session tracker.
         // This channel is separate from event_tx so the tracker never re-applies
         // events that were broadcast for the UI (e.g. from emit_snapshot_events).
         let (notification_tx, notification_rx) = mpsc::channel::<SessionNotification>(256);
+        let (domain_event_tx, domain_event_rx) = mpsc::channel(256);
+        let (permission_tx, permission_rx) = mpsc::channel(32);
+        let runtime = AgentRuntime::new(params.conversation_id.clone(), params.workspace.path.clone(), 256);
 
         let protocol = AcpProtocol::connect(stdin, stdout, runtime.event_sender(), permission_tx, notification_tx)
             .await
@@ -138,55 +160,31 @@ impl AcpAgentManager {
                 );
                 AppError::from(e)
             })?;
-
-        let init_handshake = AgentHandshake {
-            agent_capabilities: protocol.agent_capabilities().and_then(|c| sdk_to_snake_value(&c)),
-            auth_methods: protocol.auth_methods().and_then(|m| sdk_to_snake_value(&m)),
-            ..Default::default()
-        };
-        if init_handshake.agent_capabilities.is_some() || init_handshake.auth_methods.is_some() {
-            catalog_tx.send_partial(params.metadata.id.clone(), init_handshake);
-        }
+        let permission_router = Arc::new(PermissionRouter::new(permission_rx));
 
         let snapshot = params.session_snapshot.as_ref();
 
         // Prefer the last-persisted mode; for brand-new conversations
         // fall back to `AcpBuildExtra::session_mode` so the first turn
         // still honours the caller's choice.
-        let initial_mode = snapshot
-            .and_then(|s| s.current_mode_id.as_ref())
-            .map(|m| normalize_requested_mode(&params.metadata, m.as_str()))
-            .or_else(|| {
-                params
-                    .config
-                    .session_mode
-                    .as_ref()
-                    .map(|m| normalize_requested_mode(&params.metadata, m))
-            })
-            .filter(|m| !m.is_empty())
-            .map(ModeId::new);
+        let (initial_mode, initial_model, initial_config) = (
+            snapshot
+                .and_then(|s| s.current_mode_id.as_ref())
+                .map(|m| normalize_requested_mode(&params.metadata, m.as_str()))
+                .or_else(|| {
+                    params
+                        .config
+                        .session_mode
+                        .as_ref()
+                        .map(|m| normalize_requested_mode(&params.metadata, m))
+                })
+                .filter(|m| !m.is_empty())
+                .map(ModeId::new),
+            snapshot.and_then(|s| s.current_model_id.clone()),
+            snapshot.map(|s| s.config_selections.clone()).unwrap_or_default(),
+        );
 
-        let initial_model = snapshot.and_then(|s| s.current_model_id.clone());
-        let initial_config = snapshot.map(|s| s.config_selections.clone()).unwrap_or_default();
-
-        let mut session = AcpSession::new(initial_mode, initial_model, initial_config);
-        // Seed the observed/advertised layers (observed mode/model, cached
-        // context_usage) from the persisted snapshot. Desired fields are
-        // already populated via `AcpSession::new`.
-        if let Some(snapshot) = snapshot {
-            session.preload_persisted(snapshot);
-            // Preload did not come from the user this turn — drain so the
-            // persistence consumer doesn't echo the DB back into itself.
-            session.drain_events();
-        }
-        if let Some(agent_capabilities) = protocol.agent_capabilities() {
-            session.apply_advertised_capabilities(agent_capabilities);
-        }
-        if let Some(auth_methods) = protocol.auth_methods() {
-            session.apply_advertised_auth_methods(auth_methods);
-        }
-
-        let permission_router = Arc::new(PermissionRouter::new(permission_rx));
+        let session = AcpSession::new(initial_mode, initial_model, initial_config);
 
         let manager = Self {
             params,
@@ -199,8 +197,37 @@ impl AcpAgentManager {
             skill_manager,
             domain_event_tx,
         };
-
         Ok((manager, domain_event_rx, notification_rx))
+    }
+
+    async fn init(&self, catalog_tx: &CatalogSender) {
+        let init_handshake = AgentHandshake {
+            agent_capabilities: self.protocol.agent_capabilities().and_then(|c| sdk_to_snake_value(&c)),
+            auth_methods: self.protocol.auth_methods().and_then(|m| sdk_to_snake_value(&m)),
+            ..Default::default()
+        };
+        if init_handshake.agent_capabilities.is_some() || init_handshake.auth_methods.is_some() {
+            catalog_tx.send_partial(self.params.metadata.id.clone(), init_handshake);
+        }
+
+        // Seed the observed/advertised layers (observed mode/model, cached
+        // context_usage) from the persisted snapshot. Desired fields are
+        // already populated via `AcpSession::new`.
+        if let Some(snapshot) = self.params.session_snapshot.as_ref() {
+            let mut session = self.session.write().await;
+            session.preload_persisted(snapshot);
+            // Preload did not come from the user this turn — drain so the
+            // persistence consumer doesn't echo the DB back into itself.
+            session.drain_events();
+        }
+        if let Some(agent_capabilities) = self.protocol.agent_capabilities() {
+            let mut session = self.session.write().await;
+            session.apply_advertised_capabilities(agent_capabilities);
+        }
+        if let Some(auth_methods) = self.protocol.auth_methods() {
+            let mut session = self.session.write().await;
+            session.apply_advertised_auth_methods(auth_methods);
+        }
     }
 }
 

--- a/crates/aionui-ai-agent/src/manager/acp/session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session_flow.rs
@@ -8,30 +8,21 @@ use crate::types::SendMessageData;
 use agent_client_protocol::schema::{ContentBlock, LoadSessionRequest, PromptRequest, SessionId};
 use aionui_common::AppError;
 use serde_json::Value;
-use tracing::info;
 
 use super::agent::sdk_to_snake_value;
 
 impl AcpAgentManager {
-    /// Create a new ACP session and send the first prompt.
-    pub(super) async fn session_new_and_prompt(&self, data: &SendMessageData) -> Result<(), AppError> {
-        // Emit Start event
-        self.runtime
-            .emit(AgentStreamEvent::Start(StartEventData { session_id: None }));
-
+    /// Establish a fresh ACP session (session/new) and apply desired
+    /// mode/model/config via reconcile. Does NOT send a prompt and
+    /// does NOT emit Start/Finish — callers wrap that around if needed.
+    ///
+    /// Returns the CLI-assigned session id.
+    pub(super) async fn open_session_new(&self) -> Result<String, AppError> {
         let req = self.params.new_session_request();
-        tracing::info!(
-            has_team_mcp = self.params.config.team_mcp_stdio_config.is_some(),
-            has_guide_mcp = self.params.config.guide_mcp_config.is_some(),
-            guide_mcp_port = self.params.config.guide_mcp_config.as_ref().map(|c| c.port),
-            mcp_servers_count = req.mcp_servers.len(),
-            "session_new_and_prompt: sending session/new"
-        );
         let session_response = self.protocol.new_session(req).await.map_err(AppError::from)?;
 
         let sid = session_response.session_id.to_string();
 
-        // Populate the session aggregate from the session response
         {
             let mut session = self.session.write().await;
             if let Some(models) = session_response.models {
@@ -48,15 +39,23 @@ impl AcpAgentManager {
         }
         self.emit_snapshot_events().await;
 
-        // Notify subscribers (e.g. session_sync consumer) so the new id is
-        // persisted into `acp_session.session_id` — resume can then
-        // choose `session/load` instead of a fresh `session/new`.
+        // Notify session_sync consumer so the new id hits the DB and
+        // future rebuilds can take the resume path.
         self.runtime
             .emit(AgentStreamEvent::SessionAssigned(SessionAssignedEventData {
                 session_id: sid.clone(),
             }));
 
         self.reconcile_session(&sid).await;
+        Ok(sid)
+    }
+
+    /// Create a new ACP session and send the first prompt.
+    pub(super) async fn session_new_and_prompt(&self, data: &SendMessageData) -> Result<(), AppError> {
+        self.runtime
+            .emit(AgentStreamEvent::Start(StartEventData { session_id: None }));
+
+        let sid = self.open_session_new().await?;
 
         let injected_content = inject_first_message_prefix(
             &data.content,
@@ -70,7 +69,6 @@ impl AcpAgentManager {
         )
         .await;
 
-        // Send the prompt
         self.protocol
             .prompt(PromptRequest::new(
                 SessionId::new(sid.clone()),
@@ -79,7 +77,6 @@ impl AcpAgentManager {
             .await
             .map_err(AppError::from)?;
 
-        // Emit Finish event when prompt completes
         self.runtime
             .emit(AgentStreamEvent::Finish(FinishEventData { session_id: Some(sid) }));
 
@@ -113,18 +110,11 @@ impl AcpAgentManager {
                 claude_code.insert("options".into(), Value::Object(options));
                 meta.insert("claudeCode".into(), Value::Object(claude_code));
 
-                let req = self.params.new_session_request().meta(meta);
-
-                info!(
-                    session_id = %sid,
-                    has_team_mcp = self.params.config.team_mcp_stdio_config.is_some(),
-                    has_guide_mcp = self.params.config.guide_mcp_config.is_some(),
-                    guide_mcp_port = self.params.config.guide_mcp_config.as_ref().map(|c| c.port),
-                    mcp_servers_count = req.mcp_servers.len(),
-                    "session_resume: using session/new with claudeCode.options.resume"
-                );
-
-                let session_response = self.protocol.new_session(req).await.map_err(AppError::from)?;
+                let session_response = self
+                    .protocol
+                    .new_session(self.params.new_session_request().meta(meta))
+                    .await
+                    .map_err(AppError::from)?;
 
                 let new_sid = session_response.session_id.to_string();
                 {

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -108,7 +108,7 @@ async fn make_mock_agent(script: &str, backend: &str) -> (Arc<AcpAgentManager>, 
         .await,
     );
 
-    let (manager, _, _) = AcpAgentManager::new(params, skill_manager, &catalog_tx)
+    let (manager, _, _) = AcpAgentManager::build(params, skill_manager, &catalog_tx)
         .await
         .expect("Failed to spawn mock ACP agent");
 


### PR DESCRIPTION
## Summary

- 将 `AcpAgentManager::new` 拆分为 `new` (构造) + `init` (初始化) 两阶段
- 重命名公共构造方法为 `build`,使接口语义更清晰
- 提取 `open_session_new` 方法,移除 Start/Finish 事件发射(调用方关注点)
- 按内聚性重新组织 `AcpAgentManager` 字段分组
- 使初始化序列更加明确:spawn → connect → build session → init state → emit events

## Why

之前的单体构造函数将 CLI 进程启动、协议握手、会话状态初始化、目录更新混在一个 async 块中。拆分为 new+init 使依赖流向更明确(协议必须在 init 读取 capabilities 之前连接),并允许未来在 init 时进行依赖注入而无需重新启动进程。

## Test plan

- [x] 运行 `cargo test -p aionui-ai-agent` 确保集成测试通过
- [x] 验证重构后的构造逻辑与原有行为一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)