### PR TITLE
fix(shell): support UNC paths in Windows terminal

### DIFF
--- a/crates/aionui-shell/src/shell.rs
+++ b/crates/aionui-shell/src/shell.rs
@@ -79,8 +79,9 @@ impl ShellService {
         if cfg!(target_os = "macos") {
             self.opener.run_command("open", &["-a", "Terminal", &path_str]).await
         } else if cfg!(target_os = "windows") {
+            let command = build_windows_terminal_command(&path_str);
             self.opener
-                .run_command("cmd", &["/c", "start", "cmd", "/K", &format!("cd /d {path_str}")])
+                .run_command("cmd", &["/c", "start", "cmd", "/K", &command])
                 .await
         } else {
             self.try_linux_terminal(&path_str).await
@@ -151,6 +152,10 @@ fn validate_directory_exists(dir_path: &str) -> Result<std::path::PathBuf, Shell
         return Err(ShellError::DirectoryNotFound(dir_path.to_owned()));
     }
     Ok(canonical)
+}
+
+fn build_windows_terminal_command(path: &str) -> String {
+    format!(r#"pushd "{path}""#)
 }
 
 fn validate_url(url: &str) -> Result<(), ShellError> {
@@ -340,5 +345,17 @@ mod tests {
             .open_folder_with(file_path.to_str().unwrap(), ToolType::Explorer)
             .await;
         assert!(matches!(result, Err(ShellError::DirectoryNotFound(_))));
+    }
+
+    #[test]
+    fn build_windows_terminal_command_quotes_paths_with_spaces() {
+        let command = build_windows_terminal_command(r#"C:\Users\zhoukai\My Project"#);
+        assert_eq!(command, r#"pushd "C:\Users\zhoukai\My Project""#);
+    }
+
+    #[test]
+    fn build_windows_terminal_command_supports_unc_paths() {
+        let command = build_windows_terminal_command(r#"\\server\share\My Project"#);
+        assert_eq!(command, r#"pushd "\\server\share\My Project""#);
     }
 }


### PR DESCRIPTION
Summary
- switch Windows terminal open-folder command from cd /d to pushd so UNC shares resolve correctly
- quote the path in the generated cmd command so paths with spaces also work
- add regression tests for local paths with spaces and UNC paths

## Testing
- just push -u origin agent/fix/windows-terminal-pushd