### PR TITLE
feat(system): add feedback diagnostics report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sqlx",
  "thiserror 2.0.18",
  "tokio",
  "tower",

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -151,7 +151,9 @@ pub use skill::{
     WriteAssistantRuleRequest,
 };
 pub use system::{
-    ClientPreferencesResponse, SystemSettingsResponse, UpdateClientPreferencesRequest, UpdateSettingsRequest,
+    ClientPreferencesResponse, FeedbackDiagnosticsContextResponse, FeedbackDiagnosticsPrivacyResponse,
+    FeedbackDiagnosticsProfileResponse, FeedbackDiagnosticsQuery, FeedbackDiagnosticsResponse, SystemSettingsResponse,
+    UpdateClientPreferencesRequest, UpdateSettingsRequest,
 };
 pub use team::{
     AddAgentRequest, CancelTeamChildTurnRequest, CancelTeamRunRequest, CreateTeamRequest, PauseTeamSlotRequest,

--- a/crates/aionui-api-types/src/system.rs
+++ b/crates/aionui-api-types/src/system.rs
@@ -65,6 +65,61 @@ pub type ClientPreferencesResponse = HashMap<String, Value>;
 /// the key should be deleted. Non-null values are persisted as-is.
 pub type UpdateClientPreferencesRequest = HashMap<String, Value>;
 
+/// Query parameters for `GET /api/system/diagnostics/feedback-report`.
+///
+/// The UI sends only routing and explicit context. aionCore owns profile
+/// resolution, SQL selection, and redaction.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FeedbackDiagnosticsQuery {
+    pub route_at_open: Option<String>,
+    pub route_at_submit: Option<String>,
+    pub selected_module: Option<String>,
+    /// Optional comma-separated kebab-case profile names.
+    pub profiles: Option<String>,
+    pub conversation_id: Option<String>,
+    pub provider_id: Option<String>,
+    pub agent_id: Option<String>,
+    pub team_id: Option<String>,
+    pub mcp_server_id: Option<String>,
+}
+
+/// Response for `GET /api/system/diagnostics/feedback-report`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FeedbackDiagnosticsResponse {
+    pub schema_version: String,
+    pub context: FeedbackDiagnosticsContextResponse,
+    pub profiles: Vec<FeedbackDiagnosticsProfileResponse>,
+    pub privacy: FeedbackDiagnosticsPrivacyResponse,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FeedbackDiagnosticsContextResponse {
+    pub route_at_open: Option<String>,
+    pub route_at_submit: Option<String>,
+    pub selected_module: Option<String>,
+    pub conversation_id: Option<String>,
+    pub provider_id: Option<String>,
+    pub agent_id: Option<String>,
+    pub team_id: Option<String>,
+    pub mcp_server_id: Option<String>,
+    pub selected_profiles: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FeedbackDiagnosticsProfileResponse {
+    pub name: String,
+    pub mode: String,
+    pub data: Value,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FeedbackDiagnosticsPrivacyResponse {
+    pub redaction: String,
+    pub raw_content_included: bool,
+    pub api_keys_included: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -20,7 +20,8 @@ use aionui_db::{
     IProviderRepository, SqliteAcpSessionRepository, SqliteAgentMetadataRepository,
     SqliteAssistantDefinitionRepository, SqliteAssistantOverlayRepository, SqliteAssistantOverrideRepository,
     SqliteAssistantPreferenceRepository, SqliteAssistantRepository, SqliteClientPreferenceRepository,
-    SqliteConversationRepository, SqliteProviderRepository, SqliteRemoteAgentRepository, SqliteSettingsRepository,
+    SqliteConversationRepository, SqliteFeedbackDiagnosticsRepository, SqliteProviderRepository,
+    SqliteRemoteAgentRepository, SqliteSettingsRepository,
 };
 use aionui_extension::{
     AssistantRuleDispatcher, ExtensionRegistry, ExtensionRouterState, ExtensionStateStore, ExternalPathsManager,
@@ -38,8 +39,9 @@ use aionui_office::{
 use aionui_realtime::{NoopMessageRouter, WsHandlerState};
 use aionui_shell::ShellRouterState;
 use aionui_system::{
-    ClientPrefService, ConnectionTestRouterState, ConnectionTestService, ModelFetchService, ProtocolDetectionService,
-    ProviderService, RuntimePrepareService, SettingsService, SystemRouterState, VersionCheckService,
+    ClientPrefService, ConnectionTestRouterState, ConnectionTestService, FeedbackDiagnosticsService, ModelFetchService,
+    ProtocolDetectionService, ProviderService, RuntimePrepareService, SettingsService, SystemRouterState,
+    VersionCheckService,
 };
 use aionui_team::{
     AgentTurnCancellationPort, AgentTurnExecutionPort, TeamAssistantCatalogEntry, TeamAssistantCatalogPort,
@@ -357,12 +359,15 @@ pub fn build_system_state(services: &AppServices) -> SystemRouterState {
 
     SystemRouterState {
         settings_service: SettingsService::new(Arc::new(SqliteSettingsRepository::new(pool.clone()))),
-        client_pref_service: ClientPrefService::new(Arc::new(SqliteClientPreferenceRepository::new(pool))),
+        client_pref_service: ClientPrefService::new(Arc::new(SqliteClientPreferenceRepository::new(pool.clone()))),
         provider_service: ProviderService::new(provider_repo.clone(), encryption_key),
         model_fetch_service: ModelFetchService::new(provider_repo, encryption_key, http_client.clone()),
         protocol_detection_service: ProtocolDetectionService::new(http_client.clone()),
         version_check_service: VersionCheckService::new(http_client, env!("CARGO_PKG_VERSION").to_owned()),
         runtime_prepare_service: RuntimePrepareService::new(services.event_bus.clone()),
+        feedback_diagnostics_service: FeedbackDiagnosticsService::new(Arc::new(
+            SqliteFeedbackDiagnosticsRepository::new(pool),
+        )),
     }
 }
 

--- a/crates/aionui-db/src/lib.rs
+++ b/crates/aionui-db/src/lib.rs
@@ -37,16 +37,19 @@ pub use repository::remote_agent::{CreateRemoteAgentParams, UpdateRemoteAgentPar
 pub use repository::skill::{CreateSkillImportRecordParams, UpsertSkillParams};
 pub use repository::team::{UpdateTaskParams, UpdateTeamParams};
 pub use repository::{
-    CreateAcpSessionParams, IAcpSessionRepository, IAgentMetadataRepository, IAssistantDefinitionRepository,
-    IAssistantOverlayRepository, IAssistantOverrideRepository, IAssistantPreferenceRepository, IAssistantRepository,
-    IChannelRepository, IClientPreferenceRepository, IConversationRepository, ICronRepository, IMcpServerRepository,
+    CreateAcpSessionParams, FeedbackDiagnosticsDbContext, FeedbackDiagnosticsProfile, FeedbackDiagnosticsProfileResult,
+    FeedbackDiagnosticsRequest, FeedbackDiagnosticsResult, IAcpSessionRepository, IAgentMetadataRepository,
+    IAssistantDefinitionRepository, IAssistantOverlayRepository, IAssistantOverrideRepository,
+    IAssistantPreferenceRepository, IAssistantRepository, IChannelRepository, IClientPreferenceRepository,
+    IConversationRepository, ICronRepository, IFeedbackDiagnosticsRepository, IMcpServerRepository,
     IOAuthTokenRepository, IProviderRepository, IRemoteAgentRepository, ISettingsRepository, ISkillRepository,
     ITeamRepository, IUserRepository, PersistedSessionState, SaveRuntimeStateParams, SqliteAcpSessionRepository,
     SqliteAgentMetadataRepository, SqliteAssistantDefinitionRepository, SqliteAssistantOverlayRepository,
     SqliteAssistantOverrideRepository, SqliteAssistantPreferenceRepository, SqliteAssistantRepository,
     SqliteChannelRepository, SqliteClientPreferenceRepository, SqliteConversationRepository, SqliteCronRepository,
-    SqliteMcpServerRepository, SqliteOAuthTokenRepository, SqliteProviderRepository, SqliteRemoteAgentRepository,
-    SqliteSettingsRepository, SqliteSkillRepository, SqliteTeamRepository, SqliteUserRepository,
+    SqliteFeedbackDiagnosticsRepository, SqliteMcpServerRepository, SqliteOAuthTokenRepository,
+    SqliteProviderRepository, SqliteRemoteAgentRepository, SqliteSettingsRepository, SqliteSkillRepository,
+    SqliteTeamRepository, SqliteUserRepository,
 };
 
 // Re-export sqlx pool type for downstream crates

--- a/crates/aionui-db/src/repository/diagnostics.rs
+++ b/crates/aionui-db/src/repository/diagnostics.rs
@@ -1,0 +1,66 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::DbError;
+
+/// Feedback diagnostics profile requested by the UI.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FeedbackDiagnosticsProfile {
+    ConversationSession,
+    ModelAuth,
+    AgentTeam,
+    McpTools,
+    GlobalSummary,
+}
+
+impl FeedbackDiagnosticsProfile {
+    pub fn as_name(&self) -> &'static str {
+        match self {
+            Self::ConversationSession => "conversation-session",
+            Self::ModelAuth => "model-auth",
+            Self::AgentTeam => "agent-team",
+            Self::McpTools => "mcp-tools",
+            Self::GlobalSummary => "global-summary",
+        }
+    }
+}
+
+/// Explicit identifiers known at feedback submission time.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FeedbackDiagnosticsDbContext {
+    pub conversation_id: Option<String>,
+    pub provider_id: Option<String>,
+    pub agent_id: Option<String>,
+    pub team_id: Option<String>,
+    pub mcp_server_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FeedbackDiagnosticsRequest {
+    pub user_id: String,
+    pub profiles: Vec<FeedbackDiagnosticsProfile>,
+    pub context: FeedbackDiagnosticsDbContext,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FeedbackDiagnosticsResult {
+    pub schema_version: String,
+    pub profiles: Vec<FeedbackDiagnosticsProfileResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FeedbackDiagnosticsProfileResult {
+    pub name: String,
+    pub mode: String,
+    pub data: Value,
+    pub warnings: Vec<String>,
+}
+
+#[async_trait::async_trait]
+pub trait IFeedbackDiagnosticsRepository: Send + Sync {
+    async fn collect_feedback_diagnostics(
+        &self,
+        request: &FeedbackDiagnosticsRequest,
+    ) -> Result<FeedbackDiagnosticsResult, DbError>;
+}

--- a/crates/aionui-db/src/repository/diagnostics_sanitizer.rs
+++ b/crates/aionui-db/src/repository/diagnostics_sanitizer.rs
@@ -1,0 +1,180 @@
+use serde_json::{Map, Value};
+
+const REDACTED: &str = "<redacted>";
+
+pub(crate) fn sanitize_mcp_original_json(raw: Option<&str>) -> Option<String> {
+    raw.map(|raw| match serde_json::from_str::<Value>(raw) {
+        Ok(value) => {
+            serde_json::to_string(&sanitize_mcp_value(&value, None)).unwrap_or_else(|_| sanitize_credential_text(raw))
+        }
+        Err(_) => sanitize_credential_text(raw),
+    })
+}
+
+fn sanitize_mcp_value(value: &Value, key: Option<&str>) -> Value {
+    if key.is_some_and(is_sensitive_key) {
+        return sanitize_sensitive_value(value);
+    }
+
+    match value {
+        Value::Object(object) => Value::Object(
+            object
+                .iter()
+                .map(|(key, value)| (key.clone(), sanitize_mcp_value(value, Some(key))))
+                .collect::<Map<_, _>>(),
+        ),
+        Value::Array(items) => sanitize_mcp_array(items),
+        Value::String(text) => Value::String(sanitize_credential_text(text)),
+        _ => value.clone(),
+    }
+}
+
+fn sanitize_mcp_array(items: &[Value]) -> Value {
+    let mut sanitized = Vec::with_capacity(items.len());
+    let mut redact_next_string = false;
+
+    for item in items {
+        if redact_next_string && let Some(text) = item.as_str() {
+            sanitized.push(Value::String(if text.trim().is_empty() {
+                text.to_owned()
+            } else {
+                REDACTED.to_owned()
+            }));
+            redact_next_string = false;
+            continue;
+        }
+
+        if let Some(text) = item.as_str() {
+            redact_next_string = is_sensitive_cli_flag(text);
+        } else {
+            redact_next_string = false;
+        }
+        sanitized.push(sanitize_mcp_value(item, None));
+    }
+
+    Value::Array(sanitized)
+}
+
+fn sanitize_sensitive_value(value: &Value) -> Value {
+    match value {
+        Value::Null => Value::Null,
+        Value::Bool(_) | Value::Number(_) => value.clone(),
+        _ => Value::String(REDACTED.to_owned()),
+    }
+}
+
+fn sanitize_credential_text(text: &str) -> String {
+    let mut ranges = Vec::new();
+    collect_assignment_ranges(text, &mut ranges);
+    collect_bearer_ranges(text, &mut ranges);
+    collect_known_token_ranges(text, &mut ranges);
+    apply_redaction_ranges(text, ranges)
+}
+
+fn collect_assignment_ranges(text: &str, ranges: &mut Vec<(usize, usize)>) {
+    for marker in [
+        "--access-token=",
+        "--api-key=",
+        "--api_key=",
+        "--token=",
+        "--secret=",
+        "--password=",
+        "access_token=",
+        "access-token=",
+        "api_key=",
+        "apikey=",
+        "authorization=",
+        "token=",
+        "secret=",
+        "password=",
+    ] {
+        collect_value_after_marker(text, marker, ranges);
+    }
+}
+
+fn collect_bearer_ranges(text: &str, ranges: &mut Vec<(usize, usize)>) {
+    collect_value_after_marker(text, "bearer ", ranges);
+}
+
+fn collect_value_after_marker(text: &str, marker: &str, ranges: &mut Vec<(usize, usize)>) {
+    let lower = text.to_ascii_lowercase();
+    let mut search_from = 0;
+    while let Some(relative_start) = lower[search_from..].find(marker) {
+        let marker_start = search_from + relative_start;
+        let value_start = marker_start + marker.len();
+        let value_end = credential_value_end(text, value_start);
+        if value_end > value_start {
+            ranges.push((value_start, value_end));
+        }
+        search_from = value_end.max(value_start);
+    }
+}
+
+fn collect_known_token_ranges(text: &str, ranges: &mut Vec<(usize, usize)>) {
+    for prefix in ["sk-", "sntryu_", "AIza"] {
+        let mut search_from = 0;
+        while let Some(relative_start) = text[search_from..].find(prefix) {
+            let start = search_from + relative_start;
+            let end = credential_value_end(text, start);
+            if end > start {
+                ranges.push((start, end));
+            }
+            search_from = end.max(start + prefix.len());
+        }
+    }
+}
+
+fn credential_value_end(text: &str, value_start: usize) -> usize {
+    for (offset, ch) in text[value_start..].char_indices() {
+        if is_credential_delimiter(ch) {
+            return value_start + offset;
+        }
+    }
+    text.len()
+}
+
+fn is_credential_delimiter(ch: char) -> bool {
+    ch.is_whitespace() || matches!(ch, '"' | '\'' | ',' | '}' | ']' | '&' | ';')
+}
+
+fn apply_redaction_ranges(text: &str, mut ranges: Vec<(usize, usize)>) -> String {
+    if ranges.is_empty() {
+        return text.to_owned();
+    }
+
+    ranges.sort_unstable_by_key(|(start, end)| (*start, *end));
+    let mut out = String::with_capacity(text.len());
+    let mut copied_until = 0;
+    let mut redacted_until = 0;
+
+    for (start, end) in ranges {
+        if end <= redacted_until || start >= end {
+            continue;
+        }
+        let start = start.max(redacted_until);
+        out.push_str(&text[copied_until..start]);
+        out.push_str(REDACTED);
+        copied_until = end;
+        redacted_until = end;
+    }
+    out.push_str(&text[copied_until..]);
+    out
+}
+
+fn is_sensitive_cli_flag(value: &str) -> bool {
+    let flag = value.trim();
+    flag.starts_with("--") && !flag.contains('=') && is_sensitive_key(flag.trim_start_matches("--"))
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    let normalized = key.replace(['_', '-'], "");
+    normalized.contains("apikey")
+        || normalized.contains("accesskey")
+        || normalized.contains("accesstoken")
+        || normalized.contains("authorization")
+        || normalized.contains("credential")
+        || key.contains("token")
+        || key.contains("secret")
+        || key.contains("password")
+}

--- a/crates/aionui-db/src/repository/mod.rs
+++ b/crates/aionui-db/src/repository/mod.rs
@@ -5,6 +5,7 @@ pub mod channel;
 mod client_preference;
 pub mod conversation;
 pub mod cron;
+pub mod diagnostics;
 pub mod mcp_server;
 pub mod oauth_token;
 pub mod provider;
@@ -18,6 +19,7 @@ mod sqlite_channel;
 mod sqlite_client_preference;
 mod sqlite_conversation;
 mod sqlite_cron;
+mod sqlite_diagnostics;
 mod sqlite_mcp_server;
 mod sqlite_oauth_token;
 mod sqlite_provider;
@@ -39,6 +41,10 @@ pub use channel::IChannelRepository;
 pub use client_preference::IClientPreferenceRepository;
 pub use conversation::IConversationRepository;
 pub use cron::ICronRepository;
+pub use diagnostics::{
+    FeedbackDiagnosticsDbContext, FeedbackDiagnosticsProfile, FeedbackDiagnosticsProfileResult,
+    FeedbackDiagnosticsRequest, FeedbackDiagnosticsResult, IFeedbackDiagnosticsRepository,
+};
 pub use mcp_server::IMcpServerRepository;
 pub use oauth_token::IOAuthTokenRepository;
 pub use provider::IProviderRepository;
@@ -55,6 +61,7 @@ pub use sqlite_channel::SqliteChannelRepository;
 pub use sqlite_client_preference::SqliteClientPreferenceRepository;
 pub use sqlite_conversation::SqliteConversationRepository;
 pub use sqlite_cron::SqliteCronRepository;
+pub use sqlite_diagnostics::SqliteFeedbackDiagnosticsRepository;
 pub use sqlite_mcp_server::SqliteMcpServerRepository;
 pub use sqlite_oauth_token::SqliteOAuthTokenRepository;
 pub use sqlite_provider::SqliteProviderRepository;

--- a/crates/aionui-db/src/repository/mod.rs
+++ b/crates/aionui-db/src/repository/mod.rs
@@ -6,6 +6,7 @@ mod client_preference;
 pub mod conversation;
 pub mod cron;
 pub mod diagnostics;
+mod diagnostics_sanitizer;
 pub mod mcp_server;
 pub mod oauth_token;
 pub mod provider;

--- a/crates/aionui-db/src/repository/sqlite_diagnostics.rs
+++ b/crates/aionui-db/src/repository/sqlite_diagnostics.rs
@@ -1,0 +1,1554 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::{Map, Value, json};
+use sqlx::{Row, SqlitePool};
+
+use crate::error::DbError;
+use crate::repository::diagnostics::{
+    FeedbackDiagnosticsProfile, FeedbackDiagnosticsProfileResult, FeedbackDiagnosticsRequest,
+    FeedbackDiagnosticsResult, IFeedbackDiagnosticsRepository,
+};
+
+const RECENT_CONVERSATION_WINDOW_MS: i64 = 24 * 60 * 60 * 1000;
+const RECENT_CONVERSATION_LIMIT: i64 = 20;
+const GLOBAL_RECENT_CONVERSATION_LIMIT: i64 = 20;
+const GLOBAL_RECENT_CONVERSATION_SCAN_LIMIT: i64 = 100;
+const GLOBAL_CONVERSATION_ERROR_LIMIT: i64 = 10;
+const GLOBAL_CONVERSATION_MESSAGE_LIMIT: i64 = 10;
+const GLOBAL_RECENT_ERROR_LIMIT: i64 = 20;
+const GLOBAL_HEALTH_LIMIT: i64 = 20;
+
+#[derive(Clone, Debug)]
+pub struct SqliteFeedbackDiagnosticsRepository {
+    pool: SqlitePool,
+}
+
+impl SqliteFeedbackDiagnosticsRepository {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    async fn collect_conversation_session(
+        &self,
+        request: &FeedbackDiagnosticsRequest,
+    ) -> Result<FeedbackDiagnosticsProfileResult, DbError> {
+        let Some(conversation_id) = request.context.conversation_id.as_deref() else {
+            return self.collect_conversation_summary(&request.user_id).await;
+        };
+
+        let conversation = sqlx::query(
+            "SELECT \
+                id, type, status, source, pinned, created_at, updated_at, \
+                name AS title, length(name) AS name_length, length(extra) AS extra_bytes, \
+                CASE WHEN json_valid(model) THEN COALESCE(json_extract(model, '$.providerId'), json_extract(model, '$.provider_id')) END AS model_provider_id, \
+                CASE WHEN json_valid(model) THEN COALESCE(json_extract(model, '$.modelId'), json_extract(model, '$.model_id')) END AS model_id, \
+                CASE WHEN json_valid(extra) THEN COALESCE(json_extract(extra, '$.agentId'), json_extract(extra, '$.agent_id')) END AS extra_agent_id, \
+                CASE WHEN json_valid(extra) THEN COALESCE(json_extract(extra, '$.teamId'), json_extract(extra, '$.team_id')) END AS extra_team_id \
+             FROM conversations \
+             WHERE id = ? AND user_id = ?",
+        )
+        .bind(conversation_id)
+        .bind(&request.user_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let Some(conversation) = conversation else {
+            return Ok(profile_result(
+                FeedbackDiagnosticsProfile::ConversationSession,
+                "not_found",
+                json!({ "conversation": Value::Null }),
+            ));
+        };
+
+        let agent_id = request.context.agent_id.as_deref().map(ToOwned::to_owned).or_else(|| {
+            conversation
+                .try_get::<Option<String>, _>("extra_agent_id")
+                .ok()
+                .flatten()
+        });
+
+        let data = json!({
+            "conversation": {
+                "id": conversation.try_get::<String, _>("id")?,
+                "type": conversation.try_get::<String, _>("type")?,
+                "status": conversation.try_get::<Option<String>, _>("status")?,
+                "source": conversation.try_get::<Option<String>, _>("source")?,
+                "pinned": conversation.try_get::<bool, _>("pinned")?,
+                "title": conversation.try_get::<String, _>("title")?,
+                "name_length": conversation.try_get::<Option<i64>, _>("name_length")?,
+                "extra_bytes": conversation.try_get::<Option<i64>, _>("extra_bytes")?,
+                "model_provider_id": conversation.try_get::<Option<String>, _>("model_provider_id")?,
+                "model_id": conversation.try_get::<Option<String>, _>("model_id")?,
+                "extra_agent_id": conversation.try_get::<Option<String>, _>("extra_agent_id")?,
+                "extra_team_id": conversation.try_get::<Option<String>, _>("extra_team_id")?,
+                "created_at": conversation.try_get::<i64, _>("created_at")?,
+                "updated_at": conversation.try_get::<i64, _>("updated_at")?,
+            },
+            "messages": self.collect_message_diagnostics(conversation_id).await?,
+            "recent_conversations": self.collect_recent_conversations(
+                &request.user_id,
+                conversation_id,
+                conversation.try_get::<i64, _>("updated_at")?,
+            ).await?,
+            "acp_session": self.collect_acp_session(conversation_id).await?,
+            "agent_metadata": self.collect_agent_metadata(agent_id.as_deref()).await?,
+            "assistant_snapshot": self.collect_assistant_snapshot(&request.user_id, conversation_id).await?,
+        });
+
+        Ok(profile_result(
+            FeedbackDiagnosticsProfile::ConversationSession,
+            "detail",
+            data,
+        ))
+    }
+
+    async fn collect_conversation_summary(&self, user_id: &str) -> Result<FeedbackDiagnosticsProfileResult, DbError> {
+        let rows = sqlx::query(
+            "SELECT c.type, c.status, COUNT(*) AS count, MAX(c.updated_at) AS last_updated_at \
+             FROM conversations c \
+             LEFT JOIN conversation_assistant_snapshots cas ON cas.conversation_id = c.id \
+             LEFT JOIN assistant_definitions ad ON ad.id = cas.assistant_definition_id \
+             LEFT JOIN teams t ON t.id = CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.teamId'), json_extract(c.extra, '$.team_id')) END \
+                AND t.user_id = c.user_id \
+             WHERE c.user_id = ? \
+               AND (CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.teamId'), json_extract(c.extra, '$.team_id')) END IS NULL OR t.id IS NOT NULL) \
+               AND (cas.conversation_id IS NULL OR (ad.id IS NOT NULL AND ad.deleted_at IS NULL)) \
+             GROUP BY c.type, c.status \
+             ORDER BY last_updated_at DESC \
+             LIMIT 25",
+        )
+        .bind(user_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let items = rows
+            .into_iter()
+            .map(|row| {
+                Ok(json!({
+                    "type": row.try_get::<String, _>("type")?,
+                    "status": row.try_get::<Option<String>, _>("status")?,
+                    "count": row.try_get::<i64, _>("count")?,
+                    "last_updated_at": row.try_get::<Option<i64>, _>("last_updated_at")?,
+                }))
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()?;
+
+        Ok(profile_result(
+            FeedbackDiagnosticsProfile::ConversationSession,
+            "summary",
+            json!({ "conversations": items }),
+        ))
+    }
+
+    async fn collect_recent_conversations(
+        &self,
+        user_id: &str,
+        anchor_conversation_id: &str,
+        anchor_updated_at: i64,
+    ) -> Result<Value, DbError> {
+        let window_start = anchor_updated_at.saturating_sub(RECENT_CONVERSATION_WINDOW_MS);
+        let rows = sqlx::query(
+            "SELECT \
+                c.id, c.name AS title, c.type, c.status, c.source, c.pinned, c.created_at, c.updated_at, \
+                length(c.extra) AS extra_bytes, \
+                CASE WHEN json_valid(c.model) THEN COALESCE(json_extract(c.model, '$.providerId'), json_extract(c.model, '$.provider_id')) END AS model_provider_id, \
+                CASE WHEN json_valid(c.model) THEN COALESCE(json_extract(c.model, '$.modelId'), json_extract(c.model, '$.model_id')) END AS model_id, \
+                CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.agentId'), json_extract(c.extra, '$.agent_id')) END AS extra_agent_id, \
+                CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.teamId'), json_extract(c.extra, '$.team_id')) END AS extra_team_id, \
+                (SELECT COUNT(*) FROM messages m WHERE m.conversation_id = c.id) AS message_count, \
+                (SELECT COUNT(*) FROM messages m WHERE m.conversation_id = c.id AND (m.status = 'error' OR m.type = 'tips' OR (json_valid(m.content) AND json_extract(m.content, '$.error.code') IS NOT NULL))) AS error_message_count, \
+                (SELECT CASE WHEN json_valid(m.content) THEN COALESCE(json_extract(m.content, '$.error.code'), json_extract(m.content, '$.code')) END \
+                   FROM messages m \
+                  WHERE m.conversation_id = c.id \
+                    AND (m.status = 'error' OR m.type = 'tips' OR (json_valid(m.content) AND json_extract(m.content, '$.error.code') IS NOT NULL)) \
+                  ORDER BY m.created_at DESC, m.id DESC \
+                  LIMIT 1) AS latest_error_code \
+             FROM conversations c \
+             LEFT JOIN conversation_assistant_snapshots cas ON cas.conversation_id = c.id \
+             LEFT JOIN assistant_definitions ad ON ad.id = cas.assistant_definition_id \
+             LEFT JOIN teams t ON t.id = CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.teamId'), json_extract(c.extra, '$.team_id')) END \
+                AND t.user_id = c.user_id \
+             WHERE c.user_id = ? AND c.updated_at >= ? \
+               AND (CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.teamId'), json_extract(c.extra, '$.team_id')) END IS NULL OR t.id IS NOT NULL) \
+               AND (cas.conversation_id IS NULL OR (ad.id IS NOT NULL AND ad.deleted_at IS NULL)) \
+             ORDER BY CASE WHEN c.id = ? THEN 0 ELSE 1 END, c.updated_at DESC, c.id DESC \
+             LIMIT ?",
+        )
+        .bind(user_id)
+        .bind(window_start)
+        .bind(anchor_conversation_id)
+        .bind(RECENT_CONVERSATION_LIMIT)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let items = rows
+            .into_iter()
+            .map(|row| {
+                let id = row.try_get::<String, _>("id")?;
+                Ok(json!({
+                    "id": id,
+                    "is_anchor": id == anchor_conversation_id,
+                    "title": row.try_get::<String, _>("title")?,
+                    "type": row.try_get::<String, _>("type")?,
+                    "status": row.try_get::<Option<String>, _>("status")?,
+                    "source": row.try_get::<Option<String>, _>("source")?,
+                    "pinned": row.try_get::<bool, _>("pinned")?,
+                    "extra_bytes": row.try_get::<Option<i64>, _>("extra_bytes")?,
+                    "model_provider_id": row.try_get::<Option<String>, _>("model_provider_id")?,
+                    "model_id": row.try_get::<Option<String>, _>("model_id")?,
+                    "extra_agent_id": row.try_get::<Option<String>, _>("extra_agent_id")?,
+                    "extra_team_id": row.try_get::<Option<String>, _>("extra_team_id")?,
+                    "message_count": row.try_get::<i64, _>("message_count")?,
+                    "error_message_count": row.try_get::<i64, _>("error_message_count")?,
+                    "latest_error_code": row.try_get::<Option<String>, _>("latest_error_code")?,
+                    "created_at": row.try_get::<i64, _>("created_at")?,
+                    "updated_at": row.try_get::<i64, _>("updated_at")?,
+                }))
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()?;
+
+        Ok(json!({
+            "window_ms": RECENT_CONVERSATION_WINDOW_MS,
+            "limit": RECENT_CONVERSATION_LIMIT,
+            "anchor_updated_at": anchor_updated_at,
+            "items": items,
+        }))
+    }
+
+    async fn collect_message_diagnostics(&self, conversation_id: &str) -> Result<Value, DbError> {
+        let aggregate_rows = sqlx::query(
+            "SELECT type, status, hidden, COUNT(*) AS count, SUM(length(content)) AS content_bytes \
+             FROM messages \
+             WHERE conversation_id = ? \
+             GROUP BY type, status, hidden",
+        )
+        .bind(conversation_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut total_count = 0_i64;
+        let mut total_content_bytes = 0_i64;
+        let mut by_type = Map::new();
+        let mut by_status = Map::new();
+        let mut hidden = Map::new();
+        for row in aggregate_rows {
+            let count = row.try_get::<i64, _>("count")?;
+            let content_bytes = row.try_get::<Option<i64>, _>("content_bytes")?.unwrap_or_default();
+            total_count += count;
+            total_content_bytes += content_bytes;
+            bump_count(&mut by_type, &row.try_get::<String, _>("type")?, count);
+            if let Some(status) = row.try_get::<Option<String>, _>("status")? {
+                bump_count(&mut by_status, &status, count);
+            }
+            let hidden_key = if row.try_get::<bool, _>("hidden")? {
+                "true"
+            } else {
+                "false"
+            };
+            bump_count(&mut hidden, hidden_key, count);
+        }
+
+        let recent_messages = sqlx::query(
+            "SELECT \
+                id, msg_id, type, position, status, hidden, created_at, length(content) AS content_bytes, \
+                CASE WHEN json_valid(content) THEN length(json_extract(content, '$.text')) END AS text_length, \
+                CASE WHEN json_valid(content) THEN json_array_length(content, '$.attachments') END AS attachment_count, \
+                CASE WHEN json_valid(content) THEN json_array_length(content, '$.images') END AS image_count, \
+                CASE WHEN json_valid(content) THEN json_array_length(content, '$.toolCalls') END AS tool_call_count \
+             FROM messages \
+             WHERE conversation_id = ? \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT 20",
+        )
+        .bind(conversation_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let recent_messages = recent_messages
+            .into_iter()
+            .map(|row| {
+                Ok(json!({
+                    "id": row.try_get::<String, _>("id")?,
+                    "msg_id": row.try_get::<Option<String>, _>("msg_id")?,
+                    "type": row.try_get::<String, _>("type")?,
+                    "position": row.try_get::<Option<String>, _>("position")?,
+                    "status": row.try_get::<Option<String>, _>("status")?,
+                    "hidden": row.try_get::<bool, _>("hidden")?,
+                    "created_at": row.try_get::<i64, _>("created_at")?,
+                    "content_bytes": row.try_get::<Option<i64>, _>("content_bytes")?,
+                    "text_length": row.try_get::<Option<i64>, _>("text_length")?,
+                    "attachment_count": row.try_get::<Option<i64>, _>("attachment_count")?.unwrap_or_default(),
+                    "image_count": row.try_get::<Option<i64>, _>("image_count")?.unwrap_or_default(),
+                    "tool_call_count": row.try_get::<Option<i64>, _>("tool_call_count")?.unwrap_or_default(),
+                }))
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()?;
+
+        let recent_errors = sqlx::query(
+            "SELECT \
+                id, type, status, position, created_at, length(content) AS content_bytes, \
+                CASE WHEN json_valid(content) THEN COALESCE(json_extract(content, '$.error.code'), json_extract(content, '$.code')) END AS code, \
+                CASE WHEN json_valid(content) THEN COALESCE(json_extract(content, '$.error.ownership'), json_extract(content, '$.ownership')) END AS ownership, \
+                CASE WHEN json_valid(content) THEN COALESCE(json_extract(content, '$.error.retryable'), json_extract(content, '$.retryable')) END AS retryable, \
+                CASE WHEN json_valid(content) THEN json_extract(content, '$.resolution.kind') END AS resolution_kind, \
+                CASE WHEN json_valid(content) THEN json_extract(content, '$.resolution.targetId') END AS resolution_target_id, \
+                CASE WHEN json_valid(content) THEN json_extract(content, '$.feedbackRecommended') END AS feedback_recommended \
+             FROM messages \
+             WHERE conversation_id = ? \
+               AND (status = 'error' OR type = 'tips' OR (json_valid(content) AND json_extract(content, '$.error.code') IS NOT NULL)) \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT 10",
+        )
+        .bind(conversation_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let recent_errors = recent_errors
+            .into_iter()
+            .map(|row| {
+                Ok(json!({
+                    "id": row.try_get::<String, _>("id")?,
+                    "type": row.try_get::<String, _>("type")?,
+                    "status": row.try_get::<Option<String>, _>("status")?,
+                    "position": row.try_get::<Option<String>, _>("position")?,
+                    "created_at": row.try_get::<i64, _>("created_at")?,
+                    "content_bytes": row.try_get::<Option<i64>, _>("content_bytes")?,
+                    "code": row.try_get::<Option<String>, _>("code")?,
+                    "ownership": row.try_get::<Option<String>, _>("ownership")?,
+                    "retryable": sqlite_bool_value(row.try_get::<Option<i64>, _>("retryable")?),
+                    "resolution_kind": row.try_get::<Option<String>, _>("resolution_kind")?,
+                    "resolution_target_id": row.try_get::<Option<String>, _>("resolution_target_id")?,
+                    "feedback_recommended": sqlite_bool_value(row.try_get::<Option<i64>, _>("feedback_recommended")?),
+                }))
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()?;
+
+        Ok(json!({
+            "total_count": total_count,
+            "total_content_bytes": total_content_bytes,
+            "by_type": by_type,
+            "by_status": by_status,
+            "hidden": hidden,
+            "recent_messages": recent_messages,
+            "recent_errors": recent_errors,
+        }))
+    }
+
+    async fn collect_acp_session(&self, conversation_id: &str) -> Result<Value, DbError> {
+        let row = sqlx::query(
+            "SELECT \
+                conversation_id, agent_source, agent_id, session_id, session_status, \
+                session_config, length(session_config) AS session_config_bytes, \
+                last_active_at, suspended_at, \
+                CASE WHEN json_valid(session_config) THEN json_extract(session_config, '$.runtime.current_mode_id') END AS current_mode_id, \
+                CASE WHEN json_valid(session_config) THEN json_extract(session_config, '$.runtime.current_model_id') END AS current_model_id \
+             FROM acp_session \
+             WHERE conversation_id = ?",
+        )
+        .bind(conversation_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let Some(row) = row else {
+            return Ok(Value::Null);
+        };
+
+        let session_config = row.try_get::<String, _>("session_config")?;
+        let config_summary = runtime_config_selection_summary(&session_config);
+
+        Ok(json!({
+            "conversation_id": row.try_get::<String, _>("conversation_id")?,
+            "agent_source": row.try_get::<String, _>("agent_source")?,
+            "agent_id": row.try_get::<String, _>("agent_id")?,
+            "has_session_id": row.try_get::<Option<String>, _>("session_id")?.is_some(),
+            "session_status": row.try_get::<String, _>("session_status")?,
+            "session_config_bytes": row.try_get::<Option<i64>, _>("session_config_bytes")?,
+            "last_active_at": row.try_get::<Option<i64>, _>("last_active_at")?,
+            "suspended_at": row.try_get::<Option<i64>, _>("suspended_at")?,
+            "current_mode_id": row.try_get::<Option<String>, _>("current_mode_id")?,
+            "current_model_id": row.try_get::<Option<String>, _>("current_model_id")?,
+            "config_selection_keys": config_summary.keys,
+            "config_selections": config_summary.values,
+            "mode_selection": config_summary.mode_selection,
+            "model_selection": config_summary.model_selection,
+        }))
+    }
+
+    async fn collect_agent_metadata(&self, agent_id: Option<&str>) -> Result<Value, DbError> {
+        let Some(agent_id) = agent_id else {
+            return Ok(Value::Null);
+        };
+
+        let row = sqlx::query(
+            "SELECT \
+                id, name, backend, agent_type, agent_source, enabled, sort_order, \
+                length(command) AS command_bytes, length(args) AS args_bytes, length(env) AS env_bytes, \
+                available_modes, available_models, available_commands, config_options, \
+                last_check_status, last_check_kind, last_check_error_code, last_check_latency_ms, \
+                last_check_at, last_success_at, last_failure_at \
+             FROM agent_metadata \
+             WHERE id = ?",
+        )
+        .bind(agent_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let Some(row) = row else {
+            return Ok(Value::Null);
+        };
+
+        Ok(json!({
+            "id": row.try_get::<String, _>("id")?,
+            "name": row.try_get::<String, _>("name")?,
+            "backend": row.try_get::<Option<String>, _>("backend")?,
+            "agent_type": row.try_get::<String, _>("agent_type")?,
+            "agent_source": row.try_get::<String, _>("agent_source")?,
+            "enabled": row.try_get::<bool, _>("enabled")?,
+            "sort_order": row.try_get::<i64, _>("sort_order")?,
+            "command_bytes": row.try_get::<Option<i64>, _>("command_bytes")?,
+            "args_bytes": row.try_get::<Option<i64>, _>("args_bytes")?,
+            "env_bytes": row.try_get::<Option<i64>, _>("env_bytes")?,
+            "available_mode_count": json_array_count(row.try_get::<Option<String>, _>("available_modes")?.as_deref()),
+            "available_model_count": json_array_count(row.try_get::<Option<String>, _>("available_models")?.as_deref()),
+            "available_command_count": json_array_count(row.try_get::<Option<String>, _>("available_commands")?.as_deref()),
+            "config_option_count": json_array_count(row.try_get::<Option<String>, _>("config_options")?.as_deref()),
+            "last_check_status": row.try_get::<Option<String>, _>("last_check_status")?,
+            "last_check_kind": row.try_get::<Option<String>, _>("last_check_kind")?,
+            "last_check_error_code": row.try_get::<Option<String>, _>("last_check_error_code")?,
+            "last_check_latency_ms": row.try_get::<Option<i64>, _>("last_check_latency_ms")?,
+            "last_check_at": row.try_get::<Option<i64>, _>("last_check_at")?,
+            "last_success_at": row.try_get::<Option<i64>, _>("last_success_at")?,
+            "last_failure_at": row.try_get::<Option<i64>, _>("last_failure_at")?,
+        }))
+    }
+
+    async fn collect_assistant_snapshot(&self, user_id: &str, conversation_id: &str) -> Result<Value, DbError> {
+        let row = sqlx::query(
+            "SELECT \
+                cas.assistant_definition_id, cas.assistant_id, cas.assistant_source, cas.agent_id, \
+                cas.default_model_mode, cas.resolved_model_id, \
+                cas.default_permission_mode, cas.resolved_permission_value, \
+                cas.default_thought_level_mode, cas.resolved_thought_level_value, \
+                cas.default_skills_mode, cas.resolved_skill_ids, cas.resolved_disabled_builtin_skill_ids, \
+                cas.default_mcps_mode, cas.resolved_mcp_ids, \
+                length(cas.rules_content) AS rules_content_bytes, cas.created_at, cas.updated_at \
+             FROM conversation_assistant_snapshots cas \
+             JOIN conversations c ON c.id = cas.conversation_id \
+             WHERE cas.conversation_id = ? AND c.user_id = ?",
+        )
+        .bind(conversation_id)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let Some(row) = row else {
+            return Ok(Value::Null);
+        };
+
+        Ok(json!({
+            "assistant_definition_id": row.try_get::<String, _>("assistant_definition_id")?,
+            "assistant_id": row.try_get::<String, _>("assistant_id")?,
+            "assistant_source": row.try_get::<String, _>("assistant_source")?,
+            "agent_id": row.try_get::<String, _>("agent_id")?,
+            "default_model_mode": row.try_get::<String, _>("default_model_mode")?,
+            "resolved_model_id": row.try_get::<Option<String>, _>("resolved_model_id")?,
+            "default_permission_mode": row.try_get::<String, _>("default_permission_mode")?,
+            "resolved_permission_value": row.try_get::<Option<String>, _>("resolved_permission_value")?,
+            "default_thought_level_mode": row.try_get::<String, _>("default_thought_level_mode")?,
+            "resolved_thought_level_value": row.try_get::<Option<String>, _>("resolved_thought_level_value")?,
+            "default_skills_mode": row.try_get::<String, _>("default_skills_mode")?,
+            "resolved_skill_count": json_array_count(Some(&row.try_get::<String, _>("resolved_skill_ids")?)),
+            "resolved_disabled_builtin_skill_count": json_array_count(Some(&row.try_get::<String, _>("resolved_disabled_builtin_skill_ids")?)),
+            "default_mcps_mode": row.try_get::<String, _>("default_mcps_mode")?,
+            "resolved_mcp_count": json_array_count(Some(&row.try_get::<String, _>("resolved_mcp_ids")?)),
+            "rules_content_bytes": row.try_get::<Option<i64>, _>("rules_content_bytes")?,
+            "created_at": row.try_get::<i64, _>("created_at")?,
+            "updated_at": row.try_get::<i64, _>("updated_at")?,
+        }))
+    }
+
+    async fn collect_model_auth(
+        &self,
+        request: &FeedbackDiagnosticsRequest,
+    ) -> Result<FeedbackDiagnosticsProfileResult, DbError> {
+        let provider_id = self.resolve_provider_id(request).await?;
+        let mut query = "SELECT id, platform, name, base_url, api_key_encrypted, models, enabled, capabilities, \
+                            context_limit, model_enabled, model_health, is_full_url, created_at, updated_at \
+                         FROM providers"
+            .to_owned();
+        if provider_id.is_some() {
+            query.push_str(" WHERE id = ?");
+        }
+        query.push_str(" ORDER BY updated_at DESC LIMIT 20");
+
+        let rows = if let Some(provider_id) = provider_id.as_deref() {
+            sqlx::query(&query).bind(provider_id).fetch_all(&self.pool).await?
+        } else {
+            sqlx::query(&query).fetch_all(&self.pool).await?
+        };
+
+        let providers = rows
+            .into_iter()
+            .map(|row| {
+                let models = row.try_get::<String, _>("models")?;
+                let model_enabled = row.try_get::<Option<String>, _>("model_enabled")?;
+                let model_health = row.try_get::<Option<String>, _>("model_health")?;
+                let api_key_encrypted = row.try_get::<String, _>("api_key_encrypted")?;
+                Ok(json!({
+                    "id": row.try_get::<String, _>("id")?,
+                    "platform": row.try_get::<String, _>("platform")?,
+                    "name": row.try_get::<String, _>("name")?,
+                    "base_url_host": base_url_host(&row.try_get::<String, _>("base_url")?),
+                    "api_key_configured": !api_key_encrypted.trim().is_empty(),
+                    "enabled": row.try_get::<bool, _>("enabled")?,
+                    "model_count": json_array_count(Some(&models)),
+                    "disabled_model_count": disabled_model_count(model_enabled.as_deref()),
+                    "unhealthy_model_count": unhealthy_model_count(model_health.as_deref()),
+                    "capability_count": json_array_count(Some(&row.try_get::<String, _>("capabilities")?)),
+                    "context_limit": row.try_get::<Option<i64>, _>("context_limit")?,
+                    "is_full_url": row.try_get::<bool, _>("is_full_url")?,
+                    "created_at": row.try_get::<i64, _>("created_at")?,
+                    "updated_at": row.try_get::<i64, _>("updated_at")?,
+                }))
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()?;
+
+        let mode = if provider_id.is_some() { "detail" } else { "summary" };
+        Ok(profile_result(
+            FeedbackDiagnosticsProfile::ModelAuth,
+            mode,
+            json!({ "providers": providers }),
+        ))
+    }
+
+    async fn resolve_provider_id(&self, request: &FeedbackDiagnosticsRequest) -> Result<Option<String>, DbError> {
+        if request.context.provider_id.is_some() {
+            return Ok(request.context.provider_id.clone());
+        }
+
+        let Some(conversation_id) = request.context.conversation_id.as_deref() else {
+            return Ok(None);
+        };
+
+        let provider_id: Option<String> = sqlx::query_scalar(
+            "SELECT CASE WHEN json_valid(model) THEN COALESCE(json_extract(model, '$.providerId'), json_extract(model, '$.provider_id')) END \
+             FROM conversations \
+             WHERE id = ? AND user_id = ?",
+        )
+        .bind(conversation_id)
+        .bind(&request.user_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .flatten();
+
+        Ok(provider_id)
+    }
+
+    async fn collect_agent_team(
+        &self,
+        request: &FeedbackDiagnosticsRequest,
+    ) -> Result<FeedbackDiagnosticsProfileResult, DbError> {
+        let team_id = self.resolve_team_id(request).await?;
+        let Some(team_id) = team_id else {
+            return Ok(profile_result(
+                FeedbackDiagnosticsProfile::AgentTeam,
+                "summary",
+                json!({ "teams": self.collect_team_summary(&request.user_id).await? }),
+            ));
+        };
+
+        let team = sqlx::query(
+            "SELECT id, name, workspace_mode, session_mode, agents, lead_agent_id, agents_version, created_at, updated_at \
+             FROM teams \
+             WHERE id = ? AND user_id = ?",
+        )
+        .bind(&team_id)
+        .bind(&request.user_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let Some(team) = team else {
+            return Ok(profile_result(
+                FeedbackDiagnosticsProfile::AgentTeam,
+                "not_found",
+                json!({ "team": Value::Null }),
+            ));
+        };
+
+        let task_rows = sqlx::query(
+            "SELECT status, COUNT(*) AS count, MAX(updated_at) AS last_updated_at \
+             FROM team_tasks \
+             WHERE team_id = ? \
+             GROUP BY status",
+        )
+        .bind(&team_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mailbox_rows = sqlx::query(
+            "SELECT type, read, COUNT(*) AS count, MAX(created_at) AS last_created_at \
+             FROM mailbox \
+             WHERE team_id = ? \
+             GROUP BY type, read",
+        )
+        .bind(&team_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(profile_result(
+            FeedbackDiagnosticsProfile::AgentTeam,
+            "detail",
+            json!({
+                "team": {
+                    "id": team.try_get::<String, _>("id")?,
+                    "name_length": team.try_get::<String, _>("name")?.chars().count(),
+                    "workspace_mode": team.try_get::<String, _>("workspace_mode")?,
+                    "session_mode": team.try_get::<Option<String>, _>("session_mode")?,
+                    "agent_count": json_array_count(Some(&team.try_get::<String, _>("agents")?)),
+                    "lead_agent_id": team.try_get::<Option<String>, _>("lead_agent_id")?,
+                    "agents_version": team.try_get::<String, _>("agents_version")?,
+                    "created_at": team.try_get::<i64, _>("created_at")?,
+                    "updated_at": team.try_get::<i64, _>("updated_at")?,
+                },
+                "tasks": rows_to_group_counts(task_rows, "status")?,
+                "mailbox": mailbox_rows_to_counts(mailbox_rows)?,
+            }),
+        ))
+    }
+
+    async fn resolve_team_id(&self, request: &FeedbackDiagnosticsRequest) -> Result<Option<String>, DbError> {
+        if request.context.team_id.is_some() {
+            return Ok(request.context.team_id.clone());
+        }
+
+        let Some(conversation_id) = request.context.conversation_id.as_deref() else {
+            return Ok(None);
+        };
+
+        let team_id: Option<String> = sqlx::query_scalar(
+            "SELECT CASE WHEN json_valid(extra) THEN COALESCE(json_extract(extra, '$.teamId'), json_extract(extra, '$.team_id')) END \
+             FROM conversations \
+             WHERE id = ? AND user_id = ?",
+        )
+        .bind(conversation_id)
+        .bind(&request.user_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .flatten();
+
+        Ok(team_id)
+    }
+
+    async fn collect_team_summary(&self, user_id: &str) -> Result<Value, DbError> {
+        let rows = sqlx::query(
+            "SELECT workspace_mode, session_mode, COUNT(*) AS count, MAX(updated_at) AS last_updated_at \
+             FROM teams \
+             WHERE user_id = ? \
+             GROUP BY workspace_mode, session_mode",
+        )
+        .bind(user_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok(json!({
+                    "workspace_mode": row.try_get::<String, _>("workspace_mode")?,
+                    "session_mode": row.try_get::<Option<String>, _>("session_mode")?,
+                    "count": row.try_get::<i64, _>("count")?,
+                    "last_updated_at": row.try_get::<Option<i64>, _>("last_updated_at")?,
+                }))
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()
+            .map(Value::Array)
+            .map_err(DbError::from)
+    }
+
+    async fn collect_mcp_tools(
+        &self,
+        request: &FeedbackDiagnosticsRequest,
+    ) -> Result<FeedbackDiagnosticsProfileResult, DbError> {
+        let mut query = "SELECT id, name, enabled, transport_type, tools, last_test_status, last_connected, \
+                            original_json, builtin, deleted_at, created_at, updated_at, length(transport_config) AS transport_config_bytes, \
+                            length(original_json) AS original_json_bytes \
+                         FROM mcp_servers \
+                         WHERE deleted_at IS NULL"
+            .to_owned();
+        if request.context.mcp_server_id.is_some() {
+            query.push_str(" AND id = ?");
+        }
+        query.push_str(" ORDER BY updated_at DESC LIMIT 30");
+
+        let rows = if let Some(mcp_server_id) = request.context.mcp_server_id.as_deref() {
+            sqlx::query(&query).bind(mcp_server_id).fetch_all(&self.pool).await?
+        } else {
+            sqlx::query(&query).fetch_all(&self.pool).await?
+        };
+
+        let servers = rows
+            .into_iter()
+            .map(|row| {
+                Ok(json!({
+                    "id": row.try_get::<String, _>("id")?,
+                    "name": row.try_get::<String, _>("name")?,
+                    "enabled": row.try_get::<bool, _>("enabled")?,
+                    "transport_type": row.try_get::<String, _>("transport_type")?,
+                    "tool_count": json_array_count(row.try_get::<Option<String>, _>("tools")?.as_deref()),
+                    "last_test_status": row.try_get::<String, _>("last_test_status")?,
+                    "last_connected": row.try_get::<Option<i64>, _>("last_connected")?,
+                    "original_json": row.try_get::<Option<String>, _>("original_json")?,
+                    "builtin": row.try_get::<bool, _>("builtin")?,
+                    "deleted": row.try_get::<Option<i64>, _>("deleted_at")?.is_some(),
+                    "transport_config_bytes": row.try_get::<Option<i64>, _>("transport_config_bytes")?,
+                    "original_json_bytes": row.try_get::<Option<i64>, _>("original_json_bytes")?,
+                    "created_at": row.try_get::<i64, _>("created_at")?,
+                    "updated_at": row.try_get::<i64, _>("updated_at")?,
+                }))
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()?;
+
+        let mode = if request.context.mcp_server_id.is_some() {
+            "detail"
+        } else {
+            "summary"
+        };
+        Ok(profile_result(
+            FeedbackDiagnosticsProfile::McpTools,
+            mode,
+            json!({ "servers": servers }),
+        ))
+    }
+
+    async fn collect_global_summary(
+        &self,
+        request: &FeedbackDiagnosticsRequest,
+    ) -> Result<FeedbackDiagnosticsProfileResult, DbError> {
+        let conversation_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) \
+             FROM conversations c \
+             LEFT JOIN conversation_assistant_snapshots cas ON cas.conversation_id = c.id \
+             LEFT JOIN assistant_definitions ad ON ad.id = cas.assistant_definition_id \
+             LEFT JOIN teams t ON t.id = CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.teamId'), json_extract(c.extra, '$.team_id')) END \
+                AND t.user_id = c.user_id \
+             WHERE c.user_id = ? \
+               AND (CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.teamId'), json_extract(c.extra, '$.team_id')) END IS NULL OR t.id IS NOT NULL) \
+               AND (cas.conversation_id IS NULL OR (ad.id IS NOT NULL AND ad.deleted_at IS NULL))",
+        )
+        .bind(&request.user_id)
+        .fetch_one(&self.pool)
+        .await?;
+        let message_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) \
+             FROM messages m \
+             JOIN conversations c ON c.id = m.conversation_id \
+             LEFT JOIN conversation_assistant_snapshots cas ON cas.conversation_id = c.id \
+             LEFT JOIN assistant_definitions ad ON ad.id = cas.assistant_definition_id \
+             LEFT JOIN teams t ON t.id = CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.teamId'), json_extract(c.extra, '$.team_id')) END \
+                AND t.user_id = c.user_id \
+             WHERE c.user_id = ? \
+               AND (CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.teamId'), json_extract(c.extra, '$.team_id')) END IS NULL OR t.id IS NOT NULL) \
+               AND (cas.conversation_id IS NULL OR (ad.id IS NOT NULL AND ad.deleted_at IS NULL))",
+        )
+        .bind(&request.user_id)
+        .fetch_one(&self.pool)
+        .await?;
+        let provider_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM providers")
+            .fetch_one(&self.pool)
+            .await?;
+        let agent_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM agent_metadata")
+            .fetch_one(&self.pool)
+            .await?;
+        let active_mcp_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM mcp_servers WHERE deleted_at IS NULL")
+            .fetch_one(&self.pool)
+            .await?;
+
+        Ok(profile_result(
+            FeedbackDiagnosticsProfile::GlobalSummary,
+            "summary",
+            json!({
+                "conversation_count": conversation_count,
+                "message_count": message_count,
+                "provider_count": provider_count,
+                "agent_count": agent_count,
+                "active_mcp_count": active_mcp_count,
+                "conversation_status_counts": self.collect_global_conversation_status_counts(&request.user_id).await?,
+                "recent_conversations": self.collect_global_recent_conversations(&request.user_id).await?,
+                "recent_errors": self.collect_global_recent_errors(&request.user_id).await?,
+                "agent_health": self.collect_global_agent_health().await?,
+                "provider_health": self.collect_global_provider_health().await?,
+            }),
+        ))
+    }
+
+    async fn collect_global_conversation_status_counts(&self, user_id: &str) -> Result<Value, DbError> {
+        let rows = sqlx::query(
+            "SELECT c.type, c.status, COUNT(*) AS count, MAX(c.updated_at) AS last_updated_at \
+             FROM conversations c \
+             LEFT JOIN conversation_assistant_snapshots cas ON cas.conversation_id = c.id \
+             LEFT JOIN assistant_definitions ad ON ad.id = cas.assistant_definition_id \
+             LEFT JOIN teams t ON t.id = CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.teamId'), json_extract(c.extra, '$.team_id')) END \
+                AND t.user_id = c.user_id \
+             WHERE c.user_id = ? \
+               AND (CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.teamId'), json_extract(c.extra, '$.team_id')) END IS NULL OR t.id IS NOT NULL) \
+               AND (cas.conversation_id IS NULL OR (ad.id IS NOT NULL AND ad.deleted_at IS NULL)) \
+             GROUP BY c.type, c.status \
+             ORDER BY last_updated_at DESC",
+        )
+        .bind(user_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok(json!({
+                    "type": row.try_get::<String, _>("type")?,
+                    "status": row.try_get::<Option<String>, _>("status")?,
+                    "count": row.try_get::<i64, _>("count")?,
+                    "last_updated_at": row.try_get::<Option<i64>, _>("last_updated_at")?,
+                }))
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()
+            .map(Value::Array)
+            .map_err(DbError::from)
+    }
+
+    async fn collect_global_recent_conversations(&self, user_id: &str) -> Result<Value, DbError> {
+        struct RecentTeamGroup {
+            team_id: String,
+            name: Option<String>,
+            name_length: Option<usize>,
+            workspace_mode: Option<String>,
+            session_mode: Option<String>,
+            lead_agent_id: Option<String>,
+            agent_count: usize,
+            agents_version: Option<String>,
+            created_at: Option<i64>,
+            updated_at: Option<i64>,
+            latest_updated_at: i64,
+            message_count: i64,
+            error_message_count: i64,
+            conversations: Vec<Value>,
+        }
+
+        let rows = sqlx::query(
+            "SELECT \
+                c.id, c.name AS title, c.type, c.status, c.source, c.pinned, c.created_at, c.updated_at, \
+                length(c.extra) AS extra_bytes, \
+                CASE WHEN json_valid(c.model) OR json_valid(c.extra) THEN COALESCE( \
+                    CASE WHEN json_valid(c.model) THEN json_extract(c.model, '$.providerId') END, \
+                    CASE WHEN json_valid(c.model) THEN json_extract(c.model, '$.provider_id') END, \
+                    CASE WHEN json_valid(c.extra) THEN json_extract(c.extra, '$.providerId') END, \
+                    CASE WHEN json_valid(c.extra) THEN json_extract(c.extra, '$.provider_id') END \
+                ) END AS model_provider_id, \
+                CASE WHEN json_valid(c.model) OR json_valid(c.extra) THEN COALESCE( \
+                    CASE WHEN json_valid(c.model) THEN json_extract(c.model, '$.modelId') END, \
+                    CASE WHEN json_valid(c.model) THEN json_extract(c.model, '$.model_id') END, \
+                    CASE WHEN json_valid(c.extra) THEN json_extract(c.extra, '$.currentModelId') END, \
+                    CASE WHEN json_valid(c.extra) THEN json_extract(c.extra, '$.current_model_id') END \
+                ) END AS model_id, \
+                CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.agentId'), json_extract(c.extra, '$.agent_id')) END AS extra_agent_id, \
+                CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.teamId'), json_extract(c.extra, '$.team_id')) END AS extra_team_id, \
+                CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.assistantId'), json_extract(c.extra, '$.assistant_id')) END AS extra_assistant_id, \
+                CASE WHEN json_valid(c.extra) THEN json_extract(c.extra, '$.role') END AS role, \
+                CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.slotId'), json_extract(c.extra, '$.slot_id')) END AS slot_id, \
+                CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.sessionMode'), json_extract(c.extra, '$.session_mode')) END AS session_mode, \
+                cas.assistant_definition_id, cas.assistant_id AS snapshot_assistant_id, cas.assistant_source, \
+                cas.agent_id AS snapshot_agent_id, cas.default_model_mode, cas.resolved_model_id, \
+                cas.default_permission_mode, cas.resolved_permission_value, \
+                cas.default_thought_level_mode, cas.resolved_thought_level_value, \
+                s.agent_source AS session_agent_source, s.agent_id AS session_agent_id, s.session_status, \
+                CASE WHEN json_valid(s.session_config) OR json_valid(c.extra) THEN COALESCE( \
+                    CASE WHEN json_valid(s.session_config) THEN json_extract(s.session_config, '$.runtime.current_mode_id') END, \
+                    CASE WHEN json_valid(c.extra) THEN json_extract(c.extra, '$.currentModeId') END, \
+                    CASE WHEN json_valid(c.extra) THEN json_extract(c.extra, '$.current_mode_id') END \
+                ) END AS current_mode_id, \
+                CASE WHEN json_valid(s.session_config) OR json_valid(c.extra) THEN COALESCE( \
+                    CASE WHEN json_valid(s.session_config) THEN json_extract(s.session_config, '$.runtime.current_model_id') END, \
+                    CASE WHEN json_valid(c.extra) THEN json_extract(c.extra, '$.currentModelId') END, \
+                    CASE WHEN json_valid(c.extra) THEN json_extract(c.extra, '$.current_model_id') END \
+                ) END AS current_model_id, \
+                (SELECT COUNT(*) FROM messages m WHERE m.conversation_id = c.id) AS message_count, \
+                (SELECT COUNT(*) FROM messages m WHERE m.conversation_id = c.id AND (m.status = 'error' OR m.type = 'tips' OR (json_valid(m.content) AND json_extract(m.content, '$.error.code') IS NOT NULL))) AS error_message_count, \
+                (SELECT CASE WHEN json_valid(m.content) THEN COALESCE(json_extract(m.content, '$.error.code'), json_extract(m.content, '$.code')) END \
+                   FROM messages m \
+                  WHERE m.conversation_id = c.id \
+                    AND (m.status = 'error' OR m.type = 'tips' OR (json_valid(m.content) AND json_extract(m.content, '$.error.code') IS NOT NULL)) \
+                  ORDER BY m.created_at DESC, m.id DESC \
+                  LIMIT 1) AS latest_error_code, \
+                t.id AS team_row_id, t.name AS team_name, t.workspace_mode AS team_workspace_mode, \
+                t.session_mode AS team_session_mode, t.agents AS team_agents, \
+                t.lead_agent_id AS team_lead_agent_id, t.agents_version AS team_agents_version, \
+                t.created_at AS team_created_at, t.updated_at AS team_updated_at \
+             FROM conversations c \
+             LEFT JOIN conversation_assistant_snapshots cas ON cas.conversation_id = c.id \
+             LEFT JOIN assistant_definitions ad ON ad.id = cas.assistant_definition_id \
+             LEFT JOIN acp_session s ON s.conversation_id = c.id \
+             LEFT JOIN teams t ON t.id = CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.teamId'), json_extract(c.extra, '$.team_id')) END \
+                AND t.user_id = c.user_id \
+             WHERE c.user_id = ? \
+               AND (CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.teamId'), json_extract(c.extra, '$.team_id')) END IS NULL OR t.id IS NOT NULL) \
+               AND (cas.conversation_id IS NULL OR (ad.id IS NOT NULL AND ad.deleted_at IS NULL)) \
+             ORDER BY c.updated_at DESC, c.id DESC \
+             LIMIT ?",
+        )
+        .bind(user_id)
+        .bind(GLOBAL_RECENT_CONVERSATION_SCAN_LIMIT)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut direct_items = Vec::new();
+        let mut team_groups = Vec::<RecentTeamGroup>::new();
+        for row in rows {
+            let id = row.try_get::<String, _>("id")?;
+            let team_id = row.try_get::<Option<String>, _>("extra_team_id")?;
+            let conversation_message_count = row.try_get::<i64, _>("message_count")?;
+            let conversation_error_message_count = row.try_get::<i64, _>("error_message_count")?;
+            let conversation_updated_at = row.try_get::<i64, _>("updated_at")?;
+            let messages = self.collect_global_conversation_message_samples(&id).await?;
+            let item = json!({
+                "id": id.clone(),
+                "conversation_id": id,
+                "title": row.try_get::<String, _>("title")?,
+                "type": row.try_get::<String, _>("type")?,
+                "status": row.try_get::<Option<String>, _>("status")?,
+                "source": row.try_get::<Option<String>, _>("source")?,
+                "pinned": row.try_get::<bool, _>("pinned")?,
+                "extra_bytes": row.try_get::<Option<i64>, _>("extra_bytes")?,
+                "provider_id": row.try_get::<Option<String>, _>("model_provider_id")?,
+                "model_provider_id": row.try_get::<Option<String>, _>("model_provider_id")?,
+                "model_id": row.try_get::<Option<String>, _>("model_id")?,
+                "assistant_definition_id": row.try_get::<Option<String>, _>("assistant_definition_id")?,
+                "assistant_id": row.try_get::<Option<String>, _>("snapshot_assistant_id")?
+                    .or(row.try_get::<Option<String>, _>("extra_assistant_id")?),
+                "assistant_source": row.try_get::<Option<String>, _>("assistant_source")?,
+                "agent_id": row.try_get::<Option<String>, _>("snapshot_agent_id")?
+                    .or(row.try_get::<Option<String>, _>("session_agent_id")?)
+                    .or(row.try_get::<Option<String>, _>("extra_agent_id")?),
+                "extra_agent_id": row.try_get::<Option<String>, _>("extra_agent_id")?,
+                "team_id": team_id.clone(),
+                "extra_team_id": team_id.clone(),
+                "role": row.try_get::<Option<String>, _>("role")?,
+                "slot_id": row.try_get::<Option<String>, _>("slot_id")?,
+                "session_mode": row.try_get::<Option<String>, _>("session_mode")?,
+                "session_agent_source": row.try_get::<Option<String>, _>("session_agent_source")?,
+                "session_status": row.try_get::<Option<String>, _>("session_status")?,
+                "current_mode_id": row.try_get::<Option<String>, _>("current_mode_id")?,
+                "current_model_id": row.try_get::<Option<String>, _>("current_model_id")?,
+                "default_model_mode": row.try_get::<Option<String>, _>("default_model_mode")?,
+                "resolved_model_id": row.try_get::<Option<String>, _>("resolved_model_id")?,
+                "default_permission_mode": row.try_get::<Option<String>, _>("default_permission_mode")?,
+                "resolved_permission_value": row.try_get::<Option<String>, _>("resolved_permission_value")?,
+                "default_thought_level_mode": row.try_get::<Option<String>, _>("default_thought_level_mode")?,
+                "resolved_thought_level_value": row.try_get::<Option<String>, _>("resolved_thought_level_value")?,
+                "message_count": conversation_message_count,
+                "error_message_count": conversation_error_message_count,
+                "latest_error_code": row.try_get::<Option<String>, _>("latest_error_code")?,
+                "created_at": row.try_get::<i64, _>("created_at")?,
+                "updated_at": conversation_updated_at,
+                "recent_errors": messages.get("recent_errors").cloned().unwrap_or_else(|| json!([])),
+                "recent_messages": messages.get("recent_messages").cloned().unwrap_or_else(|| json!([])),
+            });
+
+            if let Some(team_id) = team_id {
+                let group_index = team_groups.iter().position(|group| group.team_id == team_id);
+                let Some(group_index) = group_index.or_else(|| {
+                    if team_groups.len() >= GLOBAL_RECENT_CONVERSATION_LIMIT as usize {
+                        return None;
+                    }
+
+                    let team_name = row.try_get::<Option<String>, _>("team_name").ok().flatten();
+                    let team_agents = row.try_get::<Option<String>, _>("team_agents").ok().flatten();
+                    team_groups.push(RecentTeamGroup {
+                        team_id: team_id.clone(),
+                        name_length: team_name.as_ref().map(|name| name.chars().count()),
+                        name: team_name,
+                        workspace_mode: row.try_get::<Option<String>, _>("team_workspace_mode").ok().flatten(),
+                        session_mode: row.try_get::<Option<String>, _>("team_session_mode").ok().flatten(),
+                        lead_agent_id: row.try_get::<Option<String>, _>("team_lead_agent_id").ok().flatten(),
+                        agent_count: json_array_count(team_agents.as_deref()),
+                        agents_version: row.try_get::<Option<String>, _>("team_agents_version").ok().flatten(),
+                        created_at: row.try_get::<Option<i64>, _>("team_created_at").ok().flatten(),
+                        updated_at: row.try_get::<Option<i64>, _>("team_updated_at").ok().flatten(),
+                        latest_updated_at: conversation_updated_at,
+                        message_count: 0,
+                        error_message_count: 0,
+                        conversations: Vec::new(),
+                    });
+                    Some(team_groups.len() - 1)
+                }) else {
+                    continue;
+                };
+
+                let group = &mut team_groups[group_index];
+                group.latest_updated_at = group.latest_updated_at.max(conversation_updated_at);
+                if group.conversations.len() < GLOBAL_RECENT_CONVERSATION_LIMIT as usize {
+                    group.message_count += conversation_message_count;
+                    group.error_message_count += conversation_error_message_count;
+                    group.conversations.push(item);
+                }
+            } else if direct_items.len() < GLOBAL_RECENT_CONVERSATION_LIMIT as usize {
+                direct_items.push(item);
+            }
+        }
+
+        let team_items = team_groups
+            .into_iter()
+            .map(|group| {
+                let team_id = group.team_id;
+                json!({
+                    "id": team_id.clone(),
+                    "team_id": team_id,
+                    "name": group.name,
+                    "name_length": group.name_length,
+                    "workspace_mode": group.workspace_mode,
+                    "session_mode": group.session_mode,
+                    "lead_agent_id": group.lead_agent_id,
+                    "agent_count": group.agent_count,
+                    "agents_version": group.agents_version,
+                    "created_at": group.created_at,
+                    "updated_at": group.updated_at,
+                    "latest_updated_at": group.latest_updated_at,
+                    "conversation_count": group.conversations.len(),
+                    "message_count": group.message_count,
+                    "error_message_count": group.error_message_count,
+                    "conversations": {
+                        "limit": GLOBAL_RECENT_CONVERSATION_LIMIT,
+                        "items": group.conversations,
+                    },
+                })
+            })
+            .collect::<Vec<_>>();
+
+        Ok(json!({
+            "direct": {
+                "limit": GLOBAL_RECENT_CONVERSATION_LIMIT,
+                "items": direct_items,
+            },
+            "team": {
+                "limit": GLOBAL_RECENT_CONVERSATION_LIMIT,
+                "items": team_items,
+            },
+        }))
+    }
+
+    async fn collect_global_conversation_message_samples(&self, conversation_id: &str) -> Result<Value, DbError> {
+        let error_rows = sqlx::query(
+            "SELECT \
+                id, msg_id, type, status, position, hidden, created_at, length(content) AS content_bytes, content, \
+                CASE WHEN json_valid(content) THEN COALESCE(json_extract(content, '$.error.code'), json_extract(content, '$.code')) END AS code, \
+                CASE WHEN json_valid(content) THEN COALESCE(json_extract(content, '$.error.ownership'), json_extract(content, '$.ownership')) END AS ownership, \
+                CASE WHEN json_valid(content) THEN COALESCE(json_extract(content, '$.error.retryable'), json_extract(content, '$.retryable')) END AS retryable, \
+                CASE WHEN json_valid(content) THEN json_extract(content, '$.resolution.kind') END AS resolution_kind, \
+                CASE WHEN json_valid(content) THEN json_extract(content, '$.resolution.targetId') END AS resolution_target_id, \
+                CASE WHEN json_valid(content) THEN json_extract(content, '$.feedbackRecommended') END AS feedback_recommended \
+             FROM messages \
+             WHERE conversation_id = ? \
+               AND (status = 'error' OR type = 'tips' OR (json_valid(content) AND json_extract(content, '$.error.code') IS NOT NULL)) \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT ?",
+        )
+        .bind(conversation_id)
+        .bind(GLOBAL_CONVERSATION_ERROR_LIMIT)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let recent_errors = error_rows
+            .into_iter()
+            .map(|row| {
+                let content = row.try_get::<String, _>("content")?;
+                Ok(json!({
+                    "id": row.try_get::<String, _>("id")?,
+                    "msg_id": row.try_get::<Option<String>, _>("msg_id")?,
+                    "type": row.try_get::<String, _>("type")?,
+                    "status": row.try_get::<Option<String>, _>("status")?,
+                    "position": row.try_get::<Option<String>, _>("position")?,
+                    "hidden": row.try_get::<bool, _>("hidden")?,
+                    "created_at": row.try_get::<i64, _>("created_at")?,
+                    "content_bytes": row.try_get::<Option<i64>, _>("content_bytes")?,
+                    "content": json_value_or_string(&content),
+                    "code": row.try_get::<Option<String>, _>("code")?,
+                    "ownership": row.try_get::<Option<String>, _>("ownership")?,
+                    "retryable": sqlite_bool_value(row.try_get::<Option<i64>, _>("retryable")?),
+                    "resolution_kind": row.try_get::<Option<String>, _>("resolution_kind")?,
+                    "resolution_target_id": row.try_get::<Option<String>, _>("resolution_target_id")?,
+                    "feedback_recommended": sqlite_bool_value(row.try_get::<Option<i64>, _>("feedback_recommended")?),
+                }))
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()?;
+
+        let message_rows = sqlx::query(
+            "SELECT \
+                id, msg_id, type, status, position, hidden, created_at, length(content) AS content_bytes, content, \
+                CASE WHEN json_valid(content) THEN length(json_extract(content, '$.text')) END AS text_length, \
+                CASE WHEN json_valid(content) THEN json_array_length(content, '$.attachments') END AS attachment_count, \
+                CASE WHEN json_valid(content) THEN json_array_length(content, '$.images') END AS image_count, \
+                CASE WHEN json_valid(content) THEN json_array_length(content, '$.toolCalls') END AS tool_call_count \
+             FROM messages \
+             WHERE conversation_id = ? \
+               AND NOT (status = 'error' OR type = 'tips' OR (json_valid(content) AND json_extract(content, '$.error.code') IS NOT NULL)) \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT ?",
+        )
+        .bind(conversation_id)
+        .bind(GLOBAL_CONVERSATION_MESSAGE_LIMIT)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let recent_messages = message_rows
+            .into_iter()
+            .map(|row| {
+                let content = row.try_get::<String, _>("content")?;
+                Ok(json!({
+                    "id": row.try_get::<String, _>("id")?,
+                    "msg_id": row.try_get::<Option<String>, _>("msg_id")?,
+                    "type": row.try_get::<String, _>("type")?,
+                    "status": row.try_get::<Option<String>, _>("status")?,
+                    "position": row.try_get::<Option<String>, _>("position")?,
+                    "hidden": row.try_get::<bool, _>("hidden")?,
+                    "created_at": row.try_get::<i64, _>("created_at")?,
+                    "content_bytes": row.try_get::<Option<i64>, _>("content_bytes")?,
+                    "text_length": row.try_get::<Option<i64>, _>("text_length")?,
+                    "attachment_count": row.try_get::<Option<i64>, _>("attachment_count")?.unwrap_or_default(),
+                    "image_count": row.try_get::<Option<i64>, _>("image_count")?.unwrap_or_default(),
+                    "tool_call_count": row.try_get::<Option<i64>, _>("tool_call_count")?.unwrap_or_default(),
+                    "content": sanitized_message_content(&content),
+                }))
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()?;
+
+        Ok(json!({
+            "recent_errors": recent_errors,
+            "recent_messages": recent_messages,
+        }))
+    }
+
+    async fn collect_global_recent_errors(&self, user_id: &str) -> Result<Value, DbError> {
+        let rows = sqlx::query(
+            "SELECT \
+                c.id AS conversation_id, c.name AS conversation_title, c.type AS conversation_type, \
+                c.status AS conversation_status, c.updated_at AS conversation_updated_at, \
+                m.id, m.msg_id, m.type, m.status, m.position, m.created_at, length(m.content) AS content_bytes, m.content, \
+                CASE WHEN json_valid(m.content) THEN COALESCE(json_extract(m.content, '$.error.code'), json_extract(m.content, '$.code')) END AS code, \
+                CASE WHEN json_valid(m.content) THEN COALESCE(json_extract(m.content, '$.error.ownership'), json_extract(m.content, '$.ownership')) END AS ownership, \
+                CASE WHEN json_valid(m.content) THEN COALESCE(json_extract(m.content, '$.error.retryable'), json_extract(m.content, '$.retryable')) END AS retryable, \
+                CASE WHEN json_valid(m.content) THEN json_extract(m.content, '$.resolution.kind') END AS resolution_kind, \
+                CASE WHEN json_valid(m.content) THEN json_extract(m.content, '$.resolution.targetId') END AS resolution_target_id, \
+                CASE WHEN json_valid(m.content) THEN json_extract(m.content, '$.feedbackRecommended') END AS feedback_recommended \
+             FROM messages m \
+             JOIN conversations c ON c.id = m.conversation_id \
+             LEFT JOIN conversation_assistant_snapshots cas ON cas.conversation_id = c.id \
+             LEFT JOIN assistant_definitions ad ON ad.id = cas.assistant_definition_id \
+             LEFT JOIN teams t ON t.id = CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.teamId'), json_extract(c.extra, '$.team_id')) END \
+                AND t.user_id = c.user_id \
+             WHERE c.user_id = ? \
+               AND (CASE WHEN json_valid(c.extra) THEN COALESCE(json_extract(c.extra, '$.teamId'), json_extract(c.extra, '$.team_id')) END IS NULL OR t.id IS NOT NULL) \
+               AND (cas.conversation_id IS NULL OR (ad.id IS NOT NULL AND ad.deleted_at IS NULL)) \
+               AND (m.status = 'error' OR m.type = 'tips' OR (json_valid(m.content) AND json_extract(m.content, '$.error.code') IS NOT NULL)) \
+             ORDER BY m.created_at DESC, m.id DESC \
+             LIMIT ?",
+        )
+        .bind(user_id)
+        .bind(GLOBAL_RECENT_ERROR_LIMIT)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let items = rows
+            .into_iter()
+            .map(|row| {
+                Ok(json!({
+                    "conversation_id": row.try_get::<String, _>("conversation_id")?,
+                    "conversation_title": row.try_get::<String, _>("conversation_title")?,
+                    "conversation_type": row.try_get::<String, _>("conversation_type")?,
+                    "conversation_status": row.try_get::<Option<String>, _>("conversation_status")?,
+                    "conversation_updated_at": row.try_get::<i64, _>("conversation_updated_at")?,
+                    "id": row.try_get::<String, _>("id")?,
+                    "msg_id": row.try_get::<Option<String>, _>("msg_id")?,
+                    "type": row.try_get::<String, _>("type")?,
+                    "status": row.try_get::<Option<String>, _>("status")?,
+                    "position": row.try_get::<Option<String>, _>("position")?,
+                    "created_at": row.try_get::<i64, _>("created_at")?,
+                    "content_bytes": row.try_get::<Option<i64>, _>("content_bytes")?,
+                    "content": json_value_or_string(&row.try_get::<String, _>("content")?),
+                    "code": row.try_get::<Option<String>, _>("code")?,
+                    "ownership": row.try_get::<Option<String>, _>("ownership")?,
+                    "retryable": sqlite_bool_value(row.try_get::<Option<i64>, _>("retryable")?),
+                    "resolution_kind": row.try_get::<Option<String>, _>("resolution_kind")?,
+                    "resolution_target_id": row.try_get::<Option<String>, _>("resolution_target_id")?,
+                    "feedback_recommended": sqlite_bool_value(row.try_get::<Option<i64>, _>("feedback_recommended")?),
+                }))
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()?;
+
+        Ok(json!({
+            "limit": GLOBAL_RECENT_ERROR_LIMIT,
+            "items": items,
+        }))
+    }
+
+    async fn collect_global_agent_health(&self) -> Result<Value, DbError> {
+        let rows = sqlx::query(
+            "SELECT \
+                id, name, backend, agent_type, agent_source, enabled, sort_order, \
+                length(command) AS command_bytes, length(args) AS args_bytes, length(env) AS env_bytes, \
+                last_check_status, last_check_kind, last_check_error_code, last_check_latency_ms, \
+                last_check_at, last_success_at, last_failure_at, updated_at \
+             FROM agent_metadata \
+             ORDER BY updated_at DESC, id DESC \
+             LIMIT ?",
+        )
+        .bind(GLOBAL_HEALTH_LIMIT)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let items = rows
+            .into_iter()
+            .map(|row| {
+                Ok(json!({
+                    "id": row.try_get::<String, _>("id")?,
+                    "name": row.try_get::<String, _>("name")?,
+                    "backend": row.try_get::<Option<String>, _>("backend")?,
+                    "agent_type": row.try_get::<String, _>("agent_type")?,
+                    "agent_source": row.try_get::<String, _>("agent_source")?,
+                    "enabled": row.try_get::<bool, _>("enabled")?,
+                    "sort_order": row.try_get::<i64, _>("sort_order")?,
+                    "command_bytes": row.try_get::<Option<i64>, _>("command_bytes")?,
+                    "args_bytes": row.try_get::<Option<i64>, _>("args_bytes")?,
+                    "env_bytes": row.try_get::<Option<i64>, _>("env_bytes")?,
+                    "last_check_status": row.try_get::<Option<String>, _>("last_check_status")?,
+                    "last_check_kind": row.try_get::<Option<String>, _>("last_check_kind")?,
+                    "last_check_error_code": row.try_get::<Option<String>, _>("last_check_error_code")?,
+                    "last_check_latency_ms": row.try_get::<Option<i64>, _>("last_check_latency_ms")?,
+                    "last_check_at": row.try_get::<Option<i64>, _>("last_check_at")?,
+                    "last_success_at": row.try_get::<Option<i64>, _>("last_success_at")?,
+                    "last_failure_at": row.try_get::<Option<i64>, _>("last_failure_at")?,
+                    "updated_at": row.try_get::<i64, _>("updated_at")?,
+                }))
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()?;
+
+        Ok(json!({
+            "limit": GLOBAL_HEALTH_LIMIT,
+            "items": items,
+        }))
+    }
+
+    async fn collect_global_provider_health(&self) -> Result<Value, DbError> {
+        let rows = sqlx::query(
+            "SELECT id, platform, name, base_url, api_key_encrypted, models, enabled, capabilities, \
+                    context_limit, model_enabled, model_health, is_full_url, created_at, updated_at \
+             FROM providers \
+             ORDER BY updated_at DESC, id DESC \
+             LIMIT ?",
+        )
+        .bind(GLOBAL_HEALTH_LIMIT)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let items = rows
+            .into_iter()
+            .map(|row| {
+                let models = row.try_get::<String, _>("models")?;
+                let model_enabled = row.try_get::<Option<String>, _>("model_enabled")?;
+                let model_health = row.try_get::<Option<String>, _>("model_health")?;
+                let api_key_encrypted = row.try_get::<String, _>("api_key_encrypted")?;
+                Ok(json!({
+                    "id": row.try_get::<String, _>("id")?,
+                    "platform": row.try_get::<String, _>("platform")?,
+                    "name": row.try_get::<String, _>("name")?,
+                    "base_url_host": base_url_host(&row.try_get::<String, _>("base_url")?),
+                    "api_key_configured": !api_key_encrypted.trim().is_empty(),
+                    "enabled": row.try_get::<bool, _>("enabled")?,
+                    "model_count": json_array_count(Some(&models)),
+                    "disabled_model_count": disabled_model_count(model_enabled.as_deref()),
+                    "unhealthy_model_count": unhealthy_model_count(model_health.as_deref()),
+                    "capability_count": json_array_count(Some(&row.try_get::<String, _>("capabilities")?)),
+                    "context_limit": row.try_get::<Option<i64>, _>("context_limit")?,
+                    "is_full_url": row.try_get::<bool, _>("is_full_url")?,
+                    "created_at": row.try_get::<i64, _>("created_at")?,
+                    "updated_at": row.try_get::<i64, _>("updated_at")?,
+                }))
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()?;
+
+        Ok(json!({
+            "limit": GLOBAL_HEALTH_LIMIT,
+            "items": items,
+        }))
+    }
+}
+
+#[async_trait::async_trait]
+impl IFeedbackDiagnosticsRepository for SqliteFeedbackDiagnosticsRepository {
+    async fn collect_feedback_diagnostics(
+        &self,
+        request: &FeedbackDiagnosticsRequest,
+    ) -> Result<FeedbackDiagnosticsResult, DbError> {
+        let mut profiles = Vec::new();
+        let mut seen = BTreeSet::new();
+
+        for profile in &request.profiles {
+            if !seen.insert(profile.clone()) {
+                continue;
+            }
+            let result = match profile {
+                FeedbackDiagnosticsProfile::ConversationSession => self.collect_conversation_session(request).await?,
+                FeedbackDiagnosticsProfile::ModelAuth => self.collect_model_auth(request).await?,
+                FeedbackDiagnosticsProfile::AgentTeam => self.collect_agent_team(request).await?,
+                FeedbackDiagnosticsProfile::McpTools => self.collect_mcp_tools(request).await?,
+                FeedbackDiagnosticsProfile::GlobalSummary => self.collect_global_summary(request).await?,
+            };
+            profiles.push(result);
+        }
+
+        Ok(FeedbackDiagnosticsResult {
+            schema_version: "feedback-diagnostics/v1".to_owned(),
+            profiles,
+        })
+    }
+}
+
+fn profile_result(profile: FeedbackDiagnosticsProfile, mode: &str, data: Value) -> FeedbackDiagnosticsProfileResult {
+    FeedbackDiagnosticsProfileResult {
+        name: profile.as_name().to_owned(),
+        mode: mode.to_owned(),
+        data,
+        warnings: Vec::new(),
+    }
+}
+
+fn bump_count(map: &mut Map<String, Value>, key: &str, count: i64) {
+    let current = map.get(key).and_then(Value::as_i64).unwrap_or_default();
+    map.insert(key.to_owned(), Value::from(current + count));
+}
+
+fn sqlite_bool_value(value: Option<i64>) -> Value {
+    value.map_or(Value::Null, |v| Value::Bool(v != 0))
+}
+
+fn json_value_or_string(raw: &str) -> Value {
+    serde_json::from_str::<Value>(raw).unwrap_or_else(|_| Value::String(raw.to_owned()))
+}
+
+fn sanitized_message_content(raw: &str) -> Value {
+    sanitize_message_value(&json_value_or_string(raw), None)
+}
+
+fn sanitize_message_value(value: &Value, key: Option<&str>) -> Value {
+    if key.is_some_and(|key| is_sensitive_key(key) || is_message_content_key(key)) {
+        return redacted_value_summary(value);
+    }
+
+    match value {
+        Value::Object(object) => Value::Object(
+            object
+                .iter()
+                .map(|(key, value)| (key.clone(), sanitize_message_value(value, Some(key))))
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(items.iter().map(|item| sanitize_message_value(item, key)).collect()),
+        Value::String(_) => redacted_value_summary(value),
+        _ => value.clone(),
+    }
+}
+
+fn redacted_value_summary(value: &Value) -> Value {
+    match value {
+        Value::String(text) => json!({
+            "redacted": true,
+            "chars": text.chars().count(),
+        }),
+        Value::Array(items) => json!({
+            "redacted": true,
+            "items": items.len(),
+        }),
+        Value::Object(object) => json!({
+            "redacted": true,
+            "keys": object.len(),
+        }),
+        _ => json!({ "redacted": true }),
+    }
+}
+
+fn is_message_content_key(key: &str) -> bool {
+    matches!(
+        key.to_ascii_lowercase().as_str(),
+        "text" | "content" | "message" | "prompt" | "input" | "output" | "raw"
+    )
+}
+
+fn json_array_count(raw: Option<&str>) -> usize {
+    raw.and_then(|value| serde_json::from_str::<Value>(value).ok())
+        .and_then(|value| value.as_array().map(Vec::len))
+        .unwrap_or_default()
+}
+
+struct RuntimeConfigSelectionSummary {
+    keys: Vec<String>,
+    values: Map<String, Value>,
+    mode_selection: Option<String>,
+    model_selection: Option<String>,
+}
+
+fn runtime_config_selection_summary(raw: &str) -> RuntimeConfigSelectionSummary {
+    let Ok(value) = serde_json::from_str::<Value>(raw) else {
+        return RuntimeConfigSelectionSummary {
+            keys: Vec::new(),
+            values: Map::new(),
+            mode_selection: None,
+            model_selection: None,
+        };
+    };
+    let Some(selections) = value
+        .get("runtime")
+        .and_then(|runtime| runtime.get("config_selections"))
+        .and_then(Value::as_object)
+    else {
+        return RuntimeConfigSelectionSummary {
+            keys: Vec::new(),
+            values: Map::new(),
+            mode_selection: None,
+            model_selection: None,
+        };
+    };
+
+    let mut keys = Vec::new();
+    let mut values = Map::new();
+    let mut mode_selection = None;
+    let mut model_selection = None;
+
+    for (key, value) in selections {
+        if is_sensitive_key(key) {
+            continue;
+        }
+        keys.push(key.clone());
+        values.insert(key.clone(), safe_config_value(value));
+        if key == "mode" {
+            mode_selection = value.as_str().map(ToOwned::to_owned);
+        } else if key == "model" {
+            model_selection = value.as_str().map(ToOwned::to_owned);
+        }
+    }
+
+    keys.sort();
+    RuntimeConfigSelectionSummary {
+        keys,
+        values,
+        mode_selection,
+        model_selection,
+    }
+}
+
+fn safe_config_value(value: &Value) -> Value {
+    match value {
+        Value::Object(object) => {
+            let sanitized = object
+                .iter()
+                .filter(|(key, _)| !is_sensitive_key(key))
+                .map(|(key, value)| (key.clone(), safe_config_value(value)))
+                .collect();
+            Value::Object(sanitized)
+        }
+        Value::Array(items) => Value::Array(items.iter().map(safe_config_value).collect()),
+        _ => value.clone(),
+    }
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    let normalized = key.replace(['_', '-'], "");
+    normalized.contains("apikey")
+        || normalized.contains("accesskey")
+        || key.contains("token")
+        || key.contains("secret")
+        || key.contains("password")
+        || key.contains("prompt")
+}
+
+fn base_url_host(url: &str) -> String {
+    let without_scheme = url.split_once("://").map_or(url, |(_, rest)| rest);
+    let without_userinfo = without_scheme.rsplit_once('@').map_or(without_scheme, |(_, rest)| rest);
+    let authority = without_userinfo
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or_default()
+        .trim();
+
+    if authority.starts_with('[') {
+        return authority
+            .split(']')
+            .next()
+            .map(|host| format!("{host}]"))
+            .unwrap_or_default();
+    }
+
+    authority.split(':').next().unwrap_or_default().to_owned()
+}
+
+fn disabled_model_count(raw: Option<&str>) -> usize {
+    raw.and_then(|value| serde_json::from_str::<Value>(value).ok())
+        .and_then(|value| value.as_object().cloned())
+        .map(|object| object.values().filter(|value| value.as_bool() == Some(false)).count())
+        .unwrap_or_default()
+}
+
+fn unhealthy_model_count(raw: Option<&str>) -> usize {
+    raw.and_then(|value| serde_json::from_str::<Value>(value).ok())
+        .and_then(|value| value.as_object().cloned())
+        .map(|object| {
+            object
+                .values()
+                .filter(|value| {
+                    if let Some(ok) = value.get("ok").and_then(Value::as_bool) {
+                        return !ok;
+                    }
+                    value
+                        .get("status")
+                        .and_then(Value::as_str)
+                        .is_some_and(|status| !matches!(status, "ok" | "healthy" | "available"))
+                })
+                .count()
+        })
+        .unwrap_or_default()
+}
+
+fn rows_to_group_counts(rows: Vec<sqlx::sqlite::SqliteRow>, key_column: &str) -> Result<Value, sqlx::Error> {
+    let mut result = BTreeMap::new();
+    for row in rows {
+        let key = row.try_get::<String, _>(key_column)?;
+        result.insert(
+            key,
+            json!({
+                "count": row.try_get::<i64, _>("count")?,
+                "last_updated_at": row.try_get::<Option<i64>, _>("last_updated_at")?,
+            }),
+        );
+    }
+    Ok(json!(result))
+}
+
+fn mailbox_rows_to_counts(rows: Vec<sqlx::sqlite::SqliteRow>) -> Result<Value, sqlx::Error> {
+    let mut by_type = BTreeMap::new();
+    let mut unread_count = 0_i64;
+    for row in rows {
+        let count = row.try_get::<i64, _>("count")?;
+        let read = row.try_get::<bool, _>("read")?;
+        if !read {
+            unread_count += count;
+        }
+        by_type.insert(
+            format!(
+                "{}:{}",
+                row.try_get::<String, _>("type")?,
+                if read { "read" } else { "unread" }
+            ),
+            json!({
+                "count": count,
+                "last_created_at": row.try_get::<Option<i64>, _>("last_created_at")?,
+            }),
+        );
+    }
+    Ok(json!({
+        "unread_count": unread_count,
+        "by_type": by_type,
+    }))
+}

--- a/crates/aionui-db/src/repository/sqlite_diagnostics.rs
+++ b/crates/aionui-db/src/repository/sqlite_diagnostics.rs
@@ -8,6 +8,7 @@ use crate::repository::diagnostics::{
     FeedbackDiagnosticsProfile, FeedbackDiagnosticsProfileResult, FeedbackDiagnosticsRequest,
     FeedbackDiagnosticsResult, IFeedbackDiagnosticsRepository,
 };
+use crate::repository::diagnostics_sanitizer::sanitize_mcp_original_json;
 
 const RECENT_CONVERSATION_WINDOW_MS: i64 = 24 * 60 * 60 * 1000;
 const RECENT_CONVERSATION_LIMIT: i64 = 20;
@@ -688,6 +689,7 @@ impl SqliteFeedbackDiagnosticsRepository {
         let servers = rows
             .into_iter()
             .map(|row| {
+                let original_json = row.try_get::<Option<String>, _>("original_json")?;
                 Ok(json!({
                     "id": row.try_get::<String, _>("id")?,
                     "name": row.try_get::<String, _>("name")?,
@@ -696,7 +698,7 @@ impl SqliteFeedbackDiagnosticsRepository {
                     "tool_count": json_array_count(row.try_get::<Option<String>, _>("tools")?.as_deref()),
                     "last_test_status": row.try_get::<String, _>("last_test_status")?,
                     "last_connected": row.try_get::<Option<i64>, _>("last_connected")?,
-                    "original_json": row.try_get::<Option<String>, _>("original_json")?,
+                    "original_json": sanitize_mcp_original_json(original_json.as_deref()),
                     "builtin": row.try_get::<bool, _>("builtin")?,
                     "deleted": row.try_get::<Option<i64>, _>("deleted_at")?.is_some(),
                     "transport_config_bytes": row.try_get::<Option<i64>, _>("transport_config_bytes")?,

--- a/crates/aionui-db/tests/feedback_diagnostics_repository.rs
+++ b/crates/aionui-db/tests/feedback_diagnostics_repository.rs
@@ -539,10 +539,11 @@ async fn insert_feedback_fixture(db: &aionui_db::Database) {
 
 async fn insert_mcp_feedback_fixture(db: &aionui_db::Database) {
     let original_json = json!({
-        "command": "npx",
-        "args": ["raw-config-mcp", "--access-token=raw-token-for-diagnostics"],
+        "command": "npx @sentry/mcp-server@latest --access-token=raw-token-for-diagnostics --organization-slug=iofficeai",
+        "args": ["raw-config-mcp", "--header=Authorization: Bearer raw-bearer-for-diagnostics"],
         "env": {
-            "MCP_API_KEY": "raw-api-key-for-diagnostics"
+            "MCP_API_KEY": "raw-api-key-for-diagnostics",
+            "MCP_MODEL": "diagnostic-model"
         }
     })
     .to_string();
@@ -665,15 +666,16 @@ async fn collects_conversation_auth_signals_without_sensitive_payloads() {
 }
 
 #[tokio::test]
-async fn mcp_tools_profile_includes_original_json_raw() {
+async fn mcp_tools_profile_preserves_original_json_shape_with_redacted_credentials() {
     let db = init_database_memory().await.unwrap();
     insert_mcp_feedback_fixture(&db).await;
     let repo = SqliteFeedbackDiagnosticsRepository::new(db.pool().clone());
-    let expected_original_json = json!({
-        "command": "npx",
-        "args": ["raw-config-mcp", "--access-token=raw-token-for-diagnostics"],
+    let raw_original_json = json!({
+        "command": "npx @sentry/mcp-server@latest --access-token=raw-token-for-diagnostics --organization-slug=iofficeai",
+        "args": ["raw-config-mcp", "--header=Authorization: Bearer raw-bearer-for-diagnostics"],
         "env": {
-            "MCP_API_KEY": "raw-api-key-for-diagnostics"
+            "MCP_API_KEY": "raw-api-key-for-diagnostics",
+            "MCP_MODEL": "diagnostic-model"
         }
     })
     .to_string();
@@ -695,8 +697,34 @@ async fn mcp_tools_profile_includes_original_json_raw() {
     let server = &mcp_tools.data["servers"][0];
 
     assert_eq!(server["name"], "raw-config-mcp");
-    assert_eq!(server["original_json"], expected_original_json);
-    assert_eq!(server["original_json_bytes"], expected_original_json.len());
+    assert_eq!(server["original_json_bytes"], raw_original_json.len());
+
+    let original_json = server["original_json"]
+        .as_str()
+        .expect("sanitized original_json should remain a JSON string");
+    let parsed: serde_json::Value = serde_json::from_str(original_json).unwrap();
+    assert_eq!(
+        parsed["command"],
+        "npx @sentry/mcp-server@latest --access-token=<redacted> --organization-slug=iofficeai"
+    );
+    assert_eq!(
+        parsed["args"],
+        json!(["raw-config-mcp", "--header=Authorization: Bearer <redacted>"])
+    );
+    assert_eq!(parsed["env"]["MCP_API_KEY"], "<redacted>");
+    assert_eq!(parsed["env"]["MCP_MODEL"], "diagnostic-model");
+
+    let serialized = serde_json::to_string(&result).unwrap();
+    for secret in [
+        "raw-token-for-diagnostics",
+        "raw-api-key-for-diagnostics",
+        "raw-bearer-for-diagnostics",
+    ] {
+        assert!(
+            !serialized.contains(secret),
+            "diagnostics response leaked MCP credential payload: {secret}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/aionui-db/tests/feedback_diagnostics_repository.rs
+++ b/crates/aionui-db/tests/feedback_diagnostics_repository.rs
@@ -1,0 +1,885 @@
+use aionui_db::{
+    FeedbackDiagnosticsDbContext, FeedbackDiagnosticsProfile, FeedbackDiagnosticsRequest,
+    IFeedbackDiagnosticsRepository, SqliteFeedbackDiagnosticsRepository, init_database_memory,
+};
+use serde_json::json;
+
+const ANCHOR_CREATED_AT: i64 = 9_000_000_000_000;
+const ANCHOR_UPDATED_AT: i64 = 9_000_000_010_000;
+
+async fn insert_feedback_fixture(db: &aionui_db::Database) {
+    let pool = db.pool();
+    sqlx::query(
+        "INSERT INTO providers \
+            (id, platform, name, base_url, api_key_encrypted, models, enabled, \
+             capabilities, context_limit, model_protocols, model_enabled, model_health, \
+             bedrock_config, is_full_url, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("prov-secret")
+    .bind("openrouter")
+    .bind("OpenRouter")
+    .bind("https://sk-live-secret@example.invalid/v1/chat/completions?api_key=sk-query")
+    .bind("encrypted-sk-live-secret")
+    .bind(r#"["sakana/fugu-ultra","anthropic/claude-sonnet-4"]"#)
+    .bind(true)
+    .bind(r#"[{"type":"text"},{"type":"image"}]"#)
+    .bind(128000_i64)
+    .bind(r#"{"sakana/fugu-ultra":"openai"}"#)
+    .bind(r#"{"sakana/fugu-ultra":true,"anthropic/claude-sonnet-4":false}"#)
+    .bind(r#"{"sakana/fugu-ultra":{"ok":false,"code":"auth_failed"}}"#)
+    .bind(None::<String>)
+    .bind(false)
+    .bind(ANCHOR_CREATED_AT)
+    .bind(ANCHOR_UPDATED_AT)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO teams \
+            (id, user_id, name, workspace, workspace_mode, agents, lead_agent_id, \
+             session_mode, agents_version, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("team-1")
+    .bind("system_default_user")
+    .bind("Diagnostics Team")
+    .bind("/tmp/team-workspace")
+    .bind("shared")
+    .bind(
+        json!([
+            {"slot_id":"slot-lead","agent_id":"opencode","role":"lead"},
+            {"slot_id":"slot-1","agent_id":"opencode","role":"teammate"}
+        ])
+        .to_string(),
+    )
+    .bind("opencode")
+    .bind("build")
+    .bind("1.0.0")
+    .bind(ANCHOR_CREATED_AT)
+    .bind(ANCHOR_UPDATED_AT)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO conversations \
+            (id, user_id, name, type, extra, model, status, source, channel_chat_id, \
+             pinned, pinned_at, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("conv-auth")
+    .bind("system_default_user")
+    .bind("Auth failure title should be visible")
+    .bind("aionrs")
+    .bind(
+        json!({
+            "agentId": "opencode",
+            "assistant_id": "assistant-team",
+            "teamId": "team-1",
+            "role": "teammate",
+            "slot_id": "slot-1",
+            "session_mode": "build",
+            "apiKey": "sk-extra-secret"
+        })
+        .to_string(),
+    )
+    .bind(json!({"providerId":"prov-secret","modelId":"sakana/fugu-ultra"}).to_string())
+    .bind("running")
+    .bind("aionui")
+    .bind(None::<String>)
+    .bind(false)
+    .bind(None::<i64>)
+    .bind(ANCHOR_CREATED_AT)
+    .bind(ANCHOR_UPDATED_AT)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO conversations \
+            (id, user_id, name, type, extra, model, status, source, channel_chat_id, \
+             pinned, pinned_at, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("conv-nearby")
+    .bind("system_default_user")
+    .bind("Nearby conversation shown in screenshot")
+    .bind("aionrs")
+    .bind(json!({"agentId":"opencode"}).to_string())
+    .bind(json!({"providerId":"prov-secret","modelId":"anthropic/claude-sonnet-4"}).to_string())
+    .bind("finished")
+    .bind("aionui")
+    .bind(None::<String>)
+    .bind(false)
+    .bind(None::<i64>)
+    .bind(ANCHOR_CREATED_AT - 2_000)
+    .bind(ANCHOR_UPDATED_AT - 1_000)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO conversations \
+            (id, user_id, name, type, extra, model, status, source, channel_chat_id, \
+             pinned, pinned_at, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("conv-old")
+    .bind("system_default_user")
+    .bind("Old conversation outside feedback window")
+    .bind("aionrs")
+    .bind(json!({}).to_string())
+    .bind(None::<String>)
+    .bind("finished")
+    .bind("aionui")
+    .bind(None::<String>)
+    .bind(false)
+    .bind(None::<i64>)
+    .bind(ANCHOR_CREATED_AT - 90_000_000)
+    .bind(ANCHOR_UPDATED_AT - 90_000_000)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO conversations \
+            (id, user_id, name, type, extra, model, status, source, channel_chat_id, \
+             pinned, pinned_at, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("conv-deleted-team")
+    .bind("system_default_user")
+    .bind("Deleted team conversation should not be returned")
+    .bind("aionrs")
+    .bind(
+        json!({
+            "agentId": "opencode",
+            "teamId": "team-deleted",
+            "role": "lead",
+            "slot_id": "slot-deleted"
+        })
+        .to_string(),
+    )
+    .bind(json!({"providerId":"prov-secret","modelId":"deleted/model"}).to_string())
+    .bind("finished")
+    .bind("aionui")
+    .bind(None::<String>)
+    .bind(false)
+    .bind(None::<i64>)
+    .bind(ANCHOR_CREATED_AT)
+    .bind(ANCHOR_UPDATED_AT + 2_000)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO conversations \
+            (id, user_id, name, type, extra, model, status, source, channel_chat_id, \
+             pinned, pinned_at, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("conv-deleted-assistant")
+    .bind("system_default_user")
+    .bind("Deleted assistant direct conversation should not be returned")
+    .bind("aionrs")
+    .bind(json!({"agentId":"opencode"}).to_string())
+    .bind(json!({"providerId":"prov-secret","modelId":"deleted/assistant-model"}).to_string())
+    .bind("finished")
+    .bind("aionui")
+    .bind(None::<String>)
+    .bind(false)
+    .bind(None::<i64>)
+    .bind(ANCHOR_CREATED_AT)
+    .bind(ANCHOR_UPDATED_AT + 3_000)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO messages \
+            (id, conversation_id, msg_id, type, content, position, status, hidden, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("msg-deleted-assistant-error")
+    .bind("conv-deleted-assistant")
+    .bind("turn-deleted-assistant")
+    .bind("tips")
+    .bind(
+        json!({
+            "error": {
+                "code": "DeletedAssistantConversationError",
+                "message": "deleted assistant conversation error should not be returned"
+            }
+        })
+        .to_string(),
+    )
+    .bind("center")
+    .bind("error")
+    .bind(false)
+    .bind(ANCHOR_UPDATED_AT + 3_000)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO messages \
+            (id, conversation_id, msg_id, type, content, position, status, hidden, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("msg-deleted-team-error")
+    .bind("conv-deleted-team")
+    .bind("turn-deleted")
+    .bind("tips")
+    .bind(
+        json!({
+            "error": {
+                "code": "DeletedTeamConversationError",
+                "message": "deleted team conversation error should not be returned"
+            }
+        })
+        .to_string(),
+    )
+    .bind("center")
+    .bind("error")
+    .bind(false)
+    .bind(ANCHOR_UPDATED_AT + 2_000)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO messages \
+            (id, conversation_id, msg_id, type, content, position, status, hidden, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("msg-user")
+    .bind("conv-auth")
+    .bind("turn-1")
+    .bind("text")
+    .bind(json!({"text":"my prompt contains sk-prompt-secret and private content"}).to_string())
+    .bind("right")
+    .bind("finish")
+    .bind(false)
+    .bind(4100_i64)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO messages \
+            (id, conversation_id, msg_id, type, content, position, status, hidden, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("msg-error")
+    .bind("conv-auth")
+    .bind("turn-1")
+    .bind("tips")
+    .bind(
+        json!({
+            "error": {
+                "code": "UserLlmProviderAuthFailed",
+                "ownership": "UserLlmProvider",
+                "retryable": false,
+                "message": "Missing Authentication header sk-error-secret"
+            },
+            "resolution": {
+                "kind": "provider_settings",
+                "targetId": "prov-secret"
+            },
+            "feedbackRecommended": true
+        })
+        .to_string(),
+    )
+    .bind("center")
+    .bind("error")
+    .bind(false)
+    .bind(4200_i64)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO messages \
+            (id, conversation_id, msg_id, type, content, position, status, hidden, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("msg-nearby-error")
+    .bind("conv-nearby")
+    .bind("turn-nearby")
+    .bind("tips")
+    .bind(
+        json!({
+            "error": {
+                "code": "NearbyProviderTimeout",
+                "message": "Nearby raw provider timeout should not leak"
+            }
+        })
+        .to_string(),
+    )
+    .bind("center")
+    .bind("error")
+    .bind(false)
+    .bind(ANCHOR_UPDATED_AT - 500)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO acp_session \
+            (conversation_id, agent_source, agent_id, session_id, session_status, \
+             session_config, last_active_at, suspended_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("conv-auth")
+    .bind("builtin")
+    .bind("opencode")
+    .bind("sess-1")
+    .bind("idle")
+    .bind(
+        json!({
+            "runtime": {
+                "current_mode_id": "build",
+                "current_model_id": "sakana/fugu-ultra",
+                "config_selections": {
+                    "mode": "plan",
+                    "model": "sakana/fugu-ultra",
+                    "effort": "high",
+                    "apiKey": "sk-session-secret"
+                }
+            }
+        })
+        .to_string(),
+    )
+    .bind(4300_i64)
+    .bind(None::<i64>)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO acp_session \
+            (conversation_id, agent_source, agent_id, session_id, session_status, \
+             session_config, last_active_at, suspended_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("conv-nearby")
+    .bind("builtin")
+    .bind("opencode")
+    .bind("sess-nearby")
+    .bind("idle")
+    .bind(
+        json!({
+            "runtime": {
+                "current_mode_id": "inspect",
+                "current_model_id": "anthropic/claude-sonnet-4",
+                "config_selections": {
+                    "mode": "inspect",
+                    "model": "anthropic/claude-sonnet-4",
+                    "apiKey": "sk-nearby-session-secret"
+                }
+            }
+        })
+        .to_string(),
+    )
+    .bind(ANCHOR_UPDATED_AT - 900)
+    .bind(None::<i64>)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO agent_metadata \
+            (id, name, backend, agent_type, agent_source, enabled, command, args, env, \
+             native_skills_dirs, behavior_policy, available_modes, available_models, sort_order, \
+             last_check_status, last_check_kind, last_check_error_code, last_check_error_message, \
+             created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("opencode")
+    .bind("OpenCode")
+    .bind("opencode")
+    .bind("acp")
+    .bind("builtin")
+    .bind(true)
+    .bind("opencode")
+    .bind(json!(["run", "--token", "sk-agent-args-secret"]).to_string())
+    .bind(json!({"OPENAI_API_KEY":"sk-agent-env-secret"}).to_string())
+    .bind(None::<String>)
+    .bind(None::<String>)
+    .bind(json!([{"id":"build"},{"id":"plan"}]).to_string())
+    .bind(json!([{"id":"sakana/fugu-ultra"},{"id":"anthropic/claude-sonnet-4"}]).to_string())
+    .bind(1_i64)
+    .bind("ok")
+    .bind("session")
+    .bind(None::<String>)
+    .bind(None::<String>)
+    .bind(ANCHOR_CREATED_AT)
+    .bind(ANCHOR_UPDATED_AT)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    for (definition_id, assistant_id, deleted_at) in [
+        ("assistant-def-team", "assistant-team", None),
+        ("assistant-def-direct", "assistant-direct", None),
+        (
+            "assistant-def-deleted",
+            "assistant-deleted",
+            Some(ANCHOR_UPDATED_AT + 1_000),
+        ),
+    ] {
+        sqlx::query(
+            "INSERT INTO assistant_definitions \
+                (id, assistant_id, source, owner_type, source_ref, source_version, source_hash, \
+                 name, name_i18n, description, description_i18n, avatar_type, avatar_value, \
+                 agent_id, rule_resource_type, rule_resource_ref, rule_inline_content, \
+                 recommended_prompts, recommended_prompts_i18n, default_model_mode, default_model_value, \
+                 default_permission_mode, default_permission_value, default_skills_mode, default_skill_ids, \
+                 custom_skill_names, default_disabled_builtin_skill_ids, default_mcps_mode, default_mcp_ids, \
+                 created_at, updated_at, deleted_at, default_thought_level_mode, default_thought_level_value) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(definition_id)
+        .bind(assistant_id)
+        .bind("user")
+        .bind("user")
+        .bind(None::<String>)
+        .bind(None::<String>)
+        .bind(None::<String>)
+        .bind(assistant_id)
+        .bind("{}")
+        .bind(None::<String>)
+        .bind("{}")
+        .bind("none")
+        .bind(None::<String>)
+        .bind("opencode")
+        .bind("none")
+        .bind(None::<String>)
+        .bind(None::<String>)
+        .bind("[]")
+        .bind("{}")
+        .bind("auto")
+        .bind(None::<String>)
+        .bind("auto")
+        .bind(None::<String>)
+        .bind("auto")
+        .bind("[]")
+        .bind("[]")
+        .bind("[]")
+        .bind("auto")
+        .bind("[]")
+        .bind(ANCHOR_CREATED_AT)
+        .bind(ANCHOR_UPDATED_AT)
+        .bind(deleted_at)
+        .bind("auto")
+        .bind(None::<String>)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    for (conversation_id, definition_id, assistant_id, resolved_model_id, thought_level) in [
+        (
+            "conv-auth",
+            "assistant-def-team",
+            "assistant-team",
+            "sakana/fugu-ultra",
+            Some("high"),
+        ),
+        (
+            "conv-nearby",
+            "assistant-def-direct",
+            "assistant-direct",
+            "anthropic/claude-sonnet-4",
+            None,
+        ),
+        (
+            "conv-deleted-assistant",
+            "assistant-def-deleted",
+            "assistant-deleted",
+            "deleted/assistant-model",
+            None,
+        ),
+    ] {
+        sqlx::query(
+            "INSERT INTO conversation_assistant_snapshots \
+                (conversation_id, assistant_definition_id, assistant_id, assistant_source, agent_id, \
+                 rules_content, default_model_mode, resolved_model_id, default_permission_mode, \
+                 resolved_permission_value, default_skills_mode, resolved_skill_ids, \
+                 resolved_disabled_builtin_skill_ids, default_mcps_mode, resolved_mcp_ids, \
+                 created_at, updated_at, default_thought_level_mode, resolved_thought_level_value) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(conversation_id)
+        .bind(definition_id)
+        .bind(assistant_id)
+        .bind("user")
+        .bind("opencode")
+        .bind("rules should not leak")
+        .bind("auto")
+        .bind(resolved_model_id)
+        .bind("auto")
+        .bind(None::<String>)
+        .bind("auto")
+        .bind("[]")
+        .bind("[]")
+        .bind("auto")
+        .bind("[]")
+        .bind(ANCHOR_CREATED_AT)
+        .bind(ANCHOR_UPDATED_AT)
+        .bind("auto")
+        .bind(thought_level)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+}
+
+async fn insert_mcp_feedback_fixture(db: &aionui_db::Database) {
+    let original_json = json!({
+        "command": "npx",
+        "args": ["raw-config-mcp", "--access-token=raw-token-for-diagnostics"],
+        "env": {
+            "MCP_API_KEY": "raw-api-key-for-diagnostics"
+        }
+    })
+    .to_string();
+
+    sqlx::query(
+        "INSERT INTO mcp_servers \
+            (id, name, description, enabled, transport_type, transport_config, tools, \
+             last_test_status, last_connected, original_json, builtin, deleted_at, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("mcp-raw-config")
+    .bind("raw-config-mcp")
+    .bind(None::<String>)
+    .bind(true)
+    .bind("stdio")
+    .bind(json!({"command":"npx","args":["raw-config-mcp"],"env":{}}).to_string())
+    .bind(None::<String>)
+    .bind("error")
+    .bind(None::<i64>)
+    .bind(original_json)
+    .bind(false)
+    .bind(None::<i64>)
+    .bind(ANCHOR_CREATED_AT)
+    .bind(ANCHOR_UPDATED_AT)
+    .execute(db.pool())
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn collects_conversation_auth_signals_without_sensitive_payloads() {
+    let db = init_database_memory().await.unwrap();
+    insert_feedback_fixture(&db).await;
+    let repo = SqliteFeedbackDiagnosticsRepository::new(db.pool().clone());
+
+    let result = repo
+        .collect_feedback_diagnostics(&FeedbackDiagnosticsRequest {
+            user_id: "system_default_user".to_owned(),
+            profiles: vec![
+                FeedbackDiagnosticsProfile::ConversationSession,
+                FeedbackDiagnosticsProfile::ModelAuth,
+            ],
+            context: FeedbackDiagnosticsDbContext {
+                conversation_id: Some("conv-auth".to_owned()),
+                ..FeedbackDiagnosticsDbContext::default()
+            },
+        })
+        .await
+        .unwrap();
+
+    let conversation = result
+        .profiles
+        .iter()
+        .find(|profile| profile.name == "conversation-session")
+        .expect("conversation profile should exist");
+    assert_eq!(conversation.mode, "detail");
+    assert_eq!(conversation.data["conversation"]["id"], "conv-auth");
+    assert_eq!(
+        conversation.data["conversation"]["title"],
+        "Auth failure title should be visible"
+    );
+    assert_eq!(conversation.data["conversation"]["model_provider_id"], "prov-secret");
+    assert_eq!(conversation.data["messages"]["by_type"]["tips"], 1);
+    assert_eq!(
+        conversation.data["messages"]["recent_errors"][0]["code"],
+        "UserLlmProviderAuthFailed"
+    );
+    assert_eq!(conversation.data["acp_session"]["current_mode_id"], "build");
+    assert_eq!(conversation.data["acp_session"]["config_selections"]["mode"], "plan");
+    assert_eq!(
+        conversation.data["acp_session"]["config_selections"]["model"],
+        "sakana/fugu-ultra"
+    );
+    assert_eq!(conversation.data["acp_session"]["config_selections"]["effort"], "high");
+    assert_eq!(conversation.data["agent_metadata"]["available_model_count"], 2);
+    let recent_conversations = conversation.data["recent_conversations"]["items"]
+        .as_array()
+        .expect("recent conversations should be an array");
+    let recent_ids = recent_conversations
+        .iter()
+        .map(|item| item["id"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(recent_ids, vec!["conv-auth", "conv-nearby"]);
+    assert_eq!(
+        recent_conversations[1]["title"],
+        "Nearby conversation shown in screenshot"
+    );
+    assert_eq!(recent_conversations[1]["latest_error_code"], "NearbyProviderTimeout");
+
+    let model_auth = result
+        .profiles
+        .iter()
+        .find(|profile| profile.name == "model-auth")
+        .expect("model auth profile should exist");
+    assert_eq!(model_auth.data["providers"][0]["id"], "prov-secret");
+    assert_eq!(model_auth.data["providers"][0]["base_url_host"], "example.invalid");
+    assert_eq!(model_auth.data["providers"][0]["api_key_configured"], true);
+
+    let serialized = serde_json::to_string(&result).unwrap();
+    for secret in [
+        "sk-live-secret",
+        "encrypted-sk-live-secret",
+        "sk-query",
+        "sk-extra-secret",
+        "sk-prompt-secret",
+        "private content",
+        "sk-error-secret",
+        "sk-session-secret",
+        "sk-agent-args-secret",
+        "sk-agent-env-secret",
+        "Missing Authentication header",
+        "Nearby raw provider timeout",
+        "Old conversation outside feedback window",
+    ] {
+        assert!(
+            !serialized.contains(secret),
+            "diagnostics response leaked sensitive payload: {secret}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn mcp_tools_profile_includes_original_json_raw() {
+    let db = init_database_memory().await.unwrap();
+    insert_mcp_feedback_fixture(&db).await;
+    let repo = SqliteFeedbackDiagnosticsRepository::new(db.pool().clone());
+    let expected_original_json = json!({
+        "command": "npx",
+        "args": ["raw-config-mcp", "--access-token=raw-token-for-diagnostics"],
+        "env": {
+            "MCP_API_KEY": "raw-api-key-for-diagnostics"
+        }
+    })
+    .to_string();
+
+    let result = repo
+        .collect_feedback_diagnostics(&FeedbackDiagnosticsRequest {
+            user_id: "system_default_user".to_owned(),
+            profiles: vec![FeedbackDiagnosticsProfile::McpTools],
+            context: FeedbackDiagnosticsDbContext::default(),
+        })
+        .await
+        .unwrap();
+
+    let mcp_tools = result
+        .profiles
+        .iter()
+        .find(|profile| profile.name == "mcp-tools")
+        .expect("mcp tools profile should exist");
+    let server = &mcp_tools.data["servers"][0];
+
+    assert_eq!(server["name"], "raw-config-mcp");
+    assert_eq!(server["original_json"], expected_original_json);
+    assert_eq!(server["original_json_bytes"], expected_original_json.len());
+}
+
+#[tokio::test]
+async fn conversation_profile_is_scoped_to_current_user() {
+    let db = init_database_memory().await.unwrap();
+    insert_feedback_fixture(&db).await;
+    let repo = SqliteFeedbackDiagnosticsRepository::new(db.pool().clone());
+
+    let result = repo
+        .collect_feedback_diagnostics(&FeedbackDiagnosticsRequest {
+            user_id: "other-user".to_owned(),
+            profiles: vec![FeedbackDiagnosticsProfile::ConversationSession],
+            context: FeedbackDiagnosticsDbContext {
+                conversation_id: Some("conv-auth".to_owned()),
+                ..FeedbackDiagnosticsDbContext::default()
+            },
+        })
+        .await
+        .unwrap();
+
+    let conversation = result
+        .profiles
+        .iter()
+        .find(|profile| profile.name == "conversation-session")
+        .expect("conversation profile should exist");
+    assert_eq!(conversation.mode, "not_found");
+    assert!(conversation.data["conversation"].is_null());
+}
+
+#[tokio::test]
+async fn global_summary_includes_recent_diagnostics_without_sensitive_payloads() {
+    let db = init_database_memory().await.unwrap();
+    insert_feedback_fixture(&db).await;
+    let repo = SqliteFeedbackDiagnosticsRepository::new(db.pool().clone());
+
+    let result = repo
+        .collect_feedback_diagnostics(&FeedbackDiagnosticsRequest {
+            user_id: "system_default_user".to_owned(),
+            profiles: vec![FeedbackDiagnosticsProfile::GlobalSummary],
+            context: FeedbackDiagnosticsDbContext::default(),
+        })
+        .await
+        .unwrap();
+
+    let global = result
+        .profiles
+        .iter()
+        .find(|profile| profile.name == "global-summary")
+        .expect("global summary profile should exist");
+    assert_eq!(global.mode, "summary");
+    assert_eq!(global.data["conversation_count"], 3);
+    assert_eq!(global.data["message_count"], 3);
+    let status_count_total = global.data["conversation_status_counts"]
+        .as_array()
+        .expect("conversation status counts should be included")
+        .iter()
+        .map(|item| item["count"].as_i64().unwrap())
+        .sum::<i64>();
+    assert_eq!(status_count_total, 3);
+
+    let direct_conversations = global.data["recent_conversations"]["direct"]["items"]
+        .as_array()
+        .expect("direct recent conversations should be included");
+    let direct_ids = direct_conversations
+        .iter()
+        .map(|item| item["id"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(direct_ids, vec!["conv-nearby", "conv-old"]);
+    assert!(!direct_ids.contains(&"conv-deleted-assistant"));
+    assert_eq!(
+        direct_conversations[0]["title"],
+        "Nearby conversation shown in screenshot"
+    );
+    assert_eq!(direct_conversations[0]["assistant_id"], "assistant-direct");
+    assert_eq!(direct_conversations[0]["agent_id"], "opencode");
+    assert_eq!(direct_conversations[0]["current_model_id"], "anthropic/claude-sonnet-4");
+    assert_eq!(
+        direct_conversations[0]["recent_errors"][0]["content"]["error"]["message"],
+        "Nearby raw provider timeout should not leak"
+    );
+    assert_eq!(direct_conversations[0]["message_count"], 1);
+
+    let teams = global.data["recent_conversations"]["team"]["items"]
+        .as_array()
+        .expect("recent team groups should be included");
+    let team_ids = teams
+        .iter()
+        .map(|item| item["team_id"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(team_ids, vec!["team-1"]);
+    assert!(!team_ids.contains(&"team-deleted"));
+    assert_eq!(teams[0]["id"], "team-1");
+    assert_eq!(teams[0]["name"], "Diagnostics Team");
+    assert_eq!(teams[0]["workspace_mode"], "shared");
+    assert_eq!(teams[0]["session_mode"], "build");
+    assert_eq!(teams[0]["lead_agent_id"], "opencode");
+    assert_eq!(teams[0]["agent_count"], 2);
+    assert_eq!(teams[0]["conversation_count"], 1);
+    assert_eq!(teams[0]["message_count"], 2);
+    assert_eq!(teams[0]["error_message_count"], 1);
+
+    let team_conversations = teams[0]["conversations"]["items"]
+        .as_array()
+        .expect("team conversations should be nested under their team group");
+    assert_eq!(teams[0]["conversations"]["limit"], 20);
+    assert_eq!(team_conversations[0]["id"], "conv-auth");
+    assert!(team_conversations.iter().all(|item| item["id"] != "conv-deleted-team"));
+    assert_eq!(team_conversations[0]["team_id"], "team-1");
+    assert_eq!(team_conversations[0]["role"], "teammate");
+    assert_eq!(team_conversations[0]["slot_id"], "slot-1");
+    assert_eq!(team_conversations[0]["assistant_id"], "assistant-team");
+    assert_eq!(team_conversations[0]["latest_error_code"], "UserLlmProviderAuthFailed");
+    assert_eq!(
+        team_conversations[0]["recent_errors"][0]["content"]["error"]["message"],
+        "Missing Authentication header sk-error-secret"
+    );
+    assert_eq!(
+        team_conversations[0]["recent_messages"][0]["content"]["text"]["redacted"],
+        true
+    );
+    assert_eq!(team_conversations[0]["message_count"], 2);
+
+    let recent_errors = global.data["recent_errors"]["items"]
+        .as_array()
+        .expect("recent errors should be included");
+    assert_eq!(recent_errors[0]["conversation_id"], "conv-nearby");
+    assert_eq!(
+        recent_errors[0]["conversation_title"],
+        "Nearby conversation shown in screenshot"
+    );
+    assert_eq!(recent_errors[0]["code"], "NearbyProviderTimeout");
+    assert_eq!(
+        recent_errors[0]["content"]["error"]["message"],
+        "Nearby raw provider timeout should not leak"
+    );
+    assert_eq!(recent_errors[1]["conversation_id"], "conv-auth");
+    assert_eq!(recent_errors[1]["code"], "UserLlmProviderAuthFailed");
+    assert_eq!(recent_errors[1]["resolution_target_id"], "prov-secret");
+    assert!(
+        recent_errors
+            .iter()
+            .all(|item| item["conversation_id"] != "conv-deleted-team"
+                && item["conversation_id"] != "conv-deleted-assistant"),
+        "deleted data conversations should be excluded from recent errors"
+    );
+
+    let agent_items = global.data["agent_health"]["items"]
+        .as_array()
+        .expect("agent health items should be included");
+    let opencode_agent = agent_items
+        .iter()
+        .find(|item| item["id"] == "opencode")
+        .expect("opencode agent health should be included");
+    assert_eq!(opencode_agent["last_check_status"], "ok");
+
+    let provider_items = global.data["provider_health"]["items"]
+        .as_array()
+        .expect("provider health items should be included");
+    let secret_provider = provider_items
+        .iter()
+        .find(|item| item["id"] == "prov-secret")
+        .expect("fixture provider health should be included");
+    assert_eq!(secret_provider["base_url_host"], "example.invalid");
+    assert_eq!(secret_provider["api_key_configured"], true);
+    assert_eq!(secret_provider["unhealthy_model_count"], 1);
+
+    let serialized = serde_json::to_string(&result).unwrap();
+    for secret in [
+        "sk-live-secret",
+        "encrypted-sk-live-secret",
+        "sk-query",
+        "sk-extra-secret",
+        "sk-prompt-secret",
+        "private content",
+        "sk-session-secret",
+        "sk-nearby-session-secret",
+        "sk-agent-args-secret",
+        "sk-agent-env-secret",
+        "rules should not leak",
+    ] {
+        assert!(
+            !serialized.contains(secret),
+            "global diagnostics response leaked sensitive payload: {secret}"
+        );
+    }
+}

--- a/crates/aionui-system/Cargo.toml
+++ b/crates/aionui-system/Cargo.toml
@@ -27,4 +27,5 @@ dirs.workspace = true
 tower = { workspace = true }
 http-body-util.workspace = true
 reqwest.workspace = true
+sqlx.workspace = true
 wiremock = "0.6"

--- a/crates/aionui-system/src/diagnostics.rs
+++ b/crates/aionui-system/src/diagnostics.rs
@@ -1,0 +1,407 @@
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use aionui_api_types::{
+    FeedbackDiagnosticsContextResponse, FeedbackDiagnosticsPrivacyResponse, FeedbackDiagnosticsProfileResponse,
+    FeedbackDiagnosticsQuery, FeedbackDiagnosticsResponse,
+};
+use aionui_db::{
+    FeedbackDiagnosticsDbContext, FeedbackDiagnosticsProfile, FeedbackDiagnosticsRequest,
+    IFeedbackDiagnosticsRepository,
+};
+
+use crate::error::SystemError;
+
+#[derive(Clone)]
+pub struct FeedbackDiagnosticsService {
+    repo: Arc<dyn IFeedbackDiagnosticsRepository>,
+}
+
+impl FeedbackDiagnosticsService {
+    pub fn new(repo: Arc<dyn IFeedbackDiagnosticsRepository>) -> Self {
+        Self { repo }
+    }
+
+    pub async fn collect(
+        &self,
+        user_id: &str,
+        query: FeedbackDiagnosticsQuery,
+    ) -> Result<FeedbackDiagnosticsResponse, SystemError> {
+        let context = resolve_context(&query);
+        let profiles = resolve_profiles(&query, context.conversation_id.as_deref());
+        let db_request = FeedbackDiagnosticsRequest {
+            user_id: user_id.to_owned(),
+            profiles: profiles.clone(),
+            context: FeedbackDiagnosticsDbContext {
+                conversation_id: context.conversation_id.clone(),
+                provider_id: context.provider_id.clone(),
+                agent_id: context.agent_id.clone(),
+                team_id: context.team_id.clone(),
+                mcp_server_id: context.mcp_server_id.clone(),
+            },
+        };
+
+        let result = self.repo.collect_feedback_diagnostics(&db_request).await?;
+        let profile_names = profiles.iter().map(|profile| profile.as_name().to_owned()).collect();
+
+        Ok(FeedbackDiagnosticsResponse {
+            schema_version: result.schema_version,
+            context: FeedbackDiagnosticsContextResponse {
+                route_at_open: query.route_at_open,
+                route_at_submit: query.route_at_submit,
+                selected_module: query.selected_module,
+                conversation_id: context.conversation_id,
+                provider_id: context.provider_id,
+                agent_id: context.agent_id,
+                team_id: context.team_id,
+                mcp_server_id: context.mcp_server_id,
+                selected_profiles: profile_names,
+            },
+            profiles: result
+                .profiles
+                .into_iter()
+                .map(|profile| FeedbackDiagnosticsProfileResponse {
+                    name: profile.name,
+                    mode: profile.mode,
+                    data: profile.data,
+                    warnings: profile.warnings,
+                })
+                .collect(),
+            privacy: FeedbackDiagnosticsPrivacyResponse {
+                redaction: "aionCore returns selected metadata, ids, titles, status fields, counts, endpoint hosts, and selected configuration values; raw error and tool-call diagnostic content may be included; MCP original_json is returned as stored and can contain credentials; non-error message content and prompts are summarized or redacted."
+                    .to_owned(),
+                raw_content_included: true,
+                api_keys_included: true,
+            },
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ResolvedContext {
+    conversation_id: Option<String>,
+    provider_id: Option<String>,
+    agent_id: Option<String>,
+    team_id: Option<String>,
+    mcp_server_id: Option<String>,
+}
+
+fn resolve_context(query: &FeedbackDiagnosticsQuery) -> ResolvedContext {
+    let route_conversation_id = query
+        .route_at_submit
+        .as_deref()
+        .and_then(extract_conversation_id)
+        .or_else(|| query.route_at_open.as_deref().and_then(extract_conversation_id));
+
+    ResolvedContext {
+        conversation_id: query.conversation_id.clone().or(route_conversation_id),
+        provider_id: query.provider_id.clone(),
+        agent_id: query.agent_id.clone(),
+        team_id: query.team_id.clone(),
+        mcp_server_id: query.mcp_server_id.clone(),
+    }
+}
+
+fn resolve_profiles(
+    query: &FeedbackDiagnosticsQuery,
+    conversation_id: Option<&str>,
+) -> Vec<FeedbackDiagnosticsProfile> {
+    let mut selected = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    if let Some(route) = query.route_at_submit.as_deref() {
+        push_route_profiles(&mut selected, &mut seen, route, conversation_id);
+    }
+    if let Some(route) = query.route_at_open.as_deref() {
+        push_route_profiles(&mut selected, &mut seen, route, conversation_id);
+    }
+    if let Some(module) = query.selected_module.as_deref() {
+        push_module_profiles(&mut selected, &mut seen, module);
+    }
+    if let Some(profiles) = query.profiles.as_deref() {
+        for profile in profiles.split(',').filter_map(|value| parse_profile(value.trim())) {
+            push_profile(&mut selected, &mut seen, profile);
+        }
+    }
+    push_profile(&mut selected, &mut seen, FeedbackDiagnosticsProfile::GlobalSummary);
+
+    selected
+}
+
+fn push_route_profiles(
+    selected: &mut Vec<FeedbackDiagnosticsProfile>,
+    seen: &mut BTreeSet<FeedbackDiagnosticsProfile>,
+    route: &str,
+    conversation_id: Option<&str>,
+) {
+    let route = route.to_ascii_lowercase();
+
+    if conversation_id.is_some()
+        || route.contains("conversation")
+        || route.contains("chat")
+        || route.contains("session")
+    {
+        push_profile(selected, seen, FeedbackDiagnosticsProfile::ConversationSession);
+        push_profile(selected, seen, FeedbackDiagnosticsProfile::ModelAuth);
+        push_profile(selected, seen, FeedbackDiagnosticsProfile::McpTools);
+    }
+    if route.contains("team") || route.contains("collaboration") {
+        push_profile(selected, seen, FeedbackDiagnosticsProfile::AgentTeam);
+    }
+    if route.contains("mcp") || route.contains("tool") {
+        push_profile(selected, seen, FeedbackDiagnosticsProfile::McpTools);
+    }
+    if route.contains("provider") || route.contains("model") || route.contains("settings") || route.contains("agent") {
+        push_profile(selected, seen, FeedbackDiagnosticsProfile::ModelAuth);
+    }
+}
+
+fn push_module_profiles(
+    selected: &mut Vec<FeedbackDiagnosticsProfile>,
+    seen: &mut BTreeSet<FeedbackDiagnosticsProfile>,
+    module: &str,
+) {
+    match module.to_ascii_lowercase().as_str() {
+        "conversation-session"
+        | "dialogue-session"
+        | "assistant-preset"
+        | "channel"
+        | "search-history"
+        | "workspace-preview"
+        | "display-desktop"
+        | "对话与会话" => {
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::ConversationSession);
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::ModelAuth);
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::McpTools);
+        }
+        "agent-detection" => {
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::ModelAuth);
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::McpTools);
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::ConversationSession);
+        }
+        "agent-team" | "team-collaboration" | "团队协作" => {
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::AgentTeam);
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::ConversationSession);
+        }
+        "mcp-tools" | "mcp" => {
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::McpTools);
+        }
+        "model-auth" => {
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::ModelAuth);
+        }
+        "skills-plugin" => {
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::McpTools);
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::ConversationSession);
+        }
+        "webui-remote" => {
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::ModelAuth);
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::McpTools);
+        }
+        "scheduled-task" => {
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::ConversationSession);
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::AgentTeam);
+        }
+        "system-settings" | "settings" | "系统设置" => {
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::ModelAuth);
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::McpTools);
+        }
+        _ => {}
+    }
+}
+
+fn push_profile(
+    selected: &mut Vec<FeedbackDiagnosticsProfile>,
+    seen: &mut BTreeSet<FeedbackDiagnosticsProfile>,
+    profile: FeedbackDiagnosticsProfile,
+) {
+    if seen.insert(profile.clone()) {
+        selected.push(profile);
+    }
+}
+
+fn parse_profile(value: &str) -> Option<FeedbackDiagnosticsProfile> {
+    match value {
+        "conversation-session" => Some(FeedbackDiagnosticsProfile::ConversationSession),
+        "model-auth" => Some(FeedbackDiagnosticsProfile::ModelAuth),
+        "agent-team" => Some(FeedbackDiagnosticsProfile::AgentTeam),
+        "mcp-tools" => Some(FeedbackDiagnosticsProfile::McpTools),
+        "global-summary" => Some(FeedbackDiagnosticsProfile::GlobalSummary),
+        _ => None,
+    }
+}
+
+fn extract_conversation_id(route: &str) -> Option<String> {
+    extract_query_value(route, "conversationId")
+        .or_else(|| extract_query_value(route, "conversation_id"))
+        .or_else(|| extract_segment_after(route, "conversations"))
+        .or_else(|| extract_segment_after(route, "conversation"))
+}
+
+fn extract_query_value(route: &str, key: &str) -> Option<String> {
+    let needle = format!("{key}=");
+    let start = route.find(&needle)? + needle.len();
+    let value = route[start..]
+        .split(['&', '#'])
+        .next()
+        .unwrap_or_default()
+        .trim_matches('/');
+    non_reserved_id(value)
+}
+
+fn extract_segment_after(route: &str, marker: &str) -> Option<String> {
+    let normalized = route.replace(['#', '?', '&', '='], "/");
+    let mut segments = normalized.split('/').filter(|segment| !segment.is_empty());
+    while let Some(segment) = segments.next() {
+        if segment == marker
+            && let Some(value) = segments.next()
+        {
+            return non_reserved_id(value);
+        }
+    }
+    None
+}
+
+fn non_reserved_id(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() || matches!(value, "new" | "clone" | "active-count" | "search") {
+        return None;
+    }
+    Some(value.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn route_context_takes_submit_route_before_open_route() {
+        let query = FeedbackDiagnosticsQuery {
+            route_at_open: Some("#/conversations/conv-open".to_owned()),
+            route_at_submit: Some("#/conversations/conv-submit".to_owned()),
+            ..FeedbackDiagnosticsQuery::default()
+        };
+
+        let context = resolve_context(&query);
+
+        assert_eq!(context.conversation_id.as_deref(), Some("conv-submit"));
+    }
+
+    #[test]
+    fn explicit_context_overrides_route_extraction() {
+        let query = FeedbackDiagnosticsQuery {
+            route_at_submit: Some("#/conversations/conv-route".to_owned()),
+            conversation_id: Some("conv-explicit".to_owned()),
+            ..FeedbackDiagnosticsQuery::default()
+        };
+
+        let context = resolve_context(&query);
+
+        assert_eq!(context.conversation_id.as_deref(), Some("conv-explicit"));
+    }
+
+    #[test]
+    fn profile_resolution_unions_route_module_and_explicit_profiles() {
+        let query = FeedbackDiagnosticsQuery {
+            route_at_submit: Some("#/conversations/conv-1".to_owned()),
+            selected_module: Some("system-settings".to_owned()),
+            profiles: Some("agent-team".to_owned()),
+            ..FeedbackDiagnosticsQuery::default()
+        };
+
+        let profiles = resolve_profiles(&query, Some("conv-1"));
+
+        assert_eq!(profiles[0], FeedbackDiagnosticsProfile::ConversationSession);
+        assert!(profiles.contains(&FeedbackDiagnosticsProfile::ModelAuth));
+        assert!(profiles.contains(&FeedbackDiagnosticsProfile::McpTools));
+        assert!(profiles.contains(&FeedbackDiagnosticsProfile::AgentTeam));
+        assert!(profiles.contains(&FeedbackDiagnosticsProfile::GlobalSummary));
+    }
+
+    #[test]
+    fn known_feedback_modules_resolve_to_diagnostic_profiles() {
+        let cases = [
+            (
+                "agent-detection",
+                vec![
+                    FeedbackDiagnosticsProfile::ModelAuth,
+                    FeedbackDiagnosticsProfile::McpTools,
+                    FeedbackDiagnosticsProfile::ConversationSession,
+                ],
+            ),
+            (
+                "assistant-preset",
+                vec![
+                    FeedbackDiagnosticsProfile::ConversationSession,
+                    FeedbackDiagnosticsProfile::ModelAuth,
+                    FeedbackDiagnosticsProfile::McpTools,
+                ],
+            ),
+            ("model-auth", vec![FeedbackDiagnosticsProfile::ModelAuth]),
+            ("mcp-tools", vec![FeedbackDiagnosticsProfile::McpTools]),
+            (
+                "skills-plugin",
+                vec![
+                    FeedbackDiagnosticsProfile::McpTools,
+                    FeedbackDiagnosticsProfile::ConversationSession,
+                ],
+            ),
+            ("channel", vec![FeedbackDiagnosticsProfile::ConversationSession]),
+            ("search-history", vec![FeedbackDiagnosticsProfile::ConversationSession]),
+            (
+                "workspace-preview",
+                vec![FeedbackDiagnosticsProfile::ConversationSession],
+            ),
+            (
+                "webui-remote",
+                vec![
+                    FeedbackDiagnosticsProfile::ModelAuth,
+                    FeedbackDiagnosticsProfile::McpTools,
+                ],
+            ),
+            (
+                "scheduled-task",
+                vec![
+                    FeedbackDiagnosticsProfile::ConversationSession,
+                    FeedbackDiagnosticsProfile::AgentTeam,
+                ],
+            ),
+            (
+                "agent-team",
+                vec![
+                    FeedbackDiagnosticsProfile::AgentTeam,
+                    FeedbackDiagnosticsProfile::ConversationSession,
+                ],
+            ),
+            ("display-desktop", vec![FeedbackDiagnosticsProfile::ConversationSession]),
+            (
+                "system-settings",
+                vec![
+                    FeedbackDiagnosticsProfile::ModelAuth,
+                    FeedbackDiagnosticsProfile::McpTools,
+                ],
+            ),
+            ("other", vec![]),
+        ];
+
+        for (module, expected_profiles) in cases {
+            let query = FeedbackDiagnosticsQuery {
+                selected_module: Some(module.to_owned()),
+                ..FeedbackDiagnosticsQuery::default()
+            };
+
+            let profiles = resolve_profiles(&query, None);
+
+            for profile in expected_profiles {
+                assert!(
+                    profiles.contains(&profile),
+                    "{module} should include {}",
+                    profile.as_name()
+                );
+            }
+            assert!(
+                profiles.contains(&FeedbackDiagnosticsProfile::GlobalSummary),
+                "{module} should always include global-summary"
+            );
+        }
+    }
+}

--- a/crates/aionui-system/src/diagnostics.rs
+++ b/crates/aionui-system/src/diagnostics.rs
@@ -68,10 +68,10 @@ impl FeedbackDiagnosticsService {
                 })
                 .collect(),
             privacy: FeedbackDiagnosticsPrivacyResponse {
-                redaction: "aionCore returns selected metadata, ids, titles, status fields, counts, endpoint hosts, and selected configuration values; raw error and tool-call diagnostic content may be included; MCP original_json is returned as stored and can contain credentials; non-error message content and prompts are summarized or redacted."
+                redaction: "aionCore returns selected metadata, ids, titles, status fields, counts, endpoint hosts, selected configuration values, and MCP original_json keeps connection structure while credential values are redacted; raw error and tool-call diagnostic content may be included; non-error message content and prompts are summarized or redacted."
                     .to_owned(),
                 raw_content_included: true,
-                api_keys_included: true,
+                api_keys_included: false,
             },
         })
     }

--- a/crates/aionui-system/src/lib.rs
+++ b/crates/aionui-system/src/lib.rs
@@ -3,6 +3,7 @@
 //! System services: provider management, model fetching, settings, and version checks.
 pub mod bedrock_probe;
 pub mod client_pref;
+pub mod diagnostics;
 pub mod error;
 pub mod model_fetcher;
 pub mod protocol;
@@ -15,6 +16,7 @@ pub mod version;
 
 pub use bedrock_probe::{ConnectionTestRouterState, ConnectionTestService, connection_test_routes};
 pub use client_pref::ClientPrefService;
+pub use diagnostics::FeedbackDiagnosticsService;
 pub use error::SystemError;
 pub use model_fetcher::ModelFetchService;
 pub use protocol::ProtocolDetectionService;

--- a/crates/aionui-system/src/routes.rs
+++ b/crates/aionui-system/src/routes.rs
@@ -2,20 +2,22 @@
 
 use axum::Router;
 use axum::extract::rejection::JsonRejection;
-use axum::extract::{Json, Path, Query, State};
+use axum::extract::{Extension, Json, Path, Query, State};
 use axum::http::StatusCode;
 use axum::routing::{delete, get, post};
 
 use aionui_api_types::{
     ApiResponse, ClientPreferencesResponse, CreateProviderRequest, DetectProtocolRequest, EnsureManagedAcpToolRequest,
-    EnsureManagedAcpToolResponse, EnsureNodeRuntimeRequest, EnsureNodeRuntimeResponse, FetchModelsAnonymousRequest,
-    FetchModelsRequest, FetchModelsResponse, ProtocolDetectionResponse, ProviderResponse, SystemInfoResponse,
-    SystemSettingsResponse, UpdateCheckRequest, UpdateCheckResult, UpdateClientPreferencesRequest,
-    UpdateProviderRequest, UpdateSettingsRequest,
+    EnsureManagedAcpToolResponse, EnsureNodeRuntimeRequest, EnsureNodeRuntimeResponse, FeedbackDiagnosticsQuery,
+    FeedbackDiagnosticsResponse, FetchModelsAnonymousRequest, FetchModelsRequest, FetchModelsResponse,
+    ProtocolDetectionResponse, ProviderResponse, SystemInfoResponse, SystemSettingsResponse, UpdateCheckRequest,
+    UpdateCheckResult, UpdateClientPreferencesRequest, UpdateProviderRequest, UpdateSettingsRequest,
 };
+use aionui_auth::CurrentUser;
 use aionui_common::ApiError;
 
 use crate::client_pref::ClientPrefService;
+use crate::diagnostics::FeedbackDiagnosticsService;
 use crate::error::SystemError;
 use crate::model_fetcher::ModelFetchService;
 use crate::protocol::ProtocolDetectionService;
@@ -34,6 +36,7 @@ pub struct SystemRouterState {
     pub protocol_detection_service: ProtocolDetectionService,
     pub version_check_service: VersionCheckService,
     pub runtime_prepare_service: RuntimePrepareService,
+    pub feedback_diagnostics_service: FeedbackDiagnosticsService,
 }
 
 impl From<SystemError> for ApiError {
@@ -70,6 +73,7 @@ impl From<SystemError> for ApiError {
 /// - `POST /api/system/check-update`         — check GitHub for new versions
 /// - `POST /api/system/ensure-node-runtime`  — prepare managed Node runtime
 /// - `POST /api/system/ensure-managed-acp-tool` — prepare managed ACP tool artifact
+/// - `GET  /api/system/diagnostics/feedback-report` — collect sanitized feedback diagnostics
 pub fn system_routes(state: SystemRouterState) -> Router {
     Router::new()
         .route("/api/settings", get(get_settings).patch(update_settings))
@@ -89,6 +93,7 @@ pub fn system_routes(state: SystemRouterState) -> Router {
         .route("/api/system/check-update", post(check_update))
         .route("/api/system/ensure-node-runtime", post(ensure_node_runtime))
         .route("/api/system/ensure-managed-acp-tool", post(ensure_managed_acp_tool))
+        .route("/api/system/diagnostics/feedback-report", get(get_feedback_diagnostics))
         .with_state(state)
 }
 
@@ -106,6 +111,19 @@ async fn get_settings(
 ) -> Result<Json<ApiResponse<SystemSettingsResponse>>, ApiError> {
     let settings = state.settings_service.get_settings().await.map_err(ApiError::from)?;
     Ok(Json(ApiResponse::ok(settings)))
+}
+
+async fn get_feedback_diagnostics(
+    State(state): State<SystemRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    Query(query): Query<FeedbackDiagnosticsQuery>,
+) -> Result<Json<ApiResponse<FeedbackDiagnosticsResponse>>, ApiError> {
+    let diagnostics = state
+        .feedback_diagnostics_service
+        .collect(&user.id, query)
+        .await
+        .map_err(ApiError::from)?;
+    Ok(Json(ApiResponse::ok(diagnostics)))
 }
 
 async fn update_settings(

--- a/crates/aionui-system/tests/feedback_diagnostics_routes.rs
+++ b/crates/aionui-system/tests/feedback_diagnostics_routes.rs
@@ -181,13 +181,14 @@ async fn diagnostics_privacy_statement_matches_included_raw_diagnostics() {
     let json = body_json(resp).await;
     assert_eq!(json["success"], true);
     assert_eq!(json["data"]["privacy"]["raw_content_included"], true);
-    assert_eq!(json["data"]["privacy"]["api_keys_included"], true);
+    assert_eq!(json["data"]["privacy"]["api_keys_included"], false);
 
     let redaction = json["data"]["privacy"]["redaction"]
         .as_str()
         .expect("privacy redaction should be text");
     assert!(redaction.contains("raw error and tool-call diagnostic content may be included"));
-    assert!(redaction.contains("MCP original_json is returned as stored"));
+    assert!(redaction.contains("MCP original_json keeps connection structure"));
+    assert!(redaction.contains("credential values are redacted"));
     assert!(redaction.contains("non-error message content and prompts are summarized or redacted"));
 }
 

--- a/crates/aionui-system/tests/feedback_diagnostics_routes.rs
+++ b/crates/aionui-system/tests/feedback_diagnostics_routes.rs
@@ -1,0 +1,246 @@
+use std::sync::Arc;
+
+use aionui_auth::CurrentUser;
+use aionui_realtime::BroadcastEventBus;
+use aionui_system::{
+    ClientPrefService, FeedbackDiagnosticsService, ModelFetchService, ProtocolDetectionService, ProviderService,
+    RuntimePrepareService, SettingsService, SystemRouterState, VersionCheckService, system_routes,
+};
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+use aionui_db::{
+    SqliteClientPreferenceRepository, SqliteFeedbackDiagnosticsRepository, SqliteProviderRepository,
+    SqliteSettingsRepository, init_database_memory,
+};
+
+const TEST_ENCRYPTION_KEY: [u8; 32] = [0x42; 32];
+
+fn build_state(db: &aionui_db::Database) -> SystemRouterState {
+    let provider_repo = Arc::new(SqliteProviderRepository::new(db.pool().clone()));
+    let http_client = reqwest::Client::new();
+    SystemRouterState {
+        settings_service: SettingsService::new(Arc::new(SqliteSettingsRepository::new(db.pool().clone()))),
+        client_pref_service: ClientPrefService::new(Arc::new(SqliteClientPreferenceRepository::new(db.pool().clone()))),
+        provider_service: ProviderService::new(provider_repo.clone(), TEST_ENCRYPTION_KEY),
+        model_fetch_service: ModelFetchService::new(provider_repo, TEST_ENCRYPTION_KEY, http_client.clone()),
+        protocol_detection_service: ProtocolDetectionService::new(http_client.clone()),
+        version_check_service: VersionCheckService::new(http_client, "0.1.0".to_owned()),
+        runtime_prepare_service: RuntimePrepareService::new(Arc::new(BroadcastEventBus::new(16))),
+        feedback_diagnostics_service: FeedbackDiagnosticsService::new(Arc::new(
+            SqliteFeedbackDiagnosticsRepository::new(db.pool().clone()),
+        )),
+    }
+}
+
+async fn setup() -> (axum::Router, aionui_db::Database) {
+    let db = init_database_memory().await.unwrap();
+    insert_fixture(&db).await;
+    (system_routes(build_state(&db)), db)
+}
+
+async fn insert_fixture(db: &aionui_db::Database) {
+    let pool = db.pool();
+    sqlx::query(
+        "INSERT INTO providers \
+            (id, platform, name, base_url, api_key_encrypted, models, enabled, \
+             capabilities, context_limit, model_protocols, model_enabled, model_health, \
+             bedrock_config, is_full_url, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("prov-route")
+    .bind("openrouter")
+    .bind("OpenRouter")
+    .bind("https://sk-route-secret@example.invalid/v1")
+    .bind("encrypted-sk-route-secret")
+    .bind(r#"["sakana/fugu-ultra"]"#)
+    .bind(true)
+    .bind(r#"[{"type":"text"}]"#)
+    .bind(128000_i64)
+    .bind(None::<String>)
+    .bind(None::<String>)
+    .bind(None::<String>)
+    .bind(None::<String>)
+    .bind(false)
+    .bind(1000_i64)
+    .bind(2000_i64)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO conversations \
+            (id, user_id, name, type, extra, model, status, source, channel_chat_id, \
+             pinned, pinned_at, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("conv-route")
+    .bind("system_default_user")
+    .bind("Route-selected conversation")
+    .bind("aionrs")
+    .bind(json!({"agentId":"opencode"}).to_string())
+    .bind(json!({"providerId":"prov-route","modelId":"sakana/fugu-ultra"}).to_string())
+    .bind("running")
+    .bind("aionui")
+    .bind(None::<String>)
+    .bind(false)
+    .bind(None::<i64>)
+    .bind(3000_i64)
+    .bind(4000_i64)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO messages \
+            (id, conversation_id, msg_id, type, content, position, status, hidden, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("msg-route-error")
+    .bind("conv-route")
+    .bind("turn-route")
+    .bind("tips")
+    .bind(
+        json!({
+            "error": {
+                "code": "RouteProviderAuthFailed",
+                "message": "Route raw error should not leak sk-route-message-secret"
+            },
+            "feedbackRecommended": true
+        })
+        .to_string(),
+    )
+    .bind("center")
+    .bind("error")
+    .bind(false)
+    .bind(5000_i64)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+fn diagnostics_request(uri: &str) -> Request<Body> {
+    let mut req = Request::builder().method("GET").uri(uri).body(Body::empty()).unwrap();
+    req.extensions_mut().insert(CurrentUser {
+        id: "system_default_user".to_owned(),
+        username: "system_default_user".to_owned(),
+    });
+    req
+}
+
+#[tokio::test]
+async fn diagnostics_uses_route_context_and_unions_selected_module_profiles() {
+    let (app, _db) = setup().await;
+    let resp = app
+        .oneshot(diagnostics_request(
+            "/api/system/diagnostics/feedback-report?route_at_submit=%23%2Fconversations%2Fconv-route&selected_module=system-settings",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    assert_eq!(json["data"]["context"]["conversation_id"], "conv-route");
+    assert_eq!(json["data"]["profiles"][0]["name"], "conversation-session");
+    let profile_names = json["data"]["profiles"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|profile| profile["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert!(profile_names.contains(&"conversation-session"));
+    assert!(profile_names.contains(&"model-auth"));
+    assert!(profile_names.contains(&"mcp-tools"));
+    assert!(profile_names.contains(&"global-summary"));
+
+    let serialized = serde_json::to_string(&json).unwrap();
+    assert!(!serialized.contains("sk-route-secret"));
+    assert!(!serialized.contains("encrypted-sk-route-secret"));
+}
+
+#[tokio::test]
+async fn diagnostics_privacy_statement_matches_included_raw_diagnostics() {
+    let (app, _db) = setup().await;
+    let resp = app
+        .oneshot(diagnostics_request(
+            "/api/system/diagnostics/feedback-report?route_at_submit=%23%2Fguid&selected_module=conversation-session",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    assert_eq!(json["data"]["privacy"]["raw_content_included"], true);
+    assert_eq!(json["data"]["privacy"]["api_keys_included"], true);
+
+    let redaction = json["data"]["privacy"]["redaction"]
+        .as_str()
+        .expect("privacy redaction should be text");
+    assert!(redaction.contains("raw error and tool-call diagnostic content may be included"));
+    assert!(redaction.contains("MCP original_json is returned as stored"));
+    assert!(redaction.contains("non-error message content and prompts are summarized or redacted"));
+}
+
+#[tokio::test]
+async fn diagnostics_home_route_uses_module_and_global_summary_context() {
+    let (app, _db) = setup().await;
+    let resp = app
+        .oneshot(diagnostics_request(
+            "/api/system/diagnostics/feedback-report?route_at_submit=%23%2Fguid&selected_module=agent-detection",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    assert!(json["data"]["context"]["conversation_id"].is_null());
+
+    let profile_names = json["data"]["profiles"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|profile| profile["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert!(profile_names.contains(&"conversation-session"));
+    assert!(profile_names.contains(&"model-auth"));
+    assert!(profile_names.contains(&"mcp-tools"));
+    assert!(profile_names.contains(&"global-summary"));
+
+    let global = json["data"]["profiles"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|profile| profile["name"] == "global-summary")
+        .expect("global summary should be included");
+    assert_eq!(
+        global["data"]["recent_conversations"]["direct"]["items"][0]["title"],
+        "Route-selected conversation"
+    );
+    assert_eq!(
+        global["data"]["recent_conversations"]["direct"]["items"][0]["recent_errors"][0]["content"]["error"]["message"],
+        "Route raw error should not leak sk-route-message-secret"
+    );
+    assert_eq!(
+        global["data"]["recent_errors"]["items"][0]["code"],
+        "RouteProviderAuthFailed"
+    );
+    assert_eq!(
+        global["data"]["recent_errors"]["items"][0]["content"]["error"]["message"],
+        "Route raw error should not leak sk-route-message-secret"
+    );
+
+    let serialized = serde_json::to_string(&json).unwrap();
+    assert!(!serialized.contains("sk-route-secret"));
+    assert!(!serialized.contains("encrypted-sk-route-secret"));
+}

--- a/crates/aionui-system/tests/model_fetch_routes.rs
+++ b/crates/aionui-system/tests/model_fetch_routes.rs
@@ -15,13 +15,13 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use aionui_common::encrypt_string;
 use aionui_db::{
-    CreateProviderParams, IProviderRepository, SqliteClientPreferenceRepository, SqliteProviderRepository,
-    SqliteSettingsRepository, init_database_memory,
+    CreateProviderParams, IProviderRepository, SqliteClientPreferenceRepository, SqliteFeedbackDiagnosticsRepository,
+    SqliteProviderRepository, SqliteSettingsRepository, init_database_memory,
 };
 use aionui_realtime::BroadcastEventBus;
 use aionui_system::{
-    ClientPrefService, ModelFetchService, ProtocolDetectionService, ProviderService, RuntimePrepareService,
-    SettingsService, SystemRouterState, VersionCheckService, system_routes,
+    ClientPrefService, FeedbackDiagnosticsService, ModelFetchService, ProtocolDetectionService, ProviderService,
+    RuntimePrepareService, SettingsService, SystemRouterState, VersionCheckService, system_routes,
 };
 
 // ---------------------------------------------------------------------------
@@ -41,6 +41,9 @@ fn build_state(db: &aionui_db::Database) -> SystemRouterState {
         protocol_detection_service: ProtocolDetectionService::new(http_client.clone()),
         version_check_service: VersionCheckService::new(http_client, "0.1.0".to_owned()),
         runtime_prepare_service: RuntimePrepareService::new(Arc::new(BroadcastEventBus::new(16))),
+        feedback_diagnostics_service: FeedbackDiagnosticsService::new(Arc::new(
+            SqliteFeedbackDiagnosticsRepository::new(db.pool().clone()),
+        )),
     }
 }
 

--- a/crates/aionui-system/tests/protocol_detection_routes.rs
+++ b/crates/aionui-system/tests/protocol_detection_routes.rs
@@ -15,11 +15,12 @@ use wiremock::matchers::{header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use aionui_db::{
-    SqliteClientPreferenceRepository, SqliteProviderRepository, SqliteSettingsRepository, init_database_memory,
+    SqliteClientPreferenceRepository, SqliteFeedbackDiagnosticsRepository, SqliteProviderRepository,
+    SqliteSettingsRepository, init_database_memory,
 };
 use aionui_system::{
-    ClientPrefService, ModelFetchService, ProtocolDetectionService, ProviderService, RuntimePrepareService,
-    SettingsService, SystemRouterState, VersionCheckService, system_routes,
+    ClientPrefService, FeedbackDiagnosticsService, ModelFetchService, ProtocolDetectionService, ProviderService,
+    RuntimePrepareService, SettingsService, SystemRouterState, VersionCheckService, system_routes,
 };
 
 // ---------------------------------------------------------------------------
@@ -39,6 +40,9 @@ fn build_state(db: &aionui_db::Database) -> SystemRouterState {
         protocol_detection_service: ProtocolDetectionService::new(http_client.clone()),
         version_check_service: VersionCheckService::new(http_client, "0.1.0".to_owned()),
         runtime_prepare_service: RuntimePrepareService::new(Arc::new(BroadcastEventBus::new(16))),
+        feedback_diagnostics_service: FeedbackDiagnosticsService::new(Arc::new(
+            SqliteFeedbackDiagnosticsRepository::new(db.pool().clone()),
+        )),
     }
 }
 

--- a/crates/aionui-system/tests/provider_routes.rs
+++ b/crates/aionui-system/tests/provider_routes.rs
@@ -14,11 +14,12 @@ use serde_json::json;
 use tower::ServiceExt;
 
 use aionui_db::{
-    SqliteClientPreferenceRepository, SqliteProviderRepository, SqliteSettingsRepository, init_database_memory,
+    SqliteClientPreferenceRepository, SqliteFeedbackDiagnosticsRepository, SqliteProviderRepository,
+    SqliteSettingsRepository, init_database_memory,
 };
 use aionui_system::{
-    ClientPrefService, ModelFetchService, ProtocolDetectionService, ProviderService, RuntimePrepareService,
-    SettingsService, SystemRouterState, VersionCheckService, system_routes,
+    ClientPrefService, FeedbackDiagnosticsService, ModelFetchService, ProtocolDetectionService, ProviderService,
+    RuntimePrepareService, SettingsService, SystemRouterState, VersionCheckService, system_routes,
 };
 
 // ---------------------------------------------------------------------------
@@ -38,6 +39,9 @@ fn build_state(db: &aionui_db::Database) -> SystemRouterState {
         protocol_detection_service: ProtocolDetectionService::new(http_client.clone()),
         version_check_service: VersionCheckService::new(http_client, "0.1.0".to_owned()),
         runtime_prepare_service: RuntimePrepareService::new(Arc::new(BroadcastEventBus::new(16))),
+        feedback_diagnostics_service: FeedbackDiagnosticsService::new(Arc::new(
+            SqliteFeedbackDiagnosticsRepository::new(db.pool().clone()),
+        )),
     }
 }
 

--- a/crates/aionui-system/tests/settings_routes.rs
+++ b/crates/aionui-system/tests/settings_routes.rs
@@ -13,11 +13,12 @@ use http_body_util::BodyExt;
 use tower::ServiceExt;
 
 use aionui_db::{
-    SqliteClientPreferenceRepository, SqliteProviderRepository, SqliteSettingsRepository, init_database_memory,
+    SqliteClientPreferenceRepository, SqliteFeedbackDiagnosticsRepository, SqliteProviderRepository,
+    SqliteSettingsRepository, init_database_memory,
 };
 use aionui_system::{
-    ClientPrefService, ModelFetchService, ProtocolDetectionService, ProviderService, RuntimePrepareService,
-    SettingsService, SystemRouterState, VersionCheckService, settings_routes,
+    ClientPrefService, FeedbackDiagnosticsService, ModelFetchService, ProtocolDetectionService, ProviderService,
+    RuntimePrepareService, SettingsService, SystemRouterState, VersionCheckService, settings_routes,
 };
 
 // ---------------------------------------------------------------------------
@@ -37,6 +38,9 @@ fn build_state(db: &aionui_db::Database) -> SystemRouterState {
         protocol_detection_service: ProtocolDetectionService::new(http_client.clone()),
         version_check_service: VersionCheckService::new(http_client, "0.1.0".to_owned()),
         runtime_prepare_service: RuntimePrepareService::new(Arc::new(BroadcastEventBus::new(16))),
+        feedback_diagnostics_service: FeedbackDiagnosticsService::new(Arc::new(
+            SqliteFeedbackDiagnosticsRepository::new(db.pool().clone()),
+        )),
     }
 }
 

--- a/crates/aionui-system/tests/system_info_routes.rs
+++ b/crates/aionui-system/tests/system_info_routes.rs
@@ -18,11 +18,12 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use aionui_db::{
-    SqliteClientPreferenceRepository, SqliteProviderRepository, SqliteSettingsRepository, init_database_memory,
+    SqliteClientPreferenceRepository, SqliteFeedbackDiagnosticsRepository, SqliteProviderRepository,
+    SqliteSettingsRepository, init_database_memory,
 };
 use aionui_system::{
-    ClientPrefService, ModelFetchService, ProtocolDetectionService, ProviderService, RuntimePrepareService,
-    SettingsService, SystemRouterState, VersionCheckService, system_routes,
+    ClientPrefService, FeedbackDiagnosticsService, ModelFetchService, ProtocolDetectionService, ProviderService,
+    RuntimePrepareService, SettingsService, SystemRouterState, VersionCheckService, system_routes,
 };
 
 // ---------------------------------------------------------------------------
@@ -42,6 +43,9 @@ fn build_state(db: &aionui_db::Database, version_check_service: VersionCheckServ
         protocol_detection_service: ProtocolDetectionService::new(http_client),
         version_check_service,
         runtime_prepare_service: RuntimePrepareService::new(Arc::new(BroadcastEventBus::new(16))),
+        feedback_diagnostics_service: FeedbackDiagnosticsService::new(Arc::new(
+            SqliteFeedbackDiagnosticsRepository::new(db.pool().clone()),
+        )),
     }
 }
 


### PR DESCRIPTION
## Summary
- aionCore provides a feedback diagnostics report API.
- Report generation selects profiles by route/module.
- global-summary includes direct/team recent conversations and recent errors.
- mcp original_json is returned unchanged, and the privacy statement has been updated.

## Verified
- cargo fmt --all -- --check
- cargo test -p aionui-db --test feedback_diagnostics_repository
- cargo test -p aionui-system --test feedback_diagnostics_routes
- cargo clippy -p aionui-db -p aionui-system -- -D warnings
- just push full gate passed: Summary [411.457s] 6661 tests run: 6661 passed (2 slow), 18 skipped