### PR TITLE
fix(ai-agent): prevent stuck session after ACP cancel

### DIFF
--- a/crates/aionui-ai-agent/src/agent_runtime.rs
+++ b/crates/aionui-ai-agent/src/agent_runtime.rs
@@ -237,4 +237,34 @@ mod tests {
         let res = tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
         assert!(res.is_err());
     }
+
+    #[tokio::test]
+    async fn reset_for_new_turn_overrides_finished() {
+        let rt = runtime();
+        rt.emit_finish(None);
+        assert_eq!(rt.status(), Some(ConversationStatus::Finished));
+
+        rt.reset_for_new_turn(ConversationStatus::Running);
+        assert_eq!(rt.status(), Some(ConversationStatus::Running));
+    }
+
+    #[tokio::test]
+    async fn reset_for_new_turn_then_emit_finish_sends_event() {
+        let rt = runtime();
+        rt.emit_finish(None);
+        assert_eq!(rt.status(), Some(ConversationStatus::Finished));
+
+        rt.reset_for_new_turn(ConversationStatus::Running);
+        let mut rx = rt.subscribe();
+        rt.emit_finish(Some("sess-2".into()));
+        assert_eq!(rt.status(), Some(ConversationStatus::Finished));
+
+        let ev = rx.recv().await.expect("finish event after reset");
+        match ev {
+            AgentStreamEvent::Finish(data) => {
+                assert_eq!(data.session_id.as_deref(), Some("sess-2"));
+            }
+            other => panic!("expected Finish, got {other:?}"),
+        }
+    }
 }

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -9,7 +9,7 @@ use crate::manager::acp::{
 };
 use crate::protocol::acp::AcpProtocol;
 use crate::protocol::error::AcpError;
-use crate::protocol::events::AgentStreamEvent;
+use crate::protocol::events::{AgentStreamEvent, FinishEventData};
 use crate::registry::CatalogSender;
 use crate::shared_kernel::{ModeId, ModelId, SessionId as DomainSessionId};
 use crate::types::SendMessageData;
@@ -490,7 +490,7 @@ impl AcpAgentManager {
     /// `pending_model_notice`) and prepends the appropriate block when set.
     async fn ensure_session_and_send(&self, data: &SendMessageData) -> Result<(), AppError> {
         let sid = self.ensure_session_opened().await?;
-        self.runtime.transition_to(ConversationStatus::Running);
+        self.runtime.reset_for_new_turn(ConversationStatus::Running);
 
         let content = {
             let mut s = self.session.write().await;
@@ -585,15 +585,19 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
     async fn cancel(&self) -> Result<(), AppError> {
         info!("Cancelling ACP session");
         let session_id = self.session.read().await.session_id().map(ToOwned::to_owned);
-        if let Some(sid) = session_id {
-            self.protocol.cancel(CancelNotification::new(SessionId::new(sid)));
+        if let Some(sid) = &session_id {
+            self.protocol
+                .cancel(CancelNotification::new(SessionId::new(sid.as_str())));
         }
         self.permission_router.cancel_all();
 
-        // m1 fix: mark task as Finished on explicit stop, so external
-        // status() observers see a consistent terminal state. Idempotent —
-        // if send_message already emitted Finish, this is a no-op.
-        self.runtime.emit_finish(None);
+        // Force status to Finished and emit unconditionally, bypassing the
+        // absorbing-state guard. This ensures StreamRelay always receives
+        // its terminal event regardless of prior state.
+        self.runtime.reset_for_new_turn(ConversationStatus::Finished);
+        self.runtime
+            .emit(AgentStreamEvent::Finish(FinishEventData { session_id: None }));
+
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- Use `reset_for_new_turn(Running)` instead of `transition_to(Running)` in `ensure_session_and_send`, allowing a new turn to emit Finish even when the previous turn already reached the Finished absorbing state.
- Rewrite `cancel()` to unconditionally emit a Finish event via `reset_for_new_turn(Finished)` + raw `emit(Finish)`, bypassing the absorbing-state guard so StreamRelay always receives its terminal event regardless of prior state.
- Add unit tests verifying `reset_for_new_turn` correctly overrides the Finished absorbing state.

## Context

After a user clicks stop, the session could become stuck (unable to stop or send new messages, returning 409). Root cause: `transition_to(Running)` is a no-op when status is already `Finished`, so the subsequent `emit_finish` detects `already_finished=true` and skips broadcasting the Finish event. StreamRelay never receives the terminal event.

Sentry: SENTRY-121561142

## Test Plan

- [x] `cargo test -p aionui-ai-agent` — all tests pass (including 2 new unit tests)
- [x] `cargo clippy -p aionui-ai-agent -- -D warnings` — no warnings
- [x] `just push` — full workspace passes (5577 tests, 0 failures)
- [x] Manual verification: cancel mid-stream → send "继续" → response completes normally