### PR TITLE
fix(acp): preserve selectors for partial config snapshots

### DIFF
--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -588,7 +588,7 @@ impl AcpAgentManager {
         let (session_id, set_path, is_mode_option) = {
             let session = self.session.read().await;
             let snapshot = session.config_snapshot();
-            let mut set_path = resolve_set_path(&snapshot, option_id, value).map_err(|err| match err {
+            let set_path = resolve_set_path(&snapshot, option_id, value).map_err(|err| match err {
                 ConfigSetPathError::OptionNotFound => {
                     AgentError::bad_request(format!("Config option '{option_id}' is not available"))
                 }
@@ -596,13 +596,6 @@ impl AcpAgentManager {
                     "Value '{value}' is not selectable for config option '{option_id}'"
                 )),
             })?;
-            if session.config_options().is_none() {
-                set_path = match option_id {
-                    "mode" => ConfigSetPath::LegacyMode,
-                    "model" => ConfigSetPath::LegacyModel,
-                    _ => set_path,
-                };
-            }
             let session_id = session.session_id().map(ToOwned::to_owned).ok_or_else(|| {
                 warn!(
                     conversation_id = %self.params.conversation_id,

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -54,6 +54,7 @@ pub(super) fn user_facing_message(err: &AgentError) -> String {
 }
 
 use super::codex_sandbox;
+use super::config_option_catalog::{extract_models_from_value, extract_modes_from_value};
 use super::config_options::{ConfigSetPath, ConfigSetPathError, ConfigSnapshot, resolve_set_path};
 use super::mode_normalize::normalize_requested_mode;
 
@@ -164,6 +165,13 @@ fn seed_startup_config_preferences(
             ConfigValue::new(thought_level.to_owned()),
         );
     }
+}
+
+fn preload_metadata_catalogs(session: &mut AcpSession, handshake: &AgentHandshake) {
+    session.preload_advertised_catalogs(
+        handshake.available_modes.as_ref().and_then(extract_modes_from_value),
+        handshake.available_models.as_ref().and_then(extract_models_from_value),
+    );
 }
 
 fn confirm_option_id(data: &Value) -> Option<String> {
@@ -428,6 +436,7 @@ impl AcpAgentManager {
 
         let startup_config_seed_base = initial_config.clone();
         let mut session = AcpSession::new(initial_mode, initial_model, initial_config);
+        preload_metadata_catalogs(&mut session, &params.metadata.handshake);
         seed_startup_config_preferences(&mut session, &params, &startup_config_seed_base);
 
         let pipeline = PromptPipeline::new(vec![Arc::new(SessionNewPreludeHook)]);
@@ -1274,8 +1283,11 @@ mod tests {
     use crate::error::AgentError;
     use crate::manager::acp::{AcpAgentManager, AcpSession};
     use crate::protocol::error::{AcpError, CloseReason};
-    use crate::shared_kernel::{ConfigKey, ConfigValue, SessionId as DomainSessionId};
-    use agent_client_protocol::schema::{AvailableCommand, SessionConfigOptionCategory};
+    use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, SessionId as DomainSessionId};
+    use agent_client_protocol::schema::{
+        AvailableCommand, SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption,
+    };
+    use aionui_api_types::AgentHandshake;
     use serde_json::json;
     use std::collections::HashMap;
 
@@ -1349,6 +1361,42 @@ mod tests {
     fn rate_limited_has_no_colon_returns_full_string() {
         let err = AgentError::RateLimited;
         assert_eq!(user_facing_message(&err), "Rate limited");
+    }
+
+    #[test]
+    fn preload_metadata_catalogs_seeds_mode_catalog_for_partial_session_config_options() {
+        let mut session = AcpSession::new(Some(ModeId::new("full-access")), None, HashMap::new());
+        let handshake = AgentHandshake {
+            available_modes: Some(json!({
+                "current_mode_id": "auto",
+                "available_modes": [
+                    {"id": "read-only", "name": "Read Only"},
+                    {"id": "auto", "name": "Default"},
+                    {"id": "full-access", "name": "Full Access"}
+                ]
+            })),
+            ..Default::default()
+        };
+
+        super::preload_metadata_catalogs(&mut session, &handshake);
+        session.apply_advertised_config_options(vec![
+            SessionConfigOption::select(
+                "reasoning_effort",
+                "Reasoning Effort",
+                "high",
+                vec![SessionConfigSelectOption::new("high", "High")],
+            )
+            .category(SessionConfigOptionCategory::ThoughtLevel),
+        ]);
+
+        let snapshot = session.config_snapshot();
+        let mode = snapshot
+            .options
+            .iter()
+            .find(|option| option.id == "mode")
+            .expect("metadata catalog should supplement missing mode");
+        assert_eq!(mode.current_value.as_deref(), Some("full-access"));
+        assert_eq!(mode.options.len(), 3);
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -167,11 +167,27 @@ fn seed_startup_config_preferences(
     }
 }
 
-fn preload_metadata_catalogs(session: &mut AcpSession, handshake: &AgentHandshake) {
-    session.preload_advertised_catalogs(
+fn preload_metadata_catalogs(
+    session: &mut AcpSession,
+    agent_id: &str,
+    agent_backend: Option<&str>,
+    handshake: &AgentHandshake,
+) {
+    let summary = session.preload_advertised_catalogs(
         handshake.available_modes.as_ref().and_then(extract_modes_from_value),
         handshake.available_models.as_ref().and_then(extract_models_from_value),
     );
+    if summary.any_preloaded() {
+        info!(
+            agent_metadata_id = %agent_id,
+            agent_backend,
+            mode_preloaded = summary.mode_preloaded,
+            model_preloaded = summary.model_preloaded,
+            mode_catalog_count = summary.mode_catalog_count,
+            model_catalog_count = summary.model_catalog_count,
+            "ACP session catalogs preloaded from agent metadata"
+        );
+    }
 }
 
 fn confirm_option_id(data: &Value) -> Option<String> {
@@ -436,7 +452,12 @@ impl AcpAgentManager {
 
         let startup_config_seed_base = initial_config.clone();
         let mut session = AcpSession::new(initial_mode, initial_model, initial_config);
-        preload_metadata_catalogs(&mut session, &params.metadata.handshake);
+        preload_metadata_catalogs(
+            &mut session,
+            &params.metadata.id,
+            params.metadata.backend.as_deref(),
+            &params.metadata.handshake,
+        );
         seed_startup_config_preferences(&mut session, &params, &startup_config_seed_base);
 
         let pipeline = PromptPipeline::new(vec![Arc::new(SessionNewPreludeHook)]);
@@ -1378,7 +1399,7 @@ mod tests {
             ..Default::default()
         };
 
-        super::preload_metadata_catalogs(&mut session, &handshake);
+        super::preload_metadata_catalogs(&mut session, "codex-agent", Some("codex"), &handshake);
         session.apply_advertised_config_options(vec![
             SessionConfigOption::select(
                 "reasoning_effort",

--- a/crates/aionui-ai-agent/src/manager/acp/config_option_catalog.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/config_option_catalog.rs
@@ -130,6 +130,21 @@ pub(crate) fn extract_config_options_from_value(value: &Value) -> Option<Vec<Ses
     })
 }
 
+pub(crate) fn extract_modes_from_value(value: &Value) -> Option<SessionModeState> {
+    serde_json::from_value(value.clone())
+        .ok()
+        .or_else(|| serde_json::from_value(keys_to_camel_case(value.clone())).ok())
+        .filter(|modes: &SessionModeState| !modes.available_modes.is_empty())
+}
+
+pub(crate) fn extract_models_from_value(value: &Value) -> Option<SessionModelState> {
+    serde_json::from_value(value.clone())
+        .ok()
+        .or_else(|| serde_json::from_value(keys_to_camel_case(value.clone())).ok())
+        .filter(|models: &SessionModelState| !models.available_models.is_empty())
+        .or_else(|| model_payload_to_state(value))
+}
+
 fn find_select<'a>(
     options: &'a [SessionConfigOption],
     ids: &[&str],
@@ -173,6 +188,37 @@ fn decode_config_options(value: &Value) -> Option<Vec<SessionConfigOption>> {
     serde_json::from_value(value.clone())
         .ok()
         .or_else(|| serde_json::from_value(keys_to_camel_case(value.clone())).ok())
+}
+
+fn model_payload_to_state(value: &Value) -> Option<SessionModelState> {
+    let object = value.as_object()?;
+    let models_value = object
+        .get("available_models")
+        .or_else(|| object.get("availableModels"))?;
+    let models = models_value.as_array()?;
+    let available_models: Vec<ModelInfo> = models
+        .iter()
+        .filter_map(|entry| {
+            let object = entry.as_object()?;
+            let id = object.get("id")?.as_str()?;
+            let label = object
+                .get("label")
+                .or_else(|| object.get("name"))
+                .and_then(Value::as_str)
+                .unwrap_or(id);
+            Some(ModelInfo::new(id.to_owned(), label.to_owned()))
+        })
+        .collect();
+    if available_models.is_empty() {
+        return None;
+    }
+    let current_model_id = object
+        .get("current_model_id")
+        .or_else(|| object.get("currentModelId"))
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+        .unwrap_or_else(|| available_models[0].model_id.0.as_ref());
+    Some(SessionModelState::new(current_model_id.to_owned(), available_models))
 }
 
 fn mode_state_to_snake_value(modes: &SessionModeState) -> Option<Value> {
@@ -535,6 +581,42 @@ mod tests {
                 .to_string(),
             "plan"
         );
+    }
+
+    #[test]
+    fn extracts_mode_state_from_snake_metadata_catalog() {
+        let value = json!({
+            "current_mode_id": "auto",
+            "available_modes": [
+                {"id": "read-only", "name": "Read Only"},
+                {"id": "full-access", "name": "Full Access"}
+            ]
+        });
+
+        let modes = extract_modes_from_value(&value).expect("mode state");
+
+        assert_eq!(modes.current_mode_id.to_string(), "auto");
+        assert_eq!(modes.available_modes.len(), 2);
+        assert_eq!(modes.available_modes[1].id.to_string(), "full-access");
+    }
+
+    #[test]
+    fn extracts_model_state_from_frontend_metadata_payload() {
+        let value = json!({
+            "current_model_id": "gpt-5.5",
+            "current_model_label": "GPT-5.5",
+            "available_models": [
+                {"id": "gpt-5.5", "label": "GPT-5.5"},
+                {"id": "gpt-5.4", "label": "gpt-5.4"}
+            ]
+        });
+
+        let models = extract_models_from_value(&value).expect("model state");
+
+        assert_eq!(models.current_model_id.to_string(), "gpt-5.5");
+        assert_eq!(models.available_models.len(), 2);
+        assert_eq!(models.available_models[1].model_id.to_string(), "gpt-5.4");
+        assert_eq!(models.available_models[1].name, "gpt-5.4");
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/manager/acp/config_options.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/config_options.rs
@@ -7,29 +7,111 @@ use aionui_api_types::{AcpConfigOptionDto, AcpConfigSelectOptionDto};
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct ConfigSnapshot {
     pub(crate) options: Vec<AcpConfigOptionDto>,
+    option_origins: Vec<ConfigOptionOrigin>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigOptionOrigin {
+    Real,
+    SyntheticLegacyMode,
+    SyntheticLegacyModel,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct ConfigSupplementSummary {
+    pub(crate) mode: bool,
+    pub(crate) model: bool,
+}
+
+impl ConfigSupplementSummary {
+    pub(crate) fn categories_csv(self) -> Option<&'static str> {
+        match (self.mode, self.model) {
+            (true, true) => Some("mode,model"),
+            (true, false) => Some("mode"),
+            (false, true) => Some("model"),
+            (false, false) => None,
+        }
+    }
 }
 
 impl ConfigSnapshot {
+    fn new(options: Vec<AcpConfigOptionDto>, option_origins: Vec<ConfigOptionOrigin>) -> Self {
+        debug_assert_eq!(
+            options.len(),
+            option_origins.len(),
+            "ConfigSnapshot options and origins must stay aligned"
+        );
+        Self {
+            options,
+            option_origins,
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn empty() -> Self {
-        Self { options: Vec::new() }
+        Self::new(Vec::new(), Vec::new())
     }
 
     pub(crate) fn from_real_options(options: Vec<SessionConfigOption>) -> Self {
-        Self {
-            options: options.into_iter().map(dto_from_sdk_option).collect(),
-        }
+        let options: Vec<AcpConfigOptionDto> = options.into_iter().map(dto_from_sdk_option).collect();
+        let option_origins = vec![ConfigOptionOrigin::Real; options.len()];
+        Self::new(options, option_origins)
     }
 
     pub(crate) fn from_legacy_catalogs(modes: Option<&SessionModeState>, models: Option<&SessionModelState>) -> Self {
         let mut options = Vec::new();
+        let mut option_origins = Vec::new();
         if let Some(modes) = modes {
             options.push(dto_from_modes(modes));
+            option_origins.push(ConfigOptionOrigin::SyntheticLegacyMode);
         }
         if let Some(models) = models {
             options.push(dto_from_models(models));
+            option_origins.push(ConfigOptionOrigin::SyntheticLegacyModel);
         }
-        Self { options }
+        Self::new(options, option_origins)
+    }
+
+    pub(crate) fn supplement_summary_for_real_options(
+        options: &[SessionConfigOption],
+        modes: Option<&SessionModeState>,
+        models: Option<&SessionModelState>,
+    ) -> ConfigSupplementSummary {
+        let has_real_mode = options
+            .iter()
+            .any(|option| real_option_matches_category_or_id(option, &SessionConfigOptionCategory::Mode, "mode"));
+        let has_real_model = options
+            .iter()
+            .any(|option| real_option_matches_category_or_id(option, &SessionConfigOptionCategory::Model, "model"));
+
+        ConfigSupplementSummary {
+            mode: !has_real_mode && modes.is_some_and(|modes| !modes.available_modes.is_empty()),
+            model: !has_real_model && models.is_some_and(|models| !models.available_models.is_empty()),
+        }
+    }
+
+    pub(crate) fn from_real_options_with_runtime_supplements(
+        options: Vec<SessionConfigOption>,
+        modes: Option<&SessionModeState>,
+        models: Option<&SessionModelState>,
+    ) -> Self {
+        let summary = Self::supplement_summary_for_real_options(&options, modes, models);
+        let mut snapshot = Self::from_real_options(options);
+
+        if summary.mode
+            && let Some(modes) = modes
+        {
+            snapshot.options.push(dto_from_modes(modes));
+            snapshot.option_origins.push(ConfigOptionOrigin::SyntheticLegacyMode);
+        }
+        if summary.model
+            && let Some(models) = models
+        {
+            snapshot.options.push(dto_from_models(models));
+            snapshot.option_origins.push(ConfigOptionOrigin::SyntheticLegacyModel);
+        }
+
+        snapshot
     }
 
     pub(crate) fn option_current(&self, option_id: &str) -> Option<String> {
@@ -69,15 +151,29 @@ pub(crate) fn resolve_set_path(
     option_id: &str,
     requested: &str,
 ) -> Result<ConfigSetPath, ConfigSetPathError> {
-    let Some(option) = snapshot.options.iter().find(|option| option.id == option_id) else {
+    let Some((index, option)) = snapshot
+        .options
+        .iter()
+        .enumerate()
+        .find(|(_, option)| option.id == option_id)
+    else {
         return Err(ConfigSetPathError::OptionNotFound);
     };
     if !option.options.is_empty() && !option.options.iter().any(|option| option.value == requested) {
         return Err(ConfigSetPathError::ValueNotSelectable);
     }
-    Ok(ConfigSetPath::ConfigOption {
-        option_id: option.id.clone(),
-    })
+    match snapshot
+        .option_origins
+        .get(index)
+        .copied()
+        .unwrap_or(ConfigOptionOrigin::Real)
+    {
+        ConfigOptionOrigin::Real => Ok(ConfigSetPath::ConfigOption {
+            option_id: option.id.clone(),
+        }),
+        ConfigOptionOrigin::SyntheticLegacyMode => Ok(ConfigSetPath::LegacyMode),
+        ConfigOptionOrigin::SyntheticLegacyModel => Ok(ConfigSetPath::LegacyModel),
+    }
 }
 
 fn dto_from_sdk_option(option: SessionConfigOption) -> AcpConfigOptionDto {
@@ -166,6 +262,14 @@ fn category_to_api(category: &SessionConfigOptionCategory) -> String {
     }
 }
 
+fn real_option_matches_category_or_id(
+    option: &SessionConfigOption,
+    category: &SessionConfigOptionCategory,
+    option_id: &str,
+) -> bool {
+    option.category.as_ref() == Some(category) || option.id.to_string() == option_id
+}
+
 fn flatten_select_options(options: &SessionConfigSelectOptions) -> Vec<&SessionConfigSelectOption> {
     match options {
         SessionConfigSelectOptions::Ungrouped(options) => options.iter().collect(),
@@ -223,23 +327,15 @@ mod tests {
 
     #[test]
     fn resolve_set_path_prefers_real_config_option_over_legacy_mode() {
-        let snapshot = ConfigSnapshot {
-            options: vec![AcpConfigOptionDto {
-                id: "mode".to_owned(),
-                name: Some("Mode".to_owned()),
-                label: None,
-                description: None,
-                category: Some("mode".to_owned()),
-                option_type: "select".to_owned(),
-                current_value: Some("auto".to_owned()),
-                options: vec![AcpConfigSelectOptionDto {
-                    value: "full-access".to_owned(),
-                    name: Some("Full Access".to_owned()),
-                    label: None,
-                    description: None,
-                }],
-            }],
-        };
+        let snapshot = ConfigSnapshot::from_real_options(vec![
+            SessionConfigOption::select(
+                "mode",
+                "Mode",
+                "auto",
+                vec![SessionConfigSelectOption::new("full-access", "Full Access")],
+            )
+            .category(SessionConfigOptionCategory::Mode),
+        ]);
 
         assert_eq!(
             resolve_set_path(&snapshot, "mode", "full-access"),

--- a/crates/aionui-ai-agent/src/manager/acp/session.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session.rs
@@ -43,6 +43,20 @@ struct Advertised {
     available_commands: Option<Vec<AvailableCommand>>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct CatalogPreloadSummary {
+    pub(crate) mode_preloaded: bool,
+    pub(crate) model_preloaded: bool,
+    pub(crate) mode_catalog_count: usize,
+    pub(crate) model_catalog_count: usize,
+}
+
+impl CatalogPreloadSummary {
+    pub(crate) fn any_preloaded(self) -> bool {
+        self.mode_preloaded || self.model_preloaded
+    }
+}
+
 /// Aggregate root for a single ACP session's lifecycle and state.
 ///
 /// Encapsulates the three-layer state model (desired / observed / advertised)
@@ -641,7 +655,7 @@ impl AcpSession {
                     .models
                     .as_ref()
                     .map_or(0, |models| models.available_models.len()),
-                "ACP config options supplemented from runtime catalog"
+                "ACP config options supplemented from advertised catalog"
             );
         }
 
@@ -722,7 +736,9 @@ impl AcpSession {
         &mut self,
         modes: Option<SessionModeState>,
         models: Option<SessionModelState>,
-    ) {
+    ) -> CatalogPreloadSummary {
+        let mut summary = CatalogPreloadSummary::default();
+
         if let Some(modes) = modes.filter(|modes| !modes.available_modes.is_empty())
             && self
                 .advertised
@@ -730,6 +746,8 @@ impl AcpSession {
                 .as_ref()
                 .is_none_or(|existing| existing.available_modes.is_empty())
         {
+            summary.mode_preloaded = true;
+            summary.mode_catalog_count = modes.available_modes.len();
             self.advertised.modes = Some(self.mode_catalog_with_session_current(modes));
         }
 
@@ -740,8 +758,12 @@ impl AcpSession {
                 .as_ref()
                 .is_none_or(|existing| existing.available_models.is_empty())
         {
+            summary.model_preloaded = true;
+            summary.model_catalog_count = models.available_models.len();
             self.advertised.models = Some(self.model_catalog_with_session_current(models));
         }
+
+        summary
     }
 
     fn mode_catalog_with_session_current(&self, mut modes: SessionModeState) -> SessionModeState {

--- a/crates/aionui-ai-agent/src/manager/acp/session.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session.rs
@@ -717,6 +717,68 @@ impl AcpSession {
             self.advertised.context_usage = Some(usage.clone());
         }
     }
+
+    pub(crate) fn preload_advertised_catalogs(
+        &mut self,
+        modes: Option<SessionModeState>,
+        models: Option<SessionModelState>,
+    ) {
+        if let Some(modes) = modes.filter(|modes| !modes.available_modes.is_empty())
+            && self
+                .advertised
+                .modes
+                .as_ref()
+                .is_none_or(|existing| existing.available_modes.is_empty())
+        {
+            self.advertised.modes = Some(self.mode_catalog_with_session_current(modes));
+        }
+
+        if let Some(models) = models.filter(|models| !models.available_models.is_empty())
+            && self
+                .advertised
+                .models
+                .as_ref()
+                .is_none_or(|existing| existing.available_models.is_empty())
+        {
+            self.advertised.models = Some(self.model_catalog_with_session_current(models));
+        }
+    }
+
+    fn mode_catalog_with_session_current(&self, mut modes: SessionModeState) -> SessionModeState {
+        let current = self
+            .observed
+            .mode_id
+            .as_ref()
+            .or(self.desired.mode_id.as_ref())
+            .filter(|mode| {
+                modes
+                    .available_modes
+                    .iter()
+                    .any(|available| available.id.0.as_ref() == mode.as_str())
+            });
+        if let Some(current) = current {
+            modes.current_mode_id = current.as_str().to_owned().into();
+        }
+        modes
+    }
+
+    fn model_catalog_with_session_current(&self, mut models: SessionModelState) -> SessionModelState {
+        let current = self
+            .observed
+            .model_id
+            .as_ref()
+            .or(self.desired.model_id.as_ref())
+            .filter(|model| {
+                models
+                    .available_models
+                    .iter()
+                    .any(|available| available.model_id.0.as_ref() == model.as_str())
+            });
+        if let Some(current) = current {
+            models.current_model_id = current.as_str().to_owned().into();
+        }
+        models
+    }
 }
 
 // ─── Reconcile ─────────────────────────────────────────────────────

--- a/crates/aionui-ai-agent/src/manager/acp/session.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session.rs
@@ -473,7 +473,11 @@ impl AcpSession {
 
     pub(crate) fn config_snapshot(&self) -> ConfigSnapshot {
         if let Some(options) = self.advertised.config_options.clone() {
-            return ConfigSnapshot::from_real_options(options);
+            return ConfigSnapshot::from_real_options_with_runtime_supplements(
+                options,
+                self.advertised.modes.as_ref(),
+                self.advertised.models.as_ref(),
+            );
         }
         ConfigSnapshot::from_legacy_catalogs(self.advertised.modes.as_ref(), self.advertised.models.as_ref())
     }
@@ -618,6 +622,28 @@ impl AcpSession {
 
     pub fn apply_advertised_config_options(&mut self, options: Vec<SessionConfigOption>) {
         let options = merge_config_options(self.advertised.config_options.as_deref(), options);
+        let supplement_summary = ConfigSnapshot::supplement_summary_for_real_options(
+            &options,
+            self.advertised.modes.as_ref(),
+            self.advertised.models.as_ref(),
+        );
+        if let Some(supplemented_categories) = supplement_summary.categories_csv() {
+            tracing::info!(
+                supplemented_categories,
+                real_option_count = options.len(),
+                mode_catalog_count = self
+                    .advertised
+                    .modes
+                    .as_ref()
+                    .map_or(0, |modes| modes.available_modes.len()),
+                model_catalog_count = self
+                    .advertised
+                    .models
+                    .as_ref()
+                    .map_or(0, |models| models.available_models.len()),
+                "ACP config options supplemented from runtime catalog"
+            );
+        }
 
         if let Some(modes) = derive_modes_from_config_options(&options) {
             self.apply_advertised_modes(modes);
@@ -811,9 +837,13 @@ fn select_option_contains_value(kind: &SessionConfigKind, value: &str) -> bool {
     }
 }
 
-// Tests live in `session_tests.rs` (linked via `#[path]`) so this file
-// stays under the 1000-line per-file budget. Inside that file `super::*`
-// resolves to this module's private items.
+// Tests live in sibling files linked via `#[path]` so this file stays under
+// the 1000-line per-file budget. Inside those files `super::*` resolves to
+// this module's private items.
 #[cfg(test)]
 #[path = "session_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "session_config_snapshot_tests.rs"]
+mod config_snapshot_tests;

--- a/crates/aionui-ai-agent/src/manager/acp/session_config_snapshot_tests.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session_config_snapshot_tests.rs
@@ -91,6 +91,35 @@ fn config_snapshot_supplements_missing_mode_from_preloaded_catalog_using_desired
 }
 
 #[test]
+fn preload_advertised_catalogs_reports_seeded_catalog_counts() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+
+    let summary = session.preload_advertised_catalogs(
+        Some(SessionModeState::new(
+            "auto",
+            vec![
+                SessionMode::new("read-only", "Read Only"),
+                SessionMode::new("auto", "Default"),
+                SessionMode::new("full-access", "Full Access"),
+            ],
+        )),
+        Some(SessionModelState::new(
+            "gpt-5.5",
+            vec![
+                ModelInfo::new("gpt-5.5", "GPT-5.5"),
+                ModelInfo::new("gpt-5.4", "GPT-5.4"),
+            ],
+        )),
+    );
+
+    assert!(summary.any_preloaded());
+    assert!(summary.mode_preloaded);
+    assert!(summary.model_preloaded);
+    assert_eq!(summary.mode_catalog_count, 3);
+    assert_eq!(summary.model_catalog_count, 2);
+}
+
+#[test]
 fn config_snapshot_supplements_missing_model_from_non_empty_runtime_catalog() {
     let mut session = AcpSession::new(None, None, HashMap::new());
     session.apply_advertised_models(SessionModelState::new(

--- a/crates/aionui-ai-agent/src/manager/acp/session_config_snapshot_tests.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session_config_snapshot_tests.rs
@@ -56,6 +56,41 @@ fn config_snapshot_supplements_missing_mode_from_non_empty_runtime_catalog() {
 }
 
 #[test]
+fn config_snapshot_supplements_missing_mode_from_preloaded_catalog_using_desired_current() {
+    let mut session = AcpSession::new(Some(ModeId::new("full-access")), None, HashMap::new());
+    session.preload_advertised_catalogs(
+        Some(SessionModeState::new(
+            "auto",
+            vec![
+                SessionMode::new("read-only", "Read Only"),
+                SessionMode::new("auto", "Default"),
+                SessionMode::new("full-access", "Full Access"),
+            ],
+        )),
+        None,
+    );
+
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "reasoning_effort",
+            "Reasoning Effort",
+            "high",
+            vec![SessionConfigSelectOption::new("high", "High")],
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel),
+    ]);
+
+    let snapshot = session.config_snapshot();
+    let mode = snapshot_option(&snapshot, "mode");
+    assert_eq!(mode.current_value.as_deref(), Some("full-access"));
+    assert_eq!(mode.options.len(), 3);
+    assert_eq!(
+        resolve_set_path(&snapshot, "mode", "read-only"),
+        Ok(ConfigSetPath::LegacyMode)
+    );
+}
+
+#[test]
 fn config_snapshot_supplements_missing_model_from_non_empty_runtime_catalog() {
     let mut session = AcpSession::new(None, None, HashMap::new());
     session.apply_advertised_models(SessionModelState::new(

--- a/crates/aionui-ai-agent/src/manager/acp/session_config_snapshot_tests.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session_config_snapshot_tests.rs
@@ -1,0 +1,311 @@
+//! Unit tests for partial real ACP config option snapshots and set-path routing.
+
+use agent_client_protocol::schema::{
+    ModelInfo, SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption, SessionMode,
+    SessionModeState, SessionModelState,
+};
+
+use super::super::config_options::{ConfigSetPath, resolve_set_path};
+use super::*;
+
+fn snapshot_option<'a>(snapshot: &'a ConfigSnapshot, option_id: &str) -> &'a aionui_api_types::AcpConfigOptionDto {
+    snapshot
+        .options
+        .iter()
+        .find(|option| option.id == option_id)
+        .unwrap_or_else(|| panic!("missing config option {option_id}"))
+}
+
+#[test]
+fn config_snapshot_supplements_missing_mode_from_non_empty_runtime_catalog() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+    session.apply_advertised_modes(SessionModeState::new(
+        "full-access",
+        vec![
+            SessionMode::new("read-only", "Read Only"),
+            SessionMode::new("full-access", "Full Access"),
+        ],
+    ));
+    session.drain_events();
+
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "reasoning_effort",
+            "Reasoning Effort",
+            "high",
+            vec![SessionConfigSelectOption::new("high", "High")],
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel),
+    ]);
+
+    let snapshot = session.config_snapshot();
+    assert_eq!(snapshot.options.len(), 2);
+    assert_eq!(
+        snapshot_option(&snapshot, "reasoning_effort").current_value.as_deref(),
+        Some("high")
+    );
+    let mode = snapshot_option(&snapshot, "mode");
+    assert_eq!(mode.category.as_deref(), Some("mode"));
+    assert_eq!(mode.current_value.as_deref(), Some("full-access"));
+    assert_eq!(mode.options.len(), 2);
+    assert_eq!(mode.options[1].value, "full-access");
+
+    let real_options = session.config_options().expect("real options remain cached");
+    assert_eq!(real_options.len(), 1);
+    assert_eq!(real_options[0].id.to_string(), "reasoning_effort");
+}
+
+#[test]
+fn config_snapshot_supplements_missing_model_from_non_empty_runtime_catalog() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+    session.apply_advertised_models(SessionModelState::new(
+        "gpt-5",
+        vec![ModelInfo::new("gpt-5", "GPT-5"), ModelInfo::new("gpt-4.1", "GPT-4.1")],
+    ));
+    session.drain_events();
+
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "reasoning_effort",
+            "Reasoning Effort",
+            "medium",
+            vec![SessionConfigSelectOption::new("medium", "Medium")],
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel),
+    ]);
+
+    let snapshot = session.config_snapshot();
+    assert_eq!(snapshot.options.len(), 2);
+    let model = snapshot_option(&snapshot, "model");
+    assert_eq!(model.category.as_deref(), Some("model"));
+    assert_eq!(model.current_value.as_deref(), Some("gpt-5"));
+    assert_eq!(model.options.len(), 2);
+    assert_eq!(model.options[0].value, "gpt-5");
+
+    let real_options = session.config_options().expect("real options remain cached");
+    assert_eq!(real_options.len(), 1);
+    assert_eq!(real_options[0].id.to_string(), "reasoning_effort");
+}
+
+#[test]
+fn config_snapshot_keeps_real_mode_option_without_runtime_merge() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+    session.apply_advertised_modes(SessionModeState::new(
+        "runtime-build",
+        vec![
+            SessionMode::new("runtime-build", "Runtime Build"),
+            SessionMode::new("runtime-plan", "Runtime Plan"),
+        ],
+    ));
+    session.drain_events();
+
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "mode",
+            "Mode",
+            "real-plan",
+            vec![SessionConfigSelectOption::new("real-plan", "Real Plan")],
+        )
+        .category(SessionConfigOptionCategory::Mode),
+    ]);
+
+    let snapshot = session.config_snapshot();
+    assert_eq!(snapshot.options.len(), 1);
+    let mode = snapshot_option(&snapshot, "mode");
+    assert_eq!(mode.current_value.as_deref(), Some("real-plan"));
+    assert_eq!(mode.options.len(), 1);
+    assert_eq!(mode.options[0].value, "real-plan");
+}
+
+#[test]
+fn config_snapshot_keeps_real_model_option_without_runtime_merge() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+    session.apply_advertised_models(SessionModelState::new(
+        "runtime-model",
+        vec![
+            ModelInfo::new("runtime-model", "Runtime Model"),
+            ModelInfo::new("runtime-extra", "Runtime Extra"),
+        ],
+    ));
+    session.drain_events();
+
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "model",
+            "Model",
+            "real-model",
+            vec![SessionConfigSelectOption::new("real-model", "Real Model")],
+        )
+        .category(SessionConfigOptionCategory::Model),
+    ]);
+
+    let snapshot = session.config_snapshot();
+    assert_eq!(snapshot.options.len(), 1);
+    let model = snapshot_option(&snapshot, "model");
+    assert_eq!(model.current_value.as_deref(), Some("real-model"));
+    assert_eq!(model.options.len(), 1);
+    assert_eq!(model.options[0].value, "real-model");
+}
+
+#[test]
+fn config_snapshot_does_not_supplement_mode_from_empty_runtime_catalog() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+    session.apply_advertised_modes(SessionModeState::new("full-access", Vec::new()));
+    session.drain_events();
+
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "reasoning_effort",
+            "Reasoning Effort",
+            "high",
+            vec![SessionConfigSelectOption::new("high", "High")],
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel),
+    ]);
+
+    let snapshot = session.config_snapshot();
+    assert!(snapshot.option_current("mode").is_none());
+    assert_eq!(snapshot.options.len(), 1);
+}
+
+#[test]
+fn config_snapshot_does_not_supplement_model_from_empty_runtime_catalog() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+    session.apply_advertised_models(SessionModelState::new("gpt-5", Vec::new()));
+    session.drain_events();
+
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "reasoning_effort",
+            "Reasoning Effort",
+            "medium",
+            vec![SessionConfigSelectOption::new("medium", "Medium")],
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel),
+    ]);
+
+    let snapshot = session.config_snapshot();
+    assert!(snapshot.option_current("model").is_none());
+    assert_eq!(snapshot.options.len(), 1);
+}
+
+#[test]
+fn config_snapshot_does_not_supplement_thought_level() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+    session.apply_advertised_modes(SessionModeState::new("build", vec![SessionMode::new("build", "Build")]));
+    session.apply_advertised_models(SessionModelState::new("gpt-5", vec![ModelInfo::new("gpt-5", "GPT-5")]));
+    session.drain_events();
+
+    session.apply_advertised_config_options(vec![SessionConfigOption::select(
+        "temperature",
+        "Temperature",
+        "low",
+        vec![SessionConfigSelectOption::new("low", "Low")],
+    )]);
+
+    let snapshot = session.config_snapshot();
+    assert!(snapshot.option_current("thought_level").is_none());
+    assert!(snapshot.option_current("reasoning_effort").is_none());
+    assert!(snapshot.option_current("mode").is_some());
+    assert!(snapshot.option_current("model").is_some());
+}
+
+#[test]
+fn config_snapshot_synthetic_mode_resolves_to_legacy_set_mode() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+    session.apply_advertised_modes(SessionModeState::new(
+        "read-only",
+        vec![
+            SessionMode::new("read-only", "Read Only"),
+            SessionMode::new("full-access", "Full Access"),
+        ],
+    ));
+    session.drain_events();
+
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "reasoning_effort",
+            "Reasoning Effort",
+            "high",
+            vec![SessionConfigSelectOption::new("high", "High")],
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel),
+    ]);
+
+    let snapshot = session.config_snapshot();
+    assert_eq!(
+        resolve_set_path(&snapshot, "mode", "full-access"),
+        Ok(ConfigSetPath::LegacyMode)
+    );
+}
+
+#[test]
+fn config_snapshot_synthetic_model_resolves_to_legacy_set_model() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+    session.apply_advertised_models(SessionModelState::new(
+        "gpt-4.1",
+        vec![ModelInfo::new("gpt-4.1", "GPT-4.1"), ModelInfo::new("gpt-5", "GPT-5")],
+    ));
+    session.drain_events();
+
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "reasoning_effort",
+            "Reasoning Effort",
+            "high",
+            vec![SessionConfigSelectOption::new("high", "High")],
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel),
+    ]);
+
+    let snapshot = session.config_snapshot();
+    assert_eq!(
+        resolve_set_path(&snapshot, "model", "gpt-5"),
+        Ok(ConfigSetPath::LegacyModel)
+    );
+}
+
+#[test]
+fn config_snapshot_real_mode_and_model_resolve_to_set_config_option() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+    session.apply_advertised_modes(SessionModeState::new(
+        "runtime-build",
+        vec![SessionMode::new("runtime-build", "Runtime Build")],
+    ));
+    session.apply_advertised_models(SessionModelState::new(
+        "runtime-model",
+        vec![ModelInfo::new("runtime-model", "Runtime Model")],
+    ));
+    session.drain_events();
+
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "mode",
+            "Mode",
+            "real-read-only",
+            vec![SessionConfigSelectOption::new("real-read-only", "Real Read Only")],
+        )
+        .category(SessionConfigOptionCategory::Mode),
+        SessionConfigOption::select(
+            "model",
+            "Model",
+            "real-model",
+            vec![SessionConfigSelectOption::new("real-model", "Real Model")],
+        )
+        .category(SessionConfigOptionCategory::Model),
+    ]);
+
+    let snapshot = session.config_snapshot();
+    assert_eq!(
+        resolve_set_path(&snapshot, "mode", "real-read-only"),
+        Ok(ConfigSetPath::ConfigOption {
+            option_id: "mode".to_owned(),
+        })
+    );
+    assert_eq!(
+        resolve_set_path(&snapshot, "model", "real-model"),
+        Ok(ConfigSetPath::ConfigOption {
+            option_id: "model".to_owned(),
+        })
+    );
+}

--- a/crates/aionui-ai-agent/src/manager/acp/session_tests.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session_tests.rs
@@ -951,6 +951,47 @@ fn pending_mode_seed_falls_back_to_legacy_set_mode_when_mode_config_option_is_ab
 }
 
 #[test]
+fn pending_mode_seed_uses_legacy_set_mode_when_preloaded_catalog_is_supplemental_only() {
+    let mut session = AcpSession::new(Some(ModeId::new("full-access")), None, HashMap::new());
+    session.preload_advertised_catalogs(
+        Some(SessionModeState::new(
+            "auto",
+            vec![
+                SessionMode::new("read-only", "Read Only"),
+                SessionMode::new("auto", "Default"),
+                SessionMode::new("full-access", "Full Access"),
+            ],
+        )),
+        None,
+    );
+    session.seed_pending_startup_config(SessionConfigOptionCategory::Mode, ConfigValue::new("full-access"));
+
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "reasoning_effort",
+            "Reasoning Effort",
+            "high",
+            vec![SessionConfigSelectOption::new("high", "High")],
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel),
+    ]);
+
+    assert_eq!(
+        session.resolve_pending_startup_config_seeds(),
+        vec![PendingStartupConfigSeedResult::OptionNotAdvertised {
+            category: SessionConfigOptionCategory::Mode,
+        }]
+    );
+
+    assert_eq!(
+        session.plan_reconcile(),
+        vec![ReconcileAction::SetMode {
+            mode: ModeId::new("full-access"),
+        }]
+    );
+}
+
+#[test]
 fn pending_model_seed_is_dropped_without_legacy_fallback_when_model_config_option_rejects_value() {
     let mut session = AcpSession::new(None, Some(ModelId::new("openai/gpt-5")), HashMap::new());
     session.seed_pending_startup_config(SessionConfigOptionCategory::Model, ConfigValue::new("openai/gpt-5"));

--- a/crates/aionui-conversation/src/session_context.rs
+++ b/crates/aionui-conversation/src/session_context.rs
@@ -208,8 +208,10 @@ impl<'a> SessionContextBuilder<'a> {
             .map_err(|e| ConversationError::internal(format!("Failed to load acp_session row: {e}")))?;
         self.resolve_acp_identity(row, &mut config, &extra, session_row.as_ref())
             .await?;
-        let session_id = session_row.and_then(|row| row.session_id);
-        let session_snapshot = self.load_acp_session_snapshot(row, &config).await?;
+        let session_id = session_row.as_ref().and_then(|row| row.session_id.clone());
+        let session_snapshot = self
+            .load_acp_session_snapshot(row, &config, session_id.as_deref())
+            .await?;
 
         Ok(AcpSessionBuildContext {
             config,
@@ -293,7 +295,16 @@ impl<'a> SessionContextBuilder<'a> {
         &self,
         row: &ConversationRow,
         config: &AcpBuildExtra,
+        session_id: Option<&str>,
     ) -> Result<Option<PersistedSessionState>, ConversationError> {
+        if session_id.is_none() {
+            debug!(
+                conversation_id = %row.id,
+                "session_context: skipping ACP runtime snapshot before session assignment"
+            );
+            return Ok(None);
+        }
+
         let db_state = self
             .acp_session_repo
             .load_runtime_state(&row.id)
@@ -647,6 +658,11 @@ mod tests {
             .unwrap();
         repos
             .acp_session_repo
+            .update_session_id("conv-1", "sess-1")
+            .await
+            .unwrap();
+        repos
+            .acp_session_repo
             .save_runtime_state(
                 "conv-1",
                 &SaveRuntimeStateParams {
@@ -675,6 +691,49 @@ mod tests {
         assert_eq!(snapshot.current_model_id.unwrap().as_str(), "persisted-model");
         assert_eq!(acp.config.session_mode.as_deref(), Some("legacy-mode"));
         assert_eq!(acp.config.current_model_id.as_deref(), Some("legacy-model"));
+    }
+
+    #[tokio::test]
+    async fn acp_unassigned_session_runtime_is_startup_seed_not_resume_snapshot() {
+        let repos = setup().await;
+        upsert_builtin(&repos, "builtin-codex-test", "codex").await;
+        repos
+            .acp_session_repo
+            .create(&CreateAcpSessionParams {
+                conversation_id: "conv-1",
+                agent_source: "builtin",
+                agent_id: "builtin-codex-test",
+            })
+            .await
+            .unwrap();
+        repos
+            .acp_session_repo
+            .save_runtime_state(
+                "conv-1",
+                &SaveRuntimeStateParams {
+                    current_mode_id: Some(Some("full-access")),
+                    current_model_id: Some(Some("gpt-5.5")),
+                    config_selections_json: None,
+                    context_usage_json: None,
+                },
+            )
+            .await
+            .unwrap();
+        let row = row(
+            "acp",
+            serde_json::json!({
+                "backend": "codex",
+                "current_mode_id": "full-access",
+                "current_model_id": "gpt-5.5"
+            }),
+            None,
+        );
+
+        let context = repos.builder().build(&row).await.unwrap();
+        let acp = acp_context(context);
+        assert_eq!(acp.config.session_mode.as_deref(), Some("full-access"));
+        assert_eq!(acp.config.current_model_id.as_deref(), Some("gpt-5.5"));
+        assert!(acp.session_snapshot.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Supplement partial ACP config snapshots with synthetic mode and model options from the active session runtime catalogs when real ACP options omit them.
- Track option origin metadata so synthetic mode/model updates route through legacy set_mode/set_model paths while real config options continue using set_config_option.
- Seed session catalogs from agent metadata and treat runtime state without an assigned ACP session ID as startup seed data instead of a resume snapshot.

## Test Plan
- [x] cargo fmt --all -- --check
- [x] cargo test -p aionui-ai-agent config_snapshot
- [x] cargo clippy -p aionui-ai-agent -- -D warnings
- [x] cargo test -p aionui-ai-agent
- [x] just push -u origin aionissue/task-20260630-001-001

## Notes
- No database migrations are included.
- AionUi manual UI verification for the sendbox selector remains recommended because this change is limited to AionCore.