### PR TITLE
fix(auth): allow same-origin framing on office preview proxy routes

### DIFF
--- a/crates/aionui-app/tests/health.rs
+++ b/crates/aionui-app/tests/health.rs
@@ -110,3 +110,30 @@ async fn health_check_has_security_headers() {
         "strict-origin-when-cross-origin"
     );
 }
+
+#[tokio::test]
+async fn office_proxy_routes_allow_same_origin_framing() {
+    // Regression for iOfficeAI/AionUi#3177: the global security headers
+    // middleware must not overwrite the office preview proxies' framing
+    // policy with DENY, or the preview iframe is blanked in browsers.
+    let app = build_app().await;
+
+    for uri in ["/api/ppt-proxy/59999", "/api/office-watch-proxy/59999"] {
+        let response = app
+            .clone()
+            .oneshot(build_request("GET", uri))
+            .await
+            .expect("request failed");
+
+        assert_eq!(
+            response.headers().get("x-frame-options").unwrap(),
+            "SAMEORIGIN",
+            "{uri} must stay frameable by the same-origin web UI"
+        );
+        assert_eq!(
+            response.headers().get("content-security-policy").unwrap(),
+            "frame-ancestors 'self'",
+            "{uri} should carry the modern frame-ancestors policy"
+        );
+    }
+}

--- a/crates/aionui-auth/src/security.rs
+++ b/crates/aionui-auth/src/security.rs
@@ -1,5 +1,7 @@
 use axum::extract::Request;
-use axum::http::header::{HeaderValue, REFERRER_POLICY, X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS, X_XSS_PROTECTION};
+use axum::http::header::{
+    CONTENT_SECURITY_POLICY, HeaderValue, REFERRER_POLICY, X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS, X_XSS_PROTECTION,
+};
 use axum::middleware::Next;
 use axum::response::Response;
 
@@ -11,10 +13,17 @@ fn allows_embedding(path: &str) -> bool {
     )
 }
 
+/// Office preview proxies serve content loaded in same-origin iframes by
+/// the web UI; `DENY` here blanks the preview (iOfficeAI/AionUi#3177).
+fn allows_same_origin_embedding(path: &str) -> bool {
+    path.starts_with("/api/ppt-proxy/") || path.starts_with("/api/office-watch-proxy/")
+}
+
 /// Middleware that adds security response headers to every response.
 ///
 /// Headers set:
 /// - `X-Frame-Options: DENY` — prevent clickjacking on non-embeddable routes
+///   (`SAMEORIGIN` + `frame-ancestors 'self'` on office preview proxies)
 /// - `X-Content-Type-Options: nosniff` — prevent MIME sniffing
 /// - `X-XSS-Protection: 1; mode=block` — enable XSS filter
 /// - `Referrer-Policy: strict-origin-when-cross-origin` — limit referrer leakage
@@ -23,7 +32,15 @@ pub async fn security_headers_middleware(request: Request, next: Next) -> Respon
     let mut response = next.run(request).await;
     let headers = response.headers_mut();
 
-    if !allows_embedding(&path) {
+    if allows_same_origin_embedding(&path) {
+        headers.insert(X_FRAME_OPTIONS, HeaderValue::from_static("SAMEORIGIN"));
+        // Append rather than insert: CSP allows multiple policies and all
+        // are enforced, so an upstream policy is never silently dropped.
+        headers.append(
+            CONTENT_SECURITY_POLICY,
+            HeaderValue::from_static("frame-ancestors 'self'"),
+        );
+    } else if !allows_embedding(&path) {
         headers.insert(X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
     }
     headers.insert(X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static("nosniff"));
@@ -86,6 +103,37 @@ mod tests {
         assert_eq!(response.status(), axum::http::StatusCode::INTERNAL_SERVER_ERROR);
         // Security headers still present even on error responses
         assert_eq!(response.headers().get("x-frame-options").unwrap(), "DENY");
+    }
+
+    #[tokio::test]
+    async fn office_proxy_routes_get_sameorigin_frame_headers() {
+        // Regression for iOfficeAI/AionUi#3177: the office preview proxies
+        // serve iframe content for the same-origin web UI; `DENY` blanks
+        // the preview iframe in browsers.
+        let app = Router::new()
+            .route("/api/ppt-proxy/{port}", get(|| async { "ok" }))
+            .route("/api/office-watch-proxy/{port}/{*path}", get(|| async { "ok" }))
+            .layer(middleware::from_fn(security_headers_middleware));
+
+        for uri in ["/api/ppt-proxy/41307", "/api/office-watch-proxy/41307/some/page"] {
+            let response = app
+                .clone()
+                .oneshot(axum::http::Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+
+            assert_eq!(
+                response.headers().get("x-frame-options").unwrap(),
+                "SAMEORIGIN",
+                "{uri} must stay frameable by the same-origin web UI"
+            );
+            assert_eq!(
+                response.headers().get("content-security-policy").unwrap(),
+                "frame-ancestors 'self'",
+                "{uri} should carry the modern frame-ancestors policy"
+            );
+            assert_eq!(response.headers().get("x-content-type-options").unwrap(), "nosniff");
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Fixes iOfficeAI/AionUi#3177

In web mode, PPT/Office previews render blank. The browser console shows:

```
Refused to display 'http://host:25800/api/ppt-proxy/41307' in a frame because it set 'X-Frame-Options' to 'deny'.
```

## Root Cause

Two pieces of code conflict:

- The office `ProxyService` (`aionui-office/src/proxy.rs`) intentionally pushes `x-frame-options: SAMEORIGIN` on forwarded responses so the same-origin web UI can frame the preview.
- The global `security_headers_middleware` (`aionui-auth/src/security.rs`) runs as the outermost response layer and unconditionally `insert`s `X-Frame-Options: DENY`, replacing the proxy's value. Its only framing exemption is `/api/extensions/{name}/assets/*`.

The existing test `proxy_sets_x_frame_options_sameorigin` calls `proxy.forward()` directly and never goes through the middleware stack, so the override was invisible to CI.

## Fix

In `security_headers_middleware`, the office preview proxy prefixes (`/api/ppt-proxy/`, `/api/office-watch-proxy/`) now get:

- `X-Frame-Options: SAMEORIGIN`
- `Content-Security-Policy: frame-ancestors 'self'` (appended, so an upstream CSP is never dropped; modern browsers prefer CSP and validate the full ancestor chain)

All other routes keep `DENY` unchanged. Third-party sites still cannot frame these endpoints, and the preview pages are read-only viewers with no state-changing interactions, so no clickjacking surface is opened.

## Tests

- Middleware-level regression test in `security.rs` covering both proxy prefixes (TDD: failed with `DENY` before the fix)
- Full-router regression test `office_proxy_routes_allow_same_origin_framing` in `aionui-app/tests/health.rs` — goes through the real route tree and complete middleware stack, closing the integration blind spot that let this slip through
- Existing `DENY` baseline tests (`/health`, error responses, extension assets) unchanged and passing

## Verification on the real binary

Built `aioncore`, ran `--local`, and inspected headers with curl:

| Request | Before | After |
|---|---|---|
| `GET /health` (baseline) | `DENY` | `DENY` (unchanged) |
| `GET /api/ppt-proxy/:port` (403, inactive port) | `DENY` | `SAMEORIGIN` + `frame-ancestors 'self'` |
| `GET /api/ppt-proxy/:port` (200, live officecli PPTX preview) | `DENY` | `SAMEORIGIN` + `frame-ancestors 'self'` |

The 200-path check used a real preview session started via `POST /api/ppt-preview/start`, returning the actual officecli preview HTML.