### PR TITLE
fix(db): serialize migrations with fs2 file lock to avoid concurrent race (ELECTRON-1KK)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ version = "0.1.10"
 dependencies = [
  "aionui-common",
  "async-trait",
+ "fs2",
  "serde",
  "serde_json",
  "sqlx",

--- a/crates/aionui-db/Cargo.toml
+++ b/crates/aionui-db/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 aionui-common.workspace = true
 sqlx = { workspace = true, features = ["migrate"] }
 async-trait.workspace = true
+fs2.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/aionui-db/src/database.rs
+++ b/crates/aionui-db/src/database.rs
@@ -1,7 +1,9 @@
-use std::path::Path;
+use std::fs::OpenOptions;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Duration;
 
+use fs2::FileExt;
 use sqlx::pool::PoolOptions;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
 use sqlx::{Sqlite, SqlitePool};
@@ -76,7 +78,9 @@ pub async fn init_database_memory() -> Result<Database, DbError> {
         .await
         .map_err(DbError::Query)?;
 
-    run_migrations(&pool).await?;
+    // In-memory DBs are not shared across processes, so no advisory lock is
+    // needed (and there is no on-disk path we could create one against).
+    run_migrations(&pool, None).await?;
     ensure_system_user(&pool).await?;
 
     info!("In-memory database initialized");
@@ -123,14 +127,30 @@ async fn try_init_file(path: &Path) -> Result<Database, DbError> {
         .await
         .map_err(DbError::Query)?;
 
-    run_migrations(&pool).await?;
+    run_migrations(&pool, Some(&migrate_lock_path(path))).await?;
     ensure_system_user(&pool).await?;
 
     info!("Database initialized at {}", path.display());
     Ok(Database { pool })
 }
 
-async fn run_migrations(pool: &SqlitePool) -> Result<(), DbError> {
+/// Path of the cross-process advisory lock file used to serialize concurrent
+/// migrators on the same database.
+///
+/// We put it next to the DB file so it lives on the same filesystem (avoids
+/// odd flock semantics across mount points) and gets cleaned up alongside the
+/// DB if a user resets their data directory.
+fn migrate_lock_path(db_path: &Path) -> PathBuf {
+    let mut p = db_path.to_path_buf();
+    let new_name = match p.file_name().and_then(|s| s.to_str()) {
+        Some(name) => format!("{name}.migrate.lock"),
+        None => "aionui.migrate.lock".to_string(),
+    };
+    p.set_file_name(new_name);
+    p
+}
+
+async fn run_migrations(pool: &SqlitePool, lock_path: Option<&Path>) -> Result<(), DbError> {
     ensure_schema_columns(pool).await?;
     // Migration 002 rebuilds tables via RENAME+DROP. Two pragmas are needed:
     // - foreign_keys=OFF: prevents DROP TABLE from triggering ON DELETE CASCADE
@@ -142,12 +162,99 @@ async fn run_migrations(pool: &SqlitePool) -> Result<(), DbError> {
         .execute(&mut *conn)
         .await
         .map_err(DbError::Query)?;
-    let result = sqlx::migrate!().run(&mut *conn).await.map_err(DbError::Migration);
+
+    // Cross-process serialisation. sqlx-sqlite's Migrate impl has no-op
+    // lock()/unlock() and the migrator does list_applied → apply without an
+    // outer transaction, so two processes opening the same DB simultaneously
+    // (e.g. Electron auto-update spawning v2.1.1 while v2.0.x is still
+    // shutting down, or `aioncore doctor` racing the server) can both decide
+    // to apply the same version and the slower one's INSERT into
+    // `_sqlx_migrations` blows up with `UNIQUE constraint failed:
+    // _sqlx_migrations.version`. Acquire an advisory file lock for the
+    // duration of migrate-run so the two processes serialise. The lock is
+    // released when the guard drops.
+    let _guard = lock_path.and_then(|p| match MigrateLockGuard::acquire(p) {
+        Ok(guard) => Some(guard),
+        Err(e) => {
+            // Don't fail startup if flock isn't available (e.g. on some
+            // network filesystems) — fall back to retry-on-conflict below.
+            warn!("Could not acquire migrate lock {}: {e}", p.display());
+            None
+        }
+    });
+
+    let result = run_migrations_with_retry(&mut conn).await;
+
     sqlx::query("PRAGMA foreign_keys = ON; PRAGMA legacy_alter_table = OFF")
         .execute(&mut *conn)
         .await
         .map_err(DbError::Query)?;
     result
+}
+
+/// Run sqlx migrations with one retry on `_sqlx_migrations` UNIQUE conflict.
+///
+/// The advisory file lock above already serialises well-behaved processes,
+/// but a UNIQUE conflict can still leak through when:
+/// - flock() failed (network FS, sandbox restrictions) and we proceeded.
+/// - Two processes that both bypassed the lock raced.
+///
+/// In every UNIQUE-conflict scenario the failing migration's transaction was
+/// rolled back, so re-running `sqlx::migrate!().run` is safe: the second
+/// pass sees the row that the winner committed, checksum matches (same
+/// shipped binary), and the migration is treated as already applied.
+async fn run_migrations_with_retry(conn: &mut sqlx::SqliteConnection) -> Result<(), DbError> {
+    match sqlx::migrate!().run(&mut *conn).await {
+        Ok(()) => Ok(()),
+        Err(e) if is_migrations_table_unique_conflict(&e) => {
+            warn!("Concurrent migrator detected (UNIQUE conflict on _sqlx_migrations); retrying");
+            sqlx::migrate!().run(&mut *conn).await.map_err(DbError::Migration)
+        }
+        Err(e) => Err(DbError::Migration(e)),
+    }
+}
+
+/// Detect the specific "another process inserted this version first" error.
+///
+/// sqlx wraps the SQLite error inside `MigrateError::Execute(sqlx::Error)`.
+/// We match on the textual message rather than the SQLite extended error code
+/// because sqlx loses the structured code by the time it bubbles up here.
+fn is_migrations_table_unique_conflict(err: &sqlx::migrate::MigrateError) -> bool {
+    let msg = err.to_string();
+    msg.contains("UNIQUE constraint failed: _sqlx_migrations.version")
+}
+
+/// RAII guard that holds an exclusive file lock for the lifetime of the
+/// migration run. Drop unlocks and best-effort closes the file handle.
+struct MigrateLockGuard {
+    file: std::fs::File,
+}
+
+impl MigrateLockGuard {
+    fn acquire(path: &Path) -> std::io::Result<Self> {
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(path)?;
+        // Blocking lock — fs2 has no async variant. We're inside an async
+        // context but startup blocks anyway and the critical section is
+        // bounded (single-process migration run), so this is acceptable.
+        FileExt::lock_exclusive(&file)?;
+        Ok(Self { file })
+    }
+}
+
+impl Drop for MigrateLockGuard {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
 }
 
 /// Ensure columns expected by Rust models exist in the database.
@@ -306,5 +413,35 @@ mod tests {
         .unwrap();
 
         assert_eq!(fk_table, "conversations");
+    }
+
+    #[test]
+    fn migrations_table_unique_conflict_detected_from_message() {
+        // Build the same Execute(sqlx::Error) shape that surfaces when two
+        // processes race on `INSERT INTO _sqlx_migrations`. The detector has
+        // to match on the textual message because the SQLite extended code
+        // is not preserved on the path through MigrateError.
+        let inner = sqlx::Error::Protocol("UNIQUE constraint failed: _sqlx_migrations.version".to_string());
+        let err = sqlx::migrate::MigrateError::Execute(inner);
+        assert!(is_migrations_table_unique_conflict(&err));
+    }
+
+    #[test]
+    fn migrations_table_unique_conflict_ignores_other_errors() {
+        let other = sqlx::migrate::MigrateError::VersionMismatch(3);
+        assert!(!is_migrations_table_unique_conflict(&other));
+
+        let unrelated = sqlx::migrate::MigrateError::Execute(sqlx::Error::Protocol(
+            "UNIQUE constraint failed: users.username".to_string(),
+        ));
+        assert!(!is_migrations_table_unique_conflict(&unrelated));
+    }
+
+    #[test]
+    fn migrate_lock_path_sits_next_to_db() {
+        let db = Path::new("/var/lib/aionui/aionui-backend.db");
+        let lock = migrate_lock_path(db);
+        assert_eq!(lock.parent(), db.parent());
+        assert_eq!(lock.file_name().unwrap(), "aionui-backend.db.migrate.lock");
     }
 }

--- a/crates/aionui-db/tests/db_lifecycle.rs
+++ b/crates/aionui-db/tests/db_lifecycle.rs
@@ -389,3 +389,77 @@ async fn copy_legacy_then_init_database_works() {
     db.close().await;
     legacy_db2.close().await;
 }
+
+// -- Concurrent migrator regression (ELECTRON-1KK) --
+//
+// Repro for the Sentry secondary symptom: two processes opening the same
+// SQLite DB on first start (e.g. Electron auto-update spawning the new
+// version while the old one is still finalising shutdown, or
+// `aioncore doctor` racing the server) both decide to apply the same
+// migration version. sqlx-sqlite's lock()/unlock() are no-ops, so without
+// the advisory file lock and retry-on-UNIQUE the slower process used to
+// blow up with `UNIQUE constraint failed: _sqlx_migrations.version`.
+//
+// We use OS threads (not tokio::spawn) so each migrator runs on its own
+// runtime — this matches the real "two processes" topology more closely
+// than cooperative tasks would, and avoids the `&SqlitePool: Send` lifetime
+// gymnastics that block tokio::spawn on this future.
+#[test]
+fn concurrent_init_database_does_not_panic_on_unique_conflict() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("aionui-backend.db");
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let p = path.clone();
+        handles.push(std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async move { init_database(&p).await })
+        }));
+    }
+
+    // Every thread must succeed — none should bubble up the UNIQUE-constraint
+    // error from `_sqlx_migrations`.
+    let mut errors = Vec::new();
+    for h in handles {
+        match h.join().expect("thread panicked") {
+            Ok(_db) => {}
+            Err(e) => errors.push(e.to_string()),
+        }
+    }
+    assert!(
+        errors.is_empty(),
+        "all parallel migrators should succeed, got errors: {errors:?}"
+    );
+
+    // All migrators converged on the same baseline schema with no duplicate
+    // `_sqlx_migrations` rows.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let db = init_database(&path).await.unwrap();
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM _sqlx_migrations WHERE success = 1")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert!(count.0 >= 1, "at least one migration should be recorded");
+
+        let dup: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM (SELECT version FROM _sqlx_migrations GROUP BY version HAVING COUNT(*) > 1)",
+        )
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(dup.0, 0, "no duplicate versions should ever exist in _sqlx_migrations");
+        db.close().await;
+    });
+
+    // Lock file is created next to the DB and is harmless to leave behind.
+    let lock = path.with_file_name("aionui-backend.db.migrate.lock");
+    assert!(lock.exists(), "advisory lock file should be present after migrate");
+}


### PR DESCRIPTION
## Summary
- Fix Sentry **ELECTRON-1KK**: when multiple processes start at the same time, `_sqlx_migrations` occasionally hits `UNIQUE constraint failed`.
- `aionui-db` now depends on `fs2`; `MigrateLockGuard` takes an advisory lock on `<db>.migrate.lock` to serialize the migration path.
- `run_migrations_with_retry` performs a bounded retry if a UNIQUE conflict still slips through.
- Add 4 tests, including 1 integration test that drives 8 OS threads concurrently initializing the DB.

## Diagnosis update
- Original hypothesis: "migration files were renumbered, causing checksum drift."
- After auditing every 0.1.x release tag, the migration files are byte-identical and were never renumbered — the hypothesis was disproved.
- True root cause: concurrent processes running `sqlx migrate` against the same DB file race on `_sqlx_migrations` inserts. The fix shifts to a cross-process file lock accordingly.

## Test plan
- [x] `cargo test -p aionui-db` (includes the new concurrent integration test)
- [x] `just build -f`
- [ ] Manual: launch two dev processes simultaneously and confirm the `_sqlx_migrations` UNIQUE error no longer appears.

Generated with [Claude Code](https://claude.com/claude-code)