### PR TITLE
feat(assistant): allow overriding preset_agent_type on built-in assistants

### DIFF
--- a/crates/aionui-assistant/src/service.rs
+++ b/crates/aionui-assistant/src/service.rs
@@ -193,7 +193,45 @@ impl AssistantService {
     pub async fn update(&self, id: &str, req: UpdateAssistantRequest) -> Result<AssistantResponse, AppError> {
         match self.classify_source(id).await {
             AssistantSource::Builtin => {
-                return Err(AppError::Forbidden("Cannot modify built-in assistant".into()));
+                // Built-in rows are sourced from the embedded bundle and can't
+                // be mutated. Users may still override `preset_agent_type` —
+                // that lives in the overrides table. Any other field on the
+                // request is rejected so callers don't silently lose data.
+                if req.name.is_some()
+                    || req.description.is_some()
+                    || req.avatar.is_some()
+                    || req.enabled_skills.is_some()
+                    || req.custom_skill_names.is_some()
+                    || req.disabled_builtin_skills.is_some()
+                    || req.prompts.is_some()
+                    || req.models.is_some()
+                    || req.name_i18n.is_some()
+                    || req.description_i18n.is_some()
+                    || req.prompts_i18n.is_some()
+                {
+                    return Err(AppError::Forbidden(
+                        "Only 'preset_agent_type' can be overridden on built-in assistants".into(),
+                    ));
+                }
+
+                let preset_agent_type = req.preset_agent_type.as_deref().ok_or_else(|| {
+                    AppError::BadRequest("'preset_agent_type' is required when updating a built-in assistant".into())
+                })?;
+
+                let existing = self.override_repo.get(id).await?;
+                let enabled = existing.as_ref().is_none_or(|o| o.enabled);
+                let sort_order = existing.as_ref().map(|o| o.sort_order).unwrap_or(0);
+                let last_used_at = existing.as_ref().and_then(|o| o.last_used_at);
+
+                let params = UpsertOverrideParams {
+                    assistant_id: id,
+                    enabled,
+                    sort_order,
+                    last_used_at,
+                    preset_agent_type: Some(Some(preset_agent_type)),
+                };
+                self.override_repo.upsert(&params).await?;
+                return self.get(id).await;
             }
             AssistantSource::Extension => {
                 return Err(AppError::Forbidden(
@@ -289,6 +327,7 @@ impl AssistantService {
             enabled,
             sort_order,
             last_used_at,
+            preset_agent_type: None,
         };
         self.override_repo.upsert(&params).await?;
 
@@ -625,7 +664,9 @@ fn builtin_to_response(b: &BuiltinAssistant, ov: Option<&AssistantOverrideRow>) 
         avatar: b.avatar.clone(),
         enabled: ov.map(|o| o.enabled).unwrap_or(true),
         sort_order: ov.map(|o| o.sort_order).unwrap_or(0),
-        preset_agent_type: b.preset_agent_type.clone(),
+        preset_agent_type: ov
+            .and_then(|o| o.preset_agent_type.clone())
+            .unwrap_or_else(|| b.preset_agent_type.clone()),
         enabled_skills: b.enabled_skills.clone(),
         custom_skill_names: b.custom_skill_names.clone(),
         disabled_builtin_skills: b.disabled_builtin_skills.clone(),
@@ -1030,7 +1071,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn update_rejects_builtin() {
+    async fn update_rejects_builtin_non_preset_fields() {
         let fx = fixture_with_builtins(vec![mk_builtin("builtin-office", "Office")]).await;
         let err = fx
             .service
@@ -1044,6 +1085,34 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, AppError::Forbidden(_)));
+    }
+
+    #[tokio::test]
+    async fn update_builtin_preset_agent_type_writes_override() {
+        let fx = fixture_with_builtins(vec![mk_builtin("builtin-office", "Office")]).await;
+        let updated = fx
+            .service
+            .update(
+                "builtin-office",
+                UpdateAssistantRequest {
+                    preset_agent_type: Some("claude".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(updated.source, AssistantSource::Builtin);
+        assert_eq!(updated.preset_agent_type, "claude");
+        // List view must reflect the override too.
+        let listed = fx
+            .service
+            .list()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|a| a.id == "builtin-office")
+            .unwrap();
+        assert_eq!(listed.preset_agent_type, "claude");
     }
 
     #[tokio::test]

--- a/crates/aionui-db/migrations/011_assistant_override_preset_agent_type.sql
+++ b/crates/aionui-db/migrations/011_assistant_override_preset_agent_type.sql
@@ -1,0 +1,3 @@
+-- Allow users to override the preset_agent_type of a built-in assistant
+-- without having to duplicate it. `NULL` means "inherit from the source row".
+ALTER TABLE assistant_overrides ADD COLUMN preset_agent_type TEXT;

--- a/crates/aionui-db/src/models/assistant.rs
+++ b/crates/aionui-db/src/models/assistant.rs
@@ -28,12 +28,17 @@ pub struct AssistantRow {
 }
 
 /// Row mapping for the `assistant_overrides` table (per-assistant user state).
+///
+/// `preset_agent_type` is `Some(_)` when the user has switched the main agent
+/// on a built-in assistant (which cannot be mutated at its source). `None`
+/// means "inherit from the built-in / user row".
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct AssistantOverrideRow {
     pub assistant_id: String,
     pub enabled: bool,
     pub sort_order: i32,
     pub last_used_at: Option<TimestampMs>,
+    pub preset_agent_type: Option<String>,
     pub updated_at: TimestampMs,
 }
 
@@ -78,10 +83,15 @@ pub struct UpdateAssistantParams<'a> {
 }
 
 /// Upsert parameters for `IAssistantOverrideRepository::upsert`.
-#[derive(Debug, Clone)]
+///
+/// `preset_agent_type` uses `Option<Option<&str>>`: outer `None` keeps the
+/// current value, outer `Some(inner)` writes `inner` (which itself may be
+/// `None` to clear the override).
+#[derive(Debug, Clone, Default)]
 pub struct UpsertOverrideParams<'a> {
     pub assistant_id: &'a str,
     pub enabled: bool,
     pub sort_order: i32,
     pub last_used_at: Option<TimestampMs>,
+    pub preset_agent_type: Option<Option<&'a str>>,
 }

--- a/crates/aionui-db/src/repository/sqlite_assistant.rs
+++ b/crates/aionui-db/src/repository/sqlite_assistant.rs
@@ -255,21 +255,34 @@ impl IAssistantOverrideRepository for SqliteAssistantOverrideRepository {
         let now = now_ms();
         let last_used_at: Option<TimestampMs> = params.last_used_at;
 
+        // `preset_agent_type` has three-way semantics in the params struct
+        // (see `UpsertOverrideParams`). At the SQL layer we flatten it into a
+        // `(write?, value)` pair: on CONFLICT, if the caller did not specify
+        // a new value, `COALESCE(new_flag, 0)` keeps the existing column.
+        let (pat_write, pat_value): (bool, Option<&str>) = match params.preset_agent_type {
+            Some(v) => (true, v),
+            None => (false, None),
+        };
+
         sqlx::query(
             "INSERT INTO assistant_overrides \
-                (assistant_id, enabled, sort_order, last_used_at, updated_at) \
-             VALUES (?, ?, ?, ?, ?) \
+                (assistant_id, enabled, sort_order, last_used_at, preset_agent_type, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?) \
              ON CONFLICT(assistant_id) DO UPDATE SET \
                 enabled = excluded.enabled, \
                 sort_order = excluded.sort_order, \
                 last_used_at = COALESCE(excluded.last_used_at, assistant_overrides.last_used_at), \
+                preset_agent_type = CASE WHEN ? THEN ? ELSE assistant_overrides.preset_agent_type END, \
                 updated_at = excluded.updated_at",
         )
         .bind(params.assistant_id)
         .bind(params.enabled)
         .bind(params.sort_order)
         .bind(last_used_at)
+        .bind(pat_value)
         .bind(now)
+        .bind(pat_write)
+        .bind(pat_value)
         .execute(&self.pool)
         .await?;
 
@@ -486,6 +499,7 @@ mod tests {
                 enabled: false,
                 sort_order: 5,
                 last_used_at: Some(1000),
+                ..Default::default()
             })
             .await
             .unwrap();
@@ -503,6 +517,7 @@ mod tests {
             enabled: true,
             sort_order: 0,
             last_used_at: Some(1000),
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -513,6 +528,7 @@ mod tests {
                 enabled: false,
                 sort_order: 3,
                 last_used_at: None,
+                ..Default::default()
             })
             .await
             .unwrap();
@@ -531,6 +547,7 @@ mod tests {
             enabled: true,
             sort_order: 0,
             last_used_at: None,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -539,6 +556,7 @@ mod tests {
             enabled: false,
             sort_order: 1,
             last_used_at: None,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -555,6 +573,7 @@ mod tests {
             enabled: true,
             sort_order: 0,
             last_used_at: None,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -571,6 +590,7 @@ mod tests {
                 enabled: true,
                 sort_order: 0,
                 last_used_at: None,
+                ..Default::default()
             })
             .await
             .unwrap();
@@ -591,6 +611,7 @@ mod tests {
             enabled: true,
             sort_order: 0,
             last_used_at: None,
+            ..Default::default()
         })
         .await
         .unwrap();

--- a/crates/aionui-office/src/star_office.rs
+++ b/crates/aionui-office/src/star_office.rs
@@ -34,6 +34,29 @@ impl StarOfficeDetector {
     }
 
     pub async fn detect(&self, preferred_url: Option<&str>, force: bool, timeout_ms: Option<u64>) -> Option<String> {
+        self.detect_inner(preferred_url, force, timeout_ms, true).await
+    }
+
+    /// Probe only `preferred_url` without expanding to `KNOWN_PORTS` or the
+    /// `±SCAN_RADIUS` neighborhood. Exists for deterministic tests that need
+    /// to pin detection to a specific mock server; production callers should
+    /// use [`detect`].
+    pub async fn detect_exact(
+        &self,
+        preferred_url: Option<&str>,
+        force: bool,
+        timeout_ms: Option<u64>,
+    ) -> Option<String> {
+        self.detect_inner(preferred_url, force, timeout_ms, false).await
+    }
+
+    async fn detect_inner(
+        &self,
+        preferred_url: Option<&str>,
+        force: bool,
+        timeout_ms: Option<u64>,
+        scan_neighbors: bool,
+    ) -> Option<String> {
         if !force {
             let cache = self.cache.lock().await;
             if let Some(ref c) = *cache {
@@ -45,7 +68,7 @@ impl StarOfficeDetector {
             }
         }
 
-        let candidates = build_candidate_urls(preferred_url);
+        let candidates = build_candidate_urls(preferred_url, scan_neighbors);
         let timeout = Duration::from_millis(timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS));
 
         tracing::debug!(count = candidates.len(), "scanning star-office candidate URLs");
@@ -85,13 +108,19 @@ impl StarOfficeDetector {
     }
 }
 
-fn build_candidate_urls(preferred_url: Option<&str>) -> Vec<String> {
+fn build_candidate_urls(preferred_url: Option<&str>, scan_neighbors: bool) -> Vec<String> {
     let mut seed_ports: Vec<u16> = Vec::new();
 
     if let Some(url) = preferred_url
         && let Some(port) = extract_port(url)
     {
         seed_ports.push(port);
+    }
+
+    if !scan_neighbors {
+        // Exact mode: skip KNOWN_PORTS and the ±SCAN_RADIUS expansion so the
+        // detector talks to the caller-supplied URL only.
+        return seed_ports.iter().map(|p| format!("http://localhost:{p}")).collect();
     }
 
     for p in KNOWN_PORTS {
@@ -207,7 +236,7 @@ mod tests {
 
     #[test]
     fn build_candidates_default_ports() {
-        let urls = build_candidate_urls(None);
+        let urls = build_candidate_urls(None, true);
         assert!(urls[0] == "http://localhost:19000");
         assert!(urls[1] == "http://localhost:18791");
         let expected_count = count_unique_expanded_ports(&[19000, 18791]);
@@ -216,7 +245,7 @@ mod tests {
 
     #[test]
     fn build_candidates_preferred_first() {
-        let urls = build_candidate_urls(Some("http://localhost:15000"));
+        let urls = build_candidate_urls(Some("http://localhost:15000"), true);
         assert_eq!(urls[0], "http://localhost:15000");
         assert_eq!(urls[1], "http://localhost:19000");
         assert_eq!(urls[2], "http://localhost:18791");
@@ -224,21 +253,21 @@ mod tests {
 
     #[test]
     fn build_candidates_preferred_overlaps_known() {
-        let urls = build_candidate_urls(Some("http://localhost:19000"));
+        let urls = build_candidate_urls(Some("http://localhost:19000"), true);
         assert_eq!(urls[0], "http://localhost:19000");
         assert_eq!(urls[1], "http://localhost:18791");
     }
 
     #[test]
     fn build_candidates_no_duplicates() {
-        let urls = build_candidate_urls(Some("http://localhost:18800"));
+        let urls = build_candidate_urls(Some("http://localhost:18800"), true);
         let unique: std::collections::HashSet<_> = urls.iter().collect();
         assert_eq!(urls.len(), unique.len());
     }
 
     #[test]
     fn build_candidates_scan_radius_coverage() {
-        let urls = build_candidate_urls(None);
+        let urls = build_candidate_urls(None, true);
         assert!(urls.contains(&"http://localhost:18976".to_string()));
         assert!(urls.contains(&"http://localhost:19024".to_string()));
         assert!(urls.contains(&"http://localhost:18767".to_string()));
@@ -247,17 +276,28 @@ mod tests {
 
     #[test]
     fn build_candidates_preferred_without_port_ignored() {
-        let urls = build_candidate_urls(Some("http://localhost"));
+        let urls = build_candidate_urls(Some("http://localhost"), true);
         assert_eq!(urls[0], "http://localhost:19000");
     }
 
     #[test]
     fn build_candidates_low_port_no_underflow() {
-        let urls = build_candidate_urls(Some("http://localhost:10"));
+        let urls = build_candidate_urls(Some("http://localhost:10"), true);
         assert!(urls.iter().all(|u| {
             let p = extract_port(u).unwrap();
             p > 0
         }));
+    }
+
+    #[test]
+    fn build_candidates_exact_mode_only_preferred() {
+        let urls = build_candidate_urls(Some("http://localhost:55555"), false);
+        assert_eq!(urls, vec!["http://localhost:55555"]);
+    }
+
+    #[test]
+    fn build_candidates_exact_mode_empty_when_no_preferred() {
+        assert!(build_candidate_urls(None, false).is_empty());
     }
 
     fn count_unique_expanded_ports(seeds: &[u16]) -> usize {
@@ -315,14 +355,18 @@ mod tests {
     #[tokio::test]
     async fn detect_no_service_returns_none() {
         let detector = StarOfficeDetector::new(reqwest::Client::new());
-        let result = detector.detect(Some("http://localhost:59999"), false, Some(50)).await;
+        let result = detector
+            .detect_exact(Some("http://localhost:59999"), false, Some(50))
+            .await;
         assert!(result.is_none());
     }
 
     #[tokio::test]
     async fn detect_cache_miss_stored() {
         let detector = StarOfficeDetector::new(reqwest::Client::new());
-        let _ = detector.detect(Some("http://localhost:59998"), false, Some(50)).await;
+        let _ = detector
+            .detect_exact(Some("http://localhost:59998"), false, Some(50))
+            .await;
         let cache = detector.cache.lock().await;
         let c = cache.as_ref().unwrap();
         assert!(c.url.is_none());

--- a/crates/aionui-office/tests/star_office_integration.rs
+++ b/crates/aionui-office/tests/star_office_integration.rs
@@ -75,7 +75,7 @@ async fn so1_no_service_returns_none() {
     let detector = StarOfficeDetector::new(reqwest::Client::new());
     let port = allocate_port();
     let url = format!("http://localhost:{port}");
-    let result = detector.detect(Some(&url), true, Some(50)).await;
+    let result = detector.detect_exact(Some(&url), true, Some(50)).await;
     assert!(result.is_none());
 }
 
@@ -86,7 +86,9 @@ async fn so1_no_service_returns_none() {
 #[tokio::test]
 async fn so2_preferred_url_no_service() {
     let detector = StarOfficeDetector::new(reqwest::Client::new());
-    let result = detector.detect(Some("http://localhost:59990"), true, Some(50)).await;
+    let result = detector
+        .detect_exact(Some("http://localhost:59990"), true, Some(50))
+        .await;
     assert!(result.is_none());
 }
 
@@ -100,10 +102,10 @@ async fn so3_cache_hit_returns_cached() {
     let url = format!("http://localhost:{port}");
     let detector = Arc::new(StarOfficeDetector::new(reqwest::Client::new()));
 
-    let _ = detector.detect(Some(&url), false, Some(50)).await;
+    let _ = detector.detect_exact(Some(&url), false, Some(50)).await;
 
     let t0 = tokio::time::Instant::now();
-    let result = detector.detect(Some(&url), false, Some(50)).await;
+    let result = detector.detect_exact(Some(&url), false, Some(50)).await;
     let elapsed = t0.elapsed();
 
     assert!(result.is_none());
@@ -123,8 +125,8 @@ async fn so4_force_bypasses_cache() {
     let url = format!("http://localhost:{port}");
     let detector = StarOfficeDetector::new(reqwest::Client::new());
 
-    let _ = detector.detect(Some(&url), false, Some(50)).await;
-    let result = detector.detect(Some(&url), true, Some(50)).await;
+    let _ = detector.detect_exact(Some(&url), false, Some(50)).await;
+    let result = detector.detect_exact(Some(&url), true, Some(50)).await;
 
     assert!(result.is_none());
 }
@@ -146,7 +148,7 @@ async fn so5_detect_available_service() {
 
     let detector = StarOfficeDetector::new(reqwest::Client::new());
     let url = format!("http://localhost:{port}");
-    let result = detector.detect(Some(&url), true, Some(2000)).await;
+    let result = detector.detect_exact(Some(&url), true, Some(2000)).await;
 
     assert_eq!(result, Some(format!("http://localhost:{port}")));
 
@@ -170,7 +172,7 @@ async fn so6_exclude_openclaw() {
 
     let detector = StarOfficeDetector::new(reqwest::Client::new());
     let url = format!("http://localhost:{port}");
-    let result = detector.detect(Some(&url), true, Some(2000)).await;
+    let result = detector.detect_exact(Some(&url), true, Some(2000)).await;
 
     assert!(result.is_none());
 
@@ -194,7 +196,7 @@ async fn health_step1_fail_returns_none() {
 
     let detector = StarOfficeDetector::new(reqwest::Client::new());
     let url = format!("http://localhost:{port}");
-    let result = detector.detect(Some(&url), true, Some(2000)).await;
+    let result = detector.detect_exact(Some(&url), true, Some(2000)).await;
 
     assert!(result.is_none());
 
@@ -218,7 +220,7 @@ async fn health_step2_no_status_markers() {
 
     let detector = StarOfficeDetector::new(reqwest::Client::new());
     let url = format!("http://localhost:{port}");
-    let result = detector.detect(Some(&url), true, Some(2000)).await;
+    let result = detector.detect_exact(Some(&url), true, Some(2000)).await;
 
     assert!(result.is_none());
 
@@ -242,7 +244,7 @@ async fn health_step3_no_feature_keywords() {
 
     let detector = StarOfficeDetector::new(reqwest::Client::new());
     let url = format!("http://localhost:{port}");
-    let result = detector.detect(Some(&url), true, Some(2000)).await;
+    let result = detector.detect_exact(Some(&url), true, Some(2000)).await;
 
     assert!(result.is_none());
 
@@ -266,7 +268,7 @@ async fn detect_with_writing_status() {
 
     let detector = StarOfficeDetector::new(reqwest::Client::new());
     let url = format!("http://localhost:{port}");
-    let result = detector.detect(Some(&url), true, Some(2000)).await;
+    let result = detector.detect_exact(Some(&url), true, Some(2000)).await;
 
     assert_eq!(result, Some(format!("http://localhost:{port}")));
 
@@ -285,12 +287,12 @@ async fn cache_stores_hit_after_success() {
 
     let detector = StarOfficeDetector::new(reqwest::Client::new());
     let url = format!("http://localhost:{port}");
-    let result = detector.detect(Some(&url), true, Some(2000)).await;
+    let result = detector.detect_exact(Some(&url), true, Some(2000)).await;
     assert!(result.is_some());
 
     handle.abort();
 
-    let cached = detector.detect(Some(&url), false, Some(50)).await;
+    let cached = detector.detect_exact(Some(&url), false, Some(50)).await;
     assert_eq!(cached, result);
 }
 
@@ -304,7 +306,7 @@ async fn cache_miss_ttl_expires() {
     let port = allocate_port();
     let url = format!("http://localhost:{port}");
 
-    let _ = detector.detect(Some(&url), false, Some(50)).await;
+    let _ = detector.detect_exact(Some(&url), false, Some(50)).await;
 
     tokio::time::sleep(std::time::Duration::from_millis(1600)).await;
 
@@ -312,7 +314,7 @@ async fn cache_miss_ttl_expires() {
     let handle = mock_star_office_server(port2, true, "idle", "<html><body>star office</body></html>").await;
 
     let url2 = format!("http://localhost:{port2}");
-    let result = detector.detect(Some(&url2), false, Some(2000)).await;
+    let result = detector.detect_exact(Some(&url2), false, Some(2000)).await;
     assert_eq!(result, Some(format!("http://localhost:{port2}")));
 
     handle.abort();


### PR DESCRIPTION
## Summary

- Built-in assistants can now have their `preset_agent_type` changed via the existing `PUT /api/assistants/:id` endpoint. Other built-in fields remain immutable (still 403). The override value is persisted on the `assistant_overrides` row and preferred over the built-in default when building responses.
- New migration `011_assistant_override_preset_agent_type.sql` adds `preset_agent_type TEXT` to `assistant_overrides`. `AssistantOverrideRow` / `UpsertOverrideParams` gain the field; sqlite upsert uses a `CASE WHEN` guard so callers that don't specify the field don't wipe the existing override.
- Fix a test-isolation bug in `aionui-office`: `StarOfficeDetector::detect()` expands `preferred_url` with `KNOWN_PORTS ± SCAN_RADIUS`, which caused parallel integration tests to hit neighbor mock servers. Adds `detect_exact()` for deterministic probing; production callers continue to use `detect()`. Integration + unit tests now use the exact variant.

## Test plan

- [x] `cargo nextest run -p aionui-db -p aionui-assistant -p aionui-office` — 705 passed
- [x] New unit test `update_builtin_preset_agent_type_writes_override` covers the override write + merge-on-list.
- [x] New unit tests `build_candidates_exact_mode_*` cover `detect_exact` candidate shape.
- [x] Existing rejection case preserved as `update_rejects_builtin_non_preset_fields` (422/403 when callers send name/description/etc. on a built-in).