### PR TITLE
feat(agent): use aionrs runtime env API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -680,7 +680,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "walkdir",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -773,7 +773,7 @@ dependencies = [
  "wait-timeout",
  "walkdir",
  "which 7.0.3",
- "zip",
+ "zip 2.4.2",
  "zstd",
 ]
 
@@ -977,6 +977,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "atoi_simd"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cdb3708a128e559a30fb830e8a77a5022ee6902806925c216658652b452a44"
+dependencies = [
+ "debug_unsafe",
+ "rustversion",
 ]
 
 [[package]]
@@ -1593,17 +1603,19 @@ dependencies = [
 
 [[package]]
 name = "calamine"
-version = "0.26.1"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138646b9af2c5d7f1804ea4bf93afc597737d2bd4f7341d67c48b03316976eb1"
+checksum = "6975084f43060e56343ffba7f9731fa52a7dcf2e1cd8e2459fd4c6bf4a1bff59"
 dependencies = [
+ "atoi_simd",
  "byteorder",
  "codepage",
  "encoding_rs",
+ "fast-float2",
  "log",
  "quick-xml",
  "serde",
- "zip",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -1860,9 +1872,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2067,6 +2079,12 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "debug_unsafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
 
 [[package]]
 name = "deflate64"
@@ -2354,6 +2372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2405,6 +2429,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -4005,9 +4030,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "encoding_rs",
  "memchr",
@@ -4409,7 +4434,7 @@ version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61a82de4e7b30fc427909f2c5aafaada88cc7ae8316edabae435f74341f9278"
 dependencies = [
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -5677,6 +5702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6069,7 +6100,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6733,6 +6764,26 @@ dependencies = [
  "zopfli",
  "zstd",
 ]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,8 +117,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.1.38"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.38#fdcf0296fc8a3434688d023d00fc5339c315b557"
+version = "0.2.0"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -142,13 +142,14 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
  "workspace-hack",
 ]
 
 [[package]]
 name = "aion-compact"
-version = "0.1.38"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.38#fdcf0296fc8a3434688d023d00fc5339c315b557"
+version = "0.2.0"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
 dependencies = [
  "regex",
  "serde",
@@ -159,8 +160,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.1.38"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.38#fdcf0296fc8a3434688d023d00fc5339c315b557"
+version = "0.2.0"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
 dependencies = [
  "aion-compact",
  "aion-process",
@@ -184,8 +185,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.1.38"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.38#fdcf0296fc8a3434688d023d00fc5339c315b557"
+version = "0.2.0"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -205,8 +206,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.1.38"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.38#fdcf0296fc8a3434688d023d00fc5339c315b557"
+version = "0.2.0"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
 dependencies = [
  "aion-config",
  "chrono",
@@ -219,8 +220,8 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.1.38"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.38#fdcf0296fc8a3434688d023d00fc5339c315b557"
+version = "0.2.0"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
 dependencies = [
  "libc",
  "tokio",
@@ -230,8 +231,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.1.38"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.38#fdcf0296fc8a3434688d023d00fc5339c315b557"
+version = "0.2.0"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
 dependencies = [
  "aion-types",
  "serde",
@@ -243,8 +244,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.1.38"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.38#fdcf0296fc8a3434688d023d00fc5339c315b557"
+version = "0.2.0"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -271,8 +272,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.1.38"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.38#fdcf0296fc8a3434688d023d00fc5339c315b557"
+version = "0.2.0"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -298,8 +299,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.1.38"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.38#fdcf0296fc8a3434688d023d00fc5339c315b557"
+version = "0.2.0"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -319,8 +320,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.1.38"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.38#fdcf0296fc8a3434688d023d00fc5339c315b557"
+version = "0.2.0"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6068,7 +6069,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6511,7 +6512,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.1.38#fdcf0296fc8a3434688d023d00fc5339c315b557"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
 dependencies = [
  "bitflags",
  "cc",
@@ -6549,6 +6550,7 @@ dependencies = [
  "toml_parser",
  "tracing",
  "tracing-core",
+ "windows-sys 0.52.0",
  "windows-sys 0.61.2",
  "winnow 1.0.2",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,12 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.38" }
-aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.38" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.38" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.38" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.38" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.1.38" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.0" }
+aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.0" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.0" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.0" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.0" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.0" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ open = "5"
 which = "7"
 
 # Office
-calamine = "0.26"
+calamine = "0.36"
 rust_xlsxwriter = "0.82"
 sha1 = "0.10"
 sha2 = "0.10"

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -1,7 +1,5 @@
-use std::ffi::OsString;
-use std::future::Future;
 use std::path::PathBuf;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 use std::time::Duration;
 
 use aion_agent::bootstrap::AgentBootstrap;
@@ -34,7 +32,6 @@ use super::error::aionrs_engine_error_to_send_error;
 pub struct AionrsAgentManager {
     runtime: AgentRuntime,
     engine: Mutex<AgentEngine>,
-    runtime_env: Vec<(String, String)>,
     /// Static slash command metadata captured at bootstrap so UI lookups do
     /// not wait behind an active `engine.run()` turn.
     slash_commands: Vec<SlashCommandItem>,
@@ -62,62 +59,6 @@ impl Drop for AionrsAgentManager {
         // connection. This impl exists to document the intentional Drop-order
         // semantics rather than as a lint escape hatch.
     }
-}
-
-static AIONRS_RUNTIME_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-
-struct RuntimeEnvGuard {
-    previous: Vec<(String, Option<OsString>)>,
-}
-
-impl RuntimeEnvGuard {
-    fn apply(runtime_env: &[(String, String)]) -> Self {
-        let previous = runtime_env
-            .iter()
-            .map(|(key, _)| (key.clone(), std::env::var_os(key)))
-            .collect();
-
-        for (key, value) in runtime_env {
-            // SAFETY: aionrs v0.1.37 has no API for per-command env injection.
-            // AIONRS_RUNTIME_ENV_LOCK serializes all aionrs turns using this bridge,
-            // and the guard restores every changed key when the future completes or
-            // is cancelled.
-            unsafe {
-                std::env::set_var(key, value);
-            }
-        }
-
-        Self { previous }
-    }
-}
-
-impl Drop for RuntimeEnvGuard {
-    fn drop(&mut self) {
-        for (key, value) in self.previous.iter().rev() {
-            // SAFETY: see RuntimeEnvGuard::apply. Restoration happens while the
-            // same process-wide aionrs env lock is still held.
-            unsafe {
-                match value {
-                    Some(value) => std::env::set_var(key, value),
-                    None => std::env::remove_var(key),
-                }
-            }
-        }
-    }
-}
-
-async fn run_with_runtime_env<F, T>(runtime_env: &[(String, String)], future: F) -> T
-where
-    F: Future<Output = T>,
-{
-    if runtime_env.is_empty() {
-        return future.await;
-    }
-
-    let lock = AIONRS_RUNTIME_ENV_LOCK.get_or_init(|| Mutex::new(()));
-    let _lock = lock.lock().await;
-    let _guard = RuntimeEnvGuard::apply(runtime_env);
-    future.await
 }
 
 impl AionrsAgentManager {
@@ -168,7 +109,7 @@ impl AionrsAgentManager {
         let is_resume = resume_session.is_some();
         let provider_label = config.provider_label.clone();
 
-        let mut bootstrap = AgentBootstrap::new(config, &workspace, sink);
+        let mut bootstrap = AgentBootstrap::new(config, &workspace, sink).runtime_env(runtime_env);
         if let Some(session) = resume_session {
             info!(
                 conversation_id = %conversation_id,
@@ -226,7 +167,6 @@ impl AionrsAgentManager {
         Ok(Self {
             runtime,
             engine: Mutex::new(engine),
-            runtime_env,
             slash_commands,
             mcp_managers: result.mcp_managers,
             approval_manager,
@@ -299,7 +239,7 @@ impl crate::agent_task::IAgentTask for AionrsAgentManager {
         let mut engine = self.engine.lock().await;
 
         let result = tokio::select! {
-            res = run_with_runtime_env(&self.runtime_env, engine.run(&data.content, &data.msg_id)) => Some(res),
+            res = engine.run(&data.content, &data.msg_id) => Some(res),
             _ = self.cancel_notify.notified() => {
                 info!(
                     conversation_id = %self.runtime.conversation_id(),
@@ -555,30 +495,6 @@ mod tests {
             extra_mcp_servers: std::collections::HashMap::new(),
             bedrock_config: None,
             runtime_env: Vec::new(),
-        }
-    }
-
-    #[tokio::test]
-    async fn run_with_runtime_env_sets_values_during_future_and_restores_after() {
-        const KEY: &str = "AIONUI_TEST_RUNTIME_ENV_BRIDGE";
-        let original = std::env::var_os(KEY);
-        unsafe {
-            std::env::set_var(KEY, "original");
-        }
-
-        let observed = run_with_runtime_env(&[(KEY.to_owned(), "in-turn".to_owned())], async {
-            std::env::var(KEY).unwrap()
-        })
-        .await;
-
-        assert_eq!(observed, "in-turn");
-        assert_eq!(std::env::var(KEY).unwrap(), "original");
-
-        unsafe {
-            match original {
-                Some(value) => std::env::set_var(KEY, value),
-                None => std::env::remove_var(KEY),
-            }
         }
     }
 

--- a/crates/aionui-ai-agent/src/services/provider_health.rs
+++ b/crates/aionui-ai-agent/src/services/provider_health.rs
@@ -219,6 +219,7 @@ async fn build_probe_engine(config_extra: AionrsResolvedConfig) -> Result<AgentE
     }
 
     AgentBootstrap::new(config, workspace, sink)
+        .runtime_env(config_extra.runtime_env)
         .build()
         .await
         .map(|result| result.engine)

--- a/crates/aionui-office/src/conversion.rs
+++ b/crates/aionui-office/src/conversion.rs
@@ -1,11 +1,14 @@
-use std::path::{Path, PathBuf};
+use std::{
+    io::{Read, Seek},
+    path::{Path, PathBuf},
+};
 
 use aionui_api_types::{
     CellCoord, CellRange, ConversionResultDto, ConversionTarget, DocumentConversionResponse, ExcelSheetData,
     ExcelWorkbookData,
 };
 use aionui_runtime::Builder as CmdBuilder;
-use calamine::{DataType, Reader, Sheets, open_workbook_auto};
+use calamine::{Data, DataType, Range, Reader, Sheets, open_workbook_auto};
 use serde_json::Value;
 use tracing::warn;
 
@@ -153,7 +156,7 @@ fn validate_file_exists(file_path: &str) -> Result<(), OfficeError> {
     Ok(())
 }
 
-fn convert_range_to_2d_array(range: &calamine::Range<calamine::Data>) -> Vec<Vec<Value>> {
+fn convert_range_to_2d_array(range: &Range<Data>) -> Vec<Vec<Value>> {
     let (rows, cols) = range.get_size();
     let mut data = Vec::with_capacity(rows);
 
@@ -170,7 +173,7 @@ fn convert_range_to_2d_array(range: &calamine::Range<calamine::Data>) -> Vec<Vec
     data
 }
 
-fn cell_to_json_value(cell: &calamine::Data) -> Value {
+fn cell_to_json_value(cell: &Data) -> Value {
     if cell.is_empty() {
         return Value::Null;
     }
@@ -191,28 +194,26 @@ fn cell_to_json_value(cell: &calamine::Data) -> Value {
     Value::Null
 }
 
-fn extract_merge_regions<RS: std::io::Read + std::io::Seek>(
-    workbook: &mut Sheets<RS>,
-    sheet_name: &str,
-) -> Option<Vec<CellRange>> {
+fn extract_merge_regions<RS: Read + Seek>(workbook: &mut Sheets<RS>, sheet_name: &str) -> Option<Vec<CellRange>> {
     let xlsx = match workbook {
         Sheets::Xlsx(wb) => wb,
         _ => return None,
     };
 
-    if xlsx.load_merged_regions().is_err() {
-        warn!("failed to load merged regions");
-        return None;
-    }
-
-    let regions = xlsx.merged_regions_by_sheet(sheet_name);
+    let regions = match xlsx.merge_cells_by_sheet_name(sheet_name) {
+        Ok(regions) => regions,
+        Err(_) => {
+            warn!("failed to load merged regions");
+            return None;
+        }
+    };
     if regions.is_empty() {
         return None;
     }
 
     let ranges: Vec<CellRange> = regions
         .into_iter()
-        .map(|(_, _, dim)| CellRange {
+        .map(|dim| CellRange {
             s: CellCoord {
                 r: dim.start.0 as usize,
                 c: dim.start.1 as usize,


### PR DESCRIPTION
Remove the temporary process-wide environment bridge used by AionrsAgentManager. Runtime environment values are now passed into AgentBootstrap::runtime_env so aionrs can inject them into tools, hooks, MCP stdio processes, and sub-agents without serializing every aionrs turn behind a global env lock.

This preserves the existing per-conversation engine mutex, so multiple entries into the same conversation/session remain serialized by the conversation runtime, while different conversations no longer contend on an AionRS_RUNTIME_ENV_LOCK.

Provider health probes also pass the resolved runtime environment into AgentBootstrap, keeping probe behavior consistent with normal aionrs agent construction.

Follow-up required after the aionrs release: update the aionrs git tag/version in Cargo.toml and regenerate Cargo.lock so this branch builds against the released API instead of a local checkout.