### PR TITLE
fix(channel): wire assistant repos into channel ConversationService

### DIFF
--- a/crates/aionui-app/src/lib.rs
+++ b/crates/aionui-app/src/lib.rs
@@ -11,8 +11,8 @@ mod services;
 
 pub use config::{AppConfig, derive_encryption_key};
 pub use router::{
-    ChannelOrchestratorComponents, ModuleStates, RouterBuildError, build_assistant_state, build_conversation_state,
-    build_extension_states, build_module_states, build_ws_state, create_router, create_router_with_all_state,
-    create_router_with_states,
+    ChannelOrchestratorComponents, ModuleStates, RouterBuildError, build_assistant_state,
+    build_channel_conversation_service, build_conversation_state, build_extension_states, build_module_states,
+    build_ws_state, create_router, create_router_with_all_state, create_router_with_states,
 };
 pub use services::AppServices;

--- a/crates/aionui-app/src/router/mod.rs
+++ b/crates/aionui-app/src/router/mod.rs
@@ -8,6 +8,7 @@ mod trace;
 
 pub use routes::{create_router, create_router_with_all_state, create_router_with_states};
 pub use state::{
-    ChannelOrchestratorComponents, ModuleStates, RouterBuildError, build_assistant_state, build_conversation_state,
-    build_extension_states, build_module_states, build_ws_state,
+    ChannelOrchestratorComponents, ModuleStates, RouterBuildError, build_assistant_state,
+    build_channel_conversation_service, build_conversation_state, build_extension_states, build_module_states,
+    build_ws_state,
 };

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -446,6 +446,65 @@ pub fn build_mcp_state(services: &AppServices) -> McpRouterState {
     }
 }
 
+/// Build the channel `ConversationService` with every repository wired,
+/// including the three assistant repos required to resolve an assistant
+/// snapshot for channel-bound (e.g. Telegram) conversations.
+///
+/// Without the assistant repos, a platform bound to an assistant suppresses the
+/// explicit conversation `type` (see `aionui-channel` `message_service.rs`) but
+/// the service cannot produce a snapshot, so conversation creation fails with
+/// "Either `type` or `assistant.id` is required". This mirrors the MAIN
+/// (`services.rs`) and CRON ConversationService instances.
+///
+/// Extracted from `build_channel_state` so the wiring can be guarded by a
+/// regression test (`crates/aionui-app/tests/channel_conversation_service.rs`);
+/// the test fails if the assistant repos are dropped here again.
+pub fn build_channel_conversation_service(services: &AppServices) -> Arc<ConversationService> {
+    let conv_repo: Arc<dyn aionui_db::IConversationRepository> = Arc::new(
+        aionui_db::SqliteConversationRepository::new(services.database.pool().clone()),
+    );
+    let skill_resolver = Arc::new(aionui_conversation::skill_resolver::ExtensionSkillResolver::new(
+        services.skill_paths.clone(),
+        services.skill_repo.clone(),
+    ));
+    let agent_metadata_repo: Arc<dyn aionui_db::IAgentMetadataRepository> = Arc::new(
+        aionui_db::SqliteAgentMetadataRepository::new(services.database.pool().clone()),
+    );
+    let acp_session_repo: Arc<dyn aionui_db::IAcpSessionRepository> = Arc::new(
+        aionui_db::SqliteAcpSessionRepository::new(services.database.pool().clone()),
+    );
+    let conversation_svc = Arc::new(
+        ConversationService::new(
+            services.work_dir.clone(),
+            services.event_bus.clone(),
+            skill_resolver,
+            services.worker_task_manager.clone(),
+            conv_repo,
+            agent_metadata_repo,
+            acp_session_repo,
+        )
+        .with_runtime_state(services.conversation_runtime_state.clone()),
+    );
+    conversation_svc.with_mcp_server_repo(Arc::new(aionui_db::SqliteMcpServerRepository::new(
+        services.database.pool().clone(),
+    )));
+    // Assistant repos — the regressed wiring; see this function's doc comment
+    // for why channel-bound-assistant conversations require them.
+    conversation_svc.with_assistant_definition_repo(Arc::new(SqliteAssistantDefinitionRepository::new(
+        services.database.pool().clone(),
+    )));
+    conversation_svc.with_assistant_state_repo(Arc::new(SqliteAssistantOverlayRepository::new(
+        services.database.pool().clone(),
+    )));
+    conversation_svc.with_assistant_preference_repo(Arc::new(SqliteAssistantPreferenceRepository::new(
+        services.database.pool().clone(),
+    )));
+    if let Some(hook) = services.task_manager_delete_hook.clone() {
+        conversation_svc.with_delete_hook(hook);
+    }
+    conversation_svc
+}
+
 /// Build the default `ChannelRouterState` and orchestrator components.
 pub async fn build_channel_state(
     services: &AppServices,
@@ -500,37 +559,7 @@ pub async fn build_channel_state(
         Arc::clone(&channel_settings),
     ));
 
-    let conv_repo: Arc<dyn aionui_db::IConversationRepository> = Arc::new(
-        aionui_db::SqliteConversationRepository::new(services.database.pool().clone()),
-    );
-    let skill_resolver = Arc::new(aionui_conversation::skill_resolver::ExtensionSkillResolver::new(
-        services.skill_paths.clone(),
-        services.skill_repo.clone(),
-    ));
-    let agent_metadata_repo: Arc<dyn aionui_db::IAgentMetadataRepository> = Arc::new(
-        aionui_db::SqliteAgentMetadataRepository::new(services.database.pool().clone()),
-    );
-    let acp_session_repo: Arc<dyn aionui_db::IAcpSessionRepository> = Arc::new(
-        aionui_db::SqliteAcpSessionRepository::new(services.database.pool().clone()),
-    );
-    let conversation_svc = Arc::new(
-        ConversationService::new(
-            services.work_dir.clone(),
-            services.event_bus.clone(),
-            skill_resolver,
-            services.worker_task_manager.clone(),
-            conv_repo,
-            agent_metadata_repo,
-            acp_session_repo,
-        )
-        .with_runtime_state(services.conversation_runtime_state.clone()),
-    );
-    conversation_svc.with_mcp_server_repo(Arc::new(aionui_db::SqliteMcpServerRepository::new(
-        services.database.pool().clone(),
-    )));
-    if let Some(hook) = services.task_manager_delete_hook.clone() {
-        conversation_svc.with_delete_hook(hook);
-    }
+    let conversation_svc = build_channel_conversation_service(services);
 
     let owner_user_id = services
         .user_repo

--- a/crates/aionui-app/tests/channel_conversation_service.rs
+++ b/crates/aionui-app/tests/channel_conversation_service.rs
@@ -1,0 +1,138 @@
+//! Regression test for the channel `ConversationService` wiring.
+//!
+//! Guards the fix for "Either `type` or `assistant.id` is required when
+//! creating a conversation": the channel `ConversationService` built in
+//! `build_channel_state` must carry the assistant repositories, otherwise an IM
+//! platform (e.g. Telegram) bound to an assistant cannot resolve a snapshot and
+//! conversation creation fails.
+//!
+//! Unlike the behavioral twin in `aionui-channel`, this test drives the real
+//! production builder `build_channel_conversation_service`, so it fails if the
+//! assistant repos are ever dropped from that wiring again.
+
+mod common;
+
+use std::sync::Arc;
+
+use aionui_app::build_channel_conversation_service;
+use aionui_channel::channel_settings::ChannelSettingsService;
+use aionui_channel::message_service::ChannelMessageService;
+use aionui_channel::types::PluginType;
+use aionui_common::AgentType;
+use aionui_db::models::{AssistantSessionRow, UpsertAssistantDefinitionParams};
+use aionui_db::{
+    IAssistantDefinitionRepository, IClientPreferenceRepository, IConversationRepository,
+    SqliteAssistantDefinitionRepository, SqliteAssistantOverlayRepository, SqliteClientPreferenceRepository,
+    SqliteConversationRepository,
+};
+
+use common::build_app_with_mock_agents;
+
+fn bare_assistant_definition_params<'a>(
+    definition_id: &'a str,
+    assistant_id: &'a str,
+    agent_id: &'a str,
+) -> UpsertAssistantDefinitionParams<'a> {
+    UpsertAssistantDefinitionParams {
+        id: definition_id,
+        assistant_id,
+        source: "generated",
+        owner_type: "system",
+        source_ref: Some(assistant_id),
+        source_version: None,
+        source_hash: None,
+        name: assistant_id,
+        name_i18n: "{}",
+        description: Some("Channel bare assistant"),
+        description_i18n: "{}",
+        avatar_type: "emoji",
+        avatar_value: Some("🤖"),
+        agent_id,
+        rule_resource_type: "inline",
+        rule_resource_ref: None,
+        rule_inline_content: Some(""),
+        recommended_prompts: "[]",
+        recommended_prompts_i18n: "{}",
+        default_model_mode: "auto",
+        default_model_value: None,
+        default_permission_mode: "auto",
+        default_permission_value: None,
+        default_skills_mode: "auto",
+        default_skill_ids: "[]",
+        custom_skill_names: "[]",
+        default_disabled_builtin_skill_ids: "[]",
+        default_mcps_mode: "auto",
+        default_mcp_ids: "[]",
+    }
+}
+
+/// A Telegram message to a bot bound to an assistant must create a conversation
+/// with a persisted assistant snapshot. This exercises the channel
+/// `ConversationService` exactly as it is wired in `build_channel_state`.
+#[tokio::test]
+async fn channel_conversation_service_resolves_assistant_snapshot_for_bound_telegram_bot() {
+    let (_app, services) = build_app_with_mock_agents().await;
+    let pool = services.database.pool().clone();
+
+    // Build the conversation service through the production channel builder.
+    // The assistant repos must be wired by this function (the regressed line).
+    let conversation_svc = build_channel_conversation_service(&services);
+
+    // Seed a bare assistant definition and bind the Telegram platform to it.
+    let definition_repo = Arc::new(SqliteAssistantDefinitionRepository::new(pool.clone()));
+    let overlay_repo = Arc::new(SqliteAssistantOverlayRepository::new(pool.clone()));
+    let pref_repo = Arc::new(SqliteClientPreferenceRepository::new(pool.clone()));
+    definition_repo
+        .upsert(&bare_assistant_definition_params(
+            "asstdef-channel-claude",
+            "bare-claude",
+            "claude",
+        ))
+        .await
+        .unwrap();
+    pref_repo
+        .upsert_batch(&[(
+            "assistant.telegram.agent",
+            r#"{"assistant_id":"bare-claude","name":"Claude"}"#,
+        )])
+        .await
+        .unwrap();
+
+    let settings = Arc::new(ChannelSettingsService::new(pref_repo).with_assistant_repos(definition_repo, overlay_repo));
+    let message_svc = ChannelMessageService::new(
+        conversation_svc,
+        services.worker_task_manager.clone(),
+        settings,
+        "system_default_user".to_owned(),
+    );
+
+    let session = AssistantSessionRow {
+        id: "session-assisted".to_owned(),
+        user_id: "channel-user-1".to_owned(),
+        agent_type: "aionrs".to_owned(),
+        conversation_id: None,
+        workspace: None,
+        chat_id: Some("123456789".to_owned()),
+        created_at: 1,
+        last_activity: 1,
+    };
+
+    let result = message_svc
+        .send_to_agent(&session, "hello", PluginType::Telegram)
+        .await
+        .expect("channel-bound-assistant conversation must be created (no \"Either `type` or `assistant.id`\" error)");
+
+    let conversation_repo = SqliteConversationRepository::new(pool);
+    let snapshot = conversation_repo
+        .get_assistant_snapshot(&result.conversation_id)
+        .await
+        .unwrap();
+    assert!(
+        snapshot.is_some(),
+        "channel-created conversation should persist an assistant snapshot when the platform is bound to an assistant"
+    );
+    assert_eq!(snapshot.unwrap().assistant_id, "bare-claude");
+
+    let conversation = conversation_repo.get(&result.conversation_id).await.unwrap().unwrap();
+    assert_eq!(conversation.r#type, AgentType::Acp.serde_name());
+}


### PR DESCRIPTION
## Description

Inbound Telegram (and other IM channel) messages to a bot bound to an assistant failed (reported in #529) with:

> Bad request: Either `type` or `assistant.id` is required when creating a conversation.

This wires the channel `ConversationService` with the assistant repositories so a channel-bound-assistant conversation can resolve its snapshot, matching the MAIN and CRON instances.

Fixes #529

## Root cause

There are three `ConversationService` instances. MAIN (`crates/aionui-app/src/services.rs`) and CRON (`router/state.rs` cron block) wire the assistant repos; the CHANNEL instance built in `router/state.rs::build_channel_state` did **not**.

The channel path canonicalizes any platform binding to a bare `assistant_id` (`channel_settings.rs`) and then suppresses the explicit conversation `type` (`message_service.rs`: `r#type: if assistant_id.is_some() { None } else { Some(agent_type) }`). With no assistant repos, the channel service cannot resolve a snapshot (`conversation/service.rs` returns `None`), so `resolve_create_agent_type` throws. This is a wiring defect, not data.

## Fix

- Extract the channel `ConversationService` construction into `build_channel_conversation_service`.
- Wire `with_assistant_definition_repo` / `with_assistant_state_repo` / `with_assistant_preference_repo` into it.

The extraction is intentionally minimal and exists so the wiring can be guarded by a test; it is **not** the broader main/cron/channel dedup (left for a follow-up).

## Testing

- **Regression test** (`crates/aionui-app/tests/channel_conversation_service.rs`): drives the real `build_channel_conversation_service`, binds Telegram to a bare assistant, and asserts the conversation is created with a persisted assistant snapshot. Verified single-variable: dropping the three `with_assistant_*_repo` calls makes the test fail with the exact production error `Either type or assistant.id is required`.
- `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`, `cargo nextest run` for the affected crates — all green.
- Verified live earlier on a copy of the DB: a real Telegram message to an assistant-bound bot created a conversation (`req_type=None` → "Conversation created from assistant") with no error.

## Compatibility

Non-breaking: additive repository wiring only. No schema/migration changes.
