### PR TITLE
refactor(app): replace argv sniffing with clap Subcommand for mcp-* helpers

### DIFF
--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -3,7 +3,7 @@ use std::process::ExitCode;
 use std::time::Instant;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use tokio::net::TcpListener;
 use tracing::info;
 use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt};
@@ -45,6 +45,23 @@ struct Cli {
     /// Log level filter (e.g. "info", "debug", "info,aionui_mcp=trace").
     #[arg(long)]
     log_level: Option<String>,
+
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+// `Mcp` prefix is load-bearing — clap derives kebab-case subcommand names
+// (`mcp-bridge`, `mcp-guide-stdio`, `mcp-team-stdio`) that external callers
+// (ACP agent CLI, team MCP bridge spec) depend on verbatim.
+#[allow(clippy::enum_variant_names)]
+enum Command {
+    /// Stdio ↔ TCP bridge for the team MCP server (spawned by the ACP agent CLI).
+    McpBridge,
+    /// MCP stdio server for team-guide tools (spawned by the ACP agent CLI).
+    McpGuideStdio,
+    /// MCP stdio server for team tools (spawned by the ACP agent CLI).
+    McpTeamStdio,
 }
 
 const NOISE_SUPPRESSIONS: &[&str] = &["sqlx::query=warn", "hyper_util=warn", "reqwest=warn"];
@@ -133,28 +150,15 @@ fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> LogGuards {
 }
 
 fn main() -> Result<ExitCode> {
-    // mcp-* subcommands route into short-lived stdio helpers that don't
-    // accept `--data-dir`. Detect them via argv[1] BEFORE `Cli::parse`
-    // (which rejects unknown positional args) so those paths can bypass
-    // both `aionui_runtime::init` and the full CLI parse.
-    let mcp_subcommand: Option<&str> = match std::env::args().nth(1).as_deref() {
-        Some("mcp-bridge") => Some("mcp-bridge"),
-        Some("mcp-guide-stdio") => Some("mcp-guide-stdio"),
-        Some("mcp-team-stdio") => Some("mcp-team-stdio"),
-        _ => None,
-    };
+    let cli = Cli::parse();
 
-    // Anchor the bun runtime cache under --data-dir BEFORE any code path
-    // that resolves it (enhance_process_path below + every later
-    // resolve_bun call). MCP subcommands fall back to the OS default
-    // cache, which is fine — they're short-lived helpers, not agent hosts.
-    let cli = if mcp_subcommand.is_some() {
-        None
-    } else {
-        let parsed = Cli::parse();
-        aionui_runtime::init(&parsed.data_dir);
-        Some(parsed)
-    };
+    // mcp-* subcommands route into short-lived stdio helpers that live entirely
+    // outside the main HTTP server. They share the global flags so clap can
+    // parse a uniform CLI, but bypass `aionui_runtime::init` (which would
+    // anchor the bun cache under --data-dir) — these helpers don't host agents.
+    if cli.command.is_none() {
+        aionui_runtime::init(&cli.data_dir);
+    }
 
     // SAFETY: called before any worker thread exists (including the tokio
     // runtime constructed below). Rust 2024 requires `unsafe` for
@@ -162,20 +166,17 @@ fn main() -> Result<ExitCode> {
     let merged_path = unsafe { aionui_runtime::enhance_process_path() };
 
     let runtime = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
-    runtime.block_on(async_main(merged_path, mcp_subcommand, cli))
+    runtime.block_on(async_main(merged_path, cli))
 }
 
-async fn async_main(merged_path: String, mcp_subcommand: Option<&str>, cli: Option<Cli>) -> Result<ExitCode> {
-    // mcp-bridge / mcp-guide-stdio subcommands: live entirely outside the main
-    // HTTP server and must not touch the database, logging setup, or `AppServices`.
-    match mcp_subcommand {
-        Some("mcp-bridge") => return Ok(bridge::run_mcp_bridge().await),
-        Some("mcp-guide-stdio") => return Ok(guide_stdio::run_guide_stdio().await),
-        Some("mcp-team-stdio") => return Ok(team_stdio::run_team_stdio().await),
-        _ => {}
+async fn async_main(merged_path: String, cli: Cli) -> Result<ExitCode> {
+    // MCP stdio helpers must not touch the database, logging setup, or `AppServices`.
+    match cli.command {
+        Some(Command::McpBridge) => return Ok(bridge::run_mcp_bridge().await),
+        Some(Command::McpGuideStdio) => return Ok(guide_stdio::run_guide_stdio().await),
+        Some(Command::McpTeamStdio) => return Ok(team_stdio::run_team_stdio().await),
+        None => {}
     }
-
-    let cli = cli.expect("non-mcp entry guarantees cli is parsed");
 
     let log_dir = cli.log_dir.unwrap_or_else(|| cli.data_dir.join("logs"));
     let _log_guard = init_tracing(&log_dir, cli.log_level.as_deref());


### PR DESCRIPTION
## Summary
- Replace the ad-hoc `std::env::args().nth(1)` sniff in `aionui-app/src/main.rs` with a proper clap `Subcommand` derive.
- Subcommand strings (`mcp-bridge`, `mcp-guide-stdio`, `mcp-team-stdio`) are unchanged — clap derives them as kebab-case from the enum variants — so external callers in `aionui-team` and `aionui-ai-agent` keep working verbatim.
- `aionui_runtime::init` is still skipped for the MCP helpers (no bun cache anchoring); behavior parity preserved.

Side benefit: `aionui-backend --help` now lists the helper subcommands, and unknown subcommands are rejected by clap instead of silently routed to the HTTP server path.

## Test plan
- [x] `cargo build -p aionui-app`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p aionui-app -- -D warnings`
- [x] `cargo test -p aionui-app` (3/3 passed)
- [x] `aionui-backend --help` lists the three subcommands
- [x] `aionui-backend mcp-bridge --help` / `mcp-guide-stdio --help` / `mcp-team-stdio --help` all show their per-subcommand help