### PR TITLE
chore: update aionrs to v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,8 +117,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -148,8 +148,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "regex",
  "serde",
@@ -160,8 +160,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "aion-compact",
  "aion-process",
@@ -185,8 +185,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -206,8 +206,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "aion-config",
  "chrono",
@@ -220,8 +220,8 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "libc",
  "tokio",
@@ -231,8 +231,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "aion-types",
  "serde",
@@ -244,8 +244,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -272,8 +272,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -299,8 +299,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -320,8 +320,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6102,7 +6102,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6545,7 +6545,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "bitflags",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,12 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.2" }
-aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.2" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.2" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.2" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.2" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.2" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
+aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## Summary
- Update AionCore workspace aionrs dependencies from v0.2.2 to v0.2.3.
- Refresh Cargo.lock to resolve aionrs crates at v0.2.3 (e884400a).
- Pulls in the merged aionrs tool-call failure fingerprint fix from iOfficeAI/aionrs#223.

## Related
- iOfficeAI/aionrs#223

## Test Plan
- cargo fmt --all -- --check
- cargo test -p aionui-ai-agent
- cargo clippy -p aionui-ai-agent -- -D warnings
- cargo tree -p aionui-ai-agent -i aion-agent

## Notes
- Tried `just push -u origin chore/update-aionrs-v0.2.3`, but the local workspace has an existing nested `crates/aionui-app/data/conversations/...` path that makes Cargo fail before lint with `File name too long (os error 63)`. The branch was pushed after the targeted checks above passed.