### PR TITLE
fix(ai-agent): return 409 when remote WS not connected on cancel (ELECTRON-1CV)

### DIFF
--- a/crates/aionui-ai-agent/src/manager/remote/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/remote/agent.rs
@@ -316,9 +316,7 @@ impl crate::agent_task::IAgentTask for RemoteAgentManager {
 
     async fn cancel(&self) -> Result<(), AppError> {
         if self.ws_sink.lock().await.is_none() {
-            return Err(AppError::Conflict(
-                "WebSocket not connected; nothing to cancel".into(),
-            ));
+            return Err(AppError::Conflict("WebSocket not connected; nothing to cancel".into()));
         }
         let payload = json!({ "type": "session/cancel", "data": {} });
         self.ws_send(&payload).await?;

--- a/crates/aionui-ai-agent/src/manager/remote/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/remote/agent.rs
@@ -315,6 +315,11 @@ impl crate::agent_task::IAgentTask for RemoteAgentManager {
     }
 
     async fn cancel(&self) -> Result<(), AppError> {
+        if self.ws_sink.lock().await.is_none() {
+            return Err(AppError::Conflict(
+                "WebSocket not connected; nothing to cancel".into(),
+            ));
+        }
         let payload = json!({ "type": "session/cancel", "data": {} });
         self.ws_send(&payload).await?;
 


### PR DESCRIPTION
## Summary
- Cancelling a remote conversation right after sending a message races the WebSocket setup. The cancel handler called `ws_send` unconditionally, mapping the missing sink to `AppError::Internal` → HTTP 500 / `INTERNAL_ERROR`.
- Treat "WS not connected" as a no-op race in `RemoteAgentManager::cancel` and return `AppError::Conflict` (HTTP 409 / `CONFLICT`) instead, so the renderer can swallow the expected case without it surfacing as an unhandled rejection in Sentry.

Sentry: [ELECTRON-1CV](https://iofficeai.sentry.io/issues/120247119/)

## Test plan
- [x] `cargo test -p aionui-ai-agent --lib` (383 passed)
- [x] `cargo test -p aionui-conversation --lib` (146 passed)
- [x] `cargo clippy -p aionui-ai-agent -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)