### PR TITLE
chore(skills): sync builtin officecli skills from upstream OfficeCli (c764bb7d)

### DIFF
--- a/crates/aionui-app/assets/builtin-skills/morph-ppt/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/morph-ppt/SKILL.md
@@ -40,12 +40,13 @@ Verify with `officecli --version` (open a new terminal if PATH hasn't picked up)
 
 ```bash
 officecli help pptx slide           # authoritative for: transition, advanceTime, advanceClick, background
+officecli help pptx transition      # transition / transitionDuration / transitionSpeed (Parent: slide)
 officecli help pptx shape           # name, preset, x/y/width/height, fill, rotation, opacity, animation
 officecli help pptx animation       # preset + trigger + duration values
 officecli help pptx <element> --json  # machine-readable schema
 ```
 
-Help reflects the installed CLI version. When skill and help disagree, **help wins.** Every `--prop X=` in this file is grep-verified against `officecli help pptx <element>`. Specific confirmations: `transition=morph` is a listed value on `slide`; `advanceTime` / `advanceClick` are valid. **There is NO standalone `transition` element** — `officecli help pptx transition` returns error. Sub-props such as `duration` / `delay` / `easing` for the transition itself are **not exposed on `slide`** — see §Known Issues for the raw-set path if you need them.
+Help reflects the installed CLI version. When skill and help disagree, **help wins.** Every `--prop X=` in this file is grep-verified against `officecli help pptx <element>`. Specific confirmations: `transition=morph` is a listed value on `slide`; `advanceTime` / `advanceClick` are valid. `transition` is a real element (`officecli help pptx transition`, Parent: slide, set/get) — it exposes `transition`, `transitionDuration`, and `transitionSpeed`. Set the transition with the high-level path `set <slide> --prop transition=morph`; tune speed/duration with the combined shorthand `transition=morph-slow` (or `-fast`, or `transition=morph-<DUR_MS>`). Speed/duration are set only via that shorthand on the `transition` prop, not as independent sub-props. Both round-trip on readback: `transition=morph-slow`/`-fast` reads back as `transitionSpeed=slow`/`fast`, and `transition=morph-<DUR_MS>` (e.g. `morph-1500`) reads back as `transitionDuration=1500`.
 
 ## Mental Model & Inheritance
 
@@ -69,7 +70,7 @@ Help reflects the installed CLI version. When skill and help disagree, **help wi
 - **Cross-slide shape-name binding.** PowerPoint's Morph engine pairs shapes by **identical `name=`** across adjacent slides and interpolates their position / size / rotation / fill / opacity. No matching name ⇒ no animation, silent fade. This is a workflow discipline, not a CLI feature.
 - **Namespace prefixes:** `!!scene-*` (persistent decoration, never ghosted) / `!!actor-*` (content that evolves then exits) / `#sN-*` (per-slide content, ghosted on slide N+1). Plan the names BEFORE you `add`.
 - **Ghost position `x=36cm`** (off the right edge of the 33.87cm canvas). Never delete a `!!`-prefixed shape — move it off-canvas so the morph exit animation still plays.
-- **`transition=morph` auto-prefix quirk.** The CLI auto-prepends `!!` to every shape on a morph slide, which silently breaks `@name=` path selectors. Use `/slide[N]/shape[K]` index paths after morph is set. See §Known Issues.
+- **`transition=morph` auto-prefix quirk.** The CLI auto-prepends `!!` to every shape on a morph slide (`#s1-title` is stored as `!!#s1-title`). `@name=` path selectors **still resolve** — `get .../shape[@name=#s1-title]` returns the shape (matching is suffix/prefix-tolerant). The name you read back is the prefixed form. See §Known Issues.
 - **Adjacent-slide spatial variety.** Displacement ≥ 5cm or rotation ≥ 15° between pairs — otherwise morph interpolates nothing visible.
 - **Renderer reality.** Morph renders in PowerPoint 365 / Keynote / WPS. LibreOffice and many web viewers render as plain fade (runtime feature). Not a skill defect — `[RENDERER-BUG]`.
 
@@ -87,7 +88,7 @@ Stay in **pptx v2 base** for any deck without cross-slide motion (board reviews,
 - **`$` in prop text — single-quote (price tokens).** `--prop text='$9/mo'` and `--prop text='$199/yr'` — NEVER `--prop text="$9/mo"` (zsh/bash eat `$9` as empty var → text rendered as `.` / stray period). Same for `${VAR}`, `$USER`, `\n`, `\r`, `\t` inside a double-quoted prop. Gate 2 morph addendum below greps for the leak signature.
 - **`#` in shell values — safe, but quote anyway.** `#` is a comment leader only at the start of a shell word. `--prop name=#s1-title` works, but `--prop 'name=#s1-title'` is the habit that stops you guessing.
 - **Batch heredoc is the cleanest path for multi-shape slides.** `<<'EOF' | officecli batch $FILE` disables all shell expansion — safe for `$`, `!!`, `#`, `'` inside the JSON body.
-- **`--json` responses wrap the payload in `.data.*`.** `query` returns `.data.results[]` (array of matches); `get` returns `.data.children[]` (direct content); `format` always sits at `.data.results[].format.X` / `.data.children[].format.X`. Always prefix jq paths with `.data.` — bare `.children[]` or `.results[]` returns null silently.
+- **`--json` responses wrap the payload in `.data.results[]`.** Both `query` and `get` return a `.data.results[]` array. A single node's `format` sits at `.data.results[0].format.X`; that node's children sit at `.data.results[0].children[]` (each child's format at `.data.results[0].children[].format.X`). Always go through `.data.results[0]` — bare `.data.children[]` or `.data.format` returns null silently.
 - **Variable:** `FILE="deck.pptx"` at the top of every build script; every example below uses `$FILE`.
 - **Gate shell pattern — COUNT, then if/else.** Never write `grep … && echo LEAK || echo OK` — when grep exits 1 (0 matches), the `||` branch fires with empty stdout and prints "OK" confusingly (or prints "LEAK" from prior pipes). Canonical form: `COUNT=$(cmd | wc -l); if [ "$COUNT" -gt 0 ]; then echo "LEAK: …"; else echo "OK"; fi`.
 
@@ -123,7 +124,7 @@ Morph only runs if slide N+1 carries `transition=morph`. Apply it via `officecli
 
 **Hard rule:** `!!scene-*` and `!!actor-*` names must NEVER collide (e.g., `!!scene-card` + `!!actor-card` in the same deck — morph engine confuses them). Disambiguate: `!!scene-card-bg` vs `!!actor-card-content`.
 
-**Charts are opaque to morph.** `officecli add … --type chart` does NOT accept `--prop name=!!…` (returns `UNSUPPORTED props: name`), so a chart cannot participate in shape-name morph pairing. For bar-grow / line-grow narratives: (a) accept plain fade-in of the chart as-is, OR (b) build N `!!actor-bar-K` rectangles manually sized to the values and morph those — each rect carries the same `!!actor-bar-K` name across adjacent slides while width / height / fill evolves.
+**Charts can be morph-paired.** `officecli add … --type chart` accepts `--prop name=!!…` (the name reads back), so a chart with an identical `!!`-name on adjacent slides participates in shape-name morph pairing — the chart frame interpolates position / size. Note morph cannot interpolate the *plotted data* inside the chart frame. For bar-grow / line-grow narratives where the bars themselves must animate: (a) accept plain fade-in of the chart as-is, OR (b) build N `!!actor-bar-K` rectangles manually sized to the values and morph those — each rect carries the same `!!actor-bar-K` name across adjacent slides while width / height / fill evolves.
 
 **Ghost accumulation is silent.** Once a `!!`-prefixed shape appears on any slide, it stays visible on every subsequent morph slide unless explicitly moved to `x=36cm`. `final-check` helper does NOT detect `!!` shapes lingering in the visible area — **only Gate 5b screenshot audit does.** Plan every actor's exit slide in the pair table BEFORE coding.
 
@@ -215,13 +216,14 @@ officecli add "$FILE" /slide[2] --type shape --prop 'name=!!scene-ring' --prop p
   --prop fill=E94560 --prop opacity=0.6 --prop x=20cm --prop y=2cm --prop width=12cm --prop height=12cm
 officecli add "$FILE" /slide[2] --type shape --prop 'name=!!scene-dot' --prop preset=ellipse \
   --prop fill=0F3460 --prop x=3cm --prop y=16cm --prop width=1.5cm --prop height=1.5cm
-# Ghost slide-1 content
-officecli set "$FILE" "/slide[2]/shape[@name=#s1-title]" --prop x=36cm 2>/dev/null || true  # name path may fail after morph — see Known Issues
+# Ghost slide-1 content (name path still resolves after morph — see Known Issues)
+officecli set "$FILE" "/slide[2]/shape[@name=#s1-title]" --prop x=36cm 2>/dev/null || true
 
 # Verify morph pair: identical names on slides 1 & 2
-officecli get "$FILE" /slide[1] --depth 1 --json | jq -r '.data.children[]?.format.name // empty'
-officecli get "$FILE" /slide[2] --depth 1 --json | jq -r '.data.children[]?.format.name // empty'
+officecli get "$FILE" /slide[1] --depth 1 --json | jq -r '.data.results[0].children[]?.format.name // empty'
+officecli get "$FILE" /slide[2] --depth 1 --json | jq -r '.data.results[0].children[]?.format.name // empty'
 # Compare — `!!scene-ring` and `!!scene-dot` MUST appear on both, byte-identical.
+# Note: morph stores names with a `!!` prefix; compare the prefixed forms.
 ```
 
 ### (c) Continuous multi-slide morph (story arc) — use helpers
@@ -241,9 +243,11 @@ def helper(*args):
 
 # ... assume slide 1 is built with 2 scene actors (!!scene-ring, !!scene-dot) + #s1-title
 # Helper builds slide 2–5 with: clone from previous + apply transition=morph + ghost previous #sN- content
+# `clone` prints the cloned slide's shape list — read it to pick which shape indices carry the
+# previous slide's #s(n-1)- content, then pass those explicit indices to `ghost`.
 for n in range(2, 6):
-    helper("clone", FILE, n - 1, n)          # clone + set transition=morph + list shapes
-    helper("ghost", FILE, n, "all-content")  # ghost all #s(n-1)-* via duplicate-text detection
+    helper("clone", FILE, n - 1, n)          # clone + set transition=morph + list shapes (note the #s(n-1)- indices)
+    helper("ghost", FILE, n, 1, 2)           # ghost the #s(n-1)- content shapes by index (here shapes 1 & 2)
     # …then add THIS slide's #sN- content via officecli add as normal…
 helper("final-check", FILE)                   # structural pass; DOES NOT catch !! lingering in visible area
 ```
@@ -264,7 +268,7 @@ officecli add "$FILE" /slide[2] --type shape --prop 'name=#s2-card' --prop prese
 # Apply simultaneous-with-morph fade entrance to the new card.
 # 'fade-entrance-300-with' = fade in, 300ms, trigger=withPrevious (plays with the morph transition).
 officecli set "$FILE" "/slide[2]/shape[@name=#s2-card]" --prop animation=fade-entrance-300-with
-officecli get "$FILE" "/slide[2]/shape[@name=#s2-card]" --json | jq '.data.format.animation'  # readback sanity
+officecli get "$FILE" "/slide[2]/shape[@name=#s2-card]" --json | jq '.data.results[0].format.animation'  # readback sanity — drops the trigger suffix, reads back as "fade-entrance-300"
 ```
 
 **Why this works.** Morph animates the `!!scene-*` shapes only (they have a pair on slide 1); the new `#s2-card` has no slide-1 counterpart, so morph would default-fade it — `fade-entrance-300-with` makes that fade explicit and timed. Keep the animation per pptx v2 floor: ≤ 600ms, no bounce / swivel / fly-from-edge (`officecli help pptx animation` for the canonical preset list).
@@ -321,7 +325,7 @@ Off-canvas (ghost): x ≥ 33.87cm  (canvas right edge; use x=36cm for explicit g
 
 ```bash
 officecli get "$FILE" "/slide[$N]" --depth 1 --json | \
-  jq -r '.data.children[]? | "\(.format.name // .path)  x=\(.format.x) y=\(.format.y) w=\(.format.width) h=\(.format.height)"'
+  jq -r '.data.results[0].children[]? | "\(.format.name // .path)  x=\(.format.x) y=\(.format.y) w=\(.format.width) h=\(.format.height)"'
 ```
 
 Confirm the actor's target position does not overlap any `#sN-*` content shape's bounding box (`x` to `x + width`, `y` to `y + height`). If it would overlap, lower actor `opacity` ≤ 0.15 OR move it to a safe zone.
@@ -369,7 +373,7 @@ Run `officecli view "$FILE" html` and Read the returned HTML path. For every sli
   NSLIDES=$(officecli query "$FILE" slide --json | jq '.data.results | length')
   for N in $(seq 1 $NSLIDES); do
     officecli get "$FILE" "/slide[$N]" --depth 1 --json | \
-      jq -r --arg n "$N" '.data.children[]? |
+      jq -r --arg n "$N" '.data.results[0].children[]? |
         select(.format.name? // "" | startswith("!!actor-")) |
         select((.format.x // "0cm" | rtrimstr("cm") | tonumber) < 33.87) |
         "slide \($n) leak: \(.format.name) stuck at x=\(.format.x)"'
@@ -381,22 +385,22 @@ Run `officecli view "$FILE" html` and Read the returned HTML path. For every sli
   ```bash
   for K in 1 2 3 4; do
     A=$(officecli get "$FILE" "/slide[$K]" --depth 1 --json | \
-      jq -r '.data.children[]? | select(.format.name? // "" | startswith("!!")) |
+      jq -r '.data.results[0].children[]? | select(.format.name? // "" | startswith("!!")) |
         "\(.format.name)|\(.format.x)|\(.format.y)|\(.format.width)|\(.format.height)|\(.format.rotation // 0)"')
     B=$(officecli get "$FILE" "/slide[$((K+1))]" --depth 1 --json | \
-      jq -r '.data.children[]? | select(.format.name? // "" | startswith("!!")) |
+      jq -r '.data.results[0].children[]? | select(.format.name? // "" | startswith("!!")) |
         "\(.format.name)|\(.format.x)|\(.format.y)|\(.format.width)|\(.format.height)|\(.format.rotation // 0)"')
     VARIES=$(diff <(echo "$A") <(echo "$B") | grep -c '^[<>]')
     if [ "$VARIES" -lt 6 ]; then echo "pair $K→$((K+1)) FLAT: only $VARIES diff-lines (need ≥ 6 = 3 shapes × 2 sides)"; fi
   done
   ```
 
-- **5b-morph-3 — Morph-pair name mismatches.** Adjacent slides must share at least 2 `!!`-prefixed names exactly. Proof (note: `.data.children[]` — bare `.children[]` returns null):
+- **5b-morph-3 — Morph-pair name mismatches.** Adjacent slides must share at least 2 `!!`-prefixed names exactly. Proof (note: children live at `.data.results[0].children[]` — bare `.data.children[]` returns null):
   ```bash
   for N in 1 2 3 4 5; do
     echo "--- slide $N ---"
     officecli get "$FILE" "/slide[$N]" --depth 1 --json | \
-      jq -r '.data.children[]? | select(.format.name? // "" | startswith("!!")) | .format.name'
+      jq -r '.data.results[0].children[]? | select(.format.name? // "" | startswith("!!")) | .format.name'
   done
   ```
   Visually compare sequential blocks — shared `!!` names between N and N+1 are the morph pairs. Zero overlap = the pair is a plain fade.
@@ -407,7 +411,7 @@ Run `officecli view "$FILE" html` and Read the returned HTML path. For every sli
   for N in $(seq 2 $NSLIDES); do
     PREV=$((N-1))
     officecli get "$FILE" "/slide[$N]" --depth 1 --json | \
-      jq -r --arg n "$N" --arg p "$PREV" '.data.children[]? |
+      jq -r --arg n "$N" --arg p "$PREV" '.data.results[0].children[]? |
         select(.format.name? // "" | startswith("#s\($p)-")) |
         select((.format.x // "0cm" | rtrimstr("cm") | tonumber) < 33.87) |
         "slide \($n) leak: \(.format.name) stuck at x=\(.format.x)"'
@@ -483,14 +487,14 @@ Base pptx pitfalls (shell quoting, zsh `[N]` globbing, hex `#` prefix, `\n` in p
 | Placing `!!actor-*` into the content core without planning an exit | Every `!!actor-*` needs a ghost slide. Plan it in the pair table BEFORE coding |
 | **Ghost accumulation (M-2): forgetting to re-ghost `!!actor-*` on later slides** | **CRITICAL:** When you add new content to slide N+1, ALL `!!actor-*` from slide N that should not be visible must be moved to `x=36cm` again. Do NOT assume they stay off-screen once ghosted — each slide is independent. Build pattern: `for each new slide: add content shapes → then loop: set each active !!actor-* to x=36cm`. `morph-helpers.py final-check` will REJECT if ghost count exceeds 50. |
 | Forgetting `transition=morph` on a slide | Silent fade. Gate 5b-morph-2 (no motion) catches it; fix via `set /slide[N] --prop transition=morph` |
-| Using `@name=` path on a morph slide after `transition=morph` was set | Selector breaks (M-1). Switch to index paths `/slide[N]/shape[K]` |
+| Assuming `@name=` paths break on a morph slide | They do not — `@name=` still resolves after `transition=morph` (M-1); only the *readback* name gains a `!!` prefix |
 | Adjacent slides visually identical | Morph has nothing to interpolate — collapses to plain fade. Apply §Scene-actor spatial rule and move ≥ 3 shapes by ≥ 5cm / ≥ 15° |
 | Trying to stagger 2 shapes via per-shape timing | Not supported — split the pair into two transitions with an intermediate keyframe slide |
 | Testing morph motion in LibreOffice or a browser | `[RENDERER-BUG]`, not skill defect. Test in PowerPoint 365 / Keynote / WPS |
 | Deleting a `!!` shape on exit instead of ghosting it | Deletion breaks morph pairing — the shape vanishes without animation. Always ghost to `x=36cm` |
 | Writing `--prop text="$9/mo"` with double quotes | Shell eats `$9` as empty variable → text stored as `/mo` or stray `.`. Use single quotes: `--prop text='$9/mo'`. Gate 2 morph addendum greps this leak. |
 | Using `<a:br/>` literal inside `--prop text='line1<a:br/>line2'` | Stored as 7 literal characters, not a line break. Use `officecli add "/slide[N]/shape[@id=K]" --type paragraph` once per line (M-6). |
-| Using `shape[name^=!!actor-]` selector | `officecli query` has no `^=` operator — returns `invalid_selector`. Use `get /slide[N] --depth 1 --json \| jq '.data.children[]? \| select(.format.name \| startswith("!!actor-"))'`. |
+| Using `shape[name^=!!actor-]` selector | `officecli query` has no `^=` operator — returns `invalid_selector`. Use `get /slide[N] --depth 1 --json \| jq '.data.results[0].children[]? \| select(.format.name \| startswith("!!actor-"))'`. |
 | Running `validate` while resident mode is open | Pptx v2 inherits this trap — `officecli close "$FILE"` BEFORE `validate` |
 
 ## Known Issues & Pitfalls
@@ -501,14 +505,14 @@ Base pptx bugs C-P-1..7 (hyperlink rPr, chart ChartShapeProperties warning, anim
 
 | # | Symptom | Workaround |
 |---|---|---|
-| **M-1** | After `officecli set '/slide[N]' --prop transition=morph`, every shape on that slide has `!!` auto-prepended to its name (`#s1-title` → `!!#s1-title`). Name-path selectors like `/slide[N]/shape[@name=#s1-title]` stop matching silently. **Selector filter caveat:** after auto-prefix, `!!#sN-caption` coexists alongside `!!actor-*` — filtering "scene actors" with `startswith("!!")` produces false matches on auto-prefixed content. Always filter with `startswith("!!actor-")` or `startswith("!!scene-")`, never bare `startswith("!!")`. | Use **index paths** after morph is set: `get /slide[N] --depth 1` to list shapes, then address via `/slide[N]/shape[K]`. Keep a shape-index comment at the top of the build script. |
+| **M-1** | After `officecli set '/slide[N]' --prop transition=morph`, every shape on that slide has `!!` auto-prepended to its name (`#s1-title` → `!!#s1-title`). The readback name is the prefixed form. **Selector filter caveat:** after auto-prefix, `!!#sN-caption` coexists alongside `!!actor-*` — filtering "scene actors" in `jq` with `startswith("!!")` produces false matches on auto-prefixed content. Always filter with `startswith("!!actor-")` or `startswith("!!scene-")`, never bare `startswith("!!")`. | `@name=` path selectors **still resolve** — `/slide[N]/shape[@name=#s1-title]` returns the shape (matching is suffix/prefix-tolerant), so no path rewrite is needed. When you need the prefixed name in a jq filter, account for the leading `!!`. |
 | **M-2 🚨** | **Ghost accumulation — `!!actor-*` introduced on slide 3 stays visible on slides 4, 5, 6 unless EXPLICITLY ghosted every page.** `final-check` helper detects this and rejects if ghost count > 50. | **MANDATORY per-slide rule:** After you add new content to a slide, immediately set ALL active `!!actor-*` from previous slides to `x=36cm` (or explicitly position them visible if they belong in the current context). Example: `officecli set /slide[4]/shape[@name=!!actor-ring] --prop x=36cm`. Run after EVERY slide addition, not just at the end. See §Ghost Discipline & Actor Lifecycle below. |
 | **M-3** | Section-transition boundary — on the first slide of a new topic section, previous-section `!!actor-*` shapes visibly linger. No command errors; only visual clutter. | On every section-start slide, explicitly ghost ALL `!!actor-*` from the previous section to `x=36cm`. Scene shapes (`!!scene-*`) stay. |
-| **M-4** | `officecli help pptx slide` lists `transition=` but NO sub-props for duration / delay / easing of the transition itself. Agents sometimes invent `morph.duration=` / `transition.delay=` — they are rejected as UNSUPPORTED. | Accept defaults (morph ~1s, linear ease). For custom speed, use `raw-set` to add the `spd` attribute on `<p:transition>` — see M-4 example block below. Help does not list sub-props; `raw-set` is the only path. |
+| **M-4** | Agents sometimes invent `morph.duration=` / `transition.delay=` as independent props — they are rejected as UNSUPPORTED. | Use the combined shorthand on the `transition` prop: `transition=morph-slow` / `-fast`, or `transition=morph-<DUR_MS>` (e.g. `transition=morph-1500`). Both round-trip on readback (`transitionSpeed=slow`, `transitionDuration=1500`). Only beyond what the shorthand exposes (fine control of the raw XML), fall back to `raw-set` on `<p:transition>` — see M-4 example block below. |
 | **M-5** | `[RENDERER-BUG]` LibreOffice / Google Slides web viewer render morph slides as plain fade (no interpolation). | Test in PowerPoint 365 / Keynote / WPS. Not a skill defect — do not chase. |
 | **M-6** | `<a:br/>` written inside `--prop text='line1<a:br/>line2'` is stored as the literal 7-character string, NOT interpreted as a line break. Audience sees `line1<a:br/>line2` rendered verbatim. | For multi-line bullets / captions, add one paragraph per line: `officecli add "/slide[N]/shape[@id=K]" --type paragraph --prop text='line1'` then repeat with `text='line2'`. See pptx v2 §Shell escape for the real-newline workflow. |
 
-**M-4 example — slow down all morph transitions** (`raw-set` requires a `<part>` positional arg; `//p:transition` matches both `mc:Choice` and `mc:Fallback` on a morph slide, yielding `2 element(s) affected`):
+**M-4 example — slow down all morph transitions, raw-set fallback** (prefer `transition=morph-slow`; use this only for control beyond the shorthand). Note `//p:transition` matches both `mc:Choice` and `mc:Fallback` on a morph slide, yielding `2 element(s) affected`:
 
 ```bash
 # Per-slide: add spd="slow" to every transition element on slide N (2 XML hits per morph slide)

--- a/crates/aionui-app/assets/builtin-skills/officecli-academic-paper/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/officecli-academic-paper/SKILL.md
@@ -204,7 +204,7 @@ QA: `officecli query "$FILE" 'footnote'` count ≥ body-paragraph citation count
 - Body is **two-column** (see §Multi-column below). Abstract is single-column above the fold, 10pt, 1.15x line spacing, typically 200-250 words.
 - First-line indent on body paragraphs = 0.2" (`firstLineIndent=288` twips ≈ 14pt). Smaller than APA's 0.5" because the 2-col width is narrower.
 - **Section headings: ALL CAPS with Roman numerals** — `I. INTRODUCTION`, `II. RELATED WORK`, `III. METHOD`. Sub-sections `A. Datasets`, `B. Baselines` in title case. Do NOT use `1. Introduction` (Arabic) for IEEE — that is Chicago style.
-- **Tables are numbered Roman**: `Table I`, `Table II`, `Table III`. Figures remain Arabic (`Fig. 1`, `Fig. 2`). The `SEQ Table` field emits Arabic cached values — for IEEE, patch the cached `<w:t>` to Roman manually (see §SEQ cached-value trap), or accept Arabic and note in the cover letter.
+- **Tables are numbered Roman**: `Table I`, `Table II`, `Table III`. Figures remain Arabic (`Fig. 1`, `Fig. 2`). `recalcFields=seq` writes Arabic cached values for both — for IEEE Roman tables, either patch the cached `<w:t>` to Roman manually after recalc, or accept Arabic and note it in the cover letter.
 
 ```bash
 # Body citing reference 1
@@ -250,38 +250,44 @@ If the body prose contains raw `lambda_1`, `x_{t+1}`, `\alpha` or similar plain-
 
 **LaTeX subset pitfalls** (non-negotiable):
 
-1. `\left(...\right)` / `\left[...\right]` + sub/superscript inside → **cast error crash**. Use plain `(`, `)`, `[`, `]` — OMML auto-sizes delimiters in display mode.
-2. `\mathcal{L}` → invalid OMML. Use `\mathit{L}` or plain uppercase letters.
-3. `move` on `/body/oMathPara[N]` does not reliably reposition. Workaround: `add` at target position, `remove` the original.
+1. `\left(...\right)` / `\left[...\right]` with a sub/superscript **inside** the delimiters → parse error (`Error: cast object … Subscript`). An OUTER script (`\left(x+y\right)^2`) is fine; plain `(`, `)`, `[`, `]` always work and OMML auto-sizes them in display mode.
+2. `move` on `/body/oMathPara[N]` reorders the display equation (it repositions the wrapping paragraph). `--before <path>` may leave a stray empty paragraph; prefer `--index` or `--after` for a clean reorder.
 
-**Equation numbering** — no native `\eqno`. Add the display equation, then add a right-aligned paragraph `"(1)"` immediately after with `spaceBefore=0 spaceAfter=6pt`. Separate line, works in 2-col. **Do NOT place `--type equation` directly in a table cell `tc[N]`** — it emits `oMathPara` as a direct `<w:tc>` child (illegal OOXML). Target `tc[N]/p[1]` with `mode=inline` if you need equations in cells.
+**Equation numbering** — no native `\eqno`. The journal-standard layout is **one line**: equation centered, number flush-right at the column edge (`Y = A(X) ⊗ X      (1)`). Build it with two paragraph **tab stops** — a `center` tab at the column mid-point and a `right` tab at the column right edge — then lay out `[tab] equation(inline) [tab] (1)` in a single paragraph. Do NOT use a centered display equation followed by a separate right-aligned `(1)` line — that splits the number onto its own line and is the most common reason agents fail to reproduce the expected look.
+
+```bash
+# Tab positions depend on the COLUMN width (twips). Default blank doc = A4, 3.18cm margins
+#   → text width = 8300 twips.
+#   single column: center tab = 4150, right tab = 8300
+#   two columns (default 720-twip gutter): col = (8300-720)/2 = 3790 → center 1895, right 3790
+# (other page size / margins: text width = pageWidth - marginLeft - marginRight; recompute.)
+officecli add "$FILE" /body --type paragraph                                   # the equation paragraph (say it lands at p[N])
+officecli add "$FILE" "/body/p[N]" --type tab --prop pos=4150 --prop val=center
+officecli add "$FILE" "/body/p[N]" --type tab --prop pos=8300 --prop val=right
+officecli add "$FILE" "/body/p[N]" --type run --prop text=$'\t'                 # tab → jump to center
+officecli add "$FILE" "/body/p[N]" --type equation --prop mode=inline --prop formula='Y = A(X) \otimes X'
+officecli add "$FILE" "/body/p[N]" --type run --prop text=$'\t(1)'             # tab → jump to right edge, then the number
+```
+
+For a two-column section just use the two-column tab positions (1895 / 3790); the same paragraph then centers the equation within its column with `(1)` at the column's right edge. Schema: `officecli help docx tab`.
+
+**Do NOT place `--type equation` directly on a table cell `tc[N]` path** — it is rejected with a guard error (`table cells only accept paragraphs, tables, or SDTs`), so no bad XML is written. Target `tc[N]/p[1]` with `mode=inline` if you need equations in cells.
 
 Full equation schema: `officecli help docx equation`.
 
 ## Figures, tables, and cross-references (SEQ + PAGEREF)
 
-Two primitives, both **native fieldTypes** (verified against `officecli help docx field` v1.0.63): `seq` for auto-numbered caption counters, `pageref` for "see Fig. 2 on page 7" back-references. Native fields insert correctly, but their **cached rendered values** need a one-shot raw-set patch per field (see §SEQ cached-value trap below) — otherwise downstream viewers that don't recompute cached fields will show every figure as "Fig. 1".
+Two primitives, both **native fieldTypes** (`officecli help docx field` for the enum): `seq` for auto-numbered caption counters, `pageref` for "see Fig. 2 on page 7" back-references. Native fields insert with an unevaluated cached result; a single `set "$FILE" / --prop recalcFields=seq` (see §SEQ numbering below) fills the real numbers in document order — no per-field patching.
 
 ### SEQ auto-numbering — figures and tables
 
 A SEQ field is a counter with a name (`identifier`). Every `SEQ Figure` increments the Figure counter on **recalc**; every `SEQ Table` increments the Table counter.
 
-**⚠️ SEQ cached-value trap (verified on v1.0.63).** The CLI emits every SEQ field with cached result `1` — so a document with 3 Figure captions readbacks as `Figure 1 / Figure 1 / Figure 1` via `view text` or `query field[fieldType=seq]`, and any downstream viewer that doesn't recompute cached fields will display the same `Figure 1 / Figure 1 / Figure 1`. Word and WPS recompute on open when `w:updateFields=true` is set in settings. **Two must-do steps per paper with multiple figures/tables:**
-
-1. Flip `updateFields=true` in settings once per document (right after `create`). **Position matters** — OOXML `CT_Settings` schema rejects `<w:updateFields>` as the first child; insert it *before* `<w:compat>`:
-   ```bash
-   officecli raw-set "$FILE" /settings --xpath '//w:compat' --action insertbefore \
-     --xml '<w:updateFields xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" w:val="true"/>'
-   ```
-2. **Patch the cached `<w:t>` after each SEQ field** so the artifact reads correctly in every viewer:
-   ```bash
-   # After adding the Nth SEQ Figure caption, override cached "1" to the real number N:
-   officecli raw-set "$FILE" /document \
-     --xpath "(//w:p[.//w:instrText[contains(text(),'SEQ Figure')]])[N]//w:fldChar[@w:fldCharType='separate']/following::w:t[1]" \
-     --action replace \
-     --xml '<w:t xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xml:space="preserve">N</w:t>'
-   ```
-   Repeat for N = 1, 2, 3, ... for every figure; same pattern with `SEQ Table` for tables. After patching, `officecli view "$FILE" text` will show `Figure 1 / Figure 2 / Figure 3` — and downstream viewers will too.
+**SEQ cached values — one command, after all captions are added.** A freshly-added SEQ field has no evaluated cached number; `view text` shows the `#OCLI_NOTEVAL!{SEQ Figure}` sentinel (and `Format["evaluated"]=false`) until you recalc. **Do NOT patch each field by hand.** Once every figure/table caption is in place, run once:
+```bash
+officecli set "$FILE" / --prop recalcFields=seq
+```
+It counts `SEQ Figure` / `SEQ Table` fields in body document order and writes the real cached values (`Figure 1 / Figure 2 / Figure 3`), flipping `evaluated` true. Re-run it after inserting a caption mid-document so the numbers stay in sync. (Heading-relative `\s` and SEQ inside headers/footers defer to Word's own recompute — see `help docx document`.) Verify: `officecli view "$FILE" text` shows distinct ascending numbers.
 
 ```bash
 # Figure with caption BELOW the image. Caption = "Figure <seq>: title" + optional bookmark for cross-ref.
@@ -293,10 +299,7 @@ officecli add "$FILE" "/body/p[last()]" --type field --prop fieldType=seq --prop
 officecli add "$FILE" "/body/p[last()]" --type run --prop text=": Attention-based anomaly detection model."
 # Bookmark the caption so other paragraphs can PAGEREF it
 officecli add "$FILE" /body --type bookmark --prop name=fig_arch
-# Patch cached value — this is Figure 1 (first SEQ Figure in doc)
-officecli raw-set "$FILE" /document \
-  --xpath "(//w:p[.//w:instrText[contains(text(),'SEQ Figure')]])[1]//w:fldChar[@w:fldCharType='separate']/following::w:t[1]" \
-  --action replace --xml '<w:t xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xml:space="preserve">1</w:t>'
+# (Numbers are filled later by a single `set / --prop recalcFields=seq`, after all captions exist.)
 ```
 
 ### PAGEREF — cross-reference by bookmark
@@ -338,8 +341,8 @@ Live fields carry **cached values** that render stale until a human presses F9 i
 ```bash
 # Footnote anchored to paragraph N
 officecli add "$FILE" "/body/p[3]" --type footnote --prop text="Smith et al. reported similar findings in their 2023 review."
-# Endnote
-officecli add "$FILE" /endnotes --type endnote --prop text="Extended derivation of equation (4) is available at the project repository."
+# Endnote — anchored to paragraph N (like footnote); lands at /endnote[@endnoteId=N]
+officecli add "$FILE" "/body/p[3]" --type endnote --prop text="Extended derivation of equation (4) is available at the project repository."
 ```
 
 Both appear as empty-string runs in `view annotated` output (`r[N] ""`) — the run carries a `<w:footnoteReference>` XML element, not visible text. Confirm insertion with `officecli query "$FILE" 'footnote'` or `officecli get "$FILE" "/footnotes/footnote[N]"`. Footnotes do NOT shift paragraph indices; add them in any order after body content is in place. Full schema: `officecli help docx footnote` / `officecli help docx endnote`.
@@ -382,7 +385,7 @@ officecli add "$FILE" /body --type paragraph --prop text="Abstract" --prop align
 officecli add "$FILE" /body --type paragraph --prop text="We present an attention-based model for detecting anomalies in industrial sensor time series..." --prop size=10pt --prop lineSpacing=1.15x --prop spaceAfter=12pt
 
 # 3. Section break + two-column from here on
-#    CRITICAL: `/section[last()]` is REJECTED on v1.0.63 (cast-error). Count sections first, use explicit /section[N].
+#    `/section[last()]` resolves to the final section (like p[last()]); an explicit /section[N] also works.
 officecli add "$FILE" /body --type section --prop type=continuous
 SECTION_COUNT=$(officecli query "$FILE" section --json | jq '.data.results | length')
 # After the add, SECTION_COUNT should be 2 — [1] is pre-break, [2] is post-break (2-col body area).
@@ -395,7 +398,7 @@ officecli add "$FILE" /body --type paragraph --prop text="Industrial anomaly det
 # 5. At the end of 2-column body, ANOTHER section break + revert to single column for references / appendices
 # (If you want references in 2-col too, skip step 5 — but most IEEE papers use 2-col for references as well.)
 # officecli add "$FILE" /body --type section --prop type=continuous
-# Then re-count and use the new explicit /section[N], NOT /section[last()]:
+# Use /section[last()] for the final section, or re-count for an explicit /section[N]:
 # officecli set "$FILE" "/section[3]" --prop columns=1
 
 # 6. Footer, close, validate
@@ -424,7 +427,7 @@ officecli add "$FILE" "/body/p[last()]" --type run --prop text="2" --prop supers
 officecli add "$FILE" / --type header --prop type=default --prop align=right --prop size=9pt --prop text="Short Running Title"
 ```
 
-**Nature-family 2-col abstract** is rare — if required, open a `section type=continuous columns=2` BEFORE the abstract heading; short abstracts (<100 words) leave ragged columns. **Mirrored odd/even headers** need `<w:evenAndOddHeaders/>` in settings via `raw-set` — not exposed by high-level API on 1.0.63; deliver without mirroring or inject the flag manually. Full header schema: `officecli help docx header`.
+**Nature-family 2-col abstract** is rare — if required, open a `section type=continuous columns=2` BEFORE the abstract heading; short abstracts (<100 words) leave ragged columns. **Mirrored odd/even headers** are exposed by the high-level API: `officecli set "$FILE" /settings --prop evenAndOddHeaders=true`, then add the even header with `--type header --prop type=even`. Full header schema: `officecli help docx header`.
 
 ## QA — Delivery Gate (executable)
 
@@ -459,10 +462,10 @@ if [ "$VISIBLE_FIG" -gt 0 ] && [ "$SEQ_COUNT" -eq 0 ]; then
   echo "REJECT Gate 5a: $VISIBLE_FIG visible Figure/Table labels but 0 SEQ fields."
   exit 1
 fi
-# Cached values must be distinct (CLI emits "1" per field by default → all three would show "Figure 1").
-# After the raw-set patches in §SEQ, view text should show Figure 1 / Figure 2 / Figure 3:
+# Cached values must be distinct. Run `set / --prop recalcFields=seq` once after all captions exist;
+# before recalc the fields render the #OCLI_NOTEVAL! sentinel, after recalc Figure 1 / Figure 2 / Figure 3:
 DISTINCT=$(officecli view "$FILE" text | grep -oE '(Figure|Table) [0-9]+' | sort -u | wc -l)
-[ "$SEQ_COUNT" -le "$DISTINCT" ] && echo "Gate 5a OK (SEQ=$SEQ_COUNT, distinct=$DISTINCT)" || { echo "REJECT Gate 5a: $SEQ_COUNT SEQ fields but only $DISTINCT distinct rendered labels — patch cached <w:t> after each SEQ field"; exit 1; }
+[ "$SEQ_COUNT" -le "$DISTINCT" ] && echo "Gate 5a OK (SEQ=$SEQ_COUNT, distinct=$DISTINCT)" || { echo "REJECT Gate 5a: $SEQ_COUNT SEQ fields but only $DISTINCT distinct rendered labels — run 'set \"$FILE\" / --prop recalcFields=seq'"; exit 1; }
 ```
 
 ### Gate 5b — Visual audit via HTML preview (MANDATORY, not optional)
@@ -494,18 +497,18 @@ Report every instance. If even one defect is present → REJECT; do not deliver 
 
 Academic-specific:
 
-- **`\left(...\right)` / `\left[...\right]` + sub/superscript crashes.** Cast error. Use plain `(`, `)`, `[`, `]` — OMML auto-sizes in display mode.
-- **`\mathcal{L}` emits invalid OMML.** Use `\mathit{L}` or plain uppercase. `\mathbf`, `\mathit`, `\mathbb` work; `\mathcal` does not.
-- **`move` on `/body/oMathPara[N]` not reliable.** Do not rely on `move` to reposition display equations. Workaround: `add` at the target position, `remove` the original.
+- **`\left(...\right)` / `\left[...\right]` with a sub/superscript INSIDE the delimiters → parse error** (`cast object … Subscript`). An outer script (`\left(x+y\right)^2`) is fine. Use plain `(`, `)`, `[`, `]` — OMML auto-sizes in display mode.
+- **`move` on `/body/oMathPara[N]` reorders the equation** (the wrapping paragraph moves). `--before <path>` may leave a stray empty paragraph; prefer `--index` / `--after`.
 - **Section break +1 paragraph offset.** Each `add /body --type section` inserts one empty paragraph into `/body`. All `p[N]` indices after the break shift by +1. Plan breaks; after any `add section`, `officecli get "$FILE" /body --depth 1` to re-index.
-- **`/section[last()]` is REJECTED on v1.0.63** (cast-error, same family as pptx's `/slide[last()]`). Always resolve to an explicit `/section[N]`:
+- **`/section[last()]` resolves to the final section** (mirrors `p[last()]`), for both get and set. An explicit `/section[N]` also works:
   ```bash
   SECTION_COUNT=$(officecli query "$FILE" section --json | jq '.data.results | length')
-  # then use /section[2], /section[3], ..., NEVER /section[last()]
+  # use /section[last()] for the final section, or an explicit /section[2], /section[3], ...
   ```
   Each `add /body --type section` increments the count. Re-query after every break.
 - **Multi-column does NOT auto-revert.** After a `columns=2` section, you must add another section break and explicitly set `columns=1` on the new `/section[N]` (N = post-revert count) — otherwise the rest of the document, including references, renders as two columns. Verify with `officecli get "$FILE" "/section[N]"` for each N.
-- **`--type equation` targeting a `tc[N]` path emits illegal OOXML.** Inside a table cell, target `tc[N]/p[1]` with `--prop mode=inline` instead. Display equations (`oMathPara`) are not legal as direct `<w:tc>` children.
+- **`--type equation` on a `tc[N]` cell path is rejected with a guard error** (`table cells only accept paragraphs, tables, or SDTs`) — no bad XML is written. Inside a table cell, target `tc[N]/p[1]` with `--prop mode=inline` instead.
+- **SEQ caption numbers are filled by `set / --prop recalcFields=seq`** (run once after all captions exist), not by per-field raw-set patching. A pre-recalc SEQ field shows the `#OCLI_NOTEVAL!` sentinel in `view text`.
 - **Hanging-indent canonical form is `indent=720 hangingIndent=720`.** Not `ind.firstLine=-720`. The dotted form emits `<w:ind>` after `<w:jc>` and fails schema on emit.
 - **Footnote reference runs show as empty strings in `view annotated`.** The `<w:footnoteReference>` XML element has no visible text on the reference side; the note body lives in `/footnotes/footnote[N]`. Confirm with `officecli query "$FILE" 'footnote'`, not by eyeballing `view text`.
 - **Caption placement:** Table caption ABOVE the table; Figure caption BELOW the figure. Every major style (APA, Chicago, IEEE, MLA) agrees. Putting a Table caption below the table is an academic-style error, not a rendering issue — `validate` will not catch it.

--- a/crates/aionui-app/assets/builtin-skills/officecli-data-dashboard/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/officecli-data-dashboard/SKILL.md
@@ -43,7 +43,7 @@ officecli help xlsx sparkline                # sparklines
 officecli help xlsx conditionalformatting    # all CF rule types
 ```
 
-Help reflects the installed CLI version. When this skill and help disagree, **help wins**. DeferredAddKeys (`preset`, `referenceline`, `trendline`, `axisNumFmt`, `holesize`, `combosplit`) work on `add` only — see Reference.
+Help reflects the installed CLI version. When this skill and help disagree, **help wins**. DeferredAddKeys (`combosplit`, `holesize`) work on `add` only — see Reference.
 
 ## Mental Model & Inheritance
 
@@ -199,7 +199,7 @@ Options, not templates. The user's data and audience drive the choices.
 | Comparison across categories in time order | `column` | Not `bar` — horizontal bars break left-to-right time reading |
 | Part-of-whole breakdown | `doughnut` | Prefer over `pie`: `chartType=pie` has a known LibreOffice blank-render regression |
 | Budget vs actual | `combo` with `combosplit=1` | First series as bars, rest as lines |
-| Correlation | `scatter` | Uses `series1.xValues`, NOT `series1.categories` |
+| Correlation | `scatter` | X-axis via `categories` / `series1.categories` — `series1.xValues` is UNSUPPORTED |
 
 ### Preset options
 
@@ -211,10 +211,10 @@ Four CF rule types; each uses `--type <shorthand>` at `add` time:
 
 | Intent | `--type` | Typical props |
 |---|---|---|
-| Magnitude bar (sales, spend) | `databar` | `sqref=B2:B13 color=4472C4 min=0 max=<plausible>` — always set explicit `min`/`max`; defaults emit invalid XML |
+| Magnitude bar (sales, spend) | `databar` | `sqref=B2:B13 color=4472C4` — explicit `min=0 max=<plausible>` recommended for predictable scaling, but omitting them is valid (defaults to data min/max) |
 | Heat map (rates, growth) | `colorscale` | `sqref=D2:D13 mincolor=FFCDD2 midcolor=FFFFFF maxcolor=C8E6C9` |
 | Status indicator | `iconset` | `sqref=E2:E13 iconset=3Arrows` — see help for the full enum |
-| Custom business rule | `formulacf` | `sqref=B2:B13 'formula=$B2>=100000' fill=C8E6C9 font.color=2E7D32` — NEVER `font.bold` (schema rejects `<b>`) |
+| Custom business rule | `formulacf` | `sqref=B2:B13 'formula=$B2>=100000' fill=C8E6C9 font.color=2E7D32` — `font.bold` works on CF too |
 
 Semantic colors to stay consistent within a dashboard:
 
@@ -230,7 +230,7 @@ A card is a label cell + a value cell. The label is small gray (font.size=9, fon
 
 At the `dashboard` preset's default title font, the chart plot-box width (in column units) must stay ahead of the title string, or the title clips mid-word. Rule of thumb: `chart.width ≥ ceil(title.length × 0.18)`. A 35-character title ("Department: Year-End Headcount vs Attrition Rate") needs `width ≥ 7`; be safer and use 10–12. If the anchor cannot be widened, shorten the title to ≤ 25 characters — clipped titles in a board-ready deliverable are indefensible.
 
-`officecli get chart[N]` does not expose numeric `width` on 1.0.63 — it returns `.data.format.anchor` (e.g. `"A6:K21"`). Derive column span from letters (A→K = 10 cols) for Gate 2.
+`officecli get chart[N]` exposes numeric `width` (e.g. `width=480pt`) alongside `anchor` (e.g. `"A6:K21"`) at `.data.results[0].format`. Either is usable for Gate 2 — derive column span from anchor letters (A→K = 10 cols) when you need a column-unit budget.
 
 ### Print-ready delivery (board-pack / investor-send / one-pager)
 
@@ -276,9 +276,9 @@ CHART_COUNT=$(officecli query "$FILE" chart --json | jq '.data.results | length'
 col_num () { local c=$1 n=0; for ((k=0;k<${#c};k++)); do n=$((n*26+$(printf '%d' "'${c:$k:1}")-64)); done; echo "$n"; }
 for i in $(seq 1 "$CHART_COUNT"); do
   JSON=$(officecli get "$FILE" "/Dashboard/chart[$i]" --json)
-  SC=$(echo "$JSON" | jq -r '.data.format.seriesCount // 0')
-  TITLE=$(echo "$JSON" | jq -r '.data.format.title // ""')
-  ANCHOR=$(echo "$JSON" | jq -r '.data.format.anchor // ""')
+  SC=$(echo "$JSON" | jq -r '.data.results[0].format.seriesCount // 0')
+  TITLE=$(echo "$JSON" | jq -r '.data.results[0].format.title // ""')
+  ANCHOR=$(echo "$JSON" | jq -r '.data.results[0].format.anchor // ""')
   [ "$SC" = "0" ] || [ -z "$TITLE" ] && { echo "REJECT Gate 2: chart[$i] seriesCount=$SC title='$TITLE'"; exit 1; }
   [ -z "$ANCHOR" ] && continue
   LCOL=$(echo "${ANCHOR%%:*}" | sed 's/[0-9]*$//'); RCOL=$(echo "${ANCHOR##*:}" | sed 's/[0-9]*$//')
@@ -294,7 +294,7 @@ Narrower titles at preset `minimal` / `magazine` may clip earlier than the 0.18 
 
 ```bash
 for i in $(seq 1 "$CHART_COUNT"); do
-  BAD=$(officecli get "$FILE" "/Dashboard/chart[$i]" --json | jq '[.data.children[]? | select(.type == "series") | select((.format.name // "") | test("^Series[0-9]+$"; "i"))] | length')
+  BAD=$(officecli get "$FILE" "/Dashboard/chart[$i]" --json | jq '[.data.results[0].children[]? | select(.type == "series") | select((.format.name // "") | test("^Series[0-9]+$"; "i"))] | length')
   [ "$BAD" -gt 0 ] && { echo "REJECT Gate 3: chart[$i] has $BAD auto-named series"; exit 1; }
 done
 ```
@@ -312,8 +312,8 @@ Note: `query conditionalformatting` is the canonical element name; `query cf` re
 
 ```bash
 DASH_IDX=$(officecli query "$FILE" sheet --json | jq '[.data.results[].path] | index("/Dashboard")')
-ACTIVE=$(officecli get "$FILE" /workbook --json | jq '.data.format.activeTab // -1')
-FULLCALC=$(officecli get "$FILE" /workbook --json | jq -r '.data.format["calc.fullCalcOnLoad"] // false')
+ACTIVE=$(officecli get "$FILE" /workbook --json | jq '.data.results[0].format.activeTab // -1')
+FULLCALC=$(officecli get "$FILE" /workbook --json | jq -r '.data.results[0].format["calc.fullCalcOnLoad"] // false')
 [ "$ACTIVE" != "$DASH_IDX" ] && { echo "REJECT Gate 5: activeTab=$ACTIVE Dashboard=$DASH_IDX"; exit 1; }
 [ "$FULLCALC" != "true" ] && { echo "REJECT Gate 5: calc.fullCalcOnLoad=$FULLCALC — stale caches will ship"; exit 1; }
 ```
@@ -341,8 +341,8 @@ If `view html` is blocked (renderer conflict, headless, port busy), Gate 7 is st
 officecli view "$FILE" text 2>/dev/null | grep -nE '###|\{\{|<TODO>|\$fy\$|xxxx' && { echo "REJECT Gate 7: tokens or ### present"; exit 1; }
 # b) Per-KPI: cachedValue length × coef must fit col width. coef=0.55 fit-to-page, 0.85 otherwise.
 for CELL in A2 C2 E2 G2; do
-  CV=$(officecli get "$FILE" "/Dashboard/$CELL" --json | jq -r '.data.format.cachedValue // .data.text // ""')
-  W=$(officecli get "$FILE" "/Dashboard/col[${CELL%%[0-9]*}]" --json | jq -r '.data.format.width // 0')
+  CV=$(officecli get "$FILE" "/Dashboard/$CELL" --json | jq -r '.data.results[0].format.cachedValue // .data.results[0].text // ""')
+  W=$(officecli get "$FILE" "/Dashboard/col[${CELL%%[0-9]*}]" --json | jq -r '.data.results[0].format.width // 0')
   CAP=$(echo "$W * 0.55" | bc -l | awk '{print int($1)}')
   [ "${#CV}" -gt "$CAP" ] && { echo "REJECT Gate 7: $CELL '$CV' (${#CV} chars) > cap $CAP"; exit 1; }
 done
@@ -356,8 +356,15 @@ If scene keywords include print / 一页 / board / 投资人 / 董事会, extend
 ```bash
 if echo "$USER_REQ" | grep -qiE 'print|一页|投资人|董事会|board'; then
   # Every non-Dashboard sheet must be hidden or veryHidden.
-  LEAKING=$(officecli query "$FILE" 'sheet' --json | jq -r '.data.results[] | select(.name != "Dashboard" and (.state // "visible") == "visible") | .name')
-  [ -n "$LEAKING" ] && { echo "REJECT Gate 7 print-scope: visible non-Dashboard sheet(s): $LEAKING — hide before delivery"; exit 1; }
+  # query sheet --json carries the name in .preview (no .name/.state); visibility lives in
+  # each sheet's own get .format.hidden (absent => visible), so iterate + probe per sheet.
+  LEAKING=""
+  while IFS=$'\t' read -r SPATH SNAME; do
+    [ "$SNAME" = "Dashboard" ] && continue
+    HIDDEN=$(officecli get "$FILE" "$SPATH" --json | jq -r '.data.results[0].format.hidden // false')
+    [ "$HIDDEN" != "true" ] && LEAKING="$LEAKING $SNAME"
+  done < <(officecli query "$FILE" 'sheet' --json | jq -r '.data.results[] | [.path, .preview] | @tsv')
+  [ -n "$LEAKING" ] && { echo "REJECT Gate 7 print-scope: visible non-Dashboard sheet(s):$LEAKING — hide before delivery"; exit 1; }
   # Dashboard must carry an explicit Print_Area named range.
   PA=$(officecli query "$FILE" 'namedrange[name="_xlnm.Print_Area"]' --json | jq '.data.results | length')
   [ "$PA" -ge 1 ] || { echo "REJECT Gate 7 print-scope: no _xlnm.Print_Area set"; exit 1; }
@@ -371,8 +378,8 @@ The user opens the file in their target viewer (Office / WPS / Numbers) for the 
 ```bash
 for CELL in A2 C2 E2 G2; do
   JSON=$(officecli get "$FILE" "/Dashboard/$CELL" --json)
-  [ -z "$(echo "$JSON" | jq -r '.data.format.formula // ""')" ] && continue
-  CV=$(echo "$JSON" | jq -r '.data.format.cachedValue // ""')
+  [ -z "$(echo "$JSON" | jq -r '.data.results[0].format.formula // ""')" ] && continue
+  CV=$(echo "$JSON" | jq -r '.data.results[0].format.cachedValue // ""')
   case "$CV" in
     "" | "0" | "#DIV/0!" | "#REF!" | "#N/A" | "#VALUE!" | "#NAME?" | "null")
       echo "REJECT Gate 8: $CELL cachedValue='$CV' — re-issue formula or close+reopen"; exit 1 ;;
@@ -386,13 +393,13 @@ If anything fails, fix at source, re-run the full cycle.
 
 ### Honest limits
 
-Scatter's `series1.xValues` is not exposed in `get --json` (series `values=""`) — use chart-level `seriesCount`. LibreOffice chart color drift / pie-slice collapse / checkbox double-box are viewer artifacts — spot-check in Office / WPS / Numbers first.
+Scatter charts do not accept `series1.xValues` (UNSUPPORTED) — feed the x-axis via `categories` / `series1.categories`. LibreOffice chart color drift / pie-slice collapse / checkbox double-box are viewer artifacts — spot-check in Office / WPS / Numbers first.
 
 ## Reference
 
 - **Shorthand `--type` at `add`:** `chart`, `sparkline`, `databar`, `colorscale`, `iconset`, `formulacf`. CF rules map to `help xlsx conditionalformatting`; path suffix `/Sheet/cf[N]`.
 - **Full schemas live in help:** `officecli help xlsx chart` / `sparkline` / `conditionalformatting`. This skill does not mirror them.
-- **DeferredAddKeys (add-only, ignored on `set`):** `preset`, `trendline`, `referenceline`, `axisNumFmt`, `combosplit`, `holesize`. See D-1.
+- **DeferredAddKeys (add-only):** `combosplit`, `holesize`. See D-1. (`preset`, `trendline`, `referenceline`, `axisNumFmt` now work on `set` too — help shows `[add/set]`.)
 - **Build order:** charts + sparklines + CF + tabColors first → `calc.fullCalcOnLoad=true` via high-level `set` → `raw-set activeTab` **LAST** (after all sheets exist).
 
 ## Known Issues & Pitfalls
@@ -401,23 +408,23 @@ Scatter's `series1.xValues` is not exposed in `get --json` (series `values=""`) 
 
 | # | Issue | Mitigation |
 |---|---|---|
-| D-1 | `preset`, `referenceline`, `trendline`, `axisNumFmt` are DeferredAddKeys — work on `add` only, silently ignored on `set` | Include them at `add` time. Cannot apply after the fact — remove + re-add. |
+| D-1 | `combosplit` is a DeferredAddKey — works on `add` only. (`preset`, `referenceline`, `trendline`, `axisNumFmt` now apply on `set` too — help shows `[add/set]`.) | Set `combosplit` at `add` time; cannot apply after the fact — remove + re-add. The other four can be applied or changed post-creation via `set`. |
 | D-2 | `referenceline` format is `value:color:label:dash` (color BEFORE label). `"0:Break-Even:FF0000:dash"` fails `Invalid color value`. | Order is value, color, label, dash. |
-| D-3 | Scatter charts use `series1.xValues`, not `series1.categories`. `<cat>` inside `<scatterChart>` is schema-invalid. | `--prop series1.xValues="Sheet1!A2:A13"` |
-| D-4 | `formulacf` rejects `font.bold` (dxf/font schema disallows `<b>`). | Use `fill` + `font.color` only; bold is not available via CF. |
+| D-3 | Scatter charts do NOT accept `series1.xValues` (UNSUPPORTED). Feed the x-axis through `categories` / `series1.categories`. | `--prop series1.categories="Sheet1!A2:A13"` (or `--prop categories="Sheet1!A2:A13"`) |
+| D-4 | `formulacf` honors `font.bold` / `font.italic` (written to the dxf font and surfaced on readback), alongside `fill` and `font.color`. | Use any of `fill` / `font.color` / `font.bold` / `font.italic` to signal a CF rule. |
 | D-5 | Dashboard column widths default to 8.43 — KPI values at 24pt bold show `###` | Size by cachedValue bracket: 4–6 digits → 22–24; 7–9 digits (million) → 26–30; 10+ digits (亿 / billion) → 32–36; 百亿 / 10-digit + currency symbol + fit-to-page landscape → **40–44**. Formula `ceil((visible_chars+2)*1.3)` is a starting point; always verify via Gate 7 fallback b). Sparkline columns: 12. |
 | D-6 | `raw-set activeTab` must be the LAST mutation. Inserting before all sheets exist shifts indices. | Finish all sheets / charts / CF / sparklines / tabColors, then `raw-set`. |
 | D-7 | `calc.fullCalcOnLoad` via `raw-set` creates duplicate `<calcPr>` → validate fails | Use `officecli set "$FILE" / --prop calc.fullCalcOnLoad=true`. |
 | D-8 | LibreOffice does not evaluate hidden-column formulas at render → charts referencing hidden cells render blank | Aggregate into a visible Summary sheet, chart reads from Summary. Hide only columns that are not chart sources. |
-| D-9 | `chartType=pie` blank-renders in LibreOffice (v1.0.x) | Use `doughnut` as the safe substitute for part-of-whole breakdowns. |
+| D-9 | `chartType=pie` blank-renders in LibreOffice | Use `doughnut` as the safe substitute for part-of-whole breakdowns. |
 | D-10 | `SUMIFS` / `AVERAGEIFS` with date criteria fails silently if the criterion is a string | Wrap with `DATE()` or `DATEVALUE()`: `=SUMIFS(B2:B13,A2:A13,DATE(2025,1,5))`. |
 | D-11 | Summary sheet percentage formulas display as raw decimals (0.098) without `numFmt` | Set `numFmt="0.0%"` at the same `set` call as the formula. |
-| D-12 | `import --header` sets freeze + AutoFilter but does NOT set column widths; `numFmt` on a `col[]` path is rejected | Set widths on `col[]`; set `numFmt` on the cell range (`A2:A13`), not the column. |
+| D-12 | `import --header` sets freeze + AutoFilter but does NOT set column widths. | Set widths on `col[]`. `numFmt` on a `col[]` path now applies a column-level style (`<col s=...>`, schema-valid, reads back as `numberformat`); it formats blank cells in the column. Cells with their own style still need a per-cell-range `numFmt`. |
 | D-13 | Sparkline `highpoint` is a bool (highlight on/off), not a color. `--prop highpoint=FF0000` errors `Invalid boolean value` | `--prop highPoint=true --prop highMarkerColor=FF0000`. Same pattern for lowPoint / firstPoint / lastPoint and their *MarkerColor. |
 | D-14 | Sparkline cross-sectional data is meaningless (a region or department has no ordering) | Skip sparklines unless rows are a sequential time-series (dates, months, quarters). |
-| D-15 | 1.0.63+ rejects empty chart `add` (`Chart requires data`) at the CLI layer — legacy skills that relied on silent accept will fail here | Always provide `series1.values=` / `dataRange=` / inline `data=` at chart `add` time. Treat Gate 2 seriesCount check as a belt-and-braces verification. |
+| D-15 | Empty chart `add` is rejected (`Chart requires a 'data' property`) at the CLI layer — legacy skills that relied on silent accept will fail here | Always provide `series1.values=` / `dataRange=` / inline `data=` at chart `add` time. Treat Gate 2 seriesCount check as a belt-and-braces verification. |
 | D-16 | `fullCalcOnLoad=true` guarantees a **runtime** recalc when the end user opens the file; it does NOT refresh the build-time `cachedValue` in XML. Build sequence `set B=100 → set E==B+D → fix B=150` leaves `E.cachedValue` stale (board sees "Net Change = 0"). | After all upstream edits are final, re-issue every downstream formula (`officecli set "$FILE" /Sheet/E2 --prop formula==B2+D2`) OR `close` + re-open the file. Gate 8 verifies. |
-| D-17 | 1.0.63 built-in calc engine does NOT evaluate `SUMPRODUCT` with array-predicate form `SUMPRODUCT((A2:A97=X)*C2:C97*D2:D97)` — cachedValue stays `0`/`null`, Gate 8 rejects. Runtime Excel / WPS compute fine, but board-delivered XLSX with stale cache still ships `0`. | Rewrite as helper column + `SUMIF`: `F2==C2*D2` on source sheet, then `=SUMIF(B:B, "Region X", F:F)`. Or pre-aggregate in Summary sheet and chart from there. |
+| D-17 | The built-in calc engine does NOT evaluate `SUMPRODUCT` with array-predicate form `SUMPRODUCT((A2:A97=X)*C2:C97*D2:D97)` — cachedValue stays `0`/`null`, Gate 8 rejects. Runtime Excel / WPS compute fine, but board-delivered XLSX with stale cache still ships `0`. | Rewrite as helper column + `SUMIF`: `F2==C2*D2` on source sheet, then `=SUMIF(B:B, "Region X", F:F)`. Or pre-aggregate in Summary sheet and chart from there. |
 
 ### Inherited (pointer only)
 

--- a/crates/aionui-app/assets/builtin-skills/officecli-docx/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/officecli-docx/SKILL.md
@@ -276,7 +276,7 @@ For any document with 3+ headings:
 officecli add "$FILE" /body --type toc --prop levels="1-3" --prop title="Table of Contents" --prop hyperlinks=true --index 0
 ```
 
-Page numbers render automatically (`--prop pageNumbers=true` toggles them explicitly). Address the TOC directly (1.0.60+): `/toc[1]` or `/tableofcontents` resolve to the first TOC field for `get`/`set`/`remove` without hand-walking XPath.
+Page numbers render automatically (`--prop pageNumbers=true` toggles them explicitly). Address the TOC directly: `/toc[1]` or `/tableofcontents` resolve to the first TOC field for `get`/`set`/`remove` without hand-walking XPath.
 
 **TOC delivery step (mandatory before handoff).** The live TOC field is a placeholder until recalculated. Some viewers populate it on first open; others show the literal `Update field to see table of contents` until the reader recalculates. Pick by recipient:
 
@@ -310,10 +310,10 @@ officecli add "$FILE" /body --type chart --prop chartType=bar --prop title="Reve
 External links go via `hyperlink`:
 
 ```bash
-officecli add "$FILE" "/body/p[2]" --type hyperlink --prop uri="https://example.com" --prop text="our site"
+officecli add "$FILE" "/body/p[2]" --type hyperlink --prop url="https://example.com" --prop text="our site"
 ```
 
-**Internal links** (to a bookmark) use `--prop anchor=bookmarkName` — not a `#fragment` in `uri`:
+**Internal links** (to a bookmark) use `--prop anchor=bookmarkName` — not a `#fragment` in `url`:
 
 ```bash
 officecli add "$FILE" "/body/p[2]" --type hyperlink --prop anchor=chapter1 --prop text="See Chapter 1"
@@ -340,7 +340,7 @@ officecli add "$FILE" /body --type pagebreak --index <N>          # 1. pagebreak
 officecli set "$FILE" "/body/p[<N+1>]" --prop pageBreakBefore=true # 2. on the heading itself
 ```
 
-`--prop break=newPage` (1.0.61+) is a shorter alias for `pageBreakBefore=true` (accepts `newPage|page|nextPage|pageBreak`). Same XML, same belt-and-suspenders rule. Preview with `view html` and count pages.
+`--prop break=newPage` is a shorter alias for `pageBreakBefore=true` (accepts `newPage|page|nextPage|pageBreak`). Same XML, same belt-and-suspenders rule. Preview with `view html` and count pages.
 
 ### Report-level recipes
 
@@ -435,7 +435,7 @@ officecli add "$FILE" /body --type equation --prop formula="\\frac{a}{b} + \\sum
 officecli add "$FILE" "/body/p[3]" --type footnote --prop text="See Appendix A for methodology."
 ```
 
-**Comments and tracked changes.** Bulk accept/reject: `set / --prop accept-changes=all` (or `reject-changes=all`). Locate individual changes with `query ins` and `query del` (`trackedchange` is not a selector). Create tracked changes on a run with `--prop revision.type=ins|del --prop revision.author=…` (`help docx run` for the full `revision.*` set — `format`/`moveFrom`/`moveTo` too). Add a comment: `add "/body/p[4]" --type comment --prop author=… --prop text=…`; reply-thread it with `--prop parentId=N` and mark it resolved with `set "/comments/comment[N]" --prop done=true` (resolve rather than delete to keep the audit trail — `query 'comment[done=false]'` then lists what's still open). Prop schema: `help docx comment` / `help docx run`.
+**Comments and tracked changes.** Bulk accept/reject: `set "$FILE" /revision --prop revision.action=accept` (or `--prop revision.action=reject`); narrow with a selector like `/revision[@author=Alice]` or `/revision[@type=ins]`. Locate individual changes with `query ins` and `query del` (`trackedchange` is not a selector). Create tracked changes on a run with `--prop revision.type=ins|del --prop revision.author=…` (`help docx run` for the full `revision.*` set — `format`/`moveFrom`/`moveTo` too). Add a comment: `add "/body/p[4]" --type comment --prop author=… --prop text=…`; reply-thread it with `--prop parentId=N` and mark it resolved with `set "/comments/comment[N]" --prop done=true` (resolve rather than delete to keep the audit trail — `query 'comment[done=false]'` then lists what's still open). Prop schema: `help docx comment` / `help docx run`.
 
 **Watermark.** `add / --type watermark --prop text="DRAFT" --prop color=BFBFBF --prop opacity=0.8` in one command (default opacity 0.5); `set /watermark --prop opacity=…` adjusts it later.
 
@@ -449,7 +449,7 @@ Three tiers of precision; use the lowest that does the job.
 - **L2 — dotted-attr fallback** (`pbdr.top=`, `ind.left=`, `shd.fill=`, `padding.top=`, `font.size=`): when L1 lacks the knob. Example: `--prop pbdr.bottom="single;6;1F4E79;0"`. Emits schema-valid XML.
 - **L3 — `raw-set` with XML**: last resort, no schema protection. Use for internal hyperlinks, composite fields, and other shapes the typed verbs can't express (see XML appendix).
 
-Borders use the format `style;size;color;space`: `single;4;FF0000;1`. Hex colors never start with `#`: `FF0000`. Scheme color names (`accent1..6`, `dark1`/`dark2`, `light1`/`light2`, `hyperlink`) are accepted anywhere a hex color is (1.0.60+) — prefer hex for stable colors across themes.
+Borders use the format `style;size;color;space`: `single;4;FF0000;1`. Hex colors never start with `#`: `FF0000`. Scheme color names (`accent1..6`, `dark1`/`dark2`, `light1`/`light2`, `hyperlink`) are accepted anywhere a hex color is — prefer hex for stable colors across themes.
 
 ## QA (Required)
 

--- a/crates/aionui-app/assets/builtin-skills/officecli-financial-model/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/officecli-financial-model/SKILL.md
@@ -36,7 +36,7 @@ Verify with `officecli --version` (open a new terminal if PATH hasn't picked up)
 
 ## Help-First Rule
 
-This skill teaches what a financial model requires, not every CLI flag. When a prop name / alias / enum is uncertain, consult help BEFORE guessing: `officecli help xlsx [element] [--json]`. Help is pinned to installed version — when this skill and help disagree, **help wins**. Every `--prop X=` below was verified against `officecli help xlsx <element>` on v1.0.63.
+This skill teaches what a financial model requires, not every CLI flag. When a prop name / alias / enum is uncertain, consult help BEFORE guessing: `officecli help xlsx [element] [--json]`. Help is authoritative for the installed version — when this skill and help disagree, **help wins**. Every `--prop X=` below was verified against `officecli help xlsx <element>`.
 
 ## Mental Model & Inheritance
 
@@ -55,7 +55,7 @@ A financial model is an xlsx with a **decision-grade, formula-driven layer**: ev
 3. **Statements balance every period.** `Assets − Liab − Equity = 0`, `CF.EndingCash = BS.Cash`. Gate 4 fails on `IMBALANCED`.
 4. **Hardcodes audited.** Calc sheets carry zero hardcoded numbers; Gate 6 counts.
 5. **Sensitivity / scenario is first-class.** 2-axis grid, dropdown `INDEX/MATCH` switch, or Base/Upside/Downside cols. Excel Data Tables not reliably supported — manual grids only.
-6. **Cached values on valuation cells load-bearing.** NPV / IRR / XNPV caching `0` ships a wrong number to non-recalculating readers. Gate 5 spot-checks.
+6. **Cached values on valuation cells load-bearing.** A valuation cell that ships with no cached result (or the `#OCLI_NOTEVAL!` sentinel) sends a blank/wrong number to non-recalculating readers. The evaluator now computes NPV / XNPV / IRR / XIRR; verify the cached value with a readback. Gate 5 spot-checks.
 7. **Circularity is a design choice.** Legitimate rings (interest ↔ cash, revolver plug ↔ ending cash) use `calc.iterate=true`. Accidental circularity is broken algebra — never papered with `iterate`.
 8. **Named ranges for ≥ 3-use assumptions.** `WACC`, `TaxRate`, `TerminalGrowth`, `ExitMultiple`, `ChurnRate`. Declared-unused names are dead decoration — Gate 6 flags.
 
@@ -78,7 +78,7 @@ Every model in this skill builds on three zones. **Name them, tab-color them, an
 **Executable zone audit** (run before Gate 4):
 
 ```bash
-# Calc zone: zero numeric hardcodes allowed. NOTE: `:not(:has(formula))` pseudo doesn't filter on v1.0.63+ — filter via jq on .format.formula == null.
+# Calc zone: zero numeric hardcodes allowed. `cell:not(:has(formula))` selects the literal (non-formula) cells; `cell:has(formula)` selects the formula cells.
 HARDCODE=$(officecli query "$FILE" 'cell[type=Number]' --json | jq '[.data.results[] | select(.format.formula == null) | select(.path | test("/(P&L|Balance Sheet|Cash Flow|DCF|Debt|ARR)/"))] | length')
 [ "$HARDCODE" -eq 0 ] && echo "Zone audit OK" || { echo "REJECT: $HARDCODE hardcoded numeric cells on Calc sheets — move to Assumptions"; exit 1; }
 # Assumptions zone: should be non-zero.
@@ -110,7 +110,7 @@ Three facts cause silent wrong numbers: (1) new formulas ship without cached val
 **Discipline (every recipe):**
 - Build order follows the data chain: `P&L → BS → CF` (3-statement); `FCF → WACC → NPV → Sensitivity` (DCF); `S&U → Debt → P&L → CF → Returns` (LBO).
 - After the cross-sheet chain, **cache-refresh pass:** re-issue `set` on every summary / valuation / balance-check cell, non-resident.
-- Spot-check: `officecli get "$FILE" /Summary/B2 --json | jq .format.cachedValue` returns non-zero non-null. `null` ≠ `0`: `null` means Excel will compute on open (OK for delivery); `0` is a cached lie. If `0` persists: close residents, re-set; still `0` → cache-fallback (§Financial function patterns).
+- Spot-check: `officecli get "$FILE" /Summary/B2 --json | jq '.data.results[0].format.cachedValue'` returns a plausible non-null value. `null` means Excel will compute on open (OK for delivery). If a cell shows the `#OCLI_NOTEVAL!` sentinel: close residents, re-set; still unevaluated → cache-fallback (§Financial function patterns).
 
 ## Recipes — three model types
 
@@ -194,12 +194,12 @@ officecli add "$FILE" /Summary --type chart --prop chartType=area --prop dataRan
 **Verification (run all three):**
 
 ```bash
-# Balance check every period must say OK
-officecli get "$FILE" "/Balance Sheet/B18:E18" --json | jq '.data[].cachedValue // .data[].value'
+# Balance check every period must say OK (range get → cells under .data.results[0].children[])
+officecli get "$FILE" "/Balance Sheet/B18:E18" --json | jq '.data.results[0].children[] | .format.cachedValue // .text'
 # Cash recon every period must say OK
-officecli get "$FILE" "/Cash Flow/B21:E21" --json | jq '.data[].cachedValue // .data[].value'
-# Summary KPIs are plausible numbers, not 0 or null
-officecli get "$FILE" "/Summary/B2:B5" --json | jq '.data[].cachedValue'
+officecli get "$FILE" "/Cash Flow/B21:E21" --json | jq '.data.results[0].children[] | .format.cachedValue // .text'
+# Summary KPIs are plausible numbers, not null
+officecli get "$FILE" "/Summary/B2:B5" --json | jq '.data.results[0].children[].format.cachedValue'
 ```
 
 ### Recipe B — DCF valuation
@@ -249,7 +249,7 @@ cat <<'EOF' | officecli batch "$FILE"
 EOF
 ```
 
-**Why `SUMPRODUCT` not `NPV`.** `NPV(rate, cross_sheet_range)` silently caches `0` on v1.0.63 — ships a wrong valuation to any non-recalculating reader. `SUMPRODUCT(values/(1+rate)^periods)` is algebraically equivalent and caches correctly (period row `FCF!B2:K2 = 1..10` is a one-time setup). For irregular dates (`XNPV`), use `SUMPRODUCT(values/(1+rate)^((dates-base_date)/365))`. See §Known Issues.
+**`NPV` vs `SUMPRODUCT` — both cache correctly.** The evaluator computes `NPV(rate, cross_sheet_range)` and caches the right value (verify with a readback). `SUMPRODUCT(values/(1+rate)^periods)` is the algebraic equivalent (period row `FCF!B2:K2 = 1..10` is a one-time setup); it is shown here as an OPTIONAL audit-readability choice — the explicit discounting series is sometimes easier for a reviewer to trace, not a cache workaround. Either form is fine. For irregular dates, `XNPV(rate, values, dates)` likewise caches; the SUMPRODUCT equivalent is `SUMPRODUCT(values/(1+rate)^((dates-base_date)/365))`.
 
 **Step 5 — 2-axis sensitivity grid (WACC × g).** 5×5 grid. Rows = WACC values `7.5% ... 11.5%`, cols = `g` values `1.5% ... 3.5%`. Each cell = one self-contained formula re-running the DCF with the grid's WACC and g substituted. Template:
 
@@ -275,12 +275,12 @@ officecli add "$FILE" /Sensitivity --type conditionalformatting \
 **Verification.**
 
 ```bash
-officecli get "$FILE" "/DCF/C8" --json | jq .format.cachedValue   # equity value, plausible $
-officecli get "$FILE" "/DCF/C9" --json | jq .format.cachedValue   # per-share, in $XX.XX range
-officecli get "$FILE" "/Sensitivity/F17" --json | jq .format.cachedValue   # grid center cell, plausible
+officecli get "$FILE" "/DCF/C8" --json | jq '.data.results[0].format.cachedValue'   # equity value, plausible $
+officecli get "$FILE" "/DCF/C9" --json | jq '.data.results[0].format.cachedValue'   # per-share, in $XX.XX range
+officecli get "$FILE" "/Sensitivity/F17" --json | jq '.data.results[0].format.cachedValue'   # grid center cell, plausible
 ```
 
-If `C8` or `C9` cache `0`, re-set them (non-resident) — see §Build-order & cache-drift.
+If `C8` or `C9` come back `null` or show the `#OCLI_NOTEVAL!` sentinel, re-set them (non-resident) — see §Build-order & cache-drift.
 
 ### Recipe C — LBO model
 
@@ -303,8 +303,8 @@ Sources = Senior_TLB + Mezz + Revolver_drawn + Sponsor_equity
 officecli set "$FILE" /S&U/B12 --prop formula='IF(ABS(SUM(B4:B7)-SUM(B9:B11))<1,"BALANCED","S&U IMBALANCE: "&ROUND(SUM(B4:B7)-SUM(B9:B11),0))' --prop bold=true
 
 # Stated-vs-plug consistency (Gate 4 addendum; only run if you chose pattern (a)).
-STATED=$(officecli get "$FILE" /Assumptions/B12 --json | jq -r '.format.cachedValue // "null"')
-PLUGGED=$(officecli get "$FILE" /S&U/B10 --json | jq -r '.format.cachedValue // "null"')   # B10 = sponsor-equity row on S&U
+STATED=$(officecli get "$FILE" /Assumptions/B12 --json | jq -r '.data.results[0].format.cachedValue // "null"')
+PLUGGED=$(officecli get "$FILE" /S&U/B10 --json | jq -r '.data.results[0].format.cachedValue // "null"')   # B10 = sponsor-equity row on S&U
 DELTA=$(python3 -c "print(abs(float('$STATED') - float('$PLUGGED')))" 2>/dev/null || echo 99999)
 python3 -c "import sys; sys.exit(0 if float('$DELTA') <= 1 else 1)" && echo "S&U sponsor OK (stated=$STATED plug=$PLUGGED)" || { echo "REJECT Gate 4 S&U: stated $STATED ≠ plug $PLUGGED (Δ=$DELTA) — fees silently absorbed"; exit 1; }
 ```
@@ -369,7 +369,7 @@ officecli add "$FILE" /Returns --type comment --prop ref=B4 --prop text='IRR —
 ```
 
 **Callout — labels: `comment` element vs Notes column vs `formula` (three distinct mechanics).**
-- **Hover tooltip** → `officecli add ... --type comment --prop ref=<cell> --prop text='...'`. The **`comment` key is NOT a valid prop on `set cell`** (not in `officecli help xlsx cell` on v1.0.63) — it silently drops when embedded inside a `set cell` props dict. Use the dedicated element.
+- **Hover tooltip** → `officecli add ... --type comment --prop ref=<cell> --prop text='...'`. The **`comment` key is NOT a valid prop on `set cell`** (not in `officecli help xlsx cell`) — it silently drops when embedded inside a `set cell` props dict. Use the dedicated element.
 - **Visible text in an adjacent Notes column** → `{"command":"set","path":"/DCF/D3","props":{"value":"TV = FCF × (1+g) / (WACC−g)"}}` — **`value`, not `formula`**, plain quoted string.
 - **Formula-style prose written as a real formula** → NEVER. `{"formula":"FCF10*(1+g)/(WACC-g)"}` produces `#NAME?` in Excel (`FCF10`, `g`, `WACC` are unbound identifiers in that cell context).
 
@@ -380,9 +380,9 @@ For mid-year dividends or partial exits, use `XIRR({cashflows}, {dates})` instea
 **Verification.**
 
 ```bash
-officecli get "$FILE" /S&U/B12 --json | jq '.data.value // .data.cachedValue'   # must say BALANCED
-officecli get "$FILE" /Returns/B3 --json | jq .format.cachedValue                # MOIC, expect 2.0x-4.0x typical
-officecli get "$FILE" /Returns/B4 --json | jq .format.cachedValue                # IRR, expect 0.15-0.30 typical
+officecli get "$FILE" /S&U/B12 --json | jq '.data.results[0].format.cachedValue // .data.results[0].text'   # must say BALANCED
+officecli get "$FILE" /Returns/B3 --json | jq '.data.results[0].format.cachedValue'                # MOIC, expect 2.0x-4.0x typical
+officecli get "$FILE" /Returns/B4 --json | jq '.data.results[0].format.cachedValue'                # IRR, expect 0.15-0.30 typical
 # Iterate converged?
 officecli query "$FILE" 'cell:contains("#REF!")' --json | jq '.data.results | length'   # must be 0
 ```
@@ -426,13 +426,9 @@ Terse reference — not a finance textbook. If you don't know what these do, pau
 | `INDEX(range, MATCH(lookup, key, 0))` | `VLOOKUP` | Insert-safe (VLOOKUP breaks when a column is inserted in the source range) |
 | `IFERROR(x/y, 0)` or `IF(y=0, 0, x/y)` | bare division | Guard every `/` in a financial model — `#DIV/0!` shipped = delivery failure |
 | `MIRR(values, financeRate, reinvestRate)` | `IRR` with sign flips | When cash-flow pattern has 2+ sign changes |
-| `SUMIFS(sumRange, criteriaRange1, criterion1, ...)` | `SUMPRODUCT((...))` array | Avoids the cached-value trap on array formulas (→ xlsx v2 §Common Workflow Step 5 array-formula fallback) |
+| `SUMIFS(sumRange, criteriaRange1, criterion1, ...)` | `SUMPRODUCT((...))` array | Clearer intent for conditional sums; either evaluates correctly |
 
-**`SUMPRODUCT(1/COUNTIF(...))` distinct-count trap.** The CLI engine caches the inner division per-row → `1/N` (e.g. `0.001543`) rather than the true distinct count. `SUMPRODUCT(--((range<>"")/COUNTIF(range,range&"")))` pattern is likewise affected. **Fallback (from xlsx v2):** hardcode the correct distinct count with a blue font + adjacent comment `"hardcoded distinct count; update if rows change"`, and disclose at delivery. LBO deal-count or portfolio headcount from a transactions list is the typical pattern that hits this.
-
-**Cross-sheet `NPV()` / `XNPV()` cache-0 fallback (preferred).** When the engine caches `0` on a cross-sheet `NPV()` / `XNPV()`, replace the formula with its algebraic equivalent `SUMPRODUCT(values/(1+rate)^periods)` — same result, caches correctly, audits cleanly. This is the first-line fix, used in Recipe B Step 4 by default. For `XNPV`, the period exponent is `(dates - base_date) / 365`.
-
-**Cache fallback on `IRR` / `MOIC` / summary KPI cells (last resort).** If a valuation cell still ships with `cachedValue = 0` after algebraic rewrite + re-set after close, hardcode the computed value with a blue font and add a classic comment via `officecli add "$FILE" /Sheet --type comment --prop ref=<cell> --prop text='cached valuation; refreshes on open in Excel — do not edit'`. Disclose in delivery notes. Prefer re-set after close first.
+**Evaluator coverage — verify, don't preemptively hardcode.** The CLI evaluator computes the finance functions this skill uses — `NPV` / `XNPV` / `IRR` / `XIRR`, array-literal formulas (`IRR({...})`), and `SUMPRODUCT(1/COUNTIF(range,range))` distinct-count — and caches the correct value with `evaluated:true`. There is no `NPV→0` rewrite obligation and no distinct-count `1/N` trap. The honest rule: build the formula you mean, then verify the cached value with a readback (`get ... --json | jq '.data.results[0].format.cachedValue'`). Only if a specific cell genuinely comes back with the `#OCLI_NOTEVAL!` sentinel (formula written before its inputs, or an unsupported function) should you fall back — first re-set non-resident after `close`; if it still won't evaluate, hardcode the computed value with a blue font and a classic comment via `officecli add "$FILE" /Sheet --type comment --prop ref=<cell> --prop text='cached valuation; refreshes on open in Excel — do not edit'`, and disclose in delivery notes.
 
 ## Circular references & iterative calc
 
@@ -453,17 +449,17 @@ officecli set "$FILE" / --prop calc.iterate=true --prop calc.iterateCount=100 --
 2. **Write downstream** — build all non-circular chains (P&L, CF, Exit, Returns, Summary, grid) non-resident, one heredoc per sheet. Everything caches against the zeroed cells.
 3. **Re-ring** — close all residents, re-set each circular cell with its real formula, one `set` per cell, non-resident.
 
-**Acceptance.** `get /Debt/C7 --json | jq .format.cachedValue` returns non-zero non-null. If a cell still deadlocks, leave `=0` + classic comment `"circular; recalculates in Excel on F9"`, flag at delivery. Never paper over with `iterateCount=1000`.
+**Acceptance.** `get /Debt/C7 --json | jq '.data.results[0].format.cachedValue'` returns non-zero non-null. If a cell still deadlocks, leave `=0` + classic comment `"circular; recalculates in Excel on F9"`, flag at delivery. Never paper over with `iterateCount=1000`.
 
 **Do NOT use `iterate` as a band-aid for `#REF!` / divergent values.** Raising `iterateCount` to 1000 hides the bug and ships a plausibly-wrong value; `validate` does not catch it. Break the loop algebraically (e.g. interest on opening balance only, not average).
 
 **Verify convergence.** Read the loop cell, bump a driving assumption and back, re-read — values must match:
 
 ```bash
-V1=$(officecli get "$FILE" /Debt/C9 --json | jq .format.cachedValue)
+V1=$(officecli get "$FILE" /Debt/C9 --json | jq '.data.results[0].format.cachedValue')
 officecli set "$FILE" /Assumptions/B31 --prop value=0.085
 officecli set "$FILE" /Assumptions/B31 --prop value=0.0845
-V2=$(officecli get "$FILE" /Debt/C9 --json | jq .format.cachedValue)
+V2=$(officecli get "$FILE" /Debt/C9 --json | jq '.data.results[0].format.cachedValue')
 [ "$V1" = "$V2" ] && echo "Iterate converged" || echo "WARN: drift V1=$V1 V2=$V2 — tighten iterateDelta or check algebra"
 ```
 
@@ -494,14 +490,14 @@ If any fail, the model is silently wrong — fix the upstream chain before deliv
 
 ### Gate 5 — cached-value sanity on valuation cells
 
-NPV / IRR / XIRR / equity-bridge / MOIC / summary KPI cells cached `0` = wrong number shipped to a reader who does not recalc on open. List every valuation cell and check `cachedValue`:
+NPV / IRR / XIRR / equity-bridge / MOIC / summary KPI cells that ship unevaluated (`#OCLI_NOTEVAL!` sentinel, typically because the formula was written before its inputs) send a blank/wrong number to a reader who does not recalc on open. List every valuation cell and confirm a cached value is present:
 
 ```bash
 # Customize the path list per recipe — this is the DCF example
 for P in "/DCF/C4" "/DCF/C5" "/DCF/C6" "/DCF/C8" "/DCF/C9"; do
-  V=$(officecli get "$FILE" "$P" --json | jq -r '.format.cachedValue // "null"')
-  if [ "$V" = "0" ] || [ "$V" = "null" ]; then
-    echo "REJECT Gate 5: $P cached $V — re-set after close (see §Build-order & cache-drift)"; exit 1
+  V=$(officecli get "$FILE" "$P" --json | jq -r '.data.results[0].format.cachedValue // "null"')
+  if [ "$V" = "null" ] || [ "${V#\#OCLI_NOTEVAL}" != "$V" ]; then
+    echo "REJECT Gate 5: $P unevaluated (cached=$V) — re-set after close (see §Build-order & cache-drift)"; exit 1
   fi
   echo "Gate 5 $P: cached=$V OK"
 done
@@ -514,16 +510,19 @@ For LBO, extend the list: `/Exit/B5`, `/Returns/B3`, `/Returns/B4`. For 3-statem
 Every Calc sheet has zero numeric hardcodes. Executable:
 
 ```bash
-HARDCODE=$(officecli query "$FILE" 'cell[type=Number]:not(:has(formula))' --json \
-  | jq '[.data.results[] | select(.path | test("/(P&L|Balance Sheet|Cash Flow|DCF|Debt|FCF|WACC|Exit|Returns)/"))] | length')
+# `cell:not(:has(formula))` selects the literal cells (and `cell:has(formula)` the formula cells).
+HARDCODE=$(officecli query "$FILE" 'cell[type=Number]' --json \
+  | jq '[.data.results[] | select(.format.formula == null) | select(.path | test("/(P&L|Balance Sheet|Cash Flow|DCF|Debt|FCF|WACC|Exit|Returns)/"))] | length')
 [ "$HARDCODE" -eq 0 ] && echo "Gate 6 OK (no hardcodes on Calc sheets)" || { echo "REJECT Gate 6: $HARDCODE hardcoded numeric cells on Calc zone — move to Assumptions"; exit 1; }
 
 # Named-range coverage + dead-decoration audit: ≥3 ranges declared AND each referenced by ≥1 formula.
 NR=$(officecli query "$FILE" namedrange --json | jq '.data.results | length')
 [ "$NR" -ge 3 ] && echo "Gate 6 OK ($NR named ranges)" || echo "WARN Gate 6: only $NR named ranges"
 DEAD=0
-for NR_NAME in $(officecli query "$FILE" namedrange --json | jq -r '.data.results[].name'); do
-  USES=$(officecli query "$FILE" "cell:has(formula):contains(\"$NR_NAME\")" --json | jq '.data.results | length')
+for NR_NAME in $(officecli query "$FILE" namedrange --json | jq -r '.data.results[].format.name'); do
+  # Match the formula SOURCE (`formula~=`), not the cached/displayed RESULT — `:contains` would scan
+  # the computed value and report every name as dead (false reject).
+  USES=$(officecli query "$FILE" "cell[formula~=$NR_NAME]" --json | jq '.data.results | length')
   [ "$USES" -ge 1 ] && echo "  $NR_NAME: $USES uses OK" || { echo "  WARN: $NR_NAME unused"; DEAD=$((DEAD+1)); }
 done
 [ "$DEAD" -eq 0 ] && echo "Gate 6 named-range audit OK" || { echo "REJECT Gate 6: $DEAD dead-decoration name(s)"; exit 1; }
@@ -565,8 +564,8 @@ Financial-model-specific:
 - **Iterative calc silent non-convergence.** `calc.iterate=true iterateCount=100` converges at whatever the cap lands on — even if the true answer is 2× that. Always run convergence verify (§Circular references). Complex LBO rings (multi-tranche debt + sweep + tax shield) may not converge; when `cachedValue=0` on a ring cell, use §Write-order surgery.
 - **Batch-while-resident deadlock on circular writes.** Writing the closing leg of a cross-sheet ring via `batch` with a resident open deadlocks at 100% CPU. Even single `set` on a ring cell can hang. Fix: close residents, write the ring in two passes per §Write-order surgery. Non-resident single-heredoc is the only safe form.
 - **Cross-sheet cached value stale in `view html`.** Downstream written in the same sequence as upstream caches `0`. Excel resolves on open; HTML preview does NOT. Re-set every downstream non-resident after the chain (§Build-order & cache-drift).
-- **`NPV()` / `XNPV()` cross-sheet caches `0` on v1.0.63.** Rewrite as `SUMPRODUCT(values/(1+rate)^periods)` — algebraically equivalent, caches correctly. Applied by default in Recipe B Step 4.
-- **Sensitivity-grid cache trap.** Grid built before FCF/WACC → every cell caches `0`. Build FCF + WACC + DCF first, then grid in a separate non-resident batch. Fallback: hardcode blue + comment `"hardcoded sensitivity; refresh on assumption change"`.
+- **`NPV()` / `XNPV()` evaluate and cache correctly.** The evaluator computes both (same-sheet and cross-sheet); no rewrite is required. `SUMPRODUCT(values/(1+rate)^periods)` remains an optional audit-readability alternative, not a cache workaround.
+- **Sensitivity-grid build order still matters.** A grid cell written before its FCF/WACC inputs exist evaluates against empty inputs and may cache a wrong/blank value. Build FCF + WACC + DCF first, then the grid in a separate non-resident batch, and verify (`jq '.data.results[0].format.cachedValue'`). This is an ordering discipline, not an evaluator limitation.
 - **`BS.Cash` = CF ending cash always** (including Y1: `BS.Cash = 'Cash Flow'!B19`). Never an independent plug or Assumptions ref — a plugged `BS.Cash` hides balance errors.
 - **Year 2+ `Opening Cash` = prior period `Ending Cash`** (`C17=B19`, `D17=C19`). Independent Y2+ opening-cash inputs silently drift from BS.
 - **Waterfall chart "total" bars.** `chartType=waterfall` cannot mark total programmatically — use `colors=` convention (dark = total, medium = positive, red = negative). See `help xlsx chart`.

--- a/crates/aionui-app/assets/builtin-skills/officecli-pitch-deck/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/officecli-pitch-deck/SKILL.md
@@ -303,6 +303,8 @@ The 10 slides every pitch deck carries. Each recipe below gives: **visual outcom
 
 **Long-title wrap rule.** A 36pt+ title that wraps to 2 lines: add `height` (e.g. 2cm → 3.5cm) — never drop the font below 36pt. Titles < 36pt on a pitch deck read as timid regardless of content.
 
+> **Chart `series1.color=` on `add` works** (applies to every chart recipe below). Passing `--prop series1.color=` (or `series2.color=`, …) on chart `add` applies the series color and exits 0. Verify with a readback if you like: `officecli get "$FILE" "/slide[N]/chart[1]/series[1]" --json | jq '.data.results[0].format.color'`.
+
 ### (1) Cover slide — company · tagline · round · date
 
 **Visual outcome.** Dark navy fill, centered 44pt company name, 20pt one-line tagline underneath, small 16pt meta line at the bottom with round + amount + date. Thin brand band at the very bottom (0.5cm high) in the accent color.
@@ -632,7 +634,7 @@ officecli add "$FILE" / --type slide --prop layout=blank --prop background=FFFFF
 officecli add "$FILE" "/slide[$SLIDE]" --type shape --prop text="Competitive landscape" \
   --prop x=1.5cm --prop y=1.2cm --prop width=30.87cm --prop height=2cm \
   --prop font=Georgia --prop size=36 --prop bold=true --prop color=1E2761 --prop fill=none
-# Inline table via --prop data= (confirmed on v1.0.63; per-cell r#c# rejected). Single-quote the data value — '$15/host' would strip.
+# Inline table via --prop data= (per-cell r#c# is silently ignored / not honored — use data=). Single-quote the data value — '$15/host' would strip.
 officecli add "$FILE" "/slide[$SLIDE]" --type table \
   --prop data='Competitor,Speed,Price,Integrations,Margin;Datadog,12 min,$15/host,680,75%;New Relic,18 min,$25/host,520,68%;Splunk,45 min,$45/GB,310,62%;You (Acme DevOps),90 sec,$8/host,1200,82%' \
   --prop style=medium1 --prop headerFill=1E2761 \
@@ -797,7 +799,7 @@ AXISMIN_HIT=$(officecli query "$FILE" 'chart' --json | jq '[.data.results[]? | s
 echo "Delivery Gate 6 PASS (token + narrative checks) — proceed to Gate 5b fresh-eyes (MANDATORY)"
 ```
 
-**Readback key note.** CLI accepts lowercase `axismin` as input (on `--prop axismin=0`) but emits camelCase `axisMin` in `query --json` on v1.0.63. The jq above accepts both for forward-compat.
+**Readback key note.** CLI accepts lowercase `axismin` as input (on `--prop axismin=0`) but emits camelCase `axisMin` in `query --json` readback. The jq above accepts both for forward-compat.
 
 Gate 6 is a grep floor. Gate 5b is the visual ceiling. Ship only when both print PASS.
 

--- a/crates/aionui-app/assets/builtin-skills/officecli-pptx/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/officecli-pptx/SKILL.md
@@ -36,7 +36,7 @@ Verify with `officecli --version` (open a new terminal if PATH hasn't picked up)
 
 ```bash
 officecli help pptx                         # List all pptx elements
-officecli help pptx <element>               # Full element schema (e.g. shape, chart, animation, connector, zoom, group, background)
+officecli help pptx <element>               # Full element schema (e.g. shape, chart, animation, connector, zoom, group)
 officecli help pptx <verb> <element>        # Verb-scoped (e.g. add shape, set slide)
 officecli help pptx <element> --json        # Machine-readable schema
 ```
@@ -308,7 +308,7 @@ A slide is `/slide[N]`. Always pass `layout=blank` for custom designs. Backgroun
 ```bash
 officecli add "$FILE" / --type slide --prop layout=blank --prop background=1E2761                 # solid
 officecli add "$FILE" / --type slide --prop layout=blank --prop "background=1E2761-CADCFC-180"   # gradient (start-end-angle)
-officecli add "$FILE" / --type slide --prop layout=blank --prop "background.image=hero.jpg"      # image background (LEAD)
+officecli add "$FILE" / --type slide --prop layout=blank --prop background=image:/path/to/hero.jpg  # image background (LEAD)
 ```
 
 ### Shapes
@@ -383,10 +383,10 @@ officecli set "$FILE" "/slide[2]/shape[@name=HeroCard]" --prop animation=none   
 
 ### Tables, placeholders, groups, zoom — one-liners
 
-- **Tables** — `--type table --prop rows=N --prop cols=M`. Row-level `set` supports `height`, `header`, `c1/c2/c3`. Cell formatting lives on the cell paragraph / run. Populate rows BEFORE setting table-level font (font cascade gets reset by row ops).
+- **Tables** — `--type table --prop rows=N --prop cols=M`. Row-level `set` supports `height` and `c1/c2/c3` (seed cell text). Header-row styling is table-level (`firstRow=true` / `headerFill=`), not a row prop. Cell formatting lives on the cell paragraph / run. Populate rows BEFORE setting table-level font (font cascade gets reset by row ops).
 - **Placeholders** — `"/slide[N]/placeholder[title]"` / `placeholder[body]`. Available only when the slide uses a layout with placeholders (not `layout=blank`).
 - **Groups** (LEAD) — address children via `"/slide[N]/group[@name=G]/shape[1]"`. Survives reordering better than positional indexes.
-- **Zoom slide** (LEAD) — `--type zoom --prop targets="3,7,15"`. Section-navigation hub. Zoom is a runtime feature — `view html` shows the static geometry; the zoom interaction runs only in a live presentation viewer.
+- **Zoom slide** (LEAD) — `--type zoom --prop target=N` (one link per target; alias `slide`). Emit N separate zoom shapes for a multi-target nav hub. Zoom is a runtime feature — `view html` shows the static geometry; the zoom interaction runs only in a live presentation viewer.
 - **Slide comments** — reviewer annotations anchored at `/slide[N]/comment[M]`. Full lifecycle (`add / set / get / query / remove`). Props: `text`, `author`, `initials` (auto-derived), `date` (ISO 8601, defaults to UtcNow), `x` / `y` (length anchor).
   ```bash
   officecli add "$FILE" "/slide[2]" --type comment --prop author="Alice" --prop text="Tighten this bullet" --prop x=20cm --prop y=3cm

--- a/crates/aionui-app/assets/builtin-skills/officecli-word-form/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/officecli-word-form/SKILL.md
@@ -51,11 +51,11 @@ If the install command above fails (e.g. blocked by security policy, no network 
 
 ## Help-First Rule
 
-This skill teaches what a real form needs, not every CLI flag. When a prop / alias / enum is uncertain, consult help BEFORE guessing: `officecli help docx [element] [--json]` (e.g. `sdt`, `formfield`, `field`). Help is pinned to installed version — when this skill and help disagree, **help wins**. Every `--prop X=` below was verified against `officecli help docx <element>` on v1.0.63.
+This skill teaches what a real form needs, not every CLI flag. When a prop / alias / enum is uncertain, consult help BEFORE guessing: `officecli help docx [element] [--json]` (e.g. `sdt`, `formfield`, `field`). Help is pinned to the installed CLI version and is authoritative — when this skill and help disagree, **help wins** (the prop set on `sdt` in particular has grown over time; trust `help docx sdt`, not a hardcoded list).
 
 ## Mental Model & Inheritance
 
-A Word form is a `.docx` plus four OpenXML payload layers plain-docx skills do not touch: **`<w:sdt>`** content controls (5 types: text / richtext / dropdown / combobox / date), **`<w:ffData>`** legacy FormField (ONLY way to get a real checkbox on v1.0.63), **`<w:fldChar>`** complex fields (MERGEFIELD, REF, PAGEREF, SEQ, IF — template-time, not user-fill), and **`documentProtection`** (the lock that makes non-field text read-only in Word).
+A Word form is a `.docx` plus four OpenXML payload layers plain-docx skills do not touch: **`<w:sdt>`** content controls (types: text / richtext / dropdown / combobox / date / picture / group), **`<w:ffData>`** legacy FormField (still the only way to get a real checkbox — SDT `type=checkbox` is not implemented), **`<w:fldChar>`** complex fields (MERGEFIELD, REF, PAGEREF, SEQ, IF — template-time, not user-fill), and **`documentProtection`** (the lock that makes non-field text read-only in Word — and, on the CLI, `protection=forms` locks non-field content edits (those need `--force` or `raw-set`) but still allows form-field (SDT) edits, which is the point of forms protection).
 
 **No inheritance from docx v2.** docx's Delivery Gate (cover-fill %, live-PAGE check) does NOT apply — form QA is `view forms` + `query sdt alias+tag` + `protectionEnforced`.
 
@@ -71,9 +71,9 @@ A Word form is a `.docx` plus four OpenXML payload layers plain-docx skills do n
 2. **Single-quote any prop containing `$`** — `"Total: $50,000"` becomes `"Total: ,000"` after `$50` variable expansion. Correct: `'Total: $50,000'`.
 3. **`--after find:<text>` uses outer single quotes, never inner double quotes** — `--after find:"Client Signature:"` makes the quotes part of the search string; match fails. Correct: `--after 'find:Client Signature:'`.
 
-**`WARNING: UNSUPPORTED` (exit 2) is a silently-wrong element.** The CLI created the element *without* the rejected prop — dropdown with no items, date with default format, SDT with no lock. Any UNSUPPORTED in your build log means your command was wrong: stop, rewrite to Path B (raw-set) or a separate `set`. Do not ship on top.
+**`WARNING: UNSUPPORTED` (exit 2) is a silently-wrong element.** The CLI created the element *without* the rejected prop. Any UNSUPPORTED in your build log means a prop name the current CLI does not accept on that element — stop, check `help docx <element>` for the right prop name (most SDT props such as `items`/`format`/`lock` ARE accepted now; `maxlength` is not), fix the command, and re-run. Do not ship on top.
 
-**`protection=forms` is the LAST command.** Not CLI-enforced — `add` / `set` / `raw-set` still run under any protection mode — but finishing with protection gives Word users a consistent locked experience on first open.
+**`protection=forms` is the LAST structural command.** Once it is set, `protection=forms` locks non-field content (those edits need `--force` or `raw-set`) but still allows form-field (SDT) edits — which is the point of forms protection. A non-field content edit (e.g. `set /body/p[N] --prop text=`) is refused (`ERROR: Document is protected … use --force`); a form-field edit (e.g. `set /body/sdt[N] --prop text=` / `--prop alias=`) succeeds (exit 0). Use `Query("editable")` to find fillable fields. So finish all non-field (static layout) edits first, then lock; if you must edit static content afterward, pass `--force` (or temporarily clear protection, edit, re-lock).
 
 ### `--after find:` micro-playbook
 
@@ -130,41 +130,43 @@ Every form must satisfy these — Delivery Gate enforces each as an executable c
 
 ## Three Paths (core decision)
 
-CLI v1.0.63 exposes exactly **four canonical props** on SDT: `{type, tag, alias, text}`. Everything else — `items`, `format`, `lock`, `placeholder`, `name`, `maxlength` — is UNSUPPORTED at add-time and silently discarded. The skill therefore splits every SDT need into three paths. **Pick the path before writing a single command.**
+SDT props are **first-class on `add`** — confirm the current set with `officecli help docx sdt`. Today that includes `type, tag, alias, text, items, format, lock, placeholder/placeholderText, date.*` and the SDT types `text / richtext / dropdown / combobox / date / group / picture`. So most forms are pure `add` — no raw-set, no Word template. Two paths remain only for the genuinely-unreachable cases. **Pick the path before writing a single command.**
 
-### Path A — Pure CLI (simple forms)
+### Path A — Pure CLI (the default for almost everything)
 
-**Use when**: the field only needs a label, an initial text, and a type. Acceptable if dropdown/combobox items can be empty at first and dates can default to `yyyy-MM-dd`.
+**Use when**: any text / richtext / dropdown / combobox / date / picture / group SDT — including its options, date format, and lock. Pass the props straight on `add`; verify each persists with `get '/body/sdt[N]' --json`.
 
 ```bash
+# dropdown WITH its options and a non-default date format, in one add each — no raw-set:
 officecli add "$FILE" /body --type sdt \
-  --prop type=text \
-  --prop alias="Full Name" --prop tag=full_name \
-  --prop text="Enter full name"
-# Canonical follow-ups (not on add):
-# officecli set "$FILE" '/body/sdt[N]' --prop lock=sdtlocked
+  --prop type=dropdown --prop alias="Department" --prop tag=dept \
+  --prop items="Engineering,Finance,HR"
+officecli add "$FILE" /body --type sdt \
+  --prop type=date --prop alias="Start Date" --prop tag=start \
+  --prop format="yyyy年MM月dd日"
+# lock works on add AND set:
+officecli add "$FILE" /body --type sdt --prop type=text --prop tag=full_name \
+  --prop alias="Full Name" --prop text="Enter full name" --prop lock=sdtLocked
+# protection comes last, once all fields exist:
 # officecli set "$FILE" / --prop protection=forms
 ```
 
-### Path B — CLI + `raw-set` bridge (complex attrs)
+### Path B — CLI + `raw-set` bridge (only an attribute help does NOT expose)
 
-**Use when**: dropdown/combobox needs options, or date needs a non-default format. `raw-set` is OfficeCLI's universal OpenXML fallback — `officecli --help` lists it as a top-level command.
+**Use when**: you need an SDT attribute that `help docx sdt` does not list (e.g. a `<w:listItem>` whose `w:value` must differ from its display text, or a sdtPr child with no `--prop`). `raw-set` is OfficeCLI's universal OpenXML fallback — `officecli --help` lists it as a top-level command. For ordinary dropdowns use `--prop items=` (Path A); raw-set here is the exception, not the rule.
 
 ```bash
-# Step 1 — Path A skeleton (generates <w:dropDownList/> automatically)
-officecli add "$FILE" /body --type sdt \
-  --prop type=dropdown --prop alias="Department" --prop tag=dept
-
-# Step 2 — raw-set injects <w:listItem>s
+# Display text ≠ stored value — not expressible via items=, so inject the listItems directly:
+officecli add "$FILE" /body --type sdt --prop type=dropdown --prop alias="Department" --prop tag=dept
 officecli raw-set "$FILE" /document \
   --xpath "//w:sdt[w:sdtPr/w:tag/@w:val='dept']/w:sdtPr/w:dropDownList" \
   --action append \
-  --xml '<w:listItem xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" w:displayText="Engineering" w:value="Engineering"/><w:listItem xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" w:displayText="Finance" w:value="Finance"/>'
+  --xml '<w:listItem xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" w:displayText="Engineering" w:value="ENG"/><w:listItem xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" w:displayText="Finance" w:value="FIN"/>'
 ```
 
-### Path C — Word template (beyond raw-set)
+### Path C — Word template (only what no API reaches)
 
-**Use when**: `picture` SDT (signature image), real SDT checkbox (`type=checkbox` exits 1), `placeholderDocPart` prompt text, grouped SDTs wrapping multiple paragraphs, or custom richtext appearance. These involve cross-part relationships or nesting beyond `--prop` reach.
+**Use when**: a **real SDT checkbox** (`type=checkbox` still exits 1 — use a legacy FormField instead, see §Legacy FormField), a `placeholderDocPart` prompt-text part, or custom richtext appearance / cross-part nesting beyond `--prop` reach. Picture and grouped SDTs are NO LONGER here — they add fine via Path A.
 
 ```bash
 # One-time in Word: Developer tab → Insert Content Control → Save as template.docx
@@ -179,13 +181,15 @@ officecli set "$FILE" / --prop protection=forms
 
 | Need | Path | Note |
 |---|---|---|
-| text / richtext SDT with default string | **A** | four canonical props cover it |
-| text SDT that must be locked | **A + set lock** | `lock` only takes effect via `set`, not `add` |
-| dropdown / combobox **with options** | **B** | raw-set append `<w:listItem>` |
-| date SDT with non-default format | **B** | raw-set setattr `w:dateFormat/@w:val` |
+| text / richtext SDT with default string | **A** | `--prop type/alias/tag/text` |
+| text SDT that must be locked | **A** | `--prop lock=sdtLocked` works on `add` (and `set`) |
+| dropdown / combobox **with options** | **A** | `--prop items="A,B,C"` |
+| date SDT with non-default format | **A** | `--prop format="yyyy年MM月dd日"` |
+| signature picture SDT, grouped SDT | **A** | `--prop type=picture` / `type=group` add directly |
+| dropdown whose stored value ≠ display text | **B** | raw-set append `<w:listItem w:value=…>` |
 | real checkbox | **FormField** | `--type formfield --prop type=checkbox` (see §Legacy FormField) |
 | mail-merge placeholder | **MERGEFIELD** | `--type field --prop fieldType=mergefield` (see §MERGEFIELD) |
-| signature picture, grouped SDT, placeholder part | **C** | build skeleton in Word, fill via CLI |
+| real SDT checkbox / placeholder part / custom appearance | **C** | build skeleton in Word, fill via CLI |
 
 ## Quick Start — Path A + FormField (minimal intake form)
 
@@ -319,7 +323,7 @@ officecli close "$FILE"
 
 ## MERGEFIELD (data-driven track)
 
-`help docx field` on v1.0.63 declares a `fieldType` enum of ~30 values including `mergefield`, `ref`, `pageref`, `seq`, `if` — all CLI-expressible with their typed props. MERGEFIELD coexists with SDT in the same file but is reported by `query field` only; `view forms` does NOT list MERGEFIELDs (they are not user-fillable).
+`help docx field` declares a `fieldType` enum of ~30 values including `mergefield`, `ref`, `pageref`, `seq`, `if` — all CLI-expressible with their typed props. MERGEFIELD coexists with SDT in the same file but is reported by `query field` only; `view forms` does NOT list MERGEFIELDs (they are not user-fillable).
 
 **Canonical MERGEFIELD:**
 
@@ -338,7 +342,7 @@ officecli add "$FILE" '/body/p[1]' --type field --prop fieldType=mergefield --pr
 | Pattern | Call shape |
 |---|---|
 | Mail-merge placeholder | `--type field --prop fieldType=mergefield --prop name=<FieldName>` |
-| Mail-merge with numeric picture (money, percent) | `--type field --prop fieldType=mergefield --prop name=Amount --prop instr='MERGEFIELD Amount \# "#,##0.00"'`. On v1.0.63 the typed `format` prop is ignored for mergefield (prints a warning) — use `instr` (alias `instruction`) to embed the full field code. Verify: `query "$FILE" field --json \| jq '.data.results[].format.instruction'` must contain `\#` and the picture. |
+| Mail-merge with numeric picture (money, percent) | `--type field --prop fieldType=mergefield --prop name=Amount --prop instr='MERGEFIELD Amount \# "#,##0.00"'`. The typed `format` prop is ignored for mergefield (prints a warning) — use `instr` (alias `instruction`) to embed the full field code. Verify: `query "$FILE" field --json \| jq '.data.results[].format.instruction'` must contain `\#` and the picture. |
 | Mail-merge with date picture | `--type field --prop fieldType=mergefield --prop name=StartDate --prop instr='MERGEFIELD StartDate \@ "yyyy-MM-dd"'` |
 | Cross-reference to bookmark text | `--type field --prop fieldType=ref --prop name=<BookmarkName>` |
 | Cross-reference to bookmark's page number | `--type field --prop fieldType=pageref --prop name=<BookmarkName>` |
@@ -347,7 +351,7 @@ officecli add "$FILE" '/body/p[1]' --type field --prop fieldType=mergefield --pr
 | "Page X of Y" | two fields: `fieldType=page` + `fieldType=numpages` |
 | Conditional text | `--type field --prop fieldType=if --prop expression='{ MERGEFIELD Gender } = "Male"' --prop trueText="Mr." --prop falseText="Ms."` |
 
-### IF conditional (CLI-expressible on v1.0.63)
+### IF conditional (CLI-expressible)
 
 ```bash
 officecli add "$FILE" /body --type paragraph --prop text=""
@@ -370,7 +374,7 @@ Use FormField **when you need a real checkbox**. For text/dropdown, prefer SDT.
 `help docx formfield`: `type` (text/checkbox/check/dropdown), `name` (required, **≤ 20 chars** — OpenXML schema MaxLength; add passes longer but `validate` rejects), `text` (text only, alias `value`), `checked` (checkbox only).
 
 ```bash
-# CHECKBOX — the only real checkbox available in v1.0.63
+# CHECKBOX — the only real checkbox (SDT type=checkbox is not implemented)
 officecli add "$FILE" /body --type formfield --prop type=checkbox \
   --prop name=agree_terms --prop checked=false
 
@@ -407,15 +411,15 @@ officecli get "$FILE" /                                  # look for: protectionE
 
 | Mode | Word user can | CLI behavior |
 |---|---|---|
-| `forms` | Fill SDT + formfield only | All ops work; no `--force` needed |
-| `readOnly` | Read only | All ops work |
-| `comments` | Add comments only | All ops work |
-| `trackedChanges` | Edit with tracked changes only | All ops work |
+| `forms` | Fill SDT + formfield only | Form-field (SDT) edits work (exit 0); non-field content edits need `--force` or `raw-set` |
+| `readOnly` | Read only | Non-field edits need `--force`; raw-set bypasses |
+| `comments` | Add comments only | Non-field edits need `--force`; raw-set bypasses |
+| `trackedChanges` | Edit with tracked changes only | Non-field edits need `--force`; raw-set bypasses |
 | `none` | Full editing | All ops work |
 
-**KEY:** Document protection restricts **Word users**, not the CLI. You can fill / modify / lock a protected form via CLI freely. The CLI does NOT require `--force` on v1.0.63.
+**KEY:** Document protection restricts Word users AND the CLI. Under `protection=forms`, form-field (SDT) edits — `set /body/sdt[N] --prop text=` / `--prop alias=` — succeed (exit 0); this is the point of forms protection. Only NON-field content edits (e.g. `set /body/p[N] --prop text=`) are refused with `ERROR: Document is protected (mode: forms). … use --force to override`; pass `--force` (or `raw-set`, the only verb that fully bypasses protection) to edit static content anyway. Use `Query("editable")` to find the fields a Word user could still fill.
 
-### Lock values (applied via `set`, never `add`)
+### Lock values (settable on `add` and `set`)
 
 ```bash
 officecli set "$FILE" '/body/sdt[1]' --prop lock=sdtlocked           # content editable; control cannot be deleted
@@ -424,7 +428,7 @@ officecli set "$FILE" '/body/sdt[1]' --prop lock=sdtcontentlocked    # both lock
 # Omit lock entirely → unlocked (default)
 ```
 
-`--prop lock=...` on `add` is UNSUPPORTED (silently discarded). Apply lock via a separate `set`. Readback normalises to camelCase (`sdtLocked`) regardless of input case — both accepted.
+`--prop lock=...` works on `add` as well as `set` — set it inline when you create the control. Readback normalises to camelCase (`sdtLocked`) regardless of input case — both accepted.
 
 ### lock × `protection=forms` interaction
 
@@ -446,11 +450,23 @@ officecli add "$FILE" /body --type paragraph \
   --prop text="I authorize the above and acknowledge all clauses." --prop size=11 --prop spaceAfter=12pt
 PID=$(officecli query "$FILE" paragraph --json | jq -r '.data.results[-1].format.paraId')
 
-# v1.0.63 raw-set actions: append | prepend | insertbefore | insertafter | replace | remove | setattr
+# raw-set actions: append | prepend | insertbefore | insertafter | replace | remove | setattr
 # No `wrap` action — two-step instead: (1) insertbefore an empty <w:sdt><w:sdtContent/></w:sdt>,
 # (2) move the original <w:p> inside by `replace` on the sdtContent with a copy of the paragraph XML.
 # Simpler alternative: read the paragraph XML via `officecli raw`, then `replace` the whole <w:p> with <w:sdt>...<w:sdtContent>[original w:p]</w:sdtContent></w:sdt>:
-PARA_XML=$(officecli raw "$FILE" /document | awk "/w14:paraId=\"$PID\"/,/<\\/w:p>/" | tr -d '\n')
+# NOTE: this needs an XML-aware extraction, NOT awk. `raw /document` emits the whole document on ONE line,
+# so an awk range like `/paraId=.../,/<\/w:p>/` grabs the entire <w:document> (schema-invalid). Parse the XML
+# and pull the single <w:p> by paraId instead:
+PARA_XML=$(officecli raw "$FILE" /document | python3 -c '
+import sys, xml.etree.ElementTree as ET
+xml = sys.stdin.read(); pid = sys.argv[1]
+ns = {"w":"http://schemas.openxmlformats.org/wordprocessingml/2006/main","w14":"http://schemas.microsoft.com/office/word/2010/wordml"}
+for p, u in ns.items(): ET.register_namespace(p, u)
+root = ET.fromstring(xml); key = "{%s}paraId" % ns["w14"]
+for p in root.iter("{%s}p" % ns["w"]):
+    if p.attrib.get(key) == pid:
+        sys.stdout.write(ET.tostring(p, encoding="unicode")); break
+' "$PID")
 officecli raw-set "$FILE" /document \
   --xpath "//w:p[@w14:paraId='$PID']" \
   --action replace \
@@ -504,29 +520,24 @@ officecli add "$FILE" '/body/p[last()]' --type field \
   --prop fieldType=mergefield --prop name=ContractNo
 ```
 
-### Recipe (sow-b) SDT fields + Path B raw-set specials
+### Recipe (sow-b) SDT fields — all via Path A
 
-Adds the three block-level SDTs (project / date / dropdown), the inline signature SDT anchored via `--after 'find:Client Signature:'`, then Path B raw-set to inject the date format and dropdown items (both are UNSUPPORTED via `add --prop`).
+Adds the three block-level SDTs (project / date / dropdown) and the inline signature SDT anchored via `--after 'find:Client Signature:'`. The date format and dropdown items go straight on `add` — no raw-set needed.
 
 ```bash
 officecli add "$FILE" /body --type sdt --prop type=text \
   --prop alias="Project Name" --prop tag=project_name --prop text="Enter project name"
 officecli add "$FILE" /body --type sdt --prop type=date \
-  --prop alias="Contract Start Date" --prop tag=contract_start
+  --prop alias="Contract Start Date" --prop tag=contract_start --prop format="MM/dd/yyyy"
 officecli add "$FILE" /body --type sdt --prop type=dropdown \
-  --prop alias="Payment Schedule" --prop tag=payment_schedule
+  --prop alias="Payment Schedule" --prop tag=payment_schedule \
+  --prop items="Full Prepayment,Net 30 Upon Delivery"
 officecli add "$FILE" /body --type paragraph --prop text="Client Signature:" \
   --prop bold=true --prop spaceBefore=18pt --prop spaceAfter=4pt
 officecli add "$FILE" /body --type sdt --prop type=text \
   --prop alias="Signatory Name" --prop tag=signatory_name --prop text="Authorized Signatory" \
   --after 'find:Client Signature:'
-officecli raw-set "$FILE" /document \
-  --xpath "//w:sdt[w:sdtPr/w:tag/@w:val='contract_start']/w:sdtPr/w:date/w:dateFormat" \
-  --action setattr --xml "w:val=MM/dd/yyyy"
-officecli raw-set "$FILE" /document \
-  --xpath "//w:sdt[w:sdtPr/w:tag/@w:val='payment_schedule']/w:sdtPr/w:dropDownList" \
-  --action append \
-  --xml '<w:listItem xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" w:displayText="Full Prepayment" w:value="Full Prepayment"/><w:listItem xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" w:displayText="Net 30 Upon Delivery" w:value="Net 30 Upon Delivery"/>'
+# (Only reach for raw-set if a listItem's stored value must differ from its display text — see Path B.)
 ```
 
 ### Recipe (sow-c) Watermark + locks + document protection
@@ -597,8 +608,8 @@ officecli set "$FILE" / --prop protection=forms
 ```
 
 - Escape inner `"` in `xml` with `\"`. Use single-quoted heredoc `<<'EOF'` so `$var` does not expand.
-- **P0 batch trap:** unsupported props in batch are silently dropped, **no WARNING** (interactive `add` would print WARNING: UNSUPPORTED, exit 2). Defence: send only `{type, tag, alias, text}` in SDT entries; put items/format into `raw-set` entries in the same batch.
-- `batch` supports `add`, `set`, `get`, `query`, `remove`, `validate`, `raw-set` on v1.0.63.
+- **P0 batch trap:** genuinely-unsupported props in batch are silently dropped, **no WARNING** (interactive `add` would print WARNING: UNSUPPORTED, exit 2). Defence: send only props `help docx sdt` lists (`type/tag/alias/text/items/format/lock/...` are fine on `add`; `maxlength` is not), and verify with a readback after the batch.
+- `batch` supports `add`, `set`, `get`, `query`, `remove`, `validate`, `raw-set`.
 
 ## Delivery Gate (executable)
 
@@ -607,13 +618,11 @@ Run every gate below after every form. Each gate must print its `OK` line. Any `
 ```bash
 # Assumes FILE=<your-form.docx>, document has been closed with officecli close "$FILE"
 
-# Gate 1 — Validate (documentProtection waiver: K8 allows this ONE schema error under protection=forms)
+# Gate 1 — Validate (must be clean; protection=forms no longer produces a schema error)
 VAL_OUT=$(officecli validate "$FILE" 2>&1)
 VAL_ERRS=$(echo "$VAL_OUT" | grep -c '\[Schema\]')
-VAL_PROT=$(echo "$VAL_OUT" | grep -c 'documentProtection')
-if   [ "$VAL_ERRS" -eq 0 ]; then echo "Gate 1 OK (validate clean)"
-elif [ "$VAL_ERRS" -eq 1 ] && [ "$VAL_PROT" -eq 1 ]; then echo "Gate 1 OK (1 documentProtection waiver — K8)"
-else echo "REJECT Gate 1: $VAL_ERRS schema errors beyond the K8 waiver"; echo "$VAL_OUT"; exit 1
+if [ "$VAL_ERRS" -eq 0 ]; then echo "Gate 1 OK (validate clean)"
+else echo "REJECT Gate 1: $VAL_ERRS schema errors"; echo "$VAL_OUT"; exit 1
 fi
 
 # Gate 2 — Token / placeholder leak (labels used as visual underscore substitutes)
@@ -628,12 +637,12 @@ TOTAL=$((SDT_N + FF_N + FLD_N))
 [ "$TOTAL" -gt 0 ] && echo "Gate 3 OK ($SDT_N sdt + $FF_N formfield + $FLD_N field)" || { echo "REJECT Gate 3: 0 structured fields — this is not a form"; exit 1; }
 
 # Gate 4 — Every SDT has alias + tag (skill-imposed H2)
-# NOTE: v1.0.63 `query --json` wraps prop fields under `.format.{prop}` — jq paths below use `.format.alias` / `.format.tag` (not bare `.alias`).
+# NOTE: `query`/`get --json` wrap prop fields under `.data.results[N].format.{prop}` — use `.data.results[0].format.alias` / `.format.tag`, never bare `.alias` or `.data.format`.
 SDT_MISSING=$(officecli query "$FILE" sdt --json | jq '[.data.results[] | select(.format.alias == null or .format.alias == "" or .format.tag == null or .format.tag == "")] | length')
 [ "$SDT_MISSING" -eq 0 ] && echo "Gate 4 OK (every SDT has alias+tag)" || { echo "REJECT Gate 4: $SDT_MISSING SDT(s) missing alias or tag"; exit 1; }
 
 # Gate 5 — Protection enforced + per-field lock inventory
-PROT=$(officecli get "$FILE" / --json | jq -r '.data.format.protection // "none"')
+PROT=$(officecli get "$FILE" / --json | jq -r '.data.results[0].format.protection // "none"')
 [ "$PROT" = "forms" ] && echo "Gate 5 OK (protection=forms enforced)" || { echo "REJECT Gate 5: protection is '$PROT', expected 'forms'"; exit 1; }
 officecli view "$FILE" forms | head -40   # visual spot-check: every dropdown shows items=; every date shows format=; every locked SDT shows lock=
 
@@ -648,21 +657,19 @@ BAD_CB=$(officecli query "$FILE" sdt --json | jq '[.data.results[] | select(.for
 
 | # | Issue | Behavior | Workaround |
 |---|---|---|---|
-| K1 | SDT `type=checkbox` not implemented on v1.0.63 | `add ... --type sdt --prop type=checkbox` → `Error: SDT type 'checkbox' is not implemented`, exit 1 | Use `--type formfield --prop type=checkbox`, or Path C template |
-| K2 | SDT `items` / `format` / `lock` UNSUPPORTED on `add` | `WARNING: UNSUPPORTED props`, exit 2; element created without them | Path B `raw-set` for items/format; separate `set` for lock |
-| K3 | SDT `placeholder` / `name` / `maxlength` UNSUPPORTED | `WARNING: UNSUPPORTED`, exit 2; element still created | Use `text` for initial content; use `alias`+`tag` instead of `name`; prompt text requires Path C |
-| K4 | SDT `items` / `format` / `type` not settable after creation | `set --prop items=...` → `UNSUPPORTED props (use raw-set instead)` | Path B `raw-set`, or `remove` + re-add |
+| K1 | SDT `type=checkbox` not implemented | `add ... --type sdt --prop type=checkbox` → `Error: SDT type 'checkbox' is not implemented`, exit 1 (error now lists the supported types incl. group/picture) | Use `--type formfield --prop type=checkbox` |
+| K3 | SDT `maxlength` UNSUPPORTED on `add` | `WARNING: UNSUPPORTED: maxlength`, exit 2; element still created. (`items` / `format` / `lock` / `placeholderText` are NOW supported on `add` — only `maxlength` is rejected; `name` is accepted but a no-op on SDT — use `alias`/`tag`) | Enforce length downstream; use `text` for initial content |
+| K4 | SDT `items` / `format` / `type` not settable AFTER creation | `set --prop items=...` → `UNSUPPORTED props (use raw-set instead)`. (They ARE settable on `add` — set them inline at creation) | Set at `add` time; to change later, Path B `raw-set` or `remove` + re-add |
 | K5 | FormField `maxlength` UNSUPPORTED | `WARNING: UNSUPPORTED: maxlength`; formfield created | Enforce length in downstream validation |
-| K6 | FormField dropdown `items` UNSUPPORTED | Dropdown formfield is created with empty option list | Use SDT dropdown + Path B, or build in Word (Path C) |
-| K7 | Watermark `opacity` / `width` / `height` / `size` UNSUPPORTED | Watermark created without them; `get /watermark` still prints hardcoded `opacity=0.5` | Do not set them. For size, open Word + adjust shape (Phase 2) |
-| K8 | `validate` reports a `documentProtection` Schema error under `protection=forms` | Prints the error line, exits **0**. Gate 1 waives this one specific error | Confirm protection with `get $FILE /` → `protectionEnforced=True`. Known validator bug, not a document bug |
-| K9 | Batch mode silently drops UNSUPPORTED props | No `WARNING` line; batch reports "N succeeded" even when props were dropped | Pass only `{type, tag, alias, text}` in batch SDT entries; put items/format into `raw-set` entries in the same batch |
+| K6 | FormField dropdown `items` UNSUPPORTED | Dropdown formfield is created with empty option list | Use an SDT dropdown with `--prop items=` instead |
+| K7 | Watermark `width` / `height` not settable | Watermark created without them; `opacity` IS settable on `add` and reads back (real dims are computed) | For an exact size, open Word + adjust the shape (Phase 2) |
+| K9 | Batch mode silently drops genuinely-UNSUPPORTED props | No `WARNING` line; batch reports "N succeeded" even when a prop (e.g. `maxlength`) was dropped | Keep batch SDT entries to props `help docx sdt` lists; verify with a readback after the batch |
 | K13 | FormField `name` > 20 characters | `add` returns exit 0 with no warning; `validate` later reports `[Schema] ... MaxLength=20` on `/w:ffData/w:name` | Keep `name` ≤ 20 characters (OpenXML schema limit). SDT `alias` / `tag` have no such limit |
 | K14 | `shd.fill` on a paragraph emits schema-invalid `<w:pPr>/<w:shd>` | `validate` reports 2 schema errors per instance (`unexpected child element`, `required attribute 'val' missing`); Word renders it anyway | Apply highlight on the run instead (`shading=HEX`, flat canonical), or raw-set `<w:shd w:val="clear" w:fill="HEX"/>` into the run's `<w:rPr>` |
 | K15 | `view forms` does NOT list MERGEFIELDs | Only SDT + formfield in output; MERGEFIELDs are template-time, not end-user fillable | Treat `query field` and `view forms` as two disjoint inventories. Every recipe verifies both |
 | K16 | Header / footer are predefined at section creation (default/first/even, 3 each) | `add $FILE /header ...` returns `already exists` or silently no-ops on the first call | First mutation uses `set` against the existing part: `officecli query $FILE header --json` to read `type`, then `set '/header[@type=default]' --prop text=...`. Only use `add` for a brand-new section's header/footer |
-| K17 | Watermark injected into header emits `<w:noProof>` child that is schema-invalid | `validate` adds an extra `[Schema]` error at `/header[N]/w:sdt/.../w:noProof` — NOT covered by K8's documentProtection waiver | After `add $FILE / --type watermark`, run once per header part: `officecli raw-set $FILE /word/header1.xml --xpath "//w:noProof" --action remove` (repeat for `header2.xml`, `header3.xml` if present) |
-| K18 | `query --json` wraps prop fields under `.format.{prop}` | Writing jq against bare `.alias` / `.tag` / `.protection` returns 0 matches, Gate 4/5 falsely report "missing=N" | Always prefix jq with `.format.`: `.data.results[].format.alias`, `.data.results[].format.tag`, `.data.format.protection` (for `get /`). Same for `.format.type` and `.format.paraId` |
+| K17 | Watermark injected into header emits `<w:noProof>` child that is schema-invalid | `validate` adds an extra `[Schema]` error at `/header[N]/w:sdt/.../w:noProof` — a real schema error to fix, not a benign one | After `add $FILE / --type watermark`, run once per header part: `officecli raw-set $FILE /word/header1.xml --xpath "//w:noProof" --action remove` (repeat for `header2.xml`, `header3.xml` if present) |
+| K18 | `query`/`get --json` wrap prop fields under `.data.results[N].format.{prop}` | Writing jq against bare `.alias` / `.tag` / `.protection`, or `.data.format.*`, returns null/0 matches and Gate 4/5 falsely report "missing=N" | Use `.data.results[].format.alias` / `.format.tag`; for `get /` use `.data.results[0].format.protection` (NOT `.data.format.protection`). Same for `.format.type` / `.format.paraId` |
 | K19 | LibreOffice renders formfield checkbox as `☐☐` (double box) in PDF export | Cosmetic only — Word / WPS render a single box, clickable to toggle ☑. A LibreOffice renderer quirk, flagged as [RENDERER-BUG] | Do not try to "fix" in the skill. If an evaluator screenshots from LibreOffice-generated PDF and sees `☐☐`, attribute to [RENDERER-BUG], not a form-quality defect |
 
 ## Phase 2 — enhance in Word
@@ -671,12 +678,12 @@ Some polish is out of CLI scope. Hand the file to a human for these; none are re
 
 | Need | Why open Word |
 |---|---|
-| Signature image field (`picture` SDT) | Cross-part relationship + media file |
-| Real SDT checkbox with specific locking | `type=checkbox` exits 1; use Developer → Check Box Content Control |
+| Real SDT checkbox with specific locking | `type=checkbox` exits 1; use Developer → Check Box Content Control (or a legacy FormField checkbox via CLI) |
 | Prompt text ("Click here to enter a date") | Needs `placeholderDocPart` in `/word/glossary/document.xml` |
-| Grouped SDT wrapping multiple paragraphs | Block-level `<w:sdt>` nesting beyond `add` |
 | Custom richtext default appearance | Adjust the referenced style in Word's style pane |
-| Watermark resize | `width` / `height` not in schema; drag shape handles |
+| Watermark resize | `width` / `height` not settable; drag shape handles |
+
+(`picture` and `group` SDTs add directly via `--type sdt --prop type=picture` / `type=group` — no longer Phase-2 items.)
 
 For the first four, build the skeleton once (Path C) and reuse.
 

--- a/crates/aionui-app/assets/builtin-skills/officecli-xlsx/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/officecli-xlsx/SKILL.md
@@ -242,12 +242,12 @@ officecli query "$FILE" 'Sheet1!B[value!=0]'      # sheet-scoped
 
 Operators: `=`, `!=`, `~=` (contains), `>=`, `<=`, `[attr]` (exists).
 
-**Merge cells shortcut.** `officecli query $FILE merge` or `mergedrange` — both are aliases for `mergeCell` (1.0.60+). Returns every merged range in the workbook without hand-walking `<mergeCell>` entries.
+**Merge cells shortcut.** `officecli query $FILE merge` or `mergedrange` — both are aliases for `mergeCell`. Returns every merged range in the workbook without hand-walking `<mergeCell>` entries.
 
 **When the data is big enough that a row-walk is useless**, reach for Excel's own analytical elements:
 
 - Build a **pivot table** with `officecli add` (`--type pivottable`) to group/aggregate without writing 20 SUMIFs. Attach a **slicer** (`--type slicer`) to give the reader a filter UI.
-- Drop a **sparkline** (`--type sparkline`) in a row to show per-row trends — cheaper than one line chart per row and they print inline. `type` is a strict enum: **`line | column | stacked`** (plus aliases `winloss` / `win-loss` → `stacked`). Invalid `type=` values hard-fail on 1.0.58+ — no silent fallback to `line` anymore.
+- Drop a **sparkline** (`--type sparkline`) in a row to show per-row trends — cheaper than one line chart per row and they print inline. `type` is a strict enum: **`line | column | stacked`** (plus aliases `winloss` / `win-loss` → `stacked`). Invalid `type=` values hard-fail — no silent fallback to `line` anymore.
 - Run `officecli help xlsx pivottable`, `officecli help xlsx slicer`, `officecli help xlsx sparkline` for the exact prop names.
 
 ## Creating & Editing
@@ -317,7 +317,7 @@ Three common flavors, each with its own prop shape (consult `officecli help xlsx
 
 - **Color scales**: cells shaded on a gradient by value — `type=colorscale` with `minColor` / `midColor` / `maxColor`.
 - **Data bars**: in-cell bars showing magnitude — `type=databar`. Set explicit `min` / `max` for consistent scaling across a column; defaults are valid if you omit them.
-- **Formula rules**: highlight row when a condition is true — `type=formulacf` with `formula="$C2>1000"` and a fill/font.
+- **Formula rules** (the `formulacf` element): highlight row when a condition is true — `type=formula` with `formula="$C2>1000"` and a fill/font.
 
 Rule: apply CF sparingly. A workbook where every cell is colored tells the reader nothing.
 
@@ -461,7 +461,7 @@ CLI constraints and gaps to work around — not defects in the output file.
 - **Batch + resident for formulas — avoid.** Observed deadlocks (CPU 99%, `main pipe busy`, kill -9 required) for cross-sheet formula batches even at 3-5 ops; the prior "≤ 12 ops safe" guideline is **not reliable**. Rule: **cross-sheet formulas go through non-resident one-big-batch OR individual `set`** (100% reliable). Pure value-set batches (no formulas) stay reliable at 50-80+ ops even in resident. **Multiple officecli resident processes on the same machine also contend** — if another agent/session is running resident, expect non-deterministic hangs.
 - **Conditional formatting naming asymmetry** — the element name for `--type` is `conditionalformatting`; the path suffix is `/cf[N]`. Use `officecli help xlsx conditionalformatting` for schema, `/cf[N]` for paths.
 - **Sheet `position` prop on add** — help says Add processes `position`, but the prop is often ignored. Reorder with `officecli move --index` / `--after` / `--before` after creating the sheet.
-- **`remove /sheet[N]` cascade guard** — 1.0.59+ rejects sheet remove/rename when the sheet is referenced by validation / conditional format / sparkline / hyperlink / named range on another sheet. Remove those dependent elements first, then remove the sheet.
+- **`remove /sheet[N]` cascade guard** — rejects sheet remove/rename when the sheet is referenced by validation / conditional format / sparkline / hyperlink / named range on another sheet. Remove those dependent elements first, then remove the sheet.
 - **Batch JSON rejects cell `color` alias** — inside batch `props`, `"color": "FF0000"` errors `ambiguous in cell context — use 'font.color' (text) or 'fill' (bg)`. The CLI at shell level accepts `--prop color=...` / `--prop size=14` as aliases on non-cell elements, but inside batch JSON on a cell always write the full dotted name: `"font.color"`, `"font.size"`, `"font.name"`.
 
 ### Renderer caveats (cross-viewer color fidelity)


### PR DESCRIPTION
## Summary

Sync the builtin officecli skills under `crates/aionui-app/assets/builtin-skills/` with the latest upstream OfficeCli `main` (`54d7b0e6` → `c764bb7d`), applied as upstream **deltas** so the AionUi-local Windows platform-note blocks (#489) are preserved.

9 SKILL.md files refreshed:
- `morph-ppt`
- `officecli-academic-paper`
- `officecli-data-dashboard`
- `officecli-docx`
- `officecli-financial-model`
- `officecli-pitch-deck`
- `officecli-pptx`
- `officecli-word-form`
- `officecli-xlsx`

No file adds/removes and no non-SKILL.md (reference/asset) changes upstream this round.

## Verification

Each changed file was diffed line-for-line against upstream `c764bb7d`, in both directions:
- **Nothing missing** — every upstream line is present.
- **Only addition** — the AionUi-local Windows platform-note block.

No code changes; assets only.

## Test plan

- [ ] CI build (`cargo build -p aionui-app`) — corpus is embedded via `include_dir!`
- [ ] Skills hub renders the refreshed SKILL.md content for each changed skill