### PR TITLE
fix(acp): load user MCP servers and emit empty-finish diagnostic (ELECTRON-1JG)

### DIFF
--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -6,9 +6,12 @@ use crate::factory::acp_assembler::{WorkspaceInfo, assemble_acp_params};
 use crate::factory::context::FactoryContext;
 use crate::manager::acp::{AcpAgentManager, CatalogForwarder};
 use crate::types::BuildTaskOptions;
+use agent_client_protocol::schema::{EnvVariable, HttpHeader, McpServer, McpServerHttp, McpServerSse, McpServerStdio};
 use aionui_api_types::AcpBuildExtra;
 use aionui_common::{AppError, CommandSpec};
-use tracing::{debug, info};
+use aionui_db::IMcpServerRepository;
+use aionui_db::models::McpServerRow;
+use tracing::{debug, info, warn};
 
 pub(super) async fn build(
     deps: Arc<AgentFactoryDeps>,
@@ -113,6 +116,15 @@ pub(super) async fn build(
     };
     let session_snapshot = deps.acp_agent_service.load_snapshot_state(&ctx.conversation_id).await;
 
+    // Load user-configured MCP servers from the DB so they reach
+    // ACP `session/new` mcpServers payload. Without this the agent
+    // starts with zero MCP tools even when the user configured them
+    // via Settings → MCP (ELECTRON-1JG).
+    let user_mcp_servers = match deps.mcp_server_repo.as_ref() {
+        Some(repo) => load_user_mcp_servers(repo.as_ref(), &ctx.conversation_id).await,
+        None => Vec::new(),
+    };
+
     let params = Arc::new(
         assemble_acp_params(
             ctx.conversation_id.clone(),
@@ -123,6 +135,7 @@ pub(super) async fn build(
             meta,
             command_spec,
             config,
+            user_mcp_servers,
             session_snapshot,
             deps.data_dir.clone(),
         )
@@ -165,4 +178,339 @@ pub(super) async fn build(
     deps.acp_agent_service.attach(ctx.conversation_id, domain_rx).await;
 
     Ok(instance)
+}
+
+/// Load the operator's enabled MCP servers from the DB, log+skip any rows
+/// whose `transport_config` JSON fails to parse (better to start without one
+/// MCP tool than fail the whole session), and return them in SDK shape ready
+/// for `NewSessionRequest::mcp_servers`.
+///
+/// Skips disabled and builtin rows: builtins are wired through other paths
+/// (e.g. team/guide MCP) and the user can't manage them directly.
+async fn load_user_mcp_servers(repo: &dyn IMcpServerRepository, conversation_id: &str) -> Vec<McpServer> {
+    let rows = match repo.list().await {
+        Ok(r) => r,
+        Err(err) => {
+            warn!(
+                conversation_id,
+                error = %err,
+                "user_mcp: list() failed; skipping injection"
+            );
+            return Vec::new();
+        }
+    };
+
+    let mut servers = Vec::with_capacity(rows.len());
+    for row in rows {
+        if !row.enabled || row.builtin {
+            continue;
+        }
+        match row_to_sdk_mcp_server(&row) {
+            Ok(server) => servers.push(server),
+            Err(err) => {
+                warn!(
+                    conversation_id,
+                    server_id = %row.id,
+                    server_name = %row.name,
+                    error = %err,
+                    "user_mcp: failed to convert row; skipping"
+                );
+            }
+        }
+    }
+
+    if !servers.is_empty() {
+        info!(
+            conversation_id,
+            count = servers.len(),
+            "user_mcp: injected into session/new"
+        );
+    }
+    servers
+}
+
+/// Convert an `McpServerRow` into the SDK `McpServer` shape used by
+/// `NewSessionRequest::mcp_servers`. Returns an error string when
+/// `transport_config` is malformed or required fields are missing.
+fn row_to_sdk_mcp_server(row: &McpServerRow) -> Result<McpServer, String> {
+    let value: serde_json::Value =
+        serde_json::from_str(&row.transport_config).map_err(|e| format!("invalid transport_config JSON: {e}"))?;
+
+    match row.transport_type.as_str() {
+        "stdio" => {
+            let command = value
+                .get("command")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "stdio: missing command".to_owned())?;
+            let args: Vec<String> = value
+                .get("args")
+                .and_then(|v| v.as_array())
+                .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+                .unwrap_or_default();
+            let env: Vec<EnvVariable> = value
+                .get("env")
+                .and_then(|v| v.as_object())
+                .map(|obj| {
+                    let mut entries: Vec<(String, String)> = obj
+                        .iter()
+                        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_owned())))
+                        .collect();
+                    // Sort for deterministic ordering across runs.
+                    entries.sort_by(|a, b| a.0.cmp(&b.0));
+                    entries.into_iter().map(|(k, v)| EnvVariable::new(k, v)).collect()
+                })
+                .unwrap_or_default();
+
+            let stdio = McpServerStdio::new(row.name.clone(), command).args(args).env(env);
+            Ok(McpServer::Stdio(stdio))
+        }
+        "http" => {
+            let url = value
+                .get("url")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "http: missing url".to_owned())?;
+            let headers = parse_headers(value.get("headers"));
+            Ok(McpServer::Http(
+                McpServerHttp::new(row.name.clone(), url).headers(headers),
+            ))
+        }
+        "sse" => {
+            let url = value
+                .get("url")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "sse: missing url".to_owned())?;
+            let headers = parse_headers(value.get("headers"));
+            Ok(McpServer::Sse(
+                McpServerSse::new(row.name.clone(), url).headers(headers),
+            ))
+        }
+        other => Err(format!("unknown transport type: {other}")),
+    }
+}
+
+fn parse_headers(value: Option<&serde_json::Value>) -> Vec<HttpHeader> {
+    let Some(obj) = value.and_then(|v| v.as_object()) else {
+        return Vec::new();
+    };
+    let mut entries: Vec<(String, String)> = obj
+        .iter()
+        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_owned())))
+        .collect();
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries.into_iter().map(|(k, v)| HttpHeader::new(k, v)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_row(
+        name: &str,
+        transport_type: &str,
+        transport_config: &str,
+        enabled: bool,
+        builtin: bool,
+    ) -> McpServerRow {
+        McpServerRow {
+            id: format!("mcp_{name}"),
+            name: name.to_owned(),
+            description: None,
+            enabled,
+            transport_type: transport_type.into(),
+            transport_config: transport_config.into(),
+            tools: None,
+            status: "disconnected".into(),
+            last_connected: None,
+            original_json: None,
+            builtin,
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    #[test]
+    fn row_to_sdk_stdio_roundtrip() {
+        let row = make_row(
+            "ctx7",
+            "stdio",
+            r#"{"command":"npx","args":["-y","@upstash/context7-mcp"],"env":{"K":"V"}}"#,
+            true,
+            false,
+        );
+        let server = row_to_sdk_mcp_server(&row).expect("convert");
+        match server {
+            McpServer::Stdio(s) => {
+                assert_eq!(s.name, "ctx7");
+                assert_eq!(s.command.to_string_lossy(), "npx");
+                assert_eq!(s.args, vec!["-y".to_owned(), "@upstash/context7-mcp".to_owned()]);
+                assert_eq!(s.env.len(), 1);
+                assert_eq!(s.env[0].name, "K");
+                assert_eq!(s.env[0].value, "V");
+            }
+            _ => panic!("expected Stdio"),
+        }
+    }
+
+    #[test]
+    fn row_to_sdk_http_with_headers() {
+        let row = make_row(
+            "remote",
+            "http",
+            r#"{"url":"https://example.com/mcp","headers":{"Authorization":"Bearer tok"}}"#,
+            true,
+            false,
+        );
+        let server = row_to_sdk_mcp_server(&row).expect("convert");
+        match server {
+            McpServer::Http(h) => {
+                assert_eq!(h.name, "remote");
+                assert_eq!(h.url, "https://example.com/mcp");
+                assert_eq!(h.headers.len(), 1);
+                assert_eq!(h.headers[0].name, "Authorization");
+                assert_eq!(h.headers[0].value, "Bearer tok");
+            }
+            _ => panic!("expected Http"),
+        }
+    }
+
+    #[test]
+    fn row_to_sdk_unknown_transport_type_errors() {
+        let row = make_row("bad", "websocket", "{}", true, false);
+        assert!(row_to_sdk_mcp_server(&row).is_err());
+    }
+
+    #[test]
+    fn row_to_sdk_invalid_json_errors() {
+        let row = make_row("bad", "stdio", "not-json", true, false);
+        assert!(row_to_sdk_mcp_server(&row).is_err());
+    }
+
+    #[test]
+    fn row_to_sdk_stdio_missing_command_errors() {
+        let row = make_row("bad", "stdio", r#"{"args":[]}"#, true, false);
+        assert!(row_to_sdk_mcp_server(&row).is_err());
+    }
+
+    // -- load_user_mcp_servers integration -----------------------------------
+
+    use async_trait::async_trait;
+    use std::sync::Arc;
+
+    struct MockRepo {
+        rows: Vec<McpServerRow>,
+        fail: bool,
+    }
+
+    #[async_trait]
+    impl IMcpServerRepository for MockRepo {
+        async fn list(&self) -> Result<Vec<McpServerRow>, aionui_db::DbError> {
+            if self.fail {
+                Err(aionui_db::DbError::Init("simulated".into()))
+            } else {
+                Ok(self.rows.clone())
+            }
+        }
+        async fn find_by_id(&self, _id: &str) -> Result<Option<McpServerRow>, aionui_db::DbError> {
+            unimplemented!()
+        }
+        async fn find_by_name(&self, _name: &str) -> Result<Option<McpServerRow>, aionui_db::DbError> {
+            unimplemented!()
+        }
+        async fn create(
+            &self,
+            _params: aionui_db::CreateMcpServerParams<'_>,
+        ) -> Result<McpServerRow, aionui_db::DbError> {
+            unimplemented!()
+        }
+        async fn update(
+            &self,
+            _id: &str,
+            _params: aionui_db::UpdateMcpServerParams<'_>,
+        ) -> Result<McpServerRow, aionui_db::DbError> {
+            unimplemented!()
+        }
+        async fn delete(&self, _id: &str) -> Result<(), aionui_db::DbError> {
+            unimplemented!()
+        }
+        async fn batch_upsert(
+            &self,
+            _servers: &[aionui_db::CreateMcpServerParams<'_>],
+        ) -> Result<Vec<McpServerRow>, aionui_db::DbError> {
+            unimplemented!()
+        }
+        async fn update_status(
+            &self,
+            _id: &str,
+            _status: &str,
+            _last_connected: Option<aionui_common::TimestampMs>,
+        ) -> Result<(), aionui_db::DbError> {
+            unimplemented!()
+        }
+        async fn update_tools(&self, _id: &str, _tools: Option<&str>) -> Result<(), aionui_db::DbError> {
+            unimplemented!()
+        }
+    }
+
+    #[tokio::test]
+    async fn load_user_mcp_servers_skips_disabled_and_builtin() {
+        let repo: Arc<dyn IMcpServerRepository> = Arc::new(MockRepo {
+            rows: vec![
+                make_row(
+                    "user-enabled",
+                    "stdio",
+                    r#"{"command":"npx","args":[],"env":{}}"#,
+                    true,
+                    false,
+                ),
+                make_row(
+                    "user-disabled",
+                    "stdio",
+                    r#"{"command":"npx","args":[],"env":{}}"#,
+                    false,
+                    false,
+                ),
+                make_row(
+                    "builtin",
+                    "stdio",
+                    r#"{"command":"img-gen","args":[],"env":{}}"#,
+                    true,
+                    true,
+                ),
+            ],
+            fail: false,
+        });
+        let servers = load_user_mcp_servers(repo.as_ref(), "conv-1").await;
+        assert_eq!(servers.len(), 1);
+        match &servers[0] {
+            McpServer::Stdio(s) => assert_eq!(s.name, "user-enabled"),
+            _ => panic!("expected stdio"),
+        }
+    }
+
+    #[tokio::test]
+    async fn load_user_mcp_servers_returns_empty_on_repo_failure() {
+        let repo: Arc<dyn IMcpServerRepository> = Arc::new(MockRepo {
+            rows: vec![],
+            fail: true,
+        });
+        let servers = load_user_mcp_servers(repo.as_ref(), "conv-1").await;
+        assert!(servers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn load_user_mcp_servers_skips_malformed_rows_but_keeps_others() {
+        let repo: Arc<dyn IMcpServerRepository> = Arc::new(MockRepo {
+            rows: vec![
+                make_row("good", "stdio", r#"{"command":"npx","args":[],"env":{}}"#, true, false),
+                make_row("bad", "stdio", "not-json", true, false),
+            ],
+            fail: false,
+        });
+        let servers = load_user_mcp_servers(repo.as_ref(), "conv-1").await;
+        assert_eq!(servers.len(), 1);
+        match &servers[0] {
+            McpServer::Stdio(s) => assert_eq!(s.name, "good"),
+            _ => panic!("expected stdio"),
+        }
+    }
 }

--- a/crates/aionui-ai-agent/src/factory/acp_assembler.rs
+++ b/crates/aionui-ai-agent/src/factory/acp_assembler.rs
@@ -54,16 +54,22 @@ impl AcpSessionParams {
 /// This front-loads all decision logic that was previously scattered across
 /// `build_new_session_request`, `compose_preset_context_with_team_guide`,
 /// and the factory's ACP match arm.
+///
+/// `user_mcp_servers` are operator-configured MCP servers loaded from the DB
+/// by the factory layer; they are appended after the team/guide injection so
+/// the agent gets *all* the user's tools on `session/new` (ELECTRON-1JG fix).
+#[allow(clippy::too_many_arguments)]
 pub async fn assemble_acp_params(
     conversation_id: String,
     workspace: WorkspaceInfo,
     metadata: AgentMetadata,
     command_spec: CommandSpec,
     config: AcpBuildExtra,
+    user_mcp_servers: Vec<McpServer>,
     session_snapshot: Option<PersistedSessionState>,
     data_dir: PathBuf,
 ) -> AcpSessionParams {
-    let mcp_servers = resolve_mcp_servers(&config, &conversation_id);
+    let mcp_servers = resolve_mcp_servers(&config, &conversation_id, user_mcp_servers);
     let preset_context = compose_preset_context(
         config.preset_context.as_deref(),
         config.backend.as_deref(),
@@ -85,21 +91,28 @@ pub async fn assemble_acp_params(
 
 /// Determine which MCP servers to inject into `session/new`.
 ///
-/// Priority: team session > solo guide > none. The two injections are
-/// mutually exclusive.
-fn resolve_mcp_servers(config: &AcpBuildExtra, conversation_id: &str) -> Vec<McpServer> {
+/// Layout: `[team-or-guide?, ...user_mcp_servers]`. The team/guide
+/// injection is mutually exclusive (team takes priority); the user's
+/// own enabled MCP servers are always appended on top so a team
+/// session still gets the operator's tools.
+fn resolve_mcp_servers(
+    config: &AcpBuildExtra,
+    conversation_id: &str,
+    user_mcp_servers: Vec<McpServer>,
+) -> Vec<McpServer> {
+    let mut servers: Vec<McpServer> = Vec::new();
     if let Some(cfg) = config.team_mcp_stdio_config.as_ref() {
-        return vec![team_mcp_server(cfg)];
-    }
-    if let Some(guide_cfg) = config.guide_mcp_config.as_ref()
+        servers.push(team_mcp_server(cfg));
+    } else if let Some(guide_cfg) = config.guide_mcp_config.as_ref()
         && config
             .backend
             .as_deref()
             .is_some_and(|b| TEAM_CAPABLE_BACKENDS.contains(&b))
     {
-        return vec![guide_mcp_server(guide_cfg, config, conversation_id)];
+        servers.push(guide_mcp_server(guide_cfg, config, conversation_id));
     }
-    Vec::new()
+    servers.extend(user_mcp_servers);
+    servers
 }
 
 /// Compose first-message preset context, optionally appending the Team Guide
@@ -190,6 +203,10 @@ mod tests {
         assert_eq!(result, None);
     }
 
+    fn user_stdio(name: &str) -> McpServer {
+        McpServer::Stdio(McpServerStdio::new(name, "/bin/sh"))
+    }
+
     #[test]
     fn resolve_mcp_servers_prefers_team_over_guide() {
         let config = AcpBuildExtra {
@@ -218,7 +235,7 @@ mod tests {
             }),
             user_id: None,
         };
-        let servers = resolve_mcp_servers(&config, "conv-1");
+        let servers = resolve_mcp_servers(&config, "conv-1", Vec::new());
         assert_eq!(servers.len(), 1);
         match &servers[0] {
             McpServer::Stdio(s) => assert!(s.name.contains("team-1")),
@@ -248,7 +265,7 @@ mod tests {
             }),
             user_id: None,
         };
-        let servers = resolve_mcp_servers(&config, "conv-1");
+        let servers = resolve_mcp_servers(&config, "conv-1", Vec::new());
         assert_eq!(servers.len(), 1);
         match &servers[0] {
             McpServer::Stdio(s) => assert_eq!(s.name, "aionui-team-guide"),
@@ -278,7 +295,143 @@ mod tests {
             }),
             user_id: None,
         };
-        let servers = resolve_mcp_servers(&config, "conv-1");
+        let servers = resolve_mcp_servers(&config, "conv-1", Vec::new());
+        assert!(servers.is_empty());
+    }
+
+    /// Core ELECTRON-1JG regression contract: when the operator has
+    /// configured user MCP servers (e.g. via Settings → MCP), they must
+    /// reach the `session/new` payload — even when there's no team or
+    /// guide injection. Pre-fix: this returned an empty Vec because the
+    /// factory only knew about team_mcp_stdio_config / guide_mcp_config.
+    #[test]
+    fn resolve_mcp_servers_appends_user_servers_in_solo_session() {
+        let config = AcpBuildExtra {
+            agent_id: None,
+            backend: Some("unknown-backend".into()),
+            cli_path: None,
+            agent_name: None,
+            custom_agent_id: None,
+            preset_context: None,
+            skills: vec![],
+            preset_assistant_id: None,
+            session_mode: None,
+            current_model_id: None,
+            cron_job_id: None,
+            team_mcp_stdio_config: None,
+            guide_mcp_config: None,
+            user_id: None,
+        };
+        let user = vec![user_stdio("ctx7"), user_stdio("playwright")];
+        let servers = resolve_mcp_servers(&config, "conv-1", user);
+        assert_eq!(servers.len(), 2);
+        let names: Vec<_> = servers
+            .iter()
+            .map(|s| match s {
+                McpServer::Stdio(s) => s.name.as_str(),
+                _ => panic!(),
+            })
+            .collect();
+        assert_eq!(names, vec!["ctx7", "playwright"]);
+    }
+
+    /// User-configured MCP servers must coexist with the team injection,
+    /// not replace it. Order: team first, then user servers.
+    #[test]
+    fn resolve_mcp_servers_team_plus_user_servers() {
+        let config = AcpBuildExtra {
+            agent_id: None,
+            backend: Some("claude".into()),
+            cli_path: None,
+            agent_name: None,
+            custom_agent_id: None,
+            preset_context: None,
+            skills: vec![],
+            preset_assistant_id: None,
+            session_mode: None,
+            current_model_id: None,
+            cron_job_id: None,
+            team_mcp_stdio_config: Some(TeamMcpStdioConfig {
+                team_id: "team-1".into(),
+                port: 9999,
+                token: "tok".into(),
+                slot_id: "slot-lead".into(),
+                binary_path: "/bin/backend".into(),
+            }),
+            guide_mcp_config: None,
+            user_id: None,
+        };
+        let user = vec![user_stdio("ctx7")];
+        let servers = resolve_mcp_servers(&config, "conv-1", user);
+        assert_eq!(servers.len(), 2);
+        match &servers[0] {
+            McpServer::Stdio(s) => assert!(s.name.contains("team-1"), "team must come first"),
+            _ => panic!("expected stdio"),
+        }
+        match &servers[1] {
+            McpServer::Stdio(s) => assert_eq!(s.name, "ctx7"),
+            _ => panic!("expected stdio"),
+        }
+    }
+
+    /// Guide injection coexists with user MCP servers too.
+    #[test]
+    fn resolve_mcp_servers_guide_plus_user_servers() {
+        let config = AcpBuildExtra {
+            agent_id: None,
+            backend: Some("claude".into()),
+            cli_path: None,
+            agent_name: None,
+            custom_agent_id: None,
+            preset_context: None,
+            skills: vec![],
+            preset_assistant_id: None,
+            session_mode: None,
+            current_model_id: None,
+            cron_job_id: None,
+            team_mcp_stdio_config: None,
+            guide_mcp_config: Some(GuideMcpConfig {
+                port: 8888,
+                token: "guide-tok".into(),
+                binary_path: "/bin/backend".into(),
+            }),
+            user_id: None,
+        };
+        let user = vec![user_stdio("ctx7")];
+        let servers = resolve_mcp_servers(&config, "conv-1", user);
+        assert_eq!(servers.len(), 2);
+        match &servers[0] {
+            McpServer::Stdio(s) => assert_eq!(s.name, "aionui-team-guide"),
+            _ => panic!("expected stdio"),
+        }
+        match &servers[1] {
+            McpServer::Stdio(s) => assert_eq!(s.name, "ctx7"),
+            _ => panic!("expected stdio"),
+        }
+    }
+
+    /// The pre-fix bug: with no team/guide configured and an empty
+    /// user-server list, the payload is empty. This is the *no-fix*
+    /// scenario and remains valid (no MCP configured anywhere).
+    #[test]
+    fn resolve_mcp_servers_empty_when_nothing_configured() {
+        let config = AcpBuildExtra {
+            agent_id: None,
+            backend: Some("claude".into()),
+            cli_path: None,
+            agent_name: None,
+            custom_agent_id: None,
+            preset_context: None,
+            skills: vec![],
+            preset_assistant_id: None,
+            session_mode: None,
+            current_model_id: None,
+            cron_job_id: None,
+            team_mcp_stdio_config: None,
+            guide_mcp_config: None,
+            user_id: None,
+        };
+        let servers = resolve_mcp_servers(&config, "conv-1", Vec::new());
         assert!(servers.is_empty());
     }
 }

--- a/crates/aionui-ai-agent/src/factory/mod.rs
+++ b/crates/aionui-ai-agent/src/factory/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use aionui_api_types::GuideMcpConfig;
 use aionui_common::{AgentType, AppError};
-use aionui_db::{IProviderRepository, IRemoteAgentRepository};
+use aionui_db::{IMcpServerRepository, IProviderRepository, IRemoteAgentRepository};
 use futures_util::FutureExt;
 
 use crate::agent_task::AgentInstance;
@@ -40,6 +40,10 @@ pub struct AgentFactoryDeps {
     /// ACP agent sessions so the agent gets the `aion_create_team` tool.
     /// `None` when the Guide server failed to start (graceful degradation).
     pub guide_mcp_config: Option<GuideMcpConfig>,
+    /// User-configured MCP servers repository. Used by ACP factory to
+    /// inject enabled servers into `session/new` (ELECTRON-1JG fix).
+    /// `None` for tests/composition paths that do not need MCP injection.
+    pub mcp_server_repo: Option<Arc<dyn IMcpServerRepository>>,
 }
 
 /// Build a production agent factory that dispatches to concrete agent types.

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -1,13 +1,15 @@
 use crate::manager::acp::AcpAgentManager;
 use crate::manager::acp::mode_normalize::agent_metadata_uses_meta_resume;
 use crate::protocol::events::{
-    AgentStreamEvent, AvailableCommandsEventData, FinishEventData, SessionAssignedEventData, StartEventData,
+    AgentStreamEvent, AvailableCommandsEventData, ErrorEventData, FinishEventData, SessionAssignedEventData,
+    StartEventData,
 };
 use crate::shared_kernel::SessionId as DomainSessionId;
 use crate::types::SendMessageData;
-use agent_client_protocol::schema::{ContentBlock, LoadSessionRequest, PromptRequest, SessionId};
+use agent_client_protocol::schema::{ContentBlock, LoadSessionRequest, PromptRequest, SessionId, StopReason};
 use aionui_common::AppError;
 use serde_json::Value;
+use tokio::sync::broadcast::error::TryRecvError;
 
 use super::agent::sdk_to_snake_value;
 use tracing::warn;
@@ -230,18 +232,41 @@ impl AcpAgentManager {
 
         let content = data.content.clone();
 
+        // Subscribe BEFORE emitting Start so we can observe every event
+        // produced during this turn. Used after `prompt()` returns to detect
+        // the "empty finish" scenario (model produced no text and no tool
+        // calls); see `is_empty_turn` below.
+        let mut probe_rx = self.runtime.subscribe();
+
         // Emit Start event
         self.runtime.emit(AgentStreamEvent::Start(StartEventData {
             session_id: Some(sid.to_owned()),
         }));
 
-        self.protocol
+        let prompt_response = self
+            .protocol
             .prompt(PromptRequest::new(
                 SessionId::new(sid),
                 vec![ContentBlock::from(content)],
             ))
             .await
             .map_err(AppError::from)?;
+
+        // Diagnose the "blank reply" case: the agent finished a turn without
+        // producing any user-visible output. We surface a structured error to
+        // the renderer so the user gets actionable feedback instead of a
+        // silent success. Cancelled turns are deliberately excluded — the
+        // user already initiated the cancel and doesn't need a second
+        // notification.
+        if !matches!(prompt_response.stop_reason, StopReason::Cancelled) && is_empty_turn(&mut probe_rx) {
+            self.runtime.emit(AgentStreamEvent::Error(ErrorEventData {
+                // TODO(i18n): wire to a frontend translation key once a
+                // pattern is established. For now this is the user-facing
+                // English string.
+                message: empty_finish_diagnostic_message(prompt_response.stop_reason),
+                code: Some("acp.empty_finish".into()),
+            }));
+        }
 
         // Emit Finish event
         self.runtime.emit(AgentStreamEvent::Finish(FinishEventData {
@@ -306,6 +331,71 @@ impl AcpAgentManager {
                     commands: cmds.to_vec(),
                 }));
         }
+    }
+}
+
+/// Drain the supplied turn-scoped receiver and return `true` when the turn
+/// produced neither agent text nor any tool-call activity.
+///
+/// Used by `prompt_existing_session` to detect the "blank reply" scenario
+/// (ELECTRON-1JG): the ACP backend returned `StopReason::EndTurn` (or
+/// similar terminal reason) without ever emitting a `Text` /
+/// `Thinking` / `ToolCall` / `AcpToolCall` chunk. We treat presence of
+/// any of those as a non-empty turn.
+///
+/// `Lagged` is treated as non-empty: the broadcast buffer overflowed,
+/// meaning many events flew by — definitely not an empty turn.
+fn is_empty_turn(rx: &mut tokio::sync::broadcast::Receiver<AgentStreamEvent>) -> bool {
+    loop {
+        match rx.try_recv() {
+            Ok(event) => {
+                if event_is_user_visible_output(&event) {
+                    return false;
+                }
+            }
+            Err(TryRecvError::Empty) => return true,
+            Err(TryRecvError::Closed) => return true,
+            // Buffer overflow: many events occurred — turn was clearly not empty.
+            Err(TryRecvError::Lagged(_)) => return false,
+        }
+    }
+}
+
+/// Whether a stream event represents user-visible output produced by the
+/// model during a turn. Anything that would render in chat counts.
+fn event_is_user_visible_output(event: &AgentStreamEvent) -> bool {
+    matches!(
+        event,
+        AgentStreamEvent::Text(_)
+            | AgentStreamEvent::Thinking(_)
+            | AgentStreamEvent::ToolCall(_)
+            | AgentStreamEvent::AcpToolCall(_)
+            | AgentStreamEvent::ToolGroup(_)
+            | AgentStreamEvent::Plan(_)
+            | AgentStreamEvent::Permission(_)
+            | AgentStreamEvent::AcpPermission(_)
+    )
+}
+
+/// Build the user-facing message shown when the agent finished a turn
+/// without emitting any output. Wording is deliberately concrete so the
+/// user has something to act on (retry, reword, check provider).
+fn empty_finish_diagnostic_message(stop_reason: StopReason) -> String {
+    match stop_reason {
+        StopReason::MaxTokens => "The model reached its output token limit before producing any reply. \
+             Try asking a shorter question or raising the model's max output."
+            .to_owned(),
+        StopReason::MaxTurnRequests => "The model hit the per-turn request cap before producing any reply. \
+             Try a simpler request or restart the conversation."
+            .to_owned(),
+        StopReason::Refusal => "The model refused to continue without producing a reply.".to_owned(),
+        // EndTurn (and any non-exhaustive future variants) all map to the
+        // generic empty-reply message — the model said it was done but
+        // produced nothing.
+        _ => "The model finished without producing any reply. \
+              This usually means the request returned an empty response — \
+              try resending the message or switching model/provider."
+            .to_owned(),
     }
 }
 
@@ -481,5 +571,104 @@ mod tests {
 
         let bad_request = AppError::BadRequest("anything".into());
         assert!(!super::is_session_not_found(&bad_request));
+    }
+
+    // -- empty-finish diagnostic (ELECTRON-1JG) -------------------------------
+
+    use crate::protocol::events::{
+        AgentStreamEvent, FinishEventData, StartEventData, TextEventData, ThinkingEventData, ToolCallEventData,
+        ToolCallStatus,
+    };
+    use agent_client_protocol::schema::StopReason;
+    use tokio::sync::broadcast;
+
+    /// Lifecycle-only events (`Start`/`Finish`) must NOT count as
+    /// user-visible output. This is the core empty-finish detection
+    /// contract: the helper has to look past Start before declaring
+    /// the turn empty.
+    #[tokio::test]
+    async fn is_empty_turn_returns_true_when_only_lifecycle_events() {
+        let (tx, _) = broadcast::channel::<AgentStreamEvent>(8);
+        let mut rx = tx.subscribe();
+        tx.send(AgentStreamEvent::Start(StartEventData {
+            session_id: Some("s1".into()),
+        }))
+        .unwrap();
+        tx.send(AgentStreamEvent::Finish(FinishEventData {
+            session_id: Some("s1".into()),
+        }))
+        .unwrap();
+
+        assert!(super::is_empty_turn(&mut rx));
+    }
+
+    /// A single Text chunk is enough to mark the turn non-empty,
+    /// even when sandwiched between lifecycle events.
+    #[tokio::test]
+    async fn is_empty_turn_returns_false_when_text_emitted() {
+        let (tx, _) = broadcast::channel::<AgentStreamEvent>(8);
+        let mut rx = tx.subscribe();
+        tx.send(AgentStreamEvent::Start(StartEventData::default())).unwrap();
+        tx.send(AgentStreamEvent::Text(TextEventData { content: "hi".into() }))
+            .unwrap();
+        tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
+
+        assert!(!super::is_empty_turn(&mut rx));
+    }
+
+    /// Tool calls also count as visible output — even if the model
+    /// produced no Text, executing a tool means the turn was not blank.
+    #[tokio::test]
+    async fn is_empty_turn_returns_false_when_tool_call_emitted() {
+        let (tx, _) = broadcast::channel::<AgentStreamEvent>(8);
+        let mut rx = tx.subscribe();
+        tx.send(AgentStreamEvent::Start(StartEventData::default())).unwrap();
+        tx.send(AgentStreamEvent::ToolCall(ToolCallEventData {
+            call_id: "c1".into(),
+            name: "read_file".into(),
+            args: serde_json::json!({}),
+            status: ToolCallStatus::Running,
+            input: None,
+            output: None,
+            description: None,
+        }))
+        .unwrap();
+
+        assert!(!super::is_empty_turn(&mut rx));
+    }
+
+    /// Thinking-only output (no final reply) still counts: the user
+    /// saw something happen, even though the model didn't commit
+    /// to a response. We don't want to double-up the diagnostic.
+    #[tokio::test]
+    async fn is_empty_turn_returns_false_when_only_thinking_emitted() {
+        let (tx, _) = broadcast::channel::<AgentStreamEvent>(8);
+        let mut rx = tx.subscribe();
+        tx.send(AgentStreamEvent::Thinking(ThinkingEventData {
+            content: "hmm".into(),
+            subject: None,
+            duration: None,
+            status: None,
+        }))
+        .unwrap();
+
+        assert!(!super::is_empty_turn(&mut rx));
+    }
+
+    /// Each `StopReason` variant maps to a distinct, user-actionable
+    /// message. Pin the wording so future copy changes are deliberate.
+    #[test]
+    fn empty_finish_diagnostic_message_per_stop_reason() {
+        let endturn = super::empty_finish_diagnostic_message(StopReason::EndTurn);
+        assert!(endturn.to_lowercase().contains("finished"));
+
+        let max_tokens = super::empty_finish_diagnostic_message(StopReason::MaxTokens);
+        assert!(max_tokens.to_lowercase().contains("token"));
+
+        let max_turn = super::empty_finish_diagnostic_message(StopReason::MaxTurnRequests);
+        assert!(max_turn.to_lowercase().contains("per-turn") || max_turn.to_lowercase().contains("cap"));
+
+        let refusal = super::empty_finish_diagnostic_message(StopReason::Refusal);
+        assert!(refusal.to_lowercase().contains("refused"));
     }
 }

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -108,6 +108,7 @@ async fn make_mock_agent(script: &str, backend: &str) -> (Arc<AcpAgentManager>, 
                 cwd: None,
             },
             config,
+            Vec::new(),
             None,
             std::env::temp_dir(),
         )

--- a/crates/aionui-ai-agent/tests/factory_provider_integration.rs
+++ b/crates/aionui-ai-agent/tests/factory_provider_integration.rs
@@ -75,6 +75,7 @@ fn make_factory(
         data_dir: PathBuf::from("/tmp/aionrs-test"),
         backend_binary_path: Arc::new(PathBuf::from("/tmp/aionrs-test/aioncore")),
         guide_mcp_config: None,
+        mcp_server_repo: None,
     })
 }
 

--- a/crates/aionui-ai-agent/tests/prompt_pipeline_integration.rs
+++ b/crates/aionui-ai-agent/tests/prompt_pipeline_integration.rs
@@ -66,6 +66,7 @@ async fn fixture_params(
                 cwd: None,
             },
             config,
+            Vec::new(),
             None,
             std::env::temp_dir(),
         )

--- a/crates/aionui-app/src/services.rs
+++ b/crates/aionui-app/src/services.rs
@@ -11,9 +11,9 @@ use aionui_api_types::GuideMcpConfig;
 use aionui_auth::{CookieConfig, JwtService, QrTokenStore, resolve_jwt_secret};
 use aionui_common::OnConversationDelete;
 use aionui_db::{
-    Database, IAcpSessionRepository, IAgentMetadataRepository, IConversationRepository, IUserRepository,
-    SqliteAcpSessionRepository, SqliteAgentMetadataRepository, SqliteConversationRepository, SqliteProviderRepository,
-    SqliteRemoteAgentRepository, SqliteUserRepository,
+    Database, IAcpSessionRepository, IAgentMetadataRepository, IConversationRepository, IMcpServerRepository,
+    IUserRepository, SqliteAcpSessionRepository, SqliteAgentMetadataRepository, SqliteConversationRepository,
+    SqliteMcpServerRepository, SqliteProviderRepository, SqliteRemoteAgentRepository, SqliteUserRepository,
 };
 use aionui_realtime::{BroadcastEventBus, WebSocketManager};
 use aionui_team::GuideMcpServer;
@@ -106,6 +106,10 @@ impl AppServices {
 
         let remote_agent_repo = Arc::new(SqliteRemoteAgentRepository::new(database.pool().clone()));
         let provider_repo = Arc::new(SqliteProviderRepository::new(database.pool().clone()));
+        // User-configured MCP servers — injected into ACP `session/new`
+        // so the agent gets the operator's tools (ELECTRON-1JG fix).
+        let mcp_server_repo: Arc<dyn IMcpServerRepository> =
+            Arc::new(SqliteMcpServerRepository::new(database.pool().clone()));
 
         let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> =
             Arc::new(SqliteAgentMetadataRepository::new(database.pool().clone()));
@@ -166,6 +170,7 @@ impl AppServices {
             data_dir: data_dir.clone(),
             backend_binary_path: backend_binary_path.clone(),
             guide_mcp_config: guide_mcp_config.clone(),
+            mcp_server_repo: Some(mcp_server_repo),
         });
 
         // Agent factory is now wired. Future extension/custom agents


### PR DESCRIPTION
## Summary
- Mitigate Sentry **ELECTRON-1JG**: the ACP factory was not injecting user-configured MCP servers when assembling sessions, and empty `finish` events lacked any diagnostic signal.
- `factory/acp.rs` + `acp_assembler.rs`: load and inject user MCP servers from the DB.
- `agent_session_flow.rs`: on empty `finish`, emit `AgentStreamEvent::Error { code: "acp.empty_finish", ... }` so the issue is correlatable in Sentry.
- Update 3 integration tests accordingly.

## Caveat
- The Sentry event is `type=user-feedback` (164 breadcrumbs ending with the feedback button click), not a crash, so there is no direct stack trace.
- The fix rests on two hypotheses ("user MCP servers not loaded" and "empty finish lacks observability"); neither is directly verifiable from the available logs. If the next wave of the issue persists, finer-grained diagnostics will be needed.

## Test plan
- [x] `cargo test -p aionui-ai-agent` (updated integration tests pass)
- [x] `just build -f`
- [ ] Manual: with user MCP servers configured, create an ACP session and confirm injection; simulate an empty finish and confirm the `acp.empty_finish` event is emitted.

Generated with [Claude Code](https://claude.com/claude-code)