### PR TITLE
fix(agent): support aionrs 0.1.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,8 +117,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.30"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.30#f048034140aa7974b82fd38e5e492d5851329c00"
+version = "0.1.31"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -147,8 +147,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.30"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.30#f048034140aa7974b82fd38e5e492d5851329c00"
+version = "0.1.31"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
 dependencies = [
  "regex",
  "serde",
@@ -158,8 +158,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.30"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.30#f048034140aa7974b82fd38e5e492d5851329c00"
+version = "0.1.31"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
 dependencies = [
  "aion-compact",
  "aion-types",
@@ -182,8 +182,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.30"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.30#f048034140aa7974b82fd38e5e492d5851329c00"
+version = "0.1.31"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -203,8 +203,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.30"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.30#f048034140aa7974b82fd38e5e492d5851329c00"
+version = "0.1.31"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
 dependencies = [
  "aion-config",
  "chrono",
@@ -217,8 +217,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.30"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.30#f048034140aa7974b82fd38e5e492d5851329c00"
+version = "0.1.31"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
 dependencies = [
  "aion-types",
  "serde",
@@ -230,8 +230,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.30"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.30#f048034140aa7974b82fd38e5e492d5851329c00"
+version = "0.1.31"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -258,8 +258,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.30"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.30#f048034140aa7974b82fd38e5e492d5851329c00"
+version = "0.1.31"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -284,8 +284,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.30"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.30#f048034140aa7974b82fd38e5e492d5851329c00"
+version = "0.1.31"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -304,8 +304,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.30"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.30#f048034140aa7974b82fd38e5e492d5851329c00"
+version = "0.1.31"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6484,7 +6484,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.30#f048034140aa7974b82fd38e5e492d5851329c00"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,12 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.30" }
-aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.30" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.30" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.30" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.30" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.30" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.31" }
+aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.31" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.31" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.31" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.31" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.31" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }

--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -1031,8 +1031,10 @@ mod tests {
 
     #[test]
     fn aionrs_guide_prompt_hands_off_after_create_team() {
-        let mut overrides = AionrsBuildExtra::default();
-        overrides.system_prompt = Some(team_guide_prompt::build_solo_team_guide_prompt("aionrs"));
+        let overrides = AionrsBuildExtra {
+            system_prompt: Some(team_guide_prompt::build_solo_team_guide_prompt("aionrs")),
+            ..Default::default()
+        };
 
         let prompt = overrides.system_prompt.as_deref().unwrap();
         assert!(prompt.contains("aion_create_team"));

--- a/crates/aionui-ai-agent/src/manager/aionrs/error.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/error.rs
@@ -1,4 +1,4 @@
-use aion_agent::engine::AgentError as AionrsAgentError;
+use aion_agent::error::AgentError as AionrsAgentError;
 use aion_providers::ProviderError;
 use aionui_api_types::{
     AgentErrorCode, AgentErrorOwnership, AgentErrorResolution, AgentErrorResolutionKind, AgentErrorResolutionTarget,

--- a/crates/aionui-office/src/watch_manager.rs
+++ b/crates/aionui-office/src/watch_manager.rs
@@ -15,6 +15,7 @@ use crate::types::DocType;
 
 const POLL_INTERVAL_MS: u64 = 100;
 const POLL_MAX_ATTEMPTS: u32 = 150;
+const START_PORT_MAX_ATTEMPTS: usize = 3;
 const STOP_DELAY_MS: u64 = 500;
 const VERSION_CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 
@@ -118,35 +119,58 @@ impl OfficecliWatchManager {
     }
 
     async fn try_start(&self, resolved: &str, doc_type: DocType) -> Result<u16, OfficeError> {
-        let port = allocate_port()?;
+        for attempt in 1..=START_PORT_MAX_ATTEMPTS {
+            let port = allocate_port()?;
+            match self.spawn_officecli_with_install(resolved, port, doc_type).await {
+                Ok(process) => {
+                    self.poll_port_ready(port, resolved).await?;
 
-        let spawn_result = self.spawner.spawn_officecli(resolved, port, doc_type).await;
+                    let key = session_key(resolved, doc_type);
+                    self.sessions.insert(
+                        key,
+                        WatchSession {
+                            port,
+                            process,
+                            file_path: resolved.to_owned(),
+                            doc_type,
+                            aborted: false,
+                        },
+                    );
 
-        let process = match spawn_result {
-            Ok(p) => p,
+                    return Ok(port);
+                }
+                Err(error) if is_port_in_use_start_failure(&error) && attempt < START_PORT_MAX_ATTEMPTS => {
+                    tracing::debug!(
+                        port,
+                        attempt,
+                        max_attempts = START_PORT_MAX_ATTEMPTS,
+                        "allocated preview port was already in use; retrying"
+                    );
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        Err(OfficeError::StartFailed(
+            "failed to allocate an available preview port".into(),
+        ))
+    }
+
+    async fn spawn_officecli_with_install(
+        &self,
+        resolved: &str,
+        port: u16,
+        doc_type: DocType,
+    ) -> Result<Box<dyn ProcessHandle>, OfficeError> {
+        match self.spawner.spawn_officecli(resolved, port, doc_type).await {
+            Ok(process) => Ok(process),
             Err(OfficeError::OfficecliNotFound) => {
                 self.broadcast_status(doc_type, PreviewState::Installing, None);
                 self.spawner.install_officecli().await?;
-                self.spawner.spawn_officecli(resolved, port, doc_type).await?
+                self.spawner.spawn_officecli(resolved, port, doc_type).await
             }
-            Err(e) => return Err(e),
-        };
-
-        self.poll_port_ready(port, resolved).await?;
-
-        let key = session_key(resolved, doc_type);
-        self.sessions.insert(
-            key,
-            WatchSession {
-                port,
-                process,
-                file_path: resolved.to_owned(),
-                doc_type,
-                aborted: false,
-            },
-        );
-
-        Ok(port)
+            Err(error) => Err(error),
+        }
     }
 
     async fn poll_port_ready(&self, port: u16, file_path: &str) -> Result<(), OfficeError> {
@@ -404,6 +428,18 @@ fn session_key(resolved_path: &str, doc_type: DocType) -> String {
     format!("{doc_type}:{resolved_path}")
 }
 
+fn is_port_in_use_start_failure(error: &OfficeError) -> bool {
+    matches!(error, OfficeError::StartFailed(message) if is_port_in_use_message(message))
+}
+
+fn is_port_in_use_message(message: &str) -> bool {
+    message.contains("Address already in use")
+        || message.contains("Only one usage of each socket address")
+        || message.contains("os error 98")
+        || message.contains("os error 48")
+        || message.contains("os error 10048")
+}
+
 fn normalize_officecli_version(raw: &str) -> String {
     raw.split_whitespace()
         .last()
@@ -476,6 +512,7 @@ mod tests {
         install_count: AtomicU32,
         update_count: AtomicU32,
         fail_spawn: AtomicBool,
+        fail_with_address_in_use_once: AtomicBool,
         start_listener: AtomicBool,
     }
 
@@ -487,6 +524,7 @@ mod tests {
                 install_count: AtomicU32::new(0),
                 update_count: AtomicU32::new(0),
                 fail_spawn: AtomicBool::new(false),
+                fail_with_address_in_use_once: AtomicBool::new(false),
                 start_listener: AtomicBool::new(true),
             }
         }
@@ -504,6 +542,10 @@ mod tests {
 
             if self.fail_spawn.load(Ordering::SeqCst) {
                 return Err(OfficeError::StartFailed("mock spawn failure".into()));
+            }
+
+            if self.fail_with_address_in_use_once.swap(false, Ordering::SeqCst) {
+                return Err(OfficeError::StartFailed("Address already in use (os error 98)".into()));
             }
 
             if !self.installed.load(Ordering::SeqCst) {
@@ -580,6 +622,25 @@ mod tests {
         assert_eq!(public_preview_error_message(&err), "officecli install failed");
     }
 
+    #[test]
+    fn port_in_use_start_failure_detects_platform_messages() {
+        for message in [
+            "Address already in use (os error 98)",
+            "Address already in use (os error 48)",
+            "Only one usage of each socket address (protocol/network address/port) is normally permitted. (os error 10048)",
+        ] {
+            assert!(is_port_in_use_start_failure(&OfficeError::StartFailed(message.into())));
+        }
+    }
+
+    #[test]
+    fn port_in_use_start_failure_ignores_other_errors() {
+        assert!(!is_port_in_use_start_failure(&OfficeError::StartFailed(
+            "mock spawn failure".into()
+        )));
+        assert!(!is_port_in_use_start_failure(&OfficeError::OfficecliNotFound));
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn officecli_capability_probe_requires_watch_command() {
@@ -629,6 +690,24 @@ mod tests {
 
         assert_eq!(p1, p2);
         assert_eq!(spawner.spawn_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn start_retries_when_allocated_port_is_taken() {
+        let spawner = Arc::new(MockSpawner::new());
+        spawner.fail_with_address_in_use_once.store(true, Ordering::SeqCst);
+        let broadcaster = Arc::new(RecordingBroadcaster::new());
+        let mgr = make_manager(Arc::clone(&spawner), Arc::clone(&broadcaster));
+
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("test.docx");
+        std::fs::write(&file, b"test").unwrap();
+
+        let port = mgr.start(file.to_str().unwrap(), DocType::Word).await.unwrap();
+
+        assert!(port > 0);
+        assert!(mgr.is_active_port(port, DocType::Word));
+        assert_eq!(spawner.spawn_count.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Update aionrs git dependencies to v0.1.31.
- Import `AgentError` from `aion_agent::error` after the aionrs error type moved out of `engine`.
- Clean up the AionRS guide prompt test initialization to satisfy clippy.

## Verification
- `just update-aionrs`
- `just push -u origin HEAD`
  - migration immutability check passed
  - `cargo fix` passed
  - workspace `clippy --fix -D warnings` passed
  - `cargo fmt --all` passed
  - `nextest run --workspace`: 6345 passed, 18 skipped