### PR TITLE
feat(agent): add ACP warmup endpoint

### DIFF
--- a/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
+++ b/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
@@ -16,8 +16,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use aionui_api_types::TryConnectCustomAgentResponse;
-use aionui_common::{CommandSpec, EnvVar};
+use aionui_api_types::{AgentHandshake, TryConnectCustomAgentResponse};
+use aionui_common::{CommandSpec, EnvVar, normalize_keys_to_snake_case};
 use aionui_runtime::resolve_command_path;
 use tokio::sync::{broadcast, mpsc};
 use tracing::debug;
@@ -52,7 +52,7 @@ pub async fn try_connect_custom_agent(
 
     // ── Step 2 — spawn + ACP initialize ─────────────────────────────
     match tokio::time::timeout(STEP2_TIMEOUT, acp_initialize(resolved, args, env, data_dir)).await {
-        Ok(Ok(())) => TryConnectCustomAgentResponse::Success,
+        Ok(Ok(_)) => TryConnectCustomAgentResponse::Success,
         Ok(Err(msg)) => TryConnectCustomAgentResponse::FailAcp { error: msg },
         Err(_) => TryConnectCustomAgentResponse::FailAcp {
             error: format!("ACP initialize did not complete within {}s", STEP2_TIMEOUT.as_secs()),
@@ -64,12 +64,12 @@ fn first_token(command: &str) -> &str {
     command.split_whitespace().next().unwrap_or(command)
 }
 
-async fn acp_initialize(
+pub(crate) async fn acp_initialize(
     resolved: PathBuf,
     args: &[String],
     env: &HashMap<String, String>,
     data_dir: &Path,
-) -> Result<(), String> {
+) -> Result<AgentHandshake, String> {
     let spec = CommandSpec {
         command: resolved,
         args: args.to_vec(),
@@ -107,11 +107,16 @@ async fn acp_initialize(
         biased;
         res = connect => {
             let protocol = res.map_err(|e| format!("ACP initialize failed: {e}"))?;
+            let handshake = AgentHandshake {
+                agent_capabilities: protocol.agent_capabilities().and_then(sdk_to_snake_value),
+                auth_methods: protocol.auth_methods().and_then(sdk_to_snake_value),
+                ..Default::default()
+            };
             // Dropping `protocol` fires the shutdown oneshot; the child
             // process was spawned with `kill_on_drop(true)` via
             // `aionui_runtime::Builder` so CPU stays clean.
             drop(protocol);
-            Ok(())
+            Ok(handshake)
         }
         exit = proc.wait_for_exit() => {
             let stderr = proc.take_stderr().await;
@@ -127,6 +132,12 @@ async fn acp_initialize(
             }
         }
     }
+}
+
+fn sdk_to_snake_value<T: serde::Serialize>(value: T) -> Option<serde_json::Value> {
+    let mut v = serde_json::to_value(value).ok()?;
+    normalize_keys_to_snake_case(&mut v);
+    Some(v)
 }
 
 #[cfg(test)]

--- a/crates/aionui-ai-agent/src/routes/agent.rs
+++ b/crates/aionui-ai-agent/src/routes/agent.rs
@@ -12,8 +12,9 @@ use axum::extract::{Extension, Json, Path, State};
 use axum::routing::{get, patch, post, put};
 
 use aionui_api_types::{
-    AcpHealthCheckRequest, AcpHealthCheckResponse, AgentMetadata, ApiResponse, CustomAgentUpsertRequest,
-    DeleteCustomAgentResponse, SetEnabledRequest, TryConnectCustomAgentRequest, TryConnectCustomAgentResponse,
+    AcpHealthCheckRequest, AcpHealthCheckResponse, AgentMetadata, AgentWarmupRequest, AgentWarmupResponse, ApiResponse,
+    CustomAgentUpsertRequest, DeleteCustomAgentResponse, SetEnabledRequest, TryConnectCustomAgentRequest,
+    TryConnectCustomAgentResponse,
 };
 use aionui_auth::CurrentUser;
 use aionui_common::AppError;
@@ -24,6 +25,7 @@ pub fn agent_routes(state: AgentRouterState) -> Router {
     Router::new()
         .route("/api/agents", get(list_agents))
         .route("/api/agents/refresh", post(refresh_agents))
+        .route("/api/agents/warmup", post(warmup_agents))
         .route("/api/agents/health-check", post(health_check))
         .route("/api/agents/{id}/enabled", patch(set_agent_enabled))
         .route("/api/agents/custom", post(create_custom))
@@ -44,6 +46,15 @@ async fn refresh_agents(
     Extension(_user): Extension<CurrentUser>,
 ) -> Result<Json<ApiResponse<Vec<AgentMetadata>>>, AppError> {
     Ok(Json(ApiResponse::ok(state.service.refresh_agents().await?)))
+}
+
+async fn warmup_agents(
+    State(state): State<AgentRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    body: Result<Json<AgentWarmupRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<AgentWarmupResponse>>, AppError> {
+    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
+    Ok(Json(ApiResponse::ok(state.service.warmup_agents(req).await?)))
 }
 
 async fn health_check(

--- a/crates/aionui-ai-agent/src/services/agent.rs
+++ b/crates/aionui-ai-agent/src/services/agent.rs
@@ -12,11 +12,15 @@
 //! ACP health-check responsibilities, plus support for the custom-agent
 //! CRUD endpoints (see `services::custom`).
 
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use aionui_api_types::{AcpHealthCheckRequest, AcpHealthCheckResponse, AgentMetadata};
-use aionui_common::AppError;
+use aionui_api_types::{
+    AcpHealthCheckRequest, AcpHealthCheckResponse, AgentMetadata, AgentSource, AgentWarmupRequest, AgentWarmupResponse,
+    AgentWarmupResult, AgentWarmupStatus,
+};
+use aionui_common::{AgentType, AppError};
 
 use crate::registry::AgentRegistry;
 
@@ -56,5 +60,182 @@ impl AgentService {
 
     pub async fn acp_health_check(&self, req: AcpHealthCheckRequest) -> Result<AcpHealthCheckResponse, AppError> {
         Ok(crate::protocol::cli_detect::health_check(&self.registry, &req.backend).await)
+    }
+
+    pub async fn warmup_agents(&self, req: AgentWarmupRequest) -> Result<AgentWarmupResponse, AppError> {
+        let mut results = Vec::with_capacity(req.backends.len());
+        let mut seen = HashSet::new();
+
+        for raw_backend in req.backends {
+            let backend = raw_backend.trim().to_lowercase();
+            if backend.is_empty() || !seen.insert(backend.clone()) {
+                continue;
+            }
+
+            results.push(self.warmup_backend(&backend).await);
+        }
+
+        Ok(AgentWarmupResponse { results })
+    }
+
+    async fn warmup_backend(&self, backend: &str) -> AgentWarmupResult {
+        let Some(meta) = self.registry.find_builtin_by_backend(backend).await else {
+            return AgentWarmupResult {
+                backend: backend.to_owned(),
+                status: AgentWarmupStatus::Skipped,
+                agent_id: None,
+                error: Some("agent backend is not registered".into()),
+            };
+        };
+
+        if meta.agent_type != AgentType::Acp || meta.agent_source != AgentSource::Builtin {
+            return AgentWarmupResult {
+                backend: backend.to_owned(),
+                status: AgentWarmupStatus::Skipped,
+                agent_id: Some(meta.id),
+                error: Some("agent backend is not a builtin ACP agent".into()),
+            };
+        }
+
+        let Some(command) = meta.resolved_command.clone() else {
+            return AgentWarmupResult {
+                backend: backend.to_owned(),
+                status: AgentWarmupStatus::Skipped,
+                agent_id: Some(meta.id),
+                error: Some("agent CLI is not available".into()),
+            };
+        };
+
+        let mut env: HashMap<String, String> = meta
+            .env
+            .iter()
+            .map(|entry| (entry.name.clone(), entry.value.clone()))
+            .collect();
+        if meta.backend.as_deref() == Some("claude") {
+            env.extend(crate::cc_switch::read_claude_provider_env());
+        }
+
+        match crate::protocol::custom_agent_probe::acp_initialize(command, &meta.args, &env, &self.data_dir).await {
+            Ok(handshake) => {
+                if handshake.agent_capabilities.is_some() || handshake.auth_methods.is_some() {
+                    self.registry.catalog_sender().send_partial(meta.id.clone(), handshake);
+                }
+                AgentWarmupResult {
+                    backend: backend.to_owned(),
+                    status: AgentWarmupStatus::Ready,
+                    agent_id: Some(meta.id),
+                    error: None,
+                }
+            }
+            Err(error) => AgentWarmupResult {
+                backend: backend.to_owned(),
+                status: AgentWarmupStatus::Failed,
+                agent_id: Some(meta.id),
+                error: Some(error),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use aionui_api_types::{AgentWarmupReason, AgentWarmupRequest, AgentWarmupStatus};
+    use aionui_db::{IAgentMetadataRepository, SqliteAgentMetadataRepository, UpsertAgentMetadataParams};
+
+    use super::*;
+
+    async fn setup_service() -> (Arc<AgentService>, Arc<dyn IAgentMetadataRepository>) {
+        let db = aionui_db::init_database_memory().await.unwrap();
+        let repo: Arc<dyn IAgentMetadataRepository> = Arc::new(SqliteAgentMetadataRepository::new(db.pool().clone()));
+        let registry = AgentRegistry::new(repo.clone());
+        registry.hydrate().await.unwrap();
+        (AgentService::new(registry, PathBuf::from(std::env::temp_dir())), repo)
+    }
+
+    fn missing_builtin_params<'a>(id: &'a str, backend: &'a str) -> UpsertAgentMetadataParams<'a> {
+        UpsertAgentMetadataParams {
+            id,
+            icon: None,
+            name: "Missing Warmup Agent",
+            name_i18n: None,
+            description: Some("missing warmup test row"),
+            description_i18n: None,
+            backend: Some(backend),
+            agent_type: "acp",
+            agent_source: "builtin",
+            agent_source_info: Some(r#"{"binary_name":"aionui-definitely-missing-warmup"}"#),
+            enabled: true,
+            command: Some("aionui-definitely-missing-warmup"),
+            args: Some("[]"),
+            env: Some("[]"),
+            native_skills_dirs: None,
+            behavior_policy: None,
+            yolo_id: None,
+            agent_capabilities: None,
+            auth_methods: None,
+            config_options: None,
+            available_modes: None,
+            available_models: None,
+            available_commands: None,
+            sort_order: 9900,
+        }
+    }
+
+    #[tokio::test]
+    async fn warmup_empty_backends_returns_empty_results() {
+        let (service, _repo) = setup_service().await;
+
+        let resp = service
+            .warmup_agents(AgentWarmupRequest {
+                backends: vec![],
+                reason: AgentWarmupReason::Idle,
+            })
+            .await
+            .unwrap();
+
+        assert!(resp.results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn warmup_unknown_backend_returns_structured_skip() {
+        let (service, _repo) = setup_service().await;
+
+        let resp = service
+            .warmup_agents(AgentWarmupRequest {
+                backends: vec!["not-real-agent".into()],
+                reason: AgentWarmupReason::UserSelect,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(resp.results.len(), 1);
+        assert_eq!(resp.results[0].backend, "not-real-agent");
+        assert_eq!(resp.results[0].status, AgentWarmupStatus::Skipped);
+        assert!(resp.results[0].error.as_deref().unwrap().contains("not registered"));
+    }
+
+    #[tokio::test]
+    async fn warmup_missing_builtin_cli_returns_structured_skip() {
+        let (service, repo) = setup_service().await;
+        repo.upsert(&missing_builtin_params("missing-warmup", "missing-warmup"))
+            .await
+            .unwrap();
+        service.registry.invalidate_and_rehydrate().await.unwrap();
+
+        let resp = service
+            .warmup_agents(AgentWarmupRequest {
+                backends: vec!["missing-warmup".into()],
+                reason: AgentWarmupReason::BeforeSend,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(resp.results.len(), 1);
+        assert_eq!(resp.results[0].status, AgentWarmupStatus::Skipped);
+        assert_eq!(resp.results[0].agent_id.as_deref(), Some("missing-warmup"));
+        assert!(resp.results[0].error.as_deref().unwrap().contains("not available"));
     }
 }

--- a/crates/aionui-api-types/src/agent_discovery.rs
+++ b/crates/aionui-api-types/src/agent_discovery.rs
@@ -106,6 +106,49 @@ pub struct AgentHandshake {
     pub available_commands: Option<serde_json::Value>,
 }
 
+/// Reason a caller asked the backend to pre-initialize agent metadata.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentWarmupReason {
+    #[default]
+    Idle,
+    UserSelect,
+    BeforeSend,
+}
+
+/// Request body for `POST /api/agents/warmup`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AgentWarmupRequest {
+    #[serde(default)]
+    pub backends: Vec<String>,
+    #[serde(default)]
+    pub reason: AgentWarmupReason,
+}
+
+/// Per-backend result for a metadata warmup attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentWarmupStatus {
+    Ready,
+    Skipped,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentWarmupResult {
+    pub backend: String,
+    pub status: AgentWarmupStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AgentWarmupResponse {
+    pub results: Vec<AgentWarmupResult>,
+}
+
 /// The unified, decoded view of an `agent_metadata` row.
 ///
 /// Also the API response shape: `/api/agents` returns a list of these
@@ -254,6 +297,23 @@ mod tests {
         assert!(!meta.available);
         assert!(!meta.behavior_policy.supports_side_question);
         assert!(meta.handshake.agent_capabilities.is_none());
+    }
+
+    #[test]
+    fn agent_warmup_reason_uses_snake_case() {
+        let value = serde_json::to_value(AgentWarmupRequest {
+            backends: vec!["codex".into()],
+            reason: AgentWarmupReason::UserSelect,
+        })
+        .unwrap();
+        assert_eq!(value["reason"], "user_select");
+
+        let parsed: AgentWarmupRequest = serde_json::from_value(serde_json::json!({
+            "backends": ["claude"],
+            "reason": "before_send"
+        }))
+        .unwrap();
+        assert_eq!(parsed.reason, AgentWarmupReason::BeforeSend);
     }
 }
 

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -37,7 +37,10 @@ pub use agent_build_extra::{
     AcpBuildExtra, AcpModelInfo, AionrsBuildExtra, OpenClawBuildExtra, OpenClawGatewayConfig, RemoteBuildExtra,
     SlashCommandItem,
 };
-pub use agent_discovery::{AgentEnvEntry, AgentHandshake, AgentMetadata, AgentSource, AgentSourceInfo, BehaviorPolicy};
+pub use agent_discovery::{
+    AgentEnvEntry, AgentHandshake, AgentMetadata, AgentSource, AgentSourceInfo, AgentWarmupReason, AgentWarmupRequest,
+    AgentWarmupResponse, AgentWarmupResult, AgentWarmupStatus, BehaviorPolicy,
+};
 pub use assistant::{
     AssistantResponse, AssistantSource, CreateAssistantRequest, ImportAssistantsRequest, ImportAssistantsResult,
     ImportError, SetAssistantStateRequest, UpdateAssistantRequest,

--- a/crates/aionui-app/tests/acp_e2e.rs
+++ b/crates/aionui-app/tests/acp_e2e.rs
@@ -5,11 +5,13 @@
 
 mod common;
 
-use axum::http::StatusCode;
+use aionui_db::UpsertAgentMetadataParams;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
 use serde_json::json;
 use tower::ServiceExt;
 
-use common::{body_json, build_app, get_with_token, json_with_token, setup_and_login};
+use common::{body_json, build_app, extract_csrf_token, get_request, get_with_token, json_with_token, setup_and_login};
 
 // ── Global ACP routes ────────────────────────────────────────────
 
@@ -41,6 +43,147 @@ async fn refresh_agents_returns_array() {
     let body = body_json(resp).await;
     assert_eq!(body["success"], true);
     assert!(body["data"].is_array());
+}
+
+#[tokio::test]
+async fn warmup_agents_empty_backends_returns_empty_results() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "user1", "pass123").await;
+
+    let req = json_with_token(
+        "POST",
+        "/api/agents/warmup",
+        json!({ "backends": [], "reason": "idle" }),
+        &token,
+        &csrf,
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = body_json(resp).await;
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"]["results"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn warmup_agents_unknown_backend_is_structured_skip() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "user1", "pass123").await;
+
+    let req = json_with_token(
+        "POST",
+        "/api/agents/warmup",
+        json!({ "backends": ["not-real-agent"], "reason": "user_select" }),
+        &token,
+        &csrf,
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = body_json(resp).await;
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"]["results"][0]["backend"], "not-real-agent");
+    assert_eq!(body["data"]["results"][0]["status"], "skipped");
+    assert!(
+        body["data"]["results"][0]["error"]
+            .as_str()
+            .unwrap()
+            .contains("not registered")
+    );
+}
+
+#[tokio::test]
+async fn warmup_agents_missing_builtin_cli_is_structured_skip() {
+    let (mut app, services) = build_app().await;
+    services
+        .agent_registry
+        .repo_handle()
+        .upsert(&UpsertAgentMetadataParams {
+            id: "missing-warmup",
+            icon: None,
+            name: "Missing Warmup Agent",
+            name_i18n: None,
+            description: Some("missing warmup test row"),
+            description_i18n: None,
+            backend: Some("missing-warmup"),
+            agent_type: "acp",
+            agent_source: "builtin",
+            agent_source_info: Some(r#"{"binary_name":"aionui-definitely-missing-warmup"}"#),
+            enabled: true,
+            command: Some("aionui-definitely-missing-warmup"),
+            args: Some("[]"),
+            env: Some("[]"),
+            native_skills_dirs: None,
+            behavior_policy: None,
+            yolo_id: None,
+            agent_capabilities: None,
+            auth_methods: None,
+            config_options: None,
+            available_modes: None,
+            available_models: None,
+            available_commands: None,
+            sort_order: 9900,
+        })
+        .await
+        .unwrap();
+    services.agent_registry.invalidate_and_rehydrate().await.unwrap();
+
+    let (token, csrf) = setup_and_login(&mut app, &services, "user1", "pass123").await;
+    let req = json_with_token(
+        "POST",
+        "/api/agents/warmup",
+        json!({ "backends": ["missing-warmup"], "reason": "before_send" }),
+        &token,
+        &csrf,
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = body_json(resp).await;
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"]["results"][0]["backend"], "missing-warmup");
+    assert_eq!(body["data"]["results"][0]["status"], "skipped");
+    assert_eq!(body["data"]["results"][0]["agent_id"], "missing-warmup");
+    assert!(
+        body["data"]["results"][0]["error"]
+            .as_str()
+            .unwrap()
+            .contains("not available")
+    );
+}
+
+#[tokio::test]
+async fn warmup_agents_rejects_unauthenticated_request() {
+    let (app, _services) = build_app().await;
+    let csrf_resp = app.clone().oneshot(get_request("/api/auth/status")).await.unwrap();
+    let csrf = extract_csrf_token(&csrf_resp).expect("CSRF cookie should be set");
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/agents/warmup")
+        .header("content-type", "application/json")
+        .header("x-csrf-token", &csrf)
+        .header("cookie", format!("aionui-csrf-token={csrf}"))
+        .body(Body::from(r#"{"backends":["codex"],"reason":"idle"}"#))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn warmup_agents_requires_csrf() {
+    let (mut app, services) = build_app().await;
+    let (token, _csrf) = setup_and_login(&mut app, &services, "user1", "pass123").await;
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/agents/warmup")
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::from(r#"{"backends":["codex"]}"#))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Add `POST /api/agents/warmup` for warming local ACP agents before the first user prompt.
- Return structured warmup results (`ready`, `skipped`, `failed`) so unknown or unavailable backends do not surface as generic server errors.
- Persist handshake metadata for builtin ACP agents and cover unauthenticated/CSRF/skip paths in e2e tests.

## Test plan

- [x] cargo fmt --all -- --check
- [x] cargo test -p aionui-api-types -p aionui-ai-agent
- [x] cargo test -p aionui-app --test acp_e2e
- [x] cargo clippy -p aionui-api-types -p aionui-ai-agent -p aionui-app -- -D warnings
- [x] git diff --check
