### PR TITLE
Fix startup materialization and migration races

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "async-trait",
  "axum",
  "dirs",
+ "fs2",
  "http-body-util",
  "include_dir",
  "junction",

--- a/crates/aionui-db/src/database.rs
+++ b/crates/aionui-db/src/database.rs
@@ -80,7 +80,7 @@ pub async fn init_database_memory() -> Result<Database, DbError> {
 
     // In-memory DBs are not shared across processes, so no advisory lock is
     // needed (and there is no on-disk path we could create one against).
-    run_migrations(&pool, None).await?;
+    run_migrations(&pool).await?;
     ensure_system_user(&pool).await?;
 
     info!("In-memory database initialized");
@@ -114,6 +114,21 @@ pub fn maybe_copy_legacy_database(target: &Path) -> Result<(), DbError> {
 }
 
 async fn try_init_file(path: &Path) -> Result<Database, DbError> {
+    // Serialize the whole file-backed startup path, not only the sqlx
+    // migrator. Opening a fresh SQLite file also runs connection-level PRAGMAs
+    // such as WAL setup, which can race before migrations start.
+    let lock_path = migrate_lock_path(path);
+    let _guard = match MigrateLockGuard::acquire(&lock_path) {
+        Ok(guard) => Some(guard),
+        Err(e) => {
+            // Don't fail startup if flock isn't available (e.g. on some
+            // network filesystems) - fall back to SQLite busy-timeout and
+            // retry-on-conflict behavior below.
+            warn!("Could not acquire database startup lock {}: {e}", lock_path.display());
+            None
+        }
+    };
+
     let opts = SqliteConnectOptions::new()
         .filename(path)
         .create_if_missing(true)
@@ -127,7 +142,7 @@ async fn try_init_file(path: &Path) -> Result<Database, DbError> {
         .await
         .map_err(DbError::Query)?;
 
-    run_migrations(&pool, Some(&migrate_lock_path(path))).await?;
+    run_migrations(&pool).await?;
     ensure_system_user(&pool).await?;
 
     info!("Database initialized at {}", path.display());
@@ -150,7 +165,17 @@ fn migrate_lock_path(db_path: &Path) -> PathBuf {
     p
 }
 
-async fn run_migrations(pool: &SqlitePool, lock_path: Option<&Path>) -> Result<(), DbError> {
+async fn run_migrations(pool: &SqlitePool) -> Result<(), DbError> {
+    // File-backed callers hold a cross-process startup lock before opening the
+    // SQLite pool. sqlx-sqlite's Migrate impl has no-op
+    // lock()/unlock() and the migrator does list_applied → apply without an
+    // outer transaction, so two processes opening the same DB simultaneously
+    // (e.g. Electron auto-update spawning v2.1.1 while v2.0.x is still
+    // shutting down, or `aioncore doctor` racing the server) can both decide
+    // to apply the same version and the slower one's INSERT into
+    // `_sqlx_migrations` blows up with `UNIQUE constraint failed:
+    // _sqlx_migrations.version`. The outer startup lock also covers
+    // schema-repair and connection PRAGMAs before migration execution.
     ensure_schema_columns(pool).await?;
     // Migration 002 rebuilds tables via RENAME+DROP. Two pragmas are needed:
     // - foreign_keys=OFF: prevents DROP TABLE from triggering ON DELETE CASCADE
@@ -162,26 +187,6 @@ async fn run_migrations(pool: &SqlitePool, lock_path: Option<&Path>) -> Result<(
         .execute(&mut *conn)
         .await
         .map_err(DbError::Query)?;
-
-    // Cross-process serialisation. sqlx-sqlite's Migrate impl has no-op
-    // lock()/unlock() and the migrator does list_applied → apply without an
-    // outer transaction, so two processes opening the same DB simultaneously
-    // (e.g. Electron auto-update spawning v2.1.1 while v2.0.x is still
-    // shutting down, or `aioncore doctor` racing the server) can both decide
-    // to apply the same version and the slower one's INSERT into
-    // `_sqlx_migrations` blows up with `UNIQUE constraint failed:
-    // _sqlx_migrations.version`. Acquire an advisory file lock for the
-    // duration of migrate-run so the two processes serialise. The lock is
-    // released when the guard drops.
-    let _guard = lock_path.and_then(|p| match MigrateLockGuard::acquire(p) {
-        Ok(guard) => Some(guard),
-        Err(e) => {
-            // Don't fail startup if flock isn't available (e.g. on some
-            // network filesystems) — fall back to retry-on-conflict below.
-            warn!("Could not acquire migrate lock {}: {e}", p.display());
-            None
-        }
-    });
 
     let result = run_migrations_with_retry(&mut conn).await;
 

--- a/crates/aionui-extension/Cargo.toml
+++ b/crates/aionui-extension/Cargo.toml
@@ -12,6 +12,7 @@ aionui-runtime.workspace = true
 async-trait.workspace = true
 axum.workspace = true
 dirs.workspace = true
+fs2.workspace = true
 include_dir.workspace = true
 semver.workspace = true
 notify.workspace = true

--- a/crates/aionui-extension/src/startup_materialize.rs
+++ b/crates/aionui-extension/src/startup_materialize.rs
@@ -13,14 +13,17 @@
 //! crash mid-write, never observe a half-populated target — the old tree
 //! stays in place until staging is fully ready.
 
+use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 
+use fs2::FileExt;
 use include_dir::Dir;
 use tracing::{info, warn};
 
 use crate::error::ExtensionError;
 
 const VERSION_FILE: &str = ".version";
+const LOCK_FILE_NAME: &str = ".builtin-skills.lock";
 const STAGING_DIR_NAME: &str = ".builtin-skills.tmp";
 const OLD_DIR_NAME: &str = ".builtin-skills.old";
 
@@ -53,7 +56,17 @@ pub async fn materialize_if_needed(
         version = binary_version,
         "materializing embedded builtin skills"
     );
-    materialize_embedded_builtin_skills(data_dir, corpus, binary_version).await?;
+    let _guard = MaterializeLockGuard::acquire(data_dir).await?;
+    if version_file_matches(&target, binary_version).await {
+        info!(
+            target = %target.display(),
+            version = binary_version,
+            "builtin skills up to date after materialize lock; skipping rewrite"
+        );
+        return Ok(false);
+    }
+
+    materialize_embedded_builtin_skills_unlocked(data_dir, corpus, binary_version).await?;
     Ok(true)
 }
 
@@ -71,6 +84,15 @@ async fn version_file_matches(target: &Path, binary_version: &str) -> bool {
 /// Unconditional materialize: stage, write each file, atomic rename.
 /// Exposed separately for tests that want to bypass the gate.
 pub async fn materialize_embedded_builtin_skills(
+    data_dir: &Path,
+    corpus: &Dir<'static>,
+    binary_version: &str,
+) -> Result<(), ExtensionError> {
+    let _guard = MaterializeLockGuard::acquire(data_dir).await?;
+    materialize_embedded_builtin_skills_unlocked(data_dir, corpus, binary_version).await
+}
+
+async fn materialize_embedded_builtin_skills_unlocked(
     data_dir: &Path,
     corpus: &Dir<'static>,
     binary_version: &str,
@@ -135,6 +157,36 @@ pub async fn materialize_embedded_builtin_skills(
     }
 
     Ok(())
+}
+
+struct MaterializeLockGuard {
+    file: std::fs::File,
+}
+
+impl MaterializeLockGuard {
+    async fn acquire(data_dir: &Path) -> std::io::Result<Self> {
+        let data_dir = data_dir.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            std::fs::create_dir_all(&data_dir)?;
+            let lock_path = data_dir.join(LOCK_FILE_NAME);
+            let file = OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .read(true)
+                .write(true)
+                .open(lock_path)?;
+            FileExt::lock_exclusive(&file)?;
+            Ok(Self { file })
+        })
+        .await
+        .map_err(|e| std::io::Error::other(format!("builtin skills lock task failed: {e}")))?
+    }
+}
+
+impl Drop for MaterializeLockGuard {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
 }
 
 /// Recursively copy every file in an `include_dir::Dir` tree into `dest`.

--- a/crates/aionui-extension/tests/startup_materialize.rs
+++ b/crates/aionui-extension/tests/startup_materialize.rs
@@ -137,3 +137,35 @@ async fn concurrent_materialize_produces_consistent_tree() {
     assert_eq!(read_version(&target).as_deref(), Some("1.2.3"));
     assert!(target.join("example-skill").join("SKILL.md").is_file());
 }
+
+#[tokio::test]
+async fn concurrent_gate_materialize_all_callers_succeed() {
+    let tmp = TempDir::new().unwrap();
+    let data_dir = tmp.path().to_path_buf();
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let dir = data_dir.clone();
+        handles.push(tokio::spawn(async move {
+            materialize_if_needed(&dir, &FIXTURE_CORPUS, "1.2.3").await
+        }));
+    }
+    let mut results = Vec::new();
+    for handle in handles {
+        results.push(handle.await.unwrap());
+    }
+
+    for result in &results {
+        assert!(
+            result.is_ok(),
+            "concurrent startup materialize callers should not fail: {results:?}"
+        );
+    }
+    assert!(
+        results.iter().filter(|result| matches!(result, Ok(true))).count() >= 1,
+        "at least one caller should perform the materialize write: {results:?}"
+    );
+
+    let target = tmp.path().join("builtin-skills");
+    assert_eq!(read_version(&target).as_deref(), Some("1.2.3"));
+    assert!(target.join("example-skill").join("SKILL.md").is_file());
+}


### PR DESCRIPTION
## Summary
- Serialize builtin skills startup materialization with an advisory `.builtin-skills.lock`, and re-check `.version` inside the lock so concurrent aioncore starts do not share staging/old dirs.
- Move the file-backed database startup lock ahead of SQLite pool creation, migrations, and system-user initialization so concurrent first-run startup does not hit SQLite `database is locked`.
- Refs Sentry `ELECTRON-1N7`; this addresses the builtin-skills materialize subcause and a related startup DB initialization race. The readonly-database user-permission subcause remains follow-up/diagnostic work.

## Test plan
- `cargo test -p aionui-extension --test startup_materialize concurrent_gate_materialize_all_callers_succeed -- --nocapture`
- `cargo test -p aionui-extension --test startup_materialize`
- `cargo fmt --all -- --check`
- `cargo clippy -p aionui-extension -- -D warnings`
- `cargo test -p aionui-extension`
- `cargo test -p aionui-db --test db_lifecycle concurrent_init_database_does_not_panic_on_unique_conflict -- --nocapture`
- `cargo clippy -p aionui-db -- -D warnings`
- `cargo test -p aionui-db --test db_lifecycle`
- `just push -u origin fix/builtin-skills-materialize`
