### PR TITLE
fix: recover deleted conversation workspaces

### DIFF
--- a/crates/aionui-ai-agent/src/capability/cli_process/mod.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/mod.rs
@@ -1,3 +1,5 @@
+use std::fs;
+use std::path::PathBuf;
 use std::process::ExitStatus;
 use std::sync::Arc;
 use std::time::Duration;
@@ -6,7 +8,7 @@ use aionui_common::AppError;
 use tokio::io::AsyncWriteExt;
 use tokio::process::{ChildStdin, ChildStdout};
 use tokio::sync::{Mutex, broadcast, watch};
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 mod spawn_legacy;
 mod spawn_sdk;
@@ -23,6 +25,49 @@ pub(super) const EVENT_CHANNEL_CAPACITY: usize = 256;
 
 /// Maximum stderr ring-buffer size in bytes.
 pub(super) const STDERR_BUFFER_MAX: usize = 8192;
+
+pub(super) fn prepare_command_cwd(cwd: &str) -> Result<PathBuf, AppError> {
+    let trimmed = cwd.trim_end();
+    if trimmed.is_empty() {
+        return Err(AppError::BadRequest("Workspace directory is empty".into()));
+    }
+
+    if trimmed != cwd {
+        warn!(
+            original_cwd = %cwd,
+            normalized_cwd = %trimmed,
+            "Normalized CLI process cwd by trimming trailing whitespace"
+        );
+    }
+
+    let path = PathBuf::from(trimmed);
+    match fs::metadata(&path) {
+        Ok(metadata) if metadata.is_dir() => Ok(path),
+        Ok(_) => Err(AppError::BadRequest(format!(
+            "Workspace path is not a directory: {}",
+            path.display()
+        ))),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            fs::create_dir_all(&path).map_err(|create_err| {
+                AppError::BadRequest(format!(
+                    "Workspace directory no longer exists and could not be recreated: {}: {}",
+                    path.display(),
+                    create_err
+                ))
+            })?;
+            info!(
+                cwd = %path.display(),
+                "Recreated missing workspace directory before spawning CLI process"
+            );
+            Ok(path)
+        }
+        Err(e) => Err(AppError::BadRequest(format!(
+            "Workspace directory is not accessible: {}: {}",
+            path.display(),
+            e
+        ))),
+    }
+}
 
 /// Manages a CLI subprocess with optional JSON-over-stdin/stdout communication.
 ///
@@ -346,6 +391,51 @@ pub(super) mod tests {
             .expect("Timed out")
             .expect("Channel closed");
         assert_eq!(event["val"], "hello_env");
+    }
+
+    #[tokio::test]
+    async fn spawn_recreates_missing_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing_cwd = dir.path().join("missing").join("workspace");
+        assert!(!missing_cwd.exists());
+
+        let config = CommandSpec {
+            command: "sh".into(),
+            args: vec!["-c".into(), "echo \"{\\\"cwd\\\":\\\"$PWD\\\"}\"".into()],
+            env: vec![],
+            cwd: Some(missing_cwd.to_string_lossy().into_owned()),
+        };
+        let proc = CliAgentProcess::spawn(config).await.unwrap();
+        let mut rx = proc.subscribe();
+
+        let event = timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("Timed out")
+            .expect("Channel closed");
+        assert!(missing_cwd.is_dir());
+        assert_eq!(
+            fs::canonicalize(event["cwd"].as_str().unwrap()).unwrap(),
+            fs::canonicalize(&missing_cwd).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_for_sdk_recreates_missing_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = tempfile::tempdir().unwrap();
+        let missing_cwd = dir.path().join("missing-sdk").join("workspace");
+        assert!(!missing_cwd.exists());
+
+        let config = CommandSpec {
+            command: "sh".into(),
+            args: vec!["-c".into(), "sleep 10".into()],
+            env: vec![],
+            cwd: Some(missing_cwd.to_string_lossy().into_owned()),
+        };
+        let proc = CliAgentProcess::spawn_for_sdk(config, data_dir.path()).await.unwrap();
+
+        assert!(missing_cwd.is_dir());
+        proc.kill(Duration::from_millis(100)).await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/aionui-ai-agent/src/capability/cli_process/spawn_legacy.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/spawn_legacy.rs
@@ -7,7 +7,9 @@ use tokio::process::Child;
 use tokio::sync::{Mutex, broadcast, watch};
 use tracing::{debug, error, info, trace, warn};
 
-use super::{CliAgentProcess, EVENT_CHANNEL_CAPACITY, STDERR_BUFFER_MAX, tracked_process_group_id};
+use super::{
+    CliAgentProcess, EVENT_CHANNEL_CAPACITY, STDERR_BUFFER_MAX, prepare_command_cwd, tracked_process_group_id,
+};
 
 impl CliAgentProcess {
     /// Spawn a new CLI subprocess in **legacy mode**.
@@ -28,7 +30,7 @@ impl CliAgentProcess {
             .stderr(std::process::Stdio::piped());
 
         if let Some(ref cwd) = config.cwd {
-            cmd.current_dir(cwd);
+            cmd.current_dir(prepare_command_cwd(cwd)?);
         }
 
         let preview = cmd.to_string();

--- a/crates/aionui-ai-agent/src/capability/cli_process/spawn_sdk.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/spawn_sdk.rs
@@ -7,7 +7,9 @@ use tokio::process::Child;
 use tokio::sync::{Mutex, broadcast, watch};
 use tracing::{debug, error, info, warn};
 
-use super::{CliAgentProcess, EVENT_CHANNEL_CAPACITY, STDERR_BUFFER_MAX, tracked_process_group_id};
+use super::{
+    CliAgentProcess, EVENT_CHANNEL_CAPACITY, STDERR_BUFFER_MAX, prepare_command_cwd, tracked_process_group_id,
+};
 
 impl CliAgentProcess {
     /// Spawn a new CLI subprocess in **SDK mode**.
@@ -34,7 +36,7 @@ impl CliAgentProcess {
             .stderr(std::process::Stdio::piped());
 
         if let Some(ref cwd) = config.cwd {
-            cmd.current_dir(cwd);
+            cmd.current_dir(prepare_command_cwd(cwd)?);
         }
         let preview = cmd.to_string();
         info!(command = %preview, "Spawning CLI process (SDK mode)");

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
@@ -16,7 +17,7 @@ use aionui_common::{
     AgentType, AppError, ConversationSource, ConversationStatus, ErrorChain, MessageType, OnConversationDelete,
     PaginatedResult, generate_short_id, now_ms,
 };
-use aionui_db::models::MessageRow;
+use aionui_db::models::{ConversationRow, MessageRow};
 use aionui_db::{
     ConversationFilters, ConversationRowUpdate, CreateAcpSessionParams, IAcpSessionRepository,
     IAgentMetadataRepository, IConversationRepository, IMcpServerRepository, SaveRuntimeStateParams, SortOrder,
@@ -86,7 +87,7 @@ impl McpSupportPolicy {
 
 #[derive(Clone)]
 pub struct ConversationService {
-    workspace_root: std::path::PathBuf,
+    workspace_root: PathBuf,
     broadcaster: Arc<dyn EventBroadcaster>,
     skill_resolver: Arc<dyn SkillResolver>,
     task_manager: Arc<dyn IWorkerTaskManager>,
@@ -109,7 +110,7 @@ pub struct ConversationService {
 
 impl ConversationService {
     pub fn new(
-        workspace_root: std::path::PathBuf,
+        workspace_root: PathBuf,
         broadcaster: Arc<dyn EventBroadcaster>,
         skill_resolver: Arc<dyn SkillResolver>,
         task_manager: Arc<dyn IWorkerTaskManager>,
@@ -1285,6 +1286,7 @@ impl ConversationService {
                 return Err(err);
             }
         };
+        self.ensure_auto_workspace_skill_links(&row, &build_opts).await;
         let stored_workspace = build_opts.workspace.clone();
 
         // TODO: 好蠢的设计, status 写数据库, 最好干掉啦
@@ -1532,6 +1534,7 @@ impl ConversationService {
             .ok_or_else(|| AppError::NotFound(format!("Conversation {conversation_id} not found")))?;
 
         let build_opts = self.build_task_options(&row)?;
+        self.ensure_auto_workspace_skill_links(&row, &build_opts).await;
         let stored_workspace = build_opts.workspace.clone();
         let agent = task_manager.get_or_build_task(conversation_id, build_opts).await?;
 
@@ -1579,6 +1582,65 @@ impl ConversationService {
             conversation_id: row.id.clone(),
             extra,
         })
+    }
+
+    async fn ensure_auto_workspace_skill_links(&self, row: &ConversationRow, build_opts: &BuildTaskOptions) {
+        let expected_workspace = self.workspace_root.join("conversations").join(format!(
+            "{}-temp-{}",
+            conversation_label(&build_opts.agent_type, build_opts.extra.get("backend")),
+            row.id
+        ));
+
+        let stored_workspace = build_opts.workspace.trim();
+        let workspace = if stored_workspace.is_empty() {
+            expected_workspace
+        } else {
+            let workspace = PathBuf::from(stored_workspace);
+            if workspace != expected_workspace {
+                return;
+            }
+            workspace
+        };
+
+        let skill_names = build_opts
+            .extra
+            .get("skills")
+            .cloned()
+            .and_then(|v| serde_json::from_value::<Vec<String>>(v).ok())
+            .unwrap_or_default();
+        if skill_names.is_empty() {
+            return;
+        }
+
+        let Some(rel_dirs) = native_skills_dirs(
+            &self.agent_metadata_repo,
+            &build_opts.agent_type,
+            build_opts.extra.get("backend"),
+        )
+        .await
+        else {
+            return;
+        };
+        if rel_dirs.is_empty() {
+            return;
+        }
+
+        let resolved = self.skill_resolver.resolve_skills(&skill_names).await;
+        if resolved.is_empty() {
+            return;
+        }
+
+        let rel_dirs_refs: Vec<&str> = rel_dirs.iter().map(String::as_str).collect();
+        let n = self
+            .skill_resolver
+            .link_workspace_skills(&workspace, &rel_dirs_refs, &resolved)
+            .await;
+        debug!(
+            conversation_id = %row.id,
+            workspace = %workspace.display(),
+            links = n,
+            "ensured skill symlinks in auto workspace"
+        );
     }
 
     /// Write the resolved workspace back to `conversation.extra.workspace` when

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
 use std::sync::{
     Arc, Mutex,
     atomic::{AtomicBool, Ordering},
@@ -34,7 +35,67 @@ use serde_json::json;
 use tokio::sync::broadcast;
 
 use crate::service::ConversationService;
-use crate::skill_resolver::FixedSkillResolver;
+use crate::skill_resolver::{FixedSkillResolver, ResolvedAgentSkill, SkillResolver};
+
+#[derive(Clone, Debug)]
+struct SkillLinkCall {
+    workspace: PathBuf,
+    rel_dirs: Vec<String>,
+    skill_names: Vec<String>,
+}
+
+struct RecordingSkillResolver {
+    names: Vec<String>,
+    links: Arc<Mutex<Vec<SkillLinkCall>>>,
+}
+
+impl RecordingSkillResolver {
+    fn new(names: Vec<String>) -> Self {
+        Self {
+            names,
+            links: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl SkillResolver for RecordingSkillResolver {
+    async fn auto_inject_names(&self) -> Vec<String> {
+        self.names.clone()
+    }
+
+    async fn resolve_skills(&self, names: &[String]) -> Vec<ResolvedAgentSkill> {
+        names
+            .iter()
+            .map(|name| ResolvedAgentSkill {
+                name: name.clone(),
+                source_path: std::env::temp_dir().join(format!("skill-source-{name}")),
+            })
+            .collect()
+    }
+
+    async fn link_workspace_skills(&self, workspace: &Path, rel_dirs: &[&str], skills: &[ResolvedAgentSkill]) -> usize {
+        self.links.lock().unwrap().push(SkillLinkCall {
+            workspace: workspace.to_path_buf(),
+            rel_dirs: rel_dirs.iter().map(|s| (*s).to_owned()).collect(),
+            skill_names: skills.iter().map(|skill| skill.name.clone()).collect(),
+        });
+
+        let mut linked = 0;
+        for rel_dir in rel_dirs {
+            let target_dir = workspace.join(rel_dir);
+            if std::fs::create_dir_all(&target_dir).is_err() {
+                continue;
+            }
+            for skill in skills {
+                if std::fs::create_dir_all(target_dir.join(&skill.name)).is_ok() {
+                    linked += 1;
+                }
+            }
+        }
+        linked
+    }
+}
 
 // ── Mock EventBroadcaster ──────────────────────────────────────────
 
@@ -2287,6 +2348,37 @@ async fn create_writes_empty_skills_when_no_auto_inject_and_no_preset() {
     let resp = svc.create("user-1", req).await.unwrap();
 
     assert_eq!(resp.extra["skills"], json!([]));
+}
+
+#[tokio::test]
+async fn warmup_restores_skill_links_for_recreated_auto_workspace() {
+    let resolver = Arc::new(RecordingSkillResolver::new(vec!["cron".into()]));
+    let links = resolver.links.clone();
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service_with_resolver(resolver);
+
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "aionrs",
+        "extra": {},
+    }))
+    .unwrap();
+    let resp = svc.create("user-1", req).await.unwrap();
+    let workspace = PathBuf::from(resp.extra["workspace"].as_str().unwrap());
+    assert!(workspace.join(".aionrs/skills/cron").is_dir());
+
+    std::fs::remove_dir_all(&workspace).unwrap();
+    assert!(!workspace.exists());
+    links.lock().unwrap().clear();
+
+    let task_mgr: Arc<dyn IWorkerTaskManager> =
+        Arc::new(MockTaskManagerWithWorkspace::new(workspace.to_str().unwrap()));
+    svc.warmup("user-1", &resp.id, &task_mgr).await.unwrap();
+
+    assert!(workspace.join(".aionrs/skills/cron").is_dir());
+    let calls = links.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].workspace, workspace);
+    assert_eq!(calls[0].rel_dirs, vec![".aionrs/skills"]);
+    assert_eq!(calls[0].skill_names, vec!["cron"]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Recreate a missing command cwd before spawning legacy or SDK-backed agent processes, with clearer path validation errors.
- Re-link native skill directories for auto-provisioned conversation workspaces before warmup/send task builds, so recreated workspaces regain entries such as `.claude/skills/<skill>` or `.aionrs/skills/<skill>`.
- Keep user-provided custom workspaces untouched.

## Verification
- `cargo test -p aionui-conversation warmup_restores_skill_links_for_recreated_auto_workspace`
- `cargo test -p aionui-conversation`
- `just push` (`cargo fix`, workspace clippy with `-D warnings`, `cargo fmt --all`, `cargo nextest run --workspace`)
- `cargo nextest run --workspace`: 5743 passed, 18 skipped

Multica issue: AIO-94
