### PR TITLE
fix(ai-agent): negotiate OpenClaw protocol v3..v4

### DIFF
--- a/crates/aionui-ai-agent/src/manager/openclaw/connection.rs
+++ b/crates/aionui-ai-agent/src/manager/openclaw/connection.rs
@@ -14,7 +14,7 @@ use tracing::{debug, error, warn};
 use super::device_identity::{DeviceIdentity, build_device_auth_params};
 use super::protocol::{
     AuthParams, CLIENT_DISPLAY_NAME, CLIENT_ID, CLIENT_MODE, CLIENT_VERSION, ClientInfo, ConnectParams, EventFrame,
-    HelloOk, IncomingFrame, OPENCLAW_PROTOCOL_VERSION, RequestFrame,
+    HelloOk, IncomingFrame, OPENCLAW_MAX_PROTOCOL_VERSION, OPENCLAW_MIN_PROTOCOL_VERSION, RequestFrame,
 };
 
 type WsSink = futures_util::stream::SplitSink<
@@ -149,8 +149,8 @@ impl OpenClawConnection {
         let device_params = build_device_auth_params(identity, nonce, auth.as_ref().and_then(|a| a.token.as_deref()));
 
         let params = ConnectParams {
-            min_protocol: OPENCLAW_PROTOCOL_VERSION,
-            max_protocol: OPENCLAW_PROTOCOL_VERSION,
+            min_protocol: OPENCLAW_MIN_PROTOCOL_VERSION,
+            max_protocol: OPENCLAW_MAX_PROTOCOL_VERSION,
             client: ClientInfo {
                 id: CLIENT_ID,
                 display_name: CLIENT_DISPLAY_NAME,

--- a/crates/aionui-ai-agent/src/manager/openclaw/event_mapper.rs
+++ b/crates/aionui-ai-agent/src/manager/openclaw/event_mapper.rs
@@ -88,7 +88,21 @@ fn map_chat_event(
                 }));
             }
 
-            if let Some(delta) = compute_text_delta(&chat.message, &mut text_state.accumulated_text) {
+            // v4 schema delivers the incremental chunk in `deltaText` (with optional
+            // `replace=true` meaning the whole accumulated text should be reset to it).
+            // v3 schema instead sends cumulative text on `message` — we diff it.
+            let delta = if let Some(delta_text) = chat.delta_text.as_deref() {
+                if chat.replace == Some(true) {
+                    text_state.accumulated_text = delta_text.to_owned();
+                } else {
+                    text_state.accumulated_text.push_str(delta_text);
+                }
+                (!delta_text.is_empty()).then(|| delta_text.to_owned())
+            } else {
+                compute_text_delta(&chat.message, &mut text_state.accumulated_text)
+            };
+
+            if let Some(delta) = delta {
                 if text_state.current_msg_id.is_none() {
                     text_state.current_msg_id = Some(uuid::Uuid::new_v4().to_string());
                 }
@@ -317,6 +331,41 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert!(matches!(&events[0], AgentStreamEvent::Text(d) if d.content == "Hello"));
         assert_eq!(state.accumulated_text, "Hello");
+    }
+
+    #[test]
+    fn chat_delta_v4_uses_delta_text() {
+        let mut state = TextFallbackState::new();
+        state.reset_for_new_turn();
+
+        let e1 = make_event("chat", json!({ "state": "delta", "deltaText": "He" }));
+        let e2 = make_event("chat", json!({ "state": "delta", "deltaText": "llo" }));
+
+        let events1 = map_openclaw_event(&e1, &mut state, None);
+        assert_eq!(events1.len(), 1);
+        assert!(matches!(&events1[0], AgentStreamEvent::Text(d) if d.content == "He"));
+
+        let events2 = map_openclaw_event(&e2, &mut state, None);
+        assert_eq!(events2.len(), 1);
+        assert!(matches!(&events2[0], AgentStreamEvent::Text(d) if d.content == "llo"));
+        assert_eq!(state.accumulated_text, "Hello");
+    }
+
+    #[test]
+    fn chat_delta_v4_replace_resets_buffer() {
+        let mut state = TextFallbackState::new();
+        state.reset_for_new_turn();
+        state.accumulated_text = "stale draft".into();
+
+        let event = make_event(
+            "chat",
+            json!({ "state": "delta", "deltaText": "fresh", "replace": true }),
+        );
+        let events = map_openclaw_event(&event, &mut state, None);
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], AgentStreamEvent::Text(d) if d.content == "fresh"));
+        assert_eq!(state.accumulated_text, "fresh");
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/manager/openclaw/protocol.rs
+++ b/crates/aionui-ai-agent/src/manager/openclaw/protocol.rs
@@ -1,7 +1,11 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-pub const OPENCLAW_PROTOCOL_VERSION: u32 = 3;
+// Negotiated protocol range. Gateway 2026.5.12+ requires v4 (chat events become a
+// discriminated union with required `deltaText` on delta frames); older Gateways still
+// speak v3. Advertising `min=3, max=4` lets the same client connect to both.
+pub const OPENCLAW_MIN_PROTOCOL_VERSION: u32 = 3;
+pub const OPENCLAW_MAX_PROTOCOL_VERSION: u32 = 4;
 
 pub const CLIENT_ID: &str = "gateway-client";
 pub const CLIENT_DISPLAY_NAME: &str = "AionUI-Backend";
@@ -212,6 +216,14 @@ pub struct ChatEvent {
     pub state: ChatEventState,
     #[serde(default)]
     pub message: Option<Value>,
+    /// v4-only: incremental delta text on `state == "delta"` frames. Required by the
+    /// v4 schema (`ChatDeltaEventSchema`), absent on v3 Gateways. When present it is
+    /// the authoritative delta — `message` may be missing or carry only metadata.
+    #[serde(default)]
+    pub delta_text: Option<String>,
+    /// v4-only: when true the delta replaces the accumulated text instead of appending.
+    #[serde(default)]
+    pub replace: Option<bool>,
     #[serde(default)]
     pub error_message: Option<String>,
 }
@@ -382,13 +394,32 @@ mod tests {
         });
         let event: ChatEvent = serde_json::from_value(json).unwrap();
         assert_eq!(event.state, ChatEventState::Delta);
+        assert!(event.delta_text.is_none());
+        assert!(event.replace.is_none());
+    }
+
+    #[test]
+    fn chat_event_v4_delta_with_delta_text() {
+        let json = serde_json::json!({
+            "runId": "run-1",
+            "sessionKey": "sk-1",
+            "seq": 0,
+            "state": "delta",
+            "deltaText": "Hello",
+            "replace": false,
+        });
+        let event: ChatEvent = serde_json::from_value(json).unwrap();
+        assert_eq!(event.state, ChatEventState::Delta);
+        assert_eq!(event.delta_text.as_deref(), Some("Hello"));
+        assert_eq!(event.replace, Some(false));
+        assert!(event.message.is_none());
     }
 
     #[test]
     fn connect_params_serializes() {
         let params = ConnectParams {
-            min_protocol: 3,
-            max_protocol: 3,
+            min_protocol: OPENCLAW_MIN_PROTOCOL_VERSION,
+            max_protocol: OPENCLAW_MAX_PROTOCOL_VERSION,
             client: ClientInfo {
                 id: CLIENT_ID,
                 display_name: CLIENT_DISPLAY_NAME,
@@ -404,6 +435,7 @@ mod tests {
         };
         let json = serde_json::to_value(&params).unwrap();
         assert_eq!(json["minProtocol"], 3);
+        assert_eq!(json["maxProtocol"], 4);
         assert_eq!(json["client"]["id"], "gateway-client");
         assert_eq!(json["caps"][0], "tool-events");
     }


### PR DESCRIPTION
## Summary

OpenClaw Gateway 2026.5.12 (gateway commit `150bebcd0c` "fix(gateway): require v4 chat deltas") bumps `PROTOCOL_VERSION` to `4` and tightens both `MIN_CLIENT_PROTOCOL_VERSION` and `MIN_PROBE_PROTOCOL_VERSION` to `4`. Backends pinned at v3 are rejected during handshake with `protocol mismatch` (close code `1002`):

```
denying node-host ClawApp because it speaks an outdated protocol
minProtocol:3, maxProtocol:3, expectedProtocol:4, minimumProbeProtocol:4
node-host update required to speak version 4, rejecting outdated connections
```

Older Gateways (≤ 2026.5.11) still speak v3 only, so we cannot blindly bump the constant.

## What changed

- `OPENCLAW_PROTOCOL_VERSION` is split into `OPENCLAW_MIN_PROTOCOL_VERSION = 3` / `OPENCLAW_MAX_PROTOCOL_VERSION = 4`. `OpenClawConnection::send_connect` advertises the range `[3, 4]`, mirroring the gateway's own client (`src/gateway/client.ts:572` upstream uses `MIN_CLIENT_PROTOCOL_VERSION..PROTOCOL_VERSION`).
- `ChatEvent` gains the v4-only optional fields `delta_text` and `replace`. Both default to `None` so v3 frames still deserialize cleanly.
- `event_mapper::map_chat_event` now prefers `delta_text` for the incremental chunk (v4 schema makes it required on `delta` frames), honoring `replace=true` to reset the accumulated buffer. When `delta_text` is absent it falls back to the v3 cumulative-text diff.
- PRD `docs/prds/conversations/remote/remote-agent.md` updated to reflect the `min=3, max=4` range. *(Frontend PRD lives in the AionUi v2 repo; companion PR linked below.)*

## Test plan

- [x] `cargo test -p aionui-ai-agent --lib openclaw` — 66 passed (4 new/updated covering v4 delta-text increments, the `replace=true` reset, and the v3..v4 connect range)
- [x] `cargo clippy -p aionui-ai-agent --all-targets -- -D warnings` — 0 warnings
- [x] `cargo fmt --all -- --check`
- [x] `just push` (fmt + clippy + workspace test gate)
- [x] Behavioral: v3 path verified against the locally-running OpenClaw 2026.5.7 gateway (`PROTOCOL_VERSION=3`); v4 path verified against an upgraded ≥ 2026.5.12 gateway. Handshake succeeds in both directions and chat deltas stream through.

Sentry: closes ELECTRON-1CP (`https://iofficeai.sentry.io/issues/120169651/`).