### PR TITLE
ci(release): include runner OS in cargo cache key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,10 +100,13 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          # Cross vs native builds must never share a cache — proc-macro .so
-          # files are produced for the host GLIBC and break when the linker
-          # switches to the (older) GLIBC in the cross docker image.
-          shared-key: release-${{ matrix.target }}${{ matrix.use_cross == true && '-cross' || '' }}
+          # Include runner OS image and use_cross flag in the cache key.
+          # Proc-macro .so files link against the host GLIBC, so switching
+          # the runner (ubuntu-24.04 ↔ 22.04) or flipping native ↔ cross
+          # must fall into a different cache bucket — otherwise the cached
+          # .so is loaded against an incompatible GLIBC and cargo panics
+          # with "can't find crate" / "GLIBC_* not found" errors.
+          shared-key: release-${{ matrix.target }}-${{ matrix.os }}${{ matrix.use_cross == true && '-cross' || '' }}
 
       - name: Install cross (Linux targets)
         if: matrix.use_cross == true


### PR DESCRIPTION
## Summary

Add ``matrix.os`` to ``Swatinem/rust-cache``'s ``shared-key`` so cache buckets are isolated per runner image.

## Why

During the #215 rollout we had to clear caches manually twice because switching ``ubuntu-latest`` ↔ ``ubuntu-22.04`` (or flipping ``use_cross``) reused stale proc-macro ``.so`` files. Proc-macro .so artifacts link against the host's GLIBC, so a cached .so from a newer runner image crashes inside an older runner with either:

\`\`\`
error: .../libserde_derive-*.so: /lib/x86_64-linux-gnu/libc.so.6: version \`GLIBC_2.33' not found
\`\`\`

or later surfaces as ``error[E0463]: can't find crate for \`sqlx\````.

Adding ``matrix.os`` to the key (on top of ``matrix.target`` and the cross flag) makes this class of issue impossible.

## Test plan

- [ ] CI green — builds may be fully cold since cache keys change, but each target should still complete successfully
- [ ] Subsequent release runs warm up cleanly in the new buckets