### PR TITLE
Sync Codex sandbox mode for full access

### DIFF
--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -44,6 +44,7 @@ pub(super) fn user_facing_message(err: &AppError) -> String {
     full.split_once(": ").map(|(_, rest)| rest.to_owned()).unwrap_or(full)
 }
 
+use super::codex_sandbox;
 use super::mode_normalize::normalize_requested_mode;
 
 /// Grace period before force-killing an ACP process (ms).
@@ -73,6 +74,26 @@ pub(super) fn exit_status_parts(exit: Option<std::process::ExitStatus>) -> (Opti
         }
     }
     (status.code(), None)
+}
+
+fn initial_mode_from_params(params: &AcpSessionParams) -> Option<ModeId> {
+    // Prefer the last-persisted mode; for brand-new conversations
+    // fall back to `AcpBuildExtra::session_mode` so the first turn
+    // still honours the caller's choice.
+    params
+        .session_snapshot
+        .as_ref()
+        .and_then(|s| s.current_mode_id.as_ref())
+        .map(|m| normalize_requested_mode(&params.metadata, m.as_str()))
+        .or_else(|| {
+            params
+                .config
+                .session_mode
+                .as_ref()
+                .map(|m| normalize_requested_mode(&params.metadata, m))
+        })
+        .filter(|m| !m.is_empty())
+        .map(ModeId::new)
 }
 
 fn confirm_option_id(data: &Value) -> Option<String> {
@@ -189,6 +210,9 @@ impl AcpAgentManager {
         ),
         AppError,
     > {
+        let initial_mode = initial_mode_from_params(&params);
+        codex_sandbox::sync_for_agent(&params.metadata, initial_mode.as_ref().map(|m| m.as_str())).await?;
+
         let process = CliAgentProcess::spawn_for_sdk(params.command_spec.clone(), &params.data_dir).await?;
         let (stdin, stdout) = process.take_stdio().await.ok_or_else(|| {
             error!(conversation_id = %params.conversation_id, "Failed to take stdio from CLI process");
@@ -237,22 +261,7 @@ impl AcpAgentManager {
 
         let snapshot = params.session_snapshot.as_ref();
 
-        // Prefer the last-persisted mode; for brand-new conversations
-        // fall back to `AcpBuildExtra::session_mode` so the first turn
-        // still honours the caller's choice.
-        let (initial_mode, initial_model, initial_config) = (
-            snapshot
-                .and_then(|s| s.current_mode_id.as_ref())
-                .map(|m| normalize_requested_mode(&params.metadata, m.as_str()))
-                .or_else(|| {
-                    params
-                        .config
-                        .session_mode
-                        .as_ref()
-                        .map(|m| normalize_requested_mode(&params.metadata, m))
-                })
-                .filter(|m| !m.is_empty())
-                .map(ModeId::new),
+        let (initial_model, initial_config) = (
             snapshot.and_then(|s| s.current_model_id.clone()).or_else(|| {
                 params
                     .config
@@ -359,6 +368,7 @@ impl AcpAgentManager {
         if normalized_mode.is_empty() {
             return Ok(());
         }
+        codex_sandbox::sync_for_agent(&self.params.metadata, Some(&normalized_mode)).await?;
         let session_id = self.session.read().await.session_id().map(ToOwned::to_owned);
 
         // Write desired — the aggregate root's legitimate intent write-point.

--- a/crates/aionui-ai-agent/src/manager/acp/codex_sandbox.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/codex_sandbox.rs
@@ -1,0 +1,181 @@
+use std::path::PathBuf;
+
+use aionui_api_types::AgentMetadata;
+use aionui_common::{AppError, ErrorChain};
+use tokio::fs;
+use tracing::info;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CodexSandboxMode {
+    WorkspaceWrite,
+    DangerFullAccess,
+}
+
+impl CodexSandboxMode {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::WorkspaceWrite => "workspace-write",
+            Self::DangerFullAccess => "danger-full-access",
+        }
+    }
+}
+
+pub(super) fn sandbox_mode_for_requested_mode(mode: Option<&str>) -> CodexSandboxMode {
+    match mode.map(str::trim) {
+        Some("full-access" | "yoloNoSandbox") => CodexSandboxMode::DangerFullAccess,
+        _ => CodexSandboxMode::WorkspaceWrite,
+    }
+}
+
+pub(super) async fn sync_for_agent(metadata: &AgentMetadata, requested_mode: Option<&str>) -> Result<(), AppError> {
+    if metadata.backend.as_deref() != Some("codex") {
+        return Ok(());
+    }
+
+    let sandbox_mode = sandbox_mode_for_requested_mode(requested_mode);
+    write_codex_sandbox_mode(sandbox_mode).await?;
+    info!(
+        requested_mode = requested_mode.unwrap_or_default(),
+        sandbox_mode = sandbox_mode.as_str(),
+        "Codex sandbox config synced"
+    );
+    Ok(())
+}
+
+pub(super) async fn write_codex_sandbox_mode(mode: CodexSandboxMode) -> Result<(), AppError> {
+    let path = codex_config_path()?;
+    write_codex_sandbox_mode_to_path(mode, &path).await
+}
+
+async fn write_codex_sandbox_mode_to_path(mode: CodexSandboxMode, path: &std::path::Path) -> Result<(), AppError> {
+    let content = fs::read_to_string(&path).await.unwrap_or_default();
+    let rendered = render_config_with_sandbox_mode(&content, mode.as_str());
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to create Codex config directory: {}", ErrorChain(&e))))?;
+    }
+
+    fs::write(&path, rendered)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to write Codex sandbox config: {}", ErrorChain(&e))))?;
+    Ok(())
+}
+
+fn codex_config_path() -> Result<PathBuf, AppError> {
+    if let Some(home) = std::env::var_os("CODEX_HOME")
+        && !home.is_empty()
+    {
+        return Ok(PathBuf::from(home).join("config.toml"));
+    }
+
+    let home = dirs::home_dir()
+        .ok_or_else(|| AppError::Internal("Failed to resolve home directory for Codex config".into()))?;
+    Ok(home.join(".codex").join("config.toml"))
+}
+
+fn render_config_with_sandbox_mode(content: &str, mode: &str) -> String {
+    let newline = if content.contains("\r\n") { "\r\n" } else { "\n" };
+    let sandbox_line = format!("sandbox_mode = \"{mode}\"");
+    let mut replaced = false;
+    let mut lines = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        let is_sandbox_line = trimmed
+            .strip_prefix("sandbox_mode")
+            .is_some_and(|rest| rest.trim_start().starts_with('='));
+        if is_sandbox_line {
+            lines.push(sandbox_line.clone());
+            replaced = true;
+        } else {
+            lines.push(line.to_owned());
+        }
+    }
+
+    if replaced {
+        let mut rendered = lines.join(newline);
+        if content.ends_with('\n') {
+            rendered.push_str(newline);
+        }
+        return rendered;
+    }
+
+    if content.trim_start().starts_with('[') {
+        format!("{sandbox_line}{newline}{newline}{content}")
+    } else if let Some(section_index) = content.find("\n[") {
+        let split_at = section_index + 1;
+        let prefix = content[..split_at].trim_end();
+        let suffix = &content[split_at..];
+        if prefix.is_empty() {
+            format!("{sandbox_line}{newline}{newline}{suffix}")
+        } else {
+            format!("{prefix}{newline}{sandbox_line}{newline}{newline}{suffix}")
+        }
+    } else if content.trim().is_empty() {
+        format!("{sandbox_line}{newline}")
+    } else {
+        format!("{}{newline}{sandbox_line}{newline}", content.trim_end())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_access_maps_to_danger_full_access() {
+        assert_eq!(
+            sandbox_mode_for_requested_mode(Some("full-access")).as_str(),
+            "danger-full-access"
+        );
+    }
+
+    #[test]
+    fn non_full_access_modes_map_to_workspace_write() {
+        for mode in [None, Some(""), Some("auto"), Some("read-only"), Some("default")] {
+            assert_eq!(sandbox_mode_for_requested_mode(mode).as_str(), "workspace-write");
+        }
+    }
+
+    #[test]
+    fn config_render_replaces_existing_sandbox_mode() {
+        let input = r#"model = "gpt-5"
+sandbox_mode = "read-only"
+
+[tools]
+web_search = true
+"#;
+
+        let rendered = render_config_with_sandbox_mode(input, "danger-full-access");
+
+        assert!(rendered.contains(r#"sandbox_mode = "danger-full-access""#));
+        assert!(!rendered.contains(r#"sandbox_mode = "read-only""#));
+        assert!(rendered.contains("[tools]"));
+    }
+
+    #[test]
+    fn config_render_inserts_before_first_section() {
+        let input = r#"[tools]
+web_search = true
+"#;
+
+        let rendered = render_config_with_sandbox_mode(input, "workspace-write");
+
+        assert!(rendered.starts_with("sandbox_mode = \"workspace-write\"\n\n[tools]"));
+    }
+
+    #[tokio::test]
+    async fn write_codex_sandbox_mode_to_path_creates_parent_and_writes_full_access() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("nested").join("config.toml");
+
+        write_codex_sandbox_mode_to_path(CodexSandboxMode::DangerFullAccess, &config_path)
+            .await
+            .unwrap();
+
+        let rendered = fs::read_to_string(config_path).await.unwrap();
+        assert_eq!(rendered, "sandbox_mode = \"danger-full-access\"\n");
+    }
+}

--- a/crates/aionui-ai-agent/src/manager/acp/mod.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/mod.rs
@@ -4,6 +4,7 @@ pub mod agent_event_tracker;
 pub mod agent_reconcile;
 mod agent_session_flow;
 pub mod catalog_forwarder;
+mod codex_sandbox;
 pub mod hooks;
 mod mode_normalize;
 pub mod permission_router;


### PR DESCRIPTION
## Summary
- Sync Codex sandbox_mode before launching Codex ACP sessions and when switching modes at runtime.
- Map full-access/yoloNoSandbox to danger-full-access and other modes to workspace-write.
- Preserve existing Codex config content while replacing or inserting the top-level sandbox_mode setting.

## Test Plan
- cargo test -p aionui-ai-agent codex_sandbox
- cargo test -p aionui-ai-agent
- cargo fmt --all -- --check
- cargo clippy -p aionui-ai-agent -- -D warnings
- just push -u origin codex-full-access-sandbox