### PR TITLE
Persist ACP send failure tips in history

### DIFF
--- a/crates/aionui-conversation/src/lib.rs
+++ b/crates/aionui-conversation/src/lib.rs
@@ -1,5 +1,6 @@
 //! Conversation and message CRUD with streaming relay and event emission.
 mod convert;
+mod message_persistence;
 pub mod response_middleware;
 pub mod routes;
 pub mod routes_aux;

--- a/crates/aionui-conversation/src/message_persistence.rs
+++ b/crates/aionui-conversation/src/message_persistence.rs
@@ -1,0 +1,35 @@
+use aionui_common::{AppError, ErrorChain, now_ms};
+use aionui_db::models::MessageRow;
+use tracing::warn;
+
+use crate::service::ConversationService;
+
+impl ConversationService {
+    pub(crate) async fn persist_send_failure_tip(&self, conversation_id: &str, err: &AppError) {
+        let row = MessageRow {
+            id: Self::mint_msg_id(),
+            conversation_id: conversation_id.to_owned(),
+            msg_id: None,
+            r#type: "tips".into(),
+            content: serde_json::json!({
+                "content": err.to_string(),
+                "type": "error",
+                "source": "send_failed",
+                "code": err.error_code(),
+            })
+            .to_string(),
+            position: Some("center".into()),
+            status: Some("error".into()),
+            hidden: false,
+            created_at: now_ms(),
+        };
+
+        if let Err(store_err) = self.conversation_repo().insert_message(&row).await {
+            warn!(
+                conversation_id,
+                error = %ErrorChain(&store_err),
+                "Failed to persist send failure error tip"
+            );
+        }
+    }
+}

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -1040,14 +1040,31 @@ impl ConversationService {
         ));
 
         // Build task options from conversation row
-        let build_opts = self.build_task_options(&row)?;
+        let build_opts = match self.build_task_options(&row) {
+            Ok(opts) => opts,
+            Err(err) => {
+                self.persist_send_failure_tip(conversation_id, &err).await;
+                return Err(err);
+            }
+        };
         let stored_workspace = build_opts.workspace.clone();
-        let agent = task_manager.get_or_build_task(conversation_id, build_opts).await?;
+        let agent = match task_manager.get_or_build_task(conversation_id, build_opts).await {
+            Ok(agent) => agent,
+            Err(err) => {
+                self.persist_send_failure_tip(conversation_id, &err).await;
+                return Err(err);
+            }
+        };
 
         // If the factory resolved a different workspace (e.g. auto-created temp
         // dir for a legacy conversation with empty workspace), persist it back.
-        self.maybe_persist_workspace(conversation_id, &stored_workspace, agent.workspace())
-            .await?;
+        if let Err(err) = self
+            .maybe_persist_workspace(conversation_id, &stored_workspace, agent.workspace())
+            .await
+        {
+            self.persist_send_failure_tip(conversation_id, &err).await;
+            return Err(err);
+        }
 
         info!(agent_type = ?agent.agent_type(), "Agent task ready");
 

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1165,6 +1165,53 @@ impl MockTaskManager {
     }
 }
 
+struct FailingBuildTaskManager {
+    error: String,
+}
+
+impl FailingBuildTaskManager {
+    fn new(error: impl Into<String>) -> Self {
+        Self { error: error.into() }
+    }
+}
+
+#[async_trait::async_trait]
+impl IWorkerTaskManager for FailingBuildTaskManager {
+    fn get_task(&self, _conversation_id: &str) -> Option<AgentInstance> {
+        None
+    }
+
+    async fn get_or_build_task(
+        &self,
+        _conversation_id: &str,
+        _options: BuildTaskOptions,
+    ) -> Result<AgentInstance, AppError> {
+        Err(AppError::BadGateway(self.error.clone()))
+    }
+
+    fn kill(&self, _conversation_id: &str, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        Ok(())
+    }
+
+    fn kill_and_wait(
+        &self,
+        _conversation_id: &str,
+        _reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        Box::pin(std::future::ready(()))
+    }
+
+    fn clear(&self) {}
+
+    fn active_count(&self) -> usize {
+        0
+    }
+
+    fn collect_idle(&self, _idle_threshold_ms: TimestampMs) -> Vec<String> {
+        vec![]
+    }
+}
+
 #[async_trait::async_trait]
 impl IWorkerTaskManager for MockTaskManager {
     fn get_task(&self, conversation_id: &str) -> Option<AgentInstance> {
@@ -1462,6 +1509,41 @@ async fn send_message_persists_hidden_user_message_when_requested() {
     assert!(user_message.hidden);
     // msg_id is server-generated and must be non-empty for frontend routing.
     assert!(user_message.msg_id.as_deref().is_some_and(|s| !s.is_empty()));
+}
+
+#[tokio::test]
+async fn send_message_persists_error_tip_when_agent_build_fails() {
+    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let task_mgr: Arc<dyn IWorkerTaskManager> =
+        Arc::new(FailingBuildTaskManager::new("ACP init failed: config file is invalid"));
+
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let err = svc
+        .send_message("user_1", &conv.id, make_send_req(), &task_mgr)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, AppError::BadGateway(_)));
+
+    let messages = repo.get_messages(&conv.id, 1, 20, SortOrder::Asc).await.unwrap().items;
+    assert_eq!(messages.len(), 2, "user message and error tip should be persisted");
+
+    let error_tip = messages
+        .iter()
+        .find(|message| message.r#type == "tips")
+        .expect("agent build failure should persist an error tips message");
+    assert_eq!(error_tip.status.as_deref(), Some("error"));
+    assert_eq!(error_tip.position.as_deref(), Some("center"));
+
+    let content: serde_json::Value = serde_json::from_str(&error_tip.content).unwrap();
+    assert_eq!(content["type"], "error");
+    assert_eq!(content["source"], "send_failed");
+    assert_eq!(content["code"], "BAD_GATEWAY");
+    assert_eq!(
+        content["content"],
+        "Bad gateway: ACP init failed: config file is invalid"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Persist a structured error tips message when conversation send fails before the agent stream relay starts.
- Store send-failure metadata with `source=send_failed` and the `AppError` code without broadcasting an extra websocket event.
- Add a regression test covering agent build failures after the user message is persisted.

## Test Plan
- `cargo fmt --all -- --check`
- `cargo test -p aionui-conversation`
- `cargo clippy -p aionui-conversation -- -D warnings`
- `just push -u origin fix/acp-send-error-history`