### PR TITLE
fix: resolve ACP backends from metadata

### DIFF
--- a/crates/aionui-team/src/provisioning.rs
+++ b/crates/aionui-team/src/provisioning.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use aionui_ai_agent::IWorkerTaskManager;
 use aionui_api_types::{AddAgentRequest, TeamAgentInput};
 use aionui_common::{AgentKillReason, AgentType, ProviderWithModel, generate_id};
-use aionui_db::models::TeamRow;
+use aionui_db::models::{AgentMetadataRow, TeamRow};
 use aionui_db::{
     IAgentMetadataRepository, IAssistantDefinitionRepository, IAssistantOverlayRepository, IProviderRepository,
     ITeamRepository, UpdateTeamParams,
@@ -14,7 +14,9 @@ use tracing::{info, warn};
 use crate::error::TeamError;
 use crate::mcp::TeamMcpStdioConfig;
 use crate::service::inherit_team_workspace;
-use crate::service::spawn_support::{parse_agent_type, resolve_full_auto_mode, resolve_runtime_backend};
+use crate::service::spawn_support::{
+    acp_backend_metadata, parse_agent_type, resolve_runtime_backend, session_mode_for_backend,
+};
 use crate::types::{Team, TeamAgent, TeammateRole};
 use crate::workspace::TeamWorkspaceResolver;
 
@@ -358,9 +360,16 @@ impl TeamAgentProvisioner {
         agent: &TeamAgent,
         mcp_stdio_cfg: TeamMcpStdioConfig,
     ) -> Result<(), TeamError> {
+        let acp_metadata = acp_backend_metadata(&self.agent_metadata_repo, &agent.backend).await?;
+        let agent_type = if acp_metadata.is_some() {
+            AgentType::Acp
+        } else {
+            parse_agent_type(&agent.backend)?
+        };
+        let session_mode = session_mode_for_backend(&agent.backend, agent_type, acp_metadata.as_ref());
         let patch = serde_json::json!({
             "team_mcp_stdio_config": mcp_stdio_cfg,
-            "session_mode": resolve_full_auto_mode(&agent.backend),
+            "session_mode": session_mode,
         });
         self.conversation_port
             .patch_runtime_config(&agent.conversation_id, patch)
@@ -430,11 +439,23 @@ impl TeamAgentProvisioner {
         assistant_id: Option<&str>,
         workspace: Option<&str>,
     ) -> Result<ProvisionedConversation, TeamError> {
-        let extra = self
-            .build_team_extra(team_id, slot_id, role, backend, model, assistant_id, workspace)
-            .await?;
-
-        let agent_type = parse_agent_type(backend)?;
+        let acp_metadata = acp_backend_metadata(&self.agent_metadata_repo, backend).await?;
+        let agent_type = if acp_metadata.is_some() {
+            AgentType::Acp
+        } else {
+            parse_agent_type(backend)?
+        };
+        let extra = self.build_team_extra(
+            team_id,
+            slot_id,
+            role,
+            backend,
+            model,
+            assistant_id,
+            workspace,
+            agent_type,
+            acp_metadata.as_ref(),
+        );
         let provider_id = if agent_type == AgentType::Aionrs {
             self.resolve_provider_for_model(model)
                 .await
@@ -524,7 +545,7 @@ impl TeamAgentProvisioner {
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn build_team_extra(
+    fn build_team_extra(
         &self,
         team_id: &str,
         slot_id: &str,
@@ -533,15 +554,18 @@ impl TeamAgentProvisioner {
         model: &str,
         assistant_id: Option<&str>,
         workspace: Option<&str>,
-    ) -> Result<serde_json::Value, TeamError> {
+        agent_type: AgentType,
+        acp_metadata: Option<&AgentMetadataRow>,
+    ) -> serde_json::Value {
+        let session_mode = session_mode_for_backend(backend, agent_type, acp_metadata);
         let mut extra = serde_json::json!({
             "teamId": team_id,
             "slot_id": slot_id,
             "role": role.to_string(),
             "backend": backend,
-            "session_mode": resolve_full_auto_mode(backend),
+            "session_mode": session_mode,
         });
-        if parse_agent_type(backend)? != AgentType::Aionrs {
+        if agent_type != AgentType::Aionrs {
             extra["current_model_id"] = serde_json::Value::String(model.to_owned());
         }
         if let Some(assistant_id) = assistant_id {
@@ -550,7 +574,7 @@ impl TeamAgentProvisioner {
         if let Some(workspace) = workspace {
             inherit_team_workspace(&mut extra, workspace);
         }
-        Ok(extra)
+        extra
     }
 
     async fn persist_agents(&self, team_id: &str, agents: &[TeamAgent]) -> Result<(), TeamError> {

--- a/crates/aionui-team/src/service/spawn_support.rs
+++ b/crates/aionui-team/src/service/spawn_support.rs
@@ -2,7 +2,7 @@ use super::*;
 use aionui_api_types::BehaviorPolicy;
 use aionui_common::AgentType;
 use aionui_common::constants::{TEAM_CAPABLE_BACKENDS, has_mcp_capability};
-use aionui_db::models::AssistantOverlayRow;
+use aionui_db::models::{AgentMetadataRow, AssistantOverlayRow};
 use aionui_db::{IAgentMetadataRepository, resolve_agent_binding_from_rows};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -11,39 +11,9 @@ use crate::prompts::AvailableAssistant;
 
 use crate::provisioning::PersistSpawnedAgentRequest;
 
-/// Known ACP vendor labels. Kept in lockstep with the `agent_metadata`
-/// seed in `005_agent_metadata.sql` — a caller hitting an unknown
-/// vendor should trigger a schema drift discussion, not silently fall
-/// through.
-const ACP_VENDOR_LABELS: &[&str] = &[
-    "claude",
-    "codex",
-    "gemini",
-    "qwen",
-    "codebuddy",
-    "droid",
-    "goose",
-    "auggie",
-    "kimi",
-    "opencode",
-    "copilot",
-    "qoder",
-    "vibe",
-    "cursor",
-    "kiro",
-    "hermes",
-    "snow",
-];
-
 const DEPRECATED_AGENT_TYPE_MESSAGE: &str = "This agent type is no longer supported for new conversations.";
 
 pub(crate) fn parse_agent_type(backend: &str) -> Result<AgentType, TeamError> {
-    // Any registered ACP vendor label collapses to `AgentType::Acp`.
-    if ACP_VENDOR_LABELS.contains(&backend) {
-        return Ok(AgentType::Acp);
-    }
-    // Otherwise interpret as a top-level `AgentType` (e.g. "acp",
-    // "nanobot", "aionrs", "remote", "openclaw-gateway").
     let quoted = format!("\"{backend}\"");
     if let Ok(agent_type) = serde_json::from_str::<AgentType>(&quoted) {
         if agent_type.is_deprecated_runtime() {
@@ -54,16 +24,31 @@ pub(crate) fn parse_agent_type(backend: &str) -> Result<AgentType, TeamError> {
     Err(TeamError::InvalidRequest(format!("unsupported backend: {backend}")))
 }
 
-/// Resolve the most permissive session mode for a given backend string.
-/// Reuses `AgentType::full_auto_mode_id` from aionui-common.
-pub(crate) fn resolve_full_auto_mode(backend: &str) -> &'static str {
-    let agent_type = if ACP_VENDOR_LABELS.contains(&backend) {
-        AgentType::Acp
-    } else {
-        let quoted = format!("\"{backend}\"");
-        serde_json::from_str::<AgentType>(&quoted).unwrap_or(AgentType::Acp)
-    };
-    agent_type.full_auto_mode_id(Some(backend))
+fn find_acp_backend_metadata(rows: &[AgentMetadataRow], backend: &str) -> Option<AgentMetadataRow> {
+    rows.iter()
+        .find(|row| row.agent_type == AgentType::Acp.serde_name() && row.backend.as_deref() == Some(backend))
+        .cloned()
+}
+
+pub(crate) async fn acp_backend_metadata(
+    agent_metadata_repo: &Arc<dyn IAgentMetadataRepository>,
+    backend: &str,
+) -> Result<Option<AgentMetadataRow>, TeamError> {
+    let rows = agent_metadata_repo.list_all().await?;
+    Ok(find_acp_backend_metadata(&rows, backend))
+}
+
+pub(crate) fn session_mode_for_backend(
+    backend: &str,
+    agent_type: AgentType,
+    acp_metadata: Option<&AgentMetadataRow>,
+) -> String {
+    if let Some(row) = acp_metadata
+        && let Some(yolo_id) = row.yolo_id.as_deref().map(str::trim).filter(|value| !value.is_empty())
+    {
+        return yolo_id.to_owned();
+    }
+    agent_type.full_auto_mode_id(Some(backend)).to_owned()
 }
 
 pub(crate) async fn resolve_runtime_backend(
@@ -486,15 +471,14 @@ mod tests {
     }
 
     #[test]
-    fn parse_agent_type_known_backends() {
+    fn parse_agent_type_accepts_top_level_supported_runtimes() {
         assert_eq!(parse_agent_type("acp").unwrap(), AgentType::Acp);
-        assert_eq!(parse_agent_type("gemini").unwrap(), AgentType::Acp);
         assert_eq!(parse_agent_type("aionrs").unwrap(), AgentType::Aionrs);
     }
 
     #[test]
     fn parse_agent_type_rejects_deprecated_runtime_types() {
-        for backend in ["nanobot", "remote", "openclaw-gateway"] {
+        for backend in ["codex", "gemini", "nanobot", "remote", "openclaw-gateway"] {
             let err = parse_agent_type(backend).unwrap_err();
             assert!(matches!(err, TeamError::InvalidRequest(_)));
             assert!(
@@ -509,11 +493,6 @@ mod tests {
     fn parse_agent_type_unknown_backend_returns_error() {
         let err = parse_agent_type("unknown").unwrap_err();
         assert!(matches!(err, TeamError::InvalidRequest(_)));
-    }
-
-    #[test]
-    fn resolve_full_auto_mode_keeps_hermes_on_default() {
-        assert_eq!(resolve_full_auto_mode("hermes"), "default");
     }
 
     #[tokio::test]

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -1659,6 +1659,20 @@ fn make_agent_metadata_row(id: &str, backend: &str, icon: &str) -> AgentMetadata
     }
 }
 
+fn acp_agent_metadata_row(id: &str, backend: &str, yolo_id: Option<&str>) -> AgentMetadataRow {
+    let mut row = make_agent_metadata_row(id, backend, "");
+    row.yolo_id = yolo_id.map(str::to_owned);
+    row
+}
+
+fn seeded_agent_metadata_repo() -> Arc<dyn IAgentMetadataRepository> {
+    Arc::new(StubAgentMetadataRepo::with_rows(vec![
+        acp_agent_metadata_row("claude-id", "claude", Some("bypassPermissions")),
+        acp_agent_metadata_row("codex-id", "codex", Some("full-access")),
+        acp_agent_metadata_row("gemini-id", "gemini", Some("yolo")),
+    ]))
+}
+
 fn word_creator_definition() -> AssistantDefinitionRow {
     AssistantDefinitionRow {
         id: "def-word-creator".into(),
@@ -1941,7 +1955,7 @@ async fn tc_create_team_prefers_assistant_avatar_over_backend_logo() {
 
 #[tokio::test]
 async fn tc_create_team_carries_assistant_identity_into_lead_conversation_extra() {
-    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = Arc::new(StubAgentMetadataRepo::empty());
+    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = seeded_agent_metadata_repo();
     let definition_repo: Arc<dyn IAssistantDefinitionRepository> = Arc::new(SingleAssistantDefinitionRepo {
         row: AssistantDefinitionRow {
             id: "def-team-lead".into(),
@@ -2017,7 +2031,7 @@ async fn tc_create_team_carries_assistant_identity_into_lead_conversation_extra(
 
 #[tokio::test]
 async fn tc_create_team_derives_backend_from_assistant_when_backend_missing() {
-    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = Arc::new(StubAgentMetadataRepo::empty());
+    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = seeded_agent_metadata_repo();
     let definition_repo: Arc<dyn IAssistantDefinitionRepository> = Arc::new(SingleAssistantDefinitionRepo {
         row: AssistantDefinitionRow {
             id: "def-team-lead".into(),
@@ -2104,7 +2118,7 @@ async fn tc_create_team_derives_backend_from_assistant_when_backend_missing() {
 
 #[tokio::test]
 async fn tc_create_team_ignores_requested_backend_when_assistant_id_present() {
-    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = Arc::new(StubAgentMetadataRepo::empty());
+    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = seeded_agent_metadata_repo();
     let definition_repo: Arc<dyn IAssistantDefinitionRepository> = Arc::new(SingleAssistantDefinitionRepo {
         row: AssistantDefinitionRow {
             id: "def-team-lead".into(),
@@ -2208,7 +2222,7 @@ async fn team_preset_assistant_snapshot_is_frozen() {
     });
     let (svc, _team_repo, conversation_ports, conv_repo) = setup_with_ports_metadata_assistants_and_conversation_repo(
         success_factory(),
-        Arc::new(StubAgentMetadataRepo::empty()),
+        seeded_agent_metadata_repo(),
         definition_repo,
         Arc::new(EmptyAssistantOverlayRepo),
     );
@@ -2255,7 +2269,7 @@ async fn spawned_preset_assistant_snapshot_is_frozen() {
     });
     let (svc, _team_repo, conversation_ports, conv_repo) = setup_with_ports_metadata_assistants_and_conversation_repo(
         success_factory(),
-        Arc::new(StubAgentMetadataRepo::empty()),
+        seeded_agent_metadata_repo(),
         definition_repo,
         Arc::new(EmptyAssistantOverlayRepo),
     );
@@ -2400,7 +2414,7 @@ async fn ta_add_agent_derives_backend_from_assistant_when_backend_missing() {
             updated_at: 0,
         },
     });
-    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = Arc::new(StubAgentMetadataRepo::empty());
+    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = seeded_agent_metadata_repo();
     let (svc, _team_repo, _task_manager, _conv_repo) = setup_with_factory_metadata_assistants_and_conversation_repo(
         success_factory(),
         agent_metadata_repo,
@@ -2495,7 +2509,7 @@ async fn ta_add_agent_ignores_requested_backend_when_assistant_id_present() {
             updated_at: 0,
         },
     });
-    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = Arc::new(StubAgentMetadataRepo::empty());
+    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = seeded_agent_metadata_repo();
     let (svc, _team_repo, _task_manager, _conv_repo) = setup_with_factory_metadata_assistants_and_conversation_repo(
         success_factory(),
         agent_metadata_repo,
@@ -3268,6 +3282,59 @@ async fn provisioning_writes_typed_team_binding_for_create_and_add_agent() {
 }
 
 #[tokio::test]
+async fn provisioning_resolves_acp_backend_from_agent_metadata() {
+    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> =
+        Arc::new(StubAgentMetadataRepo::with_rows(vec![acp_agent_metadata_row(
+            "future-acp-id",
+            "future-acp",
+            Some("turbo"),
+        )]));
+    let (svc, _, conv_repo) =
+        setup_with_factory_and_metadata_and_conversation_repo(success_factory(), agent_metadata_repo);
+
+    let created = svc
+        .create_team(
+            "user1",
+            CreateTeamRequest {
+                name: "Metadata ACP".into(),
+                agents: vec![TeamAgentInput {
+                    name: "Lead".into(),
+                    role: "lead".into(),
+                    backend: Some("future-acp".into()),
+                    model: "model-x".into(),
+                    assistant_id: None,
+                    conversation_id: None,
+                }],
+                workspace: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let row = conv_repo
+        .get(&created.assistants[0].conversation_id)
+        .await
+        .unwrap()
+        .expect("conversation row");
+    assert_eq!(row.r#type, "acp");
+    let extra = conv_repo
+        .get_extra(&created.assistants[0].conversation_id)
+        .expect("conversation extra");
+    assert_eq!(
+        extra.get("backend").and_then(serde_json::Value::as_str),
+        Some("future-acp")
+    );
+    assert_eq!(
+        extra.get("session_mode").and_then(serde_json::Value::as_str),
+        Some("turbo")
+    );
+    assert_eq!(
+        extra.get("provider_id").and_then(serde_json::Value::as_str),
+        Some("future-acp")
+    );
+}
+
+#[tokio::test]
 async fn aa4_add_agent_to_nonexistent_team() {
     let svc = setup();
     let result = svc
@@ -3443,7 +3510,7 @@ async fn spawn_agent_in_session_succeeds_without_active_team_run() {
             updated_at: 0,
         },
     });
-    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = Arc::new(StubAgentMetadataRepo::empty());
+    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = seeded_agent_metadata_repo();
     let (svc, _team_repo, _task_manager, _conv_repo) = setup_with_factory_metadata_assistants_and_conversation_repo(
         success_factory(),
         agent_metadata_repo,
@@ -3539,7 +3606,7 @@ async fn lead_send_agent_message_in_session_requires_active_team_run() {
 async fn spawn_agent_in_session_aborts_lease_when_persistence_fails() {
     let (svc, team_repo, _, _) = setup_with_factory_metadata_assistants_and_conversation_repo(
         success_factory(),
-        Arc::new(StubAgentMetadataRepo::empty()),
+        seeded_agent_metadata_repo(),
         Arc::new(SingleAssistantDefinitionRepo {
             row: word_creator_definition(),
         }),
@@ -3586,7 +3653,7 @@ async fn spawn_agent_in_session_aborts_lease_when_persistence_fails() {
 async fn spawn_agent_in_session_compensates_when_welcome_mailbox_write_fails() {
     let (svc, team_repo, _, _) = setup_with_factory_metadata_assistants_and_conversation_repo(
         success_factory(),
-        Arc::new(StubAgentMetadataRepo::empty()),
+        seeded_agent_metadata_repo(),
         Arc::new(SingleAssistantDefinitionRepo {
             row: word_creator_definition(),
         }),


### PR DESCRIPTION
## Summary
- Remove the hardcoded ACP vendor label list and resolve ACP backends from agent_metadata rows instead.
- Use metadata yolo_id for ACP session mode when creating or rebuilding team agent runtime config.
- Add a regression test for a metadata-defined ACP backend.

## Test Plan
- cargo fmt --all -- --check
- cargo clippy -p aionui-team -- -D warnings
- cargo test -p aionui-team --quiet
- cargo test -p aionui-team --test e2e_smoke --quiet
- cargo test -p aionui-team --test e2e_team_flow --quiet
- cargo test -p aionui-team --test session_service_integration provisioning_resolves_acp_backend_from_agent_metadata --quiet