### PR TITLE
fix(conversation): kill agent process on conversation delete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,7 @@ name = "aionui-common"
 version = "0.1.1"
 dependencies = [
  "aes-gcm",
+ "async-trait",
  "axum",
  "base64",
  "getrandom 0.2.17",

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -555,6 +555,7 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
             Some(AgentKillReason::IdleTimeout) => "Agent killed: idle timeout".to_owned(),
             Some(AgentKillReason::TeamMcpRebuild) => "Agent killed: team MCP rebuild".to_owned(),
             Some(AgentKillReason::TeamDeleted) => "Agent killed: team deleted".to_owned(),
+            Some(AgentKillReason::ConversationDeleted) => "Agent killed: conversation deleted".to_owned(),
             None => "Agent killed".to_owned(),
         };
         self.runtime.emit_error(message);

--- a/crates/aionui-ai-agent/src/task_manager.rs
+++ b/crates/aionui-ai-agent/src/task_manager.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
-use aionui_common::{AgentKillReason, AgentType, AppError, ConversationStatus, TimestampMs, now_ms};
+use aionui_common::{
+    AgentKillReason, AgentType, AppError, ConversationStatus, ErrorChain, OnConversationDelete, TimestampMs, now_ms,
+};
 use async_trait::async_trait;
 use dashmap::DashMap;
 use futures_util::future::BoxFuture;
 use tokio::sync::OnceCell;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::agent_task::AgentInstance;
 use crate::types::BuildTaskOptions;
@@ -174,6 +176,23 @@ impl IWorkerTaskManager for WorkerTaskManagerImpl {
                     .then(|| entry.key().clone())
             })
             .collect()
+    }
+}
+
+/// Wired up by `aionui-app` so deleting a conversation tears down its
+/// agent process. Without this hook, ACP/aionrs/nanobot subprocesses keep
+/// streaming events for a `conversation_id` whose DB row is already gone
+/// (Sentry ELECTRON-1BD).
+#[async_trait]
+impl OnConversationDelete for WorkerTaskManagerImpl {
+    async fn on_conversation_deleted(&self, conversation_id: &str) {
+        if let Err(e) = self.kill(conversation_id, Some(AgentKillReason::ConversationDeleted)) {
+            warn!(
+                conversation_id,
+                error = %ErrorChain(&e),
+                "Failed to kill agent task on conversation delete (non-fatal)",
+            );
+        }
     }
 }
 

--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -31,6 +31,7 @@ use aionui_auth::{
 #[cfg(feature = "weixin")]
 use aionui_channel::weixin_login_route;
 use aionui_channel::{ChannelRouterState, channel_routes};
+use aionui_common::OnConversationDelete;
 use aionui_conversation::{ConversationRouterState, conversation_ops_routes, conversation_routes};
 use aionui_cron::{CronRouterState, cron_routes};
 use aionui_db::{
@@ -101,6 +102,11 @@ pub struct AppServices {
     pub ws_manager: Arc<WebSocketManager>,
     pub event_bus: Arc<BroadcastEventBus>,
     pub worker_task_manager: Arc<dyn IWorkerTaskManager>,
+    /// Same instance as `worker_task_manager`, exposed through the
+    /// `OnConversationDelete` trait so `ConversationService::with_delete_hook`
+    /// can wire it up. Optional because tests construct `AppServices` with a
+    /// mock `worker_task_manager` that does not implement the trait.
+    pub task_manager_delete_hook: Option<Arc<dyn OnConversationDelete>>,
     pub agent_registry: Arc<AgentRegistry>,
     pub conversation_repo: Arc<dyn IConversationRepository>,
     pub acp_session_sync: Arc<AcpSessionSyncService>,
@@ -238,7 +244,9 @@ impl AppServices {
         // Agent factory is now wired. Future extension/custom agents
         // that get written to `agent_metadata` will show up after the
         // relevant service calls `AgentRegistry::hydrate`.
-        let worker_task_manager: Arc<dyn IWorkerTaskManager> = Arc::new(WorkerTaskManagerImpl::new(factory));
+        let task_manager_concrete = Arc::new(WorkerTaskManagerImpl::new(factory));
+        let worker_task_manager: Arc<dyn IWorkerTaskManager> = task_manager_concrete.clone();
+        let task_manager_delete_hook: Arc<dyn OnConversationDelete> = task_manager_concrete;
 
         Ok(Self {
             database,
@@ -249,6 +257,7 @@ impl AppServices {
             ws_manager: Arc::new(WebSocketManager::new()),
             event_bus: Arc::new(BroadcastEventBus::new(256)),
             worker_task_manager,
+            task_manager_delete_hook: Some(task_manager_delete_hook),
             agent_registry,
             conversation_repo,
             acp_session_sync: acp_agent_service,

--- a/crates/aionui-app/src/state_builders.rs
+++ b/crates/aionui-app/src/state_builders.rs
@@ -164,7 +164,11 @@ pub fn build_conversation_state(
         agent_metadata_repo,
         acp_session_repo,
     );
+    if let Some(hook) = services.task_manager_delete_hook.clone() {
+        conversation_service.with_delete_hook(hook);
+    }
     if let Some(cron_service) = cron_service {
+        conversation_service.with_delete_hook(cron_service.clone());
         conversation_service.with_cron_service(Some(cron_service));
     }
     ConversationRouterState {
@@ -301,6 +305,9 @@ pub async fn build_channel_state(
         agent_metadata_repo,
         acp_session_repo,
     ));
+    if let Some(hook) = services.task_manager_delete_hook.clone() {
+        conversation_svc.with_delete_hook(hook);
+    }
 
     let owner_user_id = services
         .user_repo
@@ -376,7 +383,11 @@ pub fn build_team_state(
         agent_metadata_repo,
         acp_session_repo,
     );
+    if let Some(hook) = services.task_manager_delete_hook.clone() {
+        conv_service.with_delete_hook(hook);
+    }
     if let Some(cron_service) = cron_service {
+        conv_service.with_delete_hook(cron_service.clone());
         conv_service.with_cron_service(Some(cron_service));
     }
     let service = TeamSessionService::new(

--- a/crates/aionui-common/Cargo.toml
+++ b/crates/aionui-common/Cargo.toml
@@ -9,6 +9,7 @@ serde = { workspace = true }
 serde_json.workspace = true
 uuid.workspace = true
 aes-gcm.workspace = true
+async-trait.workspace = true
 axum.workspace = true
 base64.workspace = true
 getrandom.workspace = true

--- a/crates/aionui-common/src/enums.rs
+++ b/crates/aionui-common/src/enums.rs
@@ -211,6 +211,10 @@ pub enum AgentKillReason {
     /// Team is being deleted; every agent process under it must be torn
     /// down before the team's conversations / rows are removed.
     TeamDeleted,
+    /// The owning conversation was deleted via `DELETE /api/conversations/{id}`.
+    /// The agent process must be torn down so it stops emitting stream events
+    /// for a conversation row that no longer exists.
+    ConversationDeleted,
 }
 
 /// Preview content type for document preview history.

--- a/crates/aionui-common/src/hooks.rs
+++ b/crates/aionui-common/src/hooks.rs
@@ -1,0 +1,19 @@
+//! Cross-crate lifecycle hook traits.
+//!
+//! Hooks defined here let lower-layer crates (e.g. `aionui-ai-agent`,
+//! `aionui-cron`) react to events owned by higher-layer crates (e.g.
+//! `aionui-conversation`) without forming a dependency cycle.
+
+use async_trait::async_trait;
+
+/// Notified when a conversation row is deleted via
+/// `ConversationService::delete`.
+///
+/// Implementors are responsible for cleaning up their per-conversation state
+/// (kill agent processes, drop cron jobs, etc.). Hooks run sequentially in
+/// registration order; failures must be logged inside the hook and not
+/// propagated.
+#[async_trait]
+pub trait OnConversationDelete: Send + Sync {
+    async fn on_conversation_deleted(&self, conversation_id: &str);
+}

--- a/crates/aionui-common/src/lib.rs
+++ b/crates/aionui-common/src/lib.rs
@@ -5,6 +5,7 @@ mod case_convert;
 mod crypto;
 mod enums;
 mod error;
+mod hooks;
 mod id;
 mod pagination;
 mod timestamp;
@@ -18,6 +19,7 @@ pub use enums::{
     RemoteAgentProtocol, RemoteAgentStatus,
 };
 pub use error::{AppError, ErrorChain};
+pub use hooks::OnConversationDelete;
 pub use id::{fnv1a_hex8, generate_id, generate_id_with_length, generate_prefixed_id, generate_short_id};
 pub use pagination::PaginatedResult;
 pub use timestamp::{TimestampMs, now_ms};

--- a/crates/aionui-conversation/src/lib.rs
+++ b/crates/aionui-conversation/src/lib.rs
@@ -16,7 +16,7 @@ pub use response_middleware::{
 };
 pub use routes::conversation_routes;
 pub use routes_aux::conversation_ops_routes;
-pub use service::{ConversationService, OnConversationDelete};
+pub use service::ConversationService;
 pub use state::ConversationRouterState;
 
 #[cfg(test)]

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -13,7 +13,8 @@ use aionui_api_types::{
     WebSocketMessage,
 };
 use aionui_common::{
-    AgentType, AppError, ConversationSource, ConversationStatus, ErrorChain, PaginatedResult, generate_short_id, now_ms,
+    AgentType, AppError, ConversationSource, ConversationStatus, ErrorChain, OnConversationDelete, PaginatedResult,
+    generate_short_id, now_ms,
 };
 use aionui_db::models::MessageRow;
 use aionui_db::{
@@ -34,18 +35,18 @@ use std::sync::RwLock;
 
 const MAX_CRON_CONTINUATIONS_PER_TURN: usize = 4;
 
-#[async_trait::async_trait]
-pub trait OnConversationDelete: Send + Sync {
-    async fn on_conversation_deleted(&self, conversation_id: &str);
-}
-
 #[derive(Clone)]
 pub struct ConversationService {
     workspace_root: std::path::PathBuf,
     broadcaster: Arc<dyn EventBroadcaster>,
     skill_resolver: Arc<dyn SkillResolver>,
     task_manager: Arc<dyn IWorkerTaskManager>,
-    delete_hooks: Vec<Arc<dyn OnConversationDelete>>,
+    /// Hooks invoked at the end of `delete()` so other services
+    /// (`WorkerTaskManagerImpl`, `CronService`, …) can clean up their
+    /// per-conversation state. Wrapped in `Arc<RwLock<…>>` so registration
+    /// can happen post-construction without breaking the `Clone` impl —
+    /// mirrors the `cron_service` slot pattern below.
+    delete_hooks: Arc<RwLock<Vec<Arc<dyn OnConversationDelete>>>>,
     cron_service: Arc<RwLock<Option<Arc<dyn ICronService>>>>,
 
     // Repos for conversation, acp_session and agent_metadata access.
@@ -72,7 +73,7 @@ impl ConversationService {
             broadcaster,
             skill_resolver,
             task_manager,
-            delete_hooks: Vec::new(),
+            delete_hooks: Arc::new(RwLock::new(Vec::new())),
             cron_service: Arc::new(RwLock::new(None)),
 
             conversation_repo,
@@ -84,6 +85,17 @@ impl ConversationService {
     pub fn with_cron_service(&self, cron_service: Option<Arc<dyn ICronService>>) {
         if let Ok(mut guard) = self.cron_service.write() {
             *guard = cron_service;
+        }
+    }
+
+    /// Register a hook to be notified when a conversation is deleted.
+    ///
+    /// Hooks are dispatched sequentially in registration order from
+    /// `delete()`. Used by `aionui-app` to wire up `WorkerTaskManagerImpl`
+    /// (kill the agent process) and `CronService` (cascade-delete cron jobs).
+    pub fn with_delete_hook(&self, hook: Arc<dyn OnConversationDelete>) {
+        if let Ok(mut guard) = self.delete_hooks.write() {
+            guard.push(hook);
         }
     }
 
@@ -608,7 +620,12 @@ impl ConversationService {
             );
         }
 
-        for hook in &self.delete_hooks {
+        // Snapshot the hook list under the read lock, then drop the guard
+        // before awaiting — `RwLockReadGuard` is not `Send`, so holding it
+        // across `.await` would make this future non-`Send`.
+        let hooks: Vec<Arc<dyn OnConversationDelete>> =
+            self.delete_hooks.read().map(|guard| guard.clone()).unwrap_or_default();
+        for hook in hooks {
             hook.on_conversation_deleted(id).await;
         }
 

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -783,6 +783,29 @@ async fn delete_not_found() {
     assert!(matches!(err, AppError::NotFound(_)));
 }
 
+#[tokio::test]
+async fn delete_invokes_registered_hook() {
+    use aionui_common::OnConversationDelete;
+
+    struct RecordingHook(Mutex<Vec<String>>);
+    #[async_trait::async_trait]
+    impl OnConversationDelete for RecordingHook {
+        async fn on_conversation_deleted(&self, conversation_id: &str) {
+            self.0.lock().unwrap().push(conversation_id.to_owned());
+        }
+    }
+
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
+    let hook = Arc::new(RecordingHook(Mutex::new(vec![])));
+    svc.with_delete_hook(hook.clone());
+
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+    svc.delete("user_1", &conv.id).await.unwrap();
+
+    let calls = hook.0.lock().unwrap();
+    assert_eq!(calls.as_slice(), &[conv.id]);
+}
+
 // ── Broadcast payload tests ────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/aionui-cron/src/service.rs
+++ b/crates/aionui-cron/src/service.rs
@@ -814,7 +814,7 @@ impl CronService {
 // ---------------------------------------------------------------------------
 
 #[async_trait::async_trait]
-impl aionui_conversation::OnConversationDelete for CronService {
+impl aionui_common::OnConversationDelete for CronService {
     async fn on_conversation_deleted(&self, conversation_id: &str) {
         self.delete_jobs_by_conversation(conversation_id).await;
     }

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -1591,7 +1591,7 @@ async fn cd2_cascade_delete_no_matching_jobs() {
 
 #[tokio::test]
 async fn cd3_on_conversation_delete_trait() {
-    use aionui_conversation::OnConversationDelete;
+    use aionui_common::OnConversationDelete;
 
     let (svc, _repo, bc) = setup().await;
 


### PR DESCRIPTION
## Summary

- Fixes Sentry **ELECTRON-1BD** — deleting a conversation while its agent was streaming left the ACP/aionrs/nanobot subprocess running and pushing `message.stream` events for a row that no longer existed.
- Wires up the existing `OnConversationDelete` hook plumbing that was dead code: the `delete_hooks` field had no setter, so neither the task manager nor the cron-cascade hook ever ran in production.
- Moves the trait into `aionui-common` (avoids `aionui-ai-agent` → `aionui-conversation` cycle), implements it on `WorkerTaskManagerImpl`, exposes `ConversationService::with_delete_hook`, and registers both the task manager and the cron service from `state_builders`. Adds `AgentKillReason::ConversationDeleted` so the terminal-event message reflects the kill cause.

## Test plan

- [x] `cargo build -p aionui-common -p aionui-conversation -p aionui-ai-agent -p aionui-cron -p aionui-app`
- [x] `cargo clippy -p ... -- -D warnings` (no warnings)
- [x] `cargo test -p aionui-common -p aionui-conversation -p aionui-ai-agent -p aionui-cron -p aionui-app` (all green)
- [x] New unit test `delete_invokes_registered_hook` in `aionui-conversation/src/service_test.rs` proves the hook dispatch path
- [x] Existing `cd3_on_conversation_delete_trait` cron integration test still passes (trait import path migrated)
- [ ] Manual: start backend, create an ACP conversation, send a long prompt, delete the conversation while it's streaming → verify the agent CLI process is killed and `message.stream` stops