### PR TITLE
fix(agent): send non-empty clientInfo in ACP initialize handshake

### DIFF
--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -27,7 +27,7 @@ use std::sync::{Arc, RwLock};
 
 use agent_client_protocol::schema::{
     AGENT_METHOD_NAMES, AuthenticateResponse, ClientNotification, ClientRequest, CloseSessionResponse, ExtResponse,
-    ForkSessionResponse, InitializeRequest, LoadSessionResponse, PromptResponse, ProtocolVersion,
+    ForkSessionResponse, Implementation, InitializeRequest, LoadSessionResponse, PromptResponse, ProtocolVersion,
     RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse, ResumeSessionResponse,
     SelectedPermissionOutcome, SessionNotification, SetSessionConfigOptionResponse, SetSessionModeResponse,
     SetSessionModelResponse,
@@ -53,6 +53,22 @@ use agent_client_protocol::schema::{
 
 /// Timeout for the ACP initialize handshake (seconds).
 const INIT_TIMEOUT_SECS: u64 = 30;
+
+/// Client identity reported in the ACP `initialize` handshake (`clientInfo`).
+///
+/// Some agents forward these fields downstream as client metadata — e.g. Mistral
+/// Vibe passes them to the Mistral API as `client_name`/`client_version`, which the
+/// API rejects when empty. Always send non-empty values (see issue #3326).
+const ACP_CLIENT_NAME: &str = "AionUi";
+const ACP_CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Build the ACP `initialize` request, always populating `clientInfo` with a
+/// non-empty name and version so downstream agents that require client metadata
+/// (e.g. Mistral Vibe) accept the request. See issue #3326.
+fn build_initialize_request() -> InitializeRequest {
+    InitializeRequest::new(ProtocolVersion::LATEST)
+        .client_info(Implementation::new(ACP_CLIENT_NAME, ACP_CLIENT_VERSION))
+}
 
 /// A pending permission request from the agent, awaiting user decision.
 pub struct PermissionRequest {
@@ -421,7 +437,7 @@ async fn run_sdk_background(
             // Step 1 — initialize handshake. main_fn is the canonical place
             // to call `block_task` (see SDK `connect_with` doc example).
             let init_result = {
-                let req = InitializeRequest::new(ProtocolVersion::LATEST);
+                let req = build_initialize_request();
                 log_client_request("initialize", &json_str(&req));
                 let raw = connection.send_request(req).block_task().await;
                 log_agent_response("initialize", &json_or_err(&raw));
@@ -890,5 +906,22 @@ mod tests {
         assert!(!is_streaming_chunk(mode_update));
         assert!(!is_streaming_chunk(unknown), "unknown kinds default to keep");
         assert!(!is_streaming_chunk(malformed), "malformed bodies default to keep");
+    }
+
+    #[test]
+    fn initialize_request_sends_non_empty_client_info() {
+        // Regression test for #3326: agents like Mistral Vibe forward clientInfo
+        // downstream as client_name/client_version and reject empty values.
+        let req = build_initialize_request();
+
+        let client_info = req.client_info.as_ref().expect("clientInfo must be present");
+        assert_eq!(client_info.name, "AionUi");
+        assert!(!client_info.name.is_empty(), "client name must not be empty");
+        assert!(!client_info.version.is_empty(), "client version must not be empty");
+
+        // The serialized handshake must carry non-empty camelCase clientInfo fields.
+        let json = serde_json::to_value(&req).expect("request serializes");
+        assert_eq!(json["clientInfo"]["name"], "AionUi");
+        assert_ne!(json["clientInfo"]["version"], "");
     }
 }


### PR DESCRIPTION
## Summary

- ACP `initialize` was built via `InitializeRequest::new(...)`, leaving `client_info: None`, so the handshake carried no `clientInfo`.
- Agents that forward client metadata downstream (Mistral Vibe → Mistral API as `client_name`/`client_version`) received empty values and rejected **every** request with `metadata value cannot be empty`. The UI only surfaced a generic `UNKNOWN_UPSTREAM_ERROR` / `code -32603`.
- Now always populate `clientInfo` with name `"AionUi"` and the backend version (`env!("CARGO_PKG_VERSION")`).

Other agents (Claude Code, OpenCode) don't validate this field, which is why only Mistral Vibe was affected.

## Related Issues

Fixes iOfficeAI/AionUi#3326

## Test Plan

- [x] New regression test `initialize_request_sends_non_empty_client_info` verifies serialized `clientInfo.name == "AionUi"` and non-empty version
- [x] `cargo test -p aionui-ai-agent` (protocol::acp module) passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p aionui-ai-agent` no new warnings