### PR TITLE
fix(agent): wait for task shutdown during clear

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -576,3 +576,4 @@ graphify-out/
 .graphify_*
 
 .tmp/
+.playwright-mcp/

--- a/crates/aionui-ai-agent/src/task_manager.rs
+++ b/crates/aionui-ai-agent/src/task_manager.rs
@@ -5,7 +5,7 @@ use aionui_common::{
 };
 use async_trait::async_trait;
 use dashmap::DashMap;
-use futures_util::future::BoxFuture;
+use futures_util::future::{BoxFuture, join_all};
 use tokio::sync::OnceCell;
 use tracing::{info, warn};
 
@@ -54,8 +54,8 @@ pub trait IWorkerTaskManager: Send + Sync {
         reason: Option<AgentKillReason>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>;
 
-    /// Kill and remove all active tasks.
-    fn clear(&self);
+    /// Kill, remove, and wait for all active tasks to stop.
+    async fn clear(&self);
 
     /// Number of active tasks (useful for diagnostics).
     fn active_count(&self) -> usize;
@@ -148,16 +148,18 @@ impl IWorkerTaskManager for WorkerTaskManagerImpl {
         Box::pin(std::future::ready(()))
     }
 
-    fn clear(&self) {
+    async fn clear(&self) {
         let keys: Vec<String> = self.tasks.iter().map(|r| r.key().clone()).collect();
+        let mut waits = Vec::new();
         for key in keys {
             if let Some((id, slot)) = self.tasks.remove(&key) {
                 info!(conversation_id = %id, "Clearing agent task");
                 if let Some(agent) = slot.get() {
-                    let _ = agent.kill(None);
+                    waits.push(agent.kill_and_wait(None));
                 }
             }
         }
+        join_all(waits).await;
     }
 
     fn active_count(&self) -> usize {
@@ -457,7 +459,7 @@ mod tests {
         mgr.get_or_build_task("conv-2", make_options("conv-2")).await.unwrap();
         assert_eq!(mgr.active_count(), 2);
 
-        mgr.clear();
+        mgr.clear().await;
         assert_eq!(mgr.active_count(), 0);
     }
 

--- a/crates/aionui-app/src/commands/cmd_server.rs
+++ b/crates/aionui-app/src/commands/cmd_server.rs
@@ -3,7 +3,7 @@
 use std::io::{self, Write};
 use std::net::SocketAddr;
 use std::process::ExitCode;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use std::{future::Future, pin::Pin};
 
 use tokio::net::TcpListener;
@@ -17,6 +17,7 @@ use crate::bootstrap::{BootstrapError, BootstrapErrorCode, ParentExitSignal, Ser
 
 const LISTENING_EVENT_PREFIX: &str = "AIONCORE_LISTENING";
 const DYNAMIC_BACKEND_BIND_MAX_ATTEMPTS: usize = 50;
+const WORKER_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ShutdownReason {
@@ -293,7 +294,11 @@ pub(crate) async fn run_server(
                         reason = "graceful_shutdown",
                         active_turn_count, "conversation runtime shutdown prepared"
                     );
-                    worker_task_manager.clear();
+                    let active_task_count = worker_task_manager.active_count();
+                    match tokio::time::timeout(WORKER_TASK_SHUTDOWN_TIMEOUT, worker_task_manager.clear()).await {
+                        Ok(()) => info!(active_task_count, "worker task manager shutdown completed"),
+                        Err(_) => warn!(active_task_count, "worker task manager shutdown timed out"),
+                    }
                 }
             }
             let _ = shutdown_tx.send(true);

--- a/crates/aionui-app/tests/agent_integration_e2e.rs
+++ b/crates/aionui-app/tests/agent_integration_e2e.rs
@@ -173,7 +173,7 @@ impl IWorkerTaskManager for MockTaskManager {
         Box::pin(std::future::ready(()))
     }
 
-    fn clear(&self) {
+    async fn clear(&self) {
         self.agents.lock().unwrap().clear();
     }
 

--- a/crates/aionui-channel/tests/message_service_integration.rs
+++ b/crates/aionui-channel/tests/message_service_integration.rs
@@ -164,7 +164,7 @@ impl IWorkerTaskManager for RecordingTaskManager {
         Box::pin(std::future::ready(()))
     }
 
-    fn clear(&self) {
+    async fn clear(&self) {
         self.agents.lock().unwrap().clear();
     }
 

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1935,7 +1935,7 @@ impl IWorkerTaskManager for DelayedFailingBuildTaskManager {
         Box::pin(std::future::ready(()))
     }
 
-    fn clear(&self) {}
+    async fn clear(&self) {}
 
     fn active_count(&self) -> usize {
         0
@@ -1972,7 +1972,7 @@ impl IWorkerTaskManager for FailingBuildTaskManager {
         Box::pin(std::future::ready(()))
     }
 
-    fn clear(&self) {}
+    async fn clear(&self) {}
 
     fn active_count(&self) -> usize {
         0
@@ -2022,7 +2022,7 @@ impl IWorkerTaskManager for MockTaskManager {
         Box::pin(std::future::ready(()))
     }
 
-    fn clear(&self) {
+    async fn clear(&self) {
         self.agents.lock().unwrap().clear();
     }
 
@@ -2081,7 +2081,7 @@ impl IWorkerTaskManager for SlowBuildTaskManager {
         Box::pin(std::future::ready(()))
     }
 
-    fn clear(&self) {}
+    async fn clear(&self) {}
 
     fn active_count(&self) -> usize {
         usize::from(self.was_built())
@@ -2144,7 +2144,7 @@ impl IWorkerTaskManager for MockTaskManagerWithWorkspace {
         Box::pin(std::future::ready(()))
     }
 
-    fn clear(&self) {
+    async fn clear(&self) {
         self.agents.lock().unwrap().clear();
     }
 

--- a/crates/aionui-conversation/tests/conversation_crud.rs
+++ b/crates/aionui-conversation/tests/conversation_crud.rs
@@ -60,7 +60,7 @@ impl IWorkerTaskManager for NoopTaskManager {
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
         Box::pin(std::future::ready(()))
     }
-    fn clear(&self) {}
+    async fn clear(&self) {}
     fn active_count(&self) -> usize {
         0
     }

--- a/crates/aionui-conversation/tests/conversation_extended.rs
+++ b/crates/aionui-conversation/tests/conversation_extended.rs
@@ -57,7 +57,7 @@ impl IWorkerTaskManager for NoopTaskManager {
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
         Box::pin(std::future::ready(()))
     }
-    fn clear(&self) {}
+    async fn clear(&self) {}
     fn active_count(&self) -> usize {
         0
     }

--- a/crates/aionui-conversation/tests/stream_relay_tool_call.rs
+++ b/crates/aionui-conversation/tests/stream_relay_tool_call.rs
@@ -215,7 +215,7 @@ impl IWorkerTaskManager for ToolCallTaskManager {
         Box::pin(std::future::ready(()))
     }
 
-    fn clear(&self) {}
+    async fn clear(&self) {}
 
     fn active_count(&self) -> usize {
         1

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -2141,7 +2141,7 @@ mod tests {
             ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
                 Box::pin(std::future::ready(()))
             }
-            fn clear(&self) {}
+            async fn clear(&self) {}
             fn active_count(&self) -> usize {
                 0
             }
@@ -2436,7 +2436,7 @@ mod tests {
             Box::pin(std::future::ready(()))
         }
 
-        fn clear(&self) {}
+        async fn clear(&self) {}
 
         fn active_count(&self) -> usize {
             1
@@ -2500,7 +2500,7 @@ mod tests {
             Box::pin(std::future::ready(()))
         }
 
-        fn clear(&self) {}
+        async fn clear(&self) {}
 
         fn active_count(&self) -> usize {
             1

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -89,7 +89,7 @@ impl aionui_ai_agent::task_manager::IWorkerTaskManager for StubTaskManager {
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
         Box::pin(std::future::ready(()))
     }
-    fn clear(&self) {}
+    async fn clear(&self) {}
     fn active_count(&self) -> usize {
         0
     }

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -1174,7 +1174,7 @@ mod tests {
             let _ = self.kill(conversation_id, reason);
             Box::pin(std::future::ready(()))
         }
-        fn clear(&self) {}
+        async fn clear(&self) {}
         fn active_count(&self) -> usize {
             self.tasks.lock().unwrap().len()
         }

--- a/crates/aionui-team/tests/e2e_team_flow.rs
+++ b/crates/aionui-team/tests/e2e_team_flow.rs
@@ -425,7 +425,7 @@ impl aionui_ai_agent::IWorkerTaskManager for StubTaskManager {
         let _ = self.kill(conversation_id, reason);
         Box::pin(std::future::ready(()))
     }
-    fn clear(&self) {}
+    async fn clear(&self) {}
     fn active_count(&self) -> usize {
         self.tasks.lock().unwrap().len()
     }

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -695,8 +695,8 @@ impl CountingTaskManager {
         }
     }
 
-    fn reset(&self) {
-        self.inner.clear();
+    async fn reset(&self) {
+        self.inner.clear().await;
         *self.calls.lock().unwrap() = TaskManagerCalls::default();
     }
 
@@ -734,8 +734,8 @@ impl IWorkerTaskManager for CountingTaskManager {
         let _ = self.kill(conversation_id, reason);
         Box::pin(std::future::ready(()))
     }
-    fn clear(&self) {
-        self.inner.clear()
+    async fn clear(&self) {
+        self.inner.clear().await
     }
     fn active_count(&self) -> usize {
         self.inner.active_count()
@@ -1060,7 +1060,7 @@ fn two_agent_input() -> Vec<TeamAgentInput> {
 
 async fn reset_auto_started_session(svc: &Arc<TeamSessionService>, tm: &Arc<CountingTaskManager>, team_id: &str) {
     svc.stop_session("user1", team_id).await.unwrap();
-    tm.reset();
+    tm.reset().await;
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary

- Make worker task manager clear() async so shutdown can wait for active agent processes.
- Use kill_and_wait during clear() and wait for worker task shutdown during server graceful shutdown.
- Add .playwright-mcp/ to .gitignore and update task manager test doubles to match the async clear contract.

Related AionUi PR: https://github.com/iOfficeAI/AionUi/pull/3270
Refs iOfficeAI/AionUi#3258

## Test plan

- [x] cargo fmt --all -- --check
- [x] cargo clippy -p aionui-ai-agent -p aionui-app -- -D warnings
- [x] cargo test -p aionui-ai-agent clear_removes_all
- [x] just push --force-with-lease