### PR TITLE
test(conversation): assert channel closed relay terminal

### DIFF
--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -1528,6 +1528,7 @@ mod tests {
 
         let outcome = relay.consume(rx).await;
         assert!(outcome.system_responses.is_empty());
+        assert_eq!(outcome.terminal, RelayTerminal::ChannelClosed);
 
         // Should still persist the partial text
         let inserts = repo.take_inserts();


### PR DESCRIPTION
## Summary
- Add an explicit assertion that stream relay channel-closed fallback returns `RelayTerminal::ChannelClosed`.
- Preserve the existing partial-text persistence coverage for closed channels.

## Test Plan
- `cargo test -p aionui-conversation stream_relay::tests::run_channel_closed_finalizes`
- `cargo test -p aionui-conversation`
- `just push -u origin test/channel-closed-terminal-assertion`