### PR TITLE
fix(runtime): bump managed codex-acp to 0.15.0

### DIFF
--- a/crates/aionui-runtime/src/acp_tool_runtime/mod.rs
+++ b/crates/aionui-runtime/src/acp_tool_runtime/mod.rs
@@ -994,7 +994,7 @@ mod tests {
         };
         let tool = ResolvedManagedAcpTool {
             id: ManagedAcpToolId::CodexAcp,
-            version: "0.14.0".into(),
+            version: "0.15.0".into(),
             root: PathBuf::from("/tmp/tool"),
             entrypoint: PathBuf::from("/tmp/tool/dist/index.js"),
             env_path_entries: vec![PathBuf::from("/tmp/tool/bin")],
@@ -1025,7 +1025,7 @@ mod tests {
     #[test]
     fn classify_error_detects_bundled_acp_validation_failure() {
         let error = ManagedAcpToolError::invalid(
-            "bundled managed Codex ACP artifact failed validation under /app/resources/managed-resources/acp/codex-acp/0.14.0/linux-x64: managed ACP entrypoint missing",
+            "bundled managed Codex ACP artifact failed validation under /app/resources/managed-resources/acp/codex-acp/0.15.0/linux-x64: managed ACP entrypoint missing",
         );
         let (kind, status_code) = classify_error(&error);
 
@@ -1208,7 +1208,7 @@ mod tests {
         let source_root = bundled_root
             .join("acp")
             .join("codex-acp")
-            .join("0.14.0")
+            .join("0.15.0")
             .join(spec.manifest_key);
         std::fs::create_dir_all(&source_root).unwrap();
         std::fs::write(
@@ -1218,7 +1218,7 @@ mod tests {
         .unwrap();
 
         let runtime_root = tmp.path().join("runtime");
-        let tool_root = runtime_root.join("codex-acp").join("0.14.0").join(spec.manifest_key);
+        let tool_root = runtime_root.join("codex-acp").join("0.15.0").join(spec.manifest_key);
 
         managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Bundled);
         let result = activate_local_tool_source(ManagedAcpToolId::CodexAcp, spec, &tool_root, None);
@@ -1248,7 +1248,7 @@ mod tests {
             bundle_root
                 .join("acp")
                 .join("codex-acp")
-                .join("0.14.0")
+                .join("0.15.0")
                 .join("win32-x64")
         );
     }

--- a/crates/aionui-runtime/src/acp_tool_runtime/types.rs
+++ b/crates/aionui-runtime/src/acp_tool_runtime/types.rs
@@ -20,7 +20,7 @@ impl ManagedAcpToolId {
 
     pub fn version(self) -> &'static str {
         match self {
-            Self::CodexAcp => "0.14.0",
+            Self::CodexAcp => "0.15.0",
             Self::ClaudeAgentAcp => "0.39.0",
         }
     }


### PR DESCRIPTION
## Description

Bumps `ManagedAcpToolId::CodexAcp` version in `crates/aionui-runtime/src/acp_tool_runtime/types.rs` from `0.14.0` to `0.15.0`, and updates the version literals in the `acp_tool_runtime` test fixtures to match.

**Why:** codex-acp 0.14.0 parses `service_tier` in the shared `~/.codex/config.toml` as a strict enum (`fast`/`flex`) and aborts on `"default"` — the value the official Codex CLI/Desktop itself writes there. The builtin Codex agent then fails to start (`USER_AGENT_STARTUP_FAILED`). codex-acp 0.15.0 relaxed the field and accepts any value. Full diagnosis with stderr logs: iOfficeAI/AionUi#3225.

Companion to iOfficeAI/AionUi#3279, which bumps the same pin in AionUi's `prepare-managed-acp-tools.sh` (bundling + CDN publish pipeline).

## Notes for maintainers

- The managed ACP artifacts for `codex-acp/0.15.0` are not yet published on `static.aionui.com/managed/acp` (currently 403). The download path needs those artifacts published (same note as in iOfficeAI/AionUi#3279); the bundled-resources path needs AionUi to bundle 0.15.0.
- No DB migration is needed: since migration `009_builtin_managed_acp_tools.sql` the builtin Codex row no longer persists a command/args pin — runtime resolution derives the version from `ManagedAcpToolId::version()`.

## Verification

- `scripts/check-migration-immutability.sh` ✅
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace` ✅ (all green; the 5 updated literals are test fixtures coupled to `ManagedAcpToolId::version()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)