### PR TITLE
Fix conversation stream stalls

### DIFF
--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
+use aionui_ai_agent::protocol::events::ErrorEventData;
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
-use aionui_ai_agent::{AgentInstance, IWorkerTaskManager};
+use aionui_ai_agent::{AgentInstance, AgentStreamEvent, IWorkerTaskManager};
 
 use crate::response_middleware::ICronService;
 use aionui_api_types::{
@@ -34,6 +35,8 @@ use crate::stream_relay::StreamRelay;
 use std::sync::RwLock;
 
 const MAX_CRON_CONTINUATIONS_PER_TURN: usize = 4;
+const RELAY_BRIDGE_CHANNEL_CAPACITY: usize = 64;
+const AGENT_SEND_MESSAGE_FAILED_CODE: &str = "AGENT_SEND_MESSAGE_FAILED";
 
 #[derive(Clone)]
 pub struct ConversationService {
@@ -1101,7 +1104,7 @@ impl ConversationService {
 
                 let relay = StreamRelay::new(
                     conv_id.clone(),
-                    msg_id,
+                    msg_id.clone(),
                     user_id_owned.clone(),
                     Arc::clone(&repo),
                     Arc::clone(&broadcaster),
@@ -1109,17 +1112,23 @@ impl ConversationService {
                 )
                 .with_turn_completion(false);
 
-                let rx = agent.subscribe();
+                let (relay_tx, rx) = tokio::sync::broadcast::channel(RELAY_BRIDGE_CHANNEL_CAPACITY);
+                let bridge_handle =
+                    spawn_agent_stream_bridge(agent.subscribe(), relay_tx.clone(), conv_id.clone(), msg_id.clone());
                 let send_agent = agent.clone();
                 let conv_id_send = conv_id.clone();
+                let send_error_tx = relay_tx.clone();
+                drop(relay_tx);
                 // 1. Send the message to the agent and concurrently run the relay to stream events.
                 tokio::spawn(async move {
                     if let Err(e) = send_agent.send_message(current_send).await {
                         error!(conversation_id = %conv_id_send, error = %ErrorChain(&e), "Agent send_message failed");
+                        let _ = send_error_tx.send(agent_send_failure_event(&e));
                     }
                 });
                 // 2. Wait for the agent to process the message and complete the turn, while the relay streams events in real time.
                 let outcome = relay.consume(rx).await;
+                bridge_handle.abort();
 
                 if let Some(session_key) = agent.get_session_key() {
                     persist_session_key(&repo, &conv_id, &session_key).await;
@@ -1452,6 +1461,46 @@ fn enum_to_db<T: serde::Serialize>(val: &T) -> Result<String, AppError> {
         .as_str()
         .map(|s| s.to_owned())
         .ok_or_else(|| AppError::Internal("Expected string enum value".into()))
+}
+
+fn spawn_agent_stream_bridge(
+    mut source_rx: tokio::sync::broadcast::Receiver<AgentStreamEvent>,
+    relay_tx: tokio::sync::broadcast::Sender<AgentStreamEvent>,
+    conversation_id: String,
+    msg_id: String,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match source_rx.recv().await {
+                Ok(event) => {
+                    let terminal = matches!(event, AgentStreamEvent::Finish(_) | AgentStreamEvent::Error(_));
+                    if relay_tx.send(event).is_err() {
+                        debug!(conversation_id, msg_id, "Agent stream bridge receiver closed");
+                        break;
+                    }
+                    if terminal {
+                        break;
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    warn!(
+                        conversation_id,
+                        msg_id,
+                        lagged = n,
+                        "Agent stream bridge lagged, forwarding will resume with latest events"
+                    );
+                }
+            }
+        }
+    })
+}
+
+fn agent_send_failure_event(error: &AppError) -> AgentStreamEvent {
+    AgentStreamEvent::Error(ErrorEventData {
+        message: error.to_string(),
+        code: Some(AGENT_SEND_MESSAGE_FAILED_CODE.to_owned()),
+    })
 }
 
 /// Persist the agent's session key into `conversation.extra.sessionKey`.

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1284,6 +1284,64 @@ struct ScriptedAgent {
     sent_contents: Mutex<Vec<String>>,
 }
 
+struct FailingAgent {
+    conversation_id: String,
+    event_tx: broadcast::Sender<AgentStreamEvent>,
+    message: String,
+}
+
+impl FailingAgent {
+    fn new(conversation_id: &str, message: &str) -> Self {
+        let (event_tx, _) = broadcast::channel(64);
+        Self {
+            conversation_id: conversation_id.to_owned(),
+            event_tx,
+            message: message.to_owned(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl IAgentTask for FailingAgent {
+    fn agent_type(&self) -> AgentType {
+        AgentType::Acp
+    }
+
+    fn conversation_id(&self) -> &str {
+        &self.conversation_id
+    }
+
+    fn workspace(&self) -> &str {
+        "/tmp/test"
+    }
+
+    fn status(&self) -> Option<ConversationStatus> {
+        Some(ConversationStatus::Finished)
+    }
+
+    fn last_activity_at(&self) -> TimestampMs {
+        0
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
+        self.event_tx.subscribe()
+    }
+
+    async fn send_message(&self, _data: SendMessageData) -> Result<(), AppError> {
+        Err(AppError::BadGateway(self.message.clone()))
+    }
+
+    async fn cancel(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+
+    fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        Ok(())
+    }
+}
+
+impl IMockAgent for FailingAgent {}
+
 impl ScriptedAgent {
     fn new(conversation_id: &str, scripts: Vec<Vec<AgentStreamEvent>>) -> Self {
         let (event_tx, _) = broadcast::channel(64);
@@ -1637,6 +1695,64 @@ async fn send_message_continues_cron_system_responses() {
     let events = broadcaster.take_events();
     let turn_completed = events.iter().filter(|evt| evt.name == "turn.completed").count();
     assert_eq!(turn_completed, 1);
+}
+
+#[tokio::test]
+async fn send_message_agent_failure_broadcasts_error_without_waiting_for_watchdog() {
+    let (svc, broadcaster, repo, _default_task_mgr) = make_service();
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+    task_mgr.insert_agent(
+        &conv.id,
+        AgentInstance::Mock(Arc::new(FailingAgent::new(&conv.id, "Provider unavailable"))),
+    );
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    let _ = broadcaster.take_events();
+
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+
+    let events = tokio::time::timeout(std::time::Duration::from_millis(500), async {
+        loop {
+            let events = broadcaster.take_events();
+            let saw_stream_error = events
+                .iter()
+                .any(|evt| evt.name == "message.stream" && evt.data["type"] == "error");
+            let saw_turn_completed = events
+                .iter()
+                .any(|evt| evt.name == "turn.completed" && evt.data["status"] == "finished");
+            if saw_stream_error && saw_turn_completed {
+                break events;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("send_message failure should surface promptly");
+
+    let stream_error = events
+        .iter()
+        .find(|evt| evt.name == "message.stream" && evt.data["type"] == "error")
+        .expect("stream error event should be present");
+    assert_eq!(stream_error.data["data"]["code"], "AGENT_SEND_MESSAGE_FAILED");
+    assert!(
+        stream_error.data["data"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("Provider unavailable"))
+    );
+
+    let messages = repo.get_messages(&conv.id, 1, 20, SortOrder::Asc).await.unwrap().items;
+    let tips = messages
+        .iter()
+        .find(|message| message.r#type == "tips" && message.status.as_deref() == Some("error"))
+        .expect("error tips message should be persisted");
+    let content: serde_json::Value = serde_json::from_str(&tips.content).unwrap();
+    assert!(
+        content["content"]
+            .as_str()
+            .is_some_and(|message| message.contains("Provider unavailable"))
+    );
 }
 
 // ── stop_stream tests ───────────────────────────────────────────

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -1,9 +1,9 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use aionui_ai_agent::{
     AgentStreamEvent,
     protocol::events::{
-        ThinkingEventData,
+        ErrorEventData, ThinkingEventData,
         tool_call::{AcpToolCallSessionUpdateKind, AcpToolCallStatus, ToolCallStatus},
     },
 };
@@ -22,6 +22,7 @@ use tracing::{debug, error, info, warn};
 
 /// Number of text chunks to accumulate before flushing to the database.
 const FLUSH_INTERVAL: u32 = 20;
+const STREAM_RELAY_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(90);
 
 #[derive(Debug, Clone)]
 struct TextSegmentState {
@@ -108,8 +109,8 @@ impl StreamRelay {
         let mut used_primary_segment_msg_id = false;
 
         loop {
-            match rx.recv().await {
-                Ok(event) => match &event {
+            match tokio::time::timeout(STREAM_RELAY_INACTIVITY_TIMEOUT, rx.recv()).await {
+                Ok(Ok(event)) => match &event {
                     AgentStreamEvent::Thinking(data) => {
                         if data.status.as_deref() == Some("done") {
                             self.complete_active_thinking(&mut active_thinking).await;
@@ -203,7 +204,7 @@ impl StreamRelay {
                         self.forward_to_websocket(&event);
                     }
                 },
-                Err(broadcast::error::RecvError::Closed) => {
+                Ok(Err(broadcast::error::RecvError::Closed)) => {
                     let elapsed_ms = now_ms() - started_at;
                     warn!(
                         elapsed_ms,
@@ -227,8 +228,35 @@ impl StreamRelay {
                     }
                     break outcome;
                 }
-                Err(broadcast::error::RecvError::Lagged(n)) => {
+                Ok(Err(broadcast::error::RecvError::Lagged(n))) => {
                     warn!(lagged = n, "Stream relay lagged, some events dropped");
+                }
+                Err(_) => {
+                    let elapsed_ms = now_ms() - started_at;
+                    warn!(
+                        elapsed_ms,
+                        timeout_secs = STREAM_RELAY_INACTIVITY_TIMEOUT.as_secs(),
+                        text_len = full_text_buffer.len(),
+                        "StreamRelay timed out waiting for agent event"
+                    );
+
+                    let event = AgentStreamEvent::Error(ErrorEventData {
+                        message: format!(
+                            "Agent stream timed out after {} seconds without updates",
+                            STREAM_RELAY_INACTIVITY_TIMEOUT.as_secs()
+                        ),
+                        code: Some("STREAM_INACTIVITY_TIMEOUT".into()),
+                    });
+
+                    self.complete_active_thinking(&mut active_thinking).await;
+                    self.close_active_text_segment(&mut active_text, &mut text_segments, "error")
+                        .await;
+                    self.forward_to_websocket(&event);
+                    let outcome = self.finalize(&full_text_buffer, &text_segments, &event).await;
+                    if self.complete_turn {
+                        Self::complete_conversation(&self.repo, &self.broadcaster, &self.conversation_id).await;
+                    }
+                    break outcome;
                 }
             }
         }
@@ -1120,6 +1148,55 @@ mod tests {
         assert_eq!(inserts.len(), 1);
         let content: serde_json::Value = serde_json::from_str(&inserts[0].content).unwrap();
         assert_eq!(content["content"], "partial");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn run_inactivity_timeout_finalizes_with_error() {
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let (_tx, _) = broadcast::channel(64);
+
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+            None,
+        );
+
+        let mut ws_rx = bus.subscribe();
+        let rx = _tx.subscribe();
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(95), relay.consume(rx)).await;
+        assert!(result.is_ok(), "relay should finalize before the outer timeout");
+
+        let inserts = repo.take_inserts();
+        assert_eq!(inserts.len(), 1);
+        assert_eq!(inserts[0].r#type, "tips");
+        assert_eq!(inserts[0].status.as_deref(), Some("error"));
+        let content: serde_json::Value = serde_json::from_str(&inserts[0].content).unwrap();
+        assert_eq!(content["type"], "error");
+        assert!(
+            content["content"]
+                .as_str()
+                .is_some_and(|message| message.contains("timed out")),
+            "expected timeout error message, got {content}"
+        );
+
+        let mut saw_stream_error = false;
+        let mut saw_turn_completed = false;
+        while let Ok(evt) = ws_rx.try_recv() {
+            if evt.name == "message.stream" && evt.data["type"] == "error" {
+                saw_stream_error = true;
+            }
+            if evt.name == "turn.completed" && evt.data["status"] == "finished" {
+                saw_turn_completed = true;
+            }
+        }
+
+        assert!(saw_stream_error, "stream error event should be broadcast");
+        assert!(saw_turn_completed, "turn should complete so UI can stop loading");
     }
 
     #[tokio::test]

--- a/crates/aionui-runtime/src/resolver.rs
+++ b/crates/aionui-runtime/src/resolver.rs
@@ -223,6 +223,13 @@ mod tests {
     use super::*;
     use crate::embed::FakeEmbed;
     use std::io::Write as _;
+    use std::sync::{Mutex, MutexGuard};
+
+    static BUN_PATH_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock_bun_path_env() -> MutexGuard<'static, ()> {
+        BUN_PATH_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
 
     fn make_blob(payload: &[u8]) -> Vec<u8> {
         let mut out = Vec::new();
@@ -241,6 +248,7 @@ mod tests {
 
     #[test]
     fn no_embed_falls_back_to_which() {
+        let _guard = lock_bun_path_env();
         // Safety: unset to avoid env override winning.
         // SAFETY: single-threaded test, `cargo test` default is per-process.
         unsafe {
@@ -264,6 +272,7 @@ mod tests {
 
     #[test]
     fn env_override_wins_over_embed() {
+        let _guard = lock_bun_path_env();
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let path = tmp.path().to_path_buf();
         // SAFETY: single-threaded test.
@@ -312,6 +321,7 @@ mod tests {
 
     #[test]
     fn bad_env_override_falls_through_to_embed() {
+        let _guard = lock_bun_path_env();
         // SAFETY: single-threaded test.
         unsafe {
             std::env::set_var("AIONUI_BUN_PATH", "/definitely/does/not/exist");


### PR DESCRIPTION
## Summary
- Finalize silent agent streams with a timeout error so the UI stops loading instead of spinning forever.
- Surface agent send failures through the stream relay immediately.
- Serialize bun path env override tests to avoid workspace test flakiness.

## Verification
- cargo fmt --all -- --check
- cargo test -p aionui-runtime --lib
- cargo test -p aionui-conversation
- cargo clippy -p aionui-conversation -p aionui-runtime -- -D warnings
- cargo test --workspace
- just push -u origin fix/conversation-stream-timeout