### PR TITLE
refactor: rename binary from aioncli to aioncore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ permissions:
   contents: write
 
 env:
-  BINARY_NAME: aioncli
+  BINARY_NAME: aioncore
   CARGO_TERM_COLOR: always
   CARGO_HTTP_TIMEOUT: "600"
   CARGO_NET_RETRY: "10"
@@ -64,25 +64,25 @@ jobs:
           # deliberately drop it.
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            binary_name: aioncli
+            binary_name: aioncore
           # Linux aarch64: keep `cross` (its image happens to not trip the
           # aws-lc-sys check and also yields an older GLIBC baseline).
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            binary_name: aioncli
+            binary_name: aioncore
             use_cross: true
           - os: macos-latest
             target: x86_64-apple-darwin
-            binary_name: aioncli
+            binary_name: aioncore
           - os: macos-latest
             target: aarch64-apple-darwin
-            binary_name: aioncli
+            binary_name: aioncore
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            binary_name: aioncli.exe
+            binary_name: aioncore.exe
           - os: windows-latest
             target: aarch64-pc-windows-msvc
-            binary_name: aioncli.exe
+            binary_name: aioncore.exe
 
     steps:
       - uses: actions/checkout@v6
@@ -130,7 +130,7 @@ jobs:
           VERSION: ${{ needs.prepare-release.outputs.version }}
         run: |
           mkdir -p dist
-          ARCHIVE="aioncli-v${VERSION}-${{ matrix.target }}.tar.gz"
+          ARCHIVE="aioncore-v${VERSION}-${{ matrix.target }}.tar.gz"
           tar -C target/${{ matrix.target }}/release -czf "dist/${ARCHIVE}" ${{ matrix.binary_name }}
           echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
 
@@ -141,7 +141,7 @@ jobs:
           VERSION: ${{ needs.prepare-release.outputs.version }}
         run: |
           New-Item -ItemType Directory -Force -Path dist | Out-Null
-          $archive = "aioncli-v${env:VERSION}-${{ matrix.target }}.zip"
+          $archive = "aioncore-v${env:VERSION}-${{ matrix.target }}.zip"
           Compress-Archive -Path "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" -DestinationPath "dist/${archive}" -Force
           "ARCHIVE=${archive}" | Out-File -FilePath $env:GITHUB_ENV -Append
 
@@ -169,7 +169,7 @@ jobs:
         shell: bash
         run: |
           cd artifacts
-          sha256sum aioncli-* > aioncli-checksums.txt
+          sha256sum aioncore-* > aioncore-checksums.txt
 
       - name: Upload release assets
         shell: bash

--- a/crates/aionui-ai-agent/src/capability/backend_protocol_sink.rs
+++ b/crates/aionui-ai-agent/src/capability/backend_protocol_sink.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 
 use crate::protocol::events::{AcpPermissionEventData, AgentStreamEvent, ToolCallEventData, ToolCallStatus};
 
-/// Implements `ProtocolEmitter` for the aioncli context.
+/// Implements `ProtocolEmitter` for the aioncore context.
 ///
 /// Bridges aionrs `ProtocolEvent` emissions to `AgentStreamEvent` on a
 /// broadcast channel. Only handles events relevant to the approval flow;

--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -356,7 +356,7 @@ fn probe_with_reason(meta: &AgentMetadata) -> (Option<PathBuf>, Option<Unavailab
 
 /// Emit a single per-row line summarizing the probe outcome. Available
 /// rows go to `debug!` (one per startup × N agents is noisy at info);
-/// unavailable rows go to `info!` so the default aioncli.log surfaces
+/// unavailable rows go to `info!` so the default aioncore.log surfaces
 /// the reason without needing `--log-level debug` after a user
 /// reports "no agent works".
 fn log_probe_result(meta: &AgentMetadata, reason: &Option<UnavailableReason>) {

--- a/crates/aionui-ai-agent/tests/factory_provider_integration.rs
+++ b/crates/aionui-ai-agent/tests/factory_provider_integration.rs
@@ -72,7 +72,7 @@ fn make_factory(
         agent_registry,
         acp_agent_service,
         data_dir: PathBuf::from("/tmp/aionrs-test"),
-        backend_binary_path: Arc::new(PathBuf::from("/tmp/aionrs-test/aioncli")),
+        backend_binary_path: Arc::new(PathBuf::from("/tmp/aionrs-test/aioncore")),
         guide_mcp_config: None,
     })
 }

--- a/crates/aionui-api-types/src/team_mcp.rs
+++ b/crates/aionui-api-types/src/team_mcp.rs
@@ -53,7 +53,7 @@ mod tests {
             port: 54321,
             token: "tok-abc".into(),
             slot_id: "slot-1".into(),
-            binary_path: "/usr/bin/aioncli".into(),
+            binary_path: "/usr/bin/aioncore".into(),
         };
         let json = serde_json::to_string(&cfg).unwrap();
         let parsed: TeamMcpStdioConfig = serde_json::from_str(&json).unwrap();
@@ -65,7 +65,7 @@ mod tests {
         // Forward-compat: extra fields in persisted `conversation.extra.team_mcp_stdio_config`
         // JSON (e.g. added by a later backend version) must still round-trip through
         // older binaries without error.
-        let json = r#"{"team_id":"t-1","port":1,"token":"t","slot_id":"s","binary_path":"/usr/bin/aioncli","future_field":42}"#;
+        let json = r#"{"team_id":"t-1","port":1,"token":"t","slot_id":"s","binary_path":"/usr/bin/aioncore","future_field":42}"#;
         let parsed: TeamMcpStdioConfig = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.team_id, "t-1");
         assert_eq!(parsed.port, 1);

--- a/crates/aionui-app/Cargo.toml
+++ b/crates/aionui-app/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [[bin]]
-name = "aioncli"
+name = "aioncore"
 path = "src/main.rs"
 
 [features]

--- a/crates/aionui-app/src/bootstrap/tracing_init.rs
+++ b/crates/aionui-app/src/bootstrap/tracing_init.rs
@@ -53,7 +53,7 @@ pub fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> LogGuards {
     // Backend file layer — excludes aion_* targets
     let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
         .rotation(tracing_appender::rolling::Rotation::DAILY)
-        .filename_suffix("aioncli.log")
+        .filename_suffix("aioncore.log")
         .build(log_dir)
         .expect("failed to create backend log file appender");
     let (non_blocking, backend_guard) = tracing_appender::non_blocking(file_appender);

--- a/crates/aionui-app/src/cli.rs
+++ b/crates/aionui-app/src/cli.rs
@@ -1,4 +1,4 @@
-//! CLI argument definitions for the `aioncli` binary.
+//! CLI argument definitions for the `aioncore` binary.
 //!
 //! Kept separate from `main.rs` to isolate the clap surface (struct + enum +
 //! attribute soup) from the runtime entry point. Visibility is `pub(crate)`
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(name = "aioncli", about = "AionUi Backend Server")]
+#[command(name = "aioncore", about = "AionUi Backend Server")]
 pub(crate) struct Cli {
     /// Host address to listen on.
     #[arg(long, default_value_t = String::from(aionui_common::constants::DEFAULT_HOST))]

--- a/crates/aionui-app/src/commands/bridge.rs
+++ b/crates/aionui-app/src/commands/bridge.rs
@@ -1,6 +1,6 @@
-//! `aioncli mcp-bridge` subcommand: stdio ↔ TCP bridge for the team MCP server.
+//! `aioncore mcp-bridge` subcommand: stdio ↔ TCP bridge for the team MCP server.
 //!
-//! Spawned by the ACP agent CLI as an MCP server with command `aioncli mcp-bridge`.
+//! Spawned by the ACP agent CLI as an MCP server with command `aioncore mcp-bridge`.
 //! stdio side speaks newline-delimited JSON-RPC 2.0 (the MCP stdio transport);
 //! TCP side speaks 4-byte big-endian length-prefixed JSON frames against
 //! `127.0.0.1:<TEAM_MCP_PORT>` (reusing `aionui_team::mcp::protocol`).
@@ -22,7 +22,7 @@ use tokio::net::TcpStream;
 
 const CONNECT_ADDR_HOST: &str = "127.0.0.1";
 
-/// Entry point for `aioncli mcp-bridge`. Returns an [`ExitCode`] so the
+/// Entry point for `aioncore mcp-bridge`. Returns an [`ExitCode`] so the
 /// binary surfaces non-zero on any failure (ACP CLI uses that to mark the MCP
 /// server as broken).
 pub async fn run_mcp_bridge() -> ExitCode {

--- a/crates/aionui-app/src/commands/doctor.rs
+++ b/crates/aionui-app/src/commands/doctor.rs
@@ -1,4 +1,4 @@
-//! `aioncli doctor` subcommand: agent CLI detection self-check.
+//! `aioncore doctor` subcommand: agent CLI detection self-check.
 //!
 //! Hydrates the agent registry against the real on-disk database and
 //! prints a per-agent availability table to stdout. Mirrors the
@@ -7,7 +7,7 @@
 //! does for the server, so the bundled `bun` resolves through the
 //! same cache the server uses.
 //!
-//! Writes to stdout (not the rolling aioncli.log) — the user
+//! Writes to stdout (not the rolling aioncore.log) — the user
 //! typically runs `doctor` interactively after reporting "no agent
 //! works", and the answer needs to be visible in their terminal
 //! without grepping logs. We deliberately skip `init_environment` to

--- a/crates/aionui-app/src/commands/mod.rs
+++ b/crates/aionui-app/src/commands/mod.rs
@@ -1,4 +1,4 @@
-//! Subcommand implementations for the `aioncli` binary.
+//! Subcommand implementations for the `aioncore` binary.
 //!
 //! This file is a façade — module declarations and re-exports only.
 //! All logic lives in the submodules.

--- a/crates/aionui-app/src/commands/server.rs
+++ b/crates/aionui-app/src/commands/server.rs
@@ -1,4 +1,4 @@
-//! `aioncli` (no subcommand): the main HTTP server.
+//! `aioncore` (no subcommand): the main HTTP server.
 
 use std::process::ExitCode;
 use std::time::Instant;

--- a/crates/aionui-app/src/commands/team_guide.rs
+++ b/crates/aionui-app/src/commands/team_guide.rs
@@ -1,4 +1,4 @@
-//! `aioncli mcp-guide-stdio` subcommand: MCP stdio server for team-guide tools.
+//! `aioncore mcp-guide-stdio` subcommand: MCP stdio server for team-guide tools.
 //!
 //! Uses the `rmcp` crate (Rust MCP SDK) for protocol handling, ensuring full
 //! compatibility with Claude CLI's MCP client implementation.

--- a/crates/aionui-app/src/commands/team_stdio.rs
+++ b/crates/aionui-app/src/commands/team_stdio.rs
@@ -1,4 +1,4 @@
-//! `aioncli mcp-team-stdio` subcommand: MCP stdio server for team tools.
+//! `aioncore mcp-team-stdio` subcommand: MCP stdio server for team tools.
 //!
 //! Uses the `rmcp` crate (Rust MCP SDK) for protocol handling. Tool calls are
 //! forwarded to the TeamMcpServer TCP listener via 4-byte big-endian

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -110,7 +110,7 @@ pub async fn build_module_states(services: &AppServices) -> (ModuleStates, Chann
         std::env::current_exe()
             .ok()
             .and_then(|p| p.canonicalize().ok())
-            .unwrap_or_else(|| std::path::PathBuf::from("aioncli")),
+            .unwrap_or_else(|| std::path::PathBuf::from("aioncore")),
     );
 
     let agent_service = AgentService::new(services.agent_registry.clone(), services.data_dir.clone());

--- a/crates/aionui-app/src/services.rs
+++ b/crates/aionui-app/src/services.rs
@@ -136,7 +136,7 @@ impl AppServices {
         // the stdio MCP bridge spawned by ACP CLIs when a team session is
         // attached to a conversation (phase1 mcp.md §4.6 single-binary model).
         let backend_binary_path =
-            Arc::new(std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("aioncli")));
+            Arc::new(std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("aioncore")));
 
         // Start Guide MCP server. Failure is non-fatal: solo agents simply
         // won't get the `aion_create_team` tool.

--- a/crates/aionui-channel/src/plugins/dingtalk/api.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/api.rs
@@ -163,7 +163,7 @@ impl DingtalkApi {
                     topic: "/v1.0/card/instances/callback".into(),
                 },
             ],
-            ua: Some("aioncli".into()),
+            ua: Some("aioncore".into()),
         };
 
         let raw_resp = self

--- a/crates/aionui-channel/src/plugins/dingtalk/types.rs
+++ b/crates/aionui-channel/src/plugins/dingtalk/types.rs
@@ -801,12 +801,12 @@ mod tests {
                     topic: "/v1.0/im/bot/messages/get".into(),
                 },
             ],
-            ua: Some("aioncli".into()),
+            ua: Some("aioncore".into()),
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["clientId"], "my_client_id");
         assert_eq!(json["clientSecret"], "my_secret");
-        assert_eq!(json["ua"], "aioncli");
+        assert_eq!(json["ua"], "aioncore");
         assert_eq!(json["subscriptions"][0]["type"], "EVENT");
         assert_eq!(json["subscriptions"][0]["topic"], "*");
         assert_eq!(json["subscriptions"][1]["type"], "CALLBACK");

--- a/crates/aionui-runtime/Cargo.toml
+++ b/crates/aionui-runtime/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [package.metadata.aionui-runtime]
 # 1.3.x required: 1.1.38 has a stdin-buffering bug in `bun x --bun` that
 # prevents AionUi's ACP adapter (long-lived stdio protocol) from ever
-# receiving the initialize request — see aioncli fix notes for
+# receiving the initialize request — see aioncore fix notes for
 # AionUi#2828. If bumping, keep >= 1.3.13.
 bun_version = "1.3.13"
 

--- a/crates/aionui-runtime/src/lib.rs
+++ b/crates/aionui-runtime/src/lib.rs
@@ -1,4 +1,4 @@
-//! Bundled runtime (bun) resolver for aioncli.
+//! Bundled runtime (bun) resolver for aioncore.
 //!
 //! Embeds the bun runtime at build time (zstd-compressed) and extracts it
 //! to the user's OS cache directory on first call. Callers use

--- a/crates/aionui-system/src/version.rs
+++ b/crates/aionui-system/src/version.rs
@@ -86,7 +86,7 @@ impl VersionCheckService {
                 .http_client
                 .get(&url)
                 .header("Accept", "application/vnd.github+json")
-                .header("User-Agent", "aioncli")
+                .header("User-Agent", "aioncore")
                 .send()
                 .await
                 .map_err(|e| AppError::BadGateway(format!("GitHub API request failed: {e}")))?;

--- a/crates/aionui-team/src/mcp/bridge.rs
+++ b/crates/aionui-team/src/mcp/bridge.rs
@@ -33,7 +33,7 @@ pub struct TeamMcpStdioServerSpec {
 impl TeamMcpStdioServerSpec {
     /// Build the spec from the persisted stdio config plus runtime context.
     ///
-    /// `backend_binary_path` is the absolute path to the `aioncli`
+    /// `backend_binary_path` is the absolute path to the `aioncore`
     /// executable (phase1 single-binary constraint — no standalone bridge).
     /// `team_id` is read from `cfg.team_id` rather than taken as a separate
     /// parameter so the wire-level server name stays in sync with the
@@ -79,16 +79,16 @@ mod tests {
             port: 12345,
             token: "tok-abc".into(),
             slot_id: "slot-1".into(),
-            binary_path: "/usr/bin/aioncli".into(),
+            binary_path: "/usr/bin/aioncore".into(),
         }
     }
 
     #[test]
     fn from_config_fills_all_fields() {
-        let spec = TeamMcpStdioServerSpec::from_config("/usr/bin/aioncli", &sample_cfg());
+        let spec = TeamMcpStdioServerSpec::from_config("/usr/bin/aioncore", &sample_cfg());
 
         assert_eq!(spec.name, "aionui-team-team-42");
-        assert_eq!(spec.command, "/usr/bin/aioncli");
+        assert_eq!(spec.command, "/usr/bin/aioncore");
         assert_eq!(spec.args, vec!["mcp-bridge".to_owned()]);
         assert_eq!(spec.env.len(), 3);
     }
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn into_sdk_serializes_as_stdio_variant() {
-        let spec = TeamMcpStdioServerSpec::from_config("/bin/aioncli", &sample_cfg());
+        let spec = TeamMcpStdioServerSpec::from_config("/bin/aioncore", &sample_cfg());
         let sdk = spec.into_sdk();
 
         let json = serde_json::to_value(&sdk).expect("serialize");
@@ -119,7 +119,7 @@ mod tests {
         // `Stdio` variant is `#[serde(untagged)]` inside `McpServer`, so the
         // JSON is the raw `McpServerStdio` shape — no `"type":"stdio"` tag.
         assert_eq!(json["name"], "aionui-team-team-42");
-        assert_eq!(json["command"], "/bin/aioncli");
+        assert_eq!(json["command"], "/bin/aioncore");
         assert_eq!(json["args"], serde_json::json!(["mcp-bridge"]));
 
         let env = json["env"].as_array().expect("env array");

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -879,7 +879,7 @@ mod tests {
     }
 
     fn backend_path() -> Arc<PathBuf> {
-        Arc::new(PathBuf::from("/tmp/aioncli-test"))
+        Arc::new(PathBuf::from("/tmp/aioncore-test"))
     }
 
     /// Mock agent whose `send_message` pushes the received payload into a
@@ -1128,7 +1128,7 @@ mod tests {
         let session = start_session().await;
         let spec = session.stdio_spec("lead-1");
         assert_eq!(spec.name, "aionui-team-t1");
-        assert_eq!(spec.command, "/tmp/aioncli-test");
+        assert_eq!(spec.command, "/tmp/aioncore-test");
         assert_eq!(spec.args, vec!["mcp-bridge".to_string()]);
         assert!(spec.env.iter().any(|(k, v)| k == "TEAM_AGENT_SLOT_ID" && v == "lead-1"));
         session.stop();

--- a/crates/aionui-team/tests/e2e_team_flow.rs
+++ b/crates/aionui-team/tests/e2e_team_flow.rs
@@ -324,7 +324,7 @@ fn mcp_text(resp: &Value) -> &str {
 // ---------------------------------------------------------------------------
 
 fn backend_path() -> Arc<PathBuf> {
-    Arc::new(PathBuf::from("/tmp/aioncli-e2e-test"))
+    Arc::new(PathBuf::from("/tmp/aioncore-e2e-test"))
 }
 
 /// Two-agent team definition: one Lead + one Worker.

--- a/crates/aionui-team/tests/mcp_server_integration.rs
+++ b/crates/aionui-team/tests/mcp_server_integration.rs
@@ -796,10 +796,10 @@ async fn sb1_bridge_config_generation() {
         port: env.server.port(),
         token: env.server.auth_token().to_string(),
         slot_id: "lead-1".into(),
-        binary_path: "/bin/aioncli".into(),
+        binary_path: "/bin/aioncore".into(),
     };
 
-    let spec = TeamMcpStdioServerSpec::from_config("/bin/aioncli", &config);
+    let spec = TeamMcpStdioServerSpec::from_config("/bin/aioncore", &config);
     let env_map: std::collections::HashMap<_, _> = spec.env.iter().cloned().collect();
     assert_eq!(env_map[TeamMcpStdioConfig::ENV_PORT], env.server.port().to_string());
     assert_eq!(env_map[TeamMcpStdioConfig::ENV_TOKEN], "test-token-123");

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -619,7 +619,7 @@ fn setup_with_factory_and_metadata(
         agent_metadata_repo.clone(),
         acp_session_repo,
     );
-    let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aioncli-test"));
+    let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aioncore-test"));
     let provider_repo: Arc<dyn IProviderRepository> = Arc::new(EmptyProviderRepo);
     let svc = TeamSessionService::new(
         team_repo,
@@ -655,7 +655,7 @@ fn setup_with_recording_broadcaster() -> (Arc<TeamSessionService>, Arc<Recording
         agent_metadata_repo.clone(),
         acp_session_repo,
     );
-    let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aioncli-test"));
+    let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aioncore-test"));
     let provider_repo: Arc<dyn IProviderRepository> = Arc::new(EmptyProviderRepo);
     let svc = TeamSessionService::new(
         team_repo,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
   "include-v-in-tag": true,
   "packages": {
     ".": {
-      "package-name": "aioncli",
+      "package-name": "aioncore",
       "include-component-in-tag": false,
       "release-type": "simple",
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Summary

- Rename CLI binary from `aioncli` to `aioncore`
- Update CI/Release workflow: artifact names, checksums, matrix binary names
- Update release-please config package name
- Update User-Agent strings, log file suffix, fallback paths
- Update all doc comments, test fixtures, and internal references

Database file (`aionui-backend.db`) is intentionally unchanged for backward compatibility.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (5558 tests)
- [x] Built binary is correctly named `target/debug/aioncore`