### PR TITLE
fix: expose managed resource preparation failure details

### DIFF
--- a/crates/aionui-app/src/commands/cmd_prepare_managed_resources.rs
+++ b/crates/aionui-app/src/commands/cmd_prepare_managed_resources.rs
@@ -14,14 +14,14 @@ pub async fn run_prepare_managed_resources(args: PrepareManagedResourcesArgs) ->
 
     let node_runtime = ensure_node_runtime()
         .await
-        .map_err(|_| prepare_managed_resources_error("node.prepare"))?;
+        .map_err(|error| prepare_managed_resources_error_with_detail("node.prepare", error))?;
     let node_dir_name = node_runtime
         .root
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(|| prepare_managed_resources_error("node.layout"))?;
     let exported_node = export_node_runtime_to_root(&output_root, &node_runtime.root, node_dir_name)
-        .map_err(|_| prepare_managed_resources_error("node.export"))?;
+        .map_err(|error| prepare_managed_resources_error_with_detail("node.export", error))?;
 
     println!("Prepared managed resources under {}", output_root.display());
     println!("  node   -> {}", exported_node.display());
@@ -29,7 +29,7 @@ pub async fn run_prepare_managed_resources(args: PrepareManagedResourcesArgs) ->
     for tool in [ManagedAcpToolId::CodexAcp, ManagedAcpToolId::ClaudeAgentAcp] {
         let prepared = prepare_managed_acp_tool_to_root(tool, &output_root)
             .await
-            .map_err(|_| prepare_managed_resources_error("acp.prepare"))?;
+            .map_err(|error| prepare_managed_resources_error_with_detail("acp.prepare", error))?;
         println!("  {:<6} -> {}", tool.slug(), prepared.root.display());
     }
 
@@ -43,6 +43,11 @@ fn prepare_managed_resources_error(stage: &'static str) -> CliBoundaryError {
         "failed to prepare managed resources",
     )
     .with_field("stage", stage)
+}
+
+fn prepare_managed_resources_error_with_detail(stage: &'static str, error: impl std::fmt::Display) -> CliBoundaryError {
+    eprintln!("prepare-managed-resources stage={stage} detail: {error}");
+    prepare_managed_resources_error(stage)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- print the inner `prepare-managed-resources` failure detail to stderr before returning the stable CLI boundary error
- keep the existing `CLI_PREPARE_MANAGED_RESOURCES_FAILED` code and `stage=...` contract unchanged
- make Windows packaging failures actionable in AionUi CI by surfacing the underlying ACP preparation error

## Verification
- cargo test -p aionui-app cmd_prepare_managed_resources:: -- --nocapture
- cargo clippy -p aionui-app -- -D warnings
- just push -u origin fix/prepare-managed-resources-diagnostics