### PR TITLE
fix(cron): lazy-bind existing jobs and tighten orphan cleanup

### DIFF
--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -369,6 +369,15 @@ impl JobExecutor {
     ) -> Result<String, CronError> {
         match job.execution_mode {
             ExecutionMode::Existing => {
+                // A job created without an anchor conversation (the frontend
+                // creates "continue-this-conversation" jobs from the cron page
+                // before any conversation exists) keeps `conversation_id`
+                // empty until the first run. Treat that first run as a new
+                // conversation; the service layer then persists the new id
+                // back onto the job so subsequent runs reuse it.
+                if job.conversation_id.trim().is_empty() {
+                    return self.create_new_conversation(job, saved_skill).await;
+                }
                 self.verify_conversation_exists(&job.conversation_id).await?;
                 Ok(job.conversation_id.clone())
             }

--- a/crates/aionui-cron/src/service.rs
+++ b/crates/aionui-cron/src/service.rs
@@ -247,6 +247,13 @@ impl CronService {
             };
 
             if self.is_orphan(&job).await {
+                warn!(
+                    job_id = %job.id,
+                    job_name = %job.name,
+                    conversation_id = %job.conversation_id,
+                    execution_mode = job.execution_mode.as_str(),
+                    "Deleting orphan cron job whose bound conversation no longer exists"
+                );
                 if let Err(e) = self.repo.delete(&job.id).await {
                     error!(job_id = %job.id, error = %e, "Failed to delete orphan cron job");
                 }
@@ -438,14 +445,25 @@ impl CronService {
     }
 
     async fn is_orphan(&self, job: &CronJob) -> bool {
+        // NewConversation jobs never depend on an existing conversation —
+        // every run materializes a fresh one. They must not be cleaned up
+        // based on conversation state.
+        if matches!(job.execution_mode, ExecutionMode::NewConversation) {
+            return false;
+        }
+
+        // Existing-mode jobs can legitimately carry an empty conversation_id
+        // until the first run performs lazy binding. Leave them alone.
+        if job.conversation_id.trim().is_empty() {
+            return false;
+        }
+
         if self.executor.busy_guard().is_busy(&job.conversation_id) {
             return false;
         }
 
-        if job.conversation_id.trim().is_empty() {
-            return true;
-        }
-
+        // Only true orphan case: Existing + bound conversation_id, but that
+        // conversation has been deleted.
         match self.executor.conversation_exists(&job.conversation_id).await {
             Ok(exists) => !exists,
             Err(err) => {
@@ -540,9 +558,9 @@ impl CronService {
         }
     }
 
-    async fn update_job_after_success(&self, job_id: &str, _conversation_id: &str) {
-        let run_count = match self.repo.get_by_id(job_id).await {
-            Ok(Some(r)) => r.run_count,
+    async fn update_job_after_success(&self, job_id: &str, conversation_id: &str) {
+        let existing_row = match self.repo.get_by_id(job_id).await {
+            Ok(Some(r)) => r,
             Ok(None) => return,
             Err(e) => {
                 error!(job_id, error = %e, "Failed to read job for run_count");
@@ -550,16 +568,38 @@ impl CronService {
             }
         };
         let now = now_ms();
+        // Persist the conversation_id back onto the job the first time an
+        // "existing" job is materialized (lazy binding). Subsequent runs then
+        // reuse the same conversation, matching the UX where the job is the
+        // continuation anchor.
+        let needs_conversation_bind =
+            existing_row.conversation_id.trim().is_empty() && !conversation_id.trim().is_empty();
         let params = UpdateCronJobParams {
             last_run_at: Some(Some(now)),
             last_status: Some(Some("ok".into())),
             last_error: Some(None),
             retry_count: Some(0),
-            run_count: Some(run_count + 1),
+            run_count: Some(existing_row.run_count + 1),
+            conversation_id: needs_conversation_bind.then(|| conversation_id.to_owned()),
             ..Default::default()
         };
         if let Err(e) = self.repo.update(job_id, &params).await {
             error!(job_id, error = %e, "Failed to update job after success");
+            return;
+        }
+
+        if needs_conversation_bind
+            && let Err(e) = self
+                .executor
+                .bind_cron_job_to_conversation(conversation_id, job_id)
+                .await
+        {
+            warn!(
+                job_id,
+                conversation_id,
+                error = %e,
+                "Failed to bind lazily-created conversation to cron job"
+            );
         }
     }
 

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -1102,26 +1102,59 @@ async fn sc8_every_negative_interval() {
     assert!(matches!(err, aionui_cron::error::CronError::InvalidSchedule(_)));
 }
 
-// ── OC-1: Init cleans orphan jobs ─────────────────────────────────
+// ── OC-1: Init preserves lazy-bind "existing" jobs with empty conversation_id ─────
 
 #[tokio::test]
-async fn oc1_init_cleans_orphans() {
+async fn oc1_init_preserves_lazy_existing_jobs() {
+    // "existing + empty conversation_id" is a legitimate lazy-binding job:
+    // the frontend creates a cron from the standalone cron page before any
+    // conversation exists, and the first execution materializes it. Those
+    // jobs must survive init, not be cleaned up as orphans.
     let (svc, _repo, _) = setup().await;
 
-    let mut req = make_create_req("Orphan", every_60s());
+    let mut req = make_create_req("Lazy Existing", every_60s());
     req.conversation_id = "".into();
-    let orphan = svc.add_job(req).await.unwrap();
+    req.execution_mode = Some("existing".into());
+    let lazy = svc.add_job(req).await.unwrap();
 
     let normal_req = make_create_req("Normal", every_60s());
     let normal = svc.add_job(normal_req).await.unwrap();
 
     svc.init().await;
 
-    let err = svc.get_job(&orphan.id).await;
-    assert!(err.is_err());
+    let found_lazy = svc.get_job(&lazy.id).await;
+    assert!(found_lazy.is_ok(), "lazy-bind existing job should survive init");
 
     let found = svc.get_job(&normal.id).await;
     assert!(found.is_ok());
+}
+
+// NewConversation jobs don't depend on any existing conversation — they
+// create one on every run. They must never be cleaned up as orphans.
+#[tokio::test]
+async fn oc1b_init_preserves_new_conversation_jobs() {
+    let (svc, _repo, _) = setup().await;
+
+    let mut empty_req = make_create_req("New-conv empty", every_60s());
+    empty_req.conversation_id = "".into();
+    empty_req.execution_mode = Some("new_conversation".into());
+    let empty = svc.add_job(empty_req).await.unwrap();
+
+    let mut stale_req = make_create_req("New-conv with stale id", every_60s());
+    stale_req.conversation_id = "conv-that-no-longer-exists".into();
+    stale_req.execution_mode = Some("new_conversation".into());
+    let stale = svc.add_job(stale_req).await.unwrap();
+
+    svc.init().await;
+
+    assert!(
+        svc.get_job(&empty.id).await.is_ok(),
+        "empty new_conversation job must survive"
+    );
+    assert!(
+        svc.get_job(&stale.id).await.is_ok(),
+        "new_conversation job with stale id must survive"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Two related issues surfaced on the cron page when a job is created before any conversation exists:

1. **`execution_mode=existing` + empty `conversation_id` failed with `"conversation  not found"`** — the frontend creates continuation-style cron jobs from the standalone cron page, but no conversation is anchored yet. The executor now treats the first run of such a job as a `new_conversation` creation, then persists the new id back onto the job (and binds `cron_job_id` into the conversation's `extra`), so later runs resume the same conversation.
2. **Orphan cleanup at startup was too aggressive, silently deleting legitimate jobs**:
   - `NewConversation` jobs don't depend on any existing conversation — they create one each run. They were being deleted whenever `conversation_id` was empty or pointed at a removed conversation.
   - `Existing` jobs still in the lazy-bind window (empty `conversation_id`) were being deleted before they ever got a chance to run.

`is_orphan` is now tightened:
- `NewConversation` → never orphan.
- `Existing` with empty `conversation_id` → never orphan (waiting for lazy-bind).
- `Existing` with a bound `conversation_id` whose conversation has been deleted → still orphan.

The deletion site also gains a `warn!` with `job_id`/`name`/`conversation_id`/`execution_mode`, so any future data loss is traceable in logs.

## Test plan

- [x] `cargo test -p aionui-cron` (lib + all integration suites) — 210+ tests green locally.
- [x] Renamed `oc1_init_cleans_orphans` to `oc1_init_preserves_lazy_existing_jobs` (asserts lazy-bind jobs survive).
- [x] Added `oc1b_init_preserves_new_conversation_jobs` covering NewConversation + empty conversation_id and NewConversation + stale conversation_id.
- [x] `oc2_init_cleans_jobs_with_missing_conversation` keeps covering the true-orphan case (Existing + bound id that no longer exists).
- [ ] Manual: create a cron job from the standalone cron page (no current conversation), trigger run-now → first run materializes a new conversation and job gets bound; subsequent runs reuse it.
- [ ] Manual: restart backend with a lazy `existing + empty conversation_id` job — it is still there after init.