### PR TITLE
fix(ci): remove openssl-sys dependency via git2 default-features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2542,8 +2542,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe 0.1.6",
- "openssl-sys",
  "url",
 ]
 
@@ -3236,9 +3234,7 @@ checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -3267,20 +3263,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -3611,27 +3593,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -4347,7 +4311,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ notify = "8"
 walkdir = "2"
 ignore = "0.4"
 zip = "2"
-git2 = "0.20"
+git2 = { version = "0.20", default-features = false }
 mime_guess = "2"
 rust-embed = "8"
 


### PR DESCRIPTION
## Summary
- Disable `git2` default features (`https`, `ssh`) to completely eliminate `openssl-sys` from the dependency tree
- PR#204 only addressed `reqwest`/`tokio-tungstenite`, but `git2` still pulled `openssl-sys` via `libgit2-sys` → `libssh2-sys`
- Project only uses `git2` for local operations (init, commit, status, reset, checkout, branches) — no network features needed

## Root Cause
The `x86_64-apple-darwin` cross-compilation failure at [run #25598413909](https://github.com/iOfficeAI/aionui-backend/actions/runs/25598413909/job/75148231704) was caused by `openssl-sys` still being in the dependency tree through `git2`'s default features.

## Changes
- `Cargo.toml`: `git2 = "0.20"` → `git2 = { version = "0.20", default-features = false }`
- `Cargo.lock`: removes `openssl-sys`, `libssh2-sys`, `openssl-probe 0.1.6`

## Test plan
- [x] `cargo tree -i openssl-sys` confirms package no longer exists in tree
- [x] `cargo check -p aionui-app` passes
- [x] `cargo check -p aionui-file` passes
- [ ] Re-trigger release workflow to verify all 6 targets build successfully