### PR TITLE
Fix Windows release CRT linkage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,9 +80,11 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             binary_name: aioncore.exe
+            rustflags: "-C target-feature=+crt-static"
           - os: windows-latest
             target: aarch64-pc-windows-msvc
             binary_name: aioncore.exe
+            rustflags: "-C target-feature=+crt-static"
 
     steps:
       - uses: actions/checkout@v6
@@ -116,7 +118,12 @@ jobs:
 
       - name: Build release binary
         shell: bash
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags || '' }}
         run: |
+          if [[ -n "${RUSTFLAGS:-}" ]]; then
+            echo "Using RUSTFLAGS=${RUSTFLAGS}"
+          fi
           if [[ "${{ matrix.use_cross }}" == "true" ]]; then
             cross build --release --target ${{ matrix.target }} -p aionui-app
           else


### PR DESCRIPTION
## Summary
- Statically link the Windows CRT for x64 and arm64 release builds.
- Reduce loader-stage startup failures where packaged `aioncore.exe` exits before health checks with Windows status `0xc0000135`.
- Refs Sentry `ELECTRON-1N7`; this addresses the Windows loader subcause, not the builtin-skills materialization or readonly database subcauses.

## Test plan
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml parsed"'`
- `git diff --check`
- `just push -u origin fix/windows-static-crt`
