### PR TITLE
fix(office): restore OfficeCLI installer resolution

### DIFF
--- a/crates/aionui-office/src/conversion.rs
+++ b/crates/aionui-office/src/conversion.rs
@@ -14,22 +14,15 @@ use crate::officecli_runtime::resolve_officecli_path;
 
 pub struct ConversionService {
     officecli_path: Option<String>,
-    data_dir: Option<PathBuf>,
 }
 
 impl ConversionService {
     pub fn new(officecli_path: Option<String>) -> Self {
-        Self {
-            officecli_path,
-            data_dir: None,
-        }
+        Self { officecli_path }
     }
 
-    pub fn with_data_dir(officecli_path: Option<String>, data_dir: PathBuf) -> Self {
-        Self {
-            officecli_path,
-            data_dir: Some(data_dir),
-        }
+    pub fn with_data_dir(officecli_path: Option<String>, _data_dir: PathBuf) -> Self {
+        Self { officecli_path }
     }
 
     pub async fn convert(
@@ -128,7 +121,7 @@ impl ConversionService {
     async fn ppt_to_json(&self, file_path: &str) -> Result<Value, OfficeError> {
         validate_file_exists(file_path)?;
 
-        let officecli = resolve_officecli(&self.officecli_path, self.data_dir.as_deref()).await?;
+        let officecli = resolve_officecli(&self.officecli_path).await?;
 
         let mut builder = CmdBuilder::clean_cli(&officecli);
         builder.args(["ppt2json", file_path]);
@@ -238,25 +231,19 @@ fn find_executable(name: &str) -> Option<String> {
     which::which(name).ok().map(|p| p.to_string_lossy().into_owned())
 }
 
-async fn resolve_officecli(configured_path: &Option<String>, data_dir: Option<&Path>) -> Result<String, OfficeError> {
+async fn resolve_officecli(configured_path: &Option<String>) -> Result<String, OfficeError> {
     if let Some(path) = configured_path
         && Path::new(path).exists()
     {
         return Ok(path.clone());
     }
 
-    if let Some(data_dir) = data_dir
-        && let Some(path) = resolve_officecli_path(data_dir)
-    {
+    if let Some(path) = resolve_officecli_path() {
         return Ok(path.to_string_lossy().into_owned());
     }
 
-    if let Some(found) = find_executable("officecli") {
-        return Ok(found);
-    }
-
     Err(OfficeError::ToolNotFound(
-        "officecli not installed. Install it to enable PPT → JSON conversion".into(),
+        "officecli not installed. Install iOfficeAI/OfficeCli to enable PPT -> JSON conversion".into(),
     ))
 }
 
@@ -326,29 +313,26 @@ mod tests {
     fn conversion_service_new() {
         let svc = ConversionService::new(None);
         assert!(svc.officecli_path.is_none());
-        assert!(svc.data_dir.is_none());
 
         let svc = ConversionService::new(Some("/usr/local/bin/officecli".into()));
         assert_eq!(svc.officecli_path.as_deref(), Some("/usr/local/bin/officecli"));
-        assert!(svc.data_dir.is_none());
 
         let svc = ConversionService::with_data_dir(None, PathBuf::from("/tmp/aionui"));
-        assert_eq!(svc.data_dir.as_deref(), Some(Path::new("/tmp/aionui")));
+        assert!(svc.officecli_path.is_none());
     }
 
-    #[cfg(unix)]
     #[tokio::test]
-    async fn resolve_officecli_prefers_managed_prefix_when_available() {
+    async fn resolve_officecli_without_config_ignores_legacy_managed_prefix() {
         let tmp = tempfile::tempdir().unwrap();
-        let managed_bin = tmp.path().join("runtime/node/tools/officecli/bin/officecli");
-        std::fs::create_dir_all(managed_bin.parent().unwrap()).unwrap();
-        std::fs::write(&managed_bin, b"#!/bin/sh\nexit 0\n").unwrap();
+        let legacy_bin = ["runtime", "node", "tools", "officecli", "bin", "officecli"]
+            .into_iter()
+            .fold(tmp.path().to_path_buf(), |path, segment| path.join(segment));
+        std::fs::create_dir_all(legacy_bin.parent().unwrap()).unwrap();
+        std::fs::write(&legacy_bin, b"#!/bin/sh\nexit 0\n").unwrap();
 
-        let resolved = resolve_officecli(&Some("/nonexistent/officecli".into()), Some(tmp.path()))
-            .await
-            .expect("managed officecli");
-
-        assert_eq!(resolved, managed_bin.to_string_lossy());
+        if let Ok(resolved) = resolve_officecli(&None).await {
+            assert_ne!(resolved, legacy_bin.to_string_lossy());
+        }
     }
 
     #[tokio::test]

--- a/crates/aionui-office/src/error.rs
+++ b/crates/aionui-office/src/error.rs
@@ -36,8 +36,8 @@ mod tests {
     fn display_messages() {
         assert_eq!(OfficeError::OfficecliNotFound.to_string(), "officecli not found");
         assert_eq!(
-            OfficeError::InstallFailed("npm error".into()).to_string(),
-            "officecli install failed: npm error"
+            OfficeError::InstallFailed("installer error".into()).to_string(),
+            "officecli install failed: installer error"
         );
         assert_eq!(
             OfficeError::PortTimeout("/a.docx".into()).to_string(),

--- a/crates/aionui-office/src/officecli_runtime.rs
+++ b/crates/aionui-office/src/officecli_runtime.rs
@@ -1,31 +1,168 @@
-use std::path::{Path, PathBuf};
+use std::ffi::{OsStr, OsString};
+#[cfg(test)]
+use std::path::Path;
+use std::path::PathBuf;
 
-use aionui_runtime::{ResolvedCommand, ensure_runtime_command};
+use aionui_runtime::resolve_command_path;
 
-use crate::error::OfficeError;
+pub(crate) const OFFICECLI_INSTALL_SH_URL: &str =
+    "https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh";
+pub(crate) const OFFICECLI_INSTALL_PS1_URL: &str =
+    "https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.ps1";
+pub(crate) const OFFICECLI_LATEST_RELEASE_URL: &str = "https://github.com/iOfficeAI/OfficeCli/releases/latest";
 
-pub(crate) fn officecli_prefix(data_dir: &Path) -> PathBuf {
-    data_dir.join("runtime").join("node").join("tools").join("officecli")
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OfficecliInstallPlatform {
+    Unix,
+    Windows,
 }
 
-pub(crate) fn resolve_officecli_path(data_dir: &Path) -> Option<PathBuf> {
-    let prefix = officecli_prefix(data_dir);
-    let bin = if cfg!(windows) {
-        prefix.join("bin").join("officecli.cmd")
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OfficecliInstallCommand {
+    pub program: OsString,
+    pub args: Vec<OsString>,
+}
+
+pub(crate) fn resolve_officecli_path() -> Option<PathBuf> {
+    resolve_command_path("officecli").or_else(resolve_known_officecli_install_path)
+}
+
+pub(crate) fn install_command() -> OfficecliInstallCommand {
+    if cfg!(windows) {
+        install_command_for_platform(OfficecliInstallPlatform::Windows)
     } else {
-        prefix.join("bin").join("officecli")
-    };
-    bin.is_file().then_some(bin)
+        install_command_for_platform(OfficecliInstallPlatform::Unix)
+    }
 }
 
-pub(crate) async fn resolve_officecli_command(data_dir: &Path) -> Result<ResolvedCommand, OfficeError> {
-    let path = resolve_officecli_path(data_dir).ok_or(OfficeError::OfficecliNotFound)?;
-    let runtime = ensure_runtime_command("npm")
-        .await
-        .map_err(|e| OfficeError::InstallFailed(e.to_string()))?;
-    Ok(ResolvedCommand {
-        program: path,
-        args_prefix: vec![],
-        env: runtime.env,
+pub(crate) fn install_command_for_platform(platform: OfficecliInstallPlatform) -> OfficecliInstallCommand {
+    match platform {
+        OfficecliInstallPlatform::Windows => OfficecliInstallCommand {
+            program: OsString::from("powershell.exe"),
+            args: vec![
+                OsString::from("-NoProfile"),
+                OsString::from("-ExecutionPolicy"),
+                OsString::from("Bypass"),
+                OsString::from("-Command"),
+                OsString::from(format!("irm {OFFICECLI_INSTALL_PS1_URL} | iex")),
+            ],
+        },
+        OfficecliInstallPlatform::Unix => OfficecliInstallCommand {
+            program: OsString::from("bash"),
+            args: vec![
+                OsString::from("-lc"),
+                OsString::from(format!("curl -fsSL {OFFICECLI_INSTALL_SH_URL} | bash")),
+            ],
+        },
+    }
+}
+
+fn resolve_known_officecli_install_path() -> Option<PathBuf> {
+    resolve_known_officecli_install_path_from_env(
+        std::env::var_os("HOME").as_deref(),
+        std::env::var_os("LOCALAPPDATA").as_deref(),
+    )
+}
+
+fn resolve_known_officecli_install_path_from_env(
+    home: Option<&OsStr>,
+    local_app_data: Option<&OsStr>,
+) -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(local_app_data) = local_app_data {
+        candidates.push(PathBuf::from(local_app_data).join("OfficeCli").join("officecli.exe"));
+    }
+
+    if let Some(home) = home {
+        candidates.push(PathBuf::from(home).join(".local").join("bin").join("officecli"));
+    }
+
+    candidates.into_iter().find(|path| path.is_file())
+}
+
+#[cfg(test)]
+pub(crate) fn resolve_officecli_path_from_env_for_test(
+    path_env: Option<&OsStr>,
+    home: Option<&Path>,
+    local_app_data: Option<&Path>,
+) -> Option<PathBuf> {
+    find_officecli_in_path(path_env).or_else(|| {
+        resolve_known_officecli_install_path_from_env(home.map(Path::as_os_str), local_app_data.map(Path::as_os_str))
     })
+}
+
+#[cfg(test)]
+fn find_officecli_in_path(path_env: Option<&OsStr>) -> Option<PathBuf> {
+    let path_env = path_env?;
+    for dir in std::env::split_paths(path_env) {
+        let candidate = dir.join("officecli");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+
+        #[cfg(windows)]
+        {
+            let candidate = dir.join("officecli.exe");
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+pub(crate) fn install_command_for_test(platform: OfficecliInstallPlatform) -> OfficecliInstallCommand {
+    install_command_for_platform(platform)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_marker_file(path: &std::path::Path) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, b"#!/bin/sh\nexit 0\n").unwrap();
+    }
+
+    #[test]
+    fn officecli_resolution_uses_path_binary_not_legacy_prefix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path_bin = tmp.path().join("path-bin").join("officecli");
+        let legacy_bin = ["runtime", "node", "tools", "officecli", "bin", "officecli"]
+            .into_iter()
+            .fold(tmp.path().to_path_buf(), |path, segment| path.join(segment));
+        write_marker_file(&path_bin);
+        write_marker_file(&legacy_bin);
+
+        let path_env = std::env::join_paths([path_bin.parent().unwrap()]).unwrap();
+        let resolved = resolve_officecli_path_from_env_for_test(Some(&path_env), Some(tmp.path()), None);
+
+        assert_eq!(resolved, Some(path_bin));
+    }
+
+    #[test]
+    fn officecli_resolution_discovers_windows_installer_location() {
+        let tmp = tempfile::tempdir().unwrap();
+        let local_app_data = tmp.path().join("LocalAppData");
+        let officecli_exe = local_app_data.join("OfficeCli").join("officecli.exe");
+        std::fs::create_dir_all(officecli_exe.parent().unwrap()).unwrap();
+        std::fs::write(&officecli_exe, b"fake exe").unwrap();
+
+        let resolved = resolve_officecli_path_from_env_for_test(None, None, Some(&local_app_data));
+
+        assert_eq!(resolved, Some(officecli_exe));
+    }
+
+    #[test]
+    fn official_installer_commands_use_official_officecli_channel() {
+        let unix = install_command_for_test(OfficecliInstallPlatform::Unix);
+        let windows = install_command_for_test(OfficecliInstallPlatform::Windows);
+        let unix_text = format!("{:?} {:?}", unix.program, unix.args);
+        let windows_text = format!("{:?} {:?}", windows.program, windows.args);
+
+        assert!(unix_text.contains("iOfficeAI/OfficeCli/main/install.sh"));
+        assert!(windows_text.contains("iOfficeAI/OfficeCli/main/install.ps1"));
+    }
 }

--- a/crates/aionui-office/src/routes.rs
+++ b/crates/aionui-office/src/routes.rs
@@ -26,7 +26,7 @@ impl From<OfficeError> for ApiError {
     fn from(err: OfficeError) -> Self {
         match err {
             OfficeError::OfficecliNotFound => ApiError::BadRequest("officecli not found".into()),
-            OfficeError::InstallFailed(msg) => ApiError::Internal(format!("officecli install failed: {msg}")),
+            OfficeError::InstallFailed(_) => ApiError::Internal("officecli install failed".into()),
             OfficeError::StartFailed(msg) => ApiError::Internal(format!("preview start failed: {msg}")),
             OfficeError::PortTimeout(path) => {
                 ApiError::Internal(format!("preview service readiness timeout for {path}"))
@@ -380,8 +380,8 @@ mod tests {
 
     #[test]
     fn install_failed_maps_to_internal() {
-        let err = ApiError::from(OfficeError::InstallFailed("npm error".into()));
-        assert!(matches!(err, ApiError::Internal(msg) if msg.contains("npm error")));
+        let err = ApiError::from(OfficeError::InstallFailed("installer stderr".into()));
+        assert!(matches!(err, ApiError::Internal(msg) if msg == "officecli install failed"));
     }
 
     #[test]

--- a/crates/aionui-office/src/watch_manager.rs
+++ b/crates/aionui-office/src/watch_manager.rs
@@ -4,14 +4,12 @@ use std::time::Duration;
 
 use aionui_api_types::{PreviewState, PreviewStatusEvent, WebSocketMessage};
 use aionui_realtime::EventBroadcaster;
-use aionui_runtime::{Builder as CmdBuilder, ensure_runtime_command};
+use aionui_runtime::Builder as CmdBuilder;
 use dashmap::DashMap;
 use tokio::sync::Mutex;
 
 use crate::error::OfficeError;
-#[cfg(test)]
-use crate::officecli_runtime::resolve_officecli_path;
-use crate::officecli_runtime::{officecli_prefix, resolve_officecli_command};
+use crate::officecli_runtime::{OFFICECLI_LATEST_RELEASE_URL, install_command, resolve_officecli_path};
 use crate::port::{allocate_port, is_port_listening};
 use crate::types::DocType;
 
@@ -103,7 +101,7 @@ impl OfficecliWatchManager {
                 Ok(*port)
             }
             Err(e) => {
-                self.broadcast_status(doc_type, PreviewState::Error, Some(e.to_string()));
+                self.broadcast_status(doc_type, PreviewState::Error, Some(public_preview_error_message(e)));
                 Err(match e {
                     OfficeError::OfficecliNotFound => OfficeError::OfficecliNotFound,
                     OfficeError::InstallFailed(m) => OfficeError::InstallFailed(m.clone()),
@@ -249,12 +247,12 @@ impl Drop for OfficecliWatchManager {
 // ---------------------------------------------------------------------------
 
 pub struct DefaultProcessSpawner {
-    data_dir: PathBuf,
+    _data_dir: PathBuf,
 }
 
 impl DefaultProcessSpawner {
     pub fn new(data_dir: PathBuf) -> Self {
-        Self { data_dir }
+        Self { _data_dir: data_dir }
     }
 }
 
@@ -290,8 +288,12 @@ impl ProcessSpawner for DefaultProcessSpawner {
         port: u16,
         _doc_type: DocType,
     ) -> Result<Box<dyn ProcessHandle>, OfficeError> {
-        let resolved = resolve_officecli_command(&self.data_dir).await?;
-        let mut builder = CmdBuilder::from_resolved(&resolved);
+        let officecli = resolve_officecli_path().ok_or(OfficeError::OfficecliNotFound)?;
+        if !officecli_supports_watch(&officecli).await {
+            return Err(OfficeError::OfficecliNotFound);
+        }
+
+        let mut builder = CmdBuilder::new(&officecli);
         builder
             .arg("watch")
             .arg(file_path)
@@ -314,63 +316,76 @@ impl ProcessSpawner for DefaultProcessSpawner {
     }
 
     async fn install_officecli(&self) -> Result<(), OfficeError> {
-        let resolved = ensure_runtime_command("npm")
-            .await
-            .map_err(|e| OfficeError::InstallFailed(e.to_string()))?;
-        let prefix = officecli_prefix(&self.data_dir);
-        std::fs::create_dir_all(&prefix).map_err(OfficeError::Io)?;
-        let prefix_arg = prefix.to_string_lossy().into_owned();
-        let mut builder = CmdBuilder::from_resolved(&resolved);
-        builder.args(["install", "--prefix", prefix_arg.as_str(), "officecli"]);
+        let command = install_command();
+        tracing::info!(
+            platform = std::env::consts::OS,
+            "installing officecli via official iOfficeAI/OfficeCli installer"
+        );
+
+        let mut builder = CmdBuilder::clean_cli(&command.program);
+        builder.args(command.args.iter());
         let output = builder
             .output()
             .await
             .map_err(|e| OfficeError::InstallFailed(e.to_string()))?;
 
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(OfficeError::InstallFailed(stderr.into_owned()));
+            tracing::warn!(
+                status = ?output.status.code(),
+                "officecli official installer failed"
+            );
+            return Err(OfficeError::InstallFailed("official OfficeCLI installer failed".into()));
         }
         Ok(())
     }
 
     async fn is_officecli_installed(&self) -> bool {
-        let Ok(resolved) = resolve_officecli_command(&self.data_dir).await else {
+        let Some(officecli) = resolve_officecli_path() else {
             return false;
         };
-        let mut builder = CmdBuilder::from_resolved(&resolved);
-        builder.arg("--version");
-        builder.output().await.is_ok_and(|o| o.status.success())
+
+        officecli_supports_watch(&officecli).await
     }
 
     async fn check_update(&self, _doc_type: DocType) -> Result<(), OfficeError> {
-        let resolved = ensure_runtime_command("npm")
-            .await
-            .map_err(|e| OfficeError::StartFailed(e.to_string()))?;
-        let prefix = officecli_prefix(&self.data_dir);
-        std::fs::create_dir_all(&prefix).map_err(OfficeError::Io)?;
-        let prefix_arg = prefix.to_string_lossy().into_owned();
-        let mut builder = CmdBuilder::from_resolved(&resolved);
-        builder.args(["outdated", "--prefix", prefix_arg.as_str(), "officecli"]);
+        let officecli = resolve_officecli_path().ok_or(OfficeError::OfficecliNotFound)?;
+        if !officecli_supports_watch(&officecli).await {
+            return Err(OfficeError::OfficecliNotFound);
+        }
+
+        let mut builder = CmdBuilder::clean_cli(&officecli);
+        builder.arg("--version");
         let output = builder
             .output()
             .await
             .map_err(|e| OfficeError::StartFailed(e.to_string()))?;
 
         if !output.status.success() {
-            tracing::info!("officecli update available, installing...");
-            let mut install_builder = CmdBuilder::from_resolved(&resolved);
-            install_builder.args(["install", "--prefix", prefix_arg.as_str(), "officecli@latest"]);
-            let install = install_builder
-                .output()
-                .await
-                .map_err(|e| OfficeError::InstallFailed(e.to_string()))?;
-
-            if !install.status.success() {
-                let stderr = String::from_utf8_lossy(&install.stderr);
-                tracing::warn!("officecli update failed: {stderr}");
-            }
+            return Ok(());
         }
+
+        let local_version = normalize_officecli_version(&String::from_utf8_lossy(&output.stdout));
+        let response = reqwest::Client::new()
+            .get(OFFICECLI_LATEST_RELEASE_URL)
+            .send()
+            .await
+            .map_err(|e| OfficeError::StartFailed(e.to_string()))?;
+        let remote_version = response
+            .url()
+            .path_segments()
+            .and_then(|mut segments| segments.next_back())
+            .map(normalize_officecli_version)
+            .unwrap_or_default();
+
+        if !remote_version.is_empty() && remote_version != local_version {
+            tracing::info!(
+                local_version = %local_version,
+                remote_version = %remote_version,
+                "officecli update available, installing via official installer"
+            );
+            self.install_officecli().await?;
+        }
+
         Ok(())
     }
 }
@@ -387,6 +402,38 @@ fn resolve_path(file_path: &str) -> Result<String, OfficeError> {
 
 fn session_key(resolved_path: &str, doc_type: DocType) -> String {
     format!("{doc_type}:{resolved_path}")
+}
+
+fn normalize_officecli_version(raw: &str) -> String {
+    raw.split_whitespace()
+        .last()
+        .unwrap_or_default()
+        .trim_start_matches('v')
+        .to_owned()
+}
+
+async fn officecli_supports_watch(officecli: &Path) -> bool {
+    let mut version = CmdBuilder::clean_cli(officecli);
+    version.arg("--version");
+    if !version.output().await.is_ok_and(|o| o.status.success()) {
+        return false;
+    }
+
+    let mut watch_help = CmdBuilder::clean_cli(officecli);
+    watch_help.args(["watch", "--help"]);
+    let ok = watch_help.output().await.is_ok_and(|o| o.status.success());
+    if !ok {
+        tracing::warn!("officecli exists but does not expose watch command");
+    }
+    ok
+}
+
+fn public_preview_error_message(error: &OfficeError) -> String {
+    match error {
+        OfficeError::InstallFailed(_) => "officecli install failed".to_owned(),
+        OfficeError::OfficecliNotFound => "officecli not found".to_owned(),
+        _ => error.to_string(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -528,14 +575,27 @@ mod tests {
     }
 
     #[test]
-    fn officecli_spawn_prefers_managed_prefix_binary() {
-        let tmp = tempfile::tempdir().unwrap();
-        let managed_bin = tmp.path().join("runtime/node/tools/officecli/bin/officecli");
-        std::fs::create_dir_all(managed_bin.parent().unwrap()).unwrap();
-        std::fs::write(&managed_bin, b"#!/bin/sh\nexit 0\n").unwrap();
+    fn install_failed_public_preview_message_is_sanitized() {
+        let err = OfficeError::InstallFailed("installer stderr".into());
+        assert_eq!(public_preview_error_message(&err), "officecli install failed");
+    }
 
-        let path = resolve_officecli_path(tmp.path()).expect("managed officecli");
-        assert_eq!(path, managed_bin);
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn officecli_capability_probe_requires_watch_command() {
+        let tmp = tempfile::tempdir().unwrap();
+        let officecli = tmp.path().join("officecli");
+        std::fs::write(
+            &officecli,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then exit 0; fi\nif [ \"$1\" = \"watch\" ] && [ \"$2\" = \"--help\" ]; then exit 1; fi\nexit 0\n",
+        )
+        .unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&officecli).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&officecli, perms).unwrap();
+
+        assert!(!officecli_supports_watch(&officecli).await);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Restore OfficeCLI discovery to official iOfficeAI/OfficeCli channels instead of the managed npm package path.
- Install and update OfficeCLI through the official installer and GitHub release flow.
- Probe `watch --help` before using an `officecli` binary and keep install failures sanitized.

## Test plan
- [x] `just push -u origin restore-officecli-installer`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p aionui-office -- -D warnings`
- [x] `cargo test -p aionui-office`
- [x] Negative search for npm OfficeCLI traces