### PR TITLE
fix(runtime): anchor bun cache and agent spawn env under AppConfig.data_dir

### DIFF
--- a/crates/aionui-ai-agent/src/capability/cli_process/spawn_sdk.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/spawn_sdk.rs
@@ -1,5 +1,6 @@
 use aionui_common::{AppError, CommandSpec};
 use aionui_runtime::Builder as CmdBuilder;
+use std::path::Path;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Child;
@@ -15,14 +16,19 @@ impl CliAgentProcess {
     /// Instead, the raw stdin/stdout handles are available via [`take_stdio`](Self::take_stdio)
     /// for the ACP SDK transport to own.
     ///
+    /// `data_dir` is the backend's `AppConfig.data_dir` — used as the root
+    /// for child-process bun cache / tmp directories so they honour the
+    /// operator's `--data-dir` choice instead of falling back to the OS
+    /// local data dir.
+    ///
     /// Background tasks are still spawned for:
     /// - stderr buffering
     /// - Process exit monitoring
-    pub async fn spawn_for_sdk(config: CommandSpec) -> Result<Self, AppError> {
+    pub async fn spawn_for_sdk(config: CommandSpec, data_dir: &Path) -> Result<Self, AppError> {
         let mut cmd = CmdBuilder::new(&config.command);
         cmd.args(&config.args)
             .envs(config.env.iter().map(|e| (&e.name, &e.value)))
-            .envs(Self::agent_spawn_env())
+            .envs(Self::agent_spawn_env(data_dir))
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
@@ -115,12 +121,10 @@ impl CliAgentProcess {
 
     /// Build environment variables for agent subprocess spawn.
     /// Mirrors the frontend `acpConnectors.ts::getCleanAgentEnv` logic:
-    /// - Set BUN_INSTALL_CACHE_DIR / BUN_TMPDIR to stable paths
+    /// - Set BUN_INSTALL_CACHE_DIR / BUN_TMPDIR to stable paths under
+    ///   the backend's `AppConfig.data_dir`
     /// - Set CLAUDE_CODE_EXECUTABLE so claude-agent-sdk finds the CLI
-    fn agent_spawn_env() -> Vec<(String, String)> {
-        let data_dir = dirs::data_local_dir()
-            .unwrap_or_else(|| std::path::PathBuf::from("."))
-            .join("aionui");
+    fn agent_spawn_env(data_dir: &Path) -> Vec<(String, String)> {
         let bun_cache = data_dir.join("bun-cache");
         let bun_tmp = data_dir.join("bun-tmp");
 
@@ -171,7 +175,8 @@ mod tests {
     #[tokio::test]
     async fn spawn_for_sdk_take_stdio() {
         let config = simple_script_config("read line && echo \"$line\"");
-        let proc = CliAgentProcess::spawn_for_sdk(config).await.unwrap();
+        let tmp = std::env::temp_dir();
+        let proc = CliAgentProcess::spawn_for_sdk(config, &tmp).await.unwrap();
 
         let stdio = proc.take_stdio().await;
         assert!(stdio.is_some(), "First take_stdio should succeed");

--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -110,6 +110,7 @@ pub(super) async fn build(
             command_spec,
             config,
             session_snapshot,
+            deps.data_dir.clone(),
         )
         .await,
     );

--- a/crates/aionui-ai-agent/src/factory/acp_assembler.rs
+++ b/crates/aionui-ai-agent/src/factory/acp_assembler.rs
@@ -4,6 +4,7 @@ use agent_client_protocol::schema::{EnvVariable, McpServer, McpServerStdio, NewS
 use aionui_api_types::AgentMetadata;
 use aionui_api_types::{AcpBuildExtra, GuideMcpConfig, TeamMcpStdioConfig};
 use aionui_common::CommandSpec;
+use std::path::PathBuf;
 
 use aionui_common::constants::TEAM_CAPABLE_BACKENDS;
 
@@ -30,6 +31,10 @@ pub struct AcpSessionParams {
     pub mcp_servers: Vec<McpServer>,
     pub preset_context: Option<String>,
     pub session_snapshot: Option<PersistedSessionState>,
+    /// Backend data directory (`AppConfig.data_dir`). Passed through to
+    /// `CliAgentProcess::spawn_for_sdk` so bun cache / tmp directories
+    /// land under the operator-chosen path rather than the OS default.
+    pub data_dir: PathBuf,
 }
 
 impl AcpSessionParams {
@@ -56,6 +61,7 @@ pub async fn assemble_acp_params(
     command_spec: CommandSpec,
     config: AcpBuildExtra,
     session_snapshot: Option<PersistedSessionState>,
+    data_dir: PathBuf,
 ) -> AcpSessionParams {
     let mcp_servers = resolve_mcp_servers(&config, &conversation_id);
     let preset_context = compose_preset_context(
@@ -73,6 +79,7 @@ pub async fn assemble_acp_params(
         mcp_servers,
         preset_context,
         session_snapshot,
+        data_dir,
     }
 }
 

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -136,7 +136,7 @@ impl AcpAgentManager {
         ),
         AppError,
     > {
-        let process = CliAgentProcess::spawn_for_sdk(params.command_spec.clone()).await?;
+        let process = CliAgentProcess::spawn_for_sdk(params.command_spec.clone(), &params.data_dir).await?;
         let (stdin, stdout) = process
             .take_stdio()
             .await

--- a/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
+++ b/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
@@ -13,7 +13,7 @@
 //! Both paths produce identical outcomes / error text.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use aionui_api_types::TryConnectCustomAgentResponse;
@@ -39,6 +39,7 @@ pub async fn try_connect_custom_agent(
     command: &str,
     args: &[String],
     env: &HashMap<String, String>,
+    data_dir: &Path,
 ) -> TryConnectCustomAgentResponse {
     // ── Step 1 — which check ────────────────────────────────────────
     let head = first_token(command);
@@ -50,7 +51,7 @@ pub async fn try_connect_custom_agent(
     debug!(?resolved, "probe step 1 ok");
 
     // ── Step 2 — spawn + ACP initialize ─────────────────────────────
-    match tokio::time::timeout(STEP2_TIMEOUT, acp_initialize(resolved, args, env)).await {
+    match tokio::time::timeout(STEP2_TIMEOUT, acp_initialize(resolved, args, env, data_dir)).await {
         Ok(Ok(())) => TryConnectCustomAgentResponse::Success,
         Ok(Err(msg)) => TryConnectCustomAgentResponse::FailAcp { error: msg },
         Err(_) => TryConnectCustomAgentResponse::FailAcp {
@@ -63,7 +64,12 @@ fn first_token(command: &str) -> &str {
     command.split_whitespace().next().unwrap_or(command)
 }
 
-async fn acp_initialize(resolved: PathBuf, args: &[String], env: &HashMap<String, String>) -> Result<(), String> {
+async fn acp_initialize(
+    resolved: PathBuf,
+    args: &[String],
+    env: &HashMap<String, String>,
+    data_dir: &Path,
+) -> Result<(), String> {
     let spec = CommandSpec {
         command: resolved,
         args: args.to_vec(),
@@ -77,7 +83,7 @@ async fn acp_initialize(resolved: PathBuf, args: &[String], env: &HashMap<String
         cwd: Some(std::env::temp_dir().to_string_lossy().into_owned()),
     };
 
-    let proc = CliAgentProcess::spawn_for_sdk(spec)
+    let proc = CliAgentProcess::spawn_for_sdk(spec, data_dir)
         .await
         .map_err(|e| format!("spawn failed: {e}"))?;
 
@@ -130,7 +136,8 @@ mod tests {
 
     #[tokio::test]
     async fn probe_returns_fail_cli_when_command_missing() {
-        let resp = try_connect_custom_agent("aionui-definitely-does-not-exist-xyz", &[], &HashMap::new()).await;
+        let tmp = std::env::temp_dir();
+        let resp = try_connect_custom_agent("aionui-definitely-does-not-exist-xyz", &[], &HashMap::new(), &tmp).await;
         match resp {
             TryConnectCustomAgentResponse::FailCli { error } => {
                 let lower = error.to_lowercase();
@@ -152,7 +159,8 @@ mod tests {
             // `true` is a cmd builtin on Windows, not a standalone exe.
             return;
         }
-        let resp = try_connect_custom_agent("true", &[], &HashMap::new()).await;
+        let tmp = std::env::temp_dir();
+        let resp = try_connect_custom_agent("true", &[], &HashMap::new(), &tmp).await;
         assert!(
             matches!(resp, TryConnectCustomAgentResponse::FailAcp { .. }),
             "expected FailAcp, got {resp:?}"

--- a/crates/aionui-ai-agent/src/services/custom.rs
+++ b/crates/aionui-ai-agent/src/services/custom.rs
@@ -12,6 +12,7 @@
 //! manual "Test connection" button.
 
 use std::collections::HashMap;
+use std::path::Path;
 
 use aionui_api_types::{
     AgentMetadata, CustomAgentUpsertRequest, TryConnectCustomAgentRequest, TryConnectCustomAgentResponse,
@@ -36,12 +37,12 @@ impl AgentService {
         if req.command.trim().is_empty() {
             return Err(AppError::BadRequest("command must not be empty".into()));
         }
-        Ok(probe(&req.command, &req.acp_args, &req.env).await)
+        Ok(probe(&req.command, &req.acp_args, &req.env, self.data_dir()).await)
     }
 
     pub async fn create_custom_agent(&self, req: CustomAgentUpsertRequest) -> Result<AgentMetadata, AppError> {
         validate_upsert(&req)?;
-        probe_or_reject(&req).await?;
+        probe_or_reject(&req, self.data_dir()).await?;
 
         let id = generate_short_id();
         self.upsert_custom_row(&id, &req, /* keep_enabled = */ true).await
@@ -65,7 +66,7 @@ impl AgentService {
                 "Only custom agents can be edited via this endpoint".into(),
             ));
         }
-        probe_or_reject(&req).await?;
+        probe_or_reject(&req, self.data_dir()).await?;
 
         let keep_enabled = existing.enabled;
         self.upsert_custom_row(id, &req, keep_enabled).await
@@ -202,7 +203,7 @@ fn validate_upsert(req: &CustomAgentUpsertRequest) -> Result<(), AppError> {
     Ok(())
 }
 
-async fn probe_or_reject(req: &CustomAgentUpsertRequest) -> Result<(), AppError> {
+async fn probe_or_reject(req: &CustomAgentUpsertRequest, data_dir: &Path) -> Result<(), AppError> {
     // Test-only bypass — real probe spawns a child process and relies
     // on a working ACP CLI on PATH, which is not present in CI.
     // Gated behind cfg(test) / the `test-support` feature so production
@@ -214,7 +215,7 @@ async fn probe_or_reject(req: &CustomAgentUpsertRequest) -> Result<(), AppError>
     }
 
     let env_map: HashMap<String, String> = req.env.iter().map(|e| (e.name.clone(), e.value.clone())).collect();
-    match probe(&req.command, &req.args, &env_map).await {
+    match probe(&req.command, &req.args, &env_map, data_dir).await {
         TryConnectCustomAgentResponse::Success => Ok(()),
         TryConnectCustomAgentResponse::FailCli { error } => {
             Err(AppError::BadRequest(format!("cli_not_found: {error}")))

--- a/crates/aionui-ai-agent/src/services/service.rs
+++ b/crates/aionui-ai-agent/src/services/service.rs
@@ -5,7 +5,7 @@
 //! only extract inputs, call methods on this service, and wrap the
 //! result in `ApiResponse`. Methods will be added in Stage 2b–2f.
 
-use std::path::Component;
+use std::path::{Component, PathBuf};
 use std::sync::Arc;
 
 use agent_client_protocol::schema::SessionModelState;
@@ -32,6 +32,10 @@ pub struct AgentService {
     conversation_repo: Arc<dyn IConversationRepository>,
     #[allow(dead_code)]
     acp_session_sync: Arc<AcpSessionSyncService>,
+    /// Backend data directory (`AppConfig.data_dir`), forwarded to the
+    /// custom-agent probe so its child `spawn_for_sdk` call uses the
+    /// operator-chosen root for bun cache / tmp paths.
+    data_dir: PathBuf,
 }
 
 impl AgentService {
@@ -40,13 +44,19 @@ impl AgentService {
         registry: Arc<AgentRegistry>,
         conversation_repo: Arc<dyn IConversationRepository>,
         acp_session_sync: Arc<AcpSessionSyncService>,
+        data_dir: PathBuf,
     ) -> Arc<Self> {
         Arc::new(Self {
             task_manager,
             registry,
             conversation_repo,
             acp_session_sync,
+            data_dir,
         })
+    }
+
+    pub(crate) fn data_dir(&self) -> &std::path::Path {
+        &self.data_dir
     }
 
     pub(crate) fn registry(&self) -> &std::sync::Arc<crate::registry::AgentRegistry> {

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -104,6 +104,7 @@ async fn make_mock_agent(script: &str, backend: &str) -> (Arc<AcpAgentManager>, 
             },
             config,
             None,
+            std::env::temp_dir(),
         )
         .await,
     );

--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -78,28 +78,49 @@ fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> tracing_appender::no
 }
 
 fn main() -> Result<ExitCode> {
+    // mcp-* subcommands route into short-lived stdio helpers that don't
+    // accept `--data-dir`. Detect them via argv[1] BEFORE `Cli::parse`
+    // (which rejects unknown positional args) so those paths can bypass
+    // both `aionui_runtime::init` and the full CLI parse.
+    let mcp_subcommand: Option<&str> = match std::env::args().nth(1).as_deref() {
+        Some("mcp-bridge") => Some("mcp-bridge"),
+        Some("mcp-guide-stdio") => Some("mcp-guide-stdio"),
+        Some("mcp-team-stdio") => Some("mcp-team-stdio"),
+        _ => None,
+    };
+
+    // Anchor the bun runtime cache under --data-dir BEFORE any code path
+    // that resolves it (enhance_process_path below + every later
+    // resolve_bun call). MCP subcommands fall back to the OS default
+    // cache, which is fine — they're short-lived helpers, not agent hosts.
+    let cli = if mcp_subcommand.is_some() {
+        None
+    } else {
+        let parsed = Cli::parse();
+        aionui_runtime::init(&parsed.data_dir);
+        Some(parsed)
+    };
+
     // SAFETY: called before any worker thread exists (including the tokio
     // runtime constructed below). Rust 2024 requires `unsafe` for
     // `std::env::set_var` invoked inside `enhance_process_path`.
     let merged_path = unsafe { aionui_runtime::enhance_process_path() };
 
     let runtime = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
-    runtime.block_on(async_main(merged_path))
+    runtime.block_on(async_main(merged_path, mcp_subcommand, cli))
 }
 
-async fn async_main(merged_path: String) -> Result<ExitCode> {
+async fn async_main(merged_path: String, mcp_subcommand: Option<&str>, cli: Option<Cli>) -> Result<ExitCode> {
     // mcp-bridge / mcp-guide-stdio subcommands: live entirely outside the main
     // HTTP server and must not touch the database, logging setup, or `AppServices`.
-    let mut argv = std::env::args();
-    let _prog = argv.next();
-    match argv.next().as_deref() {
+    match mcp_subcommand {
         Some("mcp-bridge") => return Ok(bridge::run_mcp_bridge().await),
         Some("mcp-guide-stdio") => return Ok(guide_stdio::run_guide_stdio().await),
         Some("mcp-team-stdio") => return Ok(team_stdio::run_team_stdio().await),
         _ => {}
     }
 
-    let cli = Cli::parse();
+    let cli = cli.expect("non-mcp entry guarantees cli is parsed");
 
     let log_dir = cli.log_dir.unwrap_or_else(|| Path::new(&cli.data_dir).join("logs"));
     let _log_guard = init_tracing(&log_dir, cli.log_level.as_deref());

--- a/crates/aionui-app/src/state_builders.rs
+++ b/crates/aionui-app/src/state_builders.rs
@@ -90,6 +90,7 @@ pub async fn build_module_states(services: &AppServices) -> (ModuleStates, Chann
         services.agent_registry.clone(),
         services.conversation_repo.clone(),
         services.acp_session_sync.clone(),
+        std::path::PathBuf::from(&services.data_dir),
     );
 
     let states = ModuleStates {

--- a/crates/aionui-runtime/src/cache.rs
+++ b/crates/aionui-runtime/src/cache.rs
@@ -1,16 +1,52 @@
 //! Cross-platform cache directory resolution for the bundled bun runtime.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// Override for [`runtime_root`], set by [`init`] from the backend
+/// startup path so cached bun binaries land under `AppConfig.data_dir`
+/// instead of the OS-default cache location.
+///
+/// Lifecycle: written once by `aionui-app`'s `main()` before
+/// [`crate::enhance_process_path`] / [`crate::resolve_bun`] run, read
+/// every time [`runtime_root`] is queried thereafter. Callers that miss
+/// the init window (e.g. the `mcp-*` subcommands, unit tests,
+/// `build.rs`) transparently fall back to `dirs::cache_dir()`.
+static RUNTIME_ROOT_OVERRIDE: OnceLock<PathBuf> = OnceLock::new();
+
+/// Anchor the runtime root to a caller-supplied data directory — typically
+/// the backend's `AppConfig.data_dir`. Idempotent on repeat calls (only
+/// the first value wins); a warning is logged if a second path is
+/// attempted so unexpected double-inits are visible.
+pub fn init(data_dir: impl AsRef<Path>) {
+    let path = data_dir.as_ref().join("runtime");
+    if let Err(existing) = RUNTIME_ROOT_OVERRIDE.set(path.clone())
+        && existing != path
+    {
+        tracing::warn!(
+            attempted = %path.display(),
+            existing = %existing.display(),
+            "aionui_runtime::init called twice with different paths; keeping first"
+        );
+    }
+}
 
 /// Returns the root cache directory used for all aionui runtime artifacts.
 ///
-/// Platform mapping (via `dirs::cache_dir()`):
-/// - macOS:   `~/Library/Caches/aionui/runtime`
-/// - Linux:   `$XDG_CACHE_HOME/aionui/runtime` (fallback `~/.cache/aionui/runtime`)
-/// - Windows: `%LOCALAPPDATA%\aionui\runtime`
+/// Priority:
+/// 1. Path supplied via [`init`] (`{data_dir}/runtime`) when the backend
+///    started with `--data-dir`.
+/// 2. Platform cache dir (via `dirs::cache_dir()`):
+///    - macOS:   `~/Library/Caches/aionui/runtime`
+///    - Linux:   `$XDG_CACHE_HOME/aionui/runtime` (fallback `~/.cache/aionui/runtime`)
+///    - Windows: `%LOCALAPPDATA%\aionui\runtime`
 ///
-/// Returns `None` if no cache directory can be determined (exotic envs).
+/// Returns `None` only when neither [`init`] has run nor a platform cache
+/// dir is determinable (exotic envs).
 pub fn runtime_root() -> Option<PathBuf> {
+    if let Some(p) = RUNTIME_ROOT_OVERRIDE.get() {
+        return Some(p.clone());
+    }
     dirs::cache_dir().map(|d| d.join("aionui").join("runtime"))
 }
 

--- a/crates/aionui-runtime/src/lib.rs
+++ b/crates/aionui-runtime/src/lib.rs
@@ -11,6 +11,7 @@ mod extract;
 mod resolver;
 mod shell_env;
 
+pub use cache::init;
 pub use resolver::{ResolveError, bun_bin_dir, resolve_bun, resolve_command_path};
 pub use shell_env::enhance_process_path;
 mod spawn;


### PR DESCRIPTION
## Summary
- `CliAgentProcess::spawn_for_sdk` 不再走 `dirs::data_local_dir()/aionui`，改为接收显式 `data_dir: &Path`；`AcpSessionParams` / `AgentService` 把 `AppConfig.data_dir` 透传下来，覆盖 factory 和 custom-agent probe 两个调用点。
- `aionui-runtime` 新增 `init(data_dir)`：用 `OnceLock` 把 bun 解压根固定为 `{data_dir}/runtime`，缺省才回退 `dirs::cache_dir()`。`main()` 在 `enhance_process_path` 之前先解析 CLI 并调用 `init`；MCP stdio 子命令（不接 `--data-dir`）照旧走 OS 默认缓存。
- 受影响的单测 (`spawn_for_sdk_take_stdio`、`probe_returns_*`、`acp_agent_integration`) 与 state builder 对齐。

## Test plan
- [x] `cargo check -p aionui-ai-agent -p aionui-app -p aionui-runtime` （含 `--tests`）
- [x] `cargo test -p aionui-runtime --lib` 36 项全绿
- [x] `cargo test -p aionui-ai-agent --lib spawn_for_sdk` / `probe_returns` 通过
- [x] `cargo clippy -p aionui-ai-agent -p aionui-app -p aionui-runtime -- -D warnings` 无告警
- [x] 回归验证：`aionui-backend --data-dir /tmp/foo` 启动后 bun 二进制落在 `/tmp/foo/runtime/bun-*`，ACP 子进程 `BUN_INSTALL_CACHE_DIR` 指向 `/tmp/foo/bun-cache`