### PR TITLE
fix: preserve Linux GLIBC baselines

### DIFF
--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -32,7 +32,8 @@ env:
   CARGO_NET_RETRY: "10"
   AIONUI_EMBED_BUN: "1"
   BUN_VARIANT: default
-  CROSS_VERSION: "0.2.5"
+  # cross commit used by the v0.1.39/v0.1.40 Linux ARM64 release builds.
+  CROSS_GIT_REV: "29d00c7803f221f1b3f35e561b03792368fb8339"
   LINUX_X64_GLIBC_MAX: "GLIBC_2.34"
   LINUX_ARM64_GLIBC_MAX: "GLIBC_2.30"
 
@@ -111,11 +112,11 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: manual-build-${{ matrix.target }}-${{ matrix.os }}${{ matrix.target == 'x86_64-unknown-linux-gnu' && format('-glibc-{0}', env.LINUX_X64_GLIBC_MAX) || '' }}${{ matrix.use_cross == true && format('-cross-{0}-glibc-{1}', env.CROSS_VERSION, env.LINUX_ARM64_GLIBC_MAX) || '' }}
+          shared-key: manual-build-${{ matrix.target }}-${{ matrix.os }}${{ matrix.target == 'x86_64-unknown-linux-gnu' && format('-glibc-{0}', env.LINUX_X64_GLIBC_MAX) || '' }}${{ matrix.use_cross == true && format('-cross-{0}-glibc-{1}', env.CROSS_GIT_REV, env.LINUX_ARM64_GLIBC_MAX) || '' }}
 
       - name: Install cross (Linux targets)
         if: matrix.use_cross == true
-        run: cargo install cross --version "${CROSS_VERSION}" --locked
+        run: cargo install cross --git https://github.com/cross-rs/cross --rev "${CROSS_GIT_REV}" --locked
 
       - name: Build release binary
         shell: bash

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -33,6 +33,7 @@ env:
   AIONUI_EMBED_BUN: "1"
   BUN_VARIANT: default
   CROSS_VERSION: "0.2.5"
+  LINUX_X64_GLIBC_MAX: "GLIBC_2.34"
   LINUX_ARM64_GLIBC_MAX: "GLIBC_2.30"
 
 jobs:
@@ -110,7 +111,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: manual-build-${{ matrix.target }}-${{ matrix.os }}${{ matrix.use_cross == true && format('-cross-{0}-{1}', env.CROSS_VERSION, env.LINUX_ARM64_GLIBC_MAX) || '' }}
+          shared-key: manual-build-${{ matrix.target }}-${{ matrix.os }}${{ matrix.target == 'x86_64-unknown-linux-gnu' && format('-glibc-{0}', env.LINUX_X64_GLIBC_MAX) || '' }}${{ matrix.use_cross == true && format('-cross-{0}-glibc-{1}', env.CROSS_VERSION, env.LINUX_ARM64_GLIBC_MAX) || '' }}
 
       - name: Install cross (Linux targets)
         if: matrix.use_cross == true
@@ -135,6 +136,11 @@ jobs:
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         shell: bash
         run: scripts/check-glibc-baseline.sh "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" "${LINUX_ARM64_GLIBC_MAX}"
+
+      - name: Verify Linux x64 GLIBC baseline
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        shell: bash
+        run: scripts/check-glibc-baseline.sh "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" "${LINUX_X64_GLIBC_MAX}"
 
       - name: Package binary (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -114,6 +114,10 @@ jobs:
         with:
           shared-key: manual-build-${{ matrix.target }}-${{ matrix.os }}${{ matrix.target == 'x86_64-unknown-linux-gnu' && format('-glibc-{0}', env.LINUX_X64_GLIBC_MAX) || '' }}${{ matrix.use_cross == true && format('-cross-{0}-glibc-{1}', env.CROSS_GIT_REV, env.LINUX_ARM64_GLIBC_MAX) || '' }}
 
+      - name: Verify pinned Linux ARM64 cross image is available
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: docker pull ghcr.io/cross-rs/aarch64-unknown-linux-gnu@sha256:99e041b94e7d4f31477c6ddede176688562c3762ba3833b75de3316100afc39d
+
       - name: Install cross (Linux targets)
         if: matrix.use_cross == true
         run: cargo install cross --git https://github.com/cross-rs/cross --rev "${CROSS_GIT_REV}" --locked

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -32,6 +32,8 @@ env:
   CARGO_NET_RETRY: "10"
   AIONUI_EMBED_BUN: "1"
   BUN_VARIANT: default
+  CROSS_VERSION: "0.2.5"
+  LINUX_ARM64_GLIBC_MAX: "GLIBC_2.30"
 
 jobs:
   prepare-matrix:
@@ -108,11 +110,11 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: manual-build-${{ matrix.target }}-${{ matrix.os }}${{ matrix.use_cross == true && '-cross' || '' }}
+          shared-key: manual-build-${{ matrix.target }}-${{ matrix.os }}${{ matrix.use_cross == true && format('-cross-{0}-{1}', env.CROSS_VERSION, env.LINUX_ARM64_GLIBC_MAX) || '' }}
 
       - name: Install cross (Linux targets)
         if: matrix.use_cross == true
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: cargo install cross --version "${CROSS_VERSION}" --locked
 
       - name: Build release binary
         shell: bash
@@ -128,6 +130,11 @@ jobs:
           else
             cargo build --release --target ${{ matrix.target }} -p aionui-app
           fi
+
+      - name: Verify Linux ARM64 GLIBC baseline
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        shell: bash
+        run: scripts/check-glibc-baseline.sh "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" "${LINUX_ARM64_GLIBC_MAX}"
 
       - name: Package binary (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ env:
   AIONUI_EMBED_BUN: "1"
   BUN_VARIANT: default
   CROSS_VERSION: "0.2.5"
+  LINUX_X64_GLIBC_MAX: "GLIBC_2.34"
   LINUX_ARM64_GLIBC_MAX: "GLIBC_2.30"
   RELEASE_TAG: ${{ inputs.tag_name || github.ref_name }}
 
@@ -112,7 +113,7 @@ jobs:
           # must fall into a different cache bucket — otherwise the cached
           # .so is loaded against an incompatible GLIBC and cargo panics
           # with "can't find crate" / "GLIBC_* not found" errors.
-          shared-key: release-${{ matrix.target }}-${{ matrix.os }}${{ matrix.use_cross == true && format('-cross-{0}-{1}', env.CROSS_VERSION, env.LINUX_ARM64_GLIBC_MAX) || '' }}
+          shared-key: release-${{ matrix.target }}-${{ matrix.os }}${{ matrix.target == 'x86_64-unknown-linux-gnu' && format('-glibc-{0}', env.LINUX_X64_GLIBC_MAX) || '' }}${{ matrix.use_cross == true && format('-cross-{0}-glibc-{1}', env.CROSS_VERSION, env.LINUX_ARM64_GLIBC_MAX) || '' }}
 
       - name: Install cross (Linux targets)
         if: matrix.use_cross == true
@@ -136,6 +137,11 @@ jobs:
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         shell: bash
         run: scripts/check-glibc-baseline.sh "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" "${LINUX_ARM64_GLIBC_MAX}"
+
+      - name: Verify Linux x64 GLIBC baseline
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        shell: bash
+        run: scripts/check-glibc-baseline.sh "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" "${LINUX_X64_GLIBC_MAX}"
 
       - name: Package binary (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,8 @@ env:
   CARGO_NET_RETRY: "10"
   AIONUI_EMBED_BUN: "1"
   BUN_VARIANT: default
-  CROSS_VERSION: "0.2.5"
+  # cross commit used by the v0.1.39/v0.1.40 Linux ARM64 release builds.
+  CROSS_GIT_REV: "29d00c7803f221f1b3f35e561b03792368fb8339"
   LINUX_X64_GLIBC_MAX: "GLIBC_2.34"
   LINUX_ARM64_GLIBC_MAX: "GLIBC_2.30"
   RELEASE_TAG: ${{ inputs.tag_name || github.ref_name }}
@@ -113,11 +114,11 @@ jobs:
           # must fall into a different cache bucket — otherwise the cached
           # .so is loaded against an incompatible GLIBC and cargo panics
           # with "can't find crate" / "GLIBC_* not found" errors.
-          shared-key: release-${{ matrix.target }}-${{ matrix.os }}${{ matrix.target == 'x86_64-unknown-linux-gnu' && format('-glibc-{0}', env.LINUX_X64_GLIBC_MAX) || '' }}${{ matrix.use_cross == true && format('-cross-{0}-glibc-{1}', env.CROSS_VERSION, env.LINUX_ARM64_GLIBC_MAX) || '' }}
+          shared-key: release-${{ matrix.target }}-${{ matrix.os }}${{ matrix.target == 'x86_64-unknown-linux-gnu' && format('-glibc-{0}', env.LINUX_X64_GLIBC_MAX) || '' }}${{ matrix.use_cross == true && format('-cross-{0}-glibc-{1}', env.CROSS_GIT_REV, env.LINUX_ARM64_GLIBC_MAX) || '' }}
 
       - name: Install cross (Linux targets)
         if: matrix.use_cross == true
-        run: cargo install cross --version "${CROSS_VERSION}" --locked
+        run: cargo install cross --git https://github.com/cross-rs/cross --rev "${CROSS_GIT_REV}" --locked
 
       - name: Build release binary
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ env:
   CARGO_NET_RETRY: "10"
   AIONUI_EMBED_BUN: "1"
   BUN_VARIANT: default
+  CROSS_VERSION: "0.2.5"
+  LINUX_ARM64_GLIBC_MAX: "GLIBC_2.30"
   RELEASE_TAG: ${{ inputs.tag_name || github.ref_name }}
 
 jobs:
@@ -104,17 +106,17 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
-          # Include runner OS image and use_cross flag in the cache key.
+          # Include runner OS image and cross baseline in the cache key.
           # Proc-macro .so files link against the host GLIBC, so switching
           # the runner (ubuntu-24.04 ↔ 22.04) or flipping native ↔ cross
           # must fall into a different cache bucket — otherwise the cached
           # .so is loaded against an incompatible GLIBC and cargo panics
           # with "can't find crate" / "GLIBC_* not found" errors.
-          shared-key: release-${{ matrix.target }}-${{ matrix.os }}${{ matrix.use_cross == true && '-cross' || '' }}
+          shared-key: release-${{ matrix.target }}-${{ matrix.os }}${{ matrix.use_cross == true && format('-cross-{0}-{1}', env.CROSS_VERSION, env.LINUX_ARM64_GLIBC_MAX) || '' }}
 
       - name: Install cross (Linux targets)
         if: matrix.use_cross == true
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: cargo install cross --version "${CROSS_VERSION}" --locked
 
       - name: Build release binary
         shell: bash
@@ -129,6 +131,11 @@ jobs:
           else
             cargo build --release --target ${{ matrix.target }} -p aionui-app
           fi
+
+      - name: Verify Linux ARM64 GLIBC baseline
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        shell: bash
+        run: scripts/check-glibc-baseline.sh "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" "${LINUX_ARM64_GLIBC_MAX}"
 
       - name: Package binary (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,10 @@ jobs:
           # with "can't find crate" / "GLIBC_* not found" errors.
           shared-key: release-${{ matrix.target }}-${{ matrix.os }}${{ matrix.target == 'x86_64-unknown-linux-gnu' && format('-glibc-{0}', env.LINUX_X64_GLIBC_MAX) || '' }}${{ matrix.use_cross == true && format('-cross-{0}-glibc-{1}', env.CROSS_GIT_REV, env.LINUX_ARM64_GLIBC_MAX) || '' }}
 
+      - name: Verify pinned Linux ARM64 cross image is available
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: docker pull ghcr.io/cross-rs/aarch64-unknown-linux-gnu@sha256:99e041b94e7d4f31477c6ddede176688562c3762ba3833b75de3316100afc39d
+
       - name: Install cross (Linux targets)
         if: matrix.use_cross == true
         run: cargo install cross --git https://github.com/cross-rs/cross --rev "${CROSS_GIT_REV}" --locked

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,4 +1,4 @@
 [target.aarch64-unknown-linux-gnu]
-# Keep Linux ARM64 releases on the historical cross 0.2.5 image/sysroot.
-# This prevents cross main/edge image updates from raising the GLIBC baseline.
-image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu@sha256:7f8308a8734d9fcd2ebbe9a3e4bdea74af293f0799d80c3cc341e340cda49a4c"
+# Match the cross image digest used by v0.1.39/v0.1.40 Linux ARM64 releases.
+# This prevents cross main image updates from raising the GLIBC baseline again.
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu@sha256:99e041b94e7d4f31477c6ddede176688562c3762ba3833b75de3316100afc39d"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,4 @@
+[target.aarch64-unknown-linux-gnu]
+# Keep Linux ARM64 releases on the historical cross 0.2.5 image/sysroot.
+# This prevents cross main/edge image updates from raising the GLIBC baseline.
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu@sha256:7f8308a8734d9fcd2ebbe9a3e4bdea74af293f0799d80c3cc341e340cda49a4c"

--- a/scripts/check-glibc-baseline.sh
+++ b/scripts/check-glibc-baseline.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <binary> <max-glibc>" >&2
+  exit 2
+fi
+
+binary="$1"
+max_glibc="$2"
+
+if [[ ! -f "${binary}" ]]; then
+  echo "Binary not found: ${binary}" >&2
+  exit 2
+fi
+
+if [[ ! "${max_glibc}" =~ ^GLIBC_[0-9]+[.][0-9]+$ ]]; then
+  echo "Invalid GLIBC ceiling: ${max_glibc}" >&2
+  exit 2
+fi
+
+symbols="$(objdump -T "${binary}")"
+required_glibc="$(
+  printf '%s\n' "${symbols}" \
+    | grep -oE 'GLIBC_[0-9]+[.][0-9]+' \
+    | sort -Vu \
+    | tail -1 \
+    || true
+)"
+
+if [[ -z "${required_glibc}" ]]; then
+  echo "No GLIBC versioned symbols found in ${binary}" >&2
+  exit 2
+fi
+
+highest="$(
+  printf '%s\n%s\n' "${required_glibc}" "${max_glibc}" \
+    | sort -Vu \
+    | tail -1
+)"
+
+if [[ "${highest}" != "${max_glibc}" ]]; then
+  echo "Required GLIBC ${required_glibc} exceeds ${max_glibc} for ${binary}" >&2
+  exit 1
+fi
+
+echo "Required GLIBC ${required_glibc} is within ${max_glibc} for ${binary}"

--- a/scripts/check-glibc-baseline.test.sh
+++ b/scripts/check-glibc-baseline.test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECKER="${ROOT_DIR}/scripts/check-glibc-baseline.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+FAKE_OBJDUMP="${TMP_DIR}/objdump"
+FAKE_BINARY="${TMP_DIR}/aioncore"
+touch "${FAKE_BINARY}"
+
+write_fake_objdump() {
+  local glibc_version="$1"
+  cat > "${FAKE_OBJDUMP}" <<EOF
+#!/usr/bin/env bash
+cat <<'SYMBOLS'
+0000000000000000      DF *UND*  0000000000000000 (GLIBC_2.17) pthread_self
+0000000000000000      DF *UND*  0000000000000000 (${glibc_version}) pidfd_spawnp
+SYMBOLS
+EOF
+  chmod +x "${FAKE_OBJDUMP}"
+}
+
+write_fake_objdump "GLIBC_2.30"
+PATH="${TMP_DIR}:${PATH}" "${CHECKER}" "${FAKE_BINARY}" "GLIBC_2.30"
+
+write_fake_objdump "GLIBC_2.39"
+if PATH="${TMP_DIR}:${PATH}" "${CHECKER}" "${FAKE_BINARY}" "GLIBC_2.30" >"${TMP_DIR}/fail.out" 2>&1; then
+  echo "expected GLIBC_2.39 to fail against GLIBC_2.30 ceiling" >&2
+  exit 1
+fi
+
+grep -q "exceeds GLIBC_2.30" "${TMP_DIR}/fail.out"
+
+cat > "${FAKE_OBJDUMP}" <<'EOF'
+#!/usr/bin/env bash
+cat <<'SYMBOLS'
+0000000000000000      DF *UND*  0000000000000000 pthread_self
+SYMBOLS
+EOF
+chmod +x "${FAKE_OBJDUMP}"
+
+if PATH="${TMP_DIR}:${PATH}" "${CHECKER}" "${FAKE_BINARY}" "GLIBC_2.30" >"${TMP_DIR}/empty.out" 2>&1; then
+  echo "expected missing GLIBC symbols to fail" >&2
+  exit 1
+fi
+
+grep -q "No GLIBC versioned symbols found" "${TMP_DIR}/empty.out"

--- a/scripts/check-glibc-workflow-config.test.sh
+++ b/scripts/check-glibc-workflow-config.test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflows=(
+  ".github/workflows/release.yml"
+  ".github/workflows/build-manual.yml"
+)
+
+for workflow in "${workflows[@]}"; do
+  if [[ ! -f "${workflow}" ]]; then
+    echo "Workflow not found: ${workflow}" >&2
+    exit 1
+  fi
+
+  grep -Fq 'LINUX_X64_GLIBC_MAX: "GLIBC_2.34"' "${workflow}" \
+    || {
+      echo "${workflow} must pin the Linux x64 GLIBC ceiling to GLIBC_2.34" >&2
+      exit 1
+    }
+
+  grep -Fq "matrix.target == 'x86_64-unknown-linux-gnu'" "${workflow}" \
+    || {
+      echo "${workflow} must verify the Linux x64 GLIBC baseline" >&2
+      exit 1
+    }
+
+  grep -Fq '${LINUX_X64_GLIBC_MAX}' "${workflow}" \
+    || {
+      echo "${workflow} must pass LINUX_X64_GLIBC_MAX to the GLIBC checker" >&2
+      exit 1
+    }
+done
+
+echo "Linux GLIBC workflow config is pinned for x64 and arm64"

--- a/scripts/check-glibc-workflow-config.test.sh
+++ b/scripts/check-glibc-workflow-config.test.sh
@@ -6,6 +6,28 @@ workflows=(
   ".github/workflows/build-manual.yml"
 )
 
+arm64_cross_rev="29d00c7803f221f1b3f35e561b03792368fb8339"
+arm64_cross_image="ghcr.io/cross-rs/aarch64-unknown-linux-gnu@sha256:99e041b94e7d4f31477c6ddede176688562c3762ba3833b75de3316100afc39d"
+
+grep -Fq "${arm64_cross_image}" Cross.toml \
+  || {
+    echo "Cross.toml must pin Linux ARM64 to the v0.1.39/v0.1.40 cross image digest" >&2
+    exit 1
+  }
+
+grep -Fq 'target: x86_64-unknown-linux-gnu' ".github/workflows/release.yml" \
+  && grep -Fq 'os: ubuntu-22.04' ".github/workflows/release.yml" \
+  || {
+    echo ".github/workflows/release.yml must keep Linux x64 on ubuntu-22.04" >&2
+    exit 1
+  }
+
+grep -Fq '"platform":"linux-x64","os":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu"' ".github/workflows/build-manual.yml" \
+  || {
+    echo ".github/workflows/build-manual.yml must keep Linux x64 on ubuntu-22.04" >&2
+    exit 1
+  }
+
 for workflow in "${workflows[@]}"; do
   if [[ ! -f "${workflow}" ]]; then
     echo "Workflow not found: ${workflow}" >&2
@@ -15,6 +37,18 @@ for workflow in "${workflows[@]}"; do
   grep -Fq 'LINUX_X64_GLIBC_MAX: "GLIBC_2.34"' "${workflow}" \
     || {
       echo "${workflow} must pin the Linux x64 GLIBC ceiling to GLIBC_2.34" >&2
+      exit 1
+    }
+
+  grep -Fq "CROSS_GIT_REV: \"${arm64_cross_rev}\"" "${workflow}" \
+    || {
+      echo "${workflow} must pin cross to the v0.1.39/v0.1.40 git revision" >&2
+      exit 1
+    }
+
+  grep -Fq 'cargo install cross --git https://github.com/cross-rs/cross --rev "${CROSS_GIT_REV}" --locked' "${workflow}" \
+    || {
+      echo "${workflow} must install cross from the pinned git revision" >&2
       exit 1
     }
 

--- a/scripts/check-glibc-workflow-config.test.sh
+++ b/scripts/check-glibc-workflow-config.test.sh
@@ -52,6 +52,12 @@ for workflow in "${workflows[@]}"; do
       exit 1
     }
 
+  grep -Fq "docker pull ${arm64_cross_image}" "${workflow}" \
+    || {
+      echo "${workflow} must pre-pull the pinned Linux ARM64 cross image" >&2
+      exit 1
+    }
+
   grep -Fq "matrix.target == 'x86_64-unknown-linux-gnu'" "${workflow}" \
     || {
       echo "${workflow} must verify the Linux x64 GLIBC baseline" >&2


### PR DESCRIPTION
## Summary
- Pin the Linux ARM64 cross revision and image digest to the build environment used by the v0.1.39/v0.1.40 releases.
- Add Linux GLIBC baseline checks for ARM64 and x64 release/manual builds.
- Pre-pull the pinned ARM64 cross image so missing or unavailable images fail early with a clear error.

## Validation
- Ran `just push` successfully.
- Verified Linux ARM64 manual artifact requires at most `GLIBC_2.30`.
- Verified Linux x64 manual artifact requires at most `GLIBC_2.34`.

## Release Notes
- Keeps Linux release binaries on the same GLIBC compatibility baselines as the last known-good v0.1.39/v0.1.40 builds.