### PR TITLE
feat(cli): add --work-dir argument for conversation workspaces

### DIFF
--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -50,7 +50,8 @@ use aionui_system::{ConnectionTestRouterState, SystemRouterState, connection_tes
 use aionui_team::{GuideMcpServer, TeamRouterState, team_routes};
 
 pub use state_builders::{
-    ChannelOrchestratorComponents, build_assistant_state, build_extension_states, build_module_states, build_ws_state,
+    ChannelOrchestratorComponents, build_assistant_state, build_conversation_state, build_extension_states,
+    build_module_states, build_ws_state,
 };
 
 /// Application configuration parsed from CLI arguments.
@@ -59,6 +60,7 @@ pub struct AppConfig {
     pub host: String,
     pub port: u16,
     pub data_dir: PathBuf,
+    pub work_dir: PathBuf,
     pub app_version: String,
     /// Run in local embedded mode (skip authentication, use system_default_user).
     pub local: bool,
@@ -82,6 +84,7 @@ impl Default for AppConfig {
             host: aionui_common::constants::DEFAULT_HOST.to_string(),
             port: aionui_common::constants::DEFAULT_PORT,
             data_dir: PathBuf::from("data"),
+            work_dir: PathBuf::from("data"),
             app_version: env!("CARGO_PKG_VERSION").to_string(),
             local: false,
         }
@@ -104,6 +107,7 @@ pub struct AppServices {
     /// Raw JWT secret string, used to derive encryption keys.
     pub jwt_secret_raw: String,
     pub data_dir: PathBuf,
+    pub work_dir: PathBuf,
     /// When `true`, skip JWT authentication and use a fixed default user.
     pub local: bool,
     pub app_version: String,
@@ -135,40 +139,11 @@ impl AppServices {
         }
     }
 
-    /// Build application services from an initialized database.
-    ///
-    /// Resolves JWT secret (env → db → generate), constructs all shared
-    /// services, and persists a newly generated secret to the database.
-    pub async fn from_database(database: Database) -> anyhow::Result<Self> {
-        Self::from_database_with_data_dir_and_app_version(
-            database,
-            PathBuf::from("data"),
-            false,
-            env!("CARGO_PKG_VERSION").to_string(),
-        )
-        .await
-    }
-
-    pub async fn from_database_with_data_dir(
-        database: Database,
-        data_dir: PathBuf,
-        local: bool,
-    ) -> anyhow::Result<Self> {
-        Self::from_database_with_data_dir_and_app_version(
-            database,
-            data_dir,
-            local,
-            env!("CARGO_PKG_VERSION").to_string(),
-        )
-        .await
-    }
-
-    pub async fn from_database_with_data_dir_and_app_version(
-        database: Database,
-        data_dir: PathBuf,
-        local: bool,
-        app_version: String,
-    ) -> anyhow::Result<Self> {
+    pub async fn from_config(database: Database, config: &AppConfig) -> anyhow::Result<Self> {
+        let data_dir = config.data_dir.clone();
+        let work_dir = config.work_dir.clone();
+        let local = config.local;
+        let app_version = config.app_version.clone();
         let user_repo: Arc<dyn IUserRepository> = Arc::new(SqliteUserRepository::new(database.pool().clone()));
 
         // Resolve JWT secret: env var → system user db field → random generation
@@ -279,6 +254,7 @@ impl AppServices {
             acp_session_sync: acp_agent_service,
             jwt_secret_raw: secret,
             data_dir,
+            work_dir,
             local,
             app_version,
             skill_paths,
@@ -640,9 +616,7 @@ mod tests {
         let config = AppConfig {
             host: "0.0.0.0".to_string(),
             port: 3000,
-            data_dir: PathBuf::from("data"),
-            app_version: "1.2.3".to_string(),
-            local: false,
+            ..Default::default()
         };
         assert_eq!(config.socket_addr(), "0.0.0.0:3000");
     }
@@ -650,11 +624,8 @@ mod tests {
     #[test]
     fn test_app_config_database_path() {
         let config = AppConfig {
-            host: "127.0.0.1".to_string(),
-            port: 25808,
             data_dir: PathBuf::from("/tmp/aionui"),
-            app_version: "1.2.3".to_string(),
-            local: false,
+            ..Default::default()
         };
         assert_eq!(config.database_path(), PathBuf::from("/tmp/aionui/aionui-backend.db"));
     }
@@ -662,7 +633,7 @@ mod tests {
     #[tokio::test]
     async fn test_app_services_from_memory_db() {
         let db = aionui_db::init_database_memory().await.unwrap();
-        let services = AppServices::from_database(db).await.unwrap();
+        let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
 
         // JWT service should be functional
         let token = services.jwt_service.sign("test_user", "testuser").unwrap();
@@ -679,7 +650,7 @@ mod tests {
     #[tokio::test]
     async fn test_jwt_secret_persisted_to_db() {
         let db = aionui_db::init_database_memory().await.unwrap();
-        let services = AppServices::from_database(db).await.unwrap();
+        let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
 
         // System user should now have a jwt_secret persisted
         let system_user = services.user_repo.get_system_user().await.unwrap();
@@ -693,14 +664,11 @@ mod tests {
     #[tokio::test]
     async fn test_app_services_uses_supplied_app_version() {
         let db = aionui_db::init_database_memory().await.unwrap();
-        let services = AppServices::from_database_with_data_dir_and_app_version(
-            db,
-            PathBuf::from("data"),
-            false,
-            "9.9.9".to_string(),
-        )
-        .await
-        .unwrap();
+        let config = AppConfig {
+            app_version: "9.9.9".to_string(),
+            ..Default::default()
+        };
+        let services = AppServices::from_config(db, &config).await.unwrap();
 
         assert_eq!(services.app_version, "9.9.9");
 

--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -25,6 +25,11 @@ struct Cli {
     #[arg(long, default_value = "data")]
     data_dir: PathBuf,
 
+    /// Working directory for conversation workspaces.
+    /// Falls back to AIONUI_WORK_DIR env, then to data-dir.
+    #[arg(long)]
+    work_dir: Option<PathBuf>,
+
     /// Host application version used for extension engine compatibility.
     #[arg(long, default_value_t = env!("CARGO_PKG_VERSION").to_string())]
     app_version: String,
@@ -181,10 +186,24 @@ async fn async_main(merged_path: String, mcp_subcommand: Option<&str>, cli: Opti
         "startup: PATH ready"
     );
 
+    let work_dir = cli.work_dir.unwrap_or_else(|| {
+        std::env::var("AIONUI_WORK_DIR")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| cli.data_dir.clone())
+    });
+
+    // SAFETY: called before any service initialization; no concurrent reads.
+    unsafe {
+        std::env::set_var("AIONUI_WORK_DIR", &work_dir);
+    }
+
     let config = AppConfig {
         host: cli.host,
         port: cli.port,
         data_dir: cli.data_dir,
+        work_dir,
         app_version: cli.app_version,
         local: cli.local,
     };
@@ -239,13 +258,7 @@ async fn async_main(merged_path: String, mcp_subcommand: Option<&str>, cli: Opti
         "startup: builtin skills materialized"
     );
 
-    let services = AppServices::from_database_with_data_dir_and_app_version(
-        database,
-        config.data_dir.clone(),
-        config.local,
-        config.app_version.clone(),
-    )
-    .await?;
+    let services = AppServices::from_config(database, &config).await?;
     info!(elapsed_ms = boot.elapsed().as_millis(), "startup: services constructed");
 
     if config.local {

--- a/crates/aionui-app/src/state_builders.rs
+++ b/crates/aionui-app/src/state_builders.rs
@@ -156,7 +156,7 @@ pub fn build_conversation_state(
         services.skill_paths.clone(),
     ));
     let conversation_service = ConversationService::new(
-        services.data_dir.clone(),
+        services.work_dir.clone(),
         services.event_bus.clone(),
         skill_resolver,
         services.worker_task_manager.clone(),
@@ -293,7 +293,7 @@ pub async fn build_channel_state(
         aionui_db::SqliteAcpSessionRepository::new(services.database.pool().clone()),
     );
     let conversation_svc = Arc::new(ConversationService::new(
-        services.data_dir.clone(),
+        services.work_dir.clone(),
         services.event_bus.clone(),
         skill_resolver,
         services.worker_task_manager.clone(),
@@ -368,7 +368,7 @@ pub fn build_team_state(
         services.skill_paths.clone(),
     ));
     let conv_service = ConversationService::new(
-        services.data_dir.clone(),
+        services.work_dir.clone(),
         services.event_bus.clone(),
         skill_resolver,
         services.worker_task_manager.clone(),
@@ -406,7 +406,7 @@ pub fn build_cron_state(services: &AppServices) -> CronRouterState {
         services.skill_paths.clone(),
     ));
     let conv_service = ConversationService::new(
-        services.data_dir.clone(),
+        services.work_dir.clone(),
         services.event_bus.clone(),
         skill_resolver,
         services.worker_task_manager.clone(),
@@ -421,6 +421,7 @@ pub fn build_cron_state(services: &AppServices) -> CronRouterState {
         conv_repo,
         Arc::new(conv_service.clone()),
         busy_guard,
+        services.work_dir.clone(),
         services.data_dir.clone(),
         services.event_bus.clone(),
         services.agent_registry.clone(),
@@ -568,6 +569,7 @@ pub fn build_ws_state(services: &AppServices) -> WsHandlerState {
 mod tests {
     use super::*;
 
+    use crate::AppConfig;
     use aionui_extension::{ExtensionSource, ScanPath};
 
     #[tokio::test]
@@ -592,10 +594,13 @@ mod tests {
         .unwrap();
 
         let db = aionui_db::init_database_memory().await.unwrap();
-        let services =
-            AppServices::from_database_with_data_dir_and_app_version(db, data_dir, false, "2.1.0".to_string())
-                .await
-                .unwrap();
+        let config = AppConfig {
+            data_dir: data_dir.clone(),
+            work_dir: data_dir,
+            app_version: "2.1.0".to_string(),
+            ..Default::default()
+        };
+        let services = AppServices::from_config(db, &config).await.unwrap();
 
         let (ext_state, _hub_state, _skill_state) = build_extension_states(&services).await;
         ext_state

--- a/crates/aionui-app/tests/agent_integration_e2e.rs
+++ b/crates/aionui-app/tests/agent_integration_e2e.rs
@@ -188,7 +188,9 @@ impl IWorkerTaskManager for MockTaskManager {
 
 async fn build_app_with_mock_tasks() -> (axum::Router, aionui_app::AppServices, Arc<MockTaskManager>) {
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = aionui_app::AppServices::from_config(db, &aionui_app::AppConfig::default()).await.unwrap();
+    let services = aionui_app::AppServices::from_config(db, &aionui_app::AppConfig::default())
+        .await
+        .unwrap();
 
     let mock_tm = Arc::new(MockTaskManager::new());
     let services = services.with_worker_task_manager(mock_tm.clone());

--- a/crates/aionui-app/tests/agent_integration_e2e.rs
+++ b/crates/aionui-app/tests/agent_integration_e2e.rs
@@ -188,7 +188,7 @@ impl IWorkerTaskManager for MockTaskManager {
 
 async fn build_app_with_mock_tasks() -> (axum::Router, aionui_app::AppServices, Arc<MockTaskManager>) {
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = aionui_app::AppServices::from_database(db).await.unwrap();
+    let services = aionui_app::AppServices::from_config(db, &aionui_app::AppConfig::default()).await.unwrap();
 
     let mock_tm = Arc::new(MockTaskManager::new());
     let services = services.with_worker_task_manager(mock_tm.clone());

--- a/crates/aionui-app/tests/assistants_e2e.rs
+++ b/crates/aionui-app/tests/assistants_e2e.rs
@@ -13,7 +13,7 @@ mod common;
 
 use std::sync::Arc;
 
-use aionui_app::{AppServices, ModuleStates, build_module_states, create_router_with_states};
+use aionui_app::{AppConfig, AppServices, ModuleStates, build_module_states, create_router_with_states};
 use aionui_assistant::{AssistantRouterState, AssistantService, BuiltinAssistantRegistry};
 use aionui_db::{
     IAssistantOverrideRepository, IAssistantRepository, SqliteAssistantOverrideRepository, SqliteAssistantRepository,
@@ -130,7 +130,7 @@ async fn fixture() -> Fixture {
 
     // Bring up in-memory DB + services + default module states.
     let db = init_database_memory().await.unwrap();
-    let services = AppServices::from_database(db).await.unwrap();
+    let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
     let (mut states, _): (ModuleStates, _) = build_module_states(&services).await;
 
     // Replace the extension + hub + skill states with freshly-constructed

--- a/crates/aionui-app/tests/auth_e2e.rs
+++ b/crates/aionui-app/tests/auth_e2e.rs
@@ -9,7 +9,7 @@ use axum::http::{Request, StatusCode, header};
 use http_body_util::BodyExt;
 use tower::ServiceExt;
 
-use aionui_app::AppServices;
+use aionui_app::{AppConfig, AppServices};
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -17,7 +17,7 @@ use aionui_app::AppServices;
 
 async fn build_app() -> (axum::Router, AppServices) {
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = AppServices::from_database(db).await.unwrap();
+    let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
     let router = aionui_app::create_router(&services).await;
     (router, services)
 }

--- a/crates/aionui-app/tests/auxiliary_e2e.rs
+++ b/crates/aionui-app/tests/auxiliary_e2e.rs
@@ -64,7 +64,9 @@ async fn create_conversation(app: &mut axum::Router, token: &str, csrf: &str, na
 
 async fn build_app() -> (axum::Router, aionui_app::AppServices) {
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = aionui_app::AppServices::from_config(db, &aionui_app::AppConfig::default()).await.unwrap();
+    let services = aionui_app::AppServices::from_config(db, &aionui_app::AppConfig::default())
+        .await
+        .unwrap();
     let router = aionui_app::create_router(&services).await;
     (router, services)
 }

--- a/crates/aionui-app/tests/auxiliary_e2e.rs
+++ b/crates/aionui-app/tests/auxiliary_e2e.rs
@@ -64,7 +64,7 @@ async fn create_conversation(app: &mut axum::Router, token: &str, csrf: &str, na
 
 async fn build_app() -> (axum::Router, aionui_app::AppServices) {
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = aionui_app::AppServices::from_database(db).await.unwrap();
+    let services = aionui_app::AppServices::from_config(db, &aionui_app::AppConfig::default()).await.unwrap();
     let router = aionui_app::create_router(&services).await;
     (router, services)
 }

--- a/crates/aionui-app/tests/common/mod.rs
+++ b/crates/aionui-app/tests/common/mod.rs
@@ -8,14 +8,14 @@ use tower::ServiceExt;
 use wiremock::MockServer;
 
 use aionui_ai_agent::{AgentInstance, IAgentTask, IMockAgent, WorkerTaskManagerImpl};
-use aionui_app::{AppServices, build_module_states, create_router, create_router_with_states};
+use aionui_app::{AppConfig, AppServices, build_module_states, create_router, create_router_with_states};
 use aionui_extension::{ExternalPathsManager, SkillPaths, SkillRouterState};
 use aionui_file::FileService;
 use aionui_system::VersionCheckService;
 
 pub async fn build_app() -> (axum::Router, AppServices) {
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = AppServices::from_database(db).await.unwrap();
+    let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
     let router = create_router(&services).await;
     (router, services)
 }
@@ -29,7 +29,7 @@ pub async fn build_app() -> (axum::Router, AppServices) {
 #[allow(dead_code)]
 pub async fn build_app_with_skill_paths(root: &std::path::Path) -> (axum::Router, AppServices, SkillPaths) {
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = AppServices::from_database(db).await.unwrap();
+    let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
     let (mut states, _) = build_module_states(&services).await;
 
     let builtin_dir = root.join("builtin-skills");
@@ -65,7 +65,7 @@ pub async fn build_app_with_skill_paths(root: &std::path::Path) -> (axum::Router
 
 pub async fn build_app_with_noop_opener() -> (axum::Router, AppServices) {
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = AppServices::from_database(db).await.unwrap();
+    let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
     let (mut states, _) = build_module_states(&services).await;
     states.shell.shell_service = std::sync::Arc::new(aionui_shell::ShellService::new(std::sync::Arc::new(
         aionui_shell::NoopSystemOpener,
@@ -76,7 +76,7 @@ pub async fn build_app_with_noop_opener() -> (axum::Router, AppServices) {
 
 pub async fn build_app_with_file_roots(allowed_roots: Vec<std::path::PathBuf>) -> (axum::Router, AppServices) {
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = AppServices::from_database(db).await.unwrap();
+    let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
     let (mut states, _) = build_module_states(&services).await;
     states.file.file_service = std::sync::Arc::new(FileService::new(services.event_bus.clone(), allowed_roots));
     let router = create_router_with_states(&services, states);
@@ -88,7 +88,7 @@ pub async fn build_app_with_mock_version(
     mock_server: &MockServer,
 ) -> (axum::Router, AppServices) {
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = AppServices::from_database(db).await.unwrap();
+    let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
     let (mut states, _) = build_module_states(&services).await;
     states.system.version_check_service =
         VersionCheckService::with_api_base(reqwest::Client::new(), current_version.to_owned(), mock_server.uri());
@@ -117,7 +117,7 @@ pub async fn build_app_with_mock_agents() -> (axum::Router, AppServices) {
     });
     let wtm: std::sync::Arc<dyn aionui_ai_agent::IWorkerTaskManager> =
         std::sync::Arc::new(WorkerTaskManagerImpl::new(factory));
-    let services = AppServices::from_database(db)
+    let services = AppServices::from_config(db, &AppConfig::default())
         .await
         .unwrap()
         .with_worker_task_manager(wtm);

--- a/crates/aionui-app/tests/extension_e2e.rs
+++ b/crates/aionui-app/tests/extension_e2e.rs
@@ -5,7 +5,7 @@ use serde_json::json;
 use tempfile::TempDir;
 use tower::ServiceExt;
 
-use aionui_app::{AppServices, build_module_states, create_router_with_states, derive_encryption_key};
+use aionui_app::{AppConfig, AppServices, build_module_states, create_router_with_states, derive_encryption_key};
 use aionui_common::{decrypt_string, now_ms};
 use aionui_db::{IChannelRepository, SqliteChannelRepository};
 use aionui_extension::{ExtensionSource, ScanPath};
@@ -150,14 +150,14 @@ fn write_legacy_extension_fixture(tmp: &TempDir) -> std::path::PathBuf {
 
 async fn build_app_with_extension_root(ext_root: &std::path::Path) -> (axum::Router, AppServices) {
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = AppServices::from_database_with_data_dir_and_app_version(
-        db,
-        ext_root.join("..").join("data"),
-        false,
-        "1.0.0".to_string(),
-    )
-    .await
-    .unwrap();
+    let data_dir = ext_root.join("..").join("data");
+    let config = AppConfig {
+        data_dir: data_dir.clone(),
+        work_dir: data_dir,
+        app_version: "1.0.0".to_string(),
+        ..Default::default()
+    };
+    let services = AppServices::from_config(db, &config).await.unwrap();
     let (states, _) = build_module_states(&services).await;
     states
         .extension

--- a/crates/aionui-app/tests/health.rs
+++ b/crates/aionui-app/tests/health.rs
@@ -3,7 +3,7 @@ use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use tower::ServiceExt;
 
-use aionui_app::AppServices;
+use aionui_app::{AppConfig, AppServices};
 
 fn build_request(method: &str, uri: &str) -> Request<Body> {
     Request::builder()
@@ -20,7 +20,7 @@ async fn response_json(body: Body) -> serde_json::Value {
 
 async fn build_app() -> axum::Router {
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = AppServices::from_database(db).await.unwrap();
+    let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
     aionui_app::create_router(&services).await
 }
 

--- a/crates/aionui-app/tests/local_mode.rs
+++ b/crates/aionui-app/tests/local_mode.rs
@@ -34,7 +34,9 @@ async fn test_local_mode_skips_auth() {
 #[tokio::test]
 async fn test_non_local_mode_requires_auth() {
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = aionui_app::AppServices::from_config(db, &aionui_app::AppConfig::default()).await.unwrap();
+    let services = aionui_app::AppServices::from_config(db, &aionui_app::AppConfig::default())
+        .await
+        .unwrap();
 
     let router = aionui_app::create_router(&services).await;
 

--- a/crates/aionui-app/tests/local_mode.rs
+++ b/crates/aionui-app/tests/local_mode.rs
@@ -5,9 +5,11 @@ use tower::ServiceExt;
 #[tokio::test]
 async fn test_local_mode_skips_auth() {
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = aionui_app::AppServices::from_database_with_data_dir(db, std::path::PathBuf::from("data"), true)
-        .await
-        .unwrap();
+    let config = aionui_app::AppConfig {
+        local: true,
+        ..Default::default()
+    };
+    let services = aionui_app::AppServices::from_config(db, &config).await.unwrap();
 
     let router = aionui_app::create_router(&services).await;
 
@@ -32,9 +34,7 @@ async fn test_local_mode_skips_auth() {
 #[tokio::test]
 async fn test_non_local_mode_requires_auth() {
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = aionui_app::AppServices::from_database_with_data_dir(db, std::path::PathBuf::from("data"), false)
-        .await
-        .unwrap();
+    let services = aionui_app::AppServices::from_config(db, &aionui_app::AppConfig::default()).await.unwrap();
 
     let router = aionui_app::create_router(&services).await;
 

--- a/crates/aionui-app/tests/office_e2e.rs
+++ b/crates/aionui-app/tests/office_e2e.rs
@@ -22,7 +22,7 @@ use tower::ServiceExt;
 
 use common::{body_json, get_request, json_with_token, setup_and_login};
 
-use aionui_app::{AppServices, build_module_states, create_router_with_states};
+use aionui_app::{AppConfig, AppServices, build_module_states, create_router_with_states};
 use aionui_office::{
     ConversionService, OfficeRouterState, OfficecliWatchManager, ProxyService, SnapshotService, StarOfficeDetector,
 };
@@ -44,9 +44,12 @@ async fn build_office_app_with_roots(
     let data_dir = tmp.path().to_path_buf();
 
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = AppServices::from_database_with_data_dir(db, data_dir, false)
-        .await
-        .unwrap();
+    let config = AppConfig {
+        data_dir: data_dir.clone(),
+        work_dir: data_dir,
+        ..Default::default()
+    };
+    let services = AppServices::from_config(db, &config).await.unwrap();
     let (mut states, _) = build_module_states(&services).await;
 
     states.office = build_test_office_state(tmp.path(), allowed_roots);

--- a/crates/aionui-app/tests/skills_builtin_e2e.rs
+++ b/crates/aionui-app/tests/skills_builtin_e2e.rs
@@ -55,7 +55,9 @@ async fn fixture_embedded() -> Fixture {
         .expect("failed to materialize embedded builtin skills for test fixture");
 
     let db = init_database_memory().await.unwrap();
-    let services = aionui_app::AppServices::from_config(db, &aionui_app::AppConfig::default()).await.unwrap();
+    let services = aionui_app::AppServices::from_config(db, &aionui_app::AppConfig::default())
+        .await
+        .unwrap();
     let (mut states, _): (ModuleStates, _) = build_module_states(&services).await;
 
     // Replace the skill state with a deterministic one rooted at tmp.

--- a/crates/aionui-app/tests/skills_builtin_e2e.rs
+++ b/crates/aionui-app/tests/skills_builtin_e2e.rs
@@ -55,9 +55,7 @@ async fn fixture_embedded() -> Fixture {
         .expect("failed to materialize embedded builtin skills for test fixture");
 
     let db = init_database_memory().await.unwrap();
-    let services = aionui_app::AppServices::from_database_with_data_dir(db, std::path::PathBuf::from("data"), false)
-        .await
-        .unwrap();
+    let services = aionui_app::AppServices::from_config(db, &aionui_app::AppConfig::default()).await.unwrap();
     let (mut states, _): (ModuleStates, _) = build_module_states(&services).await;
 
     // Replace the skill state with a deterministic one rooted at tmp.

--- a/crates/aionui-app/tests/websocket_e2e.rs
+++ b/crates/aionui-app/tests/websocket_e2e.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use aionui_api_types::WebSocketMessage;
-use aionui_app::{AppServices, create_router};
+use aionui_app::{AppConfig, AppServices, create_router};
 use aionui_realtime::WebSocketManager;
 use futures_util::{SinkExt, StreamExt};
 use serde_json::{Value, json};
@@ -26,7 +26,7 @@ struct TestApp {
 
 async fn start_app() -> TestApp {
     let db = aionui_db::init_database_memory().await.unwrap();
-    let services = AppServices::from_database(db).await.unwrap();
+    let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
     let router = create_router(&services).await;
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/crates/aionui-app/tests/work_dir_e2e.rs
+++ b/crates/aionui-app/tests/work_dir_e2e.rs
@@ -1,7 +1,7 @@
 //! Integration tests verifying that --work-dir is used for conversation workspace creation.
 
-use aionui_app::{AppConfig, AppServices, build_conversation_state};
 use aionui_api_types::CreateConversationRequest;
+use aionui_app::{AppConfig, AppServices, build_conversation_state};
 use aionui_common::AgentType;
 
 #[tokio::test]

--- a/crates/aionui-app/tests/work_dir_e2e.rs
+++ b/crates/aionui-app/tests/work_dir_e2e.rs
@@ -1,0 +1,107 @@
+//! Integration tests verifying that --work-dir is used for conversation workspace creation.
+
+use aionui_app::{AppConfig, AppServices, build_conversation_state};
+use aionui_api_types::CreateConversationRequest;
+use aionui_common::AgentType;
+
+#[tokio::test]
+async fn conversation_workspace_uses_work_dir() {
+    let data_dir = tempfile::TempDir::new().unwrap();
+    let work_dir = tempfile::TempDir::new().unwrap();
+
+    let db = aionui_db::init_database_memory().await.unwrap();
+    let config = AppConfig {
+        data_dir: data_dir.path().to_path_buf(),
+        work_dir: work_dir.path().to_path_buf(),
+        local: true,
+        ..Default::default()
+    };
+    let services = AppServices::from_config(db, &config).await.unwrap();
+    let state = build_conversation_state(&services, None);
+
+    let request = CreateConversationRequest {
+        r#type: AgentType::Acp,
+        name: Some("test".to_string()),
+        model: None,
+        source: None,
+        channel_chat_id: None,
+        extra: serde_json::json!({}),
+    };
+    let response = state.service.create("system_default_user", request).await.unwrap();
+
+    let workspace = response.extra.get("workspace").and_then(|v| v.as_str()).unwrap();
+    assert!(
+        workspace.starts_with(work_dir.path().to_str().unwrap()),
+        "workspace should be under work_dir, got: {workspace}"
+    );
+    assert!(
+        !workspace.starts_with(data_dir.path().to_str().unwrap()),
+        "workspace should NOT be under data_dir, got: {workspace}"
+    );
+}
+
+#[tokio::test]
+async fn user_specified_workspace_is_not_overridden() {
+    let data_dir = tempfile::TempDir::new().unwrap();
+    let work_dir = tempfile::TempDir::new().unwrap();
+    let custom_workspace = tempfile::TempDir::new().unwrap();
+
+    let db = aionui_db::init_database_memory().await.unwrap();
+    let config = AppConfig {
+        data_dir: data_dir.path().to_path_buf(),
+        work_dir: work_dir.path().to_path_buf(),
+        local: true,
+        ..Default::default()
+    };
+    let services = AppServices::from_config(db, &config).await.unwrap();
+    let state = build_conversation_state(&services, None);
+
+    let request = CreateConversationRequest {
+        r#type: AgentType::Acp,
+        name: Some("test".to_string()),
+        model: None,
+        source: None,
+        channel_chat_id: None,
+        extra: serde_json::json!({
+            "workspace": custom_workspace.path().to_str().unwrap()
+        }),
+    };
+    let response = state.service.create("system_default_user", request).await.unwrap();
+
+    let workspace = response.extra.get("workspace").and_then(|v| v.as_str()).unwrap();
+    assert!(
+        workspace.starts_with(custom_workspace.path().to_str().unwrap()),
+        "workspace should use user-specified path, got: {workspace}"
+    );
+}
+
+#[tokio::test]
+async fn workspace_defaults_to_data_dir_when_work_dir_equals_data_dir() {
+    let data_dir = tempfile::TempDir::new().unwrap();
+
+    let db = aionui_db::init_database_memory().await.unwrap();
+    let config = AppConfig {
+        data_dir: data_dir.path().to_path_buf(),
+        work_dir: data_dir.path().to_path_buf(),
+        local: true,
+        ..Default::default()
+    };
+    let services = AppServices::from_config(db, &config).await.unwrap();
+    let state = build_conversation_state(&services, None);
+
+    let request = CreateConversationRequest {
+        r#type: AgentType::Acp,
+        name: Some("test".to_string()),
+        model: None,
+        source: None,
+        channel_chat_id: None,
+        extra: serde_json::json!({}),
+    };
+    let response = state.service.create("system_default_user", request).await.unwrap();
+
+    let workspace = response.extra.get("workspace").and_then(|v| v.as_str()).unwrap();
+    assert!(
+        workspace.starts_with(data_dir.path().to_str().unwrap()),
+        "workspace should be under data_dir when work_dir == data_dir, got: {workspace}"
+    );
+}

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -64,6 +64,7 @@ pub struct JobExecutor {
     conversation_repo: Arc<dyn IConversationRepository>,
     conversation_service: Arc<ConversationService>,
     busy_guard: Arc<CronBusyGuard>,
+    work_dir: PathBuf,
     data_dir: PathBuf,
     broadcaster: Arc<dyn EventBroadcaster>,
     agent_registry: Arc<AgentRegistry>,
@@ -76,6 +77,7 @@ impl JobExecutor {
         conversation_repo: Arc<dyn IConversationRepository>,
         conversation_service: Arc<ConversationService>,
         busy_guard: Arc<CronBusyGuard>,
+        work_dir: PathBuf,
         data_dir: PathBuf,
         broadcaster: Arc<dyn EventBroadcaster>,
         agent_registry: Arc<AgentRegistry>,
@@ -87,6 +89,7 @@ impl JobExecutor {
             conversation_repo,
             conversation_service,
             busy_guard,
+            work_dir,
             data_dir,
             broadcaster,
             agent_registry,
@@ -428,7 +431,7 @@ impl JobExecutor {
             .unwrap_or_default();
 
         if response_workspace.is_empty() {
-            let fallback_workspace = default_temp_workspace_path(&self.data_dir, &agent_type, job, &response.id);
+            let fallback_workspace = default_temp_workspace_path(&self.work_dir, &agent_type, job, &response.id);
             std::fs::create_dir_all(&fallback_workspace).map_err(|err| {
                 CronError::Scheduler(format!(
                     "create fallback cron workspace {}: {err}",
@@ -2120,6 +2123,7 @@ mod tests {
             conv_service,
             guard,
             std::env::temp_dir(),
+            std::env::temp_dir(),
             Arc::new(StubBroadcaster),
             agent_registry,
         )
@@ -2723,6 +2727,7 @@ mod tests {
             repo,
             conversation_service,
             Arc::new(CronBusyGuard::new()),
+            std::env::temp_dir(),
             std::env::temp_dir(),
             broadcaster,
             agent_registry,

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -72,6 +72,7 @@ pub struct JobExecutor {
 }
 
 impl JobExecutor {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         task_manager: Arc<dyn IWorkerTaskManager>,
         conversation_repo: Arc<dyn IConversationRepository>,

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -567,6 +567,7 @@ async fn setup_with_conv_repo() -> (
         conv_service,
         busy_guard,
         data_dir.clone(),
+        data_dir.clone(),
         bc.clone() as Arc<dyn EventBroadcaster>,
         agent_registry,
     ));

--- a/crates/aionui-realtime/tests/handler_integration.rs
+++ b/crates/aionui-realtime/tests/handler_integration.rs
@@ -373,8 +373,6 @@ async fn multiple_concurrent_connections() {
 
     let mut handles = Vec::new();
     for _ in 0..10 {
-        #[allow(clippy::redundant_locals)] // rebind to Copy-move into async block
-        let addr = addr;
         handles.push(tokio::spawn(
             async move { connect_with_token(addr, "valid-token").await },
         ));


### PR DESCRIPTION
## Summary

- Add `--work-dir` CLI argument with priority: CLI > `AIONUI_WORK_DIR` env > `--data-dir` fallback
- Conversation workspaces now create under `work_dir/conversations/` instead of `data_dir/conversations/`
- Unify `AppServices` constructors into single `from_config()` method
- `JobExecutor` receives separate `work_dir` (workspace creation) and `data_dir` (skill file detection)

## Motivation

Users configure a working directory in settings, but the backend was incorrectly using `--data-dir` for workspace creation. This separates the concepts: `data-dir` holds internal app data (DB, skills, rules), while `work-dir` holds user-facing conversation workspaces.

## Test plan

- [x] 3 new integration tests (`work_dir_e2e.rs`): workspace path, user-specified workspace preserved, fallback behavior
- [x] All 5497 workspace tests pass (`just push` verified)
- [x] Manual E2E: `--work-dir`, env var fallback, data-dir fallback all verified via `/api/system/info`
- [x] Frontend `backend-launcher.ts` passes `--work-dir` from `dirs.workDir` (committed in AionUi repo)