### PR TITLE
fix(agent): expose runtime catalogs from metadata

### DIFF
--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -280,6 +280,7 @@ impl AgentRegistry {
             .map(|meta| {
                 let status = derive_management_status(&meta);
                 let diagnostics = derive_management_diagnostics(&meta, status);
+                let handshake = meta.handshake;
                 AgentManagementRow {
                     id: meta.id,
                     icon: meta.icon,
@@ -299,6 +300,9 @@ impl AgentRegistry {
                     native_skills_dirs: meta.native_skills_dirs,
                     behavior_policy: meta.behavior_policy,
                     yolo_id: meta.yolo_id,
+                    config_options: handshake.config_options.clone(),
+                    available_modes: handshake.available_modes.clone(),
+                    available_models: handshake.available_models.clone(),
                     sort_order: meta.sort_order,
                     team_capable: meta.team_capable,
                     status,

--- a/crates/aionui-ai-agent/src/registry_tests.rs
+++ b/crates/aionui-ai-agent/src/registry_tests.rs
@@ -223,3 +223,91 @@ async fn management_rows_derive_missing_diagnostics_from_probe_reason() {
         Some("definitely-missing-cli")
     );
 }
+
+#[tokio::test]
+async fn management_rows_project_runtime_catalogs_from_agent_metadata() {
+    let db = init_database_memory().await.unwrap();
+    let repo: Arc<dyn IAgentMetadataRepository> = Arc::new(SqliteAgentMetadataRepository::new(db.pool().clone()));
+
+    repo.upsert(&UpsertAgentMetadataParams {
+        id: "agent-with-catalog",
+        icon: None,
+        name: "Catalog Agent",
+        name_i18n: None,
+        description: None,
+        description_i18n: None,
+        backend: Some("claude".into()),
+        agent_type: "acp",
+        agent_source: "builtin",
+        agent_source_info: None,
+        enabled: true,
+        command: None,
+        args: Some("[]"),
+        env: Some("[]"),
+        native_skills_dirs: None,
+        behavior_policy: None,
+        yolo_id: None,
+        agent_capabilities: None,
+        auth_methods: None,
+        config_options: Some(
+            r#"{"config_options":[{"id":"model","type":"select","category":"model","options":[{"value":"claude-opus","label":"Claude Opus"}],"current_value":"claude-opus"}]}"#,
+        ),
+        available_modes: Some(
+            r#"{"current_mode_id":"plan","available_modes":[{"id":"plan","name":"Plan"}]}"#,
+        ),
+        available_models: Some(
+            r#"{"current_model_id":"claude-opus","current_model_label":"Claude Opus","available_models":[{"id":"claude-opus","label":"Claude Opus"}]}"#,
+        ),
+        available_commands: None,
+        sort_order: 100,
+    })
+    .await
+    .unwrap();
+
+    let registry = AgentRegistry::new(repo);
+    registry.hydrate().await.unwrap();
+
+    let row = registry
+        .list_management_rows()
+        .await
+        .into_iter()
+        .find(|item| item.id == "agent-with-catalog")
+        .unwrap();
+    let row_json = serde_json::to_value(&row).unwrap();
+
+    assert_eq!(
+        row_json["available_models"]["current_model_id"].as_str(),
+        Some("claude-opus")
+    );
+    assert_eq!(row_json["available_modes"]["current_mode_id"].as_str(), Some("plan"));
+    assert_eq!(
+        row_json["config_options"]["config_options"][0]["current_value"].as_str(),
+        Some("claude-opus")
+    );
+}
+
+#[tokio::test]
+async fn management_rows_include_aionrs_builtin_mode_catalog() {
+    let db = init_database_memory().await.unwrap();
+    let repo: Arc<dyn IAgentMetadataRepository> = Arc::new(SqliteAgentMetadataRepository::new(db.pool().clone()));
+    let registry = AgentRegistry::new(repo);
+    registry.hydrate().await.unwrap();
+
+    let row = registry
+        .list_management_rows()
+        .await
+        .into_iter()
+        .find(|item| item.agent_type == AgentType::Aionrs)
+        .unwrap();
+    let row_json = serde_json::to_value(&row).unwrap();
+
+    assert_eq!(row_json["available_modes"]["current_mode_id"].as_str(), Some("default"));
+    assert_eq!(
+        row_json["available_modes"]["available_modes"][1]["id"].as_str(),
+        Some("auto_edit")
+    );
+    assert_eq!(
+        row_json["config_options"]["config_options"][0]["options"][2]["value"].as_str(),
+        Some("yolo")
+    );
+}

--- a/crates/aionui-api-types/src/agent_discovery.rs
+++ b/crates/aionui-api-types/src/agent_discovery.rs
@@ -277,6 +277,12 @@ pub struct AgentManagementRow {
     pub behavior_policy: BehaviorPolicy,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub yolo_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config_options: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub available_modes: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub available_models: Option<serde_json::Value>,
     pub sort_order: i64,
     #[serde(default)]
     pub team_capable: bool,

--- a/crates/aionui-app/tests/assistants_e2e.rs
+++ b/crates/aionui-app/tests/assistants_e2e.rs
@@ -96,6 +96,9 @@ fn test_agent_row(id: &str, backend: Option<&str>, agent_type: AgentType, name: 
             ..Default::default()
         },
         yolo_id: None,
+        config_options: None,
+        available_modes: None,
+        available_models: None,
         sort_order: 0,
         team_capable: true,
         status: AgentManagementStatus::Online,

--- a/crates/aionui-assistant/src/service.rs
+++ b/crates/aionui-assistant/src/service.rs
@@ -2639,6 +2639,9 @@ mod tests {
                 ..Default::default()
             },
             yolo_id: None,
+            config_options: None,
+            available_modes: None,
+            available_models: None,
             sort_order: 3100,
             team_capable: true,
             status,

--- a/crates/aionui-db/migrations/015_aionrs_mode_catalog.sql
+++ b/crates/aionui-db/migrations/015_aionrs_mode_catalog.sql
@@ -1,0 +1,36 @@
+-- Migration 015: persist the built-in aionrs mode catalog.
+--
+-- aionrs is not an ACP backend, so it does not populate agent_metadata through
+-- ACP handshake catalog sync. Pre-conversation surfaces such as Guid still read
+-- mode options from agent_metadata via /api/agents/management, so seed the
+-- stable aionrs runtime mode catalog here.
+
+UPDATE agent_metadata
+SET
+    available_modes = '{
+      "current_mode_id": "default",
+      "available_modes": [
+        { "id": "default", "name": "Default" },
+        { "id": "auto_edit", "name": "Auto Edit" },
+        { "id": "yolo", "name": "YOLO" }
+      ]
+    }',
+    config_options = '{
+      "config_options": [
+        {
+          "id": "mode",
+          "name": "Mode",
+          "category": "mode",
+          "type": "select",
+          "current_value": "default",
+          "options": [
+            { "value": "default", "name": "Default" },
+            { "value": "auto_edit", "name": "Auto Edit" },
+            { "value": "yolo", "name": "YOLO" }
+          ]
+        }
+      ]
+    }',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_type = 'aionrs'
+  AND agent_source = 'internal';

--- a/crates/aionui-db/src/repository/sqlite_agent_metadata.rs
+++ b/crates/aionui-db/src/repository/sqlite_agent_metadata.rs
@@ -364,8 +364,30 @@ mod tests {
         let claude = repo.get("2d23ff1c").await.unwrap().expect("seeded claude row");
         assert_eq!(claude.icon.as_deref(), Some("/api/assets/logos/ai-major/claude.svg"));
 
-        let aionrs = repo.get("632f31d2").await.unwrap().expect("seeded aion cli row");
+        let rows = repo.list_all().await.unwrap();
+        let aionrs = rows
+            .iter()
+            .find(|row| row.agent_type == "aionrs" && row.agent_source == "internal")
+            .expect("seeded aion cli row");
         assert_eq!(aionrs.icon.as_deref(), Some("/api/assets/logos/brand/aion.svg"));
+        let aionrs_modes: serde_json::Value =
+            serde_json::from_str(aionrs.available_modes.as_deref().expect("aionrs modes catalog")).unwrap();
+        assert_eq!(aionrs_modes["current_mode_id"].as_str(), Some("default"));
+        assert_eq!(
+            aionrs_modes["available_modes"]
+                .as_array()
+                .expect("aionrs available modes")
+                .iter()
+                .filter_map(|item| item.get("id").and_then(serde_json::Value::as_str))
+                .collect::<Vec<_>>(),
+            vec!["default", "auto_edit", "yolo"]
+        );
+        let aionrs_config_options: serde_json::Value =
+            serde_json::from_str(aionrs.config_options.as_deref().expect("aionrs config options")).unwrap();
+        assert_eq!(
+            aionrs_config_options["config_options"][0]["options"][1]["value"].as_str(),
+            Some("auto_edit")
+        );
 
         let kiro = repo.get("e044000d").await.unwrap().expect("seeded kiro row");
         assert!(kiro.icon.is_none());

--- a/crates/aionui-db/tests/cron_assistant_first_migration.rs
+++ b/crates/aionui-db/tests/cron_assistant_first_migration.rs
@@ -160,6 +160,40 @@ async fn seed_legacy_assistant_identity(pool: &sqlx::SqlitePool) {
     .unwrap();
 }
 
+#[tokio::test]
+async fn migration_015_populates_aionrs_catalog_by_agent_type() {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+
+    run_migrations_through(&pool, 14).await;
+    sqlx::query(
+        "INSERT INTO agent_metadata (
+            id, name, backend, command, agent_type, enabled, agent_source, sort_order, created_at, updated_at
+         ) VALUES ('agent-aionrs', 'Aion CLI', NULL, '', 'aionrs', 1, 'internal', 100, 1, 1)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    run_migration(&pool, 15).await;
+
+    let row = sqlx::query(
+        "SELECT available_modes, config_options
+         FROM agent_metadata
+         WHERE id = 'agent-aionrs'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let available_modes: String = row.get("available_modes");
+    let config_options: String = row.get("config_options");
+    assert!(available_modes.contains("\"auto_edit\""));
+    assert!(config_options.contains("\"yolo\""));
+}
+
 async fn insert_legacy_cron(
     pool: &sqlx::SqlitePool,
     id: &str,


### PR DESCRIPTION
## Summary
- Expose `config_options`, `available_modes`, and `available_models` on `/api/agents/management` rows from persisted `agent_metadata` handshake data.
- Seed and migrate built-in aionrs runtime mode catalog from `agent_metadata`, keyed by `agent_type='aionrs'` and `agent_source='internal'` instead of a fixed id.
- Add regression coverage for management catalog projection and legacy aionrs-id migration behavior.

## Test Plan
- `cargo test -p aionui-db seed_rows_include_icon_backfill`
- `cargo test -p aionui-db migration_015_populates_aionrs_catalog_by_agent_type`
- `cargo test -p aionui-ai-agent management_rows_project_runtime_catalogs_from_agent_metadata`
- `cargo test -p aionui-ai-agent management_rows_include_aionrs_builtin_mode_catalog`
- `cargo fmt --all -- --check`
