### PR TITLE
fix(file): strip Windows verbatim prefix from /api/fs/browse paths

### DIFF
--- a/crates/aionui-file/src/browse.rs
+++ b/crates/aionui-file/src/browse.rs
@@ -141,6 +141,28 @@ pub fn resolve_browse_path(raw: &str, allowed_roots: &[PathBuf]) -> Result<PathB
     Ok(canonical)
 }
 
+/// Convert a path into the string form returned to the frontend.
+///
+/// `fs::canonicalize` yields extended-length (verbatim) paths on Windows
+/// (`\\?\C:\DEV`, `\\?\UNC\server\share`). Returning those verbatim breaks
+/// downstream consumers — cmd.exe-based CLI shims refuse `\\?\` working
+/// directories and the UI treats `C:\DEV` and `\\?\C:\DEV` as two different
+/// projects (iOfficeAI/AionUi#3191) — so strip the prefix before serializing.
+/// Internal sandbox comparisons keep using the canonical (verbatim) form.
+fn to_response_path(path: &Path) -> String {
+    strip_verbatim_prefix(&path.to_string_lossy())
+}
+
+fn strip_verbatim_prefix(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{rest}")
+    } else if let Some(rest) = path.strip_prefix(r"\\?\") {
+        rest.to_owned()
+    } else {
+        path.to_owned()
+    }
+}
+
 fn expand_tilde(input: &str) -> PathBuf {
     if let Some(stripped) = input.strip_prefix('~')
         && let Some(home) = dirs::home_dir()
@@ -190,7 +212,7 @@ pub fn list_directory(
         }
         items.push(BrowseEntry {
             name,
-            path: entry_path.to_string_lossy().into_owned(),
+            path: to_response_path(&entry_path),
             is_directory: is_dir,
             is_file,
             size: Some(stat.len()),
@@ -212,7 +234,7 @@ pub fn list_directory(
     let (parent_path, can_go_up) = navigation_hints(dir, allowed_roots);
 
     Ok(BrowseDirectoryResponse {
-        current_path: dir.to_string_lossy().into_owned(),
+        current_path: to_response_path(dir),
         parent_path,
         items,
         can_go_up,
@@ -254,7 +276,7 @@ fn navigation_hints(dir: &Path, allowed_roots: &[PathBuf]) -> (Option<String>, b
         Err(_) => false,
     });
 
-    (Some(parent.to_string_lossy().into_owned()), parent_allowed)
+    (Some(to_response_path(parent)), parent_allowed)
 }
 
 // ---------------------------------------------------------------------------
@@ -469,6 +491,57 @@ mod tests {
             ),
             "expected outside-sandbox, got {err}"
         );
+    }
+
+    // Regression tests for iOfficeAI/AionUi#3191: responses must never carry
+    // Windows extended-length (verbatim) prefixes.
+
+    #[test]
+    fn strips_verbatim_disk_prefix() {
+        assert_eq!(strip_verbatim_prefix(r"\\?\C:\DEV\project"), r"C:\DEV\project");
+        assert_eq!(strip_verbatim_prefix(r"\\?\C:\"), r"C:\");
+    }
+
+    #[test]
+    fn strips_verbatim_unc_prefix() {
+        assert_eq!(
+            strip_verbatim_prefix(r"\\?\UNC\server\share\dir"),
+            r"\\server\share\dir"
+        );
+    }
+
+    #[test]
+    fn leaves_non_verbatim_paths_untouched() {
+        assert_eq!(strip_verbatim_prefix(r"C:\DEV\project"), r"C:\DEV\project");
+        assert_eq!(strip_verbatim_prefix(r"\\server\share"), r"\\server\share");
+        assert_eq!(strip_verbatim_prefix("/home/user/project"), "/home/user/project");
+        assert_eq!(strip_verbatim_prefix(""), "");
+    }
+
+    /// End-to-end assertion on Windows: `fs::canonicalize` produces verbatim
+    /// paths there, and every path in the response must come out clean.
+    #[cfg(windows)]
+    #[test]
+    fn browse_response_paths_use_no_verbatim_prefix() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir(tmp.path().join("sub")).unwrap();
+        let sub = tmp.path().join("sub");
+        fs::create_dir(sub.join("nested")).unwrap();
+        let roots = roots_from(&[tmp.path()]);
+
+        let resp = browse(Some(sub.to_str().unwrap()), false, &roots).unwrap();
+
+        assert!(
+            !resp.current_path.starts_with(r"\\?\"),
+            "current_path is verbatim: {}",
+            resp.current_path
+        );
+        if let Some(parent) = &resp.parent_path {
+            assert!(!parent.starts_with(r"\\?\"), "parent_path is verbatim: {parent}");
+        }
+        for item in &resp.items {
+            assert!(!item.path.starts_with(r"\\?\"), "item path is verbatim: {}", item.path);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

iOfficeAI/AionUi#3191 — on Windows, selecting a directory in the WebUI picker stores paths like `\\?\C:\DEV\xxxxx` as the conversation workspace. Claude Code then fails to connect (cmd.exe-based CLI shims reject verbatim working directories), and the same directory shows up as two different projects in the sidebar (`C:\DEV\xxxxx` from old sessions vs `\\?\C:\DEV\xxxxx` from new ones).

## Root cause

The `/api/fs/browse` endpoint (added in #235, replacing the legacy Express implementation in AionUi) resolves paths with `fs::canonicalize`, which on Windows returns extended-length (verbatim) paths — `\\?\C:\DEV`. Those strings were serialized verbatim into `current_path`, `parent_path` and every item `path`. The legacy Express endpoint built paths with Node's `path.join` and never produced this form, so this is an M6-cutover regression.

## Fix

Strip `\\?\` (and `\\?\UNC\` → `\\`) at the response-serialization boundary in `browse.rs`. Internal sandbox checks keep comparing canonical (verbatim) forms, so the allow-list semantics are unchanged.

## Tests

- Cross-platform string-level unit tests for the strip helper (covered by Linux CI)
- `#[cfg(windows)]` end-to-end regression test asserting no response path carries the verbatim prefix (fails on Windows without this fix)
- `cargo test` full workspace: 6022 passed; clippy `-D warnings` + fmt clean

Frontend defensive counterpart: iOfficeAI/AionUi PR (renderer-side normalization for older backend binaries) follows.

Fixes iOfficeAI/AionUi#3191