### PR TITLE
feat(db): migration 007 — switch builtin ACP agents to npm exec

### DIFF
--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -613,7 +613,20 @@ mod tests {
     async fn find_builtin_claude_has_bridge_command() {
         let reg = registry().await;
         let m = reg.find_builtin_by_backend("claude").await.unwrap();
-        assert_eq!(m.command.as_deref(), Some("bun"));
+        // Migration 007 cutover: bun x is replaced by `npm exec --prefix=…`
+        // driven by the bundled node runtime. Placeholders are expanded at
+        // spawn time by `Builder::expand_placeholders`.
+        assert_eq!(m.command.as_deref(), Some("npm"));
+        assert!(
+            m.args.iter().any(|a| a == "exec"),
+            "claude args must use `npm exec`: {:?}",
+            m.args
+        );
+        assert!(
+            m.args.iter().any(|a| a == "--prefix=${AGENT_PREFIX}"),
+            "claude args must reference AGENT_PREFIX placeholder: {:?}",
+            m.args
+        );
         assert!(m.behavior_policy.supports_side_question);
         assert_eq!(
             m.native_skills_dirs.as_deref(),

--- a/crates/aionui-db/migrations/007_switch_builtin_agents_to_node.sql
+++ b/crates/aionui-db/migrations/007_switch_builtin_agents_to_node.sql
@@ -1,0 +1,42 @@
+-- Migration 007: Switch builtin ACP agents from `bun x --bun <pkg>` to
+-- `npm exec --prefix=<stable-dir>` driven by the bundled node runtime.
+--
+-- Root cause: `bun x` is not in-place — every spawn copies the cached
+-- package into a fresh tmp dir, which collides on Windows with file-read
+-- handles held by concurrent sends (Sentry ELECTRON-1FB). `npm exec` with
+-- a fixed --prefix populates `node_modules/` once and reuses it on
+-- subsequent launches: no copy on the hot path, no EBUSY surface.
+--
+-- Rows are matched by `agent_source_info.binary_name` rather than primary
+-- key so the migration is robust to local re-installs that may have
+-- shifted IDs. Idempotent via the `command = 'bun'` guard.
+--
+-- Versions reflect those pinned in migration 004; bump to current at merge
+-- time if upstream has cut a newer release.
+
+UPDATE agent_metadata
+SET command = 'npm',
+    args = '["exec","--prefix=${AGENT_PREFIX}","--cache=${AGENT_NPM_CACHE}","--yes","--","@agentclientprotocol/claude-agent-acp@0.33.1"]',
+    agent_source_info = json_set(COALESCE(agent_source_info, '{}'), '$.bridge_binary', 'npm'),
+    updated_at = CAST(strftime('%s','now') AS INTEGER) * 1000
+WHERE agent_source = 'builtin'
+  AND command = 'bun'
+  AND json_extract(agent_source_info, '$.binary_name') = 'claude';
+
+UPDATE agent_metadata
+SET command = 'npm',
+    args = '["exec","--prefix=${AGENT_PREFIX}","--cache=${AGENT_NPM_CACHE}","--yes","--","@zed-industries/codex-acp@0.14.0"]',
+    agent_source_info = json_set(COALESCE(agent_source_info, '{}'), '$.bridge_binary', 'npm'),
+    updated_at = CAST(strftime('%s','now') AS INTEGER) * 1000
+WHERE agent_source = 'builtin'
+  AND command = 'bun'
+  AND json_extract(agent_source_info, '$.binary_name') = 'codex';
+
+UPDATE agent_metadata
+SET command = 'npm',
+    args = '["exec","--prefix=${AGENT_PREFIX}","--cache=${AGENT_NPM_CACHE}","--yes","--","@tencent-ai/codebuddy-code@2.97.0","--acp"]',
+    agent_source_info = json_set(COALESCE(agent_source_info, '{}'), '$.bridge_binary', 'npm'),
+    updated_at = CAST(strftime('%s','now') AS INTEGER) * 1000
+WHERE agent_source = 'builtin'
+  AND command = 'bun'
+  AND json_extract(agent_source_info, '$.binary_name') = 'codebuddy';

--- a/crates/aionui-db/tests/migration_007.rs
+++ b/crates/aionui-db/tests/migration_007.rs
@@ -1,0 +1,72 @@
+//! Migration 007 integration test: builtin ACP agent rows are rewritten to
+//! `npm exec` with `${AGENT_PREFIX}` / `${AGENT_NPM_CACHE}` placeholders.
+
+use aionui_db::init_database_memory;
+use sqlx::Row;
+
+#[tokio::test]
+async fn migration_007_rewrites_three_builtin_agents() {
+    let db = init_database_memory().await.expect("init memory db");
+    let pool = db.pool();
+
+    let rows = sqlx::query(
+        "SELECT id, command, args,
+                json_extract(agent_source_info, '$.binary_name') AS binary_name,
+                json_extract(agent_source_info, '$.bridge_binary') AS bridge_binary
+         FROM agent_metadata
+         WHERE agent_source = 'builtin'
+           AND json_extract(agent_source_info, '$.binary_name') IN ('claude','codex','codebuddy')",
+    )
+    .fetch_all(pool)
+    .await
+    .expect("query");
+
+    assert_eq!(rows.len(), 3, "expected three builtin rows");
+
+    for row in &rows {
+        let binary: String = row.get("binary_name");
+        let command: String = row.get("command");
+        let args: String = row.get("args");
+        let bridge: String = row.get("bridge_binary");
+
+        assert_eq!(command, "npm", "{binary}: command must be npm");
+        assert_eq!(bridge, "npm", "{binary}: bridge_binary must be npm");
+        assert!(
+            args.contains("\"exec\""),
+            "{binary}: args must use `exec` subcommand: {args}"
+        );
+        assert!(
+            args.contains("--prefix=${AGENT_PREFIX}"),
+            "{binary}: args must reference AGENT_PREFIX placeholder: {args}"
+        );
+        assert!(
+            args.contains("--cache=${AGENT_NPM_CACHE}"),
+            "{binary}: args must reference AGENT_NPM_CACHE placeholder: {args}"
+        );
+    }
+
+    let claude = rows.iter().find(|r| r.get::<String, _>("binary_name") == "claude").unwrap();
+    let claude_args: String = claude.get("args");
+    assert!(
+        claude_args.contains("@agentclientprotocol/claude-agent-acp@"),
+        "claude args must reference the claude-agent-acp package: {claude_args}"
+    );
+
+    let codex = rows.iter().find(|r| r.get::<String, _>("binary_name") == "codex").unwrap();
+    let codex_args: String = codex.get("args");
+    assert!(
+        codex_args.contains("@zed-industries/codex-acp@"),
+        "codex args must reference codex-acp package: {codex_args}"
+    );
+
+    let codebuddy = rows.iter().find(|r| r.get::<String, _>("binary_name") == "codebuddy").unwrap();
+    let codebuddy_args: String = codebuddy.get("args");
+    assert!(
+        codebuddy_args.contains("@tencent-ai/codebuddy-code@"),
+        "codebuddy args must reference codebuddy-code: {codebuddy_args}"
+    );
+    assert!(
+        codebuddy_args.contains("\"--acp\""),
+        "codebuddy args must keep the `--acp` flag: {codebuddy_args}"
+    );
+}

--- a/crates/aionui-db/tests/migration_007.rs
+++ b/crates/aionui-db/tests/migration_007.rs
@@ -45,21 +45,30 @@ async fn migration_007_rewrites_three_builtin_agents() {
         );
     }
 
-    let claude = rows.iter().find(|r| r.get::<String, _>("binary_name") == "claude").unwrap();
+    let claude = rows
+        .iter()
+        .find(|r| r.get::<String, _>("binary_name") == "claude")
+        .unwrap();
     let claude_args: String = claude.get("args");
     assert!(
         claude_args.contains("@agentclientprotocol/claude-agent-acp@"),
         "claude args must reference the claude-agent-acp package: {claude_args}"
     );
 
-    let codex = rows.iter().find(|r| r.get::<String, _>("binary_name") == "codex").unwrap();
+    let codex = rows
+        .iter()
+        .find(|r| r.get::<String, _>("binary_name") == "codex")
+        .unwrap();
     let codex_args: String = codex.get("args");
     assert!(
         codex_args.contains("@zed-industries/codex-acp@"),
         "codex args must reference codex-acp package: {codex_args}"
     );
 
-    let codebuddy = rows.iter().find(|r| r.get::<String, _>("binary_name") == "codebuddy").unwrap();
+    let codebuddy = rows
+        .iter()
+        .find(|r| r.get::<String, _>("binary_name") == "codebuddy")
+        .unwrap();
     let codebuddy_args: String = codebuddy.get("args");
     assert!(
         codebuddy_args.contains("@tencent-ai/codebuddy-code@"),


### PR DESCRIPTION
## Summary

Stacked on top of #315 (PR-A). PR-B performs the database cutover that hands the bundled-node migration its actual effect at runtime.

- New migration `007_switch_builtin_agents_to_node.sql` rewrites the three builtin ACP rows (claude / codex / codebuddy) from `bun x --bun <pkg>` to `npm exec --prefix=\${AGENT_PREFIX} --cache=\${AGENT_NPM_CACHE} -- <pkg>`.
- Each UPDATE is guarded by `command = 'bun'`, so re-running on an already-cutover database is a no-op.
- `bridge_binary` is rewritten to `npm` via `json_set` and `updated_at` is bumped.
- Integration test `migration_007.rs` asserts the resulting `agent_metadata` rows expose `command='npm'`, `bridge_binary='npm'`, and the expected placeholders + package identifiers in argv.
- The registry test `find_builtin_claude_has_bridge_command` is updated to reflect the cutover (still asserts meaningful spawn-shape behavior).

PR-A introduced the placeholder substitution and bundled-node resolver; this PR makes the existing builtin rows actually request `npm exec`. PR-C will follow to remove the now-dead bun runtime code paths.

## Test plan

- [x] `cargo test -p aionui-db` — migration test passes
- [x] `cargo test -p aionui-ai-agent` — registry tests pass
- [x] `cargo test -p aionui-runtime` — passes (one pre-existing env-var-sharing flake when run combined; passes in isolation)
- [x] `cargo clippy -p aionui-db -p aionui-ai-agent -p aionui-runtime -- -D warnings`
- [x] `cargo fmt --all -- --check`