### PR TITLE
fix(model_fetcher): extract first key from multi-line api_key for HTTP requests

### DIFF
--- a/crates/aionui-system/src/model_fetcher/mod.rs
+++ b/crates/aionui-system/src/model_fetcher/mod.rs
@@ -24,12 +24,7 @@ pub(crate) struct FetchConfig {
 /// This avoids sending a multi-line Authorization header, which the HTTP client
 /// rejects.
 fn extract_first_key(api_key: &str) -> String {
-    api_key
-        .split('\n')
-        .next()
-        .unwrap_or(api_key)
-        .trim()
-        .to_string()
+    api_key.split('\n').next().unwrap_or(api_key).trim().to_string()
 }
 
 /// Service for fetching model lists from remote provider APIs.
@@ -320,18 +315,12 @@ mod tests {
 
     #[test]
     fn extract_first_key_multi_key_newline() {
-        assert_eq!(
-            extract_first_key("sk-key1\nsk-key2"),
-            "sk-key1",
-        );
+        assert_eq!(extract_first_key("sk-key1\nsk-key2"), "sk-key1",);
     }
 
     #[test]
     fn extract_first_key_multi_key_trailing_spaces() {
-        assert_eq!(
-            extract_first_key("  sk-key1  \nsk-key2"),
-            "sk-key1",
-        );
+        assert_eq!(extract_first_key("  sk-key1  \nsk-key2"), "sk-key1",);
     }
 
     #[test]

--- a/crates/aionui-system/src/model_fetcher/mod.rs
+++ b/crates/aionui-system/src/model_fetcher/mod.rs
@@ -19,6 +19,19 @@ pub(crate) struct FetchConfig {
     pub bedrock_config: Option<BedrockConfig>,
 }
 
+/// When api_key contains multiple keys separated by newlines (the official
+/// multi-key rotation format), extract only the first key for model fetching.
+/// This avoids sending a multi-line Authorization header, which the HTTP client
+/// rejects.
+fn extract_first_key(api_key: &str) -> String {
+    api_key
+        .split('\n')
+        .next()
+        .unwrap_or(api_key)
+        .trim()
+        .to_string()
+}
+
 /// Service for fetching model lists from remote provider APIs.
 #[derive(Clone)]
 pub struct ModelFetchService {
@@ -59,7 +72,7 @@ impl ModelFetchService {
         let config = FetchConfig {
             platform: req.platform.clone(),
             base_url: req.base_url.clone(),
-            api_key: req.api_key.clone(),
+            api_key: extract_first_key(&req.api_key),
             bedrock_config: req.bedrock_config.clone(),
         };
         self.fetch_with_config(&config, req.try_fix).await
@@ -98,7 +111,7 @@ impl ModelFetchService {
         Ok(FetchConfig {
             platform: row.platform,
             base_url: row.base_url,
-            api_key,
+            api_key: extract_first_key(&api_key),
             bedrock_config,
         })
     }
@@ -296,5 +309,63 @@ mod tests {
             try_fix: false,
         };
         assert!(validate_anonymous_request(&req).is_ok());
+    }
+
+    // ── extract_first_key ─────────────────────────────────────────────
+
+    #[test]
+    fn extract_first_key_single_key() {
+        assert_eq!(extract_first_key("sk-test-key"), "sk-test-key");
+    }
+
+    #[test]
+    fn extract_first_key_multi_key_newline() {
+        assert_eq!(
+            extract_first_key("sk-key1\nsk-key2"),
+            "sk-key1",
+        );
+    }
+
+    #[test]
+    fn extract_first_key_multi_key_trailing_spaces() {
+        assert_eq!(
+            extract_first_key("  sk-key1  \nsk-key2"),
+            "sk-key1",
+        );
+    }
+
+    #[test]
+    fn extract_first_key_empty_fallback() {
+        assert!(extract_first_key("").is_empty());
+    }
+
+    #[test]
+    fn extract_first_key_just_newlines() {
+        assert!(extract_first_key("\n\n\n").is_empty());
+    }
+
+    #[tokio::test]
+    async fn fetch_models_anonymous_multikey_uses_first_key() {
+        let (svc, _db) = setup().await;
+        // Multi-key api_key — must not fail with header parsing error
+        let req = FetchModelsAnonymousRequest {
+            platform: "minimax".into(),
+            base_url: "https://unused".into(),
+            api_key: "fake-key\nanother-key".into(),
+            bedrock_config: None,
+            try_fix: false,
+        };
+        let resp = svc.fetch_models_anonymous(&req).await.unwrap();
+        assert_eq!(resp.models.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn load_config_multi_key_stores_first_key() {
+        let (svc, db) = setup().await;
+        // Save a provider with multi-key api_key
+        let id = create_provider(&db, "openai", "https://api.openai.com", "sk-key1\nsk-key2").await;
+        let config = svc.load_provider_config(&id).await.unwrap();
+        // Must extract only the first key for model fetching
+        assert_eq!(config.api_key, "sk-key1");
     }
 }

--- a/crates/aionui-system/tests/model_fetch_routes.rs
+++ b/crates/aionui-system/tests/model_fetch_routes.rs
@@ -164,6 +164,29 @@ async fn fetch_models_openai_compatible_success() {
 }
 
 #[tokio::test]
+async fn fetch_models_persisted_multi_key_uses_first_key_in_authorization_header() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/models"))
+        .and(header("Authorization", "Bearer first-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{"id": "gpt-4o"}]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let (router, db) = setup().await;
+    let id = create_provider(&db, "openai", &mock_server.uri(), "first-key\nsecond-key").await;
+
+    let req = post_request(&format!("/api/providers/{id}/models"), json!({"try_fix": false}));
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let json = body_json(resp).await;
+    assert_eq!(json["data"]["models"][0], "gpt-4o");
+}
+
+#[tokio::test]
 async fn fetch_models_openai_remote_error() {
     let mock_server = MockServer::start().await;
     Mock::given(method("GET"))
@@ -436,6 +459,35 @@ async fn fetch_models_anonymous_returns_models_for_valid_input() {
     let models = json["data"]["models"].as_array().unwrap();
     assert_eq!(models.len(), 2);
     assert_eq!(models[0], "gpt-4o");
+}
+
+#[tokio::test]
+async fn fetch_models_anonymous_multi_key_uses_first_key_in_authorization_header() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/models"))
+        .and(header("Authorization", "Bearer first-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{"id": "gpt-4o"}]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let (router, _db) = setup().await;
+    let req = post_request(
+        "/api/providers/fetch-models",
+        json!({
+            "platform": "openai",
+            "base_url": mock_server.uri(),
+            "api_key": "first-key\nsecond-key",
+            "try_fix": false
+        }),
+    );
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let json = body_json(resp).await;
+    assert_eq!(json["data"]["models"][0], "gpt-4o");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## 问题

当 `api_key` 包含多个 key（官方多 key 轮询格式 `key1\nkey2`）时，`POST /api/providers/fetch-models` 和 `POST /api/providers/{id}/models` 返回 502。

### 根因

`FetchConfig.api_key` 从请求或数据库解密后直接传入 HTTP Authorization header。多行 key 包含 `\n`，导致 reqwest HTTP 客户端拒绝设置 header，返回 "Invalid authorization header" 错误（0ms 延迟，无网络请求）。

### 修复

添加 `extract_first_key()` 辅助函数，按 `\n` 分割只取第一个 key。在 `fetch_models_anonymous` 和 `load_provider_config` 两处调用。

### 为什么只取第一个 key？

- Model fetching 只需要一个能用的 key 来获取模型列表
- 多 key 轮询由前端 `RotatingApiClient` / `ApiKeyManager` 在 chat 请求层处理（环境变量级轮换）
- `detect-protocol` 端点已有 `test_all_keys: true` 用于多 key 验证

### 测试

新增 7 个测试，全部通过。