### PR TITLE
fix: preserve ACP config catalogs on resume

### DIFF
--- a/crates/aionui-ai-agent/src/manager/acp/session.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session.rs
@@ -595,8 +595,26 @@ impl AcpSession {
     }
 
     pub fn apply_advertised_modes(&mut self, modes: SessionModeState) {
+        let incoming_mode_catalog_count = modes.available_modes.len();
+        let existing_mode_catalog_count = self
+            .advertised
+            .modes
+            .as_ref()
+            .map_or(0, |modes| modes.available_modes.len());
+        let modes = self.preserve_existing_mode_catalog_if_empty(modes);
+        let final_mode_catalog_count = modes.available_modes.len();
         let new_id = ModeId::new(modes.current_mode_id.to_string());
         let changed = self.observed.mode_id.as_ref() != Some(&new_id);
+        if incoming_mode_catalog_count == 0
+            && existing_mode_catalog_count > 0
+            && final_mode_catalog_count == existing_mode_catalog_count
+        {
+            tracing::debug!(
+                current_mode = %new_id,
+                preserved_mode_catalog_count = final_mode_catalog_count,
+                "ACP advertised modes kept existing catalog for empty runtime update"
+            );
+        }
         self.observed.mode_id = Some(new_id.clone());
         self.advertised.modes = Some(modes);
         if changed {
@@ -606,14 +624,52 @@ impl AcpSession {
     }
 
     pub fn apply_advertised_models(&mut self, models: SessionModelState) {
+        let incoming_model_catalog_count = models.available_models.len();
+        let existing_model_catalog_count = self
+            .advertised
+            .models
+            .as_ref()
+            .map_or(0, |models| models.available_models.len());
+        let models = self.preserve_existing_model_catalog_if_empty(models);
+        let final_model_catalog_count = models.available_models.len();
         let new_id = ModelId::new(models.current_model_id.to_string());
         let changed = self.observed.model_id.as_ref() != Some(&new_id);
+        if incoming_model_catalog_count == 0
+            && existing_model_catalog_count > 0
+            && final_model_catalog_count == existing_model_catalog_count
+        {
+            tracing::debug!(
+                current_model = %new_id,
+                preserved_model_catalog_count = final_model_catalog_count,
+                "ACP advertised models kept existing catalog for empty runtime update"
+            );
+        }
         self.observed.model_id = Some(new_id.clone());
         self.advertised.models = Some(models);
         if changed {
             self.pending_events
                 .push(AcpSessionEvent::ObservedModelSynced { model: new_id });
         }
+    }
+
+    fn preserve_existing_mode_catalog_if_empty(&self, mut modes: SessionModeState) -> SessionModeState {
+        if modes.available_modes.is_empty()
+            && let Some(existing) = self.advertised.modes.as_ref()
+            && !existing.available_modes.is_empty()
+        {
+            modes.available_modes.clone_from(&existing.available_modes);
+        }
+        modes
+    }
+
+    fn preserve_existing_model_catalog_if_empty(&self, mut models: SessionModelState) -> SessionModelState {
+        if models.available_models.is_empty()
+            && let Some(existing) = self.advertised.models.as_ref()
+            && !existing.available_models.is_empty()
+        {
+            models.available_models.clone_from(&existing.available_models);
+        }
+        models
     }
 
     fn preserve_desired_model_in_catalog(&self, models: SessionModelState) -> SessionModelState {
@@ -717,11 +773,23 @@ impl AcpSession {
     /// Called on resume paths before the CLI session/load response arrives.
     pub fn preload_persisted(&mut self, state: &PersistedSessionState) {
         if let Some(mode) = &state.current_mode_id {
-            self.advertised.modes = Some(SessionModeState::new(mode.as_str().to_owned(), Vec::new()));
+            let available_modes = self
+                .advertised
+                .modes
+                .as_ref()
+                .map(|modes| modes.available_modes.clone())
+                .unwrap_or_default();
+            self.advertised.modes = Some(SessionModeState::new(mode.as_str().to_owned(), available_modes));
             self.observed.mode_id = Some(mode.clone());
         }
         if let Some(model) = &state.current_model_id {
-            self.advertised.models = Some(SessionModelState::new(model.as_str().to_owned(), Vec::new()));
+            let available_models = self
+                .advertised
+                .models
+                .as_ref()
+                .map(|models| models.available_models.clone())
+                .unwrap_or_default();
+            self.advertised.models = Some(SessionModelState::new(model.as_str().to_owned(), available_models));
             self.observed.model_id = Some(model.clone());
         }
         if !state.config_selections.is_empty() {

--- a/crates/aionui-ai-agent/src/manager/acp/session_config_snapshot_tests.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session_config_snapshot_tests.rs
@@ -91,6 +91,130 @@ fn config_snapshot_supplements_missing_mode_from_preloaded_catalog_using_desired
 }
 
 #[test]
+fn config_snapshot_keeps_preloaded_mode_catalog_when_resume_load_advertises_empty_modes() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+    session.preload_persisted(&PersistedSessionState {
+        current_mode_id: Some(ModeId::new("full-access")),
+        ..Default::default()
+    });
+    session.preload_advertised_catalogs(
+        Some(SessionModeState::new(
+            "auto",
+            vec![
+                SessionMode::new("read-only", "Read Only"),
+                SessionMode::new("auto", "Default"),
+                SessionMode::new("full-access", "Full Access"),
+            ],
+        )),
+        None,
+    );
+
+    session.apply_advertised_modes(SessionModeState::new("full-access", Vec::new()));
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "reasoning_effort",
+            "Reasoning Effort",
+            "high",
+            vec![SessionConfigSelectOption::new("high", "High")],
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel),
+    ]);
+
+    let snapshot = session.config_snapshot();
+    let mode = snapshot_option(&snapshot, "mode");
+    assert_eq!(mode.current_value.as_deref(), Some("full-access"));
+    assert_eq!(mode.options.len(), 3);
+    assert_eq!(
+        resolve_set_path(&snapshot, "mode", "read-only"),
+        Ok(ConfigSetPath::LegacyMode)
+    );
+}
+
+#[test]
+fn persisted_preload_keeps_catalogs_preloaded_from_metadata() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+    session.preload_advertised_catalogs(
+        Some(SessionModeState::new(
+            "auto",
+            vec![
+                SessionMode::new("read-only", "Read Only"),
+                SessionMode::new("auto", "Default"),
+                SessionMode::new("full-access", "Full Access"),
+            ],
+        )),
+        Some(SessionModelState::new(
+            "gpt-5.4",
+            vec![
+                ModelInfo::new("gpt-5.4", "GPT-5.4"),
+                ModelInfo::new("gpt-5.5", "GPT-5.5"),
+            ],
+        )),
+    );
+
+    session.preload_persisted(&PersistedSessionState {
+        current_mode_id: Some(ModeId::new("full-access")),
+        current_model_id: Some(ModelId::new("gpt-5.5")),
+        ..Default::default()
+    });
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "reasoning_effort",
+            "Reasoning Effort",
+            "high",
+            vec![SessionConfigSelectOption::new("high", "High")],
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel),
+    ]);
+
+    let snapshot = session.config_snapshot();
+    let mode = snapshot_option(&snapshot, "mode");
+    assert_eq!(mode.current_value.as_deref(), Some("full-access"));
+    assert_eq!(mode.options.len(), 3);
+    let model = snapshot_option(&snapshot, "model");
+    assert_eq!(model.current_value.as_deref(), Some("gpt-5.5"));
+    assert_eq!(model.options.len(), 2);
+}
+
+#[test]
+fn config_snapshot_keeps_preloaded_model_catalog_when_resume_load_advertises_empty_models() {
+    let mut session = AcpSession::new(None, None, HashMap::new());
+    session.preload_persisted(&PersistedSessionState {
+        current_model_id: Some(ModelId::new("gpt-5.5")),
+        ..Default::default()
+    });
+    session.preload_advertised_catalogs(
+        None,
+        Some(SessionModelState::new(
+            "gpt-5.4",
+            vec![
+                ModelInfo::new("gpt-5.4", "GPT-5.4"),
+                ModelInfo::new("gpt-5.5", "GPT-5.5"),
+            ],
+        )),
+    );
+
+    session.apply_advertised_models(SessionModelState::new("gpt-5.5", Vec::new()));
+    session.apply_advertised_config_options(vec![
+        SessionConfigOption::select(
+            "reasoning_effort",
+            "Reasoning Effort",
+            "high",
+            vec![SessionConfigSelectOption::new("high", "High")],
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel),
+    ]);
+
+    let snapshot = session.config_snapshot();
+    let model = snapshot_option(&snapshot, "model");
+    assert_eq!(model.current_value.as_deref(), Some("gpt-5.5"));
+    assert_eq!(model.options.len(), 2);
+    assert_eq!(
+        resolve_set_path(&snapshot, "model", "gpt-5.4"),
+        Ok(ConfigSetPath::LegacyModel)
+    );
+}
+
+#[test]
 fn preload_advertised_catalogs_reports_seeded_catalog_counts() {
     let mut session = AcpSession::new(None, None, HashMap::new());
 


### PR DESCRIPTION
## Summary
- Preserve preloaded ACP mode and model catalogs when persisted resume state supplies only current values.
- Keep existing non-empty catalogs when runtime resume updates advertise empty mode/model catalogs.
- Add regression coverage for resume/load catalog preservation and config option synthesis.

## Test Plan
- cargo fmt --all -- --check
- cargo clippy -p aionui-ai-agent -- -D warnings
- cargo test -p aionui-ai-agent
- just push -u origin work/acp-config-options-resume-fix