### PR TITLE
perf(team): lazy warm — only start agent processes on first message

### DIFF
--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -384,7 +384,6 @@ pub async fn create_router(services: &AppServices) -> Router {
         }
     });
 
-
     create_router_with_states(services, states)
 }
 

--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -384,11 +384,6 @@ pub async fn create_router(services: &AppServices) -> Router {
         }
     });
 
-    // Restore team MCP sessions so agents have tools available immediately
-    let team_service = states.team.service.clone();
-    tokio::spawn(async move {
-        team_service.restore_all_sessions().await;
-    });
 
     create_router_with_states(services, states)
 }

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -846,6 +846,7 @@ impl TeamSessionService {
         content: &str,
         files: Option<Vec<String>>,
     ) -> Result<(), TeamError> {
+        self.ensure_session(team_id).await?;
         let session = {
             let entry = self
                 .sessions
@@ -863,6 +864,7 @@ impl TeamSessionService {
         content: &str,
         files: Option<Vec<String>>,
     ) -> Result<(), TeamError> {
+        self.ensure_session(team_id).await?;
         let session = {
             let entry = self
                 .sessions

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -1442,8 +1442,9 @@ async fn dispose_all_cleans_up_sessions() {
 
     svc.dispose_all();
 
-    let result = svc.send_message(&t1.id, "Hello", None).await;
-    assert!(result.is_err());
+    // After dispose, sessions are cleaned up.
+    assert!(svc.get_session_scheduler(&t1.id).is_none());
+    assert!(svc.get_session_scheduler(&t2.id).is_none());
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary

- Remove eager `restore_all_sessions` at app startup that blocked startup for 12-30s (N agents × 4-6s serial warm)
- Add `ensure_session` calls in `send_message` / `send_message_to_agent` so team sessions are created on-demand when user actually sends a message
- App startup now takes ~20ms instead of 12-30s

## How it works

Before: app start → `restore_all_sessions()` → serial warm all teams' all agents → ready
After: app start → ready (no team activity). First message → `ensure_session` (idempotent, mutex-guarded) → warm agents → deliver message

## Frontend follow-up needed

Frontend still calls `POST /api/conversations/{id}/warmup` when entering a team page, which pre-warms agents unnecessarily. This should be removed separately (mnemo keyword: `前端 team 页面进入即预热`).

## Safety

- `ensure_session` is idempotent (`contains_key` + Mutex prevents concurrent re-entry)
- `event_loop.rs:execute_turn` has fallback warmup if agent was killed by idle scanner
- No message loss: agents can't communicate without session; once session exists, mailbox + event loop are fully wired

## Test plan

- [x] `cargo clippy -p aionui-app -p aionui-team -- -D warnings` passes
- [x] `cargo build --release` succeeds
- [x] Verified via logs: startup has zero TeamSession/warmup activity
- [x] Verified: sending message to team triggers lazy ensure_session correctly
- [x] Verified: ensure_session idempotent on repeated messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)