### PR TITLE
Fix assistant bootstrap with soft-deleted definitions

### DIFF
--- a/crates/aionui-assistant/src/service.rs
+++ b/crates/aionui-assistant/src/service.rs
@@ -1656,7 +1656,7 @@ impl AssistantService {
         if let Some(source_ref) = source_ref
             && let Some(existing) = self
                 .definition_repo
-                .get_by_source_ref(source, source_ref)
+                .get_by_source_ref_including_deleted(source, source_ref)
                 .await
                 .map_err(|e| AssistantError::Internal(format!("get assistant definition by source_ref: {e}")))?
         {
@@ -1665,7 +1665,7 @@ impl AssistantService {
 
         if let Some(existing) = self
             .definition_repo
-            .get_by_assistant_id(assistant_id)
+            .get_by_assistant_id_including_deleted(assistant_id)
             .await
             .map_err(|e| AssistantError::Internal(format!("get assistant definition by key: {e}")))?
         {
@@ -3017,6 +3017,44 @@ mod tests {
         assert!(!builtin_state.enabled);
         assert_eq!(builtin_state.sort_order, 9);
         assert_eq!(builtin_state.last_used_at, Some(1234));
+    }
+
+    #[tokio::test]
+    async fn bootstrap_reactivates_soft_deleted_builtin_definition_by_source_ref() {
+        let mut builtin = mk_builtin("aionui-assistant", "AionUi Butler");
+        builtin.rule_file = Some("rules/aionui-assistant.{locale}.md".into());
+        let fx = fixture_with_builtins(vec![builtin]).await;
+
+        let original = fx
+            .definition_repo
+            .get_by_assistant_id("aionui-assistant")
+            .await
+            .unwrap()
+            .expect("builtin definition should be materialized");
+        fx.definition_repo
+            .soft_delete(&original.id, now_ms())
+            .await
+            .expect("soft-delete builtin definition");
+        assert!(
+            fx.definition_repo
+                .get_by_assistant_id("aionui-assistant")
+                .await
+                .unwrap()
+                .is_none(),
+            "active lookup should hide the soft-deleted row"
+        );
+
+        fx.service.bootstrap_assistant_storage().await.unwrap();
+
+        let restored = fx
+            .definition_repo
+            .get_by_assistant_id("aionui-assistant")
+            .await
+            .unwrap()
+            .expect("bootstrap should reactivate the soft-deleted builtin");
+        assert_eq!(restored.id, original.id);
+        assert_eq!(restored.rule_resource_ref.as_deref(), Some("aionui-assistant"));
+        assert!(restored.deleted_at.is_none());
     }
 
     #[tokio::test]

--- a/crates/aionui-db/src/repository/assistant.rs
+++ b/crates/aionui-db/src/repository/assistant.rs
@@ -61,12 +61,25 @@ pub trait IAssistantOverrideRepository: Send + Sync {
 pub trait IAssistantDefinitionRepository: Send + Sync {
     async fn list(&self) -> Result<Vec<AssistantDefinitionRow>, DbError>;
     async fn get_by_assistant_id(&self, assistant_id: &str) -> Result<Option<AssistantDefinitionRow>, DbError>;
+    async fn get_by_assistant_id_including_deleted(
+        &self,
+        assistant_id: &str,
+    ) -> Result<Option<AssistantDefinitionRow>, DbError> {
+        self.get_by_assistant_id(assistant_id).await
+    }
     async fn get_by_id(&self, id: &str) -> Result<Option<AssistantDefinitionRow>, DbError>;
     async fn get_by_source_ref(
         &self,
         source: &str,
         source_ref: &str,
     ) -> Result<Option<AssistantDefinitionRow>, DbError>;
+    async fn get_by_source_ref_including_deleted(
+        &self,
+        source: &str,
+        source_ref: &str,
+    ) -> Result<Option<AssistantDefinitionRow>, DbError> {
+        self.get_by_source_ref(source, source_ref).await
+    }
     async fn upsert(&self, params: &UpsertAssistantDefinitionParams<'_>) -> Result<AssistantDefinitionRow, DbError>;
     async fn soft_delete(&self, id: &str, deleted_at: i64) -> Result<bool, DbError>;
 }

--- a/crates/aionui-db/src/repository/sqlite_assistant.rs
+++ b/crates/aionui-db/src/repository/sqlite_assistant.rs
@@ -362,6 +362,18 @@ impl IAssistantDefinitionRepository for SqliteAssistantDefinitionRepository {
         Ok(row)
     }
 
+    async fn get_by_assistant_id_including_deleted(
+        &self,
+        assistant_id: &str,
+    ) -> Result<Option<AssistantDefinitionRow>, DbError> {
+        let row =
+            sqlx::query_as::<_, AssistantDefinitionRow>("SELECT * FROM assistant_definitions WHERE assistant_id = ?")
+                .bind(assistant_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row)
+    }
+
     async fn get_by_id(&self, id: &str) -> Result<Option<AssistantDefinitionRow>, DbError> {
         let row = sqlx::query_as::<_, AssistantDefinitionRow>(
             "SELECT * FROM assistant_definitions WHERE id = ? AND deleted_at IS NULL",
@@ -379,6 +391,21 @@ impl IAssistantDefinitionRepository for SqliteAssistantDefinitionRepository {
     ) -> Result<Option<AssistantDefinitionRow>, DbError> {
         let row = sqlx::query_as::<_, AssistantDefinitionRow>(
             "SELECT * FROM assistant_definitions WHERE source = ? AND source_ref = ? AND deleted_at IS NULL",
+        )
+        .bind(source)
+        .bind(source_ref)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    async fn get_by_source_ref_including_deleted(
+        &self,
+        source: &str,
+        source_ref: &str,
+    ) -> Result<Option<AssistantDefinitionRow>, DbError> {
+        let row = sqlx::query_as::<_, AssistantDefinitionRow>(
+            "SELECT * FROM assistant_definitions WHERE source = ? AND source_ref = ?",
         )
         .bind(source)
         .bind(source_ref)


### PR DESCRIPTION
## Summary
- Reuse soft-deleted assistant definitions during bootstrap identity resolution
- Allow builtin/generated materialization to reactivate existing rows instead of inserting duplicate stable keys
- Add regression coverage for reactivating a soft-deleted builtin assistant by source_ref

## Root cause
A migrated database can contain a soft-deleted builtin definition whose stable identity is later reused by the current builtin manifest. Bootstrap only looked up active rows, generated a new definition id, then failed on assistant_definitions unique indexes.

## Validation
- cargo test -p aionui-assistant bootstrap_reactivates_soft_deleted_builtin_definition_by_source_ref -- --nocapture

Supersedes #533, which was opened from the wrong GitHub account.