### PR TITLE
fix(ai-agent): rebuild ACP session when CLI rejects stale sid (ELECTRON-1HQ)

### DIFF
--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -367,7 +367,17 @@ impl AcpAgentManager {
         // `ObservedModeSynced`. `get_mode()` reflects the change as soon
         // as the SDK call returns.
         if let Some(sid) = session_id {
-            self.reconcile_session(&sid).await;
+            // PUT /mode is best-effort by design: the desired layer is
+            // already updated, and any SDK failure (including
+            // SessionNotFound) is handled on the next ensure_session
+            // pass when the user retries or sends a message.
+            if let Err(e) = self.reconcile_session(&sid).await {
+                debug!(
+                    conversation_id = %self.params.conversation_id,
+                    error = %e,
+                    "set_mode: reconcile failed; desired layer kept for next ensure_session"
+                );
+            }
         }
         Ok(())
     }
@@ -389,7 +399,13 @@ impl AcpAgentManager {
         }
 
         if let Some(sid) = session_id {
-            self.reconcile_session(&sid).await;
+            if let Err(e) = self.reconcile_session(&sid).await {
+                debug!(
+                    conversation_id = %self.params.conversation_id,
+                    error = %e,
+                    "set_model: reconcile failed; desired layer kept for next ensure_session"
+                );
+            }
         } else {
             return Err(AppError::BadRequest("No active session".into()));
         }

--- a/crates/aionui-ai-agent/src/manager/acp/agent_reconcile.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_reconcile.rs
@@ -1,11 +1,13 @@
 use crate::manager::acp::AcpAgentManager;
 
 use crate::manager::acp::mode_normalize::normalize_requested_mode;
+use crate::protocol::error::AcpError;
 use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId};
 use agent_client_protocol::schema::{
     SessionId, SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest,
 };
-use tracing::{error, info};
+use aionui_common::AppError;
+use tracing::{error, info, warn};
 
 /// Actions the session driver must execute to align CLI state with user intent.
 ///
@@ -23,9 +25,18 @@ impl AcpAgentManager {
     ///
     /// Compares the aggregate's desired state against what the CLI has
     /// reported as current, then issues the minimal set of SDK calls
-    /// (set_mode, set_config_option) to bring the CLI into alignment.
-    /// Best-effort: individual failures are logged but do not abort.
-    pub(super) async fn reconcile_session(&self, session_id: &str) {
+    /// (set_mode, set_model, set_config_option) to bring the CLI into
+    /// alignment.
+    ///
+    /// Failure handling:
+    /// - `SessionNotFound`: returned as `AppError::NotFound` so callers
+    ///   (e.g. `open_session_resume`) can drop the stale sid and rebuild
+    ///   the session. ELECTRON-1HQ regressed because we silently swallowed
+    ///   this case during warmup, leaving downstream `session/prompt` to
+    ///   surface the same error to the user every turn.
+    /// - Any other error: logged and skipped (best-effort), so a failed
+    ///   `set_config_option` doesn't block a successful `set_mode`.
+    pub(super) async fn reconcile_session(&self, session_id: &str) -> Result<(), AppError> {
         use crate::manager::acp::ReconcileAction;
 
         let actions = {
@@ -48,6 +59,15 @@ impl AcpAgentManager {
                         ))
                         .await
                     {
+                        if matches!(e, AcpError::SessionNotFound { .. }) {
+                            warn!(
+                                conversation_id = %self.params.conversation_id,
+                                mode_id = %normalized,
+                                error = %e,
+                                "reconcile_session: set_mode hit SessionNotFound; aborting reconcile"
+                            );
+                            return Err(AppError::from(e));
+                        }
                         error!(
                             conversation_id = %self.params.conversation_id,
                             mode_id = %normalized,
@@ -63,6 +83,7 @@ impl AcpAgentManager {
                     session.apply_observed_mode(ModeId::new(normalized));
                     self.commit_session_changes(&mut session).await;
                 }
+
                 ReconcileAction::SetModel { model } => {
                     if let Err(e) = self
                         .protocol
@@ -72,6 +93,15 @@ impl AcpAgentManager {
                         ))
                         .await
                     {
+                        if matches!(e, AcpError::SessionNotFound { .. }) {
+                            warn!(
+                                conversation_id = %self.params.conversation_id,
+                                model_id = %model,
+                                error = %e,
+                                "reconcile_session: set_model hit SessionNotFound; aborting reconcile"
+                            );
+                            return Err(AppError::from(e));
+                        }
                         error!(
                             conversation_id = %self.params.conversation_id,
                             model_id = %model,
@@ -90,6 +120,7 @@ impl AcpAgentManager {
                     }
                     self.commit_session_changes(&mut session).await;
                 }
+
                 ReconcileAction::SetConfigOption { key, value } => {
                     if let Err(err) = self
                         .protocol
@@ -100,7 +131,18 @@ impl AcpAgentManager {
                         ))
                         .await
                     {
+                        if matches!(err, AcpError::SessionNotFound { .. }) {
+                            warn!(
+                                conversation_id = %self.params.conversation_id,
+                                config_id = %key,
+                                desired = %value,
+                                error = %err,
+                                "reconcile_session: set_config_option hit SessionNotFound; aborting reconcile"
+                            );
+                            return Err(AppError::from(err));
+                        }
                         info!(
+                            conversation_id = %self.params.conversation_id,
                             config_id = %key,
                             desired = %value,
                             error = %err,
@@ -117,6 +159,7 @@ impl AcpAgentManager {
                 }
             }
         }
+        Ok(())
     }
 }
 

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -10,6 +10,18 @@ use aionui_common::AppError;
 use serde_json::Value;
 
 use super::agent::sdk_to_snake_value;
+use tracing::warn;
+
+/// True when an `AppError` originates from an ACP `SessionNotFound`
+/// reply. Used to decide whether `open_session_resume` should drop a
+/// stale sid and fall through to `open_session_new` instead of
+/// surfacing the error. The `AcpError::SessionNotFound -> AppError`
+/// converter renders as "Session not found: <sid>", so we match on
+/// that text rather than `AppError::NotFound` alone — other 404 paths
+/// (e.g. "Workspace not found") must not trigger a session rebuild.
+fn is_session_not_found(err: &AppError) -> bool {
+    matches!(err, AppError::NotFound(msg) if msg.starts_with("Session not found"))
+}
 
 impl AcpAgentManager {
     /// Establish a fresh ACP session (session/new) and apply desired
@@ -49,8 +61,30 @@ impl AcpAgentManager {
                 session_id: sid.clone(),
             }));
 
-        self.reconcile_session(&sid).await;
+        // Best-effort reconcile on a freshly-opened session. SessionNotFound
+        // here would be pathological (we just created the session) but is
+        // still surfaced for consistency.
+        self.reconcile_session(&sid).await?;
         Ok(sid)
+    }
+
+    /// Drop the in-aggregate session id and re-run `open_session_new`.
+    /// Used as the rescue path when resume helpers see `SessionNotFound`.
+    /// Emits a `warn!` so ops can still see the original failure that
+    /// triggered the rebuild.
+    async fn rebuild_after_session_not_found(&self, stale_sid: &str, err: &AppError) -> Result<String, AppError> {
+        warn!(
+            conversation_id = %self.params.conversation_id,
+            stale_session_id = %stale_sid,
+            error = %err,
+            "open_session_resume: stale session id rejected by CLI; rebuilding via session/new"
+        );
+        {
+            let mut session = self.session.write().await;
+            session.clear_session_id();
+            self.commit_session_changes(&mut session).await;
+        }
+        self.open_session_new().await
     }
 
     /// Resume an existing ACP session and apply desired mode/model/config.
@@ -59,9 +93,17 @@ impl AcpAgentManager {
     /// - Claude-meta-resume backends: `session/new` with
     ///   `_meta.claudeCode.options.resume`. The CLI may assign a new session id,
     ///   which we persist via `SessionAssigned`.
-    /// - `session/load`-capable backends (e.g. Codex): `session/load`, keep id.
+    /// - `session/load`-capable backends (e.g. Codex, OpenCode): `session/load`,
+    ///   keep id.
     /// - Backends that support neither: seed the aggregate and hope the CLI
     ///   still recognises the id (legacy behaviour — matches pre-refactor).
+    ///
+    /// In all three branches a `SessionNotFound` reply (the persisted sid
+    /// became stale, e.g. after a CLI upgrade or restart) triggers
+    /// `rebuild_after_session_not_found`, which clears the sid and
+    /// re-runs `open_session_new`. ELECTRON-1HQ regressed because we
+    /// silently swallowed this case during warmup, leaving every
+    /// subsequent `session/prompt` to surface the same error to the user.
     pub(super) async fn open_session_resume(&self, session_id: &str) -> Result<String, AppError> {
         if agent_metadata_uses_meta_resume(&self.params.metadata) {
             let mut meta = serde_json::Map::new();
@@ -72,7 +114,13 @@ impl AcpAgentManager {
             meta.insert("claudeCode".into(), Value::Object(claude_code));
 
             let req = self.params.new_session_request().meta(meta);
-            let new_response = self.protocol.new_session(req).await.map_err(AppError::from)?;
+            let new_response = match self.protocol.new_session(req).await.map_err(AppError::from) {
+                Ok(r) => r,
+                Err(e) if is_session_not_found(&e) => {
+                    return self.rebuild_after_session_not_found(session_id, &e).await;
+                }
+                Err(e) => return Err(e),
+            };
             let new_sid = new_response.session_id.to_string();
 
             {
@@ -98,24 +146,34 @@ impl AcpAgentManager {
                     }));
             }
 
-            self.reconcile_session(&new_sid).await;
-            return Ok(new_sid);
+            return match self.reconcile_session(&new_sid).await {
+                Ok(()) => Ok(new_sid),
+                Err(e) if is_session_not_found(&e) => self.rebuild_after_session_not_found(&new_sid, &e).await,
+                Err(e) => Err(e),
+            };
         }
 
-        if self.supports_session_load() {
-            let (preloaded_mode, preloaded_model) = {
-                let session = self.session.read().await;
-                (
-                    session.modes().map(|m| m.current_mode_id.to_string()),
-                    session.model_info().map(|m| m.current_model_id.to_string()),
-                )
-            };
+        let (supports_load, preloaded_mode, preloaded_model) = {
+            let session = self.session.read().await;
+            (
+                session.agent_capabilities().map(|c| c.load_session).unwrap_or(false),
+                session.modes().map(|m| m.current_mode_id.to_string()),
+                session.model_info().map(|m| m.current_model_id.to_string()),
+            )
+        };
 
+        if supports_load {
             let mut load_req = LoadSessionRequest::new(SessionId::new(session_id), &self.params.workspace.path);
             if !self.params.mcp_servers.is_empty() {
                 load_req = load_req.mcp_servers(self.params.mcp_servers.clone());
             }
-            let load_response = self.protocol.load_session(load_req).await.map_err(AppError::from)?;
+            let load_response = match self.protocol.load_session(load_req).await.map_err(AppError::from) {
+                Ok(r) => r,
+                Err(e) if is_session_not_found(&e) => {
+                    return self.rebuild_after_session_not_found(session_id, &e).await;
+                }
+                Err(e) => return Err(e),
+            };
 
             {
                 let mut session = self.session.write().await;
@@ -139,8 +197,11 @@ impl AcpAgentManager {
             }
             self.emit_snapshot_events().await;
 
-            self.reconcile_session(session_id).await;
-            return Ok(session_id.to_owned());
+            return match self.reconcile_session(session_id).await {
+                Ok(()) => Ok(session_id.to_owned()),
+                Err(e) if is_session_not_found(&e) => self.rebuild_after_session_not_found(session_id, &e).await,
+                Err(e) => Err(e),
+            };
         }
 
         // Legacy path: backend advertised neither claude-meta-resume nor
@@ -152,8 +213,11 @@ impl AcpAgentManager {
             self.commit_session_changes(&mut session).await;
         }
         self.emit_snapshot_events().await;
-        self.reconcile_session(session_id).await;
-        Ok(session_id.to_owned())
+        match self.reconcile_session(session_id).await {
+            Ok(()) => Ok(session_id.to_owned()),
+            Err(e) if is_session_not_found(&e) => self.rebuild_after_session_not_found(session_id, &e).await,
+            Err(e) => Err(e),
+        }
     }
 
     /// Send a prompt to an already-established session.
@@ -243,17 +307,6 @@ impl AcpAgentManager {
                 }));
         }
     }
-
-    fn supports_session_load(&self) -> bool {
-        self.params
-            .metadata
-            .handshake
-            .agent_capabilities
-            .as_ref()
-            .and_then(|caps: &Value| caps.get("load_session"))
-            .and_then(|v: &Value| v.as_bool())
-            .unwrap_or(false)
-    }
 }
 
 #[cfg(test)]
@@ -270,9 +323,61 @@ mod tests {
     //! / `open_session_resume` helpers leave behind.
     use crate::manager::acp::{AcpSession, AcpSessionEvent};
     use crate::shared_kernel::SessionId as DomainSessionId;
+    use agent_client_protocol::schema::AgentCapabilities;
 
     fn make_session() -> AcpSession {
         AcpSession::new(None, None, Default::default())
+    }
+
+    /// `open_session_resume` reads `session.agent_capabilities().load_session`
+    /// to decide between `session/load` and the legacy seed-and-pray path.
+    /// Reading from the SDK-typed advertised capabilities (instead of poking
+    /// at the persisted handshake JSON) is the contract that ELECTRON-1HQ
+    /// regressed against — OpenCode advertises `loadSession: true` on the
+    /// wire, the SDK exposes it as `load_session: true`, but the old code
+    /// looked up the snake-cased key in a JSON blob that hadn't always been
+    /// written yet. Pin the contract: once the CLI has handshaken, the
+    /// advertised slot must be populated and read back as the source of
+    /// truth.
+    #[test]
+    fn advertised_capabilities_drives_supports_session_load() {
+        let mut session = make_session();
+        assert!(
+            session.agent_capabilities().is_none(),
+            "precondition: capabilities unset until init handshake completes"
+        );
+
+        // After `apply_advertised_capabilities` the resume path can answer
+        // the question without consulting the persisted catalog row.
+        let mut caps = AgentCapabilities::new();
+        caps.load_session = true;
+        session.apply_advertised_capabilities(caps);
+
+        let supports_load = session.agent_capabilities().map(|c| c.load_session).unwrap_or(false);
+        assert!(
+            supports_load,
+            "OpenCode-style `loadSession: true` handshake must enable session/load"
+        );
+    }
+
+    #[test]
+    fn missing_capability_means_no_session_load() {
+        let session = make_session();
+        let supports_load = session.agent_capabilities().map(|c| c.load_session).unwrap_or(false);
+        assert!(
+            !supports_load,
+            "without an init handshake the resume path must not call session/load"
+        );
+    }
+
+    #[test]
+    fn capability_load_session_false_means_no_session_load() {
+        let mut session = make_session();
+        let caps = AgentCapabilities::new();
+        // Default is load_session = false; assert reading it back agrees.
+        session.apply_advertised_capabilities(caps);
+        let supports_load = session.agent_capabilities().map(|c| c.load_session).unwrap_or(false);
+        assert!(!supports_load);
     }
 
     /// Simulate the aggregate-state effect of a successful warmup that
@@ -333,5 +438,48 @@ mod tests {
             session.drain_events().is_empty(),
             "second warmup must not emit duplicate domain events"
         );
+    }
+
+    /// `rebuild_after_session_not_found` relies on `clear_session_id`
+    /// resetting both the sid and the `opened` flag, so the subsequent
+    /// `ensure_session_opened` re-enters the `(None, _)` branch and
+    /// calls `open_session_new`. Pin both invariants — without the
+    /// `opened = false` reset, the rescue path would land in the
+    /// `(Some, true)` no-op branch and the next prompt would still hit
+    /// the dead session.
+    #[test]
+    fn clear_session_id_resets_sid_and_opened() {
+        let mut session = make_session();
+        session.set_session_id(DomainSessionId::new("ses-stale"));
+        session.mark_opened();
+        assert!(session.is_opened());
+        assert_eq!(session.session_id(), Some("ses-stale"));
+
+        session.clear_session_id();
+
+        assert_eq!(session.session_id(), None, "stale sid must be dropped");
+        assert!(
+            !session.is_opened(),
+            "rebuild requires re-running open_session_new — opened must reset"
+        );
+    }
+
+    /// The `is_session_not_found` discriminator powers
+    /// `open_session_resume`'s rescue path. Match strictly on the
+    /// `AcpError::SessionNotFound -> AppError::NotFound` rendering;
+    /// other 404s (e.g. workspace lookup) must surface to callers
+    /// instead of triggering a phantom session rebuild.
+    #[test]
+    fn is_session_not_found_matches_session_not_found_only() {
+        use aionui_common::AppError;
+
+        let session_err = AppError::NotFound("Session not found: ses-1".into());
+        assert!(super::is_session_not_found(&session_err));
+
+        let workspace_err = AppError::NotFound("Workspace not found".into());
+        assert!(!super::is_session_not_found(&workspace_err));
+
+        let bad_request = AppError::BadRequest("anything".into());
+        assert!(!super::is_session_not_found(&bad_request));
     }
 }

--- a/crates/aionui-ai-agent/src/manager/acp/session.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session.rs
@@ -122,6 +122,17 @@ impl AcpSession {
             .push(AcpSessionEvent::SessionAssigned { session_id: sid });
     }
 
+    /// Drop a stale session id so the aggregate can be re-seeded with a
+    /// freshly-issued one. Used when the CLI rejects the persisted sid
+    /// with `SessionNotFound` (ELECTRON-1HQ): the resume helpers fall
+    /// back to `open_session_new`, which calls `set_session_id` again.
+    /// Also clears the `opened` flag so the next `ensure_session_opened`
+    /// goes down the "no sid" branch instead of the "sid+opened" no-op.
+    pub fn clear_session_id(&mut self) {
+        self.session_id = None;
+        self.opened = false;
+    }
+
     pub fn is_opened(&self) -> bool {
         self.opened
     }

--- a/crates/aionui-ai-agent/src/protocol/error.rs
+++ b/crates/aionui-ai-agent/src/protocol/error.rs
@@ -151,7 +151,13 @@ impl AcpError {
 
     /// Convert an SDK [`Error`](SdkError) into an [`AcpError`].
     ///
-    /// Mapping is by [`ErrorCode`], never by message text.
+    /// Mapping is by [`ErrorCode`], never by message text. The single
+    /// exception is `data.error == "Session not found: ..."`: OpenCode
+    /// (and likely others) return a stale-session failure as
+    /// `code = InvalidParams (-32602)` with the real reason buried in
+    /// the `data` field, so we re-classify those into `SessionNotFound`
+    /// to keep crash detection / recovery paths uniform across agents.
+    /// See ELECTRON-1HQ.
     /// `context` carries the session ID or method name for diagnostics.
     pub fn from_sdk(err: SdkError, context: &str) -> Self {
         match err.code {
@@ -162,12 +168,24 @@ impl AcpError {
             ErrorCode::MethodNotFound => AcpError::MethodNotFound {
                 method: context.to_owned(),
             },
-            ErrorCode::InvalidParams => AcpError::InvalidParams { message: err.message },
-            ErrorCode::ParseError | ErrorCode::InvalidRequest | ErrorCode::InternalError => AcpError::AgentInternal {
-                message: err.message,
-                code: i32::from(err.code),
-                data: err.data,
-            },
+            ErrorCode::InvalidParams => {
+                if let Some(sid) = extract_session_not_found(err.data.as_ref()) {
+                    AcpError::SessionNotFound { session_id: sid }
+                } else {
+                    AcpError::InvalidParams { message: err.message }
+                }
+            }
+            ErrorCode::ParseError | ErrorCode::InvalidRequest | ErrorCode::InternalError => {
+                if let Some(sid) = extract_session_not_found(err.data.as_ref()) {
+                    AcpError::SessionNotFound { session_id: sid }
+                } else {
+                    AcpError::AgentInternal {
+                        message: err.message,
+                        code: i32::from(err.code),
+                        data: err.data,
+                    }
+                }
+            }
             _ => {
                 let code = i32::from(err.code);
                 // -32001, -32002: additional session-not-found codes used by some agents
@@ -175,6 +193,8 @@ impl AcpError {
                     AcpError::SessionNotFound {
                         session_id: context.to_owned(),
                     }
+                } else if let Some(sid) = extract_session_not_found(err.data.as_ref()) {
+                    AcpError::SessionNotFound { session_id: sid }
                 } else {
                     AcpError::AgentInternal {
                         message: err.message,
@@ -185,6 +205,24 @@ impl AcpError {
             }
         }
     }
+}
+
+/// If `data` carries a `{"error": "Session not found: <sid>"}` payload
+/// (either as a JSON object or as a JSON-string-of-JSON, which is what
+/// OpenCode actually emits — see ELECTRON-1HQ), return the session id.
+/// Returns `None` for any other shape so callers can fall through to
+/// the default `code`-based mapping.
+fn extract_session_not_found(data: Option<&serde_json::Value>) -> Option<String> {
+    let value = data?;
+    let obj = match value {
+        serde_json::Value::Object(_) => value.clone(),
+        serde_json::Value::String(s) => serde_json::from_str(s).ok()?,
+        _ => return None,
+    };
+    let msg = obj.get("error")?.as_str()?;
+    let prefix = "Session not found: ";
+    let sid = msg.strip_prefix(prefix)?.trim();
+    if sid.is_empty() { None } else { Some(sid.to_owned()) }
 }
 
 /// Conversion from [`AcpError`] to [`AppError`] — the only way `AcpError`
@@ -311,6 +349,65 @@ mod tests {
     fn from_sdk_invalid_params() {
         let sdk_err = SdkError::invalid_params();
         let acp = AcpError::from_sdk(sdk_err, "ignored");
+        assert!(matches!(acp, AcpError::InvalidParams { .. }));
+    }
+
+    /// OpenCode reports a stale session as
+    /// `code: -32602 InvalidParams` with the real reason wrapped in a
+    /// JSON-string `data` payload (see ELECTRON-1HQ wire dump). Re-classify
+    /// to `SessionNotFound` so downstream crash detection /
+    /// recovery treats it uniformly with agents that return -32600 / -32001.
+    #[test]
+    fn from_sdk_invalid_params_with_session_not_found_data() {
+        let sdk_err = SdkError::invalid_params().data(serde_json::Value::String(
+            r#"{"error":"Session not found: ses_21859c95dffefejNiDf1VYXMgU"}"#.to_owned(),
+        ));
+        let acp = AcpError::from_sdk(sdk_err, "session/set_mode");
+        match acp {
+            AcpError::SessionNotFound { session_id } => {
+                assert_eq!(session_id, "ses_21859c95dffefejNiDf1VYXMgU");
+            }
+            other => panic!("expected SessionNotFound, got {other:?}"),
+        }
+    }
+
+    /// Object-shaped data should also be recognised — some agents skip the
+    /// extra string-encoding round-trip and emit a JSON object directly.
+    #[test]
+    fn from_sdk_invalid_params_with_object_data_session_not_found() {
+        let sdk_err = SdkError::invalid_params().data(serde_json::json!({
+            "error": "Session not found: sess-direct"
+        }));
+        let acp = AcpError::from_sdk(sdk_err, "ctx");
+        match acp {
+            AcpError::SessionNotFound { session_id } => assert_eq!(session_id, "sess-direct"),
+            other => panic!("expected SessionNotFound, got {other:?}"),
+        }
+    }
+
+    /// Internal-error code carrying the same payload should also re-classify;
+    /// don't tie the rescue to any single `ErrorCode`.
+    #[test]
+    fn from_sdk_internal_with_session_not_found_data() {
+        let sdk_err = SdkError::internal_error().data(serde_json::json!({
+            "error": "Session not found: sess-ie"
+        }));
+        let acp = AcpError::from_sdk(sdk_err, "ctx");
+        match acp {
+            AcpError::SessionNotFound { session_id } => assert_eq!(session_id, "sess-ie"),
+            other => panic!("expected SessionNotFound, got {other:?}"),
+        }
+    }
+
+    /// Unrelated `data` payloads must not trigger the rescue path —
+    /// otherwise we'd silently rewrite `InvalidParams` for genuinely
+    /// malformed requests.
+    #[test]
+    fn from_sdk_invalid_params_with_unrelated_data_stays_invalid_params() {
+        let sdk_err = SdkError::invalid_params().data(serde_json::json!({
+            "error": "Workspace path must be absolute"
+        }));
+        let acp = AcpError::from_sdk(sdk_err, "ctx");
         assert!(matches!(acp, AcpError::InvalidParams { .. }));
     }
 


### PR DESCRIPTION
## Summary

OpenCode (and any `session/load`-capable agent) returns a stale-session failure as `code: -32602 InvalidParams` with the real reason in `data.error: "Session not found: <sid>"`. We silently swallowed this during `warmup_session`, so every subsequent `session/prompt` surfaced the same error to the user — the user-facing symptom of [ELECTRON-1HQ](https://iofficeai.sentry.io/issues/122207067/) is "更新之后便无法对话".

Three layers of fix:

- **Capability detection (root cause)** — `supports_session_load` now reads `session.agent_capabilities().load_session` (SDK-typed field) instead of poking at the persisted handshake JSON for a snake-cased `load_session` key. The catalog write is async, so the JSON path lost the race for at least one warmup; reading the SDK field is timing-independent.
- **Error classification (defence in depth)** — `AcpError::from_sdk` now re-classifies any `data.error: "Session not found: <sid>"` payload (object or string-of-JSON, OpenCode emits the latter) to `AcpError::SessionNotFound`, regardless of the wrapper `ErrorCode`.
- **Recovery (user-visible fix)** — `reconcile_session` now returns `Result`, and `open_session_resume`'s three branches (meta-resume / `session/load` / legacy) drop the stale sid via the new `clear_session_id` and re-run `open_session_new` whenever they hit `SessionNotFound`. `PUT /mode` and `PUT /model` keep best-effort semantics because the desired layer is already updated, so the next `ensure_session_opened` will reconcile.

9 new tests cover capability detection (advertised set / unset / `load_session=false`), wire-shape variations of the rescue payload (object / string-of-JSON / `AgentInternal` / unrelated payload stays put), and the rebuild invariants (`clear_session_id` resets both sid and `opened`; `is_session_not_found` rejects unrelated 404s).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p aionui-ai-agent --tests -- -D warnings`
- [x] `cargo test -p aionui-ai-agent --lib` — 406 passed
- [x] `just push` full workspace gate — 5593 passed, 18 skipped (pre-existing)
- [ ] Manual repro on a stale OpenCode session (next time we have a Windows tester handy)