### PR TITLE
fix(cron): restore create command heading

### DIFF
--- a/crates/aionui-app/assets/builtin-skills/auto-inject/cron/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/auto-inject/cron/SKILL.md
@@ -26,7 +26,7 @@ Output `[CRON_LIST]` (nothing else in this message) and wait for the system resp
 - **Task already exists and user wants to change it** → Output `[CRON_UPDATE: <job-id>]` to modify in place.
 - **Task already exists and user wants something different** → Ask the user how to proceed.
 
-## Create: [ ]
+## Create: [CRON_CREATE]
 
 Output this format DIRECTLY (not in code blocks):
 


### PR DESCRIPTION
## Summary
- restore the cron auto-inject skill create heading from `## Create: [ ]` back to `## Create: [CRON_CREATE]`
- only reverts the SKILL.md line accidentally changed in b36fb5c471b19edefd0b63dc2acf3e3d4c2c52ae

## Test Plan
- not run per request; `just push` was interrupted before test completion