### PR TITLE
fix(runtime): make CLI detection work on Windows

### DIFF
--- a/crates/aionui-mcp/src/adapters/cli_helpers.rs
+++ b/crates/aionui-mcp/src/adapters/cli_helpers.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use aionui_runtime::Builder as CmdBuilder;
-use tokio::process::Command;
+use aionui_runtime::resolve_command_path;
 
 use crate::adapter::DetectedServer;
 use crate::error::McpError;
@@ -15,14 +15,13 @@ pub const DETECT_TIMEOUT: Duration = Duration::from_secs(30);
 pub const MUTATE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Check whether a CLI binary is available on `$PATH`.
+///
+/// Uses `aionui_runtime::resolve_command_path` so the lookup respects
+/// the bundled-bun shim and Windows `PATHEXT` rules. Previously this
+/// shelled out to `which`, which does not exist on Windows and made
+/// every MCP adapter report "not installed" there.
 pub async fn is_cli_installed(name: &str) -> Result<bool, McpError> {
-    let output = Command::new("which")
-        .arg(name)
-        .output()
-        .await
-        .map_err(|e| McpError::AgentOperationFailed(format!("failed to run `which {name}`: {e}")))?;
-
-    Ok(output.status.success())
+    Ok(resolve_command_path(name).is_some())
 }
 
 /// Run a CLI command with a timeout and clean environment variables.
@@ -228,6 +227,26 @@ pub fn build_header_args(headers: &HashMap<String, String>, flag: &str) -> Vec<S
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn is_cli_installed_finds_known_binary() {
+        // Both platforms ship a usable shell on PATH out of the box: `sh`
+        // on Unix, `cmd` on Windows. resolve_command_path must locate it.
+        #[cfg(unix)]
+        let probe = "sh";
+        #[cfg(windows)]
+        let probe = "cmd";
+
+        assert!(is_cli_installed(probe).await.unwrap(), "expected `{probe}` on PATH");
+    }
+
+    #[tokio::test]
+    async fn is_cli_installed_returns_false_for_missing_binary() {
+        let result = is_cli_installed("aionui-definitely-not-a-real-binary-xyz")
+            .await
+            .unwrap();
+        assert!(!result);
+    }
 
     #[test]
     fn strip_ansi_removes_color_codes() {

--- a/crates/aionui-runtime/src/resolver.rs
+++ b/crates/aionui-runtime/src/resolver.rs
@@ -134,6 +134,11 @@ fn env_override() -> Option<PathBuf> {
 /// For `bun` / `bunx` we go through `aionui_runtime` so the bundled
 /// runtime is used when present; everything else falls back to the
 /// user's `$PATH` via `which::which`.
+///
+/// On Windows, if a bare name lookup fails we retry with the common
+/// shim suffixes (`.cmd`, `.ps1`, `.bat`). Tools installed via npm
+/// global / pnpm / yarn typically ship as `name.cmd`, and a user with a
+/// trimmed `PATHEXT` would otherwise see them as missing.
 pub fn resolve_command_path(cmd: &str) -> Option<PathBuf> {
     match cmd {
         "bun" => resolve_bun().ok().or_else(|| which::which("bun").ok()),
@@ -147,9 +152,29 @@ pub fn resolve_command_path(cmd: &str) -> Option<PathBuf> {
             }
             which::which("bunx").ok()
         }
-        other => which::which(other).ok(),
+        other => which::which(other).ok().or_else(|| windows_shim_fallback(other)),
     }
 }
+
+#[cfg(windows)]
+fn windows_shim_fallback(cmd: &str) -> Option<PathBuf> {
+    // If the caller already passed an extension, no point retrying.
+    if Path::new(cmd).extension().is_some() {
+        return None;
+    }
+    for ext in ["cmd", "ps1", "bat"] {
+        if let Ok(p) = which::which(format!("{cmd}.{ext}")) {
+            return Some(p);
+        }
+    }
+    None
+}
+
+#[cfg(not(windows))]
+fn windows_shim_fallback(_cmd: &str) -> Option<PathBuf> {
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aionui-runtime/src/shell_env.rs
+++ b/crates/aionui-runtime/src/shell_env.rs
@@ -122,11 +122,18 @@ fn platform_extra_bins_at(home: Option<&Path>) -> Vec<PathBuf> {
         if let Ok(local) = std::env::var("LOCALAPPDATA") {
             push_if_dir(PathBuf::from(&local).join("pnpm"));
             push_if_dir(PathBuf::from(&local).join("fnm_multishells"));
+            // winget package shims (stable since App Installer 1.4).
+            push_if_dir(PathBuf::from(&local).join("Microsoft").join("WinGet").join("Links"));
+            // Yarn classic global bin.
+            push_if_dir(PathBuf::from(&local).join("Yarn").join("bin"));
         }
         if let Ok(pf) = std::env::var("ProgramFiles") {
             push_if_dir(PathBuf::from(&pf).join("Git").join("cmd"));
             push_if_dir(PathBuf::from(&pf).join("Git").join("bin"));
             push_if_dir(PathBuf::from(&pf).join("nodejs"));
+        }
+        if let Ok(pf86) = std::env::var("ProgramFiles(x86)") {
+            push_if_dir(PathBuf::from(&pf86).join("nodejs"));
         }
         if let Ok(scoop) = std::env::var("SCOOP") {
             push_if_dir(PathBuf::from(&scoop).join("shims"));

--- a/crates/aionui-runtime/src/spawn.rs
+++ b/crates/aionui-runtime/src/spawn.rs
@@ -23,12 +23,14 @@
 //! once at process startup by [`crate::enhance_process_path`]; Builder
 //! does not re-inject it.
 
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::io;
 use std::path::Path;
 use std::process::Stdio;
 
 use tokio::process::{Child, Command};
+
+use crate::resolver::resolve_command_path;
 
 /// Construction mode — determines default stdio + env extras.
 #[derive(Debug, Clone, Copy)]
@@ -60,7 +62,7 @@ impl Builder {
     /// - `kill_on_drop(true)`
     /// - removes `NODE_OPTIONS`, `NODE_INSPECT`, `NODE_DEBUG`, `CLAUDECODE`
     pub fn new<S: AsRef<OsStr>>(program: S) -> Self {
-        let mut inner = Command::new(program);
+        let mut inner = Command::new(resolve_program(program.as_ref()));
         inner.kill_on_drop(true);
         strip_pollution(&mut inner);
         Self {
@@ -77,7 +79,7 @@ impl Builder {
     /// - removes `NODE_OPTIONS`, `NODE_INSPECT`, `NODE_DEBUG`, `CLAUDECODE`
     /// - sets `NO_COLOR=1`, `TERM=dumb`
     pub fn clean_cli<S: AsRef<OsStr>>(program: S) -> Self {
-        let mut inner = Command::new(program);
+        let mut inner = Command::new(resolve_program(program.as_ref()));
         inner
             .kill_on_drop(true)
             .stdin(Stdio::null())
@@ -166,6 +168,23 @@ fn strip_pollution(cmd: &mut Command) {
         .env_remove("NODE_INSPECT")
         .env_remove("NODE_DEBUG")
         .env_remove("CLAUDECODE");
+}
+
+/// Resolve `program` through `resolve_command_path` so callers don't have
+/// to. If the input already contains a path separator (relative or
+/// absolute) we leave it alone — only bare command names go through
+/// the resolver, where the bundled-bun shim and Windows `.cmd / .ps1 /
+/// .bat` fallbacks live.
+fn resolve_program(program: &OsStr) -> OsString {
+    if let Some(s) = program.to_str()
+        && !s.is_empty()
+        && !s.contains('/')
+        && !s.contains('\\')
+        && let Some(path) = resolve_command_path(s)
+    {
+        return path.into_os_string();
+    }
+    program.to_os_string()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Fixes the user-reported Sentry issue [ELECTRON-1C3](https://iofficeai.sentry.io/issues/120067016/) — "win 2.0.1 版本本地 gemini cli 检测不到出现错误". The same root cause affects every CLI agent on Windows, not just gemini.

Three independent failure modes were stacked on top of each other:

- **`is_cli_installed` shelled out to `which`**, which doesn't exist on Windows. Every MCP adapter (gemini / qwen / claude / codex / codebuddy / aionrs) therefore reported "not installed" before even trying to spawn. Now uses `aionui_runtime::resolve_command_path`.
- **`resolve_command_path` only looked at the bare command name**, so npm/pnpm/yarn-installed CLIs that ship as `name.cmd` were invisible when the user's `PATHEXT` was trimmed. Added a Windows fallback that retries with `.cmd` / `.ps1` / `.bat`.
- **`Builder::new` / `Builder::clean_cli` bypassed the resolver entirely**, constructing `Command::new(raw_name)` directly. Both flavours now route through a new `resolve_program` helper so every Builder caller picks up the bundled-bun shim and the `.cmd` fallback for free.

Also extended startup `PATH` enhancement on Windows with:
- `%LOCALAPPDATA%\Microsoft\WinGet\Links` (winget package shims)
- `%LOCALAPPDATA%\Yarn\bin` (Yarn classic global bin)
- `%ProgramFiles(x86)%\nodejs` (32-bit Node)

## Test plan

- [x] `cargo test -p aionui-runtime -p aionui-mcp` — all relevant tests pass; the one unrelated flake (`env_override_wins_over_embed`, env-var race between concurrent tests) passes when run in isolation.
- [x] `cargo clippy -p aionui-runtime -p aionui-mcp --tests -- -D warnings` — clean.
- [x] `just build` — fmt + lint-fix + clippy + release build all green.
- [x] Added two new unit tests for `is_cli_installed` covering both "binary present" and "binary missing" on each platform.
- [ ] Manual verification on a Windows host with npm-global `gemini.cmd` (cannot run from CI; recommended before release).