### PR TITLE
fix(aionrs): preserve tool call correlation across aborts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,16 @@ Before adding a field:
 
 Only after exhausting the above — and explicitly documenting why each option is insufficient — add a new field. When doing so, also document its lifecycle (who writes, who reads, when it is invalidated) in a doc comment on the field.
 
+### Logging
+
+When changing a critical path, explicitly evaluate whether logs are needed for development diagnosis and production troubleshooting. Add structured logs with appropriate levels:
+- `debug` for detailed, high-frequency internal flow that helps verify behavior and diagnose issues in development
+- `info` for low-volume lifecycle boundaries useful in production
+- `warn` for malformed or unexpected data that is safely handled
+- `error` for contract violations or failed operations
+
+Production-visible logs must not include sensitive payloads such as prompts, tool input/output, file contents, command bodies, tokens, secrets, or raw provider requests/responses. If such payloads are needed for local debugging, they must be behind explicit development-only guards and never enabled by default.
+
 ## Architecture
 
 > For detailed background and design decisions, see [ARCHITECTURE.md](./ARCHITECTURE.md).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,6 @@ dependencies = [
 [[package]]
 name = "aion-agent"
 version = "0.1.26"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.26#6d9a4b06bc963532b7c2e6e08d47e6afd64da047"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -148,7 +147,6 @@ dependencies = [
 [[package]]
 name = "aion-compact"
 version = "0.1.26"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.26#6d9a4b06bc963532b7c2e6e08d47e6afd64da047"
 dependencies = [
  "regex",
  "serde",
@@ -159,7 +157,6 @@ dependencies = [
 [[package]]
 name = "aion-config"
 version = "0.1.26"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.26#6d9a4b06bc963532b7c2e6e08d47e6afd64da047"
 dependencies = [
  "aion-compact",
  "aion-types",
@@ -182,7 +179,6 @@ dependencies = [
 [[package]]
 name = "aion-mcp"
 version = "0.1.26"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.26#6d9a4b06bc963532b7c2e6e08d47e6afd64da047"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -203,7 +199,6 @@ dependencies = [
 [[package]]
 name = "aion-memory"
 version = "0.1.26"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.26#6d9a4b06bc963532b7c2e6e08d47e6afd64da047"
 dependencies = [
  "aion-config",
  "chrono",
@@ -217,7 +212,6 @@ dependencies = [
 [[package]]
 name = "aion-protocol"
 version = "0.1.26"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.26#6d9a4b06bc963532b7c2e6e08d47e6afd64da047"
 dependencies = [
  "aion-types",
  "serde",
@@ -230,7 +224,6 @@ dependencies = [
 [[package]]
 name = "aion-providers"
 version = "0.1.26"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.26#6d9a4b06bc963532b7c2e6e08d47e6afd64da047"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -258,7 +251,6 @@ dependencies = [
 [[package]]
 name = "aion-skills"
 version = "0.1.26"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.26#6d9a4b06bc963532b7c2e6e08d47e6afd64da047"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -284,7 +276,6 @@ dependencies = [
 [[package]]
 name = "aion-tools"
 version = "0.1.26"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.26#6d9a4b06bc963532b7c2e6e08d47e6afd64da047"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -304,7 +295,6 @@ dependencies = [
 [[package]]
 name = "aion-types"
 version = "0.1.26"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.26#6d9a4b06bc963532b7c2e6e08d47e6afd64da047"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6417,7 +6407,6 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.26#6d9a4b06bc963532b7c2e6e08d47e6afd64da047"
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.26"
+version = "0.1.27"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.27#c5f3cae1b086423fc5fe7b00c462c27dd0641767"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -146,7 +147,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.26"
+version = "0.1.27"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.27#c5f3cae1b086423fc5fe7b00c462c27dd0641767"
 dependencies = [
  "regex",
  "serde",
@@ -156,7 +158,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.26"
+version = "0.1.27"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.27#c5f3cae1b086423fc5fe7b00c462c27dd0641767"
 dependencies = [
  "aion-compact",
  "aion-types",
@@ -178,7 +181,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.26"
+version = "0.1.27"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.27#c5f3cae1b086423fc5fe7b00c462c27dd0641767"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -198,7 +202,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.26"
+version = "0.1.27"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.27#c5f3cae1b086423fc5fe7b00c462c27dd0641767"
 dependencies = [
  "aion-config",
  "chrono",
@@ -211,7 +216,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.26"
+version = "0.1.27"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.27#c5f3cae1b086423fc5fe7b00c462c27dd0641767"
 dependencies = [
  "aion-types",
  "serde",
@@ -223,7 +229,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.26"
+version = "0.1.27"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.27#c5f3cae1b086423fc5fe7b00c462c27dd0641767"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -250,7 +257,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.26"
+version = "0.1.27"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.27#c5f3cae1b086423fc5fe7b00c462c27dd0641767"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -275,7 +283,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.26"
+version = "0.1.27"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.27#c5f3cae1b086423fc5fe7b00c462c27dd0641767"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -294,7 +303,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.26"
+version = "0.1.27"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.27#c5f3cae1b086423fc5fe7b00c462c27dd0641767"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6407,6 +6417,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.27#c5f3cae1b086423fc5fe7b00c462c27dd0641767"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { path = "../../../aionrs/.worktrees/fix-tool-call-id-correlation/crates/aion-agent" }
-aion-types = { path = "../../../aionrs/.worktrees/fix-tool-call-id-correlation/crates/aion-types" }
-aion-protocol = { path = "../../../aionrs/.worktrees/fix-tool-call-id-correlation/crates/aion-protocol" }
-aion-config = { path = "../../../aionrs/.worktrees/fix-tool-call-id-correlation/crates/aion-config" }
-aion-mcp = { path = "../../../aionrs/.worktrees/fix-tool-call-id-correlation/crates/aion-mcp" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.27" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.27" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.27" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.27" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.27" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.26" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.26" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.26" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.26" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.26" }
+aion-agent = { path = "../../../aionrs/.worktrees/fix-tool-call-id-correlation/crates/aion-agent" }
+aion-types = { path = "../../../aionrs/.worktrees/fix-tool-call-id-correlation/crates/aion-types" }
+aion-protocol = { path = "../../../aionrs/.worktrees/fix-tool-call-id-correlation/crates/aion-protocol" }
+aion-config = { path = "../../../aionrs/.worktrees/fix-tool-call-id-correlation/crates/aion-config" }
+aion-mcp = { path = "../../../aionrs/.worktrees/fix-tool-call-id-correlation/crates/aion-mcp" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }

--- a/crates/aionui-ai-agent/src/capability/backend_output_sink.rs
+++ b/crates/aionui-ai-agent/src/capability/backend_output_sink.rs
@@ -1,9 +1,5 @@
-use std::collections::HashMap;
-use std::sync::Mutex;
-
 use aion_agent::output::OutputSink;
 use tokio::sync::broadcast;
-use uuid::Uuid;
 
 use crate::protocol::events::{
     AgentStreamEvent, ErrorEventData, FinishEventData, StartEventData, TextEventData, ThinkingEventData, TipType,
@@ -12,14 +8,19 @@ use crate::protocol::events::{
 
 pub struct BackendOutputSink {
     event_tx: broadcast::Sender<AgentStreamEvent>,
-    active_calls: Mutex<HashMap<String, String>>,
 }
 
 impl BackendOutputSink {
     pub fn new(event_tx: broadcast::Sender<AgentStreamEvent>) -> Self {
-        Self {
-            event_tx,
-            active_calls: Mutex::new(HashMap::new()),
+        Self { event_tx }
+    }
+
+    fn internal_call_id(tool_use_id: &str) -> Option<String> {
+        let id = tool_use_id.trim();
+        if id.is_empty() {
+            None
+        } else {
+            Some(format!("aionrs-{id}"))
         }
     }
 }
@@ -40,14 +41,13 @@ impl OutputSink for BackendOutputSink {
         }));
     }
 
-    fn emit_tool_call(&self, name: &str, input: &str) {
-        let parsed_input = serde_json::from_str(input).unwrap_or(serde_json::Value::String(input.to_owned()));
-        let call_id = format!("aionrs-{}", Uuid::now_v7());
+    fn emit_tool_call(&self, tool_use_id: &str, name: &str, input: &str) {
+        let Some(call_id) = Self::internal_call_id(tool_use_id) else {
+            tracing::error!(tool = name, "Cannot emit tool_call with empty tool_use_id");
+            return;
+        };
 
-        self.active_calls
-            .lock()
-            .unwrap()
-            .insert(name.to_owned(), call_id.clone());
+        let parsed_input = serde_json::from_str(input).unwrap_or(serde_json::Value::String(input.to_owned()));
 
         let _ = self.event_tx.send(AgentStreamEvent::ToolCall(ToolCallEventData {
             call_id,
@@ -60,14 +60,17 @@ impl OutputSink for BackendOutputSink {
         }));
     }
 
-    fn emit_tool_result(&self, name: &str, is_error: bool, content: &str) {
+    fn emit_tool_result(&self, tool_use_id: &str, name: &str, is_error: bool, content: &str) {
+        let Some(call_id) = Self::internal_call_id(tool_use_id) else {
+            tracing::error!(tool = name, "Cannot emit tool_result with empty tool_use_id");
+            return;
+        };
+
         let status = if is_error {
             ToolCallStatus::Error
         } else {
             ToolCallStatus::Completed
         };
-
-        let call_id = self.active_calls.lock().unwrap().remove(name).unwrap_or_default();
 
         let _ = self.event_tx.send(AgentStreamEvent::ToolCall(ToolCallEventData {
             call_id,
@@ -153,7 +156,7 @@ mod tests {
     #[test]
     fn emit_tool_call_sends_running_tool_call() {
         let (sink, mut rx) = make_sink();
-        sink.emit_tool_call("Read", r#"{"path":"/tmp/a.txt"}"#);
+        sink.emit_tool_call("call_read_1", "Read", r#"{"path":"/tmp/a.txt"}"#);
         let event = rx.try_recv().unwrap();
         match event {
             AgentStreamEvent::ToolCall(data) => {
@@ -167,7 +170,7 @@ mod tests {
     #[test]
     fn emit_tool_result_success_sends_completed() {
         let (sink, mut rx) = make_sink();
-        sink.emit_tool_result("Read", false, "file content here");
+        sink.emit_tool_result("call_read_1", "Read", false, "file content here");
         let event = rx.try_recv().unwrap();
         match event {
             AgentStreamEvent::ToolCall(data) => {
@@ -181,7 +184,7 @@ mod tests {
     #[test]
     fn emit_tool_result_error_sends_error_status() {
         let (sink, mut rx) = make_sink();
-        sink.emit_tool_result("Bash", true, "command failed");
+        sink.emit_tool_result("call_bash_1", "Bash", true, "command failed");
         let event = rx.try_recv().unwrap();
         match event {
             AgentStreamEvent::ToolCall(data) => {
@@ -190,6 +193,33 @@ mod tests {
             }
             other => panic!("Expected ToolCall, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn duplicate_tool_names_use_distinct_internal_call_ids() {
+        let (sink, mut rx) = make_sink();
+
+        sink.emit_tool_call("call_a", "Glob", r#"{"pattern":"*.rs"}"#);
+        sink.emit_tool_call("call_b", "Glob", r#"{"pattern":"*.toml"}"#);
+        sink.emit_tool_result("call_a", "Glob", false, "first");
+        sink.emit_tool_result("call_b", "Glob", false, "second");
+
+        let events = (0..4).map(|_| rx.try_recv().unwrap()).collect::<Vec<_>>();
+
+        let mut call_ids = vec![];
+        for event in events {
+            match event {
+                AgentStreamEvent::ToolCall(data) => call_ids.push((data.call_id, data.status)),
+                other => panic!("Expected ToolCall, got {:?}", other),
+            }
+        }
+
+        assert_eq!(call_ids[0].0, "aionrs-call_a");
+        assert_eq!(call_ids[1].0, "aionrs-call_b");
+        assert_eq!(call_ids[2].0, "aionrs-call_a");
+        assert_eq!(call_ids[3].0, "aionrs-call_b");
+        assert_eq!(call_ids[2].1, ToolCallStatus::Completed);
+        assert_eq!(call_ids[3].1, ToolCallStatus::Completed);
     }
 
     #[test]
@@ -242,7 +272,7 @@ mod tests {
     #[test]
     fn emit_tool_call_carries_input() {
         let (sink, mut rx) = make_sink();
-        sink.emit_tool_call("Glob", r#"{"pattern":"**/*.rs"}"#);
+        sink.emit_tool_call("call_glob_1", "Glob", r#"{"pattern":"**/*.rs"}"#);
         let event = rx.try_recv().unwrap();
         match event {
             AgentStreamEvent::ToolCall(data) => {
@@ -258,14 +288,14 @@ mod tests {
     #[test]
     fn emit_tool_result_carries_output_and_matching_call_id() {
         let (sink, mut rx) = make_sink();
-        sink.emit_tool_call("Glob", r#"{"pattern":"**/*.rs"}"#);
+        sink.emit_tool_call("call_glob_1", "Glob", r#"{"pattern":"**/*.rs"}"#);
         let start_event = rx.try_recv().unwrap();
         let start_call_id = match &start_event {
             AgentStreamEvent::ToolCall(data) => data.call_id.clone(),
             _ => panic!("Expected ToolCall"),
         };
 
-        sink.emit_tool_result("Glob", false, "src/main.rs\nsrc/lib.rs");
+        sink.emit_tool_result("call_glob_1", "Glob", false, "src/main.rs\nsrc/lib.rs");
         let event = rx.try_recv().unwrap();
         match event {
             AgentStreamEvent::ToolCall(data) => {
@@ -281,7 +311,7 @@ mod tests {
     #[test]
     fn emit_tool_result_empty_content_omits_output() {
         let (sink, mut rx) = make_sink();
-        sink.emit_tool_result("Glob", false, "");
+        sink.emit_tool_result("call_glob_1", "Glob", false, "");
         let event = rx.try_recv().unwrap();
         match event {
             AgentStreamEvent::ToolCall(data) => {
@@ -297,8 +327,8 @@ mod tests {
         let sink = BackendOutputSink::new(tx);
         sink.emit_text_delta("hello", "msg-1");
         sink.emit_thinking("thought", "msg-1");
-        sink.emit_tool_call("Read", "{}");
-        sink.emit_tool_result("Read", false, "ok");
+        sink.emit_tool_call("call_read_1", "Read", "{}");
+        sink.emit_tool_result("call_read_1", "Read", false, "ok");
         sink.emit_stream_start("msg-1");
         sink.emit_stream_end("msg-1", 1, 100, 50, 0, 0);
         sink.emit_error("err");

--- a/crates/aionui-ai-agent/src/capability/backend_output_sink.rs
+++ b/crates/aionui-ai-agent/src/capability/backend_output_sink.rs
@@ -49,6 +49,21 @@ impl OutputSink for BackendOutputSink {
 
         let parsed_input = serde_json::from_str(input).unwrap_or(serde_json::Value::String(input.to_owned()));
 
+        tracing::debug!(
+            tool_use_id = %tool_use_id,
+            call_id = %call_id,
+            tool = name,
+            status = ?ToolCallStatus::Running,
+            "Derived internal tool_call id from aionrs tool_use_id"
+        );
+        tracing::info!(
+            tool_use_id = %tool_use_id,
+            call_id = %call_id,
+            tool = name,
+            status = ?ToolCallStatus::Running,
+            "Emitting aionrs tool_call event"
+        );
+
         let _ = self.event_tx.send(AgentStreamEvent::ToolCall(ToolCallEventData {
             call_id,
             name: name.to_owned(),
@@ -71,6 +86,14 @@ impl OutputSink for BackendOutputSink {
         } else {
             ToolCallStatus::Completed
         };
+
+        tracing::info!(
+            tool_use_id = %tool_use_id,
+            call_id = %call_id,
+            tool = name,
+            status = ?status,
+            "Emitting aionrs tool_result event"
+        );
 
         let _ = self.event_tx.send(AgentStreamEvent::ToolCall(ToolCallEventData {
             call_id,

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -195,6 +195,7 @@ impl crate::agent_task::IAgentTask for AionrsAgentManager {
                     conversation_id = %self.runtime.conversation_id(),
                     "Aionrs engine.run() cancelled by user"
                 );
+                engine.abort_current_turn("Tool execution canceled by user");
                 None
             }
         };
@@ -225,7 +226,8 @@ impl crate::agent_task::IAgentTask for AionrsAgentManager {
                 Err(AppError::Internal(error_msg))
             }
             None => {
-                // Cancelled — Finish already emitted by cancel()
+                self.runtime.emit_error("Stopped by user");
+                self.runtime.emit_finish(None);
                 Ok(())
             }
         }
@@ -239,12 +241,6 @@ impl crate::agent_task::IAgentTask for AionrsAgentManager {
         if let Ok(mut confs) = self.confirmations.write() {
             confs.clear();
         }
-        self.runtime
-            .emit(AgentStreamEvent::Error(crate::protocol::events::ErrorEventData {
-                message: "Stopped by user".into(),
-                code: None,
-            }));
-        self.runtime.emit_finish(None);
         // Signal the tokio::select! in send_message() to drop engine.run()
         self.cancel_notify.notify_waiters();
         Ok(())
@@ -436,7 +432,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stop_emits_finish_event_and_sets_status() {
+    async fn stop_only_signals_in_flight_run() {
         let agent = AionrsAgentManager::new("conv-stop".into(), "/project".into(), make_test_config(), None)
             .await
             .unwrap();
@@ -444,18 +440,8 @@ mod tests {
 
         agent.cancel().await.unwrap();
 
-        assert_eq!(agent.status(), Some(ConversationStatus::Finished));
-
-        match rx.try_recv().unwrap() {
-            AgentStreamEvent::Error(data) => {
-                assert!(data.message.contains("Stopped"));
-            }
-            other => panic!("Expected Error, got {:?}", other),
-        }
-        match rx.try_recv().unwrap() {
-            AgentStreamEvent::Finish(_) => {}
-            other => panic!("Expected Finish, got {:?}", other),
-        }
+        assert_eq!(agent.status(), Some(ConversationStatus::Pending));
+        assert!(matches!(rx.try_recv(), Err(broadcast::error::TryRecvError::Empty)));
     }
 
     #[tokio::test]

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -358,7 +358,7 @@ impl StreamRelay {
     #[tracing::instrument(skip_all)]
     async fn persist_tool_call(&self, data: &aionui_ai_agent::protocol::events::tool_call::ToolCallEventData) {
         if data.call_id.trim().is_empty() {
-            error!(
+            warn!(
                 tool = %data.name,
                 status = ?data.status,
                 "Skipping tool_call persistence because call_id is empty"
@@ -387,7 +387,20 @@ impl StreamRelay {
                 hidden: None,
             };
             if let Err(e) = self.repo.update_message(&data.call_id, &update).await {
-                error!(error = %ErrorChain(&e), "Failed to update tool_call message");
+                error!(
+                    call_id = %data.call_id,
+                    tool = %data.name,
+                    status,
+                    error = %ErrorChain(&e),
+                    "Failed to update tool_call message"
+                );
+            } else {
+                debug!(
+                    call_id = %data.call_id,
+                    tool = %data.name,
+                    status,
+                    "Updated tool_call message"
+                );
             }
         } else {
             let row = MessageRow {
@@ -402,7 +415,20 @@ impl StreamRelay {
                 created_at: now_ms(),
             };
             if let Err(e) = self.repo.insert_message(&row).await {
-                error!(error = %ErrorChain(&e), "Failed to persist tool_call message");
+                error!(
+                    call_id = %data.call_id,
+                    tool = %data.name,
+                    status,
+                    error = %ErrorChain(&e),
+                    "Failed to persist tool_call message"
+                );
+            } else {
+                debug!(
+                    call_id = %data.call_id,
+                    tool = %data.name,
+                    status,
+                    "Persisted tool_call message"
+                );
             }
         }
     }

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -357,6 +357,15 @@ impl StreamRelay {
     /// Persist a Gemini-style tool_call event.
     #[tracing::instrument(skip_all)]
     async fn persist_tool_call(&self, data: &aionui_ai_agent::protocol::events::tool_call::ToolCallEventData) {
+        if data.call_id.trim().is_empty() {
+            error!(
+                tool = %data.name,
+                status = ?data.status,
+                "Skipping tool_call persistence because call_id is empty"
+            );
+            return;
+        }
+
         let status = match data.status {
             ToolCallStatus::Running => "work",
             ToolCallStatus::Completed => "finish",

--- a/crates/aionui-conversation/tests/stream_relay_tool_call.rs
+++ b/crates/aionui-conversation/tests/stream_relay_tool_call.rs
@@ -1,0 +1,77 @@
+use std::sync::Arc;
+
+use aionui_ai_agent::{
+    AgentStreamEvent,
+    protocol::events::{FinishEventData, ToolCallEventData, ToolCallStatus},
+};
+use aionui_common::now_ms;
+use aionui_conversation::stream_relay::StreamRelay;
+use aionui_db::{
+    IConversationRepository, SortOrder, SqliteConversationRepository, init_database_memory, models::ConversationRow,
+};
+use aionui_realtime::BroadcastEventBus;
+use serde_json::json;
+use tokio::sync::broadcast;
+
+async fn setup_repo() -> (Arc<SqliteConversationRepository>, aionui_db::Database) {
+    let db = init_database_memory().await.unwrap();
+    let repo = Arc::new(SqliteConversationRepository::new(db.pool().clone()));
+    let now = now_ms();
+    repo.create(&ConversationRow {
+        id: "conv-1".into(),
+        user_id: "system_default_user".into(),
+        name: "Tool call test".into(),
+        r#type: "aionrs".into(),
+        extra: "{}".into(),
+        model: None,
+        status: Some("running".into()),
+        source: Some("aionui".into()),
+        channel_chat_id: None,
+        pinned: false,
+        pinned_at: None,
+        created_at: now,
+        updated_at: now,
+    })
+    .await
+    .unwrap();
+
+    (repo, db)
+}
+
+#[tokio::test]
+async fn run_tool_call_with_empty_call_id_is_not_persisted() {
+    let (repo, _db) = setup_repo().await;
+    let bus = Arc::new(BroadcastEventBus::new(64));
+    let (tx, _) = broadcast::channel(64);
+
+    let relay = StreamRelay::new(
+        "conv-1".into(),
+        "asst-1".into(),
+        "system_default_user".into(),
+        repo.clone(),
+        bus,
+        None,
+    );
+
+    let rx = tx.subscribe();
+    tx.send(AgentStreamEvent::ToolCall(ToolCallEventData {
+        call_id: "".into(),
+        name: "Glob".into(),
+        args: json!({"pattern": "*.rs"}),
+        status: ToolCallStatus::Running,
+        input: Some(json!({"pattern": "*.rs"})),
+        output: None,
+        description: None,
+    }))
+    .unwrap();
+    tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
+
+    relay.consume(rx).await;
+
+    let messages = repo.get_messages("conv-1", 1, 100, SortOrder::Asc).await.unwrap();
+
+    assert!(
+        messages.items.iter().all(|row| row.r#type != "tool_call"),
+        "empty call_id tool_call must not be persisted"
+    );
+}


### PR DESCRIPTION
## Summary
- Preserves aionrs tool_use_id/call_id correlation through tool call events and stream relay persistence.
- Repairs aborted aionrs turns by closing pending provider tool uses before emitting the terminal event.
- Updates AionCore to consume aionrs v0.1.27 and documents logging expectations in AGENTS.md.

## Test Plan
- `cargo check -p aionui-ai-agent`
- `just push -u origin fix/tool-call-id-correlation`
  - runs cargo fix
  - runs workspace clippy fix with `-D warnings`
  - runs cargo fmt
  - runs `cargo nextest run --workspace`: 5658 passed, 18 skipped
  - pushes the branch after the gate passes