### PR TITLE
feat: add is_full_url flag for provider URL resolution

### DIFF
--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -94,7 +94,8 @@ pub(super) async fn build(
 
     let provider = map_aionrs_provider(&row.platform, &model_id, row.model_protocols.as_deref());
 
-    let (base_url, compat_overrides) = resolve_aionrs_url_and_compat(&row.platform, &row.base_url, &provider);
+    let (base_url, compat_overrides) =
+        resolve_aionrs_url_and_compat(&row.platform, &row.base_url, &provider, row.is_full_url);
 
     let bedrock_config = if row.platform == "bedrock" {
         resolve_bedrock_config(row.bedrock_config.as_deref())
@@ -196,8 +197,15 @@ fn resolve_aionrs_url_and_compat(
     platform: &str,
     raw_base_url: &str,
     mapped_provider: &str,
+    is_full_url: bool,
 ) -> (Option<String>, AionrsCompatOverrides) {
     let mut compat = AionrsCompatOverrides::default();
+
+    if is_full_url {
+        let trimmed = raw_base_url.trim_end_matches('/');
+        compat.api_path = Some(String::new());
+        return (Some(trimmed.to_owned()), compat);
+    }
 
     if platform == "gemini" {
         let trimmed = raw_base_url.trim_end_matches('/');
@@ -384,7 +392,7 @@ mod tests {
 
     #[test]
     fn resolve_openai_official_sets_max_completion_tokens() {
-        let (base_url, compat) = resolve_aionrs_url_and_compat("custom", "https://api.openai.com/v1", "openai");
+        let (base_url, compat) = resolve_aionrs_url_and_compat("custom", "https://api.openai.com/v1", "openai", false);
         assert_eq!(base_url.as_deref(), Some("https://api.openai.com"));
         assert_eq!(compat.max_tokens_field.as_deref(), Some("max_completion_tokens"));
         assert!(compat.api_path.is_none());
@@ -392,7 +400,7 @@ mod tests {
 
     #[test]
     fn resolve_non_openai_keeps_default_max_tokens() {
-        let (base_url, compat) = resolve_aionrs_url_and_compat("custom", "https://api.deepseek.com/v1", "openai");
+        let (base_url, compat) = resolve_aionrs_url_and_compat("custom", "https://api.deepseek.com/v1", "openai", false);
         assert_eq!(base_url.as_deref(), Some("https://api.deepseek.com"));
         assert!(compat.max_tokens_field.is_none());
     }
@@ -400,7 +408,7 @@ mod tests {
     #[test]
     fn resolve_gemini_prepends_path_and_sets_api_path() {
         let (base_url, compat) =
-            resolve_aionrs_url_and_compat("gemini", "https://generativelanguage.googleapis.com", "openai");
+            resolve_aionrs_url_and_compat("gemini", "https://generativelanguage.googleapis.com", "openai", false);
         assert_eq!(
             base_url.as_deref(),
             Some("https://generativelanguage.googleapis.com/v1beta/openai")
@@ -411,9 +419,52 @@ mod tests {
 
     #[test]
     fn resolve_anthropic_no_compat_overrides() {
-        let (base_url, compat) = resolve_aionrs_url_and_compat("anthropic", "https://api.anthropic.com", "anthropic");
+        let (base_url, compat) = resolve_aionrs_url_and_compat("anthropic", "https://api.anthropic.com", "anthropic", false);
         assert_eq!(base_url.as_deref(), Some("https://api.anthropic.com"));
         assert!(compat.max_tokens_field.is_none());
+        assert!(compat.api_path.is_none());
+    }
+
+    #[test]
+    fn resolve_full_url_mode_uses_url_as_is() {
+        let (base_url, compat) = resolve_aionrs_url_and_compat(
+            "custom",
+            "https://proxy.example.com/v1/chat/completions",
+            "openai",
+            true,
+        );
+        assert_eq!(
+            base_url.as_deref(),
+            Some("https://proxy.example.com/v1/chat/completions")
+        );
+        assert_eq!(compat.api_path.as_deref(), Some(""));
+        assert!(compat.max_tokens_field.is_none());
+    }
+
+    #[test]
+    fn resolve_full_url_mode_strips_trailing_slash() {
+        let (base_url, compat) = resolve_aionrs_url_and_compat(
+            "custom",
+            "https://proxy.example.com/v1/chat/completions/",
+            "openai",
+            true,
+        );
+        assert_eq!(
+            base_url.as_deref(),
+            Some("https://proxy.example.com/v1/chat/completions")
+        );
+        assert_eq!(compat.api_path.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn resolve_full_url_false_still_normalizes() {
+        let (base_url, compat) = resolve_aionrs_url_and_compat(
+            "custom",
+            "https://api.deepseek.com/v1",
+            "openai",
+            false,
+        );
+        assert_eq!(base_url.as_deref(), Some("https://api.deepseek.com"));
         assert!(compat.api_path.is_none());
     }
 

--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -400,7 +400,8 @@ mod tests {
 
     #[test]
     fn resolve_non_openai_keeps_default_max_tokens() {
-        let (base_url, compat) = resolve_aionrs_url_and_compat("custom", "https://api.deepseek.com/v1", "openai", false);
+        let (base_url, compat) =
+            resolve_aionrs_url_and_compat("custom", "https://api.deepseek.com/v1", "openai", false);
         assert_eq!(base_url.as_deref(), Some("https://api.deepseek.com"));
         assert!(compat.max_tokens_field.is_none());
     }
@@ -419,7 +420,8 @@ mod tests {
 
     #[test]
     fn resolve_anthropic_no_compat_overrides() {
-        let (base_url, compat) = resolve_aionrs_url_and_compat("anthropic", "https://api.anthropic.com", "anthropic", false);
+        let (base_url, compat) =
+            resolve_aionrs_url_and_compat("anthropic", "https://api.anthropic.com", "anthropic", false);
         assert_eq!(base_url.as_deref(), Some("https://api.anthropic.com"));
         assert!(compat.max_tokens_field.is_none());
         assert!(compat.api_path.is_none());
@@ -458,12 +460,8 @@ mod tests {
 
     #[test]
     fn resolve_full_url_false_still_normalizes() {
-        let (base_url, compat) = resolve_aionrs_url_and_compat(
-            "custom",
-            "https://api.deepseek.com/v1",
-            "openai",
-            false,
-        );
+        let (base_url, compat) =
+            resolve_aionrs_url_and_compat("custom", "https://api.deepseek.com/v1", "openai", false);
         assert_eq!(base_url.as_deref(), Some("https://api.deepseek.com"));
         assert!(compat.api_path.is_none());
     }

--- a/crates/aionui-ai-agent/tests/factory_provider_integration.rs
+++ b/crates/aionui-ai-agent/tests/factory_provider_integration.rs
@@ -51,6 +51,7 @@ async fn insert_test_provider(repo: &dyn IProviderRepository, id: &str, platform
         model_enabled: None,
         model_health: None,
         bedrock_config: None,
+        is_full_url: false,
     })
     .await
     .unwrap();

--- a/crates/aionui-api-types/src/provider.rs
+++ b/crates/aionui-api-types/src/provider.rs
@@ -98,6 +98,8 @@ pub struct ProviderResponse {
     pub model_health: Option<HashMap<String, ModelHealthStatus>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bedrock_config: Option<BedrockConfig>,
+    #[serde(default)]
+    pub is_full_url: bool,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -131,6 +133,8 @@ pub struct CreateProviderRequest {
     pub model_health: Option<HashMap<String, ModelHealthStatus>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bedrock_config: Option<BedrockConfig>,
+    #[serde(default)]
+    pub is_full_url: bool,
 }
 
 fn default_true() -> bool {
@@ -154,6 +158,7 @@ pub struct UpdateProviderRequest {
     pub model_enabled: Option<HashMap<String, bool>>,
     pub model_health: Option<HashMap<String, ModelHealthStatus>>,
     pub bedrock_config: Option<BedrockConfig>,
+    pub is_full_url: Option<bool>,
 }
 
 /// Request body for `POST /api/providers/:id/models`.
@@ -423,6 +428,7 @@ mod tests {
             model_enabled: Some(HashMap::from([("claude-sonnet-4-20250514".into(), true)])),
             model_health: None,
             bedrock_config: None,
+            is_full_url: false,
             created_at: 1712345678000,
             updated_at: 1712345678000,
         };
@@ -455,6 +461,7 @@ mod tests {
             model_enabled: None,
             model_health: None,
             bedrock_config: None,
+            is_full_url: false,
             created_at: 0,
             updated_at: 0,
         };
@@ -575,6 +582,7 @@ mod tests {
             model_enabled: None,
             model_health: None,
             bedrock_config: None,
+            is_full_url: false,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert!(json.get("id").is_none());
@@ -848,5 +856,32 @@ mod tests {
         assert_eq!(mkr["details"].as_array().unwrap().len(), 3);
         assert_eq!(mkr["details"][0]["masked_key"], "sk-***abcd");
         assert_eq!(mkr["details"][2]["error"], "Invalid API key");
+    }
+
+    // -- is_full_url --
+
+    #[test]
+    fn test_create_provider_request_with_is_full_url() {
+        let raw = json!({
+            "platform": "custom",
+            "name": "Custom Proxy",
+            "base_url": "https://proxy.example.com/v1/chat/completions",
+            "api_key": "sk-test",
+            "is_full_url": true
+        });
+        let req: CreateProviderRequest = serde_json::from_value(raw).unwrap();
+        assert!(req.is_full_url);
+    }
+
+    #[test]
+    fn test_create_provider_request_is_full_url_defaults_false() {
+        let raw = json!({
+            "platform": "openai",
+            "name": "OpenAI",
+            "base_url": "https://api.openai.com",
+            "api_key": "sk-test"
+        });
+        let req: CreateProviderRequest = serde_json::from_value(raw).unwrap();
+        assert!(!req.is_full_url);
     }
 }

--- a/crates/aionui-db/migrations/006_provider_is_full_url.sql
+++ b/crates/aionui-db/migrations/006_provider_is_full_url.sql
@@ -1,0 +1,1 @@
+ALTER TABLE providers ADD COLUMN is_full_url INTEGER NOT NULL DEFAULT 0;

--- a/crates/aionui-db/src/models/provider.rs
+++ b/crates/aionui-db/src/models/provider.rs
@@ -27,6 +27,9 @@ pub struct Provider {
     pub model_health: Option<String>,
     /// JSON object: Bedrock-specific configuration.
     pub bedrock_config: Option<String>,
+    /// When true, base_url is treated as a complete endpoint URL.
+    /// The system will NOT append paths like /v1/chat/completions.
+    pub is_full_url: bool,
     pub created_at: TimestampMs,
     pub updated_at: TimestampMs,
 }

--- a/crates/aionui-db/src/repository/provider.rs
+++ b/crates/aionui-db/src/repository/provider.rs
@@ -40,6 +40,7 @@ pub struct CreateProviderParams<'a> {
     pub model_enabled: Option<&'a str>,
     pub model_health: Option<&'a str>,
     pub bedrock_config: Option<&'a str>,
+    pub is_full_url: bool,
 }
 
 /// Parameters for updating an existing provider.
@@ -59,4 +60,5 @@ pub struct UpdateProviderParams<'a> {
     pub model_enabled: Option<Option<&'a str>>,
     pub model_health: Option<Option<&'a str>>,
     pub bedrock_config: Option<Option<&'a str>>,
+    pub is_full_url: Option<bool>,
 }

--- a/crates/aionui-db/src/repository/sqlite_provider.rs
+++ b/crates/aionui-db/src/repository/sqlite_provider.rs
@@ -47,8 +47,8 @@ impl IProviderRepository for SqliteProviderRepository {
             "INSERT INTO providers \
                 (id, platform, name, base_url, api_key_encrypted, models, enabled, \
                  capabilities, context_limit, model_protocols, model_enabled, \
-                 model_health, bedrock_config, created_at, updated_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                 model_health, bedrock_config, is_full_url, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&id)
         .bind(params.platform)
@@ -63,6 +63,7 @@ impl IProviderRepository for SqliteProviderRepository {
         .bind(params.model_enabled)
         .bind(params.model_health)
         .bind(params.bedrock_config)
+        .bind(params.is_full_url)
         .bind(now)
         .bind(now)
         .execute(&self.pool)
@@ -88,6 +89,7 @@ impl IProviderRepository for SqliteProviderRepository {
             model_enabled: params.model_enabled.map(String::from),
             model_health: params.model_health.map(String::from),
             bedrock_config: params.bedrock_config.map(String::from),
+            is_full_url: params.is_full_url,
             created_at: now,
             updated_at: now,
         })
@@ -106,7 +108,7 @@ impl IProviderRepository for SqliteProviderRepository {
                 platform = ?, name = ?, base_url = ?, api_key_encrypted = ?, \
                 models = ?, enabled = ?, capabilities = ?, context_limit = ?, \
                 model_protocols = ?, model_enabled = ?, model_health = ?, \
-                bedrock_config = ?, updated_at = ? \
+                bedrock_config = ?, is_full_url = ?, updated_at = ? \
              WHERE id = ?",
         )
         .bind(&merged.platform)
@@ -121,6 +123,7 @@ impl IProviderRepository for SqliteProviderRepository {
         .bind(&merged.model_enabled)
         .bind(&merged.model_health)
         .bind(&merged.bedrock_config)
+        .bind(merged.is_full_url)
         .bind(merged.updated_at)
         .bind(id)
         .execute(&self.pool)
@@ -176,6 +179,7 @@ fn merge_update(existing: Provider, params: UpdateProviderParams<'_>) -> Provide
         bedrock_config: params
             .bedrock_config
             .map_or(existing.bedrock_config, |v| v.map(String::from)),
+        is_full_url: params.is_full_url.unwrap_or(existing.is_full_url),
         created_at: existing.created_at,
         updated_at: now,
     }
@@ -207,6 +211,7 @@ mod tests {
             model_enabled: None,
             model_health: None,
             bedrock_config: None,
+            is_full_url: false,
         }
     }
 

--- a/crates/aionui-db/tests/provider_repository.rs
+++ b/crates/aionui-db/tests/provider_repository.rs
@@ -29,6 +29,7 @@ fn sample_params() -> CreateProviderParams<'static> {
         model_enabled: None,
         model_health: None,
         bedrock_config: None,
+        is_full_url: false,
     }
 }
 

--- a/crates/aionui-system/src/model_fetcher/mod.rs
+++ b/crates/aionui-system/src/model_fetcher/mod.rs
@@ -160,6 +160,7 @@ mod tests {
                 model_enabled: None,
                 model_health: None,
                 bedrock_config: None,
+                is_full_url: false,
             })
             .await
             .unwrap();

--- a/crates/aionui-system/src/provider.rs
+++ b/crates/aionui-system/src/provider.rs
@@ -56,6 +56,7 @@ impl ProviderService {
             model_enabled: model_enabled_json.as_deref(),
             model_health: model_health_json.as_deref(),
             bedrock_config: bedrock_json.as_deref(),
+            is_full_url: req.is_full_url,
         };
 
         let row = self.repo.create(params).await?;
@@ -91,6 +92,7 @@ impl ProviderService {
             model_enabled: model_enabled_json.as_ref().map(|s| Some(s.as_str())),
             model_health: model_health_json.as_ref().map(|s| Some(s.as_str())),
             bedrock_config: bedrock_json.as_ref().map(|s| Some(s.as_str())),
+            is_full_url: req.is_full_url,
         };
 
         let row = self.repo.update(id, params).await?;
@@ -140,6 +142,7 @@ impl ProviderService {
             model_enabled,
             model_health,
             bedrock_config,
+            is_full_url: row.is_full_url,
             created_at: row.created_at,
             updated_at: row.updated_at,
         })
@@ -290,6 +293,7 @@ mod tests {
             model_enabled: None,
             model_health: None,
             bedrock_config: None,
+            is_full_url: false,
         }
     }
 

--- a/crates/aionui-system/tests/model_fetch_routes.rs
+++ b/crates/aionui-system/tests/model_fetch_routes.rs
@@ -66,6 +66,7 @@ async fn create_provider(db: &aionui_db::Database, platform: &str, base_url: &st
             model_enabled: None,
             model_health: None,
             bedrock_config: None,
+            is_full_url: false,
         })
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

- Add `is_full_url` boolean column to providers table (migration 006)
- When `is_full_url` is true, bypass URL normalization and use `base_url` as-is with empty `api_path` (no `/v1/chat/completions` suffix appended)
- Thread the field through all layers: db model → repository → api-types → system service → ai-agent factory

## Test plan

- [x] Unit tests for `resolve_aionrs_url_and_compat` with `is_full_url=true` (3 new tests)
- [x] Existing tests pass with `is_full_url=false` (no regression)
- [x] All 5575 workspace tests pass
- [x] `cargo clippy --workspace` clean