### PR TITLE
fix(auth): return 401 for login against empty password_hash

### DIFF
--- a/crates/aionui-auth/src/routes.rs
+++ b/crates/aionui-auth/src/routes.rs
@@ -218,6 +218,13 @@ async fn login_handler(
         .map_err(|e| AppError::Internal(format!("Database error: {e}")))?;
 
     let (found_user, password_valid) = match user {
+        Some(u) if u.password_hash.trim().is_empty() => {
+            // Seeded user with no password yet (first-run local mode).
+            // Treat as invalid credentials; run dummy verify for timing symmetry
+            // and to avoid bcrypt error on empty hash leaking as a 500.
+            let _ = verify_password_timed(&req.password, dummy_password_hash()).await;
+            (None, false)
+        }
         Some(u) => {
             let valid = verify_password_timed(&req.password, &u.password_hash).await?;
             (Some(u), valid)

--- a/crates/aionui-auth/tests/route_tests.rs
+++ b/crates/aionui-auth/tests/route_tests.rs
@@ -213,6 +213,21 @@ async fn t4_4_login_missing_fields() {
 }
 
 #[tokio::test]
+async fn t4_5_login_empty_password_hash_returns_401() {
+    // Regression: when the seeded system user has an empty password_hash
+    // (first-run local mode), POST /login must return 401, not 500.
+    let (app, _ctx) = test_app_with_local(true).await;
+
+    let req = json_post("/login", r#"{"username":"admin","password":"anything"}"#);
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], false);
+    assert_eq!(json["code"], "UNAUTHORIZED");
+}
+
+#[tokio::test]
 async fn t4_6_login_username_too_long() {
     let (app, _ctx) = test_app().await;
 


### PR DESCRIPTION
## Summary

Fixes #224.

On first run, `aionui-web` launches the backend in `--local` mode. The DB seeds `system_default_user` with `password_hash = ""` as the "needs setup" signal. When the webui POSTs `/login` in that state, bcrypt chokes on the empty hash and the handler returns **500** instead of **401**.

This patch adds a guard in `login_handler`: if the looked-up user has an empty password_hash, run the dummy verify (for timing symmetry) and fall through to the existing 401 path. Same behavior as "user not found".

## Diff

- `crates/aionui-auth/src/routes.rs` — 7-line guard added to the user-match arm.
- `crates/aionui-auth/tests/route_tests.rs` — new regression test `t4_5_login_empty_password_hash_returns_401` asserts 401 + `code = "UNAUTHORIZED"` for the seeded-admin / empty-hash path (uses `local = true`).

## Test plan

- [x] `cargo test -p aionui-auth` — all 35 route tests pass, including the new one
- [x] `cargo fmt --check`
- [x] `cargo clippy -p aionui-auth --tests` — clean