### PR TITLE
ci(build): add manual build workflow

### DIFF
--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -1,0 +1,184 @@
+name: "🔨 Manual Build"
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch, tag, or commit to build from"
+        required: true
+        default: "main"
+        type: string
+      platform:
+        description: "Platform to build"
+        required: true
+        type: choice
+        options:
+          - macos-arm64
+          - macos-x64
+          - windows-x64
+          - windows-arm64
+          - linux-x64
+          - linux-arm64
+          - all
+        default: "macos-arm64"
+
+permissions:
+  contents: read
+
+env:
+  BINARY_NAME: aioncore
+  CARGO_TERM_COLOR: always
+  CARGO_HTTP_TIMEOUT: "600"
+  CARGO_NET_RETRY: "10"
+  AIONUI_EMBED_BUN: "1"
+  BUN_VARIANT: default
+
+jobs:
+  prepare-matrix:
+    name: Prepare Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+      - name: Generate build matrix
+        id: set-matrix
+        shell: bash
+        run: |
+          PLATFORM="${{ inputs.platform }}"
+
+          MACOS_ARM64='{"platform":"macos-arm64","os":"macos-latest","target":"aarch64-apple-darwin","binary_name":"aioncore","artifact_name":"aioncore-manual-macos-arm64","use_cross":false}'
+          MACOS_X64='{"platform":"macos-x64","os":"macos-latest","target":"x86_64-apple-darwin","binary_name":"aioncore","artifact_name":"aioncore-manual-macos-x64","use_cross":false}'
+          WINDOWS_X64='{"platform":"windows-x64","os":"windows-latest","target":"x86_64-pc-windows-msvc","binary_name":"aioncore.exe","artifact_name":"aioncore-manual-windows-x64","rustflags":"-C target-feature=+crt-static","use_cross":false}'
+          WINDOWS_ARM64='{"platform":"windows-arm64","os":"windows-latest","target":"aarch64-pc-windows-msvc","binary_name":"aioncore.exe","artifact_name":"aioncore-manual-windows-arm64","rustflags":"-C target-feature=+crt-static","use_cross":false}'
+          LINUX_X64='{"platform":"linux-x64","os":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","binary_name":"aioncore","artifact_name":"aioncore-manual-linux-x64","use_cross":false}'
+          LINUX_ARM64='{"platform":"linux-arm64","os":"ubuntu-latest","target":"aarch64-unknown-linux-gnu","binary_name":"aioncore","artifact_name":"aioncore-manual-linux-arm64","use_cross":true}'
+
+          if [ "$PLATFORM" = "all" ]; then
+            MATRIX="{\"include\":[$MACOS_ARM64,$MACOS_X64,$WINDOWS_X64,$WINDOWS_ARM64,$LINUX_X64,$LINUX_ARM64]}"
+          elif [ "$PLATFORM" = "macos-arm64" ]; then
+            MATRIX="{\"include\":[$MACOS_ARM64]}"
+          elif [ "$PLATFORM" = "macos-x64" ]; then
+            MATRIX="{\"include\":[$MACOS_X64]}"
+          elif [ "$PLATFORM" = "windows-x64" ]; then
+            MATRIX="{\"include\":[$WINDOWS_X64]}"
+          elif [ "$PLATFORM" = "windows-arm64" ]; then
+            MATRIX="{\"include\":[$WINDOWS_ARM64]}"
+          elif [ "$PLATFORM" = "linux-x64" ]; then
+            MATRIX="{\"include\":[$LINUX_X64]}"
+          elif [ "$PLATFORM" = "linux-arm64" ]; then
+            MATRIX="{\"include\":[$LINUX_ARM64]}"
+          fi
+
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "Generated matrix for platform '$PLATFORM':"
+          echo "$MATRIX" | python3 -m json.tool
+
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    needs: prepare-matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Get commit hash
+        id: commit
+        shell: bash
+        run: |
+          SHORT=$(git rev-parse --short HEAD)
+          echo "short=$SHORT" >> "$GITHUB_OUTPUT"
+          echo "Commit: $SHORT"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.95.0"
+          targets: ${{ matrix.target }}
+
+      - name: Fix MSVC linker (remove Git's link.exe)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Remove-Item 'C:\Program Files\Git\usr\bin\link.exe' -Force -ErrorAction SilentlyContinue
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: manual-build-${{ matrix.target }}-${{ matrix.os }}${{ matrix.use_cross == true && '-cross' || '' }}
+
+      - name: Install cross (Linux targets)
+        if: matrix.use_cross == true
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build release binary
+        shell: bash
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags || '' }}
+        run: |
+          if [[ -n "${RUSTFLAGS:-}" ]]; then
+            echo "Using RUSTFLAGS=${RUSTFLAGS}"
+          fi
+
+          if [[ "${{ matrix.use_cross }}" == "true" ]]; then
+            cross build --release --target ${{ matrix.target }} -p aionui-app
+          else
+            cargo build --release --target ${{ matrix.target }} -p aionui-app
+          fi
+
+      - name: Package binary (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          COMMIT_SHORT: ${{ steps.commit.outputs.short }}
+        run: |
+          mkdir -p dist
+          ARCHIVE="aioncore-${COMMIT_SHORT}-${{ matrix.target }}.tar.gz"
+          tar -C target/${{ matrix.target }}/release -czf "dist/${ARCHIVE}" ${{ matrix.binary_name }}
+          echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
+
+      - name: Package binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          COMMIT_SHORT: ${{ steps.commit.outputs.short }}
+        run: |
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          $archive = "aioncore-${env:COMMIT_SHORT}-${{ matrix.target }}.zip"
+          Compress-Archive -Path "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" -DestinationPath "dist/${archive}" -Force
+          "ARCHIVE=${archive}" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Upload manual build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: dist/${{ env.ARCHIVE }}
+          if-no-files-found: error
+          retention-days: 7
+
+  build-summary:
+    name: Build Summary
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-matrix
+      - build
+    if: always()
+
+    steps:
+      - name: Write build summary
+        env:
+          MATRIX: ${{ needs.prepare-matrix.outputs.matrix }}
+        run: |
+          PLATFORMS=$(echo "$MATRIX" | jq -r '[.include[].platform] | join(", ")')
+          ARTIFACTS=$(echo "$MATRIX" | jq -r '[.include[].artifact_name] | join(", ")')
+
+          echo "## AionCore Manual Build" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Key | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-----|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Ref | \`${{ inputs.branch }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Platforms | \`${PLATFORMS}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Artifacts | \`${ARTIFACTS}\` |" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Add an AionCore Manual Build workflow that accepts a branch/tag/commit and platform choice.
- Support single-platform builds and all-platform builds with stable `aioncore-manual-*` artifact names.
- Upload GitHub Actions artifacts only, without creating GitHub Releases.

Related AionUi PR: https://github.com/iOfficeAI/AionUi/pull/3280

## Test plan

- [x] ruby -e \"require 'yaml'; YAML.load_file('.github/workflows/build-manual.yml'); puts '.github/workflows/build-manual.yml ok'\"