### PR TITLE
fix(skills): correct aionui-config butler skill drift (2026-07)

### DIFF
--- a/crates/aionui-app/assets/builtin-skills/aionui-config/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/aionui-config/SKILL.md
@@ -76,8 +76,10 @@ An assistant has two parts stored separately:
    user_file`), written via a dedicated endpoint. Creating an assistant does
    NOT set its system prompt — that's a second call.
 
-Assistant `source` is `builtin` (shipped with the app, limited edits) or
-`user` (custom, fully editable). Custom IDs look like `custom-<digits>-<hex>`.
+Assistant `source` is `builtin` (shipped with the app, limited edits), `user`
+(custom, fully editable), or `generated` (auto-materialized from an online ACP
+agent — identity fields locked, not deletable). Custom IDs look like
+`custom-<digits>-<hex>`.
 
 ### List / inspect
 
@@ -135,11 +137,13 @@ installed agent's id — not a friendly name like `"claude"`. Read the available
 agents first and copy the id you want:
 
 ```bash
+# the LIST response is flat — each row carries agent_id + agent directly:
 python3 scripts/aionui_api.py get /api/assistants
-# look at the `engine` block of any existing assistant, e.g.
-#   "engine": {"agent_id": "2d23ff1c", "agent": {"type": "acp", "acp_backend": "claude"}}
-# reuse that agent_id for a new assistant on the same engine:
-python3 scripts/aionui_api.py put /api/assistants/<id> '{"id":"<id>","agent_id":"2d23ff1c"}'
+#   {"id": "...", "agent_id": "2d23ff1c", "agent": {"type": "acp", "acp_backend": "claude"}, ...}
+# (only the single-assistant detail read nests these under an `engine` block:
+#   GET /api/assistants/<id>?locale=en -> "engine": {"agent_id": "...", "agent": {...}})
+# reuse an existing agent_id for a new assistant on the same engine:
+python3 scripts/aionui_api.py put /api/assistants/<id> '{"agent_id":"2d23ff1c"}'
 ```
 
 > If you omit `agent_id` on create, the backend does NOT default to a CLI engine:
@@ -176,7 +180,6 @@ modes the backend accepts. The `value` is what `fixed` locks to:
 
 ```bash
 python3 scripts/aionui_api.py put /api/assistants/<id> '{
-  "id": "<id>",
   "defaults": {
     "model":      {"mode": "fixed", "value": "gemini-2.5-pro"},
     "permission": {"mode": "fixed", "value": "plan"},
@@ -187,13 +190,14 @@ python3 scripts/aionui_api.py put /api/assistants/<id> '{
 ```
 
 > Verified end-to-end: the backend stores all four entries verbatim and returns
-> them on the `?locale=` detail read. A brand-new assistant has `defaults: null`
-> until you set them.
+> them on the `?locale=` detail read. On read, `defaults` is always present with
+> all four entries — a brand-new assistant has each set to `{"mode":"auto"}` (no
+> `value`), never `null`. Lock one by sending `{"mode":"fixed","value":...}`.
 
 ### Update
 
-`PUT /api/assistants/<id>` with `{"id": "<id>", ...fields to change}`. Send only
-the fields you want to change.
+`PUT /api/assistants/<id>`, sending only the fields you want to change. The `id`
+comes from the URL path — a body `id`, if sent, is ignored.
 
 ### Set the system prompt (rules)
 
@@ -216,6 +220,12 @@ python3 scripts/aionui_api.py post /api/skills/assistant-rule/read '{"assistant_
 For multi-line / long prompts, write the text to a temp file and build the JSON
 body in Python rather than inlining a giant shell string.
 
+> To wipe an assistant's rule across all locales, `DELETE
+> /api/skills/assistant-rule/<assistant-id>`. A parallel trio exists for
+> per-assistant **skill** content (distinct from the shared registry):
+> `POST /api/skills/assistant-skill/{read,write}` (same body shape as the rule
+> endpoints) and `DELETE /api/skills/assistant-skill/<assistant-id>`.
+
 ### Avatar
 
 The `avatar` field accepts an emoji (`"📋"`), an image URL, a `data:` URI, or an
@@ -223,7 +233,7 @@ absolute local path. A self-contained inline SVG `data:` URI is a good default �
 no external dependency, renders offline:
 
 ```bash
-python3 scripts/aionui_api.py put /api/assistants/<id> '{"id":"<id>","avatar":"data:image/svg+xml;base64,<...>"}'
+python3 scripts/aionui_api.py put /api/assistants/<id> '{"avatar":"data:image/svg+xml;base64,<...>"}'
 ```
 
 > `GET /api/assistants/<id>/avatar` also serves the raw avatar binary (Content-Type
@@ -239,7 +249,8 @@ team picker without deleting it.
 ### Delete
 
 `DELETE /api/assistants/<id>` — only `source: user` assistants can be deleted.
-Builtins can only be disabled.
+`builtin` and `generated` assistants can only be disabled (check the `deletable`
+flag on the detail read).
 
 ### Bulk import
 
@@ -257,8 +268,9 @@ A skill is a folder containing a `SKILL.md` (YAML frontmatter `name` +
 `description`, then instruction body). The `description` decides when the agent
 auto-triggers the skill, so write it carefully.
 
-Three sources: `builtin` (`~/.aionui/builtin-skills/`), `custom`
-(`~/.aionui/skills/`), `extension` (external, symlinked).
+Four sources: `builtin` (`~/.aionui/builtin-skills/`), `custom`
+(`~/.aionui/skills/`), `cron` (`~/.aionui/cron/skills/`, per-scheduled-task
+skills), `extension` (external, symlinked).
 
 ### List / inspect the registry
 
@@ -270,17 +282,22 @@ python3 scripts/aionui_api.py post /api/skills/info '{"skill_path":"/abs/path/to
 
 ### Import a skill into the registry
 
-Two ways to install a skill — pick by whether you want a copy or a live link:
+`POST /api/skills/import` copies the skill(s) into the user skills dir and
+registers them. The one endpoint handles all three source shapes: a single skill
+folder, a PARENT folder containing many skills, or a `.zip` package.
 
 ```bash
-# copy the folder into the user skills dir and register it
-python3 scripts/aionui_api.py post /api/skills/import '{"skill_path":"/abs/path/to/skill-folder"}'
-
-# symlink instead of copy — good for a skill you keep editing in an external repo.
-# import-symlink (NOT bare import) is also what accepts a PARENT folder of many
-# skills, or a .zip package.
-python3 scripts/aionui_api.py post /api/skills/import-symlink '{"skill_path":"/abs/path/to/skill-or-parent-or-zip"}'
+python3 scripts/aionui_api.py post /api/skills/import '{"skill_path":"/abs/path/to/skill-or-parent-or-zip"}'
+python3 scripts/aionui_api.py get  /api/skills/import-limits   # server-side max file/total byte caps
+python3 scripts/aionui_api.py get  /api/skills/import-history  # recent import records
 ```
+
+> For external skills you keep editing in place (registered without copying), see
+> "Discover & manage skill sources" below (`external-paths`) — that's how a live,
+> non-copied source is wired in. There is no `import-symlink` endpoint; the
+> reverse operation, `POST /api/skills/export-symlink`
+> (`{"skill_path":"...","target_dir":"..."}`), symlinks an already-installed skill
+> back out to an external directory.
 
 > Caution: importing (copy) from a path that is ALREADY inside the user skills
 > dir can race with the copy step. When editing an installed skill, edit the
@@ -292,12 +309,12 @@ python3 scripts/aionui_api.py post /api/skills/import-symlink '{"skill_path":"/a
 For skills that live outside the standard dirs:
 
 ```bash
-python3 scripts/aionui_api.py post   /api/skills/scan '{"path":"/abs/dir"}'   # find skills under a dir
+python3 scripts/aionui_api.py post   /api/skills/scan '{"folder_path":"/abs/dir"}'   # find skills under a dir
 python3 scripts/aionui_api.py get    /api/skills/detect-paths                  # candidate skill locations
 python3 scripts/aionui_api.py get    /api/skills/detect-external               # external skill dirs
 python3 scripts/aionui_api.py get    /api/skills/external-paths                # list registered external paths
-python3 scripts/aionui_api.py post   /api/skills/external-paths '{"path":"/abs/dir"}'   # add one
-python3 scripts/aionui_api.py delete /api/skills/external-paths '{"path":"/abs/dir"}'   # remove one
+python3 scripts/aionui_api.py post   /api/skills/external-paths '{"name":"<label>","path":"/abs/dir"}'  # add one (both required)
+python3 scripts/aionui_api.py delete /api/skills/external-paths '{"path":"/abs/dir"}'   # remove one (path only)
 ```
 
 The **skills market** is a separate, app-wide toggle:
@@ -308,7 +325,7 @@ The **skills market** is a separate, app-wide toggle:
 Put the skill's `name` into the assistant's `enabled_skills`:
 
 ```bash
-python3 scripts/aionui_api.py put /api/assistants/<id> '{"id":"<id>","enabled_skills":["skill-a","skill-b"]}'
+python3 scripts/aionui_api.py put /api/assistants/<id> '{"enabled_skills":["skill-a","skill-b"]}'
 ```
 
 > `enabled_skills` is the full set — include every skill you want kept, not just
@@ -345,11 +362,13 @@ The `transport` object is one of:
 | --- | --- | --- |
 | `stdio` | `command`, `args?` (string[]), `env?` (map) | local process servers (npx/uvx/binaries) |
 | `sse` | `url`, `headers?` (map) | remote Server-Sent-Events servers (legacy) |
-| `http` / `streamable_http` | `url`, `headers?` (map) | remote HTTP servers (Streamable HTTP) |
+| `http` | `url`, `headers?` (map) | remote HTTP servers (Streamable HTTP) |
 
 > `headers` is an optional string→string map for auth (e.g. `{"Authorization":
-> "Bearer …"}`). `streamable_http` is accepted on create/update but always
-> normalizes to `http` in responses — don't expect `streamable_http` echoed back.
+> "Bearer …"}`). The REST API accepts exactly these three `type` values —
+> `stdio`, `sse`, `http`. Use `http` for Streamable-HTTP servers; there is no
+> separate `streamable_http` transport type at this layer (sending it fails
+> deserialization).
 
 ### Create
 
@@ -378,13 +397,19 @@ python3 scripts/aionui_api.py post /api/mcp/servers '{
 returns the server's tool list (or an error / `needs_auth`). Good to run after
 creating a remote server.
 
-### Toggle / update / delete
+### Fetch one / toggle / update / delete
 
 ```bash
+python3 scripts/aionui_api.py get    /api/mcp/servers/<id>          # one server by id
 python3 scripts/aionui_api.py post   /api/mcp/servers/<id>/toggle   # enable <-> disable
 python3 scripts/aionui_api.py put    /api/mcp/servers/<id> '{"description":"..."}'
 python3 scripts/aionui_api.py delete /api/mcp/servers/<id>
 ```
+
+> Two more list-level helpers exist: `POST /api/mcp/servers/import`
+> (`{"servers":[…]}`, bulk-restore a set at once) and `GET /api/mcp/agent-configs`
+> (scans installed Agent CLIs and returns their existing MCP configs — a source
+> for one-click import).
 
 > Remote servers may need OAuth: `/api/mcp/oauth/check-status`,
 > `/api/mcp/oauth/login`, `/api/mcp/oauth/logout` (all `post`), and
@@ -440,19 +465,21 @@ which protocol it speaks and what models it has. Use this to fill `platform` and
 
 ```bash
 python3 scripts/aionui_api.py post /api/providers/detect-protocol '{
-  "platform": "custom",
   "base_url": "https://api.deepseek.com/v1",
   "api_key": "sk-..."
 }'
 # -> {"protocol":"openai","confidence":90,"models":[...]}
 ```
 
-Optional fields on this body: `timeout` (ms), `preferred_protocol` (try a given
-protocol first), and `test_all_keys` (bool — probe every key when `api_key`
-holds several).
+Required on this body: just `base_url` + `api_key` (no `platform` — the backend
+detects it). Optional: `timeout` (ms), `preferred_protocol` (try a given protocol
+first — one of `openai`, `anthropic`, `gemini`, `unknown`), and `test_all_keys`
+(bool — probe every key when `api_key` holds several).
 
-`fetch-models` (`POST /api/providers/fetch-models`, same body) returns just the
-model list for a not-yet-saved endpoint.
+`fetch-models` (`POST /api/providers/fetch-models`) returns just the model list
+for a not-yet-saved endpoint. Its body differs from detect-protocol: `platform`,
+`base_url`, `api_key` are all **required** (plus optional `bedrock_config`,
+`try_fix`).
 
 ### Test a provider connection
 
@@ -519,11 +546,13 @@ Two stores, both verified:
 - `PUT /api/settings/client` — batch-update that store.
 
 `PUT /api/settings/client` is a **partial merge** — send only the keys you want
-to change. Read first, change one key, read back.
+to change (a key set to `null` deletes it). Its response carries no data, so
+always read the store back to confirm.
 
 ```bash
 python3 scripts/aionui_api.py get /api/settings/client
 python3 scripts/aionui_api.py put /api/settings/client '{"ui.zoomFactor": 1.0}'
+python3 scripts/aionui_api.py get /api/settings/client   # confirm — PUT returns no body
 ```
 
 > To set which model a given assistant uses, configure that assistant's
@@ -535,19 +564,20 @@ python3 scripts/aionui_api.py put /api/settings/client '{"ui.zoomFactor": 1.0}'
 
 `GET /api/agents/management` lists the available engines (`aionrs`, `claude`,
 `codex`, …). There is **no** bare `GET /api/agents` — that path 404s; always use
-the `/management` sub-path. Each row carries `id`, `enabled` (toggled on),
-`installed` (spawn command resolvable on `$PATH`), `team_capable` (can run in a
-team), `backend`, `agent_type`, and a `status` of `online` / `offline` /
-`missing`. Check `installed` (and `status`) before binding an assistant to that
+the `/management` sub-path. Each row is rich: alongside `id`, `name`, `enabled`
+(toggled on), `installed` (spawn command resolvable on `$PATH`), `team_capable`
+(can run in a team), `backend`, `agent_type`, and a `status` of `online` /
+`offline` / `missing`, it also carries `config_options`, `available_modes`,
+`available_models` (when the engine advertises them), plus `last_check_*`
+diagnostics. Check `installed` (and `status`) before binding an assistant to that
 engine (via its `agent_id` — see *Picking the engine* above).
 
-> The management row does **not** include the engine `handshake` (its
-> `agent_capabilities` / `auth_methods` / `config_options` / `available_modes` /
-> `available_models` / `available_commands`) — those live on the fuller agent
-> metadata returned by `POST /api/agents/refresh`, which re-scans custom agents
-> and returns each agent's `available` + `handshake`. Use `refresh` when you need
-> the modes/models an engine offers; use `management` for the at-a-glance
-> enabled/installed/status list.
+> What the management row does **not** carry is the rest of the engine
+> `handshake` — `agent_capabilities`, `auth_methods`, `available_commands`. For
+> those, `POST /api/agents/refresh` re-scans agents and returns each one's full
+> metadata (`available` + `handshake`). The at-a-glance modes/models are already
+> on the management row; reach for `refresh` when you need capabilities, auth
+> methods, or the command list.
 
 ---
 
@@ -623,7 +653,15 @@ python3 scripts/aionui_api.py get    /api/cron/jobs/<id>                   # one
 python3 scripts/aionui_api.py put    /api/cron/jobs/<id> '{"enabled": false}'   # partial update (pause)
 python3 scripts/aionui_api.py post   /api/cron/jobs/<id>/run              # run it once right now
 python3 scripts/aionui_api.py delete /api/cron/jobs/<id>                  # remove it
+python3 scripts/aionui_api.py get    /api/cron/jobs/<id>/conversations    # conversations this job has spawned
+python3 scripts/aionui_api.py get    /api/cron/jobs/<id>/skill            # {"has_skill": bool}
+python3 scripts/aionui_api.py post   /api/cron/jobs/<id>/skill '{"content":"<SKILL.md body>"}'  # attach/replace a per-job skill
+python3 scripts/aionui_api.py delete /api/cron/jobs/<id>/skill            # remove the attached skill
 ```
+
+> A job can carry its own inline **skill** (a `SKILL.md`-style instruction body)
+> via `.../skill` — this is the `cron` skill source. Handy when a scheduled task
+> needs bespoke instructions that shouldn't live in the shared registry.
 
 `PUT` is a partial update — send only what changes (`name`, `description`,
 `enabled`, `schedule`, `message`, `execution_mode`, `agent_config`,

--- a/crates/aionui-app/assets/builtin-skills/aionui-config/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/aionui-config/SKILL.md
@@ -115,8 +115,7 @@ Key fields in the create/update body:
 | Field | Meaning |
 | --- | --- |
 | `name`, `description` | display text (required: name) |
-| `agent_id` | **engine binding** — the id of an installed agent (see "Picking the engine" below). This, not `preset_agent_type`, is what actually sets the engine |
-| `preset_agent_type` | display/i18n hint only; does **not** bind the engine in the current backend |
+| `agent_id` | **engine binding** — the id of an installed agent (see "Picking the engine" below). This is the only field that sets the engine |
 | `prompts` | quick-start prompts shown on the assistant (NOT the system prompt) |
 | `avatar` | emoji, image URL, `data:` URI, or absolute local path |
 | `enabled_skills` | skill names attached to this assistant |
@@ -152,8 +151,9 @@ python3 scripts/aionui_api.py put /api/assistants/<id> '{"agent_id":"2d23ff1c"}'
 > (`claude`, `gemini`, `codex`, …) must be opted into explicitly with their
 > `agent_id` — an Anthropic key alone doesn't put the Claude CLI on `PATH`.
 > On read, the bound engine shows up in the assistant's `engine.agent_id` /
-> `engine.agent.acp_backend`; the create-body `preset_agent_type` is display-only
-> and reads back `null`, so don't rely on it to tell you the engine.
+> `engine.agent.acp_backend`. There is no `preset_agent_type` request field — the
+> create/update bodies don't accept it (it's silently dropped and never read
+> back), so bind the engine only via `agent_id`.
 
 ### Per-assistant defaults
 
@@ -191,8 +191,12 @@ python3 scripts/aionui_api.py put /api/assistants/<id> '{
 
 > Verified end-to-end: the backend stores all four entries verbatim and returns
 > them on the `?locale=` detail read. On read, `defaults` is always present with
-> all four entries — a brand-new assistant has each set to `{"mode":"auto"}` (no
-> `value`), never `null`. Lock one by sending `{"mode":"fixed","value":...}`.
+> all four entries, never `null`. A brand-new assistant starts with `model`,
+> `permission`, and `mcps` at `{"mode":"auto"}` (no `value`), while `skills`
+> starts at `{"mode":"fixed"}` seeded with the assistant's `enabled_skills` (an
+> empty list when it has none). Lock any entry by sending
+> `{"mode":"fixed","value":...}`, or set `skills` to `{"mode":"auto"}` to let the
+> user pick.
 
 ### Update
 
@@ -491,8 +495,9 @@ for a not-yet-saved endpoint. Its body differs from detect-protocol: `platform`,
 
 ### Create
 
-`POST /api/providers`. Required: `platform`, `name`, `base_url`. Provide
-`models` (the ones to expose) and `enabled`.
+`POST /api/providers`. Required: `platform`, `name`, `base_url`, `api_key`
+(`api_key` may be empty only for the `bedrock` platform, which authenticates via
+`bedrock_config`). Provide `models` (the ones to expose) and `enabled`.
 
 ```bash
 python3 scripts/aionui_api.py post /api/providers '{
@@ -619,9 +624,23 @@ python3 scripts/aionui_api.py post /api/cron/jobs '{
   "conversation_id": "<conv-id>",
   "created_by": "agent",
   "execution_mode": "new_conversation",
-  "agent_config": {"name": "AionUi Butler", "assistant_id": "<assistant-id>"}
+  "agent_config": {
+    "name": "AionUi Butler",
+    "assistant_id": "<assistant-id>",
+    "model": {"provider_id": "<provider-id>", "model": "<model-name>"}
+  }
 }'
 ```
+
+> **⚠️ `aionrs`-engine jobs must include `agent_config.model`.** If the target
+> assistant runs on the built-in `aionrs` engine, the backend rejects the job with
+> *"aionrs cron jobs require agent_config.model.provider_id and
+> agent_config.model.model"* unless you pass a non-empty
+> `model: {"provider_id": "...", "model": "..."}`. This bites easily: an assistant
+> created without an explicit `agent_id` falls back to `aionrs` (see *Picking the
+> engine*), so its scheduled jobs need `agent_config.model` too. CLI-engine
+> assistants (`claude`, `gemini`, `codex`, …) don't require it — omit `model` for
+> them. Read `GET /api/providers` for a valid `provider_id` + `model` pair.
 
 | Field | Required | Meaning |
 | --- | --- | --- |
@@ -631,7 +650,7 @@ python3 scripts/aionui_api.py post /api/cron/jobs '{
 | `created_by` | ✅ | `"agent"` when you create it on the user's behalf, `"user"` for a user-initiated one. **Only these two values** |
 | `message` (or `prompt`) | — | the instruction sent on each run. `message` wins if both are given; with neither, the run sends an empty prompt |
 | `execution_mode` | — | `"existing"` (default) reuses `conversation_id` every run; `"new_conversation"` spins up a fresh conversation each run |
-| `agent_config` | — | which assistant runs the task. **In practice required for a new job**: omit it and the API 400s with *"assistant_id is required for new cron jobs"*. Pass `{"name":"<label>","assistant_id":"<id>"}` |
+| `agent_config` | — | which assistant runs the task. **In practice required for a new job**: omit it and the API 400s with *"assistant_id is required for new cron jobs"*. Pass `{"name":"<label>","assistant_id":"<id>"}`; for an `aionrs`-engine assistant also add `"model":{"provider_id":"<id>","model":"<name>"}` (see the ⚠️ note above) |
 | `description` | — | optional longer description |
 
 > `agent_config` is strict (`deny_unknown_fields`): only `name`, `assistant_id`,

--- a/crates/aionui-app/assets/builtin-skills/aionui-troubleshooting/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/aionui-troubleshooting/SKILL.md
@@ -104,14 +104,20 @@ python3 scripts/aion_diag.py messages <id> [--limit N] [--errors]   # message hi
 ```
 
 - `conversation <id>` is the workhorse. It returns the live `runtime` block
-  (`state`, `task_status`, `is_processing`, `turn_id`), the 5 most recent
-  **error** messages, and a `stuck_hint` when `state=running` +
-  `is_processing=true`.
+  (`state`, `task_status`, `is_processing`, `turn_id`, plus `can_send_message`,
+  `has_task`, `pending_confirmations`), the 5 most recent **error** messages, and
+  a `stuck_hint` when `state=running` + `is_processing=true`. Note `state` (the
+  runtime machine state) and `task_status` are different fields — stuck detection
+  keys off `state`.
 - **Stuck detection is comparative, not absolute.** A single `running` snapshot
   is normal — that may just be the active turn. To confirm a hang, run
   `conversation <id>` a few times seconds apart: if `turn_id` and runtime never
   change while no new messages arrive, it's stuck. Cross-check with
   `logs --conv <id>`.
+- **Not every non-progressing turn is stuck.** `state=waiting_confirmation` (or
+  `pending_confirmations > 0`) means the turn is *blocked on a user approval*,
+  not hung — the fix is to answer the pending confirmation, not to restart the
+  conversation. The `stuck_hint` distinguishes these two cases.
 - `messages <id> --errors` pulls just the failed messages/tool-calls for that
   conversation from the unified `messages` table (engine-agnostic).
 
@@ -122,8 +128,9 @@ python3 scripts/aion_diag.py providers
 ```
 
 Lists every configured provider with its `model_health` (`status`, `latency`,
-`last_check`) and an `unhealthy_models` summary. A provider whose models show
-non-`healthy` status, huge `latency`, or a stale `last_check` is the suspect.
+`last_check`, and an `error` string on the last failed check) and an
+`unhealthy_models` summary. A provider whose models show non-`healthy` status,
+huge `latency`, or a stale `last_check` is the suspect.
 Then confirm with the log (filter by the provider's base_url or id):
 
 ```bash

--- a/crates/aionui-app/assets/builtin-skills/aionui-troubleshooting/scripts/aion_diag.py
+++ b/crates/aionui-app/assets/builtin-skills/aionui-troubleshooting/scripts/aion_diag.py
@@ -20,7 +20,7 @@ Usage:
   python3 aion_diag.py providers         # LLM providers + model_health (api_key REDACTED)
   python3 aion_diag.py mcp               # MCP servers + tool counts (flags enabled-but-0-tools)
   python3 aion_diag.py teams             # teams + members + each member's conversation state
-  python3 aion_diag.py crons             # scheduled jobs from SQLite (no REST API for these)
+  python3 aion_diag.py crons             # scheduled jobs read straight from SQLite (a REST API also exists)
 
   python3 aion_diag.py logs [--lines N] [--errors] [--conv <id>]   # tail aioncore log
   python3 aion_diag.py overview          # one-shot health snapshot across everything
@@ -266,12 +266,18 @@ def cmd_conversation(argv):
         })
         return
     runtime = d.get("runtime", {})
-    # engine-agnostic stuck-detection hint
+    # engine-agnostic stuck-detection hint. `state` is the runtime machine state
+    # (idle/starting/running/cancelling/waiting_confirmation); `task_status` is a
+    # different field (pending/running/finished), so key off `state` here.
     stuck_hint = None
-    if runtime.get("is_processing") and runtime.get("task_status") == "running":
+    if runtime.get("is_processing") and runtime.get("state") == "running":
         stuck_hint = ("state=running & is_processing=true — if this has not changed "
                       "across repeated checks, the turn may be stuck. Compare turn_id "
                       "over time and check recent errors + logs.")
+    elif runtime.get("state") == "waiting_confirmation" or runtime.get("pending_confirmations"):
+        stuck_hint = ("state=waiting_confirmation — the turn is blocked awaiting a "
+                      "user approval, not stuck. Resolve the pending confirmation to "
+                      "let it continue (pending_confirmations > 0).")
     errs = _rows(
         "SELECT msg_id, type, substr(content,1,300) AS content, created_at "
         "FROM messages WHERE conversation_id=? AND status='error' "
@@ -373,7 +379,9 @@ def cmd_teams(argv):
 
 
 def cmd_crons(argv):
-    # No REST API for crons — read AionUi's SQLite store directly.
+    # A REST API exists (/api/cron/jobs), but for diagnosis we read AionUi's
+    # SQLite store directly — it surfaces the run-state columns in one shot and
+    # needs no auth token.
     rows = _rows(
         "SELECT id, name, enabled, schedule_kind, schedule_value, "
         "schedule_description, last_status, last_error, "

--- a/crates/aionui-app/assets/builtin-skills/aionui-webui-public/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/aionui-webui-public/SKILL.md
@@ -154,6 +154,12 @@ curl -s -X POST http://127.0.0.1:25808/api/webui/change-username -H "Content-Typ
 
 (Confirm exact field names from the response if it errors; reset-password / generate-qr-token endpoints also exist.)
 
+> These `/api/webui/*` credential endpoints only work when aioncore runs in
+> **local mode** (the normal desktop/Electron case, which is exactly the scenario
+> this skill targets). If aioncore is deployed as a standalone server, they
+> return **403 Forbidden** — change the password through that deployment's own
+> mechanism instead.
+
 ### Optional - a permanent / fixed address (mention only, do not push)
 
 Only bring this up after the user has experienced the free public access and asks for a URL that does not change. A fixed address requires a Cloudflare account + your own domain wired to a cloudflared named tunnel (more setup, and a custom domain is paid). The free *.trycloudflare.com URL is always random/ephemeral. Recommend the named-tunnel path as an option, but do not set it up unless they explicitly want it.


### PR DESCRIPTION
## Why

The AionUi Butler (`aionui-assistant`) ships its knowledge as builtin skills compiled into `aioncore` via `include_dir!`. Several concrete claims in `aionui-config` had drifted from what the backend actually does, so the butler would hit a hard 400 (cron case) or give inaccurate guidance. This is the 2026-07 drift-audit sweep, fixing each finding **at the source asset**, verified to `file:line` against current backend source. **Skill content only — no file moves.**

## What (all in `crates/aionui-app/assets/builtin-skills/aionui-config/SKILL.md`)

**Breaking fix — cron guidance:**
- `aionrs`-engine cron jobs are rejected by `validate_aionrs_agent_config` (`crates/aionui-cron/src/service.rs:1366-1384`, called at `:241`) unless `agent_config.model.{provider_id,model}` are both non-empty. An assistant created without an explicit `agent_id` falls back to `aionrs` (`crates/aionui-assistant/src/service.rs:702-718`), so the butler's own scheduled jobs hit this 400. The skill's cron example only sent `{name, assistant_id}`. Added `agent_config.model` to the example + a dedicated ⚠️ note; CLI engines still omit it.

**Doc-accuracy fixes:**
- `POST /api/providers` also requires `api_key` (non-optional in `CreateProviderRequest`, `crates/aionui-api-types/src/provider.rs:158-162`; empty allowed only for `bedrock`). Required-field list corrected.
- A new assistant's `defaults.skills` starts at `mode:"fixed"` (seeded from `enabled_skills`), not `"auto"` (`crates/aionui-assistant/src/service.rs:492-500`); `model`/`permission`/`mcps` do start `"auto"`.
- Removed `preset_agent_type` as a documented request field — it does not exist on `CreateAssistantRequest`/`UpdateAssistantRequest` (`crates/aionui-api-types/src/assistant.rs:224-291`) and is silently dropped. `agent_id` is the only engine binding.

Earlier commits on this branch (unchanged): webui local-mode note, aionui-troubleshooting stuck-detection fix, and a prior round of aionui-config corrections.

## How verified

- Every reported drift re-confirmed against backend source to `file:line`, not assumptions.
- The aionrs-cron requirement is pinned by existing backend tests (`crates/aionui-cron/src/service.rs:1594-1625`).
- Dev mirror (`AionUi/.claude/skills/aionui-config/`) synced; `diff` confirms parity.

## Ship path

Assets only — **no `.rs` changes, no file relocations**. Files ship via `include_dir!` on the next `aioncore` binary build; no runtime/migration impact.