### PR TITLE
fix(runtime): harden managed Node command resolution

### DIFF
--- a/crates/aionui-runtime/src/node_runtime/managed.rs
+++ b/crates/aionui-runtime/src/node_runtime/managed.rs
@@ -53,6 +53,12 @@ struct ManagedNodeDownloadSource {
     source: &'static str,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ManagedNodeArchiveLayout {
+    Windows,
+    Unix,
+}
+
 pub fn probe_support() -> NodeRuntimeSupport {
     match platform_spec() {
         Ok(spec) => NodeRuntimeSupport {
@@ -220,6 +226,14 @@ fn platform_spec() -> Result<PlatformSpec, NodeRuntimeError> {
 }
 
 fn runtime_from_root(root: &Path, source: ResolvedNodeSource) -> Result<ResolvedNodeRuntime, NodeRuntimeError> {
+    runtime_from_root_for_layout(root, source, current_managed_node_archive_layout())
+}
+
+fn runtime_from_root_for_layout(
+    root: &Path,
+    source: ResolvedNodeSource,
+    layout: ManagedNodeArchiveLayout,
+) -> Result<ResolvedNodeRuntime, NodeRuntimeError> {
     if !root.is_dir() {
         return Err(NodeRuntimeError::managed_invalid(format!(
             "managed node runtime directory missing: {}",
@@ -229,11 +243,7 @@ fn runtime_from_root(root: &Path, source: ResolvedNodeSource) -> Result<Resolved
 
     prepare_runtime_files(root)?;
 
-    let node_path = if cfg!(windows) {
-        root.join("node.exe")
-    } else {
-        root.join("bin").join("node")
-    };
+    let node_path = managed_node_path_for_layout(root, layout);
     if !node_path.is_file() {
         return Err(NodeRuntimeError::managed_invalid(format!(
             "managed node executable missing: {}",
@@ -241,40 +251,8 @@ fn runtime_from_root(root: &Path, source: ResolvedNodeSource) -> Result<Resolved
         )));
     }
 
-    let npm_wrapper = if cfg!(windows) {
-        root.join("npm.cmd")
-    } else {
-        root.join("bin").join("npm")
-    };
-    let npx_wrapper = if cfg!(windows) {
-        root.join("npx.cmd")
-    } else {
-        root.join("bin").join("npx")
-    };
-    let npm_cli = managed_npm_cli_path(root);
-    let npx_cli = managed_npx_cli_path(root);
-
-    let (npm_path, npm_args_prefix) = if npm_wrapper.is_file() {
-        (npm_wrapper, vec![])
-    } else if npm_cli.is_file() {
-        (node_path.clone(), vec![npm_cli.into_os_string()])
-    } else {
-        return Err(NodeRuntimeError::managed_invalid(format!(
-            "managed npm entrypoint missing under {}",
-            root.display()
-        )));
-    };
-
-    let (npx_path, npx_args_prefix) = if npx_wrapper.is_file() {
-        (npx_wrapper, vec![])
-    } else if npx_cli.is_file() {
-        (node_path.clone(), vec![npx_cli.into_os_string()])
-    } else {
-        return Err(NodeRuntimeError::managed_invalid(format!(
-            "managed npx entrypoint missing under {}",
-            root.display()
-        )));
-    };
+    let (npm_path, npm_args_prefix) = resolve_managed_entrypoint(root, &node_path, layout, "npm")?;
+    let (npx_path, npx_args_prefix) = resolve_managed_entrypoint(root, &node_path, layout, "npx")?;
 
     Ok(ResolvedNodeRuntime {
         source,
@@ -289,6 +267,44 @@ fn runtime_from_root(root: &Path, source: ResolvedNodeSource) -> Result<Resolved
     })
 }
 
+fn resolve_managed_entrypoint(
+    root: &Path,
+    node_path: &Path,
+    layout: ManagedNodeArchiveLayout,
+    tool: &str,
+) -> Result<(PathBuf, Vec<OsString>), NodeRuntimeError> {
+    let cli = match tool {
+        "npm" => managed_npm_cli_path_for_layout(root, layout),
+        "npx" => managed_npx_cli_path_for_layout(root, layout),
+        _ => unreachable!("managed Node only resolves npm and npx entrypoints"),
+    };
+    let wrapper = managed_wrapper_path_for_layout(root, layout, tool);
+
+    match layout {
+        ManagedNodeArchiveLayout::Windows => {
+            if cli.is_file() {
+                return Ok((node_path.to_path_buf(), vec![cli.into_os_string()]));
+            }
+            if wrapper.is_file() {
+                return Ok((wrapper, vec![]));
+            }
+        }
+        ManagedNodeArchiveLayout::Unix => {
+            if wrapper.is_file() {
+                return Ok((wrapper, vec![]));
+            }
+            if cli.is_file() {
+                return Ok((node_path.to_path_buf(), vec![cli.into_os_string()]));
+            }
+        }
+    }
+
+    Err(NodeRuntimeError::managed_invalid(format!(
+        "managed {tool} entrypoint missing under {}",
+        root.display()
+    )))
+}
+
 fn probe_runtime_root(root: &Path, source: ResolvedNodeSource) -> Result<ResolvedNodeRuntime, NodeRuntimeError> {
     if !root.is_dir() {
         return Err(NodeRuntimeError::managed_invalid(format!(
@@ -297,28 +313,17 @@ fn probe_runtime_root(root: &Path, source: ResolvedNodeSource) -> Result<Resolve
         )));
     }
 
-    let node_path = if cfg!(windows) {
-        root.join("node.exe")
-    } else {
-        root.join("bin").join("node")
-    };
-    let npm_path = if cfg!(windows) {
-        root.join("npm.cmd")
-    } else {
-        root.join("bin").join("npm")
-    };
-    let npx_path = if cfg!(windows) {
-        root.join("npx.cmd")
-    } else {
-        root.join("bin").join("npx")
-    };
-
-    if !node_path.is_file() || !npm_path.exists() || !npx_path.exists() {
+    let layout = current_managed_node_archive_layout();
+    let node_path = managed_node_path_for_layout(root, layout);
+    if !node_path.is_file() {
         return Err(NodeRuntimeError::managed_invalid(format!(
             "managed node runtime is incomplete under {}",
             root.display()
         )));
     }
+
+    let (npm_path, npm_args_prefix) = resolve_managed_entrypoint(root, &node_path, layout, "npm")?;
+    let (npx_path, npx_args_prefix) = resolve_managed_entrypoint(root, &node_path, layout, "npx")?;
 
     Ok(ResolvedNodeRuntime {
         source,
@@ -326,9 +331,9 @@ fn probe_runtime_root(root: &Path, source: ResolvedNodeSource) -> Result<Resolve
         version: semver::Version::new(0, 0, 0),
         node_path,
         npm_path,
-        npm_args_prefix: vec![],
+        npm_args_prefix,
         npx_path,
-        npx_args_prefix: vec![],
+        npx_args_prefix,
         env: vec![],
     })
 }
@@ -709,27 +714,51 @@ fn managed_env(root: &Path) -> Result<Vec<(OsString, OsString)>, NodeRuntimeErro
 }
 
 fn managed_bin_dir(root: &Path) -> PathBuf {
+    managed_bin_dir_for_layout(root, current_managed_node_archive_layout())
+}
+
+fn current_managed_node_archive_layout() -> ManagedNodeArchiveLayout {
     if cfg!(windows) {
-        root.to_path_buf()
+        ManagedNodeArchiveLayout::Windows
     } else {
-        root.join("bin")
+        ManagedNodeArchiveLayout::Unix
     }
 }
 
-fn managed_npm_cli_path(root: &Path) -> PathBuf {
-    root.join("lib")
-        .join("node_modules")
-        .join("npm")
-        .join("bin")
-        .join("npm-cli.js")
+fn managed_bin_dir_for_layout(root: &Path, layout: ManagedNodeArchiveLayout) -> PathBuf {
+    match layout {
+        ManagedNodeArchiveLayout::Windows => root.to_path_buf(),
+        ManagedNodeArchiveLayout::Unix => root.join("bin"),
+    }
 }
 
-fn managed_npx_cli_path(root: &Path) -> PathBuf {
-    root.join("lib")
-        .join("node_modules")
-        .join("npm")
-        .join("bin")
-        .join("npx-cli.js")
+fn managed_node_path_for_layout(root: &Path, layout: ManagedNodeArchiveLayout) -> PathBuf {
+    match layout {
+        ManagedNodeArchiveLayout::Windows => root.join("node.exe"),
+        ManagedNodeArchiveLayout::Unix => root.join("bin").join("node"),
+    }
+}
+
+fn managed_wrapper_path_for_layout(root: &Path, layout: ManagedNodeArchiveLayout, tool: &str) -> PathBuf {
+    match layout {
+        ManagedNodeArchiveLayout::Windows => root.join(format!("{tool}.cmd")),
+        ManagedNodeArchiveLayout::Unix => root.join("bin").join(tool),
+    }
+}
+
+fn managed_npm_package_bin_dir_for_layout(root: &Path, layout: ManagedNodeArchiveLayout) -> PathBuf {
+    match layout {
+        ManagedNodeArchiveLayout::Windows => root.join("node_modules").join("npm").join("bin"),
+        ManagedNodeArchiveLayout::Unix => root.join("lib").join("node_modules").join("npm").join("bin"),
+    }
+}
+
+fn managed_npm_cli_path_for_layout(root: &Path, layout: ManagedNodeArchiveLayout) -> PathBuf {
+    managed_npm_package_bin_dir_for_layout(root, layout).join("npm-cli.js")
+}
+
+fn managed_npx_cli_path_for_layout(root: &Path, layout: ManagedNodeArchiveLayout) -> PathBuf {
+    managed_npm_package_bin_dir_for_layout(root, layout).join("npx-cli.js")
 }
 
 fn default_npm_prefix(root: &Path) -> PathBuf {
@@ -864,222 +893,4 @@ fn combined_retry_error(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn managed_runtime_validation_uses_real_commands() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join("node-v24.11.0-test");
-        let bin = root.join("bin");
-        std::fs::create_dir_all(&bin).unwrap();
-
-        let node = bin.join("node");
-        std::fs::write(&node, "#!/bin/sh\necho v24.11.0\n").unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = std::fs::metadata(&node).unwrap().permissions();
-            perms.set_mode(0o755);
-            std::fs::set_permissions(&node, perms).unwrap();
-        }
-
-        let err = validate_managed_runtime(&root, None).await.unwrap_err();
-        assert!(err.to_string().to_ascii_lowercase().contains("npm"));
-    }
-
-    #[test]
-    fn managed_runtime_support_reports_current_platform() {
-        let support = probe_support();
-        let expected = cfg!(target_os = "macos") || cfg!(target_os = "linux") || cfg!(windows);
-        assert_eq!(support.supported, expected);
-    }
-
-    #[test]
-    fn classify_error_detects_bundled_node_runtime_missing() {
-        let err = NodeRuntimeError::managed_invalid(
-            "bundled Node runtime missing under C:\\Program Files\\AionUi\\resources\\bundled-aioncore\\win32-x64\\managed-resources\\node\\node-v24.11.0-win-x64",
-        );
-        let (kind, status) = classify_error(&err);
-
-        assert_eq!(kind, NodeRuntimeFailureKind::BundledResourceMissing);
-        assert_eq!(status, None);
-    }
-
-    #[tokio::test]
-    async fn bundled_runtime_missing_reports_bundled_resource_missing() {
-        let tmp = tempfile::tempdir().unwrap();
-        let bundled_root = tmp.path().join("bundled");
-        if !crate::test_support::run_in_env_child(
-            "node_runtime::managed::tests::bundled_runtime_missing_reports_bundled_resource_missing",
-            |command| {
-                command.env("AIONUI_BUNDLED_MANAGED_RESOURCES", &bundled_root);
-            },
-        ) {
-            return;
-        }
-
-        crate::cache::init(tmp.path().join("data"));
-        managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Bundled);
-
-        let updates = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-        let reporter_updates = updates.clone();
-        let reporter = move |update: NodeRuntimeProgress| {
-            reporter_updates.lock().unwrap().push(update);
-        };
-
-        let result = install_and_validate_with_reporter(Some(&reporter)).await;
-        managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Download);
-
-        let error = result.expect_err("missing bundled runtime should fail");
-        assert!(error.to_string().contains("bundled Node runtime missing"));
-        let updates = updates.lock().unwrap();
-        assert!(updates.iter().any(|update| {
-            update.phase == crate::NodeRuntimeProgressPhase::Failed
-                && update.failure_kind == Some(NodeRuntimeFailureKind::BundledResourceMissing)
-        }));
-    }
-
-    #[test]
-    fn managed_runtime_install_lock_path_uses_runtime_root() {
-        let root = PathBuf::from("/tmp/aionui/runtime/node");
-        assert_eq!(install_lock_path(&root), root.join("node-runtime-install.lock"));
-    }
-
-    #[test]
-    fn managed_runtime_timeout_error_is_explicit() {
-        let error = timeout_error(
-            "download archive",
-            "https://example.com/node.tar.gz",
-            MANAGED_NODE_DOWNLOAD_TIMEOUT,
-        );
-        let message = error.to_string();
-        assert!(message.contains("download archive timed out"));
-        assert!(message.contains("600s"));
-    }
-
-    #[test]
-    fn managed_runtime_http_status_error_is_explicit() {
-        let error = http_status_error(
-            "download archive",
-            "https://example.com/node.tar.gz",
-            reqwest::StatusCode::BAD_GATEWAY,
-        );
-        let message = error.to_string();
-        assert!(message.contains("HTTP 502"));
-        assert!(message.contains("download archive"));
-    }
-
-    #[test]
-    fn managed_runtime_official_source_uses_nodejs_org() {
-        let source = ManagedNodeDownloadSource::official(PlatformSpec {
-            folder_suffix: "darwin-arm64",
-            archive_ext: "tar.gz",
-        });
-
-        assert_eq!(source.source, "nodejs.org");
-        assert_eq!(
-            source.url,
-            "https://nodejs.org/dist/v24.11.0/node-v24.11.0-darwin-arm64.tar.gz"
-        );
-        assert_eq!(source.sha256, None);
-    }
-
-    #[test]
-    fn managed_runtime_checksum_verification_detects_mismatch() {
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("node.tar.gz");
-        std::fs::write(&path, b"not-node").unwrap();
-
-        let error = verify_archive_checksum(&path, "deadbeef").unwrap_err();
-        assert!(error.to_string().contains("checksum mismatch"));
-    }
-
-    #[test]
-    fn managed_runtime_injects_npm_state_under_runtime_root() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join("node-v24.11.0-test");
-        let bin = root.join("bin");
-        std::fs::create_dir_all(&bin).unwrap();
-        std::fs::write(bin.join("node"), b"").unwrap();
-        std::fs::write(bin.join("npm"), b"").unwrap();
-        std::fs::write(bin.join("npx"), b"").unwrap();
-
-        let runtime = runtime_from_root(&root, ResolvedNodeSource::Managed).expect("runtime");
-        let env: std::collections::HashMap<_, _> = runtime
-            .npm_command()
-            .env
-            .into_iter()
-            .map(|(k, v)| (k.to_string_lossy().into_owned(), v.to_string_lossy().into_owned()))
-            .collect();
-
-        assert_eq!(
-            env.get("npm_config_cache"),
-            Some(&root.join("cache").display().to_string())
-        );
-        assert_eq!(
-            env.get("npm_config_userconfig"),
-            Some(&root.join("blank_user_npmrc").display().to_string())
-        );
-        assert_eq!(
-            env.get("npm_config_globalconfig"),
-            Some(&root.join("blank_global_npmrc").display().to_string())
-        );
-        assert_eq!(
-            env.get("npm_config_prefix"),
-            Some(&root.join("tools").join("global").display().to_string())
-        );
-    }
-
-    #[tokio::test]
-    async fn bundled_runtime_validation_failure_does_not_fallback_to_remote_download() {
-        let tmp = tempfile::tempdir().unwrap();
-        let bundled_root = tmp.path().join("bundled");
-        if !crate::test_support::run_in_env_child(
-            "node_runtime::managed::tests::bundled_runtime_validation_failure_does_not_fallback_to_remote_download",
-            |command| {
-                command.env("AIONUI_BUNDLED_MANAGED_RESOURCES", &bundled_root);
-            },
-        ) {
-            return;
-        }
-        let bundled_root = std::path::PathBuf::from(std::env::var_os("AIONUI_BUNDLED_MANAGED_RESOURCES").unwrap());
-        let runtime_root = bundled_root.join("node").join("node-v24.11.0-darwin-arm64");
-        let bin = runtime_root.join("bin");
-        std::fs::create_dir_all(&bin).unwrap();
-
-        let node = bin.join("node");
-        std::fs::write(&node, "#!/bin/sh\necho v24.11.0\n").unwrap();
-        let npm = bin.join("npm");
-        std::fs::write(&npm, "#!/bin/sh\nexit 1\n").unwrap();
-        let npx = bin.join("npx");
-        std::fs::write(&npx, "#!/bin/sh\nexit 1\n").unwrap();
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            for path in [&node, &npm, &npx] {
-                let mut perms = std::fs::metadata(path).unwrap().permissions();
-                perms.set_mode(0o755);
-                std::fs::set_permissions(path, perms).unwrap();
-            }
-        }
-
-        managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Bundled);
-        let runtime_root = tmp.path().join("runtime").join("node");
-        std::fs::create_dir_all(&runtime_root).unwrap();
-        let result = activate_local_runtime_source(
-            &runtime_root,
-            PlatformSpec {
-                folder_suffix: "darwin-arm64",
-                archive_ext: "tar.gz",
-            },
-            None,
-        )
-        .await;
-        managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Download);
-
-        let error = result.expect_err("bundled validation failure should abort");
-        assert!(error.to_string().contains("bundled Node runtime failed validation"));
-    }
-}
+mod tests;

--- a/crates/aionui-runtime/src/node_runtime/managed/tests.rs
+++ b/crates/aionui-runtime/src/node_runtime/managed/tests.rs
@@ -1,0 +1,379 @@
+use super::*;
+
+fn write_file(path: &Path) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent");
+    }
+    std::fs::write(path, b"").expect("write file");
+}
+
+#[tokio::test]
+async fn managed_runtime_validation_uses_real_commands() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("node-v24.11.0-test");
+    let bin = root.join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+
+    let node = bin.join("node");
+    std::fs::write(&node, "#!/bin/sh\necho v24.11.0\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&node).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&node, perms).unwrap();
+    }
+
+    let err = validate_managed_runtime(&root, None).await.unwrap_err();
+    assert!(err.to_string().to_ascii_lowercase().contains("npm"));
+}
+
+#[test]
+fn managed_runtime_support_reports_current_platform() {
+    let support = probe_support();
+    let expected = cfg!(target_os = "macos") || cfg!(target_os = "linux") || cfg!(windows);
+    assert_eq!(support.supported, expected);
+}
+
+#[test]
+fn classify_error_detects_bundled_node_runtime_missing() {
+    let err = NodeRuntimeError::managed_invalid(
+        "bundled Node runtime missing under C:\\Program Files\\AionUi\\resources\\bundled-aioncore\\win32-x64\\managed-resources\\node\\node-v24.11.0-win-x64",
+    );
+    let (kind, status) = classify_error(&err);
+
+    assert_eq!(kind, NodeRuntimeFailureKind::BundledResourceMissing);
+    assert_eq!(status, None);
+}
+
+#[tokio::test]
+async fn bundled_runtime_missing_reports_bundled_resource_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bundled_root = tmp.path().join("bundled");
+    if !crate::test_support::run_in_env_child(
+        "node_runtime::managed::tests::bundled_runtime_missing_reports_bundled_resource_missing",
+        |command| {
+            command.env("AIONUI_BUNDLED_MANAGED_RESOURCES", &bundled_root);
+        },
+    ) {
+        return;
+    }
+
+    crate::cache::init(tmp.path().join("data"));
+    managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Bundled);
+
+    let updates = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let reporter_updates = updates.clone();
+    let reporter = move |update: NodeRuntimeProgress| {
+        reporter_updates.lock().unwrap().push(update);
+    };
+
+    let result = install_and_validate_with_reporter(Some(&reporter)).await;
+    managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Download);
+
+    let error = result.expect_err("missing bundled runtime should fail");
+    assert!(error.to_string().contains("bundled Node runtime missing"));
+    let updates = updates.lock().unwrap();
+    assert!(updates.iter().any(|update| {
+        update.phase == crate::NodeRuntimeProgressPhase::Failed
+            && update.failure_kind == Some(NodeRuntimeFailureKind::BundledResourceMissing)
+    }));
+}
+
+#[test]
+fn managed_runtime_install_lock_path_uses_runtime_root() {
+    let root = PathBuf::from("/tmp/aionui/runtime/node");
+    assert_eq!(install_lock_path(&root), root.join("node-runtime-install.lock"));
+}
+
+#[test]
+fn managed_runtime_timeout_error_is_explicit() {
+    let error = timeout_error(
+        "download archive",
+        "https://example.com/node.tar.gz",
+        MANAGED_NODE_DOWNLOAD_TIMEOUT,
+    );
+    let message = error.to_string();
+    assert!(message.contains("download archive timed out"));
+    assert!(message.contains("600s"));
+}
+
+#[test]
+fn managed_runtime_http_status_error_is_explicit() {
+    let error = http_status_error(
+        "download archive",
+        "https://example.com/node.tar.gz",
+        reqwest::StatusCode::BAD_GATEWAY,
+    );
+    let message = error.to_string();
+    assert!(message.contains("HTTP 502"));
+    assert!(message.contains("download archive"));
+}
+
+#[test]
+fn managed_runtime_official_source_uses_nodejs_org() {
+    let source = ManagedNodeDownloadSource::official(PlatformSpec {
+        folder_suffix: "darwin-arm64",
+        archive_ext: "tar.gz",
+    });
+
+    assert_eq!(source.source, "nodejs.org");
+    assert_eq!(
+        source.url,
+        "https://nodejs.org/dist/v24.11.0/node-v24.11.0-darwin-arm64.tar.gz"
+    );
+    assert_eq!(source.sha256, None);
+}
+
+#[test]
+fn managed_runtime_checksum_verification_detects_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("node.tar.gz");
+    std::fs::write(&path, b"not-node").unwrap();
+
+    let error = verify_archive_checksum(&path, "deadbeef").unwrap_err();
+    assert!(error.to_string().contains("checksum mismatch"));
+}
+
+#[test]
+fn managed_runtime_injects_npm_state_under_runtime_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("node-v24.11.0-test");
+    let bin = root.join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    std::fs::write(bin.join("node"), b"").unwrap();
+    std::fs::write(bin.join("npm"), b"").unwrap();
+    std::fs::write(bin.join("npx"), b"").unwrap();
+
+    let runtime = runtime_from_root(&root, ResolvedNodeSource::Managed).expect("runtime");
+    let env: std::collections::HashMap<_, _> = runtime
+        .npm_command()
+        .env
+        .into_iter()
+        .map(|(k, v)| (k.to_string_lossy().into_owned(), v.to_string_lossy().into_owned()))
+        .collect();
+
+    assert_eq!(
+        env.get("npm_config_cache"),
+        Some(&root.join("cache").display().to_string())
+    );
+    assert_eq!(
+        env.get("npm_config_userconfig"),
+        Some(&root.join("blank_user_npmrc").display().to_string())
+    );
+    assert_eq!(
+        env.get("npm_config_globalconfig"),
+        Some(&root.join("blank_global_npmrc").display().to_string())
+    );
+    assert_eq!(
+        env.get("npm_config_prefix"),
+        Some(&root.join("tools").join("global").display().to_string())
+    );
+}
+
+#[tokio::test]
+async fn bundled_runtime_validation_failure_does_not_fallback_to_remote_download() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bundled_root = tmp.path().join("bundled");
+    if !crate::test_support::run_in_env_child(
+        "node_runtime::managed::tests::bundled_runtime_validation_failure_does_not_fallback_to_remote_download",
+        |command| {
+            command.env("AIONUI_BUNDLED_MANAGED_RESOURCES", &bundled_root);
+        },
+    ) {
+        return;
+    }
+    let bundled_root = std::path::PathBuf::from(std::env::var_os("AIONUI_BUNDLED_MANAGED_RESOURCES").unwrap());
+    let runtime_root = bundled_root.join("node").join("node-v24.11.0-darwin-arm64");
+    let bin = runtime_root.join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+
+    let node = bin.join("node");
+    std::fs::write(&node, "#!/bin/sh\necho v24.11.0\n").unwrap();
+    let npm = bin.join("npm");
+    std::fs::write(&npm, "#!/bin/sh\nexit 1\n").unwrap();
+    let npx = bin.join("npx");
+    std::fs::write(&npx, "#!/bin/sh\nexit 1\n").unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        for path in [&node, &npm, &npx] {
+            let mut perms = std::fs::metadata(path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(path, perms).unwrap();
+        }
+    }
+
+    managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Bundled);
+    let runtime_root = tmp.path().join("runtime").join("node");
+    std::fs::create_dir_all(&runtime_root).unwrap();
+    let result = activate_local_runtime_source(
+        &runtime_root,
+        PlatformSpec {
+            folder_suffix: "darwin-arm64",
+            archive_ext: "tar.gz",
+        },
+        None,
+    )
+    .await;
+    managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Download);
+
+    let error = result.expect_err("bundled validation failure should abort");
+    assert!(error.to_string().contains("bundled Node runtime failed validation"));
+}
+
+#[test]
+fn windows_managed_cli_paths_use_node_modules_under_archive_root() {
+    let root = PathBuf::from(r"C:\AionUi\node-v24.11.0-win-x64");
+    let npm = managed_npm_cli_path_for_layout(&root, ManagedNodeArchiveLayout::Windows);
+    let npx = managed_npx_cli_path_for_layout(&root, ManagedNodeArchiveLayout::Windows);
+
+    assert_eq!(
+        npm,
+        root.join("node_modules").join("npm").join("bin").join("npm-cli.js")
+    );
+    assert_eq!(
+        npx,
+        root.join("node_modules").join("npm").join("bin").join("npx-cli.js")
+    );
+}
+
+#[test]
+fn unix_managed_cli_paths_use_lib_node_modules() {
+    let root = PathBuf::from("/opt/aionui/node-v24.11.0-darwin-arm64");
+    let npm = managed_npm_cli_path_for_layout(&root, ManagedNodeArchiveLayout::Unix);
+    let npx = managed_npx_cli_path_for_layout(&root, ManagedNodeArchiveLayout::Unix);
+
+    assert_eq!(
+        npm,
+        root.join("lib")
+            .join("node_modules")
+            .join("npm")
+            .join("bin")
+            .join("npm-cli.js")
+    );
+    assert_eq!(
+        npx,
+        root.join("lib")
+            .join("node_modules")
+            .join("npm")
+            .join("bin")
+            .join("npx-cli.js")
+    );
+}
+
+#[test]
+fn windows_managed_runtime_prefers_direct_cli_entrypoints_over_wrappers() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("node-v24.11.0-win-x64");
+    std::fs::create_dir_all(&root).unwrap();
+
+    let node = root.join("node.exe");
+    write_file(&node);
+    write_file(&root.join("npm.cmd"));
+    write_file(&root.join("npx.cmd"));
+    let npm_cli = root.join("node_modules").join("npm").join("bin").join("npm-cli.js");
+    let npx_cli = root.join("node_modules").join("npm").join("bin").join("npx-cli.js");
+    write_file(&npm_cli);
+    write_file(&npx_cli);
+
+    let runtime = runtime_from_root_for_layout(&root, ResolvedNodeSource::Managed, ManagedNodeArchiveLayout::Windows)
+        .expect("runtime should resolve");
+
+    assert_eq!(runtime.npm_path, node);
+    assert_eq!(runtime.npm_args_prefix, vec![npm_cli.into_os_string()]);
+    assert_eq!(runtime.npx_path, root.join("node.exe"));
+    assert_eq!(runtime.npx_args_prefix, vec![npx_cli.into_os_string()]);
+
+    let npx_env: std::collections::HashMap<_, _> = runtime
+        .npx_command()
+        .env
+        .into_iter()
+        .map(|(k, v)| (k.to_string_lossy().into_owned(), v.to_string_lossy().into_owned()))
+        .collect();
+    assert!(npx_env.contains_key("npm_config_cache"));
+    assert!(npx_env.contains_key("npm_config_userconfig"));
+    assert!(npx_env.contains_key("npm_config_globalconfig"));
+    assert!(npx_env.contains_key("npm_config_prefix"));
+}
+
+#[test]
+fn windows_managed_runtime_falls_back_to_wrappers_when_direct_cli_is_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("node-v24.11.0-win-x64");
+    std::fs::create_dir_all(&root).unwrap();
+
+    write_file(&root.join("node.exe"));
+    write_file(&root.join("npm.cmd"));
+    write_file(&root.join("npx.cmd"));
+
+    let runtime = runtime_from_root_for_layout(&root, ResolvedNodeSource::Managed, ManagedNodeArchiveLayout::Windows)
+        .expect("runtime should resolve");
+
+    assert_eq!(runtime.npm_path, root.join("npm.cmd"));
+    assert!(runtime.npm_args_prefix.is_empty());
+    assert_eq!(runtime.npx_path, root.join("npx.cmd"));
+    assert!(runtime.npx_args_prefix.is_empty());
+}
+
+#[test]
+fn unix_managed_runtime_keeps_wrapper_entrypoints_when_present() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("node-v24.11.0-darwin-arm64");
+    let bin = root.join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+
+    write_file(&bin.join("node"));
+    write_file(&bin.join("npm"));
+    write_file(&bin.join("npx"));
+    write_file(
+        &root
+            .join("lib")
+            .join("node_modules")
+            .join("npm")
+            .join("bin")
+            .join("npm-cli.js"),
+    );
+    write_file(
+        &root
+            .join("lib")
+            .join("node_modules")
+            .join("npm")
+            .join("bin")
+            .join("npx-cli.js"),
+    );
+
+    let runtime = runtime_from_root_for_layout(&root, ResolvedNodeSource::Managed, ManagedNodeArchiveLayout::Unix)
+        .expect("runtime should resolve");
+
+    assert_eq!(runtime.npm_path, bin.join("npm"));
+    assert!(runtime.npm_args_prefix.is_empty());
+    assert_eq!(runtime.npx_path, bin.join("npx"));
+    assert!(runtime.npx_args_prefix.is_empty());
+}
+
+#[test]
+fn windows_managed_runtime_fails_when_entrypoints_are_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("node-v24.11.0-win-x64");
+    std::fs::create_dir_all(&root).unwrap();
+    write_file(&root.join("node.exe"));
+
+    let error = runtime_from_root_for_layout(&root, ResolvedNodeSource::Managed, ManagedNodeArchiveLayout::Windows)
+        .expect_err("missing npm should fail");
+    assert!(
+        error.to_string().contains("managed npm entrypoint missing"),
+        "unexpected error: {error}"
+    );
+
+    let npm_cli = root.join("node_modules").join("npm").join("bin").join("npm-cli.js");
+    write_file(&npm_cli);
+
+    let error = runtime_from_root_for_layout(&root, ResolvedNodeSource::Managed, ManagedNodeArchiveLayout::Windows)
+        .expect_err("missing npx should fail");
+    assert!(
+        error.to_string().contains("managed npx entrypoint missing"),
+        "unexpected error: {error}"
+    );
+}

--- a/crates/aionui-runtime/src/node_runtime/mod.rs
+++ b/crates/aionui-runtime/src/node_runtime/mod.rs
@@ -263,12 +263,32 @@ async fn command_version(command: ResolvedCommand, label: &str) -> Result<semver
 }
 
 fn parse_version_output(output: &str, label: &str) -> Result<semver::Version, NodeRuntimeError> {
-    let version = output.trim().trim_start_matches('v');
-    semver::Version::parse(version).map_err(|error| {
-        NodeRuntimeError::managed_invalid(format!(
-            "{label} returned non-semver version output '{version}': {error}"
-        ))
-    })
+    let mut versions = output
+        .lines()
+        .filter_map(parse_independent_semver_line)
+        .collect::<Vec<_>>();
+
+    match versions.len() {
+        1 => Ok(versions.remove(0)),
+        0 => {
+            let normalized = output.trim();
+            Err(NodeRuntimeError::managed_invalid(format!(
+                "{label} returned non-semver version output '{normalized}'"
+            )))
+        }
+        _ => {
+            let normalized = output.trim();
+            Err(NodeRuntimeError::managed_invalid(format!(
+                "{label} returned ambiguous semver version output '{normalized}'"
+            )))
+        }
+    }
+}
+
+fn parse_independent_semver_line(line: &str) -> Option<semver::Version> {
+    let trimmed = line.trim();
+    let version_text = trimmed.strip_prefix('v').unwrap_or(trimmed);
+    semver::Version::parse(version_text).ok()
 }
 
 pub fn doctor_snapshot_for_test(rows: Vec<(&str, &str, &str)>) -> Vec<DoctorRow> {
@@ -382,6 +402,56 @@ mod tests {
     fn probe_explicit_path_is_passthrough() {
         let probe = probe_runtime_command("/tmp/custom-node");
         assert!(matches!(probe, RuntimeCommandProbe::ExplicitPath { .. }));
+    }
+
+    #[test]
+    fn parse_version_output_accepts_banner_crlf_single_semver_line() {
+        let version = parse_version_output(
+            "Bienvenido a FenixFat\r\nFenixFat 2026-07-02 10:00:00\r\n11.6.1\r\n",
+            "npm",
+        )
+        .expect("single independent semver line should parse");
+
+        assert_eq!(version, semver::Version::new(11, 6, 1));
+    }
+
+    #[test]
+    fn parse_version_output_accepts_v_prefixed_single_semver_line() {
+        let version = parse_version_output("v24.11.0\r\n", "node").expect("v prefix should parse");
+
+        assert_eq!(version, semver::Version::new(24, 11, 0));
+    }
+
+    #[test]
+    fn parse_version_output_rejects_output_without_independent_semver_line() {
+        let error = parse_version_output("Bienvenido\r\nFenixFat\r\n", "npm").expect_err("missing semver should fail");
+
+        assert!(
+            error.to_string().contains("npm returned non-semver version output"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_version_output_rejects_embedded_semver_text() {
+        let error = parse_version_output("npm version 11.6.1\r\n", "npm").expect_err("embedded semver should fail");
+
+        assert!(
+            error.to_string().contains("npm returned non-semver version output"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_version_output_rejects_multiple_independent_semver_lines() {
+        let error = parse_version_output("11.6.1\r\n10.9.0\r\n", "npm").expect_err("ambiguous versions should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("npm returned ambiguous semver version output"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/aionui-runtime/src/spawn.rs
+++ b/crates/aionui-runtime/src/spawn.rs
@@ -268,7 +268,7 @@ fn shell_wrap_windows_script(program: &OsStr) -> Option<ProgramPlan> {
     if ext.eq_ignore_ascii_case("cmd") || ext.eq_ignore_ascii_case("bat") {
         return Some(ProgramPlan {
             program: "cmd".into(),
-            args_prefix: vec!["/c".into(), program.into()],
+            args_prefix: vec!["/d".into(), "/c".into(), program.into()],
         });
     }
 
@@ -524,6 +524,7 @@ mod tests {
         assert_eq!(
             args,
             vec![
+                OsString::from("/d"),
                 OsString::from("/c"),
                 OsString::from(r"C:\Users\me\AppData\Roaming\npm\opencode.cmd"),
                 OsString::from("run"),
@@ -540,6 +541,7 @@ mod tests {
         assert_eq!(
             args,
             vec![
+                OsString::from("/d"),
                 OsString::from("/c"),
                 OsString::from(r"C:\Users\me\AppData\Roaming\npm\opencode.bat"),
                 OsString::from("--version"),


### PR DESCRIPTION
## Summary

- Harden managed Node version parsing so validation accepts exactly one independent semver line from noisy stdout, including CRLF output and an optional `v` prefix, while still rejecting missing, embedded, or ambiguous semver output.
- Prefer `node.exe` plus bundled `npm-cli.js` / `npx-cli.js` for Windows managed npm/npx resolution, with wrapper fallback preserved when direct CLI files are missing.
- Wrap Windows `.cmd` / `.bat` fallback commands with `cmd /d /c` and move managed runtime tests into a dedicated test module.

## Context

This addresses Sentry issue `128134003`, where Windows packaged runtime validation could fail when shell or wrapper output polluted `npm --version` stdout. The fix is limited to AionCore runtime command resolution and parsing. AionUi and aionrs are unchanged in this fix run.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p aionui-runtime`
- `cargo test -p aionui-ai-agent`
- `cargo test -p aionui-mcp`
- `cargo clippy -p aionui-runtime -p aionui-ai-agent -p aionui-mcp -- -D warnings`
- `cargo test --workspace`
- `git diff --check 174be67fabbc248856e9329c13fb7eb388f04057..HEAD`
- `just push -u origin aionissue/fix-2.1.25-128134003-002`

The final `just push` run completed the full pre-push gate and reported 6600 tests passed with 18 skipped before pushing the branch.

## Manual Follow-Up

- Validate a packaged Windows AionUi build with `cmd.exe` AutoRun or equivalent stdout banner pollution.
- Confirm bundled Windows managed Node contains `node_modules/npm/bin/npm-cli.js` and `npx-cli.js` and that npm/npx resolution uses `node.exe` plus the CLI JS files.
- Confirm built-in MCP preflight no longer returns `MCP_COMMAND_START_FAILED` from the stdout pollution root cause.
