### PR TITLE
Improve message send latency and aionrs slash-command handling

### DIFF
--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -9,7 +9,7 @@ use aion_config::config::{CliArgs, Config};
 use aion_mcp::manager::McpManager;
 use aion_protocol::commands::SessionMode;
 use aion_protocol::{ToolApprovalManager, ToolApprovalResult};
-use aionui_api_types::AgentModeResponse;
+use aionui_api_types::{AgentModeResponse, SlashCommandItem};
 use aionui_common::{
     AgentKillReason, AgentType, AppError, Confirmation, ConversationStatus, ErrorChain, TimestampMs, now_ms,
 };
@@ -26,6 +26,9 @@ use crate::types::{AionrsResolvedConfig, SendMessageData};
 pub struct AionrsAgentManager {
     runtime: AgentRuntime,
     engine: Mutex<AgentEngine>,
+    /// Static slash command metadata captured at bootstrap so UI lookups do
+    /// not wait behind an active `engine.run()` turn.
+    slash_commands: Vec<SlashCommandItem>,
     /// Holds `Arc<McpManager>` instances alive for the duration of this agent's
     /// lifetime. The managers are not accessed after construction — they exist
     /// solely so their underlying MCP connections outlive the engine's event
@@ -136,12 +139,18 @@ impl AionrsAgentManager {
         let protocol_sink = BackendProtocolSink::new(runtime.event_sender(), confirmations.clone());
         engine.set_approval_manager(approval_manager.clone());
         engine.set_protocol_writer(Arc::new(protocol_sink));
+        let slash_commands = engine
+            .slash_command_list()
+            .into_iter()
+            .map(|(command, description)| SlashCommandItem { command, description })
+            .collect();
 
         runtime.transition_to(ConversationStatus::Pending);
 
         Ok(Self {
             runtime,
             engine: Mutex::new(engine),
+            slash_commands,
             mcp_managers: result.mcp_managers,
             approval_manager,
             confirmations,
@@ -331,13 +340,8 @@ impl AionrsAgentManager {
         Ok(())
     }
 
-    pub async fn get_slash_commands(&self) -> Result<Vec<aionui_api_types::SlashCommandItem>, AppError> {
-        let engine = self.engine.lock().await;
-        Ok(engine
-            .slash_command_list()
-            .into_iter()
-            .map(|(command, description)| aionui_api_types::SlashCommandItem { command, description })
-            .collect())
+    pub async fn get_slash_commands(&self) -> Result<Vec<SlashCommandItem>, AppError> {
+        Ok(self.slash_commands.clone())
     }
 }
 
@@ -421,6 +425,21 @@ mod tests {
             .await
             .unwrap();
         assert!(agent.get_confirmations().is_empty());
+    }
+
+    #[tokio::test]
+    async fn aionrs_agent_get_slash_commands_does_not_wait_for_engine_lock() {
+        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config(), None)
+            .await
+            .unwrap();
+
+        let _engine_guard = agent.engine.lock().await;
+        let commands = tokio::time::timeout(std::time::Duration::from_millis(50), agent.get_slash_commands())
+            .await
+            .expect("slash command metadata should not wait for an active engine run")
+            .unwrap();
+
+        assert!(!commands.is_empty());
     }
 
     #[tokio::test]

--- a/crates/aionui-conversation/src/message_persistence.rs
+++ b/crates/aionui-conversation/src/message_persistence.rs
@@ -5,7 +5,7 @@ use tracing::warn;
 use crate::service::ConversationService;
 
 impl ConversationService {
-    pub(crate) async fn persist_send_failure_tip(&self, conversation_id: &str, err: &AppError) {
+    pub(crate) async fn persist_send_failure_tip(&self, conversation_id: &str, err: &AppError) -> Option<MessageRow> {
         let row = MessageRow {
             id: Self::mint_msg_id(),
             conversation_id: conversation_id.to_owned(),
@@ -30,6 +30,9 @@ impl ConversationService {
                 error = %ErrorChain(&store_err),
                 "Failed to persist send failure error tip"
             );
+            return None;
         }
+
+        Some(row)
     }
 }

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -954,10 +954,9 @@ impl ConversationService {
     ///
     /// 1. Validates the conversation belongs to the user
     /// 2. Stores the user message (position: "right", status: "finish")
-    /// 3. Gets or builds the agent task
-    /// 4. Sends the message to the agent
-    /// 5. Spawns a background relay (agent events → WebSocket + DB)
-    /// 6. Returns immediately (202 Accepted semantics)
+    /// 3. Marks the conversation as running
+    /// 4. Spawns background agent build/send and stream relay work
+    /// 5. Returns immediately (202 Accepted semantics)
     #[tracing::instrument(skip_all, fields(user_id = %user_id, conversation_id = %conversation_id))]
     pub async fn send_message(
         &self,
@@ -969,6 +968,7 @@ impl ConversationService {
         if req.content.trim().is_empty() {
             return Err(AppError::BadRequest("Message content must not be empty".into()));
         }
+        let send_started_at = now_ms();
 
         // Verify conversation exists and belongs to user
         let row = self
@@ -1043,30 +1043,11 @@ impl ConversationService {
         let build_opts = match self.build_task_options(&row) {
             Ok(opts) => opts,
             Err(err) => {
-                self.persist_send_failure_tip(conversation_id, &err).await;
+                let _ = self.persist_send_failure_tip(conversation_id, &err).await;
                 return Err(err);
             }
         };
         let stored_workspace = build_opts.workspace.clone();
-        let agent = match task_manager.get_or_build_task(conversation_id, build_opts).await {
-            Ok(agent) => agent,
-            Err(err) => {
-                self.persist_send_failure_tip(conversation_id, &err).await;
-                return Err(err);
-            }
-        };
-
-        // If the factory resolved a different workspace (e.g. auto-created temp
-        // dir for a legacy conversation with empty workspace), persist it back.
-        if let Err(err) = self
-            .maybe_persist_workspace(conversation_id, &stored_workspace, agent.workspace())
-            .await
-        {
-            self.persist_send_failure_tip(conversation_id, &err).await;
-            return Err(err);
-        }
-
-        info!(agent_type = ?agent.agent_type(), "Agent task ready");
 
         // TODO: 好蠢的设计, status 写数据库, 最好干掉啦
         let update = ConversationRowUpdate {
@@ -1084,6 +1065,8 @@ impl ConversationService {
         let broadcaster = Arc::clone(&self.broadcaster);
         let cron_service = self.current_cron_service();
         let user_id_owned = user_id.to_owned();
+        let service = self.clone();
+        let task_manager = Arc::clone(task_manager);
 
         // Send message to the agent in a background task.
         // prompt() blocks until the PromptResponse arrives (turn completed),
@@ -1094,6 +1077,37 @@ impl ConversationService {
         // agent-internal tracing all share one identifier per turn.
         let user_msg_id_ret = user_msg_id.clone();
         tokio::spawn(async move {
+            let build_started_at = now_ms();
+            info!(conversation_id = %conv_id, "Agent task build started");
+            let agent = match task_manager.get_or_build_task(&conv_id, build_opts).await {
+                Ok(agent) => agent,
+                Err(err) => {
+                    warn!(conversation_id = %conv_id, error = %ErrorChain(&err), "Agent task build failed");
+                    service.persist_and_broadcast_send_failure_tip(&conv_id, &err).await;
+                    StreamRelay::complete_conversation(&repo, &broadcaster, &conv_id).await;
+                    return;
+                }
+            };
+
+            // If the factory resolved a different workspace (e.g. auto-created temp
+            // dir for a legacy conversation with empty workspace), persist it back.
+            if let Err(err) = service
+                .maybe_persist_workspace(&conv_id, &stored_workspace, agent.workspace())
+                .await
+            {
+                warn!(conversation_id = %conv_id, error = %ErrorChain(&err), "Failed to persist resolved workspace");
+                service.persist_and_broadcast_send_failure_tip(&conv_id, &err).await;
+                StreamRelay::complete_conversation(&repo, &broadcaster, &conv_id).await;
+                return;
+            }
+
+            info!(
+                conversation_id = %conv_id,
+                agent_type = ?agent.agent_type(),
+                elapsed_ms = now_ms().saturating_sub(build_started_at),
+                "Agent task ready"
+            );
+
             let first_turn_msg_id = Self::mint_msg_id();
             let mut pending_send = Some((
                 SendMessageData {
@@ -1161,8 +1175,35 @@ impl ConversationService {
             StreamRelay::complete_conversation(&repo, &broadcaster, &conv_id).await;
         });
 
-        info!(msg_id = %user_msg_id_ret, "Message dispatched, stream relay started");
+        info!(
+            msg_id = %user_msg_id_ret,
+            elapsed_ms = now_ms().saturating_sub(send_started_at),
+            "Message accepted, agent work scheduled"
+        );
         Ok(user_msg_id_ret)
+    }
+
+    async fn persist_and_broadcast_send_failure_tip(&self, conversation_id: &str, err: &AppError) {
+        let Some(row) = self.persist_send_failure_tip(conversation_id, err).await else {
+            return;
+        };
+
+        let msg_id = row.msg_id.clone().unwrap_or_else(|| row.id.clone());
+        let content_value: serde_json::Value =
+            serde_json::from_str(&row.content).unwrap_or_else(|_| serde_json::Value::String(row.content.clone()));
+        self.broadcaster.broadcast(WebSocketMessage::new(
+            "message.stream",
+            serde_json::json!({
+                "conversation_id": row.conversation_id,
+                "msg_id": msg_id,
+                "type": row.r#type,
+                "data": content_value,
+                "position": row.position,
+                "status": row.status,
+                "hidden": row.hidden,
+                "replace": true,
+            }),
+        ));
     }
 
     /// Insert a pre-built `MessageRow` into the conversation's message history

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1,5 +1,9 @@
 use std::collections::VecDeque;
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::Duration;
 
 use aionui_ai_agent::IWorkerTaskManager;
 use aionui_ai_agent::agent_task::{AgentInstance, IAgentTask, IMockAgent};
@@ -1259,6 +1263,63 @@ impl IWorkerTaskManager for MockTaskManager {
     }
 }
 
+struct SlowBuildTaskManager {
+    delay: Duration,
+    built: AtomicBool,
+}
+
+impl SlowBuildTaskManager {
+    fn new(delay: Duration) -> Self {
+        Self {
+            delay,
+            built: AtomicBool::new(false),
+        }
+    }
+
+    fn was_built(&self) -> bool {
+        self.built.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl IWorkerTaskManager for SlowBuildTaskManager {
+    fn get_task(&self, _conversation_id: &str) -> Option<AgentInstance> {
+        None
+    }
+
+    async fn get_or_build_task(
+        &self,
+        conversation_id: &str,
+        _options: BuildTaskOptions,
+    ) -> Result<AgentInstance, AppError> {
+        tokio::time::sleep(self.delay).await;
+        self.built.store(true, Ordering::SeqCst);
+        Ok(AgentInstance::Mock(Arc::new(MockAgent::new(conversation_id))))
+    }
+
+    fn kill(&self, _conversation_id: &str, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        Ok(())
+    }
+
+    fn kill_and_wait(
+        &self,
+        _conversation_id: &str,
+        _reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        Box::pin(std::future::ready(()))
+    }
+
+    fn clear(&self) {}
+
+    fn active_count(&self) -> usize {
+        usize::from(self.was_built())
+    }
+
+    fn collect_idle(&self, _idle_threshold_ms: TimestampMs) -> Vec<String> {
+        vec![]
+    }
+}
+
 /// A variant of MockTaskManager that always builds agents with a specific workspace.
 struct MockTaskManagerWithWorkspace {
     workspace: String,
@@ -1487,6 +1548,31 @@ async fn send_message_broadcasts_user_created_event() {
 }
 
 #[tokio::test]
+async fn send_message_returns_before_cold_agent_build_completes() {
+    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let slow_task_mgr = Arc::new(SlowBuildTaskManager::new(Duration::from_millis(500)));
+    let task_mgr: Arc<dyn IWorkerTaskManager> = slow_task_mgr.clone();
+
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+    let msg_id = tokio::time::timeout(
+        Duration::from_millis(50),
+        svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr),
+    )
+    .await
+    .expect("send_message should return before cold agent build finishes")
+    .unwrap();
+
+    assert!(!msg_id.is_empty(), "msg_id must be non-empty");
+    assert!(
+        !slow_task_mgr.was_built(),
+        "cold agent build should continue in the background after send_message returns"
+    );
+
+    let updated = repo.get(&conv.id).await.unwrap().unwrap();
+    assert_eq!(updated.status.as_deref(), Some("running"));
+}
+
+#[tokio::test]
 async fn send_message_persists_hidden_user_message_when_requested() {
     let (svc, _broadcaster, repo, _task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
@@ -1513,20 +1599,31 @@ async fn send_message_persists_hidden_user_message_when_requested() {
 
 #[tokio::test]
 async fn send_message_persists_error_tip_when_agent_build_fails() {
-    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let (svc, broadcaster, repo, _task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> =
         Arc::new(FailingBuildTaskManager::new("ACP init failed: config file is invalid"));
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
+    broadcaster.take_events();
 
-    let err = svc
+    let msg_id = svc
         .send_message("user_1", &conv.id, make_send_req(), &task_mgr)
         .await
-        .unwrap_err();
+        .unwrap();
 
-    assert!(matches!(err, AppError::BadGateway(_)));
+    assert!(!msg_id.is_empty(), "msg_id must be non-empty");
 
-    let messages = repo.get_messages(&conv.id, 1, 20, SortOrder::Asc).await.unwrap().items;
+    let messages = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let messages = repo.get_messages(&conv.id, 1, 20, SortOrder::Asc).await.unwrap().items;
+            if messages.iter().any(|message| message.r#type == "tips") {
+                return messages;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("agent build failure should persist an error tip");
     assert_eq!(messages.len(), 2, "user message and error tip should be persisted");
 
     let error_tip = messages
@@ -1544,6 +1641,17 @@ async fn send_message_persists_error_tip_when_agent_build_fails() {
         content["content"],
         "Bad gateway: ACP init failed: config file is invalid"
     );
+
+    let updated = repo.get(&conv.id).await.unwrap().unwrap();
+    assert_eq!(updated.status.as_deref(), Some("finished"));
+
+    let events = broadcaster.take_events();
+    let error_tip_event = events
+        .iter()
+        .find(|event| event.name == "message.stream" && event.data["type"] == "tips")
+        .expect("agent build failure should broadcast the error tips message");
+    assert_eq!(error_tip_event.data["status"], "error");
+    assert_eq!(error_tip_event.data["data"]["code"], "BAD_GATEWAY");
 }
 
 #[tokio::test]
@@ -1652,7 +1760,17 @@ async fn send_message_persists_factory_resolved_workspace() {
         .unwrap();
 
     // Verify the workspace was written back.
-    let updated = svc.get("user_1", &conv.id).await.unwrap();
+    let updated = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let updated = svc.get("user_1", &conv.id).await.unwrap();
+            if updated.extra["workspace"] == auto_workspace {
+                return updated;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("factory-resolved workspace should be persisted in the background");
     assert_eq!(updated.extra["workspace"], auto_workspace);
 }
 

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -106,103 +106,132 @@ impl StreamRelay {
         let mut active_text: Option<TextSegmentState> = None;
         let mut active_thinking: Option<ThinkingSegmentState> = None;
         let mut used_primary_segment_msg_id = false;
+        let mut first_agent_event_logged = false;
+        let mut first_visible_output_logged = false;
 
         loop {
             match rx.recv().await {
-                Ok(event) => match &event {
-                    AgentStreamEvent::Thinking(data) => {
-                        if data.status.as_deref() == Some("done") {
-                            self.complete_active_thinking(&mut active_thinking).await;
-                            continue;
-                        }
-
-                        self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
-                            .await;
-
-                        let segment = active_thinking.get_or_insert_with(|| ThinkingSegmentState {
-                            id: Self::mint_segment_msg_id(&mut used_primary_segment_msg_id, &self.msg_id),
-                            buffer: String::new(),
-                            started_at: now_ms(),
-                        });
-                        segment.buffer.push_str(&data.content);
-                        self.forward_to_websocket_with_msg_id(&segment.id, &event);
-                    }
-                    AgentStreamEvent::Text(data) => {
-                        self.complete_active_thinking(&mut active_thinking).await;
-
-                        let segment = active_text.get_or_insert_with(|| TextSegmentState {
-                            id: Self::mint_segment_msg_id(&mut used_primary_segment_msg_id, &self.msg_id),
-                            buffer: String::new(),
-                            created_at: now_ms(),
-                            record_created: false,
-                            flush_counter: 0,
-                        });
-                        self.forward_to_websocket_with_msg_id(&segment.id, &event);
-                        segment.buffer.push_str(&data.content);
-                        full_text_buffer.push_str(&data.content);
-                        segment.flush_counter += 1;
-                        if segment.flush_counter >= FLUSH_INTERVAL {
-                            self.flush_text_segment(segment).await;
-                            segment.flush_counter = 0;
-                        }
-                    }
-                    AgentStreamEvent::Finish(_) | AgentStreamEvent::Error(_) => {
-                        let elapsed_ms = now_ms() - started_at;
-                        let event_type = if matches!(event, AgentStreamEvent::Finish(_)) {
-                            "Finish"
-                        } else {
-                            "Error"
-                        };
+                Ok(event) => {
+                    if !first_agent_event_logged {
+                        first_agent_event_logged = true;
                         info!(
-                            event_type,
-                            elapsed_ms,
-                            text_len = full_text_buffer.len(),
-                            "StreamRelay received terminal event"
+                            event_type = Self::event_kind(&event),
+                            elapsed_ms = now_ms().saturating_sub(started_at),
+                            "StreamRelay received first agent event"
                         );
+                    }
 
-                        self.complete_active_thinking(&mut active_thinking).await;
-                        self.close_active_text_segment(
-                            &mut active_text,
-                            &mut text_segments,
-                            if matches!(event, AgentStreamEvent::Error(_)) {
-                                "error"
-                            } else {
-                                "finish"
-                            },
-                        )
-                        .await;
-                        self.forward_to_websocket(&event);
-                        let outcome = self.finalize(&full_text_buffer, &text_segments, &event).await;
-                        if self.complete_turn {
-                            Self::complete_conversation(&self.repo, &self.broadcaster, &self.conversation_id).await;
+                    match &event {
+                        AgentStreamEvent::Thinking(data) => {
+                            if data.status.as_deref() == Some("done") {
+                                self.complete_active_thinking(&mut active_thinking).await;
+                                continue;
+                            }
+
+                            self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
+                                .await;
+                            if !first_visible_output_logged && !data.content.is_empty() {
+                                first_visible_output_logged = true;
+                                info!(
+                                    event_type = "Thinking",
+                                    elapsed_ms = now_ms().saturating_sub(started_at),
+                                    "StreamRelay received first visible output"
+                                );
+                            }
+
+                            let segment = active_thinking.get_or_insert_with(|| ThinkingSegmentState {
+                                id: Self::mint_segment_msg_id(&mut used_primary_segment_msg_id, &self.msg_id),
+                                buffer: String::new(),
+                                started_at: now_ms(),
+                            });
+                            segment.buffer.push_str(&data.content);
+                            self.forward_to_websocket_with_msg_id(&segment.id, &event);
                         }
-                        break outcome;
-                    }
-                    AgentStreamEvent::ToolCall(data) => {
-                        self.complete_active_thinking(&mut active_thinking).await;
-                        self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
+                        AgentStreamEvent::Text(data) => {
+                            self.complete_active_thinking(&mut active_thinking).await;
+                            if !first_visible_output_logged && !data.content.is_empty() {
+                                first_visible_output_logged = true;
+                                info!(
+                                    event_type = "Text",
+                                    elapsed_ms = now_ms().saturating_sub(started_at),
+                                    "StreamRelay received first visible output"
+                                );
+                            }
+
+                            let segment = active_text.get_or_insert_with(|| TextSegmentState {
+                                id: Self::mint_segment_msg_id(&mut used_primary_segment_msg_id, &self.msg_id),
+                                buffer: String::new(),
+                                created_at: now_ms(),
+                                record_created: false,
+                                flush_counter: 0,
+                            });
+                            self.forward_to_websocket_with_msg_id(&segment.id, &event);
+                            segment.buffer.push_str(&data.content);
+                            full_text_buffer.push_str(&data.content);
+                            segment.flush_counter += 1;
+                            if segment.flush_counter >= FLUSH_INTERVAL {
+                                self.flush_text_segment(segment).await;
+                                segment.flush_counter = 0;
+                            }
+                        }
+                        AgentStreamEvent::Finish(_) | AgentStreamEvent::Error(_) => {
+                            let elapsed_ms = now_ms() - started_at;
+                            let event_type = if matches!(event, AgentStreamEvent::Finish(_)) {
+                                "Finish"
+                            } else {
+                                "Error"
+                            };
+                            info!(
+                                event_type,
+                                elapsed_ms,
+                                text_len = full_text_buffer.len(),
+                                "StreamRelay received terminal event"
+                            );
+
+                            self.complete_active_thinking(&mut active_thinking).await;
+                            self.close_active_text_segment(
+                                &mut active_text,
+                                &mut text_segments,
+                                if matches!(event, AgentStreamEvent::Error(_)) {
+                                    "error"
+                                } else {
+                                    "finish"
+                                },
+                            )
                             .await;
-                        self.forward_to_websocket(&event);
-                        self.persist_tool_call(data).await;
+                            self.forward_to_websocket(&event);
+                            let outcome = self.finalize(&full_text_buffer, &text_segments, &event).await;
+                            if self.complete_turn {
+                                Self::complete_conversation(&self.repo, &self.broadcaster, &self.conversation_id).await;
+                            }
+                            break outcome;
+                        }
+                        AgentStreamEvent::ToolCall(data) => {
+                            self.complete_active_thinking(&mut active_thinking).await;
+                            self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
+                                .await;
+                            self.forward_to_websocket(&event);
+                            self.persist_tool_call(data).await;
+                        }
+                        AgentStreamEvent::AcpToolCall(data) => {
+                            self.complete_active_thinking(&mut active_thinking).await;
+                            self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
+                                .await;
+                            self.forward_to_websocket(&event);
+                            self.persist_acp_tool_call(data).await;
+                        }
+                        AgentStreamEvent::ToolGroup(entries) => {
+                            self.complete_active_thinking(&mut active_thinking).await;
+                            self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
+                                .await;
+                            self.forward_to_websocket(&event);
+                            self.persist_tool_group(entries).await;
+                        }
+                        _ => {
+                            self.forward_to_websocket(&event);
+                        }
                     }
-                    AgentStreamEvent::AcpToolCall(data) => {
-                        self.complete_active_thinking(&mut active_thinking).await;
-                        self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
-                            .await;
-                        self.forward_to_websocket(&event);
-                        self.persist_acp_tool_call(data).await;
-                    }
-                    AgentStreamEvent::ToolGroup(entries) => {
-                        self.complete_active_thinking(&mut active_thinking).await;
-                        self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
-                            .await;
-                        self.forward_to_websocket(&event);
-                        self.persist_tool_group(entries).await;
-                    }
-                    _ => {
-                        self.forward_to_websocket(&event);
-                    }
-                },
+                }
                 Err(broadcast::error::RecvError::Closed) => {
                     let elapsed_ms = now_ms() - started_at;
                     warn!(
@@ -231,6 +260,37 @@ impl StreamRelay {
                     warn!(lagged = n, "Stream relay lagged, some events dropped");
                 }
             }
+        }
+    }
+
+    fn event_kind(event: &AgentStreamEvent) -> &'static str {
+        match event {
+            AgentStreamEvent::Start(_) => "Start",
+            AgentStreamEvent::Text(_) => "Text",
+            AgentStreamEvent::Tips(_) => "Tips",
+            AgentStreamEvent::Thinking(_) => "Thinking",
+            AgentStreamEvent::ToolCall(_) => "ToolCall",
+            AgentStreamEvent::AcpToolCall(_) => "AcpToolCall",
+            AgentStreamEvent::ToolGroup(_) => "ToolGroup",
+            AgentStreamEvent::AgentStatus(_) => "AgentStatus",
+            AgentStreamEvent::Plan(_) => "Plan",
+            AgentStreamEvent::Permission(_) => "Permission",
+            AgentStreamEvent::AcpPermission(_) => "AcpPermission",
+            AgentStreamEvent::SkillSuggest(_) => "SkillSuggest",
+            AgentStreamEvent::CronTrigger(_) => "CronTrigger",
+            AgentStreamEvent::AcpModelInfo(_) => "AcpModelInfo",
+            AgentStreamEvent::AcpModeInfo(_) => "AcpModeInfo",
+            AgentStreamEvent::AcpConfigOption(_) => "AcpConfigOption",
+            AgentStreamEvent::AcpSessionInfo(_) => "AcpSessionInfo",
+            AgentStreamEvent::AcpContextUsage(_) => "AcpContextUsage",
+            AgentStreamEvent::AcpPromptHookWarning(_) => "AcpPromptHookWarning",
+            AgentStreamEvent::SlashCommandsUpdated(_) => "SlashCommandsUpdated",
+            AgentStreamEvent::AvailableCommands(_) => "AvailableCommands",
+            AgentStreamEvent::Finish(_) => "Finish",
+            AgentStreamEvent::Error(_) => "Error",
+            AgentStreamEvent::System(_) => "System",
+            AgentStreamEvent::RequestTrace(_) => "RequestTrace",
+            AgentStreamEvent::SessionAssigned(_) => "SessionAssigned",
         }
     }
 


### PR DESCRIPTION
## Summary
- Return message-send responses immediately after persisting and broadcasting the user message.
- Move agent preparation/send work to the background and add latency markers for the message lifecycle.
- Cache aionrs slash commands at bootstrap so slash-command lookup does not block on the active engine lock.

## Test Plan
- `just push -u origin perf/message-latency`
- `cargo nextest run --workspace` via `just push`: 5679 passed, 18 skipped