### PR TITLE
fix(conversation): derive assistant runtime type from metadata

### DIFF
--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -58,25 +58,6 @@ const ACP_CANCEL_DRAIN_TIMEOUT: Duration = Duration::from_secs(15);
 const LEGACY_CONVERSATION_ARCHIVED_MESSAGE: &str =
     "This historical conversation can no longer be continued. Please start a new conversation.";
 const DEPRECATED_AGENT_TYPE_MESSAGE: &str = "This agent type is no longer supported for new conversations.";
-const ACP_VENDOR_LABELS: &[&str] = &[
-    "claude",
-    "codex",
-    "gemini",
-    "qwen",
-    "codebuddy",
-    "droid",
-    "goose",
-    "auggie",
-    "kimi",
-    "opencode",
-    "copilot",
-    "qoder",
-    "vibe",
-    "cursor",
-    "kiro",
-    "hermes",
-    "snow",
-];
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
 struct AssistantConversationOverrides {
@@ -152,6 +133,8 @@ struct AssistantSnapshot {
     agent_source: String,
     #[serde(default, alias = "agent_backend", deserialize_with = "deserialize_string_or_null")]
     runtime_backend: String,
+    #[serde(default = "default_assistant_snapshot_agent_type")]
+    agent_type: AgentType,
     rules: AssistantSnapshotRules,
     #[serde(default)]
     default_modes: AssistantSnapshotDefaultModes,
@@ -164,6 +147,10 @@ where
     D: serde::Deserializer<'de>,
 {
     Ok(<Option<String> as serde::Deserialize>::deserialize(deserializer)?.unwrap_or_default())
+}
+
+fn default_assistant_snapshot_agent_type() -> AgentType {
+    AgentType::Acp
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -196,23 +183,10 @@ fn assistant_snapshot_modes<'a>(
     }
 }
 
-fn parse_supported_agent_type_from_backend(backend: &str) -> Result<AgentType, ConversationError> {
-    if ACP_VENDOR_LABELS.contains(&backend) {
-        return Ok(AgentType::Acp);
-    }
-
-    let quoted = format!("\"{backend}\"");
-    if let Ok(agent_type) = serde_json::from_str::<AgentType>(&quoted) {
-        if agent_type.is_deprecated_runtime() {
-            return Err(ConversationError::BadRequest {
-                reason: DEPRECATED_AGENT_TYPE_MESSAGE.into(),
-            });
-        }
-        return Ok(agent_type);
-    }
-
-    Err(ConversationError::BadRequest {
-        reason: format!("unsupported assistant backend: {backend}"),
+fn parse_agent_type_from_metadata(value: &str) -> Result<AgentType, ConversationError> {
+    let quoted = format!("\"{}\"", value.trim());
+    serde_json::from_str::<AgentType>(&quoted).map_err(|_| ConversationError::BadRequest {
+        reason: format!("unsupported assistant agent type in agent_metadata: {value}"),
     })
 }
 
@@ -221,7 +195,7 @@ fn resolve_create_agent_type(
     assistant_snapshot: Option<&AssistantSnapshot>,
 ) -> Result<AgentType, ConversationError> {
     if let Some(snapshot) = assistant_snapshot {
-        let derived = parse_supported_agent_type_from_backend(snapshot.runtime_backend.trim())?;
+        let derived = snapshot.agent_type;
         if let Some(explicit) = explicit_type
             && explicit != derived
         {
@@ -1340,7 +1314,13 @@ impl ConversationService {
             .as_ref()
             .and_then(|row| row.agent_id_override.clone())
             .unwrap_or_else(|| definition.agent_id.clone());
-        let agent_binding = self.resolve_assistant_agent_binding(&effective_agent_id).await?;
+        let agent_binding = self
+            .resolve_assistant_agent_binding(&effective_agent_id)
+            .await?
+            .ok_or_else(|| ConversationError::BadRequest {
+                reason: format!("assistant agent `{effective_agent_id}` is not registered in agent_metadata"),
+            })?;
+        let agent_type = parse_agent_type_from_metadata(&agent_binding.agent_type)?;
 
         Ok(Some(AssistantSnapshot {
             assistant_definition_id: definition.id,
@@ -1349,17 +1329,10 @@ impl ConversationService {
             name: definition.name,
             avatar_type: definition.avatar_type,
             avatar: definition.avatar_value,
-            agent_id: agent_binding
-                .as_ref()
-                .map(|binding| binding.agent_id.clone())
-                .unwrap_or(effective_agent_id.clone()),
-            agent_source: agent_binding
-                .as_ref()
-                .map(|binding| binding.agent_source.clone())
-                .unwrap_or_else(|| "builtin".to_owned()),
-            runtime_backend: agent_binding
-                .map(|binding| binding.runtime_backend)
-                .unwrap_or(effective_agent_id),
+            agent_id: agent_binding.agent_id,
+            agent_source: agent_binding.agent_source,
+            runtime_backend: agent_binding.runtime_backend,
+            agent_type,
             rules: AssistantSnapshotRules {
                 content: if rules_content.is_empty() {
                     fallback_rules.to_owned()

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -660,6 +660,9 @@ fn stub_agent_metadata_rows() -> Vec<AgentMetadataRow> {
         ("8e1acf31", Some("codex"), "acp", "Codex CLI", 110),
         ("cc126dd5", Some("gemini"), "acp", "Gemini CLI", 120),
         ("632f31d2", None, "aionrs", "Aion CLI", 200),
+        ("b7e8a9c4", Some("openclaw"), "acp", "OpenClaw", 3140),
+        ("f9f61666", None, "openclaw-gateway", "OpenClaw Gateway", 3150),
+        ("custom-acp-1", None, "acp", "My Custom ACP", 1500),
     ]
     .into_iter()
     .map(|(id, backend, agent_type, name, sort_order)| AgentMetadataRow {
@@ -671,7 +674,7 @@ fn stub_agent_metadata_rows() -> Vec<AgentMetadataRow> {
         description_i18n: None,
         backend: backend.map(ToOwned::to_owned),
         agent_type: agent_type.to_owned(),
-        agent_source: "builtin".to_owned(),
+        agent_source: if id.starts_with("custom-") { "custom" } else { "builtin" }.to_owned(),
         agent_source_info: None,
         enabled: true,
         command: backend.map(ToOwned::to_owned),
@@ -1527,6 +1530,203 @@ async fn create_derives_acp_type_from_assistant_backend_when_type_is_missing() {
     let resp = svc.create("user_1", req).await.unwrap();
     assert_eq!(resp.r#type, AgentType::Acp);
     assert!(repo.get_assistant_snapshot(&resp.id).await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn create_derives_acp_type_from_openclaw_agent_metadata_when_type_is_missing() {
+    let resolver = Arc::new(FixedSkillResolver { names: vec![] });
+    let dispatcher = Arc::new(StaticAssistantDispatcher {
+        rules: std::collections::HashMap::new(),
+    });
+    let (svc, _broadcaster, repo, definition_repo, overlay_repo, _preference_repo) =
+        make_service_with_assistant_support(resolver, dispatcher).await;
+
+    upsert_test_assistant_definition(
+        &definition_repo,
+        "asstdef_openclaw_missing_type",
+        "assistant-openclaw-missing-type",
+        "b7e8a9c4",
+        "auto",
+        "auto",
+    )
+    .await;
+    overlay_repo
+        .upsert(&UpsertAssistantOverlayParams {
+            assistant_definition_id: "asstdef_openclaw_missing_type",
+            enabled: true,
+            sort_order: 0,
+            agent_id_override: None,
+            last_used_at: None,
+        })
+        .await
+        .unwrap();
+
+    let workspace = ensure_test_workspace_path();
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "assistant": {
+            "id": "assistant-openclaw-missing-type",
+            "locale": "en-US"
+        },
+        "extra": {
+            "workspace": workspace
+        }
+    }))
+    .unwrap();
+
+    let resp = svc.create("user_1", req).await.unwrap();
+    assert_eq!(resp.r#type, AgentType::Acp);
+    assert_eq!(resp.extra["agent_id"], json!("b7e8a9c4"));
+    assert_eq!(resp.extra["backend"], json!("openclaw"));
+    assert!(repo.get_assistant_snapshot(&resp.id).await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn create_derives_acp_type_from_custom_agent_metadata_when_type_is_missing() {
+    let resolver = Arc::new(FixedSkillResolver { names: vec![] });
+    let dispatcher = Arc::new(StaticAssistantDispatcher {
+        rules: std::collections::HashMap::new(),
+    });
+    let (svc, _broadcaster, repo, definition_repo, overlay_repo, _preference_repo) =
+        make_service_with_assistant_support(resolver, dispatcher).await;
+
+    upsert_test_assistant_definition(
+        &definition_repo,
+        "asstdef_custom_acp_missing_type",
+        "assistant-custom-acp-missing-type",
+        "custom-acp-1",
+        "auto",
+        "auto",
+    )
+    .await;
+    overlay_repo
+        .upsert(&UpsertAssistantOverlayParams {
+            assistant_definition_id: "asstdef_custom_acp_missing_type",
+            enabled: true,
+            sort_order: 0,
+            agent_id_override: None,
+            last_used_at: None,
+        })
+        .await
+        .unwrap();
+
+    let workspace = ensure_test_workspace_path();
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "assistant": {
+            "id": "assistant-custom-acp-missing-type",
+            "locale": "en-US"
+        },
+        "extra": {
+            "workspace": workspace
+        }
+    }))
+    .unwrap();
+
+    let resp = svc.create("user_1", req).await.unwrap();
+    assert_eq!(resp.r#type, AgentType::Acp);
+    assert_eq!(resp.extra["agent_id"], json!("custom-acp-1"));
+    assert_eq!(resp.extra["agent_source"], json!("custom"));
+    assert_eq!(resp.extra["backend"], json!("acp"));
+    assert!(repo.get_assistant_snapshot(&resp.id).await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn create_rejects_assistant_bound_to_deprecated_agent_metadata() {
+    let resolver = Arc::new(FixedSkillResolver { names: vec![] });
+    let dispatcher = Arc::new(StaticAssistantDispatcher {
+        rules: std::collections::HashMap::new(),
+    });
+    let (svc, _broadcaster, _repo, definition_repo, overlay_repo, _preference_repo) =
+        make_service_with_assistant_support(resolver, dispatcher).await;
+
+    upsert_test_assistant_definition(
+        &definition_repo,
+        "asstdef_openclaw_gateway_deprecated",
+        "assistant-openclaw-gateway-deprecated",
+        "f9f61666",
+        "auto",
+        "auto",
+    )
+    .await;
+    overlay_repo
+        .upsert(&UpsertAssistantOverlayParams {
+            assistant_definition_id: "asstdef_openclaw_gateway_deprecated",
+            enabled: true,
+            sort_order: 0,
+            agent_id_override: None,
+            last_used_at: None,
+        })
+        .await
+        .unwrap();
+
+    let workspace = ensure_test_workspace_path();
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "assistant": {
+            "id": "assistant-openclaw-gateway-deprecated",
+            "locale": "en-US"
+        },
+        "extra": {
+            "workspace": workspace
+        }
+    }))
+    .unwrap();
+
+    let err = svc.create("user_1", req).await.unwrap_err();
+    assert_eq!(err.error_code(), "BAD_REQUEST");
+    assert!(
+        err.to_string()
+            .contains("This agent type is no longer supported for new conversations."),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn create_rejects_assistant_with_unregistered_agent_metadata() {
+    let resolver = Arc::new(FixedSkillResolver { names: vec![] });
+    let dispatcher = Arc::new(StaticAssistantDispatcher {
+        rules: std::collections::HashMap::new(),
+    });
+    let (svc, _broadcaster, _repo, definition_repo, overlay_repo, _preference_repo) =
+        make_service_with_assistant_support(resolver, dispatcher).await;
+
+    upsert_test_assistant_definition(
+        &definition_repo,
+        "asstdef_missing_agent",
+        "assistant-missing-agent",
+        "missing-agent",
+        "auto",
+        "auto",
+    )
+    .await;
+    overlay_repo
+        .upsert(&UpsertAssistantOverlayParams {
+            assistant_definition_id: "asstdef_missing_agent",
+            enabled: true,
+            sort_order: 0,
+            agent_id_override: None,
+            last_used_at: None,
+        })
+        .await
+        .unwrap();
+
+    let workspace = ensure_test_workspace_path();
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "assistant": {
+            "id": "assistant-missing-agent",
+            "locale": "en-US"
+        },
+        "extra": {
+            "workspace": workspace
+        }
+    }))
+    .unwrap();
+
+    let err = svc.create("user_1", req).await.unwrap_err();
+    assert_eq!(err.error_code(), "BAD_REQUEST");
+    assert!(
+        err.to_string()
+            .contains("assistant agent `missing-agent` is not registered in agent_metadata"),
+        "unexpected error: {err}"
+    );
 }
 
 // ── Get tests ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Derive assistant-backed conversation runtime type from `agent_metadata.agent_type` instead of backend label inference.
- Resolve assistant snapshots from registered agent metadata, including OpenClaw ACP bindings, and reject deprecated or unregistered metadata.
- Add regression coverage for OpenClaw, custom ACP, deprecated metadata, and missing metadata bindings.

## Test Plan
- [x] `just push -u origin agent-metadata-runtime-type`