### PR TITLE
feat(cli): canonicalize CLI and bootstrap boundary errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "sqlx",
  "tempfile",
  "tokio",
  "tokio-tungstenite 0.26.2",

--- a/crates/aionui-app/Cargo.toml
+++ b/crates/aionui-app/Cargo.toml
@@ -62,6 +62,7 @@ base64.workspace = true
 git2.workspace = true
 http-body-util.workspace = true
 rust_xlsxwriter.workspace = true
+sqlx = { workspace = true, features = ["migrate"] }
 tempfile = "3"
 tower = { workspace = true, features = ["util"] }
 tokio-tungstenite.workspace = true

--- a/crates/aionui-app/src/bootstrap/environment.rs
+++ b/crates/aionui-app/src/bootstrap/environment.rs
@@ -2,7 +2,6 @@
 
 use std::time::Instant;
 
-use anyhow::Result;
 use tracing::info;
 
 use aionui_app::AppConfig;
@@ -13,6 +12,7 @@ use crate::cli::Cli;
 use super::builtin_skills::materialize_builtin_skills;
 use super::tracing_init::{LogGuards, init_tracing};
 use super::work_dir::resolve_work_dir;
+use super::{BootstrapError, BootstrapErrorCode};
 
 /// Resolved environment needed by all non-MCP subcommands.
 pub struct ServerEnvironment {
@@ -25,9 +25,9 @@ pub struct ServerEnvironment {
 ///
 /// Cheap, synchronous, no IO beyond creating the log directory.
 /// All subcommands that need logging and config should call this first.
-pub fn init_environment(cli: &Cli, merged_path: &str) -> Result<ServerEnvironment> {
+pub fn init_environment(cli: &Cli, merged_path: &str) -> Result<ServerEnvironment, BootstrapError> {
     let log_dir = cli.log_dir.clone().unwrap_or_else(|| cli.data_dir.join("logs"));
-    let log_guard = init_tracing(&log_dir, cli.log_level.as_deref());
+    let log_guard = init_tracing(&log_dir, cli.log_level.as_deref())?;
 
     info!(
         path_segments = merged_path.split(if cfg!(windows) { ';' } else { ':' }).count(),
@@ -66,20 +66,58 @@ pub fn init_environment(cli: &Cli, merged_path: &str) -> Result<ServerEnvironmen
 ///
 /// Requires only `data_dir`. Subcommands that need persistent state
 /// (database, skill files) should call this after `init_environment`.
-pub async fn init_data_layer(config: &AppConfig) -> Result<Database> {
+pub async fn init_data_layer(config: &AppConfig) -> Result<Database, BootstrapError> {
     let boot = Instant::now();
 
-    materialize_builtin_skills(&config.data_dir).await?;
+    materialize_builtin_skills(&config.data_dir).await.map_err(|e| {
+        BootstrapError::new(
+            BootstrapErrorCode::DataInitFailed,
+            "data.builtin_skills",
+            "failed to initialize application data",
+        )
+        .with_source(e)
+        .with_field("dataDir", config.data_dir.display().to_string())
+    })?;
     info!(
         elapsed_ms = boot.elapsed().as_millis(),
         "startup: builtin skills materialized"
     );
 
     let db_path = config.database_path();
-    aionui_db::maybe_copy_legacy_database(&db_path)?;
+    aionui_db::maybe_copy_legacy_database(&db_path).map_err(|e| {
+        BootstrapError::new(
+            BootstrapErrorCode::DataInitFailed,
+            "data.legacy_db",
+            "failed to initialize application data",
+        )
+        .with_source(e)
+        .with_field("databasePath", db_path.display().to_string())
+    })?;
     info!("Initializing database at {}", db_path.display());
-    let database = aionui_db::init_database(&db_path).await?;
+    let database = aionui_db::init_database_staged(&db_path).await.map_err(|e| {
+        let stage = e.stage();
+        BootstrapError::new(
+            BootstrapErrorCode::DataInitFailed,
+            stage,
+            "failed to initialize application data",
+        )
+        .with_source(e.into_source())
+        .with_field("databasePath", db_path.display().to_string())
+    })?;
     info!(elapsed_ms = boot.elapsed().as_millis(), "startup: database initialized");
 
     Ok(database)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn database_stage_comes_from_db_boundary_error() {
+        let err = aionui_db::DatabaseInitError::new(
+            "database.migration",
+            aionui_db::DbError::Migration(sqlx::migrate::MigrateError::VersionMismatch(42)),
+        );
+
+        assert_eq!(err.stage(), "database.migration");
+    }
 }

--- a/crates/aionui-app/src/bootstrap/error.rs
+++ b/crates/aionui-app/src/bootstrap/error.rs
@@ -1,0 +1,177 @@
+use std::process::ExitCode;
+
+use crate::process_report::{ExitKind, ProcessReport};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BootstrapErrorCode {
+    ConfigInvalid,
+    RuntimeInitFailed,
+    LoggingInitFailed,
+    BindFailed,
+    DataInitFailed,
+    ServiceInitFailed,
+    ServerFailed,
+    ShutdownFailed,
+}
+
+impl BootstrapErrorCode {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::ConfigInvalid => "BOOTSTRAP_CONFIG_INVALID",
+            Self::RuntimeInitFailed => "BOOTSTRAP_RUNTIME_INIT_FAILED",
+            Self::LoggingInitFailed => "BOOTSTRAP_LOGGING_INIT_FAILED",
+            Self::BindFailed => "BOOTSTRAP_BIND_FAILED",
+            Self::DataInitFailed => "BOOTSTRAP_DATA_INIT_FAILED",
+            Self::ServiceInitFailed => "BOOTSTRAP_SERVICE_INIT_FAILED",
+            Self::ServerFailed => "BOOTSTRAP_SERVER_FAILED",
+            Self::ShutdownFailed => "BOOTSTRAP_SHUTDOWN_FAILED",
+        }
+    }
+
+    pub(crate) fn exit_kind(self) -> ExitKind {
+        match self {
+            Self::ConfigInvalid => ExitKind::Config,
+            Self::BindFailed => ExitKind::Unavailable,
+            Self::RuntimeInitFailed
+            | Self::LoggingInitFailed
+            | Self::DataInitFailed
+            | Self::ServiceInitFailed
+            | Self::ServerFailed
+            | Self::ShutdownFailed => ExitKind::Internal,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct BootstrapError {
+    code: BootstrapErrorCode,
+    stage: &'static str,
+    message: &'static str,
+    source: Option<anyhow::Error>,
+    fields: Vec<(&'static str, String)>,
+}
+
+impl BootstrapError {
+    pub(crate) fn new(code: BootstrapErrorCode, stage: &'static str, message: &'static str) -> Self {
+        Self {
+            code,
+            stage,
+            message,
+            source: None,
+            fields: Vec::new(),
+        }
+    }
+
+    pub(crate) fn with_source(mut self, source: impl Into<anyhow::Error>) -> Self {
+        self.source = Some(source.into());
+        self
+    }
+
+    pub(crate) fn with_field(mut self, key: &'static str, value: impl Into<String>) -> Self {
+        self.fields.push((key, value.into()));
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn code(&self) -> BootstrapErrorCode {
+        self.code
+    }
+
+    #[cfg(test)]
+    pub(crate) fn stage(&self) -> &'static str {
+        self.stage
+    }
+
+    pub(crate) fn exit_code(&self) -> ExitCode {
+        self.code.exit_kind().exit_code()
+    }
+
+    pub(crate) fn stderr_line(&self) -> String {
+        let mut fields = vec![("stage", self.stage.to_owned())];
+        fields.extend(self.fields.clone());
+        ProcessReport {
+            code: self.code.as_str(),
+            message: self.message,
+            exit_kind: self.code.exit_kind(),
+            fields,
+        }
+        .stderr_line()
+    }
+
+    pub(crate) fn log_source(&self) {
+        if let Some(source) = &self.source {
+            tracing::error!(
+                code = self.code.as_str(),
+                stage = self.stage,
+                error = %source,
+                "bootstrap boundary failure"
+            );
+        }
+    }
+}
+
+impl std::fmt::Display for BootstrapError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code.as_str(), self.message)
+    }
+}
+
+impl std::error::Error for BootstrapError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_ref()
+            .map(|source| source.as_ref() as &(dyn std::error::Error + 'static))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::ExitCode;
+
+    #[test]
+    fn bootstrap_error_renders_code_stage_and_exit() {
+        let err = BootstrapError::new(
+            BootstrapErrorCode::BindFailed,
+            "bind.listener",
+            "failed to bind HTTP listener",
+        )
+        .with_field("port", "13400");
+
+        assert_eq!(err.code(), BootstrapErrorCode::BindFailed);
+        assert_eq!(err.stage(), "bind.listener");
+        assert_eq!(err.exit_code(), ExitCode::from(3));
+        assert_eq!(
+            err.stderr_line(),
+            "BOOTSTRAP_BIND_FAILED stage=bind.listener port=13400: failed to bind HTTP listener"
+        );
+    }
+
+    #[test]
+    fn config_invalid_uses_exit_2() {
+        let err = BootstrapError::new(
+            BootstrapErrorCode::ConfigInvalid,
+            "config.parse",
+            "invalid application configuration",
+        );
+
+        assert_eq!(err.exit_code(), ExitCode::from(2));
+    }
+
+    #[test]
+    fn source_is_preserved_but_not_rendered_to_stderr() {
+        let err = BootstrapError::new(
+            BootstrapErrorCode::DataInitFailed,
+            "data.open",
+            "failed to initialize data layer",
+        )
+        .with_source(anyhow::anyhow!("secret disk path /tmp/secret.db"));
+
+        let stderr = err.stderr_line();
+        assert!(!stderr.contains("secret"));
+        assert!(!stderr.contains("/tmp/secret.db"));
+
+        let source = std::error::Error::source(&err).expect("source should be preserved");
+        assert!(source.to_string().contains("secret disk path /tmp/secret.db"));
+    }
+}

--- a/crates/aionui-app/src/bootstrap/error.rs
+++ b/crates/aionui-app/src/bootstrap/error.rs
@@ -99,6 +99,12 @@ impl BootstrapError {
     }
 
     pub(crate) fn log_source(&self) {
+        if self.code == BootstrapErrorCode::LoggingInitFailed {
+            // Logging setup failed before a tracing subscriber was available.
+            // Keep raw source private on the error object; public stderr remains
+            // the stable boundary line only.
+            return;
+        }
         if let Some(source) = &self.source {
             tracing::error!(
                 code = self.code.as_str(),
@@ -173,5 +179,28 @@ mod tests {
 
         let source = std::error::Error::source(&err).expect("source should be preserved");
         assert!(source.to_string().contains("secret disk path /tmp/secret.db"));
+    }
+
+    #[test]
+    fn logging_init_source_remains_private_when_tracing_is_unavailable() {
+        let err = BootstrapError::new(
+            BootstrapErrorCode::LoggingInitFailed,
+            "logging.init",
+            "failed to initialize logging",
+        )
+        .with_source(anyhow::anyhow!("secret log path /tmp/aion.log"));
+
+        err.log_source();
+
+        let stderr = err.stderr_line();
+        assert!(stderr.contains("BOOTSTRAP_LOGGING_INIT_FAILED"));
+        assert!(!stderr.contains("secret log path"));
+        assert!(!stderr.contains("/tmp/aion.log"));
+        assert!(
+            std::error::Error::source(&err)
+                .expect("source should be preserved")
+                .to_string()
+                .contains("secret log path")
+        );
     }
 }

--- a/crates/aionui-app/src/bootstrap/mod.rs
+++ b/crates/aionui-app/src/bootstrap/mod.rs
@@ -6,7 +6,9 @@
 
 mod builtin_skills;
 mod environment;
+mod error;
 mod tracing_init;
 mod work_dir;
 
 pub use environment::{ServerEnvironment, init_data_layer, init_environment};
+pub(crate) use error::{BootstrapError, BootstrapErrorCode};

--- a/crates/aionui-app/src/bootstrap/tracing_init.rs
+++ b/crates/aionui-app/src/bootstrap/tracing_init.rs
@@ -8,6 +8,8 @@ use std::path::Path;
 
 use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
+use super::{BootstrapError, BootstrapErrorCode};
+
 const NOISE_SUPPRESSIONS: &[&str] = &[
     "sqlx::query=warn",
     "hyper_util=warn",
@@ -77,8 +79,18 @@ pub struct LogGuards {
     _aionrs: tracing_appender::non_blocking::WorkerGuard,
 }
 
-pub fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> LogGuards {
-    std::fs::create_dir_all(log_dir).expect("failed to create log directory");
+const LOGGING_INIT_MESSAGE: &str = "failed to initialize logging";
+
+pub fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> Result<LogGuards, BootstrapError> {
+    std::fs::create_dir_all(log_dir).map_err(|e| {
+        BootstrapError::new(
+            BootstrapErrorCode::LoggingInitFailed,
+            "logging.dir",
+            LOGGING_INIT_MESSAGE,
+        )
+        .with_source(e)
+        .with_field("logDir", log_dir.display().to_string())
+    })?;
 
     let console_layer = fmt::layer().with_target(true).with_filter(build_env_filter(log_level));
 
@@ -87,7 +99,15 @@ pub fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> LogGuards {
         .rotation(tracing_appender::rolling::Rotation::DAILY)
         .filename_suffix("aioncore.log")
         .build(log_dir)
-        .expect("failed to create backend log file appender");
+        .map_err(|e| {
+            BootstrapError::new(
+                BootstrapErrorCode::LoggingInitFailed,
+                "logging.appender",
+                LOGGING_INIT_MESSAGE,
+            )
+            .with_source(e)
+            .with_field("logDir", log_dir.display().to_string())
+        })?;
     let (non_blocking, backend_guard) = tracing_appender::non_blocking(file_appender);
 
     let backend_file_layer = fmt::layer()
@@ -104,19 +124,35 @@ pub fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> LogGuards {
         level: aionrs_level,
         dir: log_dir.to_path_buf(),
     };
-    let (aionrs_layer, aionrs_guard) =
-        aion_config::logging::create_file_layer(&aionrs_resolved).expect("failed to create aionrs log layer");
+    let (aionrs_layer, aionrs_guard) = aion_config::logging::create_file_layer(&aionrs_resolved).map_err(|e| {
+        BootstrapError::new(
+            BootstrapErrorCode::LoggingInitFailed,
+            "logging.appender",
+            LOGGING_INIT_MESSAGE,
+        )
+        .with_source(e)
+        .with_field("logDir", log_dir.display().to_string())
+    })?;
 
     tracing_subscriber::registry()
         .with(console_layer)
         .with(backend_file_layer)
         .with(aionrs_layer)
-        .init();
+        .try_init()
+        .map_err(|e| {
+            BootstrapError::new(
+                BootstrapErrorCode::LoggingInitFailed,
+                "logging.subscriber",
+                LOGGING_INIT_MESSAGE,
+            )
+            .with_source(e)
+            .with_field("logDir", log_dir.display().to_string())
+        })?;
 
-    LogGuards {
+    Ok(LogGuards {
         _backend: backend_guard,
         _aionrs: aionrs_guard,
-    }
+    })
 }
 
 #[cfg(test)]

--- a/crates/aionui-app/src/commands/bridge.rs
+++ b/crates/aionui-app/src/commands/bridge.rs
@@ -1,7 +1,7 @@
 //! `aioncore mcp-bridge` subcommand: stdio ↔ TCP bridge for the team MCP server.
 //!
 //! Spawned by the ACP agent CLI as an MCP server with command `aioncore mcp-bridge`.
-//! stdio side speaks newline-delimited JSON-RPC 2.0 (the MCP stdio transport);
+//! stdio side speaks MCP Content-Length framed JSON-RPC 2.0;
 //! TCP side speaks 4-byte big-endian length-prefixed JSON frames against
 //! `127.0.0.1:<TEAM_MCP_PORT>` (reusing `aionui_team::mcp::protocol`).
 //!
@@ -20,7 +20,14 @@ use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 
+use crate::commands::cli_error::{CliBoundaryCode, CliBoundaryError, missing_env, parse_required_port};
+
+const SUBCOMMAND: &str = "mcp-bridge";
 const CONNECT_ADDR_HOST: &str = "127.0.0.1";
+const MCP_STDIO_FRAME_MAX_BYTES: usize = 10 * 1024 * 1024;
+const MCP_STDIO_HEADER_LINE_MAX_BYTES: usize = 8 * 1024;
+const MCP_STDIO_HEADER_SECTION_MAX_BYTES: usize = 16 * 1024;
+const MCP_STDIO_HEADER_MAX_COUNT: usize = 64;
 
 /// Entry point for `aioncore mcp-bridge`. Returns an [`ExitCode`] so the
 /// binary surfaces non-zero on any failure (ACP CLI uses that to mark the MCP
@@ -31,23 +38,33 @@ pub async fn run_mcp_bridge() -> ExitCode {
         Err(err) => {
             // stderr, not tracing: the parent agent CLI captures stderr and
             // shows it to the user when the bridge dies on startup.
-            eprintln!("mcp-bridge: {err}");
-            ExitCode::from(1)
+            eprintln!("{}", err.stderr_line());
+            err.exit_code()
         }
     }
 }
 
-async fn run() -> Result<(), String> {
+async fn run() -> Result<(), CliBoundaryError> {
     let env = BridgeEnv::from_env()?;
 
-    let tcp = TcpStream::connect((CONNECT_ADDR_HOST, env.port))
-        .await
-        .map_err(|e| format!("failed to connect 127.0.0.1:{}: {e}", env.port))?;
+    let tcp = TcpStream::connect((CONNECT_ADDR_HOST, env.port)).await.map_err(|_| {
+        CliBoundaryError::new(
+            CliBoundaryCode::McpTcpConnectFailed,
+            SUBCOMMAND,
+            "failed to connect to local MCP TCP listener",
+        )
+        .with_field("host", CONNECT_ADDR_HOST)
+        .with_field("port", env.port.to_string())
+    })?;
     tcp.set_nodelay(true).ok();
     let (tcp_reader, tcp_writer) = tcp.into_split();
 
     if std::io::stdin().is_terminal() {
-        return Err("stdin is a TTY; mcp-bridge must be spawned by an MCP-capable agent CLI".into());
+        return Err(CliBoundaryError::new(
+            CliBoundaryCode::McpStdinTty,
+            SUBCOMMAND,
+            "stdin must be provided by an MCP-capable agent CLI",
+        ));
     }
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
@@ -60,13 +77,21 @@ async fn run() -> Result<(), String> {
     // either side as "other side closed, we're done".
     tokio::select! {
         res = stdin_task => {
-            res.map_err(|e| format!("stdin task panicked: {e}"))??;
+            res.map_err(|_| task_join_error())??;
         }
         res = tcp_task => {
-            res.map_err(|e| format!("tcp task panicked: {e}"))??;
+            res.map_err(|_| task_join_error())??;
         }
     }
     Ok(())
+}
+
+fn task_join_error() -> CliBoundaryError {
+    CliBoundaryError::new(
+        CliBoundaryCode::McpTaskJoinPanic,
+        SUBCOMMAND,
+        "MCP bridge worker task failed",
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -81,93 +106,168 @@ struct BridgeEnv {
 }
 
 impl BridgeEnv {
-    fn from_env() -> Result<Self, String> {
+    fn from_env() -> Result<Self, CliBoundaryError> {
         let port_raw = std::env::var(TeamMcpStdioConfig::ENV_PORT)
-            .map_err(|_| format!("missing env var {}", TeamMcpStdioConfig::ENV_PORT))?;
-        let port: u16 = port_raw
-            .parse()
-            .map_err(|e| format!("invalid {} value {port_raw:?}: {e}", TeamMcpStdioConfig::ENV_PORT))?;
+            .map_err(|_| missing_env(SUBCOMMAND, TeamMcpStdioConfig::ENV_PORT))?;
         let token = std::env::var(TeamMcpStdioConfig::ENV_TOKEN)
-            .map_err(|_| format!("missing env var {}", TeamMcpStdioConfig::ENV_TOKEN))?;
+            .map_err(|_| missing_env(SUBCOMMAND, TeamMcpStdioConfig::ENV_TOKEN))?;
         let slot_id = std::env::var(TeamMcpStdioConfig::ENV_SLOT_ID)
-            .map_err(|_| format!("missing env var {}", TeamMcpStdioConfig::ENV_SLOT_ID))?;
-        Ok(Self { port, token, slot_id })
+            .map_err(|_| missing_env(SUBCOMMAND, TeamMcpStdioConfig::ENV_SLOT_ID))?;
+        Self::from_values(&port_raw, &token, &slot_id)
+    }
+
+    fn from_values(port_raw: &str, token: &str, slot_id: &str) -> Result<Self, CliBoundaryError> {
+        let port = parse_required_port(SUBCOMMAND, TeamMcpStdioConfig::ENV_PORT, port_raw)?;
+        Ok(Self {
+            port,
+            token: token.to_owned(),
+            slot_id: slot_id.to_owned(),
+        })
     }
 }
 
 // ---------------------------------------------------------------------------
-// stdin → TCP: read newline-delimited JSON, inject auth on `initialize`, frame to TCP
+// stdin → TCP: read MCP Content-Length frames, inject auth on `initialize`, frame to TCP
 // ---------------------------------------------------------------------------
 
-async fn forward_stdin_to_tcp<R, W>(stdin: R, mut tcp_writer: W, env: BridgeEnv) -> Result<(), String>
+async fn forward_stdin_to_tcp<R, W>(stdin: R, mut tcp_writer: W, env: BridgeEnv) -> Result<(), CliBoundaryError>
 where
     R: tokio::io::AsyncRead + Unpin,
     W: tokio::io::AsyncWrite + Unpin,
 {
     let mut reader = BufReader::new(stdin);
-    eprintln!("[mcp-bridge] stdin loop started (Content-Length framing)");
     loop {
         let body = match read_mcp_stdio_message(&mut reader).await {
             Ok(Some(b)) => b,
             Ok(None) => {
-                eprintln!("[mcp-bridge] stdin EOF");
                 return Ok(());
             }
             Err(e) => return Err(e),
         };
 
-        eprintln!("[mcp-bridge] stdin received: {} bytes", body.len());
-        let mut value: Value =
-            serde_json::from_slice(&body).map_err(|e| format!("stdin payload is not valid JSON: {e}"))?;
+        let mut value: Value = serde_json::from_slice(&body).map_err(|_| {
+            CliBoundaryError::new(
+                CliBoundaryCode::McpStdinJsonInvalid,
+                SUBCOMMAND,
+                "stdin MCP frame body is not valid JSON",
+            )
+        })?;
 
         if value.get("method").and_then(Value::as_str) == Some("initialize") {
             inject_auth(&mut value, &env);
         }
 
-        let bytes = serde_json::to_vec(&value).map_err(|e| format!("serialize outgoing frame: {e}"))?;
-        write_frame(&mut tcp_writer, &bytes)
-            .await
-            .map_err(|e| format!("tcp write error: {e}"))?;
-        eprintln!("[mcp-bridge] forwarded to TCP ({} bytes)", bytes.len());
+        let bytes = serde_json::to_vec(&value).map_err(|_| {
+            CliBoundaryError::new(
+                CliBoundaryCode::McpJsonSerializeFailed,
+                SUBCOMMAND,
+                "failed to serialize MCP JSON frame",
+            )
+        })?;
+        write_frame(&mut tcp_writer, &bytes).await.map_err(|_| {
+            CliBoundaryError::new(
+                CliBoundaryCode::McpTcpWriteFailed,
+                SUBCOMMAND,
+                "failed to write MCP frame to TCP listener",
+            )
+        })?;
     }
 }
 
 /// Read one MCP stdio message (Content-Length framing).
 /// Returns None on clean EOF.
-async fn read_mcp_stdio_message<R: tokio::io::AsyncBufRead + Unpin>(reader: &mut R) -> Result<Option<Vec<u8>>, String> {
+async fn read_mcp_stdio_message<R: tokio::io::AsyncBufRead + Unpin>(
+    reader: &mut R,
+) -> Result<Option<Vec<u8>>, CliBoundaryError> {
     let mut content_length: Option<usize> = None;
-    let mut header_line = String::new();
+    let mut header_line = Vec::new();
+    let mut header_bytes = 0usize;
+    let mut header_count = 0usize;
     loop {
-        header_line.clear();
-        let n = reader
-            .read_line(&mut header_line)
-            .await
-            .map_err(|e| format!("stdin header read error: {e}"))?;
+        let n = read_bounded_header_line(reader, &mut header_line).await?;
         if n == 0 {
-            return Ok(None); // EOF
+            return if header_bytes == 0 {
+                Ok(None) // Clean EOF before the next frame starts.
+            } else {
+                Err(stdin_frame_invalid())
+            };
         }
-        let trimmed = header_line.trim();
+        header_bytes = header_bytes.checked_add(n).ok_or_else(stdin_frame_invalid)?;
+        if header_bytes > MCP_STDIO_HEADER_SECTION_MAX_BYTES {
+            return Err(stdin_frame_invalid());
+        }
+        let trimmed = std::str::from_utf8(&header_line)
+            .map_err(|_| stdin_frame_invalid())?
+            .trim();
         if trimmed.is_empty() {
             // Empty line = end of headers
             break;
         }
+        header_count += 1;
+        if header_count > MCP_STDIO_HEADER_MAX_COUNT {
+            return Err(stdin_frame_invalid());
+        }
         if let Some(len_str) = trimmed.strip_prefix("Content-Length:") {
-            content_length = Some(
-                len_str
-                    .trim()
-                    .parse::<usize>()
-                    .map_err(|e| format!("invalid Content-Length: {e}"))?,
-            );
+            content_length = Some(len_str.trim().parse::<usize>().map_err(|_| stdin_frame_invalid())?);
         }
         // Ignore other headers
     }
-    let len = content_length.ok_or("missing Content-Length header")?;
+    let len = content_length.ok_or_else(stdin_frame_invalid)?;
+    if len > MCP_STDIO_FRAME_MAX_BYTES {
+        return Err(CliBoundaryError::new(
+            CliBoundaryCode::McpFrameTooLarge,
+            SUBCOMMAND,
+            "MCP stdio frame exceeds configured size limit",
+        )
+        .with_field("limitBytes", MCP_STDIO_FRAME_MAX_BYTES.to_string()));
+    }
     let mut body = vec![0u8; len];
-    reader
-        .read_exact(&mut body)
-        .await
-        .map_err(|e| format!("stdin body read error: {e}"))?;
+    reader.read_exact(&mut body).await.map_err(|_| stdin_read_error())?;
     Ok(Some(body))
+}
+
+async fn read_bounded_header_line<R: tokio::io::AsyncBufRead + Unpin>(
+    reader: &mut R,
+    line: &mut Vec<u8>,
+) -> Result<usize, CliBoundaryError> {
+    line.clear();
+    loop {
+        let (n, end_of_line) = {
+            let available = reader.fill_buf().await.map_err(|_| stdin_read_error())?;
+            if available.is_empty() {
+                return Ok(line.len());
+            }
+            let n = available
+                .iter()
+                .position(|byte| *byte == b'\n')
+                .map_or(available.len(), |pos| pos + 1);
+            if line.len() + n > MCP_STDIO_HEADER_LINE_MAX_BYTES {
+                return Err(stdin_frame_invalid());
+            }
+            line.extend_from_slice(&available[..n]);
+            (n, available[n - 1] == b'\n')
+        };
+        reader.consume(n);
+        if end_of_line {
+            return Ok(line.len());
+        }
+    }
+}
+
+fn stdin_frame_invalid() -> CliBoundaryError {
+    CliBoundaryError::new(
+        CliBoundaryCode::McpStdinFrameInvalid,
+        SUBCOMMAND,
+        "invalid MCP stdio frame",
+    )
+}
+
+fn stdin_read_error() -> CliBoundaryError {
+    CliBoundaryError::new(
+        CliBoundaryCode::McpStdinReadFailed,
+        SUBCOMMAND,
+        "failed to read MCP stdio frame from stdin",
+    )
 }
 
 fn inject_auth(value: &mut Value, env: &BridgeEnv) {
@@ -183,10 +283,10 @@ fn inject_auth(value: &mut Value, env: &BridgeEnv) {
 }
 
 // ---------------------------------------------------------------------------
-// TCP → stdout: read length-prefixed frames, write as newline-delimited JSON
+// TCP → stdout: read length-prefixed frames, write MCP Content-Length frames
 // ---------------------------------------------------------------------------
 
-async fn forward_tcp_to_stdout<R, W>(mut tcp_reader: R, mut stdout: W) -> Result<(), String>
+async fn forward_tcp_to_stdout<R, W>(mut tcp_reader: R, mut stdout: W) -> Result<(), CliBoundaryError>
 where
     R: tokio::io::AsyncRead + Unpin,
     W: tokio::io::AsyncWrite + Unpin,
@@ -195,24 +295,33 @@ where
         let frame = match read_frame(&mut tcp_reader).await {
             Ok(f) => f,
             Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
-                eprintln!("[mcp-bridge] TCP EOF");
                 return Ok(());
             }
-            Err(e) => return Err(format!("tcp read error: {e}")),
+            Err(_) => {
+                return Err(CliBoundaryError::new(
+                    CliBoundaryCode::McpTcpReadFailed,
+                    SUBCOMMAND,
+                    "failed to read MCP frame from TCP listener",
+                ));
+            }
         };
-        eprintln!("[mcp-bridge] TCP→stdout: {} bytes", frame.len());
         // Content-Length framing for stdout (MCP stdio transport)
         let header = format!("Content-Length: {}\r\n\r\n", frame.len());
         stdout
             .write_all(header.as_bytes())
             .await
-            .map_err(|e| format!("stdout write error: {e}"))?;
-        stdout
-            .write_all(&frame)
-            .await
-            .map_err(|e| format!("stdout write error: {e}"))?;
-        stdout.flush().await.map_err(|e| format!("stdout flush error: {e}"))?;
+            .map_err(|_| stdout_write_error())?;
+        stdout.write_all(&frame).await.map_err(|_| stdout_write_error())?;
+        stdout.flush().await.map_err(|_| stdout_write_error())?;
     }
+}
+
+fn stdout_write_error() -> CliBoundaryError {
+    CliBoundaryError::new(
+        CliBoundaryCode::McpStdoutWriteFailed,
+        SUBCOMMAND,
+        "failed to write MCP stdio frame to stdout",
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -230,6 +339,91 @@ mod tests {
             token: "tok".into(),
             slot_id: "slot-a".into(),
         }
+    }
+
+    #[test]
+    fn bridge_env_rejects_invalid_port_with_stable_code() {
+        let err = BridgeEnv::from_values("not-a-port", "tok", "slot-a").unwrap_err();
+        assert_eq!(
+            err.code(),
+            crate::commands::cli_error::CliBoundaryCode::McpEnvInvalidPort
+        );
+        assert_eq!(err.exit_code(), std::process::ExitCode::from(2));
+    }
+
+    #[tokio::test]
+    async fn read_mcp_stdio_message_rejects_oversized_content_length() {
+        let input = format!("Content-Length: {}\r\n\r\n", MCP_STDIO_FRAME_MAX_BYTES + 1);
+        let err = read_mcp_stdio_message(&mut input.as_bytes()).await.unwrap_err();
+        assert_eq!(
+            err.code(),
+            crate::commands::cli_error::CliBoundaryCode::McpFrameTooLarge
+        );
+    }
+
+    #[tokio::test]
+    async fn read_mcp_stdio_message_rejects_invalid_content_length() {
+        let input = "Content-Length: nope\r\n\r\n";
+        let err = read_mcp_stdio_message(&mut input.as_bytes()).await.unwrap_err();
+        assert_eq!(
+            err.code(),
+            crate::commands::cli_error::CliBoundaryCode::McpStdinFrameInvalid
+        );
+    }
+
+    #[tokio::test]
+    async fn read_mcp_stdio_message_rejects_partial_header_eof() {
+        for input in ["Content-Length: 2", "X-Header: value"] {
+            let err = read_mcp_stdio_message(&mut input.as_bytes()).await.unwrap_err();
+            assert_eq!(
+                err.code(),
+                crate::commands::cli_error::CliBoundaryCode::McpStdinFrameInvalid
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn read_mcp_stdio_message_rejects_overlong_header_line() {
+        let input = format!("X-Header: {}\r\nContent-Length: 2\r\n\r\n{{}}", "a".repeat(16 * 1024));
+        let err = read_mcp_stdio_message(&mut input.as_bytes()).await.unwrap_err();
+        assert_eq!(
+            err.code(),
+            crate::commands::cli_error::CliBoundaryCode::McpStdinFrameInvalid
+        );
+    }
+
+    #[tokio::test]
+    async fn read_mcp_stdio_message_rejects_oversized_header_section() {
+        let line_a = format!(
+            "X-A: {}\r\n",
+            "a".repeat(MCP_STDIO_HEADER_LINE_MAX_BYTES - "X-A: \r\n".len())
+        );
+        let line_b = format!(
+            "X-B: {}\r\n",
+            "b".repeat(MCP_STDIO_HEADER_LINE_MAX_BYTES - "X-B: \r\n".len())
+        );
+        let input = format!("{line_a}{line_b}X-C: v\r\nContent-Length: 0\r\n\r\n");
+
+        let err = read_mcp_stdio_message(&mut input.as_bytes()).await.unwrap_err();
+        assert_eq!(
+            err.code(),
+            crate::commands::cli_error::CliBoundaryCode::McpStdinFrameInvalid
+        );
+    }
+
+    #[tokio::test]
+    async fn read_mcp_stdio_message_rejects_too_many_headers() {
+        let mut input = String::new();
+        for index in 0..=MCP_STDIO_HEADER_MAX_COUNT {
+            input.push_str(&format!("X-{index}: v\r\n"));
+        }
+        input.push_str("Content-Length: 0\r\n\r\n");
+
+        let err = read_mcp_stdio_message(&mut input.as_bytes()).await.unwrap_err();
+        assert_eq!(
+            err.code(),
+            crate::commands::cli_error::CliBoundaryCode::McpStdinFrameInvalid
+        );
     }
 
     #[test]

--- a/crates/aionui-app/src/commands/cli_error.rs
+++ b/crates/aionui-app/src/commands/cli_error.rs
@@ -1,0 +1,188 @@
+// Consumed by following CLI/MCP boundary wiring tasks.
+#![allow(dead_code)]
+#![allow(clippy::enum_variant_names)]
+
+use std::process::ExitCode;
+
+use crate::process_report::{ExitKind, ProcessReport};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CliBoundaryCode {
+    CliRuntimeInitFailed,
+    CliDoctorDatabaseFailed,
+    CliDoctorRegistryHydrateFailed,
+    CliPrepareManagedResourcesFailed,
+    McpEnvMissing,
+    McpEnvInvalidPort,
+    McpStdinTty,
+    McpStdinReadFailed,
+    McpStdinFrameInvalid,
+    McpStdinJsonInvalid,
+    McpFrameTooLarge,
+    McpJsonSerializeFailed,
+    McpTcpConnectFailed,
+    McpTcpWriteFailed,
+    McpTcpReadFailed,
+    McpStdoutWriteFailed,
+    McpStdioServeFailed,
+    McpSessionEndedWithError,
+    McpTaskJoinPanic,
+    McpHttpConnectOrTimeout,
+    McpHttpResponseReadFailed,
+    McpHttpStatusError,
+    McpToolRemoteError,
+    McpToolResponseUnexpected,
+}
+
+impl CliBoundaryCode {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::CliRuntimeInitFailed => "CLI_RUNTIME_INIT_FAILED",
+            Self::CliDoctorDatabaseFailed => "CLI_DOCTOR_DATABASE_FAILED",
+            Self::CliDoctorRegistryHydrateFailed => "CLI_DOCTOR_REGISTRY_HYDRATE_FAILED",
+            Self::CliPrepareManagedResourcesFailed => "CLI_PREPARE_MANAGED_RESOURCES_FAILED",
+            Self::McpEnvMissing => "MCP_ENV_MISSING",
+            Self::McpEnvInvalidPort => "MCP_ENV_INVALID_PORT",
+            Self::McpStdinTty => "MCP_STDIN_TTY",
+            Self::McpStdinReadFailed => "MCP_STDIN_READ_FAILED",
+            Self::McpStdinFrameInvalid => "MCP_STDIN_FRAME_INVALID",
+            Self::McpStdinJsonInvalid => "MCP_STDIN_JSON_INVALID",
+            Self::McpFrameTooLarge => "MCP_FRAME_TOO_LARGE",
+            Self::McpJsonSerializeFailed => "MCP_JSON_SERIALIZE_FAILED",
+            Self::McpTcpConnectFailed => "MCP_TCP_CONNECT_FAILED",
+            Self::McpTcpWriteFailed => "MCP_TCP_WRITE_FAILED",
+            Self::McpTcpReadFailed => "MCP_TCP_READ_FAILED",
+            Self::McpStdoutWriteFailed => "MCP_STDOUT_WRITE_FAILED",
+            Self::McpStdioServeFailed => "MCP_STDIO_SERVE_FAILED",
+            Self::McpSessionEndedWithError => "MCP_SESSION_ENDED_WITH_ERROR",
+            Self::McpTaskJoinPanic => "MCP_TASK_JOIN_PANIC",
+            Self::McpHttpConnectOrTimeout => "MCP_HTTP_CONNECT_OR_TIMEOUT",
+            Self::McpHttpResponseReadFailed => "MCP_HTTP_RESPONSE_READ_FAILED",
+            Self::McpHttpStatusError => "MCP_HTTP_STATUS_ERROR",
+            Self::McpToolRemoteError => "MCP_TOOL_REMOTE_ERROR",
+            Self::McpToolResponseUnexpected => "MCP_TOOL_RESPONSE_UNEXPECTED",
+        }
+    }
+
+    fn exit_kind(self) -> ExitKind {
+        match self {
+            Self::McpEnvMissing
+            | Self::McpEnvInvalidPort
+            | Self::McpStdinTty
+            | Self::McpStdinFrameInvalid
+            | Self::McpStdinJsonInvalid
+            | Self::McpFrameTooLarge => ExitKind::Config,
+            Self::McpTcpConnectFailed | Self::McpHttpConnectOrTimeout | Self::McpHttpStatusError => {
+                ExitKind::Unavailable
+            }
+            _ => ExitKind::Internal,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CliBoundaryError {
+    code: CliBoundaryCode,
+    subcommand: &'static str,
+    message: &'static str,
+    fields: Vec<(&'static str, String)>,
+}
+
+impl CliBoundaryError {
+    pub(crate) fn new(code: CliBoundaryCode, subcommand: &'static str, message: &'static str) -> Self {
+        Self {
+            code,
+            subcommand,
+            message,
+            fields: Vec::new(),
+        }
+    }
+
+    pub(crate) fn with_field(mut self, key: &'static str, value: impl Into<String>) -> Self {
+        self.fields.push((key, value.into()));
+        self
+    }
+
+    pub(crate) fn code(&self) -> CliBoundaryCode {
+        self.code
+    }
+
+    pub(crate) fn exit_code(&self) -> ExitCode {
+        self.code.exit_kind().exit_code()
+    }
+
+    pub(crate) fn stderr_line(&self) -> String {
+        let mut fields = vec![("subcommand", self.subcommand.to_owned())];
+        fields.extend(self.fields.clone());
+        ProcessReport {
+            code: self.code.as_str(),
+            message: self.message,
+            exit_kind: self.code.exit_kind(),
+            fields,
+        }
+        .stderr_line()
+    }
+}
+
+pub(crate) fn missing_env(subcommand: &'static str, env: &'static str) -> CliBoundaryError {
+    CliBoundaryError::new(
+        CliBoundaryCode::McpEnvMissing,
+        subcommand,
+        "missing required environment variable",
+    )
+    .with_field("env", env)
+}
+
+pub(crate) fn invalid_port(subcommand: &'static str, env: &'static str) -> CliBoundaryError {
+    CliBoundaryError::new(
+        CliBoundaryCode::McpEnvInvalidPort,
+        subcommand,
+        "invalid MCP helper port",
+    )
+    .with_field("env", env)
+}
+
+pub(crate) fn parse_required_port(
+    subcommand: &'static str,
+    env: &'static str,
+    value: &str,
+) -> Result<u16, CliBoundaryError> {
+    value.parse::<u16>().map_err(|_| invalid_port(subcommand, env))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_env_renders_stable_stderr_and_exit_2() {
+        let err = missing_env("mcp-guide-stdio", "AION_MCP_PORT");
+        assert_eq!(err.code(), CliBoundaryCode::McpEnvMissing);
+        assert_eq!(err.exit_code(), ExitCode::from(2));
+        assert_eq!(
+            err.stderr_line(),
+            "MCP_ENV_MISSING subcommand=mcp-guide-stdio env=AION_MCP_PORT: missing required environment variable"
+        );
+    }
+
+    #[test]
+    fn invalid_port_renders_stable_stderr_and_exit_2() {
+        let err = parse_required_port("mcp-team-stdio", "TEAM_MCP_PORT", "not-a-port").unwrap_err();
+        assert_eq!(err.code(), CliBoundaryCode::McpEnvInvalidPort);
+        assert_eq!(err.exit_code(), ExitCode::from(2));
+        assert_eq!(
+            err.stderr_line(),
+            "MCP_ENV_INVALID_PORT subcommand=mcp-team-stdio env=TEAM_MCP_PORT: invalid MCP helper port"
+        );
+    }
+
+    #[test]
+    fn tcp_connect_failed_uses_exit_3() {
+        let err = CliBoundaryError::new(
+            CliBoundaryCode::McpTcpConnectFailed,
+            "mcp-bridge",
+            "failed to connect to local MCP TCP listener",
+        );
+        assert_eq!(err.exit_code(), ExitCode::from(3));
+    }
+}

--- a/crates/aionui-app/src/commands/doctor.rs
+++ b/crates/aionui-app/src/commands/doctor.rs
@@ -20,29 +20,27 @@ use std::path::Path;
 use std::process::ExitCode;
 use std::sync::Arc;
 
-use anyhow::Result;
-
 use aionui_ai_agent::{AgentRegistry, UnavailableReason};
 use aionui_db::{IAgentMetadataRepository, SqliteAgentMetadataRepository, init_database, maybe_copy_legacy_database};
 use aionui_runtime::{acp_tool_doctor_snapshot, doctor_snapshot};
 
 use crate::cli::Cli;
+use crate::commands::cli_error::{CliBoundaryCode, CliBoundaryError};
 
-pub async fn run_doctor(cli: &Cli, merged_path: &str) -> Result<ExitCode> {
+const SUBCOMMAND: &str = "doctor";
+
+pub async fn run_doctor(cli: &Cli, merged_path: &str) -> Result<ExitCode, CliBoundaryError> {
     print_environment(merged_path, &cli.data_dir);
 
     // Use the real on-disk DB so the report reflects the user's actual
     // catalog (including custom agents they've added via the UI).
     let db_path = cli.data_dir.join("aionui-backend.db");
-    maybe_copy_legacy_database(&db_path)?;
-    let database = init_database(&db_path).await?;
+    maybe_copy_legacy_database(&db_path).map_err(|_| doctor_database_error())?;
+    let database = init_database(&db_path).await.map_err(|_| doctor_database_error())?;
 
     let repo: Arc<dyn IAgentMetadataRepository> = Arc::new(SqliteAgentMetadataRepository::new(database.pool().clone()));
     let registry = AgentRegistry::new(repo);
-    registry
-        .hydrate()
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to hydrate agent registry: {e}"))?;
+    registry.hydrate().await.map_err(|_| doctor_registry_hydrate_error())?;
 
     let snapshot = registry.diagnostic_snapshot().await;
     print_snapshot(&snapshot);
@@ -50,6 +48,22 @@ pub async fn run_doctor(cli: &Cli, merged_path: &str) -> Result<ExitCode> {
     database.close().await;
 
     Ok(ExitCode::SUCCESS)
+}
+
+fn doctor_database_error() -> CliBoundaryError {
+    CliBoundaryError::new(
+        CliBoundaryCode::CliDoctorDatabaseFailed,
+        SUBCOMMAND,
+        "doctor failed to open the application database",
+    )
+}
+
+fn doctor_registry_hydrate_error() -> CliBoundaryError {
+    CliBoundaryError::new(
+        CliBoundaryCode::CliDoctorRegistryHydrateFailed,
+        SUBCOMMAND,
+        "doctor failed to hydrate the agent registry",
+    )
 }
 
 fn print_environment(merged_path: &str, data_dir: &Path) {
@@ -158,5 +172,28 @@ mod tests {
         assert_eq!(lines[0], "  node runtime   :");
         assert!(lines.iter().skip(1).any(|line| line.contains("node")));
         assert!(lines.iter().any(|line| line == "  managed acp    :"));
+    }
+
+    #[test]
+    fn doctor_database_error_uses_stable_code_without_raw_path() {
+        let err = doctor_database_error();
+
+        assert_eq!(err.code(), CliBoundaryCode::CliDoctorDatabaseFailed);
+        assert!(
+            err.stderr_line()
+                .starts_with("CLI_DOCTOR_DATABASE_FAILED subcommand=doctor")
+        );
+        assert!(!err.stderr_line().contains("/Users/secret/aionui-backend.db"));
+    }
+
+    #[test]
+    fn doctor_registry_error_uses_stable_code() {
+        let err = doctor_registry_hydrate_error();
+
+        assert_eq!(err.code(), CliBoundaryCode::CliDoctorRegistryHydrateFailed);
+        assert!(
+            err.stderr_line()
+                .starts_with("CLI_DOCTOR_REGISTRY_HYDRATE_FAILED subcommand=doctor")
+        );
     }
 }

--- a/crates/aionui-app/src/commands/mod.rs
+++ b/crates/aionui-app/src/commands/mod.rs
@@ -4,6 +4,7 @@
 //! All logic lives in the submodules.
 
 mod bridge;
+pub(crate) mod cli_error;
 mod doctor;
 mod prepare_managed_resources;
 mod server;

--- a/crates/aionui-app/src/commands/prepare_managed_resources.rs
+++ b/crates/aionui-app/src/commands/prepare_managed_resources.rs
@@ -1,25 +1,27 @@
 use std::process::ExitCode;
 
-use anyhow::{Context, Result};
-
 use crate::cli::PrepareManagedResourcesArgs;
+use crate::commands::cli_error::{CliBoundaryCode, CliBoundaryError};
 use aionui_runtime::acp_tool_runtime::ManagedAcpToolId;
 use aionui_runtime::managed_resources::{export_acp_tool_to_root, export_node_runtime_to_root};
 use aionui_runtime::{ensure_managed_acp_tool, ensure_node_runtime};
 
-pub async fn run_prepare_managed_resources(args: PrepareManagedResourcesArgs) -> Result<ExitCode> {
-    let output_root = args.bundle_out;
-    std::fs::create_dir_all(&output_root)
-        .with_context(|| format!("create bundle output root {}", output_root.display()))?;
+const SUBCOMMAND: &str = "prepare-managed-resources";
 
-    let node_runtime = ensure_node_runtime().await.context("prepare managed Node runtime")?;
+pub async fn run_prepare_managed_resources(args: PrepareManagedResourcesArgs) -> Result<ExitCode, CliBoundaryError> {
+    let output_root = args.bundle_out;
+    std::fs::create_dir_all(&output_root).map_err(|_| prepare_managed_resources_error("output.create"))?;
+
+    let node_runtime = ensure_node_runtime()
+        .await
+        .map_err(|_| prepare_managed_resources_error("node.prepare"))?;
     let node_dir_name = node_runtime
         .root
         .file_name()
         .and_then(|name| name.to_str())
-        .context("managed Node runtime root missing directory name")?;
+        .ok_or_else(|| prepare_managed_resources_error("node.layout"))?;
     let exported_node = export_node_runtime_to_root(&output_root, &node_runtime.root, node_dir_name)
-        .context("export managed Node runtime to bundle root")?;
+        .map_err(|_| prepare_managed_resources_error("node.export"))?;
 
     println!("Prepared managed resources under {}", output_root.display());
     println!("  node   -> {}", exported_node.display());
@@ -27,16 +29,41 @@ pub async fn run_prepare_managed_resources(args: PrepareManagedResourcesArgs) ->
     for tool in [ManagedAcpToolId::CodexAcp, ManagedAcpToolId::ClaudeAgentAcp] {
         let resolved = ensure_managed_acp_tool(tool)
             .await
-            .with_context(|| format!("prepare managed {} artifact", tool.display_name()))?;
+            .map_err(|_| prepare_managed_resources_error("acp.prepare"))?;
         let platform = resolved
             .root
             .file_name()
             .and_then(|name| name.to_str())
-            .context("managed ACP tool root missing platform directory name")?;
+            .ok_or_else(|| prepare_managed_resources_error("acp.layout"))?;
         let exported = export_acp_tool_to_root(&output_root, &resolved.root, tool.slug(), tool.version(), platform)
-            .with_context(|| format!("export managed {} artifact to bundle root", tool.display_name()))?;
+            .map_err(|_| prepare_managed_resources_error("acp.export"))?;
         println!("  {:<6} -> {}", tool.slug(), exported.display());
     }
 
     Ok(ExitCode::SUCCESS)
+}
+
+fn prepare_managed_resources_error(stage: &'static str) -> CliBoundaryError {
+    CliBoundaryError::new(
+        CliBoundaryCode::CliPrepareManagedResourcesFailed,
+        SUBCOMMAND,
+        "failed to prepare managed resources",
+    )
+    .with_field("stage", stage)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prepare_error_uses_stable_code_and_stage_without_raw_path() {
+        let err = prepare_managed_resources_error("node.export");
+
+        assert_eq!(err.code(), CliBoundaryCode::CliPrepareManagedResourcesFailed);
+        assert!(err.stderr_line().starts_with(
+            "CLI_PREPARE_MANAGED_RESOURCES_FAILED subcommand=prepare-managed-resources stage=node.export"
+        ));
+        assert!(!err.stderr_line().contains("/Users/secret/bundle"));
+    }
 }

--- a/crates/aionui-app/src/commands/server.rs
+++ b/crates/aionui-app/src/commands/server.rs
@@ -5,19 +5,19 @@ use std::net::SocketAddr;
 use std::process::ExitCode;
 use std::time::Instant;
 
-use anyhow::Result;
 use tokio::net::TcpListener;
 use tracing::{info, warn};
 
 use aionui_api_types::{RuntimeStatusScope, RuntimeStatusScopeKind};
-use aionui_app::{AppConfig, AppServices, create_router};
+use aionui_app::{AppConfig, AppServices, RouterBuildError, create_router};
 use aionui_system::RuntimePrepareService;
 
-use crate::bootstrap::ServerEnvironment;
+use crate::bootstrap::{BootstrapError, BootstrapErrorCode, ServerEnvironment};
 
 const LISTENING_EVENT_PREFIX: &str = "AIONCORE_LISTENING";
 const DYNAMIC_BACKEND_BIND_MAX_ATTEMPTS: usize = 50;
 
+#[derive(Debug)]
 pub(crate) struct BoundHttpListener {
     listener: TcpListener,
     addr: SocketAddr,
@@ -26,9 +26,14 @@ pub(crate) struct BoundHttpListener {
 /// Bind the main HTTP listener before constructing services that may start
 /// their own local listeners. When `config.port == 0`, the OS-selected port is
 /// written back to the config before downstream services are built.
-pub(crate) async fn bind_http_listener(config: &mut AppConfig) -> Result<BoundHttpListener> {
+pub(crate) async fn bind_http_listener(config: &mut AppConfig) -> Result<BoundHttpListener, BootstrapError> {
     if config.port != 0 && is_fetch_forbidden_backend_port(config.port) {
-        anyhow::bail!("backend port {} is blocked by Fetch clients", config.port);
+        return Err(BootstrapError::new(
+            BootstrapErrorCode::ConfigInvalid,
+            "config.port",
+            "invalid startup configuration",
+        )
+        .with_field("port", config.port.to_string()));
     }
 
     let dynamic_port = config.port == 0;
@@ -41,8 +46,23 @@ pub(crate) async fn bind_http_listener(config: &mut AppConfig) -> Result<BoundHt
     for attempt in 1..=max_attempts {
         let addr = config.socket_addr();
         info!(address = %addr, attempt, "startup: socket bind started");
-        let listener = TcpListener::bind(&addr).await?;
-        let local_addr = listener.local_addr()?;
+        let listener = TcpListener::bind(&addr).await.map_err(|error| {
+            BootstrapError::new(
+                BootstrapErrorCode::BindFailed,
+                "bind.listener",
+                "failed to bind HTTP listener",
+            )
+            .with_source(error)
+            .with_field("address", addr.to_string())
+        })?;
+        let local_addr = listener.local_addr().map_err(|error| {
+            BootstrapError::new(
+                BootstrapErrorCode::BindFailed,
+                "bind.listener",
+                "failed to bind HTTP listener",
+            )
+            .with_source(error)
+        })?;
 
         if dynamic_port && is_fetch_forbidden_backend_port(local_addr.port()) {
             warn!(
@@ -62,7 +82,11 @@ pub(crate) async fn bind_http_listener(config: &mut AppConfig) -> Result<BoundHt
         });
     }
 
-    anyhow::bail!("failed to bind a Fetch-compatible dynamic backend port");
+    Err(BootstrapError::new(
+        BootstrapErrorCode::BindFailed,
+        "bind.dynamic_port",
+        "failed to bind HTTP listener",
+    ))
 }
 
 fn is_fetch_forbidden_backend_port(port: u16) -> bool {
@@ -168,15 +192,24 @@ pub(crate) async fn run_server(
     env: ServerEnvironment,
     services: AppServices,
     bound: BoundHttpListener,
-) -> Result<ExitCode> {
+) -> Result<ExitCode, BootstrapError> {
     let boot = Instant::now();
 
-    let has_users = services.user_repo.has_users().await?;
+    let has_users = services.user_repo.has_users().await.map_err(|error| {
+        BootstrapError::new(
+            BootstrapErrorCode::ServerFailed,
+            "server.preflight",
+            "server startup preflight failed",
+        )
+        .with_source(error)
+    })?;
     if !has_users {
         info!("No configured users detected — initial setup required via /api/auth/status");
     }
 
-    let router = create_router(&services).await;
+    let router = create_router(&services)
+        .await
+        .map_err(router_build_error_to_bootstrap)?;
     info!(
         elapsed_ms = boot.elapsed().as_millis(),
         "startup: router ready for bound socket"
@@ -211,6 +244,8 @@ pub(crate) async fn run_server(
                 "startup: managed runtime background preparation completed"
             ),
             Err(error) => warn!(
+                code = "BOOTSTRAP_DEGRADED_MANAGED_RUNTIME_PREPARE",
+                stage = "runtime.prepare",
                 prepare_elapsed_ms = prepare_started.elapsed().as_millis(),
                 error = %error,
                 "startup: managed runtime background preparation failed"
@@ -224,20 +259,40 @@ pub(crate) async fn run_server(
     // exceeds the default 5-minute idle threshold. The watch channel
     // propagates graceful-shutdown so the scanner exits on SIGINT/SIGTERM.
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let (shutdown_error_tx, shutdown_error_rx) = tokio::sync::oneshot::channel::<BootstrapError>();
     let idle_scanner_handle =
         aionui_ai_agent::start_idle_scanner(services.worker_task_manager.clone(), shutdown_rx, None, None);
 
     axum::serve(listener, router)
         .with_graceful_shutdown(async move {
-            shutdown_signal().await;
+            if let Err(error) = shutdown_signal().await {
+                error.log_source();
+                tracing::error!(error = %error.stderr_line(), "shutdown signal handler failed");
+                let _ = shutdown_error_tx.send(error);
+            }
             let _ = shutdown_tx.send(true);
         })
-        .await?;
+        .await
+        .map_err(|error| {
+            BootstrapError::new(
+                BootstrapErrorCode::ServerFailed,
+                "server.serve",
+                "server runtime failed",
+            )
+            .with_source(error)
+        })?;
+
+    let shutdown_error = shutdown_error_rx.await.ok();
 
     // Wait for the scanner to observe the shutdown watch value and
     // return; at worst this blocks for the current 60 s tick.
     if let Err(e) = idle_scanner_handle.await {
-        warn!(error = %e, "idle scanner join failed");
+        warn!(
+            code = "BOOTSTRAP_DEGRADED_IDLE_SCANNER",
+            stage = "idle_scanner.join",
+            error = %e,
+            "idle scanner join failed"
+        );
     }
 
     services.database.close().await;
@@ -246,33 +301,65 @@ pub(crate) async fn run_server(
     // Prevent the log guard from being dropped before final log flush.
     drop(env);
 
+    finish_server_shutdown(shutdown_error)
+}
+
+fn router_build_error_to_bootstrap(error: RouterBuildError) -> BootstrapError {
+    let stage = error.stage();
+    let message = error.message();
+    BootstrapError::new(BootstrapErrorCode::ServerFailed, stage, message).with_source(error)
+}
+
+fn finish_server_shutdown(shutdown_error: Option<BootstrapError>) -> Result<ExitCode, BootstrapError> {
+    if let Some(error) = shutdown_error {
+        return Err(error);
+    }
+
     Ok(ExitCode::SUCCESS)
 }
 
-async fn shutdown_signal() {
+async fn shutdown_signal() -> Result<(), BootstrapError> {
     let ctrl_c = async {
-        tokio::signal::ctrl_c().await.expect("failed to install Ctrl+C handler");
+        tokio::signal::ctrl_c().await.map_err(|error| {
+            BootstrapError::new(
+                BootstrapErrorCode::ShutdownFailed,
+                "shutdown.signal_handler",
+                "failed to install shutdown signal handler",
+            )
+            .with_source(error)
+        })
     };
 
     #[cfg(unix)]
     let terminate = async {
-        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-            .expect("failed to install SIGTERM handler")
-            .recv()
-            .await;
+        let mut terminate =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).map_err(|error| {
+                BootstrapError::new(
+                    BootstrapErrorCode::ShutdownFailed,
+                    "shutdown.signal_handler",
+                    "failed to install shutdown signal handler",
+                )
+                .with_source(error)
+            })?;
+        terminate.recv().await;
+        Ok::<(), BootstrapError>(())
     };
 
     #[cfg(not(unix))]
-    let terminate = std::future::pending::<()>();
+    let terminate = std::future::pending::<Result<(), BootstrapError>>();
 
     tokio::select! {
-        () = ctrl_c => {
+        result = ctrl_c => {
+            result?;
             info!("Received SIGINT, shutting down...");
         }
-        () = terminate => {
+        result = terminate => {
+            result?;
             info!("Received SIGTERM, shutting down...");
         }
     }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -315,5 +402,58 @@ mod tests {
 
         assert!(config.port > 0);
         assert_eq!(config.port, bound.addr.port());
+    }
+
+    #[tokio::test]
+    async fn forbidden_backend_port_maps_to_bootstrap_config_invalid() {
+        let mut config = AppConfig {
+            port: 1720,
+            ..AppConfig::default()
+        };
+
+        let err = bind_http_listener(&mut config).await.unwrap_err();
+        assert_eq!(err.code(), crate::bootstrap::BootstrapErrorCode::ConfigInvalid);
+        assert_eq!(err.stage(), "config.port");
+        assert_eq!(err.exit_code(), std::process::ExitCode::from(2));
+        assert!(
+            err.stderr_line()
+                .starts_with("BOOTSTRAP_CONFIG_INVALID stage=config.port")
+        );
+    }
+
+    #[test]
+    fn graceful_shutdown_returns_signal_error_when_serve_succeeds() {
+        let error = BootstrapError::new(
+            BootstrapErrorCode::ShutdownFailed,
+            "shutdown.signal_handler",
+            "failed to install shutdown signal handler",
+        )
+        .with_source(anyhow::anyhow!("raw shutdown source"));
+
+        let err = finish_server_shutdown(Some(error)).unwrap_err();
+
+        assert_eq!(err.code(), BootstrapErrorCode::ShutdownFailed);
+        assert_eq!(err.stage(), "shutdown.signal_handler");
+        assert!(
+            err.stderr_line()
+                .starts_with("BOOTSTRAP_SHUTDOWN_FAILED stage=shutdown.signal_handler")
+        );
+        assert!(!err.stderr_line().contains("raw shutdown source"));
+    }
+
+    #[test]
+    fn router_build_error_maps_to_bootstrap_server_failed() {
+        let err = router_build_error_to_bootstrap(
+            RouterBuildError::new("router.file_watch", "failed to initialize file watch service")
+                .with_source(anyhow::anyhow!("raw watch backend unavailable")),
+        );
+
+        assert_eq!(err.code(), BootstrapErrorCode::ServerFailed);
+        assert_eq!(err.stage(), "router.file_watch");
+        assert!(
+            err.stderr_line()
+                .starts_with("BOOTSTRAP_SERVER_FAILED stage=router.file_watch")
+        );
+        assert!(!err.stderr_line().contains("raw watch backend unavailable"));
     }
 }

--- a/crates/aionui-app/src/commands/team_guide.rs
+++ b/crates/aionui-app/src/commands/team_guide.rs
@@ -11,43 +11,27 @@
 
 use std::process::ExitCode;
 
+use crate::commands::cli_error::{CliBoundaryCode, CliBoundaryError, missing_env, parse_required_port};
 use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{CallToolResult, Content};
 use rmcp::{schemars, service::ServiceExt, tool, tool_router, transport};
 use serde::Deserialize;
 
+const SUBCOMMAND: &str = "mcp-guide-stdio";
+const ENV_PORT: &str = "AION_MCP_PORT";
+const ENV_TOKEN: &str = "AION_MCP_TOKEN";
+const ENV_BACKEND: &str = "AION_MCP_BACKEND";
+const ENV_CONVERSATION_ID: &str = "AION_MCP_CONVERSATION_ID";
+const ENV_USER_ID: &str = "AION_MCP_USER_ID";
+
 pub async fn run_team_guide() -> ExitCode {
-    // Debug breadcrumb
-    let _ = std::fs::write(
-        "/tmp/mcp-guide-stdio-spawned.txt",
-        format!(
-            "spawned at {:?}\nargs: {:?}\nenv PORT={}\n",
-            std::time::SystemTime::now(),
-            std::env::args().collect::<Vec<_>>(),
-            std::env::var("AION_MCP_PORT").unwrap_or_default(),
-        ),
-    );
-
-    let port = match std::env::var("AION_MCP_PORT") {
-        Ok(p) => p,
-        Err(_) => {
-            eprintln!("[mcp-guide-stdio] ERROR: missing AION_MCP_PORT");
-            return ExitCode::from(1);
+    let env = match GuideEnv::from_env() {
+        Ok(env) => env,
+        Err(err) => {
+            eprintln!("{}", err.stderr_line());
+            return err.exit_code();
         }
     };
-    let token = match std::env::var("AION_MCP_TOKEN") {
-        Ok(t) => t,
-        Err(_) => {
-            eprintln!("[mcp-guide-stdio] ERROR: missing AION_MCP_TOKEN");
-            return ExitCode::from(1);
-        }
-    };
-    let backend = std::env::var("AION_MCP_BACKEND").unwrap_or_default();
-    let conversation_id = std::env::var("AION_MCP_CONVERSATION_ID").unwrap_or_default();
-    let user_id = std::env::var("AION_MCP_USER_ID").unwrap_or_default();
-
-    eprintln!(
-        "[mcp-guide-stdio] Started OK. PORT={port}, BACKEND={backend}, CONV_ID={conversation_id}, USER={user_id}"
-    );
 
     let http_client = reqwest::Client::builder()
         .pool_max_idle_per_host(0)
@@ -57,29 +41,74 @@ pub async fn run_team_guide() -> ExitCode {
         .unwrap_or_else(|_| reqwest::Client::new());
 
     let server = GuideServer {
-        port: port.parse().unwrap_or(0),
-        token,
-        backend,
-        conversation_id,
-        user_id,
+        port: env.port,
+        token: env.token,
+        backend: env.backend,
+        conversation_id: env.conversation_id,
+        user_id: env.user_id,
         http_client,
     };
 
     let transport = transport::io::stdio();
     match server.serve(transport).await {
         Ok(peer) => {
-            eprintln!("[mcp-guide-stdio] MCP session started, waiting for completion...");
-            if let Err(e) = peer.waiting().await {
-                eprintln!("[mcp-guide-stdio] Session ended with error: {e}");
+            if let Err(_e) = peer.waiting().await {
+                let err = CliBoundaryError::new(
+                    CliBoundaryCode::McpSessionEndedWithError,
+                    SUBCOMMAND,
+                    "MCP stdio session ended with an error",
+                );
+                eprintln!("{}", err.stderr_line());
+                err.exit_code()
             } else {
-                eprintln!("[mcp-guide-stdio] Session ended normally");
+                ExitCode::SUCCESS
             }
-            ExitCode::SUCCESS
         }
-        Err(e) => {
-            eprintln!("[mcp-guide-stdio] Failed to start MCP server: {e}");
-            ExitCode::from(1)
+        Err(_e) => {
+            let err = CliBoundaryError::new(
+                CliBoundaryCode::McpStdioServeFailed,
+                SUBCOMMAND,
+                "failed to start MCP stdio server",
+            );
+            eprintln!("{}", err.stderr_line());
+            err.exit_code()
         }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct GuideEnv {
+    port: u16,
+    token: String,
+    backend: String,
+    conversation_id: String,
+    user_id: String,
+}
+
+impl GuideEnv {
+    fn from_env() -> Result<Self, CliBoundaryError> {
+        let port_raw = std::env::var(ENV_PORT).map_err(|_| missing_env(SUBCOMMAND, ENV_PORT))?;
+        let token = std::env::var(ENV_TOKEN).map_err(|_| missing_env(SUBCOMMAND, ENV_TOKEN))?;
+        let backend = std::env::var(ENV_BACKEND).unwrap_or_default();
+        let conversation_id = std::env::var(ENV_CONVERSATION_ID).unwrap_or_default();
+        let user_id = std::env::var(ENV_USER_ID).unwrap_or_default();
+        Self::from_values(&port_raw, token, backend, conversation_id, user_id)
+    }
+
+    fn from_values(
+        port_raw: &str,
+        token: impl Into<String>,
+        backend: impl Into<String>,
+        conversation_id: impl Into<String>,
+        user_id: impl Into<String>,
+    ) -> Result<Self, CliBoundaryError> {
+        Ok(Self {
+            port: parse_required_port(SUBCOMMAND, ENV_PORT, port_raw)?,
+            token: token.into(),
+            backend: backend.into(),
+            conversation_id: conversation_id.into(),
+            user_id: user_id.into(),
+        })
     }
 }
 
@@ -207,8 +236,7 @@ impl GuideServer {
         name = "aion_create_team",
         description = "Create a multi-agent Team. Only call after user explicitly confirms team configuration."
     )]
-    async fn create_team(&self, Parameters(params): Parameters<CreateTeamParams>) -> String {
-        eprintln!("[mcp-guide-stdio] tools/call: aion_create_team");
+    async fn create_team(&self, Parameters(params): Parameters<CreateTeamParams>) -> CallToolResult {
         self.forward_tool(
             "aion_create_team",
             &serde_json::json!({
@@ -224,8 +252,7 @@ impl GuideServer {
         name = "aion_list_models",
         description = "Query available models for team agent types. Pass agent_type to filter, or omit to see all."
     )]
-    async fn list_models(&self, Parameters(params): Parameters<ListModelsParams>) -> String {
-        eprintln!("[mcp-guide-stdio] tools/call: aion_list_models");
+    async fn list_models(&self, Parameters(params): Parameters<ListModelsParams>) -> CallToolResult {
         self.forward_tool(
             "aion_list_models",
             &serde_json::json!({
@@ -239,8 +266,7 @@ impl GuideServer {
         name = "team_send_message",
         description = "Send a message to a teammate or broadcast to all (to=\"*\")."
     )]
-    async fn team_send_message(&self, Parameters(params): Parameters<SendMessageParams>) -> String {
-        eprintln!("[mcp-guide-stdio] tools/call: team_send_message");
+    async fn team_send_message(&self, Parameters(params): Parameters<SendMessageParams>) -> CallToolResult {
         self.forward_tool(
             "team_send_message",
             &serde_json::json!({
@@ -255,8 +281,7 @@ impl GuideServer {
         name = "team_spawn_agent",
         description = "Create a new teammate agent to join the team. Leader only."
     )]
-    async fn team_spawn_agent(&self, Parameters(params): Parameters<SpawnAgentParams>) -> String {
-        eprintln!("[mcp-guide-stdio] tools/call: team_spawn_agent");
+    async fn team_spawn_agent(&self, Parameters(params): Parameters<SpawnAgentParams>) -> CallToolResult {
         self.forward_tool(
             "team_spawn_agent",
             &serde_json::json!({
@@ -270,8 +295,7 @@ impl GuideServer {
     }
 
     #[tool(name = "team_task_create", description = "Create a new task on the team task board.")]
-    async fn team_task_create(&self, Parameters(params): Parameters<TaskCreateParams>) -> String {
-        eprintln!("[mcp-guide-stdio] tools/call: team_task_create");
+    async fn team_task_create(&self, Parameters(params): Parameters<TaskCreateParams>) -> CallToolResult {
         self.forward_tool(
             "team_task_create",
             &serde_json::json!({
@@ -288,8 +312,7 @@ impl GuideServer {
         name = "team_task_update",
         description = "Update an existing task on the team task board."
     )]
-    async fn team_task_update(&self, Parameters(params): Parameters<TaskUpdateParams>) -> String {
-        eprintln!("[mcp-guide-stdio] tools/call: team_task_update");
+    async fn team_task_update(&self, Parameters(params): Parameters<TaskUpdateParams>) -> CallToolResult {
         self.forward_tool(
             "team_task_update",
             &serde_json::json!({
@@ -304,8 +327,7 @@ impl GuideServer {
     }
 
     #[tool(name = "team_task_list", description = "List all tasks on the team task board.")]
-    async fn team_task_list(&self) -> String {
-        eprintln!("[mcp-guide-stdio] tools/call: team_task_list");
+    async fn team_task_list(&self) -> CallToolResult {
         self.forward_tool("team_task_list", &serde_json::json!({})).await
     }
 
@@ -313,14 +335,12 @@ impl GuideServer {
         name = "team_members",
         description = "List all team members with their roles and current status."
     )]
-    async fn team_members(&self) -> String {
-        eprintln!("[mcp-guide-stdio] tools/call: team_members");
+    async fn team_members(&self) -> CallToolResult {
         self.forward_tool("team_members", &serde_json::json!({})).await
     }
 
     #[tool(name = "team_rename_agent", description = "Rename a team member.")]
-    async fn team_rename_agent(&self, Parameters(params): Parameters<RenameAgentParams>) -> String {
-        eprintln!("[mcp-guide-stdio] tools/call: team_rename_agent");
+    async fn team_rename_agent(&self, Parameters(params): Parameters<RenameAgentParams>) -> CallToolResult {
         self.forward_tool(
             "team_rename_agent",
             &serde_json::json!({
@@ -335,8 +355,7 @@ impl GuideServer {
         name = "team_shutdown_agent",
         description = "Initiate graceful shutdown of a teammate. Leader only."
     )]
-    async fn team_shutdown_agent(&self, Parameters(params): Parameters<ShutdownAgentParams>) -> String {
-        eprintln!("[mcp-guide-stdio] tools/call: team_shutdown_agent");
+    async fn team_shutdown_agent(&self, Parameters(params): Parameters<ShutdownAgentParams>) -> CallToolResult {
         self.forward_tool(
             "team_shutdown_agent",
             &serde_json::json!({
@@ -351,8 +370,7 @@ impl GuideServer {
         name = "team_list_models",
         description = "Query available models for team agent types."
     )]
-    async fn team_list_models(&self, Parameters(params): Parameters<TeamListModelsParams>) -> String {
-        eprintln!("[mcp-guide-stdio] tools/call: team_list_models");
+    async fn team_list_models(&self, Parameters(params): Parameters<TeamListModelsParams>) -> CallToolResult {
         self.forward_tool(
             "team_list_models",
             &serde_json::json!({
@@ -366,8 +384,7 @@ impl GuideServer {
         name = "team_describe_assistant",
         description = "Get detailed information about a preset assistant before spawning."
     )]
-    async fn team_describe_assistant(&self, Parameters(params): Parameters<DescribeAssistantParams>) -> String {
-        eprintln!("[mcp-guide-stdio] tools/call: team_describe_assistant");
+    async fn team_describe_assistant(&self, Parameters(params): Parameters<DescribeAssistantParams>) -> CallToolResult {
         self.forward_tool(
             "team_describe_assistant",
             &serde_json::json!({
@@ -382,6 +399,14 @@ impl GuideServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn first_text(result: &CallToolResult) -> &str {
+        result.content[0].as_text().expect("text content").text.as_str()
+    }
 
     #[test]
     fn all_tool_schemas_have_properties_field() {
@@ -397,10 +422,147 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn guide_env_rejects_invalid_port_with_stable_code() {
+        let err = GuideEnv::from_values("bad", "tok", "", "", "").unwrap_err();
+        assert_eq!(
+            err.code(),
+            crate::commands::cli_error::CliBoundaryCode::McpEnvInvalidPort
+        );
+        assert_eq!(err.exit_code(), std::process::ExitCode::from(2));
+    }
+
+    #[test]
+    fn guide_env_accepts_valid_values() {
+        let env = GuideEnv::from_values("4567", "tok", "codex", "conv-1", "user-1").unwrap();
+        assert_eq!(env.port, 4567);
+        assert_eq!(env.token, "tok");
+        assert_eq!(env.backend, "codex");
+        assert_eq!(env.conversation_id, "conv-1");
+        assert_eq!(env.user_id, "user-1");
+    }
+
+    fn guide_server_for_port(port: u16) -> GuideServer {
+        GuideServer {
+            port,
+            token: "test-token".to_owned(),
+            backend: "codex".to_owned(),
+            conversation_id: "conv-secret-123".to_owned(),
+            user_id: "user-secret-456".to_owned(),
+            http_client: reqwest::Client::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn forward_tool_non_2xx_json_error_returns_status_error_without_raw_error() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tool"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": "unauthorized for conv-secret-123",
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let server = guide_server_for_port(mock_server.address().port());
+        let result = server.forward_tool("team_members", &json!({})).await;
+
+        assert_eq!(result.is_error, Some(true));
+        assert_eq!(first_text(&result), "local guide server returned HTTP 401");
+        assert_eq!(
+            result.structured_content.as_ref().unwrap()["code"],
+            "MCP_HTTP_STATUS_ERROR"
+        );
+        let serialized = serde_json::to_string(&result).unwrap();
+        assert!(!serialized.contains("unauthorized"));
+        assert!(!serialized.contains("conv-secret-123"));
+    }
+
+    #[tokio::test]
+    async fn forward_tool_2xx_json_error_returns_remote_error_without_raw_id() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tool"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "error": "tool failed for conv-secret-123",
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let server = guide_server_for_port(mock_server.address().port());
+        let result = server.forward_tool("team_members", &json!({})).await;
+
+        assert_eq!(result.is_error, Some(true));
+        assert_eq!(first_text(&result), "local guide tool returned an error");
+        assert_eq!(
+            result.structured_content.as_ref().unwrap()["code"],
+            "MCP_TOOL_REMOTE_ERROR"
+        );
+        let serialized = serde_json::to_string(&result).unwrap();
+        assert!(!serialized.contains("conv-secret-123"));
+    }
+
+    #[tokio::test]
+    async fn forward_tool_unexpected_2xx_body_returns_unexpected_without_echoing_body() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tool"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("unexpected raw body with team-secret-789"))
+            .mount(&mock_server)
+            .await;
+
+        let server = guide_server_for_port(mock_server.address().port());
+        let result = server.forward_tool("team_members", &json!({})).await;
+
+        assert_eq!(result.is_error, Some(true));
+        assert_eq!(first_text(&result), "unexpected local guide tool response");
+        assert_eq!(
+            result.structured_content.as_ref().unwrap()["code"],
+            "MCP_TOOL_RESPONSE_UNEXPECTED"
+        );
+        let serialized = serde_json::to_string(&result).unwrap();
+        assert!(!serialized.contains("team-secret-789"));
+        assert!(!serialized.contains("unexpected raw body"));
+    }
+
+    #[tokio::test]
+    async fn forward_tool_response_read_failure_is_not_overwritten_by_later_connect_failure() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server_task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\n\
+                    Content-Type: application/json\r\n\
+                    Content-Length: 128\r\n\
+                    Connection: close\r\n\
+                    \r\n\
+                    {\"result\":\"partial",
+                )
+                .await
+                .unwrap();
+            stream.shutdown().await.unwrap();
+        });
+
+        let server = guide_server_for_port(port);
+        let result = server.forward_tool("team_members", &json!({})).await;
+        server_task.await.unwrap();
+
+        assert_eq!(result.is_error, Some(true));
+        assert_eq!(first_text(&result), "failed to read local guide server response");
+        assert_eq!(
+            result.structured_content.as_ref().unwrap()["code"],
+            "MCP_HTTP_RESPONSE_READ_FAILED"
+        );
+    }
 }
 
 impl GuideServer {
-    async fn forward_tool(&self, tool_name: &str, args: &serde_json::Value) -> String {
+    async fn forward_tool(&self, tool_name: &str, args: &serde_json::Value) -> CallToolResult {
         let url = format!("http://127.0.0.1:{}/tool", self.port);
         let body = serde_json::json!({
             "tool": tool_name,
@@ -413,14 +575,12 @@ impl GuideServer {
         // Retry up to 3 times with backoff — the Guide HTTP server may not be
         // fully ready immediately after a session resume spawns this process.
         let delays_ms: &[u64] = &[0, 1000, 2000, 3000];
-        let mut last_error = String::new();
-        for (attempt, &delay_ms) in delays_ms.iter().enumerate() {
+        let mut last_error = None;
+        for &delay_ms in delays_ms {
             if delay_ms > 0 {
                 let delay = std::time::Duration::from_millis(delay_ms);
-                eprintln!("[mcp-guide-stdio] retrying in {delay:?}...");
                 tokio::time::sleep(delay).await;
             }
-            eprintln!("[mcp-guide-stdio] HTTP POST {url} (attempt {})", attempt + 1);
             match self
                 .http_client
                 .post(&url)
@@ -431,34 +591,109 @@ impl GuideServer {
             {
                 Ok(resp) => {
                     let status = resp.status();
+                    if !status.is_success() {
+                        return tool_error(
+                            CliBoundaryCode::McpHttpStatusError,
+                            &format!("local guide server returned HTTP {}", status.as_u16()),
+                            None,
+                            None,
+                        );
+                    }
                     match resp.text().await {
                         Ok(text) => {
-                            eprintln!(
-                                "[mcp-guide-stdio] HTTP POST /tool → status={status}, body_preview={}",
-                                &text[..text.len().min(100)]
-                            );
                             if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
                                 if let Some(result) = v.get("result").and_then(|r| r.as_str()) {
-                                    return result.to_owned();
+                                    return tool_success(result.to_owned());
                                 }
-                                if let Some(error) = v.get("error") {
-                                    return format!("Error: {error}");
+                                if v.get("error").is_some() {
+                                    return tool_error(
+                                        CliBoundaryCode::McpToolRemoteError,
+                                        "local guide tool returned an error",
+                                        extract_nested_code(&v, &["error", "code"]),
+                                        extract_nested_code(&v, &["error", "data", "domainCode"])
+                                            .or_else(|| extract_nested_code(&v, &["error", "data", "code"]))
+                                            .or_else(|| extract_nested_code(&v, &["error", "data", "errorCode"])),
+                                    );
                                 }
                             }
-                            return text;
+                            return tool_error(
+                                CliBoundaryCode::McpToolResponseUnexpected,
+                                "unexpected local guide tool response",
+                                None,
+                                None,
+                            );
                         }
-                        Err(e) => {
-                            last_error = format!("failed to read response: {e}");
-                            eprintln!("[mcp-guide-stdio] HTTP FAILED: {last_error}");
+                        Err(_e) => {
+                            let err = CliBoundaryError::new(
+                                CliBoundaryCode::McpHttpResponseReadFailed,
+                                SUBCOMMAND,
+                                "failed to read local guide server response",
+                            );
+                            eprintln!("{}", err.stderr_line());
+                            return tool_error(
+                                CliBoundaryCode::McpHttpResponseReadFailed,
+                                "failed to read local guide server response",
+                                None,
+                                None,
+                            );
                         }
                     }
                 }
-                Err(e) => {
-                    last_error = format!("{e:#}");
-                    eprintln!("[mcp-guide-stdio] HTTP FAILED: {last_error}");
+                Err(_e) => {
+                    let err = CliBoundaryError::new(
+                        CliBoundaryCode::McpHttpConnectOrTimeout,
+                        SUBCOMMAND,
+                        "failed to connect to local guide server or request timed out",
+                    );
+                    eprintln!("{}", err.stderr_line());
+                    last_error = Some((
+                        CliBoundaryCode::McpHttpConnectOrTimeout,
+                        "failed to connect to local guide server or request timed out",
+                    ));
                 }
             }
         }
-        format!("Error: {last_error}")
+        let (code, message) = last_error.unwrap_or((
+            CliBoundaryCode::McpHttpConnectOrTimeout,
+            "failed to connect to local guide server or request timed out",
+        ));
+        tool_error(code, message, None, None)
+    }
+}
+
+fn tool_success(text: String) -> CallToolResult {
+    CallToolResult::success(vec![Content::text(text)])
+}
+
+fn tool_error(
+    code: CliBoundaryCode,
+    message: &str,
+    upstream_code: Option<serde_json::Value>,
+    domain_code: Option<serde_json::Value>,
+) -> CallToolResult {
+    let mut structured = serde_json::json!({
+        "code": code.as_str(),
+        "message": message,
+    });
+    if let Some(upstream_code) = upstream_code {
+        structured["upstreamCode"] = upstream_code;
+    }
+    if let Some(domain_code) = domain_code {
+        structured["domainCode"] = domain_code;
+    }
+
+    let mut result = CallToolResult::error(vec![Content::text(message.to_owned())]);
+    result.structured_content = Some(structured);
+    result
+}
+
+fn extract_nested_code(value: &serde_json::Value, path: &[&str]) -> Option<serde_json::Value> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    match current {
+        serde_json::Value::String(_) | serde_json::Value::Number(_) => Some(current.clone()),
+        _ => None,
     }
 }

--- a/crates/aionui-app/src/commands/team_stdio.rs
+++ b/crates/aionui-app/src/commands/team_stdio.rs
@@ -9,76 +9,96 @@
 //! (injecting auth_token + slot_id), then sends the `tools/call` frame, reads
 //! the response, and closes the connection (one-shot mode).
 
-use std::io;
 use std::process::ExitCode;
 
+use crate::commands::cli_error::{CliBoundaryCode, CliBoundaryError, missing_env, parse_required_port};
 use aionui_api_types::TeamMcpStdioConfig;
+use aionui_team::mcp::protocol::{read_frame, write_frame};
 use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{CallToolResult, Content};
 use rmcp::{schemars, service::ServiceExt, tool, tool_router, transport};
 use serde::Deserialize;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
+const SUBCOMMAND: &str = "mcp-team-stdio";
 const CONNECT_HOST: &str = "127.0.0.1";
+const ERR_JSON_SERIALIZE: &str = "failed to serialize MCP JSON frame";
+const ERR_TCP_CONNECT: &str = "failed to connect to local MCP TCP listener";
+const ERR_TCP_WRITE: &str = "failed to write MCP frame to TCP listener";
+const ERR_TCP_READ: &str = "failed to read MCP frame from TCP listener";
+const ERR_TOOL_REMOTE: &str = "local team tool returned an error";
+const ERR_TOOL_RESPONSE_UNEXPECTED: &str = "unexpected local team tool response";
 
 pub async fn run_team_stdio() -> ExitCode {
-    let _ = std::fs::write(
-        "/tmp/mcp-team-stdio-spawned.txt",
-        format!(
-            "spawned at {:?}\nargs: {:?}\nenv PORT={}\n",
-            std::time::SystemTime::now(),
-            std::env::args().collect::<Vec<_>>(),
-            std::env::var(TeamMcpStdioConfig::ENV_PORT).unwrap_or_default(),
-        ),
-    );
-
-    let port: u16 = match std::env::var(TeamMcpStdioConfig::ENV_PORT) {
-        Ok(p) => match p.parse() {
-            Ok(v) => v,
-            Err(e) => {
-                eprintln!("[mcp-team-stdio] ERROR: invalid {}: {e}", TeamMcpStdioConfig::ENV_PORT);
-                return ExitCode::from(1);
-            }
-        },
-        Err(_) => {
-            eprintln!("[mcp-team-stdio] ERROR: missing {}", TeamMcpStdioConfig::ENV_PORT);
-            return ExitCode::from(1);
-        }
-    };
-    let token = match std::env::var(TeamMcpStdioConfig::ENV_TOKEN) {
-        Ok(t) => t,
-        Err(_) => {
-            eprintln!("[mcp-team-stdio] ERROR: missing {}", TeamMcpStdioConfig::ENV_TOKEN);
-            return ExitCode::from(1);
-        }
-    };
-    let slot_id = match std::env::var(TeamMcpStdioConfig::ENV_SLOT_ID) {
-        Ok(s) => s,
-        Err(_) => {
-            eprintln!("[mcp-team-stdio] ERROR: missing {}", TeamMcpStdioConfig::ENV_SLOT_ID);
-            return ExitCode::from(1);
+    let env = match TeamStdioEnv::from_env() {
+        Ok(env) => env,
+        Err(err) => {
+            eprintln!("{}", err.stderr_line());
+            return err.exit_code();
         }
     };
 
-    eprintln!("[mcp-team-stdio] Started. PORT={port}, SLOT_ID={slot_id}");
-
-    let server = TeamStdioServer { port, token, slot_id };
+    let server = TeamStdioServer {
+        port: env.port,
+        token: env.token,
+        slot_id: env.slot_id,
+    };
 
     let transport = transport::io::stdio();
     match server.serve(transport).await {
         Ok(peer) => {
-            eprintln!("[mcp-team-stdio] MCP session started, waiting for completion...");
-            if let Err(e) = peer.waiting().await {
-                eprintln!("[mcp-team-stdio] Session ended with error: {e}");
+            if let Err(_e) = peer.waiting().await {
+                let err = CliBoundaryError::new(
+                    CliBoundaryCode::McpSessionEndedWithError,
+                    SUBCOMMAND,
+                    "MCP stdio session ended with an error",
+                );
+                eprintln!("{}", err.stderr_line());
+                err.exit_code()
             } else {
-                eprintln!("[mcp-team-stdio] Session ended normally");
+                ExitCode::SUCCESS
             }
-            ExitCode::SUCCESS
         }
-        Err(e) => {
-            eprintln!("[mcp-team-stdio] Failed to start MCP server: {e}");
-            ExitCode::from(1)
+        Err(_e) => {
+            let err = CliBoundaryError::new(
+                CliBoundaryCode::McpStdioServeFailed,
+                SUBCOMMAND,
+                "failed to start MCP stdio server",
+            );
+            eprintln!("{}", err.stderr_line());
+            err.exit_code()
         }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct TeamStdioEnv {
+    port: u16,
+    token: String,
+    slot_id: String,
+}
+
+impl TeamStdioEnv {
+    fn from_env() -> Result<Self, CliBoundaryError> {
+        let port_raw = std::env::var(TeamMcpStdioConfig::ENV_PORT)
+            .map_err(|_| missing_env(SUBCOMMAND, TeamMcpStdioConfig::ENV_PORT))?;
+        let token = std::env::var(TeamMcpStdioConfig::ENV_TOKEN)
+            .map_err(|_| missing_env(SUBCOMMAND, TeamMcpStdioConfig::ENV_TOKEN))?;
+        let slot_id = std::env::var(TeamMcpStdioConfig::ENV_SLOT_ID)
+            .map_err(|_| missing_env(SUBCOMMAND, TeamMcpStdioConfig::ENV_SLOT_ID))?;
+        Self::from_values(&port_raw, token, slot_id)
+    }
+
+    fn from_values(
+        port_raw: &str,
+        token: impl Into<String>,
+        slot_id: impl Into<String>,
+    ) -> Result<Self, CliBoundaryError> {
+        Ok(Self {
+            port: parse_required_port(SUBCOMMAND, TeamMcpStdioConfig::ENV_PORT, port_raw)?,
+            token: token.into(),
+            slot_id: slot_id.into(),
+        })
     }
 }
 
@@ -202,8 +222,7 @@ impl TeamStdioServer {
         name = "team_send_message",
         description = "Send a message to a teammate or broadcast to all (to=\"*\")."
     )]
-    async fn send_message(&self, Parameters(params): Parameters<SendMessageParams>) -> String {
-        eprintln!("[mcp-team-stdio] tools/call: team_send_message to={}", params.to);
+    async fn send_message(&self, Parameters(params): Parameters<SendMessageParams>) -> CallToolResult {
         self.forward_to_tcp(
             "team_send_message",
             &serde_json::json!({ "to": params.to, "message": params.message }),
@@ -215,8 +234,7 @@ impl TeamStdioServer {
         name = "team_spawn_agent",
         description = "Create a new teammate agent to join the team.\n\nUse this only when one of the following is true:\n- The user explicitly approved the proposed teammate lineup in a previous message\n- The user explicitly instructed you to create a specific teammate immediately\n\nBefore calling this tool in the normal planning flow:\n- Start with one short sentence explaining why additional teammates would help\n- Tell the user which teammate(s) you recommend\n- Present the proposal as a table with: name, responsibility, recommended agent type/backend, and recommended model\n- Include each teammate's responsibility, recommended agent type/backend, and model\n- Ask whether to create them as proposed or change any names, responsibilities, or agent types\n- In that approval question, remind the user that they can later ask you to replace or adjust any teammate if the lineup is not working well\n- Do NOT call this tool in that same turn; wait for explicit approval in a later user message\n\nWhen calling this tool, provide the model parameter if a specific model was recommended and approved.\n\nThe new agent will be created and added to the team. You can then assign tasks and send messages to it."
     )]
-    async fn spawn_agent(&self, Parameters(params): Parameters<SpawnAgentParams>) -> String {
-        eprintln!("[mcp-team-stdio] tools/call: team_spawn_agent name={}", params.name);
+    async fn spawn_agent(&self, Parameters(params): Parameters<SpawnAgentParams>) -> CallToolResult {
         self.forward_to_tcp(
             "team_spawn_agent",
             &serde_json::json!({
@@ -232,11 +250,7 @@ impl TeamStdioServer {
     }
 
     #[tool(name = "team_task_create", description = "Create a new task on the team task board.")]
-    async fn task_create(&self, Parameters(params): Parameters<TaskCreateParams>) -> String {
-        eprintln!(
-            "[mcp-team-stdio] tools/call: team_task_create subject={}",
-            params.subject
-        );
+    async fn task_create(&self, Parameters(params): Parameters<TaskCreateParams>) -> CallToolResult {
         self.forward_to_tcp(
             "team_task_create",
             &serde_json::json!({
@@ -253,11 +267,7 @@ impl TeamStdioServer {
         name = "team_task_update",
         description = "Update an existing task on the team task board."
     )]
-    async fn task_update(&self, Parameters(params): Parameters<TaskUpdateParams>) -> String {
-        eprintln!(
-            "[mcp-team-stdio] tools/call: team_task_update task_id={}",
-            params.task_id
-        );
+    async fn task_update(&self, Parameters(params): Parameters<TaskUpdateParams>) -> CallToolResult {
         self.forward_to_tcp(
             "team_task_update",
             &serde_json::json!({
@@ -272,8 +282,7 @@ impl TeamStdioServer {
     }
 
     #[tool(name = "team_task_list", description = "List all tasks on the team task board.")]
-    async fn task_list(&self) -> String {
-        eprintln!("[mcp-team-stdio] tools/call: team_task_list");
+    async fn task_list(&self) -> CallToolResult {
         self.forward_to_tcp("team_task_list", &serde_json::json!({})).await
     }
 
@@ -281,17 +290,12 @@ impl TeamStdioServer {
         name = "team_members",
         description = "List all team members with their roles and current status."
     )]
-    async fn members(&self) -> String {
-        eprintln!("[mcp-team-stdio] tools/call: team_members");
+    async fn members(&self) -> CallToolResult {
         self.forward_to_tcp("team_members", &serde_json::json!({})).await
     }
 
     #[tool(name = "team_rename_agent", description = "Rename a team member.")]
-    async fn rename_agent(&self, Parameters(params): Parameters<RenameAgentParams>) -> String {
-        eprintln!(
-            "[mcp-team-stdio] tools/call: team_rename_agent slot_id={}",
-            params.slot_id
-        );
+    async fn rename_agent(&self, Parameters(params): Parameters<RenameAgentParams>) -> CallToolResult {
         self.forward_to_tcp(
             "team_rename_agent",
             &serde_json::json!({ "slot_id": params.slot_id, "new_name": params.new_name }),
@@ -303,11 +307,7 @@ impl TeamStdioServer {
         name = "team_shutdown_agent",
         description = "Initiate shutdown of a teammate (Lead only). Sends a shutdown_request to the target agent."
     )]
-    async fn shutdown_agent(&self, Parameters(params): Parameters<ShutdownAgentParams>) -> String {
-        eprintln!(
-            "[mcp-team-stdio] tools/call: team_shutdown_agent slot_id={}",
-            params.slot_id
-        );
+    async fn shutdown_agent(&self, Parameters(params): Parameters<ShutdownAgentParams>) -> CallToolResult {
         self.forward_to_tcp(
             "team_shutdown_agent",
             &serde_json::json!({ "slot_id": params.slot_id, "reason": params.reason }),
@@ -319,8 +319,7 @@ impl TeamStdioServer {
         name = "team_list_models",
         description = "Query available models for team agent types. Returns the real-time model list that matches the frontend model selector.\n\nUse this to:\n- Check what models are available before spawning an agent with a specific model\n- See all available agent types and their models at once\n- Verify a model ID is valid for a given agent type\n\nPass agent_type to query a specific backend, or omit it to see all."
     )]
-    async fn list_models(&self, Parameters(params): Parameters<ListModelsParams>) -> String {
-        eprintln!("[mcp-team-stdio] tools/call: team_list_models");
+    async fn list_models(&self, Parameters(params): Parameters<ListModelsParams>) -> CallToolResult {
         self.forward_to_tcp(
             "team_list_models",
             &serde_json::json!({ "agent_type": params.agent_type }),
@@ -332,11 +331,7 @@ impl TeamStdioServer {
         name = "team_describe_assistant",
         description = "Get detailed information about a preset assistant before spawning it as a teammate.\n\nReturns the preset's full description, enabled skills, and example tasks so you can\njudge whether it fits the user's request. Use this when two or more presets look\nrelevant from the one-line catalog in your system prompt.\n\nOnly works on preset assistants listed in \"Available Preset Assistants for Spawning\".\nAfter confirming a match, call team_spawn_agent with the same custom_agent_id."
     )]
-    async fn describe_assistant(&self, Parameters(params): Parameters<DescribeAssistantParams>) -> String {
-        eprintln!(
-            "[mcp-team-stdio] tools/call: team_describe_assistant id={}",
-            params.custom_agent_id
-        );
+    async fn describe_assistant(&self, Parameters(params): Parameters<DescribeAssistantParams>) -> CallToolResult {
         self.forward_to_tcp(
             "team_describe_assistant",
             &serde_json::json!({ "custom_agent_id": params.custom_agent_id, "locale": params.locale }),
@@ -351,18 +346,26 @@ impl TeamStdioServer {
 
 impl TeamStdioServer {
     /// One-shot TCP forward: connect → initialize (with auth) → tools/call → read response → close.
-    async fn forward_to_tcp(&self, tool_name: &str, args: &serde_json::Value) -> String {
+    async fn forward_to_tcp(&self, tool_name: &str, args: &serde_json::Value) -> CallToolResult {
         match self.do_forward(tool_name, args).await {
-            Ok(result) => result,
-            Err(e) => {
-                eprintln!("[mcp-team-stdio] TCP forward error for {tool_name}: {e}");
-                format!("Error: {e}")
+            Ok(result) => tool_success(result),
+            Err(ToolForwardError::Boundary(err)) => {
+                eprintln!("{}", err.stderr_line());
+                tool_error(err.code(), tool_error_message(err.code()), None, None)
             }
+            Err(ToolForwardError::Tool {
+                code,
+                message,
+                upstream_code,
+                domain_code,
+            }) => tool_error(code, message, upstream_code, domain_code),
         }
     }
 
-    async fn do_forward(&self, tool_name: &str, args: &serde_json::Value) -> io::Result<String> {
-        let mut stream = TcpStream::connect((CONNECT_HOST, self.port)).await?;
+    async fn do_forward(&self, tool_name: &str, args: &serde_json::Value) -> Result<String, ToolForwardError> {
+        let mut stream = TcpStream::connect((CONNECT_HOST, self.port))
+            .await
+            .map_err(|_| tcp_connect_error(self.port))?;
         stream.set_nodelay(true).ok();
 
         // initialize with auth
@@ -375,12 +378,12 @@ impl TeamStdioServer {
                 "slot_id": self.slot_id,
             }
         });
-        write_frame(&mut stream, &serde_json::to_vec(&init_frame).unwrap()).await?;
-        let init_resp = read_frame(&mut stream).await?;
-        eprintln!(
-            "[mcp-team-stdio] init response: {}",
-            String::from_utf8_lossy(&init_resp[..init_resp.len().min(200)])
-        );
+        let init_bytes = serde_json::to_vec(&init_frame).map_err(|_| json_serialize_error())?;
+        write_frame(&mut stream, &init_bytes)
+            .await
+            .map_err(|_| tcp_write_error())?;
+        let init_resp = read_frame(&mut stream).await.map_err(|_| tcp_read_error())?;
+        drop(init_resp);
 
         // tools/call
         let call_frame = serde_json::json!({
@@ -392,44 +395,308 @@ impl TeamStdioServer {
                 "arguments": args,
             }
         });
-        write_frame(&mut stream, &serde_json::to_vec(&call_frame).unwrap()).await?;
-        let resp_bytes = read_frame(&mut stream).await?;
+        let call_bytes = serde_json::to_vec(&call_frame).map_err(|_| json_serialize_error())?;
+        write_frame(&mut stream, &call_bytes)
+            .await
+            .map_err(|_| tcp_write_error())?;
+        let resp_bytes = read_frame(&mut stream).await.map_err(|_| tcp_read_error())?;
 
         let text = String::from_utf8_lossy(&resp_bytes).into_owned();
-        eprintln!(
-            "[mcp-team-stdio] tool response preview: {}",
-            &text[..text.len().min(200)]
-        );
 
-        // Extract result string if JSON, otherwise return raw text
-        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
-            if let Some(result) = v.get("result").and_then(|r| r.as_str()) {
-                return Ok(result.to_owned());
-            }
-            if let Some(error) = v.get("error") {
-                return Ok(format!("Error: {error}"));
-            }
-        }
-        Ok(text)
+        parse_tool_response(&text)
     }
 }
 
-// ---------------------------------------------------------------------------
-// Frame helpers
-// ---------------------------------------------------------------------------
-
-async fn write_frame(stream: &mut TcpStream, data: &[u8]) -> io::Result<()> {
-    let len = (data.len() as u32).to_be_bytes();
-    stream.write_all(&len).await?;
-    stream.write_all(data).await?;
-    stream.flush().await
+#[derive(Debug)]
+enum ToolForwardError {
+    Boundary(CliBoundaryError),
+    Tool {
+        code: CliBoundaryCode,
+        message: &'static str,
+        upstream_code: Option<serde_json::Value>,
+        domain_code: Option<serde_json::Value>,
+    },
 }
 
-async fn read_frame(stream: &mut TcpStream) -> io::Result<Vec<u8>> {
-    let mut len_buf = [0u8; 4];
-    stream.read_exact(&mut len_buf).await?;
-    let len = u32::from_be_bytes(len_buf) as usize;
-    let mut buf = vec![0u8; len];
-    stream.read_exact(&mut buf).await?;
-    Ok(buf)
+impl From<CliBoundaryError> for ToolForwardError {
+    fn from(error: CliBoundaryError) -> Self {
+        Self::Boundary(error)
+    }
+}
+
+fn parse_tool_response(text: &str) -> Result<String, ToolForwardError> {
+    let value = serde_json::from_str::<serde_json::Value>(text).map_err(|_| tool_response_unexpected())?;
+    if value.get("error").is_some() {
+        return Err(remote_tool_error(
+            extract_nested_code(&value, &["error", "code"]),
+            extract_nested_code(&value, &["error", "data", "domainCode"])
+                .or_else(|| extract_nested_code(&value, &["error", "data", "code"]))
+                .or_else(|| extract_nested_code(&value, &["error", "data", "errorCode"])),
+        ));
+    }
+    let result = value.get("result").ok_or_else(tool_response_unexpected)?;
+    if let Some(result) = result.as_str() {
+        return Ok(result.to_owned());
+    }
+    if result
+        .get("isError")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+    {
+        return Err(remote_tool_error(
+            extract_nested_code(result, &["structuredContent", "upstreamCode"])
+                .or_else(|| extract_nested_code(result, &["upstreamCode"])),
+            extract_nested_code(result, &["structuredContent", "domainCode"])
+                .or_else(|| extract_nested_code(result, &["structuredContent", "code"]))
+                .or_else(|| extract_nested_code(result, &["structuredContent", "errorCode"]))
+                .or_else(|| extract_nested_code(result, &["domainCode"]))
+                .or_else(|| extract_nested_code(result, &["code"]))
+                .or_else(|| extract_nested_code(result, &["errorCode"])),
+        ));
+    }
+    if let Some(content) = result.get("content").and_then(serde_json::Value::as_array) {
+        let text_parts: Vec<&str> = content
+            .iter()
+            .filter_map(|item| item.get("text").and_then(serde_json::Value::as_str))
+            .collect();
+        if !text_parts.is_empty() {
+            return Ok(text_parts.join("\n"));
+        }
+    }
+    Err(tool_response_unexpected().into())
+}
+
+fn json_serialize_error() -> CliBoundaryError {
+    CliBoundaryError::new(CliBoundaryCode::McpJsonSerializeFailed, SUBCOMMAND, ERR_JSON_SERIALIZE)
+}
+
+fn tcp_connect_error(port: u16) -> CliBoundaryError {
+    CliBoundaryError::new(CliBoundaryCode::McpTcpConnectFailed, SUBCOMMAND, ERR_TCP_CONNECT)
+        .with_field("host", CONNECT_HOST)
+        .with_field("port", port.to_string())
+}
+
+fn tcp_write_error() -> CliBoundaryError {
+    CliBoundaryError::new(CliBoundaryCode::McpTcpWriteFailed, SUBCOMMAND, ERR_TCP_WRITE)
+}
+
+fn tcp_read_error() -> CliBoundaryError {
+    CliBoundaryError::new(CliBoundaryCode::McpTcpReadFailed, SUBCOMMAND, ERR_TCP_READ)
+}
+
+fn remote_tool_error(
+    upstream_code: Option<serde_json::Value>,
+    domain_code: Option<serde_json::Value>,
+) -> ToolForwardError {
+    ToolForwardError::Tool {
+        code: CliBoundaryCode::McpToolRemoteError,
+        message: ERR_TOOL_REMOTE,
+        upstream_code,
+        domain_code,
+    }
+}
+
+fn tool_response_unexpected() -> CliBoundaryError {
+    CliBoundaryError::new(
+        CliBoundaryCode::McpToolResponseUnexpected,
+        SUBCOMMAND,
+        ERR_TOOL_RESPONSE_UNEXPECTED,
+    )
+}
+
+fn tool_success(text: String) -> CallToolResult {
+    CallToolResult::success(vec![Content::text(text)])
+}
+
+fn tool_error(
+    code: CliBoundaryCode,
+    message: &'static str,
+    upstream_code: Option<serde_json::Value>,
+    domain_code: Option<serde_json::Value>,
+) -> CallToolResult {
+    let mut structured = serde_json::json!({
+        "code": code.as_str(),
+        "message": message,
+    });
+    if let Some(upstream_code) = upstream_code {
+        structured["upstreamCode"] = upstream_code;
+    }
+    if let Some(domain_code) = domain_code {
+        structured["domainCode"] = domain_code;
+    }
+
+    let mut result = CallToolResult::error(vec![Content::text(message)]);
+    result.structured_content = Some(structured);
+    result
+}
+
+fn extract_nested_code(value: &serde_json::Value, path: &[&str]) -> Option<serde_json::Value> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    match current {
+        serde_json::Value::String(_) | serde_json::Value::Number(_) => Some(current.clone()),
+        _ => None,
+    }
+}
+
+fn tool_error_message(code: CliBoundaryCode) -> &'static str {
+    match code {
+        CliBoundaryCode::McpJsonSerializeFailed => ERR_JSON_SERIALIZE,
+        CliBoundaryCode::McpTcpConnectFailed => ERR_TCP_CONNECT,
+        CliBoundaryCode::McpTcpWriteFailed => ERR_TCP_WRITE,
+        CliBoundaryCode::McpTcpReadFailed => ERR_TCP_READ,
+        CliBoundaryCode::McpToolRemoteError => ERR_TOOL_REMOTE,
+        CliBoundaryCode::McpToolResponseUnexpected => ERR_TOOL_RESPONSE_UNEXPECTED,
+        _ => "team stdio tool forwarding failed",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::cli_error::CliBoundaryCode;
+    use serde_json::json;
+    use tokio::net::TcpListener;
+
+    fn first_text(result: &CallToolResult) -> &str {
+        result.content[0].as_text().expect("text content").text.as_str()
+    }
+
+    #[test]
+    fn team_stdio_env_rejects_invalid_port_with_stable_code() {
+        let err = TeamStdioEnv::from_values("bad", "tok", "slot-a").unwrap_err();
+        assert_eq!(err.code(), CliBoundaryCode::McpEnvInvalidPort);
+        assert_eq!(err.exit_code(), std::process::ExitCode::from(2));
+    }
+
+    #[test]
+    fn team_stdio_env_accepts_valid_values() {
+        let env = TeamStdioEnv::from_values("12345", "tok", "slot-a").unwrap();
+        assert_eq!(env.port, 12345);
+        assert_eq!(env.token, "tok");
+        assert_eq!(env.slot_id, "slot-a");
+    }
+
+    #[tokio::test]
+    async fn forward_to_tcp_reports_read_failure_after_accept_close() {
+        let listener = TcpListener::bind((CONNECT_HOST, 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accept_task = tokio::spawn(async move {
+            let _ = listener.accept().await;
+        });
+        let server = TeamStdioServer {
+            port,
+            token: "dummy-token".into(),
+            slot_id: "dummy-slot".into(),
+        };
+
+        let result = server.forward_to_tcp("team_task_list", &json!({})).await;
+
+        accept_task.await.unwrap();
+        assert_eq!(result.is_error, Some(true));
+        assert_eq!(first_text(&result), "failed to read MCP frame from TCP listener");
+        assert_eq!(
+            result.structured_content.as_ref().unwrap()["code"],
+            "MCP_TCP_READ_FAILED"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_to_tcp_sanitizes_tool_level_error_result() {
+        let listener = TcpListener::bind((CONNECT_HOST, 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accept_task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let _init = read_frame(&mut socket).await.unwrap();
+            let init_response = serde_json::to_vec(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {}
+            }))
+            .unwrap();
+            write_frame(&mut socket, &init_response).await.unwrap();
+
+            let _call = read_frame(&mut socket).await.unwrap();
+            let tool_response = serde_json::to_vec(&json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "upstream failure for conv-secret-123"
+                        }
+                    ],
+                    "isError": true
+                }
+            }))
+            .unwrap();
+            write_frame(&mut socket, &tool_response).await.unwrap();
+        });
+        let server = TeamStdioServer {
+            port,
+            token: "dummy-token".into(),
+            slot_id: "dummy-slot".into(),
+        };
+
+        let result = server.forward_to_tcp("team_task_list", &json!({})).await;
+
+        accept_task.await.unwrap();
+        assert_eq!(result.is_error, Some(true));
+        assert_eq!(first_text(&result), "local team tool returned an error");
+        assert_eq!(
+            result.structured_content.as_ref().unwrap()["code"],
+            "MCP_TOOL_REMOTE_ERROR"
+        );
+        let serialized = serde_json::to_string(&result).unwrap();
+        assert!(!serialized.contains("conv-secret-123"));
+    }
+
+    #[test]
+    fn parse_tool_response_extracts_content_text() {
+        let result = parse_tool_response(
+            &json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "result": {
+                    "content": [
+                        { "type": "text", "text": "first line" },
+                        { "type": "text", "text": "second line" }
+                    ],
+                    "isError": false
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(result, "first line\nsecond line");
+    }
+
+    #[test]
+    fn parse_tool_response_sanitizes_top_level_error() {
+        let err = parse_tool_response(
+            &json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "error": {
+                    "code": -32000,
+                    "message": "remote failure for conv-secret-123"
+                }
+            })
+            .to_string(),
+        )
+        .unwrap_err();
+
+        let ToolForwardError::Tool {
+            code, upstream_code, ..
+        } = err
+        else {
+            panic!("expected tool error");
+        };
+        assert_eq!(code, CliBoundaryCode::McpToolRemoteError);
+        assert_eq!(upstream_code, Some(json!(-32000)));
+    }
 }

--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -11,7 +11,7 @@ mod services;
 
 pub use config::{AppConfig, derive_encryption_key};
 pub use router::{
-    ChannelOrchestratorComponents, ModuleStates, build_assistant_state, build_conversation_state,
+    ChannelOrchestratorComponents, ModuleStates, RouterBuildError, build_assistant_state, build_conversation_state,
     build_extension_states, build_module_states, build_ws_state, create_router, create_router_with_all_state,
     create_router_with_states,
 };

--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -1,16 +1,76 @@
 mod bootstrap;
 mod cli;
 mod commands;
+mod process_report;
 
 use std::process::ExitCode;
 
-use anyhow::Result;
 use clap::Parser;
 
 use aionui_app::AppServices;
 use cli::{Cli, Command};
 
-fn main() -> Result<ExitCode> {
+#[derive(Debug)]
+enum MainError {
+    Bootstrap(bootstrap::BootstrapError),
+    Cli(commands::cli_error::CliBoundaryError),
+    Other(anyhow::Error),
+}
+
+impl MainError {
+    fn report(&self) {
+        match self {
+            Self::Bootstrap(err) => {
+                err.log_source();
+                eprintln!("{}", err.stderr_line());
+            }
+            Self::Cli(err) => {
+                eprintln!("{}", err.stderr_line());
+            }
+            Self::Other(err) => {
+                eprintln!("CLI_INTERNAL_ERROR: {err}");
+            }
+        }
+    }
+
+    fn exit_code(&self) -> ExitCode {
+        match self {
+            Self::Bootstrap(err) => err.exit_code(),
+            Self::Cli(err) => err.exit_code(),
+            Self::Other(_) => ExitCode::from(1),
+        }
+    }
+}
+
+impl From<bootstrap::BootstrapError> for MainError {
+    fn from(error: bootstrap::BootstrapError) -> Self {
+        Self::Bootstrap(error)
+    }
+}
+
+impl From<commands::cli_error::CliBoundaryError> for MainError {
+    fn from(error: commands::cli_error::CliBoundaryError) -> Self {
+        Self::Cli(error)
+    }
+}
+
+impl From<anyhow::Error> for MainError {
+    fn from(error: anyhow::Error) -> Self {
+        Self::Other(error)
+    }
+}
+
+fn main() -> ExitCode {
+    match run_main() {
+        Ok(exit_code) => exit_code,
+        Err(error) => {
+            error.report();
+            error.exit_code()
+        }
+    }
+}
+
+fn run_main() -> Result<ExitCode, MainError> {
     let cli = Cli::parse();
 
     // mcp-* subcommands route into short-lived stdio helpers that live entirely
@@ -36,24 +96,116 @@ fn main() -> Result<ExitCode> {
     // `std::env::set_var` invoked inside `enhance_process_path`.
     let merged_path = unsafe { aionui_runtime::enhance_process_path() };
 
-    let runtime = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| runtime_init_error_for_command(&cli.command, error))?;
     runtime.block_on(async_main(merged_path, cli))
 }
 
-async fn async_main(merged_path: String, cli: Cli) -> Result<ExitCode> {
+fn runtime_init_error_for_command(command: &Option<Command>, error: std::io::Error) -> MainError {
+    if command_uses_bootstrap_runtime_boundary(command) {
+        return MainError::Bootstrap(
+            bootstrap::BootstrapError::new(
+                bootstrap::BootstrapErrorCode::RuntimeInitFailed,
+                "process.runtime",
+                "failed to initialize async runtime",
+            )
+            .with_source(error),
+        );
+    }
+
+    MainError::Cli(commands::cli_error::CliBoundaryError::new(
+        commands::cli_error::CliBoundaryCode::CliRuntimeInitFailed,
+        command_subcommand(command),
+        "failed to initialize async runtime",
+    ))
+}
+
+fn command_uses_bootstrap_runtime_boundary(command: &Option<Command>) -> bool {
+    command.is_none()
+}
+
+fn command_subcommand(command: &Option<Command>) -> &'static str {
+    match command {
+        None => "server",
+        Some(Command::McpBridge) => "mcp-bridge",
+        Some(Command::McpGuideStdio) => "mcp-guide-stdio",
+        Some(Command::McpTeamStdio) => "mcp-team-stdio",
+        Some(Command::Doctor) => "doctor",
+        Some(Command::PrepareManagedResources(_)) => "prepare-managed-resources",
+    }
+}
+
+async fn async_main(merged_path: String, cli: Cli) -> Result<ExitCode, MainError> {
     // MCP stdio helpers must not touch the database, logging setup, or `AppServices`.
     match cli.command {
         Some(Command::McpBridge) => Ok(commands::run_mcp_bridge().await),
         Some(Command::McpGuideStdio) => Ok(commands::run_team_guide().await),
         Some(Command::McpTeamStdio) => Ok(commands::run_team_stdio().await),
-        Some(Command::Doctor) => commands::run_doctor(&cli, &merged_path).await,
-        Some(Command::PrepareManagedResources(args)) => commands::run_prepare_managed_resources(args).await,
+        Some(Command::Doctor) => Ok(commands::run_doctor(&cli, &merged_path).await?),
+        Some(Command::PrepareManagedResources(args)) => Ok(commands::run_prepare_managed_resources(args).await?),
         None => {
             let mut env = bootstrap::init_environment(&cli, &merged_path)?;
             let listener = commands::bind_http_listener(&mut env.config).await?;
             let database = bootstrap::init_data_layer(&env.config).await?;
-            let services = AppServices::from_config(database, &env.config).await?;
-            commands::run_server(env, services, listener).await
+            let services = AppServices::from_config(database, &env.config).await.map_err(|error| {
+                bootstrap::BootstrapError::new(
+                    bootstrap::BootstrapErrorCode::ServiceInitFailed,
+                    "services.init",
+                    "failed to initialize application services",
+                )
+                .with_source(error)
+            })?;
+            Ok(commands::run_server(env, services, listener).await?)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn runtime_error(command: Option<Command>) -> MainError {
+        runtime_init_error_for_command(&command, std::io::Error::other("raw runtime source"))
+    }
+
+    #[test]
+    fn runtime_init_failure_for_server_uses_bootstrap_boundary() {
+        let MainError::Bootstrap(err) = runtime_error(None) else {
+            panic!("expected bootstrap error");
+        };
+
+        assert_eq!(err.code(), bootstrap::BootstrapErrorCode::RuntimeInitFailed);
+        assert_eq!(err.stage(), "process.runtime");
+        assert!(err.stderr_line().starts_with("BOOTSTRAP_RUNTIME_INIT_FAILED"));
+        assert!(!err.stderr_line().contains("raw runtime source"));
+    }
+
+    #[test]
+    fn runtime_init_failure_for_helper_uses_cli_boundary() {
+        let MainError::Cli(err) = runtime_error(Some(Command::McpTeamStdio)) else {
+            panic!("expected CLI error");
+        };
+
+        assert_eq!(err.code(), commands::cli_error::CliBoundaryCode::CliRuntimeInitFailed);
+        assert!(
+            err.stderr_line()
+                .starts_with("CLI_RUNTIME_INIT_FAILED subcommand=mcp-team-stdio")
+        );
+        assert!(!err.stderr_line().contains("raw runtime source"));
+    }
+
+    #[test]
+    fn runtime_init_failure_for_doctor_uses_cli_boundary() {
+        let MainError::Cli(err) = runtime_error(Some(Command::Doctor)) else {
+            panic!("expected CLI error");
+        };
+
+        assert_eq!(err.code(), commands::cli_error::CliBoundaryCode::CliRuntimeInitFailed);
+        assert!(
+            err.stderr_line()
+                .starts_with("CLI_RUNTIME_INIT_FAILED subcommand=doctor")
+        );
     }
 }

--- a/crates/aionui-app/src/process_report.rs
+++ b/crates/aionui-app/src/process_report.rs
@@ -1,0 +1,97 @@
+// Consumed by following CLI/bootstrap boundary tasks.
+#![allow(dead_code)]
+
+use std::process::ExitCode;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExitKind {
+    Internal,
+    Config,
+    Unavailable,
+}
+
+impl ExitKind {
+    pub(crate) fn exit_code(self) -> ExitCode {
+        match self {
+            Self::Internal => ExitCode::from(1),
+            Self::Config => ExitCode::from(2),
+            Self::Unavailable => ExitCode::from(3),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProcessReport {
+    pub(crate) code: &'static str,
+    pub(crate) message: &'static str,
+    pub(crate) exit_kind: ExitKind,
+    pub(crate) fields: Vec<(&'static str, String)>,
+}
+
+impl ProcessReport {
+    pub(crate) fn stderr_line(&self) -> String {
+        let mut line = self.code.to_owned();
+        for (key, value) in &self.fields {
+            line.push(' ');
+            line.push_str(key);
+            line.push('=');
+            line.push_str(&sanitize_field(value));
+        }
+        line.push_str(": ");
+        line.push_str(self.message);
+        line
+    }
+}
+
+fn sanitize_field(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| if ch.is_ascii_graphic() && ch != ':' { ch } else { '_' })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exit_kind_maps_to_process_exit_codes() {
+        assert_eq!(ExitKind::Internal.exit_code(), ExitCode::from(1));
+        assert_eq!(ExitKind::Config.exit_code(), ExitCode::from(2));
+        assert_eq!(ExitKind::Unavailable.exit_code(), ExitCode::from(3));
+    }
+
+    #[test]
+    fn stderr_line_starts_with_stable_code() {
+        let report = ProcessReport {
+            code: "MCP_ENV_MISSING",
+            message: "missing required environment variable",
+            exit_kind: ExitKind::Config,
+            fields: vec![
+                ("subcommand", "mcp-guide-stdio".into()),
+                ("env", "AION_MCP_PORT".into()),
+            ],
+        };
+
+        assert_eq!(
+            report.stderr_line(),
+            "MCP_ENV_MISSING subcommand=mcp-guide-stdio env=AION_MCP_PORT: missing required environment variable"
+        );
+        assert_eq!(report.exit_kind.exit_code(), ExitCode::from(2));
+    }
+
+    #[test]
+    fn stderr_line_sanitizes_field_values() {
+        let report = ProcessReport {
+            code: "BOOTSTRAP_BIND_FAILED",
+            message: "failed to bind HTTP listener",
+            exit_kind: ExitKind::Unavailable,
+            fields: vec![("stage", "bind.listener\nsecret".into())],
+        };
+
+        assert_eq!(
+            report.stderr_line(),
+            "BOOTSTRAP_BIND_FAILED stage=bind.listener_secret: failed to bind HTTP listener"
+        );
+    }
+}

--- a/crates/aionui-app/src/router/mod.rs
+++ b/crates/aionui-app/src/router/mod.rs
@@ -7,6 +7,6 @@ mod trace;
 
 pub use routes::{create_router, create_router_with_all_state, create_router_with_states};
 pub use state::{
-    ChannelOrchestratorComponents, ModuleStates, build_assistant_state, build_conversation_state,
+    ChannelOrchestratorComponents, ModuleStates, RouterBuildError, build_assistant_state, build_conversation_state,
     build_extension_states, build_module_states, build_ws_state,
 };

--- a/crates/aionui-app/src/router/routes.rs
+++ b/crates/aionui-app/src/router/routes.rs
@@ -37,7 +37,7 @@ use aionui_team::team_routes;
 use crate::services::AppServices;
 
 use super::health::{guide_mcp_status, health_check};
-use super::state::{ModuleStates, build_module_states, build_ws_state};
+use super::state::{ModuleStates, RouterBuildError, build_module_states, build_ws_state};
 use super::trace::with_access_log;
 
 /// Create the application router with all routes and global middleware.
@@ -46,7 +46,7 @@ use super::trace::with_access_log;
 /// 1. Security response headers (X-Frame-Options, etc.)
 /// 2. CSRF protection (Double Submit Cookie)
 /// 3. Route handlers (auth routes + system routes + conversation routes + file routes + health check)
-pub async fn create_router(services: &AppServices) -> Router {
+pub async fn create_router(services: &AppServices) -> Result<Router, RouterBuildError> {
     let boot = Instant::now();
     tracing::info!("startup: router assembly started");
 
@@ -60,7 +60,7 @@ pub async fn create_router(services: &AppServices) -> Router {
         }
     });
 
-    let (states, channel_components) = build_module_states(services).await;
+    let (states, channel_components) = build_module_states(services).await?;
     tracing::info!(elapsed_ms = boot.elapsed().as_millis(), "startup: module states built");
 
     // Wire TeamSessionService into Guide MCP server now that both are available.
@@ -88,7 +88,12 @@ pub async fn create_router(services: &AppServices) -> Router {
     let chan_factory = channel_components.plugin_factory;
     tokio::spawn(async move {
         if let Err(e) = chan_mgr.restore_plugins(&chan_factory).await {
-            tracing::warn!(error = %e, "failed to restore channel plugins");
+            tracing::warn!(
+                code = "BOOTSTRAP_DEGRADED_CHANNEL_RESTORE",
+                stage = "channel.restore",
+                error = %e,
+                "failed to restore channel plugins"
+            );
         }
     });
     tracing::info!(
@@ -105,7 +110,7 @@ pub async fn create_router(services: &AppServices) -> Router {
         elapsed_ms = boot.elapsed().as_millis(),
         "startup: router assembly completed"
     );
-    router
+    Ok(router)
 }
 
 /// Create the application router with custom module states.

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -43,6 +43,50 @@ use aionui_team::{TeamRouterState, TeamSessionService};
 use crate::config::derive_encryption_key;
 use crate::services::AppServices;
 
+#[derive(Debug)]
+pub struct RouterBuildError {
+    stage: &'static str,
+    message: &'static str,
+    source: Option<anyhow::Error>,
+}
+
+impl RouterBuildError {
+    pub fn new(stage: &'static str, message: &'static str) -> Self {
+        Self {
+            stage,
+            message,
+            source: None,
+        }
+    }
+
+    pub fn with_source(mut self, source: impl Into<anyhow::Error>) -> Self {
+        self.source = Some(source.into());
+        self
+    }
+
+    pub fn stage(&self) -> &'static str {
+        self.stage
+    }
+
+    pub fn message(&self) -> &'static str {
+        self.message
+    }
+}
+
+impl std::fmt::Display for RouterBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.stage, self.message)
+    }
+}
+
+impl std::error::Error for RouterBuildError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_ref()
+            .map(|source| source.as_ref() as &(dyn std::error::Error + 'static))
+    }
+}
+
 /// All module-level router states bundled into a single struct.
 ///
 /// Reduces parameter bloat on router constructors and makes it easy for
@@ -117,7 +161,9 @@ pub struct ChannelOrchestratorComponents {
 }
 
 /// Build all default `ModuleStates` from application services.
-pub async fn build_module_states(services: &AppServices) -> (ModuleStates, ChannelOrchestratorComponents) {
+pub async fn build_module_states(
+    services: &AppServices,
+) -> Result<(ModuleStates, ChannelOrchestratorComponents), RouterBuildError> {
     let boot = Instant::now();
     tracing::info!("startup: module state build started");
 
@@ -129,7 +175,12 @@ pub async fn build_module_states(services: &AppServices) -> (ModuleStates, Chann
 
     let scan_paths = resolve_scan_paths_for_data_dir(&services.data_dir);
     if let Err(error) = ext_state.registry.initialize_with_scan_paths(scan_paths).await {
-        tracing::warn!(error = %error, "extension registry initialize failed");
+        tracing::warn!(
+            code = "BOOTSTRAP_DEGRADED_EXTENSION_REGISTRY",
+            stage = "extension.registry.initialize",
+            error = %error,
+            "extension registry initialize failed"
+        );
     }
     tracing::info!(
         elapsed_ms = boot.elapsed().as_millis(),
@@ -192,7 +243,7 @@ pub async fn build_module_states(services: &AppServices) -> (ModuleStates, Chann
             service: agent_service,
         }),
         connection_test: build_module_state_phase(&boot, "connection_test", build_connection_test_state),
-        file: build_module_state_phase(&boot, "file", || build_file_state(services)),
+        file: build_module_state_phase(&boot, "file", || build_file_state(services))?,
         mcp: build_module_state_phase(&boot, "mcp", || build_mcp_state(services)),
         extension: ext_state,
         hub: hub_state,
@@ -216,7 +267,7 @@ pub async fn build_module_states(services: &AppServices) -> (ModuleStates, Chann
         "startup: module state build completed"
     );
 
-    (states, channel_components)
+    Ok((states, channel_components))
 }
 
 /// Build the default `AssistantRouterState` from application services.
@@ -321,20 +372,24 @@ pub fn build_connection_test_state() -> ConnectionTestRouterState {
 }
 
 /// Build the default `FileRouterState` from application services.
-pub fn build_file_state(services: &AppServices) -> FileRouterState {
+pub fn build_file_state(services: &AppServices) -> Result<FileRouterState, RouterBuildError> {
     let broadcaster = services.event_bus.clone();
     let allowed_roots = default_allowed_roots(Some(services.work_dir.as_path()));
     let browse_roots = BrowseRoots::new();
     let file_service = Arc::new(FileService::new(broadcaster.clone(), allowed_roots.clone()));
-    let watch_service = Arc::new(FileWatchService::new(broadcaster).expect("file watch service initialization"));
+    let watch_service = Arc::new(FileWatchService::new(broadcaster).map_err(file_watch_init_error)?);
     let snapshot_service = Arc::new(SnapshotService::new());
-    FileRouterState {
+    Ok(FileRouterState {
         file_service,
         watch_service,
         snapshot_service,
         allowed_roots,
         browse_roots,
-    }
+    })
+}
+
+fn file_watch_init_error(error: aionui_file::FileError) -> RouterBuildError {
+    RouterBuildError::new("router.file_watch", "failed to initialize file watch service").with_source(error)
 }
 
 /// Build the default `McpRouterState` from application services.
@@ -769,5 +824,14 @@ mod tests {
         assert_eq!(loaded[0].name, "demo-ext");
 
         services.database.close().await;
+    }
+
+    #[test]
+    fn file_watch_init_error_maps_to_bootstrap_server_failed() {
+        let err = file_watch_init_error(aionui_file::FileError::Internal("watch backend unavailable".into()));
+
+        assert_eq!(err.stage(), "router.file_watch");
+        assert_eq!(err.message(), "failed to initialize file watch service");
+        assert!(!err.to_string().contains("watch backend unavailable"));
     }
 }

--- a/crates/aionui-app/src/services.rs
+++ b/crates/aionui-app/src/services.rs
@@ -158,7 +158,12 @@ impl AppServices {
                 (Some(srv), Some(config))
             }
             Err(e) => {
-                tracing::warn!(error = %e, "Guide MCP server failed to start; solo create-team disabled");
+                tracing::warn!(
+                    code = "BOOTSTRAP_DEGRADED_GUIDE_MCP",
+                    stage = "guide_mcp.start",
+                    error = %e,
+                    "Guide MCP server failed to start; solo create-team disabled"
+                );
                 (None, None)
             }
         };

--- a/crates/aionui-app/tests/agent_integration_e2e.rs
+++ b/crates/aionui-app/tests/agent_integration_e2e.rs
@@ -195,7 +195,7 @@ async fn build_app_with_mock_tasks() -> (axum::Router, aionui_app::AppServices, 
     let mock_tm = Arc::new(MockTaskManager::new());
     let services = services.with_worker_task_manager(mock_tm.clone());
 
-    let router = aionui_app::create_router(&services).await;
+    let router = aionui_app::create_router(&services).await.expect("build router");
     (router, services, mock_tm)
 }
 

--- a/crates/aionui-app/tests/assistants_e2e.rs
+++ b/crates/aionui-app/tests/assistants_e2e.rs
@@ -131,7 +131,7 @@ async fn fixture() -> Fixture {
     // Bring up in-memory DB + services + default module states.
     let db = init_database_memory().await.unwrap();
     let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
-    let (mut states, _): (ModuleStates, _) = build_module_states(&services).await;
+    let (mut states, _): (ModuleStates, _) = build_module_states(&services).await.expect("build module states");
 
     // Replace the extension + hub + skill states with freshly-constructed
     // ones rooted at our temp dirs. The defaults built by

--- a/crates/aionui-app/tests/auth_e2e.rs
+++ b/crates/aionui-app/tests/auth_e2e.rs
@@ -18,7 +18,7 @@ use aionui_app::{AppConfig, AppServices};
 async fn build_app() -> (axum::Router, AppServices) {
     let db = aionui_db::init_database_memory().await.unwrap();
     let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
-    let router = aionui_app::create_router(&services).await;
+    let router = aionui_app::create_router(&services).await.expect("build router");
     (router, services)
 }
 

--- a/crates/aionui-app/tests/auxiliary_e2e.rs
+++ b/crates/aionui-app/tests/auxiliary_e2e.rs
@@ -67,7 +67,7 @@ async fn build_app() -> (axum::Router, aionui_app::AppServices) {
     let services = aionui_app::AppServices::from_config(db, &aionui_app::AppConfig::default())
         .await
         .unwrap();
-    let router = aionui_app::create_router(&services).await;
+    let router = aionui_app::create_router(&services).await.expect("build router");
     (router, services)
 }
 

--- a/crates/aionui-app/tests/common/mod.rs
+++ b/crates/aionui-app/tests/common/mod.rs
@@ -16,7 +16,7 @@ use aionui_system::VersionCheckService;
 pub async fn build_app() -> (axum::Router, AppServices) {
     let db = aionui_db::init_database_memory().await.unwrap();
     let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
-    let router = create_router(&services).await;
+    let router = create_router(&services).await.expect("build router");
     (router, services)
 }
 
@@ -30,7 +30,7 @@ pub async fn build_app() -> (axum::Router, AppServices) {
 pub async fn build_app_with_skill_paths(root: &std::path::Path) -> (axum::Router, AppServices, SkillPaths) {
     let db = aionui_db::init_database_memory().await.unwrap();
     let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
-    let (mut states, _) = build_module_states(&services).await;
+    let (mut states, _) = build_module_states(&services).await.expect("build module states");
 
     let builtin_dir = root.join("builtin-skills");
     let paths = SkillPaths {
@@ -66,7 +66,7 @@ pub async fn build_app_with_skill_paths(root: &std::path::Path) -> (axum::Router
 pub async fn build_app_with_noop_opener() -> (axum::Router, AppServices) {
     let db = aionui_db::init_database_memory().await.unwrap();
     let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
-    let (mut states, _) = build_module_states(&services).await;
+    let (mut states, _) = build_module_states(&services).await.expect("build module states");
     states.shell.shell_service = std::sync::Arc::new(aionui_shell::ShellService::new(std::sync::Arc::new(
         aionui_shell::NoopSystemOpener,
     )));
@@ -77,7 +77,7 @@ pub async fn build_app_with_noop_opener() -> (axum::Router, AppServices) {
 pub async fn build_app_with_file_roots(allowed_roots: Vec<std::path::PathBuf>) -> (axum::Router, AppServices) {
     let db = aionui_db::init_database_memory().await.unwrap();
     let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
-    let (mut states, _) = build_module_states(&services).await;
+    let (mut states, _) = build_module_states(&services).await.expect("build module states");
     states.file.file_service = std::sync::Arc::new(FileService::new(services.event_bus.clone(), allowed_roots));
     let router = create_router_with_states(&services, states);
     (router, services)
@@ -89,7 +89,7 @@ pub async fn build_app_with_mock_version(
 ) -> (axum::Router, AppServices) {
     let db = aionui_db::init_database_memory().await.unwrap();
     let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
-    let (mut states, _) = build_module_states(&services).await;
+    let (mut states, _) = build_module_states(&services).await.expect("build module states");
     states.system.version_check_service =
         VersionCheckService::with_api_base(reqwest::Client::new(), current_version.to_owned(), mock_server.uri());
     let router = create_router_with_states(&services, states);
@@ -122,7 +122,7 @@ pub async fn build_app_with_mock_agents() -> (axum::Router, AppServices) {
         .await
         .unwrap()
         .with_worker_task_manager(wtm);
-    let router = create_router(&services).await;
+    let router = create_router(&services).await.expect("build router");
     (router, services)
 }
 

--- a/crates/aionui-app/tests/extension_e2e.rs
+++ b/crates/aionui-app/tests/extension_e2e.rs
@@ -158,7 +158,7 @@ async fn build_app_with_extension_root(ext_root: &std::path::Path) -> (axum::Rou
         ..Default::default()
     };
     let services = AppServices::from_config(db, &config).await.unwrap();
-    let (states, _) = build_module_states(&services).await;
+    let (states, _) = build_module_states(&services).await.expect("build module states");
     states
         .extension
         .registry

--- a/crates/aionui-app/tests/health.rs
+++ b/crates/aionui-app/tests/health.rs
@@ -21,7 +21,7 @@ async fn response_json(body: Body) -> serde_json::Value {
 async fn build_app() -> axum::Router {
     let db = aionui_db::init_database_memory().await.unwrap();
     let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
-    aionui_app::create_router(&services).await
+    aionui_app::create_router(&services).await.expect("build router")
 }
 
 #[tokio::test]

--- a/crates/aionui-app/tests/local_mode.rs
+++ b/crates/aionui-app/tests/local_mode.rs
@@ -12,7 +12,7 @@ async fn test_local_mode_skips_auth() {
     };
     let services = aionui_app::AppServices::from_config(db, &config).await.unwrap();
 
-    let router = aionui_app::create_router(&services).await;
+    let router = aionui_app::create_router(&services).await.expect("build router");
 
     // Health check should work
     let response = router
@@ -39,7 +39,7 @@ async fn test_non_local_mode_requires_auth() {
         .await
         .unwrap();
 
-    let router = aionui_app::create_router(&services).await;
+    let router = aionui_app::create_router(&services).await.expect("build router");
 
     let response = router
         .oneshot(Request::builder().uri("/api/settings").body(Body::empty()).unwrap())

--- a/crates/aionui-app/tests/office_e2e.rs
+++ b/crates/aionui-app/tests/office_e2e.rs
@@ -50,7 +50,7 @@ async fn build_office_app_with_roots(
         ..Default::default()
     };
     let services = AppServices::from_config(db, &config).await.unwrap();
-    let (mut states, _) = build_module_states(&services).await;
+    let (mut states, _) = build_module_states(&services).await.expect("build module states");
 
     states.office = build_test_office_state(tmp.path(), allowed_roots);
 

--- a/crates/aionui-app/tests/skills_builtin_e2e.rs
+++ b/crates/aionui-app/tests/skills_builtin_e2e.rs
@@ -58,7 +58,7 @@ async fn fixture_embedded() -> Fixture {
     let services = aionui_app::AppServices::from_config(db, &aionui_app::AppConfig::default())
         .await
         .unwrap();
-    let (mut states, _): (ModuleStates, _) = build_module_states(&services).await;
+    let (mut states, _): (ModuleStates, _) = build_module_states(&services).await.expect("build module states");
 
     // Replace the skill state with a deterministic one rooted at tmp.
     // `build_module_states` builds a state pointing at `~/.aionui/`,

--- a/crates/aionui-app/tests/websocket_e2e.rs
+++ b/crates/aionui-app/tests/websocket_e2e.rs
@@ -27,7 +27,7 @@ struct TestApp {
 async fn start_app() -> TestApp {
     let db = aionui_db::init_database_memory().await.unwrap();
     let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
-    let router = create_router(&services).await;
+    let router = create_router(&services).await.expect("build router");
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/crates/aionui-db/src/database.rs
+++ b/crates/aionui-db/src/database.rs
@@ -36,6 +36,42 @@ pub struct Database {
     pool: SqlitePool,
 }
 
+#[derive(Debug)]
+pub struct DatabaseInitError {
+    stage: &'static str,
+    source: DbError,
+}
+
+impl DatabaseInitError {
+    pub fn new(stage: &'static str, source: DbError) -> Self {
+        Self { stage, source }
+    }
+
+    pub fn stage(&self) -> &'static str {
+        self.stage
+    }
+
+    pub fn into_source(self) -> DbError {
+        self.source
+    }
+
+    fn source(&self) -> &DbError {
+        &self.source
+    }
+}
+
+impl std::fmt::Display for DatabaseInitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.stage, self.source)
+    }
+}
+
+impl std::error::Error for DatabaseInitError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
 impl Database {
     /// Returns a reference to the underlying connection pool.
     pub fn pool(&self) -> &SqlitePool {
@@ -58,18 +94,26 @@ impl Database {
 /// failures attempt recovery by backing up the corrupted file and creating a
 /// fresh database. Migration mismatches and lock contention fail fast.
 pub async fn init_database(path: &Path) -> Result<Database, DbError> {
+    init_database_staged(path).await.map_err(DatabaseInitError::into_source)
+}
+
+pub async fn init_database_staged(path: &Path) -> Result<Database, DatabaseInitError> {
     if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
     {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| DbError::Init(format!("Failed to create database directory: {e}")))?;
+        std::fs::create_dir_all(parent).map_err(|e| {
+            DatabaseInitError::new(
+                "database.open",
+                DbError::Init(format!("Failed to create database directory: {e}")),
+            )
+        })?;
     }
 
-    match try_init_file(path).await {
+    match try_init_file_staged(path).await {
         Ok(db) => Ok(db),
-        Err(e) if path.exists() && should_attempt_recovery(&e) => {
+        Err(e) if path.exists() && should_attempt_recovery(e.source()) => {
             warn!("Database initialization failed, attempting recovery: {e}");
-            recover_and_retry(path, e).await
+            recover_and_retry(path, e.into_source()).await
         }
         Err(e) => Err(e),
     }
@@ -159,7 +203,7 @@ pub fn maybe_copy_legacy_database(target: &Path) -> Result<(), DbError> {
     Ok(())
 }
 
-async fn try_init_file(path: &Path) -> Result<Database, DbError> {
+async fn try_init_file_staged(path: &Path) -> Result<Database, DatabaseInitError> {
     // Serialize the whole file-backed startup path, not only the sqlx
     // migrator. Opening a fresh SQLite file also runs connection-level PRAGMAs
     // such as WAL setup, which can race before migrations start.
@@ -186,10 +230,12 @@ async fn try_init_file(path: &Path) -> Result<Database, DbError> {
         .max_connections(MAX_CONNECTIONS)
         .connect_with(opts)
         .await
-        .map_err(DbError::Query)?;
+        .map_err(|e| DatabaseInitError::new("database.open", DbError::Query(e)))?;
 
-    run_migrations(&pool).await?;
-    ensure_system_user(&pool).await?;
+    run_migrations_staged(&pool).await?;
+    ensure_system_user(&pool)
+        .await
+        .map_err(|e| DatabaseInitError::new("database.seed", e))?;
 
     info!("Database initialized at {}", path.display());
     Ok(Database { pool })
@@ -247,6 +293,12 @@ fn is_retryable_startup_file_error(error: &std::io::Error) -> bool {
 }
 
 async fn run_migrations(pool: &SqlitePool) -> Result<(), DbError> {
+    run_migrations_staged(pool)
+        .await
+        .map_err(DatabaseInitError::into_source)
+}
+
+async fn run_migrations_staged(pool: &SqlitePool) -> Result<(), DatabaseInitError> {
     // File-backed callers hold a cross-process startup lock before opening the
     // SQLite pool. sqlx-sqlite's Migrate impl has no-op
     // lock()/unlock() and the migrator does list_applied → apply without an
@@ -257,24 +309,31 @@ async fn run_migrations(pool: &SqlitePool) -> Result<(), DbError> {
     // `_sqlx_migrations` blows up with `UNIQUE constraint failed:
     // _sqlx_migrations.version`. The outer startup lock also covers
     // schema-repair and connection PRAGMAs before migration execution.
-    ensure_schema_columns(pool).await?;
+    ensure_schema_columns(pool)
+        .await
+        .map_err(|e| DatabaseInitError::new("database.schema_repair", e))?;
     // Migration 002 rebuilds tables via RENAME+DROP. Two pragmas are needed:
     // - foreign_keys=OFF: prevents DROP TABLE from triggering ON DELETE CASCADE
     // - legacy_alter_table=ON: prevents ALTER TABLE RENAME from rewriting FK
     //   references in other tables (SQLite 3.26+ rewrites them by default)
     // Both must be set outside a transaction (sqlx wraps each migration in one).
-    let mut conn = pool.acquire().await.map_err(DbError::Query)?;
+    let mut conn = pool
+        .acquire()
+        .await
+        .map_err(|e| DatabaseInitError::new("database.migration", DbError::Query(e)))?;
     sqlx::query("PRAGMA foreign_keys = OFF; PRAGMA legacy_alter_table = ON")
         .execute(&mut *conn)
         .await
-        .map_err(DbError::Query)?;
+        .map_err(|e| DatabaseInitError::new("database.migration", DbError::Query(e)))?;
 
-    let result = run_migrations_with_retry(&mut conn).await;
+    let result = run_migrations_with_retry(&mut conn)
+        .await
+        .map_err(|e| DatabaseInitError::new("database.migration", e));
 
     sqlx::query("PRAGMA foreign_keys = ON; PRAGMA legacy_alter_table = OFF")
         .execute(&mut *conn)
         .await
-        .map_err(DbError::Query)?;
+        .map_err(|e| DatabaseInitError::new("database.migration", DbError::Query(e)))?;
     result
 }
 
@@ -577,25 +636,36 @@ async fn ensure_system_user(pool: &SqlitePool) -> Result<(), DbError> {
     Ok(())
 }
 
-async fn recover_and_retry(path: &Path, original_error: DbError) -> Result<Database, DbError> {
+async fn recover_and_retry(path: &Path, original_error: DbError) -> Result<Database, DatabaseInitError> {
     let backup_path = format!("{}.backup.{}", path.display(), aionui_common::now_ms());
     warn!("Backing up corrupted database to: {backup_path}");
 
     std::fs::rename(path, &backup_path).map_err(|e| {
-        DbError::Init(format!(
-            "Recovery failed: could not backup corrupted database: {e}. \
-             Original error: {original_error}"
-        ))
+        DatabaseInitError::new(
+            "database.recovery",
+            DbError::Init(format!(
+                "Recovery failed: could not backup corrupted database: {e}. \
+                 Original error: {original_error}"
+            )),
+        )
     })?;
 
-    match try_init_file(path).await {
+    match try_init_file_staged(path).await {
         Ok(db) => {
-            warn!("Database recovered. Backup at: {backup_path}");
+            warn!(
+                code = "BOOTSTRAP_RECOVERED_DATABASE_CORRUPTION",
+                stage = "database.recovery",
+                backup_path = %backup_path,
+                "Database recovered after corruption-like startup failure"
+            );
             Ok(db)
         }
-        Err(retry_err) => Err(DbError::Init(format!(
-            "Recovery failed after backup: {retry_err}. Original error: {original_error}"
-        ))),
+        Err(retry_err) => Err(DatabaseInitError::new(
+            "database.recovery",
+            DbError::Init(format!(
+                "Recovery failed after backup: {retry_err}. Original error: {original_error}"
+            )),
+        )),
     }
 }
 

--- a/crates/aionui-db/src/lib.rs
+++ b/crates/aionui-db/src/lib.rs
@@ -6,7 +6,9 @@ mod error;
 pub mod models;
 mod repository;
 
-pub use database::{Database, init_database, init_database_memory, maybe_copy_legacy_database};
+pub use database::{
+    Database, DatabaseInitError, init_database, init_database_memory, init_database_staged, maybe_copy_legacy_database,
+};
 pub use error::DbError;
 pub use models::{
     AgentMetadataRow, AssistantOverrideRow, AssistantRow, ConversationArtifactRow, CreateAssistantParams,


### PR DESCRIPTION
## Summary
- add stable process-boundary stderr reporting for CLI/MCP helper failures
- canonicalize MCP bridge/team stdio/team guide boundary errors
- add bootstrap startup error codes and preserve safe failure sources through server startup

## Verification
- cargo test -p aionui-app commands::bridge
- cargo test -p aionui-app commands::team_stdio
- cargo test -p aionui-app commands::team_guide
- cargo test -p aionui-app bootstrap
- cargo test -p aionui-app commands::server
- cargo clippy -p aionui-app --tests -- -D warnings
- cargo fmt --all -- --check
- just push -u origin boii/error-model-canonicalize