### PR TITLE
fix(team): add name dedup check to rename_agent

### DIFF
--- a/crates/aionui-team/src/scheduler/agent_lifecycle.rs
+++ b/crates/aionui-team/src/scheduler/agent_lifecycle.rs
@@ -62,9 +62,9 @@ impl TeammateManager {
             .ok_or_else(|| TeamError::AgentNotFound(slot_id.to_owned()))?;
 
         // Check all other agents for name collision (exclude self).
-        let conflict = slots.iter().any(|(id, s)| {
-            id != slot_id && super::normalize_name(&s.agent.name) == normalized
-        });
+        let conflict = slots
+            .iter()
+            .any(|(id, s)| id != slot_id && super::normalize_name(&s.agent.name) == normalized);
         if conflict {
             return Err(TeamError::DuplicateAgentName(new_name.to_owned()));
         }

--- a/crates/aionui-team/src/scheduler/agent_lifecycle.rs
+++ b/crates/aionui-team/src/scheduler/agent_lifecycle.rs
@@ -49,10 +49,27 @@ impl TeammateManager {
     }
 
     pub async fn rename_agent(&self, slot_id: &str, new_name: &str) -> Result<(), TeamError> {
+        let normalized = super::normalize_name(new_name);
+        if normalized.is_empty() {
+            return Err(TeamError::InvalidRequest(
+                "rename_agent.new_name is empty after normalization".into(),
+            ));
+        }
+
         let mut slots = self.slots.lock().await;
-        let slot = slots
-            .get_mut(slot_id)
+        let _target = slots
+            .get(slot_id)
             .ok_or_else(|| TeamError::AgentNotFound(slot_id.to_owned()))?;
+
+        // Check all other agents for name collision (exclude self).
+        let conflict = slots.iter().any(|(id, s)| {
+            id != slot_id && super::normalize_name(&s.agent.name) == normalized
+        });
+        if conflict {
+            return Err(TeamError::DuplicateAgentName(new_name.to_owned()));
+        }
+
+        let slot = slots.get_mut(slot_id).unwrap();
         slot.agent.name = new_name.to_owned();
         drop(slots);
         self.events.broadcast_agent_renamed(slot_id, new_name);

--- a/crates/aionui-team/src/scheduler/tests.rs
+++ b/crates/aionui-team/src/scheduler/tests.rs
@@ -426,6 +426,38 @@ async fn rename_agent_broadcasts_renamed_event() {
     assert_eq!(renamed_events[0].data["name"], "Renamed Worker");
 }
 
+#[tokio::test]
+async fn rename_agent_rejects_duplicate_name() {
+    let agents = make_team_agents();
+    let (mgr, _) = make_manager(&agents);
+
+    // "Worker2" already exists (from make_team_agents). Renaming worker-1
+    // to " Worker2 " should collide after normalization.
+    let err = mgr
+        .rename_agent("worker-1", " Worker2 ")
+        .await
+        .expect_err("duplicate name must be rejected");
+    assert!(
+        matches!(&err, TeamError::DuplicateAgentName(_)),
+        "expected DuplicateAgentName, got {err:?}"
+    );
+
+    // Original name must be preserved.
+    let agent = mgr.get_agent("worker-1").await.unwrap();
+    assert_eq!(agent.name, "Worker1");
+}
+
+#[tokio::test]
+async fn rename_agent_allows_same_agent_own_name() {
+    let agents = make_team_agents();
+    let (mgr, _) = make_manager(&agents);
+
+    // Renaming worker-1 to its own name (different casing) is not a conflict.
+    mgr.rename_agent("worker-1", "WORKER1").await.unwrap();
+    let agent = mgr.get_agent("worker-1").await.unwrap();
+    assert_eq!(agent.name, "WORKER1");
+}
+
 // -- execute_action: SendMessage -----------------------------------------
 
 #[tokio::test]

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -473,6 +473,21 @@ impl TeamSessionService {
             .ok_or_else(|| TeamError::TeamNotFound(team_id.into()))?;
         let mut team = Team::from_row(&row)?;
 
+        let normalized = crate::scheduler::normalize_name(name);
+        if normalized.is_empty() {
+            return Err(TeamError::InvalidRequest(
+                "rename_agent.name is empty after normalization".into(),
+            ));
+        }
+
+        // Uniqueness check against all other agents in the team.
+        let has_conflict = team.agents.iter().any(|a| {
+            a.slot_id != slot_id && crate::scheduler::normalize_name(&a.name) == normalized
+        });
+        if has_conflict {
+            return Err(TeamError::DuplicateAgentName(name.to_owned()));
+        }
+
         let agent = team
             .agents
             .iter_mut()

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -481,9 +481,10 @@ impl TeamSessionService {
         }
 
         // Uniqueness check against all other agents in the team.
-        let has_conflict = team.agents.iter().any(|a| {
-            a.slot_id != slot_id && crate::scheduler::normalize_name(&a.name) == normalized
-        });
+        let has_conflict = team
+            .agents
+            .iter()
+            .any(|a| a.slot_id != slot_id && crate::scheduler::normalize_name(&a.name) == normalized);
         if has_conflict {
             return Err(TeamError::DuplicateAgentName(name.to_owned()));
         }

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -1371,12 +1371,7 @@ mod tests {
     async fn rename_agent_rejects_duplicate_in_session() {
         let session = start_session().await;
         let agents = session.scheduler.list_agents().await;
-        let lead_name = agents
-            .iter()
-            .find(|a| a.slot_id == "lead-1")
-            .unwrap()
-            .name
-            .clone();
+        let lead_name = agents.iter().find(|a| a.slot_id == "lead-1").unwrap().name.clone();
 
         // Rename worker-1 to the lead's name — should collide.
         let result = session.rename_agent("worker-1", &lead_name).await;

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -1367,6 +1367,24 @@ mod tests {
         session.stop();
     }
 
+    #[tokio::test]
+    async fn rename_agent_rejects_duplicate_in_session() {
+        let session = start_session().await;
+        let agents = session.scheduler.list_agents().await;
+        let lead_name = agents
+            .iter()
+            .find(|a| a.slot_id == "lead-1")
+            .unwrap()
+            .name
+            .clone();
+
+        // Rename worker-1 to the lead's name — should collide.
+        let result = session.rename_agent("worker-1", &lead_name).await;
+        assert!(result.is_err());
+
+        session.stop();
+    }
+
     // -- spawn_agent helpers + guard tests -----------------------------------
 
     fn sample_spawn_req() -> SpawnAgentRequest {


### PR DESCRIPTION
## Summary
- `team_rename_agent` 之前没有 name 去重检查，leader 可以把 agent 改名为已有 agent 的名字，导致后续 `resolve_agent_target()` 匹配错误对象
- 在 `TeammateManager::rename_agent`（scheduler 层）加入 normalize + 唯一性检查，与 `spawn_agent` 行为一致
- 允许 agent 改名为自身名字的不同大小写形式（不视为冲突）

## Test plan
- [x] `rename_agent_rejects_duplicate_name` — 验证 normalize 后重名被拒绝
- [x] `rename_agent_allows_same_agent_own_name` — 验证自身改名不冲突
- [x] `rename_agent_rejects_duplicate_in_session` — session 层集成验证
- [x] 全量 `cargo test --workspace` 5458 tests passed
- [x] `cargo clippy --workspace -- -D warnings` 零警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)