### PR TITLE
feat(assistant): 官方助手默认关闭 + 固定顺序 + 一次性重置迁移

### DIFF
--- a/crates/aionui-app/assets/builtin-assistants/assistants.json
+++ b/crates/aionui-app/assets/builtin-assistants/assistants.json
@@ -3,6 +3,8 @@
   "assistants": [
     {
       "id": "word-creator",
+      "sort_order": 10,
+      "default_enabled": false,
       "name": "Word Creator",
       "name_i18n": {
         "en-US": "Word Creator",
@@ -56,6 +58,8 @@
     },
     {
       "id": "ppt-creator",
+      "sort_order": 20,
+      "default_enabled": false,
       "name": "PPT Creator",
       "name_i18n": {
         "en-US": "PPT Creator",
@@ -109,6 +113,8 @@
     },
     {
       "id": "excel-creator",
+      "sort_order": 30,
+      "default_enabled": false,
       "name": "Excel Creator",
       "name_i18n": {
         "en-US": "Excel Creator",
@@ -162,6 +168,8 @@
     },
     {
       "id": "morph-ppt",
+      "sort_order": 90,
+      "default_enabled": false,
       "name": "Morph PPT",
       "name_i18n": {
         "en-US": "Morph PPT",
@@ -215,6 +223,8 @@
     },
     {
       "id": "morph-ppt-3d",
+      "sort_order": 100,
+      "default_enabled": false,
       "name": "3D Morph PPT",
       "name_i18n": {
         "en-US": "3D Morph PPT",
@@ -255,6 +265,8 @@
     },
     {
       "id": "pitch-deck-creator",
+      "sort_order": 80,
+      "default_enabled": false,
       "name": "Pitch Deck Creator",
       "name_i18n": {
         "en-US": "Pitch Deck Creator",
@@ -308,6 +320,8 @@
     },
     {
       "id": "dashboard-creator",
+      "sort_order": 50,
+      "default_enabled": false,
       "name": "Dashboard Creator",
       "name_i18n": {
         "en-US": "Dashboard Creator",
@@ -361,6 +375,8 @@
     },
     {
       "id": "academic-paper",
+      "sort_order": 70,
+      "default_enabled": false,
       "name": "Academic Paper",
       "name_i18n": {
         "en-US": "Academic Paper",
@@ -414,6 +430,8 @@
     },
     {
       "id": "financial-model-creator",
+      "sort_order": 60,
+      "default_enabled": false,
       "name": "Financial Model Creator",
       "name_i18n": {
         "en-US": "Financial Model Creator",
@@ -467,6 +485,8 @@
     },
     {
       "id": "openclaw-setup",
+      "sort_order": 170,
+      "default_enabled": false,
       "name": "OpenClaw Setup Expert",
       "name_i18n": {
         "en-US": "OpenClaw Setup Expert",
@@ -521,6 +541,8 @@
     },
     {
       "id": "cowork",
+      "sort_order": 160,
+      "default_enabled": false,
       "name": "Cowork",
       "name_i18n": {
         "en-US": "Cowork",
@@ -578,6 +600,8 @@
     },
     {
       "id": "game-3d",
+      "sort_order": 130,
+      "default_enabled": false,
       "name": "3D Game",
       "name_i18n": {
         "en-US": "3D Game",
@@ -629,6 +653,8 @@
     },
     {
       "id": "ui-ux-pro-max",
+      "sort_order": 120,
+      "default_enabled": false,
       "name": "UI/UX Pro Max",
       "name_i18n": {
         "en-US": "UI/UX Pro Max",
@@ -680,6 +706,8 @@
     },
     {
       "id": "planning-with-files",
+      "sort_order": 150,
+      "default_enabled": false,
       "name": "Planning with Files",
       "name_i18n": {
         "en-US": "Planning with Files",
@@ -731,6 +759,8 @@
     },
     {
       "id": "human-3-coach",
+      "sort_order": 190,
+      "default_enabled": false,
       "name": "HUMAN 3.0 Coach",
       "name_i18n": {
         "en-US": "HUMAN 3.0 Coach",
@@ -782,6 +812,8 @@
     },
     {
       "id": "social-job-publisher",
+      "sort_order": 180,
+      "default_enabled": false,
       "name": "Social Job Publisher",
       "name_i18n": {
         "en-US": "Social Job Publisher",
@@ -836,6 +868,8 @@
     },
     {
       "id": "moltbook",
+      "sort_order": 200,
+      "default_enabled": false,
       "name": "moltbook",
       "name_i18n": {
         "en-US": "moltbook",
@@ -889,6 +923,8 @@
     },
     {
       "id": "beautiful-mermaid",
+      "sort_order": 110,
+      "default_enabled": false,
       "name": "Beautiful Mermaid",
       "name_i18n": {
         "en-US": "Beautiful Mermaid",
@@ -942,6 +978,8 @@
     },
     {
       "id": "story-roleplay",
+      "sort_order": 140,
+      "default_enabled": false,
       "name": "Story Roleplay",
       "name_i18n": {
         "en-US": "Story Roleplay",
@@ -995,6 +1033,8 @@
     },
     {
       "id": "word-form-creator",
+      "sort_order": 40,
+      "default_enabled": false,
       "name": "Word Form Creator",
       "name_i18n": {
         "en-US": "Word Form Creator",
@@ -1048,6 +1088,8 @@
     },
     {
       "id": "aionui-assistant",
+      "sort_order": 0,
+      "default_enabled": true,
       "name": "AionUi Butler",
       "name_i18n": {
         "en-US": "AionUi Butler",

--- a/crates/aionui-app/tests/assistants_e2e.rs
+++ b/crates/aionui-app/tests/assistants_e2e.rs
@@ -1082,6 +1082,10 @@ async fn delete_extension_registry_id_without_user_row_returns_404() {
 
 #[tokio::test]
 async fn set_state_inserts_override_for_builtin() {
+    // Builtin sort_order is manifest-owned (users can't reorder official
+    // assistants), so a set_state sort_order is ignored for builtins and the
+    // response keeps the manifest value (0 for this fixture). Only `enabled`
+    // is honoured.
     let fx = fixture().await;
     let req = json_with_token(
         "PATCH",
@@ -1094,7 +1098,7 @@ async fn set_state_inserts_override_for_builtin() {
     assert_eq!(resp.status(), StatusCode::OK);
     let json = body_json(resp).await;
     assert_eq!(json["data"]["enabled"], false);
-    assert_eq!(json["data"]["sort_order"], 9);
+    assert_eq!(json["data"]["sort_order"], 0);
     assert_eq!(json["data"]["source"], "builtin");
 }
 

--- a/crates/aionui-assistant/src/builtin.rs
+++ b/crates/aionui-assistant/src/builtin.rs
@@ -58,6 +58,16 @@ pub struct BuiltinAssistant {
     pub prompts_i18n: HashMap<String, Vec<String>>,
     #[serde(default)]
     pub models: Vec<String>,
+    /// Default position in the official assistant list. Lower comes first.
+    /// Owned by this manifest (users cannot reorder official assistants), so
+    /// this value is authoritative across versions. Defaults to 0.
+    #[serde(default)]
+    pub sort_order: i32,
+    /// Whether this official assistant is enabled by default when a user has
+    /// no overlay for it. Only the butler ships enabled; others default off so
+    /// they don't crowd the user's selection lists. Defaults to false.
+    #[serde(default)]
+    pub default_enabled: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/aionui-assistant/src/service.rs
+++ b/crates/aionui-assistant/src/service.rs
@@ -1921,12 +1921,29 @@ impl AssistantService {
         Some(value)
     }
 
+    /// Manifest-owned listing defaults for a builtin assistant.
+    ///
+    /// Official assistants cannot be reordered by users, so their `sort_order`
+    /// is always the manifest value (never an overlay). Their default `enabled`
+    /// (butler on, others off) applies only when the user has no overlay.
+    /// Returns `(sort_order, default_enabled)`; `None` for non-builtins.
+    fn builtin_listing_default(&self, definition: &AssistantDefinitionRow) -> Option<(i32, bool)> {
+        if definition.source != "builtin" {
+            return None;
+        }
+        let source_ref = definition.source_ref.as_deref()?;
+        self.builtin
+            .get(source_ref)
+            .map(|builtin| (builtin.sort_order, builtin.default_enabled))
+    }
+
     fn definition_to_response(
         &self,
         definition: &AssistantDefinitionRow,
         state: Option<&AssistantOverlayRow>,
         projection: &AssistantRuntimeProjection,
     ) -> Result<AssistantResponse, AssistantError> {
+        let builtin_default = self.builtin_listing_default(definition);
         let source = match definition.source.as_str() {
             "builtin" => AssistantSource::Builtin,
             "generated" => AssistantSource::Generated,
@@ -1948,8 +1965,16 @@ impl AssistantService {
             description: definition.description.clone(),
             description_i18n: decode_str_map(Some(definition.description_i18n.as_str()))?,
             avatar: self.avatar_display_value(definition),
-            enabled: state.is_none_or(|row| row.enabled),
-            sort_order: state.map(|row| row.sort_order).unwrap_or(0),
+            // For builtins: enabled = overlay if the user has one, else the
+            // manifest default (butler on, others off). sort_order = always the
+            // manifest value (users can't reorder official assistants).
+            enabled: match state {
+                Some(row) => row.enabled,
+                None => builtin_default.map(|(_, en)| en).unwrap_or(true),
+            },
+            sort_order: builtin_default
+                .map(|(so, _)| so)
+                .unwrap_or_else(|| state.map(|row| row.sort_order).unwrap_or(0)),
             agent_id: projection.agent_id.clone(),
             agent: projection.agent.clone(),
             enabled_skills: decode_str_list(Some(definition.default_skill_ids.as_str()))?,
@@ -1977,6 +2002,7 @@ impl AssistantService {
         rules_content: &str,
         projection: &AssistantRuntimeProjection,
     ) -> Result<AssistantDetailResponse, AssistantError> {
+        let builtin_default = self.builtin_listing_default(definition);
         let default_skill_ids = decode_str_list(Some(definition.default_skill_ids.as_str()))?;
         let custom_skill_names = decode_str_list(Some(definition.custom_skill_names.as_str()))?;
         let default_disabled_builtin_skill_ids =
@@ -2015,8 +2041,13 @@ impl AssistantService {
                 avatar: self.avatar_display_value(definition),
             },
             state: AssistantStateResponse {
-                enabled: state.map(|row| row.enabled).unwrap_or(true),
-                sort_order: state.map(|row| row.sort_order).unwrap_or_default(),
+                enabled: match state {
+                    Some(row) => row.enabled,
+                    None => builtin_default.map(|(_, en)| en).unwrap_or(true),
+                },
+                sort_order: builtin_default
+                    .map(|(so, _)| so)
+                    .unwrap_or_else(|| state.map(|row| row.sort_order).unwrap_or_default()),
                 last_used_at: state.and_then(|row| row.last_used_at),
             },
             engine: AssistantEngineResponse {
@@ -2754,6 +2785,8 @@ mod tests {
                         "avatar": b.avatar,
                         "agent_ref": b.agent_ref,
                         "rule_file": b.rule_file,
+                        "sort_order": b.sort_order,
+                        "default_enabled": b.default_enabled,
                     })
                 })
                 .collect::<Vec<_>>()
@@ -2845,6 +2878,8 @@ mod tests {
             prompts: Vec::new(),
             prompts_i18n: HashMap::new(),
             models: Vec::new(),
+            sort_order: 0,
+            default_enabled: true,
         }
     }
 
@@ -2972,6 +3007,31 @@ mod tests {
         assert_eq!(list.len(), 2);
         assert!(list.iter().any(|a| a.id == "builtin-office"));
         assert!(list.iter().any(|a| a.id == "u1"));
+    }
+
+    #[tokio::test]
+    async fn builtin_listing_uses_manifest_default_enabled_and_sort_order() {
+        // A builtin with default_enabled=false + sort_order=50, and no user
+        // overlay, must surface disabled with the manifest sort_order. The
+        // butler (default_enabled=true, sort_order=0) stays enabled and first.
+        let mut disabled = mk_builtin("builtin-writer", "Writer");
+        disabled.default_enabled = false;
+        disabled.sort_order = 50;
+        let mut butler = mk_builtin("aionui-assistant", "Butler");
+        butler.default_enabled = true;
+        butler.sort_order = 0;
+        let fx = fixture_with_builtins(vec![disabled, butler]).await;
+
+        let list = fx.service.list().await.unwrap();
+        let writer = list.iter().find(|a| a.id == "builtin-writer").unwrap();
+        assert!(!writer.enabled, "non-butler builtin defaults to disabled");
+        assert_eq!(writer.sort_order, 50, "sort_order comes from manifest");
+        let butler_resp = list.iter().find(|a| a.id == "aionui-assistant").unwrap();
+        assert!(butler_resp.enabled, "butler defaults to enabled");
+        assert_eq!(butler_resp.sort_order, 0);
+        let butler_idx = list.iter().position(|a| a.id == "aionui-assistant").unwrap();
+        let writer_idx = list.iter().position(|a| a.id == "builtin-writer").unwrap();
+        assert!(butler_idx < writer_idx, "butler (0) sorts before writer (50)");
     }
 
     #[tokio::test]
@@ -4806,7 +4866,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_state_builtin_writes_override() {
+    async fn set_state_builtin_writes_enabled_but_sort_order_stays_manifest() {
+        // Builtin sort_order is manifest-owned (users can't reorder official
+        // assistants), so set_state's sort_order must NOT affect the response —
+        // it stays the manifest value. Only enabled is honoured.
         let fx = fixture_with_builtins(vec![mk_builtin("builtin-office", "Office")]).await;
         let resp = fx
             .service
@@ -4821,7 +4884,8 @@ mod tests {
             .await
             .unwrap();
         assert!(!resp.enabled);
-        assert_eq!(resp.sort_order, 7);
+        // mk_builtin ships sort_order = 0; the overlay's 7 is ignored for builtins.
+        assert_eq!(resp.sort_order, 0);
         assert_eq!(resp.source, AssistantSource::Builtin);
     }
 

--- a/crates/aionui-db/migrations/018_reset_builtin_assistant_enabled.sql
+++ b/crates/aionui-db/migrations/018_reset_builtin_assistant_enabled.sql
@@ -1,0 +1,41 @@
+-- One-time reset of built-in (official) assistant enabled state to the new
+-- initial experience: only the AionUi butler is enabled by default; every
+-- other official assistant is disabled so they no longer crowd the user's
+-- selection lists.
+--
+-- Scope & safety:
+--   * Touches ONLY existing overlay rows for `builtin` definitions.
+--   * Writes ONLY the `enabled` column (+ updated_at). It never touches
+--     `sort_order` (official order is manifest-owned) and never touches
+--     `agent_backend_override` (the user's per-assistant engine/CLI choice).
+--   * Built-in definitions WITHOUT an overlay row need no action here: the
+--     application already falls back to the manifest default_enabled for them.
+--   * Runs exactly once (sqlx migration). After this, any manual enable/disable
+--     the user makes is a normal overlay write and is never reset again.
+--
+-- The butler is identified by its manifest source_ref 'aionui-assistant'.
+--
+-- Two tables must be reset in lockstep: the unified `assistant_overlays`
+-- (current) and the legacy `assistant_overrides` (kept for backward-compat and
+-- re-synced into overlays on every startup via sync_legacy_overrides_to_new_states).
+-- Resetting only one lets the other clobber it on the next boot.
+UPDATE assistant_overlays
+SET enabled = CASE
+        WHEN assistant_definition_id IN (
+            SELECT id FROM assistant_definitions
+            WHERE source = 'builtin' AND source_ref = 'aionui-assistant'
+        ) THEN 1
+        ELSE 0
+    END,
+    updated_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+WHERE assistant_definition_id IN (
+    SELECT id FROM assistant_definitions WHERE source = 'builtin'
+);
+
+-- Legacy mirror. Its primary key is the assistant_id (== builtin source_ref).
+UPDATE assistant_overrides
+SET enabled = CASE WHEN assistant_id = 'aionui-assistant' THEN 1 ELSE 0 END,
+    updated_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+WHERE assistant_id IN (
+    SELECT assistant_id FROM assistant_definitions WHERE source = 'builtin'
+);


### PR DESCRIPTION
## 背景
官方内置助手过去默认全部启用，塞满用户的选择列表，把用户自己的 CLI 助手淹没。本 PR 让官方助手默认关闭（仅管家开），顺序由官方固定，并对老用户做一次性重置。配合前端 PR iOfficeAI/AionUi#3506。

## 改动
- **`assistants.json`**：每个官方助手加显式 `sort_order`（管家最小、办公类居前）+ `default_enabled`（仅管家 true）。
- **`definition_to_response` / detail**：官方助手 `enabled` 无 overlay 时回退到 manifest 默认；`sort_order` 恒取 manifest 值（用户不可对官方排序，overlay 永不覆盖顺序）。
- **迁移 018**：一次性把已有官方 overlay 重置为新默认（管家开、其余关），新旧两张表（`assistant_overlays` + legacy `assistant_overrides`）同步。**只写 `enabled`**——绝不碰 `agent_id_override`（用户切的引擎）和 `sort_order`。

## 不覆盖用户设置（已实测 5 个 case）
- 全新用户：0 overlay，只管家开，按 manifest 排序。
- 老用户升级：一次性重置为只管家开。
- 用户切过引擎的官方助手：开关重置，**引擎保留**。
- 迁移仅一次：重启后用户手动开的官方助手不再被覆盖。
- 用户设的默认模型/权限：**永久保留**（materialize 保留既有值，迁移只碰 enabled）。

## 测试
- `cargo fmt --check` ✓ / `cargo clippy --workspace -D warnings` ✓ / `cargo test -p aionui-assistant` 91 passed ✓
- 真实二进制起隔离实例，逐个 case 用 API + DB 验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)