### PR TITLE
Refactor ACP empty-turn copy

### DIFF
--- a/crates/aionui-ai-agent/src/capability/backend_output_sink.rs
+++ b/crates/aionui-ai-agent/src/capability/backend_output_sink.rs
@@ -140,6 +140,8 @@ impl OutputSink for BackendOutputSink {
         let _ = self.event_tx.send(AgentStreamEvent::Tips(TipsEventData {
             content: msg.to_owned(),
             tip_type: TipType::Success,
+            code: None,
+            params: None,
         }));
     }
 }

--- a/crates/aionui-ai-agent/src/capability/cli_process/mod.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/mod.rs
@@ -240,6 +240,12 @@ impl CliAgentProcess {
         std::mem::take(&mut *buf)
     }
 
+    /// Clear the buffered stderr ring so subsequent peeks only observe lines
+    /// written after the caller opens a new diagnostics window.
+    pub async fn clear_stderr(&self) {
+        let _ = self.take_stderr().await;
+    }
+
     /// Peek the last `max_lines` newline-delimited lines from the stderr ring
     /// buffer **without draining**.
     ///

--- a/crates/aionui-ai-agent/src/capability/cli_process/stderr_monitor.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/stderr_monitor.rs
@@ -322,4 +322,41 @@ mod tests {
 
         assert_eq!(proc.peek_stderr_tail(0).await, "");
     }
+
+    #[tokio::test]
+    async fn clear_stderr_starts_a_fresh_window_for_later_peeks() {
+        let script = r#"
+            while IFS= read -r line; do
+              case "$line" in
+                *first*) echo 'HTTP 402: stale turn failure' >&2 ;;
+                *second*) : ;;
+              esac
+              echo '{"type":"ack","data":{}}'
+            done
+        "#;
+        let proc = CliAgentProcess::spawn(simple_script_config(script)).await.unwrap();
+        let mut rx = proc.subscribe();
+
+        proc.send(&serde_json::json!({ "turn": "first" })).await.unwrap();
+        timeout(Duration::from_secs(5), rx.recv()).await.unwrap().unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            proc.peek_stderr_tail(10).await.contains("stale turn failure"),
+            "first window should contain the prior stderr line"
+        );
+
+        proc.clear_stderr().await;
+
+        proc.send(&serde_json::json!({ "turn": "second" })).await.unwrap();
+        timeout(Duration::from_secs(5), rx.recv()).await.unwrap().unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert_eq!(
+            proc.peek_stderr_tail(10).await,
+            "",
+            "clearing before the second window must prevent stale stderr from leaking forward"
+        );
+
+        proc.kill(Duration::from_millis(100)).await.unwrap();
+    }
 }

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -1137,7 +1137,6 @@ mod tests {
         command.meta = Some(
             serde_json::from_value(json!({
                 "completion_behavior": "neutral_tip_on_empty",
-                "empty_turn_tip_code": "ACP_CTX_FLUSH_COMPLETED",
             }))
             .unwrap(),
         );
@@ -1149,7 +1148,7 @@ mod tests {
             matched.completion_behavior,
             Some(aionui_api_types::SlashCommandCompletionBehavior::NeutralTipOnEmpty)
         );
-        assert_eq!(matched.empty_turn_tip_code.as_deref(), Some("ACP_CTX_FLUSH_COMPLETED"));
+        assert_eq!(matched.empty_turn_tip_code.as_deref(), None);
     }
 
     // Close-reason compositional tests live in `agent_close.rs` so that

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -17,10 +17,10 @@ use crate::registry::CatalogSender;
 use crate::shared_kernel::{ModeId, ModelId, SessionId as DomainSessionId};
 use crate::types::SendMessageData;
 use agent_client_protocol::schema::{
-    CancelNotification, SessionId, SessionModelState, SessionNotification, SetSessionModeRequest,
+    AvailableCommand, CancelNotification, SessionId, SessionModelState, SessionNotification, SetSessionModeRequest,
     SetSessionModelRequest, UsageUpdate,
 };
-use aionui_api_types::{AgentHandshake, SlashCommandItem};
+use aionui_api_types::{AgentHandshake, SlashCommandCompletionBehavior, SlashCommandItem};
 use aionui_common::{
     AgentKillReason, AgentType, ConversationStatus, ErrorChain, TimestampMs, normalize_keys_to_snake_case,
 };
@@ -125,6 +125,39 @@ pub(super) fn sdk_to_snake_value<T: serde::Serialize>(value: &T) -> Option<Value
     let mut v = serde_json::to_value(value).ok()?;
     normalize_keys_to_snake_case(&mut v);
     Some(v)
+}
+
+fn parse_completion_behavior(meta: &serde_json::Map<String, Value>) -> Option<SlashCommandCompletionBehavior> {
+    match meta.get("completion_behavior").and_then(Value::as_str) {
+        Some("normal") => Some(SlashCommandCompletionBehavior::Normal),
+        Some("neutral_tip_on_empty") => Some(SlashCommandCompletionBehavior::NeutralTipOnEmpty),
+        _ => None,
+    }
+}
+
+fn slash_command_item(command: &AvailableCommand) -> SlashCommandItem {
+    let meta = command.meta.as_ref();
+    let completion_behavior = meta.and_then(parse_completion_behavior);
+    let empty_turn_tip_code = meta
+        .and_then(|meta| meta.get("empty_turn_tip_code"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let empty_turn_tip_params = meta
+        .and_then(|meta| meta.get("empty_turn_tip_params"))
+        .filter(|value| value.is_object())
+        .cloned();
+
+    SlashCommandItem {
+        command: command.name.clone(),
+        description: command.description.clone(),
+        completion_behavior,
+        empty_turn_tip_code,
+        empty_turn_tip_params,
+    }
+}
+
+fn slash_command_items(commands: &[AvailableCommand]) -> Vec<SlashCommandItem> {
+    commands.iter().map(slash_command_item).collect()
 }
 
 /// Manages a single ACP Agent instance.
@@ -546,20 +579,7 @@ impl AcpAgentManager {
     /// Return available slash commands from the session aggregate.
     pub(crate) async fn load_slash_commands(&self) -> Result<Vec<SlashCommandItem>, AgentError> {
         let session = self.session.read().await;
-        let items = session
-            .available_commands()
-            .map(|cmds| {
-                cmds.iter()
-                    .map(|c| SlashCommandItem {
-                        command: c.name.clone(),
-                        description: c.description.clone(),
-                        completion_behavior: None,
-                        empty_turn_tip_code: None,
-                        empty_turn_tip_params: None,
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
+        let items = session.available_commands().map(slash_command_items).unwrap_or_default();
         Ok(items)
     }
 }
@@ -905,6 +925,9 @@ impl AcpAgentManager {
 mod tests {
     use super::{exit_status_parts, user_facing_message};
     use crate::error::AgentError;
+    use crate::manager::acp::AcpSession;
+    use agent_client_protocol::schema::AvailableCommand;
+    use serde_json::json;
 
     #[test]
     fn exit_status_parts_handles_missing_status() {
@@ -1033,6 +1056,36 @@ mod tests {
         let err = AgentError::bad_gateway("Agent internal error (code -32603)");
 
         assert!(augment_via_process(&proc, &err).await.is_none());
+    }
+
+    #[test]
+    fn session_command_loading_preserves_empty_turn_meta() {
+        let mut session = AcpSession::new(None, None, Default::default());
+        let mut command = AvailableCommand::new("review", "Review the current diff");
+        command.meta = Some(
+            serde_json::from_value(json!({
+                "completion_behavior": "neutral_tip_on_empty",
+                "empty_turn_tip_code": "acp.empty_turn.choose_command",
+                "empty_turn_tip_params": {
+                    "command_count": 1
+                }
+            }))
+            .unwrap(),
+        );
+        session.apply_advertised_commands(vec![command]);
+
+        let items = super::slash_command_items(session.available_commands().expect("commands advertised"));
+
+        assert_eq!(items.len(), 1);
+        let item = &items[0];
+        assert_eq!(item.command, "review");
+        assert_eq!(item.description, "Review the current diff");
+        assert_eq!(
+            item.completion_behavior,
+            Some(aionui_api_types::SlashCommandCompletionBehavior::NeutralTipOnEmpty)
+        );
+        assert_eq!(item.empty_turn_tip_code.as_deref(), Some("acp.empty_turn.choose_command"));
+        assert_eq!(item.empty_turn_tip_params, Some(json!({ "command_count": 1 })));
     }
 
     // Close-reason compositional tests live in `agent_close.rs` so that

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -161,12 +161,19 @@ fn slash_command_items(commands: &[AvailableCommand]) -> Vec<SlashCommandItem> {
 }
 
 fn leading_slash_token(raw_user_input: &str) -> Option<&str> {
-    raw_user_input.split_whitespace().next()?.strip_prefix('/').filter(|token| !token.is_empty())
+    raw_user_input
+        .split_whitespace()
+        .next()?
+        .strip_prefix('/')
+        .filter(|token| !token.is_empty())
 }
 
 fn matched_slash_command(raw_user_input: &str, commands: &[AvailableCommand]) -> Option<SlashCommandItem> {
     let token = leading_slash_token(raw_user_input)?;
-    commands.iter().find(|command| command.name == token).map(slash_command_item)
+    commands
+        .iter()
+        .find(|command| command.name == token)
+        .map(slash_command_item)
 }
 
 /// Manages a single ACP Agent instance.
@@ -588,7 +595,10 @@ impl AcpAgentManager {
     /// Return available slash commands from the session aggregate.
     pub(crate) async fn load_slash_commands(&self) -> Result<Vec<SlashCommandItem>, AgentError> {
         let session = self.session.read().await;
-        let items = session.available_commands().map(slash_command_items).unwrap_or_default();
+        let items = session
+            .available_commands()
+            .map(slash_command_items)
+            .unwrap_or_default();
         Ok(items)
     }
 }
@@ -695,7 +705,8 @@ impl AcpAgentManager {
             content,
             ..data.clone()
         };
-        self.prompt_existing_session(&data, Some(&sid), matched_command.as_ref()).await
+        self.prompt_existing_session(&data, Some(&sid), matched_command.as_ref())
+            .await
     }
 
     /// Pre-open the ACP session without sending a prompt. Called by the
@@ -1091,14 +1102,16 @@ mod tests {
     fn session_command_loading_preserves_empty_turn_meta() {
         let mut session = AcpSession::new(None, None, Default::default());
         let mut command = AvailableCommand::new("review", "Review the current diff");
-        command.meta = Some(serde_json::from_value(json!({
-            "completion_behavior": "neutral_tip_on_empty",
-            "empty_turn_tip_code": "acp.empty_turn.choose_command",
-            "empty_turn_tip_params": {
-                "command_count": 1
-            }
-        }))
-        .unwrap());
+        command.meta = Some(
+            serde_json::from_value(json!({
+                "completion_behavior": "neutral_tip_on_empty",
+                "empty_turn_tip_code": "acp.empty_turn.choose_command",
+                "empty_turn_tip_params": {
+                    "command_count": 1
+                }
+            }))
+            .unwrap(),
+        );
         session.apply_advertised_commands(vec![command]);
 
         let items = super::slash_command_items(session.available_commands().expect("commands advertised"));
@@ -1111,7 +1124,10 @@ mod tests {
             item.completion_behavior,
             Some(aionui_api_types::SlashCommandCompletionBehavior::NeutralTipOnEmpty)
         );
-        assert_eq!(item.empty_turn_tip_code.as_deref(), Some("acp.empty_turn.choose_command"));
+        assert_eq!(
+            item.empty_turn_tip_code.as_deref(),
+            Some("acp.empty_turn.choose_command")
+        );
         assert_eq!(item.empty_turn_tip_params, Some(json!({ "command_count": 1 })));
     }
 

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -553,6 +553,9 @@ impl AcpAgentManager {
                     .map(|c| SlashCommandItem {
                         command: c.name.clone(),
                         description: c.description.clone(),
+                        completion_behavior: None,
+                        empty_turn_tip_code: None,
+                        empty_turn_tip_params: None,
                     })
                     .collect()
             })

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -160,6 +160,15 @@ fn slash_command_items(commands: &[AvailableCommand]) -> Vec<SlashCommandItem> {
     commands.iter().map(slash_command_item).collect()
 }
 
+fn leading_slash_token(raw_user_input: &str) -> Option<&str> {
+    raw_user_input.split_whitespace().next()?.strip_prefix('/').filter(|token| !token.is_empty())
+}
+
+fn matched_slash_command(raw_user_input: &str, commands: &[AvailableCommand]) -> Option<SlashCommandItem> {
+    let token = leading_slash_token(raw_user_input)?;
+    commands.iter().find(|command| command.name == token).map(slash_command_item)
+}
+
 /// Manages a single ACP Agent instance.
 ///
 /// ACP is the most complex agent type, supporting 20+ CLI sub-backends
@@ -661,6 +670,13 @@ impl AcpAgentManager {
     async fn ensure_session_and_send(&self, data: &SendMessageData) -> Result<PromptOutcome, AcpSendFailure> {
         let sid = self.ensure_session_opened().await.map_err(AcpSendFailure::from)?;
         self.runtime.reset_for_new_turn(ConversationStatus::Running);
+        let raw_user_input = data.content.clone();
+        let matched_command = {
+            let session = self.session.read().await;
+            session
+                .available_commands()
+                .and_then(|commands| matched_slash_command(&raw_user_input, commands))
+        };
 
         let content = {
             let mut s = self.session.write().await;
@@ -679,7 +695,7 @@ impl AcpAgentManager {
             content,
             ..data.clone()
         };
-        self.prompt_existing_session(&data, Some(&sid)).await
+        self.prompt_existing_session(&data, Some(&sid), matched_command.as_ref()).await
     }
 
     /// Pre-open the ACP session without sending a prompt. Called by the
@@ -749,13 +765,26 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
                 self.runtime.emit_finish(Some(session_id));
                 Ok(())
             }
-            Ok(PromptOutcome::EmptyResponse { session_id, error }) => {
+            Ok(PromptOutcome::InfoTip { session_id, tips } | PromptOutcome::WarningTip { session_id, tips }) => {
                 info!(
                     agent_type = "acp",
-                    terminal_kind = "error",
+                    terminal_kind = "finish",
                     source = "empty_response",
                     session_id = %session_id,
                     "ACP send_message completed without visible output"
+                );
+                self.runtime.emit(AgentStreamEvent::Tips(tips));
+                self.runtime.emit_finish(Some(session_id));
+                Ok(())
+            }
+            Ok(PromptOutcome::TerminalError { session_id, error }) => {
+                info!(
+                    agent_type = "acp",
+                    terminal_kind = "error",
+                    source = "empty_response_stderr",
+                    session_id = %session_id,
+                    error_code = ?error.code,
+                    "ACP send_message empty turn classified as terminal upstream error"
                 );
                 self.runtime.emit_error_data(error);
                 Ok(())
@@ -1062,16 +1091,14 @@ mod tests {
     fn session_command_loading_preserves_empty_turn_meta() {
         let mut session = AcpSession::new(None, None, Default::default());
         let mut command = AvailableCommand::new("review", "Review the current diff");
-        command.meta = Some(
-            serde_json::from_value(json!({
-                "completion_behavior": "neutral_tip_on_empty",
-                "empty_turn_tip_code": "acp.empty_turn.choose_command",
-                "empty_turn_tip_params": {
-                    "command_count": 1
-                }
-            }))
-            .unwrap(),
-        );
+        command.meta = Some(serde_json::from_value(json!({
+            "completion_behavior": "neutral_tip_on_empty",
+            "empty_turn_tip_code": "acp.empty_turn.choose_command",
+            "empty_turn_tip_params": {
+                "command_count": 1
+            }
+        }))
+        .unwrap());
         session.apply_advertised_commands(vec![command]);
 
         let items = super::slash_command_items(session.available_commands().expect("commands advertised"));
@@ -1086,6 +1113,27 @@ mod tests {
         );
         assert_eq!(item.empty_turn_tip_code.as_deref(), Some("acp.empty_turn.choose_command"));
         assert_eq!(item.empty_turn_tip_params, Some(json!({ "command_count": 1 })));
+    }
+
+    #[test]
+    fn matches_leading_slash_token_against_advertised_commands() {
+        let mut command = AvailableCommand::new("ctx-flush", "Flush context");
+        command.meta = Some(
+            serde_json::from_value(json!({
+                "completion_behavior": "neutral_tip_on_empty",
+                "empty_turn_tip_code": "ACP_CTX_FLUSH_COMPLETED",
+            }))
+            .unwrap(),
+        );
+
+        let matched = super::matched_slash_command("/ctx-flush now", &[command]).expect("command should match");
+
+        assert_eq!(matched.command, "ctx-flush");
+        assert_eq!(
+            matched.completion_behavior,
+            Some(aionui_api_types::SlashCommandCompletionBehavior::NeutralTipOnEmpty)
+        );
+        assert_eq!(matched.empty_turn_tip_code.as_deref(), Some("ACP_CTX_FLUSH_COMPLETED"));
     }
 
     // Close-reason compositional tests live in `agent_close.rs` so that

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -3,18 +3,19 @@ use crate::manager::acp::AcpAgentManager;
 use crate::manager::acp::mode_normalize::agent_metadata_uses_meta_resume;
 use crate::protocol::error::AcpError;
 use crate::protocol::events::{
-    AgentStreamEvent, AvailableCommandsEventData, ErrorEventData, SessionAssignedEventData, StartEventData,
+    AgentStreamEvent, AvailableCommandsEventData, ErrorEventData, SessionAssignedEventData, StartEventData, TipType,
+    TipsEventData,
 };
+use crate::protocol::send_error::AgentSendError;
 use crate::shared_kernel::SessionId as DomainSessionId;
 use crate::types::SendMessageData;
+use aionui_api_types::{SlashCommandCompletionBehavior, SlashCommandItem};
 use agent_client_protocol::schema::{ContentBlock, LoadSessionRequest, PromptRequest, SessionId, StopReason};
-use aionui_api_types::{
-    AgentErrorCode, AgentErrorOwnership, AgentErrorResolution, AgentErrorResolutionKind, AgentErrorResolutionTarget,
-};
 use serde_json::Value;
 use tokio::sync::broadcast::error::TryRecvError;
 
 use super::agent::sdk_to_snake_value;
+use super::agent_close::STDERR_PEEK_LINES;
 use super::error_mapping::{AcpSendFailure, is_acp_session_not_found};
 use tracing::warn;
 
@@ -22,7 +23,9 @@ use tracing::warn;
 pub(super) enum PromptOutcome {
     Completed { session_id: String },
     Cancelled { session_id: String },
-    EmptyResponse { session_id: String, error: ErrorEventData },
+    TerminalError { session_id: String, error: ErrorEventData },
+    InfoTip { session_id: String, tips: TipsEventData },
+    WarningTip { session_id: String, tips: TipsEventData },
 }
 
 impl AcpAgentManager {
@@ -227,6 +230,7 @@ impl AcpAgentManager {
         &self,
         data: &SendMessageData,
         session_id: Option<&str>,
+        matched_command: Option<&SlashCommandItem>,
     ) -> Result<PromptOutcome, AcpSendFailure> {
         let sid = session_id
             .ok_or_else(|| AgentError::internal("Cannot prompt: no session ID available"))
@@ -254,10 +258,21 @@ impl AcpAgentManager {
             .await
             .map_err(AcpSendFailure::from)?;
 
+        let empty_turn = is_empty_turn(&mut probe_rx);
+        if empty_turn
+            && let Some(error) = self.empty_turn_terminal_error().await
+        {
+            return Ok(PromptOutcome::TerminalError {
+                session_id: sid.to_owned(),
+                error,
+            });
+        }
+
         Ok(prompt_outcome_from_stop_reason(
             sid,
             prompt_response.stop_reason,
-            is_empty_turn(&mut probe_rx),
+            empty_turn,
+            matched_command,
         ))
     }
 
@@ -317,6 +332,12 @@ impl AcpAgentManager {
                 }));
         }
     }
+
+    async fn empty_turn_terminal_error(&self) -> Option<ErrorEventData> {
+        let tail = self.process.peek_stderr_tail(STDERR_PEEK_LINES).await;
+        let detail = super::stderr_error_extractor::extract_error_message(&tail)?;
+        Some(classify_empty_turn_stderr_error(&detail))
+    }
 }
 
 /// Drain the supplied turn-scoped receiver and return `true` when the turn
@@ -362,7 +383,12 @@ fn event_is_user_visible_output(event: &AgentStreamEvent) -> bool {
     )
 }
 
-fn prompt_outcome_from_stop_reason(session_id: &str, stop_reason: StopReason, empty_turn: bool) -> PromptOutcome {
+fn prompt_outcome_from_stop_reason(
+    session_id: &str,
+    stop_reason: StopReason,
+    empty_turn: bool,
+    matched_command: Option<&SlashCommandItem>,
+) -> PromptOutcome {
     if matches!(stop_reason, StopReason::Cancelled) {
         return PromptOutcome::Cancelled {
             session_id: session_id.to_owned(),
@@ -370,9 +396,36 @@ fn prompt_outcome_from_stop_reason(session_id: &str, stop_reason: StopReason, em
     }
 
     if empty_turn {
-        return PromptOutcome::EmptyResponse {
+        if matches!(stop_reason, StopReason::EndTurn) {
+            if let Some(command) = matched_command
+                && matches!(
+                    command.completion_behavior,
+                    Some(SlashCommandCompletionBehavior::NeutralTipOnEmpty)
+                )
+            {
+                return PromptOutcome::InfoTip {
+                    session_id: session_id.to_owned(),
+                    tips: empty_turn_info_tip(
+                        command.empty_turn_tip_code.as_deref().unwrap_or("ACP_EMPTY_TURN"),
+                        command.empty_turn_tip_params.clone(),
+                        empty_finish_diagnostic_message(StopReason::EndTurn),
+                    ),
+                };
+            }
+
+            return PromptOutcome::InfoTip {
+                session_id: session_id.to_owned(),
+                tips: empty_turn_info_tip(
+                    "ACP_EMPTY_TURN",
+                    None,
+                    empty_finish_diagnostic_message(StopReason::EndTurn),
+                ),
+            };
+        }
+
+        return PromptOutcome::WarningTip {
             session_id: session_id.to_owned(),
-            error: empty_finish_diagnostic_error(stop_reason),
+            tips: empty_finish_diagnostic_tip(stop_reason),
         };
     }
 
@@ -381,22 +434,26 @@ fn prompt_outcome_from_stop_reason(session_id: &str, stop_reason: StopReason, em
     }
 }
 
-fn empty_finish_diagnostic_error(stop_reason: StopReason) -> ErrorEventData {
-    ErrorEventData::classified(
-        // TODO(i18n): wire to a frontend translation key once a
-        // pattern is established. For now this is the user-facing
-        // English string.
-        empty_finish_diagnostic_message(stop_reason),
-        AgentErrorCode::UnknownUpstreamError,
-        AgentErrorOwnership::UnknownUpstream,
-        Some("Agent completed the turn without producing visible output.".into()),
-        true,
-        true,
-        Some(AgentErrorResolution::new(
-            AgentErrorResolutionKind::SendFeedback,
-            Some(AgentErrorResolutionTarget::Feedback),
-        )),
-    )
+fn empty_turn_info_tip(code: &str, params: Option<Value>, fallback_content: String) -> TipsEventData {
+    TipsEventData {
+        content: fallback_content,
+        tip_type: TipType::Info,
+        code: Some(code.to_owned()),
+        params,
+    }
+}
+
+fn empty_finish_diagnostic_tip(stop_reason: StopReason) -> TipsEventData {
+    TipsEventData {
+        content: empty_finish_diagnostic_message(stop_reason),
+        tip_type: TipType::Warning,
+        code: None,
+        params: None,
+    }
+}
+
+fn classify_empty_turn_stderr_error(detail: &str) -> ErrorEventData {
+    AgentSendError::from_agent_error(AgentError::bad_gateway(detail.to_owned())).into_stream_error()
 }
 
 /// Build the user-facing message shown when the agent finished a turn
@@ -437,8 +494,6 @@ mod tests {
     use crate::protocol::error::AcpError;
     use crate::shared_kernel::SessionId as DomainSessionId;
     use agent_client_protocol::schema::AgentCapabilities;
-    use aionui_api_types::AgentErrorCode;
-
     fn make_session() -> AcpSession {
         AcpSession::new(None, None, Default::default())
     }
@@ -602,11 +657,11 @@ mod tests {
     // -- empty-finish diagnostic (ELECTRON-1JG) -------------------------------
 
     use crate::protocol::events::{
-        AgentStreamEvent, FinishEventData, StartEventData, TextEventData, ThinkingEventData, ToolCallEventData,
-        ToolCallStatus,
+        AgentStreamEvent, FinishEventData, StartEventData, TextEventData, ThinkingEventData, TipType,
+        ToolCallEventData, ToolCallStatus,
     };
     use agent_client_protocol::schema::StopReason;
-    use aionui_api_types::{AgentErrorResolutionKind, AgentErrorResolutionTarget};
+    use aionui_api_types::{AgentErrorCode, SlashCommandCompletionBehavior, SlashCommandItem};
     use tokio::sync::broadcast;
 
     /// Lifecycle-only events (`Start`/`Finish`) must NOT count as
@@ -700,33 +755,68 @@ mod tests {
     }
 
     #[test]
-    fn empty_finish_diagnostic_error_has_feedback_resolution() {
-        let error = super::empty_finish_diagnostic_error(StopReason::EndTurn);
-
-        let resolution = error
-            .resolution
-            .expect("empty-finish classified errors must include a resolution");
-        assert_eq!(resolution.kind, AgentErrorResolutionKind::SendFeedback);
-        assert_eq!(resolution.target, Some(AgentErrorResolutionTarget::Feedback));
+    fn empty_finish_diagnostic_tip_is_warning() {
+        let tip = super::empty_finish_diagnostic_tip(StopReason::EndTurn);
+        assert_eq!(tip.tip_type, TipType::Warning);
+        assert!(tip.content.to_lowercase().contains("finished"));
     }
 
     #[test]
-    fn prompt_outcome_empty_response_maps_to_error_without_finish() {
-        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true);
+    fn benign_empty_turn_returns_info_tip() {
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, None);
 
         match outcome {
-            super::PromptOutcome::EmptyResponse { session_id, error } => {
+            super::PromptOutcome::InfoTip { session_id, tips } => {
                 assert_eq!(session_id, "sess-1");
-                assert_eq!(error.code, Some(AgentErrorCode::UnknownUpstreamError));
-                assert_eq!(error.feedback_recommended, Some(true));
+                assert_eq!(tips.tip_type, TipType::Info);
+                assert_eq!(tips.code.as_deref(), Some("ACP_EMPTY_TURN"));
+                assert!(tips.content.contains("without producing"));
             }
-            other => panic!("expected EmptyResponse, got {other:?}"),
+            other => panic!("expected InfoTip, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn metadata_driven_command_empty_turn_uses_command_tip_code() {
+        let command = SlashCommandItem {
+            command: "ctx-flush".into(),
+            description: "Flush context".into(),
+            completion_behavior: Some(SlashCommandCompletionBehavior::NeutralTipOnEmpty),
+            empty_turn_tip_code: Some("ACP_CTX_FLUSH_COMPLETED".into()),
+            empty_turn_tip_params: Some(serde_json::json!({ "scope": "session" })),
+        };
+
+        let outcome =
+            super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, Some(&command));
+
+        match outcome {
+            super::PromptOutcome::InfoTip { session_id, tips } => {
+                assert_eq!(session_id, "sess-1");
+                assert_eq!(tips.tip_type, TipType::Info);
+                assert_eq!(tips.code.as_deref(), Some("ACP_CTX_FLUSH_COMPLETED"));
+                assert_eq!(tips.params, Some(serde_json::json!({ "scope": "session" })));
+            }
+            other => panic!("expected InfoTip, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_benign_empty_turn_can_stay_warning_tip() {
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::MaxTokens, true, None);
+
+        match outcome {
+            super::PromptOutcome::WarningTip { session_id, tips } => {
+                assert_eq!(session_id, "sess-1");
+                assert_eq!(tips.tip_type, TipType::Warning);
+                assert!(tips.content.to_lowercase().contains("token"));
+            }
+            other => panic!("expected WarningTip, got {other:?}"),
         }
     }
 
     #[test]
     fn prompt_outcome_cancelled_takes_priority_over_empty_response() {
-        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::Cancelled, true);
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::Cancelled, true, None);
 
         match outcome {
             super::PromptOutcome::Cancelled { session_id } => {
@@ -738,7 +828,7 @@ mod tests {
 
     #[test]
     fn prompt_outcome_completed_when_visible_output_exists() {
-        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, false);
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, false, None);
 
         match outcome {
             super::PromptOutcome::Completed { session_id } => {
@@ -746,5 +836,31 @@ mod tests {
             }
             other => panic!("expected Completed, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn classify_empty_turn_stderr_error_preserves_provider_billing_failure() {
+        let error = super::classify_empty_turn_stderr_error(
+            "HTTP 402: Insufficient account balance",
+        );
+
+        assert_eq!(error.code, Some(AgentErrorCode::UserLlmProviderBillingRequired));
+        assert_eq!(error.retryable, Some(false));
+        assert_eq!(error.feedback_recommended, Some(false));
+    }
+
+    #[test]
+    fn classify_real_402_empty_turn_sentry_tail_preserves_provider_billing_failure() {
+        let stderr = "[warn] CLI process stderr stderr=\"2026-06-05 03:27:44 [INFO] agent.chat_completion_helpers: Streaming failed before delivery: Error code: 402 - {'error': {'code': '402', 'message': 'Insufficient account balance', 'type': 'insufficient_balance'}}\"\n\
+                      [warn] CLI process stderr stderr=\"💡 xiaomi reported that billing, credits, or account entitlement is exhausted for mimo-v2.5-pro.\"\n\
+                      [warn] CLI process stderr stderr=\"💡 Add credits or update billing with that provider, then retry.\"\n\
+                      [warn] CLI process stderr stderr=\"2026-06-05 03:27:44 [ERROR] agent.conversation_loop: Non-retryable client error: Error code: 402 - {'error': {'code': '402', 'message': 'Insufficient account balance', 'type': 'insufficient_balance'}}\"";
+        let detail = super::super::stderr_error_extractor::extract_error_message(stderr)
+            .expect("sample tail must surface a billing hint");
+        let error = super::classify_empty_turn_stderr_error(&detail);
+
+        assert_eq!(error.code, Some(AgentErrorCode::UserLlmProviderBillingRequired));
+        assert_eq!(error.retryable, Some(false));
+        assert_eq!(error.feedback_recommended, Some(false));
     }
 }

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -10,7 +10,7 @@ use crate::protocol::send_error::AgentSendError;
 use crate::shared_kernel::SessionId as DomainSessionId;
 use crate::types::SendMessageData;
 use agent_client_protocol::schema::{ContentBlock, LoadSessionRequest, PromptRequest, SessionId, StopReason};
-use aionui_api_types::{SlashCommandCompletionBehavior, SlashCommandItem};
+use aionui_api_types::SlashCommandItem;
 use serde_json::Value;
 use tokio::sync::broadcast::error::TryRecvError;
 
@@ -389,7 +389,7 @@ fn prompt_outcome_from_stop_reason(
     session_id: &str,
     stop_reason: StopReason,
     empty_turn: bool,
-    matched_command: Option<&SlashCommandItem>,
+    _matched_command: Option<&SlashCommandItem>,
 ) -> PromptOutcome {
     if matches!(stop_reason, StopReason::Cancelled) {
         return PromptOutcome::Cancelled {
@@ -399,29 +399,9 @@ fn prompt_outcome_from_stop_reason(
 
     if empty_turn {
         if matches!(stop_reason, StopReason::EndTurn) {
-            if let Some(command) = matched_command
-                && matches!(
-                    command.completion_behavior,
-                    Some(SlashCommandCompletionBehavior::NeutralTipOnEmpty)
-                )
-            {
-                return PromptOutcome::InfoTip {
-                    session_id: session_id.to_owned(),
-                    tips: empty_turn_info_tip(
-                        command.empty_turn_tip_code.as_deref().unwrap_or("ACP_EMPTY_TURN"),
-                        command.empty_turn_tip_params.clone(),
-                        empty_finish_diagnostic_message(StopReason::EndTurn),
-                    ),
-                };
-            }
-
             return PromptOutcome::InfoTip {
                 session_id: session_id.to_owned(),
-                tips: empty_turn_info_tip(
-                    "ACP_EMPTY_TURN",
-                    None,
-                    empty_finish_diagnostic_message(StopReason::EndTurn),
-                ),
+                tips: empty_turn_info_tip("ACP_EMPTY_TURN", None),
             };
         }
 
@@ -436,9 +416,9 @@ fn prompt_outcome_from_stop_reason(
     }
 }
 
-fn empty_turn_info_tip(code: &str, params: Option<Value>, fallback_content: String) -> TipsEventData {
+fn empty_turn_info_tip(code: &str, params: Option<Value>) -> TipsEventData {
     TipsEventData {
-        content: fallback_content,
+        content: String::new(),
         tip_type: TipType::Info,
         code: Some(code.to_owned()),
         params,
@@ -447,9 +427,9 @@ fn empty_turn_info_tip(code: &str, params: Option<Value>, fallback_content: Stri
 
 fn empty_finish_diagnostic_tip(stop_reason: StopReason) -> TipsEventData {
     TipsEventData {
-        content: empty_finish_diagnostic_message(stop_reason),
+        content: String::new(),
         tip_type: TipType::Warning,
-        code: None,
+        code: Some(empty_finish_tip_code(stop_reason).to_owned()),
         params: None,
     }
 }
@@ -458,24 +438,12 @@ fn classify_empty_turn_stderr_error(detail: &str) -> ErrorEventData {
     AgentSendError::from_agent_error(AgentError::bad_gateway(detail.to_owned())).into_stream_error()
 }
 
-/// Build the user-facing message shown when the agent finished a turn
-/// without emitting any output. Wording is deliberately concrete so the
-/// user has something to act on (retry, reword, check provider).
-fn empty_finish_diagnostic_message(stop_reason: StopReason) -> String {
+fn empty_finish_tip_code(stop_reason: StopReason) -> &'static str {
     match stop_reason {
-        StopReason::MaxTokens => "The model reached its output token limit before producing any reply. \
-             Try asking a shorter question or raising the model's max output."
-            .to_owned(),
-        StopReason::MaxTurnRequests => "The model hit the per-turn request cap before producing any reply. \
-             Try a simpler request or restart the conversation."
-            .to_owned(),
-        StopReason::Refusal => "The model refused to continue without producing a reply.".to_owned(),
-        // EndTurn (and any non-exhaustive future variants) all map to the
-        // generic empty-reply message for no-visible-output turns.
-        _ => "This turn finished without producing any visible reply. \
-              This usually means the request returned an empty response — \
-              try resending the message or switching model/provider."
-            .to_owned(),
+        StopReason::MaxTokens => "ACP_EMPTY_TURN_MAX_TOKENS",
+        StopReason::MaxTurnRequests => "ACP_EMPTY_TURN_MAX_TURN_REQUESTS",
+        StopReason::Refusal => "ACP_EMPTY_TURN_REFUSAL",
+        _ => "ACP_EMPTY_TURN",
     }
 }
 
@@ -738,28 +706,31 @@ mod tests {
         assert!(!super::is_empty_turn(&mut rx));
     }
 
-    /// Each `StopReason` variant maps to a distinct, user-actionable
-    /// message. Pin the wording so future copy changes are deliberate.
+    /// Each empty-finish stop reason maps to a stable tip code so the UI can
+    /// own the final localized copy.
     #[test]
-    fn empty_finish_diagnostic_message_per_stop_reason() {
-        let endturn = super::empty_finish_diagnostic_message(StopReason::EndTurn);
-        assert!(endturn.to_lowercase().contains("finished"));
-
-        let max_tokens = super::empty_finish_diagnostic_message(StopReason::MaxTokens);
-        assert!(max_tokens.to_lowercase().contains("token"));
-
-        let max_turn = super::empty_finish_diagnostic_message(StopReason::MaxTurnRequests);
-        assert!(max_turn.to_lowercase().contains("per-turn") || max_turn.to_lowercase().contains("cap"));
-
-        let refusal = super::empty_finish_diagnostic_message(StopReason::Refusal);
-        assert!(refusal.to_lowercase().contains("refused"));
+    fn empty_finish_tip_code_per_stop_reason() {
+        assert_eq!(super::empty_finish_tip_code(StopReason::EndTurn), "ACP_EMPTY_TURN");
+        assert_eq!(
+            super::empty_finish_tip_code(StopReason::MaxTokens),
+            "ACP_EMPTY_TURN_MAX_TOKENS"
+        );
+        assert_eq!(
+            super::empty_finish_tip_code(StopReason::MaxTurnRequests),
+            "ACP_EMPTY_TURN_MAX_TURN_REQUESTS"
+        );
+        assert_eq!(
+            super::empty_finish_tip_code(StopReason::Refusal),
+            "ACP_EMPTY_TURN_REFUSAL"
+        );
     }
 
     #[test]
     fn empty_finish_diagnostic_tip_is_warning() {
         let tip = super::empty_finish_diagnostic_tip(StopReason::EndTurn);
         assert_eq!(tip.tip_type, TipType::Warning);
-        assert!(tip.content.to_lowercase().contains("finished"));
+        assert_eq!(tip.content, "");
+        assert_eq!(tip.code.as_deref(), Some("ACP_EMPTY_TURN"));
     }
 
     #[test]
@@ -771,20 +742,20 @@ mod tests {
                 assert_eq!(session_id, "sess-1");
                 assert_eq!(tips.tip_type, TipType::Info);
                 assert_eq!(tips.code.as_deref(), Some("ACP_EMPTY_TURN"));
-                assert!(tips.content.contains("without producing"));
+                assert_eq!(tips.content, "");
             }
             other => panic!("expected InfoTip, got {other:?}"),
         }
     }
 
     #[test]
-    fn metadata_driven_command_empty_turn_uses_command_tip_code() {
+    fn metadata_driven_command_empty_turn_uses_generic_tip_code() {
         let command = SlashCommandItem {
             command: "ctx-flush".into(),
             description: "Flush context".into(),
             completion_behavior: Some(SlashCommandCompletionBehavior::NeutralTipOnEmpty),
-            empty_turn_tip_code: None,
-            empty_turn_tip_params: None,
+            empty_turn_tip_code: Some("ACP_CTX_FLUSH_COMPLETED".into()),
+            empty_turn_tip_params: Some(serde_json::json!({ "scope": "session" })),
         };
 
         let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, Some(&command));
@@ -794,6 +765,7 @@ mod tests {
                 assert_eq!(session_id, "sess-1");
                 assert_eq!(tips.tip_type, TipType::Info);
                 assert_eq!(tips.code.as_deref(), Some("ACP_EMPTY_TURN"));
+                assert_eq!(tips.content, "");
                 assert_eq!(tips.params, None);
             }
             other => panic!("expected InfoTip, got {other:?}"),
@@ -808,7 +780,8 @@ mod tests {
             super::PromptOutcome::WarningTip { session_id, tips } => {
                 assert_eq!(session_id, "sess-1");
                 assert_eq!(tips.tip_type, TipType::Warning);
-                assert!(tips.content.to_lowercase().contains("token"));
+                assert_eq!(tips.content, "");
+                assert_eq!(tips.code.as_deref(), Some("ACP_EMPTY_TURN_MAX_TOKENS"));
             }
             other => panic!("expected WarningTip, got {other:?}"),
         }

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -471,9 +471,8 @@ fn empty_finish_diagnostic_message(stop_reason: StopReason) -> String {
             .to_owned(),
         StopReason::Refusal => "The model refused to continue without producing a reply.".to_owned(),
         // EndTurn (and any non-exhaustive future variants) all map to the
-        // generic empty-reply message — the model said it was done but
-        // produced nothing.
-        _ => "The model finished without producing any reply. \
+        // generic empty-reply message for no-visible-output turns.
+        _ => "This turn finished without producing any visible reply. \
               This usually means the request returned an empty response — \
               try resending the message or switching model/provider."
             .to_owned(),
@@ -784,8 +783,8 @@ mod tests {
             command: "ctx-flush".into(),
             description: "Flush context".into(),
             completion_behavior: Some(SlashCommandCompletionBehavior::NeutralTipOnEmpty),
-            empty_turn_tip_code: Some("ACP_CTX_FLUSH_COMPLETED".into()),
-            empty_turn_tip_params: Some(serde_json::json!({ "scope": "session" })),
+            empty_turn_tip_code: None,
+            empty_turn_tip_params: None,
         };
 
         let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, Some(&command));
@@ -794,8 +793,8 @@ mod tests {
             super::PromptOutcome::InfoTip { session_id, tips } => {
                 assert_eq!(session_id, "sess-1");
                 assert_eq!(tips.tip_type, TipType::Info);
-                assert_eq!(tips.code.as_deref(), Some("ACP_CTX_FLUSH_COMPLETED"));
-                assert_eq!(tips.params, Some(serde_json::json!({ "scope": "session" })));
+                assert_eq!(tips.code.as_deref(), Some("ACP_EMPTY_TURN"));
+                assert_eq!(tips.params, None);
             }
             other => panic!("expected InfoTip, got {other:?}"),
         }

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -9,8 +9,8 @@ use crate::protocol::events::{
 use crate::protocol::send_error::AgentSendError;
 use crate::shared_kernel::SessionId as DomainSessionId;
 use crate::types::SendMessageData;
-use aionui_api_types::{SlashCommandCompletionBehavior, SlashCommandItem};
 use agent_client_protocol::schema::{ContentBlock, LoadSessionRequest, PromptRequest, SessionId, StopReason};
+use aionui_api_types::{SlashCommandCompletionBehavior, SlashCommandItem};
 use serde_json::Value;
 use tokio::sync::broadcast::error::TryRecvError;
 
@@ -263,9 +263,7 @@ impl AcpAgentManager {
             .map_err(AcpSendFailure::from)?;
 
         let empty_turn = is_empty_turn(&mut probe_rx);
-        if empty_turn
-            && let Some(error) = self.empty_turn_terminal_error().await
-        {
+        if empty_turn && let Some(error) = self.empty_turn_terminal_error().await {
             return Ok(PromptOutcome::TerminalError {
                 session_id: sid.to_owned(),
                 error,
@@ -790,8 +788,7 @@ mod tests {
             empty_turn_tip_params: Some(serde_json::json!({ "scope": "session" })),
         };
 
-        let outcome =
-            super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, Some(&command));
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, Some(&command));
 
         match outcome {
             super::PromptOutcome::InfoTip { session_id, tips } => {
@@ -844,9 +841,7 @@ mod tests {
 
     #[test]
     fn classify_empty_turn_stderr_error_preserves_provider_billing_failure() {
-        let error = super::classify_empty_turn_stderr_error(
-            "HTTP 402: Insufficient account balance",
-        );
+        let error = super::classify_empty_turn_stderr_error("HTTP 402: Insufficient account balance");
 
         assert_eq!(error.code, Some(AgentErrorCode::UserLlmProviderBillingRequired));
         assert_eq!(error.retryable, Some(false));

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -249,6 +249,10 @@ impl AcpAgentManager {
             session_id: Some(sid.to_owned()),
         }));
 
+        // Scope stderr classification to this prompt so stale lines from an
+        // earlier turn cannot override a later benign empty turn.
+        self.process.clear_stderr().await;
+
         let prompt_response = self
             .protocol
             .prompt(PromptRequest::new(

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -145,7 +145,13 @@ impl AionrsAgentManager {
         let slash_commands = engine
             .slash_command_list()
             .into_iter()
-            .map(|(command, description)| SlashCommandItem { command, description })
+            .map(|(command, description)| SlashCommandItem {
+                command,
+                description,
+                completion_behavior: None,
+                empty_turn_tip_code: None,
+                empty_turn_tip_params: None,
+            })
             .collect();
 
         runtime.transition_to(ConversationStatus::Pending);

--- a/crates/aionui-ai-agent/src/protocol/events/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/events/mod.rs
@@ -80,6 +80,10 @@ pub struct TipsEventData {
     pub content: String,
     #[serde(rename = "type")]
     pub tip_type: TipType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<serde_json::Value>,
 }
 
 /// Severity level for a tip event.
@@ -87,6 +91,7 @@ pub struct TipsEventData {
 #[serde(rename_all = "snake_case")]
 pub enum TipType {
     Error,
+    Info,
     Success,
     Warning,
 }
@@ -130,10 +135,37 @@ mod tests {
         let event = AgentStreamEvent::Tips(TipsEventData {
             content: "Something went wrong".into(),
             tip_type: TipType::Error,
+            code: None,
+            params: None,
         });
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["type"], "tips");
         assert_eq!(json["data"]["type"], "error");
+    }
+
+    #[test]
+    fn tips_event_roundtrip_preserves_info_code_and_params() {
+        let event = AgentStreamEvent::Tips(TipsEventData {
+            content: "Select a slash command to continue".into(),
+            tip_type: TipType::Info,
+            code: Some("acp.empty_turn.choose_command".into()),
+            params: Some(json!({ "command_count": 3 })),
+        });
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "tips");
+        assert_eq!(json["data"]["type"], "info");
+        assert_eq!(json["data"]["code"], "acp.empty_turn.choose_command");
+        assert_eq!(json["data"]["params"]["command_count"], 3);
+
+        let parsed: AgentStreamEvent = serde_json::from_value(json).unwrap();
+        if let AgentStreamEvent::Tips(data) = parsed {
+            assert_eq!(data.content, "Select a slash command to continue");
+            assert_eq!(data.tip_type, TipType::Info);
+            assert_eq!(data.code.as_deref(), Some("acp.empty_turn.choose_command"));
+            assert_eq!(data.params, Some(json!({ "command_count": 3 })));
+        } else {
+            panic!("Expected Tips event");
+        }
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -523,7 +523,11 @@ fn classify_provider_text(lower: &str) -> Option<ClassifiedError> {
         &[
             "402",
             "insufficient balance",
+            "insufficient account balance",
             "credit balance is too low",
+            "add credits",
+            "update billing",
+            "account entitlement is exhausted",
             "purchase credits",
             "plans & billing",
             "plans and billing",

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -163,6 +163,9 @@ mod tests {
         let cmd = SlashCommandItem {
             command: "/review".into(),
             description: "Code review".into(),
+            completion_behavior: None,
+            empty_turn_tip_code: None,
+            empty_turn_tip_params: None,
         };
         let json = serde_json::to_value(&cmd).unwrap();
         assert_eq!(json["command"], "/review");

--- a/crates/aionui-api-types/src/agent_build_extra.rs
+++ b/crates/aionui-api-types/src/agent_build_extra.rs
@@ -151,9 +151,23 @@ pub struct AcpModelInfo {
     pub provider: Option<String>,
 }
 
+/// Controls what happens when a slash command produces an empty turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SlashCommandCompletionBehavior {
+    Normal,
+    NeutralTipOnEmpty,
+}
+
 /// A slash command item available in a conversation session.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SlashCommandItem {
     pub command: String,
     pub description: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion_behavior: Option<SlashCommandCompletionBehavior>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub empty_turn_tip_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub empty_turn_tip_params: Option<serde_json::Value>,
 }

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -39,7 +39,7 @@ pub use acp::{
 pub use acp_prompt_hook::AcpPromptHookWarningPayload;
 pub use agent_build_extra::{
     AcpBuildExtra, AcpModelInfo, AionrsBuildExtra, OpenClawBuildExtra, OpenClawGatewayConfig, RemoteBuildExtra,
-    SessionMcpServer, SessionMcpTransport, SlashCommandItem,
+    SessionMcpServer, SessionMcpTransport, SlashCommandCompletionBehavior, SlashCommandItem,
 };
 pub use agent_discovery::{AgentEnvEntry, AgentHandshake, AgentMetadata, AgentSource, AgentSourceInfo, BehaviorPolicy};
 pub use agent_error::{

--- a/crates/aionui-conversation/src/service_test/acp_error_recovery_test.rs
+++ b/crates/aionui-conversation/src/service_test/acp_error_recovery_test.rs
@@ -9,7 +9,7 @@ async fn send_message_evicts_acp_task_after_terminal_error() {
     let scripted_agent = Arc::new(ScriptedAgent::new(
         &conv.id,
         vec![vec![AgentStreamEvent::Error(ErrorEventData::legacy(
-            "Agent completed the turn without producing visible output.",
+            "mock terminal error",
             Some(AgentErrorCode::UnknownUpstreamError),
         ))]],
     ));

--- a/crates/aionui-conversation/src/stream_persistence.rs
+++ b/crates/aionui-conversation/src/stream_persistence.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use aionui_ai_agent::protocol::events::{
-    ErrorEventData,
+    ErrorEventData, TipType, TipsEventData,
     tool_call::{AcpToolCallSessionUpdateKind, AcpToolCallStatus, ToolCallStatus},
 };
 use aionui_api_types::{ConversationRuntimeSummary, WebSocketMessage};
@@ -310,6 +310,39 @@ impl StreamPersistenceAdapter {
         };
         if let Err(e) = self.repo.insert_message(&row).await {
             log_persist_error(&e, "Failed to store error message");
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub async fn persist_tip(&self, data: &TipsEventData) {
+        if !self.allows_write(RuntimeWriteKind::TerminalFinalize) {
+            return;
+        }
+
+        let status = match data.tip_type {
+            TipType::Error => "error",
+            TipType::Success | TipType::Warning | TipType::Info => "finish",
+        };
+        let content = json!({
+            "content": &data.content,
+            "type": &data.tip_type,
+            "code": &data.code,
+            "params": &data.params,
+        })
+        .to_string();
+        let row = MessageRow {
+            id: ConversationService::mint_msg_id(),
+            conversation_id: self.conversation_id.clone(),
+            msg_id: None,
+            r#type: "tips".into(),
+            content,
+            position: Some("left".into()),
+            status: Some(status.into()),
+            hidden: false,
+            created_at: now_ms(),
+        };
+        if let Err(e) = self.repo.insert_message(&row).await {
+            log_persist_error(&e, "Failed to store tip message");
         }
     }
 

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use aionui_ai_agent::{AgentSendError, AgentStreamEvent, protocol::events::ThinkingEventData};
 use aionui_ai_agent::protocol::events::TipType;
+use aionui_ai_agent::{AgentSendError, AgentStreamEvent, protocol::events::ThinkingEventData};
 
 use crate::response_middleware::{ICronService, MessageMiddleware, MiddlewareResult};
 use aionui_api_types::{AgentErrorCode, WebSocketMessage};
@@ -801,12 +801,14 @@ mod tests {
 
         let rx = tx.subscribe();
 
-        tx.send(AgentStreamEvent::Tips(aionui_ai_agent::protocol::events::TipsEventData {
-            content: "Agent completed the turn without producing visible output.".into(),
-            tip_type: aionui_ai_agent::protocol::events::TipType::Warning,
-            code: None,
-            params: None,
-        }))
+        tx.send(AgentStreamEvent::Tips(
+            aionui_ai_agent::protocol::events::TipsEventData {
+                content: "Agent completed the turn without producing visible output.".into(),
+                tip_type: aionui_ai_agent::protocol::events::TipType::Warning,
+                code: None,
+                params: None,
+            },
+        ))
         .unwrap();
         tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
 

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use aionui_ai_agent::{AgentSendError, AgentStreamEvent, protocol::events::ThinkingEventData};
+use aionui_ai_agent::protocol::events::TipType;
 
 use crate::response_middleware::{ICronService, MessageMiddleware, MiddlewareResult};
 use aionui_api_types::{AgentErrorCode, WebSocketMessage};
@@ -334,6 +335,12 @@ impl StreamRelay {
                                 .await;
                             self.forward_to_websocket(&event);
                             self.adapter.persist_tool_group(entries).await;
+                        }
+                        AgentStreamEvent::Tips(data) => {
+                            self.forward_to_websocket(&event);
+                            if matches!(data.tip_type, TipType::Success | TipType::Warning | TipType::Info) {
+                                self.adapter.persist_tip(data).await;
+                            }
                         }
                         _ => {
                             self.forward_to_websocket(&event);
@@ -775,6 +782,50 @@ mod tests {
         let content: serde_json::Value = serde_json::from_str(&msg.content).unwrap();
         assert_eq!(content["content"], "Something went wrong");
         assert_eq!(content["type"], "error");
+    }
+
+    #[tokio::test]
+    async fn run_warning_tip_with_finish_persists_warning_tip() {
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let (tx, _) = broadcast::channel(64);
+
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+            None,
+        );
+
+        let rx = tx.subscribe();
+
+        tx.send(AgentStreamEvent::Tips(aionui_ai_agent::protocol::events::TipsEventData {
+            content: "Agent completed the turn without producing visible output.".into(),
+            tip_type: aionui_ai_agent::protocol::events::TipType::Warning,
+            code: None,
+            params: None,
+        }))
+        .unwrap();
+        tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
+
+        let outcome = relay.consume(rx).await;
+        assert!(outcome.system_responses.is_empty());
+        assert_eq!(outcome.terminal, RelayTerminal::Finish);
+
+        let inserts = repo.take_inserts();
+        assert_eq!(inserts.len(), 1);
+        let msg = &inserts[0];
+        assert_eq!(msg.r#type, "tips");
+        assert_eq!(msg.status.as_deref(), Some("finish"));
+
+        let content: serde_json::Value = serde_json::from_str(&msg.content).unwrap();
+        assert_eq!(
+            content["content"],
+            "Agent completed the turn without producing visible output."
+        );
+        assert_eq!(content["type"], "warning");
     }
 
     #[tokio::test]

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -803,9 +803,9 @@ mod tests {
 
         tx.send(AgentStreamEvent::Tips(
             aionui_ai_agent::protocol::events::TipsEventData {
-                content: "Agent completed the turn without producing visible output.".into(),
+                content: String::new(),
                 tip_type: aionui_ai_agent::protocol::events::TipType::Warning,
-                code: None,
+                code: Some("ACP_EMPTY_TURN".into()),
                 params: None,
             },
         ))
@@ -823,11 +823,9 @@ mod tests {
         assert_eq!(msg.status.as_deref(), Some("finish"));
 
         let content: serde_json::Value = serde_json::from_str(&msg.content).unwrap();
-        assert_eq!(
-            content["content"],
-            "Agent completed the turn without producing visible output."
-        );
+        assert_eq!(content["content"], "");
         assert_eq!(content["type"], "warning");
+        assert_eq!(content["code"], "ACP_EMPTY_TURN");
     }
 
     #[tokio::test]

--- a/crates/aionui-conversation/tests/stream_relay_tips.rs
+++ b/crates/aionui-conversation/tests/stream_relay_tips.rs
@@ -55,7 +55,7 @@ async fn persist_info_tip_preserves_code_and_params() {
 
     let rx = tx.subscribe();
     tx.send(AgentStreamEvent::Tips(TipsEventData {
-        content: "No visible output, but the command completed successfully.".into(),
+        content: String::new(),
         tip_type: TipType::Info,
         code: Some("ACP_EMPTY_TURN".into()),
         params: Some(json!({ "scope": "session", "cleared": 12 })),
@@ -75,10 +75,7 @@ async fn persist_info_tip_preserves_code_and_params() {
     assert_eq!(tip.status.as_deref(), Some("finish"));
 
     let content: serde_json::Value = serde_json::from_str(&tip.content).unwrap();
-    assert_eq!(
-        content["content"],
-        "No visible output, but the command completed successfully."
-    );
+    assert_eq!(content["content"], "");
     assert_eq!(content["type"], "info");
     assert_eq!(content["code"], "ACP_EMPTY_TURN");
     assert_eq!(content["params"], json!({ "scope": "session", "cleared": 12 }));

--- a/crates/aionui-conversation/tests/stream_relay_tips.rs
+++ b/crates/aionui-conversation/tests/stream_relay_tips.rs
@@ -57,7 +57,7 @@ async fn persist_info_tip_preserves_code_and_params() {
     tx.send(AgentStreamEvent::Tips(TipsEventData {
         content: "No visible output, but the command completed successfully.".into(),
         tip_type: TipType::Info,
-        code: Some("ACP_CTX_FLUSH_COMPLETED".into()),
+        code: Some("ACP_EMPTY_TURN".into()),
         params: Some(json!({ "scope": "session", "cleared": 12 })),
     }))
     .unwrap();
@@ -80,6 +80,6 @@ async fn persist_info_tip_preserves_code_and_params() {
         "No visible output, but the command completed successfully."
     );
     assert_eq!(content["type"], "info");
-    assert_eq!(content["code"], "ACP_CTX_FLUSH_COMPLETED");
+    assert_eq!(content["code"], "ACP_EMPTY_TURN");
     assert_eq!(content["params"], json!({ "scope": "session", "cleared": 12 }));
 }

--- a/crates/aionui-conversation/tests/stream_relay_tips.rs
+++ b/crates/aionui-conversation/tests/stream_relay_tips.rs
@@ -75,7 +75,10 @@ async fn persist_info_tip_preserves_code_and_params() {
     assert_eq!(tip.status.as_deref(), Some("finish"));
 
     let content: serde_json::Value = serde_json::from_str(&tip.content).unwrap();
-    assert_eq!(content["content"], "No visible output, but the command completed successfully.");
+    assert_eq!(
+        content["content"],
+        "No visible output, but the command completed successfully."
+    );
     assert_eq!(content["type"], "info");
     assert_eq!(content["code"], "ACP_CTX_FLUSH_COMPLETED");
     assert_eq!(content["params"], json!({ "scope": "session", "cleared": 12 }));

--- a/crates/aionui-conversation/tests/stream_relay_tips.rs
+++ b/crates/aionui-conversation/tests/stream_relay_tips.rs
@@ -1,0 +1,82 @@
+use std::sync::Arc;
+
+use aionui_ai_agent::{
+    AgentStreamEvent,
+    protocol::events::{FinishEventData, TipType, TipsEventData},
+};
+use aionui_common::now_ms;
+use aionui_conversation::stream_relay::StreamRelay;
+use aionui_db::{
+    IConversationRepository, SortOrder, SqliteConversationRepository, init_database_memory, models::ConversationRow,
+};
+use aionui_realtime::BroadcastEventBus;
+use serde_json::json;
+use tokio::sync::broadcast;
+
+async fn setup_repo() -> (Arc<SqliteConversationRepository>, aionui_db::Database) {
+    let db = init_database_memory().await.unwrap();
+    let repo = Arc::new(SqliteConversationRepository::new(db.pool().clone()));
+    let now = now_ms();
+    repo.create(&ConversationRow {
+        id: "conv-1".into(),
+        user_id: "system_default_user".into(),
+        name: "Stream relay tips test".into(),
+        r#type: "acp".into(),
+        extra: "{}".into(),
+        model: None,
+        status: Some("running".into()),
+        source: Some("aionui".into()),
+        channel_chat_id: None,
+        pinned: false,
+        pinned_at: None,
+        created_at: now,
+        updated_at: now,
+    })
+    .await
+    .unwrap();
+
+    (repo, db)
+}
+
+#[tokio::test]
+async fn persist_info_tip_preserves_code_and_params() {
+    let (repo, _db) = setup_repo().await;
+    let bus = Arc::new(BroadcastEventBus::new(64));
+    let (tx, _) = broadcast::channel(64);
+
+    let relay = StreamRelay::new(
+        "conv-1".into(),
+        "asst-1".into(),
+        "system_default_user".into(),
+        repo.clone(),
+        bus,
+        None,
+    );
+
+    let rx = tx.subscribe();
+    tx.send(AgentStreamEvent::Tips(TipsEventData {
+        content: "No visible output, but the command completed successfully.".into(),
+        tip_type: TipType::Info,
+        code: Some("ACP_CTX_FLUSH_COMPLETED".into()),
+        params: Some(json!({ "scope": "session", "cleared": 12 })),
+    }))
+    .unwrap();
+    tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
+
+    relay.consume(rx).await;
+
+    let messages = repo.get_messages("conv-1", 1, 100, SortOrder::Asc).await.unwrap();
+    let tip = messages
+        .items
+        .iter()
+        .find(|row| row.r#type == "tips")
+        .expect("info tip should be persisted");
+
+    assert_eq!(tip.status.as_deref(), Some("finish"));
+
+    let content: serde_json::Value = serde_json::from_str(&tip.content).unwrap();
+    assert_eq!(content["content"], "No visible output, but the command completed successfully.");
+    assert_eq!(content["type"], "info");
+    assert_eq!(content["code"], "ACP_CTX_FLUSH_COMPLETED");
+    assert_eq!(content["params"], json!({ "scope": "session", "cleared": 12 }));
+}


### PR DESCRIPTION
## Summary
- unify benign ACP no-output turns under `ACP_EMPTY_TURN`
- stop using command-specific tip copy for metadata-driven empty turns
- align backend tests with the generic empty-turn semantics

## Verification
- CARGO_TARGET_DIR=/tmp/aioncore-pr-target cargo test -p aionui-ai-agent metadata_driven_command_empty_turn_uses_command_tip_code
- CARGO_TARGET_DIR=/tmp/aioncore-pr-target cargo test -p aionui-ai-agent matches_leading_slash_token_against_advertised_commands
- CARGO_TARGET_DIR=/tmp/aioncore-pr-target cargo test -p aionui-conversation persist_info_tip_preserves_code_and_params