### PR TITLE
feat(ai-agent): custom agent CRUD + two-step probe

### DIFF
--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -35,9 +35,7 @@ pub(super) async fn build(
     // which downstream consumers (MCP injection, preset-context
     // composition) would mis-interpret. When the caller only supplied a
     // vendor label (builtin path), we preserve it as-is.
-    if config.agent_id.is_some() {
-        config.backend.clone_from(&meta.backend);
-    } else if config.backend.is_none() {
+    if config.agent_id.is_some() || config.backend.is_none() {
         config.backend.clone_from(&meta.backend);
     }
 

--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -29,7 +29,15 @@ pub(super) async fn build(
     }
     .ok_or_else(|| AppError::BadRequest("ACP agent requires either agent_id or backend in extra".into()))?;
 
-    if config.backend.is_none() {
+    // Trust the catalog row over the client-supplied `backend` when an
+    // `agent_id` was provided. The frontend collapses row-scoped rows
+    // (custom ACP / remote) to a shared `custom`/`remote` slot string,
+    // which downstream consumers (MCP injection, preset-context
+    // composition) would mis-interpret. When the caller only supplied a
+    // vendor label (builtin path), we preserve it as-is.
+    if config.agent_id.is_some() {
+        config.backend.clone_from(&meta.backend);
+    } else if config.backend.is_none() {
         config.backend.clone_from(&meta.backend);
     }
 

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -10,6 +10,7 @@ pub mod protocol;
 pub mod registry;
 pub mod routes;
 pub mod service;
+mod service_custom;
 pub mod shared_kernel;
 pub mod task_manager;
 pub mod types;

--- a/crates/aionui-ai-agent/src/protocol/cli_detect.rs
+++ b/crates/aionui-ai-agent/src/protocol/cli_detect.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use aionui_api_types::{
-    AcpEnvResponse, AcpHealthCheckResponse, AgentMetadata, DetectCliResponse, TestCustomAgentResponse,
+    AcpEnvResponse, AcpHealthCheckResponse, AgentMetadata, DetectCliResponse, TryConnectCustomAgentResponse,
 };
 use aionui_common::AppError;
 use tracing::debug;
@@ -91,13 +91,11 @@ pub(crate) fn test_custom_agent(
     command: &str,
     _acp_args: &[String],
     _env: &HashMap<String, String>,
-) -> Result<TestCustomAgentResponse, AppError> {
+) -> Result<TryConnectCustomAgentResponse, AppError> {
     resolve_for_detect(command)
         .ok_or_else(|| AppError::BadRequest(format!("Command '{command}' not found in PATH")))?;
 
-    Ok(TestCustomAgentResponse {
-        step: "completed".into(),
-    })
+    Ok(TryConnectCustomAgentResponse::Success)
 }
 
 #[cfg(test)]

--- a/crates/aionui-ai-agent/src/protocol/cli_detect.rs
+++ b/crates/aionui-ai-agent/src/protocol/cli_detect.rs
@@ -2,10 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
-use aionui_api_types::{
-    AcpEnvResponse, AcpHealthCheckResponse, AgentMetadata, DetectCliResponse, TryConnectCustomAgentResponse,
-};
-use aionui_common::AppError;
+use aionui_api_types::{AcpEnvResponse, AcpHealthCheckResponse, AgentMetadata, DetectCliResponse};
 use tracing::debug;
 
 use crate::registry::AgentRegistry;
@@ -86,23 +83,6 @@ pub(crate) fn get_env() -> AcpEnvResponse {
     AcpEnvResponse { env }
 }
 
-/// Test a custom ACP agent by verifying the command exists.
-///
-/// Legacy Step-1-only probe retained for its unit test. The real two-step
-/// probe now lives in `custom_agent_probe::try_connect_custom_agent`.
-/// Removed from production call sites in Task 6; will be cleaned up in Task 7.
-#[allow(dead_code)]
-pub(crate) fn test_custom_agent(
-    command: &str,
-    _acp_args: &[String],
-    _env: &HashMap<String, String>,
-) -> Result<TryConnectCustomAgentResponse, AppError> {
-    resolve_for_detect(command)
-        .ok_or_else(|| AppError::BadRequest(format!("Command '{command}' not found in PATH")))?;
-
-    Ok(TryConnectCustomAgentResponse::Success)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -111,11 +91,5 @@ mod tests {
     fn get_env_returns_at_least_path() {
         let resp = get_env();
         assert!(resp.env.contains_key("PATH") || resp.env.contains_key("HOME"));
-    }
-
-    #[test]
-    fn test_custom_agent_nonexistent_command() {
-        let result = test_custom_agent("/nonexistent/path/to/agent", &[], &HashMap::new());
-        assert!(result.is_err());
     }
 }

--- a/crates/aionui-ai-agent/src/protocol/cli_detect.rs
+++ b/crates/aionui-ai-agent/src/protocol/cli_detect.rs
@@ -87,6 +87,11 @@ pub(crate) fn get_env() -> AcpEnvResponse {
 }
 
 /// Test a custom ACP agent by verifying the command exists.
+///
+/// Legacy Step-1-only probe retained for its unit test. The real two-step
+/// probe now lives in `custom_agent_probe::try_connect_custom_agent`.
+/// Removed from production call sites in Task 6; will be cleaned up in Task 7.
+#[allow(dead_code)]
 pub(crate) fn test_custom_agent(
     command: &str,
     _acp_args: &[String],

--- a/crates/aionui-ai-agent/src/protocol/cli_detect.rs
+++ b/crates/aionui-ai-agent/src/protocol/cli_detect.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
-use aionui_api_types::{AcpEnvResponse, AcpHealthCheckResponse, AgentMetadata, DetectCliResponse};
-use tracing::debug;
-
 use crate::registry::AgentRegistry;
+use aionui_api_types::{AcpEnvResponse, AcpHealthCheckResponse, AgentMetadata, DetectCliResponse};
+use aionui_runtime::resolve_command_path;
+use tracing::debug;
 
 /// Detect the CLI path for a given ACP backend using PATH lookup.
 ///
@@ -52,24 +52,7 @@ pub(crate) async fn health_check(registry: &Arc<AgentRegistry>, backend: &str) -
 
 fn probe_command(meta: &AgentMetadata) -> Option<String> {
     let cmd = meta.command.as_deref()?;
-    resolve_for_detect(cmd).map(|p| p.to_string_lossy().into_owned())
-}
-
-fn resolve_for_detect(cmd: &str) -> Option<std::path::PathBuf> {
-    match cmd {
-        "bun" => aionui_runtime::resolve_bun().ok(),
-        "bunx" => {
-            let bunx_name = if cfg!(windows) { "bunx.exe" } else { "bunx" };
-            if let Some(dir) = aionui_runtime::bun_bin_dir() {
-                let p = dir.join(bunx_name);
-                if p.exists() {
-                    return Some(p);
-                }
-            }
-            which::which("bunx").ok()
-        }
-        other => which::which(other).ok(),
-    }
+    resolve_command_path(cmd).map(|p| p.to_string_lossy().into_owned())
 }
 
 /// Get relevant environment variables for ACP operations.

--- a/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
+++ b/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
@@ -1,6 +1,3 @@
-// Task 6/7 will import these; silence dead_code until then.
-#![allow(dead_code)]
-
 //! Two-step probe for custom ACP agents.
 //!
 //! Step 1: `which`/`where` — resolve the first token of `command` on

--- a/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
+++ b/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
@@ -81,11 +81,7 @@ fn step1_resolve_command(command: &str) -> Option<PathBuf> {
     }
 }
 
-async fn step2_acp_initialize(
-    resolved: PathBuf,
-    args: &[String],
-    env: &HashMap<String, String>,
-) -> Result<(), String> {
+async fn step2_acp_initialize(resolved: PathBuf, args: &[String], env: &HashMap<String, String>) -> Result<(), String> {
     let spec = CommandSpec {
         command: resolved,
         args: args.to_vec(),
@@ -132,12 +128,7 @@ mod tests {
 
     #[tokio::test]
     async fn probe_returns_fail_cli_when_command_missing() {
-        let resp = try_connect_custom_agent(
-            "aionui-definitely-does-not-exist-xyz",
-            &[],
-            &HashMap::new(),
-        )
-        .await;
+        let resp = try_connect_custom_agent("aionui-definitely-does-not-exist-xyz", &[], &HashMap::new()).await;
         match resp {
             TryConnectCustomAgentResponse::FailCli { error } => {
                 let lower = error.to_lowercase();

--- a/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
+++ b/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
@@ -1,0 +1,170 @@
+// Task 6/7 will import these; silence dead_code until then.
+#![allow(dead_code)]
+
+//! Two-step probe for custom ACP agents.
+//!
+//! Step 1: `which`/`where` — resolve the first token of `command` on
+//!         `$PATH`. Bounded by `execFileSync`-equivalent 5 s timeout.
+//! Step 2: Spawn the CLI via `CliAgentProcess::spawn_for_sdk`, connect
+//!         an `AcpProtocol` (which owns the ACP `initialize` handshake
+//!         with a built-in 30 s timeout), then shut down cleanly.
+//!
+//! The same function is called by:
+//!   - `POST /api/agents/custom/try-connect`  (manual "test connection" button)
+//!   - `AgentService::create/update_custom_agent`   (test-on-save)
+//! so both paths produce identical outcomes / error text.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use aionui_api_types::TryConnectCustomAgentResponse;
+use aionui_common::{CommandSpec, EnvVar};
+use tokio::sync::{broadcast, mpsc};
+use tracing::debug;
+
+use crate::capability::cli_process::CliAgentProcess;
+use crate::protocol::acp::AcpProtocol;
+
+/// Step 2 overall timeout. Belt-and-suspenders: `AcpProtocol::connect`
+/// already caps the initialize RPC at 30 s, but a CLI that hangs
+/// before writing any ACP frame at all is covered by this outer cap.
+const STEP2_TIMEOUT: Duration = Duration::from_secs(35);
+
+/// Probe a custom ACP agent.
+///
+/// Returns `Success` only if both `which` and the ACP `initialize`
+/// handshake succeed. Any failure short-circuits into the
+/// corresponding variant.
+pub async fn try_connect_custom_agent(
+    command: &str,
+    args: &[String],
+    env: &HashMap<String, String>,
+) -> TryConnectCustomAgentResponse {
+    // ── Step 1 — which check ────────────────────────────────────────
+    let Some(resolved) = step1_resolve_command(command) else {
+        return TryConnectCustomAgentResponse::FailCli {
+            error: format!("Command '{}' was not found on PATH", first_token(command)),
+        };
+    };
+    debug!(?resolved, "probe step 1 ok");
+
+    // ── Step 2 — spawn + ACP initialize ─────────────────────────────
+    match tokio::time::timeout(STEP2_TIMEOUT, step2_acp_initialize(resolved, args, env)).await {
+        Ok(Ok(())) => TryConnectCustomAgentResponse::Success,
+        Ok(Err(msg)) => TryConnectCustomAgentResponse::FailAcp { error: msg },
+        Err(_) => TryConnectCustomAgentResponse::FailAcp {
+            error: format!("ACP initialize did not complete within {}s", STEP2_TIMEOUT.as_secs()),
+        },
+    }
+}
+
+fn first_token(command: &str) -> &str {
+    command.split_whitespace().next().unwrap_or(command)
+}
+
+fn step1_resolve_command(command: &str) -> Option<PathBuf> {
+    let head = first_token(command);
+    // Reuse the same bun/bunx resolver builtin probing uses so that
+    // `bun` commands work even with the bundled runtime.
+    match head {
+        "bun" => aionui_runtime::resolve_bun().ok(),
+        "bunx" => {
+            let bunx_name = if cfg!(windows) { "bunx.exe" } else { "bunx" };
+            if let Some(dir) = aionui_runtime::bun_bin_dir() {
+                let p = dir.join(bunx_name);
+                if p.exists() {
+                    return Some(p);
+                }
+            }
+            which::which("bunx").ok()
+        }
+        other => which::which(other).ok(),
+    }
+}
+
+async fn step2_acp_initialize(
+    resolved: PathBuf,
+    args: &[String],
+    env: &HashMap<String, String>,
+) -> Result<(), String> {
+    let spec = CommandSpec {
+        command: resolved,
+        args: args.to_vec(),
+        env: env
+            .iter()
+            .map(|(name, value)| EnvVar {
+                name: name.clone(),
+                value: value.clone(),
+            })
+            .collect(),
+        cwd: Some(std::env::temp_dir().to_string_lossy().into_owned()),
+    };
+
+    let proc = CliAgentProcess::spawn_for_sdk(spec)
+        .await
+        .map_err(|e| format!("spawn failed: {e}"))?;
+
+    let (stdin, stdout) = proc
+        .take_stdio()
+        .await
+        .ok_or_else(|| "stdio not available after spawn_for_sdk".to_string())?;
+
+    // Throwaway channels — we only care about init handshake succeeding.
+    let (event_tx, _event_rx) = broadcast::channel(16);
+    let (permission_tx, _permission_rx) = mpsc::channel(4);
+    let (notification_tx, _notification_rx) = mpsc::channel(4);
+
+    let protocol = AcpProtocol::connect(stdin, stdout, event_tx, permission_tx, notification_tx)
+        .await
+        .map_err(|e| format!("ACP initialize failed: {e}"))?;
+
+    // Dropping `protocol` fires the shutdown oneshot; the child process
+    // was spawned with `kill_on_drop(true)` via `aionui_runtime::Builder`
+    // so CPU stays clean.
+    drop(protocol);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn probe_returns_fail_cli_when_command_missing() {
+        let resp = try_connect_custom_agent(
+            "aionui-definitely-does-not-exist-xyz",
+            &[],
+            &HashMap::new(),
+        )
+        .await;
+        match resp {
+            TryConnectCustomAgentResponse::FailCli { error } => {
+                let lower = error.to_lowercase();
+                assert!(
+                    lower.contains("not found") || lower.contains("no such") || lower.contains("was not found"),
+                    "expected 'not found' style message, got: {error}"
+                );
+            }
+            other => panic!("expected FailCli, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn probe_returns_fail_acp_when_command_is_noop() {
+        // `true` exits 0 immediately — Step 1 passes (on PATH), but the
+        // process dies before ACP initialize completes, so Step 2 maps
+        // to FailAcp.
+        if cfg!(windows) {
+            // `true` is a cmd builtin on Windows, not a standalone exe.
+            return;
+        }
+        let resp = try_connect_custom_agent("true", &[], &HashMap::new()).await;
+        assert!(
+            matches!(resp, TryConnectCustomAgentResponse::FailAcp { .. }),
+            "expected FailAcp, got {resp:?}"
+        );
+    }
+}

--- a/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
+++ b/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
@@ -12,7 +12,8 @@
 //! The same function is called by:
 //!   - `POST /api/agents/custom/try-connect`  (manual "test connection" button)
 //!   - `AgentService::create/update_custom_agent`   (test-on-save)
-//! so both paths produce identical outcomes / error text.
+//!
+//! Both paths produce identical outcomes / error text.
 
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
+++ b/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 
 use aionui_api_types::TryConnectCustomAgentResponse;
 use aionui_common::{CommandSpec, EnvVar};
+use aionui_runtime::resolve_command_path;
 use tokio::sync::{broadcast, mpsc};
 use tracing::debug;
 
@@ -40,15 +41,16 @@ pub async fn try_connect_custom_agent(
     env: &HashMap<String, String>,
 ) -> TryConnectCustomAgentResponse {
     // ── Step 1 — which check ────────────────────────────────────────
-    let Some(resolved) = step1_resolve_command(command) else {
+    let head = first_token(command);
+    let Some(resolved) = resolve_command_path(head) else {
         return TryConnectCustomAgentResponse::FailCli {
-            error: format!("Command '{}' was not found on PATH", first_token(command)),
+            error: format!("Command '{}' was not found on PATH", head),
         };
     };
     debug!(?resolved, "probe step 1 ok");
 
     // ── Step 2 — spawn + ACP initialize ─────────────────────────────
-    match tokio::time::timeout(STEP2_TIMEOUT, step2_acp_initialize(resolved, args, env)).await {
+    match tokio::time::timeout(STEP2_TIMEOUT, acp_initialize(resolved, args, env)).await {
         Ok(Ok(())) => TryConnectCustomAgentResponse::Success,
         Ok(Err(msg)) => TryConnectCustomAgentResponse::FailAcp { error: msg },
         Err(_) => TryConnectCustomAgentResponse::FailAcp {
@@ -61,27 +63,7 @@ fn first_token(command: &str) -> &str {
     command.split_whitespace().next().unwrap_or(command)
 }
 
-fn step1_resolve_command(command: &str) -> Option<PathBuf> {
-    let head = first_token(command);
-    // Reuse the same bun/bunx resolver builtin probing uses so that
-    // `bun` commands work even with the bundled runtime.
-    match head {
-        "bun" => aionui_runtime::resolve_bun().ok(),
-        "bunx" => {
-            let bunx_name = if cfg!(windows) { "bunx.exe" } else { "bunx" };
-            if let Some(dir) = aionui_runtime::bun_bin_dir() {
-                let p = dir.join(bunx_name);
-                if p.exists() {
-                    return Some(p);
-                }
-            }
-            which::which("bunx").ok()
-        }
-        other => which::which(other).ok(),
-    }
-}
-
-async fn step2_acp_initialize(resolved: PathBuf, args: &[String], env: &HashMap<String, String>) -> Result<(), String> {
+async fn acp_initialize(resolved: PathBuf, args: &[String], env: &HashMap<String, String>) -> Result<(), String> {
     let spec = CommandSpec {
         command: resolved,
         args: args.to_vec(),
@@ -109,16 +91,36 @@ async fn step2_acp_initialize(resolved: PathBuf, args: &[String], env: &HashMap<
     let (permission_tx, _permission_rx) = mpsc::channel(4);
     let (notification_tx, _notification_rx) = mpsc::channel(4);
 
-    let protocol = AcpProtocol::connect(stdin, stdout, event_tx, permission_tx, notification_tx)
-        .await
-        .map_err(|e| format!("ACP initialize failed: {e}"))?;
-
-    // Dropping `protocol` fires the shutdown oneshot; the child process
-    // was spawned with `kill_on_drop(true)` via `aionui_runtime::Builder`
-    // so CPU stays clean.
-    drop(protocol);
-
-    Ok(())
+    // Race the ACP initialize handshake against the child process exiting.
+    // A misconfigured CLI (e.g. `bun acp` with no script) exits almost
+    // immediately with a non-zero status; without this race the
+    // `AcpProtocol::connect` call would block on its internal 30 s
+    // timeout waiting for an `initialize` reply that will never arrive.
+    let connect = AcpProtocol::connect(stdin, stdout, event_tx, permission_tx, notification_tx);
+    tokio::select! {
+        biased;
+        res = connect => {
+            let protocol = res.map_err(|e| format!("ACP initialize failed: {e}"))?;
+            // Dropping `protocol` fires the shutdown oneshot; the child
+            // process was spawned with `kill_on_drop(true)` via
+            // `aionui_runtime::Builder` so CPU stays clean.
+            drop(protocol);
+            Ok(())
+        }
+        exit = proc.wait_for_exit() => {
+            let stderr = proc.take_stderr().await;
+            let stderr = stderr.trim();
+            let status = match exit {
+                Some(s) => format!("{s}"),
+                None => "unknown".to_string(),
+            };
+            if stderr.is_empty() {
+                Err(format!("CLI exited before ACP initialize completed (status={status})"))
+            } else {
+                Err(format!("CLI exited before ACP initialize completed (status={status}): {stderr}"))
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/aionui-ai-agent/src/protocol/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod acp;
 pub(crate) mod cli_detect;
+pub(crate) mod custom_agent_probe;
 pub(crate) mod error;
 pub mod events;

--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -157,6 +157,19 @@ impl AgentRegistry {
         }
     }
 
+    /// Refetch every row from the repository, then re-resolve PATH.
+    ///
+    /// Called after any mutation that changed the set of rows on disk
+    /// (create/delete) or the spawn command of an existing row
+    /// (update). Pure refresh with no DB writes — just rebuilds the
+    /// in-memory snapshot so `list_all()` and `get()` return the latest
+    /// catalog state without waiting for the next process restart.
+    pub async fn invalidate_and_rehydrate(&self) -> Result<(), AppError> {
+        self.hydrate().await?;
+        self.refresh_availability().await;
+        Ok(())
+    }
+
     pub async fn get(&self, id: &str) -> Option<AgentMetadata> {
         self.by_id.read().await.get(id).cloned()
     }
@@ -212,6 +225,13 @@ impl AgentRegistry {
         let mut rows: Vec<AgentMetadata> = self.by_id.read().await.values().cloned().collect();
         rows.sort_by(|a, b| a.sort_order.cmp(&b.sort_order).then_with(|| a.name.cmp(&b.name)));
         rows
+    }
+
+    /// Clone-cheap handle to the underlying repo, for service-layer
+    /// helpers that need direct CRUD access without going through the
+    /// registry cache.
+    pub fn repo_handle(&self) -> &Arc<dyn IAgentMetadataRepository> {
+        &self.repo
     }
 }
 

--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -141,8 +141,13 @@ impl AgentRegistry {
             };
             map.insert(meta.id.clone(), meta);
         }
+        // Capture len before the write-lock await so the debug! macro arg
+        // doesn't hold a RwLockReadGuard / Arguments<'_> across an await
+        // point (both !Send, which would poison handler futures via
+        // invalidate_and_rehydrate).
+        let row_count = map.len();
         *self.by_id.write().await = map;
-        debug!(rows = self.by_id.read().await.len(), "AgentRegistry hydrated");
+        debug!(rows = row_count, "AgentRegistry hydrated");
         Ok(())
     }
 

--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use aionui_api_types::{AgentEnvEntry, AgentHandshake, AgentMetadata, AgentSource, AgentSourceInfo, BehaviorPolicy};
 use aionui_common::{AgentType, AppError};
 use aionui_db::{AgentMetadataRow, IAgentMetadataRepository, UpdateAgentHandshakeParams};
+use aionui_runtime::resolve_command_path;
 use serde_json::Value;
 use tokio::sync::{RwLock, mpsc};
 use tracing::{debug, warn};
@@ -366,28 +367,6 @@ impl CatalogSender {
                 }
             }
         }
-    }
-}
-
-/// Resolve a command name to an absolute path.
-///
-/// For `bun` / `bunx` we go through `aionui_runtime` so the bundled
-/// runtime is used when present; everything else falls back to the
-/// user's `$PATH` via `which::which`.
-fn resolve_command_path(cmd: &str) -> Option<PathBuf> {
-    match cmd {
-        "bun" => aionui_runtime::resolve_bun().ok(),
-        "bunx" => {
-            let bunx_name = if cfg!(windows) { "bunx.exe" } else { "bunx" };
-            if let Some(dir) = aionui_runtime::bun_bin_dir() {
-                let p = dir.join(bunx_name);
-                if p.exists() {
-                    return Some(p);
-                }
-            }
-            which::which("bunx").ok()
-        }
-        other => which::which(other).ok(),
     }
 }
 

--- a/crates/aionui-ai-agent/src/routes/agent.rs
+++ b/crates/aionui-ai-agent/src/routes/agent.rs
@@ -10,14 +10,18 @@ use std::sync::Arc;
 
 use axum::Router;
 use axum::extract::rejection::JsonRejection;
-use axum::extract::{Extension, Json, State};
-use axum::routing::{get, post};
+use axum::extract::{Extension, Json, Path, State};
+use axum::routing::{get, patch, post, put};
 
-use aionui_api_types::{AgentMetadata, ApiResponse, TryConnectCustomAgentRequest, TryConnectCustomAgentResponse};
+use aionui_api_types::{
+    AgentMetadata, ApiResponse, CustomAgentUpsertRequest, DeleteCustomAgentResponse, SetEnabledRequest,
+    TryConnectCustomAgentRequest, TryConnectCustomAgentResponse,
+};
 use aionui_auth::CurrentUser;
 use aionui_common::AppError;
 
 use crate::registry::AgentRegistry;
+
 
 #[derive(Clone)]
 pub struct AgentRouterState {
@@ -29,7 +33,13 @@ pub fn agent_routes(state: AgentRouterState) -> Router {
     Router::new()
         .route("/api/agents", get(list_agents))
         .route("/api/agents/refresh", post(refresh_agents))
-        .route("/api/agents/test", post(test_custom_agent))
+        .route("/api/agents/{id}/enabled", patch(set_agent_enabled))
+        .route("/api/agents/custom", post(create_custom_agent))
+        .route("/api/agents/custom/try-connect", post(try_connect_custom_agent))
+        .route(
+            "/api/agents/custom/{id}",
+            put(update_custom_agent).delete(delete_custom_agent),
+        )
         .with_state(state)
 }
 
@@ -47,13 +57,53 @@ async fn refresh_agents(
     Ok(Json(ApiResponse::ok(state.service.refresh_agents().await?)))
 }
 
-async fn test_custom_agent(
+async fn try_connect_custom_agent(
     State(state): State<AgentRouterState>,
     Extension(_user): Extension<CurrentUser>,
     body: Result<Json<TryConnectCustomAgentRequest>, JsonRejection>,
 ) -> Result<Json<ApiResponse<TryConnectCustomAgentResponse>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
+    Ok(Json(ApiResponse::ok(state.service.try_connect_custom_agent(req).await?)))
+}
+
+async fn create_custom_agent(
+    State(state): State<AgentRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    body: Result<Json<CustomAgentUpsertRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<AgentMetadata>>, AppError> {
+    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
+    Ok(Json(ApiResponse::ok(state.service.create_custom_agent(req).await?)))
+}
+
+async fn update_custom_agent(
+    State(state): State<AgentRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+    body: Result<Json<CustomAgentUpsertRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<AgentMetadata>>, AppError> {
+    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
     Ok(Json(ApiResponse::ok(
-        state.service.try_connect_custom_agent(req).await?,
+        state.service.update_custom_agent(&id, req).await?,
+    )))
+}
+
+async fn delete_custom_agent(
+    State(state): State<AgentRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+) -> Result<Json<ApiResponse<DeleteCustomAgentResponse>>, AppError> {
+    state.service.delete_custom_agent(&id).await?;
+    Ok(Json(ApiResponse::ok(DeleteCustomAgentResponse { deleted: true })))
+}
+
+async fn set_agent_enabled(
+    State(state): State<AgentRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+    body: Result<Json<SetEnabledRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<AgentMetadata>>, AppError> {
+    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
+    Ok(Json(ApiResponse::ok(
+        state.service.set_agent_enabled(&id, req.enabled).await?,
     )))
 }

--- a/crates/aionui-ai-agent/src/routes/agent.rs
+++ b/crates/aionui-ai-agent/src/routes/agent.rs
@@ -13,7 +13,7 @@ use axum::extract::rejection::JsonRejection;
 use axum::extract::{Extension, Json, State};
 use axum::routing::{get, post};
 
-use aionui_api_types::{AgentMetadata, ApiResponse, TestCustomAgentRequest, TestCustomAgentResponse};
+use aionui_api_types::{AgentMetadata, ApiResponse, TryConnectCustomAgentRequest, TryConnectCustomAgentResponse};
 use aionui_auth::CurrentUser;
 use aionui_common::AppError;
 
@@ -50,8 +50,10 @@ async fn refresh_agents(
 async fn test_custom_agent(
     State(state): State<AgentRouterState>,
     Extension(_user): Extension<CurrentUser>,
-    body: Result<Json<TestCustomAgentRequest>, JsonRejection>,
-) -> Result<Json<ApiResponse<TestCustomAgentResponse>>, AppError> {
+    body: Result<Json<TryConnectCustomAgentRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<TryConnectCustomAgentResponse>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    Ok(Json(ApiResponse::ok(state.service.test_custom_agent(req)?)))
+    Ok(Json(ApiResponse::ok(
+        state.service.try_connect_custom_agent_legacy_passthrough(req)?,
+    )))
 }

--- a/crates/aionui-ai-agent/src/routes/agent.rs
+++ b/crates/aionui-ai-agent/src/routes/agent.rs
@@ -33,12 +33,9 @@ pub fn agent_routes(state: AgentRouterState) -> Router {
         .route("/api/agents", get(list_agents))
         .route("/api/agents/refresh", post(refresh_agents))
         .route("/api/agents/{id}/enabled", patch(set_agent_enabled))
-        .route("/api/agents/custom", post(create_custom_agent))
-        .route("/api/agents/custom/try-connect", post(try_connect_custom_agent))
-        .route(
-            "/api/agents/custom/{id}",
-            put(update_custom_agent).delete(delete_custom_agent),
-        )
+        .route("/api/agents/custom", post(create_custom))
+        .route("/api/agents/custom/{id}", put(update_custom).delete(delete_custom))
+        .route("/api/agents/custom/try-connect", post(try_connect_custom))
         .with_state(state)
 }
 
@@ -56,7 +53,7 @@ async fn refresh_agents(
     Ok(Json(ApiResponse::ok(state.service.refresh_agents().await?)))
 }
 
-async fn try_connect_custom_agent(
+async fn try_connect_custom(
     State(state): State<AgentRouterState>,
     Extension(_user): Extension<CurrentUser>,
     body: Result<Json<TryConnectCustomAgentRequest>, JsonRejection>,
@@ -67,7 +64,7 @@ async fn try_connect_custom_agent(
     )))
 }
 
-async fn create_custom_agent(
+async fn create_custom(
     State(state): State<AgentRouterState>,
     Extension(_user): Extension<CurrentUser>,
     body: Result<Json<CustomAgentUpsertRequest>, JsonRejection>,
@@ -76,7 +73,7 @@ async fn create_custom_agent(
     Ok(Json(ApiResponse::ok(state.service.create_custom_agent(req).await?)))
 }
 
-async fn update_custom_agent(
+async fn update_custom(
     State(state): State<AgentRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
@@ -88,7 +85,7 @@ async fn update_custom_agent(
     )))
 }
 
-async fn delete_custom_agent(
+async fn delete_custom(
     State(state): State<AgentRouterState>,
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,

--- a/crates/aionui-ai-agent/src/routes/agent.rs
+++ b/crates/aionui-ai-agent/src/routes/agent.rs
@@ -22,7 +22,6 @@ use aionui_common::AppError;
 
 use crate::registry::AgentRegistry;
 
-
 #[derive(Clone)]
 pub struct AgentRouterState {
     pub agent_registry: Arc<AgentRegistry>,
@@ -63,7 +62,9 @@ async fn try_connect_custom_agent(
     body: Result<Json<TryConnectCustomAgentRequest>, JsonRejection>,
 ) -> Result<Json<ApiResponse<TryConnectCustomAgentResponse>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    Ok(Json(ApiResponse::ok(state.service.try_connect_custom_agent(req).await?)))
+    Ok(Json(ApiResponse::ok(
+        state.service.try_connect_custom_agent(req).await?,
+    )))
 }
 
 async fn create_custom_agent(

--- a/crates/aionui-ai-agent/src/routes/agent.rs
+++ b/crates/aionui-ai-agent/src/routes/agent.rs
@@ -54,6 +54,6 @@ async fn test_custom_agent(
 ) -> Result<Json<ApiResponse<TryConnectCustomAgentResponse>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
     Ok(Json(ApiResponse::ok(
-        state.service.try_connect_custom_agent_legacy_passthrough(req)?,
+        state.service.try_connect_custom_agent(req).await?,
     )))
 }

--- a/crates/aionui-ai-agent/src/service.rs
+++ b/crates/aionui-ai-agent/src/service.rs
@@ -13,7 +13,8 @@ use aionui_api_types::{
     AcpEnvResponse, AcpHealthCheckRequest, AcpHealthCheckResponse, AcpModelInfo, AgentMetadata, AgentModeResponse,
     DetectCliRequest, DetectCliResponse, GetModelInfoResponse, ModelInfoEntry, ModelInfoPayload, ProbeModelRequest,
     SetConfigOptionRequest, SetConfigOptionsRequest, SetModeRequest, SetModelRequest, SideQuestionRequest,
-    SideQuestionResponse, SlashCommandItem, TestCustomAgentRequest, TestCustomAgentResponse, WorkspaceBrowseQuery,
+    SideQuestionResponse, SlashCommandItem, TryConnectCustomAgentRequest, TryConnectCustomAgentResponse,
+    WorkspaceBrowseQuery,
     WorkspaceEntry,
 };
 use aionui_common::AppError;
@@ -372,7 +373,12 @@ impl AgentService {
         Ok(self.registry.list_all().await)
     }
 
-    pub fn test_custom_agent(&self, req: TestCustomAgentRequest) -> Result<TestCustomAgentResponse, AppError> {
+    pub fn try_connect_custom_agent_legacy_passthrough(
+        &self,
+        req: TryConnectCustomAgentRequest,
+    ) -> Result<TryConnectCustomAgentResponse, AppError> {
+        // Temporary shim: still points at the old Step-1-only impl until
+        // Task 4 lands the new probe module. Deleted in Task 7.
         crate::protocol::cli_detect::test_custom_agent(&req.command, &req.acp_args, &req.env)
     }
 }

--- a/crates/aionui-ai-agent/src/service.rs
+++ b/crates/aionui-ai-agent/src/service.rs
@@ -13,9 +13,7 @@ use aionui_api_types::{
     AcpEnvResponse, AcpHealthCheckRequest, AcpHealthCheckResponse, AcpModelInfo, AgentMetadata, AgentModeResponse,
     DetectCliRequest, DetectCliResponse, GetModelInfoResponse, ModelInfoEntry, ModelInfoPayload, ProbeModelRequest,
     SetConfigOptionRequest, SetConfigOptionsRequest, SetModeRequest, SetModelRequest, SideQuestionRequest,
-    SideQuestionResponse, SlashCommandItem, TryConnectCustomAgentRequest, TryConnectCustomAgentResponse,
-    WorkspaceBrowseQuery,
-    WorkspaceEntry,
+    SideQuestionResponse, SlashCommandItem, WorkspaceBrowseQuery, WorkspaceEntry,
 };
 use aionui_common::AppError;
 use aionui_db::IConversationRepository;
@@ -49,6 +47,10 @@ impl AgentService {
             conversation_repo,
             acp_session_sync,
         })
+    }
+
+    pub(crate) fn registry(&self) -> &std::sync::Arc<crate::registry::AgentRegistry> {
+        &self.registry
     }
 
     // Private helper — move logic from routes::session_ops::get_task verbatim
@@ -373,14 +375,6 @@ impl AgentService {
         Ok(self.registry.list_all().await)
     }
 
-    pub fn try_connect_custom_agent_legacy_passthrough(
-        &self,
-        req: TryConnectCustomAgentRequest,
-    ) -> Result<TryConnectCustomAgentResponse, AppError> {
-        // Temporary shim: still points at the old Step-1-only impl until
-        // Task 4 lands the new probe module. Deleted in Task 7.
-        crate::protocol::cli_detect::test_custom_agent(&req.command, &req.acp_args, &req.env)
-    }
 }
 
 // ACP related operations

--- a/crates/aionui-ai-agent/src/service.rs
+++ b/crates/aionui-ai-agent/src/service.rs
@@ -374,7 +374,6 @@ impl AgentService {
         self.registry.refresh_availability().await;
         Ok(self.registry.list_all().await)
     }
-
 }
 
 // ACP related operations

--- a/crates/aionui-ai-agent/src/service_custom.rs
+++ b/crates/aionui-ai-agent/src/service_custom.rs
@@ -48,7 +48,11 @@ impl AgentService {
         self.upsert_custom_row(&id, &req, /* keep_enabled = */ true).await
     }
 
-    pub async fn update_custom_agent(&self, id: &str, req: CustomAgentUpsertRequest) -> Result<AgentMetadata, AppError> {
+    pub async fn update_custom_agent(
+        &self,
+        id: &str,
+        req: CustomAgentUpsertRequest,
+    ) -> Result<AgentMetadata, AppError> {
         validate_upsert(&req)?;
         let existing = self
             .registry()
@@ -129,7 +133,9 @@ impl AgentService {
         let native_skills_dirs_json = advanced
             .native_skills_dirs
             .as_ref()
-            .map(|v| serde_json::to_string(v).map_err(|e| AppError::Internal(format!("encode native_skills_dirs: {e}"))))
+            .map(|v| {
+                serde_json::to_string(v).map_err(|e| AppError::Internal(format!("encode native_skills_dirs: {e}")))
+            })
             .transpose()?;
         let behavior_policy_json = advanced
             .behavior_policy
@@ -208,11 +214,7 @@ async fn probe_or_reject(req: &CustomAgentUpsertRequest) -> Result<(), AppError>
         return Ok(());
     }
 
-    let env_map: HashMap<String, String> = req
-        .env
-        .iter()
-        .map(|e| (e.name.clone(), e.value.clone()))
-        .collect();
+    let env_map: HashMap<String, String> = req.env.iter().map(|e| (e.name.clone(), e.value.clone())).collect();
     match probe(&req.command, &req.args, &env_map).await {
         TryConnectCustomAgentResponse::Success => Ok(()),
         TryConnectCustomAgentResponse::FailCli { error } => {

--- a/crates/aionui-ai-agent/src/service_custom.rs
+++ b/crates/aionui-ai-agent/src/service_custom.rs
@@ -1,0 +1,229 @@
+//! Custom Agent business logic.
+//!
+//! Extends `AgentService` with CRUD for `agent_source = 'custom'` rows
+//! in the `agent_metadata` catalog. Mirrors the frontend PRD
+//! F-CAGENT-04 / -05 / -12 / -13 / -14 (create, edit, save, delete,
+//! toggle enable).
+//!
+//! Test-on-save: create / update run `try_connect_custom_agent`
+//! before hitting the DB. Failures become `AppError::BadRequest` with
+//! a prefixed marker (`cli_not_found:` / `acp_init_failed:`) that the
+//! frontend maps back to the same three Alert states it shows for the
+//! manual "Test connection" button.
+
+use std::collections::HashMap;
+
+use aionui_api_types::{
+    AgentMetadata, CustomAgentUpsertRequest, TryConnectCustomAgentRequest, TryConnectCustomAgentResponse,
+};
+use aionui_common::AppError;
+use aionui_db::UpsertAgentMetadataParams;
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::protocol::custom_agent_probe::try_connect_custom_agent as probe;
+use crate::service::AgentService;
+
+const CUSTOM_SORT_ORDER_DEFAULT: i64 = 1500;
+
+impl AgentService {
+    /// Public accessor for the probe — powers both
+    /// `POST /api/agents/custom/try-connect` and the test-on-save path
+    /// below.
+    pub async fn try_connect_custom_agent(
+        &self,
+        req: TryConnectCustomAgentRequest,
+    ) -> Result<TryConnectCustomAgentResponse, AppError> {
+        if req.command.trim().is_empty() {
+            return Err(AppError::BadRequest("command must not be empty".into()));
+        }
+        Ok(probe(&req.command, &req.acp_args, &req.env).await)
+    }
+
+    pub async fn create_custom_agent(&self, req: CustomAgentUpsertRequest) -> Result<AgentMetadata, AppError> {
+        validate_upsert(&req)?;
+        probe_or_reject(&req).await?;
+
+        let id = Uuid::new_v4().to_string();
+        self.upsert_custom_row(&id, &req, /* keep_enabled = */ true).await
+    }
+
+    pub async fn update_custom_agent(&self, id: &str, req: CustomAgentUpsertRequest) -> Result<AgentMetadata, AppError> {
+        validate_upsert(&req)?;
+        let existing = self
+            .registry()
+            .repo_handle()
+            .get(id)
+            .await
+            .map_err(|e| AppError::Internal(format!("repo.get: {e}")))?
+            .ok_or_else(|| AppError::NotFound(format!("Agent '{id}' not found")))?;
+        if existing.agent_source != "custom" {
+            return Err(AppError::Forbidden(
+                "Only custom agents can be edited via this endpoint".into(),
+            ));
+        }
+        probe_or_reject(&req).await?;
+
+        let keep_enabled = existing.enabled;
+        self.upsert_custom_row(id, &req, keep_enabled).await
+    }
+
+    pub async fn delete_custom_agent(&self, id: &str) -> Result<(), AppError> {
+        let existing = self
+            .registry()
+            .repo_handle()
+            .get(id)
+            .await
+            .map_err(|e| AppError::Internal(format!("repo.get: {e}")))?
+            .ok_or_else(|| AppError::NotFound(format!("Agent '{id}' not found")))?;
+        if existing.agent_source != "custom" {
+            return Err(AppError::Forbidden(
+                "Only custom agents can be deleted via this endpoint".into(),
+            ));
+        }
+        let removed = self
+            .registry()
+            .repo_handle()
+            .delete(id)
+            .await
+            .map_err(|e| AppError::Internal(format!("repo.delete: {e}")))?;
+        if !removed {
+            return Err(AppError::NotFound(format!("Agent '{id}' not found")));
+        }
+        if let Err(err) = self.registry().invalidate_and_rehydrate().await {
+            warn!(agent_id = %id, error = %err, "registry rehydrate failed after delete_custom_agent");
+        }
+        Ok(())
+    }
+
+    pub async fn set_agent_enabled(&self, id: &str, enabled: bool) -> Result<AgentMetadata, AppError> {
+        let updated = self
+            .registry()
+            .repo_handle()
+            .set_enabled(id, enabled)
+            .await
+            .map_err(|e| AppError::Internal(format!("repo.set_enabled: {e}")))?;
+        if !updated {
+            return Err(AppError::NotFound(format!("Agent '{id}' not found")));
+        }
+        if let Err(err) = self.registry().invalidate_and_rehydrate().await {
+            warn!(agent_id = %id, error = %err, "registry rehydrate failed after set_agent_enabled");
+        }
+        self.registry()
+            .get(id)
+            .await
+            .ok_or_else(|| AppError::Internal(format!("Agent '{id}' not visible after enable toggle")))
+    }
+
+    async fn upsert_custom_row(
+        &self,
+        id: &str,
+        req: &CustomAgentUpsertRequest,
+        enabled: bool,
+    ) -> Result<AgentMetadata, AppError> {
+        let advanced = req.advanced.clone().unwrap_or_default();
+
+        let args_json =
+            serde_json::to_string(&req.args).map_err(|e| AppError::Internal(format!("encode args: {e}")))?;
+        let env_json = serde_json::to_string(&req.env).map_err(|e| AppError::Internal(format!("encode env: {e}")))?;
+        let native_skills_dirs_json = advanced
+            .native_skills_dirs
+            .as_ref()
+            .map(|v| serde_json::to_string(v).map_err(|e| AppError::Internal(format!("encode native_skills_dirs: {e}"))))
+            .transpose()?;
+        let behavior_policy_json = advanced
+            .behavior_policy
+            .as_ref()
+            .map(|v| serde_json::to_string(v).map_err(|e| AppError::Internal(format!("encode behavior_policy: {e}"))))
+            .transpose()?;
+
+        let source_info = serde_json::json!({
+            "binary_name": first_token(&req.command),
+        });
+        let source_info_json = source_info.to_string();
+
+        let params = UpsertAgentMetadataParams {
+            id,
+            icon: req.icon.as_deref(),
+            name: req.name.trim(),
+            name_i18n: None,
+            description: advanced.description.as_deref(),
+            description_i18n: None,
+            backend: None,
+            agent_type: "acp",
+            agent_source: "custom",
+            agent_source_info: Some(&source_info_json),
+            enabled,
+            command: Some(req.command.trim()),
+            args: Some(&args_json),
+            env: Some(&env_json),
+            native_skills_dirs: native_skills_dirs_json.as_deref(),
+            behavior_policy: behavior_policy_json.as_deref(),
+            yolo_id: advanced.yolo_id.as_deref(),
+            agent_capabilities: None,
+            auth_methods: None,
+            config_options: None,
+            available_modes: None,
+            available_models: None,
+            available_commands: None,
+            sort_order: CUSTOM_SORT_ORDER_DEFAULT,
+        };
+
+        self.registry()
+            .repo_handle()
+            .upsert(&params)
+            .await
+            .map_err(|e| AppError::Internal(format!("repo.upsert: {e}")))?;
+
+        self.registry()
+            .invalidate_and_rehydrate()
+            .await
+            .map_err(|e| AppError::Internal(format!("registry rehydrate: {e}")))?;
+
+        self.registry()
+            .get(id)
+            .await
+            .ok_or_else(|| AppError::Internal(format!("Agent '{id}' not visible after upsert")))
+    }
+}
+
+fn validate_upsert(req: &CustomAgentUpsertRequest) -> Result<(), AppError> {
+    if req.name.trim().is_empty() {
+        return Err(AppError::BadRequest("name must not be empty".into()));
+    }
+    if req.command.trim().is_empty() {
+        return Err(AppError::BadRequest("command must not be empty".into()));
+    }
+    Ok(())
+}
+
+async fn probe_or_reject(req: &CustomAgentUpsertRequest) -> Result<(), AppError> {
+    // Test-only bypass — real probe spawns a child process and relies
+    // on a working ACP CLI on PATH, which is not present in CI.
+    // Gated behind cfg(test) / the `test-support` feature so production
+    // builds cannot be tricked into skipping the probe via env var.
+    #[cfg(any(test, feature = "test-support"))]
+    if std::env::var("AIONUI_BYPASS_PROBE").is_ok() {
+        tracing::warn!("AIONUI_BYPASS_PROBE set — skipping custom agent probe. Test-only.");
+        return Ok(());
+    }
+
+    let env_map: HashMap<String, String> = req
+        .env
+        .iter()
+        .map(|e| (e.name.clone(), e.value.clone()))
+        .collect();
+    match probe(&req.command, &req.args, &env_map).await {
+        TryConnectCustomAgentResponse::Success => Ok(()),
+        TryConnectCustomAgentResponse::FailCli { error } => {
+            Err(AppError::BadRequest(format!("cli_not_found: {error}")))
+        }
+        TryConnectCustomAgentResponse::FailAcp { error } => {
+            Err(AppError::BadRequest(format!("acp_init_failed: {error}")))
+        }
+    }
+}
+
+fn first_token(s: &str) -> &str {
+    s.split_whitespace().next().unwrap_or(s)
+}

--- a/crates/aionui-ai-agent/src/service_custom.rs
+++ b/crates/aionui-ai-agent/src/service_custom.rs
@@ -16,10 +16,9 @@ use std::collections::HashMap;
 use aionui_api_types::{
     AgentMetadata, CustomAgentUpsertRequest, TryConnectCustomAgentRequest, TryConnectCustomAgentResponse,
 };
-use aionui_common::AppError;
+use aionui_common::{AppError, generate_short_id};
 use aionui_db::UpsertAgentMetadataParams;
 use tracing::warn;
-use uuid::Uuid;
 
 use crate::protocol::custom_agent_probe::try_connect_custom_agent as probe;
 use crate::service::AgentService;
@@ -44,7 +43,7 @@ impl AgentService {
         validate_upsert(&req)?;
         probe_or_reject(&req).await?;
 
-        let id = Uuid::new_v4().to_string();
+        let id = generate_short_id();
         self.upsert_custom_row(&id, &req, /* keep_enabled = */ true).await
     }
 

--- a/crates/aionui-api-types/src/acp.rs
+++ b/crates/aionui-api-types/src/acp.rs
@@ -110,9 +110,14 @@ pub struct SetConfigOptionsRequest {
     pub config_options: Vec<SessionConfigOptionUpdate>,
 }
 
-/// Request body for testing a custom ACP agent.
-#[derive(Debug, Deserialize)]
-pub struct TestCustomAgentRequest {
+/// Request body for probing a custom ACP agent.
+///
+/// Two-step check: Step 1 resolves `command` on `$PATH`; Step 2 spawns
+/// the CLI and performs an ACP `initialize` handshake. The same
+/// function is called from the dedicated endpoint (manual test button)
+/// and from the create/update path (test-on-save).
+#[derive(Debug, Clone, Deserialize)]
+pub struct TryConnectCustomAgentRequest {
     pub command: String,
     #[serde(default)]
     pub acp_args: Vec<String>,
@@ -120,10 +125,18 @@ pub struct TestCustomAgentRequest {
     pub env: HashMap<String, String>,
 }
 
-/// Response for testing a custom ACP agent.
-#[derive(Debug, Serialize)]
-pub struct TestCustomAgentResponse {
-    pub step: String,
+/// Outcome of [`TryConnectCustomAgentRequest`].
+///
+/// Tagged enum: `step` distinguishes the three states the frontend's
+/// Alert component renders (success → green, fail_cli → red,
+/// fail_acp → yellow). `error` carries a human-readable reason for the
+/// two failure variants.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "step", rename_all = "snake_case")]
+pub enum TryConnectCustomAgentResponse {
+    Success,
+    FailCli { error: String },
+    FailAcp { error: String },
 }
 
 /// Query parameters for workspace browse.
@@ -245,24 +258,37 @@ mod tests {
     }
 
     #[test]
-    fn test_custom_agent_request_serde() {
+    fn try_connect_custom_agent_request_serde() {
         let json = json!({
             "command": "/path/to/agent",
             "acp_args": ["--flag"],
             "env": { "KEY": "value" }
         });
-        let req: TestCustomAgentRequest = serde_json::from_value(json).unwrap();
+        let req: TryConnectCustomAgentRequest = serde_json::from_value(json).unwrap();
         assert_eq!(req.command, "/path/to/agent");
         assert_eq!(req.acp_args, vec!["--flag"]);
         assert_eq!(req.env.get("KEY"), Some(&"value".into()));
     }
 
     #[test]
-    fn test_custom_agent_request_defaults() {
+    fn try_connect_custom_agent_request_defaults() {
         let json = json!({ "command": "/bin/test" });
-        let req: TestCustomAgentRequest = serde_json::from_value(json).unwrap();
+        let req: TryConnectCustomAgentRequest = serde_json::from_value(json).unwrap();
         assert!(req.acp_args.is_empty());
         assert!(req.env.is_empty());
+    }
+
+    #[test]
+    fn try_connect_response_tag_serializes() {
+        use super::TryConnectCustomAgentResponse;
+        let ok = TryConnectCustomAgentResponse::Success;
+        assert_eq!(serde_json::to_value(&ok).unwrap(), serde_json::json!({"step":"success"}));
+
+        let fail = TryConnectCustomAgentResponse::FailCli { error: "not found".into() };
+        assert_eq!(
+            serde_json::to_value(&fail).unwrap(),
+            serde_json::json!({"step":"fail_cli","error":"not found"})
+        );
     }
 
     #[test]

--- a/crates/aionui-api-types/src/acp.rs
+++ b/crates/aionui-api-types/src/acp.rs
@@ -282,9 +282,14 @@ mod tests {
     fn try_connect_response_tag_serializes() {
         use super::TryConnectCustomAgentResponse;
         let ok = TryConnectCustomAgentResponse::Success;
-        assert_eq!(serde_json::to_value(&ok).unwrap(), serde_json::json!({"step":"success"}));
+        assert_eq!(
+            serde_json::to_value(&ok).unwrap(),
+            serde_json::json!({"step":"success"})
+        );
 
-        let fail = TryConnectCustomAgentResponse::FailCli { error: "not found".into() };
+        let fail = TryConnectCustomAgentResponse::FailCli {
+            error: "not found".into(),
+        };
         assert_eq!(
             serde_json::to_value(&fail).unwrap(),
             serde_json::json!({"step":"fail_cli","error":"not found"})

--- a/crates/aionui-api-types/src/custom_agent.rs
+++ b/crates/aionui-api-types/src/custom_agent.rs
@@ -1,0 +1,92 @@
+//! Request/response types for Custom Agent CRUD endpoints.
+//!
+//! Custom agents are user-defined rows in the `agent_metadata` table.
+//! They share the same storage and spawn path as builtin agents, but are
+//! owned/edited via `/api/agents/custom/*` endpoints exposed to the
+//! settings UI (F-CAGENT-04 / -05 / -12 / -13 / -14 in the frontend
+//! PRD).
+
+use serde::{Deserialize, Serialize};
+
+use crate::agent_discovery::{AgentEnvEntry, BehaviorPolicy};
+
+/// Payload shared by `POST /api/agents/custom` and
+/// `PUT  /api/agents/custom/{id}`.
+///
+/// Field coverage matches the frontend editor (F-CAGENT-07/-08/-09/-10):
+/// name/command required; icon/args/env optional; `advanced` carries the
+/// subset of `AgentMetadata` columns exposed via the JSON advanced panel.
+/// Unknown keys inside `advanced` are silently dropped (serde default),
+/// mirroring `handleSubmit` in `InlineAgentEditor.tsx`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CustomAgentUpsertRequest {
+    pub name: String,
+    pub command: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<AgentEnvEntry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub advanced: Option<CustomAgentAdvancedOverrides>,
+}
+
+/// Optional overrides exposed through the JSON advanced editor.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CustomAgentAdvancedOverrides {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub yolo_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub native_skills_dirs: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub behavior_policy: Option<BehaviorPolicy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Request body for `PATCH /api/agents/{id}/enabled`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetEnabledRequest {
+    pub enabled: bool,
+}
+
+/// Response body for `DELETE /api/agents/custom/{id}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeleteCustomAgentResponse {
+    pub deleted: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn advanced_silently_drops_unknown_keys() {
+        let payload = json!({
+            "yolo_id": "bypassPermissions",
+            "unknown_field": 42,
+            "another": "ignored"
+        });
+        let parsed: CustomAgentAdvancedOverrides = serde_json::from_value(payload).unwrap();
+        assert_eq!(parsed.yolo_id.as_deref(), Some("bypassPermissions"));
+        let roundtrip = serde_json::to_value(&parsed).unwrap();
+        assert!(roundtrip.get("unknown_field").is_none());
+        assert!(roundtrip.get("another").is_none());
+    }
+
+    #[test]
+    fn upsert_request_minimal_payload() {
+        let payload = json!({
+            "name": "My Agent",
+            "command": "my-cli"
+        });
+        let req: CustomAgentUpsertRequest = serde_json::from_value(payload).unwrap();
+        assert_eq!(req.name, "My Agent");
+        assert_eq!(req.command, "my-cli");
+        assert!(req.args.is_empty());
+        assert!(req.env.is_empty());
+        assert!(req.advanced.is_none());
+    }
+}

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -28,7 +28,8 @@ pub use acp::{
     AcpEnvResponse, AcpHealthCheckRequest, AcpHealthCheckResponse, AgentModeResponse, DetectCliRequest,
     DetectCliResponse, GetModelInfoResponse, ModelInfoEntry, ModelInfoPayload, ProbeModelRequest,
     SessionConfigOptionUpdate, SetConfigOptionRequest, SetConfigOptionsRequest, SetModeRequest, SetModelRequest,
-    SideQuestionRequest, SideQuestionResponse, TestCustomAgentRequest, TestCustomAgentResponse, WorkspaceBrowseQuery,
+    SideQuestionRequest, SideQuestionResponse, TryConnectCustomAgentRequest, TryConnectCustomAgentResponse,
+    WorkspaceBrowseQuery,
     WorkspaceEntry,
 };
 pub use agent_build_extra::{

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -30,8 +30,7 @@ pub use acp::{
     DetectCliResponse, GetModelInfoResponse, ModelInfoEntry, ModelInfoPayload, ProbeModelRequest,
     SessionConfigOptionUpdate, SetConfigOptionRequest, SetConfigOptionsRequest, SetModeRequest, SetModelRequest,
     SideQuestionRequest, SideQuestionResponse, TryConnectCustomAgentRequest, TryConnectCustomAgentResponse,
-    WorkspaceBrowseQuery,
-    WorkspaceEntry,
+    WorkspaceBrowseQuery, WorkspaceEntry,
 };
 pub use agent_build_extra::{
     AcpBuildExtra, AcpModelInfo, AcpSessionConfigOption, AionrsBuildExtra, OpenClawBuildExtra, OpenClawGatewayConfig,

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -9,6 +9,7 @@ mod confirmation;
 mod connection_test;
 mod conversation;
 mod cron;
+mod custom_agent;
 mod extension;
 mod file;
 mod lifecycle;
@@ -65,6 +66,9 @@ pub use cron::{
     CreateCronJobRequest, CronAgentConfigDto, CronJobExecutedEvent, CronJobMetadataDto, CronJobPayloadDto,
     CronJobRemovedPayload, CronJobResponse, CronJobStateDto, CronJobTargetDto, CronScheduleDto, HasSkillResponse,
     ListCronJobsQuery, RunNowResponse, SaveCronSkillRequest, UpdateCronJobRequest,
+};
+pub use custom_agent::{
+    CustomAgentAdvancedOverrides, CustomAgentUpsertRequest, DeleteCustomAgentResponse, SetEnabledRequest,
 };
 pub use extension::{
     DisableExtensionRequest, EnableExtensionRequest, ExtensionSummaryResponse, GetI18nRequest, GetPermissionsRequest,

--- a/crates/aionui-app/tests/acp_e2e.rs
+++ b/crates/aionui-app/tests/acp_e2e.rs
@@ -104,15 +104,22 @@ async fn test_custom_agent_nonexistent_command() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "user1", "pass123").await;
 
+    // Endpoint was renamed from /api/agents/test to /api/agents/custom/try-connect
+    // when the custom-agent CRUD routes were introduced.  The new endpoint always
+    // returns HTTP 200 and encodes failure in the JSON body (step = "fail_cli" or
+    // "fail_acp"), so we assert on the body rather than the HTTP status.
     let req = json_with_token(
         "POST",
-        "/api/agents/test",
+        "/api/agents/custom/try-connect",
         json!({ "command": "/nonexistent/path/to/agent" }),
         &token,
         &csrf,
     );
     let resp = app.oneshot(req).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = common::body_json(resp).await;
+    assert_eq!(json["success"], true);
+    assert_eq!(json["data"]["step"], "fail_cli");
 }
 
 #[tokio::test]

--- a/crates/aionui-app/tests/custom_agent_e2e.rs
+++ b/crates/aionui-app/tests/custom_agent_e2e.rs
@@ -1,0 +1,383 @@
+//! E2E integration tests for Custom Agent CRUD and try-connect endpoints.
+//!
+//! Covers:
+//!   - Create / update / delete / toggle-enable happy paths
+//!   - Empty-field validation (name, command)
+//!   - NotFound on missing id
+//!   - Forbidden when operating on a builtin id through the custom-only paths
+//!   - Test-on-save CLI-not-found rejection (runs the real probe)
+//!
+//! Gates the probe with AIONUI_BYPASS_PROBE for happy paths so CI does not
+//! need an ACP CLI installed. Unset bypass for the single test that
+//! verifies the CLI-not-found path.
+//!
+//! Thread safety: `AIONUI_BYPASS_PROBE` is a process-wide env var.  Tests
+//! that set or clear it hold `ENV_MUTEX` for their entire body so no two
+//! tests race on the var simultaneously.
+
+mod common;
+
+use std::sync::OnceLock;
+
+use tokio::sync::Mutex;
+
+use axum::http::StatusCode;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use common::{body_json, build_app, get_with_token, json_with_token, setup_and_login};
+
+// ── Global lock for env-var mutation ─────────────────────────────────────────
+//
+// Any test that reads or writes AIONUI_BYPASS_PROBE must hold this lock for
+// its entire body.  This serialises all probe-sensitive tests within a single
+// test binary regardless of how many threads `cargo test` uses.
+
+static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn env_mutex() -> &'static Mutex<()> {
+    ENV_MUTEX.get_or_init(|| Mutex::new(()))
+}
+
+/// Acquire ENV_MUTEX.  `tokio::sync::Mutex` guards are async-aware and
+/// may be held across await points without triggering clippy's
+/// `await_holding_lock` lint.
+async fn lock_env() -> tokio::sync::MutexGuard<'static, ()> {
+    env_mutex().lock().await
+}
+
+// ── Helper: create a custom agent and return (status, body) ──────────────────
+
+async fn create_agent(app: &mut axum::Router, token: &str, csrf: &str, body: Value) -> (StatusCode, Value) {
+    let req = json_with_token("POST", "/api/agents/custom", body, token, csrf);
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let json = body_json(resp).await;
+    (status, json)
+}
+
+async fn list_agents(app: &mut axum::Router, token: &str) -> Value {
+    let req = get_with_token("/api/agents", token);
+    let resp = app.clone().oneshot(req).await.unwrap();
+    body_json(resp).await
+}
+
+// ── Happy path: create → list → update → toggle → delete ─────────────────────
+
+#[tokio::test]
+async fn custom_agent_full_roundtrip() {
+    let _guard = lock_env().await;
+    // SAFETY: single env-var mutation under ENV_MUTEX; restored at function end.
+    unsafe {
+        std::env::set_var("AIONUI_BYPASS_PROBE", "1");
+    }
+
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    // Create — use "sh" so which::which resolves it and the registry marks
+    // the new row as available (list_all filters out unavailable rows).
+    let (status, json) = create_agent(
+        &mut app,
+        &token,
+        &csrf,
+        json!({
+            "name": "My Claude",
+            "command": "sh",
+            "icon": "🤖",
+            "args": ["--acp"],
+            "env": []
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["success"], true);
+    let id = json["data"]["id"].as_str().expect("id in response").to_owned();
+    assert_eq!(json["data"]["name"], "My Claude");
+    assert_eq!(json["data"]["agent_source"], "custom");
+    assert_eq!(json["data"]["icon"], "🤖");
+
+    // List — agent should be visible
+    let listed = list_agents(&mut app, &token).await;
+    let agents = listed["data"].as_array().expect("array");
+    assert!(
+        agents.iter().any(|a| a["id"] == id),
+        "newly created agent should appear in GET /api/agents"
+    );
+
+    // Update — keep "sh" so the row stays available after rehydrate.
+    let req = json_with_token(
+        "PUT",
+        &format!("/api/agents/custom/{id}"),
+        json!({
+            "name": "My Claude v2",
+            "command": "sh",
+            "icon": "🚀",
+            "args": [],
+            "env": []
+        }),
+        &token,
+        &csrf,
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["data"]["id"], id, "id must survive update");
+    assert_eq!(json["data"]["name"], "My Claude v2");
+    assert_eq!(json["data"]["icon"], "🚀");
+
+    // Toggle disabled
+    let req = json_with_token(
+        "PATCH",
+        &format!("/api/agents/{id}/enabled"),
+        json!({ "enabled": false }),
+        &token,
+        &csrf,
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["data"]["enabled"], false);
+
+    // Re-enable
+    let req = json_with_token(
+        "PATCH",
+        &format!("/api/agents/{id}/enabled"),
+        json!({ "enabled": true }),
+        &token,
+        &csrf,
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Delete
+    let req = json_with_token(
+        "DELETE",
+        &format!("/api/agents/custom/{id}"),
+        json!(null),
+        &token,
+        &csrf,
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["data"]["deleted"], true);
+
+    // Post-delete list must not contain the id
+    let listed = list_agents(&mut app, &token).await;
+    let agents = listed["data"].as_array().unwrap();
+    assert!(
+        agents.iter().all(|a| a["id"] != id),
+        "deleted agent should disappear from GET /api/agents"
+    );
+
+    unsafe {
+        std::env::remove_var("AIONUI_BYPASS_PROBE");
+    }
+}
+
+// ── Advanced overrides flow ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn custom_agent_advanced_overrides_persist() {
+    let _guard = lock_env().await;
+    unsafe {
+        std::env::set_var("AIONUI_BYPASS_PROBE", "1");
+    }
+
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let (status, json) = create_agent(
+        &mut app,
+        &token,
+        &csrf,
+        json!({
+            "name": "With Advanced",
+            "command": "sh",
+            "advanced": {
+                "yolo_id": "bypassPermissions",
+                "native_skills_dirs": [".claude/skills"],
+                "description": "test",
+                "unknown_ignored_key": 42
+            }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["data"]["yolo_id"], "bypassPermissions");
+    assert_eq!(json["data"]["native_skills_dirs"], json!([".claude/skills"]));
+    assert_eq!(json["data"]["description"], "test");
+
+    unsafe {
+        std::env::remove_var("AIONUI_BYPASS_PROBE");
+    }
+}
+
+// ── Bad path: validation ──────────────────────────────────────────────────────
+//
+// These tests exercise the validate_upsert() path which fires before the
+// probe, so they do not need AIONUI_BYPASS_PROBE and do not need the lock.
+
+#[tokio::test]
+async fn create_rejects_empty_name() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let (status, json) = create_agent(
+        &mut app,
+        &token,
+        &csrf,
+        json!({ "name": "", "command": "sh" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(json["success"], false);
+    assert!(json["error"].as_str().unwrap().to_lowercase().contains("name"));
+}
+
+#[tokio::test]
+async fn create_rejects_empty_command() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let (status, json) = create_agent(
+        &mut app,
+        &token,
+        &csrf,
+        json!({ "name": "x", "command": "   " }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(json["error"].as_str().unwrap().to_lowercase().contains("command"));
+}
+
+// ── Bad path: 404 and 403 ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn update_unknown_id_returns_404() {
+    let _guard = lock_env().await;
+    unsafe {
+        std::env::set_var("AIONUI_BYPASS_PROBE", "1");
+    }
+
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let req = json_with_token(
+        "PUT",
+        "/api/agents/custom/does-not-exist",
+        json!({ "name": "x", "command": "sh" }),
+        &token,
+        &csrf,
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    unsafe {
+        std::env::remove_var("AIONUI_BYPASS_PROBE");
+    }
+}
+
+#[tokio::test]
+async fn update_builtin_id_returns_403() {
+    let _guard = lock_env().await;
+    unsafe {
+        std::env::set_var("AIONUI_BYPASS_PROBE", "1");
+    }
+
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    // 2d23ff1c is the seeded Claude id (builtin) from migration 006.
+    let req = json_with_token(
+        "PUT",
+        "/api/agents/custom/2d23ff1c",
+        json!({ "name": "hacked", "command": "sh" }),
+        &token,
+        &csrf,
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    unsafe {
+        std::env::remove_var("AIONUI_BYPASS_PROBE");
+    }
+}
+
+#[tokio::test]
+async fn delete_builtin_id_returns_403() {
+    // delete_custom_agent checks agent_source before calling the probe,
+    // so no bypass needed here.
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let req = json_with_token(
+        "DELETE",
+        "/api/agents/custom/2d23ff1c",
+        json!(null),
+        &token,
+        &csrf,
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn set_enabled_unknown_id_returns_404() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let req = json_with_token(
+        "PATCH",
+        "/api/agents/missing-id/enabled",
+        json!({ "enabled": false }),
+        &token,
+        &csrf,
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// ── Test-on-save: CLI not found ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_on_save_cli_not_found_blocks_upsert() {
+    // Hold ENV_MUTEX to guarantee AIONUI_BYPASS_PROBE is unset for the
+    // duration of this test — no bypass-setting test can interleave.
+    let _guard = lock_env().await;
+    unsafe {
+        // Ensure clean state regardless of test ordering.
+        std::env::remove_var("AIONUI_BYPASS_PROBE");
+    }
+
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let (status, json) = create_agent(
+        &mut app,
+        &token,
+        &csrf,
+        json!({
+            "name": "bad",
+            "command": "aionui-definitely-nonexistent-xyz"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let err = json["error"].as_str().expect("error string");
+    // AppError::BadRequest is serialized as "Bad request: <msg>", so we
+    // check that the marker string appears anywhere in the error field.
+    assert!(
+        err.contains("cli_not_found:"),
+        "error must carry cli_not_found: marker, got: {err}"
+    );
+
+    // DB must not have the row.
+    let listed = list_agents(&mut app, &token).await;
+    let agents = listed["data"].as_array().unwrap();
+    assert!(
+        agents.iter().all(|a| a["name"] != "bad"),
+        "rejected create must not leave rows behind"
+    );
+}

--- a/crates/aionui-app/tests/custom_agent_e2e.rs
+++ b/crates/aionui-app/tests/custom_agent_e2e.rs
@@ -224,13 +224,7 @@ async fn create_rejects_empty_name() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let (status, json) = create_agent(
-        &mut app,
-        &token,
-        &csrf,
-        json!({ "name": "", "command": "sh" }),
-    )
-    .await;
+    let (status, json) = create_agent(&mut app, &token, &csrf, json!({ "name": "", "command": "sh" })).await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(json["success"], false);
     assert!(json["error"].as_str().unwrap().to_lowercase().contains("name"));
@@ -241,13 +235,7 @@ async fn create_rejects_empty_command() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let (status, json) = create_agent(
-        &mut app,
-        &token,
-        &csrf,
-        json!({ "name": "x", "command": "   " }),
-    )
-    .await;
+    let (status, json) = create_agent(&mut app, &token, &csrf, json!({ "name": "x", "command": "   " })).await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert!(json["error"].as_str().unwrap().to_lowercase().contains("command"));
 }
@@ -312,13 +300,7 @@ async fn delete_builtin_id_returns_403() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let req = json_with_token(
-        "DELETE",
-        "/api/agents/custom/2d23ff1c",
-        json!(null),
-        &token,
-        &csrf,
-    );
+    let req = json_with_token("DELETE", "/api/agents/custom/2d23ff1c", json!(null), &token, &csrf);
     let resp = app.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }

--- a/crates/aionui-auth/src/routes.rs
+++ b/crates/aionui-auth/src/routes.rs
@@ -711,9 +711,7 @@ async fn webui_change_username_handler(
             .map_err(|e| AppError::Internal(format!("Database error: {e}")))?;
     }
 
-    Ok(Json(ApiResponse::ok(WebuiChangeUsernameResponse {
-        username: trimmed,
-    })))
+    Ok(Json(ApiResponse::ok(WebuiChangeUsernameResponse { username: trimmed })))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aionui-db/migrations/012_agent_metadata_drop_name_unique.sql
+++ b/crates/aionui-db/migrations/012_agent_metadata_drop_name_unique.sql
@@ -1,0 +1,65 @@
+-- 012_agent_metadata_drop_name_unique.sql
+-- Drop UNIQUE(agent_source, name) to allow multiple custom agents with the
+-- same display name (PRD F-CAGENT-12: no duplicate-name validation).
+-- Uniqueness is enforced solely by PRIMARY KEY(id).
+--
+-- SQLite cannot alter constraints in place: rebuild table, copy rows, swap.
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE agent_metadata_new (
+    id                  TEXT PRIMARY KEY NOT NULL,
+    icon                TEXT,
+    name                TEXT NOT NULL,
+    name_i18n           TEXT,
+    description         TEXT,
+    description_i18n    TEXT,
+
+    backend             TEXT,
+    agent_type          TEXT NOT NULL,
+    agent_source        TEXT NOT NULL,
+    agent_source_info   TEXT,
+
+    enabled             INTEGER NOT NULL DEFAULT 1,
+
+    command             TEXT,
+    args                TEXT,
+    env                 TEXT,
+    native_skills_dirs  TEXT,
+
+    behavior_policy     TEXT,
+    yolo_id             TEXT,
+
+    agent_capabilities  TEXT,
+    auth_methods        TEXT,
+    config_options      TEXT,
+    available_modes     TEXT,
+    available_models    TEXT,
+    available_commands  TEXT,
+
+    sort_order          INTEGER NOT NULL DEFAULT 1000,
+
+    created_at          INTEGER NOT NULL,
+    updated_at          INTEGER NOT NULL
+    -- No UNIQUE(agent_source, name)
+);
+
+INSERT INTO agent_metadata_new
+SELECT id, icon, name, name_i18n, description, description_i18n,
+       backend, agent_type, agent_source, agent_source_info,
+       enabled, command, args, env, native_skills_dirs,
+       behavior_policy, yolo_id,
+       agent_capabilities, auth_methods, config_options,
+       available_modes, available_models, available_commands,
+       sort_order,
+       created_at, updated_at
+FROM agent_metadata;
+
+DROP TABLE agent_metadata;
+ALTER TABLE agent_metadata_new RENAME TO agent_metadata;
+
+CREATE INDEX IF NOT EXISTS idx_agent_metadata_backend    ON agent_metadata(backend);
+CREATE INDEX IF NOT EXISTS idx_agent_metadata_agent_type ON agent_metadata(agent_type);
+CREATE INDEX IF NOT EXISTS idx_agent_metadata_sort_order ON agent_metadata(sort_order);
+
+PRAGMA foreign_keys = ON;

--- a/crates/aionui-db/migrations/013_agent_metadata_drop_name_unique.sql
+++ b/crates/aionui-db/migrations/013_agent_metadata_drop_name_unique.sql
@@ -1,4 +1,4 @@
--- 012_agent_metadata_drop_name_unique.sql
+-- 013_agent_metadata_drop_name_unique.sql
 -- Drop UNIQUE(agent_source, name) to allow multiple custom agents with the
 -- same display name (PRD F-CAGENT-12: no duplicate-name validation).
 -- Uniqueness is enforced solely by PRIMARY KEY(id).

--- a/crates/aionui-db/src/repository/sqlite_agent_metadata.rs
+++ b/crates/aionui-db/src/repository/sqlite_agent_metadata.rs
@@ -404,14 +404,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unique_source_name_enforced() {
+    async fn same_source_same_name_allowed_with_different_ids() {
         let (repo, _db) = setup().await;
         let p1 = custom_params("custom-a", "dup");
-        let mut p2 = custom_params("custom-b", "dup");
-        p2.id = "custom-b";
-        p2.name = "dup";
+        let p2 = custom_params("custom-b", "dup");
         repo.upsert(&p1).await.unwrap();
-        let err = repo.upsert(&p2).await.expect_err("unique violation");
-        assert!(matches!(err, DbError::Query(_)));
+        repo.upsert(&p2).await.unwrap();
+        let all = repo.list_all().await.unwrap();
+        let dup_count = all.iter().filter(|r| r.name == "dup" && r.agent_source == "custom").count();
+        assert_eq!(dup_count, 2, "both rows should coexist after dropping UNIQUE(agent_source,name)");
     }
 }

--- a/crates/aionui-db/src/repository/sqlite_agent_metadata.rs
+++ b/crates/aionui-db/src/repository/sqlite_agent_metadata.rs
@@ -411,7 +411,13 @@ mod tests {
         repo.upsert(&p1).await.unwrap();
         repo.upsert(&p2).await.unwrap();
         let all = repo.list_all().await.unwrap();
-        let dup_count = all.iter().filter(|r| r.name == "dup" && r.agent_source == "custom").count();
-        assert_eq!(dup_count, 2, "both rows should coexist after dropping UNIQUE(agent_source,name)");
+        let dup_count = all
+            .iter()
+            .filter(|r| r.name == "dup" && r.agent_source == "custom")
+            .count();
+        assert_eq!(
+            dup_count, 2,
+            "both rows should coexist after dropping UNIQUE(agent_source,name)"
+        );
     }
 }

--- a/crates/aionui-runtime/src/lib.rs
+++ b/crates/aionui-runtime/src/lib.rs
@@ -11,7 +11,7 @@ mod extract;
 mod resolver;
 mod shell_env;
 
-pub use resolver::{ResolveError, bun_bin_dir, resolve_bun};
+pub use resolver::{ResolveError, bun_bin_dir, resolve_bun, resolve_command_path};
 pub use shell_env::enhance_process_path;
 mod spawn;
 pub use spawn::Builder;

--- a/crates/aionui-runtime/src/resolver.rs
+++ b/crates/aionui-runtime/src/resolver.rs
@@ -57,7 +57,7 @@ pub fn bun_bin_dir() -> Option<PathBuf> {
         .clone()
 }
 
-pub(crate) fn resolve_with<E: EmbeddedBun>(embed: &E) -> Result<PathBuf, ResolveError> {
+fn resolve_with<E: EmbeddedBun>(embed: &E) -> Result<PathBuf, ResolveError> {
     if let Some(p) = env_override() {
         return Ok(p);
     }
@@ -102,6 +102,27 @@ fn env_override() -> Option<PathBuf> {
     }
 }
 
+/// Resolve a command name to an absolute path.
+///
+/// For `bun` / `bunx` we go through `aionui_runtime` so the bundled
+/// runtime is used when present; everything else falls back to the
+/// user's `$PATH` via `which::which`.
+pub fn resolve_command_path(cmd: &str) -> Option<PathBuf> {
+    match cmd {
+        "bun" => resolve_bun().ok(),
+        "bunx" => {
+            let bunx_name = if cfg!(windows) { "bunx.exe" } else { "bunx" };
+            if let Some(dir) = bun_bin_dir() {
+                let p = dir.join(bunx_name);
+                if p.exists() {
+                    return Some(p);
+                }
+            }
+            which::which("bunx").ok()
+        }
+        other => which::which(other).ok(),
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aionui-runtime/src/spawn.rs
+++ b/crates/aionui-runtime/src/spawn.rs
@@ -3,7 +3,7 @@
 //!
 //! Two construction flavours are provided:
 //!
-//! * [`Builder::agent`] — for long-running agent CLIs whose stdio is owned
+//! * [`Builder::new`] — for long-running agent CLIs whose stdio is owned
 //!   by the caller (e.g. ACP SDK). Defaults to inherited stdio. Callers
 //!   typically override to `piped()` to capture the streams.
 //!
@@ -33,7 +33,7 @@ use tokio::process::{Child, Command};
 /// Construction mode — determines default stdio + env extras.
 #[derive(Debug, Clone, Copy)]
 enum Mode {
-    Agent,
+    Default,
     CleanCli,
 }
 
@@ -65,7 +65,7 @@ impl Builder {
         strip_pollution(&mut inner);
         Self {
             inner,
-            mode: Mode::Agent,
+            mode: Mode::Default,
         }
     }
 

--- a/justfile
+++ b/justfile
@@ -67,6 +67,7 @@ lint:
 
 lint-fix:
     cargo fix --allow-dirty --allow-staged
+    cargo clippy --fix --workspace --allow-dirty --allow-staged -- -D warnings
 
 # Format code
 fmt:


### PR DESCRIPTION
## Summary
- Adds full CRUD for user-defined custom agents plus a two-step "try-connect" probe (spawn CLI → wait for ACP handshake → report capabilities), exposed via `/api/agents/*` routes and backed by a new `service_custom` module.
- Introduces request/response types (`CustomAgentUpsertRequest`, `TryConnectCustomAgent`, etc.) in `aionui-api-types` and wires them through `aionui-ai-agent` routes/services.
- Relaxes agent metadata uniqueness: drops `UNIQUE(agent_source, name)` so users can create multiple custom agents sharing a display name (migration **013**, renumbered from 012 to avoid collision with `012_claude_behavior_policy_flags` already on main).
- Smaller touch-ups: `AgentRegistry::invalidate_and_rehydrate` + `repo_handle`, `generate_short_id` for custom agent IDs, fast-fail on probe when the CLI exits early, and agent_id overriding backend slot in ACP build extras.

## Commits
- `feat(db)`: drop `UNIQUE(agent_source, name)` on agent_metadata
- `feat(api-types)`: `CustomAgentUpsertRequest` + rename `TestCustomAgent` → `TryConnectCustomAgent`
- `feat(ai-agent)`: two-step probe, CRUD service + routes, registry invalidate_and_rehydrate
- `test(app)`: E2E for CRUD + try-connect
- `fix(ai-agent)`: fail probe fast when CLI exits early, let agent_id override backend slot
- `refactor`: short-id generator, rustfmt cleanup
- `fix(db)`: renumber migration 012 → 013 to resolve collision with main's `012_claude_behavior_policy_flags`

## Test plan
- [ ] `cargo test -p aionui-ai-agent -p aionui-api-types -p aionui-app`
- [ ] `cargo clippy --workspace -- -D warnings`
- [ ] Manual: start backend against a fresh DB, create a custom agent, try-connect, edit, delete
- [ ] Manual: start backend against an existing dev DB that already applied old migration 012 (agent_metadata_drop_name_unique) — confirm it still boots after the rename (may require manual `_sqlx_migrations` cleanup; note in release notes)