### PR TITLE
fix(ai-agent): surface ACP startup crashes and accept work_dir paths (ELECTRON-1BT)

### DIFF
--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -8,6 +8,7 @@ use crate::manager::acp::{
     AcpSession, AcpSessionEvent, ModelIdentityReminderHook, PermissionRouter, SessionNewPreludeHook,
 };
 use crate::protocol::acp::AcpProtocol;
+use crate::protocol::error::AcpError;
 use crate::protocol::events::AgentStreamEvent;
 use crate::registry::CatalogSender;
 use crate::shared_kernel::{ModeId, ModelId, SessionId as DomainSessionId};
@@ -44,6 +45,29 @@ use super::mode_normalize::normalize_requested_mode;
 
 /// Grace period before force-killing an ACP process (ms).
 const ACP_KILL_GRACE_MS: u64 = 500;
+
+/// Decompose a child `ExitStatus` (or its absence) into the
+/// `(exit_code, signal)` pair that `AcpError::StartupCrash` /
+/// `AcpError::Disconnected` carry.
+///
+/// `None` ⇒ wait failed; we have no actionable info to pass on.
+/// On Unix, terminating signals surface via `ExitStatusExt::signal()`; the
+/// numeric value is rendered as `Some("signal:N")`. On Windows there are no
+/// POSIX signals, so `signal` stays `None` and the upstream exit code is the
+/// only diagnostic.
+fn exit_status_parts(exit: Option<std::process::ExitStatus>) -> (Option<i32>, Option<String>) {
+    let Some(status) = exit else {
+        return (None, None);
+    };
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(sig) = status.signal() {
+            return (status.code(), Some(format!("signal:{sig}")));
+        }
+    }
+    (status.code(), None)
+}
 
 fn confirm_option_id(data: &Value) -> Option<String> {
     match data {
@@ -171,16 +195,36 @@ impl AcpAgentManager {
         let (permission_tx, permission_rx) = mpsc::channel(32);
         let runtime = AgentRuntime::new(params.conversation_id.clone(), params.workspace.path.clone(), 256);
 
-        let protocol = AcpProtocol::connect(stdin, stdout, runtime.event_sender(), permission_tx, notification_tx)
-            .await
-            .map_err(|e| {
+        // Race the handshake against process exit. The SDK's stdout EOF
+        // detection can lag (observed: 30s on Windows when the agent dies
+        // 70ms in — ELECTRON-1BT), so we explicitly watch the child. If
+        // it dies before init completes, surface a `StartupCrash` carrying
+        // the buffered stderr instead of waiting out the timeout.
+        let connect_fut = AcpProtocol::connect(stdin, stdout, runtime.event_sender(), permission_tx, notification_tx);
+        tokio::pin!(connect_fut);
+        let protocol = tokio::select! {
+            biased;
+            exit = process.wait_for_exit() => {
+                let stderr = process.peek_stderr_tail(64).await;
+                let (exit_code, signal) = exit_status_parts(exit);
+                error!(
+                    conversation_id = %params.conversation_id,
+                    exit_code = ?exit_code,
+                    signal = ?signal,
+                    stderr = %stderr,
+                    "Agent process exited before ACP handshake completed"
+                );
+                return Err(AppError::from(AcpError::StartupCrash { exit_code, signal, stderr }));
+            }
+            res = &mut connect_fut => res.map_err(|e| {
                 error!(
                     conversation_id = %params.conversation_id,
                     error = %ErrorChain(&e),
                     "Failed to establish ACP protocol connection"
                 );
                 AppError::from(e)
-            })?;
+            })?,
+        };
         let permission_router = Arc::new(PermissionRouter::new(permission_rx));
 
         let snapshot = params.session_snapshot.as_ref();
@@ -686,8 +730,26 @@ impl AcpAgentManager {
 
 #[cfg(test)]
 mod tests {
-    use super::user_facing_message;
+    use super::{exit_status_parts, user_facing_message};
     use aionui_common::AppError;
+
+    #[test]
+    fn exit_status_parts_handles_missing_status() {
+        assert_eq!(exit_status_parts(None), (None, None));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exit_status_parts_extracts_unix_exit_code() {
+        // ExitStatus::from_raw is the only stable constructor. On Unix the
+        // low 8 bits are the signal; bits 8..15 are the exit code when the
+        // process exited normally.
+        use std::os::unix::process::ExitStatusExt;
+        let status = std::process::ExitStatus::from_raw(1 << 8); // exit 1
+        let (code, signal) = exit_status_parts(Some(status));
+        assert_eq!(code, Some(1));
+        assert_eq!(signal, None);
+    }
 
     #[test]
     fn strips_bad_gateway_prefix() {

--- a/crates/aionui-ai-agent/src/protocol/error.rs
+++ b/crates/aionui-ai-agent/src/protocol/error.rs
@@ -58,6 +58,18 @@ pub(crate) enum AcpError {
     InitTimeout { timeout_secs: u64 },
 }
 
+/// Format the human-readable suffix for `StartupCrash` / `Disconnected`.
+/// stderr is deliberately omitted — see the `From<AcpError> for AppError`
+/// security note.
+fn format_exit_detail(exit_code: Option<i32>, signal: Option<&str>) -> String {
+    match (exit_code, signal) {
+        (Some(code), Some(sig)) => format!(" (exit code {code}, {sig})"),
+        (Some(code), None) => format!(" (exit code {code})"),
+        (None, Some(sig)) => format!(" ({sig})"),
+        (None, None) => String::new(),
+    }
+}
+
 /// JSON-RPC default message strings that carry no useful information.
 /// When `AgentInternal` arrives with one of these as its `message`, we fall
 /// back to a diagnostic display ("Agent internal error (code -32603)").
@@ -81,13 +93,12 @@ impl std::fmt::Display for AcpError {
             }
             AcpError::StartupCrash { exit_code, signal, .. } => {
                 // stderr intentionally NOT included — may carry secrets.
-                write!(
-                    f,
-                    "Agent process exited during startup (exit={exit_code:?}, signal={signal:?})"
-                )
+                let detail = format_exit_detail(*exit_code, signal.as_deref());
+                write!(f, "Agent process exited before initialize handshake completed{detail}")
             }
             AcpError::Disconnected { exit_code, signal, .. } => {
-                write!(f, "Agent process disconnected (exit={exit_code:?}, signal={signal:?})")
+                let detail = format_exit_detail(*exit_code, signal.as_deref());
+                write!(f, "Agent process disconnected{detail}")
             }
             AcpError::AuthRequired => f.write_str("Authentication required"),
             AcpError::SessionNotFound { session_id } => {
@@ -374,6 +385,44 @@ mod tests {
             !display.contains("SUPER SECRET"),
             "Display should not leak stderr: {display}"
         );
+    }
+
+    #[test]
+    fn startup_crash_display_includes_exit_code() {
+        let err = AcpError::StartupCrash {
+            exit_code: Some(1),
+            signal: None,
+            stderr: String::new(),
+        };
+        let display = err.to_string();
+        assert!(display.contains("exit code 1"), "got {display}");
+        assert!(
+            display.contains("before initialize handshake"),
+            "must explain when in lifecycle the crash happened; got {display}"
+        );
+    }
+
+    #[test]
+    fn startup_crash_display_omits_detail_when_unknown() {
+        let err = AcpError::StartupCrash {
+            exit_code: None,
+            signal: None,
+            stderr: String::new(),
+        };
+        let display = err.to_string();
+        assert!(!display.contains("None"), "must not surface raw `None`; got {display}");
+        assert!(!display.contains("()"), "must not produce empty parens; got {display}");
+    }
+
+    #[test]
+    fn disconnected_display_includes_signal_when_present() {
+        let err = AcpError::Disconnected {
+            exit_code: None,
+            signal: Some("signal:9".into()),
+            stderr: String::new(),
+        };
+        let display = err.to_string();
+        assert!(display.contains("signal:9"), "got {display}");
     }
 
     #[test]

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -66,11 +66,26 @@ pub struct ModuleStates {
     pub assistant: AssistantRouterState,
 }
 
-fn default_allowed_roots() -> Vec<std::path::PathBuf> {
-    vec![
+fn default_allowed_roots(work_dir: Option<&std::path::Path>) -> Vec<std::path::PathBuf> {
+    let mut roots = vec![
         std::env::temp_dir(),
         dirs::home_dir().unwrap_or_else(std::env::temp_dir),
-    ]
+    ];
+    // Auto-provisioned per-conversation workspaces live under
+    // `{work_dir}/conversations/{label}-temp-{id}/`. On Windows the
+    // operator may put `work_dir` on a separate drive (e.g. `X:\AionUi`)
+    // that's neither under `temp_dir` nor `home_dir`, which previously
+    // caused `/api/fs/list` to 403 every Hermes-mode session
+    // (ELECTRON-1BT). Including `work_dir` keeps temp + custom-on-drive
+    // workspaces on the allowlist without widening the sandbox to
+    // unrelated paths.
+    if let Some(wd) = work_dir
+        && !wd.as_os_str().is_empty()
+        && !roots.iter().any(|r| r == wd)
+    {
+        roots.push(wd.to_path_buf());
+    }
+    roots
 }
 /// Components needed to start the channel orchestrator.
 ///
@@ -238,7 +253,7 @@ pub fn build_connection_test_state() -> ConnectionTestRouterState {
 /// Build the default `FileRouterState` from application services.
 pub fn build_file_state(services: &AppServices) -> FileRouterState {
     let broadcaster = services.event_bus.clone();
-    let allowed_roots = default_allowed_roots();
+    let allowed_roots = default_allowed_roots(Some(services.work_dir.as_path()));
     let browse_roots = aionui_file::browse::default_browse_roots();
     let file_service = Arc::new(FileService::new(broadcaster.clone(), allowed_roots.clone()));
     let watch_service = Arc::new(FileWatchService::new(broadcaster).expect("file watch service initialization"));
@@ -512,7 +527,7 @@ pub fn build_cron_state(services: &AppServices) -> CronRouterState {
 /// Build the default `OfficeRouterState` from application services.
 pub fn build_office_state(services: &AppServices) -> OfficeRouterState {
     let data_dir = services.data_dir.as_path();
-    let allowed_roots = default_allowed_roots();
+    let allowed_roots = default_allowed_roots(Some(services.work_dir.as_path()));
 
     let spawner: Arc<dyn aionui_office::ProcessSpawner> = Arc::new(aionui_office::DefaultProcessSpawner);
     let watch_manager = Arc::new(OfficecliWatchManager::new(spawner, services.event_bus.clone()));


### PR DESCRIPTION
## Summary

Two related fixes both surfaced by Sentry [ELECTRON-1BT](https://iofficeai.sentry.io/issues/119944873/) — a Hermes-mode user on Windows whose conversation died at every layer:

- **Race ACP handshake against process exit.** `AcpProtocol::connect` previously waited the full 30s `INIT_TIMEOUT_SECS` even when the child (`hermes.exe`) had already `exit(1)` 70ms in. Now `AcpAgentManager::new` runs the connect future inside a `tokio::select!` with `process.wait_for_exit()`; an early death returns `AcpError::StartupCrash { exit_code, signal, stderr }` immediately. `StartupCrash` / `Disconnected` `Display` reworded to spell out the lifecycle phase plus the exit detail (`exit code 1` / `signal:9`), still without leaking stderr to the user-facing message — operator log keeps it via `ErrorChain` + structured `tracing`.
- **Allow `services.work_dir` in the file sandbox.** `default_allowed_roots` only listed `temp_dir` + `home_dir`. Auto-provisioned per-conversation workspaces live at `{work_dir}/conversations/{label}-temp-{id}/`; on macOS this is usually inside `home_dir` so nothing breaks, but on Windows the operator commonly puts `work_dir` on a separate drive (the Sentry user had `X:\AionUi\work-directory`), which made every Hermes session 403 on `/api/fs/list` immediately. Pass `services.work_dir` through to the allowlist for both `build_file_state` and `build_office_state`.

Companion frontend PR (404 breadcrumb noise on `getMode`/`getModel`): iOfficeAI/AionUi#TBD.

## Test plan

- [x] `cargo test -p aionui-ai-agent --lib protocol::error` (20/20)
- [x] `cargo test -p aionui-ai-agent --lib manager::acp::agent` (19/19, includes new `exit_status_parts` tests)
- [x] `cargo test -p aionui-file --lib path_safety` (14/14)
- [x] `cargo clippy -p aionui-ai-agent -p aionui-app -- -D warnings`
- [ ] CI to run the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)