### PR TITLE
feat(runtime): full shell-style command in spawn logs

### DIFF
--- a/crates/aionui-ai-agent/src/capability/cli_process/spawn_legacy.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/spawn_legacy.rs
@@ -31,19 +31,17 @@ impl CliAgentProcess {
             cmd.current_dir(cwd);
         }
 
+        let preview = cmd.to_string();
+        info!(command = %preview, "Spawning CLI process");
         let mut child: Child = cmd.spawn().map_err(|e| {
-            error!(command = %config.command.display(), error = %ErrorChain(&e), "Failed to spawn CLI process");
-            AppError::Internal(format!(
-                "Failed to spawn CLI process '{}': {}",
-                config.command.display(),
-                e
-            ))
+            error!(command = %preview, error = %ErrorChain(&e), "Failed to spawn CLI process");
+            AppError::Internal(format!("Failed to spawn CLI process '{preview}': {e}"))
         })?;
 
         let pid = child
             .id()
             .ok_or_else(|| AppError::Internal("Failed to obtain PID from spawned process".into()))?;
-        info!(pid, command = %config.command.display(), "CLI process spawned");
+        info!(pid, command = %preview, "CLI process spawned");
 
         let stdout = child
             .stdout

--- a/crates/aionui-ai-agent/src/capability/cli_process/spawn_sdk.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/spawn_sdk.rs
@@ -36,21 +36,18 @@ impl CliAgentProcess {
         if let Some(ref cwd) = config.cwd {
             cmd.current_dir(cwd);
         }
-        info!(command = %config.command.display(), "Spawning CLI process (SDK mode)");
+        let preview = cmd.to_string();
+        info!(command = %preview, "Spawning CLI process (SDK mode)");
         let mut child: Child = cmd.spawn().map_err(|e| {
-            error!(command = %config.command.display(), error = %ErrorChain(&e), "Failed to spawn CLI process");
-            AppError::Internal(format!(
-                "Failed to spawn CLI process '{}': {}",
-                config.command.display(),
-                e
-            ))
+            error!(command = %preview, error = %ErrorChain(&e), "Failed to spawn CLI process");
+            AppError::Internal(format!("Failed to spawn CLI process '{preview}': {e}"))
         })?;
 
         let pid = child.id().ok_or_else(|| {
-            error!(command = %config.command.display(), "Failed to obtain PID from spawned process");
+            error!(command = %preview, "Failed to obtain PID from spawned process");
             AppError::Internal("Failed to obtain PID from spawned process".into())
         })?;
-        info!(pid, command = %config.command.display(), "CLI process spawned (SDK mode)");
+        info!(pid, command = %preview, "CLI process spawned (SDK mode)");
 
         let stdout = child.stdout.take().ok_or_else(|| {
             error!(pid, "Failed to capture stdout from child process");

--- a/crates/aionui-runtime/src/spawn.rs
+++ b/crates/aionui-runtime/src/spawn.rs
@@ -53,6 +53,15 @@ impl std::fmt::Debug for Builder {
     }
 }
 
+/// Renders the configured spawn as a shell-style preview (`cd … && env -u
+/// X K=V <prog> <args>…`) suitable for logs and error messages. Format
+/// comes for free from `std::process::Command`'s `Debug` impl.
+impl std::fmt::Display for Builder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self.inner.as_std(), f)
+    }
+}
+
 impl Builder {
     /// Builder for long-running agent subprocesses (ACP SDK, legacy CLI).
     ///
@@ -275,5 +284,34 @@ mod tests {
         assert!(child.id().is_some());
         let status = child.wait().await.unwrap();
         assert!(status.success());
+    }
+
+    #[test]
+    fn display_renders_shell_style_command() {
+        let mut b = Builder::new("/usr/local/bin/bun");
+        b.current_dir("/tmp/work dir")
+            .env("FOO", "bar baz")
+            .args(["x", "--flag", "with space"]);
+
+        let preview = format!("{b}");
+        // Format inherited from std Command Debug: `cd "..." && env -u X K=V "prog" "args"...`
+        assert!(
+            preview.starts_with(r#"cd "/tmp/work dir" &&"#),
+            "missing cwd prefix: {preview}"
+        );
+        assert!(preview.contains("env "), "expected env section: {preview}");
+        assert!(preview.contains(r#"FOO="bar baz""#), "FOO missing: {preview}");
+        // strip_pollution unsets these
+        assert!(
+            preview.contains("-u NODE_OPTIONS"),
+            "missing -u NODE_OPTIONS: {preview}"
+        );
+        assert!(preview.contains("-u CLAUDECODE"), "missing -u CLAUDECODE: {preview}");
+        assert!(
+            preview.contains(r#""/usr/local/bin/bun""#),
+            "program missing: {preview}"
+        );
+        assert!(preview.contains(r#""--flag""#), "arg --flag missing: {preview}");
+        assert!(preview.contains(r#""with space""#), "arg with space missing: {preview}");
     }
 }


### PR DESCRIPTION
## Summary
- `aionui_runtime::Builder` now `impl Display`, delegating to `std::process::Command::Debug` so spawn previews come out as `cd "..." && env -u X K=V "prog" "args"...` — copy-pasteable into a shell.
- `cli_process::spawn_sdk` / `spawn_legacy` log the full preview (cwd, env tweaks incl. strip-pollution unsets, program, all args) on spawn / spawn-failure / process-spawned, replacing the prior `command=<program-only>` lines that hid args + env.

## Why
Spawn-time issues were hard to diagnose from `command=/Users/.../bun` alone — args, cwd and env tweaks (`BUN_INSTALL_CACHE_DIR`, `CLAUDE_CODE_EXECUTABLE`, `NODE_OPTIONS` unsets, etc.) were invisible. Reusing std `Command`'s existing `Debug` formatter avoids hand-rolling shell-quoting.

## Test plan
- [x] `cargo test -p aionui-runtime spawn::` — new `Display` regression test passes
- [x] `cargo test -p aionui-ai-agent --lib capability::cli_process` — all 20 cases pass
- [x] `cargo clippy -p aionui-runtime -p aionui-ai-agent --lib -- -D warnings` — clean
- [x] Verify dev-mode log shows full `cd ... && env ... bun x ...` line on next agent spawn