### PR TITLE
fix(agent): preserve process-group cleanup after leader exit

### DIFF
--- a/crates/aionui-ai-agent/src/capability/cli_process/mod.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/mod.rs
@@ -43,6 +43,9 @@ pub struct CliAgentProcess {
     stdout: Mutex<Option<ChildStdout>>,
     /// OS-level process ID.
     pid: u32,
+    /// Process group ID captured at spawn time so teardown can still target
+    /// the whole tree after the direct child exits.
+    process_group_id: Option<u32>,
     /// Broadcast sender for parsed stdout events (legacy mode only).
     #[allow(dead_code)] // Part of the complete CliProcess API; used in legacy mode via subscribe()
     event_tx: broadcast::Sender<serde_json::Value>,
@@ -156,7 +159,7 @@ impl CliAgentProcess {
 
         // Force kill
         warn!(pid = self.pid, "Grace period expired, sending SIGKILL");
-        force_kill(self.pid)?;
+        force_kill(self.pid, self.process_group_id)?;
 
         // Wait for the exit monitor to observe process termination so callers
         // do not race a still-live child after force-kill returns.
@@ -189,6 +192,11 @@ impl CliAgentProcess {
     #[allow(dead_code)] // Complete CliProcess lifecycle API
     pub fn pid(&self) -> u32 {
         self.pid
+    }
+
+    /// Get the cached process group ID captured when the child was spawned.
+    pub fn process_group_id(&self) -> Option<u32> {
+        self.process_group_id
     }
 
     /// Wait for the process to exit (blocks until exit or cancellation).
@@ -242,6 +250,16 @@ impl CliAgentProcess {
         tail.reverse();
         tail.join("\n")
     }
+}
+
+#[cfg(unix)]
+pub(super) fn tracked_process_group_id(pid: u32) -> Option<u32> {
+    Some(pid)
+}
+
+#[cfg(not(unix))]
+pub(super) fn tracked_process_group_id(_pid: u32) -> Option<u32> {
+    None
 }
 
 #[cfg(test)]

--- a/crates/aionui-ai-agent/src/capability/cli_process/spawn_legacy.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/spawn_legacy.rs
@@ -7,7 +7,7 @@ use tokio::process::Child;
 use tokio::sync::{Mutex, broadcast, watch};
 use tracing::{debug, error, info, trace, warn};
 
-use super::{CliAgentProcess, EVENT_CHANNEL_CAPACITY, STDERR_BUFFER_MAX};
+use super::{CliAgentProcess, EVENT_CHANNEL_CAPACITY, STDERR_BUFFER_MAX, tracked_process_group_id};
 
 impl CliAgentProcess {
     /// Spawn a new CLI subprocess in **legacy mode**.
@@ -130,6 +130,7 @@ impl CliAgentProcess {
             stdin: Mutex::new(Some(stdin)),
             stdout: Mutex::new(None), // stdout consumed by reader task
             pid,
+            process_group_id: tracked_process_group_id(pid),
             event_tx,
             exit_rx,
             initial_rx: std::sync::Mutex::new(Some(initial_rx)),

--- a/crates/aionui-ai-agent/src/capability/cli_process/spawn_sdk.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/spawn_sdk.rs
@@ -7,7 +7,7 @@ use tokio::process::Child;
 use tokio::sync::{Mutex, broadcast, watch};
 use tracing::{debug, error, info, warn};
 
-use super::{CliAgentProcess, EVENT_CHANNEL_CAPACITY, STDERR_BUFFER_MAX};
+use super::{CliAgentProcess, EVENT_CHANNEL_CAPACITY, STDERR_BUFFER_MAX, tracked_process_group_id};
 
 impl CliAgentProcess {
     /// Spawn a new CLI subprocess in **SDK mode**.
@@ -107,6 +107,7 @@ impl CliAgentProcess {
             stdin: Mutex::new(Some(stdin)),
             stdout: Mutex::new(Some(stdout)),
             pid,
+            process_group_id: tracked_process_group_id(pid),
             event_tx,
             exit_rx,
             initial_rx: std::sync::Mutex::new(None),

--- a/crates/aionui-ai-agent/src/capability/cli_process/stderr_monitor.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/stderr_monitor.rs
@@ -10,7 +10,7 @@ use tracing::{debug, error};
 ///   the ACP CLI typically spawns a node/bun child that must die with it)
 ///
 /// If the process has already exited, this is a no-op.
-pub(super) fn force_kill(pid: u32) -> Result<(), AppError> {
+pub(super) fn force_kill(pid: u32, process_group_id: Option<u32>) -> Result<(), AppError> {
     #[cfg(unix)]
     {
         use std::io;
@@ -34,34 +34,30 @@ pub(super) fn force_kill(pid: u32) -> Result<(), AppError> {
             }
         }
 
-        let pgid = unsafe { libc::getpgid(pid as i32) };
-        if pgid == -1 {
-            let err = io::Error::last_os_error();
-            if err.raw_os_error() == Some(libc::ESRCH) {
-                debug!(pid, "Process already exited before resolving process group");
+        if let Some(group_id) = process_group_id.filter(|group_id| *group_id > 1) {
+            let rc = unsafe { libc::kill(-(group_id as i32), libc::SIGKILL) };
+            if rc == 0 {
+                debug!(pid, process_group = group_id, "SIGKILL sent successfully");
                 return Ok(());
             }
 
-            error!(pid, error = %err, "Failed to resolve process group");
-            return kill_pid(pid);
-        }
-
-        let rc = unsafe { libc::kill(-pgid, libc::SIGKILL) };
-        if rc == 0 {
-            debug!(pid, process_group = pgid, "SIGKILL sent successfully");
-            Ok(())
-        } else {
             let err = io::Error::last_os_error();
             if err.raw_os_error() == Some(libc::ESRCH) {
-                debug!(pid, process_group = pgid, "Process group already exited before SIGKILL");
-                kill_pid(pid)
-            } else {
-                error!(pid, process_group = pgid, error = %err, "Failed to send SIGKILL to process group");
-                Err(AppError::Internal(format!(
-                    "Failed to kill process group {pgid}: {err}"
-                )))
+                debug!(
+                    pid,
+                    process_group = group_id,
+                    "Process group already exited before SIGKILL"
+                );
+                return kill_pid(pid);
             }
+
+            error!(pid, process_group = group_id, error = %err, "Failed to send SIGKILL to process group");
+            return Err(AppError::Internal(format!(
+                "Failed to kill process group {group_id}: {err}"
+            )));
         }
+
+        kill_pid(pid)
     }
     #[cfg(windows)]
     {
@@ -152,7 +148,7 @@ mod force_kill_tests {
         let mut child = spawn_blocker();
         let pid = child.id();
 
-        force_kill(pid).expect("force_kill should succeed for live pid");
+        force_kill(pid, Some(pid)).expect("force_kill should succeed for live pid");
 
         assert!(
             wait_for_exit(&mut child, Duration::from_secs(5)),
@@ -172,7 +168,78 @@ mod force_kill_tests {
         // expectation is "kill returns success when nothing matches" — both the
         // unix `kill` non-zero exit and Windows `taskkill` rc=128 are mapped to
         // Ok in `force_kill`, so this should not produce an error.
-        force_kill(pid).expect("force_kill on dead pid must not error");
+        force_kill(pid, Some(pid)).expect("force_kill on dead pid must not error");
+    }
+
+    #[cfg(unix)]
+    fn wait_for_pid_exit(pid: u32, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if !is_pid_alive(pid) {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    #[cfg(unix)]
+    fn is_pid_alive(pid: u32) -> bool {
+        let result = unsafe { libc::kill(pid as i32, 0) };
+        if result == 0 {
+            return true;
+        }
+        !matches!(std::io::Error::last_os_error().raw_os_error(), Some(libc::ESRCH))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn force_kill_uses_cached_group_when_leader_has_exited() {
+        use std::fs;
+        use std::process::Stdio;
+
+        let marker = tempfile::NamedTempFile::new().unwrap();
+        let marker_path = marker.path().to_string_lossy().into_owned();
+
+        let mut command = Command::new("sh");
+        command
+            .args([
+                "-c",
+                "sleep 60 & child=$!; printf '%s' \"$child\" > \"$1\"; exit 0",
+                "cached-group-cleanup",
+                marker_path.as_str(),
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0);
+
+        let mut leader = command.spawn().expect("spawn shell with background child");
+        let leader_pid = leader.id();
+
+        assert!(
+            wait_for_exit(&mut leader, Duration::from_secs(5)),
+            "leader pid={leader_pid} should exit promptly",
+        );
+
+        let child_pid: u32 = fs::read_to_string(marker.path())
+            .expect("background child pid marker should exist")
+            .trim()
+            .parse()
+            .expect("background child pid should be numeric");
+
+        assert!(
+            is_pid_alive(child_pid),
+            "background child pid={child_pid} should still be alive"
+        );
+
+        force_kill(leader_pid, Some(leader_pid)).expect("force_kill should use cached process group id");
+
+        assert!(
+            wait_for_pid_exit(child_pid, Duration::from_secs(5)),
+            "background child pid={child_pid} should exit after group kill",
+        );
     }
 }
 

--- a/crates/aionui-ai-agent/src/manager/process_registry.rs
+++ b/crates/aionui-ai-agent/src/manager/process_registry.rs
@@ -57,9 +57,10 @@ pub(crate) fn register_session_process(
     command_preview: Option<String>,
 ) -> Result<(), AppError> {
     let pid = process.pid();
+    let process_group_id = process.process_group_id();
     let entry = RegisteredAgentProcess {
         pid,
-        process_group_id: process_group_id(pid),
+        process_group_id,
         conversation_id: conversation_id.into(),
         agent_type: agent_type.serde_name().to_owned(),
         backend,
@@ -76,7 +77,7 @@ pub(crate) fn register_session_process(
     let data_dir = data_dir.to_path_buf();
     tokio::spawn(async move {
         let _ = process.wait_for_exit().await;
-        wait_for_process_tree_exit(pid, process_group_id(pid)).await;
+        wait_for_process_tree_exit(pid, process_group_id).await;
         if let Err(e) = unregister_agent_process(&data_dir, pid) {
             warn!(
                 pid,
@@ -163,16 +164,6 @@ fn is_registered_process_tree_alive(pid: u32, process_group_id: Option<u32>) -> 
         .filter(|group_id| *group_id > 1)
         .is_some_and(is_unix_process_group_alive)
         || is_unix_process_alive(pid)
-}
-
-#[cfg(unix)]
-fn process_group_id(pid: u32) -> Option<u32> {
-    Some(pid)
-}
-
-#[cfg(not(unix))]
-fn process_group_id(_pid: u32) -> Option<u32> {
-    None
 }
 
 #[cfg(unix)]

--- a/crates/aionui-runtime/src/spawn.rs
+++ b/crates/aionui-runtime/src/spawn.rs
@@ -55,7 +55,7 @@ pub async fn kill_process_tree(child: &mut Child) -> io::Result<()> {
     };
 
     #[cfg(unix)]
-    force_kill_process_tree(pid)?;
+    force_kill_process_tree(pid, Some(pid))?;
     #[cfg(windows)]
     kill_windows_process_tree(pid).await?;
     #[cfg(not(any(unix, windows)))]
@@ -211,21 +211,21 @@ fn configure_platform_spawn(cmd: &mut Command) {
 fn configure_platform_spawn(_cmd: &mut Command) {}
 
 #[cfg(unix)]
-fn force_kill_process_tree(pid: u32) -> io::Result<()> {
-    let pgid = unsafe { libc::getpgid(pid as i32) };
-    if pgid == -1 {
-        let err = io::Error::last_os_error();
-        if err.raw_os_error() == Some(libc::ESRCH) {
+fn force_kill_process_tree(pid: u32, process_group_id: Option<u32>) -> io::Result<()> {
+    if let Some(group_id) = process_group_id.filter(|group_id| *group_id > 1) {
+        let result = unsafe { libc::kill(-(group_id as i32), libc::SIGKILL) };
+        if result == 0 {
             return Ok(());
         }
-        return kill_unix_target(pid as i32);
+
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::ESRCH) {
+            return kill_unix_target(pid as i32);
+        }
+        return Err(err);
     }
 
-    if pgid > 1 && pgid as u32 == pid {
-        kill_unix_target(-pgid)
-    } else {
-        kill_unix_target(pid as i32)
-    }
+    kill_unix_target(pid as i32)
 }
 
 #[cfg(unix)]
@@ -283,6 +283,7 @@ fn resolve_program(program: &OsStr) -> OsString {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{Duration, Instant};
 
     #[tokio::test]
     async fn clean_cli_captures_stdout_and_strips_env_pollution() {
@@ -397,5 +398,69 @@ mod tests {
         );
         assert!(preview.contains(r#""--flag""#), "arg --flag missing: {preview}");
         assert!(preview.contains(r#""with space""#), "arg with space missing: {preview}");
+    }
+
+    #[cfg(unix)]
+    fn wait_for_pid_exit(pid: u32, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if !is_pid_alive(pid) {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    #[cfg(unix)]
+    fn is_pid_alive(pid: u32) -> bool {
+        let result = unsafe { libc::kill(pid as i32, 0) };
+        if result == 0 {
+            return true;
+        }
+        !matches!(io::Error::last_os_error().raw_os_error(), Some(libc::ESRCH))
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn kill_process_tree_uses_cached_group_when_leader_has_exited() {
+        let marker = tempfile::NamedTempFile::new().unwrap();
+        let marker_path = marker.path().to_string_lossy().into_owned();
+
+        let mut builder = Builder::new("sh");
+        builder
+            .args([
+                "-c",
+                "sleep 60 & child=$!; printf '%s' \"$child\" > \"$1\"; exit 0",
+                "runtime-cached-group-cleanup",
+                marker_path.as_str(),
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+
+        let mut child = builder.spawn().unwrap();
+        let leader_pid = child.id().expect("leader pid should exist");
+        let status = child.wait().await.unwrap();
+        assert!(status.success(), "leader should exit before cleanup test");
+
+        let child_pid: u32 = std::fs::read_to_string(marker.path())
+            .expect("background child pid marker should exist")
+            .trim()
+            .parse()
+            .expect("background child pid should be numeric");
+
+        assert!(
+            is_pid_alive(child_pid),
+            "background child pid={child_pid} should still be alive"
+        );
+
+        force_kill_process_tree(leader_pid, Some(leader_pid)).expect("cached group kill should succeed");
+
+        assert!(
+            wait_for_pid_exit(child_pid, Duration::from_secs(5)),
+            "background child pid={child_pid} should exit after cached group kill",
+        );
     }
 }


### PR DESCRIPTION
## Summary
- cache each CLI agent process group ID at spawn time and reuse it during forced teardown
- stop re-deriving process groups from exited leaders in agent cleanup and registry wait paths
- align the runtime process-tree helper with the same behavior and add regression coverage for leader-exited/background-child-alive cases

## Testing
- cargo test -p aionui-runtime -p aionui-ai-agent
- cargo clippy -p aionui-runtime -p aionui-ai-agent -- -D warnings