### PR TITLE
build(just): split recipes into cross-platform scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+*.ps1 text eol=crlf

--- a/justfile
+++ b/justfile
@@ -1,268 +1,99 @@
 # Default: list available recipes
+set windows-shell := ["powershell.exe", "-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command"]
+
+cargo_script := if os_family() == "windows" { "powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/just/cargo.ps1" } else { "bash scripts/just/cargo.sh" }
+build_script := if os_family() == "windows" { "powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/just/build.ps1" } else { "bash scripts/just/build.sh" }
+install_script := if os_family() == "windows" { "powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/just/install.ps1" } else { "bash scripts/just/install.sh" }
+migration_check_script := if os_family() == "windows" { "powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/migration/check-immutability.ps1" } else { "bash scripts/migration/check-immutability.sh" }
+migration_check_test_script := if os_family() == "windows" { "powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/migration/check-immutability.test.ps1" } else { "bash scripts/migration/check-immutability.test.sh" }
+auto_commit_script := if os_family() == "windows" { "powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/just/auto-commit-fixes.ps1" } else { "bash scripts/just/auto-commit-fixes.sh" }
+update_aionrs_script := if os_family() == "windows" { "powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/just/update-aionrs.ps1" } else { "bash scripts/just/update-aionrs.sh" }
+cat_config_script := if os_family() == "windows" { "powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/just/cat-config.ps1" } else { "bash scripts/just/cat-config.sh" }
+
 default:
     @just --list
 
 # Enable pre-commit hooks (run once after clone)
 setup:
     git config core.hooksPath .githooks
-    @echo "✅ Git hooks enabled"
+    @echo "Git hooks enabled"
 
 # Run cargo with optional local aionrs SDK patches.
 _cargo *ARGS:
-    #!/usr/bin/env bash
-    set -euo pipefail
+    @{{cargo_script}} {{ARGS}}
 
-    restore_cargo_lock=false
-    cargo_lock_snapshot=""
-    cargo_config_file=".cargo/config.toml"
-    cargo_config_snapshot=""
-    cargo_config_created=false
-    aionrs_root=""
-
-    restore_local_state() {
-        local status=$?
-
-        if [[ -n "$cargo_lock_snapshot" && -f "$cargo_lock_snapshot" ]]; then
-            if [[ "$restore_cargo_lock" == "true" || "$status" -ne 0 ]]; then
-                cp "$cargo_lock_snapshot" Cargo.lock || status=$?
-            fi
-        fi
-        if [[ -n "$cargo_lock_snapshot" ]]; then
-            rm -f "$cargo_lock_snapshot"
-        fi
-
-        if [[ -n "$cargo_config_snapshot" && -f "$cargo_config_snapshot" ]]; then
-            cp "$cargo_config_snapshot" "$cargo_config_file" || status=$?
-            rm -f "$cargo_config_snapshot"
-        elif [[ "$cargo_config_created" == "true" ]]; then
-            rm -f "$cargo_config_file"
-            rmdir .cargo 2>/dev/null || true
-        fi
-
-        return "$status"
-    }
-    trap restore_local_state EXIT
-
-    verify_local_aionrs_patch() {
-        local crate expected_path pkgid
-        for crate in "${crates[@]}"; do
-            expected_path="$aionrs_root/crates/$crate"
-            pkgid=$(cargo pkgid -p "$crate")
-
-            if ! python3 -c 'import sys; from pathlib import Path; from urllib.parse import unquote, urlparse; pkgid=sys.argv[1]; expected=str(Path(sys.argv[2]).resolve()); ok=pkgid.startswith("path+file://") and str(Path(unquote(urlparse(pkgid[len("path+"):]).path)).resolve()) == expected; sys.exit(0 if ok else 1)' "$pkgid" "$expected_path"
-            then
-                echo "AIONRS patch was not used for $crate." >&2
-                echo "  resolved: $pkgid" >&2
-                echo "  expected: $expected_path" >&2
-                exit 1
-            fi
-        done
-    }
-
-    if [[ -n "${AIONRS:-}" ]]; then
-        if [[ ! -d "$AIONRS" ]]; then
-            echo "AIONRS does not exist or is not a directory: $AIONRS" >&2
-            exit 1
-        fi
-
-        aionrs_root=$(cd "$AIONRS" && pwd -P)
-        crates=(
-            aion-agent
-            aion-compact
-            aion-config
-            aion-mcp
-            aion-memory
-            aion-process
-            aion-protocol
-            aion-providers
-            aion-skills
-            aion-tools
-            aion-types
-        )
-
-        patch_config=$(mktemp)
-        {
-            echo
-            echo "[patch.'https://github.com/iOfficeAI/aionrs.git']"
-        } > "$patch_config"
-
-        for crate in "${crates[@]}"; do
-            crate_dir="$aionrs_root/crates/$crate"
-            if [[ ! -f "$crate_dir/Cargo.toml" ]]; then
-                echo "AIONRS is missing $crate: $crate_dir/Cargo.toml" >&2
-                exit 1
-            fi
-
-            toml_path=${crate_dir//\\/\\\\}
-            toml_path=${toml_path//\"/\\\"}
-            echo "$crate = { path = \"$toml_path\" }" >> "$patch_config"
-        done
-
-        mkdir -p .cargo
-        if [[ -f "$cargo_config_file" ]]; then
-            cargo_config_snapshot=$(mktemp)
-            cp "$cargo_config_file" "$cargo_config_snapshot"
-        else
-            cargo_config_created=true
-        fi
-        cat "$patch_config" >> "$cargo_config_file"
-        rm -f "$patch_config"
-
-        echo "Using local aionrs SDK: $aionrs_root" >&2
-
-        if [[ -f Cargo.lock ]]; then
-            cargo_lock_snapshot=$(mktemp)
-            cp Cargo.lock "$cargo_lock_snapshot"
-
-            if git diff --quiet -- Cargo.lock && git diff --cached --quiet -- Cargo.lock; then
-                restore_cargo_lock=true
-            else
-                echo "Cargo.lock already has changes; leaving successful AIONRS lockfile updates in place." >&2
-            fi
-        fi
-
-        echo "Resolving Cargo.lock against local aionrs SDK" >&2
-        update_args=()
-        for crate in "${crates[@]}"; do
-            update_args+=(-p "$crate")
-        done
-        cargo update "${update_args[@]}"
-        verify_local_aionrs_patch
-    fi
-
-    args=({{ARGS}})
-
-    set +e
-    cargo "${args[@]}"
-    status=$?
-    set -e
-    exit "$status"
-
-# Build in release mode and install to ~/.cargo/bin
+# Build in release mode and install to cargo bin
 # Use `just build --force` to skip cache check
 build *FLAGS: lint-fix fmt
-    #!/usr/bin/env bash
-    set -euo pipefail
-    just _cargo build --release
-    new_sum=$(shasum -a 256 target/release/aioncore | cut -d' ' -f1)
-    force=false
-    for flag in {{FLAGS}}; do
-        if [[ "$flag" == "--force" || "$flag" == "-f" ]]; then
-            force=true
-        fi
-    done
-    old_sum=""
-    if [[ -f target/.build-sum ]] && [[ "$force" == "false" ]]; then
-        old_sum=$(cat target/.build-sum)
-    fi
-    if [[ "$new_sum" == "$old_sum" ]]; then
-        echo -e "\n⏭️  Binary unchanged — skipping install (sha256: ${new_sum:0:16}…)"
-    else
-        cp target/release/aioncore ~/.cargo/bin/
-        codesign --force --sign - ~/.cargo/bin/aioncore
-        echo "$new_sum" > target/.build-sum
-        echo -e "\n✅ Build complete — sha256: ${new_sum:0:16}…"
-    fi
+    @{{build_script}} release {{FLAGS}}
 
 # Build in debug mode
 # Use `just build-debug --force` to skip cache check
 build-debug *FLAGS:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    just _cargo build
-    new_sum=$(shasum -a 256 target/debug/aioncore | cut -d' ' -f1)
-    force=false
-    for flag in {{FLAGS}}; do
-        if [[ "$flag" == "--force" || "$flag" == "-f" ]]; then
-            force=true
-        fi
-    done
-    old_sum=""
-    if [[ -f target/.build-debug-sum ]] && [[ "$force" == "false" ]]; then
-        old_sum=$(cat target/.build-debug-sum)
-    fi
-    if [[ "$new_sum" == "$old_sum" ]]; then
-        echo -e "\n⏭️  Debug binary unchanged (sha256: ${new_sum:0:16}…)"
-    else
-        echo "$new_sum" > target/.build-debug-sum
-        echo -e "\n✅ Debug build complete — sha256: ${new_sum:0:16}…"
-    fi
+    @{{build_script}} debug {{FLAGS}}
 
 install:
-    cp target/release/aioncore ~/.cargo/bin/
-    codesign --force --sign - ~/.cargo/bin/aioncore
+    @{{install_script}} release
 
 # Run all tests
 test:
-    just _cargo nextest run --workspace
+    @just _cargo nextest run --workspace
 
 # Ensure already-shipped database migrations stay immutable
 migration-check:
-    scripts/check-migration-immutability.sh
+    @{{migration_check_script}}
 
 # Test the migration immutability guard itself
 migration-check-test:
-    scripts/check-migration-immutability.test.sh
+    @{{migration_check_test_script}}
 
 # Lint (warnings = errors)
 lint:
-    just _cargo clippy --workspace -- -D warnings
+    @just _cargo clippy --workspace -- -D warnings
 
 lint-fix:
-    just _cargo fix --allow-dirty --allow-staged
-    just _cargo clippy --fix --workspace --allow-dirty --allow-staged -- -D warnings
+    @just _cargo fix --allow-dirty --allow-staged
+    @just _cargo clippy --fix --workspace --allow-dirty --allow-staged -- -D warnings
 
 # Format code
 fmt:
-    cargo fmt --all
+    @cargo fmt --all
 
 # Check formatting (CI)
 fmt-check:
-    cargo fmt --all -- --check
+    @cargo fmt --all -- --check
 
 # Lint + format check + migration check + test
 check: migration-check lint fmt-check test
 
 # Run the server (debug)
 run *ARGS:
-    just _cargo run --bin aioncore -- {{ARGS}}
+    @just _cargo run --bin aioncore -- {{ARGS}}
 
 # Run the server (release)
 run-release *ARGS:
-    just _cargo run --release --bin aioncore -- {{ARGS}}
+    @just _cargo run --release --bin aioncore -- {{ARGS}}
 
 # Pre-push gate: migration check, format, lint, auto-commit fixes, test, then push
 push *ARGS: migration-check lint-fix fmt _auto-commit-fixes test
-    git push {{ ARGS }}
+    git push {{ARGS}}
 
 # Auto-commit any formatting/lint fixes if there are changes
 _auto-commit-fixes:
-    #!/usr/bin/env bash
-    if [ -n "$(git diff --name-only)" ]; then
-        git add -A
-        git commit -m "chore: apply auto-fixes (fmt + clippy)"
-    fi
+    @{{auto_commit_script}}
 
 # Update aionrs dependency (e.g. just update-aionrs or just update-aionrs v0.1.19)
 update-aionrs *TAG:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    tag="{{ TAG }}"
-    if [ -z "$tag" ]; then
-        tag=$(git ls-remote --tags https://github.com/iOfficeAI/aionrs.git | awk -F/ '{print $NF}' | grep -v '\\^{}' | sort -V | tail -1)
-        echo "Using latest tag: $tag"
-    fi
-    sed -i '' "s|git = \"https://github.com/iOfficeAI/aionrs.git\", tag = \"[^\"]*\"|git = \"https://github.com/iOfficeAI/aionrs.git\", tag = \"$tag\"|g" Cargo.toml
-    cargo check --workspace
+    @{{update_aionrs_script}} {{TAG}}
 
 # Security audit
 audit:
-    cargo audit
+    @cargo audit
 
 # Clean build artifacts
 clean:
-    cargo clean
+    @cargo clean
 
-# Decode dev config and copy to clipboard
+# Decode dev config and copy to clipboard when possible
 cat-config:
-    @base64 -D -i ~/.aionui-config-dev/aionui-config.txt | python3 -c 'import sys, urllib.parse; print(urllib.parse.unquote(sys.stdin.read()))' | pbcopy
+    @{{cat_config_script}}

--- a/scripts/just/auto-commit-fixes.ps1
+++ b/scripts/just/auto-commit-fixes.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = "Stop"
+
+$changed = git diff --name-only
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+if (-not [string]::IsNullOrWhiteSpace(($changed -join "`n"))) {
+    git add -A
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    git commit -m "chore: apply auto-fixes (fmt + clippy)"
+    exit $LASTEXITCODE
+}

--- a/scripts/just/auto-commit-fixes.sh
+++ b/scripts/just/auto-commit-fixes.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "$(git diff --name-only)" ]]; then
+    git add -A
+    git commit -m "chore: apply auto-fixes (fmt + clippy)"
+fi

--- a/scripts/just/build.ps1
+++ b/scripts/just/build.ps1
@@ -1,0 +1,53 @@
+param(
+    [ValidateSet("release", "debug")]
+    [string] $Mode = "release",
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $Flags
+)
+
+$ErrorActionPreference = "Stop"
+
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Command,
+        [string[]] $Arguments = @()
+    )
+
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}
+
+$force = $Flags -contains "--force" -or $Flags -contains "-f"
+
+if ($Mode -eq "release") {
+    Invoke-Native "just" @("_cargo", "build", "--release")
+    $binary = "target/release/aioncore.exe"
+    $sumFile = "target/.build-sum"
+    $label = "Build"
+} else {
+    Invoke-Native "just" @("_cargo", "build")
+    $binary = "target/debug/aioncore.exe"
+    $sumFile = "target/.build-debug-sum"
+    $label = "Debug build"
+}
+
+$newSum = (Get-FileHash -Algorithm SHA256 -LiteralPath $binary).Hash.ToLowerInvariant()
+$oldSum = ""
+if ((Test-Path -LiteralPath $sumFile -PathType Leaf) -and -not $force) {
+    $oldSum = (Get-Content -LiteralPath $sumFile -Raw).Trim()
+}
+
+if ($newSum -eq $oldSum) {
+    Write-Output ""
+    Write-Output "$label unchanged (sha256: $($newSum.Substring(0, 16)))"
+} else {
+    if ($Mode -eq "release") {
+        Invoke-Native "powershell.exe" @("-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "scripts/just/install.ps1", "release")
+    }
+    Set-Content -LiteralPath $sumFile -Value $newSum -NoNewline
+    Write-Output ""
+    Write-Output "$label complete (sha256: $($newSum.Substring(0, 16)))"
+}

--- a/scripts/just/build.sh
+++ b/scripts/just/build.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:-release}"
+shift || true
+
+force=false
+for flag in "$@"; do
+    if [[ "$flag" == "--force" || "$flag" == "-f" ]]; then
+        force=true
+    fi
+done
+
+sha256_file() {
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    elif command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        python3 -c 'import hashlib, sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "$1"
+    fi
+}
+
+case "$mode" in
+    release)
+        just _cargo build --release
+        binary="target/release/aioncore"
+        sum_file="target/.build-sum"
+        label="Build"
+        ;;
+    debug)
+        just _cargo build
+        binary="target/debug/aioncore"
+        sum_file="target/.build-debug-sum"
+        label="Debug build"
+        ;;
+    *)
+        echo "unknown build mode: $mode" >&2
+        exit 1
+        ;;
+esac
+
+new_sum=$(sha256_file "$binary")
+old_sum=""
+if [[ -f "$sum_file" && "$force" == "false" ]]; then
+    old_sum=$(cat "$sum_file")
+fi
+
+if [[ "$new_sum" == "$old_sum" ]]; then
+    echo
+    echo "$label unchanged (sha256: ${new_sum:0:16})"
+else
+    if [[ "$mode" == "release" ]]; then
+        bash scripts/just/install.sh release
+    fi
+    echo "$new_sum" > "$sum_file"
+    echo
+    echo "$label complete (sha256: ${new_sum:0:16})"
+fi

--- a/scripts/just/cargo.ps1
+++ b/scripts/just/cargo.ps1
@@ -1,0 +1,142 @@
+$ErrorActionPreference = "Stop"
+
+$CargoArgs = @($args)
+$cargoConfig = @()
+$restoreCargoLock = $false
+$cargoLockSnapshot = $null
+$aionrsRoot = $null
+$crates = @()
+
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Command,
+        [string[]] $Arguments = @()
+    )
+
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        $script:status = $LASTEXITCODE
+        exit $LASTEXITCODE
+    }
+}
+
+function Test-GitDiffClean {
+    param([string[]] $Arguments)
+
+    & git @Arguments | Out-Null
+    return $LASTEXITCODE -eq 0
+}
+
+function Resolve-LocalPath {
+    param([string] $Path)
+
+    return [System.IO.Path]::GetFullPath($Path).TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+}
+
+function Test-AionrsPatch {
+    $metadataJson = & cargo @cargoConfig metadata --format-version 1
+    if ($LASTEXITCODE -ne 0) {
+        $script:status = $LASTEXITCODE
+        exit $LASTEXITCODE
+    }
+    $metadata = $metadataJson | ConvertFrom-Json
+
+    foreach ($crate in $crates) {
+        $expectedPath = Resolve-LocalPath (Join-Path $aionrsRoot "crates/$crate")
+        $package = $metadata.packages | Where-Object { $_.name -eq $crate } | Select-Object -First 1
+        $actualPath = if ($null -eq $package) {
+            "package not found"
+        } else {
+            Resolve-LocalPath (Split-Path -Parent $package.manifest_path)
+        }
+
+        if ($actualPath -ne $expectedPath) {
+            Write-Error "AIONRS patch was not used for $crate.`n  resolved: $actualPath`n  expected: $expectedPath"
+            $script:status = 1
+            exit 1
+        }
+    }
+}
+
+$status = 0
+try {
+    if (-not [string]::IsNullOrWhiteSpace($env:AIONRS)) {
+        if (-not (Test-Path -LiteralPath $env:AIONRS -PathType Container)) {
+            Write-Error "AIONRS does not exist or is not a directory: $env:AIONRS"
+            exit 1
+        }
+
+        $aionrsRoot = (Resolve-Path -LiteralPath $env:AIONRS).ProviderPath
+        $crates = @(
+            "aion-agent",
+            "aion-compact",
+            "aion-config",
+            "aion-mcp",
+            "aion-memory",
+            "aion-process",
+            "aion-protocol",
+            "aion-providers",
+            "aion-skills",
+            "aion-tools",
+            "aion-types"
+        )
+
+        foreach ($crate in $crates) {
+            $crateDir = Join-Path $aionrsRoot "crates/$crate"
+            $manifest = Join-Path $crateDir "Cargo.toml"
+            if (-not (Test-Path -LiteralPath $manifest -PathType Leaf)) {
+                Write-Error "AIONRS is missing ${crate}: $manifest"
+                exit 1
+            }
+
+            $tomlPath = $crateDir.Replace("\", "/").Replace('"', '\"')
+            $cargoConfig += @("--config", "patch.'https://github.com/iOfficeAI/aionrs.git'.$crate.path = `"`"$tomlPath`"`"")
+        }
+
+        [Console]::Error.WriteLine("Using local aionrs SDK: $aionrsRoot")
+
+        if (Test-Path -LiteralPath "Cargo.lock" -PathType Leaf) {
+            $cargoLockSnapshot = [System.IO.Path]::GetTempFileName()
+            Copy-Item -LiteralPath "Cargo.lock" -Destination $cargoLockSnapshot -Force
+
+            $worktreeClean = Test-GitDiffClean @("diff", "--quiet", "--", "Cargo.lock")
+            $indexClean = Test-GitDiffClean @("diff", "--cached", "--quiet", "--", "Cargo.lock")
+            if ($worktreeClean -and $indexClean) {
+                $restoreCargoLock = $true
+            } else {
+                [Console]::Error.WriteLine("Cargo.lock already has changes; leaving successful AIONRS lockfile updates in place.")
+            }
+        }
+
+        [Console]::Error.WriteLine("Resolving Cargo.lock against local aionrs SDK")
+        $updateArgs = @($cargoConfig) + @(
+            "update",
+            "-p", "aion-agent",
+            "-p", "aion-compact",
+            "-p", "aion-config",
+            "-p", "aion-mcp",
+            "-p", "aion-memory",
+            "-p", "aion-process",
+            "-p", "aion-protocol",
+            "-p", "aion-providers",
+            "-p", "aion-skills",
+            "-p", "aion-tools",
+            "-p", "aion-types"
+        )
+        Invoke-Native "cargo" $updateArgs
+        Test-AionrsPatch
+    }
+
+    & cargo @cargoConfig @CargoArgs
+    $status = $LASTEXITCODE
+} finally {
+    if ($null -ne $cargoLockSnapshot -and (Test-Path -LiteralPath $cargoLockSnapshot -PathType Leaf)) {
+        if ($restoreCargoLock -or $status -ne 0) {
+            Copy-Item -LiteralPath $cargoLockSnapshot -Destination "Cargo.lock" -Force
+        }
+        Remove-Item -LiteralPath $cargoLockSnapshot -Force
+    }
+}
+
+exit $status

--- a/scripts/just/cargo.sh
+++ b/scripts/just/cargo.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cargo_config=()
+restore_cargo_lock=false
+cargo_lock_snapshot=""
+aionrs_root=""
+
+restore_local_lockfile() {
+    local status=$?
+
+    if [[ -n "$cargo_lock_snapshot" && -f "$cargo_lock_snapshot" ]]; then
+        if [[ "$restore_cargo_lock" == "true" || "$status" -ne 0 ]]; then
+            cp "$cargo_lock_snapshot" Cargo.lock || status=$?
+        fi
+    fi
+    if [[ -n "$cargo_lock_snapshot" ]]; then
+        rm -f "$cargo_lock_snapshot"
+    fi
+
+    return "$status"
+}
+trap restore_local_lockfile EXIT
+
+verify_local_aionrs_patch() {
+    local metadata_file
+    metadata_file=$(mktemp)
+    cargo "${cargo_config[@]}" metadata --format-version 1 > "$metadata_file"
+
+    python3 - "$aionrs_root" "$metadata_file" "${crates[@]}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+aionrs_root = Path(sys.argv[1]).resolve()
+metadata_path = Path(sys.argv[2])
+crates = sys.argv[3:]
+metadata = json.loads(metadata_path.read_text())
+packages = {package["name"]: package for package in metadata["packages"]}
+
+for crate in crates:
+    package = packages.get(crate)
+    expected = (aionrs_root / "crates" / crate).resolve()
+    if not package:
+        print(f"AIONRS patch was not used for {crate}.", file=sys.stderr)
+        print("  resolved: package not found", file=sys.stderr)
+        print(f"  expected: {expected}", file=sys.stderr)
+        sys.exit(1)
+
+    actual = Path(package["manifest_path"]).resolve().parent
+    if actual != expected:
+        print(f"AIONRS patch was not used for {crate}.", file=sys.stderr)
+        print(f"  resolved: {actual}", file=sys.stderr)
+        print(f"  expected: {expected}", file=sys.stderr)
+        sys.exit(1)
+PY
+
+    rm -f "$metadata_file"
+}
+
+if [[ -n "${AIONRS:-}" ]]; then
+    if [[ ! -d "$AIONRS" ]]; then
+        echo "AIONRS does not exist or is not a directory: $AIONRS" >&2
+        exit 1
+    fi
+
+    aionrs_root=$(cd "$AIONRS" && pwd -P)
+    crates=(
+        aion-agent
+        aion-compact
+        aion-config
+        aion-mcp
+        aion-memory
+        aion-process
+        aion-protocol
+        aion-providers
+        aion-skills
+        aion-tools
+        aion-types
+    )
+
+    for crate in "${crates[@]}"; do
+        crate_dir="$aionrs_root/crates/$crate"
+        if [[ ! -f "$crate_dir/Cargo.toml" ]]; then
+            echo "AIONRS is missing $crate: $crate_dir/Cargo.toml" >&2
+            exit 1
+        fi
+
+        toml_path=${crate_dir//\\/\\\\}
+        toml_path=${toml_path//\"/\\\"}
+        cargo_config+=(--config "patch.'https://github.com/iOfficeAI/aionrs.git'.$crate.path = \"$toml_path\"")
+    done
+
+    echo "Using local aionrs SDK: $aionrs_root" >&2
+
+    if [[ -f Cargo.lock ]]; then
+        cargo_lock_snapshot=$(mktemp)
+        cp Cargo.lock "$cargo_lock_snapshot"
+
+        if git diff --quiet -- Cargo.lock && git diff --cached --quiet -- Cargo.lock; then
+            restore_cargo_lock=true
+        else
+            echo "Cargo.lock already has changes; leaving successful AIONRS lockfile updates in place." >&2
+        fi
+    fi
+
+    echo "Resolving Cargo.lock against local aionrs SDK" >&2
+    cargo "${cargo_config[@]}" update \
+        -p aion-agent \
+        -p aion-compact \
+        -p aion-config \
+        -p aion-mcp \
+        -p aion-memory \
+        -p aion-process \
+        -p aion-protocol \
+        -p aion-providers \
+        -p aion-skills \
+        -p aion-tools \
+        -p aion-types
+    verify_local_aionrs_patch
+fi
+
+if ((${#cargo_config[@]})); then
+    cargo "${cargo_config[@]}" "$@"
+else
+    cargo "$@"
+fi

--- a/scripts/just/cat-config.ps1
+++ b/scripts/just/cat-config.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = "Stop"
+
+$configFile = if ([string]::IsNullOrWhiteSpace($env:AIONUI_CONFIG_DEV_FILE)) {
+    Join-Path $HOME ".aionui-config-dev/aionui-config.txt"
+} else {
+    $env:AIONUI_CONFIG_DEV_FILE
+}
+
+if (-not (Test-Path -LiteralPath $configFile -PathType Leaf)) {
+    Write-Error "config file not found: $configFile"
+    exit 1
+}
+
+$encoded = (Get-Content -LiteralPath $configFile -Raw).Trim()
+$bytes = [Convert]::FromBase64String($encoded)
+$decoded = [Text.Encoding]::UTF8.GetString($bytes)
+$plain = [Uri]::UnescapeDataString($decoded)
+
+if (Get-Command Set-Clipboard -ErrorAction SilentlyContinue) {
+    Set-Clipboard -Value $plain
+    Write-Output "Config copied to clipboard"
+} else {
+    Write-Output $plain
+}

--- a/scripts/just/cat-config.sh
+++ b/scripts/just/cat-config.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+config_file="${AIONUI_CONFIG_DEV_FILE:-$HOME/.aionui-config-dev/aionui-config.txt}"
+if [[ ! -f "$config_file" ]]; then
+    echo "config file not found: $config_file" >&2
+    exit 1
+fi
+
+if base64 --help 2>&1 | grep -q -- "-D"; then
+    decoded=$(base64 -D -i "$config_file")
+else
+    decoded=$(base64 -d "$config_file")
+fi
+
+plain=$(printf "%s" "$decoded" | python3 -c 'import sys, urllib.parse; print(urllib.parse.unquote(sys.stdin.read()))')
+
+if command -v pbcopy >/dev/null 2>&1; then
+    printf "%s" "$plain" | pbcopy
+    echo "Config copied to clipboard"
+elif command -v wl-copy >/dev/null 2>&1; then
+    printf "%s" "$plain" | wl-copy
+    echo "Config copied to clipboard"
+elif command -v xclip >/dev/null 2>&1; then
+    printf "%s" "$plain" | xclip -selection clipboard
+    echo "Config copied to clipboard"
+else
+    printf "%s\n" "$plain"
+fi

--- a/scripts/just/install.ps1
+++ b/scripts/just/install.ps1
@@ -1,0 +1,28 @@
+param(
+    [ValidateSet("release", "debug")]
+    [string] $Mode = "release"
+)
+
+$ErrorActionPreference = "Stop"
+
+$binary = if ($Mode -eq "release") {
+    "target/release/aioncore.exe"
+} else {
+    "target/debug/aioncore.exe"
+}
+
+if (-not (Test-Path -LiteralPath $binary -PathType Leaf)) {
+    Write-Error "binary not found: $binary"
+    exit 1
+}
+
+$cargoHome = if ([string]::IsNullOrWhiteSpace($env:CARGO_HOME)) {
+    Join-Path $HOME ".cargo"
+} else {
+    $env:CARGO_HOME
+}
+$installDir = Join-Path $cargoHome "bin"
+New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+
+Copy-Item -LiteralPath $binary -Destination $installDir -Force
+Write-Output "Installed aioncore.exe to $installDir"

--- a/scripts/just/install.sh
+++ b/scripts/just/install.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:-release}"
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) exe_suffix=".exe" ;;
+    *) exe_suffix="" ;;
+esac
+
+case "$mode" in
+    release) binary="target/release/aioncore$exe_suffix" ;;
+    debug) binary="target/debug/aioncore$exe_suffix" ;;
+    *) echo "unknown install mode: $mode" >&2; exit 1 ;;
+esac
+
+if [[ ! -f "$binary" ]]; then
+    echo "binary not found: $binary" >&2
+    exit 1
+fi
+
+cargo_home="${CARGO_HOME:-$HOME/.cargo}"
+install_dir="$cargo_home/bin"
+mkdir -p "$install_dir"
+cp "$binary" "$install_dir/"
+
+if [[ "$(uname -s)" == "Darwin" ]] && command -v codesign >/dev/null 2>&1; then
+    codesign --force --sign - "$install_dir/$(basename "$binary")"
+fi
+
+echo "Installed $(basename "$binary") to $install_dir"

--- a/scripts/just/update-aionrs.ps1
+++ b/scripts/just/update-aionrs.ps1
@@ -1,0 +1,46 @@
+param(
+    [string] $Tag = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($Tag)) {
+    $refs = git ls-remote --tags https://github.com/iOfficeAI/aionrs.git
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    $Tag = $refs |
+        ForEach-Object {
+            if ($_ -match "refs/tags/(v[0-9]+(?:\.[0-9]+)*(?:[-+][0-9A-Za-z.-]+)?)$") {
+                $Matches[1]
+            }
+        } |
+        Sort-Object { [version](($_ -replace "^v", "") -replace "[-+].*$", "") } |
+        Select-Object -Last 1
+
+    if ([string]::IsNullOrWhiteSpace($Tag)) {
+        Write-Error "No aionrs tags found"
+        exit 1
+    }
+    Write-Output "Using latest tag: $Tag"
+}
+
+$path = "Cargo.toml"
+$text = Get-Content -LiteralPath $path -Raw
+$pattern = 'git = "https://github\.com/iOfficeAI/aionrs\.git", tag = "[^"]*"'
+$replacement = "git = `"https://github.com/iOfficeAI/aionrs.git`", tag = `"$Tag`""
+$matches = [regex]::Matches($text, $pattern)
+if ($matches.Count -eq 0) {
+    Write-Error "No aionrs git dependency tags found in Cargo.toml"
+    exit 1
+}
+$updated = [regex]::Replace($text, $pattern, $replacement)
+
+[System.IO.File]::WriteAllText(
+    (Resolve-Path -LiteralPath $path).ProviderPath,
+    $updated,
+    [System.Text.UTF8Encoding]::new($false)
+)
+cargo check --workspace
+exit $LASTEXITCODE

--- a/scripts/just/update-aionrs.sh
+++ b/scripts/just/update-aionrs.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${1:-}"
+if [[ -z "$tag" ]]; then
+    tag=$(
+        git ls-remote --tags https://github.com/iOfficeAI/aionrs.git |
+            python3 -c 'import re, sys; tags=[]; [tags.append(m.group(1)) for line in sys.stdin for m in [re.search(r"refs/tags/(v[0-9]+(?:\.[0-9]+)*(?:[-+][0-9A-Za-z.-]+)?)$", line)] if m]; print(sorted(tags, key=lambda t: [int(p) if p.isdigit() else p for p in re.split(r"[.-]", t.lstrip("v"))])[-1])'
+    )
+    echo "Using latest tag: $tag"
+fi
+
+python3 - "$tag" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+tag = sys.argv[1]
+path = Path("Cargo.toml")
+text = path.read_text()
+updated = re.sub(
+    r'git = "https://github\.com/iOfficeAI/aionrs\.git", tag = "[^"]*"',
+    f'git = "https://github.com/iOfficeAI/aionrs.git", tag = "{tag}"',
+    text,
+)
+if not re.search(r'git = "https://github\.com/iOfficeAI/aionrs\.git", tag = "[^"]*"', text):
+    raise SystemExit("No aionrs git dependency tags found in Cargo.toml")
+path.write_text(updated)
+PY
+
+cargo check --workspace


### PR DESCRIPTION
## Summary
- Move just recipe implementations into `scripts/just` shell and PowerShell scripts.
- Add platform-aware just dispatch for cargo, build, install, migration checks, and helper recipes.
- Preserve release install/checksum ordering and Cargo.lock rollback behavior.

## Test Plan
- rtk just lint-fix
- rtk just fmt
- rtk just --dry-run _cargo check
- rtk just --dry-run build --force
- rtk just --dry-run migration-check
- rtk just --dry-run migration-check-test
- rtk bash -n scripts/just/build.sh
- rtk bash -n scripts/just/cargo.sh

## Not Run
- PowerShell ps1 runtime validation locally; this environment does not provide `pwsh` or `powershell`.