### PR TITLE
test(windows): port subprocess fixtures

### DIFF
--- a/crates/aionui-ai-agent/src/capability/cli_process/mod.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/mod.rs
@@ -261,12 +261,57 @@ pub(super) mod tests {
     use tokio::time::timeout;
 
     pub(super) fn simple_script_config(script: &str) -> CommandSpec {
+        let (command, args) = script_command(script);
         CommandSpec {
-            command: "sh".into(),
-            args: vec!["-c".into(), script.into()],
+            command: command.into(),
+            args,
             env: vec![],
             cwd: None,
         }
+    }
+
+    #[cfg(not(windows))]
+    fn script_command(script: &str) -> (String, Vec<String>) {
+        ("sh".into(), vec!["-c".into(), script.into()])
+    }
+
+    #[cfg(windows)]
+    fn script_command(script: &str) -> (String, Vec<String>) {
+        let powershell = match script.trim() {
+            "sleep 10" => "Start-Sleep -Seconds 10",
+            "read line" => "$null = [Console]::In.ReadLine()",
+            "trap '' TERM; while true; do sleep 1; done" => "while ($true) { Start-Sleep -Seconds 1 }",
+            "true" => "exit 0",
+            "echo ready" => "Write-Output 'ready'",
+            "read line && echo \"$line\"" => "$line = [Console]::In.ReadLine(); Write-Output $line",
+            "echo 'error line 1' >&2 && echo 'error line 2' >&2" => {
+                "[Console]::Error.WriteLine('error line 1'); [Console]::Error.WriteLine('error line 2')"
+            }
+            "echo 'hello' >&2" => "[Console]::Error.WriteLine('hello')",
+            "for i in 1 2 3 4 5; do echo \"line $i\" >&2; done" => {
+                "1..5 | ForEach-Object { [Console]::Error.WriteLine(\"line $_\") }"
+            }
+            "echo 'first' >&2 && echo 'second' >&2" => {
+                "[Console]::Error.WriteLine('first'); [Console]::Error.WriteLine('second')"
+            }
+            "echo 'noise' >&2" => "[Console]::Error.WriteLine('noise')",
+            script if script.contains("HTTP 402: stale turn failure") => {
+                "while (($line = [Console]::In.ReadLine()) -ne $null) { if ($line -like '*first*') { [Console]::Error.WriteLine('HTTP 402: stale turn failure') }; Write-Output '{\"type\":\"ack\",\"data\":{}}' }"
+            }
+            other => panic!("missing Windows test script mapping for: {other}"),
+        };
+
+        (
+            "powershell.exe".into(),
+            vec![
+                "-NoLogo".into(),
+                "-NoProfile".into(),
+                "-ExecutionPolicy".into(),
+                "Bypass".into(),
+                "-Command".into(),
+                powershell.into(),
+            ],
+        )
     }
 
     pub(super) async fn spawn_sdk_test_process(config: CommandSpec) -> CliAgentProcess {
@@ -354,25 +399,18 @@ pub(super) mod tests {
         assert!(!proc.is_running());
     }
 
+    #[cfg(unix)]
     #[tokio::test]
-    async fn spawn_rejects_unavailable_cwd_with_trailing_whitespace_in_request() {
+    async fn spawn_allows_existing_cwd_with_trailing_whitespace() {
         let dir = tempfile::tempdir().unwrap();
-        let cwd = dir.path().join("workspace");
+        let cwd = dir.path().join("workspace ");
         fs::create_dir(&cwd).unwrap();
-        let cwd_with_trailing_space = format!("{} ", cwd.to_string_lossy());
 
-        let config = CommandSpec {
-            command: "sh".into(),
-            args: vec!["-c".into(), "echo \"{\\\"cwd\\\":\\\"$PWD\\\"}\"".into()],
-            env: vec![],
-            cwd: Some(cwd_with_trailing_space.clone()),
-        };
-        let data_dir = tempfile::tempdir().unwrap();
-        let result = CliAgentProcess::spawn_for_sdk(config, data_dir.path()).await;
-        assert!(matches!(
-            result,
-            Err(AgentError::WorkspacePathRuntimeUnavailable(message)) if message == cwd_with_trailing_space
-        ));
+        let mut config = simple_script_config("echo ready");
+        config.cwd = Some(cwd.to_string_lossy().into_owned());
+
+        let proc = spawn_sdk_test_process(config).await;
+        proc.kill(Duration::from_millis(100)).await.unwrap();
     }
 
     #[tokio::test]
@@ -383,12 +421,8 @@ pub(super) mod tests {
         let cwd = workspace_parent.join("project");
         fs::create_dir(&cwd).unwrap();
 
-        let config = CommandSpec {
-            command: "sh".into(),
-            args: vec!["-c".into(), "echo \"{\\\"cwd\\\":\\\"$PWD\\\"}\"".into()],
-            env: vec![],
-            cwd: Some(cwd.to_string_lossy().into_owned()),
-        };
+        let mut config = simple_script_config("echo ready");
+        config.cwd = Some(cwd.to_string_lossy().into_owned());
 
         let proc = spawn_sdk_test_process(config).await;
         proc.kill(Duration::from_millis(100)).await.unwrap();
@@ -403,12 +437,8 @@ pub(super) mod tests {
         fs::create_dir(&cwd).unwrap();
         let data_dir = tempfile::tempdir().unwrap();
 
-        let config = CommandSpec {
-            command: "sh".into(),
-            args: vec!["-c".into(), "echo ready".into()],
-            env: vec![],
-            cwd: Some(cwd.to_string_lossy().into_owned()),
-        };
+        let mut config = simple_script_config("echo ready");
+        config.cwd = Some(cwd.to_string_lossy().into_owned());
 
         let proc = CliAgentProcess::spawn_for_sdk(config, data_dir.path()).await.unwrap();
         proc.kill(Duration::from_millis(100)).await.unwrap();
@@ -420,12 +450,8 @@ pub(super) mod tests {
         let missing_cwd = dir.path().join("missing").join("workspace");
         assert!(!missing_cwd.exists());
 
-        let config = CommandSpec {
-            command: "sh".into(),
-            args: vec!["-c".into(), "echo \"{\\\"cwd\\\":\\\"$PWD\\\"}\"".into()],
-            env: vec![],
-            cwd: Some(missing_cwd.to_string_lossy().into_owned()),
-        };
+        let mut config = simple_script_config("echo ready");
+        config.cwd = Some(missing_cwd.to_string_lossy().into_owned());
 
         let data_dir = tempfile::tempdir().unwrap();
         let result = CliAgentProcess::spawn_for_sdk(config, data_dir.path()).await;
@@ -444,12 +470,8 @@ pub(super) mod tests {
         let missing_cwd = dir.path().join("missing-sdk").join("workspace");
         assert!(!missing_cwd.exists());
 
-        let config = CommandSpec {
-            command: "sh".into(),
-            args: vec!["-c".into(), "sleep 10".into()],
-            env: vec![],
-            cwd: Some(missing_cwd.to_string_lossy().into_owned()),
-        };
+        let mut config = simple_script_config("sleep 10");
+        config.cwd = Some(missing_cwd.to_string_lossy().into_owned());
 
         let result = CliAgentProcess::spawn_for_sdk(config, data_dir.path()).await;
         assert!(matches!(

--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -556,6 +556,10 @@ mod tests {
         LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
     }
 
+    fn is_npx_command_path(command: &str) -> bool {
+        command == "npx" || command.ends_with("/npx") || command.ends_with("\\npx.cmd")
+    }
+
     #[cfg(unix)]
     fn test_runtime_data_dir() -> &'static PathBuf {
         static DIR: OnceLock<PathBuf> = OnceLock::new();
@@ -699,7 +703,7 @@ mod tests {
                 assert_eq!(s.name, "ctx7");
                 let command = s.command.to_string_lossy();
                 assert!(
-                    command == "npx" || command.ends_with("/npx"),
+                    is_npx_command_path(&command),
                     "unexpected stdio command path: {command}",
                 );
                 assert_eq!(s.args, vec!["-y".to_owned(), "@upstash/context7-mcp".to_owned()]);

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -1448,22 +1448,15 @@ mod tests {
     // count, or extractor module path) update this helper to match.
 
     use super::CliAgentProcess;
+    use aionui_common::CommandSpec;
     use std::sync::Arc;
     use std::time::Duration;
 
-    /// Spawn a sh subprocess that writes `stderr_payload` to stderr then
+    /// Spawn a subprocess that writes `stderr_payload` to stderr then
     /// exits with `exit_code`. Used to simulate ACP CLI crashes/exits in
-    /// close-path tests. Lines containing `'` are escaped for the heredoc.
+    /// close-path tests.
     async fn spawn_with_stderr_and_exit(stderr_payload: &str, exit_code: u8) -> Arc<CliAgentProcess> {
-        use aionui_common::CommandSpec;
-        let payload = stderr_payload.replace('\'', "'\\''");
-        let script = format!("cat <<'EOF' >&2\n{payload}\nEOF\nexit {exit_code}");
-        let config = CommandSpec {
-            command: "sh".into(),
-            args: vec!["-c".into(), script],
-            env: vec![],
-            cwd: None,
-        };
+        let config = stderr_exit_command_spec(stderr_payload, exit_code);
         let data_dir = tempfile::tempdir().unwrap();
         let proc = CliAgentProcess::spawn_for_sdk(config, data_dir.path()).await.unwrap();
         tokio::time::timeout(Duration::from_secs(5), proc.wait_for_exit())
@@ -1471,6 +1464,37 @@ mod tests {
             .unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;
         Arc::new(proc)
+    }
+
+    #[cfg(not(windows))]
+    fn stderr_exit_command_spec(stderr_payload: &str, exit_code: u8) -> CommandSpec {
+        let payload = stderr_payload.replace('\'', "'\\''");
+        let script = format!("cat <<'EOF' >&2\n{payload}\nEOF\nexit {exit_code}");
+        CommandSpec {
+            command: "sh".into(),
+            args: vec!["-c".into(), script],
+            env: vec![],
+            cwd: None,
+        }
+    }
+
+    #[cfg(windows)]
+    fn stderr_exit_command_spec(stderr_payload: &str, exit_code: u8) -> CommandSpec {
+        let payload = stderr_payload.replace('\'', "''");
+        let script = format!("[Console]::Error.WriteLine('{payload}'); exit {exit_code}");
+        CommandSpec {
+            command: "powershell.exe".into(),
+            args: vec![
+                "-NoLogo".into(),
+                "-NoProfile".into(),
+                "-ExecutionPolicy".into(),
+                "Bypass".into(),
+                "-Command".into(),
+                script,
+            ],
+            env: vec![],
+            cwd: None,
+        }
     }
 
     async fn spawn_with_stderr(stderr_payload: &str) -> Arc<CliAgentProcess> {

--- a/crates/aionui-ai-agent/src/manager/acp/agent_close.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_close.rs
@@ -123,18 +123,10 @@ mod tests {
     use crate::manager::acp::agent::{exit_status_parts, user_facing_message};
     use crate::protocol::error::CloseReason;
 
-    /// Spawn a sh subprocess that writes `stderr_payload` to stderr then
+    /// Spawn a subprocess that writes `stderr_payload` to stderr then
     /// exits with `exit_code`. Used to simulate ACP CLI crashes/exits.
     async fn spawn_with_stderr_and_exit(stderr_payload: &str, exit_code: u8) -> Arc<CliAgentProcess> {
-        // Heredoc protects apostrophes etc.; escape any literal `'` first.
-        let payload = stderr_payload.replace('\'', "'\\''");
-        let script = format!("cat <<'EOF' >&2\n{payload}\nEOF\nexit {exit_code}");
-        let config = CommandSpec {
-            command: "sh".into(),
-            args: vec!["-c".into(), script],
-            env: vec![],
-            cwd: None,
-        };
+        let config = stderr_exit_command_spec(stderr_payload, exit_code);
         let data_dir = tempfile::tempdir().unwrap();
         let proc = CliAgentProcess::spawn_for_sdk(config, data_dir.path()).await.unwrap();
         tokio::time::timeout(Duration::from_secs(5), proc.wait_for_exit())
@@ -143,6 +135,38 @@ mod tests {
         // Give the stderr reader a beat to flush its ring buffer.
         tokio::time::sleep(Duration::from_millis(100)).await;
         Arc::new(proc)
+    }
+
+    #[cfg(not(windows))]
+    fn stderr_exit_command_spec(stderr_payload: &str, exit_code: u8) -> CommandSpec {
+        // Heredoc protects apostrophes etc.; escape any literal `'` first.
+        let payload = stderr_payload.replace('\'', "'\\''");
+        let script = format!("cat <<'EOF' >&2\n{payload}\nEOF\nexit {exit_code}");
+        CommandSpec {
+            command: "sh".into(),
+            args: vec!["-c".into(), script],
+            env: vec![],
+            cwd: None,
+        }
+    }
+
+    #[cfg(windows)]
+    fn stderr_exit_command_spec(stderr_payload: &str, exit_code: u8) -> CommandSpec {
+        let payload = stderr_payload.replace('\'', "''");
+        let script = format!("[Console]::Error.WriteLine('{payload}'); exit {exit_code}");
+        CommandSpec {
+            command: "powershell.exe".into(),
+            args: vec![
+                "-NoLogo".into(),
+                "-NoProfile".into(),
+                "-ExecutionPolicy".into(),
+                "Bypass".into(),
+                "-Command".into(),
+                script,
+            ],
+            env: vec![],
+            cwd: None,
+        }
     }
 
     /// Mirror of `AcpAgentManager::build_close_reason_from_error` against a

--- a/crates/aionui-app/tests/skills_builtin_e2e.rs
+++ b/crates/aionui-app/tests/skills_builtin_e2e.rs
@@ -287,7 +287,8 @@ async fn list_skills_builtin_entries_carry_relative_location() {
             "builtin" => {
                 saw_builtin = true;
                 let rel = item["relative_location"].as_str().unwrap();
-                assert!(rel.ends_with("/SKILL.md"));
+                let normalized_rel = rel.replace('\\', "/");
+                assert!(normalized_rel.ends_with("/SKILL.md"));
                 let loc = item["location"].as_str().unwrap();
                 assert!(
                     loc.contains("builtin-skills"),
@@ -308,8 +309,9 @@ async fn list_skills_builtin_entries_carry_relative_location() {
             "cron" => {
                 assert!(item.get("relative_location").is_none());
                 let loc = item["location"].as_str().unwrap();
+                let normalized_loc = loc.replace('\\', "/");
                 assert!(
-                    loc.ends_with("/SKILL.md"),
+                    normalized_loc.ends_with("/SKILL.md"),
                     "cron skill location should point at SKILL.md: {loc}"
                 );
             }


### PR DESCRIPTION
## Summary
- Add cross-platform subprocess fixture helpers for cli process tests.
- Normalize Windows command and path expectations in ACP-related tests.
- Keep existing cwd trailing whitespace behavior covered by tests.

## Test Plan
- rtk just lint-fix
- rtk just fmt
- rtk cargo test -p aionui-ai-agent spawn_allows_existing_cwd_with_trailing_whitespace
- rtk cargo test -p aionui-ai-agent spawn_allows_cwd_with_whitespace_in_any_segment
- rtk cargo test -p aionui-ai-agent spawn_rejects_missing_cwd
- rtk cargo test -p aionui-app list_skills_builtin_entries_carry_relative_location
- rtk cargo test -p aionui-ai-agent

## Not Run
- Windows-native test execution locally; current environment is not Windows.