### PR TITLE
feat(analytics): 添加 aionui-analytics crate（使用统计后端 + v2 仪表盘契约）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,6 +367,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tower",
  "tracing",
  "walkdir",
 ]
@@ -386,6 +387,7 @@ version = "0.1.7"
 dependencies = [
  "aion-config",
  "aionui-ai-agent",
+ "aionui-analytics",
  "aionui-api-types",
  "aionui-assets",
  "aionui-assistant",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aionui-analytics"
+version = "0.1.4"
+dependencies = [
+ "aionui-api-types",
+ "aionui-common",
+ "axum",
+ "chrono",
+ "dashmap",
+ "dirs",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "walkdir",
+]
+
+[[package]]
 name = "aionui-api-types"
 version = "0.1.7"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "3"
 members = [
+    "crates/aionui-analytics",
     "crates/aionui-assets",
     "crates/aionui-common",
     "crates/aionui-db",
@@ -30,6 +31,7 @@ license = "MIT"
 
 [workspace.dependencies]
 # Internal crates
+aionui-analytics = { path = "crates/aionui-analytics" }
 aionui-common = { path = "crates/aionui-common" }
 aionui-assets = { path = "crates/aionui-assets" }
 aionui-db = { path = "crates/aionui-db" }

--- a/crates/aionui-analytics/Cargo.toml
+++ b/crates/aionui-analytics/Cargo.toml
@@ -18,3 +18,4 @@ dashmap.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+tower = { workspace = true, features = ["util"] }

--- a/crates/aionui-analytics/Cargo.toml
+++ b/crates/aionui-analytics/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "aionui-analytics"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+aionui-common.workspace = true
+aionui-api-types.workspace = true
+axum.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+chrono.workspace = true
+tracing.workspace = true
+walkdir.workspace = true
+dirs.workspace = true
+dashmap.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/aionui-analytics/src/aggregate.rs
+++ b/crates/aionui-analytics/src/aggregate.rs
@@ -1,0 +1,1 @@
+// Implemented in Task 1.6.

--- a/crates/aionui-analytics/src/aggregate.rs
+++ b/crates/aionui-analytics/src/aggregate.rs
@@ -6,10 +6,12 @@ use std::collections::BTreeMap;
 
 /// 把 sessions 聚合为响应 (纯函数, 无 IO)。
 /// `time_range` 仅写入响应回显; 事件级时间过滤由 service 在调用前完成。
+/// `trend_dimension`: 趋势内层分段维度，可选 "agent" | "project" | "model"，默认行为同 "agent"。
 pub fn aggregate(
     sessions: Vec<ParsedSession>,
     granularity: &str,
     time_range: &str,
+    trend_dimension: &str,
     sessions_limit: u32,
     sessions_offset: u32,
 ) -> AgentUsageResponse {
@@ -35,6 +37,12 @@ pub fn aggregate(
         a.messages += s.message_count;
         let m = by_model.entry((an, s.model.clone())).or_default();
         m.sessions += 1;
+        // 根据 trend_dimension 确定本 session 的分段 key（session 级别，事件共享）
+        let seg: String = match trend_dimension {
+            "project" => s.project.clone(),
+            "model" => s.model.clone(),
+            _ => an.to_string(), // 默认 "agent"
+        };
         for e in &s.events {
             a.input += e.input_tokens;
             a.output += e.output_tokens;
@@ -45,7 +53,7 @@ pub fn aggregate(
             m.cache_read += e.cache_read_tokens;
             m.cache_creation += e.cache_creation_tokens;
             let bucket = bucket_key(e.at, gran);
-            *trend.entry(bucket).or_default().entry(an.to_string()).or_insert(0) += e.total();
+            *trend.entry(bucket).or_default().entry(seg.clone()).or_insert(0) += e.total();
         }
     }
 
@@ -81,9 +89,9 @@ pub fn aggregate(
 
     let trend_points: Vec<TrendPoint> = trend
         .into_iter()
-        .map(|(bucket, by_agent)| TrendPoint {
+        .map(|(bucket, by_segment)| TrendPoint {
             bucket,
-            by_agent: by_agent.into_iter().collect(),
+            by_segment: by_segment.into_iter().collect(),
         })
         .collect();
 

--- a/crates/aionui-analytics/src/aggregate.rs
+++ b/crates/aionui-analytics/src/aggregate.rs
@@ -1,1 +1,134 @@
-// Implemented in Task 1.6.
+use crate::types::ParsedSession;
+use aionui_api_types::{
+    AgentUsageResponse, SessionRow, TrendPoint, UsageByAgent, UsageByModel, UsageSummary, UsageTrend,
+};
+use std::collections::BTreeMap;
+
+/// 把 sessions 聚合为响应 (纯函数, 无 IO)。
+/// `time_range` 仅写入响应回显; 事件级时间过滤由 service 在调用前完成。
+pub fn aggregate(
+    sessions: Vec<ParsedSession>,
+    granularity: &str,
+    time_range: &str,
+    sessions_limit: u32,
+    sessions_offset: u32,
+) -> AgentUsageResponse {
+    let gran = if granularity == "week" { "week" } else { "day" };
+
+    #[derive(Default, Clone)]
+    struct Acc {
+        sessions: u64,
+        messages: u64,
+        input: u64,
+        output: u64,
+        cache_read: u64,
+        cache_creation: u64,
+    }
+    let mut by_agent: BTreeMap<&'static str, Acc> = BTreeMap::new();
+    let mut by_model: BTreeMap<(&'static str, String), Acc> = BTreeMap::new();
+    let mut trend: BTreeMap<String, BTreeMap<String, u64>> = BTreeMap::new();
+
+    for s in &sessions {
+        let an = s.agent.as_str();
+        let a = by_agent.entry(an).or_default();
+        a.sessions += 1;
+        a.messages += s.message_count;
+        let m = by_model.entry((an, s.model.clone())).or_default();
+        m.sessions += 1;
+        for e in &s.events {
+            a.input += e.input_tokens;
+            a.output += e.output_tokens;
+            a.cache_read += e.cache_read_tokens;
+            a.cache_creation += e.cache_creation_tokens;
+            m.input += e.input_tokens;
+            m.output += e.output_tokens;
+            m.cache_read += e.cache_read_tokens;
+            m.cache_creation += e.cache_creation_tokens;
+            let bucket = bucket_key(e.at, gran);
+            *trend.entry(bucket).or_default().entry(an.to_string()).or_insert(0) += e.total();
+        }
+    }
+
+    let summary = UsageSummary {
+        by_agent: by_agent
+            .iter()
+            .map(|(name, a)| UsageByAgent {
+                agent: name.to_string(),
+                sessions: a.sessions,
+                messages: a.messages,
+                input_tokens: a.input,
+                output_tokens: a.output,
+                cache_read_tokens: a.cache_read,
+                cache_creation_tokens: a.cache_creation,
+                total_tokens: a.input + a.output + a.cache_read + a.cache_creation,
+            })
+            .collect(),
+    };
+
+    let by_model_vec: Vec<UsageByModel> = by_model
+        .iter()
+        .map(|((agent, model), m)| UsageByModel {
+            agent: agent.to_string(),
+            model: model.clone(),
+            sessions: m.sessions,
+            input_tokens: m.input,
+            output_tokens: m.output,
+            cache_read_tokens: m.cache_read,
+            cache_creation_tokens: m.cache_creation,
+            total_tokens: m.input + m.output + m.cache_read + m.cache_creation,
+        })
+        .collect();
+
+    let trend_points: Vec<TrendPoint> = trend
+        .into_iter()
+        .map(|(bucket, by_agent)| TrendPoint {
+            bucket,
+            by_agent: by_agent.into_iter().collect(),
+        })
+        .collect();
+
+    let mut rows: Vec<&ParsedSession> = sessions.iter().collect();
+    rows.sort_by_key(|b| std::cmp::Reverse(b.last_active_at));
+    let sessions_total = rows.len() as u64;
+    let page: Vec<SessionRow> = rows
+        .into_iter()
+        .skip(sessions_offset as usize)
+        .take(sessions_limit as usize)
+        .map(|s| SessionRow {
+            agent: s.agent.as_str().to_string(),
+            session_id: s.session_id.clone(),
+            project: s.project.clone(),
+            model: s.model.clone(),
+            started_at: s.started_at.to_rfc3339(),
+            last_active_at: s.last_active_at.to_rfc3339(),
+            messages: s.message_count,
+            total_tokens: s.events.iter().map(|e| e.total()).sum(),
+        })
+        .collect();
+
+    AgentUsageResponse {
+        scanned_at: chrono::Utc::now().to_rfc3339(),
+        sources: Vec::new(),
+        summary,
+        by_model: by_model_vec,
+        trend: UsageTrend {
+            granularity: gran.to_string(),
+            points: trend_points,
+        },
+        time_range: time_range.to_string(),
+        sessions_total,
+        sessions_limit,
+        sessions_offset,
+        sessions: page,
+    }
+}
+
+fn bucket_key(at: chrono::DateTime<chrono::Utc>, gran: &str) -> String {
+    use chrono::Datelike;
+    if gran == "week" {
+        let iso = at.iso_week();
+        format!("{}-W{:02}", iso.year(), iso.week())
+    } else {
+        at.format("%Y-%m-%d").to_string()
+    }
+}

--- a/crates/aionui-analytics/src/aggregate.rs
+++ b/crates/aionui-analytics/src/aggregate.rs
@@ -1,6 +1,7 @@
 use crate::types::ParsedSession;
 use aionui_api_types::{
-    AgentUsageResponse, SessionRow, TrendPoint, UsageByAgent, UsageByModel, UsageSummary, UsageTrend,
+    AgentUsageResponse, SessionRow, TokenKindBreakdown, TrendPoint, UsageByAgent, UsageByModel, UsageByProject,
+    UsageSummary, UsageTrend,
 };
 use std::collections::BTreeMap;
 
@@ -29,6 +30,9 @@ pub fn aggregate(
     let mut by_agent: BTreeMap<&'static str, Acc> = BTreeMap::new();
     let mut by_model: BTreeMap<(&'static str, String), Acc> = BTreeMap::new();
     let mut trend: BTreeMap<String, BTreeMap<String, u64>> = BTreeMap::new();
+    let mut by_project: BTreeMap<(&'static str, String), Acc> = BTreeMap::new();
+    // 每个 bucket 的 token 类型分层 (input, output, cache_read, cache_creation)
+    let mut trend_kind: BTreeMap<String, (u64, u64, u64, u64)> = BTreeMap::new();
 
     for s in &sessions {
         let an = s.agent.as_str();
@@ -37,6 +41,8 @@ pub fn aggregate(
         a.messages += s.message_count;
         let m = by_model.entry((an, s.model.clone())).or_default();
         m.sessions += 1;
+        let pj = by_project.entry((an, s.project.clone())).or_default();
+        pj.sessions += 1;
         // 根据 trend_dimension 确定本 session 的分段 key（session 级别，事件共享）
         let seg: String = match trend_dimension {
             "project" => s.project.clone(),
@@ -52,8 +58,17 @@ pub fn aggregate(
             m.output += e.output_tokens;
             m.cache_read += e.cache_read_tokens;
             m.cache_creation += e.cache_creation_tokens;
+            pj.input += e.input_tokens;
+            pj.output += e.output_tokens;
+            pj.cache_read += e.cache_read_tokens;
+            pj.cache_creation += e.cache_creation_tokens;
             let bucket = bucket_key(e.at, gran);
-            *trend.entry(bucket).or_default().entry(seg.clone()).or_insert(0) += e.total();
+            *trend.entry(bucket.clone()).or_default().entry(seg.clone()).or_insert(0) += e.total();
+            let tk = trend_kind.entry(bucket).or_default();
+            tk.0 += e.input_tokens;
+            tk.1 += e.output_tokens;
+            tk.2 += e.cache_read_tokens;
+            tk.3 += e.cache_creation_tokens;
         }
     }
 
@@ -87,11 +102,34 @@ pub fn aggregate(
         })
         .collect();
 
+    let by_project_vec: Vec<UsageByProject> = by_project
+        .iter()
+        .map(|((agent, project), pj)| UsageByProject {
+            agent: agent.to_string(),
+            project: project.clone(),
+            sessions: pj.sessions,
+            input_tokens: pj.input,
+            output_tokens: pj.output,
+            cache_read_tokens: pj.cache_read,
+            cache_creation_tokens: pj.cache_creation,
+            total_tokens: pj.input + pj.output + pj.cache_read + pj.cache_creation,
+        })
+        .collect();
+
     let trend_points: Vec<TrendPoint> = trend
         .into_iter()
-        .map(|(bucket, by_segment)| TrendPoint {
-            bucket,
-            by_segment: by_segment.into_iter().collect(),
+        .map(|(bucket, by_segment)| {
+            let tk = trend_kind.get(&bucket).copied().unwrap_or((0, 0, 0, 0));
+            TrendPoint {
+                bucket,
+                by_segment: by_segment.into_iter().collect(),
+                by_token_kind: TokenKindBreakdown {
+                    input: tk.0,
+                    output: tk.1,
+                    cache_read: tk.2,
+                    cache_creation: tk.3,
+                },
+            }
         })
         .collect();
 
@@ -119,6 +157,7 @@ pub fn aggregate(
         sources: Vec::new(),
         summary,
         by_model: by_model_vec,
+        by_project: by_project_vec,
         trend: UsageTrend {
             granularity: gran.to_string(),
             points: trend_points,

--- a/crates/aionui-analytics/src/cache.rs
+++ b/crates/aionui-analytics/src/cache.rs
@@ -1,1 +1,54 @@
-// Implemented in Task 1.7.
+use crate::parser::LogParser;
+use crate::types::{ParseError, ParsedSession};
+use dashmap::DashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+#[derive(Clone)]
+struct Entry {
+    mtime: std::time::SystemTime,
+    size: u64,
+    session: Arc<ParsedSession>,
+}
+
+#[derive(Default)]
+pub struct UsageCache {
+    map: DashMap<PathBuf, Entry>,
+}
+
+impl UsageCache {
+    pub fn new() -> Self {
+        Self { map: DashMap::new() }
+    }
+
+    /// mtime+size 未变则返回缓存; 否则用 parser 重解析并更新。
+    /// `bypass=true` 时忽略缓存但仍写回。
+    pub fn get_or_parse(
+        &self,
+        path: &Path,
+        parser: &dyn LogParser,
+        bypass: bool,
+    ) -> Result<Arc<ParsedSession>, ParseError> {
+        let meta = std::fs::metadata(path)?;
+        let mtime = meta.modified()?;
+        let size = meta.len();
+
+        if !bypass
+            && let Some(e) = self.map.get(path)
+            && e.mtime == mtime
+            && e.size == size
+        {
+            return Ok(e.session.clone());
+        }
+        let session = Arc::new(parser.parse_file(path)?);
+        self.map.insert(
+            path.to_path_buf(),
+            Entry {
+                mtime,
+                size,
+                session: session.clone(),
+            },
+        );
+        Ok(session)
+    }
+}

--- a/crates/aionui-analytics/src/cache.rs
+++ b/crates/aionui-analytics/src/cache.rs
@@ -1,0 +1,1 @@
+// Implemented in Task 1.7.

--- a/crates/aionui-analytics/src/lib.rs
+++ b/crates/aionui-analytics/src/lib.rs
@@ -1,0 +1,9 @@
+//! Local agent usage analytics: parse Codex/Claude Code session logs and aggregate token usage.
+pub mod aggregate;
+pub mod cache;
+pub mod parser;
+pub mod routes;
+pub mod service;
+pub mod types;
+
+pub use routes::{AnalyticsRouterState, analytics_routes};

--- a/crates/aionui-analytics/src/parser/claude.rs
+++ b/crates/aionui-analytics/src/parser/claude.rs
@@ -1,0 +1,85 @@
+use super::{LogParser, for_each_json_line, parse_ts};
+use crate::types::{Agent, ParseError, ParsedSession, UsageEvent};
+use std::collections::HashMap;
+use std::path::Path;
+
+pub struct ClaudeParser;
+
+impl LogParser for ClaudeParser {
+    fn parse_file(&self, path: &Path) -> Result<ParsedSession, ParseError> {
+        let mut events: Vec<UsageEvent> = Vec::new();
+        let mut model_counts: HashMap<String, u64> = HashMap::new();
+        let mut session_id = String::new();
+        let mut project = String::new();
+        let mut message_count: u64 = 0;
+
+        for_each_json_line(path, |v| {
+            if v.get("type").and_then(|t| t.as_str()) != Some("assistant") {
+                return;
+            }
+            let ts = v.get("timestamp").and_then(|t| t.as_str()).and_then(parse_ts);
+            let msg = v.get("message");
+            let usage = msg.and_then(|m| m.get("usage"));
+            let (ts, usage) = match (ts, usage) {
+                (Some(ts), Some(u)) => (ts, u),
+                _ => return,
+            };
+            if session_id.is_empty()
+                && let Some(s) = v.get("sessionId").and_then(|s| s.as_str())
+            {
+                session_id = s.to_string();
+            }
+            if project.is_empty()
+                && let Some(c) = v.get("cwd").and_then(|c| c.as_str())
+            {
+                project = c.to_string();
+            }
+            if let Some(m) = msg.and_then(|m| m.get("model")).and_then(|m| m.as_str()) {
+                *model_counts.entry(m.to_string()).or_insert(0) += 1;
+            }
+            let g = |k: &str| usage.get(k).and_then(|x| x.as_u64()).unwrap_or(0);
+            events.push(UsageEvent {
+                at: ts,
+                input_tokens: g("input_tokens"),
+                output_tokens: g("output_tokens"),
+                cache_read_tokens: g("cache_read_input_tokens"),
+                cache_creation_tokens: g("cache_creation_input_tokens"),
+            });
+            message_count += 1;
+        })?;
+
+        if events.is_empty() {
+            return Err(ParseError::Empty);
+        }
+        events.sort_by_key(|e| e.at);
+        let model = model_counts
+            .into_iter()
+            .max_by_key(|(_, c)| *c)
+            .map(|(m, _)| m)
+            .unwrap_or_else(|| "unknown".to_string());
+        let started_at = events.first().unwrap().at;
+        let last_active_at = events.last().unwrap().at;
+
+        Ok(ParsedSession {
+            agent: Agent::Claude,
+            session_id: if session_id.is_empty() {
+                path.file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("unknown")
+                    .to_string()
+            } else {
+                session_id
+            },
+            project: if project.is_empty() {
+                "unknown".to_string()
+            } else {
+                project
+            },
+            model,
+            started_at,
+            last_active_at,
+            events,
+            message_count,
+        })
+    }
+}

--- a/crates/aionui-analytics/src/parser/codex.rs
+++ b/crates/aionui-analytics/src/parser/codex.rs
@@ -1,0 +1,1 @@
+// Implemented in Task 1.4.

--- a/crates/aionui-analytics/src/parser/codex.rs
+++ b/crates/aionui-analytics/src/parser/codex.rs
@@ -1,1 +1,130 @@
-// Implemented in Task 1.4.
+use super::{LogParser, for_each_json_line, parse_ts};
+use crate::types::{Agent, ParseError, ParsedSession, UsageEvent};
+use std::path::Path;
+
+pub struct CodexParser;
+
+impl LogParser for CodexParser {
+    fn parse_file(&self, path: &Path) -> Result<ParsedSession, ParseError> {
+        let mut events: Vec<UsageEvent> = Vec::new();
+        let mut session_id = String::new();
+        let mut project = String::new();
+        let mut model = String::new();
+        let mut started_at: Option<chrono::DateTime<chrono::Utc>> = None;
+        let mut message_count: u64 = 0;
+        // (input, output, cached) 最后一个 total_token_usage, 用于 fallback。
+        let mut last_total: Option<(u64, u64, u64)> = None;
+
+        for_each_json_line(path, |v| {
+            let line_ts = v.get("timestamp").and_then(|t| t.as_str()).and_then(parse_ts);
+            let kind = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            let payload = v.get("payload");
+
+            match kind {
+                "session_meta" => {
+                    if let Some(p) = payload {
+                        if let Some(s) = p.get("id").and_then(|s| s.as_str()) {
+                            session_id = s.to_string();
+                        }
+                        if let Some(c) = p.get("cwd").and_then(|c| c.as_str()) {
+                            project = c.to_string();
+                        }
+                        if let Some(t) = p.get("timestamp").and_then(|t| t.as_str()).and_then(parse_ts) {
+                            started_at.get_or_insert(t);
+                        }
+                    }
+                }
+                "turn_context" => {
+                    if model.is_empty()
+                        && let Some(m) = payload.and_then(|p| p.get("model")).and_then(|m| m.as_str())
+                    {
+                        model = m.to_string();
+                    }
+                }
+                "response_item" => {
+                    let is_assistant_msg = payload
+                        .map(|p| {
+                            p.get("type").and_then(|t| t.as_str()) == Some("message")
+                                && p.get("role").and_then(|r| r.as_str()) == Some("assistant")
+                        })
+                        .unwrap_or(false);
+                    if is_assistant_msg {
+                        message_count += 1;
+                    }
+                }
+                "event_msg" => {
+                    let is_tc = payload
+                        .map(|p| p.get("type").and_then(|t| t.as_str()) == Some("token_count"))
+                        .unwrap_or(false);
+                    if !is_tc {
+                        return;
+                    }
+                    let info = payload.and_then(|p| p.get("info"));
+                    // 记录最后一个 total_token_usage 作为 fallback 兜底 (回应 review P2)。
+                    if let Some(total) = info.and_then(|i| i.get("total_token_usage")) {
+                        let g = |k: &str| total.get(k).and_then(|x| x.as_u64()).unwrap_or(0);
+                        last_total = Some((g("input_tokens"), g("output_tokens"), g("cached_input_tokens")));
+                    }
+                    let last = info.and_then(|i| i.get("last_token_usage"));
+                    // 事件级: 需要 last_token_usage + 行级时间; 缺任一则不记事件,
+                    // 由文件末尾的 fallback 兜底, 不静默丢弃整段用量。
+                    let (last, at) = match (last, line_ts) {
+                        (Some(l), Some(at)) => (l, at),
+                        _ => return,
+                    };
+                    let g = |k: &str| last.get(k).and_then(|x| x.as_u64()).unwrap_or(0);
+                    events.push(UsageEvent {
+                        at,
+                        input_tokens: g("input_tokens"),
+                        output_tokens: g("output_tokens"),
+                        cache_read_tokens: g("cached_input_tokens"),
+                        cache_creation_tokens: 0,
+                    });
+                }
+                _ => {}
+            }
+        })?;
+
+        // Fallback (回应 review P2, 见 design.md:158): 若无任何事件级用量, 但存在
+        // total_token_usage, 把整会话总量归到会话开始日 (无开始日则跳过该会话)。
+        if events.is_empty() {
+            match (last_total, started_at) {
+                (Some((i, o, c)), Some(start)) if i + o + c > 0 => {
+                    events.push(UsageEvent {
+                        at: start,
+                        input_tokens: i,
+                        output_tokens: o,
+                        cache_read_tokens: c,
+                        cache_creation_tokens: 0,
+                    });
+                }
+                _ => return Err(ParseError::Empty),
+            }
+        }
+        events.sort_by_key(|e| e.at);
+        let started_at = started_at.unwrap_or_else(|| events.first().unwrap().at);
+        let last_active_at = events.last().unwrap().at;
+
+        Ok(ParsedSession {
+            agent: Agent::Codex,
+            session_id: if session_id.is_empty() {
+                path.file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("unknown")
+                    .to_string()
+            } else {
+                session_id
+            },
+            project: if project.is_empty() {
+                "unknown".to_string()
+            } else {
+                project
+            },
+            model: if model.is_empty() { "unknown".to_string() } else { model },
+            started_at,
+            last_active_at,
+            events,
+            message_count,
+        })
+    }
+}

--- a/crates/aionui-analytics/src/parser/mod.rs
+++ b/crates/aionui-analytics/src/parser/mod.rs
@@ -1,0 +1,37 @@
+pub mod claude;
+pub mod codex;
+
+use crate::types::{ParseError, ParsedSession};
+use std::path::Path;
+
+pub trait LogParser {
+    fn parse_file(&self, path: &Path) -> Result<ParsedSession, ParseError>;
+}
+
+/// 读取 jsonl 文件, 对每个非空行调用 `f`; 解析失败的行被静默跳过。
+pub(crate) fn for_each_json_line<F>(path: &Path, mut f: F) -> Result<(), std::io::Error>
+where
+    F: FnMut(&serde_json::Value),
+{
+    use std::io::BufRead;
+    let file = std::fs::File::open(path)?;
+    let reader = std::io::BufReader::new(file);
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) {
+            f(&v);
+        }
+    }
+    Ok(())
+}
+
+/// 解析 RFC3339 时间戳; 失败返回 None。
+pub(crate) fn parse_ts(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+}

--- a/crates/aionui-analytics/src/routes.rs
+++ b/crates/aionui-analytics/src/routes.rs
@@ -1,0 +1,9 @@
+// Minimal placeholder — full impl in Task 1.9.
+use axum::Router;
+
+#[derive(Clone)]
+pub struct AnalyticsRouterState;
+
+pub fn analytics_routes(_state: AnalyticsRouterState) -> Router {
+    Router::new()
+}

--- a/crates/aionui-analytics/src/routes.rs
+++ b/crates/aionui-analytics/src/routes.rs
@@ -41,6 +41,7 @@ async fn get_agent_usage(
         .service
         .build(UsageRequest {
             trend_granularity: q.trend_granularity.unwrap_or_else(|| "day".into()),
+            trend_dimension: q.trend_dimension.unwrap_or_else(|| "agent".into()),
             time_range: q.time_range.unwrap_or_else(|| "30d".into()),
             refresh: q.refresh.unwrap_or(false),
             sessions_limit: q.sessions_limit.unwrap_or(200),

--- a/crates/aionui-analytics/src/routes.rs
+++ b/crates/aionui-analytics/src/routes.rs
@@ -1,9 +1,52 @@
-// Minimal placeholder — full impl in Task 1.9.
 use axum::Router;
+use axum::extract::{Json, Query, State};
+use axum::http::HeaderMap;
+use axum::routing::get;
+
+use aionui_api_types::{AgentUsageQuery, AgentUsageResponse, ApiResponse};
+use aionui_common::AppError;
+
+use crate::service::{AgentUsageService, UsageRequest};
+
+/// WebHost 反向代理在转发 WebUI 远程请求时注入的标志 header。
+/// 安全模型 (回应 review P1, 见 design.md 访问边界):
+/// - 本机 Electron 直连后端, 不经 WebHost 代理, 不带此 header → is_remote=false → 不脱敏
+/// - WebUI remote 必经 WebHost 代理, WebHost **先剥离客户端同名 header 再注入** → is_remote=true → 脱敏
+/// - 即使公网客户端自带伪造 header, 经 WebHost 时会被剥离重置; 退一步即便到达,
+///   也只会让该客户端看到**更脱敏**的结果 (安全方向), 不会泄露更多
+pub const WEBUI_REMOTE_HEADER: &str = "x-aionui-webui-remote";
 
 #[derive(Clone)]
-pub struct AnalyticsRouterState;
+pub struct AnalyticsRouterState {
+    pub service: AgentUsageService,
+}
 
-pub fn analytics_routes(_state: AnalyticsRouterState) -> Router {
+pub fn analytics_routes(state: AnalyticsRouterState) -> Router {
     Router::new()
+        .route("/api/analytics/agent-usage", get(get_agent_usage))
+        .with_state(state)
+}
+
+async fn get_agent_usage(
+    State(state): State<AnalyticsRouterState>,
+    headers: HeaderMap,
+    Query(q): Query<AgentUsageQuery>,
+) -> Result<Json<ApiResponse<AgentUsageResponse>>, AppError> {
+    let is_remote = headers
+        .get(WEBUI_REMOTE_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v == "1")
+        .unwrap_or(false);
+    let resp = state
+        .service
+        .build(UsageRequest {
+            trend_granularity: q.trend_granularity.unwrap_or_else(|| "day".into()),
+            time_range: q.time_range.unwrap_or_else(|| "30d".into()),
+            refresh: q.refresh.unwrap_or(false),
+            sessions_limit: q.sessions_limit.unwrap_or(200),
+            sessions_offset: q.sessions_offset.unwrap_or(0),
+            is_remote,
+        })
+        .await?;
+    Ok(Json(ApiResponse::ok(resp)))
 }

--- a/crates/aionui-analytics/src/service.rs
+++ b/crates/aionui-analytics/src/service.rs
@@ -181,7 +181,10 @@ mod tests {
         // 今天发生的事件(此刻)不应被切掉; 昨天此刻应被切掉
         let now = Utc::now();
         assert!(now >= cut, "现在的事件应保留 (>= today cutoff)");
-        assert!(now - chrono::Duration::days(1) < cut, "昨天此刻应被切掉 (< today cutoff)");
+        assert!(
+            now - chrono::Duration::days(1) < cut,
+            "昨天此刻应被切掉 (< today cutoff)"
+        );
     }
 
     #[test]

--- a/crates/aionui-analytics/src/service.rs
+++ b/crates/aionui-analytics/src/service.rs
@@ -137,6 +137,17 @@ impl Default for AgentUsageService {
 }
 
 fn time_range_cutoff(tr: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    use chrono::{Local, TimeZone};
+    if tr == "today" {
+        // 本地自然日 00:00 起 (桌面应用: 服务与 UI 同机, 本地时区即用户视角的"今天")
+        let local_midnight = Local::now().date_naive().and_hms_opt(0, 0, 0)?;
+        return Some(
+            Local
+                .from_local_datetime(&local_midnight)
+                .single()?
+                .with_timezone(&chrono::Utc),
+        );
+    }
     let days = match tr {
         "7d" => 7,
         "90d" => 90,
@@ -152,4 +163,40 @@ fn sanitize_project(p: &str) -> String {
         .and_then(|s| s.to_str())
         .unwrap_or("unknown")
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::time_range_cutoff;
+    use chrono::{Local, TimeZone, Utc};
+
+    #[test]
+    fn today_cutoff_is_local_midnight() {
+        let cut = time_range_cutoff("today").expect("today must yield a cutoff");
+        // 本地当日 00:00 对应的 UTC 时刻
+        let local_midnight = Local::now().date_naive().and_hms_opt(0, 0, 0).unwrap();
+        let expected = Local.from_local_datetime(&local_midnight).unwrap().with_timezone(&Utc);
+        assert_eq!(cut, expected, "today cutoff 必须是本地当日 00:00 对应的 UTC 时刻");
+
+        // 今天发生的事件(此刻)不应被切掉; 昨天此刻应被切掉
+        let now = Utc::now();
+        assert!(now >= cut, "现在的事件应保留 (>= today cutoff)");
+        assert!(now - chrono::Duration::days(1) < cut, "昨天此刻应被切掉 (< today cutoff)");
+    }
+
+    #[test]
+    fn existing_ranges_unchanged() {
+        assert!(time_range_cutoff("all").is_none());
+        let now = Utc::now();
+        // 用秒级容差 (±5s) 而非 num_days() — 后者截断且对调用时刻的微秒漂移敏感会 flake
+        for (tr, days) in [("7d", 7i64), ("90d", 90), ("garbage", 30)] {
+            let cut = time_range_cutoff(tr).unwrap();
+            let expected_secs = chrono::Duration::days(days).num_seconds();
+            let actual_secs = (now - cut).num_seconds();
+            assert!(
+                (actual_secs - expected_secs).abs() <= 5,
+                "{tr}: cutoff 应为 now-{days}d (±5s), 实测差 {actual_secs}s"
+            );
+        }
+    }
 }

--- a/crates/aionui-analytics/src/service.rs
+++ b/crates/aionui-analytics/src/service.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 pub struct UsageRequest {
     pub trend_granularity: String,
+    pub trend_dimension: String,
     pub time_range: String,
     pub refresh: bool,
     pub sessions_limit: u32,
@@ -56,6 +57,7 @@ impl AgentUsageService {
             all,
             &req.trend_granularity,
             &req.time_range,
+            &req.trend_dimension,
             req.sessions_limit.clamp(1, 1000),
             req.sessions_offset,
         );

--- a/crates/aionui-analytics/src/service.rs
+++ b/crates/aionui-analytics/src/service.rs
@@ -1,1 +1,153 @@
-// Implemented in Task 1.8.
+use crate::aggregate::aggregate;
+use crate::cache::UsageCache;
+use crate::parser::{LogParser, claude::ClaudeParser, codex::CodexParser};
+use crate::types::{Agent, ParseError, ParsedSession};
+use aionui_api_types::{AgentUsageResponse, UsageSourceStatus};
+use aionui_common::AppError;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+pub struct UsageRequest {
+    pub trend_granularity: String,
+    pub time_range: String,
+    pub refresh: bool,
+    pub sessions_limit: u32,
+    pub sessions_offset: u32,
+    pub is_remote: bool,
+}
+
+#[derive(Clone)]
+pub struct AgentUsageService {
+    home: PathBuf,
+    cache: Arc<UsageCache>,
+}
+
+impl AgentUsageService {
+    pub fn new() -> Self {
+        Self::with_home(dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")))
+    }
+
+    pub fn with_home(home: PathBuf) -> Self {
+        Self {
+            home,
+            cache: Arc::new(UsageCache::new()),
+        }
+    }
+
+    pub async fn build(&self, req: UsageRequest) -> Result<AgentUsageResponse, AppError> {
+        let cutoff = time_range_cutoff(&req.time_range);
+
+        let (claude_sessions, claude_status) =
+            self.scan(Agent::Claude, &self.claude_dir(), &ClaudeParser, req.refresh, cutoff);
+        let (codex_sessions, codex_status) =
+            self.scan(Agent::Codex, &self.codex_dir(), &CodexParser, req.refresh, cutoff);
+
+        let mut all: Vec<ParsedSession> = Vec::new();
+        all.extend(claude_sessions);
+        all.extend(codex_sessions);
+
+        if req.is_remote {
+            for s in &mut all {
+                s.project = sanitize_project(&s.project);
+            }
+        }
+
+        let mut resp = aggregate(
+            all,
+            &req.trend_granularity,
+            &req.time_range,
+            req.sessions_limit.clamp(1, 1000),
+            req.sessions_offset,
+        );
+        resp.sources = vec![claude_status, codex_status];
+        Ok(resp)
+    }
+
+    fn claude_dir(&self) -> PathBuf {
+        self.home.join(".claude/projects")
+    }
+
+    fn codex_dir(&self) -> PathBuf {
+        self.home.join(".codex/sessions")
+    }
+
+    fn scan(
+        &self,
+        agent: Agent,
+        dir: &Path,
+        parser: &dyn LogParser,
+        refresh: bool,
+        cutoff: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> (Vec<ParsedSession>, UsageSourceStatus) {
+        let mut status = UsageSourceStatus {
+            agent: agent.as_str().to_string(),
+            files_total: 0,
+            files_parsed: 0,
+            files_skipped: 0,
+            available: std::fs::read_dir(dir).is_ok(),
+            error: None,
+        };
+        if std::fs::read_dir(dir).is_err() {
+            return (Vec::new(), status);
+        }
+        let mut out = Vec::new();
+        for entry in walkdir::WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
+            let path = entry.path();
+            if path.extension().and_then(|x| x.to_str()) != Some("jsonl") {
+                continue;
+            }
+            // 文件级 mtime 粗筛: cutoff 之前且 mtime 早于 cutoff 直接跳过。
+            if let Some(c) = cutoff
+                && let Ok(meta) = std::fs::metadata(path)
+                && let Ok(mt) = meta.modified()
+                && Into::<chrono::DateTime<chrono::Utc>>::into(mt) < c
+            {
+                continue;
+            }
+            status.files_total += 1;
+            match self.cache.get_or_parse(path, parser, refresh) {
+                Ok(session) => {
+                    let mut s = (*session).clone();
+                    // 事件级精筛。
+                    if let Some(c) = cutoff {
+                        s.events.retain(|e| e.at >= c);
+                        if s.events.is_empty() {
+                            status.files_parsed += 1;
+                            continue;
+                        }
+                        s.last_active_at = s.events.last().unwrap().at;
+                    }
+                    status.files_parsed += 1;
+                    out.push(s);
+                }
+                Err(ParseError::Empty) => status.files_skipped += 1,
+                Err(ParseError::Io(_)) => status.files_skipped += 1,
+            }
+        }
+        (out, status)
+    }
+}
+
+impl Default for AgentUsageService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn time_range_cutoff(tr: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    let days = match tr {
+        "7d" => 7,
+        "90d" => 90,
+        "all" => return None,
+        _ => 30, // 默认 30d
+    };
+    Some(chrono::Utc::now() - chrono::Duration::days(days))
+}
+
+fn sanitize_project(p: &str) -> String {
+    Path::new(p)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}

--- a/crates/aionui-analytics/src/service.rs
+++ b/crates/aionui-analytics/src/service.rs
@@ -1,0 +1,1 @@
+// Implemented in Task 1.8.

--- a/crates/aionui-analytics/src/types.rs
+++ b/crates/aionui-analytics/src/types.rs
@@ -1,0 +1,65 @@
+use serde::Serialize;
+
+/// Agent 标识。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Agent {
+    Claude,
+    Codex,
+}
+
+impl Agent {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Agent::Claude => "claude",
+            Agent::Codex => "codex",
+        }
+    }
+}
+
+/// 单个用量事件 (Claude 一条 assistant 消息 / Codex 一个 token_count 事件)。
+#[derive(Debug, Clone)]
+pub struct UsageEvent {
+    /// 事件 UTC 时间戳。
+    pub at: chrono::DateTime<chrono::Utc>,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+}
+
+impl UsageEvent {
+    pub fn total(&self) -> u64 {
+        self.input_tokens + self.output_tokens + self.cache_read_tokens + self.cache_creation_tokens
+    }
+}
+
+/// 解析一个日志文件得到的会话。
+#[derive(Debug, Clone)]
+pub struct ParsedSession {
+    pub agent: Agent,
+    pub session_id: String,
+    pub project: String,
+    /// 会话级主要 model (出现最多者; 缺失为 "unknown")。
+    pub model: String,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    pub last_active_at: chrono::DateTime<chrono::Utc>,
+    /// 该会话所有用量事件 (已按时间升序)。
+    pub events: Vec<UsageEvent>,
+    /// 消息计数 (Claude: assistant 消息数; Codex: assistant role 的 response_item 数)。
+    pub message_count: u64,
+}
+
+/// 解析失败原因 (用于上层计 skipped)。
+#[derive(Debug)]
+pub enum ParseError {
+    Io(std::io::Error),
+    /// 文件存在但无任何可识别内容。
+    Empty,
+}
+
+impl From<std::io::Error> for ParseError {
+    fn from(e: std::io::Error) -> Self {
+        ParseError::Io(e)
+    }
+}

--- a/crates/aionui-analytics/tests/aggregate.rs
+++ b/crates/aionui-analytics/tests/aggregate.rs
@@ -1,0 +1,51 @@
+use aionui_analytics::aggregate::aggregate;
+use aionui_analytics::types::{Agent, ParsedSession, UsageEvent};
+use chrono::{TimeZone, Utc};
+
+fn ev(day: u32, tok: u64) -> UsageEvent {
+    UsageEvent {
+        at: Utc.with_ymd_and_hms(2026, 5, day, 12, 0, 0).unwrap(),
+        input_tokens: tok,
+        output_tokens: 0,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+    }
+}
+
+fn session() -> ParsedSession {
+    ParsedSession {
+        agent: Agent::Codex,
+        session_id: "s1".into(),
+        project: "/work/p".into(),
+        model: "gpt-5.1-codex".into(),
+        started_at: Utc.with_ymd_and_hms(2026, 5, 16, 12, 0, 0).unwrap(),
+        last_active_at: Utc.with_ymd_and_hms(2026, 5, 17, 12, 0, 0).unwrap(),
+        events: vec![ev(16, 100), ev(17, 200)],
+        message_count: 2,
+    }
+}
+
+#[test]
+fn cross_day_session_split_into_daily_buckets() {
+    let resp = aggregate(vec![session()], "day", "all", 200, 0);
+
+    let codex = resp.summary.by_agent.iter().find(|a| a.agent == "codex").unwrap();
+    assert_eq!(codex.total_tokens, 300);
+
+    let mut sum = 0u64;
+    for p in &resp.trend.points {
+        sum += p.by_agent.get("codex").copied().unwrap_or(0);
+    }
+    assert_eq!(sum, 300, "趋势之和应等于汇总");
+    assert_eq!(resp.trend.points.len(), 2);
+
+    assert_eq!(resp.sessions_total, 1);
+    assert_eq!(resp.sessions.len(), 1);
+    assert_eq!(resp.sessions[0].total_tokens, 300);
+}
+
+#[test]
+fn time_range_filters_events_by_event_time() {
+    let resp = aggregate(vec![session()], "day", "all", 200, 0);
+    assert_eq!(resp.trend.points[0].bucket, "2026-05-16");
+}

--- a/crates/aionui-analytics/tests/aggregate.rs
+++ b/crates/aionui-analytics/tests/aggregate.rs
@@ -27,14 +27,14 @@ fn session() -> ParsedSession {
 
 #[test]
 fn cross_day_session_split_into_daily_buckets() {
-    let resp = aggregate(vec![session()], "day", "all", 200, 0);
+    let resp = aggregate(vec![session()], "day", "all", "agent", 200, 0);
 
     let codex = resp.summary.by_agent.iter().find(|a| a.agent == "codex").unwrap();
     assert_eq!(codex.total_tokens, 300);
 
     let mut sum = 0u64;
     for p in &resp.trend.points {
-        sum += p.by_agent.get("codex").copied().unwrap_or(0);
+        sum += p.by_segment.get("codex").copied().unwrap_or(0);
     }
     assert_eq!(sum, 300, "趋势之和应等于汇总");
     assert_eq!(resp.trend.points.len(), 2);
@@ -46,6 +46,128 @@ fn cross_day_session_split_into_daily_buckets() {
 
 #[test]
 fn time_range_filters_events_by_event_time() {
-    let resp = aggregate(vec![session()], "day", "all", 200, 0);
+    let resp = aggregate(vec![session()], "day", "all", "agent", 200, 0);
     assert_eq!(resp.trend.points[0].bucket, "2026-05-16");
+}
+
+#[test]
+fn trend_splits_by_project_dimension() {
+    // 两个 session，不同 project，同一天事件
+    let s1 = ParsedSession {
+        agent: Agent::Claude,
+        session_id: "p1".into(),
+        project: "/work/a".into(),
+        model: "claude-opus-4-7".into(),
+        started_at: Utc.with_ymd_and_hms(2026, 5, 20, 10, 0, 0).unwrap(),
+        last_active_at: Utc.with_ymd_and_hms(2026, 5, 20, 11, 0, 0).unwrap(),
+        events: vec![UsageEvent {
+            at: Utc.with_ymd_and_hms(2026, 5, 20, 10, 0, 0).unwrap(),
+            input_tokens: 150,
+            output_tokens: 50,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+        }],
+        message_count: 1,
+    };
+    let s2 = ParsedSession {
+        agent: Agent::Claude,
+        session_id: "p2".into(),
+        project: "/work/b".into(),
+        model: "claude-opus-4-7".into(),
+        started_at: Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap(),
+        last_active_at: Utc.with_ymd_and_hms(2026, 5, 20, 13, 0, 0).unwrap(),
+        events: vec![UsageEvent {
+            at: Utc.with_ymd_and_hms(2026, 5, 20, 12, 0, 0).unwrap(),
+            input_tokens: 300,
+            output_tokens: 100,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+        }],
+        message_count: 1,
+    };
+
+    let resp = aggregate(vec![s1, s2], "day", "all", "project", 200, 0);
+
+    assert_eq!(resp.trend.points.len(), 1, "同一天应只有一个 bucket");
+    let point = &resp.trend.points[0];
+    assert_eq!(point.bucket, "2026-05-20");
+
+    // /work/a: 150+50=200, /work/b: 300+100=400
+    assert_eq!(
+        point.by_segment.get("/work/a").copied().unwrap_or(0),
+        200,
+        "/work/a token 应为 200"
+    );
+    assert_eq!(
+        point.by_segment.get("/work/b").copied().unwrap_or(0),
+        400,
+        "/work/b token 应为 400"
+    );
+    assert_eq!(point.by_segment.len(), 2, "应有两个 project 分段");
+
+    // 分段之和等于 summary total
+    let summary_total: u64 = resp.summary.by_agent.iter().map(|a| a.total_tokens).sum();
+    let trend_total: u64 = point.by_segment.values().sum();
+    assert_eq!(trend_total, summary_total, "趋势分段之和应等于 summary total");
+}
+
+#[test]
+fn trend_splits_by_model_dimension() {
+    // 两个 session，不同 model，同一天事件
+    let s1 = ParsedSession {
+        agent: Agent::Claude,
+        session_id: "m1".into(),
+        project: "/work/shared".into(),
+        model: "claude-opus-4-7".into(),
+        started_at: Utc.with_ymd_and_hms(2026, 5, 21, 8, 0, 0).unwrap(),
+        last_active_at: Utc.with_ymd_and_hms(2026, 5, 21, 9, 0, 0).unwrap(),
+        events: vec![UsageEvent {
+            at: Utc.with_ymd_and_hms(2026, 5, 21, 8, 0, 0).unwrap(),
+            input_tokens: 500,
+            output_tokens: 100,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+        }],
+        message_count: 1,
+    };
+    let s2 = ParsedSession {
+        agent: Agent::Claude,
+        session_id: "m2".into(),
+        project: "/work/shared".into(),
+        model: "claude-sonnet-4-6".into(),
+        started_at: Utc.with_ymd_and_hms(2026, 5, 21, 10, 0, 0).unwrap(),
+        last_active_at: Utc.with_ymd_and_hms(2026, 5, 21, 11, 0, 0).unwrap(),
+        events: vec![UsageEvent {
+            at: Utc.with_ymd_and_hms(2026, 5, 21, 10, 0, 0).unwrap(),
+            input_tokens: 200,
+            output_tokens: 50,
+            cache_read_tokens: 10,
+            cache_creation_tokens: 0,
+        }],
+        message_count: 1,
+    };
+
+    let resp = aggregate(vec![s1, s2], "day", "all", "model", 200, 0);
+
+    assert_eq!(resp.trend.points.len(), 1, "同一天应只有一个 bucket");
+    let point = &resp.trend.points[0];
+    assert_eq!(point.bucket, "2026-05-21");
+
+    // claude-opus-4-7: 500+100=600, claude-sonnet-4-6: 200+50+10=260
+    assert_eq!(
+        point.by_segment.get("claude-opus-4-7").copied().unwrap_or(0),
+        600,
+        "claude-opus-4-7 token 应为 600"
+    );
+    assert_eq!(
+        point.by_segment.get("claude-sonnet-4-6").copied().unwrap_or(0),
+        260,
+        "claude-sonnet-4-6 token 应为 260"
+    );
+    assert_eq!(point.by_segment.len(), 2, "应有两个 model 分段");
+
+    // 分段之和等于 summary total
+    let summary_total: u64 = resp.summary.by_agent.iter().map(|a| a.total_tokens).sum();
+    let trend_total: u64 = point.by_segment.values().sum();
+    assert_eq!(trend_total, summary_total, "趋势分段之和应等于 summary total");
 }

--- a/crates/aionui-analytics/tests/aggregate.rs
+++ b/crates/aionui-analytics/tests/aggregate.rs
@@ -171,3 +171,44 @@ fn trend_splits_by_model_dimension() {
     let trend_total: u64 = point.by_segment.values().sum();
     assert_eq!(trend_total, summary_total, "趋势分段之和应等于 summary total");
 }
+
+#[test]
+fn week_granularity_uses_iso_week_bucket_keys() {
+    // 单会话两事件: 2026-05-16 (周六, ISO W20) 与 2026-05-18 (周一, ISO W21)
+    // → week 粒度下应落入两个不同的 "YYYY-Www" 桶。
+    let s = ParsedSession {
+        agent: Agent::Codex,
+        session_id: "w1".into(),
+        project: "/work/p".into(),
+        model: "gpt-5.1-codex".into(),
+        started_at: Utc.with_ymd_and_hms(2026, 5, 16, 12, 0, 0).unwrap(),
+        last_active_at: Utc.with_ymd_and_hms(2026, 5, 18, 12, 0, 0).unwrap(),
+        events: vec![ev(16, 100), ev(18, 200)],
+        message_count: 2,
+    };
+    let resp = aggregate(vec![s], "week", "all", "agent", 200, 0);
+
+    assert_eq!(resp.trend.granularity, "week");
+    // 每个桶 key 必须是 ISO 周格式 YYYY-Www
+    for p in &resp.trend.points {
+        assert!(
+            regex_like_iso_week(&p.bucket),
+            "bucket {:?} 不是 ISO 周格式 YYYY-Www",
+            p.bucket
+        );
+    }
+    // 跨两个 ISO 周 → 两个桶, 之和 = 300
+    assert_eq!(resp.trend.points.len(), 2, "跨 W20/W21 应有两个周桶");
+    let sum: u64 = resp.trend.points.iter().flat_map(|p| p.by_segment.values()).sum();
+    assert_eq!(sum, 300);
+}
+
+// 轻量校验 "YYYY-Www" (无需引入 regex crate)
+fn regex_like_iso_week(s: &str) -> bool {
+    let b = s.as_bytes();
+    s.len() == 8
+        && b[0..4].iter().all(u8::is_ascii_digit)
+        && b[4] == b'-'
+        && b[5] == b'W'
+        && b[6..8].iter().all(u8::is_ascii_digit)
+}

--- a/crates/aionui-analytics/tests/aggregate.rs
+++ b/crates/aionui-analytics/tests/aggregate.rs
@@ -212,3 +212,48 @@ fn regex_like_iso_week(s: &str) -> bool {
         && b[5] == b'W'
         && b[6..8].iter().all(u8::is_ascii_digit)
 }
+
+#[test]
+fn token_kind_breakdown_sums_match_segment_totals() {
+    use aionui_analytics::types::UsageEvent;
+    let mut s = session(); // 默认 Codex, project "/work/p"
+    s.events = vec![UsageEvent {
+        at: Utc.with_ymd_and_hms(2026, 5, 16, 12, 0, 0).unwrap(),
+        input_tokens: 10,
+        output_tokens: 20,
+        cache_read_tokens: 30,
+        cache_creation_tokens: 40,
+    }];
+    let resp = aggregate(vec![s], "day", "all", "agent", 200, 0);
+    let p = &resp.trend.points[0];
+    assert_eq!(p.by_token_kind.input, 10);
+    assert_eq!(p.by_token_kind.output, 20);
+    assert_eq!(p.by_token_kind.cache_read, 30);
+    assert_eq!(p.by_token_kind.cache_creation, 40);
+    let kind_sum =
+        p.by_token_kind.input + p.by_token_kind.output + p.by_token_kind.cache_read + p.by_token_kind.cache_creation;
+    let seg_sum: u64 = p.by_segment.values().sum();
+    assert_eq!(kind_sum, seg_sum, "by_token_kind 四项和必须等于 by_segment 总和");
+}
+
+#[test]
+fn by_project_aggregates_per_project() {
+    let mut s1 = session();
+    s1.project = "/work/alpha".into();
+    s1.events = vec![ev(16, 100)];
+    let mut s2 = session();
+    s2.project = "/work/beta".into();
+    s2.events = vec![ev(16, 250)];
+    let resp = aggregate(vec![s1, s2], "day", "all", "agent", 200, 0);
+    let mut got: std::collections::BTreeMap<String, u64> = Default::default();
+    for bp in &resp.by_project {
+        got.insert(bp.project.clone(), bp.total_tokens);
+    }
+    assert_eq!(got.get("/work/alpha").copied(), Some(100));
+    assert_eq!(got.get("/work/beta").copied(), Some(250));
+    let proj_total: u64 = resp.by_project.iter().map(|p| p.total_tokens).sum();
+    let model_total: u64 = resp.by_model.iter().map(|m| m.total_tokens).sum();
+    let agent_total: u64 = resp.summary.by_agent.iter().map(|a| a.total_tokens).sum();
+    assert_eq!(proj_total, model_total);
+    assert_eq!(model_total, agent_total);
+}

--- a/crates/aionui-analytics/tests/cache.rs
+++ b/crates/aionui-analytics/tests/cache.rs
@@ -1,0 +1,91 @@
+//! UsageCache unit tests — verifies the mtime+size cache-hit / bypass logic
+//! (cache.rs get_or_parse), which the service tests only exercise indirectly.
+
+use aionui_analytics::cache::UsageCache;
+use aionui_analytics::parser::LogParser;
+use aionui_analytics::types::{Agent, ParseError, ParsedSession};
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Parser stub that counts how many times parse_file actually ran.
+struct CountingParser {
+    calls: AtomicUsize,
+}
+
+impl LogParser for CountingParser {
+    fn parse_file(&self, _path: &Path) -> Result<ParsedSession, ParseError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(ParsedSession {
+            agent: Agent::Claude,
+            session_id: "s".into(),
+            project: "/p".into(),
+            model: "m".into(),
+            started_at: chrono::Utc::now(),
+            last_active_at: chrono::Utc::now(),
+            events: vec![],
+            message_count: 0,
+        })
+    }
+}
+
+#[test]
+fn second_call_hits_cache_without_reparsing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let f = tmp.path().join("a.jsonl");
+    std::fs::write(&f, "x").unwrap();
+    let cache = UsageCache::new();
+    let parser = CountingParser {
+        calls: AtomicUsize::new(0),
+    };
+
+    cache.get_or_parse(&f, &parser, false).unwrap();
+    assert_eq!(parser.calls.load(Ordering::SeqCst), 1, "首次必须解析");
+
+    // Same file, unchanged mtime+size → cache hit, parser NOT called again.
+    cache.get_or_parse(&f, &parser, false).unwrap();
+    assert_eq!(parser.calls.load(Ordering::SeqCst), 1, "命中缓存不应重新解析");
+}
+
+#[test]
+fn bypass_forces_reparse_even_when_cached() {
+    let tmp = tempfile::tempdir().unwrap();
+    let f = tmp.path().join("b.jsonl");
+    std::fs::write(&f, "x").unwrap();
+    let cache = UsageCache::new();
+    let parser = CountingParser {
+        calls: AtomicUsize::new(0),
+    };
+
+    cache.get_or_parse(&f, &parser, false).unwrap();
+    // bypass=true → ignore cache, reparse, but still write back.
+    cache.get_or_parse(&f, &parser, true).unwrap();
+    assert_eq!(parser.calls.load(Ordering::SeqCst), 2, "bypass 必须强制重新解析");
+}
+
+#[test]
+fn changed_file_invalidates_cache() {
+    let tmp = tempfile::tempdir().unwrap();
+    let f = tmp.path().join("c.jsonl");
+    std::fs::write(&f, "x").unwrap();
+    let cache = UsageCache::new();
+    let parser = CountingParser {
+        calls: AtomicUsize::new(0),
+    };
+
+    cache.get_or_parse(&f, &parser, false).unwrap();
+    // Change size (and mtime) → cache entry stale → reparse.
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    std::fs::write(&f, "xxxxxx").unwrap();
+    cache.get_or_parse(&f, &parser, false).unwrap();
+    assert_eq!(parser.calls.load(Ordering::SeqCst), 2, "文件变化应使缓存失效并重新解析");
+}
+
+#[test]
+fn missing_file_returns_io_error() {
+    let cache = UsageCache::new();
+    let parser = CountingParser {
+        calls: AtomicUsize::new(0),
+    };
+    let r = cache.get_or_parse(Path::new("/no/such/file.jsonl"), &parser, false);
+    assert!(matches!(r, Err(ParseError::Io(_))), "不存在的文件应返回 Io 错误");
+}

--- a/crates/aionui-analytics/tests/claude_parser.rs
+++ b/crates/aionui-analytics/tests/claude_parser.rs
@@ -1,0 +1,19 @@
+use aionui_analytics::parser::{LogParser, claude::ClaudeParser};
+use aionui_analytics::types::Agent;
+
+#[test]
+fn parses_claude_session_with_usage_accumulation() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/claude_sample.jsonl");
+    let session = ClaudeParser.parse_file(&path).expect("should parse");
+
+    assert_eq!(session.agent, Agent::Claude);
+    assert_eq!(session.session_id, "sess-claude-1");
+    assert_eq!(session.project, "/work/proj-a");
+    assert_eq!(session.model, "claude-opus-4-7");
+    assert_eq!(session.events.len(), 2);
+    assert_eq!(session.message_count, 2);
+    let total: u64 = session.events.iter().map(|e| e.total()).sum();
+    assert_eq!(total, 665);
+    assert!(session.events[0].at < session.events[1].at);
+    assert_eq!(session.started_at.to_rfc3339(), "2026-05-16T10:00:05+00:00");
+}

--- a/crates/aionui-analytics/tests/codex_parser.rs
+++ b/crates/aionui-analytics/tests/codex_parser.rs
@@ -1,0 +1,42 @@
+use aionui_analytics::parser::{LogParser, codex::CodexParser};
+use aionui_analytics::types::Agent;
+
+#[test]
+fn parses_codex_session_event_level() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/codex_sample.jsonl");
+    let session = CodexParser.parse_file(&path).expect("should parse");
+
+    assert_eq!(session.agent, Agent::Codex);
+    assert_eq!(session.session_id, "sess-codex-1");
+    assert_eq!(session.project, "/work/proj-b");
+    assert_eq!(session.model, "gpt-5.1-codex");
+    assert_eq!(session.events.len(), 2);
+    assert_eq!(session.message_count, 2);
+    assert_eq!(session.events[0].input_tokens, 1000);
+    assert_eq!(session.events[0].cache_read_tokens, 200);
+    assert_eq!(session.events[1].input_tokens, 500);
+    assert!(session.events[0].at < session.events[1].at);
+}
+
+#[test]
+fn codex_fallback_when_no_event_level_usage() {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let path = dir.join("codex_fallback.jsonl");
+    let session = CodexParser.parse_file(&path).expect("must fallback, not Empty");
+    assert_eq!(session.agent, Agent::Codex);
+    assert_eq!(session.events.len(), 1);
+    let e = &session.events[0];
+    assert_eq!(e.input_tokens, 700);
+    assert_eq!(e.output_tokens, 40);
+    assert_eq!(e.at, session.started_at);
+}
+
+#[test]
+fn codex_truncated_log_without_session_meta_is_dropped() {
+    // 文档化已知取舍 (review Important): 损坏/截断的 Codex 日志若缺 session_meta,
+    // started_at 无从得知, 即便有 total_token_usage 也会被丢弃 (ParseError::Empty)。
+    // 这是有意取舍 (损坏日志罕见); 此测试锁定该行为, 防止未来无意改变语义。
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/codex_no_meta.jsonl");
+    let result = CodexParser.parse_file(&path);
+    assert!(result.is_err(), "无 session_meta 的截断日志当前被丢弃 (已知取舍)");
+}

--- a/crates/aionui-analytics/tests/fixtures/claude_sample.jsonl
+++ b/crates/aionui-analytics/tests/fixtures/claude_sample.jsonl
@@ -1,0 +1,4 @@
+{"type":"user","timestamp":"2026-05-16T10:00:00.000Z","cwd":"/work/proj-a","sessionId":"sess-claude-1","message":{"role":"user","content":"hi"}}
+{"type":"assistant","timestamp":"2026-05-16T10:00:05.000Z","cwd":"/work/proj-a","sessionId":"sess-claude-1","message":{"model":"claude-opus-4-7","role":"assistant","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":200,"cache_read_input_tokens":0}}}
+{"type":"assistant","timestamp":"2026-05-17T09:00:00.000Z","cwd":"/work/proj-a","sessionId":"sess-claude-1","message":{"model":"claude-opus-4-7","role":"assistant","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":300}}}
+{"type":"assistant","timestamp":"bad-line-no-usage","message":{"role":"assistant"}}

--- a/crates/aionui-analytics/tests/fixtures/codex_fallback.jsonl
+++ b/crates/aionui-analytics/tests/fixtures/codex_fallback.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-05-10T08:00:00.000Z","type":"session_meta","payload":{"id":"sess-fb","timestamp":"2026-05-10T08:00:00.000Z","cwd":"/work/fb","cli_version":"0.111.0","model_provider":"crs"}}
+{"timestamp":"2026-05-10T08:00:05.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":700,"cached_input_tokens":0,"output_tokens":40,"reasoning_output_tokens":0,"total_tokens":740}}}}

--- a/crates/aionui-analytics/tests/fixtures/codex_no_meta.jsonl
+++ b/crates/aionui-analytics/tests/fixtures/codex_no_meta.jsonl
@@ -1,0 +1,1 @@
+{"timestamp":"2026-05-11T08:00:00.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":500,"cached_input_tokens":0,"output_tokens":30,"reasoning_output_tokens":0,"total_tokens":530}}}}

--- a/crates/aionui-analytics/tests/fixtures/codex_sample.jsonl
+++ b/crates/aionui-analytics/tests/fixtures/codex_sample.jsonl
@@ -1,0 +1,6 @@
+{"timestamp":"2026-05-16T08:00:00.000Z","type":"session_meta","payload":{"id":"sess-codex-1","timestamp":"2026-05-16T08:00:00.000Z","cwd":"/work/proj-b","cli_version":"0.111.0","model_provider":"crs"}}
+{"timestamp":"2026-05-16T08:00:10.000Z","type":"turn_context","payload":{"model":"gpt-5.1-codex"}}
+{"timestamp":"2026-05-16T08:00:20.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"ok"}}
+{"timestamp":"2026-05-16T08:00:21.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":200,"output_tokens":50,"reasoning_output_tokens":10,"total_tokens":1060},"last_token_usage":{"input_tokens":1000,"cached_input_tokens":200,"output_tokens":50,"reasoning_output_tokens":10,"total_tokens":1060},"model_context_window":258400}}}
+{"timestamp":"2026-05-17T09:00:00.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"more"}}
+{"timestamp":"2026-05-17T09:00:01.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1500,"cached_input_tokens":400,"output_tokens":80,"reasoning_output_tokens":20,"total_tokens":1580},"last_token_usage":{"input_tokens":500,"cached_input_tokens":200,"output_tokens":30,"reasoning_output_tokens":10,"total_tokens":520},"model_context_window":258400}}}

--- a/crates/aionui-analytics/tests/service.rs
+++ b/crates/aionui-analytics/tests/service.rs
@@ -7,6 +7,7 @@ async fn missing_dirs_degrade_not_error() {
     let resp = svc
         .build(UsageRequest {
             trend_granularity: "day".into(),
+            trend_dimension: "agent".into(),
             time_range: "all".into(),
             refresh: false,
             sessions_limit: 200,
@@ -36,6 +37,7 @@ async fn remote_request_sanitizes_project_path() {
     let resp = svc
         .build(UsageRequest {
             trend_granularity: "day".into(),
+            trend_dimension: "agent".into(),
             time_range: "all".into(),
             refresh: false,
             sessions_limit: 200,
@@ -72,6 +74,7 @@ async fn remote_sanitizes_both_claude_and_codex_projects() {
     let resp = svc
         .build(UsageRequest {
             trend_granularity: "day".into(),
+            trend_dimension: "agent".into(),
             time_range: "all".into(),
             refresh: false,
             sessions_limit: 200,

--- a/crates/aionui-analytics/tests/service.rs
+++ b/crates/aionui-analytics/tests/service.rs
@@ -93,3 +93,68 @@ async fn remote_sanitizes_both_claude_and_codex_projects() {
     assert!(projects.contains(&"claude-proj"));
     assert!(projects.contains(&"codex-proj"));
 }
+
+#[tokio::test]
+async fn handler_returns_apiresponse_envelope() {
+    use aionui_analytics::routes::{AnalyticsRouterState, analytics_routes};
+    use aionui_analytics::service::AgentUsageService;
+    use tower::ServiceExt;
+    let tmp = tempfile::tempdir().unwrap();
+    let app = analytics_routes(AnalyticsRouterState {
+        service: AgentUsageService::with_home(tmp.path().join("nohome")),
+    });
+    let res = app
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/api/analytics/agent-usage?time_range=all")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let bytes = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(v["success"], true);
+    assert!(v["data"]["sources"].is_array());
+}
+
+#[tokio::test]
+async fn webui_remote_header_triggers_project_sanitize() {
+    use aionui_analytics::routes::{AnalyticsRouterState, WEBUI_REMOTE_HEADER, analytics_routes};
+    use aionui_analytics::service::AgentUsageService;
+    use tower::ServiceExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let cdir = home.join(".claude/projects/encoded");
+    std::fs::create_dir_all(&cdir).unwrap();
+    std::fs::write(
+        cdir.join("s.jsonl"),
+        r#"{"type":"assistant","timestamp":"2026-05-17T10:00:00.000Z","cwd":"/Users/secret/proj","sessionId":"s1","message":{"model":"claude-opus-4-7","role":"assistant","usage":{"input_tokens":1,"output_tokens":1,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}"#,
+    )
+    .unwrap();
+
+    let mk = || {
+        analytics_routes(AnalyticsRouterState {
+            service: AgentUsageService::with_home(home.to_path_buf()),
+        })
+    };
+    let get = |with_header: bool| {
+        let mut b = axum::http::Request::builder().uri("/api/analytics/agent-usage?time_range=all");
+        if with_header {
+            b = b.header(WEBUI_REMOTE_HEADER, "1");
+        }
+        b.body(axum::body::Body::empty()).unwrap()
+    };
+
+    let res = mk().oneshot(get(false)).await.unwrap();
+    let bytes = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(v["data"]["sessions"][0]["project"], "/Users/secret/proj");
+
+    let res = mk().oneshot(get(true)).await.unwrap();
+    let bytes = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(v["data"]["sessions"][0]["project"], "proj");
+}

--- a/crates/aionui-analytics/tests/service.rs
+++ b/crates/aionui-analytics/tests/service.rs
@@ -1,0 +1,95 @@
+use aionui_analytics::service::{AgentUsageService, UsageRequest};
+
+#[tokio::test]
+async fn missing_dirs_degrade_not_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let svc = AgentUsageService::with_home(tmp.path().join("nohome"));
+    let resp = svc
+        .build(UsageRequest {
+            trend_granularity: "day".into(),
+            time_range: "all".into(),
+            refresh: false,
+            sessions_limit: 200,
+            sessions_offset: 0,
+            is_remote: false,
+        })
+        .await
+        .expect("must not error");
+    assert_eq!(resp.sources.len(), 2);
+    assert!(resp.sources.iter().all(|s| !s.available));
+    assert_eq!(resp.sessions_total, 0);
+}
+
+#[tokio::test]
+async fn remote_request_sanitizes_project_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let cdir = home.join(".claude/projects/encoded");
+    std::fs::create_dir_all(&cdir).unwrap();
+    std::fs::write(
+        cdir.join("sess.jsonl"),
+        r#"{"type":"assistant","timestamp":"2026-05-17T10:00:00.000Z","cwd":"/Users/secret/proj","sessionId":"s1","message":{"model":"claude-opus-4-7","role":"assistant","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}"#,
+    )
+    .unwrap();
+
+    let svc = AgentUsageService::with_home(home.to_path_buf());
+    let resp = svc
+        .build(UsageRequest {
+            trend_granularity: "day".into(),
+            time_range: "all".into(),
+            refresh: false,
+            sessions_limit: 200,
+            sessions_offset: 0,
+            is_remote: true,
+        })
+        .await
+        .unwrap();
+    assert_eq!(resp.sessions.len(), 1);
+    assert_eq!(resp.sessions[0].project, "proj");
+    assert!(!resp.sessions[0].project.contains("secret"));
+}
+
+#[tokio::test]
+async fn remote_sanitizes_both_claude_and_codex_projects() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+
+    let cdir = home.join(".claude/projects/encoded");
+    std::fs::create_dir_all(&cdir).unwrap();
+    std::fs::write(
+        cdir.join("claude.jsonl"),
+        r#"{"type":"assistant","timestamp":"2026-05-17T10:00:00.000Z","cwd":"/Users/secret/claude-proj","sessionId":"c1","message":{"model":"claude-opus-4-7","role":"assistant","usage":{"input_tokens":1,"output_tokens":1,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}"#,
+    ).unwrap();
+
+    let ddir = home.join(".codex/sessions");
+    std::fs::create_dir_all(&ddir).unwrap();
+    std::fs::write(
+        ddir.join("codex.jsonl"),
+        "{\"timestamp\":\"2026-05-17T08:00:00.000Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"d1\",\"timestamp\":\"2026-05-17T08:00:00.000Z\",\"cwd\":\"/Users/secret/codex-proj\",\"cli_version\":\"0.1\",\"model_provider\":\"crs\"}}\n{\"timestamp\":\"2026-05-17T08:01:00.000Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":10,\"cached_input_tokens\":0,\"output_tokens\":5,\"reasoning_output_tokens\":0,\"total_tokens\":15},\"last_token_usage\":{\"input_tokens\":10,\"cached_input_tokens\":0,\"output_tokens\":5,\"reasoning_output_tokens\":0,\"total_tokens\":15}}}}",
+    ).unwrap();
+
+    let svc = AgentUsageService::with_home(home.to_path_buf());
+    let resp = svc
+        .build(UsageRequest {
+            trend_granularity: "day".into(),
+            time_range: "all".into(),
+            refresh: false,
+            sessions_limit: 200,
+            sessions_offset: 0,
+            is_remote: true,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(resp.sessions.len(), 2);
+    for s in &resp.sessions {
+        assert!(
+            !s.project.contains("secret"),
+            "project {:?} still contains 'secret'",
+            s.project
+        );
+    }
+    let projects: Vec<&str> = resp.sessions.iter().map(|s| s.project.as_str()).collect();
+    assert!(projects.contains(&"claude-proj"));
+    assert!(projects.contains(&"codex-proj"));
+}

--- a/crates/aionui-api-types/src/analytics.rs
+++ b/crates/aionui-api-types/src/analytics.rs
@@ -1,0 +1,89 @@
+use serde::{Deserialize, Serialize};
+
+/// Query for `GET /api/analytics/agent-usage`.
+#[derive(Debug, Default, Deserialize)]
+pub struct AgentUsageQuery {
+    pub trend_granularity: Option<String>,
+    pub refresh: Option<bool>,
+    pub time_range: Option<String>,
+    pub sessions_limit: Option<u32>,
+    pub sessions_offset: Option<u32>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UsageSourceStatus {
+    pub agent: String,
+    pub files_total: u32,
+    pub files_parsed: u32,
+    pub files_skipped: u32,
+    pub available: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UsageByAgent {
+    pub agent: String,
+    pub sessions: u64,
+    pub messages: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub total_tokens: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UsageSummary {
+    pub by_agent: Vec<UsageByAgent>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UsageByModel {
+    pub agent: String,
+    pub model: String,
+    pub sessions: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub total_tokens: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TrendPoint {
+    pub bucket: String,
+    /// agent 名 → 该桶 total_tokens。
+    pub by_agent: std::collections::BTreeMap<String, u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UsageTrend {
+    pub granularity: String,
+    pub points: Vec<TrendPoint>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SessionRow {
+    pub agent: String,
+    pub session_id: String,
+    pub project: String,
+    pub model: String,
+    pub started_at: String,
+    pub last_active_at: String,
+    pub messages: u64,
+    pub total_tokens: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AgentUsageResponse {
+    pub scanned_at: String,
+    pub sources: Vec<UsageSourceStatus>,
+    pub summary: UsageSummary,
+    pub by_model: Vec<UsageByModel>,
+    pub trend: UsageTrend,
+    pub time_range: String,
+    pub sessions_total: u64,
+    pub sessions_limit: u32,
+    pub sessions_offset: u32,
+    pub sessions: Vec<SessionRow>,
+}

--- a/crates/aionui-api-types/src/analytics.rs
+++ b/crates/aionui-api-types/src/analytics.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Default, Deserialize)]
 pub struct AgentUsageQuery {
     pub trend_granularity: Option<String>,
+    /// 趋势维度：agent | project | model，默认 agent。
+    pub trend_dimension: Option<String>,
     pub refresh: Option<bool>,
     pub time_range: Option<String>,
     pub sessions_limit: Option<u32>,
@@ -52,8 +54,8 @@ pub struct UsageByModel {
 #[derive(Debug, Serialize)]
 pub struct TrendPoint {
     pub bucket: String,
-    /// agent 名 → 该桶 total_tokens。
-    pub by_agent: std::collections::BTreeMap<String, u64>,
+    /// 分段名 (agent/project/model) → 该桶 total_tokens。
+    pub by_segment: std::collections::BTreeMap<String, u64>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/aionui-api-types/src/analytics.rs
+++ b/crates/aionui-api-types/src/analytics.rs
@@ -52,10 +52,32 @@ pub struct UsageByModel {
 }
 
 #[derive(Debug, Serialize)]
+pub struct UsageByProject {
+    pub agent: String,
+    pub project: String,
+    pub sessions: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub total_tokens: u64,
+}
+
+#[derive(Debug, Serialize, Default)]
+pub struct TokenKindBreakdown {
+    pub input: u64,
+    pub output: u64,
+    pub cache_read: u64,
+    pub cache_creation: u64,
+}
+
+#[derive(Debug, Serialize)]
 pub struct TrendPoint {
     pub bucket: String,
     /// 分段名 (agent/project/model) → 该桶 total_tokens。
     pub by_segment: std::collections::BTreeMap<String, u64>,
+    /// 该桶按 token 类型的分层 (四项之和 == by_segment 所有值之和)。
+    pub by_token_kind: TokenKindBreakdown,
 }
 
 #[derive(Debug, Serialize)]
@@ -82,6 +104,7 @@ pub struct AgentUsageResponse {
     pub sources: Vec<UsageSourceStatus>,
     pub summary: UsageSummary,
     pub by_model: Vec<UsageByModel>,
+    pub by_project: Vec<UsageByProject>,
     pub trend: UsageTrend,
     pub time_range: String,
     pub sessions_total: u64,

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -40,8 +40,8 @@ pub use agent_build_extra::{
 };
 pub use agent_discovery::{AgentEnvEntry, AgentHandshake, AgentMetadata, AgentSource, AgentSourceInfo, BehaviorPolicy};
 pub use analytics::{
-    AgentUsageQuery, AgentUsageResponse, SessionRow, TrendPoint, UsageByAgent, UsageByModel, UsageSourceStatus,
-    UsageSummary, UsageTrend,
+    AgentUsageQuery, AgentUsageResponse, SessionRow, TokenKindBreakdown, TrendPoint, UsageByAgent, UsageByModel,
+    UsageByProject, UsageSourceStatus, UsageSummary, UsageTrend,
 };
 pub use assistant::{
     AssistantResponse, AssistantSource, CreateAssistantRequest, ImportAssistantsRequest, ImportAssistantsResult,

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -3,6 +3,7 @@ mod acp;
 mod acp_prompt_hook;
 mod agent_build_extra;
 mod agent_discovery;
+mod analytics;
 mod assistant;
 mod auth;
 mod channel;
@@ -38,6 +39,10 @@ pub use agent_build_extra::{
     SlashCommandItem,
 };
 pub use agent_discovery::{AgentEnvEntry, AgentHandshake, AgentMetadata, AgentSource, AgentSourceInfo, BehaviorPolicy};
+pub use analytics::{
+    AgentUsageQuery, AgentUsageResponse, SessionRow, TrendPoint, UsageByAgent, UsageByModel, UsageSourceStatus,
+    UsageSummary, UsageTrend,
+};
 pub use assistant::{
     AssistantResponse, AssistantSource, CreateAssistantRequest, ImportAssistantsRequest, ImportAssistantsResult,
     ImportError, SetAssistantStateRequest, UpdateAssistantRequest,

--- a/crates/aionui-app/Cargo.toml
+++ b/crates/aionui-app/Cargo.toml
@@ -33,6 +33,7 @@ aionui-channel.workspace = true
 aionui-team.workspace = true
 aionui-cron.workspace = true
 aionui-assistant.workspace = true
+aionui-analytics.workspace = true
 aionui-runtime.workspace = true
 aion-config.workspace = true
 axum.workspace = true

--- a/crates/aionui-app/src/router/routes.rs
+++ b/crates/aionui-app/src/router/routes.rs
@@ -10,6 +10,7 @@ use axum::{Router, middleware};
 use tower_http::cors::{Any, CorsLayer};
 
 use aionui_ai_agent::{agent_routes, remote_agent_routes};
+use aionui_analytics::analytics_routes;
 use aionui_assets::{AssetRouterState, asset_routes};
 use aionui_assistant::assistant_routes;
 use aionui_auth::{
@@ -177,6 +178,10 @@ pub fn create_router_with_all_state(services: &AppServices, states: ModuleStates
     let assistant_authenticated =
         assistant_routes(states.assistant).route_layer(from_fn_with_state(auth_mw_state.clone(), auth_middleware));
 
+    // Analytics routes protected by auth middleware (webui-remote header triggers project sanitize)
+    let analytics_authenticated =
+        analytics_routes(states.analytics).route_layer(from_fn_with_state(auth_mw_state.clone(), auth_middleware));
+
     // Guide MCP diagnostic endpoint protected by auth middleware
     let guide_mcp_authenticated = Router::new()
         .route("/api/system/guide-mcp", get(guide_mcp_status))
@@ -211,6 +216,7 @@ pub fn create_router_with_all_state(services: &AppServices, states: ModuleStates
         .merge(office_authenticated)
         .merge(shell_authenticated)
         .merge(assistant_authenticated)
+        .merge(analytics_authenticated)
         .merge(guide_mcp_authenticated);
 
     // Conditionally merge WeChat login SSE route (feature-gated)

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use aionui_ai_agent::{AgentRouterState, AgentService, RemoteAgentRouterState, RemoteAgentService};
+use aionui_analytics::{AnalyticsRouterState, service::AgentUsageService};
 use aionui_assistant::{AssistantRouterState, AssistantService, BuiltinAssistantRegistry};
 use aionui_auth::extract_token_from_ws_headers;
 use aionui_channel::ChannelRouterState;
@@ -64,6 +65,7 @@ pub struct ModuleStates {
     pub office: OfficeRouterState,
     pub shell: ShellRouterState,
     pub assistant: AssistantRouterState,
+    pub analytics: AnalyticsRouterState,
 }
 
 fn default_allowed_roots(work_dir: Option<&std::path::Path>) -> Vec<std::path::PathBuf> {
@@ -155,6 +157,9 @@ pub async fn build_module_states(services: &AppServices) -> (ModuleStates, Chann
         office: build_office_state(services),
         shell: build_shell_state(services),
         assistant,
+        analytics: AnalyticsRouterState {
+            service: AgentUsageService::new(),
+        },
     };
 
     (states, channel_components)

--- a/crates/aionui-app/tests/analytics_auth.rs
+++ b/crates/aionui-app/tests/analytics_auth.rs
@@ -1,0 +1,68 @@
+//! App-level integration test proving that `GET /api/analytics/agent-usage`
+//! is protected by the auth middleware in the fully-composed application router.
+//!
+//! **Why this test exists (design.md §322)**
+//!
+//! The `aionui-analytics` crate's own unit tests use a naked `analytics_routes`
+//! router (no auth layer), so they cannot verify that auth protection is wired
+//! correctly.  This file is the **only automated proof** that the route is
+//! reachable only with a valid token, because it goes through the real
+//! `create_router` / `create_router_with_states` call that applies:
+//!
+//! ```text
+//! analytics_routes(states.analytics)
+//!     .route_layer(from_fn_with_state(auth_mw_state.clone(), auth_middleware))
+//! ```
+//!
+//! **Status-code convention**: `aionui_auth::middleware::auth_middleware` returns
+//! `403 Forbidden` for *any* authentication failure (missing token, bad token,
+//! expired token).  This matches `assistants_e2e.rs::list_requires_auth` and the
+//! assertion in `assistants_e2e.rs` comments.  design.md §322 also specifies 403.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+// ---------------------------------------------------------------------------
+// Test: unauthenticated GET returns 403
+// ---------------------------------------------------------------------------
+
+/// Sends `GET /api/analytics/agent-usage` with NO `Authorization` header to
+/// the fully-composed application router and asserts the auth middleware
+/// rejects it with `403 Forbidden`.
+///
+/// This exercises the exact composition path in `create_router_with_all_state`:
+/// ```text
+/// let analytics_authenticated =
+///     analytics_routes(states.analytics)
+///         .route_layer(from_fn_with_state(auth_mw_state.clone(), auth_middleware));
+/// // ...
+/// Router::new().merge(analytics_authenticated)
+/// ```
+#[tokio::test]
+async fn analytics_agent_usage_requires_auth() {
+    // Build the full composed app router (identical to `build_app` in common/mod.rs).
+    // `AppConfig::default()` sets `local = false`, so the auth middleware is
+    // active for all authenticated routes.
+    let (app, _services) = common::build_app().await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/api/analytics/agent-usage")
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+
+    // `auth_middleware` returns 403 Forbidden for any authentication failure
+    // (missing token, invalid token, expired token).
+    // See `aionui_auth::middleware::auth_middleware` and the analogous
+    // `list_requires_auth` test in `assistants_e2e.rs`.
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "unauthenticated request to /api/analytics/agent-usage must be rejected with 403 Forbidden"
+    );
+}


### PR DESCRIPTION
## 概述

新增 `aionui-analytics` crate 实现**本地 agent 使用统计**的后端聚合，配套 `aionui-api-types` 的 DTO 契约，支持 Claude Code / Codex 日志解析、按工具/项目/模型分维度聚合、时间窗过滤。

本 PR 包含从零搭建 crate 到 v2 可观测性增强的**完整工作**：

### v1（前 12 commit）
- 新增 `aionui-analytics` 整个 crate（日志解析、聚合纯函数、缓存、HTTP 路由）
- Claude / Codex 双 agent 日志解析器（TDD）
- 按日/周时间桶聚合，可切换 `agent` / `project` / `model` 维度
- mtime+size 文件级缓存
- 鉴权路由 + WebUI Remote 自动脱敏（project 路径取 basename）

### v2（最后 3 commit）
- **DTO 扩展**：`TrendPoint` 新增 `by_token_kind`（input/output/cache_read/cache_creation 四类分层），响应顶层新增 `by_project`
- **聚合扩展**：**同一事件循环**内额外累计 `by_project` + `trend_kind`，零额外遍历、零性能影响
- **不变量测试**：per-bucket `by_token_kind 四项之和 == by_segment 总和`、全局 `proj_total == model_total == agent_total`
- **`today` 时间窗**：`time_range_cutoff("today")` 用 `chrono::Local::now()` 取本地当日 00:00 作为 cutoff（桌面应用服务与 UI 同机，本地时区即用户视角的"今天"），加 2 个单测验证

## 关键设计

- **向后兼容**：所有新增字段都是响应新增项，旧前端忽略即可；前端 mapper 也带 `?? []` / `?? {0}` 守卫
- **不变量结构性正确**：`by_project` 用 `(agent, project)` 与现有 `by_model` 同 `(agent, model)` 镜像聚合，事件流相同 → 数学上 `sum(by_project) == sum(by_model) == sum(by_agent)` 由构造保证
- **远程脱敏继承**：`by_project` 用服务层已脱敏的 `s.project`（WebHost 注入 `x-aionui-webui-remote` header 时取 basename），无新增安全面

## 测试

- `aionui-analytics` lib tests：3 passed（含新增 `today_cutoff_is_local_midnight` / `existing_ranges_unchanged`）
- `aionui-analytics` integration tests：5 passed（含新增 `token_kind_breakdown_sums_match_segment_totals` / `by_project_aggregates_per_project` 两个不变量测试）
- `cargo clippy --workspace -- -D warnings`：✅
- `cargo fmt --all --check`：✅

## 配套前端 PR

前端使用统计页仪表盘重构（消费这些新字段）：iOfficeAI/AionUi 配套 PR（关联中提及）。

## 关联 issue / 设计文档

设计文档已合入前端 PR 的 `docs/prds/settings/agent_usage/`。

---

🤖 Generated with AionUi v2 dashboard work.