### PR TITLE
fix: handle Hermes yolo fallback correctly

### DIFF
--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -810,6 +810,13 @@ mod tests {
         assert_eq!(claude.yolo_id.as_deref(), Some("bypassPermissions"));
     }
 
+    #[tokio::test]
+    async fn hermes_builtin_does_not_advertise_a_yolo_id() {
+        let reg = registry().await;
+        let hermes = reg.find_builtin_by_backend("hermes").await.unwrap();
+        assert_eq!(hermes.yolo_id, None);
+    }
+
     /// On a host that has *none* of the seeded CLIs installed, the
     /// public listing collapses to the rows that don't need one
     /// (Aion CLI is `agent_source = internal` with no `command`).

--- a/crates/aionui-common/src/enums.rs
+++ b/crates/aionui-common/src/enums.rs
@@ -77,7 +77,9 @@ impl AgentType {
     /// Canonical full-auto session mode id for this agent type.
     ///
     /// ACP agents need backend-specific mode ids, while other agent types
-    /// currently converge on the permissive `yolo` mode.
+    /// currently converge on the permissive `yolo` mode. Hermes is the
+    /// exception: it has no full-auto ACP mode, so callers must stay on its
+    /// native `default`.
     ///
     /// `backend` is the vendor label (e.g. `"claude"`, `"codex"`) used
     /// only by ACP; pass `None` for non-ACP agents. This mapping is
@@ -89,6 +91,7 @@ impl AgentType {
             AgentType::Acp => match backend {
                 Some("claude") | Some("codebuddy") => "bypassPermissions",
                 Some("codex") => "full-access",
+                Some("hermes") => "default",
                 Some("opencode") => "build",
                 Some("cursor") => "agent",
                 _ => "yolo",
@@ -422,6 +425,7 @@ mod tests {
         assert_eq!(AgentType::Acp.full_auto_mode_id(Some("codex")), "full-access");
         assert_eq!(AgentType::Acp.full_auto_mode_id(Some("claude")), "bypassPermissions");
         assert_eq!(AgentType::Acp.full_auto_mode_id(Some("gemini")), "yolo");
+        assert_eq!(AgentType::Acp.full_auto_mode_id(Some("hermes")), "default");
         assert_eq!(AgentType::Acp.full_auto_mode_id(None), "yolo");
         assert_eq!(AgentType::Aionrs.full_auto_mode_id(None), "yolo");
         assert_eq!(AgentType::Remote.full_auto_mode_id(None), "yolo");

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -175,6 +175,36 @@ impl IConversationRepository for StubConvRepo {
                 created_at: 1000,
                 updated_at: 1000,
             }
+        } else if id == "conv_mode_hermes" {
+            aionui_db::models::ConversationRow {
+                id: id.into(),
+                user_id: "u1".into(),
+                name: "Hermes Chat".into(),
+                r#type: "acp".into(),
+                model: Some(
+                    serde_json::json!({
+                        "provider_id": "hermes",
+                        "model": "gemini-2.5-pro",
+                        "use_model": "gemini-2.5-pro"
+                    })
+                    .to_string(),
+                ),
+                status: Some("active".into()),
+                source: None,
+                channel_chat_id: None,
+                extra: serde_json::json!({
+                    "backend": "hermes",
+                    "agent_name": "Hermes",
+                    "workspace": ensure_named_workspace_path("aionui-cron-service-hermes-workspace"),
+                    "session_mode": "default",
+                    "current_model_id": "gemini-2.5-pro"
+                })
+                .to_string(),
+                pinned: false,
+                pinned_at: None,
+                created_at: 1000,
+                updated_at: 1000,
+            }
         } else if id == "conv_mode_default" {
             aionui_db::models::ConversationRow {
                 id: id.into(),
@@ -1300,6 +1330,9 @@ async fn icron_service_create_job_forces_full_auto_mode_for_generated_crons() {
     let claude = ICronService::create_job(&svc, "user_1", "conv_mode_claude", &params).await;
     assert!(claude.success);
 
+    let hermes = ICronService::create_job(&svc, "user_1", "conv_mode_hermes", &params).await;
+    assert!(hermes.success);
+
     let aionrs = ICronService::create_job(&svc, "user_1", "conv_mode_aionrs", &params).await;
     assert!(aionrs.success);
 
@@ -1343,6 +1376,20 @@ async fn icron_service_create_job_forces_full_auto_mode_for_generated_crons() {
             .as_ref()
             .and_then(|config| config.mode.as_deref()),
         Some("bypassPermissions")
+    );
+
+    let hermes_jobs = svc
+        .list_jobs(&ListCronJobsQuery {
+            conversation_id: Some("conv_mode_hermes".into()),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        hermes_jobs[0]
+            .agent_config
+            .as_ref()
+            .and_then(|config| config.mode.as_deref()),
+        Some("default")
     );
 
     let aionrs_jobs = svc

--- a/crates/aionui-db/migrations/010_hermes_yolo_id_null.sql
+++ b/crates/aionui-db/migrations/010_hermes_yolo_id_null.sql
@@ -1,0 +1,5 @@
+UPDATE agent_metadata
+SET yolo_id = NULL
+WHERE id = '55f3ed1c'
+  AND backend = 'hermes'
+  AND agent_source = 'builtin';

--- a/crates/aionui-db/src/repository/sqlite_agent_metadata.rs
+++ b/crates/aionui-db/src/repository/sqlite_agent_metadata.rs
@@ -268,6 +268,11 @@ mod tests {
         // Nanobot and OpenClaw are builtin (not internal).
         assert!(rows.iter().any(|r| r.name == "Nanobot" && r.agent_source == "builtin"));
         assert!(rows.iter().any(|r| r.name == "OpenClaw" && r.agent_source == "builtin"));
+        let hermes = rows
+            .iter()
+            .find(|r| r.name == "Hermes" && r.agent_source == "builtin")
+            .expect("seeded hermes row");
+        assert_eq!(hermes.yolo_id, None);
     }
 
     #[tokio::test]

--- a/crates/aionui-team/src/service/spawn_support.rs
+++ b/crates/aionui-team/src/service/spawn_support.rs
@@ -360,4 +360,9 @@ mod tests {
             AgentType::OpenclawGateway
         );
     }
+
+    #[test]
+    fn resolve_full_auto_mode_keeps_hermes_on_default() {
+        assert_eq!(resolve_full_auto_mode("hermes"), "default");
+    }
 }


### PR DESCRIPTION
## Summary
- clear Hermes `yolo_id` via a new DB migration so builtin metadata no longer advertises startup `--yolo` support
- map Hermes ACP full-auto fallback to `default` so cron and team flows stop forcing `session_mode=yolo`
- add regression coverage for the registry seed, cron-generated jobs, and team full-auto mode resolution

## Test Plan
- [x] rustfmt --check crates/aionui-ai-agent/src/registry.rs crates/aionui-common/src/enums.rs crates/aionui-db/src/repository/sqlite_agent_metadata.rs crates/aionui-team/src/service/spawn_support.rs crates/aionui-cron/tests/service_integration.rs
- [x] cargo test -p aionui-common agent_type_full_auto_mode_id_supports_non_acp_agents
- [x] cargo test -p aionui-db seed_rows_populated_after_migrations
- [x] cargo test -p aionui-cron icron_service_create_job_forces_full_auto_mode_for_generated_crons
- [x] cargo test -p aionui-ai-agent hermes_builtin_does_not_advertise_a_yolo_id
- [x] cargo test -p aionui-team resolve_full_auto_mode_keeps_hermes_on_default
- [x] cargo clippy -p aionui-common -p aionui-db -p aionui-ai-agent -p aionui-cron -p aionui-team -- -D warnings
- [x] cargo test -p aionui-common -p aionui-db -p aionui-ai-agent -p aionui-cron -p aionui-team

## Notes
- I intentionally did not run `just push` for this branch because the repo's `push` recipe auto-commits any `cargo fmt --all` diff, and the current branch base has an unrelated `aionui-runtime` formatting delta that would have polluted this PR.
