### PR TITLE
chore(assistant): switch built-in assistants to aionrs preset agent

### DIFF
--- a/crates/aionui-app/assets/builtin-assistants/assistants.json
+++ b/crates/aionui-app/assets/builtin-assistants/assistants.json
@@ -18,7 +18,7 @@
         "uk-UA": "Створюйте, редагуйте та аналізуйте професійні документи Word за допомогою officecli: звіти, пропозиції, листи, нотатки тощо."
       },
       "avatar": "📝",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "officecli-docx"
       ],
@@ -71,7 +71,7 @@
         "uk-UA": "Створюйте, редагуйте та аналізуйте професійні презентації PowerPoint за допомогою officecli: виразний дизайн, різноманітні макети та візуальний вплив."
       },
       "avatar": "📊",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "officecli-pptx"
       ],
@@ -124,7 +124,7 @@
         "uk-UA": "Створюйте, редагуйте та аналізуйте професійні таблиці Excel за допомогою officecli: фінансові моделі, дашборди, трекери та аналіз даних."
       },
       "avatar": "📈",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "officecli-xlsx"
       ],
@@ -177,7 +177,7 @@
         "uk-UA": "Створюйте професійні презентації з анімацією Morph за допомогою officecli. Підтримує різні візуальні стилі та повний робочий процес від ідеї до готових слайдів."
       },
       "avatar": "✨",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "morph-ppt"
       ],
@@ -226,7 +226,7 @@
         "zh-CN": "把 GLB 3D 模型变成电影感 Morph 演示文稿。模型是视觉主角——特写看细节、俯视看结构、仰拍看气势，每页之间用 Morph 转场做流畅的镜头运动。注意：3D 模型和 Morph 转场效果需要在微软 PowerPoint 中打开才能正常显示。"
       },
       "avatar": "🎬",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "morph-ppt-3d",
         "morph-ppt"
@@ -270,7 +270,7 @@
         "uk-UA": "Створюйте інвесторські пітч-деки, презентації продуктів та корпоративні продажі: градієнтний дизайн, графіки, таблиці конкурентів, слайди команди та нотатки доповідача. Підходить для стадій від Seed до Series A+."
       },
       "avatar": "🎯",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "officecli-pitch-deck"
       ],
@@ -323,7 +323,7 @@
         "uk-UA": "Перетворюйте CSV або табличні дані на професійні дашборди Excel: KPI-картки, графіки з прив'язкою до даних, спарклайни та умовне форматування. Автоматично масштабує складність під обсяг даних."
       },
       "avatar": "📊",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "officecli-data-dashboard"
       ],
@@ -376,7 +376,7 @@
         "uk-UA": "Створюйте структуровані академічні статті, наукові роботи та White Papers: зміст Word, формули LaTeX в OMML, бібліографія (APA/Physics/Chicago), виноски та багатоколонкова верстка."
       },
       "avatar": "📚",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "officecli-academic-paper"
       ],
@@ -429,7 +429,7 @@
         "uk-UA": "Будуйте фінансові моделі на основі формул за текстовим запитом: три фінансові форми, DCF-оцінка, Cap Tables, сценарний аналіз та графіки боргів."
       },
       "avatar": "💰",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "officecli-financial-model"
       ],
@@ -482,7 +482,7 @@
         "uk-UA": "Допомагає встановлювати, підключати та діагностувати візуалізацію Star-Office-UI для попереднього перегляду в Aion."
       },
       "avatar": "📺",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "star-office-helper"
       ],
@@ -535,7 +535,7 @@
         "uk-UA": "Експертний посібник зі встановлення, розгортання, налаштування та усунення несправностей OpenClaw. Допомагає з налаштуванням та безпекою."
       },
       "avatar": "🦞",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "openclaw-setup",
         "aionui-webui-setup"
@@ -589,7 +589,7 @@
         "uk-UA": "Автономне виконання завдань з роботою з файлами, обробкою документів та багатокроковим плануванням робочих процесів."
       },
       "avatar": "cowork.svg",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "skill-creator",
         "officecli-pptx",
@@ -647,7 +647,7 @@
         "uk-UA": "Генеруйте повноцінну 3D-гру-платформер зі збором предметів в одному HTML-файлі."
       },
       "avatar": "🎮",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [],
       "custom_skill_names": [],
       "disabled_builtin_skills": [],
@@ -698,7 +698,7 @@
         "uk-UA": "Професійний UI/UX-помічник з 57 стилями, 95 кольоровими палітрами, 56 поєднаннями шрифтів та найкращими практиками для різних технологій."
       },
       "avatar": "🎨",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [],
       "custom_skill_names": [],
       "disabled_builtin_skills": [],
@@ -749,7 +749,7 @@
         "uk-UA": "Файлове планування в стилі Manus для складних завдань. Використовує task_plan.md, findings.md та progress.md для збереження контексту."
       },
       "avatar": "📋",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [],
       "custom_skill_names": [],
       "disabled_builtin_skills": [],
@@ -800,7 +800,7 @@
         "uk-UA": "Коуч з особистого розвитку на основі фреймворка HUMAN 3.0: 4 квадранти (Розум/Тіло/Дух/Призвання), 3 рівні та 3 фази росту."
       },
       "avatar": "🧭",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [],
       "custom_skill_names": [],
       "disabled_builtin_skills": [],
@@ -851,7 +851,7 @@
         "uk-UA": "Розгортає запит на найм у повноцінний опис вакансії та зображення, а потім публікує це в соцмережах через конектори."
       },
       "avatar": "📣",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "xiaohongshu-recruiter",
         "x-recruiter"
@@ -906,7 +906,7 @@
         "uk-UA": "Соціальна мережа для AI-агентів. Публікації, коментарі, голосування та створення спільнот."
       },
       "avatar": "🦞",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "moltbook"
       ],
@@ -960,7 +960,7 @@
         "uk-UA": "Створюйте блок-схеми, діаграми послідовності, станів, класів та ER-діаграми з красивими темами оформлення."
       },
       "avatar": "📈",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "mermaid"
       ],
@@ -1013,7 +1013,7 @@
         "uk-UA": "Іммерсивний сюжетний рольовий режим. Можна почати трьома способами: описати персонажів словами, вставити PNG-зображення або відкрити папку з картками персонажів та лором світу."
       },
       "avatar": "📖",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "story-roleplay"
       ],
@@ -1066,7 +1066,7 @@
         "uk-UA": "Створюйте заповнювані форми Word (.docx) зі справжніми елементами керування вмістом, полями-прапорцями, MERGEFIELD для злиття пошти та захистом документа — редагуються лише задані поля, решта залишається заблокованою. HR-анкети, опитування, шаблони контрактів / SOW, комплаєнс-чеклисти, медичні анкети."
       },
       "avatar": "📋",
-      "preset_agent_type": "gemini",
+      "preset_agent_type": "aionrs",
       "enabled_skills": [
         "officecli-word-form"
       ],


### PR DESCRIPTION
## Summary
- Flip every built-in assistant in `crates/aionui-app/assets/builtin-assistants/assistants.json` from `"preset_agent_type": "gemini"` to `"aionrs"` (21 entries).
- Scope is intentionally narrow: only the manifest changes. `DEFAULT_AGENT_TYPE` (`aionui-assistant/src/service.rs:654`), the extension fallback (`:717`), and the `PRESET_AGENT_TYPES` whitelist (`aionui-extension/src/constants.rs:26`) are left untouched.

## Impact
`GET /api/assistants` now returns `preset_agent_type: "aionrs"` for built-in assistants when the user has no override row. Users who previously wrote a per-assistant override via `PUT /api/assistants/{id}` are unaffected.

## Test plan
- [ ] `cargo test -p aionui-assistant`
- [ ] Smoke `GET /api/assistants` and confirm built-ins report `preset_agent_type: "aionrs"`.