### PR TITLE
fix(office): resolve officecli shim from node_modules/.bin after npm prefix install

### DIFF
--- a/crates/aionui-office/src/officecli_runtime.rs
+++ b/crates/aionui-office/src/officecli_runtime.rs
@@ -10,12 +10,15 @@ pub(crate) fn officecli_prefix(data_dir: &Path) -> PathBuf {
 
 pub(crate) fn resolve_officecli_path(data_dir: &Path) -> Option<PathBuf> {
     let prefix = officecli_prefix(data_dir);
-    let bin = if cfg!(windows) {
-        prefix.join("bin").join("officecli.cmd")
-    } else {
-        prefix.join("bin").join("officecli")
-    };
-    bin.is_file().then_some(bin)
+    let shim_name = if cfg!(windows) { "officecli.cmd" } else { "officecli" };
+    let candidates = [
+        prefix.join("bin").join(shim_name),
+        // `npm install --prefix <dir> officecli` (see install_officecli) is a
+        // local-style install: the executable shim lands in
+        // <dir>/node_modules/.bin, and <dir>/bin is never created.
+        prefix.join("node_modules").join(".bin").join(shim_name),
+    ];
+    candidates.into_iter().find(|bin| bin.is_file())
 }
 
 pub(crate) async fn resolve_officecli_command(data_dir: &Path) -> Result<ResolvedCommand, OfficeError> {

--- a/crates/aionui-office/src/watch_manager.rs
+++ b/crates/aionui-office/src/watch_manager.rs
@@ -538,6 +538,24 @@ mod tests {
         assert_eq!(path, managed_bin);
     }
 
+    #[test]
+    fn officecli_resolves_npm_prefix_install_layout() {
+        // `npm install --prefix <dir> officecli` (see install_officecli) is a
+        // local-style install: the executable shim lands in
+        // <dir>/node_modules/.bin, and <dir>/bin is never created.
+        let tmp = tempfile::tempdir().unwrap();
+        let shim_name = if cfg!(windows) { "officecli.cmd" } else { "officecli" };
+        let npm_shim = tmp
+            .path()
+            .join("runtime/node/tools/officecli/node_modules/.bin")
+            .join(shim_name);
+        std::fs::create_dir_all(npm_shim.parent().unwrap()).unwrap();
+        std::fs::write(&npm_shim, b"#!/bin/sh\nexit 0\n").unwrap();
+
+        let path = resolve_officecli_path(tmp.path()).expect("npm-installed officecli");
+        assert_eq!(path, npm_shim);
+    }
+
     #[tokio::test]
     async fn start_creates_session() {
         let spawner = Arc::new(MockSpawner::new());


### PR DESCRIPTION
## Summary

Office preview (PPT/Word/Excel) has been permanently broken since #403: every preview start returns `OFFICECLI_NOT_FOUND` (surfaced in AionUi as "未安装 officecli" / "自动安装 officecli 失败"), even though the auto-install succeeds.

Root cause: `install_officecli` runs `npm install --prefix <dir> officecli`, which is a **local-style** install — the executable shim lands in `<dir>/node_modules/.bin/` and `<dir>/bin/` is never created. But `resolve_officecli_path` only checks `<dir>/bin/officecli(.cmd)`, so resolution fails forever and each retry reinstalls and fails again.

Reproduced end-to-end against a release `aioncore` binary in `--local` mode with a fresh data dir:

1. `POST /api/ppt-preview/start` → `{"error":"OFFICECLI_NOT_FOUND"}` while `<data>/runtime/node/tools/officecli/node_modules/.bin/officecli` exists and `<data>/.../officecli/bin/` does not.
2. With this fix (fresh data dir): the shim is resolved and spawned.

Related user reports: iOfficeAI/AionUi#3252, iOfficeAI/AionUi#3228, iOfficeAI/AionUi#3205, iOfficeAI/AionUi#3098, iOfficeAI/AionUi#3118.

## Changes

- `resolve_officecli_path` now also checks `<prefix>/node_modules/.bin/officecli(.cmd)` — the layout that `npm install --prefix` actually produces. `<prefix>/bin/` remains the preferred location for manually provisioned binaries.
- Regression test `officecli_resolves_npm_prefix_install_layout` (fails on main, passes here).

## Known remaining issue (separate, not fixed here)

Even with resolution fixed, the npm channel of officecli is stale: `officecli@0.2.106` (latest on npm, 2026-05-29) no longer ships the `watch` subcommand — it drops into TUI bootstrap and exits ("officecli TUI requires a TTY"), so preview start ends in `OFFICECLI_PORT_TIMEOUT`. The GitHub-release channel (v1.0.108) does have `watch`; I verified the full preview flow works end-to-end with this fix once a watch-capable binary is at the resolved path (`/api/ppt-preview/start` returns a working proxy URL). Restoring preview for end users additionally needs a watch-capable officecli published to npm (or switching the installer channel).

## Testing

- `cargo test -p aionui-office` (179 passed, includes new regression test)
- `cargo clippy --workspace -- -D warnings`, `cargo fmt`, migration check, full `cargo test --workspace` — all clean
- Manual E2E as described above