### PR TITLE
fix(mcp): support aionrs config path subcommand with legacy fallback

### DIFF
--- a/crates/aionui-mcp/src/adapters/aionrs.rs
+++ b/crates/aionui-mcp/src/adapters/aionrs.rs
@@ -6,7 +6,7 @@ use crate::adapter::{DetectedServer, McpAgentAdapter};
 use crate::error::McpError;
 use crate::types::McpServerTransport;
 
-use super::cli_helpers::{DETECT_TIMEOUT, is_cli_installed, run_cli_strict};
+use super::cli_helpers::{DETECT_TIMEOUT, is_cli_installed, run_cli, run_cli_strict};
 
 const CLI_NAME: &str = "aionrs";
 
@@ -171,13 +171,27 @@ impl McpAgentAdapter for AionrsAdapter {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Run `aionrs --config-path` to get the TOML config file path.
+/// Resolve the TOML config file path from the `aionrs` CLI.
+///
+/// Newer `aionrs` exposes this via the `config path` subcommand; older
+/// versions used the `--config-path` flag. We try the subcommand first and
+/// fall back to the legacy flag so both CLI versions keep working. The
+/// subcommand attempt uses `run_cli` (tolerating a non-zero exit) so an old
+/// CLI rejecting `config path` falls through to the flag instead of erroring.
 async fn get_config_path() -> Result<String, McpError> {
+    if let Ok((stdout, _stderr)) = run_cli(CLI_NAME, &["config", "path"], DETECT_TIMEOUT).await {
+        let path = stdout.trim();
+        if !path.is_empty() {
+            return Ok(path.to_owned());
+        }
+    }
+
+    // Legacy fallback for `aionrs` versions predating the `config` subcommand.
     let stdout = run_cli_strict(CLI_NAME, &["--config-path"], DETECT_TIMEOUT).await?;
     let path = stdout.trim().to_owned();
     if path.is_empty() {
         return Err(McpError::AgentOperationFailed(
-            "aionrs --config-path returned empty output".into(),
+            "aionrs config path returned empty output".into(),
         ));
     }
     Ok(path)


### PR DESCRIPTION
## Background

aionrs (AionCLI) restructured its flat management flags into hierarchical subcommands in [aionrs#184](https://github.com/iOfficeAI/aionrs/pull/184). As part of that, the top-level `--config-path` flag was removed in favor of `aionrs config path`.

The aionrs MCP adapter in `aionui-mcp` (`adapters/aionrs.rs`) shells out to `aionrs --config-path` to locate the MCP config file. Once a user's aionrs CLI on `$PATH` upgrades to the new version, this call fails with "unknown argument", breaking aionrs MCP detection.

> Note: aionrs is used here as an **external CLI** (same as the Claude/Codex/Gemini adapters, resolved via `$PATH`) and is not bundled with AionUi.app. This repo's **library dependency** on aionrs (via git tag) is unaffected.

## Changes

`get_config_path` now tries the **new subcommand first and falls back to the legacy flag**, so both old and new aionrs CLI versions keep working:

1. Try `aionrs config path` (new) via `run_cli` (tolerating a non-zero exit) so an old CLI that rejects the subcommand falls through instead of erroring out.
2. On failure or empty output, fall back to `aionrs --config-path` (legacy) via `run_cli_strict`.
3. Only return `AgentOperationFailed` if both fail.

The fallback branch can be removed once the legacy aionrs versions are fully retired.

## Verification

- `cargo build -p aionui-mcp` / `cargo clippy -p aionui-mcp --all-targets -- -D warnings` (zero warnings)
- `cargo test -p aionui-mcp`: all pass
- `just push` gate: fmt + clippy + workspace test (6624 tests) all pass

## Related

- aionrs side: https://github.com/iOfficeAI/aionrs/pull/184