### PR TITLE
fix: harden managed ACP bundle preparation and builtin CLI availability

### DIFF
--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -15,7 +15,7 @@ use aionui_db::models::McpServerRow;
 use aionui_mcp::{AcpMcpCapabilities, parse_acp_mcp_capabilities};
 use aionui_runtime::{
     ManagedAcpToolId, ensure_managed_acp_tool_with_reporter, ensure_node_runtime_with_reporter, ensure_runtime_command,
-    ensure_runtime_command_with_reporter,
+    ensure_runtime_command_with_reporter, resolve_command_path,
 };
 use tracing::{debug, info, warn};
 
@@ -254,6 +254,15 @@ async fn resolve_builtin_managed_acp_command_spec(
     broadcaster: Arc<dyn aionui_realtime::EventBroadcaster>,
     tool: ManagedAcpToolId,
 ) -> Result<CommandSpec, AgentError> {
+    if let Some(primary) = meta.agent_source_info.binary_name.as_deref()
+        && resolve_command_path(primary).is_none()
+    {
+        return Err(AgentError::bad_request(format!(
+            "Agent '{}' requires `{primary}` to be installed and available on PATH",
+            meta.name
+        )));
+    }
+
     let node_reporter = conversation_runtime_reporter(broadcaster.clone(), conversation_id.to_owned());
     let node_runtime = ensure_node_runtime_with_reporter(Some(node_reporter.as_ref()))
         .await

--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -589,6 +589,13 @@ fn probe_resolved_command(meta: &AgentMetadata) -> Result<PathBuf, UnavailableRe
                 detail: tool_support.detail,
             });
         }
+        if let Some(primary) = meta.agent_source_info.binary_name.as_deref()
+            && probe_command_candidate(primary).is_none()
+        {
+            return Err(UnavailableReason::PrimaryMissing {
+                binary: primary.to_owned(),
+            });
+        }
         return Ok(PathBuf::from(tool.slug()));
     }
 
@@ -675,6 +682,93 @@ mod tests {
 
         let resolved = probe_resolved_command(&meta).expect("probe");
         assert_eq!(resolved, PathBuf::from("npx"));
+    }
+
+
+    #[test]
+    fn probe_resolved_command_requires_primary_binary_for_builtin_managed_claude() {
+        if !probe_node_runtime_supported().is_supported()
+            || !probe_managed_acp_tool_supported(ManagedAcpToolId::ClaudeAgentAcp).is_supported()
+        {
+            return;
+        }
+
+        let meta = AgentMetadata {
+            id: "agent-claude".into(),
+            icon: None,
+            name: "Claude Code".into(),
+            name_i18n: None,
+            description: None,
+            description_i18n: None,
+            backend: Some("claude".into()),
+            agent_type: AgentType::Acp,
+            agent_source: AgentSource::Builtin,
+            agent_source_info: AgentSourceInfo {
+                binary_name: Some("definitely-missing-claude-cli".into()),
+                ..Default::default()
+            },
+            enabled: true,
+            available: false,
+            command: None,
+            resolved_command: None,
+            args: vec![],
+            env: vec![],
+            native_skills_dirs: None,
+            behavior_policy: BehaviorPolicy::default(),
+            yolo_id: None,
+            sort_order: 0,
+            team_capable: false,
+            handshake: AgentHandshake::default(),
+        };
+
+        let reason = probe_resolved_command(&meta).expect_err("missing claude CLI must hide builtin row");
+        assert!(matches!(
+            reason,
+            UnavailableReason::PrimaryMissing { binary } if binary == "definitely-missing-claude-cli"
+        ));
+    }
+
+    #[test]
+    fn probe_resolved_command_requires_primary_binary_for_builtin_managed_codex() {
+        if !probe_node_runtime_supported().is_supported()
+            || !probe_managed_acp_tool_supported(ManagedAcpToolId::CodexAcp).is_supported()
+        {
+            return;
+        }
+
+        let meta = AgentMetadata {
+            id: "agent-codex".into(),
+            icon: None,
+            name: "Codex".into(),
+            name_i18n: None,
+            description: None,
+            description_i18n: None,
+            backend: Some("codex".into()),
+            agent_type: AgentType::Acp,
+            agent_source: AgentSource::Builtin,
+            agent_source_info: AgentSourceInfo {
+                binary_name: Some("definitely-missing-codex-cli".into()),
+                ..Default::default()
+            },
+            enabled: true,
+            available: false,
+            command: None,
+            resolved_command: None,
+            args: vec![],
+            env: vec![],
+            native_skills_dirs: None,
+            behavior_policy: BehaviorPolicy::default(),
+            yolo_id: None,
+            sort_order: 0,
+            team_capable: false,
+            handshake: AgentHandshake::default(),
+        };
+
+        let reason = probe_resolved_command(&meta).expect_err("missing codex CLI must hide builtin row");
+        assert!(matches!(
+            reason,
+            UnavailableReason::PrimaryMissing { binary } if binary == "definitely-missing-codex-cli"
+        ));
     }
 
     #[tokio::test]

--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -684,7 +684,6 @@ mod tests {
         assert_eq!(resolved, PathBuf::from("npx"));
     }
 
-
     #[test]
     fn probe_resolved_command_requires_primary_binary_for_builtin_managed_claude() {
         if !probe_node_runtime_supported().is_supported()

--- a/crates/aionui-app/src/commands/cmd_prepare_managed_resources.rs
+++ b/crates/aionui-app/src/commands/cmd_prepare_managed_resources.rs
@@ -3,8 +3,8 @@ use std::process::ExitCode;
 use crate::cli::PrepareManagedResourcesArgs;
 use crate::commands::error::{CliBoundaryCode, CliBoundaryError};
 use aionui_runtime::acp_tool_runtime::ManagedAcpToolId;
-use aionui_runtime::managed_resources::{export_acp_tool_to_root, export_node_runtime_to_root};
-use aionui_runtime::{ensure_managed_acp_tool, ensure_node_runtime};
+use aionui_runtime::managed_resources::export_node_runtime_to_root;
+use aionui_runtime::{ensure_node_runtime, prepare_managed_acp_tool_to_root};
 
 const SUBCOMMAND: &str = "prepare-managed-resources";
 
@@ -27,17 +27,10 @@ pub async fn run_prepare_managed_resources(args: PrepareManagedResourcesArgs) ->
     println!("  node   -> {}", exported_node.display());
 
     for tool in [ManagedAcpToolId::CodexAcp, ManagedAcpToolId::ClaudeAgentAcp] {
-        let resolved = ensure_managed_acp_tool(tool)
+        let prepared = prepare_managed_acp_tool_to_root(tool, &output_root)
             .await
             .map_err(|_| prepare_managed_resources_error("acp.prepare"))?;
-        let platform = resolved
-            .root
-            .file_name()
-            .and_then(|name| name.to_str())
-            .ok_or_else(|| prepare_managed_resources_error("acp.layout"))?;
-        let exported = export_acp_tool_to_root(&output_root, &resolved.root, tool.slug(), tool.version(), platform)
-            .map_err(|_| prepare_managed_resources_error("acp.export"))?;
-        println!("  {:<6} -> {}", tool.slug(), exported.display());
+        println!("  {:<6} -> {}", tool.slug(), prepared.root.display());
     }
 
     Ok(ExitCode::SUCCESS)

--- a/crates/aionui-runtime/src/acp_tool_runtime/mod.rs
+++ b/crates/aionui-runtime/src/acp_tool_runtime/mod.rs
@@ -22,6 +22,7 @@ pub use types::{
 };
 
 static INSTALL_LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+const MANAGED_ACP_SMOKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 
 #[derive(Debug, Clone, Copy)]
 struct PlatformSpec {
@@ -85,6 +86,37 @@ pub async fn ensure_managed_acp_tool_with_reporter(
     }
 
     Err(report_failure(unavailable_error(tool, &root), reporter))
+}
+
+pub async fn prepare_managed_acp_tool_to_root(
+    tool: ManagedAcpToolId,
+    root: &Path,
+) -> Result<ResolvedManagedAcpTool, ManagedAcpToolError> {
+    let spec = platform_spec()?;
+    let node_runtime = ensure_node_runtime_with_reporter(None)
+        .await
+        .map_err(|error| ManagedAcpToolError::invalid(format!("prepare managed Node runtime: {error}")))?;
+    let staging_root = bundle_prepare_staging_root(tool, spec, root);
+    if staging_root.exists() {
+        let _ = fs::remove_dir_all(&staging_root);
+    }
+    fs::create_dir_all(&staging_root).map_err(ManagedAcpToolError::io)?;
+
+    let result = prepare_local_tool_source_to_root(tool, spec, &node_runtime, &staging_root, root).await;
+
+    if let Err(error) = fs::remove_dir_all(&staging_root)
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        warn!(
+            tool = tool.slug(),
+            version = tool.version(),
+            staging_root = %staging_root.display(),
+            error = %error,
+            "failed to clean up managed ACP bundle preparation staging directory"
+        );
+    }
+
+    result
 }
 
 fn report_failure(
@@ -428,6 +460,18 @@ async fn prepare_local_tool_source(
     staging_root: &Path,
     target_root: &Path,
 ) -> Result<(), ManagedAcpToolError> {
+    prepare_local_tool_source_to_root(tool, spec, node_runtime, staging_root, target_root)
+        .await
+        .map(|_| ())
+}
+
+async fn prepare_local_tool_source_to_root(
+    tool: ManagedAcpToolId,
+    spec: PlatformSpec,
+    node_runtime: &crate::ResolvedNodeRuntime,
+    staging_root: &Path,
+    target_root: &Path,
+) -> Result<ResolvedManagedAcpTool, ManagedAcpToolError> {
     let project_dir = staging_root.join("project");
     let npm_cache_dir = staging_root.join("npm-cache");
     fs::create_dir_all(&project_dir).map_err(ManagedAcpToolError::io)?;
@@ -478,6 +522,8 @@ async fn prepare_local_tool_source(
     let manifest = build_local_artifact_manifest(tool, &project_dir)?;
     validate_bridge_entrypoint(&project_dir, &manifest)?;
     validate_platform_binary(tool, &project_dir, spec)?;
+    validate_dependency_tree(node_runtime, &project_dir, &npm_cache_dir, tool).await?;
+    validate_package_import_smoke(node_runtime, &project_dir, tool).await?;
 
     let manifest_path = project_dir.join("manifest.json");
     fs::write(
@@ -488,6 +534,9 @@ async fn prepare_local_tool_source(
     .map_err(ManagedAcpToolError::io)?;
 
     managed_resources::materialize_directory(&project_dir, target_root).map_err(ManagedAcpToolError::io)?;
+    let resolved = validate_tool_root(tool, target_root, None)?;
+    validate_dependency_tree(node_runtime, target_root, &npm_cache_dir, tool).await?;
+    validate_package_import_smoke(node_runtime, target_root, tool).await?;
     info!(
         tool = tool.slug(),
         version = tool.version(),
@@ -495,7 +544,7 @@ async fn prepare_local_tool_source(
         target_root = %target_root.display(),
         "prepared managed ACP tool under local runtime resources"
     );
-    Ok(())
+    Ok(resolved)
 }
 
 async fn run_npm_prepare_step<const N: usize>(
@@ -624,6 +673,64 @@ fn validate_platform_binary(
     }
 }
 
+async fn validate_dependency_tree(
+    node_runtime: &crate::ResolvedNodeRuntime,
+    project_dir: &Path,
+    npm_cache_dir: &Path,
+    tool: ManagedAcpToolId,
+) -> Result<(), ManagedAcpToolError> {
+    run_npm_prepare_step(
+        node_runtime,
+        project_dir,
+        npm_cache_dir,
+        ["ls", "--omit=dev", "--all"],
+        &format!("validate managed {} dependency tree", tool.display_name()),
+    )
+    .await
+}
+
+async fn validate_package_import_smoke(
+    node_runtime: &crate::ResolvedNodeRuntime,
+    project_dir: &Path,
+    tool: ManagedAcpToolId,
+) -> Result<(), ManagedAcpToolError> {
+    let mut builder = Builder::clean_cli(node_runtime.node_path.clone());
+    builder.current_dir(project_dir).args([
+        "--input-type=module",
+        "-e",
+        "await import(process.argv[1]);",
+        tool.package_name(),
+    ]);
+    let output = tokio::time::timeout(MANAGED_ACP_SMOKE_TIMEOUT, builder.output())
+        .await
+        .map_err(|_| {
+            ManagedAcpToolError::invalid(format!(
+                "smoke test for managed {} package import timed out after {}s",
+                tool.display_name(),
+                MANAGED_ACP_SMOKE_TIMEOUT.as_secs()
+            ))
+        })?
+        .map_err(ManagedAcpToolError::io)?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    let detail = if stderr.is_empty() {
+        stdout
+    } else if stdout.is_empty() {
+        stderr
+    } else {
+        format!("{stderr}; stdout: {stdout}")
+    };
+    Err(ManagedAcpToolError::invalid(format!(
+        "smoke test for managed {} package import failed with exit code {:?}: {detail}",
+        tool.display_name(),
+        output.status.code()
+    )))
+}
+
 fn package_json_path(project_dir: &Path, package_name: &str) -> PathBuf {
     let mut path = project_dir.join("node_modules");
     for segment in package_path_segments(package_name) {
@@ -685,6 +792,20 @@ fn prepare_staging_root(tool: ManagedAcpToolId, spec: PlatformSpec) -> Result<Pa
         spec.manifest_key,
         nonce
     )))
+}
+
+fn bundle_prepare_staging_root(tool: ManagedAcpToolId, spec: PlatformSpec, bundle_root: &Path) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    bundle_root.join(".staging").join(format!(
+        "{}-{}-{}-{}",
+        tool.slug(),
+        tool.version(),
+        spec.manifest_key,
+        nonce
+    ))
 }
 
 fn platform_spec() -> Result<PlatformSpec, ManagedAcpToolError> {

--- a/crates/aionui-runtime/src/lib.rs
+++ b/crates/aionui-runtime/src/lib.rs
@@ -22,7 +22,7 @@ pub use acp_tool_runtime::{
     ManagedAcpToolError, ManagedAcpToolFailureKind, ManagedAcpToolId, ManagedAcpToolProgress,
     ManagedAcpToolProgressPhase, ManagedAcpToolProgressReporter, ManagedAcpToolSupport, ResolvedManagedAcpTool,
     SharedManagedAcpToolProgressReporter, doctor_snapshot as acp_tool_doctor_snapshot, ensure_managed_acp_tool,
-    ensure_managed_acp_tool_with_reporter, probe_managed_acp_tool_supported,
+    ensure_managed_acp_tool_with_reporter, prepare_managed_acp_tool_to_root, probe_managed_acp_tool_supported,
 };
 pub use agent_env::agent_process_env;
 pub use cache::init;


### PR DESCRIPTION
## Summary
- require host `claude` and `codex` CLIs before exposing builtin managed ACP entries
- rebuild managed ACP bundle outputs during `prepare-managed-resources --bundle-out` instead of re-exporting cached runtime state
- validate ACP bundle dependency closure with `npm ls --omit=dev --all`
- smoke-test managed ACP package imports with managed Node before and after materialization

## Verification
- `cargo test -p aionui-runtime acp_tool_runtime:: -- --nocapture`
- `cargo test -p aionui-ai-agent probe_resolved_command_requires_primary_binary_for_builtin_managed_claude -- --nocapture`
- `cargo test -p aionui-ai-agent probe_resolved_command_requires_primary_binary_for_builtin_managed_codex -- --nocapture`
- `cargo test -p aionui-app prepare_managed_resources -- --nocapture`
- `cargo clippy -p aionui-runtime -p aionui-app -p aionui-ai-agent -- -D warnings`
- `just push -u origin fix/managed-acp-suite-integrity`
