### PR TITLE
fix(mcp): fix OpenAI schema rejection for no-arg team-guide tools

### DIFF
--- a/crates/aionui-app/src/guide_stdio.rs
+++ b/crates/aionui-app/src/guide_stdio.rs
@@ -165,7 +165,6 @@ struct TaskUpdateParams {
     blocked_by: Option<Vec<String>>,
 }
 
-
 #[derive(Deserialize, schemars::JsonSchema)]
 struct RenameAgentParams {
     /// Slot ID of the team member to rename.

--- a/crates/aionui-app/src/guide_stdio.rs
+++ b/crates/aionui-app/src/guide_stdio.rs
@@ -165,11 +165,6 @@ struct TaskUpdateParams {
     blocked_by: Option<Vec<String>>,
 }
 
-#[derive(Deserialize, schemars::JsonSchema)]
-struct TaskListParams {}
-
-#[derive(Deserialize, schemars::JsonSchema)]
-struct MembersParams {}
 
 #[derive(Deserialize, schemars::JsonSchema)]
 struct RenameAgentParams {
@@ -307,7 +302,7 @@ impl GuideServer {
     }
 
     #[tool(name = "team_task_list", description = "List all tasks on the team task board.")]
-    async fn team_task_list(&self, Parameters(_params): Parameters<TaskListParams>) -> String {
+    async fn team_task_list(&self) -> String {
         eprintln!("[mcp-guide-stdio] tools/call: team_task_list");
         self.forward_tool("team_task_list", &serde_json::json!({})).await
     }
@@ -316,7 +311,7 @@ impl GuideServer {
         name = "team_members",
         description = "List all team members with their roles and current status."
     )]
-    async fn team_members(&self, Parameters(_params): Parameters<MembersParams>) -> String {
+    async fn team_members(&self) -> String {
         eprintln!("[mcp-guide-stdio] tools/call: team_members");
         self.forward_tool("team_members", &serde_json::json!({})).await
     }
@@ -379,6 +374,26 @@ impl GuideServer {
             }),
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_tool_schemas_have_properties_field() {
+        let router = GuideServer::tool_router();
+        let tools = router.list_all();
+        assert!(!tools.is_empty());
+        for tool in &tools {
+            assert!(
+                tool.input_schema.contains_key("properties"),
+                "Tool '{}' schema missing 'properties' field: {:?}. OpenAI API rejects schemas without it.",
+                tool.name,
+                tool.input_schema,
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Remove empty `MembersParams` and `TaskListParams` structs from `guide_stdio.rs`
- Drop `Parameters<T>` wrapper from `team_members` and `team_task_list` methods so rmcp uses its built-in `schema_for_empty_input()` (which includes `"properties": {}`)
- Add regression test `all_tool_schemas_have_properties_field` to prevent future violations

## Root Cause

OpenAI API requires all function tool schemas to include a `"properties"` field. `schemars` generates `{"type": "object"}` (without properties) for empty structs, causing:

```
API error 400: Invalid schema for function 'team_members': 
In context=(), object schema missing properties.
```

## Test plan

- [x] `cargo test -p aionui-app --lib all_tool_schemas` passes
- [x] `cargo clippy --workspace` passes
- [x] `cargo test --workspace` passes (via `just push`)
- [ ] Manual: send message in conversation using GPT model with team-guide MCP injected — should no longer get 400 error