### PR TITLE
ci(release): build Linux x86_64 with cross to pin GLIBC baseline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Linux targets use `cross` so the resulting binary links against the
+          # older GLIBC baked into the cross docker image (currently GLIBC 2.31,
+          # manylinux_2_31 equivalent) instead of whatever GLIBC happens to be
+          # on the GitHub Actions runner. This keeps the release binaries
+          # compatible with Debian 11+/Ubuntu 20.04+/RHEL 9 users regardless of
+          # whether `ubuntu-latest` points at 22.04 or 24.04.
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary_name: aionui-backend
+            use_cross: true
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             binary_name: aionui-backend
@@ -93,7 +100,7 @@ jobs:
         with:
           shared-key: release-${{ matrix.target }}
 
-      - name: Install cross (Linux aarch64)
+      - name: Install cross (Linux targets)
         if: matrix.use_cross == true
         run: cargo install cross --git https://github.com/cross-rs/cross
 


### PR DESCRIPTION
Closes #212

## Summary

Add ``use_cross: true`` to the ``x86_64-unknown-linux-gnu`` matrix entry in ``release.yml``, mirroring aarch64. This moves the x86_64 build into the ``cross-rs/cross`` docker image (manylinux_2_31 baseline, GLIBC 2.31) and decouples the released binary's GLIBC requirement from whatever version ``ubuntu-latest`` happens to ship.

## Why

``ubuntu-latest`` is currently Ubuntu 24.04 (GLIBC 2.39). A native x86_64 build there links against symbols that don't exist on users running Debian 12 (GLIBC 2.36), Ubuntu 22.04 (2.35), RHEL 9 / CentOS Stream 9, or any distribution older than ~2024. AionUi's smoke-test-web-cli job (which runs in ``debian:bookworm-slim``) caught this in [run 25614335921](https://github.com/iOfficeAI/AionUi/actions/runs/25614335921):

\`\`\`
aionui-backend: /lib/x86_64-linux-gnu/libc.so.6: version \`GLIBC_2.38' not found
\`\`\`

``aarch64`` already uses ``cross`` and was unaffected.

## Test plan

- [ ] PR CI green (no matrix job produces a GLIBC-bound binary)
- [ ] After merge + new tag cut, download the x86_64 tarball and run ``./aionui-backend --app-version 0.0.0`` inside ``debian:bookworm-slim``: should exit 0
- [ ] AionUi ``Smoke test web-cli tarball (Linux x86_64)`` job should pass against the new release