### PR TITLE
fix(conversation): recover dead ACP turns after agent process loss

### DIFF
--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -217,6 +217,10 @@ impl AgentSendError {
         self.stream_error
     }
 
+    pub fn from_stream_error_data(stream_error: AgentStreamErrorData) -> Self {
+        Self { stream_error }
+    }
+
     pub fn code(&self) -> Option<AgentErrorCode> {
         self.stream_error.code
     }

--- a/crates/aionui-conversation/src/agent_health_policy.rs
+++ b/crates/aionui-conversation/src/agent_health_policy.rs
@@ -22,7 +22,10 @@ impl AgentHealthPolicy {
         outcome: &RelayOutcome,
         lifecycle: RuntimeLifecycleState,
     ) -> AgentHealthAction {
-        if lifecycle != RuntimeLifecycleState::Active {
+        if matches!(
+            lifecycle,
+            RuntimeLifecycleState::Deleting | RuntimeLifecycleState::ShuttingDown
+        ) {
             return AgentHealthAction::Keep;
         }
         if agent_type != AgentType::Acp || !outcome.terminal.is_error() {
@@ -105,6 +108,18 @@ mod tests {
             AgentHealthPolicy::decide(AgentType::Acp, &outcome, RuntimeLifecycleState::Active),
             AgentHealthAction::Keep
         );
+    }
+
+    #[test]
+    fn cancelling_acp_terminal_error_evicts_task() {
+        let outcome = error_outcome(Some(AgentErrorCode::UnknownUpstreamError));
+        assert!(matches!(
+            AgentHealthPolicy::decide(AgentType::Acp, &outcome, RuntimeLifecycleState::Cancelling),
+            AgentHealthAction::EvictAcpTask {
+                clear_model_seed: false,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/aionui-conversation/src/agent_health_policy.rs
+++ b/crates/aionui-conversation/src/agent_health_policy.rs
@@ -45,11 +45,11 @@ mod tests {
 
     fn error_outcome(code: Option<AgentErrorCode>) -> RelayOutcome {
         RelayOutcome {
-            system_responses: Vec::new(),
             terminal: RelayTerminal::Error {
                 code,
                 retryable: Some(true),
             },
+            ..RelayOutcome::default()
         }
     }
 
@@ -98,8 +98,8 @@ mod tests {
     #[test]
     fn channel_closed_does_not_evict_by_default() {
         let outcome = RelayOutcome {
-            system_responses: Vec::new(),
             terminal: RelayTerminal::ChannelClosed,
+            ..RelayOutcome::default()
         };
         assert_eq!(
             AgentHealthPolicy::decide(AgentType::Acp, &outcome, RuntimeLifecycleState::Active),

--- a/crates/aionui-conversation/src/lib.rs
+++ b/crates/aionui-conversation/src/lib.rs
@@ -24,6 +24,7 @@ pub mod stream_relay;
 pub mod task_options;
 mod turn_continuation_policy;
 mod turn_orchestrator;
+mod turn_recovery_policy;
 
 pub use error::ConversationError;
 pub use response_middleware::{

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -3865,6 +3865,35 @@ async fn send_message_injects_send_error_when_runtime_terminal_missing() {
 }
 
 #[tokio::test]
+async fn send_message_recovers_when_finished_task_has_no_runtime_terminal() {
+    let (svc, _broadcaster, repo, _default_task_mgr) = make_service();
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let scripted_agent = Arc::new(
+        ScriptedAgent::new(&conv.id, vec![vec![]])
+            .with_status(Some(ConversationStatus::Finished))
+            .with_send_error(AgentSendError::from_agent_error(AgentError::bad_gateway(
+                "acp protocol not connected",
+            ))),
+    );
+    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(scripted_agent));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    assert_eq!(task_mgr.kill_count(), 1);
+    assert_eq!(task_mgr.active_count(), 1);
+
+    let messages = repo.get_messages(&conv.id, 1, 20, SortOrder::Asc).await.unwrap().items;
+    let tips: Vec<_> = messages.iter().filter(|msg| msg.r#type == "tips").collect();
+    assert!(tips.is_empty());
+}
+
+#[tokio::test]
 async fn send_message_auto_replays_clean_retryable_acp_error_once() {
     let (svc, _broadcaster, repo, _default_task_mgr) = make_service();
     let conv = svc.create("user_1", make_create_req()).await.unwrap();

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use aionui_ai_agent::agent_task::{AgentInstance, IAgentTask, IMockAgent};
 use aionui_ai_agent::protocol::events::{AgentStreamEvent, ErrorEventData, FinishEventData, TextEventData};
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
-use aionui_ai_agent::{AcpError, AgentError, AgentSendError, IWorkerTaskManager};
+use aionui_ai_agent::{AcpError, AgentError, AgentSendError, AgentSessionKind, IWorkerTaskManager};
 
 use crate::response_middleware::{CronCommandResult, CronCreateParams, CronUpdateParams, ICronService};
 use aionui_api_types::{
@@ -663,36 +663,59 @@ struct RuntimeStateSaveCall {
 #[derive(Default)]
 struct StubAcpSessionRepo {
     runtime_state_saves: Mutex<Vec<RuntimeStateSaveCall>>,
+    session_id: Mutex<Option<String>>,
 }
 
 impl StubAcpSessionRepo {
+    fn with_session_id(session_id: impl Into<String>) -> Self {
+        Self {
+            runtime_state_saves: Mutex::new(Vec::new()),
+            session_id: Mutex::new(Some(session_id.into())),
+        }
+    }
+
     fn runtime_state_saves(&self) -> Vec<RuntimeStateSaveCall> {
         self.runtime_state_saves.lock().unwrap().clone()
+    }
+
+    fn row_for(&self, conversation_id: &str) -> AcpSessionRow {
+        AcpSessionRow {
+            conversation_id: conversation_id.to_owned(),
+            agent_backend: "codex".into(),
+            agent_source: "builtin".into(),
+            agent_id: "codex".into(),
+            session_id: self.session_id.lock().unwrap().clone(),
+            session_status: "idle".into(),
+            session_config: "{}".into(),
+            last_active_at: None,
+            suspended_at: None,
+        }
     }
 }
 
 #[async_trait::async_trait]
 impl IAcpSessionRepository for StubAcpSessionRepo {
-    async fn get(&self, _conversation_id: &str) -> Result<Option<AcpSessionRow>, DbError> {
-        Ok(None)
+    async fn get(&self, conversation_id: &str) -> Result<Option<AcpSessionRow>, DbError> {
+        Ok(Some(self.row_for(conversation_id)))
     }
-    async fn create(&self, _params: &CreateAcpSessionParams<'_>) -> Result<AcpSessionRow, DbError> {
+    async fn create(&self, params: &CreateAcpSessionParams<'_>) -> Result<AcpSessionRow, DbError> {
         // Return a synthetic row so `ConversationService::create` can
         // succeed for ACP conversations in unit tests.
         Ok(AcpSessionRow {
-            conversation_id: "stub".into(),
-            agent_backend: "stub".into(),
-            agent_source: "stub".into(),
-            agent_id: "stub".into(),
-            session_id: None,
+            conversation_id: params.conversation_id.to_owned(),
+            agent_backend: params.agent_backend.to_owned(),
+            agent_source: params.agent_source.to_owned(),
+            agent_id: params.agent_id.to_owned(),
+            session_id: self.session_id.lock().unwrap().clone(),
             session_status: "idle".into(),
             session_config: "{}".into(),
             last_active_at: None,
             suspended_at: None,
         })
     }
-    async fn update_session_id(&self, _conversation_id: &str, _session_id: &str) -> Result<bool, DbError> {
-        Ok(false)
+    async fn update_session_id(&self, _conversation_id: &str, session_id: &str) -> Result<bool, DbError> {
+        *self.session_id.lock().unwrap() = Some(session_id.to_owned());
+        Ok(true)
     }
     async fn delete(&self, _conversation_id: &str) -> Result<bool, DbError> {
         Ok(false)
@@ -2015,6 +2038,81 @@ impl MockTaskManager {
 
     fn kill_records(&self) -> Vec<(String, Option<AgentKillReason>)> {
         self.kill_records.lock().unwrap().clone()
+    }
+}
+
+struct RebuildingScriptedTaskManager {
+    agents: Mutex<VecDeque<AgentInstance>>,
+    build_count: AtomicUsize,
+    kill_count: AtomicUsize,
+    captured_options: Mutex<Vec<BuildTaskOptions>>,
+}
+
+impl RebuildingScriptedTaskManager {
+    fn new(agents: Vec<AgentInstance>) -> Self {
+        Self {
+            agents: Mutex::new(agents.into()),
+            build_count: AtomicUsize::new(0),
+            kill_count: AtomicUsize::new(0),
+            captured_options: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn build_count(&self) -> usize {
+        self.build_count.load(Ordering::SeqCst)
+    }
+
+    fn kill_count(&self) -> usize {
+        self.kill_count.load(Ordering::SeqCst)
+    }
+
+    fn captured_options(&self) -> Vec<BuildTaskOptions> {
+        self.captured_options.lock().unwrap().clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl IWorkerTaskManager for RebuildingScriptedTaskManager {
+    fn get_task(&self, _conversation_id: &str) -> Option<AgentInstance> {
+        None
+    }
+
+    async fn get_or_build_task(
+        &self,
+        _conversation_id: &str,
+        options: BuildTaskOptions,
+    ) -> Result<AgentInstance, AgentError> {
+        self.build_count.fetch_add(1, Ordering::SeqCst);
+        self.captured_options.lock().unwrap().push(options);
+        self.agents
+            .lock()
+            .unwrap()
+            .pop_front()
+            .ok_or_else(|| AgentError::bad_gateway("no scripted agent left"))
+    }
+
+    fn kill(&self, _conversation_id: &str, _reason: Option<AgentKillReason>) -> Result<(), AgentError> {
+        self.kill_count.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn kill_and_wait(
+        &self,
+        conversation_id: &str,
+        reason: Option<AgentKillReason>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+        let _ = self.kill(conversation_id, reason);
+        Box::pin(std::future::ready(()))
+    }
+
+    async fn clear(&self) {}
+
+    fn active_count(&self) -> usize {
+        0
+    }
+
+    fn collect_idle(&self, _idle_threshold_ms: TimestampMs) -> Vec<String> {
+        Vec::new()
     }
 }
 
@@ -3763,6 +3861,115 @@ async fn send_message_injects_send_error_when_runtime_terminal_missing() {
     let content: serde_json::Value = serde_json::from_str(&tips[0].content).unwrap();
     assert_eq!(content["type"], "error");
     assert_eq!(content["error"]["code"], "USER_LLM_PROVIDER_AUTH_FAILED");
+}
+
+#[tokio::test]
+async fn send_message_auto_replays_clean_retryable_acp_error_once() {
+    let (svc, _broadcaster, repo, _default_task_mgr) = make_service();
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let first = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Error(ErrorEventData {
+            message: "temporary provider failure".into(),
+            code: Some(AgentErrorCode::UnknownUpstreamError),
+            ownership: None,
+            detail: None,
+            workspace_path: None,
+            retryable: Some(true),
+            feedback_recommended: None,
+            resolution: None,
+        })]],
+    ));
+    let second = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![
+            AgentStreamEvent::Text(TextEventData { content: "done".into() }),
+            AgentStreamEvent::Finish(FinishEventData::default()),
+        ]],
+    ));
+    let task_mgr = Arc::new(RebuildingScriptedTaskManager::new(vec![
+        AgentInstance::Mock(first.clone()),
+        AgentInstance::Mock(second.clone()),
+    ]));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    assert_eq!(task_mgr.build_count(), 2);
+    assert_eq!(task_mgr.kill_count(), 1);
+    assert_eq!(first.sent_contents(), vec!["Hello"]);
+    assert_eq!(second.sent_contents(), vec!["Hello"]);
+
+    let messages = repo.get_messages(&conv.id, 1, 20, SortOrder::Asc).await.unwrap().items;
+    let users: Vec<_> = messages
+        .iter()
+        .filter(|msg| msg.r#type == "text" && msg.position.as_deref() == Some("right"))
+        .collect();
+    let assistants: Vec<_> = messages
+        .iter()
+        .filter(|msg| msg.r#type == "text" && msg.position.as_deref() == Some("left"))
+        .collect();
+    let tips: Vec<_> = messages.iter().filter(|msg| msg.r#type == "tips").collect();
+    assert_eq!(users.len(), 1, "auto replay must not insert the user message again");
+    assert_eq!(assistants.len(), 1);
+    assert_eq!(
+        tips.len(),
+        0,
+        "first clean retryable error stays hidden when replay succeeds"
+    );
+}
+
+#[tokio::test]
+async fn auto_replay_rebuild_keeps_existing_acp_session_id_in_build_options() {
+    let acp_session_repo = Arc::new(StubAcpSessionRepo::with_session_id("sess-existing"));
+    let (svc, _broadcaster, _repo, _default_task_mgr) = make_service_with_resolver_and_acp_session_repo(
+        Arc::new(FixedSkillResolver { names: vec![] }),
+        acp_session_repo,
+    );
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let first = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Error(ErrorEventData {
+            message: "temporary provider failure".into(),
+            code: Some(AgentErrorCode::UnknownUpstreamError),
+            ownership: None,
+            detail: None,
+            workspace_path: None,
+            retryable: Some(true),
+            feedback_recommended: None,
+            resolution: None,
+        })]],
+    ));
+    let second = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Finish(FinishEventData::default())]],
+    ));
+    let task_mgr = Arc::new(RebuildingScriptedTaskManager::new(vec![
+        AgentInstance::Mock(first),
+        AgentInstance::Mock(second),
+    ]));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    let options = task_mgr.captured_options();
+    assert_eq!(options.len(), 2);
+    for options in options {
+        match options.context.kind {
+            AgentSessionKind::Acp(ctx) => {
+                assert_eq!(ctx.session_id.as_deref(), Some("sess-existing"));
+            }
+            AgentSessionKind::Aionrs(_) => panic!("test conversation should build ACP options"),
+        }
+    }
 }
 
 // ── stop_stream tests ───────────────────────────────────────────

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -7,6 +7,7 @@ use std::sync::{
 use std::time::Duration;
 
 use aionui_ai_agent::agent_task::{AgentInstance, IAgentTask, IMockAgent};
+use aionui_ai_agent::protocol::events::tool_call::{ToolCallEventData, ToolCallStatus};
 use aionui_ai_agent::protocol::events::{AgentStreamEvent, ErrorEventData, FinishEventData, TextEventData};
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
 use aionui_ai_agent::{AcpError, AgentError, AgentSendError, AgentSessionKind, IWorkerTaskManager};
@@ -3970,6 +3971,203 @@ async fn auto_replay_rebuild_keeps_existing_acp_session_id_in_build_options() {
             AgentSessionKind::Aionrs(_) => panic!("test conversation should build ACP options"),
         }
     }
+}
+
+#[tokio::test]
+async fn send_message_does_not_auto_replay_after_visible_output() {
+    let (svc, _broadcaster, repo, _default_task_mgr) = make_service();
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let first = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![
+            AgentStreamEvent::Text(TextEventData {
+                content: "partial".into(),
+            }),
+            AgentStreamEvent::Error(ErrorEventData {
+                message: "temporary provider failure".into(),
+                code: Some(AgentErrorCode::UnknownUpstreamError),
+                ownership: None,
+                detail: None,
+                workspace_path: None,
+                retryable: Some(true),
+                feedback_recommended: None,
+                resolution: None,
+            }),
+        ]],
+    ));
+    let second = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Finish(FinishEventData::default())]],
+    ));
+    let task_mgr = Arc::new(RebuildingScriptedTaskManager::new(vec![
+        AgentInstance::Mock(first),
+        AgentInstance::Mock(second),
+    ]));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    assert_eq!(task_mgr.build_count(), 1);
+    assert_eq!(task_mgr.kill_count(), 1);
+    let messages = repo.get_messages(&conv.id, 1, 20, SortOrder::Asc).await.unwrap().items;
+    let assistants: Vec<_> = messages
+        .iter()
+        .filter(|msg| msg.r#type == "text" && msg.position.as_deref() == Some("left"))
+        .collect();
+    assert_eq!(assistants.len(), 1);
+    assert!(assistants[0].content.contains("partial"));
+}
+
+#[tokio::test]
+async fn send_message_does_not_auto_replay_after_tool_side_effect() {
+    let (svc, _broadcaster, _repo, _default_task_mgr) = make_service();
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let first = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![
+            AgentStreamEvent::ToolCall(ToolCallEventData {
+                call_id: "call-1".into(),
+                name: "write_file".into(),
+                args: serde_json::json!({ "path": "a.txt" }),
+                status: ToolCallStatus::Running,
+                input: None,
+                output: None,
+                description: None,
+            }),
+            AgentStreamEvent::Error(ErrorEventData {
+                message: "temporary provider failure".into(),
+                code: Some(AgentErrorCode::UnknownUpstreamError),
+                ownership: None,
+                detail: None,
+                workspace_path: None,
+                retryable: Some(true),
+                feedback_recommended: None,
+                resolution: None,
+            }),
+        ]],
+    ));
+    let second = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Finish(FinishEventData::default())]],
+    ));
+    let task_mgr = Arc::new(RebuildingScriptedTaskManager::new(vec![
+        AgentInstance::Mock(first),
+        AgentInstance::Mock(second),
+    ]));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    assert_eq!(task_mgr.build_count(), 1);
+    assert_eq!(task_mgr.kill_count(), 1);
+}
+
+#[tokio::test]
+async fn send_message_does_not_auto_replay_model_not_found() {
+    let (svc, _broadcaster, repo, _default_task_mgr) = make_service();
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let first = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Error(ErrorEventData {
+            message: "model not found".into(),
+            code: Some(AgentErrorCode::UserLlmProviderModelNotFound),
+            ownership: None,
+            detail: None,
+            workspace_path: None,
+            retryable: Some(true),
+            feedback_recommended: None,
+            resolution: None,
+        })]],
+    ));
+    let second = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Finish(FinishEventData::default())]],
+    ));
+    let task_mgr = Arc::new(RebuildingScriptedTaskManager::new(vec![
+        AgentInstance::Mock(first),
+        AgentInstance::Mock(second),
+    ]));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    assert_eq!(task_mgr.build_count(), 1);
+    assert_eq!(task_mgr.kill_count(), 1);
+    let messages = repo.get_messages(&conv.id, 1, 20, SortOrder::Asc).await.unwrap().items;
+    let tips: Vec<_> = messages.iter().filter(|msg| msg.r#type == "tips").collect();
+    assert_eq!(
+        tips.len(),
+        1,
+        "model_not_found should remain visible and must not be swallowed by replay deferral"
+    );
+}
+
+#[tokio::test]
+async fn send_message_auto_replay_stops_after_second_retryable_failure() {
+    let (svc, _broadcaster, repo, _default_task_mgr) = make_service();
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+
+    let first = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Error(ErrorEventData {
+            message: "temporary provider failure one".into(),
+            code: Some(AgentErrorCode::UnknownUpstreamError),
+            ownership: None,
+            detail: None,
+            workspace_path: None,
+            retryable: Some(true),
+            feedback_recommended: None,
+            resolution: None,
+        })]],
+    ));
+    let second = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Error(ErrorEventData {
+            message: "temporary provider failure two".into(),
+            code: Some(AgentErrorCode::UnknownUpstreamError),
+            ownership: None,
+            detail: None,
+            workspace_path: None,
+            retryable: Some(true),
+            feedback_recommended: None,
+            resolution: None,
+        })]],
+    ));
+    let third = Arc::new(ScriptedAgent::new(
+        &conv.id,
+        vec![vec![AgentStreamEvent::Finish(FinishEventData::default())]],
+    ));
+    let task_mgr = Arc::new(RebuildingScriptedTaskManager::new(vec![
+        AgentInstance::Mock(first),
+        AgentInstance::Mock(second),
+        AgentInstance::Mock(third),
+    ]));
+
+    let task_mgr_dyn: Arc<dyn IWorkerTaskManager> = task_mgr.clone();
+    svc.send_message("user_1", &conv.id, make_send_req(), &task_mgr_dyn)
+        .await
+        .unwrap();
+    wait_for_turn_released(&svc, &conv.id).await;
+
+    assert_eq!(task_mgr.build_count(), 2);
+    assert_eq!(task_mgr.kill_count(), 2);
+    let messages = repo.get_messages(&conv.id, 1, 20, SortOrder::Asc).await.unwrap().items;
+    let tips: Vec<_> = messages.iter().filter(|msg| msg.r#type == "tips").collect();
+    assert_eq!(tips.len(), 1, "second failure is final and visible");
+    let content: serde_json::Value = serde_json::from_str(&tips[0].content).unwrap();
+    assert_eq!(content["content"], "temporary provider failure two");
 }
 
 // ── stop_stream tests ───────────────────────────────────────────

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -17,6 +17,7 @@ use crate::stream_persistence::{
 use aionui_db::IConversationRepository;
 use aionui_realtime::EventBroadcaster;
 use serde_json::json;
+use tokio::sync::broadcast::error::TryRecvError;
 use tokio::sync::{broadcast, oneshot};
 use tracing::{debug, info, warn};
 
@@ -219,11 +220,34 @@ impl StreamRelay {
         let mut first_agent_event_logged = false;
         let mut first_visible_output_logged = false;
         let mut send_error_done = send_error_rx.is_none();
+        let mut pending_send_error: Option<AgentSendError> = None;
         let mut attempt = TurnAttemptSummary::default();
 
         loop {
             let recv_result = if send_error_done {
-                rx.recv().await
+                if let Some(send_error) = pending_send_error.take() {
+                    match rx.try_recv() {
+                        Ok(event) => {
+                            if !matches!(event, AgentStreamEvent::Finish(_) | AgentStreamEvent::Error(_)) {
+                                pending_send_error = Some(send_error);
+                            } else {
+                                debug!("Runtime terminal event won race with fallback send error");
+                            }
+                            Ok(event)
+                        }
+                        Err(TryRecvError::Empty) | Err(TryRecvError::Closed) => {
+                            warn!(
+                                code = ?send_error.code(),
+                                ownership = ?send_error.ownership(),
+                                "Injecting stream error for failed agent send"
+                            );
+                            Ok(AgentStreamEvent::Error(send_error.into_stream_error()))
+                        }
+                        Err(TryRecvError::Lagged(n)) => Err(broadcast::error::RecvError::Lagged(n)),
+                    }
+                } else {
+                    rx.recv().await
+                }
             } else {
                 tokio::select! {
                     recv = rx.recv() => recv,
@@ -231,12 +255,8 @@ impl StreamRelay {
                         send_error_done = true;
                         match send_error {
                             Ok(send_error) => {
-                                warn!(
-                                    code = ?send_error.code(),
-                                    ownership = ?send_error.ownership(),
-                                    "Injecting stream error for failed agent send"
-                                );
-                                Ok(AgentStreamEvent::Error(send_error.into_stream_error()))
+                                pending_send_error = Some(send_error);
+                                continue;
                             }
                             Err(_) => continue,
                         }

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use aionui_ai_agent::protocol::events::TipType;
+use aionui_ai_agent::protocol::events::{ErrorEventData, TipType};
 use aionui_ai_agent::{AgentSendError, AgentStreamEvent, protocol::events::ThinkingEventData};
 
 use crate::response_middleware::{ICronService, ISkillLoadService, MessageMiddleware, MiddlewareResult};
@@ -23,11 +23,38 @@ use tracing::{debug, info, warn};
 /// Number of text chunks to accumulate before flushing to the database.
 const FLUSH_INTERVAL: u32 = 20;
 
+/// Conservative summary of what happened during one agent send attempt.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TurnAttemptSummary {
+    pub saw_visible_output: bool,
+    pub saw_tool_or_side_effect: bool,
+    pub persisted_assistant_output: bool,
+    pub terminal_error: Option<ErrorEventData>,
+    pub terminal_error_deferred: bool,
+}
+
+impl TurnAttemptSummary {
+    pub fn safe_to_auto_replay(&self) -> bool {
+        !self.saw_visible_output && !self.saw_tool_or_side_effect && !self.persisted_assistant_output
+    }
+
+    pub fn merge(&mut self, other: &TurnAttemptSummary) {
+        self.saw_visible_output |= other.saw_visible_output;
+        self.saw_tool_or_side_effect |= other.saw_tool_or_side_effect;
+        self.persisted_assistant_output |= other.persisted_assistant_output;
+        if other.terminal_error.is_some() {
+            self.terminal_error = other.terminal_error.clone();
+        }
+        self.terminal_error_deferred |= other.terminal_error_deferred;
+    }
+}
+
 /// Result returned after a relay turn has fully drained and finalized.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RelayOutcome {
     pub system_responses: Vec<String>,
     pub terminal: RelayTerminal,
+    pub attempt: TurnAttemptSummary,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -78,6 +105,7 @@ pub struct StreamRelay {
     persistence: Option<RuntimePersistenceCoordinator>,
     adapter: StreamPersistenceAdapter,
     complete_turn: bool,
+    defer_clean_terminal_errors: bool,
 }
 
 impl StreamRelay {
@@ -104,6 +132,7 @@ impl StreamRelay {
             persistence: None,
             adapter,
             complete_turn: true,
+            defer_clean_terminal_errors: false,
         }
     }
 
@@ -130,6 +159,11 @@ impl StreamRelay {
 
     pub fn with_turn_completion(mut self, enabled: bool) -> Self {
         self.complete_turn = enabled;
+        self
+    }
+
+    pub fn with_defer_clean_terminal_errors(mut self, enabled: bool) -> Self {
+        self.defer_clean_terminal_errors = enabled;
         self
     }
 
@@ -185,6 +219,7 @@ impl StreamRelay {
         let mut first_agent_event_logged = false;
         let mut first_visible_output_logged = false;
         let mut send_error_done = send_error_rx.is_none();
+        let mut attempt = TurnAttemptSummary::default();
 
         loop {
             let recv_result = if send_error_done {
@@ -246,6 +281,9 @@ impl StreamRelay {
                                     "StreamRelay received first visible output"
                                 );
                             }
+                            if !data.content.is_empty() {
+                                attempt.saw_visible_output = true;
+                            }
 
                             let segment = active_thinking.get_or_insert_with(|| ThinkingSegmentState {
                                 id: Self::mint_segment_msg_id(&mut used_primary_segment_msg_id, &self.msg_id),
@@ -264,6 +302,9 @@ impl StreamRelay {
                                     elapsed_ms = now_ms().saturating_sub(started_at),
                                     "StreamRelay received first visible output"
                                 );
+                            }
+                            if !data.content.is_empty() {
+                                attempt.saw_visible_output = true;
                             }
 
                             let segment = active_text.get_or_insert_with(|| TextSegmentState {
@@ -311,6 +352,33 @@ impl StreamRelay {
                                 }
                             }
 
+                            let defer_clean_error = self.defer_clean_terminal_errors
+                                && matches!(
+                                    terminal,
+                                    RelayTerminal::Error {
+                                        retryable: Some(true),
+                                        ..
+                                    }
+                                )
+                                && terminal.code() != Some(AgentErrorCode::UserLlmProviderModelNotFound)
+                                && attempt.safe_to_auto_replay();
+
+                            if defer_clean_error {
+                                if let AgentStreamEvent::Error(data) = &event {
+                                    attempt.terminal_error = Some(data.clone());
+                                    attempt.terminal_error_deferred = true;
+                                }
+                                info!(
+                                    event_type,
+                                    elapsed_ms, "StreamRelay deferred clean terminal error for possible auto replay"
+                                );
+                                break RelayOutcome {
+                                    system_responses: Vec::new(),
+                                    terminal,
+                                    attempt,
+                                };
+                            }
+
                             if deleting {
                                 debug!("Skipping terminal DB finalization because conversation is deleting");
                             } else {
@@ -327,14 +395,22 @@ impl StreamRelay {
                                 .await;
                             }
                             self.forward_to_websocket(&event);
-                            let outcome = if deleting {
+                            if let AgentStreamEvent::Error(data) = &event {
+                                attempt.terminal_error = Some(data.clone());
+                            }
+                            let mut outcome = if deleting {
                                 RelayOutcome {
                                     system_responses: Vec::new(),
                                     terminal,
+                                    attempt: attempt.clone(),
                                 }
                             } else {
                                 self.finalize(&full_text_buffer, &text_segments, &event, terminal).await
                             };
+                            outcome.attempt = attempt.clone();
+                            if !full_text_buffer.is_empty() {
+                                outcome.attempt.persisted_assistant_output = true;
+                            }
                             if self.complete_turn && !deleting {
                                 self.adapter
                                     .complete_conversation(&self.broadcaster, &self.turn_id, None)
@@ -343,6 +419,7 @@ impl StreamRelay {
                             break outcome;
                         }
                         AgentStreamEvent::ToolCall(data) => {
+                            attempt.saw_tool_or_side_effect = true;
                             self.complete_active_thinking(&mut active_thinking).await;
                             self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
                                 .await;
@@ -350,6 +427,7 @@ impl StreamRelay {
                             self.adapter.persist_tool_call(data).await;
                         }
                         AgentStreamEvent::AcpToolCall(data) => {
+                            attempt.saw_tool_or_side_effect = true;
                             self.complete_active_thinking(&mut active_thinking).await;
                             self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
                                 .await;
@@ -357,6 +435,7 @@ impl StreamRelay {
                             self.adapter.persist_acp_tool_call(data).await;
                         }
                         AgentStreamEvent::ToolGroup(entries) => {
+                            attempt.saw_tool_or_side_effect = true;
                             self.complete_active_thinking(&mut active_thinking).await;
                             self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
                                 .await;
@@ -364,10 +443,19 @@ impl StreamRelay {
                             self.adapter.persist_tool_group(entries).await;
                         }
                         AgentStreamEvent::Tips(data) => {
+                            if matches!(data.tip_type, TipType::Success | TipType::Warning | TipType::Info) {
+                                attempt.saw_visible_output = true;
+                            }
                             self.forward_to_websocket(&event);
                             if matches!(data.tip_type, TipType::Success | TipType::Warning | TipType::Info) {
                                 self.adapter.persist_tip(data).await;
                             }
+                        }
+                        AgentStreamEvent::CronTrigger(_)
+                        | AgentStreamEvent::Permission(_)
+                        | AgentStreamEvent::AcpPermission(_) => {
+                            attempt.saw_tool_or_side_effect = true;
+                            self.forward_to_websocket(&event);
                         }
                         _ => {
                             self.forward_to_websocket(&event);
@@ -391,10 +479,11 @@ impl StreamRelay {
                             .await;
                     }
                     // Channel closed without finish/error — still finalize
-                    let outcome = if deleting {
+                    let mut outcome = if deleting {
                         RelayOutcome {
                             system_responses: Vec::new(),
                             terminal: RelayTerminal::ChannelClosed,
+                            attempt: attempt.clone(),
                         }
                     } else {
                         self.finalize(
@@ -405,6 +494,10 @@ impl StreamRelay {
                         )
                         .await
                     };
+                    outcome.attempt = attempt.clone();
+                    if !full_text_buffer.is_empty() {
+                        outcome.attempt.persisted_assistant_output = true;
+                    }
                     if self.complete_turn && !deleting {
                         self.adapter
                             .complete_conversation(&self.broadcaster, &self.turn_id, None)
@@ -520,6 +613,7 @@ impl StreamRelay {
         let mut outcome = RelayOutcome {
             system_responses: Vec::new(),
             terminal,
+            attempt: TurnAttemptSummary::default(),
         };
         let status = match event {
             AgentStreamEvent::Error(_) => "error",
@@ -899,6 +993,154 @@ mod tests {
         let content: serde_json::Value = serde_json::from_str(&msg.content).unwrap();
         assert_eq!(content["content"], "Something went wrong");
         assert_eq!(content["type"], "error");
+    }
+
+    #[tokio::test]
+    async fn clean_retryable_error_can_be_deferred_for_replay() {
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let mut ws_rx = bus.subscribe();
+        let (tx, rx) = broadcast::channel(8);
+
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "msg-1".into(),
+            "turn-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+            None,
+        )
+        .with_turn_completion(false)
+        .with_defer_clean_terminal_errors(true);
+
+        tx.send(AgentStreamEvent::Error(ErrorEventData {
+            message: "temporary provider failure".into(),
+            code: Some(AgentErrorCode::UnknownUpstreamError),
+            ownership: None,
+            detail: None,
+            workspace_path: None,
+            retryable: Some(true),
+            feedback_recommended: None,
+            resolution: None,
+        }))
+        .unwrap();
+        drop(tx);
+
+        let outcome = relay.consume(rx).await;
+
+        assert_eq!(
+            outcome.terminal,
+            RelayTerminal::Error {
+                code: Some(AgentErrorCode::UnknownUpstreamError),
+                retryable: Some(true),
+            }
+        );
+        assert!(outcome.attempt.safe_to_auto_replay());
+        assert!(
+            ws_rx.try_recv().is_err(),
+            "clean first-attempt errors stay hidden before replay"
+        );
+        assert!(
+            repo.take_inserts().is_empty(),
+            "no assistant error tip is persisted before replay"
+        );
+    }
+
+    #[tokio::test]
+    async fn text_before_retryable_error_is_not_clean_for_replay() {
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let mut ws_rx = bus.subscribe();
+        let (tx, rx) = broadcast::channel(8);
+
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "msg-1".into(),
+            "turn-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+            None,
+        )
+        .with_turn_completion(false)
+        .with_defer_clean_terminal_errors(true);
+
+        tx.send(AgentStreamEvent::Text(TextEventData {
+            content: "partial".into(),
+        }))
+        .unwrap();
+        tx.send(AgentStreamEvent::Error(ErrorEventData {
+            message: "temporary provider failure".into(),
+            code: Some(AgentErrorCode::UnknownUpstreamError),
+            ownership: None,
+            detail: None,
+            workspace_path: None,
+            retryable: Some(true),
+            feedback_recommended: None,
+            resolution: None,
+        }))
+        .unwrap();
+        drop(tx);
+
+        let outcome = relay.consume(rx).await;
+
+        assert!(outcome.attempt.saw_visible_output);
+        assert!(!outcome.attempt.safe_to_auto_replay());
+        let mut saw_error = false;
+        while let Ok(event) = ws_rx.try_recv() {
+            saw_error |= event.data["type"] == "error";
+        }
+        assert!(saw_error, "unsafe errors are still broadcast");
+    }
+
+    #[tokio::test]
+    async fn tool_call_before_retryable_error_is_not_clean_for_replay() {
+        use aionui_ai_agent::protocol::events::tool_call::{ToolCallEventData, ToolCallStatus};
+
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let (tx, rx) = broadcast::channel(8);
+
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "msg-1".into(),
+            "turn-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+            None,
+        )
+        .with_turn_completion(false)
+        .with_defer_clean_terminal_errors(true);
+
+        tx.send(AgentStreamEvent::ToolCall(ToolCallEventData {
+            call_id: "call-1".into(),
+            name: "write_file".into(),
+            args: serde_json::json!({}),
+            status: ToolCallStatus::Running,
+            input: None,
+            output: None,
+            description: None,
+        }))
+        .unwrap();
+        tx.send(AgentStreamEvent::Error(ErrorEventData {
+            message: "temporary provider failure".into(),
+            code: Some(AgentErrorCode::UnknownUpstreamError),
+            ownership: None,
+            detail: None,
+            workspace_path: None,
+            retryable: Some(true),
+            feedback_recommended: None,
+            resolution: None,
+        }))
+        .unwrap();
+        drop(tx);
+
+        let outcome = relay.consume(rx).await;
+
+        assert!(outcome.attempt.saw_tool_or_side_effect);
+        assert!(!outcome.attempt.safe_to_auto_replay());
     }
 
     #[tokio::test]

--- a/crates/aionui-conversation/src/turn_continuation_policy.rs
+++ b/crates/aionui-conversation/src/turn_continuation_policy.rs
@@ -71,6 +71,7 @@ mod tests {
         let outcome = RelayOutcome {
             system_responses: vec!["one".into(), "two".into()],
             terminal: RelayTerminal::Finish,
+            ..RelayOutcome::default()
         };
 
         assert_eq!(
@@ -91,6 +92,7 @@ mod tests {
                 code: Some(AgentErrorCode::UnknownUpstreamError),
                 retryable: Some(true),
             },
+            ..RelayOutcome::default()
         };
 
         assert_eq!(
@@ -105,6 +107,7 @@ mod tests {
         let outcome = RelayOutcome {
             system_responses: vec!["next".into()],
             terminal: RelayTerminal::Finish,
+            ..RelayOutcome::default()
         };
 
         assert_eq!(
@@ -119,6 +122,7 @@ mod tests {
         let outcome = RelayOutcome {
             system_responses: vec!["next".into()],
             terminal: RelayTerminal::Finish,
+            ..RelayOutcome::default()
         };
 
         assert_eq!(

--- a/crates/aionui-conversation/src/turn_orchestrator.rs
+++ b/crates/aionui-conversation/src/turn_orchestrator.rs
@@ -2,18 +2,20 @@ use std::sync::Arc;
 
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
 use aionui_ai_agent::{AgentSendError, AgentSessionKind, IWorkerTaskManager};
-use aionui_common::{ConversationStatus, ErrorChain, now_ms};
+use aionui_common::{AgentType, ConversationStatus, ErrorChain, now_ms};
 use aionui_db::models::ConversationRow;
 use tokio::sync::oneshot;
 use tracing::{debug, error, info, warn};
 
 use crate::agent_health_policy::{AgentHealthAction, AgentHealthPolicy};
+use crate::runtime_state::RuntimeLifecycleState;
 use crate::runtime_state::TurnClaim;
 use crate::service::{
     ConversationService, MAX_CRON_CONTINUATIONS_PER_TURN, agent_error_top_level_code, persist_session_key,
 };
-use crate::stream_relay::StreamRelay;
+use crate::stream_relay::{RelayOutcome, StreamRelay, TurnAttemptSummary};
 use crate::turn_continuation_policy::{ContinuationDecision, TurnContinuationPolicy};
+use crate::turn_recovery_policy::{TurnRecoveryDecision, TurnRecoveryPolicy};
 use aionui_api_types::SendMessageRequest;
 
 fn acp_backend_from_build_options(options: &BuildTaskOptions) -> Option<&str> {
@@ -48,6 +50,26 @@ pub(crate) struct ConversationTurnOrchestrator {
     task_manager: Arc<dyn IWorkerTaskManager>,
 }
 
+struct TurnAttemptInput {
+    conv_id: String,
+    turn_id: String,
+    user_id: String,
+    build_options: BuildTaskOptions,
+    stored_workspace: String,
+    send: SendMessageData,
+    msg_id: String,
+    allowed_skill_names: Vec<String>,
+    continuation_count: usize,
+    defer_clean_terminal_errors: bool,
+}
+
+struct TurnAttemptResult {
+    outcome: RelayOutcome,
+    summary: TurnAttemptSummary,
+    agent_type: AgentType,
+    backend: Option<String>,
+}
+
 impl ConversationTurnOrchestrator {
     pub fn new(service: ConversationService, task_manager: Arc<dyn IWorkerTaskManager>) -> Self {
         Self { service, task_manager }
@@ -59,20 +81,20 @@ impl ConversationTurnOrchestrator {
         });
     }
 
-    pub(crate) async fn run_user_turn(self, input: TurnStartInput) -> ConversationTurnResult {
-        let mut turn_claim = input.turn_claim;
-        let conv_id = input.conversation.id.clone();
-        let turn_id = input.turn_id.clone();
+    async fn run_attempt(&self, input: TurnAttemptInput) -> Result<TurnAttemptResult, ConversationTurnResult> {
         let build_started_at = now_ms();
-        let persistence = self.service.runtime_persistence();
-        let runtime_state = self.service.runtime_state();
-        let allowed_skill_names = input.build_options.context.skills.clone();
-        let mut turn_failed = false;
-
-        info!(conversation_id = %conv_id, turn_id = %turn_id, "conversation turn orchestrator started");
-        info!(conversation_id = %conv_id, turn_id = %turn_id, "Agent task build started");
         let backend = acp_backend_from_build_options(&input.build_options).map(str::to_owned);
-        let agent = match self.task_manager.get_or_build_task(&conv_id, input.build_options).await {
+        info!(
+            conversation_id = %input.conv_id,
+            turn_id = %input.turn_id,
+            "Agent task build started"
+        );
+
+        let agent = match self
+            .task_manager
+            .get_or_build_task(&input.conv_id, input.build_options)
+            .await
+        {
             Ok(agent) => agent,
             Err(err) => {
                 let top_level_code = agent_error_top_level_code(&err);
@@ -84,8 +106,8 @@ impl ConversationTurnOrchestrator {
                 };
                 if send_error.is_openclaw_gateway_unreachable() {
                     warn!(
-                        conversation_id = %conv_id,
-                        turn_id = %turn_id,
+                        conversation_id = %input.conv_id,
+                        turn_id = %input.turn_id,
                         backend = "openclaw",
                         error_kind = "openclaw_gateway_unreachable",
                         port = 18789_u16,
@@ -94,93 +116,95 @@ impl ConversationTurnOrchestrator {
                     );
                 }
                 error!(
-                    conversation_id = %conv_id,
-                    turn_id = %turn_id,
+                    conversation_id = %input.conv_id,
+                    turn_id = %input.turn_id,
                     error_code = ?send_error.code(),
                     error = %ErrorChain(&err),
                     "Agent task build failed"
                 );
                 self.service
-                    .persist_and_broadcast_send_failure_tip(&conv_id, &turn_id, &send_error, Some(top_level_code))
+                    .persist_and_broadcast_send_failure_tip(
+                        &input.conv_id,
+                        &input.turn_id,
+                        &send_error,
+                        Some(top_level_code),
+                    )
                     .await;
-                let was_deleting = turn_claim.release_for_turn(&turn_id);
-                self.service
-                    .complete_released_turn(&conv_id, &turn_id, was_deleting)
-                    .await;
-                return ConversationTurnResult {
+                return Err(ConversationTurnResult {
                     status: ConversationTurnStatus::Failed,
-                };
+                });
             }
         };
 
         if let Err(err) = self
             .service
-            .maybe_persist_workspace(&conv_id, &input.stored_workspace, agent.workspace())
+            .maybe_persist_workspace(&input.conv_id, &input.stored_workspace, agent.workspace())
             .await
         {
             let top_level_code = err.error_code();
             let send_error = AgentSendError::from_agent_error(err.to_agent_error());
             error!(
-                conversation_id = %conv_id,
-                turn_id = %turn_id,
+                conversation_id = %input.conv_id,
+                turn_id = %input.turn_id,
                 error_code = err.error_code(),
                 error = %ErrorChain(&err),
                 "Failed to persist resolved workspace"
             );
             self.service
-                .persist_and_broadcast_send_failure_tip(&conv_id, &turn_id, &send_error, Some(top_level_code))
+                .persist_and_broadcast_send_failure_tip(
+                    &input.conv_id,
+                    &input.turn_id,
+                    &send_error,
+                    Some(top_level_code),
+                )
                 .await;
-            let was_deleting = turn_claim.release_for_turn(&turn_id);
-            self.service
-                .complete_released_turn(&conv_id, &turn_id, was_deleting)
-                .await;
-            return ConversationTurnResult {
+            return Err(ConversationTurnResult {
                 status: ConversationTurnStatus::Failed,
-            };
+            });
         }
 
         info!(
-            conversation_id = %conv_id,
-            turn_id = %turn_id,
+            conversation_id = %input.conv_id,
+            turn_id = %input.turn_id,
             agent_type = ?agent.agent_type(),
             elapsed_ms = now_ms().saturating_sub(build_started_at),
             "Agent task ready"
         );
 
-        let first_turn_msg_id = ConversationService::mint_msg_id();
-        let mut pending_send = Some((
-            SendMessageData {
-                content: input.request.content,
-                msg_id: first_turn_msg_id.clone(),
-                turn_id: Some(turn_id.clone()),
-                files: input.request.files,
-                inject_skills: input.request.inject_skills,
-            },
-            first_turn_msg_id,
-        ));
-        let mut continuation_count = 0usize;
+        let persistence = self.service.runtime_persistence();
+        let runtime_state = self.service.runtime_state();
+        let mut pending_send = Some((input.send, input.msg_id));
+        let mut continuation_count = input.continuation_count;
         let continuation_policy = TurnContinuationPolicy::new(MAX_CRON_CONTINUATIONS_PER_TURN);
+        let mut last_outcome = None;
+        let mut aggregate_summary = TurnAttemptSummary::default();
 
         while let Some((current_send, msg_id)) = pending_send.take() {
+            let lifecycle = runtime_state.lifecycle_for(&input.conv_id);
+            let defer_clean_terminal_errors = input.defer_clean_terminal_errors
+                && agent.agent_type() == AgentType::Acp
+                && lifecycle == RuntimeLifecycleState::Active
+                && aggregate_summary.safe_to_auto_replay();
             let relay = StreamRelay::new(
-                conv_id.clone(),
+                input.conv_id.clone(),
                 msg_id,
-                turn_id.clone(),
+                input.turn_id.clone(),
                 input.user_id.clone(),
                 self.service.conversation_repo().clone(),
                 self.service.broadcaster().clone(),
                 self.service.current_cron_service(),
             )
             .with_skill_resolver(self.service.skill_resolver())
-            .with_allowed_skill_names(allowed_skill_names.clone())
+            .with_allowed_skill_names(input.allowed_skill_names.clone())
             .with_runtime_state(Arc::clone(&runtime_state))
             .with_persistence(persistence.clone())
-            .with_turn_completion(false);
+            .with_turn_completion(false)
+            .with_defer_clean_terminal_errors(defer_clean_terminal_errors);
 
             let rx = agent.subscribe();
             let send_agent = agent.clone();
-            let conv_id_send = conv_id.clone();
-            let turn_id_for_send = turn_id.clone();
+            let conv_id_send = input.conv_id.clone();
+            let turn_id_for_send = input.turn_id.clone();
             let (send_error_tx, send_error_rx) = oneshot::channel();
 
             tokio::spawn(async move {
@@ -217,29 +241,19 @@ impl ConversationTurnOrchestrator {
             });
 
             let outcome = relay.consume_with_send_error(rx, send_error_rx).await;
-            let lifecycle = runtime_state.lifecycle_for(&conv_id);
-            if outcome.terminal.is_error() {
-                turn_failed = true;
-            }
+            aggregate_summary.merge(&outcome.attempt);
 
             if let Some(session_key) = agent.get_session_key() {
-                persist_session_key(self.service.conversation_repo(), &persistence, &conv_id, &session_key).await;
+                persist_session_key(
+                    self.service.conversation_repo(),
+                    &persistence,
+                    &input.conv_id,
+                    &session_key,
+                )
+                .await;
             }
 
-            match AgentHealthPolicy::decide(agent.agent_type(), &outcome, lifecycle) {
-                AgentHealthAction::Keep => {}
-                AgentHealthAction::EvictAcpTask { .. } => {
-                    if self
-                        .service
-                        .evict_acp_task_after_terminal_error(&conv_id, agent.agent_type(), &outcome, &self.task_manager)
-                        .await
-                    {
-                        break;
-                    }
-                }
-            }
-
-            match continuation_policy.decide(&conv_id, continuation_count, &outcome, lifecycle) {
+            match continuation_policy.decide(&input.conv_id, continuation_count, &outcome, lifecycle) {
                 ContinuationDecision::Continue { content, next_count } => {
                     continuation_count = next_count;
                     let next_turn_msg_id = ConversationService::mint_msg_id();
@@ -247,23 +261,137 @@ impl ConversationTurnOrchestrator {
                         SendMessageData {
                             content,
                             msg_id: next_turn_msg_id.clone(),
-                            turn_id: Some(turn_id.clone()),
+                            turn_id: Some(input.turn_id.clone()),
                             files: vec![],
                             inject_skills: vec![],
                         },
                         next_turn_msg_id,
                     ));
                 }
-                ContinuationDecision::Stop(_) => break,
+                ContinuationDecision::Stop(_) => {
+                    last_outcome = Some(outcome);
+                    break;
+                }
             }
         }
+
+        Ok(TurnAttemptResult {
+            outcome: last_outcome.unwrap_or_default(),
+            summary: aggregate_summary,
+            agent_type: agent.agent_type(),
+            backend,
+        })
+    }
+
+    pub(crate) async fn run_user_turn(self, input: TurnStartInput) -> ConversationTurnResult {
+        let mut turn_claim = input.turn_claim;
+        let conv_id = input.conversation.id.clone();
+        let turn_id = input.turn_id.clone();
+        let runtime_state = self.service.runtime_state();
+        let allowed_skill_names = input.build_options.context.skills.clone();
+        let first_turn_msg_id = ConversationService::mint_msg_id();
+        let initial_send = SendMessageData {
+            content: input.request.content,
+            msg_id: first_turn_msg_id.clone(),
+            turn_id: Some(turn_id.clone()),
+            files: input.request.files,
+            inject_skills: input.request.inject_skills,
+        };
+        let mut replayed = false;
+
+        info!(conversation_id = %conv_id, turn_id = %turn_id, "conversation turn orchestrator started");
+
+        let final_failed = loop {
+            let attempt_result = match self
+                .run_attempt(TurnAttemptInput {
+                    conv_id: conv_id.clone(),
+                    turn_id: turn_id.clone(),
+                    user_id: input.user_id.clone(),
+                    build_options: input.build_options.clone(),
+                    stored_workspace: input.stored_workspace.clone(),
+                    send: initial_send.clone(),
+                    msg_id: first_turn_msg_id.clone(),
+                    allowed_skill_names: allowed_skill_names.clone(),
+                    continuation_count: 0,
+                    defer_clean_terminal_errors: !replayed,
+                })
+                .await
+            {
+                Ok(result) => result,
+                Err(result) => {
+                    break result.status == ConversationTurnStatus::Failed;
+                }
+            };
+
+            let lifecycle = runtime_state.lifecycle_for(&conv_id);
+            if !attempt_result.outcome.terminal.is_error() {
+                break false;
+            }
+
+            let mut recovery_outcome = attempt_result.outcome.clone();
+            recovery_outcome.attempt = attempt_result.summary.clone();
+            let decision = TurnRecoveryPolicy::decide(
+                attempt_result.agent_type,
+                attempt_result.backend.as_deref(),
+                &recovery_outcome,
+                lifecycle,
+                replayed,
+            );
+
+            match decision {
+                TurnRecoveryDecision::AutoReplayOnce { reason, .. } => {
+                    info!(
+                        conversation_id = %conv_id,
+                        turn_id = %turn_id,
+                        ?reason,
+                        "conversation turn auto replay starting after retryable clean terminal error"
+                    );
+                    self.service
+                        .evict_acp_task_after_terminal_error(
+                            &conv_id,
+                            attempt_result.agent_type,
+                            &attempt_result.outcome,
+                            &self.task_manager,
+                        )
+                        .await;
+                    replayed = true;
+                    continue;
+                }
+                TurnRecoveryDecision::None => {
+                    if attempt_result.outcome.attempt.terminal_error_deferred {
+                        if let Some(data) = attempt_result.outcome.attempt.terminal_error.clone() {
+                            let send_error = AgentSendError::from_stream_error_data(data);
+                            self.service
+                                .persist_and_broadcast_send_failure_tip(&conv_id, &turn_id, &send_error, None)
+                                .await;
+                        }
+                    }
+
+                    match AgentHealthPolicy::decide(attempt_result.agent_type, &attempt_result.outcome, lifecycle) {
+                        AgentHealthAction::Keep => {}
+                        AgentHealthAction::EvictAcpTask { .. } => {
+                            self.service
+                                .evict_acp_task_after_terminal_error(
+                                    &conv_id,
+                                    attempt_result.agent_type,
+                                    &attempt_result.outcome,
+                                    &self.task_manager,
+                                )
+                                .await;
+                        }
+                    }
+                    break true;
+                }
+            }
+        };
 
         let was_deleting = turn_claim.release_for_turn(&turn_id);
         self.service
             .complete_released_turn(&conv_id, &turn_id, was_deleting)
             .await;
+
         ConversationTurnResult {
-            status: if turn_failed {
+            status: if final_failed {
                 ConversationTurnStatus::Failed
             } else {
                 ConversationTurnStatus::Completed

--- a/crates/aionui-conversation/src/turn_orchestrator.rs
+++ b/crates/aionui-conversation/src/turn_orchestrator.rs
@@ -298,10 +298,12 @@ impl ConversationTurnOrchestrator {
             inject_skills: input.request.inject_skills,
         };
         let mut replayed = false;
+        let mut replay_started_at = None;
 
         info!(conversation_id = %conv_id, turn_id = %turn_id, "conversation turn orchestrator started");
 
         let final_failed = loop {
+            let attempt_number = if replayed { 2 } else { 1 };
             let attempt_result = match self
                 .run_attempt(TurnAttemptInput {
                     conv_id: conv_id.clone(),
@@ -325,7 +327,28 @@ impl ConversationTurnOrchestrator {
 
             let lifecycle = runtime_state.lifecycle_for(&conv_id);
             if !attempt_result.outcome.terminal.is_error() {
+                if replayed {
+                    info!(
+                        conversation_id = %conv_id,
+                        turn_id = %turn_id,
+                        attempt = attempt_number,
+                        elapsed_ms = replay_started_at
+                            .map(|started_at| now_ms().saturating_sub(started_at))
+                            .unwrap_or_default(),
+                        "conversation turn auto replay completed"
+                    );
+                }
                 break false;
+            }
+            if replayed {
+                warn!(
+                    conversation_id = %conv_id,
+                    turn_id = %turn_id,
+                    attempt = attempt_number,
+                    error_code = ?attempt_result.outcome.terminal.code(),
+                    retryable = ?attempt_result.outcome.terminal.retryable(),
+                    "conversation turn auto replay failed"
+                );
             }
 
             let mut recovery_outcome = attempt_result.outcome.clone();
@@ -340,11 +363,17 @@ impl ConversationTurnOrchestrator {
 
             match decision {
                 TurnRecoveryDecision::AutoReplayOnce { reason, .. } => {
+                    replay_started_at = Some(now_ms());
                     info!(
                         conversation_id = %conv_id,
                         turn_id = %turn_id,
+                        attempt = attempt_number,
+                        next_attempt = attempt_number + 1,
+                        backend = attempt_result.backend.as_deref().unwrap_or("unknown"),
+                        error_code = ?attempt_result.outcome.terminal.code(),
+                        retryable = ?attempt_result.outcome.terminal.retryable(),
                         ?reason,
-                        "conversation turn auto replay starting after retryable clean terminal error"
+                        "conversation turn auto replay starting"
                     );
                     self.service
                         .evict_acp_task_after_terminal_error(
@@ -358,13 +387,13 @@ impl ConversationTurnOrchestrator {
                     continue;
                 }
                 TurnRecoveryDecision::None => {
-                    if attempt_result.outcome.attempt.terminal_error_deferred {
-                        if let Some(data) = attempt_result.outcome.attempt.terminal_error.clone() {
-                            let send_error = AgentSendError::from_stream_error_data(data);
-                            self.service
-                                .persist_and_broadcast_send_failure_tip(&conv_id, &turn_id, &send_error, None)
-                                .await;
-                        }
+                    if attempt_result.outcome.attempt.terminal_error_deferred
+                        && let Some(data) = attempt_result.outcome.attempt.terminal_error.clone()
+                    {
+                        let send_error = AgentSendError::from_stream_error_data(data);
+                        self.service
+                            .persist_and_broadcast_send_failure_tip(&conv_id, &turn_id, &send_error, None)
+                            .await;
                     }
 
                     match AgentHealthPolicy::decide(attempt_result.agent_type, &attempt_result.outcome, lifecycle) {

--- a/crates/aionui-conversation/src/turn_orchestrator.rs
+++ b/crates/aionui-conversation/src/turn_orchestrator.rs
@@ -224,19 +224,18 @@ impl ConversationTurnOrchestrator {
                             conversation_id = %conv_id_send,
                             turn_id = %turn_id_for_send,
                             ?agent_type,
-                            "Agent send_message failure already published runtime terminal; skipping fallback stream error"
+                            "Agent send_message failed on finished task; relay will prefer any runtime terminal before fallback"
                         );
-                    } else {
-                        warn!(
-                            conversation_id = %conv_id_send,
-                            turn_id = %turn_id_for_send,
-                            ?agent_type,
-                            code = ?e.code(),
-                            ownership = ?e.ownership(),
-                            "Agent send_message returned error without runtime terminal; injecting fallback stream error"
-                        );
-                        let _ = send_error_tx.send(e);
                     }
+                    warn!(
+                        conversation_id = %conv_id_send,
+                        turn_id = %turn_id_for_send,
+                        ?agent_type,
+                        code = ?e.code(),
+                        ownership = ?e.ownership(),
+                        "Agent send_message returned error; offering fallback stream error to relay"
+                    );
+                    let _ = send_error_tx.send(e);
                 }
             });
 

--- a/crates/aionui-conversation/src/turn_recovery_policy.rs
+++ b/crates/aionui-conversation/src/turn_recovery_policy.rs
@@ -1,0 +1,308 @@
+use aionui_api_types::AgentErrorCode;
+use aionui_common::{AgentKillReason, AgentType};
+use tracing::info;
+
+use crate::runtime_state::RuntimeLifecycleState;
+use crate::stream_relay::RelayOutcome;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionRecoverySignal {
+    CompactFailed,
+    ResumeFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TurnRecoveryDecision {
+    None,
+    AutoReplayOnce {
+        reason: AgentKillReason,
+        safe_to_auto_replay: bool,
+        session_recovery_signal: Option<SessionRecoverySignal>,
+    },
+}
+
+pub struct TurnRecoveryPolicy;
+
+impl TurnRecoveryPolicy {
+    pub fn decide(
+        agent_type: AgentType,
+        backend: Option<&str>,
+        outcome: &RelayOutcome,
+        lifecycle: RuntimeLifecycleState,
+        already_replayed: bool,
+    ) -> TurnRecoveryDecision {
+        let error_code = outcome.terminal.code();
+        let retryable = outcome.terminal.retryable();
+        let safe_to_auto_replay = outcome.attempt.safe_to_auto_replay();
+        let session_recovery_signal = classify_session_recovery_signal(outcome);
+
+        let decision = if lifecycle == RuntimeLifecycleState::Active
+            && agent_type == AgentType::Acp
+            && outcome.terminal.is_error()
+            && retryable == Some(true)
+            && error_code != Some(AgentErrorCode::UserLlmProviderModelNotFound)
+            && safe_to_auto_replay
+            && !already_replayed
+        {
+            TurnRecoveryDecision::AutoReplayOnce {
+                reason: AgentKillReason::AgentErrorRecovery,
+                safe_to_auto_replay,
+                session_recovery_signal: session_recovery_signal.clone(),
+            }
+        } else {
+            TurnRecoveryDecision::None
+        };
+
+        info!(
+            ?agent_type,
+            backend = backend.unwrap_or("unknown"),
+            error_code = ?error_code,
+            retryable = ?retryable,
+            lifecycle = ?lifecycle,
+            already_replayed,
+            safe_to_auto_replay,
+            session_recovery_signal = ?session_recovery_signal,
+            saw_visible_output = outcome.attempt.saw_visible_output,
+            saw_tool_or_side_effect = outcome.attempt.saw_tool_or_side_effect,
+            persisted_assistant_output = outcome.attempt.persisted_assistant_output,
+            decision = ?decision,
+            "conversation turn recovery decision"
+        );
+
+        decision
+    }
+}
+
+fn classify_session_recovery_signal(outcome: &RelayOutcome) -> Option<SessionRecoverySignal> {
+    let data = outcome.attempt.terminal_error.as_ref()?;
+    let haystack = format!("{}\n{}", data.message, data.detail.as_deref().unwrap_or_default()).to_ascii_lowercase();
+
+    if haystack.contains("/responses/compact") || haystack.contains("remote compact failed") {
+        return Some(SessionRecoverySignal::CompactFailed);
+    }
+    if haystack.contains("session/load") || haystack.contains("resume") {
+        return Some(SessionRecoverySignal::ResumeFailed);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use aionui_api_types::{AgentErrorCode, AgentErrorOwnership, AgentStreamErrorData};
+    use aionui_common::{AgentKillReason, AgentType};
+
+    use super::*;
+    use crate::runtime_state::RuntimeLifecycleState;
+    use crate::stream_relay::{RelayOutcome, RelayTerminal, TurnAttemptSummary};
+
+    fn retryable_clean_error() -> RelayOutcome {
+        RelayOutcome {
+            terminal: RelayTerminal::Error {
+                code: Some(AgentErrorCode::UnknownUpstreamError),
+                retryable: Some(true),
+            },
+            attempt: TurnAttemptSummary::default(),
+            ..RelayOutcome::default()
+        }
+    }
+
+    #[test]
+    fn retryable_clean_acp_error_auto_replays_once() {
+        let outcome = retryable_clean_error();
+
+        let decision = TurnRecoveryPolicy::decide(
+            AgentType::Acp,
+            Some("codex"),
+            &outcome,
+            RuntimeLifecycleState::Active,
+            false,
+        );
+
+        assert_eq!(
+            decision,
+            TurnRecoveryDecision::AutoReplayOnce {
+                reason: AgentKillReason::AgentErrorRecovery,
+                safe_to_auto_replay: true,
+                session_recovery_signal: None,
+            }
+        );
+    }
+
+    #[test]
+    fn compact_error_records_session_recovery_signal_without_fresh_session() {
+        let mut outcome = retryable_clean_error();
+        outcome.attempt.terminal_error = Some(AgentStreamErrorData::classified(
+            "The model provider could not be reached",
+            AgentErrorCode::UserLlmProviderNetworkError,
+            AgentErrorOwnership::UserLlmProvider,
+            Some("remote compact failed: error sending request for url (https://chatgpt.com/backend-api/codex/responses/compact)".into()),
+            true,
+            false,
+            None,
+        ));
+
+        let decision = TurnRecoveryPolicy::decide(
+            AgentType::Acp,
+            Some("codex"),
+            &outcome,
+            RuntimeLifecycleState::Active,
+            false,
+        );
+
+        assert_eq!(
+            decision,
+            TurnRecoveryDecision::AutoReplayOnce {
+                reason: AgentKillReason::AgentErrorRecovery,
+                safe_to_auto_replay: true,
+                session_recovery_signal: Some(SessionRecoverySignal::CompactFailed),
+            }
+        );
+    }
+
+    #[test]
+    fn session_load_error_records_resume_failed_signal() {
+        let mut outcome = retryable_clean_error();
+        outcome.attempt.terminal_error = Some(AgentStreamErrorData::classified(
+            "The Agent session could not be resumed",
+            AgentErrorCode::UserAgentSessionNotFound,
+            AgentErrorOwnership::UserAgent,
+            Some("session/load failed while resuming previous ACP session".into()),
+            true,
+            false,
+            None,
+        ));
+
+        let decision = TurnRecoveryPolicy::decide(
+            AgentType::Acp,
+            Some("codex"),
+            &outcome,
+            RuntimeLifecycleState::Active,
+            false,
+        );
+
+        assert_eq!(
+            decision,
+            TurnRecoveryDecision::AutoReplayOnce {
+                reason: AgentKillReason::AgentErrorRecovery,
+                safe_to_auto_replay: true,
+                session_recovery_signal: Some(SessionRecoverySignal::ResumeFailed),
+            }
+        );
+    }
+
+    #[test]
+    fn already_replayed_error_does_not_replay_again() {
+        let outcome = retryable_clean_error();
+
+        let decision = TurnRecoveryPolicy::decide(
+            AgentType::Acp,
+            Some("codex"),
+            &outcome,
+            RuntimeLifecycleState::Active,
+            true,
+        );
+
+        assert_eq!(decision, TurnRecoveryDecision::None);
+    }
+
+    #[test]
+    fn visible_output_blocks_auto_replay() {
+        let mut outcome = retryable_clean_error();
+        outcome.attempt.saw_visible_output = true;
+
+        let decision = TurnRecoveryPolicy::decide(
+            AgentType::Acp,
+            Some("codex"),
+            &outcome,
+            RuntimeLifecycleState::Active,
+            false,
+        );
+
+        assert_eq!(decision, TurnRecoveryDecision::None);
+    }
+
+    #[test]
+    fn tool_side_effect_blocks_auto_replay() {
+        let mut outcome = retryable_clean_error();
+        outcome.attempt.saw_tool_or_side_effect = true;
+
+        let decision = TurnRecoveryPolicy::decide(
+            AgentType::Acp,
+            Some("codex"),
+            &outcome,
+            RuntimeLifecycleState::Active,
+            false,
+        );
+
+        assert_eq!(decision, TurnRecoveryDecision::None);
+    }
+
+    #[test]
+    fn non_retryable_error_does_not_auto_replay() {
+        let outcome = RelayOutcome {
+            terminal: RelayTerminal::Error {
+                code: Some(AgentErrorCode::UserLlmProviderAuthFailed),
+                retryable: Some(false),
+            },
+            attempt: TurnAttemptSummary::default(),
+            ..RelayOutcome::default()
+        };
+
+        let decision = TurnRecoveryPolicy::decide(
+            AgentType::Acp,
+            Some("codex"),
+            &outcome,
+            RuntimeLifecycleState::Active,
+            false,
+        );
+
+        assert_eq!(decision, TurnRecoveryDecision::None);
+    }
+
+    #[test]
+    fn model_not_found_does_not_auto_replay_even_if_retryable() {
+        let outcome = RelayOutcome {
+            terminal: RelayTerminal::Error {
+                code: Some(AgentErrorCode::UserLlmProviderModelNotFound),
+                retryable: Some(true),
+            },
+            attempt: TurnAttemptSummary::default(),
+            ..RelayOutcome::default()
+        };
+
+        let decision = TurnRecoveryPolicy::decide(
+            AgentType::Acp,
+            Some("codex"),
+            &outcome,
+            RuntimeLifecycleState::Active,
+            false,
+        );
+
+        assert_eq!(decision, TurnRecoveryDecision::None);
+    }
+
+    #[test]
+    fn non_active_lifecycle_does_not_auto_replay() {
+        let outcome = retryable_clean_error();
+
+        let decision = TurnRecoveryPolicy::decide(
+            AgentType::Acp,
+            Some("codex"),
+            &outcome,
+            RuntimeLifecycleState::Deleting,
+            false,
+        );
+
+        assert_eq!(decision, TurnRecoveryDecision::None);
+    }
+
+    #[test]
+    fn non_acp_agent_does_not_auto_replay() {
+        let outcome = retryable_clean_error();
+
+        let decision =
+            TurnRecoveryPolicy::decide(AgentType::Aionrs, None, &outcome, RuntimeLifecycleState::Active, false);
+
+        assert_eq!(decision, TurnRecoveryDecision::None);
+    }
+}

--- a/crates/aionui-team/src/team_run.rs
+++ b/crates/aionui-team/src/team_run.rs
@@ -3264,6 +3264,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn completed_child_after_internal_conversation_replay_does_not_emit_failed_run() {
+        let (manager, bc) = manager();
+        let ack = manager
+            .accept_user_message("lead", TeamRunTargetRole::Lead, false, Some("msg-user".into()))
+            .await
+            .unwrap();
+        manager
+            .record_pending_wake("lead", TeamRunTargetRole::Lead, TeamWakeSource::UserMessage)
+            .await
+            .unwrap();
+        let reservation = manager
+            .claim_wake_for_turn("lead", TeamRunTargetRole::Lead, "conv-lead")
+            .await
+            .unwrap();
+        assert_eq!(
+            manager
+                .record_child_started(
+                    &reservation.reservation_id,
+                    ActiveChildTurn {
+                        team_run_id: ack.team_run_id,
+                        slot_id: "lead".into(),
+                        role: TeamRunTargetRole::Lead,
+                        conversation_id: "conv-lead".into(),
+                        turn_id: "turn-replayed-in-conversation".into(),
+                        started_at_ms: now_ms(),
+                        last_slow_notified_at_ms: None,
+                    },
+                )
+                .await,
+            ChildStartDecision::Accepted
+        );
+
+        let completed = manager
+            .record_child_completed("lead", "turn-replayed-in-conversation", TeamRunStatus::Completed)
+            .await
+            .expect("run should complete after conversation reports final completed outcome");
+
+        assert_eq!(completed.status, TeamRunStatus::Completed);
+        let names = bc.names();
+        assert!(names.contains(&TEAM_RUN_COMPLETED_EVENT.to_owned()));
+        assert!(
+            !names.contains(&TEAM_RUN_FAILED_EVENT.to_owned()),
+            "internal conversation replay must not surface as an intermediate team_run failed event"
+        );
+    }
+
+    #[tokio::test]
     async fn child_start_failed_releases_reservation_and_fails_run() {
         let (manager, bc) = manager();
         manager


### PR DESCRIPTION
## Summary
- Add ACP turn recovery policy support to automatically replay safe retryable turns once after upstream agent/process failures.
- Evict unhealthy ACP tasks after recoverable terminal errors so later stop/cancel/send flows bind to a fresh runtime instead of a dead task.
- Keep team child-turn status handling transparent across recovered replays and cover recovery safety boundaries with focused tests.

## Test Plan
- [x] `just push -u origin feat/agent-turn-recoverable-error` (migration immutability, cargo fix/fmt, clippy, and `cargo nextest run --workspace`: 6379 passed, 18 skipped)
- [x] Local AionUi Dev solo smoke for Claude, Codex, and OpenCode: kill ACP child process immediately after sending; subsequent stop/cancel/send remains usable
- [x] Local AionUi Dev team smoke: kill ACP child process during a team turn; child turn auto-recovers and the team run completes
