### PR TITLE
fix(team): force-stop agents on team delete, fix DashMap deadlock

### DIFF
--- a/crates/aionui-ai-agent/src/agent_task.rs
+++ b/crates/aionui-ai-agent/src/agent_task.rs
@@ -207,6 +207,23 @@ impl AgentInstance {
         self.as_task().kill(reason)
     }
 
+    /// Terminate the agent process and return a future that resolves when the
+    /// underlying OS process has exited.
+    pub fn kill_and_wait(
+        &self,
+        reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        match self {
+            Self::Acp(m) => m.kill_and_wait(reason),
+            Self::OpenClaw(m) => m.kill_and_wait(reason),
+            Self::Nanobot(m) => m.kill_and_wait(reason),
+            Self::Aionrs(m) => m.kill_and_wait(reason),
+            Self::Remote(m) => m.kill_and_wait(reason),
+            #[cfg(any(test, feature = "test-support"))]
+            Self::Mock(_) => Box::pin(std::future::ready(())),
+        }
+    }
+
     // ── Cross-variant semi-specific helpers ──────────────────────────
     //
     // These fan out to inherent methods on concrete managers. Variants

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -602,6 +602,18 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
 }
 
 impl AcpAgentManager {
+    pub fn kill_and_wait(
+        &self,
+        reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        let _ = crate::agent_task::IAgentTask::kill(self, reason);
+        let process = Arc::clone(&self.process);
+        let grace = Duration::from_millis(ACP_KILL_GRACE_MS);
+        Box::pin(async move {
+            let _ = process.kill(grace).await;
+        })
+    }
+
     /// Submit a permission response for a pending tool call. ACP confirms
     /// always carry an `option_id`; `always_allow` is consumed by the CLI
     /// and is not reflected in the local approval memory (the ACP CLI

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -241,6 +241,16 @@ impl crate::agent_task::IAgentTask for AionrsAgentManager {
     }
 }
 
+impl AionrsAgentManager {
+    pub fn kill_and_wait(
+        &self,
+        reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        let _ = crate::agent_task::IAgentTask::kill(self, reason);
+        Box::pin(std::future::ready(()))
+    }
+}
+
 /// Aionrs-specific operations reached through `AgentInstance::Aionrs(..)`
 /// matches in the routes + services.
 impl AionrsAgentManager {

--- a/crates/aionui-ai-agent/src/manager/nanobot/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/nanobot/agent.rs
@@ -217,6 +217,20 @@ impl crate::agent_task::IAgentTask for NanobotAgentManager {
     }
 }
 
+impl NanobotAgentManager {
+    pub fn kill_and_wait(
+        &self,
+        reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        let _ = crate::agent_task::IAgentTask::kill(self, reason);
+        let process = Arc::clone(&self.process);
+        let grace = Duration::from_millis(NANOBOT_KILL_GRACE_MS);
+        Box::pin(async move {
+            let _ = process.kill(grace).await;
+        })
+    }
+}
+
 /// Nanobot-specific operations reached through `AgentInstance::Nanobot(..)`.
 /// Nanobot does not track tool confirmations or approval memory, so these
 /// are trivial stubs matching the semantics of the removed `IAgentManager`

--- a/crates/aionui-ai-agent/src/manager/openclaw/agent/mod.rs
+++ b/crates/aionui-ai-agent/src/manager/openclaw/agent/mod.rs
@@ -487,3 +487,21 @@ impl crate::agent_task::IAgentTask for OpenClawAgentManager {
         Ok(())
     }
 }
+
+impl OpenClawAgentManager {
+    pub fn kill_and_wait(
+        &self,
+        reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        let _ = crate::agent_task::IAgentTask::kill(self, reason);
+        if let Some(ref process) = self.gateway_process {
+            let process = Arc::clone(process);
+            let grace = Duration::from_millis(OPENCLAW_KILL_GRACE_MS);
+            Box::pin(async move {
+                let _ = process.kill(grace).await;
+            })
+        } else {
+            Box::pin(std::future::ready(()))
+        }
+    }
+}

--- a/crates/aionui-ai-agent/src/manager/remote/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/remote/agent.rs
@@ -342,6 +342,16 @@ impl crate::agent_task::IAgentTask for RemoteAgentManager {
     }
 }
 
+impl RemoteAgentManager {
+    pub fn kill_and_wait(
+        &self,
+        reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        let _ = crate::agent_task::IAgentTask::kill(self, reason);
+        Box::pin(std::future::ready(()))
+    }
+}
+
 /// Remote-specific operations reached through `AgentInstance::Remote(..)`.
 impl RemoteAgentManager {
     pub fn confirm(&self, _msg_id: &str, call_id: &str, _data: Value, always_allow: bool) -> Result<(), AppError> {

--- a/crates/aionui-ai-agent/src/task_manager.rs
+++ b/crates/aionui-ai-agent/src/task_manager.rs
@@ -44,6 +44,13 @@ pub trait IWorkerTaskManager: Send + Sync {
     /// Kill and remove a task.
     fn kill(&self, conversation_id: &str, reason: Option<AgentKillReason>) -> Result<(), AppError>;
 
+    /// Kill a task and return a future that resolves when the process has terminated.
+    fn kill_and_wait(
+        &self,
+        conversation_id: &str,
+        reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>;
+
     /// Kill and remove all active tasks.
     fn clear(&self);
 
@@ -122,6 +129,20 @@ impl IWorkerTaskManager for WorkerTaskManagerImpl {
             }
         }
         Ok(())
+    }
+
+    fn kill_and_wait(
+        &self,
+        conversation_id: &str,
+        reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        if let Some((id, slot)) = self.tasks.remove(conversation_id) {
+            info!(conversation_id = %id, ?reason, "Killing agent task (awaitable)");
+            if let Some(agent) = slot.get() {
+                return agent.kill_and_wait(reason);
+            }
+        }
+        Box::pin(std::future::ready(()))
     }
 
     fn clear(&self) {

--- a/crates/aionui-app/tests/agent_integration_e2e.rs
+++ b/crates/aionui-app/tests/agent_integration_e2e.rs
@@ -162,6 +162,15 @@ impl IWorkerTaskManager for MockTaskManager {
         Ok(())
     }
 
+    fn kill_and_wait(
+        &self,
+        conversation_id: &str,
+        reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        let _ = self.kill(conversation_id, reason);
+        Box::pin(std::future::ready(()))
+    }
+
     fn clear(&self) {
         self.agents.lock().unwrap().clear();
     }

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1315,6 +1315,15 @@ impl IWorkerTaskManager for MockTaskManager {
         Ok(())
     }
 
+    fn kill_and_wait(
+        &self,
+        conversation_id: &str,
+        reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        let _ = self.kill(conversation_id, reason);
+        Box::pin(std::future::ready(()))
+    }
+
     fn clear(&self) {
         self.agents.lock().unwrap().clear();
     }
@@ -1369,6 +1378,15 @@ impl IWorkerTaskManager for MockTaskManagerWithWorkspace {
     fn kill(&self, conversation_id: &str, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
         self.agents.lock().unwrap().remove(conversation_id);
         Ok(())
+    }
+
+    fn kill_and_wait(
+        &self,
+        conversation_id: &str,
+        reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        let _ = self.kill(conversation_id, reason);
+        Box::pin(std::future::ready(()))
     }
 
     fn clear(&self) {

--- a/crates/aionui-conversation/tests/conversation_crud.rs
+++ b/crates/aionui-conversation/tests/conversation_crud.rs
@@ -53,6 +53,13 @@ impl IWorkerTaskManager for NoopTaskManager {
     fn kill(&self, _: &str, _: Option<AgentKillReason>) -> Result<(), AppError> {
         Ok(())
     }
+    fn kill_and_wait(
+        &self,
+        _: &str,
+        _: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        Box::pin(std::future::ready(()))
+    }
     fn clear(&self) {}
     fn active_count(&self) -> usize {
         0

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -1869,6 +1869,13 @@ mod tests {
             fn kill(&self, _: &str, _: Option<aionui_common::AgentKillReason>) -> Result<(), aionui_common::AppError> {
                 Ok(())
             }
+            fn kill_and_wait(
+                &self,
+                _: &str,
+                _: Option<aionui_common::AgentKillReason>,
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+                Box::pin(std::future::ready(()))
+            }
             fn clear(&self) {}
             fn active_count(&self) -> usize {
                 0
@@ -2155,6 +2162,14 @@ mod tests {
             Ok(())
         }
 
+        fn kill_and_wait(
+            &self,
+            _: &str,
+            _: Option<AgentKillReason>,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+            Box::pin(std::future::ready(()))
+        }
+
         fn clear(&self) {}
 
         fn active_count(&self) -> usize {
@@ -2209,6 +2224,14 @@ mod tests {
             _reason: Option<AgentKillReason>,
         ) -> Result<(), aionui_common::AppError> {
             Ok(())
+        }
+
+        fn kill_and_wait(
+            &self,
+            _: &str,
+            _: Option<AgentKillReason>,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+            Box::pin(std::future::ready(()))
         }
 
         fn clear(&self) {}

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -73,6 +73,13 @@ impl aionui_ai_agent::task_manager::IWorkerTaskManager for StubTaskManager {
     fn kill(&self, _: &str, _: Option<aionui_common::AgentKillReason>) -> Result<(), aionui_common::AppError> {
         Ok(())
     }
+    fn kill_and_wait(
+        &self,
+        _: &str,
+        _: Option<aionui_common::AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        Box::pin(std::future::ready(()))
+    }
     fn clear(&self) {}
     fn active_count(&self) -> usize {
         0

--- a/crates/aionui-team/Cargo.toml
+++ b/crates/aionui-team/Cargo.toml
@@ -21,6 +21,7 @@ async-trait.workspace = true
 dashmap.workspace = true
 regex.workspace = true
 agent-client-protocol = "0.11.1"
+futures-util.workspace = true
 
 [dev-dependencies]
 sqlx.workspace = true

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -24,7 +24,7 @@ use crate::session::TeamSession;
 use crate::types::{Team, TeamAgent, TeammateRole};
 
 struct SessionEntry {
-    session: TeamSession,
+    session: Arc<TeamSession>,
     /// Background tasks that forward `Finish` / `Error` stream events to
     /// `session.on_agent_finish`. Aborted in `stop_session`.
     finish_subscribers: Vec<JoinHandle<()>>,
@@ -299,15 +299,20 @@ impl TeamSessionService {
 
         self.stop_session(team_id);
 
-        // D11.5: tear down every agent worker before the team's conversations
-        // are deleted — otherwise the spawned ACP/CLI processes become orphans.
-        // Failures here (e.g. the task was never built, or already gone) must
-        // not block the delete path.
-        for agent in &team.agents {
-            let _ = self
-                .task_manager
-                .kill(&agent.conversation_id, Some(AgentKillReason::TeamDeleted));
-        }
+        let kill_futures: Vec<_> = team
+            .agents
+            .iter()
+            .map(|agent| {
+                self.task_manager
+                    .kill_and_wait(&agent.conversation_id, Some(AgentKillReason::TeamDeleted))
+            })
+            .collect();
+
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            futures_util::future::join_all(kill_futures),
+        )
+        .await;
 
         for agent in &team.agents {
             let _ = self.conversation_service.delete(user_id, &agent.conversation_id).await;
@@ -317,8 +322,6 @@ impl TeamSessionService {
         self.repo.delete_tasks_by_team(team_id).await?;
         self.repo.delete_team(team_id).await?;
 
-        // Drop the per-team add_agent lock so the DashMap entry does not leak
-        // across team lifecycles (W4-D23).
         self.add_agent_locks.remove(team_id);
 
         info!(team_id = %team_id, "Team removed");
@@ -415,8 +418,8 @@ impl TeamSessionService {
             )
             .await?;
 
-        if let Some(entry) = self.sessions.get(team_id) {
-            entry.session.add_agent(&agent).await;
+        if let Some(session) = self.sessions.get(team_id).map(|e| Arc::clone(&e.session)) {
+            session.add_agent(&agent).await;
         }
 
         self.build_agent_response(&agent).await
@@ -455,8 +458,8 @@ impl TeamSessionService {
             )
             .await?;
 
-        if let Some(entry) = self.sessions.get(team_id) {
-            let _ = entry.session.remove_agent(slot_id).await;
+        if let Some(session) = self.sessions.get(team_id).map(|e| Arc::clone(&e.session)) {
+            let _ = session.remove_agent(slot_id).await;
         }
 
         Ok(())
@@ -489,8 +492,8 @@ impl TeamSessionService {
             )
             .await?;
 
-        if let Some(entry) = self.sessions.get(team_id) {
-            let _ = entry.session.rename_agent(slot_id, name).await;
+        if let Some(session) = self.sessions.get(team_id).map(|e| Arc::clone(&e.session)) {
+            let _ = session.rename_agent(slot_id, name).await;
         }
 
         Ok(())
@@ -583,7 +586,7 @@ impl TeamSessionService {
         let finish_subscribers = self.spawn_finish_subscribers(team_id, &agents_snapshot);
 
         let entry = SessionEntry {
-            session,
+            session: Arc::new(session),
             finish_subscribers,
         };
         self.sessions.insert(team_id.to_owned(), entry);
@@ -703,12 +706,15 @@ impl TeamSessionService {
                     if !is_error && !matches!(event, AgentStreamEvent::Finish(_)) {
                         continue;
                     }
-                    let Some(entry) = sessions.get(&team_id) else {
-                        break;
+                    let session = {
+                        let Some(entry) = sessions.get(&team_id) else {
+                            break;
+                        };
+                        Arc::clone(&entry.session)
                     };
-                    match entry.session.on_agent_finish(&conv_id, is_error).await {
+                    match session.on_agent_finish(&conv_id, is_error).await {
                         Ok(Some(wake_target)) => {
-                            entry.session.try_wake(&wake_target, None).await;
+                            session.try_wake(&wake_target, None).await;
                         }
                         Ok(None) => {}
                         Err(e) => {
@@ -756,12 +762,15 @@ impl TeamSessionService {
                 if !is_error && !matches!(event, AgentStreamEvent::Finish(_)) {
                     continue;
                 }
-                let Some(entry) = sessions.get(&team_id_owned) else {
-                    break;
+                let session = {
+                    let Some(entry) = sessions.get(&team_id_owned) else {
+                        break;
+                    };
+                    Arc::clone(&entry.session)
                 };
-                match entry.session.on_agent_finish(&conv_id, is_error).await {
+                match session.on_agent_finish(&conv_id, is_error).await {
                     Ok(Some(wake_target)) => {
-                        entry.session.try_wake(&wake_target, None).await;
+                        session.try_wake(&wake_target, None).await;
                     }
                     Ok(None) => {}
                     Err(e) => {
@@ -804,11 +813,14 @@ impl TeamSessionService {
         content: &str,
         files: Option<Vec<String>>,
     ) -> Result<(), TeamError> {
-        let entry = self
-            .sessions
-            .get(team_id)
-            .ok_or_else(|| TeamError::SessionNotFound(team_id.into()))?;
-        entry.session.send_message(content, files).await
+        let session = {
+            let entry = self
+                .sessions
+                .get(team_id)
+                .ok_or_else(|| TeamError::SessionNotFound(team_id.into()))?;
+            Arc::clone(&entry.session)
+        };
+        session.send_message(content, files).await
     }
 
     pub async fn send_message_to_agent(
@@ -818,44 +830,43 @@ impl TeamSessionService {
         content: &str,
         files: Option<Vec<String>>,
     ) -> Result<(), TeamError> {
-        let entry = self
-            .sessions
-            .get(team_id)
-            .ok_or_else(|| TeamError::SessionNotFound(team_id.into()))?;
-        entry.session.send_message_to_agent(slot_id, content, files).await
+        let session = {
+            let entry = self
+                .sessions
+                .get(team_id)
+                .ok_or_else(|| TeamError::SessionNotFound(team_id.into()))?;
+            Arc::clone(&entry.session)
+        };
+        session.send_message_to_agent(slot_id, content, files).await
     }
 
     /// Wake a specific agent in a team session (trigger it to read mailbox).
     /// Called by MCP dispatch after `team_send_message` writes to mailbox.
     pub async fn wake_agent_in_session(&self, team_id: &str, slot_id: &str) -> Result<(), TeamError> {
-        let entry = self
-            .sessions
-            .get(team_id)
-            .ok_or_else(|| TeamError::SessionNotFound(team_id.into()))?;
+        let (session, scheduler) = {
+            let entry = self
+                .sessions
+                .get(team_id)
+                .ok_or_else(|| TeamError::SessionNotFound(team_id.into()))?;
+            (Arc::clone(&entry.session), entry.session.scheduler().clone())
+        };
 
-        // Acquire an exclusive wake lock before proceeding. If another wake is
-        // already in-flight for this slot, skip — the queued wake will produce
-        // its own Finish event when it completes (Bug 3: race with finish_subscriber).
-        if !entry.session.scheduler().acquire_wake_lock(slot_id) {
+        if !scheduler.acquire_wake_lock(slot_id) {
             return Ok(());
         }
 
-        entry
-            .session
-            .scheduler()
+        scheduler
             .set_status(slot_id, crate::types::TeammateStatus::Working)
             .await?;
-        let input = entry.session.compute_wake_input(slot_id).await;
+        let input = session.compute_wake_input(slot_id).await;
 
         if let Ok(Some(ref i)) = input
             && i.should_send
         {
-            entry.session.mirror_unread_to_conversation(i).await;
+            session.mirror_unread_to_conversation(i).await;
         }
 
-        let user_id = entry.session.user_id().to_owned();
-        let scheduler = entry.session.scheduler().clone();
-        drop(entry);
+        let user_id = session.user_id().to_owned();
 
         let conv_id = match &input {
             Ok(Some(i)) if i.should_send => i.conversation_id.clone(),
@@ -922,28 +933,26 @@ impl TeamSessionService {
 
             let send_result = handle.send_message(data).await;
 
-            if send_result.is_ok()
-                && !msg_ids.is_empty()
-                && let Some(entry) = sessions.get(&team_id_owned)
-                && let Err(e) = entry.session.mailbox().mark_read_batch(&msg_ids).await
-            {
-                warn!(
-                    slot_id = %slot_id_owned,
-                    error = %e,
-                    "mark_read_batch failed after successful send in wake_agent_in_session (non-fatal)"
-                );
+            if send_result.is_ok() && !msg_ids.is_empty() {
+                let session = sessions.get(&team_id_owned).map(|e| Arc::clone(&e.session));
+                if let Some(session) = session {
+                    if let Err(e) = session.mailbox().mark_read_batch(&msg_ids).await {
+                        warn!(
+                            slot_id = %slot_id_owned,
+                            error = %e,
+                            "mark_read_batch failed after successful send in wake_agent_in_session (non-fatal)"
+                        );
+                    }
+                }
             }
 
             scheduler.release_wake_lock(&slot_id_owned);
 
-            // The Finish event was emitted inside send_message (before it
-            // returned), so on_agent_finish already ran but skipped finalization
-            // because is_wake_active was still true at that point. Now that the
-            // lock is released, we must finalize the turn ourselves.
-            if let Some(entry) = sessions.get(&team_id_owned) {
-                match entry.session.on_agent_finish(&conv_id, false).await {
+            let session = sessions.get(&team_id_owned).map(|e| Arc::clone(&e.session));
+            if let Some(session) = session {
+                match session.on_agent_finish(&conv_id, false).await {
                     Ok(Some(wake_target)) => {
-                        entry.session.try_wake(&wake_target, None).await;
+                        session.try_wake(&wake_target, None).await;
                     }
                     Ok(None) => {}
                     Err(e) => {

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -935,14 +935,14 @@ impl TeamSessionService {
 
             if send_result.is_ok() && !msg_ids.is_empty() {
                 let session = sessions.get(&team_id_owned).map(|e| Arc::clone(&e.session));
-                if let Some(session) = session {
-                    if let Err(e) = session.mailbox().mark_read_batch(&msg_ids).await {
-                        warn!(
-                            slot_id = %slot_id_owned,
-                            error = %e,
-                            "mark_read_batch failed after successful send in wake_agent_in_session (non-fatal)"
-                        );
-                    }
+                if let Some(session) = session
+                    && let Err(e) = session.mailbox().mark_read_batch(&msg_ids).await
+                {
+                    warn!(
+                        slot_id = %slot_id_owned,
+                        error = %e,
+                        "mark_read_batch failed after successful send in wake_agent_in_session (non-fatal)"
+                    );
                 }
             }
 

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -1078,6 +1078,14 @@ mod tests {
             }
             Ok(())
         }
+        fn kill_and_wait(
+            &self,
+            conversation_id: &str,
+            reason: Option<AgentKillReason>,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+            let _ = self.kill(conversation_id, reason);
+            Box::pin(std::future::ready(()))
+        }
         fn clear(&self) {}
         fn active_count(&self) -> usize {
             self.tasks.lock().unwrap().len()

--- a/crates/aionui-team/tests/e2e_team_flow.rs
+++ b/crates/aionui-team/tests/e2e_team_flow.rs
@@ -223,6 +223,14 @@ impl aionui_ai_agent::IWorkerTaskManager for StubTaskManager {
             .push((conversation_id.to_owned(), reason));
         Ok(())
     }
+    fn kill_and_wait(
+        &self,
+        conversation_id: &str,
+        reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        let _ = self.kill(conversation_id, reason);
+        Box::pin(std::future::ready(()))
+    }
     fn clear(&self) {}
     fn active_count(&self) -> usize {
         self.tasks.lock().unwrap().len()

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -476,6 +476,14 @@ impl IWorkerTaskManager for CountingTaskManager {
             .push((conversation_id.to_owned(), reason));
         self.inner.kill(conversation_id, reason)
     }
+    fn kill_and_wait(
+        &self,
+        conversation_id: &str,
+        reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        let _ = self.kill(conversation_id, reason);
+        Box::pin(std::future::ready(()))
+    }
     fn clear(&self) {
         self.inner.clear()
     }


### PR DESCRIPTION
## Summary
- Force-stop all running agents when a team is deleted, preventing orphaned agent processes
- Fix DashMap deadlock in `TeamSessionService` by avoiding holding references across await points
- Add `kill_and_wait` method to `TaskManager` trait and all agent implementations for graceful shutdown
- Minor refactor: use let-chains syntax in `wake_agent_in_session`

## Test plan
- [x] All 5455 existing tests pass
- [x] `StubTaskManager` in cron service_integration test updated with new trait method
- [x] Verified no clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)