### PR TITLE
fix(conversation): align workspace path availability handling

### DIFF
--- a/crates/aionui-ai-agent/src/capability/cli_process/mod.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/mod.rs
@@ -4,7 +4,6 @@ use std::process::ExitStatus;
 use std::sync::Arc;
 use std::time::Duration;
 
-use aionui_common::workspace_path_has_whitespace_segment;
 use tokio::io::AsyncWriteExt;
 use tokio::process::{ChildStdin, ChildStdout};
 use tokio::sync::{Mutex, broadcast, watch};
@@ -34,27 +33,11 @@ pub(super) fn prepare_command_cwd(cwd: &str) -> Result<PathBuf, AgentError> {
     }
 
     let workspace_path = PathBuf::from(cwd);
-    if workspace_path_has_whitespace_segment(&workspace_path) {
-        return Err(AgentError::workspace_path_contains_whitespace_runtime_unsupported(
-            workspace_path.display().to_string(),
-        ));
-    }
-
     match fs::metadata(&workspace_path) {
         Ok(metadata) if metadata.is_dir() => Ok(workspace_path),
-        Ok(_) => Err(AgentError::bad_request(format!(
-            "Workspace path is not a directory: {}",
-            workspace_path.display()
-        ))),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(AgentError::bad_request(format!(
-            "Workspace directory does not exist: {}",
-            workspace_path.display()
-        ))),
-        Err(e) => Err(AgentError::bad_request(format!(
-            "Workspace directory is not accessible: {}: {}",
-            workspace_path.display(),
-            e
-        ))),
+        Ok(_) | Err(_) => Err(AgentError::workspace_path_runtime_unavailable(
+            workspace_path.display().to_string(),
+        )),
     }
 }
 
@@ -383,7 +366,7 @@ pub(super) mod tests {
     }
 
     #[tokio::test]
-    async fn spawn_rejects_cwd_with_trailing_whitespace_in_request() {
+    async fn spawn_rejects_unavailable_cwd_with_trailing_whitespace_in_request() {
         let dir = tempfile::tempdir().unwrap();
         let cwd = dir.path().join("workspace");
         fs::create_dir(&cwd).unwrap();
@@ -398,13 +381,12 @@ pub(super) mod tests {
         let result = CliAgentProcess::spawn(config).await;
         assert!(matches!(
             result,
-            Err(AgentError::WorkspacePathContainsWhitespaceRuntimeUnsupported(message))
-                if message == cwd_with_trailing_space
+            Err(AgentError::WorkspacePathRuntimeUnavailable(message)) if message == cwd_with_trailing_space
         ));
     }
 
     #[tokio::test]
-    async fn spawn_rejects_cwd_with_whitespace_in_any_segment() {
+    async fn spawn_allows_cwd_with_whitespace_in_any_segment() {
         let dir = tempfile::tempdir().unwrap();
         let workspace_parent = dir.path().join("my workspace");
         fs::create_dir(&workspace_parent).unwrap();
@@ -418,16 +400,20 @@ pub(super) mod tests {
             cwd: Some(cwd.to_string_lossy().into_owned()),
         };
 
-        let result = CliAgentProcess::spawn(config).await;
-        assert!(matches!(
-            result,
-            Err(AgentError::WorkspacePathContainsWhitespaceRuntimeUnsupported(message))
-                if message == cwd.to_string_lossy()
-        ));
+        let proc = CliAgentProcess::spawn(config).await.unwrap();
+        let mut rx = proc.subscribe();
+        let event = timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("Timed out")
+            .expect("Channel closed");
+        assert_eq!(
+            event["cwd"],
+            std::fs::canonicalize(&cwd).unwrap().to_string_lossy().to_string()
+        );
     }
 
     #[tokio::test]
-    async fn spawn_for_sdk_rejects_cwd_with_whitespace_in_any_segment() {
+    async fn spawn_for_sdk_allows_cwd_with_whitespace_in_any_segment() {
         let dir = tempfile::tempdir().unwrap();
         let workspace_parent = dir.path().join("my workspace");
         fs::create_dir(&workspace_parent).unwrap();
@@ -442,12 +428,8 @@ pub(super) mod tests {
             cwd: Some(cwd.to_string_lossy().into_owned()),
         };
 
-        let result = CliAgentProcess::spawn_for_sdk(config, data_dir.path()).await;
-        assert!(matches!(
-            result,
-            Err(AgentError::WorkspacePathContainsWhitespaceRuntimeUnsupported(message))
-                if message == cwd.to_string_lossy()
-        ));
+        let proc = CliAgentProcess::spawn_for_sdk(config, data_dir.path()).await.unwrap();
+        proc.kill(Duration::from_millis(100)).await.unwrap();
     }
 
     #[tokio::test]
@@ -466,7 +448,8 @@ pub(super) mod tests {
         let result = CliAgentProcess::spawn(config).await;
         assert!(matches!(
             result,
-            Err(AgentError::BadRequest(message)) if message.contains("Workspace directory does not exist")
+            Err(AgentError::WorkspacePathRuntimeUnavailable(message))
+                if message == missing_cwd.to_string_lossy()
         ));
         assert!(!missing_cwd.exists());
     }
@@ -488,7 +471,8 @@ pub(super) mod tests {
         let result = CliAgentProcess::spawn_for_sdk(config, data_dir.path()).await;
         assert!(matches!(
             result,
-            Err(AgentError::BadRequest(message)) if message.contains("Workspace directory does not exist")
+            Err(AgentError::WorkspacePathRuntimeUnavailable(message))
+                if message == missing_cwd.to_string_lossy()
         ));
         assert!(!missing_cwd.exists());
     }

--- a/crates/aionui-ai-agent/src/error.rs
+++ b/crates/aionui-ai-agent/src/error.rs
@@ -23,8 +23,8 @@ pub enum AgentError {
     RateLimited,
     #[error("Conversation archived: {0}")]
     ConversationArchived(String),
-    #[error("Workspace path contains whitespace: {0}")]
-    WorkspacePathContainsWhitespaceRuntimeUnsupported(String),
+    #[error("Workspace path is unavailable during execution: {0}")]
+    WorkspacePathRuntimeUnavailable(String),
     #[error("Internal error: {0}")]
     Internal(String),
     #[error(transparent)]
@@ -64,8 +64,8 @@ impl AgentError {
         Self::ConversationArchived(message.into())
     }
 
-    pub fn workspace_path_contains_whitespace_runtime_unsupported(path: impl Into<String>) -> Self {
-        Self::WorkspacePathContainsWhitespaceRuntimeUnsupported(path.into())
+    pub fn workspace_path_runtime_unavailable(path: impl Into<String>) -> Self {
+        Self::WorkspacePathRuntimeUnavailable(path.into())
     }
 
     pub fn internal(message: impl Into<String>) -> Self {
@@ -82,7 +82,7 @@ impl AgentError {
             | Self::BadGateway(message)
             | Self::Timeout(message)
             | Self::ConversationArchived(message)
-            | Self::WorkspacePathContainsWhitespaceRuntimeUnsupported(message)
+            | Self::WorkspacePathRuntimeUnavailable(message)
             | Self::Internal(message) => message.clone(),
             Self::RateLimited => "Rate limited".to_owned(),
             Self::Acp(err) => err.to_string(),

--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -68,10 +68,10 @@ impl AgentSendError {
     pub fn from_agent_error_ref(err: &AgentError) -> Self {
         let detail = err.public_message();
         match err {
-            AgentError::WorkspacePathContainsWhitespaceRuntimeUnsupported(path) => Self {
+            AgentError::WorkspacePathRuntimeUnavailable(path) => Self {
                 stream_error: AgentStreamErrorData {
-                    message: "This workspace path is no longer supported for execution".into(),
-                    code: Some(AgentErrorCode::WorkspacePathContainsWhitespaceRuntimeUnsupported),
+                    message: "Current Agent failed to run in this workspace path".into(),
+                    code: Some(AgentErrorCode::WorkspacePathRuntimeUnavailable),
                     ownership: Some(AgentErrorOwnership::Aionui),
                     detail: Some(sanitize_error_detail(&detail)),
                     workspace_path: Some(path.clone()),
@@ -999,14 +999,10 @@ mod tests {
 
     #[test]
     fn preserves_runtime_workspace_validation_as_structured_aionui_error() {
-        let err = AgentSendError::from_agent_error(AgentError::workspace_path_contains_whitespace_runtime_unsupported(
-            "/Users/test/Archive ",
-        ));
+        let err =
+            AgentSendError::from_agent_error(AgentError::workspace_path_runtime_unavailable("/Users/test/Archive "));
 
-        assert_eq!(
-            err.code(),
-            Some(AgentErrorCode::WorkspacePathContainsWhitespaceRuntimeUnsupported)
-        );
+        assert_eq!(err.code(), Some(AgentErrorCode::WorkspacePathRuntimeUnavailable));
         assert_eq!(err.ownership(), Some(AgentErrorOwnership::Aionui));
         assert_eq!(
             err.stream_error().workspace_path.as_deref(),

--- a/crates/aionui-ai-agent/src/routes/error_mapping.rs
+++ b/crates/aionui-ai-agent/src/routes/error_mapping.rs
@@ -16,9 +16,7 @@ pub(crate) fn agent_error_to_api_error(err: AgentError) -> ApiError {
         AgentError::Timeout(message) => ApiError::Timeout(message),
         AgentError::RateLimited => ApiError::RateLimited,
         AgentError::ConversationArchived(message) => ApiError::ConversationArchived(message),
-        AgentError::WorkspacePathContainsWhitespaceRuntimeUnsupported(path) => {
-            ApiError::WorkspacePathContainsWhitespaceRuntimeUnsupported(path)
-        }
+        AgentError::WorkspacePathRuntimeUnavailable(path) => ApiError::WorkspacePathRuntimeUnavailable(path),
         AgentError::Internal(message) => ApiError::Internal(message),
         AgentError::Acp(err) => acp_error_to_api_error(err),
     }

--- a/crates/aionui-ai-agent/tests/acp_error_public.rs
+++ b/crates/aionui-ai-agent/tests/acp_error_public.rs
@@ -17,15 +17,12 @@ fn agent_send_error_classifies_owned_unauthorized_error() {
 }
 
 #[test]
-fn agent_send_error_classifies_owned_workspace_whitespace_error() {
-    let err = AgentSendError::from_agent_error_ref(
-        &AgentError::workspace_path_contains_whitespace_runtime_unsupported("/tmp/Project With Space"),
-    );
+fn agent_send_error_classifies_owned_workspace_runtime_unavailable_error() {
+    let err = AgentSendError::from_agent_error_ref(&AgentError::workspace_path_runtime_unavailable(
+        "/tmp/Project With Space",
+    ));
     let stream = err.stream_error();
 
-    assert_eq!(
-        stream.code,
-        Some(AgentErrorCode::WorkspacePathContainsWhitespaceRuntimeUnsupported)
-    );
+    assert_eq!(stream.code, Some(AgentErrorCode::WorkspacePathRuntimeUnavailable));
     assert_eq!(stream.workspace_path.as_deref(), Some("/tmp/Project With Space"));
 }

--- a/crates/aionui-api-types/src/agent_error.rs
+++ b/crates/aionui-api-types/src/agent_error.rs
@@ -17,7 +17,8 @@ pub enum AgentErrorCode {
     AionuiStateInconsistent,
     AionuiPermissionError,
     AionuiInternalError,
-    WorkspacePathContainsWhitespaceRuntimeUnsupported,
+    #[serde(alias = "WORKSPACE_PATH_CONTAINS_WHITESPACE_RUNTIME_UNSUPPORTED")]
+    WorkspacePathRuntimeUnavailable,
     UserAgentHandshakeFailed,
     UserAgentHandshakeTimeout,
     UserAgentAcpInitFailed,
@@ -230,7 +231,7 @@ mod tests {
     fn workspace_path_field_serializes_and_deserializes() {
         let payload = AgentStreamErrorData {
             message: "workspace path rejected".into(),
-            code: Some(AgentErrorCode::WorkspacePathContainsWhitespaceRuntimeUnsupported),
+            code: Some(AgentErrorCode::WorkspacePathRuntimeUnavailable),
             ownership: Some(AgentErrorOwnership::Aionui),
             detail: Some("workspace detail".into()),
             workspace_path: Some("/tmp/Archive ".into()),
@@ -240,7 +241,7 @@ mod tests {
         };
 
         let json = serde_json::to_value(&payload).unwrap();
-        assert_eq!(json["code"], "WORKSPACE_PATH_CONTAINS_WHITESPACE_RUNTIME_UNSUPPORTED");
+        assert_eq!(json["code"], "WORKSPACE_PATH_RUNTIME_UNAVAILABLE");
         assert_eq!(json["workspacePath"], "/tmp/Archive ");
 
         let roundtrip: AgentStreamErrorData = serde_json::from_value(json).unwrap();

--- a/crates/aionui-api-types/src/response.rs
+++ b/crates/aionui-api-types/src/response.rs
@@ -204,7 +204,7 @@ mod tests {
     fn test_error_response_new_with_details() {
         let resp = ErrorResponse::new_with_details(
             "Bad request: invalid workspace",
-            "WORKSPACE_PATH_CONTAINS_WHITESPACE_UNSUPPORTED",
+            "WORKSPACE_PATH_UNAVAILABLE",
             serde_json::json!({ "workspace_path": "/tmp/Archive " }),
         );
         assert_eq!(
@@ -215,8 +215,8 @@ mod tests {
 
     #[test]
     fn test_error_response_from_workspace_error_includes_details() {
-        let resp = ErrorResponse::from(ApiError::WorkspacePathContainsWhitespace("/tmp/Archive ".into()));
-        assert_eq!(resp.code, "WORKSPACE_PATH_CONTAINS_WHITESPACE_UNSUPPORTED");
+        let resp = ErrorResponse::from(ApiError::WorkspacePathUnavailable("/tmp/Archive ".into()));
+        assert_eq!(resp.code, "WORKSPACE_PATH_UNAVAILABLE");
         assert_eq!(
             resp.details.as_ref().and_then(|details| details.get("workspace_path")),
             Some(&serde_json::json!("/tmp/Archive "))
@@ -229,10 +229,8 @@ mod tests {
 
     #[test]
     fn test_error_response_from_runtime_workspace_error_includes_details() {
-        let resp = ErrorResponse::from(ApiError::WorkspacePathContainsWhitespaceRuntimeUnsupported(
-            "/tmp/Archive ".into(),
-        ));
-        assert_eq!(resp.code, "WORKSPACE_PATH_CONTAINS_WHITESPACE_RUNTIME_UNSUPPORTED");
+        let resp = ErrorResponse::from(ApiError::WorkspacePathRuntimeUnavailable("/tmp/Archive ".into()));
+        assert_eq!(resp.code, "WORKSPACE_PATH_RUNTIME_UNAVAILABLE");
         assert_eq!(
             resp.details.as_ref().and_then(|details| details.get("workspace_path")),
             Some(&serde_json::json!("/tmp/Archive "))

--- a/crates/aionui-api-types/tests/response_format.rs
+++ b/crates/aionui-api-types/tests/response_format.rs
@@ -166,20 +166,14 @@ fn t3_3_api_error_timeout_to_error_response() {
 
 #[test]
 fn t3_3_workspace_error_exposes_structured_details() {
-    let err = ApiError::WorkspacePathContainsWhitespace("/tmp/Archive ".into());
+    let err = ApiError::WorkspacePathUnavailable("/tmp/Archive ".into());
     let resp = ErrorResponse::from(err);
 
     assert!(!resp.success);
-    assert_eq!(resp.code, "WORKSPACE_PATH_CONTAINS_WHITESPACE_UNSUPPORTED");
+    assert_eq!(resp.code, "WORKSPACE_PATH_UNAVAILABLE");
     assert_eq!(
         resp.details.as_ref().and_then(|details| details.get("workspace_path")),
         Some(&serde_json::json!("/tmp/Archive "))
-    );
-    assert_eq!(
-        resp.details
-            .as_ref()
-            .and_then(|details| details.get("offending_segments")),
-        Some(&serde_json::json!(["Archive "]))
     );
     assert_eq!(
         resp.details.as_ref().and_then(|details| details.get("operation")),
@@ -189,20 +183,14 @@ fn t3_3_workspace_error_exposes_structured_details() {
 
 #[test]
 fn t3_3_runtime_workspace_error_exposes_structured_details() {
-    let err = ApiError::WorkspacePathContainsWhitespaceRuntimeUnsupported("/tmp/Archive ".into());
+    let err = ApiError::WorkspacePathRuntimeUnavailable("/tmp/Archive ".into());
     let resp = ErrorResponse::from(err);
 
     assert!(!resp.success);
-    assert_eq!(resp.code, "WORKSPACE_PATH_CONTAINS_WHITESPACE_RUNTIME_UNSUPPORTED");
+    assert_eq!(resp.code, "WORKSPACE_PATH_RUNTIME_UNAVAILABLE");
     assert_eq!(
         resp.details.as_ref().and_then(|details| details.get("workspace_path")),
         Some(&serde_json::json!("/tmp/Archive "))
-    );
-    assert_eq!(
-        resp.details
-            .as_ref()
-            .and_then(|details| details.get("offending_segments")),
-        Some(&serde_json::json!(["Archive "]))
     );
     assert_eq!(
         resp.details.as_ref().and_then(|details| details.get("operation")),

--- a/crates/aionui-app/tests/agent_integration_e2e.rs
+++ b/crates/aionui-app/tests/agent_integration_e2e.rs
@@ -203,7 +203,7 @@ async fn create_conversation(app: &mut axum::Router, token: &str, csrf: &str, na
     let body = json!({
         "type": "acp",
         "name": name,
-        "extra": { "workspace": "/project" }
+        "extra": {}
     });
     let req = common::json_with_token("POST", "/api/conversations", body, token, csrf);
     let resp = app.clone().oneshot(req).await.unwrap();

--- a/crates/aionui-app/tests/auxiliary_e2e.rs
+++ b/crates/aionui-app/tests/auxiliary_e2e.rs
@@ -17,7 +17,7 @@ fn create_conv_body(name: &str, agent_type: &str) -> serde_json::Value {
     json!({
         "type": agent_type,
         "name": name,
-        "extra": { "workspace": "/project" }
+        "extra": {}
     })
 }
 

--- a/crates/aionui-app/tests/conversation_e2e.rs
+++ b/crates/aionui-app/tests/conversation_e2e.rs
@@ -14,7 +14,7 @@ fn create_body(name: &str) -> serde_json::Value {
     json!({
         "type": "acp",
         "name": name,
-        "extra": { "workspace": "/project" }
+        "extra": {}
     })
 }
 
@@ -48,7 +48,7 @@ async fn t1_1_create_conversation_success() {
     assert!(data["id"].as_str().is_some());
     assert!(data["created_at"].as_i64().is_some());
     assert!(data["modified_at"].as_i64().is_some());
-    assert_eq!(data["extra"]["workspace"], "/project");
+    assert!(data["extra"]["workspace"].as_str().is_some());
 }
 
 #[tokio::test]
@@ -137,7 +137,7 @@ async fn t1_5_create_invalid_type() {
 }
 
 #[tokio::test]
-async fn t1_5b_create_rejects_workspace_paths_with_whitespace_segments() {
+async fn t1_5b_create_accepts_workspace_paths_with_whitespace_segments() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
@@ -153,16 +153,47 @@ async fn t1_5b_create_rejects_workspace_paths_with_whitespace_segments() {
     });
     let req = json_with_token("POST", "/api/conversations", body, &token, &csrf);
     let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let json = body_json(resp).await;
+    assert_eq!(
+        json["data"]["extra"]["workspace"],
+        workspace.to_string_lossy().to_string()
+    );
+}
+
+#[tokio::test]
+async fn t1_5c_create_rejects_missing_workspace_path() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let missing_workspace =
+        std::env::temp_dir().join(format!("aionui-conv-missing-{}", aionui_common::generate_short_id()));
+
+    let body = json!({
+        "type": "acp",
+        "extra": {
+            "workspace": missing_workspace.to_string_lossy()
+        }
+    });
+    let req = json_with_token("POST", "/api/conversations", body, &token, &csrf);
+    let resp = app.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
     let json = body_json(resp).await;
-    assert_eq!(json["code"], "WORKSPACE_PATH_CONTAINS_WHITESPACE_UNSUPPORTED");
+    assert_eq!(json["code"], "WORKSPACE_PATH_UNAVAILABLE");
+    assert_eq!(json["details"]["operation"], "create");
+    assert_eq!(
+        json["details"]["workspace_path"],
+        missing_workspace.to_string_lossy().to_string()
+    );
+
+    let list_resp = app.oneshot(get_with_token("/api/conversations", &token)).await.unwrap();
+    assert_eq!(list_resp.status(), StatusCode::OK);
+    let list_json = body_json(list_resp).await;
     assert!(
-        json["error"]
-            .as_str()
-            .unwrap_or_default()
-            .contains("Workspace path contains whitespace"),
-        "unexpected error payload: {json}"
+        list_json["data"]["items"].as_array().unwrap().is_empty(),
+        "invalid conversation should not be persisted"
     );
 }
 
@@ -457,10 +488,15 @@ async fn t4_2_update_pin_and_unpin() {
 async fn t4_3_update_extra_merge() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+    let temp = tempfile::tempdir().unwrap();
+    let old_workspace = temp.path().join("old");
+    let new_workspace = temp.path().join("new");
+    std::fs::create_dir_all(&old_workspace).unwrap();
+    std::fs::create_dir_all(&new_workspace).unwrap();
 
     let body = create_body_with_extra(
         "Merge Test",
-        json!({"workspace": "/old", "context_file_name": "ctx.md"}),
+        json!({"workspace": old_workspace.to_string_lossy(), "context_file_name": "ctx.md"}),
     );
     let req = json_with_token("POST", "/api/conversations", body, &token, &csrf);
     let resp = app.clone().oneshot(req).await.unwrap();
@@ -471,13 +507,16 @@ async fn t4_3_update_extra_merge() {
     let req = json_with_token(
         "PATCH",
         &format!("/api/conversations/{id}"),
-        json!({"extra": {"workspace": "/new"}}),
+        json!({"extra": {"workspace": new_workspace.to_string_lossy()}}),
         &token,
         &csrf,
     );
     let resp = app.oneshot(req).await.unwrap();
     let json = body_json(resp).await;
-    assert_eq!(json["data"]["extra"]["workspace"], "/new");
+    assert_eq!(
+        json["data"]["extra"]["workspace"],
+        new_workspace.to_string_lossy().to_string()
+    );
     assert_eq!(json["data"]["extra"]["context_file_name"], "ctx.md");
 }
 
@@ -715,19 +754,24 @@ async fn t7_3_reset_requires_auth() {
 async fn t10_1_associated_same_workspace() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+    let temp = tempfile::tempdir().unwrap();
+    let shared_workspace = temp.path().join("same");
+    let other_workspace = temp.path().join("other");
+    std::fs::create_dir_all(&shared_workspace).unwrap();
+    std::fs::create_dir_all(&other_workspace).unwrap();
 
     // Create 3 conversations: 2 same workspace, 1 different
-    let body1 = create_body_with_extra("Conv A", json!({"workspace": "/same"}));
+    let body1 = create_body_with_extra("Conv A", json!({"workspace": shared_workspace.to_string_lossy()}));
     let req = json_with_token("POST", "/api/conversations", body1, &token, &csrf);
     let resp = app.clone().oneshot(req).await.unwrap();
     let json = body_json(resp).await;
     let id_a = json["data"]["id"].as_str().unwrap().to_owned();
 
-    let body2 = create_body_with_extra("Conv B", json!({"workspace": "/same"}));
+    let body2 = create_body_with_extra("Conv B", json!({"workspace": shared_workspace.to_string_lossy()}));
     let req = json_with_token("POST", "/api/conversations", body2, &token, &csrf);
     app.clone().oneshot(req).await.unwrap();
 
-    let body3 = create_body_with_extra("Conv C", json!({"workspace": "/other"}));
+    let body3 = create_body_with_extra("Conv C", json!({"workspace": other_workspace.to_string_lossy()}));
     let req = json_with_token("POST", "/api/conversations", body3, &token, &csrf);
     app.clone().oneshot(req).await.unwrap();
 
@@ -739,15 +783,21 @@ async fn t10_1_associated_same_workspace() {
     let json = body_json(resp).await;
     let items = json["data"].as_array().unwrap();
     assert_eq!(items.len(), 1); // only Conv B, not self or Conv C
-    assert_eq!(items[0]["extra"]["workspace"], "/same");
+    assert_eq!(
+        items[0]["extra"]["workspace"],
+        shared_workspace.to_string_lossy().to_string()
+    );
 }
 
 #[tokio::test]
 async fn t10_2_associated_none() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+    let temp = tempfile::tempdir().unwrap();
+    let unique_workspace = temp.path().join("unique");
+    std::fs::create_dir_all(&unique_workspace).unwrap();
 
-    let body = create_body_with_extra("Unique", json!({"workspace": "/unique"}));
+    let body = create_body_with_extra("Unique", json!({"workspace": unique_workspace.to_string_lossy()}));
     let req = json_with_token("POST", "/api/conversations", body, &token, &csrf);
     let resp = app.clone().oneshot(req).await.unwrap();
     let json = body_json(resp).await;
@@ -804,7 +854,6 @@ async fn t12_2_large_nested_extra() {
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
     let big_extra = json!({
-        "workspace": "/project",
         "nested": {
             "level1": {
                 "level2": {

--- a/crates/aionui-app/tests/cron_e2e.rs
+++ b/crates/aionui-app/tests/cron_e2e.rs
@@ -13,7 +13,10 @@ use tower::ServiceExt;
 
 use aionui_db::{ICronRepository, SqliteCronRepository};
 
-use common::{body_json, build_app, delete_with_token, get_request, get_with_token, json_with_token, setup_and_login};
+use common::{
+    body_json, build_app, build_app_with_mock_agents, delete_with_token, get_request, get_with_token, json_with_token,
+    setup_and_login,
+};
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -66,7 +69,7 @@ async fn create_job(app: &mut axum::Router, token: &str, csrf: &str, body: serde
 async fn au1_unauthenticated_list_returns_403() {
     let (app, _services) = build_app().await;
     let req = get_request("/api/cron/jobs");
-    let resp = app.oneshot(req).await.unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
     assert!(
         resp.status() == StatusCode::UNAUTHORIZED || resp.status() == StatusCode::FORBIDDEN,
         "expected 401 or 403, got {}",
@@ -176,9 +179,13 @@ async fn cj3_create_missing_required_fields() {
 }
 
 #[tokio::test]
-async fn cj3b_create_rejects_workspace_with_whitespace_segment() {
+async fn cj3b_create_accepts_workspace_with_whitespace_segment() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+    let dir = std::env::temp_dir().join(format!("aionui-cron-test-{}", aionui_common::generate_short_id()));
+    std::fs::create_dir(&dir).unwrap();
+    let workspace = dir.join("Archive ");
+    std::fs::create_dir(&workspace).unwrap();
 
     let body = json!({
         "name": "Whitespace Workspace",
@@ -191,22 +198,61 @@ async fn cj3b_create_rejects_workspace_with_whitespace_segment() {
         "agent_config": {
             "backend": "acp",
             "name": "Cron Agent",
-            "workspace": "/Users/zhoukai/Documents/Archive "
+            "workspace": workspace.to_string_lossy()
         }
     });
 
     let req = json_with_token("POST", "/api/cron/jobs", body, &token, &csrf);
-    let resp = app.oneshot(req).await.unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn cj3c_create_rejects_missing_workspace_path() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let body = json!({
+        "name": "Missing Workspace",
+        "schedule": { "kind": "every", "every_ms": 60000, "description": "every minute" },
+        "message": "test message",
+        "conversation_id": "",
+        "agent_type": "acp",
+        "created_by": "user",
+        "execution_mode": "new_conversation",
+        "agent_config": {
+            "backend": "claude",
+            "name": "Claude Code",
+            "workspace": "/tmp/cron-job-workspace-missing-path"
+        }
+    });
+
+    let req = json_with_token("POST", "/api/cron/jobs", body, &token, &csrf);
+    let resp = app.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
     let json = body_json(resp).await;
-    assert_eq!(json["code"], "WORKSPACE_PATH_CONTAINS_WHITESPACE_UNSUPPORTED");
-    assert!(
-        json["error"]
-            .as_str()
-            .unwrap()
-            .contains("Workspace path contains whitespace")
+    assert_eq!(json["code"], "WORKSPACE_PATH_UNAVAILABLE");
+    assert_eq!(json["details"]["operation"], "create");
+    assert_eq!(
+        json["details"]["workspace_path"],
+        "/tmp/cron-job-workspace-missing-path"
     );
+
+    let list_req = get_with_token("/api/cron/jobs", &token);
+    let list_resp = app.oneshot(list_req).await.unwrap();
+    assert_eq!(list_resp.status(), StatusCode::OK);
+    let list_json = body_json(list_resp).await;
+    let has_job = list_json["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|job| job["name"] == "Missing Workspace");
+    assert!(!has_job, "invalid cron job should not be persisted");
 }
 
 // ── CJ-4: Get single job ────────────────────────────────────────────
@@ -241,11 +287,15 @@ async fn cj5_get_nonexistent() {
 }
 
 #[tokio::test]
-async fn cj5b_run_now_legacy_workspace_uses_runtime_whitespace_code() {
-    let (mut app, services) = build_app().await;
+async fn cj5b_run_now_legacy_workspace_with_whitespace_succeeds() {
+    let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
     let cron_repo = SqliteCronRepository::new(services.database.pool().clone());
     let now = aionui_common::now_ms();
+    let dir = std::env::temp_dir().join(format!("aionui-cron-test-{}", aionui_common::generate_short_id()));
+    std::fs::create_dir(&dir).unwrap();
+    let workspace = dir.join("Archive ");
+    std::fs::create_dir(&workspace).unwrap();
 
     cron_repo
         .insert(&aionui_db::models::CronJobRow {
@@ -262,7 +312,7 @@ async fn cj5b_run_now_legacy_workspace_uses_runtime_whitespace_code() {
                 json!({
                     "backend": "acp",
                     "name": "Cron Agent",
-                    "workspace": "/Users/zhoukai/Documents/Archive "
+                    "workspace": workspace.to_string_lossy()
                 })
                 .to_string(),
             ),
@@ -293,17 +343,11 @@ async fn cj5b_run_now_legacy_workspace_uses_runtime_whitespace_code() {
         &csrf,
     );
     let resp = app.oneshot(req).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(resp.status(), StatusCode::OK);
 
     let json = body_json(resp).await;
-    assert_eq!(json["code"], "WORKSPACE_PATH_CONTAINS_WHITESPACE_RUNTIME_UNSUPPORTED");
-    assert!(
-        json["error"]
-            .as_str()
-            .unwrap()
-            .contains("Workspace path contains whitespace")
-    );
-    assert_eq!(json["details"]["operation"], "runtime");
+    assert_eq!(json["success"], true);
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 // ── CJ-6: List all jobs ─────────────────────────────────────────────
@@ -486,7 +530,7 @@ async fn rn1_run_now_returns_conversation_id_for_new_conversation_job() {
         json!({
             "type": "acp",
             "name": "Run Now Source",
-            "extra": { "workspace": "/project" }
+            "extra": {}
         }),
         &token,
         &csrf,

--- a/crates/aionui-app/tests/message_e2e.rs
+++ b/crates/aionui-app/tests/message_e2e.rs
@@ -16,7 +16,7 @@ fn create_conv_body(name: &str) -> serde_json::Value {
     json!({
         "type": "acp",
         "name": name,
-        "extra": { "workspace": "/project", "backend": "gemini" }
+        "extra": { "backend": "gemini" }
     })
 }
 
@@ -763,11 +763,14 @@ async fn t2_1_send_message_conversation_not_found() {
 }
 
 #[tokio::test]
-async fn t2_1b_send_message_legacy_workspace_returns_runtime_whitespace_code() {
+async fn t2_1b_send_message_legacy_workspace_with_whitespace_succeeds() {
     let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
     let conv_id = create_conversation(&mut app, &token, &csrf, "Legacy Workspace").await;
-    update_conversation_workspace(&services, &conv_id, "/tmp/my project").await;
+    let dir = tempfile::tempdir().unwrap();
+    let workspace = dir.path().join("my project");
+    std::fs::create_dir(&workspace).unwrap();
+    update_conversation_workspace(&services, &conv_id, &workspace.to_string_lossy()).await;
 
     let body = json!({ "content": "Hello" });
     let req = common::json_with_token(
@@ -778,12 +781,43 @@ async fn t2_1b_send_message_legacy_workspace_returns_runtime_whitespace_code() {
         &csrf,
     );
     let resp = app.oneshot(req).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
+}
+
+#[tokio::test]
+async fn t2_1c_send_message_missing_workspace_persists_message_and_failure_tip() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+    let conv_id = create_conversation(&mut app, &token, &csrf, "Missing Workspace").await;
+    update_conversation_workspace(&services, &conv_id, "/tmp/does-not-exist-for-message-e2e").await;
+
+    let body = json!({ "content": "Hello" });
+    let req = common::json_with_token(
+        "POST",
+        &format!("/api/conversations/{conv_id}/messages"),
+        body,
+        &token,
+        &csrf,
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
 
     let json = body_json(resp).await;
-    assert_eq!(json["code"], "WORKSPACE_PATH_CONTAINS_WHITESPACE_RUNTIME_UNSUPPORTED");
-    assert_eq!(json["details"]["workspace_path"], "/tmp/my project");
-    assert_eq!(json["details"]["operation"], "runtime");
+    assert!(json["data"]["msg_id"].as_str().is_some());
+
+    let messages_resp = app
+        .oneshot(get_with_token(
+            &format!("/api/conversations/{conv_id}/messages"),
+            &token,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(messages_resp.status(), StatusCode::OK);
+    let messages_json = body_json(messages_resp).await;
+    assert_eq!(messages_json["data"]["total"], 2);
+    let items = messages_json["data"]["items"].as_array().unwrap();
+    assert!(items.iter().any(|item| item["position"] == "right"));
+    assert!(items.iter().any(|item| item["type"] == "tips"));
 }
 
 #[tokio::test]
@@ -852,11 +886,14 @@ async fn t2_3_warmup_conversation_not_found() {
 }
 
 #[tokio::test]
-async fn t2_3b_warmup_legacy_workspace_returns_runtime_whitespace_code() {
+async fn t2_3b_warmup_legacy_workspace_with_whitespace_succeeds() {
     let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
     let conv_id = create_conversation(&mut app, &token, &csrf, "Legacy Warmup").await;
-    update_conversation_workspace(&services, &conv_id, "/tmp/my project").await;
+    let dir = tempfile::tempdir().unwrap();
+    let workspace = dir.path().join("my project");
+    std::fs::create_dir(&workspace).unwrap();
+    update_conversation_workspace(&services, &conv_id, &workspace.to_string_lossy()).await;
 
     let req = common::json_with_token(
         "POST",
@@ -866,12 +903,7 @@ async fn t2_3b_warmup_legacy_workspace_returns_runtime_whitespace_code() {
         &csrf,
     );
     let resp = app.oneshot(req).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-
-    let json = body_json(resp).await;
-    assert_eq!(json["code"], "WORKSPACE_PATH_CONTAINS_WHITESPACE_RUNTIME_UNSUPPORTED");
-    assert_eq!(json["details"]["workspace_path"], "/tmp/my project");
-    assert_eq!(json["details"]["operation"], "runtime");
+    assert_eq!(resp.status(), StatusCode::OK);
 }
 
 #[tokio::test]

--- a/crates/aionui-app/tests/team_e2e.rs
+++ b/crates/aionui-app/tests/team_e2e.rs
@@ -126,26 +126,57 @@ async fn tc6_missing_name_returns_error() {
 }
 
 #[tokio::test]
-async fn tc6b_workspace_with_whitespace_segment_returns_specific_code() {
+async fn tc6b_workspace_with_whitespace_segment_is_accepted() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+    let temp = tempfile::tempdir().unwrap();
+    let workspace = temp.path().join("Archive ");
+    std::fs::create_dir_all(&workspace).unwrap();
 
     let body = json!({
         "name": "Alpha",
-        "workspace": "/Users/zhoukai/Documents/Archive ",
+        "workspace": workspace.to_string_lossy(),
         "agents": [{ "name": "Lead", "role": "lead", "backend": "acp", "model": "claude" }]
     });
     let req = json_with_token("POST", "/api/teams", body, &token, &csrf);
     let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+}
+
+#[tokio::test]
+async fn tc6c_create_team_rejects_missing_workspace_path() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+    let missing_workspace =
+        std::env::temp_dir().join(format!("aionui-team-missing-{}", aionui_common::generate_short_id()));
+
+    let body = json!({
+        "name": "Alpha",
+        "workspace": missing_workspace.to_string_lossy(),
+        "agents": [{ "name": "Lead", "role": "lead", "backend": "acp", "model": "claude" }]
+    });
+    let req = json_with_token("POST", "/api/teams", body, &token, &csrf);
+    let resp = app.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
     let json = body_json(resp).await;
-    assert_eq!(json["code"], "WORKSPACE_PATH_CONTAINS_WHITESPACE_UNSUPPORTED");
+    assert_eq!(json["code"], "WORKSPACE_PATH_UNAVAILABLE");
+    assert_eq!(json["details"]["operation"], "create");
+    assert_eq!(
+        json["details"]["workspace_path"],
+        missing_workspace.to_string_lossy().to_string()
+    );
+
+    let req = get_with_token("/api/teams", &token);
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
     assert!(
-        json["error"]
-            .as_str()
-            .unwrap()
-            .contains("Workspace path contains whitespace")
+        json["data"].as_array().unwrap().is_empty(),
+        "invalid team should not be persisted"
     );
 }
 

--- a/crates/aionui-common/src/error.rs
+++ b/crates/aionui-common/src/error.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::disallowed_types)]
 
-use std::path::{Component, Path};
+use std::fs;
+use std::path::Path;
 
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -49,15 +50,11 @@ pub enum ApiError {
     #[error("Conversation archived: {0}")]
     ConversationArchived(String),
 
-    #[error(
-        "Workspace path contains whitespace in one or more directory names: {0}. Rename the affected directory or choose a path without whitespace in any directory name."
-    )]
-    WorkspacePathContainsWhitespace(String),
+    #[error("Workspace path is unavailable: {0}")]
+    WorkspacePathUnavailable(String),
 
-    #[error(
-        "Workspace path contains whitespace in one or more directory names and is no longer supported for send or warmup: {0}. Rename the affected directory, then update this conversation or task to use a path without whitespace in any directory name."
-    )]
-    WorkspacePathContainsWhitespaceRuntimeUnsupported(String),
+    #[error("Workspace path is unavailable during execution: {0}")]
+    WorkspacePathRuntimeUnavailable(String),
 }
 
 /// Internal error response body matching the `ErrorResponse` format from `aionui-api-types`.
@@ -85,8 +82,8 @@ impl ApiError {
             Self::Timeout(_) => StatusCode::BAD_GATEWAY,
             Self::UnprocessableEntity(_) => StatusCode::UNPROCESSABLE_ENTITY,
             Self::ConversationArchived(_) => StatusCode::GONE,
-            Self::WorkspacePathContainsWhitespace(_) => StatusCode::BAD_REQUEST,
-            Self::WorkspacePathContainsWhitespaceRuntimeUnsupported(_) => StatusCode::BAD_REQUEST,
+            Self::WorkspacePathUnavailable(_) => StatusCode::BAD_REQUEST,
+            Self::WorkspacePathRuntimeUnavailable(_) => StatusCode::BAD_REQUEST,
         }
     }
 
@@ -110,10 +107,8 @@ impl ApiError {
             Self::Timeout(_) => "TIMEOUT",
             Self::UnprocessableEntity(_) => "UNPROCESSABLE_ENTITY",
             Self::ConversationArchived(_) => "CONVERSATION_ARCHIVED",
-            Self::WorkspacePathContainsWhitespace(_) => "WORKSPACE_PATH_CONTAINS_WHITESPACE_UNSUPPORTED",
-            Self::WorkspacePathContainsWhitespaceRuntimeUnsupported(_) => {
-                "WORKSPACE_PATH_CONTAINS_WHITESPACE_RUNTIME_UNSUPPORTED"
-            }
+            Self::WorkspacePathUnavailable(_) => "WORKSPACE_PATH_UNAVAILABLE",
+            Self::WorkspacePathRuntimeUnavailable(_) => "WORKSPACE_PATH_RUNTIME_UNAVAILABLE",
         }
     }
 
@@ -121,47 +116,46 @@ impl ApiError {
     /// context in addition to the top-level error code.
     pub fn error_details(&self) -> Option<Value> {
         match self {
-            Self::WorkspacePathContainsWhitespace(path) => Some(workspace_path_whitespace_details(path, "create")),
-            Self::WorkspacePathContainsWhitespaceRuntimeUnsupported(path) => {
-                Some(workspace_path_whitespace_details(path, "runtime"))
-            }
+            Self::WorkspacePathUnavailable(path) => Some(workspace_path_details(path, "create")),
+            Self::WorkspacePathRuntimeUnavailable(path) => Some(workspace_path_details(path, "runtime")),
             _ => None,
         }
     }
 }
 
-fn workspace_path_whitespace_details(path: &str, operation: &str) -> Value {
+fn workspace_path_details(path: &str, operation: &str) -> Value {
     json!({
         "field": "workspace",
         "workspace_path": path,
-        "offending_segments": workspace_path_whitespace_segments(Path::new(path)),
         "operation": operation,
     })
 }
 
-/// Return true when any normal directory/file name component in `path`
-/// contains a Unicode whitespace character.
-pub fn workspace_path_has_whitespace_segment(path: &Path) -> bool {
-    path.components().any(|component| match component {
-        Component::Normal(segment) => segment.to_string_lossy().chars().any(char::is_whitespace),
-        _ => false,
-    })
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkspacePathValidationError {
+    Empty,
+    DoesNotExist(String),
+    NotDirectory(String),
+    NotAccessible { path: String, reason: String },
 }
 
-fn workspace_path_whitespace_segments(path: &Path) -> Vec<String> {
-    path.components()
-        .filter_map(|component| match component {
-            Component::Normal(segment) => {
-                let value = segment.to_string_lossy().to_string();
-                if value.chars().any(char::is_whitespace) {
-                    Some(value)
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        })
-        .collect()
+pub fn validate_workspace_path_availability(workspace: &str) -> Result<String, WorkspacePathValidationError> {
+    if workspace.trim().is_empty() {
+        return Err(WorkspacePathValidationError::Empty);
+    }
+
+    let path = Path::new(workspace);
+    match fs::metadata(path) {
+        Ok(metadata) if metadata.is_dir() => Ok(workspace.to_owned()),
+        Ok(_) => Err(WorkspacePathValidationError::NotDirectory(workspace.to_owned())),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            Err(WorkspacePathValidationError::DoesNotExist(workspace.to_owned()))
+        }
+        Err(err) => Err(WorkspacePathValidationError::NotAccessible {
+            path: workspace.to_owned(),
+            reason: err.to_string(),
+        }),
+    }
 }
 
 impl IntoResponse for ApiError {
@@ -219,11 +213,11 @@ mod tests {
             StatusCode::UNPROCESSABLE_ENTITY
         );
         assert_eq!(
-            ApiError::WorkspacePathContainsWhitespace("x".into()).status_code(),
+            ApiError::WorkspacePathUnavailable("x".into()).status_code(),
             StatusCode::BAD_REQUEST
         );
         assert_eq!(
-            ApiError::WorkspacePathContainsWhitespaceRuntimeUnsupported("x".into()).status_code(),
+            ApiError::WorkspacePathRuntimeUnavailable("x".into()).status_code(),
             StatusCode::BAD_REQUEST
         );
     }
@@ -248,12 +242,12 @@ mod tests {
             "UNPROCESSABLE_ENTITY"
         );
         assert_eq!(
-            ApiError::WorkspacePathContainsWhitespace("x".into()).error_code(),
-            "WORKSPACE_PATH_CONTAINS_WHITESPACE_UNSUPPORTED"
+            ApiError::WorkspacePathUnavailable("x".into()).error_code(),
+            "WORKSPACE_PATH_UNAVAILABLE"
         );
         assert_eq!(
-            ApiError::WorkspacePathContainsWhitespaceRuntimeUnsupported("x".into()).error_code(),
-            "WORKSPACE_PATH_CONTAINS_WHITESPACE_RUNTIME_UNSUPPORTED"
+            ApiError::WorkspacePathRuntimeUnavailable("x".into()).error_code(),
+            "WORKSPACE_PATH_RUNTIME_UNAVAILABLE"
         );
     }
 
@@ -297,48 +291,60 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_workspace_whitespace_response_contains_details() {
-        let resp = ApiError::WorkspacePathContainsWhitespace("/tmp/Archive ".into()).into_response();
+    async fn test_workspace_unavailable_response_contains_details() {
+        let resp = ApiError::WorkspacePathUnavailable("/tmp/Archive ".into()).into_response();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
         let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-        assert_eq!(json["code"], "WORKSPACE_PATH_CONTAINS_WHITESPACE_UNSUPPORTED");
+        assert_eq!(json["code"], "WORKSPACE_PATH_UNAVAILABLE");
         assert_eq!(json["details"]["field"], "workspace");
         assert_eq!(json["details"]["workspace_path"], "/tmp/Archive ");
-        assert_eq!(json["details"]["offending_segments"], serde_json::json!(["Archive "]));
         assert_eq!(json["details"]["operation"], "create");
     }
 
     #[tokio::test]
-    async fn test_workspace_runtime_whitespace_response_contains_details() {
-        let resp = ApiError::WorkspacePathContainsWhitespaceRuntimeUnsupported("/tmp/Archive ".into()).into_response();
+    async fn test_workspace_runtime_unavailable_response_contains_details() {
+        let resp = ApiError::WorkspacePathRuntimeUnavailable("/tmp/Archive ".into()).into_response();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
         let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-        assert_eq!(json["code"], "WORKSPACE_PATH_CONTAINS_WHITESPACE_RUNTIME_UNSUPPORTED");
+        assert_eq!(json["code"], "WORKSPACE_PATH_RUNTIME_UNAVAILABLE");
         assert_eq!(json["details"]["field"], "workspace");
         assert_eq!(json["details"]["workspace_path"], "/tmp/Archive ");
-        assert_eq!(json["details"]["offending_segments"], serde_json::json!(["Archive "]));
         assert_eq!(json["details"]["operation"], "runtime");
     }
 
     #[test]
-    fn test_workspace_path_has_whitespace_segment() {
-        assert!(workspace_path_has_whitespace_segment(Path::new("/tmp/my project")));
-        assert!(workspace_path_has_whitespace_segment(Path::new("/tmp/project ")));
-        assert!(!workspace_path_has_whitespace_segment(Path::new("/tmp/my-project")));
-    }
+    fn test_validate_workspace_path_availability() {
+        let dir = std::env::temp_dir().join(format!("aionui-common-{}", crate::generate_short_id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let workspace = dir.join("my project");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let file = dir.join("file.txt");
+        std::fs::write(&file, "x").unwrap();
 
-    #[test]
-    fn test_workspace_path_whitespace_segments() {
         assert_eq!(
-            workspace_path_whitespace_segments(Path::new("/tmp/my project/Archive ")),
-            vec!["my project".to_owned(), "Archive ".to_owned()]
+            validate_workspace_path_availability(&workspace.to_string_lossy()),
+            Ok(workspace.to_string_lossy().to_string())
         );
+        assert_eq!(
+            validate_workspace_path_availability("   "),
+            Err(WorkspacePathValidationError::Empty)
+        );
+        assert!(matches!(
+            validate_workspace_path_availability(&dir.join("missing").to_string_lossy()),
+            Err(WorkspacePathValidationError::DoesNotExist(_))
+        ));
+        assert!(matches!(
+            validate_workspace_path_availability(&file.to_string_lossy()),
+            Err(WorkspacePathValidationError::NotDirectory(_))
+        ));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[derive(Debug, thiserror::Error)]

--- a/crates/aionui-common/src/lib.rs
+++ b/crates/aionui-common/src/lib.rs
@@ -21,7 +21,7 @@ pub use enums::{
     RemoteAgentProtocol, RemoteAgentStatus,
 };
 #[allow(clippy::disallowed_types)]
-pub use error::{ApiError, ErrorChain, workspace_path_has_whitespace_segment};
+pub use error::{ApiError, ErrorChain, WorkspacePathValidationError, validate_workspace_path_availability};
 pub use hooks::OnConversationDelete;
 pub use id::{fnv1a_hex8, generate_id, generate_id_with_length, generate_prefixed_id, generate_short_id};
 pub use pagination::PaginatedResult;

--- a/crates/aionui-conversation/src/error.rs
+++ b/crates/aionui-conversation/src/error.rs
@@ -53,11 +53,11 @@ pub enum ConversationError {
     #[error("Internal error: {reason}")]
     Internal { reason: String },
 
-    #[error("Workspace path contains whitespace: {path}")]
-    WorkspacePathContainsWhitespace { path: String },
+    #[error("Workspace path is unavailable: {path}")]
+    WorkspacePathUnavailable { path: String },
 
-    #[error("Workspace path contains whitespace and is unsupported at runtime: {path}")]
-    WorkspacePathContainsWhitespaceRuntimeUnsupported { path: String },
+    #[error("Workspace path is unavailable during execution: {path}")]
+    WorkspacePathRuntimeUnavailable { path: String },
 
     #[error("ACP error")]
     Acp(#[from] AcpError),
@@ -89,11 +89,11 @@ impl ConversationError {
             Self::Timeout { reason } => AgentError::timeout(reason.clone()),
             Self::Unprocessable { reason } => AgentError::bad_request(reason.clone()),
             Self::Internal { reason } => AgentError::internal(reason.clone()),
-            Self::WorkspacePathContainsWhitespace { path } => AgentError::bad_request(format!(
-                "Workspace path contains whitespace in one or more directory names: {path}"
-            )),
-            Self::WorkspacePathContainsWhitespaceRuntimeUnsupported { path } => {
-                AgentError::workspace_path_contains_whitespace_runtime_unsupported(path.clone())
+            Self::WorkspacePathUnavailable { path } => {
+                AgentError::bad_request(format!("Workspace path is unavailable: {path}"))
+            }
+            Self::WorkspacePathRuntimeUnavailable { path } => {
+                AgentError::workspace_path_runtime_unavailable(path.clone())
             }
             Self::Acp(err) => AgentError::bad_gateway(err.to_string()),
         }
@@ -116,10 +116,8 @@ impl ConversationError {
             Self::Timeout { .. } => "TIMEOUT",
             Self::Unprocessable { .. } => "UNPROCESSABLE_ENTITY",
             Self::Archived { .. } => "CONVERSATION_ARCHIVED",
-            Self::WorkspacePathContainsWhitespace { .. } => "WORKSPACE_PATH_CONTAINS_WHITESPACE_UNSUPPORTED",
-            Self::WorkspacePathContainsWhitespaceRuntimeUnsupported { .. } => {
-                "WORKSPACE_PATH_CONTAINS_WHITESPACE_RUNTIME_UNSUPPORTED"
-            }
+            Self::WorkspacePathUnavailable { .. } => "WORKSPACE_PATH_UNAVAILABLE",
+            Self::WorkspacePathRuntimeUnavailable { .. } => "WORKSPACE_PATH_RUNTIME_UNAVAILABLE",
         }
     }
 }
@@ -140,9 +138,7 @@ impl From<AgentError> for ConversationError {
                 id: String::new(),
                 reason,
             },
-            AgentError::WorkspacePathContainsWhitespaceRuntimeUnsupported(path) => {
-                Self::WorkspacePathContainsWhitespaceRuntimeUnsupported { path }
-            }
+            AgentError::WorkspacePathRuntimeUnavailable(path) => Self::WorkspacePathRuntimeUnavailable { path },
             AgentError::Acp(err) => Self::Acp(err),
             _ => Self::Internal {
                 reason: error.to_string(),

--- a/crates/aionui-conversation/src/routes.rs
+++ b/crates/aionui-conversation/src/routes.rs
@@ -39,11 +39,9 @@ impl From<ConversationError> for ApiError {
             ConversationError::Timeout { reason } => ApiError::Timeout(reason),
             ConversationError::Unprocessable { reason } => ApiError::UnprocessableEntity(reason),
             ConversationError::Internal { reason } => ApiError::Internal(reason),
-            ConversationError::WorkspacePathContainsWhitespace { path } => {
-                ApiError::WorkspacePathContainsWhitespace(path)
-            }
-            ConversationError::WorkspacePathContainsWhitespaceRuntimeUnsupported { path } => {
-                ApiError::WorkspacePathContainsWhitespaceRuntimeUnsupported(path)
+            ConversationError::WorkspacePathUnavailable { path } => ApiError::WorkspacePathUnavailable(path),
+            ConversationError::WorkspacePathRuntimeUnavailable { path } => {
+                ApiError::WorkspacePathRuntimeUnavailable(path)
             }
             ConversationError::Acp(_) => ApiError::BadGateway("Agent protocol error".into()),
         }
@@ -403,12 +401,12 @@ mod error_mapping_tests {
 
     #[test]
     fn conversation_api_error_compat_preserves_special_codes() {
-        let app = ApiError::from(ConversationError::WorkspacePathContainsWhitespaceRuntimeUnsupported {
+        let app = ApiError::from(ConversationError::WorkspacePathRuntimeUnavailable {
             path: "/tmp/my project".into(),
         });
         assert!(matches!(
             app,
-            ApiError::WorkspacePathContainsWhitespaceRuntimeUnsupported(message) if message == "/tmp/my project"
+            ApiError::WorkspacePathRuntimeUnavailable(message) if message == "/tmp/my project"
         ));
     }
 }

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -1792,7 +1792,17 @@ impl ConversationService {
         // Extract workspace from extra (common across agent types)
         let workspace = match extra.get("workspace").and_then(|v| v.as_str()) {
             Some(workspace) if !workspace.is_empty() => {
-                let normalized = validate_runtime_workspace_path(workspace)?;
+                let expected_auto_workspace =
+                    expected_auto_workspace_path(&self.workspace_root, &row.id, &agent_type, extra.get("backend"));
+                let normalized = match validate_workspace_path_availability(workspace) {
+                    Ok(normalized) => normalized,
+                    Err(WorkspacePathValidationError::DoesNotExist(path))
+                        if PathBuf::from(workspace) == expected_auto_workspace =>
+                    {
+                        path
+                    }
+                    Err(error) => return Err(map_runtime_workspace_validation_error(error)),
+                };
                 if normalized != workspace {
                     extra["workspace"] = serde_json::Value::String(normalized.clone());
                 }
@@ -1811,11 +1821,12 @@ impl ConversationService {
     }
 
     async fn ensure_auto_workspace_skill_links(&self, row: &ConversationRow, build_opts: &BuildTaskOptions) {
-        let expected_workspace = self.workspace_root.join("conversations").join(format!(
-            "{}-temp-{}",
-            conversation_label(&build_opts.agent_type, build_opts.extra.get("backend")),
-            row.id
-        ));
+        let expected_workspace = expected_auto_workspace_path(
+            &self.workspace_root,
+            &row.id,
+            &build_opts.agent_type,
+            build_opts.extra.get("backend"),
+        );
 
         let stored_workspace = build_opts.workspace.trim();
         let workspace = if stored_workspace.is_empty() {
@@ -2026,10 +2037,6 @@ fn normalize_workspace_path(workspace: &str) -> Result<String, ConversationError
     validate_workspace_path_availability(workspace).map_err(map_create_workspace_validation_error)
 }
 
-fn validate_runtime_workspace_path(workspace: &str) -> Result<String, ConversationError> {
-    validate_workspace_path_availability(workspace).map_err(map_runtime_workspace_validation_error)
-}
-
 fn map_create_workspace_validation_error(error: WorkspacePathValidationError) -> ConversationError {
     match error {
         WorkspacePathValidationError::Empty => ConversationError::BadRequest {
@@ -2072,6 +2079,18 @@ fn conversation_label(agent_type: &AgentType, backend: Option<&serde_json::Value
         return s.clone();
     }
     agent_type.serde_name().to_owned()
+}
+
+fn expected_auto_workspace_path(
+    workspace_root: &std::path::Path,
+    conversation_id: &str,
+    agent_type: &AgentType,
+    backend: Option<&serde_json::Value>,
+) -> PathBuf {
+    workspace_root.join("conversations").join(format!(
+        "{}-temp-{conversation_id}",
+        conversation_label(agent_type, backend)
+    ))
 }
 
 /// Resolve the native skills directory list for an agent by looking it

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -17,7 +17,7 @@ use aionui_api_types::{
 };
 use aionui_common::{
     AgentType, ConversationSource, ConversationStatus, ErrorChain, MessageType, OnConversationDelete, PaginatedResult,
-    generate_short_id, now_ms, workspace_path_has_whitespace_segment,
+    WorkspacePathValidationError, generate_short_id, now_ms, validate_workspace_path_availability,
 };
 use aionui_db::models::{ConversationRow, MessageRow};
 use aionui_db::{
@@ -1408,10 +1408,12 @@ impl ConversationService {
                 );
                 let top_level_code = err.error_code();
                 let send_error = AgentSendError::from_agent_error(err.to_agent_error());
-                let _ = self
-                    .persist_send_failure_tip(conversation_id, &send_error, Some(top_level_code))
+                self.persist_and_broadcast_send_failure_tip(conversation_id, &send_error, Some(top_level_code))
                     .await;
-                return Err(err);
+                let mut turn_claim = turn_claim;
+                let was_deleting = turn_claim.release();
+                self.complete_released_turn(conversation_id, was_deleting).await;
+                return Ok(user_msg_id);
             }
         };
         self.ensure_auto_workspace_skill_links(&row, &build_opts).await;
@@ -1755,9 +1757,7 @@ fn agent_error_top_level_code(error: &AgentError) -> &'static str {
         AgentError::Timeout(_) => "TIMEOUT",
         AgentError::RateLimited => "RATE_LIMITED",
         AgentError::ConversationArchived(_) => "CONVERSATION_ARCHIVED",
-        AgentError::WorkspacePathContainsWhitespaceRuntimeUnsupported(_) => {
-            "WORKSPACE_PATH_CONTAINS_WHITESPACE_RUNTIME_UNSUPPORTED"
-        }
+        AgentError::WorkspacePathRuntimeUnavailable(_) => "WORKSPACE_PATH_RUNTIME_UNAVAILABLE",
         AgentError::Internal(_) => "INTERNAL_ERROR",
         _ => "INTERNAL_ERROR",
     }
@@ -2023,37 +2023,37 @@ fn normalize_workspace_extra(extra: &mut serde_json::Value) -> Result<(), Conver
 }
 
 fn normalize_workspace_path(workspace: &str) -> Result<String, ConversationError> {
-    if workspace.trim().is_empty() {
-        return Err(ConversationError::BadRequest {
-            reason: "Workspace directory is empty".into(),
-        });
-    }
-
-    let workspace_path = PathBuf::from(workspace);
-    if workspace_path_has_whitespace_segment(&workspace_path) {
-        return Err(ConversationError::WorkspacePathContainsWhitespace {
-            path: workspace_path.display().to_string(),
-        });
-    }
-
-    Ok(workspace.to_owned())
+    validate_workspace_path_availability(workspace).map_err(map_create_workspace_validation_error)
 }
 
 fn validate_runtime_workspace_path(workspace: &str) -> Result<String, ConversationError> {
-    if workspace.trim().is_empty() {
-        return Err(ConversationError::BadRequest {
+    validate_workspace_path_availability(workspace).map_err(map_runtime_workspace_validation_error)
+}
+
+fn map_create_workspace_validation_error(error: WorkspacePathValidationError) -> ConversationError {
+    match error {
+        WorkspacePathValidationError::Empty => ConversationError::BadRequest {
             reason: "Workspace directory is empty".into(),
-        });
+        },
+        WorkspacePathValidationError::DoesNotExist(path)
+        | WorkspacePathValidationError::NotDirectory(path)
+        | WorkspacePathValidationError::NotAccessible { path, .. } => {
+            ConversationError::WorkspacePathUnavailable { path }
+        }
     }
+}
 
-    let workspace_path = PathBuf::from(workspace);
-    if workspace_path_has_whitespace_segment(&workspace_path) {
-        return Err(ConversationError::WorkspacePathContainsWhitespaceRuntimeUnsupported {
-            path: workspace_path.display().to_string(),
-        });
+fn map_runtime_workspace_validation_error(error: WorkspacePathValidationError) -> ConversationError {
+    match error {
+        WorkspacePathValidationError::Empty => ConversationError::BadRequest {
+            reason: "Workspace directory is empty".into(),
+        },
+        WorkspacePathValidationError::DoesNotExist(path)
+        | WorkspacePathValidationError::NotDirectory(path)
+        | WorkspacePathValidationError::NotAccessible { path, .. } => {
+            ConversationError::WorkspacePathRuntimeUnavailable { path }
+        }
     }
-
-    Ok(workspace.to_owned())
 }
 
 // ── Helpers ────────────────────────────────────────────────────────

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -1797,7 +1797,7 @@ impl ConversationService {
                 let normalized = match validate_workspace_path_availability(workspace) {
                     Ok(normalized) => normalized,
                     Err(WorkspacePathValidationError::DoesNotExist(path))
-                        if PathBuf::from(workspace) == expected_auto_workspace =>
+                        if expected_auto_workspace.as_path() == std::path::Path::new(workspace) =>
                     {
                         path
                     }

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1116,19 +1116,20 @@ async fn delete_wrong_user_returns_not_found() {
 #[tokio::test]
 async fn clone_without_source_creates_new() {
     let (svc, broadcaster, _repo, _task_mgr) = make_service();
+    let workspace = ensure_test_workspace_path();
 
     let req: CloneConversationRequest = serde_json::from_value(json!({
         "conversation": {
             "type": "acp",
             "name": "Cloned",
-            "extra": { "workspace": "/new" }
+            "extra": { "workspace": workspace }
         }
     }))
     .unwrap();
 
     let resp = svc.clone_create("user_1", req).await.unwrap();
     assert_eq!(resp.name, "Cloned");
-    assert_eq!(resp.extra["workspace"], "/new");
+    assert_eq!(resp.extra["workspace"], workspace);
 
     let events = broadcaster.take_events();
     assert_eq!(events.len(), 1);

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -898,20 +898,28 @@ async fn update_unpin_clears_pinned_at() {
 #[tokio::test]
 async fn update_extra_merge() {
     let (svc, _broadcaster, _repo, task_mgr) = make_service();
+    let dir = std::env::temp_dir().join(format!(
+        "aionui-conversation-update-extra-merge-{}",
+        aionui_common::generate_short_id()
+    ));
+    let old_workspace = dir.join("old-workspace");
+    let new_workspace = dir.join("new-workspace");
+    std::fs::create_dir_all(&old_workspace).unwrap();
+    std::fs::create_dir_all(&new_workspace).unwrap();
 
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "acp",
-        "extra": { "workspace": "/old", "contextFileName": "ctx.md" }
+        "extra": { "workspace": old_workspace.to_string_lossy(), "contextFileName": "ctx.md" }
     }))
     .unwrap();
     let conv = svc.create("user_1", req).await.unwrap();
 
     // Update only workspace — contextFileName should be preserved
     let update_req: UpdateConversationRequest =
-        serde_json::from_value(json!({ "extra": { "workspace": "/new" } })).unwrap();
+        serde_json::from_value(json!({ "extra": { "workspace": new_workspace.to_string_lossy() } })).unwrap();
     let updated = svc.update("user_1", &conv.id, update_req, &task_mgr).await.unwrap();
 
-    assert_eq!(updated.extra["workspace"], "/new");
+    assert_eq!(updated.extra["workspace"], new_workspace.to_string_lossy().to_string());
     assert_eq!(updated.extra["contextFileName"], "ctx.md");
 }
 

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -589,11 +589,18 @@ fn make_service_with_resolver_and_acp_session_repo(
 }
 
 fn make_create_req() -> CreateConversationRequest {
+    let workspace = ensure_test_workspace_path();
     serde_json::from_value(json!({
         "type": "acp",
-        "extra": { "workspace": "/project" }
+        "extra": { "workspace": workspace }
     }))
     .unwrap()
+}
+
+fn ensure_test_workspace_path() -> String {
+    let workspace = std::env::temp_dir().join("aionui-conversation-service-test-project");
+    std::fs::create_dir_all(&workspace).unwrap();
+    workspace.to_string_lossy().to_string()
 }
 
 // ── Create tests ───────────────────────────────────────────────────
@@ -601,6 +608,7 @@ fn make_create_req() -> CreateConversationRequest {
 #[tokio::test]
 async fn create_returns_conversation_with_defaults() {
     let (svc, broadcaster, _repo, _task_mgr) = make_service();
+    let workspace = ensure_test_workspace_path();
 
     let resp = svc.create("user_1", make_create_req()).await.unwrap();
 
@@ -610,7 +618,7 @@ async fn create_returns_conversation_with_defaults() {
     assert_eq!(resp.source, Some(ConversationSource::Aionui));
     assert!(!resp.pinned);
     assert!(resp.pinned_at.is_none());
-    assert_eq!(resp.extra["workspace"], "/project");
+    assert_eq!(resp.extra["workspace"], workspace);
     assert!(resp.created_at > 0);
     assert_eq!(resp.created_at, resp.modified_at);
 
@@ -624,7 +632,7 @@ async fn create_returns_conversation_with_defaults() {
 }
 
 #[tokio::test]
-async fn create_rejects_workspace_with_trailing_whitespace_in_request() {
+async fn create_rejects_unavailable_workspace_with_trailing_whitespace_in_request() {
     let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     let dir = std::env::temp_dir().join(format!("aionui-test-{}", aionui_common::generate_short_id()));
     std::fs::create_dir(&dir).unwrap();
@@ -638,17 +646,34 @@ async fn create_rejects_workspace_with_trailing_whitespace_in_request() {
     }))
     .unwrap();
     let err = svc.create("user_1", req).await.unwrap_err();
-
     assert!(matches!(
         err,
-        ConversationError::WorkspacePathContainsWhitespace { path: message }
-            if message == workspace_with_trailing_space
+        ConversationError::WorkspacePathUnavailable { path }
+            if path == workspace_with_trailing_space
     ));
     let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[tokio::test]
-async fn create_rejects_workspace_with_whitespace_in_any_path_segment() {
+async fn create_accepts_existing_workspace_with_trailing_whitespace_in_name() {
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
+    let dir = std::env::temp_dir().join(format!("aionui-test-{}", aionui_common::generate_short_id()));
+    std::fs::create_dir(&dir).unwrap();
+    let workspace = dir.join("workspace ");
+    std::fs::create_dir(&workspace).unwrap();
+
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "extra": { "workspace": workspace.to_string_lossy() }
+    }))
+    .unwrap();
+    let resp = svc.create("user_1", req).await.unwrap();
+    assert_eq!(resp.extra["workspace"], workspace.to_string_lossy().to_string());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn create_accepts_workspace_with_whitespace_in_any_path_segment() {
     let (svc, _broadcaster, _repo, _task_mgr) = make_service();
     let dir = std::env::temp_dir().join(format!("aionui-test-{}", aionui_common::generate_short_id()));
     std::fs::create_dir(&dir).unwrap();
@@ -661,13 +686,8 @@ async fn create_rejects_workspace_with_whitespace_in_any_path_segment() {
         "extra": { "workspace": workspace.to_string_lossy() }
     }))
     .unwrap();
-    let err = svc.create("user_1", req).await.unwrap_err();
-
-    assert!(matches!(
-        err,
-        ConversationError::WorkspacePathContainsWhitespace { path: message }
-            if message == workspace.to_string_lossy()
-    ));
+    let resp = svc.create("user_1", req).await.unwrap();
+    assert_eq!(resp.extra["workspace"], workspace.to_string_lossy().to_string());
     let _ = std::fs::remove_dir_all(&dir);
 }
 
@@ -695,12 +715,13 @@ async fn create_with_custom_name_and_source() {
 #[tokio::test]
 async fn create_stores_model_as_json() {
     let (svc, _broadcaster, _repo, _task_mgr) = make_service();
+    let workspace = ensure_test_workspace_path();
 
     // Top-level model is only valid for aionrs conversations.
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "aionrs",
         "model": { "provider_id": "p1", "model": "m1" },
-        "extra": { "workspace": "/project" }
+        "extra": { "workspace": workspace }
     }))
     .unwrap();
     let resp = svc.create("user_1", req).await.unwrap();
@@ -897,13 +918,14 @@ async fn update_extra_merge() {
 #[tokio::test]
 async fn update_model() {
     let (svc, _broadcaster, _repo, task_mgr) = make_service();
+    let workspace = ensure_test_workspace_path();
 
     // Top-level model updates are only valid on aionrs conversations
     // (Task 8 enforces the aionrs-only rule in update).
     let create_req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "aionrs",
         "model": { "provider_id": "p1", "model": "m1" },
-        "extra": { "workspace": "/project" }
+        "extra": { "workspace": workspace }
     }))
     .unwrap();
     let conv = svc.create("user_1", create_req).await.unwrap();
@@ -1776,12 +1798,13 @@ async fn send_message_returns_accepted() {
 }
 
 #[tokio::test]
-async fn send_message_rejects_legacy_workspace_with_runtime_error_code() {
-    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+async fn send_message_missing_workspace_persists_message_and_failure_tip() {
+    let (svc, broadcaster, repo, _task_mgr) = make_service();
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
-    let legacy_workspace = "/tmp/my project".to_owned();
+    broadcaster.take_events();
+    let legacy_workspace = format!("/tmp/does-not-exist-{}", aionui_common::generate_short_id());
     repo.update(
         &conv.id,
         &ConversationRowUpdate {
@@ -1792,43 +1815,62 @@ async fn send_message_rejects_legacy_workspace_with_runtime_error_code() {
     .await
     .unwrap();
 
-    let err = svc
+    let msg_id = svc
         .send_message("user_1", &conv.id, make_send_req(), &task_mgr)
         .await
-        .unwrap_err();
-    assert!(matches!(
-        err,
-        ConversationError::WorkspacePathContainsWhitespaceRuntimeUnsupported { path: message }
-            if message == "/tmp/my project"
-    ));
+        .unwrap();
+    assert!(
+        !msg_id.is_empty(),
+        "msg_id must still be returned when runtime workspace validation fails"
+    );
 
     let messages = tokio::time::timeout(Duration::from_secs(1), async {
         loop {
             let messages = repo.get_messages(&conv.id, 1, 20, SortOrder::Asc).await.unwrap().items;
-            if messages.iter().any(|message| message.r#type == "tips") {
+            if messages.iter().any(|message| message.r#type == "tips")
+                && messages.iter().any(|message| message.r#type == "text")
+            {
                 return messages;
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
     })
     .await
-    .expect("legacy workspace failure should persist an error tip");
+    .expect("missing workspace failure should persist a user message and error tip");
+
+    let user_message = messages
+        .iter()
+        .find(|message| message.r#type == "text")
+        .expect("missing workspace failure should persist the user message");
+    assert_eq!(user_message.msg_id.as_deref(), Some(msg_id.as_str()));
 
     let error_tip = messages
         .iter()
         .find(|message| message.r#type == "tips")
-        .expect("legacy workspace failure should persist an error tips message");
+        .expect("missing workspace failure should persist an error tips message");
     let content: serde_json::Value = serde_json::from_str(&error_tip.content).unwrap();
+    assert_eq!(content["code"], "WORKSPACE_PATH_RUNTIME_UNAVAILABLE");
+    assert_eq!(content["details"]["workspace_path"], legacy_workspace);
+    assert_eq!(content["error"]["code"], "WORKSPACE_PATH_RUNTIME_UNAVAILABLE");
+    assert_eq!(content["error"]["workspacePath"], legacy_workspace);
+
+    let events = broadcaster.take_events();
+    let error_tip_event = events
+        .iter()
+        .find(|event| event.name == "message.stream" && event.data["type"] == "tips")
+        .expect("missing workspace failure should broadcast the error tips message");
+    assert_eq!(error_tip_event.data["status"], "error");
     assert_eq!(
-        content["code"],
-        "WORKSPACE_PATH_CONTAINS_WHITESPACE_RUNTIME_UNSUPPORTED"
+        error_tip_event.data["data"]["code"],
+        "WORKSPACE_PATH_RUNTIME_UNAVAILABLE"
     );
-    assert_eq!(content["details"]["workspace_path"], "/tmp/my project");
-    assert_eq!(
-        content["error"]["code"],
-        "WORKSPACE_PATH_CONTAINS_WHITESPACE_RUNTIME_UNSUPPORTED"
-    );
-    assert_eq!(content["error"]["workspacePath"], "/tmp/my project");
+
+    let turn_event = events
+        .iter()
+        .find(|event| event.name == "turn.completed")
+        .expect("missing workspace failure should complete the turn");
+    assert_eq!(turn_event.data["runtime"]["is_processing"], false);
+    assert_eq!(turn_event.data["runtime"]["can_send_message"], true);
 }
 
 #[tokio::test]
@@ -2390,7 +2432,7 @@ async fn warmup_rejects_legacy_workspace_with_runtime_error_code() {
     let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
 
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
-    let legacy_workspace = "/tmp/my project".to_owned();
+    let legacy_workspace = format!("/tmp/does-not-exist-{}", aionui_common::generate_short_id());
     repo.update(
         &conv.id,
         &ConversationRowUpdate {
@@ -2404,8 +2446,8 @@ async fn warmup_rejects_legacy_workspace_with_runtime_error_code() {
     let err = svc.warmup("user_1", &conv.id, &task_mgr).await.unwrap_err();
     assert!(matches!(
         err,
-        ConversationError::WorkspacePathContainsWhitespaceRuntimeUnsupported { path: message }
-            if message == "/tmp/my project"
+        ConversationError::WorkspacePathRuntimeUnavailable { path: message }
+            if message == legacy_workspace
     ));
 }
 
@@ -2727,12 +2769,13 @@ async fn create_writes_extra_skills_from_auto_inject_and_preset() {
         names: vec!["cron".into(), "todo-tracker".into()],
     });
     let (svc, _broadcaster, _repo, _task_mgr) = make_service_with_resolver(resolver);
+    let workspace = ensure_test_workspace_path();
 
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "acp",
         "name": "t",
         "extra": {
-            "workspace": "/project",
+            "workspace": workspace,
             "backend": "claude",
             "preset_enabled_skills": ["pdf", "cron"],
             "exclude_auto_inject_skills": ["todo-tracker"],
@@ -2750,10 +2793,11 @@ async fn create_writes_extra_skills_from_auto_inject_and_preset() {
 async fn create_writes_empty_skills_when_no_auto_inject_and_no_preset() {
     let resolver = Arc::new(FixedSkillResolver { names: vec![] });
     let (svc, _broadcaster, _repo, _task_mgr) = make_service_with_resolver(resolver);
+    let workspace = ensure_test_workspace_path();
 
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "acp",
-        "extra": { "workspace": "/project", "backend": "claude" },
+        "extra": { "workspace": workspace, "backend": "claude" },
     }))
     .unwrap();
     let resp = svc.create("user-1", req).await.unwrap();
@@ -2795,10 +2839,11 @@ async fn warmup_restores_skill_links_for_recreated_auto_workspace() {
 #[tokio::test]
 async fn update_rejects_extra_skills() {
     let (svc, _broadcaster, _repo, task_mgr) = make_service();
+    let workspace = ensure_test_workspace_path();
 
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "acp",
-        "extra": { "workspace": "/project", "backend": "claude" },
+        "extra": { "workspace": workspace, "backend": "claude" },
     }))
     .unwrap();
     let resp = svc.create("u", req).await.unwrap();
@@ -2818,10 +2863,11 @@ async fn update_rejects_extra_skills() {
 #[tokio::test]
 async fn update_allows_other_extra_fields() {
     let (svc, _broadcaster, _repo, task_mgr) = make_service();
+    let workspace = ensure_test_workspace_path();
 
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "acp",
-        "extra": { "workspace": "/project", "backend": "claude" },
+        "extra": { "workspace": workspace, "backend": "claude" },
     }))
     .unwrap();
     let resp = svc.create("u", req).await.unwrap();
@@ -2950,10 +2996,11 @@ async fn create_honors_legacy_alias_fields_from_clone_merge() {
 
     // Legacy-shaped extra — what clone_create might merge in from an
     // unmigrated source conversation.
+    let workspace = ensure_test_workspace_path();
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "acp",
         "extra": {
-            "workspace": "/project",
+            "workspace": workspace,
             "backend": "claude",
             "enabled_skills": ["pdf"],
             "exclude_builtin_skills": ["cron"],

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -2982,10 +2982,11 @@ async fn update_rejects_extra_skills() {
 #[tokio::test]
 async fn update_rejects_acp_runtime_current_extra_fields() {
     let (svc, _broadcaster, _repo, task_mgr) = make_service();
+    let workspace = ensure_test_workspace_path();
 
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "acp",
-        "extra": { "workspace": "/project", "backend": "claude" },
+        "extra": { "workspace": workspace, "backend": "claude" },
     }))
     .unwrap();
     let resp = svc.create("u", req).await.unwrap();

--- a/crates/aionui-conversation/src/service_test/acp_error_recovery_test.rs
+++ b/crates/aionui-conversation/src/service_test/acp_error_recovery_test.rs
@@ -48,12 +48,13 @@ async fn send_message_clears_persisted_acp_model_after_model_not_found() {
     );
     let task_mgr = Arc::new(MockTaskManager::new());
     let conv = svc.create("user_1", make_create_req()).await.unwrap();
+    let workspace = ensure_test_workspace_path();
     repo.update(
         &conv.id,
         &ConversationRowUpdate {
             extra: Some(
                 serde_json::to_string(&json!({
-                    "workspace": "/project",
+                    "workspace": workspace,
                     "current_model_id": "deepseek-v4-pro",
                 }))
                 .unwrap(),

--- a/crates/aionui-conversation/tests/conversation_crud.rs
+++ b/crates/aionui-conversation/tests/conversation_crud.rs
@@ -114,10 +114,17 @@ async fn setup() -> (ConversationService, Arc<TestBroadcaster>, Arc<dyn IWorkerT
 
 const USER_ID: &str = "system_default_user";
 
+fn ensure_test_workspace_path() -> String {
+    let workspace = std::env::temp_dir().join("aionui-conversation-crud-test-project");
+    std::fs::create_dir_all(&workspace).unwrap();
+    workspace.to_string_lossy().to_string()
+}
+
 fn make_create_req() -> CreateConversationRequest {
+    let workspace = ensure_test_workspace_path();
     serde_json::from_value(json!({
         "type": "acp",
-        "extra": { "workspace": "/home/user/project" }
+        "extra": { "workspace": workspace }
     }))
     .unwrap()
 }
@@ -127,6 +134,7 @@ fn make_create_req() -> CreateConversationRequest {
 #[tokio::test]
 async fn t1_1_create_with_defaults() {
     let (svc, broadcaster, _task_mgr) = setup().await;
+    let workspace = ensure_test_workspace_path();
 
     let resp = svc.create(USER_ID, make_create_req()).await.unwrap();
 
@@ -136,7 +144,7 @@ async fn t1_1_create_with_defaults() {
     assert_eq!(resp.source, Some(ConversationSource::Aionui));
     assert!(!resp.pinned);
     assert!(resp.pinned_at.is_none());
-    assert_eq!(resp.extra["workspace"], "/home/user/project");
+    assert_eq!(resp.extra["workspace"], workspace);
     assert!(resp.created_at > 0);
     assert_eq!(resp.created_at, resp.modified_at);
 
@@ -191,13 +199,14 @@ async fn t1_2_create_each_agent_type() {
 #[tokio::test]
 async fn t1_3_create_with_optional_fields() {
     let (svc, _, _task_mgr) = setup().await;
+    let workspace = ensure_test_workspace_path();
 
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "acp",
         "name": "Custom Name",
         "source": "telegram",
         "channel_chat_id": "user:123",
-        "extra": { "workspace": "/path" }
+        "extra": { "workspace": workspace }
     }))
     .unwrap();
     let resp = svc.create(USER_ID, req).await.unwrap();
@@ -398,20 +407,25 @@ async fn t4_3_unpin_clears_pinned_at() {
 #[tokio::test]
 async fn t4_4_extra_merge_preserves_existing_keys() {
     let (svc, _, task_mgr) = setup().await;
+    let dir = std::env::temp_dir().join("aionui-conversation-crud-extra-merge");
+    let old_workspace = dir.join("old-workspace");
+    let new_workspace = dir.join("new-workspace");
+    std::fs::create_dir_all(&old_workspace).unwrap();
+    std::fs::create_dir_all(&new_workspace).unwrap();
 
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "acp",
-        "extra": { "workspace": "/old", "contextFileName": "ctx.md" }
+        "extra": { "workspace": old_workspace.to_string_lossy(), "contextFileName": "ctx.md" }
     }))
     .unwrap();
     let conv = svc.create(USER_ID, req).await.unwrap();
 
     // Update only workspace
     let update_req: UpdateConversationRequest =
-        serde_json::from_value(json!({ "extra": { "workspace": "/new" } })).unwrap();
+        serde_json::from_value(json!({ "extra": { "workspace": new_workspace.to_string_lossy() } })).unwrap();
     let updated = svc.update(USER_ID, &conv.id, update_req, &task_mgr).await.unwrap();
 
-    assert_eq!(updated.extra["workspace"], "/new");
+    assert_eq!(updated.extra["workspace"], new_workspace.to_string_lossy().to_string());
     assert_eq!(updated.extra["contextFileName"], "ctx.md");
 }
 
@@ -545,9 +559,10 @@ async fn t12_1_long_name() {
 #[tokio::test]
 async fn t12_2_large_extra_json() {
     let (svc, _, _task_mgr) = setup().await;
+    let workspace = ensure_test_workspace_path();
 
     let large_extra = json!({
-        "workspace": "/project",
+        "workspace": workspace,
         "nested": {
             "deep": {
                 "array": [1, 2, 3, 4, 5],
@@ -564,7 +579,7 @@ async fn t12_2_large_extra_json() {
     .unwrap();
     let resp = svc.create(USER_ID, req).await.unwrap();
 
-    assert_eq!(resp.extra["workspace"], "/project");
+    assert_eq!(resp.extra["workspace"], workspace);
     assert_eq!(resp.extra["nested"]["deep"]["array"][2], 3);
 }
 
@@ -596,6 +611,8 @@ async fn t12_3_concurrent_creates() {
 #[tokio::test]
 async fn full_lifecycle_create_get_update_delete() {
     let (svc, broadcaster, task_mgr) = setup().await;
+    let updated_workspace = std::env::temp_dir().join("aionui-conversation-crud-updated-workspace");
+    std::fs::create_dir_all(&updated_workspace).unwrap();
 
     // Create
     let created = svc.create(USER_ID, make_create_req()).await.unwrap();
@@ -609,13 +626,16 @@ async fn full_lifecycle_create_get_update_delete() {
     let update_req: UpdateConversationRequest = serde_json::from_value(json!({
         "name": "Updated",
         "pinned": true,
-        "extra": { "workspace": "/updated" }
+        "extra": { "workspace": updated_workspace.to_string_lossy() }
     }))
     .unwrap();
     let updated = svc.update(USER_ID, &created.id, update_req, &task_mgr).await.unwrap();
     assert_eq!(updated.name, "Updated");
     assert!(updated.pinned);
-    assert_eq!(updated.extra["workspace"], "/updated");
+    assert_eq!(
+        updated.extra["workspace"],
+        updated_workspace.to_string_lossy().to_string()
+    );
 
     // Delete
     svc.delete(USER_ID, &created.id).await.unwrap();
@@ -690,12 +710,13 @@ async fn create_accepts_top_level_model_for_aionrs() {
 #[tokio::test]
 async fn create_aionrs_strips_extra_model_field() {
     let (svc, _, _task_mgr) = setup().await;
+    let workspace = ensure_test_workspace_path();
 
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "aionrs",
         "model": { "provider_id": "p1", "model": "gpt-4o" },
         "extra": {
-            "workspace": "/home/user/project",
+            "workspace": workspace,
             "model": "bogus-from-legacy-client"
         }
     }))

--- a/crates/aionui-conversation/tests/conversation_extended.rs
+++ b/crates/aionui-conversation/tests/conversation_extended.rs
@@ -115,10 +115,21 @@ async fn setup() -> (
 
 const USER_ID: &str = "system_default_user";
 
+fn ensure_test_workspace_path() -> String {
+    ensure_named_workspace_path("aionui-conversation-extended-test-project")
+}
+
+fn ensure_named_workspace_path(name: &str) -> String {
+    let workspace = std::env::temp_dir().join(name);
+    std::fs::create_dir_all(&workspace).unwrap();
+    workspace.to_string_lossy().to_string()
+}
+
 fn make_create_req() -> CreateConversationRequest {
+    let workspace = ensure_test_workspace_path();
     serde_json::from_value(json!({
         "type": "acp",
-        "extra": { "workspace": "/home/user/project" }
+        "extra": { "workspace": workspace }
     }))
     .unwrap()
 }
@@ -402,6 +413,7 @@ async fn t8_8_get_message_not_found() {
 #[tokio::test]
 async fn t9_1_keyword_match() {
     let (svc, repo, _b) = setup().await;
+    let workspace = ensure_test_workspace_path();
     let conv = svc.create(USER_ID, make_create_req()).await.unwrap();
 
     repo.insert_message(&make_message(&conv.id, "Rust review report", 0))
@@ -427,7 +439,7 @@ async fn t9_1_keyword_match() {
 
     assert_eq!(item.conversation.id, conv.id);
     assert_eq!(item.conversation.name, conv.name);
-    assert_eq!(item.conversation.extra["workspace"], "/home/user/project");
+    assert_eq!(item.conversation.extra["workspace"], workspace);
 }
 
 #[tokio::test]
@@ -519,13 +531,14 @@ async fn t9_5_preview_text_extracts_from_json_content() {
 #[tokio::test]
 async fn t9_6_search_result_includes_conversation_model() {
     let (svc, repo, _b) = setup().await;
+    let workspace = ensure_test_workspace_path();
 
     // Search surfaces conversation.model only for aionrs (the only type that
     // carries a top-level model under the aionrs-only rule).
     let aionrs_req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "aionrs",
         "model": { "provider_id": "p1", "model": "claude-sonnet-4-20250514" },
-        "extra": { "workspace": "/home/user/project" }
+        "extra": { "workspace": workspace }
     }))
     .unwrap();
     let conv = svc.create(USER_ID, aionrs_req).await.unwrap();
@@ -572,11 +585,13 @@ async fn t9_7_search_does_not_leak_other_users_messages() {
 #[tokio::test]
 async fn t10_1_same_workspace() {
     let (svc, _repo, _b) = setup().await;
+    let shared_workspace = ensure_named_workspace_path("aionui-conversation-extended-shared-workspace");
+    let other_workspace = ensure_named_workspace_path("aionui-conversation-extended-other-workspace");
 
     let req1: CreateConversationRequest = serde_json::from_value(json!({
         "type": "acp",
         "name": "Conv A",
-        "extra": { "workspace": "/shared/path" }
+        "extra": { "workspace": shared_workspace }
     }))
     .unwrap();
     let conv1 = svc.create(USER_ID, req1).await.unwrap();
@@ -584,7 +599,7 @@ async fn t10_1_same_workspace() {
     let req2: CreateConversationRequest = serde_json::from_value(json!({
         "type": "acp",
         "name": "Conv B",
-        "extra": { "workspace": "/shared/path" }
+        "extra": { "workspace": shared_workspace }
     }))
     .unwrap();
     let conv2 = svc.create(USER_ID, req2).await.unwrap();
@@ -593,7 +608,7 @@ async fn t10_1_same_workspace() {
     let req3: CreateConversationRequest = serde_json::from_value(json!({
         "type": "acp",
         "name": "Conv C",
-        "extra": { "workspace": "/other/path" }
+        "extra": { "workspace": other_workspace }
     }))
     .unwrap();
     svc.create(USER_ID, req3).await.unwrap();
@@ -606,10 +621,11 @@ async fn t10_1_same_workspace() {
 #[tokio::test]
 async fn t10_2_no_associated() {
     let (svc, _repo, _b) = setup().await;
+    let workspace = ensure_named_workspace_path("aionui-conversation-extended-unique-workspace");
 
     let req: CreateConversationRequest = serde_json::from_value(json!({
         "type": "acp",
-        "extra": { "workspace": "/unique/path" }
+        "extra": { "workspace": workspace }
     }))
     .unwrap();
     let conv = svc.create(USER_ID, req).await.unwrap();

--- a/crates/aionui-cron/src/error.rs
+++ b/crates/aionui-cron/src/error.rs
@@ -32,11 +32,11 @@ pub enum CronError {
     #[error("Scheduler error: {0}")]
     Scheduler(String),
 
-    #[error("Workspace path contains whitespace: {0}")]
-    WorkspacePathContainsWhitespace(String),
+    #[error("Workspace path is unavailable: {0}")]
+    WorkspacePathUnavailable(String),
 
-    #[error("Workspace path contains whitespace and is unsupported at runtime: {0}")]
-    WorkspacePathContainsWhitespaceRuntimeUnsupported(String),
+    #[error("Workspace path is unavailable during execution: {0}")]
+    WorkspacePathRuntimeUnavailable(String),
 
     #[error(transparent)]
     Conversation(#[from] ConversationError),
@@ -51,10 +51,8 @@ pub enum CronError {
 impl CronError {
     pub(crate) fn from_conversation_create(error: ConversationError) -> Self {
         match error {
-            ConversationError::WorkspacePathContainsWhitespace { path } => Self::WorkspacePathContainsWhitespace(path),
-            ConversationError::WorkspacePathContainsWhitespaceRuntimeUnsupported { path } => {
-                Self::WorkspacePathContainsWhitespaceRuntimeUnsupported(path)
-            }
+            ConversationError::WorkspacePathUnavailable { path } => Self::WorkspacePathUnavailable(path),
+            ConversationError::WorkspacePathRuntimeUnavailable { path } => Self::WorkspacePathRuntimeUnavailable(path),
             other => Self::Scheduler(format!("create conversation: {other}")),
         }
     }
@@ -66,10 +64,10 @@ mod tests {
 
     #[test]
     fn conversation_create_preserves_workspace_error_code() {
-        let err = CronError::from_conversation_create(ConversationError::WorkspacePathContainsWhitespace {
+        let err = CronError::from_conversation_create(ConversationError::WorkspacePathUnavailable {
             path: "/tmp/a b".into(),
         });
-        assert!(matches!(err, CronError::WorkspacePathContainsWhitespace(msg) if msg == "/tmp/a b"));
+        assert!(matches!(err, CronError::WorkspacePathUnavailable(msg) if msg == "/tmp/a b"));
     }
 
     #[test]

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -6,7 +6,9 @@ use aionui_ai_agent::task_manager::IWorkerTaskManager;
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
 use aionui_ai_agent::{AgentRegistry, AgentStreamEvent};
 use aionui_api_types::{CreateConversationRequest, SendMessageRequest};
-use aionui_common::{AgentType, ProviderWithModel, now_ms, workspace_path_has_whitespace_segment};
+use aionui_common::{
+    AgentType, ProviderWithModel, WorkspacePathValidationError, now_ms, validate_workspace_path_availability,
+};
 use aionui_conversation::ConversationService;
 use aionui_db::models::MessageRow;
 use aionui_db::{ConversationRowUpdate, IConversationRepository};
@@ -200,15 +202,15 @@ impl JobExecutor {
 
     pub(crate) async fn validate_runtime_job_workspace(&self, job: &CronJob) -> Result<(), CronError> {
         let workspace = self.resolve_job_workspace_raw(job).await?;
-        if workspace.trim().is_empty() {
-            return Ok(());
+        match validate_workspace_path_availability(&workspace) {
+            Ok(_) => Ok(()),
+            Err(WorkspacePathValidationError::Empty) => Ok(()),
+            Err(WorkspacePathValidationError::DoesNotExist(path))
+            | Err(WorkspacePathValidationError::NotDirectory(path))
+            | Err(WorkspacePathValidationError::NotAccessible { path, .. }) => {
+                Err(CronError::WorkspacePathRuntimeUnavailable(path))
+            }
         }
-
-        if workspace_path_has_whitespace_segment(Path::new(&workspace)) {
-            return Err(CronError::WorkspacePathContainsWhitespaceRuntimeUnsupported(workspace));
-        }
-
-        Ok(())
     }
 
     pub async fn insert_tips_message(

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -1202,6 +1202,12 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use tokio::sync::{RwLock, broadcast};
 
+    fn ensure_named_workspace_path(name: &str) -> String {
+        let workspace = std::env::temp_dir().join(name);
+        std::fs::create_dir_all(&workspace).unwrap();
+        workspace.to_string_lossy().to_string()
+    }
+
     fn sample_job() -> CronJob {
         CronJob {
             id: "cron_test1".into(),
@@ -1223,7 +1229,7 @@ mod tests {
                 mode: None,
                 model_id: Some("claude-sonnet-4".into()),
                 config_options: None,
-                workspace: Some("/home/user/project".into()),
+                workspace: Some(ensure_named_workspace_path("aionui-cron-sample-job-workspace")),
             }),
             conversation_id: "conv_1".into(),
             conversation_title: Some("Test Conv".into()),
@@ -1610,7 +1616,10 @@ mod tests {
 
         let extra = build_conversation_extra(&registry, &job, None).await;
 
-        assert_eq!(extra["workspace"], "/home/user/project");
+        assert_eq!(
+            extra["workspace"],
+            ensure_named_workspace_path("aionui-cron-sample-job-workspace")
+        );
     }
 
     #[tokio::test]
@@ -1868,7 +1877,10 @@ mod tests {
         let options = task_manager
             .last_options()
             .expect("task manager should capture build options");
-        assert_eq!(options.workspace, "/tmp/existing-conversation-workspace");
+        assert_eq!(
+            options.workspace,
+            ensure_named_workspace_path("aionui-cron-existing-conversation-workspace")
+        );
     }
 
     #[tokio::test]
@@ -1902,7 +1914,10 @@ mod tests {
             .expect("conversation workspace should be persisted");
         let extra = update.extra.expect("workspace update should write extra");
         let value: serde_json::Value = serde_json::from_str(&extra).expect("valid extra json");
-        assert_eq!(value["workspace"], "/tmp/cron-test");
+        assert_eq!(
+            value["workspace"],
+            ensure_named_workspace_path("aionui-cron-agent-workspace")
+        );
     }
 
     #[tokio::test]
@@ -1911,7 +1926,9 @@ mod tests {
         let task_manager = Arc::new(RecordingTaskManager::new(AgentInstance::Mock(agent.clone())));
         let repo = Arc::new(MissingWorkspaceConversationRepo::new(
             "conv_1",
-            serde_json::json!({ "workspace": "/tmp/existing-conversation-workspace" }),
+            serde_json::json!({
+                "workspace": ensure_named_workspace_path("aionui-cron-existing-conversation-workspace")
+            }),
         ));
         let executor = make_executor_with_task_manager_and_repo(task_manager, repo.clone());
         let job = CronJob {
@@ -1946,7 +1963,9 @@ mod tests {
         let task_manager = Arc::new(RecordingTaskManager::new(AgentInstance::Mock(agent.clone())));
         let repo = Arc::new(MissingWorkspaceConversationRepo::new(
             "conv_1",
-            serde_json::json!({ "workspace": "/tmp/existing-conversation-workspace" }),
+            serde_json::json!({
+                "workspace": ensure_named_workspace_path("aionui-cron-existing-conversation-workspace")
+            }),
         ));
         let broadcaster = Arc::new(RecordingBroadcaster::new());
         let executor =
@@ -2190,7 +2209,7 @@ mod tests {
             let (event_tx, _) = broadcast::channel(16);
             Self {
                 conversation_id: conversation_id.to_owned(),
-                workspace: "/tmp/cron-test".to_owned(),
+                workspace: ensure_named_workspace_path("aionui-cron-agent-workspace"),
                 event_tx,
                 mode: RwLock::new(mode.to_owned()),
                 sent_messages: RwLock::new(Vec::new()),
@@ -2395,7 +2414,7 @@ mod tests {
                 name: "Cron Conversation".into(),
                 r#type: "acp".into(),
                 extra: serde_json::json!({
-                    "workspace": "/tmp/existing-conversation-workspace"
+                    "workspace": ensure_named_workspace_path("aionui-cron-existing-conversation-workspace")
                 })
                 .to_string(),
                 model: None,

--- a/crates/aionui-cron/src/routes.rs
+++ b/crates/aionui-cron/src/routes.rs
@@ -41,10 +41,8 @@ impl From<CronError> for ApiError {
             CronError::InvalidSkillContent(msg) => ApiError::BadRequest(msg),
             CronError::InvalidAgentConfig(msg) => ApiError::BadRequest(msg),
             CronError::Scheduler(msg) => ApiError::Internal(msg),
-            CronError::WorkspacePathContainsWhitespace(path) => ApiError::WorkspacePathContainsWhitespace(path),
-            CronError::WorkspacePathContainsWhitespaceRuntimeUnsupported(path) => {
-                ApiError::WorkspacePathContainsWhitespaceRuntimeUnsupported(path)
-            }
+            CronError::WorkspacePathUnavailable(path) => ApiError::WorkspacePathUnavailable(path),
+            CronError::WorkspacePathRuntimeUnavailable(path) => ApiError::WorkspacePathRuntimeUnavailable(path),
             CronError::Conversation(conversation_err) => ApiError::from(conversation_err),
             CronError::Database(db_err) => db_error_to_api_error(db_err),
             CronError::Json(e) => ApiError::Internal(format!("JSON error: {e}")),
@@ -242,8 +240,8 @@ mod tests {
 
     #[test]
     fn workspace_error_preserves_code() {
-        let err: ApiError = CronError::WorkspacePathContainsWhitespace("/tmp/a b".into()).into();
-        assert!(matches!(err, ApiError::WorkspacePathContainsWhitespace(msg) if msg == "/tmp/a b"));
+        let err: ApiError = CronError::WorkspacePathUnavailable("/tmp/a b".into()).into();
+        assert!(matches!(err, ApiError::WorkspacePathUnavailable(msg) if msg == "/tmp/a b"));
     }
 
     #[test]
@@ -255,10 +253,10 @@ mod tests {
 
     #[test]
     fn runtime_workspace_error_preserves_code() {
-        let err: ApiError = CronError::WorkspacePathContainsWhitespaceRuntimeUnsupported("/tmp/a b".into()).into();
+        let err: ApiError = CronError::WorkspacePathRuntimeUnavailable("/tmp/a b".into()).into();
         assert!(matches!(
             err,
-            ApiError::WorkspacePathContainsWhitespaceRuntimeUnsupported(msg) if msg == "/tmp/a b"
+            ApiError::WorkspacePathRuntimeUnavailable(msg) if msg == "/tmp/a b"
         ));
     }
 

--- a/crates/aionui-cron/src/service.rs
+++ b/crates/aionui-cron/src/service.rs
@@ -6,7 +6,9 @@ use aionui_api_types::{
     CreateCronJobRequest, CronJobResponse, CronScheduleDto, HasSkillResponse, ListCronJobsQuery, RunNowResponse,
     SaveCronSkillRequest, UpdateCronJobRequest,
 };
-use aionui_common::{AgentType, generate_prefixed_id, now_ms, workspace_path_has_whitespace_segment};
+use aionui_common::{
+    AgentType, WorkspacePathValidationError, generate_prefixed_id, now_ms, validate_workspace_path_availability,
+};
 use aionui_db::{ICronRepository, UpdateCronJobParams};
 use tracing::{error, info, warn};
 
@@ -483,15 +485,15 @@ impl CronService {
 
     async fn validate_job_workspace(&self, job: &CronJob) -> Result<(), CronError> {
         let workspace = self.executor.resolve_job_workspace_raw(job).await?;
-        if workspace.trim().is_empty() {
-            return Ok(());
+        match validate_workspace_path_availability(&workspace) {
+            Ok(_) => Ok(()),
+            Err(WorkspacePathValidationError::Empty) => Ok(()),
+            Err(WorkspacePathValidationError::DoesNotExist(path))
+            | Err(WorkspacePathValidationError::NotDirectory(path))
+            | Err(WorkspacePathValidationError::NotAccessible { path, .. }) => {
+                Err(CronError::WorkspacePathUnavailable(path))
+            }
         }
-
-        if workspace_path_has_whitespace_segment(Path::new(&workspace)) {
-            return Err(CronError::WorkspacePathContainsWhitespace(workspace));
-        }
-
-        Ok(())
     }
 
     async fn handle_execution_result(&self, job: CronJob, result: ExecutionResult) {

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -37,6 +37,12 @@ use aionui_cron::types::JobStatus;
 
 // ── Test infrastructure ────────────────────────────────────────────
 
+fn ensure_named_workspace_path(name: &str) -> String {
+    let workspace = std::env::temp_dir().join(name);
+    std::fs::create_dir_all(&workspace).unwrap();
+    workspace.to_string_lossy().to_string()
+}
+
 struct MockBroadcaster {
     events: Mutex<Vec<WebSocketMessage<serde_json::Value>>>,
 }
@@ -159,7 +165,7 @@ impl IConversationRepository for StubConvRepo {
                 extra: serde_json::json!({
                     "backend": "gemini",
                     "agent_name": "Gemini",
-                    "workspace": "/tmp/gemini-workspace",
+                    "workspace": ensure_named_workspace_path("aionui-cron-service-gemini-workspace"),
                     "session_mode": "yolo",
                     "current_model_id": "gemini-2.5-pro"
                 })
@@ -189,7 +195,7 @@ impl IConversationRepository for StubConvRepo {
                 extra: serde_json::json!({
                     "backend": "gemini",
                     "agent_name": "Gemini",
-                    "workspace": "/tmp/gemini-default-workspace",
+                    "workspace": ensure_named_workspace_path("aionui-cron-service-gemini-default-workspace"),
                     "session_mode": "default",
                     "current_model_id": "gemini-2.5-pro"
                 })
@@ -219,7 +225,7 @@ impl IConversationRepository for StubConvRepo {
                 extra: serde_json::json!({
                     "backend": "codex",
                     "agent_name": "Codex",
-                    "workspace": "/tmp/codex-workspace",
+                    "workspace": ensure_named_workspace_path("aionui-cron-service-codex-workspace"),
                     "session_mode": "default",
                     "current_model_id": "gpt-5-codex"
                 })
@@ -249,7 +255,7 @@ impl IConversationRepository for StubConvRepo {
                 extra: serde_json::json!({
                     "backend": "claude",
                     "agent_name": "Claude",
-                    "workspace": "/tmp/claude-workspace",
+                    "workspace": ensure_named_workspace_path("aionui-cron-service-claude-workspace"),
                     "session_mode": "default",
                     "current_model_id": "claude-sonnet-4-20250514"
                 })
@@ -279,7 +285,7 @@ impl IConversationRepository for StubConvRepo {
                 extra: serde_json::json!({
                     "backend": "anthropic",
                     "agent_name": "Aion CLI",
-                    "workspace": "/tmp/aionrs-workspace",
+                    "workspace": ensure_named_workspace_path("aionui-cron-service-aionrs-workspace"),
                     "session_mode": "default",
                     "current_model_id": "claude-sonnet-4-20250514"
                 })
@@ -1266,7 +1272,10 @@ async fn icron_service_create_job_inherits_conversation_mode_and_backend() {
     assert_eq!(config.name, "Gemini");
     assert_eq!(config.mode.as_deref(), Some("yolo"));
     assert_eq!(config.model_id.as_deref(), Some("gemini-2.5-pro"));
-    assert_eq!(config.workspace.as_deref(), Some("/tmp/gemini-workspace"));
+    assert_eq!(
+        config.workspace.as_deref(),
+        Some(ensure_named_workspace_path("aionui-cron-service-gemini-workspace").as_str())
+    );
 }
 
 #[tokio::test]

--- a/crates/aionui-team/src/error.rs
+++ b/crates/aionui-team/src/error.rs
@@ -29,11 +29,11 @@ pub enum TeamError {
     #[error("Agent name already taken: {0}")]
     DuplicateAgentName(String),
 
-    #[error("Workspace path contains whitespace: {0}")]
-    WorkspacePathContainsWhitespace(String),
+    #[error("Workspace path is unavailable: {0}")]
+    WorkspacePathUnavailable(String),
 
-    #[error("Workspace path contains whitespace and is unsupported at runtime: {0}")]
-    WorkspacePathContainsWhitespaceRuntimeUnsupported(String),
+    #[error("Workspace path is unavailable during execution: {0}")]
+    WorkspacePathRuntimeUnavailable(String),
 
     #[error(transparent)]
     Conversation(#[from] ConversationError),
@@ -48,10 +48,8 @@ pub enum TeamError {
 impl TeamError {
     pub(crate) fn from_conversation_create(error: ConversationError) -> Self {
         match error {
-            ConversationError::WorkspacePathContainsWhitespace { path } => Self::WorkspacePathContainsWhitespace(path),
-            ConversationError::WorkspacePathContainsWhitespaceRuntimeUnsupported { path } => {
-                Self::WorkspacePathContainsWhitespaceRuntimeUnsupported(path)
-            }
+            ConversationError::WorkspacePathUnavailable { path } => Self::WorkspacePathUnavailable(path),
+            ConversationError::WorkspacePathRuntimeUnavailable { path } => Self::WorkspacePathRuntimeUnavailable(path),
             other => Self::InvalidRequest(format!("failed to create conversation: {other}")),
         }
     }
@@ -63,10 +61,10 @@ mod tests {
 
     #[test]
     fn conversation_create_preserves_workspace_error_code() {
-        let err = TeamError::from_conversation_create(ConversationError::WorkspacePathContainsWhitespace {
+        let err = TeamError::from_conversation_create(ConversationError::WorkspacePathUnavailable {
             path: "/tmp/a b".into(),
         });
-        assert!(matches!(err, TeamError::WorkspacePathContainsWhitespace(msg) if msg == "/tmp/a b"));
+        assert!(matches!(err, TeamError::WorkspacePathUnavailable(msg) if msg == "/tmp/a b"));
     }
 
     #[test]

--- a/crates/aionui-team/src/routes.rs
+++ b/crates/aionui-team/src/routes.rs
@@ -46,10 +46,8 @@ impl From<TeamError> for ApiError {
             TeamError::BlockedTaskNotFound(msg) => ApiError::BadRequest(msg),
             TeamError::BackendNotAllowed(msg) => ApiError::BadRequest(msg),
             TeamError::DuplicateAgentName(msg) => ApiError::BadRequest(format!("Agent name already taken: {msg}")),
-            TeamError::WorkspacePathContainsWhitespace(path) => ApiError::WorkspacePathContainsWhitespace(path),
-            TeamError::WorkspacePathContainsWhitespaceRuntimeUnsupported(path) => {
-                ApiError::WorkspacePathContainsWhitespaceRuntimeUnsupported(path)
-            }
+            TeamError::WorkspacePathUnavailable(path) => ApiError::WorkspacePathUnavailable(path),
+            TeamError::WorkspacePathRuntimeUnavailable(path) => ApiError::WorkspacePathRuntimeUnavailable(path),
             TeamError::Conversation(conversation_err) => ApiError::from(conversation_err),
             TeamError::Database(db_err) => db_error_to_api_error(db_err),
             TeamError::Json(e) => ApiError::Internal(format!("JSON error: {e}")),
@@ -274,8 +272,8 @@ mod tests {
 
     #[test]
     fn workspace_error_preserves_code() {
-        let err: ApiError = TeamError::WorkspacePathContainsWhitespace("/tmp/a b".into()).into();
-        assert!(matches!(err, ApiError::WorkspacePathContainsWhitespace(msg) if msg == "/tmp/a b"));
+        let err: ApiError = TeamError::WorkspacePathUnavailable("/tmp/a b".into()).into();
+        assert!(matches!(err, ApiError::WorkspacePathUnavailable(msg) if msg == "/tmp/a b"));
     }
 
     #[test]
@@ -287,10 +285,10 @@ mod tests {
 
     #[test]
     fn runtime_workspace_error_preserves_code() {
-        let err: ApiError = TeamError::WorkspacePathContainsWhitespaceRuntimeUnsupported("/tmp/a b".into()).into();
+        let err: ApiError = TeamError::WorkspacePathRuntimeUnavailable("/tmp/a b".into()).into();
         assert!(matches!(
             err,
-            ApiError::WorkspacePathContainsWhitespaceRuntimeUnsupported(msg) if msg == "/tmp/a b"
+            ApiError::WorkspacePathRuntimeUnavailable(msg) if msg == "/tmp/a b"
         ));
     }
 

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -9,7 +9,10 @@ use aionui_api_types::{
     AddAgentRequest, CreateConversationRequest, CreateTeamRequest, GuideMcpConfig, TeamAgentResponse, TeamMcpPhase,
     TeamMcpStatusPayload, TeamResponse, WebSocketMessage,
 };
-use aionui_common::{AgentKillReason, AgentType, ProviderWithModel, generate_id, now_ms};
+use aionui_common::{
+    AgentKillReason, AgentType, ProviderWithModel, WorkspacePathValidationError, generate_id, now_ms,
+    validate_workspace_path_availability,
+};
 use aionui_conversation::ConversationService;
 use aionui_db::models::TeamRow;
 use aionui_db::{IAgentMetadataRepository, IProviderRepository, ITeamRepository, UpdateTeamParams};
@@ -138,6 +141,11 @@ impl TeamSessionService {
             return Err(TeamError::InvalidRequest("at least one agent is required".into()));
         }
 
+        let shared_workspace = match req.workspace.as_deref() {
+            Some(workspace) if !workspace.is_empty() => Some(validate_create_workspace_path(workspace)?),
+            _ => None,
+        };
+
         let team_id = generate_id();
         let now = now_ms();
         let mut agents = Vec::with_capacity(req.agents.len());
@@ -190,9 +198,7 @@ impl TeamSessionService {
                         "backend": input.backend,
                         "session_mode": resolve_full_auto_mode(&input.backend),
                     });
-                    if let Some(ref ws) = req.workspace
-                        && !ws.is_empty()
-                    {
+                    if let Some(ref ws) = shared_workspace {
                         extra["workspace"] = serde_json::Value::String(ws.clone());
                     }
                     (
@@ -211,9 +217,7 @@ impl TeamSessionService {
                         "provider_id": provider_id,
                         "current_model_id": input.model.clone(),
                     });
-                    if let Some(ref ws) = req.workspace
-                        && !ws.is_empty()
-                    {
+                    if let Some(ref ws) = shared_workspace {
                         extra["workspace"] = serde_json::Value::String(ws.clone());
                     }
                     (None, extra)
@@ -255,7 +259,7 @@ impl TeamSessionService {
             id: team_id.clone(),
             user_id: user_id.to_owned(),
             name: req.name.clone(),
-            workspace: req.workspace.clone().unwrap_or_default(),
+            workspace: shared_workspace.clone().unwrap_or_default(),
             workspace_mode: "shared".into(),
             agents: agents_json,
             lead_agent_id: lead_agent_id.clone(),
@@ -921,4 +925,13 @@ impl TeamSessionService {
         entry.session.notify_agent(slot_id);
         Ok(())
     }
+}
+
+fn validate_create_workspace_path(workspace: &str) -> Result<String, TeamError> {
+    validate_workspace_path_availability(workspace).map_err(|error| match error {
+        WorkspacePathValidationError::Empty => TeamError::InvalidRequest("Workspace directory is empty".into()),
+        WorkspacePathValidationError::DoesNotExist(path)
+        | WorkspacePathValidationError::NotDirectory(path)
+        | WorkspacePathValidationError::NotAccessible { path, .. } => TeamError::WorkspacePathUnavailable(path),
+    })
 }


### PR DESCRIPTION
## Summary
- align workspace validation with real path availability instead of treating whitespace as invalid
- keep runtime auto-workspace recovery for system-managed temp workspaces while still rejecting missing user-selected paths
- preserve user messages and broadcast runtime failure tips/turn completion for unavailable workspaces
- update conversation/cron/team test fixtures to use real temporary directories now that create-time validation requires existing paths

## Testing
- `just push`
