### PR TITLE
Compact tool message history responses

### DIFF
--- a/crates/aionui-api-types/src/conversation.rs
+++ b/crates/aionui-api-types/src/conversation.rs
@@ -77,6 +77,7 @@ pub struct ListMessagesQuery {
     pub page: Option<u32>,
     pub page_size: Option<u32>,
     pub order: Option<String>,
+    pub content_mode: Option<String>,
 }
 
 /// Body for `PATCH /api/conversations/:id/artifacts/:artifact_id`.
@@ -377,15 +378,17 @@ mod tests {
         assert!(q.page.is_none());
         assert!(q.page_size.is_none());
         assert!(q.order.is_none());
+        assert!(q.content_mode.is_none());
     }
 
     #[test]
     fn deserialize_messages_query_with_values() {
-        let raw = json!({ "page": 2, "page_size": 30, "order": "ASC" });
+        let raw = json!({ "page": 2, "page_size": 30, "order": "ASC", "content_mode": "compact" });
         let q: ListMessagesQuery = serde_json::from_value(raw).unwrap();
         assert_eq!(q.page, Some(2));
         assert_eq!(q.page_size, Some(30));
         assert_eq!(q.order.as_deref(), Some("ASC"));
+        assert_eq!(q.content_mode.as_deref(), Some("compact"));
     }
 
     // ── SearchMessagesQuery ─────────────────────────────────────────

--- a/crates/aionui-app/tests/message_e2e.rs
+++ b/crates/aionui-app/tests/message_e2e.rs
@@ -50,6 +50,45 @@ async fn insert_message(
         .unwrap();
 }
 
+async fn insert_acp_tool_message(
+    services: &aionui_app::AppServices,
+    conv_id: &str,
+    msg_id: &str,
+    output: &str,
+    created_at: i64,
+) {
+    let repo = aionui_db::SqliteConversationRepository::new(services.database.pool().clone());
+    let msg = aionui_db::models::MessageRow {
+        id: msg_id.into(),
+        conversation_id: conv_id.into(),
+        msg_id: Some(msg_id.into()),
+        r#type: "acp_tool_call".into(),
+        content: serde_json::json!({
+            "session_id": "session-1",
+            "update": {
+                "session_update": "tool_call",
+                "tool_call_id": msg_id,
+                "status": "completed",
+                "title": "rg",
+                "kind": "search",
+                "raw_input": { "pattern": "needle", "path": "." },
+                "content": [{
+                    "type": "content",
+                    "content": { "type": "text", "text": output }
+                }]
+            }
+        })
+        .to_string(),
+        position: Some("left".into()),
+        status: Some("finish".into()),
+        hidden: false,
+        created_at,
+    };
+    aionui_db::IConversationRepository::insert_message(&repo, &msg)
+        .await
+        .unwrap();
+}
+
 async fn upsert_artifact(services: &aionui_app::AppServices, artifact: aionui_db::ConversationArtifactRow) {
     let repo = aionui_db::SqliteConversationRepository::new(services.database.pool().clone());
     aionui_db::IConversationRepository::upsert_artifact(&repo, &artifact)
@@ -121,6 +160,132 @@ async fn t8_2_messages_pagination() {
     let json = body_json(resp).await;
     assert_eq!(json["data"]["items"].as_array().unwrap().len(), 1);
     assert_eq!(json["data"]["has_more"], false);
+}
+
+#[tokio::test]
+async fn t8_2b_messages_compact_mode_truncates_large_tool_payload() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+    let conv_id = create_conversation(&mut app, &token, &csrf, "Compact Tool Conv").await;
+    let large_output = "match line\n".repeat(10_000);
+
+    insert_acp_tool_message(&services, &conv_id, "tool-big", &large_output, 1000).await;
+
+    let resp = app
+        .clone()
+        .oneshot(get_with_token(
+            &format!("/api/conversations/{conv_id}/messages?content_mode=compact"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    let content = &json["data"]["items"][0]["content"];
+    let preview = content["update"]["content"][0]["content"]["text"].as_str().unwrap();
+
+    assert_eq!(content["_compact"]["truncated"], true);
+    assert!(preview.len() < large_output.len());
+    assert!(!preview.contains(&large_output));
+}
+
+#[tokio::test]
+async fn t8_2c_get_message_returns_full_tool_payload() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+    let conv_id = create_conversation(&mut app, &token, &csrf, "Tool Detail Conv").await;
+    let large_output = "wide rg output\n".repeat(10_000);
+
+    insert_acp_tool_message(&services, &conv_id, "tool-detail", &large_output, 1000).await;
+
+    let resp = app
+        .clone()
+        .oneshot(get_with_token(
+            &format!("/api/conversations/{conv_id}/messages/tool-detail"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+
+    assert_eq!(
+        json["data"]["content"]["update"]["content"][0]["content"]["text"]
+            .as_str()
+            .unwrap(),
+        large_output
+    );
+}
+
+#[tokio::test]
+async fn t8_2d_get_message_requires_auth() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+    let conv_id = create_conversation(&mut app, &token, &csrf, "Tool Detail Auth Conv").await;
+
+    let resp = app
+        .oneshot(get_request(&format!(
+            "/api/conversations/{conv_id}/messages/tool-detail"
+        )))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn t8_2e_get_message_not_found_returns_specific_error() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+    let conv_id = create_conversation(&mut app, &token, &csrf, "Tool Detail Missing Conv").await;
+
+    let resp = app
+        .oneshot(get_with_token(
+            &format!("/api/conversations/{conv_id}/messages/missing-message"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let json = body_json(resp).await;
+
+    assert_eq!(json["code"], "NOT_FOUND");
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("Message missing-message not found")
+    );
+}
+
+#[tokio::test]
+async fn t8_2f_get_message_does_not_leak_cross_user_conversation() {
+    let (mut app, services) = build_app().await;
+    let (owner_token, owner_csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+    let owner_conv_id = create_conversation(&mut app, &owner_token, &owner_csrf, "Owner Tool Conv").await;
+    insert_acp_tool_message(&services, &owner_conv_id, "owner-tool", "private output", 1000).await;
+
+    let (other_token, _other_csrf) = setup_and_login(&mut app, &services, "other-user", "StrongP@ss2").await;
+
+    let resp = app
+        .oneshot(get_with_token(
+            &format!("/api/conversations/{owner_conv_id}/messages/owner-tool"),
+            &other_token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let json = body_json(resp).await;
+
+    assert_eq!(json["code"], "NOT_FOUND");
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains(&format!("Conversation {owner_conv_id} not found"))
+    );
+    assert!(!json["error"].as_str().unwrap().contains("owner-tool"));
+    assert!(!json["error"].as_str().unwrap().contains("private output"));
 }
 
 #[tokio::test]

--- a/crates/aionui-conversation/src/convert.rs
+++ b/crates/aionui-conversation/src/convert.rs
@@ -8,6 +8,9 @@ use aionui_common::{
 use aionui_db::MessageSearchRow;
 use aionui_db::models::{ConversationArtifactRow, ConversationRow, MessageRow};
 
+const TOOL_CONTENT_COMPACT_THRESHOLD_BYTES: usize = 64 * 1024;
+const TOOL_CONTENT_PREVIEW_CHARS: usize = 4096;
+
 /// Convert a database row into an API response DTO.
 ///
 /// Parses string enum fields and JSON text fields back into typed values.
@@ -149,6 +152,58 @@ pub fn row_to_message_response(row: MessageRow) -> Result<MessageResponse, AppEr
         hidden: row.hidden,
         created_at: row.created_at,
     })
+}
+
+/// Convert a message row for history-list use, compacting oversized tool payloads.
+pub fn row_to_message_response_compact(row: MessageRow) -> Result<MessageResponse, AppError> {
+    let original_size = row.content.len();
+    let mut response = row_to_message_response(row)?;
+    if !is_tool_message(response.r#type) || original_size <= TOOL_CONTENT_COMPACT_THRESHOLD_BYTES {
+        return Ok(response);
+    }
+
+    let mut truncated = false;
+    truncate_large_strings(&mut response.content, TOOL_CONTENT_PREVIEW_CHARS, &mut truncated);
+    if truncated && let Some(obj) = response.content.as_object_mut() {
+        obj.insert(
+            "_compact".to_string(),
+            serde_json::json!({
+                "truncated": true,
+                "original_size": original_size,
+                "preview_chars": TOOL_CONTENT_PREVIEW_CHARS
+            }),
+        );
+    }
+
+    Ok(response)
+}
+
+fn is_tool_message(msg_type: MessageType) -> bool {
+    matches!(
+        msg_type,
+        MessageType::ToolCall | MessageType::ToolGroup | MessageType::AcpToolCall
+    )
+}
+
+fn truncate_large_strings(value: &mut serde_json::Value, max_chars: usize, truncated: &mut bool) {
+    match value {
+        serde_json::Value::String(text) if text.chars().count() > max_chars => {
+            let preview: String = text.chars().take(max_chars).collect();
+            *text = format!("{preview}\n...[truncated]");
+            *truncated = true;
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                truncate_large_strings(item, max_chars, truncated);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for entry in map.values_mut() {
+                truncate_large_strings(entry, max_chars, truncated);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Convert an artifact database row into an API response DTO.

--- a/crates/aionui-conversation/src/convert.rs
+++ b/crates/aionui-conversation/src/convert.rs
@@ -8,7 +8,7 @@ use aionui_common::{
 use aionui_db::MessageSearchRow;
 use aionui_db::models::{ConversationArtifactRow, ConversationRow, MessageRow};
 
-const TOOL_CONTENT_COMPACT_THRESHOLD_BYTES: usize = 64 * 1024;
+pub(crate) const TOOL_CONTENT_COMPACT_THRESHOLD_BYTES: usize = 64 * 1024;
 const TOOL_CONTENT_PREVIEW_CHARS: usize = 4096;
 
 /// Convert a database row into an API response DTO.

--- a/crates/aionui-conversation/src/routes.rs
+++ b/crates/aionui-conversation/src/routes.rs
@@ -8,8 +8,8 @@ use aionui_api_types::{
     ActiveCountResponse, ApiResponse, ApprovalCheckQuery, ApprovalCheckResponse, CloneConversationRequest,
     ConfirmRequest, ConfirmationListResponse, ConversationArtifactListResponse, ConversationArtifactResponse,
     ConversationListResponse, ConversationResponse, CreateConversationRequest, ListConversationsQuery,
-    ListMessagesQuery, MessageListResponse, MessageSearchResponse, SearchMessagesQuery, SendMessageRequest,
-    SendMessageResponse, UpdateConversationArtifactRequest, UpdateConversationRequest,
+    ListMessagesQuery, MessageListResponse, MessageResponse, MessageSearchResponse, SearchMessagesQuery,
+    SendMessageRequest, SendMessageResponse, UpdateConversationArtifactRequest, UpdateConversationRequest,
 };
 use aionui_auth::CurrentUser;
 use aionui_common::AppError;
@@ -26,6 +26,7 @@ pub fn conversation_routes(state: ConversationRouterState) -> Router {
         .route("/api/conversations/{id}/reset", post(reset))
         .route("/api/conversations/{id}/associated", get(associated))
         .route("/api/conversations/{id}/messages", get(list_msg).post(send_msg))
+        .route("/api/conversations/{id}/messages/{messageId}", get(get_msg))
         .route("/api/conversations/{id}/artifacts", get(list_artifacts))
         .route("/api/conversations/{id}/artifacts/{artifactId}", patch(update_artifact))
         .route("/api/conversations/{id}/cancel", post(cancel))
@@ -125,6 +126,25 @@ async fn list_msg(
     Query(query): Query<ListMessagesQuery>,
 ) -> Result<Json<ApiResponse<MessageListResponse>>, AppError> {
     let result = state.service.list_messages(&user.id, &id, query).await?;
+    Ok(Json(ApiResponse::ok(result)))
+}
+
+#[derive(serde::Deserialize)]
+struct MessagePathParams {
+    id: String,
+    #[serde(rename = "messageId")]
+    message_id: String,
+}
+
+async fn get_msg(
+    State(state): State<ConversationRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    Path(params): Path<MessagePathParams>,
+) -> Result<Json<ApiResponse<MessageResponse>>, AppError> {
+    let result = state
+        .service
+        .get_message(&user.id, &params.id, &params.message_id)
+        .await?;
     Ok(Json(ApiResponse::ok(result)))
 }
 

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -25,8 +25,8 @@ use aionui_realtime::EventBroadcaster;
 use tracing::{debug, error, info, warn};
 
 use crate::convert::{
-    row_to_artifact_response, row_to_message_response, row_to_response, row_to_response_with_extra, search_row_to_item,
-    string_to_enum,
+    row_to_artifact_response, row_to_message_response, row_to_message_response_compact, row_to_response,
+    row_to_response_with_extra, search_row_to_item, string_to_enum,
 };
 use crate::skill_resolver::SkillResolver;
 use crate::skill_snapshot::{backfill_skills_if_missing, compute_initial_skills};
@@ -734,6 +734,7 @@ impl ConversationService {
             Some("DESC" | "desc") => SortOrder::Desc,
             _ => SortOrder::Asc,
         };
+        let compact_content = matches!(query.content_mode.as_deref(), Some("compact"));
 
         let result = self
             .conversation_repo
@@ -743,7 +744,13 @@ impl ConversationService {
         let items: Vec<MessageResponse> = result
             .items
             .into_iter()
-            .map(row_to_message_response)
+            .map(|row| {
+                if compact_content {
+                    row_to_message_response_compact(row)
+                } else {
+                    row_to_message_response(row)
+                }
+            })
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(PaginatedResult {
@@ -751,6 +758,28 @@ impl ConversationService {
             total: result.total,
             has_more: result.has_more,
         })
+    }
+
+    /// Return one full message for a conversation after verifying ownership.
+    pub async fn get_message(
+        &self,
+        user_id: &str,
+        conversation_id: &str,
+        message_id: &str,
+    ) -> Result<MessageResponse, AppError> {
+        self.conversation_repo
+            .get(conversation_id)
+            .await?
+            .filter(|r| r.user_id == user_id)
+            .ok_or_else(|| AppError::NotFound(format!("Conversation {conversation_id} not found")))?;
+
+        let row = self
+            .conversation_repo
+            .get_message(conversation_id, message_id)
+            .await?
+            .ok_or_else(|| AppError::NotFound(format!("Message {message_id} not found")))?;
+
+        row_to_message_response(row)
     }
 
     /// List artifacts for a conversation with durable status state.

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -13,8 +13,8 @@ use aionui_api_types::{
     WebSocketMessage,
 };
 use aionui_common::{
-    AgentType, AppError, ConversationSource, ConversationStatus, ErrorChain, OnConversationDelete, PaginatedResult,
-    generate_short_id, now_ms,
+    AgentType, AppError, ConversationSource, ConversationStatus, ErrorChain, MessageType, OnConversationDelete,
+    PaginatedResult, generate_short_id, now_ms,
 };
 use aionui_db::models::MessageRow;
 use aionui_db::{
@@ -25,8 +25,8 @@ use aionui_realtime::EventBroadcaster;
 use tracing::{debug, error, info, warn};
 
 use crate::convert::{
-    row_to_artifact_response, row_to_message_response, row_to_message_response_compact, row_to_response,
-    row_to_response_with_extra, search_row_to_item, string_to_enum,
+    TOOL_CONTENT_COMPACT_THRESHOLD_BYTES, row_to_artifact_response, row_to_message_response,
+    row_to_message_response_compact, row_to_response, row_to_response_with_extra, search_row_to_item, string_to_enum,
 };
 use crate::skill_resolver::SkillResolver;
 use crate::skill_snapshot::{backfill_skills_if_missing, compute_initial_skills};
@@ -741,17 +741,48 @@ impl ConversationService {
             .get_messages(conversation_id, page, page_size, order)
             .await?;
 
-        let items: Vec<MessageResponse> = result
-            .items
-            .into_iter()
-            .map(|row| {
-                if compact_content {
-                    row_to_message_response_compact(row)
-                } else {
-                    row_to_message_response(row)
+        let mut compacted_count = 0usize;
+        let mut total_original_content_bytes = 0usize;
+        let mut total_response_content_bytes = 0usize;
+        let mut items = Vec::with_capacity(result.items.len());
+        for row in result.items {
+            let original_content_bytes = row.content.len();
+            total_original_content_bytes += original_content_bytes;
+            let response = if compact_content {
+                row_to_message_response_compact(row)?
+            } else {
+                row_to_message_response(row)?
+            };
+
+            if compact_content {
+                if response
+                    .content
+                    .get("_compact")
+                    .and_then(|compact| compact.get("truncated"))
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false)
+                {
+                    compacted_count += 1;
                 }
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+                total_response_content_bytes += response.content.to_string().len();
+            }
+            items.push(response);
+        }
+
+        if compact_content && compacted_count > 0 {
+            info!(
+                conversation_id,
+                page,
+                page_size,
+                order = ?order,
+                items = items.len(),
+                total = result.total,
+                compacted = compacted_count,
+                total_original_content_bytes,
+                total_response_content_bytes,
+                "Compacted tool message list response"
+            );
+        }
 
         Ok(PaginatedResult {
             items,
@@ -779,7 +810,19 @@ impl ConversationService {
             .await?
             .ok_or_else(|| AppError::NotFound(format!("Message {message_id} not found")))?;
 
-        row_to_message_response(row)
+        let content_bytes = row.content.len();
+        let response = row_to_message_response(row)?;
+        if is_tool_message_type(response.r#type) || content_bytes > TOOL_CONTENT_COMPACT_THRESHOLD_BYTES {
+            info!(
+                conversation_id,
+                message_id,
+                message_type = ?response.r#type,
+                content_bytes,
+                "Loaded full message content"
+            );
+        }
+
+        Ok(response)
     }
 
     /// List artifacts for a conversation with durable status state.
@@ -1627,6 +1670,13 @@ fn log_conversation_created(response: &ConversationResponse, extra: &serde_json:
             "Conversation created (no assistant)"
         );
     }
+}
+
+fn is_tool_message_type(message_type: MessageType) -> bool {
+    matches!(
+        message_type,
+        MessageType::ToolCall | MessageType::ToolGroup | MessageType::AcpToolCall
+    )
 }
 
 #[cfg(test)]

--- a/crates/aionui-conversation/tests/conversation_extended.rs
+++ b/crates/aionui-conversation/tests/conversation_extended.rs
@@ -137,6 +137,35 @@ fn make_message(conv_id: &str, content: &str, offset_ms: i64) -> MessageRow {
     }
 }
 
+fn make_acp_tool_message(conv_id: &str, id: &str, output: &str, offset_ms: i64) -> MessageRow {
+    MessageRow {
+        id: id.to_string(),
+        conversation_id: conv_id.to_string(),
+        msg_id: Some(id.to_string()),
+        r#type: "acp_tool_call".to_string(),
+        content: json!({
+            "session_id": "session-1",
+            "update": {
+                "session_update": "tool_call",
+                "tool_call_id": id,
+                "status": "completed",
+                "title": "rg",
+                "kind": "search",
+                "raw_input": { "pattern": "needle", "path": "." },
+                "content": [{
+                    "type": "content",
+                    "content": { "type": "text", "text": output }
+                }]
+            }
+        })
+        .to_string(),
+        position: Some("left".to_string()),
+        status: Some("finish".to_string()),
+        hidden: false,
+        created_at: now_ms() + offset_ms,
+    }
+}
+
 // ── T6: Clone conversation ─────────────────────────────────────────
 
 #[tokio::test]
@@ -222,6 +251,7 @@ async fn t8_2_pagination() {
         page: Some(1),
         page_size: Some(3),
         order: None,
+        content_mode: None,
     };
     let result = svc.list_messages(USER_ID, &conv.id, query).await.unwrap();
     assert_eq!(result.items.len(), 3);
@@ -280,6 +310,81 @@ async fn t8_5_conversation_not_found() {
 }
 
 // ── T9: Message search ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn t8_6_compact_mode_truncates_large_tool_content_only_for_list_response() {
+    let (svc, repo, _b) = setup().await;
+    let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
+    let large_output = "match line\n".repeat(10_000);
+
+    repo.insert_message(&make_acp_tool_message(&conv.id, "tool-big", &large_output, 0))
+        .await
+        .unwrap();
+
+    let full = svc
+        .list_messages(USER_ID, &conv.id, ListMessagesQuery::default())
+        .await
+        .unwrap();
+    assert_eq!(
+        full.items[0].content["update"]["content"][0]["content"]["text"]
+            .as_str()
+            .unwrap(),
+        large_output
+    );
+
+    let compact = svc
+        .list_messages(
+            USER_ID,
+            &conv.id,
+            ListMessagesQuery {
+                content_mode: Some("compact".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let compact_content = &compact.items[0].content;
+    let preview = compact_content["update"]["content"][0]["content"]["text"]
+        .as_str()
+        .unwrap();
+
+    assert!(compact_content["_compact"]["truncated"].as_bool().unwrap());
+    assert!(compact_content["_compact"]["original_size"].as_u64().unwrap() > preview.len() as u64);
+    assert!(preview.len() < large_output.len());
+    assert!(!preview.contains(&large_output));
+}
+
+#[tokio::test]
+async fn t8_7_get_message_returns_full_tool_content_after_compact_list() {
+    let (svc, repo, _b) = setup().await;
+    let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
+    let large_output = "wide rg output\n".repeat(10_000);
+
+    repo.insert_message(&make_acp_tool_message(&conv.id, "tool-detail", &large_output, 0))
+        .await
+        .unwrap();
+
+    let _ = svc
+        .list_messages(
+            USER_ID,
+            &conv.id,
+            ListMessagesQuery {
+                content_mode: Some("compact".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let detail = svc.get_message(USER_ID, &conv.id, "tool-detail").await.unwrap();
+
+    assert_eq!(
+        detail.content["update"]["content"][0]["content"]["text"]
+            .as_str()
+            .unwrap(),
+        large_output
+    );
+}
 
 #[tokio::test]
 async fn t9_1_keyword_match() {

--- a/crates/aionui-db/src/repository/conversation.rs
+++ b/crates/aionui-db/src/repository/conversation.rs
@@ -64,6 +64,11 @@ pub trait IConversationRepository: Send + Sync {
         order: SortOrder,
     ) -> Result<PaginatedResult<MessageRow>, DbError>;
 
+    /// Returns a single message scoped to a conversation.
+    async fn get_message(&self, _conv_id: &str, _message_id: &str) -> Result<Option<MessageRow>, DbError> {
+        Ok(None)
+    }
+
     /// Inserts a new message row.
     async fn insert_message(&self, message: &MessageRow) -> Result<(), DbError>;
 

--- a/crates/aionui-db/src/repository/sqlite_conversation.rs
+++ b/crates/aionui-db/src/repository/sqlite_conversation.rs
@@ -321,6 +321,21 @@ impl IConversationRepository for SqliteConversationRepository {
         })
     }
 
+    async fn get_message(&self, conv_id: &str, message_id: &str) -> Result<Option<MessageRow>, DbError> {
+        let row = sqlx::query_as::<_, MessageRow>(
+            "SELECT * FROM messages \
+             WHERE conversation_id = ? \
+               AND id = ? \
+               AND type NOT IN ('cron_trigger', 'skill_suggest')",
+        )
+        .bind(conv_id)
+        .bind(message_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
     async fn insert_message(&self, message: &MessageRow) -> Result<(), DbError> {
         sqlx::query(
             "INSERT INTO messages \


### PR DESCRIPTION
## Summary
- Add compact history response mode for oversized tool messages.
- Add a full single-message endpoint for lazy detail loading.
- Log compact-list and full-detail metadata for production diagnosis.

## Test Plan
- cargo fmt --all -- --check
- cargo clippy -p aionui-conversation -p aionui-app -- -D warnings
- cargo test -p aionui-conversation t8_6_compact_mode_truncates_large_tool_content_only_for_list_response -- --nocapture
- cargo test -p aionui-app t8_2 --test message_e2e -- --nocapture
- just push -u origin feat/tool-message-compact
