### PR TITLE
Fix ACP recovery for stale model state

### DIFF
--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -429,6 +429,16 @@ impl AcpAgentManager {
 
         {
             let mut session = self.session.write().await;
+            if !session.can_select_model(model_id) {
+                warn!(
+                    conversation_id = %self.params.conversation_id,
+                    model_id = %model_id,
+                    "set_model rejected unavailable ACP model"
+                );
+                return Err(AppError::BadRequest(format!(
+                    "Model '{model_id}' is not available for this ACP session"
+                )));
+            }
             session.set_desired_model(ModelId::new(model_id));
             self.commit_session_changes(&mut session).await;
         }

--- a/crates/aionui-ai-agent/src/manager/acp/agent_reconcile.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_reconcile.rs
@@ -39,11 +39,19 @@ impl AcpAgentManager {
     pub(super) async fn reconcile_session(&self, session_id: &str) -> Result<(), AppError> {
         use crate::manager::acp::ReconcileAction;
 
-        let actions = {
-            let session = self.session.read().await;
-            session.plan_reconcile()
+        let (invalid_model, actions) = {
+            let mut session = self.session.write().await;
+            let invalid_model = session.clear_invalid_desired_model();
+            let actions = session.plan_reconcile();
+            (invalid_model, actions)
         };
-
+        if let Some(model) = invalid_model {
+            warn!(
+                conversation_id = %self.params.conversation_id,
+                model_id = %model,
+                "reconcile_session: dropped unavailable desired model"
+            );
+        }
         for action in actions {
             match action {
                 ReconcileAction::SetMode { mode } => {

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -158,12 +158,11 @@ impl AcpAgentManager {
             };
         }
 
-        let (supports_load, preloaded_mode, preloaded_model) = {
+        let (supports_load, preloaded_mode) = {
             let session = self.session.read().await;
             (
                 session.agent_capabilities().map(|c| c.load_session).unwrap_or(false),
                 session.modes().map(|m| m.current_mode_id.to_string()),
-                session.model_info().map(|m| m.current_model_id.to_string()),
             )
         };
 
@@ -182,10 +181,7 @@ impl AcpAgentManager {
 
             {
                 let mut session = self.session.write().await;
-                if let Some(mut models) = load_response.models {
-                    if let Some(db_current) = preloaded_model {
-                        models.current_model_id = db_current.into();
-                    }
+                if let Some(models) = load_response.models {
                     session.apply_advertised_models(models);
                 }
                 if let Some(mut modes) = load_response.modes {

--- a/crates/aionui-ai-agent/src/manager/acp/session.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session.rs
@@ -218,6 +218,14 @@ impl AcpSession {
         &self.desired.config_selections
     }
 
+    /// Whether the requested model can be selected in the current session.
+    ///
+    /// Before the ACP backend advertises models, keep the historical permissive
+    /// behavior so initial seeds can still be reconciled once the session opens.
+    pub fn can_select_model(&self, model_id: &str) -> bool {
+        !model_id.is_empty() && self.is_model_valid(model_id)
+    }
+
     /// Set the user's desired mode. Emits `DesiredModeChanged` if the
     /// value actually changed. When advertised modes are known, the mode
     /// must be in the list (otherwise the call is a no-op).

--- a/crates/aionui-ai-agent/src/manager/acp/session.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session.rs
@@ -254,6 +254,23 @@ impl AcpSession {
         true
     }
 
+    /// Drop a desired model that is not advertised by the active ACP session.
+    ///
+    /// Initial model seeds can be loaded before `session/new` reports the
+    /// provider's available models. Once advertised models are known, reconcile
+    /// must not issue `session/set_model` for a stale seed.
+    pub fn clear_invalid_desired_model(&mut self) -> Option<ModelId> {
+        let model = self.desired.model_id.clone()?;
+        if self.is_model_valid(model.as_str()) {
+            return None;
+        }
+        self.desired.model_id = None;
+        if self.pending_model_notice.as_ref() == Some(&model) {
+            self.pending_model_notice = None;
+        }
+        Some(model)
+    }
+
     /// Set a user's desired config selection.
     pub fn set_desired_config(&mut self, key: ConfigKey, value: ConfigValue) {
         let changed = self.desired.config_selections.get(&key) != Some(&value);

--- a/crates/aionui-ai-agent/src/manager/acp/session_tests.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session_tests.rs
@@ -364,6 +364,31 @@ fn new_with_initial_model_sets_desired_model() {
 }
 
 #[test]
+fn clear_invalid_desired_model_drops_stale_initial_model() {
+    use agent_client_protocol::schema::ModelInfo;
+
+    let mut session = AcpSession::new(None, Some(ModelId::new("deepseek-v4-pro")), HashMap::new());
+    session.apply_advertised_models(SessionModelState::new(
+        "opus",
+        vec![
+            ModelInfo::new("default", "Default"),
+            ModelInfo::new("opus", "Opus"),
+            ModelInfo::new("sonnet", "Sonnet"),
+        ],
+    ));
+
+    assert_eq!(
+        session.clear_invalid_desired_model(),
+        Some(ModelId::new("deepseek-v4-pro"))
+    );
+    assert_eq!(session.desired_model(), None);
+    assert!(
+        session.plan_reconcile().is_empty(),
+        "invalid desired model must not produce session/set_model"
+    );
+}
+
+#[test]
 fn apply_advertised_config_options_emits_observed_config_synced_on_change() {
     let mut session = AcpSession::new(None, None, HashMap::new());
     session.apply_advertised_config_options(vec![SessionConfigOption::select(

--- a/crates/aionui-ai-agent/src/manager/acp/session_tests.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session_tests.rs
@@ -320,6 +320,23 @@ fn set_desired_model_validates_against_advertised() {
 }
 
 #[test]
+fn can_select_model_reports_unavailable_advertised_model() {
+    use agent_client_protocol::schema::ModelInfo;
+    let mut session = make_session();
+    session.apply_advertised_models(SessionModelState::new(
+        "claude-sonnet-4",
+        vec![
+            ModelInfo::new("claude-sonnet-4", "Sonnet 4"),
+            ModelInfo::new("claude-opus-4", "Opus 4"),
+        ],
+    ));
+
+    assert!(session.can_select_model("claude-opus-4"));
+    assert!(!session.can_select_model("nonexistent"));
+    assert!(!session.can_select_model(""));
+}
+
+#[test]
 fn set_desired_model_allows_any_when_advertised_empty() {
     let mut session = make_session();
     assert!(session.set_desired_model(ModelId::new("anything")));

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -158,6 +158,26 @@ impl AionrsAgentManager {
             cancel_notify: Arc::new(Notify::new()),
         })
     }
+
+    fn request_stop(&self, reason: Option<AgentKillReason>, operation: &'static str) {
+        let was_running = self.runtime.status() == Some(ConversationStatus::Running);
+
+        if let Ok(mut confs) = self.confirmations.write() {
+            confs.clear();
+        }
+
+        if was_running {
+            self.cancel_notify.notify_waiters();
+        }
+
+        info!(
+            conversation_id = %self.runtime.conversation_id(),
+            ?reason,
+            was_running,
+            operation,
+            "Aionrs stop signal requested"
+        );
+    }
 }
 
 #[async_trait::async_trait]
@@ -203,7 +223,7 @@ impl crate::agent_task::IAgentTask for AionrsAgentManager {
             _ = self.cancel_notify.notified() => {
                 info!(
                     conversation_id = %self.runtime.conversation_id(),
-                    "Aionrs engine.run() cancelled by user"
+                    "Aionrs engine.run() cancelled by stop signal"
                 );
                 engine.abort_current_turn("Tool execution canceled by user");
                 None
@@ -245,24 +265,12 @@ impl crate::agent_task::IAgentTask for AionrsAgentManager {
     }
 
     async fn cancel(&self) -> Result<(), AppError> {
-        info!(
-            conversation_id = %self.runtime.conversation_id(),
-            "Aionrs stop requested"
-        );
-        if let Ok(mut confs) = self.confirmations.write() {
-            confs.clear();
-        }
-        // Signal the tokio::select! in send_message() to drop engine.run()
-        self.cancel_notify.notify_waiters();
+        self.request_stop(None, "cancel");
         Ok(())
     }
 
     fn kill(&self, reason: Option<AgentKillReason>) -> Result<(), AppError> {
-        info!(
-            conversation_id = %self.runtime.conversation_id(),
-            ?reason,
-            "Killing Aionrs agent"
-        );
+        self.request_stop(reason, "kill");
         Ok(())
     }
 }
@@ -368,6 +376,18 @@ mod tests {
     use super::*;
     use crate::agent_task::IAgentTask;
 
+    async fn assert_no_stop_signal(agent: &AionrsAgentManager) {
+        let notified = agent.cancel_notify.notified();
+        tokio::pin!(notified);
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), &mut notified)
+                .await
+                .is_err(),
+            "idle stop must not leave a stale cancellation signal for the next turn"
+        );
+    }
+
     fn make_test_config() -> AionrsResolvedConfig {
         AionrsResolvedConfig {
             provider: "anthropic".into(),
@@ -417,7 +437,7 @@ mod tests {
             .await
             .unwrap();
         assert!(agent.kill(None).is_ok());
-        // kill() is a no-op for aionrs (no subprocess); status remains Pending.
+        // Idle kill only clears transient state; task-manager removal owns lifecycle cleanup.
         assert_eq!(agent.status(), Some(ConversationStatus::Pending));
     }
 
@@ -427,6 +447,43 @@ mod tests {
             .await
             .unwrap();
         assert!(agent.kill(Some(AgentKillReason::IdleTimeout)).is_ok());
+    }
+
+    #[tokio::test]
+    async fn aionrs_agent_kill_running_turn_sends_stop_signal() {
+        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config(), None)
+            .await
+            .unwrap();
+        agent.runtime.reset_for_new_turn(ConversationStatus::Running);
+
+        let notified = agent.cancel_notify.notified();
+        tokio::pin!(notified);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), &mut notified)
+                .await
+                .is_err()
+        );
+
+        agent
+            .kill(Some(AgentKillReason::ConversationDeleted))
+            .expect("kill should request stop");
+
+        tokio::time::timeout(std::time::Duration::from_millis(50), &mut notified)
+            .await
+            .expect("running kill should wake in-flight turn");
+    }
+
+    #[tokio::test]
+    async fn aionrs_agent_kill_idle_turn_does_not_leave_stale_stop_signal() {
+        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config(), None)
+            .await
+            .unwrap();
+
+        agent
+            .kill(Some(AgentKillReason::ConversationDeleted))
+            .expect("idle kill should be harmless");
+
+        assert_no_stop_signal(&agent).await;
     }
 
     #[tokio::test]
@@ -471,6 +528,7 @@ mod tests {
 
         assert_eq!(agent.status(), Some(ConversationStatus::Pending));
         assert!(matches!(rx.try_recv(), Err(broadcast::error::TryRecvError::Empty)));
+        assert_no_stop_signal(&agent).await;
     }
 
     #[tokio::test]

--- a/crates/aionui-ai-agent/src/protocol/error.rs
+++ b/crates/aionui-ai-agent/src/protocol/error.rs
@@ -55,6 +55,7 @@ impl CloseReason {
             CloseReason::UserCancel => "Conversation cancelled".to_owned(),
             CloseReason::Killed { reason } => match reason {
                 Some(AgentKillReason::IdleTimeout) => "Agent killed: idle timeout".to_owned(),
+                Some(AgentKillReason::AgentErrorRecovery) => "Agent killed: error recovery".to_owned(),
                 Some(AgentKillReason::TeamMcpRebuild) => "Agent killed: team MCP rebuild".to_owned(),
                 Some(AgentKillReason::TeamDeleted) => "Agent killed: team deleted".to_owned(),
                 Some(AgentKillReason::ConversationDeleted) => "Agent killed: conversation deleted".to_owned(),

--- a/crates/aionui-api-types/src/conversation.rs
+++ b/crates/aionui-api-types/src/conversation.rs
@@ -78,6 +78,25 @@ pub struct SendMessageResponse {
     pub msg_id: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConversationRuntimeStateKind {
+    Idle,
+    Starting,
+    Running,
+    WaitingConfirmation,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConversationRuntimeSummary {
+    pub state: ConversationRuntimeStateKind,
+    pub can_send_message: bool,
+    pub has_task: bool,
+    pub task_status: Option<ConversationStatus>,
+    pub is_processing: bool,
+    pub pending_confirmations: usize,
+}
+
 // ── Query types ────────────────────────────────────────────────────
 
 /// Query parameters for `GET /api/conversations`.
@@ -135,6 +154,8 @@ pub struct ConversationResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<ProviderWithModel>,
     pub status: ConversationStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<ConversationRuntimeSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<ConversationSource>,
     pub pinned: bool,
@@ -441,6 +462,7 @@ mod tests {
                 use_model: None,
             }),
             status: ConversationStatus::Pending,
+            runtime: None,
             source: Some(ConversationSource::Aionui),
             pinned: false,
             pinned_at: None,
@@ -477,6 +499,7 @@ mod tests {
             r#type: AgentType::Acp,
             model: None,
             status: ConversationStatus::Pending,
+            runtime: None,
             source: None,
             pinned: false,
             pinned_at: None,
@@ -507,6 +530,7 @@ mod tests {
             r#type: AgentType::Acp,
             model: None,
             status: ConversationStatus::Running,
+            runtime: None,
             source: None,
             pinned: true,
             pinned_at: Some(1712345678000),
@@ -589,6 +613,7 @@ mod tests {
                 r#type: AgentType::Acp,
                 model: None,
                 status: ConversationStatus::Finished,
+                runtime: None,
                 source: None,
                 pinned: false,
                 pinned_at: None,
@@ -624,6 +649,7 @@ mod tests {
                 r#type: AgentType::Acp,
                 model: None,
                 status: ConversationStatus::Finished,
+                runtime: None,
                 source: None,
                 pinned: false,
                 pinned_at: None,
@@ -693,6 +719,7 @@ mod tests {
                 r#type: AgentType::Acp,
                 model: None,
                 status: ConversationStatus::Pending,
+                runtime: None,
                 source: None,
                 pinned: false,
                 pinned_at: None,
@@ -736,6 +763,7 @@ mod tests {
                     r#type: AgentType::Acp,
                     model: None,
                     status: ConversationStatus::Finished,
+                    runtime: None,
                     source: None,
                     pinned: false,
                     pinned_at: None,

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -63,10 +63,10 @@ pub use connection_test::TestBedrockConnectionRequest;
 pub use conversation::{
     ActiveCountResponse, CloneConversationRequest, ConversationArtifactKind, ConversationArtifactListResponse,
     ConversationArtifactResponse, ConversationArtifactStatus, ConversationListResponse, ConversationMcpStatus,
-    ConversationMcpStatusKind, ConversationResponse, CreateConversationRequest, ListConversationsQuery,
-    ListMessagesQuery, MessageListResponse, MessageResponse, MessageSearchItem, MessageSearchResponse,
-    SearchMessagesQuery, SendMessageRequest, SendMessageResponse, UpdateConversationArtifactRequest,
-    UpdateConversationRequest,
+    ConversationMcpStatusKind, ConversationResponse, ConversationRuntimeStateKind, ConversationRuntimeSummary,
+    CreateConversationRequest, ListConversationsQuery, ListMessagesQuery, MessageListResponse, MessageResponse,
+    MessageSearchItem, MessageSearchResponse, SearchMessagesQuery, SendMessageRequest, SendMessageResponse,
+    UpdateConversationArtifactRequest, UpdateConversationRequest,
 };
 pub use cron::{
     CreateCronJobRequest, CronAgentConfigDto, CronJobExecutedEvent, CronJobMetadataDto, CronJobPayloadDto,

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -254,7 +254,8 @@ pub fn build_conversation_state(
         conversaion_repo,
         agent_metadata_repo,
         acp_session_repo,
-    );
+    )
+    .with_runtime_state(services.conversation_runtime_state.clone());
     conversation_service.with_mcp_server_repo(Arc::new(aionui_db::SqliteMcpServerRepository::new(
         services.database.pool().clone(),
     )));
@@ -390,15 +391,18 @@ pub async fn build_channel_state(
     let acp_session_repo: Arc<dyn aionui_db::IAcpSessionRepository> = Arc::new(
         aionui_db::SqliteAcpSessionRepository::new(services.database.pool().clone()),
     );
-    let conversation_svc = Arc::new(ConversationService::new(
-        services.work_dir.clone(),
-        services.event_bus.clone(),
-        skill_resolver,
-        services.worker_task_manager.clone(),
-        conv_repo,
-        agent_metadata_repo,
-        acp_session_repo,
-    ));
+    let conversation_svc = Arc::new(
+        ConversationService::new(
+            services.work_dir.clone(),
+            services.event_bus.clone(),
+            skill_resolver,
+            services.worker_task_manager.clone(),
+            conv_repo,
+            agent_metadata_repo,
+            acp_session_repo,
+        )
+        .with_runtime_state(services.conversation_runtime_state.clone()),
+    );
     conversation_svc.with_mcp_server_repo(Arc::new(aionui_db::SqliteMcpServerRepository::new(
         services.database.pool().clone(),
     )));
@@ -479,7 +483,8 @@ pub fn build_team_state(
         conv_repo,
         agent_metadata_repo,
         acp_session_repo,
-    );
+    )
+    .with_runtime_state(services.conversation_runtime_state.clone());
     conv_service.with_mcp_server_repo(Arc::new(aionui_db::SqliteMcpServerRepository::new(
         services.database.pool().clone(),
     )));
@@ -524,7 +529,8 @@ pub fn build_cron_state(services: &AppServices) -> CronRouterState {
         conv_repo.clone(),
         agent_metadata_repo,
         acp_session_repo,
-    );
+    )
+    .with_runtime_state(services.conversation_runtime_state.clone());
     conv_service.with_mcp_server_repo(Arc::new(aionui_db::SqliteMcpServerRepository::new(
         services.database.pool().clone(),
     )));

--- a/crates/aionui-app/src/services.rs
+++ b/crates/aionui-app/src/services.rs
@@ -10,6 +10,7 @@ use aionui_ai_agent::{
 use aionui_api_types::GuideMcpConfig;
 use aionui_auth::{CookieConfig, JwtService, QrTokenStore, resolve_jwt_secret};
 use aionui_common::OnConversationDelete;
+use aionui_conversation::runtime_state::ConversationRuntimeStateService;
 use aionui_db::{
     Database, IAcpSessionRepository, IAgentMetadataRepository, IConversationRepository, IMcpServerRepository,
     IUserRepository, SqliteAcpSessionRepository, SqliteAgentMetadataRepository, SqliteConversationRepository,
@@ -29,6 +30,7 @@ pub struct AppServices {
     pub ws_manager: Arc<WebSocketManager>,
     pub event_bus: Arc<BroadcastEventBus>,
     pub worker_task_manager: Arc<dyn IWorkerTaskManager>,
+    pub conversation_runtime_state: Arc<ConversationRuntimeStateService>,
     /// Same instance as `worker_task_manager`, exposed through the
     /// `OnConversationDelete` trait so `ConversationService::with_delete_hook`
     /// can wire it up. Optional because tests construct `AppServices` with a
@@ -179,6 +181,7 @@ impl AppServices {
         let task_manager_concrete = Arc::new(WorkerTaskManagerImpl::new(factory));
         let worker_task_manager: Arc<dyn IWorkerTaskManager> = task_manager_concrete.clone();
         let task_manager_delete_hook: Arc<dyn OnConversationDelete> = task_manager_concrete;
+        let conversation_runtime_state = Arc::new(ConversationRuntimeStateService::default());
 
         Ok(Self {
             database,
@@ -189,6 +192,7 @@ impl AppServices {
             ws_manager: Arc::new(WebSocketManager::new()),
             event_bus: Arc::new(BroadcastEventBus::new(256)),
             worker_task_manager,
+            conversation_runtime_state,
             task_manager_delete_hook: Some(task_manager_delete_hook),
             agent_registry,
             conversation_repo,

--- a/crates/aionui-common/src/enums.rs
+++ b/crates/aionui-common/src/enums.rs
@@ -204,6 +204,10 @@ pub enum RemoteAgentStatus {
 #[serde(rename_all = "snake_case")]
 pub enum AgentKillReason {
     IdleTimeout,
+    /// The ACP session ended a turn with a terminal error. The conversation is
+    /// preserved; only the in-memory agent task is recycled before the next send
+    /// so a potentially desynchronised upstream session is not reused.
+    AgentErrorRecovery,
     /// Team session is rebuilding the agent process to inject a fresh
     /// `team_mcp_stdio_config`. The conversation is preserved; only the
     /// in-memory ACP CLI is recycled.

--- a/crates/aionui-conversation/src/acp_error_recovery.rs
+++ b/crates/aionui-conversation/src/acp_error_recovery.rs
@@ -1,0 +1,113 @@
+use std::sync::Arc;
+
+use aionui_api_types::AgentErrorCode;
+use aionui_common::{AgentKillReason, AgentType, now_ms};
+use aionui_db::SaveRuntimeStateParams;
+use tracing::{info, warn};
+
+use crate::service::ConversationService;
+use crate::stream_relay::RelayOutcome;
+use aionui_ai_agent::IWorkerTaskManager;
+
+impl ConversationService {
+    async fn clear_persisted_acp_model_after_model_not_found(
+        &self,
+        conversation_id: &str,
+        error_code: Option<AgentErrorCode>,
+    ) {
+        if error_code != Some(AgentErrorCode::UserLlmProviderModelNotFound) {
+            return;
+        }
+
+        let previous_model_id = match self.acp_session_repo().load_runtime_state(conversation_id).await {
+            Ok(Some(state)) => state.current_model_id,
+            Ok(None) => None,
+            Err(err) => {
+                warn!(
+                    conversation_id,
+                    error = %err,
+                    "Failed to load ACP persisted model before clearing after model_not_found"
+                );
+                None
+            }
+        };
+
+        let params = SaveRuntimeStateParams {
+            current_model_id: Some(None),
+            ..Default::default()
+        };
+        match self
+            .acp_session_repo()
+            .save_runtime_state(conversation_id, &params)
+            .await
+        {
+            Ok(true) => {
+                info!(
+                    conversation_id,
+                    ?previous_model_id,
+                    error_code = ?error_code,
+                    reason = ?AgentKillReason::AgentErrorRecovery,
+                    "ACP persisted model cleared after model_not_found"
+                );
+            }
+            Ok(false) => {
+                warn!(
+                    conversation_id,
+                    ?previous_model_id,
+                    error_code = ?error_code,
+                    reason = ?AgentKillReason::AgentErrorRecovery,
+                    "ACP persisted model clear skipped because session row is missing"
+                );
+            }
+            Err(err) => {
+                warn!(
+                    conversation_id,
+                    ?previous_model_id,
+                    error = %err,
+                    error_code = ?error_code,
+                    reason = ?AgentKillReason::AgentErrorRecovery,
+                    "Failed to clear ACP persisted model after model_not_found"
+                );
+            }
+        }
+    }
+
+    pub(crate) async fn evict_acp_task_after_terminal_error(
+        &self,
+        conversation_id: &str,
+        agent_type: AgentType,
+        outcome: &RelayOutcome,
+        task_manager: &Arc<dyn IWorkerTaskManager>,
+    ) -> bool {
+        if agent_type != AgentType::Acp || !outcome.terminal.is_error() {
+            return false;
+        }
+
+        let started_at = now_ms();
+        let error_code = outcome.terminal.code();
+        let retryable = outcome.terminal.retryable();
+        info!(
+            conversation_id,
+            ?agent_type,
+            error_code = ?error_code,
+            retryable = ?retryable,
+            reason = ?AgentKillReason::AgentErrorRecovery,
+            "ACP task marked unhealthy after terminal error; evicting task"
+        );
+        task_manager
+            .kill_and_wait(conversation_id, Some(AgentKillReason::AgentErrorRecovery))
+            .await;
+        self.clear_persisted_acp_model_after_model_not_found(conversation_id, error_code)
+            .await;
+        info!(
+            conversation_id,
+            ?agent_type,
+            error_code = ?error_code,
+            retryable = ?retryable,
+            elapsed_ms = now_ms().saturating_sub(started_at),
+            reason = ?AgentKillReason::AgentErrorRecovery,
+            "ACP task eviction completed after terminal error"
+        );
+        true
+    }
+}

--- a/crates/aionui-conversation/src/acp_error_recovery.rs
+++ b/crates/aionui-conversation/src/acp_error_recovery.rs
@@ -1,15 +1,129 @@
 use std::sync::Arc;
 
 use aionui_api_types::AgentErrorCode;
-use aionui_common::{AgentKillReason, AgentType, now_ms};
-use aionui_db::SaveRuntimeStateParams;
+use aionui_common::{AgentKillReason, AgentType, ConversationSource, now_ms};
+use aionui_db::{ConversationRowUpdate, SaveRuntimeStateParams};
 use tracing::{info, warn};
 
+use crate::convert::string_to_enum;
 use crate::service::ConversationService;
 use crate::stream_relay::RelayOutcome;
 use aionui_ai_agent::IWorkerTaskManager;
 
 impl ConversationService {
+    async fn clear_conversation_model_seed_after_model_not_found(
+        &self,
+        conversation_id: &str,
+        error_code: Option<AgentErrorCode>,
+    ) {
+        if error_code != Some(AgentErrorCode::UserLlmProviderModelNotFound) {
+            return;
+        }
+
+        let row = match self.conversation_repo().get(conversation_id).await {
+            Ok(Some(row)) => row,
+            Ok(None) => {
+                warn!(
+                    conversation_id,
+                    error_code = ?error_code,
+                    reason = ?AgentKillReason::AgentErrorRecovery,
+                    "Conversation ACP model seed clear skipped because conversation row is missing"
+                );
+                return;
+            }
+            Err(err) => {
+                warn!(
+                    conversation_id,
+                    error = %err,
+                    error_code = ?error_code,
+                    reason = ?AgentKillReason::AgentErrorRecovery,
+                    "Failed to load conversation before clearing ACP model seed"
+                );
+                return;
+            }
+        };
+
+        let mut extra: serde_json::Value = match serde_json::from_str(&row.extra) {
+            Ok(extra) => extra,
+            Err(err) => {
+                warn!(
+                    conversation_id,
+                    error = %err,
+                    error_code = ?error_code,
+                    reason = ?AgentKillReason::AgentErrorRecovery,
+                    "Conversation ACP model seed clear skipped because extra JSON is invalid"
+                );
+                return;
+            }
+        };
+
+        let Some(extra_obj) = extra.as_object_mut() else {
+            warn!(
+                conversation_id,
+                error_code = ?error_code,
+                reason = ?AgentKillReason::AgentErrorRecovery,
+                "Conversation ACP model seed clear skipped because extra is not an object"
+            );
+            return;
+        };
+        let Some(previous_model_value) = extra_obj.remove("current_model_id") else {
+            return;
+        };
+        let previous_model_id = previous_model_value.as_str().map(ToOwned::to_owned);
+        if previous_model_id.is_none() {
+            warn!(
+                conversation_id,
+                error_code = ?error_code,
+                reason = ?AgentKillReason::AgentErrorRecovery,
+                "Conversation ACP model seed was malformed and will be cleared"
+            );
+        }
+
+        let extra_json = match serde_json::to_string(&extra) {
+            Ok(json) => json,
+            Err(err) => {
+                warn!(
+                    conversation_id,
+                    ?previous_model_id,
+                    error = %err,
+                    error_code = ?error_code,
+                    reason = ?AgentKillReason::AgentErrorRecovery,
+                    "Failed to serialize conversation extra after clearing ACP model seed"
+                );
+                return;
+            }
+        };
+        let update = ConversationRowUpdate {
+            extra: Some(extra_json),
+            updated_at: Some(now_ms()),
+            ..Default::default()
+        };
+        if let Err(err) = self.conversation_repo().update(conversation_id, &update).await {
+            warn!(
+                conversation_id,
+                ?previous_model_id,
+                error = %err,
+                error_code = ?error_code,
+                reason = ?AgentKillReason::AgentErrorRecovery,
+                "Failed to clear conversation ACP model seed after model_not_found"
+            );
+            return;
+        }
+
+        let source = row
+            .source
+            .as_deref()
+            .and_then(|value| string_to_enum::<ConversationSource>(value).ok());
+        self.broadcast_list_changed(conversation_id, "updated", source.as_ref());
+        info!(
+            conversation_id,
+            ?previous_model_id,
+            error_code = ?error_code,
+            reason = ?AgentKillReason::AgentErrorRecovery,
+            "Conversation ACP model seed cleared after model_not_found"
+        );
+    }
+
     async fn clear_persisted_acp_model_after_model_not_found(
         &self,
         conversation_id: &str,
@@ -98,6 +212,8 @@ impl ConversationService {
             .kill_and_wait(conversation_id, Some(AgentKillReason::AgentErrorRecovery))
             .await;
         self.clear_persisted_acp_model_after_model_not_found(conversation_id, error_code)
+            .await;
+        self.clear_conversation_model_seed_after_model_not_found(conversation_id, error_code)
             .await;
         info!(
             conversation_id,

--- a/crates/aionui-conversation/src/convert.rs
+++ b/crates/aionui-conversation/src/convert.rs
@@ -65,6 +65,7 @@ pub fn row_to_response_with_extra(
         r#type: agent_type,
         model,
         status,
+        runtime: None,
         source,
         pinned: row.pinned,
         pinned_at: row.pinned_at,

--- a/crates/aionui-conversation/src/lib.rs
+++ b/crates/aionui-conversation/src/lib.rs
@@ -1,4 +1,5 @@
 //! Conversation and message CRUD with streaming relay and event emission.
+mod acp_error_recovery;
 mod convert;
 mod message_persistence;
 pub mod response_middleware;

--- a/crates/aionui-conversation/src/lib.rs
+++ b/crates/aionui-conversation/src/lib.rs
@@ -4,6 +4,7 @@ mod message_persistence;
 pub mod response_middleware;
 pub mod routes;
 pub mod routes_aux;
+pub mod runtime_state;
 pub mod service;
 mod service_ops;
 pub mod skill_resolver;

--- a/crates/aionui-conversation/src/runtime_state.rs
+++ b/crates/aionui-conversation/src/runtime_state.rs
@@ -1,0 +1,163 @@
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex, Weak},
+};
+
+use aionui_api_types::{ConversationRuntimeStateKind, ConversationRuntimeSummary};
+use aionui_common::{AppError, ConversationStatus};
+use tracing::{info, warn};
+
+#[derive(Debug, Default)]
+pub struct ConversationRuntimeStateService {
+    active_turns: Mutex<HashSet<String>>,
+}
+
+#[derive(Debug)]
+pub struct TurnClaim {
+    conversation_id: String,
+    state: Weak<ConversationRuntimeStateService>,
+    released: bool,
+}
+
+impl ConversationRuntimeStateService {
+    pub fn try_claim_turn(self: &Arc<Self>, conversation_id: &str) -> Result<TurnClaim, AppError> {
+        let mut active_turns = self.active_turns.lock().map_err(|_| {
+            warn!(
+                conversation_id,
+                "conversation runtime state lock poisoned while claiming turn"
+            );
+            AppError::Internal("conversation runtime state lock poisoned".into())
+        })?;
+
+        if !active_turns.insert(conversation_id.to_owned()) {
+            info!(conversation_id, "conversation runtime turn claim rejected");
+            return Err(AppError::Conflict(format!(
+                "conversation {conversation_id} is already running"
+            )));
+        }
+
+        info!(conversation_id, "conversation runtime turn claimed");
+
+        Ok(TurnClaim {
+            conversation_id: conversation_id.to_owned(),
+            state: Arc::downgrade(self),
+            released: false,
+        })
+    }
+
+    pub fn is_claimed(&self, conversation_id: &str) -> bool {
+        self.active_turns
+            .lock()
+            .map(|active_turns| active_turns.contains(conversation_id))
+            .unwrap_or(false)
+    }
+
+    pub fn summary_from_parts(
+        &self,
+        conversation_id: &str,
+        task_status: Option<ConversationStatus>,
+        has_task: bool,
+        pending_confirmations: usize,
+    ) -> ConversationRuntimeSummary {
+        let claimed = self.is_claimed(conversation_id);
+
+        let state = if pending_confirmations > 0 {
+            ConversationRuntimeStateKind::WaitingConfirmation
+        } else if claimed && task_status != Some(ConversationStatus::Running) {
+            ConversationRuntimeStateKind::Starting
+        } else if claimed || task_status == Some(ConversationStatus::Running) {
+            ConversationRuntimeStateKind::Running
+        } else {
+            ConversationRuntimeStateKind::Idle
+        };
+
+        let is_processing = state != ConversationRuntimeStateKind::Idle;
+
+        ConversationRuntimeSummary {
+            state,
+            can_send_message: !is_processing,
+            has_task,
+            task_status,
+            is_processing,
+            pending_confirmations,
+        }
+    }
+
+    fn release(&self, conversation_id: &str) {
+        match self.active_turns.lock() {
+            Ok(mut active_turns) => {
+                active_turns.remove(conversation_id);
+                info!(conversation_id, "conversation runtime turn claim released");
+            }
+            Err(_) => {
+                warn!(
+                    conversation_id,
+                    "conversation runtime state lock poisoned while releasing turn"
+                );
+            }
+        }
+    }
+}
+
+impl TurnClaim {
+    pub fn release(&mut self) {
+        self.release_inner();
+    }
+
+    fn release_inner(&mut self) {
+        if self.released {
+            return;
+        }
+
+        if let Some(state) = self.state.upgrade() {
+            state.release(&self.conversation_id);
+        }
+        self.released = true;
+    }
+}
+
+impl Drop for TurnClaim {
+    fn drop(&mut self) {
+        self.release_inner();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[test]
+    fn claim_rejects_second_active_turn() {
+        let state = Arc::new(ConversationRuntimeStateService::default());
+        let _claim = state.try_claim_turn("conv-1").expect("first claim should win");
+
+        let err = state.try_claim_turn("conv-1").expect_err("second claim should fail");
+        assert!(err.to_string().contains("already running"));
+    }
+
+    #[test]
+    fn claim_releases_on_drop() {
+        let state = Arc::new(ConversationRuntimeStateService::default());
+        {
+            let _claim = state.try_claim_turn("conv-1").expect("claim should be created");
+            assert!(state.is_claimed("conv-1"));
+        }
+
+        assert!(!state.is_claimed("conv-1"));
+        assert!(state.try_claim_turn("conv-1").is_ok());
+    }
+
+    #[test]
+    fn summary_uses_claim_as_starting_state() {
+        let state = Arc::new(ConversationRuntimeStateService::default());
+        let _claim = state.try_claim_turn("conv-1").expect("claim should be created");
+
+        let summary = state.summary_from_parts("conv-1", None, false, 0);
+
+        assert_eq!(summary.state, ConversationRuntimeStateKind::Starting);
+        assert!(summary.is_processing);
+        assert!(!summary.can_send_message);
+    }
+}

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -16,8 +16,8 @@ use aionui_api_types::{
     UpdateConversationRequest, WebSocketMessage,
 };
 use aionui_common::{
-    AgentType, AppError, ConversationSource, ConversationStatus, ErrorChain, MessageType, OnConversationDelete,
-    PaginatedResult, generate_short_id, now_ms,
+    AgentKillReason, AgentType, AppError, ConversationSource, ConversationStatus, ErrorChain, MessageType,
+    OnConversationDelete, PaginatedResult, generate_short_id, now_ms,
 };
 use aionui_db::models::{ConversationRow, MessageRow};
 use aionui_db::{
@@ -37,7 +37,7 @@ use crate::convert::{
 };
 use crate::skill_resolver::SkillResolver;
 use crate::skill_snapshot::{backfill_skills_if_missing, compute_initial_skills};
-use crate::stream_relay::StreamRelay;
+use crate::stream_relay::{RelayOutcome, StreamRelay};
 use std::sync::RwLock;
 
 const MAX_CRON_CONTINUATIONS_PER_TURN: usize = 4;
@@ -213,6 +213,42 @@ impl ConversationService {
             Some(runtime),
         )
         .await;
+    }
+
+    async fn evict_acp_task_after_terminal_error(
+        conversation_id: &str,
+        agent_type: AgentType,
+        outcome: &RelayOutcome,
+        task_manager: &Arc<dyn IWorkerTaskManager>,
+    ) -> bool {
+        if agent_type != AgentType::Acp || !outcome.terminal.is_error() {
+            return false;
+        }
+
+        let started_at = now_ms();
+        let error_code = outcome.terminal.code();
+        let retryable = outcome.terminal.retryable();
+        info!(
+            conversation_id,
+            ?agent_type,
+            error_code = ?error_code,
+            retryable = ?retryable,
+            reason = ?AgentKillReason::AgentErrorRecovery,
+            "ACP task marked unhealthy after terminal error; evicting task"
+        );
+        task_manager
+            .kill_and_wait(conversation_id, Some(AgentKillReason::AgentErrorRecovery))
+            .await;
+        info!(
+            conversation_id,
+            ?agent_type,
+            error_code = ?error_code,
+            retryable = ?retryable,
+            elapsed_ms = now_ms().saturating_sub(started_at),
+            reason = ?AgentKillReason::AgentErrorRecovery,
+            "ACP task eviction completed after terminal error"
+        );
+        true
     }
 }
 
@@ -1425,6 +1461,12 @@ impl ConversationService {
 
                 if let Some(session_key) = agent.get_session_key() {
                     persist_session_key(&repo, &conv_id, &session_key).await;
+                }
+
+                if Self::evict_acp_task_after_terminal_error(&conv_id, agent.agent_type(), &outcome, &task_manager)
+                    .await
+                {
+                    break;
                 }
 
                 if outcome.system_responses.is_empty() {

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -1719,7 +1719,12 @@ impl ConversationService {
     }
 
     /// Broadcast a `conversation.listChanged` WebSocket event.
-    fn broadcast_list_changed(&self, conversation_id: &str, action: &str, source: Option<&ConversationSource>) {
+    pub(crate) fn broadcast_list_changed(
+        &self,
+        conversation_id: &str,
+        action: &str,
+        source: Option<&ConversationSource>,
+    ) {
         let payload = serde_json::json!({
             "conversation_id": conversation_id,
             "action": action,

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -7,7 +7,7 @@ use aionui_ai_agent::{AgentInstance, IWorkerTaskManager};
 use crate::response_middleware::ICronService;
 use crate::runtime_state::ConversationRuntimeStateService;
 use aionui_api_types::{
-    ApprovalCheckResponse, CloneConversationRequest, ConfirmRequest, ConfirmationListResponse,
+    AgentErrorCode, ApprovalCheckResponse, CloneConversationRequest, ConfirmRequest, ConfirmationListResponse,
     ConversationArtifactKind, ConversationArtifactListResponse, ConversationArtifactResponse,
     ConversationArtifactStatus, ConversationListResponse, ConversationMcpStatus, ConversationMcpStatusKind,
     ConversationResponse, ConversationRuntimeSummary, CreateConversationRequest, ListConversationsQuery,
@@ -215,7 +215,66 @@ impl ConversationService {
         .await;
     }
 
+    async fn clear_persisted_acp_model_after_model_not_found(
+        &self,
+        conversation_id: &str,
+        error_code: Option<AgentErrorCode>,
+    ) {
+        if error_code != Some(AgentErrorCode::UserLlmProviderModelNotFound) {
+            return;
+        }
+
+        let previous_model_id = match self.acp_session_repo.load_runtime_state(conversation_id).await {
+            Ok(Some(state)) => state.current_model_id,
+            Ok(None) => None,
+            Err(err) => {
+                warn!(
+                    conversation_id,
+                    error = %err,
+                    "Failed to load ACP persisted model before clearing after model_not_found"
+                );
+                None
+            }
+        };
+
+        let params = SaveRuntimeStateParams {
+            current_model_id: Some(None),
+            ..Default::default()
+        };
+        match self.acp_session_repo.save_runtime_state(conversation_id, &params).await {
+            Ok(true) => {
+                info!(
+                    conversation_id,
+                    ?previous_model_id,
+                    error_code = ?error_code,
+                    reason = ?AgentKillReason::AgentErrorRecovery,
+                    "ACP persisted model cleared after model_not_found"
+                );
+            }
+            Ok(false) => {
+                warn!(
+                    conversation_id,
+                    ?previous_model_id,
+                    error_code = ?error_code,
+                    reason = ?AgentKillReason::AgentErrorRecovery,
+                    "ACP persisted model clear skipped because session row is missing"
+                );
+            }
+            Err(err) => {
+                warn!(
+                    conversation_id,
+                    ?previous_model_id,
+                    error = %err,
+                    error_code = ?error_code,
+                    reason = ?AgentKillReason::AgentErrorRecovery,
+                    "Failed to clear ACP persisted model after model_not_found"
+                );
+            }
+        }
+    }
+
     async fn evict_acp_task_after_terminal_error(
+        &self,
         conversation_id: &str,
         agent_type: AgentType,
         outcome: &RelayOutcome,
@@ -238,6 +297,8 @@ impl ConversationService {
         );
         task_manager
             .kill_and_wait(conversation_id, Some(AgentKillReason::AgentErrorRecovery))
+            .await;
+        self.clear_persisted_acp_model_after_model_not_found(conversation_id, error_code)
             .await;
         info!(
             conversation_id,
@@ -1463,7 +1524,8 @@ impl ConversationService {
                     persist_session_key(&repo, &conv_id, &session_key).await;
                 }
 
-                if Self::evict_acp_task_after_terminal_error(&conv_id, agent.agent_type(), &outcome, &task_manager)
+                if service
+                    .evict_acp_task_after_terminal_error(&conv_id, agent.agent_type(), &outcome, &task_manager)
                     .await
                 {
                     break;

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -7,7 +7,7 @@ use aionui_ai_agent::{AgentInstance, IWorkerTaskManager};
 use crate::response_middleware::ICronService;
 use crate::runtime_state::ConversationRuntimeStateService;
 use aionui_api_types::{
-    AgentErrorCode, ApprovalCheckResponse, CloneConversationRequest, ConfirmRequest, ConfirmationListResponse,
+    ApprovalCheckResponse, CloneConversationRequest, ConfirmRequest, ConfirmationListResponse,
     ConversationArtifactKind, ConversationArtifactListResponse, ConversationArtifactResponse,
     ConversationArtifactStatus, ConversationListResponse, ConversationMcpStatus, ConversationMcpStatusKind,
     ConversationResponse, ConversationRuntimeSummary, CreateConversationRequest, ListConversationsQuery,
@@ -16,8 +16,8 @@ use aionui_api_types::{
     UpdateConversationRequest, WebSocketMessage,
 };
 use aionui_common::{
-    AgentKillReason, AgentType, AppError, ConversationSource, ConversationStatus, ErrorChain, MessageType,
-    OnConversationDelete, PaginatedResult, generate_short_id, now_ms,
+    AgentType, AppError, ConversationSource, ConversationStatus, ErrorChain, MessageType, OnConversationDelete,
+    PaginatedResult, generate_short_id, now_ms,
 };
 use aionui_db::models::{ConversationRow, MessageRow};
 use aionui_db::{
@@ -37,7 +37,7 @@ use crate::convert::{
 };
 use crate::skill_resolver::SkillResolver;
 use crate::skill_snapshot::{backfill_skills_if_missing, compute_initial_skills};
-use crate::stream_relay::{RelayOutcome, StreamRelay};
+use crate::stream_relay::StreamRelay;
 use std::sync::RwLock;
 
 const MAX_CRON_CONTINUATIONS_PER_TURN: usize = 4;
@@ -184,6 +184,10 @@ impl ConversationService {
         &self.conversation_repo
     }
 
+    pub(crate) fn acp_session_repo(&self) -> &Arc<dyn IAcpSessionRepository> {
+        &self.acp_session_repo
+    }
+
     pub fn runtime_state(&self) -> Arc<ConversationRuntimeStateService> {
         self.runtime_state.clone()
     }
@@ -213,103 +217,6 @@ impl ConversationService {
             Some(runtime),
         )
         .await;
-    }
-
-    async fn clear_persisted_acp_model_after_model_not_found(
-        &self,
-        conversation_id: &str,
-        error_code: Option<AgentErrorCode>,
-    ) {
-        if error_code != Some(AgentErrorCode::UserLlmProviderModelNotFound) {
-            return;
-        }
-
-        let previous_model_id = match self.acp_session_repo.load_runtime_state(conversation_id).await {
-            Ok(Some(state)) => state.current_model_id,
-            Ok(None) => None,
-            Err(err) => {
-                warn!(
-                    conversation_id,
-                    error = %err,
-                    "Failed to load ACP persisted model before clearing after model_not_found"
-                );
-                None
-            }
-        };
-
-        let params = SaveRuntimeStateParams {
-            current_model_id: Some(None),
-            ..Default::default()
-        };
-        match self.acp_session_repo.save_runtime_state(conversation_id, &params).await {
-            Ok(true) => {
-                info!(
-                    conversation_id,
-                    ?previous_model_id,
-                    error_code = ?error_code,
-                    reason = ?AgentKillReason::AgentErrorRecovery,
-                    "ACP persisted model cleared after model_not_found"
-                );
-            }
-            Ok(false) => {
-                warn!(
-                    conversation_id,
-                    ?previous_model_id,
-                    error_code = ?error_code,
-                    reason = ?AgentKillReason::AgentErrorRecovery,
-                    "ACP persisted model clear skipped because session row is missing"
-                );
-            }
-            Err(err) => {
-                warn!(
-                    conversation_id,
-                    ?previous_model_id,
-                    error = %err,
-                    error_code = ?error_code,
-                    reason = ?AgentKillReason::AgentErrorRecovery,
-                    "Failed to clear ACP persisted model after model_not_found"
-                );
-            }
-        }
-    }
-
-    async fn evict_acp_task_after_terminal_error(
-        &self,
-        conversation_id: &str,
-        agent_type: AgentType,
-        outcome: &RelayOutcome,
-        task_manager: &Arc<dyn IWorkerTaskManager>,
-    ) -> bool {
-        if agent_type != AgentType::Acp || !outcome.terminal.is_error() {
-            return false;
-        }
-
-        let started_at = now_ms();
-        let error_code = outcome.terminal.code();
-        let retryable = outcome.terminal.retryable();
-        info!(
-            conversation_id,
-            ?agent_type,
-            error_code = ?error_code,
-            retryable = ?retryable,
-            reason = ?AgentKillReason::AgentErrorRecovery,
-            "ACP task marked unhealthy after terminal error; evicting task"
-        );
-        task_manager
-            .kill_and_wait(conversation_id, Some(AgentKillReason::AgentErrorRecovery))
-            .await;
-        self.clear_persisted_acp_model_after_model_not_found(conversation_id, error_code)
-            .await;
-        info!(
-            conversation_id,
-            ?agent_type,
-            error_code = ?error_code,
-            retryable = ?retryable,
-            elapsed_ms = now_ms().saturating_sub(started_at),
-            reason = ?AgentKillReason::AgentErrorRecovery,
-            "ACP task eviction completed after terminal error"
-        );
-        true
     }
 }
 

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -5,13 +5,15 @@ use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
 use aionui_ai_agent::{AgentInstance, IWorkerTaskManager};
 
 use crate::response_middleware::ICronService;
+use crate::runtime_state::ConversationRuntimeStateService;
 use aionui_api_types::{
     ApprovalCheckResponse, CloneConversationRequest, ConfirmRequest, ConfirmationListResponse,
     ConversationArtifactKind, ConversationArtifactListResponse, ConversationArtifactResponse,
     ConversationArtifactStatus, ConversationListResponse, ConversationMcpStatus, ConversationMcpStatusKind,
-    ConversationResponse, CreateConversationRequest, ListConversationsQuery, ListMessagesQuery, MessageListResponse,
-    MessageResponse, MessageSearchResponse, SearchMessagesQuery, SendMessageRequest, SessionMcpServer,
-    SessionMcpTransport, UpdateConversationArtifactRequest, UpdateConversationRequest, WebSocketMessage,
+    ConversationResponse, ConversationRuntimeSummary, CreateConversationRequest, ListConversationsQuery,
+    ListMessagesQuery, MessageListResponse, MessageResponse, MessageSearchResponse, SearchMessagesQuery,
+    SendMessageRequest, SessionMcpServer, SessionMcpTransport, UpdateConversationArtifactRequest,
+    UpdateConversationRequest, WebSocketMessage,
 };
 use aionui_common::{
     AgentType, AppError, ConversationSource, ConversationStatus, ErrorChain, MessageType, OnConversationDelete,
@@ -99,6 +101,7 @@ pub struct ConversationService {
     delete_hooks: Arc<RwLock<Vec<Arc<dyn OnConversationDelete>>>>,
     cron_service: Arc<RwLock<Option<Arc<dyn ICronService>>>>,
     mcp_server_repo: Arc<RwLock<Option<Arc<dyn IMcpServerRepository>>>>,
+    runtime_state: Arc<ConversationRuntimeStateService>,
 
     // Repos for conversation, acp_session and agent_metadata access.
     conversation_repo: Arc<dyn IConversationRepository>,
@@ -127,11 +130,17 @@ impl ConversationService {
             delete_hooks: Arc::new(RwLock::new(Vec::new())),
             cron_service: Arc::new(RwLock::new(None)),
             mcp_server_repo: Arc::new(RwLock::new(None)),
+            runtime_state: Arc::new(ConversationRuntimeStateService::default()),
 
             conversation_repo,
             agent_metadata_repo,
             acp_session_repo,
         }
+    }
+
+    pub fn with_runtime_state(mut self, runtime_state: Arc<ConversationRuntimeStateService>) -> Self {
+        self.runtime_state = runtime_state;
+        self
     }
 
     pub fn with_cron_service(&self, cron_service: Option<Arc<dyn ICronService>>) {
@@ -175,10 +184,35 @@ impl ConversationService {
         &self.conversation_repo
     }
 
+    pub fn runtime_state(&self) -> Arc<ConversationRuntimeStateService> {
+        self.runtime_state.clone()
+    }
+
     pub(crate) fn task(&self, conversation_id: &str) -> Result<AgentInstance, AppError> {
         self.task_manager
             .get_task(conversation_id)
             .ok_or_else(|| AppError::NotFound(format!("No active agent for conversation '{conversation_id}'")))
+    }
+
+    pub async fn runtime_summary_for(&self, conversation_id: &str) -> ConversationRuntimeSummary {
+        let agent = self.task_manager.get_task(conversation_id);
+        let has_task = agent.is_some();
+        let task_status = agent.as_ref().and_then(|agent| agent.status());
+        let pending_confirmations = agent.as_ref().map(|agent| agent.get_confirmations().len()).unwrap_or(0);
+
+        self.runtime_state
+            .summary_from_parts(conversation_id, task_status, has_task, pending_confirmations)
+    }
+
+    pub async fn complete_turn(&self, conversation_id: &str) {
+        let runtime = self.runtime_summary_for(conversation_id).await;
+        StreamRelay::complete_conversation_with_runtime(
+            &self.conversation_repo,
+            &self.broadcaster,
+            conversation_id,
+            Some(runtime),
+        )
+        .await;
     }
 }
 
@@ -544,7 +578,9 @@ impl ConversationService {
         let mut extra: serde_json::Value =
             serde_json::from_str(&row.extra).map_err(|e| AppError::Internal(format!("Invalid extra JSON: {e}")))?;
         self.backfill_extra_inplace(&row.id, &mut extra).await;
-        row_to_response_with_extra(row, extra, &self.workspace_root)
+        let mut response = row_to_response_with_extra(row, extra, &self.workspace_root)?;
+        response.runtime = Some(self.runtime_summary_for(id).await);
+        Ok(response)
     }
 
     /// List conversations with cursor-based pagination and optional filters.
@@ -1188,7 +1224,7 @@ impl ConversationService {
     ///
     /// 1. Validates the conversation belongs to the user
     /// 2. Stores the user message (position: "right", status: "finish")
-    /// 3. Marks the conversation as running
+    /// 3. Claims the conversation in runtime state
     /// 4. Spawns background agent build/send and stream relay work
     /// 5. Returns immediately (202 Accepted semantics)
     #[tracing::instrument(skip_all, fields(user_id = %user_id, conversation_id = %conversation_id))]
@@ -1226,16 +1262,7 @@ impl ConversationService {
             ));
         }
 
-        // Check if conversation is already processing (simple guard)
-        let status: ConversationStatus = match row.status.as_deref() {
-            None | Some("") => ConversationStatus::Finished,
-            Some(s) => string_to_enum(s)?,
-        };
-        if status == ConversationStatus::Running {
-            return Err(AppError::Conflict(
-                "Conversation is already processing a message".into(),
-            ));
-        }
+        let turn_claim = self.runtime_state.try_claim_turn(conversation_id)?;
 
         // Store user message. `msg_id` is server-generated so the WebSocket
         // stream, DB row, and client-side message index all agree on the same
@@ -1289,17 +1316,6 @@ impl ConversationService {
         self.ensure_auto_workspace_skill_links(&row, &build_opts).await;
         let stored_workspace = build_opts.workspace.clone();
 
-        // TODO: 好蠢的设计, status 写数据库, 最好干掉啦
-        let update = ConversationRowUpdate {
-            status: Some(enum_to_db(&ConversationStatus::Running)?),
-            updated_at: Some(now_ms()),
-            ..Default::default()
-        };
-
-        if let Err(e) = self.conversation_repo.update(conversation_id, &update).await {
-            warn!(error = %ErrorChain(&e), "Failed to set conversation status to Running");
-            return Err(e.into());
-        }
         let conv_id = conversation_id.to_owned();
         let repo = Arc::clone(&self.conversation_repo);
         let broadcaster = Arc::clone(&self.broadcaster);
@@ -1317,6 +1333,7 @@ impl ConversationService {
         // agent-internal tracing all share one identifier per turn.
         let user_msg_id_ret = user_msg_id.clone();
         tokio::spawn(async move {
+            let mut turn_claim = turn_claim;
             let build_started_at = now_ms();
             info!(conversation_id = %conv_id, "Agent task build started");
             let agent = match task_manager.get_or_build_task(&conv_id, build_opts).await {
@@ -1329,7 +1346,8 @@ impl ConversationService {
                         "Agent task build failed"
                     );
                     service.persist_and_broadcast_send_failure_tip(&conv_id, &err).await;
-                    StreamRelay::complete_conversation(&repo, &broadcaster, &conv_id).await;
+                    turn_claim.release();
+                    service.complete_turn(&conv_id).await;
                     return;
                 }
             };
@@ -1347,7 +1365,8 @@ impl ConversationService {
                     "Failed to persist resolved workspace"
                 );
                 service.persist_and_broadcast_send_failure_tip(&conv_id, &err).await;
-                StreamRelay::complete_conversation(&repo, &broadcaster, &conv_id).await;
+                turn_claim.release();
+                service.complete_turn(&conv_id).await;
                 return;
             }
 
@@ -1424,7 +1443,8 @@ impl ConversationService {
                 ));
             }
 
-            StreamRelay::complete_conversation(&repo, &broadcaster, &conv_id).await;
+            turn_claim.release();
+            service.complete_turn(&conv_id).await;
         });
 
         info!(
@@ -2215,6 +2235,7 @@ mod tests {
             r#type: agent_type,
             model: None,
             status: ConversationStatus::Pending,
+            runtime: None,
             source: None,
             pinned: false,
             pinned_at: None,

--- a/crates/aionui-conversation/src/service_ops.rs
+++ b/crates/aionui-conversation/src/service_ops.rs
@@ -44,7 +44,19 @@ impl ConversationService {
         if req.model_id.trim().is_empty() {
             return Err(AppError::BadRequest("model_id must not be empty".into()));
         }
-        self.task(conversation_id)?.set_model(&req.model_id).await
+        let task = match self.task(conversation_id) {
+            Ok(task) => task,
+            Err(err) => {
+                tracing::warn!(
+                    conversation_id,
+                    model_id = %req.model_id,
+                    error_code = err.error_code(),
+                    "Set model skipped because active agent task is unavailable"
+                );
+                return Err(err);
+            }
+        };
+        task.set_model(&req.model_id).await
     }
 
     // ── Usage / Slash commands ──────────────────────────────────────

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -2,17 +2,17 @@ use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 use std::sync::{
     Arc, Mutex,
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 use std::time::Duration;
 
 use aionui_ai_agent::agent_task::{AgentInstance, IAgentTask, IMockAgent};
-use aionui_ai_agent::protocol::events::{AgentStreamEvent, FinishEventData, TextEventData};
+use aionui_ai_agent::protocol::events::{AgentStreamEvent, ErrorEventData, FinishEventData, TextEventData};
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
 use aionui_ai_agent::{AgentSendError, IWorkerTaskManager};
 
 use crate::response_middleware::{CronCommandResult, CronCreateParams, CronUpdateParams, ICronService};
-use aionui_api_types::ConversationArtifactKind;
+use aionui_api_types::{AgentErrorCode, ConversationArtifactKind};
 use aionui_api_types::{
     CloneConversationRequest, CreateConversationRequest, ListConversationsQuery, SearchMessagesQuery,
     SendMessageRequest, UpdateConversationRequest, WebSocketMessage,
@@ -1239,17 +1239,29 @@ impl IMockAgent for MockAgent {
 
 struct MockTaskManager {
     agents: Mutex<std::collections::HashMap<String, AgentInstance>>,
+    kill_records: Mutex<Vec<(String, Option<AgentKillReason>)>>,
+    kill_count: AtomicUsize,
 }
 
 impl MockTaskManager {
     fn new() -> Self {
         Self {
             agents: Mutex::new(std::collections::HashMap::new()),
+            kill_records: Mutex::new(Vec::new()),
+            kill_count: AtomicUsize::new(0),
         }
     }
 
     fn insert_agent(&self, conversation_id: &str, agent: AgentInstance) {
         self.agents.lock().unwrap().insert(conversation_id.to_owned(), agent);
+    }
+
+    fn kill_count(&self) -> usize {
+        self.kill_count.load(Ordering::SeqCst)
+    }
+
+    fn kill_records(&self) -> Vec<(String, Option<AgentKillReason>)> {
+        self.kill_records.lock().unwrap().clone()
     }
 }
 
@@ -1321,6 +1333,11 @@ impl IWorkerTaskManager for MockTaskManager {
     }
 
     fn kill(&self, conversation_id: &str, _reason: Option<AgentKillReason>) -> Result<(), AppError> {
+        self.kill_count.fetch_add(1, Ordering::SeqCst);
+        self.kill_records
+            .lock()
+            .unwrap()
+            .push((conversation_id.to_owned(), _reason));
         self.agents.lock().unwrap().remove(conversation_id);
         Ok(())
     }
@@ -1471,6 +1488,7 @@ impl IWorkerTaskManager for MockTaskManagerWithWorkspace {
 
 struct ScriptedAgent {
     conversation_id: String,
+    agent_type: AgentType,
     event_tx: broadcast::Sender<AgentStreamEvent>,
     scripts: Mutex<VecDeque<Vec<AgentStreamEvent>>>,
     sent_contents: Mutex<Vec<String>>,
@@ -1481,10 +1499,16 @@ impl ScriptedAgent {
         let (event_tx, _) = broadcast::channel(64);
         Self {
             conversation_id: conversation_id.to_owned(),
+            agent_type: AgentType::Acp,
             event_tx,
             scripts: Mutex::new(VecDeque::from(scripts)),
             sent_contents: Mutex::new(vec![]),
         }
+    }
+
+    fn with_agent_type(mut self, agent_type: AgentType) -> Self {
+        self.agent_type = agent_type;
+        self
     }
 
     fn sent_contents(&self) -> Vec<String> {
@@ -1495,7 +1519,7 @@ impl ScriptedAgent {
 #[async_trait::async_trait]
 impl IAgentTask for ScriptedAgent {
     fn agent_type(&self) -> AgentType {
-        AgentType::Acp
+        self.agent_type
     }
 
     fn conversation_id(&self) -> &str {
@@ -1588,6 +1612,19 @@ fn make_send_req() -> SendMessageRequest {
         "content": "Hello"
     }))
     .unwrap()
+}
+
+async fn wait_for_turn_released(svc: &ConversationService, conversation_id: &str) {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if !svc.runtime_state().is_claimed(conversation_id) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("turn should release runtime claim");
 }
 
 #[tokio::test]
@@ -1951,6 +1988,95 @@ async fn send_message_continues_cron_system_responses() {
     assert_eq!(turn_events.len(), 1);
     assert_eq!(turn_events[0].data["runtime"]["is_processing"], false);
     assert_eq!(turn_events[0].data["runtime"]["can_send_message"], true);
+}
+
+#[tokio::test]
+async fn send_message_evicts_acp_task_after_terminal_error() {
+    let (svc, _broadcaster, _repo, _default_task_mgr) = make_service();
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let scripted_agent = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Error(ErrorEventData::legacy(
+            "Agent completed the turn without producing visible output.",
+            Some(AgentErrorCode::UnknownUpstreamError),
+        ))]],
+    ));
+    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(scripted_agent));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if task_mgr.kill_count() == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("ACP terminal error should evict the cached task");
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    assert_eq!(task_mgr.active_count(), 0);
+    assert_eq!(
+        task_mgr.kill_records(),
+        vec![(conv.id.clone(), Some(AgentKillReason::AgentErrorRecovery))]
+    );
+}
+
+#[tokio::test]
+async fn send_message_keeps_acp_task_after_normal_finish() {
+    let (svc, _broadcaster, _repo, _default_task_mgr) = make_service();
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let scripted_agent = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Finish(FinishEventData::default())]],
+    ));
+    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(scripted_agent));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    assert_eq!(task_mgr.kill_count(), 0);
+    assert_eq!(task_mgr.active_count(), 1);
+}
+
+#[tokio::test]
+async fn send_message_does_not_evict_non_acp_task_after_terminal_error() {
+    let (svc, _broadcaster, _repo, _default_task_mgr) = make_service();
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let scripted_agent = Arc::new(
+        ScriptedAgent::new(
+            &conv.id,
+            vec![vec![AgentStreamEvent::Error(ErrorEventData::legacy(
+                "aionrs terminal error",
+                Some(AgentErrorCode::UnknownUpstreamError),
+            ))]],
+        )
+        .with_agent_type(AgentType::Aionrs),
+    );
+    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(scripted_agent));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    assert_eq!(task_mgr.kill_count(), 0);
+    assert_eq!(task_mgr.active_count(), 1);
 }
 
 // ── stop_stream tests ───────────────────────────────────────────

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -636,6 +636,29 @@ async fn get_existing_conversation() {
     let fetched = svc.get("user_1", &created.id).await.unwrap();
     assert_eq!(fetched.id, created.id);
     assert_eq!(fetched.name, created.name);
+    assert!(fetched.runtime.is_some());
+}
+
+#[tokio::test]
+async fn get_reports_idle_runtime_when_only_persisted_status_is_running() {
+    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let created = svc.create("user_1", make_create_req()).await.unwrap();
+    repo.update(
+        &created.id,
+        &ConversationRowUpdate {
+            status: Some("running".into()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let fetched = svc.get("user_1", &created.id).await.unwrap();
+    let runtime = fetched.runtime.expect("runtime summary should be present");
+
+    assert_eq!(fetched.status, ConversationStatus::Running);
+    assert_eq!(runtime.state, aionui_api_types::ConversationRuntimeStateKind::Idle);
+    assert!(runtime.can_send_message);
 }
 
 #[tokio::test]
@@ -1630,7 +1653,11 @@ async fn send_message_returns_before_cold_agent_build_completes() {
     );
 
     let updated = repo.get(&conv.id).await.unwrap().unwrap();
-    assert_eq!(updated.status.as_deref(), Some("running"));
+    assert_ne!(updated.status.as_deref(), Some("running"));
+    assert!(
+        svc.runtime_state().is_claimed(&conv.id),
+        "runtime claim must cover the cold agent build window"
+    );
 }
 
 #[tokio::test]
@@ -1710,6 +1737,10 @@ async fn send_message_persists_error_tip_when_agent_build_fails() {
 
     let updated = repo.get(&conv.id).await.unwrap().unwrap();
     assert_eq!(updated.status.as_deref(), Some("finished"));
+    assert!(
+        !svc.runtime_state().is_claimed(&conv.id),
+        "runtime claim must be released after failed turn"
+    );
 
     let events = broadcaster.take_events();
     let error_tip_event = events
@@ -1776,7 +1807,7 @@ async fn send_message_wrong_user_returns_not_found() {
 }
 
 #[tokio::test]
-async fn send_message_running_conversation_returns_conflict() {
+async fn send_message_allows_stale_db_running_without_runtime_claim() {
     let (svc, _broadcaster, repo, _task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
@@ -1788,6 +1819,21 @@ async fn send_message_running_conversation_returns_conflict() {
         ..Default::default()
     };
     repo.update(&conv.id, &update).await.unwrap();
+
+    let result = svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr).await;
+    assert!(result.is_ok(), "stale DB running must not block sending");
+}
+
+#[tokio::test]
+async fn send_message_rejects_active_runtime_claim() {
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
+
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+    let _claim = svc
+        .runtime_state()
+        .try_claim_turn(&conv.id)
+        .expect("test claim should be created");
 
     let err = svc
         .send_message("user_1", &conv.id, make_send_req(), &task_mgr)
@@ -1901,8 +1947,10 @@ async fn send_message_continues_cron_system_responses() {
     assert_eq!(finished.status, ConversationStatus::Finished);
 
     let events = broadcaster.take_events();
-    let turn_completed = events.iter().filter(|evt| evt.name == "turn.completed").count();
-    assert_eq!(turn_completed, 1);
+    let turn_events: Vec<_> = events.iter().filter(|evt| evt.name == "turn.completed").collect();
+    assert_eq!(turn_events.len(), 1);
+    assert_eq!(turn_events[0].data["runtime"]["is_processing"], false);
+    assert_eq!(turn_events[0].data["runtime"]["can_send_message"], true);
 }
 
 // ── stop_stream tests ───────────────────────────────────────────

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -478,7 +478,22 @@ impl IAgentMetadataRepository for StubAgentMetadataRepo {
     }
 }
 
-struct StubAcpSessionRepo;
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimeStateSaveCall {
+    conversation_id: String,
+    current_model_id: Option<Option<String>>,
+}
+
+#[derive(Default)]
+struct StubAcpSessionRepo {
+    runtime_state_saves: Mutex<Vec<RuntimeStateSaveCall>>,
+}
+
+impl StubAcpSessionRepo {
+    fn runtime_state_saves(&self) -> Vec<RuntimeStateSaveCall> {
+        self.runtime_state_saves.lock().unwrap().clone()
+    }
+}
 
 #[async_trait::async_trait]
 impl IAcpSessionRepository for StubAcpSessionRepo {
@@ -507,14 +522,21 @@ impl IAcpSessionRepository for StubAcpSessionRepo {
         Ok(false)
     }
     async fn load_runtime_state(&self, _conversation_id: &str) -> Result<Option<PersistedSessionState>, DbError> {
-        Ok(None)
+        Ok(Some(PersistedSessionState {
+            current_model_id: Some("deepseek-v4-pro".to_owned()),
+            ..Default::default()
+        }))
     }
     async fn save_runtime_state(
         &self,
-        _conversation_id: &str,
-        _params: &SaveRuntimeStateParams<'_>,
+        conversation_id: &str,
+        params: &SaveRuntimeStateParams<'_>,
     ) -> Result<bool, DbError> {
-        Ok(false)
+        self.runtime_state_saves.lock().unwrap().push(RuntimeStateSaveCall {
+            conversation_id: conversation_id.to_owned(),
+            current_model_id: params.current_model_id.map(|outer| outer.map(ToOwned::to_owned)),
+        });
+        Ok(true)
     }
 }
 
@@ -535,10 +557,21 @@ fn make_service_with_resolver(
     Arc<MockRepo>,
     Arc<dyn IWorkerTaskManager>,
 ) {
+    make_service_with_resolver_and_acp_session_repo(skill_resolver, Arc::new(StubAcpSessionRepo::default()))
+}
+
+fn make_service_with_resolver_and_acp_session_repo(
+    skill_resolver: Arc<dyn crate::skill_resolver::SkillResolver>,
+    acp_session_repo: Arc<dyn IAcpSessionRepository>,
+) -> (
+    ConversationService,
+    Arc<MockBroadcaster>,
+    Arc<MockRepo>,
+    Arc<dyn IWorkerTaskManager>,
+) {
     let repo = Arc::new(MockRepo::new());
     let broadcaster = Arc::new(MockBroadcaster::new());
     let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = Arc::new(StubAgentMetadataRepo);
-    let acp_session_repo: Arc<dyn IAcpSessionRepository> = Arc::new(StubAcpSessionRepo);
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
     let svc = ConversationService::new(
         std::env::temp_dir(),
@@ -2027,6 +2060,85 @@ async fn send_message_evicts_acp_task_after_terminal_error() {
         task_mgr.kill_records(),
         vec![(conv.id.clone(), Some(AgentKillReason::AgentErrorRecovery))]
     );
+}
+
+#[tokio::test]
+async fn send_message_clears_persisted_acp_model_after_model_not_found() {
+    let acp_session_repo = Arc::new(StubAcpSessionRepo::default());
+    let (svc, _broadcaster, _repo, _default_task_mgr) = make_service_with_resolver_and_acp_session_repo(
+        Arc::new(FixedSkillResolver { names: vec![] }),
+        acp_session_repo.clone(),
+    );
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let scripted_agent = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Error(ErrorEventData::legacy(
+            "The configured model was not found by the provider.",
+            Some(AgentErrorCode::UserLlmProviderModelNotFound),
+        ))]],
+    ));
+    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(scripted_agent));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let saves = acp_session_repo.runtime_state_saves();
+            if saves
+                .iter()
+                .any(|call| call.conversation_id == conv.id && call.current_model_id == Some(None))
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("model_not_found should clear persisted ACP model");
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    assert_eq!(task_mgr.active_count(), 0);
+    assert_eq!(
+        acp_session_repo.runtime_state_saves(),
+        vec![RuntimeStateSaveCall {
+            conversation_id: conv.id,
+            current_model_id: Some(None),
+        }]
+    );
+}
+
+#[tokio::test]
+async fn send_message_does_not_clear_persisted_acp_model_for_other_terminal_errors() {
+    let acp_session_repo = Arc::new(StubAcpSessionRepo::default());
+    let (svc, _broadcaster, _repo, _default_task_mgr) = make_service_with_resolver_and_acp_session_repo(
+        Arc::new(FixedSkillResolver { names: vec![] }),
+        acp_session_repo.clone(),
+    );
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let scripted_agent = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Error(ErrorEventData::legacy(
+            "Unknown upstream error.",
+            Some(AgentErrorCode::UnknownUpstreamError),
+        ))]],
+    ));
+    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(scripted_agent));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    assert_eq!(task_mgr.active_count(), 0);
+    assert!(acp_session_repo.runtime_state_saves().is_empty());
 }
 
 #[tokio::test]

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -37,6 +37,9 @@ use tokio::sync::broadcast;
 use crate::service::ConversationService;
 use crate::skill_resolver::{FixedSkillResolver, ResolvedAgentSkill, SkillResolver};
 
+#[path = "service_test/acp_error_recovery_test.rs"]
+mod acp_error_recovery_test;
+
 #[derive(Clone, Debug)]
 struct SkillLinkCall {
     workspace: PathBuf,
@@ -2021,124 +2024,6 @@ async fn send_message_continues_cron_system_responses() {
     assert_eq!(turn_events.len(), 1);
     assert_eq!(turn_events[0].data["runtime"]["is_processing"], false);
     assert_eq!(turn_events[0].data["runtime"]["can_send_message"], true);
-}
-
-#[tokio::test]
-async fn send_message_evicts_acp_task_after_terminal_error() {
-    let (svc, _broadcaster, _repo, _default_task_mgr) = make_service();
-    let task_mgr = Arc::new(MockTaskManager::new());
-    let conv = svc.create("user_1", make_create_req()).await.unwrap();
-
-    let scripted_agent = Arc::new(ScriptedAgent::new(
-        &conv.id,
-        vec![vec![AgentStreamEvent::Error(ErrorEventData::legacy(
-            "Agent completed the turn without producing visible output.",
-            Some(AgentErrorCode::UnknownUpstreamError),
-        ))]],
-    ));
-    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(scripted_agent));
-
-    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
-    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
-        .await
-        .unwrap();
-
-    tokio::time::timeout(Duration::from_secs(2), async {
-        loop {
-            if task_mgr.kill_count() == 1 {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .expect("ACP terminal error should evict the cached task");
-    wait_for_turn_released(&svc, &conv.id).await;
-
-    assert_eq!(task_mgr.active_count(), 0);
-    assert_eq!(
-        task_mgr.kill_records(),
-        vec![(conv.id.clone(), Some(AgentKillReason::AgentErrorRecovery))]
-    );
-}
-
-#[tokio::test]
-async fn send_message_clears_persisted_acp_model_after_model_not_found() {
-    let acp_session_repo = Arc::new(StubAcpSessionRepo::default());
-    let (svc, _broadcaster, _repo, _default_task_mgr) = make_service_with_resolver_and_acp_session_repo(
-        Arc::new(FixedSkillResolver { names: vec![] }),
-        acp_session_repo.clone(),
-    );
-    let task_mgr = Arc::new(MockTaskManager::new());
-    let conv = svc.create("user_1", make_create_req()).await.unwrap();
-
-    let scripted_agent = Arc::new(ScriptedAgent::new(
-        &conv.id,
-        vec![vec![AgentStreamEvent::Error(ErrorEventData::legacy(
-            "The configured model was not found by the provider.",
-            Some(AgentErrorCode::UserLlmProviderModelNotFound),
-        ))]],
-    ));
-    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(scripted_agent));
-
-    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
-    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
-        .await
-        .unwrap();
-
-    tokio::time::timeout(Duration::from_secs(2), async {
-        loop {
-            let saves = acp_session_repo.runtime_state_saves();
-            if saves
-                .iter()
-                .any(|call| call.conversation_id == conv.id && call.current_model_id == Some(None))
-            {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .expect("model_not_found should clear persisted ACP model");
-    wait_for_turn_released(&svc, &conv.id).await;
-
-    assert_eq!(task_mgr.active_count(), 0);
-    assert_eq!(
-        acp_session_repo.runtime_state_saves(),
-        vec![RuntimeStateSaveCall {
-            conversation_id: conv.id,
-            current_model_id: Some(None),
-        }]
-    );
-}
-
-#[tokio::test]
-async fn send_message_does_not_clear_persisted_acp_model_for_other_terminal_errors() {
-    let acp_session_repo = Arc::new(StubAcpSessionRepo::default());
-    let (svc, _broadcaster, _repo, _default_task_mgr) = make_service_with_resolver_and_acp_session_repo(
-        Arc::new(FixedSkillResolver { names: vec![] }),
-        acp_session_repo.clone(),
-    );
-    let task_mgr = Arc::new(MockTaskManager::new());
-    let conv = svc.create("user_1", make_create_req()).await.unwrap();
-
-    let scripted_agent = Arc::new(ScriptedAgent::new(
-        &conv.id,
-        vec![vec![AgentStreamEvent::Error(ErrorEventData::legacy(
-            "Unknown upstream error.",
-            Some(AgentErrorCode::UnknownUpstreamError),
-        ))]],
-    ));
-    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(scripted_agent));
-
-    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
-    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
-        .await
-        .unwrap();
-    wait_for_turn_released(&svc, &conv.id).await;
-
-    assert_eq!(task_mgr.active_count(), 0);
-    assert!(acp_session_repo.runtime_state_saves().is_empty());
 }
 
 #[tokio::test]

--- a/crates/aionui-conversation/src/service_test/acp_error_recovery_test.rs
+++ b/crates/aionui-conversation/src/service_test/acp_error_recovery_test.rs
@@ -42,12 +42,27 @@ async fn send_message_evicts_acp_task_after_terminal_error() {
 #[tokio::test]
 async fn send_message_clears_persisted_acp_model_after_model_not_found() {
     let acp_session_repo = Arc::new(StubAcpSessionRepo::default());
-    let (svc, _broadcaster, _repo, _default_task_mgr) = make_service_with_resolver_and_acp_session_repo(
+    let (svc, _broadcaster, repo, _default_task_mgr) = make_service_with_resolver_and_acp_session_repo(
         Arc::new(FixedSkillResolver { names: vec![] }),
         acp_session_repo.clone(),
     );
     let task_mgr = Arc::new(MockTaskManager::new());
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
+    repo.update(
+        &conv.id,
+        &ConversationRowUpdate {
+            extra: Some(
+                serde_json::to_string(&json!({
+                    "workspace": "/project",
+                    "current_model_id": "deepseek-v4-pro",
+                }))
+                .unwrap(),
+            ),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
 
     let scripted_agent = Arc::new(ScriptedAgent::new(
         &conv.id,
@@ -83,9 +98,17 @@ async fn send_message_clears_persisted_acp_model_after_model_not_found() {
     assert_eq!(
         acp_session_repo.runtime_state_saves(),
         vec![RuntimeStateSaveCall {
-            conversation_id: conv.id,
+            conversation_id: conv.id.clone(),
             current_model_id: Some(None),
         }]
+    );
+
+    let row = repo.get(&conv.id).await.unwrap().unwrap();
+    let extra: serde_json::Value = serde_json::from_str(&row.extra).unwrap();
+    assert!(extra.get("workspace").is_some());
+    assert!(
+        extra.get("current_model_id").is_none(),
+        "model_not_found must clear conversation.extra.current_model_id so rebuild cannot reseed stale desired model"
     );
 }
 

--- a/crates/aionui-conversation/src/service_test/acp_error_recovery_test.rs
+++ b/crates/aionui-conversation/src/service_test/acp_error_recovery_test.rs
@@ -1,0 +1,119 @@
+use super::*;
+
+#[tokio::test]
+async fn send_message_evicts_acp_task_after_terminal_error() {
+    let (svc, _broadcaster, _repo, _default_task_mgr) = make_service();
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let scripted_agent = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Error(ErrorEventData::legacy(
+            "Agent completed the turn without producing visible output.",
+            Some(AgentErrorCode::UnknownUpstreamError),
+        ))]],
+    ));
+    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(scripted_agent));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if task_mgr.kill_count() == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("ACP terminal error should evict the cached task");
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    assert_eq!(task_mgr.active_count(), 0);
+    assert_eq!(
+        task_mgr.kill_records(),
+        vec![(conv.id.clone(), Some(AgentKillReason::AgentErrorRecovery))]
+    );
+}
+
+#[tokio::test]
+async fn send_message_clears_persisted_acp_model_after_model_not_found() {
+    let acp_session_repo = Arc::new(StubAcpSessionRepo::default());
+    let (svc, _broadcaster, _repo, _default_task_mgr) = make_service_with_resolver_and_acp_session_repo(
+        Arc::new(FixedSkillResolver { names: vec![] }),
+        acp_session_repo.clone(),
+    );
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let scripted_agent = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Error(ErrorEventData::legacy(
+            "The configured model was not found by the provider.",
+            Some(AgentErrorCode::UserLlmProviderModelNotFound),
+        ))]],
+    ));
+    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(scripted_agent));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let saves = acp_session_repo.runtime_state_saves();
+            if saves
+                .iter()
+                .any(|call| call.conversation_id == conv.id && call.current_model_id == Some(None))
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("model_not_found should clear persisted ACP model");
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    assert_eq!(task_mgr.active_count(), 0);
+    assert_eq!(
+        acp_session_repo.runtime_state_saves(),
+        vec![RuntimeStateSaveCall {
+            conversation_id: conv.id,
+            current_model_id: Some(None),
+        }]
+    );
+}
+
+#[tokio::test]
+async fn send_message_does_not_clear_persisted_acp_model_for_other_terminal_errors() {
+    let acp_session_repo = Arc::new(StubAcpSessionRepo::default());
+    let (svc, _broadcaster, _repo, _default_task_mgr) = make_service_with_resolver_and_acp_session_repo(
+        Arc::new(FixedSkillResolver { names: vec![] }),
+        acp_session_repo.clone(),
+    );
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let scripted_agent = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Error(ErrorEventData::legacy(
+            "Unknown upstream error.",
+            Some(AgentErrorCode::UnknownUpstreamError),
+        ))]],
+    ));
+    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(scripted_agent));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    assert_eq!(task_mgr.active_count(), 0);
+    assert!(acp_session_repo.runtime_state_saves().is_empty());
+}

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -9,7 +9,7 @@ use aionui_ai_agent::{
 };
 
 use crate::response_middleware::{ICronService, MessageMiddleware, MiddlewareResult};
-use aionui_api_types::{ConversationRuntimeSummary, WebSocketMessage};
+use aionui_api_types::{AgentErrorCode, ConversationRuntimeSummary, WebSocketMessage};
 use aionui_common::{ErrorChain, normalize_keys_to_snake_case, now_ms};
 
 use crate::service::ConversationService;
@@ -48,6 +48,38 @@ struct ThinkingSegmentState {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RelayOutcome {
     pub system_responses: Vec<String>,
+    pub terminal: RelayTerminal,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum RelayTerminal {
+    #[default]
+    Finish,
+    Error {
+        code: Option<AgentErrorCode>,
+        retryable: Option<bool>,
+    },
+    ChannelClosed,
+}
+
+impl RelayTerminal {
+    pub fn is_error(&self) -> bool {
+        matches!(self, Self::Error { .. })
+    }
+
+    pub fn code(&self) -> Option<AgentErrorCode> {
+        match self {
+            Self::Error { code, .. } => *code,
+            Self::Finish | Self::ChannelClosed => None,
+        }
+    }
+
+    pub fn retryable(&self) -> Option<bool> {
+        match self {
+            Self::Error { retryable, .. } => *retryable,
+            Self::Finish | Self::ChannelClosed => None,
+        }
+    }
 }
 
 /// Relays agent stream events to WebSocket and persists messages.
@@ -229,12 +261,27 @@ impl StreamRelay {
                             } else {
                                 "Error"
                             };
-                            info!(
-                                event_type,
-                                elapsed_ms,
-                                text_len = full_text_buffer.len(),
-                                "StreamRelay received terminal event"
-                            );
+                            let terminal = Self::terminal_from_event(&event);
+                            match &terminal {
+                                RelayTerminal::Error { code, retryable } => {
+                                    info!(
+                                        event_type,
+                                        elapsed_ms,
+                                        text_len = full_text_buffer.len(),
+                                        error_code = ?code,
+                                        retryable = ?retryable,
+                                        "StreamRelay received terminal event"
+                                    );
+                                }
+                                RelayTerminal::Finish | RelayTerminal::ChannelClosed => {
+                                    info!(
+                                        event_type,
+                                        elapsed_ms,
+                                        text_len = full_text_buffer.len(),
+                                        "StreamRelay received terminal event"
+                                    );
+                                }
+                            }
 
                             self.complete_active_thinking(&mut active_thinking).await;
                             self.close_active_text_segment(
@@ -248,7 +295,7 @@ impl StreamRelay {
                             )
                             .await;
                             self.forward_to_websocket(&event);
-                            let outcome = self.finalize(&full_text_buffer, &text_segments, &event).await;
+                            let outcome = self.finalize(&full_text_buffer, &text_segments, &event, terminal).await;
                             if self.complete_turn {
                                 Self::complete_conversation(&self.repo, &self.broadcaster, &self.conversation_id).await;
                             }
@@ -297,6 +344,7 @@ impl StreamRelay {
                             &full_text_buffer,
                             &text_segments,
                             &AgentStreamEvent::Finish(aionui_ai_agent::protocol::events::FinishEventData::default()),
+                            RelayTerminal::ChannelClosed,
                         )
                         .await;
                     if self.complete_turn {
@@ -339,6 +387,17 @@ impl StreamRelay {
             AgentStreamEvent::System(_) => "System",
             AgentStreamEvent::RequestTrace(_) => "RequestTrace",
             AgentStreamEvent::SessionAssigned(_) => "SessionAssigned",
+        }
+    }
+
+    fn terminal_from_event(event: &AgentStreamEvent) -> RelayTerminal {
+        match event {
+            AgentStreamEvent::Error(data) => RelayTerminal::Error {
+                code: data.code,
+                retryable: data.retryable,
+            },
+            AgentStreamEvent::Finish(_) => RelayTerminal::Finish,
+            _ => RelayTerminal::ChannelClosed,
         }
     }
 
@@ -462,8 +521,12 @@ impl StreamRelay {
         text: &str,
         text_segments: &[PersistedTextSegment],
         event: &AgentStreamEvent,
+        terminal: RelayTerminal,
     ) -> RelayOutcome {
-        let mut outcome = RelayOutcome::default();
+        let mut outcome = RelayOutcome {
+            system_responses: Vec::new(),
+            terminal,
+        };
         let status = match event {
             AgentStreamEvent::Error(_) => "error",
             _ => "finish",
@@ -973,6 +1036,7 @@ mod tests {
 
         let outcome = relay.consume(rx).await;
         assert!(outcome.system_responses.is_empty());
+        assert_eq!(outcome.terminal, RelayTerminal::Finish);
 
         // Should have inserted a message with accumulated text
         let inserts = repo.take_inserts();
@@ -1069,6 +1133,13 @@ mod tests {
 
         let outcome = relay.consume(rx).await;
         assert!(outcome.system_responses.is_empty());
+        assert_eq!(
+            outcome.terminal,
+            RelayTerminal::Error {
+                code: None,
+                retryable: None
+            }
+        );
 
         let inserts = repo.take_inserts();
         assert_eq!(inserts.len(), 1);
@@ -1107,6 +1178,13 @@ mod tests {
 
         let outcome = relay.consume_with_send_error(rx, send_error_rx).await;
         assert!(outcome.system_responses.is_empty());
+        assert_eq!(
+            outcome.terminal,
+            RelayTerminal::Error {
+                code: Some(aionui_api_types::AgentErrorCode::UserLlmProviderAuthFailed),
+                retryable: Some(false)
+            }
+        );
 
         let inserts = repo.take_inserts();
         assert_eq!(inserts.len(), 1);
@@ -1212,6 +1290,13 @@ mod tests {
         let outcome = relay.consume_with_send_error(rx, send_error_rx).await;
         delayed_stream_error.await.unwrap();
         assert!(outcome.system_responses.is_empty());
+        assert_eq!(
+            outcome.terminal,
+            RelayTerminal::Error {
+                code: Some(aionui_api_types::AgentErrorCode::UserLlmProviderAuthFailed),
+                retryable: Some(false)
+            }
+        );
 
         let inserts = repo.take_inserts();
         assert_eq!(inserts.len(), 1);

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -9,7 +9,7 @@ use aionui_ai_agent::{
 };
 
 use crate::response_middleware::{ICronService, MessageMiddleware, MiddlewareResult};
-use aionui_api_types::WebSocketMessage;
+use aionui_api_types::{ConversationRuntimeSummary, WebSocketMessage};
 use aionui_common::{ErrorChain, normalize_keys_to_snake_case, now_ms};
 
 use crate::service::ConversationService;
@@ -870,6 +870,16 @@ impl StreamRelay {
         broadcaster: &Arc<dyn EventBroadcaster>,
         conversation_id: &str,
     ) {
+        Self::complete_conversation_with_runtime(repo, broadcaster, conversation_id, None).await;
+    }
+
+    #[tracing::instrument(skip_all, fields(conversation_id = %conversation_id))]
+    pub async fn complete_conversation_with_runtime(
+        repo: &Arc<dyn IConversationRepository>,
+        broadcaster: &Arc<dyn EventBroadcaster>,
+        conversation_id: &str,
+        runtime: Option<ConversationRuntimeSummary>,
+    ) {
         let update = aionui_db::ConversationRowUpdate {
             status: Some("finished".to_owned()),
             updated_at: Some(now_ms()),
@@ -884,6 +894,7 @@ impl StreamRelay {
             "session_id": conversation_id,
             "status": "finished",
             "canSendMessage": true,
+            "runtime": runtime,
         });
         let msg = WebSocketMessage::new("turn.completed", payload);
         broadcaster.broadcast(msg);

--- a/crates/aionui-team/src/event_loop.rs
+++ b/crates/aionui-team/src/event_loop.rs
@@ -5,6 +5,7 @@ use aionui_ai_agent::IWorkerTaskManager;
 use aionui_ai_agent::types::SendMessageData;
 use aionui_common::ConversationStatus;
 use aionui_conversation::ConversationService;
+use aionui_conversation::runtime_state::TurnClaim;
 use aionui_realtime::EventBroadcaster;
 use dashmap::DashMap;
 use tokio::sync::Notify;
@@ -96,6 +97,11 @@ pub struct AgentLoopContext {
     pub registry: Arc<EventLoopRegistry>,
 }
 
+struct TurnExecution {
+    finish_ok: bool,
+    claim: TurnClaim,
+}
+
 /// The event loop for one agent slot. Spawned as a tokio task.
 ///
 /// Flow:
@@ -154,7 +160,7 @@ async fn run_event_loop(
             }
 
             match execute_turn(&ctx, &input).await {
-                Some(finish_ok) => finalize_turn(&ctx, finish_ok, &input.conversation_id).await,
+                Some(turn) => finalize_turn(&ctx, turn, &input.conversation_id).await,
                 None => break, // Turn not started (guard/warmup); retry on next signal
             }
         }
@@ -164,7 +170,7 @@ async fn run_event_loop(
 /// Execute one agent turn: warmup → guard → set Working → StreamRelay → send_message (blocking).
 /// Returns `Some(true)` on success, `Some(false)` on error,
 /// `None` if the turn was not started (guard hit, warmup fail, etc.).
-async fn execute_turn(ctx: &AgentLoopContext, input: &crate::session::WakeInput) -> Option<bool> {
+async fn execute_turn(ctx: &AgentLoopContext, input: &crate::session::WakeInput) -> Option<TurnExecution> {
     ctx.session.mirror_unread_to_conversation(input).await;
 
     // Ensure agent task exists
@@ -204,21 +210,27 @@ async fn execute_turn(ctx: &AgentLoopContext, input: &crate::session::WakeInput)
     if handle.status() == Some(ConversationStatus::Running) {
         return None;
     }
-    let repo = ctx.conversation_service.conversation_repo();
-    if let Ok(Some(row)) = repo.get(&input.conversation_id).await
-        && row.status.as_deref() == Some("running")
+    let claim = match ctx
+        .conversation_service
+        .runtime_state()
+        .try_claim_turn(&input.conversation_id)
     {
-        return None;
-    }
-
-    // Point-of-no-return: set Working + claim DB running
-    let _ = ctx.scheduler.set_status(&ctx.slot_id, TeammateStatus::Working).await;
-    let update = aionui_db::ConversationRowUpdate {
-        status: Some("running".to_owned()),
-        updated_at: Some(aionui_common::now_ms()),
-        ..Default::default()
+        Ok(claim) => claim,
+        Err(e) => {
+            warn!(
+                team_id = %ctx.team_id,
+                slot_id = %ctx.slot_id,
+                conversation_id = %input.conversation_id,
+                error = %e,
+                "event loop: runtime turn claim rejected"
+            );
+            return None;
+        }
     };
-    let _ = repo.update(&input.conversation_id, &update).await;
+
+    // Point-of-no-return: set Working. Runtime state, not DB status, is the turn guard.
+    let _ = ctx.scheduler.set_status(&ctx.slot_id, TeammateStatus::Working).await;
+    let repo = ctx.conversation_service.conversation_repo();
 
     // StreamRelay for response persistence + WebSocket forwarding
     let msg_id = ConversationService::mint_msg_id();
@@ -276,21 +288,17 @@ async fn execute_turn(ctx: &AgentLoopContext, input: &crate::session::WakeInput)
         );
     }
 
-    Some(turn_ok)
+    Some(TurnExecution {
+        finish_ok: turn_ok,
+        claim,
+    })
 }
 
-/// Finalize a completed turn: reset DB status, mark idle (or error), cascade to leader.
-async fn finalize_turn(ctx: &AgentLoopContext, finish_ok: bool, conversation_id: &str) {
-    // Reset conversation DB status so future turns pass the guard check.
-    let repo = ctx.conversation_service.conversation_repo();
-    let update = aionui_db::ConversationRowUpdate {
-        status: Some("finished".to_owned()),
-        updated_at: Some(aionui_common::now_ms()),
-        ..Default::default()
-    };
-    let _ = repo.update(conversation_id, &update).await;
+/// Finalize a completed turn: release runtime claim, mark idle (or error), cascade to leader.
+async fn finalize_turn(ctx: &AgentLoopContext, mut turn: TurnExecution, _conversation_id: &str) {
+    turn.claim.release();
 
-    if !finish_ok {
+    if !turn.finish_ok {
         let _ = ctx.scheduler.set_status(&ctx.slot_id, TeammateStatus::Error).await;
     }
     match ctx.scheduler.finalize_turn(&ctx.slot_id, &[]).await {


### PR DESCRIPTION
## Summary
- Evict unhealthy ACP tasks after terminal provider/model errors
- Clear stale persisted ACP model state and conversation model seeds after provider model misses
- Reject unavailable desired session models during reconciliation
- Split ACP error recovery logic and tests out of the large service module

## Testing
- just push -u origin feat/conversation-runtime-state