### PR TITLE
Recover pending ACP permission prompts

### DIFF
--- a/crates/aionui-ai-agent/src/agent_task.rs
+++ b/crates/aionui-ai-agent/src/agent_task.rs
@@ -260,13 +260,12 @@ impl AgentInstance {
 
     /// Pending confirmation items for this task.
     ///
-    /// ACP currently tracks permission prompts inline through the
-    /// permission router (not surfaced here), so returns empty.
-    /// Aionrs / OpenClaw / Remote maintain inline confirmation lists.
+    /// ACP surfaces pending permission prompts through its permission
+    /// router. Aionrs / OpenClaw / Remote maintain inline confirmation lists.
     /// Nanobot has no concept of confirmations.
     pub fn get_confirmations(&self) -> Vec<aionui_common::Confirmation> {
         match self {
-            Self::Acp(_) => Vec::new(),
+            Self::Acp(m) => m.get_confirmations(),
             Self::Aionrs(m) => m.get_confirmations(),
             Self::OpenClaw(m) => m.get_confirmations(),
             Self::Nanobot(_) => Vec::new(),

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -720,6 +720,12 @@ impl AcpAgentManager {
         })
     }
 
+    /// Pending ACP permission prompts recoverable through the conversation
+    /// confirmation API.
+    pub fn get_confirmations(&self) -> Vec<aionui_common::Confirmation> {
+        self.permission_router.get_confirmations()
+    }
+
     /// Submit a permission response for a pending tool call. ACP confirms
     /// always carry an `option_id`; `always_allow` is consumed by the CLI
     /// and is not reflected in the local approval memory (the ACP CLI

--- a/crates/aionui-ai-agent/src/manager/acp/permission_router.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/permission_router.rs
@@ -1,6 +1,7 @@
 use crate::agent_runtime::AgentRuntime;
 use crate::protocol::acp::{PermissionDecision, PermissionRequest};
 use crate::protocol::events::{AgentStreamEvent, permission_request_to_event_data};
+use aionui_common::Confirmation;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
@@ -15,6 +16,11 @@ use tracing::debug;
 /// `mcp__aionui-team-guide__` matches the solo-session Guide tools.
 const AUTO_APPROVE_PREFIXES: &[&str] = &["mcp__aionui-team__", "mcp__aionui-team-guide__"];
 
+struct PendingPermission {
+    responder: oneshot::Sender<PermissionDecision>,
+    confirmation: Confirmation,
+}
+
 /// Routes ACP permission requests from the protocol layer to the user
 /// (via `event_tx`) and back (via `confirm`). Owns the receiver channel
 /// for incoming permission requests, the pending responder map, and the
@@ -23,8 +29,8 @@ const AUTO_APPROVE_PREFIXES: &[&str] = &["mcp__aionui-team__", "mcp__aionui-team
 pub struct PermissionRouter {
     /// Receiver for permission requests from the protocol layer.
     permission_rx: Mutex<mpsc::Receiver<PermissionRequest>>,
-    /// Pending ACP permission responders keyed by tool call ID.
-    pending_permissions: StdMutex<HashMap<String, oneshot::Sender<PermissionDecision>>>,
+    /// Pending ACP permission responders and recovery data keyed by tool call ID.
+    pending_permissions: StdMutex<HashMap<String, PendingPermission>>,
     /// Whether a graceful shutdown is in progress.
     closing: AtomicBool,
 }
@@ -67,24 +73,48 @@ impl PermissionRouter {
                     continue;
                 }
 
+                let permission_event = permission_request_to_event_data(&perm_req.request);
+                let confirmation = permission_event
+                    .as_confirmation()
+                    .expect("ACP permission events must be recoverable as confirmations");
+
                 let mut pending = this.pending_permissions.lock().unwrap();
-                if let Some(previous) = pending.insert(call_id.clone(), perm_req.response_tx) {
-                    let _ = previous.send(PermissionDecision::Cancelled);
+                if let Some(previous) = pending.insert(
+                    call_id.clone(),
+                    PendingPermission {
+                        responder: perm_req.response_tx,
+                        confirmation,
+                    },
+                ) {
+                    let _ = previous.responder.send(PermissionDecision::Cancelled);
                 }
                 drop(pending);
-
-                let permission_event = permission_request_to_event_data(&perm_req.request);
+                debug!(
+                    conversation_id = %runtime.conversation_id(),
+                    call_id,
+                    "ACP permission pending confirmation registered"
+                );
 
                 if runtime
                     .event_sender()
                     .send(AgentStreamEvent::AcpPermission(permission_event))
                     .is_err()
-                    && let Some(response_tx) = this.pending_permissions.lock().unwrap().remove(&call_id)
+                    && let Some(pending) = this.pending_permissions.lock().unwrap().remove(&call_id)
                 {
-                    let _ = response_tx.send(PermissionDecision::Cancelled);
+                    let _ = pending.responder.send(PermissionDecision::Cancelled);
                 }
             }
         });
+    }
+
+    /// Pending permission items recoverable by conversation confirmation APIs.
+    pub fn get_confirmations(&self) -> Vec<Confirmation> {
+        self.pending_permissions
+            .lock()
+            .unwrap()
+            .values()
+            .map(|pending| pending.confirmation.clone())
+            .collect()
     }
 
     /// Resolve a pending permission request with the user's selected option.
@@ -94,7 +124,7 @@ impl PermissionRouter {
         option_id: String,
         conversation_id: &str,
     ) -> Result<(), aionui_common::AppError> {
-        let responder = self
+        let pending = self
             .pending_permissions
             .lock()
             .unwrap()
@@ -103,7 +133,8 @@ impl PermissionRouter {
                 aionui_common::AppError::BadRequest(format!("Pending ACP permission not found: {call_id}"))
             })?;
 
-        responder
+        pending
+            .responder
             .send(PermissionDecision::Selected { option_id })
             .map_err(|_| aionui_common::AppError::BadRequest(format!("Pending ACP permission expired: {call_id}")))?;
 
@@ -113,8 +144,8 @@ impl PermissionRouter {
 
     /// Cancel all pending permission requests. Called during `stop()` and `kill()`.
     pub fn cancel_all(&self) {
-        for (_, responder) in self.pending_permissions.lock().unwrap().drain() {
-            let _ = responder.send(PermissionDecision::Cancelled);
+        for (_, pending) in self.pending_permissions.lock().unwrap().drain() {
+            let _ = pending.responder.send(PermissionDecision::Cancelled);
         }
     }
 
@@ -127,9 +158,168 @@ impl PermissionRouter {
     pub fn set_closing(&self) {
         self.closing.store(true, Ordering::Release);
     }
+
+    #[cfg(test)]
+    fn insert_pending_for_test(
+        &self,
+        call_id: String,
+        responder: oneshot::Sender<PermissionDecision>,
+        confirmation: Confirmation,
+    ) {
+        self.pending_permissions.lock().unwrap().insert(
+            call_id,
+            PendingPermission {
+                responder,
+                confirmation,
+            },
+        );
+    }
 }
 
 fn is_auto_approve_tool(request: &agent_client_protocol::schema::RequestPermissionRequest) -> bool {
     let title = request.tool_call.fields.title.as_deref().unwrap_or("");
     AUTO_APPROVE_PREFIXES.iter().any(|prefix| title.starts_with(prefix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::events::AgentStreamEvent;
+    use agent_client_protocol::schema::{
+        PermissionOption, PermissionOptionKind as SdkPermissionOptionKind, RequestPermissionRequest,
+        ToolCallUpdate as SdkToolCallUpdate, ToolCallUpdateFields, ToolKind as SdkToolKind,
+    };
+    use aionui_common::Confirmation;
+    use serde_json::json;
+    use std::time::Duration;
+
+    fn sample_confirmation(call_id: &str) -> Confirmation {
+        Confirmation {
+            id: call_id.to_owned(),
+            call_id: call_id.to_owned(),
+            title: Some("Write file".to_owned()),
+            action: None,
+            description: "Write /tmp/current_time.txt".to_owned(),
+            command_type: Some("edit".to_owned()),
+            options: vec![aionui_common::ConfirmationOption {
+                label: "Allow".to_owned(),
+                value: json!("allow_once"),
+                params: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn get_confirmations_returns_pending_acp_permission() {
+        let (_tx, rx) = mpsc::channel(1);
+        let router = PermissionRouter::new(rx);
+        let (response_tx, _response_rx) = oneshot::channel();
+
+        router.insert_pending_for_test("tool-1".to_owned(), response_tx, sample_confirmation("tool-1"));
+
+        let confirmations = router.get_confirmations();
+        assert_eq!(confirmations.len(), 1);
+        assert_eq!(confirmations[0].id, "tool-1");
+        assert_eq!(confirmations[0].call_id, "tool-1");
+        assert_eq!(confirmations[0].description, "Write /tmp/current_time.txt");
+    }
+
+    #[test]
+    fn confirm_removes_pending_confirmation_and_forwards_option() {
+        let (_tx, rx) = mpsc::channel(1);
+        let router = PermissionRouter::new(rx);
+        let (response_tx, mut response_rx) = oneshot::channel();
+        router.insert_pending_for_test("tool-1".to_owned(), response_tx, sample_confirmation("tool-1"));
+
+        router
+            .confirm("tool-1", "allow_once".to_owned(), "conv-1")
+            .expect("confirm should succeed");
+
+        assert!(router.get_confirmations().is_empty());
+        assert!(matches!(
+            response_rx.try_recv(),
+            Ok(PermissionDecision::Selected { option_id }) if option_id == "allow_once"
+        ));
+    }
+
+    #[test]
+    fn confirm_missing_permission_returns_specific_error() {
+        let (_tx, rx) = mpsc::channel(1);
+        let router = PermissionRouter::new(rx);
+
+        let error = router
+            .confirm("missing-tool", "allow_once".to_owned(), "conv-1")
+            .expect_err("missing permission should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Pending ACP permission not found: missing-tool")
+        );
+    }
+
+    #[test]
+    fn cancel_all_removes_pending_confirmations() {
+        let (_tx, rx) = mpsc::channel(1);
+        let router = PermissionRouter::new(rx);
+        let (response_tx, _response_rx) = oneshot::channel();
+        router.insert_pending_for_test("tool-1".to_owned(), response_tx, sample_confirmation("tool-1"));
+
+        router.cancel_all();
+
+        assert!(router.get_confirmations().is_empty());
+    }
+
+    #[tokio::test]
+    async fn start_routes_permission_request_and_exposes_recoverable_confirmation() {
+        let (permission_tx, permission_rx) = mpsc::channel(1);
+        let router = Arc::new(PermissionRouter::new(permission_rx));
+        let runtime = AgentRuntime::new("conv-1", "/tmp/workspace", 8);
+        let mut event_rx = runtime.subscribe();
+        router.start(runtime);
+
+        let request = RequestPermissionRequest::new(
+            "session-1",
+            SdkToolCallUpdate::new(
+                "tool-1",
+                ToolCallUpdateFields::new()
+                    .title("Write file")
+                    .kind(SdkToolKind::Edit)
+                    .raw_input(json!({ "description": "Write /tmp/current_time.txt" })),
+            ),
+            vec![PermissionOption::new(
+                "allow_once",
+                "Allow",
+                SdkPermissionOptionKind::AllowOnce,
+            )],
+        );
+        let (response_tx, mut response_rx) = oneshot::channel();
+
+        permission_tx
+            .send(PermissionRequest { request, response_tx })
+            .await
+            .expect("permission request should be accepted");
+
+        let event = tokio::time::timeout(Duration::from_secs(1), event_rx.recv())
+            .await
+            .expect("permission event should be emitted")
+            .expect("permission event channel should stay open");
+        assert!(matches!(event, AgentStreamEvent::AcpPermission(_)));
+
+        let confirmations = router.get_confirmations();
+        assert_eq!(confirmations.len(), 1);
+        assert_eq!(confirmations[0].id, "tool-1");
+        assert_eq!(confirmations[0].call_id, "tool-1");
+        assert_eq!(confirmations[0].command_type.as_deref(), Some("edit"));
+
+        router
+            .confirm("tool-1", "allow_once".to_owned(), "conv-1")
+            .expect("confirm should resolve routed request");
+
+        assert!(router.get_confirmations().is_empty());
+        assert!(matches!(
+            response_rx.try_recv(),
+            Ok(PermissionDecision::Selected { option_id }) if option_id == "allow_once"
+        ));
+    }
 }


### PR DESCRIPTION
## Summary
- Store ACP pending permission responder state together with recoverable confirmation data in `PermissionRouter`
- Expose ACP pending confirmations through `AgentInstance::get_confirmations()` without adding new `AcpAgentManager` fields
- Add tests for pending permission recovery, confirm forwarding, cancellation, and routed ACP permission requests

## Test Plan
- `cargo fmt --all -- --check`
- `cargo test -p aionui-ai-agent`
- `cargo test -p aionui-conversation confirmation`
- `cargo clippy -p aionui-ai-agent -- -D warnings`
- `just push -u origin fix/pending-permission-recovery`
