### PR TITLE
fix(channel): resolve WebSocket TLS panic from ambiguous CryptoProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,8 @@ dependencies = [
  "prost",
  "regex",
  "reqwest",
+ "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -4301,6 +4303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,10 @@ aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-bedrock = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
 aws-sdk-bedrockruntime = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
 
+# TLS
+rustls = "0.23"
+rustls-native-certs = "0.8"
+
 # Pin rustls-webpki to fix RUSTSEC-2026-{0098,0099,0104}
 rustls-webpki = "0.103.13"
 

--- a/crates/aionui-channel/Cargo.toml
+++ b/crates/aionui-channel/Cargo.toml
@@ -6,8 +6,8 @@ edition.workspace = true
 [features]
 default = []
 telegram = ["dep:reqwest"]
-lark = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures-util", "dep:prost"]
-dingtalk = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures-util"]
+lark = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures-util", "dep:prost", "dep:rustls", "dep:rustls-native-certs"]
+dingtalk = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures-util", "dep:rustls", "dep:rustls-native-certs"]
 weixin = ["dep:reqwest", "dep:futures-util", "dep:base64", "dep:uuid"]
 
 [dependencies]
@@ -32,5 +32,7 @@ reqwest = { workspace = true, optional = true }
 tokio-tungstenite = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
 prost = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
+rustls-native-certs = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/aionui-channel/src/plugins/dingtalk/plugin.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/plugin.rs
@@ -473,6 +473,33 @@ async fn ws_stream_loop(
     debug!("DingTalk WS loop exited");
 }
 
+/// Build a TLS connector for WebSocket connections.
+///
+/// Explicitly sets ALPN to `http/1.1` only — WebSocket requires an HTTP/1.1
+/// upgrade handshake and is incompatible with h2. Without this, some servers
+/// negotiate h2 via ALPN and the WebSocket upgrade never completes.
+fn build_ws_tls_connector() -> Result<tokio_tungstenite::Connector, ChannelError> {
+    use std::sync::Arc;
+    use tokio_tungstenite::Connector;
+
+    let certs = rustls_native_certs::load_native_certs();
+    let mut root_store = rustls::RootCertStore::empty();
+    root_store.add_parsable_certificates(certs.certs);
+
+    let provider = rustls::crypto::CryptoProvider::get_default()
+        .cloned()
+        .unwrap_or_else(|| Arc::new(rustls::crypto::ring::default_provider()));
+
+    let mut config = rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| ChannelError::ConnectionFailed(format!("TLS config error: {e}")))?
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    config.alpn_protocols = vec![b"http/1.1".to_vec()];
+
+    Ok(Connector::Rustls(Arc::new(config)))
+}
+
 /// Connect to the WebSocket and listen for frames until disconnected.
 async fn connect_and_listen(
     ws_url: &str,
@@ -481,10 +508,11 @@ async fn connect_and_listen(
     shutdown_rx: &mut watch::Receiver<bool>,
 ) -> Result<(), ChannelError> {
     use futures_util::{SinkExt, StreamExt};
-    use tokio_tungstenite::connect_async;
+    use tokio_tungstenite::connect_async_tls_with_config;
     use tokio_tungstenite::tungstenite::Message as WsMessage;
 
-    let (ws_stream, _) = connect_async(ws_url)
+    let connector = build_ws_tls_connector()?;
+    let (ws_stream, _) = connect_async_tls_with_config(ws_url, None, false, Some(connector))
         .await
         .map_err(|e| ChannelError::ConnectionFailed(format!("DingTalk WS connect failed: {e}")))?;
 

--- a/crates/aionui-channel/src/plugins/lark/plugin.rs
+++ b/crates/aionui-channel/src/plugins/lark/plugin.rs
@@ -345,10 +345,11 @@ async fn connect_and_listen(
     shutdown_rx: &mut watch::Receiver<bool>,
 ) -> Result<(), ChannelError> {
     use futures_util::{SinkExt, StreamExt};
-    use tokio_tungstenite::connect_async;
+    use tokio_tungstenite::connect_async_tls_with_config;
     use tokio_tungstenite::tungstenite::Message as WsMessage;
 
-    let (ws_stream, _) = connect_async(ws_url)
+    let connector = build_ws_tls_connector()?;
+    let (ws_stream, _) = connect_async_tls_with_config(ws_url, None, false, Some(connector))
         .await
         .map_err(|e| ChannelError::ConnectionFailed(format!("Lark WS connect failed: {e}")))?;
 
@@ -847,6 +848,33 @@ fn chrono_now() -> i64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0)
+}
+
+/// Build a TLS connector for WebSocket connections.
+///
+/// Explicitly sets ALPN to `http/1.1` only — WebSocket requires an HTTP/1.1
+/// upgrade handshake and is incompatible with h2. Without this, some servers
+/// negotiate h2 via ALPN and the WebSocket upgrade never completes.
+fn build_ws_tls_connector() -> Result<tokio_tungstenite::Connector, ChannelError> {
+    use std::sync::Arc;
+    use tokio_tungstenite::Connector;
+
+    let certs = rustls_native_certs::load_native_certs();
+    let mut root_store = rustls::RootCertStore::empty();
+    root_store.add_parsable_certificates(certs.certs);
+
+    let provider = rustls::crypto::CryptoProvider::get_default()
+        .cloned()
+        .unwrap_or_else(|| Arc::new(rustls::crypto::ring::default_provider()));
+
+    let mut config = rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| ChannelError::ConnectionFailed(format!("TLS config error: {e}")))?
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    config.alpn_protocols = vec![b"http/1.1".to_vec()];
+
+    Ok(Connector::Rustls(Arc::new(config)))
 }
 
 /// Extract service_id from a WebSocket URL query string.


### PR DESCRIPTION
## Summary

- Lark 和 DingTalk WebSocket 连接在 PR#204 切换 `tokio-tungstenite` 到 `rustls` 后静默失败
- 根因：workspace 中 `rustls` 同时启用了 `ring`（来自 reqwest）和 `aws-lc-rs`（来自 aws-sdk）features，导致 `ClientConfig::builder()` 无法自动选择 CryptoProvider 而 panic
- 修复：使用 `connect_async_tls_with_config` + 自定义 TLS connector，通过 `builder_with_provider()` 显式选择 CryptoProvider，并设置 ALPN 为 `http/1.1`

## Test plan

- [x] `cargo clippy -p aionui-channel --features lark,dingtalk -- -D warnings` 通过
- [x] `cargo test --workspace` 5492 测试全部通过
- [x] 飞书连接后发消息能收到配对请求（手动验证）
- [x] 钉钉连接后发消息能收到配对请求（手动验证）