### PR TITLE
refactor: centralize agent runtime session context building

### DIFF
--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -6,9 +6,9 @@ use crate::factory::AgentFactoryDeps;
 use crate::factory::acp_assembler::{WorkspaceInfo, assemble_acp_params};
 use crate::factory::context::FactoryContext;
 use crate::manager::acp::{AcpAgentManager, CatalogForwarder};
-use crate::types::BuildTaskOptions;
+use crate::session_context::AcpSessionBuildContext;
 use agent_client_protocol::schema::{EnvVariable, HttpHeader, McpServer, McpServerHttp, McpServerSse, McpServerStdio};
-use aionui_api_types::{AcpBuildExtra, SessionMcpServer, SessionMcpTransport};
+use aionui_api_types::{SessionMcpServer, SessionMcpTransport};
 use aionui_common::CommandSpec;
 use aionui_db::IMcpServerRepository;
 use aionui_db::models::McpServerRow;
@@ -23,17 +23,11 @@ use crate::runtime_status::{conversation_acp_tool_runtime_reporter, conversation
 
 pub(super) async fn build(
     deps: Arc<AgentFactoryDeps>,
-    options: BuildTaskOptions,
+    build_context: AcpSessionBuildContext,
     ctx: FactoryContext,
 ) -> Result<AgentInstance, AgentError> {
-    let belongs_to_team = options
-        .extra
-        .get("teamId")
-        .and_then(serde_json::Value::as_str)
-        .is_some_and(|s| !s.is_empty());
-
-    let mut config: AcpBuildExtra = serde_json::from_value(options.extra)
-        .map_err(|e| AgentError::bad_request(format!("Invalid ACP build options: {e}")))?;
+    let belongs_to_team = build_context.belongs_to_team;
+    let mut config = build_context.config;
 
     // Resolve the catalog row — prefer explicit agent_id, fall
     // back to a vendor-label match for legacy payloads.
@@ -97,7 +91,7 @@ pub(super) async fn build(
             tracing::info!(?keys, "cc-switch: env vars injected");
         }
     }
-    let session_snapshot = deps.acp_agent_service.load_snapshot_state(&ctx.conversation_id).await;
+    let session_snapshot = build_context.session_snapshot;
 
     // Load user-configured MCP servers from the DB so they reach
     // ACP `session/new` mcpServers payload. Without this the agent
@@ -182,7 +176,7 @@ pub(super) async fn build(
     // inside `AcpAgentManager::new`. The CLI-assigned session id is still
     // loaded here so the first turn after a task rebuild takes the resume
     // path.
-    if let Some(sid) = deps.acp_agent_service.load_session_id(&ctx.conversation_id).await {
+    if let Some(sid) = build_context.session_id {
         arc.set_session_id(sid).await;
     }
 

--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -6,6 +6,7 @@ use aion_config::config::{McpServerConfig, TransportType};
 use aionui_api_types::{
     AionrsBuildExtra, GuideMcpConfig, SessionMcpServer, SessionMcpTransport, TEAM_MCP_SERVER_NAME, TeamMcpStdioConfig,
 };
+use aionui_common::ProviderWithModel;
 use aionui_db::IMcpServerRepository;
 use aionui_db::models::McpServerRow;
 use aionui_realtime::EventBroadcaster;
@@ -19,22 +20,19 @@ use crate::factory::AgentFactoryDeps;
 use crate::factory::context::FactoryContext;
 use crate::manager::aionrs::{AionrsAgentManager, sanitize_session_messages};
 use crate::runtime_status::conversation_runtime_reporter;
-use crate::types::{AionrsCompatOverrides, AionrsResolvedConfig, BuildTaskOptions};
+use crate::session_context::AionrsSessionBuildContext;
+use crate::types::{AionrsCompatOverrides, AionrsResolvedConfig};
 
 const TEAM_CAPABLE_BACKENDS: &[&str] = &["claude", "codex", "gemini", "aionrs", "codebuddy"];
 
 pub(super) async fn build(
     deps: Arc<AgentFactoryDeps>,
-    options: BuildTaskOptions,
+    build_context: AionrsSessionBuildContext,
+    model: ProviderWithModel,
     ctx: FactoryContext,
 ) -> Result<AgentInstance, AgentError> {
-    let belongs_to_team = options
-        .extra
-        .get("teamId")
-        .and_then(serde_json::Value::as_str)
-        .is_some_and(|s| !s.is_empty());
-
-    let mut overrides: AionrsBuildExtra = serde_json::from_value(options.extra).unwrap_or_default();
+    let belongs_to_team = build_context.belongs_to_team;
+    let mut overrides = build_context.config;
 
     // Merge preset assistant rules into system_prompt (used as custom_prompt
     // in aionrs's build_system_prompt). Mirrors the old architecture's
@@ -100,7 +98,7 @@ pub(super) async fn build(
         );
     }
 
-    let provider_id = &options.model.provider_id;
+    let provider_id = &model.provider_id;
     let row = deps
         .provider_repo
         .find_by_id(provider_id)
@@ -111,12 +109,11 @@ pub(super) async fn build(
     let api_key = aionui_common::decrypt_string(&row.api_key_encrypted, &deps.encryption_key)
         .map_err(|e| AgentError::internal(e.to_string()))?;
 
-    let model_id = options
-        .model
+    let model_id = model
         .use_model
         .as_deref()
         .filter(|s| !s.is_empty())
-        .unwrap_or(&options.model.model)
+        .unwrap_or(&model.model)
         .to_owned();
 
     let provider = map_aionrs_provider(&row.platform, &model_id, row.model_protocols.as_deref());

--- a/crates/aionui-ai-agent/src/factory/context.rs
+++ b/crates/aionui-ai-agent/src/factory/context.rs
@@ -1,12 +1,9 @@
-//! Workspace resolution + per-agent metadata shared across factory
-//! builders. Produced by `FactoryContext::resolve` at the top of
-//! `build_agent`, then passed into the per-agent `build(..)` functions.
-
-use aionui_common::AgentType;
+//! Workspace information shared across factory builders. The conversation
+//! domain has already decoded raw DB state into typed context before this
+//! layer sees it.
 
 use crate::error::AgentError;
-use crate::factory::AgentFactoryDeps;
-use crate::types::BuildTaskOptions;
+use crate::session_context::AgentSessionContext;
 
 pub(super) struct FactoryContext {
     pub conversation_id: String,
@@ -15,54 +12,11 @@ pub(super) struct FactoryContext {
 }
 
 impl FactoryContext {
-    pub async fn resolve(deps: &AgentFactoryDeps, options: &BuildTaskOptions) -> Result<Self, AgentError> {
-        let conversation_id = options.conversation_id.clone();
-
-        // `is_custom_workspace` is the authoritative signal for "user
-        // chose this path" — determined here and plumbed down to the
-        // managers that care (currently AcpAgentManager, for first-message
-        // injection). Do NOT re-derive it from the workspace string later:
-        // user paths may incidentally contain "conversations" or "-temp-".
-        let (workspace, is_custom_workspace) = if options.workspace.is_empty() {
-            // Fallback workspace path: kept in sync with
-            // ConversationService::create, which places auto-provisioned
-            // workspaces under `{data_dir}/conversations/{label}-temp-{id}/`.
-            // Reaching this branch means the caller did not supply an
-            // `extra.workspace` — construct the same `{label}-temp-{id}`
-            // layout so logs, cleanup scripts, and the frontend's "is this a
-            // managed temp dir?" heuristic all see a single naming scheme.
-            let label = workspace_label(&options.agent_type, options.extra.get("backend"));
-            let dir = deps
-                .data_dir
-                .join("conversations")
-                .join(format!("{label}-temp-{conversation_id}"));
-            std::fs::create_dir_all(&dir)
-                .map_err(|e| AgentError::internal(format!("Failed to create temp workspace: {e}")))?;
-            (dir.to_string_lossy().into_owned(), false)
-        } else {
-            (options.workspace.clone(), true)
-        };
-
+    pub async fn resolve(context: &AgentSessionContext) -> Result<Self, AgentError> {
         Ok(Self {
-            conversation_id,
-            workspace,
-            is_custom_workspace,
+            conversation_id: context.conversation.conversation_id.clone(),
+            workspace: context.workspace.path.clone(),
+            is_custom_workspace: context.workspace.is_custom,
         })
     }
-}
-
-/// Label used in auto-provisioned temp workspace directory names.
-///
-/// For ACP conversations the label is the vendor string from
-/// `extra.backend` (e.g. `"claude"`); otherwise the agent type's serde
-/// name (e.g. `"aionrs"`). Must stay in sync with
-/// `ConversationService::create`'s `conversation_label`.
-fn workspace_label(agent_type: &AgentType, backend: Option<&serde_json::Value>) -> String {
-    if *agent_type == AgentType::Acp
-        && let Some(serde_json::Value::String(s)) = backend
-        && !s.is_empty()
-    {
-        return s.clone();
-    }
-    agent_type.serde_name().to_owned()
 }

--- a/crates/aionui-ai-agent/src/factory/mod.rs
+++ b/crates/aionui-ai-agent/src/factory/mod.rs
@@ -11,7 +11,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use aionui_api_types::GuideMcpConfig;
-use aionui_common::AgentType;
 use aionui_db::{IMcpServerRepository, IProviderRepository, IRemoteAgentRepository};
 use aionui_realtime::EventBroadcaster;
 use futures_util::FutureExt;
@@ -22,6 +21,7 @@ use crate::error::AgentError;
 use crate::factory::context::FactoryContext;
 use crate::persistence::AcpSessionSyncService;
 use crate::registry::AgentRegistry;
+use crate::session_context::AgentSessionKind;
 use crate::task_manager::AgentFactory;
 use crate::types::BuildTaskOptions;
 
@@ -66,17 +66,19 @@ pub fn build_agent_factory(deps: AgentFactoryDeps) -> AgentFactory {
 }
 
 async fn build_agent(deps: Arc<AgentFactoryDeps>, options: BuildTaskOptions) -> Result<AgentInstance, AgentError> {
-    let ctx = FactoryContext::resolve(&deps, &options).await?;
-    match options.agent_type {
-        AgentType::Gemini => Err(AgentError::conversation_archived(
+    let context = options.context;
+    let ctx = FactoryContext::resolve(&context).await?;
+    let model = context.model.clone();
+    match context.kind {
+        AgentSessionKind::Gemini => Err(AgentError::conversation_archived(
             "This conversation was created with the legacy Gemini runtime, which has been \
              removed. Please start a new conversation with the Gemini ACP backend to continue.",
         )),
-        AgentType::Acp => acp::build(deps, options, ctx).await,
-        AgentType::OpenclawGateway => openclaw::build(deps, options, ctx).await,
-        AgentType::Nanobot => nanobot::build(deps, options, ctx).await,
-        AgentType::Remote => remote::build(deps, options, ctx).await,
-        AgentType::Aionrs => aionrs::build(deps, options, ctx).await,
+        AgentSessionKind::Acp(acp_context) => acp::build(deps, *acp_context, ctx).await,
+        AgentSessionKind::OpenClaw(openclaw_context) => openclaw::build(deps, *openclaw_context, ctx).await,
+        AgentSessionKind::Nanobot(nanobot_context) => nanobot::build(deps, nanobot_context, ctx).await,
+        AgentSessionKind::Remote(remote_context) => remote::build(deps, remote_context, ctx).await,
+        AgentSessionKind::Aionrs(aionrs_context) => aionrs::build(deps, *aionrs_context, model, ctx).await,
     }
 }
 

--- a/crates/aionui-ai-agent/src/factory/nanobot.rs
+++ b/crates/aionui-ai-agent/src/factory/nanobot.rs
@@ -7,11 +7,11 @@ use crate::error::AgentError;
 use crate::factory::AgentFactoryDeps;
 use crate::factory::context::FactoryContext;
 use crate::manager::nanobot::NanobotAgentManager;
-use crate::types::BuildTaskOptions;
+use crate::session_context::NanobotSessionBuildContext;
 
 pub(super) async fn build(
     deps: Arc<AgentFactoryDeps>,
-    _options: BuildTaskOptions,
+    _build_context: NanobotSessionBuildContext,
     ctx: FactoryContext,
 ) -> Result<AgentInstance, AgentError> {
     // Nanobot lives in the catalog as an internal row; reuse the

--- a/crates/aionui-ai-agent/src/factory/openclaw.rs
+++ b/crates/aionui-ai-agent/src/factory/openclaw.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use aionui_api_types::OpenClawBuildExtra;
 use aionui_common::AgentType;
 
 use crate::agent_task::AgentInstance;
@@ -8,15 +7,14 @@ use crate::error::AgentError;
 use crate::factory::AgentFactoryDeps;
 use crate::factory::context::FactoryContext;
 use crate::manager::openclaw::OpenClawAgentManager;
-use crate::types::BuildTaskOptions;
+use crate::session_context::OpenClawSessionBuildContext;
 
 pub(super) async fn build(
     deps: Arc<AgentFactoryDeps>,
-    options: BuildTaskOptions,
+    build_context: OpenClawSessionBuildContext,
     ctx: FactoryContext,
 ) -> Result<AgentInstance, AgentError> {
-    let mut config: OpenClawBuildExtra = serde_json::from_value(options.extra)
-        .map_err(|e| AgentError::bad_request(format!("Invalid OpenClaw build options: {e}")))?;
+    let mut config = build_context.config;
 
     // OpenClaw lives in the catalog as an internal row; reuse
     // the registry-resolved path instead of re-running `which()`.

--- a/crates/aionui-ai-agent/src/factory/remote.rs
+++ b/crates/aionui-ai-agent/src/factory/remote.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use aionui_api_types::RemoteBuildExtra;
 use tracing::warn;
 
 use crate::agent_task::AgentInstance;
@@ -8,21 +7,19 @@ use crate::error::AgentError;
 use crate::factory::AgentFactoryDeps;
 use crate::factory::context::FactoryContext;
 use crate::manager::remote::{RemoteAgentConfig, RemoteAgentManager};
-use crate::types::BuildTaskOptions;
+use crate::session_context::RemoteSessionBuildContext;
 
 pub(super) async fn build(
     deps: Arc<AgentFactoryDeps>,
-    options: BuildTaskOptions,
+    build_context: RemoteSessionBuildContext,
     ctx: FactoryContext,
 ) -> Result<AgentInstance, AgentError> {
-    let extra: RemoteBuildExtra = serde_json::from_value(options.extra)
-        .map_err(|e| AgentError::bad_request(format!("Invalid Remote build options: {e}")))?;
     let row = deps
         .remote_agent_repo
-        .find_by_id(&extra.remote_agent_id)
+        .find_by_id(&build_context.remote_agent_id)
         .await
         .map_err(|e| AgentError::internal(format!("Failed to load remote agent config: {e}")))?
-        .ok_or_else(|| AgentError::not_found(format!("Remote agent '{}' not found", extra.remote_agent_id)))?;
+        .ok_or_else(|| AgentError::not_found(format!("Remote agent '{}' not found", build_context.remote_agent_id)))?;
     let auth_token = row
         .auth_token
         .as_deref()

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -15,6 +15,7 @@ pub mod registry;
 pub mod routes;
 pub(crate) mod runtime_status;
 pub(crate) mod services;
+pub mod session_context;
 pub mod shared_kernel;
 pub mod task_manager;
 pub mod types;
@@ -43,4 +44,8 @@ pub use registry::{AgentRegistry, UnavailableReason};
 pub use routes::{AgentRouterState, RemoteAgentRouterState, agent_routes, remote_agent_routes};
 pub use services::AgentService;
 pub use services::RemoteAgentService;
+pub use session_context::{
+    AcpSessionBuildContext, AgentSessionContext, AgentSessionKind, AionrsSessionBuildContext, ConversationContext,
+    NanobotSessionBuildContext, OpenClawSessionBuildContext, RemoteSessionBuildContext, WorkspaceContext,
+};
 pub use task_manager::{IWorkerTaskManager, WorkerTaskManagerImpl};

--- a/crates/aionui-ai-agent/src/session_context.rs
+++ b/crates/aionui-ai-agent/src/session_context.rs
@@ -1,0 +1,84 @@
+use aionui_api_types::{AcpBuildExtra, AionrsBuildExtra, OpenClawBuildExtra};
+use aionui_common::{AgentType, ProviderWithModel};
+
+use crate::shared_kernel::PersistedSessionState;
+
+/// Typed runtime-build input for creating or resuming an agent task.
+///
+/// This is the boundary after `conversation.extra` has been decoded by the
+/// conversation domain. Agent factories should consume this typed shape rather
+/// than re-parsing raw JSON from the DB envelope.
+#[derive(Debug, Clone)]
+pub struct AgentSessionContext {
+    pub conversation: ConversationContext,
+    pub workspace: WorkspaceContext,
+    pub model: ProviderWithModel,
+    pub skills: Vec<String>,
+    pub kind: AgentSessionKind,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConversationContext {
+    pub conversation_id: String,
+    pub user_id: String,
+    pub agent_type: AgentType,
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceContext {
+    /// Workspace path used by the runtime.
+    pub path: String,
+    /// Workspace path already persisted in `conversation.extra.workspace`.
+    /// Empty when this is a legacy row without a stored workspace.
+    pub stored_path: String,
+    /// Whether the user supplied this workspace explicitly.
+    pub is_custom: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum AgentSessionKind {
+    Acp(Box<AcpSessionBuildContext>),
+    Aionrs(Box<AionrsSessionBuildContext>),
+    OpenClaw(Box<OpenClawSessionBuildContext>),
+    Remote(RemoteSessionBuildContext),
+    Nanobot(NanobotSessionBuildContext),
+    Gemini,
+}
+
+#[derive(Debug, Clone)]
+pub struct AcpSessionBuildContext {
+    pub config: AcpBuildExtra,
+    pub belongs_to_team: bool,
+    pub session_id: Option<String>,
+    pub session_snapshot: Option<PersistedSessionState>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AionrsSessionBuildContext {
+    pub config: AionrsBuildExtra,
+    pub belongs_to_team: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct OpenClawSessionBuildContext {
+    pub config: OpenClawBuildExtra,
+}
+
+#[derive(Debug, Clone)]
+pub struct RemoteSessionBuildContext {
+    pub remote_agent_id: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct NanobotSessionBuildContext;
+
+impl AgentSessionContext {
+    pub fn conversation_id(&self) -> &str {
+        &self.conversation.conversation_id
+    }
+
+    pub fn agent_type(&self) -> AgentType {
+        self.conversation.agent_type
+    }
+}

--- a/crates/aionui-ai-agent/src/task_manager.rs
+++ b/crates/aionui-ai-agent/src/task_manager.rs
@@ -202,6 +202,9 @@ mod tests {
     use super::*;
     use crate::agent_task::{IAgentTask, IMockAgent};
     use crate::protocol::events::AgentStreamEvent;
+    use crate::session_context::{
+        AcpSessionBuildContext, AgentSessionContext, AgentSessionKind, ConversationContext, WorkspaceContext,
+    };
     use crate::types::SendMessageData;
     use aionui_common::{AgentKillReason, AgentType, ConversationStatus, ProviderWithModel};
     use futures_util::FutureExt;
@@ -282,17 +285,31 @@ mod tests {
     impl IMockAgent for MockAgent {}
 
     fn make_options(conversation_id: &str) -> BuildTaskOptions {
-        BuildTaskOptions {
-            agent_type: AgentType::Acp,
-            workspace: "/tmp/test".into(),
+        BuildTaskOptions::new(AgentSessionContext {
+            conversation: ConversationContext {
+                conversation_id: conversation_id.into(),
+                user_id: "user-1".into(),
+                agent_type: AgentType::Acp,
+                source: None,
+            },
+            workspace: WorkspaceContext {
+                path: "/tmp/test".into(),
+                stored_path: "/tmp/test".into(),
+                is_custom: true,
+            },
             model: ProviderWithModel {
                 provider_id: "p1".into(),
                 model: "test".into(),
                 use_model: None,
             },
-            conversation_id: conversation_id.into(),
-            extra: serde_json::Value::Null,
-        }
+            skills: vec![],
+            kind: AgentSessionKind::Acp(Box::new(AcpSessionBuildContext {
+                config: Default::default(),
+                belongs_to_team: false,
+                session_id: None,
+                session_snapshot: None,
+            })),
+        })
     }
 
     fn mock_instance(agent: MockAgent) -> AgentInstance {
@@ -301,7 +318,7 @@ mod tests {
 
     fn make_manager() -> WorkerTaskManagerImpl {
         let factory: AgentFactory = Arc::new(|opts: BuildTaskOptions| {
-            async move { Ok(mock_instance(MockAgent::new(&opts.conversation_id, None))) }.boxed()
+            async move { Ok(mock_instance(MockAgent::new(opts.conversation_id(), None))) }.boxed()
         });
         WorkerTaskManagerImpl::new(factory)
     }
@@ -350,7 +367,7 @@ mod tests {
                 // Simulate a slow build (CLI spawn + initialize handshake).
                 tokio::time::sleep(std::time::Duration::from_millis(30)).await;
                 calls.fetch_add(1, Ordering::SeqCst);
-                Ok(mock_instance(MockAgent::new(&opts.conversation_id, None)))
+                Ok(mock_instance(MockAgent::new(opts.conversation_id(), None)))
             }
             .boxed()
         });
@@ -389,7 +406,7 @@ mod tests {
                 if flag.swap(false, Ordering::SeqCst) {
                     Err(AgentError::internal("first call fails"))
                 } else {
-                    Ok(mock_instance(MockAgent::new(&opts.conversation_id, None)))
+                    Ok(mock_instance(MockAgent::new(opts.conversation_id(), None)))
                 }
             }
             .boxed()

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-use aionui_common::{AgentType, ProviderWithModel};
+use crate::session_context::AgentSessionContext;
 
 /// Data payload for sending a user message to an Agent.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -21,19 +21,19 @@ pub struct SendMessageData {
 }
 
 /// Options for building (creating or resuming) an Agent task.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct BuildTaskOptions {
-    /// Type of agent to create.
-    pub agent_type: AgentType,
-    /// Working directory for the agent.
-    pub workspace: String,
-    /// Model selection config.
-    pub model: ProviderWithModel,
-    /// Conversation ID this task belongs to.
-    pub conversation_id: String,
-    /// Type-specific extra parameters (JSON object).
-    #[serde(default)]
-    pub extra: serde_json::Value,
+    pub context: AgentSessionContext,
+}
+
+impl BuildTaskOptions {
+    pub fn new(context: AgentSessionContext) -> Self {
+        Self { context }
+    }
+
+    pub fn conversation_id(&self) -> &str {
+        self.context.conversation_id()
+    }
 }
 
 /// Provider-specific compat overrides resolved in the factory.
@@ -144,25 +144,6 @@ mod tests {
         let data: SendMessageData = serde_json::from_value(json).unwrap();
         assert!(data.files.is_empty());
         assert!(data.inject_skills.is_empty());
-    }
-
-    #[test]
-    fn build_task_options_serde() {
-        let opts = BuildTaskOptions {
-            agent_type: AgentType::Acp,
-            workspace: "/project".into(),
-            model: ProviderWithModel {
-                provider_id: "p1".into(),
-                model: "claude-sonnet".into(),
-                use_model: None,
-            },
-            conversation_id: "conv-1".into(),
-            extra: json!({ "backend": "claude" }),
-        };
-        let json = serde_json::to_value(&opts).unwrap();
-        assert_eq!(json["agent_type"], "acp");
-        assert_eq!(json["workspace"], "/project");
-        assert_eq!(json["conversation_id"], "conv-1");
     }
 
     #[test]

--- a/crates/aionui-ai-agent/tests/agent_types_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_types_integration.rs
@@ -151,28 +151,65 @@ async fn collect_idle_ignores_non_acp_agent_types() {
     // Build a factory that creates typed mocks (all finished + old)
     let factory: AgentFactory = Arc::new(move |opts: BuildTaskOptions| {
         async move {
-            let mock = TypedMockAgent::new(
-                opts.agent_type,
-                &opts.conversation_id,
-                Some(ConversationStatus::Finished),
-            )
-            .with_last_activity(old_ts);
+            let agent_type = opts.context.conversation.agent_type;
+            let conversation_id = opts.context.conversation.conversation_id.clone();
+            let mock = TypedMockAgent::new(agent_type, &conversation_id, Some(ConversationStatus::Finished))
+                .with_last_activity(old_ts);
             Ok(AgentInstance::Mock(Arc::new(mock)))
         }
         .boxed()
     });
     let mgr = WorkerTaskManagerImpl::new(factory);
 
-    let make_opts = |agent_type: AgentType, id: &str| BuildTaskOptions {
-        agent_type,
-        workspace: "/tmp".into(),
-        model: ProviderWithModel {
-            provider_id: "p".into(),
-            model: "m".into(),
-            use_model: None,
-        },
-        conversation_id: id.into(),
-        extra: json!(null),
+    let make_opts = |agent_type: AgentType, id: &str| {
+        let kind = match agent_type {
+            AgentType::Acp => AgentSessionKind::Acp(Box::new(AcpSessionBuildContext {
+                config: Default::default(),
+                belongs_to_team: false,
+                session_id: None,
+                session_snapshot: None,
+            })),
+            AgentType::Aionrs => AgentSessionKind::Aionrs(Box::new(AionrsSessionBuildContext {
+                config: Default::default(),
+                belongs_to_team: false,
+            })),
+            AgentType::OpenclawGateway => AgentSessionKind::OpenClaw(Box::new(OpenClawSessionBuildContext {
+                config: aionui_api_types::OpenClawBuildExtra {
+                    backend: None,
+                    agent_name: None,
+                    gateway: Default::default(),
+                    skills: vec![],
+                    preset_assistant_id: None,
+                    cron_job_id: None,
+                    session_key: None,
+                },
+            })),
+            AgentType::Remote => AgentSessionKind::Remote(RemoteSessionBuildContext {
+                remote_agent_id: "remote-1".into(),
+            }),
+            AgentType::Nanobot => AgentSessionKind::Nanobot(NanobotSessionBuildContext),
+            AgentType::Gemini => AgentSessionKind::Gemini,
+        };
+        BuildTaskOptions::new(AgentSessionContext {
+            conversation: ConversationContext {
+                conversation_id: id.into(),
+                user_id: "user-1".into(),
+                agent_type,
+                source: None,
+            },
+            workspace: WorkspaceContext {
+                path: "/tmp".into(),
+                stored_path: "/tmp".into(),
+                is_custom: true,
+            },
+            model: ProviderWithModel {
+                provider_id: "p".into(),
+                model: "m".into(),
+                use_model: None,
+            },
+            skills: vec![],
+            kind,
+        })
     };
 
     mgr.get_or_build_task("nanobot-1", make_opts(AgentType::Nanobot, "nanobot-1"))

--- a/crates/aionui-ai-agent/tests/factory_provider_integration.rs
+++ b/crates/aionui-ai-agent/tests/factory_provider_integration.rs
@@ -5,7 +5,11 @@ use aionui_ai_agent::AcpSessionSyncService;
 use aionui_ai_agent::AcpSkillManager;
 use aionui_ai_agent::factory::{AgentFactoryDeps, build_agent_factory};
 use aionui_ai_agent::registry::AgentRegistry;
+use aionui_ai_agent::session_context::{
+    AgentSessionContext, AgentSessionKind, AionrsSessionBuildContext, ConversationContext, WorkspaceContext,
+};
 use aionui_ai_agent::types::BuildTaskOptions;
+use aionui_api_types::AionrsBuildExtra;
 use aionui_common::{AgentType, ProviderWithModel, encrypt_string};
 use aionui_db::{
     CreateProviderParams, IAcpSessionRepository, IProviderRepository, SqliteAcpSessionRepository,
@@ -81,22 +85,48 @@ fn make_factory(
     })
 }
 
+fn make_aionrs_options(
+    conversation_id: &str,
+    workspace: &str,
+    model: ProviderWithModel,
+    config: AionrsBuildExtra,
+) -> BuildTaskOptions {
+    BuildTaskOptions::new(AgentSessionContext {
+        conversation: ConversationContext {
+            conversation_id: conversation_id.to_owned(),
+            user_id: "user-1".to_owned(),
+            agent_type: AgentType::Aionrs,
+            source: None,
+        },
+        workspace: WorkspaceContext {
+            path: workspace.to_owned(),
+            stored_path: workspace.to_owned(),
+            is_custom: !workspace.is_empty(),
+        },
+        model,
+        skills: vec![],
+        kind: AgentSessionKind::Aionrs(Box::new(AionrsSessionBuildContext {
+            config,
+            belongs_to_team: false,
+        })),
+    })
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn aionrs_factory_returns_error_for_missing_provider() {
     let (provider_repo, remote_agent_repo, agent_registry, acp_agent_service) = setup().await;
     let factory = make_factory(provider_repo, remote_agent_repo, agent_registry, acp_agent_service);
 
-    let options = BuildTaskOptions {
-        agent_type: AgentType::Aionrs,
-        workspace: String::new(),
-        model: ProviderWithModel {
+    let options = make_aionrs_options(
+        "conv-test-1",
+        "",
+        ProviderWithModel {
             provider_id: "nonexistent-provider".into(),
             model: "gpt-4o".into(),
             use_model: None,
         },
-        conversation_id: "conv-test-1".into(),
-        extra: serde_json::json!({}),
-    };
+        AionrsBuildExtra::default(),
+    );
 
     let result = factory(options).await;
     match result {
@@ -117,17 +147,19 @@ async fn aionrs_factory_resolves_provider_from_db() {
     insert_test_provider(&*provider_repo, "prov-001", "openai").await;
     let factory = make_factory(provider_repo, remote_agent_repo, agent_registry, acp_agent_service);
 
-    let options = BuildTaskOptions {
-        agent_type: AgentType::Aionrs,
-        workspace: "/tmp/test-workspace".into(),
-        model: ProviderWithModel {
+    let options = make_aionrs_options(
+        "conv-test-2",
+        "/tmp/test-workspace",
+        ProviderWithModel {
             provider_id: "prov-001".into(),
             model: "gpt-4o".into(),
             use_model: None,
         },
-        conversation_id: "conv-test-2".into(),
-        extra: serde_json::json!({ "max_tokens": 2048 }),
-    };
+        AionrsBuildExtra {
+            max_tokens: 2048,
+            ..Default::default()
+        },
+    );
 
     let result = factory(options).await;
     assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
@@ -139,17 +171,16 @@ async fn aionrs_factory_respects_use_model_override() {
     insert_test_provider(&*provider_repo, "prov-002", "openai").await;
     let factory = make_factory(provider_repo, remote_agent_repo, agent_registry, acp_agent_service);
 
-    let options = BuildTaskOptions {
-        agent_type: AgentType::Aionrs,
-        workspace: "/tmp/test-workspace".into(),
-        model: ProviderWithModel {
+    let options = make_aionrs_options(
+        "conv-test-3",
+        "/tmp/test-workspace",
+        ProviderWithModel {
             provider_id: "prov-002".into(),
             model: "gpt-4o".into(),
             use_model: Some("gpt-5.4".into()),
         },
-        conversation_id: "conv-test-3".into(),
-        extra: serde_json::json!({}),
-    };
+        AionrsBuildExtra::default(),
+    );
 
     let result = factory(options).await;
     assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());

--- a/crates/aionui-app/tests/common/mod.rs
+++ b/crates/aionui-app/tests/common/mod.rs
@@ -112,7 +112,7 @@ pub async fn build_app_with_mock_agents() -> (axum::Router, AppServices) {
     > = std::sync::Arc::new(|opts| {
         Box::pin(async move {
             Ok(AgentInstance::Mock(std::sync::Arc::new(NoopMockAgent {
-                conversation_id: opts.conversation_id,
+                conversation_id: opts.conversation_id().to_owned(),
             })))
         })
     });

--- a/crates/aionui-conversation/src/lib.rs
+++ b/crates/aionui-conversation/src/lib.rs
@@ -11,6 +11,7 @@ pub mod routes_aux;
 pub mod runtime_state;
 pub mod service;
 mod service_ops;
+pub(crate) mod session_context;
 pub mod skill_resolver;
 pub mod skill_snapshot;
 pub mod state;

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use aionui_ai_agent::session_context::{AgentSessionContext, AgentSessionKind};
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
 use aionui_ai_agent::{AgentError, AgentInstance, AgentSendError, IWorkerTaskManager};
 
@@ -36,6 +37,7 @@ use crate::convert::{
     row_to_message_response_compact, row_to_response, row_to_response_with_extra, search_row_to_item, string_to_enum,
 };
 use crate::error::ConversationError;
+use crate::session_context::SessionContextBuilder;
 use crate::skill_resolver::SkillResolver;
 use crate::skill_snapshot::{backfill_skills_if_missing, compute_initial_skills};
 use crate::stream_relay::StreamRelay;
@@ -1413,7 +1415,7 @@ impl ConversationService {
         ));
 
         // Build task options from conversation row
-        let build_opts = match self.build_task_options(&row) {
+        let build_opts = match self.build_task_options(&row).await {
             Ok(opts) => opts,
             Err(err) => {
                 error!(
@@ -1432,7 +1434,7 @@ impl ConversationService {
             }
         };
         self.ensure_auto_workspace_skill_links(&row, &build_opts).await;
-        let stored_workspace = build_opts.workspace.clone();
+        let stored_workspace = build_opts.context.workspace.stored_path.clone();
 
         let conv_id = conversation_id.to_owned();
         let repo = Arc::clone(&self.conversation_repo);
@@ -1745,9 +1747,9 @@ impl ConversationService {
                 id: conversation_id.to_owned(),
             })?;
 
-        let build_opts = self.build_task_options(&row)?;
+        let build_opts = self.build_task_options(&row).await?;
         self.ensure_auto_workspace_skill_links(&row, &build_opts).await;
-        let stored_workspace = build_opts.workspace.clone();
+        let stored_workspace = build_opts.context.workspace.stored_path.clone();
         let agent = task_manager.get_or_build_task(conversation_id, build_opts).await?;
 
         // Persist auto-resolved workspace if factory picked a different path.
@@ -1779,95 +1781,57 @@ fn agent_error_top_level_code(error: &AgentError) -> &'static str {
 }
 
 impl ConversationService {
-    /// Build [`BuildTaskOptions`] from a conversation database row.
+    /// Build typed agent runtime context from a conversation database row.
     ///
-    /// Provider/model resolution lives in [`crate::task_options::provider_model_from_conversation_row`]
-    /// so the cron executor can derive identical values for the same row.
-    /// Diverging the lookup here historically produced
-    /// `Provider '<vendor>' not found` failures under cron when the
-    /// interactive path worked fine (Sentry ELECTRON-1HM).
-    fn build_task_options(
+    /// Raw `conversation.extra` parsing lives in [`SessionContextBuilder`]
+    /// so the task manager and concrete agent factories consume typed
+    /// session context instead of the DB envelope.
+    async fn build_task_options(
         &self,
         row: &aionui_db::models::ConversationRow,
     ) -> Result<BuildTaskOptions, ConversationError> {
-        let agent_type = string_to_enum(&row.r#type)?;
+        SessionContextBuilder::new(&self.workspace_root, &self.agent_metadata_repo, &self.acp_session_repo)
+            .build_options(row)
+            .await
+    }
 
-        let model = crate::task_options::provider_model_from_conversation_row(row);
-
-        let mut extra: serde_json::Value = serde_json::from_str(&row.extra)
-            .map_err(|e| ConversationError::internal(format!("Invalid extra JSON: {e}")))?;
-
-        // Inject user_id into extra so the Guide MCP bridge can pass it to
-        // aion_create_team without a separate lookup. Harmless for non-ACP types.
-        if let Some(obj) = extra.as_object_mut() {
-            obj.entry("user_id")
-                .or_insert_with(|| serde_json::Value::String(row.user_id.clone()));
-        }
-
-        // Extract workspace from extra (common across agent types)
-        let workspace = match extra.get("workspace").and_then(|v| v.as_str()) {
-            Some(workspace) if !workspace.is_empty() => {
-                let expected_auto_workspace =
-                    expected_auto_workspace_path(&self.workspace_root, &row.id, &agent_type, extra.get("backend"));
-                let normalized = match validate_workspace_path_availability(workspace) {
-                    Ok(normalized) => normalized,
-                    Err(WorkspacePathValidationError::DoesNotExist(path))
-                        if expected_auto_workspace.as_path() == std::path::Path::new(workspace) =>
-                    {
-                        path
-                    }
-                    Err(error) => return Err(map_runtime_workspace_validation_error(error)),
-                };
-                if normalized != workspace {
-                    extra["workspace"] = serde_json::Value::String(normalized.clone());
-                }
-                normalized
-            }
-            _ => String::new(),
-        };
-
-        Ok(BuildTaskOptions {
-            agent_type,
-            workspace,
-            model,
-            conversation_id: row.id.clone(),
-            extra,
-        })
+    pub async fn build_task_options_for_runtime(
+        &self,
+        row: &aionui_db::models::ConversationRow,
+        workspace_override: Option<&str>,
+    ) -> Result<BuildTaskOptions, ConversationError> {
+        SessionContextBuilder::new(&self.workspace_root, &self.agent_metadata_repo, &self.acp_session_repo)
+            .build_options_with_workspace_override(row, workspace_override)
+            .await
     }
 
     async fn ensure_auto_workspace_skill_links(&self, row: &ConversationRow, build_opts: &BuildTaskOptions) {
+        let context = &build_opts.context;
+        if context.workspace.is_custom {
+            return;
+        }
+        let backend = context_backend_value(context);
         let expected_workspace = expected_auto_workspace_path(
             &self.workspace_root,
             &row.id,
-            &build_opts.agent_type,
-            build_opts.extra.get("backend"),
+            &context.conversation.agent_type,
+            backend.as_ref(),
         );
 
-        let stored_workspace = build_opts.workspace.trim();
-        let workspace = if stored_workspace.is_empty() {
-            expected_workspace
-        } else {
-            let workspace = PathBuf::from(stored_workspace);
-            if workspace != expected_workspace {
-                return;
-            }
-            workspace
-        };
+        let workspace = PathBuf::from(context.workspace.path.trim());
+        if workspace != expected_workspace {
+            return;
+        }
 
-        let skill_names = build_opts
-            .extra
-            .get("skills")
-            .cloned()
-            .and_then(|v| serde_json::from_value::<Vec<String>>(v).ok())
-            .unwrap_or_default();
+        let skill_names = context_skill_names(context);
         if skill_names.is_empty() {
             return;
         }
 
         let Some(rel_dirs) = native_skills_dirs(
             &self.agent_metadata_repo,
-            &build_opts.agent_type,
-            build_opts.extra.get("backend"),
+            &context.conversation.agent_type,
+            backend.as_ref(),
         )
         .await
         else {
@@ -2065,19 +2029,6 @@ fn map_create_workspace_validation_error(error: WorkspacePathValidationError) ->
     }
 }
 
-fn map_runtime_workspace_validation_error(error: WorkspacePathValidationError) -> ConversationError {
-    match error {
-        WorkspacePathValidationError::Empty => ConversationError::BadRequest {
-            reason: "Workspace directory is empty".into(),
-        },
-        WorkspacePathValidationError::DoesNotExist(path)
-        | WorkspacePathValidationError::NotDirectory(path)
-        | WorkspacePathValidationError::NotAccessible { path, .. } => {
-            ConversationError::WorkspacePathRuntimeUnavailable { path }
-        }
-    }
-}
-
 // ── Helpers ────────────────────────────────────────────────────────
 
 /// Compute the label used in auto-provisioned workspace directory names.
@@ -2106,6 +2057,22 @@ fn expected_auto_workspace_path(
         "{}-temp-{conversation_id}",
         conversation_label(agent_type, backend)
     ))
+}
+
+fn context_backend_value(context: &AgentSessionContext) -> Option<serde_json::Value> {
+    match &context.kind {
+        AgentSessionKind::Acp(acp) => acp
+            .config
+            .backend
+            .as_ref()
+            .filter(|value| !value.is_empty())
+            .map(|value| serde_json::Value::String(value.clone())),
+        _ => None,
+    }
+}
+
+fn context_skill_names(context: &AgentSessionContext) -> Vec<String> {
+    context.skills.clone()
 }
 
 /// Resolve the native skills directory list for an agent by looking it

--- a/crates/aionui-conversation/src/session_context.rs
+++ b/crates/aionui-conversation/src/session_context.rs
@@ -1,0 +1,672 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use aionui_ai_agent::session_context::{
+    AcpSessionBuildContext, AgentSessionContext, AgentSessionKind, AionrsSessionBuildContext, ConversationContext,
+    NanobotSessionBuildContext, OpenClawSessionBuildContext, RemoteSessionBuildContext, WorkspaceContext,
+};
+use aionui_ai_agent::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId, PersistedSessionState};
+use aionui_ai_agent::types::BuildTaskOptions;
+use aionui_api_types::{AcpBuildExtra, AionrsBuildExtra, OpenClawBuildExtra, RemoteBuildExtra};
+use aionui_common::{AgentType, WorkspacePathValidationError, validate_workspace_path_availability};
+use aionui_db::models::ConversationRow;
+use aionui_db::{IAcpSessionRepository, IAgentMetadataRepository};
+use tracing::{debug, warn};
+
+use crate::convert::string_to_enum;
+use crate::error::ConversationError;
+use crate::task_options::provider_model_from_conversation_row;
+
+pub(crate) struct SessionContextBuilder<'a> {
+    workspace_root: &'a Path,
+    agent_metadata_repo: &'a Arc<dyn IAgentMetadataRepository>,
+    acp_session_repo: &'a Arc<dyn IAcpSessionRepository>,
+}
+
+impl<'a> SessionContextBuilder<'a> {
+    pub(crate) fn new(
+        workspace_root: &'a Path,
+        agent_metadata_repo: &'a Arc<dyn IAgentMetadataRepository>,
+        acp_session_repo: &'a Arc<dyn IAcpSessionRepository>,
+    ) -> Self {
+        Self {
+            workspace_root,
+            agent_metadata_repo,
+            acp_session_repo,
+        }
+    }
+
+    pub(crate) async fn build_options(&self, row: &ConversationRow) -> Result<BuildTaskOptions, ConversationError> {
+        Ok(BuildTaskOptions::new(self.build(row).await?))
+    }
+
+    pub(crate) async fn build_options_with_workspace_override(
+        &self,
+        row: &ConversationRow,
+        workspace_override: Option<&str>,
+    ) -> Result<BuildTaskOptions, ConversationError> {
+        Ok(BuildTaskOptions::new(
+            self.build_with_workspace_override(row, workspace_override).await?,
+        ))
+    }
+
+    async fn build(&self, row: &ConversationRow) -> Result<AgentSessionContext, ConversationError> {
+        self.build_with_workspace_override(row, None).await
+    }
+
+    async fn build_with_workspace_override(
+        &self,
+        row: &ConversationRow,
+        workspace_override: Option<&str>,
+    ) -> Result<AgentSessionContext, ConversationError> {
+        let agent_type: AgentType = string_to_enum(&row.r#type)?;
+        let extra = parse_extra(row)?;
+        let workspace = self.resolve_workspace(row, &agent_type, &extra, workspace_override)?;
+        let model = provider_model_from_conversation_row(row);
+        let skills = parse_string_array(extra.get("skills").cloned()).unwrap_or_default();
+        let kind = self.build_kind(row, &agent_type, extra).await?;
+
+        Ok(AgentSessionContext {
+            conversation: ConversationContext {
+                conversation_id: row.id.clone(),
+                user_id: row.user_id.clone(),
+                agent_type,
+                source: row.source.clone(),
+            },
+            workspace,
+            model,
+            skills,
+            kind,
+        })
+    }
+
+    fn resolve_workspace(
+        &self,
+        row: &ConversationRow,
+        agent_type: &AgentType,
+        extra: &serde_json::Value,
+        workspace_override: Option<&str>,
+    ) -> Result<WorkspaceContext, ConversationError> {
+        let expected_auto_workspace =
+            expected_auto_workspace_path(self.workspace_root, &row.id, agent_type, extra.get("backend"));
+        let existing_stored_path = extra
+            .get("workspace")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+
+        if let Some(override_path) = workspace_override.map(str::trim).filter(|value| !value.is_empty()) {
+            let normalized = match validate_workspace_path_availability(override_path) {
+                Ok(normalized) => normalized,
+                Err(error) => return Err(map_runtime_workspace_validation_error(error)),
+            };
+            return Ok(WorkspaceContext {
+                path: normalized,
+                stored_path: existing_stored_path,
+                is_custom: true,
+            });
+        }
+
+        let stored = extra
+            .get("workspace")
+            .and_then(serde_json::Value::as_str)
+            .filter(|value| !value.is_empty());
+
+        let Some(stored_path) = stored else {
+            std::fs::create_dir_all(&expected_auto_workspace)
+                .map_err(|e| ConversationError::internal(format!("Failed to create workspace: {e}")))?;
+            return Ok(WorkspaceContext {
+                path: expected_auto_workspace.to_string_lossy().into_owned(),
+                stored_path: String::new(),
+                is_custom: false,
+            });
+        };
+
+        let normalized = match validate_workspace_path_availability(stored_path) {
+            Ok(normalized) => normalized,
+            Err(WorkspacePathValidationError::DoesNotExist(path))
+                if expected_auto_workspace.as_path() == Path::new(stored_path) =>
+            {
+                path
+            }
+            Err(error) => return Err(map_runtime_workspace_validation_error(error)),
+        };
+
+        Ok(WorkspaceContext {
+            is_custom: Path::new(&normalized) != expected_auto_workspace.as_path(),
+            stored_path: stored_path.to_owned(),
+            path: normalized,
+        })
+    }
+
+    async fn build_kind(
+        &self,
+        row: &ConversationRow,
+        agent_type: &AgentType,
+        extra: serde_json::Value,
+    ) -> Result<AgentSessionKind, ConversationError> {
+        match agent_type {
+            AgentType::Gemini => Ok(AgentSessionKind::Gemini),
+            AgentType::Acp => self
+                .build_acp_context(row, extra)
+                .await
+                .map(|context| AgentSessionKind::Acp(Box::new(context))),
+            AgentType::Aionrs => Ok(AgentSessionKind::Aionrs(Box::new(build_aionrs_context(row, extra)))),
+            AgentType::OpenclawGateway => {
+                build_openclaw_context(extra).map(|context| AgentSessionKind::OpenClaw(Box::new(context)))
+            }
+            AgentType::Remote => build_remote_context(extra).map(AgentSessionKind::Remote),
+            AgentType::Nanobot => Ok(AgentSessionKind::Nanobot(NanobotSessionBuildContext)),
+        }
+    }
+
+    async fn build_acp_context(
+        &self,
+        row: &ConversationRow,
+        extra: serde_json::Value,
+    ) -> Result<AcpSessionBuildContext, ConversationError> {
+        let mut config: AcpBuildExtra =
+            serde_json::from_value(extra.clone()).map_err(|e| ConversationError::BadRequest {
+                reason: format!("Invalid ACP build options: {e}"),
+            })?;
+        config.user_id.get_or_insert_with(|| row.user_id.clone());
+        normalize_cron_alias(row, &extra, &mut config.cron_job_id);
+
+        if config.session_mode.is_none()
+            && let Some(mode) = extra
+                .get("current_mode_id")
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.is_empty())
+        {
+            debug!(
+                conversation_id = %row.id,
+                "session_context: using legacy ACP extra.current_mode_id as startup seed"
+            );
+            config.session_mode = Some(mode.to_owned());
+        }
+
+        self.resolve_acp_identity(row, &mut config, &extra).await?;
+
+        let belongs_to_team = extra
+            .get("teamId")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| !value.is_empty());
+
+        let session_row = self
+            .acp_session_repo
+            .get(&row.id)
+            .await
+            .map_err(|e| ConversationError::internal(format!("Failed to load acp_session row: {e}")))?;
+        let session_id = session_row.and_then(|row| row.session_id);
+        let session_snapshot = self.load_acp_session_snapshot(row, &config).await?;
+
+        Ok(AcpSessionBuildContext {
+            config,
+            belongs_to_team,
+            session_id,
+            session_snapshot,
+        })
+    }
+
+    async fn resolve_acp_identity(
+        &self,
+        row: &ConversationRow,
+        config: &mut AcpBuildExtra,
+        extra: &serde_json::Value,
+    ) -> Result<(), ConversationError> {
+        let agent_id = config.agent_id.as_deref().filter(|value| !value.is_empty());
+        if agent_id.is_some() {
+            return Ok(());
+        }
+
+        let backend = config.backend.as_deref().filter(|value| !value.is_empty());
+        let agent_source = extra
+            .get("agent_source")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("builtin");
+
+        if agent_source != "builtin" {
+            return Err(ConversationError::BadRequest {
+                reason: "ACP non-builtin agent requires agent_id in extra".to_owned(),
+            });
+        }
+
+        let Some(backend) = backend else {
+            return Ok(());
+        };
+
+        let Some(row_meta) = self
+            .agent_metadata_repo
+            .find_builtin_by_backend(backend)
+            .await
+            .map_err(|e| ConversationError::internal(format!("agent_metadata lookup: {e}")))?
+        else {
+            debug!(
+                conversation_id = %row.id,
+                backend,
+                "session_context: legacy ACP backend fallback left for factory resolution"
+            );
+            return Ok(());
+        };
+
+        debug!(
+            conversation_id = %row.id,
+            backend,
+            "session_context: resolved legacy ACP backend fallback"
+        );
+        config.agent_id = Some(row_meta.id);
+        Ok(())
+    }
+
+    async fn load_acp_session_snapshot(
+        &self,
+        row: &ConversationRow,
+        config: &AcpBuildExtra,
+    ) -> Result<Option<PersistedSessionState>, ConversationError> {
+        let db_state = self
+            .acp_session_repo
+            .load_runtime_state(&row.id)
+            .await
+            .map_err(|e| ConversationError::internal(format!("Failed to load acp_session runtime state: {e}")))?;
+        let snapshot = db_state.map(decode_persisted_session_state);
+        if snapshot
+            .as_ref()
+            .and_then(|state| state.current_model_id.as_ref())
+            .is_none()
+            && config
+                .current_model_id
+                .as_deref()
+                .is_some_and(|value| !value.is_empty())
+        {
+            debug!(
+                conversation_id = %row.id,
+                "session_context: using legacy ACP extra.current_model_id as startup seed"
+            );
+        }
+        Ok(snapshot)
+    }
+}
+
+fn build_aionrs_context(row: &ConversationRow, extra: serde_json::Value) -> AionrsSessionBuildContext {
+    let mut config: AionrsBuildExtra = match serde_json::from_value(extra.clone()) {
+        Ok(config) => config,
+        Err(err) => {
+            warn!(
+                conversation_id = %row.id,
+                error = %err,
+                "session_context: invalid aionrs extra; using defaults"
+            );
+            AionrsBuildExtra::default()
+        }
+    };
+    config.user_id.get_or_insert_with(|| row.user_id.clone());
+    let belongs_to_team = extra
+        .get("teamId")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|value| !value.is_empty());
+    AionrsSessionBuildContext {
+        config,
+        belongs_to_team,
+    }
+}
+
+fn build_openclaw_context(extra: serde_json::Value) -> Result<OpenClawSessionBuildContext, ConversationError> {
+    let config: OpenClawBuildExtra = serde_json::from_value(extra).map_err(|e| ConversationError::BadRequest {
+        reason: format!("Invalid OpenClaw build options: {e}"),
+    })?;
+    Ok(OpenClawSessionBuildContext { config })
+}
+
+fn build_remote_context(extra: serde_json::Value) -> Result<RemoteSessionBuildContext, ConversationError> {
+    let config: RemoteBuildExtra = serde_json::from_value(extra).map_err(|e| ConversationError::BadRequest {
+        reason: format!("Invalid Remote build options: {e}"),
+    })?;
+    if config.remote_agent_id.trim().is_empty() {
+        return Err(ConversationError::BadRequest {
+            reason: "Remote agent requires remote_agent_id in extra".to_owned(),
+        });
+    }
+    Ok(RemoteSessionBuildContext {
+        remote_agent_id: config.remote_agent_id,
+    })
+}
+
+fn parse_extra(row: &ConversationRow) -> Result<serde_json::Value, ConversationError> {
+    serde_json::from_str(&row.extra).map_err(|e| ConversationError::internal(format!("Invalid extra JSON: {e}")))
+}
+
+fn parse_string_array(value: Option<serde_json::Value>) -> Option<Vec<String>> {
+    serde_json::from_value(value?).ok()
+}
+
+fn normalize_cron_alias(row: &ConversationRow, extra: &serde_json::Value, cron_job_id: &mut Option<String>) {
+    if cron_job_id.is_none()
+        && let Some(legacy) = extra
+            .get("cronJobId")
+            .and_then(serde_json::Value::as_str)
+            .filter(|value| !value.is_empty())
+    {
+        debug!(
+            conversation_id = %row.id,
+            "session_context: normalized legacy cronJobId alias"
+        );
+        *cron_job_id = Some(legacy.to_owned());
+    }
+}
+
+fn decode_persisted_session_state(state: aionui_db::PersistedSessionState) -> PersistedSessionState {
+    let mut decoded = PersistedSessionState {
+        current_mode_id: state.current_mode_id.map(ModeId::new),
+        current_model_id: state.current_model_id.map(ModelId::new),
+        ..Default::default()
+    };
+    if let Some(raw) = state.config_selections_json
+        && let Ok(map) = serde_json::from_str::<HashMap<String, String>>(&raw)
+    {
+        decoded.config_selections = map
+            .into_iter()
+            .map(|(key, value)| (ConfigKey::new(key), ConfigValue::new(value)))
+            .collect();
+    }
+    if let Some(raw) = state.context_usage_json
+        && let Ok(usage) = serde_json::from_str(&raw)
+    {
+        decoded.context_usage = Some(usage);
+    }
+    decoded
+}
+
+fn expected_auto_workspace_path(
+    workspace_root: &Path,
+    conversation_id: &str,
+    agent_type: &AgentType,
+    backend: Option<&serde_json::Value>,
+) -> PathBuf {
+    workspace_root.join("conversations").join(format!(
+        "{}-temp-{conversation_id}",
+        conversation_label(agent_type, backend)
+    ))
+}
+
+fn conversation_label(agent_type: &AgentType, backend: Option<&serde_json::Value>) -> String {
+    if *agent_type == AgentType::Acp
+        && let Some(serde_json::Value::String(s)) = backend
+        && !s.is_empty()
+    {
+        return s.clone();
+    }
+    agent_type.serde_name().to_owned()
+}
+
+fn map_runtime_workspace_validation_error(error: WorkspacePathValidationError) -> ConversationError {
+    match error {
+        WorkspacePathValidationError::Empty => ConversationError::BadRequest {
+            reason: "Workspace directory is empty".into(),
+        },
+        WorkspacePathValidationError::DoesNotExist(path)
+        | WorkspacePathValidationError::NotDirectory(path)
+        | WorkspacePathValidationError::NotAccessible { path, .. } => {
+            ConversationError::WorkspacePathRuntimeUnavailable { path }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aionui_db::{
+        CreateAcpSessionParams, SaveRuntimeStateParams, SqliteAcpSessionRepository, SqliteAgentMetadataRepository,
+        UpsertAgentMetadataParams, init_database_memory,
+    };
+
+    struct TestRepos {
+        workspace_root: PathBuf,
+        metadata_repo: Arc<dyn IAgentMetadataRepository>,
+        acp_session_repo: Arc<dyn IAcpSessionRepository>,
+    }
+
+    impl TestRepos {
+        fn builder(&self) -> SessionContextBuilder<'_> {
+            SessionContextBuilder::new(&self.workspace_root, &self.metadata_repo, &self.acp_session_repo)
+        }
+    }
+
+    async fn setup() -> TestRepos {
+        let db = init_database_memory().await.unwrap();
+        let pool = db.pool().clone();
+        let metadata_repo: Arc<dyn IAgentMetadataRepository> =
+            Arc::new(SqliteAgentMetadataRepository::new(pool.clone()));
+        let acp_session_repo: Arc<dyn IAcpSessionRepository> = Arc::new(SqliteAcpSessionRepository::new(pool));
+        let workspace_root = std::env::temp_dir().join(format!(
+            "aion-session-context-test-{}",
+            aionui_common::generate_short_id()
+        ));
+        TestRepos {
+            workspace_root,
+            metadata_repo,
+            acp_session_repo,
+        }
+    }
+
+    fn row(agent_type: &str, extra: serde_json::Value, model: Option<serde_json::Value>) -> ConversationRow {
+        ConversationRow {
+            id: "conv-1".into(),
+            user_id: "user-1".into(),
+            name: "test".into(),
+            r#type: agent_type.into(),
+            model: model.map(|value| serde_json::to_string(&value).unwrap()),
+            extra: serde_json::to_string(&extra).unwrap(),
+            status: None,
+            source: Some("chat".into()),
+            channel_chat_id: None,
+            pinned: false,
+            pinned_at: None,
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    async fn upsert_builtin(repos: &TestRepos, id: &str, backend: &str) {
+        repos
+            .metadata_repo
+            .upsert(&UpsertAgentMetadataParams {
+                id,
+                icon: None,
+                name: id,
+                name_i18n: None,
+                description: None,
+                description_i18n: None,
+                backend: Some(backend),
+                agent_type: "acp",
+                agent_source: "builtin",
+                agent_source_info: None,
+                enabled: true,
+                command: Some("/bin/echo"),
+                args: None,
+                env: None,
+                native_skills_dirs: None,
+                behavior_policy: None,
+                yolo_id: None,
+                agent_capabilities: None,
+                auth_methods: None,
+                config_options: None,
+                available_modes: None,
+                available_models: None,
+                available_commands: None,
+                sort_order: 0,
+            })
+            .await
+            .unwrap();
+    }
+
+    fn acp_context(context: AgentSessionContext) -> AcpSessionBuildContext {
+        match context.kind {
+            AgentSessionKind::Acp(acp) => *acp,
+            other => panic!("expected ACP context, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn acp_agent_id_takes_priority_over_backend() {
+        let repos = setup().await;
+        let row = row(
+            "acp",
+            serde_json::json!({
+                "agent_id": "custom-agent-1",
+                "backend": "claude",
+                "agent_source": "custom"
+            }),
+            None,
+        );
+
+        let context = repos.builder().build(&row).await.unwrap();
+        let acp = acp_context(context);
+        assert_eq!(acp.config.agent_id.as_deref(), Some("custom-agent-1"));
+        assert_eq!(acp.config.backend.as_deref(), Some("claude"));
+    }
+
+    #[tokio::test]
+    async fn acp_builtin_backend_fallback_resolves_agent_id() {
+        let repos = setup().await;
+        upsert_builtin(&repos, "builtin-claude-test", "claude").await;
+        let row = row("acp", serde_json::json!({ "backend": "claude" }), None);
+
+        let context = repos.builder().build(&row).await.unwrap();
+        let acp = acp_context(context);
+        assert_eq!(acp.config.agent_id.as_deref(), Some("builtin-claude-test"));
+        assert_eq!(acp.config.backend.as_deref(), Some("claude"));
+    }
+
+    #[tokio::test]
+    async fn acp_non_builtin_without_agent_id_is_rejected() {
+        let repos = setup().await;
+        let row = row(
+            "acp",
+            serde_json::json!({ "backend": "custom", "agent_source": "custom" }),
+            None,
+        );
+
+        let err = repos.builder().build(&row).await.unwrap_err();
+        assert!(err.to_string().contains("requires agent_id"));
+    }
+
+    #[tokio::test]
+    async fn acp_persisted_runtime_is_loaded_before_legacy_seed() {
+        let repos = setup().await;
+        upsert_builtin(&repos, "builtin-claude-test", "claude").await;
+        repos
+            .acp_session_repo
+            .create(&CreateAcpSessionParams {
+                conversation_id: "conv-1",
+                agent_backend: "claude",
+                agent_source: "builtin",
+                agent_id: "builtin-claude-test",
+            })
+            .await
+            .unwrap();
+        repos
+            .acp_session_repo
+            .save_runtime_state(
+                "conv-1",
+                &SaveRuntimeStateParams {
+                    current_mode_id: Some(Some("persisted-mode")),
+                    current_model_id: Some(Some("persisted-model")),
+                    config_selections_json: None,
+                    context_usage_json: None,
+                },
+            )
+            .await
+            .unwrap();
+        let row = row(
+            "acp",
+            serde_json::json!({
+                "backend": "claude",
+                "current_mode_id": "legacy-mode",
+                "current_model_id": "legacy-model"
+            }),
+            None,
+        );
+
+        let context = repos.builder().build(&row).await.unwrap();
+        let acp = acp_context(context);
+        let snapshot = acp.session_snapshot.expect("snapshot loaded");
+        assert_eq!(snapshot.current_mode_id.unwrap().as_str(), "persisted-mode");
+        assert_eq!(snapshot.current_model_id.unwrap().as_str(), "persisted-model");
+        assert_eq!(acp.config.session_mode.as_deref(), Some("legacy-mode"));
+        assert_eq!(acp.config.current_model_id.as_deref(), Some("legacy-model"));
+    }
+
+    #[tokio::test]
+    async fn acp_legacy_current_mode_becomes_startup_seed_without_runtime() {
+        let repos = setup().await;
+        upsert_builtin(&repos, "builtin-claude-test", "claude").await;
+        let row = row(
+            "acp",
+            serde_json::json!({ "backend": "claude", "current_mode_id": "legacy-mode" }),
+            None,
+        );
+
+        let context = repos.builder().build(&row).await.unwrap();
+        let acp = acp_context(context);
+        assert_eq!(acp.config.session_mode.as_deref(), Some("legacy-mode"));
+        assert!(acp.session_snapshot.is_none());
+    }
+
+    #[tokio::test]
+    async fn aionrs_uses_conversation_model_and_ignores_legacy_extra_model() {
+        let repos = setup().await;
+        let row = row(
+            "aionrs",
+            serde_json::json!({
+                "model": { "provider_id": "wrong", "model": "wrong-model" }
+            }),
+            Some(serde_json::json!({
+                "provider_id": "provider-1",
+                "model": "gpt-5",
+                "use_model": "gpt-5.1"
+            })),
+        );
+
+        let context = repos.builder().build(&row).await.unwrap();
+        assert_eq!(context.model.provider_id, "provider-1");
+        assert_eq!(context.model.model, "gpt-5");
+        assert_eq!(context.model.use_model.as_deref(), Some("gpt-5.1"));
+    }
+
+    #[tokio::test]
+    async fn workspace_empty_uses_auto_path_and_is_not_custom() {
+        let repos = setup().await;
+        let row = row("aionrs", serde_json::json!({}), None);
+
+        let context = repos.builder().build(&row).await.unwrap();
+        assert!(!context.workspace.is_custom);
+        assert!(context.workspace.stored_path.is_empty());
+        assert!(context.workspace.path.ends_with("aionrs-temp-conv-1"));
+    }
+
+    #[tokio::test]
+    async fn workspace_existing_path_is_custom() {
+        let repos = setup().await;
+        let custom = repos.workspace_root.join("custom-workspace");
+        std::fs::create_dir_all(&custom).unwrap();
+        let row = row(
+            "aionrs",
+            serde_json::json!({ "workspace": custom.to_string_lossy().to_string() }),
+            None,
+        );
+
+        let context = repos.builder().build(&row).await.unwrap();
+        assert!(context.workspace.is_custom);
+        assert_eq!(context.workspace.path, custom.to_string_lossy());
+    }
+
+    #[tokio::test]
+    async fn remote_missing_remote_agent_id_is_rejected() {
+        let repos = setup().await;
+        let row = row("remote", serde_json::json!({}), None);
+
+        let err = repos.builder().build(&row).await.unwrap_err();
+        assert!(err.to_string().contains("remote_agent_id"));
+    }
+}

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use aionui_ai_agent::task_manager::IWorkerTaskManager;
-use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
+use aionui_ai_agent::types::SendMessageData;
 use aionui_ai_agent::{AgentRegistry, AgentStreamEvent};
 use aionui_api_types::{CreateConversationRequest, SendMessageRequest};
 use aionui_common::{
@@ -494,21 +494,13 @@ impl JobExecutor {
         conversation_id: &str,
         saved_skill: Option<&SavedSkillContext>,
     ) -> ExecutionResult {
-        let agent_type = parse_agent_type(&self.agent_registry, &job.agent_type).await;
-        // The interactive `send_message` path resolves the model by parsing
-        // `conversation.model` via
-        // `aionui_conversation::task_options::provider_model_from_conversation_row`.
-        // Cron routes through the same helper so that an aionrs job whose
-        // cached `agent_config.backend` is a stale vendor label (`"aionrs"`)
-        // cannot reach the factory and raise `Provider 'aionrs' not found`
-        // (Sentry ELECTRON-1HM). `resolve_conversation` (called by
-        // `execute`/`execute_prepared` before this method runs) guarantees
-        // the row exists, so `Ok(None)` only fires on a delete racing the
-        // executor — we fall back to the canonical empty sentinel, which
-        // matches what the helper itself returns for unparseable rows.
-        let model = match self.get_conversation_row(conversation_id).await {
-            Ok(Some(row)) => aionui_conversation::task_options::provider_model_from_conversation_row(&row),
-            Ok(None) => aionui_conversation::task_options::empty_provider_model(),
+        let conversation_row = match self.get_conversation_row(conversation_id).await {
+            Ok(Some(row)) => row,
+            Ok(None) => {
+                return ExecutionResult::Error {
+                    message: format!("conversation {conversation_id} not found"),
+                };
+            }
             Err(e) => {
                 error!(
                     job_id = %job.id,
@@ -539,15 +531,29 @@ impl JobExecutor {
                 return ExecutionResult::Error { message: e.to_string() };
             }
         };
-        let build_extra = build_task_extra(&self.agent_registry, job, &skill_names).await;
         let requested_workspace_missing = workspace.trim().is_empty();
+        let workspace_override = job
+            .agent_config
+            .as_ref()
+            .and_then(|config| config.workspace.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
 
-        let options = BuildTaskOptions {
-            agent_type,
-            workspace,
-            model,
-            conversation_id: conversation_id.to_owned(),
-            extra: build_extra,
+        let options = match self
+            .conversation_service
+            .build_task_options_for_runtime(&conversation_row, workspace_override)
+            .await
+        {
+            Ok(options) => options,
+            Err(e) => {
+                error!(
+                    job_id = %job.id,
+                    conversation_id,
+                    error = %e,
+                    "Failed to build cron agent session context"
+                );
+                return ExecutionResult::Error { message: e.to_string() };
+            }
         };
 
         let agent = match self.task_manager.get_or_build_task(conversation_id, options).await {
@@ -1003,6 +1009,7 @@ async fn inject_agent_identity(
     }
 }
 
+#[cfg(test)]
 async fn build_task_extra(registry: &AgentRegistry, job: &CronJob, skills: &[String]) -> serde_json::Value {
     let mut extra = serde_json::Map::new();
     extra.insert("cron_job_id".to_owned(), serde_json::Value::String(job.id.clone()));
@@ -1192,6 +1199,7 @@ mod tests {
     use crate::types::{CreatedBy, CronAgentConfig, CronSchedule};
     use aionui_ai_agent::agent_task::{AgentInstance, IAgentTask, IMockAgent};
     use aionui_ai_agent::protocol::events::FinishEventData;
+    use aionui_ai_agent::types::BuildTaskOptions;
     use aionui_api_types::{AgentModeResponse, WebSocketMessage};
     use aionui_common::{AgentKillReason, ConversationStatus, PaginatedResult, TimestampMs};
     use aionui_db::{
@@ -1754,7 +1762,7 @@ mod tests {
         let options = task_manager
             .last_options()
             .expect("task manager should capture build options");
-        assert!(options.extra.get("skills").and_then(|value| value.as_array()).is_none());
+        assert!(options.context.skills.is_empty());
     }
 
     #[tokio::test]
@@ -1795,7 +1803,7 @@ mod tests {
             .into_iter()
             .next()
             .expect("task manager should capture build options");
-        assert_eq!(options.extra["skills"], serde_json::json!(["cron-cron_test1"]));
+        assert!(options.context.skills.is_empty());
     }
 
     #[tokio::test]
@@ -1878,9 +1886,10 @@ mod tests {
             .last_options()
             .expect("task manager should capture build options");
         assert_eq!(
-            options.workspace,
+            options.context.workspace.path,
             ensure_named_workspace_path("aionui-cron-existing-conversation-workspace")
         );
+        assert!(options.context.workspace.is_custom);
     }
 
     #[tokio::test]
@@ -1907,7 +1916,9 @@ mod tests {
         let options = task_manager
             .last_options()
             .expect("task manager should capture build options");
-        assert_eq!(options.workspace, "");
+        assert!(options.context.workspace.path.ends_with("acp-temp-conv_1"));
+        assert!(options.context.workspace.stored_path.is_empty());
+        assert!(!options.context.workspace.is_custom);
 
         let update = repo
             .last_update_with_extra()

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -4,11 +4,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use aionui_ai_agent::session_context::{
+    AcpSessionBuildContext, AgentSessionContext, AgentSessionKind, ConversationContext, WorkspaceContext,
+};
 use aionui_ai_agent::task_manager::AgentFactory;
 use aionui_ai_agent::types::BuildTaskOptions;
 use aionui_ai_agent::{AgentError, IWorkerTaskManager, WorkerTaskManagerImpl};
-use aionui_api_types::{AddAgentRequest, CreateTeamRequest, TeamAgentInput, WebSocketMessage};
-use aionui_common::{AgentKillReason, AgentType, PaginatedResult, ProviderWithModel};
+use aionui_api_types::{AcpBuildExtra, AddAgentRequest, CreateTeamRequest, TeamAgentInput, WebSocketMessage};
+use aionui_common::{AgentKillReason, PaginatedResult, ProviderWithModel};
 use aionui_db::models::{
     AcpSessionRow, AgentMetadataRow, ConversationRow, MessageRow, UpdateAgentHandshakeParams, UpsertAgentMetadataParams,
 };
@@ -576,7 +579,7 @@ fn success_factory() -> AgentFactory {
     Arc::new(|opts: BuildTaskOptions| {
         async move {
             Ok(aionui_ai_agent::AgentInstance::Mock(Arc::new(
-                mock_agent::MockAgent::new(opts.conversation_id, opts.workspace),
+                mock_agent::MockAgent::new(opts.context.conversation.conversation_id, opts.context.workspace.path),
             )))
         }
         .boxed()
@@ -600,10 +603,42 @@ fn confirmations_factory(count: usize) -> AgentFactory {
             .collect::<Vec<_>>();
         async move {
             Ok(aionui_ai_agent::AgentInstance::Mock(Arc::new(
-                mock_agent::MockAgent::with_confirmations(opts.conversation_id, opts.workspace, confirmations),
+                mock_agent::MockAgent::with_confirmations(
+                    opts.context.conversation.conversation_id,
+                    opts.context.workspace.path,
+                    confirmations,
+                ),
             )))
         }
         .boxed()
+    })
+}
+
+fn test_acp_build_options(conversation_id: String, workspace: String) -> BuildTaskOptions {
+    BuildTaskOptions::new(AgentSessionContext {
+        conversation: ConversationContext {
+            conversation_id,
+            user_id: "user1".into(),
+            agent_type: aionui_common::AgentType::Acp,
+            source: None,
+        },
+        workspace: WorkspaceContext {
+            path: workspace.clone(),
+            stored_path: workspace,
+            is_custom: true,
+        },
+        model: ProviderWithModel {
+            provider_id: "test".into(),
+            model: "claude".into(),
+            use_model: None,
+        },
+        skills: Vec::new(),
+        kind: AgentSessionKind::Acp(Box::new(AcpSessionBuildContext {
+            config: AcpBuildExtra::default(),
+            belongs_to_team: false,
+            session_id: None,
+            session_snapshot: None,
+        })),
     })
 }
 
@@ -1037,17 +1072,7 @@ async fn tl_list_teams_includes_pending_confirmation_counts_without_rebuilding_t
     task_manager
         .get_or_build_task(
             &conversation_id,
-            BuildTaskOptions {
-                agent_type: AgentType::Acp,
-                workspace: "/tmp/ws".into(),
-                model: ProviderWithModel {
-                    provider_id: "test".into(),
-                    model: "claude".into(),
-                    use_model: None,
-                },
-                conversation_id: conversation_id.clone(),
-                extra: serde_json::json!({}),
-            },
+            test_acp_build_options(conversation_id.clone(), "/tmp/ws".into()),
         )
         .await
         .unwrap();
@@ -1604,18 +1629,22 @@ async fn d9_ensure_session_persists_team_mcp_stdio_config() {
     use futures_util::FutureExt;
     let (svc, _tm) = setup_with_factory(Arc::new(|opts: BuildTaskOptions| {
         async move {
-            let extra_has_cfg = opts
-                .extra
-                .get("team_mcp_stdio_config")
-                .and_then(|v| v.as_object())
-                .is_some_and(|o| o.contains_key("port") && o.contains_key("slot_id"));
+            let context = opts.context;
+            let extra_has_cfg = match &context.kind {
+                AgentSessionKind::Acp(acp) => acp
+                    .config
+                    .team_mcp_stdio_config
+                    .as_ref()
+                    .is_some_and(|cfg| cfg.port > 0 && !cfg.slot_id.is_empty()),
+                _ => false,
+            };
             assert!(
                 extra_has_cfg,
-                "factory called without team_mcp_stdio_config in extra: {:?}",
-                opts.extra
+                "factory called without team_mcp_stdio_config in typed context: {:?}",
+                context.kind
             );
             Ok(aionui_ai_agent::AgentInstance::Mock(Arc::new(
-                mock_agent::MockAgent::new(opts.conversation_id, opts.workspace),
+                mock_agent::MockAgent::new(context.conversation.conversation_id, context.workspace.path),
             )))
         }
         .boxed()


### PR DESCRIPTION
## Summary
- Introduce typed AgentSessionContext / AgentSessionKind as the runtime build input.
- Move conversation.extra decoding into the conversation SessionContextBuilder and reuse it from conversation and cron build paths.
- Update agent factories and tests to consume typed context instead of raw BuildTaskOptions fields.

## Verification
- just push -u origin round-3-session-context-builder
- cargo test --no-run -p aionui-app