### PR TITLE
Expose team pending confirmation counts

### DIFF
--- a/crates/aionui-api-types/src/team.rs
+++ b/crates/aionui-api-types/src/team.rs
@@ -117,6 +117,8 @@ pub struct TeamAgentResponse {
     pub custom_agent_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
+    #[serde(default)]
+    pub pending_confirmations: usize,
 }
 
 /// Full team response returned by create, get, and list endpoints.
@@ -450,6 +452,7 @@ mod tests {
             model: "claude".into(),
             custom_agent_id: Some("agent-x".into()),
             status: Some("idle".into()),
+            pending_confirmations: 2,
         };
         let json = serde_json::to_value(&agent).unwrap();
         assert_eq!(json["slot_id"], "slot-1");
@@ -461,6 +464,7 @@ mod tests {
         assert_eq!(json["model"], "claude");
         assert_eq!(json["custom_agent_id"], "agent-x");
         assert_eq!(json["status"], "idle");
+        assert_eq!(json["pending_confirmations"], 2);
     }
 
     #[test]
@@ -475,6 +479,7 @@ mod tests {
             model: "claude".into(),
             custom_agent_id: None,
             status: None,
+            pending_confirmations: 0,
         };
         let json = serde_json::to_value(&agent).unwrap();
         assert!(json.get("icon").is_none());
@@ -497,6 +502,7 @@ mod tests {
                 model: "claude".into(),
                 custom_agent_id: None,
                 status: None,
+                pending_confirmations: 0,
             }],
             lead_agent_id: Some("slot-1".into()),
             created_at: 1700000000000,
@@ -556,6 +562,7 @@ mod tests {
                 model: "opus".into(),
                 custom_agent_id: None,
                 status: Some("idle".into()),
+                pending_confirmations: 0,
             },
         };
         let json = serde_json::to_value(&payload).unwrap();
@@ -604,6 +611,7 @@ mod tests {
             model: "claude".into(),
             custom_agent_id: Some("custom-1".into()),
             status: Some("working".into()),
+            pending_confirmations: 1,
         };
         let json = serde_json::to_string(&agent).unwrap();
         let parsed: TeamAgentResponse = serde_json::from_str(&json).unwrap();
@@ -626,6 +634,7 @@ mod tests {
                     model: "claude".into(),
                     custom_agent_id: None,
                     status: None,
+                    pending_confirmations: 0,
                 },
                 TeamAgentResponse {
                     slot_id: "s2".into(),
@@ -637,6 +646,7 @@ mod tests {
                     model: "claude".into(),
                     custom_agent_id: Some("x".into()),
                     status: Some("idle".into()),
+                    pending_confirmations: 3,
                 },
             ],
             lead_agent_id: Some("s1".into()),
@@ -674,6 +684,7 @@ mod tests {
                 model: "sonnet".into(),
                 custom_agent_id: None,
                 status: None,
+                pending_confirmations: 0,
             },
         };
         let json = serde_json::to_string(&payload).unwrap();
@@ -736,6 +747,7 @@ mod tests {
         assert_eq!(agent.conversation_id, "c1");
         assert_eq!(agent.custom_agent_id.as_deref(), Some("cust-1"));
         assert_eq!(agent.status.as_deref(), Some("idle"));
+        assert_eq!(agent.pending_confirmations, 0);
     }
 
     #[test]

--- a/crates/aionui-team/src/service/response_builder.rs
+++ b/crates/aionui-team/src/service/response_builder.rs
@@ -22,7 +22,16 @@ impl TeamSessionService {
         agent: &TeamAgent,
     ) -> Result<aionui_api_types::TeamAgentResponse, TeamError> {
         let icon = self.resolve_agent_icon(agent).await?;
-        Ok(agent.to_response_with_icon(icon))
+        let mut response = agent.to_response_with_icon(icon);
+        response.pending_confirmations = self.pending_confirmation_count(&agent.conversation_id);
+        Ok(response)
+    }
+
+    fn pending_confirmation_count(&self, conversation_id: &str) -> usize {
+        self.task_manager
+            .get_task(conversation_id)
+            .map(|agent| agent.get_confirmations().len())
+            .unwrap_or(0)
     }
 
     async fn resolve_agent_icon(&self, agent: &TeamAgent) -> Result<Option<String>, TeamError> {

--- a/crates/aionui-team/src/types.rs
+++ b/crates/aionui-team/src/types.rs
@@ -124,6 +124,7 @@ impl TeamAgent {
             model: self.model.clone(),
             custom_agent_id: self.custom_agent_id.clone(),
             status: self.status.map(|s| s.to_string()),
+            pending_confirmations: 0,
         }
     }
 }

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -8,7 +8,7 @@ use aionui_ai_agent::task_manager::AgentFactory;
 use aionui_ai_agent::types::BuildTaskOptions;
 use aionui_ai_agent::{IWorkerTaskManager, WorkerTaskManagerImpl};
 use aionui_api_types::{AddAgentRequest, CreateTeamRequest, TeamAgentInput, WebSocketMessage};
-use aionui_common::{AgentKillReason, AppError, PaginatedResult};
+use aionui_common::{AgentKillReason, AgentType, AppError, PaginatedResult, ProviderWithModel};
 use aionui_db::models::{
     AcpSessionRow, AgentMetadataRow, ConversationRow, MessageRow, UpdateAgentHandshakeParams, UpsertAgentMetadataParams,
 };
@@ -502,22 +502,32 @@ mod mock_agent {
     use aionui_ai_agent::agent_task::{IAgentTask, IMockAgent};
     use aionui_ai_agent::protocol::events::AgentStreamEvent;
     use aionui_ai_agent::types::SendMessageData;
-    use aionui_common::{AgentKillReason, AgentType, AppError, ConversationStatus, TimestampMs};
+    use aionui_common::{AgentKillReason, AgentType, AppError, Confirmation, ConversationStatus, TimestampMs};
     use tokio::sync::broadcast;
 
     pub struct MockAgent {
         pub conversation_id: String,
         pub workspace: String,
         pub event_tx: broadcast::Sender<AgentStreamEvent>,
+        pub confirmations: Vec<Confirmation>,
     }
 
     impl MockAgent {
         pub fn new(conversation_id: String, workspace: String) -> Self {
+            Self::with_confirmations(conversation_id, workspace, Vec::new())
+        }
+
+        pub fn with_confirmations(
+            conversation_id: String,
+            workspace: String,
+            confirmations: Vec<Confirmation>,
+        ) -> Self {
             let (event_tx, _) = broadcast::channel(16);
             Self {
                 conversation_id,
                 workspace,
                 event_tx,
+                confirmations,
             }
         }
     }
@@ -553,7 +563,11 @@ mod mock_agent {
         }
     }
 
-    impl IMockAgent for MockAgent {}
+    impl IMockAgent for MockAgent {
+        fn get_confirmations(&self) -> Vec<Confirmation> {
+            self.confirmations.clone()
+        }
+    }
 }
 
 fn success_factory() -> AgentFactory {
@@ -562,6 +576,30 @@ fn success_factory() -> AgentFactory {
         async move {
             Ok(aionui_ai_agent::AgentInstance::Mock(Arc::new(
                 mock_agent::MockAgent::new(opts.conversation_id, opts.workspace),
+            )))
+        }
+        .boxed()
+    })
+}
+
+fn confirmations_factory(count: usize) -> AgentFactory {
+    use aionui_common::Confirmation;
+    use futures_util::FutureExt;
+    Arc::new(move |opts: BuildTaskOptions| {
+        let confirmations = (0..count)
+            .map(|idx| Confirmation {
+                id: format!("tool-{idx}"),
+                call_id: format!("tool-{idx}"),
+                title: None,
+                action: None,
+                description: format!("Confirm tool {idx}"),
+                command_type: None,
+                options: vec![],
+            })
+            .collect::<Vec<_>>();
+        async move {
+            Ok(aionui_ai_agent::AgentInstance::Mock(Arc::new(
+                mock_agent::MockAgent::with_confirmations(opts.conversation_id, opts.workspace, confirmations),
             )))
         }
         .boxed()
@@ -971,6 +1009,56 @@ async fn tl2_list_multiple_teams() {
 
     let list = svc.list_teams().await.unwrap();
     assert_eq!(list.len(), 2);
+}
+
+#[tokio::test]
+async fn tl_list_teams_includes_pending_confirmation_counts_without_rebuilding_tasks() {
+    let (svc, task_manager) = setup_with_factory(confirmations_factory(2));
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "With Confirmations".into(),
+                agents: vec![TeamAgentInput {
+                    name: "Lead".into(),
+                    role: "lead".into(),
+                    backend: "acp".into(),
+                    model: "claude".into(),
+                    custom_agent_id: None,
+                    conversation_id: None,
+                }],
+                workspace: None,
+            },
+        )
+        .await
+        .unwrap();
+    let conversation_id = created.agents[0].conversation_id.clone();
+    task_manager
+        .get_or_build_task(
+            &conversation_id,
+            BuildTaskOptions {
+                agent_type: AgentType::Acp,
+                workspace: "/tmp/ws".into(),
+                model: ProviderWithModel {
+                    provider_id: "test".into(),
+                    model: "claude".into(),
+                    use_model: None,
+                },
+                conversation_id: conversation_id.clone(),
+                extra: serde_json::json!({}),
+            },
+        )
+        .await
+        .unwrap();
+    let before = task_manager.snapshot();
+
+    let list = svc.list_teams().await.unwrap();
+    let after = task_manager.snapshot();
+
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].id, created.id);
+    assert_eq!(list[0].agents[0].pending_confirmations, 2);
+    assert_eq!(after.build, before.build);
 }
 
 // -- Get team -----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add pending confirmation counts to team agent API responses.
- Compute counts from existing in-memory tasks without rebuilding or starting agent sessions.
- Cover the team list behavior with integration tests.

## Validation
- just push -u origin codex/aio-3-confirmation-counts
