### PR TITLE
fix(stt): STT compatibility fixes for Groq Whisper and AionUI web frontend

### DIFF
--- a/crates/aionui-app/tests/shell_e2e.rs
+++ b/crates/aionui-app/tests/shell_e2e.rs
@@ -49,6 +49,29 @@ impl MultipartBuilder {
         self
     }
 
+    fn add_file_without_content_type(mut self, name: &str, filename: &str, data: &[u8]) -> Self {
+        self.parts
+            .extend_from_slice(format!("--{}\r\n", self.boundary).as_bytes());
+        self.parts.extend_from_slice(
+            format!("Content-Disposition: form-data; name=\"{name}\"; filename=\"{filename}\"\r\n\r\n").as_bytes(),
+        );
+        self.parts.extend_from_slice(data);
+        self.parts.extend_from_slice(b"\r\n");
+        self
+    }
+
+    fn add_file_without_filename(mut self, name: &str, mime: &str, data: &[u8]) -> Self {
+        self.parts
+            .extend_from_slice(format!("--{}\r\n", self.boundary).as_bytes());
+        self.parts
+            .extend_from_slice(format!("Content-Disposition: form-data; name=\"{name}\"\r\n").as_bytes());
+        self.parts
+            .extend_from_slice(format!("Content-Type: {mime}\r\n\r\n").as_bytes());
+        self.parts.extend_from_slice(data);
+        self.parts.extend_from_slice(b"\r\n");
+        self
+    }
+
     fn build(mut self) -> (String, Vec<u8>) {
         self.parts
             .extend_from_slice(format!("--{}--\r\n", self.boundary).as_bytes());
@@ -70,13 +93,11 @@ fn multipart_request(uri: &str, content_type: &str, body: Vec<u8>, token: &str, 
 }
 
 async fn set_stt_config(app: &mut axum::Router, token: &str, csrf: &str, config: serde_json::Value) {
-    let req = json_with_token(
-        "PUT",
-        "/api/settings/client",
-        json!({ "speechToText": config }),
-        token,
-        csrf,
-    );
+    set_stt_config_at_key(app, token, csrf, "speechToText", config).await;
+}
+
+async fn set_stt_config_at_key(app: &mut axum::Router, token: &str, csrf: &str, key: &str, config: serde_json::Value) {
+    let req = json_with_token("PUT", "/api/settings/client", json!({ key: config }), token, csrf);
     let resp = app.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
 }
@@ -425,7 +446,7 @@ async fn st8_multipart_missing_filename() {
     .await;
 
     let (content_type, body) = MultipartBuilder::new()
-        .add_file("file", "test.wav", "audio/wav", b"fake audio data")
+        .add_file_without_filename("file", "audio/wav", b"fake audio data")
         .add_text("mimeType", "audio/wav")
         .build();
 
@@ -607,6 +628,54 @@ async fn st10_language_hint_passed() {
     assert_eq!(json["data"]["text"], "你好世界");
 }
 
+// ST-11: AionUI web frontend compatibility shape.
+#[tokio::test]
+async fn st11_web_frontend_tools_key_audio_part_headers_only() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/transcriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "text": "web frontend" })))
+        .mount(&mock_server)
+        .await;
+
+    let (mut app, services) = build_app_with_noop_opener().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    set_stt_config_at_key(
+        &mut app,
+        &token,
+        &csrf,
+        "tools.speechToText",
+        json!({
+            "enabled": true,
+            "provider": "openai",
+            "openai": {
+                "api_key": "sk-test-key",
+                "base_url": mock_server.uri(),
+                "model": "whisper-1"
+            }
+        }),
+    )
+    .await;
+
+    let (content_type, body) = MultipartBuilder::new()
+        .add_file(
+            "audio",
+            "recording.webm",
+            "audio/webm;codecs=opus",
+            b"fake web audio data",
+        )
+        .add_text("languageHint", "en-US")
+        .build();
+
+    let req = multipart_request("/api/stt", &content_type, body, &token, &csrf);
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    assert_eq!(json["data"]["text"], "web frontend");
+}
+
 // ===========================================================================
 // C. Authentication
 // ===========================================================================
@@ -679,7 +748,7 @@ async fn st_multipart_missing_mimetype() {
     .await;
 
     let (content_type, body) = MultipartBuilder::new()
-        .add_file("file", "test.wav", "audio/wav", b"fake audio data")
+        .add_file_without_content_type("file", "test.wav", b"fake audio data")
         .add_text("fileName", "test.wav")
         .build();
 

--- a/crates/aionui-shell/src/routes.rs
+++ b/crates/aionui-shell/src/routes.rs
@@ -114,22 +114,15 @@ async fn extract_stt_multipart(mut multipart: Multipart) -> Result<SttMultipartF
         let name = field.name().unwrap_or("").to_owned();
         match name.as_str() {
             "file" | "audio" => {
-                // Extract filename from Content-Disposition if not already set
-                if file_name.is_none() {
-                    if let Some(cd) = field.headers().get("content-disposition") {
-                        // Parse filename from Content-Disposition: form-data; name="audio"; filename="recording.webm"
-                        if let Ok(cd_str) = cd.to_str() {
-                            for part in cd_str.split(';') {
-                                let part = part.trim();
-                                if part.starts_with("filename=") {
-                                    let fname = part.trim_start_matches("filename=").trim_matches('"');
-                                    if !fname.is_empty() {
-                                        file_name = Some(fname.to_owned());
-                                    }
-                                }
-                            }
-                        }
-                    }
+                if file_name.is_none()
+                    && let Some(name) = field.file_name().filter(|name| !name.is_empty())
+                {
+                    file_name = Some(name.to_owned());
+                }
+                if mime_type.is_none()
+                    && let Some(content_type) = field.content_type().filter(|value| !value.is_empty())
+                {
+                    mime_type = Some(content_type.to_owned());
                 }
                 file_data = Some(
                     field

--- a/crates/aionui-shell/src/routes.rs
+++ b/crates/aionui-shell/src/routes.rs
@@ -113,7 +113,24 @@ async fn extract_stt_multipart(mut multipart: Multipart) -> Result<SttMultipartF
     {
         let name = field.name().unwrap_or("").to_owned();
         match name.as_str() {
-            "file" => {
+            "file" | "audio" => {
+                // Extract filename from Content-Disposition if not already set
+                if file_name.is_none() {
+                    if let Some(cd) = field.headers().get("content-disposition") {
+                        // Parse filename from Content-Disposition: form-data; name="audio"; filename="recording.webm"
+                        if let Ok(cd_str) = cd.to_str() {
+                            for part in cd_str.split(';') {
+                                let part = part.trim();
+                                if part.starts_with("filename=") {
+                                    let fname = part.trim_start_matches("filename=").trim_matches('"');
+                                    if !fname.is_empty() {
+                                        file_name = Some(fname.to_owned());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
                 file_data = Some(
                     field
                         .bytes()
@@ -177,9 +194,12 @@ async fn speech_to_text(
         (status, Json(body))
     })?;
 
+    // Key mismatch fix: frontend stores as "tools.speechToText" but backend
+    // previously queried only "speechToText". Request both keys to ensure
+    // we find the config regardless of which key name was used.
     let prefs = state
         .client_pref_service
-        .get_preferences(Some(&["speechToText"]))
+        .get_preferences(Some(&["speechToText", "tools.speechToText"]))
         .await
         .map_err(|e| {
             let status = e.status_code();
@@ -191,8 +211,11 @@ async fn speech_to_text(
             (status, Json(body))
         })?;
 
+    // Key mismatch fix: AionUI frontend sends "tools.speechToText" but backend
+    // expects "speechToText". Try both keys for backward compatibility.
     let config: SpeechToTextConfig = prefs
-        .get("speechToText")
+        .get("tools.speechToText")
+        .or_else(|| prefs.get("speechToText"))
         .and_then(|v| serde_json::from_value(v.clone()).ok())
         .unwrap_or(SpeechToTextConfig {
             enabled: false,

--- a/crates/aionui-shell/src/stt_openai.rs
+++ b/crates/aionui-shell/src/stt_openai.rs
@@ -40,11 +40,13 @@ pub async fn transcribe(
     // This lets users override the browser's locale (e.g. browser sends "en-US"
     // but user prefers "es" for transcription).
     let language = config.language.as_deref().filter(|s| !s.is_empty()).or(language_hint);
-    if let Some(lang) = language {
+    let normalized_language = language.map(|lang| {
         // Normalize language codes: "en-US" → "en", "es-MX" → "es"
         // Groq/OpenAI Whisper only accepts base language codes (e.g. "en", "es")
-        let normalized = lang.split('-').next().unwrap_or(lang).to_owned();
-        form = form.text("language", normalized);
+        lang.split('-').next().unwrap_or(lang).to_owned()
+    });
+    if let Some(lang) = normalized_language.as_deref() {
+        form = form.text("language", lang.to_owned());
     }
 
     if let Some(prompt) = config.prompt.as_deref().filter(|s| !s.is_empty()) {
@@ -80,7 +82,7 @@ pub async fn transcribe(
         text,
         model: config.model.clone(),
         provider: SpeechToTextProvider::Openai,
-        language: language.map(|s| s.to_owned()),
+        language: normalized_language,
     })
 }
 

--- a/crates/aionui-shell/src/stt_openai.rs
+++ b/crates/aionui-shell/src/stt_openai.rs
@@ -21,21 +21,30 @@ pub async fn transcribe(
         .base_url
         .as_deref()
         .unwrap_or(DEFAULT_BASE_URL)
-        .trim_end_matches('/');
+        .trim_end_matches('/')
+        .trim_end_matches("/v1");
     let url = format!("{base_url}/v1/audio/transcriptions");
 
+    // Normalize MIME type: strip codec parameters (e.g. "audio/webm;codecs=opus" → "audio/webm")
+    let clean_mime_type = mime_type.split(';').next().unwrap_or(mime_type).trim();
     let file_part = reqwest::multipart::Part::bytes(audio_data)
         .file_name(file_name.to_owned())
-        .mime_str(mime_type)
+        .mime_str(clean_mime_type)
         .map_err(|e| SttError::Unknown(format!("invalid MIME type: {e}")))?;
 
     let mut form = reqwest::multipart::Form::new()
         .part("file", file_part)
         .text("model", config.model.clone());
 
-    let language = language_hint.or(config.language.as_deref()).filter(|s| !s.is_empty());
+    // User-configured language takes precedence over browser languageHint.
+    // This lets users override the browser's locale (e.g. browser sends "en-US"
+    // but user prefers "es" for transcription).
+    let language = config.language.as_deref().filter(|s| !s.is_empty()).or(language_hint);
     if let Some(lang) = language {
-        form = form.text("language", lang.to_owned());
+        // Normalize language codes: "en-US" → "en", "es-MX" → "es"
+        // Groq/OpenAI Whisper only accepts base language codes (e.g. "en", "es")
+        let normalized = lang.split('-').next().unwrap_or(lang).to_owned();
+        form = form.text("language", normalized);
     }
 
     if let Some(prompt) = config.prompt.as_deref().filter(|s| !s.is_empty()) {

--- a/crates/aionui-shell/tests/stt_integration.rs
+++ b/crates/aionui-shell/tests/stt_integration.rs
@@ -2,7 +2,7 @@ use aionui_api_types::{
     DeepgramSpeechToTextConfig, OpenAISpeechToTextConfig, SpeechToTextConfig, SpeechToTextProvider,
 };
 use aionui_shell::{SttError, SttService};
-use wiremock::matchers::{header, method, path};
+use wiremock::matchers::{body_string_contains, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn dummy_audio() -> Vec<u8> {
@@ -313,14 +313,16 @@ async fn st7b_deepgram_upstream_failure() {
 }
 
 // ---------------------------------------------------------------------------
-// ST-10: languageHint passed to OpenAI
+// ST-10: configured language overrides languageHint for OpenAI
 // ---------------------------------------------------------------------------
 #[tokio::test]
-async fn st10_openai_language_hint_passed() {
+async fn st10_openai_config_language_overrides_language_hint() {
     let mock_server = MockServer::start().await;
 
     Mock::given(method("POST"))
         .and(path("/v1/audio/transcriptions"))
+        .and(body_string_contains("name=\"language\""))
+        .and(body_string_contains("\r\nen\r\n"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "text": "你好世界" })))
         .mount(&mock_server)
         .await;
@@ -346,7 +348,116 @@ async fn st10_openai_language_hint_passed() {
         .unwrap();
 
     assert_eq!(result.text, "你好世界");
-    assert_eq!(result.language.as_deref(), Some("zh"));
+    assert_eq!(result.language.as_deref(), Some("en"));
+}
+
+#[tokio::test]
+async fn st10c_openai_language_hint_region_is_normalized() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/transcriptions"))
+        .and(body_string_contains("name=\"language\""))
+        .and(body_string_contains("\r\nen\r\n"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "text": "hello" })))
+        .mount(&mock_server)
+        .await;
+
+    let config = SpeechToTextConfig {
+        enabled: true,
+        provider: SpeechToTextProvider::Openai,
+        auto_send: None,
+        openai: Some(OpenAISpeechToTextConfig {
+            api_key: "sk-test".into(),
+            base_url: Some(mock_server.uri()),
+            model: "whisper-1".into(),
+            language: None,
+            prompt: None,
+            temperature: None,
+        }),
+        deepgram: None,
+    };
+
+    let result = stt_service()
+        .transcribe(
+            dummy_audio(),
+            "test.webm",
+            "audio/webm;codecs=opus",
+            Some("en-US"),
+            &config,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.text, "hello");
+    assert_eq!(result.language.as_deref(), Some("en"));
+}
+
+#[tokio::test]
+async fn openai_base_url_with_v1_suffix_is_not_duplicated() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/transcriptions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "text": "ok" })))
+        .mount(&mock_server)
+        .await;
+
+    let config = SpeechToTextConfig {
+        enabled: true,
+        provider: SpeechToTextProvider::Openai,
+        auto_send: None,
+        openai: Some(OpenAISpeechToTextConfig {
+            api_key: "sk-test".into(),
+            base_url: Some(format!("{}/v1", mock_server.uri())),
+            model: "whisper-1".into(),
+            language: None,
+            prompt: None,
+            temperature: None,
+        }),
+        deepgram: None,
+    };
+
+    let result = stt_service()
+        .transcribe(dummy_audio(), "test.wav", "audio/wav", None, &config)
+        .await
+        .unwrap();
+
+    assert_eq!(result.text, "ok");
+}
+
+#[tokio::test]
+async fn openai_mime_type_codec_params_are_removed() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/audio/transcriptions"))
+        .and(body_string_contains("Content-Type: audio/webm\r\n"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "text": "ok" })))
+        .mount(&mock_server)
+        .await;
+
+    let config = SpeechToTextConfig {
+        enabled: true,
+        provider: SpeechToTextProvider::Openai,
+        auto_send: None,
+        openai: Some(OpenAISpeechToTextConfig {
+            api_key: "sk-test".into(),
+            base_url: Some(mock_server.uri()),
+            model: "whisper-1".into(),
+            language: None,
+            prompt: None,
+            temperature: None,
+        }),
+        deepgram: None,
+    };
+
+    let result = stt_service()
+        .transcribe(dummy_audio(), "test.webm", "audio/webm;codecs=opus", None, &config)
+        .await
+        .unwrap();
+
+    assert_eq!(result.text, "ok");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When using AionUI web frontend with Groq Whisper as the STT provider, speech-to-text fails with 400/502 errors. There are four distinct issues:

1. **Preference key mismatch**: The AionUI web frontend stores STT config under the key `tools.speechToText` in `client_preferences`, but the backend queries only `speechToText`. Since `get_preferences()` filters with `WHERE key IN (...)`, the config row is never found, causing `STT_DISABLED` even when the user has configured STT.

2. **Multipart field name mismatch**: The web frontend sends audio as FormData field `audio` (via `formData.append('audio', blob, filename)`), but the backend expects field name `file`. This causes a `400 Bad Request: missing 'file' field` error. The frontend also embeds the filename in the blob's Content-Disposition header rather than as a separate multipart field.

3. **Double `/v1` in Groq URL**: When `base_url` includes `/v1` (e.g. `https://api.groq.com/openai/v1`), the code appends `/v1/audio/transcriptions`, producing `https://api.groq.com/openai/v1/v1/audio/transcriptions` → `502 Bad Gateway`.

4. **Language code and MIME type incompatibility**: The browser sends `languageHint: "en-US"` but Groq Whisper only accepts ISO 639-1 base codes (e.g. `en`). Similarly, the browser sends `audio/webm;codecs=opus` as the MIME type, but `reqwest::mime_str()` requires clean MIME types without codec parameters.

## Solution

1. **Key mismatch**: Query both `speechToText` and `tools.speechToText` in `get_preferences()`. Use `prefs.get("tools.speechToText").or_else(|| prefs.get("speechToText"))` for backward compatibility.

2. **Multipart field**: Accept both `"file"` and `"audio"` field names. Parse filename from the Content-Disposition header when the frontend sends it as part of the blob rather than a separate field.

3. **Double `/v1`**: Add `.trim_end_matches("/v1")` after `.trim_end_matches('/')` when constructing the base URL, before appending `/v1/audio/transcriptions`.

4. **Language normalization**: Strip region codes via `lang.split('-').next()` (e.g. `en-US` → `en`). User-configured language in settings now takes precedence over browser `languageHint`, so users can override the browser locale for transcription.

5. **MIME normalization**: Strip codec parameters via `mime_type.split(';').next().trim()` (e.g. `audio/webm;codecs=opus` → `audio/webm`).

## Testing

- Tested with AionUI v2.1.10 web frontend speaking into the microphone
- Verified Groq Whisper returns correct transcriptions in both English and Spanish
- Verified `curl` tests directly against aioncore `/api/stt` endpoint return 200 OK
- Verified setting `language: "es"` in STT settings correctly overrides browser locale
- Confirmed no debug/temporary code in the final commit

## Checklist

- [x] Changes are minimal and focused on the STT compatibility issues
- [x] No debug/temporary code included
- [x] Backward compatible — both old (`speechToText`) and new (`tools.speechToText`) keys work
- [x] Both `"file"` and `"audio"` multipart field names accepted
- [x] No changes to error.rs — upstream already has the correct error model

---

Fixes #373