### PR TITLE
fix(assistant): pin user_data_dir to runtime --data-dir

### DIFF
--- a/crates/aionui-app/src/state_builders.rs
+++ b/crates/aionui-app/src/state_builders.rs
@@ -121,7 +121,18 @@ pub fn build_assistant_state(services: &AppServices, extension_registry: Extensi
     let repo: Arc<dyn IAssistantRepository> = Arc::new(SqliteAssistantRepository::new(pool.clone()));
     let override_repo: Arc<dyn IAssistantOverrideRepository> = Arc::new(SqliteAssistantOverrideRepository::new(pool));
     let builtin = Arc::new(BuiltinAssistantRegistry::load());
-    let service = Arc::new(AssistantService::new(repo, override_repo, builtin, extension_registry));
+    // Pin user_data_dir to the runtime-resolved data directory so dev /
+    // packaged / multi-instance launches all keep their assistant rule files
+    // alongside the matching SQLite database (avoiding the historical bug
+    // where dev wrote rules to the release `~/.aionui/` while the db lived
+    // under `~/.aionui-dev/`).
+    let service = Arc::new(AssistantService::new(
+        repo,
+        override_repo,
+        builtin,
+        extension_registry,
+        services.data_dir.clone(),
+    ));
     AssistantRouterState { service }
 }
 

--- a/crates/aionui-app/tests/assistants_e2e.rs
+++ b/crates/aionui-app/tests/assistants_e2e.rs
@@ -184,9 +184,13 @@ async fn fixture() -> Fixture {
     let repo: Arc<dyn IAssistantRepository> = Arc::new(SqliteAssistantRepository::new(pool.clone()));
     let override_repo: Arc<dyn IAssistantOverrideRepository> = Arc::new(SqliteAssistantOverrideRepository::new(pool));
     let builtin = Arc::new(BuiltinAssistantRegistry::load_from_dir(builtin_assets_dir.clone()));
-    let service = Arc::new(
-        AssistantService::new(repo, override_repo, builtin, registry).with_user_data_dir(user_data_dir.clone()),
-    );
+    let service = Arc::new(AssistantService::new(
+        repo,
+        override_repo,
+        builtin,
+        registry,
+        user_data_dir.clone(),
+    ));
     states.assistant = AssistantRouterState {
         service: service.clone(),
     };

--- a/crates/aionui-assistant/src/service.rs
+++ b/crates/aionui-assistant/src/service.rs
@@ -32,26 +32,35 @@ pub struct AssistantService {
 }
 
 impl AssistantService {
+    /// Construct an `AssistantService` pinned to the runtime data directory.
+    ///
+    /// `user_data_dir` is the on-disk root for user-authored rule and skill
+    /// `.md` files plus avatar uploads (`<user_data_dir>/assistant-rules/`,
+    /// `<user_data_dir>/assistant-skills/`, `<user_data_dir>/assistant-avatars/`).
+    /// Production code passes the same `services.data_dir` that the SQLite
+    /// database lives under, so dev / packaged / multi-instance launches
+    /// keep their rule files alongside the matching db. Tests pin a temp
+    /// directory.
+    ///
+    /// There is no implicit `~/.aionui` fallback on purpose: an earlier
+    /// version had one, and dev builds silently wrote rule files to the
+    /// release directory while the db lived under `~/.aionui-dev/`,
+    /// resulting in `read_rule` returning empty in dev mode. Forcing the
+    /// caller to pass a path makes the wiring explicit.
     pub fn new(
         repo: Arc<dyn IAssistantRepository>,
         override_repo: Arc<dyn IAssistantOverrideRepository>,
         builtin: Arc<BuiltinAssistantRegistry>,
         extension_registry: ExtensionRegistry,
+        user_data_dir: PathBuf,
     ) -> Self {
         Self {
             repo,
             override_repo,
             builtin,
             extension_registry,
-            user_data_dir: default_user_data_dir(),
+            user_data_dir,
         }
-    }
-
-    /// Override the user-data directory. Used by tests and callers that want
-    /// to pin a custom root (e.g. `~/.aionui-dev/`).
-    pub fn with_user_data_dir(mut self, dir: PathBuf) -> Self {
-        self.user_data_dir = dir;
-        self
     }
 
     // -----------------------------------------------------------------------
@@ -826,10 +835,6 @@ fn decode_list_map(raw: Option<&str>) -> Result<HashMap<String, Vec<String>>, Ap
 // Filesystem helpers
 // ---------------------------------------------------------------------------
 
-fn default_user_data_dir() -> PathBuf {
-    dirs::home_dir().unwrap_or_else(std::env::temp_dir).join(".aionui")
-}
-
 fn assistant_md_path(dir: &Path, id: &str, locale: Option<&str>) -> PathBuf {
     let filename = match locale {
         Some(loc) if !loc.is_empty() => format!("{id}.{loc}.md"),
@@ -959,8 +964,7 @@ mod tests {
         let ext_state_store = ExtensionStateStore::new(tmp.path().join("ext-states.json"));
         let extension_registry = ExtensionRegistry::new(ext_state_store, event_bus, "1.0.0".to_string());
 
-        let service = AssistantService::new(repo, orepo, builtin_reg, extension_registry)
-            .with_user_data_dir(tmp.path().to_path_buf());
+        let service = AssistantService::new(repo, orepo, builtin_reg, extension_registry, tmp.path().to_path_buf());
 
         Fixture {
             service,
@@ -1381,7 +1385,7 @@ mod tests {
         let ext_state_store = ExtensionStateStore::new(tmp.path().join("ext-states.json"));
         let extension_registry = ExtensionRegistry::new(ext_state_store, event_bus, "1.0.0".to_string());
 
-        let service = AssistantService::new(repo, orepo, builtin_reg, extension_registry);
+        let service = AssistantService::new(repo, orepo, builtin_reg, extension_registry, tmp.path().to_path_buf());
         let content = service.read_rule("builtin-office", Some("en-US")).await.unwrap();
         assert_eq!(content, "office rules");
     }


### PR DESCRIPTION
## Summary

- Promote `user_data_dir` to a required argument on `AssistantService::new`; remove the `~/.aionui` fallback so the type system forces every caller to wire it explicitly.
- `build_assistant_state` now passes `services.data_dir`, keeping rule .md files alongside the SQLite database.
- Update unit + e2e tests to pass the temp dir directly.

## Why

`AssistantService` previously fell back to `dirs::home_dir().join(".aionui")` when the caller forgot to wire a path. That string happens to match the packaged-release data dir, so it worked in production by coincidence — but in dev / multi-instance launches the db lives under `~/.aionui-dev/` while rule writes silently landed under `~/.aionui/assistant-rules/`. Result: every `read_rule` for a user-authored assistant returned an empty string in dev mode.

Surveyed the rest of the workspace — every other service (cron, agent, conversation, skill paths) already accepts `data_dir: &Path` explicitly. `AssistantService` was the lone holdout. Loader's legacy `~/.aionui` branch is dead code under production wiring (`resolve_scan_paths_for_data_dir` is always called).

## Test plan

- [x] `cargo test -p aionui-assistant -p aionui-app` (all suites pass)
- [x] `cargo clippy -p aionui-assistant -p aionui-app --all-targets --no-deps` clean
- [x] `cargo fmt --check`
- [x] Manual: launched dev build, created a custom assistant with a rule body, verified `~/.aionui-dev/assistant-rules/<id>.<locale>.md` is populated and the file matches the dev db row.