### PR TITLE
fix(cron): lock team cron execution mode

### DIFF
--- a/crates/aionui-cron/src/service.rs
+++ b/crates/aionui-cron/src/service.rs
@@ -324,7 +324,13 @@ impl CronService {
             job.message = message.clone();
         }
         if let Some(mode_str) = &req.execution_mode {
-            job.execution_mode = parse_execution_mode(Some(mode_str))?;
+            let requested_mode = parse_execution_mode(Some(mode_str))?;
+            if requested_mode != original_execution_mode && self.is_team_conversation_job(&job).await? {
+                return Err(CronError::InvalidExecutionMode(
+                    "Team cron jobs must keep running in their owning Team conversation".into(),
+                ));
+            }
+            job.execution_mode = requested_mode;
         }
         if req.agent_config.is_some()
             && (matches!(original_execution_mode, ExecutionMode::Existing)
@@ -645,6 +651,23 @@ impl CronService {
         };
 
         self.resolve_agent_type_for_assistant_id(assistant_id).await
+    }
+
+    async fn is_team_conversation_job(&self, job: &CronJob) -> Result<bool, CronError> {
+        let conversation_id = job.conversation_id.trim();
+        if conversation_id.is_empty() {
+            return Ok(false);
+        }
+
+        let Some(row) = self.executor.get_conversation_row(conversation_id).await? else {
+            return Ok(false);
+        };
+        let extra = serde_json::from_str::<serde_json::Value>(&row.extra)?;
+        Ok(extra
+            .get("team_id")
+            .or_else(|| extra.get("teamId"))
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty()))
     }
 
     async fn resolve_agent_type_for_assistant_id(&self, assistant_id: &str) -> Result<String, CronError> {

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -144,6 +144,28 @@ impl StubConvRepo {
     fn fail_updates_for(&self, conversation_id: &str) {
         self.update_failures.lock().unwrap().push(conversation_id.to_owned());
     }
+
+    fn set_conversation_extra(&self, conversation_id: &str, extra: serde_json::Value) {
+        let mut rows = self.rows.lock().unwrap();
+        let row = rows
+            .entry(conversation_id.to_owned())
+            .or_insert_with(|| aionui_db::models::ConversationRow {
+                id: conversation_id.to_owned(),
+                user_id: "u1".into(),
+                name: "stub".into(),
+                r#type: "default".into(),
+                model: None,
+                status: Some("active".into()),
+                source: None,
+                channel_chat_id: None,
+                extra: "{}".into(),
+                pinned: false,
+                pinned_at: None,
+                created_at: 1000,
+                updated_at: 1000,
+            });
+        row.extra = extra.to_string();
+    }
 }
 
 #[async_trait::async_trait]
@@ -1451,6 +1473,36 @@ async fn update_existing_conversation_job_rejects_agent_config_even_when_switchi
     assert!(
         matches!(err, aionui_cron::error::CronError::InvalidAgentConfig(message) if message.contains("ongoing conversation"))
     );
+}
+
+#[tokio::test]
+async fn update_team_conversation_job_rejects_execution_mode_change() {
+    let (svc, _, _, conv_repo) = setup_with_conv_repo().await;
+    let mut create_req = make_create_req("Team Cron Mode Lock", every_60s());
+    create_req.conversation_id = "conv_team_cron".into();
+    conv_repo.set_conversation_extra(
+        "conv_team_cron",
+        serde_json::json!({
+            "team_id": "team-1",
+            "workspace": ensure_named_workspace_path("aionui-cron-service-team-workspace")
+        }),
+    );
+    let created = svc.add_job(create_req).await.unwrap();
+
+    let req = UpdateCronJobRequest {
+        name: None,
+        description: None,
+        enabled: None,
+        schedule: None,
+        message: None,
+        execution_mode: Some("new_conversation".into()),
+        agent_config: None,
+        conversation_title: None,
+        max_retries: None,
+    };
+
+    let err = svc.update_job(&created.id, req).await.unwrap_err();
+    assert!(matches!(err, aionui_cron::error::CronError::InvalidExecutionMode(message) if message.contains("Team")));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Reject `execution_mode` changes for cron jobs bound to Team conversations in `CronService::update_job`.
- Detect Team-owned cron jobs through the associated conversation `extra.team_id` / `extra.teamId` marker.
- Add an integration regression test proving a Team cron job cannot be switched from its owning conversation mode to `new_conversation` through the backend API.

## Why
Frontend PR iOfficeAI/AionUi#3496 locks the execution mode and assistant controls for Team cron jobs in the edit UI, but UI-only locking is not enough. The cron update API can still be called directly, so a Team-created scheduled task could otherwise be moved out of the owning Team conversation from the backend side.

Team cron jobs must keep running in their Team conversation because the task is tied to Team context, Team member/leader ownership, and the conversation association used by cron history/navigation. Changing the mode would silently break that model even if the frontend prevents it in normal editing flows.

## Behavior
- Team-bound cron job + changed `execution_mode`: returns `InvalidExecutionMode`.
- Team-bound cron job + omitted or unchanged `execution_mode`: still allowed.
- Non-Team cron jobs: unchanged behavior.
- Existing ongoing-conversation assistant locking remains in place.

## Related PRs
- Companion frontend/UI lock and Team cleanup: iOfficeAI/AionUi#3496

## Test Plan
- `cargo fmt --all -- --check`
- `cargo clippy -p aionui-cron -- -D warnings`
- `cargo test -p aionui-cron`
- `just push -u origin fix/team-cron-edit-lock` (migration check, workspace clippy/fmt, nextest: 6607 passed, 18 skipped, then push)
