### PR TITLE
fix(startup): add startup phase diagnostics

### DIFF
--- a/crates/aionui-app/src/commands/server.rs
+++ b/crates/aionui-app/src/commands/server.rs
@@ -21,8 +21,22 @@ pub async fn run_server(env: ServerEnvironment, services: AppServices) -> Result
     }
 
     let router = create_router(&services).await;
+    info!(
+        elapsed_ms = boot.elapsed().as_millis(),
+        "startup: router ready for socket bind"
+    );
     let addr = env.config.socket_addr();
+    info!(
+        elapsed_ms = boot.elapsed().as_millis(),
+        address = %addr,
+        "startup: socket bind started"
+    );
     let listener = TcpListener::bind(&addr).await?;
+    info!(
+        elapsed_ms = boot.elapsed().as_millis(),
+        address = %addr,
+        "startup: socket bind completed"
+    );
     info!(elapsed_ms = boot.elapsed().as_millis(), "Server listening on {addr}");
 
     // Kick off the idle-ACP-agent reaper. `start_idle_scanner` returns

--- a/crates/aionui-app/src/router/routes.rs
+++ b/crates/aionui-app/src/router/routes.rs
@@ -92,6 +92,10 @@ pub async fn create_router(services: &AppServices) -> Router {
         "startup: channel plugin restore scheduled"
     );
 
+    tracing::info!(
+        elapsed_ms = boot.elapsed().as_millis(),
+        "startup: route tree build started"
+    );
     let router = create_router_with_states(services, states);
     tracing::info!(
         elapsed_ms = boot.elapsed().as_millis(),
@@ -114,6 +118,9 @@ pub fn create_router_with_states(services: &AppServices, states: ModuleStates) -
 /// Full-control variant used by tests that need to override
 /// module services and WebSocket behaviour.
 pub fn create_router_with_all_state(services: &AppServices, states: ModuleStates, ws_state: WsHandlerState) -> Router {
+    let boot = Instant::now();
+    tracing::info!("startup: route tree build with states started");
+
     let auth_state = AuthRouterState {
         jwt_service: services.jwt_service.clone(),
         user_repo: services.user_repo.clone(),
@@ -212,6 +219,7 @@ pub fn create_router_with_all_state(services: &AppServices, states: ModuleStates
     // WebSocket upgrade route — exempt from CSRF (no cookie-based
     // double-submit) but still gets security response headers.
     let ws_routes = Router::new().route("/ws", get(ws_upgrade_handler)).with_state(ws_state);
+    tracing::info!(elapsed_ms = boot.elapsed().as_millis(), "startup: route groups built");
 
     let router = Router::new()
         .route("/health", get(health_check))
@@ -258,6 +266,10 @@ pub fn create_router_with_all_state(services: &AppServices, states: ModuleStates
     let router = router.layer(DefaultBodyLimit::max(aionui_common::constants::BODY_LIMIT));
 
     let router = with_access_log(router);
+    tracing::info!(
+        elapsed_ms = boot.elapsed().as_millis(),
+        "startup: route tree build with states completed"
+    );
 
     if services.local {
         let cors = CorsLayer::new()

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -144,6 +144,10 @@ pub async fn build_module_states(services: &AppServices) -> (ModuleStates, Chann
             .and_then(|p| p.canonicalize().ok())
             .unwrap_or_else(|| std::path::PathBuf::from("aioncore")),
     );
+    tracing::info!(
+        elapsed_ms = boot.elapsed().as_millis(),
+        "startup: backend binary path resolved"
+    );
 
     let pool = services.database.pool().clone();
     let provider_repo: Arc<dyn IProviderRepository> = Arc::new(SqliteProviderRepository::new(pool));
@@ -154,7 +158,12 @@ pub async fn build_module_states(services: &AppServices) -> (ModuleStates, Chann
         encryption_key,
         services.data_dir.clone(),
     );
+    tracing::info!(elapsed_ms = boot.elapsed().as_millis(), "startup: agent service built");
 
+    tracing::info!(
+        elapsed_ms = boot.elapsed().as_millis(),
+        "startup: module states bundle started"
+    );
     let states = ModuleStates {
         system: build_system_state(services),
         conversation: build_conversation_state(services, Some(cron.cron_service.clone())),


### PR DESCRIPTION
## Summary
- Add startup phase logs around router readiness, route tree construction, and socket bind.
- Add module state construction boundary logs after channel state initialization.
- Improve observability for ELECTRON-1N8 health timeout samples before Server listening.

## Test plan
- [x] cargo fmt --all -- --check
- [x] cargo test -p aionui-app
- [x] cargo clippy -p aionui-app -- -D warnings
- [x] just push -u origin fix/1n8-startup-phase-diagnostics