### PR TITLE
ci: add tag push trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - "v*"
   workflow_call:
     inputs:
       tag_name:
@@ -24,6 +27,7 @@ env:
   CARGO_NET_RETRY: "10"
   AIONUI_EMBED_BUN: "1"
   BUN_VARIANT: default
+  RELEASE_TAG: ${{ inputs.tag_name || github.ref_name }}
 
 jobs:
   prepare-release:
@@ -34,13 +38,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: refs/tags/${{ inputs.tag_name }}
+          ref: refs/tags/${{ env.RELEASE_TAG }}
 
       - name: Extract version from tag
         id: metadata
         shell: bash
-        env:
-          RELEASE_TAG: ${{ inputs.tag_name }}
         run: |
           version="${RELEASE_TAG#v}"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
@@ -85,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: refs/tags/${{ inputs.tag_name }}
+          ref: refs/tags/${{ env.RELEASE_TAG }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -173,7 +175,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ inputs.tag_name }}
+          RELEASE_TAG: ${{ inputs.tag_name || github.ref_name }}
           REPOSITORY: ${{ github.repository }}
         run: |
           release_url="https://github.com/${REPOSITORY}/releases/tag/${RELEASE_TAG}"


### PR DESCRIPTION
## Summary
- 为 release.yml 添加 `push: tags: [v*]` 触发器，支持手动打 tag 自动触发打包
- 所有 `inputs.tag_name` 引用加 `|| github.ref_name` 兜底，确保 tag push 场景下能正确获取版本号
- release-please 流程保持不变，通过 `gh workflow run` 继续正常工作

## Test plan
- [ ] 手动打 tag push 验证 release workflow 触发
- [ ] 合并 release-please PR 验证原有流程不受影响