### PR TITLE
fix(aionrs): pass bedrock credentials from DB to aion-agent config

### DIFF
--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -78,6 +78,12 @@ pub(super) async fn build(
 
     let (base_url, compat_overrides) = resolve_aionrs_url_and_compat(&row.platform, &row.base_url, &provider);
 
+    let bedrock_config = if row.platform == "bedrock" {
+        resolve_bedrock_config(row.bedrock_config.as_deref())
+    } else {
+        None
+    };
+
     let session_directory = deps.data_dir.join("aionrs-sessions");
 
     let resume_session = {
@@ -115,6 +121,7 @@ pub(super) async fn build(
         session_directory,
         session_mode: overrides.session_mode,
         extra_mcp_servers,
+        bedrock_config,
     };
 
     let agent = AionrsAgentManager::new(ctx.conversation_id, ctx.workspace, config, resume_session).await?;
@@ -189,6 +196,17 @@ fn is_openai_host(url: &str) -> bool {
 fn normalize_aionrs_base_url(url: &str) -> String {
     let trimmed = url.trim_end_matches('/');
     trimmed.strip_suffix("/v1").unwrap_or(trimmed).to_owned()
+}
+
+fn resolve_bedrock_config(json: Option<&str>) -> Option<aion_config::config::BedrockConfig> {
+    let bc: aionui_api_types::BedrockConfig = serde_json::from_str(json?).ok()?;
+    Some(aion_config::config::BedrockConfig {
+        region: Some(bc.region),
+        access_key_id: bc.access_key_id,
+        secret_access_key: bc.secret_access_key,
+        session_token: None,
+        profile: bc.profile,
+    })
 }
 
 fn resolve_mcp_servers(overrides: &AionrsBuildExtra, conversation_id: &str) -> HashMap<String, McpServerConfig> {
@@ -468,5 +486,36 @@ mod tests {
 
         let result = resolve_mcp_servers(&overrides, "conv-5");
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn resolve_bedrock_config_access_key() {
+        let json = r#"{"auth_method":"accessKey","region":"us-west-2","access_key_id":"AKIA123","secret_access_key":"secret456"}"#;
+        let result = resolve_bedrock_config(Some(json)).unwrap();
+        assert_eq!(result.region.as_deref(), Some("us-west-2"));
+        assert_eq!(result.access_key_id.as_deref(), Some("AKIA123"));
+        assert_eq!(result.secret_access_key.as_deref(), Some("secret456"));
+        assert!(result.profile.is_none());
+        assert!(result.session_token.is_none());
+    }
+
+    #[test]
+    fn resolve_bedrock_config_profile() {
+        let json = r#"{"auth_method":"profile","region":"eu-west-1","profile":"my-profile"}"#;
+        let result = resolve_bedrock_config(Some(json)).unwrap();
+        assert_eq!(result.region.as_deref(), Some("eu-west-1"));
+        assert_eq!(result.profile.as_deref(), Some("my-profile"));
+        assert!(result.access_key_id.is_none());
+        assert!(result.secret_access_key.is_none());
+    }
+
+    #[test]
+    fn resolve_bedrock_config_none_when_json_missing() {
+        assert!(resolve_bedrock_config(None).is_none());
+    }
+
+    #[test]
+    fn resolve_bedrock_config_none_when_json_invalid() {
+        assert!(resolve_bedrock_config(Some("not-json")).is_none());
     }
 }

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -72,6 +72,7 @@ impl AionrsAgentManager {
             Config::resolve(&cli_args).map_err(|e| AppError::Internal(format!("Config resolve failed: {e}")))?;
 
         // Backend-specific overrides
+        config.bedrock = config_extra.bedrock_config;
         config.session.enabled = true;
         config.session.directory = config_extra.session_directory.to_string_lossy().into_owned();
 
@@ -332,6 +333,7 @@ mod tests {
             session_directory: std::env::temp_dir().join("aionrs-test-sessions"),
             session_mode: None,
             extra_mcp_servers: std::collections::HashMap::new(),
+            bedrock_config: None,
         }
     }
 

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -68,6 +68,8 @@ pub struct AionrsResolvedConfig {
     pub session_mode: Option<String>,
     /// Extra MCP servers to inject (team coordination or guide).
     pub extra_mcp_servers: HashMap<String, aion_config::config::McpServerConfig>,
+    /// AWS Bedrock credentials (region + access key or profile).
+    pub bedrock_config: Option<aion_config::config::BedrockConfig>,
 }
 
 #[cfg(test)]

--- a/crates/aionui-ai-agent/tests/agent_types_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_types_integration.rs
@@ -101,6 +101,7 @@ fn make_aionrs_config() -> AionrsResolvedConfig {
         session_directory: std::env::temp_dir().join("aionrs-test-sessions"),
         session_mode: None,
         extra_mcp_servers: Default::default(),
+        bedrock_config: None,
     }
 }
 


### PR DESCRIPTION
## Summary
- Bedrock provider's AWS credentials (region, access_key_id, secret_access_key, or profile) were not being passed from the database to the aionrs agent engine, causing "the credential provider was not enabled" errors
- Extract `resolve_bedrock_config()` helper to convert `aionui_api_types::BedrockConfig` JSON → `aion_config::config::BedrockConfig`, and inject it into `Config.bedrock` after `Config::resolve()`
- Other provider types (anthropic, openai, vertex) are unaffected — they already work correctly via `api_key` + `base_url`

## Test plan
- [x] Unit tests for `resolve_bedrock_config` (access_key, profile, None, invalid JSON)
- [x] All 5436 workspace tests pass
- [ ] Manual verification: create a Bedrock provider in settings, send message via aionrs — should no longer error