### PR TITLE
fix(ai-agent): surface upstream ACP error messages without status prefix

### DIFF
--- a/crates/aionui-ai-agent/src/capability/cli_process/mod.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/mod.rs
@@ -200,6 +200,33 @@ impl CliAgentProcess {
         let mut buf = self.stderr_buffer.lock().await;
         std::mem::take(&mut *buf)
     }
+
+    /// Peek the last `max_lines` newline-delimited lines from the stderr ring
+    /// buffer **without draining**.
+    ///
+    /// Used by error-augmentation paths (`AcpAgentManager::send_message`) that
+    /// need to surface tracing-level error context the SDK didn't include in
+    /// its JSON-RPC response. Returns an owned `String` so the buffer mutex
+    /// is released immediately.
+    ///
+    /// `max_lines == 0` returns an empty string. Trailing newline (if any) is
+    /// preserved — the caller may trim if they care.
+    #[allow(dead_code)] // Called by error-augmentation path in AcpAgentManager::send_message (Task 5)
+    pub async fn peek_stderr_tail(&self, max_lines: usize) -> String {
+        if max_lines == 0 {
+            return String::new();
+        }
+        let buf = self.stderr_buffer.lock().await;
+        let trimmed = buf.trim_end_matches('\n');
+        if trimmed.is_empty() {
+            return String::new();
+        }
+        // `rsplit('\n')` walks lines from the end. Take up to `max_lines`,
+        // then re-collect into the original top-to-bottom order.
+        let mut tail: Vec<&str> = trimmed.rsplit('\n').take(max_lines).collect();
+        tail.reverse();
+        tail.join("\n")
+    }
 }
 
 #[cfg(test)]

--- a/crates/aionui-ai-agent/src/capability/cli_process/mod.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/mod.rs
@@ -206,11 +206,12 @@ impl CliAgentProcess {
     ///
     /// Used by error-augmentation paths (`AcpAgentManager::send_message`) that
     /// need to surface tracing-level error context the SDK didn't include in
-    /// its JSON-RPC response. Returns an owned `String` so the buffer mutex
-    /// is released immediately.
+    /// its JSON-RPC response. Returns an owned `String`; the buffer lock is
+    /// held for the duration of this call (microseconds at the bounded sizes
+    /// we read) and dropped before the result is returned.
     ///
-    /// `max_lines == 0` returns an empty string. Trailing newline (if any) is
-    /// preserved — the caller may trim if they care.
+    /// `max_lines == 0` returns an empty string. The returned string has no
+    /// trailing newline — the caller may append one if they want.
     #[allow(dead_code)] // Called by error-augmentation path in AcpAgentManager::send_message (Task 5)
     pub async fn peek_stderr_tail(&self, max_lines: usize) -> String {
         if max_lines == 0 {

--- a/crates/aionui-ai-agent/src/capability/cli_process/stderr_monitor.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/stderr_monitor.rs
@@ -73,9 +73,7 @@ mod tests {
 
     #[tokio::test]
     async fn peek_stderr_tail_returns_last_n_lines() {
-        let config = simple_script_config(
-            "for i in 1 2 3 4 5; do echo \"line $i\" >&2; done",
-        );
+        let config = simple_script_config("for i in 1 2 3 4 5; do echo \"line $i\" >&2; done");
         let proc = CliAgentProcess::spawn(config).await.unwrap();
 
         timeout(Duration::from_secs(5), proc.wait_for_exit()).await.unwrap();

--- a/crates/aionui-ai-agent/src/capability/cli_process/stderr_monitor.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/stderr_monitor.rs
@@ -70,4 +70,51 @@ mod tests {
         let second = proc.take_stderr().await;
         assert!(second.is_empty(), "Second take should be empty");
     }
+
+    #[tokio::test]
+    async fn peek_stderr_tail_returns_last_n_lines() {
+        let config = simple_script_config(
+            "for i in 1 2 3 4 5; do echo \"line $i\" >&2; done",
+        );
+        let proc = CliAgentProcess::spawn(config).await.unwrap();
+
+        timeout(Duration::from_secs(5), proc.wait_for_exit()).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let tail = proc.peek_stderr_tail(3).await;
+        // Last three lines, in original order.
+        assert!(tail.contains("line 3"), "tail: {tail}");
+        assert!(tail.contains("line 4"), "tail: {tail}");
+        assert!(tail.contains("line 5"), "tail: {tail}");
+        assert!(!tail.contains("line 1"), "tail must drop earliest line; got {tail}");
+        assert!(!tail.contains("line 2"), "tail must drop earliest line; got {tail}");
+    }
+
+    #[tokio::test]
+    async fn peek_stderr_tail_does_not_drain() {
+        let config = simple_script_config("echo 'first' >&2 && echo 'second' >&2");
+        let proc = CliAgentProcess::spawn(config).await.unwrap();
+
+        timeout(Duration::from_secs(5), proc.wait_for_exit()).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let peek1 = proc.peek_stderr_tail(10).await;
+        let peek2 = proc.peek_stderr_tail(10).await;
+        assert_eq!(peek1, peek2, "peek must be idempotent");
+
+        let drained = proc.take_stderr().await;
+        assert!(drained.contains("first"));
+        assert!(drained.contains("second"));
+    }
+
+    #[tokio::test]
+    async fn peek_stderr_tail_zero_returns_empty() {
+        let config = simple_script_config("echo 'noise' >&2");
+        let proc = CliAgentProcess::spawn(config).await.unwrap();
+
+        timeout(Duration::from_secs(5), proc.wait_for_exit()).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert_eq!(proc.peek_stderr_tail(0).await, "");
+    }
 }

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -37,9 +37,7 @@ fn user_facing_message(err: &AppError) -> String {
     // Each variant's Display starts with `"<Tag>: "`. Find the first ": " and
     // return what follows. Variants without a colon (e.g. `RateLimited` →
     // "Rate limited") fall through to the full string.
-    full.split_once(": ")
-        .map(|(_, rest)| rest.to_owned())
-        .unwrap_or(full)
+    full.split_once(": ").map(|(_, rest)| rest.to_owned()).unwrap_or(full)
 }
 
 use super::mode_normalize::normalize_requested_mode;
@@ -648,8 +646,7 @@ impl AcpAgentManager {
         // Examples that match:  "Bad gateway: Agent internal error (code -32603)"
         //                       "Bad gateway: Agent internal error (code -32099)"
         // Do NOT match anything that has a real upstream message after the prefix.
-        let is_default_internal =
-            display.starts_with(SDK_DEFAULT_BAD_GATEWAY_PREFIX) && display.ends_with(')');
+        let is_default_internal = display.starts_with(SDK_DEFAULT_BAD_GATEWAY_PREFIX) && display.ends_with(')');
         if !is_default_internal {
             return None;
         }
@@ -669,10 +666,7 @@ mod tests {
     #[test]
     fn strips_bad_gateway_prefix() {
         let err = AppError::BadGateway("API Error: Internal server error".into());
-        assert_eq!(
-            user_facing_message(&err),
-            "API Error: Internal server error"
-        );
+        assert_eq!(user_facing_message(&err), "API Error: Internal server error");
     }
 
     #[test]
@@ -732,14 +726,10 @@ mod tests {
         Arc::new(proc)
     }
 
-    async fn augment_via_process(
-        proc: &Arc<CliAgentProcess>,
-        err: &AppError,
-    ) -> Option<String> {
+    async fn augment_via_process(proc: &Arc<CliAgentProcess>, err: &AppError) -> Option<String> {
         const SDK_DEFAULT_BAD_GATEWAY_PREFIX: &str = "Bad gateway: Agent internal error (code ";
         let display = err.to_string();
-        let is_default_internal =
-            display.starts_with(SDK_DEFAULT_BAD_GATEWAY_PREFIX) && display.ends_with(')');
+        let is_default_internal = display.starts_with(SDK_DEFAULT_BAD_GATEWAY_PREFIX) && display.ends_with(')');
         if !is_default_internal {
             return None;
         }
@@ -763,9 +753,7 @@ mod tests {
     async fn does_not_augment_when_message_is_specific() {
         // 1BF case: SDK already gave us a real message → don't second-guess.
         let proc = spawn_with_stderr("ERROR something: usage limit exceeded").await;
-        let err = AppError::BadGateway(
-            "Internal error: API Error: Internal server error".into(),
-        );
+        let err = AppError::BadGateway("Internal error: API Error: Internal server error".into());
 
         assert!(augment_via_process(&proc, &err).await.is_none());
     }

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -614,7 +614,7 @@ impl AcpAgentManager {
 }
 
 #[cfg(test)]
-mod user_facing_message_tests {
+mod tests {
     use super::user_facing_message;
     use aionui_common::AppError;
 

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -515,8 +515,14 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
                 self.runtime.emit_finish(None);
             }
             Err(err) => {
-                warn!(error = %ErrorChain(err), "ACP send_message failed");
-                self.runtime.emit_error(user_facing_message(err));
+                let augmented = self.augment_with_stderr(err).await;
+                if let Some(d) = augmented.as_deref() {
+                    warn!(error = %ErrorChain(err), augmented = %d, "ACP send_message failed");
+                } else {
+                    warn!(error = %ErrorChain(err), "ACP send_message failed");
+                }
+                let payload = augmented.unwrap_or_else(|| user_facing_message(err));
+                self.runtime.emit_error(payload);
             }
         }
         result
@@ -613,6 +619,40 @@ impl AcpAgentManager {
     }
 }
 
+impl AcpAgentManager {
+    /// If `err` is the "SDK gave us default Internal error with no data" shape,
+    /// peek the child's recent stderr and try to surface a more informative
+    /// message. Returns `None` when augmentation does not apply or finds nothing.
+    ///
+    /// Why string-matching: `AppError::BadGateway(String)` has discarded the
+    /// structured `AcpError` by the time we see it. The default-message
+    /// signature is narrow and stable enough that matching on the inner string
+    /// is cheaper than threading typed errors through the manager API. Keep
+    /// this in sync with `AcpError::Display` in
+    /// `crates/aionui-ai-agent/src/protocol/error.rs` if its fallback wording
+    /// changes.
+    async fn augment_with_stderr(&self, err: &AppError) -> Option<String> {
+        const SDK_DEFAULT_BAD_GATEWAY_PREFIX: &str = "Bad gateway: Agent internal error (code ";
+
+        let display = err.to_string();
+        // Match the Display produced by Task 1 for `AgentInternal { message=SDK
+        // default, data=None }` after wrapping in `AppError::BadGateway`.
+        // Examples that match:  "Bad gateway: Agent internal error (code -32603)"
+        //                       "Bad gateway: Agent internal error (code -32099)"
+        // Do NOT match anything that has a real upstream message after the prefix.
+        let is_default_internal =
+            display.starts_with(SDK_DEFAULT_BAD_GATEWAY_PREFIX) && display.ends_with(')');
+        if !is_default_internal {
+            return None;
+        }
+
+        // Read the last 32 lines of the child's stderr (cheap; ring buffer is
+        // bounded to 8 KiB ≈ a few hundred lines max).
+        let tail = self.process.peek_stderr_tail(32).await;
+        super::stderr_error_extractor::extract_error_message(&tail)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::user_facing_message;
@@ -647,5 +687,86 @@ mod tests {
             user_facing_message(&err),
             "Internal error: API Error: Internal server error"
         );
+    }
+
+    // ---- augment_with_stderr behavioral tests ------------------------------
+    //
+    // We can't easily construct a real AcpAgentManager in a unit test (it
+    // needs the full ACP plumbing). Instead we test the *composition* of
+    // Task 3's peek_stderr_tail + Task 4's extract_error_message + this
+    // task's "SDK default Display" shape detection by spawning a real
+    // CliAgentProcess that writes the chosen stderr, then running the same
+    // detection+peek+extract pipeline against it.
+    //
+    // The helper below MIRRORS `AcpAgentManager::augment_with_stderr`. If
+    // you change the production helper (e.g. the prefix string, peek line
+    // count, or extractor module path) update this helper to match.
+
+    use super::CliAgentProcess;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    async fn spawn_with_stderr(stderr_payload: &str) -> Arc<CliAgentProcess> {
+        use aionui_common::CommandSpec;
+        // Heredoc lets us embed apostrophes etc. without quoting headaches.
+        let script = format!("cat <<'EOF' >&2\n{stderr_payload}\nEOF");
+        let config = CommandSpec {
+            command: "sh".into(),
+            args: vec!["-c".into(), script],
+            env: vec![],
+            cwd: None,
+        };
+        let proc = CliAgentProcess::spawn(config).await.unwrap();
+        tokio::time::timeout(Duration::from_secs(5), proc.wait_for_exit())
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        Arc::new(proc)
+    }
+
+    async fn augment_via_process(
+        proc: &Arc<CliAgentProcess>,
+        err: &AppError,
+    ) -> Option<String> {
+        const SDK_DEFAULT_BAD_GATEWAY_PREFIX: &str = "Bad gateway: Agent internal error (code ";
+        let display = err.to_string();
+        let is_default_internal =
+            display.starts_with(SDK_DEFAULT_BAD_GATEWAY_PREFIX) && display.ends_with(')');
+        if !is_default_internal {
+            return None;
+        }
+        let tail = proc.peek_stderr_tail(32).await;
+        super::super::stderr_error_extractor::extract_error_message(&tail)
+    }
+
+    #[tokio::test]
+    async fn augments_when_codex_usage_limit_in_stderr() {
+        let stderr = "\u{1b}[2m2026-05-13T20:01:21Z\u{1b}[0m \u{1b}[31mERROR\u{1b}[0m codex_acp::thread: Unhandled error during turn: You've hit your usage limit. Try again later. Some(UsageLimitExceeded)";
+        let proc = spawn_with_stderr(stderr).await;
+        let err = AppError::BadGateway("Agent internal error (code -32603)".into());
+
+        let augmented = augment_via_process(&proc, &err).await;
+        let msg = augmented.expect("must augment when stderr matches allowlist");
+        assert!(msg.to_lowercase().contains("usage limit"), "got {msg}");
+    }
+
+    #[tokio::test]
+    async fn does_not_augment_when_message_is_specific() {
+        // 1BF case: SDK already gave us a real message → don't second-guess.
+        let proc = spawn_with_stderr("ERROR something: usage limit exceeded").await;
+        let err = AppError::BadGateway(
+            "Internal error: API Error: Internal server error".into(),
+        );
+
+        assert!(augment_via_process(&proc, &err).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn returns_none_when_stderr_has_no_allowlisted_keywords() {
+        let stderr = "ERROR widget_loader: failed to load module 'foo'";
+        let proc = spawn_with_stderr(stderr).await;
+        let err = AppError::BadGateway("Agent internal error (code -32603)".into());
+
+        assert!(augment_via_process(&proc, &err).await.is_none());
     }
 }

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -633,10 +633,18 @@ impl AcpAgentManager {
     /// changes.
     async fn augment_with_stderr(&self, err: &AppError) -> Option<String> {
         const SDK_DEFAULT_BAD_GATEWAY_PREFIX: &str = "Bad gateway: Agent internal error (code ";
+        /// How many trailing stderr lines we hand to the extractor.
+        /// 32 lines is well below the 8 KiB ring-buffer cap and comfortably
+        /// covers a tracing event with its preceding context.
+        const STDERR_PEEK_LINES: usize = 32;
 
         let display = err.to_string();
-        // Match the Display produced by Task 1 for `AgentInternal { message=SDK
-        // default, data=None }` after wrapping in `AppError::BadGateway`.
+        // Match the Display produced by Task 1 for `AgentInternal` whenever the
+        // SDK gave us its default "Internal error" message — with or without
+        // `data`. When `data=Some`, Display ends in ") ({json})" which still
+        // satisfies `ends_with(')')`, so we augment in that case too. That is
+        // intentional: stderr context is generally more user-friendly than the
+        // raw `data` JSON, and the operator log retains both via `ErrorChain`.
         // Examples that match:  "Bad gateway: Agent internal error (code -32603)"
         //                       "Bad gateway: Agent internal error (code -32099)"
         // Do NOT match anything that has a real upstream message after the prefix.
@@ -646,9 +654,9 @@ impl AcpAgentManager {
             return None;
         }
 
-        // Read the last 32 lines of the child's stderr (cheap; ring buffer is
-        // bounded to 8 KiB ≈ a few hundred lines max).
-        let tail = self.process.peek_stderr_tail(32).await;
+        // Read the last STDERR_PEEK_LINES lines of the child's stderr (cheap;
+        // ring buffer is bounded to 8 KiB ≈ a few hundred lines max).
+        let tail = self.process.peek_stderr_tail(STDERR_PEEK_LINES).await;
         super::stderr_error_extractor::extract_error_message(&tail)
     }
 }
@@ -735,6 +743,7 @@ mod tests {
         if !is_default_internal {
             return None;
         }
+        // Mirror the production STDERR_PEEK_LINES (32). If you change one, change both.
         let tail = proc.peek_stderr_tail(32).await;
         super::super::stderr_error_extractor::extract_error_message(&tail)
     }

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -25,6 +25,23 @@ use std::time::Duration;
 use tokio::sync::{Mutex, RwLock, broadcast, mpsc};
 use tracing::{debug, error, info, warn};
 
+/// The user-visible body inside an [`AppError`].
+///
+/// `AppError`'s `Display` prefixes every variant with its HTTP status name
+/// (`"Bad gateway: ..."`, `"Not found: ..."`, etc.). That's correct for HTTP
+/// response bodies, but the WebSocket `error` event we broadcast goes straight
+/// to the renderer and gets shown verbatim — the prefix only adds noise. Strip
+/// it so the user sees the upstream message.
+fn user_facing_message(err: &AppError) -> String {
+    let full = err.to_string();
+    // Each variant's Display starts with `"<Tag>: "`. Find the first ": " and
+    // return what follows. Variants without a colon (e.g. `RateLimited` →
+    // "Rate limited") fall through to the full string.
+    full.split_once(": ")
+        .map(|(_, rest)| rest.to_owned())
+        .unwrap_or(full)
+}
+
 use super::mode_normalize::normalize_requested_mode;
 
 /// Grace period before force-killing an ACP process (ms).
@@ -499,7 +516,7 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
             }
             Err(err) => {
                 warn!(error = %ErrorChain(err), "ACP send_message failed");
-                self.runtime.emit_error(err.to_string());
+                self.runtime.emit_error(user_facing_message(err));
             }
         }
         result
@@ -593,5 +610,42 @@ impl AcpAgentManager {
 
         self.permission_router
             .confirm(call_id, option_id, &self.params.conversation_id)
+    }
+}
+
+#[cfg(test)]
+mod user_facing_message_tests {
+    use super::user_facing_message;
+    use aionui_common::AppError;
+
+    #[test]
+    fn strips_bad_gateway_prefix() {
+        let err = AppError::BadGateway("API Error: Internal server error".into());
+        assert_eq!(
+            user_facing_message(&err),
+            "API Error: Internal server error"
+        );
+    }
+
+    #[test]
+    fn strips_not_found_prefix() {
+        let err = AppError::NotFound("user 42".into());
+        assert_eq!(user_facing_message(&err), "user 42");
+    }
+
+    #[test]
+    fn rate_limited_has_no_colon_returns_full_string() {
+        let err = AppError::RateLimited;
+        assert_eq!(user_facing_message(&err), "Rate limited");
+    }
+
+    #[test]
+    fn nested_colons_only_strip_first() {
+        // "Bad gateway: Internal error: API Error: ..." → keep everything after the first ": "
+        let err = AppError::BadGateway("Internal error: API Error: Internal server error".into());
+        assert_eq!(
+            user_facing_message(&err),
+            "Internal error: API Error: Internal server error"
+        );
     }
 }

--- a/crates/aionui-ai-agent/src/manager/acp/mod.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/mod.rs
@@ -7,6 +7,7 @@ pub mod hooks;
 mod mode_normalize;
 pub mod permission_router;
 pub mod session;
+mod stderr_error_extractor;
 
 pub use agent::AcpAgentManager;
 pub use agent_event_tracker::AcpSessionEvent;

--- a/crates/aionui-ai-agent/src/manager/acp/stderr_error_extractor.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/stderr_error_extractor.rs
@@ -81,7 +81,6 @@ fn matches_allowlist(line_lower: &str) -> bool {
 ///
 /// Returns `None` if nothing matches the allowlist — caller should keep its
 /// existing error message rather than substitute an empty string.
-#[allow(dead_code)]
 pub(super) fn extract_error_message(stderr_tail: &str) -> Option<String> {
     if stderr_tail.trim().is_empty() {
         return None;

--- a/crates/aionui-ai-agent/src/manager/acp/stderr_error_extractor.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/stderr_error_extractor.rs
@@ -136,10 +136,7 @@ mod tests {
         let result = extract_error_message(STDERR_USAGE_LIMIT);
         let msg = result.expect("usage limit must match");
         assert!(msg.contains("usage limit"), "got {msg}");
-        assert!(
-            !msg.contains("\u{1b}["),
-            "ANSI escapes must be stripped; got {msg:?}"
-        );
+        assert!(!msg.contains("\u{1b}["), "ANSI escapes must be stripped; got {msg:?}");
         assert!(
             !msg.contains("ERROR"),
             "tracing level prefix should not leak into user message; got {msg}"
@@ -206,7 +203,8 @@ mod tests {
     fn strips_ansi_then_keeps_only_message_after_last_colon() {
         // tracing format: "<timestamp> <LEVEL> <target>: <fields>: <message>"
         // We want just the message tail.
-        let stderr = "\u{1b}[2m2026-05-13T20:01:21Z\u{1b}[0m \u{1b}[31mERROR\u{1b}[0m foo::bar: ctx=abc: usage limit exceeded";
+        let stderr =
+            "\u{1b}[2m2026-05-13T20:01:21Z\u{1b}[0m \u{1b}[31mERROR\u{1b}[0m foo::bar: ctx=abc: usage limit exceeded";
         let result = extract_error_message(stderr).expect("must match");
         assert_eq!(result, "usage limit exceeded");
     }

--- a/crates/aionui-ai-agent/src/manager/acp/stderr_error_extractor.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/stderr_error_extractor.rs
@@ -1,0 +1,211 @@
+//! Extracts a user-facing error message from a CLI subprocess's recent stderr.
+//!
+//! ACP child processes (codex-acp, claude-acp, …) often emit important error
+//! context as `tracing` events to stderr **without** including it in the
+//! JSON-RPC error response we receive. This module turns the last few stderr
+//! lines into a single human-readable message, but only if the content
+//! matches an allowlisted error keyword — stderr is not a trusted source.
+//!
+//! Returns `None` whenever no allowlisted line is found; callers must keep
+//! their existing error string in that case.
+
+/// Allowlisted lowercase keywords. A stderr line is considered "user-relevant"
+/// only if it contains at least one of these (case-insensitive).
+///
+/// Order does not matter for matching, but keep this short and audited — every
+/// new entry expands what stderr content can reach end-users.
+const ERROR_KEYWORDS: &[&str] = &[
+    "usage limit",
+    "rate limit",
+    "exceeded",
+    "unauthorized",
+    "forbidden",
+    "network",
+    "timeout",
+    "connection refused",
+    "connection reset",
+    "tls",
+    "dns",
+    "credentials",
+    "api key",
+    "quota",
+    "billing",
+];
+
+const MAX_MESSAGE_CHARS: usize = 240;
+
+/// Strip ANSI CSI escape sequences (`\u{1b}[...m` and similar) from `s`.
+///
+/// Minimal implementation — handles the SGR (`m`) terminator that `tracing`'s
+/// ANSI subscriber uses. Other CSI commands (cursor moves etc.) are stripped
+/// the same way as long as they end in `[A-Za-z]`.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut iter = s.chars().peekable();
+    while let Some(c) = iter.next() {
+        if c == '\u{1b}' && matches!(iter.peek(), Some('[')) {
+            iter.next(); // consume '['
+            for ch in iter.by_ref() {
+                if ch.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Extract the user-relevant message tail from a single stripped tracing line.
+///
+/// Tracing format roughly: `<ts> <LEVEL> <target>{<fields>}: <message>`.
+/// We split on `": "` and take the last segment — that's almost always the
+/// message. Returns the trimmed segment.
+fn message_tail(stripped_line: &str) -> &str {
+    stripped_line
+        .rsplit_once(": ")
+        .map(|(_, tail)| tail)
+        .unwrap_or(stripped_line)
+        .trim()
+}
+
+fn matches_allowlist(line_lower: &str) -> bool {
+    ERROR_KEYWORDS.iter().any(|kw| line_lower.contains(kw))
+}
+
+/// Pick the most informative error line from a chunk of recent stderr.
+///
+/// Returns `None` if nothing matches the allowlist — caller should keep its
+/// existing error message rather than substitute an empty string.
+#[allow(dead_code)]
+pub(super) fn extract_error_message(stderr_tail: &str) -> Option<String> {
+    if stderr_tail.trim().is_empty() {
+        return None;
+    }
+
+    let lines: Vec<String> = stderr_tail
+        .lines()
+        .map(strip_ansi)
+        .map(|l| l.trim().to_owned())
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    // Pass 1: latest line whose stripped form contains "ERROR" AND matches the allowlist.
+    let mut chosen: Option<&str> = None;
+    for line in lines.iter().rev() {
+        let lower = line.to_lowercase();
+        if lower.contains("error") && matches_allowlist(&lower) {
+            chosen = Some(line.as_str());
+            break;
+        }
+    }
+    // Pass 2: latest line that matches the allowlist regardless of level (e.g. WARN).
+    if chosen.is_none() {
+        for line in lines.iter().rev() {
+            let lower = line.to_lowercase();
+            if matches_allowlist(&lower) {
+                chosen = Some(line.as_str());
+                break;
+            }
+        }
+    }
+
+    let line = chosen?;
+    let tail = message_tail(line);
+    let truncated: String = if tail.chars().count() > MAX_MESSAGE_CHARS {
+        let mut buf: String = tail.chars().take(MAX_MESSAGE_CHARS - 1).collect();
+        buf.push('…');
+        buf
+    } else {
+        tail.to_owned()
+    };
+    Some(truncated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_error_message;
+
+    const STDERR_USAGE_LIMIT: &str = "\u{1b}[2m2026-05-13T20:01:21.330370Z\u{1b}[0m \u{1b}[31mERROR\u{1b}[0m \u{1b}[2mcodex_acp::thread\u{1b}[0m\u{1b}[2m:\u{1b}[0m Unhandled error during turn: You've hit your usage limit. To get more access now, send a request to your admin or try again at May 14th, 2026 8:16 PM. Some(UsageLimitExceeded)";
+
+    #[test]
+    fn extracts_usage_limit_message() {
+        let result = extract_error_message(STDERR_USAGE_LIMIT);
+        let msg = result.expect("usage limit must match");
+        assert!(msg.contains("usage limit"), "got {msg}");
+        assert!(
+            !msg.contains("\u{1b}["),
+            "ANSI escapes must be stripped; got {msg:?}"
+        );
+        assert!(
+            !msg.contains("ERROR"),
+            "tracing level prefix should not leak into user message; got {msg}"
+        );
+    }
+
+    #[test]
+    fn returns_none_for_unrelated_stderr() {
+        // No allowlisted keywords → return None, do not pretend.
+        let stderr = "ERROR widget_loader: failed to load widget xyz";
+        assert!(extract_error_message(stderr).is_none());
+    }
+
+    #[test]
+    fn returns_none_for_empty_input() {
+        assert!(extract_error_message("").is_none());
+        assert!(extract_error_message("   \n\n  ").is_none());
+    }
+
+    #[test]
+    fn truncates_overlong_message_to_240_chars() {
+        let mut long = String::from("ERROR upstream: usage limit exceeded ");
+        long.push_str(&"x".repeat(500));
+        let result = extract_error_message(&long).expect("matched on usage limit");
+        assert!(
+            result.chars().count() <= 240,
+            "result must be ≤240 chars; got {} chars",
+            result.chars().count()
+        );
+    }
+
+    #[test]
+    fn prefers_error_over_warn_lines() {
+        let stderr = "WARN widget: usage limit warning happens\n\
+                      ERROR upstream: network connection refused\n\
+                      WARN cleanup: usage limit cleanup ran";
+        let result = extract_error_message(stderr).expect("ERROR line must match");
+        assert!(
+            result.contains("network connection refused"),
+            "ERROR line should win over WARN; got {result}"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_warn_when_no_matching_error() {
+        let stderr = "ERROR widget: something unrelated happened\n\
+                      WARN upstream: rate limit exceeded for token xyz";
+        let result = extract_error_message(stderr).expect("WARN match must surface");
+        assert!(result.contains("rate limit"), "got {result}");
+    }
+
+    #[test]
+    fn picks_latest_matching_line_when_multiple() {
+        let stderr = "ERROR upstream: connection timeout 1\n\
+                      ERROR upstream: connection timeout 2 (latest)";
+        let result = extract_error_message(stderr).expect("must match");
+        assert!(
+            result.contains("(latest)"),
+            "must pick the most recent matching line; got {result}"
+        );
+    }
+
+    #[test]
+    fn strips_ansi_then_keeps_only_message_after_last_colon() {
+        // tracing format: "<timestamp> <LEVEL> <target>: <fields>: <message>"
+        // We want just the message tail.
+        let stderr = "\u{1b}[2m2026-05-13T20:01:21Z\u{1b}[0m \u{1b}[31mERROR\u{1b}[0m foo::bar: ctx=abc: usage limit exceeded";
+        let result = extract_error_message(stderr).expect("must match");
+        assert_eq!(result, "usage limit exceeded");
+    }
+}

--- a/crates/aionui-ai-agent/src/manager/acp/stderr_error_extractor.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/stderr_error_extractor.rs
@@ -26,6 +26,9 @@ const ERROR_KEYWORDS: &[&str] = &[
     "connection reset",
     "tls",
     "dns",
+    // HIGH-RISK: may surface token/key values from stderr (e.g. "credentials:
+    // Bearer eyJ..."). The 240-char cap does not protect a 40-60 char secret.
+    // Keep matched lines out of operator logs that get exfiltrated.
     "credentials",
     "api key",
     "quota",
@@ -207,5 +210,14 @@ mod tests {
         let stderr = "\u{1b}[2m2026-05-13T20:01:21Z\u{1b}[0m \u{1b}[31mERROR\u{1b}[0m foo::bar: ctx=abc: usage limit exceeded";
         let result = extract_error_message(stderr).expect("must match");
         assert_eq!(result, "usage limit exceeded");
+    }
+
+    #[test]
+    fn handles_line_without_colon_separator() {
+        // Some logs aren't tracing-formatted; we should still surface the line
+        // when it matches the allowlist, instead of silently mangling it.
+        let stderr = "usage limit exceeded no colon here";
+        let result = extract_error_message(stderr).expect("should match");
+        assert_eq!(result, "usage limit exceeded no colon here");
     }
 }

--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -272,6 +272,7 @@ impl AcpProtocol {
         let raw = serde_json::value::to_raw_value(&value).map_err(|e| AcpError::AgentInternal {
             message: format!("Failed to convert ext response: {e}"),
             code: -32603,
+            data: None,
         })?;
         Ok(ExtResponse::new(raw.into()))
     }

--- a/crates/aionui-ai-agent/src/protocol/error.rs
+++ b/crates/aionui-ai-agent/src/protocol/error.rs
@@ -40,8 +40,10 @@ pub(crate) enum AcpError {
     InvalidParams { message: String },
 
     /// Agent reported an internal error. `data` carries the optional JSON-RPC
-    /// `error.data` payload from the agent — see [`AcpError::display`] for how
+    /// `error.data` payload from the agent — see the [`Display`] impl for how
     /// it is rendered.
+    ///
+    /// [`Display`]: std::fmt::Display
     AgentInternal {
         message: String,
         code: i32,
@@ -59,6 +61,10 @@ pub(crate) enum AcpError {
 /// JSON-RPC default message strings that carry no useful information.
 /// When `AgentInternal` arrives with one of these as its `message`, we fall
 /// back to a diagnostic display ("Agent internal error (code -32603)").
+///
+/// These strings are copied from `ErrorCode`'s `strum::Display` attributes in
+/// `agent-client-protocol-schema`. If the SDK changes them, update this list
+/// to avoid silently reverting to the diagnostic fallback.
 const SDK_DEFAULT_MESSAGES: &[&str] = &[
     "Parse error",
     "Invalid request",
@@ -106,6 +112,8 @@ impl std::fmt::Display for AcpError {
                     f.write_str(trimmed)?;
                 }
                 if let Some(data) = data {
+                    // serde_json::to_string on a Value cannot actually fail;
+                    // the fallback exists only because Display must be infallible.
                     let compact = serde_json::to_string(data)
                         .unwrap_or_else(|_| "<unserializable data>".to_owned());
                     write!(f, " ({compact})")?;
@@ -178,7 +186,7 @@ impl AcpError {
 /// leaves this crate.
 ///
 /// **Security:** `StartupCrash` and `Disconnected` contain `stderr` which may
-/// hold sensitive data. The `Display` impl (from `thiserror`) only includes
+/// hold sensitive data. The `Display` impl only includes
 /// `exit_code` and `signal`. `stderr` is available for structured logging
 /// (`tracing`) but never serialized into HTTP responses.
 impl From<AcpError> for AppError {
@@ -432,6 +440,33 @@ mod tests {
         assert!(
             display.contains("-32603"),
             "Display must include the JSON-RPC code as a diagnostic when message is empty/default; got {display}"
+        );
+    }
+
+    #[test]
+    fn agent_internal_display_appends_data_when_message_is_sdk_default() {
+        // Real-world shape: SDK returned its default `"Internal error"` but
+        // attached structured data. Display must use the diagnostic header
+        // AND append the data.
+        let err = AcpError::AgentInternal {
+            message: "Internal error".into(),
+            code: -32603,
+            data: Some(serde_json::json!({"retry_after": 30})),
+        };
+        let display = err.to_string();
+        assert!(
+            display.contains("Agent internal error"),
+            "header must use diagnostic fallback when message is the SDK default; got {display}"
+        );
+        assert!(
+            display.contains("-32603"),
+            "header must include the code; got {display}"
+        );
+        assert!(display.contains("retry_after"), "data must be appended; got {display}");
+        assert!(display.contains("30"), "data value must be appended; got {display}");
+        assert!(
+            !display.contains('\n'),
+            "data must be inline; got {display}"
         );
     }
 

--- a/crates/aionui-ai-agent/src/protocol/error.rs
+++ b/crates/aionui-ai-agent/src/protocol/error.rs
@@ -87,10 +87,7 @@ impl std::fmt::Display for AcpError {
                 )
             }
             AcpError::Disconnected { exit_code, signal, .. } => {
-                write!(
-                    f,
-                    "Agent process disconnected (exit={exit_code:?}, signal={signal:?})"
-                )
+                write!(f, "Agent process disconnected (exit={exit_code:?}, signal={signal:?})")
             }
             AcpError::AuthRequired => f.write_str("Authentication required"),
             AcpError::SessionNotFound { session_id } => {
@@ -104,8 +101,8 @@ impl std::fmt::Display for AcpError {
             }
             AcpError::AgentInternal { message, code, data } => {
                 let trimmed = message.trim();
-                let is_default = trimmed.is_empty()
-                    || SDK_DEFAULT_MESSAGES.iter().any(|d| d.eq_ignore_ascii_case(trimmed));
+                let is_default =
+                    trimmed.is_empty() || SDK_DEFAULT_MESSAGES.iter().any(|d| d.eq_ignore_ascii_case(trimmed));
                 if is_default {
                     write!(f, "Agent internal error (code {code})")?;
                 } else {
@@ -114,8 +111,7 @@ impl std::fmt::Display for AcpError {
                 if let Some(data) = data {
                     // serde_json::to_string on a Value cannot actually fail;
                     // the fallback exists only because Display must be infallible.
-                    let compact = serde_json::to_string(data)
-                        .unwrap_or_else(|_| "<unserializable data>".to_owned());
+                    let compact = serde_json::to_string(data).unwrap_or_else(|_| "<unserializable data>".to_owned());
                     write!(f, " ({compact})")?;
                 }
                 Ok(())
@@ -156,13 +152,11 @@ impl AcpError {
                 method: context.to_owned(),
             },
             ErrorCode::InvalidParams => AcpError::InvalidParams { message: err.message },
-            ErrorCode::ParseError | ErrorCode::InvalidRequest | ErrorCode::InternalError => {
-                AcpError::AgentInternal {
-                    message: err.message,
-                    code: i32::from(err.code),
-                    data: err.data,
-                }
-            }
+            ErrorCode::ParseError | ErrorCode::InvalidRequest | ErrorCode::InternalError => AcpError::AgentInternal {
+                message: err.message,
+                code: i32::from(err.code),
+                data: err.data,
+            },
             _ => {
                 let code = i32::from(err.code);
                 // -32001, -32002: additional session-not-found codes used by some agents
@@ -384,8 +378,7 @@ mod tests {
 
     #[test]
     fn from_sdk_captures_data_payload() {
-        let sdk_err = SdkError::internal_error()
-            .data(serde_json::json!({"reason": "rate_limited", "retry_after": 30}));
+        let sdk_err = SdkError::internal_error().data(serde_json::json!({"reason": "rate_limited", "retry_after": 30}));
         let acp = AcpError::from_sdk(sdk_err, "context");
         match acp {
             AcpError::AgentInternal { code, message, data } => {
@@ -464,10 +457,7 @@ mod tests {
         );
         assert!(display.contains("retry_after"), "data must be appended; got {display}");
         assert!(display.contains("30"), "data value must be appended; got {display}");
-        assert!(
-            !display.contains('\n'),
-            "data must be inline; got {display}"
-        );
+        assert!(!display.contains('\n'), "data must be inline; got {display}");
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/protocol/error.rs
+++ b/crates/aionui-ai-agent/src/protocol/error.rs
@@ -10,11 +10,9 @@ use aionui_common::AppError;
 pub(crate) enum AcpError {
     // ── Process lifecycle ──────────────────────────────────────────
     /// CLI binary not found or not executable.
-    #[error("Failed to spawn agent process: {message}")]
     SpawnFailed { message: String },
 
     /// Process exited before the initialize handshake completed.
-    #[error("Agent process exited during startup (exit={exit_code:?}, signal={signal:?})")]
     StartupCrash {
         exit_code: Option<i32>,
         signal: Option<String>,
@@ -22,7 +20,6 @@ pub(crate) enum AcpError {
     },
 
     /// Process crashed while a request was in flight.
-    #[error("Agent process disconnected (exit={exit_code:?}, signal={signal:?})")]
     Disconnected {
         exit_code: Option<i32>,
         signal: Option<String>,
@@ -31,33 +28,96 @@ pub(crate) enum AcpError {
 
     // ── ACP protocol errors (from SDK ErrorCode) ──────────────────
     /// Agent requires authentication first.
-    #[error("Authentication required")]
     AuthRequired,
 
     /// Agent-side session not found.
-    #[error("Session not found: {session_id}")]
     SessionNotFound { session_id: String },
 
     /// Agent does not support the requested method.
-    #[error("Method not supported: {method}")]
     MethodNotFound { method: String },
 
     /// Invalid request parameters.
-    #[error("Invalid parameters: {message}")]
     InvalidParams { message: String },
 
-    /// Agent reported an internal error.
-    #[error("Agent internal error: {message}")]
-    AgentInternal { message: String, code: i32 },
+    /// Agent reported an internal error. `data` carries the optional JSON-RPC
+    /// `error.data` payload from the agent — see [`AcpError::display`] for how
+    /// it is rendered.
+    AgentInternal {
+        message: String,
+        code: i32,
+        data: Option<serde_json::Value>,
+    },
 
     // ── Local errors ──────────────────────────────────────────────
     /// Protocol not connected (used before connect or after disconnect).
-    #[error("ACP protocol not connected")]
     NotConnected,
 
     /// Initialize handshake timed out.
-    #[error("Initialize handshake timed out after {timeout_secs}s")]
     InitTimeout { timeout_secs: u64 },
+}
+
+/// JSON-RPC default message strings that carry no useful information.
+/// When `AgentInternal` arrives with one of these as its `message`, we fall
+/// back to a diagnostic display ("Agent internal error (code -32603)").
+const SDK_DEFAULT_MESSAGES: &[&str] = &[
+    "Parse error",
+    "Invalid request",
+    "Method not found",
+    "Invalid params",
+    "Internal error",
+];
+
+impl std::fmt::Display for AcpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AcpError::SpawnFailed { message } => {
+                write!(f, "Failed to spawn agent process: {message}")
+            }
+            AcpError::StartupCrash { exit_code, signal, .. } => {
+                // stderr intentionally NOT included — may carry secrets.
+                write!(
+                    f,
+                    "Agent process exited during startup (exit={exit_code:?}, signal={signal:?})"
+                )
+            }
+            AcpError::Disconnected { exit_code, signal, .. } => {
+                write!(
+                    f,
+                    "Agent process disconnected (exit={exit_code:?}, signal={signal:?})"
+                )
+            }
+            AcpError::AuthRequired => f.write_str("Authentication required"),
+            AcpError::SessionNotFound { session_id } => {
+                write!(f, "Session not found: {session_id}")
+            }
+            AcpError::MethodNotFound { method } => {
+                write!(f, "Method not supported: {method}")
+            }
+            AcpError::InvalidParams { message } => {
+                write!(f, "Invalid parameters: {message}")
+            }
+            AcpError::AgentInternal { message, code, data } => {
+                let trimmed = message.trim();
+                let is_default = trimmed.is_empty()
+                    || SDK_DEFAULT_MESSAGES.iter().any(|d| d.eq_ignore_ascii_case(trimmed));
+                if is_default {
+                    write!(f, "Agent internal error (code {code})")?;
+                } else {
+                    f.write_str(trimmed)?;
+                }
+                if let Some(data) = data {
+                    let compact = serde_json::to_string(data)
+                        .unwrap_or_else(|_| "<unserializable data>".to_owned());
+                    write!(f, " ({compact})")?;
+                }
+                Ok(())
+            }
+            AcpError::NotConnected => f.write_str("ACP protocol not connected"),
+            AcpError::InitTimeout { timeout_secs } => {
+                write!(f, "Initialize handshake timed out after {timeout_secs}s")
+            }
+        }
+    }
 }
 
 impl AcpError {
@@ -88,10 +148,13 @@ impl AcpError {
                 method: context.to_owned(),
             },
             ErrorCode::InvalidParams => AcpError::InvalidParams { message: err.message },
-            ErrorCode::ParseError | ErrorCode::InvalidRequest | ErrorCode::InternalError => AcpError::AgentInternal {
-                message: err.message,
-                code: i32::from(err.code),
-            },
+            ErrorCode::ParseError | ErrorCode::InvalidRequest | ErrorCode::InternalError => {
+                AcpError::AgentInternal {
+                    message: err.message,
+                    code: i32::from(err.code),
+                    data: err.data,
+                }
+            }
             _ => {
                 let code = i32::from(err.code);
                 // -32001, -32002: additional session-not-found codes used by some agents
@@ -103,6 +166,7 @@ impl AcpError {
                     AcpError::AgentInternal {
                         message: err.message,
                         code,
+                        data: err.data,
                     }
                 }
             }
@@ -182,6 +246,7 @@ mod tests {
             AcpError::AgentInternal {
                 message: "oops".into(),
                 code: -32603,
+                data: None,
             }
             .is_retryable()
         );
@@ -258,7 +323,7 @@ mod tests {
         let sdk_err = SdkError::new(-32099, "custom error");
         let acp = AcpError::from_sdk(sdk_err, "ctx");
         match acp {
-            AcpError::AgentInternal { code, message } => {
+            AcpError::AgentInternal { code, message, .. } => {
                 assert_eq!(code, -32099);
                 assert_eq!(message, "custom error");
             }
@@ -281,6 +346,7 @@ mod tests {
                 AcpError::AgentInternal {
                     message: "e".into(),
                     code: -1,
+                    data: None,
                 },
                 StatusCode::BAD_GATEWAY,
             ),
@@ -305,6 +371,84 @@ mod tests {
         assert!(
             !display.contains("SUPER SECRET"),
             "Display should not leak stderr: {display}"
+        );
+    }
+
+    #[test]
+    fn from_sdk_captures_data_payload() {
+        let sdk_err = SdkError::internal_error()
+            .data(serde_json::json!({"reason": "rate_limited", "retry_after": 30}));
+        let acp = AcpError::from_sdk(sdk_err, "context");
+        match acp {
+            AcpError::AgentInternal { code, message, data } => {
+                assert_eq!(code, -32603);
+                assert_eq!(message, "Internal error");
+                let data = data.expect("data must be preserved");
+                assert_eq!(data["reason"], "rate_limited");
+                assert_eq!(data["retry_after"], 30);
+            }
+            other => panic!("Expected AgentInternal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_sdk_no_data_yields_none() {
+        let sdk_err = SdkError::internal_error();
+        let acp = AcpError::from_sdk(sdk_err, "context");
+        match acp {
+            AcpError::AgentInternal { data, .. } => assert!(data.is_none()),
+            other => panic!("Expected AgentInternal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_internal_display_uses_message_only_when_no_data() {
+        let err = AcpError::AgentInternal {
+            message: "API Error: Internal server error".into(),
+            code: -32603,
+            data: None,
+        };
+        assert_eq!(
+            err.to_string(),
+            "API Error: Internal server error",
+            "Display must NOT prefix with 'Agent internal error:' when message carries upstream context"
+        );
+    }
+
+    #[test]
+    fn agent_internal_display_falls_back_when_message_is_sdk_default() {
+        // SDK default for ErrorCode::InternalError is the plain string "Internal error".
+        // When that's all we have, the user sees nothing useful, so add a hint.
+        let err = AcpError::AgentInternal {
+            message: "Internal error".into(),
+            code: -32603,
+            data: None,
+        };
+        let display = err.to_string();
+        assert!(
+            display.contains("Agent internal error"),
+            "Display must include 'Agent internal error' hint when SDK gave us its default message; got {display}"
+        );
+        assert!(
+            display.contains("-32603"),
+            "Display must include the JSON-RPC code as a diagnostic when message is empty/default; got {display}"
+        );
+    }
+
+    #[test]
+    fn agent_internal_display_appends_data_inline() {
+        let err = AcpError::AgentInternal {
+            message: "API Error".into(),
+            code: -32603,
+            data: Some(serde_json::json!({"upstream_status": 503})),
+        };
+        let display = err.to_string();
+        assert!(display.contains("API Error"), "got {display}");
+        assert!(display.contains("upstream_status"), "got {display}");
+        assert!(display.contains("503"), "got {display}");
+        assert!(
+            !display.contains('\n'),
+            "data must be appended on a single line, not pretty-printed; got {display}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Stop showing `Bad gateway: Agent internal error: Internal error: <real msg>` to end users; the renderer now sees the upstream provider's message directly.
- Capture the JSON-RPC `error.data` payload from the SDK so future agents can attach structured error context.
- For the codex-acp pattern where the real error text only appears in stderr (`UsageLimitExceeded`, network/timeout from `tracing::error!`), peek the child's stderr ring buffer and surface a strict-allowlisted line in place of the SDK's default `"Internal error"`.

## Background
Sentry user-feedbacks ELECTRON-1AS, ELECTRON-1AT, ELECTRON-1BF reported the triple-prefixed error string. Root cause was three layered `Display` impls (`AppError::BadGateway` → `AcpError::AgentInternal` → SDK `ErrorCode::InternalError`), all of which prepended their own tag. ELECTRON-1BF (Anthropic 5xx) carried a real upstream message that was being buried; ELECTRON-1AT (codex `UsageLimitExceeded`) had only the SDK default with the real text in stderr only.

## Approach
- `AcpError::AgentInternal` gains an optional `data` field; its `Display` no longer adds `"Agent internal error: "` when the SDK message has real content. Falls back to `"Agent internal error (code -32xxx)"` only when the SDK gave us its default string.
- New non-consuming `CliAgentProcess::peek_stderr_tail(n)` reads recent stderr without draining the ring buffer.
- New `manager/acp/stderr_error_extractor.rs` matches stderr lines against a strict allowlist of error keywords (`usage limit`, `rate limit`, `unauthorized`, `network`, `timeout`, ...); strips ANSI/tracing decoration; truncates to 240 chars. `credentials`/`api key` entries flagged as HIGH-RISK in source.
- `AcpAgentManager::send_message` augments the WS broadcast with the extracted line when (and only when) the SDK gave us its default-message shape. Operator log line gains an `augmented=` field; the original `error=` chain is preserved.
- WS `error` event drops the `Bad gateway:` HTTP prefix (HTTP responses still have it, since 502 status code semantics need it).

## Implementation
11 commits, broken into 5 logical tasks:
1. `AcpError::AgentInternal` + Display refactor + tests
2. WS broadcast strips status prefix
3. `peek_stderr_tail` API
4. stderr extractor module (15-keyword allowlist + ANSI strip + truncation, fully unit-tested)
5. Wire extractor into `send_message`

Each task went through spec-compliance + code-quality review with follow-up polish commits.

## Test plan
- [x] `cargo test -p aionui-ai-agent` — 367/367 unit tests + 22 integration tests pass
- [x] `cargo clippy -p aionui-ai-agent -- -D warnings` clean
- [x] `cargo build --workspace --all-features --all-targets` clean
- [ ] Manual flavour A: trigger an upstream 5xx from a Claude provider; renderer toast should show `API Error: Internal server error` (no `Bad gateway:` prefix). **Pending — please verify before merge.**
- [ ] Manual flavour B: trigger a codex `UsageLimitExceeded`; renderer toast should show usage-limit text from stderr; backend log should carry `augmented=<...>` field. **Pending — please verify before merge.**

## Security notes
- stderr-tail extraction is gated by a strict 15-entry keyword allowlist. Two entries (`credentials`, `api key`) are explicitly annotated as HIGH-RISK in source because the 240-char cap cannot prevent secret-bearing lines from reaching end users; reviewers adjusting the list should consult the comment.
- The full `Bad gateway: Agent internal error: ...` chain is still emitted to the backend `tracing::warn!` operator log for incident analysis.

## Out of scope
- Mapping `UsageLimitExceeded` to a non-502 status code (HTTP body still says 502; only the message text improves).
- Frontend changes to drop the `Conversation & Sessions:` toast prefix.