### PR TITLE
fix(conversation): force-complete stuck conversation on cancel

### DIFF
--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -1191,16 +1191,25 @@ impl ConversationService {
             .filter(|r| r.user_id == user_id)
             .ok_or_else(|| AppError::NotFound(format!("Conversation {conversation_id} not found")))?;
 
-        let agent = task_manager
-            .get_task(conversation_id)
-            .ok_or_else(|| AppError::Conflict("No active agent for this conversation".into()))?;
-
-        if let Err(e) = agent.cancel().await {
-            warn!(error = %ErrorChain(&e), "Failed to cancel agent");
-            return Err(e);
+        match task_manager.get_task(conversation_id) {
+            Some(agent) => {
+                if let Err(e) = agent.cancel().await {
+                    warn!(error = %ErrorChain(&e), "Failed to cancel agent");
+                    return Err(e);
+                }
+                info!("Stream canceled");
+            }
+            None => {
+                // No active agent — force-reset DB status if stuck at "running"
+                StreamRelay::complete_conversation(
+                    &self.conversation_repo,
+                    &self.broadcaster,
+                    conversation_id,
+                )
+                .await;
+                info!("No active agent; force-completed conversation status");
+            }
         }
-
-        info!("Stream canceled");
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Fixes ELECTRON-1FZ: when `cancel()` is called but no agent task exists in task_manager (e.g. after backend restart/crash), force-reset the conversation status to "finished" via `StreamRelay::complete_conversation` instead of returning 409 Conflict.

This prevents conversations from being permanently stuck in "running" status.

## Test plan

- [ ] Unit test: mock task_manager returning None, verify cancel succeeds and status becomes "finished"
- [ ] Integration: kill backend during streaming, restart, call cancel → verify 200 response and status reset
- [ ] Verify normal cancel flow (agent exists) still works unchanged

## Related

- Frontend companion PR: https://github.com/iOfficeAI/AionUi/pull/2962