### PR TITLE
fix(runtime): upgrade bundled bun from 1.1.38 to 1.3.13 (fixes ACP adapter spawn)

### DIFF
--- a/crates/aionui-runtime/Cargo.toml
+++ b/crates/aionui-runtime/Cargo.toml
@@ -4,7 +4,11 @@ version.workspace = true
 edition.workspace = true
 
 [package.metadata.aionui-runtime]
-bun_version = "1.1.38"
+# 1.3.x required: 1.1.38 has a stdin-buffering bug in `bun x --bun` that
+# prevents AionUi's ACP adapter (long-lived stdio protocol) from ever
+# receiving the initialize request — see aionui-backend fix notes for
+# AionUi#2828. If bumping, keep >= 1.3.13.
+bun_version = "1.3.13"
 
 [dependencies]
 thiserror.workspace = true


### PR DESCRIPTION
Closes #217

## Summary

Bump the bundled bun runtime from 1.1.38 → 1.3.13 in \`\`crates/aionui-runtime/Cargo.toml\`\`. Fixes the Claude ACP adapter handshake that has been failing with \`\`Initialize handshake timed out after 30s\`\`.

## Root cause (see #217 for full repro)

\`\`bun 1.1.38\`\`'s \`\`bun x --bun <package>\`\` has a stdin-buffering bug: data that the parent writes to stdin **before** bun \`\`exec\`\`s into the adapter's node entrypoint gets buffered by bun and is **not flushed** unless the parent closes stdin (EOF).

ACP (and MCP / LSP) are long-lived stdio protocols — the parent keeps stdin open for the session's lifetime. So the Claude adapter never sees the \`\`initialize\`\` message and times out. Codex is unaffected because it's a native binary spawn, not a bun-wrapped node script.

## Verified

Minimal Rust + \`\`tokio::process::Command\`\` reproducer:

| bun version | close stdin? | result |
|---|---|---|
| 1.1.38 | no (protocol mode) | ❌ adapter never responds, 30s timeout |
| 1.1.38 | yes (write once + drop) | ✅ responds in ~1s (incorrect semantics but proves the bug) |
| 1.3.13 | no (protocol mode) | ✅ responds in ~1s |

End-to-end verification requires AionUi to pick up a new backend release; deferred until this PR merges and a new \`\`aionui-backend\`\` tag publishes.

## Test plan

- [ ] CI green (Clippy / Test / Format)
- [ ] After merge + new tag, AionUi picks up the new backend via \`\`package.json#aionuiBackendVersion\`\` and Claude chat works end-to-end in the \`\`aionui-web\`\` tarball