### PR TITLE
fix(channel): rewrite WeChat plugin to match iLink Bot protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,7 @@ dependencies = [
  "aionui-realtime",
  "async-trait",
  "axum",
+ "base64",
  "dashmap",
  "futures-util",
  "getrandom 0.2.17",
@@ -477,6 +478,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/aionui-channel/Cargo.toml
+++ b/crates/aionui-channel/Cargo.toml
@@ -8,7 +8,7 @@ default = []
 telegram = ["dep:reqwest"]
 lark = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures-util", "dep:prost"]
 dingtalk = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures-util"]
-weixin = ["dep:reqwest", "dep:futures-util"]
+weixin = ["dep:reqwest", "dep:futures-util", "dep:base64", "dep:uuid"]
 
 [dependencies]
 aionui-common.workspace = true
@@ -32,3 +32,5 @@ reqwest = { workspace = true, optional = true }
 tokio-tungstenite = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
 prost = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true }

--- a/crates/aionui-channel/src/constants.rs
+++ b/crates/aionui-channel/src/constants.rs
@@ -79,11 +79,20 @@ pub const WEIXIN_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 /// Maximum file size for WeChat file handling (200 MB).
 pub const WEIXIN_MAX_FILE_SIZE: u64 = 200 * 1024 * 1024;
 
-/// Maximum consecutive failures before WeChat stops retrying.
+/// Maximum consecutive failures before WeChat applies longer backoff.
 pub const WEIXIN_MAX_RETRIES: u32 = 3;
 
-/// Backoff delay between WeChat retry attempts.
-pub const WEIXIN_RETRY_DELAY: Duration = Duration::from_secs(30);
+/// Short retry delay between WeChat poll attempts on failure.
+pub const WEIXIN_RETRY_DELAY: Duration = Duration::from_secs(2);
+
+/// Longer backoff delay after max consecutive failures.
+pub const WEIXIN_BACKOFF_DELAY: Duration = Duration::from_secs(30);
+
+/// Long-polling timeout for WeChat getupdates (matches iLink API).
+pub const WEIXIN_POLL_TIMEOUT: Duration = Duration::from_secs(35);
+
+/// Timeout for non-polling WeChat API calls.
+pub const WEIXIN_API_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[cfg(test)]
 mod tests {
@@ -156,6 +165,9 @@ mod tests {
         assert_eq!(WEIXIN_RESPONSE_TIMEOUT, Duration::from_secs(300));
         assert_eq!(WEIXIN_MAX_FILE_SIZE, 200 * 1024 * 1024);
         assert_eq!(WEIXIN_MAX_RETRIES, 3);
-        assert_eq!(WEIXIN_RETRY_DELAY, Duration::from_secs(30));
+        assert_eq!(WEIXIN_RETRY_DELAY, Duration::from_secs(2));
+        assert_eq!(WEIXIN_BACKOFF_DELAY, Duration::from_secs(30));
+        assert_eq!(WEIXIN_POLL_TIMEOUT, Duration::from_secs(35));
+        assert_eq!(WEIXIN_API_TIMEOUT, Duration::from_secs(15));
     }
 }

--- a/crates/aionui-channel/src/plugins/weixin/api.rs
+++ b/crates/aionui-channel/src/plugins/weixin/api.rs
@@ -2,8 +2,8 @@ use std::time::Duration;
 
 use base64::Engine;
 use reqwest::Client;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
@@ -11,8 +11,8 @@ use crate::constants::{WEIXIN_API_TIMEOUT, WEIXIN_POLL_TIMEOUT};
 use crate::error::ChannelError;
 
 use super::types::{
-    GetUpdatesRequest, GetUpdatesResponse, ILinkResponse, QrCodeData, QrCodeStatusData, SendMessageItem,
-    SendMessageMsg, SendMessageRequest, SendTextItem, ITEM_TYPE_TEXT,
+    GetUpdatesRequest, GetUpdatesResponse, ILinkResponse, ITEM_TYPE_TEXT, QrCodeData, QrCodeStatusData,
+    SendMessageItem, SendMessageMsg, SendMessageRequest, SendTextItem,
 };
 
 /// HTTP client for the WeChat iLink Bot API.
@@ -85,11 +85,7 @@ impl WeixinApi {
             .map_err(|e| ChannelError::PlatformApi(format!("{endpoint} parse failed: {e}")))
     }
 
-    async fn ilink_get<T: DeserializeOwned>(
-        &self,
-        endpoint: &str,
-        query: &[(&str, &str)],
-    ) -> Result<T, ChannelError> {
+    async fn ilink_get<T: DeserializeOwned>(&self, endpoint: &str, query: &[(&str, &str)]) -> Result<T, ChannelError> {
         let url = format!("{}/{}", self.base_url, endpoint);
 
         let resp = self
@@ -123,8 +119,7 @@ impl WeixinApi {
         debug!("Fetching WeChat QR code");
 
         // Try direct response first, then wrapped
-        let result: Result<QrCodeData, _> =
-            self.ilink_get("ilink/bot/get_bot_qrcode", &[("bot_type", "3")]).await;
+        let result: Result<QrCodeData, _> = self.ilink_get("ilink/bot/get_bot_qrcode", &[("bot_type", "3")]).await;
 
         match result {
             Ok(data) if data.qrcode.is_some() => Ok(data),
@@ -143,14 +138,16 @@ impl WeixinApi {
     /// `GET /ilink/bot/get_qrcode_status?qrcode=<ticket>`
     pub async fn get_qrcode_status(&self, qrcode: &str) -> Result<QrCodeStatusData, ChannelError> {
         // Try direct response first, then wrapped
-        let result: Result<QrCodeStatusData, _> =
-            self.ilink_get("ilink/bot/get_qrcode_status", &[("qrcode", qrcode)]).await;
+        let result: Result<QrCodeStatusData, _> = self
+            .ilink_get("ilink/bot/get_qrcode_status", &[("qrcode", qrcode)])
+            .await;
 
         match result {
             Ok(data) if data.status.is_some() => Ok(data),
             _ => {
-                let wrapped: ILinkResponse<QrCodeStatusData> =
-                    self.ilink_get("ilink/bot/get_qrcode_status", &[("qrcode", qrcode)]).await?;
+                let wrapped: ILinkResponse<QrCodeStatusData> = self
+                    .ilink_get("ilink/bot/get_qrcode_status", &[("qrcode", qrcode)])
+                    .await?;
                 wrapped
                     .data
                     .ok_or_else(|| ChannelError::PlatformApi("get_qrcode_status returned no data".into()))

--- a/crates/aionui-channel/src/plugins/weixin/api.rs
+++ b/crates/aionui-channel/src/plugins/weixin/api.rs
@@ -1,36 +1,115 @@
-use reqwest::Client;
-use tracing::{debug, warn};
+use std::time::Duration;
 
+use base64::Engine;
+use reqwest::Client;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use tracing::{debug, warn};
+use uuid::Uuid;
+
+use crate::constants::{WEIXIN_API_TIMEOUT, WEIXIN_POLL_TIMEOUT};
 use crate::error::ChannelError;
 
-use super::types::{ILinkResponse, QrCodeData, QrCodeStatusData, SendMessageData, SendMessageRequest, WxUpdate};
+use super::types::{
+    GetUpdatesRequest, GetUpdatesResponse, ILinkResponse, QrCodeData, QrCodeStatusData, SendMessageItem,
+    SendMessageMsg, SendMessageRequest, SendTextItem, ITEM_TYPE_TEXT,
+};
 
 /// HTTP client for the WeChat iLink Bot API.
-///
-/// Provides typed methods for QR code login, long-polling updates,
-/// and message sending.
 pub(crate) struct WeixinApi {
     client: Client,
     base_url: String,
     bot_token: String,
+    wechat_uin: String,
 }
 
 impl WeixinApi {
-    /// Create a new WeChat iLink Bot API client.
     pub fn new(client: Client, base_url: &str, bot_token: &str) -> Self {
-        // Normalize: strip trailing slash
         let base = base_url.trim_end_matches('/');
+
+        let mut uin_bytes = [0u8; 4];
+        getrandom::getrandom(&mut uin_bytes).expect("RNG failure");
+        let wechat_uin = base64::engine::general_purpose::STANDARD.encode(uin_bytes);
+
         Self {
             client,
             base_url: base.to_string(),
             bot_token: bot_token.to_string(),
+            wechat_uin,
         }
     }
 
-    /// Get bot token (for tests / debug).
     #[cfg(test)]
     pub fn bot_token(&self) -> &str {
         &self.bot_token
+    }
+
+    #[cfg(test)]
+    pub fn wechat_uin(&self) -> &str {
+        &self.wechat_uin
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    async fn authenticated_post<T: DeserializeOwned>(
+        &self,
+        endpoint: &str,
+        body: &impl Serialize,
+        timeout: Duration,
+    ) -> Result<T, ChannelError> {
+        let url = format!("{}/{}", self.base_url, endpoint);
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("AuthorizationType", "ilink_bot_token")
+            .header("Authorization", format!("Bearer {}", self.bot_token))
+            .header("X-WECHAT-UIN", &self.wechat_uin)
+            .timeout(timeout)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| ChannelError::PlatformApi(format!("{endpoint} request failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(ChannelError::PlatformApi(format!("{endpoint} HTTP {status}: {text}")));
+        }
+
+        resp.json()
+            .await
+            .map_err(|e| ChannelError::PlatformApi(format!("{endpoint} parse failed: {e}")))
+    }
+
+    async fn ilink_get<T: DeserializeOwned>(
+        &self,
+        endpoint: &str,
+        query: &[(&str, &str)],
+    ) -> Result<T, ChannelError> {
+        let url = format!("{}/{}", self.base_url, endpoint);
+
+        let resp = self
+            .client
+            .get(&url)
+            .header("iLink-App-ClientVersion", "1")
+            .query(query)
+            .send()
+            .await
+            .map_err(|e| ChannelError::PlatformApi(format!("{endpoint} request failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(ChannelError::PlatformApi(format!("{endpoint} HTTP {status}: {text}")));
+        }
+
+        resp.json()
+            .await
+            .map_err(|e| ChannelError::PlatformApi(format!("{endpoint} parse failed: {e}")))
     }
 
     // -----------------------------------------------------------------------
@@ -41,99 +120,60 @@ impl WeixinApi {
     ///
     /// `GET /ilink/bot/get_bot_qrcode?bot_type=3`
     pub async fn get_bot_qrcode(&self) -> Result<QrCodeData, ChannelError> {
-        let url = format!("{}/ilink/bot/get_bot_qrcode", self.base_url);
         debug!("Fetching WeChat QR code");
 
-        let resp: ILinkResponse<QrCodeData> = self
-            .client
-            .get(&url)
-            .query(&[("bot_type", "3")])
-            .send()
-            .await
-            .map_err(|e| ChannelError::PlatformApi(format!("get_bot_qrcode request failed: {e}")))?
-            .json()
-            .await
-            .map_err(|e| ChannelError::PlatformApi(format!("get_bot_qrcode parse failed: {e}")))?;
+        // Try direct response first, then wrapped
+        let result: Result<QrCodeData, _> =
+            self.ilink_get("ilink/bot/get_bot_qrcode", &[("bot_type", "3")]).await;
 
-        if !resp.is_ok() {
-            return Err(ChannelError::PlatformApi(format!(
-                "get_bot_qrcode failed: {}",
-                resp.error_message()
-            )));
+        match result {
+            Ok(data) if data.qrcode.is_some() => Ok(data),
+            _ => {
+                let wrapped: ILinkResponse<QrCodeData> =
+                    self.ilink_get("ilink/bot/get_bot_qrcode", &[("bot_type", "3")]).await?;
+                wrapped
+                    .data
+                    .ok_or_else(|| ChannelError::PlatformApi("get_bot_qrcode returned no data".into()))
+            }
         }
-
-        resp.data
-            .ok_or_else(|| ChannelError::PlatformApi("get_bot_qrcode returned no data".into()))
     }
 
     /// Check the status of a QR code scan.
     ///
     /// `GET /ilink/bot/get_qrcode_status?qrcode=<ticket>`
     pub async fn get_qrcode_status(&self, qrcode: &str) -> Result<QrCodeStatusData, ChannelError> {
-        let url = format!("{}/ilink/bot/get_qrcode_status", self.base_url);
+        // Try direct response first, then wrapped
+        let result: Result<QrCodeStatusData, _> =
+            self.ilink_get("ilink/bot/get_qrcode_status", &[("qrcode", qrcode)]).await;
 
-        let resp: ILinkResponse<QrCodeStatusData> = self
-            .client
-            .get(&url)
-            .query(&[("qrcode", qrcode)])
-            .send()
-            .await
-            .map_err(|e| ChannelError::PlatformApi(format!("get_qrcode_status request failed: {e}")))?
-            .json()
-            .await
-            .map_err(|e| ChannelError::PlatformApi(format!("get_qrcode_status parse failed: {e}")))?;
-
-        if !resp.is_ok() {
-            return Err(ChannelError::PlatformApi(format!(
-                "get_qrcode_status failed: {}",
-                resp.error_message()
-            )));
+        match result {
+            Ok(data) if data.status.is_some() => Ok(data),
+            _ => {
+                let wrapped: ILinkResponse<QrCodeStatusData> =
+                    self.ilink_get("ilink/bot/get_qrcode_status", &[("qrcode", qrcode)]).await?;
+                wrapped
+                    .data
+                    .ok_or_else(|| ChannelError::PlatformApi("get_qrcode_status returned no data".into()))
+            }
         }
-
-        resp.data
-            .ok_or_else(|| ChannelError::PlatformApi("get_qrcode_status returned no data".into()))
     }
 
     // -----------------------------------------------------------------------
     // Long-polling
     // -----------------------------------------------------------------------
 
-    /// Long-poll for new updates.
+    /// Long-poll for new updates using buffer-based protocol.
     ///
     /// `POST /ilink/bot/getupdates`
-    ///
-    /// - `offset`: return updates with update_id >= offset
-    /// - `timeout`: long-polling timeout in seconds
-    pub async fn get_updates(&self, offset: Option<i64>, timeout: u32) -> Result<Vec<WxUpdate>, ChannelError> {
-        let url = format!("{}/ilink/bot/getupdates", self.base_url);
+    pub async fn get_updates(&self, buf: &str) -> Result<GetUpdatesResponse, ChannelError> {
+        let body = GetUpdatesRequest {
+            get_updates_buf: buf.to_string(),
+            base_info: serde_json::json!({}),
+        };
 
-        let mut body = serde_json::json!({
-            "botToken": self.bot_token,
-            "timeout": timeout,
-        });
+        let timeout = WEIXIN_POLL_TIMEOUT + Duration::from_secs(10);
 
-        if let Some(off) = offset {
-            body["offset"] = serde_json::json!(off);
-        }
-
-        let resp: ILinkResponse<Vec<WxUpdate>> = self
-            .client
-            .post(&url)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| ChannelError::PlatformApi(format!("getupdates request failed: {e}")))?
-            .json()
-            .await
-            .map_err(|e| ChannelError::PlatformApi(format!("getupdates parse failed: {e}")))?;
-
-        if !resp.is_ok() {
-            let msg = resp.error_message();
-            warn!("WeChat getupdates error: {msg}");
-            return Err(ChannelError::PlatformApi(format!("getupdates failed: {msg}")));
-        }
-
-        Ok(resp.data.unwrap_or_default())
+        self.authenticated_post("ilink/bot/getupdates", &body, timeout).await
     }
 
     // -----------------------------------------------------------------------
@@ -143,34 +183,38 @@ impl WeixinApi {
     /// Send a text message.
     ///
     /// `POST /ilink/bot/sendmessage`
-    pub async fn send_message(&self, req: &SendMessageRequest) -> Result<SendMessageData, ChannelError> {
-        let url = format!("{}/ilink/bot/sendmessage", self.base_url);
-        debug!(chat_id = %req.chat_id, "Sending WeChat message");
+    pub async fn send_message(
+        &self,
+        to_user_id: &str,
+        text: &str,
+        context_token: Option<&str>,
+    ) -> Result<(), ChannelError> {
+        debug!(to_user_id, "Sending WeChat message");
 
-        let mut body = serde_json::to_value(req).map_err(ChannelError::Json)?;
-        // Inject bot token into the request body
-        body["botToken"] = serde_json::json!(self.bot_token);
+        let body = SendMessageRequest {
+            msg: SendMessageMsg {
+                to_user_id: to_user_id.to_string(),
+                client_id: Uuid::new_v4().to_string(),
+                message_type: 2,
+                message_state: 2,
+                item_list: vec![SendMessageItem {
+                    item_type: ITEM_TYPE_TEXT,
+                    text_item: Some(SendTextItem { text: text.to_string() }),
+                }],
+                context_token: context_token.map(String::from),
+            },
+            base_info: serde_json::json!({}),
+        };
 
-        let resp: ILinkResponse<SendMessageData> = self
-            .client
-            .post(&url)
-            .json(&body)
-            .send()
+        let _resp: serde_json::Value = self
+            .authenticated_post("ilink/bot/sendmessage", &body, WEIXIN_API_TIMEOUT)
             .await
-            .map_err(|e| ChannelError::MessageSendFailed(format!("sendmessage request failed: {e}")))?
-            .json()
-            .await
-            .map_err(|e| ChannelError::MessageSendFailed(format!("sendmessage parse failed: {e}")))?;
+            .map_err(|e| {
+                warn!(to_user_id, error = %e, "sendmessage failed");
+                ChannelError::MessageSendFailed(format!("sendmessage failed: {e}"))
+            })?;
 
-        if !resp.is_ok() {
-            return Err(ChannelError::MessageSendFailed(format!(
-                "sendmessage failed: {}",
-                resp.error_message()
-            )));
-        }
-
-        resp.data
-            .ok_or_else(|| ChannelError::MessageSendFailed("sendmessage returned no data".into()))
+        Ok(())
     }
 }
 
@@ -181,16 +225,37 @@ mod tests {
     #[test]
     fn api_stores_credentials() {
         let client = Client::new();
-        let api = WeixinApi::new(client, "https://api.example.com/", "tok_abc");
-        assert_eq!(api.base_url, "https://api.example.com");
+        let api = WeixinApi::new(client, "https://ilinkai.weixin.qq.com/", "tok_abc");
+        assert_eq!(api.base_url, "https://ilinkai.weixin.qq.com");
         assert_eq!(api.bot_token(), "tok_abc");
     }
 
     #[test]
     fn api_normalizes_trailing_slash() {
         let client = Client::new();
-        let api = WeixinApi::new(client, "https://api.example.com///", "tok");
-        // strips only trailing slashes
+        let api = WeixinApi::new(client, "https://ilinkai.weixin.qq.com///", "tok");
         assert!(api.base_url.ends_with("com"));
+    }
+
+    #[test]
+    fn api_generates_wechat_uin() {
+        let client = Client::new();
+        let api = WeixinApi::new(client, "https://example.com", "tok");
+        // base64 of 4 bytes should be 8 chars (with padding)
+        assert_eq!(api.wechat_uin().len(), 8);
+        // Should be valid base64
+        let decoded = base64::engine::general_purpose::STANDARD.decode(api.wechat_uin());
+        assert!(decoded.is_ok());
+        assert_eq!(decoded.unwrap().len(), 4);
+    }
+
+    #[test]
+    fn api_generates_different_uin_each_time() {
+        let client1 = Client::new();
+        let api1 = WeixinApi::new(client1, "https://example.com", "tok");
+        let client2 = Client::new();
+        let api2 = WeixinApi::new(client2, "https://example.com", "tok");
+        // Extremely unlikely to collide (2^32 space)
+        assert_ne!(api1.wechat_uin(), api2.wechat_uin());
     }
 }

--- a/crates/aionui-channel/src/plugins/weixin/login.rs
+++ b/crates/aionui-channel/src/plugins/weixin/login.rs
@@ -117,7 +117,9 @@ async fn login_flow(tx: mpsc::Sender<WeixinLoginEvent>) {
         Some(ref url) if !url.is_empty() => url.clone(),
         _ => {
             let _ = tx
-                .send(WeixinLoginEvent::Error("QR code response missing qrcode_img_content".into()))
+                .send(WeixinLoginEvent::Error(
+                    "QR code response missing qrcode_img_content".into(),
+                ))
                 .await;
             return;
         }

--- a/crates/aionui-channel/src/plugins/weixin/login.rs
+++ b/crates/aionui-channel/src/plugins/weixin/login.rs
@@ -8,7 +8,7 @@ use super::api::WeixinApi;
 use super::types::{SseDoneEvent, SseErrorEvent, SseQrEvent};
 
 /// Default base URL for the iLink Bot login API.
-const LOGIN_BASE_URL: &str = "https://api.ilink.bot";
+const LOGIN_BASE_URL: &str = "https://ilinkai.weixin.qq.com";
 
 /// Polling interval for checking QR code scan status.
 const QR_POLL_INTERVAL: Duration = Duration::from_secs(2);
@@ -71,15 +71,6 @@ impl WeixinLoginEvent {
 }
 
 /// Start the WeChat QR code login flow, returning a channel of SSE events.
-///
-/// The flow:
-/// 1. Fetch QR code from iLink Bot API → emit `qr` event
-/// 2. Poll scan status every 2s → emit `scanned` when user scans
-/// 3. On confirmation → emit `done` with bot credentials
-/// 4. On error/timeout → emit `error`
-///
-/// The returned receiver should be consumed by an SSE endpoint handler
-/// (wired in the routes layer, task 10.12).
 pub fn weixin_login_stream() -> mpsc::Receiver<WeixinLoginEvent> {
     let (tx, rx) = mpsc::channel(16);
     tokio::spawn(login_flow(tx));
@@ -88,7 +79,7 @@ pub fn weixin_login_stream() -> mpsc::Receiver<WeixinLoginEvent> {
 
 /// Internal login flow that drives the SSE event sequence.
 async fn login_flow(tx: mpsc::Sender<WeixinLoginEvent>) {
-    let client = match Client::builder().timeout(Duration::from_secs(30)).build() {
+    let client = match Client::builder().timeout(Duration::from_secs(40)).build() {
         Ok(c) => c,
         Err(e) => {
             let _ = tx
@@ -98,8 +89,6 @@ async fn login_flow(tx: mpsc::Sender<WeixinLoginEvent>) {
         }
     };
 
-    // The login API uses a temporary token-less client; bot_token is
-    // received on successful login.
     let api = WeixinApi::new(client, LOGIN_BASE_URL, "");
 
     // Step 1: Fetch QR code
@@ -124,9 +113,19 @@ async fn login_flow(tx: mpsc::Sender<WeixinLoginEvent>) {
         }
     };
 
+    let qr_content = match qr_data.qrcode_img_content {
+        Some(ref url) if !url.is_empty() => url.clone(),
+        _ => {
+            let _ = tx
+                .send(WeixinLoginEvent::Error("QR code response missing qrcode_img_content".into()))
+                .await;
+            return;
+        }
+    };
+
     info!("WeChat QR code generated, waiting for scan");
-    if tx.send(WeixinLoginEvent::Qr(ticket.clone())).await.is_err() {
-        return; // receiver dropped
+    if tx.send(WeixinLoginEvent::Qr(qr_content)).await.is_err() {
+        return;
     }
 
     // Step 2: Poll for scan status
@@ -147,16 +146,17 @@ async fn login_flow(tx: mpsc::Sender<WeixinLoginEvent>) {
                 debug!(status = state, "WeChat QR code status");
 
                 match state {
-                    "scanned" if !scanned_sent => {
+                    // NOTE: The API returns "scaned" (missing an 'n') — this is intentional.
+                    "scaned" if !scanned_sent => {
                         scanned_sent = true;
                         if tx.send(WeixinLoginEvent::Scanned).await.is_err() {
                             return;
                         }
                     }
                     "confirmed" => {
-                        let account_id = status.account_id.unwrap_or_default();
+                        let account_id = status.ilink_bot_id.unwrap_or_default();
                         let bot_token = status.bot_token.unwrap_or_default();
-                        let base_url = status.base_url.unwrap_or_else(|| LOGIN_BASE_URL.into());
+                        let base_url = status.baseurl.unwrap_or_else(|| LOGIN_BASE_URL.into());
 
                         info!(
                             account_id = %account_id,
@@ -175,11 +175,16 @@ async fn login_flow(tx: mpsc::Sender<WeixinLoginEvent>) {
                         let _ = tx.send(WeixinLoginEvent::Error("QR code expired".into())).await;
                         return;
                     }
-                    // "wait" or unknown → keep polling
                     _ => {}
                 }
             }
             Err(e) => {
+                // Timeout on long-poll is expected — treat as "wait" and retry
+                let err_str = e.to_string();
+                if err_str.contains("timed out") || err_str.contains("Timeout") {
+                    debug!("QR status poll timeout, retrying");
+                    continue;
+                }
                 error!(error = %e, "Failed to poll QR code status");
                 let _ = tx
                     .send(WeixinLoginEvent::Error(format!("Status poll failed: {e}")))
@@ -233,7 +238,7 @@ mod tests {
         let evt = WeixinLoginEvent::Done {
             account_id: "acc_1".into(),
             bot_token: "tok_1".into(),
-            base_url: "https://api.example.com".into(),
+            base_url: "https://ilinkai.weixin.qq.com".into(),
         };
         let json = evt.to_json_data();
         assert!(json.contains("accountId"));

--- a/crates/aionui-channel/src/plugins/weixin/plugin.rs
+++ b/crates/aionui-channel/src/plugins/weixin/plugin.rs
@@ -16,7 +16,7 @@ use crate::types::{
 };
 
 use super::api::WeixinApi;
-use super::types::{WeixinRawItem, WeixinRawMessage, ITEM_TYPE_TEXT, ITEM_TYPE_VOICE};
+use super::types::{ITEM_TYPE_TEXT, ITEM_TYPE_VOICE, WeixinRawItem, WeixinRawMessage};
 
 /// Default base URL for the iLink Bot API.
 const DEFAULT_BASE_URL: &str = "https://ilinkai.weixin.qq.com";
@@ -218,8 +218,7 @@ async fn poll_loop(
 
         match api.get_updates(&buf).await {
             Ok(resp) => {
-                let is_api_error =
-                    resp.ret.unwrap_or(0) != 0 || resp.errcode.unwrap_or(0) != 0;
+                let is_api_error = resp.ret.unwrap_or(0) != 0 || resp.errcode.unwrap_or(0) != 0;
 
                 if is_api_error {
                     consecutive_failures += 1;

--- a/crates/aionui-channel/src/plugins/weixin/plugin.rs
+++ b/crates/aionui-channel/src/plugins/weixin/plugin.rs
@@ -1,33 +1,31 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use dashmap::DashMap;
 use reqwest::Client;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
-use crate::constants::{WEIXIN_MAX_RETRIES, WEIXIN_RETRY_DELAY};
+use crate::constants::{WEIXIN_BACKOFF_DELAY, WEIXIN_MAX_RETRIES, WEIXIN_POLL_TIMEOUT, WEIXIN_RETRY_DELAY};
 use crate::error::ChannelError;
 use crate::plugin::{ChannelPlugin, PluginCallbacks};
 use crate::types::{
-    BotInfo, MessageContentType, PluginConfig, PluginStatus, PluginType, UnifiedAttachment, UnifiedIncomingMessage,
-    UnifiedMessageContent, UnifiedOutgoingMessage, UnifiedUser,
+    BotInfo, MessageContentType, PluginConfig, PluginStatus, PluginType, UnifiedIncomingMessage, UnifiedMessageContent,
+    UnifiedOutgoingMessage, UnifiedUser,
 };
 
 use super::api::WeixinApi;
-use super::types::{SendMessageRequest, WxMessage};
-
-/// iLink Bot long-polling timeout in seconds.
-const POLL_TIMEOUT: u32 = 25;
+use super::types::{WeixinRawItem, WeixinRawMessage, ITEM_TYPE_TEXT, ITEM_TYPE_VOICE};
 
 /// Default base URL for the iLink Bot API.
-const DEFAULT_BASE_URL: &str = "https://api.ilink.bot";
+const DEFAULT_BASE_URL: &str = "https://ilinkai.weixin.qq.com";
 
 /// WeChat (iLink Bot) platform plugin.
 ///
-/// Connects via long-polling (`getupdates`), handles text/voice/image/
-/// file/card messages. Does not support editing messages (WeChat
-/// limitation); `edit_message` sends a new reply instead.
+/// Connects via long-polling (buffer-based `getupdates`), handles text/voice
+/// messages. Does not support editing messages (WeChat limitation);
+/// `edit_message` sends a new reply instead.
 pub struct WeixinPlugin {
     status: PluginStatus,
     bot_info: Option<BotInfo>,
@@ -35,6 +33,7 @@ pub struct WeixinPlugin {
     api: Option<Arc<WeixinApi>>,
     poll_handle: Option<JoinHandle<()>>,
     shutdown_tx: Option<watch::Sender<bool>>,
+    context_tokens: Arc<DashMap<String, String>>,
 }
 
 impl Default for WeixinPlugin {
@@ -46,6 +45,7 @@ impl Default for WeixinPlugin {
             api: None,
             poll_handle: None,
             shutdown_tx: None,
+            context_tokens: Arc::new(DashMap::new()),
         }
     }
 }
@@ -83,7 +83,6 @@ impl ChannelPlugin for WeixinPlugin {
                 ChannelError::InvalidConfig("Missing WeChat account_id".into())
             })?;
 
-        // Use base URL from extra config, or the default iLink Bot URL.
         let base_url = config
             .credentials
             .extra
@@ -92,7 +91,7 @@ impl ChannelPlugin for WeixinPlugin {
             .unwrap_or(DEFAULT_BASE_URL);
 
         let http_client = Client::builder()
-            .timeout(Duration::from_secs(POLL_TIMEOUT as u64 + 10))
+            .timeout(Duration::from_secs(WEIXIN_POLL_TIMEOUT.as_secs() + 10))
             .build()
             .map_err(|e| {
                 self.status = PluginStatus::Error;
@@ -112,16 +111,16 @@ impl ChannelPlugin for WeixinPlugin {
 
         self.api = Some(api);
 
-        // Set up shutdown channel and spawn the long-polling task
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         self.shutdown_tx = Some(shutdown_tx);
 
         let api_clone = Arc::clone(self.api.as_ref().expect("api just set"));
+        let context_tokens = Arc::clone(&self.context_tokens);
         self.poll_handle = Some(tokio::spawn(poll_loop(
             api_clone,
             callbacks.message_tx,
-            callbacks.confirm_tx,
             shutdown_rx,
+            context_tokens,
         )));
 
         self.status = PluginStatus::Ready;
@@ -130,7 +129,6 @@ impl ChannelPlugin for WeixinPlugin {
 
     async fn start(&mut self) -> Result<(), ChannelError> {
         self.status = PluginStatus::Starting;
-        // Polling task was spawned in initialize; start just transitions status.
         self.status = PluginStatus::Running;
         info!("WeChat plugin started");
         Ok(())
@@ -148,6 +146,7 @@ impl ChannelPlugin for WeixinPlugin {
         }
 
         self.api = None;
+        self.context_tokens.clear();
         self.status = PluginStatus::Stopped;
         info!("WeChat plugin stopped");
         Ok(())
@@ -160,19 +159,13 @@ impl ChannelPlugin for WeixinPlugin {
             .ok_or_else(|| ChannelError::PlatformApi("Plugin not initialized".into()))?;
 
         let text = message.text.as_deref().unwrap_or("").to_string();
+        let context_token = self.context_tokens.get(chat_id).map(|v| v.clone());
 
-        let req = SendMessageRequest {
-            chat_id: chat_id.to_string(),
-            text: Some(text),
-            msg_type: Some("text".into()),
-        };
-
-        let data = api.send_message(&req).await?;
-        Ok(data.message_id.unwrap_or_default())
+        api.send_message(chat_id, &text, context_token.as_deref()).await?;
+        Ok(String::new())
     }
 
     /// WeChat does not support editing messages.
-    /// Fallback: send a new message as a reply.
     async fn edit_message(
         &self,
         chat_id: &str,
@@ -184,7 +177,6 @@ impl ChannelPlugin for WeixinPlugin {
     }
 
     fn active_user_count(&self) -> usize {
-        // Tracked externally by ChannelManager via SessionManager
         0
     }
 
@@ -206,21 +198,17 @@ impl ChannelPlugin for WeixinPlugin {
 }
 
 // ---------------------------------------------------------------------------
-// Long-polling loop
+// Long-polling loop (buffer-based protocol)
 // ---------------------------------------------------------------------------
 
-/// Background task that continuously polls iLink Bot for updates.
-///
-/// Retries on error up to `WEIXIN_MAX_RETRIES` consecutive failures
-/// with `WEIXIN_RETRY_DELAY` between attempts.
 async fn poll_loop(
     api: Arc<WeixinApi>,
     message_tx: tokio::sync::mpsc::Sender<UnifiedIncomingMessage>,
-    _confirm_tx: tokio::sync::mpsc::Sender<(String, String)>,
     mut shutdown_rx: watch::Receiver<bool>,
+    context_tokens: Arc<DashMap<String, String>>,
 ) {
-    let mut offset: Option<i64> = None;
-    let mut consecutive_errors: u32 = 0;
+    let mut buf = String::new();
+    let mut consecutive_failures: u32 = 0;
 
     loop {
         if *shutdown_rx.borrow() {
@@ -228,36 +216,71 @@ async fn poll_loop(
             break;
         }
 
-        match api.get_updates(offset, POLL_TIMEOUT).await {
-            Ok(updates) => {
-                consecutive_errors = 0;
+        match api.get_updates(&buf).await {
+            Ok(resp) => {
+                let is_api_error =
+                    resp.ret.unwrap_or(0) != 0 || resp.errcode.unwrap_or(0) != 0;
 
-                for update in updates {
-                    offset = Some(update.update_id + 1);
+                if is_api_error {
+                    consecutive_failures += 1;
+                    warn!(
+                        ret = resp.ret,
+                        errcode = resp.errcode,
+                        consecutive_failures,
+                        "WeChat getupdates API error"
+                    );
 
-                    if let Some(msg) = update.message {
-                        handle_message(&msg, &message_tx).await;
+                    if consecutive_failures >= WEIXIN_MAX_RETRIES {
+                        consecutive_failures = 0;
+                        tokio::select! {
+                            _ = tokio::time::sleep(WEIXIN_BACKOFF_DELAY) => {}
+                            _ = shutdown_rx.changed() => {
+                                debug!("WeChat poll loop shutdown during backoff");
+                                break;
+                            }
+                        }
+                    } else {
+                        tokio::select! {
+                            _ = tokio::time::sleep(WEIXIN_RETRY_DELAY) => {}
+                            _ = shutdown_rx.changed() => {
+                                debug!("WeChat poll loop shutdown during retry");
+                                break;
+                            }
+                        }
                     }
+                    continue;
+                }
+
+                consecutive_failures = 0;
+
+                if let Some(new_buf) = resp.get_updates_buf {
+                    buf = new_buf;
+                }
+
+                for msg in resp.msgs.unwrap_or_default() {
+                    handle_message(&msg, &message_tx, &context_tokens).await;
                 }
             }
             Err(e) => {
-                consecutive_errors += 1;
-                warn!(
-                    error = %e,
-                    consecutive_errors,
-                    "WeChat poll error"
-                );
+                consecutive_failures += 1;
+                warn!(error = %e, consecutive_failures, "WeChat poll error");
 
-                if consecutive_errors >= WEIXIN_MAX_RETRIES {
-                    error!("WeChat max retry attempts reached, stopping poll loop");
-                    break;
-                }
-
-                tokio::select! {
-                    _ = tokio::time::sleep(WEIXIN_RETRY_DELAY) => {}
-                    _ = shutdown_rx.changed() => {
-                        debug!("WeChat poll loop shutdown during backoff");
-                        break;
+                if consecutive_failures >= WEIXIN_MAX_RETRIES {
+                    consecutive_failures = 0;
+                    tokio::select! {
+                        _ = tokio::time::sleep(WEIXIN_BACKOFF_DELAY) => {}
+                        _ = shutdown_rx.changed() => {
+                            debug!("WeChat poll loop shutdown during backoff");
+                            break;
+                        }
+                    }
+                } else {
+                    tokio::select! {
+                        _ = tokio::time::sleep(WEIXIN_RETRY_DELAY) => {}
+                        _ = shutdown_rx.changed() => {
+                            debug!("WeChat poll loop shutdown during retry");
+                            break;
+                        }
                     }
                 }
             }
@@ -271,33 +294,52 @@ async fn poll_loop(
 // Message handling
 // ---------------------------------------------------------------------------
 
-/// Convert a WeChat message into a `UnifiedIncomingMessage` and forward it.
-async fn handle_message(msg: &WxMessage, message_tx: &tokio::sync::mpsc::Sender<UnifiedIncomingMessage>) {
-    let from = match &msg.from {
-        Some(u) => u,
-        None => return, // system messages without a sender
+async fn handle_message(
+    msg: &WeixinRawMessage,
+    message_tx: &tokio::sync::mpsc::Sender<UnifiedIncomingMessage>,
+    context_tokens: &DashMap<String, String>,
+) {
+    let from_user_id = match &msg.from_user_id {
+        Some(id) if !id.is_empty() => id.clone(),
+        _ => return,
     };
 
-    let user = UnifiedUser {
-        id: from.id.clone(),
-        username: None,
-        display_name: from.name.clone().unwrap_or_else(|| from.id.clone()),
-        avatar_url: from.avatar.clone(),
-    };
+    // Store context_token for reply use
+    if let Some(ctx) = &msg.context_token
+        && !ctx.is_empty()
+    {
+        context_tokens.insert(from_user_id.clone(), ctx.clone());
+    }
 
-    let (content_type, text, attachments) = extract_content(msg);
+    let items = msg.item_list.as_deref().unwrap_or_default();
+    let (content_type, text, _has_media) = extract_content(items);
+
+    if text.is_empty() {
+        return;
+    }
+
+    let display_name = if from_user_id.len() > 6 {
+        from_user_id[from_user_id.len() - 6..].to_string()
+    } else {
+        from_user_id.clone()
+    };
 
     let unified = UnifiedIncomingMessage {
-        id: msg.message_id.clone(),
+        id: msg.msg_id.clone().unwrap_or_default(),
         platform: PluginType::Weixin,
-        chat_id: msg.chat_id.clone(),
-        user,
+        chat_id: from_user_id.clone(),
+        user: UnifiedUser {
+            id: from_user_id,
+            username: None,
+            display_name,
+            avatar_url: None,
+        },
         content: UnifiedMessageContent {
             content_type,
             text,
-            attachments,
+            attachments: None,
         },
-        timestamp: msg.date,
+        timestamp: chrono_now(),
         reply_to_message_id: None,
         action: None,
         raw: None,
@@ -306,72 +348,54 @@ async fn handle_message(msg: &WxMessage, message_tx: &tokio::sync::mpsc::Sender<
     let _ = message_tx.send(unified).await;
 }
 
-/// Extract content type, text, and attachments from a WeChat message.
-fn extract_content(msg: &WxMessage) -> (MessageContentType, String, Option<Vec<UnifiedAttachment>>) {
-    let msg_type = msg.msg_type.as_deref().unwrap_or("text");
+/// Extract text content from item_list.
+///
+/// Returns (content_type, combined_text, has_media_items).
+fn extract_content(items: &[WeixinRawItem]) -> (MessageContentType, String, bool) {
+    let mut text_parts: Vec<&str> = Vec::new();
+    let mut has_media = false;
 
-    match msg_type {
-        "image" => {
-            let attachments = msg.file.as_ref().map(|f| {
-                vec![UnifiedAttachment {
-                    file_id: f.file_id.clone(),
-                    file_name: f.file_name.clone(),
-                    mime_type: f.mime_type.clone().or(Some("image/jpeg".into())),
-                    file_size: f.file_size,
-                    url: f.url.clone(),
-                }]
-            });
-            let text = msg.text.clone().unwrap_or_default();
-            (MessageContentType::Photo, text, attachments)
-        }
-        "voice" => {
-            let attachments = msg.file.as_ref().map(|f| {
-                vec![UnifiedAttachment {
-                    file_id: f.file_id.clone(),
-                    file_name: f.file_name.clone(),
-                    mime_type: f.mime_type.clone(),
-                    file_size: f.file_size,
-                    url: f.url.clone(),
-                }]
-            });
-            let text = msg.text.clone().unwrap_or_default();
-            (MessageContentType::Voice, text, attachments)
-        }
-        "file" => {
-            let attachments = msg.file.as_ref().map(|f| {
-                vec![UnifiedAttachment {
-                    file_id: f.file_id.clone(),
-                    file_name: f.file_name.clone(),
-                    mime_type: f.mime_type.clone(),
-                    file_size: f.file_size,
-                    url: f.url.clone(),
-                }]
-            });
-            let text = msg.text.clone().unwrap_or_default();
-            (MessageContentType::Document, text, attachments)
-        }
-        "card" => {
-            let text = msg
-                .card
-                .as_ref()
-                .and_then(|c| c.description.clone())
-                .or_else(|| msg.card.as_ref().and_then(|c| c.title.clone()))
-                .unwrap_or_default();
-            (MessageContentType::Text, text, None)
-        }
-        // Default: text
-        _ => {
-            let text = msg.text.clone().unwrap_or_default();
-            if text.starts_with('/') {
-                return (MessageContentType::Command, text, None);
+    for item in items {
+        match item.item_type {
+            Some(ITEM_TYPE_TEXT) => {
+                if let Some(ref ti) = item.text_item
+                    && let Some(ref t) = ti.text
+                {
+                    let trimmed = t.trim();
+                    if !trimmed.is_empty() {
+                        text_parts.push(trimmed);
+                    }
+                }
             }
-            (MessageContentType::Text, text, None)
+            Some(ITEM_TYPE_VOICE) => {
+                if let Some(ref vi) = item.voice_item
+                    && let Some(ref t) = vi.text
+                {
+                    let trimmed = t.trim();
+                    if !trimmed.is_empty() {
+                        text_parts.push(trimmed);
+                    }
+                }
+            }
+            Some(2) | Some(4) => {
+                has_media = true;
+            }
+            _ => {}
         }
     }
+
+    let text = text_parts.join("\n\n");
+
+    let content_type = if text.starts_with('/') {
+        MessageContentType::Command
+    } else {
+        MessageContentType::Text
+    };
+
+    (content_type, text, has_media)
 }
 
-/// Current unix timestamp in seconds.
-fn _chrono_now() -> i64 {
+fn chrono_now() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
@@ -391,107 +415,76 @@ mod tests {
     // -- extract_content -------------------------------------------------------
 
     #[test]
-    fn extract_text_message() {
-        let msg = make_wx_message("text", Some("Hello world"), None, None);
-        let (ct, text, att) = extract_content(&msg);
+    fn extract_text_only() {
+        let items = vec![make_text_item("Hello world")];
+        let (ct, text, has_media) = extract_content(&items);
         assert_eq!(ct, MessageContentType::Text);
         assert_eq!(text, "Hello world");
-        assert!(att.is_none());
+        assert!(!has_media);
     }
 
     #[test]
-    fn extract_command_message() {
-        let msg = make_wx_message("text", Some("/start"), None, None);
-        let (ct, text, _) = extract_content(&msg);
+    fn extract_command() {
+        let items = vec![make_text_item("/start")];
+        let (ct, text, _) = extract_content(&items);
         assert_eq!(ct, MessageContentType::Command);
         assert_eq!(text, "/start");
     }
 
     #[test]
-    fn extract_image_message() {
-        let file = super::super::types::WxFile {
-            file_id: Some("img_1".into()),
-            file_name: Some("photo.jpg".into()),
-            mime_type: Some("image/jpeg".into()),
-            file_size: Some(5000),
-            url: Some("https://example.com/img_1".into()),
-        };
-        let msg = make_wx_message("image", None, Some(file), None);
-        let (ct, _, att) = extract_content(&msg);
-        assert_eq!(ct, MessageContentType::Photo);
-        let atts = att.unwrap();
-        assert_eq!(atts.len(), 1);
-        assert_eq!(atts[0].file_id.as_deref(), Some("img_1"));
-    }
-
-    #[test]
-    fn extract_voice_message() {
-        let file = super::super::types::WxFile {
-            file_id: Some("voice_1".into()),
-            file_name: None,
-            mime_type: Some("audio/amr".into()),
-            file_size: Some(3000),
-            url: None,
-        };
-        let msg = make_wx_message("voice", None, Some(file), None);
-        let (ct, _, att) = extract_content(&msg);
-        assert_eq!(ct, MessageContentType::Voice);
-        assert!(att.is_some());
-    }
-
-    #[test]
-    fn extract_file_message() {
-        let file = super::super::types::WxFile {
-            file_id: Some("doc_1".into()),
-            file_name: Some("report.pdf".into()),
-            mime_type: Some("application/pdf".into()),
-            file_size: Some(10240),
-            url: None,
-        };
-        let msg = make_wx_message("file", None, Some(file), None);
-        let (ct, _, att) = extract_content(&msg);
-        assert_eq!(ct, MessageContentType::Document);
-        let atts = att.unwrap();
-        assert_eq!(atts[0].file_name.as_deref(), Some("report.pdf"));
-    }
-
-    #[test]
-    fn extract_card_message() {
-        let card = super::super::types::WxCard {
-            title: Some("Alert".into()),
-            description: Some("Something happened".into()),
-        };
-        let msg = make_wx_message("card", None, None, Some(card));
-        let (ct, text, _) = extract_content(&msg);
+    fn extract_voice_text() {
+        let items = vec![WeixinRawItem {
+            item_type: Some(ITEM_TYPE_VOICE),
+            voice_item: Some(super::super::types::VoiceItem {
+                text: Some("transcribed text".into()),
+            }),
+            ..Default::default()
+        }];
+        let (ct, text, _) = extract_content(&items);
         assert_eq!(ct, MessageContentType::Text);
-        assert_eq!(text, "Something happened");
+        assert_eq!(text, "transcribed text");
     }
 
     #[test]
-    fn extract_card_message_fallback_to_title() {
-        let card = super::super::types::WxCard {
-            title: Some("Alert Title".into()),
-            description: None,
-        };
-        let msg = make_wx_message("card", None, None, Some(card));
-        let (_, text, _) = extract_content(&msg);
-        assert_eq!(text, "Alert Title");
+    fn extract_mixed_text_and_voice() {
+        let items = vec![
+            make_text_item("Hello"),
+            WeixinRawItem {
+                item_type: Some(ITEM_TYPE_VOICE),
+                voice_item: Some(super::super::types::VoiceItem {
+                    text: Some("voice part".into()),
+                }),
+                ..Default::default()
+            },
+        ];
+        let (_, text, _) = extract_content(&items);
+        assert_eq!(text, "Hello\n\nvoice part");
     }
 
     #[test]
-    fn extract_unknown_type_defaults_to_text() {
-        let msg = make_wx_message("unknown_type", Some("data"), None, None);
-        let (ct, text, _) = extract_content(&msg);
-        assert_eq!(ct, MessageContentType::Text);
-        assert_eq!(text, "data");
+    fn extract_media_items_detected() {
+        let items = vec![WeixinRawItem {
+            item_type: Some(2),
+            image_item: Some(super::super::types::MediaItemData {
+                media: Some(super::super::types::MediaEncryptInfo {
+                    encrypt_query_param: Some("enc".into()),
+                    aes_key: Some("key".into()),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }];
+        let (_, text, has_media) = extract_content(&items);
+        assert!(text.is_empty());
+        assert!(has_media);
     }
 
     #[test]
-    fn extract_image_without_file_has_no_attachments() {
-        let msg = make_wx_message("image", None, None, None);
-        let (ct, _, att) = extract_content(&msg);
-        assert_eq!(ct, MessageContentType::Photo);
-        assert!(att.is_none());
+    fn extract_empty_items() {
+        let items: Vec<WeixinRawItem> = vec![];
+        let (_, text, has_media) = extract_content(&items);
+        assert!(text.is_empty());
+        assert!(!has_media);
     }
 
     // -- WeixinPlugin constructor -----------------------------------------------
@@ -542,25 +535,13 @@ mod tests {
 
     // -- Test helpers -----------------------------------------------------------
 
-    fn make_wx_message(
-        msg_type: &str,
-        text: Option<&str>,
-        file: Option<super::super::types::WxFile>,
-        card: Option<super::super::types::WxCard>,
-    ) -> WxMessage {
-        WxMessage {
-            message_id: "msg_test".into(),
-            chat_id: "chat_test".into(),
-            from: Some(super::super::types::WxUser {
-                id: "user_1".into(),
-                name: Some("TestUser".into()),
-                avatar: None,
+    fn make_text_item(text: &str) -> WeixinRawItem {
+        WeixinRawItem {
+            item_type: Some(ITEM_TYPE_TEXT),
+            text_item: Some(super::super::types::TextItem {
+                text: Some(text.into()),
             }),
-            date: 1700000000,
-            text: text.map(String::from),
-            msg_type: Some(msg_type.into()),
-            file,
-            card,
+            ..Default::default()
         }
     }
 

--- a/crates/aionui-channel/src/plugins/weixin/types.rs
+++ b/crates/aionui-channel/src/plugins/weixin/types.rs
@@ -289,10 +289,16 @@ mod tests {
         let items = msgs[0].item_list.as_ref().unwrap();
         assert_eq!(items[0].item_type, Some(2));
         let img = items[0].image_item.as_ref().unwrap();
-        assert_eq!(img.media.as_ref().unwrap().encrypt_query_param.as_deref(), Some("enc_param"));
+        assert_eq!(
+            img.media.as_ref().unwrap().encrypt_query_param.as_deref(),
+            Some("enc_param")
+        );
         assert_eq!(img.aeskey.as_deref(), Some("hex_key"));
         assert_eq!(items[1].item_type, Some(4));
-        assert_eq!(items[1].file_item.as_ref().unwrap().file_name.as_deref(), Some("doc.pdf"));
+        assert_eq!(
+            items[1].file_item.as_ref().unwrap().file_name.as_deref(),
+            Some("doc.pdf")
+        );
     }
 
     #[test]
@@ -353,7 +359,9 @@ mod tests {
 
     #[test]
     fn serialize_sse_qr_event() {
-        let evt = SseQrEvent { qrcode_data: "ticket_abc".into() };
+        let evt = SseQrEvent {
+            qrcode_data: "ticket_abc".into(),
+        };
         let json = serde_json::to_string(&evt).unwrap();
         assert!(json.contains(r#""qrcodeData":"ticket_abc"#));
     }
@@ -373,7 +381,9 @@ mod tests {
 
     #[test]
     fn serialize_sse_error_event() {
-        let evt = SseErrorEvent { message: "timeout".into() };
+        let evt = SseErrorEvent {
+            message: "timeout".into(),
+        };
         let json = serde_json::to_string(&evt).unwrap();
         assert!(json.contains(r#""message":"timeout"#));
     }

--- a/crates/aionui-channel/src/plugins/weixin/types.rs
+++ b/crates/aionui-channel/src/plugins/weixin/types.rs
@@ -1,193 +1,189 @@
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
-// iLink Bot API response envelope
+// Item type constants
 // ---------------------------------------------------------------------------
 
-/// Generic iLink Bot API response wrapper.
+pub(crate) const ITEM_TYPE_TEXT: i32 = 1;
+#[allow(dead_code)]
+pub(crate) const ITEM_TYPE_IMAGE: i32 = 2;
+pub(crate) const ITEM_TYPE_VOICE: i32 = 3;
+#[allow(dead_code)]
+pub(crate) const ITEM_TYPE_FILE: i32 = 4;
+
+// ---------------------------------------------------------------------------
+// ILinkResponse wrapper (kept for QR code endpoints that may use it)
+// ---------------------------------------------------------------------------
+
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
 pub(crate) struct ILinkResponse<T> {
-    pub code: i32,
+    #[serde(default)]
+    pub code: Option<i32>,
     #[serde(default)]
     pub msg: Option<String>,
     #[serde(default)]
     pub data: Option<T>,
 }
 
-impl<T> ILinkResponse<T> {
-    /// Returns `true` if the API call succeeded (code == 0).
-    pub fn is_ok(&self) -> bool {
-        self.code == 0
-    }
-
-    /// Extract the error message, falling back to a generic string.
-    pub fn error_message(&self) -> String {
-        self.msg
-            .clone()
-            .unwrap_or_else(|| format!("iLink API error (code={})", self.code))
-    }
-}
-
 // ---------------------------------------------------------------------------
 // QR code login
 // ---------------------------------------------------------------------------
 
-/// Response data from `get_bot_qrcode`.
 #[derive(Debug, Clone, Default, Deserialize)]
+#[allow(dead_code)]
 pub(crate) struct QrCodeData {
-    /// QR code ticket string (rendered by the frontend).
     #[serde(default)]
     pub qrcode: Option<String>,
+    #[serde(default)]
+    pub qrcode_img_content: Option<String>,
 }
 
-/// Response data from `get_qrcode_status`.
+/// Response from `get_qrcode_status`.
+///
+/// The actual API returns snake_case with non-standard field names:
+/// `{ status, bot_token, ilink_bot_id, baseurl }`
 #[derive(Debug, Clone, Default, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub(crate) struct QrCodeStatusData {
-    /// Status: "wait", "scanned", "confirmed", "expired".
     #[serde(default)]
     pub status: Option<String>,
-    /// Account ID returned on confirmed status.
-    #[serde(default)]
-    pub account_id: Option<String>,
-    /// Bot token returned on confirmed status.
     #[serde(default)]
     pub bot_token: Option<String>,
-    /// Base URL for the iLink Bot API.
     #[serde(default)]
-    pub base_url: Option<String>,
+    pub ilink_bot_id: Option<String>,
+    /// All lowercase — NOT `base_url`.
+    #[serde(default)]
+    pub baseurl: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
-// getupdates (long-polling)
+// getupdates (long-polling, buffer-based protocol)
 // ---------------------------------------------------------------------------
 
-/// A single update from `getupdates`.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct WxUpdate {
-    /// Update ID for offset tracking.
-    #[serde(default)]
-    pub update_id: i64,
-    /// The message payload (present for incoming messages).
-    #[serde(default)]
-    pub message: Option<WxMessage>,
+#[derive(Debug, Serialize)]
+pub(crate) struct GetUpdatesRequest {
+    pub get_updates_buf: String,
+    pub base_info: serde_json::Value,
 }
 
-/// An incoming message from the WeChat iLink Bot API.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct WxMessage {
-    /// Unique message ID.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct GetUpdatesResponse {
     #[serde(default)]
-    pub message_id: String,
-    /// Chat / conversation identifier.
+    pub ret: Option<i32>,
     #[serde(default)]
-    pub chat_id: String,
-    /// Sender information.
+    pub errcode: Option<i32>,
     #[serde(default)]
-    pub from: Option<WxUser>,
-    /// Unix timestamp of the message.
+    pub errmsg: Option<String>,
     #[serde(default)]
-    pub date: i64,
-    /// Text content (for text messages).
+    pub msgs: Option<Vec<WeixinRawMessage>>,
+    #[serde(default)]
+    pub get_updates_buf: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct WeixinRawMessage {
+    #[serde(default)]
+    pub from_user_id: Option<String>,
+    #[serde(default)]
+    pub context_token: Option<String>,
+    #[serde(default)]
+    pub msg_id: Option<String>,
+    #[serde(default)]
+    pub item_list: Option<Vec<WeixinRawItem>>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct WeixinRawItem {
+    #[serde(default, rename = "type")]
+    pub item_type: Option<i32>,
+    #[serde(default)]
+    pub text_item: Option<TextItem>,
+    #[serde(default)]
+    pub voice_item: Option<VoiceItem>,
+    #[serde(default)]
+    pub image_item: Option<MediaItemData>,
+    #[serde(default)]
+    pub file_item: Option<MediaItemData>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct TextItem {
     #[serde(default)]
     pub text: Option<String>,
-    /// Message type: "text", "voice", "image", "file", "card".
-    #[serde(default, rename = "type")]
-    pub msg_type: Option<String>,
-    /// File attachment (for file/image/voice messages).
-    #[serde(default)]
-    pub file: Option<WxFile>,
-    /// Card content (for card messages).
-    #[serde(default)]
-    pub card: Option<WxCard>,
 }
 
-/// Sender identity from the WeChat iLink Bot API.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct WxUser {
-    /// Platform user ID.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct VoiceItem {
     #[serde(default)]
-    pub id: String,
-    /// Display name.
-    #[serde(default)]
-    pub name: Option<String>,
-    /// Avatar URL.
-    #[serde(default)]
-    pub avatar: Option<String>,
+    pub text: Option<String>,
 }
 
-/// File attachment in a WeChat message.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct WxFile {
-    /// File ID for download.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct MediaItemData {
     #[serde(default)]
-    pub file_id: Option<String>,
-    /// Original file name.
+    pub media: Option<MediaEncryptInfo>,
+    #[serde(default)]
+    pub aeskey: Option<String>,
     #[serde(default)]
     pub file_name: Option<String>,
-    /// MIME type.
-    #[serde(default)]
-    pub mime_type: Option<String>,
-    /// File size in bytes.
-    #[serde(default)]
-    pub file_size: Option<u64>,
-    /// Download URL (may require decryption).
-    #[serde(default)]
-    pub url: Option<String>,
 }
 
-/// Card content in a WeChat message.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct WxCard {
-    /// Card title.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct MediaEncryptInfo {
     #[serde(default)]
-    pub title: Option<String>,
-    /// Card description / body text.
+    pub encrypt_query_param: Option<String>,
     #[serde(default)]
-    pub description: Option<String>,
+    pub aes_key: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
 // sendmessage
 // ---------------------------------------------------------------------------
 
-/// Request body for sending a message via the iLink Bot API.
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Serialize)]
 pub(crate) struct SendMessageRequest {
-    pub chat_id: String,
+    pub msg: SendMessageMsg,
+    pub base_info: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct SendMessageMsg {
+    pub to_user_id: String,
+    pub client_id: String,
+    pub message_type: i32,
+    pub message_state: i32,
+    pub item_list: Vec<SendMessageItem>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub text: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
-    pub msg_type: Option<String>,
+    pub context_token: Option<String>,
 }
 
-/// Response data from `sendmessage`.
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct SendMessageData {
-    /// The message ID of the sent message.
-    #[serde(default)]
-    pub message_id: Option<String>,
+#[derive(Debug, Serialize)]
+pub(crate) struct SendMessageItem {
+    #[serde(rename = "type")]
+    pub item_type: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_item: Option<SendTextItem>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct SendTextItem {
+    pub text: String,
 }
 
 // ---------------------------------------------------------------------------
-// SSE event payloads
+// SSE event payloads (frontend-facing — DO NOT CHANGE field names)
 // ---------------------------------------------------------------------------
 
-/// SSE event for QR code login flow.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SseQrEvent {
     pub qrcode_data: String,
 }
 
-/// SSE event for login completion.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SseDoneEvent {
@@ -196,7 +192,6 @@ pub(crate) struct SseDoneEvent {
     pub base_url: String,
 }
 
-/// SSE event for errors.
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct SseErrorEvent {
     pub message: String,
@@ -211,156 +206,154 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ilink_response_success() {
-        let resp: ILinkResponse<String> = ILinkResponse {
-            code: 0,
-            msg: Some("ok".into()),
-            data: Some("result".into()),
-        };
-        assert!(resp.is_ok());
+    fn deserialize_qr_code_data_direct() {
+        let json = r#"{"qrcode": "ticket_123", "qrcode_img_content": "https://example.com/qr.png"}"#;
+        let data: QrCodeData = serde_json::from_str(json).unwrap();
+        assert_eq!(data.qrcode.as_deref(), Some("ticket_123"));
+        assert_eq!(data.qrcode_img_content.as_deref(), Some("https://example.com/qr.png"));
     }
 
     #[test]
-    fn ilink_response_error() {
-        let resp: ILinkResponse<String> = ILinkResponse {
-            code: 1001,
-            msg: Some("invalid token".into()),
-            data: None,
-        };
-        assert!(!resp.is_ok());
-        assert_eq!(resp.error_message(), "invalid token");
-    }
-
-    #[test]
-    fn ilink_response_error_no_message() {
-        let resp: ILinkResponse<()> = ILinkResponse {
-            code: 500,
-            msg: None,
-            data: None,
-        };
-        assert_eq!(resp.error_message(), "iLink API error (code=500)");
-    }
-
-    #[test]
-    fn deserialize_qr_code_data() {
-        let json = r#"{"code": 0, "data": {"qrcode": "ticket_123"}}"#;
+    fn deserialize_qr_code_data_wrapped() {
+        let json = r#"{"code": 0, "data": {"qrcode": "ticket_456"}}"#;
         let resp: ILinkResponse<QrCodeData> = serde_json::from_str(json).unwrap();
-        assert!(resp.is_ok());
-        assert_eq!(resp.data.unwrap().qrcode.unwrap(), "ticket_123");
+        assert_eq!(resp.code, Some(0));
+        assert_eq!(resp.data.unwrap().qrcode.unwrap(), "ticket_456");
     }
 
     #[test]
     fn deserialize_qr_status_confirmed() {
         let json = r#"{
-            "code": 0,
-            "data": {
-                "status": "confirmed",
-                "accountId": "acc_1",
-                "botToken": "tok_1",
-                "baseUrl": "https://api.ilink.bot"
-            }
+            "status": "confirmed",
+            "bot_token": "tok_1",
+            "ilink_bot_id": "acc_1",
+            "baseurl": "https://ilinkai.weixin.qq.com"
         }"#;
-        let resp: ILinkResponse<QrCodeStatusData> = serde_json::from_str(json).unwrap();
-        assert!(resp.is_ok());
-        let data = resp.data.unwrap();
+        let data: QrCodeStatusData = serde_json::from_str(json).unwrap();
         assert_eq!(data.status.as_deref(), Some("confirmed"));
-        assert_eq!(data.account_id.as_deref(), Some("acc_1"));
         assert_eq!(data.bot_token.as_deref(), Some("tok_1"));
-        assert_eq!(data.base_url.as_deref(), Some("https://api.ilink.bot"));
+        assert_eq!(data.ilink_bot_id.as_deref(), Some("acc_1"));
+        assert_eq!(data.baseurl.as_deref(), Some("https://ilinkai.weixin.qq.com"));
     }
 
     #[test]
-    fn deserialize_wx_update() {
-        let json = r#"{
-            "updateId": 42,
-            "message": {
-                "messageId": "msg_1",
-                "chatId": "chat_1",
-                "from": { "id": "user_1", "name": "Alice" },
-                "date": 1700000000,
-                "text": "Hello",
-                "type": "text"
-            }
-        }"#;
-        let update: WxUpdate = serde_json::from_str(json).unwrap();
-        assert_eq!(update.update_id, 42);
-        let msg = update.message.unwrap();
-        assert_eq!(msg.message_id, "msg_1");
-        assert_eq!(msg.chat_id, "chat_1");
-        assert_eq!(msg.text.as_deref(), Some("Hello"));
-        assert_eq!(msg.msg_type.as_deref(), Some("text"));
-        let from = msg.from.unwrap();
-        assert_eq!(from.id, "user_1");
-        assert_eq!(from.name.as_deref(), Some("Alice"));
+    fn deserialize_qr_status_scaned() {
+        let json = r#"{"status": "scaned"}"#;
+        let data: QrCodeStatusData = serde_json::from_str(json).unwrap();
+        assert_eq!(data.status.as_deref(), Some("scaned"));
     }
 
     #[test]
-    fn deserialize_wx_update_with_file() {
+    fn deserialize_get_updates_response() {
         let json = r#"{
-            "updateId": 43,
-            "message": {
-                "messageId": "msg_2",
-                "chatId": "chat_1",
-                "date": 1700000001,
-                "type": "file",
-                "file": {
-                    "fileId": "f_1",
-                    "fileName": "report.pdf",
-                    "mimeType": "application/pdf",
-                    "fileSize": 1024,
-                    "url": "https://example.com/f_1"
-                }
-            }
+            "ret": 0,
+            "errcode": 0,
+            "msgs": [{
+                "from_user_id": "user_1",
+                "context_token": "ctx_abc",
+                "msg_id": "msg_1",
+                "item_list": [
+                    {"type": 1, "text_item": {"text": "Hello"}}
+                ]
+            }],
+            "get_updates_buf": "base64buf=="
         }"#;
-        let update: WxUpdate = serde_json::from_str(json).unwrap();
-        let msg = update.message.unwrap();
-        assert_eq!(msg.msg_type.as_deref(), Some("file"));
-        let file = msg.file.unwrap();
-        assert_eq!(file.file_id.as_deref(), Some("f_1"));
-        assert_eq!(file.file_name.as_deref(), Some("report.pdf"));
-        assert_eq!(file.file_size, Some(1024));
+        let resp: GetUpdatesResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.ret, Some(0));
+        assert_eq!(resp.errcode, Some(0));
+        let msgs = resp.msgs.unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].from_user_id.as_deref(), Some("user_1"));
+        assert_eq!(msgs[0].context_token.as_deref(), Some("ctx_abc"));
+        let items = msgs[0].item_list.as_ref().unwrap();
+        assert_eq!(items[0].item_type, Some(1));
+        assert_eq!(items[0].text_item.as_ref().unwrap().text.as_deref(), Some("Hello"));
+        assert_eq!(resp.get_updates_buf.as_deref(), Some("base64buf=="));
     }
 
     #[test]
-    fn deserialize_wx_update_with_card() {
+    fn deserialize_get_updates_with_media() {
         let json = r#"{
-            "updateId": 44,
-            "message": {
-                "messageId": "msg_3",
-                "chatId": "chat_1",
-                "date": 1700000002,
-                "type": "card",
-                "card": {
-                    "title": "Alert",
-                    "description": "Something happened"
-                }
-            }
+            "ret": 0,
+            "msgs": [{
+                "from_user_id": "user_2",
+                "msg_id": "msg_2",
+                "item_list": [
+                    {"type": 2, "image_item": {"media": {"encrypt_query_param": "enc_param", "aes_key": "key123"}, "aeskey": "hex_key"}},
+                    {"type": 4, "file_item": {"media": {"encrypt_query_param": "enc_f"}, "file_name": "doc.pdf"}}
+                ]
+            }]
         }"#;
-        let update: WxUpdate = serde_json::from_str(json).unwrap();
-        let msg = update.message.unwrap();
-        let card = msg.card.unwrap();
-        assert_eq!(card.title.as_deref(), Some("Alert"));
-        assert_eq!(card.description.as_deref(), Some("Something happened"));
+        let resp: GetUpdatesResponse = serde_json::from_str(json).unwrap();
+        let msgs = resp.msgs.unwrap();
+        let items = msgs[0].item_list.as_ref().unwrap();
+        assert_eq!(items[0].item_type, Some(2));
+        let img = items[0].image_item.as_ref().unwrap();
+        assert_eq!(img.media.as_ref().unwrap().encrypt_query_param.as_deref(), Some("enc_param"));
+        assert_eq!(img.aeskey.as_deref(), Some("hex_key"));
+        assert_eq!(items[1].item_type, Some(4));
+        assert_eq!(items[1].file_item.as_ref().unwrap().file_name.as_deref(), Some("doc.pdf"));
+    }
+
+    #[test]
+    fn deserialize_get_updates_api_error() {
+        let json = r#"{"ret": 1001, "errcode": 401, "errmsg": "invalid token"}"#;
+        let resp: GetUpdatesResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.ret, Some(1001));
+        assert_eq!(resp.errcode, Some(401));
+        assert!(resp.msgs.is_none());
     }
 
     #[test]
     fn serialize_send_message_request() {
         let req = SendMessageRequest {
-            chat_id: "chat_1".into(),
-            text: Some("Hello".into()),
-            msg_type: Some("text".into()),
+            msg: SendMessageMsg {
+                to_user_id: "user_1".into(),
+                client_id: "uuid-1234".into(),
+                message_type: 2,
+                message_state: 2,
+                item_list: vec![SendMessageItem {
+                    item_type: ITEM_TYPE_TEXT,
+                    text_item: Some(SendTextItem { text: "Hello".into() }),
+                }],
+                context_token: Some("ctx_abc".into()),
+            },
+            base_info: serde_json::json!({}),
         };
         let json = serde_json::to_string(&req).unwrap();
-        assert!(json.contains(r#""chatId":"chat_1"#));
+        assert!(json.contains(r#""to_user_id":"user_1"#));
+        assert!(json.contains(r#""client_id":"uuid-1234"#));
+        assert!(json.contains(r#""message_type":2"#));
+        assert!(json.contains(r#""message_state":2"#));
+        assert!(json.contains(r#""type":1"#));
         assert!(json.contains(r#""text":"Hello"#));
-        assert!(json.contains(r#""type":"text"#));
+        assert!(json.contains(r#""context_token":"ctx_abc"#));
+        assert!(json.contains(r#""base_info":{}"#));
+    }
+
+    #[test]
+    fn serialize_send_message_no_context_token() {
+        let req = SendMessageRequest {
+            msg: SendMessageMsg {
+                to_user_id: "user_1".into(),
+                client_id: "uuid-1234".into(),
+                message_type: 2,
+                message_state: 2,
+                item_list: vec![SendMessageItem {
+                    item_type: ITEM_TYPE_TEXT,
+                    text_item: Some(SendTextItem { text: "Hi".into() }),
+                }],
+                context_token: None,
+            },
+            base_info: serde_json::json!({}),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(!json.contains("context_token"));
     }
 
     #[test]
     fn serialize_sse_qr_event() {
-        let evt = SseQrEvent {
-            qrcode_data: "ticket_abc".into(),
-        };
+        let evt = SseQrEvent { qrcode_data: "ticket_abc".into() };
         let json = serde_json::to_string(&evt).unwrap();
         assert!(json.contains(r#""qrcodeData":"ticket_abc"#));
     }
@@ -370,20 +363,26 @@ mod tests {
         let evt = SseDoneEvent {
             account_id: "acc_1".into(),
             bot_token: "tok_1".into(),
-            base_url: "https://api.example.com".into(),
+            base_url: "https://example.com".into(),
         };
         let json = serde_json::to_string(&evt).unwrap();
         assert!(json.contains(r#""accountId":"acc_1"#));
         assert!(json.contains(r#""botToken":"tok_1"#));
-        assert!(json.contains(r#""baseUrl":"https://api.example.com"#));
+        assert!(json.contains(r#""baseUrl":"https://example.com"#));
     }
 
     #[test]
     fn serialize_sse_error_event() {
-        let evt = SseErrorEvent {
-            message: "timeout".into(),
-        };
+        let evt = SseErrorEvent { message: "timeout".into() };
         let json = serde_json::to_string(&evt).unwrap();
         assert!(json.contains(r#""message":"timeout"#));
+    }
+
+    #[test]
+    fn item_type_constants() {
+        assert_eq!(ITEM_TYPE_TEXT, 1);
+        assert_eq!(ITEM_TYPE_IMAGE, 2);
+        assert_eq!(ITEM_TYPE_VOICE, 3);
+        assert_eq!(ITEM_TYPE_FILE, 4);
     }
 }

--- a/crates/aionui-channel/src/stream_relay.rs
+++ b/crates/aionui-channel/src/stream_relay.rs
@@ -80,9 +80,7 @@ impl ChannelStreamRelay {
                         has_content = true;
                     }
                     Some(StreamAction::Thinking(_)) => {}
-                    Some(StreamAction::ToolCall { .. })
-                        if has_content && !text_buffer.trim().is_empty() =>
-                    {
+                    Some(StreamAction::ToolCall { .. }) if has_content && !text_buffer.trim().is_empty() => {
                         let formatted = format_text_for_platform(&text_buffer, self.config.platform);
                         let flush_msg = ChannelMessageService::build_streaming_message(&formatted);
                         let _ = self

--- a/crates/aionui-channel/src/stream_relay.rs
+++ b/crates/aionui-channel/src/stream_relay.rs
@@ -59,7 +59,105 @@ impl ChannelStreamRelay {
     }
 
     /// Run the relay loop until the agent stream ends.
-    pub async fn run(self, mut rx: broadcast::Receiver<AgentStreamEvent>) {
+    pub async fn run(self, rx: broadcast::Receiver<AgentStreamEvent>) {
+        if is_weixin_platform(self.config.platform) {
+            self.run_weixin(rx).await;
+        } else {
+            self.run_editable(rx).await;
+        }
+    }
+
+    /// WeChat-specific relay: no edit support, accumulate text then send once.
+    async fn run_weixin(self, mut rx: broadcast::Receiver<AgentStreamEvent>) {
+        let mut text_buffer = String::new();
+        let mut has_content = false;
+
+        loop {
+            match rx.recv().await {
+                Ok(event) => match ChannelMessageService::process_stream_event(&event) {
+                    Some(StreamAction::AppendText(chunk)) => {
+                        text_buffer.push_str(&chunk);
+                        has_content = true;
+                    }
+                    Some(StreamAction::Thinking(_)) => {}
+                    Some(StreamAction::ToolCall { .. })
+                        if has_content && !text_buffer.trim().is_empty() =>
+                    {
+                        let formatted = format_text_for_platform(&text_buffer, self.config.platform);
+                        let flush_msg = ChannelMessageService::build_streaming_message(&formatted);
+                        let _ = self
+                            .sender
+                            .send_message(&self.config.plugin_id, &self.config.chat_id, flush_msg)
+                            .await;
+                        text_buffer.clear();
+                        has_content = false;
+                    }
+                    Some(StreamAction::ToolCall { .. }) => {}
+                    Some(StreamAction::Finish) => {
+                        if has_content && !text_buffer.trim().is_empty() {
+                            let formatted = format_text_for_platform(&text_buffer, self.config.platform);
+                            let final_msg = ChannelMessageService::build_final_message(&formatted);
+                            let _ = self
+                                .sender
+                                .send_message(&self.config.plugin_id, &self.config.chat_id, final_msg)
+                                .await;
+                        }
+                        info!(
+                            plugin_id = %self.config.plugin_id,
+                            chat_id = %self.config.chat_id,
+                            text_len = text_buffer.len(),
+                            "channel stream relay finished (weixin)"
+                        );
+                        break;
+                    }
+                    Some(StreamAction::Error(msg)) => {
+                        let error_msg = UnifiedOutgoingMessage {
+                            message_type: OutgoingMessageType::Text,
+                            text: Some(format!("\u{274c} {msg}")),
+                            parse_mode: None,
+                            buttons: None,
+                            keyboard: None,
+                            image_url: None,
+                            file_url: None,
+                            file_name: None,
+                            media_actions: None,
+                            reply_to_message_id: None,
+                            silent: None,
+                        };
+                        let _ = self
+                            .sender
+                            .send_message(&self.config.plugin_id, &self.config.chat_id, error_msg)
+                            .await;
+                        break;
+                    }
+                    None => {}
+                },
+                Err(broadcast::error::RecvError::Closed) => {
+                    if has_content && !text_buffer.trim().is_empty() {
+                        let formatted = format_text_for_platform(&text_buffer, self.config.platform);
+                        let final_msg = ChannelMessageService::build_final_message(&formatted);
+                        let _ = self
+                            .sender
+                            .send_message(&self.config.plugin_id, &self.config.chat_id, final_msg)
+                            .await;
+                    }
+                    break;
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    warn!(lagged = n, "channel stream relay lagged (weixin)");
+                }
+            }
+        }
+
+        debug!(
+            plugin_id = %self.config.plugin_id,
+            chat_id = %self.config.chat_id,
+            "channel stream relay exited (weixin)"
+        );
+    }
+
+    /// Standard relay for platforms that support edit (Telegram, Lark, DingTalk).
+    async fn run_editable(self, mut rx: broadcast::Receiver<AgentStreamEvent>) {
         let throttle = Duration::from_millis(self.config.throttle_ms);
 
         let thinking_msg = ChannelMessageService::build_thinking_message();
@@ -97,21 +195,6 @@ impl ChannelStreamRelay {
                     }
                     Some(StreamAction::Thinking(_)) => {}
                     Some(StreamAction::ToolCall { name, .. }) => {
-                        // Weixin parity with TS commit 406a62665: before rendering
-                        // a silent/non-text event (tool call), flush any pending
-                        // assistant text to the user as an independent message so
-                        // it doesn't get overwritten or deferred until Finish.
-                        if is_weixin_platform(self.config.platform) && has_content && !text_buffer.trim().is_empty() {
-                            let formatted = format_text_for_platform(&text_buffer, self.config.platform);
-                            let flush_msg = ChannelMessageService::build_streaming_message(&formatted);
-                            let _ = self
-                                .sender
-                                .send_message(&self.config.plugin_id, &self.config.chat_id, flush_msg)
-                                .await;
-                            text_buffer.clear();
-                            has_content = false;
-                            last_edit = Instant::now();
-                        }
                         let msg = ChannelMessageService::build_streaming_message(&format!("\u{23f3} {name}..."));
                         let _ = self
                             .sender
@@ -119,7 +202,7 @@ impl ChannelStreamRelay {
                             .await;
                     }
                     Some(StreamAction::Finish) => {
-                        self.send_final(&text_buffer, has_content, &thinking_msg_id).await;
+                        self.send_final_edit(&text_buffer, has_content, &thinking_msg_id).await;
                         info!(
                             plugin_id = %self.config.plugin_id,
                             chat_id = %self.config.chat_id,
@@ -157,7 +240,7 @@ impl ChannelStreamRelay {
                 },
                 Err(broadcast::error::RecvError::Closed) => {
                     warn!("channel stream relay: broadcast closed without terminal event");
-                    self.send_final(&text_buffer, has_content, &thinking_msg_id).await;
+                    self.send_final_edit(&text_buffer, has_content, &thinking_msg_id).await;
                     break;
                 }
                 Err(broadcast::error::RecvError::Lagged(n)) => {
@@ -173,7 +256,7 @@ impl ChannelStreamRelay {
         );
     }
 
-    async fn send_final(&self, text_buffer: &str, has_content: bool, msg_id: &str) {
+    async fn send_final_edit(&self, text_buffer: &str, has_content: bool, msg_id: &str) {
         if has_content {
             let formatted = format_text_for_platform(text_buffer, self.config.platform);
             let final_msg = ChannelMessageService::build_final_message(&formatted);

--- a/crates/aionui-channel/tests/stream_relay_test.rs
+++ b/crates/aionui-channel/tests/stream_relay_test.rs
@@ -136,11 +136,11 @@ async fn weixin_flushes_pending_text_before_tool_call() {
     relay.run(rx).await;
 
     let sends = recorder.take_sends();
-    // First send is the "Thinking..." placeholder; the second must be the
-    // flushed assistant text triggered by the ToolCall silent event.
-    assert!(sends.len() >= 2, "expected flush send_message, got {:?}", sends);
-    assert!(sends[0].text.as_deref().unwrap().contains("Thinking"));
-    let flushed = &sends[1];
+    // WeChat relay does NOT send a "Thinking..." placeholder. The first
+    // send_message should be the flushed assistant text triggered by the
+    // ToolCall event.
+    assert!(!sends.is_empty(), "expected flush send_message, got {:?}", sends);
+    let flushed = &sends[0];
     assert!(
         flushed.text.as_deref().unwrap().contains("Here is the plan"),
         "expected flushed text, got {:?}",
@@ -225,7 +225,9 @@ async fn weixin_skips_flush_when_buffer_is_empty() {
     relay.run(rx).await;
 
     let sends = recorder.take_sends();
-    assert_eq!(sends.len(), 1, "only Thinking placeholder expected: {:?}", sends);
+    // WeChat relay does NOT send Thinking placeholder, and with no buffered
+    // text there should be zero sends (no flush needed).
+    assert_eq!(sends.len(), 0, "no sends expected for empty buffer: {:?}", sends);
 }
 
 #[tokio::test]

--- a/crates/aionui-db/migrations/002_legacy_data_normalize.sql
+++ b/crates/aionui-db/migrations/002_legacy_data_normalize.sql
@@ -141,7 +141,40 @@ WHERE agents_version = '1.0.0'
   AND (agents = '[]' OR json_array_length(agents) = 0);
 
 ------------------------------------------------------------------------
--- Part D: Backfill acp_session rows from conversations.extra
+-- Part D: Remove legacy CHECK(agent_type IN ...) from assistant_sessions
+--
+-- Early dev builds had a CHECK constraint limiting agent_type to
+-- ('gemini', 'acp', 'codex'). The consolidated 001 schema no longer has
+-- this constraint, but CREATE TABLE IF NOT EXISTS won't alter an existing
+-- table. Rebuild only if the constraint is still present.
+------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS _assistant_sessions_new (
+    id              TEXT PRIMARY KEY NOT NULL,
+    user_id         TEXT    NOT NULL,
+    agent_type      TEXT    NOT NULL,
+    conversation_id TEXT,
+    workspace       TEXT,
+    chat_id         TEXT,
+    created_at      INTEGER NOT NULL,
+    last_activity   INTEGER NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES assistant_users(id) ON DELETE CASCADE,
+    FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE SET NULL
+);
+
+INSERT OR IGNORE INTO _assistant_sessions_new (id, user_id, agent_type, conversation_id, workspace, chat_id, created_at, last_activity)
+    SELECT id, user_id, agent_type, conversation_id, workspace, chat_id, created_at, last_activity
+    FROM assistant_sessions;
+
+DROP TABLE IF EXISTS assistant_sessions;
+
+ALTER TABLE _assistant_sessions_new RENAME TO assistant_sessions;
+
+CREATE INDEX IF NOT EXISTS idx_assistant_sessions_user_id ON assistant_sessions(user_id);
+CREATE INDEX IF NOT EXISTS idx_assistant_sessions_user_chat ON assistant_sessions(user_id, chat_id);
+
+------------------------------------------------------------------------
+-- Part E: Backfill acp_session rows from conversations.extra
 ------------------------------------------------------------------------
 
 INSERT OR IGNORE INTO acp_session (


### PR DESCRIPTION
## Summary

- Rewrote WeChat (iLink Bot) channel plugin to use correct protocol: buffer-based getupdates long-polling, proper auth headers, correct sendmessage format
- Fixed QR code login to send `qrcode_img_content` (scannable URL) instead of `qrcode` (opaque ticket hash)
- Split `ChannelStreamRelay` into WeChat-specific path (no Thinking placeholder, no edits, send-only at Finish) and editable path (unchanged behavior for Telegram/Lark/DingTalk)
- Added migration to remove legacy `CHECK(agent_type IN ...)` constraint from `assistant_sessions` table inherited from Electron-era databases

## Test plan

- [x] `cargo clippy -p aionui-channel --features weixin -- -D warnings` passes
- [x] `cargo test -p aionui-channel --features weixin` passes (all 15 unit + 7 integration tests)
- [x] `just push` passes (5492 tests, 0 failures)
- [ ] Manual: WeChat QR code login shows correct login page when scanned
- [ ] Manual: Messages sent from WeChat arrive in AionUI conversation
- [ ] Manual: AI responses appear as single message on phone (no duplicates/empty bubbles)
- [ ] Manual: Telegram/Lark/DingTalk channels unaffected (still use edit-in-place behavior)