### PR TITLE
Fix idempotent conversation cancel

### DIFF
--- a/crates/aionui-app/tests/auxiliary_e2e.rs
+++ b/crates/aionui-app/tests/auxiliary_e2e.rs
@@ -333,7 +333,7 @@ async fn check_approval_no_task() {
     assert_eq!(json["data"]["approved"], false);
 }
 
-// ── Stop + Warmup (no active task → error) ────────────────────
+// ── Stop + Warmup (no active task → idempotent success) ───────
 
 #[tokio::test]
 async fn stop_stream_no_task() {
@@ -349,6 +349,6 @@ async fn stop_stream_no_task() {
         &csrf,
     );
     let resp = app.oneshot(req).await.unwrap();
-    // Stop with no active agent → 409 Conflict
-    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    // Stop with no active agent is idempotent.
+    assert_eq!(resp.status(), StatusCode::OK);
 }

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -1191,9 +1191,10 @@ impl ConversationService {
             .filter(|r| r.user_id == user_id)
             .ok_or_else(|| AppError::NotFound(format!("Conversation {conversation_id} not found")))?;
 
-        let agent = task_manager
-            .get_task(conversation_id)
-            .ok_or_else(|| AppError::Conflict("No active agent for this conversation".into()))?;
+        let Some(agent) = task_manager.get_task(conversation_id) else {
+            info!("No active agent to cancel; treating as idempotent success");
+            return Ok(());
+        };
 
         if let Err(e) = agent.cancel().await {
             warn!(error = %ErrorChain(&e), "Failed to cancel agent");

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1675,14 +1675,14 @@ async fn stop_stream_conversation_not_found() {
 }
 
 #[tokio::test]
-async fn stop_stream_no_active_agent_returns_conflict() {
+async fn stop_stream_no_active_agent_is_idempotent() {
     let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
 
-    let err = svc.cancel("user_1", &conv.id, &task_mgr).await.unwrap_err();
-    assert!(matches!(err, AppError::Conflict(_)));
+    let result = svc.cancel("user_1", &conv.id, &task_mgr).await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Treat cancel requests with no active agent as an idempotent success after verifying conversation ownership
- Update service and HTTP E2E tests to expect success for no-op cancel

## Verification
- cargo test -p aionui-conversation stop_stream_no_active_agent_is_idempotent
- cargo test -p aionui-app stop_stream_no_task
- cargo test -p aionui-conversation stop_stream_
- cargo fmt --all -- --check
- cargo clippy -p aionui-conversation -p aionui-app -- -D warnings
- cargo test -p aionui-conversation -p aionui-app
- just push -u origin fix/cancel-idempotent