### PR TITLE
fix(team): prevent guide MCP leak into team leaders

### DIFF
--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -15,6 +15,12 @@ pub(super) async fn build(
     options: BuildTaskOptions,
     ctx: FactoryContext,
 ) -> Result<AgentInstance, AppError> {
+    let belongs_to_team = options
+        .extra
+        .get("teamId")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|s| !s.is_empty());
+
     let mut config: AcpBuildExtra = serde_json::from_value(options.extra)
         .map_err(|e| AppError::BadRequest(format!("Invalid ACP build options: {e}")))?;
 
@@ -44,6 +50,8 @@ pub(super) async fn build(
     // two are mutually exclusive per the build_new_session_request guard.
     if config.team_mcp_stdio_config.is_some() {
         debug!(ctx.conversation_id, "guide_mcp: skipped: has team_mcp");
+    } else if belongs_to_team {
+        debug!(ctx.conversation_id, "guide_mcp: skipped: conversation belongs to a team (extra.teamId)");
     } else if config.guide_mcp_config.is_some() {
         debug!(
             ctx.conversation_id,

--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -51,7 +51,10 @@ pub(super) async fn build(
     if config.team_mcp_stdio_config.is_some() {
         debug!(ctx.conversation_id, "guide_mcp: skipped: has team_mcp");
     } else if belongs_to_team {
-        debug!(ctx.conversation_id, "guide_mcp: skipped: conversation belongs to a team (extra.teamId)");
+        debug!(
+            ctx.conversation_id,
+            "guide_mcp: skipped: conversation belongs to a team (extra.teamId)"
+        );
     } else if config.guide_mcp_config.is_some() {
         debug!(
             ctx.conversation_id,

--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -21,6 +21,12 @@ pub(super) async fn build(
     options: BuildTaskOptions,
     ctx: FactoryContext,
 ) -> Result<AgentInstance, AppError> {
+    let belongs_to_team = options
+        .extra
+        .get("teamId")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|s| !s.is_empty());
+
     let mut overrides: AionrsBuildExtra = serde_json::from_value(options.extra).unwrap_or_default();
 
     // Merge preset assistant rules into system_prompt (used as custom_prompt
@@ -33,10 +39,12 @@ pub(super) async fn build(
         });
     }
 
-    // Inject Guide MCP config for solo (non-team) sessions, mirroring acp.rs:39-55.
+    // Inject Guide MCP config for solo (non-team) sessions, mirroring acp.rs.
+    // Skip if the conversation already belongs to a team (extra.teamId set).
     if overrides.team_mcp_stdio_config.is_none()
         && overrides.guide_mcp_config.is_none()
         && deps.guide_mcp_config.is_some()
+        && !belongs_to_team
     {
         overrides.guide_mcp_config.clone_from(&deps.guide_mcp_config);
         overrides.backend.get_or_insert_with(|| "aionrs".to_owned());

--- a/crates/aionui-team/src/guide/server.rs
+++ b/crates/aionui-team/src/guide/server.rs
@@ -218,6 +218,30 @@ async fn exec_create_team(
         .filter(|s| !s.is_empty())
         .map(str::to_owned);
 
+    // Refuse if the caller conversation already belongs to a team.
+    // This prevents duplicate team creation when guide MCP is
+    // erroneously injected into an existing team leader session.
+    if let Some(ref conv_id) = caller_conversation_id {
+        let repo = svc.conversation_service_ref().conversation_repo().clone();
+        if let Ok(Some(row)) = repo.get(conv_id).await {
+            let extra: serde_json::Value =
+                serde_json::from_str(&row.extra).unwrap_or(serde_json::Value::Null);
+            if extra
+                .get("teamId")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|s| !s.is_empty())
+            {
+                warn!(
+                    conversation_id = conv_id,
+                    "Guide HTTP: aion_create_team refused — conversation already belongs to a team"
+                );
+                return serde_json::json!({
+                    "error": "This conversation already belongs to a team. Cannot create another team from here."
+                });
+            }
+        }
+    }
+
     let req = CreateTeamRequest {
         name: params.name.clone(),
         agents: vec![TeamAgentInput {

--- a/crates/aionui-team/src/guide/server.rs
+++ b/crates/aionui-team/src/guide/server.rs
@@ -224,8 +224,7 @@ async fn exec_create_team(
     if let Some(ref conv_id) = caller_conversation_id {
         let repo = svc.conversation_service_ref().conversation_repo().clone();
         if let Ok(Some(row)) = repo.get(conv_id).await {
-            let extra: serde_json::Value =
-                serde_json::from_str(&row.extra).unwrap_or(serde_json::Value::Null);
+            let extra: serde_json::Value = serde_json::from_str(&row.extra).unwrap_or(serde_json::Value::Null);
             if extra
                 .get("teamId")
                 .and_then(serde_json::Value::as_str)

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -704,14 +704,30 @@ impl TeamSessionService {
         skip_leader: bool,
     ) -> Result<(), TeamError> {
         for agent in agents {
-            if skip_leader && agent.role == TeammateRole::Lead {
-                continue;
-            }
             let cfg = session.mcp_stdio_config(&agent.slot_id);
             let patch = serde_json::json!({
                 "team_mcp_stdio_config": cfg,
                 "session_mode": resolve_full_auto_mode(&agent.backend),
             });
+
+            // Always persist team_mcp_stdio_config into the leader's extra
+            // so subsequent warmups pick it up. Only skip the kill+warmup
+            // when the leader is already running (guide flow).
+            if skip_leader && agent.role == TeammateRole::Lead {
+                if let Err(e) = self
+                    .conversation_service
+                    .update_extra(&agent.conversation_id, patch)
+                    .await
+                {
+                    warn!(
+                        team_id,
+                        slot_id = %agent.slot_id,
+                        error = %e,
+                        "failed to persist team_mcp_stdio_config for skipped leader"
+                    );
+                }
+                continue;
+            }
 
             if let Err(e) = self
                 .conversation_service


### PR DESCRIPTION
## Summary
- Block guide MCP injection for conversations that already belong to a team (`extra.teamId` check in both ACP and aionrs factories)
- Add server-side guard in `exec_create_team` to refuse creating a team from a conversation that already has a `teamId`
- Always persist `team_mcp_stdio_config` into leader's extra during `rebuild_agent_processes` even when skipping warmup (guide→team flow)

## Root Cause
When a solo chat converted to a team, the leader's conversation got `teamId` written to extra. But on the next warmup/rebuild, the guide MCP was still being injected because the factory only checked `team_mcp_stdio_config` presence — not the `teamId` field. This allowed the leader to call `aion_create_team` again, creating duplicate teams and overwriting `extra.teamId`, causing cross-contamination between team sessions.

## Test plan
- [x] All 5513 workspace tests pass
- [x] Create a solo chat, convert to team → only 1 team created
- [x] Verify the team leader cannot call `aion_create_team` again
- [x] Verify aionrs team leader retains team tools after creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)