### PR TITLE
Expose aioncore version flag

### DIFF
--- a/crates/aionui-app/src/cli.rs
+++ b/crates/aionui-app/src/cli.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(name = "aioncore", about = "AionUi Backend Server")]
+#[command(name = "aioncore", about = "AionUi Backend Server", version)]
 pub(crate) struct Cli {
     /// Host address to listen on.
     #[arg(long, default_value_t = String::from(aionui_common::constants::DEFAULT_HOST))]
@@ -66,4 +66,54 @@ pub(crate) enum Command {
     /// app launched from confirms whether each backend is detectable
     /// before involving server logs.
     Doctor,
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+    use clap::error::ErrorKind;
+
+    use super::Cli;
+
+    #[test]
+    fn long_version_flag_uses_workspace_package_version() {
+        let result = Cli::try_parse_from(["aioncore", "--version"]);
+        let err = match result {
+            Ok(_) => panic!("expected --version to exit through clap DisplayVersion"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), ErrorKind::DisplayVersion);
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("aioncore"),
+            "version output should contain binary name, got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains(env!("CARGO_PKG_VERSION")),
+            "version output should contain package version {}, got: {rendered:?}",
+            env!("CARGO_PKG_VERSION")
+        );
+    }
+
+    #[test]
+    fn short_version_flag_uses_workspace_package_version() {
+        let result = Cli::try_parse_from(["aioncore", "-V"]);
+        let err = match result {
+            Ok(_) => panic!("expected -V to exit through clap DisplayVersion"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), ErrorKind::DisplayVersion);
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("aioncore"),
+            "version output should contain binary name, got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains(env!("CARGO_PKG_VERSION")),
+            "version output should contain package version {}, got: {rendered:?}",
+            env!("CARGO_PKG_VERSION")
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Enable clap's standard version metadata for the aioncore CLI
- Add unit coverage for both \aioncore 0.1.15 and \aioncore 0.1.15

## Verification
- \branch 'codex/aio-8-version-command' set up to track 'origin/codex/aio-8-version-command'.