### PR TITLE
Fix MCP config sync source

### DIFF
--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -86,10 +86,11 @@ pub use file::{
 };
 pub use lifecycle::{GitHubReleaseAsset, SystemInfoResponse, UpdateCheckRequest, UpdateCheckResult, UpdateReleaseInfo};
 pub use mcp::{
-    BatchImportMcpServersRequest, CreateMcpServerRequest, DetectedMcpServerResponse, McpAgentSyncResult, McpAuthMethod,
-    McpConnectionTestResult, McpServerResponse, McpSyncResult, McpToolResponse, McpTransport, OAuthCheckStatusRequest,
-    OAuthLoginRequest, OAuthLoginResponse, OAuthLogoutRequest, OAuthStatusResponse, RemoveFromAgentsRequest,
-    SyncToAgentsRequest, TestMcpConnectionRequest, UpdateMcpServerRequest,
+    BatchImportMcpServersRequest, CreateMcpServerRequest, DetectedMcpServerResponse, ImportMcpServerRequest,
+    McpAgentSyncResult, McpAuthMethod, McpConnectionTestResult, McpServerResponse, McpSyncResult, McpToolResponse,
+    McpTransport, OAuthCheckStatusRequest, OAuthLoginRequest, OAuthLoginResponse, OAuthLogoutRequest,
+    OAuthStatusResponse, RemoveFromAgentsRequest, SyncToAgentsRequest, TestMcpConnectionRequest,
+    UpdateMcpServerRequest,
 };
 pub use office::{
     CellCoord, CellRange, ConversionResultDto, ConversionTarget, DetectStarOfficeRequest, DocumentConversionRequest,

--- a/crates/aionui-api-types/src/mcp.rs
+++ b/crates/aionui-api-types/src/mcp.rs
@@ -66,6 +66,25 @@ pub struct CreateMcpServerRequest {
     pub builtin: bool,
 }
 
+/// Request item for `POST /api/mcp/servers/import`.
+///
+/// Import can preserve the enabled state from a legacy source. Plain create
+/// intentionally does not accept `enabled`, because enabling must also sync
+/// the server to agent configs.
+#[derive(Debug, Deserialize)]
+pub struct ImportMcpServerRequest {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub transport: McpTransport,
+    #[serde(default)]
+    pub original_json: Option<String>,
+    #[serde(default)]
+    pub builtin: bool,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+}
+
 /// Request body for `PUT /api/mcp/servers/:id` — partial update.
 #[derive(Debug, Deserialize)]
 pub struct UpdateMcpServerRequest {
@@ -82,7 +101,7 @@ pub struct UpdateMcpServerRequest {
 /// Request body for `POST /api/mcp/servers/import` — batch import.
 #[derive(Debug, Deserialize)]
 pub struct BatchImportMcpServersRequest {
-    pub servers: Vec<CreateMcpServerRequest>,
+    pub servers: Vec<ImportMcpServerRequest>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aionui-mcp/src/adapters/aionrs.rs
+++ b/crates/aionui-mcp/src/adapters/aionrs.rs
@@ -19,7 +19,7 @@ const CLI_NAME: &str = "aionrs";
 ///
 /// ```toml
 /// [mcp.servers.server-name]
-/// type = "stdio"
+/// transport = "stdio"
 /// command = "npx"
 /// args = ["-y", "@test/server"]
 ///
@@ -27,7 +27,7 @@ const CLI_NAME: &str = "aionrs";
 /// KEY = "VALUE"
 ///
 /// [mcp.servers.remote-server]
-/// type = "http"
+/// transport = "http"
 /// url = "https://example.com/mcp"
 ///
 /// [mcp.servers.remote-server.headers]
@@ -214,7 +214,11 @@ fn parse_toml_servers(content: &str) -> Result<Vec<DetectedServer>, McpError> {
 fn parse_toml_server_entry(name: &str, config: &toml::Value) -> Option<DetectedServer> {
     let table = config.as_table()?;
 
-    let transport_type = table.get("type").and_then(|v| v.as_str()).unwrap_or("stdio");
+    let transport_type = table
+        .get("transport")
+        .or_else(|| table.get("type"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("stdio");
 
     let transport = match transport_type {
         "stdio" => {
@@ -273,7 +277,7 @@ fn transport_to_toml(transport: &McpServerTransport) -> toml::Value {
 
     match transport {
         McpServerTransport::Stdio { command, args, env } => {
-            table.insert("type".into(), toml::Value::String("stdio".into()));
+            table.insert("transport".into(), toml::Value::String("stdio".into()));
             table.insert("command".into(), toml::Value::String(command.clone()));
             if !args.is_empty() {
                 table.insert(
@@ -290,12 +294,12 @@ fn transport_to_toml(transport: &McpServerTransport) -> toml::Value {
             }
         }
         McpServerTransport::Sse { url, headers } => {
-            table.insert("type".into(), toml::Value::String("sse".into()));
+            table.insert("transport".into(), toml::Value::String("sse".into()));
             table.insert("url".into(), toml::Value::String(url.clone()));
             insert_toml_headers(&mut table, headers);
         }
         McpServerTransport::Http { url, headers } => {
-            table.insert("type".into(), toml::Value::String("http".into()));
+            table.insert("transport".into(), toml::Value::String("http".into()));
             table.insert("url".into(), toml::Value::String(url.clone()));
             insert_toml_headers(&mut table, headers);
         }
@@ -377,6 +381,29 @@ NODE_ENV = "production"
                 assert_eq!(args, &["-y", "@test/server"]);
                 assert_eq!(env.get("KEY").unwrap(), "VALUE");
                 assert_eq!(env.get("NODE_ENV").unwrap(), "production");
+            }
+            _ => panic!("expected Stdio"),
+        }
+    }
+
+    #[test]
+    fn parse_stdio_server_with_transport_key() {
+        let toml = r#"
+[mcp.servers.test-mcp]
+transport = "stdio"
+command = "npx"
+args = ["-y", "@test/server"]
+
+[mcp.servers.test-mcp.env]
+KEY = "VALUE"
+"#;
+        let servers = parse_toml_servers(toml).unwrap();
+        assert_eq!(servers.len(), 1);
+        match &servers[0].transport {
+            McpServerTransport::Stdio { command, args, env } => {
+                assert_eq!(command, "npx");
+                assert_eq!(args, &["-y", "@test/server"]);
+                assert_eq!(env.get("KEY").unwrap(), "VALUE");
             }
             _ => panic!("expected Stdio"),
         }
@@ -496,6 +523,18 @@ args = ["srv.js"]
             env: HashMap::from([("K".into(), "V".into())]),
         };
         let toml_val = transport_to_toml(&transport);
+        let table = toml_val.as_table().unwrap();
+        assert_eq!(table.get("transport").unwrap().as_str().unwrap(), "stdio");
+        assert!(table.get("type").is_none());
+        assert_eq!(
+            table
+                .get("env")
+                .and_then(|v| v.as_table())
+                .and_then(|env| env.get("K"))
+                .and_then(|v| v.as_str())
+                .unwrap(),
+            "V"
+        );
         let server = parse_toml_server_entry("test", &toml_val).unwrap();
         assert_eq!(server.transport, transport);
     }

--- a/crates/aionui-mcp/src/service.rs
+++ b/crates/aionui-mcp/src/service.rs
@@ -4,6 +4,7 @@ use aionui_api_types::{
     BatchImportMcpServersRequest, CreateMcpServerRequest, McpServerResponse, UpdateMcpServerRequest,
 };
 use aionui_db::{CreateMcpServerParams, IMcpServerRepository, UpdateMcpServerParams};
+use tracing::info;
 
 use crate::error::McpError;
 use crate::types::{McpServer, McpServerTransport};
@@ -175,7 +176,7 @@ impl McpConfigService {
             .map(|(server_req, (transport, config_json))| CreateMcpServerParams {
                 name: &server_req.name,
                 description: server_req.description.as_deref(),
-                enabled: false,
+                enabled: server_req.enabled.unwrap_or(false),
                 transport_type: transport.transport_type(),
                 transport_config: config_json.as_str(),
                 tools: None,
@@ -185,6 +186,12 @@ impl McpConfigService {
             .collect();
 
         let rows = self.repo.batch_upsert(&create_params).await?;
+        info!(
+            requested_count = req.servers.len(),
+            imported_count = rows.len(),
+            enabled_count = rows.iter().filter(|row| row.enabled).count(),
+            "batch imported MCP servers"
+        );
         rows.into_iter()
             .map(|row| McpServer::from_row(row).map(McpServer::into_response))
             .collect()
@@ -198,7 +205,7 @@ impl McpConfigService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aionui_api_types::McpTransport;
+    use aionui_api_types::{ImportMcpServerRequest, McpTransport};
     use aionui_common::{McpServerStatus, TimestampMs};
     use aionui_db::models::McpServerRow;
     use aionui_db::{CreateMcpServerParams, DbError, UpdateMcpServerParams};
@@ -420,6 +427,35 @@ mod tests {
             },
             original_json: None,
             builtin: false,
+        }
+    }
+
+    fn stdio_import_req(name: &str) -> ImportMcpServerRequest {
+        ImportMcpServerRequest {
+            name: name.to_owned(),
+            description: Some("test server".to_owned()),
+            transport: McpTransport::Stdio {
+                command: "npx".into(),
+                args: vec!["-y".into(), "@test/server".into()],
+                env: HashMap::new(),
+            },
+            original_json: None,
+            builtin: false,
+            enabled: None,
+        }
+    }
+
+    fn http_import_req(name: &str) -> ImportMcpServerRequest {
+        ImportMcpServerRequest {
+            name: name.to_owned(),
+            description: None,
+            transport: McpTransport::Http {
+                url: "https://example.com/mcp".into(),
+                headers: HashMap::new(),
+            },
+            original_json: None,
+            builtin: false,
+            enabled: None,
         }
     }
 
@@ -696,7 +732,7 @@ mod tests {
     async fn batch_import_creates_new_servers() {
         let svc = make_service();
         let req = BatchImportMcpServersRequest {
-            servers: vec![stdio_create_req("a"), http_create_req("b")],
+            servers: vec![stdio_import_req("a"), http_import_req("b")],
         };
         let results = svc.batch_import(req).await.unwrap();
         assert_eq!(results.len(), 2);
@@ -712,8 +748,8 @@ mod tests {
 
         let req = BatchImportMcpServersRequest {
             servers: vec![
-                http_create_req("existing"),   // update
-                stdio_create_req("brand-new"), // create
+                http_import_req("existing"),   // update
+                stdio_import_req("brand-new"), // create
             ],
         };
         let results = svc.batch_import(req).await.unwrap();
@@ -721,6 +757,20 @@ mod tests {
 
         let all = svc.list_servers().await.unwrap();
         assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn batch_import_preserves_enabled_state() {
+        let svc = make_service();
+        let mut req = stdio_import_req("enabled-mcp");
+        req.enabled = Some(true);
+        let result = svc
+            .batch_import(BatchImportMcpServersRequest { servers: vec![req] })
+            .await
+            .unwrap();
+
+        assert_eq!(result[0].name, "enabled-mcp");
+        assert!(result[0].enabled);
     }
 
     #[tokio::test]

--- a/crates/aionui-mcp/src/sync_service.rs
+++ b/crates/aionui-mcp/src/sync_service.rs
@@ -98,7 +98,17 @@ impl McpSyncService {
         let _guard = self.service_lock.lock().await;
 
         let servers = self.load_servers_by_ids(server_ids).await?;
-        info!(count = servers.len(), "syncing MCP servers to agents");
+        info!(
+            requested_count = server_ids.len(),
+            loaded_count = servers.len(),
+            "syncing MCP servers to agents"
+        );
+        if !server_ids.is_empty() && servers.is_empty() {
+            warn!(
+                requested_count = server_ids.len(),
+                "requested MCP sync loaded zero servers"
+            );
+        }
 
         let mut agent_results = Vec::new();
         for adapter in self.adapters.iter() {

--- a/crates/aionui-mcp/tests/service_integration.rs
+++ b/crates/aionui-mcp/tests/service_integration.rs
@@ -5,7 +5,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use aionui_api_types::{BatchImportMcpServersRequest, CreateMcpServerRequest, McpTransport, UpdateMcpServerRequest};
+use aionui_api_types::{
+    BatchImportMcpServersRequest, CreateMcpServerRequest, ImportMcpServerRequest, McpTransport, UpdateMcpServerRequest,
+};
 use aionui_db::SqliteMcpServerRepository;
 use aionui_mcp::{McpConfigService, McpError};
 
@@ -39,6 +41,35 @@ fn http_req(name: &str) -> CreateMcpServerRequest {
         },
         original_json: None,
         builtin: false,
+    }
+}
+
+fn stdio_import_req(name: &str) -> ImportMcpServerRequest {
+    ImportMcpServerRequest {
+        name: name.to_owned(),
+        description: Some("test".to_owned()),
+        transport: McpTransport::Stdio {
+            command: "npx".into(),
+            args: vec!["-y".into(), "@test/server".into()],
+            env: HashMap::new(),
+        },
+        original_json: None,
+        builtin: false,
+        enabled: None,
+    }
+}
+
+fn http_import_req(name: &str) -> ImportMcpServerRequest {
+    ImportMcpServerRequest {
+        name: name.to_owned(),
+        description: None,
+        transport: McpTransport::Http {
+            url: "https://example.com/mcp".into(),
+            headers: HashMap::from([("Auth".into(), "Bearer tok".into())]),
+        },
+        original_json: None,
+        builtin: false,
+        enabled: None,
     }
 }
 
@@ -282,8 +313,8 @@ async fn batch_import_creates_and_upserts() {
 
     let req = BatchImportMcpServersRequest {
         servers: vec![
-            http_req("existing"), // upsert
-            stdio_req("new"),     // create
+            http_import_req("existing"), // upsert
+            stdio_import_req("new"),     // create
         ],
     };
     let results = svc.batch_import(req).await.unwrap();
@@ -291,4 +322,24 @@ async fn batch_import_creates_and_upserts() {
 
     let all = svc.list_servers().await.unwrap();
     assert_eq!(all.len(), 2);
+}
+
+#[tokio::test]
+async fn batch_import_preserves_enabled_in_database() {
+    let svc = make_service().await;
+    let mut req = stdio_import_req("enabled-db-mcp");
+    req.enabled = Some(true);
+
+    let result = svc
+        .batch_import(BatchImportMcpServersRequest { servers: vec![req] })
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].name, "enabled-db-mcp");
+    assert!(result[0].enabled);
+
+    let listed = svc.list_servers().await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert!(listed[0].enabled);
 }


### PR DESCRIPTION
## Summary
- Use backend DB MCP server rows as the source for agent CLI sync instead of stale frontend config state.
- Preserve aionrs-compatible MCP TOML output by writing `transport` for stdio/http/sse servers.
- Add MCP sync diagnostics and coverage for the DB import/sync path.

## Test Plan
- `just push -u origin fix/mcp-db-source-migration`