### PR TITLE
Revert "fix(office): resolve officecli shim from node_modules/.bin after npm prefix install"

### DIFF
--- a/crates/aionui-office/src/officecli_runtime.rs
+++ b/crates/aionui-office/src/officecli_runtime.rs
@@ -10,15 +10,12 @@ pub(crate) fn officecli_prefix(data_dir: &Path) -> PathBuf {
 
 pub(crate) fn resolve_officecli_path(data_dir: &Path) -> Option<PathBuf> {
     let prefix = officecli_prefix(data_dir);
-    let shim_name = if cfg!(windows) { "officecli.cmd" } else { "officecli" };
-    let candidates = [
-        prefix.join("bin").join(shim_name),
-        // `npm install --prefix <dir> officecli` (see install_officecli) is a
-        // local-style install: the executable shim lands in
-        // <dir>/node_modules/.bin, and <dir>/bin is never created.
-        prefix.join("node_modules").join(".bin").join(shim_name),
-    ];
-    candidates.into_iter().find(|bin| bin.is_file())
+    let bin = if cfg!(windows) {
+        prefix.join("bin").join("officecli.cmd")
+    } else {
+        prefix.join("bin").join("officecli")
+    };
+    bin.is_file().then_some(bin)
 }
 
 pub(crate) async fn resolve_officecli_command(data_dir: &Path) -> Result<ResolvedCommand, OfficeError> {

--- a/crates/aionui-office/src/watch_manager.rs
+++ b/crates/aionui-office/src/watch_manager.rs
@@ -538,24 +538,6 @@ mod tests {
         assert_eq!(path, managed_bin);
     }
 
-    #[test]
-    fn officecli_resolves_npm_prefix_install_layout() {
-        // `npm install --prefix <dir> officecli` (see install_officecli) is a
-        // local-style install: the executable shim lands in
-        // <dir>/node_modules/.bin, and <dir>/bin is never created.
-        let tmp = tempfile::tempdir().unwrap();
-        let shim_name = if cfg!(windows) { "officecli.cmd" } else { "officecli" };
-        let npm_shim = tmp
-            .path()
-            .join("runtime/node/tools/officecli/node_modules/.bin")
-            .join(shim_name);
-        std::fs::create_dir_all(npm_shim.parent().unwrap()).unwrap();
-        std::fs::write(&npm_shim, b"#!/bin/sh\nexit 0\n").unwrap();
-
-        let path = resolve_officecli_path(tmp.path()).expect("npm-installed officecli");
-        assert_eq!(path, npm_shim);
-    }
-
     #[tokio::test]
     async fn start_creates_session() {
         let spawner = Arc::new(MockSpawner::new());


### PR DESCRIPTION
Reverts iOfficeAI/AionCore#440