### PR TITLE
feat(conversation): expose GET /api/conversations/active-count

### DIFF
--- a/crates/aionui-api-types/src/conversation.rs
+++ b/crates/aionui-api-types/src/conversation.rs
@@ -145,6 +145,12 @@ pub struct MessageResponse {
 /// Paginated list of messages.
 pub type MessageListResponse = PaginatedResult<MessageResponse>;
 
+/// Response for `GET /api/conversations/active-count`.
+#[derive(Debug, Serialize)]
+pub struct ActiveCountResponse {
+    pub count: usize,
+}
+
 /// Artifact kind discriminant for conversation-bound UI artifacts.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -55,10 +55,10 @@ pub use channel::{
 pub use confirmation::{ApprovalCheckQuery, ApprovalCheckResponse, ConfirmRequest, ConfirmationListResponse};
 pub use connection_test::TestBedrockConnectionRequest;
 pub use conversation::{
-    CloneConversationRequest, ConversationArtifactKind, ConversationArtifactListResponse, ConversationArtifactResponse,
-    ConversationArtifactStatus, ConversationListResponse, ConversationResponse, CreateConversationRequest,
-    ListConversationsQuery, ListMessagesQuery, MessageListResponse, MessageResponse, MessageSearchItem,
-    MessageSearchResponse, SearchMessagesQuery, SendMessageRequest, SendMessageResponse,
+    ActiveCountResponse, CloneConversationRequest, ConversationArtifactKind, ConversationArtifactListResponse,
+    ConversationArtifactResponse, ConversationArtifactStatus, ConversationListResponse, ConversationResponse,
+    CreateConversationRequest, ListConversationsQuery, ListMessagesQuery, MessageListResponse, MessageResponse,
+    MessageSearchItem, MessageSearchResponse, SearchMessagesQuery, SendMessageRequest, SendMessageResponse,
     UpdateConversationArtifactRequest, UpdateConversationRequest,
 };
 pub use cron::{

--- a/crates/aionui-conversation/src/routes.rs
+++ b/crates/aionui-conversation/src/routes.rs
@@ -5,11 +5,11 @@ use axum::http::StatusCode;
 use axum::routing::{get, patch, post};
 
 use aionui_api_types::{
-    ApiResponse, ApprovalCheckQuery, ApprovalCheckResponse, CloneConversationRequest, ConfirmRequest,
-    ConfirmationListResponse, ConversationArtifactListResponse, ConversationArtifactResponse, ConversationListResponse,
-    ConversationResponse, CreateConversationRequest, ListConversationsQuery, ListMessagesQuery, MessageListResponse,
-    MessageSearchResponse, SearchMessagesQuery, SendMessageRequest, SendMessageResponse,
-    UpdateConversationArtifactRequest, UpdateConversationRequest,
+    ActiveCountResponse, ApiResponse, ApprovalCheckQuery, ApprovalCheckResponse, CloneConversationRequest,
+    ConfirmRequest, ConfirmationListResponse, ConversationArtifactListResponse, ConversationArtifactResponse,
+    ConversationListResponse, ConversationResponse, CreateConversationRequest, ListConversationsQuery,
+    ListMessagesQuery, MessageListResponse, MessageSearchResponse, SearchMessagesQuery, SendMessageRequest,
+    SendMessageResponse, UpdateConversationArtifactRequest, UpdateConversationRequest,
 };
 use aionui_auth::CurrentUser;
 use aionui_common::AppError;
@@ -23,6 +23,7 @@ pub fn conversation_routes(state: ConversationRouterState) -> Router {
     Router::new()
         .route("/api/conversations", post(create).get(list))
         // Static path must come before `{id}` wildcard
+        .route("/api/conversations/active-count", get(active_count))
         .route("/api/conversations/clone", post(clone))
         .route("/api/conversations/{id}", get(get_one).patch(update).delete(delete_one))
         .route("/api/conversations/{id}/reset", post(reset))
@@ -267,4 +268,12 @@ async fn check_approval(
         )
         .await?;
     Ok(Json(ApiResponse::ok(result)))
+}
+
+async fn active_count(
+    State(state): State<ConversationRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+) -> Result<Json<ApiResponse<ActiveCountResponse>>, AppError> {
+    let count = state.worker_task_manager.active_count();
+    Ok(Json(ApiResponse::ok(ActiveCountResponse { count })))
 }


### PR DESCRIPTION
## Summary

Expose HTTP endpoint `GET /api/conversations/active-count` that returns `{ count: number }` (the number of active agent tasks managed by `WorkerTaskManager`).

This replaces the frontend's temporary hardcoded `return 0` in `tray.ts` with live backend state.

## Changes

- **aionui-api-types/conversation.rs**: Add `ActiveCountResponse { count: usize }`
- **aionui-api-types/lib.rs**: Export `ActiveCountResponse`
- **aionui-conversation/routes.rs**:
  - Register `/api/conversations/active-count` route
  - Implement `active_count` handler (calls `worker_task_manager.active_count()`)

## Safety

- Read-only handler, no DB writes
- Requires authentication (applied by middleware)
- No breaking changes
- Passes `cargo check`, `cargo clippy -- -D warnings`, `cargo test -p aionui-conversation`, `cargo fmt -- --check`

## Related

- **Frontend follow-up PR**: Will consume this endpoint in `packages/desktop/src/process/utils/tray.ts` to display live task count in the system tray badge.
- The frontend PR depends on this one being merged first (otherwise CI will fail with 404 on the new route).

## Test Plan

```bash
# After backend merge + frontend rebuild
curl -s http://localhost:41595/api/conversations/active-count
# Expected: {"ok":true,"data":{"count":0}}

# Start a conversation, then curl again
# Expected: {"ok":true,"data":{"count":1}}
```