### PR TITLE
fix(db): cast REAL timestamps to INTEGER in conversations table

### DIFF
--- a/crates/aionui-db/migrations/005_fix_real_timestamps.sql
+++ b/crates/aionui-db/migrations/005_fix_real_timestamps.sql
@@ -1,0 +1,9 @@
+-- Fix legacy rows where timestamps were stored as REAL (float) instead of INTEGER.
+-- sqlx cannot decode REAL values into i64, causing the conversations list API to fail.
+UPDATE conversations
+SET created_at = CAST(created_at AS INTEGER)
+WHERE typeof(created_at) = 'real';
+
+UPDATE conversations
+SET updated_at = CAST(updated_at AS INTEGER)
+WHERE typeof(updated_at) = 'real';


### PR DESCRIPTION
## Summary

- 部分用户的旧数据库中 `conversations.created_at` 以 SQLite REAL 类型存储（如 `1757385243697.21`）
- sqlx 无法将 REAL 解码为 i64，导致 `GET /api/conversations` 整体返回 500，前端显示会话列表为空
- 添加 migration 005，将受影响的行 CAST 为 INTEGER，对已经是 INTEGER 的行无影响

## Test plan

- [x] 在含 REAL 时间戳的用户数据库上验证：修复前 500，修复后正常返回会话列表
- [x] `cargo test --workspace` 5533 tests passed
- [x] 对已使用新架构的数据库无影响（WHERE typeof = 'real' 匹配 0 行）