### PR TITLE
fix: preserve assistant snapshot and skill wiring for cron

### DIFF
--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -618,6 +618,15 @@ pub fn build_cron_state(services: &AppServices) -> CronRouterState {
     conv_service.with_mcp_server_repo(Arc::new(aionui_db::SqliteMcpServerRepository::new(
         services.database.pool().clone(),
     )));
+    conv_service.with_assistant_definition_repo(Arc::new(SqliteAssistantDefinitionRepository::new(
+        services.database.pool().clone(),
+    )));
+    conv_service.with_assistant_state_repo(Arc::new(SqliteAssistantOverlayRepository::new(
+        services.database.pool().clone(),
+    )));
+    conv_service.with_assistant_preference_repo(Arc::new(SqliteAssistantPreferenceRepository::new(
+        services.database.pool().clone(),
+    )));
 
     let executor = Arc::new(aionui_cron::executor::JobExecutor::new(
         services.worker_task_manager.clone(),

--- a/crates/aionui-app/tests/assistants_e2e.rs
+++ b/crates/aionui-app/tests/assistants_e2e.rs
@@ -59,6 +59,7 @@ struct Fixture {
 ///   `builtin-bare` with nothing referenced)
 /// - a temp user-data dir that `AssistantService` uses for user rule/skill/
 ///   avatar storage
+///
 /// Also logs in `admin` and hands back the session + CSRF tokens so tests
 /// can issue authenticated mutating requests.
 async fn fixture() -> Fixture {

--- a/crates/aionui-app/tests/cron_e2e.rs
+++ b/crates/aionui-app/tests/cron_e2e.rs
@@ -11,7 +11,10 @@ use axum::http::StatusCode;
 use serde_json::json;
 use tower::ServiceExt;
 
-use aionui_db::{ICronRepository, SqliteCronRepository};
+use aionui_db::{
+    CreateMcpServerParams, IConversationRepository, ICronRepository, IMcpServerRepository,
+    SqliteConversationRepository, SqliteCronRepository, SqliteMcpServerRepository,
+};
 
 use common::{
     body_json, build_app, build_app_with_mock_agents, delete_with_token, get_request, get_with_token, json_with_token,
@@ -608,6 +611,143 @@ async fn rn1b_run_now_returns_conflict_when_conversation_is_busy() {
     );
 
     drop(claim);
+}
+
+#[tokio::test]
+async fn rn1c_run_now_new_conversation_preset_assistant_uses_fixed_assistant_mcps() {
+    let (mut app, services) = build_app_with_mock_agents().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let mcp_repo = SqliteMcpServerRepository::new(services.database.pool().clone());
+    let fixed_mcp = mcp_repo
+        .create(CreateMcpServerParams {
+            name: "fixed-mcp",
+            description: None,
+            enabled: true,
+            transport_type: "http",
+            transport_config: r#"{"url":"https://example.invalid/fixed"}"#,
+            tools: None,
+            original_json: None,
+            builtin: false,
+        })
+        .await
+        .expect("create fixed mcp");
+    let extra_mcp = mcp_repo
+        .create(CreateMcpServerParams {
+            name: "extra-mcp",
+            description: None,
+            enabled: true,
+            transport_type: "http",
+            transport_config: r#"{"url":"https://example.invalid/extra"}"#,
+            tools: None,
+            original_json: None,
+            builtin: false,
+        })
+        .await
+        .expect("create extra mcp");
+
+    let create_assistant_req = json_with_token(
+        "POST",
+        "/api/assistants",
+        json!({
+            "id": "u-fixed-mcp",
+            "name": "Cron MCP Assistant",
+            "preset_agent_type": "codex",
+            "defaults": {
+                "mcps": {
+                    "mode": "fixed",
+                    "value": [fixed_mcp.id]
+                }
+            }
+        }),
+        &token,
+        &csrf,
+    );
+    let create_assistant_resp = app.clone().oneshot(create_assistant_req).await.unwrap();
+    assert_eq!(create_assistant_resp.status(), StatusCode::CREATED);
+
+    let create_job_req = json_with_token(
+        "POST",
+        "/api/cron/jobs",
+        json!({
+            "name": "Preset Assistant Cron",
+            "schedule": { "kind": "every", "every_ms": 60000, "description": "every minute" },
+            "message": "cron preset assistant message",
+            "conversation_id": "",
+            "agent_type": "acp",
+            "created_by": "user",
+            "execution_mode": "new_conversation",
+            "agent_config": {
+                "backend": "codex",
+                "name": "Cron MCP Assistant",
+                "is_preset": true,
+                "custom_agent_id": "u-fixed-mcp",
+                "preset_agent_type": "codex"
+            }
+        }),
+        &token,
+        &csrf,
+    );
+    let create_job_resp = app.clone().oneshot(create_job_req).await.unwrap();
+    assert_eq!(create_job_resp.status(), StatusCode::CREATED);
+    let create_job_body = body_json(create_job_resp).await;
+    let job_id = create_job_body["data"]["id"]
+        .as_str()
+        .expect("cron job id should be present");
+    let saved_skill_name = format!("cron-{job_id}");
+
+    let save_skill_req = json_with_token(
+        "POST",
+        &format!("/api/cron/jobs/{job_id}/skill"),
+        json!({
+            "content": "---\nname: saved cron skill\ndescription: saved cron skill\n---\nUse the saved cron skill"
+        }),
+        &token,
+        &csrf,
+    );
+    let save_skill_resp = app.clone().oneshot(save_skill_req).await.unwrap();
+    assert_eq!(save_skill_resp.status(), StatusCode::OK);
+
+    let run_req = json_with_token(
+        "POST",
+        &format!("/api/cron/jobs/{job_id}/run"),
+        json!({}),
+        &token,
+        &csrf,
+    );
+    let run_resp = app.clone().oneshot(run_req).await.unwrap();
+    assert_eq!(run_resp.status(), StatusCode::OK);
+    let run_body = body_json(run_resp).await;
+    let conversation_id = run_body["data"]["conversation_id"]
+        .as_str()
+        .expect("run-now should return created conversation id");
+
+    let conversation_repo = SqliteConversationRepository::new(services.database.pool().clone());
+    let conversation = conversation_repo
+        .get(conversation_id)
+        .await
+        .expect("load conversation")
+        .expect("conversation should exist");
+    let extra: serde_json::Value =
+        serde_json::from_str(&conversation.extra).expect("conversation extra should be valid json");
+    assert_eq!(extra["preset_assistant_id"], "u-fixed-mcp");
+    assert_eq!(extra["mcp_server_ids"], json!([fixed_mcp.id]));
+    assert_eq!(extra["mcp_servers"], json!(["fixed-mcp"]));
+    assert!(
+        extra["skills"].as_array().is_some_and(|skills| {
+            skills.iter().all(|skill| skill != "cron") && skills.iter().any(|skill| skill == &saved_skill_name)
+        }),
+        "cron-created conversations must exclude builtin cron but keep the saved job skill"
+    );
+    assert_ne!(fixed_mcp.id, extra_mcp.id, "fixture should seed two distinct MCP rows");
+
+    let snapshot = conversation_repo
+        .get_assistant_snapshot(conversation_id)
+        .await
+        .expect("load assistant snapshot")
+        .expect("preset assistant cron conversation should persist snapshot");
+    assert_eq!(snapshot.assistant_key, "u-fixed-mcp");
+    assert_eq!(snapshot.resolved_mcp_ids, json!([fixed_mcp.id]).to_string());
 }
 
 #[tokio::test]

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -665,21 +665,30 @@ impl ConversationService {
             Vec::new()
         }
 
+        fn merge_string_lists(primary: &[String], secondary: &[String]) -> Vec<String> {
+            let mut merged = primary.to_vec();
+            for value in secondary {
+                if !merged.iter().any(|existing| existing == value) {
+                    merged.push(value.clone());
+                }
+            }
+            merged
+        }
+
         let (preset_enabled, exclude_auto_inject) = match extra.as_object_mut() {
             Some(obj) => {
-                let preset = assistant_snapshot
-                    .as_ref()
-                    .map(|snapshot| snapshot.resolved_defaults.skill_ids.clone())
-                    .unwrap_or_else(|| take_string_array(obj, &["preset_enabled_skills", "enabled_skills"]));
-                let exclude = assistant_snapshot
-                    .as_ref()
-                    .map(|snapshot| snapshot.resolved_defaults.disabled_builtin_skill_ids.clone())
-                    .unwrap_or_else(|| {
-                        take_string_array(obj, &["exclude_auto_inject_skills", "exclude_builtin_skills"])
-                    });
+                let extra_preset = take_string_array(obj, &["preset_enabled_skills", "enabled_skills"]);
+                let extra_exclude = take_string_array(obj, &["exclude_auto_inject_skills", "exclude_builtin_skills"]);
                 // Strip the stale cache field if a clone copied it in.
                 obj.remove("loaded_skills");
-                (preset, exclude)
+
+                match assistant_snapshot.as_ref() {
+                    Some(snapshot) => (
+                        merge_string_lists(&snapshot.resolved_defaults.skill_ids, &extra_preset),
+                        merge_string_lists(&snapshot.resolved_defaults.disabled_builtin_skill_ids, &extra_exclude),
+                    ),
+                    None => (extra_preset, extra_exclude),
+                }
             }
             None => (Vec::new(), Vec::new()),
         };

--- a/crates/aionui-team/src/provisioning.rs
+++ b/crates/aionui-team/src/provisioning.rs
@@ -103,13 +103,13 @@ impl TeamAgentProvisioner {
                     team_id,
                     &slot_id,
                     role,
-                &input.name,
-                &input.backend,
-                &input.model,
-                input.custom_agent_id.as_deref(),
-                input.conversation_id.as_deref(),
-                shared_workspace,
-            )
+                    &input.name,
+                    &input.backend,
+                    &input.model,
+                    input.custom_agent_id.as_deref(),
+                    input.conversation_id.as_deref(),
+                    shared_workspace,
+                )
                 .await?;
             agents.push(TeamAgent {
                 slot_id,
@@ -368,6 +368,7 @@ impl TeamAgentProvisioner {
             .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn build_team_extra(
         &self,
         team_id: &str,

--- a/crates/aionui-team/src/provisioning.rs
+++ b/crates/aionui-team/src/provisioning.rs
@@ -103,12 +103,13 @@ impl TeamAgentProvisioner {
                     team_id,
                     &slot_id,
                     role,
-                    &input.name,
-                    &input.backend,
-                    &input.model,
-                    input.conversation_id.as_deref(),
-                    shared_workspace,
-                )
+                &input.name,
+                &input.backend,
+                &input.model,
+                input.custom_agent_id.as_deref(),
+                input.conversation_id.as_deref(),
+                shared_workspace,
+            )
                 .await?;
             agents.push(TeamAgent {
                 slot_id,
@@ -258,6 +259,7 @@ impl TeamAgentProvisioner {
                 &input.name,
                 &input.backend,
                 &input.model,
+                input.custom_agent_id.as_deref(),
                 None,
                 input.workspace.as_deref(),
             )
@@ -286,11 +288,12 @@ impl TeamAgentProvisioner {
         name: &str,
         backend: &str,
         model: &str,
+        custom_agent_id: Option<&str>,
         existing_conversation_id: Option<&str>,
         workspace: Option<&str>,
     ) -> Result<String, TeamError> {
         let extra = self
-            .build_team_extra(team_id, slot_id, role, backend, model, workspace)
+            .build_team_extra(team_id, slot_id, role, backend, model, custom_agent_id, workspace)
             .await?;
         if let Some(existing_id) = existing_conversation_id {
             self.conversation_port
@@ -372,6 +375,7 @@ impl TeamAgentProvisioner {
         role: TeammateRole,
         backend: &str,
         model: &str,
+        custom_agent_id: Option<&str>,
         workspace: Option<&str>,
     ) -> Result<serde_json::Value, TeamError> {
         let mut extra = serde_json::json!({
@@ -383,6 +387,10 @@ impl TeamAgentProvisioner {
         });
         if parse_agent_type(backend)? != AgentType::Aionrs {
             extra["current_model_id"] = serde_json::Value::String(model.to_owned());
+        }
+        if let Some(custom_agent_id) = custom_agent_id {
+            extra["custom_agent_id"] = serde_json::Value::String(custom_agent_id.to_owned());
+            extra["preset_assistant_id"] = serde_json::Value::String(custom_agent_id.to_owned());
         }
         if let Some(workspace) = workspace {
             inherit_team_workspace(&mut extra, workspace);

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -1124,6 +1124,44 @@ async fn tc_create_team_uses_custom_agent_id_icon_lookup() {
 }
 
 #[tokio::test]
+async fn tc_create_team_carries_assistant_identity_into_lead_conversation_extra() {
+    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = Arc::new(StubAgentMetadataRepo::with_rows(vec![
+        make_agent_metadata_row("2d23ff1c", "claude", "/api/assets/logos/ai-major/claude.svg"),
+    ]));
+    let (svc, _task_manager, conv_repo) =
+        setup_with_factory_and_metadata_and_conversation_repo(success_factory(), agent_metadata_repo);
+
+    let resp = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "Alpha".into(),
+                agents: vec![TeamAgentInput {
+                    name: "Lead".into(),
+                    role: "lead".into(),
+                    backend: "claude".into(),
+                    model: "claude".into(),
+                    custom_agent_id: Some("2d23ff1c".into()),
+                    conversation_id: None,
+                }],
+                workspace: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let row = conv_repo
+        .get(&resp.agents[0].conversation_id)
+        .await
+        .unwrap()
+        .expect("lead conversation row");
+    let extra: serde_json::Value = serde_json::from_str(&row.extra).unwrap();
+
+    assert_eq!(extra["custom_agent_id"], serde_json::json!("2d23ff1c"));
+    assert_eq!(extra["preset_assistant_id"], serde_json::json!("2d23ff1c"));
+}
+
+#[tokio::test]
 async fn ta_add_agent_uses_model_fallback_for_acp_backend() {
     let svc = setup_with_metadata_rows(vec![make_agent_metadata_row(
         "8e1acf31",

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -1125,9 +1125,12 @@ async fn tc_create_team_uses_custom_agent_id_icon_lookup() {
 
 #[tokio::test]
 async fn tc_create_team_carries_assistant_identity_into_lead_conversation_extra() {
-    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = Arc::new(StubAgentMetadataRepo::with_rows(vec![
-        make_agent_metadata_row("2d23ff1c", "claude", "/api/assets/logos/ai-major/claude.svg"),
-    ]));
+    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> =
+        Arc::new(StubAgentMetadataRepo::with_rows(vec![make_agent_metadata_row(
+            "2d23ff1c",
+            "claude",
+            "/api/assets/logos/ai-major/claude.svg",
+        )]));
     let (svc, _task_manager, conv_repo) =
         setup_with_factory_and_metadata_and_conversation_repo(success_factory(), agent_metadata_repo);
 


### PR DESCRIPTION
## Summary
- wire assistant repositories into the cron-specific conversation service so preset assistant cron runs create snapshots
- merge cron-specific skill overrides with assistant snapshot defaults instead of overwriting them
- add cron e2e coverage for fixed MCP assistants and saved cron skill propagation

## Verification
- cargo test -p aionui-app --test cron_e2e
- cargo test -p aionui-team tc_create_team_carries_assistant_identity_into_lead_conversation_extra --test session_service_integration

## Paired frontend PR
- iOfficeAI/AionUi: fix assistant cron and guid metadata flows