### PR TITLE
fix(cron): preserve existing conversation jobs across lifecycle changes

### DIFF
--- a/crates/aionui-app/assets/builtin-skills/auto-inject/cron/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/auto-inject/cron/SKILL.md
@@ -31,7 +31,7 @@ You can manage scheduled tasks for the current conversation. Use the bundled HTT
 Create and update payloads use the same fields:
 
 - `name`: Short descriptive name.
-- `schedule`: Valid cron expression.
+- `schedule`: Standard 5-field cron expression.
 - `schedule_description`: Human-readable schedule.
 - `message`: Complete, self-contained instruction sent to the AI when the task runs.
 
@@ -93,3 +93,5 @@ Multiline message example:
 Format: `minute hour day-of-month month day-of-week`.
 
 Example: `0 9 * * MON-FRI` means weekdays at 9:00 AM.
+
+Use only standard cron fields and ranges supported by the backend parser. Do not use Quartz-style extensions such as `L`, `L-N`, `W`, `LW`, `#`, or `?`.

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -627,7 +627,8 @@ pub fn build_cron_state(services: &AppServices) -> CronRouterState {
         agent_metadata_repo.clone(),
         acp_session_repo,
     )
-    .with_runtime_state(services.conversation_runtime_state.clone());
+    .with_runtime_state(services.conversation_runtime_state.clone())
+    .with_runtime_helper_context(services.runtime_helper_bin(), services.runtime_base_url());
     conv_service.with_mcp_server_repo(Arc::new(aionui_db::SqliteMcpServerRepository::new(
         services.database.pool().clone(),
     )));
@@ -793,14 +794,16 @@ pub fn build_ws_state(services: &AppServices) -> WsHandlerState {
 mod tests {
     use super::*;
 
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
     use crate::AppConfig;
-    use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
+    use aionui_ai_agent::types::{AIONUI_BASE_URL_ENV, AIONUI_HELPER_BIN_ENV, BuildTaskOptions, SendMessageData};
     use aionui_ai_agent::{
         AgentError, AgentInstance, AgentSendError, AgentStreamEvent, IAgentTask, IMockAgent, IWorkerTaskManager,
         WorkerTaskManagerImpl,
     };
+    use aionui_api_types::{CreateConversationRequest, SendMessageRequest};
     use aionui_channel::types::PluginType;
     use aionui_common::{AgentKillReason, AgentType, ConversationStatus, TimestampMs};
     use aionui_db::models::{AssistantSessionRow, UpsertAssistantDefinitionParams};
@@ -868,6 +871,42 @@ mod tests {
         });
 
         Arc::new(WorkerTaskManagerImpl::new(factory))
+    }
+
+    fn capturing_worker_task_manager(
+        captured_env: Arc<Mutex<Vec<Vec<(String, String)>>>>,
+    ) -> Arc<dyn IWorkerTaskManager> {
+        let factory = Arc::new(move |opts: BuildTaskOptions| {
+            let captured_env = captured_env.clone();
+            Box::pin(async move {
+                let conversation_id = opts.conversation_id().to_owned();
+                let workspace = opts.context.workspace.path.clone();
+                captured_env.lock().unwrap().push(opts.context.runtime_env.clone());
+                Ok(AgentInstance::Mock(Arc::new(ChannelStateNoopAgent {
+                    conversation_id,
+                    workspace,
+                })))
+            }) as futures_util::future::BoxFuture<'static, Result<AgentInstance, AgentError>>
+        });
+
+        Arc::new(WorkerTaskManagerImpl::new(factory))
+    }
+
+    async fn wait_for_captured_env(captured_env: &Arc<Mutex<Vec<Vec<(String, String)>>>>) -> Vec<(String, String)> {
+        for _ in 0..50 {
+            if let Some(env) = captured_env.lock().unwrap().first().cloned() {
+                return env;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("expected task options to be captured");
+    }
+
+    fn make_send_message_request() -> SendMessageRequest {
+        serde_json::from_value(serde_json::json!({
+            "content": "Check runtime env"
+        }))
+        .unwrap()
     }
 
     fn channel_state_assistant_definition() -> UpsertAssistantDefinitionParams<'static> {
@@ -972,6 +1011,64 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(second.conversation_id, first.conversation_id);
+
+        services.database.close().await;
+    }
+
+    #[tokio::test]
+    async fn build_cron_state_conversation_service_injects_runtime_helper_context() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let config = AppConfig {
+            data_dir: tmp.path().join("data"),
+            work_dir: tmp.path().join("work"),
+            ..Default::default()
+        };
+        let db = aionui_db::init_database_memory().await.unwrap();
+        let captured_env = Arc::new(Mutex::new(Vec::new()));
+        let task_manager = capturing_worker_task_manager(captured_env.clone());
+        let services = AppServices::from_config(db, &config)
+            .await
+            .unwrap()
+            .with_worker_task_manager(task_manager.clone());
+        let cron = build_cron_state(&services);
+        let conversation = cron
+            .conversation_service
+            .create(
+                "system_default_user",
+                serde_json::from_value::<CreateConversationRequest>(serde_json::json!({
+                    "type": "acp",
+                    "extra": {
+                        "workspace": workspace,
+                        "custom_workspace": true
+                    }
+                }))
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        cron.conversation_service
+            .send_message(
+                "system_default_user",
+                &conversation.id,
+                make_send_message_request(),
+                &task_manager,
+            )
+            .await
+            .unwrap();
+
+        let env = wait_for_captured_env(&captured_env).await;
+        assert!(
+            env.iter()
+                .any(|(key, value)| key == AIONUI_HELPER_BIN_ENV && !value.is_empty()),
+            "cron conversation runtime env should include AIONUI_HELPER_BIN"
+        );
+        assert!(
+            env.contains(&(AIONUI_BASE_URL_ENV.to_owned(), config.local_base_url())),
+            "cron conversation runtime env should include AIONUI_BASE_URL"
+        );
 
         services.database.close().await;
     }

--- a/crates/aionui-app/src/services.rs
+++ b/crates/aionui-app/src/services.rs
@@ -57,6 +57,14 @@ pub struct AppServices {
 }
 
 impl AppServices {
+    pub(crate) fn runtime_helper_bin(&self) -> String {
+        self.runtime_helper_bin.clone()
+    }
+
+    pub(crate) fn runtime_base_url(&self) -> String {
+        self.runtime_base_url.clone()
+    }
+
     /// Replace the worker task manager after construction.
     ///
     /// Primarily used by tests to inject mock implementations.

--- a/crates/aionui-app/tests/cron_e2e.rs
+++ b/crates/aionui-app/tests/cron_e2e.rs
@@ -941,7 +941,7 @@ async fn rn1_run_now_returns_conversation_id_for_new_conversation_job() {
 }
 
 #[tokio::test]
-async fn rn1b_run_now_returns_conflict_when_conversation_is_busy() {
+async fn rn1b_run_now_returns_active_conversation_when_conversation_is_busy() {
     let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
@@ -979,14 +979,10 @@ async fn rn1b_run_now_returns_conflict_when_conversation_is_busy() {
         &csrf,
     );
     let resp = app.oneshot(req).await.unwrap();
-    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    assert_eq!(resp.status(), StatusCode::OK);
 
     let body = body_json(resp).await;
-    assert_eq!(body["code"], "CONFLICT");
-    assert!(
-        body["error"].as_str().unwrap_or_default().contains("already running"),
-        "busy run-now should surface conversation busy semantics"
-    );
+    assert_eq!(body["data"]["conversation_id"], json!(conversation_id));
 
     drop(claim);
 }

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -483,6 +483,14 @@ impl ConversationService {
         self.runtime_state.clone()
     }
 
+    pub fn auto_workspace_to_delete_for_row(
+        &self,
+        row: &aionui_db::models::ConversationRow,
+        conversation_id: &str,
+    ) -> Option<PathBuf> {
+        auto_provisioned_workspace_to_delete(&self.workspace_root, row, conversation_id)
+    }
+
     fn assistant_definition_repo(&self) -> Option<Arc<dyn IAssistantDefinitionRepository>> {
         self.assistant_definition_repo
             .read()

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -44,6 +44,11 @@ pub(crate) struct PreparedExecution {
     saved_skill: Option<SavedSkillContext>,
 }
 
+pub(crate) enum PreparedRunNow {
+    Ready(PreparedExecution),
+    AlreadyRunning { conversation_id: String },
+}
+
 struct SkillSuggestContext {
     conversation_id: String,
     job_id: String,
@@ -85,41 +90,52 @@ impl JobExecutor {
     }
 
     pub async fn execute(&self, job: &CronJob) -> ExecutionResult {
+        let prepared = match self.prepare_scheduled(job).await {
+            Ok(prepared) => prepared,
+            Err(result) => return result,
+        };
+
+        self.execute_prepared_scheduled(job, prepared).await
+    }
+
+    pub(crate) async fn prepare_scheduled(&self, job: &CronJob) -> Result<PreparedExecution, ExecutionResult> {
         let saved_skill = match self.prepare_saved_skill(job).await {
             Ok(skill) => skill,
             Err(e) => {
                 error!(job_id = %job.id, error = %e, "Failed to prepare saved cron skill");
-                return ExecutionResult::Error { message: e.to_string() };
+                return Err(ExecutionResult::Error { message: e.to_string() });
             }
         };
 
         if let Err(e) = self.validate_runtime_job_workspace(job).await {
             error!(job_id = %job.id, error = %e, "Failed cron workspace validation");
-            return ExecutionResult::Error { message: e.to_string() };
+            return Err(ExecutionResult::Error { message: e.to_string() });
         }
 
-        let target_conversation_id = match self.resolve_conversation(job, saved_skill.as_ref()).await {
+        let conversation_id = match self.resolve_conversation(job, saved_skill.as_ref()).await {
             Ok(id) => id,
             Err(e) => {
                 error!(job_id = %job.id, error = %e, "Failed to resolve conversation");
-                return ExecutionResult::Error { message: e.to_string() };
+                return Err(ExecutionResult::Error { message: e.to_string() });
             }
         };
 
-        if self.is_conversation_claimed(&target_conversation_id) {
+        if self.is_conversation_claimed(&conversation_id) {
             info!(
                 job_id = %job.id,
-                conversation_id = %target_conversation_id,
+                conversation_id = %conversation_id,
                 "Cron target conversation already has an active turn; scheduling retry"
             );
-            return self.handle_busy(job);
+            return Err(self.handle_busy(job));
         }
 
-        self.execute_inner(job, &target_conversation_id, saved_skill.as_ref())
-            .await
+        Ok(PreparedExecution {
+            conversation_id,
+            saved_skill,
+        })
     }
 
-    pub(crate) async fn prepare_run_now(&self, job: &CronJob) -> Result<PreparedExecution, CronError> {
+    pub(crate) async fn prepare_run_now(&self, job: &CronJob) -> Result<PreparedRunNow, CronError> {
         let saved_skill = match self.prepare_saved_skill(job).await {
             Ok(skill) => skill,
             Err(err) => {
@@ -139,21 +155,39 @@ impl JobExecutor {
             info!(
                 job_id = %job.id,
                 conversation_id = %conversation_id,
-                "Run-now rejected because target conversation already has an active turn"
+                "Run-now target conversation already has an active turn; returning it for navigation"
             );
-            return Err(CronError::Conversation(ConversationError::Busy {
-                reason: format!("conversation {conversation_id} is already running"),
-            }));
+            return Ok(PreparedRunNow::AlreadyRunning { conversation_id });
         }
 
-        Ok(PreparedExecution {
+        Ok(PreparedRunNow::Ready(PreparedExecution {
             conversation_id,
             saved_skill,
-        })
+        }))
     }
 
     pub(crate) async fn execute_prepared(&self, job: &CronJob, prepared: PreparedExecution) -> ExecutionResult {
         self.execute_inner_with_busy_retry(job, &prepared.conversation_id, prepared.saved_skill.as_ref(), false)
+            .await
+    }
+
+    pub(crate) async fn execute_prepared_scheduled(
+        &self,
+        job: &CronJob,
+        prepared: PreparedExecution,
+    ) -> ExecutionResult {
+        self.execute_inner_with_busy_retry(job, &prepared.conversation_id, prepared.saved_skill.as_ref(), true)
+            .await
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn execute_inner(
+        &self,
+        job: &CronJob,
+        conversation_id: &str,
+        saved_skill: Option<&SavedSkillContext>,
+    ) -> ExecutionResult {
+        self.execute_inner_with_busy_retry(job, conversation_id, saved_skill, true)
             .await
     }
 
@@ -178,6 +212,18 @@ impl JobExecutor {
             .get(conversation_id)
             .await
             .map_err(CronError::Database)
+    }
+
+    pub async fn auto_workspace_to_delete_for_conversation(
+        &self,
+        conversation_id: &str,
+    ) -> Result<Option<PathBuf>, CronError> {
+        let Some(row) = self.get_conversation_row(conversation_id).await? else {
+            return Ok(None);
+        };
+        Ok(self
+            .conversation_service
+            .auto_workspace_to_delete_for_row(&row, conversation_id))
     }
 
     pub async fn get_assistant_snapshot(
@@ -301,6 +347,44 @@ impl JobExecutor {
             .map_err(CronError::Database)
     }
 
+    pub async fn unbind_cron_job_from_conversation(
+        &self,
+        conversation_id: &str,
+        cron_job_id: &str,
+    ) -> Result<(), CronError> {
+        let Some(row) = self.get_conversation_row(conversation_id).await? else {
+            return Ok(());
+        };
+
+        let mut extra: serde_json::Value = serde_json::from_str(&row.extra).unwrap_or_else(|_| serde_json::json!({}));
+        let Some(obj) = extra.as_object_mut() else {
+            return Ok(());
+        };
+
+        let snake_matches = obj.get("cron_job_id").and_then(|value| value.as_str()) == Some(cron_job_id);
+        let camel_matches = obj.get("cronJobId").and_then(|value| value.as_str()) == Some(cron_job_id);
+        if !snake_matches && !camel_matches {
+            return Ok(());
+        }
+
+        if snake_matches {
+            obj.remove("cron_job_id");
+        }
+        if camel_matches {
+            obj.remove("cronJobId");
+        }
+
+        let update = ConversationRowUpdate {
+            extra: Some(extra.to_string()),
+            updated_at: Some(now_ms()),
+            ..Default::default()
+        };
+        self.conversation_repo
+            .update(conversation_id, &update)
+            .await
+            .map_err(CronError::Database)
+    }
+
     pub async fn persist_workspace_if_missing(
         &self,
         conversation_id: &str,
@@ -394,39 +478,46 @@ impl JobExecutor {
             ExecutionMode::Existing => {
                 // A job created without an anchor conversation (the frontend
                 // creates "continue-this-conversation" jobs from the cron page
-                // before any conversation exists) keeps `conversation_id`
-                // empty until the first run. Treat that first run as a new
-                // conversation; the service layer then persists the new id
-                // back onto the job so subsequent runs reuse it.
-                if job.conversation_id.trim().is_empty() {
-                    return self.create_new_conversation(job, saved_skill).await;
+                // before any conversation exists), or whose anchor was later
+                // deleted, materializes a replacement conversation on demand.
+                // The service layer then persists the new id back onto the job
+                // so subsequent runs reuse it.
+                let conversation_id = job.conversation_id.trim();
+                if conversation_id.is_empty() {
+                    return self
+                        .create_new_conversation(job, saved_skill, ConversationPurpose::ExistingReplacement)
+                        .await;
                 }
-                self.verify_conversation_exists(&job.conversation_id).await?;
+                if !self.conversation_exists(conversation_id).await? {
+                    warn!(
+                        job_id = %job.id,
+                        conversation_id,
+                        "Cron existing-mode conversation is missing; creating a replacement conversation"
+                    );
+                    return self
+                        .create_new_conversation(job, saved_skill, ConversationPurpose::ExistingReplacement)
+                        .await;
+                }
                 Ok(job.conversation_id.clone())
             }
-            ExecutionMode::NewConversation => self.create_new_conversation(job, saved_skill).await,
+            ExecutionMode::NewConversation => {
+                self.create_new_conversation(job, saved_skill, ConversationPurpose::NewConversationExecution)
+                    .await
+            }
         }
-    }
-
-    async fn verify_conversation_exists(&self, conversation_id: &str) -> Result<(), CronError> {
-        if !self.conversation_exists(conversation_id).await? {
-            return Err(CronError::Scheduler(format!(
-                "conversation {conversation_id} not found"
-            )));
-        }
-        Ok(())
     }
 
     async fn create_new_conversation(
         &self,
         job: &CronJob,
         saved_skill: Option<&SavedSkillContext>,
+        purpose: ConversationPurpose,
     ) -> Result<String, CronError> {
         let agent_type = parse_agent_type(&self.agent_registry, &job.agent_type).await?;
         let model = resolve_model(job);
         let user_id = self.resolve_conversation_owner_user_id(job).await?;
 
-        let extra = build_conversation_extra(&self.agent_registry, job, saved_skill).await;
+        let extra = build_conversation_extra(&self.agent_registry, job, saved_skill, purpose).await;
         let assistant = build_assistant_request(job);
 
         let req = CreateConversationRequest {
@@ -482,16 +573,6 @@ impl JobExecutor {
         }
 
         Ok(SYSTEM_DEFAULT_USER_ID.to_owned())
-    }
-
-    async fn execute_inner(
-        &self,
-        job: &CronJob,
-        conversation_id: &str,
-        saved_skill: Option<&SavedSkillContext>,
-    ) -> ExecutionResult {
-        self.execute_inner_with_busy_retry(job, conversation_id, saved_skill, true)
-            .await
     }
 
     async fn execute_inner_with_busy_retry(
@@ -976,19 +1057,28 @@ struct SavedSkillContext {
     raw_content: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConversationPurpose {
+    NewConversationExecution,
+    ExistingReplacement,
+}
+
 async fn build_conversation_extra(
     registry: &AgentRegistry,
     job: &CronJob,
     saved_skill: Option<&SavedSkillContext>,
+    purpose: ConversationPurpose,
 ) -> serde_json::Value {
     let assistant_backed = build_assistant_request(job).is_some();
     let mut extra = serde_json::Map::new();
     extra.insert("cron_job_id".to_owned(), serde_json::Value::String(job.id.clone()));
     extra.insert("cronJobId".to_owned(), serde_json::Value::String(job.id.clone()));
-    extra.insert(
-        "exclude_auto_inject_skills".to_owned(),
-        serde_json::Value::Array(vec![serde_json::Value::String("cron".to_owned())]),
-    );
+    if matches!(purpose, ConversationPurpose::NewConversationExecution) {
+        extra.insert(
+            "exclude_auto_inject_skills".to_owned(),
+            serde_json::Value::Array(vec![serde_json::Value::String("cron".to_owned())]),
+        );
+    }
 
     if let Some(saved_skill) = saved_skill {
         extra.insert(
@@ -1237,7 +1327,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prepare_run_now_returns_busy_error_when_runtime_state_is_already_claimed() {
+    async fn prepare_run_now_returns_active_conversation_when_runtime_state_is_already_claimed() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
         let executor = make_executor_with_agent(AgentInstance::Mock(agent));
         let job = sample_job();
@@ -1247,15 +1337,15 @@ mod tests {
             .try_claim_turn(&job.conversation_id, "turn-existing")
             .expect("runtime claim should succeed");
 
-        let err = executor
+        let prepared = executor
             .prepare_run_now(&job)
             .await
-            .expect_err("run-now should reject a claimed conversation");
+            .expect("run-now should return the claimed conversation");
 
         assert!(matches!(
-            err,
-            CronError::Conversation(ConversationError::Busy { reason })
-                if reason == format!("conversation {} is already running", job.conversation_id)
+            prepared,
+            PreparedRunNow::AlreadyRunning { conversation_id }
+                if conversation_id == job.conversation_id
         ));
 
         drop(claim);
@@ -1561,10 +1651,26 @@ mod tests {
             ..sample_job()
         };
 
-        let extra = build_conversation_extra(&registry, &job, None).await;
+        let extra =
+            build_conversation_extra(&registry, &job, None, ConversationPurpose::NewConversationExecution).await;
 
         assert_eq!(extra["cron_job_id"], "cron_test1");
         assert_eq!(extra["exclude_auto_inject_skills"], serde_json::json!(["cron"]));
+        assert!(extra.get("preset_enabled_skills").is_none());
+    }
+
+    #[tokio::test]
+    async fn build_conversation_extra_for_existing_replacement_keeps_cron_auto_inject() {
+        let registry = hydrated_registry().await;
+        let job = CronJob {
+            execution_mode: ExecutionMode::Existing,
+            ..sample_job()
+        };
+
+        let extra = build_conversation_extra(&registry, &job, None, ConversationPurpose::ExistingReplacement).await;
+
+        assert_eq!(extra["cron_job_id"], "cron_test1");
+        assert!(extra.get("exclude_auto_inject_skills").is_none());
         assert!(extra.get("preset_enabled_skills").is_none());
     }
 
@@ -1580,7 +1686,13 @@ mod tests {
             raw_content: "---\nname: test\ndescription: desc\n---\nDo X".into(),
         };
 
-        let extra = build_conversation_extra(&registry, &job, Some(&saved_skill)).await;
+        let extra = build_conversation_extra(
+            &registry,
+            &job,
+            Some(&saved_skill),
+            ConversationPurpose::NewConversationExecution,
+        )
+        .await;
 
         assert_eq!(extra["exclude_auto_inject_skills"], serde_json::json!(["cron"]));
         assert_eq!(extra["preset_enabled_skills"], serde_json::json!(["cron-cron_test1"]));
@@ -1596,7 +1708,8 @@ mod tests {
         config.is_preset = Some(true);
         config.custom_agent_id = None;
 
-        let extra = build_conversation_extra(&registry, &job, None).await;
+        let extra =
+            build_conversation_extra(&registry, &job, None, ConversationPurpose::NewConversationExecution).await;
 
         assert!(extra.get("assistant_id").is_none());
         assert!(extra.get("preset_assistant_id").is_none());
@@ -1628,7 +1741,8 @@ mod tests {
             ..sample_job()
         };
 
-        let extra = build_conversation_extra(&registry, &job, None).await;
+        let extra =
+            build_conversation_extra(&registry, &job, None, ConversationPurpose::NewConversationExecution).await;
 
         assert_eq!(
             extra["workspace"],
@@ -1646,7 +1760,8 @@ mod tests {
             ..sample_job()
         };
 
-        let extra = build_conversation_extra(&registry, &job, None).await;
+        let extra =
+            build_conversation_extra(&registry, &job, None, ConversationPurpose::NewConversationExecution).await;
 
         assert_eq!(extra["backend"], "claude");
     }

--- a/crates/aionui-cron/src/service.rs
+++ b/crates/aionui-cron/src/service.rs
@@ -15,12 +15,12 @@ use aionui_db::{
     IAgentMetadataRepository, IAssistantDefinitionRepository, IAssistantOverlayRepository, ICronRepository,
     UpdateCronJobParams, resolve_agent_binding_from_rows,
 };
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::events::CronEventEmitter;
 
 use crate::error::CronError;
-use crate::executor::{ExecutionResult, JobExecutor, RETRY_INTERVAL_MS};
+use crate::executor::{ExecutionResult, JobExecutor, PreparedRunNow, RETRY_INTERVAL_MS};
 use crate::scheduler::{CronScheduler, compute_next_run, validate_schedule};
 use crate::skill_file::{delete_skill_file, has_skill_file, write_raw_skill_file, write_skill_file};
 use crate::types::{
@@ -305,6 +305,9 @@ impl CronService {
         let mut job = cron_job_from_row(existing_row)?;
         job.agent_type = self.resolve_job_agent_type(&job).await?;
         let original_execution_mode = job.execution_mode;
+        let original_conversation_id = job.conversation_id.clone();
+        let mut clear_conversation_binding = false;
+        let mut agent_config_changed = false;
 
         if let Some(name) = &req.name {
             job.name = name.clone();
@@ -331,6 +334,11 @@ impl CronService {
                 ));
             }
             job.execution_mode = requested_mode;
+            if requested_mode != original_execution_mode && matches!(requested_mode, ExecutionMode::NewConversation) {
+                clear_conversation_binding = !job.conversation_id.trim().is_empty();
+                job.conversation_id.clear();
+                job.conversation_title = None;
+            }
         }
         if req.agent_config.is_some()
             && (matches!(original_execution_mode, ExecutionMode::Existing)
@@ -346,7 +354,9 @@ impl CronService {
             validate_aionrs_agent_config(&job.agent_type, Some(&config_dto))?;
             job.agent_config = Some(self.build_cron_agent_config(&job.agent_type, config_dto, None).await?);
         }
-        if let Some(title) = &req.conversation_title {
+        if let Some(title) = &req.conversation_title
+            && !clear_conversation_binding
+        {
             job.conversation_title = Some(title.clone());
         }
         if let Some(max_retries) = req.max_retries {
@@ -356,12 +366,40 @@ impl CronService {
         if req.schedule.is_some() || req.enabled.is_some() {
             job.next_run_at = compute_next_run(&job.schedule, now_ms());
         }
+        if clear_conversation_binding
+            && self
+                .clear_auto_workspace_from_job_config(&mut job, &original_conversation_id)
+                .await
+        {
+            agent_config_changed = true;
+        }
 
         job.updated_at = now_ms();
         self.validate_job_workspace(&job).await?;
 
-        let params = build_update_params(&job, &req);
+        let mut params = build_update_params(&job, &req);
+        if clear_conversation_binding {
+            params.conversation_id = Some(String::new());
+            params.conversation_title = Some(None);
+        }
+        if agent_config_changed {
+            params.agent_config = Some(job.agent_config.as_ref().map(serde_json::to_string).transpose()?);
+        }
         self.repo.update(job_id, &params).await?;
+
+        if clear_conversation_binding
+            && let Err(err) = self
+                .executor
+                .unbind_cron_job_from_conversation(&original_conversation_id, &job.id)
+                .await
+        {
+            warn!(
+                conversation_id = %original_conversation_id,
+                job_id = %job.id,
+                error = %err,
+                "Failed to remove cron job binding from previous conversation"
+            );
+        }
 
         self.bind_existing_conversation_if_needed(&job).await;
         self.scheduler.reschedule_job(&job);
@@ -423,7 +461,6 @@ impl CronService {
         };
 
         let mut scheduled = 0u32;
-        let mut orphans = 0u32;
 
         for row in rows {
             let job = match cron_job_from_row(row) {
@@ -434,26 +471,11 @@ impl CronService {
                 }
             };
 
-            if self.is_orphan(&job).await {
-                warn!(
-                    job_id = %job.id,
-                    job_name = %job.name,
-                    conversation_id = %job.conversation_id,
-                    execution_mode = job.execution_mode.as_str(),
-                    "Deleting orphan cron job whose bound conversation no longer exists"
-                );
-                if let Err(e) = self.repo.delete(&job.id).await {
-                    error!(job_id = %job.id, error = %e, "Failed to delete orphan cron job");
-                }
-                orphans += 1;
-                continue;
-            }
-
             self.scheduler.schedule_job(&job);
             scheduled += 1;
         }
 
-        info!(scheduled, orphans, "Cron service initialized");
+        info!(scheduled, "Cron service initialized");
     }
 
     pub async fn tick(&self, job_id: &str) {
@@ -490,8 +512,36 @@ impl CronService {
             return;
         }
 
-        let result = self.executor.execute(&job).await;
-        self.handle_execution_result(job, result).await;
+        let prepared = match self.executor.prepare_scheduled(&job).await {
+            Ok(prepared) => prepared,
+            Err(result) => {
+                self.handle_execution_result(job, result).await;
+                return;
+            }
+        };
+        let mut execution_job = job;
+        if let Err(err) = self
+            .bind_materialized_existing_conversation_if_needed(&mut execution_job, &prepared.conversation_id)
+            .await
+        {
+            error!(
+                job_id,
+                conversation_id = %prepared.conversation_id,
+                error = %err,
+                "Failed to bind materialized cron replacement conversation before execution"
+            );
+            self.handle_execution_result(
+                execution_job,
+                ExecutionResult::Error {
+                    message: err.to_string(),
+                },
+            )
+            .await;
+            return;
+        }
+
+        let result = self.executor.execute_prepared_scheduled(&execution_job, prepared).await;
+        self.handle_execution_result(execution_job, result).await;
     }
 
     pub async fn handle_system_resume(&self) {
@@ -543,7 +593,14 @@ impl CronService {
             .ok_or_else(|| CronError::JobNotFound(job_id.to_owned()))?;
         let mut job = cron_job_from_row(row)?;
         job.agent_type = self.resolve_job_agent_type(&job).await?;
-        let prepared = self.executor.prepare_run_now(&job).await?;
+        let prepared = match self.executor.prepare_run_now(&job).await? {
+            PreparedRunNow::Ready(prepared) => prepared,
+            PreparedRunNow::AlreadyRunning { conversation_id } => {
+                return Ok(RunNowResponse { conversation_id });
+            }
+        };
+        self.bind_materialized_existing_conversation_if_needed(&mut job, &prepared.conversation_id)
+            .await?;
         let conversation_id = prepared.conversation_id.clone();
         let service = self.clone();
         let job_id = job.id.clone();
@@ -705,38 +762,30 @@ impl CronService {
         }
     }
 
-    async fn is_orphan(&self, job: &CronJob) -> bool {
-        // NewConversation jobs never depend on an existing conversation —
-        // every run materializes a fresh one. They must not be cleaned up
-        // based on conversation state.
-        if matches!(job.execution_mode, ExecutionMode::NewConversation) {
-            return false;
+    async fn bind_materialized_existing_conversation_if_needed(
+        &self,
+        job: &mut CronJob,
+        conversation_id: &str,
+    ) -> Result<(), CronError> {
+        let conversation_id = conversation_id.trim();
+        if !matches!(job.execution_mode, ExecutionMode::Existing)
+            || conversation_id.is_empty()
+            || job.conversation_id.trim() == conversation_id
+        {
+            return Ok(());
         }
 
-        // Existing-mode jobs can legitimately carry an empty conversation_id
-        // until the first run performs lazy binding. Leave them alone.
-        if job.conversation_id.trim().is_empty() {
-            return false;
-        }
+        let params = UpdateCronJobParams {
+            conversation_id: Some(conversation_id.to_owned()),
+            ..Default::default()
+        };
+        self.repo.update(&job.id, &params).await?;
+        self.executor
+            .bind_cron_job_to_conversation(conversation_id, &job.id)
+            .await?;
+        job.conversation_id = conversation_id.to_owned();
 
-        if self.executor.is_conversation_claimed(&job.conversation_id) {
-            return false;
-        }
-
-        // Only true orphan case: Existing + bound conversation_id, but that
-        // conversation has been deleted.
-        match self.executor.conversation_exists(&job.conversation_id).await {
-            Ok(exists) => !exists,
-            Err(err) => {
-                warn!(
-                    job_id = %job.id,
-                    conversation_id = %job.conversation_id,
-                    error = %err,
-                    "Failed to verify cron conversation during orphan cleanup"
-                );
-                false
-            }
-        }
+        Ok(())
     }
 
     async fn validate_job_workspace(&self, job: &CronJob) -> Result<(), CronError> {
@@ -750,6 +799,39 @@ impl CronService {
                 Err(CronError::WorkspacePathUnavailable(path))
             }
         }
+    }
+
+    async fn clear_auto_workspace_from_job_config(&self, job: &mut CronJob, conversation_id: &str) -> bool {
+        let Some(config) = job.agent_config.as_mut() else {
+            return false;
+        };
+        let Some(workspace) = config.workspace.as_deref() else {
+            return false;
+        };
+        let workspace_to_clear = match self
+            .executor
+            .auto_workspace_to_delete_for_conversation(conversation_id)
+            .await
+        {
+            Ok(Some(path)) => path,
+            Ok(None) => return false,
+            Err(err) => {
+                warn!(
+                    conversation_id,
+                    job_id = %job.id,
+                    error = %err,
+                    "Failed to inspect previous conversation workspace for cron cleanup"
+                );
+                return false;
+            }
+        };
+
+        if !workspace_matches_path(workspace, &workspace_to_clear) {
+            return false;
+        }
+
+        config.workspace = None;
+        true
     }
 
     async fn handle_execution_result(&self, job: CronJob, result: ExecutionResult) {
@@ -842,12 +924,14 @@ impl CronService {
             }
         };
         let now = now_ms();
-        // Persist the conversation_id back onto the job the first time an
-        // "existing" job is materialized (lazy binding). Subsequent runs then
-        // reuse the same conversation, matching the UX where the job is the
-        // continuation anchor.
-        let needs_conversation_bind =
-            existing_row.conversation_id.trim().is_empty() && !conversation_id.trim().is_empty();
+        // Persist the conversation_id back onto existing-mode jobs whenever
+        // execution materializes a new anchor conversation. This covers both
+        // lazy binding and recovery after the previous conversation was deleted.
+        let needs_conversation_bind = should_bind_success_conversation(
+            &existing_row.execution_mode,
+            &existing_row.conversation_id,
+            conversation_id,
+        );
         let params = UpdateCronJobParams {
             last_run_at: Some(Some(now)),
             last_status: Some(Some("ok".into())),
@@ -1058,26 +1142,106 @@ impl CronService {
     }
 
     pub async fn delete_jobs_by_conversation(&self, conversation_id: &str) {
-        let jobs = match self.repo.list_by_conversation(conversation_id).await {
-            Ok(rows) => rows,
-            Err(e) => {
-                error!(conversation_id, error = %e, "Failed to list cron jobs for cascade delete");
+        let workspace_to_clear = match self
+            .executor
+            .auto_workspace_to_delete_for_conversation(conversation_id)
+            .await
+        {
+            Ok(value) => value,
+            Err(err) => {
+                warn!(
+                    conversation_id,
+                    error = %err,
+                    "Failed to inspect deleted conversation workspace for cron cleanup"
+                );
                 return;
             }
         };
 
-        for row in &jobs {
-            self.scheduler.cancel_job(&row.id);
-            self.emitter.emit_job_removed(&row.id);
+        let Some(workspace_to_clear) = workspace_to_clear else {
+            debug!(conversation_id, "Conversation deleted; cron jobs are preserved");
+            return;
+        };
+
+        self.clear_deleted_workspace_from_jobs(conversation_id, &workspace_to_clear)
+            .await;
+        debug!(conversation_id, "Conversation deleted; cron jobs are preserved");
+    }
+
+    async fn clear_deleted_workspace_from_jobs(&self, conversation_id: &str, workspace_to_clear: &Path) {
+        let jobs = match self.repo.list_by_conversation(conversation_id).await {
+            Ok(rows) => rows,
+            Err(err) => {
+                error!(
+                    conversation_id,
+                    error = %err,
+                    "Failed to list cron jobs for deleted workspace cleanup"
+                );
+                return;
+            }
+        };
+
+        let mut cleared = 0usize;
+        for row in jobs {
+            let Some(agent_config_json) = row.agent_config.as_deref() else {
+                continue;
+            };
+            let mut agent_config = match serde_json::from_str::<CronAgentConfig>(agent_config_json) {
+                Ok(config) => config,
+                Err(err) => {
+                    warn!(
+                        job_id = %row.id,
+                        conversation_id,
+                        error = %err,
+                        "Failed to parse cron agent config for deleted workspace cleanup"
+                    );
+                    continue;
+                }
+            };
+            if !agent_config
+                .workspace
+                .as_deref()
+                .is_some_and(|workspace| workspace_matches_path(workspace, workspace_to_clear))
+            {
+                continue;
+            }
+
+            agent_config.workspace = None;
+            let agent_config_json = match serde_json::to_string(&agent_config) {
+                Ok(value) => value,
+                Err(err) => {
+                    warn!(
+                        job_id = %row.id,
+                        conversation_id,
+                        error = %err,
+                        "Failed to serialize cron agent config for deleted workspace cleanup"
+                    );
+                    continue;
+                }
+            };
+            let params = UpdateCronJobParams {
+                agent_config: Some(Some(agent_config_json)),
+                ..Default::default()
+            };
+            match self.repo.update(&row.id, &params).await {
+                Ok(()) => cleared += 1,
+                Err(err) => {
+                    error!(
+                        job_id = %row.id,
+                        conversation_id,
+                        error = %err,
+                        "Failed to clear deleted workspace from cron job"
+                    );
+                }
+            }
         }
 
-        if let Err(e) = self.repo.delete_by_conversation(conversation_id).await {
-            error!(conversation_id, error = %e, "Failed to cascade-delete cron jobs");
-        } else if !jobs.is_empty() {
+        if cleared > 0 {
             info!(
                 conversation_id,
-                count = jobs.len(),
-                "Cascade-deleted cron jobs for conversation"
+                cleared,
+                workspace = %workspace_to_clear.display(),
+                "Cleared deleted conversation workspace from cron jobs"
             );
         }
     }
@@ -1438,6 +1602,29 @@ fn parse_execution_mode(mode: Option<&str>) -> Result<ExecutionMode, CronError> 
     }
 }
 
+fn should_bind_success_conversation(
+    execution_mode: &str,
+    existing_conversation_id: &str,
+    success_conversation_id: &str,
+) -> bool {
+    let success_conversation_id = success_conversation_id.trim();
+    execution_mode == ExecutionMode::Existing.as_str()
+        && !success_conversation_id.is_empty()
+        && existing_conversation_id.trim() != success_conversation_id
+}
+
+fn workspace_matches_path(stored_workspace: &str, target_workspace: &Path) -> bool {
+    let stored_path = Path::new(stored_workspace);
+    if stored_path == target_workspace {
+        return true;
+    }
+
+    match std::fs::canonicalize(stored_path) {
+        Ok(canonical_stored_path) => canonical_stored_path == target_workspace,
+        Err(_) => false,
+    }
+}
+
 fn validate_skill_body_content(content: &str) -> Result<(), CronError> {
     let trimmed = content.trim();
 
@@ -1727,6 +1914,15 @@ mod tests {
     fn parse_mode_invalid() {
         let err = parse_execution_mode(Some("parallel")).unwrap_err();
         assert!(matches!(err, CronError::InvalidExecutionMode(_)));
+    }
+
+    #[test]
+    fn success_conversation_bind_only_applies_to_existing_mode() {
+        assert!(should_bind_success_conversation("existing", "", "conv_run"));
+        assert!(should_bind_success_conversation("existing", "missing_old", "conv_run"));
+        assert!(!should_bind_success_conversation("new_conversation", "", "conv_run"));
+        assert!(!should_bind_success_conversation("existing", "conv_run", "conv_run"));
+        assert!(!should_bind_success_conversation("existing", "", "   "));
     }
 
     // -- build_update_params --------------------------------------------------

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -23,10 +23,12 @@ use aionui_conversation::ConversationService;
 use aionui_cron::{CronRouterState, cron_routes};
 use aionui_db::{
     ConversationFilters, ConversationRowUpdate, IAcpSessionRepository, IAgentMetadataRepository,
-    IAssistantDefinitionRepository, IAssistantOverlayRepository, IConversationRepository, ICronRepository,
-    MessagePageParams, MessagePageResult, MessageRowUpdate, MessageSearchRow, SqliteAcpSessionRepository,
-    SqliteAgentMetadataRepository, SqliteAssistantDefinitionRepository, SqliteAssistantOverlayRepository,
-    SqliteCronRepository, UpsertAssistantDefinitionParams, UpsertAssistantOverlayParams, init_database_memory,
+    IAssistantDefinitionRepository, IAssistantOverlayRepository, IAssistantPreferenceRepository,
+    IConversationRepository, ICronRepository, MessagePageParams, MessagePageResult, MessageRowUpdate, MessageSearchRow,
+    SqliteAcpSessionRepository, SqliteAgentMetadataRepository, SqliteAssistantDefinitionRepository,
+    SqliteAssistantOverlayRepository, SqliteAssistantPreferenceRepository, SqliteCronRepository,
+    UpsertAssistantDefinitionParams, UpsertAssistantOverlayParams, UpsertConversationAssistantSnapshotParams,
+    init_database_memory,
     models::{ConversationAssistantSnapshotRow, CronJobRow, MessageRow},
 };
 use aionui_realtime::EventBroadcaster;
@@ -37,6 +39,7 @@ use aionui_cron::events::CronEventEmitter;
 use aionui_cron::executor::JobExecutor;
 use aionui_cron::scheduler::CronScheduler;
 use aionui_cron::service::{CronService, CronServiceDeps};
+use aionui_cron::types::CronAgentConfig;
 use aionui_cron::types::JobStatus;
 use tower::ServiceExt;
 
@@ -485,6 +488,37 @@ impl IConversationRepository for StubConvRepo {
         Ok(self.assistant_snapshots.lock().unwrap().get(conversation_id).cloned())
     }
 
+    async fn upsert_assistant_snapshot(
+        &self,
+        params: &UpsertConversationAssistantSnapshotParams<'_>,
+    ) -> Result<Option<ConversationAssistantSnapshotRow>, aionui_db::DbError> {
+        let now = now_ms();
+        let row = ConversationAssistantSnapshotRow {
+            conversation_id: params.conversation_id.to_owned(),
+            assistant_definition_id: params.assistant_definition_id.to_owned(),
+            assistant_id: params.assistant_id.to_owned(),
+            assistant_source: params.assistant_source.to_owned(),
+            agent_id: params.agent_id.to_owned(),
+            rules_content: params.rules_content.to_owned(),
+            default_model_mode: params.default_model_mode.to_owned(),
+            resolved_model_id: params.resolved_model_id.map(ToOwned::to_owned),
+            default_permission_mode: params.default_permission_mode.to_owned(),
+            resolved_permission_value: params.resolved_permission_value.map(ToOwned::to_owned),
+            default_skills_mode: params.default_skills_mode.to_owned(),
+            resolved_skill_ids: params.resolved_skill_ids.to_owned(),
+            resolved_disabled_builtin_skill_ids: params.resolved_disabled_builtin_skill_ids.to_owned(),
+            default_mcps_mode: params.default_mcps_mode.to_owned(),
+            resolved_mcp_ids: params.resolved_mcp_ids.to_owned(),
+            created_at: now,
+            updated_at: now,
+        };
+        self.assistant_snapshots
+            .lock()
+            .unwrap()
+            .insert(row.conversation_id.clone(), row.clone());
+        Ok(Some(row))
+    }
+
     async fn create(&self, row: &aionui_db::models::ConversationRow) -> Result<(), aionui_db::DbError> {
         self.rows.lock().unwrap().insert(row.id.clone(), row.clone());
         Ok(())
@@ -713,6 +747,8 @@ async fn setup_with_conv_runtime() -> (
         Arc::new(SqliteAssistantDefinitionRepository::new(pool.clone()));
     let assistant_overlay_repo: Arc<dyn IAssistantOverlayRepository> =
         Arc::new(SqliteAssistantOverlayRepository::new(pool.clone()));
+    let assistant_preference_repo: Arc<dyn IAssistantPreferenceRepository> =
+        Arc::new(SqliteAssistantPreferenceRepository::new(pool.clone()));
     let acp_session_repo: Arc<dyn IAcpSessionRepository> = Arc::new(SqliteAcpSessionRepository::new(pool));
     let bc = Arc::new(MockBroadcaster::new());
     let data_dir = std::env::temp_dir().join(format!("aionui-cron-test-{}", now_ms()));
@@ -754,6 +790,9 @@ async fn setup_with_conv_runtime() -> (
         Arc::clone(&agent_metadata_repo),
         acp_session_repo,
     ));
+    conv_service.with_assistant_definition_repo(assistant_definition_repo.clone());
+    conv_service.with_assistant_state_repo(assistant_overlay_repo.clone());
+    conv_service.with_assistant_preference_repo(assistant_preference_repo);
     let agent_registry = AgentRegistry::new(agent_metadata_repo.clone());
     agent_registry.hydrate().await.unwrap();
     let executor = Arc::new(JobExecutor::new(
@@ -810,6 +849,8 @@ async fn setup_with_assistant_repos() -> (
         Arc::new(SqliteAssistantDefinitionRepository::new(pool.clone()));
     let assistant_overlay_repo: Arc<dyn IAssistantOverlayRepository> =
         Arc::new(SqliteAssistantOverlayRepository::new(pool.clone()));
+    let assistant_preference_repo: Arc<dyn IAssistantPreferenceRepository> =
+        Arc::new(SqliteAssistantPreferenceRepository::new(pool.clone()));
     let acp_session_repo: Arc<dyn IAcpSessionRepository> = Arc::new(SqliteAcpSessionRepository::new(pool));
     let bc = Arc::new(MockBroadcaster::new());
     let data_dir = std::env::temp_dir().join(format!("aionui-cron-test-{}", now_ms()));
@@ -851,6 +892,9 @@ async fn setup_with_assistant_repos() -> (
         Arc::clone(&agent_metadata_repo),
         acp_session_repo,
     ));
+    conv_service.with_assistant_definition_repo(assistant_definition_repo.clone());
+    conv_service.with_assistant_state_repo(assistant_overlay_repo.clone());
+    conv_service.with_assistant_preference_repo(assistant_preference_repo);
     let agent_registry = AgentRegistry::new(agent_metadata_repo.clone());
     agent_registry.hydrate().await.unwrap();
     let executor = Arc::new(JobExecutor::new(
@@ -1476,6 +1520,152 @@ async fn update_existing_conversation_job_rejects_agent_config_even_when_switchi
 }
 
 #[tokio::test]
+async fn update_existing_job_to_new_conversation_removes_previous_conversation_binding() {
+    use aionui_common::OnConversationDelete;
+
+    let (svc, cron_repo, _, conv_repo) = setup_with_conv_repo().await;
+    let mut create_req = make_create_req("Mode Switch Clears Binding", every_60s());
+    create_req.conversation_id = "conv_mode_switch".into();
+    create_req.execution_mode = Some("existing".into());
+    let created = svc.add_job(create_req).await.unwrap();
+
+    let bound_before = conv_repo.get("conv_mode_switch").await.unwrap().unwrap();
+    let extra_before: serde_json::Value = serde_json::from_str(&bound_before.extra).unwrap();
+    assert_eq!(extra_before["cron_job_id"], created.id);
+    assert_eq!(extra_before["cronJobId"], created.id);
+
+    let updated = svc
+        .update_job(
+            &created.id,
+            UpdateCronJobRequest {
+                name: None,
+                description: None,
+                enabled: None,
+                schedule: None,
+                message: None,
+                execution_mode: Some("new_conversation".into()),
+                agent_config: None,
+                conversation_title: None,
+                max_retries: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(updated.execution_mode.as_str(), "new_conversation");
+
+    let row = cron_repo.get_by_id(&created.id).await.unwrap().unwrap();
+    assert_eq!(row.execution_mode, "new_conversation");
+    assert_eq!(row.conversation_id, "");
+    assert!(row.conversation_title.is_none());
+
+    let bound_after = conv_repo.get("conv_mode_switch").await.unwrap().unwrap();
+    let extra_after: serde_json::Value = serde_json::from_str(&bound_after.extra).unwrap();
+    assert!(extra_after.get("cron_job_id").is_none());
+    assert!(extra_after.get("cronJobId").is_none());
+
+    svc.on_conversation_deleted("conv_mode_switch").await;
+    assert!(
+        svc.get_job(&created.id).await.is_ok(),
+        "deleting the previous existing-mode conversation must not delete the switched new-conversation job"
+    );
+}
+
+#[tokio::test]
+async fn update_existing_job_to_new_conversation_clears_previous_auto_workspace() {
+    let (svc, cron_repo, _, conv_repo, conv_service) = setup_with_conv_runtime().await;
+    let conversation_id = format!("conv_mode_switch_workspace_{}", now_ms());
+    let auto_workspace_path = std::env::temp_dir()
+        .join("conversations")
+        .join(format!("acp-temp-{conversation_id}"));
+    std::fs::create_dir_all(&auto_workspace_path).unwrap();
+    let auto_workspace = auto_workspace_path.to_string_lossy().to_string();
+    conv_repo.set_conversation_extra(
+        &conversation_id,
+        serde_json::json!({
+            "workspace": auto_workspace,
+        }),
+    );
+
+    let mut create_req = make_create_req("Mode Switch Clears Workspace", every_60s());
+    create_req.conversation_id = conversation_id.clone();
+    create_req.execution_mode = Some("existing".into());
+    create_req.agent_config.as_mut().unwrap().workspace = Some(auto_workspace);
+    let created = svc.add_job(create_req).await.unwrap();
+
+    let bound_conversation = conv_repo.get(&conversation_id).await.unwrap().unwrap();
+    assert!(
+        conv_service
+            .auto_workspace_to_delete_for_row(&bound_conversation, &conversation_id)
+            .is_some(),
+        "test setup should use a workspace ConversationService will delete"
+    );
+
+    svc.update_job(
+        &created.id,
+        UpdateCronJobRequest {
+            name: None,
+            description: None,
+            enabled: None,
+            schedule: None,
+            message: None,
+            execution_mode: Some("new_conversation".into()),
+            agent_config: None,
+            conversation_title: None,
+            max_retries: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let row = cron_repo.get_by_id(&created.id).await.unwrap().unwrap();
+    let config: CronAgentConfig = serde_json::from_str(row.agent_config.as_deref().unwrap()).unwrap();
+    assert!(
+        config.workspace.is_none(),
+        "switching away from an existing conversation should drop that conversation's auto workspace"
+    );
+}
+
+#[tokio::test]
+async fn update_existing_job_to_new_conversation_preserves_custom_workspace() {
+    let (svc, cron_repo, _, conv_repo) = setup_with_conv_repo().await;
+    let conversation_id = format!("conv_mode_switch_custom_workspace_{}", now_ms());
+    let custom_workspace = ensure_named_workspace_path(&format!("aionui-cron-switch-custom-{conversation_id}"));
+    conv_repo.set_conversation_extra(
+        &conversation_id,
+        serde_json::json!({
+            "workspace": custom_workspace,
+        }),
+    );
+
+    let mut create_req = make_create_req("Mode Switch Preserves Workspace", every_60s());
+    create_req.conversation_id = conversation_id.clone();
+    create_req.execution_mode = Some("existing".into());
+    create_req.agent_config.as_mut().unwrap().workspace = Some(custom_workspace.clone());
+    let created = svc.add_job(create_req).await.unwrap();
+
+    svc.update_job(
+        &created.id,
+        UpdateCronJobRequest {
+            name: None,
+            description: None,
+            enabled: None,
+            schedule: None,
+            message: None,
+            execution_mode: Some("new_conversation".into()),
+            agent_config: None,
+            conversation_title: None,
+            max_retries: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let row = cron_repo.get_by_id(&created.id).await.unwrap().unwrap();
+    let config: CronAgentConfig = serde_json::from_str(row.agent_config.as_deref().unwrap()).unwrap();
+    assert_eq!(config.workspace.as_deref(), Some(custom_workspace.as_str()));
+}
+
+#[tokio::test]
 async fn update_team_conversation_job_rejects_execution_mode_change() {
     let (svc, _, _, conv_repo) = setup_with_conv_repo().await;
     let mut create_req = make_create_req("Team Cron Mode Lock", every_60s());
@@ -1969,7 +2159,7 @@ async fn oc1b_init_preserves_new_conversation_jobs() {
 }
 
 #[tokio::test]
-async fn oc2_init_cleans_jobs_with_missing_conversation() {
+async fn oc2_init_preserves_existing_jobs_with_missing_conversation() {
     let (svc, _repo, _) = setup().await;
 
     let mut missing_req = make_create_req("Missing Conversation", every_60s());
@@ -1982,11 +2172,71 @@ async fn oc2_init_cleans_jobs_with_missing_conversation() {
 
     svc.init().await;
 
-    let err = svc.get_job(&missing.id).await;
-    assert!(err.is_err());
+    let missing_found = svc.get_job(&missing.id).await;
+    assert!(
+        missing_found.is_ok(),
+        "existing job with deleted conversation should survive init and recover on next execution"
+    );
 
     let found = svc.get_job(&normal.id).await;
     assert!(found.is_ok());
+}
+
+#[tokio::test]
+async fn existing_job_with_missing_conversation_run_now_creates_replacement_conversation() {
+    let (svc, _repo, _bc, conv_repo) = setup_with_conv_repo().await;
+
+    let mut req = make_create_req("Missing Existing RunNow", every_60s());
+    req.conversation_id = "missing-conv-run-now".into();
+    req.execution_mode = Some("existing".into());
+    let job = svc.add_job(req).await.unwrap();
+
+    let response = svc.run_now(&job.id).await.unwrap();
+
+    assert_ne!(response.conversation_id, "missing-conv-run-now");
+    assert!(
+        conv_repo.get(&response.conversation_id).await.unwrap().is_some(),
+        "run-now should create a replacement conversation for an existing job whose previous conversation was deleted"
+    );
+
+    let rebound = svc.get_job(&job.id).await.unwrap();
+    assert_eq!(
+        rebound.conversation_id, response.conversation_id,
+        "existing-mode replacement conversations must bind before the async turn finishes"
+    );
+}
+
+#[tokio::test]
+async fn run_now_on_running_existing_conversation_returns_active_conversation_without_new_execution() {
+    let (svc, cron_repo, bc, _conv_repo, conv_service) = setup_with_conv_runtime().await;
+
+    let mut req = make_create_req("Running Existing RunNow", every_60s());
+    req.conversation_id = "conv-running-run-now".into();
+    req.execution_mode = Some("existing".into());
+    let job = svc.add_job(req).await.unwrap();
+    bc.take_events();
+
+    let claim = conv_service
+        .runtime_state()
+        .try_claim_turn(&job.conversation_id, "turn-active")
+        .expect("runtime claim should succeed");
+
+    let response = svc.run_now(&job.id).await.unwrap();
+
+    assert_eq!(response.conversation_id, job.conversation_id);
+    for _ in 0..20 {
+        tokio::task::yield_now().await;
+    }
+
+    let row = cron_repo.get_by_id(&job.id).await.unwrap().unwrap();
+    assert_eq!(row.run_count, 0);
+    assert!(row.last_status.is_none());
+    assert!(
+        bc.take_events().iter().all(|event| event.name != "cron.job-executed"),
+        "clicking run-now on an already running conversation should only return it for navigation"
+    );
+
+    drop(claim);
 }
 
 // ── Delete skill explicitly ───────────────────────────────────────
@@ -2539,10 +2789,10 @@ async fn sr1_system_resume_missed_job() {
     );
 }
 
-// ── CD-1: Cascade delete cron jobs when conversation is deleted ──
+// ── CD-1: Preserve cron jobs when conversation is deleted ─────────
 
 #[tokio::test]
-async fn cd1_cascade_delete_by_conversation() {
+async fn cd1_delete_by_conversation_preserves_jobs() {
     let (svc, _repo, bc) = setup().await;
 
     let mut req_a = make_create_req("Cascade A", every_60s());
@@ -2561,21 +2811,24 @@ async fn cd1_cascade_delete_by_conversation() {
 
     svc.delete_jobs_by_conversation("conv_cascade").await;
 
-    assert!(svc.get_job(&job_a.id).await.is_err());
-    assert!(svc.get_job(&job_b.id).await.is_err());
+    assert!(svc.get_job(&job_a.id).await.is_ok());
+    assert!(svc.get_job(&job_b.id).await.is_ok());
 
     let remaining = svc.list_jobs(&ListCronJobsQuery::default()).await.unwrap();
-    assert_eq!(remaining.len(), 1, "only the unrelated job should remain");
+    assert_eq!(remaining.len(), 3, "all cron jobs should remain");
 
     let events = bc.take_events();
     let removed_events: Vec<_> = events.iter().filter(|e| e.name == "cron.job-removed").collect();
-    assert_eq!(removed_events.len(), 2, "should emit 2 removed events");
+    assert!(
+        removed_events.is_empty(),
+        "conversation delete should not emit cron removal events"
+    );
 }
 
-// ── CD-2: Cascade delete on empty conversation (no-op) ──────────
+// ── CD-2: Preserve on empty conversation (no-op) ──────────────────
 
 #[tokio::test]
-async fn cd2_cascade_delete_no_matching_jobs() {
+async fn cd2_delete_by_conversation_no_matching_jobs() {
     let (svc, _repo, bc) = setup().await;
 
     svc.add_job(make_create_req("Existing", every_60s())).await.unwrap();
@@ -2590,10 +2843,10 @@ async fn cd2_cascade_delete_no_matching_jobs() {
     assert_eq!(all.len(), 1, "existing job should remain untouched");
 }
 
-// ── CD-3: OnConversationDelete trait dispatches cascade ──────────
+// ── CD-3: OnConversationDelete trait preserves jobs ───────────────
 
 #[tokio::test]
-async fn cd3_on_conversation_delete_trait() {
+async fn cd3_on_conversation_delete_trait_preserves_jobs() {
     use aionui_common::OnConversationDelete;
 
     let (svc, _repo, bc) = setup().await;
@@ -2605,9 +2858,124 @@ async fn cd3_on_conversation_delete_trait() {
 
     svc.on_conversation_deleted("conv_trait_del").await;
 
-    assert!(svc.get_job(&job.id).await.is_err());
+    assert!(svc.get_job(&job.id).await.is_ok());
 
     let events = bc.take_events();
-    assert_eq!(events.len(), 1);
-    assert_eq!(events[0].name, "cron.job-removed");
+    assert!(events.is_empty());
+}
+
+#[tokio::test]
+async fn cd3b_on_conversation_delete_clears_deleted_workspace_from_jobs() {
+    use aionui_common::OnConversationDelete;
+
+    let (svc, cron_repo, bc, conv_repo, conv_service) = setup_with_conv_runtime().await;
+    let conversation_id = format!("conv_workspace_deleted_{}", now_ms());
+    let deleted_workspace_path = std::env::temp_dir()
+        .join("conversations")
+        .join(format!("acp-temp-{conversation_id}"));
+    std::fs::create_dir_all(&deleted_workspace_path).unwrap();
+    let deleted_workspace = deleted_workspace_path.to_string_lossy().to_string();
+    conv_repo.set_conversation_extra(
+        &conversation_id,
+        serde_json::json!({
+            "workspace": deleted_workspace,
+        }),
+    );
+
+    let mut req = make_create_req("Clears Deleted Workspace", every_60s());
+    req.conversation_id = conversation_id.clone();
+    req.agent_config.as_mut().unwrap().workspace = Some(deleted_workspace);
+    let job = svc.add_job(req).await.unwrap();
+    bc.take_events();
+
+    let bound_conversation = conv_repo.get(&conversation_id).await.unwrap().unwrap();
+    assert!(
+        conv_service
+            .auto_workspace_to_delete_for_row(&bound_conversation, &conversation_id)
+            .is_some(),
+        "test setup should use a workspace ConversationService will delete"
+    );
+    let row_before = cron_repo.get_by_id(&job.id).await.unwrap().unwrap();
+    let config_before: CronAgentConfig = serde_json::from_str(row_before.agent_config.as_deref().unwrap()).unwrap();
+    assert_eq!(
+        config_before.workspace.as_deref(),
+        Some(deleted_workspace_path.to_str().unwrap())
+    );
+
+    svc.on_conversation_deleted(&conversation_id).await;
+
+    assert!(svc.get_job(&job.id).await.is_ok());
+    let row = cron_repo.get_by_id(&job.id).await.unwrap().unwrap();
+    let config: CronAgentConfig = serde_json::from_str(row.agent_config.as_deref().unwrap()).unwrap();
+    assert!(
+        config.workspace.is_none(),
+        "cron job should drop workspace cached from the deleted conversation"
+    );
+
+    let events = bc.take_events();
+    assert!(events.is_empty());
+}
+
+#[tokio::test]
+async fn cd3c_on_conversation_delete_preserves_custom_workspace_on_jobs() {
+    use aionui_common::OnConversationDelete;
+
+    let (svc, cron_repo, bc, conv_repo) = setup_with_conv_repo().await;
+    let conversation_id = format!("conv_workspace_custom_{}", now_ms());
+    let custom_workspace = ensure_named_workspace_path(&format!("aionui-cron-custom-workspace-{conversation_id}"));
+    conv_repo.set_conversation_extra(
+        &conversation_id,
+        serde_json::json!({
+            "workspace": custom_workspace,
+        }),
+    );
+
+    let mut req = make_create_req("Preserves Custom Workspace", every_60s());
+    req.conversation_id = conversation_id.clone();
+    req.agent_config.as_mut().unwrap().workspace = Some(custom_workspace.clone());
+    let job = svc.add_job(req).await.unwrap();
+    bc.take_events();
+
+    svc.on_conversation_deleted(&conversation_id).await;
+
+    let row = cron_repo.get_by_id(&job.id).await.unwrap().unwrap();
+    let config: CronAgentConfig = serde_json::from_str(row.agent_config.as_deref().unwrap()).unwrap();
+    assert_eq!(config.workspace.as_deref(), Some(custom_workspace.as_str()));
+
+    let events = bc.take_events();
+    assert!(events.is_empty());
+}
+
+#[tokio::test]
+async fn cd4_on_conversation_delete_preserves_all_cron_jobs() {
+    use aionui_common::OnConversationDelete;
+
+    let (svc, _repo, bc) = setup().await;
+
+    let mut new_conversation_req = make_create_req("Generated Run History", every_60s());
+    new_conversation_req.conversation_id = "conv_generated_run".into();
+    new_conversation_req.execution_mode = Some("new_conversation".into());
+    let new_conversation_job = svc.add_job(new_conversation_req).await.unwrap();
+
+    let mut existing_req = make_create_req("Existing Bound Job", every_60s());
+    existing_req.conversation_id = "conv_generated_run".into();
+    existing_req.execution_mode = Some("existing".into());
+    let existing_job = svc.add_job(existing_req).await.unwrap();
+
+    bc.take_events();
+
+    svc.on_conversation_deleted("conv_generated_run").await;
+
+    assert!(
+        svc.get_job(&new_conversation_job.id).await.is_ok(),
+        "deleting a generated run conversation must not delete its new-conversation cron job"
+    );
+    assert!(
+        svc.get_job(&existing_job.id).await.is_ok(),
+        "existing-mode jobs should also survive conversation deletion"
+    );
+
+    let events = bc.take_events();
+    let removed_events: Vec<_> = events.iter().filter(|e| e.name == "cron.job-removed").collect();
+    assert!(removed_events.is_empty());
 }


### PR DESCRIPTION
## Summary

- Preserve cron jobs when their bound conversation is deleted, and materialize a replacement conversation on the next existing-mode run.
- Bind replacement conversations before scheduled/run-now execution so later runs reuse the recovered anchor.
- Clear stale auto-provisioned workspace references while preserving custom workspaces and cron job records.
- Inject helper runtime context into cron conversation state and document supported standard cron syntax.

## Related Issues

- Refs iOfficeAI/AionUi#3475
- Refs iOfficeAI/AionUi#3474
- Refs iOfficeAI/AionUi#3465
- Related frontend PR: iOfficeAI/AionUi#3510

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo nextest run -p aionui-cron`
- [x] `cargo nextest run -p aionui-app build_cron_state_conversation_service_injects_runtime_helper_context`
- [x] `cargo nextest run -p aionui-app --test cron_e2e`
- [x] `cargo nextest run --status-level fail --final-status-level fail` (6646 passed, 18 skipped, 1 leaky)
- [x] `cargo clippy -p aionui-cron -p aionui-conversation -p aionui-app -- -D warnings`
- [x] `git diff --check`