### PR TITLE
fix(aionrs): merge preset_rules into system_prompt for preset assistants

### DIFF
--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -23,6 +23,16 @@ pub(super) async fn build(
 ) -> Result<AgentInstance, AppError> {
     let mut overrides: AionrsBuildExtra = serde_json::from_value(options.extra).unwrap_or_default();
 
+    // Merge preset assistant rules into system_prompt (used as custom_prompt
+    // in aionrs's build_system_prompt). Mirrors the old architecture's
+    // `init_history` injection of `[Assistant System Rules]`.
+    if let Some(rules) = overrides.preset_rules.take() {
+        overrides.system_prompt = Some(match overrides.system_prompt.take() {
+            Some(existing) => format!("{existing}\n\n{rules}"),
+            None => rules,
+        });
+    }
+
     // Inject Guide MCP config for solo (non-team) sessions, mirroring acp.rs:39-55.
     if overrides.team_mcp_stdio_config.is_none()
         && overrides.guide_mcp_config.is_none()
@@ -517,5 +527,64 @@ mod tests {
     #[test]
     fn resolve_bedrock_config_none_when_json_invalid() {
         assert!(resolve_bedrock_config(Some("not-json")).is_none());
+    }
+
+    #[test]
+    fn preset_rules_merged_into_system_prompt_when_no_existing() {
+        let json = serde_json::json!({
+            "preset_rules": "You are a data analyst. Always use Python.",
+        });
+        let mut overrides: AionrsBuildExtra = serde_json::from_value(json).unwrap();
+
+        if let Some(rules) = overrides.preset_rules.take() {
+            overrides.system_prompt = Some(match overrides.system_prompt.take() {
+                Some(existing) => format!("{existing}\n\n{rules}"),
+                None => rules,
+            });
+        }
+
+        assert_eq!(
+            overrides.system_prompt.as_deref(),
+            Some("You are a data analyst. Always use Python.")
+        );
+        assert!(overrides.preset_rules.is_none());
+    }
+
+    #[test]
+    fn preset_rules_appended_to_existing_system_prompt() {
+        let json = serde_json::json!({
+            "system_prompt": "Be concise.",
+            "preset_rules": "You are a data analyst.",
+        });
+        let mut overrides: AionrsBuildExtra = serde_json::from_value(json).unwrap();
+
+        if let Some(rules) = overrides.preset_rules.take() {
+            overrides.system_prompt = Some(match overrides.system_prompt.take() {
+                Some(existing) => format!("{existing}\n\n{rules}"),
+                None => rules,
+            });
+        }
+
+        assert_eq!(
+            overrides.system_prompt.as_deref(),
+            Some("Be concise.\n\nYou are a data analyst.")
+        );
+    }
+
+    #[test]
+    fn no_preset_rules_leaves_system_prompt_unchanged() {
+        let json = serde_json::json!({
+            "system_prompt": "Be concise.",
+        });
+        let mut overrides: AionrsBuildExtra = serde_json::from_value(json).unwrap();
+
+        if let Some(rules) = overrides.preset_rules.take() {
+            overrides.system_prompt = Some(match overrides.system_prompt.take() {
+                Some(existing) => format!("{existing}\n\n{rules}"),
+                None => rules,
+            });
+        }
+
+        assert_eq!(overrides.system_prompt.as_deref(), Some("Be concise."));
     }
 }

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -216,6 +216,7 @@ mod tests {
         let json = json!({});
         let extra: AionrsBuildExtra = serde_json::from_value(json).unwrap();
         assert!(extra.system_prompt.is_none());
+        assert!(extra.preset_rules.is_none());
         assert_eq!(extra.max_tokens, 8192);
         assert!(extra.max_turns.is_none());
     }
@@ -231,5 +232,16 @@ mod tests {
         assert_eq!(extra.system_prompt.unwrap(), "You are a helpful assistant.");
         assert_eq!(extra.max_tokens, 4096);
         assert_eq!(extra.max_turns.unwrap(), 10);
+    }
+
+    #[test]
+    fn aionrs_build_extra_serde_with_preset_rules() {
+        let json = json!({
+            "preset_rules": "You are a data analyst.",
+            "max_tokens": 8192
+        });
+        let extra: AionrsBuildExtra = serde_json::from_value(json).unwrap();
+        assert!(extra.system_prompt.is_none());
+        assert_eq!(extra.preset_rules.unwrap(), "You are a data analyst.");
     }
 }

--- a/crates/aionui-api-types/src/agent_build_extra.rs
+++ b/crates/aionui-api-types/src/agent_build_extra.rs
@@ -75,6 +75,8 @@ pub struct RemoteBuildExtra {
 pub struct AionrsBuildExtra {
     #[serde(default)]
     pub system_prompt: Option<String>,
+    #[serde(default)]
+    pub preset_rules: Option<String>,
     #[serde(default = "default_aionrs_max_tokens")]
     pub max_tokens: u32,
     #[serde(default)]


### PR DESCRIPTION
## Summary

- Fix preset assistant rules being silently discarded when creating aionrs conversations in the new frontend-backend separated architecture
- The new frontend sends rules as `extra.preset_rules`, but `AionrsBuildExtra` lacked this field — serde silently ignored it
- Add `preset_rules` field to `AionrsBuildExtra` and merge it into `system_prompt` in the aionrs factory before guide-prompt injection

## Context

In the old monolithic architecture, preset rules were injected via `init_history` protocol command as conversation context. In the new backend (which embeds `aion-agent` as a library), the equivalent injection point is `system_prompt` which feeds into `build_system_prompt()` as `custom_prompt`.

## Test plan

- [x] Unit test: `preset_rules` deserialized correctly from JSON
- [x] Unit test: `preset_rules` merged into empty `system_prompt`
- [x] Unit test: `preset_rules` appended to existing `system_prompt`
- [x] Unit test: absent `preset_rules` leaves `system_prompt` unchanged
- [x] All 5444 workspace tests pass
- [x] Clippy clean, fmt clean