### PR TITLE
fix(cron): run jobs through conversation service

### DIFF
--- a/crates/aionui-app/assets/builtin-skills/auto-inject/cron/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/auto-inject/cron/SKILL.md
@@ -26,7 +26,7 @@ Output `[CRON_LIST]` (nothing else in this message) and wait for the system resp
 - **Task already exists and user wants to change it** → Output `[CRON_UPDATE: <job-id>]` to modify in place.
 - **Task already exists and user wants something different** → Ask the user how to proceed.
 
-## Create: [CRON_CREATE]
+## Create: [ ]
 
 Output this format DIRECTLY (not in code blocks):
 

--- a/crates/aionui-app/src/router/team_conversation_adapters.rs
+++ b/crates/aionui-app/src/router/team_conversation_adapters.rs
@@ -80,6 +80,8 @@ impl AgentTurnExecutionPort for TeamConversationAdapters {
                     content: request.content.clone(),
                     files: request.files.clone(),
                     inject_skills: Vec::new(),
+                    persist_user_message: false,
+                    user_message_hidden: false,
                     on_started: on_started.clone(),
                 })
                 .await

--- a/crates/aionui-app/tests/cron_e2e.rs
+++ b/crates/aionui-app/tests/cron_e2e.rs
@@ -157,6 +157,17 @@ async fn cj1_create_cron_job() {
     assert_eq!(data["metadata"]["created_by"], "user");
 }
 
+#[tokio::test]
+async fn cj1b_create_job_allows_missing_task_description() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let data = create_job(&mut app, &token, &csrf, create_job_body("No Description")).await;
+
+    assert!(data.get("description").is_none());
+    assert_eq!(data["schedule"]["description"], "every minute");
+}
+
 // ── CJ-2: Create three schedule types ────────────────────────────────
 
 #[tokio::test]

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -344,6 +344,8 @@ pub struct ConversationAgentTurnRequest {
     pub content: String,
     pub files: Vec<String>,
     pub inject_skills: Vec<String>,
+    pub persist_user_message: bool,
+    pub user_message_hidden: bool,
     pub on_started: Option<ConversationAgentTurnStartedCallback>,
 }
 
@@ -367,6 +369,7 @@ pub struct ConversationAgentTurnOutcome {
     pub conversation_id: String,
     pub turn_id: String,
     pub status: ConversationAgentTurnStatus,
+    pub error_message: Option<String>,
     pub runtime: ConversationRuntimeSummary,
 }
 
@@ -2605,6 +2608,36 @@ impl ConversationService {
 
         let turn_id = Self::mint_turn_id();
         let turn_claim = self.runtime_state.try_claim_turn(&request.conversation_id, &turn_id)?;
+        if request.persist_user_message {
+            let user_msg_id = Self::mint_msg_id();
+            let user_msg = aionui_db::models::MessageRow {
+                id: user_msg_id.clone(),
+                conversation_id: request.conversation_id.clone(),
+                msg_id: Some(user_msg_id),
+                r#type: "text".into(),
+                content: serde_json::json!({ "content": request.content }).to_string(),
+                position: Some("right".into()),
+                status: Some("finish".into()),
+                hidden: request.user_message_hidden,
+                created_at: now_ms(),
+            };
+            if self
+                .runtime_persistence()
+                .allows(&request.conversation_id, RuntimeWriteKind::UserMessage)
+                && let Err(e) = self.conversation_repo.insert_message(&user_msg).await
+            {
+                warn!(
+                    msg_id = %user_msg.id,
+                    error = %ErrorChain(&e),
+                    "Failed to insert agent turn user message"
+                );
+                let mut turn_claim = turn_claim;
+                let was_deleting = turn_claim.release();
+                self.complete_released_turn(&request.conversation_id, &turn_id, was_deleting)
+                    .await;
+                return Err(e.into());
+            }
+        }
         if let Some(on_started) = request.on_started.as_ref() {
             on_started(ConversationAgentTurnStarted {
                 conversation_id: request.conversation_id.clone(),
@@ -2633,6 +2666,7 @@ impl ConversationService {
                     conversation_id: request.conversation_id.clone(),
                     turn_id,
                     status: ConversationAgentTurnStatus::Failed,
+                    error_message: Some(send_error_display_message(&send_error)),
                     runtime: self.runtime_summary_for(&request.conversation_id).await,
                 });
             }
@@ -2649,7 +2683,7 @@ impl ConversationService {
                     content: request.content,
                     files: request.files,
                     inject_skills: request.inject_skills,
-                    hidden: false,
+                    hidden: request.user_message_hidden,
                 },
                 build_options: build_opts,
                 stored_workspace,
@@ -2666,7 +2700,26 @@ impl ConversationService {
                 ConversationTurnStatus::Completed => ConversationAgentTurnStatus::Completed,
                 ConversationTurnStatus::Failed => ConversationAgentTurnStatus::Failed,
             },
+            error_message: result.error_message,
         })
+    }
+
+    pub async fn latest_conversation_error_message(
+        &self,
+        conversation_id: &str,
+    ) -> Result<Option<String>, ConversationError> {
+        let page = self
+            .conversation_repo
+            .list_messages_page(
+                conversation_id,
+                &MessagePageParams {
+                    limit: 30,
+                    direction: MessagePageDirection::InitialLatest,
+                },
+            )
+            .await?;
+
+        Ok(page.items.iter().rev().find_map(error_message_from_message_row))
     }
 
     pub(crate) async fn persist_and_broadcast_send_failure_tip(
@@ -2865,6 +2918,49 @@ impl ConversationService {
         debug!("Agent warmed up");
         Ok(())
     }
+}
+
+fn send_error_display_message(error: &AgentSendError) -> String {
+    error
+        .stream_error()
+        .detail
+        .as_deref()
+        .filter(|detail| !detail.trim().is_empty())
+        .unwrap_or(error.stream_error().message.as_str())
+        .to_owned()
+}
+
+fn error_message_from_message_row(row: &MessageRow) -> Option<String> {
+    if row.r#type != "tips" && row.status.as_deref() != Some("error") {
+        return None;
+    }
+
+    let content: serde_json::Value = serde_json::from_str(&row.content).ok()?;
+    let is_error_tip = content.get("type").and_then(serde_json::Value::as_str) == Some("error")
+        || row.status.as_deref() == Some("error");
+    if !is_error_tip {
+        return None;
+    }
+
+    [
+        content.pointer("/error/detail"),
+        content.pointer("/details/detail"),
+        content.get("details"),
+        content.get("content"),
+        content.pointer("/error/message"),
+    ]
+    .into_iter()
+    .flatten()
+    .filter_map(non_empty_json_string)
+    .find(|message| message != "cron conversation turn failed")
+}
+
+fn non_empty_json_string(value: &serde_json::Value) -> Option<String> {
+    value
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
 }
 
 // ── Internal Helpers ────────────────────────────────────────────────

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -47,9 +47,9 @@ use aionui_realtime::EventBroadcaster;
 use serde_json::json;
 use tokio::sync::{Notify, broadcast};
 
-use crate::ConversationError;
 use crate::service::ConversationService;
 use crate::skill_resolver::{FixedSkillResolver, ResolvedAgentSkill, SkillResolver};
+use crate::{ConversationAgentTurnRequest, ConversationAgentTurnStatus, ConversationError};
 
 #[path = "service_test/acp_error_recovery_test.rs"]
 mod acp_error_recovery_test;
@@ -3761,6 +3761,81 @@ async fn send_message_persists_error_tip_when_agent_build_fails() {
     assert_eq!(error_tip_event.data["status"], "error");
     assert_eq!(error_tip_event.data["data"]["code"], "BAD_GATEWAY");
     assert_eq!(error_tip_event.data["turn_id"], response.turn_id);
+}
+
+#[tokio::test]
+async fn run_agent_turn_returns_error_message_when_agent_build_fails() {
+    let task_mgr: Arc<dyn IWorkerTaskManager> =
+        Arc::new(FailingBuildTaskManager::new("ACP init failed: config file is invalid"));
+    let repo = Arc::new(MockRepo::new());
+    let broadcaster = Arc::new(MockBroadcaster::new());
+    let service = ConversationService::new(
+        std::env::temp_dir(),
+        broadcaster,
+        Arc::new(FixedSkillResolver { names: vec![] }),
+        task_mgr,
+        repo,
+        Arc::new(StubAgentMetadataRepo),
+        Arc::new(StubAcpSessionRepo::default()),
+    );
+
+    let conv = service.create("user_1", make_create_req()).await.unwrap();
+    let outcome = service
+        .run_agent_turn(ConversationAgentTurnRequest {
+            user_id: "user_1".into(),
+            conversation_id: conv.id,
+            content: "run scheduled task".into(),
+            files: Vec::new(),
+            inject_skills: Vec::new(),
+            persist_user_message: true,
+            user_message_hidden: true,
+            on_started: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.status, ConversationAgentTurnStatus::Failed);
+    assert_eq!(
+        outcome.error_message.as_deref(),
+        Some("ACP init failed: config file is invalid")
+    );
+}
+
+#[tokio::test]
+async fn latest_conversation_error_message_prefers_error_detail() {
+    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+    repo.insert_message(&MessageRow {
+        id: "msg_error".into(),
+        conversation_id: conv.id.clone(),
+        msg_id: None,
+        r#type: "tips".into(),
+        content: serde_json::json!({
+            "content": "Current agent failed",
+            "type": "error",
+            "details": {
+                "detail": "Cannot resume Claude session with Codex assistant"
+            },
+            "error": {
+                "message": "Current agent failed",
+                "detail": "Codex cannot resume a conversation created by Claude"
+            }
+        })
+        .to_string(),
+        position: Some("center".into()),
+        status: Some("error".into()),
+        hidden: false,
+        created_at: 10,
+    })
+    .await
+    .unwrap();
+
+    let message = svc.latest_conversation_error_message(&conv.id).await.unwrap();
+
+    assert_eq!(
+        message.as_deref(),
+        Some("Codex cannot resume a conversation created by Claude")
+    );
 }
 
 #[tokio::test]

--- a/crates/aionui-conversation/src/turn_orchestrator.rs
+++ b/crates/aionui-conversation/src/turn_orchestrator.rs
@@ -43,6 +43,7 @@ pub(crate) enum ConversationTurnStatus {
 
 pub(crate) struct ConversationTurnResult {
     pub status: ConversationTurnStatus,
+    pub error_message: Option<String>,
 }
 
 pub(crate) struct ConversationTurnOrchestrator {
@@ -123,7 +124,7 @@ impl ConversationTurnOrchestrator {
                     error = %ErrorChain(&err),
                     "Agent task build failed"
                 );
-                let failure_message = err.to_string();
+                let failure_message = send_error_display_message(&send_error);
                 record_agent_session_failure(
                     &self.service,
                     availability_agent_id.as_deref(),
@@ -141,6 +142,7 @@ impl ConversationTurnOrchestrator {
                     .await;
                 return Err(ConversationTurnResult {
                     status: ConversationTurnStatus::Failed,
+                    error_message: Some(failure_message),
                 });
             }
         };
@@ -151,6 +153,7 @@ impl ConversationTurnOrchestrator {
             .await
         {
             let top_level_code = err.error_code();
+            let failure_message = err.to_string();
             let send_error = AgentSendError::from_agent_error(err.to_agent_error());
             error!(
                 conversation_id = %input.conv_id,
@@ -169,6 +172,7 @@ impl ConversationTurnOrchestrator {
                 .await;
             return Err(ConversationTurnResult {
                 status: ConversationTurnStatus::Failed,
+                error_message: Some(failure_message),
             });
         }
 
@@ -220,7 +224,7 @@ impl ConversationTurnOrchestrator {
 
             tokio::spawn(async move {
                 if let Err(e) = send_agent.send_message(current_send).await {
-                    let failure_message = availability_failure_message(&e);
+                    let failure_message = send_error_display_message(&e);
                     record_agent_session_failure(
                         &feedback_service,
                         feedback_agent_id.as_deref(),
@@ -317,6 +321,7 @@ impl ConversationTurnOrchestrator {
         };
         let mut replayed = false;
         let mut replay_started_at = None;
+        let mut final_error_message;
 
         info!(conversation_id = %conv_id, turn_id = %turn_id, "conversation turn orchestrator started");
 
@@ -339,12 +344,14 @@ impl ConversationTurnOrchestrator {
             {
                 Ok(result) => result,
                 Err(result) => {
+                    final_error_message = result.error_message;
                     break result.status == ConversationTurnStatus::Failed;
                 }
             };
 
             let lifecycle = runtime_state.lifecycle_for(&conv_id);
             if !attempt_result.outcome.terminal.is_error() {
+                final_error_message = None;
                 if replayed {
                     info!(
                         conversation_id = %conv_id,
@@ -358,6 +365,7 @@ impl ConversationTurnOrchestrator {
                 }
                 break false;
             }
+            final_error_message = turn_attempt_error_message(&attempt_result.summary);
             if replayed {
                 warn!(
                     conversation_id = %conv_id,
@@ -447,6 +455,7 @@ impl ConversationTurnOrchestrator {
             } else {
                 ConversationTurnStatus::Completed
             },
+            error_message: if final_failed { final_error_message } else { None },
         }
     }
 }
@@ -463,12 +472,23 @@ fn availability_agent_id(options: &BuildTaskOptions) -> Option<String> {
     }
 }
 
-fn availability_failure_message(error: &AgentSendError) -> String {
+fn send_error_display_message(error: &AgentSendError) -> String {
     error
         .stream_error()
         .detail
         .clone()
         .unwrap_or_else(|| error.stream_error().message.clone())
+}
+
+fn turn_attempt_error_message(summary: &TurnAttemptSummary) -> Option<String> {
+    summary.terminal_error.as_ref().map(|error| {
+        error
+            .detail
+            .as_deref()
+            .filter(|detail| !detail.trim().is_empty())
+            .unwrap_or(error.message.as_str())
+            .to_owned()
+    })
 }
 
 async fn record_agent_session_failure(

--- a/crates/aionui-conversation/tests/stream_relay_tool_call.rs
+++ b/crates/aionui-conversation/tests/stream_relay_tool_call.rs
@@ -324,6 +324,8 @@ async fn run_agent_turn_with_empty_call_id_tool_call_is_not_persisted() {
             content: "run glob".into(),
             files: Vec::new(),
             inject_skills: Vec::new(),
+            persist_user_message: false,
+            user_message_hidden: false,
             on_started: None,
         })
         .await

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -1,27 +1,26 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
 
+use aionui_ai_agent::AgentRegistry;
 use aionui_ai_agent::task_manager::IWorkerTaskManager;
-use aionui_ai_agent::types::SendMessageData;
-use aionui_ai_agent::{AgentRegistry, AgentStreamEvent};
-use aionui_api_types::{AssistantConversationRequest, CreateConversationRequest, SendMessageRequest};
+use aionui_api_types::{AssistantConversationRequest, CreateConversationRequest};
 use aionui_common::{
     AgentType, ProviderWithModel, WorkspacePathValidationError, now_ms, validate_workspace_path_availability,
 };
-use aionui_conversation::{ConversationError, ConversationService};
+use aionui_conversation::{
+    ConversationAgentTurnOutcome, ConversationAgentTurnRequest, ConversationAgentTurnStarted,
+    ConversationAgentTurnStartedCallback, ConversationAgentTurnStatus, ConversationError, ConversationService,
+};
 use aionui_db::models::MessageRow;
 use aionui_db::{ConversationRowUpdate, IConversationRepository};
 use aionui_realtime::EventBroadcaster;
-use tokio::sync::broadcast;
-use tokio::time::timeout;
 use tracing::{error, info, warn};
 
 use crate::artifacts::{broadcast_artifact, build_cron_trigger_artifact};
 use crate::error::CronError;
 use crate::prompt::{
     build_existing_conversation_prompt, build_new_conversation_prompt_with_skill_suggest,
-    build_new_conversation_with_skill_prompt, build_skill_suggest_prompt,
+    build_new_conversation_with_skill_prompt,
 };
 use crate::skill_file::{cron_skill_name, read_skill_content, write_raw_skill_file, write_skill_file};
 use crate::skill_suggest::SkillSuggestDetector;
@@ -31,8 +30,6 @@ pub const RETRY_INTERVAL_MS: u64 = 30_000;
 pub const MAX_RETRIES_DEFAULT: i64 = 3;
 const SYSTEM_DEFAULT_USER_ID: &str = "system_default_user";
 const DEPRECATED_AGENT_TYPE_MESSAGE: &str = "This agent type is no longer supported for new conversations.";
-const SKILL_SUGGEST_TERMINAL_TIMEOUT: Duration = Duration::from_secs(120);
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExecutionResult {
     Success { conversation_id: String },
@@ -47,22 +44,13 @@ pub(crate) struct PreparedExecution {
     saved_skill: Option<SavedSkillContext>,
 }
 
-/// Inputs captured for the post-turn skill-suggest detection pipeline.
-/// Grouped into a struct so the spawning function stays under the
-/// clippy `too_many_arguments` threshold and so the agent/receiver
-/// (which the spawner clones) remain distinct from these metadata
-/// fields.
 struct SkillSuggestContext {
     conversation_id: String,
     job_id: String,
-    job_name: String,
     workspace: String,
-    needs_follow_up: bool,
-    skill_names: Vec<String>,
 }
 
 pub struct JobExecutor {
-    task_manager: Arc<dyn IWorkerTaskManager>,
     conversation_repo: Arc<dyn IConversationRepository>,
     conversation_service: Arc<ConversationService>,
     work_dir: PathBuf,
@@ -75,7 +63,7 @@ pub struct JobExecutor {
 impl JobExecutor {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        task_manager: Arc<dyn IWorkerTaskManager>,
+        _task_manager: Arc<dyn IWorkerTaskManager>,
         conversation_repo: Arc<dyn IConversationRepository>,
         conversation_service: Arc<ConversationService>,
         work_dir: PathBuf,
@@ -86,7 +74,6 @@ impl JobExecutor {
         let skill_suggest_detector =
             SkillSuggestDetector::new(Arc::clone(&broadcaster), conversation_repo.clone(), data_dir.clone());
         Self {
-            task_manager,
             conversation_repo,
             conversation_service,
             work_dir,
@@ -514,8 +501,8 @@ impl JobExecutor {
         saved_skill: Option<&SavedSkillContext>,
         retry_on_busy: bool,
     ) -> ExecutionResult {
-        let conversation_row = match self.get_conversation_row(conversation_id).await {
-            Ok(Some(row)) => row,
+        match self.get_conversation_row(conversation_id).await {
+            Ok(Some(_)) => {}
             Ok(None) => {
                 return ExecutionResult::Error {
                     message: format!("conversation {conversation_id} not found"),
@@ -530,19 +517,7 @@ impl JobExecutor {
                 );
                 return ExecutionResult::Error { message: e.to_string() };
             }
-        };
-        let workspace = match self.resolve_execution_workspace(job, conversation_id).await {
-            Ok(workspace) => workspace,
-            Err(e) => {
-                error!(
-                    job_id = %job.id,
-                    conversation_id,
-                    error = %e,
-                    "Failed to resolve cron execution workspace"
-                );
-                return ExecutionResult::Error { message: e.to_string() };
-            }
-        };
+        }
 
         let skill_names = match self.resolve_task_skill_names(job, conversation_id, saved_skill).await {
             Ok(names) => names,
@@ -551,69 +526,8 @@ impl JobExecutor {
                 return ExecutionResult::Error { message: e.to_string() };
             }
         };
-        let requested_workspace_missing = workspace.trim().is_empty();
-        let workspace_override = job
-            .agent_config
-            .as_ref()
-            .and_then(|config| config.workspace.as_deref())
-            .map(str::trim)
-            .filter(|value| !value.is_empty());
-
-        let options = match self
-            .conversation_service
-            .build_task_options_for_runtime(&conversation_row, workspace_override)
-            .await
-        {
-            Ok(options) => options,
-            Err(e) => {
-                error!(
-                    job_id = %job.id,
-                    conversation_id,
-                    error = %e,
-                    "Failed to build cron agent session context"
-                );
-                return ExecutionResult::Error { message: e.to_string() };
-            }
-        };
-
-        let agent = match self.task_manager.get_or_build_task(conversation_id, options).await {
-            Ok(handle) => handle,
-            Err(e) => {
-                error!(
-                    job_id = %job.id,
-                    error = %e,
-                    "Failed to get or build agent task"
-                );
-                return ExecutionResult::Error { message: e.to_string() };
-            }
-        };
-
-        if requested_workspace_missing
-            && let Err(e) = self
-                .persist_workspace_if_missing(conversation_id, agent.workspace())
-                .await
-        {
-            error!(
-                job_id = %job.id,
-                conversation_id,
-                error = %e,
-                "Failed to persist resolved cron workspace back to conversation"
-            );
-            return ExecutionResult::Error { message: e.to_string() };
-        }
-
-        if let Err(e) = self.ensure_agent_session_mode(job, &agent).await {
-            error!(
-                job_id = %job.id,
-                conversation_id,
-                error = %e,
-                "Failed to apply cron session mode"
-            );
-            return ExecutionResult::Error { message: e.to_string() };
-        }
 
         let prompt = build_prompt(job, saved_skill);
-        let terminal_rx = agent.subscribe();
         let user_id = match self.resolve_target_conversation_user_id(conversation_id).await {
             Ok(user_id) => user_id,
             Err(e) => {
@@ -626,42 +540,79 @@ impl JobExecutor {
                 return ExecutionResult::Error { message: e.to_string() };
             }
         };
-        // msg_id is generated by ConversationService::send_message — we
-        // intentionally do not set it here.
-        let send_req = SendMessageRequest {
+
+        let on_started = {
+            let job = job.clone();
+            let conversation_repo = Arc::clone(&self.conversation_repo);
+            let broadcaster = Arc::clone(&self.broadcaster);
+            Some(Arc::new(move |started: ConversationAgentTurnStarted| {
+                let job = job.clone();
+                let conversation_repo = Arc::clone(&conversation_repo);
+                let broadcaster = Arc::clone(&broadcaster);
+                let fut: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> = Box::pin(async move {
+                    let created_at = now_ms();
+                    let row = build_cron_trigger_artifact(&started.conversation_id, &job, created_at);
+                    match conversation_repo.upsert_artifact(&row).await {
+                        Ok(row) => {
+                            if let Err(e) = broadcast_artifact(&broadcaster, &row) {
+                                warn!(
+                                    job_id = %job.id,
+                                    conversation_id = %started.conversation_id,
+                                    error = %e,
+                                    "Failed to broadcast cron trigger artifact"
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                job_id = %job.id,
+                                conversation_id = %started.conversation_id,
+                                error = %e,
+                                "Failed to persist cron trigger artifact"
+                            );
+                        }
+                    }
+                });
+                fut
+            }) as ConversationAgentTurnStartedCallback)
+        };
+
+        let turn_req = ConversationAgentTurnRequest {
+            user_id,
+            conversation_id: conversation_id.to_owned(),
             content: prompt,
             files: vec![],
             inject_skills: skill_names.clone(),
-            hidden: true,
+            persist_user_message: true,
+            user_message_hidden: true,
+            on_started,
         };
 
-        match self
-            .conversation_service
-            .send_message(&user_id, conversation_id, send_req, &self.task_manager)
-            .await
-        {
-            Ok(_) => {
-                if let Err(e) = self.upsert_cron_trigger_artifact(conversation_id, job).await {
-                    warn!(
-                        job_id = %job.id,
-                        conversation_id,
-                        error = %e,
-                        "Failed to persist/broadcast cron trigger artifact"
-                    );
+        match self.conversation_service.run_agent_turn(turn_req).await {
+            Ok(outcome) => {
+                if outcome.status == ConversationAgentTurnStatus::Failed {
+                    return ExecutionResult::Error {
+                        message: self.conversation_turn_failed_message(conversation_id, outcome).await,
+                    };
                 }
                 if saved_skill.is_none() && matches!(job.execution_mode, ExecutionMode::NewConversation) {
-                    self.spawn_skill_suggest_flow(
-                        agent.clone(),
-                        terminal_rx,
-                        SkillSuggestContext {
-                            conversation_id: conversation_id.to_owned(),
-                            job_id: job.id.clone(),
-                            job_name: job.name.clone(),
-                            workspace: agent.workspace().to_owned(),
-                            needs_follow_up: false,
-                            skill_names: skill_names.clone(),
-                        },
-                    );
+                    let workspace = self
+                        .resolve_execution_workspace(job, conversation_id)
+                        .await
+                        .unwrap_or_else(|err| {
+                            warn!(
+                                job_id = %job.id,
+                                conversation_id,
+                                error = %err,
+                                "Failed to resolve cron workspace for skill suggestion check"
+                            );
+                            String::new()
+                        });
+                    self.schedule_skill_suggest_check(SkillSuggestContext {
+                        conversation_id: conversation_id.to_owned(),
+                        job_id: job.id.clone(),
+                        workspace,
+                    });
                 }
                 info!(
                     job_id = %job.id,
@@ -693,6 +644,45 @@ impl JobExecutor {
         }
     }
 
+    async fn conversation_turn_failed_message(
+        &self,
+        conversation_id: &str,
+        outcome: ConversationAgentTurnOutcome,
+    ) -> String {
+        if let Some(message) = outcome
+            .error_message
+            .as_deref()
+            .map(str::trim)
+            .filter(|message| !message.is_empty())
+        {
+            return message.to_owned();
+        }
+
+        match self
+            .conversation_service
+            .latest_conversation_error_message(conversation_id)
+            .await
+        {
+            Ok(Some(message)) => message,
+            Ok(None) => format!(
+                "Conversation turn {} failed without agent error details",
+                outcome.turn_id
+            ),
+            Err(err) => {
+                warn!(
+                    conversation_id,
+                    turn_id = %outcome.turn_id,
+                    error = %err,
+                    "Failed to load latest conversation error message"
+                );
+                format!(
+                    "Conversation turn {} failed without agent error details",
+                    outcome.turn_id
+                )
+            }
+        }
+    }
+
     async fn resolve_target_conversation_user_id(&self, conversation_id: &str) -> Result<String, CronError> {
         let Some(row) = self.get_conversation_row(conversation_id).await? else {
             return Err(CronError::Scheduler(format!(
@@ -705,19 +695,6 @@ impl JobExecutor {
         }
 
         Ok(row.user_id)
-    }
-
-    async fn upsert_cron_trigger_artifact(&self, conversation_id: &str, job: &CronJob) -> Result<(), CronError> {
-        let created_at = now_ms();
-        let row = build_cron_trigger_artifact(conversation_id, job, created_at);
-        let row = self
-            .conversation_repo
-            .upsert_artifact(&row)
-            .await
-            .map_err(CronError::Database)?;
-        broadcast_artifact(&self.broadcaster, &row)?;
-
-        Ok(())
     }
 
     pub async fn mark_skill_suggest_artifacts_saved(&self, job_id: &str) -> Result<(), CronError> {
@@ -759,64 +736,9 @@ impl JobExecutor {
             .to_owned())
     }
 
-    fn spawn_skill_suggest_flow(
-        &self,
-        agent: aionui_ai_agent::AgentInstance,
-        main_rx: broadcast::Receiver<AgentStreamEvent>,
-        ctx: SkillSuggestContext,
-    ) {
-        let detector = self.skill_suggest_detector.clone();
-        let SkillSuggestContext {
-            conversation_id,
-            job_id,
-            job_name,
-            workspace,
-            needs_follow_up,
-            skill_names,
-        } = ctx;
-
-        tokio::spawn(async move {
-            if !wait_for_terminal_event(main_rx).await {
-                warn!(
-                    conversation_id,
-                    job_id, "Timed out waiting for cron turn completion before skill suggestion check"
-                );
-                return;
-            }
-
-            if needs_follow_up {
-                let follow_up_rx = agent.subscribe();
-                // msg_id flows through the conversation service so every
-                // id in the system shares one minting path.
-                let follow_up = SendMessageData {
-                    content: build_skill_suggest_prompt(&job_name),
-                    msg_id: ConversationService::mint_msg_id(),
-                    turn_id: None,
-                    files: vec![],
-                    inject_skills: skill_names,
-                };
-
-                if let Err(err) = agent.send_message(follow_up).await {
-                    warn!(
-                        conversation_id,
-                        job_id,
-                        error = %err,
-                        "Failed to send cron skill suggestion follow-up prompt"
-                    );
-                    return;
-                }
-
-                if !wait_for_terminal_event(follow_up_rx).await {
-                    warn!(
-                        conversation_id,
-                        job_id, "Timed out waiting for cron skill suggestion follow-up completion"
-                    );
-                    return;
-                }
-            }
-
-            detector.schedule_check(conversation_id, job_id, workspace);
-        });
+    fn schedule_skill_suggest_check(&self, ctx: SkillSuggestContext) {
+        self.skill_suggest_detector
+            .schedule_check(ctx.conversation_id, ctx.job_id, ctx.workspace);
     }
 
     async fn prepare_saved_skill(&self, job: &CronJob) -> Result<Option<SavedSkillContext>, CronError> {
@@ -871,46 +793,6 @@ impl JobExecutor {
         Ok(skills)
     }
 
-    async fn ensure_agent_session_mode(
-        &self,
-        job: &CronJob,
-        agent: &aionui_ai_agent::AgentInstance,
-    ) -> Result<(), CronError> {
-        let Some(desired_mode) = job
-            .agent_config
-            .as_ref()
-            .and_then(|config| config.mode.as_deref())
-            .map(str::trim)
-            .filter(|mode| !mode.is_empty())
-        else {
-            return Ok(());
-        };
-
-        let current_mode = agent
-            .get_mode()
-            .await
-            .map_err(|e| CronError::Scheduler(format!("get session mode: {e}")))?;
-
-        if current_mode.mode == desired_mode {
-            return Ok(());
-        }
-
-        agent
-            .set_config_option("mode", desired_mode)
-            .await
-            .map_err(|e| CronError::Scheduler(format!("set session mode to {desired_mode}: {e}")))?;
-
-        info!(
-            conversation_id = %agent.conversation_id(),
-            from_mode = %current_mode.mode,
-            to_mode = desired_mode,
-            initialized = current_mode.initialized,
-            "Applied cron session mode before execution"
-        );
-
-        Ok(())
-    }
-
     async fn load_conversation_skill_names(&self, conversation_id: &str) -> Result<Vec<String>, CronError> {
         let Some(row) = self
             .conversation_repo
@@ -936,21 +818,6 @@ impl JobExecutor {
             })
             .unwrap_or_default())
     }
-}
-
-async fn wait_for_terminal_event(mut rx: broadcast::Receiver<AgentStreamEvent>) -> bool {
-    let fut = async move {
-        loop {
-            match rx.recv().await {
-                Ok(AgentStreamEvent::Finish(_)) | Ok(AgentStreamEvent::Error(_)) => return true,
-                Ok(_) => continue,
-                Err(broadcast::error::RecvError::Closed) => return true,
-                Err(broadcast::error::RecvError::Lagged(_)) => continue,
-            }
-        }
-    };
-
-    timeout(SKILL_SUGGEST_TERMINAL_TIMEOUT, fut).await.unwrap_or(false)
 }
 
 /// Resolve a cron job's stored `agent_type` string into an [`AgentType`].
@@ -1221,9 +1088,10 @@ async fn persist_legacy_skill_file(data_dir: &Path, job: &CronJob, raw_content: 
 mod tests {
     use super::*;
     use crate::types::{CreatedBy, CronAgentConfig, CronSchedule};
+    use aionui_ai_agent::AgentStreamEvent;
     use aionui_ai_agent::agent_task::{AgentInstance, IAgentTask, IMockAgent};
-    use aionui_ai_agent::protocol::events::FinishEventData;
-    use aionui_ai_agent::types::BuildTaskOptions;
+    use aionui_ai_agent::protocol::events::{FinishEventData, TextEventData};
+    use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
     use aionui_api_types::{AgentModeResponse, ConfigOptionConfirmation, SetConfigOptionResponse, WebSocketMessage};
     use aionui_common::{AgentKillReason, ConversationStatus, PaginatedResult, TimestampMs};
     use aionui_db::{
@@ -1233,6 +1101,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use tokio::sync::{RwLock, broadcast};
+    use tokio::time::timeout;
 
     fn ensure_named_workspace_path(name: &str) -> String {
         let workspace = std::env::temp_dir().join(name);
@@ -1806,7 +1675,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_inner_applies_desired_session_mode_before_sending() {
+    async fn execute_inner_leaves_session_mode_to_conversation_runtime() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
         let executor = make_executor_with_agent(AgentInstance::Mock(agent.clone()));
         let mut job = sample_job();
@@ -1821,13 +1690,13 @@ mod tests {
             }
         );
         wait_for_agent_send(&agent, 1).await;
-        assert_eq!(agent.mode().await, "yolo");
-        assert_eq!(agent.set_mode_calls(), 1);
+        assert_eq!(agent.mode().await, "default");
+        assert_eq!(agent.set_mode_calls(), 0);
         assert_eq!(agent.send_calls(), 1);
     }
 
     #[tokio::test]
-    async fn execute_inner_applies_mode_even_for_uninitialized_agent() {
+    async fn execute_inner_does_not_directly_set_mode_for_uninitialized_agent() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", false));
         let executor = make_executor_with_agent(AgentInstance::Mock(agent.clone()));
         let mut job = sample_job();
@@ -1842,8 +1711,8 @@ mod tests {
             }
         );
         wait_for_agent_send(&agent, 1).await;
-        assert_eq!(agent.mode().await, "yolo");
-        assert_eq!(agent.set_mode_calls(), 1);
+        assert_eq!(agent.mode().await, "default");
+        assert_eq!(agent.set_mode_calls(), 0);
         assert_eq!(agent.send_calls(), 1);
     }
 
@@ -1900,6 +1769,52 @@ mod tests {
             .last_options()
             .expect("task manager should capture build options");
         assert!(options.context.skills.is_empty());
+    }
+
+    #[tokio::test]
+    async fn execute_inner_builds_agent_task_once_through_conversation_service() {
+        let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
+        let task_manager = Arc::new(RecordingTaskManager::new(AgentInstance::Mock(agent.clone())));
+        let executor = make_executor_with_task_manager(task_manager.clone());
+        let job = CronJob {
+            execution_mode: ExecutionMode::NewConversation,
+            ..sample_job()
+        };
+
+        let result = executor.execute_inner(&job, "conv_1", None).await;
+
+        assert_eq!(
+            result,
+            ExecutionResult::Success {
+                conversation_id: "conv_1".into()
+            }
+        );
+        wait_for_agent_send(&agent, 1).await;
+        assert_eq!(
+            task_manager.recorded_options().len(),
+            1,
+            "cron execution should let the conversation layer build the agent task exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_inner_returns_conversation_turn_error_message() {
+        let executor = make_executor_with_task_manager(Arc::new(FailingTaskManager::new(
+            "ACP init failed: config file is invalid",
+        )));
+        let job = CronJob {
+            execution_mode: ExecutionMode::NewConversation,
+            ..sample_job()
+        };
+
+        let result = executor.execute_inner(&job, "conv_1", None).await;
+
+        assert_eq!(
+            result,
+            ExecutionResult::Error {
+                message: "ACP init failed: config file is invalid".into()
+            }
+        );
     }
 
     #[tokio::test]
@@ -2151,6 +2066,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_inner_places_cron_trigger_artifact_before_assistant_response() {
+        let agent = Arc::new(RecordingAgent::new("conv_1", "default", true).with_text_response("assistant reply"));
+        let task_manager = Arc::new(RecordingTaskManager::new(AgentInstance::Mock(agent.clone())));
+        let repo = Arc::new(MissingWorkspaceConversationRepo::new(
+            "conv_1",
+            serde_json::json!({
+                "workspace": ensure_named_workspace_path("aionui-cron-existing-conversation-workspace")
+            }),
+        ));
+        let executor = make_executor_with_task_manager_and_repo(task_manager, repo.clone());
+        let job = CronJob {
+            execution_mode: ExecutionMode::NewConversation,
+            ..sample_job()
+        };
+
+        let result = executor.execute_inner(&job, "conv_1", None).await;
+
+        assert_eq!(
+            result,
+            ExecutionResult::Success {
+                conversation_id: "conv_1".into()
+            }
+        );
+        wait_for_agent_send(&agent, 1).await;
+
+        let operations = repo.operations();
+        let trigger_index = operations
+            .iter()
+            .position(|operation| operation == "upsert_artifact:cron_trigger")
+            .expect("cron trigger artifact should be upserted");
+        let assistant_index = operations
+            .iter()
+            .position(|operation| operation == "insert_message:left:text")
+            .expect("assistant response should be persisted");
+        assert!(
+            trigger_index < assistant_index,
+            "cron trigger card must be created before assistant responses so it renders before the AI reply"
+        );
+    }
+
+    #[tokio::test]
     async fn execute_inner_returns_retrying_when_send_message_reports_busy() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
         let executor = make_executor_with_agent(AgentInstance::Mock(agent.clone()));
@@ -2363,6 +2319,7 @@ mod tests {
         event_tx: broadcast::Sender<AgentStreamEvent>,
         mode: RwLock<String>,
         sent_messages: RwLock<Vec<SendMessageData>>,
+        response_text: Option<String>,
         initialized: bool,
         set_mode_calls: AtomicUsize,
         send_calls: AtomicUsize,
@@ -2377,10 +2334,16 @@ mod tests {
                 event_tx,
                 mode: RwLock::new(mode.to_owned()),
                 sent_messages: RwLock::new(Vec::new()),
+                response_text: None,
                 initialized,
                 set_mode_calls: AtomicUsize::new(0),
                 send_calls: AtomicUsize::new(0),
             }
+        }
+
+        fn with_text_response(mut self, content: &str) -> Self {
+            self.response_text = Some(content.to_owned());
+            self
         }
 
         async fn mode(&self) -> String {
@@ -2429,6 +2392,12 @@ mod tests {
         async fn send_message(&self, data: SendMessageData) -> Result<(), aionui_ai_agent::AgentSendError> {
             self.send_calls.fetch_add(1, Ordering::Relaxed);
             self.sent_messages.write().await.push(data);
+            if let Some(content) = self.response_text.as_ref() {
+                let _ = self.event_tx.send(AgentStreamEvent::Text(TextEventData {
+                    content: content.clone(),
+                }));
+            }
+            let _ = self.event_tx.send(AgentStreamEvent::Finish(FinishEventData::default()));
             Ok(())
         }
 
@@ -2472,6 +2441,59 @@ mod tests {
 
     struct FixedTaskManager {
         agent: AgentInstance,
+    }
+
+    struct FailingTaskManager {
+        message: String,
+    }
+
+    impl FailingTaskManager {
+        fn new(message: impl Into<String>) -> Self {
+            Self {
+                message: message.into(),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl IWorkerTaskManager for FailingTaskManager {
+        fn get_task(&self, _conversation_id: &str) -> Option<AgentInstance> {
+            None
+        }
+
+        async fn get_or_build_task(
+            &self,
+            _conversation_id: &str,
+            _options: BuildTaskOptions,
+        ) -> Result<AgentInstance, aionui_ai_agent::AgentError> {
+            Err(aionui_ai_agent::AgentError::bad_gateway(self.message.clone()))
+        }
+
+        fn kill(
+            &self,
+            _conversation_id: &str,
+            _reason: Option<AgentKillReason>,
+        ) -> Result<(), aionui_ai_agent::AgentError> {
+            Ok(())
+        }
+
+        fn kill_and_wait(
+            &self,
+            _: &str,
+            _: Option<AgentKillReason>,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+            Box::pin(std::future::ready(()))
+        }
+
+        async fn clear(&self) {}
+
+        fn active_count(&self) -> usize {
+            0
+        }
+
+        fn collect_idle(&self, _idle_threshold_ms: TimestampMs) -> Vec<String> {
+            Vec::new()
+        }
     }
 
     #[async_trait::async_trait]
@@ -2707,6 +2729,7 @@ mod tests {
         updates: Mutex<Vec<ConversationRowUpdate>>,
         inserted_messages: Mutex<Vec<aionui_db::models::MessageRow>>,
         artifacts: Mutex<Vec<ConversationArtifactRow>>,
+        operations: Mutex<Vec<String>>,
     }
 
     impl MissingWorkspaceConversationRepo {
@@ -2730,6 +2753,7 @@ mod tests {
                 updates: Mutex::new(Vec::new()),
                 inserted_messages: Mutex::new(Vec::new()),
                 artifacts: Mutex::new(Vec::new()),
+                operations: Mutex::new(Vec::new()),
             }
         }
 
@@ -2745,6 +2769,10 @@ mod tests {
                 .lock()
                 .map(|items| items.clone())
                 .unwrap_or_default()
+        }
+
+        fn operations(&self) -> Vec<String> {
+            self.operations.lock().map(|items| items.clone()).unwrap_or_default()
         }
     }
 
@@ -2849,6 +2877,11 @@ mod tests {
         }
 
         async fn insert_message(&self, message: &aionui_db::models::MessageRow) -> Result<(), aionui_db::DbError> {
+            self.operations.lock().unwrap().push(format!(
+                "insert_message:{}:{}",
+                message.position.as_deref().unwrap_or("none"),
+                message.r#type
+            ));
             self.inserted_messages.lock().unwrap().push(message.clone());
             Ok(())
         }
@@ -2888,6 +2921,10 @@ mod tests {
             &self,
             artifact: &ConversationArtifactRow,
         ) -> Result<ConversationArtifactRow, aionui_db::DbError> {
+            self.operations
+                .lock()
+                .unwrap()
+                .push(format!("upsert_artifact:{}", artifact.kind));
             let mut artifacts = self.artifacts.lock().unwrap();
             if let Some(existing) = artifacts.iter_mut().find(|row| row.id == artifact.id) {
                 *existing = artifact.clone();

--- a/crates/aionui-cron/src/service.rs
+++ b/crates/aionui-cron/src/service.rs
@@ -162,6 +162,7 @@ impl CronService {
             .ok_or_else(|| CronError::JobNotFound(job_id.to_owned()))?;
         let mut job = cron_job_from_row(existing_row)?;
         job.agent_type = self.resolve_job_agent_type(&job).await?;
+        let original_execution_mode = job.execution_mode;
 
         if let Some(name) = &req.name {
             job.name = name.clone();
@@ -182,6 +183,14 @@ impl CronService {
         }
         if let Some(mode_str) = &req.execution_mode {
             job.execution_mode = parse_execution_mode(Some(mode_str))?;
+        }
+        if req.agent_config.is_some()
+            && (matches!(original_execution_mode, ExecutionMode::Existing)
+                || matches!(job.execution_mode, ExecutionMode::Existing))
+        {
+            return Err(CronError::InvalidAgentConfig(
+                "ongoing conversation jobs must keep their original assistant".into(),
+            ));
         }
         if let Some(config_dto) = &req.agent_config {
             let config_dto = sanitize_agent_config_dto(config_dto.clone());
@@ -485,7 +494,7 @@ impl CronService {
         let Some(assistant_id) = job
             .agent_config
             .as_ref()
-            .and_then(|config| config.assistant_id.as_deref())
+            .and_then(|config| config.assistant_id.as_deref().or(config.custom_agent_id.as_deref()))
             .filter(|value| !value.trim().is_empty())
         else {
             return Err(CronError::InvalidAgentConfig(

--- a/crates/aionui-cron/src/skill_suggest.rs
+++ b/crates/aionui-cron/src/skill_suggest.rs
@@ -22,7 +22,7 @@ pub struct SkillSuggestDetector {
     broadcaster: Arc<dyn EventBroadcaster>,
     conversation_repo: Arc<dyn IConversationRepository>,
     data_dir: PathBuf,
-    last_hash_by_job: Arc<Mutex<HashMap<String, String>>>,
+    last_hash_by_target: Arc<Mutex<HashMap<String, String>>>,
 }
 
 impl SkillSuggestDetector {
@@ -35,7 +35,7 @@ impl SkillSuggestDetector {
             broadcaster,
             conversation_repo,
             data_dir,
-            last_hash_by_job: Arc::new(Mutex::new(HashMap::new())),
+            last_hash_by_target: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -93,11 +93,11 @@ impl SkillSuggestDetector {
         };
 
         let hash = content_hash(&content);
-        if self.last_hash(job_id).as_deref() == Some(hash.as_str()) {
+        if self.last_hash(conversation_id, job_id).as_deref() == Some(hash.as_str()) {
             return Ok(true);
         }
 
-        self.set_last_hash(job_id, hash);
+        self.set_last_hash(conversation_id, job_id, hash);
         self.emit(
             conversation_id,
             job_id,
@@ -149,24 +149,30 @@ impl SkillSuggestDetector {
         debug!(conversation_id, job_id, "Broadcasted cron skill suggestion artifact");
     }
 
-    fn last_hash(&self, job_id: &str) -> Option<String> {
-        self.last_hash_by_job
+    fn last_hash(&self, conversation_id: &str, job_id: &str) -> Option<String> {
+        let key = last_hash_key(conversation_id, job_id);
+        self.last_hash_by_target
             .lock()
             .ok()
-            .and_then(|hashes| hashes.get(job_id).cloned())
+            .and_then(|hashes| hashes.get(&key).cloned())
     }
 
-    fn set_last_hash(&self, job_id: &str, hash: String) {
-        if let Ok(mut hashes) = self.last_hash_by_job.lock() {
-            hashes.insert(job_id.to_owned(), hash);
+    fn set_last_hash(&self, conversation_id: &str, job_id: &str, hash: String) {
+        if let Ok(mut hashes) = self.last_hash_by_target.lock() {
+            hashes.insert(last_hash_key(conversation_id, job_id), hash);
         }
     }
 
     fn clear_last_hash(&self, job_id: &str) {
-        if let Ok(mut hashes) = self.last_hash_by_job.lock() {
-            hashes.remove(job_id);
+        if let Ok(mut hashes) = self.last_hash_by_target.lock() {
+            let prefix = format!("{job_id}:");
+            hashes.retain(|key, _| !key.starts_with(&prefix));
         }
     }
+}
+
+fn last_hash_key(conversation_id: &str, job_id: &str) -> String {
+    format!("{job_id}:{conversation_id}")
 }
 
 #[cfg(test)]
@@ -236,7 +242,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn suppresses_duplicate_skill_suggest_content() {
+    async fn emits_same_skill_suggest_content_for_each_conversation() {
         let temp = tempdir().unwrap();
         let workspace = temp.path().join("workspace");
         tokio::fs::create_dir_all(&workspace).await.unwrap();
@@ -267,6 +273,46 @@ mod tests {
         assert!(
             detector
                 .check_and_emit("conv-2", "cron-1", &workspace.to_string_lossy())
+                .await
+                .unwrap()
+        );
+        let msg = rx.try_recv().unwrap();
+        assert_eq!(msg.name, "conversation.artifact");
+        assert_eq!(msg.data["conversation_id"], "conv-2");
+        assert_eq!(msg.data["kind"], "skill_suggest");
+    }
+
+    #[tokio::test]
+    async fn suppresses_duplicate_skill_suggest_content_for_same_conversation() {
+        let temp = tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        tokio::fs::write(
+            workspace.join(SKILL_SUGGEST_FILENAME),
+            "---\nname: daily-report\ndescription: Daily report\n---\n\nCheck sources.\n",
+        )
+        .await
+        .unwrap();
+
+        let db = init_database_memory().await.unwrap();
+        let repo: Arc<dyn IConversationRepository> = Arc::new(SqliteConversationRepository::new(db.pool().clone()));
+        repo.create(&make_conversation("conv-1")).await.unwrap();
+
+        let bus = Arc::new(BroadcastEventBus::new(16));
+        let detector = SkillSuggestDetector::new(bus.clone(), repo, temp.path().to_path_buf());
+        let mut rx = bus.subscribe();
+
+        assert!(
+            detector
+                .check_and_emit("conv-1", "cron-1", &workspace.to_string_lossy())
+                .await
+                .unwrap()
+        );
+        assert!(rx.try_recv().is_ok());
+
+        assert!(
+            detector
+                .check_and_emit("conv-1", "cron-1", &workspace.to_string_lossy())
                 .await
                 .unwrap()
         );

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -26,7 +26,7 @@ use aionui_db::{
     MessagePageParams, MessagePageResult, MessageRowUpdate, MessageSearchRow, SqliteAcpSessionRepository,
     SqliteAgentMetadataRepository, SqliteAssistantDefinitionRepository, SqliteAssistantOverlayRepository,
     SqliteCronRepository, UpsertAssistantDefinitionParams, UpsertAssistantOverlayParams, init_database_memory,
-    models::{ConversationAssistantSnapshotRow, MessageRow},
+    models::{ConversationAssistantSnapshotRow, CronJobRow, MessageRow},
 };
 use aionui_realtime::EventBroadcaster;
 
@@ -1002,6 +1002,19 @@ async fn cj1_create_cron_job() {
 }
 
 #[tokio::test]
+async fn create_job_allows_missing_task_description() {
+    let (svc, cron_repo, _) = setup().await;
+    let mut req = make_create_req("No Description", every_60s());
+    req.description = None;
+
+    let job = svc.add_job(req).await.unwrap();
+
+    assert_eq!(job.description, None);
+    let row = cron_repo.get_by_id(&job.id).await.unwrap().unwrap();
+    assert_eq!(row.description, None);
+}
+
+#[tokio::test]
 async fn create_job_strips_legacy_agent_ids_when_assistant_id_present() {
     let (svc, _, _, _, definition_repo, _) = setup_with_assistant_repos().await;
     seed_assistant_definition(&definition_repo, "asstdef_assistant_1", "assistant-1", "claude").await;
@@ -1225,6 +1238,55 @@ async fn cj6_list_all_jobs() {
     assert!(jobs.len() >= 3);
 }
 
+#[tokio::test]
+async fn list_jobs_allows_legacy_custom_agent_id_without_assistant_id() {
+    let (svc, cron_repo, _) = setup().await;
+    cron_repo
+        .insert(&CronJobRow {
+            id: "cron_legacy_custom_agent".into(),
+            name: "Legacy custom agent job".into(),
+            enabled: true,
+            schedule_kind: "every".into(),
+            schedule_value: "60000".into(),
+            schedule_tz: None,
+            schedule_description: Some("every minute".into()),
+            payload_message: "ping".into(),
+            execution_mode: "new_conversation".into(),
+            agent_config: Some(
+                serde_json::json!({
+                    "name": "Legacy assistant",
+                    "custom_agent_id": "assistant-default",
+                    "is_preset": true
+                })
+                .to_string(),
+            ),
+            conversation_id: "conv_legacy".into(),
+            conversation_title: None,
+            created_by: "user".into(),
+            skill_content: None,
+            description: None,
+            created_at: now_ms(),
+            updated_at: now_ms(),
+            next_run_at: None,
+            last_run_at: None,
+            last_status: None,
+            last_error: None,
+            run_count: 0,
+            retry_count: 0,
+            max_retries: 3,
+        })
+        .await
+        .unwrap();
+
+    let jobs = svc.list_jobs(&ListCronJobsQuery::default()).await.unwrap();
+
+    let legacy = jobs
+        .iter()
+        .find(|job| job.id == "cron_legacy_custom_agent")
+        .expect("legacy job should be listed");
+    assert_eq!(legacy.agent_type, "acp");
+}
+
 // ── CJ-7: List by conversation ────────────────────────────────────
 
 #[tokio::test]
@@ -1301,11 +1363,10 @@ async fn cj8_update_job() {
 }
 
 #[tokio::test]
-async fn update_job_strips_legacy_agent_ids_when_assistant_id_present() {
-    let (svc, _, _, _, definition_repo, _) = setup_with_assistant_repos().await;
-    seed_assistant_definition(&definition_repo, "asstdef_update_assistant_1", "assistant-1", "claude").await;
+async fn update_existing_conversation_job_rejects_agent_config_changes() {
+    let (svc, _, _) = setup().await;
     let created = svc
-        .add_job(make_create_req("Assistant Only Update", every_60s()))
+        .add_job(make_create_req("Existing Conversation Assistant Lock", every_60s()))
         .await
         .unwrap();
 
@@ -1316,6 +1377,79 @@ async fn update_job_strips_legacy_agent_ids_when_assistant_id_present() {
         schedule: None,
         message: None,
         execution_mode: None,
+        agent_config: Some(aionui_api_types::CronAgentConfigWriteDto {
+            name: "Other Assistant".into(),
+            cli_path: None,
+            assistant_id: Some("assistant-default".into()),
+            mode: Some("default".into()),
+            model_id: Some("claude-sonnet-4".into()),
+            model: None,
+            config_options: None,
+            workspace: None,
+        }),
+        conversation_title: None,
+        max_retries: None,
+    };
+
+    let err = svc.update_job(&created.id, req).await.unwrap_err();
+    assert!(
+        matches!(err, aionui_cron::error::CronError::InvalidAgentConfig(message) if message.contains("ongoing conversation"))
+    );
+}
+
+#[tokio::test]
+async fn update_existing_conversation_job_rejects_agent_config_even_when_switching_to_new_conversation() {
+    let (svc, _, _) = setup().await;
+    let created = svc
+        .add_job(make_create_req(
+            "Existing Conversation Assistant Lock Mode Switch",
+            every_60s(),
+        ))
+        .await
+        .unwrap();
+
+    let req = UpdateCronJobRequest {
+        name: None,
+        description: None,
+        enabled: None,
+        schedule: None,
+        message: None,
+        execution_mode: Some("new_conversation".into()),
+        agent_config: Some(aionui_api_types::CronAgentConfigWriteDto {
+            name: "Other Assistant".into(),
+            cli_path: None,
+            assistant_id: Some("assistant-default".into()),
+            mode: Some("default".into()),
+            model_id: Some("claude-sonnet-4".into()),
+            model: None,
+            config_options: None,
+            workspace: None,
+        }),
+        conversation_title: None,
+        max_retries: None,
+    };
+
+    let err = svc.update_job(&created.id, req).await.unwrap_err();
+    assert!(
+        matches!(err, aionui_cron::error::CronError::InvalidAgentConfig(message) if message.contains("ongoing conversation"))
+    );
+}
+
+#[tokio::test]
+async fn update_job_strips_legacy_agent_ids_when_assistant_id_present() {
+    let (svc, _, _, _, definition_repo, _) = setup_with_assistant_repos().await;
+    seed_assistant_definition(&definition_repo, "asstdef_update_assistant_1", "assistant-1", "claude").await;
+    let mut create_req = make_create_req("Assistant Only Update", every_60s());
+    create_req.execution_mode = Some("new_conversation".into());
+    let created = svc.add_job(create_req).await.unwrap();
+
+    let req = UpdateCronJobRequest {
+        name: None,
+        description: None,
+        enabled: None,
+        schedule: None,
+        message: None,
+        execution_mode: Some("new_conversation".into()),
         agent_config: Some(aionui_api_types::CronAgentConfigWriteDto {
             name: "Helper".into(),
             cli_path: None,
@@ -1341,10 +1475,9 @@ async fn update_job_strips_legacy_agent_ids_when_assistant_id_present() {
 #[tokio::test]
 async fn update_job_rejects_when_assistant_id_cannot_resolve() {
     let (svc, _, _) = setup().await;
-    let created = svc
-        .add_job(make_create_req("Assistant Missing Update", every_60s()))
-        .await
-        .unwrap();
+    let mut create_req = make_create_req("Assistant Missing Update", every_60s());
+    create_req.execution_mode = Some("new_conversation".into());
+    let created = svc.add_job(create_req).await.unwrap();
 
     let req = UpdateCronJobRequest {
         name: None,
@@ -1352,7 +1485,7 @@ async fn update_job_rejects_when_assistant_id_cannot_resolve() {
         enabled: None,
         schedule: None,
         message: None,
-        execution_mode: None,
+        execution_mode: Some("new_conversation".into()),
         agent_config: Some(aionui_api_types::CronAgentConfigWriteDto {
             name: "Helper".into(),
             cli_path: None,


### PR DESCRIPTION
## Summary
- execute cron jobs through aionui-conversation instead of bypassing the conversation turn path
- preserve assistant binding for existing-conversation cron jobs and reject assistant changes in that mode
- persist cron trigger artifacts before assistant output and emit skill suggestions per conversation

Refs iOfficeAI/AionUi#3472

## Test Plan
- cargo fmt --all -- --check
- cargo test -p aionui-cron
- cargo test -p aionui-conversation
- just push -u origin fix/cron-description-optional