### PR TITLE
fix(deps): update quinn-proto for RustSec advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4022,9 +4022,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary
- Update the transitive `quinn-proto` lockfile entry from `0.11.14` to `0.11.15`.
- Resolve `RUSTSEC-2026-0185` reported by `cargo audit`.
- Keep the change scoped to `Cargo.lock` only.

## Test Plan
- [x] `cargo audit`
- [x] `cargo test --workspace`
- [x] `just push -u origin fix/quinn-proto-audit`