### PR TITLE
fix(agent): surface OpenClaw Gateway unreachable errors

### DIFF
--- a/crates/aionui-ai-agent/src/idle_scanner.rs
+++ b/crates/aionui-ai-agent/src/idle_scanner.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use aionui_common::AgentKillReason;
+use aionui_common::{AgentKillReason, now_ms};
 use tracing::{debug, info};
 
 use crate::task_manager::IWorkerTaskManager;
@@ -55,6 +55,7 @@ pub fn start_idle_scanner(
 
 /// Perform one scan: find idle tasks and kill them.
 fn scan_and_cleanup(manager: &Arc<dyn IWorkerTaskManager>, threshold_ms: i64) {
+    let started_at = now_ms();
     let idle_ids = manager.collect_idle(threshold_ms);
 
     if idle_ids.is_empty() {
@@ -62,7 +63,8 @@ fn scan_and_cleanup(manager: &Arc<dyn IWorkerTaskManager>, threshold_ms: i64) {
         return;
     }
 
-    info!(count = idle_ids.len(), "Idle scan: cleaning up idle agents");
+    let count = idle_ids.len();
+    info!(count, "Idle scan: cleaning up idle agents");
 
     for id in idle_ids {
         let manager = Arc::clone(manager);
@@ -71,4 +73,10 @@ fn scan_and_cleanup(manager: &Arc<dyn IWorkerTaskManager>, threshold_ms: i64) {
             manager.kill_and_wait(&id, Some(AgentKillReason::IdleTimeout)).await;
         });
     }
+
+    info!(
+        count,
+        elapsed_ms = now_ms().saturating_sub(started_at),
+        "Idle scan: cleanup completed"
+    );
 }

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -23,7 +23,7 @@ use aionui_api_types::{
     SlashCommandCompletionBehavior, SlashCommandItem,
 };
 use aionui_common::{
-    AgentKillReason, AgentType, ConversationStatus, ErrorChain, TimestampMs, normalize_keys_to_snake_case,
+    AgentKillReason, AgentType, ConversationStatus, ErrorChain, TimestampMs, normalize_keys_to_snake_case, now_ms,
 };
 use serde_json::Value;
 use std::collections::HashMap;
@@ -935,6 +935,37 @@ impl AcpAgentManager {
     }
 }
 
+fn log_idle_acp_shutdown_started(conversation_id: &str, backend: &str, session_id: Option<&str>, pid: u32) {
+    info!(
+        conversation_id = %conversation_id,
+        backend = %backend,
+        session_id = %session_id.unwrap_or("none"),
+        pid,
+        reason = %"IdleTimeout",
+        "Idle kill: ACP shutdown started"
+    );
+}
+
+fn log_idle_acp_cancel_sent(conversation_id: &str, backend: &str, session_id: &str, pid: u32) {
+    info!(
+        conversation_id = %conversation_id,
+        backend = %backend,
+        session_id = %session_id,
+        pid,
+        "Idle kill: ACP session cancel sent"
+    );
+}
+
+fn log_idle_acp_cancel_skipped(conversation_id: &str, backend: &str, pid: u32) {
+    info!(
+        conversation_id = %conversation_id,
+        backend = %backend,
+        pid,
+        reason = %"no_session_id",
+        "Idle kill: ACP session cancel skipped"
+    );
+}
+
 #[async_trait::async_trait]
 impl crate::agent_task::IAgentTask for AcpAgentManager {
     fn agent_type(&self) -> AgentType {
@@ -1083,34 +1114,65 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
         // Mark closing to prevent reconnect attempts
         self.permission_router.set_closing();
 
-        // Cancel the current session if active
-        if let Ok(session) = self.session.try_read()
-            && let Some(sid) = session.session_id()
-        {
+        let backend = self.params.metadata.backend.as_deref().unwrap_or("unknown");
+        let pid = self.process.pid();
+        let idle_timeout = matches!(reason, Some(AgentKillReason::IdleTimeout));
+        let session_id = self
+            .session
+            .try_read()
+            .ok()
+            .and_then(|session| session.session_id().map(ToOwned::to_owned));
+
+        if idle_timeout {
+            log_idle_acp_shutdown_started(&self.params.conversation_id, backend, session_id.as_deref(), pid);
+        }
+
+        if let Some(sid) = session_id.as_deref() {
             self.protocol.cancel(CancelNotification::new(SessionId::new(sid)));
+            if idle_timeout {
+                log_idle_acp_cancel_sent(&self.params.conversation_id, backend, sid, pid);
+            }
+        } else if idle_timeout {
+            log_idle_acp_cancel_skipped(&self.params.conversation_id, backend, pid);
         }
 
         let process = Arc::clone(&self.process);
         let grace = Duration::from_millis(ACP_KILL_GRACE_MS);
         let conversation_id = self.params.conversation_id.clone();
-        let pid = process.pid();
+        let process_group_id = process.process_group_id();
+        let backend = backend.to_owned();
+        let idle_timeout = matches!(reason, Some(AgentKillReason::IdleTimeout));
 
         tokio::spawn(async move {
-            if let Err(e) = process.kill(grace).await {
-                // Tag the failure with conversation_id + pid so Sentry can
-                // group these and ops can correlate with the matching
-                // "Killing ACP agent" log line. ELECTRON-1E9: an unannotated
-                // failure here on Windows left the CLI subprocess running
-                // while the manager believed it had been torn down,
-                // producing the "no reply / second send hangs" symptom.
-                error!(
-                    %conversation_id,
-                    pid,
-                    error = %ErrorChain(&e),
-                    "Failed to kill ACP process"
-                );
-            } else {
-                debug!(%conversation_id, pid, "ACP process kill completed");
+            let started_at = now_ms();
+            match process.kill(grace).await {
+                Ok(()) => {
+                    if idle_timeout {
+                        info!(
+                            %conversation_id,
+                            backend,
+                            pid,
+                            process_group_id,
+                            elapsed_ms = now_ms().saturating_sub(started_at),
+                            result = "ok",
+                            "Idle kill: ACP process shutdown completed"
+                        );
+                    } else {
+                        debug!(%conversation_id, pid, process_group_id, "ACP process kill completed");
+                    }
+                }
+                Err(e) => {
+                    error!(
+                        %conversation_id,
+                        backend,
+                        pid,
+                        process_group_id,
+                        elapsed_ms = now_ms().saturating_sub(started_at),
+                        result = "error",
+                        error = %ErrorChain(&e),
+                        "Idle kill: ACP process shutdown completed"
+                    );
+                }
             }
         });
 
@@ -1190,6 +1252,42 @@ mod tests {
     use serde_json::json;
     use std::collections::HashMap;
 
+    fn capture_logs(max_level: tracing::Level, f: impl FnOnce()) -> String {
+        use std::io::Write;
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::fmt;
+
+        #[derive(Clone)]
+        struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+        impl Write for SharedBuf {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let make_writer = {
+            let buffer = Arc::clone(&buffer);
+            move || SharedBuf(Arc::clone(&buffer))
+        };
+
+        let subscriber = fmt::Subscriber::builder()
+            .with_max_level(max_level)
+            .with_writer(make_writer)
+            .with_ansi(false)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, f);
+
+        String::from_utf8(buffer.lock().unwrap().clone()).unwrap()
+    }
+
     #[test]
     fn exit_status_parts_handles_missing_status() {
         assert_eq!(exit_status_parts(None), (None, None));
@@ -1224,6 +1322,33 @@ mod tests {
     fn rate_limited_has_no_colon_returns_full_string() {
         let err = AgentError::RateLimited;
         assert_eq!(user_facing_message(&err), "Rate limited");
+    }
+
+    #[test]
+    fn idle_acp_shutdown_started_log_contains_diagnostic_context() {
+        let captured = capture_logs(tracing::Level::INFO, || {
+            super::log_idle_acp_shutdown_started("conv_openclaw", "openclaw", Some("session_123"), 4242);
+        });
+
+        assert!(captured.contains("Idle kill: ACP shutdown started"));
+        assert!(captured.contains("conversation_id=conv_openclaw"));
+        assert!(captured.contains("backend=openclaw"));
+        assert!(captured.contains("session_id=session_123"));
+        assert!(captured.contains("pid=4242"));
+        assert!(captured.contains("reason=IdleTimeout"));
+    }
+
+    #[test]
+    fn idle_acp_cancel_skipped_log_contains_reason() {
+        let captured = capture_logs(tracing::Level::INFO, || {
+            super::log_idle_acp_cancel_skipped("conv_openclaw", "openclaw", 4242);
+        });
+
+        assert!(captured.contains("Idle kill: ACP session cancel skipped"));
+        assert!(captured.contains("conversation_id=conv_openclaw"));
+        assert!(captured.contains("backend=openclaw"));
+        assert!(captured.contains("pid=4242"));
+        assert!(captured.contains("reason=no_session_id"));
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -1017,7 +1017,8 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
                 Ok(())
             }
             Err(err) => {
-                let send_error = err.to_agent_send_error();
+                let backend = self.params.metadata.backend.as_deref();
+                let send_error = err.to_agent_send_error_for_backend(backend);
                 let agent_err = err.into_agent_error();
                 // Build a CloseReason that captures whatever context we still
                 // have. Two cases matter:

--- a/crates/aionui-ai-agent/src/manager/acp/error_mapping.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/error_mapping.rs
@@ -9,10 +9,18 @@ pub(super) enum AcpSendFailure {
 }
 
 impl AcpSendFailure {
+    #[allow(dead_code)]
     pub(super) fn to_agent_send_error(&self) -> AgentSendError {
         match self {
             AcpSendFailure::Agent(err) => AgentSendError::from_agent_error_ref(err),
             AcpSendFailure::Acp(err) => AgentSendError::from_acp_error_ref(err),
+        }
+    }
+
+    pub(super) fn to_agent_send_error_for_backend(&self, backend: Option<&str>) -> AgentSendError {
+        match self {
+            AcpSendFailure::Agent(err) => AgentSendError::from_agent_error_ref_for_backend(err, backend),
+            AcpSendFailure::Acp(err) => AgentSendError::from_acp_error_ref_for_backend(err, backend),
         }
     }
 

--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -7,6 +7,9 @@ use super::error::AcpError;
 use crate::error::AgentError;
 
 const MAX_DETAIL_CHARS: usize = 1000;
+const OPENCLAW_BACKEND: &str = "openclaw";
+const OPENCLAW_GATEWAY_MESSAGE: &str = "OpenClaw Gateway is not reachable";
+const OPENCLAW_GATEWAY_DETAIL: &str = "OpenClaw Gateway is not running or cannot be reached at 127.0.0.1:18789.\n\nStart OpenClaw Gateway and try again. You can run:\nopenclaw gateway status\nopenclaw gateway start";
 
 #[derive(Debug, Clone)]
 pub struct AgentSendError {
@@ -190,6 +193,22 @@ impl AgentSendError {
         }
     }
 
+    pub fn from_agent_error_ref_for_backend(err: &AgentError, backend: Option<&str>) -> Self {
+        match err {
+            AgentError::Acp(acp_err)
+                if is_openclaw_backend(backend) && openclaw_gateway_unreachable_from_acp_error(acp_err) =>
+            {
+                openclaw_gateway_unreachable_send_error()
+            }
+            AgentError::BadGateway(detail)
+                if is_openclaw_backend(backend) && contains_openclaw_gateway_unreachable_signature(detail) =>
+            {
+                openclaw_gateway_unreachable_send_error()
+            }
+            _ => Self::from_agent_error_ref(err),
+        }
+    }
+
     pub fn stream_error(&self) -> &AgentStreamErrorData {
         &self.stream_error
     }
@@ -208,6 +227,17 @@ impl AgentSendError {
 
     pub(crate) fn from_acp_error_ref(err: &AcpError) -> Self {
         classify_acp_error(err)
+    }
+
+    pub(crate) fn from_acp_error_ref_for_backend(err: &AcpError, backend: Option<&str>) -> Self {
+        if is_openclaw_backend(backend) && openclaw_gateway_unreachable_from_acp_error(err) {
+            return openclaw_gateway_unreachable_send_error();
+        }
+        Self::from_acp_error_ref(err)
+    }
+
+    pub fn is_openclaw_gateway_unreachable(&self) -> bool {
+        self.code() == Some(AgentErrorCode::UserAgentOpenClawGatewayUnreachable)
     }
 
     fn from_acp_non_internal(err: &AcpError, detail: String) -> Self {
@@ -862,6 +892,48 @@ fn contains_any(haystack: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| haystack.contains(needle))
 }
 
+fn is_openclaw_backend(backend: Option<&str>) -> bool {
+    matches!(backend, Some(value) if value.eq_ignore_ascii_case(OPENCLAW_BACKEND))
+}
+
+fn contains_openclaw_gateway_unreachable_signature(detail: &str) -> bool {
+    let lower = detail.to_ascii_lowercase();
+    contains_any(
+        &lower,
+        &[
+            "acp bridge failed",
+            "connect econnrefused 127.0.0.1:18789",
+            "econnrefused 127.0.0.1:18789",
+        ],
+    )
+}
+
+fn openclaw_gateway_unreachable_from_acp_error(err: &AcpError) -> bool {
+    match err {
+        AcpError::StartupCrash { stderr, .. } => contains_openclaw_gateway_unreachable_signature(stderr),
+        AcpError::AgentInternal { message, data, .. } => acp_agent_internal_texts(message, data.as_ref())
+            .into_iter()
+            .any(contains_openclaw_gateway_unreachable_signature),
+        AcpError::InitTimeout { .. } => contains_openclaw_gateway_unreachable_signature(&err.to_string()),
+        _ => false,
+    }
+}
+
+fn openclaw_gateway_unreachable_send_error() -> AgentSendError {
+    AgentSendError::new(
+        OPENCLAW_GATEWAY_MESSAGE,
+        AgentErrorCode::UserAgentOpenClawGatewayUnreachable,
+        AgentErrorOwnership::UserAgent,
+        Some(OPENCLAW_GATEWAY_DETAIL.to_owned()),
+        true,
+        false,
+        resolution(
+            AgentErrorResolutionKind::CheckAgentInstallation,
+            Some(AgentErrorResolutionTarget::AgentSettings),
+        ),
+    )
+}
+
 pub(crate) fn sanitize_error_detail(input: &str) -> String {
     let stripped = strip_markup(input);
     let without_query = redact_url_queries(&stripped);
@@ -1007,6 +1079,99 @@ mod tests {
             err.stream_error().resolution.and_then(|value| value.target),
             Some(target)
         );
+    }
+
+    #[test]
+    fn classifies_openclaw_gateway_unreachable_from_startup_stderr_with_backend_context() {
+        let err = AgentError::from(AcpError::StartupCrash {
+            exit_code: Some(1),
+            signal: None,
+            stderr: "ACP bridge failed: connect ECONNREFUSED 127.0.0.1:18789".into(),
+        });
+
+        let send_error = AgentSendError::from_agent_error_ref_for_backend(&err, Some("openclaw"));
+
+        assert_eq!(
+            send_error.code(),
+            Some(AgentErrorCode::UserAgentOpenClawGatewayUnreachable)
+        );
+        assert_eq!(send_error.ownership(), Some(AgentErrorOwnership::UserAgent));
+        assert_eq!(send_error.stream_error().retryable, Some(true));
+        assert_eq!(send_error.stream_error().feedback_recommended, Some(false));
+        assert_eq!(
+            send_error.stream_error().resolution.map(|value| value.kind),
+            Some(AgentErrorResolutionKind::CheckAgentInstallation)
+        );
+        assert!(
+            send_error
+                .stream_error()
+                .detail
+                .as_deref()
+                .unwrap_or_default()
+                .contains("openclaw gateway start")
+        );
+    }
+
+    #[test]
+    fn keeps_openclaw_generic_startup_crash_when_gateway_signature_is_absent() {
+        let err = AgentError::from(AcpError::StartupCrash {
+            exit_code: Some(1),
+            signal: None,
+            stderr: "ordinary OpenClaw startup failure without gateway signature".into(),
+        });
+
+        let send_error = AgentSendError::from_agent_error_ref_for_backend(&err, Some("openclaw"));
+
+        assert_ne!(
+            send_error.code(),
+            Some(AgentErrorCode::UserAgentOpenClawGatewayUnreachable)
+        );
+        assert_eq!(send_error.code(), Some(AgentErrorCode::UserAgentStartupFailed));
+    }
+
+    #[test]
+    fn does_not_classify_openclaw_gateway_signature_for_other_backends() {
+        let err = AgentError::from(AcpError::StartupCrash {
+            exit_code: Some(1),
+            signal: None,
+            stderr: "ACP bridge failed: connect ECONNREFUSED 127.0.0.1:18789".into(),
+        });
+
+        let send_error = AgentSendError::from_agent_error_ref_for_backend(&err, Some("codex"));
+
+        assert_ne!(
+            send_error.code(),
+            Some(AgentErrorCode::UserAgentOpenClawGatewayUnreachable)
+        );
+        assert_eq!(send_error.code(), Some(AgentErrorCode::UserAgentStartupFailed));
+    }
+
+    #[test]
+    fn does_not_classify_plain_init_timeout_as_openclaw_gateway_unreachable() {
+        let err = AgentError::from(AcpError::InitTimeout { timeout_secs: 30 });
+
+        let send_error = AgentSendError::from_agent_error_ref_for_backend(&err, Some("openclaw"));
+
+        assert_ne!(
+            send_error.code(),
+            Some(AgentErrorCode::UserAgentOpenClawGatewayUnreachable)
+        );
+        assert_eq!(send_error.code(), Some(AgentErrorCode::UserAgentStartupFailed));
+    }
+
+    #[test]
+    fn classifies_openclaw_gateway_unreachable_from_bad_gateway_detail_only_with_backend_context() {
+        let detail = "Bad gateway: ACP bridge failed: connect ECONNREFUSED 127.0.0.1:18789";
+        let err = AgentError::bad_gateway(detail);
+
+        let openclaw = AgentSendError::from_agent_error_ref_for_backend(&err, Some("openclaw"));
+        let codex = AgentSendError::from_agent_error_ref_for_backend(&err, Some("codex"));
+
+        assert_eq!(
+            openclaw.code(),
+            Some(AgentErrorCode::UserAgentOpenClawGatewayUnreachable)
+        );
+        assert_ne!(codex.code(), Some(AgentErrorCode::UserAgentOpenClawGatewayUnreachable));
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/task_manager.rs
+++ b/crates/aionui-ai-agent/src/task_manager.rs
@@ -126,7 +126,17 @@ impl IWorkerTaskManager for WorkerTaskManagerImpl {
 
     fn kill(&self, conversation_id: &str, reason: Option<AgentKillReason>) -> Result<(), AgentError> {
         if let Some((id, slot)) = self.tasks.remove(conversation_id) {
-            info!(conversation_id = %id, ?reason, "Killing agent task");
+            let agent_type = slot.get().map(|agent| agent.agent_type());
+            if matches!(reason, Some(AgentKillReason::IdleTimeout)) {
+                info!(
+                    conversation_id = %id,
+                    ?agent_type,
+                    reason = %"IdleTimeout",
+                    "Idle kill: task removed from manager"
+                );
+            } else {
+                info!(conversation_id = %id, ?reason, "Killing agent task");
+            }
             if let Some(agent) = slot.get() {
                 agent.kill(reason)?;
             }
@@ -140,7 +150,17 @@ impl IWorkerTaskManager for WorkerTaskManagerImpl {
         reason: Option<AgentKillReason>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
         if let Some((id, slot)) = self.tasks.remove(conversation_id) {
-            info!(conversation_id = %id, ?reason, "Killing agent task (awaitable)");
+            let agent_type = slot.get().map(|agent| agent.agent_type());
+            if matches!(reason, Some(AgentKillReason::IdleTimeout)) {
+                info!(
+                    conversation_id = %id,
+                    ?agent_type,
+                    reason = %"IdleTimeout",
+                    "Idle kill: task removed from manager"
+                );
+            } else {
+                info!(conversation_id = %id, ?reason, "Killing agent task (awaitable)");
+            }
             if let Some(agent) = slot.get() {
                 return agent.kill_and_wait(reason);
             }
@@ -172,11 +192,28 @@ impl IWorkerTaskManager for WorkerTaskManagerImpl {
             .iter()
             .filter_map(|entry| {
                 let agent = entry.value().get()?;
-                // Only ACP agents participate in idle cleanup per API Spec
-                (agent.agent_type() == AgentType::Acp
-                    && agent.status() == Some(ConversationStatus::Finished)
-                    && (now - agent.last_activity_at()) > idle_threshold_ms)
-                    .then(|| entry.key().clone())
+                let agent_type = agent.agent_type();
+                let status = agent.status();
+                let last_activity_at = agent.last_activity_at();
+                let idle_ms = now.saturating_sub(last_activity_at);
+
+                let selected = agent_type == AgentType::Acp
+                    && status == Some(ConversationStatus::Finished)
+                    && idle_ms > idle_threshold_ms;
+                if selected {
+                    info!(
+                        conversation_id = %entry.key(),
+                        ?agent_type,
+                        ?status,
+                        idle_ms,
+                        threshold_ms = idle_threshold_ms,
+                        last_activity_at,
+                        "Idle scan: selected idle agent"
+                    );
+                    Some(entry.key().clone())
+                } else {
+                    None
+                }
             })
             .collect()
     }
@@ -325,6 +362,42 @@ mod tests {
             async move { Ok(mock_instance(MockAgent::new(opts.conversation_id(), None))) }.boxed()
         });
         WorkerTaskManagerImpl::new(factory)
+    }
+
+    fn capture_logs(max_level: tracing::Level, f: impl FnOnce()) -> String {
+        use std::io::Write;
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::fmt;
+
+        #[derive(Clone)]
+        struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+        impl Write for SharedBuf {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let make_writer = {
+            let buffer = Arc::clone(&buffer);
+            move || SharedBuf(Arc::clone(&buffer))
+        };
+
+        let subscriber = fmt::Subscriber::builder()
+            .with_max_level(max_level)
+            .with_writer(make_writer)
+            .with_ansi(false)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, f);
+
+        String::from_utf8(buffer.lock().unwrap().clone()).unwrap()
     }
 
     /// Two [`AgentInstance`]s point to the same underlying agent iff they
@@ -513,6 +586,53 @@ mod tests {
         let idle = mgr.collect_idle(300_000); // 5-min threshold
         assert_eq!(idle.len(), 1);
         assert_eq!(idle[0], "conv-stale");
+    }
+
+    #[test]
+    fn collect_idle_logs_selected_agent_with_idle_fields() {
+        let manager = WorkerTaskManagerImpl::new(Arc::new(|_options| {
+            async { Err(AgentError::bad_gateway("not used")) }.boxed()
+        }));
+        let now = now_ms();
+        let agent =
+            Arc::new(MockAgent::new("conv_idle", Some(ConversationStatus::Finished)).with_last_activity(now - 10_000));
+        let slot = Arc::new(OnceCell::new());
+        assert!(slot.set(AgentInstance::Mock(agent)).is_ok());
+        manager.tasks.insert("conv_idle".to_owned(), slot);
+
+        let captured = capture_logs(tracing::Level::INFO, || {
+            let ids = manager.collect_idle(5_000);
+            assert_eq!(ids, vec!["conv_idle".to_owned()]);
+        });
+
+        assert!(captured.contains("Idle scan: selected idle agent"));
+        assert!(captured.contains("conversation_id=conv_idle"));
+        assert!(captured.contains("agent_type=Acp"));
+        assert!(captured.contains("status=Some(Finished)"));
+        assert!(captured.contains("idle_ms="));
+        assert!(captured.contains("threshold_ms=5000"));
+        assert!(captured.contains("last_activity_at="));
+    }
+
+    #[test]
+    fn kill_and_wait_logs_idle_task_removed_with_agent_type() {
+        let manager = WorkerTaskManagerImpl::new(Arc::new(|_options| {
+            async { Err(AgentError::bad_gateway("not used")) }.boxed()
+        }));
+        let agent = Arc::new(MockAgent::new("conv_idle", Some(ConversationStatus::Finished)));
+        let slot = Arc::new(OnceCell::new());
+        assert!(slot.set(AgentInstance::Mock(agent)).is_ok());
+        manager.tasks.insert("conv_idle".to_owned(), slot);
+
+        let captured = capture_logs(tracing::Level::INFO, || {
+            let wait = manager.kill_and_wait("conv_idle", Some(AgentKillReason::IdleTimeout));
+            drop(wait);
+        });
+
+        assert!(captured.contains("Idle kill: task removed from manager"));
+        assert!(captured.contains("conversation_id=conv_idle"));
+        assert!(captured.contains("agent_type=Some(Acp)"));
+        assert!(captured.contains("reason=IdleTimeout"));
     }
 
     #[test]

--- a/crates/aionui-api-types/src/agent_error.rs
+++ b/crates/aionui-api-types/src/agent_error.rs
@@ -25,6 +25,8 @@ pub enum AgentErrorCode {
     UserAgentProtocolMismatch,
     UserAgentNotInstalled,
     UserAgentStartupFailed,
+    #[serde(rename = "USER_AGENT_OPENCLAW_GATEWAY_UNREACHABLE")]
+    UserAgentOpenClawGatewayUnreachable,
     UserAgentDisconnected,
     UserAgentAuthRequired,
     UserAgentSessionNotFound,
@@ -198,6 +200,16 @@ mod tests {
         assert_eq!(json["code"], "AIONUI_CONVERSATION_BUSY");
         assert_eq!(json["resolution"]["kind"], "wait_for_current_response");
         assert_eq!(json["resolution"]["target"], "new_conversation");
+    }
+
+    #[test]
+    fn openclaw_gateway_unreachable_serializes_with_compact_vendor_name() {
+        let json = serde_json::to_value(AgentErrorCode::UserAgentOpenClawGatewayUnreachable).unwrap();
+        assert_eq!(json, "USER_AGENT_OPENCLAW_GATEWAY_UNREACHABLE");
+
+        let decoded: AgentErrorCode =
+            serde_json::from_value(serde_json::json!("USER_AGENT_OPENCLAW_GATEWAY_UNREACHABLE")).unwrap();
+        assert_eq!(decoded, AgentErrorCode::UserAgentOpenClawGatewayUnreachable);
     }
 
     #[test]

--- a/crates/aionui-conversation/src/error.rs
+++ b/crates/aionui-conversation/src/error.rs
@@ -74,6 +74,9 @@ pub enum ConversationError {
     #[error("Workspace path is unavailable during execution: {path}")]
     WorkspacePathRuntimeUnavailable { path: String },
 
+    #[error("OpenClaw Gateway is not reachable: {detail}")]
+    OpenClawGatewayUnreachable { detail: String },
+
     #[error("ACP error")]
     Acp(#[from] AcpError),
 }
@@ -112,6 +115,7 @@ impl ConversationError {
             Self::WorkspacePathRuntimeUnavailable { path } => {
                 AgentError::workspace_path_runtime_unavailable(path.clone())
             }
+            Self::OpenClawGatewayUnreachable { detail } => AgentError::bad_gateway(detail.clone()),
             Self::Acp(err) => AgentError::bad_gateway(err.to_string()),
         }
     }
@@ -137,6 +141,7 @@ impl ConversationError {
             Self::Archived { .. } => "CONVERSATION_ARCHIVED",
             Self::WorkspacePathUnavailable { .. } => "WORKSPACE_PATH_UNAVAILABLE",
             Self::WorkspacePathRuntimeUnavailable { .. } => "WORKSPACE_PATH_RUNTIME_UNAVAILABLE",
+            Self::OpenClawGatewayUnreachable { .. } => "USER_AGENT_OPENCLAW_GATEWAY_UNREACHABLE",
         }
     }
 }

--- a/crates/aionui-conversation/src/routes.rs
+++ b/crates/aionui-conversation/src/routes.rs
@@ -74,6 +74,17 @@ impl From<ConversationError> for ApiError {
             ConversationError::WorkspacePathRuntimeUnavailable { path } => {
                 ApiError::WorkspacePathRuntimeUnavailable(path)
             }
+            ConversationError::OpenClawGatewayUnreachable { detail } => ApiError::coded(
+                StatusCode::BAD_GATEWAY,
+                "USER_AGENT_OPENCLAW_GATEWAY_UNREACHABLE",
+                "OpenClaw Gateway is not reachable",
+                Some(serde_json::json!({
+                    "detail": detail,
+                    "error_kind": "openclaw_gateway_unreachable",
+                    "backend": "openclaw",
+                    "port": 18789
+                })),
+            ),
             ConversationError::Acp(_) => ApiError::BadGateway("Agent protocol error".into()),
         }
     }
@@ -438,5 +449,19 @@ mod error_mapping_tests {
             app,
             ApiError::WorkspacePathRuntimeUnavailable(message) if message == "/tmp/my project"
         ));
+    }
+
+    #[test]
+    fn openclaw_gateway_unreachable_maps_to_coded_bad_gateway() {
+        let app = ApiError::from(ConversationError::OpenClawGatewayUnreachable {
+            detail: "OpenClaw Gateway is not running or cannot be reached at 127.0.0.1:18789.".into(),
+        });
+
+        assert_eq!(app.status_code(), StatusCode::BAD_GATEWAY);
+        assert_eq!(app.error_code(), "USER_AGENT_OPENCLAW_GATEWAY_UNREACHABLE");
+        assert_eq!(app.public_message(), "OpenClaw Gateway is not reachable");
+        let details = app.error_details().expect("details should be present");
+        assert_eq!(details["backend"], "openclaw");
+        assert_eq!(details["port"], 18789);
     }
 }

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -2546,7 +2546,30 @@ impl ConversationService {
         let build_opts = self.build_task_options(&row).await?;
         self.ensure_auto_workspace_skill_links(&row, &build_opts).await;
         let stored_workspace = build_opts.context.workspace.stored_path.clone();
-        let agent = task_manager.get_or_build_task(conversation_id, build_opts).await?;
+        let backend = build_options_backend(&build_opts).map(str::to_owned);
+        let agent = match task_manager.get_or_build_task(conversation_id, build_opts).await {
+            Ok(agent) => agent,
+            Err(err) => {
+                let send_error = AgentSendError::from_agent_error_ref_for_backend(&err, backend.as_deref());
+                if send_error.is_openclaw_gateway_unreachable() {
+                    warn!(
+                        conversation_id = %conversation_id,
+                        backend = "openclaw",
+                        error_kind = "openclaw_gateway_unreachable",
+                        port = 18789_u16,
+                        phase = "warmup",
+                        "OpenClaw Gateway unreachable during ACP startup"
+                    );
+                    let detail = send_error
+                        .stream_error()
+                        .detail
+                        .clone()
+                        .unwrap_or_else(|| send_error.stream_error().message.clone());
+                    return Err(ConversationError::OpenClawGatewayUnreachable { detail });
+                }
+                return Err(err.into());
+            }
+        };
 
         // Persist auto-resolved workspace if factory picked a different path.
         self.maybe_persist_workspace(conversation_id, &stored_workspace, agent.workspace())
@@ -2876,6 +2899,13 @@ fn context_backend_value(context: &AgentSessionContext) -> Option<serde_json::Va
             .filter(|value| !value.is_empty())
             .map(|value| serde_json::Value::String(value.clone())),
         _ => None,
+    }
+}
+
+fn build_options_backend(options: &BuildTaskOptions) -> Option<&str> {
+    match &options.context.kind {
+        AgentSessionKind::Acp(ctx) => ctx.config.backend.as_deref(),
+        AgentSessionKind::Aionrs(_) => None,
     }
 }
 

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -3956,6 +3956,58 @@ async fn warmup_rejects_legacy_workspace_with_runtime_error_code() {
     ));
 }
 
+#[tokio::test]
+async fn warmup_returns_openclaw_gateway_unreachable_when_startup_stderr_matches() {
+    let (svc, _broadcaster, _repo, _default_task_mgr) = make_service();
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(AgentErrorFailingBuildTaskManager::new(AgentError::from(
+        AcpError::StartupCrash {
+            exit_code: Some(1),
+            signal: None,
+            stderr: "ACP bridge failed: connect ECONNREFUSED 127.0.0.1:18789".into(),
+        },
+    )));
+
+    let conv = svc
+        .create("user_1", make_create_req_with_backend("openclaw"))
+        .await
+        .unwrap();
+
+    let err = svc.warmup("user_1", &conv.id, &task_mgr).await.unwrap_err();
+
+    match err {
+        ConversationError::OpenClawGatewayUnreachable { detail } => {
+            assert!(detail.contains("127.0.0.1:18789"));
+            assert!(detail.contains("openclaw gateway status"));
+            assert!(detail.contains("openclaw gateway start"));
+        }
+        other => panic!("expected OpenClawGatewayUnreachable, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn warmup_keeps_generic_error_for_non_openclaw_gateway_signature() {
+    let (svc, _broadcaster, _repo, _default_task_mgr) = make_service();
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(AgentErrorFailingBuildTaskManager::new(AgentError::from(
+        AcpError::StartupCrash {
+            exit_code: Some(1),
+            signal: None,
+            stderr: "ACP bridge failed: connect ECONNREFUSED 127.0.0.1:18789".into(),
+        },
+    )));
+
+    let conv = svc
+        .create("user_1", make_create_req_with_backend("codex"))
+        .await
+        .unwrap();
+
+    let err = svc.warmup("user_1", &conv.id, &task_mgr).await.unwrap_err();
+
+    assert!(
+        !matches!(err, ConversationError::OpenClawGatewayUnreachable { .. }),
+        "non-OpenClaw backend must not receive the OpenClaw Gateway error"
+    );
+}
+
 // ── Confirmation system tests ────────────────────────────────────
 
 fn make_test_confirmations() -> Vec<Confirmation> {

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -768,6 +768,19 @@ fn make_create_req() -> CreateConversationRequest {
     .unwrap()
 }
 
+fn make_create_req_with_backend(backend: &str) -> CreateConversationRequest {
+    let workspace = ensure_test_workspace_path();
+    serde_json::from_value(json!({
+        "type": "acp",
+        "extra": {
+            "workspace": workspace,
+            "custom_workspace": true,
+            "backend": backend
+        }
+    }))
+    .unwrap()
+}
+
 fn ensure_test_workspace_path() -> String {
     let workspace = std::env::temp_dir().join("aionui-conversation-service-test-project");
     std::fs::create_dir_all(&workspace).unwrap();
@@ -1912,6 +1925,18 @@ impl FailingBuildTaskManager {
     }
 }
 
+struct AgentErrorFailingBuildTaskManager {
+    error: Mutex<Option<AgentError>>,
+}
+
+impl AgentErrorFailingBuildTaskManager {
+    fn new(error: AgentError) -> Self {
+        Self {
+            error: Mutex::new(Some(error)),
+        }
+    }
+}
+
 struct DelayedFailingBuildTaskManager {
     delay: Duration,
     error: String,
@@ -1923,6 +1948,48 @@ impl DelayedFailingBuildTaskManager {
             delay,
             error: error.into(),
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl IWorkerTaskManager for AgentErrorFailingBuildTaskManager {
+    fn get_task(&self, _conversation_id: &str) -> Option<AgentInstance> {
+        None
+    }
+
+    async fn get_or_build_task(
+        &self,
+        _conversation_id: &str,
+        _options: BuildTaskOptions,
+    ) -> Result<AgentInstance, AgentError> {
+        Err(self
+            .error
+            .lock()
+            .unwrap()
+            .take()
+            .expect("test build error should be consumed once"))
+    }
+
+    fn kill(&self, _conversation_id: &str, _reason: Option<AgentKillReason>) -> Result<(), AgentError> {
+        Ok(())
+    }
+
+    fn kill_and_wait(
+        &self,
+        _conversation_id: &str,
+        _reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        Box::pin(std::future::ready(()))
+    }
+
+    async fn clear(&self) {}
+
+    fn active_count(&self) -> usize {
+        0
+    }
+
+    fn collect_idle(&self, _idle_threshold_ms: TimestampMs) -> Vec<String> {
+        vec![]
     }
 }
 
@@ -3107,6 +3174,74 @@ async fn send_message_persists_error_tip_when_agent_build_fails() {
         .expect("agent build failure should broadcast the error tips message");
     assert_eq!(error_tip_event.data["status"], "error");
     assert_eq!(error_tip_event.data["data"]["code"], "BAD_GATEWAY");
+    assert_eq!(error_tip_event.data["turn_id"], response.turn_id);
+}
+
+#[tokio::test]
+async fn send_message_persists_openclaw_gateway_unreachable_tip_when_turn_build_fails() {
+    let (svc, broadcaster, repo, _default_task_mgr) = make_service();
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(AgentErrorFailingBuildTaskManager::new(AgentError::from(
+        AcpError::StartupCrash {
+            exit_code: Some(1),
+            signal: None,
+            stderr: "ACP bridge failed: connect ECONNREFUSED 127.0.0.1:18789".into(),
+        },
+    )));
+
+    let conv = svc
+        .create("user_1", make_create_req_with_backend("openclaw"))
+        .await
+        .unwrap();
+    broadcaster.take_events();
+
+    let response = svc
+        .send_message(
+            "user_1",
+            &conv.id,
+            SendMessageRequest {
+                content: "hello".into(),
+                hidden: false,
+                files: vec![],
+                inject_skills: vec![],
+            },
+            &task_mgr,
+        )
+        .await
+        .unwrap();
+
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    let messages = repo.get_messages(&conv.id, 1, 20, SortOrder::Asc).await.unwrap().items;
+    let tip = messages
+        .iter()
+        .find(|row| row.r#type == "tips" && row.status.as_deref() == Some("error"))
+        .expect("send failure tip should be persisted");
+    let content: serde_json::Value = serde_json::from_str(&tip.content).unwrap();
+
+    assert_eq!(content["source"], "send_failed");
+    assert_eq!(content["error"]["code"], "USER_AGENT_OPENCLAW_GATEWAY_UNREACHABLE");
+    assert_eq!(content["error"]["ownership"], "user_agent");
+    assert!(
+        content["error"]["detail"]
+            .as_str()
+            .unwrap()
+            .contains("openclaw gateway start")
+    );
+
+    let events = broadcaster.take_events();
+    let error_tip_event = events
+        .iter()
+        .find(|event| event.name == "message.stream" && event.data["type"] == "tips")
+        .expect("OpenClaw Gateway build failure should broadcast the error tips message");
+    assert_eq!(error_tip_event.data["status"], "error");
+    assert_eq!(
+        error_tip_event.data["data"]["code"],
+        "USER_AGENT_OPENCLAW_GATEWAY_UNREACHABLE"
+    );
+    assert_eq!(
+        error_tip_event.data["data"]["error"]["code"],
+        "USER_AGENT_OPENCLAW_GATEWAY_UNREACHABLE"
+    );
     assert_eq!(error_tip_event.data["turn_id"], response.turn_id);
 }
 

--- a/crates/aionui-conversation/src/turn_orchestrator.rs
+++ b/crates/aionui-conversation/src/turn_orchestrator.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
-use aionui_ai_agent::{AgentSendError, IWorkerTaskManager};
+use aionui_ai_agent::{AgentSendError, AgentSessionKind, IWorkerTaskManager};
 use aionui_common::{ConversationStatus, ErrorChain, now_ms};
 use aionui_db::models::ConversationRow;
 use tokio::sync::oneshot;
@@ -15,6 +15,13 @@ use crate::service::{
 use crate::stream_relay::StreamRelay;
 use crate::turn_continuation_policy::{ContinuationDecision, TurnContinuationPolicy};
 use aionui_api_types::SendMessageRequest;
+
+fn acp_backend_from_build_options(options: &BuildTaskOptions) -> Option<&str> {
+    match &options.context.kind {
+        AgentSessionKind::Acp(ctx) => ctx.config.backend.as_deref(),
+        AgentSessionKind::Aionrs(_) => None,
+    }
+}
 
 pub(crate) struct TurnStartInput {
     pub user_id: String,
@@ -63,11 +70,28 @@ impl ConversationTurnOrchestrator {
 
         info!(conversation_id = %conv_id, turn_id = %turn_id, "conversation turn orchestrator started");
         info!(conversation_id = %conv_id, turn_id = %turn_id, "Agent task build started");
+        let backend = acp_backend_from_build_options(&input.build_options).map(str::to_owned);
         let agent = match self.task_manager.get_or_build_task(&conv_id, input.build_options).await {
             Ok(agent) => agent,
             Err(err) => {
                 let top_level_code = agent_error_top_level_code(&err);
-                let send_error = AgentSendError::from_agent_error_ref(&err);
+                let send_error = AgentSendError::from_agent_error_ref_for_backend(&err, backend.as_deref());
+                let top_level_code = if send_error.is_openclaw_gateway_unreachable() {
+                    "USER_AGENT_OPENCLAW_GATEWAY_UNREACHABLE"
+                } else {
+                    top_level_code
+                };
+                if send_error.is_openclaw_gateway_unreachable() {
+                    warn!(
+                        conversation_id = %conv_id,
+                        turn_id = %turn_id,
+                        backend = "openclaw",
+                        error_kind = "openclaw_gateway_unreachable",
+                        port = 18789_u16,
+                        phase = "turn_build",
+                        "OpenClaw Gateway unreachable during ACP startup"
+                    );
+                }
                 error!(
                     conversation_id = %conv_id,
                     turn_id = %turn_id,


### PR DESCRIPTION
## Summary
- Add the dedicated `USER_AGENT_OPENCLAW_GATEWAY_UNREACHABLE` agent error code and backend-aware OpenClaw Gateway classification.
- Surface the structured error through ACP send, turn build, and warmup paths without starting or supervising OpenClaw Gateway.
- Add low-volume diagnostic logs for Gateway classification and ACP idle cleanup.

## Paired Frontend Change
- Paired with iOfficeAI/AionUi#3392.

## Test Plan
- [x] `just push -u origin openclaw-gateway-unreachable`
- [x] Local development verification with OpenClaw Gateway stopped: UI shows the dedicated recovery tip and logs include `error_kind=openclaw_gateway_unreachable`, `backend=openclaw`, `port=18789`, and `phase=turn_build`.

## Release Notes
- Bug Fixes: OpenClaw ACP startup failures caused by an unreachable Gateway now surface a dedicated actionable user-agent error.