### PR TITLE
fix(acp): apply AvailableCommands event to session aggregate

### DIFF
--- a/crates/aionui-ai-agent/src/manager/acp/agent_event_tracker.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_event_tracker.rs
@@ -123,6 +123,11 @@ impl AcpAgentManager {
                     self.commit_session_changes(&mut s).await;
                 }
             }
+            AgentStreamEvent::AvailableCommands(data) => {
+                let mut s = self.session.write().await;
+                s.apply_advertised_commands(data.commands.clone());
+                self.commit_session_changes(&mut s).await;
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
## Summary

- Store `AvailableCommands` event data in the ACP session aggregate via `apply_advertised_commands`
- Ensures `emit_snapshot_events()` can re-broadcast commands on session restore

## Root Cause

The `event_tracker` was not handling `AgentStreamEvent::AvailableCommands`, so the session aggregate's `available_commands` field remained `None`. This caused:
1. `emit_snapshot_events()` to skip broadcasting commands on session restore
2. HTTP `GET /slash-commands` endpoint to return an empty list

## Test plan

- [x] Warmup a conversation → `load_slash_commands()` returns CLI-advertised commands
- [x] Session restore path → commands re-broadcast via `emit_snapshot_events`