### PR TITLE
feat: align team shared workspace resolution

### DIFF
--- a/crates/aionui-api-types/src/team.rs
+++ b/crates/aionui-api-types/src/team.rs
@@ -305,6 +305,8 @@ pub struct TeamAgentResponse {
 pub struct TeamResponse {
     pub id: String,
     pub name: String,
+    #[serde(default)]
+    pub workspace: String,
     pub agents: Vec<TeamAgentResponse>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lead_agent_id: Option<String>,
@@ -656,6 +658,7 @@ mod tests {
         let team = TeamResponse {
             id: "team-1".into(),
             name: "Alpha".into(),
+            workspace: "/workspace/team-1".into(),
             agents: vec![TeamAgentResponse {
                 slot_id: "slot-1".into(),
                 name: "Lead".into(),
@@ -675,6 +678,7 @@ mod tests {
         let json = serde_json::to_value(&team).unwrap();
         assert_eq!(json["id"], "team-1");
         assert_eq!(json["name"], "Alpha");
+        assert_eq!(json["workspace"], "/workspace/team-1");
         assert_eq!(json["lead_agent_id"], "slot-1");
         assert_eq!(json["created_at"], 1700000000000_i64);
         assert_eq!(json["updated_at"], 1700001000000_i64);
@@ -687,6 +691,7 @@ mod tests {
         let team = TeamResponse {
             id: "team-2".into(),
             name: "Beta".into(),
+            workspace: String::new(),
             agents: vec![],
             lead_agent_id: None,
             created_at: 1700000000000,
@@ -787,6 +792,7 @@ mod tests {
         let team = TeamResponse {
             id: "team-1".into(),
             name: "Alpha".into(),
+            workspace: "/workspace/team-1".into(),
             agents: vec![
                 TeamAgentResponse {
                     slot_id: "s1".into(),

--- a/crates/aionui-app/src/router/team_conversation_adapters.rs
+++ b/crates/aionui-app/src/router/team_conversation_adapters.rs
@@ -12,8 +12,8 @@ use aionui_realtime::EventBroadcaster;
 use aionui_team::{
     AgentTurnCancellationPort, AgentTurnExecutionError, AgentTurnExecutionPort, AgentTurnOutcome, AgentTurnRequest,
     AgentTurnStarted, AgentTurnStatus, TeamConversationAdoptRequest, TeamConversationBindingLookup,
-    TeamConversationCreateRequest, TeamConversationLookupPort, TeamConversationProvisioningPort, TeamError,
-    TeamProjectionMessageStore,
+    TeamConversationCreateRequest, TeamConversationCreateResult, TeamConversationLookupPort,
+    TeamConversationProvisioningPort, TeamError, TeamProjectionMessageStore,
 };
 use async_trait::async_trait;
 
@@ -142,7 +142,10 @@ impl TeamProjectionMessageStore for TeamConversationAdapters {
 
 #[async_trait]
 impl TeamConversationProvisioningPort for TeamConversationAdapters {
-    async fn create_team_conversation(&self, request: TeamConversationCreateRequest) -> Result<String, TeamError> {
+    async fn create_team_conversation(
+        &self,
+        request: TeamConversationCreateRequest,
+    ) -> Result<TeamConversationCreateResult, TeamError> {
         let response = self
             .conversation_service
             .create(
@@ -159,7 +162,17 @@ impl TeamConversationProvisioningPort for TeamConversationAdapters {
             )
             .await
             .map_err(map_conversation_create_error)?;
-        Ok(response.id)
+        let workspace = response
+            .extra
+            .get("workspace")
+            .and_then(serde_json::Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| TeamError::InvalidRequest("created team conversation did not resolve a workspace".into()))?
+            .to_owned();
+        Ok(TeamConversationCreateResult {
+            conversation_id: response.id,
+            workspace,
+        })
     }
 
     async fn adopt_team_conversation(&self, request: TeamConversationAdoptRequest) -> Result<(), TeamError> {
@@ -175,6 +188,25 @@ impl TeamConversationProvisioningPort for TeamConversationAdapters {
             }),
         ));
         Ok(())
+    }
+
+    async fn conversation_workspace(&self, conversation_id: &str) -> Result<Option<String>, TeamError> {
+        let Some(row) = self.conversation_repo.get(conversation_id).await? else {
+            return Ok(None);
+        };
+        let extra: serde_json::Value = serde_json::from_str(&row.extra).unwrap_or(serde_json::Value::Null);
+        Ok(extra
+            .get("workspace")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned))
+    }
+
+    async fn create_team_temp_workspace(&self, team_id: &str) -> Result<String, TeamError> {
+        self.conversation_service
+            .create_team_temp_workspace(team_id)
+            .map_err(map_conversation_update_error)
     }
 
     async fn patch_runtime_config(&self, conversation_id: &str, patch: serde_json::Value) -> Result<(), TeamError> {

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -327,6 +327,16 @@ impl ConversationService {
         self
     }
 
+    pub fn create_team_temp_workspace(&self, team_id: &str) -> Result<String, ConversationError> {
+        let ws_path = self
+            .workspace_root
+            .join("conversations")
+            .join(format!("team-temp-{team_id}"));
+        std::fs::create_dir_all(&ws_path)
+            .map_err(|e| ConversationError::internal(format!("Failed to create Team temporary workspace: {e}")))?;
+        Ok(ws_path.to_string_lossy().into_owned())
+    }
+
     pub fn with_cron_service(&self, cron_service: Option<Arc<dyn ICronService>>) {
         if let Ok(mut guard) = self.cron_service.write() {
             *guard = cron_service;

--- a/crates/aionui-db/src/repository/sqlite_team.rs
+++ b/crates/aionui-db/src/repository/sqlite_team.rs
@@ -70,6 +70,9 @@ impl ITeamRepository for SqliteTeamRepository {
         if params.name.is_some() {
             set_clauses.push("name = ?");
         }
+        if params.workspace.is_some() {
+            set_clauses.push("workspace = ?");
+        }
         if params.agents.is_some() {
             set_clauses.push("agents = ?");
         }
@@ -87,6 +90,9 @@ impl ITeamRepository for SqliteTeamRepository {
         let mut query = sqlx::query(&sql);
         if let Some(ref name) = params.name {
             query = query.bind(name);
+        }
+        if let Some(ref workspace) = params.workspace {
+            query = query.bind(workspace);
         }
         if let Some(ref agents) = params.agents {
             query = query.bind(agents);

--- a/crates/aionui-db/src/repository/team.rs
+++ b/crates/aionui-db/src/repository/team.rs
@@ -5,6 +5,7 @@ use crate::models::{MailboxMessageRow, TeamRow, TeamTaskRow};
 #[derive(Debug, Clone, Default)]
 pub struct UpdateTeamParams {
     pub name: Option<String>,
+    pub workspace: Option<String>,
     pub agents: Option<String>,
     pub lead_agent_id: Option<String>,
 }

--- a/crates/aionui-db/tests/team_repository.rs
+++ b/crates/aionui-db/tests/team_repository.rs
@@ -179,6 +179,26 @@ async fn update_team_agents_json() {
 }
 
 #[tokio::test]
+async fn update_team_can_patch_workspace() {
+    let db = init_database_memory().await.unwrap();
+    let repo = SqliteTeamRepository::new(db.pool().clone());
+    repo.create_team(&make_team("t1", "Team")).await.unwrap();
+
+    repo.update_team(
+        "t1",
+        &UpdateTeamParams {
+            workspace: Some("/tmp/aionui-team-shared-workspace".into()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let updated = repo.get_team("t1").await.unwrap().unwrap();
+    assert_eq!(updated.workspace, "/tmp/aionui-team-shared-workspace");
+}
+
+#[tokio::test]
 async fn update_nonexistent_team_returns_not_found() {
     let (repo, _db) = repo().await;
     let result = repo

--- a/crates/aionui-team/src/lib.rs
+++ b/crates/aionui-team/src/lib.rs
@@ -24,6 +24,7 @@ pub(crate) mod test_utils;
 pub mod types;
 pub mod visibility;
 mod wake;
+mod workspace;
 
 pub use crash_detection::{CrashReason, detect_crash, is_rate_limited};
 pub use error::TeamError;

--- a/crates/aionui-team/src/lib.rs
+++ b/crates/aionui-team/src/lib.rs
@@ -43,7 +43,8 @@ pub use ports::{
 
 pub use prompts::{build_lead_prompt, build_teammate_prompt, build_wake_payload};
 pub use provisioning::{
-    TeamAgentProvisioner, TeamConversationAdoptRequest, TeamConversationCreateRequest, TeamConversationProvisioningPort,
+    TeamAgentProvisioner, TeamConversationAdoptRequest, TeamConversationCreateRequest, TeamConversationCreateResult,
+    TeamConversationProvisioningPort,
 };
 pub use routes::{TeamRouterState, team_routes};
 pub use scheduler::{

--- a/crates/aionui-team/src/provisioning.rs
+++ b/crates/aionui-team/src/provisioning.rs
@@ -396,9 +396,8 @@ impl TeamAgentProvisioner {
             .update_team(
                 team_id,
                 &UpdateTeamParams {
-                    name: None,
                     agents: Some(agents_json),
-                    lead_agent_id: None,
+                    ..Default::default()
                 },
             )
             .await?;

--- a/crates/aionui-team/src/provisioning.rs
+++ b/crates/aionui-team/src/provisioning.rs
@@ -44,6 +44,12 @@ pub struct TeamConversationCreateRequest {
     pub extra: serde_json::Value,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TeamConversationCreateResult {
+    pub conversation_id: String,
+    pub workspace: String,
+}
+
 pub struct TeamConversationAdoptRequest {
     pub conversation_id: String,
     pub extra: serde_json::Value,
@@ -51,9 +57,16 @@ pub struct TeamConversationAdoptRequest {
 
 #[async_trait]
 pub trait TeamConversationProvisioningPort: Send + Sync {
-    async fn create_team_conversation(&self, request: TeamConversationCreateRequest) -> Result<String, TeamError>;
+    async fn create_team_conversation(
+        &self,
+        request: TeamConversationCreateRequest,
+    ) -> Result<TeamConversationCreateResult, TeamError>;
 
     async fn adopt_team_conversation(&self, request: TeamConversationAdoptRequest) -> Result<(), TeamError>;
+
+    async fn conversation_workspace(&self, conversation_id: &str) -> Result<Option<String>, TeamError>;
+
+    async fn create_team_temp_workspace(&self, team_id: &str) -> Result<String, TeamError>;
 
     async fn patch_runtime_config(&self, conversation_id: &str, patch: serde_json::Value) -> Result<(), TeamError>;
 
@@ -332,7 +345,7 @@ impl TeamAgentProvisioner {
             extra["current_model_id"] = serde_json::Value::String(model.to_owned());
             (None, extra)
         };
-        let conv_id = self
+        let created = self
             .conversation_port
             .create_team_conversation(TeamConversationCreateRequest {
                 user_id: user_id.to_owned(),
@@ -342,6 +355,7 @@ impl TeamAgentProvisioner {
                 extra,
             })
             .await?;
+        let conv_id = created.conversation_id;
         info!(
             team_id,
             slot_id,

--- a/crates/aionui-team/src/provisioning.rs
+++ b/crates/aionui-team/src/provisioning.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use aionui_ai_agent::IWorkerTaskManager;
 use aionui_api_types::{AddAgentRequest, TeamAgentInput};
 use aionui_common::{AgentKillReason, AgentType, ProviderWithModel, generate_id};
+use aionui_db::models::TeamRow;
 use aionui_db::{IProviderRepository, ITeamRepository, UpdateTeamParams};
 use async_trait::async_trait;
 use tracing::{info, warn};
@@ -210,11 +211,12 @@ impl TeamAgentProvisioner {
     pub(crate) async fn add_agent(
         &self,
         user_id: &str,
+        row: &TeamRow,
         team: &mut Team,
         req: AddAgentRequest,
-        workspace: &str,
     ) -> Result<TeamAgent, TeamError> {
         let role = TeammateRole::parse(&req.role).unwrap_or(TeammateRole::Teammate);
+        let workspace = self.workspace_resolver().resolve_for_new_agent(row, team).await?;
         let agent = self
             .provision_new_agent(NewAgentProvisioning {
                 user_id: user_id.to_owned(),
@@ -224,7 +226,7 @@ impl TeamAgentProvisioner {
                 backend: req.backend,
                 model: req.model,
                 custom_agent_id: req.custom_agent_id,
-                workspace: Some(workspace.to_owned()),
+                workspace: Some(workspace),
             })
             .await?;
         team.agents.push(agent.clone());
@@ -247,6 +249,7 @@ impl TeamAgentProvisioner {
             .await?
             .ok_or_else(|| TeamError::TeamNotFound(team_id.into()))?;
         let mut team = Team::from_row(&row)?;
+        let workspace = self.workspace_resolver().resolve_for_new_agent(&row, &team).await?;
         let agent = self
             .provision_new_agent(NewAgentProvisioning {
                 user_id: user_id.to_owned(),
@@ -256,7 +259,7 @@ impl TeamAgentProvisioner {
                 backend,
                 model,
                 custom_agent_id,
-                workspace: Some(row.workspace.clone()),
+                workspace: Some(workspace),
             })
             .await?;
         team.agents.push(agent.clone());

--- a/crates/aionui-team/src/provisioning.rs
+++ b/crates/aionui-team/src/provisioning.rs
@@ -5,7 +5,7 @@ use aionui_api_types::{AddAgentRequest, TeamAgentInput};
 use aionui_common::{AgentKillReason, AgentType, ProviderWithModel, generate_id};
 use aionui_db::{IProviderRepository, ITeamRepository, UpdateTeamParams};
 use async_trait::async_trait;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::error::TeamError;
 use crate::mcp::TeamMcpStdioConfig;
@@ -23,6 +23,12 @@ pub struct TeamAgentProvisioner {
 pub(crate) struct InitialProvisioningResult {
     pub agents: Vec<TeamAgent>,
     pub lead_agent_id: Option<String>,
+    pub team_workspace: String,
+}
+
+struct ProvisionedConversation {
+    conversation_id: String,
+    workspace: Option<String>,
 }
 
 struct NewAgentProvisioning {
@@ -102,15 +108,56 @@ impl TeamAgentProvisioner {
         inputs: &[TeamAgentInput],
         shared_workspace: Option<&str>,
     ) -> Result<InitialProvisioningResult, TeamError> {
+        let Some((leader_input, teammate_inputs)) = inputs.split_first() else {
+            return Err(TeamError::InvalidRequest("at least one agent is required".into()));
+        };
+
+        let leader_slot_id = generate_id();
+        let leader_role = TeammateRole::Lead;
+        let leader_conversation = self
+            .create_or_adopt_conversation(
+                user_id,
+                team_id,
+                &leader_slot_id,
+                leader_role,
+                &leader_input.name,
+                &leader_input.backend,
+                &leader_input.model,
+                leader_input.conversation_id.as_deref(),
+                shared_workspace,
+            )
+            .await?;
+
+        let team_workspace = match shared_workspace {
+            Some(workspace) => workspace.to_owned(),
+            None => {
+                self.resolve_initial_leader_workspace(
+                    team_id,
+                    &leader_conversation.conversation_id,
+                    leader_conversation.workspace,
+                )
+                .await?
+            }
+        };
+
         let mut agents = Vec::with_capacity(inputs.len());
-        for (index, input) in inputs.iter().enumerate() {
+        agents.push(TeamAgent {
+            slot_id: leader_slot_id.clone(),
+            name: leader_input.name.clone(),
+            role: leader_role,
+            conversation_id: leader_conversation.conversation_id,
+            backend: leader_input.backend.clone(),
+            model: leader_input.model.clone(),
+            custom_agent_id: leader_input.custom_agent_id.clone(),
+            status: None,
+            conversation_type: None,
+            cli_path: None,
+        });
+
+        for input in teammate_inputs {
             let slot_id = generate_id();
-            let role = if index == 0 {
-                TeammateRole::Lead
-            } else {
-                TeammateRole::parse(&input.role).unwrap_or(TeammateRole::Teammate)
-            };
-            let conversation_id = self
+            let role = TeammateRole::parse(&input.role).unwrap_or(TeammateRole::Teammate);
+            let conversation = self
                 .create_or_adopt_conversation(
                     user_id,
                     team_id,
@@ -120,14 +167,14 @@ impl TeamAgentProvisioner {
                     &input.backend,
                     &input.model,
                     input.conversation_id.as_deref(),
-                    shared_workspace,
+                    Some(&team_workspace),
                 )
                 .await?;
             agents.push(TeamAgent {
                 slot_id,
                 name: input.name.clone(),
                 role,
-                conversation_id,
+                conversation_id: conversation.conversation_id,
                 backend: input.backend.clone(),
                 model: input.model.clone(),
                 custom_agent_id: input.custom_agent_id.clone(),
@@ -136,9 +183,23 @@ impl TeamAgentProvisioner {
                 cli_path: None,
             });
         }
-        let lead_agent_id = agents.first().map(|agent| agent.slot_id.clone());
-        info!(team_id, count = agents.len(), "Team agents provisioned");
-        Ok(InitialProvisioningResult { agents, lead_agent_id })
+
+        let lead_agent_id = Some(leader_slot_id);
+        info!(
+            team_id,
+            count = agents.len(),
+            workspace_source = if shared_workspace.is_some() {
+                "user_supplied"
+            } else {
+                "auto_from_leader"
+            },
+            "Team agents provisioned"
+        );
+        Ok(InitialProvisioningResult {
+            agents,
+            lead_agent_id,
+            team_workspace,
+        })
     }
 
     pub(crate) async fn add_agent(
@@ -262,7 +323,7 @@ impl TeamAgentProvisioner {
 
     async fn provision_new_agent(&self, input: NewAgentProvisioning) -> Result<TeamAgent, TeamError> {
         let slot_id = generate_id();
-        let conversation_id = self
+        let conversation = self
             .create_or_adopt_conversation(
                 &input.user_id,
                 &input.team_id,
@@ -279,7 +340,7 @@ impl TeamAgentProvisioner {
             slot_id,
             name: input.name,
             role: input.role,
-            conversation_id,
+            conversation_id: conversation.conversation_id,
             backend: input.backend,
             model: input.model,
             custom_agent_id: input.custom_agent_id,
@@ -301,7 +362,7 @@ impl TeamAgentProvisioner {
         model: &str,
         existing_conversation_id: Option<&str>,
         workspace: Option<&str>,
-    ) -> Result<String, TeamError> {
+    ) -> Result<ProvisionedConversation, TeamError> {
         let extra = self
             .build_team_extra(team_id, slot_id, role, backend, model, workspace)
             .await?;
@@ -319,7 +380,10 @@ impl TeamAgentProvisioner {
                 outcome = "adopted",
                 "Team agent provisioned"
             );
-            return Ok(existing_id.to_owned());
+            return Ok(ProvisionedConversation {
+                conversation_id: existing_id.to_owned(),
+                workspace: workspace.map(str::to_owned),
+            });
         }
 
         let agent_type = parse_agent_type(backend)?;
@@ -356,6 +420,7 @@ impl TeamAgentProvisioner {
             })
             .await?;
         let conv_id = created.conversation_id;
+        let resolved_workspace = created.workspace;
         info!(
             team_id,
             slot_id,
@@ -363,7 +428,50 @@ impl TeamAgentProvisioner {
             outcome = "created",
             "Team agent provisioned"
         );
-        Ok(conv_id)
+        Ok(ProvisionedConversation {
+            conversation_id: conv_id,
+            workspace: Some(resolved_workspace),
+        })
+    }
+
+    async fn resolve_initial_leader_workspace(
+        &self,
+        team_id: &str,
+        leader_conversation_id: &str,
+        created_workspace: Option<String>,
+    ) -> Result<String, TeamError> {
+        if let Some(workspace) = created_workspace
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Ok(workspace.to_owned());
+        }
+
+        if let Some(workspace) = self
+            .conversation_port
+            .conversation_workspace(leader_conversation_id)
+            .await?
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+        {
+            return Ok(workspace);
+        }
+
+        let workspace = self.conversation_port.create_team_temp_workspace(team_id).await?;
+        if let Err(e) = self
+            .conversation_port
+            .patch_runtime_config(leader_conversation_id, serde_json::json!({ "workspace": workspace }))
+            .await
+        {
+            warn!(
+                team_id,
+                conversation_id = %leader_conversation_id,
+                error = %e,
+                "failed to patch leader workspace during initial team provisioning"
+            );
+        }
+        Ok(workspace)
     }
 
     pub(crate) async fn patch_guide_mcp_config(

--- a/crates/aionui-team/src/provisioning.rs
+++ b/crates/aionui-team/src/provisioning.rs
@@ -12,6 +12,7 @@ use crate::mcp::TeamMcpStdioConfig;
 use crate::service::inherit_team_workspace;
 use crate::service::spawn_support::{parse_agent_type, resolve_full_auto_mode};
 use crate::types::{Team, TeamAgent, TeammateRole};
+use crate::workspace::TeamWorkspaceResolver;
 
 #[derive(Clone)]
 pub struct TeamAgentProvisioner {
@@ -99,6 +100,10 @@ impl TeamAgentProvisioner {
             provider_repo,
             conversation_port,
         }
+    }
+
+    fn workspace_resolver(&self) -> TeamWorkspaceResolver {
+        TeamWorkspaceResolver::new(self.repo.clone(), self.conversation_port.clone())
     }
 
     pub(crate) async fn provision_initial_agents(

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -313,8 +313,7 @@ impl TeamSessionService {
                 team_id,
                 &UpdateTeamParams {
                     name: Some(name.to_owned()),
-                    agents: None,
-                    lead_agent_id: None,
+                    ..Default::default()
                 },
             )
             .await?;
@@ -380,9 +379,8 @@ impl TeamSessionService {
             .update_team(
                 team_id,
                 &UpdateTeamParams {
-                    name: None,
                     agents: Some(agents_json),
-                    lead_agent_id: None,
+                    ..Default::default()
                 },
             )
             .await?;
@@ -425,9 +423,8 @@ impl TeamSessionService {
             .update_team(
                 team_id,
                 &UpdateTeamParams {
-                    name: None,
                     agents: Some(agents_json),
-                    lead_agent_id: None,
+                    ..Default::default()
                 },
             )
             .await?;

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -9,9 +9,7 @@ use aionui_api_types::{
     AddAgentRequest, CreateTeamRequest, GuideMcpConfig, TeamAgentResponse, TeamMcpPhase, TeamMcpStatusPayload,
     TeamResponse, TeamRunAckResponse, TeamRunTargetRole, WebSocketMessage,
 };
-use aionui_common::{
-    AgentKillReason, WorkspacePathValidationError, generate_id, now_ms, validate_workspace_path_availability,
-};
+use aionui_common::{AgentKillReason, generate_id, now_ms};
 use aionui_db::models::TeamRow;
 use aionui_db::{IAgentMetadataRepository, IProviderRepository, ITeamRepository, UpdateTeamParams};
 use aionui_realtime::EventBroadcaster;
@@ -29,6 +27,7 @@ use crate::provisioning::{TeamAgentProvisioner, TeamConversationProvisioningPort
 use crate::session::TeamSession;
 use crate::types::{Team, TeamAgent, TeammateRole};
 use crate::wake::TeamWakeSource;
+use crate::workspace::validate_create_workspace_path;
 
 pub(crate) fn inherit_team_workspace(extra: &mut serde_json::Value, workspace: &str) {
     if !workspace.trim().is_empty() {
@@ -984,13 +983,4 @@ impl TeamSessionService {
             .wake_leader_after_recovery_message(source_slot_id, source)
             .await
     }
-}
-
-fn validate_create_workspace_path(workspace: &str) -> Result<String, TeamError> {
-    validate_workspace_path_availability(workspace).map_err(|error| match error {
-        WorkspacePathValidationError::Empty => TeamError::InvalidRequest("Workspace directory is empty".into()),
-        WorkspacePathValidationError::DoesNotExist(path)
-        | WorkspacePathValidationError::NotDirectory(path)
-        | WorkspacePathValidationError::NotAccessible { path, .. } => TeamError::WorkspacePathUnavailable(path),
-    })
 }

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -355,10 +355,7 @@ impl TeamSessionService {
             )));
         }
         let mut team = Team::from_row(&row)?;
-        let agent = self
-            .provisioner()
-            .add_agent(user_id, &mut team, req, &row.workspace)
-            .await?;
+        let agent = self.provisioner().add_agent(user_id, &row, &mut team, req).await?;
 
         if let Some(session) = self.sessions.get(team_id).map(|e| Arc::clone(&e.session)) {
             session.add_agent(&agent).await;

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -203,13 +203,14 @@ impl TeamSessionService {
             .await?;
         let agents = provisioned.agents;
         let lead_agent_id = provisioned.lead_agent_id;
+        let team_workspace = provisioned.team_workspace;
         let agents_json = serde_json::to_string(&agents)?;
 
         let row = TeamRow {
             id: team_id.clone(),
             user_id: user_id.to_owned(),
             name: req.name.clone(),
-            workspace: shared_workspace.clone().unwrap_or_default(),
+            workspace: team_workspace.clone(),
             workspace_mode: "shared".into(),
             agents: agents_json,
             lead_agent_id: lead_agent_id.clone(),
@@ -223,13 +224,23 @@ impl TeamSessionService {
         let team = Team {
             id: team_id,
             name: req.name,
+            workspace: team_workspace,
             agents,
             lead_agent_id,
             created_at: now,
             updated_at: now,
         };
 
-        info!(team_id = %team.id, "Team created");
+        info!(
+            team_id = %team.id,
+            workspace_source = if shared_workspace.is_some() {
+                "user_supplied"
+            } else {
+                "auto_from_leader"
+            },
+            agent_count = team.agents.len(),
+            "Team created"
+        );
 
         self.broadcast_team_created(&team.id, &team.name);
 

--- a/crates/aionui-team/src/service/response_builder.rs
+++ b/crates/aionui-team/src/service/response_builder.rs
@@ -10,6 +10,7 @@ impl TeamSessionService {
         Ok(TeamResponse {
             id: team.id.clone(),
             name: team.name.clone(),
+            workspace: team.workspace.clone(),
             agents,
             lead_agent_id: team.lead_agent_id.clone(),
             created_at: team.created_at,

--- a/crates/aionui-team/src/service/spawn_support.rs
+++ b/crates/aionui-team/src/service/spawn_support.rs
@@ -247,6 +247,9 @@ fn capitalize(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::workspace_harness::{
+        force_team_workspace, setup_with_factory_metadata_team_repo_and_conversation_repo, single_agent_team_request,
+    };
 
     #[test]
     fn parse_agent_type_known_backends() {
@@ -277,5 +280,40 @@ mod tests {
     #[test]
     fn resolve_full_auto_mode_keeps_hermes_on_default() {
         assert_eq!(resolve_full_auto_mode("hermes"), "default");
+    }
+
+    #[tokio::test]
+    async fn persist_spawned_agent_uses_team_workspace_resolver() {
+        let (svc, team_repo, _, conv_repo) = setup_with_factory_metadata_team_repo_and_conversation_repo();
+        let created = svc
+            .create_team("user1", single_agent_team_request("Spawn Legacy"))
+            .await
+            .unwrap();
+        let leader_workspace = conv_repo.get_extra(&created.agents[0].conversation_id).unwrap()["workspace"]
+            .as_str()
+            .unwrap()
+            .to_owned();
+
+        force_team_workspace(&team_repo, &created.id, "").await;
+
+        let spawned = svc
+            .persist_spawned_agent(
+                &created.id,
+                "user1",
+                "Spawned".into(),
+                "acp".into(),
+                "claude".into(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let got = svc.get_team("user1", &created.id).await.unwrap();
+        assert_eq!(got.workspace, leader_workspace);
+        let spawned_extra = conv_repo.get_extra(&spawned.conversation_id).unwrap();
+        assert_eq!(
+            spawned_extra.get("workspace").and_then(serde_json::Value::as_str),
+            Some(leader_workspace.as_str())
+        );
     }
 }

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -1413,6 +1413,7 @@ mod tests {
         Team {
             id: "t1".into(),
             name: "Test Team".into(),
+            workspace: "/tmp/test-team".into(),
             agents: vec![
                 TeamAgent {
                     slot_id: "lead-1".into(),

--- a/crates/aionui-team/src/test_utils.rs
+++ b/crates/aionui-team/src/test_utils.rs
@@ -187,3 +187,687 @@ impl ITeamRepository for MockTeamRepo {
         Ok(())
     }
 }
+
+#[cfg(test)]
+pub(crate) mod workspace_harness {
+    use std::sync::{Arc, Mutex};
+
+    use aionui_ai_agent::{AgentError, IWorkerTaskManager};
+    use aionui_api_types::{CreateTeamRequest, WebSocketMessage};
+    use aionui_common::{AgentKillReason, PaginatedResult, now_ms};
+    use aionui_db::models::{
+        AgentMetadataRow, ConversationRow, MessageRow, TeamRow, TeamTaskRow, UpdateAgentHandshakeParams,
+        UpsertAgentMetadataParams,
+    };
+    use aionui_db::{
+        ConversationFilters, ConversationRowUpdate, DbError, IAgentMetadataRepository, IConversationRepository,
+        IProviderRepository, ITeamRepository, MessageRowUpdate, MessageSearchRow, SortOrder, UpdateTeamParams,
+    };
+    use aionui_realtime::EventBroadcaster;
+    use async_trait::async_trait;
+
+    use crate::ports::{
+        AgentTurnCancellationPort, AgentTurnExecutionError, AgentTurnExecutionPort, AgentTurnOutcome, AgentTurnRequest,
+        AgentTurnStarted, AgentTurnStatus, TeamConversationBindingLookup, TeamConversationLookupPort,
+    };
+    use crate::provisioning::{
+        TeamConversationAdoptRequest, TeamConversationCreateRequest, TeamConversationCreateResult,
+        TeamConversationProvisioningPort,
+    };
+    use crate::{TeamError, TeamProjectionMessageStore, TeamSessionService};
+
+    pub(crate) struct MockConversationRepo {
+        conversations: Mutex<Vec<ConversationRow>>,
+    }
+
+    impl MockConversationRepo {
+        fn new() -> Self {
+            Self {
+                conversations: Mutex::new(Vec::new()),
+            }
+        }
+
+        pub(crate) fn get_extra(&self, id: &str) -> Option<serde_json::Value> {
+            self.conversations
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|c| c.id == id)
+                .and_then(|c| serde_json::from_str(&c.extra).ok())
+        }
+    }
+
+    #[async_trait]
+    impl IConversationRepository for MockConversationRepo {
+        async fn get(&self, id: &str) -> Result<Option<ConversationRow>, DbError> {
+            Ok(self.conversations.lock().unwrap().iter().find(|c| c.id == id).cloned())
+        }
+
+        async fn create(&self, row: &ConversationRow) -> Result<(), DbError> {
+            self.conversations.lock().unwrap().push(row.clone());
+            Ok(())
+        }
+
+        async fn update(&self, id: &str, updates: &ConversationRowUpdate) -> Result<(), DbError> {
+            let mut conversations = self.conversations.lock().unwrap();
+            let conversation = conversations
+                .iter_mut()
+                .find(|c| c.id == id)
+                .ok_or_else(|| DbError::NotFound(id.to_owned()))?;
+            if let Some(ref extra) = updates.extra {
+                conversation.extra = extra.clone();
+            }
+            if let Some(ref name) = updates.name {
+                conversation.name = name.clone();
+            }
+            if let Some(ref model) = updates.model {
+                conversation.model = model.clone();
+            }
+            if let Some(pinned) = updates.pinned {
+                conversation.pinned = pinned;
+            }
+            if let Some(updated_at) = updates.updated_at {
+                conversation.updated_at = updated_at;
+            }
+            Ok(())
+        }
+
+        async fn delete(&self, id: &str) -> Result<(), DbError> {
+            self.conversations.lock().unwrap().retain(|c| c.id != id);
+            Ok(())
+        }
+
+        async fn list_paginated(
+            &self,
+            _user_id: &str,
+            _filters: &ConversationFilters,
+        ) -> Result<PaginatedResult<ConversationRow>, DbError> {
+            Ok(PaginatedResult {
+                items: vec![],
+                total: 0,
+                has_more: false,
+            })
+        }
+
+        async fn find_by_source_and_chat(
+            &self,
+            _user_id: &str,
+            _source: &str,
+            _chat_id: &str,
+            _agent_type: &str,
+        ) -> Result<Option<ConversationRow>, DbError> {
+            Ok(None)
+        }
+
+        async fn list_by_cron_job(&self, _user_id: &str, _cron_job_id: &str) -> Result<Vec<ConversationRow>, DbError> {
+            Ok(vec![])
+        }
+
+        async fn list_associated(
+            &self,
+            _user_id: &str,
+            _conversation_id: &str,
+        ) -> Result<Vec<ConversationRow>, DbError> {
+            Ok(vec![])
+        }
+
+        async fn get_messages(
+            &self,
+            _conv_id: &str,
+            _page: u32,
+            _page_size: u32,
+            _order: SortOrder,
+        ) -> Result<PaginatedResult<MessageRow>, DbError> {
+            Ok(PaginatedResult {
+                items: vec![],
+                total: 0,
+                has_more: false,
+            })
+        }
+
+        async fn insert_message(&self, _message: &MessageRow) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn update_message(&self, _id: &str, _updates: &MessageRowUpdate) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn delete_messages_by_conversation(&self, _conv_id: &str) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn get_message_by_msg_id(
+            &self,
+            _conv_id: &str,
+            _msg_id: &str,
+            _msg_type: &str,
+        ) -> Result<Option<MessageRow>, DbError> {
+            Ok(None)
+        }
+
+        async fn search_messages(
+            &self,
+            _user_id: &str,
+            _keyword: &str,
+            _page: u32,
+            _page_size: u32,
+        ) -> Result<PaginatedResult<MessageSearchRow>, DbError> {
+            Ok(PaginatedResult {
+                items: vec![],
+                total: 0,
+                has_more: false,
+            })
+        }
+    }
+
+    pub(crate) struct FullMockTeamRepo {
+        teams: Mutex<Vec<TeamRow>>,
+    }
+
+    impl FullMockTeamRepo {
+        fn new() -> Self {
+            Self {
+                teams: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ITeamRepository for FullMockTeamRepo {
+        async fn create_team(&self, row: &TeamRow) -> Result<(), DbError> {
+            self.teams.lock().unwrap().push(row.clone());
+            Ok(())
+        }
+
+        async fn list_teams(&self) -> Result<Vec<TeamRow>, DbError> {
+            Ok(self.teams.lock().unwrap().clone())
+        }
+
+        async fn list_teams_by_user(&self, user_id: &str) -> Result<Vec<TeamRow>, DbError> {
+            Ok(self
+                .teams
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|team| team.user_id == user_id)
+                .cloned()
+                .collect())
+        }
+
+        async fn get_team(&self, id: &str) -> Result<Option<TeamRow>, DbError> {
+            Ok(self.teams.lock().unwrap().iter().find(|t| t.id == id).cloned())
+        }
+
+        async fn update_team(&self, id: &str, params: &UpdateTeamParams) -> Result<(), DbError> {
+            let mut teams = self.teams.lock().unwrap();
+            let team = teams
+                .iter_mut()
+                .find(|t| t.id == id)
+                .ok_or_else(|| DbError::NotFound(id.to_owned()))?;
+            if let Some(ref name) = params.name {
+                team.name = name.clone();
+            }
+            if let Some(ref workspace) = params.workspace {
+                team.workspace = workspace.clone();
+            }
+            if let Some(ref agents) = params.agents {
+                team.agents = agents.clone();
+            }
+            if let Some(ref lead_id) = params.lead_agent_id {
+                team.lead_agent_id = Some(lead_id.clone());
+            }
+            team.updated_at = now_ms();
+            Ok(())
+        }
+
+        async fn delete_team(&self, id: &str) -> Result<(), DbError> {
+            self.teams.lock().unwrap().retain(|t| t.id != id);
+            Ok(())
+        }
+
+        async fn write_message(&self, _row: &aionui_db::models::MailboxMessageRow) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn read_unread_and_mark(
+            &self,
+            _team_id: &str,
+            _to_agent_id: &str,
+        ) -> Result<Vec<aionui_db::models::MailboxMessageRow>, DbError> {
+            Ok(vec![])
+        }
+
+        async fn peek_unread(
+            &self,
+            _team_id: &str,
+            _to_agent_id: &str,
+        ) -> Result<Vec<aionui_db::models::MailboxMessageRow>, DbError> {
+            Ok(vec![])
+        }
+
+        async fn mark_read_batch(&self, _ids: &[String]) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn get_history(
+            &self,
+            _team_id: &str,
+            _to_agent_id: &str,
+            _limit: Option<i64>,
+        ) -> Result<Vec<aionui_db::models::MailboxMessageRow>, DbError> {
+            Ok(vec![])
+        }
+
+        async fn delete_mailbox_by_team(&self, _team_id: &str) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn create_task(&self, _row: &TeamTaskRow) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn find_task_by_id(&self, _team_id: &str, _task_id: &str) -> Result<Option<TeamTaskRow>, DbError> {
+            Ok(None)
+        }
+
+        async fn update_task(&self, _task_id: &str, _params: &aionui_db::UpdateTaskParams) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn list_tasks(&self, _team_id: &str) -> Result<Vec<TeamTaskRow>, DbError> {
+            Ok(vec![])
+        }
+
+        async fn append_to_blocks(&self, _task_id: &str, _blocked_task_id: &str) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn remove_from_blocked_by(&self, _task_id: &str, _unblocked_task_id: &str) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn delete_tasks_by_team(&self, _team_id: &str) -> Result<(), DbError> {
+            Ok(())
+        }
+    }
+
+    struct FakeConversationPorts {
+        repo: Arc<MockConversationRepo>,
+        workspace_root: std::path::PathBuf,
+    }
+
+    impl FakeConversationPorts {
+        fn new(repo: Arc<MockConversationRepo>) -> Self {
+            Self {
+                repo,
+                workspace_root: std::env::temp_dir().join(format!(
+                    "aionui-team-workspace-harness-{}",
+                    aionui_common::generate_id()
+                )),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl TeamConversationProvisioningPort for FakeConversationPorts {
+        async fn create_team_conversation(
+            &self,
+            request: TeamConversationCreateRequest,
+        ) -> Result<TeamConversationCreateResult, TeamError> {
+            let id = aionui_common::generate_id();
+            let workspace = request
+                .extra
+                .get("workspace")
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .map(str::to_owned)
+                .unwrap_or_else(|| {
+                    let path = self.workspace_root.join("conversations").join(format!("acp-temp-{id}"));
+                    std::fs::create_dir_all(&path).unwrap();
+                    path.to_string_lossy().into_owned()
+                });
+            let mut extra = request.extra;
+            extra["workspace"] = serde_json::Value::String(workspace.clone());
+            self.repo
+                .create(&ConversationRow {
+                    id: id.clone(),
+                    user_id: request.user_id,
+                    name: request.name,
+                    r#type: request.agent_type.serde_name().to_owned(),
+                    pinned: false,
+                    pinned_at: None,
+                    source: None,
+                    channel_chat_id: None,
+                    extra: serde_json::to_string(&extra).unwrap(),
+                    model: request
+                        .top_level_model
+                        .map(|model| serde_json::to_string(&model).expect("serialize provider model")),
+                    status: Some("pending".into()),
+                    created_at: now_ms(),
+                    updated_at: now_ms(),
+                })
+                .await?;
+            Ok(TeamConversationCreateResult {
+                conversation_id: id,
+                workspace,
+            })
+        }
+
+        async fn adopt_team_conversation(&self, _request: TeamConversationAdoptRequest) -> Result<(), TeamError> {
+            Ok(())
+        }
+
+        async fn conversation_workspace(&self, conversation_id: &str) -> Result<Option<String>, TeamError> {
+            Ok(self.repo.get_extra(conversation_id).and_then(|extra| {
+                extra
+                    .get("workspace")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned)
+            }))
+        }
+
+        async fn create_team_temp_workspace(&self, team_id: &str) -> Result<String, TeamError> {
+            let path = self
+                .workspace_root
+                .join("conversations")
+                .join(format!("team-temp-{team_id}"));
+            std::fs::create_dir_all(&path).unwrap();
+            Ok(path.to_string_lossy().into_owned())
+        }
+
+        async fn patch_runtime_config(&self, conversation_id: &str, patch: serde_json::Value) -> Result<(), TeamError> {
+            let mut extra = self
+                .repo
+                .get_extra(conversation_id)
+                .unwrap_or_else(|| serde_json::json!({}));
+            if let (Some(target), Some(source)) = (extra.as_object_mut(), patch.as_object()) {
+                for (key, value) in source {
+                    target.insert(key.clone(), value.clone());
+                }
+            }
+            self.repo
+                .update(
+                    conversation_id,
+                    &ConversationRowUpdate {
+                        name: None,
+                        model: None,
+                        pinned: None,
+                        pinned_at: None,
+                        extra: Some(serde_json::to_string(&extra).unwrap()),
+                        status: None,
+                        updated_at: Some(now_ms()),
+                    },
+                )
+                .await?;
+            Ok(())
+        }
+
+        async fn save_acp_runtime_mode(&self, conversation_id: &str, mode: &str) -> Result<(), TeamError> {
+            self.patch_runtime_config(conversation_id, serde_json::json!({ "session_mode": mode }))
+                .await
+        }
+
+        async fn warmup_agent_process(
+            &self,
+            _user_id: &str,
+            _conversation_id: &str,
+            _task_manager: &Arc<dyn IWorkerTaskManager>,
+        ) -> Result<(), TeamError> {
+            Ok(())
+        }
+
+        async fn delete_team_conversation(&self, _user_id: &str, _conversation_id: &str) -> Result<(), TeamError> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl TeamProjectionMessageStore for FakeConversationPorts {
+        fn mint_message_id(&self) -> String {
+            aionui_common::generate_id()
+        }
+
+        async fn find_projected_message(
+            &self,
+            _conversation_id: &str,
+            _msg_id: &str,
+            _msg_type: &str,
+        ) -> Result<Option<MessageRow>, TeamError> {
+            Ok(None)
+        }
+
+        async fn insert_projected_message(&self, _row: &MessageRow) -> Result<(), TeamError> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl TeamConversationLookupPort for FakeConversationPorts {
+        async fn lookup_team_binding_by_conversation(
+            &self,
+            _conversation_id: &str,
+        ) -> Result<Option<TeamConversationBindingLookup>, TeamError> {
+            Ok(None)
+        }
+    }
+
+    struct NullBroadcaster;
+
+    impl EventBroadcaster for NullBroadcaster {
+        fn broadcast(&self, _event: WebSocketMessage<serde_json::Value>) {}
+    }
+
+    struct NoopTaskManager;
+
+    #[async_trait]
+    impl IWorkerTaskManager for NoopTaskManager {
+        fn get_task(&self, _conversation_id: &str) -> Option<aionui_ai_agent::AgentInstance> {
+            None
+        }
+
+        async fn get_or_build_task(
+            &self,
+            _conversation_id: &str,
+            _options: aionui_ai_agent::types::BuildTaskOptions,
+        ) -> Result<aionui_ai_agent::AgentInstance, AgentError> {
+            Err(AgentError::Internal("workspace harness does not spawn agents".into()))
+        }
+
+        fn kill(&self, _conversation_id: &str, _reason: Option<AgentKillReason>) -> Result<(), AgentError> {
+            Ok(())
+        }
+
+        fn kill_and_wait(
+            &self,
+            _conversation_id: &str,
+            _reason: Option<AgentKillReason>,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+            Box::pin(std::future::ready(()))
+        }
+
+        async fn clear(&self) {}
+
+        fn active_count(&self) -> usize {
+            0
+        }
+
+        fn collect_idle(&self, _idle_threshold_ms: aionui_common::TimestampMs) -> Vec<String> {
+            vec![]
+        }
+    }
+
+    struct EmptyAgentMetadataRepo;
+
+    #[async_trait]
+    impl IAgentMetadataRepository for EmptyAgentMetadataRepo {
+        async fn list_all(&self) -> Result<Vec<AgentMetadataRow>, DbError> {
+            Ok(vec![])
+        }
+
+        async fn get(&self, _id: &str) -> Result<Option<AgentMetadataRow>, DbError> {
+            Ok(None)
+        }
+
+        async fn find_by_source_and_name(
+            &self,
+            _agent_source: &str,
+            _name: &str,
+        ) -> Result<Option<AgentMetadataRow>, DbError> {
+            Ok(None)
+        }
+
+        async fn find_builtin_by_backend(&self, _backend: &str) -> Result<Option<AgentMetadataRow>, DbError> {
+            Ok(None)
+        }
+
+        async fn upsert(&self, _params: &UpsertAgentMetadataParams<'_>) -> Result<AgentMetadataRow, DbError> {
+            Err(DbError::NotFound("not implemented".into()))
+        }
+
+        async fn apply_handshake(
+            &self,
+            _id: &str,
+            _params: &UpdateAgentHandshakeParams<'_>,
+        ) -> Result<Option<AgentMetadataRow>, DbError> {
+            Ok(None)
+        }
+
+        async fn set_enabled(&self, _id: &str, _enabled: bool) -> Result<bool, DbError> {
+            Ok(false)
+        }
+
+        async fn delete(&self, _id: &str) -> Result<bool, DbError> {
+            Ok(false)
+        }
+    }
+
+    struct EmptyProviderRepo;
+
+    #[async_trait]
+    impl IProviderRepository for EmptyProviderRepo {
+        async fn list(&self) -> Result<Vec<aionui_db::models::Provider>, DbError> {
+            Ok(vec![])
+        }
+
+        async fn find_by_id(&self, _id: &str) -> Result<Option<aionui_db::models::Provider>, DbError> {
+            Ok(None)
+        }
+
+        async fn create(
+            &self,
+            _params: aionui_db::CreateProviderParams<'_>,
+        ) -> Result<aionui_db::models::Provider, DbError> {
+            Err(DbError::NotFound("not implemented".into()))
+        }
+
+        async fn update(
+            &self,
+            _id: &str,
+            _params: aionui_db::UpdateProviderParams<'_>,
+        ) -> Result<aionui_db::models::Provider, DbError> {
+            Err(DbError::NotFound("not implemented".into()))
+        }
+
+        async fn delete(&self, _id: &str) -> Result<(), DbError> {
+            Ok(())
+        }
+    }
+
+    struct NoopTurnPort;
+
+    #[async_trait]
+    impl AgentTurnExecutionPort for NoopTurnPort {
+        async fn run_agent_turn(&self, request: AgentTurnRequest) -> Result<AgentTurnOutcome, AgentTurnExecutionError> {
+            if let Some(on_started) = request.on_started.as_ref() {
+                on_started(AgentTurnStarted {
+                    team_run_id: request.team_run_id.clone().expect("team run id"),
+                    slot_id: request.slot_id.clone(),
+                    role: request.role.clone(),
+                    conversation_id: request.conversation_id.clone(),
+                    turn_id: "turn-test".into(),
+                })
+                .await;
+            }
+            Ok(AgentTurnOutcome {
+                conversation_id: request.conversation_id,
+                turn_id: "turn-test".into(),
+                status: AgentTurnStatus::Completed,
+                runtime: None,
+            })
+        }
+    }
+
+    struct NoopCancellationPort;
+
+    #[async_trait]
+    impl AgentTurnCancellationPort for NoopCancellationPort {
+        async fn cancel_agent_turn(
+            &self,
+            _user_id: &str,
+            _conversation_id: &str,
+            _turn_id: &str,
+        ) -> Result<(), AgentTurnExecutionError> {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn setup_with_factory_metadata_team_repo_and_conversation_repo() -> (
+        Arc<TeamSessionService>,
+        Arc<FullMockTeamRepo>,
+        Arc<dyn IWorkerTaskManager>,
+        Arc<MockConversationRepo>,
+    ) {
+        let team_repo = Arc::new(FullMockTeamRepo::new());
+        let team_repo_dyn: Arc<dyn ITeamRepository> = team_repo.clone();
+        let conv_repo = Arc::new(MockConversationRepo::new());
+        let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
+        let conversation_ports = Arc::new(FakeConversationPorts::new(conv_repo.clone()));
+        let conversation_port: Arc<dyn TeamConversationProvisioningPort> = conversation_ports.clone();
+        let projection_store: Arc<dyn TeamProjectionMessageStore> = conversation_ports.clone();
+        let lookup_port: Arc<dyn TeamConversationLookupPort> = conversation_ports;
+        let task_manager: Arc<dyn IWorkerTaskManager> = Arc::new(NoopTaskManager);
+        let svc = TeamSessionService::new(
+            team_repo_dyn,
+            Arc::new(EmptyAgentMetadataRepo),
+            Arc::new(EmptyProviderRepo),
+            conversation_port,
+            projection_store,
+            lookup_port,
+            broadcaster,
+            task_manager.clone(),
+            Arc::new(NoopTurnPort),
+            Arc::new(NoopCancellationPort),
+            Arc::new(std::path::PathBuf::from("/tmp/aioncore-test")),
+            None,
+        );
+        (svc, team_repo, task_manager, conv_repo)
+    }
+
+    pub(crate) async fn force_team_workspace(repo: &Arc<FullMockTeamRepo>, team_id: &str, workspace: &str) {
+        repo.update_team(
+            team_id,
+            &UpdateTeamParams {
+                workspace: Some(workspace.to_owned()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("force workspace");
+    }
+
+    pub(crate) fn single_agent_team_request(name: &str) -> CreateTeamRequest {
+        CreateTeamRequest {
+            name: name.into(),
+            agents: vec![aionui_api_types::TeamAgentInput {
+                name: "Lead".into(),
+                role: "lead".into(),
+                backend: "acp".into(),
+                model: "claude".into(),
+                custom_agent_id: None,
+                conversation_id: None,
+            }],
+            workspace: None,
+        }
+    }
+}

--- a/crates/aionui-team/src/types.rs
+++ b/crates/aionui-team/src/types.rs
@@ -137,6 +137,7 @@ impl TeamAgent {
 pub struct Team {
     pub id: String,
     pub name: String,
+    pub workspace: String,
     pub agents: Vec<TeamAgent>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lead_agent_id: Option<String>,
@@ -268,6 +269,7 @@ impl Team {
         Ok(Self {
             id: row.id.clone(),
             name: row.name.clone(),
+            workspace: row.workspace.clone(),
             agents,
             lead_agent_id: row.lead_agent_id.clone(),
             created_at: row.created_at,
@@ -279,6 +281,7 @@ impl Team {
         TeamResponse {
             id: self.id.clone(),
             name: self.name.clone(),
+            workspace: self.workspace.clone(),
             agents: self.agents.iter().map(|a| a.to_response()).collect(),
             lead_agent_id: self.lead_agent_id.clone(),
             created_at: self.created_at,
@@ -642,6 +645,7 @@ mod tests {
         let team = Team {
             id: "t1".into(),
             name: "Alpha".into(),
+            workspace: "/workspace/team".into(),
             agents: vec![TeamAgent {
                 slot_id: "s1".into(),
                 name: "Lead".into(),

--- a/crates/aionui-team/src/workspace.rs
+++ b/crates/aionui-team/src/workspace.rs
@@ -1,0 +1,131 @@
+use std::sync::Arc;
+
+use aionui_common::{WorkspacePathValidationError, validate_workspace_path_availability};
+use aionui_db::models::TeamRow;
+use aionui_db::{ITeamRepository, UpdateTeamParams};
+use tracing::warn;
+
+use crate::error::TeamError;
+use crate::provisioning::TeamConversationProvisioningPort;
+use crate::types::{Team, TeammateRole};
+
+pub(crate) fn validate_create_workspace_path(workspace: &str) -> Result<String, TeamError> {
+    validate_workspace_path_availability(workspace).map_err(|error| match error {
+        WorkspacePathValidationError::Empty => TeamError::InvalidRequest("Workspace directory is empty".into()),
+        WorkspacePathValidationError::DoesNotExist(path)
+        | WorkspacePathValidationError::NotDirectory(path)
+        | WorkspacePathValidationError::NotAccessible { path, .. } => TeamError::WorkspacePathUnavailable(path),
+    })
+}
+
+fn validate_runtime_workspace_path(workspace: &str) -> Result<String, TeamError> {
+    validate_workspace_path_availability(workspace).map_err(|error| match error {
+        WorkspacePathValidationError::Empty => TeamError::InvalidRequest("Team workspace is empty".into()),
+        WorkspacePathValidationError::DoesNotExist(path)
+        | WorkspacePathValidationError::NotDirectory(path)
+        | WorkspacePathValidationError::NotAccessible { path, .. } => TeamError::WorkspacePathRuntimeUnavailable(path),
+    })
+}
+
+fn usable_runtime_workspace(workspace: &str) -> Option<String> {
+    validate_runtime_workspace_path(workspace).ok()
+}
+
+pub(crate) struct TeamWorkspaceResolver {
+    repo: Arc<dyn ITeamRepository>,
+    conversation_port: Arc<dyn TeamConversationProvisioningPort>,
+}
+
+impl TeamWorkspaceResolver {
+    pub(crate) fn new(
+        repo: Arc<dyn ITeamRepository>,
+        conversation_port: Arc<dyn TeamConversationProvisioningPort>,
+    ) -> Self {
+        Self {
+            repo,
+            conversation_port,
+        }
+    }
+
+    pub(crate) async fn resolve_for_new_agent(&self, row: &TeamRow, team: &Team) -> Result<String, TeamError> {
+        if let Some(workspace) = usable_runtime_workspace(row.workspace.trim()) {
+            return Ok(workspace);
+        }
+
+        if let Some(leader_workspace) = self.resolve_from_leader(team).await? {
+            self.write_team_workspace(&row.id, &leader_workspace).await?;
+            warn!(
+                team_id = %row.id,
+                workspace_source = "leader_conversation",
+                "team workspace lazy backfilled"
+            );
+            return Ok(leader_workspace);
+        }
+
+        let workspace = self.conversation_port.create_team_temp_workspace(&row.id).await?;
+        let workspace = validate_runtime_workspace_path(&workspace)?;
+        self.write_team_workspace(&row.id, &workspace).await?;
+        self.patch_leader_workspace_best_effort(&row.id, team, &workspace).await;
+        warn!(
+            team_id = %row.id,
+            workspace_source = "team_temp_fallback",
+            "team workspace lazy backfilled"
+        );
+        Ok(workspace)
+    }
+
+    async fn resolve_from_leader(&self, team: &Team) -> Result<Option<String>, TeamError> {
+        let Some(leader) = team
+            .agents
+            .iter()
+            .find(|agent| Some(&agent.slot_id) == team.lead_agent_id.as_ref())
+            .or_else(|| team.agents.iter().find(|agent| agent.role == TeammateRole::Lead))
+        else {
+            return Ok(None);
+        };
+        let Some(workspace) = self
+            .conversation_port
+            .conversation_workspace(&leader.conversation_id)
+            .await?
+        else {
+            return Ok(None);
+        };
+        Ok(usable_runtime_workspace(workspace.trim()))
+    }
+
+    async fn write_team_workspace(&self, team_id: &str, workspace: &str) -> Result<(), TeamError> {
+        self.repo
+            .update_team(
+                team_id,
+                &UpdateTeamParams {
+                    workspace: Some(workspace.to_owned()),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn patch_leader_workspace_best_effort(&self, team_id: &str, team: &Team, workspace: &str) {
+        let Some(leader) = team
+            .agents
+            .iter()
+            .find(|agent| Some(&agent.slot_id) == team.lead_agent_id.as_ref())
+            .or_else(|| team.agents.iter().find(|agent| agent.role == TeammateRole::Lead))
+        else {
+            return;
+        };
+        if let Err(e) = self
+            .conversation_port
+            .patch_runtime_config(&leader.conversation_id, serde_json::json!({ "workspace": workspace }))
+            .await
+        {
+            warn!(
+                team_id = %team_id,
+                conversation_id = %leader.conversation_id,
+                error = %e,
+                "failed to patch leader workspace after team temp fallback"
+            );
+        }
+    }
+}

--- a/crates/aionui-team/tests/e2e_team_flow.rs
+++ b/crates/aionui-team/tests/e2e_team_flow.rs
@@ -604,6 +604,7 @@ async fn setup_session_with_turn_recorder_inner(
     let team = aionui_team::types::Team {
         id: "e2e-team".into(),
         name: "E2E Team".into(),
+        workspace: "/tmp/e2e-team".into(),
         agents: two_agents(),
         lead_agent_id: Some("lead-1".into()),
         created_at: 1000,
@@ -661,6 +662,7 @@ async fn setup_session_with_runtime_ports(
     let team = aionui_team::types::Team {
         id: "e2e-team".into(),
         name: "E2E Team".into(),
+        workspace: "/tmp/e2e-team".into(),
         agents: two_agents(),
         lead_agent_id: Some("lead-1".into()),
         created_at: 1000,

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -529,6 +529,9 @@ impl ITeamRepository for FullMockTeamRepo {
         if let Some(ref name) = params.name {
             team.name = name.clone();
         }
+        if let Some(ref workspace) = params.workspace {
+            team.workspace = workspace.clone();
+        }
         if let Some(ref agents) = params.agents {
             team.agents = agents.clone();
         }

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -56,6 +56,10 @@ impl MockConversationRepo {
             .and_then(|c| serde_json::from_str(&c.extra).ok())
     }
 
+    fn conversation_count(&self) -> usize {
+        self.conversations.lock().unwrap().len()
+    }
+
     fn patch_extra(&self, id: &str, patch: serde_json::Value) -> Result<(), DbError> {
         let mut convs = self.conversations.lock().unwrap();
         let conv = convs
@@ -565,6 +569,7 @@ impl EventBroadcaster for RecordingBroadcaster {
 struct FullMockTeamRepo {
     inner: MockTeamRepo,
     teams: std::sync::Mutex<Vec<aionui_db::models::TeamRow>>,
+    fail_workspace_update: std::sync::Mutex<bool>,
 }
 
 impl FullMockTeamRepo {
@@ -572,7 +577,12 @@ impl FullMockTeamRepo {
         Self {
             inner: MockTeamRepo::new(),
             teams: std::sync::Mutex::new(Vec::new()),
+            fail_workspace_update: std::sync::Mutex::new(false),
         }
+    }
+
+    fn fail_workspace_update(&self) {
+        *self.fail_workspace_update.lock().unwrap() = true;
     }
 }
 
@@ -599,6 +609,9 @@ impl ITeamRepository for FullMockTeamRepo {
         Ok(self.teams.lock().unwrap().iter().find(|t| t.id == id).cloned())
     }
     async fn update_team(&self, id: &str, params: &aionui_db::UpdateTeamParams) -> Result<(), DbError> {
+        if params.workspace.is_some() && *self.fail_workspace_update.lock().unwrap() {
+            return Err(DbError::Init("forced workspace writeback failure".into()));
+        }
         let mut teams = self.teams.lock().unwrap();
         let team = teams
             .iter_mut()
@@ -1061,6 +1074,43 @@ fn setup_with_factory_metadata_team_repo_and_conversation_repo(
         None,
     );
     (svc, team_repo, task_manager, conv_repo)
+}
+
+fn setup_with_ports_team_repo_and_conversation_repo(
+    factory: AgentFactory,
+    agent_metadata_repo: Arc<dyn IAgentMetadataRepository>,
+) -> (
+    Arc<TeamSessionService>,
+    Arc<FullMockTeamRepo>,
+    Arc<FakeConversationPorts>,
+    Arc<MockConversationRepo>,
+) {
+    let team_repo = Arc::new(FullMockTeamRepo::new());
+    let team_repo_dyn: Arc<dyn ITeamRepository> = team_repo.clone();
+    let conv_repo = Arc::new(MockConversationRepo::new());
+    let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
+    let conversation_ports = Arc::new(FakeConversationPorts::new(conv_repo.clone(), broadcaster.clone()));
+    let conversation_port: Arc<dyn TeamConversationProvisioningPort> = conversation_ports.clone();
+    let projection_store: Arc<dyn TeamProjectionMessageStore> = conversation_ports.clone();
+    let lookup_port: Arc<dyn TeamConversationLookupPort> = conversation_ports.clone();
+    let task_manager: Arc<dyn IWorkerTaskManager> = Arc::new(CountingTaskManager::new(factory));
+    let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aioncore-test"));
+    let provider_repo: Arc<dyn IProviderRepository> = Arc::new(EmptyProviderRepo);
+    let svc = TeamSessionService::new(
+        team_repo_dyn,
+        agent_metadata_repo,
+        provider_repo,
+        conversation_port,
+        projection_store,
+        lookup_port,
+        broadcaster,
+        task_manager,
+        noop_turn_port(),
+        noop_cancellation_port(),
+        backend_binary_path,
+        None,
+    );
+    (svc, team_repo, conversation_ports, conv_repo)
 }
 
 fn setup() -> Arc<TeamSessionService> {
@@ -1883,6 +1933,118 @@ async fn add_agent_uses_team_temp_workspace_when_team_and_leader_workspaces_are_
             .contains(&format!("/conversations/team-temp-{}", created.id)),
         "unexpected team temp workspace: {}",
         got.workspace
+    );
+    let added_extra = conv_repo.get_extra(&added.conversation_id).unwrap();
+    assert_eq!(
+        added_extra.get("workspace").and_then(serde_json::Value::as_str),
+        Some(got.workspace.as_str())
+    );
+}
+
+#[tokio::test]
+async fn add_agent_does_not_create_teammate_when_workspace_writeback_fails() {
+    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = Arc::new(StubAgentMetadataRepo::empty());
+    let (svc, team_repo, _, conv_repo) =
+        setup_with_factory_metadata_team_repo_and_conversation_repo(success_factory(), agent_metadata_repo);
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "Writeback Failure".into(),
+                agents: vec![TeamAgentInput {
+                    name: "Lead".into(),
+                    role: "lead".into(),
+                    backend: "acp".into(),
+                    model: "claude".into(),
+                    custom_agent_id: None,
+                    conversation_id: None,
+                }],
+                workspace: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    force_team_workspace(&team_repo, &created.id, "").await;
+    team_repo.fail_workspace_update();
+    let before_count = conv_repo.conversation_count();
+
+    let err = svc
+        .add_agent(
+            "user1",
+            &created.id,
+            AddAgentRequest {
+                name: "Worker".into(),
+                role: "teammate".into(),
+                backend: "acp".into(),
+                model: "claude".into(),
+                custom_agent_id: None,
+            },
+        )
+        .await
+        .expect_err("workspace writeback failure must block teammate creation");
+
+    assert!(
+        err.to_string().contains("forced workspace writeback failure"),
+        "unexpected error: {err}"
+    );
+    assert_eq!(conv_repo.conversation_count(), before_count);
+}
+
+#[tokio::test]
+async fn add_agent_continues_when_team_temp_leader_patch_fails() {
+    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = Arc::new(StubAgentMetadataRepo::empty());
+    let (svc, team_repo, conversation_ports, conv_repo) =
+        setup_with_ports_team_repo_and_conversation_repo(success_factory(), agent_metadata_repo);
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "Patch Failure".into(),
+                agents: vec![TeamAgentInput {
+                    name: "Lead".into(),
+                    role: "lead".into(),
+                    backend: "acp".into(),
+                    model: "claude".into(),
+                    custom_agent_id: None,
+                    conversation_id: None,
+                }],
+                workspace: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    force_team_workspace(&team_repo, &created.id, "").await;
+    conv_repo
+        .patch_extra(
+            &created.agents[0].conversation_id,
+            serde_json::json!({ "workspace": "/tmp/aionui-team-missing-leader-workspace" }),
+        )
+        .unwrap();
+    conversation_ports
+        .fail_leader_workspace_patch
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+
+    let added = svc
+        .add_agent(
+            "user1",
+            &created.id,
+            AddAgentRequest {
+                name: "Worker".into(),
+                role: "teammate".into(),
+                backend: "acp".into(),
+                model: "claude".into(),
+                custom_agent_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let got = svc.get_team("user1", &created.id).await.unwrap();
+    assert!(
+        got.workspace
+            .contains(&format!("/conversations/team-temp-{}", created.id))
     );
     let added_extra = conv_repo.get_extra(&added.conversation_id).unwrap();
     assert_eq!(

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -55,6 +55,22 @@ impl MockConversationRepo {
             .find(|c| c.id == id)
             .and_then(|c| serde_json::from_str(&c.extra).ok())
     }
+
+    fn patch_extra(&self, id: &str, patch: serde_json::Value) -> Result<(), DbError> {
+        let mut convs = self.conversations.lock().unwrap();
+        let conv = convs
+            .iter_mut()
+            .find(|c| c.id == id)
+            .ok_or_else(|| DbError::NotFound(id.to_owned()))?;
+        let mut extra: serde_json::Value = serde_json::from_str(&conv.extra).unwrap_or_else(|_| serde_json::json!({}));
+        if let (Some(target), Some(source)) = (extra.as_object_mut(), patch.as_object()) {
+            for (key, value) in source {
+                target.insert(key.clone(), value.clone());
+            }
+        }
+        conv.extra = serde_json::to_string(&extra).unwrap();
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -1004,7 +1020,22 @@ fn setup_with_factory_and_metadata_and_conversation_repo(
     Arc<CountingTaskManager>,
     Arc<MockConversationRepo>,
 ) {
-    let team_repo: Arc<dyn ITeamRepository> = Arc::new(FullMockTeamRepo::new());
+    let (svc, _, task_manager, conv_repo) =
+        setup_with_factory_metadata_team_repo_and_conversation_repo(factory, agent_metadata_repo);
+    (svc, task_manager, conv_repo)
+}
+
+fn setup_with_factory_metadata_team_repo_and_conversation_repo(
+    factory: AgentFactory,
+    agent_metadata_repo: Arc<dyn IAgentMetadataRepository>,
+) -> (
+    Arc<TeamSessionService>,
+    Arc<FullMockTeamRepo>,
+    Arc<CountingTaskManager>,
+    Arc<MockConversationRepo>,
+) {
+    let team_repo = Arc::new(FullMockTeamRepo::new());
+    let team_repo_dyn: Arc<dyn ITeamRepository> = team_repo.clone();
     let conv_repo = Arc::new(MockConversationRepo::new());
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
     let conversation_ports = Arc::new(FakeConversationPorts::new(conv_repo.clone(), broadcaster.clone()));
@@ -1016,7 +1047,7 @@ fn setup_with_factory_and_metadata_and_conversation_repo(
     let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aioncore-test"));
     let provider_repo: Arc<dyn IProviderRepository> = Arc::new(EmptyProviderRepo);
     let svc = TeamSessionService::new(
-        team_repo,
+        team_repo_dyn,
         agent_metadata_repo,
         provider_repo,
         conversation_port,
@@ -1029,7 +1060,7 @@ fn setup_with_factory_and_metadata_and_conversation_repo(
         backend_binary_path,
         None,
     );
-    (svc, task_manager, conv_repo)
+    (svc, team_repo, task_manager, conv_repo)
 }
 
 fn setup() -> Arc<TeamSessionService> {
@@ -1126,6 +1157,18 @@ fn two_agent_input() -> Vec<TeamAgentInput> {
 async fn reset_auto_started_session(svc: &Arc<TeamSessionService>, tm: &Arc<CountingTaskManager>, team_id: &str) {
     svc.stop_session("user1", team_id).await.unwrap();
     tm.reset().await;
+}
+
+async fn force_team_workspace(repo: &Arc<FullMockTeamRepo>, team_id: &str, workspace: &str) {
+    repo.update_team(
+        team_id,
+        &aionui_db::UpdateTeamParams {
+            workspace: Some(workspace.to_owned()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("force workspace");
 }
 
 // ===========================================================================
@@ -1730,6 +1773,121 @@ async fn aa_add_agent_inherits_team_workspace() {
     assert_eq!(
         extra.get("workspace").and_then(|v| v.as_str()),
         Some(workspace.as_str())
+    );
+}
+
+#[tokio::test]
+async fn add_agent_backfills_empty_team_workspace_from_leader_workspace() {
+    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = Arc::new(StubAgentMetadataRepo::empty());
+    let (svc, team_repo, _, conv_repo) =
+        setup_with_factory_metadata_team_repo_and_conversation_repo(success_factory(), agent_metadata_repo);
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "Legacy".into(),
+                agents: vec![TeamAgentInput {
+                    name: "Lead".into(),
+                    role: "lead".into(),
+                    backend: "acp".into(),
+                    model: "claude".into(),
+                    custom_agent_id: None,
+                    conversation_id: None,
+                }],
+                workspace: None,
+            },
+        )
+        .await
+        .unwrap();
+    let leader_workspace = conv_repo.get_extra(&created.agents[0].conversation_id).unwrap()["workspace"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+
+    force_team_workspace(&team_repo, &created.id, "").await;
+
+    let added = svc
+        .add_agent(
+            "user1",
+            &created.id,
+            AddAgentRequest {
+                name: "Worker".into(),
+                role: "teammate".into(),
+                backend: "acp".into(),
+                model: "claude".into(),
+                custom_agent_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let got = svc.get_team("user1", &created.id).await.unwrap();
+    assert_eq!(got.workspace, leader_workspace);
+    let added_extra = conv_repo.get_extra(&added.conversation_id).unwrap();
+    assert_eq!(
+        added_extra.get("workspace").and_then(serde_json::Value::as_str),
+        Some(leader_workspace.as_str())
+    );
+}
+
+#[tokio::test]
+async fn add_agent_uses_team_temp_workspace_when_team_and_leader_workspaces_are_unusable() {
+    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = Arc::new(StubAgentMetadataRepo::empty());
+    let (svc, team_repo, _, conv_repo) =
+        setup_with_factory_metadata_team_repo_and_conversation_repo(success_factory(), agent_metadata_repo);
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "Legacy Empty".into(),
+                agents: vec![TeamAgentInput {
+                    name: "Lead".into(),
+                    role: "lead".into(),
+                    backend: "acp".into(),
+                    model: "claude".into(),
+                    custom_agent_id: None,
+                    conversation_id: None,
+                }],
+                workspace: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    force_team_workspace(&team_repo, &created.id, "").await;
+    conv_repo
+        .patch_extra(
+            &created.agents[0].conversation_id,
+            serde_json::json!({ "workspace": "/tmp/aionui-team-missing-leader-workspace" }),
+        )
+        .unwrap();
+
+    let added = svc
+        .add_agent(
+            "user1",
+            &created.id,
+            AddAgentRequest {
+                name: "Worker".into(),
+                role: "teammate".into(),
+                backend: "acp".into(),
+                model: "claude".into(),
+                custom_agent_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let got = svc.get_team("user1", &created.id).await.unwrap();
+    assert!(
+        got.workspace
+            .contains(&format!("/conversations/team-temp-{}", created.id)),
+        "unexpected team temp workspace: {}",
+        got.workspace
+    );
+    let added_extra = conv_repo.get_extra(&added.conversation_id).unwrap();
+    assert_eq!(
+        added_extra.get("workspace").and_then(serde_json::Value::as_str),
+        Some(got.workspace.as_str())
     );
 }
 

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -1156,6 +1156,74 @@ async fn tc1_create_team_with_multiple_agents() {
 }
 
 #[tokio::test]
+async fn create_team_with_workspace_writes_same_workspace_to_team_and_initial_agents() {
+    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = Arc::new(StubAgentMetadataRepo::empty());
+    let (svc, _, conv_repo) =
+        setup_with_factory_and_metadata_and_conversation_repo(success_factory(), agent_metadata_repo);
+    let workspace_dir =
+        std::env::temp_dir().join(format!("aionui-team-user-workspace-{}", aionui_common::generate_id()));
+    std::fs::create_dir_all(&workspace_dir).unwrap();
+    let workspace = workspace_dir.to_string_lossy().into_owned();
+
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "Shared".into(),
+                agents: two_agent_input(),
+                workspace: Some(workspace.clone()),
+            },
+        )
+        .await
+        .unwrap();
+
+    let got = svc.get_team("user1", &created.id).await.unwrap();
+    assert_eq!(got.workspace, workspace);
+    for agent in &got.agents {
+        let extra = conv_repo.get_extra(&agent.conversation_id).unwrap();
+        assert_eq!(
+            extra.get("workspace").and_then(serde_json::Value::as_str),
+            Some(workspace.as_str())
+        );
+    }
+}
+
+#[tokio::test]
+async fn create_team_without_workspace_uses_leader_auto_workspace_for_all_initial_agents() {
+    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = Arc::new(StubAgentMetadataRepo::empty());
+    let (svc, _, conv_repo) =
+        setup_with_factory_and_metadata_and_conversation_repo(success_factory(), agent_metadata_repo);
+
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "Auto Shared".into(),
+                agents: two_agent_input(),
+                workspace: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let got = svc.get_team("user1", &created.id).await.unwrap();
+    assert!(!got.workspace.trim().is_empty(), "teams.workspace must be set");
+    assert!(
+        got.workspace.contains("/conversations/acp-temp-"),
+        "unexpected auto workspace: {}",
+        got.workspace
+    );
+
+    for agent in &got.agents {
+        let extra = conv_repo.get_extra(&agent.conversation_id).unwrap();
+        assert_eq!(
+            extra.get("workspace").and_then(serde_json::Value::as_str),
+            Some(got.workspace.as_str())
+        );
+    }
+}
+
+#[tokio::test]
 async fn tc_create_team_uses_custom_agent_id_icon_lookup() {
     let svc = setup_with_metadata_rows(vec![make_agent_metadata_row(
         "2d23ff1c",

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -27,8 +27,8 @@ use aionui_team::ports::{
 };
 use aionui_team::session::SpawnAgentRequest;
 use aionui_team::{
-    TeamConversationAdoptRequest, TeamConversationCreateRequest, TeamConversationProvisioningPort,
-    TeamProjectionMessageStore,
+    TeamConversationAdoptRequest, TeamConversationCreateRequest, TeamConversationCreateResult,
+    TeamConversationProvisioningPort, TeamProjectionMessageStore,
 };
 use aionui_team::{TeamError, TeamSessionService};
 use common::MockTeamRepo;
@@ -223,11 +223,22 @@ fn noop_cancellation_port() -> Arc<dyn AgentTurnCancellationPort> {
 struct FakeConversationPorts {
     repo: Arc<MockConversationRepo>,
     broadcaster: Arc<dyn EventBroadcaster>,
+    workspace_root: std::path::PathBuf,
+    fail_team_temp_create: std::sync::atomic::AtomicBool,
+    fail_leader_workspace_patch: std::sync::atomic::AtomicBool,
 }
 
 impl FakeConversationPorts {
     fn new(repo: Arc<MockConversationRepo>, broadcaster: Arc<dyn EventBroadcaster>) -> Self {
-        Self { repo, broadcaster }
+        let workspace_root =
+            std::env::temp_dir().join(format!("aionui-team-fake-workspaces-{}", aionui_common::generate_id()));
+        Self {
+            repo,
+            broadcaster,
+            workspace_root,
+            fail_team_temp_create: std::sync::atomic::AtomicBool::new(false),
+            fail_leader_workspace_patch: std::sync::atomic::AtomicBool::new(false),
+        }
     }
 }
 
@@ -236,9 +247,22 @@ impl TeamConversationProvisioningPort for FakeConversationPorts {
     async fn create_team_conversation(
         &self,
         request: TeamConversationCreateRequest,
-    ) -> Result<String, aionui_team::TeamError> {
+    ) -> Result<TeamConversationCreateResult, aionui_team::TeamError> {
         let id = aionui_common::generate_id();
         let now = aionui_common::now_ms();
+        let workspace = request
+            .extra
+            .get("workspace")
+            .and_then(serde_json::Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_owned)
+            .unwrap_or_else(|| {
+                let path = self.workspace_root.join("conversations").join(format!("acp-temp-{id}"));
+                std::fs::create_dir_all(&path).unwrap();
+                path.to_string_lossy().into_owned()
+            });
+        let mut extra = request.extra;
+        extra["workspace"] = serde_json::Value::String(workspace.clone());
         self.repo
             .create(&ConversationRow {
                 id: id.clone(),
@@ -249,7 +273,7 @@ impl TeamConversationProvisioningPort for FakeConversationPorts {
                 pinned_at: None,
                 source: None,
                 channel_chat_id: None,
-                extra: serde_json::to_string(&request.extra).unwrap(),
+                extra: serde_json::to_string(&extra).unwrap(),
                 model: request
                     .top_level_model
                     .map(|m| serde_json::to_string(&m).expect("serialize provider model")),
@@ -258,7 +282,10 @@ impl TeamConversationProvisioningPort for FakeConversationPorts {
                 updated_at: now,
             })
             .await?;
-        Ok(id)
+        Ok(TeamConversationCreateResult {
+            conversation_id: id,
+            workspace,
+        })
     }
 
     async fn adopt_team_conversation(
@@ -289,11 +316,46 @@ impl TeamConversationProvisioningPort for FakeConversationPorts {
         Ok(())
     }
 
+    async fn conversation_workspace(&self, conversation_id: &str) -> Result<Option<String>, aionui_team::TeamError> {
+        Ok(self.repo.get_extra(conversation_id).and_then(|extra| {
+            extra
+                .get("workspace")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        }))
+    }
+
+    async fn create_team_temp_workspace(&self, team_id: &str) -> Result<String, aionui_team::TeamError> {
+        if self
+            .fail_team_temp_create
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
+        {
+            return Err(aionui_team::TeamError::InvalidRequest(
+                "failed to create Team temporary workspace for test".into(),
+            ));
+        }
+        let path = self
+            .workspace_root
+            .join("conversations")
+            .join(format!("team-temp-{team_id}"));
+        std::fs::create_dir_all(&path).unwrap();
+        Ok(path.to_string_lossy().into_owned())
+    }
+
     async fn patch_runtime_config(
         &self,
         conversation_id: &str,
         patch: serde_json::Value,
     ) -> Result<(), aionui_team::TeamError> {
+        if patch.get("workspace").is_some()
+            && self
+                .fail_leader_workspace_patch
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+        {
+            return Err(aionui_team::TeamError::InvalidRequest(
+                "forced leader workspace patch failure".into(),
+            ));
+        }
         let mut extra = self
             .repo
             .get_extra(conversation_id)


### PR DESCRIPTION
## Summary
- Persist the resolved team workspace during team creation and expose it through team API responses.
- Resolve add-agent and spawned-agent workspaces from the team record, with leader backfill and team-temp fallback behavior.
- Add integration coverage for new teams without a workspace, existing temp-workspace teams, writeback failure handling, and user-supplied workspaces.

## Test Plan
- `just push -u origin feat/team-shared-workspace-alignment`
- Manual dev verification against `~/Library/Logs/AionUi-Dev/*.log` and `~/.aionui-dev/aionui-backend.db` for:
  - new team without a workspace, then create teammates
  - existing team with a temp workspace, then create a teammate
  - new team with a user-supplied workspace, then create teammates