### PR TITLE
feat(team): dynamic agent type list + fix warmup race skipping preset_context

### DIFF
--- a/crates/aionui-ai-agent/src/capability/team_guide_prompt.rs
+++ b/crates/aionui-ai-agent/src/capability/team_guide_prompt.rs
@@ -14,12 +14,7 @@
 //! (`leader_label = None`). The preset-assistant label branch does not apply
 //! to Wave 5 solo-agent injection.
 
-/// Vendor backends for which the solo Team Guide prompt is injected. Matches
-/// `TEAM_CAPABLE_BACKENDS` in `crates/aionui-team/src/guide/capability.rs` at
-/// the time of W5-D28b. Kept as a local copy to avoid a crate-dependency
-/// cycle (see module docs); when a new backend is whitelisted for team
-/// membership it must be added in **both** places.
-const TEAM_GUIDE_CAPABLE_BACKENDS: &[&str] = &["claude", "codex", "gemini", "aionrs", "codebuddy"];
+use aionui_common::constants::TEAM_CAPABLE_BACKENDS;
 
 const EXPLICIT_TEAM_REQUEST_CRITERIA: &str = "\
 - The user explicitly asks to create a Team
@@ -76,16 +71,8 @@ Before team creation: use **only** `aion_create_team` and `aion_list_models`. Af
 /// Return `true` iff the given backend is a known team-capable backend. An
 /// empty or unrecognized backend returns `false`; solo agents with unknown
 /// backends do not receive the Team Guide prompt.
-///
-/// The `mcp_stdio_capable` dynamic escape hatch that `aionui_team` exposes is
-/// intentionally omitted here — at session/new time in the factory we have
-/// no general way to probe MCP capability across all 20+ vendor CLIs, and
-/// the team-audit authority (aionui-audit §8) only requires the whitelist
-/// to gate prompt injection. Extend this list in lockstep with
-/// `aionui_team::guide::capability::TEAM_CAPABLE_BACKENDS` if the policy
-/// changes.
 pub(crate) fn is_solo_team_guide_backend(backend: &str) -> bool {
-    TEAM_GUIDE_CAPABLE_BACKENDS.contains(&backend)
+    TEAM_CAPABLE_BACKENDS.contains(&backend)
 }
 
 /// Build the Team Guide prompt for a solo agent with the given backend label.

--- a/crates/aionui-ai-agent/src/factory/acp_assembler.rs
+++ b/crates/aionui-ai-agent/src/factory/acp_assembler.rs
@@ -5,8 +5,7 @@ use aionui_api_types::AgentMetadata;
 use aionui_api_types::{AcpBuildExtra, GuideMcpConfig, TeamMcpStdioConfig};
 use aionui_common::CommandSpec;
 
-/// Backends for which solo conversations receive the Guide MCP server.
-const TEAM_CAPABLE_BACKENDS: &[&str] = &["claude", "codex", "gemini", "aionrs", "codebuddy"];
+use aionui_common::constants::TEAM_CAPABLE_BACKENDS;
 
 /// Pre-computed workspace information.
 #[derive(Debug, Clone)]

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -391,9 +391,13 @@ impl AcpAgentManager {
     /// brand new and still needs `session/load` (or claude-meta-resume) to
     /// re-attach to the persisted session before the next prompt. Subsequent
     /// turns — once the resume handshake has run — take the short path.
+    ///
+    /// Also consumes the first-message injection flag: resumed sessions already
+    /// have the preset_context baked into the prior conversation history.
     pub async fn set_session_id(&self, sid: String) {
         let mut session = self.session.write().await;
         session.set_session_id(DomainSessionId::new(sid));
+        session.take_needs_first_message_injection();
         // Discarded — the session_id already came from DB, no need to re-persist.
         session.drain_events();
     }
@@ -447,20 +451,21 @@ impl AcpAgentManager {
 
     /// Initialize or resume a session, then send the user message.
     ///
-    /// For brand-new sessions (no prior session id and CLI has not opened
-    /// one) the first prompt is augmented with `[Assistant Rules]` /
-    /// skill-index injection. Resume paths skip injection — the prior
-    /// context is already present in the CLI session.
+    /// The first real user message is augmented with `[Assistant Rules]` /
+    /// skill-index injection via a one-shot flag in `AcpSession`. This is
+    /// independent of whether `warmup` already opened the session, avoiding
+    /// a race where warmup marks the session opened before the first message
+    /// arrives.
     async fn ensure_session_and_send(&self, data: &SendMessageData) -> Result<(), AppError> {
-        let is_brand_new = {
-            let s = self.session.read().await;
-            s.session_id().is_none() && !s.is_opened()
-        };
-
         let sid = self.ensure_session_opened().await?;
         self.runtime.transition_to(ConversationStatus::Running);
 
-        if is_brand_new {
+        let needs_injection = {
+            let mut s = self.session.write().await;
+            s.take_needs_first_message_injection()
+        };
+
+        if needs_injection {
             let injected_content = inject_first_message_prefix(
                 &data.content,
                 &self.skill_manager,

--- a/crates/aionui-ai-agent/src/manager/acp/mode_normalize.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/mode_normalize.rs
@@ -70,6 +70,7 @@ mod tests {
             behavior_policy: BehaviorPolicy::default(),
             yolo_id: yolo_id.map(ToOwned::to_owned),
             sort_order: 3130,
+            team_capable: false,
             handshake: AgentHandshake::default(),
         }
     }

--- a/crates/aionui-ai-agent/src/manager/acp/session.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session.rs
@@ -51,6 +51,11 @@ struct Advertised {
 pub struct AcpSession {
     session_id: Option<SessionId>,
     opened: bool,
+    /// Whether the first real user message still needs preset_context /
+    /// skill-index injection. Starts `true` and is consumed (set to `false`)
+    /// on the first `prompt` call. Separate from `opened` because `warmup`
+    /// may open the session before any message is sent.
+    needs_first_message_injection: bool,
     desired: Desired,
     observed: Observed,
     advertised: Advertised,
@@ -73,6 +78,7 @@ impl AcpSession {
         Self {
             session_id: None,
             opened: false,
+            needs_first_message_injection: true,
             desired: Desired {
                 mode_id: initial_mode,
                 model_id: initial_model,
@@ -119,6 +125,12 @@ impl AcpSession {
             self.opened = true;
             self.pending_events.push(AcpSessionEvent::SessionOpened);
         }
+    }
+
+    /// Returns `true` exactly once: on the first real user message.
+    /// After this call the flag is consumed and future calls return `false`.
+    pub fn take_needs_first_message_injection(&mut self) -> bool {
+        std::mem::replace(&mut self.needs_first_message_injection, false)
     }
 }
 

--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -272,8 +272,7 @@ fn decode_row(row: AgentMetadataRow) -> Option<AgentMetadata> {
     };
 
     let backend_str = row.backend.as_deref().unwrap_or("");
-    let team_capable =
-        aionui_common::constants::is_team_capable(backend_str, handshake.agent_capabilities.as_ref());
+    let team_capable = aionui_common::constants::is_team_capable(backend_str, handshake.agent_capabilities.as_ref());
 
     let mut meta = AgentMetadata {
         id: row.id,

--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -271,6 +271,10 @@ fn decode_row(row: AgentMetadataRow) -> Option<AgentMetadata> {
         available_commands: parse_json(row.available_commands.as_deref(), "available_commands"),
     };
 
+    let backend_str = row.backend.as_deref().unwrap_or("");
+    let team_capable =
+        aionui_common::constants::is_team_capable(backend_str, handshake.agent_capabilities.as_ref());
+
     let mut meta = AgentMetadata {
         id: row.id,
         icon: row.icon,
@@ -292,6 +296,7 @@ fn decode_row(row: AgentMetadataRow) -> Option<AgentMetadata> {
         behavior_policy,
         yolo_id: row.yolo_id,
         sort_order: row.sort_order,
+        team_capable,
         handshake,
     };
 

--- a/crates/aionui-api-types/src/agent_discovery.rs
+++ b/crates/aionui-api-types/src/agent_discovery.rs
@@ -167,6 +167,12 @@ pub struct AgentMetadata {
     /// scheme is documented in `007_agent_metadata_sort_order.sql`.
     pub sort_order: i64,
 
+    /// Whether this agent supports team mode. Derived at hydrate time from
+    /// the hard whitelist + persisted `agent_capabilities` MCP declarations.
+    /// Not a persisted column.
+    #[serde(default)]
+    pub team_capable: bool,
+
     #[serde(default)]
     pub handshake: AgentHandshake,
 }
@@ -214,6 +220,7 @@ mod tests {
             behavior_policy: BehaviorPolicy::default(),
             yolo_id: None,
             sort_order: 3100,
+            team_capable: true,
             handshake: AgentHandshake::default(),
         };
         let v = serde_json::to_value(&meta).unwrap();
@@ -222,6 +229,7 @@ mod tests {
         assert!(v.get("resolved_command").is_none());
         assert_eq!(v["backend"], "claude");
         assert_eq!(v["available"], true);
+        assert_eq!(v["team_capable"], true);
         assert!(v.get("command").is_none());
         assert!(v.get("icon").is_none());
     }

--- a/crates/aionui-common/src/constants.rs
+++ b/crates/aionui-common/src/constants.rs
@@ -28,6 +28,36 @@ pub const BODY_LIMIT: usize = 10 * 1024 * 1024;
 /// File upload size limit (30 MB).
 pub const UPLOAD_MAX_SIZE: usize = 30 * 1024 * 1024;
 
+// --- Team mode ---
+
+/// Hard-coded backends that always support team mode, regardless of ACP capability detection.
+pub const TEAM_CAPABLE_BACKENDS: &[&str] = &["claude", "codex", "gemini", "aionrs", "codebuddy"];
+
+/// Determine if an agent supports team mode based on its persisted `agent_capabilities` JSON.
+///
+/// Returns `true` if:
+/// 1. The backend is in the hard whitelist, OR
+/// 2. The `agent_capabilities` JSON contains an `mcp_capabilities` / `mcpCapabilities` / `mcp`
+///    field (per ACP spec, presence of any MCP transport implies stdio support).
+pub fn is_team_capable(backend: &str, agent_capabilities: Option<&serde_json::Value>) -> bool {
+    if TEAM_CAPABLE_BACKENDS.contains(&backend) {
+        return true;
+    }
+    has_mcp_capability(agent_capabilities)
+}
+
+/// Check whether `agent_capabilities` JSON declares any MCP transport.
+/// Per ACP spec: stdio is the baseline; if any transport is declared, the agent supports MCP.
+pub fn has_mcp_capability(agent_capabilities: Option<&serde_json::Value>) -> bool {
+    let Some(caps) = agent_capabilities else {
+        return false;
+    };
+    caps.get("mcp_capabilities")
+        .or_else(|| caps.get("mcpCapabilities"))
+        .or_else(|| caps.get("mcp"))
+        .is_some()
+}
+
 // --- Image processing ---
 
 pub const SUPPORTED_IMAGE_EXTENSIONS: &[&str] = &[".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff", ".svg"];

--- a/crates/aionui-team/src/guide/capability.rs
+++ b/crates/aionui-team/src/guide/capability.rs
@@ -1,32 +1,46 @@
-pub const TEAM_CAPABLE_BACKENDS: &[&str] = &["claude", "codex", "gemini", "aionrs", "codebuddy"];
+pub use aionui_common::constants::TEAM_CAPABLE_BACKENDS;
+use aionui_common::constants::is_team_capable;
 
-pub fn is_team_capable_backend(backend: &str, mcp_stdio_capable: bool) -> bool {
-    TEAM_CAPABLE_BACKENDS.contains(&backend) || mcp_stdio_capable
+/// Determine if a backend supports team mode.
+///
+/// Hard whitelist always passes. For non-whitelisted backends, checks the
+/// persisted `agent_capabilities` JSON for MCP transport declarations.
+pub fn is_team_capable_backend(backend: &str, agent_capabilities: Option<&serde_json::Value>) -> bool {
+    is_team_capable(backend, agent_capabilities)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
-    fn whitelist_backend_is_capable_regardless_of_mcp_flag() {
-        assert!(is_team_capable_backend("claude", false));
-        assert!(is_team_capable_backend("claude", true));
-        assert!(is_team_capable_backend("codex", false));
-        assert!(is_team_capable_backend("gemini", false));
-        assert!(is_team_capable_backend("aionrs", false));
+    fn whitelist_backend_is_capable_regardless_of_capabilities() {
+        assert!(is_team_capable_backend("claude", None));
+        assert!(is_team_capable_backend("claude", Some(&json!({}))));
+        assert!(is_team_capable_backend("codex", None));
+        assert!(is_team_capable_backend("gemini", None));
+        assert!(is_team_capable_backend("aionrs", None));
+        assert!(is_team_capable_backend("codebuddy", None));
     }
 
     #[test]
-    fn non_whitelist_backend_with_mcp_stdio_is_capable() {
-        assert!(is_team_capable_backend("custom", true));
-        assert!(is_team_capable_backend("unknown-backend", true));
+    fn non_whitelist_backend_with_mcp_capabilities_is_capable() {
+        let caps_stdio = json!({"mcp_capabilities": {"stdio": true}});
+        assert!(is_team_capable_backend("qwen", Some(&caps_stdio)));
+
+        let caps_http = json!({"mcpCapabilities": {"http": true, "sse": true}});
+        assert!(is_team_capable_backend("droid", Some(&caps_http)));
+
+        let caps_mcp = json!({"mcp": {"stdio": true}});
+        assert!(is_team_capable_backend("goose", Some(&caps_mcp)));
     }
 
     #[test]
-    fn non_whitelist_backend_without_mcp_stdio_is_not_capable() {
-        assert!(!is_team_capable_backend("custom", false));
-        assert!(!is_team_capable_backend("", false));
-        assert!(!is_team_capable_backend("Claude", false));
+    fn non_whitelist_backend_without_mcp_capabilities_is_not_capable() {
+        assert!(!is_team_capable_backend("custom", None));
+        assert!(!is_team_capable_backend("custom", Some(&json!({}))));
+        assert!(!is_team_capable_backend("", None));
+        assert!(!is_team_capable_backend("Claude", None));
     }
 }

--- a/crates/aionui-team/src/mcp/server.rs
+++ b/crates/aionui-team/src/mcp/server.rs
@@ -20,7 +20,7 @@ use super::protocol::{
 };
 use super::tools::{
     RenameAgentInput, SendMessageInput, ShutdownAgentInput, SpawnAgentInput, TaskCreateInput, TaskUpdateInput,
-    all_tool_descriptors, handle_team_describe_assistant, handle_team_list_models, is_whitelisted_backend,
+    all_tool_descriptors, handle_team_describe_assistant, handle_team_list_models,
 };
 
 // ---------------------------------------------------------------------------
@@ -587,19 +587,8 @@ async fn exec_spawn_agent(
     // caller) is accepted.
     let agent_type = input.agent_type.or(input.backend);
 
-    // Dispatch-layer whitelist gate for explicitly provided backends. Keeps
-    // the "not allowed" user-visible phrasing that existing clients depend
-    // on and avoids a pointless round-trip into the session for obvious
-    // bad input. `TeamSession::spawn_agent` re-checks (including the
-    // empty/unset-inherits-from-caller path) so this is pure defense-in-depth.
-    if let Some(bk) = agent_type.as_deref()
-        && !is_whitelisted_backend(bk)
-    {
-        return Err(format!(
-            "Backend '{bk}' not allowed. Whitelist: {}",
-            crate::guide::capability::TEAM_CAPABLE_BACKENDS.join(", ")
-        ));
-    }
+    // Dynamic capability check happens in `TeamSession::spawn_agent` which
+    // queries both the hard whitelist and persisted MCP capabilities.
 
     let req = SpawnAgentRequest {
         name: requested_name.clone(),

--- a/crates/aionui-team/src/mcp/tools.rs
+++ b/crates/aionui-team/src/mcp/tools.rs
@@ -246,13 +246,12 @@ pub struct ShutdownAgentInput {
 }
 
 // ---------------------------------------------------------------------------
-// Backend whitelist for spawn_agent
+// Backend whitelist for spawn_agent (hard whitelist only — synchronous fast-path).
+// Dynamic capability check (MCP-based) happens in TeamSession::spawn_agent.
 // ---------------------------------------------------------------------------
 
-const SPAWN_BACKEND_WHITELIST: &[&str] = crate::guide::capability::TEAM_CAPABLE_BACKENDS;
-
 pub fn is_whitelisted_backend(backend: &str) -> bool {
-    SPAWN_BACKEND_WHITELIST.contains(&backend)
+    aionui_common::constants::TEAM_CAPABLE_BACKENDS.contains(&backend)
 }
 
 // ---------------------------------------------------------------------------
@@ -286,9 +285,9 @@ pub fn parse_tool_call(
                 .ok_or_else(|| "Missing 'agent_type' (or legacy 'backend') for team_spawn_agent".to_string())?;
             if !is_whitelisted_backend(&backend) {
                 return Err(format!(
-                    "Backend '{}' not allowed. Whitelist: {}",
+                    "Backend '{}' not in hard whitelist. Whitelist: {}",
                     backend,
-                    SPAWN_BACKEND_WHITELIST.join(", ")
+                    aionui_common::constants::TEAM_CAPABLE_BACKENDS.join(", ")
                 ));
             }
             Ok(SchedulerAction::SpawnAgent {
@@ -439,7 +438,7 @@ mod tests {
         let args = json!({"name": "X", "backend": "malicious"});
         let result = parse_tool_call("team_spawn_agent", &args, TeammateRole::Lead);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("not allowed"));
+        assert!(result.unwrap_err().contains("not in hard whitelist"));
     }
 
     #[test]

--- a/crates/aionui-team/src/service/spawn_support.rs
+++ b/crates/aionui-team/src/service/spawn_support.rs
@@ -1,5 +1,6 @@
 use super::*;
 use aionui_common::AgentType;
+use aionui_common::constants::{TEAM_CAPABLE_BACKENDS, has_mcp_capability};
 
 /// Known ACP vendor labels. Kept in lockstep with the `agent_metadata`
 /// seed in `005_agent_metadata.sql` — a caller hitting an unknown
@@ -52,6 +53,61 @@ pub(crate) fn resolve_full_auto_mode(backend: &str) -> &'static str {
 }
 
 impl TeamSessionService {
+    /// Check if a backend is allowed to participate in team mode.
+    /// Hard whitelist passes immediately; otherwise queries the persisted
+    /// `agent_capabilities` from `agent_metadata` for MCP transport declarations.
+    pub(crate) async fn is_backend_team_capable(&self, backend: &str) -> bool {
+        if TEAM_CAPABLE_BACKENDS.contains(&backend) {
+            return true;
+        }
+        let Ok(Some(row)) = self.agent_metadata_repo.find_builtin_by_backend(backend).await else {
+            return false;
+        };
+        let caps = row
+            .agent_capabilities
+            .as_deref()
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok());
+        has_mcp_capability(caps.as_ref())
+    }
+
+    /// Return all backends currently team-capable (hard whitelist + dynamically detected).
+    /// Used to build the Lead prompt's `available_agent_types` list.
+    pub(crate) async fn list_team_capable_backends(&self) -> Vec<(String, String)> {
+        let Ok(rows) = self.agent_metadata_repo.list_all().await else {
+            return TEAM_CAPABLE_BACKENDS
+                .iter()
+                .map(|b| (b.to_string(), capitalize(b)))
+                .collect();
+        };
+        let mut result: Vec<(String, String)> = Vec::new();
+        for row in &rows {
+            if !row.enabled {
+                continue;
+            }
+            let Some(backend) = row.backend.as_deref() else {
+                continue;
+            };
+            if TEAM_CAPABLE_BACKENDS.contains(&backend) {
+                result.push((backend.to_string(), row.name.clone()));
+                continue;
+            }
+            let caps = row
+                .agent_capabilities
+                .as_deref()
+                .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok());
+            if has_mcp_capability(caps.as_ref()) {
+                result.push((backend.to_string(), row.name.clone()));
+            }
+        }
+        // Ensure hard whitelist entries are present even if not in DB
+        for &b in TEAM_CAPABLE_BACKENDS {
+            if !result.iter().any(|(bk, _)| bk == b) {
+                result.push((b.to_string(), capitalize(b)));
+            }
+        }
+        result
+    }
+
     pub async fn spawn_agent_in_session(
         &self,
         team_id: &str,
@@ -158,6 +214,14 @@ impl TeamSessionService {
             .await?;
 
         Ok(agent)
+    }
+}
+
+fn capitalize(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
     }
 }
 

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -206,14 +206,20 @@ impl TeamSession {
         let first_message = if needs_role_prompt {
             let role_prompt = match agent.role {
                 TeammateRole::Lead => {
-                    // TODO(W5+): source display names from the dynamic backend registry
-                    // once it exposes a public listing. For now, hard-code the
-                    // team-capable whitelist from `guide::capability::TEAM_CAPABLE_BACKENDS`.
-                    let available_agent_types: Vec<(String, String)> = vec![
-                        ("claude".into(), "Claude".into()),
-                        ("codex".into(), "Codex".into()),
-                        ("gemini".into(), "Gemini".into()),
-                    ];
+                    let available_agent_types = match self.service.upgrade() {
+                        Some(svc) => svc.list_team_capable_backends().await,
+                        None => crate::guide::capability::TEAM_CAPABLE_BACKENDS
+                            .iter()
+                            .map(|b| {
+                                let mut c = b.chars();
+                                let display = match c.next() {
+                                    None => String::new(),
+                                    Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+                                };
+                                (b.to_string(), display)
+                            })
+                            .collect(),
+                    };
                     build_lead_prompt(
                         &self.team.name,
                         &self.scheduler.list_agents().await,
@@ -704,9 +710,8 @@ impl TeamSession {
             return Err(TeamError::DuplicateAgentName(requested_name));
         }
 
-        // Step 3: backend whitelist. Canonical list lives in
-        // guide::capability::TEAM_CAPABLE_BACKENDS.
-        let spawn_backend_whitelist = crate::guide::capability::TEAM_CAPABLE_BACKENDS;
+        // Step 3: backend capability check. Hard whitelist passes immediately;
+        // otherwise query persisted agent_capabilities for MCP support.
         let backend = req
             .agent_type
             .as_deref()
@@ -714,19 +719,21 @@ impl TeamSession {
             .filter(|s| !s.is_empty())
             .unwrap_or(caller.backend.as_str())
             .to_owned();
-        if !spawn_backend_whitelist.contains(&backend.as_str()) {
-            return Err(TeamError::BackendNotAllowed(backend));
+        if !crate::guide::capability::TEAM_CAPABLE_BACKENDS.contains(&backend.as_str()) {
+            let capable = match self.service.upgrade() {
+                Some(svc) => svc.is_backend_team_capable(&backend).await,
+                None => false,
+            };
+            if !capable {
+                return Err(TeamError::BackendNotAllowed(backend));
+            }
         }
 
-        // Step 4: DB side-effects (new conversation + persisted agent slot)
-        // happen inside TeamSessionService where the conversation service and
-        // the per-team add_agent lock live. Unit tests with no service wire
-        // cannot reach this path.
+        // Step 4: DB side-effects (new conversation + persisted agent slot).
         let service = self
             .service
             .upgrade()
             .ok_or_else(|| TeamError::InvalidRequest("spawn_agent requires a live TeamSessionService".into()))?;
-
         let model = req.model.as_deref().unwrap_or(&caller.model).to_owned();
         let new_agent = service
             .persist_spawned_agent(

--- a/crates/aionui-team/tests/mcp_server_integration.rs
+++ b/crates/aionui-team/tests/mcp_server_integration.rs
@@ -443,7 +443,11 @@ async fn sp2_non_whitelisted_backend_rejected() {
 
     assert!(is_error_response(&resp));
     let text = extract_text(&resp);
-    assert!(text.contains("not allowed"));
+    // Without a live TeamSessionService the spawn fails at capability check or service access.
+    assert!(
+        text.contains("not allowed") || text.contains("not available"),
+        "unexpected error: {text}"
+    );
 
     env.server.stop();
 }


### PR DESCRIPTION
## Summary
- Dynamic agent type list for team sessions based on ACP MCP capabilities
- Add `team_capable` computed field to AgentMetadata response
- **Fix critical bug**: warmup race condition caused preset_context (team guide prompt) to never be injected into the first user message

## Bug Fix Detail
PR #207 introduced eager session opening via `warmup_session()`. When warmup and the first message arrived concurrently, warmup marked the session as `opened` before `ensure_session_and_send()` checked `is_brand_new`, causing it to skip preset_context injection entirely. The solo agent never received the team guide prompt, so it skipped the "recommend lineup → wait for confirmation" flow and directly called `aion_create_team`.

**Fix**: Replace the racy `is_brand_new` check with a dedicated `needs_first_message_injection` flag on `AcpSession` that is consumed exactly once by the first real prompt, independent of session open state.

## Test plan
- [x] `cargo nextest run --workspace` — 5432 passed
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manual: new solo conversation with Claude → send "创建成员进来吵架" → verify agent proposes lineup before creating team

🤖 Generated with [Claude Code](https://claude.com/claude-code)