### PR TITLE
fix(acp): prefer config options catalogs

### DIFF
--- a/crates/aionui-ai-agent/src/manager/acp/agent_event_tracker.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_event_tracker.rs
@@ -1,8 +1,6 @@
 use crate::manager::acp::{AcpAgentManager, AcpSession};
 use crate::protocol::events::AgentStreamEvent;
-use agent_client_protocol::schema::{
-    SessionConfigOption, SessionModeState, SessionModelState, SessionNotification, UsageUpdate,
-};
+use agent_client_protocol::schema::{SessionModeState, SessionModelState, SessionNotification, UsageUpdate};
 use serde_json::Value;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -10,6 +8,8 @@ use tokio::sync::mpsc;
 use std::collections::HashMap;
 
 use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId, SessionId};
+
+use super::config_option_catalog::extract_config_options_from_value;
 
 /// Domain events emitted by the `AcpSession` aggregate.
 ///
@@ -110,7 +110,7 @@ impl AcpAgentManager {
                 }
             }
             AgentStreamEvent::AcpConfigOption(value) => {
-                if let Ok(update) = serde_json::from_value::<Vec<SessionConfigOption>>(value.clone()) {
+                if let Some(update) = extract_config_options_from_value(value) {
                     let mut s = self.session.write().await;
                     s.apply_advertised_config_options(update);
                     self.commit_session_changes(&mut s).await;

--- a/crates/aionui-ai-agent/src/manager/acp/config_option_catalog.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/config_option_catalog.rs
@@ -1,0 +1,557 @@
+use agent_client_protocol::schema::{
+    ModelInfo, SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption,
+    SessionConfigSelectOptions, SessionMode, SessionModeState, SessionModelState,
+};
+use aionui_api_types::{AgentHandshake, ModelInfoEntry, ModelInfoPayload};
+use aionui_common::normalize_keys_to_snake_case;
+use serde_json::{Map, Value};
+
+pub(crate) fn derive_modes_from_config_options(options: &[SessionConfigOption]) -> Option<SessionModeState> {
+    let select = find_select(options, &["mode", "modes"], &SessionConfigOptionCategory::Mode)?;
+    let available_modes: Vec<SessionMode> = flatten_select_options(&select.options)
+        .into_iter()
+        .map(|option| {
+            SessionMode::new(option.value.to_string(), option.name.clone()).description(option.description.clone())
+        })
+        .collect();
+
+    if available_modes.is_empty() {
+        return None;
+    }
+
+    let current_mode_id = non_empty_or_first(select.current_value.to_string(), &available_modes[0].id.to_string());
+    Some(SessionModeState::new(current_mode_id, available_modes))
+}
+
+pub(crate) fn derive_models_from_config_options(options: &[SessionConfigOption]) -> Option<SessionModelState> {
+    let select = find_select(options, &["model", "models"], &SessionConfigOptionCategory::Model)?;
+    let available_models: Vec<ModelInfo> = flatten_select_options(&select.options)
+        .into_iter()
+        .map(|option| {
+            ModelInfo::new(option.value.to_string(), option.name.clone()).description(option.description.clone())
+        })
+        .collect();
+
+    if available_models.is_empty() {
+        return None;
+    }
+
+    let current_model_id = non_empty_or_first(
+        select.current_value.to_string(),
+        &available_models[0].model_id.to_string(),
+    );
+    Some(SessionModelState::new(current_model_id, available_models))
+}
+
+pub(crate) fn enrich_handshake_with_existing_config_option_catalog(
+    handshake: &AgentHandshake,
+    existing: Option<&AgentHandshake>,
+) -> AgentHandshake {
+    let mut enriched = handshake.clone();
+    let Some(config_options) = handshake
+        .config_options
+        .as_ref()
+        .and_then(extract_config_options_from_value)
+    else {
+        return enriched;
+    };
+
+    if should_fill_catalog(
+        &enriched.available_modes,
+        existing.and_then(|handshake| handshake.available_modes.as_ref()),
+        "available_modes",
+        "availableModes",
+    ) && let Some(modes) = derive_modes_from_config_options(&config_options)
+        && let Some(value) = mode_state_to_snake_value(&modes)
+    {
+        enriched.available_modes = Some(value);
+    }
+
+    if should_fill_catalog(
+        &enriched.available_models,
+        existing.and_then(|handshake| handshake.available_models.as_ref()),
+        "available_models",
+        "availableModels",
+    ) && let Some(models) = derive_models_from_config_options(&config_options)
+        && let Some(value) = model_state_to_payload_value(&models)
+    {
+        enriched.available_models = Some(value);
+    }
+
+    enriched
+}
+
+pub(crate) fn extract_config_options_from_value(value: &Value) -> Option<Vec<SessionConfigOption>> {
+    decode_config_options(value).or_else(|| {
+        value
+            .as_object()
+            .and_then(|map| map.get("config_options").or_else(|| map.get("configOptions")))
+            .and_then(decode_config_options)
+    })
+}
+
+fn find_select<'a>(
+    options: &'a [SessionConfigOption],
+    ids: &[&str],
+    category: &SessionConfigOptionCategory,
+) -> Option<&'a agent_client_protocol::schema::SessionConfigSelect> {
+    options
+        .iter()
+        .find_map(|option| {
+            if option.category.as_ref() == Some(category) {
+                return select_from_kind(&option.kind);
+            }
+            None
+        })
+        .or_else(|| {
+            options.iter().find_map(|option| {
+                let id = option.id.to_string();
+                if !ids.iter().any(|candidate| *candidate == id) {
+                    return None;
+                }
+                select_from_kind(&option.kind)
+            })
+        })
+}
+
+fn select_from_kind(kind: &SessionConfigKind) -> Option<&agent_client_protocol::schema::SessionConfigSelect> {
+    match kind {
+        SessionConfigKind::Select(select) => Some(select),
+        _ => None,
+    }
+}
+
+fn flatten_select_options(options: &SessionConfigSelectOptions) -> Vec<&SessionConfigSelectOption> {
+    match options {
+        SessionConfigSelectOptions::Ungrouped(options) => options.iter().collect(),
+        SessionConfigSelectOptions::Grouped(groups) => groups.iter().flat_map(|group| group.options.iter()).collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn decode_config_options(value: &Value) -> Option<Vec<SessionConfigOption>> {
+    serde_json::from_value(value.clone())
+        .ok()
+        .or_else(|| serde_json::from_value(keys_to_camel_case(value.clone())).ok())
+}
+
+fn mode_state_to_snake_value(modes: &SessionModeState) -> Option<Value> {
+    let mut value = serde_json::to_value(modes).ok()?;
+    normalize_keys_to_snake_case(&mut value);
+    Some(value)
+}
+
+fn model_state_to_payload_value(models: &SessionModelState) -> Option<Value> {
+    let available_models: Vec<ModelInfoEntry> = models
+        .available_models
+        .iter()
+        .map(|model| ModelInfoEntry {
+            id: model.model_id.to_string(),
+            label: model.name.clone(),
+        })
+        .collect();
+    let current_model_id = models.current_model_id.to_string();
+    let current_model_label = available_models
+        .iter()
+        .find(|model| model.id == current_model_id)
+        .map(|model| model.label.clone())
+        .unwrap_or_else(|| current_model_id.clone());
+
+    serde_json::to_value(ModelInfoPayload {
+        current_model_id: Some(current_model_id),
+        current_model_label: Some(current_model_label),
+        available_models,
+    })
+    .ok()
+}
+
+fn has_non_empty_catalog(value: &Option<Value>, snake_key: &str, camel_key: &str) -> bool {
+    value
+        .as_ref()
+        .is_some_and(|value| has_non_empty_catalog_value(value, snake_key, camel_key))
+}
+
+fn has_non_empty_catalog_value(value: &Value, snake_key: &str, camel_key: &str) -> bool {
+    match value {
+        Value::Array(items) => !items.is_empty(),
+        Value::Object(map) => map
+            .get(snake_key)
+            .or_else(|| map.get(camel_key))
+            .and_then(Value::as_array)
+            .is_some_and(|items| !items.is_empty()),
+        _ => false,
+    }
+}
+
+fn should_fill_catalog(incoming: &Option<Value>, existing: Option<&Value>, snake_key: &str, camel_key: &str) -> bool {
+    if has_non_empty_catalog(incoming, snake_key, camel_key) {
+        return false;
+    }
+    if incoming.is_none() && existing.is_some_and(|value| has_non_empty_catalog_value(value, snake_key, camel_key)) {
+        return false;
+    }
+    true
+}
+
+fn keys_to_camel_case(value: Value) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(key, value)| {
+                    let next_key = if key == "_meta" { key } else { snake_to_camel(&key) };
+                    let next_value = if next_key == "_meta" {
+                        value
+                    } else {
+                        keys_to_camel_case(value)
+                    };
+                    (next_key, next_value)
+                })
+                .collect::<Map<_, _>>(),
+        ),
+        Value::Array(items) => Value::Array(items.into_iter().map(keys_to_camel_case).collect()),
+        other => other,
+    }
+}
+
+fn snake_to_camel(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut uppercase_next = false;
+    for ch in input.chars() {
+        if ch == '_' {
+            uppercase_next = true;
+        } else if uppercase_next {
+            out.extend(ch.to_uppercase());
+            uppercase_next = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+fn non_empty_or_first(current: String, first: &str) -> String {
+    if current.is_empty() { first.to_owned() } else { current }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agent_client_protocol::schema::{
+        SessionConfigOptionCategory, SessionConfigSelectGroup, SessionConfigSelectOption, SessionMode,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn derives_modes_and_models_from_ungrouped_select_options() {
+        let options = vec![
+            SessionConfigOption::select(
+                "mode",
+                "Mode",
+                "plan",
+                vec![
+                    SessionConfigSelectOption::new("build", "Build"),
+                    SessionConfigSelectOption::new("plan", "Plan"),
+                ],
+            ),
+            SessionConfigOption::select(
+                "model",
+                "Model",
+                "opus",
+                vec![
+                    SessionConfigSelectOption::new("sonnet", "Sonnet"),
+                    SessionConfigSelectOption::new("opus", "Opus"),
+                ],
+            ),
+        ];
+
+        let modes = derive_modes_from_config_options(&options).expect("mode catalog");
+        assert_eq!(modes.current_mode_id.to_string(), "plan");
+        assert_eq!(
+            modes.available_modes,
+            vec![SessionMode::new("build", "Build"), SessionMode::new("plan", "Plan")]
+        );
+
+        let models = derive_models_from_config_options(&options).expect("model catalog");
+        assert_eq!(models.current_model_id.to_string(), "opus");
+        assert_eq!(models.available_models.len(), 2);
+        assert_eq!(models.available_models[0].model_id.to_string(), "sonnet");
+        assert_eq!(models.available_models[0].name, "Sonnet");
+    }
+
+    #[test]
+    fn derives_models_from_grouped_select_options() {
+        let options = vec![SessionConfigOption::select(
+            "models",
+            "Model",
+            "gpt-5",
+            vec![
+                SessionConfigSelectGroup::new(
+                    "openai",
+                    "OpenAI",
+                    vec![
+                        SessionConfigSelectOption::new("gpt-5", "GPT-5"),
+                        SessionConfigSelectOption::new("gpt-5-mini", "GPT-5 mini"),
+                    ],
+                ),
+                SessionConfigSelectGroup::new(
+                    "anthropic",
+                    "Anthropic",
+                    vec![SessionConfigSelectOption::new("claude-sonnet-4", "Claude Sonnet 4")],
+                ),
+            ],
+        )];
+
+        let models = derive_models_from_config_options(&options).expect("model catalog");
+        assert_eq!(models.current_model_id.to_string(), "gpt-5");
+        assert_eq!(models.available_models.len(), 3);
+        assert_eq!(models.available_models[2].model_id.to_string(), "claude-sonnet-4");
+    }
+
+    #[test]
+    fn derives_from_semantic_categories_before_id_aliases() {
+        let options = vec![
+            SessionConfigOption::select(
+                "reasoning",
+                "Reasoning",
+                "high",
+                vec![SessionConfigSelectOption::new("high", "High")],
+            ),
+            SessionConfigOption::select(
+                "session_mode",
+                "Mode",
+                "plan",
+                vec![SessionConfigSelectOption::new("plan", "Plan")],
+            )
+            .category(SessionConfigOptionCategory::Mode),
+            SessionConfigOption::select(
+                "default_model",
+                "Model",
+                "opus",
+                vec![SessionConfigSelectOption::new("opus", "Opus")],
+            )
+            .category(SessionConfigOptionCategory::Model),
+        ];
+
+        let modes = derive_modes_from_config_options(&options).expect("mode category");
+        assert_eq!(modes.current_mode_id.to_string(), "plan");
+
+        let models = derive_models_from_config_options(&options).expect("model category");
+        assert_eq!(models.current_model_id.to_string(), "opus");
+    }
+
+    #[test]
+    fn ignores_unknown_non_select_and_empty_options() {
+        let options = vec![
+            SessionConfigOption::select(
+                "reasoning",
+                "Reasoning",
+                "high",
+                vec![
+                    SessionConfigSelectOption::new("low", "Low"),
+                    SessionConfigSelectOption::new("high", "High"),
+                ],
+            ),
+            SessionConfigOption::select("mode", "Mode", "plan", Vec::<SessionConfigSelectOption>::new()),
+        ];
+
+        assert!(derive_modes_from_config_options(&options).is_none());
+        assert!(derive_models_from_config_options(&options).is_none());
+    }
+
+    #[test]
+    fn falls_back_to_first_option_when_current_value_is_empty() {
+        let options = vec![
+            SessionConfigOption::select(
+                "mode",
+                "Mode",
+                "",
+                vec![
+                    SessionConfigSelectOption::new("build", "Build"),
+                    SessionConfigSelectOption::new("plan", "Plan"),
+                ],
+            ),
+            SessionConfigOption::select(
+                "model",
+                "Model",
+                "",
+                vec![
+                    SessionConfigSelectOption::new("sonnet", "Sonnet"),
+                    SessionConfigSelectOption::new("opus", "Opus"),
+                ],
+            ),
+        ];
+
+        let modes = derive_modes_from_config_options(&options).expect("mode catalog");
+        assert_eq!(modes.current_mode_id.to_string(), "build");
+
+        let models = derive_models_from_config_options(&options).expect("model catalog");
+        assert_eq!(models.current_model_id.to_string(), "sonnet");
+    }
+
+    #[test]
+    fn enriches_missing_handshake_catalogs_from_config_options() {
+        let options = vec![
+            SessionConfigOption::select(
+                "modes",
+                "Mode",
+                "build",
+                vec![
+                    SessionConfigSelectOption::new("build", "Build"),
+                    SessionConfigSelectOption::new("plan", "Plan"),
+                ],
+            ),
+            SessionConfigOption::select(
+                "models",
+                "Model",
+                "sonnet",
+                vec![
+                    SessionConfigSelectOption::new("sonnet", "Sonnet"),
+                    SessionConfigSelectOption::new("opus", "Opus"),
+                ],
+            ),
+        ];
+        let handshake = AgentHandshake {
+            config_options: Some(serde_json::to_value(&options).unwrap()),
+            ..Default::default()
+        };
+
+        let enriched = enrich_handshake_with_existing_config_option_catalog(&handshake, None);
+
+        assert_eq!(
+            enriched.available_modes,
+            Some(json!({
+                "current_mode_id": "build",
+                "available_modes": [
+                    {"id": "build", "name": "Build"},
+                    {"id": "plan", "name": "Plan"}
+                ]
+            }))
+        );
+        assert_eq!(
+            enriched.available_models,
+            Some(json!({
+                "current_model_id": "sonnet",
+                "current_model_label": "Sonnet",
+                "available_models": [
+                    {"id": "sonnet", "label": "Sonnet"},
+                    {"id": "opus", "label": "Opus"}
+                ]
+            }))
+        );
+    }
+
+    #[test]
+    fn extracts_wrapped_config_option_update_shapes() {
+        let snake_wrapped = json!({
+            "config_options": [
+                {
+                    "id": "models",
+                    "name": "Model",
+                    "type": "select",
+                    "current_value": "opus",
+                    "options": [
+                        {"value": "sonnet", "name": "Sonnet"},
+                        {"value": "opus", "name": "Opus"}
+                    ]
+                }
+            ]
+        });
+        let camel_wrapped = json!({
+            "configOptions": [
+                {
+                    "id": "modes",
+                    "name": "Mode",
+                    "type": "select",
+                    "currentValue": "plan",
+                    "options": [
+                        {"value": "build", "name": "Build"},
+                        {"value": "plan", "name": "Plan"}
+                    ]
+                }
+            ]
+        });
+
+        let models = extract_config_options_from_value(&snake_wrapped).expect("snake wrapper");
+        assert_eq!(
+            derive_models_from_config_options(&models)
+                .expect("model catalog")
+                .current_model_id
+                .to_string(),
+            "opus"
+        );
+
+        let modes = extract_config_options_from_value(&camel_wrapped).expect("camel wrapper");
+        assert_eq!(
+            derive_modes_from_config_options(&modes)
+                .expect("mode catalog")
+                .current_mode_id
+                .to_string(),
+            "plan"
+        );
+    }
+
+    #[test]
+    fn enrich_keeps_explicit_non_empty_catalogs() {
+        let explicit_modes = json!({
+            "current_mode_id": "explicit",
+            "available_modes": [{"id": "explicit", "name": "Explicit"}]
+        });
+        let explicit_models = json!({
+            "current_model_id": "explicit-model",
+            "current_model_label": "Explicit Model",
+            "available_models": [{"id": "explicit-model", "label": "Explicit Model"}]
+        });
+        let handshake = AgentHandshake {
+            config_options: Some(json!([
+                {
+                    "id": "models",
+                    "name": "Model",
+                    "type": "select",
+                    "currentValue": "derived",
+                    "options": [{"value": "derived", "name": "Derived"}]
+                }
+            ])),
+            available_modes: Some(explicit_modes.clone()),
+            available_models: Some(explicit_models.clone()),
+            ..Default::default()
+        };
+
+        let enriched = enrich_handshake_with_existing_config_option_catalog(&handshake, None);
+
+        assert_eq!(enriched.available_modes, Some(explicit_modes));
+        assert_eq!(enriched.available_models, Some(explicit_models));
+    }
+
+    #[test]
+    fn enrich_skips_config_only_fallback_when_existing_catalog_is_non_empty() {
+        let existing = AgentHandshake {
+            available_models: Some(json!({
+                "current_model_id": "explicit-model",
+                "current_model_label": "Explicit Model",
+                "available_models": [{"id": "explicit-model", "label": "Explicit Model"}]
+            })),
+            ..Default::default()
+        };
+        let incoming = AgentHandshake {
+            config_options: Some(json!({
+                "configOptions": [
+                    {
+                        "id": "models",
+                        "name": "Model",
+                        "type": "select",
+                        "currentValue": "derived",
+                        "options": [{"value": "derived", "name": "Derived"}]
+                    }
+                ]
+            })),
+            ..Default::default()
+        };
+
+        let enriched = enrich_handshake_with_existing_config_option_catalog(&incoming, Some(&existing));
+
+        assert!(
+            enriched.available_models.is_none(),
+            "config-only partial must not overwrite an existing explicit catalog"
+        );
+    }
+}

--- a/crates/aionui-ai-agent/src/manager/acp/config_option_catalog.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/config_option_catalog.rs
@@ -25,16 +25,52 @@ pub(crate) fn derive_modes_from_config_options(options: &[SessionConfigOption]) 
 
 pub(crate) fn derive_models_from_config_options(options: &[SessionConfigOption]) -> Option<SessionModelState> {
     let select = find_select(options, &["model", "models"], &SessionConfigOptionCategory::Model)?;
-    let available_models: Vec<ModelInfo> = flatten_select_options(&select.options)
+    let model_options = flatten_select_options(&select.options);
+
+    if model_options.is_empty() {
+        return None;
+    }
+
+    if let Some(thought_select) = find_select(
+        options,
+        &["thought_level", "reasoning_effort"],
+        &SessionConfigOptionCategory::ThoughtLevel,
+    ) {
+        let thought_options = flatten_select_options(&thought_select.options);
+        if !thought_options.is_empty() {
+            let current_model =
+                non_empty_or_first(select.current_value.to_string(), &model_options[0].value.to_string());
+            let current_thought = non_empty_or_first(
+                thought_select.current_value.to_string(),
+                &thought_options[0].value.to_string(),
+            );
+            let available_models: Vec<ModelInfo> = model_options
+                .into_iter()
+                .flat_map(|model| {
+                    thought_options.iter().map(move |thought| {
+                        let thought_value = thought.value.to_string();
+                        ModelInfo::new(
+                            format!("{}/{}", model.value, thought.value),
+                            format!("{} ({thought_value})", model.name),
+                        )
+                        .description(model.description.clone())
+                    })
+                })
+                .collect();
+
+            return Some(SessionModelState::new(
+                format!("{current_model}/{current_thought}"),
+                available_models,
+            ));
+        }
+    }
+
+    let available_models: Vec<ModelInfo> = model_options
         .into_iter()
         .map(|option| {
             ModelInfo::new(option.value.to_string(), option.name.clone()).description(option.description.clone())
         })
         .collect();
-
-    if available_models.is_empty() {
-        return None;
-    }
 
     let current_model_id = non_empty_or_first(
         select.current_value.to_string(),
@@ -43,10 +79,58 @@ pub(crate) fn derive_models_from_config_options(options: &[SessionConfigOption])
     Some(SessionModelState::new(current_model_id, available_models))
 }
 
-pub(crate) fn enrich_handshake_with_existing_config_option_catalog(
-    handshake: &AgentHandshake,
-    existing: Option<&AgentHandshake>,
-) -> AgentHandshake {
+pub(crate) fn merge_config_options(
+    existing: Option<&[SessionConfigOption]>,
+    incoming: Vec<SessionConfigOption>,
+) -> Vec<SessionConfigOption> {
+    let Some(existing) = existing else {
+        return incoming;
+    };
+
+    let mut merged = existing.to_vec();
+    for option in incoming {
+        let incoming_id = option.id.to_string();
+        if let Some(existing) = merged
+            .iter_mut()
+            .find(|existing| existing.id.to_string() == incoming_id)
+        {
+            *existing = option;
+        } else {
+            merged.push(option);
+        }
+    }
+    merged
+}
+
+pub(crate) fn merge_config_option_values(existing: Option<&Value>, incoming: &Value) -> Option<Value> {
+    let incoming_options = extract_config_options_from_value(incoming)?;
+    let existing_options = existing.and_then(extract_config_options_from_value);
+    let merged_options = merge_config_options(existing_options.as_deref(), incoming_options);
+    Some(config_options_value_like(incoming, merged_options))
+}
+
+fn config_options_value_like(template: &Value, options: Vec<SessionConfigOption>) -> Value {
+    let options_value = serde_json::to_value(options).unwrap_or_else(|_| Value::Array(Vec::new()));
+    let Some(template_map) = template.as_object() else {
+        return options_value;
+    };
+
+    if template_map.contains_key("config_options") {
+        let mut map = template_map.clone();
+        map.insert("config_options".to_owned(), options_value);
+        return Value::Object(map);
+    }
+
+    if template_map.contains_key("configOptions") {
+        let mut map = template_map.clone();
+        map.insert("configOptions".to_owned(), options_value);
+        return Value::Object(map);
+    }
+
+    options_value
+}
+
+pub(crate) fn enrich_handshake_with_config_option_catalog(handshake: &AgentHandshake) -> AgentHandshake {
     let mut enriched = handshake.clone();
     let Some(config_options) = handshake
         .config_options
@@ -56,23 +140,13 @@ pub(crate) fn enrich_handshake_with_existing_config_option_catalog(
         return enriched;
     };
 
-    if should_fill_catalog(
-        &enriched.available_modes,
-        existing.and_then(|handshake| handshake.available_modes.as_ref()),
-        "available_modes",
-        "availableModes",
-    ) && let Some(modes) = derive_modes_from_config_options(&config_options)
+    if let Some(modes) = derive_modes_from_config_options(&config_options)
         && let Some(value) = mode_state_to_snake_value(&modes)
     {
         enriched.available_modes = Some(value);
     }
 
-    if should_fill_catalog(
-        &enriched.available_models,
-        existing.and_then(|handshake| handshake.available_models.as_ref()),
-        "available_models",
-        "availableModels",
-    ) && let Some(models) = derive_models_from_config_options(&config_options)
+    if let Some(models) = derive_models_from_config_options(&config_options)
         && let Some(value) = model_state_to_payload_value(&models)
     {
         enriched.available_models = Some(value);
@@ -163,34 +237,6 @@ fn model_state_to_payload_value(models: &SessionModelState) -> Option<Value> {
         available_models,
     })
     .ok()
-}
-
-fn has_non_empty_catalog(value: &Option<Value>, snake_key: &str, camel_key: &str) -> bool {
-    value
-        .as_ref()
-        .is_some_and(|value| has_non_empty_catalog_value(value, snake_key, camel_key))
-}
-
-fn has_non_empty_catalog_value(value: &Value, snake_key: &str, camel_key: &str) -> bool {
-    match value {
-        Value::Array(items) => !items.is_empty(),
-        Value::Object(map) => map
-            .get(snake_key)
-            .or_else(|| map.get(camel_key))
-            .and_then(Value::as_array)
-            .is_some_and(|items| !items.is_empty()),
-        _ => false,
-    }
-}
-
-fn should_fill_catalog(incoming: &Option<Value>, existing: Option<&Value>, snake_key: &str, camel_key: &str) -> bool {
-    if has_non_empty_catalog(incoming, snake_key, camel_key) {
-        return false;
-    }
-    if incoming.is_none() && existing.is_some_and(|value| has_non_empty_catalog_value(value, snake_key, camel_key)) {
-        return false;
-    }
-    true
 }
 
 fn keys_to_camel_case(value: Value) -> Value {
@@ -308,6 +354,43 @@ mod tests {
     }
 
     #[test]
+    fn derives_codex_model_variants_from_model_and_thought_level_options() {
+        let options = vec![
+            SessionConfigOption::select(
+                "model",
+                "Model",
+                "gpt-5.5",
+                vec![
+                    SessionConfigSelectOption::new("gpt-5.5", "GPT-5.5"),
+                    SessionConfigSelectOption::new("gpt-5.4", "gpt-5.4"),
+                ],
+            )
+            .category(SessionConfigOptionCategory::Model),
+            SessionConfigOption::select(
+                "reasoning_effort",
+                "Reasoning Effort",
+                "medium",
+                vec![
+                    SessionConfigSelectOption::new("low", "Low"),
+                    SessionConfigSelectOption::new("medium", "Medium"),
+                ],
+            )
+            .category(SessionConfigOptionCategory::ThoughtLevel),
+        ];
+
+        let models = derive_models_from_config_options(&options).expect("combined model catalog");
+
+        assert_eq!(models.current_model_id.to_string(), "gpt-5.5/medium");
+        assert_eq!(models.available_models.len(), 4);
+        assert_eq!(models.available_models[0].model_id.to_string(), "gpt-5.5/low");
+        assert_eq!(models.available_models[0].name, "GPT-5.5 (low)");
+        assert_eq!(models.available_models[1].model_id.to_string(), "gpt-5.5/medium");
+        assert_eq!(models.available_models[1].name, "GPT-5.5 (medium)");
+        assert_eq!(models.available_models[3].model_id.to_string(), "gpt-5.4/medium");
+        assert_eq!(models.available_models[3].name, "gpt-5.4 (medium)");
+    }
+
+    #[test]
     fn derives_from_semantic_categories_before_id_aliases() {
         let options = vec![
             SessionConfigOption::select(
@@ -415,7 +498,7 @@ mod tests {
             ..Default::default()
         };
 
-        let enriched = enrich_handshake_with_existing_config_option_catalog(&handshake, None);
+        let enriched = enrich_handshake_with_config_option_catalog(&handshake);
 
         assert_eq!(
             enriched.available_modes,
@@ -491,7 +574,7 @@ mod tests {
     }
 
     #[test]
-    fn enrich_keeps_explicit_non_empty_catalogs() {
+    fn enrich_falls_back_to_available_catalogs_when_config_options_have_no_catalogs() {
         let explicit_modes = json!({
             "current_mode_id": "explicit",
             "available_modes": [{"id": "explicit", "name": "Explicit"}]
@@ -504,11 +587,11 @@ mod tests {
         let handshake = AgentHandshake {
             config_options: Some(json!([
                 {
-                    "id": "models",
-                    "name": "Model",
+                    "id": "reasoning",
+                    "name": "Reasoning",
                     "type": "select",
-                    "currentValue": "derived",
-                    "options": [{"value": "derived", "name": "Derived"}]
+                    "currentValue": "high",
+                    "options": [{"value": "high", "name": "High"}]
                 }
             ])),
             available_modes: Some(explicit_modes.clone()),
@@ -516,22 +599,14 @@ mod tests {
             ..Default::default()
         };
 
-        let enriched = enrich_handshake_with_existing_config_option_catalog(&handshake, None);
+        let enriched = enrich_handshake_with_config_option_catalog(&handshake);
 
         assert_eq!(enriched.available_modes, Some(explicit_modes));
         assert_eq!(enriched.available_models, Some(explicit_models));
     }
 
     #[test]
-    fn enrich_skips_config_only_fallback_when_existing_catalog_is_non_empty() {
-        let existing = AgentHandshake {
-            available_models: Some(json!({
-                "current_model_id": "explicit-model",
-                "current_model_label": "Explicit Model",
-                "available_models": [{"id": "explicit-model", "label": "Explicit Model"}]
-            })),
-            ..Default::default()
-        };
+    fn enrich_prefers_config_options_over_available_catalogs() {
         let incoming = AgentHandshake {
             config_options: Some(json!({
                 "configOptions": [
@@ -544,14 +619,23 @@ mod tests {
                     }
                 ]
             })),
+            available_models: Some(json!({
+                "current_model_id": "available-model",
+                "current_model_label": "Available Model",
+                "available_models": [{"id": "available-model", "label": "Available Model"}]
+            })),
             ..Default::default()
         };
 
-        let enriched = enrich_handshake_with_existing_config_option_catalog(&incoming, Some(&existing));
+        let enriched = enrich_handshake_with_config_option_catalog(&incoming);
 
-        assert!(
-            enriched.available_models.is_none(),
-            "config-only partial must not overwrite an existing explicit catalog"
+        assert_eq!(
+            enriched.available_models,
+            Some(json!({
+                "current_model_id": "derived",
+                "current_model_label": "Derived",
+                "available_models": [{"id": "derived", "label": "Derived"}]
+            }))
         );
     }
 }

--- a/crates/aionui-ai-agent/src/manager/acp/mod.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/mod.rs
@@ -5,6 +5,7 @@ pub mod agent_reconcile;
 mod agent_session_flow;
 pub mod catalog_forwarder;
 mod codex_sandbox;
+pub(crate) mod config_option_catalog;
 mod error_mapping;
 pub mod hooks;
 mod mode_normalize;

--- a/crates/aionui-ai-agent/src/manager/acp/session.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session.rs
@@ -7,6 +7,7 @@ use agent_client_protocol::schema::{
 
 use super::agent_event_tracker::AcpSessionEvent;
 use super::agent_reconcile::ReconcileAction;
+use super::config_option_catalog::{derive_models_from_config_options, derive_modes_from_config_options};
 use crate::protocol::error::CloseReason;
 use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId, PersistedSessionState, SessionId};
 
@@ -52,6 +53,10 @@ struct Advertised {
 pub struct AcpSession {
     session_id: Option<SessionId>,
     opened: bool,
+    desired: Desired,
+    observed: Observed,
+    advertised: Advertised,
+    pending_events: Vec<AcpSessionEvent>,
     /// Whether `open_session_new` has just completed and the next prompt
     /// should receive preset_context / skill-index injection.
     ///
@@ -64,10 +69,6 @@ pub struct AcpSession {
     /// Starts `false` so resume paths, warmup-only flows, and aborted
     /// session/new attempts all correctly observe "no prelude pending".
     pending_session_new_prelude: bool,
-    desired: Desired,
-    observed: Observed,
-    advertised: Advertised,
-    pending_events: Vec<AcpSessionEvent>,
     /// Model id the next prompt should announce to the CLI via an
     /// injected `<system-reminder>`. Written when the CLI bakes
     /// model identity into its cached system prompt (see
@@ -467,6 +468,26 @@ impl AcpSession {
     }
 
     pub fn apply_advertised_config_options(&mut self, options: Vec<SessionConfigOption>) {
+        if self
+            .advertised
+            .modes
+            .as_ref()
+            .is_none_or(|modes| modes.available_modes.is_empty())
+            && let Some(modes) = derive_modes_from_config_options(&options)
+        {
+            self.apply_advertised_modes(modes);
+        }
+
+        if self
+            .advertised
+            .models
+            .as_ref()
+            .is_none_or(|models| models.available_models.is_empty())
+            && let Some(models) = derive_models_from_config_options(&options)
+        {
+            self.apply_advertised_models(models);
+        }
+
         let mut changed = false;
         for opt in &options {
             if let Some(current) = extract_config_current_value(&opt.kind) {

--- a/crates/aionui-ai-agent/src/manager/acp/session.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session.rs
@@ -7,7 +7,9 @@ use agent_client_protocol::schema::{
 
 use super::agent_event_tracker::AcpSessionEvent;
 use super::agent_reconcile::ReconcileAction;
-use super::config_option_catalog::{derive_models_from_config_options, derive_modes_from_config_options};
+use super::config_option_catalog::{
+    derive_models_from_config_options, derive_modes_from_config_options, merge_config_options,
+};
 use crate::protocol::error::CloseReason;
 use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId, PersistedSessionState, SessionId};
 
@@ -468,23 +470,13 @@ impl AcpSession {
     }
 
     pub fn apply_advertised_config_options(&mut self, options: Vec<SessionConfigOption>) {
-        if self
-            .advertised
-            .modes
-            .as_ref()
-            .is_none_or(|modes| modes.available_modes.is_empty())
-            && let Some(modes) = derive_modes_from_config_options(&options)
-        {
+        let options = merge_config_options(self.advertised.config_options.as_deref(), options);
+
+        if let Some(modes) = derive_modes_from_config_options(&options) {
             self.apply_advertised_modes(modes);
         }
 
-        if self
-            .advertised
-            .models
-            .as_ref()
-            .is_none_or(|models| models.available_models.is_empty())
-            && let Some(models) = derive_models_from_config_options(&options)
-        {
+        if let Some(models) = derive_models_from_config_options(&options) {
             self.apply_advertised_models(models);
         }
 

--- a/crates/aionui-ai-agent/src/manager/acp/session_tests.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session_tests.rs
@@ -3,7 +3,7 @@
 //! `#[path = "session_tests.rs"] mod tests;` from `session.rs`, so
 //! `super::*` resolves to the `session` module's private scope.
 
-use agent_client_protocol::schema::{ModelInfo, SessionConfigSelectOption, SessionMode};
+use agent_client_protocol::schema::{ModelInfo, SessionConfigOptionCategory, SessionConfigSelectOption, SessionMode};
 
 use super::*;
 
@@ -574,7 +574,7 @@ fn apply_advertised_config_options_derives_missing_mode_and_model_catalogs() {
 }
 
 #[test]
-fn apply_advertised_config_options_keeps_explicit_non_empty_mode_and_model_catalogs() {
+fn apply_advertised_config_options_falls_back_to_existing_catalogs_when_config_options_have_no_catalogs() {
     let mut session = AcpSession::new(None, None, HashMap::new());
     session.apply_advertised_modes(SessionModeState::new(
         "build",
@@ -586,20 +586,12 @@ fn apply_advertised_config_options_keeps_explicit_non_empty_mode_and_model_catal
     ));
     session.drain_events();
 
-    session.apply_advertised_config_options(vec![
-        SessionConfigOption::select(
-            "modes",
-            "Mode",
-            "derived-mode",
-            vec![SessionConfigSelectOption::new("derived-mode", "Derived mode")],
-        ),
-        SessionConfigOption::select(
-            "models",
-            "Model",
-            "derived-model",
-            vec![SessionConfigSelectOption::new("derived-model", "Derived model")],
-        ),
-    ]);
+    session.apply_advertised_config_options(vec![SessionConfigOption::select(
+        "reasoning",
+        "Reasoning",
+        "high",
+        vec![SessionConfigSelectOption::new("high", "High")],
+    )]);
 
     assert_eq!(session.observed_mode(), Some("build"));
     assert_eq!(session.current_mode_id().as_deref(), Some("build"));
@@ -612,6 +604,116 @@ fn apply_advertised_config_options_keeps_explicit_non_empty_mode_and_model_catal
     let models = session.model_info().expect("explicit models");
     assert_eq!(models.available_models.len(), 2);
     assert_eq!(models.available_models[0].model_id.to_string(), "sonnet");
+}
+
+#[test]
+fn apply_advertised_config_options_prefers_config_option_catalogs_over_existing_catalogs() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+    session.apply_advertised_modes(SessionModeState::new(
+        "available-mode",
+        vec![SessionMode::new("available-mode", "Available Mode")],
+    ));
+    session.apply_advertised_models(SessionModelState::new(
+        "available-model",
+        vec![ModelInfo::new("available-model", "Available Model")],
+    ));
+    session.drain_events();
+
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "modes",
+            "Mode",
+            "config-mode",
+            vec![SessionConfigSelectOption::new("config-mode", "Config Mode")],
+        ),
+        SessionConfigOption::select(
+            "models",
+            "Model",
+            "config-model",
+            vec![SessionConfigSelectOption::new("config-model", "Config Model")],
+        ),
+    ]);
+
+    assert_eq!(session.observed_mode(), Some("config-mode"));
+    assert_eq!(session.current_mode_id().as_deref(), Some("config-mode"));
+    let modes = session.modes().expect("config option modes");
+    assert_eq!(modes.available_modes.len(), 1);
+    assert_eq!(modes.available_modes[0].id.to_string(), "config-mode");
+
+    assert_eq!(session.observed_model(), Some("config-model"));
+    assert_eq!(session.current_model_id().as_deref(), Some("config-model"));
+    let models = session.model_info().expect("config option models");
+    assert_eq!(models.available_models.len(), 1);
+    assert_eq!(models.available_models[0].model_id.to_string(), "config-model");
+}
+
+#[test]
+fn apply_advertised_config_options_merges_partial_updates_and_derives_model_reasoning_variants() {
+    let mut session = make_session();
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "mode",
+            "Mode",
+            "full-access",
+            vec![
+                SessionConfigSelectOption::new("auto", "Default"),
+                SessionConfigSelectOption::new("full-access", "Full Access"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::Mode),
+        SessionConfigOption::select(
+            "model",
+            "Model",
+            "gpt-5.4",
+            vec![SessionConfigSelectOption::new("gpt-5.4", "gpt-5.4")],
+        )
+        .category(SessionConfigOptionCategory::Model),
+        SessionConfigOption::select(
+            "reasoning_effort",
+            "Reasoning Effort",
+            "low",
+            vec![SessionConfigSelectOption::new("low", "Low")],
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel),
+    ]);
+    session.drain_events();
+
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "model",
+            "Model",
+            "gpt-5.5",
+            vec![
+                SessionConfigSelectOption::new("gpt-5.5", "GPT-5.5"),
+                SessionConfigSelectOption::new("gpt-5.4", "gpt-5.4"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::Model),
+        SessionConfigOption::select(
+            "reasoning_effort",
+            "Reasoning Effort",
+            "medium",
+            vec![
+                SessionConfigSelectOption::new("low", "Low"),
+                SessionConfigSelectOption::new("medium", "Medium"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel),
+    ]);
+
+    let modes = session.modes().expect("mode catalog is preserved");
+    assert_eq!(modes.current_mode_id.to_string(), "full-access");
+    assert_eq!(modes.available_modes.len(), 2);
+
+    let config_options = session.config_options().expect("config options are preserved");
+    assert_eq!(config_options.len(), 3);
+    assert!(config_options.iter().any(|option| option.id.to_string() == "mode"));
+
+    let models = session.model_info().expect("model catalog");
+    assert_eq!(models.current_model_id.to_string(), "gpt-5.5/medium");
+    assert_eq!(models.available_models.len(), 4);
+    assert_eq!(models.available_models[0].model_id.to_string(), "gpt-5.5/low");
+    assert_eq!(models.available_models[1].model_id.to_string(), "gpt-5.5/medium");
 }
 
 #[test]

--- a/crates/aionui-ai-agent/src/manager/acp/session_tests.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session_tests.rs
@@ -3,7 +3,7 @@
 //! `#[path = "session_tests.rs"] mod tests;` from `session.rs`, so
 //! `super::*` resolves to the `session` module's private scope.
 
-use agent_client_protocol::schema::{SessionConfigSelectOption, SessionMode};
+use agent_client_protocol::schema::{ModelInfo, SessionConfigSelectOption, SessionMode};
 
 use super::*;
 
@@ -533,6 +533,85 @@ fn apply_advertised_config_options_idempotent_when_unchanged() {
         events.is_empty(),
         "no ObservedConfigSynced when observed unchanged, got {events:?}"
     );
+}
+
+#[test]
+fn apply_advertised_config_options_derives_missing_mode_and_model_catalogs() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "modes",
+            "Mode",
+            "plan",
+            vec![
+                SessionConfigSelectOption::new("build", "Build"),
+                SessionConfigSelectOption::new("plan", "Plan"),
+            ],
+        ),
+        SessionConfigOption::select(
+            "models",
+            "Model",
+            "opus",
+            vec![
+                SessionConfigSelectOption::new("sonnet", "Sonnet"),
+                SessionConfigSelectOption::new("opus", "Opus"),
+            ],
+        ),
+    ]);
+
+    assert_eq!(session.observed_mode(), Some("plan"));
+    assert_eq!(session.current_mode_id().as_deref(), Some("plan"));
+    let modes = session.modes().expect("derived modes");
+    assert_eq!(modes.available_modes.len(), 2);
+    assert_eq!(modes.available_modes[1].id.to_string(), "plan");
+
+    assert_eq!(session.observed_model(), Some("opus"));
+    assert_eq!(session.current_model_id().as_deref(), Some("opus"));
+    let models = session.model_info().expect("derived models");
+    assert_eq!(models.available_models.len(), 2);
+    assert_eq!(models.available_models[1].model_id.to_string(), "opus");
+}
+
+#[test]
+fn apply_advertised_config_options_keeps_explicit_non_empty_mode_and_model_catalogs() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+    session.apply_advertised_modes(SessionModeState::new(
+        "build",
+        vec![SessionMode::new("build", "Build"), SessionMode::new("plan", "Plan")],
+    ));
+    session.apply_advertised_models(SessionModelState::new(
+        "sonnet",
+        vec![ModelInfo::new("sonnet", "Sonnet"), ModelInfo::new("opus", "Opus")],
+    ));
+    session.drain_events();
+
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "modes",
+            "Mode",
+            "derived-mode",
+            vec![SessionConfigSelectOption::new("derived-mode", "Derived mode")],
+        ),
+        SessionConfigOption::select(
+            "models",
+            "Model",
+            "derived-model",
+            vec![SessionConfigSelectOption::new("derived-model", "Derived model")],
+        ),
+    ]);
+
+    assert_eq!(session.observed_mode(), Some("build"));
+    assert_eq!(session.current_mode_id().as_deref(), Some("build"));
+    let modes = session.modes().expect("explicit modes");
+    assert_eq!(modes.available_modes.len(), 2);
+    assert_eq!(modes.available_modes[0].id.to_string(), "build");
+
+    assert_eq!(session.observed_model(), Some("sonnet"));
+    assert_eq!(session.current_model_id().as_deref(), Some("sonnet"));
+    let models = session.model_info().expect("explicit models");
+    assert_eq!(models.available_models.len(), 2);
+    assert_eq!(models.available_models[0].model_id.to_string(), "sonnet");
 }
 
 #[test]

--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -29,6 +29,7 @@ use tokio::sync::{RwLock, mpsc};
 use tracing::{debug, info, warn};
 
 use crate::error::AgentError;
+use crate::manager::acp::config_option_catalog::enrich_handshake_with_existing_config_option_catalog;
 
 /// Capacity of the catalog-sync MPSC channel. A single writer thread
 /// drains it serially, so the bound just sizes the burst we can absorb
@@ -41,6 +42,10 @@ struct CatalogSyncMessage {
     agent_metadata_id: String,
     handshake: AgentHandshake,
 }
+
+#[cfg(test)]
+#[path = "registry_config_option_tests.rs"]
+mod registry_config_option_tests;
 
 pub struct AgentRegistry {
     repo: Arc<dyn IAgentMetadataRepository>,
@@ -91,6 +96,8 @@ impl AgentRegistry {
     ///
     /// `None` fields are left untouched (partial update).
     async fn apply_handshake_inner(&self, id: &str, snapshot: &AgentHandshake) -> Result<(), AgentError> {
+        let existing = self.by_id.read().await.get(id).map(|meta| meta.handshake.clone());
+        let snapshot = enrich_handshake_with_existing_config_option_catalog(snapshot, existing.as_ref());
         let agent_capabilities = encode_optional(&snapshot.agent_capabilities, "agent_capabilities")?;
         let auth_methods = encode_optional(&snapshot.auth_methods, "auth_methods")?;
         let config_options = encode_optional(&snapshot.config_options, "config_options")?;

--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -29,7 +29,9 @@ use tokio::sync::{RwLock, mpsc};
 use tracing::{debug, info, warn};
 
 use crate::error::AgentError;
-use crate::manager::acp::config_option_catalog::enrich_handshake_with_existing_config_option_catalog;
+use crate::manager::acp::config_option_catalog::{
+    enrich_handshake_with_config_option_catalog, merge_config_option_values,
+};
 
 /// Capacity of the catalog-sync MPSC channel. A single writer thread
 /// drains it serially, so the bound just sizes the burst we can absorb
@@ -46,6 +48,10 @@ struct CatalogSyncMessage {
 #[cfg(test)]
 #[path = "registry_config_option_tests.rs"]
 mod registry_config_option_tests;
+
+#[cfg(test)]
+#[path = "registry_tests.rs"]
+mod registry_tests;
 
 pub struct AgentRegistry {
     repo: Arc<dyn IAgentMetadataRepository>,
@@ -96,8 +102,20 @@ impl AgentRegistry {
     ///
     /// `None` fields are left untouched (partial update).
     async fn apply_handshake_inner(&self, id: &str, snapshot: &AgentHandshake) -> Result<(), AgentError> {
-        let existing = self.by_id.read().await.get(id).map(|meta| meta.handshake.clone());
-        let snapshot = enrich_handshake_with_existing_config_option_catalog(snapshot, existing.as_ref());
+        let mut snapshot = snapshot.clone();
+        if let Some(incoming_config_options) = snapshot.config_options.as_ref() {
+            let existing_config_options = {
+                let guard = self.by_id.read().await;
+                guard.get(id).and_then(|meta| meta.handshake.config_options.clone())
+            };
+            if let Some(merged_config_options) =
+                merge_config_option_values(existing_config_options.as_ref(), incoming_config_options)
+            {
+                snapshot.config_options = Some(merged_config_options);
+            }
+        }
+
+        let snapshot = enrich_handshake_with_config_option_catalog(&snapshot);
         let agent_capabilities = encode_optional(&snapshot.agent_capabilities, "agent_capabilities")?;
         let auth_methods = encode_optional(&snapshot.auth_methods, "auth_methods")?;
         let config_options = encode_optional(&snapshot.config_options, "config_options")?;
@@ -654,127 +672,6 @@ mod tests {
         let reg = AgentRegistry::new(repo);
         reg.hydrate().await.unwrap();
         reg
-    }
-
-    #[test]
-    fn probe_resolved_command_accepts_bare_npx_when_managed_runtime_is_supported() {
-        if !probe_node_runtime_supported().is_supported() {
-            return;
-        }
-
-        let meta = AgentMetadata {
-            id: "agent-1".into(),
-            icon: None,
-            name: "Test ACP".into(),
-            name_i18n: None,
-            description: None,
-            description_i18n: None,
-            backend: Some("custom".into()),
-            agent_type: AgentType::Acp,
-            agent_source: AgentSource::Custom,
-            agent_source_info: AgentSourceInfo::default(),
-            enabled: true,
-            available: false,
-            command: Some("npx".into()),
-            resolved_command: None,
-            args: vec![],
-            env: vec![],
-            native_skills_dirs: None,
-            behavior_policy: BehaviorPolicy::default(),
-            yolo_id: None,
-            sort_order: 0,
-            team_capable: false,
-            handshake: AgentHandshake::default(),
-        };
-
-        let resolved = probe_resolved_command(&meta).expect("probe");
-        assert_eq!(resolved, PathBuf::from("npx"));
-    }
-
-    #[test]
-    fn probe_resolved_command_requires_primary_binary_for_builtin_managed_claude() {
-        if !probe_node_runtime_supported().is_supported()
-            || !probe_managed_acp_tool_supported(ManagedAcpToolId::ClaudeAgentAcp).is_supported()
-        {
-            return;
-        }
-
-        let meta = AgentMetadata {
-            id: "agent-claude".into(),
-            icon: None,
-            name: "Claude Code".into(),
-            name_i18n: None,
-            description: None,
-            description_i18n: None,
-            backend: Some("claude".into()),
-            agent_type: AgentType::Acp,
-            agent_source: AgentSource::Builtin,
-            agent_source_info: AgentSourceInfo {
-                binary_name: Some("definitely-missing-claude-cli".into()),
-                ..Default::default()
-            },
-            enabled: true,
-            available: false,
-            command: None,
-            resolved_command: None,
-            args: vec![],
-            env: vec![],
-            native_skills_dirs: None,
-            behavior_policy: BehaviorPolicy::default(),
-            yolo_id: None,
-            sort_order: 0,
-            team_capable: false,
-            handshake: AgentHandshake::default(),
-        };
-
-        let reason = probe_resolved_command(&meta).expect_err("missing claude CLI must hide builtin row");
-        assert!(matches!(
-            reason,
-            UnavailableReason::PrimaryMissing { binary } if binary == "definitely-missing-claude-cli"
-        ));
-    }
-
-    #[test]
-    fn probe_resolved_command_requires_primary_binary_for_builtin_managed_codex() {
-        if !probe_node_runtime_supported().is_supported()
-            || !probe_managed_acp_tool_supported(ManagedAcpToolId::CodexAcp).is_supported()
-        {
-            return;
-        }
-
-        let meta = AgentMetadata {
-            id: "agent-codex".into(),
-            icon: None,
-            name: "Codex".into(),
-            name_i18n: None,
-            description: None,
-            description_i18n: None,
-            backend: Some("codex".into()),
-            agent_type: AgentType::Acp,
-            agent_source: AgentSource::Builtin,
-            agent_source_info: AgentSourceInfo {
-                binary_name: Some("definitely-missing-codex-cli".into()),
-                ..Default::default()
-            },
-            enabled: true,
-            available: false,
-            command: None,
-            resolved_command: None,
-            args: vec![],
-            env: vec![],
-            native_skills_dirs: None,
-            behavior_policy: BehaviorPolicy::default(),
-            yolo_id: None,
-            sort_order: 0,
-            team_capable: false,
-            handshake: AgentHandshake::default(),
-        };
-
-        let reason = probe_resolved_command(&meta).expect_err("missing codex CLI must hide builtin row");
-        assert!(matches!(
-            reason,
-            UnavailableReason::PrimaryMissing { binary } if binary == "definitely-missing-codex-cli"
-        ));
     }
 
     #[tokio::test]

--- a/crates/aionui-ai-agent/src/registry_config_option_tests.rs
+++ b/crates/aionui-ai-agent/src/registry_config_option_tests.rs
@@ -1,0 +1,168 @@
+use std::sync::Arc;
+
+use aionui_api_types::AgentHandshake;
+use aionui_db::{SqliteAgentMetadataRepository, init_database_memory};
+
+use super::AgentRegistry;
+
+async fn registry() -> Arc<AgentRegistry> {
+    let db = init_database_memory().await.unwrap();
+    let repo = Arc::new(SqliteAgentMetadataRepository::new(db.pool().clone()));
+    let reg = AgentRegistry::new(repo);
+    reg.hydrate().await.unwrap();
+    reg
+}
+
+#[tokio::test]
+async fn apply_handshake_derives_catalogs_from_config_options_before_persisting() {
+    let reg = registry().await;
+    let opencode = reg.find_builtin_by_backend("opencode").await.unwrap();
+
+    reg.apply_handshake_inner(
+        &opencode.id,
+        &AgentHandshake {
+            config_options: Some(serde_json::json!({
+                "config_options": [
+                    {
+                        "id": "modes",
+                        "name": "Mode",
+                        "type": "select",
+                        "current_value": "build",
+                        "options": [
+                            {"value": "build", "name": "Build"},
+                            {"value": "plan", "name": "Plan"}
+                        ]
+                    },
+                    {
+                        "id": "models",
+                        "name": "Model",
+                        "type": "select",
+                        "current_value": "sonnet",
+                        "options": [
+                            {"value": "sonnet", "name": "Sonnet"},
+                            {"value": "opus", "name": "Opus"}
+                        ]
+                    }
+                ]
+            })),
+            available_modes: Some(serde_json::json!({"available_modes": []})),
+            available_models: Some(serde_json::json!({"available_models": []})),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let refreshed = reg.get(&opencode.id).await.unwrap();
+    assert_eq!(
+        refreshed.handshake.available_modes,
+        Some(serde_json::json!({
+            "current_mode_id": "build",
+            "available_modes": [
+                {"id": "build", "name": "Build"},
+                {"id": "plan", "name": "Plan"}
+            ]
+        }))
+    );
+    assert_eq!(
+        refreshed.handshake.available_models,
+        Some(serde_json::json!({
+            "current_model_id": "sonnet",
+            "current_model_label": "Sonnet",
+            "available_models": [
+                {"id": "sonnet", "label": "Sonnet"},
+                {"id": "opus", "label": "Opus"}
+            ]
+        }))
+    );
+}
+
+#[tokio::test]
+async fn apply_handshake_keeps_explicit_non_empty_available_models() {
+    let reg = registry().await;
+    let opencode = reg.find_builtin_by_backend("opencode").await.unwrap();
+    let explicit_models = serde_json::json!({
+        "current_model_id": "explicit",
+        "current_model_label": "Explicit",
+        "available_models": [{"id": "explicit", "label": "Explicit"}]
+    });
+
+    reg.apply_handshake_inner(
+        &opencode.id,
+        &AgentHandshake {
+            config_options: Some(serde_json::json!([
+                {
+                    "id": "model",
+                    "name": "Model",
+                    "type": "select",
+                    "currentValue": "derived",
+                    "options": [{"value": "derived", "name": "Derived"}]
+                }
+            ])),
+            available_models: Some(explicit_models.clone()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let refreshed = reg.get(&opencode.id).await.unwrap();
+    assert_eq!(refreshed.handshake.available_models, Some(explicit_models));
+}
+
+#[tokio::test]
+async fn apply_handshake_config_only_partial_does_not_overwrite_existing_catalogs() {
+    let reg = registry().await;
+    let opencode = reg.find_builtin_by_backend("opencode").await.unwrap();
+    let explicit_modes = serde_json::json!({
+        "current_mode_id": "explicit-mode",
+        "available_modes": [{"id": "explicit-mode", "name": "Explicit Mode"}]
+    });
+    let explicit_models = serde_json::json!({
+        "current_model_id": "explicit-model",
+        "current_model_label": "Explicit Model",
+        "available_models": [{"id": "explicit-model", "label": "Explicit Model"}]
+    });
+
+    reg.apply_handshake_inner(
+        &opencode.id,
+        &AgentHandshake {
+            available_modes: Some(explicit_modes.clone()),
+            available_models: Some(explicit_models.clone()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    reg.apply_handshake_inner(
+        &opencode.id,
+        &AgentHandshake {
+            config_options: Some(serde_json::json!({
+                "configOptions": [
+                    {
+                        "id": "modes",
+                        "name": "Mode",
+                        "type": "select",
+                        "currentValue": "derived-mode",
+                        "options": [{"value": "derived-mode", "name": "Derived Mode"}]
+                    },
+                    {
+                        "id": "models",
+                        "name": "Model",
+                        "type": "select",
+                        "currentValue": "derived-model",
+                        "options": [{"value": "derived-model", "name": "Derived Model"}]
+                    }
+                ]
+            })),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let refreshed = reg.get(&opencode.id).await.unwrap();
+    assert_eq!(refreshed.handshake.available_modes, Some(explicit_modes));
+    assert_eq!(refreshed.handshake.available_models, Some(explicit_models));
+}

--- a/crates/aionui-ai-agent/src/registry_config_option_tests.rs
+++ b/crates/aionui-ai-agent/src/registry_config_option_tests.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use aionui_api_types::AgentHandshake;
 use aionui_db::{SqliteAgentMetadataRepository, init_database_memory};
 
+use crate::manager::acp::config_option_catalog::extract_config_options_from_value;
+
 use super::AgentRegistry;
 
 async fn registry() -> Arc<AgentRegistry> {
@@ -78,7 +80,7 @@ async fn apply_handshake_derives_catalogs_from_config_options_before_persisting(
 }
 
 #[tokio::test]
-async fn apply_handshake_keeps_explicit_non_empty_available_models() {
+async fn apply_handshake_falls_back_to_available_catalogs_when_config_options_have_no_catalogs() {
     let reg = registry().await;
     let opencode = reg.find_builtin_by_backend("opencode").await.unwrap();
     let explicit_models = serde_json::json!({
@@ -92,11 +94,11 @@ async fn apply_handshake_keeps_explicit_non_empty_available_models() {
         &AgentHandshake {
             config_options: Some(serde_json::json!([
                 {
-                    "id": "model",
-                    "name": "Model",
+                    "id": "reasoning",
+                    "name": "Reasoning",
                     "type": "select",
-                    "currentValue": "derived",
-                    "options": [{"value": "derived", "name": "Derived"}]
+                    "currentValue": "high",
+                    "options": [{"value": "high", "name": "High"}]
                 }
             ])),
             available_models: Some(explicit_models.clone()),
@@ -111,7 +113,86 @@ async fn apply_handshake_keeps_explicit_non_empty_available_models() {
 }
 
 #[tokio::test]
-async fn apply_handshake_config_only_partial_does_not_overwrite_existing_catalogs() {
+async fn apply_handshake_prefers_config_options_over_available_catalogs() {
+    let reg = registry().await;
+    let opencode = reg.find_builtin_by_backend("opencode").await.unwrap();
+    let existing_modes = serde_json::json!({
+        "current_mode_id": "existing-mode",
+        "available_modes": [{"id": "existing-mode", "name": "Existing Mode"}]
+    });
+    let existing_models = serde_json::json!({
+        "current_model_id": "existing-model",
+        "current_model_label": "Existing Model",
+        "available_models": [{"id": "existing-model", "label": "Existing Model"}]
+    });
+
+    reg.apply_handshake_inner(
+        &opencode.id,
+        &AgentHandshake {
+            available_modes: Some(existing_modes),
+            available_models: Some(existing_models),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    reg.apply_handshake_inner(
+        &opencode.id,
+        &AgentHandshake {
+            config_options: Some(serde_json::json!({
+                "configOptions": [
+                    {
+                        "id": "modes",
+                        "name": "Mode",
+                        "type": "select",
+                        "currentValue": "config-mode",
+                        "options": [{"value": "config-mode", "name": "Config Mode"}]
+                    },
+                    {
+                        "id": "models",
+                        "name": "Model",
+                        "type": "select",
+                        "currentValue": "config-model",
+                        "options": [{"value": "config-model", "name": "Config Model"}]
+                    }
+                ]
+            })),
+            available_modes: Some(serde_json::json!({
+                "current_mode_id": "incoming-mode",
+                "available_modes": [{"id": "incoming-mode", "name": "Incoming Mode"}]
+            })),
+            available_models: Some(serde_json::json!({
+                "current_model_id": "incoming-model",
+                "current_model_label": "Incoming Model",
+                "available_models": [{"id": "incoming-model", "label": "Incoming Model"}]
+            })),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let refreshed = reg.get(&opencode.id).await.unwrap();
+    assert_eq!(
+        refreshed.handshake.available_modes,
+        Some(serde_json::json!({
+            "current_mode_id": "config-mode",
+            "available_modes": [{"id": "config-mode", "name": "Config Mode"}]
+        }))
+    );
+    assert_eq!(
+        refreshed.handshake.available_models,
+        Some(serde_json::json!({
+            "current_model_id": "config-model",
+            "current_model_label": "Config Model",
+            "available_models": [{"id": "config-model", "label": "Config Model"}]
+        }))
+    );
+}
+
+#[tokio::test]
+async fn apply_handshake_config_only_partial_prefers_config_options_over_existing_catalogs() {
     let reg = registry().await;
     let opencode = reg.find_builtin_by_backend("opencode").await.unwrap();
     let explicit_modes = serde_json::json!({
@@ -163,6 +244,131 @@ async fn apply_handshake_config_only_partial_does_not_overwrite_existing_catalog
     .unwrap();
 
     let refreshed = reg.get(&opencode.id).await.unwrap();
-    assert_eq!(refreshed.handshake.available_modes, Some(explicit_modes));
-    assert_eq!(refreshed.handshake.available_models, Some(explicit_models));
+    assert_eq!(
+        refreshed.handshake.available_modes,
+        Some(serde_json::json!({
+            "current_mode_id": "derived-mode",
+            "available_modes": [{"id": "derived-mode", "name": "Derived Mode"}]
+        }))
+    );
+    assert_eq!(
+        refreshed.handshake.available_models,
+        Some(serde_json::json!({
+            "current_model_id": "derived-model",
+            "current_model_label": "Derived Model",
+            "available_models": [{"id": "derived-model", "label": "Derived Model"}]
+        }))
+    );
+}
+
+#[tokio::test]
+async fn apply_handshake_merges_partial_config_option_updates_before_persisting() {
+    let reg = registry().await;
+    let opencode = reg.find_builtin_by_backend("opencode").await.unwrap();
+
+    reg.apply_handshake_inner(
+        &opencode.id,
+        &AgentHandshake {
+            config_options: Some(serde_json::json!({
+                "config_options": [
+                    {
+                        "id": "mode",
+                        "name": "Mode",
+                        "type": "select",
+                        "category": "mode",
+                        "current_value": "full-access",
+                        "options": [
+                            {"value": "auto", "name": "Default"},
+                            {"value": "full-access", "name": "Full Access"}
+                        ]
+                    },
+                    {
+                        "id": "model",
+                        "name": "Model",
+                        "type": "select",
+                        "category": "model",
+                        "current_value": "gpt-5.4",
+                        "options": [{"value": "gpt-5.4", "name": "gpt-5.4"}]
+                    },
+                    {
+                        "id": "reasoning_effort",
+                        "name": "Reasoning Effort",
+                        "type": "select",
+                        "category": "thought_level",
+                        "current_value": "low",
+                        "options": [{"value": "low", "name": "Low"}]
+                    }
+                ]
+            })),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    reg.apply_handshake_inner(
+        &opencode.id,
+        &AgentHandshake {
+            config_options: Some(serde_json::json!({
+                "config_options": [
+                    {
+                        "id": "model",
+                        "name": "Model",
+                        "type": "select",
+                        "category": "model",
+                        "current_value": "gpt-5.5",
+                        "options": [
+                            {"value": "gpt-5.5", "name": "GPT-5.5"},
+                            {"value": "gpt-5.4", "name": "gpt-5.4"}
+                        ]
+                    },
+                    {
+                        "id": "reasoning_effort",
+                        "name": "Reasoning Effort",
+                        "type": "select",
+                        "category": "thought_level",
+                        "current_value": "medium",
+                        "options": [
+                            {"value": "low", "name": "Low"},
+                            {"value": "medium", "name": "Medium"}
+                        ]
+                    }
+                ]
+            })),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let refreshed = reg.get(&opencode.id).await.unwrap();
+    let config_options =
+        extract_config_options_from_value(refreshed.handshake.config_options.as_ref().expect("config options"))
+            .expect("decoded config options");
+
+    assert_eq!(config_options.len(), 3);
+    assert!(config_options.iter().any(|option| option.id.to_string() == "mode"));
+    assert_eq!(
+        refreshed.handshake.available_modes,
+        Some(serde_json::json!({
+            "current_mode_id": "full-access",
+            "available_modes": [
+                {"id": "auto", "name": "Default"},
+                {"id": "full-access", "name": "Full Access"}
+            ]
+        }))
+    );
+    assert_eq!(
+        refreshed.handshake.available_models,
+        Some(serde_json::json!({
+            "current_model_id": "gpt-5.5/medium",
+            "current_model_label": "GPT-5.5 (medium)",
+            "available_models": [
+                {"id": "gpt-5.5/low", "label": "GPT-5.5 (low)"},
+                {"id": "gpt-5.5/medium", "label": "GPT-5.5 (medium)"},
+                {"id": "gpt-5.4/low", "label": "gpt-5.4 (low)"},
+                {"id": "gpt-5.4/medium", "label": "gpt-5.4 (medium)"}
+            ]
+        }))
+    );
 }

--- a/crates/aionui-ai-agent/src/registry_tests.rs
+++ b/crates/aionui-ai-agent/src/registry_tests.rs
@@ -1,0 +1,122 @@
+use super::*;
+
+#[test]
+fn probe_resolved_command_accepts_bare_npx_when_managed_runtime_is_supported() {
+    if !probe_node_runtime_supported().is_supported() {
+        return;
+    }
+
+    let meta = AgentMetadata {
+        id: "agent-1".into(),
+        icon: None,
+        name: "Test ACP".into(),
+        name_i18n: None,
+        description: None,
+        description_i18n: None,
+        backend: Some("custom".into()),
+        agent_type: AgentType::Acp,
+        agent_source: AgentSource::Custom,
+        agent_source_info: AgentSourceInfo::default(),
+        enabled: true,
+        available: false,
+        command: Some("npx".into()),
+        resolved_command: None,
+        args: vec![],
+        env: vec![],
+        native_skills_dirs: None,
+        behavior_policy: BehaviorPolicy::default(),
+        yolo_id: None,
+        sort_order: 0,
+        team_capable: false,
+        handshake: AgentHandshake::default(),
+    };
+
+    let resolved = probe_resolved_command(&meta).expect("probe");
+    assert_eq!(resolved, PathBuf::from("npx"));
+}
+
+#[test]
+fn probe_resolved_command_requires_primary_binary_for_builtin_managed_claude() {
+    if !probe_node_runtime_supported().is_supported()
+        || !probe_managed_acp_tool_supported(ManagedAcpToolId::ClaudeAgentAcp).is_supported()
+    {
+        return;
+    }
+
+    let meta = AgentMetadata {
+        id: "agent-claude".into(),
+        icon: None,
+        name: "Claude Code".into(),
+        name_i18n: None,
+        description: None,
+        description_i18n: None,
+        backend: Some("claude".into()),
+        agent_type: AgentType::Acp,
+        agent_source: AgentSource::Builtin,
+        agent_source_info: AgentSourceInfo {
+            binary_name: Some("definitely-missing-claude-cli".into()),
+            ..Default::default()
+        },
+        enabled: true,
+        available: false,
+        command: None,
+        resolved_command: None,
+        args: vec![],
+        env: vec![],
+        native_skills_dirs: None,
+        behavior_policy: BehaviorPolicy::default(),
+        yolo_id: None,
+        sort_order: 0,
+        team_capable: false,
+        handshake: AgentHandshake::default(),
+    };
+
+    let reason = probe_resolved_command(&meta).expect_err("missing claude CLI must hide builtin row");
+    assert!(matches!(
+        reason,
+        UnavailableReason::PrimaryMissing { binary } if binary == "definitely-missing-claude-cli"
+    ));
+}
+
+#[test]
+fn probe_resolved_command_requires_primary_binary_for_builtin_managed_codex() {
+    if !probe_node_runtime_supported().is_supported()
+        || !probe_managed_acp_tool_supported(ManagedAcpToolId::CodexAcp).is_supported()
+    {
+        return;
+    }
+
+    let meta = AgentMetadata {
+        id: "agent-codex".into(),
+        icon: None,
+        name: "Codex".into(),
+        name_i18n: None,
+        description: None,
+        description_i18n: None,
+        backend: Some("codex".into()),
+        agent_type: AgentType::Acp,
+        agent_source: AgentSource::Builtin,
+        agent_source_info: AgentSourceInfo {
+            binary_name: Some("definitely-missing-codex-cli".into()),
+            ..Default::default()
+        },
+        enabled: true,
+        available: false,
+        command: None,
+        resolved_command: None,
+        args: vec![],
+        env: vec![],
+        native_skills_dirs: None,
+        behavior_policy: BehaviorPolicy::default(),
+        yolo_id: None,
+        sort_order: 0,
+        team_capable: false,
+        handshake: AgentHandshake::default(),
+    };
+
+    let reason = probe_resolved_command(&meta).expect_err("missing codex CLI must hide builtin row");
+    assert!(matches!(
+        reason,
+        UnavailableReason::PrimaryMissing { binary } if binary == "definitely-missing-codex-cli"
+    ));
+}


### PR DESCRIPTION
## Summary

Fixes ACP backends such as OpenCode that advertise mode/model choices through `config_options` / `configOptions`.

Per the ACP direction, `configOptions` is the primary source for selectable catalogs when it contains that catalog dimension. `available_modes` and `available_models` are fallback data. The important nuance is that this precedence is per dimension, and partial `configOptions` updates must not erase dimensions that were advertised earlier.

This keeps the existing persistence architecture intact: ACP events still flow through `CatalogForwarder` into the `AgentRegistry` catalog channel, and `AgentRegistry` still serializes DB writes through its single consumer. The change is a normalization/merge step before persistence plus a matching live-session sync step.

## What changed

- Added `config_option_catalog` helpers to decode ACP config option payloads from all observed shapes:
  - bare `Vec<SessionConfigOption>`
  - `{ "config_options": [...] }`
  - `{ "configOptions": [...] }`
  - snake_case or camelCase option fields
- In `AcpSession::apply_advertised_config_options`, merge incoming partial config options by option id before deriving live advertised catalogs.
- In `AgentRegistry::apply_handshake_inner`, merge incoming partial config options with cached handshake config options before enriching and writing `agent_metadata`.
- Derive mode catalogs from configOptions `mode` selects when present.
- Derive model catalogs from configOptions `model` selects, including Codex-style `model + thought_level/reasoning_effort` combinations such as `gpt-5.5/medium`.
- Keep `available_*` fallback behavior when configOptions does not contain that dimension.
- Added regression coverage for live session sync, registry persistence, wrapper payload shapes, category-first selection, configOptions priority, partial configOptions merge, and model/reasoning combination derivation.

## Data flow

Before:

1. `AcpConfigOption` event arrives.
2. `CatalogForwarder` stores it as `handshake.config_options`.
3. `AgentRegistry` writes only that partial shape unless separate `available_*` events arrive.
4. If an ACP backend omits or later thins `available_models` / `available_modes`, the UI can lose selectable choices until another page/session reload restores older data.

After:

1. `AcpConfigOption` event arrives.
2. Runtime session merges it with the previously advertised config options for that session.
3. Runtime session derives `advertised.models` / `advertised.modes` from configOptions where those dimensions are present.
4. `CatalogForwarder` still forwards through the existing catalog channel.
5. `AgentRegistry` merges the incoming partial configOptions with cached handshake configOptions before enrichment.
6. `AgentRegistry` derives `available_models` / `available_modes` from configOptions where present, then writes the enriched handshake to `agent_metadata`.
7. If configOptions lacks a mode/model dimension, incoming or existing `available_*` remains the fallback.

## Selection matrix

How a `SessionConfigOption` is classified as a catalog source:

| Config option shape | Mode derivation | Model derivation | Result |
| --- | --- | --- | --- |
| `category: Mode` select | Use first | Ignore | Derives `available_modes` |
| `category: Model` select | Ignore | Use first | Derives model options |
| No category, id `mode` / `modes` | Use as fallback | Ignore | Derives `available_modes` |
| No category, id `model` / `models` | Ignore | Use as fallback | Derives model options |
| Category and id alias both present | Category wins | Category wins | Avoids matching unrelated config by id/name |
| Non-select kind | Ignore | Ignore | No catalog derived |
| Empty select options | Ignore | Ignore | No catalog derived |
| Empty current value | Use first option as current | Use first option as current | Catalog remains selectable |

## Model derivation matrix

| ConfigOptions model shape | Derived `available_models` | Current model |
| --- | --- | --- |
| `model` select only | One entry per model option, e.g. `gpt-5.5` | `model.current_value` or first model option |
| `model` select + `thought_level` category select | Cartesian product, e.g. `gpt-5.5/low`, `gpt-5.5/medium` | `<model.current_value>/<thought.current_value>` |
| `model` select + id `thought_level` select | Same cartesian product | `<model>/<thought>` |
| `model` select + id `reasoning_effort` select | Same cartesian product | `<model>/<reasoning_effort>` |
| `model` select + unrelated `reasoning` id without `ThoughtLevel` category | Bare model list | Avoids treating unrelated reasoning config as model variants |

## Precedence and merge matrix

| Incoming configOptions | Cached/previous configOptions | Incoming or stored `available_*` | Action |
| --- | --- | --- | --- |
| Contains `mode` select | Any | Any | Derive `available_modes` from configOptions; configOptions is authoritative for mode |
| Lacks `mode` select | Has previous `mode` select | Any | Merge keeps previous mode option, then derive `available_modes` |
| Lacks `mode` select | No previous `mode` select | Non-empty `available_modes` | Keep `available_modes` fallback |
| Contains `model` select | Any | Any | Derive `available_models` from configOptions; configOptions is authoritative for model |
| Contains `model + thought_level` | Any | Any | Derive combined model ids/labels such as `gpt-5.5/medium` |
| Lacks `model` select | Has previous `model` select | Any | Merge keeps previous model option, then derive `available_models` |
| Lacks `model` select | No previous `model` select | Non-empty `available_models` | Keep `available_models` fallback |
| Empty/missing configOptions | Any | Existing DB catalog | Preserve existing DB catalog via partial update behavior |

## Notes

- No new `AcpAgentManager` fields were added.
- No new logging was added. This is deterministic normalization/merge logic, and behavior is covered at both runtime-session and registry-persistence boundaries.
- `registry.rs` remains below the project file-size limit after splitting registry regression tests into a dedicated test module.

## Verification

- TDD RED checks before implementation confirmed the regressions:
  - live session partial configOptions dropped the prior `mode` option
  - registry persistence overwrote full configOptions with partial configOptions
  - model derivation produced bare `gpt-5.5` instead of `gpt-5.5/medium`
- `cargo fmt --all -- --check`
- `cargo test -p aionui-ai-agent`
- `cargo clippy -p aionui-ai-agent -- -D warnings`
- `just push`
  - includes workspace `cargo fix`
  - includes workspace `cargo clippy --fix -- -D warnings`
  - includes `cargo fmt --all`
  - includes `cargo nextest run --workspace`: 6039 passed, 18 skipped