### PR TITLE
fix(cron): validate aionrs agent_config and scope model to aionrs

### DIFF
--- a/crates/aionui-cron/src/error.rs
+++ b/crates/aionui-cron/src/error.rs
@@ -26,6 +26,9 @@ pub enum CronError {
     #[error("Invalid skill content: {0}")]
     InvalidSkillContent(String),
 
+    #[error("Invalid agent config: {0}")]
+    InvalidAgentConfig(String),
+
     #[error("Scheduler error: {0}")]
     Scheduler(String),
 
@@ -47,6 +50,7 @@ impl From<CronError> for AppError {
             CronError::InvalidJobStatus(msg) => AppError::BadRequest(msg),
             CronError::InvalidTimezone(msg) => AppError::BadRequest(msg),
             CronError::InvalidSkillContent(msg) => AppError::BadRequest(msg),
+            CronError::InvalidAgentConfig(msg) => AppError::BadRequest(msg),
             CronError::Scheduler(msg) => AppError::Internal(msg),
             CronError::Database(db_err) => AppError::from(db_err),
             CronError::Json(e) => AppError::Internal(format!("JSON error: {e}")),
@@ -103,6 +107,12 @@ mod tests {
     #[test]
     fn invalid_skill_content_maps_to_bad_request() {
         let err: AppError = CronError::InvalidSkillContent("empty".into()).into();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn invalid_agent_config_maps_to_bad_request() {
+        let err: AppError = CronError::InvalidAgentConfig("missing backend".into()).into();
         assert!(matches!(err, AppError::BadRequest(_)));
     }
 

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -399,7 +399,7 @@ impl JobExecutor {
         let req = CreateConversationRequest {
             r#type: agent_type,
             name: Some(job.name.clone()),
-            model: Some(model),
+            model,
             source: None,
             channel_chat_id: None,
             extra,
@@ -457,7 +457,15 @@ impl JobExecutor {
         saved_skill: Option<&SavedSkillContext>,
     ) -> ExecutionResult {
         let agent_type = parse_agent_type(&self.agent_registry, &job.agent_type).await;
-        let model = resolve_model(job);
+        // `BuildTaskOptions.model` is non-optional; non-aionrs agent types
+        // ignore it in their factory branches, so a blank placeholder is the
+        // canonical empty value (mirrors `ConversationService::build_task_options`
+        // for rows with NULL `model`).
+        let model = resolve_model(job).unwrap_or_else(|| ProviderWithModel {
+            provider_id: String::new(),
+            model: String::new(),
+            use_model: None,
+        });
         let workspace = match self.resolve_execution_workspace(job, conversation_id).await {
             Ok(workspace) => workspace,
             Err(e) => {
@@ -876,20 +884,29 @@ async fn parse_agent_type(registry: &AgentRegistry, agent_type_str: &str) -> Age
     serde_json::from_value::<AgentType>(serde_json::Value::String(agent_type_str.to_owned())).unwrap_or(AgentType::Acp)
 }
 
-fn resolve_model(job: &CronJob) -> ProviderWithModel {
-    if let Some(config) = &job.agent_config {
-        ProviderWithModel {
-            provider_id: config.backend.clone(),
-            model: config.model_id.clone().unwrap_or_else(|| "default".to_owned()),
-            use_model: None,
-        }
-    } else {
-        ProviderWithModel {
-            provider_id: job.agent_type.clone(),
-            model: "default".to_owned(),
-            use_model: None,
-        }
+/// Only aionrs conversations carry meaningful model info in `conversations.model`;
+/// ACP and other agent types ignore this field and resolve the model via their own
+/// mechanisms (catalog defaults, CLI flags, etc.). Returning `None` lets the
+/// `CreateConversationRequest.model` stay `None` for those types, which is the
+/// correct semantic.
+///
+/// For aionrs, `agent_config.backend` holds the provider_id (a DB hash, not a
+/// vendor label). `CronService::add_job`/`update_job` already rejects aionrs
+/// jobs lacking this field, so the `None` return here is defensive for any
+/// legacy in-memory row that somehow slipped through.
+fn resolve_model(job: &CronJob) -> Option<ProviderWithModel> {
+    if job.agent_type != "aionrs" {
+        return None;
     }
+    let config = job.agent_config.as_ref()?;
+    if config.backend.trim().is_empty() {
+        return None;
+    }
+    Some(ProviderWithModel {
+        provider_id: config.backend.clone(),
+        model: config.model_id.clone().unwrap_or_else(|| "default".to_owned()),
+        use_model: None,
+    })
 }
 
 /// Fill `extra` with the agent identity the factory should use.
@@ -1346,30 +1363,60 @@ mod tests {
     // -- resolve_model tests -------------------------------------------------
 
     #[test]
-    fn resolve_model_with_config() {
+    fn resolve_model_returns_none_for_acp() {
+        // Model info only applies to aionrs; ACP ignores it.
         let job = sample_job();
-        let model = resolve_model(&job);
-        assert_eq!(model.provider_id, "acp");
-        assert_eq!(model.model, "claude-sonnet-4");
+        assert!(resolve_model(&job).is_none());
     }
 
     #[test]
-    fn resolve_model_without_config() {
+    fn resolve_model_returns_none_for_acp_without_config() {
         let job = CronJob {
             agent_config: None,
             ..sample_job()
         };
-        let model = resolve_model(&job);
-        assert_eq!(model.provider_id, "acp");
-        assert_eq!(model.model, "default");
+        assert!(resolve_model(&job).is_none());
     }
 
     #[test]
-    fn resolve_model_config_no_model_id() {
+    fn resolve_model_returns_none_for_non_aionrs_type() {
         let job = CronJob {
+            agent_type: "claude".into(),
+            ..sample_job()
+        };
+        assert!(resolve_model(&job).is_none());
+    }
+
+    #[test]
+    fn resolve_model_aionrs_with_full_config() {
+        let job = CronJob {
+            agent_type: "aionrs".into(),
             agent_config: Some(CronAgentConfig {
-                backend: "gemini".into(),
-                name: "Gemini".into(),
+                backend: "4056cdea".into(),
+                name: "OpenAI".into(),
+                cli_path: None,
+                is_preset: None,
+                custom_agent_id: None,
+                preset_agent_type: None,
+                mode: None,
+                model_id: Some("gpt-5".into()),
+                config_options: None,
+                workspace: None,
+            }),
+            ..sample_job()
+        };
+        let model = resolve_model(&job).expect("aionrs + full config returns Some");
+        assert_eq!(model.provider_id, "4056cdea");
+        assert_eq!(model.model, "gpt-5");
+    }
+
+    #[test]
+    fn resolve_model_aionrs_without_model_id_defaults_to_default() {
+        let job = CronJob {
+            agent_type: "aionrs".into(),
+            agent_config: Some(CronAgentConfig {
+                backend: "4056cdea".into(),
+                name: "OpenAI".into(),
                 cli_path: None,
                 is_preset: None,
                 custom_agent_id: None,
@@ -1381,9 +1428,42 @@ mod tests {
             }),
             ..sample_job()
         };
-        let model = resolve_model(&job);
-        assert_eq!(model.provider_id, "gemini");
+        let model = resolve_model(&job).expect("aionrs without model_id still returns Some");
+        assert_eq!(model.provider_id, "4056cdea");
         assert_eq!(model.model, "default");
+    }
+
+    #[test]
+    fn resolve_model_aionrs_without_config_returns_none() {
+        // Defensive: `add_job` rejects this shape, but resolve_model must not
+        // fabricate a provider_id from the agent_type like the old code did.
+        let job = CronJob {
+            agent_type: "aionrs".into(),
+            agent_config: None,
+            ..sample_job()
+        };
+        assert!(resolve_model(&job).is_none());
+    }
+
+    #[test]
+    fn resolve_model_aionrs_with_empty_backend_returns_none() {
+        let job = CronJob {
+            agent_type: "aionrs".into(),
+            agent_config: Some(CronAgentConfig {
+                backend: "   ".into(),
+                name: "Bogus".into(),
+                cli_path: None,
+                is_preset: None,
+                custom_agent_id: None,
+                preset_agent_type: None,
+                mode: None,
+                model_id: Some("gpt-5".into()),
+                config_options: None,
+                workspace: None,
+            }),
+            ..sample_job()
+        };
+        assert!(resolve_model(&job).is_none());
     }
 
     // -- build_task_extra tests -----------------------------------------------

--- a/crates/aionui-cron/src/service.rs
+++ b/crates/aionui-cron/src/service.rs
@@ -67,6 +67,7 @@ impl CronService {
     pub async fn add_job(&self, req: CreateCronJobRequest) -> Result<CronJob, CronError> {
         let schedule = schedule_from_dto(&req.schedule);
         validate_schedule(&schedule)?;
+        validate_aionrs_agent_config(&req.agent_type, req.agent_config.as_ref())?;
 
         let execution_mode = parse_execution_mode(req.execution_mode.as_deref())?;
         let created_by = CreatedBy::from_str(&req.created_by)?;
@@ -152,6 +153,7 @@ impl CronService {
             job.execution_mode = parse_execution_mode(Some(mode_str))?;
         }
         if let Some(config_dto) = &req.agent_config {
+            validate_aionrs_agent_config(&job.agent_type, Some(config_dto))?;
             job.agent_config = Some(CronAgentConfig {
                 backend: config_dto.backend.clone(),
                 name: config_dto.name.clone(),
@@ -1083,6 +1085,25 @@ fn parse_provider_with_model_loose(model_json: Option<&str>) -> Option<ProviderW
 // Free functions
 // ---------------------------------------------------------------------------
 
+/// Aionrs cron jobs require `agent_config.backend` (provider_id) to be set —
+/// the executor uses it to look up the provider row and build the agent.
+/// Reject add/update requests that would produce an invalid aionrs job.
+fn validate_aionrs_agent_config(
+    agent_type: &str,
+    agent_config: Option<&aionui_api_types::CronAgentConfigDto>,
+) -> Result<(), CronError> {
+    if agent_type != "aionrs" {
+        return Ok(());
+    }
+    let backend_ok = agent_config.is_some_and(|c| !c.backend.trim().is_empty());
+    if !backend_ok {
+        return Err(CronError::InvalidAgentConfig(
+            "aionrs cron jobs require agent_config.backend (provider_id)".into(),
+        ));
+    }
+    Ok(())
+}
+
 fn parse_execution_mode(mode: Option<&str>) -> Result<ExecutionMode, CronError> {
     match mode {
         None | Some("existing") => Ok(ExecutionMode::Existing),
@@ -1252,6 +1273,57 @@ mod tests {
     #[test]
     fn validate_skill_valid_short() {
         assert!(validate_skill_body_content("Run daily report").is_ok());
+    }
+
+    // -- validate_aionrs_agent_config ----------------------------------------
+
+    fn agent_cfg_dto(backend: &str) -> aionui_api_types::CronAgentConfigDto {
+        aionui_api_types::CronAgentConfigDto {
+            backend: backend.to_owned(),
+            name: "provider".into(),
+            cli_path: None,
+            is_preset: None,
+            custom_agent_id: None,
+            preset_agent_type: None,
+            mode: None,
+            model_id: Some("gpt-4o".into()),
+            config_options: None,
+            workspace: None,
+        }
+    }
+
+    #[test]
+    fn validate_aionrs_accepts_valid_config() {
+        let cfg = agent_cfg_dto("4056cdea");
+        assert!(validate_aionrs_agent_config("aionrs", Some(&cfg)).is_ok());
+    }
+
+    #[test]
+    fn validate_aionrs_rejects_missing_config() {
+        let err = validate_aionrs_agent_config("aionrs", None).unwrap_err();
+        assert!(matches!(err, CronError::InvalidAgentConfig(_)));
+    }
+
+    #[test]
+    fn validate_aionrs_rejects_empty_backend() {
+        let cfg = agent_cfg_dto("");
+        let err = validate_aionrs_agent_config("aionrs", Some(&cfg)).unwrap_err();
+        assert!(matches!(err, CronError::InvalidAgentConfig(_)));
+    }
+
+    #[test]
+    fn validate_aionrs_rejects_whitespace_backend() {
+        let cfg = agent_cfg_dto("   ");
+        let err = validate_aionrs_agent_config("aionrs", Some(&cfg)).unwrap_err();
+        assert!(matches!(err, CronError::InvalidAgentConfig(_)));
+    }
+
+    #[test]
+    fn validate_aionrs_ignores_non_aionrs_type() {
+        // ACP / other types may legitimately omit agent_config or leave backend empty.
+        assert!(validate_aionrs_agent_config("acp", None).is_ok());
+        let cfg = agent_cfg_dto("");
+        assert!(validate_aionrs_agent_config("claude", Some(&cfg)).is_ok());
     }
 
     // -- parse_execution_mode -------------------------------------------------


### PR DESCRIPTION
## Summary

Aionrs cron jobs require `agent_config.backend` (provider_id) to resolve an LLM provider at warmup time. Previously, rows with NULL `agent_config` passed validation, and the cron executor's `resolve_model()` fabricated a fake provider_id from `job.agent_type`, causing the factory's provider lookup to fail with `Provider 'aionrs' not found` (BAD_REQUEST).

- Add `CronError::InvalidAgentConfig` → `AppError::BadRequest` mapping
- Reject `CreateCronJobRequest` / `UpdateCronJobRequest` in `add_job` and `update_job` when `agent_type == "aionrs"` and `agent_config.backend` is missing or blank; non-aionrs types remain unrestricted
- Refactor `resolve_model` to return `Option<ProviderWithModel>`: `None` for any non-aionrs type (model is aionrs-only metadata; ACP ignores it), `Some` only when aionrs + non-empty backend. Defensive fallback in `execute_inner` preserves the old empty-placeholder contract for `BuildTaskOptions.model`

## Test Plan

- [x] `cargo test -p aionui-cron` — 214 tests pass (160 + 5 + 41 + 8)
- [x] 5 new `validate_aionrs_agent_config` cases
- [x] 7 rewritten `resolve_model` cases covering non-aionrs None, aionrs full config, missing model_id, missing agent_config, empty backend