### PR TITLE
fix(skill): raise import size limits

### DIFF
--- a/crates/aionui-app/tests/extension_e2e.rs
+++ b/crates/aionui-app/tests/extension_e2e.rs
@@ -1221,7 +1221,9 @@ async fn skill_import_returns_specific_code_for_oversized_file() {
         "---\nname: huge-skill\ndescription: Huge skill\n---\nBody",
     )
     .unwrap();
-    std::fs::write(skill_dir.join("movie.bin"), vec![0u8; 10 * 1024 * 1024 + 1]).unwrap();
+    let oversized_file_bytes = 50 * 1024 * 1024 + 1;
+    let oversized_file = std::fs::File::create(skill_dir.join("movie.bin")).unwrap();
+    oversized_file.set_len(oversized_file_bytes).unwrap();
 
     let resp = app
         .oneshot(json_with_token(
@@ -1244,8 +1246,8 @@ async fn skill_import_returns_specific_code_for_oversized_file() {
             "source_name": "huge-skill",
             "code": "SKILL_IMPORT_FILE_TOO_LARGE",
             "error_path": "movie.bin",
-            "actual_bytes": 10 * 1024 * 1024 + 1,
-            "limit_bytes": 10 * 1024 * 1024
+            "actual_bytes": oversized_file_bytes,
+            "limit_bytes": 50 * 1024 * 1024
         }])
     );
 }
@@ -1271,7 +1273,9 @@ async fn skill_batch_import_reports_partial_failures_without_rolling_back_succes
         "---\nname: sample-beta\ndescription: Beta skill\n---\nBody",
     )
     .unwrap();
-    std::fs::write(beta_dir.join("movie.bin"), vec![0u8; 10 * 1024 * 1024 + 1]).unwrap();
+    let oversized_file_bytes = 50 * 1024 * 1024 + 1;
+    let oversized_file = std::fs::File::create(beta_dir.join("movie.bin")).unwrap();
+    oversized_file.set_len(oversized_file_bytes).unwrap();
 
     let resp = app
         .clone()
@@ -1295,8 +1299,8 @@ async fn skill_batch_import_reports_partial_failures_without_rolling_back_succes
             "source_name": "beta-skill",
             "code": "SKILL_IMPORT_FILE_TOO_LARGE",
             "error_path": "movie.bin",
-            "actual_bytes": 10 * 1024 * 1024 + 1,
-            "limit_bytes": 10 * 1024 * 1024
+            "actual_bytes": oversized_file_bytes,
+            "limit_bytes": 50 * 1024 * 1024
         }])
     );
     assert!(paths.user_skills_dir.join("sample-alpha").join("SKILL.md").exists());
@@ -1315,8 +1319,8 @@ async fn skill_batch_import_reports_partial_failures_without_rolling_back_succes
                 && record["status"] == "failed"
                 && record["error_code"] == "SKILL_IMPORT_FILE_TOO_LARGE"
                 && record["error_path"] == "movie.bin"
-                && record["actual_bytes"] == 10 * 1024 * 1024 + 1
-                && record["limit_bytes"] == 10 * 1024 * 1024
+                && record["actual_bytes"] == oversized_file_bytes
+                && record["limit_bytes"] == 50 * 1024 * 1024
         }),
         "history records = {records:?}"
     );

--- a/crates/aionui-extension/src/skill_service.rs
+++ b/crates/aionui-extension/src/skill_service.rs
@@ -26,8 +26,8 @@ static BUILTIN_SKILLS: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/../aionu
 /// corpus with an on-disk directory. Consumed by
 /// [`resolve_skill_paths`] when building [`SkillPaths`].
 pub const BUILTIN_SKILLS_ENV_VAR: &str = "AIONUI_BUILTIN_SKILLS_PATH";
-const MAX_SKILL_IMPORT_FILE_BYTES: u64 = 10 * 1024 * 1024;
-const MAX_SKILL_IMPORT_TOTAL_BYTES: u64 = 50 * 1024 * 1024;
+const MAX_SKILL_IMPORT_FILE_BYTES: u64 = 50 * 1024 * 1024;
+const MAX_SKILL_IMPORT_TOTAL_BYTES: u64 = 200 * 1024 * 1024;
 const IMPORT_STAGING_PREFIX: &str = ".import-staging-";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/aionui-extension/tests/assistant_dispatch_test.rs
+++ b/crates/aionui-extension/tests/assistant_dispatch_test.rs
@@ -206,8 +206,8 @@ async fn import_limits_route_returns_server_configured_limits() {
 
     let body: ApiResponse<SkillImportLimitsResponse> = body_json(resp).await;
     let limits = body.data.expect("import limits response data");
-    assert_eq!(limits.max_file_bytes, 10 * 1024 * 1024);
-    assert_eq!(limits.max_total_bytes, 50 * 1024 * 1024);
+    assert_eq!(limits.max_file_bytes, 50 * 1024 * 1024);
+    assert_eq!(limits.max_total_bytes, 200 * 1024 * 1024);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Raise skill import per-file limit from 10 MB to 50 MB.
- Raise skill import total directory limit from 50 MB to 200 MB.
- Update import limit and oversized-file regression tests to match the new budget.

## Context
`hugohe3/ppt-master` has a real skill at `skills/ppt-master` that is about 97 MB. Its largest individual file is below 2 MB, but the skill includes many SVG icons and visual reference images, so it exceeds the previous 50 MB total cap despite not being a mistaken whole-repo import.

## Test Plan
- cargo test -p aionui-extension import_limits_route_returns_server_configured_limits
- cargo test -p aionui-app skill_import_returns_specific_code_for_oversized_file
- cargo test -p aionui-app skill_batch_import_reports_partial_failures_without_rolling_back_successes
- cargo fmt --all -- --check
- cargo clippy -p aionui-extension -p aionui-app -- -D warnings