### PR TITLE
fix(agent): align unchecked availability with team runtime selection

### DIFF
--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -644,20 +644,31 @@ fn apply_cached_availability(meta: &mut AgentMetadata) -> Option<UnavailableReas
         meta.available = true;
         return None;
     }
-    if meta.command.as_deref().filter(|s| !s.is_empty()).is_none() {
-        meta.available = false;
-        return Some(UnavailableReason::NoCommand);
-    }
     if cached_snapshot_indicates_missing(meta) {
         meta.available = false;
         return cached_unavailable_reason(meta);
     }
     if !has_availability_snapshot(meta) {
         meta.available = false;
-        return None;
+        return if is_builtin_managed_agent(meta) {
+            None
+        } else if meta.command.as_deref().filter(|s| !s.is_empty()).is_none() {
+            Some(UnavailableReason::NoCommand)
+        } else {
+            None
+        };
     }
     meta.available = true;
     None
+}
+
+fn is_builtin_managed_agent(meta: &AgentMetadata) -> bool {
+    meta.agent_source == AgentSource::Builtin
+        && meta
+            .backend
+            .as_deref()
+            .and_then(ManagedAcpToolId::from_backend)
+            .is_some()
 }
 
 fn has_availability_snapshot(meta: &AgentMetadata) -> bool {

--- a/crates/aionui-ai-agent/tests/agent_availability_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_availability_integration.rs
@@ -197,6 +197,70 @@ async fn hydrate_uses_persisted_availability_without_reprobing_path() {
 }
 
 #[tokio::test]
+async fn hydrate_uses_persisted_availability_for_commandless_managed_builtin() {
+    let db = init_database_memory().await.unwrap();
+    let repo: Arc<dyn IAgentMetadataRepository> = Arc::new(SqliteAgentMetadataRepository::new(db.pool().clone()));
+
+    repo.upsert(&UpsertAgentMetadataParams {
+        id: "agent-managed-cached",
+        icon: None,
+        name: "Managed Cached Agent",
+        name_i18n: None,
+        description: None,
+        description_i18n: None,
+        backend: Some("claude"),
+        agent_type: "acp",
+        agent_source: "builtin",
+        agent_source_info: Some(r#"{"binary_name":"claude"}"#),
+        enabled: true,
+        command: None,
+        args: Some("[]"),
+        env: Some("[]"),
+        native_skills_dirs: None,
+        behavior_policy: None,
+        yolo_id: None,
+        agent_capabilities: None,
+        auth_methods: None,
+        config_options: None,
+        available_modes: None,
+        available_models: None,
+        available_commands: None,
+        sort_order: 100,
+    })
+    .await
+    .unwrap();
+    repo.update_availability_snapshot(
+        "agent-managed-cached",
+        &UpdateAgentAvailabilitySnapshotParams {
+            last_check_status: Some("online"),
+            last_check_kind: Some("manual"),
+            last_check_error_code: None,
+            last_check_error_message: None,
+            last_check_guidance: None,
+            last_check_latency_ms: Some(120),
+            last_check_at: Some(1_750_000_100_000),
+            last_success_at: Some(1_750_000_100_000),
+            last_failure_at: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let registry = AgentRegistry::new(repo);
+    registry.hydrate().await.unwrap();
+
+    let rows = registry.list_management_rows().await;
+    let cached = rows.iter().find(|row| row.id == "agent-managed-cached").unwrap();
+
+    assert_eq!(cached.status, AgentManagementStatus::Online);
+    assert!(
+        cached.installed,
+        "managed builtin should trust persisted online snapshot"
+    );
+    assert_eq!(cached.last_check_status, Some(AgentSnapshotCheckStatus::Online));
+}
+
+#[tokio::test]
 async fn management_list_uses_cached_availability_without_reprobing_path() {
     let db = init_database_memory().await.unwrap();
     let repo: Arc<dyn IAgentMetadataRepository> = Arc::new(SqliteAgentMetadataRepository::new(db.pool().clone()));

--- a/crates/aionui-app/assets/builtin-skills/aionui-config/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/aionui-config/SKILL.md
@@ -115,7 +115,7 @@ Key fields in the create/update body:
 | Field | Meaning |
 | --- | --- |
 | `name`, `description` | display text (required: name) |
-| `agent_id` | **engine binding** — the id of an installed agent (see "Picking the engine" below). This, not `preset_agent_type`, is what actually sets the engine |
+| `agent_id` | **engine binding** — the id of an agent row from `/api/agents/management` (see "Picking the engine" below). This, not `preset_agent_type`, is what actually sets the engine |
 | `preset_agent_type` | display/i18n hint only; does **not** bind the engine in the current backend |
 | `prompts` | quick-start prompts shown on the assistant (NOT the system prompt) |
 | `avatar` | emoji, image URL, `data:` URI, or absolute local path |
@@ -133,8 +133,8 @@ Key fields in the create/update body:
 ### Picking the engine (`agent_id`)
 
 The engine is bound by the request-body field **`agent_id`**, whose value is an
-installed agent's id — not a friendly name like `"claude"`. Read the available
-agents first and copy the id you want:
+agent row id from `/api/agents/management` — not a friendly name like
+`"claude"`. Read the engine catalog first and copy the id you want:
 
 ```bash
 # the LIST response is flat — each row carries agent_id + agent directly:
@@ -562,16 +562,19 @@ python3 scripts/aionui_api.py get /api/settings/client   # confirm — PUT retur
 
 ## Engines (agents)
 
-`GET /api/agents/management` lists the available engines (`aionrs`, `claude`,
+`GET /api/agents/management` lists the engine catalog (`aionrs`, `claude`,
 `codex`, …). There is **no** bare `GET /api/agents` — that path 404s; always use
 the `/management` sub-path. Each row is rich: alongside `id`, `name`, `enabled`
-(toggled on), `installed` (spawn command resolvable on `$PATH`), `team_capable`
+(toggled on), `installed` (diagnostic spawn-command state), `team_capable`
 (can run in a team), `backend`, `agent_type`, and a `status` of `online` /
 `offline` / `missing` / `unchecked`, it also carries `config_options`,
 `available_modes`, `available_models` (when the engine advertises them), plus
-`last_check_*` diagnostics. `unchecked` means no persisted connectivity check has
-run for that row yet. Check `installed` (and `status`) before binding an
-assistant to that engine (via its `agent_id` — see *Picking the engine* above).
+`last_check_*` diagnostics. Treat `status` as the selection source of truth:
+`online` is verified usable, `unchecked` has not been probed yet and is still
+valid to bind/select, while `missing` and `offline` are known unusable until
+repaired or rechecked. `installed` is legacy/diagnostic; do not use it by itself
+to decide whether an assistant may bind to an engine because startup no longer
+performs full availability probes.
 
 The management row is the supported engine catalog surface. Do not call legacy
 agent refresh endpoints; connectivity checks are explicit per-agent operations.

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -42,8 +42,8 @@ use aionui_system::{
     ProviderService, RuntimePrepareService, SettingsService, SystemRouterState, VersionCheckService,
 };
 use aionui_team::{
-    AgentTurnCancellationPort, AgentTurnExecutionPort, TeamConversationProvisioningPort, TeamProjectionMessageStore,
-    TeamRouterState, TeamSessionService,
+    AgentTurnCancellationPort, AgentTurnExecutionPort, TeamAssistantCatalogEntry, TeamAssistantCatalogPort,
+    TeamConversationProvisioningPort, TeamProjectionMessageStore, TeamRouterState, TeamSessionService,
 };
 
 use crate::config::derive_encryption_key;
@@ -270,7 +270,12 @@ pub async fn build_module_states(
         skill: skill_state,
         channel: channel_state,
         team: build_module_state_phase(&boot, "team", || {
-            build_team_state(services, Some(cron.cron_service.clone()), backend_binary_path.clone())
+            build_team_state(
+                services,
+                Some(cron.cron_service.clone()),
+                backend_binary_path.clone(),
+                assistant.service.clone(),
+            )
         }),
         cron,
         office: build_module_state_phase(&boot, "office", || build_office_state(services)),
@@ -568,7 +573,46 @@ pub fn build_team_state(
     services: &AppServices,
     _cron_service: Option<Arc<aionui_cron::service::CronService>>,
     backend_binary_path: Arc<std::path::PathBuf>,
+    assistant_service: Arc<AssistantService>,
 ) -> TeamRouterState {
+    #[derive(Clone)]
+    struct AssistantServiceTeamCatalog {
+        assistant_service: Arc<AssistantService>,
+    }
+
+    #[async_trait::async_trait]
+    impl TeamAssistantCatalogPort for AssistantServiceTeamCatalog {
+        async fn list_team_selectable_assistants(
+            &self,
+        ) -> Result<Vec<TeamAssistantCatalogEntry>, aionui_team::TeamError> {
+            let assistants = self.assistant_service.list().await.map_err(|error| {
+                aionui_team::TeamError::InvalidRequest(format!("assistant catalog unavailable: {error}"))
+            })?;
+
+            Ok(assistants
+                .into_iter()
+                .filter(|assistant| assistant.team_selectable)
+                .filter_map(|assistant| {
+                    let agent = assistant.agent?;
+                    let backend = agent
+                        .acp_backend
+                        .unwrap_or_else(|| agent.r#type.serde_name().to_owned());
+                    Some(TeamAssistantCatalogEntry {
+                        assistant_id: assistant.id,
+                        name: assistant.name,
+                        backend,
+                        description: assistant.description.unwrap_or_default(),
+                        skills: assistant
+                            .enabled_skills
+                            .into_iter()
+                            .chain(assistant.custom_skill_names)
+                            .collect(),
+                    })
+                })
+                .collect())
+        }
+    }
+
     let pool = services.database.pool().clone();
     let team_repo: Arc<dyn aionui_db::ITeamRepository> = Arc::new(aionui_db::SqliteTeamRepository::new(pool.clone()));
     let conv_service = services.conversation_service.clone();
@@ -585,6 +629,7 @@ pub fn build_team_state(
     let service = TeamSessionService::new(
         team_repo,
         Arc::new(SqliteAgentMetadataRepository::new(services.database.pool().clone())),
+        Arc::new(AssistantServiceTeamCatalog { assistant_service }),
         Arc::new(SqliteAssistantDefinitionRepository::new(
             services.database.pool().clone(),
         )),

--- a/crates/aionui-app/tests/team_e2e.rs
+++ b/crates/aionui-app/tests/team_e2e.rs
@@ -2,9 +2,12 @@ mod common;
 
 use aionui_db::{IConversationRepository, MessagePageDirection, MessagePageParams};
 use axum::http::StatusCode;
-use serde_json::json;
+use serde_json::{Value, json};
+use tokio::net::TcpStream;
 use tower::ServiceExt;
 
+use aionui_api_types::TeamMcpStdioConfig;
+use aionui_team::mcp::protocol::{read_frame, write_frame};
 use common::{
     body_json, build_app, build_app_with_mock_agents, delete_with_token, get_request, get_with_token, json_with_token,
     setup_and_login,
@@ -59,6 +62,56 @@ async fn create_team(app: &mut axum::Router, token: &str, csrf: &str) -> serde_j
     let json = body_json(resp).await;
     assert!(json["success"].as_bool().unwrap());
     json["data"].clone()
+}
+
+async fn mcp_send(stream: &mut TcpStream, req: &Value) {
+    let bytes = serde_json::to_vec(req).unwrap();
+    write_frame(stream, &bytes).await.unwrap();
+}
+
+async fn mcp_recv(stream: &mut TcpStream) -> Value {
+    let frame = read_frame(stream).await.unwrap();
+    serde_json::from_slice(&frame).unwrap()
+}
+
+async fn mcp_connect(port: u16, auth_token: &str, slot_id: &str) -> TcpStream {
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .expect("tcp connect to TeamMcpServer");
+    let init_req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "auth_token": auth_token,
+            "slot_id": slot_id,
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "app-team-e2e", "version": "0.1" }
+        }
+    });
+    mcp_send(&mut stream, &init_req).await;
+    let resp = mcp_recv(&mut stream).await;
+    assert!(
+        resp["result"]["serverInfo"]["name"].is_string(),
+        "initialize failed: {resp}"
+    );
+    stream
+}
+
+async fn mcp_call_tool(stream: &mut TcpStream, id: u64, tool: &str, args: Value) -> Value {
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": { "name": tool, "arguments": args }
+    });
+    mcp_send(stream, &req).await;
+    mcp_recv(stream).await
+}
+
+fn mcp_text(resp: &Value) -> &str {
+    resp["result"]["content"][0]["text"].as_str().unwrap_or("")
 }
 
 // ===========================================================================
@@ -890,6 +943,88 @@ async fn es1_ensure_session() {
     );
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn es1b_team_mcp_list_assistants_matches_assistant_projection() {
+    let (mut app, services) = build_app_with_mock_agents().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let data = create_team(&mut app, &token, &csrf).await;
+    let team_id = data["id"].as_str().unwrap();
+    let lead = &data["assistants"][0];
+    let lead_conversation_id = lead["conversation_id"].as_str().unwrap();
+    let lead_slot_id = lead["slot_id"].as_str().unwrap();
+
+    let assistants_resp = app
+        .clone()
+        .oneshot(get_with_token("/api/assistants", &token))
+        .await
+        .unwrap();
+    assert_eq!(assistants_resp.status(), StatusCode::OK);
+    let assistants_body = body_json(assistants_resp).await;
+    let mut expected_ids: Vec<String> = assistants_body["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|assistant| assistant["team_selectable"].as_bool().unwrap_or(false))
+        .filter(|assistant| assistant["agent"].is_object())
+        .map(|assistant| assistant["id"].as_str().unwrap().to_owned())
+        .collect();
+    expected_ids.sort();
+    assert!(
+        !expected_ids.is_empty(),
+        "fixture must expose at least one team-selectable assistant via /api/assistants: {assistants_body}"
+    );
+    assert!(
+        expected_ids.contains(&DEFAULT_TEAM_ASSISTANT_ID.to_owned()),
+        "seeded team assistant must be team-selectable in assistant projection: {assistants_body}"
+    );
+
+    let ensure_req = json_with_token(
+        "POST",
+        &format!("/api/teams/{team_id}/session"),
+        json!({}),
+        &token,
+        &csrf,
+    );
+    let ensure_resp = app.clone().oneshot(ensure_req).await.unwrap();
+    assert_eq!(ensure_resp.status(), StatusCode::OK);
+
+    let lead_conversation = services
+        .conversation_repo
+        .get(lead_conversation_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let extra: Value = serde_json::from_str(&lead_conversation.extra).unwrap();
+    let mcp_config: TeamMcpStdioConfig =
+        serde_json::from_value(extra["team_mcp_stdio_config"].clone()).expect("team mcp config");
+    assert_eq!(mcp_config.slot_id, lead_slot_id);
+
+    let mut stream = mcp_connect(mcp_config.port, &mcp_config.token, &mcp_config.slot_id).await;
+    let list_resp = mcp_call_tool(&mut stream, 2, "team_list_assistants", json!({})).await;
+    assert!(
+        !list_resp["result"]["isError"].as_bool().unwrap_or(false),
+        "team_list_assistants failed: {list_resp}"
+    );
+    let list_body: Value = serde_json::from_str(mcp_text(&list_resp)).expect("team_list_assistants JSON");
+    let mut runtime_ids: Vec<String> = list_body["assistants"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|assistant| assistant["assistant_id"].as_str().unwrap().to_owned())
+        .collect();
+    runtime_ids.sort();
+
+    assert_eq!(
+        runtime_ids, expected_ids,
+        "Team MCP runtime assistant list must match /api/assistants team_selectable projection"
+    );
+
+    let stop_req = delete_with_token(&format!("/api/teams/{team_id}/session"), &token, &csrf);
+    let stop_resp = app.oneshot(stop_req).await.unwrap();
+    assert_eq!(stop_resp.status(), StatusCode::OK);
 }
 
 // ES-2: Ensure session is idempotent

--- a/crates/aionui-assistant/src/service.rs
+++ b/crates/aionui-assistant/src/service.rs
@@ -364,7 +364,10 @@ impl AssistantService {
             .filter(|row| {
                 row.enabled
                     && row.agent_type.supports_new_conversation()
-                    && matches!(row.status, AgentManagementStatus::Online)
+                    && matches!(
+                        row.status,
+                        AgentManagementStatus::Online | AgentManagementStatus::Unchecked
+                    )
             })
             .collect();
         let missing_generated_count = generated_rows
@@ -2270,7 +2273,12 @@ fn assistant_projection_for_definition(
         agent_status,
         agent_status_message,
         team_selectable: enabled
-            && agent_row.is_some_and(|row| matches!(row.status, AgentManagementStatus::Online) && row.team_capable),
+            && agent_row.is_some_and(|row| {
+                matches!(
+                    row.status,
+                    AgentManagementStatus::Online | AgentManagementStatus::Unchecked
+                ) && row.team_capable
+            }),
         team_block_reason,
         deletable: matches!(source, AssistantSource::User),
     }
@@ -3114,6 +3122,36 @@ mod tests {
         assert_eq!(detail.defaults.skills.mode, "fixed");
         assert!(detail.defaults.skills.value.is_empty());
         assert!(detail.capabilities.default_disabled_builtin_skill_ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn bootstrap_materializes_generated_assistant_from_unchecked_agent() {
+        let mut unchecked_row = mk_agent_row(
+            "agent-cursor",
+            "cursor",
+            aionui_api_types::AgentManagementStatus::Unchecked,
+        );
+        unchecked_row.last_check_status = None;
+        unchecked_row.last_check_kind = None;
+        unchecked_row.last_check_at = None;
+        unchecked_row.last_success_at = None;
+
+        let fx = fixture_with_options(FixtureOpts {
+            agent_rows: vec![unchecked_row],
+            ..Default::default()
+        })
+        .await;
+
+        let list = fx.service.list().await.unwrap();
+        let bare = list
+            .iter()
+            .find(|assistant| assistant.id == "bare:agent-cursor")
+            .expect("unchecked agent should be selectable as a generated assistant");
+        assert_eq!(bare.source, AssistantSource::Generated);
+        assert_eq!(bare.agent_id, "agent-cursor");
+        assert_eq!(bare.agent_status, aionui_api_types::AgentManagementStatus::Unchecked);
+        assert!(bare.team_selectable);
+        assert!(bare.agent_status_message.is_none());
     }
 
     #[tokio::test]

--- a/crates/aionui-team/src/lib.rs
+++ b/crates/aionui-team/src/lib.rs
@@ -37,8 +37,8 @@ pub use message_projection::{
 };
 pub use ports::{
     AgentTurnCancellationPort, AgentTurnExecutionError, AgentTurnExecutionPort, AgentTurnOutcome, AgentTurnRequest,
-    AgentTurnSource, AgentTurnStarted, AgentTurnStartedCallback, AgentTurnStatus, TeamConversationBindingLookup,
-    TeamConversationLookupPort,
+    AgentTurnSource, AgentTurnStarted, AgentTurnStartedCallback, AgentTurnStatus, TeamAssistantCatalogEntry,
+    TeamAssistantCatalogPort, TeamConversationBindingLookup, TeamConversationLookupPort,
 };
 
 pub use prompts::{build_lead_prompt, build_teammate_prompt, build_wake_payload};

--- a/crates/aionui-team/src/ports.rs
+++ b/crates/aionui-team/src/ports.rs
@@ -25,6 +25,20 @@ pub trait TeamConversationLookupPort: Send + Sync {
     ) -> Result<Option<TeamConversationBindingLookup>, TeamError>;
 }
 
+#[async_trait]
+pub trait TeamAssistantCatalogPort: Send + Sync {
+    async fn list_team_selectable_assistants(&self) -> Result<Vec<TeamAssistantCatalogEntry>, TeamError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TeamAssistantCatalogEntry {
+    pub assistant_id: String,
+    pub name: String,
+    pub backend: String,
+    pub description: String,
+    pub skills: Vec<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentTurnSource {
     Mailbox {

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -24,7 +24,7 @@ use crate::error::TeamError;
 use crate::event_loop::AgentLoopContext;
 use crate::events::{TEAM_CREATED_EVENT, TEAM_MCP_STATUS_EVENT, TEAM_REMOVED_EVENT, TEAM_RENAMED_EVENT};
 use crate::message_projection::TeamProjectionMessageStore;
-use crate::ports::{AgentTurnCancellationPort, AgentTurnExecutionPort};
+use crate::ports::{AgentTurnCancellationPort, AgentTurnExecutionPort, TeamAssistantCatalogPort};
 use crate::provisioning::{TeamAgentProvisioner, TeamConversationProvisioningPort};
 use crate::session::{AgentMessageQueueResult, TeamSession};
 use crate::types::{Team, TeamAgent};
@@ -45,6 +45,7 @@ struct SessionEntry {
 pub struct TeamSessionService {
     repo: Arc<dyn ITeamRepository>,
     agent_metadata_repo: Arc<dyn IAgentMetadataRepository>,
+    assistant_catalog: Arc<dyn TeamAssistantCatalogPort>,
     assistant_definition_repo: Arc<dyn IAssistantDefinitionRepository>,
     assistant_overlay_repo: Arc<dyn IAssistantOverlayRepository>,
     provider_repo: Arc<dyn IProviderRepository>,
@@ -77,6 +78,7 @@ impl TeamSessionService {
     pub fn new(
         repo: Arc<dyn ITeamRepository>,
         agent_metadata_repo: Arc<dyn IAgentMetadataRepository>,
+        assistant_catalog: Arc<dyn TeamAssistantCatalogPort>,
         assistant_definition_repo: Arc<dyn IAssistantDefinitionRepository>,
         assistant_overlay_repo: Arc<dyn IAssistantOverlayRepository>,
         provider_repo: Arc<dyn IProviderRepository>,
@@ -91,6 +93,7 @@ impl TeamSessionService {
         Arc::new_cyclic(|weak| Self {
             repo,
             agent_metadata_repo,
+            assistant_catalog,
             assistant_definition_repo,
             assistant_overlay_repo,
             provider_repo,

--- a/crates/aionui-team/src/service/spawn_support.rs
+++ b/crates/aionui-team/src/service/spawn_support.rs
@@ -2,9 +2,8 @@ use super::*;
 use aionui_api_types::BehaviorPolicy;
 use aionui_common::AgentType;
 use aionui_common::constants::{TEAM_CAPABLE_BACKENDS, has_mcp_capability};
-use aionui_db::models::{AgentMetadataRow, AssistantOverlayRow};
+use aionui_db::models::AgentMetadataRow;
 use aionui_db::{IAgentMetadataRepository, resolve_agent_binding_from_rows};
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::prompts::AvailableAssistant;
@@ -137,93 +136,23 @@ impl TeamSessionService {
     }
 
     /// Return all enabled assistants that can currently participate in team mode.
-    /// This is the assistant-first candidate source for the leader prompt.
+    /// This consumes the same assistant projection as the Team creation UI, so
+    /// `team_selectable` has a single source of truth.
     pub(crate) async fn list_team_selectable_assistants(&self) -> Vec<AvailableAssistant> {
-        let Ok(definitions) = self.assistant_definition_repo.list().await else {
-            return Vec::new();
-        };
-        let Ok(overlays) = self.assistant_overlay_repo.list().await else {
-            return Vec::new();
-        };
-        let Ok(agent_rows) = self.agent_metadata_repo.list_all().await else {
+        let Ok(assistants) = self.assistant_catalog.list_team_selectable_assistants().await else {
             return Vec::new();
         };
 
-        let overlay_by_definition: HashMap<&str, &AssistantOverlayRow> = overlays
-            .iter()
-            .map(|row| (row.assistant_definition_id.as_str(), row))
-            .collect();
-
-        let mut assistants: Vec<(i32, AvailableAssistant)> = Vec::new();
-
-        for definition in &definitions {
-            let Some(source) = (match definition.source.as_str() {
-                "builtin" | "generated" | "user" => Some(definition.source.as_str()),
-                _ => None,
-            }) else {
-                continue;
-            };
-            let overlay = overlay_by_definition.get(definition.id.as_str()).copied();
-            let enabled = overlay.is_none_or(|row| row.enabled);
-            if !enabled {
-                continue;
-            }
-
-            let effective_agent_id = overlay
-                .and_then(|row| row.agent_id_override.as_deref())
-                .filter(|value| !value.trim().is_empty())
-                .unwrap_or(definition.agent_id.as_str());
-            let effective_backend = resolve_runtime_backend(&self.agent_metadata_repo, effective_agent_id)
-                .await
-                .unwrap_or_else(|_| effective_agent_id.to_owned());
-
-            let agent_row = if source == "generated" {
-                definition
-                    .source_ref
-                    .as_deref()
-                    .and_then(|source_ref| agent_rows.iter().find(|row| row.id == source_ref))
-            } else {
-                agent_rows
-                    .iter()
-                    .find(|row| {
-                        row.backend.as_deref() == Some(effective_backend.as_str()) && row.agent_source != "custom"
-                    })
-                    .or_else(|| {
-                        agent_rows
-                            .iter()
-                            .find(|row| row.backend.as_deref() == Some(effective_backend.as_str()))
-                    })
-            };
-
-            let is_available = agent_row.is_some_and(|row| row.last_check_status.as_deref() != Some("unavailable"));
-            let is_team_capable = self.is_backend_team_capable(&effective_backend).await;
-            if !(is_available && is_team_capable) {
-                continue;
-            }
-
-            let mut skills = decode_string_list(&definition.default_skill_ids);
-            skills.extend(decode_string_list(&definition.custom_skill_names));
-
-            assistants.push((
-                overlay.map(|row| row.sort_order).unwrap_or(i32::MAX),
-                AvailableAssistant {
-                    assistant_id: definition.assistant_id.clone(),
-                    name: definition.name.clone(),
-                    backend: effective_backend.to_owned(),
-                    description: definition.description.clone().unwrap_or_default(),
-                    skills,
-                },
-            ));
-        }
-
-        assistants.sort_by(|(left_order, left), (right_order, right)| {
-            left_order
-                .cmp(right_order)
-                .then_with(|| left.name.cmp(&right.name))
-                .then_with(|| left.assistant_id.cmp(&right.assistant_id))
-        });
-
-        assistants.into_iter().map(|(_, assistant)| assistant).collect()
+        assistants
+            .into_iter()
+            .map(|assistant| AvailableAssistant {
+                assistant_id: assistant.assistant_id,
+                name: assistant.name,
+                backend: assistant.backend,
+                description: assistant.description,
+                skills: assistant.skills,
+            })
+            .collect()
     }
 
     /// Return the `team_list_models` response built from DB rows.
@@ -342,20 +271,17 @@ impl TeamSessionService {
     }
 }
 
-fn decode_string_list(raw: &str) -> Vec<String> {
-    serde_json::from_str::<Vec<String>>(raw).unwrap_or_default()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_utils::workspace_harness::{
         force_team_workspace, setup_with_factory_metadata_team_repo_and_conversation_repo, single_agent_team_request,
     };
-    use aionui_db::models::{AssistantDefinitionRow, AssistantOverlayRow, Provider};
+    use aionui_db::models::{AgentMetadataRow, AssistantDefinitionRow, AssistantOverlayRow, Provider};
     use aionui_db::{
-        DbError, IAssistantDefinitionRepository, IAssistantOverlayRepository, IProviderRepository,
-        UpsertAssistantDefinitionParams, UpsertAssistantOverlayParams,
+        DbError, IAgentMetadataRepository, IAssistantDefinitionRepository, IAssistantOverlayRepository,
+        IProviderRepository, UpdateAgentHandshakeParams, UpsertAgentMetadataParams, UpsertAssistantDefinitionParams,
+        UpsertAssistantOverlayParams,
     };
     use std::sync::Arc;
 
@@ -399,6 +325,45 @@ mod tests {
     }
 
     #[derive(Clone)]
+    struct MultiAssistantDefinitionRepo {
+        rows: Vec<AssistantDefinitionRow>,
+    }
+
+    #[async_trait::async_trait]
+    impl IAssistantDefinitionRepository for MultiAssistantDefinitionRepo {
+        async fn list(&self) -> Result<Vec<AssistantDefinitionRow>, DbError> {
+            Ok(self.rows.clone())
+        }
+
+        async fn get_by_assistant_id(&self, assistant_id: &str) -> Result<Option<AssistantDefinitionRow>, DbError> {
+            Ok(self.rows.iter().find(|row| row.assistant_id == assistant_id).cloned())
+        }
+
+        async fn get_by_id(&self, definition_id: &str) -> Result<Option<AssistantDefinitionRow>, DbError> {
+            Ok(self.rows.iter().find(|row| row.id == definition_id).cloned())
+        }
+
+        async fn get_by_source_ref(
+            &self,
+            _source: &str,
+            _source_ref: &str,
+        ) -> Result<Option<AssistantDefinitionRow>, DbError> {
+            Ok(None)
+        }
+
+        async fn upsert(
+            &self,
+            _params: &UpsertAssistantDefinitionParams<'_>,
+        ) -> Result<AssistantDefinitionRow, DbError> {
+            Err(DbError::Init("not implemented".into()))
+        }
+
+        async fn soft_delete(&self, _definition_id: &str, _deleted_at: i64) -> Result<bool, DbError> {
+            Ok(false)
+        }
+    }
+
+    #[derive(Clone)]
     struct SingleAssistantOverlayRepo {
         row: AssistantOverlayRow,
     }
@@ -411,6 +376,34 @@ mod tests {
 
         async fn list(&self) -> Result<Vec<AssistantOverlayRow>, DbError> {
             Ok(vec![self.row.clone()])
+        }
+
+        async fn upsert(&self, _params: &UpsertAssistantOverlayParams<'_>) -> Result<AssistantOverlayRow, DbError> {
+            Err(DbError::Init("not implemented".into()))
+        }
+
+        async fn delete(&self, _definition_id: &str) -> Result<bool, DbError> {
+            Ok(false)
+        }
+    }
+
+    #[derive(Clone)]
+    struct MultiAssistantOverlayRepo {
+        rows: Vec<AssistantOverlayRow>,
+    }
+
+    #[async_trait::async_trait]
+    impl IAssistantOverlayRepository for MultiAssistantOverlayRepo {
+        async fn get(&self, definition_id: &str) -> Result<Option<AssistantOverlayRow>, DbError> {
+            Ok(self
+                .rows
+                .iter()
+                .find(|row| row.assistant_definition_id == definition_id)
+                .cloned())
+        }
+
+        async fn list(&self) -> Result<Vec<AssistantOverlayRow>, DbError> {
+            Ok(self.rows.clone())
         }
 
         async fn upsert(&self, _params: &UpsertAssistantOverlayParams<'_>) -> Result<AssistantOverlayRow, DbError> {
@@ -470,6 +463,101 @@ mod tests {
         }
     }
 
+    struct RowsAgentMetadataRepo {
+        rows: Vec<AgentMetadataRow>,
+    }
+
+    #[async_trait::async_trait]
+    impl IAgentMetadataRepository for RowsAgentMetadataRepo {
+        async fn list_all(&self) -> Result<Vec<AgentMetadataRow>, DbError> {
+            Ok(self.rows.clone())
+        }
+
+        async fn get(&self, id: &str) -> Result<Option<AgentMetadataRow>, DbError> {
+            Ok(self.rows.iter().find(|row| row.id == id).cloned())
+        }
+
+        async fn find_by_source_and_name(
+            &self,
+            agent_source: &str,
+            name: &str,
+        ) -> Result<Option<AgentMetadataRow>, DbError> {
+            Ok(self
+                .rows
+                .iter()
+                .find(|row| row.agent_source == agent_source && row.name == name)
+                .cloned())
+        }
+
+        async fn find_builtin_by_backend(&self, backend: &str) -> Result<Option<AgentMetadataRow>, DbError> {
+            Ok(self
+                .rows
+                .iter()
+                .find(|row| row.agent_source == "builtin" && row.backend.as_deref() == Some(backend))
+                .cloned())
+        }
+
+        async fn upsert(&self, _params: &UpsertAgentMetadataParams<'_>) -> Result<AgentMetadataRow, DbError> {
+            Err(DbError::Init("not implemented".into()))
+        }
+
+        async fn apply_handshake(
+            &self,
+            _id: &str,
+            _params: &UpdateAgentHandshakeParams<'_>,
+        ) -> Result<Option<AgentMetadataRow>, DbError> {
+            Ok(None)
+        }
+
+        async fn update_availability_snapshot(
+            &self,
+            _id: &str,
+            _params: &aionui_db::models::UpdateAgentAvailabilitySnapshotParams<'_>,
+        ) -> Result<Option<AgentMetadataRow>, DbError> {
+            Ok(None)
+        }
+
+        async fn update_agent_overrides(
+            &self,
+            _id: &str,
+            _command_override: Option<&str>,
+            _env_override: Option<&str>,
+        ) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn set_enabled(&self, _id: &str, _enabled: bool) -> Result<bool, DbError> {
+            Ok(false)
+        }
+
+        async fn delete(&self, _id: &str) -> Result<bool, DbError> {
+            Ok(false)
+        }
+    }
+
+    struct RowsTeamAssistantCatalog {
+        rows: Vec<crate::ports::TeamAssistantCatalogEntry>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::ports::TeamAssistantCatalogPort for RowsTeamAssistantCatalog {
+        async fn list_team_selectable_assistants(
+            &self,
+        ) -> Result<Vec<crate::ports::TeamAssistantCatalogEntry>, TeamError> {
+            Ok(self.rows.clone())
+        }
+    }
+
+    fn team_assistant_entry(assistant_id: &str, name: &str, backend: &str) -> crate::ports::TeamAssistantCatalogEntry {
+        crate::ports::TeamAssistantCatalogEntry {
+            assistant_id: assistant_id.into(),
+            name: name.into(),
+            backend: backend.into(),
+            description: String::new(),
+            skills: Vec::new(),
+        }
+    }
+
     #[test]
     fn parse_agent_type_accepts_top_level_supported_runtimes() {
         assert_eq!(parse_agent_type("acp").unwrap(), AgentType::Acp);
@@ -493,6 +581,40 @@ mod tests {
     fn parse_agent_type_unknown_backend_returns_error() {
         let err = parse_agent_type("unknown").unwrap_err();
         assert!(matches!(err, TeamError::InvalidRequest(_)));
+    }
+
+    #[tokio::test]
+    async fn list_team_selectable_assistants_uses_assistant_projection_catalog() {
+        let (base, _, _, _) = setup_with_factory_metadata_team_repo_and_conversation_repo();
+        let svc = TeamSessionService::new(
+            base.repo.clone(),
+            Arc::new(RowsAgentMetadataRepo { rows: vec![] }),
+            Arc::new(RowsTeamAssistantCatalog {
+                rows: vec![team_assistant_entry(
+                    "assistant-unchecked",
+                    "Unchecked Assistant",
+                    "cursor",
+                )],
+            }),
+            Arc::new(MultiAssistantDefinitionRepo { rows: vec![] }),
+            Arc::new(MultiAssistantOverlayRepo { rows: vec![] }),
+            Arc::new(SingleProviderRepo { rows: vec![] }),
+            base.conversation_port.clone(),
+            base.projection_store.clone(),
+            base.broadcaster.clone(),
+            base.task_manager.clone(),
+            base.turn_port.clone(),
+            base.cancellation_port.clone(),
+            base.backend_binary_path.clone(),
+        );
+
+        let assistants = svc.list_team_selectable_assistants().await;
+        let ids: Vec<&str> = assistants
+            .iter()
+            .map(|assistant| assistant.assistant_id.as_str())
+            .collect();
+
+        assert_eq!(ids, vec!["assistant-unchecked"]);
     }
 
     #[tokio::test]
@@ -537,6 +659,7 @@ mod tests {
         let svc = TeamSessionService::new(
             svc.repo.clone(),
             svc.agent_metadata_repo.clone(),
+            Arc::new(RowsTeamAssistantCatalog { rows: vec![] }),
             Arc::new(SingleAssistantDefinitionRepo {
                 row: AssistantDefinitionRow {
                     id: "def-1".into(),

--- a/crates/aionui-team/src/test_utils.rs
+++ b/crates/aionui-team/src/test_utils.rs
@@ -221,7 +221,8 @@ pub(crate) mod workspace_harness {
 
     use crate::ports::{
         AgentTurnCancellationPort, AgentTurnExecutionError, AgentTurnExecutionPort, AgentTurnOutcome, AgentTurnRequest,
-        AgentTurnStarted, AgentTurnStatus, TeamConversationBindingLookup, TeamConversationLookupPort,
+        AgentTurnStarted, AgentTurnStatus, TeamAssistantCatalogEntry, TeamAssistantCatalogPort,
+        TeamConversationBindingLookup, TeamConversationLookupPort,
     };
     use crate::provisioning::{
         TeamConversationCreateRequest, TeamConversationCreateResult, TeamConversationProvisioningPort,
@@ -717,6 +718,15 @@ pub(crate) mod workspace_harness {
 
     struct EmptyAgentMetadataRepo;
 
+    struct EmptyTeamAssistantCatalog;
+
+    #[async_trait]
+    impl TeamAssistantCatalogPort for EmptyTeamAssistantCatalog {
+        async fn list_team_selectable_assistants(&self) -> Result<Vec<TeamAssistantCatalogEntry>, TeamError> {
+            Ok(Vec::new())
+        }
+    }
+
     #[async_trait]
     impl IAgentMetadataRepository for EmptyAgentMetadataRepo {
         async fn list_all(&self) -> Result<Vec<AgentMetadataRow>, DbError> {
@@ -921,6 +931,7 @@ pub(crate) mod workspace_harness {
         let svc = TeamSessionService::new(
             team_repo_dyn,
             Arc::new(EmptyAgentMetadataRepo),
+            Arc::new(EmptyTeamAssistantCatalog),
             Arc::new(EmptyAssistantDefinitionRepo),
             Arc::new(EmptyAssistantOverlayRepo),
             Arc::new(EmptyProviderRepo),

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -26,7 +26,8 @@ use aionui_realtime::EventBroadcaster;
 
 use aionui_team::ports::{
     AgentTurnCancellationPort, AgentTurnExecutionError, AgentTurnExecutionPort, AgentTurnOutcome, AgentTurnRequest,
-    AgentTurnStarted, AgentTurnStatus, TeamConversationBindingLookup, TeamConversationLookupPort,
+    AgentTurnStarted, AgentTurnStatus, TeamAssistantCatalogEntry, TeamAssistantCatalogPort,
+    TeamConversationBindingLookup, TeamConversationLookupPort,
 };
 use aionui_team::session::SpawnAgentRequest;
 use aionui_team::{
@@ -1086,6 +1087,15 @@ fn test_acp_build_options(conversation_id: String, workspace: String) -> BuildTa
     })
 }
 
+struct EmptyTeamAssistantCatalog;
+
+#[async_trait::async_trait]
+impl TeamAssistantCatalogPort for EmptyTeamAssistantCatalog {
+    async fn list_team_selectable_assistants(&self) -> Result<Vec<TeamAssistantCatalogEntry>, TeamError> {
+        Ok(Vec::new())
+    }
+}
+
 struct EmptyProviderRepo;
 
 #[async_trait::async_trait]
@@ -1274,6 +1284,7 @@ fn setup_with_factory_metadata_team_repo_and_conversation_repo(
     let svc = TeamSessionService::new(
         team_repo_dyn,
         agent_metadata_repo,
+        Arc::new(EmptyTeamAssistantCatalog),
         Arc::new(EmptyAssistantDefinitionRepo),
         Arc::new(EmptyAssistantOverlayRepo),
         provider_repo,
@@ -1313,6 +1324,7 @@ fn setup_with_factory_metadata_assistants_and_conversation_repo(
     let svc = TeamSessionService::new(
         team_repo_dyn,
         agent_metadata_repo,
+        Arc::new(EmptyTeamAssistantCatalog),
         assistant_definition_repo,
         assistant_overlay_repo,
         provider_repo,
@@ -1368,6 +1380,7 @@ fn setup_with_ports_metadata_assistants_and_conversation_repo(
     let svc = TeamSessionService::new(
         team_repo_dyn,
         agent_metadata_repo,
+        Arc::new(EmptyTeamAssistantCatalog),
         assistant_definition_repo,
         assistant_overlay_repo,
         provider_repo,
@@ -1402,6 +1415,7 @@ fn setup_with_recording_turn_port() -> (
     let svc = TeamSessionService::new(
         team_repo_dyn,
         Arc::new(StubAgentMetadataRepo::empty()),
+        Arc::new(EmptyTeamAssistantCatalog),
         Arc::new(EmptyAssistantDefinitionRepo),
         Arc::new(EmptyAssistantOverlayRepo),
         provider_repo,
@@ -1603,6 +1617,7 @@ fn setup_with_recording_broadcaster() -> (Arc<TeamSessionService>, Arc<Recording
     let svc = TeamSessionService::new(
         team_repo,
         agent_metadata_repo,
+        Arc::new(EmptyTeamAssistantCatalog),
         Arc::new(EmptyAssistantDefinitionRepo),
         Arc::new(EmptyAssistantOverlayRepo),
         provider_repo,


### PR DESCRIPTION
## Summary
- Align team runtime assistant selection with the selectable assistant projection used by the agent runtime.
- Preserve managed builtin cached availability behavior across session spawning and assistant listing.
- Update integration coverage for assistant projection and runtime selection behavior.

## Related PRs
- AionUi: https://github.com/iOfficeAI/AionUi/pull/3511

## Test Plan
- cargo fmt --all -- --check
- cargo clippy -p aionui-app -p aionui-team -p aionui-assistant -- -D warnings
- cargo test -p aionui-assistant
- cargo test -p aionui-team
- cargo test -p aionui-app --test team_e2e es1b_team_mcp_list_assistants_matches_assistant_projection -- --nocapture
- cargo build -p aionui-app --bin aioncore --features aionui-ai-agent/test-support
- AionUi 联动 e2e 已通过（另一个 repo）