### PR TITLE
fix(cron): enforce full-auto mode for scheduled tasks

### DIFF
--- a/crates/aionui-app/src/router/team_conversation_adapters.rs
+++ b/crates/aionui-app/src/router/team_conversation_adapters.rs
@@ -80,6 +80,7 @@ impl AgentTurnExecutionPort for TeamConversationAdapters {
                     content: request.content.clone(),
                     files: request.files.clone(),
                     inject_skills: Vec::new(),
+                    required_runtime_mode: None,
                     persist_user_message: false,
                     user_message_hidden: false,
                     on_started: on_started.clone(),

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -334,6 +334,7 @@ pub struct ConversationAgentTurnRequest {
     pub content: String,
     pub files: Vec<String>,
     pub inject_skills: Vec<String>,
+    pub required_runtime_mode: Option<String>,
     pub persist_user_message: bool,
     pub user_message_hidden: bool,
     pub on_started: Option<ConversationAgentTurnStartedCallback>,
@@ -1997,8 +1998,21 @@ impl ConversationService {
     }
 
     pub async fn save_acp_runtime_mode(&self, conversation_id: &str, mode: &str) -> Result<(), ConversationError> {
+        let runtime_state = self
+            .acp_session_repo
+            .load_runtime_state(conversation_id)
+            .await
+            .map_err(|e| ConversationError::internal(format!("Failed to load runtime mode state: {e}")))?;
+        let mut config_selections = runtime_state
+            .and_then(|state| state.config_selections_json)
+            .and_then(|raw| serde_json::from_str::<HashMap<String, String>>(&raw).ok())
+            .unwrap_or_default();
+        config_selections.insert("mode".to_owned(), mode.to_owned());
+        let config_selections_json = serde_json::to_string(&config_selections)
+            .map_err(|e| ConversationError::internal(format!("Failed to serialize runtime mode selection: {e}")))?;
         let params = SaveRuntimeStateParams {
             current_mode_id: Some(Some(mode)),
+            config_selections_json: Some(Some(config_selections_json.as_str())),
             ..Default::default()
         };
         self.acp_session_repo
@@ -2670,6 +2684,7 @@ impl ConversationService {
             user_id: user_id.to_owned(),
             conversation: row,
             request: req,
+            required_runtime_mode: None,
             build_options: build_opts,
             stored_workspace,
             turn_id: turn_id.clone(),
@@ -2793,6 +2808,7 @@ impl ConversationService {
                     inject_skills: request.inject_skills,
                     hidden: request.user_message_hidden,
                 },
+                required_runtime_mode: request.required_runtime_mode,
                 build_options: build_opts,
                 stored_workspace,
                 turn_id: turn_id.clone(),

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -862,6 +862,7 @@ struct RuntimeStateSaveCall {
     conversation_id: String,
     current_mode_id: Option<Option<String>>,
     current_model_id: Option<Option<String>>,
+    config_selections_json: Option<Option<String>>,
 }
 
 #[derive(Default)]
@@ -869,6 +870,7 @@ struct StubAcpSessionRepo {
     create_calls: Mutex<Vec<CreateAcpSessionCall>>,
     runtime_state_saves: Mutex<Vec<RuntimeStateSaveCall>>,
     session_id: Mutex<Option<String>>,
+    runtime_state: Mutex<Option<PersistedSessionState>>,
 }
 
 impl StubAcpSessionRepo {
@@ -881,6 +883,16 @@ impl StubAcpSessionRepo {
             create_calls: Mutex::new(Vec::new()),
             runtime_state_saves: Mutex::new(Vec::new()),
             session_id: Mutex::new(Some(session_id.into())),
+            runtime_state: Mutex::new(None),
+        }
+    }
+
+    fn with_runtime_state(state: PersistedSessionState) -> Self {
+        Self {
+            create_calls: Mutex::new(Vec::new()),
+            runtime_state_saves: Mutex::new(Vec::new()),
+            session_id: Mutex::new(None),
+            runtime_state: Mutex::new(Some(state)),
         }
     }
 
@@ -941,10 +953,12 @@ impl IAcpSessionRepository for StubAcpSessionRepo {
         Ok(false)
     }
     async fn load_runtime_state(&self, _conversation_id: &str) -> Result<Option<PersistedSessionState>, DbError> {
-        Ok(Some(PersistedSessionState {
-            current_model_id: Some("deepseek-v4-pro".to_owned()),
-            ..Default::default()
-        }))
+        Ok(Some(self.runtime_state.lock().unwrap().clone().unwrap_or(
+            PersistedSessionState {
+                current_model_id: Some("deepseek-v4-pro".to_owned()),
+                ..Default::default()
+            },
+        )))
     }
     async fn save_runtime_state(
         &self,
@@ -955,6 +969,7 @@ impl IAcpSessionRepository for StubAcpSessionRepo {
             conversation_id: conversation_id.to_owned(),
             current_mode_id: params.current_mode_id.map(|outer| outer.map(ToOwned::to_owned)),
             current_model_id: params.current_model_id.map(|outer| outer.map(ToOwned::to_owned)),
+            config_selections_json: params.config_selections_json.map(|outer| outer.map(ToOwned::to_owned)),
         });
         Ok(true)
     }
@@ -2528,6 +2543,11 @@ impl MockAgent {
         self
     }
 
+    fn with_mode(self, mode: &str) -> Self {
+        *self.mode.lock().unwrap() = mode.to_owned();
+        self
+    }
+
     fn with_set_config_option_response(self, response: SetConfigOptionResponse) -> Self {
         *self.set_config_option_response.lock().unwrap() = Some(response);
         self
@@ -2634,16 +2654,30 @@ impl IMockAgent for MockAgent {
             .lock()
             .unwrap()
             .push((option_id.to_owned(), value.to_owned()));
+        if option_id == "mode" {
+            *self.mode.lock().unwrap() = value.to_owned();
+        }
         if let Some(error) = self.set_config_option_error.lock().unwrap().take() {
             return Err(error);
         }
         if let Some(response) = self.set_config_option_response.lock().unwrap().clone() {
+            if let Some(config_options) = response.config_options.as_ref() {
+                let _ = self.event_tx.send(AgentStreamEvent::AcpConfigOption(json!({
+                    "config_options": config_options,
+                })));
+            }
             return Ok(response);
         }
-        Ok(SetConfigOptionResponse {
+        let response = SetConfigOptionResponse {
             confirmation: ConfigOptionConfirmation::Observed,
             config_options: Some(self.config_options.lock().unwrap().clone()),
-        })
+        };
+        if let Some(config_options) = response.config_options.as_ref() {
+            let _ = self.event_tx.send(AgentStreamEvent::AcpConfigOption(json!({
+                "config_options": config_options,
+            })));
+        }
+        Ok(response)
     }
 }
 
@@ -3408,6 +3442,7 @@ async fn run_agent_turn_injects_conversation_runtime_context() {
             content: "run scheduled task".into(),
             files: Vec::new(),
             inject_skills: Vec::new(),
+            required_runtime_mode: None,
             persist_user_message: true,
             user_message_hidden: true,
             on_started: None,
@@ -3581,6 +3616,90 @@ async fn set_config_option_returns_observed_confirmation() {
         agent.set_config_option_calls.lock().unwrap().as_slice(),
         &[("reasoning_effort".to_owned(), "high".to_owned())]
     );
+}
+
+#[tokio::test]
+async fn save_acp_runtime_mode_updates_runtime_mode_config_selection() {
+    let acp_repo = Arc::new(StubAcpSessionRepo::with_runtime_state(PersistedSessionState {
+        current_mode_id: Some("read-only".to_owned()),
+        current_model_id: Some("gpt-5.3-codex".to_owned()),
+        config_selections_json: Some(
+            serde_json::json!({
+                "mode": "read-only",
+                "model": "gpt-5.3-codex",
+                "reasoning_effort": "low"
+            })
+            .to_string(),
+        ),
+        context_usage_json: None,
+    }));
+    let (svc, _, _, _) = make_service_with_resolver_and_acp_session_repo(
+        Arc::new(FixedSkillResolver { names: vec![] }),
+        acp_repo.clone(),
+    );
+    svc.save_acp_runtime_mode("conv_1", "full-access").await.unwrap();
+
+    let saves = acp_repo.runtime_state_saves();
+    assert_eq!(saves.len(), 1);
+    assert_eq!(saves[0].current_mode_id, Some(Some("full-access".to_owned())));
+    let selections: serde_json::Value =
+        serde_json::from_str(saves[0].config_selections_json.as_ref().unwrap().as_ref().unwrap()).unwrap();
+    assert_eq!(selections["mode"], "full-access");
+    assert_eq!(selections["model"], "gpt-5.3-codex");
+    assert_eq!(selections["reasoning_effort"], "low");
+}
+
+#[tokio::test]
+async fn run_agent_turn_applies_required_runtime_mode_after_stream_subscription() {
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let (svc, broadcaster, _repo) = make_service_with_mock_task_manager(task_mgr.clone());
+    let conv = svc.create("user_1", make_create_req()).await.unwrap();
+    broadcaster.take_events();
+
+    let agent = Arc::new(
+        MockAgent::new(&conv.id)
+            .with_mode("yolo")
+            .with_config_options(vec![AcpConfigOptionDto {
+                id: "mode".to_owned(),
+                name: Some("Mode".to_owned()),
+                label: None,
+                description: None,
+                category: Some("mode".to_owned()),
+                option_type: "select".to_owned(),
+                current_value: Some("yolo".to_owned()),
+                options: Vec::new(),
+            }]),
+    );
+    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(agent.clone()));
+
+    let outcome = svc
+        .run_agent_turn(ConversationAgentTurnRequest {
+            user_id: "user_1".to_owned(),
+            conversation_id: conv.id.clone(),
+            content: "run scheduled task".to_owned(),
+            files: Vec::new(),
+            inject_skills: Vec::new(),
+            required_runtime_mode: Some("yolo".to_owned()),
+            persist_user_message: true,
+            user_message_hidden: true,
+            on_started: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.status, ConversationAgentTurnStatus::Completed);
+    assert_eq!(
+        agent.set_config_option_calls.lock().unwrap().as_slice(),
+        &[("mode".to_owned(), "yolo".to_owned())]
+    );
+    let events = broadcaster.take_events();
+    let config_event = events
+        .iter()
+        .find(|event| event.name == "message.stream" && event.data["type"] == "acp_config_option")
+        .expect("runtime mode switch should broadcast config option snapshot");
+    assert_eq!(config_event.data["conversation_id"], conv.id);
+    assert_eq!(config_event.data["data"]["config_options"][0]["id"], "mode");
+    assert_eq!(config_event.data["data"]["config_options"][0]["current_value"], "yolo");
 }
 
 #[tokio::test]
@@ -4304,6 +4423,7 @@ async fn run_agent_turn_returns_error_message_when_agent_build_fails() {
             content: "run scheduled task".into(),
             files: Vec::new(),
             inject_skills: Vec::new(),
+            required_runtime_mode: None,
             persist_user_message: true,
             user_message_hidden: true,
             on_started: None,

--- a/crates/aionui-conversation/src/service_test/acp_error_recovery_test.rs
+++ b/crates/aionui-conversation/src/service_test/acp_error_recovery_test.rs
@@ -102,6 +102,7 @@ async fn send_message_clears_persisted_acp_model_after_model_not_found() {
             conversation_id: conv.id.clone(),
             current_mode_id: None,
             current_model_id: Some(None),
+            config_selections_json: None,
         }]
     );
 

--- a/crates/aionui-conversation/src/turn_orchestrator.rs
+++ b/crates/aionui-conversation/src/turn_orchestrator.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
-use aionui_ai_agent::{AgentSendError, AgentSessionKind, IWorkerTaskManager};
+use aionui_ai_agent::{AgentError, AgentInstance, AgentSendError, AgentSessionKind, IWorkerTaskManager};
 use aionui_common::{AgentType, ConversationStatus, ErrorChain, now_ms};
 use aionui_db::models::ConversationRow;
 use tokio::sync::oneshot;
@@ -29,6 +29,7 @@ pub(crate) struct TurnStartInput {
     pub user_id: String,
     pub conversation: ConversationRow,
     pub request: SendMessageRequest,
+    pub required_runtime_mode: Option<String>,
     pub build_options: BuildTaskOptions,
     pub stored_workspace: String,
     pub turn_id: String,
@@ -60,6 +61,7 @@ struct TurnAttemptInput {
     send: SendMessageData,
     msg_id: String,
     allowed_skill_names: Vec<String>,
+    required_runtime_mode: Option<String>,
     continuation_count: usize,
     defer_clean_terminal_errors: bool,
 }
@@ -214,6 +216,47 @@ impl ConversationTurnOrchestrator {
             .with_defer_clean_terminal_errors(defer_clean_terminal_errors);
 
             let rx = agent.subscribe();
+            if let Some(mode) = input
+                .required_runtime_mode
+                .as_deref()
+                .map(str::trim)
+                .filter(|mode| !mode.is_empty())
+            {
+                match apply_required_runtime_mode(&agent, mode).await {
+                    Ok(()) => {
+                        info!(
+                            conversation_id = %input.conv_id,
+                            turn_id = %input.turn_id,
+                            mode,
+                            "Confirmed required runtime mode before agent turn"
+                        );
+                    }
+                    Err(err) => {
+                        let top_level_code = agent_error_top_level_code(&err);
+                        let failure_message = err.to_string();
+                        let send_error = AgentSendError::from_agent_error(err);
+                        error!(
+                            conversation_id = %input.conv_id,
+                            turn_id = %input.turn_id,
+                            mode,
+                            error = %failure_message,
+                            "Failed to apply required runtime mode before agent turn"
+                        );
+                        self.service
+                            .persist_and_broadcast_send_failure_tip(
+                                &input.conv_id,
+                                &input.turn_id,
+                                &send_error,
+                                Some(top_level_code),
+                            )
+                            .await;
+                        return Err(ConversationTurnResult {
+                            status: ConversationTurnStatus::Failed,
+                            error_message: Some(failure_message),
+                        });
+                    }
+                }
+            }
             let send_agent = agent.clone();
             let conv_id_send = input.conv_id.clone();
             let turn_id_for_send = input.turn_id.clone();
@@ -336,6 +379,7 @@ impl ConversationTurnOrchestrator {
                     send: initial_send.clone(),
                     msg_id: first_turn_msg_id.clone(),
                     allowed_skill_names: allowed_skill_names.clone(),
+                    required_runtime_mode: input.required_runtime_mode.clone(),
                     continuation_count: 0,
                     defer_clean_terminal_errors: !replayed,
                 })
@@ -469,6 +513,11 @@ fn availability_agent_id(options: &BuildTaskOptions) -> Option<String> {
             .map(str::to_owned),
         AgentSessionKind::Aionrs(_) => None,
     }
+}
+
+async fn apply_required_runtime_mode(agent: &AgentInstance, mode: &str) -> Result<(), AgentError> {
+    agent.set_config_option("mode", mode).await?;
+    Ok(())
 }
 
 fn send_error_display_message(error: &AgentSendError) -> String {

--- a/crates/aionui-conversation/tests/stream_relay_tool_call.rs
+++ b/crates/aionui-conversation/tests/stream_relay_tool_call.rs
@@ -322,6 +322,7 @@ async fn run_agent_turn_with_empty_call_id_tool_call_is_not_persisted() {
             content: "run glob".into(),
             files: Vec::new(),
             inject_skills: Vec::new(),
+            required_runtime_mode: None,
             persist_user_message: false,
             user_message_hidden: false,
             on_started: None,

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -290,61 +290,58 @@ impl JobExecutor {
         &self,
         conversation_id: &str,
         cron_job_id: &str,
+        session_mode: Option<&str>,
     ) -> Result<(), CronError> {
         let Some(row) = self.get_conversation_row(conversation_id).await? else {
             return Ok(());
         };
 
+        let session_mode = session_mode.map(str::trim).filter(|value| !value.is_empty());
+        let is_acp_conversation = row.r#type == AgentType::Acp.serde_name();
         let mut extra: serde_json::Value = serde_json::from_str(&row.extra).unwrap_or_else(|_| serde_json::json!({}));
-        let Some(obj) = extra.as_object_mut() else {
+        if !extra.is_object() {
             extra = serde_json::json!({});
-            extra.as_object_mut().expect("json object").insert(
-                "cron_job_id".to_owned(),
-                serde_json::Value::String(cron_job_id.to_owned()),
-            );
-            extra.as_object_mut().expect("json object").insert(
-                "cronJobId".to_owned(),
-                serde_json::Value::String(cron_job_id.to_owned()),
-            );
-            let update = ConversationRowUpdate {
-                extra: Some(extra.to_string()),
-                updated_at: Some(now_ms()),
-                ..Default::default()
-            };
-            return self
-                .conversation_repo
-                .update(conversation_id, &update)
-                .await
-                .map_err(CronError::Database);
-        };
+        }
+
+        let obj = extra.as_object_mut().expect("json object");
+        let mut changed = false;
 
         let current = obj
             .get("cron_job_id")
             .and_then(|value| value.as_str())
             .or_else(|| obj.get("cronJobId").and_then(|value| value.as_str()));
 
-        if current == Some(cron_job_id) {
-            return Ok(());
+        if current != Some(cron_job_id) {
+            obj.insert(
+                "cron_job_id".to_owned(),
+                serde_json::Value::String(cron_job_id.to_owned()),
+            );
+            obj.insert(
+                "cronJobId".to_owned(),
+                serde_json::Value::String(cron_job_id.to_owned()),
+            );
+            changed = true;
         }
 
-        obj.insert(
-            "cron_job_id".to_owned(),
-            serde_json::Value::String(cron_job_id.to_owned()),
-        );
-        obj.insert(
-            "cronJobId".to_owned(),
-            serde_json::Value::String(cron_job_id.to_owned()),
-        );
+        if changed {
+            let update = ConversationRowUpdate {
+                extra: Some(extra.to_string()),
+                updated_at: Some(now_ms()),
+                ..Default::default()
+            };
+            self.conversation_repo
+                .update(conversation_id, &update)
+                .await
+                .map_err(CronError::Database)?;
+        }
 
-        let update = ConversationRowUpdate {
-            extra: Some(extra.to_string()),
-            updated_at: Some(now_ms()),
-            ..Default::default()
-        };
-        self.conversation_repo
-            .update(conversation_id, &update)
-            .await
-            .map_err(CronError::Database)
+        if is_acp_conversation && let Some(mode) = session_mode {
+            self.conversation_service
+                .save_acp_runtime_mode(conversation_id, mode)
+                .await?;
+        }
+
+        Ok(())
     }
 
     pub async fn unbind_cron_job_from_conversation(
@@ -664,6 +661,7 @@ impl JobExecutor {
             content: prompt,
             files: vec![],
             inject_skills: skill_names.clone(),
+            required_runtime_mode: cron_job_runtime_mode(job).map(ToOwned::to_owned),
             persist_user_message: true,
             user_message_hidden: true,
             on_started,
@@ -1027,6 +1025,14 @@ fn build_prompt(job: &CronJob, saved_skill: Option<&SavedSkillContext>) -> Strin
             }
         }
     }
+}
+
+fn cron_job_runtime_mode(job: &CronJob) -> Option<&str> {
+    job.agent_config
+        .as_ref()
+        .and_then(|config| config.mode.as_deref())
+        .map(str::trim)
+        .filter(|mode| !mode.is_empty())
 }
 
 fn build_assistant_request(job: &CronJob) -> Option<AssistantConversationRequest> {
@@ -1790,7 +1796,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_inner_leaves_session_mode_to_conversation_runtime() {
+    async fn execute_inner_applies_session_mode_to_active_conversation_runtime() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", true));
         let executor = make_executor_with_agent(AgentInstance::Mock(agent.clone()));
         let mut job = sample_job();
@@ -1805,13 +1811,13 @@ mod tests {
             }
         );
         wait_for_agent_send(&agent, 1).await;
-        assert_eq!(agent.mode().await, "default");
-        assert_eq!(agent.set_mode_calls(), 0);
+        assert_eq!(agent.mode().await, "yolo");
+        assert_eq!(agent.set_mode_calls(), 1);
         assert_eq!(agent.send_calls(), 1);
     }
 
     #[tokio::test]
-    async fn execute_inner_does_not_directly_set_mode_for_uninitialized_agent() {
+    async fn execute_inner_applies_session_mode_when_mode_endpoint_is_uninitialized() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "default", false));
         let executor = make_executor_with_agent(AgentInstance::Mock(agent.clone()));
         let mut job = sample_job();
@@ -1826,13 +1832,13 @@ mod tests {
             }
         );
         wait_for_agent_send(&agent, 1).await;
-        assert_eq!(agent.mode().await, "default");
-        assert_eq!(agent.set_mode_calls(), 0);
+        assert_eq!(agent.mode().await, "yolo");
+        assert_eq!(agent.set_mode_calls(), 1);
         assert_eq!(agent.send_calls(), 1);
     }
 
     #[tokio::test]
-    async fn execute_inner_skips_mode_update_when_already_matching() {
+    async fn execute_inner_reconfirms_session_mode_when_reported_already_matching() {
         let agent = Arc::new(RecordingAgent::new("conv_1", "yolo", true));
         let executor = make_executor_with_agent(AgentInstance::Mock(agent.clone()));
         let mut job = sample_job();
@@ -1848,7 +1854,7 @@ mod tests {
         );
         wait_for_agent_send(&agent, 1).await;
         assert_eq!(agent.mode().await, "yolo");
-        assert_eq!(agent.set_mode_calls(), 0);
+        assert_eq!(agent.set_mode_calls(), 1);
         assert_eq!(agent.send_calls(), 1);
     }
 

--- a/crates/aionui-cron/src/service.rs
+++ b/crates/aionui-cron/src/service.rs
@@ -13,7 +13,7 @@ use aionui_common::{
 };
 use aionui_db::{
     IAgentMetadataRepository, IAssistantDefinitionRepository, IAssistantOverlayRepository, ICronRepository,
-    UpdateCronJobParams, resolve_agent_binding_from_rows,
+    UpdateCronJobParams, models::AgentMetadataRow, resolve_agent_binding_from_rows, runtime_backend_for_agent,
 };
 use tracing::{debug, error, info, warn};
 
@@ -122,7 +122,11 @@ impl CronService {
             .await?;
         if let Err(err) = self
             .executor
-            .bind_cron_job_to_conversation(conversation_id, &job.id)
+            .bind_cron_job_to_conversation(
+                conversation_id,
+                &job.id,
+                job.agent_config.as_ref().and_then(|config| config.mode.as_deref()),
+            )
             .await
         {
             if let Err(cleanup_err) = self.remove_job(&job.id).await {
@@ -198,7 +202,11 @@ impl CronService {
             .await?;
 
         self.executor
-            .bind_cron_job_to_conversation(conversation_id, &job.id)
+            .bind_cron_job_to_conversation(
+                conversation_id,
+                &job.id,
+                job.agent_config.as_ref().and_then(|config| config.mode.as_deref()),
+            )
             .await?;
 
         Ok(job)
@@ -750,7 +758,11 @@ impl CronService {
 
         if let Err(err) = self
             .executor
-            .bind_cron_job_to_conversation(&job.conversation_id, &job.id)
+            .bind_cron_job_to_conversation(
+                &job.conversation_id,
+                &job.id,
+                job.agent_config.as_ref().and_then(|config| config.mode.as_deref()),
+            )
             .await
         {
             warn!(
@@ -781,7 +793,11 @@ impl CronService {
         };
         self.repo.update(&job.id, &params).await?;
         self.executor
-            .bind_cron_job_to_conversation(conversation_id, &job.id)
+            .bind_cron_job_to_conversation(
+                conversation_id,
+                &job.id,
+                job.agent_config.as_ref().and_then(|config| config.mode.as_deref()),
+            )
             .await?;
         job.conversation_id = conversation_id.to_owned();
 
@@ -949,7 +965,7 @@ impl CronService {
         if needs_conversation_bind
             && let Err(e) = self
                 .executor
-                .bind_cron_job_to_conversation(conversation_id, job_id)
+                .bind_cron_job_to_conversation(conversation_id, job_id, None)
                 .await
         {
             warn!(
@@ -1366,11 +1382,32 @@ impl CronService {
                 .unwrap_or_else(|| row.r#type.clone())
         };
 
-        let agent_type_enum = serde_json::from_value::<AgentType>(serde_json::Value::String(row.r#type.clone())).ok();
-        let full_auto_mode = agent_type_enum
-            .unwrap_or(AgentType::Acp)
-            .full_auto_mode_id(Some(backend.as_str()))
-            .to_owned();
+        let assistant_id_for_mode = if uses_default_assistant_fallback {
+            None
+        } else {
+            assistant_id.as_deref()
+        };
+        let full_auto_mode = match self
+            .resolve_cron_full_auto_mode(
+                &row.r#type,
+                assistant_id_for_mode,
+                assistant_snapshot.as_ref().map(|snapshot| snapshot.agent_id.as_str()),
+                Some(backend.as_str()),
+            )
+            .await
+        {
+            Ok(mode) => mode,
+            Err(err) => {
+                warn!(
+                    conversation_id = %row.id,
+                    assistant_id = assistant_id.as_deref().unwrap_or(""),
+                    backend,
+                    error = %err,
+                    "Failed to resolve cron full-auto mode from agent metadata"
+                );
+                fallback_full_auto_mode(&row.r#type, Some(backend.as_str()))
+            }
+        };
         let agent_config = aionui_api_types::CronAgentConfigWriteDto {
             name: assistant_name
                 .or_else(|| get_string(&extra, &["agent_name", "agentName"]))
@@ -1418,13 +1455,22 @@ impl CronService {
             ));
         };
 
-        self.resolve_assistant_backend(Some(assistant_id))
+        let assistant_backend = self
+            .resolve_assistant_backend(Some(assistant_id))
             .await?
             .ok_or_else(|| {
                 CronError::InvalidAgentConfig(format!(
                     "assistant '{assistant_id}' could not resolve a runtime backend"
                 ))
             })?;
+        let full_auto_mode = self
+            .resolve_cron_full_auto_mode(
+                runtime_agent_type,
+                Some(assistant_id),
+                None,
+                Some(assistant_backend.as_str()),
+            )
+            .await?;
 
         Ok(CronAgentConfig {
             name: config.name,
@@ -1432,7 +1478,7 @@ impl CronService {
             is_preset: None,
             assistant_id: config.assistant_id,
             custom_agent_id: None,
-            mode: config.mode,
+            mode: Some(full_auto_mode),
             model_id: config.model_id,
             model: normalize_model(config.model, runtime_agent_type)?,
             config_options: config.config_options,
@@ -1516,6 +1562,82 @@ impl CronService {
             .map(|binding| binding.runtime_backend)
             .unwrap_or_else(|| agent_id.to_owned()))
     }
+
+    async fn resolve_cron_full_auto_mode(
+        &self,
+        runtime_agent_type: &str,
+        assistant_id: Option<&str>,
+        agent_id_hint: Option<&str>,
+        backend_hint: Option<&str>,
+    ) -> Result<String, CronError> {
+        if let Some(row) = self.resolve_agent_metadata_for_assistant(assistant_id).await? {
+            return Ok(full_auto_mode_from_metadata(&row, runtime_agent_type));
+        }
+
+        if let Some(row) = self.resolve_agent_metadata_for_value(agent_id_hint).await? {
+            return Ok(full_auto_mode_from_metadata(&row, runtime_agent_type));
+        }
+
+        if let Some(row) = self.resolve_agent_metadata_for_value(backend_hint).await? {
+            return Ok(full_auto_mode_from_metadata(&row, runtime_agent_type));
+        }
+
+        Ok(fallback_full_auto_mode(runtime_agent_type, backend_hint))
+    }
+
+    async fn resolve_agent_metadata_for_assistant(
+        &self,
+        assistant_id: Option<&str>,
+    ) -> Result<Option<AgentMetadataRow>, CronError> {
+        let Some(assistant_id) = assistant_id.map(str::trim).filter(|value| !value.is_empty()) else {
+            return Ok(None);
+        };
+
+        let Some(definition) = self.assistant_definition_repo.get_by_assistant_id(assistant_id).await? else {
+            return Ok(None);
+        };
+        let overlay = self.assistant_overlay_repo.get(&definition.id).await?;
+        let effective_agent_id = overlay
+            .as_ref()
+            .and_then(|item| item.agent_id_override.as_deref())
+            .unwrap_or(definition.agent_id.as_str());
+
+        self.resolve_agent_metadata_for_value(Some(effective_agent_id)).await
+    }
+
+    async fn resolve_agent_metadata_for_value(
+        &self,
+        value: Option<&str>,
+    ) -> Result<Option<AgentMetadataRow>, CronError> {
+        let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+            return Ok(None);
+        };
+
+        let rows = self.agent_metadata_repo.list_all().await?;
+        let Some(binding) = resolve_agent_binding_from_rows(&rows, value) else {
+            return Ok(None);
+        };
+
+        Ok(rows.into_iter().find(|row| row.id == binding.agent_id))
+    }
+}
+
+fn full_auto_mode_from_metadata(row: &AgentMetadataRow, runtime_agent_type: &str) -> String {
+    row.yolo_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| fallback_full_auto_mode(runtime_agent_type, Some(runtime_backend_for_agent(row).as_str())))
+}
+
+fn fallback_full_auto_mode(runtime_agent_type: &str, backend_hint: Option<&str>) -> String {
+    let agent_type_enum =
+        serde_json::from_value::<AgentType>(serde_json::Value::String(runtime_agent_type.to_owned())).ok();
+    agent_type_enum
+        .unwrap_or(AgentType::Acp)
+        .full_auto_mode_id(backend_hint)
+        .to_owned()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aionui-cron/tests/service_integration.rs
+++ b/crates/aionui-cron/tests/service_integration.rs
@@ -1127,6 +1127,18 @@ async fn create_job_strips_legacy_agent_ids_when_assistant_id_present() {
 }
 
 #[tokio::test]
+async fn create_job_uses_assistant_full_auto_mode_instead_of_requested_mode() {
+    let (svc, _, _) = setup().await;
+    let req = make_create_req("Full Auto Mode", every_60s());
+
+    let job = svc.add_job(req).await.unwrap();
+    let config = job.agent_config.expect("agent config");
+
+    assert_eq!(config.assistant_id.as_deref(), Some("assistant-default"));
+    assert_eq!(config.mode.as_deref(), Some("bypassPermissions"));
+}
+
+#[tokio::test]
 async fn create_job_derives_assistant_runtime_without_backend_hint() {
     let (svc, _, _) = setup().await;
 
@@ -2302,6 +2314,57 @@ async fn create_for_conversation_helper_creates_claimed_conversation_job_with_mu
     let linked = conv_repo.list_by_cron_job("u1", &response.job_id).await.unwrap();
     assert_eq!(linked.len(), 1);
     assert_eq!(linked[0].id, "conv_1");
+}
+
+#[tokio::test]
+async fn create_for_conversation_helper_keeps_conversation_extra_mode_unchanged() {
+    let (svc, cron_repo, _, conv_repo, conv_service) = setup_with_conv_runtime().await;
+    let runtime_state = conv_service.runtime_state();
+    let _claim = runtime_state
+        .try_claim_turn("conv_mode_default", "turn_helper_create_full_auto")
+        .expect("claim conversation");
+
+    let response = svc
+        .create_for_conversation_helper(
+            "u1",
+            "conv_mode_default",
+            conversation_cron_request("create files without prompting"),
+        )
+        .await
+        .unwrap();
+
+    let row = cron_repo.get_by_id(&response.job_id).await.unwrap().unwrap();
+    let config: CronAgentConfig = serde_json::from_str(row.agent_config.as_deref().unwrap()).unwrap();
+    assert_eq!(config.mode.as_deref(), Some("yolo"));
+
+    let bound = conv_repo.get("conv_mode_default").await.unwrap().unwrap();
+    let extra: serde_json::Value = serde_json::from_str(&bound.extra).unwrap();
+    assert_eq!(extra["cron_job_id"], response.job_id);
+    assert_eq!(extra["cronJobId"], response.job_id);
+    assert_eq!(extra["session_mode"], "default");
+    assert!(extra.get("current_mode_id").is_none());
+}
+
+#[tokio::test]
+async fn create_for_conversation_helper_uses_assistant_metadata_full_auto_mode() {
+    let (svc, cron_repo, _, _, conv_service) = setup_with_conv_runtime().await;
+    let runtime_state = conv_service.runtime_state();
+    let _claim = runtime_state
+        .try_claim_turn("conv_mode_codex", "turn_helper_create_codex_full_auto")
+        .expect("claim conversation");
+
+    let response = svc
+        .create_for_conversation_helper(
+            "u1",
+            "conv_mode_codex",
+            conversation_cron_request("run codex without prompting"),
+        )
+        .await
+        .unwrap();
+
+    let row = cron_repo.get_by_id(&response.job_id).await.unwrap().unwrap();
+    let config: CronAgentConfig = serde_json::from_str(row.agent_config.as_deref().unwrap()).unwrap();
+    assert_eq!(config.mode.as_deref(), Some("full-access"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- preserve cron jobs when related conversations are deleted and create replacement conversations for existing-mode jobs when needed
- enforce scheduled task runtime mode through the agent runtime before dispatch, using assistant/agent metadata full-auto mode values instead of hardcoded yolo ids
- keep existing-mode replacement conversations eligible for cron skill editing and return the active conversation when run-now is clicked while it is already running

## Tests
- cargo fmt --all -- --check
- git diff --check
- cargo nextest run -p aionui-cron
- cargo nextest run -p aionui-conversation run_agent_turn_applies_required_runtime_mode_after_stream_subscription save_acp_runtime_mode_updates_runtime_mode_config_selection
- cargo check -p aionui-app
- just push -u origin fix/cron-skill-yolo-mode