### PR TITLE
fix(app): stop backend when desktop exits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,7 @@ dependencies = [
  "futures-util",
  "git2",
  "http-body-util",
+ "libc",
  "reqwest",
  "rmcp",
  "rust_xlsxwriter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "windows-sys 0.61.2",
  "wiremock",
 ]
 

--- a/crates/aionui-app/Cargo.toml
+++ b/crates/aionui-app/Cargo.toml
@@ -51,6 +51,12 @@ reqwest.workspace = true
 rmcp = { version = "1.5", features = ["server", "transport-io", "schemars"] }
 anyhow.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+] }
+
 [dev-dependencies]
 aionui-api-types.workspace = true
 aionui-realtime.workspace = true

--- a/crates/aionui-app/Cargo.toml
+++ b/crates/aionui-app/Cargo.toml
@@ -57,6 +57,9 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_Threading",
 ] }
 
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
 aionui-api-types.workspace = true
 aionui-realtime.workspace = true

--- a/crates/aionui-app/src/bootstrap/mod.rs
+++ b/crates/aionui-app/src/bootstrap/mod.rs
@@ -7,8 +7,10 @@
 mod builtin_skills;
 mod environment;
 mod error;
+mod parent_exit;
 mod tracing_init;
 mod work_dir;
 
 pub use environment::{ServerEnvironment, init_data_layer, init_environment};
 pub(crate) use error::{BootstrapError, BootstrapErrorCode};
+pub(crate) use parent_exit::{ParentExitSignal, parent_exit_signal};

--- a/crates/aionui-app/src/bootstrap/parent_exit.rs
+++ b/crates/aionui-app/src/bootstrap/parent_exit.rs
@@ -1,0 +1,50 @@
+use std::future::Future;
+use std::pin::Pin;
+
+pub(crate) type ParentExitSignal = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+pub(crate) fn parent_exit_signal(parent_pid: Option<u32>) -> Option<ParentExitSignal> {
+    #[cfg(windows)]
+    {
+        parent_pid.map(|pid| Box::pin(wait_for_parent_exit(pid)) as ParentExitSignal)
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = parent_pid;
+        None
+    }
+}
+
+#[cfg(windows)]
+async fn wait_for_parent_exit(parent_pid: u32) {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    std::thread::spawn(move || {
+        wait_for_parent_exit_blocking(parent_pid);
+        let _ = tx.send(());
+    });
+
+    let _ = rx.await;
+}
+
+#[cfg(windows)]
+fn wait_for_parent_exit_blocking(parent_pid: u32) {
+    use windows_sys::Win32::Foundation::{CloseHandle, WAIT_OBJECT_0};
+    use windows_sys::Win32::System::Threading::{
+        INFINITE, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, SYNCHRONIZE, WaitForSingleObject,
+    };
+
+    unsafe {
+        let handle = OpenProcess(SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, 0, parent_pid);
+        if handle.is_null() {
+            return;
+        }
+
+        let wait_result = WaitForSingleObject(handle, INFINITE);
+        let _ = CloseHandle(handle);
+        if wait_result != WAIT_OBJECT_0 {
+            return;
+        }
+    }
+}

--- a/crates/aionui-app/src/bootstrap/parent_exit.rs
+++ b/crates/aionui-app/src/bootstrap/parent_exit.rs
@@ -4,12 +4,12 @@ use std::pin::Pin;
 pub(crate) type ParentExitSignal = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 
 pub(crate) fn parent_exit_signal(parent_pid: Option<u32>) -> Option<ParentExitSignal> {
-    #[cfg(windows)]
+    #[cfg(any(windows, unix))]
     {
         parent_pid.map(|pid| Box::pin(wait_for_parent_exit(pid)) as ParentExitSignal)
     }
 
-    #[cfg(not(windows))]
+    #[cfg(not(any(windows, unix)))]
     {
         let _ = parent_pid;
         None
@@ -46,5 +46,50 @@ fn wait_for_parent_exit_blocking(parent_pid: u32) {
         if wait_result != WAIT_OBJECT_0 {
             return;
         }
+    }
+}
+
+#[cfg(unix)]
+async fn wait_for_parent_exit(parent_pid: u32) {
+    while current_parent_pid() == Some(parent_pid) {
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+}
+
+#[cfg(unix)]
+fn current_parent_pid() -> Option<u32> {
+    let parent_pid = unsafe { libc::getppid() };
+    u32::try_from(parent_pid).ok().filter(|pid| *pid != 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parent_exit_signal;
+
+    #[test]
+    fn parent_exit_signal_is_absent_without_parent_pid() {
+        assert!(parent_exit_signal(None).is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unix_parent_exit_signal_resolves_when_parent_relationship_is_missing() {
+        let signal =
+            parent_exit_signal(Some(std::process::id())).expect("unix parent pid should produce a monitor");
+
+        tokio::time::timeout(std::time::Duration::from_millis(50), signal)
+            .await
+            .expect("signal should resolve when the current parent no longer matches");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unix_parent_exit_signal_waits_while_parent_still_matches() {
+        let signal = parent_exit_signal(Some(unsafe { libc::getppid() as u32 }))
+            .expect("unix parent pid should produce a monitor");
+
+        tokio::time::timeout(std::time::Duration::from_millis(50), signal)
+            .await
+            .expect_err("signal should not resolve while the current parent still matches");
     }
 }

--- a/crates/aionui-app/src/bootstrap/parent_exit.rs
+++ b/crates/aionui-app/src/bootstrap/parent_exit.rs
@@ -74,8 +74,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn unix_parent_exit_signal_resolves_when_parent_relationship_is_missing() {
-        let signal =
-            parent_exit_signal(Some(std::process::id())).expect("unix parent pid should produce a monitor");
+        let signal = parent_exit_signal(Some(std::process::id())).expect("unix parent pid should produce a monitor");
 
         tokio::time::timeout(std::time::Duration::from_millis(50), signal)
             .await

--- a/crates/aionui-app/src/cli.rs
+++ b/crates/aionui-app/src/cli.rs
@@ -23,6 +23,10 @@ pub(crate) struct Cli {
     #[arg(long, default_value = "data")]
     pub data_dir: PathBuf,
 
+    /// Parent process ID used to terminate the backend when the desktop app dies.
+    #[arg(long)]
+    pub parent_pid: Option<u32>,
+
     /// Working directory for conversation workspaces.
     /// Falls back to AIONUI_WORK_DIR env, then to data-dir.
     #[arg(long)]
@@ -191,6 +195,12 @@ mod tests {
     fn managed_resources_mode_accepts_download() {
         let cli = Cli::parse_from(["aioncore", "--managed-resources-mode", "download"]);
         assert_eq!(cli.managed_resources_mode, ManagedResourcesModeArg::Download);
+    }
+
+    #[test]
+    fn parent_pid_accepts_positive_integer() {
+        let cli = Cli::parse_from(["aioncore", "--parent-pid", "4242"]);
+        assert_eq!(cli.parent_pid, Some(4242));
     }
 
     #[test]

--- a/crates/aionui-app/src/commands/cmd_server.rs
+++ b/crates/aionui-app/src/commands/cmd_server.rs
@@ -4,6 +4,7 @@ use std::io::{self, Write};
 use std::net::SocketAddr;
 use std::process::ExitCode;
 use std::time::Instant;
+use std::{future::Future, pin::Pin};
 
 use tokio::net::TcpListener;
 use tracing::{info, warn};
@@ -12,10 +13,17 @@ use aionui_api_types::{RuntimeStatusScope, RuntimeStatusScopeKind};
 use aionui_app::{AppConfig, AppServices, RouterBuildError, create_router};
 use aionui_system::RuntimePrepareService;
 
-use crate::bootstrap::{BootstrapError, BootstrapErrorCode, ServerEnvironment};
+use crate::bootstrap::{BootstrapError, BootstrapErrorCode, ParentExitSignal, ServerEnvironment};
 
 const LISTENING_EVENT_PREFIX: &str = "AIONCORE_LISTENING";
 const DYNAMIC_BACKEND_BIND_MAX_ATTEMPTS: usize = 50;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShutdownReason {
+    Sigint,
+    Sigterm,
+    ParentExit,
+}
 
 #[derive(Debug)]
 pub(crate) struct BoundHttpListener {
@@ -192,6 +200,7 @@ pub(crate) async fn run_server(
     env: ServerEnvironment,
     services: AppServices,
     bound: BoundHttpListener,
+    parent_exit: Option<ParentExitSignal>,
 ) -> Result<ExitCode, BootstrapError> {
     let boot = Instant::now();
 
@@ -267,17 +276,25 @@ pub(crate) async fn run_server(
 
     axum::serve(listener, router)
         .with_graceful_shutdown(async move {
-            if let Err(error) = shutdown_signal().await {
-                error.log_source();
-                tracing::error!(error = %error.stderr_line(), "shutdown signal handler failed");
-                let _ = shutdown_error_tx.send(error);
-            } else {
-                let active_turn_count = conversation_runtime_state.mark_shutting_down();
-                info!(
-                    reason = "graceful_shutdown",
-                    active_turn_count, "conversation runtime shutdown prepared"
-                );
-                worker_task_manager.clear();
+            match shutdown_signal(parent_exit).await {
+                Err(error) => {
+                    error.log_source();
+                    tracing::error!(error = %error.stderr_line(), "shutdown signal handler failed");
+                    let _ = shutdown_error_tx.send(error);
+                }
+                Ok(reason) => {
+                    match reason {
+                        ShutdownReason::Sigint => info!("Received SIGINT, shutting down..."),
+                        ShutdownReason::Sigterm => info!("Received SIGTERM, shutting down..."),
+                        ShutdownReason::ParentExit => info!("Detected desktop parent exit, shutting down..."),
+                    }
+                    let active_turn_count = conversation_runtime_state.mark_shutting_down();
+                    info!(
+                        reason = "graceful_shutdown",
+                        active_turn_count, "conversation runtime shutdown prepared"
+                    );
+                    worker_task_manager.clear();
+                }
             }
             let _ = shutdown_tx.send(true);
         })
@@ -327,7 +344,9 @@ fn finish_server_shutdown(shutdown_error: Option<BootstrapError>) -> Result<Exit
     Ok(ExitCode::SUCCESS)
 }
 
-async fn shutdown_signal() -> Result<(), BootstrapError> {
+type ShutdownFuture = Pin<Box<dyn Future<Output = Result<ShutdownReason, BootstrapError>> + Send>>;
+
+async fn shutdown_signal(parent_exit: Option<ParentExitSignal>) -> Result<ShutdownReason, BootstrapError> {
     let ctrl_c = async {
         tokio::signal::ctrl_c().await.map_err(|error| {
             BootstrapError::new(
@@ -336,7 +355,8 @@ async fn shutdown_signal() -> Result<(), BootstrapError> {
                 "failed to install shutdown signal handler",
             )
             .with_source(error)
-        })
+        })?;
+        Ok::<ShutdownReason, BootstrapError>(ShutdownReason::Sigint)
     };
 
     #[cfg(unix)]
@@ -351,24 +371,25 @@ async fn shutdown_signal() -> Result<(), BootstrapError> {
                 .with_source(error)
             })?;
         terminate.recv().await;
-        Ok::<(), BootstrapError>(())
+        Ok::<ShutdownReason, BootstrapError>(ShutdownReason::Sigterm)
     };
 
     #[cfg(not(unix))]
-    let terminate = std::future::pending::<Result<(), BootstrapError>>();
+    let terminate = std::future::pending::<Result<ShutdownReason, BootstrapError>>();
+
+    let parent_exit: ShutdownFuture = match parent_exit {
+        Some(signal) => Box::pin(async move {
+            signal.await;
+            Ok(ShutdownReason::ParentExit)
+        }),
+        None => Box::pin(std::future::pending()),
+    };
 
     tokio::select! {
-        result = ctrl_c => {
-            result?;
-            info!("Received SIGINT, shutting down...");
-        }
-        result = terminate => {
-            result?;
-            info!("Received SIGTERM, shutting down...");
-        }
+        result = ctrl_c => result,
+        result = terminate => result,
+        result = parent_exit => result,
     }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -411,6 +432,15 @@ mod tests {
 
         assert!(config.port > 0);
         assert_eq!(config.port, bound.addr.port());
+    }
+
+    #[tokio::test]
+    async fn parent_exit_signal_triggers_shutdown() {
+        let reason = shutdown_signal(Some(Box::pin(std::future::ready(()))))
+            .await
+            .expect("parent exit should shut down cleanly");
+
+        assert_eq!(reason, ShutdownReason::ParentExit);
     }
 
     #[tokio::test]

--- a/crates/aionui-app/src/main.rs
+++ b/crates/aionui-app/src/main.rs
@@ -11,6 +11,7 @@ use clap::Parser;
 use aionui_app::AppServices;
 use cli::{Cli, Command};
 
+use crate::bootstrap::parent_exit_signal;
 use crate::error::MainError;
 
 // MainError has been moved to src/error.rs
@@ -94,7 +95,8 @@ async fn async_main(merged_path: String, cli: Cli) -> Result<ExitCode, MainError
                 )
                 .with_source(error)
             })?;
-            Ok(commands::run_server(env, services, listener).await?)
+            let parent_exit = parent_exit_signal(cli.parent_pid);
+            Ok(commands::run_server(env, services, listener, parent_exit).await?)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add an optional `--parent-pid` CLI flag for desktop-managed backend launches on Windows
- watch the desktop parent process and trigger the existing graceful shutdown path when the parent exits
- keep standalone `aioncore` launches unchanged by leaving `--parent-pid` optional

## Reproduction
1. On Windows, start `AionUi` and confirm both `AionUi.exe` and `aioncore.exe` are running.
2. Kill only the desktop parent process, not the process tree. For example: `taskkill /PID <AionUiPid> /F`.
3. Verify `AionUi.exe` is gone while `aioncore.exe` is still alive.
4. Run the installer for the next version and choose overwrite install.
5. Before this fix, the installer can report `AionUi 无法关闭` because the stale `aioncore.exe` still occupies bundled resources under the install directory.
6. After this change, when the bundled backend is launched with `--parent-pid`, it detects the desktop parent exit and follows the normal graceful shutdown flow.

## Verification
- `just push -u origin fix/backend-parent-exit`
