### PR TITLE
fix: improve missing MCP command guidance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,6 +666,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "toml 0.8.23",

--- a/crates/aionui-mcp/Cargo.toml
+++ b/crates/aionui-mcp/Cargo.toml
@@ -26,4 +26,5 @@ serde_json.workspace = true
 [dev-dependencies]
 axum.workspace = true
 serde_json.workspace = true
+tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/aionui-mcp/src/connection_test/mod.rs
+++ b/crates/aionui-mcp/src/connection_test/mod.rs
@@ -1,10 +1,11 @@
 mod protocol;
 
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::time::Duration;
 
 use aionui_api_types::McpConnectionTestResult;
-use aionui_runtime::{Builder as CmdBuilder, kill_process_tree};
+use aionui_runtime::{Builder as CmdBuilder, kill_process_tree, resolve_command_path};
 use serde::Serialize;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
@@ -81,7 +82,8 @@ impl McpConnectionTestService {
         args: &[String],
         env: &HashMap<String, String>,
     ) -> McpConnectionTestResult {
-        let mut cmd = CmdBuilder::new(command);
+        let program = resolve_stdio_command(command);
+        let mut cmd = CmdBuilder::new(&program);
         cmd.args(args)
             .envs(env.iter())
             .stdin(std::process::Stdio::piped())
@@ -310,6 +312,18 @@ impl McpConnectionTestService {
             .map_err(|e| e.to_string())?;
         Ok(())
     }
+}
+
+fn resolve_stdio_command(command: &str) -> OsString {
+    if !command.is_empty()
+        && !command.contains('/')
+        && !command.contains('\\')
+        && let Some(path) = resolve_command_path(command)
+    {
+        return path.into_os_string();
+    }
+
+    OsString::from(command)
 }
 
 /// Intermediate struct for HTTP transport response parsing.

--- a/crates/aionui-mcp/src/connection_test/protocol.rs
+++ b/crates/aionui-mcp/src/connection_test/protocol.rs
@@ -379,11 +379,35 @@ pub(super) fn timeout_result(duration: Duration) -> McpConnectionTestResult {
 
 pub(super) fn spawn_error_result(command: &str, error: &std::io::Error) -> McpConnectionTestResult {
     let msg = match error.kind() {
-        std::io::ErrorKind::NotFound => format!("Command not found: {command}"),
+        std::io::ErrorKind::NotFound => command_not_found_message(command),
         std::io::ErrorKind::PermissionDenied => format!("Permission denied: {command}"),
         _ => format!("Failed to start '{command}': {error}"),
     };
     error_result(msg)
+}
+
+fn command_not_found_message(command: &str) -> String {
+    let mut command_name = command
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(command)
+        .to_ascii_lowercase();
+    for suffix in [".exe", ".cmd", ".bat"] {
+        if let Some(stripped) = command_name.strip_suffix(suffix) {
+            command_name = stripped.to_owned();
+            break;
+        }
+    }
+
+    if matches!(command_name.as_str(), "npx" | "npm" | "node") {
+        return format!(
+            "Command not found: {command}. Install Node.js (which includes npm/npx), then restart AionUI or configure this MCP server to use an absolute command path."
+        );
+    }
+
+    format!(
+        "Command not found: {command}. Install the command or configure this MCP server to use an absolute command path."
+    )
 }
 
 pub(super) fn rpc_error_result(method: &str, err: &JsonRpcError) -> McpConnectionTestResult {
@@ -595,7 +619,20 @@ mod tests {
     fn spawn_error_not_found() {
         let err = std::io::Error::new(std::io::ErrorKind::NotFound, "not found");
         let result = spawn_error_result("npx", &err);
-        assert!(result.error.unwrap().contains("Command not found: npx"));
+        let error = result.error.unwrap();
+        assert!(error.contains("Command not found: npx"));
+        assert!(error.contains("Install Node.js"));
+        assert!(error.contains("absolute command path"));
+    }
+
+    #[test]
+    fn spawn_error_not_found_generic_command() {
+        let err = std::io::Error::new(std::io::ErrorKind::NotFound, "not found");
+        let result = spawn_error_result("missing-mcp", &err);
+        let error = result.error.unwrap();
+        assert!(error.contains("Command not found: missing-mcp"));
+        assert!(error.contains("Install the command"));
+        assert!(error.contains("absolute command path"));
     }
 
     #[test]

--- a/crates/aionui-mcp/tests/connection_test_path_resolution_integration.rs
+++ b/crates/aionui-mcp/tests/connection_test_path_resolution_integration.rs
@@ -1,0 +1,66 @@
+//! Isolated PATH-resolution coverage for stdio MCP connection tests.
+//!
+//! This file intentionally contains one test because it mutates process PATH
+//! to model the startup-enhanced GUI environment.
+
+#![cfg(unix)]
+
+use std::collections::HashMap;
+
+use aionui_mcp::{McpConnectionTestService, McpServerTransport};
+
+#[tokio::test]
+async fn stdio_npx_resolves_from_enhanced_process_path() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let bin_dir = tmp.path().join("bin");
+    std::fs::create_dir(&bin_dir).unwrap();
+
+    let fake_npx = bin_dir.join("npx");
+    std::fs::write(
+        &fake_npx,
+        r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *'"id":1'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"fake-npx","version":"1.0.0"}}}'
+      ;;
+    *'"id":2'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}'
+      exit 0
+      ;;
+  esac
+done
+"#,
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&fake_npx).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&fake_npx, perms).unwrap();
+
+    let original_path = std::env::var_os("PATH");
+    unsafe {
+        std::env::set_var("PATH", &bin_dir);
+    }
+
+    let svc = McpConnectionTestService::new(reqwest::Client::new());
+    let transport = McpServerTransport::Stdio {
+        command: "npx".into(),
+        args: vec![],
+        env: HashMap::new(),
+    };
+
+    let result = svc.test_connection("fake-npx", &transport).await;
+
+    unsafe {
+        if let Some(path) = original_path {
+            std::env::set_var("PATH", path);
+        } else {
+            std::env::remove_var("PATH");
+        }
+    }
+
+    assert!(result.success, "expected fake npx MCP server to connect: {result:?}");
+    assert!(result.tools.unwrap().is_empty());
+}


### PR DESCRIPTION
## Summary
- explicitly resolve stdio MCP commands through aionui_runtime::resolve_command_path before spawning
- add an isolated regression test proving a bare npx MCP server connects when npx is only discoverable from the enhanced process PATH
- expand missing-command errors with actionable Node.js/npm/npx and generic command guidance

## Verification
- cargo test -p aionui-mcp spawn_error --lib
- cargo fmt --check
- cargo test -p aionui-mcp --test connection_test_integration stdio_nonexistent_command_returns_not_found_error
- cargo test -p aionui-mcp --test connection_test_integration
- cargo test -p aionui-mcp --test connection_test_path_resolution_integration
- just push (5757 passed, 18 skipped)