### PR TITLE
refactor(error): migrate phase2 service errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tower-http",
  "tracing",

--- a/crates/aionui-assistant/src/service.rs
+++ b/crates/aionui-assistant/src/service.rs
@@ -14,7 +14,9 @@ use aionui_db::{
     AssistantOverrideRow, AssistantRow, CreateAssistantParams, IAssistantOverrideRepository, IAssistantRepository,
     IProviderRepository, UpdateAssistantParams, UpsertOverrideParams,
 };
-use aionui_extension::{AssistantClassifier, AssistantRuleDispatcher, ExtensionRegistry, ResolvedAssistant};
+use aionui_extension::{
+    AssistantClassifier, AssistantRuleDispatcher, ExtensionError, ExtensionRegistry, ResolvedAssistant,
+};
 use serde_json;
 use tracing::{debug, warn};
 
@@ -712,28 +714,49 @@ impl AssistantClassifier for AssistantService {
 
 #[async_trait::async_trait]
 impl AssistantRuleDispatcher for AssistantService {
-    async fn read_rule(&self, id: &str, locale: Option<&str>) -> Result<String, AppError> {
-        AssistantService::read_rule(self, id, locale).await
+    async fn read_rule(&self, id: &str, locale: Option<&str>) -> Result<String, ExtensionError> {
+        AssistantService::read_rule(self, id, locale)
+            .await
+            .map_err(assistant_app_error_to_extension_error)
     }
 
-    async fn write_rule(&self, id: &str, locale: Option<&str>, content: &str) -> Result<(), AppError> {
-        AssistantService::write_rule(self, id, locale, content).await
+    async fn write_rule(&self, id: &str, locale: Option<&str>, content: &str) -> Result<(), ExtensionError> {
+        AssistantService::write_rule(self, id, locale, content)
+            .await
+            .map_err(assistant_app_error_to_extension_error)
     }
 
-    async fn delete_rule(&self, id: &str) -> Result<bool, AppError> {
-        AssistantService::delete_rule(self, id).await
+    async fn delete_rule(&self, id: &str) -> Result<bool, ExtensionError> {
+        AssistantService::delete_rule(self, id)
+            .await
+            .map_err(assistant_app_error_to_extension_error)
     }
 
-    async fn read_skill(&self, id: &str, locale: Option<&str>) -> Result<String, AppError> {
-        AssistantService::read_skill(self, id, locale).await
+    async fn read_skill(&self, id: &str, locale: Option<&str>) -> Result<String, ExtensionError> {
+        AssistantService::read_skill(self, id, locale)
+            .await
+            .map_err(assistant_app_error_to_extension_error)
     }
 
-    async fn write_skill(&self, id: &str, locale: Option<&str>, content: &str) -> Result<(), AppError> {
-        AssistantService::write_skill(self, id, locale, content).await
+    async fn write_skill(&self, id: &str, locale: Option<&str>, content: &str) -> Result<(), ExtensionError> {
+        AssistantService::write_skill(self, id, locale, content)
+            .await
+            .map_err(assistant_app_error_to_extension_error)
     }
 
-    async fn delete_skill(&self, id: &str) -> Result<bool, AppError> {
-        AssistantService::delete_skill(self, id).await
+    async fn delete_skill(&self, id: &str) -> Result<bool, ExtensionError> {
+        AssistantService::delete_skill(self, id)
+            .await
+            .map_err(assistant_app_error_to_extension_error)
+    }
+}
+
+fn assistant_app_error_to_extension_error(error: AppError) -> ExtensionError {
+    match error {
+        AppError::BadRequest(message) => ExtensionError::InvalidRequest(message),
+        AppError::NotFound(message) => ExtensionError::NotFound(message),
+        AppError::Internal(message) => ExtensionError::Internal(message),
+        other => ExtensionError::Internal(other.to_string()),
     }
 }
 

--- a/crates/aionui-auth/src/error.rs
+++ b/crates/aionui-auth/src/error.rs
@@ -1,8 +1,4 @@
-use aionui_common::AppError;
-
 /// Authentication-layer errors.
-///
-/// Converts to `AppError` for HTTP response mapping.
 #[derive(Debug, thiserror::Error)]
 pub enum AuthError {
     #[error("Invalid credentials")]
@@ -23,68 +19,9 @@ pub enum AuthError {
     #[error("Token blacklisted")]
     TokenBlacklisted,
 
+    #[error("Rate limit exceeded")]
+    RateLimited,
+
     #[error("Password hash error: {0}")]
     HashError(String),
-}
-
-impl From<AuthError> for AppError {
-    fn from(err: AuthError) -> Self {
-        match err {
-            AuthError::InvalidCredentials => AppError::Unauthorized("Invalid username or password".into()),
-            AuthError::WeakPassword(msg) => AppError::BadRequest(msg),
-            AuthError::InvalidUsername(msg) => AppError::BadRequest(msg),
-            AuthError::TokenExpired => AppError::Unauthorized("Token expired".into()),
-            AuthError::TokenInvalid(msg) => AppError::Unauthorized(msg),
-            AuthError::TokenBlacklisted => AppError::Unauthorized("Token has been revoked".into()),
-            AuthError::HashError(msg) => AppError::Internal(format!("Password hash error: {msg}")),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use axum::http::StatusCode;
-
-    #[test]
-    fn invalid_credentials_maps_to_unauthorized() {
-        let app_err: AppError = AuthError::InvalidCredentials.into();
-        assert_eq!(app_err.status_code(), StatusCode::UNAUTHORIZED);
-    }
-
-    #[test]
-    fn weak_password_maps_to_bad_request() {
-        let app_err: AppError = AuthError::WeakPassword("too short".into()).into();
-        assert_eq!(app_err.status_code(), StatusCode::BAD_REQUEST);
-    }
-
-    #[test]
-    fn invalid_username_maps_to_bad_request() {
-        let app_err: AppError = AuthError::InvalidUsername("bad chars".into()).into();
-        assert_eq!(app_err.status_code(), StatusCode::BAD_REQUEST);
-    }
-
-    #[test]
-    fn token_expired_maps_to_unauthorized() {
-        let app_err: AppError = AuthError::TokenExpired.into();
-        assert_eq!(app_err.status_code(), StatusCode::UNAUTHORIZED);
-    }
-
-    #[test]
-    fn token_invalid_maps_to_unauthorized() {
-        let app_err: AppError = AuthError::TokenInvalid("bad".into()).into();
-        assert_eq!(app_err.status_code(), StatusCode::UNAUTHORIZED);
-    }
-
-    #[test]
-    fn token_blacklisted_maps_to_unauthorized() {
-        let app_err: AppError = AuthError::TokenBlacklisted.into();
-        assert_eq!(app_err.status_code(), StatusCode::UNAUTHORIZED);
-    }
-
-    #[test]
-    fn hash_error_maps_to_internal() {
-        let app_err: AppError = AuthError::HashError("failed".into()).into();
-        assert_eq!(app_err.status_code(), StatusCode::INTERNAL_SERVER_ERROR);
-    }
 }

--- a/crates/aionui-auth/src/qr_token.rs
+++ b/crates/aionui-auth/src/qr_token.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use dashmap::DashMap;
 
-use aionui_common::AppError;
+use crate::error::AuthError;
 
 /// QR token time-to-live: 5 minutes.
 const QR_TOKEN_TTL_MS: i64 = 5 * 60 * 1000;
@@ -72,20 +72,20 @@ impl QrTokenStore {
     /// Validate and consume a QR token (one-time use).
     ///
     /// Checks existence, expiry (5 min), and used status atomically.
-    pub fn validate_and_consume(&self, token: &str) -> Result<(), AppError> {
+    pub fn validate_and_consume(&self, token: &str) -> Result<(), AuthError> {
         let mut entry = self
             .tokens
             .get_mut(token)
-            .ok_or_else(|| AppError::Unauthorized("Invalid QR token".into()))?;
+            .ok_or_else(|| AuthError::TokenInvalid("Invalid QR token".into()))?;
 
         if entry.used {
-            return Err(AppError::Unauthorized("QR token already used".into()));
+            return Err(AuthError::TokenInvalid("QR token already used".into()));
         }
 
         let now = aionui_common::now_ms();
         let elapsed_ms = now.saturating_sub(entry.created_at_ms);
         if elapsed_ms > QR_TOKEN_TTL_MS {
-            return Err(AppError::Unauthorized("QR token expired".into()));
+            return Err(AuthError::TokenInvalid("QR token expired".into()));
         }
 
         entry.used = true;
@@ -158,7 +158,7 @@ mod tests {
     fn validate_nonexistent_token_fails() {
         let store = QrTokenStore::new();
         let err = store.validate_and_consume("nonexistent").unwrap_err();
-        assert!(matches!(err, AppError::Unauthorized(_)));
+        assert!(matches!(err, AuthError::TokenInvalid(_)));
     }
 
     #[test]
@@ -168,7 +168,7 @@ mod tests {
         store.validate_and_consume(&token).unwrap();
 
         let err = store.validate_and_consume(&token).unwrap_err();
-        assert!(matches!(err, AppError::Unauthorized(_)));
+        assert!(matches!(err, AuthError::TokenInvalid(_)));
     }
 
     #[test]
@@ -184,7 +184,7 @@ mod tests {
         );
 
         let err = store.validate_and_consume("expired_token").unwrap_err();
-        assert!(matches!(err, AppError::Unauthorized(_)));
+        assert!(matches!(err, AuthError::TokenInvalid(_)));
     }
 
     #[test]

--- a/crates/aionui-auth/src/rate_limit.rs
+++ b/crates/aionui-auth/src/rate_limit.rs
@@ -8,6 +8,7 @@ use dashmap::DashMap;
 
 use aionui_common::AppError;
 
+use crate::error::AuthError;
 use crate::extract::extract_client_ip;
 use crate::middleware::CurrentUser;
 
@@ -55,13 +56,13 @@ impl RateLimiter {
     ///
     /// For the auth rate limiter: check first, record failure later
     /// via [`record_attempt`](Self::record_attempt).
-    pub fn check(&self, key: &str) -> Result<(), AppError> {
+    pub fn check(&self, key: &str) -> Result<(), AuthError> {
         let now = now_ms();
         if let Some(entry) = self.entries.get(key)
             && now < entry.reset_time_ms
             && entry.count >= self.max_requests
         {
-            return Err(AppError::RateLimited);
+            return Err(AuthError::RateLimited);
         }
         Ok(())
     }
@@ -69,7 +70,7 @@ impl RateLimiter {
     /// Check rate limit and increment the counter atomically.
     ///
     /// For API and authenticated-action rate limiters.
-    pub fn check_and_increment(&self, key: &str) -> Result<(), AppError> {
+    pub fn check_and_increment(&self, key: &str) -> Result<(), AuthError> {
         let now = now_ms();
         let window_ms = self.window.as_millis() as u64;
 
@@ -84,7 +85,7 @@ impl RateLimiter {
         }
 
         if entry.count >= self.max_requests {
-            return Err(AppError::RateLimited);
+            return Err(AuthError::RateLimited);
         }
 
         entry.count += 1;
@@ -152,7 +153,7 @@ pub async fn auth_rate_limit_middleware(
     next: Next,
 ) -> Result<Response, AppError> {
     let ip = extract_client_ip(&request);
-    limiter.check(&ip)?;
+    limiter.check(&ip).map_err(AppError::from)?;
 
     let response = next.run(request).await;
 
@@ -170,7 +171,7 @@ pub async fn api_rate_limit_middleware(
     next: Next,
 ) -> Result<Response, AppError> {
     let ip = extract_client_ip(&request);
-    limiter.check_and_increment(&ip)?;
+    limiter.check_and_increment(&ip).map_err(AppError::from)?;
     Ok(next.run(request).await)
 }
 
@@ -188,7 +189,7 @@ pub async fn authenticated_action_rate_limit_middleware(
         .get::<CurrentUser>()
         .map(|u| format!("user:{}", u.id))
         .unwrap_or_else(|| format!("ip:{}", extract_client_ip(&request)));
-    limiter.check_and_increment(&key)?;
+    limiter.check_and_increment(&key).map_err(AppError::from)?;
     Ok(next.run(request).await)
 }
 

--- a/crates/aionui-auth/src/routes.rs
+++ b/crates/aionui-auth/src/routes.rs
@@ -19,6 +19,7 @@ use aionui_common::AppError;
 use aionui_common::constants::COOKIE_MAX_AGE_DAYS;
 use aionui_db::{IUserRepository, models::User};
 
+use crate::error::AuthError;
 use crate::extract::extract_token_from_headers;
 use crate::middleware::{AuthState, CurrentUser, auth_middleware};
 use crate::password::{dummy_password_hash, generate_password, hash_password, verify_password_timed};
@@ -28,6 +29,21 @@ use crate::rate_limit::{
 };
 use crate::validation::{validate_password, validate_username};
 use crate::{CookieConfig, JwtService};
+
+impl From<AuthError> for AppError {
+    fn from(err: AuthError) -> Self {
+        match err {
+            AuthError::InvalidCredentials => AppError::Unauthorized("Invalid username or password".into()),
+            AuthError::WeakPassword(msg) => AppError::BadRequest(msg),
+            AuthError::InvalidUsername(msg) => AppError::BadRequest(msg),
+            AuthError::TokenExpired => AppError::Unauthorized("Token expired".into()),
+            AuthError::TokenInvalid(msg) => AppError::Unauthorized(msg),
+            AuthError::TokenBlacklisted => AppError::Unauthorized("Token has been revoked".into()),
+            AuthError::RateLimited => AppError::RateLimited,
+            AuthError::HashError(msg) => AppError::Internal(format!("Password hash error: {msg}")),
+        }
+    }
+}
 
 /// Shared state for all auth route handlers.
 #[derive(Clone)]
@@ -762,4 +778,58 @@ async fn webui_generate_qr_token_handler(
         token,
         expires_at_ms,
     })))
+}
+
+#[cfg(test)]
+mod error_mapping_tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    #[test]
+    fn invalid_credentials_maps_to_unauthorized() {
+        let app_err = AppError::from(AuthError::InvalidCredentials);
+        assert_eq!(app_err.status_code(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn weak_password_maps_to_bad_request() {
+        let app_err = AppError::from(AuthError::WeakPassword("too short".into()));
+        assert_eq!(app_err.status_code(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_username_maps_to_bad_request() {
+        let app_err = AppError::from(AuthError::InvalidUsername("bad chars".into()));
+        assert_eq!(app_err.status_code(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn token_expired_maps_to_unauthorized() {
+        let app_err = AppError::from(AuthError::TokenExpired);
+        assert_eq!(app_err.status_code(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn token_invalid_maps_to_unauthorized() {
+        let app_err = AppError::from(AuthError::TokenInvalid("bad".into()));
+        assert_eq!(app_err.status_code(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn token_blacklisted_maps_to_unauthorized() {
+        let app_err = AppError::from(AuthError::TokenBlacklisted);
+        assert_eq!(app_err.status_code(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn rate_limited_maps_to_rate_limited() {
+        let app_err = AppError::from(AuthError::RateLimited);
+        assert_eq!(app_err.status_code(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[test]
+    fn hash_error_maps_to_internal() {
+        let app_err = AppError::from(AuthError::HashError("failed".into()));
+        assert_eq!(app_err.status_code(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
 }

--- a/crates/aionui-conversation/src/error.rs
+++ b/crates/aionui-conversation/src/error.rs
@@ -15,6 +15,12 @@ pub enum ConversationError {
     #[error("Message not found: {id}")]
     MessageNotFound { id: String },
 
+    #[error("Artifact not found: {id}")]
+    ArtifactNotFound { id: String },
+
+    #[error("Active agent not found for conversation: {conversation_id}")]
+    ActiveAgentNotFound { conversation_id: String },
+
     #[error("Conversation is archived: {reason}")]
     Archived { id: String, reason: String },
 

--- a/crates/aionui-conversation/src/error.rs
+++ b/crates/aionui-conversation/src/error.rs
@@ -1,5 +1,6 @@
 use aionui_ai_agent::AcpError;
 use aionui_common::AppError;
+use aionui_db::DbError;
 
 /// Application-level error contract for the conversation domain.
 ///
@@ -11,8 +12,17 @@ pub enum ConversationError {
     #[error("Conversation not found: {id}")]
     NotFound { id: String },
 
-    #[error("Conversation is archived: {id}")]
-    Archived { id: String },
+    #[error("Message not found: {id}")]
+    MessageNotFound { id: String },
+
+    #[error("Conversation is archived: {reason}")]
+    Archived { id: String, reason: String },
+
+    #[error("Bad request: {reason}")]
+    BadRequest { reason: String },
+
+    #[error("Conversation is busy: {reason}")]
+    Busy { reason: String },
 
     #[error("Forbidden: {reason}")]
     Forbidden { reason: String },
@@ -20,8 +30,25 @@ pub enum ConversationError {
     #[error("ACP error")]
     Acp(#[from] AcpError),
 
-    #[error(transparent)]
-    App(#[from] AppError),
+    #[error("{0}")]
+    App(#[source] AppError),
+}
+
+impl From<AppError> for ConversationError {
+    fn from(error: AppError) -> Self {
+        match error {
+            AppError::BadRequest(reason) => Self::BadRequest { reason },
+            AppError::Conflict(reason) => Self::Busy { reason },
+            AppError::Forbidden(reason) => Self::Forbidden { reason },
+            other => Self::App(other),
+        }
+    }
+}
+
+impl From<DbError> for ConversationError {
+    fn from(error: DbError) -> Self {
+        AppError::from(error).into()
+    }
 }
 
 #[cfg(test)]
@@ -32,6 +59,8 @@ mod tests {
 
     fn assert_from_acp<T: From<AcpError>>() {}
 
+    fn assert_from_db<T: From<DbError>>() {}
+
     #[test]
     fn conversation_error_is_error_contract() {
         assert_error::<ConversationError>();
@@ -40,5 +69,10 @@ mod tests {
     #[test]
     fn conversation_error_has_acp_from_impl() {
         assert_from_acp::<ConversationError>();
+    }
+
+    #[test]
+    fn conversation_error_has_db_from_impl() {
+        assert_from_db::<ConversationError>();
     }
 }

--- a/crates/aionui-conversation/src/routes.rs
+++ b/crates/aionui-conversation/src/routes.rs
@@ -22,6 +22,10 @@ impl From<ConversationError> for AppError {
         match error {
             ConversationError::NotFound { id } => AppError::NotFound(format!("Conversation {id} not found")),
             ConversationError::MessageNotFound { id } => AppError::NotFound(format!("Message {id} not found")),
+            ConversationError::ArtifactNotFound { id } => AppError::NotFound(format!("Artifact {id} not found")),
+            ConversationError::ActiveAgentNotFound { .. } => {
+                AppError::NotFound("No active agent for this conversation".into())
+            }
             ConversationError::Archived { reason, .. } => AppError::ConversationArchived(reason),
             ConversationError::BadRequest { reason } => AppError::BadRequest(reason),
             ConversationError::Busy { reason } => AppError::Conflict(reason),
@@ -65,7 +69,7 @@ async fn create(
     body: Result<Json<CreateConversationRequest>, JsonRejection>,
 ) -> Result<(StatusCode, Json<ApiResponse<ConversationResponse>>), AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    let conversation = state.service.create(&user.id, req).await?;
+    let conversation = state.service.create(&user.id, req).await.map_err(AppError::from)?;
     Ok((StatusCode::CREATED, Json(ApiResponse::ok(conversation))))
 }
 
@@ -74,7 +78,7 @@ async fn list(
     Extension(user): Extension<CurrentUser>,
     Query(query): Query<ListConversationsQuery>,
 ) -> Result<Json<ApiResponse<ConversationListResponse>>, AppError> {
-    let result = state.service.list(&user.id, query).await?;
+    let result = state.service.list(&user.id, query).await.map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(result)))
 }
 
@@ -84,7 +88,11 @@ async fn clone(
     body: Result<Json<CloneConversationRequest>, JsonRejection>,
 ) -> Result<(StatusCode, Json<ApiResponse<ConversationResponse>>), AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    let conversation = state.service.clone_create(&user.id, req).await?;
+    let conversation = state
+        .service
+        .clone_create(&user.id, req)
+        .await
+        .map_err(AppError::from)?;
     Ok((StatusCode::CREATED, Json(ApiResponse::ok(conversation))))
 }
 
@@ -104,7 +112,11 @@ async fn update(
     body: Result<Json<UpdateConversationRequest>, JsonRejection>,
 ) -> Result<Json<ApiResponse<ConversationResponse>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    let conversation = state.service.update(&user.id, &id, req, &state.task_manager).await?;
+    let conversation = state
+        .service
+        .update(&user.id, &id, req, &state.task_manager)
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(conversation)))
 }
 
@@ -113,7 +125,7 @@ async fn delete_one(
     Extension(user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<()>>, AppError> {
-    state.service.delete(&user.id, &id).await?;
+    state.service.delete(&user.id, &id).await.map_err(AppError::from)?;
     Ok(Json(ApiResponse::success()))
 }
 
@@ -122,7 +134,7 @@ async fn reset(
     Extension(user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<()>>, AppError> {
-    state.service.reset(&user.id, &id).await?;
+    state.service.reset(&user.id, &id).await.map_err(AppError::from)?;
     Ok(Json(ApiResponse::success()))
 }
 
@@ -131,7 +143,11 @@ async fn associated(
     Extension(user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<Vec<ConversationResponse>>>, AppError> {
-    let items = state.service.list_associated(&user.id, &id).await?;
+    let items = state
+        .service
+        .list_associated(&user.id, &id)
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(items)))
 }
 
@@ -192,7 +208,11 @@ async fn list_artifacts(
     Extension(user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<ConversationArtifactListResponse>>, AppError> {
-    let result = state.service.list_artifacts(&user.id, &id).await?;
+    let result = state
+        .service
+        .list_artifacts(&user.id, &id)
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(result)))
 }
 
@@ -213,7 +233,8 @@ async fn update_artifact(
     let artifact = state
         .service
         .update_artifact(&user.id, &params.id, &params.artifact_id, req)
-        .await?;
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(artifact)))
 }
 
@@ -248,7 +269,11 @@ async fn search_messages(
     Extension(user): Extension<CurrentUser>,
     Query(query): Query<SearchMessagesQuery>,
 ) -> Result<Json<ApiResponse<MessageSearchResponse>>, AppError> {
-    let result = state.service.search_messages(&user.id, query).await?;
+    let result = state
+        .service
+        .search_messages(&user.id, query)
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(result)))
 }
 
@@ -262,7 +287,8 @@ async fn list_confirmations(
     let items = state
         .service
         .list_confirmations(&user.id, &id, &state.task_manager)
-        .await?;
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(items)))
 }
 
@@ -283,7 +309,8 @@ async fn confirm(
     state
         .service
         .confirm(&user.id, &params.id, &params.call_id, req, &state.task_manager)
-        .await?;
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::success()))
 }
 
@@ -306,7 +333,8 @@ async fn check_approval(
             query.command_type.as_deref(),
             &state.task_manager,
         )
-        .await?;
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(result)))
 }
 
@@ -341,6 +369,22 @@ mod error_mapping_tests {
     fn message_not_found_maps_to_app_not_found() {
         let app = AppError::from(ConversationError::MessageNotFound { id: "msg_1".into() });
         assert!(matches!(app, AppError::NotFound(message) if message == "Message msg_1 not found"));
+    }
+
+    #[test]
+    fn artifact_not_found_maps_to_app_not_found() {
+        let app = AppError::from(ConversationError::ArtifactNotFound {
+            id: "artifact_1".into(),
+        });
+        assert!(matches!(app, AppError::NotFound(message) if message == "Artifact artifact_1 not found"));
+    }
+
+    #[test]
+    fn active_agent_not_found_maps_to_app_not_found() {
+        let app = AppError::from(ConversationError::ActiveAgentNotFound {
+            conversation_id: "conv_1".into(),
+        });
+        assert!(matches!(app, AppError::NotFound(message) if message == "No active agent for this conversation"));
     }
 
     #[test]

--- a/crates/aionui-conversation/src/routes.rs
+++ b/crates/aionui-conversation/src/routes.rs
@@ -14,7 +14,23 @@ use aionui_api_types::{
 use aionui_auth::CurrentUser;
 use aionui_common::AppError;
 
+use crate::ConversationError;
 use crate::state::ConversationRouterState;
+
+impl From<ConversationError> for AppError {
+    fn from(error: ConversationError) -> Self {
+        match error {
+            ConversationError::NotFound { id } => AppError::NotFound(format!("Conversation {id} not found")),
+            ConversationError::MessageNotFound { id } => AppError::NotFound(format!("Message {id} not found")),
+            ConversationError::Archived { reason, .. } => AppError::ConversationArchived(reason),
+            ConversationError::BadRequest { reason } => AppError::BadRequest(reason),
+            ConversationError::Busy { reason } => AppError::Conflict(reason),
+            ConversationError::Forbidden { reason } => AppError::Forbidden(reason),
+            ConversationError::Acp(_) => AppError::BadGateway("Agent protocol error".into()),
+            ConversationError::App(error) => error,
+        }
+    }
+}
 
 /// Build the conversation router (CRUD + message flow + confirmation + extended operations).
 ///
@@ -77,7 +93,7 @@ async fn get_one(
     Extension(user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<ConversationResponse>>, AppError> {
-    let conversation = state.service.get(&user.id, &id).await?;
+    let conversation = state.service.get(&user.id, &id).await.map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(conversation)))
 }
 
@@ -125,7 +141,11 @@ async fn list_msg(
     Path(id): Path<String>,
     Query(query): Query<ListMessagesQuery>,
 ) -> Result<Json<ApiResponse<MessageListResponse>>, AppError> {
-    let result = state.service.list_messages(&user.id, &id, query).await?;
+    let result = state
+        .service
+        .list_messages(&user.id, &id, query)
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(result)))
 }
 
@@ -144,7 +164,8 @@ async fn get_msg(
     let result = state
         .service
         .get_message(&user.id, &params.id, &params.message_id)
-        .await?;
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(result)))
 }
 
@@ -158,7 +179,8 @@ async fn send_msg(
     let msg_id = state
         .service
         .send_message(&user.id, &id, req, &state.task_manager)
-        .await?;
+        .await
+        .map_err(AppError::from)?;
     Ok((
         StatusCode::ACCEPTED,
         Json(ApiResponse::ok(SendMessageResponse { msg_id })),
@@ -200,7 +222,11 @@ async fn cancel(
     Extension(user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<()>>, AppError> {
-    state.service.cancel(&user.id, &id, &state.task_manager).await?;
+    state
+        .service
+        .cancel(&user.id, &id, &state.task_manager)
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::success()))
 }
 
@@ -209,7 +235,11 @@ async fn warmup(
     Extension(user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<()>>, AppError> {
-    state.service.warmup(&user.id, &id, &state.task_manager).await?;
+    state
+        .service
+        .warmup(&user.id, &id, &state.task_manager)
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::success()))
 }
 
@@ -286,4 +316,41 @@ async fn active_count(
 ) -> Result<Json<ApiResponse<ActiveCountResponse>>, AppError> {
     let count = state.task_manager.active_count();
     Ok(Json(ApiResponse::ok(ActiveCountResponse { count })))
+}
+
+#[cfg(test)]
+mod error_mapping_tests {
+    use super::*;
+
+    #[test]
+    fn conversation_not_found_maps_to_app_not_found() {
+        let app = AppError::from(ConversationError::NotFound { id: "conv_1".into() });
+        assert!(matches!(app, AppError::NotFound(message) if message == "Conversation conv_1 not found"));
+    }
+
+    #[test]
+    fn conversation_archived_maps_to_app_conversation_archived() {
+        let app = AppError::from(ConversationError::Archived {
+            id: "conv_1".into(),
+            reason: "legacy runtime".into(),
+        });
+        assert!(matches!(app, AppError::ConversationArchived(message) if message == "legacy runtime"));
+    }
+
+    #[test]
+    fn message_not_found_maps_to_app_not_found() {
+        let app = AppError::from(ConversationError::MessageNotFound { id: "msg_1".into() });
+        assert!(matches!(app, AppError::NotFound(message) if message == "Message msg_1 not found"));
+    }
+
+    #[test]
+    fn conversation_app_error_passthrough_preserves_special_codes() {
+        let app = AppError::from(ConversationError::from(
+            AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported("/tmp/my project".into()),
+        ));
+        assert!(matches!(
+            app,
+            AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(message) if message == "/tmp/my project"
+        ));
+    }
 }

--- a/crates/aionui-conversation/src/routes_aux.rs
+++ b/crates/aionui-conversation/src/routes_aux.rs
@@ -31,7 +31,9 @@ async fn get_mode(
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<AgentModeResponse>>, AppError> {
-    Ok(Json(ApiResponse::ok(state.service.get_mode(&id).await?)))
+    Ok(Json(ApiResponse::ok(
+        state.service.get_mode(&id).await.map_err(AppError::from)?,
+    )))
 }
 
 async fn set_mode(
@@ -41,7 +43,7 @@ async fn set_mode(
     body: Result<Json<SetModeRequest>, JsonRejection>,
 ) -> Result<Json<ApiResponse<()>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    state.service.set_mode(&id, req).await?;
+    state.service.set_mode(&id, req).await.map_err(AppError::from)?;
     Ok(Json(ApiResponse::success()))
 }
 
@@ -50,7 +52,9 @@ async fn get_model(
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<GetModelInfoResponse>>, AppError> {
-    Ok(Json(ApiResponse::ok(state.service.get_model(&id).await?)))
+    Ok(Json(ApiResponse::ok(
+        state.service.get_model(&id).await.map_err(AppError::from)?,
+    )))
 }
 
 async fn set_model(
@@ -60,7 +64,7 @@ async fn set_model(
     body: Result<Json<SetModelRequest>, JsonRejection>,
 ) -> Result<Json<ApiResponse<()>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    state.service.set_model(&id, req).await?;
+    state.service.set_model(&id, req).await.map_err(AppError::from)?;
     Ok(Json(ApiResponse::success()))
 }
 
@@ -69,7 +73,9 @@ async fn get_usage(
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<Option<serde_json::Value>>>, AppError> {
-    Ok(Json(ApiResponse::ok(state.service.get_usage(&id).await?)))
+    Ok(Json(ApiResponse::ok(
+        state.service.get_usage(&id).await.map_err(AppError::from)?,
+    )))
 }
 
 async fn side_question(
@@ -79,7 +85,11 @@ async fn side_question(
     Json(req): Json<SideQuestionRequest>,
 ) -> Result<Json<ApiResponse<SideQuestionResponse>>, AppError> {
     Ok(Json(ApiResponse::ok(
-        state.service.handle_side_question(&id, req).await?,
+        state
+            .service
+            .handle_side_question(&id, req)
+            .await
+            .map_err(AppError::from)?,
     )))
 }
 
@@ -88,7 +98,9 @@ async fn get_slash_commands(
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<Vec<SlashCommandItem>>>, AppError> {
-    Ok(Json(ApiResponse::ok(state.service.get_slash_commands(&id).await?)))
+    Ok(Json(ApiResponse::ok(
+        state.service.get_slash_commands(&id).await.map_err(AppError::from)?,
+    )))
 }
 
 async fn get_openclaw_runtime(
@@ -96,7 +108,9 @@ async fn get_openclaw_runtime(
     Extension(_user): Extension<CurrentUser>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, AppError> {
-    Ok(Json(ApiResponse::ok(state.service.get_openclaw_runtime(&id).await?)))
+    Ok(Json(ApiResponse::ok(
+        state.service.get_openclaw_runtime(&id).await.map_err(AppError::from)?,
+    )))
 }
 
 async fn browse_workspace(
@@ -105,5 +119,11 @@ async fn browse_workspace(
     Path(id): Path<String>,
     Query(query): Query<WorkspaceBrowseQuery>,
 ) -> Result<Json<ApiResponse<Vec<WorkspaceEntry>>>, AppError> {
-    Ok(Json(ApiResponse::ok(state.service.browse_workspace(&id, query).await?)))
+    Ok(Json(ApiResponse::ok(
+        state
+            .service
+            .browse_workspace(&id, query)
+            .await
+            .map_err(AppError::from)?,
+    )))
 }

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -193,10 +193,12 @@ impl ConversationService {
         self.runtime_state.clone()
     }
 
-    pub(crate) fn task(&self, conversation_id: &str) -> Result<AgentInstance, AppError> {
+    pub(crate) fn task(&self, conversation_id: &str) -> Result<AgentInstance, ConversationError> {
         self.task_manager
             .get_task(conversation_id)
-            .ok_or_else(|| AppError::NotFound(format!("No active agent for conversation '{conversation_id}'")))
+            .ok_or_else(|| ConversationError::ActiveAgentNotFound {
+                conversation_id: conversation_id.to_owned(),
+            })
     }
 
     pub async fn runtime_summary_for(&self, conversation_id: &str) -> ConversationRuntimeSummary {
@@ -233,7 +235,7 @@ impl ConversationService {
         &self,
         user_id: &str,
         req: CreateConversationRequest,
-    ) -> Result<ConversationResponse, AppError> {
+    ) -> Result<ConversationResponse, ConversationError> {
         let id = generate_short_id();
         let now = now_ms();
         let source = req.source.unwrap_or(ConversationSource::Aionui);
@@ -243,10 +245,12 @@ impl ConversationService {
         // clients that still ship the legacy shape get a loud 400 instead of
         // a silent write to a column nobody reads.
         if req.r#type != AgentType::Aionrs && req.model.is_some() {
-            return Err(AppError::BadRequest(format!(
-                "top-level `model` is only accepted for aionrs conversations; pass model via `extra` for {}",
-                req.r#type.serde_name()
-            )));
+            return Err(ConversationError::BadRequest {
+                reason: format!(
+                    "top-level `model` is only accepted for aionrs conversations; pass model via `extra` for {}",
+                    req.r#type.serde_name()
+                ),
+            });
         }
 
         let mut extra = req.extra;
@@ -376,10 +380,11 @@ impl ConversationService {
         };
         let selected_session_mcp_servers = match extra.as_object_mut() {
             Some(obj) => match obj.remove("selected_session_mcp_servers") {
-                Some(value) => Some(
-                    serde_json::from_value::<Vec<SessionMcpServer>>(value)
-                        .map_err(|e| AppError::BadRequest(format!("Invalid selected_session_mcp_servers: {e}")))?,
-                ),
+                Some(value) => Some(serde_json::from_value::<Vec<SessionMcpServer>>(value).map_err(|e| {
+                    ConversationError::BadRequest {
+                        reason: format!("Invalid selected_session_mcp_servers: {e}"),
+                    }
+                })?),
                 None => None,
             },
             None => None,
@@ -600,7 +605,7 @@ impl ConversationService {
         &self,
         user_id: &str,
         query: ListConversationsQuery,
-    ) -> Result<ConversationListResponse, AppError> {
+    ) -> Result<ConversationListResponse, ConversationError> {
         let filters = ConversationFilters {
             cursor: query.cursor,
             limit: query.limit.unwrap_or(0),
@@ -659,13 +664,13 @@ impl ConversationService {
         id: &str,
         req: UpdateConversationRequest,
         task_manager: &Arc<dyn IWorkerTaskManager>,
-    ) -> Result<ConversationResponse, AppError> {
+    ) -> Result<ConversationResponse, ConversationError> {
         let existing = self
             .conversation_repo
             .get(id)
             .await?
             .filter(|r| r.user_id == user_id)
-            .ok_or_else(|| AppError::NotFound(format!("Conversation {id} not found")))?;
+            .ok_or_else(|| ConversationError::NotFound { id: id.to_owned() })?;
 
         // Snapshot invariant: once written at create time, `extra.skills`
         // must not be re-shaped by PATCH. The frontend must clone the
@@ -677,9 +682,9 @@ impl ConversationService {
                 || incoming.get("mcp_statuses").is_some()
                 || incoming.get("session_mcp_servers").is_some())
         {
-            return Err(AppError::BadRequest(
-                "extra.skills and MCP snapshots are immutable post-creation".into(),
-            ));
+            return Err(ConversationError::BadRequest {
+                reason: "extra.skills and MCP snapshots are immutable post-creation".into(),
+            });
         }
 
         // Type-aware rule: top-level `model` is aionrs-only. For non-aionrs
@@ -687,10 +692,12 @@ impl ConversationService {
         // 2026-05-12).
         let existing_type: AgentType = string_to_enum(&existing.r#type)?;
         if existing_type != AgentType::Aionrs && req.model.is_some() {
-            return Err(AppError::BadRequest(format!(
-                "top-level `model` is only accepted for aionrs conversations; pass model via `extra` for {}",
-                existing.r#type
-            )));
+            return Err(ConversationError::BadRequest {
+                reason: format!(
+                    "top-level `model` is only accepted for aionrs conversations; pass model via `extra` for {}",
+                    existing.r#type
+                ),
+            });
         }
 
         let now = now_ms();
@@ -779,12 +786,14 @@ impl ConversationService {
     /// `team_mcp_stdio_config`) where a full `update()` would kill the agent
     /// on a spurious model comparison.
     #[tracing::instrument(skip_all, fields(conversation_id = %conversation_id))]
-    pub async fn update_extra(&self, conversation_id: &str, patch: serde_json::Value) -> Result<(), AppError> {
-        let existing = self
-            .conversation_repo
-            .get(conversation_id)
-            .await?
-            .ok_or_else(|| AppError::NotFound(format!("Conversation {conversation_id} not found")))?;
+    pub async fn update_extra(&self, conversation_id: &str, patch: serde_json::Value) -> Result<(), ConversationError> {
+        let existing =
+            self.conversation_repo
+                .get(conversation_id)
+                .await?
+                .ok_or_else(|| ConversationError::NotFound {
+                    id: conversation_id.to_owned(),
+                })?;
 
         let mut merged: serde_json::Value =
             serde_json::from_str(&existing.extra).unwrap_or_else(|_| serde_json::json!({}));
@@ -806,7 +815,7 @@ impl ConversationService {
         Ok(())
     }
 
-    pub async fn save_acp_runtime_mode(&self, conversation_id: &str, mode: &str) -> Result<(), AppError> {
+    pub async fn save_acp_runtime_mode(&self, conversation_id: &str, mode: &str) -> Result<(), ConversationError> {
         let params = SaveRuntimeStateParams {
             current_mode_id: Some(Some(mode)),
             ..Default::default()
@@ -822,14 +831,14 @@ impl ConversationService {
     ///
     /// Broadcasts `conversation.listChanged(deleted)`.
     #[tracing::instrument(skip_all, fields(user_id = %user_id, conversation_id = %id))]
-    pub async fn delete(&self, user_id: &str, id: &str) -> Result<(), AppError> {
+    pub async fn delete(&self, user_id: &str, id: &str) -> Result<(), ConversationError> {
         // Get existing to retrieve source for broadcast and verify ownership
         let existing = self
             .conversation_repo
             .get(id)
             .await?
             .filter(|r| r.user_id == user_id)
-            .ok_or_else(|| AppError::NotFound(format!("Conversation {id} not found")))?;
+            .ok_or_else(|| ConversationError::NotFound { id: id.to_owned() })?;
 
         let source: Option<ConversationSource> = existing
             .source
@@ -874,19 +883,19 @@ impl ConversationService {
         &self,
         user_id: &str,
         req: CloneConversationRequest,
-    ) -> Result<ConversationResponse, AppError> {
+    ) -> Result<ConversationResponse, ConversationError> {
         self.create(user_id, req.conversation).await
     }
 
     /// Reset a conversation: clear messages and set status back to pending.
     #[tracing::instrument(skip_all, fields(user_id = %user_id, conversation_id = %id))]
-    pub async fn reset(&self, user_id: &str, id: &str) -> Result<(), AppError> {
+    pub async fn reset(&self, user_id: &str, id: &str) -> Result<(), ConversationError> {
         // Verify existence and ownership
         self.conversation_repo
             .get(id)
             .await?
             .filter(|r| r.user_id == user_id)
-            .ok_or_else(|| AppError::NotFound(format!("Conversation {id} not found")))?;
+            .ok_or_else(|| ConversationError::NotFound { id: id.to_owned() })?;
 
         // Delete all messages
         self.conversation_repo.delete_messages_by_conversation(id).await?;
@@ -906,11 +915,22 @@ impl ConversationService {
     }
 
     /// List conversations associated by the same workspace.
-    pub async fn list_associated(&self, user_id: &str, id: &str) -> Result<Vec<ConversationResponse>, AppError> {
+    pub async fn list_associated(
+        &self,
+        user_id: &str,
+        id: &str,
+    ) -> Result<Vec<ConversationResponse>, ConversationError> {
+        self.conversation_repo
+            .get(id)
+            .await?
+            .filter(|r| r.user_id == user_id)
+            .ok_or_else(|| ConversationError::NotFound { id: id.to_owned() })?;
+
         let rows = self.conversation_repo.list_associated(user_id, id).await?;
         rows.into_iter()
             .map(|row| row_to_response(row, &self.workspace_root))
-            .collect()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(ConversationError::from)
     }
 
     /// List conversations spawned by a specific cron job.
@@ -918,11 +938,12 @@ impl ConversationService {
         &self,
         user_id: &str,
         cron_job_id: &str,
-    ) -> Result<Vec<ConversationResponse>, AppError> {
+    ) -> Result<Vec<ConversationResponse>, ConversationError> {
         let rows = self.conversation_repo.list_by_cron_job(user_id, cron_job_id).await?;
         rows.into_iter()
             .map(|row| row_to_response(row, &self.workspace_root))
-            .collect()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(ConversationError::from)
     }
 }
 
@@ -1051,12 +1072,14 @@ impl ConversationService {
         &self,
         user_id: &str,
         conversation_id: &str,
-    ) -> Result<ConversationArtifactListResponse, AppError> {
+    ) -> Result<ConversationArtifactListResponse, ConversationError> {
         self.conversation_repo
             .get(conversation_id)
             .await?
             .filter(|r| r.user_id == user_id)
-            .ok_or_else(|| AppError::NotFound(format!("Conversation {conversation_id} not found")))?;
+            .ok_or_else(|| ConversationError::NotFound {
+                id: conversation_id.to_owned(),
+            })?;
 
         let mut items = self
             .conversation_repo
@@ -1091,12 +1114,14 @@ impl ConversationService {
         conversation_id: &str,
         artifact_id: &str,
         req: UpdateConversationArtifactRequest,
-    ) -> Result<ConversationArtifactResponse, AppError> {
+    ) -> Result<ConversationArtifactResponse, ConversationError> {
         self.conversation_repo
             .get(conversation_id)
             .await?
             .filter(|r| r.user_id == user_id)
-            .ok_or_else(|| AppError::NotFound(format!("Conversation {conversation_id} not found")))?;
+            .ok_or_else(|| ConversationError::NotFound {
+                id: conversation_id.to_owned(),
+            })?;
 
         let status = serde_json::to_value(req.status)
             .ok()
@@ -1107,7 +1132,9 @@ impl ConversationService {
             .conversation_repo
             .update_artifact_status(conversation_id, artifact_id, &status, now_ms())
             .await?
-            .ok_or_else(|| AppError::NotFound(format!("Artifact {artifact_id} not found")))?;
+            .ok_or_else(|| ConversationError::ArtifactNotFound {
+                id: artifact_id.to_owned(),
+            })?;
 
         let response = row_to_artifact_response(row)?;
         self.broadcaster.broadcast(WebSocketMessage::new(
@@ -1124,9 +1151,11 @@ impl ConversationService {
         &self,
         user_id: &str,
         query: SearchMessagesQuery,
-    ) -> Result<MessageSearchResponse, AppError> {
+    ) -> Result<MessageSearchResponse, ConversationError> {
         if query.keyword.trim().is_empty() {
-            return Err(AppError::BadRequest("keyword must not be empty".into()));
+            return Err(ConversationError::BadRequest {
+                reason: "keyword must not be empty".into(),
+            });
         }
 
         let page = query.page.unwrap_or(1);
@@ -1160,12 +1189,14 @@ impl ConversationService {
         user_id: &str,
         conversation_id: &str,
         task_manager: &Arc<dyn IWorkerTaskManager>,
-    ) -> Result<ConfirmationListResponse, AppError> {
+    ) -> Result<ConfirmationListResponse, ConversationError> {
         self.conversation_repo
             .get(conversation_id)
             .await?
             .filter(|r| r.user_id == user_id)
-            .ok_or_else(|| AppError::NotFound(format!("Conversation {conversation_id} not found")))?;
+            .ok_or_else(|| ConversationError::NotFound {
+                id: conversation_id.to_owned(),
+            })?;
 
         let agent = match task_manager.get_task(conversation_id) {
             Some(a) => a,
@@ -1186,16 +1217,20 @@ impl ConversationService {
         call_id: &str,
         req: ConfirmRequest,
         task_manager: &Arc<dyn IWorkerTaskManager>,
-    ) -> Result<(), AppError> {
+    ) -> Result<(), ConversationError> {
         self.conversation_repo
             .get(conversation_id)
             .await?
             .filter(|r| r.user_id == user_id)
-            .ok_or_else(|| AppError::NotFound(format!("Conversation {conversation_id} not found")))?;
+            .ok_or_else(|| ConversationError::NotFound {
+                id: conversation_id.to_owned(),
+            })?;
 
         let agent = task_manager
             .get_task(conversation_id)
-            .ok_or_else(|| AppError::NotFound("No active agent for this conversation".into()))?;
+            .ok_or_else(|| ConversationError::ActiveAgentNotFound {
+                conversation_id: conversation_id.to_owned(),
+            })?;
 
         let confirmations = agent.get_confirmations();
         let conf_id = confirmations
@@ -1225,12 +1260,14 @@ impl ConversationService {
         action: &str,
         command_type: Option<&str>,
         task_manager: &Arc<dyn IWorkerTaskManager>,
-    ) -> Result<ApprovalCheckResponse, AppError> {
+    ) -> Result<ApprovalCheckResponse, ConversationError> {
         self.conversation_repo
             .get(conversation_id)
             .await?
             .filter(|r| r.user_id == user_id)
-            .ok_or_else(|| AppError::NotFound(format!("Conversation {conversation_id} not found")))?;
+            .ok_or_else(|| ConversationError::NotFound {
+                id: conversation_id.to_owned(),
+            })?;
 
         let approved = task_manager
             .get_task(conversation_id)
@@ -1520,7 +1557,7 @@ impl ConversationService {
     /// Used by paths outside the normal user→agent turn (e.g. the team
     /// scheduler writing an incoming teammate message as a left bubble in the
     /// target agent's conversation so the UI shows who spoke).
-    pub async fn insert_raw_message(&self, row: &MessageRow) -> Result<(), AppError> {
+    pub async fn insert_raw_message(&self, row: &MessageRow) -> Result<(), ConversationError> {
         self.conversation_repo.insert_message(row).await?;
 
         let msg_id = row.msg_id.clone().unwrap_or_else(|| row.id.clone());

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -35,6 +35,7 @@ use crate::convert::{
     TOOL_CONTENT_COMPACT_THRESHOLD_BYTES, row_to_artifact_response, row_to_message_response,
     row_to_message_response_compact, row_to_response, row_to_response_with_extra, search_row_to_item, string_to_enum,
 };
+use crate::error::ConversationError;
 use crate::skill_resolver::SkillResolver;
 use crate::skill_snapshot::{backfill_skills_if_missing, compute_initial_skills};
 use crate::stream_relay::StreamRelay;
@@ -577,13 +578,13 @@ impl ConversationService {
     /// Returns `NotFound` if the conversation does not exist or does not
     /// belong to the given user (avoids leaking existence to other users).
     #[tracing::instrument(skip_all, fields(user_id = %user_id, conversation_id = %id))]
-    pub async fn get(&self, user_id: &str, id: &str) -> Result<ConversationResponse, AppError> {
+    pub async fn get(&self, user_id: &str, id: &str) -> Result<ConversationResponse, ConversationError> {
         let row = self
             .conversation_repo
             .get(id)
             .await?
             .filter(|r| r.user_id == user_id)
-            .ok_or_else(|| AppError::NotFound(format!("Conversation {id} not found")))?;
+            .ok_or_else(|| ConversationError::NotFound { id: id.to_owned() })?;
 
         let mut extra: serde_json::Value =
             serde_json::from_str(&row.extra).map_err(|e| AppError::Internal(format!("Invalid extra JSON: {e}")))?;
@@ -934,13 +935,15 @@ impl ConversationService {
         user_id: &str,
         conversation_id: &str,
         query: ListMessagesQuery,
-    ) -> Result<MessageListResponse, AppError> {
+    ) -> Result<MessageListResponse, ConversationError> {
         // Verify conversation exists and belongs to user
         self.conversation_repo
             .get(conversation_id)
             .await?
             .filter(|r| r.user_id == user_id)
-            .ok_or_else(|| AppError::NotFound(format!("Conversation {conversation_id} not found")))?;
+            .ok_or_else(|| ConversationError::NotFound {
+                id: conversation_id.to_owned(),
+            })?;
 
         let page = query.page.unwrap_or(1);
         let page_size = query.page_size.unwrap_or(50);
@@ -1011,18 +1014,22 @@ impl ConversationService {
         user_id: &str,
         conversation_id: &str,
         message_id: &str,
-    ) -> Result<MessageResponse, AppError> {
+    ) -> Result<MessageResponse, ConversationError> {
         self.conversation_repo
             .get(conversation_id)
             .await?
             .filter(|r| r.user_id == user_id)
-            .ok_or_else(|| AppError::NotFound(format!("Conversation {conversation_id} not found")))?;
+            .ok_or_else(|| ConversationError::NotFound {
+                id: conversation_id.to_owned(),
+            })?;
 
         let row = self
             .conversation_repo
             .get_message(conversation_id, message_id)
             .await?
-            .ok_or_else(|| AppError::NotFound(format!("Message {message_id} not found")))?;
+            .ok_or_else(|| ConversationError::MessageNotFound {
+                id: message_id.to_owned(),
+            })?;
 
         let content_bytes = row.content.len();
         let response = row_to_message_response(row)?;
@@ -1250,9 +1257,11 @@ impl ConversationService {
         conversation_id: &str,
         req: SendMessageRequest,
         task_manager: &Arc<dyn IWorkerTaskManager>,
-    ) -> Result<String, AppError> {
+    ) -> Result<String, ConversationError> {
         if req.content.trim().is_empty() {
-            return Err(AppError::BadRequest("Message content must not be empty".into()));
+            return Err(ConversationError::BadRequest {
+                reason: "Message content must not be empty".into(),
+            });
         }
         let send_started_at = now_ms();
 
@@ -1262,7 +1271,9 @@ impl ConversationService {
             .get(conversation_id)
             .await?
             .filter(|r| r.user_id == user_id)
-            .ok_or_else(|| AppError::NotFound(format!("Conversation {conversation_id} not found")))?;
+            .ok_or_else(|| ConversationError::NotFound {
+                id: conversation_id.to_owned(),
+            })?;
 
         // Short-circuit for legacy Gemini conversations: the dedicated Gemini
         // runtime has been removed, so we cannot build an agent for this row.
@@ -1271,11 +1282,12 @@ impl ConversationService {
         // deserialize. The client identifies this case by `code` and renders
         // a dedicated archived-conversation UI rather than a generic banner.
         if row.r#type == "gemini" {
-            return Err(AppError::ConversationArchived(
-                "This conversation was created with the legacy Gemini runtime, which has been \
-                 removed. Please start a new conversation with the Gemini ACP backend to continue."
+            return Err(ConversationError::Archived {
+                id: conversation_id.to_owned(),
+                reason: "This conversation was created with the legacy Gemini runtime, which has been \
+                         removed. Please start a new conversation with the Gemini ACP backend to continue."
                     .into(),
-            ));
+            });
         }
 
         let turn_claim = self.runtime_state.try_claim_turn(conversation_id)?;
@@ -1326,7 +1338,7 @@ impl ConversationService {
                     "Failed to build task options for message send"
                 );
                 let _ = self.persist_send_failure_tip(conversation_id, &err).await;
-                return Err(err);
+                return Err(err.into());
             }
         };
         self.ensure_auto_workspace_skill_links(&row, &build_opts).await;
@@ -1536,13 +1548,15 @@ impl ConversationService {
         user_id: &str,
         conversation_id: &str,
         task_manager: &Arc<dyn IWorkerTaskManager>,
-    ) -> Result<(), AppError> {
+    ) -> Result<(), ConversationError> {
         // Verify conversation exists and belongs to user
         self.conversation_repo
             .get(conversation_id)
             .await?
             .filter(|r| r.user_id == user_id)
-            .ok_or_else(|| AppError::NotFound(format!("Conversation {conversation_id} not found")))?;
+            .ok_or_else(|| ConversationError::NotFound {
+                id: conversation_id.to_owned(),
+            })?;
 
         let Some(agent) = task_manager.get_task(conversation_id) else {
             info!("No active agent to cancel; treating as idempotent success");
@@ -1551,7 +1565,7 @@ impl ConversationService {
 
         if let Err(e) = agent.cancel().await {
             warn!(error = %ErrorChain(&e), "Failed to cancel agent");
-            return Err(e);
+            return Err(e.into());
         }
 
         info!("Stream canceled");
@@ -1568,13 +1582,15 @@ impl ConversationService {
         user_id: &str,
         conversation_id: &str,
         task_manager: &Arc<dyn IWorkerTaskManager>,
-    ) -> Result<(), AppError> {
+    ) -> Result<(), ConversationError> {
         let row = self
             .conversation_repo
             .get(conversation_id)
             .await?
             .filter(|r| r.user_id == user_id)
-            .ok_or_else(|| AppError::NotFound(format!("Conversation {conversation_id} not found")))?;
+            .ok_or_else(|| ConversationError::NotFound {
+                id: conversation_id.to_owned(),
+            })?;
 
         let build_opts = self.build_task_options(&row)?;
         self.ensure_auto_workspace_skill_links(&row, &build_opts).await;

--- a/crates/aionui-conversation/src/service_ops.rs
+++ b/crates/aionui-conversation/src/service_ops.rs
@@ -16,6 +16,7 @@ use aionui_api_types::{
 };
 use aionui_common::AppError;
 
+use crate::ConversationError;
 use crate::service::ConversationService;
 
 const MAX_DIR_DEPTH: usize = 10;
@@ -23,26 +24,39 @@ const MAX_DIR_DEPTH: usize = 10;
 impl ConversationService {
     // ── Mode ────────────────────────────────────────────────────────
 
-    pub async fn get_mode(&self, conversation_id: &str) -> Result<AgentModeResponse, AppError> {
-        self.task(conversation_id)?.get_mode().await
+    pub async fn get_mode(&self, conversation_id: &str) -> Result<AgentModeResponse, ConversationError> {
+        self.task(conversation_id)?
+            .get_mode()
+            .await
+            .map_err(ConversationError::from)
     }
 
-    pub async fn set_mode(&self, conversation_id: &str, req: SetModeRequest) -> Result<(), AppError> {
+    pub async fn set_mode(&self, conversation_id: &str, req: SetModeRequest) -> Result<(), ConversationError> {
         if req.mode.trim().is_empty() {
-            return Err(AppError::BadRequest("mode must not be empty".into()));
+            return Err(ConversationError::BadRequest {
+                reason: "mode must not be empty".into(),
+            });
         }
-        self.task(conversation_id)?.set_mode(&req.mode).await
+        self.task(conversation_id)?
+            .set_mode(&req.mode)
+            .await
+            .map_err(ConversationError::from)
     }
 
     // ── Model ───────────────────────────────────────────────────────
 
-    pub async fn get_model(&self, conversation_id: &str) -> Result<GetModelInfoResponse, AppError> {
-        self.task(conversation_id)?.get_model().await
+    pub async fn get_model(&self, conversation_id: &str) -> Result<GetModelInfoResponse, ConversationError> {
+        self.task(conversation_id)?
+            .get_model()
+            .await
+            .map_err(ConversationError::from)
     }
 
-    pub async fn set_model(&self, conversation_id: &str, req: SetModelRequest) -> Result<(), AppError> {
+    pub async fn set_model(&self, conversation_id: &str, req: SetModelRequest) -> Result<(), ConversationError> {
         if req.model_id.trim().is_empty() {
-            return Err(AppError::BadRequest("model_id must not be empty".into()));
+            return Err(ConversationError::BadRequest {
+                reason: "model_id must not be empty".into(),
+            });
         }
         let task = match self.task(conversation_id) {
             Ok(task) => task,
@@ -50,23 +64,29 @@ impl ConversationService {
                 tracing::warn!(
                     conversation_id,
                     model_id = %req.model_id,
-                    error_code = err.error_code(),
+                    error = %err,
                     "Set model skipped because active agent task is unavailable"
                 );
                 return Err(err);
             }
         };
-        task.set_model(&req.model_id).await
+        task.set_model(&req.model_id).await.map_err(ConversationError::from)
     }
 
     // ── Usage / Slash commands ──────────────────────────────────────
 
-    pub async fn get_usage(&self, conversation_id: &str) -> Result<Option<serde_json::Value>, AppError> {
-        self.task(conversation_id)?.get_usage().await
+    pub async fn get_usage(&self, conversation_id: &str) -> Result<Option<serde_json::Value>, ConversationError> {
+        self.task(conversation_id)?
+            .get_usage()
+            .await
+            .map_err(ConversationError::from)
     }
 
-    pub async fn get_slash_commands(&self, conversation_id: &str) -> Result<Vec<SlashCommandItem>, AppError> {
-        self.task(conversation_id)?.get_slash_commands().await
+    pub async fn get_slash_commands(&self, conversation_id: &str) -> Result<Vec<SlashCommandItem>, ConversationError> {
+        self.task(conversation_id)?
+            .get_slash_commands()
+            .await
+            .map_err(ConversationError::from)
     }
 
     // ── Side question ───────────────────────────────────────────────
@@ -75,16 +95,22 @@ impl ConversationService {
         &self,
         conversation_id: &str,
         req: SideQuestionRequest,
-    ) -> Result<SideQuestionResponse, AppError> {
+    ) -> Result<SideQuestionResponse, ConversationError> {
         // `AgentInstance::handle_side_question` already validates that the
         // question is non-empty; no need to duplicate the check here.
-        self.task(conversation_id)?.handle_side_question(req).await
+        self.task(conversation_id)?
+            .handle_side_question(req)
+            .await
+            .map_err(ConversationError::from)
     }
 
     // ── OpenClaw runtime diagnostics ────────────────────────────────
 
-    pub async fn get_openclaw_runtime(&self, conversation_id: &str) -> Result<serde_json::Value, AppError> {
-        self.task(conversation_id)?.get_openclaw_runtime().await
+    pub async fn get_openclaw_runtime(&self, conversation_id: &str) -> Result<serde_json::Value, ConversationError> {
+        self.task(conversation_id)?
+            .get_openclaw_runtime()
+            .await
+            .map_err(ConversationError::from)
     }
 
     // ── Workspace browsing ──────────────────────────────────────────
@@ -97,9 +123,11 @@ impl ConversationService {
         &self,
         conversation_id: &str,
         query: WorkspaceBrowseQuery,
-    ) -> Result<Vec<WorkspaceEntry>, AppError> {
+    ) -> Result<Vec<WorkspaceEntry>, ConversationError> {
         if query.path.trim().is_empty() {
-            return Err(AppError::BadRequest("path must not be empty".into()));
+            return Err(ConversationError::BadRequest {
+                reason: "path must not be empty".into(),
+            });
         }
 
         let row = self
@@ -107,7 +135,9 @@ impl ConversationService {
             .get(conversation_id)
             .await
             .map_err(|e| AppError::Internal(format!("Failed to load conversation: {e}")))?
-            .ok_or_else(|| AppError::NotFound(format!("Conversation '{conversation_id}' not found")))?;
+            .ok_or_else(|| ConversationError::NotFound {
+                id: conversation_id.to_owned(),
+            })?;
 
         let extra: serde_json::Value =
             serde_json::from_str(&row.extra).map_err(|e| AppError::Internal(format!("Invalid extra JSON: {e}")))?;
@@ -118,7 +148,9 @@ impl ConversationService {
             .trim()
             .to_owned();
         if workspace.is_empty() {
-            return Err(AppError::BadRequest("Conversation has no workspace assigned".into()));
+            return Err(ConversationError::BadRequest {
+                reason: "Conversation has no workspace assigned".into(),
+            });
         }
 
         let relative_path = query.path.trim_start_matches('/');
@@ -127,9 +159,9 @@ impl ConversationService {
             .components()
             .any(|component| matches!(component, Component::ParentDir))
         {
-            return Err(AppError::BadRequest(
-                "Path traversal outside workspace is not allowed".into(),
-            ));
+            return Err(ConversationError::BadRequest {
+                reason: "Path traversal outside workspace is not allowed".into(),
+            });
         }
 
         // Resolve the browsed path relative to the workspace root
@@ -150,17 +182,17 @@ impl ConversationService {
             .canonicalize()
             .map_err(|_| AppError::NotFound("Directory not found".into()))?;
         if !browse_path.starts_with(base) && !canonical_browse.starts_with(&canonical_base) {
-            return Err(AppError::BadRequest(
-                "Path traversal outside workspace is not allowed".into(),
-            ));
+            return Err(ConversationError::BadRequest {
+                reason: "Path traversal outside workspace is not allowed".into(),
+            });
         }
 
         // Check depth limit
         let depth = relative_path_obj.components().count();
         if depth > MAX_DIR_DEPTH {
-            return Err(AppError::BadRequest(format!(
-                "Directory depth exceeds maximum of {MAX_DIR_DEPTH}"
-            )));
+            return Err(ConversationError::BadRequest {
+                reason: format!("Directory depth exceeds maximum of {MAX_DIR_DEPTH}"),
+            });
         }
 
         let mut entries = Vec::new();

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -34,6 +34,7 @@ use aionui_realtime::EventBroadcaster;
 use serde_json::json;
 use tokio::sync::broadcast;
 
+use crate::ConversationError;
 use crate::service::ConversationService;
 use crate::skill_resolver::{FixedSkillResolver, ResolvedAgentSkill, SkillResolver};
 
@@ -749,7 +750,7 @@ async fn get_reports_idle_runtime_when_only_persisted_status_is_running() {
 async fn get_not_found() {
     let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     let err = svc.get("user_1", "non-existent").await.unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 // ── List tests ─────────────────────────────────────────────────────
@@ -939,7 +940,7 @@ async fn delete_conversation() {
 
     // Should be gone
     let err = svc.get("user_1", &conv.id).await.unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 
     // Should broadcast deleted
     let events = broadcaster.take_events();
@@ -1027,7 +1028,7 @@ async fn get_wrong_user_returns_not_found() {
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
 
     let err = svc.get("user_2", &conv.id).await.unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 #[tokio::test]
@@ -1749,7 +1750,8 @@ async fn send_message_rejects_legacy_workspace_with_runtime_error_code() {
         .unwrap_err();
     assert!(matches!(
         err,
-        AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(message) if message == "/tmp/my project"
+        ConversationError::App(AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(message))
+            if message == "/tmp/my project"
     ));
 
     let messages = tokio::time::timeout(Duration::from_secs(1), async {
@@ -1939,7 +1941,7 @@ async fn send_message_empty_content_returns_bad_request() {
     .unwrap();
 
     let err = svc.send_message("user_1", &conv.id, req, &task_mgr).await.unwrap_err();
-    assert!(matches!(err, AppError::BadRequest(_)));
+    assert!(matches!(err, ConversationError::BadRequest { .. }));
 }
 
 #[tokio::test]
@@ -1954,7 +1956,7 @@ async fn send_message_whitespace_content_returns_bad_request() {
     .unwrap();
 
     let err = svc.send_message("user_1", &conv.id, req, &task_mgr).await.unwrap_err();
-    assert!(matches!(err, AppError::BadRequest(_)));
+    assert!(matches!(err, ConversationError::BadRequest { .. }));
 }
 
 #[tokio::test]
@@ -1966,7 +1968,7 @@ async fn send_message_conversation_not_found() {
         .send_message("user_1", "no-such-id", make_send_req(), &task_mgr)
         .await
         .unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 #[tokio::test]
@@ -1979,7 +1981,7 @@ async fn send_message_wrong_user_returns_not_found() {
         .send_message("user_2", &conv.id, make_send_req(), &task_mgr)
         .await
         .unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 #[tokio::test]
@@ -2015,7 +2017,7 @@ async fn send_message_rejects_active_runtime_claim() {
         .send_message("user_1", &conv.id, make_send_req(), &task_mgr)
         .await
         .unwrap_err();
-    assert!(matches!(err, AppError::Conflict(_)));
+    assert!(matches!(err, ConversationError::Busy { .. }));
 }
 
 #[tokio::test]
@@ -2211,7 +2213,7 @@ async fn stop_stream_conversation_not_found() {
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let err = svc.cancel("user_1", "no-such-id", &task_mgr).await.unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 #[tokio::test]
@@ -2232,7 +2234,7 @@ async fn stop_stream_wrong_user_returns_not_found() {
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
     let err = svc.cancel("user_2", &conv.id, &task_mgr).await.unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 // ── warmup tests ────────────────────────────────────────────────
@@ -2259,7 +2261,7 @@ async fn warmup_conversation_not_found() {
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let err = svc.warmup("user_1", "no-such-id", &task_mgr).await.unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 #[tokio::test]
@@ -2269,7 +2271,7 @@ async fn warmup_wrong_user_returns_not_found() {
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
     let err = svc.warmup("user_2", &conv.id, &task_mgr).await.unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 #[tokio::test]
@@ -2292,7 +2294,8 @@ async fn warmup_rejects_legacy_workspace_with_runtime_error_code() {
     let err = svc.warmup("user_1", &conv.id, &task_mgr).await.unwrap_err();
     assert!(matches!(
         err,
-        AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(message) if message == "/tmp/my project"
+        ConversationError::App(AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(message))
+            if message == "/tmp/my project"
     ));
 }
 

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -642,7 +642,7 @@ async fn create_rejects_workspace_with_trailing_whitespace_in_request() {
 
     assert!(matches!(
         err,
-        AppError::WorkspacePathContainsWhitespace(message)
+        ConversationError::App(AppError::WorkspacePathContainsWhitespace(message))
             if message == workspace_with_trailing_space
     ));
     let _ = std::fs::remove_dir_all(&dir);
@@ -666,7 +666,7 @@ async fn create_rejects_workspace_with_whitespace_in_any_path_segment() {
 
     assert!(matches!(
         err,
-        AppError::WorkspacePathContainsWhitespace(message)
+        ConversationError::App(AppError::WorkspacePathContainsWhitespace(message))
             if message == workspace.to_string_lossy()
     ));
     let _ = std::fs::remove_dir_all(&dir);
@@ -925,7 +925,7 @@ async fn update_not_found() {
     let (svc, _broadcaster, _repo, task_mgr) = make_service();
     let req: UpdateConversationRequest = serde_json::from_value(json!({ "name": "x" })).unwrap();
     let err = svc.update("user_1", "non-existent", req, &task_mgr).await.unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 // ── Delete tests ───────────────────────────────────────────────────
@@ -953,7 +953,7 @@ async fn delete_conversation() {
 async fn delete_not_found() {
     let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     let err = svc.delete("user_1", "non-existent").await.unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 #[tokio::test]
@@ -1038,7 +1038,7 @@ async fn update_wrong_user_returns_not_found() {
 
     let req: UpdateConversationRequest = serde_json::from_value(json!({ "name": "hacked" })).unwrap();
     let err = svc.update("user_2", &conv.id, req, &task_mgr).await.unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 
     // Original should be unchanged
     let original = svc.get("user_1", &conv.id).await.unwrap();
@@ -1051,7 +1051,7 @@ async fn delete_wrong_user_returns_not_found() {
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
 
     let err = svc.delete("user_2", &conv.id).await.unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 
     // Should still exist
     let still_exists = svc.get("user_1", &conv.id).await.unwrap();
@@ -1153,7 +1153,7 @@ async fn list_artifacts_includes_legacy_cron_trigger_messages() {
 async fn reset_not_found() {
     let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     let err = svc.reset("user_1", "no-such-id").await.unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 #[tokio::test]
@@ -1162,7 +1162,7 @@ async fn reset_wrong_user() {
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
 
     let err = svc.reset("user_2", &conv.id).await.unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 // ── Search validation tests ───────────────────────────────────────
@@ -1177,7 +1177,7 @@ async fn search_messages_empty_keyword_returns_bad_request() {
         page_size: None,
     };
     let err = svc.search_messages("user_1", query).await.unwrap_err();
-    assert!(matches!(err, AppError::BadRequest(_)));
+    assert!(matches!(err, ConversationError::BadRequest { .. }));
 }
 
 #[tokio::test]
@@ -1190,7 +1190,7 @@ async fn search_messages_whitespace_keyword_returns_bad_request() {
         page_size: None,
     };
     let err = svc.search_messages("user_1", query).await.unwrap_err();
-    assert!(matches!(err, AppError::BadRequest(_)));
+    assert!(matches!(err, ConversationError::BadRequest { .. }));
 }
 
 // ── Mock Agent ───────────────────────────────────────────────────
@@ -2365,7 +2365,7 @@ async fn list_confirmations_not_found() {
         .list_confirmations("user_1", "no-such-id", &task_mgr)
         .await
         .unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 #[tokio::test]
@@ -2375,7 +2375,7 @@ async fn list_confirmations_wrong_user() {
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
     let err = svc.list_confirmations("user_2", &conv.id, &task_mgr).await.unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 #[tokio::test]
@@ -2477,7 +2477,7 @@ async fn confirm_nonexistent_call_id_returns_not_found() {
         )
         .await
         .unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::App(AppError::NotFound(_))));
 }
 
 #[tokio::test]
@@ -2525,7 +2525,7 @@ async fn confirm_no_agent_returns_not_found() {
         .confirm("user_1", &conv.id, "call-1", req, &task_mgr)
         .await
         .unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::ActiveAgentNotFound { .. }));
 }
 
 #[tokio::test]
@@ -2606,7 +2606,7 @@ async fn check_approval_not_found() {
         .check_approval("user_1", "no-such-id", "edit_file", None, &task_mgr)
         .await
         .unwrap_err();
-    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 // ── Skill snapshot tests ───────────────────────────────────────────
@@ -2700,7 +2700,7 @@ async fn update_rejects_extra_skills() {
     let err = svc.update("u", &resp.id, update_req, &task_mgr).await.unwrap_err();
 
     match err {
-        AppError::BadRequest(msg) => assert!(msg.contains("skills"), "msg = {msg:?}"),
+        ConversationError::BadRequest { reason: msg } => assert!(msg.contains("skills"), "msg = {msg:?}"),
         other => panic!("expected BadRequest, got {other:?}"),
     }
 }

--- a/crates/aionui-conversation/tests/conversation_crud.rs
+++ b/crates/aionui-conversation/tests/conversation_crud.rs
@@ -445,7 +445,7 @@ async fn t4_6_update_not_found() {
     let (svc, _, task_mgr) = setup().await;
     let req: UpdateConversationRequest = serde_json::from_value(json!({ "name": "x" })).unwrap();
     let err = svc.update(USER_ID, "non-existent", req, &task_mgr).await.unwrap_err();
-    assert!(matches!(err, aionui_common::AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 // ── T5: Delete conversation ────────────────────────────────────────
@@ -483,7 +483,7 @@ async fn t5_2_delete_then_get_returns_404() {
 async fn t5_3_delete_not_found() {
     let (svc, _, _task_mgr) = setup().await;
     let err = svc.delete(USER_ID, "non-existent").await.unwrap_err();
-    assert!(matches!(err, aionui_common::AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 // ── T11: WebSocket event verification ──────────────────────────────
@@ -644,7 +644,7 @@ async fn create_rejects_top_level_model_for_acp() {
 
     let err = svc.create(USER_ID, req).await.unwrap_err();
     match err {
-        AppError::BadRequest(msg) => {
+        ConversationError::BadRequest { reason: msg } => {
             assert!(msg.contains("model"), "error message should mention model: {msg}");
             assert!(msg.contains("extra"), "error message should mention extra: {msg}");
         }
@@ -663,7 +663,10 @@ async fn create_rejects_top_level_model_for_remote() {
     }))
     .unwrap();
 
-    assert!(matches!(svc.create(USER_ID, req).await, Err(AppError::BadRequest(_))));
+    assert!(matches!(
+        svc.create(USER_ID, req).await,
+        Err(ConversationError::BadRequest { .. })
+    ));
 }
 
 #[tokio::test]
@@ -720,7 +723,7 @@ async fn update_rejects_top_level_model_for_acp() {
 
     let err = svc.update(USER_ID, &conv.id, req, &task_mgr).await.unwrap_err();
     assert!(
-        matches!(err, AppError::BadRequest(_)),
+        matches!(err, ConversationError::BadRequest { .. }),
         "expected BadRequest, got {err:?}"
     );
 }

--- a/crates/aionui-conversation/tests/conversation_crud.rs
+++ b/crates/aionui-conversation/tests/conversation_crud.rs
@@ -5,8 +5,8 @@ use aionui_api_types::{
     CreateConversationRequest, ListConversationsQuery, UpdateConversationRequest, WebSocketMessage,
 };
 use aionui_common::{AgentKillReason, AgentType, AppError, ConversationSource, ConversationStatus, TimestampMs};
-use aionui_conversation::ConversationService;
 use aionui_conversation::skill_resolver::SkillResolver;
+use aionui_conversation::{ConversationError, ConversationService};
 use aionui_db::{SqliteConversationRepository, init_database_memory};
 use aionui_realtime::EventBroadcaster;
 use serde_json::json;
@@ -344,7 +344,7 @@ async fn t3_1_get_existing() {
 async fn t3_2_get_not_found() {
     let (svc, _, _task_mgr) = setup().await;
     let err = svc.get(USER_ID, "non-existent-uuid").await.unwrap_err();
-    assert!(matches!(err, aionui_common::AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 // ── T4: Update conversation ────────────────────────────────────────
@@ -460,7 +460,7 @@ async fn t5_1_delete_conversation() {
 
     // Verify gone
     let err = svc.get(USER_ID, &conv.id).await.unwrap_err();
-    assert!(matches!(err, aionui_common::AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 
     // Verify broadcast
     let events = broadcaster.take_events();
@@ -476,7 +476,7 @@ async fn t5_2_delete_then_get_returns_404() {
 
     svc.delete(USER_ID, &conv.id).await.unwrap();
     let err = svc.get(USER_ID, &conv.id).await.unwrap_err();
-    assert!(matches!(err, aionui_common::AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 #[tokio::test]

--- a/crates/aionui-conversation/tests/conversation_extended.rs
+++ b/crates/aionui-conversation/tests/conversation_extended.rs
@@ -218,7 +218,7 @@ async fn t7_1_reset_clears_messages_and_status() {
 async fn t7_3_reset_not_found() {
     let (svc, _repo, _b) = setup().await;
     let err = svc.reset(USER_ID, "nonexistent").await.unwrap_err();
-    assert!(matches!(err, aionui_common::AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 // ── T8: Message list ───────────────────────────────────────────────
@@ -480,7 +480,7 @@ async fn t9_4_empty_keyword() {
         page_size: None,
     };
     let err = svc.search_messages(USER_ID, query).await.unwrap_err();
-    assert!(matches!(err, aionui_common::AppError::BadRequest(_)));
+    assert!(matches!(err, ConversationError::BadRequest { .. }));
 }
 
 #[tokio::test]
@@ -622,7 +622,7 @@ async fn t10_2_no_associated() {
 async fn t10_3_associated_not_found() {
     let (svc, _repo, _b) = setup().await;
     let err = svc.list_associated(USER_ID, "nonexistent").await.unwrap_err();
-    assert!(matches!(err, aionui_common::AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 // ── T12: Boundary scenarios ────────────────────────────────────────
@@ -666,5 +666,5 @@ async fn reset_wrong_user_returns_not_found() {
     let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
 
     let err = svc.reset("other_user", &conv.id).await.unwrap_err();
-    assert!(matches!(err, aionui_common::AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }

--- a/crates/aionui-conversation/tests/conversation_extended.rs
+++ b/crates/aionui-conversation/tests/conversation_extended.rs
@@ -5,8 +5,8 @@ use aionui_api_types::{
     CloneConversationRequest, CreateConversationRequest, ListMessagesQuery, SearchMessagesQuery, WebSocketMessage,
 };
 use aionui_common::{AgentKillReason, AppError, ConversationStatus, TimestampMs, generate_prefixed_id, now_ms};
-use aionui_conversation::ConversationService;
 use aionui_conversation::skill_resolver::SkillResolver;
+use aionui_conversation::{ConversationError, ConversationService};
 use aionui_db::models::MessageRow;
 use aionui_db::{IConversationRepository, SqliteConversationRepository, init_database_memory};
 use aionui_realtime::EventBroadcaster;
@@ -306,7 +306,7 @@ async fn t8_5_conversation_not_found() {
         .list_messages(USER_ID, "nonexistent", ListMessagesQuery::default())
         .await
         .unwrap_err();
-    assert!(matches!(err, aionui_common::AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 // ── T9: Message search ─────────────────────────────────────────────
@@ -384,6 +384,19 @@ async fn t8_7_get_message_returns_full_tool_content_after_compact_list() {
             .unwrap(),
         large_output
     );
+}
+
+#[tokio::test]
+async fn t8_8_get_message_not_found() {
+    let (svc, _repo, _b) = setup().await;
+    let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
+
+    let err = svc.get_message(USER_ID, &conv.id, "missing-message").await.unwrap_err();
+
+    assert!(matches!(
+        err,
+        ConversationError::MessageNotFound { id } if id == "missing-message"
+    ));
 }
 
 #[tokio::test]
@@ -644,7 +657,7 @@ async fn messages_wrong_user_returns_not_found() {
         .list_messages("other_user", &conv.id, ListMessagesQuery::default())
         .await
         .unwrap_err();
-    assert!(matches!(err, aionui_common::AppError::NotFound(_)));
+    assert!(matches!(err, ConversationError::NotFound { .. }));
 }
 
 #[tokio::test]

--- a/crates/aionui-cron/src/error.rs
+++ b/crates/aionui-cron/src/error.rs
@@ -46,27 +46,6 @@ pub enum CronError {
     Json(#[from] serde_json::Error),
 }
 
-impl From<CronError> for AppError {
-    fn from(err: CronError) -> Self {
-        match err {
-            CronError::JobNotFound(msg) => AppError::NotFound(msg),
-            CronError::InvalidSchedule(msg) => AppError::BadRequest(msg),
-            CronError::InvalidCronExpression(msg) => AppError::BadRequest(msg),
-            CronError::InvalidExecutionMode(msg) => AppError::BadRequest(msg),
-            CronError::InvalidCreatedBy(msg) => AppError::BadRequest(msg),
-            CronError::InvalidJobStatus(msg) => AppError::BadRequest(msg),
-            CronError::InvalidTimezone(msg) => AppError::BadRequest(msg),
-            CronError::InvalidSkillContent(msg) => AppError::BadRequest(msg),
-            CronError::InvalidAgentConfig(msg) => AppError::BadRequest(msg),
-            CronError::Scheduler(msg) => AppError::Internal(msg),
-            CronError::App(app_err) => app_err,
-            CronError::Conversation(conversation_err) => AppError::from(conversation_err),
-            CronError::Database(db_err) => AppError::from(db_err),
-            CronError::Json(e) => AppError::Internal(format!("JSON error: {e}")),
-        }
-    }
-}
-
 impl CronError {
     pub(crate) fn from_conversation_create(error: ConversationError) -> Self {
         match error {
@@ -84,103 +63,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn job_not_found_maps_to_not_found() {
-        let err: AppError = CronError::JobNotFound("cron_abc".into()).into();
-        assert!(matches!(err, AppError::NotFound(msg) if msg == "cron_abc"));
-    }
-
-    #[test]
-    fn invalid_schedule_maps_to_bad_request() {
-        let err: AppError = CronError::InvalidSchedule("missing kind".into()).into();
-        assert!(matches!(err, AppError::BadRequest(_)));
-    }
-
-    #[test]
-    fn invalid_cron_expression_maps_to_bad_request() {
-        let err: AppError = CronError::InvalidCronExpression("bad expr".into()).into();
-        assert!(matches!(err, AppError::BadRequest(_)));
-    }
-
-    #[test]
-    fn invalid_execution_mode_maps_to_bad_request() {
-        let err: AppError = CronError::InvalidExecutionMode("unknown".into()).into();
-        assert!(matches!(err, AppError::BadRequest(_)));
-    }
-
-    #[test]
-    fn invalid_created_by_maps_to_bad_request() {
-        let err: AppError = CronError::InvalidCreatedBy("robot".into()).into();
-        assert!(matches!(err, AppError::BadRequest(_)));
-    }
-
-    #[test]
-    fn invalid_job_status_maps_to_bad_request() {
-        let err: AppError = CronError::InvalidJobStatus("unknown".into()).into();
-        assert!(matches!(err, AppError::BadRequest(_)));
-    }
-
-    #[test]
-    fn invalid_timezone_maps_to_bad_request() {
-        let err: AppError = CronError::InvalidTimezone("Mars/Olympus".into()).into();
-        assert!(matches!(err, AppError::BadRequest(_)));
-    }
-
-    #[test]
-    fn invalid_skill_content_maps_to_bad_request() {
-        let err: AppError = CronError::InvalidSkillContent("empty".into()).into();
-        assert!(matches!(err, AppError::BadRequest(_)));
-    }
-
-    #[test]
-    fn invalid_agent_config_maps_to_bad_request() {
-        let err: AppError = CronError::InvalidAgentConfig("missing backend".into()).into();
-        assert!(matches!(err, AppError::BadRequest(_)));
-    }
-
-    #[test]
-    fn scheduler_error_maps_to_internal() {
-        let err: AppError = CronError::Scheduler("timer failed".into()).into();
-        assert!(matches!(err, AppError::Internal(_)));
-    }
-
-    #[test]
-    fn app_error_passthrough_preserves_code() {
-        let err: AppError = CronError::App(AppError::WorkspacePathContainsWhitespace("/tmp/a b".into())).into();
-        assert!(matches!(err, AppError::WorkspacePathContainsWhitespace(msg) if msg == "/tmp/a b"));
-    }
-
-    #[test]
-    fn conversation_error_maps_through_boundary_mapper() {
-        let err: AppError = CronError::Conversation(ConversationError::NotFound { id: "conv-1".into() }).into();
-        assert!(matches!(err, AppError::NotFound(msg) if msg == "Conversation conv-1 not found"));
-    }
-
-    #[test]
     fn conversation_create_preserves_workspace_error_code() {
         let err = CronError::from_conversation_create(ConversationError::App(
             AppError::WorkspacePathContainsWhitespace("/tmp/a b".into()),
         ));
-        let app: AppError = err.into();
-        assert!(matches!(app, AppError::WorkspacePathContainsWhitespace(msg) if msg == "/tmp/a b"));
-    }
-
-    #[test]
-    fn runtime_workspace_app_error_passthrough_preserves_code() {
-        let err: AppError = CronError::App(AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(
-            "/tmp/a b".into(),
-        ))
-        .into();
-        assert!(matches!(
-            err,
-            AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(msg) if msg == "/tmp/a b"
-        ));
-    }
-
-    #[test]
-    fn json_error_maps_to_internal() {
-        let json_err = serde_json::from_str::<serde_json::Value>("invalid").unwrap_err();
-        let err: AppError = CronError::Json(json_err).into();
-        assert!(matches!(err, AppError::Internal(_)));
+        assert!(matches!(err, CronError::App(AppError::WorkspacePathContainsWhitespace(msg)) if msg == "/tmp/a b"));
     }
 
     #[test]

--- a/crates/aionui-cron/src/error.rs
+++ b/crates/aionui-cron/src/error.rs
@@ -1,4 +1,5 @@
 use aionui_common::AppError;
+use aionui_conversation::ConversationError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum CronError {
@@ -35,6 +36,9 @@ pub enum CronError {
     #[error(transparent)]
     App(#[from] AppError),
 
+    #[error(transparent)]
+    Conversation(#[from] ConversationError),
+
     #[error("{0}")]
     Database(#[from] aionui_db::DbError),
 
@@ -56,6 +60,7 @@ impl From<CronError> for AppError {
             CronError::InvalidAgentConfig(msg) => AppError::BadRequest(msg),
             CronError::Scheduler(msg) => AppError::Internal(msg),
             CronError::App(app_err) => app_err,
+            CronError::Conversation(conversation_err) => AppError::from(conversation_err),
             CronError::Database(db_err) => AppError::from(db_err),
             CronError::Json(e) => AppError::Internal(format!("JSON error: {e}")),
         }
@@ -63,10 +68,12 @@ impl From<CronError> for AppError {
 }
 
 impl CronError {
-    pub(crate) fn from_conversation_create(error: AppError) -> Self {
+    pub(crate) fn from_conversation_create(error: ConversationError) -> Self {
         match error {
-            AppError::WorkspacePathContainsWhitespace(_) => Self::App(error),
-            AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(_) => Self::App(error),
+            ConversationError::App(error @ AppError::WorkspacePathContainsWhitespace(_)) => Self::App(error),
+            ConversationError::App(error @ AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(_)) => {
+                Self::App(error)
+            }
             other => Self::Scheduler(format!("create conversation: {other}")),
         }
     }
@@ -140,6 +147,21 @@ mod tests {
     fn app_error_passthrough_preserves_code() {
         let err: AppError = CronError::App(AppError::WorkspacePathContainsWhitespace("/tmp/a b".into())).into();
         assert!(matches!(err, AppError::WorkspacePathContainsWhitespace(msg) if msg == "/tmp/a b"));
+    }
+
+    #[test]
+    fn conversation_error_maps_through_boundary_mapper() {
+        let err: AppError = CronError::Conversation(ConversationError::NotFound { id: "conv-1".into() }).into();
+        assert!(matches!(err, AppError::NotFound(msg) if msg == "Conversation conv-1 not found"));
+    }
+
+    #[test]
+    fn conversation_create_preserves_workspace_error_code() {
+        let err = CronError::from_conversation_create(ConversationError::App(
+            AppError::WorkspacePathContainsWhitespace("/tmp/a b".into()),
+        ));
+        let app: AppError = err.into();
+        assert!(matches!(app, AppError::WorkspacePathContainsWhitespace(msg) if msg == "/tmp/a b"));
     }
 
     #[test]

--- a/crates/aionui-cron/src/routes.rs
+++ b/crates/aionui-cron/src/routes.rs
@@ -11,8 +11,30 @@ use aionui_api_types::{
 use aionui_auth::CurrentUser;
 use aionui_common::AppError;
 
+use crate::error::CronError;
 use crate::service::CronService;
 use crate::state::CronRouterState;
+
+impl From<CronError> for AppError {
+    fn from(err: CronError) -> Self {
+        match err {
+            CronError::JobNotFound(msg) => AppError::NotFound(msg),
+            CronError::InvalidSchedule(msg) => AppError::BadRequest(msg),
+            CronError::InvalidCronExpression(msg) => AppError::BadRequest(msg),
+            CronError::InvalidExecutionMode(msg) => AppError::BadRequest(msg),
+            CronError::InvalidCreatedBy(msg) => AppError::BadRequest(msg),
+            CronError::InvalidJobStatus(msg) => AppError::BadRequest(msg),
+            CronError::InvalidTimezone(msg) => AppError::BadRequest(msg),
+            CronError::InvalidSkillContent(msg) => AppError::BadRequest(msg),
+            CronError::InvalidAgentConfig(msg) => AppError::BadRequest(msg),
+            CronError::Scheduler(msg) => AppError::Internal(msg),
+            CronError::App(app_err) => app_err,
+            CronError::Conversation(conversation_err) => AppError::from(conversation_err),
+            CronError::Database(db_err) => AppError::from(db_err),
+            CronError::Json(e) => AppError::Internal(format!("JSON error: {e}")),
+        }
+    }
+}
 
 pub fn cron_routes(state: CronRouterState) -> Router {
     Router::new()
@@ -136,4 +158,101 @@ async fn delete_skill(
 ) -> Result<Json<ApiResponse<()>>, AppError> {
     state.cron_service.delete_skill(&id).await?;
     Ok(Json(ApiResponse::success()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn job_not_found_maps_to_not_found() {
+        let err: AppError = CronError::JobNotFound("cron_abc".into()).into();
+        assert!(matches!(err, AppError::NotFound(msg) if msg == "cron_abc"));
+    }
+
+    #[test]
+    fn invalid_schedule_maps_to_bad_request() {
+        let err: AppError = CronError::InvalidSchedule("missing kind".into()).into();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn invalid_cron_expression_maps_to_bad_request() {
+        let err: AppError = CronError::InvalidCronExpression("bad expr".into()).into();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn invalid_execution_mode_maps_to_bad_request() {
+        let err: AppError = CronError::InvalidExecutionMode("unknown".into()).into();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn invalid_created_by_maps_to_bad_request() {
+        let err: AppError = CronError::InvalidCreatedBy("robot".into()).into();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn invalid_job_status_maps_to_bad_request() {
+        let err: AppError = CronError::InvalidJobStatus("unknown".into()).into();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn invalid_timezone_maps_to_bad_request() {
+        let err: AppError = CronError::InvalidTimezone("Mars/Olympus".into()).into();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn invalid_skill_content_maps_to_bad_request() {
+        let err: AppError = CronError::InvalidSkillContent("empty".into()).into();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn invalid_agent_config_maps_to_bad_request() {
+        let err: AppError = CronError::InvalidAgentConfig("missing backend".into()).into();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn scheduler_error_maps_to_internal() {
+        let err: AppError = CronError::Scheduler("timer failed".into()).into();
+        assert!(matches!(err, AppError::Internal(_)));
+    }
+
+    #[test]
+    fn app_error_passthrough_preserves_code() {
+        let err: AppError = CronError::App(AppError::WorkspacePathContainsWhitespace("/tmp/a b".into())).into();
+        assert!(matches!(err, AppError::WorkspacePathContainsWhitespace(msg) if msg == "/tmp/a b"));
+    }
+
+    #[test]
+    fn conversation_error_maps_through_boundary_mapper() {
+        let err: AppError =
+            CronError::Conversation(aionui_conversation::ConversationError::NotFound { id: "conv-1".into() }).into();
+        assert!(matches!(err, AppError::NotFound(msg) if msg == "Conversation conv-1 not found"));
+    }
+
+    #[test]
+    fn runtime_workspace_app_error_passthrough_preserves_code() {
+        let err: AppError = CronError::App(AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(
+            "/tmp/a b".into(),
+        ))
+        .into();
+        assert!(matches!(
+            err,
+            AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(msg) if msg == "/tmp/a b"
+        ));
+    }
+
+    #[test]
+    fn json_error_maps_to_internal() {
+        let json_err = serde_json::from_str::<serde_json::Value>("invalid").unwrap_err();
+        let err: AppError = CronError::Json(json_err).into();
+        assert!(matches!(err, AppError::Internal(_)));
+    }
 }

--- a/crates/aionui-extension/src/classifier.rs
+++ b/crates/aionui-extension/src/classifier.rs
@@ -8,7 +8,8 @@
 //! `aionui-assistant::AssistantService`.
 
 use aionui_api_types::AssistantSource;
-use aionui_common::AppError;
+
+use crate::error::ExtensionError;
 
 /// Classify an assistant id into its source (builtin / extension / user).
 #[async_trait::async_trait]
@@ -37,11 +38,11 @@ impl AssistantClassifier for DefaultUserClassifier {
 /// `/api/skills/assistant-skill/*` endpoints dispatch per source.
 #[async_trait::async_trait]
 pub trait AssistantRuleDispatcher: Send + Sync {
-    async fn read_rule(&self, id: &str, locale: Option<&str>) -> Result<String, AppError>;
-    async fn write_rule(&self, id: &str, locale: Option<&str>, content: &str) -> Result<(), AppError>;
-    async fn delete_rule(&self, id: &str) -> Result<bool, AppError>;
+    async fn read_rule(&self, id: &str, locale: Option<&str>) -> Result<String, ExtensionError>;
+    async fn write_rule(&self, id: &str, locale: Option<&str>, content: &str) -> Result<(), ExtensionError>;
+    async fn delete_rule(&self, id: &str) -> Result<bool, ExtensionError>;
 
-    async fn read_skill(&self, id: &str, locale: Option<&str>) -> Result<String, AppError>;
-    async fn write_skill(&self, id: &str, locale: Option<&str>, content: &str) -> Result<(), AppError>;
-    async fn delete_skill(&self, id: &str) -> Result<bool, AppError>;
+    async fn read_skill(&self, id: &str, locale: Option<&str>) -> Result<String, ExtensionError>;
+    async fn write_skill(&self, id: &str, locale: Option<&str>, content: &str) -> Result<(), ExtensionError>;
+    async fn delete_skill(&self, id: &str) -> Result<bool, ExtensionError>;
 }

--- a/crates/aionui-extension/src/error.rs
+++ b/crates/aionui-extension/src/error.rs
@@ -1,5 +1,3 @@
-use aionui_common::AppError;
-
 /// Extension system domain errors.
 #[derive(Debug, thiserror::Error)]
 pub enum ExtensionError {
@@ -79,46 +77,17 @@ pub enum ExtensionError {
     #[error("Invalid skill path: {0}")]
     InvalidSkillPath(String),
 
+    #[error("Invalid request: {0}")]
+    InvalidRequest(String),
+
+    #[error("Internal extension error: {0}")]
+    Internal(String),
+
     #[error("{0}")]
     Io(#[from] std::io::Error),
 
     #[error("{0}")]
     JsonParse(#[from] serde_json::Error),
-}
-
-impl From<ExtensionError> for AppError {
-    fn from(err: ExtensionError) -> Self {
-        match err {
-            ExtensionError::ManifestValidation(msg) => AppError::BadRequest(msg),
-            ExtensionError::ReservedNamePrefix { .. } => AppError::BadRequest(err.to_string()),
-            ExtensionError::InvalidVersion { .. } => AppError::BadRequest(err.to_string()),
-            ExtensionError::UndefinedEnvVariable(var) => {
-                AppError::BadRequest(format!("Undefined environment variable: {var}"))
-            }
-            ExtensionError::FileReferenceNotFound(path) => {
-                AppError::NotFound(format!("File reference not found: {path}"))
-            }
-            ExtensionError::PathTraversal(path) => AppError::BadRequest(format!("Path traversal detected: {path}")),
-            ExtensionError::EngineIncompatible { .. } => AppError::BadRequest(err.to_string()),
-            ExtensionError::ApiVersionIncompatible { .. } => AppError::BadRequest(err.to_string()),
-            ExtensionError::InvalidWebuiRouteNamespace { .. } => AppError::BadRequest(err.to_string()),
-            ExtensionError::ReservedWebuiRoute { .. } => AppError::BadRequest(err.to_string()),
-            ExtensionError::ThemeCssNotFound(path) => AppError::NotFound(format!("Theme CSS not found: {path}")),
-            ExtensionError::HookTimeout { .. } => AppError::Internal(err.to_string()),
-            ExtensionError::HookFailed { .. } => AppError::Internal(err.to_string()),
-            ExtensionError::HookNotFound(path) => AppError::NotFound(format!("Hook script not found: {path}")),
-            ExtensionError::ResolutionFailed { .. } => AppError::Internal(err.to_string()),
-            ExtensionError::NotFound(name) => AppError::NotFound(format!("Extension not found: {name}")),
-            ExtensionError::StatePersistence(msg) => AppError::Internal(msg),
-            ExtensionError::BuiltinSkillDeletion(name) => {
-                AppError::BadRequest(format!("Cannot delete built-in skill: {name}"))
-            }
-            ExtensionError::SkillNotFound(name) => AppError::NotFound(format!("Skill not found: {name}")),
-            ExtensionError::InvalidSkillPath(path) => AppError::BadRequest(format!("Invalid skill path: {path}")),
-            ExtensionError::Io(e) => AppError::Internal(e.to_string()),
-            ExtensionError::JsonParse(e) => AppError::BadRequest(e.to_string()),
-        }
-    }
 }
 
 #[cfg(test)]
@@ -171,32 +140,9 @@ mod tests {
     }
 
     #[test]
-    fn test_into_app_error_path_traversal() {
-        let err = ExtensionError::PathTraversal("../secret".into());
-        let app_err: AppError = err.into();
-        assert!(matches!(app_err, AppError::BadRequest(_)));
-    }
-
-    #[test]
-    fn test_into_app_error_bad_request() {
-        let err = ExtensionError::ManifestValidation("test".into());
-        let app_err: AppError = err.into();
-        assert!(matches!(app_err, AppError::BadRequest(_)));
-    }
-
-    #[test]
-    fn test_into_app_error_not_found() {
-        let err = ExtensionError::FileReferenceNotFound("missing.md".into());
-        let app_err: AppError = err.into();
-        assert!(matches!(app_err, AppError::NotFound(_)));
-    }
-
-    #[test]
     fn test_io_error_conversion() {
         let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file missing");
         let err = ExtensionError::from(io_err);
         assert!(matches!(err, ExtensionError::Io(_)));
-        let app_err: AppError = err.into();
-        assert!(matches!(app_err, AppError::Internal(_)));
     }
 }

--- a/crates/aionui-extension/src/routes.rs
+++ b/crates/aionui-extension/src/routes.rs
@@ -16,8 +16,46 @@ use aionui_api_types::{
 use aionui_common::{AppError, now_ms};
 
 use crate::asset_paths::normalize_relative_asset_path;
+use crate::error::ExtensionError;
 use crate::permission::{build_permission_summary, calculate_risk_level};
 use crate::registry::ExtensionRegistry;
+
+impl From<ExtensionError> for AppError {
+    fn from(err: ExtensionError) -> Self {
+        match err {
+            ExtensionError::ManifestValidation(msg) => AppError::BadRequest(msg),
+            ExtensionError::ReservedNamePrefix { .. } => AppError::BadRequest(err.to_string()),
+            ExtensionError::InvalidVersion { .. } => AppError::BadRequest(err.to_string()),
+            ExtensionError::UndefinedEnvVariable(var) => {
+                AppError::BadRequest(format!("Undefined environment variable: {var}"))
+            }
+            ExtensionError::FileReferenceNotFound(path) => {
+                AppError::NotFound(format!("File reference not found: {path}"))
+            }
+            ExtensionError::PathTraversal(path) => AppError::BadRequest(format!("Path traversal detected: {path}")),
+            ExtensionError::EngineIncompatible { .. } => AppError::BadRequest(err.to_string()),
+            ExtensionError::ApiVersionIncompatible { .. } => AppError::BadRequest(err.to_string()),
+            ExtensionError::InvalidWebuiRouteNamespace { .. } => AppError::BadRequest(err.to_string()),
+            ExtensionError::ReservedWebuiRoute { .. } => AppError::BadRequest(err.to_string()),
+            ExtensionError::ThemeCssNotFound(path) => AppError::NotFound(format!("Theme CSS not found: {path}")),
+            ExtensionError::HookTimeout { .. } => AppError::Internal(err.to_string()),
+            ExtensionError::HookFailed { .. } => AppError::Internal(err.to_string()),
+            ExtensionError::HookNotFound(path) => AppError::NotFound(format!("Hook script not found: {path}")),
+            ExtensionError::ResolutionFailed { .. } => AppError::Internal(err.to_string()),
+            ExtensionError::NotFound(name) => AppError::NotFound(format!("Extension not found: {name}")),
+            ExtensionError::StatePersistence(msg) => AppError::Internal(msg),
+            ExtensionError::BuiltinSkillDeletion(name) => {
+                AppError::BadRequest(format!("Cannot delete built-in skill: {name}"))
+            }
+            ExtensionError::SkillNotFound(name) => AppError::NotFound(format!("Skill not found: {name}")),
+            ExtensionError::InvalidSkillPath(path) => AppError::BadRequest(format!("Invalid skill path: {path}")),
+            ExtensionError::InvalidRequest(msg) => AppError::BadRequest(msg),
+            ExtensionError::Internal(msg) => AppError::Internal(msg),
+            ExtensionError::Io(e) => AppError::Internal(e.to_string()),
+            ExtensionError::JsonParse(e) => AppError::BadRequest(e.to_string()),
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Router state
@@ -546,6 +584,31 @@ mod tests {
     fn extension_routes_builds_router() {
         let state = make_state();
         let _router = extension_routes(state);
+    }
+
+    #[test]
+    fn extension_path_traversal_maps_to_bad_request() {
+        let app_err = AppError::from(ExtensionError::PathTraversal("../secret".into()));
+        assert!(matches!(app_err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn extension_manifest_validation_maps_to_bad_request() {
+        let app_err = AppError::from(ExtensionError::ManifestValidation("test".into()));
+        assert!(matches!(app_err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn extension_file_reference_not_found_maps_to_not_found() {
+        let app_err = AppError::from(ExtensionError::FileReferenceNotFound("missing.md".into()));
+        assert!(matches!(app_err, AppError::NotFound(_)));
+    }
+
+    #[test]
+    fn extension_io_error_maps_to_internal() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file missing");
+        let app_err = AppError::from(ExtensionError::Io(io_err));
+        assert!(matches!(app_err, AppError::Internal(_)));
     }
 
     async fn make_router_with_extension() -> (Router, tempfile::TempDir, PathBuf) {

--- a/crates/aionui-extension/tests/assistant_dispatch_test.rs
+++ b/crates/aionui-extension/tests/assistant_dispatch_test.rs
@@ -9,8 +9,8 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use aionui_api_types::{ApiResponse, AssistantSource};
-use aionui_common::AppError;
 use aionui_extension::classifier::{AssistantClassifier, AssistantRuleDispatcher};
+use aionui_extension::error::ExtensionError;
 use aionui_extension::external_paths::ExternalPathsManager;
 use aionui_extension::skill_routes::{SkillRouterState, skill_routes};
 use aionui_extension::skill_service::SkillPaths;
@@ -55,7 +55,7 @@ impl AssistantClassifier for FakeDispatcher {
 
 #[async_trait::async_trait]
 impl AssistantRuleDispatcher for FakeDispatcher {
-    async fn read_rule(&self, id: &str, locale: Option<&str>) -> Result<String, AppError> {
+    async fn read_rule(&self, id: &str, locale: Option<&str>) -> Result<String, ExtensionError> {
         self.log
             .lock()
             .unwrap()
@@ -64,9 +64,11 @@ impl AssistantRuleDispatcher for FakeDispatcher {
         Ok(self.rule_content.get(id).cloned().unwrap_or_default())
     }
 
-    async fn write_rule(&self, id: &str, locale: Option<&str>, content: &str) -> Result<(), AppError> {
+    async fn write_rule(&self, id: &str, locale: Option<&str>, content: &str) -> Result<(), ExtensionError> {
         if self.reject_writes_for.contains(id) {
-            return Err(AppError::BadRequest("Cannot write rule for built-in assistant".into()));
+            return Err(ExtensionError::InvalidRequest(
+                "Cannot write rule for built-in assistant".into(),
+            ));
         }
         self.log
             .lock()
@@ -76,15 +78,17 @@ impl AssistantRuleDispatcher for FakeDispatcher {
         Ok(())
     }
 
-    async fn delete_rule(&self, id: &str) -> Result<bool, AppError> {
+    async fn delete_rule(&self, id: &str) -> Result<bool, ExtensionError> {
         if self.reject_writes_for.contains(id) {
-            return Err(AppError::BadRequest("Cannot delete rule for built-in assistant".into()));
+            return Err(ExtensionError::InvalidRequest(
+                "Cannot delete rule for built-in assistant".into(),
+            ));
         }
         self.log.lock().unwrap().rule_deletes.push(id.to_string());
         Ok(true)
     }
 
-    async fn read_skill(&self, id: &str, locale: Option<&str>) -> Result<String, AppError> {
+    async fn read_skill(&self, id: &str, locale: Option<&str>) -> Result<String, ExtensionError> {
         self.log
             .lock()
             .unwrap()
@@ -93,9 +97,11 @@ impl AssistantRuleDispatcher for FakeDispatcher {
         Ok(self.skill_content.get(id).cloned().unwrap_or_default())
     }
 
-    async fn write_skill(&self, id: &str, locale: Option<&str>, content: &str) -> Result<(), AppError> {
+    async fn write_skill(&self, id: &str, locale: Option<&str>, content: &str) -> Result<(), ExtensionError> {
         if self.reject_writes_for.contains(id) {
-            return Err(AppError::BadRequest("Cannot write skill for built-in assistant".into()));
+            return Err(ExtensionError::InvalidRequest(
+                "Cannot write skill for built-in assistant".into(),
+            ));
         }
         self.log
             .lock()
@@ -105,9 +111,9 @@ impl AssistantRuleDispatcher for FakeDispatcher {
         Ok(())
     }
 
-    async fn delete_skill(&self, id: &str) -> Result<bool, AppError> {
+    async fn delete_skill(&self, id: &str) -> Result<bool, ExtensionError> {
         if self.reject_writes_for.contains(id) {
-            return Err(AppError::BadRequest(
+            return Err(ExtensionError::InvalidRequest(
                 "Cannot delete skill for built-in assistant".into(),
             ));
         }

--- a/crates/aionui-file/Cargo.toml
+++ b/crates/aionui-file/Cargo.toml
@@ -21,6 +21,7 @@ mime_guess.workspace = true
 base64.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 dashmap.workspace = true
 dirs.workspace = true

--- a/crates/aionui-file/src/browse.rs
+++ b/crates/aionui-file/src/browse.rs
@@ -14,8 +14,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::error::FileError;
 use aionui_api_types::{BrowseDirectoryResponse, BrowseEntry};
-use aionui_common::AppError;
 
 /// Sentinel returned as `parent_path` on Windows drive roots, signaling the
 /// frontend to navigate back to the drive-list screen.
@@ -114,15 +114,15 @@ pub fn drive_list_response() -> BrowseDirectoryResponse {
 /// `~` expansion is handled explicitly so users can paste `~/Documents`
 /// into the picker. Symlinks are resolved via `canonicalize` before the
 /// sandbox check, so a link pointing outside the allow-list is rejected.
-pub fn resolve_browse_path(raw: &str, allowed_roots: &[PathBuf]) -> Result<PathBuf, AppError> {
+pub fn resolve_browse_path(raw: &str, allowed_roots: &[PathBuf]) -> Result<PathBuf, FileError> {
     if raw.contains('\0') {
-        return Err(AppError::BadRequest("path contains null byte".into()));
+        return Err(FileError::BadRequest("path contains null byte".into()));
     }
 
     let expanded = expand_tilde(raw.trim());
     let canonical = fs::canonicalize(&expanded).map_err(|e| match e.kind() {
-        std::io::ErrorKind::NotFound => AppError::NotFound(format!("path not found: {}", raw)),
-        _ => AppError::BadRequest(format!("cannot resolve path '{}': {}", raw, e)),
+        std::io::ErrorKind::NotFound => FileError::NotFound(format!("path not found: {}", raw)),
+        _ => FileError::BadRequest(format!("cannot resolve path '{}': {}", raw, e)),
     })?;
 
     let allowed = allowed_roots.iter().any(|root| match fs::canonicalize(root) {
@@ -131,7 +131,7 @@ pub fn resolve_browse_path(raw: &str, allowed_roots: &[PathBuf]) -> Result<PathB
     });
 
     if !allowed {
-        return Err(AppError::Forbidden(format!(
+        return Err(FileError::Forbidden(format!(
             "path '{}' is outside the allowed sandbox",
             raw
         )));
@@ -163,13 +163,13 @@ pub fn list_directory(
     dir: &Path,
     show_files: bool,
     allowed_roots: &[PathBuf],
-) -> Result<BrowseDirectoryResponse, AppError> {
-    let metadata = fs::metadata(dir).map_err(|e| AppError::NotFound(format!("cannot access directory: {}", e)))?;
+) -> Result<BrowseDirectoryResponse, FileError> {
+    let metadata = fs::metadata(dir).map_err(|e| FileError::NotFound(format!("cannot access directory: {}", e)))?;
     if !metadata.is_dir() {
-        return Err(AppError::BadRequest("path is not a directory".into()));
+        return Err(FileError::BadRequest("path is not a directory".into()));
     }
 
-    let read = fs::read_dir(dir).map_err(|e| AppError::Internal(format!("readdir failed: {}", e)))?;
+    let read = fs::read_dir(dir).map_err(|e| FileError::Internal(format!("readdir failed: {}", e)))?;
 
     let mut items: Vec<BrowseEntry> = Vec::new();
     for entry in read.flatten() {
@@ -266,7 +266,7 @@ pub fn browse(
     raw_path: Option<&str>,
     show_files: bool,
     allowed_roots: &[PathBuf],
-) -> Result<BrowseDirectoryResponse, AppError> {
+) -> Result<BrowseDirectoryResponse, FileError> {
     let requested = raw_path.map(str::trim).unwrap_or("");
 
     #[cfg(windows)]
@@ -278,7 +278,7 @@ pub fn browse(
 
     let target = if requested.is_empty() {
         std::env::current_dir()
-            .map_err(|e| AppError::Internal(format!("cannot read cwd: {}", e)))?
+            .map_err(|e| FileError::Internal(format!("cannot read cwd: {}", e)))?
             .to_string_lossy()
             .into_owned()
     } else {
@@ -350,7 +350,7 @@ mod tests {
         let roots = roots_from(&[sandbox.path()]);
 
         let err = browse(Some(outside.path().to_str().unwrap()), false, &roots).unwrap_err();
-        assert!(matches!(err, AppError::Forbidden(_)), "expected forbidden, got {err}");
+        assert!(matches!(err, FileError::Forbidden(_)), "expected forbidden, got {err}");
     }
 
     #[test]
@@ -360,7 +360,7 @@ mod tests {
         let roots = roots_from(&[sandbox.path()]);
 
         let err = browse(Some(fake.to_str().unwrap()), false, &roots).unwrap_err();
-        assert!(matches!(err, AppError::NotFound(_)), "expected not-found, got {err}");
+        assert!(matches!(err, FileError::NotFound(_)), "expected not-found, got {err}");
     }
 
     #[test]
@@ -369,7 +369,7 @@ mod tests {
         let roots = roots_from(&[sandbox.path()]);
 
         let err = browse(Some("/tmp/\0evil"), false, &roots).unwrap_err();
-        assert!(matches!(err, AppError::BadRequest(_)));
+        assert!(matches!(err, FileError::BadRequest(_)));
     }
 
     #[test]
@@ -381,7 +381,7 @@ mod tests {
 
         let err = browse(Some(file.to_str().unwrap()), false, &roots).unwrap_err();
         assert!(
-            matches!(err, AppError::BadRequest(_)),
+            matches!(err, FileError::BadRequest(_)),
             "expected bad-request, got {err}"
         );
     }
@@ -447,7 +447,7 @@ mod tests {
         let roots = roots_from(&[sandbox.path()]);
 
         let err = browse(Some(link.to_str().unwrap()), false, &roots).unwrap_err();
-        assert!(matches!(err, AppError::Forbidden(_)), "expected forbidden, got {err}");
+        assert!(matches!(err, FileError::Forbidden(_)), "expected forbidden, got {err}");
     }
 
     #[test]

--- a/crates/aionui-file/src/error.rs
+++ b/crates/aionui-file/src/error.rs
@@ -1,0 +1,15 @@
+/// File crate application errors.
+#[derive(Debug, thiserror::Error)]
+pub enum FileError {
+    #[error("{0}")]
+    BadRequest(String),
+
+    #[error("{0}")]
+    Forbidden(String),
+
+    #[error("{0}")]
+    NotFound(String),
+
+    #[error("{0}")]
+    Internal(String),
+}

--- a/crates/aionui-file/src/lib.rs
+++ b/crates/aionui-file/src/lib.rs
@@ -1,5 +1,6 @@
 //! File system operations: read/write, path safety, file watching, snapshots, and zip.
 pub mod browse;
+pub mod error;
 pub mod path_safety;
 pub mod routes;
 pub mod service;
@@ -8,6 +9,7 @@ pub mod traits;
 pub mod types;
 pub mod watch_service;
 
+pub use error::FileError;
 pub use path_safety::{has_traversal, validate_path, validate_path_for_write};
 pub use routes::{FileRouterState, file_routes};
 pub use service::FileService;

--- a/crates/aionui-file/src/path_safety.rs
+++ b/crates/aionui-file/src/path_safety.rs
@@ -1,6 +1,6 @@
 use std::path::{Component, Path, PathBuf};
 
-use aionui_common::AppError;
+use crate::error::FileError;
 
 /// Canonicalize `path` and verify it falls within one of the `allowed_roots`.
 ///
@@ -10,11 +10,11 @@ use aionui_common::AppError;
 ///
 /// # Errors
 ///
-/// - `AppError::BadRequest` if `path` does not exist or cannot be
+/// - `FileError::BadRequest` if `path` does not exist or cannot be
 ///   canonicalized, or if it falls outside all allowed roots.
-pub fn validate_path(path: &str, allowed_roots: &[&Path]) -> Result<PathBuf, AppError> {
+pub fn validate_path(path: &str, allowed_roots: &[&Path]) -> Result<PathBuf, FileError> {
     let canonical = std::fs::canonicalize(path)
-        .map_err(|e| AppError::BadRequest(format!("cannot resolve path '{}': {}", path, e)))?;
+        .map_err(|e| FileError::BadRequest(format!("cannot resolve path '{}': {}", path, e)))?;
 
     let is_allowed = allowed_roots.iter().any(|root| {
         // Canonicalize the root as well so that symlinks (e.g. macOS
@@ -28,7 +28,7 @@ pub fn validate_path(path: &str, allowed_roots: &[&Path]) -> Result<PathBuf, App
     if is_allowed {
         Ok(canonical)
     } else {
-        Err(AppError::Forbidden(format!(
+        Err(FileError::Forbidden(format!(
             "path '{}' is outside the allowed sandbox",
             path
         )))
@@ -40,7 +40,7 @@ pub fn validate_path_with_extra_root(
     path: &str,
     base_roots: &[&Path],
     extra: Option<&Path>,
-) -> Result<PathBuf, AppError> {
+) -> Result<PathBuf, FileError> {
     let mut allowed_roots = base_roots.to_vec();
     if let Some(extra_root) = extra {
         allowed_roots.push(extra_root);
@@ -56,21 +56,21 @@ pub fn validate_path_with_extra_root(
 ///
 /// # Errors
 ///
-/// Same as [`validate_path`], plus `AppError::BadRequest` if the path has
+/// Same as [`validate_path`], plus `FileError::BadRequest` if the path has
 /// no parent or no file-name component.
-pub fn validate_path_for_write(path: &str, allowed_roots: &[&Path]) -> Result<PathBuf, AppError> {
+pub fn validate_path_for_write(path: &str, allowed_roots: &[&Path]) -> Result<PathBuf, FileError> {
     let p = Path::new(path);
 
     let parent = p
         .parent()
-        .ok_or_else(|| AppError::BadRequest(format!("path '{}' has no parent directory", path)))?;
+        .ok_or_else(|| FileError::BadRequest(format!("path '{}' has no parent directory", path)))?;
 
     let file_name = p
         .file_name()
-        .ok_or_else(|| AppError::BadRequest(format!("path '{}' has no file name component", path)))?;
+        .ok_or_else(|| FileError::BadRequest(format!("path '{}' has no file name component", path)))?;
 
     let canonical_parent = std::fs::canonicalize(parent)
-        .map_err(|e| AppError::BadRequest(format!("cannot resolve parent of '{}': {}", path, e)))?;
+        .map_err(|e| FileError::BadRequest(format!("cannot resolve parent of '{}': {}", path, e)))?;
 
     let is_allowed = allowed_roots.iter().any(|root| match std::fs::canonicalize(root) {
         Ok(canonical_root) => canonical_parent.starts_with(&canonical_root),
@@ -78,7 +78,7 @@ pub fn validate_path_for_write(path: &str, allowed_roots: &[&Path]) -> Result<Pa
     });
 
     if !is_allowed {
-        return Err(AppError::Forbidden(format!(
+        return Err(FileError::Forbidden(format!(
             "path '{}' is outside the allowed sandbox",
             path
         )));
@@ -126,7 +126,7 @@ mod tests {
         let result = validate_path(file.to_str().unwrap(), &[sandbox.path()]);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(matches!(err, AppError::Forbidden(_)), "unexpected error: {err}");
+        assert!(matches!(err, FileError::Forbidden(_)), "unexpected error: {err}");
     }
 
     #[test]

--- a/crates/aionui-file/src/routes.rs
+++ b/crates/aionui-file/src/routes.rs
@@ -17,11 +17,23 @@ use aionui_common::AppError;
 use aionui_common::constants::UPLOAD_MAX_SIZE;
 
 use crate::browse;
+use crate::error::FileError;
 use crate::traits::{FileServiceRef, FileWatchServiceRef, SnapshotServiceRef};
 use crate::types::{
     CompareResult, CopyResult, DirOrFile, FileChangeInfo, FileMetadata, SnapshotInfo, SnapshotMode, WorkspaceFlatFile,
     ZipEntry,
 };
+
+impl From<FileError> for AppError {
+    fn from(error: FileError) -> Self {
+        match error {
+            FileError::BadRequest(message) => AppError::BadRequest(message),
+            FileError::Forbidden(message) => AppError::Forbidden(message),
+            FileError::NotFound(message) => AppError::NotFound(message),
+            FileError::Internal(message) => AppError::Internal(message),
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Router state

--- a/crates/aionui-file/src/service.rs
+++ b/crates/aionui-file/src/service.rs
@@ -9,8 +9,8 @@ use dashmap::DashMap;
 use ignore::WalkBuilder;
 use tracing::warn;
 
+use crate::error::FileError;
 use aionui_api_types::WebSocketMessage;
-use aionui_common::AppError;
 use aionui_realtime::EventBroadcaster;
 
 use crate::path_safety::{has_traversal, validate_path, validate_path_for_write, validate_path_with_extra_root};
@@ -116,30 +116,30 @@ impl FileService {
 
     /// List immediate children of `dir`, building a single-level tree.
     /// Each child directory also lists *its* children (depth = 2 from `dir`).
-    async fn build_dir_tree(&self, dir: &Path, root: &Path) -> Result<Vec<DirOrFile>, AppError> {
+    async fn build_dir_tree(&self, dir: &Path, root: &Path) -> Result<Vec<DirOrFile>, FileError> {
         let dir_owned = dir.to_path_buf();
         let root_owned = root.to_path_buf();
 
         tokio::task::spawn_blocking(move || build_dir_tree_sync(&dir_owned, &root_owned))
             .await
-            .map_err(|e| AppError::Internal(format!("directory listing task failed: {e}")))?
+            .map_err(|e| FileError::Internal(format!("directory listing task failed: {e}")))?
     }
 }
 
 /// Synchronous directory tree builder (runs in blocking thread pool).
-fn build_dir_tree_sync(dir: &Path, root: &Path) -> Result<Vec<DirOrFile>, AppError> {
+fn build_dir_tree_sync(dir: &Path, root: &Path) -> Result<Vec<DirOrFile>, FileError> {
     let entries = std::fs::read_dir(dir)
-        .map_err(|e| AppError::BadRequest(format!("cannot read directory '{}': {e}", dir.display())))?;
+        .map_err(|e| FileError::BadRequest(format!("cannot read directory '{}': {e}", dir.display())))?;
 
     let mut result = Vec::new();
 
     for entry in entries {
-        let entry = entry.map_err(|e| AppError::Internal(format!("error reading directory entry: {e}")))?;
+        let entry = entry.map_err(|e| FileError::Internal(format!("error reading directory entry: {e}")))?;
 
         let path = entry.path();
         let metadata = entry
             .metadata()
-            .map_err(|e| AppError::Internal(format!("cannot read metadata for '{}': {e}", path.display())))?;
+            .map_err(|e| FileError::Internal(format!("cannot read metadata for '{}': {e}", path.display())))?;
 
         let name = entry.file_name().to_string_lossy().into_owned();
 
@@ -171,7 +171,7 @@ fn build_dir_tree_sync(dir: &Path, root: &Path) -> Result<Vec<DirOrFile>, AppErr
 }
 
 /// Read immediate children of a directory (one level, no grandchildren).
-fn read_children_sync(dir: &Path, root: &Path) -> Result<Vec<DirOrFile>, AppError> {
+fn read_children_sync(dir: &Path, root: &Path) -> Result<Vec<DirOrFile>, FileError> {
     let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
         Err(_) => return Ok(Vec::new()),
@@ -208,7 +208,7 @@ fn read_children_sync(dir: &Path, root: &Path) -> Result<Vec<DirOrFile>, AppErro
 }
 
 /// Recursively list files using the `ignore` crate (respects .gitignore).
-fn list_workspace_files_sync(root: &Path) -> Result<Vec<WorkspaceFlatFile>, AppError> {
+fn list_workspace_files_sync(root: &Path) -> Result<Vec<WorkspaceFlatFile>, FileError> {
     let walker = WalkBuilder::new(root)
         .hidden(false)
         .git_ignore(true)
@@ -267,14 +267,14 @@ fn list_workspace_files_sync(root: &Path) -> Result<Vec<WorkspaceFlatFile>, AppE
 /// Validate that a file exists and is within the size limit.
 /// Returns `Ok(None)` if the file does not exist.
 /// Returns `Ok(Some(()))` if the file is valid for reading.
-fn validate_file_for_read(path: &Path) -> Result<Option<()>, AppError> {
+fn validate_file_for_read(path: &Path) -> Result<Option<()>, FileError> {
     let metadata = match std::fs::metadata(path) {
         Ok(m) => m,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             return Ok(None);
         }
         Err(e) => {
-            return Err(AppError::Internal(format!(
+            return Err(FileError::Internal(format!(
                 "cannot read metadata for '{}': {e}",
                 path.display()
             )));
@@ -282,7 +282,7 @@ fn validate_file_for_read(path: &Path) -> Result<Option<()>, AppError> {
     };
 
     if metadata.len() > MAX_FILE_SIZE {
-        return Err(AppError::BadRequest(format!(
+        return Err(FileError::BadRequest(format!(
             "file '{}' exceeds 256 MB limit ({} bytes)",
             path.display(),
             metadata.len()
@@ -290,7 +290,7 @@ fn validate_file_for_read(path: &Path) -> Result<Option<()>, AppError> {
     }
 
     if metadata.is_dir() {
-        return Err(AppError::BadRequest(format!(
+        return Err(FileError::BadRequest(format!(
             "path '{}' is a directory; expected a file",
             path.display()
         )));
@@ -301,35 +301,35 @@ fn validate_file_for_read(path: &Path) -> Result<Option<()>, AppError> {
 
 /// Read a file as UTF-8 text. Returns `None` if the file does not exist.
 /// Rejects files larger than 256 MB.
-fn read_file_sync(path: &Path) -> Result<Option<String>, AppError> {
+fn read_file_sync(path: &Path) -> Result<Option<String>, FileError> {
     if validate_file_for_read(path)?.is_none() {
         return Ok(None);
     }
 
     let content = std::fs::read_to_string(path)
-        .map_err(|e| AppError::Internal(format!("cannot read file '{}': {e}", path.display())))?;
+        .map_err(|e| FileError::Internal(format!("cannot read file '{}': {e}", path.display())))?;
 
     Ok(Some(content))
 }
 
 /// Read a file as raw bytes. Returns `None` if the file does not exist.
 /// Rejects files larger than 256 MB.
-fn read_file_buffer_sync(path: &Path) -> Result<Option<Vec<u8>>, AppError> {
+fn read_file_buffer_sync(path: &Path) -> Result<Option<Vec<u8>>, FileError> {
     if validate_file_for_read(path)?.is_none() {
         return Ok(None);
     }
 
     let bytes =
-        std::fs::read(path).map_err(|e| AppError::Internal(format!("cannot read file '{}': {e}", path.display())))?;
+        std::fs::read(path).map_err(|e| FileError::Internal(format!("cannot read file '{}': {e}", path.display())))?;
 
     Ok(Some(bytes))
 }
 
 /// Write data to a file synchronously. Creates the file if it does not exist.
 /// Returns `true` on success.
-fn write_file_sync(path: &Path, data: &[u8]) -> Result<bool, AppError> {
+fn write_file_sync(path: &Path, data: &[u8]) -> Result<bool, FileError> {
     std::fs::write(path, data)
-        .map_err(|e| AppError::Internal(format!("cannot write file '{}': {e}", path.display())))?;
+        .map_err(|e| FileError::Internal(format!("cannot write file '{}': {e}", path.display())))?;
     Ok(true)
 }
 
@@ -353,9 +353,9 @@ fn split_base_ext(name: &str) -> (&str, &str) {
 }
 
 /// Get file metadata synchronously.
-fn get_file_metadata_sync(path: &Path) -> Result<FileMetadata, AppError> {
+fn get_file_metadata_sync(path: &Path) -> Result<FileMetadata, FileError> {
     let metadata = std::fs::metadata(path)
-        .map_err(|e| AppError::NotFound(format!("cannot read metadata for '{}': {e}", path.display())))?;
+        .map_err(|e| FileError::NotFound(format!("cannot read metadata for '{}': {e}", path.display())))?;
 
     let name = path
         .file_name()
@@ -392,36 +392,36 @@ fn get_file_metadata_sync(path: &Path) -> Result<FileMetadata, AppError> {
 }
 
 /// Remove a file or directory synchronously. Directories are removed recursively.
-fn remove_entry_sync(path: &Path) -> Result<(), AppError> {
+fn remove_entry_sync(path: &Path) -> Result<(), FileError> {
     let metadata =
-        std::fs::metadata(path).map_err(|e| AppError::NotFound(format!("cannot remove '{}': {e}", path.display())))?;
+        std::fs::metadata(path).map_err(|e| FileError::NotFound(format!("cannot remove '{}': {e}", path.display())))?;
 
     if metadata.is_dir() {
         std::fs::remove_dir_all(path)
-            .map_err(|e| AppError::Internal(format!("cannot remove directory '{}': {e}", path.display())))
+            .map_err(|e| FileError::Internal(format!("cannot remove directory '{}': {e}", path.display())))
     } else {
         std::fs::remove_file(path)
-            .map_err(|e| AppError::Internal(format!("cannot remove file '{}': {e}", path.display())))
+            .map_err(|e| FileError::Internal(format!("cannot remove file '{}': {e}", path.display())))
     }
 }
 
 /// Rename a file or directory synchronously. Returns the new absolute path.
-fn rename_entry_sync(path: &Path, new_name: &str) -> Result<PathBuf, AppError> {
+fn rename_entry_sync(path: &Path, new_name: &str) -> Result<PathBuf, FileError> {
     let parent = path
         .parent()
-        .ok_or_else(|| AppError::BadRequest(format!("path '{}' has no parent", path.display())))?;
+        .ok_or_else(|| FileError::BadRequest(format!("path '{}' has no parent", path.display())))?;
 
     let new_path = parent.join(new_name);
 
     if new_path.exists() {
-        return Err(AppError::BadRequest(format!(
+        return Err(FileError::BadRequest(format!(
             "target '{}' already exists",
             new_path.display()
         )));
     }
 
     std::fs::rename(path, &new_path).map_err(|e| {
-        AppError::Internal(format!(
+        FileError::Internal(format!(
             "cannot rename '{}' to '{}': {e}",
             path.display(),
             new_path.display()
@@ -432,22 +432,22 @@ fn rename_entry_sync(path: &Path, new_name: &str) -> Result<PathBuf, AppError> {
 }
 
 /// Copy a single file, creating parent directories as needed.
-fn copy_single_file_sync(src: &Path, dest: &Path) -> Result<(), AppError> {
+fn copy_single_file_sync(src: &Path, dest: &Path) -> Result<(), FileError> {
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent)
-            .map_err(|e| AppError::Internal(format!("cannot create directory '{}': {e}", parent.display())))?;
+            .map_err(|e| FileError::Internal(format!("cannot create directory '{}': {e}", parent.display())))?;
     }
 
     std::fs::copy(src, dest)
-        .map_err(|e| AppError::Internal(format!("cannot copy '{}' to '{}': {e}", src.display(), dest.display())))?;
+        .map_err(|e| FileError::Internal(format!("cannot copy '{}' to '{}': {e}", src.display(), dest.display())))?;
 
     Ok(())
 }
 
 /// Read a local image file and return a base64 Data URL.
-fn get_image_base64_sync(path: &Path) -> Result<String, AppError> {
+fn get_image_base64_sync(path: &Path) -> Result<String, FileError> {
     let bytes =
-        std::fs::read(path).map_err(|e| AppError::NotFound(format!("cannot read image '{}': {e}", path.display())))?;
+        std::fs::read(path).map_err(|e| FileError::NotFound(format!("cannot read image '{}': {e}", path.display())))?;
 
     let mime = mime_guess::from_path(path)
         .first()
@@ -501,10 +501,10 @@ fn validate_remote_image_url(raw_url: &str) -> Result<reqwest::Url, String> {
 /// Writes entries into a ZIP archive at `output_path`. Checks the
 /// `cancelled` flag between entries and aborts early if set.
 /// On cancellation, the partial ZIP file is removed.
-fn create_zip_sync(output_path: &Path, entries: &[ZipEntry], cancelled: &AtomicBool) -> Result<bool, AppError> {
+fn create_zip_sync(output_path: &Path, entries: &[ZipEntry], cancelled: &AtomicBool) -> Result<bool, FileError> {
     if let Some(parent) = output_path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| {
-            AppError::Internal(format!(
+            FileError::Internal(format!(
                 "cannot create parent directory for '{}': {e}",
                 output_path.display()
             ))
@@ -512,7 +512,7 @@ fn create_zip_sync(output_path: &Path, entries: &[ZipEntry], cancelled: &AtomicB
     }
 
     let file = std::fs::File::create(output_path)
-        .map_err(|e| AppError::Internal(format!("cannot create ZIP file '{}': {e}", output_path.display())))?;
+        .map_err(|e| FileError::Internal(format!("cannot create ZIP file '{}': {e}", output_path.display())))?;
 
     let mut zip = zip::ZipWriter::new(file);
     let options = zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
@@ -534,7 +534,7 @@ fn create_zip_sync(output_path: &Path, entries: &[ZipEntry], cancelled: &AtomicB
 
     zip.finish().map_err(|e| {
         let _ = std::fs::remove_file(output_path);
-        AppError::Internal(format!("ZIP: failed to finalize '{}': {e}", output_path.display()))
+        FileError::Internal(format!("ZIP: failed to finalize '{}': {e}", output_path.display()))
     })?;
 
     Ok(true)
@@ -547,7 +547,7 @@ fn write_zip_entries(
     entries: &[ZipEntry],
     cancelled: &AtomicBool,
     options: zip::write::SimpleFileOptions,
-) -> Result<bool, AppError> {
+) -> Result<bool, FileError> {
     for entry in entries {
         if cancelled.load(Ordering::Relaxed) {
             return Ok(false);
@@ -556,17 +556,17 @@ fn write_zip_entries(
         match entry {
             ZipEntry::Text { name, content } => {
                 zip.start_file(name, options)
-                    .map_err(|e| AppError::Internal(format!("ZIP: failed to start entry '{name}': {e}")))?;
+                    .map_err(|e| FileError::Internal(format!("ZIP: failed to start entry '{name}': {e}")))?;
                 zip.write_all(content.as_bytes())
-                    .map_err(|e| AppError::Internal(format!("ZIP: failed to write entry '{name}': {e}")))?;
+                    .map_err(|e| FileError::Internal(format!("ZIP: failed to write entry '{name}': {e}")))?;
             }
             ZipEntry::Disk { name, file_path } => {
                 let data = std::fs::read(file_path)
-                    .map_err(|e| AppError::Internal(format!("ZIP: cannot read source file '{file_path}': {e}")))?;
+                    .map_err(|e| FileError::Internal(format!("ZIP: cannot read source file '{file_path}': {e}")))?;
                 zip.start_file(name, options)
-                    .map_err(|e| AppError::Internal(format!("ZIP: failed to start entry '{name}': {e}")))?;
+                    .map_err(|e| FileError::Internal(format!("ZIP: failed to start entry '{name}': {e}")))?;
                 zip.write_all(&data)
-                    .map_err(|e| AppError::Internal(format!("ZIP: failed to write entry '{name}': {e}")))?;
+                    .map_err(|e| FileError::Internal(format!("ZIP: failed to write entry '{name}': {e}")))?;
             }
         }
     }
@@ -581,7 +581,7 @@ fn write_zip_entries(
 
 #[async_trait::async_trait]
 impl crate::traits::IFileService for FileService {
-    async fn get_files_by_dir(&self, dir: &str, root: &str) -> Result<Vec<DirOrFile>, AppError> {
+    async fn get_files_by_dir(&self, dir: &str, root: &str) -> Result<Vec<DirOrFile>, FileError> {
         let roots = self.allowed_roots_refs();
         let canonical_dir = validate_path(dir, &roots)?;
         let canonical_root = validate_path(root, &roots)?;
@@ -589,7 +589,7 @@ impl crate::traits::IFileService for FileService {
         self.build_dir_tree(&canonical_dir, &canonical_root).await
     }
 
-    async fn list_workspace_files(&self, root: &str) -> Result<Vec<WorkspaceFlatFile>, AppError> {
+    async fn list_workspace_files(&self, root: &str) -> Result<Vec<WorkspaceFlatFile>, FileError> {
         let roots = self.allowed_roots_refs();
         let canonical_root = validate_path(root, &roots)?;
         let cache_key = canonical_root.to_string_lossy().into_owned();
@@ -602,7 +602,7 @@ impl crate::traits::IFileService for FileService {
         let root_owned = canonical_root.clone();
         let files = tokio::task::spawn_blocking(move || list_workspace_files_sync(&root_owned))
             .await
-            .map_err(|e| AppError::Internal(format!("workspace file listing task failed: {e}")))??;
+            .map_err(|e| FileError::Internal(format!("workspace file listing task failed: {e}")))??;
 
         // Store in cache
         self.workspace_files_cache.insert(cache_key, files.clone());
@@ -610,22 +610,22 @@ impl crate::traits::IFileService for FileService {
         Ok(files)
     }
 
-    async fn get_file_metadata(&self, path: &str, extra_root: Option<&Path>) -> Result<FileMetadata, AppError> {
+    async fn get_file_metadata(&self, path: &str, extra_root: Option<&Path>) -> Result<FileMetadata, FileError> {
         let roots = self.allowed_roots_refs();
         let canonical = validate_path_with_extra_root(path, &roots, extra_root)?;
 
         let result = tokio::task::spawn_blocking(move || get_file_metadata_sync(&canonical))
             .await
-            .map_err(|e| AppError::Internal(format!("file metadata task failed: {e}")))??;
+            .map_err(|e| FileError::Internal(format!("file metadata task failed: {e}")))??;
 
         Ok(result)
     }
 
     // -- File read/write (task 7.4) --
 
-    async fn read_file(&self, path: &str, extra_root: Option<&Path>) -> Result<Option<String>, AppError> {
+    async fn read_file(&self, path: &str, extra_root: Option<&Path>) -> Result<Option<String>, FileError> {
         if has_traversal(path) {
-            return Err(AppError::BadRequest(format!(
+            return Err(FileError::BadRequest(format!(
                 "path '{}' contains invalid traversal patterns",
                 path
             )));
@@ -635,12 +635,12 @@ impl crate::traits::IFileService for FileService {
         let canonical = match validate_path_with_extra_root(path, &roots, extra_root) {
             Ok(c) => c,
             Err(err) => {
-                if matches!(err, AppError::BadRequest(_))
+                if matches!(err, FileError::BadRequest(_))
                     && validate_path_for_write(path, &self.allowed_roots_with_extra(extra_root)).is_ok()
                 {
                     return Ok(None);
                 }
-                if matches!(err, AppError::BadRequest(_)) && self.path_uses_allowed_root(Path::new(path), extra_root) {
+                if matches!(err, FileError::BadRequest(_)) && self.path_uses_allowed_root(Path::new(path), extra_root) {
                     return Ok(None);
                 }
                 return Err(err);
@@ -649,12 +649,12 @@ impl crate::traits::IFileService for FileService {
 
         tokio::task::spawn_blocking(move || read_file_sync(&canonical))
             .await
-            .map_err(|e| AppError::Internal(format!("read file task failed: {e}")))?
+            .map_err(|e| FileError::Internal(format!("read file task failed: {e}")))?
     }
 
-    async fn read_file_buffer(&self, path: &str, extra_root: Option<&Path>) -> Result<Option<Vec<u8>>, AppError> {
+    async fn read_file_buffer(&self, path: &str, extra_root: Option<&Path>) -> Result<Option<Vec<u8>>, FileError> {
         if has_traversal(path) {
-            return Err(AppError::BadRequest(format!(
+            return Err(FileError::BadRequest(format!(
                 "path '{}' contains invalid traversal patterns",
                 path
             )));
@@ -664,12 +664,12 @@ impl crate::traits::IFileService for FileService {
         let canonical = match validate_path_with_extra_root(path, &roots, extra_root) {
             Ok(c) => c,
             Err(err) => {
-                if matches!(err, AppError::BadRequest(_))
+                if matches!(err, FileError::BadRequest(_))
                     && validate_path_for_write(path, &self.allowed_roots_with_extra(extra_root)).is_ok()
                 {
                     return Ok(None);
                 }
-                if matches!(err, AppError::BadRequest(_)) && self.path_uses_allowed_root(Path::new(path), extra_root) {
+                if matches!(err, FileError::BadRequest(_)) && self.path_uses_allowed_root(Path::new(path), extra_root) {
                     return Ok(None);
                 }
                 return Err(err);
@@ -678,12 +678,12 @@ impl crate::traits::IFileService for FileService {
 
         tokio::task::spawn_blocking(move || read_file_buffer_sync(&canonical))
             .await
-            .map_err(|e| AppError::Internal(format!("read file buffer task failed: {e}")))?
+            .map_err(|e| FileError::Internal(format!("read file buffer task failed: {e}")))?
     }
 
-    async fn write_file(&self, path: &str, data: &[u8], workspace: &str) -> Result<bool, AppError> {
+    async fn write_file(&self, path: &str, data: &[u8], workspace: &str) -> Result<bool, FileError> {
         if has_traversal(path) {
-            return Err(AppError::BadRequest(format!(
+            return Err(FileError::BadRequest(format!(
                 "path '{}' contains invalid traversal patterns",
                 path
             )));
@@ -696,7 +696,7 @@ impl crate::traits::IFileService for FileService {
         let data_owned = data.to_vec();
         tokio::task::spawn_blocking(move || write_file_sync(&path_owned, &data_owned))
             .await
-            .map_err(|e| AppError::Internal(format!("write file task failed: {e}")))??;
+            .map_err(|e| FileError::Internal(format!("write file task failed: {e}")))??;
 
         // Compute relative path from workspace
         let workspace_path = Path::new(workspace);
@@ -733,7 +733,7 @@ impl crate::traits::IFileService for FileService {
         file_paths: &[String],
         workspace: &str,
         source_root: Option<&str>,
-    ) -> Result<CopyResult, AppError> {
+    ) -> Result<CopyResult, FileError> {
         let roots = self.allowed_roots_refs();
         let ws_canonical = validate_path(workspace, &roots)?;
 
@@ -780,12 +780,12 @@ impl crate::traits::IFileService for FileService {
             })
         })
         .await
-        .map_err(|e| AppError::Internal(format!("copy task failed: {e}")))?
+        .map_err(|e| FileError::Internal(format!("copy task failed: {e}")))?
     }
 
-    async fn remove_entry(&self, path: &str, workspace: &str) -> Result<(), AppError> {
+    async fn remove_entry(&self, path: &str, workspace: &str) -> Result<(), FileError> {
         if has_traversal(path) {
-            return Err(AppError::BadRequest(format!(
+            return Err(FileError::BadRequest(format!(
                 "path '{}' contains invalid traversal patterns",
                 path
             )));
@@ -797,7 +797,7 @@ impl crate::traits::IFileService for FileService {
         let path_owned = canonical.clone();
         tokio::task::spawn_blocking(move || remove_entry_sync(&path_owned))
             .await
-            .map_err(|e| AppError::Internal(format!("remove entry task failed: {e}")))??;
+            .map_err(|e| FileError::Internal(format!("remove entry task failed: {e}")))??;
 
         // Compute relative path from workspace
         let workspace_path = Path::new(workspace);
@@ -827,16 +827,16 @@ impl crate::traits::IFileService for FileService {
         Ok(())
     }
 
-    async fn rename_entry(&self, path: &str, new_name: &str) -> Result<String, AppError> {
+    async fn rename_entry(&self, path: &str, new_name: &str) -> Result<String, FileError> {
         if has_traversal(path) {
-            return Err(AppError::BadRequest(format!(
+            return Err(FileError::BadRequest(format!(
                 "path '{}' contains invalid traversal patterns",
                 path
             )));
         }
 
         if new_name.contains('/') || new_name.contains('\\') {
-            return Err(AppError::BadRequest(format!(
+            return Err(FileError::BadRequest(format!(
                 "new name '{}' must not contain path separators",
                 new_name
             )));
@@ -849,21 +849,21 @@ impl crate::traits::IFileService for FileService {
         let path_owned = canonical;
         let new_path: PathBuf = tokio::task::spawn_blocking(move || rename_entry_sync(&path_owned, &new_name_owned))
             .await
-            .map_err(|e| AppError::Internal(format!("rename entry task failed: {e}")))??;
+            .map_err(|e| FileError::Internal(format!("rename entry task failed: {e}")))??;
 
         Ok(new_path.to_string_lossy().into_owned())
     }
 
-    async fn create_temp_file(&self, file_name: &str) -> Result<String, AppError> {
+    async fn create_temp_file(&self, file_name: &str) -> Result<String, FileError> {
         if has_traversal(file_name) {
-            return Err(AppError::BadRequest(format!(
+            return Err(FileError::BadRequest(format!(
                 "file name '{}' contains invalid traversal patterns",
                 file_name
             )));
         }
 
         if file_name.contains('/') || file_name.contains('\\') {
-            return Err(AppError::BadRequest(format!(
+            return Err(FileError::BadRequest(format!(
                 "file name '{}' must not contain path separators",
                 file_name
             )));
@@ -874,16 +874,16 @@ impl crate::traits::IFileService for FileService {
         tokio::task::spawn_blocking(move || {
             let tmp_dir = std::env::temp_dir().join("aionui");
             std::fs::create_dir_all(&tmp_dir)
-                .map_err(|e| AppError::Internal(format!("cannot create temp directory: {e}")))?;
+                .map_err(|e| FileError::Internal(format!("cannot create temp directory: {e}")))?;
 
             let file_path = tmp_dir.join(&name);
             std::fs::File::create(&file_path)
-                .map_err(|e| AppError::Internal(format!("cannot create temp file '{}': {e}", file_path.display())))?;
+                .map_err(|e| FileError::Internal(format!("cannot create temp file '{}': {e}", file_path.display())))?;
 
             Ok(file_path.to_string_lossy().into_owned())
         })
         .await
-        .map_err(|e| AppError::Internal(format!("create temp file task failed: {e}")))?
+        .map_err(|e| FileError::Internal(format!("create temp file task failed: {e}")))?
     }
 
     async fn create_upload_file(
@@ -891,18 +891,18 @@ impl crate::traits::IFileService for FileService {
         file_name: &str,
         data: &[u8],
         conversation_id: Option<&str>,
-    ) -> Result<String, AppError> {
+    ) -> Result<String, FileError> {
         if file_name.is_empty() {
-            return Err(AppError::BadRequest("file name must not be empty".to_owned()));
+            return Err(FileError::BadRequest("file name must not be empty".to_owned()));
         }
         if has_traversal(file_name) {
-            return Err(AppError::BadRequest(format!(
+            return Err(FileError::BadRequest(format!(
                 "file name '{}' contains invalid traversal patterns",
                 file_name
             )));
         }
         if file_name.contains('/') || file_name.contains('\\') {
-            return Err(AppError::BadRequest(format!(
+            return Err(FileError::BadRequest(format!(
                 "file name '{}' must not contain path separators",
                 file_name
             )));
@@ -912,7 +912,7 @@ impl crate::traits::IFileService for FileService {
         let conv_id = match conversation_id {
             Some(id) if !id.is_empty() => {
                 if has_traversal(id) || id.contains('/') || id.contains('\\') {
-                    return Err(AppError::BadRequest(format!(
+                    return Err(FileError::BadRequest(format!(
                         "conversation id '{}' contains invalid characters",
                         id
                     )));
@@ -933,7 +933,7 @@ impl crate::traits::IFileService for FileService {
                 dir = dir.join("general");
             }
             std::fs::create_dir_all(&dir)
-                .map_err(|e| AppError::Internal(format!("cannot create upload directory: {e}")))?;
+                .map_err(|e| FileError::Internal(format!("cannot create upload directory: {e}")))?;
 
             let (base, ext) = split_base_ext(&name);
             let mut candidate = name.clone();
@@ -947,13 +947,13 @@ impl crate::traits::IFileService for FileService {
                 {
                     Ok(mut f) => {
                         f.write_all(&bytes).map_err(|e| {
-                            AppError::Internal(format!("cannot write upload file '{}': {e}", file_path.display()))
+                            FileError::Internal(format!("cannot write upload file '{}': {e}", file_path.display()))
                         })?;
                         return Ok(file_path.to_string_lossy().into_owned());
                     }
                     Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                         if counter > 1000 {
-                            return Err(AppError::Internal(format!(
+                            return Err(FileError::Internal(format!(
                                 "too many name collisions for upload file '{}'",
                                 name
                             )));
@@ -962,7 +962,7 @@ impl crate::traits::IFileService for FileService {
                         counter += 1;
                     }
                     Err(e) => {
-                        return Err(AppError::Internal(format!(
+                        return Err(FileError::Internal(format!(
                             "cannot write upload file '{}': {e}",
                             file_path.display()
                         )));
@@ -971,12 +971,12 @@ impl crate::traits::IFileService for FileService {
             }
         })
         .await
-        .map_err(|e| AppError::Internal(format!("create upload file task failed: {e}")))?
+        .map_err(|e| FileError::Internal(format!("create upload file task failed: {e}")))?
     }
 
-    async fn get_image_base64(&self, path: &str, extra_root: Option<&Path>) -> Result<String, AppError> {
+    async fn get_image_base64(&self, path: &str, extra_root: Option<&Path>) -> Result<String, FileError> {
         if has_traversal(path) {
-            return Err(AppError::BadRequest(format!(
+            return Err(FileError::BadRequest(format!(
                 "path '{}' contains invalid traversal patterns",
                 path
             )));
@@ -987,7 +987,7 @@ impl crate::traits::IFileService for FileService {
 
         tokio::task::spawn_blocking(move || get_image_base64_sync(&canonical))
             .await
-            .map_err(|e| AppError::Internal(format!("image base64 task failed: {e}")))?
+            .map_err(|e| FileError::Internal(format!("image base64 task failed: {e}")))?
     }
 
     async fn fetch_remote_image(&self, url: &str) -> String {
@@ -1069,7 +1069,7 @@ impl crate::traits::IFileService for FileService {
         path: &str,
         entries: Vec<ZipEntry>,
         request_id: Option<String>,
-    ) -> Result<bool, AppError> {
+    ) -> Result<bool, FileError> {
         // Validate output path is within the sandbox
         let roots = self.allowed_roots_refs();
         let output = validate_path_for_write(path, &roots)?;
@@ -1089,7 +1089,7 @@ impl crate::traits::IFileService for FileService {
 
         let result = tokio::task::spawn_blocking(move || create_zip_sync(&output, &entries, &cancelled))
             .await
-            .map_err(|e| AppError::Internal(format!("ZIP creation task failed: {e}")))??;
+            .map_err(|e| FileError::Internal(format!("ZIP creation task failed: {e}")))??;
 
         // Clean up cancellation token after task completes
         if let Some(ref id) = request_id {
@@ -1345,7 +1345,7 @@ mod tests {
         fs::create_dir(&folder).unwrap();
 
         let err = read_file_sync(&folder).unwrap_err();
-        assert!(matches!(err, AppError::BadRequest(_)));
+        assert!(matches!(err, FileError::BadRequest(_)));
         assert!(err.to_string().contains("is a directory"));
     }
 
@@ -1911,9 +1911,9 @@ mod tests {
         use crate::traits::IFileService;
         let svc = make_service();
         let result = svc.create_upload_file("nested/file.png", b"x", None).await;
-        assert!(matches!(result, Err(AppError::BadRequest(_))));
+        assert!(matches!(result, Err(FileError::BadRequest(_))));
         let result = svc.create_upload_file("nested\\file.png", b"x", None).await;
-        assert!(matches!(result, Err(AppError::BadRequest(_))));
+        assert!(matches!(result, Err(FileError::BadRequest(_))));
     }
 
     #[tokio::test]
@@ -1921,7 +1921,7 @@ mod tests {
         use crate::traits::IFileService;
         let svc = make_service();
         let result = svc.create_upload_file("..", b"x", None).await;
-        assert!(matches!(result, Err(AppError::BadRequest(_))));
+        assert!(matches!(result, Err(FileError::BadRequest(_))));
     }
 
     #[tokio::test]
@@ -1929,7 +1929,7 @@ mod tests {
         use crate::traits::IFileService;
         let svc = make_service();
         let result = svc.create_upload_file("", b"x", None).await;
-        assert!(matches!(result, Err(AppError::BadRequest(_))));
+        assert!(matches!(result, Err(FileError::BadRequest(_))));
     }
 
     #[tokio::test]
@@ -1937,9 +1937,9 @@ mod tests {
         use crate::traits::IFileService;
         let svc = make_service();
         let result = svc.create_upload_file("good.png", b"x", Some("../escape")).await;
-        assert!(matches!(result, Err(AppError::BadRequest(_))));
+        assert!(matches!(result, Err(FileError::BadRequest(_))));
         let result = svc.create_upload_file("good.png", b"x", Some("nested/id")).await;
-        assert!(matches!(result, Err(AppError::BadRequest(_))));
+        assert!(matches!(result, Err(FileError::BadRequest(_))));
     }
 
     // ---- name collision behaviour -----------------------------------------

--- a/crates/aionui-file/src/snapshot_service/helpers.rs
+++ b/crates/aionui-file/src/snapshot_service/helpers.rs
@@ -7,7 +7,9 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
-use aionui_common::{AppError, FileChangeOperation};
+use aionui_common::FileChangeOperation;
+
+use crate::error::FileError;
 use git2::{IndexAddOption, Repository, Signature, Status, StatusOptions};
 
 use crate::types::{CompareResult, FileChangeInfo, SnapshotInfo, SnapshotMode};
@@ -74,9 +76,9 @@ pub(super) fn temp_repo_path(workspace: &str) -> PathBuf {
 }
 
 /// Open the git repository for a workspace state.
-pub(super) fn open_repo(state: &WorkspaceState) -> Result<Repository, AppError> {
+pub(super) fn open_repo(state: &WorkspaceState) -> Result<Repository, FileError> {
     Repository::open(&state.repo_path).map_err(|e| {
-        AppError::Internal(format!(
+        FileError::Internal(format!(
             "Failed to open git repo at {}: {}",
             state.repo_path.display(),
             e
@@ -90,11 +92,11 @@ pub(super) fn open_repo(state: &WorkspaceState) -> Result<Repository, AppError> 
 /// 2. Sets `core.worktree` to point at the real workspace.
 /// 3. Writes exclude rules to `.git/info/exclude`.
 /// 4. Adds all workspace files and creates an initial commit as the baseline.
-pub(super) fn init_snapshot_repo(workspace: &Path, temp_dir: &Path) -> Result<(), AppError> {
+pub(super) fn init_snapshot_repo(workspace: &Path, temp_dir: &Path) -> Result<(), FileError> {
     // Clean up any leftover directory from a previous run with the same hash
     if temp_dir.exists() {
         std::fs::remove_dir_all(temp_dir).map_err(|e| {
-            AppError::Internal(format!(
+            FileError::Internal(format!(
                 "Failed to clean up existing snapshot dir {}: {}",
                 temp_dir.display(),
                 e
@@ -102,55 +104,55 @@ pub(super) fn init_snapshot_repo(workspace: &Path, temp_dir: &Path) -> Result<()
         })?;
     }
     std::fs::create_dir_all(temp_dir)
-        .map_err(|e| AppError::Internal(format!("Failed to create snapshot dir {}: {}", temp_dir.display(), e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to create snapshot dir {}: {}", temp_dir.display(), e)))?;
 
     // Init a standard repo (creates .git/ inside temp_dir)
     let repo = Repository::init(temp_dir)
-        .map_err(|e| AppError::Internal(format!("Failed to init snapshot repo at {}: {}", temp_dir.display(), e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to init snapshot repo at {}: {}", temp_dir.display(), e)))?;
 
     // Set workdir to the actual workspace (in-memory)
     repo.set_workdir(workspace, false)
-        .map_err(|e| AppError::Internal(format!("Failed to set workdir to {}: {}", workspace.display(), e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to set workdir to {}: {}", workspace.display(), e)))?;
 
     // Persist core.worktree in config so future opens resolve the workdir
     let mut config = repo
         .config()
-        .map_err(|e| AppError::Internal(format!("Failed to open repo config: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to open repo config: {}", e)))?;
     let ws_str = workspace.to_string_lossy();
     config
         .set_str("core.worktree", &ws_str)
-        .map_err(|e| AppError::Internal(format!("Failed to set core.worktree to {}: {}", ws_str, e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to set core.worktree to {}: {}", ws_str, e)))?;
 
     // Write exclude rules to .git/info/exclude (avoids polluting the workspace)
     let git_dir = repo.path(); // .git/ directory
     let info_dir = git_dir.join("info");
     std::fs::create_dir_all(&info_dir)
-        .map_err(|e| AppError::Internal(format!("Failed to create info dir {}: {}", info_dir.display(), e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to create info dir {}: {}", info_dir.display(), e)))?;
     std::fs::write(info_dir.join("exclude"), SNAPSHOT_EXCLUDE_RULES)
-        .map_err(|e| AppError::Internal(format!("Failed to write exclude rules: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to write exclude rules: {}", e)))?;
 
     // Stage all workspace files
     let mut index = repo
         .index()
-        .map_err(|e| AppError::Internal(format!("Failed to get index: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to get index: {}", e)))?;
     index
         .add_all(["*"].iter(), IndexAddOption::DEFAULT, None)
-        .map_err(|e| AppError::Internal(format!("Failed to add files to index: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to add files to index: {}", e)))?;
     index
         .write()
-        .map_err(|e| AppError::Internal(format!("Failed to write index: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to write index: {}", e)))?;
 
     // Create initial commit
     let tree_oid = index
         .write_tree()
-        .map_err(|e| AppError::Internal(format!("Failed to write tree: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to write tree: {}", e)))?;
     let tree = repo
         .find_tree(tree_oid)
-        .map_err(|e| AppError::Internal(format!("Failed to find tree: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to find tree: {}", e)))?;
     let sig = Signature::now(SNAPSHOT_SIG_NAME, SNAPSHOT_SIG_EMAIL)
-        .map_err(|e| AppError::Internal(format!("Failed to create signature: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to create signature: {}", e)))?;
     repo.commit(Some("HEAD"), &sig, &sig, SNAPSHOT_INITIAL_MSG, &tree, &[])
-        .map_err(|e| AppError::Internal(format!("Failed to create initial commit: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to create initial commit: {}", e)))?;
 
     Ok(())
 }
@@ -197,7 +199,7 @@ pub(super) fn worktree_operation(status: Status) -> Option<FileChangeOperation> 
 }
 
 /// Parse git2 statuses into staged and unstaged change lists.
-pub(super) fn parse_statuses(repo: &Repository, workspace: &Path) -> Result<CompareResult, AppError> {
+pub(super) fn parse_statuses(repo: &Repository, workspace: &Path) -> Result<CompareResult, FileError> {
     let mut opts = StatusOptions::new();
     opts.include_untracked(true)
         .recurse_untracked_dirs(true)
@@ -205,7 +207,7 @@ pub(super) fn parse_statuses(repo: &Repository, workspace: &Path) -> Result<Comp
 
     let statuses = repo
         .statuses(Some(&mut opts))
-        .map_err(|e| AppError::Internal(format!("Failed to get git status: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to get git status: {}", e)))?;
 
     let ws_str = workspace.to_string_lossy();
     let mut staged = Vec::new();
@@ -240,17 +242,17 @@ pub(super) fn parse_statuses(repo: &Repository, workspace: &Path) -> Result<Comp
 
 /// Read a file's content from HEAD.
 /// Returns `None` if the file is not tracked or the repo has no commits.
-pub(super) fn read_baseline(repo: &Repository, rel_path: &str) -> Result<Option<String>, AppError> {
+pub(super) fn read_baseline(repo: &Repository, rel_path: &str) -> Result<Option<String>, FileError> {
     let head = match repo.head() {
         Ok(h) => h,
         Err(_) => return Ok(None),
     };
     let commit = head
         .peel_to_commit()
-        .map_err(|e| AppError::Internal(format!("Failed to peel HEAD to commit: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to peel HEAD to commit: {}", e)))?;
     let tree = commit
         .tree()
-        .map_err(|e| AppError::Internal(format!("Failed to get commit tree: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to get commit tree: {}", e)))?;
 
     let entry = match tree.get_path(Path::new(rel_path)) {
         Ok(e) => e,
@@ -259,7 +261,7 @@ pub(super) fn read_baseline(repo: &Repository, rel_path: &str) -> Result<Option<
 
     let blob = repo
         .find_blob(entry.id())
-        .map_err(|e| AppError::Internal(format!("Failed to read blob: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to read blob: {}", e)))?;
 
     match std::str::from_utf8(blob.content()) {
         Ok(s) => Ok(Some(s.to_string())),
@@ -268,48 +270,48 @@ pub(super) fn read_baseline(repo: &Repository, rel_path: &str) -> Result<Option<
 }
 
 /// Canonicalize a workspace path and validate it exists.
-pub(super) fn resolve_workspace(workspace: &str) -> Result<PathBuf, AppError> {
+pub(super) fn resolve_workspace(workspace: &str) -> Result<PathBuf, FileError> {
     let path = Path::new(workspace);
     if !path.exists() {
-        return Err(AppError::NotFound(format!("Workspace not found: {}", workspace)));
+        return Err(FileError::NotFound(format!("Workspace not found: {}", workspace)));
     }
     std::fs::canonicalize(path)
-        .map_err(|e| AppError::Internal(format!("Failed to canonicalize workspace path {}: {}", workspace, e)))
+        .map_err(|e| FileError::Internal(format!("Failed to canonicalize workspace path {}: {}", workspace, e)))
 }
 
 /// Stage all changes including deletions.
 ///
 /// `index.add_all` with `DEFAULT` only handles new/modified files.
 /// Deleted files must be explicitly removed from the index.
-pub(super) fn stage_all_with_deletions(repo: &Repository) -> Result<(), AppError> {
+pub(super) fn stage_all_with_deletions(repo: &Repository) -> Result<(), FileError> {
     let mut index = repo
         .index()
-        .map_err(|e| AppError::Internal(format!("Failed to get index: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to get index: {}", e)))?;
 
     // Stage new and modified files
     index
         .add_all(["*"].iter(), IndexAddOption::DEFAULT, None)
-        .map_err(|e| AppError::Internal(format!("Failed to stage all files: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to stage all files: {}", e)))?;
 
     // Find and remove deleted files from the index
     let mut opts = StatusOptions::new();
     opts.include_untracked(false).include_ignored(false);
     let statuses = repo
         .statuses(Some(&mut opts))
-        .map_err(|e| AppError::Internal(format!("Failed to get status: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to get status: {}", e)))?;
     for entry in statuses.iter() {
         if entry.status().intersects(Status::WT_DELETED)
             && let Some(path) = entry.path()
         {
-            index
-                .remove_path(Path::new(path))
-                .map_err(|e| AppError::Internal(format!("Failed to remove deleted file {} from index: {}", path, e)))?;
+            index.remove_path(Path::new(path)).map_err(|e| {
+                FileError::Internal(format!("Failed to remove deleted file {} from index: {}", path, e))
+            })?;
         }
     }
 
     index
         .write()
-        .map_err(|e| AppError::Internal(format!("Failed to write index: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to write index: {}", e)))?;
     Ok(())
 }
 
@@ -317,57 +319,57 @@ pub(super) fn stage_all_with_deletions(repo: &Repository) -> Result<(), AppError
 ///
 /// For existing files, adds to the index. For deleted files, removes from
 /// the index (equivalent to `git add <deleted-file>`).
-pub(super) fn stage_single_file(repo: &Repository, rel_path: &str) -> Result<(), AppError> {
+pub(super) fn stage_single_file(repo: &Repository, rel_path: &str) -> Result<(), FileError> {
     let workdir = repo
         .workdir()
-        .ok_or_else(|| AppError::Internal("Repository has no workdir".into()))?;
+        .ok_or_else(|| FileError::Internal("Repository has no workdir".into()))?;
     let abs_path = workdir.join(rel_path);
 
     let mut index = repo
         .index()
-        .map_err(|e| AppError::Internal(format!("Failed to get index: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to get index: {}", e)))?;
 
     if abs_path.exists() {
         index
             .add_path(Path::new(rel_path))
-            .map_err(|e| AppError::Internal(format!("Failed to stage file {}: {}", rel_path, e)))?;
+            .map_err(|e| FileError::Internal(format!("Failed to stage file {}: {}", rel_path, e)))?;
     } else {
         // File was deleted from disk; remove from index
         index
             .remove_path(Path::new(rel_path))
-            .map_err(|e| AppError::Internal(format!("Failed to stage deleted file {}: {}", rel_path, e)))?;
+            .map_err(|e| FileError::Internal(format!("Failed to stage deleted file {}: {}", rel_path, e)))?;
     }
 
     index
         .write()
-        .map_err(|e| AppError::Internal(format!("Failed to write index: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to write index: {}", e)))?;
     Ok(())
 }
 
 /// Unstage a single file (reset it in the index to match HEAD).
-pub(super) fn unstage_single_file(repo: &Repository, rel_path: &str) -> Result<(), AppError> {
+pub(super) fn unstage_single_file(repo: &Repository, rel_path: &str) -> Result<(), FileError> {
     let head = repo
         .head()
-        .map_err(|e| AppError::Internal(format!("Failed to get HEAD: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to get HEAD: {}", e)))?;
     let commit = head
         .peel_to_commit()
-        .map_err(|e| AppError::Internal(format!("Failed to peel HEAD: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to peel HEAD: {}", e)))?;
     // reset_default expects a commit-ish object, not a tree
     repo.reset_default(Some(commit.as_object()), [rel_path])
-        .map_err(|e| AppError::Internal(format!("Failed to unstage file {}: {}", rel_path, e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to unstage file {}: {}", rel_path, e)))?;
     Ok(())
 }
 
 /// Unstage all staged changes (mixed reset to HEAD).
-pub(super) fn unstage_all_files(repo: &Repository) -> Result<(), AppError> {
+pub(super) fn unstage_all_files(repo: &Repository) -> Result<(), FileError> {
     let head = repo
         .head()
-        .map_err(|e| AppError::Internal(format!("Failed to get HEAD: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to get HEAD: {}", e)))?;
     let commit = head
         .peel_to_commit()
-        .map_err(|e| AppError::Internal(format!("Failed to peel HEAD: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to peel HEAD: {}", e)))?;
     repo.reset(commit.as_object(), git2::ResetType::Mixed, None)
-        .map_err(|e| AppError::Internal(format!("Failed to unstage all: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to unstage all: {}", e)))?;
     Ok(())
 }
 
@@ -381,14 +383,14 @@ pub(super) fn discard_single_file(
     workspace: &Path,
     rel_path: &str,
     operation: FileChangeOperation,
-) -> Result<(), AppError> {
+) -> Result<(), FileError> {
     match operation {
         FileChangeOperation::Create => {
             // New/untracked file: just delete it
             let abs_path = workspace.join(rel_path);
             if abs_path.exists() {
                 std::fs::remove_file(&abs_path)
-                    .map_err(|e| AppError::Internal(format!("Failed to delete file {}: {}", abs_path.display(), e)))?;
+                    .map_err(|e| FileError::Internal(format!("Failed to delete file {}: {}", abs_path.display(), e)))?;
             }
             Ok(())
         }
@@ -409,7 +411,7 @@ pub(super) fn reset_single_file(
     workspace: &Path,
     rel_path: &str,
     operation: FileChangeOperation,
-) -> Result<(), AppError> {
+) -> Result<(), FileError> {
     // Step 1: unstage (ignore errors for files not in index)
     let _ = unstage_single_file(repo, rel_path);
 
@@ -418,27 +420,27 @@ pub(super) fn reset_single_file(
 }
 
 /// Checkout a single file from HEAD, restoring it in the working tree.
-fn checkout_path_from_head(repo: &Repository, rel_path: &str) -> Result<(), AppError> {
+fn checkout_path_from_head(repo: &Repository, rel_path: &str) -> Result<(), FileError> {
     let mut cb = git2::build::CheckoutBuilder::new();
     cb.force().path(rel_path);
 
     repo.checkout_head(Some(&mut cb))
-        .map_err(|e| AppError::Internal(format!("Failed to checkout {} from HEAD: {}", rel_path, e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to checkout {} from HEAD: {}", rel_path, e)))?;
     Ok(())
 }
 
 /// List all branch names in the repository.
-pub(super) fn list_branches(repo: &Repository) -> Result<Vec<String>, AppError> {
+pub(super) fn list_branches(repo: &Repository) -> Result<Vec<String>, FileError> {
     let branches = repo
         .branches(Some(git2::BranchType::Local))
-        .map_err(|e| AppError::Internal(format!("Failed to list branches: {}", e)))?;
+        .map_err(|e| FileError::Internal(format!("Failed to list branches: {}", e)))?;
 
     let mut names = Vec::new();
     for branch_result in branches {
-        let (branch, _) = branch_result.map_err(|e| AppError::Internal(format!("Failed to read branch: {}", e)))?;
+        let (branch, _) = branch_result.map_err(|e| FileError::Internal(format!("Failed to read branch: {}", e)))?;
         if let Some(name) = branch
             .name()
-            .map_err(|e| AppError::Internal(format!("Failed to get branch name: {}", e)))?
+            .map_err(|e| FileError::Internal(format!("Failed to get branch name: {}", e)))?
         {
             names.push(name.to_string());
         }
@@ -536,7 +538,7 @@ mod tests {
     #[test]
     fn resolve_workspace_not_found() {
         let err = resolve_workspace("/nonexistent/path/xyz123").unwrap_err();
-        assert!(matches!(err, AppError::NotFound(_)));
+        assert!(matches!(err, FileError::NotFound(_)));
     }
 
     #[test]

--- a/crates/aionui-file/src/snapshot_service/mod.rs
+++ b/crates/aionui-file/src/snapshot_service/mod.rs
@@ -7,7 +7,9 @@
 
 mod helpers;
 
-use aionui_common::{AppError, FileChangeOperation};
+use aionui_common::FileChangeOperation;
+
+use crate::error::FileError;
 use dashmap::DashMap;
 use git2::Repository;
 
@@ -83,11 +85,11 @@ impl SnapshotService {
 // Helper: get workspace state or return error
 // ---------------------------------------------------------------------------
 
-fn get_state(workspaces: &DashMap<String, WorkspaceState>, workspace: &str) -> Result<WorkspaceState, AppError> {
+fn get_state(workspaces: &DashMap<String, WorkspaceState>, workspace: &str) -> Result<WorkspaceState, FileError> {
     workspaces
         .get(workspace)
         .map(|r| r.clone())
-        .ok_or_else(|| AppError::BadRequest(format!("Workspace not initialized: {}", workspace)))
+        .ok_or_else(|| FileError::BadRequest(format!("Workspace not initialized: {}", workspace)))
 }
 
 // ---------------------------------------------------------------------------
@@ -96,7 +98,7 @@ fn get_state(workspaces: &DashMap<String, WorkspaceState>, workspace: &str) -> R
 
 #[async_trait::async_trait]
 impl crate::traits::ISnapshotService for SnapshotService {
-    async fn init(&self, workspace: &str) -> Result<SnapshotInfo, AppError> {
+    async fn init(&self, workspace: &str) -> Result<SnapshotInfo, FileError> {
         let ws = workspace.to_owned();
 
         // Check if already initialized
@@ -107,7 +109,7 @@ impl crate::traits::ISnapshotService for SnapshotService {
                 Ok(build_info(st.mode, &repo))
             })
             .await
-            .map_err(|e| AppError::Internal(format!("Blocking task failed: {}", e)))?;
+            .map_err(|e| FileError::Internal(format!("Blocking task failed: {}", e)))?;
         }
 
         let ws_clone = ws.clone();
@@ -131,20 +133,20 @@ impl crate::traits::ISnapshotService for SnapshotService {
             };
 
             let repo = Repository::open(&repo_path)
-                .map_err(|e| AppError::Internal(format!("Failed to open repo after init: {}", e)))?;
+                .map_err(|e| FileError::Internal(format!("Failed to open repo after init: {}", e)))?;
             let info = build_info(mode, &repo);
 
-            Ok::<(WorkspaceState, SnapshotInfo), AppError>((state, info))
+            Ok::<(WorkspaceState, SnapshotInfo), FileError>((state, info))
         })
         .await
-        .map_err(|e| AppError::Internal(format!("Blocking task failed: {}", e)))??;
+        .map_err(|e| FileError::Internal(format!("Blocking task failed: {}", e)))??;
 
         let (state, info) = result;
         self.workspaces.insert(ws, state);
         Ok(info)
     }
 
-    async fn get_info(&self, workspace: &str) -> Result<SnapshotInfo, AppError> {
+    async fn get_info(&self, workspace: &str) -> Result<SnapshotInfo, FileError> {
         let state = get_state(&self.workspaces, workspace)?;
 
         tokio::task::spawn_blocking(move || {
@@ -152,10 +154,10 @@ impl crate::traits::ISnapshotService for SnapshotService {
             Ok(build_info(state.mode, &repo))
         })
         .await
-        .map_err(|e| AppError::Internal(format!("Blocking task failed: {}", e)))?
+        .map_err(|e| FileError::Internal(format!("Blocking task failed: {}", e)))?
     }
 
-    async fn compare(&self, workspace: &str) -> Result<CompareResult, AppError> {
+    async fn compare(&self, workspace: &str) -> Result<CompareResult, FileError> {
         let state = get_state(&self.workspaces, workspace)?;
 
         tokio::task::spawn_blocking(move || {
@@ -163,10 +165,10 @@ impl crate::traits::ISnapshotService for SnapshotService {
             parse_statuses(&repo, &state.workspace_path)
         })
         .await
-        .map_err(|e| AppError::Internal(format!("Blocking task failed: {}", e)))?
+        .map_err(|e| FileError::Internal(format!("Blocking task failed: {}", e)))?
     }
 
-    async fn get_baseline_content(&self, workspace: &str, file_path: &str) -> Result<Option<String>, AppError> {
+    async fn get_baseline_content(&self, workspace: &str, file_path: &str) -> Result<Option<String>, FileError> {
         let state = get_state(&self.workspaces, workspace)?;
         let rel = file_path.to_owned();
 
@@ -175,10 +177,10 @@ impl crate::traits::ISnapshotService for SnapshotService {
             read_baseline(&repo, &rel)
         })
         .await
-        .map_err(|e| AppError::Internal(format!("Blocking task failed: {}", e)))?
+        .map_err(|e| FileError::Internal(format!("Blocking task failed: {}", e)))?
     }
 
-    async fn stage_file(&self, workspace: &str, file_path: &str) -> Result<(), AppError> {
+    async fn stage_file(&self, workspace: &str, file_path: &str) -> Result<(), FileError> {
         let state = get_state(&self.workspaces, workspace)?;
         let fp = file_path.to_owned();
 
@@ -187,10 +189,10 @@ impl crate::traits::ISnapshotService for SnapshotService {
             stage_single_file(&repo, &fp)
         })
         .await
-        .map_err(|e| AppError::Internal(format!("Blocking task failed: {}", e)))?
+        .map_err(|e| FileError::Internal(format!("Blocking task failed: {}", e)))?
     }
 
-    async fn stage_all(&self, workspace: &str) -> Result<(), AppError> {
+    async fn stage_all(&self, workspace: &str) -> Result<(), FileError> {
         let state = get_state(&self.workspaces, workspace)?;
 
         tokio::task::spawn_blocking(move || {
@@ -198,10 +200,10 @@ impl crate::traits::ISnapshotService for SnapshotService {
             stage_all_with_deletions(&repo)
         })
         .await
-        .map_err(|e| AppError::Internal(format!("Blocking task failed: {}", e)))?
+        .map_err(|e| FileError::Internal(format!("Blocking task failed: {}", e)))?
     }
 
-    async fn unstage_file(&self, workspace: &str, file_path: &str) -> Result<(), AppError> {
+    async fn unstage_file(&self, workspace: &str, file_path: &str) -> Result<(), FileError> {
         let state = get_state(&self.workspaces, workspace)?;
         let fp = file_path.to_owned();
 
@@ -210,10 +212,10 @@ impl crate::traits::ISnapshotService for SnapshotService {
             unstage_single_file(&repo, &fp)
         })
         .await
-        .map_err(|e| AppError::Internal(format!("Blocking task failed: {}", e)))?
+        .map_err(|e| FileError::Internal(format!("Blocking task failed: {}", e)))?
     }
 
-    async fn unstage_all(&self, workspace: &str) -> Result<(), AppError> {
+    async fn unstage_all(&self, workspace: &str) -> Result<(), FileError> {
         let state = get_state(&self.workspaces, workspace)?;
 
         tokio::task::spawn_blocking(move || {
@@ -221,7 +223,7 @@ impl crate::traits::ISnapshotService for SnapshotService {
             unstage_all_files(&repo)
         })
         .await
-        .map_err(|e| AppError::Internal(format!("Blocking task failed: {}", e)))?
+        .map_err(|e| FileError::Internal(format!("Blocking task failed: {}", e)))?
     }
 
     async fn discard_file(
@@ -229,7 +231,7 @@ impl crate::traits::ISnapshotService for SnapshotService {
         workspace: &str,
         file_path: &str,
         operation: FileChangeOperation,
-    ) -> Result<(), AppError> {
+    ) -> Result<(), FileError> {
         let state = get_state(&self.workspaces, workspace)?;
         let fp = file_path.to_owned();
 
@@ -238,7 +240,7 @@ impl crate::traits::ISnapshotService for SnapshotService {
             discard_single_file(&repo, &state.workspace_path, &fp, operation)
         })
         .await
-        .map_err(|e| AppError::Internal(format!("Blocking task failed: {}", e)))?
+        .map_err(|e| FileError::Internal(format!("Blocking task failed: {}", e)))?
     }
 
     async fn reset_file(
@@ -246,7 +248,7 @@ impl crate::traits::ISnapshotService for SnapshotService {
         workspace: &str,
         file_path: &str,
         operation: FileChangeOperation,
-    ) -> Result<(), AppError> {
+    ) -> Result<(), FileError> {
         let state = get_state(&self.workspaces, workspace)?;
         let fp = file_path.to_owned();
 
@@ -255,10 +257,10 @@ impl crate::traits::ISnapshotService for SnapshotService {
             reset_single_file(&repo, &state.workspace_path, &fp, operation)
         })
         .await
-        .map_err(|e| AppError::Internal(format!("Blocking task failed: {}", e)))?
+        .map_err(|e| FileError::Internal(format!("Blocking task failed: {}", e)))?
     }
 
-    async fn get_branches(&self, workspace: &str) -> Result<Vec<String>, AppError> {
+    async fn get_branches(&self, workspace: &str) -> Result<Vec<String>, FileError> {
         let state = get_state(&self.workspaces, workspace)?;
 
         tokio::task::spawn_blocking(move || {
@@ -266,10 +268,10 @@ impl crate::traits::ISnapshotService for SnapshotService {
             list_branches(&repo)
         })
         .await
-        .map_err(|e| AppError::Internal(format!("Blocking task failed: {}", e)))?
+        .map_err(|e| FileError::Internal(format!("Blocking task failed: {}", e)))?
     }
 
-    async fn dispose(&self, workspace: &str) -> Result<(), AppError> {
+    async fn dispose(&self, workspace: &str) -> Result<(), FileError> {
         let state = match self.workspaces.remove(workspace) {
             Some((_, s)) => s,
             // Already disposed or never initialized -- idempotent
@@ -281,13 +283,13 @@ impl crate::traits::ISnapshotService for SnapshotService {
             tokio::task::spawn_blocking(move || {
                 if repo_path.exists() {
                     std::fs::remove_dir_all(&repo_path).map_err(|e| {
-                        AppError::Internal(format!("Failed to remove snapshot dir {}: {}", repo_path.display(), e))
+                        FileError::Internal(format!("Failed to remove snapshot dir {}: {}", repo_path.display(), e))
                     })?;
                 }
                 Ok(())
             })
             .await
-            .map_err(|e| AppError::Internal(format!("Blocking task failed: {}", e)))?
+            .map_err(|e| FileError::Internal(format!("Blocking task failed: {}", e)))?
         } else {
             // git-repo mode: nothing to clean up
             Ok(())

--- a/crates/aionui-file/src/traits.rs
+++ b/crates/aionui-file/src/traits.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use aionui_common::{AppError, FileChangeOperation};
+use aionui_common::FileChangeOperation;
+
+use crate::error::FileError;
 
 use crate::types::{CompareResult, CopyResult, DirOrFile, FileMetadata, SnapshotInfo, WorkspaceFlatFile, ZipEntry};
 
@@ -16,28 +18,28 @@ pub trait IFileService: Send + Sync {
 
     /// List the immediate children of `dir`, returning a tree with one level
     /// of depth. `root` is the workspace root used to compute relative paths.
-    async fn get_files_by_dir(&self, dir: &str, root: &str) -> Result<Vec<DirOrFile>, AppError>;
+    async fn get_files_by_dir(&self, dir: &str, root: &str) -> Result<Vec<DirOrFile>, FileError>;
 
     /// Recursively list all files under `root` as a flat list.
     /// Returns at most 20,000 entries.
-    async fn list_workspace_files(&self, root: &str) -> Result<Vec<WorkspaceFlatFile>, AppError>;
+    async fn list_workspace_files(&self, root: &str) -> Result<Vec<WorkspaceFlatFile>, FileError>;
 
     /// Get metadata for a single file or directory.
-    async fn get_file_metadata(&self, path: &str, extra_root: Option<&Path>) -> Result<FileMetadata, AppError>;
+    async fn get_file_metadata(&self, path: &str, extra_root: Option<&Path>) -> Result<FileMetadata, FileError>;
 
     // -- File read/write --
 
     /// Read a file as UTF-8 text. Returns `None` if the file does not exist.
     /// Files larger than 256 MB are rejected.
-    async fn read_file(&self, path: &str, extra_root: Option<&Path>) -> Result<Option<String>, AppError>;
+    async fn read_file(&self, path: &str, extra_root: Option<&Path>) -> Result<Option<String>, FileError>;
 
     /// Read a file as raw bytes. Returns `None` if the file does not exist.
     /// Files larger than 256 MB are rejected.
-    async fn read_file_buffer(&self, path: &str, extra_root: Option<&Path>) -> Result<Option<Vec<u8>>, AppError>;
+    async fn read_file_buffer(&self, path: &str, extra_root: Option<&Path>) -> Result<Option<Vec<u8>>, FileError>;
 
     /// Write `data` to `path`. On success, emits a
     /// `fileStream.contentUpdate` event with `operation = write`.
-    async fn write_file(&self, path: &str, data: &[u8], workspace: &str) -> Result<bool, AppError>;
+    async fn write_file(&self, path: &str, data: &[u8], workspace: &str) -> Result<bool, FileError>;
 
     // -- File management --
 
@@ -48,17 +50,17 @@ pub trait IFileService: Send + Sync {
         file_paths: &[String],
         workspace: &str,
         source_root: Option<&str>,
-    ) -> Result<CopyResult, AppError>;
+    ) -> Result<CopyResult, FileError>;
 
     /// Remove a file or directory (recursively). On success, emits a
     /// `fileStream.contentUpdate` event with `operation = delete`.
-    async fn remove_entry(&self, path: &str, workspace: &str) -> Result<(), AppError>;
+    async fn remove_entry(&self, path: &str, workspace: &str) -> Result<(), FileError>;
 
     /// Rename a file or directory. Returns the new absolute path.
-    async fn rename_entry(&self, path: &str, new_name: &str) -> Result<String, AppError>;
+    async fn rename_entry(&self, path: &str, new_name: &str) -> Result<String, FileError>;
 
     /// Create an empty temporary file and return its absolute path.
-    async fn create_temp_file(&self, file_name: &str) -> Result<String, AppError>;
+    async fn create_temp_file(&self, file_name: &str) -> Result<String, FileError>;
 
     /// Write `data` to a temporary file and return its absolute path.
     ///
@@ -73,13 +75,13 @@ pub trait IFileService: Send + Sync {
         file_name: &str,
         data: &[u8],
         conversation_id: Option<&str>,
-    ) -> Result<String, AppError>;
+    ) -> Result<String, FileError>;
 
     // -- Image processing --
 
     /// Read a local image and return a base64 Data URL
     /// (e.g. `data:image/png;base64,...`).
-    async fn get_image_base64(&self, path: &str, extra_root: Option<&Path>) -> Result<String, AppError>;
+    async fn get_image_base64(&self, path: &str, extra_root: Option<&Path>) -> Result<String, FileError>;
 
     /// Download a remote image and return a base64 Data URL.
     /// On failure, returns a placeholder SVG Data URL.
@@ -95,7 +97,7 @@ pub trait IFileService: Send + Sync {
         path: &str,
         entries: Vec<ZipEntry>,
         request_id: Option<String>,
-    ) -> Result<bool, AppError>;
+    ) -> Result<bool, FileError>;
 
     /// Cancel an in-progress ZIP operation by its `request_id`.
     /// Returns `true` if a matching operation was found and cancelled.
@@ -108,21 +110,21 @@ pub trait IFileService: Send + Sync {
 pub trait IFileWatchService: Send + Sync {
     /// Start watching a single file for changes.
     /// Emits `fileWatch.fileChanged` events on the broadcast channel.
-    async fn start_watch(&self, file_path: &str) -> Result<(), AppError>;
+    async fn start_watch(&self, file_path: &str) -> Result<(), FileError>;
 
     /// Stop watching a previously registered file.
-    async fn stop_watch(&self, file_path: &str) -> Result<(), AppError>;
+    async fn stop_watch(&self, file_path: &str) -> Result<(), FileError>;
 
     /// Stop all active file watches.
-    async fn stop_all_watches(&self) -> Result<(), AppError>;
+    async fn stop_all_watches(&self) -> Result<(), FileError>;
 
     /// Start watching a workspace directory for new Office files
     /// (.pptx, .docx, .xlsx).
     /// Emits `workspaceOfficeWatch.fileAdded` events.
-    async fn start_office_watch(&self, workspace: &str) -> Result<(), AppError>;
+    async fn start_office_watch(&self, workspace: &str) -> Result<(), FileError>;
 
     /// Stop watching a workspace directory for Office files.
-    async fn stop_office_watch(&self, workspace: &str) -> Result<(), AppError>;
+    async fn stop_office_watch(&self, workspace: &str) -> Result<(), FileError>;
 }
 
 /// Git-based workspace snapshot system for tracking file changes.
@@ -135,30 +137,30 @@ pub trait IFileWatchService: Send + Sync {
 pub trait ISnapshotService: Send + Sync {
     /// Initialize the snapshot system for a workspace.
     /// Auto-detects `git-repo` or `snapshot` mode.
-    async fn init(&self, workspace: &str) -> Result<SnapshotInfo, AppError>;
+    async fn init(&self, workspace: &str) -> Result<SnapshotInfo, FileError>;
 
     /// Get the current snapshot mode and branch info.
-    async fn get_info(&self, workspace: &str) -> Result<SnapshotInfo, AppError>;
+    async fn get_info(&self, workspace: &str) -> Result<SnapshotInfo, FileError>;
 
     /// Compare workspace state against the baseline.
     /// Returns staged and unstaged changes.
-    async fn compare(&self, workspace: &str) -> Result<CompareResult, AppError>;
+    async fn compare(&self, workspace: &str) -> Result<CompareResult, FileError>;
 
     /// Get the baseline (HEAD) content of a file.
     /// Returns `None` for new/untracked files.
-    async fn get_baseline_content(&self, workspace: &str, file_path: &str) -> Result<Option<String>, AppError>;
+    async fn get_baseline_content(&self, workspace: &str, file_path: &str) -> Result<Option<String>, FileError>;
 
     /// Stage a single file (git-repo mode only).
-    async fn stage_file(&self, workspace: &str, file_path: &str) -> Result<(), AppError>;
+    async fn stage_file(&self, workspace: &str, file_path: &str) -> Result<(), FileError>;
 
     /// Stage all changes.
-    async fn stage_all(&self, workspace: &str) -> Result<(), AppError>;
+    async fn stage_all(&self, workspace: &str) -> Result<(), FileError>;
 
     /// Unstage a single file.
-    async fn unstage_file(&self, workspace: &str, file_path: &str) -> Result<(), AppError>;
+    async fn unstage_file(&self, workspace: &str, file_path: &str) -> Result<(), FileError>;
 
     /// Unstage all staged changes.
-    async fn unstage_all(&self, workspace: &str) -> Result<(), AppError>;
+    async fn unstage_all(&self, workspace: &str) -> Result<(), FileError>;
 
     /// Discard changes to a file (restore to baseline).
     async fn discard_file(
@@ -166,7 +168,7 @@ pub trait ISnapshotService: Send + Sync {
         workspace: &str,
         file_path: &str,
         operation: FileChangeOperation,
-    ) -> Result<(), AppError>;
+    ) -> Result<(), FileError>;
 
     /// Reset a file to its baseline state.
     async fn reset_file(
@@ -174,14 +176,14 @@ pub trait ISnapshotService: Send + Sync {
         workspace: &str,
         file_path: &str,
         operation: FileChangeOperation,
-    ) -> Result<(), AppError>;
+    ) -> Result<(), FileError>;
 
     /// List git branches (git-repo mode only).
-    async fn get_branches(&self, workspace: &str) -> Result<Vec<String>, AppError>;
+    async fn get_branches(&self, workspace: &str) -> Result<Vec<String>, FileError>;
 
     /// Clean up snapshot resources.
     /// For snapshot mode, deletes the temporary git repository.
-    async fn dispose(&self, workspace: &str) -> Result<(), AppError>;
+    async fn dispose(&self, workspace: &str) -> Result<(), FileError>;
 }
 
 /// Convenience alias for an Arc-wrapped file service.

--- a/crates/aionui-file/src/watch_service.rs
+++ b/crates/aionui-file/src/watch_service.rs
@@ -7,8 +7,8 @@ use dashmap::DashMap;
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use tracing::warn;
 
+use crate::error::FileError;
 use aionui_api_types::WebSocketMessage;
-use aionui_common::AppError;
 use aionui_realtime::EventBroadcaster;
 
 use crate::types::{FileWatchEvent, OfficeFileAddedEvent};
@@ -83,7 +83,7 @@ pub struct FileWatchService {
 
 impl FileWatchService {
     /// Create a new watch service backed by the platform's recommended watcher.
-    pub fn new(broadcaster: Arc<dyn EventBroadcaster>) -> Result<Self, AppError> {
+    pub fn new(broadcaster: Arc<dyn EventBroadcaster>) -> Result<Self, FileError> {
         let watched_files: Arc<DashMap<String, ()>> = Arc::new(DashMap::new());
         let debounce: Arc<DashMap<String, Instant>> = Arc::new(DashMap::new());
 
@@ -121,7 +121,7 @@ impl FileWatchService {
                 bc.broadcast(WebSocketMessage::new("fileWatch.fileChanged", json));
             }
         })
-        .map_err(|e| AppError::Internal(format!("failed to create file watcher: {e}")))?;
+        .map_err(|e| FileError::Internal(format!("failed to create file watcher: {e}")))?;
 
         Ok(Self {
             broadcaster,
@@ -135,9 +135,9 @@ impl FileWatchService {
 
 #[async_trait::async_trait]
 impl crate::traits::IFileWatchService for FileWatchService {
-    async fn start_watch(&self, file_path: &str) -> Result<(), AppError> {
+    async fn start_watch(&self, file_path: &str) -> Result<(), FileError> {
         let canonical = std::fs::canonicalize(file_path)
-            .map_err(|e| AppError::NotFound(format!("cannot resolve path {file_path}: {e}")))?;
+            .map_err(|e| FileError::NotFound(format!("cannot resolve path {file_path}: {e}")))?;
         let key = canonical.to_string_lossy().into_owned();
 
         // Idempotent: already watching → no-op.
@@ -148,15 +148,15 @@ impl crate::traits::IFileWatchService for FileWatchService {
         let mut watcher = self
             .file_watcher
             .lock()
-            .map_err(|e| AppError::Internal(format!("file watcher lock poisoned: {e}")))?;
+            .map_err(|e| FileError::Internal(format!("file watcher lock poisoned: {e}")))?;
         watcher
             .watch(&canonical, RecursiveMode::NonRecursive)
-            .map_err(|e| AppError::Internal(format!("failed to watch {file_path}: {e}")))?;
+            .map_err(|e| FileError::Internal(format!("failed to watch {file_path}: {e}")))?;
         self.watched_files.insert(key, ());
         Ok(())
     }
 
-    async fn stop_watch(&self, file_path: &str) -> Result<(), AppError> {
+    async fn stop_watch(&self, file_path: &str) -> Result<(), FileError> {
         let canonical = std::fs::canonicalize(file_path).unwrap_or_else(|_| file_path.into());
         let key = canonical.to_string_lossy().into_owned();
 
@@ -167,18 +167,18 @@ impl crate::traits::IFileWatchService for FileWatchService {
         let mut watcher = self
             .file_watcher
             .lock()
-            .map_err(|e| AppError::Internal(format!("file watcher lock poisoned: {e}")))?;
+            .map_err(|e| FileError::Internal(format!("file watcher lock poisoned: {e}")))?;
         // Ignore unwatch errors — the file may have been deleted.
         let _ = watcher.unwatch(&canonical);
         self.debounce.remove(&key);
         Ok(())
     }
 
-    async fn stop_all_watches(&self) -> Result<(), AppError> {
+    async fn stop_all_watches(&self) -> Result<(), FileError> {
         let mut watcher = self
             .file_watcher
             .lock()
-            .map_err(|e| AppError::Internal(format!("file watcher lock poisoned: {e}")))?;
+            .map_err(|e| FileError::Internal(format!("file watcher lock poisoned: {e}")))?;
 
         for entry in self.watched_files.iter() {
             let path = std::path::PathBuf::from(entry.key().as_str());
@@ -190,16 +190,16 @@ impl crate::traits::IFileWatchService for FileWatchService {
         Ok(())
     }
 
-    async fn start_office_watch(&self, workspace: &str) -> Result<(), AppError> {
+    async fn start_office_watch(&self, workspace: &str) -> Result<(), FileError> {
         let canonical = std::fs::canonicalize(workspace)
-            .map_err(|e| AppError::NotFound(format!("cannot resolve workspace {workspace}: {e}")))?;
+            .map_err(|e| FileError::NotFound(format!("cannot resolve workspace {workspace}: {e}")))?;
         let key = canonical.to_string_lossy().into_owned();
 
         {
             let watchers = self
                 .office_watchers
                 .lock()
-                .map_err(|e| AppError::Internal(format!("office watcher lock poisoned: {e}")))?;
+                .map_err(|e| FileError::Internal(format!("office watcher lock poisoned: {e}")))?;
             if watchers.contains_key(&key) {
                 return Ok(());
             }
@@ -239,28 +239,28 @@ impl crate::traits::IFileWatchService for FileWatchService {
                 bc.broadcast(WebSocketMessage::new("workspaceOfficeWatch.fileAdded", json));
             }
         })
-        .map_err(|e| AppError::Internal(format!("failed to create office watcher: {e}")))?;
+        .map_err(|e| FileError::Internal(format!("failed to create office watcher: {e}")))?;
 
         watcher
             .watch(&canonical, RecursiveMode::Recursive)
-            .map_err(|e| AppError::Internal(format!("failed to watch workspace {workspace}: {e}")))?;
+            .map_err(|e| FileError::Internal(format!("failed to watch workspace {workspace}: {e}")))?;
 
         let mut watchers = self
             .office_watchers
             .lock()
-            .map_err(|e| AppError::Internal(format!("office watcher lock poisoned: {e}")))?;
+            .map_err(|e| FileError::Internal(format!("office watcher lock poisoned: {e}")))?;
         watchers.insert(key, watcher);
         Ok(())
     }
 
-    async fn stop_office_watch(&self, workspace: &str) -> Result<(), AppError> {
+    async fn stop_office_watch(&self, workspace: &str) -> Result<(), FileError> {
         let canonical = std::fs::canonicalize(workspace).unwrap_or_else(|_| workspace.into());
         let key = canonical.to_string_lossy().into_owned();
 
         let mut watchers = self
             .office_watchers
             .lock()
-            .map_err(|e| AppError::Internal(format!("office watcher lock poisoned: {e}")))?;
+            .map_err(|e| FileError::Internal(format!("office watcher lock poisoned: {e}")))?;
         // Dropping the watcher stops watching.
         watchers.remove(&key);
         Ok(())

--- a/crates/aionui-file/tests/file_read_write.rs
+++ b/crates/aionui-file/tests/file_read_write.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::sync::{Arc, Mutex};
 
 use aionui_api_types::WebSocketMessage;
-use aionui_file::{FileService, IFileService};
+use aionui_file::{FileError, FileService, IFileService};
 use aionui_realtime::EventBroadcaster;
 
 /// A broadcaster that records every event for later assertion.
@@ -155,8 +155,8 @@ async fn read_file_rejects_outside_sandbox_without_workspace() {
     let svc = make_service(sandbox.path());
     let err = svc.read_file(file.to_str().unwrap(), None).await.unwrap_err();
 
-    assert!(matches!(err, aionui_common::AppError::Forbidden(_)));
-    assert_eq!(err.error_code(), "PATH_OUTSIDE_SANDBOX");
+    assert!(matches!(err, FileError::Forbidden(_)));
+    assert!(err.to_string().contains("outside the allowed sandbox"));
 }
 
 #[tokio::test]
@@ -179,7 +179,7 @@ async fn read_file_rejects_directory() {
     let svc = make_service(dir.path());
     let err = svc.read_file(folder.to_str().unwrap(), None).await.unwrap_err();
 
-    assert!(matches!(err, aionui_common::AppError::BadRequest(_)));
+    assert!(matches!(err, FileError::BadRequest(_)));
     assert!(err.to_string().contains("is a directory"));
 }
 

--- a/crates/aionui-mcp/src/error.rs
+++ b/crates/aionui-mcp/src/error.rs
@@ -1,9 +1,4 @@
-use aionui_common::AppError;
-
 /// MCP crate-level errors.
-///
-/// Uses `thiserror` (library crate convention).
-/// Converts to `AppError` for HTTP response mapping.
 #[derive(Debug, thiserror::Error)]
 pub enum McpError {
     #[error("MCP server not found: {0}")]
@@ -37,81 +32,9 @@ pub enum McpError {
     Json(#[from] serde_json::Error),
 }
 
-impl From<McpError> for AppError {
-    fn from(err: McpError) -> Self {
-        match err {
-            McpError::NotFound(msg) => AppError::NotFound(msg),
-            McpError::Conflict(msg) => AppError::Conflict(msg),
-            McpError::InvalidEdit(msg) => AppError::BadRequest(msg),
-            McpError::InvalidTransport(msg) => AppError::BadRequest(msg),
-            McpError::AgentNotInstalled(msg) => AppError::BadRequest(msg),
-            McpError::AgentOperationFailed(msg) => AppError::Internal(msg),
-            McpError::ConnectionFailed(msg) => AppError::BadGateway(msg),
-            McpError::OAuth(msg) => AppError::Internal(format!("OAuth error: {msg}")),
-            McpError::Database(db_err) => AppError::from(db_err),
-            McpError::Json(e) => AppError::Internal(format!("JSON error: {e}")),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn not_found_maps_to_app_not_found() {
-        let err: AppError = McpError::NotFound("mcp_123".into()).into();
-        assert!(matches!(err, AppError::NotFound(msg) if msg == "mcp_123"));
-    }
-
-    #[test]
-    fn conflict_maps_to_app_conflict() {
-        let err: AppError = McpError::Conflict("test-server".into()).into();
-        assert!(matches!(err, AppError::Conflict(_)));
-    }
-
-    #[test]
-    fn invalid_transport_maps_to_bad_request() {
-        let err: AppError = McpError::InvalidTransport("missing command".into()).into();
-        assert!(matches!(err, AppError::BadRequest(_)));
-    }
-
-    #[test]
-    fn invalid_edit_maps_to_bad_request() {
-        let err: AppError = McpError::InvalidEdit("rename forbidden".into()).into();
-        assert!(matches!(err, AppError::BadRequest(_)));
-    }
-
-    #[test]
-    fn agent_not_installed_maps_to_bad_request() {
-        let err: AppError = McpError::AgentNotInstalled("claude".into()).into();
-        assert!(matches!(err, AppError::BadRequest(_)));
-    }
-
-    #[test]
-    fn agent_operation_failed_maps_to_internal() {
-        let err: AppError = McpError::AgentOperationFailed("exit code 1".into()).into();
-        assert!(matches!(err, AppError::Internal(_)));
-    }
-
-    #[test]
-    fn connection_failed_maps_to_bad_gateway() {
-        let err: AppError = McpError::ConnectionFailed("timeout".into()).into();
-        assert!(matches!(err, AppError::BadGateway(_)));
-    }
-
-    #[test]
-    fn oauth_maps_to_internal() {
-        let err: AppError = McpError::OAuth("discovery failed".into()).into();
-        assert!(matches!(err, AppError::Internal(_)));
-    }
-
-    #[test]
-    fn json_error_maps_to_internal() {
-        let json_err = serde_json::from_str::<serde_json::Value>("invalid").unwrap_err();
-        let err: AppError = McpError::Json(json_err).into();
-        assert!(matches!(err, AppError::Internal(_)));
-    }
 
     #[test]
     fn display_messages() {

--- a/crates/aionui-mcp/src/routes.rs
+++ b/crates/aionui-mcp/src/routes.rs
@@ -13,10 +13,28 @@ use aionui_api_types::{
 use aionui_common::AppError;
 
 use crate::connection_test::McpConnectionTestService;
+use crate::error::McpError;
 use crate::oauth_service::McpOAuthService;
 use crate::service::McpConfigService;
 use crate::sync_service::McpSyncService;
 use crate::types::McpServerTransport;
+
+impl From<McpError> for AppError {
+    fn from(err: McpError) -> Self {
+        match err {
+            McpError::NotFound(msg) => AppError::NotFound(msg),
+            McpError::Conflict(msg) => AppError::Conflict(msg),
+            McpError::InvalidEdit(msg) => AppError::BadRequest(msg),
+            McpError::InvalidTransport(msg) => AppError::BadRequest(msg),
+            McpError::AgentNotInstalled(msg) => AppError::BadRequest(msg),
+            McpError::AgentOperationFailed(msg) => AppError::Internal(msg),
+            McpError::ConnectionFailed(msg) => AppError::BadGateway(msg),
+            McpError::OAuth(msg) => AppError::Internal(format!("OAuth error: {msg}")),
+            McpError::Database(db_err) => AppError::from(db_err),
+            McpError::Json(e) => AppError::Internal(format!("JSON error: {e}")),
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Router state
@@ -68,7 +86,7 @@ pub fn mcp_routes(state: McpRouterState) -> Router {
 async fn list_servers(
     State(state): State<McpRouterState>,
 ) -> Result<Json<ApiResponse<Vec<McpServerResponse>>>, AppError> {
-    let servers = state.config_service.list_servers().await?;
+    let servers = state.config_service.list_servers().await.map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(servers)))
 }
 
@@ -77,7 +95,7 @@ async fn get_server(
     State(state): State<McpRouterState>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<McpServerResponse>>, AppError> {
-    let server = state.config_service.get_server(&id).await?;
+    let server = state.config_service.get_server(&id).await.map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(server)))
 }
 
@@ -87,7 +105,7 @@ async fn add_server(
     body: Result<Json<CreateMcpServerRequest>, JsonRejection>,
 ) -> Result<(StatusCode, Json<ApiResponse<McpServerResponse>>), AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    let server = state.config_service.add_server(req).await?;
+    let server = state.config_service.add_server(req).await.map_err(AppError::from)?;
     Ok((StatusCode::CREATED, Json(ApiResponse::ok(server))))
 }
 
@@ -98,7 +116,11 @@ async fn edit_server(
     body: Result<Json<UpdateMcpServerRequest>, JsonRejection>,
 ) -> Result<Json<ApiResponse<McpServerResponse>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    let server = state.config_service.edit_server(&id, req).await?;
+    let server = state
+        .config_service
+        .edit_server(&id, req)
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(server)))
 }
 
@@ -107,7 +129,7 @@ async fn delete_server(
     State(state): State<McpRouterState>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<()>>, AppError> {
-    state.config_service.delete_server(&id).await?;
+    state.config_service.delete_server(&id).await.map_err(AppError::from)?;
     Ok(Json(ApiResponse::success()))
 }
 
@@ -116,7 +138,7 @@ async fn toggle_server(
     State(state): State<McpRouterState>,
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<McpServerResponse>>, AppError> {
-    let server = state.config_service.toggle_server(&id).await?;
+    let server = state.config_service.toggle_server(&id).await.map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(server)))
 }
 
@@ -126,7 +148,7 @@ async fn batch_import(
     body: Result<Json<BatchImportMcpServersRequest>, JsonRejection>,
 ) -> Result<Json<ApiResponse<Vec<McpServerResponse>>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    let servers = state.config_service.batch_import(req).await?;
+    let servers = state.config_service.batch_import(req).await.map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(servers)))
 }
 
@@ -148,7 +170,11 @@ async fn test_connection(
         .test_connection(&req.name, &transport)
         .await;
     if let Some(server_id) = req.id.as_deref() {
-        state.config_service.persist_test_result(server_id, &result).await?;
+        state
+            .config_service
+            .persist_test_result(server_id, &result)
+            .await
+            .map_err(AppError::from)?;
     }
     if result.success || result.needs_auth == Some(true) {
         return Ok(Json(ApiResponse::ok(result)).into_response());
@@ -196,7 +222,7 @@ fn connection_test_failure_status(code: McpConnectionTestErrorCode) -> StatusCod
 async fn get_agent_configs(
     State(state): State<McpRouterState>,
 ) -> Result<Json<ApiResponse<Vec<DetectedMcpServerResponse>>>, AppError> {
-    let configs = state.sync_service.get_agent_configs().await?;
+    let configs = state.sync_service.get_agent_configs().await.map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(configs)))
 }
 
@@ -210,7 +236,11 @@ async fn oauth_check_status(
     body: Result<Json<OAuthCheckStatusRequest>, JsonRejection>,
 ) -> Result<Json<ApiResponse<OAuthStatusResponse>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    let status = state.oauth_service.check_oauth_status(&req.server_url).await?;
+    let status = state
+        .oauth_service
+        .check_oauth_status(&req.server_url)
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(status)))
 }
 
@@ -223,7 +253,11 @@ async fn oauth_login(
     body: Result<Json<OAuthLoginRequest>, JsonRejection>,
 ) -> Result<Json<ApiResponse<OAuthLoginResponse>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    let result = state.oauth_service.login(&req.server_url).await?;
+    let result = state
+        .oauth_service
+        .login(&req.server_url)
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(result)))
 }
 
@@ -233,12 +267,80 @@ async fn oauth_logout(
     body: Result<Json<OAuthLogoutRequest>, JsonRejection>,
 ) -> Result<Json<ApiResponse<()>>, AppError> {
     let Json(req) = body.map_err(|e| AppError::BadRequest(e.to_string()))?;
-    state.oauth_service.logout(&req.server_url).await?;
+    state
+        .oauth_service
+        .logout(&req.server_url)
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::success()))
 }
 
 /// `GET /api/mcp/oauth/authenticated` — list server URLs with stored tokens.
 async fn oauth_authenticated(State(state): State<McpRouterState>) -> Result<Json<ApiResponse<Vec<String>>>, AppError> {
-    let urls = state.oauth_service.get_authenticated_servers().await?;
+    let urls = state
+        .oauth_service
+        .get_authenticated_servers()
+        .await
+        .map_err(AppError::from)?;
     Ok(Json(ApiResponse::ok(urls)))
+}
+
+#[cfg(test)]
+mod error_mapping_tests {
+    use super::*;
+
+    #[test]
+    fn not_found_maps_to_app_not_found() {
+        let err = AppError::from(McpError::NotFound("mcp_123".into()));
+        assert!(matches!(err, AppError::NotFound(msg) if msg == "mcp_123"));
+    }
+
+    #[test]
+    fn conflict_maps_to_app_conflict() {
+        let err = AppError::from(McpError::Conflict("test-server".into()));
+        assert!(matches!(err, AppError::Conflict(_)));
+    }
+
+    #[test]
+    fn invalid_transport_maps_to_bad_request() {
+        let err = AppError::from(McpError::InvalidTransport("missing command".into()));
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn invalid_edit_maps_to_bad_request() {
+        let err = AppError::from(McpError::InvalidEdit("rename forbidden".into()));
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn agent_not_installed_maps_to_bad_request() {
+        let err = AppError::from(McpError::AgentNotInstalled("claude".into()));
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn agent_operation_failed_maps_to_internal() {
+        let err = AppError::from(McpError::AgentOperationFailed("exit code 1".into()));
+        assert!(matches!(err, AppError::Internal(_)));
+    }
+
+    #[test]
+    fn connection_failed_maps_to_bad_gateway() {
+        let err = AppError::from(McpError::ConnectionFailed("timeout".into()));
+        assert!(matches!(err, AppError::BadGateway(_)));
+    }
+
+    #[test]
+    fn oauth_maps_to_internal() {
+        let err = AppError::from(McpError::OAuth("discovery failed".into()));
+        assert!(matches!(err, AppError::Internal(_)));
+    }
+
+    #[test]
+    fn json_error_maps_to_internal() {
+        let json_err = serde_json::from_str::<serde_json::Value>("invalid").unwrap_err();
+        let err = AppError::from(McpError::Json(json_err));
+        assert!(matches!(err, AppError::Internal(_)));
+    }
 }

--- a/crates/aionui-office/src/error.rs
+++ b/crates/aionui-office/src/error.rs
@@ -1,5 +1,3 @@
-use aionui_common::AppError;
-
 #[derive(Debug, thiserror::Error)]
 pub enum OfficeError {
     #[error("officecli not found")]
@@ -30,68 +28,9 @@ pub enum OfficeError {
     ToolNotFound(String),
 }
 
-impl From<OfficeError> for AppError {
-    fn from(err: OfficeError) -> Self {
-        match err {
-            OfficeError::OfficecliNotFound => AppError::BadRequest("officecli not found".into()),
-            OfficeError::InstallFailed(msg) => AppError::Internal(format!("officecli install failed: {msg}")),
-            OfficeError::StartFailed(msg) => AppError::Internal(format!("preview start failed: {msg}")),
-            OfficeError::PortTimeout(path) => AppError::Timeout(format!("port readiness timeout for {path}")),
-            OfficeError::Io(e) => AppError::Internal(format!("IO error: {e}")),
-            OfficeError::Snapshot(msg) => AppError::Internal(format!("snapshot error: {msg}")),
-            OfficeError::Json(e) => AppError::Internal(format!("JSON error: {e}")),
-            OfficeError::Conversion(msg) => AppError::Internal(format!("conversion error: {msg}")),
-            OfficeError::ToolNotFound(tool) => AppError::BadRequest(format!("{tool} is not installed")),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn officecli_not_found_maps_to_bad_request() {
-        let err: AppError = OfficeError::OfficecliNotFound.into();
-        assert!(matches!(err, AppError::BadRequest(_)));
-    }
-
-    #[test]
-    fn install_failed_maps_to_internal() {
-        let err: AppError = OfficeError::InstallFailed("npm error".into()).into();
-        assert!(matches!(err, AppError::Internal(msg) if msg.contains("npm error")));
-    }
-
-    #[test]
-    fn start_failed_maps_to_internal() {
-        let err: AppError = OfficeError::StartFailed("spawn error".into()).into();
-        assert!(matches!(err, AppError::Internal(msg) if msg.contains("spawn error")));
-    }
-
-    #[test]
-    fn port_timeout_maps_to_timeout() {
-        let err: AppError = OfficeError::PortTimeout("/a.docx".into()).into();
-        assert!(matches!(err, AppError::Timeout(msg) if msg.contains("/a.docx")));
-    }
-
-    #[test]
-    fn io_error_maps_to_internal() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file missing");
-        let err: AppError = OfficeError::Io(io_err).into();
-        assert!(matches!(err, AppError::Internal(msg) if msg.contains("file missing")));
-    }
-
-    #[test]
-    fn conversion_error_maps_to_internal() {
-        let err: AppError = OfficeError::Conversion("bad format".into()).into();
-        assert!(matches!(err, AppError::Internal(msg) if msg.contains("bad format")));
-    }
-
-    #[test]
-    fn tool_not_found_maps_to_bad_request() {
-        let err: AppError = OfficeError::ToolNotFound("pandoc".into()).into();
-        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("pandoc")));
-    }
 
     #[test]
     fn display_messages() {

--- a/crates/aionui-office/src/proxy.rs
+++ b/crates/aionui-office/src/proxy.rs
@@ -192,17 +192,6 @@ pub enum ProxyError {
     RequestFailed(String),
 }
 
-impl From<ProxyError> for aionui_common::AppError {
-    fn from(err: ProxyError) -> Self {
-        match err {
-            ProxyError::PortNotActive(_) => aionui_common::AppError::Forbidden(err.to_string()),
-            ProxyError::Timeout => aionui_common::AppError::Timeout(err.to_string()),
-            ProxyError::ConnectionFailed(msg) => aionui_common::AppError::BadGateway(msg),
-            ProxyError::RequestFailed(msg) => aionui_common::AppError::BadGateway(msg),
-        }
-    }
-}
-
 fn build_target_url(port: u16, path: &str) -> String {
     let normalized = if path.starts_with('/') {
         path.to_owned()
@@ -435,30 +424,6 @@ mod tests {
     #[test]
     fn find_head_tag_end_missing() {
         assert_eq!(find_head_tag_end("<html><body>"), None);
-    }
-
-    #[test]
-    fn proxy_error_port_not_active_to_forbidden() {
-        let err: aionui_common::AppError = ProxyError::PortNotActive(8080).into();
-        assert!(matches!(err, aionui_common::AppError::Forbidden(_)));
-    }
-
-    #[test]
-    fn proxy_error_timeout_to_timeout() {
-        let err: aionui_common::AppError = ProxyError::Timeout.into();
-        assert!(matches!(err, aionui_common::AppError::Timeout(_)));
-    }
-
-    #[test]
-    fn proxy_error_connection_failed_to_bad_gateway() {
-        let err: aionui_common::AppError = ProxyError::ConnectionFailed("refused".into()).into();
-        assert!(matches!(err, aionui_common::AppError::BadGateway(_)));
-    }
-
-    #[test]
-    fn proxy_error_request_failed_to_bad_gateway() {
-        let err: aionui_common::AppError = ProxyError::RequestFailed("network error".into()).into();
-        assert!(matches!(err, aionui_common::AppError::BadGateway(_)));
     }
 
     #[test]

--- a/crates/aionui-office/src/routes.rs
+++ b/crates/aionui-office/src/routes.rs
@@ -13,11 +13,39 @@ use aionui_api_types::{
 };
 use aionui_auth::CurrentUser;
 use aionui_common::AppError;
-use aionui_file::path_safety::validate_path_with_extra_root;
+use aionui_file::{FileError, path_safety::validate_path_with_extra_root};
 
 use crate::error::OfficeError;
+use crate::proxy::ProxyError;
 use crate::state::OfficeRouterState;
 use crate::types::DocType;
+
+impl From<OfficeError> for AppError {
+    fn from(err: OfficeError) -> Self {
+        match err {
+            OfficeError::OfficecliNotFound => AppError::BadRequest("officecli not found".into()),
+            OfficeError::InstallFailed(msg) => AppError::Internal(format!("officecli install failed: {msg}")),
+            OfficeError::StartFailed(msg) => AppError::Internal(format!("preview start failed: {msg}")),
+            OfficeError::PortTimeout(path) => AppError::Timeout(format!("port readiness timeout for {path}")),
+            OfficeError::Io(e) => AppError::Internal(format!("IO error: {e}")),
+            OfficeError::Snapshot(msg) => AppError::Internal(format!("snapshot error: {msg}")),
+            OfficeError::Json(e) => AppError::Internal(format!("JSON error: {e}")),
+            OfficeError::Conversion(msg) => AppError::Internal(format!("conversion error: {msg}")),
+            OfficeError::ToolNotFound(tool) => AppError::BadRequest(format!("{tool} is not installed")),
+        }
+    }
+}
+
+impl From<ProxyError> for AppError {
+    fn from(err: ProxyError) -> Self {
+        match err {
+            ProxyError::PortNotActive(_) => AppError::Forbidden(err.to_string()),
+            ProxyError::Timeout => AppError::Timeout(err.to_string()),
+            ProxyError::ConnectionFailed(msg) => AppError::BadGateway(msg),
+            ProxyError::RequestFailed(msg) => AppError::BadGateway(msg),
+        }
+    }
+}
 
 pub fn office_routes(state: OfficeRouterState) -> Router {
     Router::new()
@@ -208,6 +236,16 @@ fn validate_office_path(
 ) -> Result<PathBuf, AppError> {
     let allowed_roots: Vec<&FsPath> = state.allowed_roots.iter().map(PathBuf::as_path).collect();
     validate_path_with_extra_root(file_path, &allowed_roots, workspace.map(FsPath::new))
+        .map_err(file_error_to_app_error)
+}
+
+fn file_error_to_app_error(error: FileError) -> AppError {
+    match error {
+        FileError::BadRequest(message) => AppError::BadRequest(message),
+        FileError::Forbidden(message) => AppError::Forbidden(message),
+        FileError::NotFound(message) => AppError::NotFound(message),
+        FileError::Internal(message) => AppError::Internal(message),
+    }
 }
 
 fn preview_error_code(error: &OfficeError) -> &'static str {
@@ -298,14 +336,14 @@ mod tests {
 
     use crate::conversion::ConversionService;
     use crate::error::OfficeError;
-    use crate::proxy::ProxyService;
+    use crate::proxy::{ProxyError, ProxyService};
     use crate::snapshot::SnapshotService;
     use crate::star_office::StarOfficeDetector;
     use crate::state::OfficeRouterState;
     use crate::types::DocType;
     use crate::watch_manager::{OfficecliWatchManager, ProcessHandle, ProcessSpawner};
 
-    use super::{office_proxy_routes, office_routes};
+    use super::{AppError, office_proxy_routes, office_routes};
 
     #[test]
     fn office_routes_builds_without_panic() {
@@ -317,6 +355,73 @@ mod tests {
     fn office_proxy_routes_builds_without_panic() {
         let state = build_test_state();
         let _router = office_proxy_routes(state);
+    }
+
+    #[test]
+    fn officecli_not_found_maps_to_bad_request() {
+        let err = AppError::from(OfficeError::OfficecliNotFound);
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn install_failed_maps_to_internal() {
+        let err = AppError::from(OfficeError::InstallFailed("npm error".into()));
+        assert!(matches!(err, AppError::Internal(msg) if msg.contains("npm error")));
+    }
+
+    #[test]
+    fn start_failed_maps_to_internal() {
+        let err = AppError::from(OfficeError::StartFailed("spawn error".into()));
+        assert!(matches!(err, AppError::Internal(msg) if msg.contains("spawn error")));
+    }
+
+    #[test]
+    fn port_timeout_maps_to_timeout() {
+        let err = AppError::from(OfficeError::PortTimeout("/a.docx".into()));
+        assert!(matches!(err, AppError::Timeout(msg) if msg.contains("/a.docx")));
+    }
+
+    #[test]
+    fn io_error_maps_to_internal() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file missing");
+        let err = AppError::from(OfficeError::Io(io_err));
+        assert!(matches!(err, AppError::Internal(msg) if msg.contains("file missing")));
+    }
+
+    #[test]
+    fn conversion_error_maps_to_internal() {
+        let err = AppError::from(OfficeError::Conversion("bad format".into()));
+        assert!(matches!(err, AppError::Internal(msg) if msg.contains("bad format")));
+    }
+
+    #[test]
+    fn tool_not_found_maps_to_bad_request() {
+        let err = AppError::from(OfficeError::ToolNotFound("pandoc".into()));
+        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("pandoc")));
+    }
+
+    #[test]
+    fn proxy_error_port_not_active_maps_to_forbidden() {
+        let err = AppError::from(ProxyError::PortNotActive(8080));
+        assert!(matches!(err, AppError::Forbidden(_)));
+    }
+
+    #[test]
+    fn proxy_error_timeout_maps_to_timeout() {
+        let err = AppError::from(ProxyError::Timeout);
+        assert!(matches!(err, AppError::Timeout(_)));
+    }
+
+    #[test]
+    fn proxy_error_connection_failed_maps_to_bad_gateway() {
+        let err = AppError::from(ProxyError::ConnectionFailed("refused".into()));
+        assert!(matches!(err, AppError::BadGateway(_)));
+    }
+
+    #[test]
+    fn proxy_error_request_failed_maps_to_bad_gateway() {
+        let err = AppError::from(ProxyError::RequestFailed("network error".into()));
+        assert!(matches!(err, AppError::BadGateway(_)));
     }
 
     fn build_test_state() -> OfficeRouterState {

--- a/crates/aionui-shell/src/error.rs
+++ b/crates/aionui-shell/src/error.rs
@@ -1,5 +1,3 @@
-use aionui_common::AppError;
-
 #[derive(Debug, thiserror::Error)]
 pub enum ShellError {
     #[error("file not found: {0}")]
@@ -19,19 +17,6 @@ pub enum ShellError {
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
-}
-
-impl From<ShellError> for AppError {
-    fn from(err: ShellError) -> Self {
-        match err {
-            ShellError::FileNotFound(path) => AppError::BadRequest(format!("file not found: {path}")),
-            ShellError::DirectoryNotFound(path) => AppError::BadRequest(format!("directory not found: {path}")),
-            ShellError::InvalidUrl(msg) => AppError::BadRequest(format!("invalid URL: {msg}")),
-            ShellError::ToolNotInstalled(tool) => AppError::BadRequest(format!("tool not installed: {tool}")),
-            ShellError::CommandFailed(msg) => AppError::Internal(format!("command failed: {msg}")),
-            ShellError::Io(e) => AppError::Internal(format!("IO error: {e}")),
-        }
-    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -72,58 +57,9 @@ impl SttError {
     }
 }
 
-impl From<SttError> for AppError {
-    fn from(err: SttError) -> Self {
-        match &err {
-            SttError::Disabled | SttError::OpenaiNotConfigured | SttError::DeepgramNotConfigured => {
-                AppError::BadRequest(err.to_string())
-            }
-            SttError::RequestFailed(_) => AppError::BadGateway(err.to_string()),
-            SttError::Unknown(_) => AppError::Internal(err.to_string()),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn file_not_found_maps_to_bad_request() {
-        let err: AppError = ShellError::FileNotFound("/tmp/missing.txt".into()).into();
-        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("/tmp/missing.txt")));
-    }
-
-    #[test]
-    fn directory_not_found_maps_to_bad_request() {
-        let err: AppError = ShellError::DirectoryNotFound("/tmp/nodir".into()).into();
-        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("/tmp/nodir")));
-    }
-
-    #[test]
-    fn invalid_url_maps_to_bad_request() {
-        let err: AppError = ShellError::InvalidUrl("not a url".into()).into();
-        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("not a url")));
-    }
-
-    #[test]
-    fn tool_not_installed_maps_to_bad_request() {
-        let err: AppError = ShellError::ToolNotInstalled("vscode".into()).into();
-        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("vscode")));
-    }
-
-    #[test]
-    fn command_failed_maps_to_internal() {
-        let err: AppError = ShellError::CommandFailed("exit code 1".into()).into();
-        assert!(matches!(err, AppError::Internal(msg) if msg.contains("exit code 1")));
-    }
-
-    #[test]
-    fn io_error_maps_to_internal() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "permission denied");
-        let err: AppError = ShellError::Io(io_err).into();
-        assert!(matches!(err, AppError::Internal(msg) if msg.contains("permission denied")));
-    }
 
     #[test]
     fn shell_error_display_messages() {
@@ -144,36 +80,6 @@ mod tests {
             ShellError::CommandFailed("oops".into()).to_string(),
             "command failed: oops"
         );
-    }
-
-    #[test]
-    fn stt_disabled_maps_to_bad_request() {
-        let err: AppError = SttError::Disabled.into();
-        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("not enabled")));
-    }
-
-    #[test]
-    fn stt_openai_not_configured_maps_to_bad_request() {
-        let err: AppError = SttError::OpenaiNotConfigured.into();
-        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("OpenAI")));
-    }
-
-    #[test]
-    fn stt_deepgram_not_configured_maps_to_bad_request() {
-        let err: AppError = SttError::DeepgramNotConfigured.into();
-        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("Deepgram")));
-    }
-
-    #[test]
-    fn stt_request_failed_maps_to_bad_gateway() {
-        let err: AppError = SttError::RequestFailed("HTTP 401".into()).into();
-        assert!(matches!(err, AppError::BadGateway(msg) if msg.contains("HTTP 401")));
-    }
-
-    #[test]
-    fn stt_unknown_maps_to_internal() {
-        let err: AppError = SttError::Unknown("unexpected".into()).into();
-        assert!(matches!(err, AppError::Internal(msg) if msg.contains("unexpected")));
     }
 
     #[test]

--- a/crates/aionui-shell/src/routes.rs
+++ b/crates/aionui-shell/src/routes.rs
@@ -9,8 +9,33 @@ use aionui_api_types::{
 };
 use aionui_common::AppError;
 
-use crate::error::SttError;
+use crate::error::{ShellError, SttError};
 use crate::state::ShellRouterState;
+
+impl From<ShellError> for AppError {
+    fn from(err: ShellError) -> Self {
+        match err {
+            ShellError::FileNotFound(path) => AppError::BadRequest(format!("file not found: {path}")),
+            ShellError::DirectoryNotFound(path) => AppError::BadRequest(format!("directory not found: {path}")),
+            ShellError::InvalidUrl(msg) => AppError::BadRequest(format!("invalid URL: {msg}")),
+            ShellError::ToolNotInstalled(tool) => AppError::BadRequest(format!("tool not installed: {tool}")),
+            ShellError::CommandFailed(msg) => AppError::Internal(format!("command failed: {msg}")),
+            ShellError::Io(e) => AppError::Internal(format!("IO error: {e}")),
+        }
+    }
+}
+
+impl From<SttError> for AppError {
+    fn from(err: SttError) -> Self {
+        match &err {
+            SttError::Disabled | SttError::OpenaiNotConfigured | SttError::DeepgramNotConfigured => {
+                AppError::BadRequest(err.to_string())
+            }
+            SttError::RequestFailed(_) => AppError::BadGateway(err.to_string()),
+            SttError::Unknown(_) => AppError::Internal(err.to_string()),
+        }
+    }
+}
 
 pub fn shell_routes(state: ShellRouterState) -> Router {
     Router::new()
@@ -350,5 +375,72 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn file_not_found_maps_to_bad_request() {
+        let err = AppError::from(ShellError::FileNotFound("/tmp/missing.txt".into()));
+        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("/tmp/missing.txt")));
+    }
+
+    #[test]
+    fn directory_not_found_maps_to_bad_request() {
+        let err = AppError::from(ShellError::DirectoryNotFound("/tmp/nodir".into()));
+        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("/tmp/nodir")));
+    }
+
+    #[test]
+    fn invalid_url_maps_to_bad_request() {
+        let err = AppError::from(ShellError::InvalidUrl("not a url".into()));
+        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("not a url")));
+    }
+
+    #[test]
+    fn tool_not_installed_maps_to_bad_request() {
+        let err = AppError::from(ShellError::ToolNotInstalled("vscode".into()));
+        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("vscode")));
+    }
+
+    #[test]
+    fn command_failed_maps_to_internal() {
+        let err = AppError::from(ShellError::CommandFailed("exit code 1".into()));
+        assert!(matches!(err, AppError::Internal(msg) if msg.contains("exit code 1")));
+    }
+
+    #[test]
+    fn io_error_maps_to_internal() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "permission denied");
+        let err = AppError::from(ShellError::Io(io_err));
+        assert!(matches!(err, AppError::Internal(msg) if msg.contains("permission denied")));
+    }
+
+    #[test]
+    fn stt_disabled_maps_to_bad_request() {
+        let err = AppError::from(SttError::Disabled);
+        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("not enabled")));
+    }
+
+    #[test]
+    fn stt_openai_not_configured_maps_to_bad_request() {
+        let err = AppError::from(SttError::OpenaiNotConfigured);
+        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("OpenAI")));
+    }
+
+    #[test]
+    fn stt_deepgram_not_configured_maps_to_bad_request() {
+        let err = AppError::from(SttError::DeepgramNotConfigured);
+        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("Deepgram")));
+    }
+
+    #[test]
+    fn stt_request_failed_maps_to_bad_gateway() {
+        let err = AppError::from(SttError::RequestFailed("HTTP 401".into()));
+        assert!(matches!(err, AppError::BadGateway(msg) if msg.contains("HTTP 401")));
+    }
+
+    #[test]
+    fn stt_unknown_maps_to_internal() {
+        let err = AppError::from(SttError::Unknown("unexpected".into()));
+        assert!(matches!(err, AppError::Internal(msg) if msg.contains("unexpected")));
     }
 }

--- a/crates/aionui-team/src/error.rs
+++ b/crates/aionui-team/src/error.rs
@@ -43,26 +43,6 @@ pub enum TeamError {
     Json(#[from] serde_json::Error),
 }
 
-impl From<TeamError> for AppError {
-    fn from(err: TeamError) -> Self {
-        match err {
-            TeamError::TeamNotFound(msg) => AppError::NotFound(msg),
-            TeamError::AgentNotFound(msg) => AppError::NotFound(msg),
-            TeamError::TaskNotFound(msg) => AppError::NotFound(msg),
-            TeamError::InvalidRequest(msg) => AppError::BadRequest(msg),
-            TeamError::LeaderOnly(msg) => AppError::Forbidden(msg),
-            TeamError::SessionNotFound(msg) => AppError::NotFound(msg),
-            TeamError::BlockedTaskNotFound(msg) => AppError::BadRequest(msg),
-            TeamError::BackendNotAllowed(msg) => AppError::BadRequest(msg),
-            TeamError::DuplicateAgentName(msg) => AppError::BadRequest(format!("Agent name already taken: {msg}")),
-            TeamError::App(app_err) => app_err,
-            TeamError::Conversation(conversation_err) => AppError::from(conversation_err),
-            TeamError::Database(db_err) => AppError::from(db_err),
-            TeamError::Json(e) => AppError::Internal(format!("JSON error: {e}")),
-        }
-    }
-}
-
 impl TeamError {
     pub(crate) fn from_conversation_create(error: ConversationError) -> Self {
         match error {
@@ -80,97 +60,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn team_not_found_maps_to_app_not_found() {
-        let err: AppError = TeamError::TeamNotFound("t1".into()).into();
-        assert!(matches!(err, AppError::NotFound(msg) if msg == "t1"));
-    }
-
-    #[test]
-    fn agent_not_found_maps_to_app_not_found() {
-        let err: AppError = TeamError::AgentNotFound("slot-1".into()).into();
-        assert!(matches!(err, AppError::NotFound(_)));
-    }
-
-    #[test]
-    fn task_not_found_maps_to_app_not_found() {
-        let err: AppError = TeamError::TaskNotFound("tk-1".into()).into();
-        assert!(matches!(err, AppError::NotFound(_)));
-    }
-
-    #[test]
-    fn invalid_request_maps_to_bad_request() {
-        let err: AppError = TeamError::InvalidRequest("empty agents".into()).into();
-        assert!(matches!(err, AppError::BadRequest(_)));
-    }
-
-    #[test]
-    fn leader_only_maps_to_forbidden() {
-        let err: AppError = TeamError::LeaderOnly("spawn_agent".into()).into();
-        assert!(matches!(err, AppError::Forbidden(msg) if msg == "spawn_agent"));
-    }
-
-    #[test]
-    fn session_not_found_maps_to_not_found() {
-        let err: AppError = TeamError::SessionNotFound("t1".into()).into();
-        assert!(matches!(err, AppError::NotFound(_)));
-    }
-
-    #[test]
-    fn blocked_task_not_found_maps_to_bad_request() {
-        let err: AppError = TeamError::BlockedTaskNotFound("tk-x".into()).into();
-        assert!(matches!(err, AppError::BadRequest(_)));
-    }
-
-    #[test]
-    fn backend_not_allowed_maps_to_bad_request() {
-        let err: AppError = TeamError::BackendNotAllowed("gemini".into()).into();
-        assert!(matches!(err, AppError::BadRequest(msg) if msg == "gemini"));
-    }
-
-    #[test]
-    fn duplicate_agent_name_maps_to_bad_request() {
-        let err: AppError = TeamError::DuplicateAgentName("alice".into()).into();
-        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("alice")));
-    }
-
-    #[test]
-    fn app_error_passthrough_preserves_code() {
-        let err: AppError = TeamError::App(AppError::WorkspacePathContainsWhitespace("/tmp/a b".into())).into();
-        assert!(matches!(err, AppError::WorkspacePathContainsWhitespace(msg) if msg == "/tmp/a b"));
-    }
-
-    #[test]
-    fn conversation_error_maps_through_boundary_mapper() {
-        let err: AppError = TeamError::Conversation(ConversationError::NotFound { id: "conv-1".into() }).into();
-        assert!(matches!(err, AppError::NotFound(msg) if msg == "Conversation conv-1 not found"));
-    }
-
-    #[test]
     fn conversation_create_preserves_workspace_error_code() {
         let err = TeamError::from_conversation_create(ConversationError::App(
             AppError::WorkspacePathContainsWhitespace("/tmp/a b".into()),
         ));
-        let app: AppError = err.into();
-        assert!(matches!(app, AppError::WorkspacePathContainsWhitespace(msg) if msg == "/tmp/a b"));
-    }
-
-    #[test]
-    fn runtime_workspace_app_error_passthrough_preserves_code() {
-        let err: AppError = TeamError::App(AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(
-            "/tmp/a b".into(),
-        ))
-        .into();
-        assert!(matches!(
-            err,
-            AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(msg) if msg == "/tmp/a b"
-        ));
-    }
-
-    #[test]
-    fn json_error_maps_to_internal() {
-        let json_err = serde_json::from_str::<serde_json::Value>("bad").unwrap_err();
-        let err: AppError = TeamError::Json(json_err).into();
-        assert!(matches!(err, AppError::Internal(_)));
+        assert!(matches!(err, TeamError::App(AppError::WorkspacePathContainsWhitespace(msg)) if msg == "/tmp/a b"));
     }
 
     #[test]

--- a/crates/aionui-team/src/error.rs
+++ b/crates/aionui-team/src/error.rs
@@ -1,4 +1,5 @@
 use aionui_common::AppError;
+use aionui_conversation::ConversationError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum TeamError {
@@ -32,6 +33,9 @@ pub enum TeamError {
     #[error(transparent)]
     App(#[from] AppError),
 
+    #[error(transparent)]
+    Conversation(#[from] ConversationError),
+
     #[error("{0}")]
     Database(#[from] aionui_db::DbError),
 
@@ -52,6 +56,7 @@ impl From<TeamError> for AppError {
             TeamError::BackendNotAllowed(msg) => AppError::BadRequest(msg),
             TeamError::DuplicateAgentName(msg) => AppError::BadRequest(format!("Agent name already taken: {msg}")),
             TeamError::App(app_err) => app_err,
+            TeamError::Conversation(conversation_err) => AppError::from(conversation_err),
             TeamError::Database(db_err) => AppError::from(db_err),
             TeamError::Json(e) => AppError::Internal(format!("JSON error: {e}")),
         }
@@ -59,10 +64,12 @@ impl From<TeamError> for AppError {
 }
 
 impl TeamError {
-    pub(crate) fn from_conversation_create(error: AppError) -> Self {
+    pub(crate) fn from_conversation_create(error: ConversationError) -> Self {
         match error {
-            AppError::WorkspacePathContainsWhitespace(_) => Self::App(error),
-            AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(_) => Self::App(error),
+            ConversationError::App(error @ AppError::WorkspacePathContainsWhitespace(_)) => Self::App(error),
+            ConversationError::App(error @ AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(_)) => {
+                Self::App(error)
+            }
             other => Self::InvalidRequest(format!("failed to create conversation: {other}")),
         }
     }
@@ -130,6 +137,21 @@ mod tests {
     fn app_error_passthrough_preserves_code() {
         let err: AppError = TeamError::App(AppError::WorkspacePathContainsWhitespace("/tmp/a b".into())).into();
         assert!(matches!(err, AppError::WorkspacePathContainsWhitespace(msg) if msg == "/tmp/a b"));
+    }
+
+    #[test]
+    fn conversation_error_maps_through_boundary_mapper() {
+        let err: AppError = TeamError::Conversation(ConversationError::NotFound { id: "conv-1".into() }).into();
+        assert!(matches!(err, AppError::NotFound(msg) if msg == "Conversation conv-1 not found"));
+    }
+
+    #[test]
+    fn conversation_create_preserves_workspace_error_code() {
+        let err = TeamError::from_conversation_create(ConversationError::App(
+            AppError::WorkspacePathContainsWhitespace("/tmp/a b".into()),
+        ));
+        let app: AppError = err.into();
+        assert!(matches!(app, AppError::WorkspacePathContainsWhitespace(msg) if msg == "/tmp/a b"));
     }
 
     #[test]

--- a/crates/aionui-team/src/routes.rs
+++ b/crates/aionui-team/src/routes.rs
@@ -13,11 +13,32 @@ use aionui_api_types::{
 use aionui_auth::CurrentUser;
 use aionui_common::AppError;
 
+use crate::error::TeamError;
 use crate::service::TeamSessionService;
 
 #[derive(Clone)]
 pub struct TeamRouterState {
     pub service: Arc<TeamSessionService>,
+}
+
+impl From<TeamError> for AppError {
+    fn from(err: TeamError) -> Self {
+        match err {
+            TeamError::TeamNotFound(msg) => AppError::NotFound(msg),
+            TeamError::AgentNotFound(msg) => AppError::NotFound(msg),
+            TeamError::TaskNotFound(msg) => AppError::NotFound(msg),
+            TeamError::InvalidRequest(msg) => AppError::BadRequest(msg),
+            TeamError::LeaderOnly(msg) => AppError::Forbidden(msg),
+            TeamError::SessionNotFound(msg) => AppError::NotFound(msg),
+            TeamError::BlockedTaskNotFound(msg) => AppError::BadRequest(msg),
+            TeamError::BackendNotAllowed(msg) => AppError::BadRequest(msg),
+            TeamError::DuplicateAgentName(msg) => AppError::BadRequest(format!("Agent name already taken: {msg}")),
+            TeamError::App(app_err) => app_err,
+            TeamError::Conversation(conversation_err) => AppError::from(conversation_err),
+            TeamError::Database(db_err) => AppError::from(db_err),
+            TeamError::Json(e) => AppError::Internal(format!("JSON error: {e}")),
+        }
+    }
 }
 
 pub fn team_routes(state: TeamRouterState) -> Router {
@@ -179,5 +200,91 @@ mod tests {
     fn team_router_state_is_clone() {
         fn assert_clone<T: Clone>() {}
         assert_clone::<TeamRouterState>();
+    }
+
+    #[test]
+    fn team_not_found_maps_to_app_not_found() {
+        let err: AppError = TeamError::TeamNotFound("t1".into()).into();
+        assert!(matches!(err, AppError::NotFound(msg) if msg == "t1"));
+    }
+
+    #[test]
+    fn agent_not_found_maps_to_app_not_found() {
+        let err: AppError = TeamError::AgentNotFound("slot-1".into()).into();
+        assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    #[test]
+    fn task_not_found_maps_to_app_not_found() {
+        let err: AppError = TeamError::TaskNotFound("tk-1".into()).into();
+        assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    #[test]
+    fn invalid_request_maps_to_bad_request() {
+        let err: AppError = TeamError::InvalidRequest("empty agents".into()).into();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn leader_only_maps_to_forbidden() {
+        let err: AppError = TeamError::LeaderOnly("spawn_agent".into()).into();
+        assert!(matches!(err, AppError::Forbidden(msg) if msg == "spawn_agent"));
+    }
+
+    #[test]
+    fn session_not_found_maps_to_not_found() {
+        let err: AppError = TeamError::SessionNotFound("t1".into()).into();
+        assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    #[test]
+    fn blocked_task_not_found_maps_to_bad_request() {
+        let err: AppError = TeamError::BlockedTaskNotFound("tk-x".into()).into();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn backend_not_allowed_maps_to_bad_request() {
+        let err: AppError = TeamError::BackendNotAllowed("gemini".into()).into();
+        assert!(matches!(err, AppError::BadRequest(msg) if msg == "gemini"));
+    }
+
+    #[test]
+    fn duplicate_agent_name_maps_to_bad_request() {
+        let err: AppError = TeamError::DuplicateAgentName("alice".into()).into();
+        assert!(matches!(err, AppError::BadRequest(msg) if msg.contains("alice")));
+    }
+
+    #[test]
+    fn app_error_passthrough_preserves_code() {
+        let err: AppError = TeamError::App(AppError::WorkspacePathContainsWhitespace("/tmp/a b".into())).into();
+        assert!(matches!(err, AppError::WorkspacePathContainsWhitespace(msg) if msg == "/tmp/a b"));
+    }
+
+    #[test]
+    fn conversation_error_maps_through_boundary_mapper() {
+        let err: AppError =
+            TeamError::Conversation(aionui_conversation::ConversationError::NotFound { id: "conv-1".into() }).into();
+        assert!(matches!(err, AppError::NotFound(msg) if msg == "Conversation conv-1 not found"));
+    }
+
+    #[test]
+    fn runtime_workspace_app_error_passthrough_preserves_code() {
+        let err: AppError = TeamError::App(AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(
+            "/tmp/a b".into(),
+        ))
+        .into();
+        assert!(matches!(
+            err,
+            AppError::WorkspacePathContainsWhitespaceRuntimeUnsupported(msg) if msg == "/tmp/a b"
+        ));
+    }
+
+    #[test]
+    fn json_error_maps_to_internal() {
+        let json_err = serde_json::from_str::<serde_json::Value>("bad").unwrap_err();
+        let err: AppError = TeamError::Json(json_err).into();
+        assert!(matches!(err, AppError::Internal(_)));
     }
 }


### PR DESCRIPTION
## Summary
- Migrate route-facing conversation service methods to `ConversationError`, with temporary `ConversationError -> AppError` HTTP mapping kept in routes for Phase 2.
- Keep team/cron cross-domain failures as `TeamError`/`CronError`, and move their HTTP mapping to route boundaries.
- Keep `McpError`, `AuthError`, `ExtensionError`, `FileError`, `OfficeError`, `ProxyError`, `ShellError`, and `SttError` owned by their crates/capabilities, with `*Error -> AppError` mappings centralized in routes.
- Introduce `FileError` for `aionui-file` service/trait/path/watch/snapshot flows so file operations no longer return HTTP boundary errors from service code.
- Change extension assistant dispatcher trait to return `ExtensionError`; assistant's existing `AppError` internals are adapted at the trait boundary as a Phase 2 bridge.
- Preserve Phase 3 deferrals: no `AppError` rename to `ApiError`, no wholesale route relocation into `aionui-app`, and no full conversation/assistant internal error rewrite.

## Verification
- `cargo test -p aionui-auth`
- `cargo clippy -p aionui-auth -- -D warnings`
- `cargo test -p aionui-mcp`
- `cargo clippy -p aionui-mcp -- -D warnings`
- `cargo test -p aionui-office -p aionui-shell -p aionui-extension -p aionui-file`
- `cargo clippy -p aionui-office -p aionui-shell -p aionui-extension -p aionui-file -- -D warnings`
- `cargo test -p aionui-team -p aionui-cron`
- `cargo clippy -p aionui-team -p aionui-cron -- -D warnings`
- `cargo test -p aionui-extension -p aionui-assistant`
- `cargo clippy -p aionui-extension -p aionui-assistant -- -D warnings`
- `cargo check -p aionui-app`
- `just push` (fmt, clippy, full workspace nextest: 5832 passed, 18 skipped)
