### PR TITLE
feat(acp,conversation): elevate ACP protocol + assistant lineage logs to info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,7 @@ dependencies = [
  "tokio-tungstenite 0.26.2",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "which",
 ]

--- a/crates/aionui-ai-agent/Cargo.toml
+++ b/crates/aionui-ai-agent/Cargo.toml
@@ -50,6 +50,7 @@ test-support = []
 [dev-dependencies]
 tempfile = "3"
 tokio = { workspace = true, features = ["full"] }
+tracing-subscriber.workspace = true
 aionui-common.workspace = true
 aionui-extension.workspace = true
 aionui-db.workspace = true

--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -550,7 +550,7 @@ fn is_streaming_chunk(body: &str) -> bool {
         return false;
     };
     let kind = value
-        .pointer("/params/update/sessionUpdate")
+        .pointer("/update/sessionUpdate")
         .and_then(serde_json::Value::as_str);
     matches!(kind, Some(k) if STREAMING_KINDS.contains(&k))
 }
@@ -696,11 +696,11 @@ mod tests {
         tracing::subscriber::with_default(subscriber, || {
             log_agent_notify(
                 "session/update",
-                r#"{"params":{"update":{"sessionUpdate":"agent_message_chunk"}}}"#,
+                r#"{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk"}}"#,
             );
             log_agent_notify(
                 "session/update",
-                r#"{"params":{"update":{"sessionUpdate":"current_mode_update","modeId":"yolo"}}}"#,
+                r#"{"sessionId":"s1","update":{"sessionUpdate":"current_mode_update","modeId":"yolo"}}"#,
             );
         });
 
@@ -725,10 +725,12 @@ mod tests {
 
     #[test]
     fn is_streaming_chunk_recognises_prompt_stream_kinds() {
-        let body_chunk =
-            r#"{"params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hi"}}}}"#;
-        let mode_update = r#"{"params":{"update":{"sessionUpdate":"current_mode_update","modeId":"yolo"}}}"#;
-        let unknown = r#"{"params":{"update":{"sessionUpdate":"future_unknown_kind"}}}"#;
+        // SDK delivers `params` already unwrapped — `body` here mirrors what
+        // the log helpers receive: the JSON-RPC params object with `sessionId`
+        // and `update` at the top level.
+        let body_chunk = r#"{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hi"}}}"#;
+        let mode_update = r#"{"sessionId":"s1","update":{"sessionUpdate":"current_mode_update","modeId":"yolo"}}"#;
+        let unknown = r#"{"sessionId":"s1","update":{"sessionUpdate":"future_unknown_kind"}}"#;
         let malformed = "not json";
 
         assert!(is_streaming_chunk(body_chunk));

--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -228,7 +228,7 @@ impl AcpProtocol {
         if !self.is_connected() {
             return;
         }
-        log_notify(AGENT_METHOD_NAMES.session_cancel, &json_str(&notification));
+        log_client_notify(AGENT_METHOD_NAMES.session_cancel, &json_str(&notification));
         let _ = self.connection.send_notification(notification);
     }
 
@@ -283,7 +283,7 @@ impl AcpProtocol {
             return;
         }
         let method = format!("_{}", notification.method);
-        log_notify(&method, &json_str(&notification));
+        log_client_notify(&method, &json_str(&notification));
         let wrapped = ClientNotification::ExtNotification(notification);
         let _ = self.connection.send_notification(wrapped);
     }
@@ -302,9 +302,9 @@ impl AcpProtocol {
         Req::Response: serde::Serialize + std::fmt::Debug + Send,
     {
         self.ensure_connected()?;
-        log_request(method, &json_str(&req));
+        log_client_request(method, &json_str(&req));
         let rsp = self.connection.send_request(req).block_task().await;
-        log_response(method, &json_or_err(&rsp));
+        log_agent_response(method, &json_or_err(&rsp));
         rsp.map_err(|e| AcpError::from_sdk(e, method))
     }
 
@@ -422,9 +422,9 @@ async fn run_sdk_background(
             // to call `block_task` (see SDK `connect_with` doc example).
             let init_result = {
                 let req = InitializeRequest::new(ProtocolVersion::LATEST);
-                log_request("initialize", &json_str(&req));
+                log_client_request("initialize", &json_str(&req));
                 let raw = connection.send_request(req).block_task().await;
-                log_response("initialize", &json_or_err(&raw));
+                log_agent_response("initialize", &json_or_err(&raw));
                 raw.map_err(|e| AcpError::from_sdk(e, "initialize"))
             };
 
@@ -473,7 +473,7 @@ async fn handle_session_notification(
     notification: SessionNotification,
     event_tx: &broadcast::Sender<AgentStreamEvent>,
 ) {
-    log_incoming("session/update", &json_str(&notification));
+    log_agent_event("session/update", &json_str(&notification));
 
     let events = stream_event::session_notification_to_events(&notification);
     for event in events {
@@ -493,7 +493,7 @@ async fn handle_permission_request(
     responder: Responder<RequestPermissionResponse>,
     event_tx: &mpsc::Sender<PermissionRequest>,
 ) {
-    log_incoming("session/request_permission", &json_str(&request));
+    log_agent_event("session/request_permission", &json_str(&request));
 
     let (response_tx, response_rx) = oneshot::channel();
 
@@ -512,7 +512,7 @@ async fn handle_permission_request(
         }
     };
 
-    log_outgoing("session/request_permission", &json_str(&response));
+    log_client_response("session/request_permission", &json_str(&response));
     let _ = responder.respond(response);
 }
 
@@ -529,28 +529,32 @@ fn json_or_err<T: serde::Serialize + std::fmt::Debug, E: std::fmt::Debug>(result
     }
 }
 
-/// Log an outgoing ACP request (`→`).
-fn log_request(method: &str, body: &str) {
+/// Log an outgoing ACP request from AionUi to the agent (`→`).
+fn log_client_request(method: &str, body: &str) {
     debug!("[ACP] {method} ->\n -> {body}");
 }
 
-/// Log an incoming ACP response (`←`).
-fn log_response(method: &str, body: &str) {
+/// Log an incoming ACP response from the agent (`←`).
+fn log_agent_response(method: &str, body: &str) {
     debug!("[ACP] {method} <-\n <- {body}");
 }
 
-/// Log a fire-and-forget notification (`⚡`).
-fn log_notify(method: &str, body: &str) {
+/// Log a fire-and-forget notification from AionUi to the agent (`⚡`).
+fn log_client_notify(method: &str, body: &str) {
     debug!("[ACP] {method} ⚡⚡\n ⚡⚡ {body}");
 }
 
-/// Log an incoming agent notification/request (`←`).
-fn log_incoming(method: &str, body: &str) {
+/// Log an inbound event from the agent (`←`).
+///
+/// Currently spans two semantically distinct paths — `session/update`
+/// (agent notification) and `session/request_permission` (agent request).
+/// Task 2 will split this into `log_agent_notify` and `log_agent_request`.
+fn log_agent_event(method: &str, body: &str) {
     debug!("[ACP] {method} <-\n <- {body}");
 }
 
-/// Log an outgoing agent notification/request (`→`).
-fn log_outgoing(method: &str, body: &str) {
+/// Log an outgoing client response from AionUi back to the agent (`→`).
+fn log_client_response(method: &str, body: &str) {
     debug!("[ACP] {method} ->\n -> {body}");
 }
 

--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -39,7 +39,7 @@ use aionui_common::ErrorChain;
 use tokio::process::{ChildStdin, ChildStdout};
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use crate::protocol::error::AcpError;
 use crate::protocol::events::{self as stream_event, AgentStreamEvent};
@@ -473,7 +473,7 @@ async fn handle_session_notification(
     notification: SessionNotification,
     event_tx: &broadcast::Sender<AgentStreamEvent>,
 ) {
-    log_agent_event("session/update", &json_str(&notification));
+    log_agent_notify("session/update", &json_str(&notification));
 
     let events = stream_event::session_notification_to_events(&notification);
     for event in events {
@@ -493,7 +493,7 @@ async fn handle_permission_request(
     responder: Responder<RequestPermissionResponse>,
     event_tx: &mpsc::Sender<PermissionRequest>,
 ) {
-    log_agent_event("session/request_permission", &json_str(&request));
+    log_agent_request("session/request_permission", &json_str(&request));
 
     let (response_tx, response_rx) = oneshot::channel();
 
@@ -529,33 +529,75 @@ fn json_or_err<T: serde::Serialize + std::fmt::Debug, E: std::fmt::Debug>(result
     }
 }
 
-/// Log an outgoing ACP request from AionUi to the agent (`→`).
-fn log_client_request(method: &str, body: &str) {
-    debug!("[ACP] {method} ->\n -> {body}");
-}
-
-/// Log an incoming ACP response from the agent (`←`).
-fn log_agent_response(method: &str, body: &str) {
-    debug!("[ACP] {method} <-\n <- {body}");
-}
-
-/// Log a fire-and-forget notification from AionUi to the agent (`⚡`).
-fn log_client_notify(method: &str, body: &str) {
-    debug!("[ACP] {method} ⚡⚡\n ⚡⚡ {body}");
-}
-
-/// Log an inbound event from the agent (`←`).
+/// Returns `true` when the `session/update` notification body carries a
+/// piece of the prompt-reply stream (high-frequency, high-volume content).
 ///
-/// Currently spans two semantically distinct paths — `session/update`
-/// (agent notification) and `session/request_permission` (agent request).
-/// Task 2 will split this into `log_agent_notify` and `log_agent_request`.
-fn log_agent_event(method: &str, body: &str) {
-    debug!("[ACP] {method} <-\n <- {body}");
+/// Unknown / new `sessionUpdate` kinds default to `false` so newly added
+/// metadata events stay visible at `info!` until explicitly classified.
+fn is_streaming_chunk(body: &str) -> bool {
+    // Streaming chunks of the prompt reply: token-level message / thought
+    // text, and the incremental tool_call / plan structures the agent emits
+    // mid-response. Their `_update` siblings are part of the same stream.
+    const STREAMING_KINDS: &[&str] = &[
+        "agent_message_chunk",
+        "agent_thought_chunk",
+        "user_message_chunk",
+        "tool_call",
+        "tool_call_update",
+        "plan",
+    ];
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
+        return false;
+    };
+    let kind = value
+        .pointer("/params/update/sessionUpdate")
+        .and_then(serde_json::Value::as_str);
+    matches!(kind, Some(k) if STREAMING_KINDS.contains(&k))
 }
 
-/// Log an outgoing client response from AionUi back to the agent (`→`).
+/// Log a JSON-RPC request from AionUi to the ACP agent.
+/// `session/prompt` carries large user input and stays at debug.
+fn log_client_request(method: &str, body: &str) {
+    if method == "session/prompt" {
+        debug!(direction = "client_request", method, body, "[ACP]");
+    } else {
+        info!(direction = "client_request", method, body, "[ACP]");
+    }
+}
+
+/// Log a JSON-RPC response from the ACP agent.
+/// `session/prompt` reply is large; stays at debug.
+fn log_agent_response(method: &str, body: &str) {
+    if method == "session/prompt" {
+        debug!(direction = "agent_response", method, body, "[ACP]");
+    } else {
+        info!(direction = "agent_response", method, body, "[ACP]");
+    }
+}
+
+/// Log a fire-and-forget notification from AionUi to the agent.
+fn log_client_notify(method: &str, body: &str) {
+    info!(direction = "client_notify", method, body, "[ACP]");
+}
+
+/// Log an inbound notification from the agent.
+/// `session/update` requires per-kind filtering — streaming chunks stay at debug.
+fn log_agent_notify(method: &str, body: &str) {
+    if method == "session/update" && is_streaming_chunk(body) {
+        debug!(direction = "agent_notify", method, body, "[ACP]");
+    } else {
+        info!(direction = "agent_notify", method, body, "[ACP]");
+    }
+}
+
+/// Log an inbound request from the agent (e.g. session/request_permission).
+fn log_agent_request(method: &str, body: &str) {
+    info!(direction = "agent_request", method, body, "[ACP]");
+}
+
+/// Log a JSON-RPC response from AionUi back to the agent.
 fn log_client_response(method: &str, body: &str) {
-    debug!("[ACP] {method} ->\n -> {body}");
+    info!(direction = "client_response", method, body, "[ACP]");
 }
 
 impl std::fmt::Debug for AcpProtocol {
@@ -618,5 +660,18 @@ mod tests {
         let seen_during = simulated_load(&flag, Arc::clone(&flag_probe)).await;
         assert!(seen_during, "flag should be true inside guarded scope");
         assert!(!flag.load(Ordering::Acquire), "flag should be false after guard drop");
+    }
+
+    #[test]
+    fn is_streaming_chunk_recognises_prompt_stream_kinds() {
+        let body_chunk = r#"{"params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hi"}}}}"#;
+        let mode_update = r#"{"params":{"update":{"sessionUpdate":"current_mode_update","modeId":"yolo"}}}"#;
+        let unknown = r#"{"params":{"update":{"sessionUpdate":"future_unknown_kind"}}}"#;
+        let malformed = "not json";
+
+        assert!(is_streaming_chunk(body_chunk));
+        assert!(!is_streaming_chunk(mode_update));
+        assert!(!is_streaming_chunk(unknown), "unknown kinds default to keep");
+        assert!(!is_streaming_chunk(malformed), "malformed bodies default to keep");
     }
 }

--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -663,8 +663,70 @@ mod tests {
     }
 
     #[test]
+    fn log_agent_notify_filters_streaming_chunks_at_info_level() {
+        use std::io::Write;
+        use std::sync::{Arc, Mutex};
+        use tracing::Level;
+        use tracing_subscriber::fmt;
+
+        #[derive(Clone)]
+        struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+        impl Write for SharedBuf {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let make_writer = {
+            let buffer = Arc::clone(&buffer);
+            move || SharedBuf(Arc::clone(&buffer))
+        };
+
+        let subscriber = fmt::Subscriber::builder()
+            .with_max_level(Level::INFO)
+            .with_writer(make_writer)
+            .with_ansi(false)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            log_agent_notify(
+                "session/update",
+                r#"{"params":{"update":{"sessionUpdate":"agent_message_chunk"}}}"#,
+            );
+            log_agent_notify(
+                "session/update",
+                r#"{"params":{"update":{"sessionUpdate":"current_mode_update","modeId":"yolo"}}}"#,
+            );
+        });
+
+        let captured = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
+        assert!(
+            !captured.contains("agent_message_chunk"),
+            "streaming chunk should NOT appear at info level: {captured}"
+        );
+        assert!(
+            captured.contains("current_mode_update"),
+            "non-streaming update should appear at info level: {captured}"
+        );
+        assert!(
+            captured.contains("agent_notify"),
+            "structured `direction` field should be `agent_notify`: {captured}"
+        );
+        assert!(
+            captured.contains("session/update"),
+            "structured `method` field should be present: {captured}"
+        );
+    }
+
+    #[test]
     fn is_streaming_chunk_recognises_prompt_stream_kinds() {
-        let body_chunk = r#"{"params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hi"}}}}"#;
+        let body_chunk =
+            r#"{"params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hi"}}}}"#;
         let mode_update = r#"{"params":{"update":{"sessionUpdate":"current_mode_update","modeId":"yolo"}}}"#;
         let unknown = r#"{"params":{"update":{"sessionUpdate":"future_unknown_kind"}}}"#;
         let malformed = "not json";

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -298,7 +298,7 @@ impl ConversationService {
 
         self.broadcast_list_changed(&response.id, "created", response.source.as_ref());
 
-        info!(conversation_id = %response.id, "Conversation created");
+        log_conversation_created(&response, &extra);
 
         Ok(response)
     }
@@ -1525,6 +1525,65 @@ fn merge_json(base: &mut serde_json::Value, patch: &serde_json::Value) {
     }
 }
 
+#[derive(Debug, Default, PartialEq, Eq)]
+struct AssistantLineage<'a> {
+    preset_assistant_id: &'a str,
+    custom_agent_id: &'a str,
+    agent_id: &'a str,
+    agent_name: &'a str,
+    backend: &'a str,
+    current_model_id: &'a str,
+    session_mode: &'a str,
+}
+
+impl<'a> AssistantLineage<'a> {
+    fn from_extra(extra: &'a serde_json::Value) -> Self {
+        fn s<'a>(extra: &'a serde_json::Value, key: &str) -> &'a str {
+            extra.get(key).and_then(serde_json::Value::as_str).unwrap_or("")
+        }
+        Self {
+            preset_assistant_id: s(extra, "preset_assistant_id"),
+            custom_agent_id: s(extra, "custom_agent_id"),
+            agent_id: s(extra, "agent_id"),
+            agent_name: s(extra, "agent_name"),
+            backend: s(extra, "backend"),
+            current_model_id: s(extra, "current_model_id"),
+            session_mode: s(extra, "session_mode"),
+        }
+    }
+
+    fn has_any_identity(&self) -> bool {
+        !self.preset_assistant_id.is_empty()
+            || !self.custom_agent_id.is_empty()
+            || !self.agent_id.is_empty()
+            || !self.agent_name.is_empty()
+    }
+}
+
+fn log_conversation_created(response: &ConversationResponse, extra: &serde_json::Value) {
+    let lineage = AssistantLineage::from_extra(extra);
+    if lineage.has_any_identity() {
+        info!(
+            conversation_id = %response.id,
+            conversation_type = %response.r#type.serde_name(),
+            preset_assistant_id = lineage.preset_assistant_id,
+            custom_agent_id = lineage.custom_agent_id,
+            agent_id = lineage.agent_id,
+            agent_name = lineage.agent_name,
+            backend = lineage.backend,
+            current_model_id = lineage.current_model_id,
+            session_mode = lineage.session_mode,
+            "Conversation created from assistant"
+        );
+    } else {
+        info!(
+            conversation_id = %response.id,
+            conversation_type = %response.r#type.serde_name(),
+            "Conversation created (no assistant)"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1581,5 +1640,64 @@ mod tests {
         let patch = json!({});
         merge_json(&mut base, &patch);
         assert_eq!(base, json!({"a": 1}));
+    }
+
+    #[test]
+    fn assistant_lineage_extracts_acp_builtin_fields() {
+        let extra = json!({
+            "agent_id": "abc-123",
+            "agent_name": "Claude Code",
+            "backend": "claude",
+            "current_model_id": "opus",
+            "session_mode": "default",
+        });
+        let lineage = AssistantLineage::from_extra(&extra);
+        assert_eq!(lineage.agent_id, "abc-123");
+        assert_eq!(lineage.agent_name, "Claude Code");
+        assert_eq!(lineage.backend, "claude");
+        assert_eq!(lineage.current_model_id, "opus");
+        assert_eq!(lineage.session_mode, "default");
+        assert_eq!(lineage.preset_assistant_id, "");
+        assert_eq!(lineage.custom_agent_id, "");
+        assert!(lineage.has_any_identity());
+    }
+
+    #[test]
+    fn assistant_lineage_extracts_aionrs_preset_id() {
+        let extra = json!({ "preset_assistant_id": "preset-xyz" });
+        let lineage = AssistantLineage::from_extra(&extra);
+        assert_eq!(lineage.preset_assistant_id, "preset-xyz");
+        assert!(lineage.has_any_identity());
+    }
+
+    #[test]
+    fn assistant_lineage_extracts_acp_custom_agent_id() {
+        let extra = json!({
+            "custom_agent_id": "custom-1",
+            "backend": "openrouter",
+        });
+        let lineage = AssistantLineage::from_extra(&extra);
+        assert_eq!(lineage.custom_agent_id, "custom-1");
+        assert_eq!(lineage.backend, "openrouter");
+        assert!(lineage.has_any_identity());
+    }
+
+    #[test]
+    fn assistant_lineage_no_identity_when_extra_lacks_assistant_fields() {
+        let extra = json!({ "workspace": "/project" });
+        let lineage = AssistantLineage::from_extra(&extra);
+        assert!(!lineage.has_any_identity());
+    }
+
+    #[test]
+    fn assistant_lineage_treats_non_string_fields_as_missing() {
+        let extra = json!({
+            "agent_id": 42,
+            "agent_name": null,
+        });
+        let lineage = AssistantLineage::from_extra(&extra);
+        assert_eq!(lineage.agent_id, "");
+        assert_eq!(lineage.agent_name, "");
+        assert!(!lineage.has_any_identity());
     }
 }

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -1527,6 +1527,7 @@ fn merge_json(base: &mut serde_json::Value, patch: &serde_json::Value) {
 
 #[derive(Debug, Default, PartialEq, Eq)]
 struct AssistantLineage<'a> {
+    agent_type: &'a str,
     preset_assistant_id: &'a str,
     custom_agent_id: &'a str,
     agent_id: &'a str,
@@ -1537,11 +1538,12 @@ struct AssistantLineage<'a> {
 }
 
 impl<'a> AssistantLineage<'a> {
-    fn from_extra(extra: &'a serde_json::Value) -> Self {
+    fn from_response_and_extra(response: &'a ConversationResponse, extra: &'a serde_json::Value) -> Self {
         fn s<'a>(extra: &'a serde_json::Value, key: &str) -> &'a str {
             extra.get(key).and_then(serde_json::Value::as_str).unwrap_or("")
         }
         Self {
+            agent_type: response.r#type.serde_name(),
             preset_assistant_id: s(extra, "preset_assistant_id"),
             custom_agent_id: s(extra, "custom_agent_id"),
             agent_id: s(extra, "agent_id"),
@@ -1561,11 +1563,11 @@ impl<'a> AssistantLineage<'a> {
 }
 
 fn log_conversation_created(response: &ConversationResponse, extra: &serde_json::Value) {
-    let lineage = AssistantLineage::from_extra(extra);
+    let lineage = AssistantLineage::from_response_and_extra(response, extra);
     if lineage.has_any_identity() {
         info!(
             conversation_id = %response.id,
-            conversation_type = %response.r#type.serde_name(),
+            agent_type = lineage.agent_type,
             preset_assistant_id = lineage.preset_assistant_id,
             custom_agent_id = lineage.custom_agent_id,
             agent_id = lineage.agent_id,
@@ -1578,7 +1580,7 @@ fn log_conversation_created(response: &ConversationResponse, extra: &serde_json:
     } else {
         info!(
             conversation_id = %response.id,
-            conversation_type = %response.r#type.serde_name(),
+            agent_type = lineage.agent_type,
             "Conversation created (no assistant)"
         );
     }
@@ -1642,8 +1644,27 @@ mod tests {
         assert_eq!(base, json!({"a": 1}));
     }
 
+    fn response_with_type(agent_type: aionui_common::AgentType) -> ConversationResponse {
+        ConversationResponse {
+            id: "conv-1".into(),
+            name: "test".into(),
+            r#type: agent_type,
+            model: None,
+            status: ConversationStatus::Pending,
+            source: None,
+            pinned: false,
+            pinned_at: None,
+            channel_chat_id: None,
+            created_at: 0,
+            modified_at: 0,
+            extra: json!({}),
+        }
+    }
+
     #[test]
     fn assistant_lineage_extracts_acp_builtin_fields() {
+        use aionui_common::AgentType;
+        let response = response_with_type(AgentType::Acp);
         let extra = json!({
             "agent_id": "abc-123",
             "agent_name": "Claude Code",
@@ -1651,7 +1672,8 @@ mod tests {
             "current_model_id": "opus",
             "session_mode": "default",
         });
-        let lineage = AssistantLineage::from_extra(&extra);
+        let lineage = AssistantLineage::from_response_and_extra(&response, &extra);
+        assert_eq!(lineage.agent_type, "acp");
         assert_eq!(lineage.agent_id, "abc-123");
         assert_eq!(lineage.agent_name, "Claude Code");
         assert_eq!(lineage.backend, "claude");
@@ -1664,19 +1686,25 @@ mod tests {
 
     #[test]
     fn assistant_lineage_extracts_aionrs_preset_id() {
+        use aionui_common::AgentType;
+        let response = response_with_type(AgentType::Aionrs);
         let extra = json!({ "preset_assistant_id": "preset-xyz" });
-        let lineage = AssistantLineage::from_extra(&extra);
+        let lineage = AssistantLineage::from_response_and_extra(&response, &extra);
+        assert_eq!(lineage.agent_type, "aionrs");
         assert_eq!(lineage.preset_assistant_id, "preset-xyz");
         assert!(lineage.has_any_identity());
     }
 
     #[test]
     fn assistant_lineage_extracts_acp_custom_agent_id() {
+        use aionui_common::AgentType;
+        let response = response_with_type(AgentType::Acp);
         let extra = json!({
             "custom_agent_id": "custom-1",
             "backend": "openrouter",
         });
-        let lineage = AssistantLineage::from_extra(&extra);
+        let lineage = AssistantLineage::from_response_and_extra(&response, &extra);
+        assert_eq!(lineage.agent_type, "acp");
         assert_eq!(lineage.custom_agent_id, "custom-1");
         assert_eq!(lineage.backend, "openrouter");
         assert!(lineage.has_any_identity());
@@ -1684,18 +1712,23 @@ mod tests {
 
     #[test]
     fn assistant_lineage_no_identity_when_extra_lacks_assistant_fields() {
+        use aionui_common::AgentType;
+        let response = response_with_type(AgentType::Acp);
         let extra = json!({ "workspace": "/project" });
-        let lineage = AssistantLineage::from_extra(&extra);
+        let lineage = AssistantLineage::from_response_and_extra(&response, &extra);
+        assert_eq!(lineage.agent_type, "acp");
         assert!(!lineage.has_any_identity());
     }
 
     #[test]
     fn assistant_lineage_treats_non_string_fields_as_missing() {
+        use aionui_common::AgentType;
+        let response = response_with_type(AgentType::Acp);
         let extra = json!({
             "agent_id": 42,
             "agent_name": null,
         });
-        let lineage = AssistantLineage::from_extra(&extra);
+        let lineage = AssistantLineage::from_response_and_extra(&response, &extra);
         assert_eq!(lineage.agent_id, "");
         assert_eq!(lineage.agent_name, "");
         assert!(!lineage.has_any_identity());


### PR DESCRIPTION
## Summary

- **ACP protocol logs**: split the four log helpers into six direction-aware ones (`log_client_request` / `log_agent_response` / `log_client_notify` / `log_agent_notify` / `log_agent_request` / `log_client_response`), and emit at `info!` with structured fields. `session/prompt` request/response stay at `debug` (large payloads), and `session/update` streaming chunks (`agent_message_chunk`, `agent_thought_chunk`, `user_message_chunk`, `tool_call`, `tool_call_update`, `plan`) are filtered down to `debug` via `is_streaming_chunk`. Unknown `sessionUpdate` kinds default to `info` so new metadata events stay visible until classified.
- **Conversation lineage**: when a conversation is created, log assistant identity (`agent_type`, `preset_assistant_id`, `custom_agent_id`, `agent_id`, `agent_name`, `backend`, `current_model_id`, `session_mode`) extracted from `ConversationResponse` + `extra`. Falls back to a minimal record when no assistant identity is present.
- Adds tests for streaming-chunk filtering and `AssistantLineage` extraction across ACP/AionRS/preset/custom paths.

## Test plan

- [x] \`cargo test --workspace\` (5584 passed via \`just push\`)
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [ ] Run an ACP session and confirm \`info!\` logs show client/agent direction, while streaming chunks remain at \`debug\`
- [ ] Create a conversation from a preset / custom / built-in ACP assistant and confirm lineage fields land in logs (and downstream Sentry breadcrumbs)