### PR TITLE
docs: catch up with aionui-backend → AionCore rename

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-aionui-backend is the backend server for AionUi, built with Rust (Axum + Tokio + SQLite).
+AionCore is the backend server for AionUi, built with Rust (Axum + Tokio + SQLite).
 It provides HTTP REST APIs and WebSocket real-time events for the AionUi desktop client.
 
 ## Tech Stack

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -1,6 +1,6 @@
 # 架构文档
 
-aionui-backend 是 AionUi 的后端服务，使用 Rust 构建（Axum + Tokio + SQLite）。
+AionCore 是 AionUi 的后端服务，使用 Rust 构建（Axum + Tokio + SQLite）。
 它通过 HTTP REST API 和 WebSocket 实时事件为 AionUi 桌面客户端提供服务。
 
 ## 技术栈

--- a/crates/aionui-assistant/src/builtin.rs
+++ b/crates/aionui-assistant/src/builtin.rs
@@ -6,7 +6,7 @@
 //! assumption, which was fragile in two ways:
 //!
 //! 1. Dev: Electron launches the backend through a symlink
-//!    (`~/.cargo/bin/aionui-backend` → `target/debug/aionui-backend`) and
+//!    (`~/.cargo/bin/aioncore` → `target/debug/aioncore`) and
 //!    `std::env::current_exe().parent()` would resolve to the symlink's
 //!    directory, not the real binary's, missing the `assets/` sibling.
 //! 2. Prod: `AionUi/scripts/prepareAionuiBackend.js` only copies the


### PR DESCRIPTION
## Summary
- Update opening line of `ARCHITECTURE.md` / `ARCHITECTURE.zh-CN.md` to say "AionCore"
- Update symlink example in `aionui-assistant/src/builtin.rs` from `aionui-backend` to `aioncore`

Stragglers from the repo rename (`aionui-backend` → `AionCore`) and binary rename (`aionui-backend` → `aioncli` → `aioncore`, #289 / #293).

Intentionally **not** changed:
- SQLite filename `aionui-backend.db` — data-migration compatibility for already-deployed users
- Internal crate names `aionui-*` — orthogonal to the repo/binary name
- `CHANGELOG.md` historical entries

## Test plan
- [ ] Docs change only + a comment line; no behavior impact