### PR TITLE
refactor(error): ACP error classification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -31,6 +31,7 @@ pub use capability::skill_manager::{
 pub use factory::{AgentFactoryDeps, build_agent_factory};
 pub use idle_scanner::start_idle_scanner;
 pub use persistence::AcpSessionSyncService;
+pub use protocol::error::AcpError;
 pub use protocol::events::AgentStreamEvent;
 pub use protocol::send_error::AgentSendError;
 pub use registry::{AgentRegistry, UnavailableReason};

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -28,6 +28,8 @@ use std::time::Duration;
 use tokio::sync::{Mutex, RwLock, broadcast, mpsc};
 use tracing::{debug, error, info, warn};
 
+use super::error_mapping::{AcpSendFailure, acp_error_to_app_error};
+
 /// The user-visible body inside an [`AppError`].
 ///
 /// `AppError`'s `Display` prefixes every variant with its HTTP status name
@@ -262,7 +264,7 @@ impl AcpAgentManager {
                     "Agent process exited before ACP handshake completed"
                 );
                 let _ = unregister_agent_process(&params.data_dir, process.pid());
-                return Err(AppError::from(AcpError::StartupCrash { exit_code, signal, stderr }));
+                return Err(acp_error_to_app_error(AcpError::StartupCrash { exit_code, signal, stderr }));
             }
             res = &mut connect_fut => res.map_err(|e| {
                 error!(
@@ -271,7 +273,7 @@ impl AcpAgentManager {
                     "Failed to establish ACP protocol connection"
                 );
                 let _ = unregister_agent_process(&params.data_dir, process.pid());
-                AppError::from(e)
+                acp_error_to_app_error(e)
             })?,
         };
         let permission_router = Arc::new(PermissionRouter::new(permission_rx));
@@ -549,8 +551,8 @@ impl AcpAgentManager {
     /// forwarded to the CLI. Each hook in the pipeline reads one-shot flags
     /// on `AcpSession` (e.g. `pending_session_new_prelude`,
     /// `pending_model_notice`) and prepends the appropriate block when set.
-    async fn ensure_session_and_send(&self, data: &SendMessageData) -> Result<(), AppError> {
-        let sid = self.ensure_session_opened().await?;
+    async fn ensure_session_and_send(&self, data: &SendMessageData) -> Result<(), AcpSendFailure> {
+        let sid = self.ensure_session_opened().await.map_err(AcpSendFailure::from)?;
         self.runtime.reset_for_new_turn(ConversationStatus::Running);
 
         let content = {
@@ -629,6 +631,8 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
                 Ok(())
             }
             Err(err) => {
+                let send_error = err.to_agent_send_error();
+                let app_err = err.into_app_error();
                 // Build a CloseReason that captures whatever context we still
                 // have. Two cases matter:
                 //   1. The CLI process has already exited — we can read the
@@ -639,19 +643,18 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
                 //      stderr-augmentation heuristic for the SDK's "default
                 //      Internal error" shape; otherwise the user-facing form
                 //      of the AppError is the best we can do.
-                let close_reason = self.build_close_reason_from_error(&err).await;
+                let close_reason = self.build_close_reason_from_error(&app_err).await;
 
                 // Operator log: full error chain + the (raw, pre-redaction)
                 // stderr peek so on-call can correlate. The redacted summary
                 // is what reaches the UI.
                 let summary = close_reason.user_facing_message();
-                error!(error = %ErrorChain(&err), close_reason_summary = %summary, "ACP send_message failed");
+                error!(error = %ErrorChain(&app_err), close_reason_summary = %summary, "ACP send_message failed");
 
                 {
                     let mut session = self.session.write().await;
                     session.record_close_reason(Some(close_reason));
                 }
-                let send_error = AgentSendError::from_app_error(err);
                 self.runtime.emit_error_data(send_error.stream_error().clone());
                 Err(send_error)
             }

--- a/crates/aionui-ai-agent/src/manager/acp/agent_reconcile.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_reconcile.rs
@@ -1,7 +1,7 @@
 use crate::manager::acp::AcpAgentManager;
 
+use crate::manager::acp::error_mapping::{acp_error_to_app_error, is_acp_session_not_found};
 use crate::manager::acp::mode_normalize::normalize_requested_mode;
-use crate::protocol::error::AcpError;
 use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId};
 use agent_client_protocol::schema::{
     SessionId, SetSessionConfigOptionRequest, SetSessionModeRequest, SetSessionModelRequest,
@@ -67,14 +67,14 @@ impl AcpAgentManager {
                         ))
                         .await
                     {
-                        if matches!(e, AcpError::SessionNotFound { .. }) {
+                        if is_acp_session_not_found(&e) {
                             warn!(
                                 conversation_id = %self.params.conversation_id,
                                 mode_id = %normalized,
                                 error = %e,
                                 "reconcile_session: set_mode hit SessionNotFound; aborting reconcile"
                             );
-                            return Err(AppError::from(e));
+                            return Err(acp_error_to_app_error(e));
                         }
                         error!(
                             conversation_id = %self.params.conversation_id,
@@ -101,14 +101,14 @@ impl AcpAgentManager {
                         ))
                         .await
                     {
-                        if matches!(e, AcpError::SessionNotFound { .. }) {
+                        if is_acp_session_not_found(&e) {
                             warn!(
                                 conversation_id = %self.params.conversation_id,
                                 model_id = %model,
                                 error = %e,
                                 "reconcile_session: set_model hit SessionNotFound; aborting reconcile"
                             );
-                            return Err(AppError::from(e));
+                            return Err(acp_error_to_app_error(e));
                         }
                         error!(
                             conversation_id = %self.params.conversation_id,
@@ -139,7 +139,7 @@ impl AcpAgentManager {
                         ))
                         .await
                     {
-                        if matches!(err, AcpError::SessionNotFound { .. }) {
+                        if is_acp_session_not_found(&err) {
                             warn!(
                                 conversation_id = %self.params.conversation_id,
                                 config_id = %key,
@@ -147,7 +147,7 @@ impl AcpAgentManager {
                                 error = %err,
                                 "reconcile_session: set_config_option hit SessionNotFound; aborting reconcile"
                             );
-                            return Err(AppError::from(err));
+                            return Err(acp_error_to_app_error(err));
                         }
                         info!(
                             conversation_id = %self.params.conversation_id,

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -1,5 +1,6 @@
 use crate::manager::acp::AcpAgentManager;
 use crate::manager::acp::mode_normalize::agent_metadata_uses_meta_resume;
+use crate::protocol::error::AcpError;
 use crate::protocol::events::{
     AgentStreamEvent, AvailableCommandsEventData, ErrorEventData, FinishEventData, SessionAssignedEventData,
     StartEventData,
@@ -15,18 +16,10 @@ use serde_json::Value;
 use tokio::sync::broadcast::error::TryRecvError;
 
 use super::agent::sdk_to_snake_value;
+use super::error_mapping::{
+    AcpSendFailure, acp_error_to_app_error, is_acp_session_not_found, is_mapped_acp_session_not_found,
+};
 use tracing::warn;
-
-/// True when an `AppError` originates from an ACP `SessionNotFound`
-/// reply. Used to decide whether `open_session_resume` should drop a
-/// stale sid and fall through to `open_session_new` instead of
-/// surfacing the error. The `AcpError::SessionNotFound -> AppError`
-/// converter renders as "Session not found: <sid>", so we match on
-/// that text rather than `AppError::NotFound` alone — other 404 paths
-/// (e.g. "Workspace not found") must not trigger a session rebuild.
-fn is_session_not_found(err: &AppError) -> bool {
-    matches!(err, AppError::NotFound(msg) if msg.starts_with("Session not found"))
-}
 
 impl AcpAgentManager {
     /// Establish a fresh ACP session (session/new) and apply desired
@@ -36,7 +29,7 @@ impl AcpAgentManager {
     /// Returns the CLI-assigned session id.
     pub(super) async fn open_session_new(&self) -> Result<String, AppError> {
         let req = self.params.new_session_request();
-        let session_response = self.protocol.new_session(req).await.map_err(AppError::from)?;
+        let session_response = self.protocol.new_session(req).await.map_err(acp_error_to_app_error)?;
 
         let sid = session_response.session_id.to_string();
 
@@ -92,6 +85,11 @@ impl AcpAgentManager {
         self.open_session_new().await
     }
 
+    async fn rebuild_after_acp_session_not_found(&self, stale_sid: &str, err: AcpError) -> Result<String, AppError> {
+        let err = acp_error_to_app_error(err);
+        self.rebuild_after_session_not_found(stale_sid, &err).await
+    }
+
     /// Resume an existing ACP session and apply desired mode/model/config.
     /// Does NOT send a prompt. Returns the (possibly rewritten) session id.
     ///
@@ -119,12 +117,12 @@ impl AcpAgentManager {
             meta.insert("claudeCode".into(), Value::Object(claude_code));
 
             let req = self.params.new_session_request().meta(meta);
-            let new_response = match self.protocol.new_session(req).await.map_err(AppError::from) {
+            let new_response = match self.protocol.new_session(req).await {
                 Ok(r) => r,
-                Err(e) if is_session_not_found(&e) => {
-                    return self.rebuild_after_session_not_found(session_id, &e).await;
+                Err(e) if is_acp_session_not_found(&e) => {
+                    return self.rebuild_after_acp_session_not_found(session_id, e).await;
                 }
-                Err(e) => return Err(e),
+                Err(e) => return Err(acp_error_to_app_error(e)),
             };
             let new_sid = new_response.session_id.to_string();
 
@@ -153,7 +151,9 @@ impl AcpAgentManager {
 
             return match self.reconcile_session(&new_sid).await {
                 Ok(()) => Ok(new_sid),
-                Err(e) if is_session_not_found(&e) => self.rebuild_after_session_not_found(&new_sid, &e).await,
+                Err(e) if is_mapped_acp_session_not_found(&e) => {
+                    self.rebuild_after_session_not_found(&new_sid, &e).await
+                }
                 Err(e) => Err(e),
             };
         }
@@ -171,12 +171,12 @@ impl AcpAgentManager {
             if !self.params.mcp_servers.is_empty() {
                 load_req = load_req.mcp_servers(self.params.mcp_servers.clone());
             }
-            let load_response = match self.protocol.load_session(load_req).await.map_err(AppError::from) {
+            let load_response = match self.protocol.load_session(load_req).await {
                 Ok(r) => r,
-                Err(e) if is_session_not_found(&e) => {
-                    return self.rebuild_after_session_not_found(session_id, &e).await;
+                Err(e) if is_acp_session_not_found(&e) => {
+                    return self.rebuild_after_acp_session_not_found(session_id, e).await;
                 }
-                Err(e) => return Err(e),
+                Err(e) => return Err(acp_error_to_app_error(e)),
             };
 
             {
@@ -200,7 +200,9 @@ impl AcpAgentManager {
 
             return match self.reconcile_session(session_id).await {
                 Ok(()) => Ok(session_id.to_owned()),
-                Err(e) if is_session_not_found(&e) => self.rebuild_after_session_not_found(session_id, &e).await,
+                Err(e) if is_mapped_acp_session_not_found(&e) => {
+                    self.rebuild_after_session_not_found(session_id, &e).await
+                }
                 Err(e) => Err(e),
             };
         }
@@ -216,7 +218,7 @@ impl AcpAgentManager {
         self.emit_snapshot_events().await;
         match self.reconcile_session(session_id).await {
             Ok(()) => Ok(session_id.to_owned()),
-            Err(e) if is_session_not_found(&e) => self.rebuild_after_session_not_found(session_id, &e).await,
+            Err(e) if is_mapped_acp_session_not_found(&e) => self.rebuild_after_session_not_found(session_id, &e).await,
             Err(e) => Err(e),
         }
     }
@@ -226,8 +228,10 @@ impl AcpAgentManager {
         &self,
         data: &SendMessageData,
         session_id: Option<&str>,
-    ) -> Result<(), AppError> {
-        let sid = session_id.ok_or_else(|| AppError::Internal("Cannot prompt: no session ID available".into()))?;
+    ) -> Result<(), AcpSendFailure> {
+        let sid = session_id
+            .ok_or_else(|| AppError::Internal("Cannot prompt: no session ID available".into()))
+            .map_err(AcpSendFailure::from)?;
 
         let content = data.content.clone();
 
@@ -249,7 +253,7 @@ impl AcpAgentManager {
                 vec![ContentBlock::from(content)],
             ))
             .await
-            .map_err(AppError::from)?;
+            .map_err(AcpSendFailure::from)?;
 
         // Diagnose the "blank reply" case: the agent finished a turn without
         // producing any user-visible output. We surface a structured error to
@@ -425,6 +429,7 @@ mod tests {
     //! `session_id()` — the same terminal state the real `open_session_new`
     //! / `open_session_resume` helpers leave behind.
     use crate::manager::acp::{AcpSession, AcpSessionEvent};
+    use crate::protocol::error::AcpError;
     use crate::shared_kernel::SessionId as DomainSessionId;
     use agent_client_protocol::schema::AgentCapabilities;
 
@@ -567,23 +572,25 @@ mod tests {
         );
     }
 
-    /// The `is_session_not_found` discriminator powers
+    /// The `is_acp_session_not_found` discriminator powers
     /// `open_session_resume`'s rescue path. Match strictly on the
-    /// `AcpError::SessionNotFound -> AppError::NotFound` rendering;
-    /// other 404s (e.g. workspace lookup) must surface to callers
-    /// instead of triggering a phantom session rebuild.
+    /// structured `AcpError::SessionNotFound` variant; other ACP failures
+    /// must surface to callers instead of triggering a phantom session
+    /// rebuild.
     #[test]
-    fn is_session_not_found_matches_session_not_found_only() {
-        use aionui_common::AppError;
+    fn is_acp_session_not_found_matches_session_not_found_only() {
+        let session_err = AcpError::SessionNotFound {
+            session_id: "ses-1".into(),
+        };
+        assert!(super::is_acp_session_not_found(&session_err));
 
-        let session_err = AppError::NotFound("Session not found: ses-1".into());
-        assert!(super::is_session_not_found(&session_err));
+        let invalid_params = AcpError::InvalidParams {
+            message: "Workspace not found".into(),
+        };
+        assert!(!super::is_acp_session_not_found(&invalid_params));
 
-        let workspace_err = AppError::NotFound("Workspace not found".into());
-        assert!(!super::is_session_not_found(&workspace_err));
-
-        let bad_request = AppError::BadRequest("anything".into());
-        assert!(!super::is_session_not_found(&bad_request));
+        let auth_required = AcpError::AuthRequired;
+        assert!(!super::is_acp_session_not_found(&auth_required));
     }
 
     // -- empty-finish diagnostic (ELECTRON-1JG) -------------------------------

--- a/crates/aionui-ai-agent/src/manager/acp/error_mapping.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/error_mapping.rs
@@ -1,0 +1,145 @@
+use crate::protocol::error::AcpError;
+use crate::protocol::send_error::AgentSendError;
+use aionui_common::AppError;
+
+#[derive(Debug)]
+pub(super) enum AcpSendFailure {
+    App(AppError),
+    Acp(AcpError),
+}
+
+impl AcpSendFailure {
+    pub(super) fn to_agent_send_error(&self) -> AgentSendError {
+        match self {
+            AcpSendFailure::App(err) => AgentSendError::from_app_error_ref(err),
+            AcpSendFailure::Acp(err) => AgentSendError::from_acp_error_ref(err),
+        }
+    }
+
+    pub(super) fn into_app_error(self) -> AppError {
+        match self {
+            AcpSendFailure::App(err) => err,
+            AcpSendFailure::Acp(err) => acp_error_to_app_error(err),
+        }
+    }
+}
+
+impl From<AppError> for AcpSendFailure {
+    fn from(err: AppError) -> Self {
+        AcpSendFailure::App(err)
+    }
+}
+
+impl From<AcpError> for AcpSendFailure {
+    fn from(err: AcpError) -> Self {
+        AcpSendFailure::Acp(err)
+    }
+}
+
+impl std::fmt::Display for AcpSendFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AcpSendFailure::App(err) => std::fmt::Display::fmt(err, f),
+            AcpSendFailure::Acp(err) => f.write_str(&acp_error_public_message(err)),
+        }
+    }
+}
+
+impl std::error::Error for AcpSendFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            AcpSendFailure::App(err) => Some(err),
+            AcpSendFailure::Acp(err) => Some(err),
+        }
+    }
+}
+
+pub(super) fn acp_error_to_app_error(err: AcpError) -> AppError {
+    match &err {
+        AcpError::SpawnFailed { .. } | AcpError::StartupCrash { .. } | AcpError::Disconnected { .. } => {
+            AppError::BadGateway(err.to_string())
+        }
+        AcpError::AuthRequired => AppError::Unauthorized("Agent requires authentication".into()),
+        AcpError::SessionNotFound { .. } => AppError::NotFound(err.to_string()),
+        AcpError::MethodNotFound { .. } => AppError::BadRequest(err.to_string()),
+        AcpError::InvalidParams { .. } => AppError::BadRequest(err.to_string()),
+        AcpError::AgentInternal { .. } => AppError::BadGateway(acp_error_public_message(&err)),
+        AcpError::NotConnected => AppError::Internal("ACP protocol not connected".into()),
+        AcpError::InitTimeout { .. } => AppError::BadGateway(err.to_string()),
+    }
+}
+
+pub(super) fn is_acp_session_not_found(err: &AcpError) -> bool {
+    matches!(err, AcpError::SessionNotFound { .. })
+}
+
+pub(super) fn is_mapped_acp_session_not_found(err: &AppError) -> bool {
+    matches!(err, AppError::NotFound(msg) if msg.starts_with("Session not found"))
+}
+
+fn acp_error_public_message(err: &AcpError) -> String {
+    match err {
+        AcpError::AgentInternal { code, .. } => format!("Agent internal error (code {code})"),
+        _ => err.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    #[test]
+    fn acp_error_to_app_error_status_codes() {
+        let cases = vec![
+            (AcpError::SpawnFailed { message: "x".into() }, StatusCode::BAD_GATEWAY),
+            (AcpError::AuthRequired, StatusCode::UNAUTHORIZED),
+            (
+                AcpError::SessionNotFound { session_id: "s".into() },
+                StatusCode::NOT_FOUND,
+            ),
+            (AcpError::MethodNotFound { method: "m".into() }, StatusCode::BAD_REQUEST),
+            (AcpError::InvalidParams { message: "p".into() }, StatusCode::BAD_REQUEST),
+            (
+                AcpError::AgentInternal {
+                    message: "e".into(),
+                    code: -1,
+                    data: None,
+                },
+                StatusCode::BAD_GATEWAY,
+            ),
+            (AcpError::NotConnected, StatusCode::INTERNAL_SERVER_ERROR),
+            (AcpError::InitTimeout { timeout_secs: 30 }, StatusCode::BAD_GATEWAY),
+        ];
+
+        for (acp_err, expected_status) in cases {
+            let app_err = acp_error_to_app_error(acp_err);
+            assert_eq!(app_err.status_code(), expected_status, "Mismatch for {app_err:?}");
+        }
+    }
+
+    #[test]
+    fn acp_error_to_app_error_omits_stderr_and_structured_data() {
+        let startup = acp_error_to_app_error(AcpError::StartupCrash {
+            exit_code: Some(1),
+            signal: None,
+            stderr: "Authorization: Bearer sk-secret".into(),
+        });
+        assert!(!startup.to_string().contains("sk-secret"));
+        assert!(!startup.to_string().contains("Authorization"));
+
+        let internal = acp_error_to_app_error(AcpError::AgentInternal {
+            message: "Internal error".into(),
+            code: -32603,
+            data: Some(serde_json::json!({
+                "error": "Failed to connect MCP servers",
+                "api_key": "sk-secret"
+            })),
+        });
+        let rendered = internal.to_string();
+        assert!(rendered.contains("Agent internal error (code -32603)"));
+        assert!(!rendered.contains("Failed to connect MCP servers"));
+        assert!(!rendered.contains("sk-secret"));
+        assert!(!rendered.contains("api_key"));
+    }
+}

--- a/crates/aionui-ai-agent/src/manager/acp/mod.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/mod.rs
@@ -5,6 +5,7 @@ pub mod agent_reconcile;
 mod agent_session_flow;
 pub mod catalog_forwarder;
 mod codex_sandbox;
+mod error_mapping;
 pub mod hooks;
 mod mode_normalize;
 pub mod permission_router;

--- a/crates/aionui-ai-agent/src/protocol/error.rs
+++ b/crates/aionui-ai-agent/src/protocol/error.rs
@@ -1,5 +1,5 @@
 use agent_client_protocol::{Error as SdkError, ErrorCode};
-use aionui_common::{AgentKillReason, AppError};
+use aionui_common::AgentKillReason;
 
 /// Why an ACP session was closed / terminated.
 ///
@@ -78,13 +78,16 @@ impl CloseReason {
     }
 }
 
-/// ACP-specific error type for protocol and process lifecycle errors.
+/// Workspace-facing owned ACP error contract.
 ///
-/// This error is internal to the `aionui-ai-agent` crate. External callers
-/// see it only after conversion to [`AppError`] via the `From` impl.
+/// Variants and fields are exposed for structured classification by workspace
+/// callers, but must not be rendered directly to public HTTP or WebSocket
+/// output. The `stderr` fields may contain sensitive data; `Display`
+/// intentionally omits them.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 #[allow(dead_code)] // Variants constructed as error paths mature; kept for complete ACP error model.
-pub(crate) enum AcpError {
+pub enum AcpError {
     // ── Process lifecycle ──────────────────────────────────────────
     /// CLI binary not found or not executable.
     SpawnFailed { message: String },
@@ -136,8 +139,8 @@ pub(crate) enum AcpError {
 }
 
 /// Format the human-readable suffix for `StartupCrash` / `Disconnected`.
-/// stderr is deliberately omitted — see the `From<AcpError> for AppError`
-/// security note.
+/// stderr is deliberately omitted; app-layer mappers must use `Display`
+/// instead of serializing raw process output.
 fn format_exit_detail(exit_code: Option<i32>, signal: Option<&str>) -> String {
     match (exit_code, signal) {
         (Some(code), Some(sig)) => format!(" (exit code {code}, {sig})"),
@@ -302,49 +305,9 @@ fn extract_session_not_found(data: Option<&serde_json::Value>) -> Option<String>
     if sid.is_empty() { None } else { Some(sid.to_owned()) }
 }
 
-/// Conversion from [`AcpError`] to [`AppError`] — the only way `AcpError`
-/// leaves this crate.
-///
-/// **Security:** `StartupCrash` and `Disconnected` contain `stderr` which may
-/// hold sensitive data. The `Display` impl only includes
-/// `exit_code` and `signal`. `stderr` is available for structured logging
-/// (`tracing`) but never serialized into HTTP responses.
-impl From<AcpError> for AppError {
-    fn from(err: AcpError) -> Self {
-        match &err {
-            // Process lifecycle → 502 Bad Gateway (upstream failure)
-            AcpError::SpawnFailed { .. } | AcpError::StartupCrash { .. } | AcpError::Disconnected { .. } => {
-                AppError::BadGateway(err.to_string())
-            }
-
-            // Authentication → 401
-            AcpError::AuthRequired => AppError::Unauthorized("Agent requires authentication".into()),
-
-            // Session not found → 404
-            AcpError::SessionNotFound { .. } => AppError::NotFound(err.to_string()),
-
-            // Method not found → 400
-            AcpError::MethodNotFound { .. } => AppError::BadRequest(err.to_string()),
-
-            // Invalid parameters → 400
-            AcpError::InvalidParams { .. } => AppError::BadRequest(err.to_string()),
-
-            // Agent internal error → 502 (upstream failure)
-            AcpError::AgentInternal { .. } => AppError::BadGateway(err.to_string()),
-
-            // Not connected → 500 (our bug)
-            AcpError::NotConnected => AppError::Internal("ACP protocol not connected".into()),
-
-            // Init timeout → 502
-            AcpError::InitTimeout { .. } => AppError::BadGateway(err.to_string()),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::http::StatusCode;
 
     // ── CloseReason ─────────────────────────────────────────────────────
 
@@ -610,35 +573,6 @@ mod tests {
     }
 
     #[test]
-    fn to_app_error_status_codes() {
-        let cases: Vec<(AcpError, StatusCode)> = vec![
-            (AcpError::SpawnFailed { message: "x".into() }, StatusCode::BAD_GATEWAY),
-            (AcpError::AuthRequired, StatusCode::UNAUTHORIZED),
-            (
-                AcpError::SessionNotFound { session_id: "s".into() },
-                StatusCode::NOT_FOUND,
-            ),
-            (AcpError::MethodNotFound { method: "m".into() }, StatusCode::BAD_REQUEST),
-            (AcpError::InvalidParams { message: "p".into() }, StatusCode::BAD_REQUEST),
-            (
-                AcpError::AgentInternal {
-                    message: "e".into(),
-                    code: -1,
-                    data: None,
-                },
-                StatusCode::BAD_GATEWAY,
-            ),
-            (AcpError::NotConnected, StatusCode::INTERNAL_SERVER_ERROR),
-            (AcpError::InitTimeout { timeout_secs: 30 }, StatusCode::BAD_GATEWAY),
-        ];
-
-        for (acp_err, expected_status) in cases {
-            let app_err: AppError = acp_err.into();
-            assert_eq!(app_err.status_code(), expected_status, "Mismatch for {app_err:?}");
-        }
-    }
-
-    #[test]
     fn display_does_not_contain_stderr() {
         let err = AcpError::StartupCrash {
             exit_code: Some(1),
@@ -698,6 +632,23 @@ mod tests {
             AcpError::AgentInternal { code, message, data } => {
                 assert_eq!(code, -32603);
                 assert_eq!(message, "Internal error");
+                let data = data.expect("data must be preserved");
+                assert_eq!(data["reason"], "rate_limited");
+                assert_eq!(data["retry_after"], 30);
+            }
+            other => panic!("Expected AgentInternal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_internal_preserves_code_and_data() {
+        let sdk_err = SdkError::new(-32099, "custom upstream error")
+            .data(serde_json::json!({"reason": "rate_limited", "retry_after": 30}));
+        let acp = AcpError::from_sdk(sdk_err, "context");
+        match acp {
+            AcpError::AgentInternal { code, message, data } => {
+                assert_eq!(code, -32099);
+                assert_eq!(message, "custom upstream error");
                 let data = data.expect("data must be preserved");
                 assert_eq!(data["reason"], "rate_limited");
                 assert_eq!(data["retry_after"], 30);

--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -204,26 +204,13 @@ impl AgentSendError {
     pub fn ownership(&self) -> Option<AgentErrorOwnership> {
         self.stream_error.ownership
     }
-}
 
-impl std::fmt::Display for AgentSendError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.stream_error.message)
+    pub(crate) fn from_acp_error_ref(err: &AcpError) -> Self {
+        classify_acp_error(err)
     }
-}
 
-impl std::error::Error for AgentSendError {}
-
-impl From<AppError> for AgentSendError {
-    fn from(err: AppError) -> Self {
-        Self::from_app_error(err)
-    }
-}
-
-impl From<AcpError> for AgentSendError {
-    fn from(err: AcpError) -> Self {
-        let detail = err.to_string();
-        match &err {
+    fn from_acp_non_internal(err: &AcpError, detail: String) -> Self {
+        match err {
             AcpError::SpawnFailed { .. } => Self::new(
                 "The selected Agent executable could not be started",
                 AgentErrorCode::UserAgentNotInstalled,
@@ -320,27 +307,131 @@ impl From<AcpError> for AgentSendError {
                     Some(AgentErrorResolutionTarget::Feedback),
                 ),
             ),
-            AcpError::AgentInternal { .. } => classify_upstream_detail(&detail),
+            AcpError::AgentInternal { .. } => unknown_upstream_error(detail),
         }
     }
+}
+
+impl std::fmt::Display for AgentSendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.stream_error.message)
+    }
+}
+
+impl std::error::Error for AgentSendError {}
+
+impl From<AppError> for AgentSendError {
+    fn from(err: AppError) -> Self {
+        Self::from_app_error(err)
+    }
+}
+
+impl From<AcpError> for AgentSendError {
+    fn from(err: AcpError) -> Self {
+        Self::from_acp_error_ref(&err)
+    }
+}
+
+fn classify_acp_error(err: &AcpError) -> AgentSendError {
+    match err {
+        AcpError::AgentInternal { message, code, data } => {
+            let detail = acp_agent_internal_public_detail(*code);
+            if *code != -32603 {
+                return unknown_upstream_error(detail);
+            }
+
+            let classified = acp_agent_internal_texts(message, data.as_ref())
+                .into_iter()
+                .find_map(|text| {
+                    let lower = text.to_ascii_lowercase();
+                    classify_agent_lifecycle(&lower)
+                        .or_else(|| classify_provider_text(&lower))
+                        .or_else(|| classify_aionui_state(&lower))
+                });
+
+            match classified {
+                Some(classification) => classification.into_send_error(detail),
+                None => unknown_upstream_error(detail),
+            }
+        }
+        _ => AgentSendError::from_acp_non_internal(err, err.to_string()),
+    }
+}
+
+fn acp_agent_internal_public_detail(code: i32) -> String {
+    format!("Agent internal error (code {code})")
+}
+
+fn acp_agent_internal_texts<'a>(message: &'a str, data: Option<&'a serde_json::Value>) -> Vec<&'a str> {
+    let mut texts = Vec::new();
+    if let Some(data) = data {
+        collect_acp_data_texts(data, &mut texts);
+    }
+
+    let trimmed = message.trim();
+    if !is_uninformative_acp_message(trimmed) {
+        texts.push(trimmed);
+    }
+
+    texts
+}
+
+fn collect_acp_data_texts<'a>(value: &'a serde_json::Value, texts: &mut Vec<&'a str>) {
+    match value {
+        serde_json::Value::String(text) => texts.push(text.as_str()),
+        serde_json::Value::Object(map) => {
+            for key in ["error", "details", "message"] {
+                if let Some(value) = map.get(key) {
+                    collect_acp_data_texts(value, texts);
+                }
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_acp_data_texts(value, texts);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_uninformative_acp_message(message: &str) -> bool {
+    message.is_empty()
+        || [
+            "Parse error",
+            "Invalid request",
+            "Method not found",
+            "Invalid params",
+            "Internal error",
+        ]
+        .iter()
+        .any(|default| default.eq_ignore_ascii_case(message))
 }
 
 fn classify_upstream_detail(detail: &str) -> AgentSendError {
     let lower = detail.to_ascii_lowercase();
     let classified = classify_agent_lifecycle(&lower)
-        .or_else(|| classify_provider_api(&lower))
+        .or_else(|| classify_provider_text(&lower))
         .or_else(|| classify_aionui_state(&lower))
-        .unwrap_or(ClassifiedError {
-            message: "The upstream Agent failed while handling the request",
-            code: AgentErrorCode::UnknownUpstreamError,
-            ownership: AgentErrorOwnership::UnknownUpstream,
-            retryable: true,
-            feedback_recommended: true,
-            resolution_kind: AgentErrorResolutionKind::SendFeedback,
-            resolution_target: Some(AgentErrorResolutionTarget::Feedback),
-        });
+        .unwrap_or_else(unknown_upstream_classification);
 
     classified.into_send_error(detail.to_owned())
+}
+
+fn unknown_upstream_error(detail: String) -> AgentSendError {
+    unknown_upstream_classification().into_send_error(detail)
+}
+
+fn unknown_upstream_classification() -> ClassifiedError {
+    ClassifiedError {
+        message: "The upstream Agent failed while handling the request",
+        code: AgentErrorCode::UnknownUpstreamError,
+        ownership: AgentErrorOwnership::UnknownUpstream,
+        retryable: true,
+        feedback_recommended: true,
+        resolution_kind: AgentErrorResolutionKind::SendFeedback,
+        resolution_target: Some(AgentErrorResolutionTarget::Feedback),
+    }
 }
 
 fn classify_agent_lifecycle(lower: &str) -> Option<ClassifiedError> {
@@ -391,6 +482,14 @@ fn classify_agent_lifecycle(lower: &str) -> Option<ClassifiedError> {
             AgentErrorCode::UserAgentNoPreviousSession,
         ));
     }
+    if lower.contains("failed to connect mcp") {
+        return Some(agent_error(
+            "The selected Agent disconnected from an MCP server",
+            AgentErrorCode::UserAgentDisconnected,
+            true,
+            AgentErrorResolutionKind::ReconnectAgent,
+        ));
+    }
     if lower.contains("session not found") {
         return Some(agent_session_error(
             "The Agent session was not found",
@@ -417,7 +516,7 @@ fn classify_agent_lifecycle(lower: &str) -> Option<ClassifiedError> {
     None
 }
 
-fn classify_provider_api(lower: &str) -> Option<ClassifiedError> {
+fn classify_provider_text(lower: &str) -> Option<ClassifiedError> {
     if contains_any(
         lower,
         &[
@@ -852,6 +951,7 @@ fn truncate_chars(value: &str, max: usize) -> String {
 mod tests {
     use super::*;
     use aionui_api_types::{AgentErrorResolutionKind, AgentErrorResolutionTarget};
+    use serde_json::json;
 
     fn assert_classification(
         detail: &str,
@@ -863,6 +963,19 @@ mod tests {
         assert_eq!(err.code(), Some(code));
         assert_eq!(err.ownership(), Some(ownership));
         assert_eq!(err.stream_error().resolution.map(|value| value.kind), Some(resolution));
+    }
+
+    fn assert_acp_classification(
+        err: AcpError,
+        code: AgentErrorCode,
+        ownership: AgentErrorOwnership,
+        resolution: AgentErrorResolutionKind,
+    ) -> AgentSendError {
+        let err = AgentSendError::from(err);
+        assert_eq!(err.code(), Some(code));
+        assert_eq!(err.ownership(), Some(ownership));
+        assert_eq!(err.stream_error().resolution.map(|value| value.kind), Some(resolution));
+        err
     }
 
     fn assert_resolution_target(detail: &str, target: AgentErrorResolutionTarget) {
@@ -1029,6 +1142,124 @@ mod tests {
         ));
         assert_eq!(err.stream_error().retryable, Some(true));
         assert_eq!(err.stream_error().feedback_recommended, Some(false));
+    }
+
+    #[test]
+    fn classifies_acp_internal_mcp_connect_failure_from_structured_data() {
+        let err = assert_acp_classification(
+            AcpError::AgentInternal {
+                message: "Internal error".into(),
+                code: -32603,
+                data: Some(json!({"error": "Failed to connect MCP servers"})),
+            },
+            AgentErrorCode::UserAgentDisconnected,
+            AgentErrorOwnership::UserAgent,
+            AgentErrorResolutionKind::ReconnectAgent,
+        );
+
+        let detail = err.stream_error().detail.as_deref().expect("detail present");
+        assert_eq!(detail, "Agent internal error (code -32603)");
+        assert!(!detail.contains("Failed to connect MCP servers"));
+    }
+
+    #[test]
+    fn classifies_acp_internal_process_exit_from_structured_details() {
+        let err = assert_acp_classification(
+            AcpError::AgentInternal {
+                message: "Internal error".into(),
+                code: -32603,
+                data: Some(json!({"details": "Claude Code process exited with code 1"})),
+            },
+            AgentErrorCode::UserAgentDisconnected,
+            AgentErrorOwnership::UserAgent,
+            AgentErrorResolutionKind::ReconnectAgent,
+        );
+
+        assert_eq!(err.stream_error().retryable, Some(true));
+        assert_eq!(err.stream_error().feedback_recommended, Some(false));
+    }
+
+    #[test]
+    fn classifies_acp_internal_provider_failure_from_structured_message() {
+        assert_acp_classification(
+            AcpError::AgentInternal {
+                message: "Provider error: API error 401: invalid x-api-key".into(),
+                code: -32603,
+                data: None,
+            },
+            AgentErrorCode::UserLlmProviderAuthFailed,
+            AgentErrorOwnership::UserLlmProvider,
+            AgentErrorResolutionKind::CheckProviderCredentials,
+        );
+    }
+
+    #[test]
+    fn classifies_acp_internal_nested_provider_error_message() {
+        assert_acp_classification(
+            AcpError::AgentInternal {
+                message: "Internal error".into(),
+                code: -32603,
+                data: Some(json!({
+                    "type": "error",
+                    "error": {
+                        "message": "Your credit balance is too low to access the Anthropic API"
+                    }
+                })),
+            },
+            AgentErrorCode::UserLlmProviderBillingRequired,
+            AgentErrorOwnership::UserLlmProvider,
+            AgentErrorResolutionKind::CheckProviderBilling,
+        );
+    }
+
+    #[test]
+    fn classifies_acp_internal_nested_provider_data_before_generic_message() {
+        assert_acp_classification(
+            AcpError::AgentInternal {
+                message: "Provider error".into(),
+                code: -32603,
+                data: Some(json!({
+                    "error": {
+                        "message": "invalid x-api-key"
+                    }
+                })),
+            },
+            AgentErrorCode::UserLlmProviderAuthFailed,
+            AgentErrorOwnership::UserLlmProvider,
+            AgentErrorResolutionKind::CheckProviderCredentials,
+        );
+    }
+
+    #[test]
+    fn acp_internal_public_detail_does_not_include_structured_data() {
+        let err = AgentSendError::from(AcpError::AgentInternal {
+            message: "Internal error".into(),
+            code: -32603,
+            data: Some(json!({
+                "error": "Failed to connect MCP servers",
+                "api_key": "sk-secret"
+            })),
+        });
+
+        let detail = err.stream_error().detail.as_deref().expect("detail present");
+        assert_eq!(detail, "Agent internal error (code -32603)");
+        assert!(!detail.contains("Failed to connect MCP servers"));
+        assert!(!detail.contains("sk-secret"));
+        assert!(!detail.contains("api_key"));
+    }
+
+    #[test]
+    fn provider_free_text_still_uses_provider_heuristic_boundary() {
+        let err = AgentSendError::from_app_error(AppError::BadGateway(
+            "Provider error: API error 401: invalid x-api-key".into(),
+        ));
+
+        assert_eq!(err.code(), Some(AgentErrorCode::UserLlmProviderAuthFailed));
+        assert_eq!(err.ownership(), Some(AgentErrorOwnership::UserLlmProvider));
+        assert_eq!(
+            err.stream_error().resolution.map(|value| value.kind),
+            Some(AgentErrorResolutionKind::CheckProviderCredentials)
+        );
     }
 
     #[test]

--- a/crates/aionui-ai-agent/tests/acp_error_public.rs
+++ b/crates/aionui-ai-agent/tests/acp_error_public.rs
@@ -1,0 +1,8 @@
+use aionui_ai_agent::AcpError;
+
+fn assert_error<E: std::error::Error + Send + Sync + 'static>() {}
+
+#[test]
+fn acp_error_is_public_error_contract() {
+    assert_error::<AcpError>();
+}

--- a/crates/aionui-conversation/Cargo.toml
+++ b/crates/aionui-conversation/Cargo.toml
@@ -20,6 +20,7 @@ serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 async-trait.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/aionui-conversation/src/error.rs
+++ b/crates/aionui-conversation/src/error.rs
@@ -1,0 +1,44 @@
+use aionui_ai_agent::AcpError;
+use aionui_common::AppError;
+
+/// Application-level error contract for the conversation domain.
+///
+/// This type may preserve structured lower-layer errors for domain decisions,
+/// but HTTP and WebSocket boundaries must map it through an explicit public
+/// output mapper. Do not render `ConversationError::Acp` directly to clients.
+#[derive(Debug, thiserror::Error)]
+pub enum ConversationError {
+    #[error("Conversation not found: {id}")]
+    NotFound { id: String },
+
+    #[error("Conversation is archived: {id}")]
+    Archived { id: String },
+
+    #[error("Forbidden: {reason}")]
+    Forbidden { reason: String },
+
+    #[error("ACP error")]
+    Acp(#[from] AcpError),
+
+    #[error(transparent)]
+    App(#[from] AppError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_error<E: std::error::Error + Send + Sync + 'static>() {}
+
+    fn assert_from_acp<T: From<AcpError>>() {}
+
+    #[test]
+    fn conversation_error_is_error_contract() {
+        assert_error::<ConversationError>();
+    }
+
+    #[test]
+    fn conversation_error_has_acp_from_impl() {
+        assert_from_acp::<ConversationError>();
+    }
+}

--- a/crates/aionui-conversation/src/lib.rs
+++ b/crates/aionui-conversation/src/lib.rs
@@ -1,6 +1,7 @@
 //! Conversation and message CRUD with streaming relay and event emission.
 mod acp_error_recovery;
 mod convert;
+pub mod error;
 mod message_persistence;
 pub mod response_middleware;
 pub mod routes;
@@ -14,6 +15,7 @@ pub mod state;
 pub mod stream_relay;
 pub mod task_options;
 
+pub use error::ConversationError;
 pub use response_middleware::{
     CronCommand, CronCommandResult, CronCreateParams, CronUpdateParams, ICronService, MessageMiddleware,
     MiddlewareResult, detect_cron_commands, has_cron_commands, strip_cron_commands, strip_think_tags,


### PR DESCRIPTION
## Summary
- expose `AcpError` as a controlled public ACP error contract and add `ConversationError`
- classify ACP send failures from structured `AcpError` data instead of `AppError::BadGateway(String)` text archaeology
- replace the global `AcpError -> AppError` conversion with ACP-manager-local mapping and preserve safe public stream details

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p aionui-ai-agent`
- `cargo test -p aionui-conversation`
- `cargo clippy -p aionui-ai-agent -p aionui-conversation -- -D warnings`
- `cargo test -p aionui-api-types agent_error`
- `just push -u origin boii/error-model-phase1` (ran `cargo fix`, workspace clippy fix, fmt, `cargo nextest run --workspace`, then pushed)
- `cargo nextest run --workspace`: 5818 passed, 18 skipped
