### PR TITLE
feat(auth): add local-only /api/webui/* routes + admin-seeded system user

### DIFF
--- a/crates/aionui-api-types/src/auth.rs
+++ b/crates/aionui-api-types/src/auth.rs
@@ -86,6 +86,51 @@ pub struct WsTokenResponse {
     pub expires_in: u64,
 }
 
+// ---------------------------------------------------------------------------
+// WebUI admin credential endpoints (local-only)
+// ---------------------------------------------------------------------------
+
+/// Change password request body for `POST /api/webui/change-password`.
+///
+/// No current_password field — this endpoint is local-mode only and assumes
+/// the caller is the trusted Electron main process.
+#[derive(Debug, Deserialize)]
+pub struct WebuiChangePasswordRequest {
+    pub new_password: String,
+}
+
+/// Change username request body for `POST /api/webui/change-username`.
+#[derive(Debug, Deserialize)]
+pub struct WebuiChangeUsernameRequest {
+    pub new_username: String,
+}
+
+/// Response for `POST /api/webui/change-username`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WebuiChangeUsernameResponse {
+    pub username: String,
+}
+
+/// Response for `POST /api/webui/reset-password`.
+///
+/// Returns the freshly generated plaintext password. This is the only time
+/// the caller sees it — subsequent reads hit the bcrypt hash only.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WebuiResetPasswordResponse {
+    pub new_password: String,
+}
+
+/// Response for `POST /api/webui/generate-qr-token`.
+///
+/// Only the token and expiry are returned. URL assembly (host + port) is the
+/// caller's responsibility, since only the Electron main process knows which
+/// lanIP/port the WebUI is exposed on.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WebuiGenerateQrTokenResponse {
+    pub token: String,
+    pub expires_at_ms: i64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -42,7 +42,8 @@ pub use assistant::{
 };
 pub use auth::{
     AuthStatusResponse, ChangePasswordRequest, LoginRequest, LoginResponse, PublicUser, QrLoginRequest,
-    RefreshResponse, RefreshTokenRequest, UserInfoResponse, WsTokenResponse,
+    RefreshResponse, RefreshTokenRequest, UserInfoResponse, WebuiChangePasswordRequest, WebuiChangeUsernameRequest,
+    WebuiChangeUsernameResponse, WebuiGenerateQrTokenResponse, WebuiResetPasswordResponse, WsTokenResponse,
 };
 pub use channel::{
     ApprovePairingRequest, BridgeResponse, ChannelSessionResponse, ChannelUserResponse, DisablePluginRequest,

--- a/crates/aionui-app/tests/auth_e2e.rs
+++ b/crates/aionui-app/tests/auth_e2e.rs
@@ -101,6 +101,10 @@ fn post_json_with_csrf(uri: &str, body: &str, token: &str, csrf: &str) -> Reques
 }
 
 /// Set up a user and login, returning (session_token, csrf_token).
+///
+/// Seeded `system_default_user` already owns `username = "admin"` with an empty
+/// hash; if the test uses that name, overwrite the seed row in place. Other
+/// usernames use the normal create_user path.
 async fn setup_and_login(
     app: &mut axum::Router,
     services: &AppServices,
@@ -109,7 +113,15 @@ async fn setup_and_login(
 ) -> (String, String) {
     // Create user
     let hash = aionui_auth::hash_password(password).unwrap();
-    services.user_repo.create_user(username, &hash).await.unwrap();
+    if username == "admin" {
+        services
+            .user_repo
+            .set_system_user_credentials(username, &hash)
+            .await
+            .unwrap();
+    } else {
+        services.user_repo.create_user(username, &hash).await.unwrap();
+    }
 
     // Get CSRF token from a GET request first
     let resp = app.clone().oneshot(get_request("/api/auth/status")).await.unwrap();
@@ -209,7 +221,13 @@ async fn t12_2_csrf_exempt_paths() {
 async fn t12_3_session_cookie_attributes() {
     let (app, services) = build_app().await;
     let hash = aionui_auth::hash_password("StrongP@ss1").unwrap();
-    services.user_repo.create_user("admin", &hash).await.unwrap();
+    // system_default_user is seeded with username='admin'; overwrite its empty
+    // password in place instead of creating a duplicate.
+    services
+        .user_repo
+        .set_system_user_credentials("admin", &hash)
+        .await
+        .unwrap();
 
     let req = post_json_login("/login", r#"{"username":"admin","password":"StrongP@ss1"}"#);
     let resp = app.oneshot(req).await.unwrap();

--- a/crates/aionui-app/tests/common/mod.rs
+++ b/crates/aionui-app/tests/common/mod.rs
@@ -225,6 +225,10 @@ pub fn delete_with_token(uri: &str, token: &str, csrf: &str) -> Request<Body> {
 }
 
 /// Set up a user and login, returning (session_token, csrf_token).
+///
+/// The seeded `system_default_user` row already uses `username = "admin"`; if
+/// the test asks for that username, overwrite the seed row's empty credentials
+/// in place instead of trying to INSERT a duplicate.
 pub async fn setup_and_login(
     app: &mut axum::Router,
     services: &AppServices,
@@ -232,7 +236,15 @@ pub async fn setup_and_login(
     password: &str,
 ) -> (String, String) {
     let hash = aionui_auth::hash_password(password).unwrap();
-    services.user_repo.create_user(username, &hash).await.unwrap();
+    if username == "admin" {
+        services
+            .user_repo
+            .set_system_user_credentials(username, &hash)
+            .await
+            .unwrap();
+    } else {
+        services.user_repo.create_user(username, &hash).await.unwrap();
+    }
 
     let resp = app.clone().oneshot(get_request("/api/auth/status")).await.unwrap();
     let csrf = extract_csrf_token(&resp).expect("CSRF cookie should be set");

--- a/crates/aionui-auth/src/lib.rs
+++ b/crates/aionui-auth/src/lib.rs
@@ -20,7 +20,8 @@ pub use jwt::{JwtService, TokenPayload, generate_random_secret_string, resolve_j
 
 // Password service
 pub use password::{
-    dummy_password_hash, generate_user_credentials, hash_password, verify_password, verify_password_timed,
+    dummy_password_hash, generate_password, generate_user_credentials, hash_password, verify_password,
+    verify_password_timed,
 };
 
 // Validation

--- a/crates/aionui-auth/src/password.rs
+++ b/crates/aionui-auth/src/password.rs
@@ -88,6 +88,15 @@ pub fn generate_user_credentials() -> (String, String) {
     (username, password)
 }
 
+/// Generate a strong random password suitable for WebUI admin reset.
+///
+/// Guarantees ≥1 character from each category (upper, lower, digit, special)
+/// and fills remaining slots from a mixed charset.
+pub fn generate_password(len: usize) -> String {
+    // Enforce minimum length of 4 to satisfy the four-category guarantee.
+    generate_strong_password(len.max(4))
+}
+
 // --- Internal helpers ---
 
 /// Fill a buffer with cryptographically random bytes.

--- a/crates/aionui-auth/src/qr_token.rs
+++ b/crates/aionui-auth/src/qr_token.rs
@@ -41,6 +41,14 @@ impl QrTokenStore {
     ///
     /// Returns the 64-character hex token string.
     pub fn generate(&self) -> String {
+        self.generate_with_expiry().0
+    }
+
+    /// Generate a new QR login token and return it along with its expiry timestamp (ms).
+    ///
+    /// Returns `(token, expires_at_ms)` where `expires_at_ms` is the absolute
+    /// Unix time in milliseconds when the token becomes invalid.
+    pub fn generate_with_expiry(&self) -> (String, i64) {
         let mut buf = [0u8; QR_TOKEN_BYTES];
         getrandom::getrandom(&mut buf).expect("OS entropy source unavailable");
 
@@ -49,15 +57,16 @@ impl QrTokenStore {
             let _ = write!(token, "{byte:02x}");
         }
 
+        let created_at_ms = aionui_common::now_ms();
         self.tokens.insert(
             token.clone(),
             QrTokenData {
-                created_at_ms: aionui_common::now_ms(),
+                created_at_ms,
                 used: false,
             },
         );
 
-        token
+        (token, created_at_ms + QR_TOKEN_TTL_MS)
     }
 
     /// Validate and consume a QR token (one-time use).

--- a/crates/aionui-auth/src/routes.rs
+++ b/crates/aionui-auth/src/routes.rs
@@ -12,7 +12,8 @@ use serde::Deserialize;
 
 use aionui_api_types::{
     ApiResponse, AuthStatusResponse, ChangePasswordRequest, LoginRequest, LoginResponse, PublicUser, QrLoginRequest,
-    RefreshResponse, RefreshTokenRequest, UserInfoResponse, WsTokenResponse,
+    RefreshResponse, RefreshTokenRequest, UserInfoResponse, WebuiChangePasswordRequest, WebuiChangeUsernameRequest,
+    WebuiChangeUsernameResponse, WebuiGenerateQrTokenResponse, WebuiResetPasswordResponse, WsTokenResponse,
 };
 use aionui_common::AppError;
 use aionui_common::constants::COOKIE_MAX_AGE_DAYS;
@@ -20,12 +21,12 @@ use aionui_db::{IUserRepository, models::User};
 
 use crate::extract::extract_token_from_headers;
 use crate::middleware::{AuthState, CurrentUser, auth_middleware};
-use crate::password::{dummy_password_hash, hash_password, verify_password_timed};
+use crate::password::{dummy_password_hash, generate_password, hash_password, verify_password_timed};
 use crate::qr_token::QrTokenStore;
 use crate::rate_limit::{
     RateLimiter, api_rate_limit_middleware, auth_rate_limit_middleware, authenticated_action_rate_limit_middleware,
 };
-use crate::validation::validate_password;
+use crate::validation::{validate_password, validate_username};
 use crate::{CookieConfig, JwtService};
 
 /// Shared state for all auth route handlers.
@@ -86,6 +87,10 @@ fn ensure_local_mode(local: bool) -> Result<(), AppError> {
 /// - `GET /api/ws-token`
 /// - `POST /api/auth/qr-login`
 /// - `GET /qr-login`
+/// - `POST /api/webui/change-password` (local-only)
+/// - `POST /api/webui/change-username` (local-only)
+/// - `POST /api/webui/reset-password` (local-only)
+/// - `POST /api/webui/generate-qr-token` (local-only)
 pub fn auth_routes(state: AuthRouterState) -> Router {
     let auth_limiter = Arc::new(RateLimiter::auth());
     let api_limiter = Arc::new(RateLimiter::api());
@@ -143,6 +148,11 @@ pub fn auth_routes(state: AuthRouterState) -> Router {
             "/api/auth/internal/users/{id}/last-login",
             post(update_user_last_login_handler),
         )
+        // WebUI admin credential endpoints — local-only, enforced inside each handler.
+        .route("/api/webui/change-password", post(webui_change_password_handler))
+        .route("/api/webui/change-username", post(webui_change_username_handler))
+        .route("/api/webui/reset-password", post(webui_reset_password_handler))
+        .route("/api/webui/generate-qr-token", post(webui_generate_qr_token_handler))
         .route_layer(from_fn_with_state(api_limiter.clone(), api_rate_limit_middleware))
         .with_state(state.clone());
 
@@ -631,3 +641,120 @@ const QR_LOGIN_HTML: &str = r#"<!DOCTYPE html>
 </script>
 </body>
 </html>"#;
+
+// ---------------------------------------------------------------------------
+// WebUI admin credential endpoints (local-only)
+// ---------------------------------------------------------------------------
+
+/// Random password length for `/api/webui/reset-password`.
+const RESET_PASSWORD_LEN: usize = 16;
+
+/// Resolve the WebUI admin user, falling back to NotFound when absent.
+async fn resolve_webui_admin(user_repo: &dyn IUserRepository) -> Result<User, AppError> {
+    user_repo
+        .get_primary_webui_user()
+        .await
+        .map_err(|e| AppError::Internal(format!("Database error: {e}")))?
+        .ok_or_else(|| AppError::NotFound("No WebUI admin user configured".into()))
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/webui/change-password
+// ---------------------------------------------------------------------------
+
+async fn webui_change_password_handler(
+    State(state): State<AuthRouterState>,
+    body: Result<Json<WebuiChangePasswordRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<()>>, AppError> {
+    ensure_local_mode(state.local)?;
+    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
+
+    validate_password(&req.new_password)?;
+
+    let user = resolve_webui_admin(&*state.user_repo).await?;
+
+    let password = req.new_password;
+    let new_hash = tokio::task::spawn_blocking(move || hash_password(&password))
+        .await
+        .map_err(|e| AppError::Internal(format!("Task join error: {e}")))??;
+
+    state
+        .user_repo
+        .update_password(&user.id, &new_hash)
+        .await
+        .map_err(|e| AppError::Internal(format!("Database error: {e}")))?;
+
+    Ok(Json(ApiResponse::message("Password changed successfully")))
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/webui/change-username
+// ---------------------------------------------------------------------------
+
+async fn webui_change_username_handler(
+    State(state): State<AuthRouterState>,
+    body: Result<Json<WebuiChangeUsernameRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<WebuiChangeUsernameResponse>>, AppError> {
+    ensure_local_mode(state.local)?;
+    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
+
+    let trimmed = req.new_username.trim().to_owned();
+    validate_username(&trimmed)?;
+
+    let user = resolve_webui_admin(&*state.user_repo).await?;
+
+    if user.username != trimmed {
+        state
+            .user_repo
+            .update_username(&user.id, &trimmed)
+            .await
+            .map_err(|e| AppError::Internal(format!("Database error: {e}")))?;
+    }
+
+    Ok(Json(ApiResponse::ok(WebuiChangeUsernameResponse {
+        username: trimmed,
+    })))
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/webui/reset-password
+// ---------------------------------------------------------------------------
+
+async fn webui_reset_password_handler(
+    State(state): State<AuthRouterState>,
+) -> Result<Json<ApiResponse<WebuiResetPasswordResponse>>, AppError> {
+    ensure_local_mode(state.local)?;
+
+    let user = resolve_webui_admin(&*state.user_repo).await?;
+
+    let new_password = generate_password(RESET_PASSWORD_LEN);
+    let password_for_hash = new_password.clone();
+    let new_hash = tokio::task::spawn_blocking(move || hash_password(&password_for_hash))
+        .await
+        .map_err(|e| AppError::Internal(format!("Task join error: {e}")))??;
+
+    state
+        .user_repo
+        .update_password(&user.id, &new_hash)
+        .await
+        .map_err(|e| AppError::Internal(format!("Database error: {e}")))?;
+
+    Ok(Json(ApiResponse::ok(WebuiResetPasswordResponse { new_password })))
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/webui/generate-qr-token
+// ---------------------------------------------------------------------------
+
+async fn webui_generate_qr_token_handler(
+    State(state): State<AuthRouterState>,
+) -> Result<Json<ApiResponse<WebuiGenerateQrTokenResponse>>, AppError> {
+    ensure_local_mode(state.local)?;
+
+    let (token, expires_at_ms) = state.qr_token_store.generate_with_expiry();
+
+    Ok(Json(ApiResponse::ok(WebuiGenerateQrTokenResponse {
+        token,
+        expires_at_ms,
+    })))
+}

--- a/crates/aionui-auth/tests/route_tests.rs
+++ b/crates/aionui-auth/tests/route_tests.rs
@@ -60,10 +60,22 @@ struct TestContext {
     _db: aionui_db::Database,
 }
 
-/// Helper: create a user with known credentials and return the username.
+/// Helper: create a test user with known credentials.
+///
+/// The seeded `system_default_user` row already uses `username = "admin"` with
+/// an empty password hash. If the test asks for that username, update the seed
+/// row in place instead of trying to INSERT a duplicate. Any other username
+/// takes the normal create_user path.
 async fn create_test_user(ctx: &TestContext, username: &str, password: &str) {
     let hash = hash_password(password).unwrap();
-    ctx.user_repo.create_user(username, &hash).await.unwrap();
+    if username == "admin" {
+        ctx.user_repo
+            .set_system_user_credentials(username, &hash)
+            .await
+            .unwrap();
+    } else {
+        ctx.user_repo.create_user(username, &hash).await.unwrap();
+    }
 }
 
 /// Helper: perform a JSON POST request.

--- a/crates/aionui-db/src/database.rs
+++ b/crates/aionui-db/src/database.rs
@@ -169,6 +169,8 @@ async fn ensure_schema_columns(pool: &SqlitePool) -> Result<(), DbError> {
 ///
 /// Uses INSERT OR IGNORE so it is safe to call on every startup.
 /// The system user has an empty password hash, which signals "needs setup".
+/// Username defaults to `admin` — matches the legacy web-host login flow so
+/// users upgrading from pre-M6 builds keep the same login username.
 async fn ensure_system_user(pool: &SqlitePool) -> Result<(), DbError> {
     let now = aionui_common::now_ms();
     sqlx::query(
@@ -176,7 +178,7 @@ async fn ensure_system_user(pool: &SqlitePool) -> Result<(), DbError> {
          VALUES (?, ?, ?, ?, ?)",
     )
     .bind("system_default_user")
-    .bind("system")
+    .bind("admin")
     .bind("")
     .bind(now)
     .bind(now)

--- a/crates/aionui-db/src/repository/sqlite_user.rs
+++ b/crates/aionui-db/src/repository/sqlite_user.rs
@@ -326,13 +326,15 @@ mod tests {
         let (repo, _db) = setup().await;
         let user = repo.get_system_user().await.unwrap().unwrap();
         assert_eq!(user.id, "system_default_user");
-        assert_eq!(user.username, "system");
+        assert_eq!(user.username, "admin");
     }
 
     #[tokio::test]
     async fn get_primary_webui_user_returns_system_user_first() {
         let (repo, _db) = setup().await;
-        repo.create_user("admin", "hash").await.unwrap();
+        // Can't use "admin" here: the seeded system_default_user already owns that
+        // username after the M6 default change. Any fresh user gets a different name.
+        repo.create_user("other", "hash").await.unwrap();
 
         let user = repo.get_primary_webui_user().await.unwrap().unwrap();
         assert_eq!(user.id, "system_default_user");

--- a/crates/aionui-db/tests/db_lifecycle.rs
+++ b/crates/aionui-db/tests/db_lifecycle.rs
@@ -117,7 +117,7 @@ async fn system_default_user_exists() {
         .unwrap();
 
     assert_eq!(row.get::<String, _>("id"), "system_default_user");
-    assert_eq!(row.get::<String, _>("username"), "system");
+    assert_eq!(row.get::<String, _>("username"), "admin");
     assert_eq!(
         row.get::<String, _>("password_hash"),
         "",

--- a/crates/aionui-db/tests/user_repository.rs
+++ b/crates/aionui-db/tests/user_repository.rs
@@ -134,12 +134,14 @@ async fn t2_8_primary_webui_user_is_system_user_when_only_system() {
 #[tokio::test]
 async fn t2_8_primary_webui_user_prefers_system_over_admin() {
     let r = repo().await;
-    r.create_user("admin", "h").await.unwrap();
+    // Can't create another user called "admin" now that seed uses it.
+    // The priority check still holds: any non-system user must not shadow system.
+    r.create_user("other", "h").await.unwrap();
 
     let user = r.get_primary_webui_user().await.unwrap().unwrap();
     assert_eq!(
         user.id, "system_default_user",
-        "system user should take priority over admin"
+        "system user should take priority over non-system users"
     );
 }
 


### PR DESCRIPTION
## Summary

- Add four `ensure_local_mode`-gated routes to `aionui-auth`: `POST /api/webui/{change-password,change-username,reset-password,generate-qr-token}`. They let the same-host caller (Electron main process, `bun run webui`, `bun run resetpass`) manage the WebUI admin user via HTTP so credentials no longer need to live in a forked on-disk config.
- Switch the seeded `system_default_user.username` from `system` to `admin` so fresh installs match the pre-M6 web-host login UX (users already type \"admin\"). `INSERT OR IGNORE` keeps existing dev databases untouched; aionui-backend has no public release yet so no SQL migration is needed.
- Supporting surface: `generate_password(len)` exported publicly, `QrTokenStore::generate_with_expiry()` returns the absolute expiry timestamp, 5 new request/response types in `aionui-api-types`.
- Integration-test helpers updated to handle the new seed (`setup_and_login` / `create_test_user` overwrite the seeded row when the test username is `admin` instead of INSERTing a duplicate).

## Context

This is the backend half of the WebUI auth M6-cleanup that is landing in the AionUi repo on top of `feat/backend-migration`. Paired PR: iOfficeAI/AionUi#<number> (see that PR for the full end-to-end story + smoke-matrix evidence).

Before this cleanup, WebUI admin credentials lived in `webui.config.json` inside `@aionui/web-host` (bcrypt + file I/O). That file and the SQLite users table on backend were separate sources of truth, and browser login validated against the config file while \"change password\" from the Electron Settings UI wrote to the file, so the `users` table was effectively dead.

After this cleanup, SQLite `users` (row id `system_default_user`) is the sole source of truth. All clients hit backend HTTP for credential operations.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test -p aionui-auth -p aionui-db -p aionui-api-types` — all green
- [x] aionui-app integration tests pass (`cargo test -p aionui-app`) once the `create_user(\"admin\", ...)` collisions with the new seed are fixed via `set_system_user_credentials` in the updated helpers
- [x] Live smoke against a Bun-built `resetpass` and `bun run webui` on an isolated data-dir — login succeeds with the reset password, QR token round-trip works