### PR TITLE
chore(agent): update aionrs to v0.1.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,8 +117,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.31"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
+version = "0.1.32"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.32#af39ce452c23067bf046899ae171dbf625adc944"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -147,8 +147,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.31"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
+version = "0.1.32"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.32#af39ce452c23067bf046899ae171dbf625adc944"
 dependencies = [
  "regex",
  "serde",
@@ -158,8 +158,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.31"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
+version = "0.1.32"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.32#af39ce452c23067bf046899ae171dbf625adc944"
 dependencies = [
  "aion-compact",
  "aion-types",
@@ -182,8 +182,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.31"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
+version = "0.1.32"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.32#af39ce452c23067bf046899ae171dbf625adc944"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -203,8 +203,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.31"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
+version = "0.1.32"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.32#af39ce452c23067bf046899ae171dbf625adc944"
 dependencies = [
  "aion-config",
  "chrono",
@@ -216,9 +216,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "aion-process"
+version = "0.1.32"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.32#af39ce452c23067bf046899ae171dbf625adc944"
+dependencies = [
+ "libc",
+ "tokio",
+ "windows-sys 0.61.2",
+ "workspace-hack",
+]
+
+[[package]]
 name = "aion-protocol"
-version = "0.1.31"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
+version = "0.1.32"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.32#af39ce452c23067bf046899ae171dbf625adc944"
 dependencies = [
  "aion-types",
  "serde",
@@ -230,8 +241,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.31"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
+version = "0.1.32"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.32#af39ce452c23067bf046899ae171dbf625adc944"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -258,8 +269,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.31"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
+version = "0.1.32"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.32#af39ce452c23067bf046899ae171dbf625adc944"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -284,10 +295,11 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.31"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
+version = "0.1.32"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.32#af39ce452c23067bf046899ae171dbf625adc944"
 dependencies = [
  "aion-config",
+ "aion-process",
  "aion-protocol",
  "aion-types",
  "anyhow",
@@ -304,8 +316,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.31"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
+version = "0.1.32"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.32#af39ce452c23067bf046899ae171dbf625adc944"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6484,7 +6496,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.31#cd519955545cd2669c0877d979c2c1aad2e446c1"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.32#af39ce452c23067bf046899ae171dbf625adc944"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,12 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.31" }
-aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.31" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.31" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.31" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.31" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.31" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.32" }
+aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.32" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.32" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.32" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.32" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.32" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## Summary
- Update AionCore's aionrs git dependencies from `v0.1.31` to `v0.1.32`.
- Refresh `Cargo.lock` for the new aionrs tag `af39ce452c23067bf046899ae171dbf625adc944`.
- Pick up the new transitive `aion-process` dependency used by `aion-tools` in aionrs `v0.1.32`.

## Test Plan
- `just update-aionrs v0.1.32`
- `just push -u origin HEAD`

## Local Verification
- `cargo check --workspace` completed inside `just update-aionrs v0.1.32`.
- `just push -u origin HEAD` completed migration check, cargo fix, clippy fix, fmt, and `cargo nextest run --workspace`.
- Local nextest summary: `6348 tests run: 6348 passed (2 slow), 18 skipped`.