### PR TITLE
fix(agent): add provider health check probe

### DIFF
--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -177,7 +177,7 @@ pub(super) async fn build(
 /// Mirrors the frontend `src/process/agent/aionrs/envBuilder.ts` mapping.
 /// For `new-api` platform, per-model protocol overrides from `model_protocols`
 /// JSON take precedence.
-fn map_aionrs_provider(platform: &str, model_id: &str, model_protocols: Option<&str>) -> String {
+pub(crate) fn map_aionrs_provider(platform: &str, model_id: &str, model_protocols: Option<&str>) -> String {
     if platform == "new-api"
         && let Some(protocols_json) = model_protocols
         && let Ok(map) = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(protocols_json)
@@ -202,7 +202,7 @@ fn map_aionrs_provider(platform: &str, model_id: &str, model_protocols: Option<&
 /// - Strips trailing `/v1` from base_url (aionrs appends its own path)
 /// - Gemini: prepends `/v1beta/openai` and overrides `api_path`
 /// - OpenAI official (`api.openai.com`): sets `max_completion_tokens`
-fn resolve_aionrs_url_and_compat(
+pub(crate) fn resolve_aionrs_url_and_compat(
     platform: &str,
     raw_base_url: &str,
     mapped_provider: &str,
@@ -249,7 +249,7 @@ fn normalize_aionrs_base_url(url: &str) -> String {
     trimmed.strip_suffix("/v1").unwrap_or(trimmed).to_owned()
 }
 
-fn resolve_bedrock_config(json: Option<&str>) -> Option<aion_config::config::BedrockConfig> {
+pub(crate) fn resolve_bedrock_config(json: Option<&str>) -> Option<aion_config::config::BedrockConfig> {
     let bc: aionui_api_types::BedrockConfig = serde_json::from_str(json?).ok()?;
     Some(aion_config::config::BedrockConfig {
         region: Some(bc.region),

--- a/crates/aionui-ai-agent/src/factory/mod.rs
+++ b/crates/aionui-ai-agent/src/factory/mod.rs
@@ -1,7 +1,7 @@
 pub mod acp_assembler;
 
 mod acp;
-mod aionrs;
+pub(crate) mod aionrs;
 mod context;
 mod nanobot;
 mod openclaw;

--- a/crates/aionui-ai-agent/src/routes/agent.rs
+++ b/crates/aionui-ai-agent/src/routes/agent.rs
@@ -13,7 +13,8 @@ use axum::routing::{get, patch, post, put};
 
 use aionui_api_types::{
     AcpHealthCheckRequest, AcpHealthCheckResponse, AgentMetadata, ApiResponse, CustomAgentUpsertRequest,
-    DeleteCustomAgentResponse, SetEnabledRequest, TryConnectCustomAgentRequest, TryConnectCustomAgentResponse,
+    DeleteCustomAgentResponse, ProviderHealthCheckRequest, ProviderHealthCheckResponse, SetEnabledRequest,
+    TryConnectCustomAgentRequest, TryConnectCustomAgentResponse,
 };
 use aionui_auth::CurrentUser;
 use aionui_common::AppError;
@@ -25,6 +26,7 @@ pub fn agent_routes(state: AgentRouterState) -> Router {
         .route("/api/agents", get(list_agents))
         .route("/api/agents/refresh", post(refresh_agents))
         .route("/api/agents/health-check", post(health_check))
+        .route("/api/agents/provider-health-check", post(provider_health_check))
         .route("/api/agents/{id}/enabled", patch(set_agent_enabled))
         .route("/api/agents/custom", post(create_custom))
         .route("/api/agents/custom/{id}", put(update_custom).delete(delete_custom))
@@ -53,6 +55,15 @@ async fn health_check(
 ) -> Result<Json<ApiResponse<AcpHealthCheckResponse>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
     Ok(Json(ApiResponse::ok(state.service.acp_health_check(req).await?)))
+}
+
+async fn provider_health_check(
+    State(state): State<AgentRouterState>,
+    Extension(_user): Extension<CurrentUser>,
+    body: Result<Json<ProviderHealthCheckRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<ProviderHealthCheckResponse>>, AppError> {
+    let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
+    Ok(Json(ApiResponse::ok(state.service.provider_health_check(req).await?)))
 }
 
 async fn try_connect_custom(

--- a/crates/aionui-ai-agent/src/services/agent.rs
+++ b/crates/aionui-ai-agent/src/services/agent.rs
@@ -15,19 +15,35 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use aionui_api_types::{AcpHealthCheckRequest, AcpHealthCheckResponse, AgentMetadata};
+use aionui_api_types::{
+    AcpHealthCheckRequest, AcpHealthCheckResponse, AgentMetadata, ProviderHealthCheckRequest,
+    ProviderHealthCheckResponse,
+};
 use aionui_common::AppError;
+use aionui_db::IProviderRepository;
 
+use super::provider_health::ProviderHealthCheckService;
 use crate::registry::AgentRegistry;
 
 pub struct AgentService {
     registry: Arc<AgentRegistry>,
     data_dir: PathBuf,
+    provider_health: ProviderHealthCheckService,
 }
 
 impl AgentService {
-    pub fn new(registry: Arc<AgentRegistry>, data_dir: PathBuf) -> Arc<Self> {
-        Arc::new(Self { registry, data_dir })
+    pub fn new(
+        registry: Arc<AgentRegistry>,
+        provider_repo: Arc<dyn IProviderRepository>,
+        encryption_key: [u8; 32],
+        data_dir: PathBuf,
+    ) -> Arc<Self> {
+        let provider_health = ProviderHealthCheckService::new(provider_repo, encryption_key, data_dir.clone());
+        Arc::new(Self {
+            registry,
+            data_dir,
+            provider_health,
+        })
     }
 
     /// Data directory used by the custom-agent probe to spawn CLI
@@ -56,5 +72,12 @@ impl AgentService {
 
     pub async fn acp_health_check(&self, req: AcpHealthCheckRequest) -> Result<AcpHealthCheckResponse, AppError> {
         Ok(crate::protocol::cli_detect::health_check(&self.registry, &req.backend).await)
+    }
+
+    pub async fn provider_health_check(
+        &self,
+        req: ProviderHealthCheckRequest,
+    ) -> Result<ProviderHealthCheckResponse, AppError> {
+        self.provider_health.health_check(req).await
     }
 }

--- a/crates/aionui-ai-agent/src/services/mod.rs
+++ b/crates/aionui-ai-agent/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod custom;
+pub mod provider_health;
 pub mod remote;
 
 pub use agent::AgentService;

--- a/crates/aionui-ai-agent/src/services/provider_health.rs
+++ b/crates/aionui-ai-agent/src/services/provider_health.rs
@@ -262,6 +262,13 @@ pub(crate) fn classify_error(message: &str, is_timeout: bool) -> ProviderHealthC
     {
         return ProviderHealthCheckErrorKind::InsufficientQuota;
     }
+    if lower.contains("aws credential")
+        || lower.contains("loading credentials")
+        || lower.contains("invalid refresh token")
+        || lower.contains("session token not found")
+    {
+        return ProviderHealthCheckErrorKind::AwsCredentials;
+    }
     if lower.contains("api error 401") || lower.contains("unauthorized") || lower.contains("invalid api key") {
         return ProviderHealthCheckErrorKind::Unauthorized;
     }
@@ -313,6 +320,24 @@ mod tests {
                 false
             ),
             ProviderHealthCheckErrorKind::InvalidAuthorizationHeader
+        );
+    }
+
+    #[test]
+    fn classify_error_detects_aws_credentials() {
+        assert_eq!(
+            classify_error(
+                "Provider error: Connection error: AWS credential error: an error occurred while loading credentials",
+                false
+            ),
+            ProviderHealthCheckErrorKind::AwsCredentials
+        );
+        assert_eq!(
+            classify_error(
+                "service error: UnauthorizedException: Session token not found or invalid",
+                false
+            ),
+            ProviderHealthCheckErrorKind::AwsCredentials
         );
     }
 

--- a/crates/aionui-ai-agent/src/services/provider_health.rs
+++ b/crates/aionui-ai-agent/src/services/provider_health.rs
@@ -1,0 +1,326 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aion_agent::bootstrap::AgentBootstrap;
+use aion_agent::engine::AgentEngine;
+use aion_agent::output::OutputSink;
+use aion_agent::output::null_sink::NullSink;
+use aion_config::config::{CliArgs, Config};
+use aionui_api_types::{
+    HealthStatus, ProviderHealthCheckErrorKind, ProviderHealthCheckRequest, ProviderHealthCheckResponse,
+};
+use aionui_common::AppError;
+use aionui_db::{IProviderRepository, models::Provider};
+use regex::Regex;
+use tracing::{info, warn};
+
+use crate::factory::aionrs::{map_aionrs_provider, resolve_aionrs_url_and_compat, resolve_bedrock_config};
+use crate::types::AionrsResolvedConfig;
+
+const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(30);
+const HEALTH_CHECK_PROMPT: &str = "Reply with exactly OK.";
+const HEALTH_CHECK_MSG_ID: &str = "provider-health-check";
+
+pub struct ProviderHealthCheckService {
+    provider_repo: Arc<dyn IProviderRepository>,
+    encryption_key: [u8; 32],
+    data_dir: PathBuf,
+}
+
+impl ProviderHealthCheckService {
+    pub fn new(provider_repo: Arc<dyn IProviderRepository>, encryption_key: [u8; 32], data_dir: PathBuf) -> Self {
+        Self {
+            provider_repo,
+            encryption_key,
+            data_dir,
+        }
+    }
+
+    pub async fn health_check(&self, req: ProviderHealthCheckRequest) -> Result<ProviderHealthCheckResponse, AppError> {
+        if req.provider_id.trim().is_empty() {
+            return Err(AppError::BadRequest("provider_id is required".into()));
+        }
+        if req.model.trim().is_empty() {
+            return Err(AppError::BadRequest("model is required".into()));
+        }
+
+        let provider_id = req.provider_id.trim();
+        let model = req.model.trim();
+        let row = self
+            .provider_repo
+            .find_by_id(provider_id)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to load provider config: {e}")))?
+            .ok_or_else(|| AppError::BadRequest(format!("Provider '{provider_id}' not found")))?;
+
+        let config = self.resolve_probe_config(&row, model)?;
+        run_probe(row.id, row.platform, config).await
+    }
+
+    fn resolve_probe_config(&self, row: &Provider, model_id: &str) -> Result<AionrsResolvedConfig, AppError> {
+        let api_key = aionui_common::decrypt_string(&row.api_key_encrypted, &self.encryption_key)?;
+        let provider = map_aionrs_provider(&row.platform, model_id, row.model_protocols.as_deref());
+        let (base_url, compat_overrides) =
+            resolve_aionrs_url_and_compat(&row.platform, &row.base_url, &provider, row.is_full_url);
+        let bedrock_config = if row.platform == "bedrock" {
+            resolve_bedrock_config(row.bedrock_config.as_deref())
+        } else {
+            None
+        };
+
+        Ok(AionrsResolvedConfig {
+            provider,
+            api_key,
+            model: model_id.to_owned(),
+            base_url,
+            system_prompt: Some("You are a provider health probe. Reply with exactly OK and do not use tools.".into()),
+            max_tokens: 16,
+            max_turns: Some(1),
+            compat_overrides,
+            session_directory: self.data_dir.join("aionrs-health-check-sessions"),
+            session_mode: None,
+            extra_mcp_servers: HashMap::new(),
+            bedrock_config,
+        })
+    }
+}
+
+async fn run_probe(
+    provider_id: String,
+    platform: String,
+    config_extra: AionrsResolvedConfig,
+) -> Result<ProviderHealthCheckResponse, AppError> {
+    let started = Instant::now();
+    let model = config_extra.model.clone();
+
+    info!(
+        provider_id = %provider_id,
+        platform = %platform,
+        model = %model,
+        "Provider health check started"
+    );
+
+    let mut engine = match build_probe_engine(config_extra).await {
+        Ok(engine) => engine,
+        Err(error) => {
+            let message = format!("Aionrs probe bootstrap failed: {error}");
+            let response = unhealthy_response(provider_id, platform, model, started.elapsed(), message, None);
+            log_health_check_result(&response);
+            return Ok(response);
+        }
+    };
+
+    match tokio::time::timeout(
+        HEALTH_CHECK_TIMEOUT,
+        engine.run(HEALTH_CHECK_PROMPT, HEALTH_CHECK_MSG_ID),
+    )
+    .await
+    {
+        Ok(Ok(_)) => {
+            let response = ProviderHealthCheckResponse {
+                provider_id,
+                platform,
+                model,
+                status: HealthStatus::Healthy,
+                elapsed_ms: elapsed_ms(started.elapsed()),
+                message: None,
+                error_kind: None,
+                http_status: None,
+                timeout_stage: None,
+            };
+            log_health_check_result(&response);
+            Ok(response)
+        }
+        Ok(Err(error)) => {
+            let message = error.to_string();
+            let response = unhealthy_response(provider_id, platform, model, started.elapsed(), message, None);
+            log_health_check_result(&response);
+            Ok(response)
+        }
+        Err(_) => {
+            let response = unhealthy_response(
+                provider_id,
+                platform,
+                model,
+                started.elapsed(),
+                format!("Health check timeout ({}s)", HEALTH_CHECK_TIMEOUT.as_secs()),
+                Some("engine_run".into()),
+            );
+            log_health_check_result(&response);
+            Ok(response)
+        }
+    }
+}
+
+fn log_health_check_result(response: &ProviderHealthCheckResponse) {
+    match response.status {
+        HealthStatus::Healthy => info!(
+            provider_id = %response.provider_id,
+            platform = %response.platform,
+            model = %response.model,
+            elapsed_ms = response.elapsed_ms,
+            "Provider health check succeeded"
+        ),
+        HealthStatus::Unhealthy | HealthStatus::Unknown => warn!(
+            provider_id = %response.provider_id,
+            platform = %response.platform,
+            model = %response.model,
+            elapsed_ms = response.elapsed_ms,
+            error_kind = ?response.error_kind,
+            http_status = ?response.http_status,
+            timeout_stage = ?response.timeout_stage,
+            "Provider health check failed"
+        ),
+    }
+}
+
+async fn build_probe_engine(config_extra: AionrsResolvedConfig) -> Result<AgentEngine, AppError> {
+    let workspace = config_extra
+        .session_directory
+        .parent()
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let sink: Arc<dyn OutputSink> = Arc::new(NullSink);
+    let cli_args = CliArgs {
+        provider: Some(config_extra.provider),
+        api_key: Some(config_extra.api_key),
+        base_url: config_extra.base_url,
+        model: Some(config_extra.model),
+        max_tokens: Some(config_extra.max_tokens),
+        max_turns: config_extra.max_turns,
+        system_prompt: config_extra.system_prompt,
+        profile: None,
+        auto_approve: false,
+        project_dir: Some(PathBuf::from(&workspace)),
+    };
+    let mut config =
+        Config::resolve(&cli_args).map_err(|error| AppError::Internal(format!("Config resolve failed: {error}")))?;
+
+    config.bedrock = config_extra.bedrock_config;
+    config.session.enabled = false;
+    config.mcp.servers.clear();
+    config.file_cache.enabled = false;
+    if let Some(field) = config_extra.compat_overrides.max_tokens_field {
+        config.compat.max_tokens_field = Some(field);
+    }
+    if let Some(path) = config_extra.compat_overrides.api_path {
+        config.compat.api_path = Some(path);
+    }
+
+    AgentBootstrap::new(config, workspace, sink)
+        .build()
+        .await
+        .map(|result| result.engine)
+        .map_err(|error| AppError::Internal(error.to_string()))
+}
+
+fn unhealthy_response(
+    provider_id: String,
+    platform: String,
+    model: String,
+    elapsed: Duration,
+    message: String,
+    timeout_stage: Option<String>,
+) -> ProviderHealthCheckResponse {
+    let error_kind = classify_error(&message, timeout_stage.is_some());
+    let http_status = extract_http_status(&message);
+    ProviderHealthCheckResponse {
+        provider_id,
+        platform,
+        model,
+        status: HealthStatus::Unhealthy,
+        elapsed_ms: elapsed_ms(elapsed),
+        message: Some(message),
+        error_kind: Some(error_kind),
+        http_status,
+        timeout_stage,
+    }
+}
+
+fn elapsed_ms(duration: Duration) -> u64 {
+    duration.as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+pub(crate) fn classify_error(message: &str, is_timeout: bool) -> ProviderHealthCheckErrorKind {
+    if is_timeout {
+        return ProviderHealthCheckErrorKind::Timeout;
+    }
+
+    let lower = message.to_lowercase();
+    if lower.contains("invalid authorization header") || lower.contains("invalid x-api-key header") {
+        return ProviderHealthCheckErrorKind::InvalidAuthorizationHeader;
+    }
+    if lower.contains("rate limited") || lower.contains(" 429") || lower.contains("api error 429") {
+        return ProviderHealthCheckErrorKind::RateLimited;
+    }
+    if lower.contains("insufficient_quota")
+        || lower.contains("insufficient quota")
+        || lower.contains("credit balance is too low")
+        || lower.contains("billing")
+    {
+        return ProviderHealthCheckErrorKind::InsufficientQuota;
+    }
+    if lower.contains("api error 401") || lower.contains("unauthorized") || lower.contains("invalid api key") {
+        return ProviderHealthCheckErrorKind::Unauthorized;
+    }
+    if lower.contains("api error 403") || lower.contains("forbidden") {
+        return ProviderHealthCheckErrorKind::Forbidden;
+    }
+    if lower.contains("api error 404") || lower.contains("not found") {
+        return ProviderHealthCheckErrorKind::NotFound;
+    }
+    if lower.contains("api error 400") || lower.contains("invalid_request") || lower.contains("invalid request") {
+        return ProviderHealthCheckErrorKind::InvalidRequest;
+    }
+    if lower.contains("connection error") || lower.contains("http error") {
+        return ProviderHealthCheckErrorKind::ConnectionError;
+    }
+    if lower.contains("api error") || lower.contains("provider error") {
+        return ProviderHealthCheckErrorKind::ApiError;
+    }
+
+    ProviderHealthCheckErrorKind::Unknown
+}
+
+pub(crate) fn extract_http_status(message: &str) -> Option<u16> {
+    let re = Regex::new(r"(?i)api error\s+(\d{3})").ok()?;
+    re.captures(message)
+        .and_then(|captures| captures.get(1))
+        .and_then(|matched| matched.as_str().parse().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_error_detects_quota_message() {
+        let message = r#"Provider error: API error 400: {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low"}}"#;
+        assert_eq!(
+            classify_error(message, false),
+            ProviderHealthCheckErrorKind::InsufficientQuota
+        );
+        assert_eq!(extract_http_status(message), Some(400));
+    }
+
+    #[test]
+    fn classify_error_detects_invalid_header() {
+        assert_eq!(
+            classify_error(
+                "Connection error: Invalid authorization header: invalid header value",
+                false
+            ),
+            ProviderHealthCheckErrorKind::InvalidAuthorizationHeader
+        );
+    }
+
+    #[test]
+    fn classify_error_detects_timeout() {
+        assert_eq!(
+            classify_error("Health check timeout (30s)", true),
+            ProviderHealthCheckErrorKind::Timeout
+        );
+    }
+}

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -102,8 +102,8 @@ pub use office::{
 pub use provider::{
     BedrockAuthMethod, BedrockConfig, CreateProviderRequest, DetectProtocolRequest, DetectionSuggestion,
     FetchModelsAnonymousRequest, FetchModelsRequest, FetchModelsResponse, HealthStatus, KeyTestResult, ModelCapability,
-    ModelHealthStatus, ModelInfo, ModelType, MultiKeyResult, ProtocolDetectionResponse, ProviderResponse,
-    SuggestionType, UpdateProviderRequest,
+    ModelHealthStatus, ModelInfo, ModelType, MultiKeyResult, ProtocolDetectionResponse, ProviderHealthCheckErrorKind,
+    ProviderHealthCheckRequest, ProviderHealthCheckResponse, ProviderResponse, SuggestionType, UpdateProviderRequest,
 };
 pub use remote_agent::{
     CreateRemoteAgentRequest, HandshakeResponse, RemoteAgentListItem, RemoteAgentResponse,

--- a/crates/aionui-api-types/src/provider.rs
+++ b/crates/aionui-api-types/src/provider.rs
@@ -60,6 +60,7 @@ pub enum ProviderHealthCheckErrorKind {
     Forbidden,
     NotFound,
     InsufficientQuota,
+    AwsCredentials,
     InvalidRequest,
     RateLimited,
     ConnectionError,

--- a/crates/aionui-api-types/src/provider.rs
+++ b/crates/aionui-api-types/src/provider.rs
@@ -50,6 +50,48 @@ pub struct ModelHealthStatus {
     pub error: Option<String>,
 }
 
+/// Coarse failure category for provider/model health checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderHealthCheckErrorKind {
+    Timeout,
+    InvalidAuthorizationHeader,
+    Unauthorized,
+    Forbidden,
+    NotFound,
+    InsufficientQuota,
+    InvalidRequest,
+    RateLimited,
+    ConnectionError,
+    ApiError,
+    Unknown,
+}
+
+/// Request body for `POST /api/agents/provider-health-check`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderHealthCheckRequest {
+    pub provider_id: String,
+    pub model: String,
+}
+
+/// Response body for `POST /api/agents/provider-health-check`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderHealthCheckResponse {
+    pub provider_id: String,
+    pub platform: String,
+    pub model: String,
+    pub status: HealthStatus,
+    pub elapsed_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<ProviderHealthCheckErrorKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub http_status: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_stage: Option<String>,
+}
+
 /// AWS Bedrock authentication method.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -883,5 +925,37 @@ mod tests {
         });
         let req: CreateProviderRequest = serde_json::from_value(raw).unwrap();
         assert!(!req.is_full_url);
+    }
+
+    #[test]
+    fn test_provider_health_check_request_serde() {
+        let raw = json!({
+            "provider_id": "anthropic",
+            "model": "claude-sonnet-4-20250514"
+        });
+        let req: ProviderHealthCheckRequest = serde_json::from_value(raw).unwrap();
+        assert_eq!(req.provider_id, "anthropic");
+        assert_eq!(req.model, "claude-sonnet-4-20250514");
+    }
+
+    #[test]
+    fn test_provider_health_check_response_serde() {
+        let resp = ProviderHealthCheckResponse {
+            provider_id: "anthropic".into(),
+            platform: "anthropic".into(),
+            model: "claude-sonnet-4-20250514".into(),
+            status: HealthStatus::Unhealthy,
+            elapsed_ms: 1234,
+            message: Some("API error 401: invalid key".into()),
+            error_kind: Some(ProviderHealthCheckErrorKind::Unauthorized),
+            http_status: Some(401),
+            timeout_stage: None,
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["provider_id"], "anthropic");
+        assert_eq!(json["status"], "unhealthy");
+        assert_eq!(json["error_kind"], "unauthorized");
+        assert_eq!(json["http_status"], 401);
+        assert!(json.get("timeout_stage").is_none());
     }
 }

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -145,7 +145,15 @@ pub async fn build_module_states(services: &AppServices) -> (ModuleStates, Chann
             .unwrap_or_else(|| std::path::PathBuf::from("aioncore")),
     );
 
-    let agent_service = AgentService::new(services.agent_registry.clone(), services.data_dir.clone());
+    let pool = services.database.pool().clone();
+    let provider_repo: Arc<dyn IProviderRepository> = Arc::new(SqliteProviderRepository::new(pool));
+    let encryption_key = derive_encryption_key(&services.jwt_secret_raw);
+    let agent_service = AgentService::new(
+        services.agent_registry.clone(),
+        provider_repo,
+        encryption_key,
+        services.data_dir.clone(),
+    );
 
     let states = ModuleStates {
         system: build_system_state(services),

--- a/crates/aionui-app/tests/agent_provider_health_e2e.rs
+++ b/crates/aionui-app/tests/agent_provider_health_e2e.rs
@@ -1,0 +1,75 @@
+//! Provider health-check route auth and validation tests.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::json;
+use tower::ServiceExt;
+
+use common::{body_json, build_app, json_with_token, setup_and_login};
+
+#[tokio::test]
+async fn provider_health_check_unauthenticated_is_rejected() {
+    let (app, _services) = build_app().await;
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/agents/provider-health-check")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::to_vec(&json!({"provider_id": "p1", "model": "gpt-4o"})).unwrap(),
+        ))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert!(
+        resp.status() == StatusCode::UNAUTHORIZED || resp.status() == StatusCode::FORBIDDEN,
+        "expected auth rejection, got {}",
+        resp.status()
+    );
+}
+
+#[tokio::test]
+async fn provider_health_check_requires_csrf_for_post() {
+    let (mut app, services) = build_app().await;
+    let (token, _csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/agents/provider-health-check")
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::from(
+            serde_json::to_vec(&json!({"provider_id": "p1", "model": "gpt-4o"})).unwrap(),
+        ))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn provider_health_check_validates_required_fields() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let req = json_with_token(
+        "POST",
+        "/api/agents/provider-health-check",
+        json!({"provider_id": "", "model": "gpt-4o"}),
+        &token,
+        &csrf,
+    );
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let json = body_json(resp).await;
+    assert_eq!(json["code"], "BAD_REQUEST");
+    assert!(
+        json["error"]
+            .as_str()
+            .is_some_and(|message| message.contains("provider_id is required")),
+        "expected provider_id validation error, got {json}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add an authenticated provider/model health probe endpoint backed by aionrs provider execution.
- Keep health probes out of conversation persistence and session state.
- Add structured health diagnostics and AWS credential error classification.

## Test plan

- [x] `MACOSX_DEPLOYMENT_TARGET=15.5 just push -u origin fix/model-health-probe`
