### PR TITLE
fix(windows): handle runtime process lifecycle

### DIFF
--- a/crates/aionui-ai-agent/src/capability/cli_process/stderr_monitor.rs
+++ b/crates/aionui-ai-agent/src/capability/cli_process/stderr_monitor.rs
@@ -61,6 +61,8 @@ pub(super) fn force_kill(pid: u32, process_group_id: Option<u32>) -> Result<(), 
     }
     #[cfg(windows)]
     {
+        let _ = process_group_id;
+
         // `taskkill` exit codes:
         //   0   — process killed
         //   128 — "not found" (already exited): treat as success, identical to
@@ -75,7 +77,7 @@ pub(super) fn force_kill(pid: u32, process_group_id: Option<u32>) -> Result<(), 
                 debug!(pid, "taskkill /F /T succeeded");
                 Ok(())
             }
-            Ok(output) if output.status.code() == Some(128) => {
+            Ok(output) if taskkill_output_is_missing_process(&output) => {
                 debug!(pid, "Process already exited before taskkill");
                 Ok(())
             }
@@ -99,6 +101,16 @@ pub(super) fn force_kill(pid: u32, process_group_id: Option<u32>) -> Result<(), 
             "Force kill not supported on this platform for pid {pid}"
         )))
     }
+}
+
+#[cfg(windows)]
+fn taskkill_output_is_missing_process(output: &std::process::Output) -> bool {
+    if output.status.code() == Some(128) {
+        return true;
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+    stderr.contains("no running instance") || stderr.contains("not found")
 }
 
 #[cfg(test)]

--- a/crates/aionui-app/src/bootstrap/parent_exit.rs
+++ b/crates/aionui-app/src/bootstrap/parent_exit.rs
@@ -30,7 +30,7 @@ async fn wait_for_parent_exit(parent_pid: u32) {
 
 #[cfg(windows)]
 fn wait_for_parent_exit_blocking(parent_pid: u32) {
-    use windows_sys::Win32::Foundation::{CloseHandle, WAIT_OBJECT_0};
+    use windows_sys::Win32::Foundation::CloseHandle;
     use windows_sys::Win32::System::Threading::{
         INFINITE, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, WaitForSingleObject,
     };
@@ -41,11 +41,10 @@ fn wait_for_parent_exit_blocking(parent_pid: u32) {
             return;
         }
 
-        let wait_result = WaitForSingleObject(handle, INFINITE);
+        // Any wait completion ends the parent-exit monitor; there is no
+        // distinct error path because callers only need a shutdown signal.
+        let _ = WaitForSingleObject(handle, INFINITE);
         let _ = CloseHandle(handle);
-        if wait_result != WAIT_OBJECT_0 {
-            return;
-        }
     }
 }
 

--- a/crates/aionui-app/src/commands/cmd_server.rs
+++ b/crates/aionui-app/src/commands/cmd_server.rs
@@ -22,6 +22,7 @@ const WORKER_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ShutdownReason {
     Sigint,
+    #[cfg(unix)]
     Sigterm,
     ParentExit,
 }
@@ -286,6 +287,7 @@ pub(crate) async fn run_server(
                 Ok(reason) => {
                     match reason {
                         ShutdownReason::Sigint => info!("Received SIGINT, shutting down..."),
+                        #[cfg(unix)]
                         ShutdownReason::Sigterm => info!("Received SIGTERM, shutting down..."),
                         ShutdownReason::ParentExit => info!("Detected desktop parent exit, shutting down..."),
                     }

--- a/crates/aionui-extension/src/skill_service.rs
+++ b/crates/aionui-extension/src/skill_service.rs
@@ -2135,12 +2135,7 @@ async fn create_symlink(src: &Path, dst: &Path) -> Result<(), ExtensionError> {
         let dst = dst.to_path_buf();
         tokio::task::spawn_blocking(move || junction::create(&src, &dst))
             .await
-            .map_err(|e| {
-                ExtensionError::Io(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("junction::create join error: {e}"),
-                ))
-            })?
+            .map_err(|e| ExtensionError::Io(std::io::Error::other(format!("junction::create join error: {e}"))))?
             .map_err(ExtensionError::Io)
     } else {
         tokio::fs::symlink_file(src, dst).await.map_err(ExtensionError::Io)

--- a/crates/aionui-runtime/src/agent_env.rs
+++ b/crates/aionui-runtime/src/agent_env.rs
@@ -1,10 +1,14 @@
 use std::collections::BTreeMap;
 use std::ffi::OsString;
-use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::path::Path;
+use std::path::PathBuf;
+#[cfg(unix)]
 use std::time::Duration;
 
 use tokio::sync::OnceCell;
 
+#[cfg(unix)]
 use crate::Builder;
 
 static FULL_SHELL_ENV: OnceCell<Vec<(OsString, OsString)>> = OnceCell::const_new();
@@ -146,6 +150,7 @@ async fn load_full_shell_env() -> Vec<(OsString, OsString)> {
     Vec::new()
 }
 
+#[cfg(unix)]
 fn parse_env_output(output: &str) -> Vec<(OsString, OsString)> {
     let mut parsed = Vec::new();
     let mut current_key: Option<String> = None;
@@ -170,6 +175,7 @@ fn parse_env_output(output: &str) -> Vec<(OsString, OsString)> {
     parsed
 }
 
+#[cfg(unix)]
 fn parse_env_start(line: &str) -> Option<(&str, &str)> {
     let (key, value) = line.split_once('=')?;
     if is_valid_env_key(key) {
@@ -179,6 +185,7 @@ fn parse_env_start(line: &str) -> Option<(&str, &str)> {
     }
 }
 
+#[cfg(unix)]
 fn is_valid_env_key(key: &str) -> bool {
     let mut chars = key.chars();
     let Some(first) = chars.next() else {

--- a/crates/aionui-runtime/src/spawn.rs
+++ b/crates/aionui-runtime/src/spawn.rs
@@ -340,14 +340,11 @@ async fn kill_windows_process_tree(pid: u32) -> io::Result<()> {
         return Ok(());
     }
 
-    Err(io::Error::new(
-        io::ErrorKind::Other,
-        format!(
-            "taskkill failed for pid {pid} (exit {:?}): {}",
-            output.status.code(),
-            String::from_utf8_lossy(&output.stderr)
-        ),
-    ))
+    Err(io::Error::other(format!(
+        "taskkill failed for pid {pid} (exit {:?}): {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    )))
 }
 
 /// Resolve `program` through `resolve_command_path` so callers don't have


### PR DESCRIPTION
## Summary
- Improve Windows-aware runtime process spawning and lifecycle handling.
- Adjust parent-exit and command server process behavior for platform differences.
- Keep production runtime changes separate from test fixture portability work.

## Test Plan
- rtk just lint-fix
- rtk just fmt
- rtk cargo test -p aionui-runtime
- rtk cargo test -p aionui-app parent_exit_signal
- rtk cargo test -p aionui-ai-agent force_kill
- rtk cargo clippy -p aionui-runtime -p aionui-app -p aionui-ai-agent -p aionui-extension -- -D warnings

## Not Run
- Windows-native runtime validation locally; current environment is not Windows.