### PR TITLE
fix(assistant): expose auto-inject skills and preserve assistant rules

### DIFF
--- a/crates/aionui-api-types/src/skill.rs
+++ b/crates/aionui-api-types/src/skill.rs
@@ -25,6 +25,9 @@ pub enum SkillSourceResponse {
 /// resolve it), and `relative_location` carries the path the frontend
 /// passes back into `POST /api/skills/builtin-skill` (e.g.
 /// `"auto-inject/cron/SKILL.md"` or `"{name}/SKILL.md"`).
+/// `is_auto_inject` is true only for built-in skills under
+/// `auto-inject/`, so clients do not need to infer that behavior from
+/// path strings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SkillListItemResponse {
     pub name: String,
@@ -32,6 +35,8 @@ pub struct SkillListItemResponse {
     pub location: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub relative_location: Option<String>,
+    #[serde(default)]
+    pub is_auto_inject: bool,
     pub is_custom: bool,
     pub source: SkillSourceResponse,
 }
@@ -288,6 +293,7 @@ mod tests {
             description: "Does things".into(),
             location: "/home/user/.aionui/skills/my-skill".into(),
             relative_location: None,
+            is_auto_inject: false,
             is_custom: true,
             source: SkillSourceResponse::Custom,
         };
@@ -295,7 +301,9 @@ mod tests {
         assert_eq!(json["name"], "my-skill");
         // Project-wide wire contract: field names are snake_case.
         assert_eq!(json["is_custom"], true);
+        assert_eq!(json["is_auto_inject"], false);
         assert!(json.get("isCustom").is_none());
+        assert!(json.get("isAutoInject").is_none());
         assert_eq!(json["source"], "custom");
         // Absent for custom source — Option<String>::None is skipped.
         assert!(json.get("relative_location").is_none());
@@ -309,13 +317,16 @@ mod tests {
             description: "Schedule recurring tasks".into(),
             location: "/home/user/.aionui/builtin-skills-view/cron/SKILL.md".into(),
             relative_location: Some("auto-inject/cron/SKILL.md".into()),
+            is_auto_inject: true,
             is_custom: false,
             source: SkillSourceResponse::Builtin,
         };
         let json = serde_json::to_value(&item).unwrap();
         // Project-wide wire contract: relative_location stays snake_case.
         assert_eq!(json["relative_location"], "auto-inject/cron/SKILL.md");
+        assert_eq!(json["is_auto_inject"], true);
         assert!(json.get("relativeLocation").is_none());
+        assert!(json.get("isAutoInject").is_none());
         assert_eq!(json["source"], "builtin");
     }
 
@@ -327,13 +338,29 @@ mod tests {
             "description": "Schedule",
             "location": "/tmp/view/cron/SKILL.md",
             "relative_location": "auto-inject/cron/SKILL.md",
+            "is_auto_inject": true,
             "is_custom": false,
             "source": "builtin",
         });
         let item: SkillListItemResponse = serde_json::from_value(raw).unwrap();
         assert_eq!(item.name, "cron");
         assert!(!item.is_custom);
+        assert!(item.is_auto_inject);
         assert_eq!(item.relative_location.as_deref(), Some("auto-inject/cron/SKILL.md"));
+    }
+
+    #[test]
+    fn test_skill_list_item_deserializes_missing_auto_inject_as_false() {
+        let raw = json!({
+            "name": "review",
+            "description": "Review",
+            "location": "/tmp/view/review/SKILL.md",
+            "relative_location": "review/SKILL.md",
+            "is_custom": false,
+            "source": "builtin",
+        });
+        let item: SkillListItemResponse = serde_json::from_value(raw).unwrap();
+        assert!(!item.is_auto_inject);
     }
 
     #[test]

--- a/crates/aionui-app/tests/extension_e2e.rs
+++ b/crates/aionui-app/tests/extension_e2e.rs
@@ -1360,6 +1360,7 @@ async fn sl1_list_skills_tags_builtin_and_custom_with_source_field() {
     let review = &by_name["review"];
     assert_eq!(review["source"], "builtin");
     assert_eq!(review["is_custom"], false);
+    assert_eq!(review["is_auto_inject"], false);
     assert!(
         review["location"].as_str().unwrap().contains("review"),
         "location should point at the skill dir",
@@ -1368,6 +1369,7 @@ async fn sl1_list_skills_tags_builtin_and_custom_with_source_field() {
     let my_skill = &by_name["my-skill"];
     assert_eq!(my_skill["source"], "custom");
     assert_eq!(my_skill["is_custom"], true);
+    assert_eq!(my_skill["is_auto_inject"], false);
 }
 
 #[tokio::test]
@@ -1436,15 +1438,18 @@ async fn ba1_unified_skill_list_includes_auto_inject_builtin_entries() {
 
     let cron = &by_name["cron"];
     assert_eq!(cron["source"], "builtin");
+    assert_eq!(cron["is_auto_inject"], true);
     assert_eq!(cron["relative_location"], "auto-inject/cron/SKILL.md");
     assert_eq!(cron["description"], "Schedule recurring tasks");
 
     let skill_creator = &by_name["skill-creator"];
     assert_eq!(skill_creator["source"], "builtin");
+    assert_eq!(skill_creator["is_auto_inject"], true);
     assert_eq!(skill_creator["relative_location"], "auto-inject/skill-creator/SKILL.md");
 
     let review = &by_name["review"];
     assert_eq!(review["source"], "builtin");
+    assert_eq!(review["is_auto_inject"], false);
     assert_eq!(review["relative_location"], "review/SKILL.md");
 }
 

--- a/crates/aionui-assistant/src/service.rs
+++ b/crates/aionui-assistant/src/service.rs
@@ -308,6 +308,9 @@ impl AssistantService {
             let avatar_value = row.icon.as_deref().filter(|value| !value.trim().is_empty());
             let (definition, should_upsert) = if let Some(mut definition) = existing_definition {
                 let avatar_type = if avatar_value.is_some() { "emoji" } else { "none" };
+                let should_upgrade_skill_defaults = definition.default_skills_mode == "auto"
+                    && decode_str_list(Some(definition.default_skill_ids.as_str()))?.is_empty()
+                    && decode_str_list(Some(definition.default_disabled_builtin_skill_ids.as_str()))?.is_empty();
                 let identity_changed = definition.name != row.name
                     || definition.avatar_type != avatar_type
                     || definition.avatar_value.as_deref() != avatar_value
@@ -319,7 +322,10 @@ impl AssistantService {
                 definition.avatar_value = avatar_value.map(ToOwned::to_owned);
                 definition.agent_id = row.id.clone();
                 definition.source_ref = Some(row.id.clone());
-                (definition, identity_changed)
+                if should_upgrade_skill_defaults {
+                    definition.default_skills_mode = "fixed".into();
+                }
+                (definition, identity_changed || should_upgrade_skill_defaults)
             } else {
                 (
                     AssistantDefinitionRow {
@@ -350,7 +356,7 @@ impl AssistantService {
                         default_model_value: None,
                         default_permission_mode: "auto".into(),
                         default_permission_value: None,
-                        default_skills_mode: "auto".into(),
+                        default_skills_mode: "fixed".into(),
                         default_skill_ids: "[]".into(),
                         custom_skill_names: "[]".into(),
                         default_disabled_builtin_skill_ids: "[]".into(),
@@ -2763,6 +2769,45 @@ mod tests {
         assert_eq!(bare.agent_status, aionui_api_types::AgentManagementStatus::Online);
         assert!(bare.team_selectable);
         assert!(!bare.deletable);
+
+        let detail = fx.service.get_detail("bare:agent-claude", Some("en-US")).await.unwrap();
+        assert_eq!(detail.defaults.skills.mode, "fixed");
+        assert!(detail.defaults.skills.value.is_empty());
+        assert!(detail.capabilities.default_disabled_builtin_skill_ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn reconcile_upgrades_empty_generated_auto_skill_defaults_to_fixed() {
+        let fx = fixture_with_options(FixtureOpts {
+            agent_rows: vec![mk_agent_row(
+                "agent-claude",
+                "claude",
+                aionui_api_types::AgentManagementStatus::Online,
+            )],
+            ..Default::default()
+        })
+        .await;
+
+        let definition = fx
+            .definition_repo
+            .get_by_assistant_id("bare:agent-claude")
+            .await
+            .unwrap()
+            .expect("generated assistant definition should exist after bootstrap");
+        let mut legacy_definition = definition.clone();
+        legacy_definition.default_skills_mode = "auto".into();
+        legacy_definition.default_skill_ids = "[]".into();
+        legacy_definition.default_disabled_builtin_skill_ids = "[]".into();
+        fx.definition_repo
+            .upsert(&upsert_params_from_definition(&legacy_definition))
+            .await
+            .unwrap();
+
+        let detail = fx.service.get_detail("bare:agent-claude", Some("en-US")).await.unwrap();
+
+        assert_eq!(detail.defaults.skills.mode, "fixed");
+        assert!(detail.defaults.skills.value.is_empty());
+        assert!(detail.capabilities.default_disabled_builtin_skill_ids.is_empty());
     }
 
     #[tokio::test]

--- a/crates/aionui-conversation/src/convert.rs
+++ b/crates/aionui-conversation/src/convert.rs
@@ -48,6 +48,8 @@ pub fn row_to_response_with_extra(
         !ws.is_empty() && Path::new(ws).starts_with(data_dir)
     };
     if let Some(obj) = extra.as_object_mut() {
+        obj.remove("preset_context");
+        obj.remove("preset_rules");
         obj.insert(
             "is_temporary_workspace".to_owned(),
             serde_json::Value::Bool(is_temporary_workspace),

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -812,6 +812,29 @@ impl ConversationService {
                     );
                 }
             }
+            if !snapshot.rules.content.trim().is_empty() {
+                match effective_type {
+                    AgentType::Acp => {
+                        obj.insert(
+                            "preset_context".to_owned(),
+                            serde_json::Value::String(snapshot.rules.content.clone()),
+                        );
+                        obj.remove("preset_rules");
+                    }
+                    AgentType::Aionrs => {
+                        obj.insert(
+                            "preset_rules".to_owned(),
+                            serde_json::Value::String(snapshot.rules.content.clone()),
+                        );
+                        obj.remove("preset_context");
+                    }
+                    AgentType::Gemini
+                    | AgentType::Codex
+                    | AgentType::OpenclawGateway
+                    | AgentType::Remote
+                    | AgentType::Nanobot => {}
+                }
+            }
         }
 
         // Consume transient skill-shaping inputs and freeze the initial

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -5571,6 +5571,89 @@ async fn create_resolves_assistant_snapshot_and_updates_preferences() {
 }
 
 #[tokio::test]
+async fn assistant_backed_acp_build_options_include_snapshot_rule_as_preset_context() {
+    let resolver = Arc::new(FixedSkillResolver { names: vec![] });
+    let dispatcher = Arc::new(StaticAssistantDispatcher {
+        rules: std::collections::HashMap::from([("preset-acp-rule".to_string(), "assistant rule body".to_string())]),
+    });
+    let (svc, _broadcaster, repo, definition_repo, state_repo, _preference_repo) =
+        make_service_with_assistant_support(resolver, dispatcher).await;
+
+    upsert_test_assistant_definition(
+        &definition_repo,
+        "asstdef_preset_acp_rule",
+        "preset-acp-rule",
+        "codex",
+        "auto",
+        "auto",
+    )
+    .await;
+    state_repo
+        .upsert(&UpsertAssistantOverlayParams {
+            assistant_definition_id: "asstdef_preset_acp_rule",
+            enabled: true,
+            sort_order: 0,
+            agent_id_override: None,
+            last_used_at: None,
+        })
+        .await
+        .unwrap();
+
+    let conv = create_assistant_backed_conversation(&svc, "user_1", Some("acp"), "codex", "preset-acp-rule").await;
+    let row = repo.get(&conv.id).await.unwrap().unwrap();
+    let options = svc.build_task_options(&row).await.unwrap();
+
+    match options.context.kind {
+        AgentSessionKind::Acp(ctx) => {
+            assert_eq!(ctx.config.preset_context.as_deref(), Some("assistant rule body"));
+        }
+        AgentSessionKind::Aionrs(_) => panic!("test conversation should build ACP options"),
+    }
+}
+
+#[tokio::test]
+async fn assistant_backed_aionrs_build_options_include_snapshot_rule_as_preset_rules() {
+    let resolver = Arc::new(FixedSkillResolver { names: vec![] });
+    let dispatcher = Arc::new(StaticAssistantDispatcher {
+        rules: std::collections::HashMap::from([("preset-aionrs-rule".to_string(), "assistant rule body".to_string())]),
+    });
+    let (svc, _broadcaster, repo, definition_repo, state_repo, _preference_repo) =
+        make_service_with_assistant_support(resolver, dispatcher).await;
+
+    upsert_test_assistant_definition(
+        &definition_repo,
+        "asstdef_preset_aionrs_rule",
+        "preset-aionrs-rule",
+        "aionrs",
+        "auto",
+        "auto",
+    )
+    .await;
+    state_repo
+        .upsert(&UpsertAssistantOverlayParams {
+            assistant_definition_id: "asstdef_preset_aionrs_rule",
+            enabled: true,
+            sort_order: 0,
+            agent_id_override: None,
+            last_used_at: None,
+        })
+        .await
+        .unwrap();
+
+    let conv =
+        create_assistant_backed_conversation(&svc, "user_1", Some("aionrs"), "aionrs", "preset-aionrs-rule").await;
+    let row = repo.get(&conv.id).await.unwrap().unwrap();
+    let options = svc.build_task_options(&row).await.unwrap();
+
+    match options.context.kind {
+        AgentSessionKind::Acp(_) => panic!("test conversation should build Aionrs options"),
+        AgentSessionKind::Aionrs(ctx) => {
+            assert_eq!(ctx.config.preset_rules.as_deref(), Some("assistant rule body"));
+        }
+    }
+}
+
+#[tokio::test]
 async fn create_prefers_assistant_snapshot_over_legacy_runtime_seed_fields() {
     let resolver = Arc::new(FixedSkillResolver {
         names: vec!["cron".into(), "todo-tracker".into()],

--- a/crates/aionui-extension/src/skill_routes.rs
+++ b/crates/aionui-extension/src/skill_routes.rs
@@ -34,6 +34,10 @@ fn to_source_response(source: SkillSource) -> SkillSourceResponse {
     }
 }
 
+fn is_auto_inject_builtin_skill(source: SkillSource, relative_location: Option<&str>) -> bool {
+    source == SkillSource::Builtin && relative_location.is_some_and(|location| location.starts_with("auto-inject/"))
+}
+
 // ---------------------------------------------------------------------------
 // Router state
 // ---------------------------------------------------------------------------
@@ -112,6 +116,7 @@ async fn list_skills(
     let resp: Vec<SkillListItemResponse> = items
         .into_iter()
         .map(|s| SkillListItemResponse {
+            is_auto_inject: is_auto_inject_builtin_skill(s.source, s.relative_location.as_deref()),
             name: s.name,
             description: s.description,
             location: s.location,


### PR DESCRIPTION
## Summary
- add `is_auto_inject` to skill list responses so clients can identify builtin auto-inject skills directly
- default new generated assistants to fixed empty skill defaults and lazily repair old empty generated auto defaults
- persist assistant snapshot rules into ACP/Aionrs runtime seed fields while keeping those internal fields out of API responses

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p aionui-conversation assistant_backed_ -- --nocapture`
- [x] `cargo test -p aionui-conversation`
- [x] `cargo test -p aionui-assistant`
- [x] `cargo test -p aionui-api-types -p aionui-extension`
- [x] `cargo test -p aionui-app --test extension_e2e sl1_list_skills_tags_builtin_and_custom_with_source_field -- --nocapture`
- [x] `cargo test -p aionui-app --test extension_e2e ba1_unified_skill_list_includes_auto_inject_builtin_entries -- --nocapture`
- [x] `cargo test -p aionui-app --test conversation_e2e t1_3b_create_persists_assistant_snapshot_and_updates_preferences -- --nocapture`
- [x] `cargo clippy -p aionui-api-types -p aionui-extension -p aionui-assistant -p aionui-conversation -p aionui-app -- -D warnings`
- [x] `git diff --check`
- [x] `just push -u origin fix/assistant-skill-rule-defaults-3437` (workspace nextest: 6527 passed, 18 skipped)

Related to iOfficeAI/AionUi#3437