### PR TITLE
fix(ci): auto-update Cargo.lock in release-please PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,7 +41,38 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'chore: release') && !startsWith(github.event.head_commit.message, 'chore(main): release')"
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release-please
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Checkout release PR branch
+        if: steps.release-please.outputs.pr
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ fromJSON(steps.release-please.outputs.pr).headBranchName }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust toolchain
+        if: steps.release-please.outputs.pr
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.95.0"
+
+      - name: Update Cargo.lock for workspace version bump
+        if: steps.release-please.outputs.pr
+        run: cargo update --workspace
+
+      - name: Commit and push Cargo.lock if changed
+        if: steps.release-please.outputs.pr
+        run: |
+          if git diff --quiet Cargo.lock; then
+            echo "Cargo.lock is already up to date"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add Cargo.lock
+            git commit -m "chore: update Cargo.lock for workspace version bump"
+            git push
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-ai-agent"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "agent-client-protocol",
  "aion-agent",
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-api-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aionui-common",
  "serde",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-app"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aion-config",
  "aionui-ai-agent",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-assets"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aionui-common",
  "axum",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-assistant"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aionui-api-types",
  "aionui-auth",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-auth"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aionui-api-types",
  "aionui-common",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-channel"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aionui-ai-agent",
  "aionui-api-types",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-common"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-conversation"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aionui-ai-agent",
  "aionui-api-types",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-cron"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aionui-ai-agent",
  "aionui-api-types",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-db"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aionui-common",
  "async-trait",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-extension"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aionui-api-types",
  "aionui-common",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-file"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aionui-api-types",
  "aionui-common",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-mcp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aionui-api-types",
  "aionui-common",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-office"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aionui-api-types",
  "aionui-auth",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-realtime"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aionui-api-types",
  "axum",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-runtime"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dirs",
  "fs2",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-shell"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aionui-api-types",
  "aionui-common",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-system"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aionui-api-types",
  "aionui-auth",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "aionui-team"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "agent-client-protocol",
  "aionui-ai-agent",


### PR DESCRIPTION
## Summary

- Release-please 更新 `Cargo.toml` 中的 `workspace.package.version` 后，`Cargo.lock` 没有同步更新，导致 merge 后本地出现未提交的 Cargo.lock 变更
- 在 `update-pr` job 中增加步骤：checkout PR 分支 → `cargo update --workspace`（只更新 workspace crate 版本，不碰第三方依赖）→ commit 回 PR 分支
- 同时提交当前 `0.1.0` → `0.1.1` 的 Cargo.lock 差异

## Test plan

- [ ] 触发一次 release-please PR 更新，确认 Cargo.lock 被自动更新并 commit 到 PR 分支
- [ ] Merge 后本地 pull，确认没有未提交的 Cargo.lock 变更