### PR TITLE
fix(ai-agent): trim stderr buffer at UTF-8 char boundary

### DIFF
--- a/crates/aionui-ai-agent/src/capability/cli_process/mod.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/mod.rs
@@ -18,6 +18,18 @@ use stderr_monitor::force_kill;
 /// Maximum stderr ring-buffer size in bytes.
 pub(super) const STDERR_BUFFER_MAX: usize = 8192;
 
+/// Trim `buf` from the front so it holds at most the last `max` bytes.
+///
+/// The raw cut point can land inside a multi-byte UTF-8 character, where
+/// `String::drain` would panic; rounding up to the next char boundary keeps
+/// the buffer valid and never exceeds `max` (issue #392).
+pub(super) fn trim_to_tail(buf: &mut String, max: usize) {
+    if buf.len() > max {
+        let cut = buf.ceil_char_boundary(buf.len() - max);
+        buf.drain(..cut);
+    }
+}
+
 pub(super) fn prepare_command_cwd(cwd: &str) -> Result<PathBuf, AgentError> {
     if cwd.trim().is_empty() {
         return Err(AgentError::bad_request("Workspace directory is empty"));
@@ -236,6 +248,46 @@ pub(super) mod tests {
     pub(super) async fn spawn_sdk_test_process(config: CommandSpec) -> CliAgentProcess {
         let data_dir = tempfile::tempdir().unwrap();
         CliAgentProcess::spawn_for_sdk(config, data_dir.path()).await.unwrap()
+    }
+
+    // ── trim_to_tail ─────────────────────────────────────────────────
+
+    #[test]
+    fn trim_to_tail_does_not_panic_when_cut_lands_inside_multibyte_char() {
+        // "ab" (2 bytes) + "中中中" (9 bytes) = 11 bytes; max 8 puts the raw
+        // cut point at byte 3, inside the first '中' (bytes 2..5).
+        let mut buf = String::from("ab中中中");
+        trim_to_tail(&mut buf, 8);
+        assert_eq!(buf, "中中");
+        assert!(buf.len() <= 8);
+    }
+
+    #[test]
+    fn trim_to_tail_keeps_exactly_max_bytes_for_ascii() {
+        let mut buf = String::from("abcdefghij");
+        trim_to_tail(&mut buf, 8);
+        assert_eq!(buf, "cdefghij");
+    }
+
+    #[test]
+    fn trim_to_tail_is_noop_when_under_max() {
+        let mut buf = String::from("short");
+        trim_to_tail(&mut buf, 8);
+        assert_eq!(buf, "short");
+    }
+
+    #[test]
+    fn trim_to_tail_never_exceeds_max_with_emoji_flood() {
+        // Regression for the production panic: emoji-rich stderr lines pushed
+        // the buffer over STDERR_BUFFER_MAX with cut points off-boundary.
+        let mut buf = String::new();
+        for _ in 0..600 {
+            buf.push_str("⚠️ API call failed 🌐\n");
+        }
+        let original = buf.clone();
+        trim_to_tail(&mut buf, STDERR_BUFFER_MAX);
+        assert!(buf.len() <= STDERR_BUFFER_MAX);
+        assert!(original.ends_with(buf.as_str()));
     }
 
     // ── Lifecycle tests (apply to both modes) ────────────────────────

--- a/crates/aionui-ai-agent/src/capability/cli_process/spawn_sdk.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/spawn_sdk.rs
@@ -84,10 +84,7 @@ impl CliAgentProcess {
                 let mut buf = stderr_buf_clone.lock().await;
                 buf.push_str(&line);
                 buf.push('\n');
-                if buf.len() > STDERR_BUFFER_MAX {
-                    let cut = buf.len() - STDERR_BUFFER_MAX;
-                    buf.drain(..cut);
-                }
+                super::trim_to_tail(&mut buf, STDERR_BUFFER_MAX);
             }
 
             debug!(pid, "Stderr reader finished");


### PR DESCRIPTION
## Problem

`String::drain(..cut)` in the SDK-mode stderr reader panics with `assertion failed: self.is_char_boundary(end)` when the cut point lands inside a multi-byte UTF-8 character (emoji, CJK, accented chars). Any agent subprocess whose accumulated stderr exceeds `STDERR_BUFFER_MAX` (8192 bytes) with multi-byte content can trigger it, killing the stderr reader task and losing crash diagnostics.

Reproduced on rustc 1.95.0 with the exact panic signature reported in the issues.

## Fix

Extract the trim logic into `trim_to_tail(buf, max)` in `cli_process/mod.rs`, which rounds the cut point **up** to the next char boundary via `ceil_char_boundary`. This keeps the buffer valid UTF-8 and guarantees `buf.len() <= max` (floor rounding would let the buffer exceed the cap by up to 3 bytes).

## Tests

Four unit tests added (written first, TDD):
- cut point inside a multi-byte char (the panic case)
- exact trim for ASCII
- no-op when under max
- emoji-flood regression mirroring the reported production logs, asserting the result stays under `STDERR_BUFFER_MAX` and is a valid suffix of the original buffer

`just push` gate passed: fmt, clippy `-D warnings`, full workspace test suite (5997 passed).

## Note on severity

The panic occurs inside a `tokio::spawn`ed task; with the workspace's default `panic = unwind` it kills only the stderr reader task, not the whole process — the "full application crash" claim in the issues does not match this codebase unless downstream packaging builds with `panic = abort`. The panic is real and worth fixing regardless.

Fixes #392
Fixes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)