### PR TITLE
docs(assistants): add word-form-creator to preset-id-whitelist

### DIFF
--- a/crates/aionui-app/assets/builtin-assistants/preset-id-whitelist.json
+++ b/crates/aionui-app/assets/builtin-assistants/preset-id-whitelist.json
@@ -1,5 +1,6 @@
 [
   "word-creator",
+  "word-form-creator",
   "ppt-creator",
   "excel-creator",
   "morph-ppt",


### PR DESCRIPTION
## Summary

\`crates/aionui-app/assets/builtin-assistants/preset-id-whitelist.json\` is the contract file that the frontend copies into \`PRESET_ID_WHITELIST\` inside \`migrateAssistants.ts\`. Its purpose: during one-shot import of legacy Electron \`assistants\`, any user-authored row whose unprefixed id collides with a built-in gets its id rewritten so the user row is not silently shadowed by a built-in of the same id.

\`word-form-creator\` was added to \`assistants.json\` without also being added here, so the frontend guard would miss an unprefixed user row named \`word-form-creator\`. Sync the two files.

Pure data change; no Rust code reads this file.

## Companion PR

Frontend sync that depends on this alignment: iOfficeAI/AionUi#2897.

## Test plan

- [x] No code paths reference this JSON; compile/test unaffected
- [ ] When frontend PR #2897 lands, verify that a fresh run over a legacy config with a user row id \`word-form-creator\` renames to \`custom-migrated-*\` instead of colliding