### PR TITLE
refactor: rename binary from aionui-backend to aioncli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ permissions:
   contents: write
 
 env:
-  BINARY_NAME: aionui-backend
+  BINARY_NAME: aioncli
   CARGO_TERM_COLOR: always
   CARGO_HTTP_TIMEOUT: "600"
   CARGO_NET_RETRY: "10"
@@ -64,25 +64,25 @@ jobs:
           # deliberately drop it.
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            binary_name: aionui-backend
+            binary_name: aioncli
           # Linux aarch64: keep `cross` (its image happens to not trip the
           # aws-lc-sys check and also yields an older GLIBC baseline).
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            binary_name: aionui-backend
+            binary_name: aioncli
             use_cross: true
           - os: macos-latest
             target: x86_64-apple-darwin
-            binary_name: aionui-backend
+            binary_name: aioncli
           - os: macos-latest
             target: aarch64-apple-darwin
-            binary_name: aionui-backend
+            binary_name: aioncli
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            binary_name: aionui-backend.exe
+            binary_name: aioncli.exe
           - os: windows-latest
             target: aarch64-pc-windows-msvc
-            binary_name: aionui-backend.exe
+            binary_name: aioncli.exe
 
     steps:
       - uses: actions/checkout@v6
@@ -130,7 +130,7 @@ jobs:
           VERSION: ${{ needs.prepare-release.outputs.version }}
         run: |
           mkdir -p dist
-          ARCHIVE="aionui-backend-v${VERSION}-${{ matrix.target }}.tar.gz"
+          ARCHIVE="aioncli-v${VERSION}-${{ matrix.target }}.tar.gz"
           tar -C target/${{ matrix.target }}/release -czf "dist/${ARCHIVE}" ${{ matrix.binary_name }}
           echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
 
@@ -141,7 +141,7 @@ jobs:
           VERSION: ${{ needs.prepare-release.outputs.version }}
         run: |
           New-Item -ItemType Directory -Force -Path dist | Out-Null
-          $archive = "aionui-backend-v${env:VERSION}-${{ matrix.target }}.zip"
+          $archive = "aioncli-v${env:VERSION}-${{ matrix.target }}.zip"
           Compress-Archive -Path "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" -DestinationPath "dist/${archive}" -Force
           "ARCHIVE=${archive}" | Out-File -FilePath $env:GITHUB_ENV -Append
 
@@ -169,7 +169,7 @@ jobs:
         shell: bash
         run: |
           cd artifacts
-          sha256sum aionui-backend-* > aionui-backend-checksums.txt
+          sha256sum aioncli-* > aioncli-checksums.txt
 
       - name: Upload release assets
         shell: bash

--- a/crates/aionui-ai-agent/src/capability/backend_protocol_sink.rs
+++ b/crates/aionui-ai-agent/src/capability/backend_protocol_sink.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 
 use crate::protocol::events::{AcpPermissionEventData, AgentStreamEvent, ToolCallEventData, ToolCallStatus};
 
-/// Implements `ProtocolEmitter` for the aionui-backend context.
+/// Implements `ProtocolEmitter` for the aioncli context.
 ///
 /// Bridges aionrs `ProtocolEvent` emissions to `AgentStreamEvent` on a
 /// broadcast channel. Only handles events relevant to the approval flow;

--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -356,7 +356,7 @@ fn probe_with_reason(meta: &AgentMetadata) -> (Option<PathBuf>, Option<Unavailab
 
 /// Emit a single per-row line summarizing the probe outcome. Available
 /// rows go to `debug!` (one per startup × N agents is noisy at info);
-/// unavailable rows go to `info!` so the default backend.log surfaces
+/// unavailable rows go to `info!` so the default aioncli.log surfaces
 /// the reason without needing `--log-level debug` after a user
 /// reports "no agent works".
 fn log_probe_result(meta: &AgentMetadata, reason: &Option<UnavailableReason>) {

--- a/crates/aionui-ai-agent/tests/factory_provider_integration.rs
+++ b/crates/aionui-ai-agent/tests/factory_provider_integration.rs
@@ -72,7 +72,7 @@ fn make_factory(
         agent_registry,
         acp_agent_service,
         data_dir: PathBuf::from("/tmp/aionrs-test"),
-        backend_binary_path: Arc::new(PathBuf::from("/tmp/aionrs-test/aionui-backend")),
+        backend_binary_path: Arc::new(PathBuf::from("/tmp/aionrs-test/aioncli")),
         guide_mcp_config: None,
     })
 }

--- a/crates/aionui-api-types/src/team_mcp.rs
+++ b/crates/aionui-api-types/src/team_mcp.rs
@@ -53,7 +53,7 @@ mod tests {
             port: 54321,
             token: "tok-abc".into(),
             slot_id: "slot-1".into(),
-            binary_path: "/usr/bin/aionui-backend".into(),
+            binary_path: "/usr/bin/aioncli".into(),
         };
         let json = serde_json::to_string(&cfg).unwrap();
         let parsed: TeamMcpStdioConfig = serde_json::from_str(&json).unwrap();
@@ -65,7 +65,7 @@ mod tests {
         // Forward-compat: extra fields in persisted `conversation.extra.team_mcp_stdio_config`
         // JSON (e.g. added by a later backend version) must still round-trip through
         // older binaries without error.
-        let json = r#"{"team_id":"t-1","port":1,"token":"t","slot_id":"s","binary_path":"/usr/bin/aionui-backend","future_field":42}"#;
+        let json = r#"{"team_id":"t-1","port":1,"token":"t","slot_id":"s","binary_path":"/usr/bin/aioncli","future_field":42}"#;
         let parsed: TeamMcpStdioConfig = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.team_id, "t-1");
         assert_eq!(parsed.port, 1);

--- a/crates/aionui-app/Cargo.toml
+++ b/crates/aionui-app/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [[bin]]
-name = "aionui-backend"
+name = "aioncli"
 path = "src/main.rs"
 
 [features]

--- a/crates/aionui-app/src/bootstrap/tracing_init.rs
+++ b/crates/aionui-app/src/bootstrap/tracing_init.rs
@@ -53,7 +53,7 @@ pub fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> LogGuards {
     // Backend file layer — excludes aion_* targets
     let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
         .rotation(tracing_appender::rolling::Rotation::DAILY)
-        .filename_suffix("backend.log")
+        .filename_suffix("aioncli.log")
         .build(log_dir)
         .expect("failed to create backend log file appender");
     let (non_blocking, backend_guard) = tracing_appender::non_blocking(file_appender);

--- a/crates/aionui-app/src/cli.rs
+++ b/crates/aionui-app/src/cli.rs
@@ -1,4 +1,4 @@
-//! CLI argument definitions for the `aionui-backend` binary.
+//! CLI argument definitions for the `aioncli` binary.
 //!
 //! Kept separate from `main.rs` to isolate the clap surface (struct + enum +
 //! attribute soup) from the runtime entry point. Visibility is `pub(crate)`
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(name = "aionui-backend", about = "AionUi Backend Server")]
+#[command(name = "aioncli", about = "AionUi Backend Server")]
 pub(crate) struct Cli {
     /// Host address to listen on.
     #[arg(long, default_value_t = String::from(aionui_common::constants::DEFAULT_HOST))]

--- a/crates/aionui-app/src/commands/bridge.rs
+++ b/crates/aionui-app/src/commands/bridge.rs
@@ -1,6 +1,6 @@
-//! `aionui-backend mcp-bridge` subcommand: stdio ↔ TCP bridge for the team MCP server.
+//! `aioncli mcp-bridge` subcommand: stdio ↔ TCP bridge for the team MCP server.
 //!
-//! Spawned by the ACP agent CLI as an MCP server with command `aionui-backend mcp-bridge`.
+//! Spawned by the ACP agent CLI as an MCP server with command `aioncli mcp-bridge`.
 //! stdio side speaks newline-delimited JSON-RPC 2.0 (the MCP stdio transport);
 //! TCP side speaks 4-byte big-endian length-prefixed JSON frames against
 //! `127.0.0.1:<TEAM_MCP_PORT>` (reusing `aionui_team::mcp::protocol`).
@@ -22,7 +22,7 @@ use tokio::net::TcpStream;
 
 const CONNECT_ADDR_HOST: &str = "127.0.0.1";
 
-/// Entry point for `aionui-backend mcp-bridge`. Returns an [`ExitCode`] so the
+/// Entry point for `aioncli mcp-bridge`. Returns an [`ExitCode`] so the
 /// binary surfaces non-zero on any failure (ACP CLI uses that to mark the MCP
 /// server as broken).
 pub async fn run_mcp_bridge() -> ExitCode {

--- a/crates/aionui-app/src/commands/doctor.rs
+++ b/crates/aionui-app/src/commands/doctor.rs
@@ -1,4 +1,4 @@
-//! `aionui-backend doctor` subcommand: agent CLI detection self-check.
+//! `aioncli doctor` subcommand: agent CLI detection self-check.
 //!
 //! Hydrates the agent registry against the real on-disk database and
 //! prints a per-agent availability table to stdout. Mirrors the
@@ -32,7 +32,7 @@ pub async fn run_doctor(cli: &Cli, merged_path: &str) -> Result<ExitCode> {
 
     // Use the real on-disk DB so the report reflects the user's actual
     // catalog (including custom agents they've added via the UI).
-    let db_path = cli.data_dir.join("aionui-backend.db");
+    let db_path = cli.data_dir.join("aioncli.db");
     maybe_copy_legacy_database(&db_path)?;
     let database = init_database(&db_path).await?;
 

--- a/crates/aionui-app/src/commands/doctor.rs
+++ b/crates/aionui-app/src/commands/doctor.rs
@@ -32,7 +32,7 @@ pub async fn run_doctor(cli: &Cli, merged_path: &str) -> Result<ExitCode> {
 
     // Use the real on-disk DB so the report reflects the user's actual
     // catalog (including custom agents they've added via the UI).
-    let db_path = cli.data_dir.join("aioncli.db");
+    let db_path = cli.data_dir.join("aionui-backend.db");
     maybe_copy_legacy_database(&db_path)?;
     let database = init_database(&db_path).await?;
 

--- a/crates/aionui-app/src/commands/doctor.rs
+++ b/crates/aionui-app/src/commands/doctor.rs
@@ -7,7 +7,7 @@
 //! does for the server, so the bundled `bun` resolves through the
 //! same cache the server uses.
 //!
-//! Writes to stdout (not the rolling backend.log) — the user
+//! Writes to stdout (not the rolling aioncli.log) — the user
 //! typically runs `doctor` interactively after reporting "no agent
 //! works", and the answer needs to be visible in their terminal
 //! without grepping logs. We deliberately skip `init_environment` to

--- a/crates/aionui-app/src/commands/mod.rs
+++ b/crates/aionui-app/src/commands/mod.rs
@@ -1,4 +1,4 @@
-//! Subcommand implementations for the `aionui-backend` binary.
+//! Subcommand implementations for the `aioncli` binary.
 //!
 //! This file is a façade — module declarations and re-exports only.
 //! All logic lives in the submodules.

--- a/crates/aionui-app/src/commands/server.rs
+++ b/crates/aionui-app/src/commands/server.rs
@@ -1,4 +1,4 @@
-//! `aionui-backend` (no subcommand): the main HTTP server.
+//! `aioncli` (no subcommand): the main HTTP server.
 
 use std::process::ExitCode;
 use std::time::Instant;

--- a/crates/aionui-app/src/commands/team_guide.rs
+++ b/crates/aionui-app/src/commands/team_guide.rs
@@ -1,4 +1,4 @@
-//! `aionui-backend mcp-guide-stdio` subcommand: MCP stdio server for team-guide tools.
+//! `aioncli mcp-guide-stdio` subcommand: MCP stdio server for team-guide tools.
 //!
 //! Uses the `rmcp` crate (Rust MCP SDK) for protocol handling, ensuring full
 //! compatibility with Claude CLI's MCP client implementation.

--- a/crates/aionui-app/src/commands/team_stdio.rs
+++ b/crates/aionui-app/src/commands/team_stdio.rs
@@ -1,4 +1,4 @@
-//! `aionui-backend mcp-team-stdio` subcommand: MCP stdio server for team tools.
+//! `aioncli mcp-team-stdio` subcommand: MCP stdio server for team tools.
 //!
 //! Uses the `rmcp` crate (Rust MCP SDK) for protocol handling. Tool calls are
 //! forwarded to the TeamMcpServer TCP listener via 4-byte big-endian

--- a/crates/aionui-app/src/config.rs
+++ b/crates/aionui-app/src/config.rs
@@ -24,7 +24,7 @@ impl AppConfig {
 
     /// Path to the SQLite database file.
     pub fn database_path(&self) -> PathBuf {
-        self.data_dir.join("aionui-backend.db")
+        self.data_dir.join("aioncli.db")
     }
 }
 
@@ -78,6 +78,6 @@ mod tests {
             data_dir: PathBuf::from("/tmp/aionui"),
             ..Default::default()
         };
-        assert_eq!(config.database_path(), PathBuf::from("/tmp/aionui/aionui-backend.db"));
+        assert_eq!(config.database_path(), PathBuf::from("/tmp/aionui/aioncli.db"));
     }
 }

--- a/crates/aionui-app/src/config.rs
+++ b/crates/aionui-app/src/config.rs
@@ -24,7 +24,7 @@ impl AppConfig {
 
     /// Path to the SQLite database file.
     pub fn database_path(&self) -> PathBuf {
-        self.data_dir.join("aioncli.db")
+        self.data_dir.join("aionui-backend.db")
     }
 }
 
@@ -78,6 +78,6 @@ mod tests {
             data_dir: PathBuf::from("/tmp/aionui"),
             ..Default::default()
         };
-        assert_eq!(config.database_path(), PathBuf::from("/tmp/aionui/aioncli.db"));
+        assert_eq!(config.database_path(), PathBuf::from("/tmp/aionui/aionui-backend.db"));
     }
 }

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -110,7 +110,7 @@ pub async fn build_module_states(services: &AppServices) -> (ModuleStates, Chann
         std::env::current_exe()
             .ok()
             .and_then(|p| p.canonicalize().ok())
-            .unwrap_or_else(|| std::path::PathBuf::from("aionui-backend")),
+            .unwrap_or_else(|| std::path::PathBuf::from("aioncli")),
     );
 
     let agent_service = AgentService::new(services.agent_registry.clone(), services.data_dir.clone());

--- a/crates/aionui-app/src/services.rs
+++ b/crates/aionui-app/src/services.rs
@@ -136,7 +136,7 @@ impl AppServices {
         // the stdio MCP bridge spawned by ACP CLIs when a team session is
         // attached to a conversation (phase1 mcp.md §4.6 single-binary model).
         let backend_binary_path =
-            Arc::new(std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("aionui-backend")));
+            Arc::new(std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("aioncli")));
 
         // Start Guide MCP server. Failure is non-fatal: solo agents simply
         // won't get the `aion_create_team` tool.

--- a/crates/aionui-channel/src/plugins/dingtalk/api.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/api.rs
@@ -163,7 +163,7 @@ impl DingtalkApi {
                     topic: "/v1.0/card/instances/callback".into(),
                 },
             ],
-            ua: Some("aionui-backend".into()),
+            ua: Some("aioncli".into()),
         };
 
         let raw_resp = self

--- a/crates/aionui-channel/src/plugins/dingtalk/types.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/types.rs
@@ -801,12 +801,12 @@ mod tests {
                     topic: "/v1.0/im/bot/messages/get".into(),
                 },
             ],
-            ua: Some("aionui-backend".into()),
+            ua: Some("aioncli".into()),
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["clientId"], "my_client_id");
         assert_eq!(json["clientSecret"], "my_secret");
-        assert_eq!(json["ua"], "aionui-backend");
+        assert_eq!(json["ua"], "aioncli");
         assert_eq!(json["subscriptions"][0]["type"], "EVENT");
         assert_eq!(json["subscriptions"][0]["topic"], "*");
         assert_eq!(json["subscriptions"][1]["type"], "CALLBACK");

--- a/crates/aionui-db/tests/db_lifecycle.rs
+++ b/crates/aionui-db/tests/db_lifecycle.rs
@@ -267,7 +267,7 @@ async fn creates_parent_directories() {
 #[test]
 fn copy_legacy_noop_when_no_legacy_db() {
     let dir = tempfile::tempdir().unwrap();
-    let target = dir.path().join("aionui-backend.db");
+    let target = dir.path().join("aioncli.db");
 
     maybe_copy_legacy_database(&target).unwrap();
     assert!(!target.exists(), "target should not be created when no legacy db");
@@ -276,7 +276,7 @@ fn copy_legacy_noop_when_no_legacy_db() {
 #[test]
 fn copy_legacy_noop_when_target_exists() {
     let dir = tempfile::tempdir().unwrap();
-    let target = dir.path().join("aionui-backend.db");
+    let target = dir.path().join("aioncli.db");
     let legacy = dir.path().join("aionui.db");
 
     std::fs::write(&legacy, b"legacy data").unwrap();
@@ -291,7 +291,7 @@ fn copy_legacy_noop_when_target_exists() {
 #[test]
 fn copy_legacy_copies_when_target_missing() {
     let dir = tempfile::tempdir().unwrap();
-    let target = dir.path().join("aionui-backend.db");
+    let target = dir.path().join("aioncli.db");
     let legacy = dir.path().join("aionui.db");
 
     std::fs::write(&legacy, b"legacy database content").unwrap();
@@ -312,7 +312,7 @@ fn copy_legacy_copies_when_target_missing() {
 #[test]
 fn copy_legacy_removes_wal_sidecars() {
     let dir = tempfile::tempdir().unwrap();
-    let target = dir.path().join("aionui-backend.db");
+    let target = dir.path().join("aioncli.db");
     let legacy = dir.path().join("aionui.db");
 
     std::fs::write(&legacy, b"legacy data").unwrap();
@@ -334,7 +334,7 @@ fn copy_legacy_removes_wal_sidecars() {
 #[test]
 fn copy_legacy_overwrites_leftover_tmp() {
     let dir = tempfile::tempdir().unwrap();
-    let target = dir.path().join("aionui-backend.db");
+    let target = dir.path().join("aioncli.db");
     let legacy = dir.path().join("aionui.db");
     let tmp = target.with_extension("db.tmp");
 
@@ -352,7 +352,7 @@ fn copy_legacy_overwrites_leftover_tmp() {
 #[tokio::test]
 async fn copy_legacy_then_init_database_works() {
     let dir = tempfile::tempdir().unwrap();
-    let target = dir.path().join("aionui-backend.db");
+    let target = dir.path().join("aioncli.db");
     let legacy = dir.path().join("aionui.db");
 
     let legacy_db = init_database(&legacy).await.unwrap();

--- a/crates/aionui-db/tests/db_lifecycle.rs
+++ b/crates/aionui-db/tests/db_lifecycle.rs
@@ -267,7 +267,7 @@ async fn creates_parent_directories() {
 #[test]
 fn copy_legacy_noop_when_no_legacy_db() {
     let dir = tempfile::tempdir().unwrap();
-    let target = dir.path().join("aioncli.db");
+    let target = dir.path().join("aionui-backend.db");
 
     maybe_copy_legacy_database(&target).unwrap();
     assert!(!target.exists(), "target should not be created when no legacy db");
@@ -276,7 +276,7 @@ fn copy_legacy_noop_when_no_legacy_db() {
 #[test]
 fn copy_legacy_noop_when_target_exists() {
     let dir = tempfile::tempdir().unwrap();
-    let target = dir.path().join("aioncli.db");
+    let target = dir.path().join("aionui-backend.db");
     let legacy = dir.path().join("aionui.db");
 
     std::fs::write(&legacy, b"legacy data").unwrap();
@@ -291,7 +291,7 @@ fn copy_legacy_noop_when_target_exists() {
 #[test]
 fn copy_legacy_copies_when_target_missing() {
     let dir = tempfile::tempdir().unwrap();
-    let target = dir.path().join("aioncli.db");
+    let target = dir.path().join("aionui-backend.db");
     let legacy = dir.path().join("aionui.db");
 
     std::fs::write(&legacy, b"legacy database content").unwrap();
@@ -312,7 +312,7 @@ fn copy_legacy_copies_when_target_missing() {
 #[test]
 fn copy_legacy_removes_wal_sidecars() {
     let dir = tempfile::tempdir().unwrap();
-    let target = dir.path().join("aioncli.db");
+    let target = dir.path().join("aionui-backend.db");
     let legacy = dir.path().join("aionui.db");
 
     std::fs::write(&legacy, b"legacy data").unwrap();
@@ -334,7 +334,7 @@ fn copy_legacy_removes_wal_sidecars() {
 #[test]
 fn copy_legacy_overwrites_leftover_tmp() {
     let dir = tempfile::tempdir().unwrap();
-    let target = dir.path().join("aioncli.db");
+    let target = dir.path().join("aionui-backend.db");
     let legacy = dir.path().join("aionui.db");
     let tmp = target.with_extension("db.tmp");
 
@@ -352,7 +352,7 @@ fn copy_legacy_overwrites_leftover_tmp() {
 #[tokio::test]
 async fn copy_legacy_then_init_database_works() {
     let dir = tempfile::tempdir().unwrap();
-    let target = dir.path().join("aioncli.db");
+    let target = dir.path().join("aionui-backend.db");
     let legacy = dir.path().join("aionui.db");
 
     let legacy_db = init_database(&legacy).await.unwrap();

--- a/crates/aionui-runtime/Cargo.toml
+++ b/crates/aionui-runtime/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [package.metadata.aionui-runtime]
 # 1.3.x required: 1.1.38 has a stdin-buffering bug in `bun x --bun` that
 # prevents AionUi's ACP adapter (long-lived stdio protocol) from ever
-# receiving the initialize request — see aionui-backend fix notes for
+# receiving the initialize request — see aioncli fix notes for
 # AionUi#2828. If bumping, keep >= 1.3.13.
 bun_version = "1.3.13"
 

--- a/crates/aionui-runtime/src/lib.rs
+++ b/crates/aionui-runtime/src/lib.rs
@@ -1,4 +1,4 @@
-//! Bundled runtime (bun) resolver for aionui-backend.
+//! Bundled runtime (bun) resolver for aioncli.
 //!
 //! Embeds the bun runtime at build time (zstd-compressed) and extracts it
 //! to the user's OS cache directory on first call. Callers use

--- a/crates/aionui-system/src/version.rs
+++ b/crates/aionui-system/src/version.rs
@@ -86,7 +86,7 @@ impl VersionCheckService {
                 .http_client
                 .get(&url)
                 .header("Accept", "application/vnd.github+json")
-                .header("User-Agent", "aionui-backend")
+                .header("User-Agent", "aioncli")
                 .send()
                 .await
                 .map_err(|e| AppError::BadGateway(format!("GitHub API request failed: {e}")))?;

--- a/crates/aionui-team/src/mcp/bridge.rs
+++ b/crates/aionui-team/src/mcp/bridge.rs
@@ -33,7 +33,7 @@ pub struct TeamMcpStdioServerSpec {
 impl TeamMcpStdioServerSpec {
     /// Build the spec from the persisted stdio config plus runtime context.
     ///
-    /// `backend_binary_path` is the absolute path to the `aionui-backend`
+    /// `backend_binary_path` is the absolute path to the `aioncli`
     /// executable (phase1 single-binary constraint — no standalone bridge).
     /// `team_id` is read from `cfg.team_id` rather than taken as a separate
     /// parameter so the wire-level server name stays in sync with the
@@ -79,16 +79,16 @@ mod tests {
             port: 12345,
             token: "tok-abc".into(),
             slot_id: "slot-1".into(),
-            binary_path: "/usr/bin/aionui-backend".into(),
+            binary_path: "/usr/bin/aioncli".into(),
         }
     }
 
     #[test]
     fn from_config_fills_all_fields() {
-        let spec = TeamMcpStdioServerSpec::from_config("/usr/bin/aionui-backend", &sample_cfg());
+        let spec = TeamMcpStdioServerSpec::from_config("/usr/bin/aioncli", &sample_cfg());
 
         assert_eq!(spec.name, "aionui-team-team-42");
-        assert_eq!(spec.command, "/usr/bin/aionui-backend");
+        assert_eq!(spec.command, "/usr/bin/aioncli");
         assert_eq!(spec.args, vec!["mcp-bridge".to_owned()]);
         assert_eq!(spec.env.len(), 3);
     }
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn into_sdk_serializes_as_stdio_variant() {
-        let spec = TeamMcpStdioServerSpec::from_config("/bin/aionui-backend", &sample_cfg());
+        let spec = TeamMcpStdioServerSpec::from_config("/bin/aioncli", &sample_cfg());
         let sdk = spec.into_sdk();
 
         let json = serde_json::to_value(&sdk).expect("serialize");
@@ -119,7 +119,7 @@ mod tests {
         // `Stdio` variant is `#[serde(untagged)]` inside `McpServer`, so the
         // JSON is the raw `McpServerStdio` shape — no `"type":"stdio"` tag.
         assert_eq!(json["name"], "aionui-team-team-42");
-        assert_eq!(json["command"], "/bin/aionui-backend");
+        assert_eq!(json["command"], "/bin/aioncli");
         assert_eq!(json["args"], serde_json::json!(["mcp-bridge"]));
 
         let env = json["env"].as_array().expect("env array");

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -879,7 +879,7 @@ mod tests {
     }
 
     fn backend_path() -> Arc<PathBuf> {
-        Arc::new(PathBuf::from("/tmp/aionui-backend-test"))
+        Arc::new(PathBuf::from("/tmp/aioncli-test"))
     }
 
     /// Mock agent whose `send_message` pushes the received payload into a
@@ -1128,7 +1128,7 @@ mod tests {
         let session = start_session().await;
         let spec = session.stdio_spec("lead-1");
         assert_eq!(spec.name, "aionui-team-t1");
-        assert_eq!(spec.command, "/tmp/aionui-backend-test");
+        assert_eq!(spec.command, "/tmp/aioncli-test");
         assert_eq!(spec.args, vec!["mcp-bridge".to_string()]);
         assert!(spec.env.iter().any(|(k, v)| k == "TEAM_AGENT_SLOT_ID" && v == "lead-1"));
         session.stop();

--- a/crates/aionui-team/tests/e2e_team_flow.rs
+++ b/crates/aionui-team/tests/e2e_team_flow.rs
@@ -324,7 +324,7 @@ fn mcp_text(resp: &Value) -> &str {
 // ---------------------------------------------------------------------------
 
 fn backend_path() -> Arc<PathBuf> {
-    Arc::new(PathBuf::from("/tmp/aionui-backend-e2e-test"))
+    Arc::new(PathBuf::from("/tmp/aioncli-e2e-test"))
 }
 
 /// Two-agent team definition: one Lead + one Worker.

--- a/crates/aionui-team/tests/mcp_server_integration.rs
+++ b/crates/aionui-team/tests/mcp_server_integration.rs
@@ -796,10 +796,10 @@ async fn sb1_bridge_config_generation() {
         port: env.server.port(),
         token: env.server.auth_token().to_string(),
         slot_id: "lead-1".into(),
-        binary_path: "/bin/aionui-backend".into(),
+        binary_path: "/bin/aioncli".into(),
     };
 
-    let spec = TeamMcpStdioServerSpec::from_config("/bin/aionui-backend", &config);
+    let spec = TeamMcpStdioServerSpec::from_config("/bin/aioncli", &config);
     let env_map: std::collections::HashMap<_, _> = spec.env.iter().cloned().collect();
     assert_eq!(env_map[TeamMcpStdioConfig::ENV_PORT], env.server.port().to_string());
     assert_eq!(env_map[TeamMcpStdioConfig::ENV_TOKEN], "test-token-123");

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -619,7 +619,7 @@ fn setup_with_factory_and_metadata(
         agent_metadata_repo.clone(),
         acp_session_repo,
     );
-    let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aionui-backend-test"));
+    let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aioncli-test"));
     let provider_repo: Arc<dyn IProviderRepository> = Arc::new(EmptyProviderRepo);
     let svc = TeamSessionService::new(
         team_repo,
@@ -655,7 +655,7 @@ fn setup_with_recording_broadcaster() -> (Arc<TeamSessionService>, Arc<Recording
         agent_metadata_repo.clone(),
         acp_session_repo,
     );
-    let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aionui-backend-test"));
+    let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aioncli-test"));
     let provider_repo: Arc<dyn IProviderRepository> = Arc::new(EmptyProviderRepo);
     let svc = TeamSessionService::new(
         team_repo,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
   "include-v-in-tag": true,
   "packages": {
     ".": {
-      "package-name": "aionui-backend",
+      "package-name": "aioncli",
       "include-component-in-tag": false,
       "release-type": "simple",
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Summary

- Rename binary from `aionui-backend` to `aioncli` (Cargo.toml `[[bin]]` name)
- Update CI release workflow: artifact names, checksums, BINARY_NAME
- Update release-please config package-name
- Update User-Agent headers (system version check, DingTalk API)
- Update CLI `#[command(name)]` and all doc comments
- Rename log file suffix from `backend.log` to `aioncli.log`
- Update fallback binary paths in services and router state
- Update all test paths referencing the old binary name
- Update git remote to `iOfficeAI/AionCLI`
- Database filename `aionui-backend.db` is **preserved** for backward compatibility

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace -- -D warnings` passes (0 warnings)
- [x] `cargo nextest run --workspace` — 5535 tests passed, 0 failures
- [ ] Verify release workflow produces `aioncli-v*.tar.gz` artifacts
- [ ] Verify DingTalk webhook UA header is correct