### PR TITLE
fix(team-mcp): use fixed server name to stay within 64-char tool limit (ELECTRON-1JY)

### DIFF
--- a/crates/aionui-ai-agent/src/factory/acp_assembler.rs
+++ b/crates/aionui-ai-agent/src/factory/acp_assembler.rs
@@ -2,7 +2,7 @@ use crate::capability::team_guide_prompt;
 use crate::shared_kernel::PersistedSessionState;
 use agent_client_protocol::schema::{EnvVariable, McpServer, McpServerStdio, NewSessionRequest};
 use aionui_api_types::AgentMetadata;
-use aionui_api_types::{AcpBuildExtra, GuideMcpConfig, TeamMcpStdioConfig};
+use aionui_api_types::{AcpBuildExtra, GuideMcpConfig, TEAM_MCP_SERVER_NAME, TeamMcpStdioConfig};
 use aionui_common::CommandSpec;
 use std::path::PathBuf;
 
@@ -148,7 +148,7 @@ fn team_mcp_server(cfg: &TeamMcpStdioConfig) -> McpServer {
         EnvVariable::new(TeamMcpStdioConfig::ENV_TOKEN.to_owned(), cfg.token.clone()),
         EnvVariable::new(TeamMcpStdioConfig::ENV_SLOT_ID.to_owned(), cfg.slot_id.clone()),
     ];
-    let stdio = McpServerStdio::new(format!("aionui-team-{}", cfg.team_id), &cfg.binary_path)
+    let stdio = McpServerStdio::new(TEAM_MCP_SERVER_NAME, &cfg.binary_path)
         .args(vec!["mcp-team-stdio".to_owned()])
         .env(env);
     McpServer::Stdio(stdio)
@@ -238,7 +238,7 @@ mod tests {
         let servers = resolve_mcp_servers(&config, "conv-1", Vec::new());
         assert_eq!(servers.len(), 1);
         match &servers[0] {
-            McpServer::Stdio(s) => assert!(s.name.contains("team-1")),
+            McpServer::Stdio(s) => assert_eq!(s.name, TEAM_MCP_SERVER_NAME),
             _ => panic!("expected stdio server"),
         }
     }
@@ -365,7 +365,7 @@ mod tests {
         let servers = resolve_mcp_servers(&config, "conv-1", user);
         assert_eq!(servers.len(), 2);
         match &servers[0] {
-            McpServer::Stdio(s) => assert!(s.name.contains("team-1"), "team must come first"),
+            McpServer::Stdio(s) => assert_eq!(s.name, TEAM_MCP_SERVER_NAME, "team must come first"),
             _ => panic!("expected stdio"),
         }
         match &servers[1] {

--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use aion_agent::session::SessionManager;
 use aion_config::config::{McpServerConfig, TransportType};
-use aionui_api_types::{AionrsBuildExtra, GuideMcpConfig, TeamMcpStdioConfig};
+use aionui_api_types::{AionrsBuildExtra, GuideMcpConfig, TEAM_MCP_SERVER_NAME, TeamMcpStdioConfig};
 use aionui_common::AppError;
 use tracing::{debug, info};
 
@@ -291,7 +291,7 @@ fn team_mcp_to_config(cfg: &TeamMcpStdioConfig) -> HashMap<String, McpServerConf
         deferred: Some(false),
     };
 
-    HashMap::from([(format!("aionui-team-{}", cfg.team_id), server)])
+    HashMap::from([(TEAM_MCP_SERVER_NAME.to_owned(), server)])
 }
 
 fn guide_mcp_to_config(
@@ -496,9 +496,9 @@ mod tests {
 
         let result = resolve_mcp_servers(&overrides, "conv-1");
         assert_eq!(result.len(), 1);
-        assert!(result.contains_key("aionui-team-team-42"));
+        assert!(result.contains_key(TEAM_MCP_SERVER_NAME));
 
-        let server = &result["aionui-team-team-42"];
+        let server = &result[TEAM_MCP_SERVER_NAME];
         assert_eq!(server.transport, TransportType::Stdio);
         assert_eq!(server.command.as_deref(), Some("/usr/bin/backend"));
         assert_eq!(server.args.as_deref(), Some(&["mcp-team-stdio".to_owned()][..]));

--- a/crates/aionui-ai-agent/src/manager/acp/permission_router.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/permission_router.rs
@@ -9,7 +9,11 @@ use tokio::sync::{Mutex, mpsc, oneshot};
 use tracing::debug;
 
 /// MCP tool prefixes that are auto-approved without user permission.
-const AUTO_APPROVE_PREFIXES: &[&str] = &["mcp__aionui-team-", "mcp__aionui-team-guide__"];
+///
+/// `mcp__aionui-team__` matches the team stdio bridge tools (server name is now
+/// the fixed `aionui-team` — see `TEAM_MCP_SERVER_NAME`).
+/// `mcp__aionui-team-guide__` matches the solo-session Guide tools.
+const AUTO_APPROVE_PREFIXES: &[&str] = &["mcp__aionui-team__", "mcp__aionui-team-guide__"];
 
 /// Routes ACP permission requests from the protocol layer to the user
 /// (via `event_tx`) and back (via `confirm`). Owns the receiver channel

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -131,5 +131,5 @@ pub use team::{
     TeamAgentShutdownPayload, TeamAgentSpawnedPayload, TeamAgentStatusPayload, TeamListResponse, TeamMcpPhase,
     TeamMcpStatusPayload, TeamResponse, TeammateMessagePayload,
 };
-pub use team_mcp::{GuideMcpConfig, TeamMcpStdioConfig};
+pub use team_mcp::{GuideMcpConfig, TEAM_MCP_SERVER_NAME, TeamMcpStdioConfig};
 pub use websocket::WebSocketMessage;

--- a/crates/aionui-api-types/src/team_mcp.rs
+++ b/crates/aionui-api-types/src/team_mcp.rs
@@ -6,6 +6,16 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Fixed wire-level MCP server name for the team stdio bridge.
+///
+/// Anthropic's tool name regex caps total length at 64 chars and the wire-level
+/// tool name is `mcp__<server_name>__<tool>`. A 36-char UUID v7 `team_id`
+/// embedded in the server name pushed `team_describe_assistant` to 78 chars and
+/// caused `invalid_request_error: 工具名称过长` (ELECTRON-1JY). Team routing
+/// has always been done via per-team TCP port + auth token, so the team_id was
+/// redundant in the server name.
+pub const TEAM_MCP_SERVER_NAME: &str = "aionui-team";
+
 /// Connection config for the Guide MCP stdio server in solo conversations.
 ///
 /// Passed through `AcpBuildExtra::guide_mcp_config` by the factory so that
@@ -20,10 +30,9 @@ pub struct GuideMcpConfig {
 
 /// Stdio connection config for the team session MCP server.
 ///
-/// `team_id` is persisted alongside the connection triple so every
-/// consumer (D3 spec builder, D10 ACP injector, D7 bridge subcommand)
-/// can derive the wire-level MCP server name `aionui-team-<team_id>`
-/// without threading a second parameter through unrelated call sites.
+/// `team_id` is persisted for diagnostics; the wire-level MCP server name is
+/// the fixed [`TEAM_MCP_SERVER_NAME`] (team routing happens via per-team TCP
+/// port + auth token, not via the server name — see ELECTRON-1JY).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TeamMcpStdioConfig {
     pub team_id: String,
@@ -58,6 +67,29 @@ mod tests {
         let json = serde_json::to_string(&cfg).unwrap();
         let parsed: TeamMcpStdioConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(cfg, parsed);
+    }
+
+    /// ELECTRON-1JY regression: Anthropic caps tool names at 64 chars,
+    /// where the wire-level name is `mcp__<server_name>__<tool>`. The
+    /// previous design embedded a 36-char UUID v7 `team_id` into the
+    /// server name, which pushed `team_describe_assistant` to 78 chars
+    /// and triggered `invalid_request_error: 工具名称过长`.
+    ///
+    /// This test pins the longest known team tool name against the
+    /// 64-char bound so any future tool / rename that would re-break the
+    /// limit fails locally instead of in production.
+    #[test]
+    fn team_mcp_tool_names_stay_within_anthropic_64_char_limit() {
+        // Longest tool name currently registered on the team MCP server.
+        // Update if a longer-named tool is added.
+        let longest_tool = "team_describe_assistant";
+        let wire_name = format!("mcp__{TEAM_MCP_SERVER_NAME}__{longest_tool}");
+        assert!(
+            wire_name.len() <= 64,
+            "Anthropic 64-char tool-name limit exceeded: {} ({} chars)",
+            wire_name,
+            wire_name.len()
+        );
     }
 
     #[test]

--- a/crates/aionui-team/src/lib.rs
+++ b/crates/aionui-team/src/lib.rs
@@ -21,7 +21,8 @@ pub use error::TeamError;
 pub use events::TeamEventEmitter;
 pub use guide::{GuideMcpServer, handle_aion_list_models};
 pub use mailbox::Mailbox;
-pub use mcp::{TeamMcpServer, TeamMcpStdioConfig, TeamMcpStdioServerSpec};
+pub use mcp::{TEAM_MCP_SERVER_NAME, TeamMcpServer, TeamMcpStdioConfig, TeamMcpStdioServerSpec};
+
 pub use prompts::{build_lead_prompt, build_teammate_prompt, build_wake_payload};
 pub use routes::{TeamRouterState, team_routes};
 pub use scheduler::{

--- a/crates/aionui-team/src/mcp/bridge.rs
+++ b/crates/aionui-team/src/mcp/bridge.rs
@@ -12,12 +12,13 @@ use std::path::PathBuf;
 
 use agent_client_protocol::schema::{EnvVariable, McpServer, McpServerStdio};
 
-pub use aionui_api_types::TeamMcpStdioConfig;
+pub use aionui_api_types::{TEAM_MCP_SERVER_NAME, TeamMcpStdioConfig};
 
 /// Stdio MCP server description ready to be handed to `session/new`.
 ///
-/// Field shapes are fixed by [phase1 interface-contracts.md §3]:
-/// - `name` = `"aionui-team-<team_id>"`
+/// Field shapes:
+/// - `name` = `"aionui-team"` (fixed; team routing is done via `port` + `token`,
+///   not via the server name — see `TeamMcpServer` per-team TCP listener)
 /// - `command` = absolute path to the backend binary (resolved via
 ///   `std::env::current_exe()` at app startup)
 /// - `args` = `["mcp-bridge"]`
@@ -35,12 +36,12 @@ impl TeamMcpStdioServerSpec {
     ///
     /// `backend_binary_path` is the absolute path to the `aioncore`
     /// executable (phase1 single-binary constraint — no standalone bridge).
-    /// `team_id` is read from `cfg.team_id` rather than taken as a separate
-    /// parameter so the wire-level server name stays in sync with the
-    /// persisted config across every consumer.
     pub fn from_config(backend_binary_path: &str, cfg: &TeamMcpStdioConfig) -> Self {
+        // `cfg.team_id` is intentionally not embedded in the server name — see
+        // `TEAM_MCP_SERVER_NAME` doc comment. It is still kept on the persisted
+        // config for diagnostics and future consumers.
         Self {
-            name: format!("aionui-team-{}", cfg.team_id),
+            name: TEAM_MCP_SERVER_NAME.to_owned(),
             command: backend_binary_path.to_owned(),
             args: vec!["mcp-bridge".to_owned()],
             env: vec![
@@ -87,7 +88,7 @@ mod tests {
     fn from_config_fills_all_fields() {
         let spec = TeamMcpStdioServerSpec::from_config("/usr/bin/aioncore", &sample_cfg());
 
-        assert_eq!(spec.name, "aionui-team-team-42");
+        assert_eq!(spec.name, TEAM_MCP_SERVER_NAME);
         assert_eq!(spec.command, "/usr/bin/aioncore");
         assert_eq!(spec.args, vec!["mcp-bridge".to_owned()]);
         assert_eq!(spec.env.len(), 3);
@@ -118,7 +119,7 @@ mod tests {
 
         // `Stdio` variant is `#[serde(untagged)]` inside `McpServer`, so the
         // JSON is the raw `McpServerStdio` shape — no `"type":"stdio"` tag.
-        assert_eq!(json["name"], "aionui-team-team-42");
+        assert_eq!(json["name"], TEAM_MCP_SERVER_NAME);
         assert_eq!(json["command"], "/bin/aioncore");
         assert_eq!(json["args"], serde_json::json!(["mcp-bridge"]));
 

--- a/crates/aionui-team/src/mcp/mod.rs
+++ b/crates/aionui-team/src/mcp/mod.rs
@@ -3,5 +3,6 @@ pub mod protocol;
 pub mod server;
 pub mod tools;
 
+pub use aionui_api_types::TEAM_MCP_SERVER_NAME;
 pub use bridge::{TeamMcpStdioConfig, TeamMcpStdioServerSpec};
 pub use server::TeamMcpServer;

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -1124,10 +1124,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stdio_spec_embeds_team_and_binary_path() {
+    async fn stdio_spec_uses_fixed_name_and_binary_path() {
         let session = start_session().await;
         let spec = session.stdio_spec("lead-1");
-        assert_eq!(spec.name, "aionui-team-t1");
+        assert_eq!(spec.name, crate::mcp::TEAM_MCP_SERVER_NAME);
         assert_eq!(spec.command, "/tmp/aioncore-test");
         assert_eq!(spec.args, vec!["mcp-bridge".to_string()]);
         assert!(spec.env.iter().any(|(k, v)| k == "TEAM_AGENT_SLOT_ID" && v == "lead-1"));


### PR DESCRIPTION
## Summary
- Anthropic caps tool names at 64 chars (wire form `mcp__<server>__<tool>`); embedding a 36-char UUID v7 `team_id` into the team MCP server name pushed `team_describe_assistant` to 78 chars and triggered `invalid_request_error: 工具名称过长` (Sentry ELECTRON-1JY).
- Hoist the server name to a fixed `TEAM_MCP_SERVER_NAME = "aionui-team"` constant in `aionui-api-types` (foundation layer reachable from both `aionui-team` and `aionui-ai-agent`); team routing was always done via per-team TCP port + auth token, so the team_id was redundant in the name.
- Tighten the auto-approve prefix in `permission_router` from `mcp__aionui-team-` to `mcp__aionui-team__` (precise double-underscore — the old single-dash form happened to also catch `mcp__aionui-team-guide__`, which is now matched by its own dedicated entry).
- Pin the limit with a unit test that asserts the longest current tool name (`team_describe_assistant`) plus `mcp__aionui-team__` stays ≤ 64 chars, so any future tool addition that would re-break the limit fails locally.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p aionui-api-types -p aionui-team -p aionui-ai-agent --all-targets -- -D warnings`
- [x] `cargo test -p aionui-api-types -p aionui-team -p aionui-ai-agent`
- [x] `just push` full-workspace nextest gate (5657 tests passed)
- [x] `just build` release binary built and reinstalled to `~/.cargo/bin/aioncore`; running AionUi Dev resolves to the new binary via system PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)