### PR TITLE
fix(provider): allow empty base_url in update for bedrock

### DIFF
--- a/crates/aionui-system/src/provider.rs
+++ b/crates/aionui-system/src/provider.rs
@@ -240,7 +240,9 @@ fn validate_update_request(req: &UpdateProviderRequest) -> Result<(), AppError> 
     {
         return Err(AppError::BadRequest("name cannot be empty".into()));
     }
-    if let Some(ref url) = req.base_url {
+    if let Some(ref url) = req.base_url
+        && !url.trim().is_empty()
+    {
         validate_base_url(url)?;
     }
     Ok(())
@@ -424,6 +426,24 @@ mod tests {
     #[test]
     fn validate_update_empty_request_ok() {
         assert!(validate_update_request(&UpdateProviderRequest::default()).is_ok());
+    }
+
+    #[test]
+    fn validate_update_empty_base_url_ok() {
+        let req = UpdateProviderRequest {
+            base_url: Some("".into()),
+            ..Default::default()
+        };
+        assert!(validate_update_request(&req).is_ok());
+    }
+
+    #[test]
+    fn validate_update_invalid_base_url_rejected() {
+        let req = UpdateProviderRequest {
+            base_url: Some("not-a-url".into()),
+            ..Default::default()
+        };
+        assert!(validate_update_request(&req).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Bedrock providers have an empty `base_url` by design (they auth via `bedrock_config`). The create path already allowed this, but `validate_update_request` was rejecting empty `base_url` on update, causing all modification operations (add model, delete model, toggle enable) on bedrock providers to fail with 400.
- Skip `base_url` format validation when the value is an empty string.
- Added two unit tests covering the fix.

## Test plan

- [x] `cargo test -p aionui-system` passes (144 tests)
- [x] `cargo clippy -p aionui-system -- -D warnings` clean
- [ ] Manual: add a model to AWS Bedrock provider → no longer returns 400
- [ ] Manual: toggle enable/disable on bedrock models → works