### PR TITLE
refactor: centralize runtime turn lifecycle

### DIFF
--- a/crates/aionui-app/src/commands/server.rs
+++ b/crates/aionui-app/src/commands/server.rs
@@ -226,10 +226,18 @@ pub(crate) async fn run_server(
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     let idle_scanner_handle =
         aionui_ai_agent::start_idle_scanner(services.worker_task_manager.clone(), shutdown_rx, None, None);
+    let conversation_runtime_state = services.conversation_runtime_state.clone();
+    let worker_task_manager = services.worker_task_manager.clone();
 
     axum::serve(listener, router)
         .with_graceful_shutdown(async move {
             shutdown_signal().await;
+            let active_turn_count = conversation_runtime_state.mark_shutting_down();
+            info!(
+                reason = "graceful_shutdown",
+                active_turn_count, "conversation runtime shutdown prepared"
+            );
+            worker_task_manager.clear();
             let _ = shutdown_tx.send(true);
         })
         .await?;

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -215,6 +215,11 @@ pub async fn build_module_states(services: &AppServices) -> (ModuleStates, Chann
         elapsed_ms = boot.elapsed().as_millis(),
         "startup: module state build completed"
     );
+    states
+        .conversation
+        .service
+        .recover_stale_runtime_state_on_startup()
+        .await;
 
     (states, channel_components)
 }

--- a/crates/aionui-conversation/src/acp_error_recovery.rs
+++ b/crates/aionui-conversation/src/acp_error_recovery.rs
@@ -10,6 +10,8 @@ use crate::service::ConversationService;
 use crate::stream_relay::RelayOutcome;
 use aionui_ai_agent::IWorkerTaskManager;
 
+use crate::runtime_persistence::RuntimeWriteKind;
+
 impl ConversationService {
     async fn clear_conversation_model_seed_after_model_not_found(
         &self,
@@ -17,6 +19,12 @@ impl ConversationService {
         error_code: Option<AgentErrorCode>,
     ) {
         if error_code != Some(AgentErrorCode::UserLlmProviderModelNotFound) {
+            return;
+        }
+        if !self
+            .runtime_persistence()
+            .allows(conversation_id, RuntimeWriteKind::AcpRecoveryCleanup)
+        {
             return;
         }
 
@@ -130,6 +138,12 @@ impl ConversationService {
         error_code: Option<AgentErrorCode>,
     ) {
         if error_code != Some(AgentErrorCode::UserLlmProviderModelNotFound) {
+            return;
+        }
+        if !self
+            .runtime_persistence()
+            .allows(conversation_id, RuntimeWriteKind::AcpRecoveryCleanup)
+        {
             return;
         }
 

--- a/crates/aionui-conversation/src/agent_health_policy.rs
+++ b/crates/aionui-conversation/src/agent_health_policy.rs
@@ -1,0 +1,118 @@
+use aionui_api_types::AgentErrorCode;
+use aionui_common::AgentType;
+
+use crate::runtime_state::RuntimeLifecycleState;
+use crate::stream_relay::RelayOutcome;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentHealthAction {
+    Keep,
+    EvictAcpTask {
+        error_code: Option<AgentErrorCode>,
+        retryable: Option<bool>,
+        clear_model_seed: bool,
+    },
+}
+
+pub struct AgentHealthPolicy;
+
+impl AgentHealthPolicy {
+    pub fn decide(
+        agent_type: AgentType,
+        outcome: &RelayOutcome,
+        lifecycle: RuntimeLifecycleState,
+    ) -> AgentHealthAction {
+        if lifecycle != RuntimeLifecycleState::Active {
+            return AgentHealthAction::Keep;
+        }
+        if agent_type != AgentType::Acp || !outcome.terminal.is_error() {
+            return AgentHealthAction::Keep;
+        }
+
+        let error_code = outcome.terminal.code();
+        AgentHealthAction::EvictAcpTask {
+            error_code,
+            retryable: outcome.terminal.retryable(),
+            clear_model_seed: error_code == Some(AgentErrorCode::UserLlmProviderModelNotFound),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stream_relay::RelayTerminal;
+
+    fn error_outcome(code: Option<AgentErrorCode>) -> RelayOutcome {
+        RelayOutcome {
+            system_responses: Vec::new(),
+            terminal: RelayTerminal::Error {
+                code,
+                retryable: Some(true),
+            },
+        }
+    }
+
+    #[test]
+    fn acp_finish_keeps_task() {
+        let outcome = RelayOutcome::default();
+        assert_eq!(
+            AgentHealthPolicy::decide(AgentType::Acp, &outcome, RuntimeLifecycleState::Active),
+            AgentHealthAction::Keep
+        );
+    }
+
+    #[test]
+    fn acp_terminal_error_evicts_task() {
+        let outcome = error_outcome(Some(AgentErrorCode::UnknownUpstreamError));
+        assert!(matches!(
+            AgentHealthPolicy::decide(AgentType::Acp, &outcome, RuntimeLifecycleState::Active),
+            AgentHealthAction::EvictAcpTask {
+                clear_model_seed: false,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn acp_model_not_found_requests_model_seed_cleanup() {
+        let outcome = error_outcome(Some(AgentErrorCode::UserLlmProviderModelNotFound));
+        assert!(matches!(
+            AgentHealthPolicy::decide(AgentType::Acp, &outcome, RuntimeLifecycleState::Active),
+            AgentHealthAction::EvictAcpTask {
+                clear_model_seed: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn non_acp_terminal_error_keeps_task() {
+        let outcome = error_outcome(Some(AgentErrorCode::UnknownUpstreamError));
+        assert_eq!(
+            AgentHealthPolicy::decide(AgentType::Aionrs, &outcome, RuntimeLifecycleState::Active),
+            AgentHealthAction::Keep
+        );
+    }
+
+    #[test]
+    fn channel_closed_does_not_evict_by_default() {
+        let outcome = RelayOutcome {
+            system_responses: Vec::new(),
+            terminal: RelayTerminal::ChannelClosed,
+        };
+        assert_eq!(
+            AgentHealthPolicy::decide(AgentType::Acp, &outcome, RuntimeLifecycleState::Active),
+            AgentHealthAction::Keep
+        );
+    }
+
+    #[test]
+    fn non_active_lifecycle_keeps_task() {
+        let outcome = error_outcome(Some(AgentErrorCode::UserLlmProviderModelNotFound));
+        assert_eq!(
+            AgentHealthPolicy::decide(AgentType::Acp, &outcome, RuntimeLifecycleState::Deleting),
+            AgentHealthAction::Keep
+        );
+    }
+}

--- a/crates/aionui-conversation/src/lib.rs
+++ b/crates/aionui-conversation/src/lib.rs
@@ -19,6 +19,7 @@ pub mod skill_resolver;
 pub mod skill_snapshot;
 mod startup_recovery;
 pub mod state;
+mod stream_persistence;
 pub mod stream_relay;
 pub mod task_options;
 mod turn_continuation_policy;

--- a/crates/aionui-conversation/src/lib.rs
+++ b/crates/aionui-conversation/src/lib.rs
@@ -2,21 +2,27 @@
 
 //! Conversation and message CRUD with streaming relay and event emission.
 mod acp_error_recovery;
+mod agent_health_policy;
 mod convert;
 pub mod error;
 mod message_persistence;
 pub mod response_middleware;
 pub mod routes;
 pub mod routes_aux;
+mod runtime_completion;
+mod runtime_persistence;
 pub mod runtime_state;
 pub mod service;
 mod service_ops;
 pub(crate) mod session_context;
 pub mod skill_resolver;
 pub mod skill_snapshot;
+mod startup_recovery;
 pub mod state;
 pub mod stream_relay;
 pub mod task_options;
+mod turn_continuation_policy;
+mod turn_orchestrator;
 
 pub use error::ConversationError;
 pub use response_middleware::{

--- a/crates/aionui-conversation/src/message_persistence.rs
+++ b/crates/aionui-conversation/src/message_persistence.rs
@@ -3,6 +3,7 @@ use aionui_common::{ErrorChain, now_ms};
 use aionui_db::models::MessageRow;
 use tracing::warn;
 
+use crate::runtime_persistence::RuntimeWriteKind;
 use crate::service::ConversationService;
 
 impl ConversationService {
@@ -12,6 +13,13 @@ impl ConversationService {
         err: &AgentSendError,
         top_level_code: Option<&'static str>,
     ) -> Option<MessageRow> {
+        if !self
+            .runtime_persistence()
+            .allows(conversation_id, RuntimeWriteKind::SendFailureTip)
+        {
+            return None;
+        }
+
         let stream_error = err.stream_error();
         let code = top_level_code.map(str::to_owned).or_else(|| {
             stream_error

--- a/crates/aionui-conversation/src/runtime_completion.rs
+++ b/crates/aionui-conversation/src/runtime_completion.rs
@@ -1,0 +1,87 @@
+use std::sync::Arc;
+
+use aionui_api_types::{ConversationRuntimeSummary, WebSocketMessage};
+use aionui_common::{ErrorChain, now_ms};
+use aionui_db::{ConversationRowUpdate, IConversationRepository};
+use aionui_realtime::EventBroadcaster;
+use serde_json::json;
+use tracing::{debug, error};
+
+use crate::runtime_persistence::{RuntimePersistenceCoordinator, RuntimeWriteKind};
+
+#[derive(Clone)]
+pub struct RuntimeCompletionPublisher {
+    repo: Arc<dyn IConversationRepository>,
+    broadcaster: Arc<dyn EventBroadcaster>,
+    persistence: RuntimePersistenceCoordinator,
+}
+
+impl RuntimeCompletionPublisher {
+    pub fn new(
+        repo: Arc<dyn IConversationRepository>,
+        broadcaster: Arc<dyn EventBroadcaster>,
+        persistence: RuntimePersistenceCoordinator,
+    ) -> Self {
+        Self {
+            repo,
+            broadcaster,
+            persistence,
+        }
+    }
+
+    #[tracing::instrument(skip_all, fields(conversation_id = %conversation_id))]
+    pub async fn publish(&self, conversation_id: &str, runtime: Option<ConversationRuntimeSummary>) {
+        if !self
+            .persistence
+            .allows(conversation_id, RuntimeWriteKind::ConversationFinished)
+        {
+            debug!(conversation_id, "turn completion skipped by runtime persistence policy");
+            return;
+        }
+
+        match self.repo.get(conversation_id).await {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                debug!(
+                    conversation_id,
+                    "turn completion skipped because conversation row is missing"
+                );
+                return;
+            }
+            Err(error) => {
+                error!(
+                    conversation_id,
+                    error = %ErrorChain(&error),
+                    "turn completion skipped because conversation row lookup failed"
+                );
+                return;
+            }
+        }
+
+        let update = ConversationRowUpdate {
+            status: Some("finished".to_owned()),
+            updated_at: Some(now_ms()),
+            ..Default::default()
+        };
+        if let Err(error) = self.repo.update(conversation_id, &update).await {
+            error!(
+                conversation_id,
+                error = %ErrorChain(&error),
+                "Failed to update conversation status"
+            );
+            return;
+        }
+
+        let payload = json!({
+            "conversation_id": conversation_id,
+            "session_id": conversation_id,
+            "status": "finished",
+            "canSendMessage": true,
+            "runtime": runtime,
+        });
+        self.broadcaster
+            .broadcast(WebSocketMessage::new("turn.completed", payload));
+
+        debug!(conversation_id, status = "finished", "Turn completed");
+    }
+}

--- a/crates/aionui-conversation/src/runtime_persistence.rs
+++ b/crates/aionui-conversation/src/runtime_persistence.rs
@@ -1,0 +1,150 @@
+use std::sync::Arc;
+
+use tracing::debug;
+
+use crate::runtime_state::{ConversationRuntimeStateService, RuntimeLifecycleState};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeWriteKind {
+    UserMessage,
+    AssistantTextCreate,
+    AssistantTextFlush,
+    AssistantTextFinalize,
+    AssistantThinkingFinalize,
+    ToolCallPersist,
+    AcpToolCallPersist,
+    ToolGroupPersist,
+    TerminalFinalize,
+    ConversationFinished,
+    SendFailureTip,
+    SessionKey,
+    AcpRecoveryCleanup,
+    ResolvedWorkspace,
+    StartupRecovery,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeWriteDecision {
+    Allow,
+    Skip(RuntimeLifecycleState),
+}
+
+#[derive(Clone)]
+pub struct RuntimePersistenceCoordinator {
+    runtime_state: Arc<ConversationRuntimeStateService>,
+}
+
+impl RuntimePersistenceCoordinator {
+    pub fn new(runtime_state: Arc<ConversationRuntimeStateService>) -> Self {
+        Self { runtime_state }
+    }
+
+    pub fn lifecycle_for(&self, conversation_id: &str) -> RuntimeLifecycleState {
+        self.runtime_state.lifecycle_for(conversation_id)
+    }
+
+    pub fn decide(&self, conversation_id: &str, kind: RuntimeWriteKind) -> RuntimeWriteDecision {
+        let lifecycle = self.lifecycle_for(conversation_id);
+        let allow = match lifecycle {
+            RuntimeLifecycleState::Active => true,
+            RuntimeLifecycleState::Deleting => matches!(kind, RuntimeWriteKind::UserMessage),
+            RuntimeLifecycleState::Cancelling => matches!(
+                kind,
+                RuntimeWriteKind::AssistantTextCreate
+                    | RuntimeWriteKind::AssistantTextFlush
+                    | RuntimeWriteKind::AssistantTextFinalize
+                    | RuntimeWriteKind::AssistantThinkingFinalize
+                    | RuntimeWriteKind::ToolCallPersist
+                    | RuntimeWriteKind::AcpToolCallPersist
+                    | RuntimeWriteKind::ToolGroupPersist
+                    | RuntimeWriteKind::TerminalFinalize
+                    | RuntimeWriteKind::ConversationFinished
+            ),
+            RuntimeLifecycleState::ShuttingDown => matches!(kind, RuntimeWriteKind::UserMessage),
+        };
+
+        if allow {
+            RuntimeWriteDecision::Allow
+        } else {
+            debug!(
+                conversation_id,
+                write_kind = ?kind,
+                lifecycle_state = ?lifecycle,
+                "runtime persistence write skipped"
+            );
+            RuntimeWriteDecision::Skip(lifecycle)
+        }
+    }
+
+    pub fn allows(&self, conversation_id: &str, kind: RuntimeWriteKind) -> bool {
+        matches!(self.decide(conversation_id, kind), RuntimeWriteDecision::Allow)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_allows_all_expected_write_kinds() {
+        let state = Arc::new(ConversationRuntimeStateService::default());
+        let coordinator = RuntimePersistenceCoordinator::new(state);
+
+        for kind in [
+            RuntimeWriteKind::UserMessage,
+            RuntimeWriteKind::AssistantTextCreate,
+            RuntimeWriteKind::AssistantTextFlush,
+            RuntimeWriteKind::AssistantTextFinalize,
+            RuntimeWriteKind::AssistantThinkingFinalize,
+            RuntimeWriteKind::ToolCallPersist,
+            RuntimeWriteKind::AcpToolCallPersist,
+            RuntimeWriteKind::ToolGroupPersist,
+            RuntimeWriteKind::TerminalFinalize,
+            RuntimeWriteKind::ConversationFinished,
+            RuntimeWriteKind::SendFailureTip,
+            RuntimeWriteKind::SessionKey,
+            RuntimeWriteKind::AcpRecoveryCleanup,
+            RuntimeWriteKind::ResolvedWorkspace,
+            RuntimeWriteKind::StartupRecovery,
+        ] {
+            assert!(coordinator.allows("conv-1", kind), "{kind:?} should be allowed");
+        }
+    }
+
+    #[test]
+    fn deleting_skips_runtime_finalization_and_recovery_writes() {
+        let state = Arc::new(ConversationRuntimeStateService::default());
+        state.mark_deleting("conv-1");
+        let coordinator = RuntimePersistenceCoordinator::new(state);
+
+        assert!(coordinator.allows("conv-1", RuntimeWriteKind::UserMessage));
+        assert!(!coordinator.allows("conv-1", RuntimeWriteKind::AssistantTextFinalize));
+        assert!(!coordinator.allows("conv-1", RuntimeWriteKind::SendFailureTip));
+        assert!(!coordinator.allows("conv-1", RuntimeWriteKind::SessionKey));
+        assert!(!coordinator.allows("conv-1", RuntimeWriteKind::AcpRecoveryCleanup));
+        assert!(!coordinator.allows("conv-1", RuntimeWriteKind::ConversationFinished));
+    }
+
+    #[test]
+    fn cancelling_allows_partial_finalization_but_skips_failure_and_recovery() {
+        let state = Arc::new(ConversationRuntimeStateService::default());
+        state.mark_cancelling("conv-1");
+        let coordinator = RuntimePersistenceCoordinator::new(state);
+
+        assert!(coordinator.allows("conv-1", RuntimeWriteKind::AssistantTextFinalize));
+        assert!(coordinator.allows("conv-1", RuntimeWriteKind::ConversationFinished));
+        assert!(!coordinator.allows("conv-1", RuntimeWriteKind::SendFailureTip));
+        assert!(!coordinator.allows("conv-1", RuntimeWriteKind::AcpRecoveryCleanup));
+    }
+
+    #[test]
+    fn shutting_down_skips_new_runtime_finalization_failure_and_recovery() {
+        let state = Arc::new(ConversationRuntimeStateService::default());
+        state.mark_shutting_down();
+        let coordinator = RuntimePersistenceCoordinator::new(state);
+
+        assert!(!coordinator.allows("conv-1", RuntimeWriteKind::ConversationFinished));
+        assert!(!coordinator.allows("conv-1", RuntimeWriteKind::SendFailureTip));
+        assert!(!coordinator.allows("conv-1", RuntimeWriteKind::AcpRecoveryCleanup));
+    }
+}

--- a/crates/aionui-conversation/src/runtime_state.rs
+++ b/crates/aionui-conversation/src/runtime_state.rs
@@ -18,6 +18,8 @@ pub struct ConversationRuntimeStateService {
 struct ConversationRuntimeState {
     active_turns: HashSet<String>,
     deleting_conversations: HashSet<String>,
+    cancelling_conversations: HashSet<String>,
+    shutting_down: bool,
 }
 
 #[derive(Debug)]
@@ -25,6 +27,14 @@ pub struct TurnClaim {
     conversation_id: String,
     state: Weak<ConversationRuntimeStateService>,
     released: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeLifecycleState {
+    Active,
+    Deleting,
+    Cancelling,
+    ShuttingDown,
 }
 
 impl ConversationRuntimeStateService {
@@ -36,6 +46,16 @@ impl ConversationRuntimeStateService {
             );
             ConversationError::internal("conversation runtime state lock poisoned")
         })?;
+
+        if state.shutting_down {
+            info!(
+                conversation_id,
+                "conversation runtime turn claim rejected because runtime is shutting down"
+            );
+            return Err(ConversationError::Busy {
+                reason: "conversation runtime is shutting down".into(),
+            });
+        }
 
         if state.deleting_conversations.contains(conversation_id) {
             info!(
@@ -109,6 +129,84 @@ impl ConversationRuntimeStateService {
             .unwrap_or(false)
     }
 
+    pub fn mark_cancelling(&self, conversation_id: &str) {
+        match self.state.lock() {
+            Ok(mut state) => {
+                state.cancelling_conversations.insert(conversation_id.to_owned());
+                info!(conversation_id, "conversation marked cancelling");
+            }
+            Err(_) => {
+                warn!(
+                    conversation_id,
+                    "conversation runtime state lock poisoned while marking cancel"
+                );
+            }
+        }
+    }
+
+    pub fn clear_cancelling(&self, conversation_id: &str) {
+        match self.state.lock() {
+            Ok(mut state) => {
+                state.cancelling_conversations.remove(conversation_id);
+            }
+            Err(_) => {
+                warn!(
+                    conversation_id,
+                    "conversation runtime state lock poisoned while clearing cancel"
+                );
+            }
+        }
+    }
+
+    pub fn is_cancelling(&self, conversation_id: &str) -> bool {
+        self.state
+            .lock()
+            .map(|state| state.cancelling_conversations.contains(conversation_id))
+            .unwrap_or(false)
+    }
+
+    pub fn mark_shutting_down(&self) -> usize {
+        match self.state.lock() {
+            Ok(mut state) => {
+                state.shutting_down = true;
+                let active_turn_count = state.active_turns.len();
+                info!(active_turn_count, "conversation runtime marked shutting down");
+                active_turn_count
+            }
+            Err(_) => {
+                warn!("conversation runtime state lock poisoned while marking shutdown");
+                0
+            }
+        }
+    }
+
+    pub fn is_shutting_down(&self) -> bool {
+        self.state.lock().map(|state| state.shutting_down).unwrap_or(true)
+    }
+
+    pub fn lifecycle_for(&self, conversation_id: &str) -> RuntimeLifecycleState {
+        match self.state.lock() {
+            Ok(state) => {
+                if state.shutting_down {
+                    RuntimeLifecycleState::ShuttingDown
+                } else if state.deleting_conversations.contains(conversation_id) {
+                    RuntimeLifecycleState::Deleting
+                } else if state.cancelling_conversations.contains(conversation_id) {
+                    RuntimeLifecycleState::Cancelling
+                } else {
+                    RuntimeLifecycleState::Active
+                }
+            }
+            Err(_) => {
+                warn!(
+                    conversation_id,
+                    "conversation runtime state lock poisoned while reading lifecycle"
+                );
+                RuntimeLifecycleState::ShuttingDown
+            }
+        }
+    }
+
     pub fn summary_from_parts(
         &self,
         conversation_id: &str,
@@ -145,6 +243,7 @@ impl ConversationRuntimeStateService {
             Ok(mut state) => {
                 state.active_turns.remove(conversation_id);
                 let was_deleting = state.deleting_conversations.remove(conversation_id);
+                state.cancelling_conversations.remove(conversation_id);
                 info!(
                     conversation_id,
                     deleting = was_deleting,
@@ -239,6 +338,43 @@ mod tests {
         assert!(claim.release());
 
         assert!(!state.is_deleting("conv-1"));
+    }
+
+    #[test]
+    fn claim_rejects_when_shutting_down() {
+        let state = Arc::new(ConversationRuntimeStateService::default());
+
+        state.mark_shutting_down();
+
+        let err = state
+            .try_claim_turn("conv-1")
+            .expect_err("shutting down runtime should reject new turns");
+        assert!(err.to_string().contains("shutting down"));
+    }
+
+    #[test]
+    fn lifecycle_prioritizes_shutdown_over_conversation_flags() {
+        let state = Arc::new(ConversationRuntimeStateService::default());
+
+        state.mark_deleting("conv-1");
+        state.mark_cancelling("conv-1");
+        assert_eq!(state.lifecycle_for("conv-1"), RuntimeLifecycleState::Deleting);
+
+        state.mark_shutting_down();
+        assert_eq!(state.lifecycle_for("conv-1"), RuntimeLifecycleState::ShuttingDown);
+    }
+
+    #[test]
+    fn release_clears_cancelling_flag_for_active_turn() {
+        let state = Arc::new(ConversationRuntimeStateService::default());
+        let mut claim = state.try_claim_turn("conv-1").expect("claim should be created");
+
+        state.mark_cancelling("conv-1");
+        assert!(state.is_cancelling("conv-1"));
+
+        assert!(!claim.release());
+
+        assert!(!state.is_cancelling("conv-1"));
     }
 
     #[test]

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -2,10 +2,12 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use aionui_ai_agent::session_context::{AgentSessionContext, AgentSessionKind};
-use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
+use aionui_ai_agent::types::BuildTaskOptions;
 use aionui_ai_agent::{AgentError, AgentInstance, AgentSendError, IWorkerTaskManager};
 
 use crate::response_middleware::ICronService;
+use crate::runtime_completion::RuntimeCompletionPublisher;
+use crate::runtime_persistence::{RuntimePersistenceCoordinator, RuntimeWriteKind};
 use crate::runtime_state::ConversationRuntimeStateService;
 use aionui_api_types::{
     ApprovalCheckResponse, CloneConversationRequest, ConfirmRequest, ConfirmationListResponse,
@@ -29,7 +31,6 @@ use aionui_mcp::{AcpMcpCapabilities, parse_acp_mcp_capabilities};
 use aionui_realtime::EventBroadcaster;
 use aionui_runtime::{RuntimeCommandProbe, probe_node_runtime_supported, probe_runtime_command, resolve_command_path};
 use std::collections::{HashMap, HashSet};
-use tokio::sync::oneshot;
 use tracing::{debug, error, info, warn};
 
 use crate::convert::{
@@ -40,10 +41,10 @@ use crate::error::ConversationError;
 use crate::session_context::SessionContextBuilder;
 use crate::skill_resolver::SkillResolver;
 use crate::skill_snapshot::{backfill_skills_if_missing, compute_initial_skills};
-use crate::stream_relay::StreamRelay;
+use crate::turn_orchestrator::{ConversationTurnOrchestrator, TurnStartInput};
 use std::sync::RwLock;
 
-const MAX_CRON_CONTINUATIONS_PER_TURN: usize = 4;
+pub(crate) const MAX_CRON_CONTINUATIONS_PER_TURN: usize = 4;
 
 #[derive(Debug, Clone, Copy)]
 struct McpSupportPolicy {
@@ -187,12 +188,28 @@ impl ConversationService {
         &self.conversation_repo
     }
 
+    pub(crate) fn broadcaster(&self) -> &Arc<dyn EventBroadcaster> {
+        &self.broadcaster
+    }
+
     pub(crate) fn acp_session_repo(&self) -> &Arc<dyn IAcpSessionRepository> {
         &self.acp_session_repo
     }
 
     pub fn runtime_state(&self) -> Arc<ConversationRuntimeStateService> {
         self.runtime_state.clone()
+    }
+
+    pub(crate) fn runtime_persistence(&self) -> RuntimePersistenceCoordinator {
+        RuntimePersistenceCoordinator::new(self.runtime_state())
+    }
+
+    pub(crate) fn completion_publisher(&self) -> RuntimeCompletionPublisher {
+        RuntimeCompletionPublisher::new(
+            self.conversation_repo.clone(),
+            self.broadcaster.clone(),
+            self.runtime_persistence(),
+        )
     }
 
     pub(crate) fn task(&self, conversation_id: &str) -> Result<AgentInstance, ConversationError> {
@@ -214,25 +231,13 @@ impl ConversationService {
     }
 
     pub async fn complete_turn(&self, conversation_id: &str) {
-        if self.runtime_state.is_deleting(conversation_id) {
-            debug!(
-                conversation_id,
-                "Skipping turn completion because conversation is deleting"
-            );
-            return;
-        }
-
         let runtime = self.runtime_summary_for(conversation_id).await;
-        StreamRelay::complete_conversation_with_runtime(
-            &self.conversation_repo,
-            &self.broadcaster,
-            conversation_id,
-            Some(runtime),
-        )
-        .await;
+        self.completion_publisher()
+            .publish(conversation_id, Some(runtime))
+            .await;
     }
 
-    async fn complete_released_turn(&self, conversation_id: &str, was_deleting: bool) {
+    pub(crate) async fn complete_released_turn(&self, conversation_id: &str, was_deleting: bool) {
         if was_deleting {
             debug!(
                 conversation_id,
@@ -1394,6 +1399,15 @@ impl ConversationService {
             hidden: req.hidden,
             created_at: now_ms(),
         };
+        if !self
+            .runtime_persistence()
+            .allows(conversation_id, RuntimeWriteKind::UserMessage)
+        {
+            let mut turn_claim = turn_claim;
+            let was_deleting = turn_claim.release();
+            self.complete_released_turn(conversation_id, was_deleting).await;
+            return Ok(user_msg_id);
+        }
         if let Err(e) = self.conversation_repo.insert_message(&user_msg).await {
             warn!(msg_id = %user_msg_id, error = %ErrorChain(&e), "Failed to insert user message");
             return Err(e.into());
@@ -1436,197 +1450,14 @@ impl ConversationService {
         self.ensure_auto_workspace_skill_links(&row, &build_opts).await;
         let stored_workspace = build_opts.context.workspace.stored_path.clone();
 
-        let conv_id = conversation_id.to_owned();
-        let repo = Arc::clone(&self.conversation_repo);
-        let broadcaster = Arc::clone(&self.broadcaster);
-        let cron_service = self.current_cron_service();
-        let runtime_state = self.runtime_state();
-        let user_id_owned = user_id.to_owned();
-        let service = self.clone();
-        let task_manager = Arc::clone(task_manager);
-
-        // Send message to the agent in a background task.
-        // prompt() blocks until the PromptResponse arrives (turn completed),
-        // but the HTTP handler should return 202 immediately.
-        //
-        // Every turn mints a fresh msg_id and passes it as the agent
-        // correlation id so DB row, WebSocket stream events, and
-        // agent-internal tracing all share one identifier per turn.
         let user_msg_id_ret = user_msg_id.clone();
-        tokio::spawn(async move {
-            let mut turn_claim = turn_claim;
-            let build_started_at = now_ms();
-            info!(conversation_id = %conv_id, "Agent task build started");
-            let agent = match task_manager.get_or_build_task(&conv_id, build_opts).await {
-                Ok(agent) => agent,
-                Err(err) => {
-                    let top_level_code = agent_error_top_level_code(&err);
-                    let send_error = AgentSendError::from_agent_error_ref(&err);
-                    error!(
-                        conversation_id = %conv_id,
-                        error_code = ?send_error.code(),
-                        error = %ErrorChain(&err),
-                        "Agent task build failed"
-                    );
-                    if service.runtime_state.is_deleting(&conv_id) {
-                        debug!(
-                            conversation_id = %conv_id,
-                            "Skipping send failure persistence because conversation is deleting"
-                        );
-                    } else {
-                        service
-                            .persist_and_broadcast_send_failure_tip(&conv_id, &send_error, Some(top_level_code))
-                            .await;
-                    }
-                    let was_deleting = turn_claim.release();
-                    service.complete_released_turn(&conv_id, was_deleting).await;
-                    return;
-                }
-            };
-
-            // If the factory resolved a different workspace (e.g. auto-created temp
-            // dir for a legacy conversation with empty workspace), persist it back.
-            if let Err(err) = service
-                .maybe_persist_workspace(&conv_id, &stored_workspace, agent.workspace())
-                .await
-            {
-                let top_level_code = err.error_code();
-                let send_error = AgentSendError::from_agent_error(err.to_agent_error());
-                error!(
-                    conversation_id = %conv_id,
-                    error_code = err.error_code(),
-                    error = %ErrorChain(&err),
-                    "Failed to persist resolved workspace"
-                );
-                if service.runtime_state.is_deleting(&conv_id) {
-                    debug!(
-                        conversation_id = %conv_id,
-                        "Skipping workspace failure persistence because conversation is deleting"
-                    );
-                } else {
-                    service
-                        .persist_and_broadcast_send_failure_tip(&conv_id, &send_error, Some(top_level_code))
-                        .await;
-                }
-                let was_deleting = turn_claim.release();
-                service.complete_released_turn(&conv_id, was_deleting).await;
-                return;
-            }
-
-            info!(
-                conversation_id = %conv_id,
-                agent_type = ?agent.agent_type(),
-                elapsed_ms = now_ms().saturating_sub(build_started_at),
-                "Agent task ready"
-            );
-
-            let first_turn_msg_id = Self::mint_msg_id();
-            let mut pending_send = Some((
-                SendMessageData {
-                    content: req.content,
-                    msg_id: first_turn_msg_id.clone(),
-                    files: req.files,
-                    inject_skills: req.inject_skills,
-                },
-                first_turn_msg_id,
-            ));
-            let mut continuation_count = 0usize;
-
-            while let Some((current_send, msg_id)) = pending_send.take() {
-                if continuation_count >= MAX_CRON_CONTINUATIONS_PER_TURN {
-                    warn!(
-                        conversation_id = %conv_id,
-                        max = MAX_CRON_CONTINUATIONS_PER_TURN,
-                        "Reached cron continuation limit; ending turn early"
-                    );
-                    break;
-                }
-
-                let relay = StreamRelay::new(
-                    conv_id.clone(),
-                    msg_id,
-                    user_id_owned.clone(),
-                    Arc::clone(&repo),
-                    Arc::clone(&broadcaster),
-                    cron_service.clone(),
-                )
-                .with_runtime_state(Arc::clone(&runtime_state))
-                .with_turn_completion(false);
-
-                let rx = agent.subscribe();
-                let send_agent = agent.clone();
-                let conv_id_send = conv_id.clone();
-                let (send_error_tx, send_error_rx) = oneshot::channel();
-                // 1. Send the message to the agent and concurrently run the relay to stream events.
-                tokio::spawn(async move {
-                    if let Err(e) = send_agent.send_message(current_send).await {
-                        let task_status = send_agent.status();
-                        let agent_type = send_agent.agent_type();
-                        error!(
-                            conversation_id = %conv_id_send,
-                            ?agent_type,
-                            ?task_status,
-                            error = %ErrorChain(&e),
-                            "Agent send_message failed"
-                        );
-                        if task_status == Some(ConversationStatus::Finished) {
-                            debug!(
-                                conversation_id = %conv_id_send,
-                                ?agent_type,
-                                "Agent send_message failure already published runtime terminal; skipping fallback stream error"
-                            );
-                        } else {
-                            warn!(
-                                conversation_id = %conv_id_send,
-                                ?agent_type,
-                                code = ?e.code(),
-                                ownership = ?e.ownership(),
-                                "Agent send_message returned error without runtime terminal; injecting fallback stream error"
-                            );
-                            let _ = send_error_tx.send(e);
-                        }
-                    }
-                });
-                // 2. Wait for the agent to process the message and complete the turn, while the relay streams events in real time.
-                let outcome = relay.consume_with_send_error(rx, send_error_rx).await;
-
-                if runtime_state.is_deleting(&conv_id) {
-                    debug!(
-                        conversation_id = %conv_id,
-                        "Skipping post-terminal persistence because conversation is deleting"
-                    );
-                    break;
-                }
-
-                if let Some(session_key) = agent.get_session_key() {
-                    persist_session_key(&repo, &conv_id, &session_key).await;
-                }
-
-                if service
-                    .evict_acp_task_after_terminal_error(&conv_id, agent.agent_type(), &outcome, &task_manager)
-                    .await
-                {
-                    break;
-                }
-
-                if outcome.system_responses.is_empty() {
-                    break;
-                }
-                continuation_count += 1;
-                let next_turn_msg_id = Self::mint_msg_id();
-                pending_send = Some((
-                    SendMessageData {
-                        content: outcome.system_responses.join("\n"),
-                        msg_id: next_turn_msg_id.clone(),
-                        files: vec![],
-                        inject_skills: vec![],
-                    },
-                    next_turn_msg_id,
-                ));
-            }
-
-            let was_deleting = turn_claim.release();
-            service.complete_released_turn(&conv_id, was_deleting).await;
+        ConversationTurnOrchestrator::new(self.clone(), Arc::clone(task_manager)).spawn_user_turn(TurnStartInput {
+            user_id: user_id.to_owned(),
+            conversation: row,
+            request: req,
+            build_options: build_opts,
+            stored_workspace,
+            turn_claim,
         });
 
         info!(
@@ -1637,7 +1468,7 @@ impl ConversationService {
         Ok(user_msg_id_ret)
     }
 
-    async fn persist_and_broadcast_send_failure_tip(
+    pub(crate) async fn persist_and_broadcast_send_failure_tip(
         &self,
         conversation_id: &str,
         err: &AgentSendError,
@@ -1763,7 +1594,7 @@ impl ConversationService {
 
 // ── Internal Helpers ────────────────────────────────────────────────
 
-fn agent_error_top_level_code(error: &AgentError) -> &'static str {
+pub(crate) fn agent_error_top_level_code(error: &AgentError) -> &'static str {
     match error {
         AgentError::BadRequest(_) => "BAD_REQUEST",
         AgentError::Unauthorized(_) => "UNAUTHORIZED",
@@ -1786,7 +1617,7 @@ impl ConversationService {
     /// Raw `conversation.extra` parsing lives in [`SessionContextBuilder`]
     /// so the task manager and concrete agent factories consume typed
     /// session context instead of the DB envelope.
-    async fn build_task_options(
+    pub(crate) async fn build_task_options(
         &self,
         row: &aionui_db::models::ConversationRow,
     ) -> Result<BuildTaskOptions, ConversationError> {
@@ -1805,7 +1636,7 @@ impl ConversationService {
             .await
     }
 
-    async fn ensure_auto_workspace_skill_links(&self, row: &ConversationRow, build_opts: &BuildTaskOptions) {
+    pub(crate) async fn ensure_auto_workspace_skill_links(&self, row: &ConversationRow, build_opts: &BuildTaskOptions) {
         let context = &build_opts.context;
         if context.workspace.is_custom {
             return;
@@ -1865,13 +1696,19 @@ impl ConversationService {
     /// This handles legacy conversations whose `extra.workspace` was empty:
     /// the factory creates a temp dir at task-build time, and we persist that
     /// path here so the frontend can display the workspace panel correctly.
-    async fn maybe_persist_workspace(
+    pub(crate) async fn maybe_persist_workspace(
         &self,
         conversation_id: &str,
         stored_workspace: &str,
         resolved_workspace: &str,
     ) -> Result<(), ConversationError> {
         if resolved_workspace.is_empty() || resolved_workspace == stored_workspace {
+            return Ok(());
+        }
+        if !self
+            .runtime_persistence()
+            .allows(conversation_id, RuntimeWriteKind::ResolvedWorkspace)
+        {
             return Ok(());
         }
 
@@ -1919,7 +1756,7 @@ impl ConversationService {
         self.broadcaster.broadcast(event);
     }
 
-    fn current_cron_service(&self) -> Option<Arc<dyn ICronService>> {
+    pub(crate) fn current_cron_service(&self) -> Option<Arc<dyn ICronService>> {
         match self.cron_service.read() {
             Ok(guard) => guard.as_ref().map(Arc::clone),
             Err(_) => None,
@@ -2311,7 +2148,16 @@ fn enum_to_db<T: serde::Serialize>(val: &T) -> Result<String, ConversationError>
 ///
 /// Called after send_message completes so the session can be resumed
 /// when the user re-enters this conversation later.
-async fn persist_session_key(repo: &Arc<dyn IConversationRepository>, conversation_id: &str, session_key: &str) {
+pub(crate) async fn persist_session_key(
+    repo: &Arc<dyn IConversationRepository>,
+    persistence: &RuntimePersistenceCoordinator,
+    conversation_id: &str,
+    session_key: &str,
+) {
+    if !persistence.allows(conversation_id, RuntimeWriteKind::SessionKey) {
+        return;
+    }
+
     let row = match repo.get(conversation_id).await {
         Ok(Some(r)) => r,
         _ => return,

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -330,6 +330,19 @@ impl IConversationRepository for MockRepo {
             .cloned())
     }
 
+    async fn list_stale_runtime_messages(&self) -> Result<Vec<MessageRow>, aionui_db::DbError> {
+        let messages = self.messages.lock().unwrap();
+        Ok(messages
+            .iter()
+            .filter(|message| {
+                message.position.as_deref() == Some("left")
+                    && matches!(message.status.as_deref(), Some("work" | "pending"))
+                    && matches!(message.r#type.as_str(), "text" | "thinking")
+            })
+            .cloned()
+            .collect())
+    }
+
     async fn search_messages(
         &self,
         _user_id: &str,
@@ -1491,6 +1504,58 @@ impl FailingBuildTaskManager {
     }
 }
 
+struct DelayedFailingBuildTaskManager {
+    delay: Duration,
+    error: String,
+}
+
+impl DelayedFailingBuildTaskManager {
+    fn new(delay: Duration, error: impl Into<String>) -> Self {
+        Self {
+            delay,
+            error: error.into(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl IWorkerTaskManager for DelayedFailingBuildTaskManager {
+    fn get_task(&self, _conversation_id: &str) -> Option<AgentInstance> {
+        None
+    }
+
+    async fn get_or_build_task(
+        &self,
+        _conversation_id: &str,
+        _options: BuildTaskOptions,
+    ) -> Result<AgentInstance, AgentError> {
+        tokio::time::sleep(self.delay).await;
+        Err(AgentError::bad_gateway(self.error.clone()))
+    }
+
+    fn kill(&self, _conversation_id: &str, _reason: Option<AgentKillReason>) -> Result<(), AgentError> {
+        Ok(())
+    }
+
+    fn kill_and_wait(
+        &self,
+        _conversation_id: &str,
+        _reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        Box::pin(std::future::ready(()))
+    }
+
+    fn clear(&self) {}
+
+    fn active_count(&self) -> usize {
+        0
+    }
+
+    fn collect_idle(&self, _idle_threshold_ms: TimestampMs) -> Vec<String> {
+        vec![]
+    }
+}
+
 #[async_trait::async_trait]
 impl IWorkerTaskManager for FailingBuildTaskManager {
     fn get_task(&self, _conversation_id: &str) -> Option<AgentInstance> {
@@ -2232,6 +2297,60 @@ async fn send_message_rejects_active_runtime_claim() {
 }
 
 #[tokio::test]
+async fn send_message_rejects_when_runtime_is_shutting_down() {
+    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
+
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+    svc.runtime_state().mark_shutting_down();
+
+    let err = svc
+        .send_message("user_1", &conv.id, make_send_req(), &task_mgr)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, ConversationError::Busy { .. }));
+
+    let messages = repo.get_messages(&conv.id, 1, 20, SortOrder::Asc).await.unwrap().items;
+    assert!(
+        messages.is_empty(),
+        "shutdown rejection must not persist a user message"
+    );
+}
+
+#[tokio::test]
+async fn send_message_build_failure_while_deleting_skips_failure_tip_and_completion() {
+    let (svc, broadcaster, repo, _task_mgr) = make_service();
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(DelayedFailingBuildTaskManager::new(
+        Duration::from_millis(100),
+        "delayed build failure",
+    ));
+
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+    broadcaster.take_events();
+
+    let msg_id = svc
+        .send_message("user_1", &conv.id, make_send_req(), &task_mgr)
+        .await
+        .unwrap();
+    assert!(!msg_id.is_empty());
+
+    svc.runtime_state().mark_deleting(&conv.id);
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    let messages = repo.get_messages(&conv.id, 1, 20, SortOrder::Asc).await.unwrap().items;
+    assert!(
+        messages.iter().all(|message| message.r#type != "tips"),
+        "deleting conversation must skip build-failure tips"
+    );
+
+    let events = broadcaster.take_events();
+    assert!(
+        events.iter().all(|event| event.name != "turn.completed"),
+        "deleting conversation must not publish turn.completed"
+    );
+}
+
+#[tokio::test]
 async fn send_message_persists_factory_resolved_workspace() {
     // Conversation created with no workspace → create() auto-assigns one.
     // Factory resolves a *different* temp dir (simulating legacy-conv fallback).
@@ -2273,6 +2392,55 @@ async fn send_message_persists_factory_resolved_workspace() {
     .await
     .expect("factory-resolved workspace should be persisted in the background");
     assert_eq!(updated.extra["workspace"], auto_workspace);
+}
+
+#[tokio::test]
+async fn startup_recovery_closes_stale_runtime_messages_without_failure_tip() {
+    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    repo.insert_message(&MessageRow {
+        id: "visible-stale".into(),
+        conversation_id: conv.id.clone(),
+        msg_id: Some("visible-stale".into()),
+        r#type: "text".into(),
+        content: json!({ "content": "partial output" }).to_string(),
+        position: Some("left".into()),
+        status: Some("work".into()),
+        hidden: false,
+        created_at: 1,
+    })
+    .await
+    .unwrap();
+    repo.insert_message(&MessageRow {
+        id: "empty-stale".into(),
+        conversation_id: conv.id.clone(),
+        msg_id: Some("empty-stale".into()),
+        r#type: "thinking".into(),
+        content: json!({ "content": "" }).to_string(),
+        position: Some("left".into()),
+        status: Some("pending".into()),
+        hidden: false,
+        created_at: 2,
+    })
+    .await
+    .unwrap();
+
+    svc.recover_stale_runtime_state_on_startup().await;
+
+    let messages = repo.get_messages(&conv.id, 1, 20, SortOrder::Asc).await.unwrap().items;
+    let visible = messages.iter().find(|message| message.id == "visible-stale").unwrap();
+    assert_eq!(visible.status.as_deref(), Some("finish"));
+    assert!(!visible.hidden);
+
+    let empty = messages.iter().find(|message| message.id == "empty-stale").unwrap();
+    assert_eq!(empty.status.as_deref(), Some("finish"));
+    assert!(empty.hidden);
+
+    assert!(
+        messages.iter().all(|message| message.r#type != "tips"),
+        "startup recovery must not write failure tips"
+    );
 }
 
 #[tokio::test]

--- a/crates/aionui-conversation/src/startup_recovery.rs
+++ b/crates/aionui-conversation/src/startup_recovery.rs
@@ -1,0 +1,136 @@
+use aionui_common::ErrorChain;
+use aionui_db::MessageRowUpdate;
+use aionui_db::models::MessageRow;
+use tracing::{info, warn};
+
+use crate::runtime_persistence::RuntimeWriteKind;
+use crate::service::ConversationService;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StartupRecoveryAction {
+    FinishVisibleOutput,
+    FinishEmptyPlaceholder,
+}
+
+impl ConversationService {
+    pub async fn recover_stale_runtime_state_on_startup(&self) {
+        let rows = match self.conversation_repo().list_stale_runtime_messages().await {
+            Ok(rows) => rows,
+            Err(error) => {
+                warn!(
+                    error = %ErrorChain(&error),
+                    "startup recovery skipped because stale runtime message query failed"
+                );
+                return;
+            }
+        };
+
+        let mut recovered = 0usize;
+        for row in rows {
+            if !self
+                .runtime_persistence()
+                .allows(&row.conversation_id, RuntimeWriteKind::StartupRecovery)
+            {
+                continue;
+            }
+
+            let action = classify_recovery_action(&row);
+            let update = MessageRowUpdate {
+                content: None,
+                status: Some(Some("finish".to_owned())),
+                hidden: Some(matches!(action, StartupRecoveryAction::FinishEmptyPlaceholder)),
+            };
+
+            match self.conversation_repo().update_message(&row.id, &update).await {
+                Ok(()) => {
+                    recovered += 1;
+                    info!(
+                        conversation_id = %row.conversation_id,
+                        msg_id = ?row.msg_id,
+                        message_type = %row.r#type,
+                        recovery_action = ?action,
+                        "startup recovery closed stale runtime message"
+                    );
+                }
+                Err(error) => {
+                    warn!(
+                        conversation_id = %row.conversation_id,
+                        msg_id = ?row.msg_id,
+                        error = %ErrorChain(&error),
+                        "startup recovery failed to close stale runtime message"
+                    );
+                }
+            }
+        }
+
+        if recovered > 0 {
+            info!(recovered, "startup recovery completed for stale runtime messages");
+        }
+    }
+}
+
+fn classify_recovery_action(row: &MessageRow) -> StartupRecoveryAction {
+    if message_has_visible_content(row) {
+        StartupRecoveryAction::FinishVisibleOutput
+    } else {
+        StartupRecoveryAction::FinishEmptyPlaceholder
+    }
+}
+
+fn message_has_visible_content(row: &MessageRow) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&row.content) else {
+        return !row.content.trim().is_empty();
+    };
+
+    value
+        .get("content")
+        .and_then(|content| content.as_str())
+        .is_some_and(|content| !content.trim().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use aionui_db::models::MessageRow;
+
+    use super::*;
+
+    #[test]
+    fn visible_text_finishes_as_visible_output() {
+        let row = MessageRow {
+            id: "msg-1".into(),
+            conversation_id: "conv-1".into(),
+            msg_id: Some("msg-1".into()),
+            r#type: "text".into(),
+            content: serde_json::json!({ "content": "hello" }).to_string(),
+            position: Some("left".into()),
+            status: Some("work".into()),
+            hidden: false,
+            created_at: 1,
+        };
+
+        assert_eq!(
+            classify_recovery_action(&row),
+            StartupRecoveryAction::FinishVisibleOutput
+        );
+    }
+
+    #[test]
+    fn empty_text_finishes_as_hidden_placeholder() {
+        let row = MessageRow {
+            id: "msg-1".into(),
+            conversation_id: "conv-1".into(),
+            msg_id: Some("msg-1".into()),
+            r#type: "text".into(),
+            content: serde_json::json!({ "content": "" }).to_string(),
+            position: Some("left".into()),
+            status: Some("work".into()),
+            hidden: false,
+            created_at: 1,
+        };
+
+        assert_eq!(
+            classify_recovery_action(&row),
+            StartupRecoveryAction::FinishEmptyPlaceholder
+        );
+    }
+}

--- a/crates/aionui-conversation/src/stream_persistence.rs
+++ b/crates/aionui-conversation/src/stream_persistence.rs
@@ -1,0 +1,570 @@
+use std::sync::Arc;
+
+use aionui_ai_agent::protocol::events::{
+    ErrorEventData,
+    tool_call::{AcpToolCallSessionUpdateKind, AcpToolCallStatus, ToolCallStatus},
+};
+use aionui_api_types::{ConversationRuntimeSummary, WebSocketMessage};
+use aionui_common::{ErrorChain, normalize_keys_to_snake_case, now_ms};
+use aionui_db::models::MessageRow;
+use aionui_db::{ConversationRowUpdate, DbError, IConversationRepository, MessageRowUpdate};
+use aionui_realtime::EventBroadcaster;
+use serde_json::json;
+use tracing::{debug, error, warn};
+
+use crate::runtime_completion::RuntimeCompletionPublisher;
+use crate::runtime_persistence::{RuntimePersistenceCoordinator, RuntimeWriteKind};
+use crate::service::ConversationService;
+
+fn is_not_found(err: &DbError) -> bool {
+    matches!(err, DbError::NotFound(_))
+}
+
+fn is_foreign_key_constraint(err: &DbError) -> bool {
+    err.to_string().contains("FOREIGN KEY constraint failed")
+}
+
+fn is_deleted_during_stream_persistence(err: &DbError) -> bool {
+    is_not_found(err) || is_foreign_key_constraint(err)
+}
+
+fn log_persist_error(err: &DbError, message: &'static str) {
+    if is_deleted_during_stream_persistence(err) {
+        debug!(error = %ErrorChain(err), "{message}; conversation was likely deleted during stream finalization");
+    } else {
+        error!(error = %ErrorChain(err), "{message}");
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TextSegmentState {
+    pub id: String,
+    pub buffer: String,
+    pub created_at: i64,
+    pub record_created: bool,
+    pub flush_counter: u32,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PersistedTextSegment {
+    pub id: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ThinkingSegmentState {
+    pub id: String,
+    pub buffer: String,
+    pub started_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FinalTextOverride {
+    pub msg_id: String,
+    pub text: String,
+    pub hidden: bool,
+}
+
+#[derive(Clone)]
+pub(crate) struct StreamPersistenceAdapter {
+    conversation_id: String,
+    msg_id: String,
+    repo: Arc<dyn IConversationRepository>,
+    persistence: Option<RuntimePersistenceCoordinator>,
+}
+
+impl StreamPersistenceAdapter {
+    pub fn new(
+        conversation_id: String,
+        msg_id: String,
+        repo: Arc<dyn IConversationRepository>,
+        persistence: Option<RuntimePersistenceCoordinator>,
+    ) -> Self {
+        Self {
+            conversation_id,
+            msg_id,
+            repo,
+            persistence,
+        }
+    }
+
+    pub fn with_persistence(mut self, persistence: RuntimePersistenceCoordinator) -> Self {
+        self.persistence = Some(persistence);
+        self
+    }
+
+    #[tracing::instrument(skip_all, fields(conversation_id = %self.conversation_id))]
+    pub async fn complete_conversation(
+        &self,
+        broadcaster: &Arc<dyn EventBroadcaster>,
+        runtime: Option<ConversationRuntimeSummary>,
+    ) {
+        if let Some(persistence) = &self.persistence {
+            RuntimeCompletionPublisher::new(self.repo.clone(), broadcaster.clone(), persistence.clone())
+                .publish(&self.conversation_id, runtime)
+                .await;
+            return;
+        }
+
+        let update = ConversationRowUpdate {
+            status: Some("finished".to_owned()),
+            updated_at: Some(now_ms()),
+            ..Default::default()
+        };
+        if let Err(e) = self.repo.update(&self.conversation_id, &update).await {
+            log_persist_error(&e, "Failed to update conversation status");
+        }
+
+        let payload = json!({
+            "conversation_id": self.conversation_id,
+            "session_id": self.conversation_id,
+            "status": "finished",
+            "canSendMessage": true,
+            "runtime": runtime,
+        });
+        broadcaster.broadcast(WebSocketMessage::new("turn.completed", payload));
+
+        debug!(conversation_id = %self.conversation_id, status = "finished", "Turn completed");
+    }
+
+    fn allows_write(&self, kind: RuntimeWriteKind) -> bool {
+        self.persistence
+            .as_ref()
+            .is_none_or(|persistence| persistence.allows(&self.conversation_id, kind))
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub async fn flush_text_segment(&self, segment: &mut TextSegmentState) {
+        if !self.allows_write(RuntimeWriteKind::AssistantTextFlush) {
+            return;
+        }
+        if segment.buffer.is_empty() {
+            return;
+        }
+
+        let content = json!({ "content": segment.buffer }).to_string();
+
+        if segment.record_created {
+            let update = MessageRowUpdate {
+                content: Some(content),
+                status: Some(Some("work".into())),
+                hidden: None,
+            };
+            if let Err(e) = self.repo.update_message(&segment.id, &update).await {
+                log_persist_error(&e, "Failed to update streaming text segment");
+            }
+        } else {
+            let row = MessageRow {
+                id: segment.id.clone(),
+                conversation_id: self.conversation_id.clone(),
+                msg_id: Some(segment.id.clone()),
+                r#type: "text".into(),
+                content,
+                position: Some("left".into()),
+                status: Some("work".into()),
+                hidden: false,
+                created_at: segment.created_at,
+            };
+            if let Err(e) = self.repo.insert_message(&row).await {
+                log_persist_error(&e, "Failed to create streaming text segment");
+            }
+            segment.record_created = true;
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub async fn finalize_text_segment(&self, segment: TextSegmentState, status: &str) -> Option<PersistedTextSegment> {
+        if !self.allows_write(RuntimeWriteKind::AssistantTextFinalize) {
+            return None;
+        }
+        if segment.buffer.is_empty() {
+            return None;
+        }
+
+        let content = json!({ "content": segment.buffer }).to_string();
+        if segment.record_created {
+            let update = MessageRowUpdate {
+                content: Some(content),
+                status: Some(Some(status.to_owned())),
+                hidden: Some(false),
+            };
+            if let Err(e) = self.repo.update_message(&segment.id, &update).await {
+                log_persist_error(&e, "Failed to finalize text segment");
+                return None;
+            }
+        } else {
+            let row = MessageRow {
+                id: segment.id.clone(),
+                conversation_id: self.conversation_id.clone(),
+                msg_id: Some(segment.id.clone()),
+                r#type: "text".into(),
+                content,
+                position: Some("left".into()),
+                status: Some(status.to_owned()),
+                hidden: false,
+                created_at: segment.created_at,
+            };
+            if let Err(e) = self.repo.insert_message(&row).await {
+                log_persist_error(&e, "Failed to create finalized text segment");
+                return None;
+            }
+        }
+
+        Some(PersistedTextSegment { id: segment.id })
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub async fn persist_final_text(
+        &self,
+        text_segments: &[PersistedTextSegment],
+        status: &str,
+        final_text: &str,
+        hidden: bool,
+        rewrite_segments: bool,
+    ) -> Vec<FinalTextOverride> {
+        if !self.allows_write(RuntimeWriteKind::TerminalFinalize) {
+            return Vec::new();
+        }
+
+        let mut overrides = Vec::new();
+        if let Some(primary_segment) = text_segments.first() {
+            if rewrite_segments {
+                let content = json!({ "content": final_text }).to_string();
+                let update = MessageRowUpdate {
+                    content: Some(content),
+                    status: Some(Some(status.to_owned())),
+                    hidden: Some(hidden),
+                };
+                if let Err(e) = self.repo.update_message(&primary_segment.id, &update).await {
+                    log_persist_error(&e, "Failed to rewrite finalized text segment");
+                }
+                overrides.push(FinalTextOverride {
+                    msg_id: primary_segment.id.clone(),
+                    text: final_text.to_owned(),
+                    hidden,
+                });
+
+                for segment in text_segments.iter().skip(1) {
+                    let hide_update = MessageRowUpdate {
+                        content: None,
+                        status: Some(Some(status.to_owned())),
+                        hidden: Some(true),
+                    };
+                    if let Err(e) = self.repo.update_message(&segment.id, &hide_update).await {
+                        log_persist_error(&e, "Failed to hide superseded text segment");
+                    }
+                    overrides.push(FinalTextOverride {
+                        msg_id: segment.id.clone(),
+                        text: String::new(),
+                        hidden: true,
+                    });
+                }
+            } else {
+                for segment in text_segments {
+                    let status_update = MessageRowUpdate {
+                        content: None,
+                        status: Some(Some(status.to_owned())),
+                        hidden: Some(false),
+                    };
+                    if let Err(e) = self.repo.update_message(&segment.id, &status_update).await {
+                        log_persist_error(&e, "Failed to finalize text segment status");
+                    }
+                }
+            }
+        } else if !hidden {
+            let row = MessageRow {
+                id: self.msg_id.clone(),
+                conversation_id: self.conversation_id.clone(),
+                msg_id: Some(self.msg_id.clone()),
+                r#type: "text".into(),
+                content: json!({ "content": final_text }).to_string(),
+                position: Some("left".into()),
+                status: Some(status.to_owned()),
+                hidden: false,
+                created_at: now_ms(),
+            };
+            if let Err(e) = self.repo.insert_message(&row).await {
+                log_persist_error(&e, "Failed to create final fallback message");
+            }
+        }
+
+        overrides
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub async fn persist_error_tip(&self, data: &ErrorEventData) {
+        if !self.allows_write(RuntimeWriteKind::TerminalFinalize) {
+            return;
+        }
+
+        let content = json!({ "content": &data.message, "type": "error", "error": &data }).to_string();
+        let row = MessageRow {
+            id: ConversationService::mint_msg_id(),
+            conversation_id: self.conversation_id.clone(),
+            msg_id: None,
+            r#type: "tips".into(),
+            content,
+            position: Some("left".into()),
+            status: Some("error".into()),
+            hidden: false,
+            created_at: now_ms(),
+        };
+        if let Err(e) = self.repo.insert_message(&row).await {
+            log_persist_error(&e, "Failed to store error message");
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub async fn persist_thinking_segment(&self, segment: ThinkingSegmentState, duration_ms: u64) {
+        if segment.buffer.is_empty() {
+            return;
+        }
+        if !self.allows_write(RuntimeWriteKind::AssistantThinkingFinalize) {
+            return;
+        }
+        let content = json!({
+            "content": segment.buffer,
+            "status": "done",
+            "duration_ms": duration_ms,
+        })
+        .to_string();
+        let row = MessageRow {
+            id: segment.id.clone(),
+            conversation_id: self.conversation_id.clone(),
+            msg_id: Some(segment.id),
+            r#type: "thinking".into(),
+            content,
+            position: Some("left".into()),
+            status: Some("finish".into()),
+            hidden: false,
+            created_at: segment.started_at,
+        };
+        if let Err(e) = self.repo.insert_message(&row).await {
+            log_persist_error(&e, "Failed to persist thinking message");
+        }
+    }
+
+    /// Persist a Gemini-style tool_call event.
+    #[tracing::instrument(skip_all)]
+    pub async fn persist_tool_call(&self, data: &aionui_ai_agent::protocol::events::tool_call::ToolCallEventData) {
+        if !self.allows_write(RuntimeWriteKind::ToolCallPersist) {
+            return;
+        }
+        if data.call_id.trim().is_empty() {
+            warn!(
+                tool = %data.name,
+                status = ?data.status,
+                "Skipping tool_call persistence because call_id is empty"
+            );
+            return;
+        }
+
+        let status = match data.status {
+            ToolCallStatus::Running => "work",
+            ToolCallStatus::Completed => "finish",
+            ToolCallStatus::Error => "error",
+        };
+        let content = serde_json::to_string(data).unwrap_or_default();
+
+        let existing = self
+            .repo
+            .get_message_by_msg_id(&self.conversation_id, &data.call_id, "tool_call")
+            .await
+            .unwrap_or(None);
+
+        if let Some(existing_row) = existing {
+            let merged_content = Self::merge_json_content(&existing_row.content, &content);
+            let update = MessageRowUpdate {
+                content: Some(merged_content),
+                status: Some(Some(status.to_owned())),
+                hidden: None,
+            };
+            if let Err(e) = self.repo.update_message(&data.call_id, &update).await {
+                error!(
+                    call_id = %data.call_id,
+                    tool = %data.name,
+                    status,
+                    error = %ErrorChain(&e),
+                    "Failed to update tool_call message"
+                );
+            } else {
+                debug!(
+                    call_id = %data.call_id,
+                    tool = %data.name,
+                    status,
+                    "Updated tool_call message"
+                );
+            }
+        } else {
+            let row = MessageRow {
+                id: data.call_id.clone(),
+                conversation_id: self.conversation_id.clone(),
+                msg_id: Some(data.call_id.clone()),
+                r#type: "tool_call".into(),
+                content,
+                position: Some("left".into()),
+                status: Some(status.to_owned()),
+                hidden: false,
+                created_at: now_ms(),
+            };
+            if let Err(e) = self.repo.insert_message(&row).await {
+                error!(
+                    call_id = %data.call_id,
+                    tool = %data.name,
+                    status,
+                    error = %ErrorChain(&e),
+                    "Failed to persist tool_call message"
+                );
+            } else {
+                debug!(
+                    call_id = %data.call_id,
+                    tool = %data.name,
+                    status,
+                    "Persisted tool_call message"
+                );
+            }
+        }
+    }
+
+    /// Persist an ACP (Claude CLI) tool call event.
+    #[tracing::instrument(skip_all)]
+    pub async fn persist_acp_tool_call(
+        &self,
+        data: &aionui_ai_agent::protocol::events::tool_call::AcpToolCallEventData,
+    ) {
+        if !self.allows_write(RuntimeWriteKind::AcpToolCallPersist) {
+            return;
+        }
+        let tool_call_id = &data.update.tool_call_id;
+        let status = match data.update.status {
+            Some(AcpToolCallStatus::Pending) | None => "work",
+            Some(AcpToolCallStatus::InProgress) => "work",
+            Some(AcpToolCallStatus::Completed) => "finish",
+            Some(AcpToolCallStatus::Failed) => "error",
+        };
+
+        let mut value = serde_json::to_value(data).unwrap_or_default();
+        normalize_keys_to_snake_case(&mut value);
+        let content = value.to_string();
+
+        match data.update.session_update {
+            AcpToolCallSessionUpdateKind::ToolCall => {
+                let row = MessageRow {
+                    id: tool_call_id.clone(),
+                    conversation_id: self.conversation_id.clone(),
+                    msg_id: Some(tool_call_id.clone()),
+                    r#type: "acp_tool_call".into(),
+                    content,
+                    position: Some("left".into()),
+                    status: Some(status.to_owned()),
+                    hidden: false,
+                    created_at: now_ms(),
+                };
+                if let Err(e) = self.repo.insert_message(&row).await {
+                    error!(error = %ErrorChain(&e), "Failed to persist acp_tool_call message");
+                }
+            }
+            AcpToolCallSessionUpdateKind::ToolCallUpdate => {
+                let merged_content = self.merge_acp_tool_call_content(tool_call_id, &value).await;
+                let update = MessageRowUpdate {
+                    content: Some(merged_content),
+                    status: Some(Some(status.to_owned())),
+                    hidden: None,
+                };
+                if let Err(e) = self.repo.update_message(tool_call_id, &update).await {
+                    error!(error = %ErrorChain(&e), "Failed to update acp_tool_call message");
+                }
+            }
+        }
+    }
+
+    /// Merge two JSON content strings: overlays non-null fields from `new_json`
+    /// onto `existing_json`, preserving fields only present in the original.
+    fn merge_json_content(existing_json: &str, new_json: &str) -> String {
+        let mut base: serde_json::Value = serde_json::from_str(existing_json).unwrap_or_default();
+        let new_value: serde_json::Value = serde_json::from_str(new_json).unwrap_or_default();
+        if let (Some(base_obj), Some(new_obj)) = (base.as_object_mut(), new_value.as_object()) {
+            for (key, val) in new_obj {
+                if !val.is_null() {
+                    base_obj.insert(key.clone(), val.clone());
+                }
+            }
+        }
+        base.to_string()
+    }
+
+    async fn merge_acp_tool_call_content(&self, tool_call_id: &str, update_value: &serde_json::Value) -> String {
+        let existing = self
+            .repo
+            .get_message_by_msg_id(&self.conversation_id, tool_call_id, "acp_tool_call")
+            .await
+            .ok()
+            .flatten();
+
+        let Some(existing_row) = existing else {
+            return update_value.to_string();
+        };
+
+        let mut base: serde_json::Value = serde_json::from_str(&existing_row.content).unwrap_or_default();
+        if let (Some(base_update), Some(new_update)) = (
+            base.get_mut("update").and_then(|v| v.as_object_mut()),
+            update_value.get("update").and_then(|v| v.as_object()),
+        ) {
+            for (key, val) in new_update {
+                if !val.is_null() {
+                    base_update.insert(key.clone(), val.clone());
+                }
+            }
+        }
+        base.to_string()
+    }
+
+    /// Persist a tool_group event (array of tool summaries).
+    #[tracing::instrument(skip_all)]
+    pub async fn persist_tool_group(&self, entries: &[aionui_ai_agent::protocol::events::tool_call::ToolGroupEntry]) {
+        if !self.allows_write(RuntimeWriteKind::ToolGroupPersist) {
+            return;
+        }
+        let all_done = entries
+            .iter()
+            .all(|e| matches!(e.status, ToolCallStatus::Completed | ToolCallStatus::Error));
+        let status = if all_done { "finish" } else { "work" };
+        let content = serde_json::to_string(entries).unwrap_or_default();
+
+        let group_id = entries
+            .first()
+            .map(|e| e.call_id.clone())
+            .unwrap_or_else(ConversationService::mint_msg_id);
+
+        let existing = self
+            .repo
+            .get_message_by_msg_id(&self.conversation_id, &group_id, "tool_group")
+            .await
+            .unwrap_or(None);
+
+        if existing.is_some() {
+            let update = MessageRowUpdate {
+                content: Some(content),
+                status: Some(Some(status.to_owned())),
+                hidden: None,
+            };
+            if let Err(e) = self.repo.update_message(&group_id, &update).await {
+                error!(error = %ErrorChain(&e), "Failed to update tool_group message");
+            }
+        } else {
+            let row = MessageRow {
+                id: group_id.clone(),
+                conversation_id: self.conversation_id.clone(),
+                msg_id: Some(group_id),
+                r#type: "tool_group".into(),
+                content,
+                position: Some("left".into()),
+                status: Some(status.to_owned()),
+                hidden: false,
+                created_at: now_ms(),
+            };
+            if let Err(e) = self.repo.insert_message(&row).await {
+                error!(error = %ErrorChain(&e), "Failed to persist tool_group message");
+            }
+        }
+    }
+}

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -1,70 +1,25 @@
 use std::sync::Arc;
 
-use aionui_ai_agent::{
-    AgentSendError, AgentStreamEvent,
-    protocol::events::{
-        ThinkingEventData,
-        tool_call::{AcpToolCallSessionUpdateKind, AcpToolCallStatus, ToolCallStatus},
-    },
-};
+use aionui_ai_agent::{AgentSendError, AgentStreamEvent, protocol::events::ThinkingEventData};
 
 use crate::response_middleware::{ICronService, MessageMiddleware, MiddlewareResult};
-use aionui_api_types::{AgentErrorCode, ConversationRuntimeSummary, WebSocketMessage};
+use aionui_api_types::{AgentErrorCode, WebSocketMessage};
 use aionui_common::{ErrorChain, normalize_keys_to_snake_case, now_ms};
 
-use crate::runtime_persistence::{RuntimePersistenceCoordinator, RuntimeWriteKind};
+use crate::runtime_persistence::RuntimePersistenceCoordinator;
 use crate::runtime_state::ConversationRuntimeStateService;
 use crate::service::ConversationService;
-use aionui_db::models::MessageRow;
-use aionui_db::{DbError, IConversationRepository};
+use crate::stream_persistence::{
+    PersistedTextSegment, StreamPersistenceAdapter, TextSegmentState, ThinkingSegmentState,
+};
+use aionui_db::IConversationRepository;
 use aionui_realtime::EventBroadcaster;
 use serde_json::json;
 use tokio::sync::{broadcast, oneshot};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 /// Number of text chunks to accumulate before flushing to the database.
 const FLUSH_INTERVAL: u32 = 20;
-
-fn is_not_found(err: &DbError) -> bool {
-    matches!(err, DbError::NotFound(_))
-}
-
-fn is_foreign_key_constraint(err: &DbError) -> bool {
-    err.to_string().contains("FOREIGN KEY constraint failed")
-}
-
-fn is_deleted_during_stream_persistence(err: &DbError) -> bool {
-    is_not_found(err) || is_foreign_key_constraint(err)
-}
-
-fn log_persist_error(err: &DbError, message: &'static str) {
-    if is_deleted_during_stream_persistence(err) {
-        debug!(error = %ErrorChain(err), "{message}; conversation was likely deleted during stream finalization");
-    } else {
-        error!(error = %ErrorChain(err), "{message}");
-    }
-}
-
-#[derive(Debug, Clone)]
-struct TextSegmentState {
-    id: String,
-    buffer: String,
-    created_at: i64,
-    record_created: bool,
-    flush_counter: u32,
-}
-
-#[derive(Debug, Clone)]
-struct PersistedTextSegment {
-    id: String,
-}
-
-#[derive(Debug, Clone)]
-struct ThinkingSegmentState {
-    id: String,
-    buffer: String,
-    started_at: i64,
-}
 
 /// Result returned after a relay turn has fully drained and finalized.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -112,11 +67,11 @@ pub struct StreamRelay {
     conversation_id: String,
     msg_id: String,
     user_id: String,
-    repo: Arc<dyn IConversationRepository>,
     broadcaster: Arc<dyn EventBroadcaster>,
     cron_service: Option<Arc<dyn ICronService>>,
     runtime_state: Option<Arc<ConversationRuntimeStateService>>,
     persistence: Option<RuntimePersistenceCoordinator>,
+    adapter: StreamPersistenceAdapter,
     complete_turn: bool,
 }
 
@@ -129,15 +84,16 @@ impl StreamRelay {
         broadcaster: Arc<dyn EventBroadcaster>,
         cron_service: Option<Arc<dyn ICronService>>,
     ) -> Self {
+        let adapter = StreamPersistenceAdapter::new(conversation_id.clone(), msg_id.clone(), repo, None);
         Self {
             conversation_id,
             msg_id,
             user_id,
-            repo,
             broadcaster,
             cron_service,
             runtime_state: None,
             persistence: None,
+            adapter,
             complete_turn: true,
         }
     }
@@ -148,7 +104,8 @@ impl StreamRelay {
     }
 
     pub fn with_persistence(mut self, persistence: RuntimePersistenceCoordinator) -> Self {
-        self.persistence = Some(persistence);
+        self.persistence = Some(persistence.clone());
+        self.adapter = self.adapter.with_persistence(persistence);
         self
     }
 
@@ -295,7 +252,7 @@ impl StreamRelay {
                             full_text_buffer.push_str(&data.content);
                             segment.flush_counter += 1;
                             if segment.flush_counter >= FLUSH_INTERVAL {
-                                self.flush_text_segment(segment).await;
+                                self.adapter.flush_text_segment(segment).await;
                                 segment.flush_counter = 0;
                             }
                         }
@@ -353,7 +310,7 @@ impl StreamRelay {
                                 self.finalize(&full_text_buffer, &text_segments, &event, terminal).await
                             };
                             if self.complete_turn && !deleting {
-                                Self::complete_conversation(&self.repo, &self.broadcaster, &self.conversation_id).await;
+                                self.adapter.complete_conversation(&self.broadcaster, None).await;
                             }
                             break outcome;
                         }
@@ -362,21 +319,21 @@ impl StreamRelay {
                             self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
                                 .await;
                             self.forward_to_websocket(&event);
-                            self.persist_tool_call(data).await;
+                            self.adapter.persist_tool_call(data).await;
                         }
                         AgentStreamEvent::AcpToolCall(data) => {
                             self.complete_active_thinking(&mut active_thinking).await;
                             self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
                                 .await;
                             self.forward_to_websocket(&event);
-                            self.persist_acp_tool_call(data).await;
+                            self.adapter.persist_acp_tool_call(data).await;
                         }
                         AgentStreamEvent::ToolGroup(entries) => {
                             self.complete_active_thinking(&mut active_thinking).await;
                             self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
                                 .await;
                             self.forward_to_websocket(&event);
-                            self.persist_tool_group(entries).await;
+                            self.adapter.persist_tool_group(entries).await;
                         }
                         _ => {
                             self.forward_to_websocket(&event);
@@ -415,7 +372,7 @@ impl StreamRelay {
                         .await
                     };
                     if self.complete_turn && !deleting {
-                        Self::complete_conversation(&self.repo, &self.broadcaster, &self.conversation_id).await;
+                        self.adapter.complete_conversation(&self.broadcaster, None).await;
                     }
                     break outcome;
                 }
@@ -430,12 +387,6 @@ impl StreamRelay {
         self.runtime_state
             .as_ref()
             .is_some_and(|state| state.is_deleting(&self.conversation_id))
-    }
-
-    fn allows_write(&self, kind: RuntimeWriteKind) -> bool {
-        self.persistence
-            .as_ref()
-            .is_none_or(|persistence| persistence.allows(&self.conversation_id, kind))
     }
 
     fn event_kind(event: &AgentStreamEvent) -> &'static str {
@@ -520,87 +471,6 @@ impl StreamRelay {
         self.broadcast_stream_payload(payload);
     }
 
-    /// Flush an active text segment to the database (create or update).
-    #[tracing::instrument(skip_all)]
-    async fn flush_text_segment(&self, segment: &mut TextSegmentState) {
-        if !self.allows_write(RuntimeWriteKind::AssistantTextFlush) {
-            return;
-        }
-        if segment.buffer.is_empty() {
-            return;
-        }
-
-        let content = json!({ "content": segment.buffer }).to_string();
-
-        if segment.record_created {
-            let update = aionui_db::MessageRowUpdate {
-                content: Some(content),
-                status: Some(Some("work".into())),
-                hidden: None,
-            };
-            if let Err(e) = self.repo.update_message(&segment.id, &update).await {
-                log_persist_error(&e, "Failed to update streaming text segment");
-            }
-        } else {
-            let row = MessageRow {
-                id: segment.id.clone(),
-                conversation_id: self.conversation_id.clone(),
-                msg_id: Some(segment.id.clone()),
-                r#type: "text".into(),
-                content,
-                position: Some("left".into()),
-                status: Some("work".into()),
-                hidden: false,
-                created_at: segment.created_at,
-            };
-            if let Err(e) = self.repo.insert_message(&row).await {
-                log_persist_error(&e, "Failed to create streaming text segment");
-            }
-            segment.record_created = true;
-        }
-    }
-
-    #[tracing::instrument(skip_all)]
-    async fn finalize_text_segment(&self, segment: TextSegmentState, status: &str) -> Option<PersistedTextSegment> {
-        if !self.allows_write(RuntimeWriteKind::AssistantTextFinalize) {
-            return None;
-        }
-        if segment.buffer.is_empty() {
-            return None;
-        }
-
-        let content = json!({ "content": segment.buffer }).to_string();
-        if segment.record_created {
-            let update = aionui_db::MessageRowUpdate {
-                content: Some(content),
-                status: Some(Some(status.to_owned())),
-                hidden: Some(false),
-            };
-            if let Err(e) = self.repo.update_message(&segment.id, &update).await {
-                log_persist_error(&e, "Failed to finalize text segment");
-                return None;
-            }
-        } else {
-            let row = MessageRow {
-                id: segment.id.clone(),
-                conversation_id: self.conversation_id.clone(),
-                msg_id: Some(segment.id.clone()),
-                r#type: "text".into(),
-                content,
-                position: Some("left".into()),
-                status: Some(status.to_owned()),
-                hidden: false,
-                created_at: segment.created_at,
-            };
-            if let Err(e) = self.repo.insert_message(&row).await {
-                log_persist_error(&e, "Failed to create finalized text segment");
-                return None;
-            }
-        }
-
-        Some(PersistedTextSegment { id: segment.id })
-    }
-
     /// Finalize assistant text on stream end and apply middleware rewrites.
     #[tracing::instrument(skip_all)]
     async fn finalize(
@@ -624,90 +494,19 @@ impl StreamRelay {
             let final_text = processed.message.trim().to_owned();
             let hidden = final_text.is_empty();
 
-            if let Some(primary_segment) = text_segments.first() {
-                if processed.message != text || hidden {
-                    if !self.allows_write(RuntimeWriteKind::TerminalFinalize) {
-                        return outcome;
-                    }
-                    let content = json!({ "content": final_text }).to_string();
-                    let update = aionui_db::MessageRowUpdate {
-                        content: Some(content),
-                        status: Some(Some(status.to_owned())),
-                        hidden: Some(hidden),
-                    };
-                    if let Err(e) = self.repo.update_message(&primary_segment.id, &update).await {
-                        log_persist_error(&e, "Failed to rewrite finalized text segment");
-                    }
-                    self.send_final_text_override(&primary_segment.id, &processed.message, hidden);
-
-                    for segment in text_segments.iter().skip(1) {
-                        let hide_update = aionui_db::MessageRowUpdate {
-                            content: None,
-                            status: Some(Some(status.to_owned())),
-                            hidden: Some(true),
-                        };
-                        if let Err(e) = self.repo.update_message(&segment.id, &hide_update).await {
-                            log_persist_error(&e, "Failed to hide superseded text segment");
-                        }
-                        self.send_final_text_override(&segment.id, "", true);
-                    }
-                } else {
-                    if !self.allows_write(RuntimeWriteKind::TerminalFinalize) {
-                        return outcome;
-                    }
-                    for segment in text_segments {
-                        let status_update = aionui_db::MessageRowUpdate {
-                            content: None,
-                            status: Some(Some(status.to_owned())),
-                            hidden: Some(false),
-                        };
-                        if let Err(e) = self.repo.update_message(&segment.id, &status_update).await {
-                            log_persist_error(&e, "Failed to finalize text segment status");
-                        }
-                    }
-                }
-            } else if !hidden {
-                if !self.allows_write(RuntimeWriteKind::TerminalFinalize) {
-                    return outcome;
-                }
-                let row = MessageRow {
-                    id: self.msg_id.clone(),
-                    conversation_id: self.conversation_id.clone(),
-                    msg_id: Some(self.msg_id.clone()),
-                    r#type: "text".into(),
-                    content: json!({ "content": final_text }).to_string(),
-                    position: Some("left".into()),
-                    status: Some(status.to_owned()),
-                    hidden: false,
-                    created_at: now_ms(),
-                };
-                if let Err(e) = self.repo.insert_message(&row).await {
-                    log_persist_error(&e, "Failed to create final fallback message");
-                }
+            let rewrite_segments = processed.message != text || hidden;
+            let overrides = self
+                .adapter
+                .persist_final_text(text_segments, status, &final_text, hidden, rewrite_segments)
+                .await;
+            for override_event in overrides {
+                self.send_final_text_override(&override_event.msg_id, &override_event.text, override_event.hidden);
             }
 
             self.send_system_responses(&processed.system_responses);
             outcome.system_responses = processed.system_responses;
         } else if let AgentStreamEvent::Error(data) = event {
-            if !self.allows_write(RuntimeWriteKind::TerminalFinalize) {
-                return outcome;
-            }
-            // No text accumulated but got an error — store error as tips message
-            let content = json!({ "content": &data.message, "type": "error", "error": &data }).to_string();
-            let row = MessageRow {
-                id: ConversationService::mint_msg_id(),
-                conversation_id: self.conversation_id.clone(),
-                msg_id: None,
-                r#type: "tips".into(),
-                content,
-                position: Some("left".into()),
-                status: Some("error".into()),
-                hidden: false,
-                created_at: now_ms(),
-            };
-            if let Err(e) = self.repo.insert_message(&row).await {
-                log_persist_error(&e, "Failed to store error message");
-            }
+            self.adapter.persist_error_tip(data).await;
         }
 
         outcome
@@ -720,32 +519,7 @@ impl StreamRelay {
         };
         let duration_ms = (now_ms() - segment.started_at).max(0);
         self.send_thinking_done(&segment.id, duration_ms as u64);
-        if segment.buffer.is_empty() {
-            return;
-        }
-        if !self.allows_write(RuntimeWriteKind::AssistantThinkingFinalize) {
-            return;
-        }
-        let content = json!({
-            "content": segment.buffer,
-            "status": "done",
-            "duration_ms": duration_ms,
-        })
-        .to_string();
-        let row = MessageRow {
-            id: segment.id.clone(),
-            conversation_id: self.conversation_id.clone(),
-            msg_id: Some(segment.id),
-            r#type: "thinking".into(),
-            content,
-            position: Some("left".into()),
-            status: Some("finish".into()),
-            hidden: false,
-            created_at: segment.started_at,
-        };
-        if let Err(e) = self.repo.insert_message(&row).await {
-            log_persist_error(&e, "Failed to persist thinking message");
-        }
+        self.adapter.persist_thinking_segment(segment, duration_ms as u64).await;
     }
 
     #[tracing::instrument(skip_all)]
@@ -758,234 +532,8 @@ impl StreamRelay {
         let Some(text_segment) = active_text.take() else {
             return;
         };
-        if let Some(segment) = self.finalize_text_segment(text_segment, status).await {
+        if let Some(segment) = self.adapter.finalize_text_segment(text_segment, status).await {
             text_segments.push(segment);
-        }
-    }
-
-    /// Persist a Gemini-style tool_call event.
-    #[tracing::instrument(skip_all)]
-    async fn persist_tool_call(&self, data: &aionui_ai_agent::protocol::events::tool_call::ToolCallEventData) {
-        if !self.allows_write(RuntimeWriteKind::ToolCallPersist) {
-            return;
-        }
-        if data.call_id.trim().is_empty() {
-            warn!(
-                tool = %data.name,
-                status = ?data.status,
-                "Skipping tool_call persistence because call_id is empty"
-            );
-            return;
-        }
-
-        let status = match data.status {
-            ToolCallStatus::Running => "work",
-            ToolCallStatus::Completed => "finish",
-            ToolCallStatus::Error => "error",
-        };
-        let content = serde_json::to_string(data).unwrap_or_default();
-
-        let existing = self
-            .repo
-            .get_message_by_msg_id(&self.conversation_id, &data.call_id, "tool_call")
-            .await
-            .unwrap_or(None);
-
-        if let Some(existing_row) = existing {
-            let merged_content = Self::merge_json_content(&existing_row.content, &content);
-            let update = aionui_db::MessageRowUpdate {
-                content: Some(merged_content),
-                status: Some(Some(status.to_owned())),
-                hidden: None,
-            };
-            if let Err(e) = self.repo.update_message(&data.call_id, &update).await {
-                error!(
-                    call_id = %data.call_id,
-                    tool = %data.name,
-                    status,
-                    error = %ErrorChain(&e),
-                    "Failed to update tool_call message"
-                );
-            } else {
-                debug!(
-                    call_id = %data.call_id,
-                    tool = %data.name,
-                    status,
-                    "Updated tool_call message"
-                );
-            }
-        } else {
-            let row = MessageRow {
-                id: data.call_id.clone(),
-                conversation_id: self.conversation_id.clone(),
-                msg_id: Some(data.call_id.clone()),
-                r#type: "tool_call".into(),
-                content,
-                position: Some("left".into()),
-                status: Some(status.to_owned()),
-                hidden: false,
-                created_at: now_ms(),
-            };
-            if let Err(e) = self.repo.insert_message(&row).await {
-                error!(
-                    call_id = %data.call_id,
-                    tool = %data.name,
-                    status,
-                    error = %ErrorChain(&e),
-                    "Failed to persist tool_call message"
-                );
-            } else {
-                debug!(
-                    call_id = %data.call_id,
-                    tool = %data.name,
-                    status,
-                    "Persisted tool_call message"
-                );
-            }
-        }
-    }
-
-    /// Persist an ACP (Claude CLI) tool call event.
-    /// First event (ToolCall) inserts; subsequent events (ToolCallUpdate) update.
-    #[tracing::instrument(skip_all)]
-    async fn persist_acp_tool_call(&self, data: &aionui_ai_agent::protocol::events::tool_call::AcpToolCallEventData) {
-        if !self.allows_write(RuntimeWriteKind::AcpToolCallPersist) {
-            return;
-        }
-        let tool_call_id = &data.update.tool_call_id;
-        let status = match data.update.status {
-            Some(AcpToolCallStatus::Pending) | None => "work",
-            Some(AcpToolCallStatus::InProgress) => "work",
-            Some(AcpToolCallStatus::Completed) => "finish",
-            Some(AcpToolCallStatus::Failed) => "error",
-        };
-
-        let mut value = serde_json::to_value(data).unwrap_or_default();
-        normalize_keys_to_snake_case(&mut value);
-        let content = value.to_string();
-
-        match data.update.session_update {
-            AcpToolCallSessionUpdateKind::ToolCall => {
-                let row = MessageRow {
-                    id: tool_call_id.clone(),
-                    conversation_id: self.conversation_id.clone(),
-                    msg_id: Some(tool_call_id.clone()),
-                    r#type: "acp_tool_call".into(),
-                    content,
-                    position: Some("left".into()),
-                    status: Some(status.to_owned()),
-                    hidden: false,
-                    created_at: now_ms(),
-                };
-                if let Err(e) = self.repo.insert_message(&row).await {
-                    error!(error = %ErrorChain(&e), "Failed to persist acp_tool_call message");
-                }
-            }
-            AcpToolCallSessionUpdateKind::ToolCallUpdate => {
-                let merged_content = self.merge_acp_tool_call_content(tool_call_id, &value).await;
-                let update = aionui_db::MessageRowUpdate {
-                    content: Some(merged_content),
-                    status: Some(Some(status.to_owned())),
-                    hidden: None,
-                };
-                if let Err(e) = self.repo.update_message(tool_call_id, &update).await {
-                    error!(error = %ErrorChain(&e), "Failed to update acp_tool_call message");
-                }
-            }
-        }
-    }
-
-    /// Merge two JSON content strings: overlays non-null fields from `new_json`
-    /// onto `existing_json`, preserving fields only present in the original.
-    fn merge_json_content(existing_json: &str, new_json: &str) -> String {
-        let mut base: serde_json::Value = serde_json::from_str(existing_json).unwrap_or_default();
-        let new_value: serde_json::Value = serde_json::from_str(new_json).unwrap_or_default();
-        if let (Some(base_obj), Some(new_obj)) = (base.as_object_mut(), new_value.as_object()) {
-            for (key, val) in new_obj {
-                if !val.is_null() {
-                    base_obj.insert(key.clone(), val.clone());
-                }
-            }
-        }
-        base.to_string()
-    }
-
-    /// Merge an AcpToolCall update into the existing DB record.
-    /// Reads the stored content, overlays non-null fields from the update,
-    /// preserving fields like `raw_input` that the update event omits.
-    async fn merge_acp_tool_call_content(&self, tool_call_id: &str, update_value: &serde_json::Value) -> String {
-        let existing = self
-            .repo
-            .get_message_by_msg_id(&self.conversation_id, tool_call_id, "acp_tool_call")
-            .await
-            .ok()
-            .flatten();
-
-        let Some(existing_row) = existing else {
-            return update_value.to_string();
-        };
-
-        let mut base: serde_json::Value = serde_json::from_str(&existing_row.content).unwrap_or_default();
-        if let (Some(base_update), Some(new_update)) = (
-            base.get_mut("update").and_then(|v| v.as_object_mut()),
-            update_value.get("update").and_then(|v| v.as_object()),
-        ) {
-            for (key, val) in new_update {
-                if !val.is_null() {
-                    base_update.insert(key.clone(), val.clone());
-                }
-            }
-        }
-        base.to_string()
-    }
-
-    /// Persist a tool_group event (array of tool summaries).
-    #[tracing::instrument(skip_all)]
-    async fn persist_tool_group(&self, entries: &[aionui_ai_agent::protocol::events::tool_call::ToolGroupEntry]) {
-        if !self.allows_write(RuntimeWriteKind::ToolGroupPersist) {
-            return;
-        }
-        let all_done = entries
-            .iter()
-            .all(|e| matches!(e.status, ToolCallStatus::Completed | ToolCallStatus::Error));
-        let status = if all_done { "finish" } else { "work" };
-        let content = serde_json::to_string(entries).unwrap_or_default();
-
-        let group_id = entries
-            .first()
-            .map(|e| e.call_id.clone())
-            .unwrap_or_else(ConversationService::mint_msg_id);
-
-        let existing = self
-            .repo
-            .get_message_by_msg_id(&self.conversation_id, &group_id, "tool_group")
-            .await
-            .unwrap_or(None);
-
-        if existing.is_some() {
-            let update = aionui_db::MessageRowUpdate {
-                content: Some(content),
-                status: Some(Some(status.to_owned())),
-                hidden: None,
-            };
-            if let Err(e) = self.repo.update_message(&group_id, &update).await {
-                error!(error = %ErrorChain(&e), "Failed to update tool_group message");
-            }
-        } else {
-            let row = MessageRow {
-                id: group_id.clone(),
-                conversation_id: self.conversation_id.clone(),
-                msg_id: Some(group_id),
-                r#type: "tool_group".into(),
-                content,
-                position: Some("left".into()),
-                status: Some(status.to_owned()),
-                hidden: false,
-                created_at: now_ms(),
-            };
-            if let Err(e) = self.repo.insert_message(&row).await {
-                error!(error = %ErrorChain(&e), "Failed to persist tool_group message");
-            }
         }
     }
 
@@ -1037,44 +585,6 @@ impl StreamRelay {
         let msg = WebSocketMessage::new("message.stream", payload);
         self.broadcaster.broadcast(msg);
     }
-
-    #[tracing::instrument(skip_all, fields(conversation_id = %conversation_id))]
-    pub async fn complete_conversation(
-        repo: &Arc<dyn IConversationRepository>,
-        broadcaster: &Arc<dyn EventBroadcaster>,
-        conversation_id: &str,
-    ) {
-        Self::complete_conversation_with_runtime(repo, broadcaster, conversation_id, None).await;
-    }
-
-    #[tracing::instrument(skip_all, fields(conversation_id = %conversation_id))]
-    pub async fn complete_conversation_with_runtime(
-        repo: &Arc<dyn IConversationRepository>,
-        broadcaster: &Arc<dyn EventBroadcaster>,
-        conversation_id: &str,
-        runtime: Option<ConversationRuntimeSummary>,
-    ) {
-        let update = aionui_db::ConversationRowUpdate {
-            status: Some("finished".to_owned()),
-            updated_at: Some(now_ms()),
-            ..Default::default()
-        };
-        if let Err(e) = repo.update(conversation_id, &update).await {
-            log_persist_error(&e, "Failed to update conversation status");
-        }
-
-        let payload = json!({
-            "conversation_id": conversation_id,
-            "session_id": conversation_id,
-            "status": "finished",
-            "canSendMessage": true,
-            "runtime": runtime,
-        });
-        let msg = WebSocketMessage::new("turn.completed", payload);
-        broadcaster.broadcast(msg);
-
-        debug!(conversation_id, status = "finished", "Turn completed");
-    }
 }
 
 struct SharedCronService(Arc<dyn ICronService>);
@@ -1111,9 +621,11 @@ impl ICronService for SharedCronService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::stream_persistence::StreamPersistenceAdapter;
     use aionui_ai_agent::AgentError;
     use aionui_ai_agent::protocol::events::{ErrorEventData, FinishEventData, TextEventData, ThinkingEventData};
     use aionui_db::DbError;
+    use aionui_db::models::MessageRow;
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -1929,8 +1441,9 @@ mod tests {
         repo.set_not_found(true);
         let repo: Arc<dyn IConversationRepository> = repo;
         let bus: Arc<dyn EventBroadcaster> = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let adapter = StreamPersistenceAdapter::new("deleted-conv".into(), "msg-1".into(), repo, None);
 
-        StreamRelay::complete_conversation_with_runtime(&repo, &bus, "deleted-conv", None).await;
+        adapter.complete_conversation(&bus, None).await;
     }
 
     #[tokio::test]

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -12,6 +12,7 @@ use crate::response_middleware::{ICronService, MessageMiddleware, MiddlewareResu
 use aionui_api_types::{AgentErrorCode, ConversationRuntimeSummary, WebSocketMessage};
 use aionui_common::{ErrorChain, normalize_keys_to_snake_case, now_ms};
 
+use crate::runtime_persistence::{RuntimePersistenceCoordinator, RuntimeWriteKind};
 use crate::runtime_state::ConversationRuntimeStateService;
 use crate::service::ConversationService;
 use aionui_db::models::MessageRow;
@@ -115,6 +116,7 @@ pub struct StreamRelay {
     broadcaster: Arc<dyn EventBroadcaster>,
     cron_service: Option<Arc<dyn ICronService>>,
     runtime_state: Option<Arc<ConversationRuntimeStateService>>,
+    persistence: Option<RuntimePersistenceCoordinator>,
     complete_turn: bool,
 }
 
@@ -135,12 +137,18 @@ impl StreamRelay {
             broadcaster,
             cron_service,
             runtime_state: None,
+            persistence: None,
             complete_turn: true,
         }
     }
 
     pub fn with_runtime_state(mut self, runtime_state: Arc<ConversationRuntimeStateService>) -> Self {
         self.runtime_state = Some(runtime_state);
+        self
+    }
+
+    pub fn with_persistence(mut self, persistence: RuntimePersistenceCoordinator) -> Self {
+        self.persistence = Some(persistence);
         self
     }
 
@@ -424,6 +432,12 @@ impl StreamRelay {
             .is_some_and(|state| state.is_deleting(&self.conversation_id))
     }
 
+    fn allows_write(&self, kind: RuntimeWriteKind) -> bool {
+        self.persistence
+            .as_ref()
+            .is_none_or(|persistence| persistence.allows(&self.conversation_id, kind))
+    }
+
     fn event_kind(event: &AgentStreamEvent) -> &'static str {
         match event {
             AgentStreamEvent::Start(_) => "Start",
@@ -509,6 +523,9 @@ impl StreamRelay {
     /// Flush an active text segment to the database (create or update).
     #[tracing::instrument(skip_all)]
     async fn flush_text_segment(&self, segment: &mut TextSegmentState) {
+        if !self.allows_write(RuntimeWriteKind::AssistantTextFlush) {
+            return;
+        }
         if segment.buffer.is_empty() {
             return;
         }
@@ -545,6 +562,9 @@ impl StreamRelay {
 
     #[tracing::instrument(skip_all)]
     async fn finalize_text_segment(&self, segment: TextSegmentState, status: &str) -> Option<PersistedTextSegment> {
+        if !self.allows_write(RuntimeWriteKind::AssistantTextFinalize) {
+            return None;
+        }
         if segment.buffer.is_empty() {
             return None;
         }
@@ -606,6 +626,9 @@ impl StreamRelay {
 
             if let Some(primary_segment) = text_segments.first() {
                 if processed.message != text || hidden {
+                    if !self.allows_write(RuntimeWriteKind::TerminalFinalize) {
+                        return outcome;
+                    }
                     let content = json!({ "content": final_text }).to_string();
                     let update = aionui_db::MessageRowUpdate {
                         content: Some(content),
@@ -629,6 +652,9 @@ impl StreamRelay {
                         self.send_final_text_override(&segment.id, "", true);
                     }
                 } else {
+                    if !self.allows_write(RuntimeWriteKind::TerminalFinalize) {
+                        return outcome;
+                    }
                     for segment in text_segments {
                         let status_update = aionui_db::MessageRowUpdate {
                             content: None,
@@ -641,6 +667,9 @@ impl StreamRelay {
                     }
                 }
             } else if !hidden {
+                if !self.allows_write(RuntimeWriteKind::TerminalFinalize) {
+                    return outcome;
+                }
                 let row = MessageRow {
                     id: self.msg_id.clone(),
                     conversation_id: self.conversation_id.clone(),
@@ -660,6 +689,9 @@ impl StreamRelay {
             self.send_system_responses(&processed.system_responses);
             outcome.system_responses = processed.system_responses;
         } else if let AgentStreamEvent::Error(data) = event {
+            if !self.allows_write(RuntimeWriteKind::TerminalFinalize) {
+                return outcome;
+            }
             // No text accumulated but got an error — store error as tips message
             let content = json!({ "content": &data.message, "type": "error", "error": &data }).to_string();
             let row = MessageRow {
@@ -689,6 +721,9 @@ impl StreamRelay {
         let duration_ms = (now_ms() - segment.started_at).max(0);
         self.send_thinking_done(&segment.id, duration_ms as u64);
         if segment.buffer.is_empty() {
+            return;
+        }
+        if !self.allows_write(RuntimeWriteKind::AssistantThinkingFinalize) {
             return;
         }
         let content = json!({
@@ -731,6 +766,9 @@ impl StreamRelay {
     /// Persist a Gemini-style tool_call event.
     #[tracing::instrument(skip_all)]
     async fn persist_tool_call(&self, data: &aionui_ai_agent::protocol::events::tool_call::ToolCallEventData) {
+        if !self.allows_write(RuntimeWriteKind::ToolCallPersist) {
+            return;
+        }
         if data.call_id.trim().is_empty() {
             warn!(
                 tool = %data.name,
@@ -811,6 +849,9 @@ impl StreamRelay {
     /// First event (ToolCall) inserts; subsequent events (ToolCallUpdate) update.
     #[tracing::instrument(skip_all)]
     async fn persist_acp_tool_call(&self, data: &aionui_ai_agent::protocol::events::tool_call::AcpToolCallEventData) {
+        if !self.allows_write(RuntimeWriteKind::AcpToolCallPersist) {
+            return;
+        }
         let tool_call_id = &data.update.tool_call_id;
         let status = match data.update.status {
             Some(AcpToolCallStatus::Pending) | None => "work",
@@ -901,6 +942,9 @@ impl StreamRelay {
     /// Persist a tool_group event (array of tool summaries).
     #[tracing::instrument(skip_all)]
     async fn persist_tool_group(&self, entries: &[aionui_ai_agent::protocol::events::tool_call::ToolGroupEntry]) {
+        if !self.allows_write(RuntimeWriteKind::ToolGroupPersist) {
+            return;
+        }
         let all_done = entries
             .iter()
             .all(|e| matches!(e.status, ToolCallStatus::Completed | ToolCallStatus::Error));

--- a/crates/aionui-conversation/src/turn_continuation_policy.rs
+++ b/crates/aionui-conversation/src/turn_continuation_policy.rs
@@ -1,0 +1,129 @@
+use tracing::warn;
+
+use crate::runtime_state::RuntimeLifecycleState;
+use crate::stream_relay::RelayOutcome;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContinuationDecision {
+    Continue { content: String, next_count: usize },
+    Stop(ContinuationStopReason),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContinuationStopReason {
+    NoSystemResponses,
+    TerminalNotFinish,
+    LifecycleNotActive,
+    LimitReached,
+}
+
+pub struct TurnContinuationPolicy {
+    max_continuations: usize,
+}
+
+impl TurnContinuationPolicy {
+    pub fn new(max_continuations: usize) -> Self {
+        Self { max_continuations }
+    }
+
+    pub fn decide(
+        &self,
+        conversation_id: &str,
+        continuation_count: usize,
+        outcome: &RelayOutcome,
+        lifecycle: RuntimeLifecycleState,
+    ) -> ContinuationDecision {
+        if lifecycle != RuntimeLifecycleState::Active {
+            return ContinuationDecision::Stop(ContinuationStopReason::LifecycleNotActive);
+        }
+        if outcome.terminal.is_error() {
+            return ContinuationDecision::Stop(ContinuationStopReason::TerminalNotFinish);
+        }
+        if outcome.system_responses.is_empty() {
+            return ContinuationDecision::Stop(ContinuationStopReason::NoSystemResponses);
+        }
+        if continuation_count >= self.max_continuations {
+            warn!(
+                conversation_id,
+                max = self.max_continuations,
+                "Reached cron continuation limit; ending turn early"
+            );
+            return ContinuationDecision::Stop(ContinuationStopReason::LimitReached);
+        }
+
+        ContinuationDecision::Continue {
+            content: outcome.system_responses.join("\n"),
+            next_count: continuation_count + 1,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use aionui_api_types::AgentErrorCode;
+
+    use super::*;
+    use crate::stream_relay::RelayTerminal;
+
+    #[test]
+    fn finish_with_system_responses_continues() {
+        let policy = TurnContinuationPolicy::new(4);
+        let outcome = RelayOutcome {
+            system_responses: vec!["one".into(), "two".into()],
+            terminal: RelayTerminal::Finish,
+        };
+
+        assert_eq!(
+            policy.decide("conv-1", 0, &outcome, RuntimeLifecycleState::Active),
+            ContinuationDecision::Continue {
+                content: "one\ntwo".into(),
+                next_count: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn terminal_error_stops() {
+        let policy = TurnContinuationPolicy::new(4);
+        let outcome = RelayOutcome {
+            system_responses: vec!["next".into()],
+            terminal: RelayTerminal::Error {
+                code: Some(AgentErrorCode::UnknownUpstreamError),
+                retryable: Some(true),
+            },
+        };
+
+        assert_eq!(
+            policy.decide("conv-1", 0, &outcome, RuntimeLifecycleState::Active),
+            ContinuationDecision::Stop(ContinuationStopReason::TerminalNotFinish)
+        );
+    }
+
+    #[test]
+    fn deleting_stops() {
+        let policy = TurnContinuationPolicy::new(4);
+        let outcome = RelayOutcome {
+            system_responses: vec!["next".into()],
+            terminal: RelayTerminal::Finish,
+        };
+
+        assert_eq!(
+            policy.decide("conv-1", 0, &outcome, RuntimeLifecycleState::Deleting),
+            ContinuationDecision::Stop(ContinuationStopReason::LifecycleNotActive)
+        );
+    }
+
+    #[test]
+    fn limit_stops() {
+        let policy = TurnContinuationPolicy::new(1);
+        let outcome = RelayOutcome {
+            system_responses: vec!["next".into()],
+            terminal: RelayTerminal::Finish,
+        };
+
+        assert_eq!(
+            policy.decide("conv-1", 1, &outcome, RuntimeLifecycleState::Active),
+            ContinuationDecision::Stop(ContinuationStopReason::LimitReached)
+        );
+    }
+}

--- a/crates/aionui-conversation/src/turn_orchestrator.rs
+++ b/crates/aionui-conversation/src/turn_orchestrator.rs
@@ -1,0 +1,203 @@
+use std::sync::Arc;
+
+use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
+use aionui_ai_agent::{AgentSendError, IWorkerTaskManager};
+use aionui_common::{ConversationStatus, ErrorChain, now_ms};
+use aionui_db::models::ConversationRow;
+use tokio::sync::oneshot;
+use tracing::{debug, error, info, warn};
+
+use crate::agent_health_policy::{AgentHealthAction, AgentHealthPolicy};
+use crate::runtime_state::TurnClaim;
+use crate::service::{
+    ConversationService, MAX_CRON_CONTINUATIONS_PER_TURN, agent_error_top_level_code, persist_session_key,
+};
+use crate::stream_relay::StreamRelay;
+use crate::turn_continuation_policy::{ContinuationDecision, TurnContinuationPolicy};
+use aionui_api_types::SendMessageRequest;
+
+pub(crate) struct TurnStartInput {
+    pub user_id: String,
+    pub conversation: ConversationRow,
+    pub request: SendMessageRequest,
+    pub build_options: BuildTaskOptions,
+    pub stored_workspace: String,
+    pub turn_claim: TurnClaim,
+}
+
+pub(crate) struct ConversationTurnOrchestrator {
+    service: ConversationService,
+    task_manager: Arc<dyn IWorkerTaskManager>,
+}
+
+impl ConversationTurnOrchestrator {
+    pub fn new(service: ConversationService, task_manager: Arc<dyn IWorkerTaskManager>) -> Self {
+        Self { service, task_manager }
+    }
+
+    pub fn spawn_user_turn(self, input: TurnStartInput) {
+        tokio::spawn(async move {
+            self.run_user_turn(input).await;
+        });
+    }
+
+    async fn run_user_turn(self, input: TurnStartInput) {
+        let mut turn_claim = input.turn_claim;
+        let conv_id = input.conversation.id.clone();
+        let build_started_at = now_ms();
+        let persistence = self.service.runtime_persistence();
+        let runtime_state = self.service.runtime_state();
+
+        info!(conversation_id = %conv_id, "conversation turn orchestrator started");
+        info!(conversation_id = %conv_id, "Agent task build started");
+        let agent = match self.task_manager.get_or_build_task(&conv_id, input.build_options).await {
+            Ok(agent) => agent,
+            Err(err) => {
+                let top_level_code = agent_error_top_level_code(&err);
+                let send_error = AgentSendError::from_agent_error_ref(&err);
+                error!(
+                    conversation_id = %conv_id,
+                    error_code = ?send_error.code(),
+                    error = %ErrorChain(&err),
+                    "Agent task build failed"
+                );
+                self.service
+                    .persist_and_broadcast_send_failure_tip(&conv_id, &send_error, Some(top_level_code))
+                    .await;
+                let was_deleting = turn_claim.release();
+                self.service.complete_released_turn(&conv_id, was_deleting).await;
+                return;
+            }
+        };
+
+        if let Err(err) = self
+            .service
+            .maybe_persist_workspace(&conv_id, &input.stored_workspace, agent.workspace())
+            .await
+        {
+            let top_level_code = err.error_code();
+            let send_error = AgentSendError::from_agent_error(err.to_agent_error());
+            error!(
+                conversation_id = %conv_id,
+                error_code = err.error_code(),
+                error = %ErrorChain(&err),
+                "Failed to persist resolved workspace"
+            );
+            self.service
+                .persist_and_broadcast_send_failure_tip(&conv_id, &send_error, Some(top_level_code))
+                .await;
+            let was_deleting = turn_claim.release();
+            self.service.complete_released_turn(&conv_id, was_deleting).await;
+            return;
+        }
+
+        info!(
+            conversation_id = %conv_id,
+            agent_type = ?agent.agent_type(),
+            elapsed_ms = now_ms().saturating_sub(build_started_at),
+            "Agent task ready"
+        );
+
+        let first_turn_msg_id = ConversationService::mint_msg_id();
+        let mut pending_send = Some((
+            SendMessageData {
+                content: input.request.content,
+                msg_id: first_turn_msg_id.clone(),
+                files: input.request.files,
+                inject_skills: input.request.inject_skills,
+            },
+            first_turn_msg_id,
+        ));
+        let mut continuation_count = 0usize;
+        let continuation_policy = TurnContinuationPolicy::new(MAX_CRON_CONTINUATIONS_PER_TURN);
+
+        while let Some((current_send, msg_id)) = pending_send.take() {
+            let relay = StreamRelay::new(
+                conv_id.clone(),
+                msg_id,
+                input.user_id.clone(),
+                self.service.conversation_repo().clone(),
+                self.service.broadcaster().clone(),
+                self.service.current_cron_service(),
+            )
+            .with_runtime_state(Arc::clone(&runtime_state))
+            .with_persistence(persistence.clone())
+            .with_turn_completion(false);
+
+            let rx = agent.subscribe();
+            let send_agent = agent.clone();
+            let conv_id_send = conv_id.clone();
+            let (send_error_tx, send_error_rx) = oneshot::channel();
+
+            tokio::spawn(async move {
+                if let Err(e) = send_agent.send_message(current_send).await {
+                    let task_status = send_agent.status();
+                    let agent_type = send_agent.agent_type();
+                    error!(
+                        conversation_id = %conv_id_send,
+                        ?agent_type,
+                        ?task_status,
+                        error = %ErrorChain(&e),
+                        "Agent send_message failed"
+                    );
+                    if task_status == Some(ConversationStatus::Finished) {
+                        debug!(
+                            conversation_id = %conv_id_send,
+                            ?agent_type,
+                            "Agent send_message failure already published runtime terminal; skipping fallback stream error"
+                        );
+                    } else {
+                        warn!(
+                            conversation_id = %conv_id_send,
+                            ?agent_type,
+                            code = ?e.code(),
+                            ownership = ?e.ownership(),
+                            "Agent send_message returned error without runtime terminal; injecting fallback stream error"
+                        );
+                        let _ = send_error_tx.send(e);
+                    }
+                }
+            });
+
+            let outcome = relay.consume_with_send_error(rx, send_error_rx).await;
+            let lifecycle = runtime_state.lifecycle_for(&conv_id);
+
+            if let Some(session_key) = agent.get_session_key() {
+                persist_session_key(self.service.conversation_repo(), &persistence, &conv_id, &session_key).await;
+            }
+
+            match AgentHealthPolicy::decide(agent.agent_type(), &outcome, lifecycle) {
+                AgentHealthAction::Keep => {}
+                AgentHealthAction::EvictAcpTask { .. } => {
+                    if self
+                        .service
+                        .evict_acp_task_after_terminal_error(&conv_id, agent.agent_type(), &outcome, &self.task_manager)
+                        .await
+                    {
+                        break;
+                    }
+                }
+            }
+
+            match continuation_policy.decide(&conv_id, continuation_count, &outcome, lifecycle) {
+                ContinuationDecision::Continue { content, next_count } => {
+                    continuation_count = next_count;
+                    let next_turn_msg_id = ConversationService::mint_msg_id();
+                    pending_send = Some((
+                        SendMessageData {
+                            content,
+                            msg_id: next_turn_msg_id.clone(),
+                            files: vec![],
+                            inject_skills: vec![],
+                        },
+                        next_turn_msg_id,
+                    ));
+                }
+                ContinuationDecision::Stop(_) => break,
+            }
+        }
+
+        let was_deleting = turn_claim.release();
+        self.service.complete_released_turn(&conv_id, was_deleting).await;
+    }
+}

--- a/crates/aionui-db/src/repository/conversation.rs
+++ b/crates/aionui-db/src/repository/conversation.rs
@@ -86,6 +86,12 @@ pub trait IConversationRepository: Send + Sync {
         msg_type: &str,
     ) -> Result<Option<MessageRow>, DbError>;
 
+    /// Lists stale assistant-side runtime messages that were left in a
+    /// non-terminal state by a previous process.
+    async fn list_stale_runtime_messages(&self) -> Result<Vec<MessageRow>, DbError> {
+        Ok(Vec::new())
+    }
+
     /// Full-text search across messages, joining conversation name.
     async fn search_messages(
         &self,

--- a/crates/aionui-db/src/repository/sqlite_conversation.rs
+++ b/crates/aionui-db/src/repository/sqlite_conversation.rs
@@ -424,6 +424,21 @@ impl IConversationRepository for SqliteConversationRepository {
         Ok(row)
     }
 
+    async fn list_stale_runtime_messages(&self) -> Result<Vec<MessageRow>, DbError> {
+        let rows = sqlx::query_as::<_, MessageRow>(
+            "SELECT m.* FROM messages m \
+             INNER JOIN conversations c ON c.id = m.conversation_id \
+             WHERE m.position = 'left' \
+               AND m.status IN ('work', 'pending') \
+               AND m.type IN ('text', 'thinking') \
+             ORDER BY m.created_at ASC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
     async fn search_messages(
         &self,
         user_id: &str,


### PR DESCRIPTION
## Summary
- add a ConversationTurnOrchestrator to own runtime turn claims, execution, completion, and release
- gate runtime persistence for deleting, cancelling, and shutting down conversations
- move stream DB writes behind StreamPersistenceAdapter and add stale runtime message recovery
- cover the lifecycle paths with focused unit and integration tests

## Verification
- `just push -u origin round-4-turn-orchestrator`
- local runtime log checks for normal turns, tool-call turns, delete-during-turn, shutdown/restart recovery, and reopened conversations