### PR TITLE
fix(agent): adapt aionrs compat API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,8 +117,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.33"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.33#1594f0ff808e939bf887b622f3efe85872365f0a"
+version = "0.1.34"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -147,8 +147,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.33"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.33#1594f0ff808e939bf887b622f3efe85872365f0a"
+version = "0.1.34"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
 dependencies = [
  "regex",
  "serde",
@@ -158,10 +158,11 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.33"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.33#1594f0ff808e939bf887b622f3efe85872365f0a"
+version = "0.1.34"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
 dependencies = [
  "aion-compact",
+ "aion-process",
  "aion-types",
  "anyhow",
  "chrono",
@@ -182,8 +183,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.33"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.33#1594f0ff808e939bf887b622f3efe85872365f0a"
+version = "0.1.34"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -203,8 +204,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.33"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.33#1594f0ff808e939bf887b622f3efe85872365f0a"
+version = "0.1.34"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
 dependencies = [
  "aion-config",
  "chrono",
@@ -217,8 +218,8 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.1.33"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.33#1594f0ff808e939bf887b622f3efe85872365f0a"
+version = "0.1.34"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
 dependencies = [
  "libc",
  "tokio",
@@ -228,8 +229,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.33"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.33#1594f0ff808e939bf887b622f3efe85872365f0a"
+version = "0.1.34"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
 dependencies = [
  "aion-types",
  "serde",
@@ -241,8 +242,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.33"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.33#1594f0ff808e939bf887b622f3efe85872365f0a"
+version = "0.1.34"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -269,11 +270,12 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.33"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.33#1594f0ff808e939bf887b622f3efe85872365f0a"
+version = "0.1.34"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
 dependencies = [
  "aion-config",
  "aion-mcp",
+ "aion-process",
  "aion-types",
  "anyhow",
  "async-trait",
@@ -295,8 +297,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.33"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.33#1594f0ff808e939bf887b622f3efe85872365f0a"
+version = "0.1.34"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -316,8 +318,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.33"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.33#1594f0ff808e939bf887b622f3efe85872365f0a"
+version = "0.1.34"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6500,7 +6502,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.33#1594f0ff808e939bf887b622f3efe85872365f0a"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,8 +117,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.34"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
+version = "0.1.35"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.35#39894e4dc07fed5617ab0cb01e2c214a1f9047ac"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -147,8 +147,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.1.34"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
+version = "0.1.35"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.35#39894e4dc07fed5617ab0cb01e2c214a1f9047ac"
 dependencies = [
  "regex",
  "serde",
@@ -158,8 +158,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.34"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
+version = "0.1.35"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.35#39894e4dc07fed5617ab0cb01e2c214a1f9047ac"
 dependencies = [
  "aion-compact",
  "aion-process",
@@ -183,8 +183,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.34"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
+version = "0.1.35"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.35#39894e4dc07fed5617ab0cb01e2c214a1f9047ac"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -204,8 +204,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.34"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
+version = "0.1.35"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.35#39894e4dc07fed5617ab0cb01e2c214a1f9047ac"
 dependencies = [
  "aion-config",
  "chrono",
@@ -218,8 +218,8 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.1.34"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
+version = "0.1.35"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.35#39894e4dc07fed5617ab0cb01e2c214a1f9047ac"
 dependencies = [
  "libc",
  "tokio",
@@ -229,8 +229,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.34"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
+version = "0.1.35"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.35#39894e4dc07fed5617ab0cb01e2c214a1f9047ac"
 dependencies = [
  "aion-types",
  "serde",
@@ -242,8 +242,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.34"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
+version = "0.1.35"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.35#39894e4dc07fed5617ab0cb01e2c214a1f9047ac"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -270,8 +270,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.34"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
+version = "0.1.35"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.35#39894e4dc07fed5617ab0cb01e2c214a1f9047ac"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -297,8 +297,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.34"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
+version = "0.1.35"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.35#39894e4dc07fed5617ab0cb01e2c214a1f9047ac"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -318,8 +318,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.34"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
+version = "0.1.35"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.35#39894e4dc07fed5617ab0cb01e2c214a1f9047ac"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6502,7 +6502,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.34#773cb49997e9c6745e3231cdd7629c3d529059ab"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.35#39894e4dc07fed5617ab0cb01e2c214a1f9047ac"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,12 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.33" }
-aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.33" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.33" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.33" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.33" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.33" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.34" }
+aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.34" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.34" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.34" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.34" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.34" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,12 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.34" }
-aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.34" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.34" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.34" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.34" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.34" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.35" }
+aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.35" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.35" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.35" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.35" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.35" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -95,10 +95,10 @@ impl AionrsAgentManager {
         config.session.directory = config_extra.session_directory.to_string_lossy().into_owned();
 
         if let Some(field) = config_extra.compat_overrides.max_tokens_field {
-            config.compat.max_tokens_field = Some(field);
+            config.compat.transport.max_tokens_field = Some(field);
         }
         if let Some(path) = config_extra.compat_overrides.api_path {
-            config.compat.api_path = Some(path);
+            config.compat.transport.api_path = Some(path);
         }
 
         if !config_extra.extra_mcp_servers.is_empty() {

--- a/crates/aionui-ai-agent/src/registry_tests.rs
+++ b/crates/aionui-ai-agent/src/registry_tests.rs
@@ -278,7 +278,7 @@ async fn management_rows_project_runtime_catalogs_from_agent_metadata() {
         name_i18n: None,
         description: None,
         description_i18n: None,
-        backend: Some("claude".into()),
+        backend: Some("claude"),
         agent_type: "acp",
         agent_source: "builtin",
         agent_source_info: None,

--- a/crates/aionui-ai-agent/src/services/provider_health.rs
+++ b/crates/aionui-ai-agent/src/services/provider_health.rs
@@ -211,10 +211,10 @@ async fn build_probe_engine(config_extra: AionrsResolvedConfig) -> Result<AgentE
     config.mcp.servers.clear();
     config.file_cache.enabled = false;
     if let Some(field) = config_extra.compat_overrides.max_tokens_field {
-        config.compat.max_tokens_field = Some(field);
+        config.compat.transport.max_tokens_field = Some(field);
     }
     if let Some(path) = config_extra.compat_overrides.api_path {
-        config.compat.api_path = Some(path);
+        config.compat.transport.api_path = Some(path);
     }
 
     AgentBootstrap::new(config, workspace, sink)

--- a/crates/aionui-app/tests/agent_integration_e2e.rs
+++ b/crates/aionui-app/tests/agent_integration_e2e.rs
@@ -648,7 +648,7 @@ async fn agent_overrides_roundtrip_and_management_summary() {
     assert_eq!(row["has_command_override"], true);
     assert_eq!(row["env_override_key_count"], 1); // PATH excluded
     assert!(
-        row["env"].as_array().map_or(true, |arr| arr.is_empty()),
+        row["env"].as_array().is_none_or(|arr| arr.is_empty()),
         "management row env must be empty or absent"
     );
     assert!(

--- a/justfile
+++ b/justfile
@@ -58,11 +58,16 @@ _cargo *ARGS:
         aionrs_root=$(cd "$AIONRS" && pwd -P)
         crates=(
             aion-agent
-            aion-providers
-            aion-types
-            aion-protocol
+            aion-compact
             aion-config
             aion-mcp
+            aion-memory
+            aion-process
+            aion-protocol
+            aion-providers
+            aion-skills
+            aion-tools
+            aion-types
         )
 
         for crate in "${crates[@]}"; do
@@ -101,11 +106,17 @@ _cargo *ARGS:
         verify_local_aionrs_patch
     fi
 
+    args=({{ARGS}})
+
     set +e
     if ((${#cargo_config[@]})); then
-        cargo "${cargo_config[@]}" {{ARGS}}
+        if ((${#args[@]})) && [[ "${args[0]}" == "clippy" ]]; then
+            cargo "${args[0]}" "${cargo_config[@]}" "${args[@]:1}"
+        else
+            cargo "${cargo_config[@]}" "${args[@]}"
+        fi
     else
-        cargo {{ARGS}}
+        cargo "${args[@]}"
     fi
     status=$?
     set -e

--- a/justfile
+++ b/justfile
@@ -12,12 +12,14 @@ _cargo *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    cargo_config=()
     restore_cargo_lock=false
     cargo_lock_snapshot=""
+    cargo_config_file=".cargo/config.toml"
+    cargo_config_snapshot=""
+    cargo_config_created=false
     aionrs_root=""
 
-    restore_local_lockfile() {
+    restore_local_state() {
         local status=$?
 
         if [[ -n "$cargo_lock_snapshot" && -f "$cargo_lock_snapshot" ]]; then
@@ -29,15 +31,23 @@ _cargo *ARGS:
             rm -f "$cargo_lock_snapshot"
         fi
 
+        if [[ -n "$cargo_config_snapshot" && -f "$cargo_config_snapshot" ]]; then
+            cp "$cargo_config_snapshot" "$cargo_config_file" || status=$?
+            rm -f "$cargo_config_snapshot"
+        elif [[ "$cargo_config_created" == "true" ]]; then
+            rm -f "$cargo_config_file"
+            rmdir .cargo 2>/dev/null || true
+        fi
+
         return "$status"
     }
-    trap restore_local_lockfile EXIT
+    trap restore_local_state EXIT
 
     verify_local_aionrs_patch() {
         local crate expected_path pkgid
         for crate in "${crates[@]}"; do
             expected_path="$aionrs_root/crates/$crate"
-            pkgid=$(cargo "${cargo_config[@]}" pkgid -p "$crate")
+            pkgid=$(cargo pkgid -p "$crate")
 
             if ! python3 -c 'import sys; from pathlib import Path; from urllib.parse import unquote, urlparse; pkgid=sys.argv[1]; expected=str(Path(sys.argv[2]).resolve()); ok=pkgid.startswith("path+file://") and str(Path(unquote(urlparse(pkgid[len("path+"):]).path)).resolve()) == expected; sys.exit(0 if ok else 1)' "$pkgid" "$expected_path"
             then
@@ -70,6 +80,12 @@ _cargo *ARGS:
             aion-types
         )
 
+        patch_config=$(mktemp)
+        {
+            echo
+            echo "[patch.'https://github.com/iOfficeAI/aionrs.git']"
+        } > "$patch_config"
+
         for crate in "${crates[@]}"; do
             crate_dir="$aionrs_root/crates/$crate"
             if [[ ! -f "$crate_dir/Cargo.toml" ]]; then
@@ -79,8 +95,18 @@ _cargo *ARGS:
 
             toml_path=${crate_dir//\\/\\\\}
             toml_path=${toml_path//\"/\\\"}
-            cargo_config+=(--config "patch.'https://github.com/iOfficeAI/aionrs.git'.$crate.path = \"$toml_path\"")
+            echo "$crate = { path = \"$toml_path\" }" >> "$patch_config"
         done
+
+        mkdir -p .cargo
+        if [[ -f "$cargo_config_file" ]]; then
+            cargo_config_snapshot=$(mktemp)
+            cp "$cargo_config_file" "$cargo_config_snapshot"
+        else
+            cargo_config_created=true
+        fi
+        cat "$patch_config" >> "$cargo_config_file"
+        rm -f "$patch_config"
 
         echo "Using local aionrs SDK: $aionrs_root" >&2
 
@@ -96,28 +122,18 @@ _cargo *ARGS:
         fi
 
         echo "Resolving Cargo.lock against local aionrs SDK" >&2
-        cargo "${cargo_config[@]}" update \
-            -p aion-agent \
-            -p aion-providers \
-            -p aion-types \
-            -p aion-protocol \
-            -p aion-config \
-            -p aion-mcp
+        update_args=()
+        for crate in "${crates[@]}"; do
+            update_args+=(-p "$crate")
+        done
+        cargo update "${update_args[@]}"
         verify_local_aionrs_patch
     fi
 
     args=({{ARGS}})
 
     set +e
-    if ((${#cargo_config[@]})); then
-        if ((${#args[@]})) && [[ "${args[0]}" == "clippy" ]]; then
-            cargo "${args[0]}" "${cargo_config[@]}" "${args[@]:1}"
-        else
-            cargo "${cargo_config[@]}" "${args[@]}"
-        fi
-    else
-        cargo "${args[@]}"
-    fi
+    cargo "${args[@]}"
     status=$?
     set -e
     exit "$status"


### PR DESCRIPTION
## Summary
- Bump the embedded aionrs SDK dependencies to `v0.1.35`.
- Adapt AionCLI provider compat overrides to the transport-scoped compat API introduced by the provider-contract work.
- Keep `AIONRS=../aionrs just ...` usable for local SDK compatibility checks, including nested Cargo commands such as `cargo nextest`.
- Clean Rust 1.95 clippy warnings in touched tests.

## Context
The provider-contract changes in aionrs moved transport-specific compat fields such as `max_tokens_field` and `api_path` under `compat.transport`. AionCore needs this follow-up so its AionCLI SDK integration compiles and continues to pass provider-health and agent startup override paths against the released aionrs API.

This branch now points all embedded aionrs SDK crates at `v0.1.35`, the release that includes the T10 provider/transport composition work.

## Verification
- `just update-aionrs`
- `just push` on head `fdb1e26a`
  - migration immutability check passed
  - `cargo fix` passed
  - workspace clippy with `-D warnings` passed
  - `cargo fmt --all` passed
  - `nextest run --workspace`: 6534 tests run, 6534 passed, 18 skipped
  - branch pushed to `origin/boii/chore/aionrs-main-compat-check`

## CI
GitHub CI for head `fdb1e26a` passed: Format, Clippy, Migration Immutability, Detect dependency changes, Security Audit, and Test.