### PR TITLE
fix(app): use process synchronize access for parent watcher

### DIFF
--- a/crates/aionui-app/src/bootstrap/parent_exit.rs
+++ b/crates/aionui-app/src/bootstrap/parent_exit.rs
@@ -32,11 +32,11 @@ async fn wait_for_parent_exit(parent_pid: u32) {
 fn wait_for_parent_exit_blocking(parent_pid: u32) {
     use windows_sys::Win32::Foundation::{CloseHandle, WAIT_OBJECT_0};
     use windows_sys::Win32::System::Threading::{
-        INFINITE, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, SYNCHRONIZE, WaitForSingleObject,
+        INFINITE, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, WaitForSingleObject,
     };
 
     unsafe {
-        let handle = OpenProcess(SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, 0, parent_pid);
+        let handle = OpenProcess(PROCESS_SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, 0, parent_pid);
         if handle.is_null() {
             return;
         }


### PR DESCRIPTION
## Summary
- Replace the invalid `windows-sys` `SYNCHRONIZE` import with `PROCESS_SYNCHRONIZE` for the Windows parent-process watcher.
- Keep the existing `OpenProcess` wait logic unchanged while using the process-specific access-right constant available in `windows-sys` 0.61.
- Restore the Windows release build path broken by the `parent_exit.rs` import error.

## Test Plan
- `cargo +1.95.0 check --target x86_64-pc-windows-msvc` in a minimal `windows-sys` repro crate fails with `SYNCHRONIZE` and passes with `PROCESS_SYNCHRONIZE`.
- `cargo fmt --all -- --check`
- `cargo test -p aionui-app parent_exit_signal`
- `git diff --check`
- `just push -u origin fix/windows-release-build` (migration check, cargo fix, clippy fix, fmt, `cargo nextest run --workspace`: 5993 passed, 18 skipped, then push)

## Notes
- A full local `cargo check -p aionui-app --target x86_64-pc-windows-msvc --message-format short` on macOS cannot complete here because the host lacks Windows C/SDK headers for transitive C dependencies (`ring` / `aws-lc-sys`). The previous Rust import error is fixed by the minimal target repro above.
