### PR TITLE
fix: load skills in custom workspaces

### DIFF
--- a/crates/aionui-ai-agent/src/capability/first_message_injector.rs
+++ b/crates/aionui-ai-agent/src/capability/first_message_injector.rs
@@ -17,18 +17,15 @@ pub struct InjectionConfig<'a> {
     pub skills: &'a [String],
     /// True iff the agent's native CLI reads skills from the workspace
     /// without needing prompt injection. Derived by callers from
-    /// `AcpBackend::native_skills_dirs().is_some()` for ACP, or hardcoded
-    /// `false` for aionrs / custom workspace scenarios.
+    /// `AcpBackend::native_skills_dirs().is_some()` for ACP.
     pub native_skill_support: bool,
-    /// True iff the user chose a custom workspace (symlinks may not exist).
-    pub custom_workspace: bool,
 }
 
 /// Produce the content string to send as the first ACP prompt.
 ///
-/// - If `native_skill_support && !custom_workspace`: **light mode** — only
-///   `preset_context` prepended as an `[Assistant Rules]` block (if present).
-///   The native CLI handles skill discovery via workspace symlinks.
+/// - If `native_skill_support`: **light mode** — only `preset_context`
+///   prepended as an `[Assistant Rules]` block (if present). The native CLI
+///   handles skill discovery via workspace links.
 /// - Else: **heavy mode** — `preset_context` + resolved skills index
 ///   injected via `prepare_first_message_with_skills_index`.
 pub async fn inject_first_message_prefix(
@@ -36,9 +33,7 @@ pub async fn inject_first_message_prefix(
     manager: &Arc<AcpSkillManager>,
     config: InjectionConfig<'_>,
 ) -> String {
-    let use_native = config.native_skill_support && !config.custom_workspace;
-
-    if use_native {
+    if config.native_skill_support {
         return match config.preset_context {
             Some(ctx) if !ctx.is_empty() => {
                 format!("[Assistant Rules]\n{ctx}\n[/Assistant Rules]\n\n{content}")
@@ -97,7 +92,6 @@ mod tests {
                 preset_context: Some("Be concise."),
                 skills: &[],
                 native_skill_support: true,
-                custom_workspace: false,
             },
         )
         .await;
@@ -119,7 +113,6 @@ mod tests {
                 preset_context: None,
                 skills: &[],
                 native_skill_support: true,
-                custom_workspace: false,
             },
         )
         .await;
@@ -139,7 +132,6 @@ mod tests {
                 preset_context: None,
                 skills: &[],
                 native_skill_support: false,
-                custom_workspace: false,
             },
         )
         .await;
@@ -159,7 +151,6 @@ mod tests {
                 preset_context: Some("Rule 1."),
                 skills: &[],
                 native_skill_support: false,
-                custom_workspace: false,
             },
         )
         .await;
@@ -196,7 +187,6 @@ mod tests {
                 preset_context: None,
                 skills: &["cron".to_owned()],
                 native_skill_support: false,
-                custom_workspace: false,
             },
         )
         .await;
@@ -206,7 +196,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn custom_workspace_forces_heavy_even_when_native_supported() {
+    async fn native_support_uses_light_mode_even_with_skills() {
         let tmp = TempDir::new().unwrap();
         let _guard = EmptyBuiltinGuard::new(tmp.path());
         let mgr = test_mgr(tmp.path());
@@ -216,14 +206,15 @@ mod tests {
             &mgr,
             InjectionConfig {
                 preset_context: Some("Custom rule"),
-                skills: &[],
+                skills: &["cron".to_owned()],
                 native_skill_support: true,
-                custom_workspace: true, // <-- overrides native
             },
         )
         .await;
 
         assert!(out.contains("[Assistant Rules]"));
         assert!(out.contains("Custom rule"));
+        assert!(!out.contains("Available Skills"));
+        assert!(out.ends_with("Do stuff"));
     }
 }

--- a/crates/aionui-ai-agent/src/manager/acp/hooks.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/hooks.rs
@@ -24,7 +24,6 @@ impl PreSendHook for SessionNewPreludeHook {
         let config = InjectionConfig {
             preset_context: ctx.params.preset_context.as_deref(),
             skills: &ctx.params.config.skills,
-            custom_workspace: ctx.params.workspace.is_custom,
             native_skill_support: metadata
                 .native_skills_dirs
                 .as_ref()

--- a/crates/aionui-conversation/src/response_middleware.rs
+++ b/crates/aionui-conversation/src/response_middleware.rs
@@ -4,6 +4,8 @@ use async_trait::async_trait;
 use regex::Regex;
 use tracing::{debug, warn};
 
+use crate::skill_resolver::LoadedAgentSkill;
+
 // ---------------------------------------------------------------------------
 // Think-tag cleaning
 // ---------------------------------------------------------------------------
@@ -38,6 +40,10 @@ static CRON_LIST_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\[CRON_LIST
 /// Regex for `[CRON_DELETE: <id>]`.
 static CRON_DELETE_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\[CRON_DELETE:\s*([^\]]+)\]").expect("valid cron-delete regex"));
+
+/// Regex for `[LOAD_SKILL: <name>]` requests emitted by prompt-protocol agents.
+static LOAD_SKILL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)\[LOAD_SKILL:\s*([^\]]+)\]").expect("valid load-skill regex"));
 
 /// A parsed cron command extracted from agent text.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -118,6 +124,24 @@ pub fn strip_cron_commands(text: &str) -> String {
     let result = CRON_LIST_RE.replace_all(&result, "");
     let result = CRON_DELETE_RE.replace_all(&result, "");
     result.into_owned()
+}
+
+pub fn detect_skill_load_requests(text: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    for cap in LOAD_SKILL_RE.captures_iter(text) {
+        let Some(name) = cap.get(1).map(|m| m.as_str().trim()) else {
+            continue;
+        };
+        if name.is_empty() || names.iter().any(|existing| existing == name) {
+            continue;
+        }
+        names.push(name.to_owned());
+    }
+    names
+}
+
+pub fn has_skill_load_requests(text: &str) -> bool {
+    LOAD_SKILL_RE.is_match(text)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -220,6 +244,11 @@ pub trait ICronService: Send + Sync {
     async fn delete_job(&self, user_id: &str, job_id: &str) -> CronCommandResult;
 }
 
+#[async_trait]
+pub trait ISkillLoadService: Send + Sync {
+    async fn load_skill_bodies(&self, names: &[String]) -> Vec<LoadedAgentSkill>;
+}
+
 // ---------------------------------------------------------------------------
 // MessageMiddleware
 // ---------------------------------------------------------------------------
@@ -243,6 +272,7 @@ pub struct MiddlewareResult {
 /// 3. Return cleaned message + any system responses
 pub struct MessageMiddleware {
     cron_service: Option<Box<dyn ICronService>>,
+    skill_loader: Option<Box<dyn ISkillLoadService>>,
 }
 
 impl MessageMiddleware {
@@ -251,7 +281,20 @@ impl MessageMiddleware {
     /// When `cron_service` is `None`, cron commands are still detected and
     /// stripped, but not executed (system responses will indicate unavailability).
     pub fn new(cron_service: Option<Box<dyn ICronService>>) -> Self {
-        Self { cron_service }
+        Self {
+            cron_service,
+            skill_loader: None,
+        }
+    }
+
+    pub fn new_with_skill_loader(
+        cron_service: Option<Box<dyn ICronService>>,
+        skill_loader: Option<Box<dyn ISkillLoadService>>,
+    ) -> Self {
+        Self {
+            cron_service,
+            skill_loader,
+        }
     }
 
     /// Process a completed agent message through the middleware pipeline.
@@ -259,8 +302,9 @@ impl MessageMiddleware {
         // Step 1: Strip think tags
         let cleaned = strip_think_tags(message);
 
-        // Step 2: Detect cron commands
-        if !has_cron_commands(&cleaned) {
+        let has_cron = has_cron_commands(&cleaned);
+        let has_skill_load = has_skill_load_requests(&cleaned);
+        if !has_cron && !has_skill_load {
             return MiddlewareResult {
                 message: cleaned,
                 display_message: None,
@@ -269,16 +313,50 @@ impl MessageMiddleware {
         }
 
         let commands = detect_cron_commands(&cleaned);
-        let display_message = strip_cron_commands(&cleaned);
+        let skill_names = detect_skill_load_requests(&cleaned);
+        let display_message = if has_cron {
+            strip_cron_commands(&cleaned)
+        } else {
+            cleaned.clone()
+        };
 
-        // Step 3: Execute cron commands
-        let system_responses = self.execute_cron_commands(user_id, conversation_id, &commands).await;
+        let mut system_responses = if commands.is_empty() {
+            Vec::new()
+        } else {
+            self.execute_cron_commands(user_id, conversation_id, &commands).await
+        };
+        system_responses.extend(self.load_requested_skills(&skill_names).await);
 
         MiddlewareResult {
             message: display_message.clone(),
-            display_message: Some(display_message),
+            display_message: has_cron.then_some(display_message),
             system_responses,
         }
+    }
+
+    async fn load_requested_skills(&self, names: &[String]) -> Vec<String> {
+        if names.is_empty() {
+            return Vec::new();
+        }
+
+        let Some(skill_loader) = &self.skill_loader else {
+            debug!(
+                count = names.len(),
+                "Skill load requests detected but no skill loader configured"
+            );
+            return Vec::new();
+        };
+
+        let loaded = skill_loader.load_skill_bodies(names).await;
+        if loaded.is_empty() {
+            return Vec::new();
+        }
+
+        let mut responses = Vec::new();
+        for skill in loaded {
+            responses.push(format!("[Skill: {}]\n{}", skill.name, skill.body));
+        }
+        responses
     }
 
     /// Execute a list of cron commands via the injected service.
@@ -475,6 +553,12 @@ mod tests {
         assert!(!has_cron_commands("[CRON_SOMETHING_ELSE]"));
     }
 
+    #[test]
+    fn detect_skill_load_requests_is_case_insensitive_and_dedupes() {
+        let requests = detect_skill_load_requests("[load_skill: cron] [LOAD_SKILL: cron] [LOAD_SKILL: pdf]");
+        assert_eq!(requests, vec!["cron", "pdf"]);
+    }
+
     // -----------------------------------------------------------------------
     // strip_cron_commands
     // -----------------------------------------------------------------------
@@ -603,6 +687,22 @@ mod tests {
         }
     }
 
+    struct MockSkillLoader;
+
+    #[async_trait]
+    impl ISkillLoadService for MockSkillLoader {
+        async fn load_skill_bodies(&self, names: &[String]) -> Vec<LoadedAgentSkill> {
+            names
+                .iter()
+                .filter(|name| name.as_str() == "cron")
+                .map(|name| LoadedAgentSkill {
+                    name: name.clone(),
+                    body: "Cron skill body".into(),
+                })
+                .collect()
+        }
+    }
+
     #[tokio::test]
     async fn middleware_strips_think_tags() {
         let mw = MessageMiddleware::new(None);
@@ -623,6 +723,19 @@ mod tests {
         assert!(result.display_message.is_some());
         assert_eq!(result.system_responses.len(), 1);
         assert!(result.system_responses[0].contains("Created cron job"));
+    }
+
+    #[tokio::test]
+    async fn middleware_loads_requested_skill_as_system_response() {
+        let mw = MessageMiddleware::new_with_skill_loader(None, Some(Box::new(MockSkillLoader)));
+        let input = "I'll use [LOAD_SKILL: cron] for this.";
+
+        let result = mw.process(input, "user1", "conv1").await;
+
+        assert_eq!(result.message, input);
+        assert!(result.display_message.is_none());
+        assert_eq!(result.system_responses.len(), 1);
+        assert_eq!(result.system_responses[0], "[Skill: cron]\nCron skill body");
     }
 
     #[tokio::test]

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -568,9 +568,8 @@ impl ConversationService {
 
         // Determine whether the user chose this workspace ("custom") or we
         // auto-provision one under `{data_dir}/conversations/{label}-temp-{id}/`.
-        // `is_custom_workspace` is the authoritative signal consumed later to
-        // decide whether we should wire skill symlinks (temp workspaces only
-        // — user-chosen paths must not be mutated).
+        // Skill wiring runs for both kinds so native CLI discovery behaves
+        // consistently.
         let user_supplied_workspace = match extra
             .get("workspace")
             .and_then(|v| v.as_str())
@@ -579,7 +578,6 @@ impl ConversationService {
             Some(workspace) => Some(normalize_workspace_path(workspace)?),
             None => None,
         };
-        let is_custom_workspace = user_supplied_workspace.is_some();
         if let Some(workspace) = user_supplied_workspace.as_ref() {
             extra["workspace"] = serde_json::Value::String(workspace.clone());
         }
@@ -710,12 +708,14 @@ impl ConversationService {
         let auto_inject_names = self.skill_resolver.auto_inject_names().await;
         let initial_skills = compute_initial_skills(&auto_inject_names, &preset_enabled, &exclude_auto_inject);
 
-        // Wire skill symlinks into the auto-provisioned workspace so the
-        // agent CLI picks them up via its native skills dir (e.g.
-        // `.claude/skills/`). Runs only for temp workspaces — a user-chosen
-        // path must not be mutated.
-        if let Some(ws_path) = auto_provisioned_workspace.as_ref()
-            && !is_custom_workspace
+        // Wire skill links into the runtime workspace so the agent CLI picks
+        // them up via its native skills dir (e.g. `.claude/skills/`). This
+        // applies to both temp and user-selected workspaces.
+        let skill_link_workspace = user_supplied_workspace
+            .as_ref()
+            .map(PathBuf::from)
+            .or_else(|| auto_provisioned_workspace.clone());
+        if let Some(ws_path) = skill_link_workspace.as_ref()
             && !initial_skills.is_empty()
             && let Some(rel_dirs) =
                 native_skills_dirs(&self.agent_metadata_repo, &req.r#type, extra.get("backend")).await
@@ -2265,7 +2265,7 @@ impl ConversationService {
                 return Ok(self.send_message_response(conversation_id, user_msg_id, turn_id).await);
             }
         };
-        self.ensure_auto_workspace_skill_links(&row, &build_opts).await;
+        self.ensure_workspace_skill_links(&row, &build_opts).await;
         let stored_workspace = build_opts.context.workspace.stored_path.clone();
 
         let user_msg_id_ret = user_msg_id.clone();
@@ -2351,7 +2351,7 @@ impl ConversationService {
             }
         };
 
-        self.ensure_auto_workspace_skill_links(&row, &build_opts).await;
+        self.ensure_workspace_skill_links(&row, &build_opts).await;
         let stored_workspace = build_opts.context.workspace.stored_path.clone();
         let conversation_id = request.conversation_id.clone();
         let result = ConversationTurnOrchestrator::new(self.clone(), self.task_manager.clone())
@@ -2544,7 +2544,7 @@ impl ConversationService {
         reject_deprecated_runtime_row(&row)?;
 
         let build_opts = self.build_task_options(&row).await?;
-        self.ensure_auto_workspace_skill_links(&row, &build_opts).await;
+        self.ensure_workspace_skill_links(&row, &build_opts).await;
         let stored_workspace = build_opts.context.workspace.stored_path.clone();
         let backend = build_options_backend(&build_opts).map(str::to_owned);
         let agent = match task_manager.get_or_build_task(conversation_id, build_opts).await {
@@ -2626,22 +2626,25 @@ impl ConversationService {
             .await
     }
 
-    pub(crate) async fn ensure_auto_workspace_skill_links(&self, row: &ConversationRow, build_opts: &BuildTaskOptions) {
+    /// Ensure native skill links exist in the runtime workspace. Auto
+    /// workspaces are constrained to AionUi's generated path; custom
+    /// workspaces were validated when the session context was built.
+    pub(crate) async fn ensure_workspace_skill_links(&self, row: &ConversationRow, build_opts: &BuildTaskOptions) {
         let context = &build_opts.context;
-        if context.workspace.is_custom {
-            return;
-        }
         let backend = context_backend_value(context);
-        let expected_workspace = expected_auto_workspace_path(
-            &self.workspace_root,
-            &row.id,
-            &context.conversation.agent_type,
-            backend.as_ref(),
-        );
 
         let workspace = PathBuf::from(context.workspace.path.trim());
-        if workspace != expected_workspace {
-            return;
+        if !context.workspace.is_custom {
+            let expected_workspace = expected_auto_workspace_path(
+                &self.workspace_root,
+                &row.id,
+                &context.conversation.agent_type,
+                backend.as_ref(),
+            );
+
+            if workspace != expected_workspace {
+                return;
+            }
         }
 
         let skill_names = context_skill_names(context);
@@ -2751,6 +2754,10 @@ impl ConversationService {
             Ok(guard) => guard.as_ref().map(Arc::clone),
             Err(_) => None,
         }
+    }
+
+    pub(crate) fn skill_resolver(&self) -> Arc<dyn SkillResolver> {
+        Arc::clone(&self.skill_resolver)
     }
 
     /// Backfill `extra.skills` if the row predates the snapshot model.

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -583,6 +583,77 @@ impl IAgentMetadataRepository for StubAgentMetadataRepo {
     }
 }
 
+/// Metadata repo used by custom-workspace skill-link tests. It models the
+/// builtin Claude ACP row whose native skill directory is `.claude/skills`.
+struct ClaudeNativeSkillMetadataRepo;
+
+fn claude_metadata_row() -> AgentMetadataRow {
+    AgentMetadataRow {
+        id: "agent-claude".into(),
+        icon: None,
+        name: "Claude Code".into(),
+        name_i18n: None,
+        description: None,
+        description_i18n: None,
+        backend: Some("claude".into()),
+        agent_type: "acp".into(),
+        agent_source: "builtin".into(),
+        agent_source_info: Some("{}".into()),
+        enabled: true,
+        command: Some("claude".into()),
+        args: Some("[]".into()),
+        env: Some("[]".into()),
+        native_skills_dirs: Some(r#"[".claude/skills"]"#.into()),
+        behavior_policy: Some("{}".into()),
+        yolo_id: Some("bypassPermissions".into()),
+        agent_capabilities: None,
+        auth_methods: None,
+        config_options: None,
+        available_modes: None,
+        available_models: None,
+        available_commands: None,
+        sort_order: 0,
+        created_at: 1,
+        updated_at: 1,
+    }
+}
+
+#[async_trait::async_trait]
+impl IAgentMetadataRepository for ClaudeNativeSkillMetadataRepo {
+    async fn list_all(&self) -> Result<Vec<AgentMetadataRow>, DbError> {
+        Ok(vec![claude_metadata_row()])
+    }
+    async fn get(&self, id: &str) -> Result<Option<AgentMetadataRow>, DbError> {
+        Ok((id == "agent-claude").then(claude_metadata_row))
+    }
+    async fn find_by_source_and_name(
+        &self,
+        agent_source: &str,
+        name: &str,
+    ) -> Result<Option<AgentMetadataRow>, DbError> {
+        Ok((agent_source == "builtin" && name == "Claude Code").then(claude_metadata_row))
+    }
+    async fn find_builtin_by_backend(&self, backend: &str) -> Result<Option<AgentMetadataRow>, DbError> {
+        Ok((backend == "claude").then(claude_metadata_row))
+    }
+    async fn upsert(&self, _params: &UpsertAgentMetadataParams<'_>) -> Result<AgentMetadataRow, DbError> {
+        Err(DbError::Init("stub".into()))
+    }
+    async fn apply_handshake(
+        &self,
+        _id: &str,
+        _params: &UpdateAgentHandshakeParams<'_>,
+    ) -> Result<Option<AgentMetadataRow>, DbError> {
+        Ok(None)
+    }
+    async fn set_enabled(&self, _id: &str, _enabled: bool) -> Result<bool, DbError> {
+        Ok(false)
+    }
+    async fn delete(&self, _id: &str) -> Result<bool, DbError> {
+        Ok(false)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RuntimeStateSaveCall {
     conversation_id: String,
@@ -690,6 +761,30 @@ fn make_service_with_resolver_and_acp_session_repo(
     (svc, broadcaster, repo, task_mgr)
 }
 
+fn make_service_with_resolver_and_agent_metadata_repo(
+    skill_resolver: Arc<dyn crate::skill_resolver::SkillResolver>,
+    agent_metadata_repo: Arc<dyn IAgentMetadataRepository>,
+) -> (
+    ConversationService,
+    Arc<MockBroadcaster>,
+    Arc<MockRepo>,
+    Arc<dyn IWorkerTaskManager>,
+) {
+    let repo = Arc::new(MockRepo::new());
+    let broadcaster = Arc::new(MockBroadcaster::new());
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(MockTaskManager::new());
+    let svc = ConversationService::new(
+        std::env::temp_dir(),
+        broadcaster.clone(),
+        skill_resolver,
+        task_mgr.clone(),
+        repo.clone(),
+        agent_metadata_repo,
+        Arc::new(StubAcpSessionRepo::default()),
+    );
+    (svc, broadcaster, repo, task_mgr)
+}
+
 fn make_service_with_mock_task_manager(
     task_mgr: Arc<MockTaskManager>,
 ) -> (ConversationService, Arc<MockBroadcaster>, Arc<MockRepo>) {
@@ -785,6 +880,14 @@ fn ensure_test_workspace_path() -> String {
     let workspace = std::env::temp_dir().join("aionui-conversation-service-test-project");
     std::fs::create_dir_all(&workspace).unwrap();
     workspace.to_string_lossy().to_string()
+}
+
+fn unique_test_workspace_path(label: &str) -> PathBuf {
+    let workspace = std::env::temp_dir()
+        .join(format!("aionui-conversation-service-test-{label}"))
+        .join(ConversationService::mint_msg_id());
+    std::fs::create_dir_all(&workspace).unwrap();
+    workspace
 }
 
 async fn upsert_test_assistant_definition(
@@ -4665,6 +4768,33 @@ async fn create_writes_empty_skills_when_no_auto_inject_and_no_preset() {
 }
 
 #[tokio::test]
+async fn create_links_skills_into_custom_workspace_for_native_acp_agent() {
+    let resolver = Arc::new(RecordingSkillResolver::new(vec!["cron".into()]));
+    let links = resolver.links.clone();
+    let (svc, _broadcaster, _repo, _task_mgr) =
+        make_service_with_resolver_and_agent_metadata_repo(resolver, Arc::new(ClaudeNativeSkillMetadataRepo));
+    let workspace = unique_test_workspace_path("custom-create");
+
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "extra": {
+            "workspace": workspace,
+            "backend": "claude"
+        },
+    }))
+    .unwrap();
+    let resp = svc.create("user-1", req).await.unwrap();
+
+    assert_eq!(resp.extra["skills"], json!(["cron"]));
+    assert!(workspace.join(".claude/skills/cron").is_dir());
+    let calls = links.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].workspace, workspace);
+    assert_eq!(calls[0].rel_dirs, vec![".claude/skills"]);
+    assert_eq!(calls[0].skill_names, vec!["cron"]);
+}
+
+#[tokio::test]
 async fn warmup_restores_skill_links_for_recreated_auto_workspace() {
     let resolver = Arc::new(RecordingSkillResolver::new(vec!["cron".into()]));
     let links = resolver.links.clone();
@@ -4692,6 +4822,40 @@ async fn warmup_restores_skill_links_for_recreated_auto_workspace() {
     assert_eq!(calls.len(), 1);
     assert_eq!(calls[0].workspace, workspace);
     assert_eq!(calls[0].rel_dirs, vec![".aionrs/skills"]);
+    assert_eq!(calls[0].skill_names, vec!["cron"]);
+}
+
+#[tokio::test]
+async fn warmup_restores_skill_links_for_custom_workspace() {
+    let resolver = Arc::new(RecordingSkillResolver::new(vec!["cron".into()]));
+    let links = resolver.links.clone();
+    let (svc, _broadcaster, _repo, _task_mgr) =
+        make_service_with_resolver_and_agent_metadata_repo(resolver, Arc::new(ClaudeNativeSkillMetadataRepo));
+    let workspace = unique_test_workspace_path("custom-warmup");
+
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "extra": {
+            "workspace": workspace,
+            "backend": "claude"
+        },
+    }))
+    .unwrap();
+    let resp = svc.create("user-1", req).await.unwrap();
+
+    std::fs::remove_dir_all(workspace.join(".claude")).unwrap();
+    assert!(!workspace.join(".claude/skills/cron").exists());
+    links.lock().unwrap().clear();
+
+    let task_mgr: Arc<dyn IWorkerTaskManager> =
+        Arc::new(MockTaskManagerWithWorkspace::new(workspace.to_str().unwrap()));
+    svc.warmup("user-1", &resp.id, &task_mgr).await.unwrap();
+
+    assert!(workspace.join(".claude/skills/cron").is_dir());
+    let calls = links.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].workspace, workspace);
+    assert_eq!(calls[0].rel_dirs, vec![".claude/skills"]);
     assert_eq!(calls[0].skill_names, vec!["cron"]);
 }
 

--- a/crates/aionui-conversation/src/skill_resolver.rs
+++ b/crates/aionui-conversation/src/skill_resolver.rs
@@ -7,6 +7,13 @@ use std::sync::Arc;
 
 pub use aionui_extension::ResolvedAgentSkill;
 use async_trait::async_trait;
+use tracing::warn;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadedAgentSkill {
+    pub name: String,
+    pub body: String,
+}
 
 #[async_trait]
 pub trait SkillResolver: Send + Sync {
@@ -17,6 +24,13 @@ pub trait SkillResolver: Send + Sync {
     /// Resolve each skill name to its on-disk source directory, using the
     /// same search order as `materialize_skills_for_agent`.
     async fn resolve_skills(&self, names: &[String]) -> Vec<ResolvedAgentSkill>;
+
+    /// Load full skill bodies for prompt-protocol agents that request
+    /// `[LOAD_SKILL: name]` in their response.
+    async fn load_skill_bodies(&self, names: &[String]) -> Vec<LoadedAgentSkill> {
+        let resolved = self.resolve_skills(names).await;
+        load_resolved_skill_bodies(&resolved).await
+    }
 
     /// Create symlinks pointing at each resolved skill inside the given
     /// workspace's per-backend native skills directories. `rel_dirs` is
@@ -33,6 +47,54 @@ pub struct ExtensionSkillResolver {
 impl ExtensionSkillResolver {
     pub fn new(paths: Arc<aionui_extension::SkillPaths>) -> Self {
         Self { paths }
+    }
+}
+
+async fn load_resolved_skill_bodies(skills: &[ResolvedAgentSkill]) -> Vec<LoadedAgentSkill> {
+    let mut loaded = Vec::new();
+    for skill in skills {
+        let skill_file = skill.source_path.join("SKILL.md");
+        match tokio::fs::read_to_string(&skill_file).await {
+            Ok(content) => loaded.push(LoadedAgentSkill {
+                name: skill.name.clone(),
+                body: extract_skill_body(&content),
+            }),
+            Err(e) => {
+                warn!(
+                    skill = %skill.name,
+                    path = %skill_file.display(),
+                    error = %e,
+                    "Failed to read requested skill body"
+                );
+            }
+        }
+    }
+    loaded
+}
+
+fn extract_skill_body(content: &str) -> String {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return content.to_string();
+    }
+
+    let after_open = &trimmed[3..];
+    if let Some(close_idx) = after_open.find("---") {
+        let after_close = &after_open[close_idx + 3..];
+        after_close.trim_start_matches('\n').to_string()
+    } else {
+        content.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_skill_body_removes_frontmatter() {
+        let content = "---\nname: cron\ndescription: Cron\n---\nCron body";
+        assert_eq!(extract_skill_body(content), "Cron body");
     }
 }
 

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use aionui_ai_agent::protocol::events::TipType;
 use aionui_ai_agent::{AgentSendError, AgentStreamEvent, protocol::events::ThinkingEventData};
 
-use crate::response_middleware::{ICronService, MessageMiddleware, MiddlewareResult};
+use crate::response_middleware::{ICronService, ISkillLoadService, MessageMiddleware, MiddlewareResult};
+use crate::skill_resolver::{LoadedAgentSkill, SkillResolver};
 use aionui_api_types::{AgentErrorCode, WebSocketMessage};
 use aionui_common::{ErrorChain, normalize_keys_to_snake_case, now_ms};
 
@@ -71,6 +72,8 @@ pub struct StreamRelay {
     user_id: String,
     broadcaster: Arc<dyn EventBroadcaster>,
     cron_service: Option<Arc<dyn ICronService>>,
+    skill_resolver: Option<Arc<dyn SkillResolver>>,
+    allowed_skill_names: Vec<String>,
     runtime_state: Option<Arc<ConversationRuntimeStateService>>,
     persistence: Option<RuntimePersistenceCoordinator>,
     adapter: StreamPersistenceAdapter,
@@ -95,6 +98,8 @@ impl StreamRelay {
             user_id,
             broadcaster,
             cron_service,
+            skill_resolver: None,
+            allowed_skill_names: Vec::new(),
             runtime_state: None,
             persistence: None,
             adapter,
@@ -104,6 +109,16 @@ impl StreamRelay {
 
     pub fn with_runtime_state(mut self, runtime_state: Arc<ConversationRuntimeStateService>) -> Self {
         self.runtime_state = Some(runtime_state);
+        self
+    }
+
+    pub fn with_skill_resolver(mut self, skill_resolver: Arc<dyn SkillResolver>) -> Self {
+        self.skill_resolver = Some(skill_resolver);
+        self
+    }
+
+    pub fn with_allowed_skill_names(mut self, skill_names: Vec<String>) -> Self {
+        self.allowed_skill_names = skill_names;
         self
     }
 
@@ -571,10 +586,16 @@ impl StreamRelay {
     }
 
     async fn process_final_text(&self, text: &str) -> MiddlewareResult {
-        let middleware = MessageMiddleware::new(
+        let middleware = MessageMiddleware::new_with_skill_loader(
             self.cron_service
                 .as_ref()
                 .map(|service| Box::new(SharedCronService(Arc::clone(service))) as Box<dyn ICronService>),
+            self.skill_resolver.as_ref().map(|resolver| {
+                Box::new(SharedSkillResolver {
+                    resolver: Arc::clone(resolver),
+                    allowed_skill_names: self.allowed_skill_names.clone(),
+                }) as Box<dyn ISkillLoadService>
+            }),
         );
 
         middleware.process(text, &self.user_id, &self.conversation_id).await
@@ -646,6 +667,26 @@ impl ICronService for SharedCronService {
     }
 }
 
+struct SharedSkillResolver {
+    resolver: Arc<dyn SkillResolver>,
+    allowed_skill_names: Vec<String>,
+}
+
+#[async_trait::async_trait]
+impl ISkillLoadService for SharedSkillResolver {
+    async fn load_skill_bodies(&self, names: &[String]) -> Vec<LoadedAgentSkill> {
+        if self.allowed_skill_names.is_empty() {
+            return Vec::new();
+        }
+        let filtered: Vec<String> = names
+            .iter()
+            .filter(|name| self.allowed_skill_names.iter().any(|allowed| allowed == *name))
+            .cloned()
+            .collect();
+        self.resolver.load_skill_bodies(&filtered).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -658,6 +699,58 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
 
     // ── run() async tests ─────────────────────────────────────────
+
+    #[derive(Default)]
+    struct RecordingSkillResolverForRelay {
+        requested: Mutex<Vec<String>>,
+    }
+
+    #[async_trait::async_trait]
+    impl SkillResolver for RecordingSkillResolverForRelay {
+        async fn auto_inject_names(&self) -> Vec<String> {
+            Vec::new()
+        }
+
+        async fn resolve_skills(&self, _names: &[String]) -> Vec<aionui_extension::ResolvedAgentSkill> {
+            Vec::new()
+        }
+
+        async fn load_skill_bodies(&self, names: &[String]) -> Vec<LoadedAgentSkill> {
+            self.requested.lock().unwrap().extend(names.iter().cloned());
+            names
+                .iter()
+                .map(|name| LoadedAgentSkill {
+                    name: name.clone(),
+                    body: format!("{name} body"),
+                })
+                .collect()
+        }
+
+        async fn link_workspace_skills(
+            &self,
+            _workspace: &std::path::Path,
+            _rel_dirs: &[&str],
+            _skills: &[aionui_extension::ResolvedAgentSkill],
+        ) -> usize {
+            0
+        }
+    }
+
+    #[tokio::test]
+    async fn shared_skill_resolver_filters_requests_to_allowed_skill_names() {
+        let concrete = Arc::new(RecordingSkillResolverForRelay::default());
+        let resolver: Arc<dyn SkillResolver> = concrete.clone();
+        let loader = SharedSkillResolver {
+            resolver,
+            allowed_skill_names: vec!["cron".into()],
+        };
+
+        let loaded = loader.load_skill_bodies(&["cron".to_owned(), "pdf".to_owned()]).await;
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].name, "cron");
+        assert_eq!(concrete.requested.lock().unwrap().as_slice(), ["cron"]);
+    }
 
     #[tokio::test]
     async fn run_text_then_finish_persists_message() {

--- a/crates/aionui-conversation/src/turn_orchestrator.rs
+++ b/crates/aionui-conversation/src/turn_orchestrator.rs
@@ -66,6 +66,7 @@ impl ConversationTurnOrchestrator {
         let build_started_at = now_ms();
         let persistence = self.service.runtime_persistence();
         let runtime_state = self.service.runtime_state();
+        let allowed_skill_names = input.build_options.context.skills.clone();
         let mut turn_failed = false;
 
         info!(conversation_id = %conv_id, turn_id = %turn_id, "conversation turn orchestrator started");
@@ -170,6 +171,8 @@ impl ConversationTurnOrchestrator {
                 self.service.broadcaster().clone(),
                 self.service.current_cron_service(),
             )
+            .with_skill_resolver(self.service.skill_resolver())
+            .with_allowed_skill_names(allowed_skill_names.clone())
             .with_runtime_state(Arc::clone(&runtime_state))
             .with_persistence(persistence.clone())
             .with_turn_completion(false);

--- a/crates/aionui-extension/src/skill_service.rs
+++ b/crates/aionui-extension/src/skill_service.rs
@@ -723,9 +723,12 @@ pub async fn materialize_skills_for_agent(
 /// native skills directories inside `workspace`.
 ///
 /// For each relative `skills_rel_dir` (e.g. `.claude/skills`):
-/// 1. Ensure `{workspace}/{skills_rel_dir}/` exists.
+/// 1. Resolve the target directory. Existing `{workspace}/{skills_rel_dir}/`
+///    wins; if the requested leaf is `skills` and sibling `skill` already
+///    exists, reuse that singular directory; otherwise create the requested
+///    directory.
 /// 2. For each `{ name, source_path }` in `skills`, create a symlink
-///    `{workspace}/{skills_rel_dir}/{name} -> {source_path}`.
+///    `{target_skills_dir}/{name} -> {source_path}`.
 ///
 /// Existing symlinks/files at the target name are left untouched
 /// (first-write-wins, matches the frontend's lstat-then-skip behavior
@@ -741,7 +744,7 @@ pub async fn link_workspace_skills(
 ) -> Result<usize, ExtensionError> {
     let mut created = 0usize;
     for rel in skills_rel_dirs {
-        let target_skills_dir = workspace.join(rel);
+        let target_skills_dir = resolve_workspace_skills_dir(workspace, rel).await;
         tokio::fs::create_dir_all(&target_skills_dir).await?;
 
         for skill in skills {
@@ -780,6 +783,32 @@ pub async fn link_workspace_skills(
         }
     }
     Ok(created)
+}
+
+async fn resolve_workspace_skills_dir(workspace: &Path, skills_rel_dir: &str) -> PathBuf {
+    let requested = workspace.join(skills_rel_dir);
+    if path_is_dir(&requested).await {
+        return requested;
+    }
+
+    let rel_path = Path::new(skills_rel_dir);
+    if rel_path.file_name() == Some(std::ffi::OsStr::new("skills"))
+        && let Some(parent) = rel_path.parent()
+    {
+        let singular = workspace.join(parent).join("skill");
+        if path_is_dir(&singular).await {
+            return singular;
+        }
+    }
+
+    requested
+}
+
+async fn path_is_dir(path: &Path) -> bool {
+    tokio::fs::metadata(path)
+        .await
+        .map(|metadata| metadata.is_dir())
+        .unwrap_or(false)
 }
 
 /// Resolve a skill name to its on-disk source directory using the same
@@ -2088,6 +2117,20 @@ mod tests {
         .unwrap();
     }
 
+    fn create_resolved_test_skill(source_root: &Path, name: &str) -> ResolvedAgentSkill {
+        let source_path = source_root.join(name);
+        std::fs::create_dir_all(&source_path).unwrap();
+        std::fs::write(
+            source_path.join(SKILL_MANIFEST_FILE),
+            format!("---\nname: {name}\ndescription: test\n---\nbody"),
+        )
+        .unwrap();
+        ResolvedAgentSkill {
+            name: name.to_owned(),
+            source_path,
+        }
+    }
+
     fn write_test_zip(path: &Path, entries: &[(&str, &str)]) {
         let file = std::fs::File::create(path).unwrap();
         let mut zip = zip::ZipWriter::new(file);
@@ -2402,6 +2445,78 @@ mod tests {
         assert!(manifest.contains("name: my-skill"));
         let nested = std::fs::read_to_string(target.join("nested").join("data.txt")).unwrap();
         assert_eq!(nested, "payload");
+    }
+
+    #[tokio::test]
+    async fn link_workspace_skills_uses_existing_singular_skill_dir() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        let source_root = tmp.path().join("sources");
+        let existing_skill_dir = workspace.join(".claude").join("skill");
+        std::fs::create_dir_all(&existing_skill_dir).unwrap();
+
+        let resolved = vec![create_resolved_test_skill(&source_root, "my-skill")];
+
+        let created = link_workspace_skills(&workspace, &[".claude/skills"], &resolved)
+            .await
+            .expect("link_workspace_skills should use existing singular skill dir");
+        assert_eq!(created, 1, "exactly one skill should be materialized");
+
+        assert!(
+            existing_skill_dir.join("my-skill").exists(),
+            "existing singular skill dir should receive the skill"
+        );
+        assert!(
+            !workspace.join(".claude").join("skills").exists(),
+            "plural skills dir should not be created when singular skill dir already exists"
+        );
+    }
+
+    #[tokio::test]
+    async fn link_workspace_skills_creates_requested_dir_inside_existing_agent_dir() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        let source_root = tmp.path().join("sources");
+        std::fs::create_dir_all(workspace.join(".codex")).unwrap();
+
+        let resolved = vec![create_resolved_test_skill(&source_root, "my-skill")];
+
+        let created = link_workspace_skills(&workspace, &[".codex/skills"], &resolved)
+            .await
+            .expect("link_workspace_skills should create missing skills dir");
+        assert_eq!(created, 1, "exactly one skill should be materialized");
+
+        assert!(
+            workspace.join(".codex/skills/my-skill").is_dir(),
+            "missing skills dir should be created under the existing agent dir"
+        );
+    }
+
+    #[tokio::test]
+    async fn link_workspace_skills_prefers_existing_plural_dir_over_singular_sibling() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        let source_root = tmp.path().join("sources");
+        let plural_dir = workspace.join(".gemini").join("skills");
+        let singular_dir = workspace.join(".gemini").join("skill");
+        std::fs::create_dir_all(&plural_dir).unwrap();
+        std::fs::create_dir_all(&singular_dir).unwrap();
+
+        let resolved = vec![create_resolved_test_skill(&source_root, "my-skill")];
+
+        let created = link_workspace_skills(&workspace, &[".gemini/skills"], &resolved)
+            .await
+            .expect("link_workspace_skills should prefer the requested existing dir");
+        assert_eq!(created, 1, "exactly one skill should be materialized");
+
+        assert!(
+            plural_dir.join("my-skill").is_dir(),
+            "existing plural skills dir should receive the skill"
+        );
+        assert!(
+            !singular_dir.join("my-skill").exists(),
+            "singular sibling should remain untouched when requested dir exists"
+        );
     }
 
     /// Windows-only: directory linking must go through an NTFS junction


### PR DESCRIPTION
## Summary
- Link selected skills into native agent skill directories for both temporary and user-selected workspaces.
- Preserve first-message skill injection for agents without native skill directory support, and add `[LOAD_SKILL: ...]` handling in AionCore stream response middleware.
- Resolve custom workspace skill target directories by honoring existing `.agent/skill` or `.agent/skills` folders before creating the default directory.

## Test Plan
- `cargo fmt --all -- --check`
- `cargo test -p aionui-conversation`
- `cargo test -p aionui-extension`
- `cargo test -p aionui-ai-agent`
- `cargo clippy -p aionui-conversation -p aionui-extension -p aionui-ai-agent -- -D warnings`
- `just push -u origin fix-skill-load-main` ran migration check, cargo fix, workspace clippy fix, fmt, and started full workspace nextest; interrupted at user request after 1492 passing tests to create this PR first.
