### PR TITLE
fix(aionrs): preserve non-v1 version segment in OpenAI-compatible base_url (AionUi #2713)

### DIFF
--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -256,6 +256,14 @@ pub(crate) fn resolve_aionrs_url_and_compat(
         return (Some(base), compat);
     }
 
+    // `/v1` is intentionally excluded — that case is handled by the
+    // default branch below for OpenAI/DeepSeek compatibility.
+    if has_non_v1_version_suffix(raw_base_url) {
+        let trimmed = raw_base_url.trim_end_matches('/');
+        compat.api_path = Some("/chat/completions".to_owned());
+        return (Some(trimmed.to_owned()), compat);
+    }
+
     let normalized = normalize_aionrs_base_url(raw_base_url);
     let base_url = Some(normalized).filter(|u| !u.is_empty());
 
@@ -280,6 +288,16 @@ fn is_openai_host(url: &str) -> bool {
 fn normalize_aionrs_base_url(url: &str) -> String {
     let trimmed = url.trim_end_matches('/');
     trimmed.strip_suffix("/v1").unwrap_or(trimmed).to_owned()
+}
+
+/// Detects OpenAI-compatible providers whose base URL already pins a non-v1
+/// API version segment (Zhipu `/api/paas/v4`, Alibaba Ark `/api/v3`, ...).
+fn has_non_v1_version_suffix(url: &str) -> bool {
+    let trimmed = url.trim_end_matches('/');
+    let Some(last) = trimmed.rsplit('/').next() else {
+        return false;
+    };
+    last.len() >= 2 && last.starts_with('v') && last[1..].bytes().all(|b| b.is_ascii_digit()) && last != "v1"
 }
 
 pub(crate) fn resolve_bedrock_config(json: Option<&str>) -> Option<aion_config::config::BedrockConfig> {
@@ -931,6 +949,46 @@ mod tests {
             resolve_aionrs_url_and_compat("custom", "https://api.deepseek.com/v1", "openai", false);
         assert_eq!(base_url.as_deref(), Some("https://api.deepseek.com"));
         assert!(compat.api_path.is_none());
+    }
+
+    #[test]
+    fn resolve_zhipu_v4_keeps_segment_and_sets_chat_path() {
+        let (base_url, compat) =
+            resolve_aionrs_url_and_compat("custom", "https://open.bigmodel.cn/api/paas/v4", "openai", false);
+        assert_eq!(base_url.as_deref(), Some("https://open.bigmodel.cn/api/paas/v4"));
+        assert_eq!(compat.api_path.as_deref(), Some("/chat/completions"));
+        assert!(compat.max_tokens_field.is_none());
+    }
+
+    #[test]
+    fn resolve_ark_v3_keeps_segment_and_sets_chat_path() {
+        let (base_url, compat) =
+            resolve_aionrs_url_and_compat("custom", "https://ark.cn-beijing.volces.com/api/v3", "openai", false);
+        assert_eq!(base_url.as_deref(), Some("https://ark.cn-beijing.volces.com/api/v3"));
+        assert_eq!(compat.api_path.as_deref(), Some("/chat/completions"));
+    }
+
+    #[test]
+    fn resolve_zhipu_v4_with_trailing_slash_stripped() {
+        let (base_url, compat) =
+            resolve_aionrs_url_and_compat("custom", "https://open.bigmodel.cn/api/paas/v4/", "openai", false);
+        assert_eq!(base_url.as_deref(), Some("https://open.bigmodel.cn/api/paas/v4"));
+        assert_eq!(compat.api_path.as_deref(), Some("/chat/completions"));
+    }
+
+    #[test]
+    fn has_non_v1_version_suffix_cases() {
+        assert!(has_non_v1_version_suffix("https://x/api/paas/v4"));
+        assert!(has_non_v1_version_suffix("https://x/api/v3"));
+        assert!(has_non_v1_version_suffix("https://x/v2"));
+        assert!(has_non_v1_version_suffix("https://x/v04"));
+
+        assert!(!has_non_v1_version_suffix("https://x/v1"));
+        assert!(!has_non_v1_version_suffix("https://x/v1beta"));
+        assert!(!has_non_v1_version_suffix("https://x/v"));
+        assert!(!has_non_v1_version_suffix("https://x/api"));
+        assert!(!has_non_v1_version_suffix("https://x/v1/"));
+        assert!(!has_non_v1_version_suffix(""));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the 404 reported in https://github.com/iOfficeAI/AionUi/issues/2713 — Zhipu GLM preset (and any OpenAI-compatible provider whose base URL pins a non-`/v1` API version) was unusable because aionrs assembled a double-version request path.

## Root cause

`resolve_aionrs_url_and_compat()` in `crates/aionui-ai-agent/src/factory/aionrs.rs` had four effective paths:

1. `is_full_url=true` → `api_path=""`, URL verbatim
2. `platform=="gemini"` → prepend `/v1beta/openai`, `api_path="/chat/completions"`
3. `mapped_provider=="openai" && is_openai_host(...)` → strip `/v1`, set `max_completion_tokens`
4. default → `normalize_aionrs_base_url`, which **only strips `/v1`**

For Zhipu (`base_url="https://open.bigmodel.cn/api/paas/v4"`), path 4 ran, `/v4` was **not** stripped, `api_path` stayed `None`, and aionrs substituted its default `/v1/chat/completions`. Result:

```
https://open.bigmodel.cn/api/paas/v4  +  /v1/chat/completions
= /v4/v1/chat/completions   →  HTTP 404
```

Reproduced across AionUi v1.9.22 → v2.1.25 (per issue #2713, comment from @shishan444 on 2026-06-26).

## Fix

Added a new branch in `resolve_aionrs_url_and_compat`, placed **after** the `gemini` block and **before** the generic `normalize_aionrs_base_url` call:

```rust
if has_non_v1_version_suffix(raw_base_url) {
    let trimmed = raw_base_url.trim_end_matches('/');
    compat.api_path = Some("/chat/completions".to_owned());
    return (Some(trimmed.to_owned()), compat);
}
```

The helper `has_non_v1_version_suffix` matches the URL path ending in `/v<digits>` where the digits are not `1`. `/v1` is intentionally excluded so the existing OpenAI/DeepSeek `/v1`-stripping default path is byte-identical.

This is a **URL-shape heuristic**, not a provider registry. It generically handles the "versioned root URL" convention used by Zhipu (`/paas/v4`), Alibaba Ark (`/api/v3`), and any future OpenAI-compatible endpoint following the same pattern.

## Why here, not in aionrs or AionUi

- **Not aionrs**: its `api_path = /v1/chat/completions` default is correct for the common case. The override correctly belongs at the AionCore boundary (`resolve_aionrs_url_and_compat`), which is already the designated place for provider-specific URL/compat translation (see existing gemini, is_full_url, OpenAI-official branches).
- **Not AionUi**: the Zhipu preset URL (`.../paas/v4`) is correct. The bug is in how AionCore interprets that URL. AionUi's TS types already had an `is_full_url?: boolean` field, but it cannot help here because Zhipu's URL is not a *complete* chat-completion endpoint — it still needs `/chat/completions` appended.

## Test coverage

4 new unit tests added to the existing `factory::aionrs::tests` module:

| Test | Input | Asserts |
|---|---|---|
| `resolve_zhipu_v4_keeps_segment_and_sets_chat_path` | `("custom", ".../paas/v4", "openai", false)` | base_url keeps `/paas/v4`, `api_path = "/chat/completions"` |
| `resolve_ark_v3_keeps_segment_and_sets_chat_path` | `("custom", ".../api/v3", "openai", false)` | base_url keeps `/api/v3`, `api_path = "/chat/completions"` |
| `resolve_zhipu_v4_with_trailing_slash_stripped` | `("custom", ".../paas/v4/", "openai", false)` | trailing `/` stripped, rest as above |
| `has_non_v1_version_suffix_cases` | table of 10 inputs | `v4/v3/v2/v04` → true; `v1/v1beta/v/<bare>/""` → false |

## Verification

```
$ cargo test -p aionui-ai-agent --lib factory::aionrs::tests
test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 543 filtered out
```

All 7 pre-existing `resolve_*` / `normalize_*` tests pass **unchanged** — no assertion edits, confirming backward compatibility for OpenAI, DeepSeek, Anthropic, Gemini, and `is_full_url=true` cases.

`cargo fmt -p aionui-ai-agent --check`: clean.

## Pre-existing clippy note (not introduced by this PR)

`cargo clippy -p aionui-ai-agent --tests` reports one `useless_conversion` warning at `crates/aionui-ai-agent/src/registry_tests.rs:281` — that line was added in commit `d9c2502` (2026-06-26, by `kaizhou-lab`) and is unrelated to this change. Happy to fix it in a separate PR if you prefer to keep this one focused.

## Related

- Upstream issue: https://github.com/iOfficeAI/AionUi/issues/2713
- After this merges, AionUi will need to bump `aioncoreVersion` in its `package.json` to consume the fix — that's tracked under the AionUi repo, out of scope here.
