### PR TITLE
feat(ai-agent): add cc-switch provider env injection for Claude ACP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +339,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hex",
  "regex",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2263,6 +2276,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,6 +2652,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2648,6 +2676,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -4233,6 +4270,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4817,7 +4868,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap 2.14.0",
  "log",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ clap = { version = "4", features = ["derive"] }
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 # Auth / Crypto
 jsonwebtoken = "9"

--- a/crates/aionui-ai-agent/Cargo.toml
+++ b/crates/aionui-ai-agent/Cargo.toml
@@ -37,6 +37,7 @@ aion-mcp.workspace = true
 uuid.workspace = true
 agent-client-protocol = { version = "0.11.1", features = ["unstable_session_model", "unstable_session_close", "unstable_session_usage", "unstable_session_fork", "unstable_session_additional_directories", "unstable_session_resume"] }
 tokio-util = { version = "0.7", features = ["compat"] }
+rusqlite.workspace = true
 
 [features]
 # Enables the `AgentInstance::Mock` variant used by downstream test harnesses

--- a/crates/aionui-ai-agent/src/agent_task.rs
+++ b/crates/aionui-ai-agent/src/agent_task.rs
@@ -356,7 +356,13 @@ impl AgentInstance {
         match self {
             Self::Acp(m) => {
                 let sdk_model = m.model().await;
-                let model_info = sdk_model.map(map_sdk_model_to_payload);
+                let sdk_info = sdk_model.map(map_sdk_model_to_payload);
+                let cc_switch_info = if m.is_claude_backend() {
+                    crate::cc_switch::read_claude_model_info()
+                } else {
+                    None
+                };
+                let model_info = merge_model_info(sdk_info, cc_switch_info);
                 Ok(GetModelInfoResponse { model_info })
             }
             Self::Aionrs(_) | Self::OpenClaw(_) | Self::Nanobot(_) | Self::Remote(_) => {
@@ -488,5 +494,61 @@ fn map_sdk_model_to_payload(m: agent_client_protocol::schema::SessionModelState)
         current_model_id: Some(current_id),
         current_model_label: Some(current_label),
         available_models: available,
+    }
+}
+
+fn merge_model_info(
+    sdk_info: Option<ModelInfoPayload>,
+    cc_switch_info: Option<ModelInfoPayload>,
+) -> Option<ModelInfoPayload> {
+    sdk_info.or(cc_switch_info)
+}
+
+#[cfg(test)]
+mod cc_switch_model_merge_tests {
+    use super::*;
+
+    #[test]
+    fn merge_prefers_sdk_model_over_cc_switch() {
+        let sdk_payload = ModelInfoPayload {
+            current_model_id: Some("default".into()),
+            current_model_label: Some("Claude Sonnet 4.6".into()),
+            available_models: vec![ModelInfoEntry {
+                id: "default".into(),
+                label: "Claude Sonnet 4.6".into(),
+            }],
+        };
+        let cc_switch_payload = ModelInfoPayload {
+            current_model_id: Some("default".into()),
+            current_model_label: Some("DeepSeek V4".into()),
+            available_models: vec![ModelInfoEntry {
+                id: "default".into(),
+                label: "DeepSeek V4".into(),
+            }],
+        };
+
+        let result = merge_model_info(Some(sdk_payload), Some(cc_switch_payload));
+        assert_eq!(result.unwrap().current_model_label.as_deref(), Some("Claude Sonnet 4.6"));
+    }
+
+    #[test]
+    fn merge_falls_back_to_cc_switch_when_sdk_none() {
+        let cc_switch_payload = ModelInfoPayload {
+            current_model_id: Some("default".into()),
+            current_model_label: Some("DeepSeek V4".into()),
+            available_models: vec![ModelInfoEntry {
+                id: "default".into(),
+                label: "DeepSeek V4".into(),
+            }],
+        };
+
+        let result = merge_model_info(None, Some(cc_switch_payload));
+        assert_eq!(result.unwrap().current_model_label.as_deref(), Some("DeepSeek V4"));
+    }
+
+    #[test]
+    fn merge_returns_none_when_both_none() {
+        let result = merge_model_info(None, None);
+        assert!(result.is_none());
     }
 }

--- a/crates/aionui-ai-agent/src/agent_task.rs
+++ b/crates/aionui-ai-agent/src/agent_task.rs
@@ -528,7 +528,10 @@ mod cc_switch_model_merge_tests {
         };
 
         let result = merge_model_info(Some(sdk_payload), Some(cc_switch_payload));
-        assert_eq!(result.unwrap().current_model_label.as_deref(), Some("Claude Sonnet 4.6"));
+        assert_eq!(
+            result.unwrap().current_model_label.as_deref(),
+            Some("Claude Sonnet 4.6")
+        );
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/cc_switch/mod.rs
+++ b/crates/aionui-ai-agent/src/cc_switch/mod.rs
@@ -1,3 +1,5 @@
 mod paths;
+mod provider_env;
 
 pub use paths::CcSwitchPaths;
+pub use provider_env::{read_claude_provider_env, read_claude_provider_env_with_paths};

--- a/crates/aionui-ai-agent/src/cc_switch/mod.rs
+++ b/crates/aionui-ai-agent/src/cc_switch/mod.rs
@@ -1,0 +1,3 @@
+mod paths;
+
+pub use paths::CcSwitchPaths;

--- a/crates/aionui-ai-agent/src/cc_switch/mod.rs
+++ b/crates/aionui-ai-agent/src/cc_switch/mod.rs
@@ -1,5 +1,7 @@
+mod model_info;
 mod paths;
 mod provider_env;
 
+pub use model_info::{build_model_info_from_env, read_claude_model_info, read_claude_model_info_with_paths};
 pub use paths::CcSwitchPaths;
 pub use provider_env::{read_claude_provider_env, read_claude_provider_env_with_paths};

--- a/crates/aionui-ai-agent/src/cc_switch/model_info.rs
+++ b/crates/aionui-ai-agent/src/cc_switch/model_info.rs
@@ -34,7 +34,9 @@ pub fn build_model_info_from_env(
         .filter(|s| !s.trim().is_empty())
         .or_else(|| env.get("ANTHROPIC_MODEL").filter(|s| !s.trim().is_empty()));
     let opus_model = env.get("ANTHROPIC_DEFAULT_OPUS_MODEL").filter(|s| !s.trim().is_empty());
-    let haiku_model = env.get("ANTHROPIC_DEFAULT_HAIKU_MODEL").filter(|s| !s.trim().is_empty());
+    let haiku_model = env
+        .get("ANTHROPIC_DEFAULT_HAIKU_MODEL")
+        .filter(|s| !s.trim().is_empty());
 
     let mut available = Vec::new();
     let mut seen = std::collections::HashSet::new();
@@ -42,17 +44,17 @@ pub fn build_model_info_from_env(
     let candidates = [("default", default_model), ("opus", opus_model), ("haiku", haiku_model)];
 
     for (slot, model_id_opt) in &candidates {
-        if let Some(model_id) = model_id_opt {
-            if seen.insert(model_id.as_str()) {
-                let label = labels
-                    .get(model_id.as_str())
-                    .cloned()
-                    .unwrap_or_else(|| (*model_id).clone());
-                available.push(ModelInfoEntry {
-                    id: slot.to_string(),
-                    label,
-                });
-            }
+        if let Some(model_id) = model_id_opt
+            && seen.insert(model_id.as_str())
+        {
+            let label = labels
+                .get(model_id.as_str())
+                .cloned()
+                .unwrap_or_else(|| (*model_id).clone());
+            available.push(ModelInfoEntry {
+                id: slot.to_string(),
+                label,
+            });
         }
     }
 
@@ -66,7 +68,10 @@ pub fn build_model_info_from_env(
         .find(|m| m.id == preferred_slot)
         .map(|m| m.id.clone())
         .unwrap_or_else(|| available[0].id.clone());
-    let current_model_label = available.iter().find(|m| m.id == current_model_id).map(|m| m.label.clone());
+    let current_model_label = available
+        .iter()
+        .find(|m| m.id == current_model_id)
+        .map(|m| m.label.clone());
 
     Some(ModelInfoPayload {
         current_model_id: Some(current_model_id),
@@ -130,7 +135,11 @@ pub fn read_claude_model_info_with_paths(paths: &CcSwitchPaths) -> Option<ModelI
 
     let env: HashMap<String, String> = env_obj
         .iter()
-        .filter_map(|(k, v)| v.as_str().filter(|s| !s.trim().is_empty()).map(|s| (k.clone(), s.to_owned())))
+        .filter_map(|(k, v)| {
+            v.as_str()
+                .filter(|s| !s.trim().is_empty())
+                .map(|s| (k.clone(), s.to_owned()))
+        })
         .collect();
 
     let labels = read_model_labels(&conn);

--- a/crates/aionui-ai-agent/src/cc_switch/model_info.rs
+++ b/crates/aionui-ai-agent/src/cc_switch/model_info.rs
@@ -1,0 +1,215 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use aionui_api_types::{ModelInfoEntry, ModelInfoPayload};
+use rusqlite::Connection;
+use tracing::warn;
+
+use super::CcSwitchPaths;
+
+pub(crate) fn normalize_claude_model_slot(value: &str) -> Option<&'static str> {
+    match value.trim().to_lowercase().as_str() {
+        "sonnet" | "default" => Some("default"),
+        "opus" => Some("opus"),
+        "haiku" => Some("haiku"),
+        _ => None,
+    }
+}
+
+fn read_claude_selected_slot(claude_settings_path: &Path) -> Option<&'static str> {
+    let content = fs::read_to_string(claude_settings_path).ok()?;
+    let parsed: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let model_str = parsed.get("model")?.as_str()?;
+    normalize_claude_model_slot(model_str)
+}
+
+pub fn build_model_info_from_env(
+    env: &HashMap<String, String>,
+    labels: &HashMap<String, String>,
+    active_slot: Option<&str>,
+) -> Option<ModelInfoPayload> {
+    let default_model = env
+        .get("ANTHROPIC_DEFAULT_SONNET_MODEL")
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| env.get("ANTHROPIC_MODEL").filter(|s| !s.trim().is_empty()));
+    let opus_model = env.get("ANTHROPIC_DEFAULT_OPUS_MODEL").filter(|s| !s.trim().is_empty());
+    let haiku_model = env.get("ANTHROPIC_DEFAULT_HAIKU_MODEL").filter(|s| !s.trim().is_empty());
+
+    let mut available = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    let candidates = [("default", default_model), ("opus", opus_model), ("haiku", haiku_model)];
+
+    for (slot, model_id_opt) in &candidates {
+        if let Some(model_id) = model_id_opt {
+            if seen.insert(model_id.as_str()) {
+                let label = labels
+                    .get(model_id.as_str())
+                    .cloned()
+                    .unwrap_or_else(|| (*model_id).clone());
+                available.push(ModelInfoEntry {
+                    id: slot.to_string(),
+                    label,
+                });
+            }
+        }
+    }
+
+    if available.is_empty() {
+        return None;
+    }
+
+    let preferred_slot = active_slot.and_then(normalize_claude_model_slot).unwrap_or("default");
+    let current_model_id = available
+        .iter()
+        .find(|m| m.id == preferred_slot)
+        .map(|m| m.id.clone())
+        .unwrap_or_else(|| available[0].id.clone());
+    let current_model_label = available.iter().find(|m| m.id == current_model_id).map(|m| m.label.clone());
+
+    Some(ModelInfoPayload {
+        current_model_id: Some(current_model_id),
+        current_model_label,
+        available_models: available,
+    })
+}
+
+fn read_model_labels(conn: &Connection) -> HashMap<String, String> {
+    let mut stmt = match conn.prepare("SELECT model_id, display_name FROM model_pricing") {
+        Ok(s) => s,
+        Err(_) => return HashMap::new(),
+    };
+    let rows = stmt
+        .query_map([], |row| {
+            let model_id: String = row.get(0)?;
+            let display_name: Option<String> = row.get(1)?;
+            Ok((model_id, display_name))
+        })
+        .ok();
+
+    let Some(rows) = rows else {
+        return HashMap::new();
+    };
+
+    rows.filter_map(|r| r.ok())
+        .filter(|(id, _)| !id.trim().is_empty())
+        .map(|(id, name)| {
+            let label = name.filter(|n| !n.trim().is_empty()).unwrap_or_else(|| id.clone());
+            (id, label)
+        })
+        .collect()
+}
+
+pub fn read_claude_model_info_with_paths(paths: &CcSwitchPaths) -> Option<ModelInfoPayload> {
+    let settings_content = fs::read_to_string(&paths.settings_path).ok()?;
+    let settings: serde_json::Value = serde_json::from_str(&settings_content).ok()?;
+    let provider_id = settings
+        .get("currentProviderClaude")?
+        .as_str()
+        .filter(|s| !s.trim().is_empty())?;
+
+    if !paths.database_path.exists() {
+        return None;
+    }
+
+    let conn = Connection::open_with_flags(&paths.database_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| warn!(error = %e, "cc-switch: failed to open database for model info"))
+        .ok()?;
+
+    let settings_config_json: String = conn
+        .query_row(
+            "SELECT settings_config FROM providers WHERE id = ?1 AND app_type = 'claude' LIMIT 1",
+            [provider_id],
+            |row| row.get(0),
+        )
+        .ok()?;
+
+    let config: serde_json::Value = serde_json::from_str(&settings_config_json).ok()?;
+    let env_obj = config.get("env")?.as_object()?;
+
+    let env: HashMap<String, String> = env_obj
+        .iter()
+        .filter_map(|(k, v)| v.as_str().filter(|s| !s.trim().is_empty()).map(|s| (k.clone(), s.to_owned())))
+        .collect();
+
+    let labels = read_model_labels(&conn);
+    let active_slot = read_claude_selected_slot(&paths.claude_settings_path)
+        .or_else(|| config.get("model")?.as_str().and_then(normalize_claude_model_slot));
+
+    build_model_info_from_env(&env, &labels, active_slot)
+}
+
+pub fn read_claude_model_info() -> Option<ModelInfoPayload> {
+    let paths = CcSwitchPaths::system()?;
+    read_claude_model_info_with_paths(&paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_model_info_from_env_with_all_slots() {
+        let mut env = HashMap::new();
+        env.insert("ANTHROPIC_DEFAULT_SONNET_MODEL".into(), "deepseek-v4-pro".into());
+        env.insert("ANTHROPIC_DEFAULT_OPUS_MODEL".into(), "deepseek-v4-max".into());
+        env.insert("ANTHROPIC_DEFAULT_HAIKU_MODEL".into(), "deepseek-v4-lite".into());
+
+        let labels = HashMap::from([
+            ("deepseek-v4-pro".to_owned(), "DeepSeek V4 Pro".to_owned()),
+            ("deepseek-v4-max".to_owned(), "DeepSeek V4 Max".to_owned()),
+            ("deepseek-v4-lite".to_owned(), "DeepSeek V4 Lite".to_owned()),
+        ]);
+
+        let info = build_model_info_from_env(&env, &labels, None);
+        assert!(info.is_some());
+
+        let payload = info.unwrap();
+        assert_eq!(payload.available_models.len(), 3);
+        assert_eq!(payload.current_model_id.as_deref(), Some("default"));
+        assert_eq!(payload.current_model_label.as_deref(), Some("DeepSeek V4 Pro"));
+    }
+
+    #[test]
+    fn builds_model_info_single_model() {
+        let mut env = HashMap::new();
+        env.insert("ANTHROPIC_MODEL".into(), "glm-5.1x".into());
+
+        let info = build_model_info_from_env(&env, &HashMap::new(), None);
+        assert!(info.is_some());
+
+        let payload = info.unwrap();
+        assert_eq!(payload.available_models.len(), 1);
+        assert_eq!(payload.available_models[0].id, "default");
+        assert_eq!(payload.available_models[0].label, "glm-5.1x");
+    }
+
+    #[test]
+    fn returns_none_when_no_model_env_vars() {
+        let env = HashMap::new();
+        let info = build_model_info_from_env(&env, &HashMap::new(), None);
+        assert!(info.is_none());
+    }
+
+    #[test]
+    fn respects_active_slot_override() {
+        let mut env = HashMap::new();
+        env.insert("ANTHROPIC_DEFAULT_SONNET_MODEL".into(), "model-a".into());
+        env.insert("ANTHROPIC_DEFAULT_OPUS_MODEL".into(), "model-b".into());
+
+        let info = build_model_info_from_env(&env, &HashMap::new(), Some("opus"));
+        assert!(info.is_some());
+        assert_eq!(info.unwrap().current_model_id.as_deref(), Some("opus"));
+    }
+
+    #[test]
+    fn normalize_slot_maps_sonnet_to_default() {
+        assert_eq!(normalize_claude_model_slot("sonnet"), Some("default"));
+        assert_eq!(normalize_claude_model_slot("default"), Some("default"));
+        assert_eq!(normalize_claude_model_slot("opus"), Some("opus"));
+        assert_eq!(normalize_claude_model_slot("haiku"), Some("haiku"));
+        assert_eq!(normalize_claude_model_slot("unknown"), None);
+        assert_eq!(normalize_claude_model_slot(""), None);
+    }
+}

--- a/crates/aionui-ai-agent/src/cc_switch/paths.rs
+++ b/crates/aionui-ai-agent/src/cc_switch/paths.rs
@@ -1,0 +1,43 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct CcSwitchPaths {
+    pub settings_path: PathBuf,
+    pub database_path: PathBuf,
+    pub claude_settings_path: PathBuf,
+}
+
+impl CcSwitchPaths {
+    pub fn from_home(home: &Path) -> Self {
+        let base = home.join(".cc-switch");
+        Self {
+            settings_path: base.join("settings.json"),
+            database_path: base.join("cc-switch.db"),
+            claude_settings_path: home.join(".claude").join("settings.json"),
+        }
+    }
+
+    pub fn system() -> Option<Self> {
+        dirs::home_dir().map(|h| Self::from_home(&h))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn resolves_paths_from_home() {
+        let paths = CcSwitchPaths::from_home(Path::new("/home/testuser"));
+        assert_eq!(paths.settings_path, Path::new("/home/testuser/.cc-switch/settings.json"));
+        assert_eq!(paths.database_path, Path::new("/home/testuser/.cc-switch/cc-switch.db"));
+        assert_eq!(paths.claude_settings_path, Path::new("/home/testuser/.claude/settings.json"));
+    }
+
+    #[test]
+    fn system_returns_some_when_home_exists() {
+        let paths = CcSwitchPaths::system();
+        assert!(paths.is_some());
+    }
+}

--- a/crates/aionui-ai-agent/src/cc_switch/paths.rs
+++ b/crates/aionui-ai-agent/src/cc_switch/paths.rs
@@ -30,9 +30,15 @@ mod tests {
     #[test]
     fn resolves_paths_from_home() {
         let paths = CcSwitchPaths::from_home(Path::new("/home/testuser"));
-        assert_eq!(paths.settings_path, Path::new("/home/testuser/.cc-switch/settings.json"));
+        assert_eq!(
+            paths.settings_path,
+            Path::new("/home/testuser/.cc-switch/settings.json")
+        );
         assert_eq!(paths.database_path, Path::new("/home/testuser/.cc-switch/cc-switch.db"));
-        assert_eq!(paths.claude_settings_path, Path::new("/home/testuser/.claude/settings.json"));
+        assert_eq!(
+            paths.claude_settings_path,
+            Path::new("/home/testuser/.claude/settings.json")
+        );
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/cc_switch/provider_env.rs
+++ b/crates/aionui-ai-agent/src/cc_switch/provider_env.rs
@@ -1,0 +1,153 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use rusqlite::Connection;
+use tracing::{info, warn};
+
+use super::CcSwitchPaths;
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct CcSwitchSettings {
+    #[serde(rename = "currentProviderClaude")]
+    pub(crate) current_provider_claude: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ProviderSettingsConfig {
+    #[serde(default)]
+    env: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+pub(crate) fn normalize_env(raw: &serde_json::Map<String, serde_json::Value>) -> HashMap<String, String> {
+    raw.iter()
+        .filter_map(|(k, v)| {
+            if let serde_json::Value::String(s) = v {
+                if !s.trim().is_empty() {
+                    return Some((k.clone(), s.clone()));
+                }
+            }
+            None
+        })
+        .collect()
+}
+
+pub fn read_claude_provider_env_with_paths(paths: &CcSwitchPaths) -> HashMap<String, String> {
+    let settings_content = match fs::read_to_string(&paths.settings_path) {
+        Ok(c) => c,
+        Err(_) => return HashMap::new(),
+    };
+
+    let settings: CcSwitchSettings = match serde_json::from_str(&settings_content) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(error = %e, "cc-switch: failed to parse settings.json");
+            return HashMap::new();
+        }
+    };
+
+    let provider_id = match settings.current_provider_claude {
+        Some(ref id) if !id.trim().is_empty() => id.clone(),
+        _ => return HashMap::new(),
+    };
+
+    if !paths.database_path.exists() {
+        warn!(provider_id, "cc-switch: settings.json references provider but database file not found");
+        return HashMap::new();
+    }
+
+    read_env_from_db(&paths.database_path, &provider_id)
+}
+
+fn read_env_from_db(db_path: &Path, provider_id: &str) -> HashMap<String, String> {
+    let conn = match Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(error = %e, "cc-switch: failed to open database");
+            return HashMap::new();
+        }
+    };
+
+    let settings_config_json: Option<String> = conn
+        .query_row(
+            "SELECT settings_config FROM providers WHERE id = ?1 AND app_type = 'claude' LIMIT 1",
+            [provider_id],
+            |row| row.get(0),
+        )
+        .ok()
+        .flatten();
+
+    let Some(json_str) = settings_config_json else {
+        warn!(provider_id, "cc-switch: provider not found in database");
+        return HashMap::new();
+    };
+
+    let config: ProviderSettingsConfig = match serde_json::from_str(&json_str) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(error = %e, provider_id, "cc-switch: failed to parse provider settings_config");
+            return HashMap::new();
+        }
+    };
+
+    let env = match config.env {
+        Some(ref env_map) => normalize_env(env_map),
+        None => HashMap::new(),
+    };
+
+    if env.is_empty() {
+        info!(provider_id, "cc-switch: provider has no env vars configured (using native API)");
+    } else {
+        let keys: Vec<&str> = env.keys().map(|k| k.as_str()).collect();
+        info!(provider_id, ?keys, "cc-switch: provider env vars loaded");
+    }
+
+    env
+}
+
+pub fn read_claude_provider_env() -> HashMap<String, String> {
+    let Some(paths) = CcSwitchPaths::system() else {
+        return HashMap::new();
+    };
+    read_claude_provider_env_with_paths(&paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_settings_extracts_provider_id() {
+        let json = r#"{"currentProviderClaude": "my-provider-id"}"#;
+        let settings: CcSwitchSettings = serde_json::from_str(json).unwrap();
+        assert_eq!(settings.current_provider_claude.as_deref(), Some("my-provider-id"));
+    }
+
+    #[test]
+    fn parse_settings_missing_field_returns_none() {
+        let json = r#"{}"#;
+        let settings: CcSwitchSettings = serde_json::from_str(json).unwrap();
+        assert!(settings.current_provider_claude.is_none());
+    }
+
+    #[test]
+    fn normalize_env_filters_non_string_values() {
+        let mut raw = serde_json::Map::new();
+        raw.insert("ANTHROPIC_API_KEY".into(), serde_json::Value::String("sk-123".into()));
+        raw.insert("EMPTY".into(), serde_json::Value::String("".into()));
+        raw.insert("NUMBER".into(), serde_json::Value::Number(42.into()));
+        raw.insert("VALID_URL".into(), serde_json::Value::String("https://api.example.com".into()));
+
+        let result = normalize_env(&raw);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result.get("ANTHROPIC_API_KEY").unwrap(), "sk-123");
+        assert_eq!(result.get("VALID_URL").unwrap(), "https://api.example.com");
+    }
+
+    #[test]
+    fn read_provider_env_returns_empty_when_no_paths() {
+        let paths = CcSwitchPaths::from_home(std::path::Path::new("/nonexistent"));
+        let env = read_claude_provider_env_with_paths(&paths);
+        assert!(env.is_empty());
+    }
+}

--- a/crates/aionui-ai-agent/src/cc_switch/provider_env.rs
+++ b/crates/aionui-ai-agent/src/cc_switch/provider_env.rs
@@ -22,12 +22,13 @@ struct ProviderSettingsConfig {
 pub(crate) fn normalize_env(raw: &serde_json::Map<String, serde_json::Value>) -> HashMap<String, String> {
     raw.iter()
         .filter_map(|(k, v)| {
-            if let serde_json::Value::String(s) = v {
-                if !s.trim().is_empty() {
-                    return Some((k.clone(), s.clone()));
-                }
+            if let serde_json::Value::String(s) = v
+                && !s.trim().is_empty()
+            {
+                Some((k.clone(), s.clone()))
+            } else {
+                None
             }
-            None
         })
         .collect()
 }
@@ -52,7 +53,10 @@ pub fn read_claude_provider_env_with_paths(paths: &CcSwitchPaths) -> HashMap<Str
     };
 
     if !paths.database_path.exists() {
-        warn!(provider_id, "cc-switch: settings.json references provider but database file not found");
+        warn!(
+            provider_id,
+            "cc-switch: settings.json references provider but database file not found"
+        );
         return HashMap::new();
     }
 
@@ -96,7 +100,10 @@ fn read_env_from_db(db_path: &Path, provider_id: &str) -> HashMap<String, String
     };
 
     if env.is_empty() {
-        info!(provider_id, "cc-switch: provider has no env vars configured (using native API)");
+        info!(
+            provider_id,
+            "cc-switch: provider has no env vars configured (using native API)"
+        );
     } else {
         let keys: Vec<&str> = env.keys().map(|k| k.as_str()).collect();
         info!(provider_id, ?keys, "cc-switch: provider env vars loaded");
@@ -136,7 +143,10 @@ mod tests {
         raw.insert("ANTHROPIC_API_KEY".into(), serde_json::Value::String("sk-123".into()));
         raw.insert("EMPTY".into(), serde_json::Value::String("".into()));
         raw.insert("NUMBER".into(), serde_json::Value::Number(42.into()));
-        raw.insert("VALID_URL".into(), serde_json::Value::String("https://api.example.com".into()));
+        raw.insert(
+            "VALID_URL".into(),
+            serde_json::Value::String("https://api.example.com".into()),
+        );
 
         let result = normalize_env(&raw);
         assert_eq!(result.len(), 2);

--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -94,30 +94,14 @@ pub(super) async fn build(
     if meta.backend.as_deref() == Some("claude") {
         let cc_switch_env = crate::cc_switch::read_claude_provider_env();
         if !cc_switch_env.is_empty() {
-            let mut injected: Vec<&str> = Vec::new();
-            let mut skipped: Vec<&str> = Vec::new();
-
+            let keys: Vec<&str> = cc_switch_env.keys().map(|k| k.as_str()).collect();
             for (name, value) in &cc_switch_env {
-                if std::env::var(name).is_err() {
-                    env.push(aionui_common::EnvVar {
-                        name: name.clone(),
-                        value: value.clone(),
-                    });
-                    injected.push(name.as_str());
-                } else {
-                    skipped.push(name.as_str());
-                }
+                env.push(aionui_common::EnvVar {
+                    name: name.clone(),
+                    value: value.clone(),
+                });
             }
-
-            if !injected.is_empty() {
-                tracing::info!(?injected, "cc-switch: env vars injected as fallback");
-            }
-            if !skipped.is_empty() {
-                tracing::info!(
-                    ?skipped,
-                    "cc-switch: env vars skipped (already inherited from parent process)"
-                );
-            }
+            tracing::info!(?keys, "cc-switch: env vars injected");
         }
     }
 

--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -77,7 +77,7 @@ pub(super) async fn build(
     // never had a command (e.g. remote-only). Either way the
     // caller needs to see a BadRequest, not a confusing
     // spawn-time error.
-    let (command, args, env, cwd) = (
+    let (command, args, mut env, cwd) = (
         meta.resolved_command
             .clone()
             .ok_or_else(|| AppError::BadRequest(format!("Agent '{}' CLI not found in PATH", meta.name)))?,
@@ -88,9 +88,36 @@ pub(super) async fn build(
                 name: e.name.clone(),
                 value: e.value.clone(),
             })
-            .collect(),
+            .collect::<Vec<_>>(),
         Some(ctx.workspace.clone()),
     );
+    if meta.backend.as_deref() == Some("claude") {
+        let cc_switch_env = crate::cc_switch::read_claude_provider_env();
+        if !cc_switch_env.is_empty() {
+            let mut injected: Vec<&str> = Vec::new();
+            let mut skipped: Vec<&str> = Vec::new();
+
+            for (name, value) in &cc_switch_env {
+                if std::env::var(name).is_err() {
+                    env.push(aionui_common::EnvVar {
+                        name: name.clone(),
+                        value: value.clone(),
+                    });
+                    injected.push(name.as_str());
+                } else {
+                    skipped.push(name.as_str());
+                }
+            }
+
+            if !injected.is_empty() {
+                tracing::info!(?injected, "cc-switch: env vars injected as fallback");
+            }
+            if !skipped.is_empty() {
+                tracing::info!(?skipped, "cc-switch: env vars skipped (already inherited from parent process)");
+            }
+        }
+    }
+
     let command_spec = CommandSpec {
         command,
         args,

--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -113,7 +113,10 @@ pub(super) async fn build(
                 tracing::info!(?injected, "cc-switch: env vars injected as fallback");
             }
             if !skipped.is_empty() {
-                tracing::info!(?skipped, "cc-switch: env vars skipped (already inherited from parent process)");
+                tracing::info!(
+                    ?skipped,
+                    "cc-switch: env vars skipped (already inherited from parent process)"
+                );
             }
         }
     }

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -2,6 +2,7 @@
 pub(crate) mod agent_runtime;
 pub mod agent_task;
 pub mod capability;
+pub mod cc_switch;
 pub mod factory;
 pub(crate) mod idle_scanner;
 pub mod manager;

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -287,6 +287,10 @@ impl AcpAgentManager {
         })
     }
 
+    pub(crate) fn is_claude_backend(&self) -> bool {
+        self.params.metadata.backend.as_deref() == Some("claude")
+    }
+
     /// Cached model info from the ACP backend, if any has been received.
     pub(crate) async fn model(&self) -> Option<SessionModelState> {
         self.session.read().await.model_info().cloned()

--- a/crates/aionui-ai-agent/tests/cc_switch_integration.rs
+++ b/crates/aionui-ai-agent/tests/cc_switch_integration.rs
@@ -1,0 +1,157 @@
+use aionui_ai_agent::cc_switch::{
+    build_model_info_from_env, read_claude_model_info_with_paths, read_claude_provider_env_with_paths, CcSwitchPaths,
+};
+use rusqlite::Connection;
+use std::collections::HashMap;
+use std::fs;
+use tempfile::TempDir;
+
+fn create_test_db(dir: &std::path::Path, provider_id: &str, settings_config: &str) {
+    let db_path = dir.join("cc-switch.db");
+    let conn = Connection::open(&db_path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS providers (
+            id TEXT NOT NULL,
+            app_type TEXT NOT NULL,
+            name TEXT NOT NULL,
+            settings_config TEXT NOT NULL,
+            PRIMARY KEY (id, app_type)
+        );
+        CREATE TABLE IF NOT EXISTS model_pricing (
+            model_id TEXT PRIMARY KEY,
+            display_name TEXT NOT NULL
+        );",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO providers (id, app_type, name, settings_config) VALUES (?1, 'claude', 'Test Provider', ?2)",
+        [provider_id, settings_config],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO model_pricing (model_id, display_name) VALUES (?1, ?2)",
+        ["deepseek-v4-pro", "DeepSeek V4 Pro"],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO model_pricing (model_id, display_name) VALUES (?1, ?2)",
+        ["deepseek-v4-max", "DeepSeek V4 Max"],
+    )
+    .unwrap();
+}
+
+#[test]
+fn reads_provider_env_from_fixture_db() {
+    let tmp = TempDir::new().unwrap();
+    let cc_switch_dir = tmp.path().join(".cc-switch");
+    fs::create_dir_all(&cc_switch_dir).unwrap();
+
+    let settings = r#"{"currentProviderClaude": "deepseek-relay"}"#;
+    fs::write(cc_switch_dir.join("settings.json"), settings).unwrap();
+
+    let config = serde_json::json!({
+        "env": {
+            "ANTHROPIC_BASE_URL": "https://relay.example.com/v1",
+            "ANTHROPIC_API_KEY": "sk-relay-test-key",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": "deepseek-v4-max"
+        },
+        "model": "default"
+    });
+    create_test_db(&cc_switch_dir, "deepseek-relay", &config.to_string());
+
+    let paths = CcSwitchPaths::from_home(tmp.path());
+    let env = read_claude_provider_env_with_paths(&paths);
+
+    assert_eq!(env.get("ANTHROPIC_BASE_URL").unwrap(), "https://relay.example.com/v1");
+    assert_eq!(env.get("ANTHROPIC_API_KEY").unwrap(), "sk-relay-test-key");
+    assert_eq!(env.get("ANTHROPIC_DEFAULT_SONNET_MODEL").unwrap(), "deepseek-v4-pro");
+    assert_eq!(env.get("ANTHROPIC_DEFAULT_OPUS_MODEL").unwrap(), "deepseek-v4-max");
+}
+
+#[test]
+fn reads_model_info_from_fixture_db() {
+    let tmp = TempDir::new().unwrap();
+    let cc_switch_dir = tmp.path().join(".cc-switch");
+    fs::create_dir_all(&cc_switch_dir).unwrap();
+
+    let settings = r#"{"currentProviderClaude": "deepseek-relay"}"#;
+    fs::write(cc_switch_dir.join("settings.json"), settings).unwrap();
+
+    let config = serde_json::json!({
+        "env": {
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": "deepseek-v4-max"
+        },
+        "model": "default"
+    });
+    create_test_db(&cc_switch_dir, "deepseek-relay", &config.to_string());
+
+    let paths = CcSwitchPaths::from_home(tmp.path());
+    let info = read_claude_model_info_with_paths(&paths);
+
+    assert!(info.is_some());
+    let payload = info.unwrap();
+    assert_eq!(payload.available_models.len(), 2);
+    assert_eq!(payload.current_model_id.as_deref(), Some("default"));
+    assert_eq!(payload.current_model_label.as_deref(), Some("DeepSeek V4 Pro"));
+    assert_eq!(payload.available_models[0].label, "DeepSeek V4 Pro");
+    assert_eq!(payload.available_models[1].label, "DeepSeek V4 Max");
+}
+
+#[test]
+fn gracefully_handles_missing_cc_switch() {
+    let tmp = TempDir::new().unwrap();
+    let paths = CcSwitchPaths::from_home(tmp.path());
+
+    let env = read_claude_provider_env_with_paths(&paths);
+    assert!(env.is_empty());
+
+    let info = read_claude_model_info_with_paths(&paths);
+    assert!(info.is_none());
+}
+
+#[test]
+fn gracefully_handles_empty_provider_id() {
+    let tmp = TempDir::new().unwrap();
+    let cc_switch_dir = tmp.path().join(".cc-switch");
+    fs::create_dir_all(&cc_switch_dir).unwrap();
+
+    fs::write(cc_switch_dir.join("settings.json"), r#"{"currentProviderClaude": ""}"#).unwrap();
+
+    let paths = CcSwitchPaths::from_home(tmp.path());
+    let env = read_claude_provider_env_with_paths(&paths);
+    assert!(env.is_empty());
+}
+
+#[test]
+fn default_provider_returns_empty_env_when_no_env_configured() {
+    let tmp = TempDir::new().unwrap();
+    let cc_switch_dir = tmp.path().join(".cc-switch");
+    fs::create_dir_all(&cc_switch_dir).unwrap();
+
+    let settings = r#"{"currentProviderClaude": "default"}"#;
+    fs::write(cc_switch_dir.join("settings.json"), settings).unwrap();
+
+    let config = serde_json::json!({
+        "env": {}
+    });
+    create_test_db(&cc_switch_dir, "default", &config.to_string());
+
+    let paths = CcSwitchPaths::from_home(tmp.path());
+    let env = read_claude_provider_env_with_paths(&paths);
+    assert!(env.is_empty());
+}
+
+#[test]
+fn build_model_info_from_env_works_standalone() {
+    let mut env = HashMap::new();
+    env.insert("ANTHROPIC_DEFAULT_SONNET_MODEL".into(), "test-model".into());
+
+    let labels = HashMap::from([("test-model".to_owned(), "Test Model Display".to_owned())]);
+
+    let info = build_model_info_from_env(&env, &labels, None);
+    assert!(info.is_some());
+    let payload = info.unwrap();
+    assert_eq!(payload.available_models[0].label, "Test Model Display");
+}

--- a/crates/aionui-ai-agent/tests/cc_switch_integration.rs
+++ b/crates/aionui-ai-agent/tests/cc_switch_integration.rs
@@ -1,5 +1,5 @@
 use aionui_ai_agent::cc_switch::{
-    build_model_info_from_env, read_claude_model_info_with_paths, read_claude_provider_env_with_paths, CcSwitchPaths,
+    CcSwitchPaths, build_model_info_from_env, read_claude_model_info_with_paths, read_claude_provider_env_with_paths,
 };
 use rusqlite::Connection;
 use std::collections::HashMap;


### PR DESCRIPTION
## Summary

- Add `cc_switch` module to `aionui-ai-agent` that reads `~/.cc-switch/settings.json` and `~/.cc-switch/cc-switch.db` (read-only SQLite) to extract provider environment variables and model metadata
- Inject cc-switch provider env vars unconditionally into `CommandSpec.env` when spawning Claude ACP processes — matches the old monorepo behavior where cc-switch DB is the authoritative configuration source
- Merge cc-switch model info as fallback into `get_model` response (SDK model info takes priority when available)

## Motivation

Restores support for third-party API relays (NewAPI, OneAPI, etc.) configured via cc-switch. The old Electron main process handled this injection directly; after the frontend/backend split, this functionality was lost for users who launch AionUI without a shell environment (Windows desktop, Linux .desktop files).

## Design Decisions

- **Unconditional override** (not fallback): cc-switch DB is the single source of truth. Users who switch providers in the cc-switch GUI get the new config immediately without restarting their terminal.
- **Claude-only**: Consistent with the old implementation — only Claude ACP processes receive cc-switch env injection.
- **Read-only access**: Opens cc-switch DB with `SQLITE_OPEN_READ_ONLY`.
- **SQL uses `app_type` filter**: The `providers` table has a composite PK `(id, app_type)`.
- **Silent when cc-switch is not installed**: No log noise for users without cc-switch.

## Test plan

- [x] Unit tests for path resolution, settings parsing, env normalization, model slot mapping (11 tests)
- [x] Integration tests with fixture SQLite DB: provider env reading, model info reading, graceful handling of missing/empty configs (6 tests)
- [x] Merge logic tests: SDK priority over cc-switch, fallback when SDK is None (3 tests)
- [x] Full workspace verification: `cargo fmt`, `cargo clippy -D warnings`, `cargo test` (5558 tests pass)