### PR TITLE
fix(aionui-ai-agent): preserve ACP internal error payloads (AIO-101)

### DIFF
--- a/crates/aionui-ai-agent/src/manager/acp/agent_close.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_close.rs
@@ -25,6 +25,16 @@ use crate::protocol::error::CloseReason;
 /// covers a tracing event with its preceding context.
 pub(super) const STDERR_PEEK_LINES: usize = 32;
 
+fn acp_internal_payload_display(err: &AppError) -> Option<String> {
+    const ACP_INTERNAL_PREFIX: &str = "Agent internal error (code -32603)";
+    let display = user_facing_message(err);
+    if display.starts_with(ACP_INTERNAL_PREFIX) && display.trim() != ACP_INTERNAL_PREFIX {
+        Some(display)
+    } else {
+        None
+    }
+}
+
 impl AcpAgentManager {
     /// If `err` is the "SDK gave us default Internal error with no data" shape,
     /// peek the child's recent stderr and try to surface a more informative
@@ -79,6 +89,10 @@ impl AcpAgentManager {
     ///    "default Internal error" shape; otherwise the user-facing form
     ///    of the `AppError` is the best we can do.
     pub(super) async fn build_close_reason_from_error(&self, err: &AppError) -> CloseReason {
+        if let Some(display) = acp_internal_payload_display(err) {
+            return CloseReason::Failed { display };
+        }
+
         // Branch 1 — process exit detected.
         if let Some(status) = self.process.exit_status() {
             let (exit_code, signal) = exit_status_parts(Some(status));
@@ -149,6 +163,10 @@ mod tests {
     /// the same extractor module path. Keep this aligned with the production
     /// helper or these tests stop reflecting reality.
     async fn build_close_reason_via_process(proc: &Arc<CliAgentProcess>, err: &AppError) -> CloseReason {
+        if let Some(display) = super::acp_internal_payload_display(err) {
+            return CloseReason::Failed { display };
+        }
+
         if let Some(status) = proc.exit_status() {
             let (exit_code, signal) = exit_status_parts(Some(status));
             let tail = proc.peek_stderr_tail(super::STDERR_PEEK_LINES).await;
@@ -239,6 +257,27 @@ mod tests {
                 assert!(msg.contains("exit code 42"), "got {msg}");
             }
             other => panic!("expected ProcessExited, got {other:?}"),
+        }
+    }
+
+    /// If the SDK gave us a concrete -32603 data payload, prefer that over
+    /// the later process-exit metadata. The exit code is only a fallback when
+    /// the ACP error itself has no useful content.
+    #[tokio::test]
+    async fn internal_error_with_payload_beats_process_exit_summary() {
+        let proc = spawn_with_stderr_and_exit("Saved lockfile", 1).await;
+
+        let err = AppError::BadGateway(
+            "Agent internal error (code -32603) ({\"error\":\"Failed to connect MCP servers\"})".into(),
+        );
+        let reason = build_close_reason_via_process(&proc, &err).await;
+
+        match reason {
+            CloseReason::Failed { display } => {
+                assert!(display.contains("Agent internal error"), "got {display}");
+                assert!(display.contains("Failed to connect MCP servers"), "got {display}");
+            }
+            other => panic!("expected Failed with SDK payload, got {other:?}"),
         }
     }
 

--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -312,7 +312,8 @@ impl From<AcpError> for AgentSendError {
 
 fn classify_upstream_detail(detail: &str) -> AgentSendError {
     let lower = detail.to_ascii_lowercase();
-    let classified = classify_agent_lifecycle(&lower)
+    let classified = classify_agent_internal(&lower)
+        .or_else(|| classify_agent_lifecycle(&lower))
         .or_else(|| classify_provider_api(&lower))
         .or_else(|| classify_aionui_state(&lower))
         .unwrap_or(ClassifiedError {
@@ -326,6 +327,22 @@ fn classify_upstream_detail(detail: &str) -> AgentSendError {
         });
 
     classified.into_send_error(detail.to_owned())
+}
+
+fn classify_agent_internal(lower: &str) -> Option<ClassifiedError> {
+    if lower.contains("agent internal error (code -32603)") {
+        return Some(ClassifiedError {
+            message: "Agent internal error",
+            code: AgentErrorCode::UnknownUpstreamError,
+            ownership: AgentErrorOwnership::UserAgent,
+            retryable: true,
+            feedback_recommended: false,
+            resolution_kind: AgentErrorResolutionKind::Retry,
+            resolution_target: None,
+        });
+    }
+
+    None
 }
 
 fn classify_agent_lifecycle(lower: &str) -> Option<ClassifiedError> {
@@ -975,20 +992,29 @@ mod tests {
     }
 
     #[test]
-    fn classifies_mid_session_cli_exit_as_agent_disconnected() {
-        // Mid-session ACP CLI exit (e.g. Claude Code) surfaces as -32603 with
-        // `details: "Claude Code process exited with code 1"`. Previously this
-        // fell through to UNKNOWN_UPSTREAM_ERROR; it now maps to a retryable
-        // agent disconnect.
+    fn classifies_acp_internal_error_without_hiding_sdk_detail() {
+        // ACP -32603 carries the agent's actual internal-error payload. Even
+        // when that payload mentions a later CLI exit, the user-facing error
+        // should remain "Agent internal error" and keep the SDK detail instead
+        // of collapsing to a plain disconnect/exit-code message.
         assert_classification(
             "Agent internal error (code -32603) ({\"details\":\"Claude Code process exited with code 1\"})",
-            AgentErrorCode::UserAgentDisconnected,
+            AgentErrorCode::UnknownUpstreamError,
             AgentErrorOwnership::UserAgent,
-            AgentErrorResolutionKind::ReconnectAgent,
+            AgentErrorResolutionKind::Retry,
         );
         let err = AgentSendError::from_app_error(AppError::BadGateway(
-            "Agent internal error (code -32603) ({\"details\":\"Claude Code process exited with code 1\"})".into(),
+            "Agent internal error (code -32603) ({\"error\":\"Failed to connect MCP servers: {\\\"obsidian-semantic-vault\\\": \\\"Client failed to connect\\\"}\",\"details\":\"Claude Code process exited with code 1\"})".into(),
         ));
+        assert_eq!(err.stream_error().message, "Agent internal error");
+        assert!(
+            err.stream_error()
+                .detail
+                .as_deref()
+                .is_some_and(|detail| detail.contains("Failed to connect MCP servers")),
+            "SDK detail must be preserved; got {:?}",
+            err.stream_error().detail
+        );
         assert_eq!(err.stream_error().retryable, Some(true));
         assert_eq!(err.stream_error().feedback_recommended, Some(false));
     }
@@ -1002,13 +1028,13 @@ mod tests {
             AgentErrorResolutionKind::CheckAgentVersion,
         );
         assert_classification(
-            "Agent internal error (code -32603) {\"details\":\"Session not found\"}",
+            "Session not found",
             AgentErrorCode::UserAgentSessionNotFound,
             AgentErrorOwnership::UserAgent,
             AgentErrorResolutionKind::StartNewSession,
         );
         assert_classification(
-            "Bad gateway: Agent internal error (code -32603) {\"details\":\"No previous sessions found for this project\"}",
+            "No previous sessions found for this project",
             AgentErrorCode::UserAgentNoPreviousSession,
             AgentErrorOwnership::UserAgent,
             AgentErrorResolutionKind::StartNewSession,
@@ -1036,7 +1062,7 @@ mod tests {
             AgentErrorResolutionKind::CheckLocalCommand,
         );
         assert_classification(
-            "Agent internal error (code -32603) {\"message\":\"Missing environment variable: 'OMLX API KEY'\"}",
+            "Missing environment variable: 'OMLX API KEY'",
             AgentErrorCode::UserAgentMissingEnv,
             AgentErrorOwnership::UserAgent,
             AgentErrorResolutionKind::CheckAgentInstallation,


### PR DESCRIPTION
## Summary
- Treat ACP JSON-RPC -32603 as a generic Agent internal error instead of letting lifecycle/provider heuristics hide the SDK payload.
- Preserve concrete SDK error data such as `Failed to connect MCP servers` in stream error detail for frontend display/diagnostics.
- Prefer populated -32603 payloads over later process-exit metadata in ACP close reason; exit code remains the fallback when no useful payload exists.

## Multica Issue
[AIO-101](https://multica.ai/issues/f5df9369-e092-4aaf-8304-a7af57ad0d5c)

## Verification
- `cargo fmt --check`
- `cargo test -p aionui-ai-agent`
- `cargo clippy -p aionui-ai-agent -- -D warnings`