### PR TITLE
feat(logging): integrate aionrs independent file logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.21"
+version = "0.1.22"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.22#14e408b2bca4ed0d138acecf1d300c0abfe0f2b1"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -134,7 +135,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.21"
+version = "0.1.22"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.22#14e408b2bca4ed0d138acecf1d300c0abfe0f2b1"
 dependencies = [
  "regex",
  "serde",
@@ -144,7 +146,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.21"
+version = "0.1.22"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.22#14e408b2bca4ed0d138acecf1d300c0abfe0f2b1"
 dependencies = [
  "aion-compact",
  "aion-types",
@@ -166,7 +169,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.21"
+version = "0.1.22"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.22#14e408b2bca4ed0d138acecf1d300c0abfe0f2b1"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -186,7 +190,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.21"
+version = "0.1.22"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.22#14e408b2bca4ed0d138acecf1d300c0abfe0f2b1"
 dependencies = [
  "aion-config",
  "chrono",
@@ -199,7 +204,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.21"
+version = "0.1.22"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.22#14e408b2bca4ed0d138acecf1d300c0abfe0f2b1"
 dependencies = [
  "aion-types",
  "serde",
@@ -211,7 +217,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.21"
+version = "0.1.22"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.22#14e408b2bca4ed0d138acecf1d300c0abfe0f2b1"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -238,7 +245,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.21"
+version = "0.1.22"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.22#14e408b2bca4ed0d138acecf1d300c0abfe0f2b1"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -263,7 +271,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.21"
+version = "0.1.22"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.22#14e408b2bca4ed0d138acecf1d300c0abfe0f2b1"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -282,7 +291,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.21"
+version = "0.1.22"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.22#14e408b2bca4ed0d138acecf1d300c0abfe0f2b1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6346,6 +6356,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.22#14e408b2bca4ed0d138acecf1d300c0abfe0f2b1"
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,6 @@ dependencies = [
 [[package]]
 name = "aion-agent"
 version = "0.1.21"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.21#4cc7ff222339ab8a91bbeeedc73cafd588bd5214"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -129,23 +128,23 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "workspace-hack",
 ]
 
 [[package]]
 name = "aion-compact"
 version = "0.1.21"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.21#4cc7ff222339ab8a91bbeeedc73cafd588bd5214"
 dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
 name = "aion-config"
 version = "0.1.21"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.21#4cc7ff222339ab8a91bbeeedc73cafd588bd5214"
 dependencies = [
  "aion-compact",
  "aion-types",
@@ -159,13 +158,15 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "workspace-hack",
 ]
 
 [[package]]
 name = "aion-mcp"
 version = "0.1.21"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.21#4cc7ff222339ab8a91bbeeedc73cafd588bd5214"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -179,38 +180,38 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "workspace-hack",
 ]
 
 [[package]]
 name = "aion-memory"
 version = "0.1.21"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.21#4cc7ff222339ab8a91bbeeedc73cafd588bd5214"
 dependencies = [
  "aion-config",
  "chrono",
  "serde",
  "serde_yaml",
  "thiserror 2.0.18",
+ "tracing",
  "workspace-hack",
 ]
 
 [[package]]
 name = "aion-protocol"
 version = "0.1.21"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.21#4cc7ff222339ab8a91bbeeedc73cafd588bd5214"
 dependencies = [
  "aion-types",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "workspace-hack",
 ]
 
 [[package]]
 name = "aion-providers"
 version = "0.1.21"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.21#4cc7ff222339ab8a91bbeeedc73cafd588bd5214"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -230,6 +231,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "url",
  "workspace-hack",
 ]
@@ -237,7 +239,6 @@ dependencies = [
 [[package]]
 name = "aion-skills"
 version = "0.1.21"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.21#4cc7ff222339ab8a91bbeeedc73cafd588bd5214"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -255,6 +256,7 @@ dependencies = [
  "serde_yaml",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "unicode-width",
  "workspace-hack",
 ]
@@ -262,7 +264,6 @@ dependencies = [
 [[package]]
 name = "aion-tools"
 version = "0.1.21"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.21#4cc7ff222339ab8a91bbeeedc73cafd588bd5214"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -275,13 +276,13 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "workspace-hack",
 ]
 
 [[package]]
 name = "aion-types"
 version = "0.1.21"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.21#4cc7ff222339ab8a91bbeeedc73cafd588bd5214"
 dependencies = [
  "async-trait",
  "chrono",
@@ -342,6 +343,7 @@ dependencies = [
 name = "aionui-app"
 version = "0.1.0"
 dependencies = [
+ "aion-config",
  "aionui-ai-agent",
  "aionui-api-types",
  "aionui-assets",
@@ -6344,7 +6346,6 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.21#4cc7ff222339ab8a91bbeeedc73cafd588bd5214"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { path = "/Users/zhangyaxiong/workshop/iOfficeAI/aionrs/.worktrees/feat-logging-system/crates/aion-agent" }
-aion-types = { path = "/Users/zhangyaxiong/workshop/iOfficeAI/aionrs/.worktrees/feat-logging-system/crates/aion-types" }
-aion-protocol = { path = "/Users/zhangyaxiong/workshop/iOfficeAI/aionrs/.worktrees/feat-logging-system/crates/aion-protocol" }
-aion-config = { path = "/Users/zhangyaxiong/workshop/iOfficeAI/aionrs/.worktrees/feat-logging-system/crates/aion-config" }
-aion-mcp = { path = "/Users/zhangyaxiong/workshop/iOfficeAI/aionrs/.worktrees/feat-logging-system/crates/aion-mcp" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.22" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.22" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.22" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.22" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.22" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.21" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.21" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.21" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.21" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.21" }
+aion-agent = { path = "/Users/zhangyaxiong/workshop/iOfficeAI/aionrs/.worktrees/feat-logging-system/crates/aion-agent" }
+aion-types = { path = "/Users/zhangyaxiong/workshop/iOfficeAI/aionrs/.worktrees/feat-logging-system/crates/aion-types" }
+aion-protocol = { path = "/Users/zhangyaxiong/workshop/iOfficeAI/aionrs/.worktrees/feat-logging-system/crates/aion-protocol" }
+aion-config = { path = "/Users/zhangyaxiong/workshop/iOfficeAI/aionrs/.worktrees/feat-logging-system/crates/aion-config" }
+aion-mcp = { path = "/Users/zhangyaxiong/workshop/iOfficeAI/aionrs/.worktrees/feat-logging-system/crates/aion-mcp" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }

--- a/crates/aionui-app/Cargo.toml
+++ b/crates/aionui-app/Cargo.toml
@@ -34,6 +34,7 @@ aionui-team.workspace = true
 aionui-cron.workspace = true
 aionui-assistant.workspace = true
 aionui-runtime.workspace = true
+aion-config.workspace = true
 axum.workspace = true
 dirs.workspace = true
 tokio.workspace = true

--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -77,7 +77,10 @@ struct LogGuards {
 fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> LogGuards {
     std::fs::create_dir_all(log_dir).expect("failed to create log directory");
 
-    let console_layer = fmt::layer().with_target(true).with_filter(build_env_filter(log_level));
+    let console_layer = fmt::layer()
+        .with_target(true)
+        .with_ansi(false)
+        .with_filter(build_env_filter(log_level));
 
     // Backend file layer — excludes aion_* targets
     let file_appender = tracing_appender::rolling::RollingFileAppender::builder()

--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -65,7 +65,11 @@ fn build_env_filter(log_level: Option<&str>) -> EnvFilter {
 fn build_backend_filter(log_level: Option<&str>) -> EnvFilter {
     let user_directives = log_level.unwrap_or("info");
     let suppressions = NOISE_SUPPRESSIONS.join(",");
-    let aionrs_off: String = AIONRS_TARGETS.iter().map(|t| format!("{t}=off")).collect::<Vec<_>>().join(",");
+    let aionrs_off: String = AIONRS_TARGETS
+        .iter()
+        .map(|t| format!("{t}=off"))
+        .collect::<Vec<_>>()
+        .join(",");
     EnvFilter::new(format!("{suppressions},{aionrs_off},{user_directives}"))
 }
 
@@ -100,7 +104,11 @@ fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> LogGuards {
     // Aionrs file layer — only aion_* targets
     let aionrs_level = {
         let level = log_level.unwrap_or("info");
-        AIONRS_TARGETS.iter().map(|t| format!("{t}={level}")).collect::<Vec<_>>().join(",")
+        AIONRS_TARGETS
+            .iter()
+            .map(|t| format!("{t}={level}"))
+            .collect::<Vec<_>>()
+            .join(",")
     };
     let aionrs_resolved = aion_config::logging::ResolvedLogging {
         enabled: true,

--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -81,10 +81,7 @@ struct LogGuards {
 fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> LogGuards {
     std::fs::create_dir_all(log_dir).expect("failed to create log directory");
 
-    let console_layer = fmt::layer()
-        .with_target(true)
-        .with_ansi(false)
-        .with_filter(build_env_filter(log_level));
+    let console_layer = fmt::layer().with_target(true).with_filter(build_env_filter(log_level));
 
     // Backend file layer — excludes aion_* targets
     let file_appender = tracing_appender::rolling::RollingFileAppender::builder()

--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -44,37 +44,79 @@ struct Cli {
 
 const NOISE_SUPPRESSIONS: &[&str] = &["sqlx::query=warn", "hyper_util=warn", "reqwest=warn"];
 
+const AIONRS_TARGETS: &[&str] = &[
+    "aion_agent",
+    "aion_config",
+    "aion_compact",
+    "aion_mcp",
+    "aion_providers",
+    "aion_protocol",
+    "aion_tools",
+    "aion_skills",
+    "aion_memory",
+];
+
 fn build_env_filter(log_level: Option<&str>) -> EnvFilter {
     let user_directives = log_level.unwrap_or("info");
     let suppressions = NOISE_SUPPRESSIONS.join(",");
     EnvFilter::new(format!("{suppressions},{user_directives}"))
 }
 
-fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> tracing_appender::non_blocking::WorkerGuard {
+fn build_backend_filter(log_level: Option<&str>) -> EnvFilter {
+    let user_directives = log_level.unwrap_or("info");
+    let suppressions = NOISE_SUPPRESSIONS.join(",");
+    let aionrs_off: String = AIONRS_TARGETS.iter().map(|t| format!("{t}=off")).collect::<Vec<_>>().join(",");
+    EnvFilter::new(format!("{suppressions},{aionrs_off},{user_directives}"))
+}
+
+struct LogGuards {
+    _backend: tracing_appender::non_blocking::WorkerGuard,
+    _aionrs: tracing_appender::non_blocking::WorkerGuard,
+}
+
+fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> LogGuards {
     std::fs::create_dir_all(log_dir).expect("failed to create log directory");
 
     let console_layer = fmt::layer().with_target(true).with_filter(build_env_filter(log_level));
 
+    // Backend file layer — excludes aion_* targets
     let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
         .rotation(tracing_appender::rolling::Rotation::DAILY)
         .filename_suffix("backend.log")
         .build(log_dir)
-        .expect("failed to create log file appender");
-    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+        .expect("failed to create backend log file appender");
+    let (non_blocking, backend_guard) = tracing_appender::non_blocking(file_appender);
 
-    let file_layer = fmt::layer()
+    let backend_file_layer = fmt::layer()
         .json()
         .with_writer(non_blocking)
         .with_ansi(false)
         .with_target(true)
-        .with_filter(build_env_filter(log_level));
+        .with_filter(build_backend_filter(log_level));
+
+    // Aionrs file layer — only aion_* targets
+    let aionrs_level = {
+        let level = log_level.unwrap_or("info");
+        AIONRS_TARGETS.iter().map(|t| format!("{t}={level}")).collect::<Vec<_>>().join(",")
+    };
+    let aionrs_resolved = aion_config::logging::ResolvedLogging {
+        enabled: true,
+        level: aionrs_level,
+        dir: log_dir.to_path_buf(),
+    };
+    let (aionrs_layer, aionrs_guard) =
+        aion_config::logging::create_file_layer(&aionrs_resolved).expect("failed to create aionrs log layer");
 
     tracing_subscriber::registry()
         .with(console_layer)
-        .with(file_layer)
+        .with(backend_file_layer)
+        .with(aionrs_layer)
         .init();
 
-    guard
+    LogGuards {
+        _backend: backend_guard,
+        _aionrs: aionrs_guard,
+    }
 }
 
 fn main() -> Result<ExitCode> {

--- a/crates/aionui-office/src/watch_manager.rs
+++ b/crates/aionui-office/src/watch_manager.rs
@@ -705,7 +705,7 @@ mod tests {
         assert_eq!(last.data["state"], "error");
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn port_timeout_on_no_listener() {
         let spawner = Arc::new(MockSpawner::new());
         spawner.start_listener.store(false, Ordering::SeqCst);
@@ -716,7 +716,6 @@ mod tests {
         let file = dir.path().join("test.docx");
         std::fs::write(&file, b"test").unwrap();
 
-        // Override poll to 3 attempts to avoid slow test
         let resolved = resolve_path(file.to_str().unwrap()).unwrap();
         let port = allocate_port().unwrap();
         let result = mgr.poll_port_ready(port, &resolved).await;


### PR DESCRIPTION
## Summary

- Upgrade aion-* dependencies from v0.1.21 to v0.1.22 (logging system support)
- Add `aion-config` dependency to `aionui-app` for `create_file_layer()` API
- Split `init_tracing` into separate file layers: `backend.log` (excludes `aion_*` targets) and `aionrs.log` (only `aion_*` targets via `aion_config::logging`)
- Disable ANSI escape codes in console layer for frontend dev console readability

## Test plan

- [ ] Verify `backend.log` contains only backend-originated events (no `aion_*` targets)
- [ ] Verify `aionrs.log` contains only aion_* events with JSON format and daily rotation
- [ ] Verify console output has no ANSI escape codes
- [ ] Verify `--log-dir` and `--log-level` CLI flags propagate to both layers