### PR TITLE
Fix transient startup file lock failures

### DIFF
--- a/crates/aionui-db/src/database.rs
+++ b/crates/aionui-db/src/database.rs
@@ -16,6 +16,13 @@ const MAX_CONNECTIONS: u32 = 5;
 
 /// SQLite busy timeout in milliseconds.
 const BUSY_TIMEOUT_MS: u64 = 5000;
+const STARTUP_FILE_RETRY_DELAYS: [Duration; 5] = [
+    Duration::from_millis(50),
+    Duration::from_millis(100),
+    Duration::from_millis(200),
+    Duration::from_millis(400),
+    Duration::from_millis(800),
+];
 
 /// Wraps a SQLite connection pool with lifecycle management.
 #[derive(Clone, Debug)]
@@ -102,9 +109,42 @@ pub fn maybe_copy_legacy_database(target: &Path) -> Result<(), DbError> {
         return Ok(());
     }
 
+    let lock_path = migrate_lock_path(target);
+    let _guard = match MigrateLockGuard::acquire(&lock_path) {
+        Ok(guard) => Some(guard),
+        Err(e) => {
+            warn!(
+                lock = %lock_path.display(),
+                error = %e,
+                "Could not acquire legacy database copy lock; continuing without it"
+            );
+            None
+        }
+    };
+    if target.exists() {
+        return Ok(());
+    }
+
     let tmp = target.with_extension("db.tmp");
-    std::fs::copy(&legacy, &tmp).map_err(|e| DbError::Init(format!("Failed to copy legacy database: {e}")))?;
-    std::fs::rename(&tmp, target).map_err(|e| DbError::Init(format!("Failed to rename temp database: {e}")))?;
+    retry_startup_file_op("copy legacy database", &legacy, || std::fs::copy(&legacy, &tmp))
+        .map_err(|e| DbError::Init(format!("Failed to copy legacy database: {e}")))?;
+    if target.exists() {
+        let _ = std::fs::remove_file(&tmp);
+        return Ok(());
+    }
+    match retry_startup_file_op("rename temp database", &tmp, || std::fs::rename(&tmp, target)) {
+        Ok(()) => {}
+        Err(e) if target.exists() => {
+            warn!(
+                target = %target.display(),
+                tmp = %tmp.display(),
+                error = %e,
+                "Legacy database target appeared after rename failed; using existing target"
+            );
+            let _ = std::fs::remove_file(&tmp);
+        }
+        Err(e) => return Err(DbError::Init(format!("Failed to rename temp database: {e}"))),
+    }
 
     let _ = std::fs::remove_file(target.with_extension("db-wal"));
     let _ = std::fs::remove_file(target.with_extension("db-shm"));
@@ -163,6 +203,41 @@ fn migrate_lock_path(db_path: &Path) -> PathBuf {
     };
     p.set_file_name(new_name);
     p
+}
+
+fn retry_startup_file_op<T, F>(operation: &str, path: &Path, mut op: F) -> std::io::Result<T>
+where
+    F: FnMut() -> std::io::Result<T>,
+{
+    for (attempt, delay) in STARTUP_FILE_RETRY_DELAYS.iter().enumerate() {
+        match op() {
+            Ok(value) => return Ok(value),
+            Err(e) if is_retryable_startup_file_error(&e) => {
+                warn!(
+                    operation,
+                    path = %path.display(),
+                    attempt = attempt + 1,
+                    retry_after_ms = delay.as_millis(),
+                    raw_os_error = ?e.raw_os_error(),
+                    error = %e,
+                    "Startup file operation failed; retrying"
+                );
+                std::thread::sleep(*delay);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    op()
+}
+
+fn is_retryable_startup_file_error(error: &std::io::Error) -> bool {
+    match error.kind() {
+        std::io::ErrorKind::Interrupted
+        | std::io::ErrorKind::PermissionDenied
+        | std::io::ErrorKind::TimedOut
+        | std::io::ErrorKind::WouldBlock => true,
+        _ => matches!(error.raw_os_error(), Some(5 | 32 | 33)),
+    }
 }
 
 async fn run_migrations(pool: &SqlitePool) -> Result<(), DbError> {
@@ -448,5 +523,22 @@ mod tests {
         let lock = migrate_lock_path(db);
         assert_eq!(lock.parent(), db.parent());
         assert_eq!(lock.file_name().unwrap(), "aionui-backend.db.migrate.lock");
+    }
+
+    #[test]
+    fn startup_file_retry_handles_windows_transient_lock_errors() {
+        for code in [5, 32, 33] {
+            let err = std::io::Error::from_raw_os_error(code);
+            assert!(
+                is_retryable_startup_file_error(&err),
+                "Windows startup file error {code} should be retryable"
+            );
+        }
+    }
+
+    #[test]
+    fn startup_file_retry_rejects_non_transient_errors() {
+        let err = std::io::Error::new(std::io::ErrorKind::NotFound, "missing file");
+        assert!(!is_retryable_startup_file_error(&err));
     }
 }

--- a/crates/aionui-extension/src/startup_materialize.rs
+++ b/crates/aionui-extension/src/startup_materialize.rs
@@ -14,7 +14,9 @@
 //! stays in place until staging is fully ready.
 
 use std::fs::OpenOptions;
+use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use fs2::FileExt;
 use include_dir::Dir;
@@ -26,6 +28,13 @@ const VERSION_FILE: &str = ".version";
 const LOCK_FILE_NAME: &str = ".builtin-skills.lock";
 const STAGING_DIR_NAME: &str = ".builtin-skills.tmp";
 const OLD_DIR_NAME: &str = ".builtin-skills.old";
+const STARTUP_FILE_RETRY_DELAYS: [Duration; 5] = [
+    Duration::from_millis(50),
+    Duration::from_millis(100),
+    Duration::from_millis(200),
+    Duration::from_millis(400),
+    Duration::from_millis(800),
+];
 
 /// Decide whether to materialize based on the `.version` file, then do it.
 /// Returns `true` if a write happened, `false` if the gate said "skip".
@@ -66,7 +75,19 @@ pub async fn materialize_if_needed(
         return Ok(false);
     }
 
-    materialize_embedded_builtin_skills_unlocked(data_dir, corpus, binary_version).await?;
+    match materialize_embedded_builtin_skills_unlocked(data_dir, corpus, binary_version).await {
+        Ok(()) => {}
+        Err(e) if existing_builtin_skills_looks_usable(&target).await => {
+            warn!(
+                target = %target.display(),
+                version = binary_version,
+                error = %e,
+                "failed to refresh builtin skills; continuing with existing tree"
+            );
+            return Ok(false);
+        }
+        Err(e) => return Err(e),
+    }
     Ok(true)
 }
 
@@ -106,7 +127,11 @@ async fn materialize_embedded_builtin_skills_unlocked(
 
     // Clean any leftover staging from a previous crashed run.
     if staging.exists() {
-        tokio::fs::remove_dir_all(&staging).await.map_err(|e| {
+        retry_startup_file_op("remove builtin skills staging dir", &staging, || {
+            tokio::fs::remove_dir_all(&staging)
+        })
+        .await
+        .map_err(|e| {
             ExtensionError::Io(std::io::Error::new(
                 e.kind(),
                 format!("failed to clean staging dir {}: {e}", staging.display()),
@@ -124,16 +149,43 @@ async fn materialize_embedded_builtin_skills_unlocked(
     if target.exists() {
         if old.exists() {
             // Tolerate leftover .old from a crashed rename sequence.
-            let _ = tokio::fs::remove_dir_all(&old).await;
+            if let Err(e) = retry_startup_file_op("remove old builtin skills dir", &old, || {
+                tokio::fs::remove_dir_all(&old)
+            })
+            .await
+            {
+                warn!(
+                    old = %old.display(),
+                    error = %e,
+                    "failed to remove stale old builtin skills tree before refresh"
+                );
+            }
         }
-        tokio::fs::rename(&target, &old).await?;
+        retry_startup_file_op("rename builtin skills target to old", &target, || {
+            tokio::fs::rename(&target, &old)
+        })
+        .await?;
     }
 
-    if let Err(e) = tokio::fs::rename(&staging, &target).await {
+    if let Err(e) = retry_startup_file_op("rename builtin skills staging to target", &staging, || {
+        tokio::fs::rename(&staging, &target)
+    })
+    .await
+    {
         // Try to restore the original target so we don't leave the user
         // with no builtin skills.
-        if old.exists() {
-            let _ = tokio::fs::rename(&old, &target).await;
+        if old.exists()
+            && let Err(restore_error) = retry_startup_file_op("restore old builtin skills target", &old, || {
+                tokio::fs::rename(&old, &target)
+            })
+            .await
+        {
+            warn!(
+                old = %old.display(),
+                target = %target.display(),
+                error = %restore_error,
+                "failed to restore old builtin skills tree after refresh failure"
+            );
         }
         return Err(ExtensionError::Io(std::io::Error::new(
             e.kind(),
@@ -147,7 +199,10 @@ async fn materialize_embedded_builtin_skills_unlocked(
 
     // Best-effort cleanup of the superseded tree.
     if old.exists()
-        && let Err(e) = tokio::fs::remove_dir_all(&old).await
+        && let Err(e) = retry_startup_file_op("remove superseded builtin skills dir", &old, || {
+            tokio::fs::remove_dir_all(&old)
+        })
+        .await
     {
         warn!(
             old = %old.display(),
@@ -157,6 +212,52 @@ async fn materialize_embedded_builtin_skills_unlocked(
     }
 
     Ok(())
+}
+
+async fn existing_builtin_skills_looks_usable(target: &Path) -> bool {
+    if !target.is_dir() {
+        return false;
+    }
+    tokio::fs::metadata(target.join(VERSION_FILE))
+        .await
+        .map(|metadata| metadata.is_file())
+        .unwrap_or(false)
+}
+
+async fn retry_startup_file_op<T, F, Fut>(operation: &str, path: &Path, mut op: F) -> std::io::Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = std::io::Result<T>>,
+{
+    for (attempt, delay) in STARTUP_FILE_RETRY_DELAYS.iter().enumerate() {
+        match op().await {
+            Ok(value) => return Ok(value),
+            Err(e) if is_retryable_startup_file_error(&e) => {
+                warn!(
+                    operation,
+                    path = %path.display(),
+                    attempt = attempt + 1,
+                    retry_after_ms = delay.as_millis(),
+                    raw_os_error = ?e.raw_os_error(),
+                    error = %e,
+                    "Startup file operation failed; retrying"
+                );
+                tokio::time::sleep(*delay).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    op().await
+}
+
+fn is_retryable_startup_file_error(error: &std::io::Error) -> bool {
+    match error.kind() {
+        std::io::ErrorKind::Interrupted
+        | std::io::ErrorKind::PermissionDenied
+        | std::io::ErrorKind::TimedOut
+        | std::io::ErrorKind::WouldBlock => true,
+        _ => matches!(error.raw_os_error(), Some(5 | 32 | 33)),
+    }
 }
 
 struct MaterializeLockGuard {

--- a/crates/aionui-extension/tests/startup_materialize.rs
+++ b/crates/aionui-extension/tests/startup_materialize.rs
@@ -114,6 +114,40 @@ async fn gate_triggers_when_version_file_missing() {
 }
 
 #[tokio::test]
+async fn gate_keeps_existing_tree_when_refresh_fails() {
+    let tmp = TempDir::new().unwrap();
+    let target = tmp.path().join("builtin-skills");
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(target.join(".version"), "0.0.0").unwrap();
+    std::fs::write(target.join("sentinel"), "keep-existing").unwrap();
+    std::fs::write(tmp.path().join(".builtin-skills.tmp"), "stale-file").unwrap();
+
+    let wrote = materialize_if_needed(tmp.path(), &FIXTURE_CORPUS, "1.2.3")
+        .await
+        .unwrap();
+
+    assert!(!wrote, "refresh failure should fall back to existing tree");
+    assert_eq!(read_version(&target).as_deref(), Some("0.0.0"));
+    assert!(
+        target.join("sentinel").is_file(),
+        "existing tree must be preserved when refresh fails"
+    );
+}
+
+#[tokio::test]
+async fn gate_fails_when_initial_materialize_fails_without_existing_tree() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join(".builtin-skills.tmp"), "stale-file").unwrap();
+
+    let result = materialize_if_needed(tmp.path(), &FIXTURE_CORPUS, "1.2.3").await;
+
+    assert!(
+        result.is_err(),
+        "first startup must not silently continue without a usable builtin-skills tree"
+    );
+}
+
+#[tokio::test]
 async fn concurrent_materialize_produces_consistent_tree() {
     // Two concurrent invocations share the same staging/target paths, so
     // at most one reliably wins the atomic rename; the other may legally


### PR DESCRIPTION
## Summary
- serialize legacy database copy with the startup migration lock and retry transient Windows file lock errors
- retry builtin-skills refresh file operations and fall back to an existing materialized tree when refresh fails
- keep first-start behavior strict when no usable builtin-skills tree exists
- keep recoverable fallback paths observable through structured warning logs instead of surfacing them as BackendStartupError crashes

Refs ELECTRON-1N7

## Testing
- cargo test -p aionui-db
- cargo test -p aionui-extension --test startup_materialize
- cargo clippy -p aionui-db -p aionui-extension -- -D warnings
- just push -u origin fix/electron-1n7-startup-files