### PR TITLE
fix(realtime): forward id and read nested data in subscribe-show-open

### DIFF
--- a/crates/aionui-app/tests/websocket_e2e.rs
+++ b/crates/aionui-app/tests/websocket_e2e.rs
@@ -412,12 +412,13 @@ async fn t5_2_subscribe_show_open_file_mode() {
 
     let payload = json!({
         "name": "subscribe-show-open",
-        "data": {"properties": ["openFile"]}
+        "data": {"id": "req-file", "data": {"properties": ["openFile"]}}
     });
     tx.send(send_json(&payload.to_string())).await.unwrap();
 
     let msg = read_text(&mut rx).await;
     assert_eq!(msg["name"], "show-open-request");
+    assert_eq!(msg["data"]["id"], "req-file");
     assert_eq!(msg["data"]["isFileMode"], true);
     assert_eq!(msg["data"]["properties"], json!(["openFile"]));
 }
@@ -432,12 +433,13 @@ async fn t5_3_subscribe_show_open_directory_mode() {
 
     let payload = json!({
         "name": "subscribe-show-open",
-        "data": {"properties": ["openDirectory"]}
+        "data": {"id": "req-dir", "data": {"properties": ["openDirectory"]}}
     });
     tx.send(send_json(&payload.to_string())).await.unwrap();
 
     let msg = read_text(&mut rx).await;
     assert_eq!(msg["name"], "show-open-request");
+    assert_eq!(msg["data"]["id"], "req-dir");
     assert_eq!(msg["data"]["isFileMode"], false);
 }
 
@@ -451,12 +453,13 @@ async fn t5_4_subscribe_show_open_mixed_mode() {
 
     let payload = json!({
         "name": "subscribe-show-open",
-        "data": {"properties": ["openFile", "openDirectory"]}
+        "data": {"id": "req-mixed", "data": {"properties": ["openFile", "openDirectory"]}}
     });
     tx.send(send_json(&payload.to_string())).await.unwrap();
 
     let msg = read_text(&mut rx).await;
     assert_eq!(msg["name"], "show-open-request");
+    assert_eq!(msg["data"]["id"], "req-mixed");
     assert_eq!(msg["data"]["isFileMode"], false);
 }
 

--- a/crates/aionui-realtime/src/handler.rs
+++ b/crates/aionui-realtime/src/handler.rs
@@ -212,10 +212,23 @@ fn send_error_response(state: &WsHandlerState, conn_id: ConnectionId) {
 
 /// Handle `subscribe-show-open`: reply with `show-open-request`.
 ///
+/// The inbound `data` is the @office-ai/platform bridge envelope
+/// `{ id, data: <user-params> }`. The renderer awaits a callback whose event
+/// name embeds `id` (`subscribe.callback-show-open<id>`), so we must echo it
+/// back; without it, the frontend's `useDirectorySelection` hook builds the
+/// wrong callback name and the original `invoke()` Promise never resolves.
+///
 /// `isFileMode` is `true` when `properties` contains `openFile`
 /// but NOT `openDirectory`.
 fn handle_subscribe_show_open(state: &WsHandlerState, conn_id: ConnectionId, data: Value) {
-    let properties = data
+    let id = data
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_owned();
+    let inner = data.get("data").unwrap_or(&Value::Null);
+
+    let properties = inner
         .get("properties")
         .and_then(|v| v.as_array())
         .cloned()
@@ -229,6 +242,7 @@ fn handle_subscribe_show_open(state: &WsHandlerState, conn_id: ConnectionId, dat
     let response = WebSocketMessage::new(
         "show-open-request",
         json!({
+            "id": id,
             "properties": properties,
             "isFileMode": is_file_mode,
         }),
@@ -257,7 +271,7 @@ mod tests {
         let conn_id = manager.add_client("tok".into(), tx);
         let state = test_state(manager);
 
-        let data = json!({"properties": ["openFile"]});
+        let data = json!({"id": "abc123", "data": {"properties": ["openFile"]}});
         handle_subscribe_show_open(&state, conn_id, data);
 
         let msg = rx.try_recv().unwrap();
@@ -265,6 +279,7 @@ mod tests {
             WsOutbound::Text(text) => {
                 let parsed: Value = serde_json::from_str(&text).unwrap();
                 assert_eq!(parsed["name"], "show-open-request");
+                assert_eq!(parsed["data"]["id"], "abc123");
                 assert_eq!(parsed["data"]["isFileMode"], true);
                 assert_eq!(parsed["data"]["properties"], json!(["openFile"]));
             }
@@ -279,13 +294,14 @@ mod tests {
         let conn_id = manager.add_client("tok".into(), tx);
         let state = test_state(manager);
 
-        let data = json!({"properties": ["openDirectory"]});
+        let data = json!({"id": "dir1", "data": {"properties": ["openDirectory"]}});
         handle_subscribe_show_open(&state, conn_id, data);
 
         let msg = rx.try_recv().unwrap();
         match msg {
             WsOutbound::Text(text) => {
                 let parsed: Value = serde_json::from_str(&text).unwrap();
+                assert_eq!(parsed["data"]["id"], "dir1");
                 assert_eq!(parsed["data"]["isFileMode"], false);
             }
             _ => panic!("expected Text"),
@@ -299,13 +315,14 @@ mod tests {
         let conn_id = manager.add_client("tok".into(), tx);
         let state = test_state(manager);
 
-        let data = json!({"properties": ["openFile", "openDirectory"]});
+        let data = json!({"id": "mixed", "data": {"properties": ["openFile", "openDirectory"]}});
         handle_subscribe_show_open(&state, conn_id, data);
 
         let msg = rx.try_recv().unwrap();
         match msg {
             WsOutbound::Text(text) => {
                 let parsed: Value = serde_json::from_str(&text).unwrap();
+                assert_eq!(parsed["data"]["id"], "mixed");
                 assert_eq!(parsed["data"]["isFileMode"], false);
             }
             _ => panic!("expected Text"),
@@ -319,13 +336,14 @@ mod tests {
         let conn_id = manager.add_client("tok".into(), tx);
         let state = test_state(manager);
 
-        let data = json!({"properties": []});
+        let data = json!({"id": "empty", "data": {"properties": []}});
         handle_subscribe_show_open(&state, conn_id, data);
 
         let msg = rx.try_recv().unwrap();
         match msg {
             WsOutbound::Text(text) => {
                 let parsed: Value = serde_json::from_str(&text).unwrap();
+                assert_eq!(parsed["data"]["id"], "empty");
                 assert_eq!(parsed["data"]["isFileMode"], false);
             }
             _ => panic!("expected Text"),
@@ -339,12 +357,34 @@ mod tests {
         let conn_id = manager.add_client("tok".into(), tx);
         let state = test_state(manager);
 
+        handle_subscribe_show_open(&state, conn_id, json!({"id": "noprops", "data": {}}));
+
+        let msg = rx.try_recv().unwrap();
+        match msg {
+            WsOutbound::Text(text) => {
+                let parsed: Value = serde_json::from_str(&text).unwrap();
+                assert_eq!(parsed["data"]["id"], "noprops");
+                assert_eq!(parsed["data"]["isFileMode"], false);
+                assert_eq!(parsed["data"]["properties"], json!([]));
+            }
+            _ => panic!("expected Text"),
+        }
+    }
+
+    #[test]
+    fn subscribe_show_open_missing_id_falls_back_to_empty_string() {
+        let manager = Arc::new(WebSocketManager::new());
+        let (tx, mut rx) = mpsc::channel(PER_CONNECTION_BUFFER);
+        let conn_id = manager.add_client("tok".into(), tx);
+        let state = test_state(manager);
+
         handle_subscribe_show_open(&state, conn_id, json!({}));
 
         let msg = rx.try_recv().unwrap();
         match msg {
             WsOutbound::Text(text) => {
                 let parsed: Value = serde_json::from_str(&text).unwrap();
+                assert_eq!(parsed["data"]["id"], "");
                 assert_eq!(parsed["data"]["isFileMode"], false);
                 assert_eq!(parsed["data"]["properties"], json!([]));
             }

--- a/crates/aionui-realtime/src/handler.rs
+++ b/crates/aionui-realtime/src/handler.rs
@@ -221,11 +221,7 @@ fn send_error_response(state: &WsHandlerState, conn_id: ConnectionId) {
 /// `isFileMode` is `true` when `properties` contains `openFile`
 /// but NOT `openDirectory`.
 fn handle_subscribe_show_open(state: &WsHandlerState, conn_id: ConnectionId, data: Value) {
-    let id = data
-        .get("id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_owned();
+    let id = data.get("id").and_then(|v| v.as_str()).unwrap_or("").to_owned();
     let inner = data.get("data").unwrap_or(&Value::Null);
 
     let properties = inner

--- a/crates/aionui-realtime/tests/handler_integration.rs
+++ b/crates/aionui-realtime/tests/handler_integration.rs
@@ -219,11 +219,17 @@ async fn subscribe_show_open_replies_with_show_open_request() {
     let (mut tx, mut rx) = connect_with_token(addr, "valid-token").await;
     tokio::time::sleep(Duration::from_millis(50)).await;
 
-    let payload = json!({"name": "subscribe-show-open", "data": {"properties": ["openFile"]}});
+    // Mirrors the @office-ai/platform bridge envelope shape produced by
+    // `invoke('show-open', { properties: ['openFile'] })`.
+    let payload = json!({
+        "name": "subscribe-show-open",
+        "data": {"id": "abc123", "data": {"properties": ["openFile"]}}
+    });
     tx.send(send_json(&payload.to_string())).await.unwrap();
 
     let msg = read_text(&mut rx).await;
     assert_eq!(msg["name"], "show-open-request");
+    assert_eq!(msg["data"]["id"], "abc123");
     assert_eq!(msg["data"]["isFileMode"], true);
     assert_eq!(msg["data"]["properties"], json!(["openFile"]));
 }
@@ -238,12 +244,13 @@ async fn subscribe_show_open_directory_mode() {
 
     let payload = json!({
         "name": "subscribe-show-open",
-        "data": {"properties": ["openFile", "openDirectory"]}
+        "data": {"id": "dir1", "data": {"properties": ["openFile", "openDirectory"]}}
     });
     tx.send(send_json(&payload.to_string())).await.unwrap();
 
     let msg = read_text(&mut rx).await;
     assert_eq!(msg["name"], "show-open-request");
+    assert_eq!(msg["data"]["id"], "dir1");
     assert_eq!(msg["data"]["isFileMode"], false);
 }
 


### PR DESCRIPTION
## Summary

- Fix `handle_subscribe_show_open` to match the @office-ai/platform bridge envelope: read `properties` from `data.data.properties` (nested) instead of `data.properties` (top-level), and forward the request `id` on the `show-open-request` response so the frontend's callback event name resolves correctly.
- Update the 6 existing unit tests + 2 integration tests to use the envelope shape, and add a 7th unit test covering the missing-id fallback to empty string.

## Why

The frontend `useDirectorySelection` hook (`packages/desktop/src/renderer/hooks/...`) builds the callback event name as `` `subscribe.callback-show-open${id}` ``. Without `id` echoed back, the name becomes `subscribe.callback-show-openundefined`, the original `invoke()` Promise never resolves, and WebUI directory selection silently hangs forever. AionUi's `conversation.create` then ships `workspace: ''` and the picked path is lost.

The Electron desktop path uses native IPC (`process/bridge/dialogBridge.ts`) and never reaches this handler, so this change does not affect desktop builds.

## Test plan

- [x] `cargo test -p aionui-realtime` — 13 unit tests + 14 integration tests + 9 manager tests all pass
- [x] Manual end-to-end with the matching AionUi PR: WebUI guid page → "Work in project" → pick directory → start conversation → workspace pill shows the chosen directory

## Frontend PR

iOfficeAI/AionUi#3005 — drops the `isElectron` guard on the workspace footnote and bumps `aioncoreVersion` once this PR is released.

Closes #322.