### PR TITLE
chore(runtime): bump managed ACP package versions

### DIFF
--- a/crates/aionui-runtime/src/acp_tool_runtime/mod.rs
+++ b/crates/aionui-runtime/src/acp_tool_runtime/mod.rs
@@ -997,7 +997,7 @@ mod tests {
         };
         let tool = ResolvedManagedAcpTool {
             id: ManagedAcpToolId::CodexAcp,
-            version: "0.14.0".into(),
+            version: ManagedAcpToolId::CodexAcp.version().into(),
             root: PathBuf::from("/tmp/tool"),
             entrypoint: PathBuf::from("/tmp/tool/dist/index.js"),
             env_path_entries: vec![PathBuf::from("/tmp/tool/bin")],
@@ -1027,9 +1027,10 @@ mod tests {
 
     #[test]
     fn classify_error_detects_bundled_acp_validation_failure() {
-        let error = ManagedAcpToolError::invalid(
-            "bundled managed Codex ACP artifact failed validation under /app/resources/managed-resources/acp/codex-acp/0.14.0/linux-x64: managed ACP entrypoint missing",
-        );
+        let error = ManagedAcpToolError::invalid(format!(
+            "bundled managed Codex ACP artifact failed validation under /app/resources/managed-resources/acp/codex-acp/{}/linux-x64: managed ACP entrypoint missing",
+            ManagedAcpToolId::CodexAcp.version(),
+        ));
         let (kind, status_code) = classify_error(&error);
 
         assert_eq!(kind, ManagedAcpToolFailureKind::BundledResourceInvalid);
@@ -1271,7 +1272,7 @@ mod tests {
         let source_root = bundled_root
             .join("acp")
             .join("codex-acp")
-            .join("0.14.0")
+            .join(ManagedAcpToolId::CodexAcp.version())
             .join(spec.manifest_key);
         std::fs::create_dir_all(&source_root).unwrap();
         std::fs::write(
@@ -1281,7 +1282,10 @@ mod tests {
         .unwrap();
 
         let runtime_root = tmp.path().join("runtime");
-        let tool_root = runtime_root.join("codex-acp").join("0.14.0").join(spec.manifest_key);
+        let tool_root = runtime_root
+            .join("codex-acp")
+            .join(ManagedAcpToolId::CodexAcp.version())
+            .join(spec.manifest_key);
 
         managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Bundled);
         let result = activate_local_tool_source(ManagedAcpToolId::CodexAcp, spec, &tool_root, None);
@@ -1311,7 +1315,7 @@ mod tests {
             bundle_root
                 .join("acp")
                 .join("codex-acp")
-                .join("0.14.0")
+                .join(ManagedAcpToolId::CodexAcp.version())
                 .join("win32-x64")
         );
     }

--- a/crates/aionui-runtime/src/acp_tool_runtime/types.rs
+++ b/crates/aionui-runtime/src/acp_tool_runtime/types.rs
@@ -20,8 +20,8 @@ impl ManagedAcpToolId {
 
     pub fn version(self) -> &'static str {
         match self {
-            Self::CodexAcp => "0.14.0",
-            Self::ClaudeAgentAcp => "0.39.0",
+            Self::CodexAcp => "0.16.0",
+            Self::ClaudeAgentAcp => "0.47.0",
         }
     }
 
@@ -215,6 +215,17 @@ pub struct ManagedAcpToolSupport {
 impl ManagedAcpToolSupport {
     pub fn is_supported(&self) -> bool {
         self.supported
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ManagedAcpToolId;
+
+    #[test]
+    fn managed_acp_tool_versions_match_current_pins() {
+        assert_eq!(ManagedAcpToolId::CodexAcp.version(), "0.16.0");
+        assert_eq!(ManagedAcpToolId::ClaudeAgentAcp.version(), "0.47.0");
     }
 }
 


### PR DESCRIPTION
## Summary
- Bump the managed Codex ACP package pin to 0.16.0.
- Bump the managed Claude Agent ACP package pin to 0.47.0.
- Keep ACP tool version assertions centralized while deriving test fixtures from the managed tool definitions.

## Test Plan
- [x] cargo fmt --all -- --check
- [x] cargo test -p aionui-runtime
- [x] cargo clippy -p aionui-runtime -- -D warnings
- [x] just push -u origin feat/acp-managed-tool-versions