### PR TITLE
fix(team): resolve provider_id from providers table for aionrs spawn

### DIFF
--- a/crates/aionui-file/src/browse.rs
+++ b/crates/aionui-file/src/browse.rs
@@ -125,12 +125,10 @@ pub fn resolve_browse_path(raw: &str, allowed_roots: &[PathBuf]) -> Result<PathB
         _ => AppError::BadRequest(format!("cannot resolve path '{}': {}", raw, e)),
     })?;
 
-    let allowed = allowed_roots
-        .iter()
-        .any(|root| match fs::canonicalize(root) {
-            Ok(canonical_root) => canonical.starts_with(&canonical_root),
-            Err(_) => false,
-        });
+    let allowed = allowed_roots.iter().any(|root| match fs::canonicalize(root) {
+        Ok(canonical_root) => canonical.starts_with(&canonical_root),
+        Err(_) => false,
+    });
 
     if !allowed {
         return Err(AppError::Forbidden(format!(
@@ -143,15 +141,11 @@ pub fn resolve_browse_path(raw: &str, allowed_roots: &[PathBuf]) -> Result<PathB
 }
 
 fn expand_tilde(input: &str) -> PathBuf {
-    if let Some(stripped) = input.strip_prefix('~') {
-        if let Some(home) = dirs::home_dir() {
-            let relative = stripped.trim_start_matches(['/', '\\']);
-            return if relative.is_empty() {
-                home
-            } else {
-                home.join(relative)
-            };
-        }
+    if let Some(stripped) = input.strip_prefix('~')
+        && let Some(home) = dirs::home_dir()
+    {
+        let relative = stripped.trim_start_matches(['/', '\\']);
+        return if relative.is_empty() { home } else { home.join(relative) };
     }
     PathBuf::from(input)
 }
@@ -170,8 +164,7 @@ pub fn list_directory(
     show_files: bool,
     allowed_roots: &[PathBuf],
 ) -> Result<BrowseDirectoryResponse, AppError> {
-    let metadata = fs::metadata(dir)
-        .map_err(|e| AppError::NotFound(format!("cannot access directory: {}", e)))?;
+    let metadata = fs::metadata(dir).map_err(|e| AppError::NotFound(format!("cannot access directory: {}", e)))?;
     if !metadata.is_dir() {
         return Err(AppError::BadRequest("path is not a directory".into()));
     }
@@ -255,12 +248,10 @@ fn navigation_hints(dir: &Path, allowed_roots: &[PathBuf]) -> (Option<String>, b
         return (None, false);
     }
 
-    let parent_allowed = allowed_roots
-        .iter()
-        .any(|root| match fs::canonicalize(root) {
-            Ok(canonical_root) => parent.starts_with(&canonical_root),
-            Err(_) => false,
-        });
+    let parent_allowed = allowed_roots.iter().any(|root| match fs::canonicalize(root) {
+        Ok(canonical_root) => parent.starts_with(&canonical_root),
+        Err(_) => false,
+    });
 
     (Some(parent.to_string_lossy().into_owned()), parent_allowed)
 }
@@ -389,7 +380,10 @@ mod tests {
         let roots = roots_from(&[tmp.path()]);
 
         let err = browse(Some(file.to_str().unwrap()), false, &roots).unwrap_err();
-        assert!(matches!(err, AppError::BadRequest(_)), "expected bad-request, got {err}");
+        assert!(
+            matches!(err, AppError::BadRequest(_)),
+            "expected bad-request, got {err}"
+        );
     }
 
     #[test]

--- a/crates/aionui-file/src/routes.rs
+++ b/crates/aionui-file/src/routes.rs
@@ -115,11 +115,9 @@ async fn browse_directory(
     let raw_path = query.path.clone();
     let roots = state.browse_roots.clone();
 
-    let response = tokio::task::spawn_blocking(move || {
-        browse::browse(raw_path.as_deref(), show_files, &roots)
-    })
-    .await
-    .map_err(|e| AppError::Internal(format!("browse task failed: {}", e)))??;
+    let response = tokio::task::spawn_blocking(move || browse::browse(raw_path.as_deref(), show_files, &roots))
+        .await
+        .map_err(|e| AppError::Internal(format!("browse task failed: {}", e)))??;
 
     Ok(Json(ApiResponse::ok(response)))
 }

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -9,7 +9,7 @@ use aionui_api_types::{
     AddAgentRequest, CreateConversationRequest, CreateTeamRequest, GuideMcpConfig, TeamAgentResponse, TeamMcpPhase,
     TeamMcpStatusPayload, TeamResponse, WebSocketMessage,
 };
-use aionui_common::{AgentKillReason, ProviderWithModel, generate_id, now_ms};
+use aionui_common::{AgentKillReason, AgentType, ProviderWithModel, generate_id, now_ms};
 use aionui_conversation::ConversationService;
 use aionui_db::models::TeamRow;
 use aionui_db::{IAgentMetadataRepository, IProviderRepository, ITeamRepository, UpdateTeamParams};
@@ -178,11 +178,18 @@ impl TeamSessionService {
                 existing_id.clone()
             } else {
                 let agent_type = parse_agent_type(&input.backend)?;
+                let provider_id = if agent_type == AgentType::Aionrs {
+                    self.resolve_provider_for_model(&input.model)
+                        .await
+                        .unwrap_or_else(|| input.backend.clone())
+                } else {
+                    input.backend.clone()
+                };
                 let conv_req = CreateConversationRequest {
                     r#type: agent_type,
                     name: Some(input.name.clone()),
                     model: Some(ProviderWithModel {
-                        provider_id: input.backend.clone(),
+                        provider_id,
                         model: input.model.clone(),
                         use_model: None,
                     }),
@@ -371,11 +378,18 @@ impl TeamSessionService {
         let role = TeammateRole::parse(&req.role).unwrap_or(TeammateRole::Teammate);
         let agent_type = parse_agent_type(&req.backend)?;
 
+        let provider_id = if agent_type == AgentType::Aionrs {
+            self.resolve_provider_for_model(&req.model)
+                .await
+                .unwrap_or_else(|| req.backend.clone())
+        } else {
+            req.backend.clone()
+        };
         let conv_req = CreateConversationRequest {
             r#type: agent_type,
             name: Some(req.name.clone()),
             model: Some(ProviderWithModel {
-                provider_id: req.backend.clone(),
+                provider_id,
                 model: req.model.clone(),
                 use_model: None,
             }),

--- a/crates/aionui-team/src/service/spawn_support.rs
+++ b/crates/aionui-team/src/service/spawn_support.rs
@@ -161,6 +161,22 @@ impl TeamSessionService {
             .collect()
     }
 
+    /// Find the provider ID that contains a given model name.
+    /// Iterates all enabled providers and checks their models JSON array.
+    pub(crate) async fn resolve_provider_for_model(&self, model: &str) -> Option<String> {
+        let providers = self.provider_repo.list().await.ok()?;
+        for p in providers {
+            if !p.enabled {
+                continue;
+            }
+            let models: Vec<String> = serde_json::from_str(&p.models).unwrap_or_default();
+            if models.iter().any(|m| m == model) {
+                return Some(p.id);
+            }
+        }
+        None
+    }
+
     pub async fn spawn_agent_in_session(
         &self,
         team_id: &str,
@@ -219,11 +235,16 @@ impl TeamSessionService {
         let mut team = Team::from_row(&row)?;
 
         let agent_type = parse_agent_type(&backend)?;
+        let provider_id = if agent_type == AgentType::Aionrs {
+            self.resolve_provider_for_model(&model).await.unwrap_or(backend.clone())
+        } else {
+            backend.clone()
+        };
         let conv_req = CreateConversationRequest {
             r#type: agent_type,
             name: Some(name.clone()),
             model: Some(ProviderWithModel {
-                provider_id: backend.clone(),
+                provider_id,
                 model: model.clone(),
                 use_model: None,
             }),


### PR DESCRIPTION
## Summary
- When spawning aionrs-type agents in team mode, the backend string "aionrs" was incorrectly used as `provider_id` in `ProviderWithModel`. Since "aionrs" is an agent type (not a provider entry), the aionrs factory failed with `Provider 'aionrs' not found` during warmup — leaving spawned agents unable to start or respond to messages.
- Added `resolve_provider_for_model()` that iterates enabled providers to find the one containing the requested model, then uses its real ID as `provider_id`.
- Applied the fix to all three conversation-creation paths: `create_team`, `add_agent`, and `persist_spawned_agent`.

## Test plan
- [ ] Create a team with aionrs-type members using different models (e.g. deepseek-v4-pro, gemini-3.1-pro-preview)
- [ ] Verify agents warm up successfully without "Provider not found" error
- [ ] Verify sending messages to aionrs team members gets responses
- [ ] Verify existing ACP-type team members (claude, codex) still work correctly
- [ ] Run `cargo test -p aionui-team` — all 476 tests pass