### PR TITLE
fix(assistant): filter generated assistants by installed agents

### DIFF
--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -188,12 +188,12 @@ impl AgentRegistry {
             tx: self.catalog_tx.clone(),
         }
     }
-    /// Reload every row from the database without probing spawn commands.
+    /// Reload every row from the database and refresh installation state.
     ///
-    /// Startup must be cheap and side-effect free: user-facing health checks
-    /// are explicit, so hydration projects availability from persisted
-    /// snapshots and only marks deterministic row states (disabled/no command)
-    /// as unavailable.
+    /// Startup remains side-effect free: this only checks whether the required
+    /// command / managed runtime can be resolved. It does not start agents,
+    /// perform handshakes, fetch models, or overwrite persisted health-check
+    /// snapshots. User-facing health checks stay explicit.
     pub async fn hydrate(&self) -> Result<(), AgentError> {
         let rows = self
             .repo
@@ -204,7 +204,7 @@ impl AgentRegistry {
         let mut map = HashMap::with_capacity(rows.len());
         let mut reasons = HashMap::new();
         for row in rows {
-            let Some((meta, reason)) = decode_row(row, AvailabilityProjection::Cached) else {
+            let Some((meta, reason)) = decode_row(row, AvailabilityProjection::Probe) else {
                 continue;
             };
             if let Some(reason) = reason {

--- a/crates/aionui-ai-agent/src/registry_tests.rs
+++ b/crates/aionui-ai-agent/src/registry_tests.rs
@@ -226,9 +226,14 @@ async fn management_rows_derive_missing_diagnostics_from_probe_reason() {
 }
 
 #[tokio::test]
-async fn management_rows_mark_unchecked_agents_unchecked_without_probe() {
+async fn management_rows_mark_installed_agents_without_health_check_unchecked() {
     let db = init_database_memory().await.unwrap();
     let repo: Arc<dyn IAgentMetadataRepository> = Arc::new(SqliteAgentMetadataRepository::new(db.pool().clone()));
+    let temp = tempfile::tempdir().unwrap();
+    let command_path = temp.path().join("unchecked-cli");
+    std::fs::write(&command_path, "#!/bin/sh\nexit 0\n").unwrap();
+    let command = command_path.to_string_lossy().to_string();
+    let source_info = serde_json::json!({ "binary_name": command }).to_string();
 
     repo.upsert(&UpsertAgentMetadataParams {
         id: "agent-unchecked-cli",
@@ -240,9 +245,9 @@ async fn management_rows_mark_unchecked_agents_unchecked_without_probe() {
         backend: Some("custom"),
         agent_type: "acp",
         agent_source: "custom",
-        agent_source_info: Some(r#"{"binary_name":"unchecked-cli"}"#),
+        agent_source_info: Some(&source_info),
         enabled: true,
-        command: Some("unchecked-cli"),
+        command: Some(&command),
         args: Some("[]"),
         env: Some("[]"),
         native_skills_dirs: None,
@@ -271,7 +276,7 @@ async fn management_rows_mark_unchecked_agents_unchecked_without_probe() {
 
     let row_json = serde_json::to_value(&row).unwrap();
     assert_eq!(row_json["status"].as_str(), Some("unchecked"));
-    assert!(!row.installed);
+    assert!(row.installed);
     assert!(row.last_check_status.is_none());
     assert!(row.last_check_error_code.is_none());
 }

--- a/crates/aionui-ai-agent/tests/agent_availability_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_availability_integration.rs
@@ -197,7 +197,7 @@ async fn hydrate_refreshes_installation_without_rerunning_health_check() {
 }
 
 #[tokio::test]
-async fn hydrate_uses_persisted_availability_for_commandless_managed_builtin() {
+async fn hydrate_refreshes_commandless_managed_builtin_installation() {
     let db = init_database_memory().await.unwrap();
     let repo: Arc<dyn IAgentMetadataRepository> = Arc::new(SqliteAgentMetadataRepository::new(db.pool().clone()));
 
@@ -211,7 +211,7 @@ async fn hydrate_uses_persisted_availability_for_commandless_managed_builtin() {
         backend: Some("claude"),
         agent_type: "acp",
         agent_source: "builtin",
-        agent_source_info: Some(r#"{"binary_name":"claude"}"#),
+        agent_source_info: Some(r#"{"binary_name":"definitely-missing-managed-claude-cli"}"#),
         enabled: true,
         command: None,
         args: Some("[]"),
@@ -252,10 +252,10 @@ async fn hydrate_uses_persisted_availability_for_commandless_managed_builtin() {
     let rows = registry.list_management_rows().await;
     let cached = rows.iter().find(|row| row.id == "agent-managed-cached").unwrap();
 
-    assert_eq!(cached.status, AgentManagementStatus::Online);
+    assert_eq!(cached.status, AgentManagementStatus::Missing);
     assert!(
-        cached.installed,
-        "managed builtin should trust persisted online snapshot"
+        !cached.installed,
+        "startup hydrate should refresh managed builtin installation state"
     );
     assert_eq!(cached.last_check_status, Some(AgentSnapshotCheckStatus::Online));
 }

--- a/crates/aionui-ai-agent/tests/agent_availability_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_availability_integration.rs
@@ -149,7 +149,7 @@ async fn management_rows_derive_missing_available_and_unavailable_statuses() {
 }
 
 #[tokio::test]
-async fn hydrate_uses_persisted_availability_without_reprobing_path() {
+async fn hydrate_refreshes_installation_without_rerunning_health_check() {
     let db = init_database_memory().await.unwrap();
     let repo: Arc<dyn IAgentMetadataRepository> = Arc::new(SqliteAgentMetadataRepository::new(db.pool().clone()));
     let temp = tempfile::tempdir().unwrap();
@@ -191,8 +191,8 @@ async fn hydrate_uses_persisted_availability_without_reprobing_path() {
     let rows = registry.list_management_rows().await;
     let cached = rows.iter().find(|row| row.id == "agent-startup-cached").unwrap();
 
-    assert_eq!(cached.status, AgentManagementStatus::Online);
-    assert!(cached.installed, "startup hydrate should not refresh PATH");
+    assert_eq!(cached.status, AgentManagementStatus::Missing);
+    assert!(!cached.installed, "startup hydrate should refresh installation state");
     assert_eq!(cached.last_check_status, Some(AgentSnapshotCheckStatus::Online));
 }
 
@@ -261,7 +261,7 @@ async fn hydrate_uses_persisted_availability_for_commandless_managed_builtin() {
 }
 
 #[tokio::test]
-async fn management_list_uses_cached_availability_without_reprobing_path() {
+async fn management_list_keeps_hydrated_installation_without_reprobing_path() {
     let db = init_database_memory().await.unwrap();
     let repo: Arc<dyn IAgentMetadataRepository> = Arc::new(SqliteAgentMetadataRepository::new(db.pool().clone()));
     let provider_repo: Arc<dyn IProviderRepository> = Arc::new(SqliteProviderRepository::new(db.pool().clone()));
@@ -285,7 +285,7 @@ async fn management_list_uses_cached_availability_without_reprobing_path() {
     let cached = rows.iter().find(|row| row.id == "agent-cached").unwrap();
 
     assert_eq!(cached.status, AgentManagementStatus::Unchecked);
-    assert!(!cached.installed, "management list should not refresh PATH on read");
+    assert!(cached.installed, "management list should not refresh PATH on read");
 }
 
 #[tokio::test]
@@ -328,7 +328,7 @@ async fn manual_health_check_does_not_refresh_unrelated_agents() {
 
     assert_eq!(unrelated.status, AgentManagementStatus::Unchecked);
     assert!(
-        !unrelated.installed,
+        unrelated.installed,
         "single-agent health check should not refresh unrelated agents"
     );
 }
@@ -373,7 +373,7 @@ async fn custom_enabled_toggle_does_not_refresh_unrelated_agents() {
 
     assert_eq!(unrelated.status, AgentManagementStatus::Unchecked);
     assert!(
-        !unrelated.installed,
+        unrelated.installed,
         "custom enabled toggle should not refresh unrelated agents"
     );
 }
@@ -417,9 +417,6 @@ async fn custom_delete_does_not_refresh_unrelated_agents() {
     let unrelated = rows.iter().find(|row| row.id == "agent-unrelated").unwrap();
 
     assert_eq!(unrelated.status, AgentManagementStatus::Unchecked);
-    assert!(
-        !unrelated.installed,
-        "custom delete should not refresh unrelated agents"
-    );
+    assert!(unrelated.installed, "custom delete should not refresh unrelated agents");
     assert!(rows.iter().all(|row| row.id != "agent-target-delete"));
 }

--- a/crates/aionui-app/tests/assistants_e2e.rs
+++ b/crates/aionui-app/tests/assistants_e2e.rs
@@ -135,65 +135,6 @@ fn assert_versioned_avatar_value(value: Option<&str>, expected_path: &str) {
     );
 }
 
-async fn insert_generated_bare_assistant(
-    fx: &Fixture,
-    assistant_id: &str,
-    source_ref: &str,
-    _backend: &str,
-    name: &str,
-) {
-    let pool = fx.services.database.pool().clone();
-    let definition_repo = SqliteAssistantDefinitionRepository::new(pool.clone());
-    let overlay_repo = SqliteAssistantOverlayRepository::new(pool);
-
-    definition_repo
-        .upsert(&UpsertAssistantDefinitionParams {
-            id: &format!("asstdef-{assistant_id}"),
-            assistant_id,
-            source: "generated",
-            owner_type: "system",
-            source_ref: Some(source_ref),
-            source_version: None,
-            source_hash: None,
-            name,
-            name_i18n: "{}",
-            description: None,
-            description_i18n: "{}",
-            avatar_type: "none",
-            avatar_value: None,
-            agent_id: source_ref,
-            rule_resource_type: "none",
-            rule_resource_ref: None,
-            rule_inline_content: None,
-            recommended_prompts: "[]",
-            recommended_prompts_i18n: "{}",
-            default_model_mode: "auto",
-            default_model_value: None,
-            default_permission_mode: "auto",
-            default_permission_value: None,
-            default_thought_level_mode: "auto",
-            default_thought_level_value: None,
-            default_skills_mode: "auto",
-            default_skill_ids: "[]",
-            custom_skill_names: "[]",
-            default_disabled_builtin_skill_ids: "[]",
-            default_mcps_mode: "auto",
-            default_mcp_ids: "[]",
-        })
-        .await
-        .unwrap();
-    overlay_repo
-        .upsert(&UpsertAssistantOverlayParams {
-            assistant_definition_id: &format!("asstdef-{assistant_id}"),
-            enabled: true,
-            sort_order: 5,
-            agent_id_override: None,
-            last_used_at: None,
-        })
-        .await
-        .unwrap();
-}
-
 /// Build the whole app with:
 /// - a manifest at `{builtin_tmp}/assets/assistants.json` registering two
 ///   built-ins (`builtin-office` with rule/skill/avatar files on disk, and
@@ -478,7 +419,6 @@ async fn list_builtin_file_avatar_is_served_via_assistant_avatar_route() {
 #[tokio::test]
 async fn list_generated_assistant_exposes_generated_runtime_fields() {
     let fx = fixture().await;
-    insert_generated_bare_assistant(&fx, "bare:agent-droid", "agent-droid", "droid", "Droid").await;
 
     let resp = fx
         .app
@@ -491,18 +431,15 @@ async fn list_generated_assistant_exposes_generated_runtime_fields() {
     let list = json["data"].as_array().unwrap();
     let generated = list
         .iter()
-        .find(|assistant| assistant["id"] == "bare:agent-droid")
+        .find(|assistant| assistant["id"] == "bare:8e1acf31")
         .expect("generated assistant missing from assistant list");
 
     assert_eq!(generated["source"], "generated");
     assert_eq!(generated["deletable"], false);
-    assert_eq!(generated["agent_status"], "missing");
+    assert_eq!(generated["agent_status"], "online");
     assert_eq!(generated["agent_status_message"], Value::Null);
-    assert_eq!(generated["team_selectable"], false);
-    assert_eq!(
-        generated["team_block_reason"],
-        "This assistant's agent could not be resolved."
-    );
+    assert_eq!(generated["team_selectable"], true);
+    assert_eq!(generated["team_block_reason"], Value::Null);
 }
 
 #[tokio::test]
@@ -650,33 +587,29 @@ async fn get_detail_returns_definition_state_preferences_and_rules() {
 #[tokio::test]
 async fn get_detail_generated_assistant_exposes_generated_runtime_fields() {
     let fx = fixture().await;
-    insert_generated_bare_assistant(&fx, "bare:agent-droid", "agent-droid", "droid", "Droid").await;
 
     let resp = fx
         .app
         .clone()
-        .oneshot(get_with_token(
-            "/api/assistants/bare:agent-droid?locale=en-US",
-            &fx.token,
-        ))
+        .oneshot(get_with_token("/api/assistants/bare:8e1acf31?locale=en-US", &fx.token))
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
 
     let json = body_json(resp).await;
     let data = &json["data"];
-    assert_eq!(data["id"], "bare:agent-droid");
+    assert_eq!(data["id"], "bare:8e1acf31");
     assert_eq!(data["source"], "generated");
     assert_eq!(data["deletable"], false);
-    assert_eq!(data["agent_status"], "missing");
+    assert_eq!(data["agent_status"], "online");
     assert_eq!(data["agent_status_message"], Value::Null);
-    assert_eq!(data["team_selectable"], false);
-    assert_eq!(
-        data["team_block_reason"],
-        "This assistant's agent could not be resolved."
-    );
-    assert_eq!(data["engine"]["agent_id"], "agent-droid");
-    assert_eq!(data["engine"]["agent"], Value::Null);
+    assert_eq!(data["team_selectable"], true);
+    assert_eq!(data["team_block_reason"], Value::Null);
+    assert_eq!(data["engine"]["agent_id"], "8e1acf31");
+    assert_eq!(data["engine"]["agent"]["acp_backend"], "codex");
+    assert!(data["engine"]["agent"].get("backend").is_none());
+    assert!(data["engine"]["agent"].get("id").is_none());
+    assert_eq!(data["engine"]["agent"]["type"], "acp");
 }
 
 // ===========================================================================

--- a/crates/aionui-app/tests/team_e2e.rs
+++ b/crates/aionui-app/tests/team_e2e.rs
@@ -14,6 +14,7 @@ use common::{
 };
 
 const DEFAULT_TEAM_ASSISTANT_ID: &str = "team-e2e-assistant";
+const DEFAULT_TEAM_AGENT_ID: &str = "2d23ff1c";
 
 fn team_agent(name: &str, role: &str) -> serde_json::Value {
     json!({
@@ -34,14 +35,47 @@ fn two_agent_body() -> serde_json::Value {
     })
 }
 
-async fn ensure_default_team_assistant(app: &mut axum::Router, token: &str, csrf: &str) {
+async fn ensure_default_team_agent_installed(services: &aionui_app::AppServices) {
+    let command = std::env::current_exe()
+        .expect("test executable path")
+        .to_string_lossy()
+        .to_string();
+    let source_info = json!({ "binary_name": command }).to_string();
+
+    sqlx::query(
+        "UPDATE agent_metadata \
+         SET agent_source = 'custom', agent_source_info = ?, command = ?, args = '[]', env = '[]', \
+             updated_at = unixepoch('now','subsec') * 1000 \
+         WHERE id = ?",
+    )
+    .bind(&source_info)
+    .bind(&command)
+    .bind(DEFAULT_TEAM_AGENT_ID)
+    .execute(services.database.pool())
+    .await
+    .expect("seed deterministic team agent");
+
+    services
+        .agent_registry
+        .reload_one(DEFAULT_TEAM_AGENT_ID)
+        .await
+        .expect("reload deterministic team agent");
+}
+
+async fn ensure_default_team_assistant(
+    app: &mut axum::Router,
+    services: &aionui_app::AppServices,
+    token: &str,
+    csrf: &str,
+) {
+    ensure_default_team_agent_installed(services).await;
     let req = json_with_token(
         "POST",
         "/api/assistants",
         json!({
             "id": DEFAULT_TEAM_ASSISTANT_ID,
             "name": "Team E2E Assistant",
-            "agent_id": "2d23ff1c"
+            "agent_id": DEFAULT_TEAM_AGENT_ID
         }),
         token,
         csrf,
@@ -54,8 +88,13 @@ async fn ensure_default_team_assistant(app: &mut axum::Router, token: &str, csrf
     );
 }
 
-async fn create_team(app: &mut axum::Router, token: &str, csrf: &str) -> serde_json::Value {
-    ensure_default_team_assistant(app, token, csrf).await;
+async fn create_team(
+    app: &mut axum::Router,
+    services: &aionui_app::AppServices,
+    token: &str,
+    csrf: &str,
+) -> serde_json::Value {
+    ensure_default_team_assistant(app, services, token, csrf).await;
     let req = json_with_token("POST", "/api/teams", two_agent_body(), token, csrf);
     let resp = app.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::CREATED);
@@ -124,7 +163,7 @@ async fn tc1_create_team_with_multiple_agents() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     assert_eq!(data["name"], "Alpha");
     assert_eq!(data["assistants"].as_array().unwrap().len(), 2);
     assert_eq!(data["assistants"][0]["role"], "lead");
@@ -138,7 +177,7 @@ async fn tc1_create_team_with_multiple_agents() {
 async fn tc2_create_single_agent_team() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
-    ensure_default_team_assistant(&mut app, &token, &csrf).await;
+    ensure_default_team_assistant(&mut app, &services, &token, &csrf).await;
 
     let body = json!({
         "name": "Solo",
@@ -188,7 +227,7 @@ async fn tc3_each_agent_has_conversation_id() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     for agent in data["assistants"].as_array().unwrap() {
         assert!(agent["conversation_id"].is_string());
         assert!(!agent["conversation_id"].as_str().unwrap().is_empty());
@@ -204,7 +243,7 @@ async fn tc3b_create_team_writes_legacy_extra_shape() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let conversation_id = data["assistants"][0]["conversation_id"].as_str().unwrap();
 
     let repo = aionui_db::SqliteConversationRepository::new(services.database.pool().clone());
@@ -224,7 +263,7 @@ async fn tc3b_create_team_writes_legacy_extra_shape() {
 async fn tc4_first_agent_is_lead() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
-    ensure_default_team_assistant(&mut app, &token, &csrf).await;
+    ensure_default_team_assistant(&mut app, &services, &token, &csrf).await;
 
     let body = json!({
         "name": "T",
@@ -260,7 +299,7 @@ async fn tc5_empty_agents_returns_error() {
 async fn tc6_missing_name_returns_error() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
-    ensure_default_team_assistant(&mut app, &token, &csrf).await;
+    ensure_default_team_assistant(&mut app, &services, &token, &csrf).await;
 
     let body = json!({ "agents": [json!({
         "name": "L",
@@ -277,7 +316,7 @@ async fn tc6_missing_name_returns_error() {
 async fn tc6b_workspace_with_whitespace_segment_is_accepted() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
-    ensure_default_team_assistant(&mut app, &token, &csrf).await;
+    ensure_default_team_assistant(&mut app, &services, &token, &csrf).await;
     let temp = tempfile::tempdir().unwrap();
     let workspace = temp.path().join("Archive ");
     std::fs::create_dir_all(&workspace).unwrap();
@@ -299,7 +338,7 @@ async fn tc6b_workspace_with_whitespace_segment_is_accepted() {
 async fn tc6c_create_team_rejects_missing_workspace_path() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
-    ensure_default_team_assistant(&mut app, &token, &csrf).await;
+    ensure_default_team_assistant(&mut app, &services, &token, &csrf).await;
     let missing_workspace =
         std::env::temp_dir().join(format!("aionui-team-missing-{}", aionui_common::generate_short_id()));
 
@@ -365,8 +404,8 @@ async fn tl2_list_multiple_teams() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    create_team(&mut app, &token, &csrf).await;
-    ensure_default_team_assistant(&mut app, &token, &csrf).await;
+    create_team(&mut app, &services, &token, &csrf).await;
+    ensure_default_team_assistant(&mut app, &services, &token, &csrf).await;
 
     let body = json!({
         "name": "Beta",
@@ -388,7 +427,7 @@ async fn team_api_rejects_cross_user_access() {
     let (owner_token, owner_csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
     let (other_token, other_csrf) = setup_and_login(&mut app, &services, "alice", "StrongP@ss2").await;
 
-    let data = create_team(&mut app, &owner_token, &owner_csrf).await;
+    let data = create_team(&mut app, &services, &owner_token, &owner_csrf).await;
     let team_id = data["id"].as_str().unwrap();
     let slot_id = data["assistants"][1]["slot_id"].as_str().unwrap();
 
@@ -457,7 +496,7 @@ async fn team_api_rejects_cross_user_access() {
 async fn pause_team_slot_endpoint_requires_owned_team_and_active_run() {
     let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
     let lead_slot_id = data["assistants"][0]["slot_id"].as_str().unwrap();
 
@@ -479,7 +518,7 @@ async fn pause_team_slot_endpoint_requires_owned_team_and_active_run() {
 async fn trs1_run_state_returns_null_for_existing_team_without_active_run() {
     let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let stop_req = delete_with_token(&format!("/api/teams/{team_id}/session"), &token, &csrf);
@@ -499,7 +538,7 @@ async fn trs1_run_state_returns_null_for_existing_team_without_active_run() {
 async fn trs2_run_state_returns_active_run_payload() {
     let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let send_req = json_with_token(
@@ -555,7 +594,7 @@ async fn trs4_run_state_missing_team_returns_404() {
 async fn trs5_run_state_rejects_cross_user_access() {
     let (mut app, services) = build_app_with_mock_agents().await;
     let (admin_token, admin_csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
-    let data = create_team(&mut app, &admin_token, &admin_csrf).await;
+    let data = create_team(&mut app, &services, &admin_token, &admin_csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let (other_token, _other_csrf) = setup_and_login(&mut app, &services, "other", "StrongP@ss2").await;
@@ -573,7 +612,7 @@ async fn tl3_teams_contain_full_agent_info() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    create_team(&mut app, &token, &csrf).await;
+    create_team(&mut app, &services, &token, &csrf).await;
 
     let req = get_with_token("/api/teams", &token);
     let resp = app.oneshot(req).await.unwrap();
@@ -594,7 +633,7 @@ async fn tg1_get_existing_team() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let req = get_with_token(&format!("/api/teams/{team_id}"), &token);
@@ -622,7 +661,7 @@ async fn td1_delete_existing_team() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let req = delete_with_token(&format!("/api/teams/{team_id}"), &token, &csrf);
@@ -636,7 +675,7 @@ async fn td2_delete_then_list_empty() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let req = delete_with_token(&format!("/api/teams/{team_id}"), &token, &csrf);
@@ -665,7 +704,7 @@ async fn tr1_rename_existing_team() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let req = json_with_token(
@@ -685,7 +724,7 @@ async fn tr2_rename_then_get_confirms_new_name() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let req = json_with_token(
@@ -730,7 +769,7 @@ async fn aa1_add_agent_to_team() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let body = json!({
@@ -753,7 +792,7 @@ async fn aa2_add_agent_increases_count() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let body = json!({
@@ -794,7 +833,7 @@ async fn aa5_add_agent_missing_fields() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let body = json!({ "role": "teammate" });
@@ -809,7 +848,7 @@ async fn ar1_remove_agent_from_team() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
     let slot_id = data["assistants"][1]["slot_id"].as_str().unwrap();
 
@@ -824,7 +863,7 @@ async fn ar2_after_removal_agent_gone() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
     let slot_id = data["assistants"][1]["slot_id"].as_str().unwrap();
 
@@ -845,7 +884,7 @@ async fn ar4_remove_nonexistent_agent() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let req = delete_with_token(&format!("/api/teams/{team_id}/agents/nonexistent"), &token, &csrf);
@@ -859,7 +898,7 @@ async fn an1_rename_agent() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
     let slot_id = data["assistants"][1]["slot_id"].as_str().unwrap();
 
@@ -880,7 +919,7 @@ async fn an2_rename_then_get_confirms_name() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
     let slot_id = data["assistants"][1]["slot_id"].as_str().unwrap();
 
@@ -907,7 +946,7 @@ async fn an3_rename_nonexistent_agent() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let req = json_with_token(
@@ -931,7 +970,7 @@ async fn es1_ensure_session() {
     let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let req = json_with_token(
@@ -950,7 +989,7 @@ async fn es1b_team_mcp_list_assistants_matches_assistant_projection() {
     let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
     let lead = &data["assistants"][0];
     let lead_conversation_id = lead["conversation_id"].as_str().unwrap();
@@ -1033,7 +1072,7 @@ async fn es2_ensure_session_idempotent() {
     let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let req = json_with_token(
@@ -1074,7 +1113,7 @@ async fn ss1_stop_session() {
     let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let req = json_with_token(
@@ -1097,7 +1136,7 @@ async fn ss3_stop_session_noop() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let req = delete_with_token(&format!("/api/teams/{team_id}/session"), &token, &csrf);
@@ -1115,7 +1154,7 @@ async fn sm1_send_message_with_session() {
     let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     // Start session first
@@ -1144,7 +1183,7 @@ async fn sm1b_team_send_persists_user_bubble_through_projection_adapter() {
     let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
     let lead_conversation_id = data["assistants"][0]["conversation_id"].as_str().unwrap();
 
@@ -1181,7 +1220,7 @@ async fn sm1c_team_owned_conversation_regular_send_is_forbidden() {
     let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let conversation_id = data["assistants"][0]["conversation_id"].as_str().unwrap();
 
     let req = json_with_token(
@@ -1202,7 +1241,7 @@ async fn sm1c_team_owned_conversation_regular_send_is_forbidden() {
 async fn sm1d_team_send_rejects_missing_csrf() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let req = axum::http::Request::builder()
@@ -1239,7 +1278,7 @@ async fn sm5_send_message_missing_content() {
     let (mut app, services) = build_app().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
 
     let req = json_with_token(
@@ -1259,7 +1298,7 @@ async fn sa1_send_message_to_agent() {
     let (mut app, services) = build_app_with_mock_agents().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
     let slot_id = data["assistants"][1]["slot_id"].as_str().unwrap();
 
@@ -1295,7 +1334,7 @@ async fn full_team_lifecycle() {
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
 
     // Create
-    let data = create_team(&mut app, &token, &csrf).await;
+    let data = create_team(&mut app, &services, &token, &csrf).await;
     let team_id = data["id"].as_str().unwrap();
     assert_eq!(data["assistants"].as_array().unwrap().len(), 2);
 

--- a/crates/aionui-assistant/src/service.rs
+++ b/crates/aionui-assistant/src/service.rs
@@ -374,6 +374,7 @@ impl AssistantService {
             .iter()
             .filter(|row| {
                 row.enabled
+                    && row.installed
                     && row.agent_type.supports_new_conversation()
                     && matches!(
                         row.status,
@@ -652,6 +653,9 @@ impl AssistantService {
         let mut result = Vec::new();
 
         for definition in &definitions {
+            if generated_definition_is_uninstalled(definition, &projections) {
+                continue;
+            }
             let projection = self
                 .project_definition(definition, state_map.get(&definition.id), &projections)
                 .await?;
@@ -678,6 +682,9 @@ impl AssistantService {
     pub async fn get(&self, id: &str) -> Result<AssistantResponse, AssistantError> {
         let projections = self.reconcile_generated_assistants().await?;
         if let Some(definition) = self.definition_repo.get_by_assistant_id(id).await? {
+            if generated_definition_is_uninstalled(&definition, &projections) {
+                return Err(AssistantError::NotFound(format!("assistant '{id}' not found")));
+            }
             let state = self.state_repo.get(&definition.id).await?;
             let projection = self
                 .project_definition(&definition, state.as_ref(), &projections)
@@ -691,6 +698,9 @@ impl AssistantService {
     pub async fn get_detail(&self, id: &str, locale: Option<&str>) -> Result<AssistantDetailResponse, AssistantError> {
         let projections = self.reconcile_generated_assistants().await?;
         if let Some(definition) = self.definition_repo.get_by_assistant_id(id).await? {
+            if generated_definition_is_uninstalled(&definition, &projections) {
+                return Err(AssistantError::NotFound(format!("assistant '{id}' not found")));
+            }
             let state = self.state_repo.get(&definition.id).await?;
             let preference = self.preference_repo.get(&definition.id).await?;
             let rules_content = self.read_rule(id, locale).await?;
@@ -2325,6 +2335,23 @@ fn assistant_projection_for_definition(
     }
 }
 
+fn generated_definition_is_uninstalled(definition: &AssistantDefinitionRow, agent_rows: &[AgentManagementRow]) -> bool {
+    if definition.source != "generated" {
+        return false;
+    }
+
+    let agent_id = definition.agent_id.as_str();
+    let source_ref = definition.source_ref.as_deref();
+    let Some(row) = agent_rows
+        .iter()
+        .find(|row| row.id == agent_id || source_ref == Some(row.id.as_str()))
+    else {
+        return true;
+    };
+
+    !row.installed
+}
+
 fn effective_agent_id_for_definition<'a>(
     definition: &'a AssistantDefinitionRow,
     state: Option<&'a AssistantOverlayRow>,
@@ -3006,6 +3033,66 @@ mod tests {
         }
     }
 
+    fn mk_uninstalled_agent_row(id: &str, backend: &str) -> aionui_api_types::AgentManagementRow {
+        let mut row = mk_agent_row(id, backend, aionui_api_types::AgentManagementStatus::Unchecked);
+        row.installed = false;
+        row.last_check_status = None;
+        row.last_check_kind = None;
+        row.last_check_latency_ms = None;
+        row.last_check_at = None;
+        row.last_success_at = None;
+        row
+    }
+
+    async fn insert_generated_definition(fx: &Fixture, definition_id: &str, assistant_id: &str, agent_id: &str) {
+        fx.definition_repo
+            .upsert(&UpsertAssistantDefinitionParams {
+                id: definition_id,
+                assistant_id,
+                source: "generated",
+                owner_type: "system",
+                source_ref: Some(agent_id),
+                source_version: None,
+                source_hash: None,
+                name: "Historical generated agent",
+                name_i18n: "{}",
+                description: None,
+                description_i18n: "{}",
+                avatar_type: "none",
+                avatar_value: None,
+                agent_id,
+                rule_resource_type: "none",
+                rule_resource_ref: None,
+                rule_inline_content: None,
+                recommended_prompts: "[]",
+                recommended_prompts_i18n: "{}",
+                default_model_mode: "auto",
+                default_model_value: None,
+                default_permission_mode: "auto",
+                default_permission_value: None,
+                default_thought_level_mode: "auto",
+                default_thought_level_value: None,
+                default_skills_mode: "fixed",
+                default_skill_ids: "[]",
+                custom_skill_names: "[]",
+                default_disabled_builtin_skill_ids: "[]",
+                default_mcps_mode: "auto",
+                default_mcp_ids: "[]",
+            })
+            .await
+            .unwrap();
+        fx.state_repo
+            .upsert(&UpsertAssistantOverlayParams {
+                assistant_definition_id: definition_id,
+                enabled: true,
+                sort_order: 3,
+                agent_id_override: None,
+                last_used_at: None,
+            })
+            .await
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn list_empty_is_empty() {
         let fx = fixture().await;
@@ -3107,6 +3194,14 @@ mod tests {
     #[tokio::test]
     async fn list_maps_generated_definition_to_generated_source() {
         let fx = fixture().await;
+        fx.agent_rows
+            .lock()
+            .expect("agent rows lock poisoned")
+            .push(mk_agent_row(
+                "agent-claude",
+                "claude",
+                aionui_api_types::AgentManagementStatus::Online,
+            ));
         fx.definition_repo
             .upsert(&UpsertAssistantDefinitionParams {
                 id: "asstdef-generated",
@@ -3216,6 +3311,65 @@ mod tests {
         assert_eq!(bare.agent_status, aionui_api_types::AgentManagementStatus::Unchecked);
         assert!(bare.team_selectable);
         assert!(bare.agent_status_message.is_none());
+    }
+
+    #[tokio::test]
+    async fn bootstrap_skips_generated_assistant_for_uninstalled_unchecked_agent() {
+        let fx = fixture_with_options(FixtureOpts {
+            agent_rows: vec![mk_uninstalled_agent_row("agent-snow", "snow")],
+            ..Default::default()
+        })
+        .await;
+
+        let list = fx.service.list().await.unwrap();
+
+        assert!(
+            list.iter().all(|assistant| assistant.id != "bare:agent-snow"),
+            "uninstalled agents must not occupy generated assistant list slots"
+        );
+        assert!(
+            fx.definition_repo
+                .get_by_assistant_id("bare:agent-snow")
+                .await
+                .unwrap()
+                .is_none(),
+            "bootstrap should not materialize generated assistant definitions for uninstalled agents"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_hides_existing_generated_assistant_when_agent_is_uninstalled_until_installed() {
+        let mut uninstalled_row = mk_uninstalled_agent_row("agent-snow", "snow");
+        uninstalled_row.status = aionui_api_types::AgentManagementStatus::Offline;
+        let fx = fixture_with_options(FixtureOpts {
+            agent_rows: vec![uninstalled_row],
+            ..Default::default()
+        })
+        .await;
+        insert_generated_definition(&fx, "asstdef-generated-snow", "bare:agent-snow", "agent-snow").await;
+
+        let hidden = fx.service.list().await.unwrap();
+        assert!(
+            hidden.iter().all(|assistant| assistant.id != "bare:agent-snow"),
+            "historical generated assistants should be hidden while their agent is not installed"
+        );
+
+        {
+            let mut rows = fx.agent_rows.lock().expect("agent rows lock poisoned");
+            rows[0].installed = true;
+            rows[0].status = aionui_api_types::AgentManagementStatus::Unchecked;
+        }
+
+        let restored = fx.service.list().await.unwrap();
+        let assistant = restored
+            .iter()
+            .find(|assistant| assistant.id == "bare:agent-snow")
+            .expect("installed generated assistant should reappear");
+        assert_eq!(assistant.source, AssistantSource::Generated);
+        assert_eq!(
+            assistant.agent_status,
+            aionui_api_types::AgentManagementStatus::Unchecked
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Refresh agent installation state during registry hydration without running full health checks or overwriting persisted health snapshots.
- Filter generated assistants so uninstalled agents do not create or surface generated assistant entries.
- Update assistant and app E2E coverage for installed-vs-uninstalled generated assistant behavior.

## Test Plan
- cargo fmt --all -- --check
- cargo clippy -p aionui-assistant -p aionui-ai-agent -- -D warnings
- cargo test -p aionui-assistant -p aionui-ai-agent
- cargo test -p aionui-app --test assistants_e2e generated_assistant_exposes_generated_runtime_fields -- --nocapture
- just push -u origin fix/generated-assistants-installed-filter