### PR TITLE
fix(runtime): update Claude ACP package

### DIFF
--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -1658,7 +1658,7 @@ mod tests {
         );
 
         for managed_binary_missing in [
-            "expected managed Claude ACP platform binary missing: C:\\Users\\user\\AppData\\Roaming\\AionUi\\aionui\\runtime\\acp\\claude-agent-acp\\0.39.0\\win32-x64\\node_modules\\@anthropic-ai\\claude-agent-sdk-win32-x64\\claude.exe",
+            "expected managed Claude ACP platform binary missing: C:\\Users\\user\\AppData\\Roaming\\AionUi\\aionui\\runtime\\acp\\claude-agent-acp\\0.58.1\\win32-x64\\node_modules\\@anthropic-ai\\claude-agent-sdk-win32-x64\\claude.exe",
             "expected managed Codex ACP platform binary missing: C:\\Users\\user\\AppData\\Roaming\\AionUi\\aionui\\runtime\\acp\\codex-acp\\1.1.2\\win32-x64\\node_modules\\@openai\\codex-win32-x64\\vendor\\x86_64-pc-windows-msvc\\bin\\codex.exe",
         ] {
             assert_classification(

--- a/crates/aionui-ai-agent/src/services/availability/mod.rs
+++ b/crates/aionui-ai-agent/src/services/availability/mod.rs
@@ -590,7 +590,7 @@ mod tests {
             args: vec![
                 "x".into(),
                 "--bun".into(),
-                "@agentclientprotocol/claude-agent-acp@0.39.0".into(),
+                "@agentclientprotocol/claude-agent-acp@0.58.1".into(),
             ],
             env: vec![],
             native_skills_dirs: Some(vec![".claude/skills".into()]),

--- a/crates/aionui-app/Cargo.toml
+++ b/crates/aionui-app/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aionui-app"
 version.workspace = true
 edition.workspace = true
+exclude = ["data/**"]
 
 [[bin]]
 name = "aioncore"

--- a/crates/aionui-db/build.rs
+++ b/crates/aionui-db/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=migrations");
+}

--- a/crates/aionui-runtime/src/acp_tool_runtime/types.rs
+++ b/crates/aionui-runtime/src/acp_tool_runtime/types.rs
@@ -21,7 +21,7 @@ impl ManagedAcpToolId {
     pub fn version(self) -> &'static str {
         match self {
             Self::CodexAcp => "1.1.2",
-            Self::ClaudeAgentAcp => "0.39.0",
+            Self::ClaudeAgentAcp => "0.58.1",
         }
     }
 
@@ -225,7 +225,7 @@ mod tests {
     #[test]
     fn managed_acp_tool_versions_match_current_pins() {
         assert_eq!(ManagedAcpToolId::CodexAcp.version(), "1.1.2");
-        assert_eq!(ManagedAcpToolId::ClaudeAgentAcp.version(), "0.39.0");
+        assert_eq!(ManagedAcpToolId::ClaudeAgentAcp.version(), "0.58.1");
     }
 }
 


### PR DESCRIPTION
## Summary
- Update managed Claude ACP from 0.39.0 to 0.58.1.
- Keep Codex ACP aligned with main at 1.1.2.
- Ensure migration file changes rebuild the DB crate and exclude local app runtime data from Cargo package scanning, so watch builds relink aioncore with new migrations.

Related to iOfficeAI/AionUi#3544.

## Verification
- cargo build -p aionui-app --bin aioncore
- strings target/debug/aioncore | rg "020_update_codex|update codex acp package scope"
- cargo fmt -- --check
- cargo test -p aionui-db
- cargo test -p aionui-runtime
- cargo test -p aionui-ai-agent