### PR TITLE
Stabilize agent runtime terminal lifecycle

### DIFF
--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -10,7 +10,7 @@ use crate::manager::acp::{
 use crate::manager::process_registry::{register_session_process, unregister_agent_process};
 use crate::protocol::acp::AcpProtocol;
 use crate::protocol::error::{AcpError, CloseReason};
-use crate::protocol::events::{AgentStreamEvent, FinishEventData};
+use crate::protocol::events::AgentStreamEvent;
 use crate::protocol::send_error::AgentSendError;
 use crate::registry::CatalogSender;
 use crate::shared_kernel::{ModeId, ModelId, SessionId as DomainSessionId};
@@ -28,6 +28,7 @@ use std::time::Duration;
 use tokio::sync::{Mutex, RwLock, broadcast, mpsc};
 use tracing::{debug, error, info, warn};
 
+use super::agent_session_flow::PromptOutcome;
 use super::error_mapping::{AcpSendFailure, acp_error_to_app_error};
 
 /// The user-visible body inside an [`AppError`].
@@ -551,7 +552,7 @@ impl AcpAgentManager {
     /// forwarded to the CLI. Each hook in the pipeline reads one-shot flags
     /// on `AcpSession` (e.g. `pending_session_new_prelude`,
     /// `pending_model_notice`) and prepends the appropriate block when set.
-    async fn ensure_session_and_send(&self, data: &SendMessageData) -> Result<(), AcpSendFailure> {
+    async fn ensure_session_and_send(&self, data: &SendMessageData) -> Result<PromptOutcome, AcpSendFailure> {
         let sid = self.ensure_session_opened().await.map_err(AcpSendFailure::from)?;
         self.runtime.reset_for_new_turn(ConversationStatus::Running);
 
@@ -622,12 +623,35 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
         self.runtime.bump_activity();
 
         match self.ensure_session_and_send(&data).await {
-            Ok(()) => {
-                info!("ACP send_message completed");
-                // ACP pattern: Finish with session_id = None (default).
-                // If ACP later wants to include the session_id in Finish,
-                // read it from `self.session.read().await.session_id()`.
-                self.runtime.emit_finish(None);
+            Ok(PromptOutcome::Completed { session_id }) => {
+                info!(
+                    agent_type = "acp",
+                    terminal_kind = "finish",
+                    source = "prompt_outcome",
+                    "ACP send_message completed"
+                );
+                self.runtime.emit_finish(Some(session_id));
+                Ok(())
+            }
+            Ok(PromptOutcome::Cancelled { session_id }) => {
+                info!(
+                    agent_type = "acp",
+                    terminal_kind = "finish",
+                    source = "prompt_cancelled",
+                    "ACP send_message cancelled"
+                );
+                self.runtime.emit_finish(Some(session_id));
+                Ok(())
+            }
+            Ok(PromptOutcome::EmptyResponse { session_id, error }) => {
+                info!(
+                    agent_type = "acp",
+                    terminal_kind = "error",
+                    source = "empty_response",
+                    session_id = %session_id,
+                    "ACP send_message completed without visible output"
+                );
+                self.runtime.emit_error_data(error);
                 Ok(())
             }
             Err(err) => {
@@ -681,12 +705,7 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
             session.record_close_reason(Some(CloseReason::UserCancel));
         }
 
-        // Force status to Finished and emit unconditionally, bypassing the
-        // absorbing-state guard. This ensures StreamRelay always receives
-        // its terminal event regardless of prior state.
-        self.runtime.reset_for_new_turn(ConversationStatus::Finished);
-        self.runtime
-            .emit(AgentStreamEvent::Finish(FinishEventData { session_id: None }));
+        self.runtime.emit_finish(None);
 
         Ok(())
     }

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -705,6 +705,13 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
             session.record_close_reason(Some(CloseReason::UserCancel));
         }
 
+        info!(
+            agent_type = "acp",
+            terminal_kind = "finish",
+            source = "cancel_request",
+            session_id = session_id.as_deref().unwrap_or("none"),
+            "ACP cancel emitting terminal finish"
+        );
         self.runtime.emit_finish(None);
 
         Ok(())

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -2,8 +2,7 @@ use crate::manager::acp::AcpAgentManager;
 use crate::manager::acp::mode_normalize::agent_metadata_uses_meta_resume;
 use crate::protocol::error::AcpError;
 use crate::protocol::events::{
-    AgentStreamEvent, AvailableCommandsEventData, ErrorEventData, FinishEventData, SessionAssignedEventData,
-    StartEventData,
+    AgentStreamEvent, AvailableCommandsEventData, ErrorEventData, SessionAssignedEventData, StartEventData,
 };
 use crate::shared_kernel::SessionId as DomainSessionId;
 use crate::types::SendMessageData;
@@ -20,6 +19,13 @@ use super::error_mapping::{
     AcpSendFailure, acp_error_to_app_error, is_acp_session_not_found, is_mapped_acp_session_not_found,
 };
 use tracing::warn;
+
+#[derive(Debug)]
+pub(super) enum PromptOutcome {
+    Completed { session_id: String },
+    Cancelled { session_id: String },
+    EmptyResponse { session_id: String, error: ErrorEventData },
+}
 
 impl AcpAgentManager {
     /// Establish a fresh ACP session (session/new) and apply desired
@@ -228,7 +234,7 @@ impl AcpAgentManager {
         &self,
         data: &SendMessageData,
         session_id: Option<&str>,
-    ) -> Result<(), AcpSendFailure> {
+    ) -> Result<PromptOutcome, AcpSendFailure> {
         let sid = session_id
             .ok_or_else(|| AppError::Internal("Cannot prompt: no session ID available".into()))
             .map_err(AcpSendFailure::from)?;
@@ -255,24 +261,11 @@ impl AcpAgentManager {
             .await
             .map_err(AcpSendFailure::from)?;
 
-        // Diagnose the "blank reply" case: the agent finished a turn without
-        // producing any user-visible output. We surface a structured error to
-        // the renderer so the user gets actionable feedback instead of a
-        // silent success. Cancelled turns are deliberately excluded — the
-        // user already initiated the cancel and doesn't need a second
-        // notification.
-        if !matches!(prompt_response.stop_reason, StopReason::Cancelled) && is_empty_turn(&mut probe_rx) {
-            self.runtime.emit(AgentStreamEvent::Error(empty_finish_diagnostic_error(
-                prompt_response.stop_reason,
-            )));
-        }
-
-        // Emit Finish event
-        self.runtime.emit(AgentStreamEvent::Finish(FinishEventData {
-            session_id: Some(sid.to_owned()),
-        }));
-
-        Ok(())
+        Ok(prompt_outcome_from_stop_reason(
+            sid,
+            prompt_response.stop_reason,
+            is_empty_turn(&mut probe_rx),
+        ))
     }
 
     /// Emit model/mode/config events from the session aggregate so the frontend
@@ -376,6 +369,25 @@ fn event_is_user_visible_output(event: &AgentStreamEvent) -> bool {
     )
 }
 
+fn prompt_outcome_from_stop_reason(session_id: &str, stop_reason: StopReason, empty_turn: bool) -> PromptOutcome {
+    if matches!(stop_reason, StopReason::Cancelled) {
+        return PromptOutcome::Cancelled {
+            session_id: session_id.to_owned(),
+        };
+    }
+
+    if empty_turn {
+        return PromptOutcome::EmptyResponse {
+            session_id: session_id.to_owned(),
+            error: empty_finish_diagnostic_error(stop_reason),
+        };
+    }
+
+    PromptOutcome::Completed {
+        session_id: session_id.to_owned(),
+    }
+}
+
 fn empty_finish_diagnostic_error(stop_reason: StopReason) -> ErrorEventData {
     ErrorEventData::classified(
         // TODO(i18n): wire to a frontend translation key once a
@@ -432,6 +444,7 @@ mod tests {
     use crate::protocol::error::AcpError;
     use crate::shared_kernel::SessionId as DomainSessionId;
     use agent_client_protocol::schema::AgentCapabilities;
+    use aionui_api_types::AgentErrorCode;
 
     fn make_session() -> AcpSession {
         AcpSession::new(None, None, Default::default())
@@ -702,5 +715,43 @@ mod tests {
             .expect("empty-finish classified errors must include a resolution");
         assert_eq!(resolution.kind, AgentErrorResolutionKind::SendFeedback);
         assert_eq!(resolution.target, Some(AgentErrorResolutionTarget::Feedback));
+    }
+
+    #[test]
+    fn prompt_outcome_empty_response_maps_to_error_without_finish() {
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true);
+
+        match outcome {
+            super::PromptOutcome::EmptyResponse { session_id, error } => {
+                assert_eq!(session_id, "sess-1");
+                assert_eq!(error.code, Some(AgentErrorCode::UnknownUpstreamError));
+                assert_eq!(error.feedback_recommended, Some(true));
+            }
+            other => panic!("expected EmptyResponse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prompt_outcome_cancelled_takes_priority_over_empty_response() {
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::Cancelled, true);
+
+        match outcome {
+            super::PromptOutcome::Cancelled { session_id } => {
+                assert_eq!(session_id, "sess-1");
+            }
+            other => panic!("expected Cancelled, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prompt_outcome_completed_when_visible_output_exists() {
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, false);
+
+        match outcome {
+            super::PromptOutcome::Completed { session_id } => {
+                assert_eq!(session_id, "sess-1");
+            }
+            other => panic!("expected Completed, got {other:?}"),
+        }
     }
 }

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -249,15 +249,13 @@ impl crate::agent_task::IAgentTask for AionrsAgentManager {
                     conversation_id = %self.runtime.conversation_id(),
                     elapsed_ms,
                     error = %ErrorChain(&e),
-                    "Aionrs engine.run() failed, emitting Error+Finish"
+                    "Aionrs engine.run() failed, emitting Error"
                 );
                 let send_error = aionrs_engine_error_to_send_error(error_msg);
                 self.runtime.emit_error_data(send_error.stream_error().clone());
-                self.runtime.emit_finish(None);
                 Err(send_error)
             }
             None => {
-                self.runtime.emit_error("Stopped by user");
                 self.runtime.emit_finish(None);
                 Ok(())
             }

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use aion_agent::bootstrap::AgentBootstrap;
 use aion_agent::engine::AgentEngine;
@@ -15,7 +16,7 @@ use aionui_common::{
 };
 use serde_json::Value;
 use tokio::sync::{Mutex, Notify, broadcast};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::agent_runtime::AgentRuntime;
 use crate::capability::backend_output_sink::BackendOutputSink;
@@ -42,6 +43,8 @@ pub struct AionrsAgentManager {
     /// Signalled by `cancel()` to abort an in-flight `engine.run()` via
     /// `tokio::select!` in `send_message()`.
     cancel_notify: Arc<Notify>,
+    /// Signalled after an in-flight turn emits its terminal event.
+    turn_finished_notify: Arc<Notify>,
 }
 
 impl Drop for AionrsAgentManager {
@@ -156,10 +159,11 @@ impl AionrsAgentManager {
             approval_manager,
             confirmations,
             cancel_notify: Arc::new(Notify::new()),
+            turn_finished_notify: Arc::new(Notify::new()),
         })
     }
 
-    fn request_stop(&self, reason: Option<AgentKillReason>, operation: &'static str) {
+    fn request_stop(&self, reason: Option<AgentKillReason>, operation: &'static str) -> bool {
         let was_running = self.runtime.status() == Some(ConversationStatus::Running);
 
         if let Ok(mut confs) = self.confirmations.write() {
@@ -177,6 +181,8 @@ impl AionrsAgentManager {
             operation,
             "Aionrs stop signal requested"
         );
+
+        was_running
     }
 }
 
@@ -233,7 +239,7 @@ impl crate::agent_task::IAgentTask for AionrsAgentManager {
         let elapsed_ms = now_ms() - started_at;
         self.runtime.bump_activity();
 
-        match result {
+        let send_result = match result {
             Some(Ok(_)) => {
                 info!(
                     conversation_id = %self.runtime.conversation_id(),
@@ -259,7 +265,9 @@ impl crate::agent_task::IAgentTask for AionrsAgentManager {
                 self.runtime.emit_finish(None);
                 Ok(())
             }
-        }
+        };
+        self.turn_finished_notify.notify_waiters();
+        send_result
     }
 
     async fn cancel(&self) -> Result<(), AppError> {
@@ -278,8 +286,27 @@ impl AionrsAgentManager {
         &self,
         reason: Option<AgentKillReason>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
-        let _ = crate::agent_task::IAgentTask::kill(self, reason);
-        Box::pin(std::future::ready(()))
+        let was_running = self.request_stop(reason, "kill");
+        let turn_finished_notify = Arc::clone(&self.turn_finished_notify);
+        let runtime = self.runtime.clone();
+        let conversation_id = self.runtime.conversation_id().to_owned();
+
+        Box::pin(async move {
+            if was_running
+                && tokio::time::timeout(Duration::from_secs(5), async {
+                    while runtime.status() == Some(ConversationStatus::Running) {
+                        turn_finished_notify.notified().await;
+                    }
+                })
+                .await
+                .is_err()
+            {
+                warn!(
+                    conversation_id,
+                    "Timed out waiting for aionrs turn to finish after kill"
+                );
+            }
+        })
     }
 }
 
@@ -469,6 +496,30 @@ mod tests {
         tokio::time::timeout(std::time::Duration::from_millis(50), &mut notified)
             .await
             .expect("running kill should wake in-flight turn");
+    }
+
+    #[tokio::test]
+    async fn aionrs_agent_kill_and_wait_waits_for_running_turn_terminal() {
+        let agent = AionrsAgentManager::new("conv-1".into(), "/project".into(), make_test_config(), None)
+            .await
+            .unwrap();
+        agent.runtime.reset_for_new_turn(ConversationStatus::Running);
+
+        let wait = agent.kill_and_wait(Some(AgentKillReason::ConversationDeleted));
+        tokio::pin!(wait);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), &mut wait)
+                .await
+                .is_err(),
+            "kill_and_wait must not return before a running turn reaches a terminal event"
+        );
+
+        agent.runtime.emit_finish(None);
+        agent.turn_finished_notify.notify_waiters();
+
+        tokio::time::timeout(std::time::Duration::from_millis(50), &mut wait)
+            .await
+            .expect("kill_and_wait should return after terminal notification");
     }
 
     #[tokio::test]

--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -555,49 +555,155 @@ fn is_streaming_chunk(body: &str) -> bool {
     matches!(kind, Some(k) if STREAMING_KINDS.contains(&k))
 }
 
+struct AcpLogSummary {
+    payload_bytes: usize,
+    payload_json: bool,
+    session_id: Option<String>,
+    session_update_kind: Option<String>,
+}
+
+impl AcpLogSummary {
+    fn from_payload(payload: &str) -> Self {
+        let payload_bytes = payload.len();
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(payload) else {
+            return Self {
+                payload_bytes,
+                payload_json: false,
+                session_id: None,
+                session_update_kind: None,
+            };
+        };
+
+        Self {
+            payload_bytes,
+            payload_json: true,
+            session_id: string_pointer(&value, &["/sessionId", "/session_id"]),
+            session_update_kind: string_pointer(&value, &["/update/sessionUpdate", "/update/session_update"]),
+        }
+    }
+}
+
+fn string_pointer(value: &serde_json::Value, pointers: &[&str]) -> Option<String> {
+    pointers
+        .iter()
+        .find_map(|pointer| value.pointer(pointer).and_then(serde_json::Value::as_str))
+        .map(str::to_owned)
+}
+
 /// Log a JSON-RPC request from AionUi to the ACP agent.
 /// `session/prompt` carries large user input and stays at debug.
 fn log_client_request(method: &str, body: &str) {
+    let summary = AcpLogSummary::from_payload(body);
     if method == "session/prompt" {
-        debug!(direction = "client_request", method, body, "[ACP] ->");
+        debug!(
+            direction = "client_request",
+            method,
+            payload_bytes = summary.payload_bytes,
+            payload_json = summary.payload_json,
+            session_id = summary.session_id.as_deref().unwrap_or("none"),
+            "[ACP] ->"
+        );
     } else {
-        info!(direction = "client_request", method, body, "[ACP] ->");
+        info!(
+            direction = "client_request",
+            method,
+            payload_bytes = summary.payload_bytes,
+            payload_json = summary.payload_json,
+            session_id = summary.session_id.as_deref().unwrap_or("none"),
+            "[ACP] ->"
+        );
     }
 }
 
 /// Log a JSON-RPC response from the ACP agent.
 /// `session/prompt` reply is large; stays at debug.
 fn log_agent_response(method: &str, body: &str) {
+    let summary = AcpLogSummary::from_payload(body);
     if method == "session/prompt" {
-        debug!(direction = "agent_response", method, body, "[ACP] <- ${method}");
+        debug!(
+            direction = "agent_response",
+            method,
+            payload_bytes = summary.payload_bytes,
+            payload_json = summary.payload_json,
+            session_id = summary.session_id.as_deref().unwrap_or("none"),
+            "[ACP] <- ${method}"
+        );
     } else {
-        info!(direction = "agent_response", method, body, "[ACP] <- ${method}");
+        info!(
+            direction = "agent_response",
+            method,
+            payload_bytes = summary.payload_bytes,
+            payload_json = summary.payload_json,
+            session_id = summary.session_id.as_deref().unwrap_or("none"),
+            "[ACP] <- ${method}"
+        );
     }
 }
 
 /// Log a fire-and-forget notification from AionUi to the agent.
 fn log_client_notify(method: &str, body: &str) {
-    info!(direction = "client_notify", method, body, "[ACP] -> ${method}");
+    let summary = AcpLogSummary::from_payload(body);
+    info!(
+        direction = "client_notify",
+        method,
+        payload_bytes = summary.payload_bytes,
+        payload_json = summary.payload_json,
+        session_id = summary.session_id.as_deref().unwrap_or("none"),
+        "[ACP] -> ${method}"
+    );
 }
 
 /// Log an inbound notification from the agent.
 /// `session/update` requires per-kind filtering — streaming chunks stay at debug.
 fn log_agent_notify(method: &str, body: &str) {
+    let summary = AcpLogSummary::from_payload(body);
     if method == "session/update" && is_streaming_chunk(body) {
-        debug!(direction = "agent_notify", method, body, "[ACP] <- ${method}");
+        debug!(
+            direction = "agent_notify",
+            method,
+            payload_bytes = summary.payload_bytes,
+            payload_json = summary.payload_json,
+            session_id = summary.session_id.as_deref().unwrap_or("none"),
+            session_update_kind = summary.session_update_kind.as_deref().unwrap_or("none"),
+            "[ACP] <- ${method}"
+        );
     } else {
-        info!(direction = "agent_notify", method, body, "[ACP] <- ${method}");
+        info!(
+            direction = "agent_notify",
+            method,
+            payload_bytes = summary.payload_bytes,
+            payload_json = summary.payload_json,
+            session_id = summary.session_id.as_deref().unwrap_or("none"),
+            session_update_kind = summary.session_update_kind.as_deref().unwrap_or("none"),
+            "[ACP] <- ${method}"
+        );
     }
 }
 
 /// Log an inbound request from the agent (e.g. session/request_permission).
 fn log_agent_request(method: &str, body: &str) {
-    info!(direction = "agent_request", method, body, "[ACP] <- ${method}");
+    let summary = AcpLogSummary::from_payload(body);
+    info!(
+        direction = "agent_request",
+        method,
+        payload_bytes = summary.payload_bytes,
+        payload_json = summary.payload_json,
+        session_id = summary.session_id.as_deref().unwrap_or("none"),
+        "[ACP] <- ${method}"
+    );
 }
 
 /// Log a JSON-RPC response from AionUi back to the agent.
 fn log_client_response(method: &str, body: &str) {
-    info!(direction = "client_response", method, body, "[ACP] -> ${method}");
+    let summary = AcpLogSummary::from_payload(body);
+    info!(
+        direction = "client_response",
+        method,
+        payload_bytes = summary.payload_bytes,
+        payload_json = summary.payload_json,
+        session_id = summary.session_id.as_deref().unwrap_or("none"),
+        "[ACP] -> ${method}"
+    );
 }
 
 impl std::fmt::Debug for AcpProtocol {
@@ -611,6 +717,40 @@ impl std::fmt::Debug for AcpProtocol {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn capture_logs(max_level: tracing::Level, f: impl FnOnce()) -> String {
+        use std::io::Write;
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::fmt;
+
+        #[derive(Clone)]
+        struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+        impl Write for SharedBuf {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let make_writer = {
+            let buffer = Arc::clone(&buffer);
+            move || SharedBuf(Arc::clone(&buffer))
+        };
+
+        let subscriber = fmt::Subscriber::builder()
+            .with_max_level(max_level)
+            .with_writer(make_writer)
+            .with_ansi(false)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, f);
+
+        String::from_utf8(buffer.lock().unwrap().clone()).unwrap()
+    }
 
     #[test]
     fn replay_suppression_guard_sets_and_clears_flag() {
@@ -663,40 +803,13 @@ mod tests {
     }
 
     #[test]
-    fn log_agent_notify_filters_streaming_chunks_at_info_level() {
-        use std::io::Write;
-        use std::sync::{Arc, Mutex};
+    fn log_agent_notify_filters_streaming_chunks_and_omits_raw_body() {
         use tracing::Level;
-        use tracing_subscriber::fmt;
 
-        #[derive(Clone)]
-        struct SharedBuf(Arc<Mutex<Vec<u8>>>);
-        impl Write for SharedBuf {
-            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-                self.0.lock().unwrap().extend_from_slice(buf);
-                Ok(buf.len())
-            }
-            fn flush(&mut self) -> std::io::Result<()> {
-                Ok(())
-            }
-        }
-
-        let buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
-        let make_writer = {
-            let buffer = Arc::clone(&buffer);
-            move || SharedBuf(Arc::clone(&buffer))
-        };
-
-        let subscriber = fmt::Subscriber::builder()
-            .with_max_level(Level::INFO)
-            .with_writer(make_writer)
-            .with_ansi(false)
-            .finish();
-
-        tracing::subscriber::with_default(subscriber, || {
+        let captured = capture_logs(Level::INFO, || {
             log_agent_notify(
                 "session/update",
-                r#"{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk"}}"#,
+                r#"{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hidden stream text"}}}"#,
             );
             log_agent_notify(
                 "session/update",
@@ -704,7 +817,6 @@ mod tests {
             );
         });
 
-        let captured = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
         assert!(
             !captured.contains("agent_message_chunk"),
             "streaming chunk should NOT appear at info level: {captured}"
@@ -714,12 +826,53 @@ mod tests {
             "non-streaming update should appear at info level: {captured}"
         );
         assert!(
+            !captured.contains("hidden stream text"),
+            "streaming content should not be logged: {captured}"
+        );
+        assert!(
+            !captured.contains("modeId") && !captured.contains("yolo"),
+            "raw notification body should not be logged: {captured}"
+        );
+        assert!(
             captured.contains("agent_notify"),
             "structured `direction` field should be `agent_notify`: {captured}"
         );
         assert!(
             captured.contains("session/update"),
             "structured `method` field should be present: {captured}"
+        );
+        assert!(
+            captured.contains("payload_bytes"),
+            "payload size summary should be present: {captured}"
+        );
+    }
+
+    #[test]
+    fn log_client_request_omits_prompt_body_even_at_debug_level() {
+        use tracing::Level;
+
+        let captured = capture_logs(Level::DEBUG, || {
+            log_client_request(
+                "session/prompt",
+                r#"{"sessionId":"s1","prompt":[{"type":"text","text":"secret prompt text"}]}"#,
+            );
+        });
+
+        assert!(
+            captured.contains("client_request"),
+            "structured `direction` field should be present: {captured}"
+        );
+        assert!(
+            captured.contains("session/prompt"),
+            "structured `method` field should be present: {captured}"
+        );
+        assert!(
+            captured.contains("payload_bytes"),
+            "payload size summary should be present: {captured}"
+        );
+        assert!(
+            !captured.contains("secret prompt text") && !captured.contains("\"prompt\""),
+            "raw prompt body should not be logged: {captured}"
         );
     }
 

--- a/crates/aionui-ai-agent/src/task_manager.rs
+++ b/crates/aionui-ai-agent/src/task_manager.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use aionui_common::{
-    AgentKillReason, AgentType, AppError, ConversationStatus, ErrorChain, OnConversationDelete, TimestampMs, now_ms,
+    AgentKillReason, AgentType, AppError, ConversationStatus, OnConversationDelete, TimestampMs, now_ms,
 };
 use async_trait::async_trait;
 use dashmap::DashMap;
 use futures_util::future::BoxFuture;
 use tokio::sync::OnceCell;
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::agent_task::AgentInstance;
 use crate::types::BuildTaskOptions;
@@ -186,13 +186,8 @@ impl IWorkerTaskManager for WorkerTaskManagerImpl {
 #[async_trait]
 impl OnConversationDelete for WorkerTaskManagerImpl {
     async fn on_conversation_deleted(&self, conversation_id: &str) {
-        if let Err(e) = self.kill(conversation_id, Some(AgentKillReason::ConversationDeleted)) {
-            warn!(
-                conversation_id,
-                error = %ErrorChain(&e),
-                "Failed to kill agent task on conversation delete (non-fatal)",
-            );
-        }
+        self.kill_and_wait(conversation_id, Some(AgentKillReason::ConversationDeleted))
+            .await;
     }
 }
 

--- a/crates/aionui-ai-agent/src/task_manager.rs
+++ b/crates/aionui-ai-agent/src/task_manager.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use aionui_common::{
-    AgentKillReason, AgentType, AppError, ConversationStatus, OnConversationDelete, TimestampMs, now_ms,
+    AgentKillReason, AgentType, AppError, ConversationStatus, ErrorChain, OnConversationDelete, TimestampMs, now_ms,
 };
 use async_trait::async_trait;
 use dashmap::DashMap;
 use futures_util::future::BoxFuture;
 use tokio::sync::OnceCell;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::agent_task::AgentInstance;
 use crate::types::BuildTaskOptions;
@@ -186,8 +186,13 @@ impl IWorkerTaskManager for WorkerTaskManagerImpl {
 #[async_trait]
 impl OnConversationDelete for WorkerTaskManagerImpl {
     async fn on_conversation_deleted(&self, conversation_id: &str) {
-        self.kill_and_wait(conversation_id, Some(AgentKillReason::ConversationDeleted))
-            .await;
+        if let Err(e) = self.kill(conversation_id, Some(AgentKillReason::ConversationDeleted)) {
+            warn!(
+                conversation_id,
+                error = %ErrorChain(&e),
+                "Failed to kill agent task on conversation delete (non-fatal)",
+            );
+        }
     }
 }
 

--- a/crates/aionui-app/src/bootstrap/tracing_init.rs
+++ b/crates/aionui-app/src/bootstrap/tracing_init.rs
@@ -17,6 +17,11 @@ const NOISE_SUPPRESSIONS: &[&str] = &[
     // out of default dev logs; aionui_ai_agent::protocol::acp emits sanitized
     // summaries for the ACP flow we need to debug.
     "agent_client_protocol::jsonrpc=info",
+    // Aionrs provider/agent debug logs include raw request bodies and SSE
+    // chunks. Keep lifecycle info logs, but do not write prompt/output
+    // payloads by default.
+    "aion_agent=info",
+    "aion_providers=info",
 ];
 
 const AIONRS_TARGETS: &[&str] = &[
@@ -30,6 +35,8 @@ const AIONRS_TARGETS: &[&str] = &[
     "aion_skills",
     "aion_memory",
 ];
+
+const RAW_AIONRS_PAYLOAD_TARGETS: &[&str] = &["aion_agent", "aion_providers"];
 
 fn build_env_filter(log_level: Option<&str>) -> EnvFilter {
     let user_directives = log_level.unwrap_or("info");
@@ -46,6 +53,22 @@ fn build_backend_filter(log_level: Option<&str>) -> EnvFilter {
         .collect::<Vec<_>>()
         .join(",");
     EnvFilter::new(format!("{suppressions},{aionrs_off},{user_directives}"))
+}
+
+fn build_aionrs_level(log_level: Option<&str>) -> String {
+    let level = log_level.unwrap_or("info");
+    AIONRS_TARGETS
+        .iter()
+        .map(|target| {
+            let target_level = if RAW_AIONRS_PAYLOAD_TARGETS.contains(target) {
+                "info"
+            } else {
+                level
+            };
+            format!("{target}={target_level}")
+        })
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 /// RAII guards that flush log buffers on drop. Hold for the process lifetime.
@@ -75,14 +98,7 @@ pub fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> LogGuards {
         .with_filter(build_backend_filter(log_level));
 
     // Aionrs file layer — only aion_* targets
-    let aionrs_level = {
-        let level = log_level.unwrap_or("info");
-        AIONRS_TARGETS
-            .iter()
-            .map(|t| format!("{t}={level}"))
-            .collect::<Vec<_>>()
-            .join(",")
-    };
+    let aionrs_level = build_aionrs_level(log_level);
     let aionrs_resolved = aion_config::logging::ResolvedLogging {
         enabled: true,
         level: aionrs_level,
@@ -136,5 +152,32 @@ mod tests {
                 "AionUi ACP sanitized debug summaries should still be available"
             );
         });
+    }
+
+    #[test]
+    fn env_filter_suppresses_raw_aionrs_provider_debug_even_when_debug_enabled() {
+        let subscriber = tracing_subscriber::registry().with(build_env_filter(Some("debug")));
+        tracing::subscriber::with_default(subscriber, || {
+            assert!(
+                !tracing::enabled!(target: "aion_agent", Level::DEBUG),
+                "aion_agent debug logs include raw request bodies"
+            );
+            assert!(
+                !tracing::enabled!(target: "aion_providers", Level::DEBUG),
+                "aion_providers debug logs include raw SSE chunks"
+            );
+            assert!(
+                tracing::enabled!(target: "aionui_ai_agent::manager::aionrs::agent", Level::DEBUG),
+                "AionUi aionrs lifecycle debug logs should still be available"
+            );
+        });
+    }
+
+    #[test]
+    fn aionrs_file_level_suppresses_raw_provider_targets_even_when_debug_enabled() {
+        let level = build_aionrs_level(Some("debug"));
+        assert!(level.contains("aion_agent=info"), "{level}");
+        assert!(level.contains("aion_providers=info"), "{level}");
+        assert!(level.contains("aion_tools=debug"), "{level}");
     }
 }

--- a/crates/aionui-app/src/bootstrap/tracing_init.rs
+++ b/crates/aionui-app/src/bootstrap/tracing_init.rs
@@ -8,7 +8,16 @@ use std::path::Path;
 
 use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
-const NOISE_SUPPRESSIONS: &[&str] = &["sqlx::query=warn", "hyper_util=warn", "reqwest=warn"];
+const NOISE_SUPPRESSIONS: &[&str] = &[
+    "sqlx::query=warn",
+    "hyper_util=warn",
+    "reqwest=warn",
+    // The ACP SDK logs raw UntypedMessage values at debug/trace, including
+    // session/update chunks with user/agent text. Keep its protocol internals
+    // out of default dev logs; aionui_ai_agent::protocol::acp emits sanitized
+    // summaries for the ACP flow we need to debug.
+    "agent_client_protocol::jsonrpc=info",
+];
 
 const AIONRS_TARGETS: &[&str] = &[
     "aion_agent",
@@ -91,5 +100,41 @@ pub fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> LogGuards {
     LogGuards {
         _backend: backend_guard,
         _aionrs: aionrs_guard,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing::Level;
+
+    #[test]
+    fn env_filter_suppresses_raw_acp_sdk_jsonrpc_debug_even_when_debug_enabled() {
+        let subscriber = tracing_subscriber::registry().with(build_env_filter(Some("debug")));
+        tracing::subscriber::with_default(subscriber, || {
+            assert!(
+                !tracing::enabled!(target: "agent_client_protocol::jsonrpc::handlers", Level::DEBUG),
+                "ACP SDK JSON-RPC debug logs include raw UntypedMessage payloads"
+            );
+            assert!(
+                tracing::enabled!(target: "aionui_ai_agent::protocol::acp", Level::DEBUG),
+                "AionUi ACP sanitized debug summaries should still be available"
+            );
+        });
+    }
+
+    #[test]
+    fn backend_filter_suppresses_raw_acp_sdk_jsonrpc_debug_even_when_debug_enabled() {
+        let subscriber = tracing_subscriber::registry().with(build_backend_filter(Some("debug")));
+        tracing::subscriber::with_default(subscriber, || {
+            assert!(
+                !tracing::enabled!(target: "agent_client_protocol::jsonrpc::handlers", Level::DEBUG),
+                "ACP SDK JSON-RPC debug logs include raw UntypedMessage payloads"
+            );
+            assert!(
+                tracing::enabled!(target: "aionui_ai_agent::protocol::acp", Level::DEBUG),
+                "AionUi ACP sanitized debug summaries should still be available"
+            );
+        });
     }
 }

--- a/crates/aionui-common/src/hooks.rs
+++ b/crates/aionui-common/src/hooks.rs
@@ -6,7 +6,7 @@
 
 use async_trait::async_trait;
 
-/// Notified when a conversation row is deleted via
+/// Notified before a conversation row is deleted via
 /// `ConversationService::delete`.
 ///
 /// Implementors are responsible for cleaning up their per-conversation state

--- a/crates/aionui-conversation/src/runtime_state.rs
+++ b/crates/aionui-conversation/src/runtime_state.rs
@@ -160,4 +160,38 @@ mod tests {
         assert!(summary.is_processing);
         assert!(!summary.can_send_message);
     }
+
+    #[test]
+    fn summary_waiting_confirmation_takes_priority() {
+        let state = Arc::new(ConversationRuntimeStateService::default());
+        let _claim = state.try_claim_turn("conv-1").expect("claim should be created");
+
+        let summary = state.summary_from_parts("conv-1", Some(ConversationStatus::Running), true, 1);
+
+        assert_eq!(summary.state, ConversationRuntimeStateKind::WaitingConfirmation);
+        assert!(summary.is_processing);
+        assert!(!summary.can_send_message);
+    }
+
+    #[test]
+    fn summary_uses_running_task_without_claim() {
+        let state = Arc::new(ConversationRuntimeStateService::default());
+
+        let summary = state.summary_from_parts("conv-1", Some(ConversationStatus::Running), true, 0);
+
+        assert_eq!(summary.state, ConversationRuntimeStateKind::Running);
+        assert!(summary.is_processing);
+        assert!(!summary.can_send_message);
+    }
+
+    #[test]
+    fn summary_idle_when_no_claim_running_task_or_confirmation() {
+        let state = Arc::new(ConversationRuntimeStateService::default());
+
+        let summary = state.summary_from_parts("conv-1", Some(ConversationStatus::Finished), true, 0);
+
+        assert_eq!(summary.state, ConversationRuntimeStateKind::Idle);
+        assert!(!summary.is_processing);
+        assert!(summary.can_send_message);
+    }
 }

--- a/crates/aionui-conversation/src/runtime_state.rs
+++ b/crates/aionui-conversation/src/runtime_state.rs
@@ -138,37 +138,46 @@ impl ConversationRuntimeStateService {
         }
     }
 
-    fn release(&self, conversation_id: &str) {
+    fn release(&self, conversation_id: &str) -> bool {
         match self.state.lock() {
             Ok(mut state) => {
                 state.active_turns.remove(conversation_id);
-                state.deleting_conversations.remove(conversation_id);
-                info!(conversation_id, "conversation runtime turn claim released");
+                let was_deleting = state.deleting_conversations.remove(conversation_id);
+                info!(
+                    conversation_id,
+                    deleting = was_deleting,
+                    "conversation runtime turn claim released"
+                );
+                was_deleting
             }
             Err(_) => {
                 warn!(
                     conversation_id,
                     "conversation runtime state lock poisoned while releasing turn"
                 );
+                false
             }
         }
     }
 }
 
 impl TurnClaim {
-    pub fn release(&mut self) {
-        self.release_inner();
+    pub fn release(&mut self) -> bool {
+        self.release_inner()
     }
 
-    fn release_inner(&mut self) {
+    fn release_inner(&mut self) -> bool {
         if self.released {
-            return;
+            return false;
         }
 
-        if let Some(state) = self.state.upgrade() {
-            state.release(&self.conversation_id);
-        }
+        let was_deleting = self
+            .state
+            .upgrade()
+            .map(|state| state.release(&self.conversation_id))
+            .unwrap_or(false);
         self.released = true;
+        was_deleting
     }
 }
 
@@ -220,12 +229,12 @@ mod tests {
     #[test]
     fn release_clears_deleting_flag_for_active_turn() {
         let state = Arc::new(ConversationRuntimeStateService::default());
-        let claim = state.try_claim_turn("conv-1").expect("claim should be created");
+        let mut claim = state.try_claim_turn("conv-1").expect("claim should be created");
 
         state.mark_deleting("conv-1");
         assert!(state.is_deleting("conv-1"));
 
-        drop(claim);
+        assert!(claim.release());
 
         assert!(!state.is_deleting("conv-1"));
     }

--- a/crates/aionui-conversation/src/runtime_state.rs
+++ b/crates/aionui-conversation/src/runtime_state.rs
@@ -9,7 +9,13 @@ use tracing::{info, warn};
 
 #[derive(Debug, Default)]
 pub struct ConversationRuntimeStateService {
-    active_turns: Mutex<HashSet<String>>,
+    state: Mutex<ConversationRuntimeState>,
+}
+
+#[derive(Debug, Default)]
+struct ConversationRuntimeState {
+    active_turns: HashSet<String>,
+    deleting_conversations: HashSet<String>,
 }
 
 #[derive(Debug)]
@@ -21,7 +27,7 @@ pub struct TurnClaim {
 
 impl ConversationRuntimeStateService {
     pub fn try_claim_turn(self: &Arc<Self>, conversation_id: &str) -> Result<TurnClaim, AppError> {
-        let mut active_turns = self.active_turns.lock().map_err(|_| {
+        let mut state = self.state.lock().map_err(|_| {
             warn!(
                 conversation_id,
                 "conversation runtime state lock poisoned while claiming turn"
@@ -29,7 +35,17 @@ impl ConversationRuntimeStateService {
             AppError::Internal("conversation runtime state lock poisoned".into())
         })?;
 
-        if !active_turns.insert(conversation_id.to_owned()) {
+        if state.deleting_conversations.contains(conversation_id) {
+            info!(
+                conversation_id,
+                "conversation runtime turn claim rejected because conversation is deleting"
+            );
+            return Err(AppError::Conflict(format!(
+                "conversation {conversation_id} is being deleted"
+            )));
+        }
+
+        if !state.active_turns.insert(conversation_id.to_owned()) {
             info!(conversation_id, "conversation runtime turn claim rejected");
             return Err(AppError::Conflict(format!(
                 "conversation {conversation_id} is already running"
@@ -46,9 +62,48 @@ impl ConversationRuntimeStateService {
     }
 
     pub fn is_claimed(&self, conversation_id: &str) -> bool {
-        self.active_turns
+        self.state
             .lock()
-            .map(|active_turns| active_turns.contains(conversation_id))
+            .map(|state| state.active_turns.contains(conversation_id))
+            .unwrap_or(false)
+    }
+
+    pub fn mark_deleting(&self, conversation_id: &str) -> bool {
+        match self.state.lock() {
+            Ok(mut state) => {
+                state.deleting_conversations.insert(conversation_id.to_owned());
+                let active = state.active_turns.contains(conversation_id);
+                info!(conversation_id, active, "conversation marked deleting");
+                active
+            }
+            Err(_) => {
+                warn!(
+                    conversation_id,
+                    "conversation runtime state lock poisoned while marking delete"
+                );
+                false
+            }
+        }
+    }
+
+    pub fn clear_deleting(&self, conversation_id: &str) {
+        match self.state.lock() {
+            Ok(mut state) => {
+                state.deleting_conversations.remove(conversation_id);
+            }
+            Err(_) => {
+                warn!(
+                    conversation_id,
+                    "conversation runtime state lock poisoned while clearing delete"
+                );
+            }
+        }
+    }
+
+    pub fn is_deleting(&self, conversation_id: &str) -> bool {
+        self.state
+            .lock()
+            .map(|state| state.deleting_conversations.contains(conversation_id))
             .unwrap_or(false)
     }
 
@@ -84,9 +139,10 @@ impl ConversationRuntimeStateService {
     }
 
     fn release(&self, conversation_id: &str) {
-        match self.active_turns.lock() {
-            Ok(mut active_turns) => {
-                active_turns.remove(conversation_id);
+        match self.state.lock() {
+            Ok(mut state) => {
+                state.active_turns.remove(conversation_id);
+                state.deleting_conversations.remove(conversation_id);
                 info!(conversation_id, "conversation runtime turn claim released");
             }
             Err(_) => {
@@ -147,6 +203,31 @@ mod tests {
 
         assert!(!state.is_claimed("conv-1"));
         assert!(state.try_claim_turn("conv-1").is_ok());
+    }
+
+    #[test]
+    fn deleting_rejects_new_turn_claims() {
+        let state = Arc::new(ConversationRuntimeStateService::default());
+
+        state.mark_deleting("conv-1");
+
+        let err = state
+            .try_claim_turn("conv-1")
+            .expect_err("deleting conversation should reject new turns");
+        assert!(err.to_string().contains("being deleted"));
+    }
+
+    #[test]
+    fn release_clears_deleting_flag_for_active_turn() {
+        let state = Arc::new(ConversationRuntimeStateService::default());
+        let claim = state.try_claim_turn("conv-1").expect("claim should be created");
+
+        state.mark_deleting("conv-1");
+        assert!(state.is_deleting("conv-1"));
+
+        drop(claim);
+
+        assert!(!state.is_deleting("conv-1"));
     }
 
     #[test]

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -1432,8 +1432,31 @@ impl ConversationService {
                 // 1. Send the message to the agent and concurrently run the relay to stream events.
                 tokio::spawn(async move {
                     if let Err(e) = send_agent.send_message(current_send).await {
-                        error!(conversation_id = %conv_id_send, error = %ErrorChain(&e), "Agent send_message failed");
-                        let _ = send_error_tx.send(e);
+                        let task_status = send_agent.status();
+                        let agent_type = send_agent.agent_type();
+                        error!(
+                            conversation_id = %conv_id_send,
+                            ?agent_type,
+                            ?task_status,
+                            error = %ErrorChain(&e),
+                            "Agent send_message failed"
+                        );
+                        if task_status == Some(ConversationStatus::Finished) {
+                            debug!(
+                                conversation_id = %conv_id_send,
+                                ?agent_type,
+                                "Agent send_message failure already published runtime terminal; skipping fallback stream error"
+                            );
+                        } else {
+                            warn!(
+                                conversation_id = %conv_id_send,
+                                ?agent_type,
+                                code = ?e.code(),
+                                ownership = ?e.ownership(),
+                                "Agent send_message returned error without runtime terminal; injecting fallback stream error"
+                            );
+                            let _ = send_error_tx.send(e);
+                        }
                     }
                 });
                 // 2. Wait for the agent to process the message and complete the turn, while the relay streams events in real time.

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -93,7 +93,7 @@ pub struct ConversationService {
     broadcaster: Arc<dyn EventBroadcaster>,
     skill_resolver: Arc<dyn SkillResolver>,
     task_manager: Arc<dyn IWorkerTaskManager>,
-    /// Hooks invoked at the end of `delete()` so other services
+    /// Hooks invoked during `delete()` before the DB row is removed so other services
     /// (`WorkerTaskManagerImpl`, `CronService`, …) can clean up their
     /// per-conversation state. Wrapped in `Arc<RwLock<…>>` so registration
     /// can happen post-construction without breaking the `Clone` impl —
@@ -157,8 +157,8 @@ impl ConversationService {
 
     /// Register a hook to be notified when a conversation is deleted.
     ///
-    /// Hooks are dispatched sequentially in registration order from
-    /// `delete()`. Used by `aionui-app` to wire up `WorkerTaskManagerImpl`
+    /// Hooks are dispatched sequentially in registration order before
+    /// `delete()` removes the conversation row. Used by `aionui-app` to wire up `WorkerTaskManagerImpl`
     /// (kill the agent process) and `CronService` (cascade-delete cron jobs).
     pub fn with_delete_hook(&self, hook: Arc<dyn OnConversationDelete>) {
         if let Ok(mut guard) = self.delete_hooks.write() {
@@ -835,6 +835,15 @@ impl ConversationService {
             .as_deref()
             .and_then(|s| string_to_enum::<ConversationSource>(s).ok());
 
+        // Snapshot the hook list under the read lock, then drop the guard
+        // before awaiting — `RwLockReadGuard` is not `Send`, so holding it
+        // across `.await` would make this future non-`Send`.
+        let hooks: Vec<Arc<dyn OnConversationDelete>> =
+            self.delete_hooks.read().map(|guard| guard.clone()).unwrap_or_default();
+        for hook in hooks {
+            hook.on_conversation_deleted(id).await;
+        }
+
         self.conversation_repo.delete(id).await?;
         // No FK / CASCADE on `acp_session`: clean it up here so non-ACP
         // conversations that used to be ACP (shouldn't happen but is
@@ -844,15 +853,6 @@ impl ConversationService {
                 error = %ErrorChain(&err),
                 "Failed to delete acp_session row on conversation delete"
             );
-        }
-
-        // Snapshot the hook list under the read lock, then drop the guard
-        // before awaiting — `RwLockReadGuard` is not `Send`, so holding it
-        // across `.await` would make this future non-`Send`.
-        let hooks: Vec<Arc<dyn OnConversationDelete>> =
-            self.delete_hooks.read().map(|guard| guard.clone()).unwrap_or_default();
-        for hook in hooks {
-            hook.on_conversation_deleted(id).await;
         }
 
         info!("Conversation deleted");

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -209,6 +209,14 @@ impl ConversationService {
     }
 
     pub async fn complete_turn(&self, conversation_id: &str) {
+        if self.runtime_state.is_deleting(conversation_id) {
+            debug!(
+                conversation_id,
+                "Skipping turn completion because conversation is deleting"
+            );
+            return;
+        }
+
         let runtime = self.runtime_summary_for(conversation_id).await;
         StreamRelay::complete_conversation_with_runtime(
             &self.conversation_repo,
@@ -217,6 +225,18 @@ impl ConversationService {
             Some(runtime),
         )
         .await;
+    }
+
+    async fn complete_released_turn(&self, conversation_id: &str, was_deleting: bool) {
+        if was_deleting {
+            debug!(
+                conversation_id,
+                "Skipping turn completion because conversation was deleting at claim release"
+            );
+            return;
+        }
+
+        self.complete_turn(conversation_id).await;
     }
 }
 
@@ -1370,9 +1390,16 @@ impl ConversationService {
                         error = %ErrorChain(&err),
                         "Agent task build failed"
                     );
-                    service.persist_and_broadcast_send_failure_tip(&conv_id, &err).await;
-                    turn_claim.release();
-                    service.complete_turn(&conv_id).await;
+                    if service.runtime_state.is_deleting(&conv_id) {
+                        debug!(
+                            conversation_id = %conv_id,
+                            "Skipping send failure persistence because conversation is deleting"
+                        );
+                    } else {
+                        service.persist_and_broadcast_send_failure_tip(&conv_id, &err).await;
+                    }
+                    let was_deleting = turn_claim.release();
+                    service.complete_released_turn(&conv_id, was_deleting).await;
                     return;
                 }
             };
@@ -1389,9 +1416,16 @@ impl ConversationService {
                     error = %ErrorChain(&err),
                     "Failed to persist resolved workspace"
                 );
-                service.persist_and_broadcast_send_failure_tip(&conv_id, &err).await;
-                turn_claim.release();
-                service.complete_turn(&conv_id).await;
+                if service.runtime_state.is_deleting(&conv_id) {
+                    debug!(
+                        conversation_id = %conv_id,
+                        "Skipping workspace failure persistence because conversation is deleting"
+                    );
+                } else {
+                    service.persist_and_broadcast_send_failure_tip(&conv_id, &err).await;
+                }
+                let was_deleting = turn_claim.release();
+                service.complete_released_turn(&conv_id, was_deleting).await;
                 return;
             }
 
@@ -1472,6 +1506,14 @@ impl ConversationService {
                 // 2. Wait for the agent to process the message and complete the turn, while the relay streams events in real time.
                 let outcome = relay.consume_with_send_error(rx, send_error_rx).await;
 
+                if runtime_state.is_deleting(&conv_id) {
+                    debug!(
+                        conversation_id = %conv_id,
+                        "Skipping post-terminal persistence because conversation is deleting"
+                    );
+                    break;
+                }
+
                 if let Some(session_key) = agent.get_session_key() {
                     persist_session_key(&repo, &conv_id, &session_key).await;
                 }
@@ -1499,8 +1541,8 @@ impl ConversationService {
                 ));
             }
 
-            turn_claim.release();
-            service.complete_turn(&conv_id).await;
+            let was_deleting = turn_claim.release();
+            service.complete_released_turn(&conv_id, was_deleting).await;
         });
 
         info!(

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -835,6 +835,8 @@ impl ConversationService {
             .as_deref()
             .and_then(|s| string_to_enum::<ConversationSource>(s).ok());
 
+        let had_active_turn = self.runtime_state.mark_deleting(id);
+
         // Snapshot the hook list under the read lock, then drop the guard
         // before awaiting — `RwLockReadGuard` is not `Send`, so holding it
         // across `.await` would make this future non-`Send`.
@@ -844,7 +846,13 @@ impl ConversationService {
             hook.on_conversation_deleted(id).await;
         }
 
-        self.conversation_repo.delete(id).await?;
+        if let Err(err) = self.conversation_repo.delete(id).await {
+            self.runtime_state.clear_deleting(id);
+            return Err(err.into());
+        }
+        if !had_active_turn {
+            self.runtime_state.clear_deleting(id);
+        }
         // No FK / CASCADE on `acp_session`: clean it up here so non-ACP
         // conversations that used to be ACP (shouldn't happen but is
         // cheap to cover) still drop their orphaned session row.
@@ -1336,6 +1344,7 @@ impl ConversationService {
         let repo = Arc::clone(&self.conversation_repo);
         let broadcaster = Arc::clone(&self.broadcaster);
         let cron_service = self.current_cron_service();
+        let runtime_state = self.runtime_state();
         let user_id_owned = user_id.to_owned();
         let service = self.clone();
         let task_manager = Arc::clone(task_manager);
@@ -1423,6 +1432,7 @@ impl ConversationService {
                     Arc::clone(&broadcaster),
                     cron_service.clone(),
                 )
+                .with_runtime_state(Arc::clone(&runtime_state))
                 .with_turn_completion(false);
 
                 let rx = agent.subscribe();

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1573,9 +1573,11 @@ impl IWorkerTaskManager for MockTaskManagerWithWorkspace {
 struct ScriptedAgent {
     conversation_id: String,
     agent_type: AgentType,
+    status: Option<ConversationStatus>,
     event_tx: broadcast::Sender<AgentStreamEvent>,
     scripts: Mutex<VecDeque<Vec<AgentStreamEvent>>>,
     sent_contents: Mutex<Vec<String>>,
+    send_error: Option<AgentSendError>,
 }
 
 impl ScriptedAgent {
@@ -1584,14 +1586,26 @@ impl ScriptedAgent {
         Self {
             conversation_id: conversation_id.to_owned(),
             agent_type: AgentType::Acp,
+            status: Some(ConversationStatus::Finished),
             event_tx,
             scripts: Mutex::new(VecDeque::from(scripts)),
             sent_contents: Mutex::new(vec![]),
+            send_error: None,
         }
     }
 
     fn with_agent_type(mut self, agent_type: AgentType) -> Self {
         self.agent_type = agent_type;
+        self
+    }
+
+    fn with_status(mut self, status: Option<ConversationStatus>) -> Self {
+        self.status = status;
+        self
+    }
+
+    fn with_send_error(mut self, error: AgentSendError) -> Self {
+        self.send_error = Some(error);
         self
     }
 
@@ -1615,7 +1629,7 @@ impl IAgentTask for ScriptedAgent {
     }
 
     fn status(&self) -> Option<ConversationStatus> {
-        Some(ConversationStatus::Finished)
+        self.status
     }
 
     fn last_activity_at(&self) -> TimestampMs {
@@ -1636,6 +1650,9 @@ impl IAgentTask for ScriptedAgent {
             .unwrap_or_else(|| vec![AgentStreamEvent::Finish(FinishEventData::default())]);
         for event in script {
             let _ = self.event_tx.send(event);
+        }
+        if let Some(error) = &self.send_error {
+            return Err(error.clone());
         }
         Ok(())
     }
@@ -2177,6 +2194,68 @@ async fn send_message_does_not_evict_non_acp_task_after_terminal_error() {
 
     assert_eq!(task_mgr.kill_count(), 0);
     assert_eq!(task_mgr.active_count(), 1);
+}
+
+#[tokio::test]
+async fn send_message_does_not_inject_send_error_when_runtime_terminal_exists() {
+    let (svc, _broadcaster, repo, _default_task_mgr) = make_service();
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let scripted_agent = Arc::new(
+        ScriptedAgent::new(
+            &conv.id,
+            vec![vec![AgentStreamEvent::Error(ErrorEventData::legacy(
+                "runtime already emitted",
+                Some(AgentErrorCode::UnknownUpstreamError),
+            ))]],
+        )
+        .with_send_error(AgentSendError::from_app_error(AppError::BadGateway(
+            "fallback should not render".into(),
+        ))),
+    );
+    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(scripted_agent));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    let messages = repo.get_messages(&conv.id, 1, 20, SortOrder::Asc).await.unwrap().items;
+    let tips: Vec<_> = messages.iter().filter(|msg| msg.r#type == "tips").collect();
+    assert_eq!(tips.len(), 1);
+    let content: serde_json::Value = serde_json::from_str(&tips[0].content).unwrap();
+    assert_eq!(content["content"], "runtime already emitted");
+}
+
+#[tokio::test]
+async fn send_message_injects_send_error_when_runtime_terminal_missing() {
+    let (svc, _broadcaster, repo, _default_task_mgr) = make_service();
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let scripted_agent = Arc::new(
+        ScriptedAgent::new(&conv.id, vec![vec![]])
+            .with_status(None)
+            .with_send_error(AgentSendError::from_app_error(AppError::BadGateway(
+                "provider returned 401 invalid api key".into(),
+            ))),
+    );
+    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(scripted_agent));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    let messages = repo.get_messages(&conv.id, 1, 20, SortOrder::Asc).await.unwrap().items;
+    let tips: Vec<_> = messages.iter().filter(|msg| msg.r#type == "tips").collect();
+    assert_eq!(tips.len(), 1);
+    let content: serde_json::Value = serde_json::from_str(&tips[0].content).unwrap();
+    assert_eq!(content["type"], "error");
+    assert_eq!(content["error"]["code"], "USER_LLM_PROVIDER_AUTH_FAILED");
 }
 
 // ── stop_stream tests ───────────────────────────────────────────

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -978,6 +978,38 @@ async fn delete_invokes_registered_hook() {
     assert_eq!(calls.as_slice(), &[conv.id]);
 }
 
+#[tokio::test]
+async fn delete_invokes_registered_hook_before_row_delete() {
+    use aionui_common::OnConversationDelete;
+
+    struct RowVisibleHook {
+        repo: Arc<MockRepo>,
+        observations: Mutex<Vec<bool>>,
+    }
+
+    #[async_trait::async_trait]
+    impl OnConversationDelete for RowVisibleHook {
+        async fn on_conversation_deleted(&self, conversation_id: &str) {
+            let exists = self.repo.get(conversation_id).await.unwrap().is_some();
+            self.observations.lock().unwrap().push(exists);
+        }
+    }
+
+    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let hook = Arc::new(RowVisibleHook {
+        repo: repo.clone(),
+        observations: Mutex::new(vec![]),
+    });
+    svc.with_delete_hook(hook.clone());
+
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+    svc.delete("user_1", &conv.id).await.unwrap();
+
+    let observations = hook.observations.lock().unwrap();
+    assert_eq!(observations.as_slice(), &[true]);
+    assert!(repo.get(&conv.id).await.unwrap().is_none());
+}
+
 // ── Broadcast payload tests ────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -13,8 +13,8 @@ use aionui_api_types::{AgentErrorCode, ConversationRuntimeSummary, WebSocketMess
 use aionui_common::{ErrorChain, normalize_keys_to_snake_case, now_ms};
 
 use crate::service::ConversationService;
-use aionui_db::IConversationRepository;
 use aionui_db::models::MessageRow;
+use aionui_db::{DbError, IConversationRepository};
 use aionui_realtime::EventBroadcaster;
 use serde_json::json;
 use tokio::sync::{broadcast, oneshot};
@@ -22,6 +22,18 @@ use tracing::{debug, error, info, warn};
 
 /// Number of text chunks to accumulate before flushing to the database.
 const FLUSH_INTERVAL: u32 = 20;
+
+fn is_not_found(err: &DbError) -> bool {
+    matches!(err, DbError::NotFound(_))
+}
+
+fn log_persist_error(err: &DbError, message: &'static str) {
+    if is_not_found(err) {
+        debug!(error = %ErrorChain(err), "{message}; conversation was likely deleted during stream finalization");
+    } else {
+        error!(error = %ErrorChain(err), "{message}");
+    }
+}
 
 #[derive(Debug, Clone)]
 struct TextSegmentState {
@@ -492,7 +504,8 @@ impl StreamRelay {
                 hidden: Some(false),
             };
             if let Err(e) = self.repo.update_message(&segment.id, &update).await {
-                error!(error = %ErrorChain(&e), "Failed to finalize text segment");
+                log_persist_error(&e, "Failed to finalize text segment");
+                return None;
             }
         } else {
             let row = MessageRow {
@@ -507,7 +520,8 @@ impl StreamRelay {
                 created_at: segment.created_at,
             };
             if let Err(e) = self.repo.insert_message(&row).await {
-                error!(error = %ErrorChain(&e), "Failed to create finalized text segment");
+                log_persist_error(&e, "Failed to create finalized text segment");
+                return None;
             }
         }
 
@@ -546,7 +560,7 @@ impl StreamRelay {
                         hidden: Some(hidden),
                     };
                     if let Err(e) = self.repo.update_message(&primary_segment.id, &update).await {
-                        error!(error = %ErrorChain(&e), "Failed to rewrite finalized text segment");
+                        log_persist_error(&e, "Failed to rewrite finalized text segment");
                     }
                     self.send_final_text_override(&primary_segment.id, &processed.message, hidden);
 
@@ -557,7 +571,7 @@ impl StreamRelay {
                             hidden: Some(true),
                         };
                         if let Err(e) = self.repo.update_message(&segment.id, &hide_update).await {
-                            error!(error = %ErrorChain(&e), "Failed to hide superseded text segment");
+                            log_persist_error(&e, "Failed to hide superseded text segment");
                         }
                         self.send_final_text_override(&segment.id, "", true);
                     }
@@ -569,7 +583,7 @@ impl StreamRelay {
                             hidden: Some(false),
                         };
                         if let Err(e) = self.repo.update_message(&segment.id, &status_update).await {
-                            error!(error = %ErrorChain(&e), "Failed to finalize text segment status");
+                            log_persist_error(&e, "Failed to finalize text segment status");
                         }
                     }
                 }
@@ -586,7 +600,7 @@ impl StreamRelay {
                     created_at: now_ms(),
                 };
                 if let Err(e) = self.repo.insert_message(&row).await {
-                    error!(error = %ErrorChain(&e), "Failed to create final fallback message");
+                    log_persist_error(&e, "Failed to create final fallback message");
                 }
             }
 
@@ -607,7 +621,7 @@ impl StreamRelay {
                 created_at: now_ms(),
             };
             if let Err(e) = self.repo.insert_message(&row).await {
-                error!(error = %ErrorChain(&e), "Failed to store error message");
+                log_persist_error(&e, "Failed to store error message");
             }
         }
 
@@ -949,7 +963,7 @@ impl StreamRelay {
             ..Default::default()
         };
         if let Err(e) = repo.update(conversation_id, &update).await {
-            error!(error = %ErrorChain(&e), "Failed to update conversation status");
+            log_persist_error(&e, "Failed to update conversation status");
         }
 
         let payload = json!({
@@ -1003,6 +1017,7 @@ mod tests {
     use aionui_ai_agent::protocol::events::{ErrorEventData, FinishEventData, TextEventData, ThinkingEventData};
     use aionui_db::DbError;
     use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     // ── run() async tests ─────────────────────────────────────────
 
@@ -1776,6 +1791,50 @@ mod tests {
         assert_eq!(content.as_array().unwrap().len(), 2);
     }
 
+    #[tokio::test]
+    async fn close_active_text_segment_treats_not_found_as_deleted_conversation() {
+        let repo = Arc::new(RecordingRepo::new());
+        repo.set_not_found(true);
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+
+        let relay = StreamRelay::new(
+            "deleted-conv".into(),
+            "assistant-msg".into(),
+            "user-1".into(),
+            repo,
+            bus,
+            None,
+        );
+        let mut active_text = Some(TextSegmentState {
+            id: "missing-segment".into(),
+            buffer: "partial answer".into(),
+            created_at: now_ms(),
+            record_created: true,
+            flush_counter: 0,
+        });
+        let mut text_segments = Vec::new();
+
+        relay
+            .close_active_text_segment(&mut active_text, &mut text_segments, "finish")
+            .await;
+
+        assert!(active_text.is_none());
+        assert!(
+            text_segments.is_empty(),
+            "missing DB rows should not be treated as persisted text segments"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_conversation_ignores_not_found_after_delete() {
+        let repo = Arc::new(RecordingRepo::new());
+        repo.set_not_found(true);
+        let repo: Arc<dyn IConversationRepository> = repo;
+        let bus: Arc<dyn EventBroadcaster> = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+
+        StreamRelay::complete_conversation_with_runtime(&repo, &bus, "deleted-conv", None).await;
+    }
+
     // ── Helpers ──────────────────────────────────────────────────
 
     struct MockCronService;
@@ -1829,6 +1888,7 @@ mod tests {
     struct RecordingRepo {
         inserts: Mutex<Vec<MessageRow>>,
         updates: Mutex<Vec<(String, aionui_db::MessageRowUpdate)>>,
+        not_found: AtomicBool,
     }
 
     impl RecordingRepo {
@@ -1836,7 +1896,12 @@ mod tests {
             Self {
                 inserts: Mutex::new(vec![]),
                 updates: Mutex::new(vec![]),
+                not_found: AtomicBool::new(false),
             }
+        }
+
+        fn set_not_found(&self, value: bool) {
+            self.not_found.store(value, Ordering::Release);
         }
 
         fn take_inserts(&self) -> Vec<MessageRow> {
@@ -1858,6 +1923,9 @@ mod tests {
             Ok(())
         }
         async fn update(&self, _id: &str, _updates: &aionui_db::ConversationRowUpdate) -> Result<(), DbError> {
+            if self.not_found.load(Ordering::Acquire) {
+                return Err(DbError::NotFound("Conversation deleted-conv not found".into()));
+            }
             Ok(())
         }
         async fn delete(&self, _id: &str) -> Result<(), DbError> {
@@ -1911,10 +1979,16 @@ mod tests {
             })
         }
         async fn insert_message(&self, row: &MessageRow) -> Result<(), DbError> {
+            if self.not_found.load(Ordering::Acquire) {
+                return Err(DbError::NotFound(format!("Message '{}'", row.id)));
+            }
             self.inserts.lock().unwrap().push(row.clone());
             Ok(())
         }
         async fn update_message(&self, id: &str, updates: &aionui_db::MessageRowUpdate) -> Result<(), DbError> {
+            if self.not_found.load(Ordering::Acquire) {
+                return Err(DbError::NotFound(format!("Message '{id}' not found")));
+            }
             self.updates.lock().unwrap().push((id.to_owned(), updates.clone()));
             Ok(())
         }

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -27,8 +27,16 @@ fn is_not_found(err: &DbError) -> bool {
     matches!(err, DbError::NotFound(_))
 }
 
+fn is_foreign_key_constraint(err: &DbError) -> bool {
+    err.to_string().contains("FOREIGN KEY constraint failed")
+}
+
+fn is_deleted_during_stream_persistence(err: &DbError) -> bool {
+    is_not_found(err) || is_foreign_key_constraint(err)
+}
+
 fn log_persist_error(err: &DbError, message: &'static str) {
-    if is_not_found(err) {
+    if is_deleted_during_stream_persistence(err) {
         debug!(error = %ErrorChain(err), "{message}; conversation was likely deleted during stream finalization");
     } else {
         error!(error = %ErrorChain(err), "{message}");
@@ -469,7 +477,7 @@ impl StreamRelay {
                 hidden: None,
             };
             if let Err(e) = self.repo.update_message(&segment.id, &update).await {
-                error!(error = %ErrorChain(&e), "Failed to update streaming text segment");
+                log_persist_error(&e, "Failed to update streaming text segment");
             }
         } else {
             let row = MessageRow {
@@ -484,7 +492,7 @@ impl StreamRelay {
                 created_at: segment.created_at,
             };
             if let Err(e) = self.repo.insert_message(&row).await {
-                error!(error = %ErrorChain(&e), "Failed to create streaming text segment");
+                log_persist_error(&e, "Failed to create streaming text segment");
             }
             segment.record_created = true;
         }
@@ -656,7 +664,7 @@ impl StreamRelay {
             created_at: segment.started_at,
         };
         if let Err(e) = self.repo.insert_message(&row).await {
-            error!(error = %ErrorChain(&e), "Failed to persist thinking message");
+            log_persist_error(&e, "Failed to persist thinking message");
         }
     }
 
@@ -1835,6 +1843,64 @@ mod tests {
         StreamRelay::complete_conversation_with_runtime(&repo, &bus, "deleted-conv", None).await;
     }
 
+    #[tokio::test]
+    async fn finalize_treats_foreign_key_failure_as_deleted_conversation() {
+        let repo = Arc::new(RecordingRepo::new());
+        repo.set_foreign_key_failure(true);
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let relay = StreamRelay::new(
+            "deleted-conv".into(),
+            "assistant-msg".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus,
+            None,
+        );
+
+        let outcome = relay
+            .finalize(
+                "partial answer",
+                &[],
+                &AgentStreamEvent::Finish(FinishEventData::default()),
+                RelayTerminal::Finish,
+            )
+            .await;
+
+        assert_eq!(outcome.terminal, RelayTerminal::Finish);
+        assert!(
+            repo.take_inserts().is_empty(),
+            "failed fallback writes must not be recorded as persisted messages"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_active_thinking_treats_foreign_key_failure_as_deleted_conversation() {
+        let repo = Arc::new(RecordingRepo::new());
+        repo.set_foreign_key_failure(true);
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let relay = StreamRelay::new(
+            "deleted-conv".into(),
+            "assistant-msg".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus,
+            None,
+        );
+        let mut active_thinking = Some(ThinkingSegmentState {
+            id: "thinking-1".into(),
+            buffer: "working".into(),
+            started_at: now_ms(),
+        });
+
+        relay.complete_active_thinking(&mut active_thinking).await;
+
+        assert!(active_thinking.is_none());
+        assert!(
+            repo.take_inserts().is_empty(),
+            "failed thinking writes must not be recorded as persisted messages"
+        );
+    }
+
     // ── Helpers ──────────────────────────────────────────────────
 
     struct MockCronService;
@@ -1889,6 +1955,7 @@ mod tests {
         inserts: Mutex<Vec<MessageRow>>,
         updates: Mutex<Vec<(String, aionui_db::MessageRowUpdate)>>,
         not_found: AtomicBool,
+        foreign_key_failure: AtomicBool,
     }
 
     impl RecordingRepo {
@@ -1897,11 +1964,16 @@ mod tests {
                 inserts: Mutex::new(vec![]),
                 updates: Mutex::new(vec![]),
                 not_found: AtomicBool::new(false),
+                foreign_key_failure: AtomicBool::new(false),
             }
         }
 
         fn set_not_found(&self, value: bool) {
             self.not_found.store(value, Ordering::Release);
+        }
+
+        fn set_foreign_key_failure(&self, value: bool) {
+            self.foreign_key_failure.store(value, Ordering::Release);
         }
 
         fn take_inserts(&self) -> Vec<MessageRow> {
@@ -1981,6 +2053,9 @@ mod tests {
         async fn insert_message(&self, row: &MessageRow) -> Result<(), DbError> {
             if self.not_found.load(Ordering::Acquire) {
                 return Err(DbError::NotFound(format!("Message '{}'", row.id)));
+            }
+            if self.foreign_key_failure.load(Ordering::Acquire) {
+                return Err(DbError::Init("FOREIGN KEY constraint failed".into()));
             }
             self.inserts.lock().unwrap().push(row.clone());
             Ok(())

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -12,6 +12,7 @@ use crate::response_middleware::{ICronService, MessageMiddleware, MiddlewareResu
 use aionui_api_types::{AgentErrorCode, ConversationRuntimeSummary, WebSocketMessage};
 use aionui_common::{ErrorChain, normalize_keys_to_snake_case, now_ms};
 
+use crate::runtime_state::ConversationRuntimeStateService;
 use crate::service::ConversationService;
 use aionui_db::models::MessageRow;
 use aionui_db::{DbError, IConversationRepository};
@@ -113,6 +114,7 @@ pub struct StreamRelay {
     repo: Arc<dyn IConversationRepository>,
     broadcaster: Arc<dyn EventBroadcaster>,
     cron_service: Option<Arc<dyn ICronService>>,
+    runtime_state: Option<Arc<ConversationRuntimeStateService>>,
     complete_turn: bool,
 }
 
@@ -132,8 +134,14 @@ impl StreamRelay {
             repo,
             broadcaster,
             cron_service,
+            runtime_state: None,
             complete_turn: true,
         }
+    }
+
+    pub fn with_runtime_state(mut self, runtime_state: Arc<ConversationRuntimeStateService>) -> Self {
+        self.runtime_state = Some(runtime_state);
+        self
     }
 
     pub fn with_turn_completion(mut self, enabled: bool) -> Self {
@@ -212,6 +220,15 @@ impl StreamRelay {
 
             match recv_result {
                 Ok(event) => {
+                    let deleting = self.is_deleting();
+                    if deleting && !matches!(event, AgentStreamEvent::Finish(_) | AgentStreamEvent::Error(_)) {
+                        debug!(
+                            event_type = Self::event_kind(&event),
+                            "Skipping non-terminal stream event because conversation is deleting"
+                        );
+                        continue;
+                    }
+
                     if !first_agent_event_logged {
                         first_agent_event_logged = true;
                         info!(
@@ -303,20 +320,31 @@ impl StreamRelay {
                                 }
                             }
 
-                            self.complete_active_thinking(&mut active_thinking).await;
-                            self.close_active_text_segment(
-                                &mut active_text,
-                                &mut text_segments,
-                                if matches!(event, AgentStreamEvent::Error(_)) {
-                                    "error"
-                                } else {
-                                    "finish"
-                                },
-                            )
-                            .await;
+                            if deleting {
+                                debug!("Skipping terminal DB finalization because conversation is deleting");
+                            } else {
+                                self.complete_active_thinking(&mut active_thinking).await;
+                                self.close_active_text_segment(
+                                    &mut active_text,
+                                    &mut text_segments,
+                                    if matches!(event, AgentStreamEvent::Error(_)) {
+                                        "error"
+                                    } else {
+                                        "finish"
+                                    },
+                                )
+                                .await;
+                            }
                             self.forward_to_websocket(&event);
-                            let outcome = self.finalize(&full_text_buffer, &text_segments, &event, terminal).await;
-                            if self.complete_turn {
+                            let outcome = if deleting {
+                                RelayOutcome {
+                                    system_responses: Vec::new(),
+                                    terminal,
+                                }
+                            } else {
+                                self.finalize(&full_text_buffer, &text_segments, &event, terminal).await
+                            };
+                            if self.complete_turn && !deleting {
                                 Self::complete_conversation(&self.repo, &self.broadcaster, &self.conversation_id).await;
                             }
                             break outcome;
@@ -355,19 +383,30 @@ impl StreamRelay {
                         "StreamRelay channel closed without terminal event"
                     );
 
-                    self.complete_active_thinking(&mut active_thinking).await;
-                    self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
-                        .await;
+                    let deleting = self.is_deleting();
+                    if deleting {
+                        debug!("Skipping channel-closed DB finalization because conversation is deleting");
+                    } else {
+                        self.complete_active_thinking(&mut active_thinking).await;
+                        self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
+                            .await;
+                    }
                     // Channel closed without finish/error — still finalize
-                    let outcome = self
-                        .finalize(
+                    let outcome = if deleting {
+                        RelayOutcome {
+                            system_responses: Vec::new(),
+                            terminal: RelayTerminal::ChannelClosed,
+                        }
+                    } else {
+                        self.finalize(
                             &full_text_buffer,
                             &text_segments,
                             &AgentStreamEvent::Finish(aionui_ai_agent::protocol::events::FinishEventData::default()),
                             RelayTerminal::ChannelClosed,
                         )
-                        .await;
-                    if self.complete_turn {
+                        .await
+                    };
+                    if self.complete_turn && !deleting {
                         Self::complete_conversation(&self.repo, &self.broadcaster, &self.conversation_id).await;
                     }
                     break outcome;
@@ -377,6 +416,12 @@ impl StreamRelay {
                 }
             }
         }
+    }
+
+    fn is_deleting(&self) -> bool {
+        self.runtime_state
+            .as_ref()
+            .is_some_and(|state| state.is_deleting(&self.conversation_id))
     }
 
     fn event_kind(event: &AgentStreamEvent) -> &'static str {
@@ -1841,6 +1886,38 @@ mod tests {
         let bus: Arc<dyn EventBroadcaster> = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
 
         StreamRelay::complete_conversation_with_runtime(&repo, &bus, "deleted-conv", None).await;
+    }
+
+    #[tokio::test]
+    async fn run_skips_db_finalization_when_conversation_is_deleting() {
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let runtime_state = Arc::new(ConversationRuntimeStateService::default());
+        runtime_state.mark_deleting("deleted-conv");
+        let (tx, _) = broadcast::channel(16);
+
+        let relay = StreamRelay::new(
+            "deleted-conv".into(),
+            "assistant-msg".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus,
+            None,
+        )
+        .with_runtime_state(runtime_state);
+        let rx = tx.subscribe();
+
+        tx.send(AgentStreamEvent::Text(TextEventData {
+            content: "partial answer".into(),
+        }))
+        .unwrap();
+        tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
+
+        let outcome = relay.consume(rx).await;
+
+        assert_eq!(outcome.terminal, RelayTerminal::Finish);
+        assert!(repo.take_inserts().is_empty());
+        assert!(repo.take_updates().is_empty());
     }
 
     #[tokio::test]

--- a/crates/aionui-conversation/tests/conversation_crud.rs
+++ b/crates/aionui-conversation/tests/conversation_crud.rs
@@ -746,6 +746,18 @@ async fn update_accepts_top_level_model_for_aionrs() {
 }
 
 #[tokio::test]
+async fn complete_turn_skips_status_update_when_conversation_is_deleting() {
+    let (svc, _, _task_mgr) = setup().await;
+    let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
+
+    svc.runtime_state().mark_deleting(&conv.id);
+    svc.complete_turn(&conv.id).await;
+
+    let row = svc.conversation_repo().get(&conv.id).await.unwrap().unwrap();
+    assert_eq!(row.status.as_deref(), Some("pending"));
+}
+
+#[tokio::test]
 async fn update_non_aionrs_extra_model_does_not_kill_task() {
     // Verifies the explicit rule that `extra.model` changes for non-aionrs
     // do NOT trigger task_manager.kill. Since our `NoopTaskManager::kill` is


### PR DESCRIPTION
## Summary

- Consolidate ACP and Aionrs terminal ownership so each turn resolves through a single terminal lifecycle.
- Downgrade `send_error_rx` to a fallback path instead of a normal competing terminal source.
- Add runtime lifecycle gates for deleting conversations so active-turn cleanup skips DB finalization after deletion.
- Suppress raw ACP SDK and aionrs debug payload logs while keeping structured lifecycle observability.

## Verification

- `just push -u origin round-1-terminal-lifecycle`
- `cargo nextest run --workspace`: 5841 passed, 18 skipped
