### PR TITLE
feat(lark): support Lark international domain alongside Feishu

### DIFF
--- a/crates/aionui-api-types/src/channel.rs
+++ b/crates/aionui-api-types/src/channel.rs
@@ -45,6 +45,9 @@ pub struct TestPluginExtraConfig {
     pub app_id: Option<String>,
     #[serde(default)]
     pub app_secret: Option<String>,
+    /// Lark Open Platform domain: `"feishu"` (default) or `"lark"` (international).
+    #[serde(default)]
+    pub domain: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -160,6 +163,10 @@ pub struct PluginStatusResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bot_username: Option<String>,
     pub active_users: i64,
+    /// Lark region ("feishu"/"lark") from the stored config, so the UI can
+    /// restore the selected region after reload. `None` for other platforms.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
 }
 
 /// Result of a plugin credential test.
@@ -458,6 +465,7 @@ mod tests {
             has_token: true,
             bot_username: Some("my_bot".into()),
             active_users: 5,
+            domain: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["plugin_id"], "telegram");
@@ -489,6 +497,7 @@ mod tests {
             has_token: false,
             bot_username: None,
             active_users: 0,
+            domain: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert!(json.get("status").is_none());
@@ -728,6 +737,7 @@ mod tests {
                 has_token: false,
                 bot_username: None,
                 active_users: 0,
+                domain: None,
             },
         };
         let json = serde_json::to_value(&payload).unwrap();
@@ -781,6 +791,7 @@ mod tests {
             has_token: false,
             bot_username: None,
             active_users: 0,
+            domain: None,
         };
         let json = serde_json::to_string(&resp).unwrap();
         let parsed: PluginStatusResponse = serde_json::from_str(&json).unwrap();

--- a/crates/aionui-channel/src/manager.rs
+++ b/crates/aionui-channel/src/manager.rs
@@ -527,6 +527,16 @@ impl ChannelManager {
     fn row_to_status_response(&self, row: &ChannelPluginRow, live_status: Option<String>) -> PluginStatusResponse {
         let is_running = self.plugins.contains_key(&row.id);
         let has_token = !row.config.is_empty();
+        // Best-effort: surface the stored Lark region so the UI can restore the
+        // selected domain after reload. Any decrypt/parse failure yields None.
+        let domain = if row.config.is_empty() {
+            None
+        } else {
+            decrypt_string(&row.config, &self.encryption_key)
+                .ok()
+                .and_then(|json| serde_json::from_str::<PluginConfig>(&json).ok())
+                .and_then(|cfg| cfg.credentials.domain)
+        };
         PluginStatusResponse {
             plugin_id: row.id.clone(),
             plugin_type: row.r#type.clone(),
@@ -540,6 +550,7 @@ impl ChannelManager {
             has_token,
             bot_username: None,
             active_users: 0,
+            domain,
         }
     }
 
@@ -887,6 +898,7 @@ mod tests {
                 app_secret: None,
                 encrypt_key: None,
                 verification_token: None,
+                domain: None,
                 client_id: None,
                 client_secret: None,
                 account_id: None,

--- a/crates/aionui-channel/src/plugin.rs
+++ b/crates/aionui-channel/src/plugin.rs
@@ -177,6 +177,7 @@ mod tests {
                 app_secret: None,
                 encrypt_key: None,
                 verification_token: None,
+                domain: None,
                 client_id: None,
                 client_secret: None,
                 account_id: None,

--- a/crates/aionui-channel/src/plugins/lark/api.rs
+++ b/crates/aionui-channel/src/plugins/lark/api.rs
@@ -13,8 +13,42 @@ use super::types::{
     WsEndpointResponse,
 };
 
-const LARK_OPEN_API_BASE: &str = "https://open.feishu.cn/open-apis";
-const LARK_BASE: &str = "https://open.feishu.cn";
+/// Lark Open Platform domain — Feishu (China) vs Lark (international).
+///
+/// Feishu and Lark share the same Open Platform API surface; only the host
+/// differs. The active domain is selected from stored credentials.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LarkDomain {
+    Feishu,
+    Lark,
+}
+
+impl LarkDomain {
+    /// Map a stored credential value to a domain.
+    /// Absent or unrecognized => Feishu (backward-compatible default).
+    pub fn from_config(value: Option<&str>) -> Self {
+        match value {
+            Some("lark") => Self::Lark,
+            _ => Self::Feishu,
+        }
+    }
+
+    /// Base host (used e.g. by the WebSocket endpoint request).
+    pub fn base(&self) -> &'static str {
+        match self {
+            Self::Feishu => "https://open.feishu.cn",
+            Self::Lark => "https://open.larksuite.com",
+        }
+    }
+
+    /// Open API base (host + `/open-apis`).
+    pub fn open_api_base(&self) -> &'static str {
+        match self {
+            Self::Feishu => "https://open.feishu.cn/open-apis",
+            Self::Lark => "https://open.larksuite.com/open-apis",
+        }
+    }
+}
 
 /// Token refresh margin — refresh 5 minutes before expiry.
 const TOKEN_REFRESH_MARGIN: Duration = Duration::from_secs(5 * 60);
@@ -40,16 +74,18 @@ pub(crate) struct LarkApi {
     client: Client,
     app_id: String,
     app_secret: String,
+    domain: LarkDomain,
     token_cache: Arc<RwLock<Option<TokenCache>>>,
 }
 
 impl LarkApi {
-    /// Create a new Lark API client.
-    pub fn new(client: Client, app_id: &str, app_secret: &str) -> Self {
+    /// Create a new Lark API client for the given domain (Feishu or Lark).
+    pub fn new(client: Client, app_id: &str, app_secret: &str, domain: LarkDomain) -> Self {
         Self {
             client,
             app_id: app_id.to_string(),
             app_secret: app_secret.to_string(),
+            domain,
             token_cache: Arc::new(RwLock::new(None)),
         }
     }
@@ -72,7 +108,7 @@ impl LarkApi {
 
     /// Request a new tenant access token from Lark.
     async fn refresh_token(&self) -> Result<String, ChannelError> {
-        let url = format!("{LARK_OPEN_API_BASE}/auth/v3/tenant_access_token/internal");
+        let url = format!("{}/auth/v3/tenant_access_token/internal", self.domain.open_api_base());
         let body = TenantAccessTokenRequest {
             app_id: self.app_id.clone(),
             app_secret: self.app_secret.clone(),
@@ -117,7 +153,7 @@ impl LarkApi {
     /// Get bot identity information.
     pub async fn get_bot_info(&self) -> Result<BotInfoData, ChannelError> {
         let token = self.get_token().await?;
-        let url = format!("{LARK_OPEN_API_BASE}/bot/v3/info");
+        let url = format!("{}/bot/v3/info", self.domain.open_api_base());
 
         let resp: BotInfoResponse = self
             .client
@@ -146,7 +182,7 @@ impl LarkApi {
     /// Note: This endpoint uses AppID/AppSecret in the request body for auth,
     /// NOT the Bearer token used by other Lark APIs.
     pub async fn get_ws_endpoint(&self) -> Result<WsEndpointData, ChannelError> {
-        let url = format!("{LARK_BASE}/callback/ws/endpoint");
+        let url = format!("{}/callback/ws/endpoint", self.domain.base());
 
         let body = WsEndpointRequest {
             app_id: self.app_id.clone(),
@@ -190,7 +226,7 @@ impl LarkApi {
     /// Returns the message ID of the sent card.
     pub async fn send_card(&self, chat_id: &str, card_content: &str) -> Result<SendMessageData, ChannelError> {
         let token = self.get_token().await?;
-        let url = format!("{LARK_OPEN_API_BASE}/im/v1/messages?receive_id_type=chat_id");
+        let url = format!("{}/im/v1/messages?receive_id_type=chat_id", self.domain.open_api_base());
 
         debug!(chat_id, "Sending Lark card message");
 
@@ -226,7 +262,7 @@ impl LarkApi {
     /// Update (patch) an existing interactive card message.
     pub async fn update_card(&self, message_id: &str, card_content: &str) -> Result<(), ChannelError> {
         let token = self.get_token().await?;
-        let url = format!("{LARK_OPEN_API_BASE}/im/v1/messages/{message_id}");
+        let url = format!("{}/im/v1/messages/{message_id}", self.domain.open_api_base());
 
         debug!(message_id, "Updating Lark card message");
 
@@ -265,7 +301,7 @@ mod tests {
     #[test]
     fn api_stores_credentials() {
         let client = Client::new();
-        let api = LarkApi::new(client, "cli_123", "secret_456");
+        let api = LarkApi::new(client, "cli_123", "secret_456", LarkDomain::Feishu);
         assert_eq!(api.app_id, "cli_123");
         assert_eq!(api.app_secret, "secret_456");
     }
@@ -299,5 +335,32 @@ mod tests {
             expires_in: Duration::from_secs(7200),
         };
         assert!(cache.is_expired());
+    }
+
+    // --- Lark / Feishu domain switching (Phase 01) ---
+
+    #[test]
+    fn larkdomain_from_config_maps_values() {
+        assert_eq!(LarkDomain::from_config(Some("lark")), LarkDomain::Lark);
+        assert_eq!(LarkDomain::from_config(Some("feishu")), LarkDomain::Feishu);
+        // Absent => default Feishu (backward-compat with existing users)
+        assert_eq!(LarkDomain::from_config(None), LarkDomain::Feishu);
+        // Unknown value => safe fallback to Feishu
+        assert_eq!(LarkDomain::from_config(Some("bogus")), LarkDomain::Feishu);
+    }
+
+    #[test]
+    fn larkdomain_urls() {
+        assert_eq!(LarkDomain::Feishu.base(), "https://open.feishu.cn");
+        assert_eq!(LarkDomain::Feishu.open_api_base(), "https://open.feishu.cn/open-apis");
+        assert_eq!(LarkDomain::Lark.base(), "https://open.larksuite.com");
+        assert_eq!(LarkDomain::Lark.open_api_base(), "https://open.larksuite.com/open-apis");
+    }
+
+    #[test]
+    fn api_stores_domain() {
+        let client = Client::new();
+        let api = LarkApi::new(client, "cli_123", "secret_456", LarkDomain::Lark);
+        assert_eq!(api.domain, LarkDomain::Lark);
     }
 }

--- a/crates/aionui-channel/src/plugins/lark/plugin.rs
+++ b/crates/aionui-channel/src/plugins/lark/plugin.rs
@@ -15,7 +15,7 @@ use crate::types::{
     UnifiedAttachment, UnifiedIncomingMessage, UnifiedMessageContent, UnifiedOutgoingMessage, UnifiedUser,
 };
 
-use super::api::LarkApi;
+use super::api::{LarkApi, LarkDomain};
 use super::frame::{
     METHOD_CONTROL, METHOD_DATA, build_ack_frame, build_ping_frame, decode_frame, encode_frame, get_header,
 };
@@ -98,6 +98,9 @@ impl ChannelPlugin for LarkPlugin {
                 ChannelError::InvalidConfig("Missing Lark app_secret".into())
             })?;
 
+        // Select Feishu (default) or Lark (international) domain from stored config.
+        let domain = LarkDomain::from_config(config.credentials.domain.as_deref());
+
         let http_client = Client::builder()
             .timeout(Duration::from_secs(30))
             .build()
@@ -107,7 +110,7 @@ impl ChannelPlugin for LarkPlugin {
                 ChannelError::ConnectionFailed(format!("HTTP client init failed: {e}"))
             })?;
 
-        let api = Arc::new(LarkApi::new(http_client, app_id, app_secret));
+        let api = Arc::new(LarkApi::new(http_client, app_id, app_secret, domain));
 
         // Validate credentials by getting bot info
         let bot_data = api.get_bot_info().await.map_err(|e| {

--- a/crates/aionui-channel/src/plugins/weixin/plugin.rs
+++ b/crates/aionui-channel/src/plugins/weixin/plugin.rs
@@ -552,6 +552,7 @@ mod tests {
                 app_secret: None,
                 encrypt_key: None,
                 verification_token: None,
+                domain: None,
                 client_id: None,
                 client_secret: None,
                 account_id: account_id.map(String::from),

--- a/crates/aionui-channel/src/routes.rs
+++ b/crates/aionui-channel/src/routes.rs
@@ -212,6 +212,8 @@ struct ChannelPluginStatusView {
     bot_username: Option<String>,
     active_users: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
+    domain: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     is_extension: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     extension_meta: Option<ChannelExtensionMetaView>,
@@ -248,6 +250,7 @@ impl ChannelPluginStatusView {
             has_token: status.has_token,
             bot_username: status.bot_username,
             active_users: status.active_users,
+            domain: status.domain,
             is_extension: extension_meta.as_ref().map(|_| true),
             extension_meta,
         }
@@ -267,6 +270,7 @@ impl ChannelPluginStatusView {
             has_token: false,
             bot_username: None,
             active_users: 0,
+            domain: None,
             is_extension: Some(true),
             extension_meta: Some(ChannelExtensionMetaView::from(plugin)),
         }
@@ -286,6 +290,7 @@ impl ChannelPluginStatusView {
             has_token: false,
             bot_username: None,
             active_users: 0,
+            domain: None,
             is_extension: Some(false),
             extension_meta: None,
         }
@@ -690,6 +695,7 @@ fn build_test_config(req: &TestPluginRequest) -> PluginConfig {
         app_secret: None,
         encrypt_key: None,
         verification_token: None,
+        domain: None,
         client_id: None,
         client_secret: None,
         account_id: None,
@@ -702,6 +708,7 @@ fn build_test_config(req: &TestPluginRequest) -> PluginConfig {
             if let Some(ref extra) = req.extra_config {
                 credentials.app_id = extra.app_id.clone();
                 credentials.app_secret = extra.app_secret.clone();
+                credentials.domain = extra.domain.clone();
             }
             credentials.token = Some(req.token.clone());
         }
@@ -774,6 +781,7 @@ fn build_extension_config(
         app_secret: None,
         encrypt_key: None,
         verification_token: None,
+        domain: None,
         client_id: None,
         client_secret: None,
         account_id: None,
@@ -953,12 +961,28 @@ mod tests {
             extra_config: Some(TestPluginExtraConfig {
                 app_id: Some("cli_abc".into()),
                 app_secret: Some("secret".into()),
+                domain: None,
             }),
         };
         let config = build_test_config(&req);
         assert_eq!(config.credentials.app_id.as_deref(), Some("cli_abc"));
         assert_eq!(config.credentials.app_secret.as_deref(), Some("secret"));
         assert_eq!(config.credentials.token.as_deref(), Some("xxx"));
+    }
+
+    #[test]
+    fn build_test_config_lark_maps_domain() {
+        let req = TestPluginRequest {
+            plugin_id: "lark".into(),
+            token: "xxx".into(),
+            extra_config: Some(TestPluginExtraConfig {
+                app_id: Some("cli_abc".into()),
+                app_secret: Some("secret".into()),
+                domain: Some("lark".into()),
+            }),
+        };
+        let config = build_test_config(&req);
+        assert_eq!(config.credentials.domain.as_deref(), Some("lark"));
     }
 
     #[test]
@@ -969,6 +993,7 @@ mod tests {
             extra_config: Some(TestPluginExtraConfig {
                 app_id: None,
                 app_secret: Some("client_secret_456".into()),
+                domain: None,
             }),
         };
         let config = build_test_config(&req);
@@ -984,6 +1009,7 @@ mod tests {
             extra_config: Some(TestPluginExtraConfig {
                 app_id: Some("account_abc".into()),
                 app_secret: None,
+                domain: None,
             }),
         };
         let config = build_test_config(&req);

--- a/crates/aionui-channel/src/types.rs
+++ b/crates/aionui-channel/src/types.rs
@@ -176,6 +176,9 @@ pub struct PluginCredentials {
     pub encrypt_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification_token: Option<String>,
+    /// Lark Open Platform domain: `"feishu"` (default) or `"lark"` (international).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
 
     // DingTalk
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -210,6 +213,7 @@ impl PluginCredentials {
             && self.client_secret.is_none()
             && self.account_id.is_none()
             && self.bot_token.is_none()
+            && self.domain.is_none()
             && self.extra.is_empty()
     }
 }
@@ -599,6 +603,7 @@ mod tests {
             app_secret: None,
             encrypt_key: None,
             verification_token: None,
+            domain: None,
             client_id: None,
             client_secret: None,
             account_id: None,
@@ -619,6 +624,7 @@ mod tests {
             app_secret: Some("secret".into()),
             encrypt_key: Some("ek".into()),
             verification_token: Some("vt".into()),
+            domain: None,
             client_id: None,
             client_secret: None,
             account_id: None,
@@ -641,6 +647,23 @@ mod tests {
         let creds: PluginCredentials = serde_json::from_value(raw).unwrap();
         assert_eq!(creds.token.as_deref(), Some("xxx"));
         assert_eq!(creds.extra.get("customField").unwrap(), "hello");
+    }
+
+    #[test]
+    fn plugin_credentials_lark_domain_roundtrip() {
+        let raw = json!({ "app_id": "cli_abc", "app_secret": "secret", "domain": "lark" });
+        let creds: PluginCredentials = serde_json::from_value(raw).unwrap();
+        // domain must be a first-class field, not swallowed into `extra`
+        assert_eq!(creds.domain.as_deref(), Some("lark"));
+        let json = serde_json::to_value(&creds).unwrap();
+        assert_eq!(json["domain"], "lark");
+    }
+
+    #[test]
+    fn is_empty_considers_domain() {
+        let raw = json!({ "domain": "lark" });
+        let creds: PluginCredentials = serde_json::from_value(raw).unwrap();
+        assert!(!creds.is_empty());
     }
 
     #[test]
@@ -1022,6 +1045,7 @@ mod tests {
                 app_secret: None,
                 encrypt_key: None,
                 verification_token: None,
+                domain: None,
                 client_id: None,
                 client_secret: None,
                 account_id: None,

--- a/crates/aionui-channel/tests/dingtalk_integration.rs
+++ b/crates/aionui-channel/tests/dingtalk_integration.rs
@@ -87,6 +87,7 @@ mod dingtalk_tests {
                 app_secret: None,
                 encrypt_key: None,
                 verification_token: None,
+                domain: None,
                 client_id: client_id.map(String::from),
                 client_secret: client_secret.map(String::from),
                 account_id: None,

--- a/crates/aionui-channel/tests/lark_integration.rs
+++ b/crates/aionui-channel/tests/lark_integration.rs
@@ -86,6 +86,7 @@ mod lark_tests {
                 app_secret: app_secret.map(String::from),
                 encrypt_key: None,
                 verification_token: None,
+                domain: None,
                 client_id: None,
                 client_secret: None,
                 account_id: None,

--- a/crates/aionui-channel/tests/manager_integration.rs
+++ b/crates/aionui-channel/tests/manager_integration.rs
@@ -203,6 +203,7 @@ fn make_plugin_config() -> PluginConfig {
             app_secret: None,
             encrypt_key: None,
             verification_token: None,
+            domain: None,
             client_id: None,
             client_secret: None,
             account_id: None,

--- a/crates/aionui-channel/tests/telegram_integration.rs
+++ b/crates/aionui-channel/tests/telegram_integration.rs
@@ -88,6 +88,7 @@ mod telegram_tests {
                 app_secret: None,
                 encrypt_key: None,
                 verification_token: None,
+                domain: None,
                 client_id: None,
                 client_secret: None,
                 account_id: None,

--- a/crates/aionui-channel/tests/weixin_integration.rs
+++ b/crates/aionui-channel/tests/weixin_integration.rs
@@ -88,6 +88,7 @@ mod weixin_tests {
                 app_secret: None,
                 encrypt_key: None,
                 verification_token: None,
+                domain: None,
                 client_id: None,
                 client_secret: None,
                 account_id: account_id.map(String::from),


### PR DESCRIPTION
## Summary

Support the Lark international domain (`open.larksuite.com`) alongside Feishu (`open.feishu.cn`) in the Lark channel plugin. The domain was previously hardcoded to Feishu, so Lark international apps could not connect (WebSocket long-connection returned `Incorrect domain name`).

## Changes
- Add `domain` (`"feishu"` | `"lark"`) to `PluginCredentials` and `TestPluginExtraConfig`.
- Introduce a `LarkDomain` enum; `LarkApi` is domain-aware (replaces the hardcoded `open.feishu.cn` constants) for token, bot-info, WS endpoint, and message APIs.
- `initialize()` reads the stored domain, defaulting to Feishu for backward compatibility.
- `build_test_config` maps `extra_config.domain` for the lark plugin.
- Expose the stored domain in plugin status (`PluginStatusResponse` + status view) so the UI can restore the selected region after reload.

## Testing
- `cargo test -p aionui-channel -p aionui-api-types --features lark` — all green.
- End-to-end with a real Lark (larksuite) app: bot init succeeds and `Lark WebSocket connected`.

## Compatibility
Default is Feishu, so existing Feishu setups are unaffected. The `lark` module remains behind the `lark` feature.

## Pairs with
Frontend: iOfficeAI/AionUi#3559