### PR TITLE
fix(runtime): report bundled resource installation failures

### DIFF
--- a/crates/aionui-ai-agent/src/runtime_status.rs
+++ b/crates/aionui-ai-agent/src/runtime_status.rs
@@ -106,8 +106,11 @@ fn map_failure_kind(kind: NodeRuntimeFailureKind) -> RuntimeFailureKind {
         NodeRuntimeFailureKind::Timeout => RuntimeFailureKind::Timeout,
         NodeRuntimeFailureKind::DownloadFailed => RuntimeFailureKind::DownloadFailed,
         NodeRuntimeFailureKind::HttpStatus => RuntimeFailureKind::HttpStatus,
+        NodeRuntimeFailureKind::ChecksumMismatch => RuntimeFailureKind::ChecksumMismatch,
         NodeRuntimeFailureKind::ValidationFailed => RuntimeFailureKind::ValidationFailed,
         NodeRuntimeFailureKind::UnsupportedPlatform => RuntimeFailureKind::UnsupportedPlatform,
+        NodeRuntimeFailureKind::BundledResourceMissing => RuntimeFailureKind::BundledResourceMissing,
+        NodeRuntimeFailureKind::BundledResourceInvalid => RuntimeFailureKind::BundledResourceInvalid,
         NodeRuntimeFailureKind::Unknown => RuntimeFailureKind::Unknown,
     }
 }
@@ -131,6 +134,8 @@ fn map_acp_failure_kind(kind: ManagedAcpToolFailureKind) -> RuntimeFailureKind {
         ManagedAcpToolFailureKind::ChecksumMismatch => RuntimeFailureKind::ChecksumMismatch,
         ManagedAcpToolFailureKind::ValidationFailed => RuntimeFailureKind::ValidationFailed,
         ManagedAcpToolFailureKind::UnsupportedPlatform => RuntimeFailureKind::UnsupportedPlatform,
+        ManagedAcpToolFailureKind::BundledResourceMissing => RuntimeFailureKind::BundledResourceMissing,
+        ManagedAcpToolFailureKind::BundledResourceInvalid => RuntimeFailureKind::BundledResourceInvalid,
         ManagedAcpToolFailureKind::Unknown => RuntimeFailureKind::Unknown,
     }
 }

--- a/crates/aionui-api-types/src/runtime.rs
+++ b/crates/aionui-api-types/src/runtime.rs
@@ -41,6 +41,8 @@ pub enum RuntimeFailureKind {
     ChecksumMismatch,
     ValidationFailed,
     UnsupportedPlatform,
+    BundledResourceMissing,
+    BundledResourceInvalid,
     Unknown,
 }
 
@@ -104,6 +106,15 @@ mod tests {
         assert_eq!(json["scope"]["kind"], "conversation");
         assert_eq!(json["phase"], "downloading");
         assert_eq!(json["message"], "downloading");
+    }
+
+    #[test]
+    fn bundled_runtime_failure_kind_serializes_as_snake_case() {
+        let missing = serde_json::to_value(RuntimeFailureKind::BundledResourceMissing).unwrap();
+        let invalid = serde_json::to_value(RuntimeFailureKind::BundledResourceInvalid).unwrap();
+
+        assert_eq!(missing, "bundled_resource_missing");
+        assert_eq!(invalid, "bundled_resource_invalid");
     }
 
     #[test]

--- a/crates/aionui-mcp/src/connection_test/mod.rs
+++ b/crates/aionui-mcp/src/connection_test/mod.rs
@@ -439,8 +439,11 @@ fn map_failure_kind(kind: NodeRuntimeFailureKind) -> RuntimeFailureKind {
         NodeRuntimeFailureKind::Timeout => RuntimeFailureKind::Timeout,
         NodeRuntimeFailureKind::DownloadFailed => RuntimeFailureKind::DownloadFailed,
         NodeRuntimeFailureKind::HttpStatus => RuntimeFailureKind::HttpStatus,
+        NodeRuntimeFailureKind::ChecksumMismatch => RuntimeFailureKind::ChecksumMismatch,
         NodeRuntimeFailureKind::ValidationFailed => RuntimeFailureKind::ValidationFailed,
         NodeRuntimeFailureKind::UnsupportedPlatform => RuntimeFailureKind::UnsupportedPlatform,
+        NodeRuntimeFailureKind::BundledResourceMissing => RuntimeFailureKind::BundledResourceMissing,
+        NodeRuntimeFailureKind::BundledResourceInvalid => RuntimeFailureKind::BundledResourceInvalid,
         NodeRuntimeFailureKind::Unknown => RuntimeFailureKind::Unknown,
     }
 }

--- a/crates/aionui-runtime/src/acp_tool_runtime/mod.rs
+++ b/crates/aionui-runtime/src/acp_tool_runtime/mod.rs
@@ -718,6 +718,15 @@ fn classify_error(error: &ManagedAcpToolError) -> (ManagedAcpToolFailureKind, Op
     if message.contains("unsupported") {
         return (ManagedAcpToolFailureKind::UnsupportedPlatform, None);
     }
+    if message.contains("bundled managed") && message.contains("artifact missing") {
+        return (ManagedAcpToolFailureKind::BundledResourceMissing, None);
+    }
+    if message.contains("bundled managed") && message.contains("artifact failed validation") {
+        return (ManagedAcpToolFailureKind::BundledResourceInvalid, None);
+    }
+    if message.contains("bundled managed") && message.contains("artifact is invalid") {
+        return (ManagedAcpToolFailureKind::BundledResourceInvalid, None);
+    }
     if message.contains("checksum mismatch") {
         return (ManagedAcpToolFailureKind::ChecksumMismatch, None);
     }
@@ -786,6 +795,17 @@ mod tests {
         let error = ManagedAcpToolError::invalid("managed ACP archive checksum mismatch");
         let (kind, status_code) = classify_error(&error);
         assert_eq!(kind, ManagedAcpToolFailureKind::ChecksumMismatch);
+        assert_eq!(status_code, None);
+    }
+
+    #[test]
+    fn classify_error_detects_bundled_acp_validation_failure() {
+        let error = ManagedAcpToolError::invalid(
+            "bundled managed Codex ACP artifact failed validation under /app/resources/managed-resources/acp/codex-acp/0.14.0/linux-x64: managed ACP entrypoint missing",
+        );
+        let (kind, status_code) = classify_error(&error);
+
+        assert_eq!(kind, ManagedAcpToolFailureKind::BundledResourceInvalid);
         assert_eq!(status_code, None);
     }
 

--- a/crates/aionui-runtime/src/acp_tool_runtime/mod.rs
+++ b/crates/aionui-runtime/src/acp_tool_runtime/mod.rs
@@ -71,19 +71,82 @@ pub async fn ensure_managed_acp_tool_with_reporter(
         return Ok(installed);
     }
 
-    if let Some(installed) = activate_local_tool_source(tool, spec, &root, reporter)? {
+    if let Some(installed) =
+        activate_local_tool_source(tool, spec, &root, reporter).map_err(|error| report_failure(error, reporter))?
+    {
         return Ok(installed);
     }
 
-    if maybe_prepare_local_runtime_tool_source(tool, spec, reporter).await? {
-        return validate_tool_root(tool, &root, reporter);
+    if maybe_prepare_local_runtime_tool_source(tool, spec, reporter)
+        .await
+        .map_err(|error| report_failure(error, reporter))?
+    {
+        return validate_tool_root(tool, &root, reporter).map_err(|error| report_failure(error, reporter));
     }
 
-    Err(ManagedAcpToolError::invalid(format!(
+    Err(report_failure(unavailable_error(tool, &root), reporter))
+}
+
+fn report_failure(
+    error: ManagedAcpToolError,
+    reporter: Option<&dyn ManagedAcpToolProgressReporter>,
+) -> ManagedAcpToolError {
+    let (kind, status_code) = classify_error(&error);
+    emit_progress(
+        reporter,
+        match status_code {
+            Some(status) => ManagedAcpToolProgress::failed_with_status(kind, status, error.to_string()),
+            None => ManagedAcpToolProgress::failed(kind, error.to_string()),
+        },
+    );
+    error
+}
+
+fn classify_error(error: &ManagedAcpToolError) -> (ManagedAcpToolFailureKind, Option<u16>) {
+    let message = error.to_string().to_ascii_lowercase();
+    if message.contains("timed out") {
+        return (ManagedAcpToolFailureKind::Timeout, None);
+    }
+    if let Some(status) = parse_http_status(&message) {
+        return (ManagedAcpToolFailureKind::HttpStatus, Some(status));
+    }
+    if message.contains("unsupported") {
+        return (ManagedAcpToolFailureKind::UnsupportedPlatform, None);
+    }
+    if message.contains("bundled managed") && message.contains("artifact missing") {
+        return (ManagedAcpToolFailureKind::BundledResourceMissing, None);
+    }
+    if message.contains("bundled managed") && message.contains("artifact failed validation") {
+        return (ManagedAcpToolFailureKind::BundledResourceInvalid, None);
+    }
+    if message.contains("bundled managed") && message.contains("artifact is invalid") {
+        return (ManagedAcpToolFailureKind::BundledResourceInvalid, None);
+    }
+    if message.contains("checksum mismatch") {
+        return (ManagedAcpToolFailureKind::ChecksumMismatch, None);
+    }
+    if message.contains("validate") || message.contains("entrypoint missing") {
+        return (ManagedAcpToolFailureKind::ValidationFailed, None);
+    }
+    if message.contains("download") || message.contains("extract") || message.contains("connect failed") {
+        return (ManagedAcpToolFailureKind::DownloadFailed, None);
+    }
+    (ManagedAcpToolFailureKind::Unknown, None)
+}
+
+fn parse_http_status(message: &str) -> Option<u16> {
+    let marker = "http ";
+    let start = message.find(marker)? + marker.len();
+    let digits: String = message[start..].chars().take_while(|ch| ch.is_ascii_digit()).collect();
+    digits.parse::<u16>().ok()
+}
+
+fn unavailable_error(tool: ManagedAcpToolId, root: &Path) -> ManagedAcpToolError {
+    ManagedAcpToolError::invalid(format!(
         "managed {} artifact unavailable under {} and could not be prepared locally",
         tool.display_name(),
         root.display()
-    )))
+    ))
 }
 
 pub fn probe_managed_acp_tool_supported(tool: ManagedAcpToolId) -> ManagedAcpToolSupport {
@@ -707,47 +770,6 @@ fn format_error_with_causes(error: &(dyn StdError + 'static)) -> String {
 }
 
 #[cfg(test)]
-fn classify_error(error: &ManagedAcpToolError) -> (ManagedAcpToolFailureKind, Option<u16>) {
-    let message = error.to_string().to_ascii_lowercase();
-    if message.contains("timed out") {
-        return (ManagedAcpToolFailureKind::Timeout, None);
-    }
-    if let Some(status) = parse_http_status(&message) {
-        return (ManagedAcpToolFailureKind::HttpStatus, Some(status));
-    }
-    if message.contains("unsupported") {
-        return (ManagedAcpToolFailureKind::UnsupportedPlatform, None);
-    }
-    if message.contains("bundled managed") && message.contains("artifact missing") {
-        return (ManagedAcpToolFailureKind::BundledResourceMissing, None);
-    }
-    if message.contains("bundled managed") && message.contains("artifact failed validation") {
-        return (ManagedAcpToolFailureKind::BundledResourceInvalid, None);
-    }
-    if message.contains("bundled managed") && message.contains("artifact is invalid") {
-        return (ManagedAcpToolFailureKind::BundledResourceInvalid, None);
-    }
-    if message.contains("checksum mismatch") {
-        return (ManagedAcpToolFailureKind::ChecksumMismatch, None);
-    }
-    if message.contains("validate") || message.contains("entrypoint missing") {
-        return (ManagedAcpToolFailureKind::ValidationFailed, None);
-    }
-    if message.contains("download") || message.contains("extract") || message.contains("connect failed") {
-        return (ManagedAcpToolFailureKind::DownloadFailed, None);
-    }
-    (ManagedAcpToolFailureKind::Unknown, None)
-}
-
-#[cfg(test)]
-fn parse_http_status(message: &str) -> Option<u16> {
-    let marker = "http ";
-    let start = message.find(marker)? + marker.len();
-    let digits: String = message[start..].chars().take_while(|ch| ch.is_ascii_digit()).collect();
-    digits.parse::<u16>().ok()
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
     use std::fmt;
@@ -807,6 +829,40 @@ mod tests {
 
         assert_eq!(kind, ManagedAcpToolFailureKind::BundledResourceInvalid);
         assert_eq!(status_code, None);
+    }
+
+    #[tokio::test]
+    async fn bundled_acp_tool_missing_reports_bundled_resource_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundled_root = tmp.path().join("bundled");
+        if !crate::test_support::run_in_env_child(
+            "acp_tool_runtime::tests::bundled_acp_tool_missing_reports_bundled_resource_missing",
+            |command| {
+                command.env("AIONUI_BUNDLED_MANAGED_RESOURCES", &bundled_root);
+            },
+        ) {
+            return;
+        }
+
+        crate::cache::init(tmp.path().join("data"));
+        managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Bundled);
+
+        let updates = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let reporter_updates = updates.clone();
+        let reporter = move |update: ManagedAcpToolProgress| {
+            reporter_updates.lock().unwrap().push(update);
+        };
+
+        let result = ensure_managed_acp_tool_with_reporter(ManagedAcpToolId::CodexAcp, Some(&reporter)).await;
+        managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Download);
+
+        let error = result.expect_err("missing bundled ACP tool should fail");
+        assert!(error.to_string().contains("bundled managed Codex ACP artifact missing"));
+        let updates = updates.lock().unwrap();
+        assert!(updates.iter().any(|update| {
+            update.phase == ManagedAcpToolProgressPhase::Failed
+                && update.failure_kind == Some(ManagedAcpToolFailureKind::BundledResourceMissing)
+        }));
     }
 
     #[test]

--- a/crates/aionui-runtime/src/acp_tool_runtime/types.rs
+++ b/crates/aionui-runtime/src/acp_tool_runtime/types.rs
@@ -113,6 +113,8 @@ pub enum ManagedAcpToolFailureKind {
     ChecksumMismatch,
     ValidationFailed,
     UnsupportedPlatform,
+    BundledResourceMissing,
+    BundledResourceInvalid,
     Unknown,
 }
 

--- a/crates/aionui-runtime/src/node_runtime/managed.rs
+++ b/crates/aionui-runtime/src/node_runtime/managed.rs
@@ -106,7 +106,10 @@ pub async fn install_and_validate_with_reporter(
         }
     }
 
-    if let Some(runtime) = activate_local_runtime_source(&runtime_root, spec, reporter).await? {
+    if let Some(runtime) = activate_local_runtime_source(&runtime_root, spec, reporter)
+        .await
+        .map_err(|error| install_error(error, reporter))?
+    {
         emit_progress(
             reporter,
             NodeRuntimeProgress::ready(format!(
@@ -901,6 +904,40 @@ mod tests {
 
         assert_eq!(kind, NodeRuntimeFailureKind::BundledResourceMissing);
         assert_eq!(status, None);
+    }
+
+    #[tokio::test]
+    async fn bundled_runtime_missing_reports_bundled_resource_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundled_root = tmp.path().join("bundled");
+        if !crate::test_support::run_in_env_child(
+            "node_runtime::managed::tests::bundled_runtime_missing_reports_bundled_resource_missing",
+            |command| {
+                command.env("AIONUI_BUNDLED_MANAGED_RESOURCES", &bundled_root);
+            },
+        ) {
+            return;
+        }
+
+        crate::cache::init(tmp.path().join("data"));
+        managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Bundled);
+
+        let updates = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let reporter_updates = updates.clone();
+        let reporter = move |update: NodeRuntimeProgress| {
+            reporter_updates.lock().unwrap().push(update);
+        };
+
+        let result = install_and_validate_with_reporter(Some(&reporter)).await;
+        managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Download);
+
+        let error = result.expect_err("missing bundled runtime should fail");
+        assert!(error.to_string().contains("bundled Node runtime missing"));
+        let updates = updates.lock().unwrap();
+        assert!(updates.iter().any(|update| {
+            update.phase == crate::NodeRuntimeProgressPhase::Failed
+                && update.failure_kind == Some(NodeRuntimeFailureKind::BundledResourceMissing)
+        }));
     }
 
     #[test]

--- a/crates/aionui-runtime/src/node_runtime/managed.rs
+++ b/crates/aionui-runtime/src/node_runtime/managed.rs
@@ -794,6 +794,18 @@ fn classify_error(error: &NodeRuntimeError) -> (NodeRuntimeFailureKind, Option<u
     if message.contains("unsupported") {
         return (NodeRuntimeFailureKind::UnsupportedPlatform, None);
     }
+    if message.contains("bundled node runtime missing")
+        || message.contains("bundled managed resources root unavailable")
+    {
+        return (NodeRuntimeFailureKind::BundledResourceMissing, None);
+    }
+    if message.contains("bundled node runtime is invalid") || message.contains("bundled node runtime failed validation")
+    {
+        return (NodeRuntimeFailureKind::BundledResourceInvalid, None);
+    }
+    if message.contains("checksum mismatch") {
+        return (NodeRuntimeFailureKind::ChecksumMismatch, None);
+    }
     if message.contains("validate") || message.contains("executable missing") || message.contains("entrypoint missing")
     {
         return (NodeRuntimeFailureKind::ValidationFailed, None);
@@ -878,6 +890,17 @@ mod tests {
         let support = probe_support();
         let expected = cfg!(target_os = "macos") || cfg!(target_os = "linux") || cfg!(windows);
         assert_eq!(support.supported, expected);
+    }
+
+    #[test]
+    fn classify_error_detects_bundled_node_runtime_missing() {
+        let err = NodeRuntimeError::managed_invalid(
+            "bundled Node runtime missing under C:\\Program Files\\AionUi\\resources\\bundled-aioncore\\win32-x64\\managed-resources\\node\\node-v24.11.0-win-x64",
+        );
+        let (kind, status) = classify_error(&err);
+
+        assert_eq!(kind, NodeRuntimeFailureKind::BundledResourceMissing);
+        assert_eq!(status, None);
     }
 
     #[test]

--- a/crates/aionui-runtime/src/node_runtime/types.rs
+++ b/crates/aionui-runtime/src/node_runtime/types.rs
@@ -87,8 +87,11 @@ pub enum NodeRuntimeFailureKind {
     Timeout,
     DownloadFailed,
     HttpStatus,
+    ChecksumMismatch,
     ValidationFailed,
     UnsupportedPlatform,
+    BundledResourceMissing,
+    BundledResourceInvalid,
     Unknown,
 }
 

--- a/crates/aionui-system/src/runtime_prepare.rs
+++ b/crates/aionui-system/src/runtime_prepare.rs
@@ -108,8 +108,11 @@ fn map_failure_kind(kind: NodeRuntimeFailureKind) -> RuntimeFailureKind {
         NodeRuntimeFailureKind::Timeout => RuntimeFailureKind::Timeout,
         NodeRuntimeFailureKind::DownloadFailed => RuntimeFailureKind::DownloadFailed,
         NodeRuntimeFailureKind::HttpStatus => RuntimeFailureKind::HttpStatus,
+        NodeRuntimeFailureKind::ChecksumMismatch => RuntimeFailureKind::ChecksumMismatch,
         NodeRuntimeFailureKind::ValidationFailed => RuntimeFailureKind::ValidationFailed,
         NodeRuntimeFailureKind::UnsupportedPlatform => RuntimeFailureKind::UnsupportedPlatform,
+        NodeRuntimeFailureKind::BundledResourceMissing => RuntimeFailureKind::BundledResourceMissing,
+        NodeRuntimeFailureKind::BundledResourceInvalid => RuntimeFailureKind::BundledResourceInvalid,
         NodeRuntimeFailureKind::Unknown => RuntimeFailureKind::Unknown,
     }
 }
@@ -133,6 +136,8 @@ fn map_acp_failure_kind(kind: ManagedAcpToolFailureKind) -> RuntimeFailureKind {
         ManagedAcpToolFailureKind::ChecksumMismatch => RuntimeFailureKind::ChecksumMismatch,
         ManagedAcpToolFailureKind::ValidationFailed => RuntimeFailureKind::ValidationFailed,
         ManagedAcpToolFailureKind::UnsupportedPlatform => RuntimeFailureKind::UnsupportedPlatform,
+        ManagedAcpToolFailureKind::BundledResourceMissing => RuntimeFailureKind::BundledResourceMissing,
+        ManagedAcpToolFailureKind::BundledResourceInvalid => RuntimeFailureKind::BundledResourceInvalid,
         ManagedAcpToolFailureKind::Unknown => RuntimeFailureKind::Unknown,
     }
 }


### PR DESCRIPTION
## Summary
- classify missing or invalid bundled managed Node runtime resources as installation integrity failures
- report managed ACP tool bundled resource failures through runtime status so AionUi can surface the installation recovery path
- keep the failure kinds specific enough for production diagnostics and Sentry triage

## Testing
- just push