### PR TITLE
fix(acp): preserve confirmed model selection

### DIFF
--- a/crates/aionui-ai-agent/src/agent_task.rs
+++ b/crates/aionui-ai-agent/src/agent_task.rs
@@ -120,6 +120,10 @@ pub trait IMockAgent: IAgentTask {
             "Model switching is not supported for this mock",
         ))
     }
+    async fn set_model_confirmed(&self, model_id: &str) -> Result<GetModelInfoResponse, AgentError> {
+        self.set_model(model_id).await?;
+        self.get_model().await
+    }
     async fn get_usage(&self) -> Result<Option<serde_json::Value>, AgentError> {
         Ok(None)
     }
@@ -349,6 +353,25 @@ impl AgentInstance {
             )),
             #[cfg(any(test, feature = "test-support"))]
             Self::Mock(m) => m.set_model(model_id).await,
+        }
+    }
+
+    /// Switch the active model and return the confirmed model payload for
+    /// this specific mutation, rather than re-reading potentially stale
+    /// cached state.
+    pub async fn set_model_confirmed(&self, model_id: &str) -> Result<GetModelInfoResponse, AgentError> {
+        if model_id.trim().is_empty() {
+            return Err(AgentError::bad_request("model_id must not be empty"));
+        }
+        match self {
+            Self::Acp(m) => Ok(GetModelInfoResponse {
+                model_info: Some(map_sdk_model_to_payload(m.set_model_confirmed(model_id).await?)),
+            }),
+            Self::Aionrs(_) => Err(AgentError::bad_request(
+                "Model switching is not supported for this agent type",
+            )),
+            #[cfg(any(test, feature = "test-support"))]
+            Self::Mock(m) => m.set_model_confirmed(model_id).await,
         }
     }
 

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -514,8 +514,7 @@ impl AcpAgentManager {
         Ok(())
     }
 
-    /// Set the model for the current session.
-    pub(crate) async fn set_model(&self, model_id: &str) -> Result<(), AgentError> {
+    async fn apply_confirmed_model_selection(&self, model_id: &str) -> Result<SessionModelState, AgentError> {
         let session_id = {
             let session = self.session.read().await;
             if !session.can_select_model(model_id) {
@@ -582,6 +581,10 @@ impl AcpAgentManager {
         if self.params.metadata.behavior_policy.self_identity_sticky {
             session.set_pending_model_notice(model);
         }
+        let confirmed_model = session
+            .model_info()
+            .cloned()
+            .unwrap_or_else(|| SessionModelState::new(model_id.to_owned(), Vec::new()));
         self.commit_session_changes(&mut session).await;
         info!(
             conversation_id = %self.params.conversation_id,
@@ -589,7 +592,19 @@ impl AcpAgentManager {
             confirmed_model_id = %model_id,
             "acp_set_model_confirmed"
         );
+        Ok(confirmed_model)
+    }
+
+    /// Set the model for the current session.
+    pub(crate) async fn set_model(&self, model_id: &str) -> Result<(), AgentError> {
+        self.apply_confirmed_model_selection(model_id).await?;
         Ok(())
+    }
+
+    /// Set the model and return the confirmed model state from this write,
+    /// without re-reading the asynchronously mutable session cache.
+    pub(crate) async fn set_model_confirmed(&self, model_id: &str) -> Result<SessionModelState, AgentError> {
+        self.apply_confirmed_model_selection(model_id).await
     }
 
     /// Return available slash commands from the session aggregate.

--- a/crates/aionui-ai-agent/src/manager/acp/session.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session.rs
@@ -469,6 +469,24 @@ impl AcpSession {
         }
     }
 
+    fn preserve_desired_model_in_catalog(&self, models: SessionModelState) -> SessionModelState {
+        let Some(desired_model) = self.desired.model_id.as_ref() else {
+            return models;
+        };
+        let desired_model_id = desired_model.as_str();
+        if models.current_model_id.to_string() == desired_model_id {
+            return models;
+        }
+        if models
+            .available_models
+            .iter()
+            .any(|model| model.model_id.to_string() == desired_model_id)
+        {
+            return SessionModelState::new(desired_model_id.to_owned(), models.available_models.clone());
+        }
+        models
+    }
+
     pub fn apply_advertised_config_options(&mut self, options: Vec<SessionConfigOption>) {
         let options = merge_config_options(self.advertised.config_options.as_deref(), options);
 
@@ -477,7 +495,7 @@ impl AcpSession {
         }
 
         if let Some(models) = derive_models_from_config_options(&options) {
-            self.apply_advertised_models(models);
+            self.apply_advertised_models(self.preserve_desired_model_in_catalog(models));
         }
 
         let mut changed = false;

--- a/crates/aionui-ai-agent/src/manager/acp/session_tests.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session_tests.rs
@@ -717,6 +717,68 @@ fn apply_advertised_config_options_merges_partial_updates_and_derives_model_reas
 }
 
 #[test]
+fn apply_advertised_config_options_preserves_confirmed_explicit_model_when_current_values_lag() {
+    let mut session = make_session();
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "model",
+            "Model",
+            "gpt-5.5",
+            vec![
+                SessionConfigSelectOption::new("gpt-5.5", "GPT-5.5"),
+                SessionConfigSelectOption::new("gpt-5.4", "GPT-5.4"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::Model),
+        SessionConfigOption::select(
+            "reasoning_effort",
+            "Reasoning Effort",
+            "low",
+            vec![
+                SessionConfigSelectOption::new("low", "Low"),
+                SessionConfigSelectOption::new("medium", "Medium"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel),
+    ]);
+    session.drain_events();
+
+    session.confirm_model(ModelId::new("gpt-5.5/medium"));
+    session.drain_events();
+
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "model",
+            "Model",
+            "gpt-5.5",
+            vec![
+                SessionConfigSelectOption::new("gpt-5.5", "GPT-5.5"),
+                SessionConfigSelectOption::new("gpt-5.4", "GPT-5.4"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::Model),
+        SessionConfigOption::select(
+            "reasoning_effort",
+            "Reasoning Effort",
+            "low",
+            vec![
+                SessionConfigSelectOption::new("low", "Low"),
+                SessionConfigSelectOption::new("medium", "Medium"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel),
+    ]);
+
+    let models = session.model_info().expect("model catalog");
+    assert_eq!(
+        models.current_model_id.to_string(),
+        "gpt-5.5/medium",
+        "lagging config option current values must not overwrite an explicitly confirmed model"
+    );
+    assert_eq!(models.available_models.len(), 4);
+}
+
+#[test]
 fn pending_model_notice_roundtrip_and_take_once() {
     use crate::shared_kernel::ModelId;
 

--- a/crates/aionui-conversation/src/service_ops.rs
+++ b/crates/aionui-conversation/src/service_ops.rs
@@ -75,8 +75,9 @@ impl ConversationService {
                 return Err(err);
             }
         };
-        task.set_model(&req.model_id).await.map_err(ConversationError::from)?;
-        task.get_model().await.map_err(ConversationError::from)
+        task.set_model_confirmed(&req.model_id)
+            .await
+            .map_err(ConversationError::from)
     }
 
     // ── Usage / Slash commands ──────────────────────────────────────

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1357,6 +1357,7 @@ struct MockAgent {
     stopped: Mutex<bool>,
     mode: Mutex<String>,
     model_id: Mutex<String>,
+    keep_reported_model_on_set: bool,
     confirmations: Mutex<Vec<Confirmation>>,
     approval_memory: Mutex<std::collections::HashMap<String, bool>>,
     allow_direct_confirm: bool,
@@ -1365,6 +1366,25 @@ struct MockAgent {
 }
 
 impl MockAgent {
+    fn build_model_response(current: &str) -> GetModelInfoResponse {
+        GetModelInfoResponse {
+            model_info: Some(ModelInfoPayload {
+                current_model_id: Some(current.to_owned()),
+                current_model_label: Some(current.to_owned()),
+                available_models: vec![
+                    ModelInfoEntry {
+                        id: "model-a".to_owned(),
+                        label: "Model A".to_owned(),
+                    },
+                    ModelInfoEntry {
+                        id: "model-b".to_owned(),
+                        label: "Model B".to_owned(),
+                    },
+                ],
+            }),
+        }
+    }
+
     fn new(conversation_id: &str) -> Self {
         let (event_tx, _) = broadcast::channel(64);
         Self {
@@ -1373,6 +1393,7 @@ impl MockAgent {
             stopped: Mutex::new(false),
             mode: Mutex::new("default".to_owned()),
             model_id: Mutex::new("model-a".to_owned()),
+            keep_reported_model_on_set: false,
             confirmations: Mutex::new(vec![]),
             approval_memory: Mutex::new(std::collections::HashMap::new()),
             allow_direct_confirm: false,
@@ -1388,6 +1409,7 @@ impl MockAgent {
             stopped: Mutex::new(false),
             mode: Mutex::new("default".to_owned()),
             model_id: Mutex::new("model-a".to_owned()),
+            keep_reported_model_on_set: false,
             confirmations: Mutex::new(confirmations),
             approval_memory: Mutex::new(std::collections::HashMap::new()),
             allow_direct_confirm: false,
@@ -1403,9 +1425,26 @@ impl MockAgent {
             stopped: Mutex::new(false),
             mode: Mutex::new("default".to_owned()),
             model_id: Mutex::new("model-a".to_owned()),
+            keep_reported_model_on_set: false,
             confirmations: Mutex::new(vec![]),
             approval_memory: Mutex::new(std::collections::HashMap::new()),
             allow_direct_confirm: true,
+            workspace_override: None,
+        }
+    }
+
+    fn with_stale_reported_model_after_set(conversation_id: &str) -> Self {
+        let (event_tx, _) = broadcast::channel(64);
+        Self {
+            conversation_id: conversation_id.to_owned(),
+            event_tx,
+            stopped: Mutex::new(false),
+            mode: Mutex::new("default".to_owned()),
+            model_id: Mutex::new("model-a".to_owned()),
+            keep_reported_model_on_set: true,
+            confirmations: Mutex::new(vec![]),
+            approval_memory: Mutex::new(std::collections::HashMap::new()),
+            allow_direct_confirm: false,
             workspace_override: None,
         }
     }
@@ -1497,27 +1536,19 @@ impl IMockAgent for MockAgent {
 
     async fn get_model(&self) -> Result<GetModelInfoResponse, AgentError> {
         let current = self.model_id.lock().unwrap().clone();
-        Ok(GetModelInfoResponse {
-            model_info: Some(ModelInfoPayload {
-                current_model_id: Some(current.clone()),
-                current_model_label: Some(current.clone()),
-                available_models: vec![
-                    ModelInfoEntry {
-                        id: "model-a".to_owned(),
-                        label: "Model A".to_owned(),
-                    },
-                    ModelInfoEntry {
-                        id: "model-b".to_owned(),
-                        label: "Model B".to_owned(),
-                    },
-                ],
-            }),
-        })
+        Ok(Self::build_model_response(&current))
     }
 
     async fn set_model(&self, model_id: &str) -> Result<(), AgentError> {
-        *self.model_id.lock().unwrap() = model_id.to_owned();
+        if !self.keep_reported_model_on_set {
+            *self.model_id.lock().unwrap() = model_id.to_owned();
+        }
         Ok(())
+    }
+
+    async fn set_model_confirmed(&self, model_id: &str) -> Result<GetModelInfoResponse, AgentError> {
+        self.set_model(model_id).await?;
+        Ok(Self::build_model_response(model_id))
     }
 }
 
@@ -2099,6 +2130,40 @@ async fn set_model_returns_confirmed_model_from_active_agent() {
     let model_info = response.model_info.expect("model info should be returned");
     assert_eq!(model_info.current_model_id.as_deref(), Some("model-b"));
     assert!(model_info.available_models.iter().any(|m| m.id == "model-b"));
+}
+
+#[tokio::test]
+async fn set_model_returns_confirmed_model_even_if_get_model_is_stale() {
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let (svc, _broadcaster, _repo) = make_service_with_mock_task_manager(task_mgr.clone());
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+    let agent = Arc::new(MockAgent::with_stale_reported_model_after_set(&conv.id));
+    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(agent.clone()));
+
+    let response = svc
+        .set_model(
+            &conv.id,
+            SetModelRequest {
+                model_id: "model-b".to_owned(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let model_info = response.model_info.expect("model info should be returned");
+    assert_eq!(
+        model_info.current_model_id.as_deref(),
+        Some("model-b"),
+        "set_model should return the confirmed model, not a stale get_model snapshot"
+    );
+
+    let stale_model_info = agent
+        .get_model()
+        .await
+        .unwrap()
+        .model_info
+        .expect("mock agent should still report model info");
+    assert_eq!(stale_model_info.current_model_id.as_deref(), Some("model-a"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- return the confirmed model payload from `PUT /api/conversations/:id/model` instead of re-reading stale session state
- preserve explicitly confirmed ACP model selections when lagging config-option updates still advertise the selected variant
- add regressions for stale `get_model()` responses and lagging config-option current values

## Test Plan
- cargo fmt --all --check
- cargo clippy -p aionui-ai-agent -p aionui-conversation -- -D warnings
- cargo test -p aionui-ai-agent -p aionui-conversation
- just push -u origin fix/acp-confirmed-model-selection