### PR TITLE
ci(release): build Linux x86_64 natively on ubuntu-22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,16 +53,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux targets use `cross` so the resulting binary links against the
-          # older GLIBC baked into the cross docker image (currently GLIBC 2.31,
-          # manylinux_2_31 equivalent) instead of whatever GLIBC happens to be
-          # on the GitHub Actions runner. This keeps the release binaries
-          # compatible with Debian 11+/Ubuntu 20.04+/RHEL 9 users regardless of
-          # whether `ubuntu-latest` points at 22.04 or 24.04.
-          - os: ubuntu-latest
+          # Linux x86_64: build natively on ubuntu-22.04 (GLIBC 2.35) so the
+          # release binary runs on Debian 12 / Ubuntu 22.04+ / RHEL 9 /
+          # CentOS Stream 9. We cannot use `cross` here because the default
+          # cross docker image ships a gcc that aws-lc-sys's memcmp safety
+          # check rejects. Pinning the runner is simpler and covers the
+          # target audience — Debian 11 (GLIBC 2.31) is entering ELTS so we
+          # deliberately drop it.
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             binary_name: aionui-backend
-            use_cross: true
+          # Linux aarch64: keep `cross` (its image happens to not trip the
+          # aws-lc-sys check and also yields an older GLIBC baseline).
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             binary_name: aionui-backend


### PR DESCRIPTION
## Summary

Revert Linux x86_64 to a native build, but pin the runner to ``ubuntu-22.04`` (GLIBC 2.35) instead of ``ubuntu-latest`` (currently Ubuntu 24.04 / GLIBC 2.39). Keep ``aarch64`` on ``cross``.

## Why

#213 tried ``use_cross: true`` for x86_64. The default cross docker image (``ghcr.io/cross-rs/x86_64-unknown-linux-gnu``) ships a gcc that ``aws-lc-sys`` 0.40 rejects via a hard-coded compiler-bug panic:

\`\`\`
thread 'main' panicked at aws-lc-sys-0.40.0/builder/cc_builder.rs:
  ### COMPILER BUG DETECTED ###
  Your compiler (cc) is not supported due to a memcmp related bug
  reported in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189.
\`\`\`

See failed run [25619115514](https://github.com/iOfficeAI/aionui-backend/actions/runs/25619115514).

``aarch64`` doesn't hit this (its cross image happens to have an acceptable gcc), so it stays on ``cross``.

## Coverage tradeoff

Pinning x86_64 to ``ubuntu-22.04`` gives GLIBC 2.35 baseline. This covers:

- Debian 12+ (GLIBC 2.36) ✅
- Ubuntu 22.04+ (2.35) ✅
- RHEL 9 / CentOS Stream 9 (2.34) ✅
- Fedora 36+ ✅

Explicitly **drops** Debian 11 (GLIBC 2.31), which is in its ELTS period anyway.

## Test plan

- [ ] After merge, retag ``v0.1.0-preview-test2`` at the new main HEAD and redispatch ``release.yml``
- [ ] All 6 matrix jobs green, release published with 7 assets (6 archives + checksums)
- [ ] Downloading x86_64 tarball + running ``aionui-backend --app-version 0.0.0`` inside ``debian:bookworm-slim`` exits 0