### PR TITLE
chore(runtime): pin Claude ACP to 0.39.0

### DIFF
--- a/crates/aionui-runtime/src/acp_tool_runtime/types.rs
+++ b/crates/aionui-runtime/src/acp_tool_runtime/types.rs
@@ -21,7 +21,7 @@ impl ManagedAcpToolId {
     pub fn version(self) -> &'static str {
         match self {
             Self::CodexAcp => "0.16.0",
-            Self::ClaudeAgentAcp => "0.47.0",
+            Self::ClaudeAgentAcp => "0.39.0",
         }
     }
 
@@ -225,7 +225,7 @@ mod tests {
     #[test]
     fn managed_acp_tool_versions_match_current_pins() {
         assert_eq!(ManagedAcpToolId::CodexAcp.version(), "0.16.0");
-        assert_eq!(ManagedAcpToolId::ClaudeAgentAcp.version(), "0.47.0");
+        assert_eq!(ManagedAcpToolId::ClaudeAgentAcp.version(), "0.39.0");
     }
 }
 


### PR DESCRIPTION
## Summary
- Revert the managed Claude ACP package pin from 0.47.0 to 0.39.0.
- Keep the managed ACP version pin test aligned with the rollback target.

## Test Plan
- [x] `just push -u origin fix/claude-agent-acp-039`
  - migration immutability check passed
  - workspace clippy/fmt completed
  - workspace nextest: 6318 passed, 18 skipped
  - branch pushed to origin