### PR TITLE
fix(stt): treat blank base_url as unset and log malformed config

### DIFF
--- a/crates/aionui-shell/src/routes.rs
+++ b/crates/aionui-shell/src/routes.rs
@@ -212,7 +212,15 @@ async fn speech_to_text(
     let config: SpeechToTextConfig = prefs
         .get("tools.speechToText")
         .or_else(|| prefs.get("speechToText"))
-        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .and_then(|v| match serde_json::from_value(v.clone()) {
+            Ok(config) => Some(config),
+            Err(e) => {
+                // Fall back to disabled, but leave a trace — a silent fallback
+                // makes a malformed config indistinguishable from a missing one.
+                tracing::warn!("ignoring malformed speechToText config: {e}");
+                None
+            }
+        })
         .unwrap_or(SpeechToTextConfig {
             enabled: false,
             provider: aionui_api_types::SpeechToTextProvider::Openai,

--- a/crates/aionui-shell/src/stt_deepgram.rs
+++ b/crates/aionui-shell/src/stt_deepgram.rs
@@ -5,6 +5,17 @@ use crate::error::SttError;
 
 const DEFAULT_BASE_URL: &str = "https://api.deepgram.com";
 
+/// Resolve the effective base URL. Unset or blank values fall back to the
+/// default — the settings UI saves unfilled fields as empty strings, which
+/// would otherwise produce a relative URL that fails the request builder.
+fn resolve_base_url(configured: Option<&str>) -> &str {
+    configured
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(DEFAULT_BASE_URL)
+        .trim_end_matches('/')
+}
+
 pub async fn transcribe(
     client: &Client,
     config: &DeepgramSpeechToTextConfig,
@@ -16,11 +27,7 @@ pub async fn transcribe(
         return Err(SttError::DeepgramNotConfigured);
     }
 
-    let base_url = config
-        .base_url
-        .as_deref()
-        .unwrap_or(DEFAULT_BASE_URL)
-        .trim_end_matches('/');
+    let base_url = resolve_base_url(config.base_url.as_deref());
 
     let mut query_params = vec![("model", config.model.clone())];
 
@@ -102,6 +109,23 @@ mod tests {
     #[test]
     fn default_base_url_value() {
         assert_eq!(DEFAULT_BASE_URL, "https://api.deepgram.com");
+    }
+
+    #[test]
+    fn resolve_base_url_falls_back_on_none() {
+        assert_eq!(resolve_base_url(None), DEFAULT_BASE_URL);
+    }
+
+    #[test]
+    fn resolve_base_url_falls_back_on_blank() {
+        // Settings UI saves unfilled base_url as "" — must not build a relative URL
+        assert_eq!(resolve_base_url(Some("")), DEFAULT_BASE_URL);
+        assert_eq!(resolve_base_url(Some("   ")), DEFAULT_BASE_URL);
+    }
+
+    #[test]
+    fn resolve_base_url_trims_trailing_slash() {
+        assert_eq!(resolve_base_url(Some("https://example.com/")), "https://example.com");
     }
 
     #[tokio::test]

--- a/crates/aionui-shell/src/stt_openai.rs
+++ b/crates/aionui-shell/src/stt_openai.rs
@@ -5,6 +5,18 @@ use crate::error::SttError;
 
 const DEFAULT_BASE_URL: &str = "https://api.openai.com";
 
+/// Resolve the effective base URL. Unset or blank values fall back to the
+/// default — the settings UI saves unfilled fields as empty strings, which
+/// would otherwise produce a relative URL that fails the request builder.
+fn resolve_base_url(configured: Option<&str>) -> &str {
+    configured
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(DEFAULT_BASE_URL)
+        .trim_end_matches('/')
+        .trim_end_matches("/v1")
+}
+
 pub async fn transcribe(
     client: &Client,
     config: &OpenAISpeechToTextConfig,
@@ -17,12 +29,7 @@ pub async fn transcribe(
         return Err(SttError::OpenaiNotConfigured);
     }
 
-    let base_url = config
-        .base_url
-        .as_deref()
-        .unwrap_or(DEFAULT_BASE_URL)
-        .trim_end_matches('/')
-        .trim_end_matches("/v1");
+    let base_url = resolve_base_url(config.base_url.as_deref());
     let url = format!("{base_url}/v1/audio/transcriptions");
 
     // Normalize MIME type: strip codec parameters (e.g. "audio/webm;codecs=opus" → "audio/webm")
@@ -93,6 +100,28 @@ mod tests {
     #[test]
     fn default_base_url_value() {
         assert_eq!(DEFAULT_BASE_URL, "https://api.openai.com");
+    }
+
+    #[test]
+    fn resolve_base_url_falls_back_on_none() {
+        assert_eq!(resolve_base_url(None), DEFAULT_BASE_URL);
+    }
+
+    #[test]
+    fn resolve_base_url_falls_back_on_blank() {
+        // Settings UI saves unfilled base_url as "" — must not build a relative URL
+        assert_eq!(resolve_base_url(Some("")), DEFAULT_BASE_URL);
+        assert_eq!(resolve_base_url(Some("   ")), DEFAULT_BASE_URL);
+    }
+
+    #[test]
+    fn resolve_base_url_trims_trailing_slash_and_v1() {
+        assert_eq!(
+            resolve_base_url(Some("https://api.groq.com/openai/v1")),
+            "https://api.groq.com/openai"
+        );
+        assert_eq!(resolve_base_url(Some("https://example.com/")), "https://example.com");
+        assert_eq!(resolve_base_url(Some("https://example.com/v1/")), "https://example.com");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Follow-up to #400, which fixed the preference key mismatch and multipart/language/MIME compatibility but left two gaps:

1. **Blank `base_url` breaks the request builder**: the AionUi settings UI saves unfilled fields as empty strings, so `base_url` arrives as `Some("")`. This bypasses `unwrap_or(DEFAULT_BASE_URL)` and produces the relative URL `/v1/audio/transcriptions`, which fails with `OpenAI request error: builder error`. Verified against a real user config — any user who enabled STT through the settings UI without filling in a custom base URL hits this even after #400.

2. **Silent config fallback**: when the stored `speechToText` config fails to deserialize, `.ok()` silently falls back to disabled, making a malformed config indistinguishable from a missing one (`STT_DISABLED` with no trace).

## Solution

- Extract `resolve_base_url()` in both `stt_openai.rs` and `stt_deepgram.rs`: blank/whitespace values resolve to the provider default; trailing `/` (and `/v1` for OpenAI, preserving the #400 Groq behavior) are trimmed.
- Log a `tracing::warn!` when the stored config fails to deserialize before falling back to disabled.

## Testing

- 6 new unit tests for `resolve_base_url` (None / `""` / whitespace / trailing-slash / `/v1` trimming) in both providers
- `cargo test -p aionui-shell` — all 23 unit + 17 integration tests pass; `cargo fmt --check` and `cargo clippy --all-targets` clean
- End-to-end against the rebuilt binary: a real user-shaped config (`tools.speechToText` key, `base_url: ""`, `mimeType: audio/webm;codecs=opus`, `languageHint: zh-CN`, dummy key) now reaches `api.openai.com` and returns 401 invalid_api_key instead of `builder error`; a malformed config returns `STT_DISABLED` and logs `ignoring malformed speechToText config`
