### PR TITLE
fix(startup): add backend readiness diagnostics

### DIFF
--- a/crates/aionui-app/src/router/routes.rs
+++ b/crates/aionui-app/src/router/routes.rs
@@ -1,6 +1,7 @@
 //! Top-level router assembly: middleware stack + module route merges.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use axum::extract::DefaultBodyLimit;
 use axum::http::Method;
@@ -42,6 +43,9 @@ use super::trace::with_access_log;
 /// 2. CSRF protection (Double Submit Cookie)
 /// 3. Route handlers (auth routes + system routes + conversation routes + file routes + health check)
 pub async fn create_router(services: &AppServices) -> Router {
+    let boot = Instant::now();
+    tracing::info!("startup: router assembly started");
+
     // Bridge event bus → WebSocket manager: forward all broadcast events
     // to connected WebSocket clients.
     let mut event_rx = services.event_bus.subscribe();
@@ -53,17 +57,26 @@ pub async fn create_router(services: &AppServices) -> Router {
     });
 
     let (states, channel_components) = build_module_states(services).await;
+    tracing::info!(elapsed_ms = boot.elapsed().as_millis(), "startup: module states built");
 
     // Wire TeamSessionService into Guide MCP server now that both are available.
     services
         .inject_guide_service(Arc::downgrade(&states.team.service))
         .await;
+    tracing::info!(
+        elapsed_ms = boot.elapsed().as_millis(),
+        "startup: guide MCP service injected"
+    );
 
     // Start channel orchestrator (message loop)
     tokio::spawn(
         channel_components
             .orchestrator
             .run(channel_components.message_rx, channel_components.confirm_rx),
+    );
+    tracing::info!(
+        elapsed_ms = boot.elapsed().as_millis(),
+        "startup: channel orchestrator spawned"
     );
 
     // Restore enabled channel plugins (starts receiving IM messages)
@@ -74,8 +87,17 @@ pub async fn create_router(services: &AppServices) -> Router {
             tracing::warn!(error = %e, "failed to restore channel plugins");
         }
     });
+    tracing::info!(
+        elapsed_ms = boot.elapsed().as_millis(),
+        "startup: channel plugin restore scheduled"
+    );
 
-    create_router_with_states(services, states)
+    let router = create_router_with_states(services, states);
+    tracing::info!(
+        elapsed_ms = boot.elapsed().as_millis(),
+        "startup: router assembly completed"
+    );
+    router
 }
 
 /// Create the application router with custom module states.

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -4,6 +4,7 @@
 //! `build_*_state` constructs one `*RouterState` from `AppServices`.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use aionui_ai_agent::{AgentRouterState, AgentService, RemoteAgentRouterState, RemoteAgentService};
 use aionui_assistant::{AssistantRouterState, AssistantService, BuiltinAssistantRegistry};
@@ -101,16 +102,31 @@ pub struct ChannelOrchestratorComponents {
 
 /// Build all default `ModuleStates` from application services.
 pub async fn build_module_states(services: &AppServices) -> (ModuleStates, ChannelOrchestratorComponents) {
+    let boot = Instant::now();
+    tracing::info!("startup: module state build started");
+
     let (ext_state, hub_state, mut skill_state) = build_extension_states(services).await;
+    tracing::info!(
+        elapsed_ms = boot.elapsed().as_millis(),
+        "startup: extension states built"
+    );
 
     let scan_paths = resolve_scan_paths_for_data_dir(&services.data_dir);
     if let Err(error) = ext_state.registry.initialize_with_scan_paths(scan_paths).await {
         tracing::warn!(error = %error, "extension registry initialize failed");
     }
+    tracing::info!(
+        elapsed_ms = boot.elapsed().as_millis(),
+        "startup: extension registry initialized"
+    );
 
     let assistant = build_assistant_state(services, ext_state.registry.clone());
     let cron = build_cron_state(services);
     cron.cron_service.init().await;
+    tracing::info!(
+        elapsed_ms = boot.elapsed().as_millis(),
+        "startup: cron state initialized"
+    );
 
     // The agent catalog already hydrated at startup (see `lib.rs`).
     // Extension-contributed rows will land in `agent_metadata` in a
@@ -120,6 +136,7 @@ pub async fn build_module_states(services: &AppServices) -> (ModuleStates, Chann
     skill_state.assistant_dispatcher = Some(dispatcher);
 
     let (channel_state, channel_components) = build_channel_state(services, ext_state.registry.clone()).await;
+    tracing::info!(elapsed_ms = boot.elapsed().as_millis(), "startup: channel state built");
 
     let backend_binary_path = Arc::new(
         std::env::current_exe()
@@ -156,6 +173,10 @@ pub async fn build_module_states(services: &AppServices) -> (ModuleStates, Chann
         shell: build_shell_state(services),
         assistant,
     };
+    tracing::info!(
+        elapsed_ms = boot.elapsed().as_millis(),
+        "startup: module state build completed"
+    );
 
     (states, channel_components)
 }


### PR DESCRIPTION
## Summary
- add startup milestone logs around router assembly before /health becomes available
- record elapsed timing for module state construction, extension registry setup, cron state, channel state, guide MCP injection, channel orchestration, and router completion
- improve diagnosis for Electron health-timeout startup reports that stop before the server listening log

## Verification
- just push
- cargo fmt --all
- cargo test -p aionui-app
- cargo clippy -p aionui-app -- -D warnings

## Sentry
- ELECTRON-1N8