### PR TITLE
ci(release): isolate cargo cache between native and cross builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,10 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: release-${{ matrix.target }}
+          # Cross vs native builds must never share a cache — proc-macro .so
+          # files are produced for the host GLIBC and break when the linker
+          # switches to the (older) GLIBC in the cross docker image.
+          shared-key: release-${{ matrix.target }}${{ matrix.use_cross == true && '-cross' || '' }}
 
       - name: Install cross (Linux targets)
         if: matrix.use_cross == true


### PR DESCRIPTION
## Summary

Add a ``-cross`` suffix to ``Swatinem/rust-cache``'s ``shared-key`` when ``use_cross: true``. Native and cross builds must never share a cache because proc-macro shared objects produced by the native runner's toolchain link against the runner's GLIBC (currently 2.33+), and they fail to load inside the cross docker image which has an older GLIBC (typically 2.17).

## Why

After #213 switched ``x86_64-unknown-linux-gnu`` from native to ``use_cross: true``, the first cross build reused the previous native cache and died:

\`\`\`
error: /target/release/deps/libserde_derive-*.so: /lib/x86_64-linux-gnu/libc.so.6: version \`GLIBC_2.33' not found
\`\`\`

See the failing [release run 25619056310](https://github.com/iOfficeAI/aionui-backend/actions/runs/25619056310) for ``v0.1.0-preview-test2`` (which did not produce a Release).

## Test plan

After merge, retag (delete + recreate) ``v0.1.0-preview-test2`` and re-dispatch ``release.yml``. All 6 matrix jobs (including x86_64-unknown-linux-gnu with cross) should succeed and the release should publish all assets.