### PR TITLE
feat(conversation): persist tool call events to messages table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # AGENTS.md
 
+<!-- Maintenance rule: Only add content that tells AI assistants WHAT TO DO or WHAT NOT TO DO.
+     Implementation details, design rationale, and "how the system works" belong in ARCHITECTURE.md.
+     If a section doesn't contain an actionable rule or constraint, it doesn't belong here. -->
+
 Project-specific rules and conventions for AI assistants and contributors.
 
 ## High-Priority Rules
@@ -20,14 +24,7 @@ Only after exhausting the above — and explicitly documenting why each option i
 
 > For detailed background and design decisions, see [ARCHITECTURE.md](./ARCHITECTURE.md).
 
-Cargo workspace with 19 crates under `crates/`. Dependencies flow downward through four layers:
-
-**Foundation:** `aionui-common`, `aionui-api-types`, `aionui-db`, `aionui-assets`, `aionui-runtime`
-**Capability:** `aionui-auth`, `aionui-realtime`
-**Domain:** `aionui-conversation`, `aionui-channel`, `aionui-team`, `aionui-cron`, `aionui-file`, `aionui-office`, `aionui-shell`, `aionui-mcp`, `aionui-ai-agent`, `aionui-extension`, `aionui-system`, `aionui-assistant`
-**Composition:** `aionui-app` — top-level binary, composes all crates into the axum server
-
-Binary name: `aionui-backend` (produced by `crates/aionui-app`).
+Cargo workspace organized in four layers: Foundation → Capability → Domain → Composition. Dependencies flow strictly downward.
 
 ### Crate Hierarchy & Dependencies
 
@@ -82,31 +79,6 @@ Every domain crate must follow:
 - Error responses must not leak internal details
 - Secrets must never be hardcoded
 
-## Route Map
-
-| Prefix                                                                                                                                                           | Crate               | Auth                  |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | --------------------- |
-| `POST /login`, `/api/auth/*`                                                                                                                                     | aionui-auth         | Public (rate-limited) |
-| `POST /logout`, `/api/auth/user`, `/api/auth/change-password`, `/api/ws-token`                                                                                   | aionui-auth         | Yes                   |
-| `/api/conversations/*`, `/api/messages/*`                                                                                                                        | aionui-conversation | Yes                   |
-| `/api/agents`, `/api/agents/refresh`, `/api/agents/test`                                                                                                         | aionui-ai-agent     | Yes                   |
-| `/api/acp/*`, `/api/conversations/{id}/acp/*`                                                                                                                    | aionui-ai-agent     | Yes                   |
-| `/api/bedrock/*`, `/api/gemini/*`                                                                                                                                | aionui-ai-agent     | Yes                   |
-| `/api/conversations/{id}/workspace`, `/api/conversations/{id}/side-question`, `/api/conversations/{id}/slash-commands`, `/api/conversations/{id}/reload-context` | aionui-ai-agent     | Yes                   |
-| `/api/remote-agents/*`                                                                                                                                           | aionui-ai-agent     | Yes                   |
-| `/api/settings/*`, `/api/providers/*`, `/api/system/*`                                                                                                           | aionui-system       | Yes                   |
-| `/api/fs/*`                                                                                                                                                      | aionui-file         | Yes                   |
-| `/api/mcp/*`                                                                                                                                                     | aionui-mcp          | Yes                   |
-| `/api/extensions/*`, `/api/hub/*`, `/api/skills/*`                                                                                                               | aionui-extension    | Yes                   |
-| `/api/channel/*`                                                                                                                                                 | aionui-channel      | Yes                   |
-| `/api/teams/*`                                                                                                                                                   | aionui-team         | Yes                   |
-| `/api/cron/*`                                                                                                                                                    | aionui-cron         | Yes                   |
-| `/api/word-preview/*`, `/api/excel-preview/*`, `/api/ppt-preview/*`, `/api/preview-history/*`, `/api/star-office/*`, `/api/document/*`                           | aionui-office       | Yes                   |
-| `/api/ppt-proxy/*`, `/api/office-watch-proxy/*`                                                                                                                  | aionui-office       | Public (iframe)       |
-| `/api/shell/*`, `/api/stt`                                                                                                                                       | aionui-shell        | Yes                   |
-| `/ws`                                                                                                                                                            | aionui-realtime     | Token callback        |
-| `/health`                                                                                                                                                        | aionui-app          | Public                |
-
 ## Code Style
 
 - Rust 2024 edition, stable toolchain (pinned in `rust-toolchain.toml`)
@@ -116,53 +88,9 @@ Every domain crate must follow:
 
 ## Development Workflow
 
-### Bundled bun Runtime
+### Subprocess Spawning
 
-The backend embeds a bun runtime for self-contained distribution. Relevant env vars:
-
-- `AIONUI_EMBED_BUN=1` — enable bun download + embed during `cargo build`.
-  Release CI sets this; local dev builds skip it (faster, no network).
-- `BUN_VARIANT=default|baseline` — select which Linux x64 variant to
-  embed. `baseline` targets CPUs without AVX2.
-- `AIONUI_BUN_PATH=/abs/path/to/bun` — runtime override. When set and
-  pointing to an executable file, `resolve_bun()` returns it verbatim,
-  skipping the embedded + `which` fallback chain. Useful for testing
-  custom bun builds or bisecting bun regressions.
-
-The bun version is pinned in
-`crates/aionui-runtime/Cargo.toml` under
-`[package.metadata.aionui-runtime] bun_version = "..."`. Upgrading bun is
-a one-line change — no source edits required.
-
-### Startup PATH Enhancement
-
-`fn main()` calls `aionui_runtime::enhance_process_path()` **before** the
-tokio runtime starts, so every downstream `which::which(...)` and
-`Command::new(...)` — including the existing spawn sites across the
-workspace — inherits an enriched `PATH`. Three layers are merged in priority
-order: bundled bun directory → platform extra bins (`~/.bun/bin`,
-`~/.cargo/bin`, `~/.local/bin`, Windows `%APPDATA%\npm`, Git, Scoop, …) →
-current PATH → login-shell `$PATH` (Unix, 3 s timeout). The call is
-`unsafe` because Rust 2024 requires a single-threaded precondition for
-`env::set_var`; `main()` runs this as its very first statement to
-satisfy the invariant. A `startup: PATH ready path_segments=… path_len=…`
-info log confirms the enhancement at each run (no full PATH content is
-logged at `info` level).
-
-### Subprocess Spawn Builder
-
-New subprocess spawn sites should go through
-`aionui_runtime::Builder::agent(program)` (for long-running agent CLIs
-whose stdio the caller owns) or `aionui_runtime::Builder::clean_cli(program)`
-(for short-lived tools whose output we parse). Both set
-`kill_on_drop(true)` and strip `NODE_OPTIONS`/`NODE_INSPECT`/`NODE_DEBUG`/
-`CLAUDECODE` so debug-profile env doesn't leak into the child.
-`clean_cli` additionally pipes stdio and sets `NO_COLOR=1` + `TERM=dumb`
-to keep ANSI codes out of captured output.
-
-Do NOT manually re-implement these behaviours with raw
-`tokio::process::Command` — the centralised builder is the one place to
-update policies (e.g. future `CARGO_*` cleanup, sandbox flags).
+New subprocess spawn sites must use `aionui_runtime::Builder::agent(program)` or `aionui_runtime::Builder::clean_cli(program)`. Do NOT use raw `tokio::process::Command`. See [ARCHITECTURE.md § Runtime Infrastructure](./ARCHITECTURE.md#runtime-infrastructure) for details.
 
 ### Pushing Code
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,11 +26,11 @@ It provides HTTP REST APIs and WebSocket real-time events for the AionUi desktop
 │   aionui-auth          aionui-realtime           │
 │  (JWT, CSRF, middleware) (WebSocket, events)     │
 ├─────────────────────────────────────────────────┤
-│   aionui-db            aionui-api-types          │
-│  (repositories)        (request/response types)  │
+│  aionui-db    aionui-api-types   aionui-runtime  │
+│ (repositories) (API contracts)  (subprocess/bun) │
 ├─────────────────────────────────────────────────┤
-│              aionui-common                       │
-│     (error types, enums, crypto, pagination)     │
+│       aionui-common          aionui-assets       │
+│  (error types, enums, crypto)  (embedded data)   │
 └─────────────────────────────────────────────────┘
 ```
 
@@ -39,7 +39,7 @@ and aionui-common has zero internal dependencies.
 
 ## Crate Hierarchy
 
-The project is organized as a Cargo workspace with 17 crates across four layers:
+The project is organized as a Cargo workspace with 20 crates across four layers:
 
 ### Foundation
 
@@ -50,6 +50,8 @@ Depended on by nearly all other crates. Changes require careful impact assessmen
 | `aionui-common` | Shared error types (AppError), enums, ID generation, crypto utilities, timestamps, pagination |
 | `aionui-api-types` | All HTTP/WebSocket request and response types — the single source of truth for API contracts |
 | `aionui-db` | SQLite database layer, defines Repository traits and implementations |
+| `aionui-assets` | Embedded static assets (agent metadata, prompts) |
+| `aionui-runtime` | Subprocess spawning, bun runtime resolution, PATH enhancement |
 
 ### Capability
 
@@ -77,6 +79,7 @@ Each crate owns an independent business domain. They remain loosely coupled from
 | `aionui-ai-agent` | Agent lifecycle management, worker task queues, ACP/auxiliary skills |
 | `aionui-extension` | Extension registry, hub management, skill discovery and installation |
 | `aionui-shell` | Shell command execution, speech-to-text |
+| `aionui-assistant` | Assistant configuration and management |
 
 ### Composition
 
@@ -345,9 +348,16 @@ pub struct AppServices {
     pub ws_manager: Arc<WebSocketManager>,
     pub event_bus: Arc<BroadcastEventBus>,
     pub worker_task_manager: Arc<dyn IWorkerTaskManager>,
+    pub agent_registry: Arc<AgentRegistry>,
+    pub conversation_repo: Arc<dyn IConversationRepository>,
+    pub acp_session_sync: Arc<AcpSessionSyncService>,
     pub jwt_secret_raw: String,
     pub data_dir: String,
     pub local: bool,
+    pub app_version: String,
+    pub skill_paths: Arc<SkillPaths>,
+    pub guide_mcp_config: Option<GuideMcpConfig>,
+    // ...
 }
 ```
 
@@ -671,3 +681,53 @@ Before adding a new crate, confirm:
 - [ ] Routes use `/api/` prefix with kebab-case resource names
 - [ ] Includes corresponding test files
 - [ ] WebSocket events follow `domain.camelCaseAction` naming convention
+
+## Runtime Infrastructure
+
+### Bundled bun Runtime
+
+The backend embeds a bun runtime for self-contained distribution. Relevant env vars:
+
+- `AIONUI_EMBED_BUN=1` — enable bun download + embed during `cargo build`.
+  Release CI sets this; local dev builds skip it (faster, no network).
+- `BUN_VARIANT=default|baseline` — select which Linux x64 variant to
+  embed. `baseline` targets CPUs without AVX2.
+- `AIONUI_BUN_PATH=/abs/path/to/bun` — runtime override. When set and
+  pointing to an executable file, `resolve_bun()` returns it verbatim,
+  skipping the embedded + `which` fallback chain. Useful for testing
+  custom bun builds or bisecting bun regressions.
+
+The bun version is pinned in
+`crates/aionui-runtime/Cargo.toml` under
+`[package.metadata.aionui-runtime] bun_version = "..."`. Upgrading bun is
+a one-line change — no source edits required.
+
+### Startup PATH Enhancement
+
+`fn main()` calls `aionui_runtime::enhance_process_path()` **before** the
+tokio runtime starts, so every downstream `which::which(...)` and
+`Command::new(...)` — including the existing spawn sites across the
+workspace — inherits an enriched `PATH`. Three layers are merged in priority
+order: bundled bun directory → platform extra bins (`~/.bun/bin`,
+`~/.cargo/bin`, `~/.local/bin`, Windows `%APPDATA%\npm`, Git, Scoop, …) →
+current PATH → login-shell `$PATH` (Unix, 3 s timeout). The call is
+`unsafe` because Rust 2024 requires a single-threaded precondition for
+`env::set_var`; `main()` runs this as its very first statement to
+satisfy the invariant. A `startup: PATH ready path_segments=… path_len=…`
+info log confirms the enhancement at each run (no full PATH content is
+logged at `info` level).
+
+### Subprocess Spawn Builder
+
+New subprocess spawn sites should go through
+`aionui_runtime::Builder::agent(program)` (for long-running agent CLIs
+whose stdio the caller owns) or `aionui_runtime::Builder::clean_cli(program)`
+(for short-lived tools whose output we parse). Both set
+`kill_on_drop(true)` and strip `NODE_OPTIONS`/`NODE_INSPECT`/`NODE_DEBUG`/
+`CLAUDECODE` so debug-profile env doesn't leak into the child.
+`clean_cli` additionally pipes stdio and sets `NO_COLOR=1` + `TERM=dumb`
+to keep ANSI codes out of captured output.
+
+Do NOT manually re-implement these behaviours with raw
+`tokio::process::Command` — the centralised builder is the one place to
+update policies (e.g. future `CARGO_*` cleanup, sandbox flags).

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -26,11 +26,11 @@ aionui-backend 是 AionUi 的后端服务，使用 Rust 构建（Axum + Tokio + 
 │   aionui-auth          aionui-realtime           │
 │  （JWT、CSRF、中间件）  （WebSocket、事件广播）      │
 ├─────────────────────────────────────────────────┤
-│   aionui-db            aionui-api-types          │
-│  （仓库层）             （请求/响应类型）            │
+│  aionui-db    aionui-api-types   aionui-runtime  │
+│  （仓库层）    （API 契约）       （子进程/bun）    │
 ├─────────────────────────────────────────────────┤
-│              aionui-common                       │
-│     （错误类型、枚举、加密、分页）                   │
+│       aionui-common          aionui-assets       │
+│  （错误类型、枚举、加密）      （嵌入式数据）        │
 └─────────────────────────────────────────────────┘
 ```
 
@@ -39,7 +39,7 @@ aionui-common 没有任何内部依赖。
 
 ## Crate 层级
 
-项目采用 Cargo workspace 组织，共 17 个 crate，分为四层：
+项目采用 Cargo workspace 组织，共 20 个 crate，分为四层：
 
 ### 基础层（Foundation）
 
@@ -50,6 +50,8 @@ aionui-common 没有任何内部依赖。
 | `aionui-common` | 共享错误类型（AppError）、枚举、ID 生成、加密工具、时间戳、分页 |
 | `aionui-api-types` | 所有 HTTP/WebSocket 的请求和响应类型，是 API 契约的唯一定义处 |
 | `aionui-db` | SQLite 数据库层，定义 Repository trait 和实现 |
+| `aionui-assets` | 嵌入式静态资源（Agent 元数据、提示词） |
+| `aionui-runtime` | 子进程管理、bun 运行时解析、PATH 增强 |
 
 ### 能力层（Capability）
 
@@ -77,6 +79,7 @@ aionui-common 没有任何内部依赖。
 | `aionui-ai-agent` | Agent 生命周期管理、Worker 任务队列、ACP/辅助技能 |
 | `aionui-extension` | 扩展注册中心、Hub 管理、技能发现与安装 |
 | `aionui-shell` | Shell 命令执行、语音转文字 |
+| `aionui-assistant` | Assistant 配置与管理 |
 
 ### 组装层（Composition）
 
@@ -345,9 +348,16 @@ pub struct AppServices {
     pub ws_manager: Arc<WebSocketManager>,
     pub event_bus: Arc<BroadcastEventBus>,
     pub worker_task_manager: Arc<dyn IWorkerTaskManager>,
+    pub agent_registry: Arc<AgentRegistry>,
+    pub conversation_repo: Arc<dyn IConversationRepository>,
+    pub acp_session_sync: Arc<AcpSessionSyncService>,
     pub jwt_secret_raw: String,
     pub data_dir: String,
     pub local: bool,
+    pub app_version: String,
+    pub skill_paths: Arc<SkillPaths>,
+    pub guide_mcp_config: Option<GuideMcpConfig>,
+    // ...
 }
 ```
 
@@ -671,3 +681,46 @@ crates/aionui-my-feature/
 - [ ] 路由使用 `/api/` 前缀，资源名 kebab-case
 - [ ] 包含对应的测试文件
 - [ ] WebSocket 事件遵循 `domain.camelCaseAction` 命名
+
+## 运行时基础设施
+
+### 内嵌 bun 运行时
+
+后端内嵌 bun 运行时以实现自包含分发。相关环境变量：
+
+- `AIONUI_EMBED_BUN=1` — 在 `cargo build` 时启用 bun 下载和嵌入。
+  Release CI 会设置此变量；本地开发构建跳过（更快，无网络依赖）。
+- `BUN_VARIANT=default|baseline` — 选择嵌入哪个 Linux x64 变体。
+  `baseline` 适用于不支持 AVX2 的 CPU。
+- `AIONUI_BUN_PATH=/abs/path/to/bun` — 运行时覆盖。设置后若指向
+  可执行文件，`resolve_bun()` 直接返回该路径，跳过内嵌 + `which` 回退链。
+  用于测试自定义 bun 构建或二分定位 bun 问题。
+
+bun 版本固定在 `crates/aionui-runtime/Cargo.toml` 的
+`[package.metadata.aionui-runtime] bun_version = "..."` 中。
+升级 bun 只需修改这一行，无需改动源码。
+
+### 启动时 PATH 增强
+
+`fn main()` 在 tokio 运行时启动**之前**调用
+`aionui_runtime::enhance_process_path()`，使后续所有
+`which::which(...)` 和 `Command::new(...)` 继承增强后的 `PATH`。
+三层合并优先级：内嵌 bun 目录 → 平台额外 bin 目录（`~/.bun/bin`、
+`~/.cargo/bin`、`~/.local/bin`、Windows `%APPDATA%\npm`、Git、Scoop 等）→
+当前 PATH → login-shell `$PATH`（Unix，3 秒超时）。
+该调用标记为 `unsafe`，因为 Rust 2024 要求 `env::set_var` 在单线程环境执行；
+`main()` 将其作为第一条语句以满足此不变量。
+启动时会输出 `startup: PATH ready path_segments=… path_len=…` info 日志。
+
+### 子进程 Spawn Builder
+
+新的子进程启动点应通过
+`aionui_runtime::Builder::agent(program)`（长期运行的 Agent CLI，
+调用者拥有 stdio）或 `aionui_runtime::Builder::clean_cli(program)`
+（短期工具，解析输出）创建。两者都设置 `kill_on_drop(true)`
+并清除 `NODE_OPTIONS`/`NODE_INSPECT`/`NODE_DEBUG`/`CLAUDECODE`
+防止调试环境泄露到子进程。`clean_cli` 额外设置管道 stdio
+和 `NO_COLOR=1` + `TERM=dumb` 以避免 ANSI 码干扰输出解析。
+
+禁止使用原始 `tokio::process::Command` 手动实现这些行为——
+集中化的 Builder 是更新策略的唯一位置。

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -371,9 +371,10 @@ impl StreamRelay {
             .await
             .unwrap_or(None);
 
-        if existing.is_some() {
+        if let Some(existing_row) = existing {
+            let merged_content = Self::merge_json_content(&existing_row.content, &content);
             let update = aionui_db::MessageRowUpdate {
-                content: Some(content),
+                content: Some(merged_content),
                 status: Some(Some(status.to_owned())),
                 hidden: None,
             };
@@ -434,8 +435,9 @@ impl StreamRelay {
                 }
             }
             AcpToolCallSessionUpdateKind::ToolCallUpdate => {
+                let merged_content = self.merge_acp_tool_call_content(tool_call_id, &value).await;
                 let update = aionui_db::MessageRowUpdate {
-                    content: Some(content),
+                    content: Some(merged_content),
                     status: Some(Some(status.to_owned())),
                     hidden: None,
                 };
@@ -444,6 +446,50 @@ impl StreamRelay {
                 }
             }
         }
+    }
+
+    /// Merge two JSON content strings: overlays non-null fields from `new_json`
+    /// onto `existing_json`, preserving fields only present in the original.
+    fn merge_json_content(existing_json: &str, new_json: &str) -> String {
+        let mut base: serde_json::Value = serde_json::from_str(existing_json).unwrap_or_default();
+        let new_value: serde_json::Value = serde_json::from_str(new_json).unwrap_or_default();
+        if let (Some(base_obj), Some(new_obj)) = (base.as_object_mut(), new_value.as_object()) {
+            for (key, val) in new_obj {
+                if !val.is_null() {
+                    base_obj.insert(key.clone(), val.clone());
+                }
+            }
+        }
+        base.to_string()
+    }
+
+    /// Merge an AcpToolCall update into the existing DB record.
+    /// Reads the stored content, overlays non-null fields from the update,
+    /// preserving fields like `raw_input` that the update event omits.
+    async fn merge_acp_tool_call_content(&self, tool_call_id: &str, update_value: &serde_json::Value) -> String {
+        let existing = self
+            .repo
+            .get_message_by_msg_id(&self.conversation_id, tool_call_id, "acp_tool_call")
+            .await
+            .ok()
+            .flatten();
+
+        let Some(existing_row) = existing else {
+            return update_value.to_string();
+        };
+
+        let mut base: serde_json::Value = serde_json::from_str(&existing_row.content).unwrap_or_default();
+        if let (Some(base_update), Some(new_update)) = (
+            base.get_mut("update").and_then(|v| v.as_object_mut()),
+            update_value.get("update").and_then(|v| v.as_object()),
+        ) {
+            for (key, val) in new_update {
+                if !val.is_null() {
+                    base_update.insert(key.clone(), val.clone());
+                }
+            }
+        }
+        base.to_string()
     }
 
     /// Persist a tool_group event (array of tool summaries).
@@ -833,6 +879,18 @@ mod tests {
 
         let rx = tx.subscribe();
 
+        // First event: Running with input but no output
+        tx.send(AgentStreamEvent::ToolCall(ToolCallEventData {
+            call_id: "tc-001".into(),
+            name: "image_gen".into(),
+            args: json!({"prompt": "a cat"}),
+            status: ToolCallStatus::Running,
+            input: Some(json!({"prompt": "a cat", "size": "1024x1024"})),
+            output: None,
+            description: Some("Generate image".into()),
+        }))
+        .unwrap();
+        // Second event: Completed with output but no input
         tx.send(AgentStreamEvent::ToolCall(ToolCallEventData {
             call_id: "tc-001".into(),
             name: "image_gen".into(),
@@ -840,7 +898,7 @@ mod tests {
             status: ToolCallStatus::Completed,
             input: None,
             output: Some("image.png".into()),
-            description: Some("Generate image".into()),
+            description: None,
         }))
         .unwrap();
         tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
@@ -852,11 +910,22 @@ mod tests {
         assert!(tool_msg.is_some());
         let msg = tool_msg.unwrap();
         assert_eq!(msg.id, "tc-001");
-        assert_eq!(msg.status.as_deref(), Some("finish"));
+        assert_eq!(msg.status.as_deref(), Some("work"));
 
-        let content: serde_json::Value = serde_json::from_str(&msg.content).unwrap();
-        assert_eq!(content["name"], "image_gen");
-        assert_eq!(content["status"], "completed");
+        let updates = repo.take_updates();
+        let tool_update = updates.iter().find(|(id, _)| id == "tc-001");
+        assert!(tool_update.is_some());
+        let (_, upd) = tool_update.unwrap();
+        assert_eq!(upd.status, Some(Some("finish".to_owned())));
+
+        // Verify merge: input from first event preserved, output from second event added
+        let merged: serde_json::Value = serde_json::from_str(upd.content.as_deref().unwrap()).unwrap();
+        assert_eq!(merged["name"], "image_gen");
+        assert_eq!(merged["status"], "completed");
+        assert!(merged.get("input").is_some() && !merged["input"].is_null(), "input must be preserved after merge");
+        assert_eq!(merged["input"]["prompt"], "a cat");
+        assert_eq!(merged["output"], "image.png");
+        assert_eq!(merged["description"], "Generate image");
     }
 
     #[tokio::test]
@@ -887,9 +956,9 @@ mod tests {
                 session_update: AcpToolCallSessionUpdateKind::ToolCall,
                 tool_call_id: "atc-001".into(),
                 status: Some(AcpToolCallStatus::InProgress),
-                title: Some("Read file".into()),
+                title: Some("Bash".into()),
                 kind: None,
-                raw_input: None,
+                raw_input: Some(json!({"command": "mv /tmp/a /tmp/b", "description": "Move file"})),
                 raw_output: None,
                 content: None,
                 locations: None,
@@ -904,10 +973,10 @@ mod tests {
                 session_update: AcpToolCallSessionUpdateKind::ToolCallUpdate,
                 tool_call_id: "atc-001".into(),
                 status: Some(AcpToolCallStatus::Completed),
-                title: Some("Read file".into()),
+                title: None,
                 kind: None,
                 raw_input: None,
-                raw_output: Some(json!("file content")),
+                raw_output: Some(json!("Exit code: 0\nSTDOUT:\nSTDERR:")),
                 content: None,
                 locations: None,
             },
@@ -931,6 +1000,16 @@ mod tests {
         assert!(acp_update.is_some());
         let (_, upd) = acp_update.unwrap();
         assert_eq!(upd.status, Some(Some("finish".to_owned())));
+
+        // Verify merge: raw_input from ToolCall is preserved, raw_output from ToolCallUpdate is added
+        let merged: serde_json::Value = serde_json::from_str(upd.content.as_deref().unwrap()).unwrap();
+        let update_obj = merged.get("update").unwrap();
+        assert!(update_obj.get("raw_input").is_some(), "raw_input must be preserved after merge");
+        assert_eq!(
+            update_obj.get("raw_input").unwrap().get("command").unwrap().as_str().unwrap(),
+            "mv /tmp/a /tmp/b"
+        );
+        assert!(update_obj.get("raw_output").is_some(), "raw_output must be present after merge");
     }
 
     #[tokio::test]
@@ -1131,10 +1210,14 @@ mod tests {
         async fn get_message_by_msg_id(
             &self,
             _conv_id: &str,
-            _msg_id: &str,
-            _msg_type: &str,
+            msg_id: &str,
+            msg_type: &str,
         ) -> Result<Option<MessageRow>, DbError> {
-            Ok(None)
+            let inserts = self.inserts.lock().unwrap();
+            Ok(inserts
+                .iter()
+                .find(|m| m.msg_id.as_deref() == Some(msg_id) && m.r#type == msg_type)
+                .cloned())
         }
         async fn search_messages(
             &self,

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -354,10 +354,7 @@ impl StreamRelay {
     }
 
     /// Persist a Gemini-style tool_call event.
-    async fn persist_tool_call(
-        &self,
-        data: &aionui_ai_agent::protocol::events::tool_call::ToolCallEventData,
-    ) {
+    async fn persist_tool_call(&self, data: &aionui_ai_agent::protocol::events::tool_call::ToolCallEventData) {
         let status = match data.status {
             ToolCallStatus::Running => "work",
             ToolCallStatus::Completed => "finish",
@@ -401,10 +398,7 @@ impl StreamRelay {
 
     /// Persist an ACP (Claude CLI) tool call event.
     /// First event (ToolCall) inserts; subsequent events (ToolCallUpdate) update.
-    async fn persist_acp_tool_call(
-        &self,
-        data: &aionui_ai_agent::protocol::events::tool_call::AcpToolCallEventData,
-    ) {
+    async fn persist_acp_tool_call(&self, data: &aionui_ai_agent::protocol::events::tool_call::AcpToolCallEventData) {
         let tool_call_id = &data.update.tool_call_id;
         let status = match data.update.status {
             Some(AcpToolCallStatus::Pending) | None => "work",
@@ -493,10 +487,7 @@ impl StreamRelay {
     }
 
     /// Persist a tool_group event (array of tool summaries).
-    async fn persist_tool_group(
-        &self,
-        entries: &[aionui_ai_agent::protocol::events::tool_call::ToolGroupEntry],
-    ) {
+    async fn persist_tool_group(&self, entries: &[aionui_ai_agent::protocol::events::tool_call::ToolGroupEntry]) {
         let all_done = entries
             .iter()
             .all(|e| matches!(e.status, ToolCallStatus::Completed | ToolCallStatus::Error));
@@ -922,7 +913,10 @@ mod tests {
         let merged: serde_json::Value = serde_json::from_str(upd.content.as_deref().unwrap()).unwrap();
         assert_eq!(merged["name"], "image_gen");
         assert_eq!(merged["status"], "completed");
-        assert!(merged.get("input").is_some() && !merged["input"].is_null(), "input must be preserved after merge");
+        assert!(
+            merged.get("input").is_some() && !merged["input"].is_null(),
+            "input must be preserved after merge"
+        );
         assert_eq!(merged["input"]["prompt"], "a cat");
         assert_eq!(merged["output"], "image.png");
         assert_eq!(merged["description"], "Generate image");
@@ -931,8 +925,7 @@ mod tests {
     #[tokio::test]
     async fn run_acp_tool_call_inserts_then_updates() {
         use aionui_ai_agent::protocol::events::tool_call::{
-            AcpToolCallEventData, AcpToolCallSessionUpdateKind, AcpToolCallStatus,
-            AcpToolCallUpdateData,
+            AcpToolCallEventData, AcpToolCallSessionUpdateKind, AcpToolCallStatus, AcpToolCallUpdateData,
         };
 
         let repo = Arc::new(RecordingRepo::new());
@@ -1004,12 +997,24 @@ mod tests {
         // Verify merge: raw_input from ToolCall is preserved, raw_output from ToolCallUpdate is added
         let merged: serde_json::Value = serde_json::from_str(upd.content.as_deref().unwrap()).unwrap();
         let update_obj = merged.get("update").unwrap();
-        assert!(update_obj.get("raw_input").is_some(), "raw_input must be preserved after merge");
+        assert!(
+            update_obj.get("raw_input").is_some(),
+            "raw_input must be preserved after merge"
+        );
         assert_eq!(
-            update_obj.get("raw_input").unwrap().get("command").unwrap().as_str().unwrap(),
+            update_obj
+                .get("raw_input")
+                .unwrap()
+                .get("command")
+                .unwrap()
+                .as_str()
+                .unwrap(),
             "mv /tmp/a /tmp/b"
         );
-        assert!(update_obj.get("raw_output").is_some(), "raw_output must be present after merge");
+        assert!(
+            update_obj.get("raw_output").is_some(),
+            "raw_output must be present after merge"
+        );
     }
 
     #[tokio::test]

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -1,6 +1,12 @@
 use std::sync::Arc;
 
-use aionui_ai_agent::{AgentStreamEvent, protocol::events::ThinkingEventData};
+use aionui_ai_agent::{
+    AgentStreamEvent,
+    protocol::events::{
+        ThinkingEventData,
+        tool_call::{AcpToolCallSessionUpdateKind, AcpToolCallStatus, ToolCallStatus},
+    },
+};
 
 use crate::response_middleware::{ICronService, MessageMiddleware, MiddlewareResult};
 use aionui_api_types::WebSocketMessage;
@@ -129,6 +135,18 @@ impl StreamRelay {
                                 Self::complete_conversation(&self.repo, &self.broadcaster, &self.conversation_id).await;
                             }
                             break outcome;
+                        }
+                        AgentStreamEvent::ToolCall(data) => {
+                            self.forward_to_websocket(&event);
+                            self.persist_tool_call(data).await;
+                        }
+                        AgentStreamEvent::AcpToolCall(data) => {
+                            self.forward_to_websocket(&event);
+                            self.persist_acp_tool_call(data).await;
+                        }
+                        AgentStreamEvent::ToolGroup(entries) => {
+                            self.forward_to_websocket(&event);
+                            self.persist_tool_group(entries).await;
                         }
                         _ => {
                             self.forward_to_websocket(&event);
@@ -332,6 +350,148 @@ impl StreamRelay {
         };
         if let Err(e) = self.repo.insert_message(&row).await {
             error!(error = %e, "Failed to persist thinking message");
+        }
+    }
+
+    /// Persist a Gemini-style tool_call event.
+    async fn persist_tool_call(
+        &self,
+        data: &aionui_ai_agent::protocol::events::tool_call::ToolCallEventData,
+    ) {
+        let status = match data.status {
+            ToolCallStatus::Running => "work",
+            ToolCallStatus::Completed => "finish",
+            ToolCallStatus::Error => "error",
+        };
+        let content = serde_json::to_string(data).unwrap_or_default();
+
+        let existing = self
+            .repo
+            .get_message_by_msg_id(&self.conversation_id, &data.call_id, "tool_call")
+            .await
+            .unwrap_or(None);
+
+        if existing.is_some() {
+            let update = aionui_db::MessageRowUpdate {
+                content: Some(content),
+                status: Some(Some(status.to_owned())),
+                hidden: None,
+            };
+            if let Err(e) = self.repo.update_message(&data.call_id, &update).await {
+                error!(error = %e, "Failed to update tool_call message");
+            }
+        } else {
+            let row = MessageRow {
+                id: data.call_id.clone(),
+                conversation_id: self.conversation_id.clone(),
+                msg_id: Some(data.call_id.clone()),
+                r#type: "tool_call".into(),
+                content,
+                position: Some("left".into()),
+                status: Some(status.to_owned()),
+                hidden: false,
+                created_at: now_ms(),
+            };
+            if let Err(e) = self.repo.insert_message(&row).await {
+                error!(error = %e, "Failed to persist tool_call message");
+            }
+        }
+    }
+
+    /// Persist an ACP (Claude CLI) tool call event.
+    /// First event (ToolCall) inserts; subsequent events (ToolCallUpdate) update.
+    async fn persist_acp_tool_call(
+        &self,
+        data: &aionui_ai_agent::protocol::events::tool_call::AcpToolCallEventData,
+    ) {
+        let tool_call_id = &data.update.tool_call_id;
+        let status = match data.update.status {
+            Some(AcpToolCallStatus::Pending) | None => "work",
+            Some(AcpToolCallStatus::InProgress) => "work",
+            Some(AcpToolCallStatus::Completed) => "finish",
+            Some(AcpToolCallStatus::Failed) => "error",
+        };
+
+        let mut value = serde_json::to_value(data).unwrap_or_default();
+        normalize_keys_to_snake_case(&mut value);
+        let content = value.to_string();
+
+        match data.update.session_update {
+            AcpToolCallSessionUpdateKind::ToolCall => {
+                let row = MessageRow {
+                    id: tool_call_id.clone(),
+                    conversation_id: self.conversation_id.clone(),
+                    msg_id: Some(tool_call_id.clone()),
+                    r#type: "acp_tool_call".into(),
+                    content,
+                    position: Some("left".into()),
+                    status: Some(status.to_owned()),
+                    hidden: false,
+                    created_at: now_ms(),
+                };
+                if let Err(e) = self.repo.insert_message(&row).await {
+                    error!(error = %e, "Failed to persist acp_tool_call message");
+                }
+            }
+            AcpToolCallSessionUpdateKind::ToolCallUpdate => {
+                let update = aionui_db::MessageRowUpdate {
+                    content: Some(content),
+                    status: Some(Some(status.to_owned())),
+                    hidden: None,
+                };
+                if let Err(e) = self.repo.update_message(tool_call_id, &update).await {
+                    error!(error = %e, "Failed to update acp_tool_call message");
+                }
+            }
+        }
+    }
+
+    /// Persist a tool_group event (array of tool summaries).
+    async fn persist_tool_group(
+        &self,
+        entries: &[aionui_ai_agent::protocol::events::tool_call::ToolGroupEntry],
+    ) {
+        let all_done = entries
+            .iter()
+            .all(|e| matches!(e.status, ToolCallStatus::Completed | ToolCallStatus::Error));
+        let status = if all_done { "finish" } else { "work" };
+        let content = serde_json::to_string(entries).unwrap_or_default();
+
+        let group_id = entries
+            .first()
+            .map(|e| e.call_id.clone())
+            .unwrap_or_else(ConversationService::mint_msg_id);
+
+        let existing = self
+            .repo
+            .get_message_by_msg_id(&self.conversation_id, &group_id, "tool_group")
+            .await
+            .unwrap_or(None);
+
+        if existing.is_some() {
+            let update = aionui_db::MessageRowUpdate {
+                content: Some(content),
+                status: Some(Some(status.to_owned())),
+                hidden: None,
+            };
+            if let Err(e) = self.repo.update_message(&group_id, &update).await {
+                error!(error = %e, "Failed to update tool_group message");
+            }
+        } else {
+            let row = MessageRow {
+                id: group_id.clone(),
+                conversation_id: self.conversation_id.clone(),
+                msg_id: Some(group_id),
+                r#type: "tool_group".into(),
+                content,
+                position: Some("left".into()),
+                status: Some(status.to_owned()),
+                hidden: false,
+                created_at: now_ms(),
+            };
+            if let Err(e) = self.repo.insert_message(&row).await {
+                error!(error = %e, "Failed to persist tool_group message");
+            }
         }
     }
 
@@ -650,6 +810,177 @@ mod tests {
             replacement.unwrap().data["data"]["content"].as_str().map(str::trim),
             Some("Hello")
         );
+    }
+
+    // ── Tool persistence tests ────────────────────────────────────
+
+    #[tokio::test]
+    async fn run_tool_call_persists_message() {
+        use aionui_ai_agent::protocol::events::tool_call::{ToolCallEventData, ToolCallStatus};
+
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let (tx, _) = broadcast::channel(64);
+
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+            None,
+        );
+
+        let rx = tx.subscribe();
+
+        tx.send(AgentStreamEvent::ToolCall(ToolCallEventData {
+            call_id: "tc-001".into(),
+            name: "image_gen".into(),
+            args: json!({"prompt": "a cat"}),
+            status: ToolCallStatus::Completed,
+            input: None,
+            output: Some("image.png".into()),
+            description: Some("Generate image".into()),
+        }))
+        .unwrap();
+        tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
+
+        relay.consume(rx).await;
+
+        let inserts = repo.take_inserts();
+        let tool_msg = inserts.iter().find(|m| m.r#type == "tool_call");
+        assert!(tool_msg.is_some());
+        let msg = tool_msg.unwrap();
+        assert_eq!(msg.id, "tc-001");
+        assert_eq!(msg.status.as_deref(), Some("finish"));
+
+        let content: serde_json::Value = serde_json::from_str(&msg.content).unwrap();
+        assert_eq!(content["name"], "image_gen");
+        assert_eq!(content["status"], "completed");
+    }
+
+    #[tokio::test]
+    async fn run_acp_tool_call_inserts_then_updates() {
+        use aionui_ai_agent::protocol::events::tool_call::{
+            AcpToolCallEventData, AcpToolCallSessionUpdateKind, AcpToolCallStatus,
+            AcpToolCallUpdateData,
+        };
+
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let (tx, _) = broadcast::channel(64);
+
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+            None,
+        );
+
+        let rx = tx.subscribe();
+
+        tx.send(AgentStreamEvent::AcpToolCall(AcpToolCallEventData {
+            session_id: "sess-1".into(),
+            update: AcpToolCallUpdateData {
+                session_update: AcpToolCallSessionUpdateKind::ToolCall,
+                tool_call_id: "atc-001".into(),
+                status: Some(AcpToolCallStatus::InProgress),
+                title: Some("Read file".into()),
+                kind: None,
+                raw_input: None,
+                raw_output: None,
+                content: None,
+                locations: None,
+            },
+            meta: None,
+        }))
+        .unwrap();
+
+        tx.send(AgentStreamEvent::AcpToolCall(AcpToolCallEventData {
+            session_id: "sess-1".into(),
+            update: AcpToolCallUpdateData {
+                session_update: AcpToolCallSessionUpdateKind::ToolCallUpdate,
+                tool_call_id: "atc-001".into(),
+                status: Some(AcpToolCallStatus::Completed),
+                title: Some("Read file".into()),
+                kind: None,
+                raw_input: None,
+                raw_output: Some(json!("file content")),
+                content: None,
+                locations: None,
+            },
+            meta: None,
+        }))
+        .unwrap();
+
+        tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
+
+        relay.consume(rx).await;
+
+        let inserts = repo.take_inserts();
+        let acp_msg = inserts.iter().find(|m| m.r#type == "acp_tool_call");
+        assert!(acp_msg.is_some());
+        let msg = acp_msg.unwrap();
+        assert_eq!(msg.id, "atc-001");
+        assert_eq!(msg.status.as_deref(), Some("work"));
+
+        let updates = repo.take_updates();
+        let acp_update = updates.iter().find(|(id, _)| id == "atc-001");
+        assert!(acp_update.is_some());
+        let (_, upd) = acp_update.unwrap();
+        assert_eq!(upd.status, Some(Some("finish".to_owned())));
+    }
+
+    #[tokio::test]
+    async fn run_tool_group_persists_message() {
+        use aionui_ai_agent::protocol::events::tool_call::{ToolCallStatus, ToolGroupEntry};
+
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let (tx, _) = broadcast::channel(64);
+
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+            None,
+        );
+
+        let rx = tx.subscribe();
+
+        tx.send(AgentStreamEvent::ToolGroup(vec![
+            ToolGroupEntry {
+                call_id: "tg-001".into(),
+                name: "search".into(),
+                status: ToolCallStatus::Completed,
+                description: Some("Web search".into()),
+            },
+            ToolGroupEntry {
+                call_id: "tg-002".into(),
+                name: "read_file".into(),
+                status: ToolCallStatus::Completed,
+                description: None,
+            },
+        ]))
+        .unwrap();
+        tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
+
+        relay.consume(rx).await;
+
+        let inserts = repo.take_inserts();
+        let group_msg = inserts.iter().find(|m| m.r#type == "tool_group");
+        assert!(group_msg.is_some());
+        let msg = group_msg.unwrap();
+        assert_eq!(msg.id, "tg-001");
+        assert_eq!(msg.status.as_deref(), Some("finish"));
+
+        let content: serde_json::Value = serde_json::from_str(&msg.content).unwrap();
+        assert!(content.is_array());
+        assert_eq!(content.as_array().unwrap().len(), 2);
     }
 
     // ── Helpers ──────────────────────────────────────────────────

--- a/justfile
+++ b/justfile
@@ -88,9 +88,17 @@ run *ARGS:
 run-release *ARGS:
     cargo run --release --bin aionui-backend -- {{ARGS}}
 
-# Pre-push gate: format, lint, test, then push
-push *ARGS: lint-fix fmt test
+# Pre-push gate: format, lint, auto-commit fixes, test, then push
+push *ARGS: lint-fix fmt _auto-commit-fixes test
     git push {{ ARGS }}
+
+# Auto-commit any formatting/lint fixes if there are changes
+_auto-commit-fixes:
+    #!/usr/bin/env bash
+    if [ -n "$(git diff --name-only)" ]; then
+        git add -A
+        git commit -m "chore: apply auto-fixes (fmt + clippy)"
+    fi
 
 # Update aionrs dependency (e.g. just update-aionrs or just update-aionrs v0.1.19)
 update-aionrs *TAG:


### PR DESCRIPTION
## Summary

- Persist `tool_call`, `acp_tool_call`, and `tool_group` stream events to the messages table in `StreamRelay`, so historical conversations display tool call records (commands, results) alongside text messages
- Use merge strategy (not replace) when updating tool call records, preserving fields like `raw_input` that only appear in the initial event but are omitted in subsequent updates
- Clean up AGENTS.md (remove stale route table, add maintenance rule) and sync ARCHITECTURE.md/zh-CN with current crate structure

## Test plan

- [x] Unit tests verify tool_call insert + merge (input preserved after update with output)
- [x] Unit tests verify acp_tool_call insert + merge (raw_input preserved after ToolCallUpdate)
- [x] Unit tests verify tool_group insert + update
- [x] All 145 unit tests pass (`cargo test -p aionui-conversation --lib`)
- [x] Clippy clean with zero warnings
- [x] `just push` passes (fmt + clippy + test)