### PR TITLE
feat(agent): classify structured agent send errors

### DIFF
--- a/crates/aionui-ai-agent/src/agent_runtime.rs
+++ b/crates/aionui-ai-agent/src/agent_runtime.rs
@@ -14,6 +14,7 @@ use std::sync::{Arc, RwLock};
 
 use tokio::sync::broadcast;
 
+use aionui_api_types::AgentStreamErrorData;
 use aionui_common::{ConversationStatus, TimestampMs, now_ms};
 
 use crate::protocol::events::{AgentStreamEvent, ErrorEventData, FinishEventData};
@@ -127,6 +128,12 @@ impl AgentRuntime {
     /// Atomic: set status ← Finished AND broadcast `Error { message }`.
     /// Idempotent in the Finished absorbing state (no-op).
     pub fn emit_error(&self, message: impl Into<String>) {
+        self.emit_error_data(ErrorEventData::legacy(message, None));
+    }
+
+    /// Atomic: set status ← Finished AND broadcast the structured error payload.
+    /// Idempotent in the Finished absorbing state (no-op).
+    pub fn emit_error_data(&self, data: AgentStreamErrorData) {
         let already_finished = {
             let mut guard = self.status.write().unwrap_or_else(|e| e.into_inner());
             let was_finished = matches!(*guard, Some(ConversationStatus::Finished));
@@ -138,10 +145,7 @@ impl AgentRuntime {
         if already_finished {
             return;
         }
-        let _ = self.event_tx.send(AgentStreamEvent::Error(ErrorEventData {
-            message: message.into(),
-            code: None,
-        }));
+        let _ = self.event_tx.send(AgentStreamEvent::Error(data));
     }
 }
 

--- a/crates/aionui-ai-agent/src/agent_task.rs
+++ b/crates/aionui-ai-agent/src/agent_task.rs
@@ -22,6 +22,7 @@ use crate::manager::nanobot::NanobotAgentManager;
 use crate::manager::openclaw::OpenClawAgentManager;
 use crate::manager::remote::RemoteAgentManager;
 use crate::protocol::events::AgentStreamEvent;
+use crate::protocol::send_error::AgentSendError;
 use crate::types::SendMessageData;
 
 use aionui_api_types::{
@@ -62,7 +63,7 @@ pub trait IAgentTask: Send + Sync {
     /// Send a user message to the agent. Returns once the agent has
     /// accepted the turn; actual streaming proceeds on the broadcast
     /// channel returned by [`Self::subscribe`].
-    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError>;
+    async fn send_message(&self, data: SendMessageData) -> Result<(), AgentSendError>;
 
     /// Stop the current streaming response without killing the agent.
     async fn cancel(&self) -> Result<(), AppError>;
@@ -220,7 +221,7 @@ impl AgentInstance {
     }
 
     /// Send a user message to the agent.
-    pub async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+    pub async fn send_message(&self, data: SendMessageData) -> Result<(), AgentSendError> {
         self.as_task().send_message(data).await
     }
 

--- a/crates/aionui-ai-agent/src/capability/backend_output_sink.rs
+++ b/crates/aionui-ai-agent/src/capability/backend_output_sink.rs
@@ -131,10 +131,9 @@ impl OutputSink for BackendOutputSink {
     }
 
     fn emit_error(&self, msg: &str) {
-        let _ = self.event_tx.send(AgentStreamEvent::Error(ErrorEventData {
-            message: msg.to_owned(),
-            code: None,
-        }));
+        let _ = self
+            .event_tx
+            .send(AgentStreamEvent::Error(ErrorEventData::legacy(msg, None)));
     }
 
     fn emit_info(&self, msg: &str) {

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -32,6 +32,7 @@ pub use factory::{AgentFactoryDeps, build_agent_factory};
 pub use idle_scanner::start_idle_scanner;
 pub use persistence::AcpSessionSyncService;
 pub use protocol::events::AgentStreamEvent;
+pub use protocol::send_error::AgentSendError;
 pub use registry::{AgentRegistry, UnavailableReason};
 pub use routes::{AgentRouterState, RemoteAgentRouterState, agent_routes, remote_agent_routes};
 pub use services::AgentService;

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -11,6 +11,7 @@ use crate::manager::process_registry::{register_session_process, unregister_agen
 use crate::protocol::acp::AcpProtocol;
 use crate::protocol::error::{AcpError, CloseReason};
 use crate::protocol::events::{AgentStreamEvent, FinishEventData};
+use crate::protocol::send_error::AgentSendError;
 use crate::registry::CatalogSender;
 use crate::shared_kernel::{ModeId, ModelId, SessionId as DomainSessionId};
 use crate::types::SendMessageData;
@@ -605,17 +606,17 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
     }
 
     #[tracing::instrument(skip_all, fields(conversation_id = %self.params.conversation_id, msg_id = %data.msg_id))]
-    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+    async fn send_message(&self, data: SendMessageData) -> Result<(), AgentSendError> {
         self.runtime.bump_activity();
 
-        let result = self.ensure_session_and_send(&data).await;
-        match &result {
+        match self.ensure_session_and_send(&data).await {
             Ok(()) => {
                 info!("ACP send_message completed");
                 // ACP pattern: Finish with session_id = None (default).
                 // If ACP later wants to include the session_id in Finish,
                 // read it from `self.session.read().await.session_id()`.
                 self.runtime.emit_finish(None);
+                Ok(())
             }
             Err(err) => {
                 // Build a CloseReason that captures whatever context we still
@@ -628,22 +629,23 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
                 //      stderr-augmentation heuristic for the SDK's "default
                 //      Internal error" shape; otherwise the user-facing form
                 //      of the AppError is the best we can do.
-                let close_reason = self.build_close_reason_from_error(err).await;
+                let close_reason = self.build_close_reason_from_error(&err).await;
 
                 // Operator log: full error chain + the (raw, pre-redaction)
                 // stderr peek so on-call can correlate. The redacted summary
                 // is what reaches the UI.
                 let summary = close_reason.user_facing_message();
-                warn!(error = %ErrorChain(err), close_reason_summary = %summary, "ACP send_message failed");
+                warn!(error = %ErrorChain(&err), close_reason_summary = %summary, "ACP send_message failed");
 
                 {
                     let mut session = self.session.write().await;
                     session.record_close_reason(Some(close_reason));
                 }
-                self.runtime.emit_error(summary);
+                let send_error = AgentSendError::from_app_error(err);
+                self.runtime.emit_error_data(send_error.stream_error().clone());
+                Err(send_error)
             }
         }
-        result
     }
 
     #[tracing::instrument(skip_all, fields(conversation_id = %self.params.conversation_id))]

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -635,7 +635,7 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
                 // stderr peek so on-call can correlate. The redacted summary
                 // is what reaches the UI.
                 let summary = close_reason.user_facing_message();
-                warn!(error = %ErrorChain(&err), close_reason_summary = %summary, "ACP send_message failed");
+                error!(error = %ErrorChain(&err), close_reason_summary = %summary, "ACP send_message failed");
 
                 {
                     let mut session = self.session.write().await;

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -7,6 +7,7 @@ use crate::protocol::events::{
 use crate::shared_kernel::SessionId as DomainSessionId;
 use crate::types::SendMessageData;
 use agent_client_protocol::schema::{ContentBlock, LoadSessionRequest, PromptRequest, SessionId, StopReason};
+use aionui_api_types::{AgentErrorCode, AgentErrorOwnership};
 use aionui_common::AppError;
 use serde_json::Value;
 use tokio::sync::broadcast::error::TryRecvError;
@@ -259,13 +260,17 @@ impl AcpAgentManager {
         // user already initiated the cancel and doesn't need a second
         // notification.
         if !matches!(prompt_response.stop_reason, StopReason::Cancelled) && is_empty_turn(&mut probe_rx) {
-            self.runtime.emit(AgentStreamEvent::Error(ErrorEventData {
+            self.runtime.emit(AgentStreamEvent::Error(ErrorEventData::classified(
                 // TODO(i18n): wire to a frontend translation key once a
                 // pattern is established. For now this is the user-facing
                 // English string.
-                message: empty_finish_diagnostic_message(prompt_response.stop_reason),
-                code: Some("acp.empty_finish".into()),
-            }));
+                empty_finish_diagnostic_message(prompt_response.stop_reason),
+                AgentErrorCode::UnknownUpstreamError,
+                AgentErrorOwnership::UnknownUpstream,
+                Some("Agent completed the turn without producing visible output.".into()),
+                true,
+                true,
+            )));
         }
 
         // Emit Finish event

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -270,6 +270,7 @@ impl AcpAgentManager {
                 Some("Agent completed the turn without producing visible output.".into()),
                 true,
                 true,
+                None,
             )));
         }
 

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -7,7 +7,9 @@ use crate::protocol::events::{
 use crate::shared_kernel::SessionId as DomainSessionId;
 use crate::types::SendMessageData;
 use agent_client_protocol::schema::{ContentBlock, LoadSessionRequest, PromptRequest, SessionId, StopReason};
-use aionui_api_types::{AgentErrorCode, AgentErrorOwnership};
+use aionui_api_types::{
+    AgentErrorCode, AgentErrorOwnership, AgentErrorResolution, AgentErrorResolutionKind, AgentErrorResolutionTarget,
+};
 use aionui_common::AppError;
 use serde_json::Value;
 use tokio::sync::broadcast::error::TryRecvError;
@@ -260,17 +262,8 @@ impl AcpAgentManager {
         // user already initiated the cancel and doesn't need a second
         // notification.
         if !matches!(prompt_response.stop_reason, StopReason::Cancelled) && is_empty_turn(&mut probe_rx) {
-            self.runtime.emit(AgentStreamEvent::Error(ErrorEventData::classified(
-                // TODO(i18n): wire to a frontend translation key once a
-                // pattern is established. For now this is the user-facing
-                // English string.
-                empty_finish_diagnostic_message(prompt_response.stop_reason),
-                AgentErrorCode::UnknownUpstreamError,
-                AgentErrorOwnership::UnknownUpstream,
-                Some("Agent completed the turn without producing visible output.".into()),
-                true,
-                true,
-                None,
+            self.runtime.emit(AgentStreamEvent::Error(empty_finish_diagnostic_error(
+                prompt_response.stop_reason,
             )));
         }
 
@@ -380,6 +373,24 @@ fn event_is_user_visible_output(event: &AgentStreamEvent) -> bool {
             | AgentStreamEvent::Plan(_)
             | AgentStreamEvent::Permission(_)
             | AgentStreamEvent::AcpPermission(_)
+    )
+}
+
+fn empty_finish_diagnostic_error(stop_reason: StopReason) -> ErrorEventData {
+    ErrorEventData::classified(
+        // TODO(i18n): wire to a frontend translation key once a
+        // pattern is established. For now this is the user-facing
+        // English string.
+        empty_finish_diagnostic_message(stop_reason),
+        AgentErrorCode::UnknownUpstreamError,
+        AgentErrorOwnership::UnknownUpstream,
+        Some("Agent completed the turn without producing visible output.".into()),
+        true,
+        true,
+        Some(AgentErrorResolution::new(
+            AgentErrorResolutionKind::SendFeedback,
+            Some(AgentErrorResolutionTarget::Feedback),
+        )),
     )
 }
 
@@ -586,6 +597,7 @@ mod tests {
         ToolCallStatus,
     };
     use agent_client_protocol::schema::StopReason;
+    use aionui_api_types::{AgentErrorResolutionKind, AgentErrorResolutionTarget};
     use tokio::sync::broadcast;
 
     /// Lifecycle-only events (`Start`/`Finish`) must NOT count as
@@ -676,5 +688,16 @@ mod tests {
 
         let refusal = super::empty_finish_diagnostic_message(StopReason::Refusal);
         assert!(refusal.to_lowercase().contains("refused"));
+    }
+
+    #[test]
+    fn empty_finish_diagnostic_error_has_feedback_resolution() {
+        let error = super::empty_finish_diagnostic_error(StopReason::EndTurn);
+
+        let resolution = error
+            .resolution
+            .expect("empty-finish classified errors must include a resolution");
+        assert_eq!(resolution.kind, AgentErrorResolutionKind::SendFeedback);
+        assert_eq!(resolution.target, Some(AgentErrorResolutionTarget::Feedback));
     }
 }

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -21,6 +21,7 @@ use crate::agent_runtime::AgentRuntime;
 use crate::capability::backend_output_sink::BackendOutputSink;
 use crate::capability::backend_protocol_sink::BackendProtocolSink;
 use crate::protocol::events::AgentStreamEvent;
+use crate::protocol::send_error::AgentSendError;
 use crate::types::{AionrsResolvedConfig, SendMessageData};
 
 pub struct AionrsAgentManager {
@@ -185,7 +186,7 @@ impl crate::agent_task::IAgentTask for AionrsAgentManager {
         self.runtime.subscribe()
     }
 
-    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+    async fn send_message(&self, data: SendMessageData) -> Result<(), AgentSendError> {
         let started_at = now_ms();
         info!(
             conversation_id = %self.runtime.conversation_id(),
@@ -230,9 +231,10 @@ impl crate::agent_task::IAgentTask for AionrsAgentManager {
                     error = %ErrorChain(&e),
                     "Aionrs engine.run() failed, emitting Error+Finish"
                 );
-                self.runtime.emit_error(error_msg.clone());
+                let send_error = AgentSendError::from_app_error(AppError::Internal(error_msg));
+                self.runtime.emit_error_data(send_error.stream_error().clone());
                 self.runtime.emit_finish(None);
-                Err(AppError::Internal(error_msg))
+                Err(send_error)
             }
             None => {
                 self.runtime.emit_error("Stopped by user");

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -231,7 +231,7 @@ impl crate::agent_task::IAgentTask for AionrsAgentManager {
                     error = %ErrorChain(&e),
                     "Aionrs engine.run() failed, emitting Error+Finish"
                 );
-                let send_error = AgentSendError::from_app_error(AppError::Internal(error_msg));
+                let send_error = aionrs_engine_error_to_send_error(error_msg);
                 self.runtime.emit_error_data(send_error.stream_error().clone());
                 self.runtime.emit_finish(None);
                 Err(send_error)
@@ -353,6 +353,14 @@ fn parse_session_mode(s: &str) -> SessionMode {
         "yolo" => SessionMode::Yolo,
         _ => SessionMode::Default,
     }
+}
+
+fn aionrs_engine_error_to_send_error(error_msg: String) -> AgentSendError {
+    let lower = error_msg.to_ascii_lowercase();
+    if lower.contains("provider error") || lower.contains("provider:") {
+        return AgentSendError::from_app_error(AppError::BadGateway(error_msg));
+    }
+    AgentSendError::from_app_error(AppError::Internal(error_msg))
 }
 
 #[cfg(test)]
@@ -489,5 +497,23 @@ mod tests {
             AgentStreamEvent::Finish(_) => {}
             other => panic!("Expected Finish, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn aionrs_provider_connection_error_is_user_llm_provider_error() {
+        let send_error = aionrs_engine_error_to_send_error(
+            "Aionrs agent error: Provider error: Connection error: Signable request error: failed to create canonical request"
+                .to_owned(),
+        );
+
+        assert_eq!(
+            send_error.code(),
+            Some(aionui_api_types::AgentErrorCode::UserLlmProviderConfigError)
+        );
+        assert_eq!(
+            send_error.ownership(),
+            Some(aionui_api_types::AgentErrorOwnership::UserLlmProvider)
+        );
+        assert_eq!(send_error.stream_error().retryable, Some(false));
     }
 }

--- a/crates/aionui-ai-agent/src/manager/nanobot/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/nanobot/agent.rs
@@ -12,6 +12,7 @@ use crate::agent_runtime::AgentRuntime;
 use crate::capability::cli_process::CliAgentProcess;
 use crate::manager::process_registry::register_session_process;
 use crate::protocol::events::AgentStreamEvent;
+use crate::protocol::send_error::AgentSendError;
 use crate::types::SendMessageData;
 use std::path::PathBuf;
 
@@ -187,7 +188,7 @@ impl crate::agent_task::IAgentTask for NanobotAgentManager {
         self.runtime.subscribe()
     }
 
-    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+    async fn send_message(&self, data: SendMessageData) -> Result<(), AgentSendError> {
         self.runtime.bump_activity();
 
         {
@@ -205,7 +206,14 @@ impl crate::agent_task::IAgentTask for NanobotAgentManager {
             }
         });
 
-        self.process.send(&payload).await
+        match self.process.send(&payload).await {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                let send_error = AgentSendError::from_app_error(err);
+                self.runtime.emit_error_data(send_error.stream_error().clone());
+                Err(send_error)
+            }
+        }
     }
 
     async fn cancel(&self) -> Result<(), AppError> {

--- a/crates/aionui-ai-agent/src/manager/nanobot/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/nanobot/agent.rs
@@ -209,6 +209,11 @@ impl crate::agent_task::IAgentTask for NanobotAgentManager {
         match self.process.send(&payload).await {
             Ok(()) => Ok(()),
             Err(err) => {
+                error!(
+                    conversation_id = %self.runtime.conversation_id(),
+                    error = %ErrorChain(&err),
+                    "Nanobot send_message failed, emitting Error"
+                );
                 let send_error = AgentSendError::from_app_error(err);
                 self.runtime.emit_error_data(send_error.stream_error().clone());
                 Err(send_error)

--- a/crates/aionui-ai-agent/src/manager/openclaw/agent/mod.rs
+++ b/crates/aionui-ai-agent/src/manager/openclaw/agent/mod.rs
@@ -11,6 +11,7 @@ use crate::agent_runtime::AgentRuntime;
 use crate::capability::cli_process::CliAgentProcess;
 use crate::manager::process_registry::register_session_process;
 use crate::protocol::events::AgentStreamEvent;
+use crate::protocol::send_error::AgentSendError;
 use crate::types::SendMessageData;
 use aionui_api_types::OpenClawBuildExtra;
 
@@ -403,7 +404,7 @@ impl crate::agent_task::IAgentTask for OpenClawAgentManager {
         self.runtime.subscribe()
     }
 
-    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+    async fn send_message(&self, data: SendMessageData) -> Result<(), AgentSendError> {
         self.runtime.bump_activity();
 
         let is_first = {
@@ -419,17 +420,20 @@ impl crate::agent_task::IAgentTask for OpenClawAgentManager {
             text_state.reset_for_new_turn();
         }
 
-        let result = self.do_send_message(is_first, data).await;
-        if let Err(ref e) = result {
-            error!(
-                conversation_id = %self.runtime.conversation_id(),
-                error = %ErrorChain(e),
-                "OpenClaw send_message failed, emitting Error+Finish"
-            );
-            self.runtime.emit_error(format!("OpenClaw send failed: {e}"));
-            self.runtime.emit_finish(None);
+        match self.do_send_message(is_first, data).await {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                error!(
+                    conversation_id = %self.runtime.conversation_id(),
+                    error = %ErrorChain(&err),
+                    "OpenClaw send_message failed, emitting Error+Finish"
+                );
+                let send_error = AgentSendError::from_app_error(err);
+                self.runtime.emit_error_data(send_error.stream_error().clone());
+                self.runtime.emit_finish(None);
+                Err(send_error)
+            }
         }
-        result
     }
 
     async fn cancel(&self) -> Result<(), AppError> {

--- a/crates/aionui-ai-agent/src/manager/openclaw/event_mapper.rs
+++ b/crates/aionui-ai-agent/src/manager/openclaw/event_mapper.rs
@@ -133,10 +133,7 @@ fn map_chat_event(
         }
         ChatEventState::Error => {
             let msg = chat.error_message.unwrap_or_else(|| "Unknown chat error".into());
-            events.push(AgentStreamEvent::Error(ErrorEventData {
-                message: msg,
-                code: None,
-            }));
+            events.push(AgentStreamEvent::Error(ErrorEventData::legacy(msg, None)));
             text_state.turn_active = false;
         }
     }

--- a/crates/aionui-ai-agent/src/manager/remote/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/remote/agent.rs
@@ -12,6 +12,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::agent_runtime::AgentRuntime;
 use crate::protocol::events::AgentStreamEvent;
+use crate::protocol::send_error::AgentSendError;
 use crate::types::SendMessageData;
 
 /// Internal mutable state for the Remote agent.
@@ -272,7 +273,7 @@ impl crate::agent_task::IAgentTask for RemoteAgentManager {
         self.runtime.subscribe()
     }
 
-    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+    async fn send_message(&self, data: SendMessageData) -> Result<(), AgentSendError> {
         self.runtime.bump_activity();
 
         let is_first = {
@@ -293,7 +294,14 @@ impl crate::agent_task::IAgentTask for RemoteAgentManager {
                     "msgId": data.msg_id,
                 }
             });
-            self.ws_send(&payload).await
+            match self.ws_send(&payload).await {
+                Ok(()) => Ok(()),
+                Err(err) => {
+                    let send_error = AgentSendError::from_app_error(err);
+                    self.runtime.emit_error_data(send_error.stream_error().clone());
+                    Err(send_error)
+                }
+            }
         } else {
             // Subsequent messages: try to resume session
             let session_key = self.state.read().await.session_key.clone();
@@ -310,7 +318,14 @@ impl crate::agent_task::IAgentTask for RemoteAgentManager {
             if !data.files.is_empty() {
                 payload["data"]["files"] = json!(data.files);
             }
-            self.ws_send(&payload).await
+            match self.ws_send(&payload).await {
+                Ok(()) => Ok(()),
+                Err(err) => {
+                    let send_error = AgentSendError::from_app_error(err);
+                    self.runtime.emit_error_data(send_error.stream_error().clone());
+                    Err(send_error)
+                }
+            }
         }
     }
 

--- a/crates/aionui-ai-agent/src/manager/remote/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/remote/agent.rs
@@ -297,6 +297,11 @@ impl crate::agent_task::IAgentTask for RemoteAgentManager {
             match self.ws_send(&payload).await {
                 Ok(()) => Ok(()),
                 Err(err) => {
+                    error!(
+                        conversation_id = %self.runtime.conversation_id(),
+                        error = %ErrorChain(&err),
+                        "Remote send_message failed, emitting Error"
+                    );
                     let send_error = AgentSendError::from_app_error(err);
                     self.runtime.emit_error_data(send_error.stream_error().clone());
                     Err(send_error)
@@ -321,6 +326,11 @@ impl crate::agent_task::IAgentTask for RemoteAgentManager {
             match self.ws_send(&payload).await {
                 Ok(()) => Ok(()),
                 Err(err) => {
+                    error!(
+                        conversation_id = %self.runtime.conversation_id(),
+                        error = %ErrorChain(&err),
+                        "Remote send_message failed, emitting Error"
+                    );
                     let send_error = AgentSendError::from_app_error(err);
                     self.runtime.emit_error_data(send_error.stream_error().clone());
                     Err(send_error)

--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -569,35 +569,35 @@ fn log_client_request(method: &str, body: &str) {
 /// `session/prompt` reply is large; stays at debug.
 fn log_agent_response(method: &str, body: &str) {
     if method == "session/prompt" {
-        debug!(direction = "agent_response", method, body, "[ACP] <-");
+        debug!(direction = "agent_response", method, body, "[ACP] <- ${method}");
     } else {
-        info!(direction = "agent_response", method, body, "[ACP] <-");
+        info!(direction = "agent_response", method, body, "[ACP] <- ${method}");
     }
 }
 
 /// Log a fire-and-forget notification from AionUi to the agent.
 fn log_client_notify(method: &str, body: &str) {
-    info!(direction = "client_notify", method, body, "[ACP] ->");
+    info!(direction = "client_notify", method, body, "[ACP] -> ${method}");
 }
 
 /// Log an inbound notification from the agent.
 /// `session/update` requires per-kind filtering — streaming chunks stay at debug.
 fn log_agent_notify(method: &str, body: &str) {
     if method == "session/update" && is_streaming_chunk(body) {
-        debug!(direction = "agent_notify", method, body, "[ACP] <-");
+        debug!(direction = "agent_notify", method, body, "[ACP] <- ${method}");
     } else {
-        info!(direction = "agent_notify", method, body, "[ACP] <-");
+        info!(direction = "agent_notify", method, body, "[ACP] <- ${method}");
     }
 }
 
 /// Log an inbound request from the agent (e.g. session/request_permission).
 fn log_agent_request(method: &str, body: &str) {
-    info!(direction = "agent_request", method, body, "[ACP] <-");
+    info!(direction = "agent_request", method, body, "[ACP] <- ${method}");
 }
 
 /// Log a JSON-RPC response from AionUi back to the agent.
 fn log_client_response(method: &str, body: &str) {
-    info!(direction = "client_response", method, body, "[ACP] ->");
+    info!(direction = "client_response", method, body, "[ACP] -> ${method}");
 }
 
 impl std::fmt::Debug for AcpProtocol {

--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -559,9 +559,9 @@ fn is_streaming_chunk(body: &str) -> bool {
 /// `session/prompt` carries large user input and stays at debug.
 fn log_client_request(method: &str, body: &str) {
     if method == "session/prompt" {
-        debug!(direction = "client_request", method, body, "[ACP]");
+        debug!(direction = "client_request", method, body, "[ACP] ->");
     } else {
-        info!(direction = "client_request", method, body, "[ACP]");
+        info!(direction = "client_request", method, body, "[ACP] ->");
     }
 }
 
@@ -569,35 +569,35 @@ fn log_client_request(method: &str, body: &str) {
 /// `session/prompt` reply is large; stays at debug.
 fn log_agent_response(method: &str, body: &str) {
     if method == "session/prompt" {
-        debug!(direction = "agent_response", method, body, "[ACP]");
+        debug!(direction = "agent_response", method, body, "[ACP] <-");
     } else {
-        info!(direction = "agent_response", method, body, "[ACP]");
+        info!(direction = "agent_response", method, body, "[ACP] <-");
     }
 }
 
 /// Log a fire-and-forget notification from AionUi to the agent.
 fn log_client_notify(method: &str, body: &str) {
-    info!(direction = "client_notify", method, body, "[ACP]");
+    info!(direction = "client_notify", method, body, "[ACP] ->");
 }
 
 /// Log an inbound notification from the agent.
 /// `session/update` requires per-kind filtering — streaming chunks stay at debug.
 fn log_agent_notify(method: &str, body: &str) {
     if method == "session/update" && is_streaming_chunk(body) {
-        debug!(direction = "agent_notify", method, body, "[ACP]");
+        debug!(direction = "agent_notify", method, body, "[ACP] <-");
     } else {
-        info!(direction = "agent_notify", method, body, "[ACP]");
+        info!(direction = "agent_notify", method, body, "[ACP] <-");
     }
 }
 
 /// Log an inbound request from the agent (e.g. session/request_permission).
 fn log_agent_request(method: &str, body: &str) {
-    info!(direction = "agent_request", method, body, "[ACP]");
+    info!(direction = "agent_request", method, body, "[ACP] <-");
 }
 
 /// Log a JSON-RPC response from AionUi back to the agent.
 fn log_client_response(method: &str, body: &str) {
-    info!(direction = "client_response", method, body, "[ACP]");
+    info!(direction = "client_response", method, body, "[ACP] ->");
 }
 
 impl std::fmt::Debug for AcpProtocol {

--- a/crates/aionui-ai-agent/src/protocol/events/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/events/mod.rs
@@ -5,6 +5,8 @@ pub mod translate;
 
 use serde::{Deserialize, Serialize};
 
+pub use aionui_api_types::AgentStreamErrorData as ErrorEventData;
+
 pub use permission::{
     AcpPermissionEventData, AcpPermissionOptionData, AcpPermissionOptionKind, AcpPermissionRequestData,
     AcpPermissionToolCall,
@@ -94,14 +96,6 @@ pub enum TipType {
 pub struct FinishEventData {
     #[serde(default)]
     pub session_id: Option<String>,
-}
-
-/// Data for the `Error` event.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ErrorEventData {
-    pub message: String,
-    #[serde(default)]
-    pub code: Option<String>,
 }
 
 #[cfg(test)]
@@ -206,10 +200,7 @@ mod tests {
 
     #[test]
     fn error_event_roundtrip() {
-        let event = AgentStreamEvent::Error(ErrorEventData {
-            message: "timeout".into(),
-            code: Some("E001".into()),
-        });
+        let event = AgentStreamEvent::Error(ErrorEventData::legacy("timeout", None));
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["type"], "error");
         assert_eq!(json["data"]["message"], "timeout");

--- a/crates/aionui-ai-agent/src/protocol/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/mod.rs
@@ -3,3 +3,4 @@ pub(crate) mod cli_detect;
 pub(crate) mod custom_agent_probe;
 pub(crate) mod error;
 pub mod events;
+pub mod send_error;

--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -32,8 +32,12 @@ impl AgentSendError {
     }
 
     pub fn from_app_error(err: AppError) -> Self {
+        Self::from_app_error_ref(&err)
+    }
+
+    pub fn from_app_error_ref(err: &AppError) -> Self {
         let detail = strip_error_prefix(&err.to_string());
-        match &err {
+        match err {
             AppError::Internal(_) => Self::new(
                 "AionUI failed while sending the message",
                 AgentErrorCode::AionuiInternalError,
@@ -219,6 +223,25 @@ fn classify_upstream_detail(detail: &str) -> AgentSendError {
     let (message, code, retryable) = if contains_any(
         &lower,
         &[
+            "signable request",
+            "canonical request",
+            "signature",
+            "credential",
+            "credentials",
+            "access key",
+            "secret key",
+            "base url",
+            "base_url",
+        ],
+    ) {
+        (
+            "The model provider configuration is invalid",
+            AgentErrorCode::UserLlmProviderConfigError,
+            false,
+        )
+    } else if contains_any(
+        &lower,
+        &[
             "401",
             "403",
             "unauthorized",
@@ -270,6 +293,7 @@ fn classify_upstream_detail(detail: &str) -> AgentSendError {
             "connection reset",
             "tls",
             "certificate",
+            "connection error",
             "connect error",
         ],
     ) {
@@ -281,6 +305,12 @@ fn classify_upstream_detail(detail: &str) -> AgentSendError {
     } else if contains_any(&lower, &["500", "502", "503", "bad gateway", "service unavailable"]) {
         (
             "The model provider returned a server error",
+            AgentErrorCode::UserLlmProviderGatewayError,
+            true,
+        )
+    } else if contains_any(&lower, &["provider error"]) {
+        (
+            "The model provider returned an error",
             AgentErrorCode::UserLlmProviderGatewayError,
             true,
         )
@@ -425,6 +455,27 @@ mod tests {
         assert_eq!(err.code(), Some(AgentErrorCode::UnknownUpstreamError));
         assert_eq!(err.ownership(), Some(AgentErrorOwnership::UnknownUpstream));
         assert_eq!(err.stream_error().feedback_recommended, Some(true));
+    }
+
+    #[test]
+    fn classifies_provider_error_without_specific_signal_as_provider_gateway() {
+        let err = AgentSendError::from_app_error(AppError::BadGateway("Provider error: upstream failed".into()));
+
+        assert_eq!(err.code(), Some(AgentErrorCode::UserLlmProviderGatewayError));
+        assert_eq!(err.ownership(), Some(AgentErrorOwnership::UserLlmProvider));
+        assert_eq!(err.stream_error().feedback_recommended, Some(false));
+    }
+
+    #[test]
+    fn classifies_provider_config_errors_as_not_retryable() {
+        let err = AgentSendError::from_app_error(AppError::BadGateway(
+            "Provider error: Connection error: Signable request error: failed to create canonical request".into(),
+        ));
+
+        assert_eq!(err.code(), Some(AgentErrorCode::UserLlmProviderConfigError));
+        assert_eq!(err.ownership(), Some(AgentErrorOwnership::UserLlmProvider));
+        assert_eq!(err.stream_error().retryable, Some(false));
+        assert_eq!(err.stream_error().feedback_recommended, Some(false));
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -135,7 +135,10 @@ impl AgentSendError {
                 Some(detail),
                 false,
                 false,
-                resolution(AgentErrorResolutionKind::Retry, None),
+                resolution(
+                    AgentErrorResolutionKind::SendFeedback,
+                    Some(AgentErrorResolutionTarget::Feedback),
+                ),
             ),
             AppError::Timeout(_) => Self::new(
                 "The model provider did not respond in time",
@@ -285,7 +288,10 @@ impl From<AcpError> for AgentSendError {
                 Some(detail),
                 false,
                 false,
-                resolution(AgentErrorResolutionKind::Retry, None),
+                resolution(
+                    AgentErrorResolutionKind::SendFeedback,
+                    Some(AgentErrorResolutionTarget::Feedback),
+                ),
             ),
             AcpError::NotConnected => Self::new(
                 "AionUI lost its Agent protocol connection",
@@ -398,14 +404,40 @@ fn classify_provider_api(lower: &str) -> Option<ClassifiedError> {
             Some(AgentErrorResolutionTarget::ProviderSettings),
         ));
     }
+    if contains_any(lower, &["403", "forbidden", "permission denied"]) {
+        return Some(provider_error(
+            "The model provider denied access to the request",
+            AgentErrorCode::UserLlmProviderPermissionDenied,
+            false,
+            AgentErrorResolutionKind::CheckProviderCredentials,
+            Some(AgentErrorResolutionTarget::ProviderSettings),
+        ));
+    }
+    if contains_any(
+        lower,
+        &[
+            "401",
+            "unauthorized",
+            "invalid api key",
+            "invalid_api_key",
+            "invalid x-api-key",
+            "invalid authentication credentials",
+        ],
+    ) {
+        return Some(provider_error(
+            "The model provider rejected the request",
+            AgentErrorCode::UserLlmProviderAuthFailed,
+            false,
+            AgentErrorResolutionKind::CheckProviderCredentials,
+            Some(AgentErrorResolutionTarget::ProviderSettings),
+        ));
+    }
     if contains_any(
         lower,
         &[
             "signable request",
             "canonical request",
             "signature",
-            "credential",
-            "credentials",
             "access key",
             "secret key",
             "base url",
@@ -417,26 +449,6 @@ fn classify_provider_api(lower: &str) -> Option<ClassifiedError> {
             AgentErrorCode::UserLlmProviderConfigError,
             false,
             AgentErrorResolutionKind::CheckProviderBaseUrl,
-            Some(AgentErrorResolutionTarget::ProviderSettings),
-        ));
-    }
-    if contains_any(
-        lower,
-        &[
-            "401",
-            "403",
-            "unauthorized",
-            "forbidden",
-            "invalid api key",
-            "invalid_api_key",
-            "invalid x-api-key",
-        ],
-    ) {
-        return Some(provider_error(
-            "The model provider rejected the request",
-            AgentErrorCode::UserLlmProviderAuthFailed,
-            false,
-            AgentErrorResolutionKind::CheckProviderCredentials,
             Some(AgentErrorResolutionTarget::ProviderSettings),
         ));
     }
@@ -491,17 +503,6 @@ fn classify_provider_api(lower: &str) -> Option<ClassifiedError> {
             None,
         ));
     }
-    if (lower.contains("404") || lower.contains("not found"))
-        && contains_any(lower, &["/chat/completions", "\"path\"", "endpoint", "base url"])
-    {
-        return Some(provider_error(
-            "The model provider endpoint was not found",
-            AgentErrorCode::UserLlmProviderEndpointNotFound,
-            false,
-            AgentErrorResolutionKind::CheckProviderBaseUrl,
-            Some(AgentErrorResolutionTarget::ProviderSettings),
-        ));
-    }
     if contains_any(
         lower,
         &[
@@ -517,6 +518,17 @@ fn classify_provider_api(lower: &str) -> Option<ClassifiedError> {
             AgentErrorCode::UserLlmProviderModelNotFound,
             false,
             AgentErrorResolutionKind::ChangeModel,
+            Some(AgentErrorResolutionTarget::ProviderSettings),
+        ));
+    }
+    if (lower.contains("404") || lower.contains("not found"))
+        && contains_any(lower, &["/chat/completions", "\"path\"", "endpoint", "base url"])
+    {
+        return Some(provider_error(
+            "The model provider endpoint was not found",
+            AgentErrorCode::UserLlmProviderEndpointNotFound,
+            false,
+            AgentErrorResolutionKind::CheckProviderBaseUrl,
             Some(AgentErrorResolutionTarget::ProviderSettings),
         ));
     }
@@ -571,6 +583,23 @@ fn classify_provider_api(lower: &str) -> Option<ClassifiedError> {
             true,
             AgentErrorResolutionKind::CheckProviderBaseUrl,
             Some(AgentErrorResolutionTarget::ProviderSettings),
+        ));
+    }
+    if contains_any(
+        lower,
+        &[
+            "invalid request",
+            "invalid assistant message",
+            "content is required",
+            "invalid input",
+        ],
+    ) {
+        return Some(provider_error(
+            "The model provider rejected the request",
+            AgentErrorCode::UserLlmProviderInvalidRequest,
+            false,
+            AgentErrorResolutionKind::SendFeedback,
+            Some(AgentErrorResolutionTarget::Feedback),
         ));
     }
     if contains_any(lower, &["500", "502", "503", "bad gateway", "service unavailable"]) {
@@ -929,6 +958,32 @@ mod tests {
     }
 
     #[test]
+    fn classifies_provider_auth_credentials_before_config() {
+        assert_classification(
+            "API error 401: Invalid authentication credentials",
+            AgentErrorCode::UserLlmProviderAuthFailed,
+            AgentErrorOwnership::UserLlmProvider,
+            AgentErrorResolutionKind::CheckProviderCredentials,
+        );
+    }
+
+    #[test]
+    fn classifies_provider_permission_denied_separately_from_auth() {
+        for detail in [
+            "API error 403: forbidden",
+            "Provider error: permission denied",
+            "API error 403: You do not have permission to access this resource",
+        ] {
+            assert_classification(
+                detail,
+                AgentErrorCode::UserLlmProviderPermissionDenied,
+                AgentErrorOwnership::UserLlmProvider,
+                AgentErrorResolutionKind::CheckProviderCredentials,
+            );
+        }
+    }
+
+    #[test]
     fn classifies_provider_request_model_and_context_errors() {
         assert_classification(
             "API error 400: Function calling is not enabled for this model",
@@ -947,6 +1002,56 @@ mod tests {
             AgentErrorCode::UserLlmProviderInvalidToolSchema,
             AgentErrorOwnership::UserLlmProvider,
             AgentErrorResolutionKind::Retry,
+        );
+    }
+
+    #[test]
+    fn classifies_model_not_found_before_endpoint_404() {
+        assert_classification(
+            "API error 404: model not found for path /v1/chat/completions",
+            AgentErrorCode::UserLlmProviderModelNotFound,
+            AgentErrorOwnership::UserLlmProvider,
+            AgentErrorResolutionKind::ChangeModel,
+        );
+    }
+
+    #[test]
+    fn classifies_generic_provider_invalid_requests() {
+        for detail in [
+            "API error 400: Invalid request: Invalid input",
+            "API error 400: Invalid assistant message: content or tool calls must be set",
+            "API error 400: content is required",
+        ] {
+            assert_classification(
+                detail,
+                AgentErrorCode::UserLlmProviderInvalidRequest,
+                AgentErrorOwnership::UserLlmProvider,
+                AgentErrorResolutionKind::SendFeedback,
+            );
+            let err = AgentSendError::from_app_error(AppError::BadGateway(detail.into()));
+            assert_eq!(err.stream_error().retryable, Some(false));
+        }
+    }
+
+    #[test]
+    fn non_retryable_agent_invalid_params_do_not_suggest_retry() {
+        let app_err =
+            AgentSendError::from_app_error(AppError::BadRequest("Invalid parameters: malformed request".into()));
+        assert_eq!(app_err.code(), Some(AgentErrorCode::UserAgentInvalidParams));
+        assert_eq!(app_err.stream_error().retryable, Some(false));
+        assert_eq!(
+            app_err.stream_error().resolution.map(|value| value.kind),
+            Some(AgentErrorResolutionKind::SendFeedback)
+        );
+
+        let acp_err = AgentSendError::from(AcpError::InvalidParams {
+            message: "malformed request".into(),
+        });
+        assert_eq!(acp_err.code(), Some(AgentErrorCode::UserAgentInvalidParams));
+        assert_eq!(acp_err.stream_error().retryable, Some(false));
+        assert_eq!(
+            acp_err.stream_error().resolution.map(|value| value.kind),
+            Some(AgentErrorResolutionKind::SendFeedback)
         );
     }
 

--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -134,7 +134,7 @@ impl AgentSendError {
                 AgentErrorOwnership::UserAgent,
                 Some(detail),
                 false,
-                false,
+                true,
                 resolution(
                     AgentErrorResolutionKind::SendFeedback,
                     Some(AgentErrorResolutionTarget::Feedback),
@@ -287,7 +287,7 @@ impl From<AcpError> for AgentSendError {
                 AgentErrorOwnership::UserAgent,
                 Some(detail),
                 false,
-                false,
+                true,
                 resolution(
                     AgentErrorResolutionKind::SendFeedback,
                     Some(AgentErrorResolutionTarget::Feedback),
@@ -589,6 +589,8 @@ fn classify_provider_api(lower: &str) -> Option<ClassifiedError> {
         lower,
         &[
             "invalid request",
+            "invalid_request",
+            "invalid_request_error",
             "invalid assistant message",
             "content is required",
             "invalid input",
@@ -1021,6 +1023,7 @@ mod tests {
             "API error 400: Invalid request: Invalid input",
             "API error 400: Invalid assistant message: content or tool calls must be set",
             "API error 400: content is required",
+            "Provider error: API error 400: {\"type\":\"invalid_request_error\",\"message\":\"bad payload\"}",
         ] {
             assert_classification(
                 detail,
@@ -1039,6 +1042,7 @@ mod tests {
             AgentSendError::from_app_error(AppError::BadRequest("Invalid parameters: malformed request".into()));
         assert_eq!(app_err.code(), Some(AgentErrorCode::UserAgentInvalidParams));
         assert_eq!(app_err.stream_error().retryable, Some(false));
+        assert_eq!(app_err.stream_error().feedback_recommended, Some(true));
         assert_eq!(
             app_err.stream_error().resolution.map(|value| value.kind),
             Some(AgentErrorResolutionKind::SendFeedback)
@@ -1049,6 +1053,7 @@ mod tests {
         });
         assert_eq!(acp_err.code(), Some(AgentErrorCode::UserAgentInvalidParams));
         assert_eq!(acp_err.stream_error().retryable, Some(false));
+        assert_eq!(acp_err.stream_error().feedback_recommended, Some(true));
         assert_eq!(
             acp_err.stream_error().resolution.map(|value| value.kind),
             Some(AgentErrorResolutionKind::SendFeedback)

--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -1,0 +1,444 @@
+use aionui_api_types::{AgentErrorCode, AgentErrorOwnership, AgentStreamErrorData};
+use aionui_common::AppError;
+
+use super::error::AcpError;
+
+const MAX_DETAIL_CHARS: usize = 1000;
+
+#[derive(Debug, Clone)]
+pub struct AgentSendError {
+    stream_error: AgentStreamErrorData,
+}
+
+impl AgentSendError {
+    pub fn new(
+        message: impl Into<String>,
+        code: AgentErrorCode,
+        ownership: AgentErrorOwnership,
+        detail: Option<String>,
+        retryable: bool,
+        feedback_recommended: bool,
+    ) -> Self {
+        Self {
+            stream_error: AgentStreamErrorData::classified(
+                message,
+                code,
+                ownership,
+                detail.map(|d| sanitize_error_detail(&d)),
+                retryable,
+                feedback_recommended,
+            ),
+        }
+    }
+
+    pub fn from_app_error(err: AppError) -> Self {
+        let detail = strip_error_prefix(&err.to_string());
+        match &err {
+            AppError::Internal(_) => Self::new(
+                "AionUI failed while sending the message",
+                AgentErrorCode::AionuiInternalError,
+                AgentErrorOwnership::Aionui,
+                Some(detail),
+                true,
+                true,
+            ),
+            AppError::Forbidden(_) => Self::new(
+                "AionUI blocked the request before it reached the Agent",
+                AgentErrorCode::AionuiPermissionError,
+                AgentErrorOwnership::Aionui,
+                Some(detail),
+                false,
+                true,
+            ),
+            AppError::Unauthorized(_) => Self::new(
+                "The selected Agent requires authentication",
+                AgentErrorCode::UserAgentAuthRequired,
+                AgentErrorOwnership::UserAgent,
+                Some(detail),
+                false,
+                false,
+            ),
+            AppError::NotFound(msg) if msg.starts_with("Session not found") => Self::new(
+                "The Agent session was not found",
+                AgentErrorCode::UserAgentSessionNotFound,
+                AgentErrorOwnership::UserAgent,
+                Some(detail),
+                true,
+                false,
+            ),
+            AppError::BadRequest(msg) if msg.contains("Method not supported") => Self::new(
+                "The selected Agent does not support this operation",
+                AgentErrorCode::UserAgentUnsupportedMethod,
+                AgentErrorOwnership::UserAgent,
+                Some(detail),
+                false,
+                false,
+            ),
+            AppError::BadRequest(msg) if msg.contains("Invalid parameters") => Self::new(
+                "The selected Agent rejected the request parameters",
+                AgentErrorCode::UserAgentInvalidParams,
+                AgentErrorOwnership::UserAgent,
+                Some(detail),
+                false,
+                false,
+            ),
+            AppError::Timeout(_) => Self::new(
+                "The model provider did not respond in time",
+                AgentErrorCode::UserLlmProviderTimeout,
+                AgentErrorOwnership::UserLlmProvider,
+                Some(detail),
+                true,
+                false,
+            ),
+            AppError::RateLimited => Self::new(
+                "The model provider rate limited the request",
+                AgentErrorCode::UserLlmProviderRateLimited,
+                AgentErrorOwnership::UserLlmProvider,
+                Some(detail),
+                true,
+                false,
+            ),
+            AppError::BadGateway(_) => classify_upstream_detail(&detail),
+            _ => Self::new(
+                "The upstream Agent failed while handling the request",
+                AgentErrorCode::UnknownUpstreamError,
+                AgentErrorOwnership::UnknownUpstream,
+                Some(detail),
+                true,
+                true,
+            ),
+        }
+    }
+
+    pub fn stream_error(&self) -> &AgentStreamErrorData {
+        &self.stream_error
+    }
+
+    pub fn into_stream_error(self) -> AgentStreamErrorData {
+        self.stream_error
+    }
+
+    pub fn code(&self) -> Option<AgentErrorCode> {
+        self.stream_error.code
+    }
+
+    pub fn ownership(&self) -> Option<AgentErrorOwnership> {
+        self.stream_error.ownership
+    }
+}
+
+impl std::fmt::Display for AgentSendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.stream_error.message)
+    }
+}
+
+impl std::error::Error for AgentSendError {}
+
+impl From<AppError> for AgentSendError {
+    fn from(err: AppError) -> Self {
+        Self::from_app_error(err)
+    }
+}
+
+impl From<AcpError> for AgentSendError {
+    fn from(err: AcpError) -> Self {
+        let detail = err.to_string();
+        match &err {
+            AcpError::SpawnFailed { .. } => Self::new(
+                "The selected Agent executable could not be started",
+                AgentErrorCode::UserAgentNotInstalled,
+                AgentErrorOwnership::UserAgent,
+                Some(detail),
+                false,
+                false,
+            ),
+            AcpError::StartupCrash { .. } | AcpError::InitTimeout { .. } => Self::new(
+                "The selected Agent failed to start",
+                AgentErrorCode::UserAgentStartupFailed,
+                AgentErrorOwnership::UserAgent,
+                Some(detail),
+                true,
+                false,
+            ),
+            AcpError::Disconnected { .. } => Self::new(
+                "The selected Agent disconnected",
+                AgentErrorCode::UserAgentDisconnected,
+                AgentErrorOwnership::UserAgent,
+                Some(detail),
+                true,
+                false,
+            ),
+            AcpError::AuthRequired => Self::new(
+                "The selected Agent requires authentication",
+                AgentErrorCode::UserAgentAuthRequired,
+                AgentErrorOwnership::UserAgent,
+                Some(detail),
+                false,
+                false,
+            ),
+            AcpError::SessionNotFound { .. } => Self::new(
+                "The Agent session was not found",
+                AgentErrorCode::UserAgentSessionNotFound,
+                AgentErrorOwnership::UserAgent,
+                Some(detail),
+                true,
+                false,
+            ),
+            AcpError::MethodNotFound { .. } => Self::new(
+                "The selected Agent does not support this operation",
+                AgentErrorCode::UserAgentUnsupportedMethod,
+                AgentErrorOwnership::UserAgent,
+                Some(detail),
+                false,
+                false,
+            ),
+            AcpError::InvalidParams { .. } => Self::new(
+                "The selected Agent rejected the request parameters",
+                AgentErrorCode::UserAgentInvalidParams,
+                AgentErrorOwnership::UserAgent,
+                Some(detail),
+                false,
+                false,
+            ),
+            AcpError::NotConnected => Self::new(
+                "AionUI lost its Agent protocol connection",
+                AgentErrorCode::AionuiInternalError,
+                AgentErrorOwnership::Aionui,
+                Some(detail),
+                true,
+                true,
+            ),
+            AcpError::AgentInternal { .. } => classify_upstream_detail(&detail),
+        }
+    }
+}
+
+fn classify_upstream_detail(detail: &str) -> AgentSendError {
+    let lower = detail.to_ascii_lowercase();
+    let (message, code, retryable) = if contains_any(
+        &lower,
+        &[
+            "401",
+            "403",
+            "unauthorized",
+            "forbidden",
+            "invalid api key",
+            "invalid_api_key",
+        ],
+    ) {
+        (
+            "The model provider rejected the request",
+            AgentErrorCode::UserLlmProviderAuthFailed,
+            false,
+        )
+    } else if contains_any(
+        &lower,
+        &[
+            "model not found",
+            "model does not exist",
+            "unknown model",
+            "invalid model",
+            "model_not_found",
+        ],
+    ) {
+        (
+            "The configured model was not found by the provider",
+            AgentErrorCode::UserLlmProviderModelNotFound,
+            false,
+        )
+    } else if contains_any(
+        &lower,
+        &["429", "rate limit", "rate_limit", "quota", "insufficient balance"],
+    ) {
+        (
+            "The model provider rate limited the request",
+            AgentErrorCode::UserLlmProviderRateLimited,
+            true,
+        )
+    } else if contains_any(&lower, &["504", "timeout", "deadline exceeded", "gateway timeout"]) {
+        (
+            "The model provider did not respond in time",
+            AgentErrorCode::UserLlmProviderTimeout,
+            true,
+        )
+    } else if contains_any(
+        &lower,
+        &[
+            "dns",
+            "connection refused",
+            "connection reset",
+            "tls",
+            "certificate",
+            "connect error",
+        ],
+    ) {
+        (
+            "The model provider could not be reached",
+            AgentErrorCode::UserLlmProviderNetworkError,
+            true,
+        )
+    } else if contains_any(&lower, &["500", "502", "503", "bad gateway", "service unavailable"]) {
+        (
+            "The model provider returned a server error",
+            AgentErrorCode::UserLlmProviderGatewayError,
+            true,
+        )
+    } else {
+        (
+            "The upstream Agent failed while handling the request",
+            AgentErrorCode::UnknownUpstreamError,
+            true,
+        )
+    };
+
+    let ownership = if code == AgentErrorCode::UnknownUpstreamError {
+        AgentErrorOwnership::UnknownUpstream
+    } else {
+        AgentErrorOwnership::UserLlmProvider
+    };
+    let feedback_recommended = ownership != AgentErrorOwnership::UserLlmProvider;
+
+    AgentSendError::new(
+        message,
+        code,
+        ownership,
+        Some(detail.to_owned()),
+        retryable,
+        feedback_recommended,
+    )
+}
+
+fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| haystack.contains(needle))
+}
+
+fn strip_error_prefix(message: &str) -> String {
+    message
+        .split_once(": ")
+        .map(|(_, rest)| rest)
+        .unwrap_or(message)
+        .to_owned()
+}
+
+pub(crate) fn sanitize_error_detail(input: &str) -> String {
+    let without_query = redact_url_queries(input);
+    let mut out = String::new();
+    for line in without_query.lines() {
+        if is_sensitive_header_line(line) {
+            push_bounded_line(&mut out, "<redacted header>");
+        } else {
+            push_bounded_line(&mut out, &redact_secret_words(line));
+        }
+        if out.chars().count() >= MAX_DETAIL_CHARS {
+            break;
+        }
+    }
+    truncate_chars(out.trim(), MAX_DETAIL_CHARS)
+}
+
+fn push_bounded_line(out: &mut String, line: &str) {
+    if !out.is_empty() {
+        out.push('\n');
+    }
+    out.push_str(line);
+}
+
+fn is_sensitive_header_line(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    lower.contains("authorization:")
+        || lower.contains("x-api-key:")
+        || lower.contains("api-key:")
+        || lower.contains("api_key:")
+}
+
+fn redact_secret_words(line: &str) -> String {
+    line.split_whitespace()
+        .map(|word| {
+            let lower = word.to_ascii_lowercase();
+            if lower.starts_with("bearer ")
+                || lower.starts_with("sk-")
+                || lower.contains("api_key=")
+                || lower.contains("apikey=")
+                || lower.contains("access_token=")
+                || lower.contains("token=")
+            {
+                "<redacted>"
+            } else {
+                word
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn redact_url_queries(input: &str) -> String {
+    input
+        .split_whitespace()
+        .map(|word| {
+            if (word.starts_with("http://") || word.starts_with("https://")) && word.contains('?') {
+                let end_punct = word
+                    .chars()
+                    .last()
+                    .filter(|c| matches!(c, '.' | ',' | ';' | ')' | ']'))
+                    .map(|c| c.to_string())
+                    .unwrap_or_default();
+                let trimmed = word.trim_end_matches(['.', ',', ';', ')', ']']);
+                let base = trimmed.split_once('?').map(|(base, _)| base).unwrap_or(trimmed);
+                format!("{base}?<redacted>{end_punct}")
+            } else {
+                word.to_owned()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn truncate_chars(value: &str, max: usize) -> String {
+    let mut out = String::new();
+    for ch in value.chars().take(max) {
+        out.push(ch);
+    }
+    if value.chars().count() > max {
+        out.push_str("...");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_provider_auth_failure() {
+        let err = AgentSendError::from_app_error(AppError::BadGateway("provider returned 401 invalid api key".into()));
+
+        assert_eq!(err.code(), Some(AgentErrorCode::UserLlmProviderAuthFailed));
+        assert_eq!(err.ownership(), Some(AgentErrorOwnership::UserLlmProvider));
+        assert_eq!(err.stream_error().feedback_recommended, Some(false));
+    }
+
+    #[test]
+    fn classifies_unknown_upstream_when_heuristics_do_not_match() {
+        let err = AgentSendError::from_app_error(AppError::BadGateway("agent exploded".into()));
+
+        assert_eq!(err.code(), Some(AgentErrorCode::UnknownUpstreamError));
+        assert_eq!(err.ownership(), Some(AgentErrorOwnership::UnknownUpstream));
+        assert_eq!(err.stream_error().feedback_recommended, Some(true));
+    }
+
+    #[test]
+    fn sanitizes_secrets_and_query_strings() {
+        let detail = sanitize_error_detail(
+            "Authorization: Bearer sk-secret\nGET https://example.com/v1?api_key=sk-secret\ninvalid_api_key sk-secret",
+        );
+
+        assert!(!detail.contains("sk-secret"));
+        assert!(!detail.contains("api_key=sk"));
+        assert!(detail.contains("<redacted header>"));
+        assert_eq!(
+            redact_url_queries("GET https://example.com/v1?api_key=sk-secret"),
+            "GET https://example.com/v1?<redacted>"
+        );
+    }
+}

--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -27,6 +27,7 @@ impl AgentSendError {
                 detail.map(|d| sanitize_error_detail(&d)),
                 retryable,
                 feedback_recommended,
+                None,
             ),
         }
     }

--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -1,4 +1,7 @@
-use aionui_api_types::{AgentErrorCode, AgentErrorOwnership, AgentStreamErrorData};
+use aionui_api_types::{
+    AgentErrorCode, AgentErrorOwnership, AgentErrorResolution, AgentErrorResolutionKind, AgentErrorResolutionTarget,
+    AgentStreamErrorData,
+};
 use aionui_common::AppError;
 
 use super::error::AcpError;
@@ -10,6 +13,31 @@ pub struct AgentSendError {
     stream_error: AgentStreamErrorData,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct ClassifiedError {
+    message: &'static str,
+    code: AgentErrorCode,
+    ownership: AgentErrorOwnership,
+    retryable: bool,
+    feedback_recommended: bool,
+    resolution_kind: AgentErrorResolutionKind,
+    resolution_target: Option<AgentErrorResolutionTarget>,
+}
+
+impl ClassifiedError {
+    fn into_send_error(self, detail: String) -> AgentSendError {
+        AgentSendError::new(
+            self.message,
+            self.code,
+            self.ownership,
+            Some(detail),
+            self.retryable,
+            self.feedback_recommended,
+            resolution(self.resolution_kind, self.resolution_target),
+        )
+    }
+}
+
 impl AgentSendError {
     pub fn new(
         message: impl Into<String>,
@@ -18,6 +46,7 @@ impl AgentSendError {
         detail: Option<String>,
         retryable: bool,
         feedback_recommended: bool,
+        resolution: Option<AgentErrorResolution>,
     ) -> Self {
         Self {
             stream_error: AgentStreamErrorData::classified(
@@ -27,7 +56,7 @@ impl AgentSendError {
                 detail.map(|d| sanitize_error_detail(&d)),
                 retryable,
                 feedback_recommended,
-                None,
+                resolution,
             ),
         }
     }
@@ -46,6 +75,10 @@ impl AgentSendError {
                 Some(detail),
                 true,
                 true,
+                resolution(
+                    AgentErrorResolutionKind::SendFeedback,
+                    Some(AgentErrorResolutionTarget::Feedback),
+                ),
             ),
             AppError::Forbidden(_) => Self::new(
                 "AionUI blocked the request before it reached the Agent",
@@ -54,6 +87,10 @@ impl AgentSendError {
                 Some(detail),
                 false,
                 true,
+                resolution(
+                    AgentErrorResolutionKind::SendFeedback,
+                    Some(AgentErrorResolutionTarget::Feedback),
+                ),
             ),
             AppError::Unauthorized(_) => Self::new(
                 "The selected Agent requires authentication",
@@ -62,6 +99,10 @@ impl AgentSendError {
                 Some(detail),
                 false,
                 false,
+                resolution(
+                    AgentErrorResolutionKind::CheckAgentLogin,
+                    Some(AgentErrorResolutionTarget::AgentSettings),
+                ),
             ),
             AppError::NotFound(msg) if msg.starts_with("Session not found") => Self::new(
                 "The Agent session was not found",
@@ -70,6 +111,10 @@ impl AgentSendError {
                 Some(detail),
                 true,
                 false,
+                resolution(
+                    AgentErrorResolutionKind::StartNewSession,
+                    Some(AgentErrorResolutionTarget::NewConversation),
+                ),
             ),
             AppError::BadRequest(msg) if msg.contains("Method not supported") => Self::new(
                 "The selected Agent does not support this operation",
@@ -78,6 +123,10 @@ impl AgentSendError {
                 Some(detail),
                 false,
                 false,
+                resolution(
+                    AgentErrorResolutionKind::CheckAgentVersion,
+                    Some(AgentErrorResolutionTarget::AgentSettings),
+                ),
             ),
             AppError::BadRequest(msg) if msg.contains("Invalid parameters") => Self::new(
                 "The selected Agent rejected the request parameters",
@@ -86,6 +135,7 @@ impl AgentSendError {
                 Some(detail),
                 false,
                 false,
+                resolution(AgentErrorResolutionKind::Retry, None),
             ),
             AppError::Timeout(_) => Self::new(
                 "The model provider did not respond in time",
@@ -94,6 +144,7 @@ impl AgentSendError {
                 Some(detail),
                 true,
                 false,
+                resolution(AgentErrorResolutionKind::Retry, None),
             ),
             AppError::RateLimited => Self::new(
                 "The model provider rate limited the request",
@@ -102,6 +153,7 @@ impl AgentSendError {
                 Some(detail),
                 true,
                 false,
+                resolution(AgentErrorResolutionKind::Retry, None),
             ),
             AppError::BadGateway(_) => classify_upstream_detail(&detail),
             _ => Self::new(
@@ -111,6 +163,10 @@ impl AgentSendError {
                 Some(detail),
                 true,
                 true,
+                resolution(
+                    AgentErrorResolutionKind::SendFeedback,
+                    Some(AgentErrorResolutionTarget::Feedback),
+                ),
             ),
         }
     }
@@ -157,6 +213,10 @@ impl From<AcpError> for AgentSendError {
                 Some(detail),
                 false,
                 false,
+                resolution(
+                    AgentErrorResolutionKind::CheckAgentInstallation,
+                    Some(AgentErrorResolutionTarget::AgentSettings),
+                ),
             ),
             AcpError::StartupCrash { .. } | AcpError::InitTimeout { .. } => Self::new(
                 "The selected Agent failed to start",
@@ -165,6 +225,10 @@ impl From<AcpError> for AgentSendError {
                 Some(detail),
                 true,
                 false,
+                resolution(
+                    AgentErrorResolutionKind::CheckAgentInstallation,
+                    Some(AgentErrorResolutionTarget::AgentSettings),
+                ),
             ),
             AcpError::Disconnected { .. } => Self::new(
                 "The selected Agent disconnected",
@@ -173,6 +237,10 @@ impl From<AcpError> for AgentSendError {
                 Some(detail),
                 true,
                 false,
+                resolution(
+                    AgentErrorResolutionKind::ReconnectAgent,
+                    Some(AgentErrorResolutionTarget::AgentSettings),
+                ),
             ),
             AcpError::AuthRequired => Self::new(
                 "The selected Agent requires authentication",
@@ -181,6 +249,10 @@ impl From<AcpError> for AgentSendError {
                 Some(detail),
                 false,
                 false,
+                resolution(
+                    AgentErrorResolutionKind::CheckAgentLogin,
+                    Some(AgentErrorResolutionTarget::AgentSettings),
+                ),
             ),
             AcpError::SessionNotFound { .. } => Self::new(
                 "The Agent session was not found",
@@ -189,6 +261,10 @@ impl From<AcpError> for AgentSendError {
                 Some(detail),
                 true,
                 false,
+                resolution(
+                    AgentErrorResolutionKind::StartNewSession,
+                    Some(AgentErrorResolutionTarget::NewConversation),
+                ),
             ),
             AcpError::MethodNotFound { .. } => Self::new(
                 "The selected Agent does not support this operation",
@@ -197,6 +273,10 @@ impl From<AcpError> for AgentSendError {
                 Some(detail),
                 false,
                 false,
+                resolution(
+                    AgentErrorResolutionKind::CheckAgentVersion,
+                    Some(AgentErrorResolutionTarget::AgentSettings),
+                ),
             ),
             AcpError::InvalidParams { .. } => Self::new(
                 "The selected Agent rejected the request parameters",
@@ -205,6 +285,7 @@ impl From<AcpError> for AgentSendError {
                 Some(detail),
                 false,
                 false,
+                resolution(AgentErrorResolutionKind::Retry, None),
             ),
             AcpError::NotConnected => Self::new(
                 "AionUI lost its Agent protocol connection",
@@ -213,6 +294,10 @@ impl From<AcpError> for AgentSendError {
                 Some(detail),
                 true,
                 true,
+                resolution(
+                    AgentErrorResolutionKind::SendFeedback,
+                    Some(AgentErrorResolutionTarget::Feedback),
+                ),
             ),
             AcpError::AgentInternal { .. } => classify_upstream_detail(&detail),
         }
@@ -221,8 +306,100 @@ impl From<AcpError> for AgentSendError {
 
 fn classify_upstream_detail(detail: &str) -> AgentSendError {
     let lower = detail.to_ascii_lowercase();
-    let (message, code, retryable) = if contains_any(
-        &lower,
+    let classified = classify_agent_lifecycle(&lower)
+        .or_else(|| classify_provider_api(&lower))
+        .or_else(|| classify_aionui_state(&lower))
+        .unwrap_or(ClassifiedError {
+            message: "The upstream Agent failed while handling the request",
+            code: AgentErrorCode::UnknownUpstreamError,
+            ownership: AgentErrorOwnership::UnknownUpstream,
+            retryable: true,
+            feedback_recommended: true,
+            resolution_kind: AgentErrorResolutionKind::SendFeedback,
+            resolution_target: Some(AgentErrorResolutionTarget::Feedback),
+        });
+
+    classified.into_send_error(detail.to_owned())
+}
+
+fn classify_agent_lifecycle(lower: &str) -> Option<ClassifiedError> {
+    if lower.contains("agent process exited before initialize handshake completed") {
+        return Some(agent_error(
+            "The selected Agent exited before it finished starting",
+            AgentErrorCode::UserAgentHandshakeFailed,
+            true,
+            AgentErrorResolutionKind::CheckAgentInstallation,
+        ));
+    }
+    if lower.contains("initialize handshake timed out") {
+        return Some(agent_error(
+            "The selected Agent did not finish starting in time",
+            AgentErrorCode::UserAgentHandshakeTimeout,
+            true,
+            AgentErrorResolutionKind::ReconnectAgent,
+        ));
+    }
+    if lower.contains("cli found but acp initialization failed") || lower.contains("找到 cli 但 acp 初始化失败")
+    {
+        return Some(agent_error(
+            "The selected Agent CLI was found but could not initialize ACP",
+            AgentErrorCode::UserAgentAcpInitFailed,
+            false,
+            AgentErrorResolutionKind::CheckAgentInstallation,
+        ));
+    }
+    if lower.contains("protocol mismatch") || lower.contains("max reconnect attempts") {
+        return Some(agent_error(
+            "The selected Agent protocol is incompatible",
+            AgentErrorCode::UserAgentProtocolMismatch,
+            false,
+            AgentErrorResolutionKind::CheckAgentVersion,
+        ));
+    }
+    if lower.contains("no previous sessions found") {
+        return Some(agent_session_error(
+            "No previous Agent session was found for this project",
+            AgentErrorCode::UserAgentNoPreviousSession,
+        ));
+    }
+    if lower.contains("session not found") {
+        return Some(agent_session_error(
+            "The Agent session was not found",
+            AgentErrorCode::UserAgentSessionNotFound,
+        ));
+    }
+    if lower.contains("command not found") {
+        return Some(agent_error(
+            "The selected Agent command was not found",
+            AgentErrorCode::UserAgentCommandNotFound,
+            false,
+            AgentErrorResolutionKind::CheckLocalCommand,
+        ));
+    }
+    if lower.contains("missing environment variable") {
+        return Some(agent_error(
+            "The selected Agent is missing a required environment variable",
+            AgentErrorCode::UserAgentMissingEnv,
+            false,
+            AgentErrorResolutionKind::CheckAgentInstallation,
+        ));
+    }
+
+    None
+}
+
+fn classify_provider_api(lower: &str) -> Option<ClassifiedError> {
+    if contains_any(lower, &["402", "insufficient balance"]) {
+        return Some(provider_error(
+            "The model provider account requires billing attention",
+            AgentErrorCode::UserLlmProviderBillingRequired,
+            false,
+            AgentErrorResolutionKind::CheckProviderBilling,
+            Some(AgentErrorResolutionTarget::ProviderSettings),
+        ));
+    }
+    if contains_any(
+        lower,
         &[
             "signable request",
             "canonical request",
@@ -235,13 +412,16 @@ fn classify_upstream_detail(detail: &str) -> AgentSendError {
             "base_url",
         ],
     ) {
-        (
+        return Some(provider_error(
             "The model provider configuration is invalid",
             AgentErrorCode::UserLlmProviderConfigError,
             false,
-        )
-    } else if contains_any(
-        &lower,
+            AgentErrorResolutionKind::CheckProviderBaseUrl,
+            Some(AgentErrorResolutionTarget::ProviderSettings),
+        ));
+    }
+    if contains_any(
+        lower,
         &[
             "401",
             "403",
@@ -249,15 +429,81 @@ fn classify_upstream_detail(detail: &str) -> AgentSendError {
             "forbidden",
             "invalid api key",
             "invalid_api_key",
+            "invalid x-api-key",
         ],
     ) {
-        (
+        return Some(provider_error(
             "The model provider rejected the request",
             AgentErrorCode::UserLlmProviderAuthFailed,
             false,
-        )
-    } else if contains_any(
-        &lower,
+            AgentErrorResolutionKind::CheckProviderCredentials,
+            Some(AgentErrorResolutionTarget::ProviderSettings),
+        ));
+    }
+    if contains_any(
+        lower,
+        &[
+            "function calling is not enabled",
+            "function calling disabled",
+            "unsupported model",
+        ],
+    ) {
+        return Some(provider_error(
+            "The configured model does not support this request",
+            AgentErrorCode::UserLlmProviderUnsupportedModel,
+            false,
+            AgentErrorResolutionKind::ChangeModel,
+            Some(AgentErrorResolutionTarget::ProviderSettings),
+        ));
+    }
+    if contains_any(
+        lower,
+        &[
+            "context window exceeds",
+            "context length",
+            "context too large",
+            "maximum context",
+            "prompt is too long",
+        ],
+    ) {
+        return Some(provider_error(
+            "The request is too large for the configured model context window",
+            AgentErrorCode::UserLlmProviderContextTooLarge,
+            false,
+            AgentErrorResolutionKind::ReduceContext,
+            None,
+        ));
+    }
+    if contains_any(
+        lower,
+        &[
+            "invalid schema",
+            "schema for function",
+            "tool schema",
+            "function schema",
+        ],
+    ) {
+        return Some(provider_error(
+            "The model provider rejected an internal tool schema",
+            AgentErrorCode::UserLlmProviderInvalidToolSchema,
+            true,
+            AgentErrorResolutionKind::Retry,
+            None,
+        ));
+    }
+    if (lower.contains("404") || lower.contains("not found"))
+        && contains_any(lower, &["/chat/completions", "\"path\"", "endpoint", "base url"])
+    {
+        return Some(provider_error(
+            "The model provider endpoint was not found",
+            AgentErrorCode::UserLlmProviderEndpointNotFound,
+            false,
+            AgentErrorResolutionKind::CheckProviderBaseUrl,
+            Some(AgentErrorResolutionTarget::ProviderSettings),
+        ));
+    }
+    if contains_any(
+        lower,
         &[
             "model not found",
             "model does not exist",
@@ -266,28 +512,46 @@ fn classify_upstream_detail(detail: &str) -> AgentSendError {
             "model_not_found",
         ],
     ) {
-        (
+        return Some(provider_error(
             "The configured model was not found by the provider",
             AgentErrorCode::UserLlmProviderModelNotFound,
             false,
-        )
-    } else if contains_any(
-        &lower,
-        &["429", "rate limit", "rate_limit", "quota", "insufficient balance"],
-    ) {
-        (
+            AgentErrorResolutionKind::ChangeModel,
+            Some(AgentErrorResolutionTarget::ProviderSettings),
+        ));
+    }
+    if contains_any(lower, &["429", "rate limit", "rate_limit", "quota"]) {
+        return Some(provider_error(
             "The model provider rate limited the request",
             AgentErrorCode::UserLlmProviderRateLimited,
             true,
-        )
-    } else if contains_any(&lower, &["504", "timeout", "deadline exceeded", "gateway timeout"]) {
-        (
+            AgentErrorResolutionKind::Retry,
+            None,
+        ));
+    }
+    if contains_any(
+        lower,
+        &["empty response from llm", "empty response", "response body was empty"],
+    ) {
+        return Some(provider_error(
+            "The model provider returned an empty response",
+            AgentErrorCode::UserLlmProviderEmptyResponse,
+            true,
+            AgentErrorResolutionKind::Retry,
+            None,
+        ));
+    }
+    if contains_any(lower, &["504", "timeout", "deadline exceeded", "gateway timeout"]) {
+        return Some(provider_error(
             "The model provider did not respond in time",
             AgentErrorCode::UserLlmProviderTimeout,
             true,
-        )
-    } else if contains_any(
-        &lower,
+            AgentErrorResolutionKind::Retry,
+            None,
+        ));
+    }
+    if contains_any(
+        lower,
         &[
             "dns",
             "connection refused",
@@ -296,48 +560,109 @@ fn classify_upstream_detail(detail: &str) -> AgentSendError {
             "certificate",
             "connection error",
             "connect error",
+            "error decoding response body",
+            "decoding response body",
+            "error sending request",
         ],
     ) {
-        (
+        return Some(provider_error(
             "The model provider could not be reached",
             AgentErrorCode::UserLlmProviderNetworkError,
             true,
-        )
-    } else if contains_any(&lower, &["500", "502", "503", "bad gateway", "service unavailable"]) {
-        (
+            AgentErrorResolutionKind::CheckProviderBaseUrl,
+            Some(AgentErrorResolutionTarget::ProviderSettings),
+        ));
+    }
+    if contains_any(lower, &["500", "502", "503", "bad gateway", "service unavailable"]) {
+        return Some(provider_error(
             "The model provider returned a server error",
             AgentErrorCode::UserLlmProviderGatewayError,
             true,
-        )
-    } else if contains_any(&lower, &["provider error"]) {
-        (
+            AgentErrorResolutionKind::Retry,
+            None,
+        ));
+    }
+    if lower.contains("provider error") {
+        return Some(provider_error(
             "The model provider returned an error",
             AgentErrorCode::UserLlmProviderGatewayError,
             true,
-        )
-    } else {
-        (
-            "The upstream Agent failed while handling the request",
-            AgentErrorCode::UnknownUpstreamError,
-            true,
-        )
-    };
+            AgentErrorResolutionKind::Retry,
+            None,
+        ));
+    }
 
-    let ownership = if code == AgentErrorCode::UnknownUpstreamError {
-        AgentErrorOwnership::UnknownUpstream
-    } else {
-        AgentErrorOwnership::UserLlmProvider
-    };
-    let feedback_recommended = ownership != AgentErrorOwnership::UserLlmProvider;
+    None
+}
 
-    AgentSendError::new(
+fn classify_aionui_state(lower: &str) -> Option<ClassifiedError> {
+    if lower.contains("conversation is already processing") {
+        return Some(ClassifiedError {
+            message: "The current response is still running",
+            code: AgentErrorCode::AionuiConversationBusy,
+            ownership: AgentErrorOwnership::Aionui,
+            retryable: true,
+            feedback_recommended: false,
+            resolution_kind: AgentErrorResolutionKind::WaitForCurrentResponse,
+            resolution_target: Some(AgentErrorResolutionTarget::NewConversation),
+        });
+    }
+
+    None
+}
+
+fn agent_error(
+    message: &'static str,
+    code: AgentErrorCode,
+    retryable: bool,
+    resolution_kind: AgentErrorResolutionKind,
+) -> ClassifiedError {
+    ClassifiedError {
         message,
         code,
-        ownership,
-        Some(detail.to_owned()),
+        ownership: AgentErrorOwnership::UserAgent,
         retryable,
-        feedback_recommended,
-    )
+        feedback_recommended: false,
+        resolution_kind,
+        resolution_target: Some(AgentErrorResolutionTarget::AgentSettings),
+    }
+}
+
+fn agent_session_error(message: &'static str, code: AgentErrorCode) -> ClassifiedError {
+    ClassifiedError {
+        message,
+        code,
+        ownership: AgentErrorOwnership::UserAgent,
+        retryable: true,
+        feedback_recommended: false,
+        resolution_kind: AgentErrorResolutionKind::StartNewSession,
+        resolution_target: Some(AgentErrorResolutionTarget::NewConversation),
+    }
+}
+
+fn provider_error(
+    message: &'static str,
+    code: AgentErrorCode,
+    retryable: bool,
+    resolution_kind: AgentErrorResolutionKind,
+    resolution_target: Option<AgentErrorResolutionTarget>,
+) -> ClassifiedError {
+    ClassifiedError {
+        message,
+        code,
+        ownership: AgentErrorOwnership::UserLlmProvider,
+        retryable,
+        feedback_recommended: false,
+        resolution_kind,
+        resolution_target,
+    }
+}
+
+fn resolution(
+    kind: AgentErrorResolutionKind,
+    target: Option<AgentErrorResolutionTarget>,
+) -> Option<AgentErrorResolution> {
+    Some(AgentErrorResolution::new(kind, target))
 }
 
 fn contains_any(haystack: &str, needles: &[&str]) -> bool {
@@ -439,6 +764,27 @@ fn truncate_chars(value: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aionui_api_types::{AgentErrorResolutionKind, AgentErrorResolutionTarget};
+
+    fn assert_classification(
+        detail: &str,
+        code: AgentErrorCode,
+        ownership: AgentErrorOwnership,
+        resolution: AgentErrorResolutionKind,
+    ) {
+        let err = AgentSendError::from_app_error(AppError::BadGateway(detail.into()));
+        assert_eq!(err.code(), Some(code));
+        assert_eq!(err.ownership(), Some(ownership));
+        assert_eq!(err.stream_error().resolution.map(|value| value.kind), Some(resolution));
+    }
+
+    fn assert_resolution_target(detail: &str, target: AgentErrorResolutionTarget) {
+        let err = AgentSendError::from_app_error(AppError::BadGateway(detail.into()));
+        assert_eq!(
+            err.stream_error().resolution.and_then(|value| value.target),
+            Some(target)
+        );
+    }
 
     #[test]
     fn classifies_provider_auth_failure() {
@@ -491,6 +837,158 @@ mod tests {
         assert_eq!(
             redact_url_queries("GET https://example.com/v1?api_key=sk-secret"),
             "GET https://example.com/v1?<redacted>"
+        );
+    }
+
+    #[test]
+    fn classifies_agent_lifecycle_before_bad_gateway_wrapper() {
+        assert_classification(
+            "Bad gateway: Agent process exited before initialize handshake completed (exit code 1)",
+            AgentErrorCode::UserAgentHandshakeFailed,
+            AgentErrorOwnership::UserAgent,
+            AgentErrorResolutionKind::CheckAgentInstallation,
+        );
+        assert_classification(
+            "Bad gateway: Initialize handshake timed out after 30s",
+            AgentErrorCode::UserAgentHandshakeTimeout,
+            AgentErrorOwnership::UserAgent,
+            AgentErrorResolutionKind::ReconnectAgent,
+        );
+    }
+
+    #[test]
+    fn classifies_agent_protocol_and_session_failures() {
+        assert_classification(
+            "Connection error: protocol mismatch Connection error: Max reconnect attempts (10) reached",
+            AgentErrorCode::UserAgentProtocolMismatch,
+            AgentErrorOwnership::UserAgent,
+            AgentErrorResolutionKind::CheckAgentVersion,
+        );
+        assert_classification(
+            "Agent internal error (code -32603) {\"details\":\"Session not found\"}",
+            AgentErrorCode::UserAgentSessionNotFound,
+            AgentErrorOwnership::UserAgent,
+            AgentErrorResolutionKind::StartNewSession,
+        );
+        assert_classification(
+            "Bad gateway: Agent internal error (code -32603) {\"details\":\"No previous sessions found for this project\"}",
+            AgentErrorCode::UserAgentNoPreviousSession,
+            AgentErrorOwnership::UserAgent,
+            AgentErrorResolutionKind::StartNewSession,
+        );
+    }
+
+    #[test]
+    fn classifies_agent_setup_failures() {
+        assert_classification(
+            "CLI found but ACP initialization failed.",
+            AgentErrorCode::UserAgentAcpInitFailed,
+            AgentErrorOwnership::UserAgent,
+            AgentErrorResolutionKind::CheckAgentInstallation,
+        );
+        assert_classification(
+            "找到 CLI 但 ACP 初始化失败",
+            AgentErrorCode::UserAgentAcpInitFailed,
+            AgentErrorOwnership::UserAgent,
+            AgentErrorResolutionKind::CheckAgentInstallation,
+        );
+        assert_classification(
+            "filesystem: Command not found: npx",
+            AgentErrorCode::UserAgentCommandNotFound,
+            AgentErrorOwnership::UserAgent,
+            AgentErrorResolutionKind::CheckLocalCommand,
+        );
+        assert_classification(
+            "Agent internal error (code -32603) {\"message\":\"Missing environment variable: 'OMLX API KEY'\"}",
+            AgentErrorCode::UserAgentMissingEnv,
+            AgentErrorOwnership::UserAgent,
+            AgentErrorResolutionKind::CheckAgentInstallation,
+        );
+    }
+
+    #[test]
+    fn classifies_provider_billing_auth_and_rate_limit() {
+        assert_classification(
+            "Aionrs agent error: Provider error: API error 402: {\"error\":{\"message\":\"Insufficient Balance\"}}",
+            AgentErrorCode::UserLlmProviderBillingRequired,
+            AgentErrorOwnership::UserLlmProvider,
+            AgentErrorResolutionKind::CheckProviderBilling,
+        );
+        assert_classification(
+            "Aionrs agent error: Provider error: API error 401: invalid x-api-key",
+            AgentErrorCode::UserLlmProviderAuthFailed,
+            AgentErrorOwnership::UserLlmProvider,
+            AgentErrorResolutionKind::CheckProviderCredentials,
+        );
+        assert_classification(
+            "Aionrs agent error: Provider error: Rate limited, retry after 5000ms",
+            AgentErrorCode::UserLlmProviderRateLimited,
+            AgentErrorOwnership::UserLlmProvider,
+            AgentErrorResolutionKind::Retry,
+        );
+    }
+
+    #[test]
+    fn classifies_provider_request_model_and_context_errors() {
+        assert_classification(
+            "API error 400: Function calling is not enabled for this model",
+            AgentErrorCode::UserLlmProviderUnsupportedModel,
+            AgentErrorOwnership::UserLlmProvider,
+            AgentErrorResolutionKind::ChangeModel,
+        );
+        assert_classification(
+            "API error 400: invalid params, context window exceeds limit",
+            AgentErrorCode::UserLlmProviderContextTooLarge,
+            AgentErrorOwnership::UserLlmProvider,
+            AgentErrorResolutionKind::ReduceContext,
+        );
+        assert_classification(
+            "API error 400: Invalid schema for function 'aion_list_models': None is not of type 'array'",
+            AgentErrorCode::UserLlmProviderInvalidToolSchema,
+            AgentErrorOwnership::UserLlmProvider,
+            AgentErrorResolutionKind::Retry,
+        );
+    }
+
+    #[test]
+    fn classifies_provider_endpoint_network_timeout_and_empty_response() {
+        assert_classification(
+            "API error 404: {\"status\":404,\"error\":\"Not Found\",\"path\":\"/v4/v1/chat/completions\"}",
+            AgentErrorCode::UserLlmProviderEndpointNotFound,
+            AgentErrorOwnership::UserLlmProvider,
+            AgentErrorResolutionKind::CheckProviderBaseUrl,
+        );
+        assert_resolution_target(
+            "API error 404: {\"status\":404,\"error\":\"Not Found\",\"path\":\"/v4/v1/chat/completions\"}",
+            AgentErrorResolutionTarget::ProviderSettings,
+        );
+        assert_classification(
+            "Aionrs agent error: API error: Connection error: error decoding response body",
+            AgentErrorCode::UserLlmProviderNetworkError,
+            AgentErrorOwnership::UserLlmProvider,
+            AgentErrorResolutionKind::CheckProviderBaseUrl,
+        );
+        assert_classification(
+            "Aionrs agent error: API error: error sending request for url",
+            AgentErrorCode::UserLlmProviderNetworkError,
+            AgentErrorOwnership::UserLlmProvider,
+            AgentErrorResolutionKind::CheckProviderBaseUrl,
+        );
+        assert_classification(
+            "Autocompact failed: Empty response from LLM",
+            AgentErrorCode::UserLlmProviderEmptyResponse,
+            AgentErrorOwnership::UserLlmProvider,
+            AgentErrorResolutionKind::Retry,
+        );
+    }
+
+    #[test]
+    fn classifies_aionui_conversation_busy_after_agent_and_provider_checks() {
+        assert_classification(
+            "Conflict: Conversation is already processing a message",
+            AgentErrorCode::AionuiConversationBusy,
+            AgentErrorOwnership::Aionui,
+            AgentErrorResolutionKind::WaitForCurrentResponse,
         );
     }
 }

--- a/crates/aionui-ai-agent/src/task_manager.rs
+++ b/crates/aionui-ai-agent/src/task_manager.rs
@@ -264,7 +264,10 @@ mod tests {
         fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
             self.event_tx.subscribe()
         }
-        async fn send_message(&self, _data: SendMessageData) -> Result<(), AppError> {
+        async fn send_message(
+            &self,
+            _data: SendMessageData,
+        ) -> Result<(), crate::protocol::send_error::AgentSendError> {
             Ok(())
         }
         async fn cancel(&self) -> Result<(), AppError> {

--- a/crates/aionui-ai-agent/tests/agent_types_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_types_integration.rs
@@ -71,7 +71,7 @@ impl IAgentTask for TypedMockAgent {
     fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
         self.event_tx.subscribe()
     }
-    async fn send_message(&self, _data: SendMessageData) -> Result<(), aionui_common::AppError> {
+    async fn send_message(&self, _data: SendMessageData) -> Result<(), aionui_ai_agent::AgentSendError> {
         Ok(())
     }
     async fn cancel(&self) -> Result<(), aionui_common::AppError> {

--- a/crates/aionui-api-types/src/agent_error.rs
+++ b/crates/aionui-api-types/src/agent_error.rs
@@ -164,6 +164,7 @@ mod tests {
         assert_eq!(json["ownership"], "user_llm_provider");
         assert_eq!(json["retryable"], false);
         assert_eq!(json["feedback_recommended"], false);
+        assert!(json.get("resolution").is_none());
     }
 
     #[test]

--- a/crates/aionui-api-types/src/agent_error.rs
+++ b/crates/aionui-api-types/src/agent_error.rs
@@ -78,6 +78,7 @@ pub enum AgentErrorResolutionTarget {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct AgentErrorResolution {
     pub kind: AgentErrorResolutionKind,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/aionui-api-types/src/agent_error.rs
+++ b/crates/aionui-api-types/src/agent_error.rs
@@ -12,25 +12,82 @@ pub enum AgentErrorOwnership {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum AgentErrorCode {
+    AionuiConversationBusy,
     AionuiStreamBroken,
     AionuiStateInconsistent,
     AionuiPermissionError,
     AionuiInternalError,
+    UserAgentHandshakeFailed,
+    UserAgentHandshakeTimeout,
+    UserAgentAcpInitFailed,
+    UserAgentProtocolMismatch,
     UserAgentNotInstalled,
     UserAgentStartupFailed,
     UserAgentDisconnected,
     UserAgentAuthRequired,
     UserAgentSessionNotFound,
+    UserAgentNoPreviousSession,
+    UserAgentCommandNotFound,
+    UserAgentMissingEnv,
     UserAgentUnsupportedMethod,
     UserAgentInvalidParams,
     UserLlmProviderAuthFailed,
+    UserLlmProviderPermissionDenied,
+    UserLlmProviderBillingRequired,
     UserLlmProviderConfigError,
     UserLlmProviderModelNotFound,
+    UserLlmProviderUnsupportedModel,
+    UserLlmProviderEndpointNotFound,
+    UserLlmProviderInvalidRequest,
+    UserLlmProviderInvalidToolSchema,
+    UserLlmProviderContextTooLarge,
     UserLlmProviderRateLimited,
     UserLlmProviderTimeout,
     UserLlmProviderNetworkError,
+    UserLlmProviderEmptyResponse,
     UserLlmProviderGatewayError,
     UnknownUpstreamError,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentErrorResolutionKind {
+    Retry,
+    WaitForCurrentResponse,
+    StartNewSession,
+    ReconnectAgent,
+    CheckAgentLogin,
+    CheckAgentInstallation,
+    CheckAgentVersion,
+    CheckLocalCommand,
+    CheckProviderCredentials,
+    CheckProviderBilling,
+    CheckProviderBaseUrl,
+    ChangeModel,
+    ReduceContext,
+    SendFeedback,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentErrorResolutionTarget {
+    ProviderSettings,
+    AgentSettings,
+    NewConversation,
+    Feedback,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentErrorResolution {
+    pub kind: AgentErrorResolutionKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<AgentErrorResolutionTarget>,
+}
+
+impl AgentErrorResolution {
+    pub fn new(kind: AgentErrorResolutionKind, target: Option<AgentErrorResolutionTarget>) -> Self {
+        Self { kind, target }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -46,6 +103,8 @@ pub struct AgentStreamErrorData {
     pub retryable: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub feedback_recommended: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolution: Option<AgentErrorResolution>,
 }
 
 impl AgentStreamErrorData {
@@ -57,6 +116,7 @@ impl AgentStreamErrorData {
             detail: None,
             retryable: None,
             feedback_recommended: None,
+            resolution: None,
         }
     }
 
@@ -67,6 +127,7 @@ impl AgentStreamErrorData {
         detail: Option<String>,
         retryable: bool,
         feedback_recommended: bool,
+        resolution: Option<AgentErrorResolution>,
     ) -> Self {
         Self {
             message: message.into(),
@@ -75,6 +136,7 @@ impl AgentStreamErrorData {
             detail,
             retryable: Some(retryable),
             feedback_recommended: Some(feedback_recommended),
+            resolution,
         }
     }
 }
@@ -92,6 +154,7 @@ mod tests {
             Some("Provider returned 401.".into()),
             false,
             false,
+            None,
         );
 
         let json = serde_json::to_value(payload).unwrap();
@@ -100,6 +163,27 @@ mod tests {
         assert_eq!(json["ownership"], "user_llm_provider");
         assert_eq!(json["retryable"], false);
         assert_eq!(json["feedback_recommended"], false);
+    }
+
+    #[test]
+    fn classified_error_serializes_resolution() {
+        let payload = AgentStreamErrorData::classified(
+            "The current response is still running",
+            AgentErrorCode::AionuiConversationBusy,
+            AgentErrorOwnership::Aionui,
+            Some("Conflict: Conversation is already processing a message".into()),
+            true,
+            false,
+            Some(AgentErrorResolution::new(
+                AgentErrorResolutionKind::WaitForCurrentResponse,
+                Some(AgentErrorResolutionTarget::NewConversation),
+            )),
+        );
+
+        let json = serde_json::to_value(payload).unwrap();
+        assert_eq!(json["code"], "AIONUI_CONVERSATION_BUSY");
+        assert_eq!(json["resolution"]["kind"], "wait_for_current_response");
+        assert_eq!(json["resolution"]["target"], "new_conversation");
     }
 
     #[test]
@@ -115,5 +199,16 @@ mod tests {
         assert_eq!(payload.ownership, None);
         assert_eq!(payload.retryable, None);
         assert_eq!(payload.feedback_recommended, None);
+    }
+
+    #[test]
+    fn legacy_error_payload_has_no_resolution() {
+        let json = serde_json::json!({
+            "message": "legacy failure",
+            "code": "UNKNOWN_UPSTREAM_ERROR"
+        });
+
+        let payload: AgentStreamErrorData = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.resolution, None);
     }
 }

--- a/crates/aionui-api-types/src/agent_error.rs
+++ b/crates/aionui-api-types/src/agent_error.rs
@@ -24,6 +24,7 @@ pub enum AgentErrorCode {
     UserAgentUnsupportedMethod,
     UserAgentInvalidParams,
     UserLlmProviderAuthFailed,
+    UserLlmProviderConfigError,
     UserLlmProviderModelNotFound,
     UserLlmProviderRateLimited,
     UserLlmProviderTimeout,

--- a/crates/aionui-api-types/src/agent_error.rs
+++ b/crates/aionui-api-types/src/agent_error.rs
@@ -1,0 +1,118 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentErrorOwnership {
+    Aionui,
+    UserAgent,
+    UserLlmProvider,
+    UnknownUpstream,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AgentErrorCode {
+    AionuiStreamBroken,
+    AionuiStateInconsistent,
+    AionuiPermissionError,
+    AionuiInternalError,
+    UserAgentNotInstalled,
+    UserAgentStartupFailed,
+    UserAgentDisconnected,
+    UserAgentAuthRequired,
+    UserAgentSessionNotFound,
+    UserAgentUnsupportedMethod,
+    UserAgentInvalidParams,
+    UserLlmProviderAuthFailed,
+    UserLlmProviderModelNotFound,
+    UserLlmProviderRateLimited,
+    UserLlmProviderTimeout,
+    UserLlmProviderNetworkError,
+    UserLlmProviderGatewayError,
+    UnknownUpstreamError,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentStreamErrorData {
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code: Option<AgentErrorCode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ownership: Option<AgentErrorOwnership>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub feedback_recommended: Option<bool>,
+}
+
+impl AgentStreamErrorData {
+    pub fn legacy(message: impl Into<String>, code: Option<AgentErrorCode>) -> Self {
+        Self {
+            message: message.into(),
+            code,
+            ownership: None,
+            detail: None,
+            retryable: None,
+            feedback_recommended: None,
+        }
+    }
+
+    pub fn classified(
+        message: impl Into<String>,
+        code: AgentErrorCode,
+        ownership: AgentErrorOwnership,
+        detail: Option<String>,
+        retryable: bool,
+        feedback_recommended: bool,
+    ) -> Self {
+        Self {
+            message: message.into(),
+            code: Some(code),
+            ownership: Some(ownership),
+            detail,
+            retryable: Some(retryable),
+            feedback_recommended: Some(feedback_recommended),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classified_error_serializes_as_public_contract() {
+        let payload = AgentStreamErrorData::classified(
+            "The model provider rejected the request",
+            AgentErrorCode::UserLlmProviderAuthFailed,
+            AgentErrorOwnership::UserLlmProvider,
+            Some("Provider returned 401.".into()),
+            false,
+            false,
+        );
+
+        let json = serde_json::to_value(payload).unwrap();
+        assert_eq!(json["message"], "The model provider rejected the request");
+        assert_eq!(json["code"], "USER_LLM_PROVIDER_AUTH_FAILED");
+        assert_eq!(json["ownership"], "user_llm_provider");
+        assert_eq!(json["retryable"], false);
+        assert_eq!(json["feedback_recommended"], false);
+    }
+
+    #[test]
+    fn legacy_error_payload_deserializes() {
+        let json = serde_json::json!({
+            "message": "legacy failure",
+            "code": "UNKNOWN_UPSTREAM_ERROR"
+        });
+
+        let payload: AgentStreamErrorData = serde_json::from_value(json).unwrap();
+        assert_eq!(payload.message, "legacy failure");
+        assert_eq!(payload.code, Some(AgentErrorCode::UnknownUpstreamError));
+        assert_eq!(payload.ownership, None);
+        assert_eq!(payload.retryable, None);
+        assert_eq!(payload.feedback_recommended, None);
+    }
+}

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -39,7 +39,10 @@ pub use agent_build_extra::{
     SessionMcpServer, SessionMcpTransport, SlashCommandItem,
 };
 pub use agent_discovery::{AgentEnvEntry, AgentHandshake, AgentMetadata, AgentSource, AgentSourceInfo, BehaviorPolicy};
-pub use agent_error::{AgentErrorCode, AgentErrorOwnership, AgentStreamErrorData};
+pub use agent_error::{
+    AgentErrorCode, AgentErrorOwnership, AgentErrorResolution, AgentErrorResolutionKind, AgentErrorResolutionTarget,
+    AgentStreamErrorData,
+};
 pub use assistant::{
     AssistantResponse, AssistantSource, CreateAssistantRequest, ImportAssistantsRequest, ImportAssistantsResult,
     ImportError, SetAssistantStateRequest, UpdateAssistantRequest,
@@ -136,3 +139,19 @@ pub use team::{
 };
 pub use team_mcp::{GuideMcpConfig, TEAM_MCP_SERVER_NAME, TeamMcpStdioConfig};
 pub use websocket::WebSocketMessage;
+
+#[cfg(test)]
+mod public_contract_tests {
+    use super::{AgentErrorResolution, AgentErrorResolutionKind, AgentErrorResolutionTarget};
+
+    #[test]
+    fn error_resolution_types_are_exported_from_crate_root() {
+        let resolution = AgentErrorResolution::new(
+            AgentErrorResolutionKind::Retry,
+            Some(AgentErrorResolutionTarget::Feedback),
+        );
+
+        assert_eq!(resolution.kind, AgentErrorResolutionKind::Retry);
+        assert_eq!(resolution.target, Some(AgentErrorResolutionTarget::Feedback));
+    }
+}

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -3,6 +3,7 @@ mod acp;
 mod acp_prompt_hook;
 mod agent_build_extra;
 mod agent_discovery;
+mod agent_error;
 mod assistant;
 mod auth;
 mod channel;
@@ -38,6 +39,7 @@ pub use agent_build_extra::{
     SessionMcpServer, SessionMcpTransport, SlashCommandItem,
 };
 pub use agent_discovery::{AgentEnvEntry, AgentHandshake, AgentMetadata, AgentSource, AgentSourceInfo, BehaviorPolicy};
+pub use agent_error::{AgentErrorCode, AgentErrorOwnership, AgentStreamErrorData};
 pub use assistant::{
     AssistantResponse, AssistantSource, CreateAssistantRequest, ImportAssistantsRequest, ImportAssistantsResult,
     ImportError, SetAssistantStateRequest, UpdateAssistantRequest,

--- a/crates/aionui-app/tests/agent_integration_e2e.rs
+++ b/crates/aionui-app/tests/agent_integration_e2e.rs
@@ -73,7 +73,7 @@ impl IAgentTask for MockAgent {
         self.event_tx.subscribe()
     }
 
-    async fn send_message(&self, _data: SendMessageData) -> Result<(), AppError> {
+    async fn send_message(&self, _data: SendMessageData) -> Result<(), aionui_ai_agent::AgentSendError> {
         self.last_activity.store(now_ms(), Ordering::Relaxed);
         // Emit a text event and finish
         let _ = self.event_tx.send(AgentStreamEvent::Text(TextEventData {

--- a/crates/aionui-app/tests/common/mod.rs
+++ b/crates/aionui-app/tests/common/mod.rs
@@ -153,7 +153,7 @@ impl IAgentTask for NoopMockAgent {
     async fn send_message(
         &self,
         _data: aionui_ai_agent::types::SendMessageData,
-    ) -> Result<(), aionui_common::AppError> {
+    ) -> Result<(), aionui_ai_agent::AgentSendError> {
         Ok(())
     }
     async fn cancel(&self) -> Result<(), aionui_common::AppError> {

--- a/crates/aionui-channel/src/message_service.rs
+++ b/crates/aionui-channel/src/message_service.rs
@@ -464,10 +464,7 @@ mod tests {
 
     #[test]
     fn error_event_produces_error() {
-        let event = AgentStreamEvent::Error(ErrorEventData {
-            message: "timeout".into(),
-            code: None,
-        });
+        let event = AgentStreamEvent::Error(ErrorEventData::legacy("timeout", None));
         let action = ChannelMessageService::process_stream_event(&event);
         match action {
             Some(StreamAction::Error(msg)) => assert_eq!(msg, "timeout"),

--- a/crates/aionui-channel/tests/message_service_integration.rs
+++ b/crates/aionui-channel/tests/message_service_integration.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use aionui_ai_agent::agent_task::{AgentInstance, IAgentTask};
 use aionui_ai_agent::protocol::events::FinishEventData;
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
-use aionui_ai_agent::{AgentStreamEvent, IMockAgent, IWorkerTaskManager};
+use aionui_ai_agent::{AgentSendError, AgentStreamEvent, IMockAgent, IWorkerTaskManager};
 use aionui_api_types::WebSocketMessage;
 use aionui_channel::channel_settings::ChannelSettingsService;
 use aionui_channel::message_service::ChannelMessageService;
@@ -101,7 +101,7 @@ impl IAgentTask for ScriptedAgent {
         self.event_tx.subscribe()
     }
 
-    async fn send_message(&self, _data: SendMessageData) -> Result<(), AppError> {
+    async fn send_message(&self, _data: SendMessageData) -> Result<(), AgentSendError> {
         let _ = self.event_tx.send(AgentStreamEvent::Finish(FinishEventData::default()));
         Ok(())
     }

--- a/crates/aionui-channel/tests/stream_relay_test.rs
+++ b/crates/aionui-channel/tests/stream_relay_test.rs
@@ -80,10 +80,7 @@ async fn relay_handles_error_event() {
     let rx = event_tx.subscribe();
 
     event_tx
-        .send(AgentStreamEvent::Error(ErrorEventData {
-            message: "timeout".into(),
-            code: None,
-        }))
+        .send(AgentStreamEvent::Error(ErrorEventData::legacy("timeout", None)))
         .unwrap();
 
     relay.run(rx).await;

--- a/crates/aionui-conversation/src/message_persistence.rs
+++ b/crates/aionui-conversation/src/message_persistence.rs
@@ -1,3 +1,4 @@
+use aionui_ai_agent::AgentSendError;
 use aionui_common::{AppError, ErrorChain, now_ms};
 use aionui_db::models::MessageRow;
 use tracing::warn;
@@ -6,16 +7,18 @@ use crate::service::ConversationService;
 
 impl ConversationService {
     pub(crate) async fn persist_send_failure_tip(&self, conversation_id: &str, err: &AppError) -> Option<MessageRow> {
+        let stream_error = AgentSendError::from_app_error_ref(err).into_stream_error();
         let row = MessageRow {
             id: Self::mint_msg_id(),
             conversation_id: conversation_id.to_owned(),
             msg_id: None,
             r#type: "tips".into(),
             content: serde_json::json!({
-                "content": err.to_string(),
+                "content": &stream_error.message,
                 "type": "error",
                 "source": "send_failed",
                 "code": err.error_code(),
+                "error": stream_error,
             })
             .to_string(),
             position: Some("center".into()),

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -1276,6 +1276,11 @@ impl ConversationService {
         let build_opts = match self.build_task_options(&row) {
             Ok(opts) => opts,
             Err(err) => {
+                error!(
+                    error_code = err.error_code(),
+                    error = %ErrorChain(&err),
+                    "Failed to build task options for message send"
+                );
                 let _ = self.persist_send_failure_tip(conversation_id, &err).await;
                 return Err(err);
             }
@@ -1315,7 +1320,12 @@ impl ConversationService {
             let agent = match task_manager.get_or_build_task(&conv_id, build_opts).await {
                 Ok(agent) => agent,
                 Err(err) => {
-                    warn!(conversation_id = %conv_id, error = %ErrorChain(&err), "Agent task build failed");
+                    error!(
+                        conversation_id = %conv_id,
+                        error_code = err.error_code(),
+                        error = %ErrorChain(&err),
+                        "Agent task build failed"
+                    );
                     service.persist_and_broadcast_send_failure_tip(&conv_id, &err).await;
                     StreamRelay::complete_conversation(&repo, &broadcaster, &conv_id).await;
                     return;
@@ -1328,7 +1338,12 @@ impl ConversationService {
                 .maybe_persist_workspace(&conv_id, &stored_workspace, agent.workspace())
                 .await
             {
-                warn!(conversation_id = %conv_id, error = %ErrorChain(&err), "Failed to persist resolved workspace");
+                error!(
+                    conversation_id = %conv_id,
+                    error_code = err.error_code(),
+                    error = %ErrorChain(&err),
+                    "Failed to persist resolved workspace"
+                );
                 service.persist_and_broadcast_send_failure_tip(&conv_id, &err).await;
                 StreamRelay::complete_conversation(&repo, &broadcaster, &conv_id).await;
                 return;

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -25,6 +25,7 @@ use aionui_mcp::{AcpMcpCapabilities, parse_acp_mcp_capabilities};
 use aionui_realtime::EventBroadcaster;
 use aionui_runtime::resolve_command_path;
 use std::collections::{HashMap, HashSet};
+use tokio::sync::oneshot;
 use tracing::{debug, error, info, warn};
 
 use crate::convert::{
@@ -1375,14 +1376,16 @@ impl ConversationService {
                 let rx = agent.subscribe();
                 let send_agent = agent.clone();
                 let conv_id_send = conv_id.clone();
+                let (send_error_tx, send_error_rx) = oneshot::channel();
                 // 1. Send the message to the agent and concurrently run the relay to stream events.
                 tokio::spawn(async move {
                     if let Err(e) = send_agent.send_message(current_send).await {
                         error!(conversation_id = %conv_id_send, error = %ErrorChain(&e), "Agent send_message failed");
+                        let _ = send_error_tx.send(e);
                     }
                 });
                 // 2. Wait for the agent to process the message and complete the turn, while the relay streams events in real time.
-                let outcome = relay.consume(rx).await;
+                let outcome = relay.consume_with_send_error(rx, send_error_rx).await;
 
                 if let Some(session_key) = agent.get_session_key() {
                     persist_session_key(&repo, &conv_id, &session_key).await;

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -5,10 +5,10 @@ use std::sync::{
 };
 use std::time::Duration;
 
-use aionui_ai_agent::IWorkerTaskManager;
 use aionui_ai_agent::agent_task::{AgentInstance, IAgentTask, IMockAgent};
 use aionui_ai_agent::protocol::events::{AgentStreamEvent, FinishEventData, TextEventData};
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
+use aionui_ai_agent::{AgentSendError, IWorkerTaskManager};
 
 use crate::response_middleware::{CronCommandResult, CronCreateParams, CronUpdateParams, ICronService};
 use aionui_api_types::ConversationArtifactKind;
@@ -1098,7 +1098,7 @@ impl IAgentTask for MockAgent {
     fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
         self.event_tx.subscribe()
     }
-    async fn send_message(&self, _data: SendMessageData) -> Result<(), AppError> {
+    async fn send_message(&self, _data: SendMessageData) -> Result<(), AgentSendError> {
         // Emit finish event so the relay task completes
         let _ = self.event_tx.send(AgentStreamEvent::Finish(
             aionui_ai_agent::protocol::events::FinishEventData::default(),
@@ -1434,7 +1434,7 @@ impl IAgentTask for ScriptedAgent {
         self.event_tx.subscribe()
     }
 
-    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+    async fn send_message(&self, data: SendMessageData) -> Result<(), AgentSendError> {
         self.sent_contents.lock().unwrap().push(data.content);
         let script = self
             .scripts

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1637,9 +1637,14 @@ async fn send_message_persists_error_tip_when_agent_build_fails() {
     assert_eq!(content["type"], "error");
     assert_eq!(content["source"], "send_failed");
     assert_eq!(content["code"], "BAD_GATEWAY");
+    assert_eq!(content["error"]["code"], "UNKNOWN_UPSTREAM_ERROR");
+    assert_eq!(content["error"]["ownership"], "unknown_upstream");
+    assert_eq!(content["error"]["retryable"], true);
+    assert_eq!(content["error"]["feedback_recommended"], true);
+    assert_eq!(content["error"]["detail"], "ACP init failed: config file is invalid");
     assert_eq!(
         content["content"],
-        "Bad gateway: ACP init failed: config file is invalid"
+        "The upstream Agent failed while handling the request"
     );
 
     let updated = repo.get(&conv.id).await.unwrap().unwrap();

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -134,7 +134,6 @@ impl StreamRelay {
         let mut first_agent_event_logged = false;
         let mut first_visible_output_logged = false;
         let mut send_error_done = send_error_rx.is_none();
-        let mut error_finalized = false;
 
         loop {
             let recv_result = if send_error_done {
@@ -146,14 +145,6 @@ impl StreamRelay {
                         send_error_done = true;
                         match send_error {
                             Ok(send_error) => {
-                                if error_finalized {
-                                    debug!(
-                                        code = ?send_error.code(),
-                                        ownership = ?send_error.ownership(),
-                                        "Skipping send error injection because a stream error was already handled"
-                                    );
-                                    continue;
-                                }
                                 warn!(
                                     code = ?send_error.code(),
                                     ownership = ?send_error.ownership(),
@@ -232,12 +223,6 @@ impl StreamRelay {
                             }
                         }
                         AgentStreamEvent::Finish(_) | AgentStreamEvent::Error(_) => {
-                            if matches!(event, AgentStreamEvent::Error(_))
-                                && std::mem::replace(&mut error_finalized, true)
-                            {
-                                debug!("Skipping duplicate stream error event");
-                                continue;
-                            }
                             let elapsed_ms = now_ms() - started_at;
                             let event_type = if matches!(event, AgentStreamEvent::Finish(_)) {
                                 "Finish"
@@ -1142,7 +1127,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_send_error_does_not_duplicate_existing_stream_error() {
+    async fn run_send_error_keeps_existing_stream_error_when_it_arrives_first() {
         let repo = Arc::new(RecordingRepo::new());
         let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
         let (tx, _) = broadcast::channel(64);
@@ -1160,24 +1145,71 @@ mod tests {
         let send_error = AgentSendError::from_app_error(aionui_common::AppError::BadGateway(
             "provider returned 401 invalid api key".into(),
         ));
-        tx.send(AgentStreamEvent::Error(send_error.stream_error().clone()))
-            .unwrap();
+        tx.send(AgentStreamEvent::Error(ErrorEventData::legacy(
+            "stream already emitted",
+            None,
+        )))
+        .unwrap();
         let (send_error_tx, send_error_rx) = tokio::sync::oneshot::channel();
-        send_error_tx.send(send_error).unwrap();
+        let delayed_send_error = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            let _ = send_error_tx.send(send_error);
+        });
 
         let outcome = relay.consume_with_send_error(rx, send_error_rx).await;
+        delayed_send_error.await.unwrap();
         assert!(outcome.system_responses.is_empty());
 
         let inserts = repo.take_inserts();
-        let error_tips_count = inserts
-            .iter()
-            .filter(|msg| {
-                msg.r#type == "tips"
-                    && serde_json::from_str::<serde_json::Value>(&msg.content)
-                        .is_ok_and(|content| content["type"] == "error")
-            })
-            .count();
-        assert_eq!(error_tips_count, 1);
+        assert_eq!(inserts.len(), 1);
+        assert_eq!(inserts[0].r#type, "tips");
+        let content: serde_json::Value = serde_json::from_str(&inserts[0].content).unwrap();
+        assert_eq!(content["content"], "stream already emitted");
+        assert_eq!(content["type"], "error");
+    }
+
+    #[tokio::test]
+    async fn run_send_error_uses_send_error_when_it_arrives_first() {
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let (tx, _) = broadcast::channel(64);
+
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+            None,
+        );
+
+        let rx = tx.subscribe();
+        let (send_error_tx, send_error_rx) = tokio::sync::oneshot::channel();
+        send_error_tx
+            .send(AgentSendError::from_app_error(aionui_common::AppError::BadGateway(
+                "provider returned 401 invalid api key".into(),
+            )))
+            .unwrap();
+        let delayed_stream_error = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            let _ = tx.send(AgentStreamEvent::Error(ErrorEventData::legacy(
+                "stream already emitted",
+                None,
+            )));
+        });
+
+        let outcome = relay.consume_with_send_error(rx, send_error_rx).await;
+        delayed_stream_error.await.unwrap();
+        assert!(outcome.system_responses.is_empty());
+
+        let inserts = repo.take_inserts();
+        assert_eq!(inserts.len(), 1);
+        assert_eq!(inserts[0].r#type, "tips");
+        let content: serde_json::Value = serde_json::from_str(&inserts[0].content).unwrap();
+        assert_eq!(content["content"], "The model provider rejected the request");
+        assert_eq!(content["type"], "error");
+        assert_eq!(content["error"]["resolution"]["kind"], "check_provider_credentials");
+        assert_eq!(content["error"]["resolution"]["target"], "provider_settings");
     }
 
     #[tokio::test]

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -134,6 +134,7 @@ impl StreamRelay {
         let mut first_agent_event_logged = false;
         let mut first_visible_output_logged = false;
         let mut send_error_done = send_error_rx.is_none();
+        let mut error_finalized = false;
 
         loop {
             let recv_result = if send_error_done {
@@ -145,6 +146,14 @@ impl StreamRelay {
                         send_error_done = true;
                         match send_error {
                             Ok(send_error) => {
+                                if error_finalized {
+                                    debug!(
+                                        code = ?send_error.code(),
+                                        ownership = ?send_error.ownership(),
+                                        "Skipping send error injection because a stream error was already handled"
+                                    );
+                                    continue;
+                                }
                                 warn!(
                                     code = ?send_error.code(),
                                     ownership = ?send_error.ownership(),
@@ -223,6 +232,12 @@ impl StreamRelay {
                             }
                         }
                         AgentStreamEvent::Finish(_) | AgentStreamEvent::Error(_) => {
+                            if matches!(event, AgentStreamEvent::Error(_))
+                                && std::mem::replace(&mut error_finalized, true)
+                            {
+                                debug!("Skipping duplicate stream error event");
+                                continue;
+                            }
                             let elapsed_ms = now_ms() - started_at;
                             let event_type = if matches!(event, AgentStreamEvent::Finish(_)) {
                                 "Finish"
@@ -1109,6 +1124,8 @@ mod tests {
         assert_eq!(content["error"]["retryable"], false);
         assert_eq!(content["error"]["feedback_recommended"], false);
         assert_eq!(content["error"]["detail"], "provider returned 401 invalid api key");
+        assert_eq!(content["error"]["resolution"]["kind"], "check_provider_credentials");
+        assert_eq!(content["error"]["resolution"]["target"], "provider_settings");
 
         let mut ws_events = vec![];
         while let Ok(evt) = ws_rx.try_recv() {
@@ -1122,6 +1139,45 @@ mod tests {
         assert_eq!(error_event.data["data"]["code"], "USER_LLM_PROVIDER_AUTH_FAILED");
         assert_eq!(error_event.data["data"]["ownership"], "user_llm_provider");
         assert!(ws_events.iter().any(|evt| evt.name == "turn.completed"));
+    }
+
+    #[tokio::test]
+    async fn run_send_error_does_not_duplicate_existing_stream_error() {
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let (tx, _) = broadcast::channel(64);
+
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+            None,
+        );
+
+        let rx = tx.subscribe();
+        let send_error = AgentSendError::from_app_error(aionui_common::AppError::BadGateway(
+            "provider returned 401 invalid api key".into(),
+        ));
+        tx.send(AgentStreamEvent::Error(send_error.stream_error().clone()))
+            .unwrap();
+        let (send_error_tx, send_error_rx) = tokio::sync::oneshot::channel();
+        send_error_tx.send(send_error).unwrap();
+
+        let outcome = relay.consume_with_send_error(rx, send_error_rx).await;
+        assert!(outcome.system_responses.is_empty());
+
+        let inserts = repo.take_inserts();
+        let error_tips_count = inserts
+            .iter()
+            .filter(|msg| {
+                msg.r#type == "tips"
+                    && serde_json::from_str::<serde_json::Value>(&msg.content)
+                        .is_ok_and(|content| content["type"] == "error")
+            })
+            .count();
+        assert_eq!(error_tips_count, 1);
     }
 
     #[tokio::test]

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -531,7 +531,7 @@ impl StreamRelay {
             outcome.system_responses = processed.system_responses;
         } else if let AgentStreamEvent::Error(data) = event {
             // No text accumulated but got an error — store error as tips message
-            let content = json!({ "content": data.message, "type": "error" }).to_string();
+            let content = json!({ "content": &data.message, "type": "error", "error": &data }).to_string();
             let row = MessageRow {
                 id: ConversationService::mint_msg_id(),
                 conversation_id: self.conversation_id.clone(),
@@ -1104,6 +1104,11 @@ mod tests {
         let content: serde_json::Value = serde_json::from_str(&inserts[0].content).unwrap();
         assert_eq!(content["content"], "The model provider rejected the request");
         assert_eq!(content["type"], "error");
+        assert_eq!(content["error"]["code"], "USER_LLM_PROVIDER_AUTH_FAILED");
+        assert_eq!(content["error"]["ownership"], "user_llm_provider");
+        assert_eq!(content["error"]["retryable"], false);
+        assert_eq!(content["error"]["feedback_recommended"], false);
+        assert_eq!(content["error"]["detail"], "provider returned 401 invalid api key");
 
         let mut ws_events = vec![];
         while let Ok(evt) = ws_rx.try_recv() {

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use aionui_ai_agent::{
-    AgentStreamEvent,
+    AgentSendError, AgentStreamEvent,
     protocol::events::{
         ThinkingEventData,
         tool_call::{AcpToolCallSessionUpdateKind, AcpToolCallStatus, ToolCallStatus},
@@ -17,7 +17,7 @@ use aionui_db::IConversationRepository;
 use aionui_db::models::MessageRow;
 use aionui_realtime::EventBroadcaster;
 use serde_json::json;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, oneshot};
 use tracing::{debug, error, info, warn};
 
 /// Number of text chunks to accumulate before flushing to the database.
@@ -97,7 +97,32 @@ impl StreamRelay {
             msg_id = %self.msg_id,
         )
     )]
-    pub async fn consume(self, mut rx: broadcast::Receiver<AgentStreamEvent>) -> RelayOutcome {
+    pub async fn consume(self, rx: broadcast::Receiver<AgentStreamEvent>) -> RelayOutcome {
+        self.consume_inner(rx, None).await
+    }
+
+    /// Run the relay loop while also accepting a typed send failure from the
+    /// task that called `IAgentTask::send_message`.
+    #[tracing::instrument(
+        skip_all,
+        fields(
+            conversation_id = %self.conversation_id,
+            msg_id = %self.msg_id,
+        )
+    )]
+    pub async fn consume_with_send_error(
+        self,
+        rx: broadcast::Receiver<AgentStreamEvent>,
+        send_error_rx: oneshot::Receiver<AgentSendError>,
+    ) -> RelayOutcome {
+        self.consume_inner(rx, Some(send_error_rx)).await
+    }
+
+    async fn consume_inner(
+        self,
+        mut rx: broadcast::Receiver<AgentStreamEvent>,
+        mut send_error_rx: Option<oneshot::Receiver<AgentSendError>>,
+    ) -> RelayOutcome {
         let started_at = now_ms();
         info!("StreamRelay started");
 
@@ -108,9 +133,32 @@ impl StreamRelay {
         let mut used_primary_segment_msg_id = false;
         let mut first_agent_event_logged = false;
         let mut first_visible_output_logged = false;
+        let mut send_error_done = send_error_rx.is_none();
 
         loop {
-            match rx.recv().await {
+            let recv_result = if send_error_done {
+                rx.recv().await
+            } else {
+                tokio::select! {
+                    recv = rx.recv() => recv,
+                    send_error = send_error_rx.as_mut().expect("send_error_rx exists while pending") => {
+                        send_error_done = true;
+                        match send_error {
+                            Ok(send_error) => {
+                                warn!(
+                                    code = ?send_error.code(),
+                                    ownership = ?send_error.ownership(),
+                                    "Injecting stream error for failed agent send"
+                                );
+                                Ok(AgentStreamEvent::Error(send_error.into_stream_error()))
+                            }
+                            Err(_) => continue,
+                        }
+                    }
+                }
+            };
+
+            match recv_result {
                 Ok(event) => {
                     if !first_agent_event_logged {
                         first_agent_event_logged = true;
@@ -1002,10 +1050,10 @@ mod tests {
 
         let rx = tx.subscribe();
 
-        tx.send(AgentStreamEvent::Error(ErrorEventData {
-            message: "Something went wrong".into(),
-            code: None,
-        }))
+        tx.send(AgentStreamEvent::Error(ErrorEventData::legacy(
+            "Something went wrong",
+            None,
+        )))
         .unwrap();
 
         let outcome = relay.consume(rx).await;
@@ -1020,6 +1068,55 @@ mod tests {
         let content: serde_json::Value = serde_json::from_str(&msg.content).unwrap();
         assert_eq!(content["content"], "Something went wrong");
         assert_eq!(content["type"], "error");
+    }
+
+    #[tokio::test]
+    async fn run_send_error_injects_error_and_completes_turn() {
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let (tx, _) = broadcast::channel(64);
+
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+            None,
+        );
+
+        let mut ws_rx = bus.subscribe();
+        let rx = tx.subscribe();
+        let (send_error_tx, send_error_rx) = tokio::sync::oneshot::channel();
+        send_error_tx
+            .send(AgentSendError::from_app_error(aionui_common::AppError::BadGateway(
+                "provider returned 401 invalid api key".into(),
+            )))
+            .unwrap();
+
+        let outcome = relay.consume_with_send_error(rx, send_error_rx).await;
+        assert!(outcome.system_responses.is_empty());
+
+        let inserts = repo.take_inserts();
+        assert_eq!(inserts.len(), 1);
+        assert_eq!(inserts[0].r#type, "tips");
+        assert_eq!(inserts[0].status.as_deref(), Some("error"));
+        let content: serde_json::Value = serde_json::from_str(&inserts[0].content).unwrap();
+        assert_eq!(content["content"], "The model provider rejected the request");
+        assert_eq!(content["type"], "error");
+
+        let mut ws_events = vec![];
+        while let Ok(evt) = ws_rx.try_recv() {
+            ws_events.push(evt);
+        }
+
+        let error_event = ws_events
+            .iter()
+            .find(|evt| evt.name == "message.stream" && evt.data["type"] == "error")
+            .expect("send error should be forwarded as message.stream error");
+        assert_eq!(error_event.data["data"]["code"], "USER_LLM_PROVIDER_AUTH_FAILED");
+        assert_eq!(error_event.data["data"]["ownership"], "user_llm_provider");
+        assert!(ws_events.iter().any(|evt| evt.name == "turn.completed"));
     }
 
     #[tokio::test]

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -2214,7 +2214,7 @@ mod tests {
             self.event_tx.subscribe()
         }
 
-        async fn send_message(&self, data: SendMessageData) -> Result<(), aionui_common::AppError> {
+        async fn send_message(&self, data: SendMessageData) -> Result<(), aionui_ai_agent::AgentSendError> {
             self.send_calls.fetch_add(1, Ordering::Relaxed);
             self.sent_messages.write().await.push(data);
             Ok(())

--- a/crates/aionui-team/src/crash_detection.rs
+++ b/crates/aionui-team/src/crash_detection.rs
@@ -30,10 +30,7 @@ mod tests {
     use aionui_ai_agent::protocol::events::{ErrorEventData, StartEventData};
 
     fn error_event(message: &str) -> AgentStreamEvent {
-        AgentStreamEvent::Error(ErrorEventData {
-            message: message.to_string(),
-            code: None,
-        })
+        AgentStreamEvent::Error(ErrorEventData::legacy(message, None))
     }
 
     #[test]
@@ -96,28 +93,19 @@ mod crash_tests {
 
     #[test]
     fn detect_crash_process_exited() {
-        let event = AgentStreamEvent::Error(ErrorEventData {
-            message: "process exited unexpectedly".into(),
-            code: None,
-        });
+        let event = AgentStreamEvent::Error(ErrorEventData::legacy("process exited unexpectedly", None));
         assert_eq!(detect_crash(&event), Some(CrashReason::ProcessExited));
     }
 
     #[test]
     fn detect_crash_session_not_found() {
-        let event = AgentStreamEvent::Error(ErrorEventData {
-            message: "Session not found".into(),
-            code: None,
-        });
+        let event = AgentStreamEvent::Error(ErrorEventData::legacy("Session not found", None));
         assert_eq!(detect_crash(&event), Some(CrashReason::SessionNotFound));
     }
 
     #[test]
     fn detect_crash_other_error() {
-        let event = AgentStreamEvent::Error(ErrorEventData {
-            message: "something else broke".into(),
-            code: None,
-        });
+        let event = AgentStreamEvent::Error(ErrorEventData::legacy("something else broke", None));
         assert_eq!(
             detect_crash(&event),
             Some(CrashReason::Unknown("something else broke".into()))

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -923,10 +923,12 @@ mod tests {
         fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
             self.event_tx.subscribe()
         }
-        async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+        async fn send_message(&self, data: SendMessageData) -> Result<(), aionui_ai_agent::AgentSendError> {
             self.sent.lock().unwrap().push(data);
             match &self.fail_with {
-                Some(msg) => Err(AppError::Internal(msg.clone())),
+                Some(msg) => Err(aionui_ai_agent::AgentSendError::from_app_error(AppError::Internal(
+                    msg.clone(),
+                ))),
                 None => Ok(()),
             }
         }

--- a/crates/aionui-team/tests/e2e_team_flow.rs
+++ b/crates/aionui-team/tests/e2e_team_flow.rs
@@ -149,10 +149,12 @@ impl IAgentTask for RecordingAgent {
     fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
         self.event_tx.subscribe()
     }
-    async fn send_message(&self, data: SendMessageData) -> Result<(), AppError> {
+    async fn send_message(&self, data: SendMessageData) -> Result<(), aionui_ai_agent::AgentSendError> {
         self.sent.lock().unwrap().push(data);
         match &self.fail_with {
-            Some(msg) => Err(AppError::Internal(msg.clone())),
+            Some(msg) => Err(aionui_ai_agent::AgentSendError::from_app_error(AppError::Internal(
+                msg.clone(),
+            ))),
             None => Ok(()),
         }
     }

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -552,7 +552,7 @@ mod mock_agent {
         fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
             self.event_tx.subscribe()
         }
-        async fn send_message(&self, _data: SendMessageData) -> Result<(), AppError> {
+        async fn send_message(&self, _data: SendMessageData) -> Result<(), aionui_ai_agent::AgentSendError> {
             Ok(())
         }
         async fn cancel(&self) -> Result<(), AppError> {


### PR DESCRIPTION
## Summary

- Add a public agent stream error taxonomy with ownership, code, retry, feedback, and resolution metadata.
- Convert accepted-turn send failures and empty provider replies into structured `message.stream` error events while preserving turn completion semantics.
- Classify user agent, user LLM provider, AionUI, and unknown upstream failures with priority-aware matching and redacted technical detail.
- Preserve mainline channel warmup/stream subscription behavior and adapt affected mocks/tests to `AgentSendError`.

## Verification

- [x] `just push --force-with-lease origin agent-error-taxonomy` (cargo fix, clippy fix, fmt, nextest, push)
- [x] `cargo nextest run --workspace` via `just push`: 5735 passed, 18 skipped
- [x] `cargo test -p aionui-channel`: 204 unit tests plus channel integration tests passed