### PR TITLE
fix(office): fetch officecli installer from official mirror before GitHub

### DIFF
--- a/crates/aionui-office/src/officecli_runtime.rs
+++ b/crates/aionui-office/src/officecli_runtime.rs
@@ -5,6 +5,12 @@ use std::path::PathBuf;
 
 use aionui_runtime::resolve_command_path;
 
+// The mirror serves the same install scripts and release assets as GitHub
+// (install.sh itself already downloads assets mirror-first). Fetching the
+// script must follow the same order: raw.githubusercontent.com is unreachable
+// from many server deployments (aionui#3212 follow-up).
+pub(crate) const OFFICECLI_INSTALL_SH_MIRROR_URL: &str = "https://d.officecli.ai/install.sh";
+pub(crate) const OFFICECLI_INSTALL_PS1_MIRROR_URL: &str = "https://d.officecli.ai/install.ps1";
 pub(crate) const OFFICECLI_INSTALL_SH_URL: &str =
     "https://raw.githubusercontent.com/iOfficeAI/OfficeCli/main/install.sh";
 pub(crate) const OFFICECLI_INSTALL_PS1_URL: &str =
@@ -44,14 +50,21 @@ pub(crate) fn install_command_for_platform(platform: OfficecliInstallPlatform) -
                 OsString::from("-ExecutionPolicy"),
                 OsString::from("Bypass"),
                 OsString::from("-Command"),
-                OsString::from(format!("irm {OFFICECLI_INSTALL_PS1_URL} | iex")),
+                OsString::from(format!(
+                    "$ErrorActionPreference='Stop'; try {{ $s = irm {OFFICECLI_INSTALL_PS1_MIRROR_URL} }} catch {{ $s = irm {OFFICECLI_INSTALL_PS1_URL} }}; iex $s"
+                )),
             ],
         },
         OfficecliInstallPlatform::Unix => OfficecliInstallCommand {
             program: OsString::from("bash"),
             args: vec![
                 OsString::from("-lc"),
-                OsString::from(format!("curl -fsSL {OFFICECLI_INSTALL_SH_URL} | bash")),
+                // Download to a temp file rather than piping: a connection
+                // dropped mid-stream would otherwise let the fallback output
+                // concatenate after a partial script.
+                OsString::from(format!(
+                    "f=$(mktemp) || exit 1; (curl -fsSL {OFFICECLI_INSTALL_SH_MIRROR_URL} -o \"$f\" || curl -fsSL {OFFICECLI_INSTALL_SH_URL} -o \"$f\") && bash \"$f\"; s=$?; rm -f \"$f\"; exit $s"
+                )),
             ],
         },
     }
@@ -164,5 +177,33 @@ mod tests {
 
         assert!(unix_text.contains("iOfficeAI/OfficeCli/main/install.sh"));
         assert!(windows_text.contains("iOfficeAI/OfficeCli/main/install.ps1"));
+    }
+
+    // Servers that cannot reach raw.githubusercontent.com (the common case on
+    // mainland-China clouds, see aionui#3212 follow-up) must still be able to
+    // fetch the installer: the official mirror comes first, GitHub is the
+    // fallback.
+    #[test]
+    fn installer_commands_try_mirror_before_github() {
+        let unix = install_command_for_test(OfficecliInstallPlatform::Unix);
+        let windows = install_command_for_test(OfficecliInstallPlatform::Windows);
+        let unix_text = format!("{:?} {:?}", unix.program, unix.args);
+        let windows_text = format!("{:?} {:?}", windows.program, windows.args);
+
+        let unix_mirror = unix_text.find("https://d.officecli.ai/install.sh");
+        let unix_github = unix_text.find("iOfficeAI/OfficeCli/main/install.sh");
+        assert!(unix_mirror.is_some(), "unix installer must include the mirror URL");
+        assert!(unix_mirror < unix_github, "unix installer must try the mirror first");
+
+        let windows_mirror = windows_text.find("https://d.officecli.ai/install.ps1");
+        let windows_github = windows_text.find("iOfficeAI/OfficeCli/main/install.ps1");
+        assert!(
+            windows_mirror.is_some(),
+            "windows installer must include the mirror URL"
+        );
+        assert!(
+            windows_mirror < windows_github,
+            "windows installer must try the mirror first"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- The officecli auto-install path hardcoded `raw.githubusercontent.com` for fetching the install script. `install.sh` itself already downloads release assets **mirror-first** (`d.officecli.ai`) precisely because GitHub is unreachable from many server deployments — but the script fetch was still GitHub-only, so auto-install died at step zero on those hosts (aionui#3212 follow-up: headless/remote preview availability).
- Try `https://d.officecli.ai/install.{sh,ps1}` first (verified: the mirror serves both), fall back to the GitHub raw URL.
- The Unix command now downloads to a temp file instead of piping. This fixes a second latent bug observed in testing: with `curl … | bash`, a connection failure feeds bash an **empty script that exits 0**, so `install_officecli` reported success and the user got a confusing `OFFICECLI_NOT_FOUND` instead of `INSTALL_FAILED`.

## E2E evidence (debian:bookworm-slim container, `raw.githubusercontent.com` pinned to 127.0.0.1 to simulate mainland-China clouds)

```
[OLD] curl … raw.githubusercontent.com … | bash
      curl: (7) Failed to connect … — and the pipe exits 0 (silent false success)
[NEW] mirror-first temp-file command
      Latest version: v1.0.110 / Downloading (via mirror) / Checksum verified / installed
[after install + libicu] officecli create + watch → HTTP 200, <title>t.pptx</title>
```

## Known follow-ups (out of scope here)

- Minimal Linux images lack `libicu`; officecli (.NET) aborts at startup without it ("Couldn't find a valid ICU package"). AionUi-side guidance is being added separately; OfficeCli's install.sh could also post-check and warn.
- `bash`/`curl` must exist on the host (Alpine ships neither by default).

## Test plan

- [x] New unit test `installer_commands_try_mirror_before_github` (mirror URL present and ordered before GitHub, both platforms) — watched fail before the change
- [x] `cargo test -p aionui-office` all green; `cargo fmt --check`; `cargo clippy -p aionui-office --all-targets -D warnings`
- [x] Container e2e above: old command fails (silently), new command installs via mirror, full `create → watch → HTTP 200` chain works with libicu present