### PR TITLE
fix(ci): switch TLS backend from native-tls to rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,14 +97,14 @@ aes-gcm = "0.10"
 # UUID
 uuid = { version = "1", features = ["v7"] }
 
-# HTTP client
-reqwest = { version = "0.12", features = ["json", "multipart"] }
+# HTTP client — use rustls to avoid native OpenSSL dep during cross-compilation
+reqwest = { version = "0.12", features = ["json", "multipart", "rustls-tls"], default-features = false }
 
 # Concurrency
 dashmap = "6"
 
 # WebSocket
-tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }
 
 # Protobuf
 prost = "0.13"

--- a/crates/aionui-ai-agent/tests/agent_types_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_types_integration.rs
@@ -100,6 +100,7 @@ fn make_aionrs_config() -> AionrsResolvedConfig {
         compat_overrides: Default::default(),
         session_directory: std::env::temp_dir().join("aionrs-test-sessions"),
         session_mode: None,
+        extra_mcp_servers: Default::default(),
     }
 }
 


### PR DESCRIPTION
## Summary
- Switch `reqwest` and `tokio-tungstenite` from `native-tls` (OpenSSL) to `rustls` (pure Rust TLS)
- Eliminates `openssl-sys` dependency that caused CI build failures on macOS x86 and Linux aarch64 cross-compilation
- Matches the approach already used in aionrs

## Context
Release workflow run [#25596496714](https://github.com/iOfficeAI/aionui-backend/actions/runs/25596496714) failed on `x86_64-apple-darwin` and `aarch64-unknown-linux-gnu` targets because the CI runners could not find OpenSSL installation.

## Test plan
- [x] `cargo check -p aionui-app` passes locally
- [ ] Re-trigger release workflow after merge to verify all 6 targets build successfully