### PR TITLE
feat(ai-agent): surface upstream 429 body in AgentSendError detail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,8 +117,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.2.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
+version = "0.2.1"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.1#fcb03933b2c89f56bc3270df8184f137b5f4b471"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -148,8 +148,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.2.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
+version = "0.2.1"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.1#fcb03933b2c89f56bc3270df8184f137b5f4b471"
 dependencies = [
  "regex",
  "serde",
@@ -160,8 +160,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.2.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
+version = "0.2.1"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.1#fcb03933b2c89f56bc3270df8184f137b5f4b471"
 dependencies = [
  "aion-compact",
  "aion-process",
@@ -185,8 +185,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.2.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
+version = "0.2.1"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.1#fcb03933b2c89f56bc3270df8184f137b5f4b471"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -206,8 +206,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.2.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
+version = "0.2.1"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.1#fcb03933b2c89f56bc3270df8184f137b5f4b471"
 dependencies = [
  "aion-config",
  "chrono",
@@ -220,8 +220,8 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.2.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
+version = "0.2.1"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.1#fcb03933b2c89f56bc3270df8184f137b5f4b471"
 dependencies = [
  "libc",
  "tokio",
@@ -231,8 +231,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.2.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
+version = "0.2.1"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.1#fcb03933b2c89f56bc3270df8184f137b5f4b471"
 dependencies = [
  "aion-types",
  "serde",
@@ -244,8 +244,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.2.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
+version = "0.2.1"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.1#fcb03933b2c89f56bc3270df8184f137b5f4b471"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -272,8 +272,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.2.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
+version = "0.2.1"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.1#fcb03933b2c89f56bc3270df8184f137b5f4b471"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -299,8 +299,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.2.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
+version = "0.2.1"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.1#fcb03933b2c89f56bc3270df8184f137b5f4b471"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -320,8 +320,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.2.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
+version = "0.2.1"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.1#fcb03933b2c89f56bc3270df8184f137b5f4b471"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6101,7 +6101,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6544,7 +6544,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.0#e1f50214ef5268bc3d14e7ec6e1b7d603748046f"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.1#fcb03933b2c89f56bc3270df8184f137b5f4b471"
 dependencies = [
  "bitflags",
  "cc",
@@ -6582,6 +6582,7 @@ dependencies = [
  "toml_parser",
  "tracing",
  "tracing-core",
+ "uuid",
  "windows-sys 0.52.0",
  "windows-sys 0.61.2",
  "winnow 1.0.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,12 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.0" }
-aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.0" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.0" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.0" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.0" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.0" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.1" }
+aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.1" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.1" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.1" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.1" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.1" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }

--- a/crates/aionui-ai-agent/src/factory/acp_launch_policy.rs
+++ b/crates/aionui-ai-agent/src/factory/acp_launch_policy.rs
@@ -218,8 +218,10 @@ mod tests {
 
     #[test]
     fn initial_mode_from_build_context_prefers_persisted_snapshot() {
-        let mut snapshot = PersistedSessionState::default();
-        snapshot.current_mode_id = Some(crate::shared_kernel::ModeId::new("full-access"));
+        let snapshot = PersistedSessionState {
+            current_mode_id: Some(crate::shared_kernel::ModeId::new("full-access")),
+            ..Default::default()
+        };
         let config = AcpBuildExtra {
             session_mode: Some("auto".into()),
             ..Default::default()

--- a/crates/aionui-ai-agent/src/manager/aionrs/error.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/error.rs
@@ -35,10 +35,10 @@ pub(super) fn aionrs_engine_error_to_send_error(error: &AionrsAgentError) -> Age
 fn aionrs_provider_error_to_send_error(error: &ProviderError, detail: String) -> AgentSendError {
     match error {
         ProviderError::Api { status, .. } => aionrs_provider_status_to_send_error(*status, detail),
-        ProviderError::RateLimited { .. } => provider_send_error(
+        ProviderError::RateLimited { body, .. } => provider_send_error(
             "The model provider rate limited the request",
             AgentErrorCode::UserLlmProviderRateLimited,
-            detail,
+            append_provider_body(detail, body.as_deref()),
             true,
             AgentErrorResolutionKind::Retry,
             None,
@@ -181,6 +181,19 @@ fn unknown_upstream_send_error(detail: String) -> AgentSendError {
     )
 }
 
+/// Append the raw upstream response body (if any) to the detail string so
+/// the UI's technical-details drawer surfaces provider-specific hints such
+/// as `insufficient_quota`, `payment_required`, or per-endpoint rate-limit
+/// notes. The body is passed through the existing `sanitize_error_detail`
+/// pipeline downstream (redaction + truncation), so no extra scrubbing is
+/// needed here.
+fn append_provider_body(detail: String, body: Option<&str>) -> String {
+    match body.map(str::trim).filter(|b| !b.is_empty()) {
+        Some(body) => format!("{detail}\nProvider response: {body}"),
+        None => detail,
+    }
+}
+
 fn tool_call_failure_send_error(detail: String) -> AgentSendError {
     AgentSendError::new(
         "The upstream Agent repeatedly failed while executing tool calls",
@@ -211,6 +224,77 @@ mod tests {
             Some(aionui_api_types::AgentErrorOwnership::UserLlmProvider)
         );
         assert_eq!(send_error.stream_error().retryable, Some(false));
+    }
+
+    #[test]
+    fn aionrs_provider_rate_limited_appends_response_body_to_detail() {
+        let error = AionrsAgentError::Provider(ProviderError::RateLimited {
+            retry_after_ms: 5000,
+            body: Some(
+                r#"{"error":{"code":"insufficient_quota","message":"You exceeded your current quota"}}"#.to_owned(),
+            ),
+        });
+        let send_error = aionrs_engine_error_to_send_error(&error);
+
+        assert_eq!(
+            send_error.code(),
+            Some(aionui_api_types::AgentErrorCode::UserLlmProviderRateLimited)
+        );
+        let detail = send_error
+            .stream_error()
+            .detail
+            .as_deref()
+            .expect("rate-limited errors must carry a detail");
+        assert!(
+            detail.contains("Provider response: "),
+            "detail should include the provider body marker; got: {detail}"
+        );
+        assert!(
+            detail.contains("insufficient_quota"),
+            "detail should surface the raw provider signal; got: {detail}"
+        );
+    }
+
+    #[test]
+    fn aionrs_provider_rate_limited_without_body_falls_back_to_bare_detail() {
+        let error = AionrsAgentError::Provider(ProviderError::RateLimited {
+            retry_after_ms: 5000,
+            body: None,
+        });
+        let send_error = aionrs_engine_error_to_send_error(&error);
+
+        let detail = send_error
+            .stream_error()
+            .detail
+            .as_deref()
+            .expect("rate-limited errors must carry a detail");
+        assert!(
+            !detail.contains("Provider response:"),
+            "detail must not add the body marker when body is absent; got: {detail}"
+        );
+        assert!(
+            detail.contains("Rate limited"),
+            "detail should still include the base message; got: {detail}"
+        );
+    }
+
+    #[test]
+    fn aionrs_provider_rate_limited_ignores_whitespace_only_body() {
+        let error = AionrsAgentError::Provider(ProviderError::RateLimited {
+            retry_after_ms: 5000,
+            body: Some("   \n\t  ".to_owned()),
+        });
+        let send_error = aionrs_engine_error_to_send_error(&error);
+
+        let detail = send_error
+            .stream_error()
+            .detail
+            .as_deref()
+            .expect("rate-limited errors must carry a detail");
+        assert!(
+            !detail.contains("Provider response:"),
+            "whitespace-only body should be treated as absent; got: {detail}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #590

## Summary

- Bump aionrs deps `v0.1.38` → `v0.2.1` (see companion iOfficeAI/aionrs#197 for the upstream change that retains 429 response bodies).
- In `manager/aionrs/error.rs` extract the body via `ProviderError::RateLimited { body, .. }` and append it to `AgentSendError::detail` so the UI technical-details drawer shows provider-specific hints (e.g. OpenAI `insufficient_quota`, OpenRouter `credit balance is too low`) instead of the current generic "Rate limited, retry after 5000ms".
- The body flows through the existing `sanitize_error_detail` pipeline downstream (secret + header redaction, length truncation), so no extra scrubbing is required at this layer.

## Motivation

Sentry [ELECTRON-3AC](https://iofficeai.sentry.io/issues/132793691/) captured a user-feedback event where the user complained "tokens run out for some reason, it burns through all of my tokens." The attached diagnostics showed 12 `Rate limited, retry after 5000ms` events across three days — with the response body already discarded by `aion-providers` before AionCore could see it. All 429s looked identical, and the UI could only say "temporarily limiting requests, wait a moment." For a user whose OpenRouter free-plan quota was permanently exhausted, that message was misleading.

## Non-goals

Deliberately does **not** classify body contents into a new `UserLlmProviderQuotaExhausted` error code. The current sample (n=12, single provider) is not enough to reliably distinguish "transient throttle" vs "account out of quota" across provider vendors. This PR only surfaces the raw signal; classification is a follow-up once more real Sentry samples with body payloads accumulate.

## Commits

1. `chore(deps): bump aionrs to v0.2.1` — includes a tiny `clippy::field_reassign_with_default` fix in an unrelated test that becomes visible under the new `PersistedSessionState` shape.
2. `feat(ai-agent): surface upstream 429 body in AgentSendError detail` — the actual behavior change + regression tests.

## Test plan

- [x] `cargo test -p aionui-ai-agent` (12 unit tests pass, including 3 new)
- [x] `cargo nextest run --workspace` — 6664/6664 pass (needed `AIONUI_LOG_DIR=` unset because a pre-existing `aionui-system` sysinfo test asserts substring `"aionui"` on the log dir and doesn't isolate env vars — unrelated to this PR).
- [x] `just push` full pre-push gate (migration-check → clippy --fix → fmt → nextest) green.

## Follow-up

Once this ships, watch Sentry for `USER_LLM_PROVIDER_RATE_LIMITED` events. When we have ~30-50 real samples with body payloads across OpenRouter / Groq / OpenAI / etc., we can decide whether to introduce a dedicated `USER_LLM_PROVIDER_QUOTA_EXHAUSTED` error code with `retryable=false` and a "check billing/quota" resolution.