### PR TITLE
fix(db): prevent data loss in migration 002 table rebuilds

### DIFF
--- a/crates/aionui-db/migrations/002_legacy_data_normalize.sql
+++ b/crates/aionui-db/migrations/002_legacy_data_normalize.sql
@@ -141,13 +141,61 @@ WHERE agents_version = '1.0.0'
   AND (agents = '[]' OR json_array_length(agents) = 0);
 
 ------------------------------------------------------------------------
--- Part D: Remove legacy CHECK(agent_type IN ...) from assistant_sessions
+-- Part D: Rebuild tables to match 001 target schema
 --
--- Early dev builds had a CHECK constraint limiting agent_type to
--- ('gemini', 'acp', 'codex'). The consolidated 001 schema no longer has
--- this constraint, but CREATE TABLE IF NOT EXISTS won't alter an existing
--- table. Rebuild only if the constraint is still present.
+-- CREATE TABLE IF NOT EXISTS is a no-op for existing tables, so a v26
+-- database copied from aionui.db retains its original DDL (CHECK
+-- constraints, FK constraints, NOT NULL differences, DEFAULT differences).
+-- This part rebuilds every affected table to guarantee schema parity
+-- between fresh installs and legacy upgrades.
+--
+-- Safe on fresh databases: tables are empty, so the rebuild is a no-op
+-- data-wise (just recreates the same structure).
+--
+-- REQUIRES: foreign_keys = OFF on the connection before this migration
+-- runs (handled by run_migrations() in database.rs). Without this,
+-- DROP TABLE triggers ON DELETE CASCADE and ALTER TABLE RENAME rewrites
+-- child FK references — both destroy data.
 ------------------------------------------------------------------------
+
+-- D.1: messages — hidden NOT NULL DEFAULT 0
+
+CREATE TABLE IF NOT EXISTS _messages_new (
+    id              TEXT    PRIMARY KEY NOT NULL,
+    conversation_id TEXT    NOT NULL,
+    msg_id          TEXT,
+    type            TEXT    NOT NULL,
+    content         TEXT    NOT NULL DEFAULT '{}',
+    position        TEXT    CHECK(position IN ('left', 'right', 'center', 'pop')),
+    status          TEXT    CHECK(status IN ('finish', 'pending', 'error', 'work')),
+    hidden          INTEGER NOT NULL DEFAULT 0,
+    created_at      INTEGER NOT NULL,
+    FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+);
+
+INSERT OR IGNORE INTO _messages_new
+    (id, conversation_id, msg_id, type, content, position, status, hidden, created_at)
+SELECT
+    id, conversation_id, msg_id, type,
+    COALESCE(content, '{}'),
+    position, status,
+    COALESCE(hidden, 0),
+    created_at
+FROM messages;
+
+ALTER TABLE messages RENAME TO _messages_old;
+ALTER TABLE _messages_new RENAME TO messages;
+DROP TABLE IF EXISTS _messages_old;
+
+CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id);
+CREATE INDEX IF NOT EXISTS idx_messages_created_at ON messages(created_at);
+CREATE INDEX IF NOT EXISTS idx_messages_type ON messages(type);
+CREATE INDEX IF NOT EXISTS idx_messages_msg_id ON messages(msg_id);
+CREATE INDEX IF NOT EXISTS idx_messages_conv_created ON messages(conversation_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_messages_conv_created_desc ON messages(conversation_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_messages_type_created ON messages(type, created_at DESC);
+
+-- D.2: assistant_sessions — remove agent_type CHECK constraint
 
 CREATE TABLE IF NOT EXISTS _assistant_sessions_new (
     id              TEXT PRIMARY KEY NOT NULL,
@@ -166,12 +214,277 @@ INSERT OR IGNORE INTO _assistant_sessions_new (id, user_id, agent_type, conversa
     SELECT id, user_id, agent_type, conversation_id, workspace, chat_id, created_at, last_activity
     FROM assistant_sessions;
 
-DROP TABLE IF EXISTS assistant_sessions;
-
+ALTER TABLE assistant_sessions RENAME TO _assistant_sessions_old;
 ALTER TABLE _assistant_sessions_new RENAME TO assistant_sessions;
+DROP TABLE IF EXISTS _assistant_sessions_old;
 
 CREATE INDEX IF NOT EXISTS idx_assistant_sessions_user_id ON assistant_sessions(user_id);
 CREATE INDEX IF NOT EXISTS idx_assistant_sessions_user_chat ON assistant_sessions(user_id, chat_id);
+
+-- D.3: conversations — add NOT NULL DEFAULT on status/extra, add pinned columns
+
+CREATE TABLE IF NOT EXISTS _conversations_new (
+    id              TEXT    PRIMARY KEY NOT NULL,
+    user_id         TEXT    NOT NULL,
+    name            TEXT    NOT NULL,
+    type            TEXT    NOT NULL,
+    extra           TEXT    NOT NULL DEFAULT '{}',
+    model           TEXT,
+    status          TEXT    NOT NULL DEFAULT 'pending'
+                            CHECK(status IN ('pending', 'running', 'finished')),
+    source          TEXT,
+    channel_chat_id TEXT,
+    pinned          INTEGER NOT NULL DEFAULT 0,
+    pinned_at       INTEGER,
+    created_at      INTEGER NOT NULL,
+    updated_at      INTEGER NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+INSERT OR IGNORE INTO _conversations_new
+    (id, user_id, name, type, extra, model, status, source, channel_chat_id, pinned, pinned_at, created_at, updated_at)
+SELECT
+    id, user_id, name, type,
+    COALESCE(extra, '{}'),
+    model,
+    COALESCE(status, 'pending'),
+    source, channel_chat_id,
+    COALESCE(pinned, 0),
+    pinned_at,
+    created_at, updated_at
+FROM conversations;
+
+ALTER TABLE conversations RENAME TO _conversations_old;
+ALTER TABLE _conversations_new RENAME TO conversations;
+DROP TABLE IF EXISTS _conversations_old;
+
+CREATE INDEX IF NOT EXISTS idx_conversations_user_id ON conversations(user_id);
+CREATE INDEX IF NOT EXISTS idx_conversations_updated_at ON conversations(updated_at);
+CREATE INDEX IF NOT EXISTS idx_conversations_type ON conversations(type);
+CREATE INDEX IF NOT EXISTS idx_conversations_user_updated ON conversations(user_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_conversations_source ON conversations(source);
+CREATE INDEX IF NOT EXISTS idx_conversations_source_updated ON conversations(source, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_conversations_source_chat ON conversations(source, channel_chat_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_conversations_cron_job_id ON conversations(json_extract(extra, '$.cronJobId'));
+
+-- D.4: teams — lead_agent_id nullable (no NOT NULL), remove FK, add defaults
+
+CREATE TABLE IF NOT EXISTS _teams_new (
+    id             TEXT PRIMARY KEY NOT NULL,
+    user_id        TEXT    NOT NULL DEFAULT 'system_default_user',
+    name           TEXT    NOT NULL,
+    workspace      TEXT    NOT NULL DEFAULT '',
+    workspace_mode TEXT    NOT NULL DEFAULT 'shared',
+    agents         TEXT    NOT NULL DEFAULT '[]',
+    lead_agent_id  TEXT,
+    session_mode   TEXT,
+    agents_version TEXT    NOT NULL DEFAULT '1.0.0',
+    created_at     INTEGER NOT NULL,
+    updated_at     INTEGER NOT NULL
+);
+
+INSERT OR IGNORE INTO _teams_new
+    (id, user_id, name, workspace, workspace_mode, agents, lead_agent_id, session_mode, agents_version, created_at, updated_at)
+SELECT
+    id, user_id, name, workspace, workspace_mode, agents,
+    CASE WHEN lead_agent_id = '' THEN NULL ELSE lead_agent_id END,
+    session_mode,
+    COALESCE(agents_version, '1.0.0'),
+    created_at, updated_at
+FROM teams;
+
+ALTER TABLE teams RENAME TO _teams_old;
+ALTER TABLE _teams_new RENAME TO teams;
+DROP TABLE IF EXISTS _teams_old;
+
+CREATE INDEX IF NOT EXISTS idx_teams_user_id ON teams(user_id);
+CREATE INDEX IF NOT EXISTS idx_teams_updated_at ON teams(updated_at);
+
+-- D.5: mailbox — add CHECK on type, remove FK
+
+CREATE TABLE IF NOT EXISTS _mailbox_new (
+    id            TEXT    PRIMARY KEY NOT NULL,
+    team_id       TEXT    NOT NULL,
+    to_agent_id   TEXT    NOT NULL,
+    from_agent_id TEXT    NOT NULL,
+    type          TEXT    NOT NULL CHECK (type IN ('message', 'idle_notification', 'shutdown_request')),
+    content       TEXT    NOT NULL,
+    summary       TEXT,
+    files         TEXT,
+    read          INTEGER NOT NULL DEFAULT 0,
+    created_at    INTEGER NOT NULL
+);
+
+INSERT OR IGNORE INTO _mailbox_new
+    (id, team_id, to_agent_id, from_agent_id, type, content, summary, files, read, created_at)
+SELECT
+    id, team_id, to_agent_id, from_agent_id,
+    CASE WHEN type IN ('message', 'idle_notification', 'shutdown_request') THEN type ELSE 'message' END,
+    content, summary, files, read, created_at
+FROM mailbox;
+
+ALTER TABLE mailbox RENAME TO _mailbox_old;
+ALTER TABLE _mailbox_new RENAME TO mailbox;
+DROP TABLE IF EXISTS _mailbox_old;
+
+CREATE INDEX IF NOT EXISTS idx_mailbox_team_to_read ON mailbox(team_id, to_agent_id, read);
+CREATE INDEX IF NOT EXISTS idx_mailbox_team_id ON mailbox(team_id);
+
+-- D.6: team_tasks — add CHECK on status, metadata nullable, remove FK
+
+CREATE TABLE IF NOT EXISTS _team_tasks_new (
+    id          TEXT    PRIMARY KEY NOT NULL,
+    team_id     TEXT    NOT NULL,
+    subject     TEXT    NOT NULL,
+    description TEXT,
+    status      TEXT    NOT NULL DEFAULT 'pending'
+                        CHECK (status IN ('pending', 'in_progress', 'completed', 'deleted')),
+    owner       TEXT,
+    blocked_by  TEXT    NOT NULL DEFAULT '[]',
+    blocks      TEXT    NOT NULL DEFAULT '[]',
+    metadata    TEXT,
+    created_at  INTEGER NOT NULL,
+    updated_at  INTEGER NOT NULL
+);
+
+INSERT OR IGNORE INTO _team_tasks_new
+    (id, team_id, subject, description, status, owner, blocked_by, blocks, metadata, created_at, updated_at)
+SELECT
+    id, team_id, subject, description,
+    CASE WHEN status IN ('pending', 'in_progress', 'completed', 'deleted') THEN status ELSE 'pending' END,
+    owner, blocked_by, blocks,
+    CASE WHEN metadata = '{}' THEN NULL ELSE metadata END,
+    created_at, updated_at
+FROM team_tasks;
+
+ALTER TABLE team_tasks RENAME TO _team_tasks_old;
+ALTER TABLE _team_tasks_new RENAME TO team_tasks;
+DROP TABLE IF EXISTS _team_tasks_old;
+
+CREATE INDEX IF NOT EXISTS idx_team_tasks_team_id ON team_tasks(team_id);
+
+-- D.7: assistant_plugins — remove status CHECK constraint
+
+CREATE TABLE IF NOT EXISTS _assistant_plugins_new (
+    id             TEXT PRIMARY KEY NOT NULL,
+    type           TEXT    NOT NULL,
+    name           TEXT    NOT NULL,
+    enabled        INTEGER NOT NULL DEFAULT 0,
+    config         TEXT    NOT NULL,
+    status         TEXT,
+    last_connected INTEGER,
+    created_at     INTEGER NOT NULL,
+    updated_at     INTEGER NOT NULL
+);
+
+INSERT OR IGNORE INTO _assistant_plugins_new
+    (id, type, name, enabled, config, status, last_connected, created_at, updated_at)
+SELECT id, type, name, enabled, config, status, last_connected, created_at, updated_at
+FROM assistant_plugins;
+
+ALTER TABLE assistant_plugins RENAME TO _assistant_plugins_old;
+ALTER TABLE _assistant_plugins_new RENAME TO assistant_plugins;
+DROP TABLE IF EXISTS _assistant_plugins_old;
+
+-- D.8: remote_agents — status/allow_insecure NOT NULL
+
+CREATE TABLE IF NOT EXISTS _remote_agents_new (
+    id                 TEXT PRIMARY KEY NOT NULL,
+    name               TEXT    NOT NULL,
+    protocol           TEXT    NOT NULL,
+    url                TEXT    NOT NULL,
+    auth_type          TEXT    NOT NULL,
+    auth_token         TEXT,
+    allow_insecure     INTEGER NOT NULL DEFAULT 0,
+    avatar             TEXT,
+    description        TEXT,
+    device_id          TEXT,
+    device_public_key  TEXT,
+    device_private_key TEXT,
+    device_token       TEXT,
+    status             TEXT    NOT NULL DEFAULT 'unknown',
+    last_connected_at  INTEGER,
+    created_at         INTEGER NOT NULL,
+    updated_at         INTEGER NOT NULL
+);
+
+INSERT OR IGNORE INTO _remote_agents_new
+    (id, name, protocol, url, auth_type, auth_token, allow_insecure, avatar, description,
+     device_id, device_public_key, device_private_key, device_token, status, last_connected_at,
+     created_at, updated_at)
+SELECT
+    id, name, protocol, url, auth_type, auth_token,
+    COALESCE(allow_insecure, 0),
+    avatar, description,
+    device_id, device_public_key, device_private_key, device_token,
+    COALESCE(status, 'unknown'),
+    last_connected_at, created_at, updated_at
+FROM remote_agents;
+
+ALTER TABLE remote_agents RENAME TO _remote_agents_old;
+ALTER TABLE _remote_agents_new RENAME TO remote_agents;
+DROP TABLE IF EXISTS _remote_agents_old;
+
+CREATE INDEX IF NOT EXISTS idx_remote_agents_status ON remote_agents(status);
+
+-- D.9: cron_jobs — execution_mode NOT NULL+CHECK, schedule_description nullable,
+--                  enabled NOT NULL
+
+CREATE TABLE IF NOT EXISTS _cron_jobs_new (
+    id                   TEXT    PRIMARY KEY NOT NULL,
+    name                 TEXT    NOT NULL,
+    enabled              INTEGER NOT NULL DEFAULT 1,
+    schedule_kind        TEXT    NOT NULL CHECK(schedule_kind IN ('at', 'every', 'cron')),
+    schedule_value       TEXT    NOT NULL,
+    schedule_tz          TEXT,
+    schedule_description TEXT,
+    payload_message      TEXT    NOT NULL,
+    execution_mode       TEXT    NOT NULL DEFAULT 'existing'
+                                 CHECK(execution_mode IN ('existing', 'new_conversation')),
+    agent_config         TEXT,
+    conversation_id      TEXT    NOT NULL,
+    conversation_title   TEXT,
+    agent_type           TEXT    NOT NULL,
+    created_by           TEXT    NOT NULL CHECK(created_by IN ('user', 'agent')),
+    skill_content        TEXT,
+    description          TEXT,
+    created_at           INTEGER NOT NULL,
+    updated_at           INTEGER NOT NULL,
+    next_run_at          INTEGER,
+    last_run_at          INTEGER,
+    last_status          TEXT    CHECK(last_status IN ('ok', 'error', 'skipped', 'missed')),
+    last_error           TEXT,
+    run_count            INTEGER NOT NULL DEFAULT 0,
+    retry_count          INTEGER NOT NULL DEFAULT 0,
+    max_retries          INTEGER NOT NULL DEFAULT 3
+);
+
+INSERT OR IGNORE INTO _cron_jobs_new
+    (id, name, enabled, schedule_kind, schedule_value, schedule_tz, schedule_description,
+     payload_message, execution_mode, agent_config, conversation_id, conversation_title,
+     agent_type, created_by, skill_content, description, created_at, updated_at,
+     next_run_at, last_run_at, last_status, last_error, run_count, retry_count, max_retries)
+SELECT
+    id, name,
+    COALESCE(enabled, 1),
+    schedule_kind, schedule_value, schedule_tz, schedule_description,
+    payload_message,
+    COALESCE(execution_mode, 'existing'),
+    agent_config, conversation_id, conversation_title,
+    agent_type, created_by, skill_content, description, created_at, updated_at,
+    next_run_at, last_run_at, last_status, last_error,
+    COALESCE(run_count, 0),
+    COALESCE(retry_count, 0),
+    COALESCE(max_retries, 3)
+FROM cron_jobs;
+
+ALTER TABLE cron_jobs RENAME TO _cron_jobs_old;
+ALTER TABLE _cron_jobs_new RENAME TO cron_jobs;
+DROP TABLE IF EXISTS _cron_jobs_old;
+
+CREATE INDEX IF NOT EXISTS idx_cron_jobs_conversation ON cron_jobs(conversation_id);
+CREATE INDEX IF NOT EXISTS idx_cron_jobs_next_run ON cron_jobs(next_run_at) WHERE enabled = 1;
+CREATE INDEX IF NOT EXISTS idx_cron_jobs_agent_type ON cron_jobs(agent_type);
 
 ------------------------------------------------------------------------
 -- Part E: Backfill acp_session rows from conversations.extra

--- a/crates/aionui-db/src/database.rs
+++ b/crates/aionui-db/src/database.rs
@@ -132,7 +132,22 @@ async fn try_init_file(path: &Path) -> Result<Database, DbError> {
 
 async fn run_migrations(pool: &SqlitePool) -> Result<(), DbError> {
     ensure_schema_columns(pool).await?;
-    sqlx::migrate!().run(pool).await.map_err(DbError::Migration)
+    // Migration 002 rebuilds tables via RENAME+DROP. Two pragmas are needed:
+    // - foreign_keys=OFF: prevents DROP TABLE from triggering ON DELETE CASCADE
+    // - legacy_alter_table=ON: prevents ALTER TABLE RENAME from rewriting FK
+    //   references in other tables (SQLite 3.26+ rewrites them by default)
+    // Both must be set outside a transaction (sqlx wraps each migration in one).
+    let mut conn = pool.acquire().await.map_err(DbError::Query)?;
+    sqlx::query("PRAGMA foreign_keys = OFF; PRAGMA legacy_alter_table = ON")
+        .execute(&mut *conn)
+        .await
+        .map_err(DbError::Query)?;
+    let result = sqlx::migrate!().run(&mut *conn).await.map_err(DbError::Migration);
+    sqlx::query("PRAGMA foreign_keys = ON; PRAGMA legacy_alter_table = OFF")
+        .execute(&mut *conn)
+        .await
+        .map_err(DbError::Query)?;
+    result
 }
 
 /// Ensure columns expected by Rust models exist in the database.
@@ -276,5 +291,20 @@ mod tests {
             should_attempt_recovery(&err),
             "corruption-like failures should trigger recovery"
         );
+    }
+
+    #[tokio::test]
+    async fn migration_preserves_fk_references() {
+        let db = init_database_memory().await.unwrap();
+        let pool = db.pool();
+
+        let fk_table: String = sqlx::query_scalar(
+            "SELECT \"table\" FROM pragma_foreign_key_list('messages') WHERE \"from\"='conversation_id'",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap();
+
+        assert_eq!(fk_table, "conversations");
     }
 }


### PR DESCRIPTION
## Summary

- Migration 002 的表重建（RENAME+DROP）在 `foreign_keys=ON` 时会触发 `ON DELETE CASCADE` 删除子表数据（如 messages），并且 SQLite 3.26+ 的 `ALTER TABLE RENAME` 会重写其他表的 FK 引用指向错误的表名
- 在 `run_migrations()` 中，迁移前设置 `PRAGMA foreign_keys = OFF; PRAGMA legacy_alter_table = ON`，迁移后恢复
- 重构 002 的 Part D：9 张表使用 RENAME-to-old + DROP 模式重建，保证新旧用户 schema 一致

## 验证

- 使用实际 v26 数据库（conversations=325, messages=3409, mailbox=221, team_tasks=16）验证迁移后数据零丢失
- 模拟 sqlx 的事务包裹行为（`BEGIN` + 002 SQL + `COMMIT`）确认 pragma 生效
- 全部 5514 测试通过，新增 `migration_preserves_fk_references` 测试确保 FK 指向正确

## Test plan

- [x] `cargo test -p aionui-db` 通过（487 tests）
- [x] `just push` 全量测试通过（5514 tests）
- [x] 实际 v26 数据库迁移验证（用户确认消息不丢失）
- [x] 全新数据库（内存）迁移验证（FK 引用正确）