### PR TITLE
fix(agent): classify Bedrock 'model identifier is invalid' as model-not-found (AIO-12)

### DIFF
--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -529,6 +529,7 @@ fn classify_provider_api(lower: &str) -> Option<ClassifiedError> {
             "unknown model",
             "invalid model",
             "model_not_found",
+            "model identifier is invalid",
         ],
     ) {
         return Some(provider_error(
@@ -1055,6 +1056,20 @@ mod tests {
             AgentErrorCode::UserLlmProviderModelNotFound,
             AgentErrorOwnership::UserLlmProvider,
             AgentErrorResolutionKind::ChangeModel,
+        );
+    }
+
+    #[test]
+    fn classifies_bedrock_invalid_model_identifier_as_model_not_found() {
+        assert_classification(
+            "Aionrs agent error: Provider error: API error 400: {\"message\":\"The provided model identifier is invalid.\"}",
+            AgentErrorCode::UserLlmProviderModelNotFound,
+            AgentErrorOwnership::UserLlmProvider,
+            AgentErrorResolutionKind::ChangeModel,
+        );
+        assert_resolution_target(
+            "Aionrs agent error: Provider error: API error 400: {\"message\":\"The provided model identifier is invalid.\"}",
+            AgentErrorResolutionTarget::ProviderSettings,
         );
     }
 


### PR DESCRIPTION
## Context

Multica issue: [AIO-12](https://multica.ai) — `[错误分类器] 模型或地址不可用（404 / Model not found）显示可读文案`

## Root cause

`crates/aionui-ai-agent/src/protocol/send_error.rs` 的 `classify_provider_api` 在判定模型未找到时,关键词数组只覆盖了 `model not found` / `model does not exist` / `unknown model` / `invalid model` / `model_not_found`。AWS Bedrock 在收到裸 model id(例如 `sonnet`,而非完整的 `anthropic.claude-sonnet-4-20250514-v1:0` 或推理配置 id)时返回 HTTP 400 `"The provided model identifier is invalid."`,与 OpenAI 系的 404 `"Model not found"` 同属"所选模型 ID 无效",但因关键词不匹配,落到后面的 `invalid_request_error` 分支被分类为 `UserLlmProviderInvalidRequest`(Send Feedback),让用户去提反馈,而不是去修改模型选择。

证据来源:Sentry RCA-N16(2.1.6 Windows,user feedback "what happened??"),完整 breadcrumb 显示 `provider=bedrock model=sonnet` → aionrs 抛 `Provider error: API error 400: {"message":"The provided model identifier is invalid."}`。

## Fix

- 在 `classify_provider_api` 的 model-not-found 关键词数组中追加 `"model identifier is invalid"`,使该错误归为 `UserLlmProviderModelNotFound` + `ChangeModel` + `ProviderSettings` 解决路径。
- 新增一条 unit test 覆盖 Bedrock 400 invalid model identifier 的真实文本。

i18n 侧 `USER_LLM_PROVIDER_MODEL_NOT_FOUND` 文案在 zh-CN / en-US / 等 9 个 locale 都已就绪,前端无需改动。

## Verification

- `cargo test -p aionui-ai-agent send_error` — 20 passed(含新增 test)
- `cargo clippy -p aionui-ai-agent -- -D warnings` — clean