### PR TITLE
feat(diagnostics): expand feedback runtime evidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,8 +117,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -148,8 +148,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "regex",
  "serde",
@@ -160,8 +160,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "aion-compact",
  "aion-process",
@@ -185,8 +185,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -206,8 +206,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "aion-config",
  "chrono",
@@ -220,8 +220,8 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "libc",
  "tokio",
@@ -231,8 +231,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "aion-types",
  "serde",
@@ -244,8 +244,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -272,8 +272,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -299,8 +299,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -320,8 +320,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.2.2"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+version = "0.2.3"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6102,7 +6102,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6545,7 +6545,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.2#1b224090d4888478cf09fbdc9f71531a6f75ba49"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
 dependencies = [
  "bitflags",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -707,6 +708,7 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -833,6 +835,7 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+ "tracing-subscriber",
  "wiremock",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,12 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.2" }
-aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.2" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.2" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.2" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.2" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.2" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
+aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }

--- a/crates/aionui-ai-agent/src/manager/acp/agent_close.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_close.rs
@@ -24,6 +24,25 @@ use crate::protocol::error::CloseReason;
 /// covers a tracing event with its preceding context.
 pub(super) const STDERR_PEEK_LINES: usize = 32;
 
+fn log_acp_process_exit(
+    conversation_id: &str,
+    agent_id: &str,
+    exit_code: Option<i32>,
+    signal: Option<&str>,
+    stderr_summary_present: bool,
+) {
+    tracing::warn!(
+        target: "aionui_feedback_diagnostics",
+        diagnostic_event = "feedback.runtime.acp_process_exit",
+        conversation_id = %conversation_id,
+        agent_id = %agent_id,
+        exit_code,
+        signal = %signal.unwrap_or("none"),
+        stderr_summary_present,
+        "feedback.runtime.acp_process_exit"
+    );
+}
+
 impl AcpAgentManager {
     /// If `err` is the "SDK gave us default Internal error with no data" shape,
     /// peek the child's recent stderr and try to surface a more informative
@@ -86,6 +105,13 @@ impl AcpAgentManager {
             // allowlist. Empty `redacted_summary` is fine —
             // `CloseReason::user_facing_message` omits the trailing colon then.
             let redacted_summary = super::stderr_error_extractor::extract_error_message(&tail).unwrap_or_default();
+            log_acp_process_exit(
+                &self.params.conversation_id,
+                self.agent_id(),
+                exit_code,
+                signal.as_deref(),
+                !redacted_summary.is_empty(),
+            );
             return CloseReason::ProcessExited {
                 exit_code,
                 signal,
@@ -122,6 +148,40 @@ mod tests {
     use crate::error::AgentError;
     use crate::manager::acp::agent::{exit_status_parts, user_facing_message};
     use crate::protocol::error::CloseReason;
+
+    fn capture_logs(max_level: tracing::Level, f: impl FnOnce()) -> String {
+        use std::io::Write;
+        use std::sync::Mutex;
+        use tracing_subscriber::fmt;
+
+        #[derive(Clone)]
+        struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+        impl Write for SharedBuf {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let make_writer = {
+            let buffer = Arc::clone(&buffer);
+            move || SharedBuf(Arc::clone(&buffer))
+        };
+        let subscriber = fmt::Subscriber::builder()
+            .with_max_level(max_level)
+            .with_writer(make_writer)
+            .with_ansi(false)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, f);
+        String::from_utf8(buffer.lock().unwrap().clone()).unwrap()
+    }
 
     /// Spawn a subprocess that writes `stderr_payload` to stderr then
     /// exits with `exit_code`. Used to simulate ACP CLI crashes/exits.
@@ -232,6 +292,27 @@ mod tests {
             }
             other => panic!("expected ProcessExited, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn acp_process_exit_diagnostic_log_uses_stable_contract_without_stderr_payload() {
+        let captured = capture_logs(tracing::Level::INFO, || {
+            super::log_acp_process_exit("conv-acp", "codex", Some(1), None, true);
+        });
+
+        assert!(captured.contains("aionui_feedback_diagnostics"), "{captured}");
+        assert!(captured.contains("feedback.runtime.acp_process_exit"), "{captured}");
+        assert!(captured.contains("conversation_id=conv-acp"), "{captured}");
+        assert!(captured.contains("agent_id=codex"), "{captured}");
+        assert!(
+            captured.contains("exit_code=Some(1)") || captured.contains("exit_code=1"),
+            "{captured}"
+        );
+        assert!(captured.contains("stderr_summary_present=true"), "{captured}");
+        assert!(
+            !captured.contains("raw stderr payload that should be private"),
+            "raw stderr must not be logged: {captured}"
+        );
     }
 
     /// Stderr with no allowlisted keyword must not leak into the toast,

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -28,7 +28,7 @@ use crate::protocol::events::AgentStreamEvent;
 use crate::protocol::send_error::AgentSendError;
 use crate::types::{AionrsResolvedConfig, SendMessageData};
 
-use super::error::aionrs_engine_error_to_send_error;
+use super::error::{aionrs_engine_error_to_send_error, aionrs_runtime_error_summary};
 
 #[derive(Clone, Debug)]
 struct AionrsFinalInputDumpContext {
@@ -375,11 +375,26 @@ impl crate::agent_task::IAgentTask for AionrsAgentManager {
                 Ok(())
             }
             Some(Err(e)) => {
+                let summary = aionrs_runtime_error_summary(&e);
                 error!(
                     conversation_id = %self.runtime.conversation_id(),
                     elapsed_ms,
                     error = %ErrorChain(&e),
                     "Aionrs engine.run() failed, emitting Error"
+                );
+                error!(
+                    target: "aionui_feedback_diagnostics",
+                    diagnostic_event = "feedback.runtime.aionrs_error",
+                    conversation_id = %self.runtime.conversation_id(),
+                    msg_id = %data.msg_id,
+                    turn_id = data.turn_id.as_deref().unwrap_or("none"),
+                    elapsed_ms,
+                    error_kind = summary.kind,
+                    provider_error_class = summary.provider_error_class,
+                    http_status = summary.http_status,
+                    failure_count = summary.failure_count,
+                    failure_limit = summary.failure_limit,
+                    "feedback.runtime.aionrs_error"
                 );
                 let send_error = aionrs_engine_error_to_send_error(&e);
                 self.runtime.emit_error_data(send_error.stream_error().clone());

--- a/crates/aionui-ai-agent/src/manager/aionrs/error.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/error.rs
@@ -32,6 +32,68 @@ pub(super) fn aionrs_engine_error_to_send_error(error: &AionrsAgentError) -> Age
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct AionrsRuntimeErrorSummary {
+    pub(super) kind: &'static str,
+    pub(super) provider_error_class: Option<&'static str>,
+    pub(super) http_status: Option<u16>,
+    pub(super) failure_count: Option<usize>,
+    pub(super) failure_limit: Option<usize>,
+}
+
+impl AionrsRuntimeErrorSummary {
+    fn new(kind: &'static str, provider_error_class: Option<&'static str>) -> Self {
+        Self {
+            kind,
+            provider_error_class,
+            http_status: None,
+            failure_count: None,
+            failure_limit: None,
+        }
+    }
+}
+
+pub(super) fn aionrs_runtime_error_summary(error: &AionrsAgentError) -> AionrsRuntimeErrorSummary {
+    match error {
+        AionrsAgentError::Provider(ProviderError::Api { status, .. }) => AionrsRuntimeErrorSummary {
+            http_status: Some(*status),
+            ..AionrsRuntimeErrorSummary::new("provider", Some("http_status"))
+        },
+        AionrsAgentError::Provider(ProviderError::Connection(_) | ProviderError::Http(_)) => {
+            AionrsRuntimeErrorSummary::new("provider", Some("network"))
+        }
+        AionrsAgentError::Provider(ProviderError::RateLimited { .. }) => AionrsRuntimeErrorSummary {
+            http_status: Some(429),
+            ..AionrsRuntimeErrorSummary::new("provider", Some("rate_limited"))
+        },
+        AionrsAgentError::Provider(ProviderError::PromptTooLong(_)) => {
+            AionrsRuntimeErrorSummary::new("provider", Some("context_too_large"))
+        }
+        AionrsAgentError::Provider(ProviderError::Parse(_)) => {
+            AionrsRuntimeErrorSummary::new("provider", Some("parse"))
+        }
+        AionrsAgentError::ToolCallFailures { count, limit } => AionrsRuntimeErrorSummary {
+            kind: "tool_call_failures",
+            provider_error_class: None,
+            http_status: None,
+            failure_count: Some(*count),
+            failure_limit: Some(*limit),
+        },
+        AionrsAgentError::ToolCallMalformed { count, limit } => AionrsRuntimeErrorSummary {
+            kind: "tool_call_malformed",
+            provider_error_class: None,
+            http_status: None,
+            failure_count: Some(*count),
+            failure_limit: Some(*limit),
+        },
+        AionrsAgentError::ContextTooLong { .. } => {
+            AionrsRuntimeErrorSummary::new("context_too_large", Some("context_too_large"))
+        }
+        AionrsAgentError::ApiError(_) => AionrsRuntimeErrorSummary::new("api_error", None),
+        AionrsAgentError::UserAborted => AionrsRuntimeErrorSummary::new("user_aborted", None),
+    }
+}
+
 fn aionrs_provider_error_to_send_error(error: &ProviderError, detail: String) -> AgentSendError {
     match error {
         ProviderError::Api { status, .. } => aionrs_provider_status_to_send_error(*status, detail),
@@ -313,6 +375,26 @@ mod tests {
             Some(aionui_api_types::AgentErrorOwnership::UserLlmProvider)
         );
         assert_eq!(send_error.stream_error().retryable, Some(true));
+    }
+
+    #[test]
+    fn provider_error_summary_classifies_network_without_body() {
+        let error = AionrsAgentError::Provider(ProviderError::Connection("connect failed".into()));
+        let summary = aionrs_runtime_error_summary(&error);
+
+        assert_eq!(summary.kind, "provider");
+        assert_eq!(summary.provider_error_class, Some("network"));
+        assert_eq!(summary.http_status, None);
+    }
+
+    #[test]
+    fn tool_call_failure_summary_classifies_loop() {
+        let error = AionrsAgentError::ToolCallFailures { count: 3, limit: 3 };
+        let summary = aionrs_runtime_error_summary(&error);
+
+        assert_eq!(summary.kind, "tool_call_failures");
+        assert_eq!(summary.failure_count, Some(3));
+        assert_eq!(summary.failure_limit, Some(3));
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -140,6 +140,8 @@ impl AcpProtocol {
     ) -> Result<Self, AcpError> {
         let alive = Arc::new(AtomicBool::new(true));
         let replay_suppression = Arc::new(AtomicBool::new(false));
+        let started_at = std::time::Instant::now();
+        log_acp_initialize_start();
 
         // Signals from the background task:
         // - `init_tx`: initialize handshake result (with possible SDK error)
@@ -166,16 +168,31 @@ impl AcpProtocol {
         ));
 
         // Wait for init to complete with timeout.
-        let init_response = tokio::time::timeout(std::time::Duration::from_secs(INIT_TIMEOUT_SECS), init_rx)
-            .await
-            .map_err(|_| AcpError::InitTimeout {
-                timeout_secs: INIT_TIMEOUT_SECS,
-            })?
-            .map_err(|_| AcpError::Disconnected {
-                exit_code: None,
-                signal: None,
-                stderr: "Init channel dropped".into(),
-            })??;
+        let init_response = match tokio::time::timeout(std::time::Duration::from_secs(INIT_TIMEOUT_SECS), init_rx).await
+        {
+            Ok(Ok(Ok(response))) => {
+                log_acp_initialize_success(started_at.elapsed().as_millis() as u64);
+                response
+            }
+            Ok(Ok(Err(err))) => {
+                log_acp_initialize_failed("agent_error", started_at.elapsed().as_millis() as u64);
+                return Err(err);
+            }
+            Ok(Err(_)) => {
+                log_acp_initialize_failed("channel_dropped", started_at.elapsed().as_millis() as u64);
+                return Err(AcpError::Disconnected {
+                    exit_code: None,
+                    signal: None,
+                    stderr: "Init channel dropped".into(),
+                });
+            }
+            Err(_) => {
+                log_acp_initialize_failed("timeout", started_at.elapsed().as_millis() as u64);
+                return Err(AcpError::InitTimeout {
+                    timeout_secs: INIT_TIMEOUT_SECS,
+                });
+            }
+        };
 
         // `ready_rx` should resolve almost immediately after init_tx fires.
         let connection = ready_rx.await.map_err(|_| AcpError::NotConnected)?;
@@ -620,6 +637,34 @@ fn string_pointer(value: &serde_json::Value, pointers: &[&str]) -> Option<String
         .map(str::to_owned)
 }
 
+fn log_acp_initialize_start() {
+    info!(
+        target: "aionui_feedback_diagnostics",
+        diagnostic_event = "feedback.runtime.acp_initialize_start",
+        timeout_secs = INIT_TIMEOUT_SECS,
+        "feedback.runtime.acp_initialize_start"
+    );
+}
+
+fn log_acp_initialize_success(elapsed_ms: u64) {
+    info!(
+        target: "aionui_feedback_diagnostics",
+        diagnostic_event = "feedback.runtime.acp_initialize_success",
+        elapsed_ms,
+        "feedback.runtime.acp_initialize_success"
+    );
+}
+
+fn log_acp_initialize_failed(failure_class: &'static str, elapsed_ms: u64) {
+    warn!(
+        target: "aionui_feedback_diagnostics",
+        diagnostic_event = "feedback.runtime.acp_initialize_failed",
+        failure_class = %failure_class,
+        elapsed_ms,
+        "feedback.runtime.acp_initialize_failed"
+    );
+}
+
 /// Log a JSON-RPC request from AionUi to the ACP agent.
 /// `session/prompt` carries large user input and stays at debug.
 fn log_client_request(method: &str, body: &str) {
@@ -904,6 +949,31 @@ mod tests {
             !captured.contains("secret prompt text") && !captured.contains("\"prompt\""),
             "raw prompt body should not be logged: {captured}"
         );
+    }
+
+    #[test]
+    fn acp_initialize_diagnostic_log_helpers_use_stable_contract() {
+        use tracing::Level;
+
+        let captured = capture_logs(Level::INFO, || {
+            super::log_acp_initialize_start();
+            super::log_acp_initialize_success(123);
+            super::log_acp_initialize_failed("timeout", 456);
+        });
+
+        assert!(captured.contains("aionui_feedback_diagnostics"), "{captured}");
+        assert!(captured.contains("feedback.runtime.acp_initialize_start"), "{captured}");
+        assert!(
+            captured.contains("feedback.runtime.acp_initialize_success"),
+            "{captured}"
+        );
+        assert!(
+            captured.contains("feedback.runtime.acp_initialize_failed"),
+            "{captured}"
+        );
+        assert!(captured.contains("timeout_secs=30"), "{captured}");
+        assert!(captured.contains("failure_class=timeout"), "{captured}");
+        assert!(captured.contains("elapsed_ms=456"), "{captured}");
     }
 
     #[test]

--- a/crates/aionui-conversation/Cargo.toml
+++ b/crates/aionui-conversation/Cargo.toml
@@ -27,6 +27,7 @@ thiserror.workspace = true
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 tempfile.workspace = true
+tracing-subscriber.workspace = true
 # Enable the `AgentInstance::Mock` variant so tests can build fake agents
 # through the trait-object escape hatch without spawning real CLI processes.
 aionui-ai-agent = { workspace = true, features = ["test-support"] }

--- a/crates/aionui-conversation/src/session_context.rs
+++ b/crates/aionui-conversation/src/session_context.rs
@@ -109,7 +109,10 @@ impl<'a> SessionContextBuilder<'a> {
         if let Some(override_path) = workspace_override.map(str::trim).filter(|value| !value.is_empty()) {
             let normalized = match validate_workspace_path_availability(override_path) {
                 Ok(normalized) => normalized,
-                Err(error) => return Err(map_runtime_workspace_validation_error(error)),
+                Err(error) => {
+                    log_workspace_path_check(&row.id, &error);
+                    return Err(map_runtime_workspace_validation_error(error));
+                }
             };
             return Ok(WorkspaceContext {
                 path: normalized,
@@ -140,7 +143,10 @@ impl<'a> SessionContextBuilder<'a> {
             {
                 path
             }
-            Err(error) => return Err(map_runtime_workspace_validation_error(error)),
+            Err(error) => {
+                log_workspace_path_check(&row.id, &error);
+                return Err(map_runtime_workspace_validation_error(error));
+            }
         };
 
         Ok(WorkspaceContext {
@@ -496,6 +502,30 @@ fn map_runtime_workspace_validation_error(error: WorkspacePathValidationError) -
     }
 }
 
+fn log_workspace_path_check(conversation_id: &str, error: &WorkspacePathValidationError) {
+    warn!(
+        target: "aionui_feedback_diagnostics",
+        diagnostic_event = "feedback.runtime.workspace_path_check",
+        conversation_id = %conversation_id,
+        path_present = !matches!(error, WorkspacePathValidationError::Empty),
+        path_exists = matches!(
+            error,
+            WorkspacePathValidationError::NotDirectory(_) | WorkspacePathValidationError::NotAccessible { .. }
+        ),
+        error_class = %workspace_error_class(error),
+        "feedback.runtime.workspace_path_check"
+    );
+}
+
+fn workspace_error_class(error: &WorkspacePathValidationError) -> &'static str {
+    match error {
+        WorkspacePathValidationError::Empty => "empty",
+        WorkspacePathValidationError::DoesNotExist(_) => "not_found",
+        WorkspacePathValidationError::NotDirectory(_) => "not_directory",
+        WorkspacePathValidationError::NotAccessible { .. } => "not_accessible",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -503,6 +533,10 @@ mod tests {
         CreateAcpSessionParams, SaveRuntimeStateParams, SqliteAcpSessionRepository, SqliteAgentMetadataRepository,
         UpsertAgentMetadataParams, init_database_memory,
     };
+    use std::io::Write;
+    use std::sync::Mutex;
+    use tracing::Level;
+    use tracing_subscriber::fmt;
 
     struct TestRepos {
         workspace_root: PathBuf,
@@ -514,6 +548,36 @@ mod tests {
         fn builder(&self) -> SessionContextBuilder<'_> {
             SessionContextBuilder::new(&self.workspace_root, &self.metadata_repo, &self.acp_session_repo)
         }
+    }
+
+    #[derive(Clone)]
+    struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn capture_logs(max_level: Level, f: impl FnOnce()) -> String {
+        let buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let make_writer = {
+            let buffer = Arc::clone(&buffer);
+            move || SharedBuf(Arc::clone(&buffer))
+        };
+        let subscriber = fmt::Subscriber::builder()
+            .with_max_level(max_level)
+            .with_writer(make_writer)
+            .with_ansi(false)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, f);
+        String::from_utf8(buffer.lock().unwrap().clone()).unwrap()
     }
 
     async fn setup() -> TestRepos {
@@ -928,6 +992,33 @@ mod tests {
         let context = repos.builder().build(&row).await.unwrap();
         assert!(context.workspace.is_custom);
         assert_eq!(context.workspace.path, custom.to_string_lossy());
+    }
+
+    #[test]
+    fn workspace_validation_failure_logs_redacted_runtime_check() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let raw_path = "/tmp/aionui-secret-workspace-token-12345";
+        let captured = capture_logs(Level::WARN, || {
+            runtime.block_on(async {
+                let repos = setup().await;
+                let row = row("aionrs", serde_json::json!({ "workspace": raw_path }), None);
+
+                let err = repos.builder().build(&row).await.unwrap_err();
+                assert!(matches!(err, ConversationError::WorkspacePathRuntimeUnavailable { .. }));
+            });
+        });
+
+        assert!(captured.contains("aionui_feedback_diagnostics"), "{captured}");
+        assert!(captured.contains("feedback.runtime.workspace_path_check"), "{captured}");
+        assert!(captured.contains("conversation_id=conv-1"), "{captured}");
+        assert!(captured.contains("path_present=true"), "{captured}");
+        assert!(captured.contains("path_exists=false"), "{captured}");
+        assert!(captured.contains("error_class=not_found"), "{captured}");
+        assert!(!captured.contains(raw_path), "{captured}");
+        assert!(!captured.contains("token-12345"), "{captured}");
     }
 
     fn assert_archived(err: ConversationError, expected_id: &str) {

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -203,10 +203,12 @@ impl StreamRelay {
     ) -> RelayOutcome {
         let started_at = now_ms();
         info!(
+            target: "aionui_feedback_diagnostics",
+            diagnostic_event = "feedback.runtime.turn_start",
             conversation_id = %self.conversation_id,
             turn_id = %self.turn_id,
             msg_id = %self.msg_id,
-            "StreamRelay started"
+            "feedback.runtime.turn_start"
         );
 
         let mut full_text_buffer = String::new();
@@ -275,9 +277,14 @@ impl StreamRelay {
                     if !first_agent_event_logged {
                         first_agent_event_logged = true;
                         info!(
-                            event_type = Self::event_kind(&event),
+                            target: "aionui_feedback_diagnostics",
+                            diagnostic_event = "feedback.runtime.turn_first_agent_event",
+                            conversation_id = %self.conversation_id,
+                            turn_id = %self.turn_id,
+                            msg_id = %self.msg_id,
+                            event_type = %Self::event_kind(&event),
                             elapsed_ms = now_ms().saturating_sub(started_at),
-                            "StreamRelay received first agent event"
+                            "feedback.runtime.turn_first_agent_event"
                         );
                     }
 
@@ -293,9 +300,14 @@ impl StreamRelay {
                             if !first_visible_output_logged && !data.content.is_empty() {
                                 first_visible_output_logged = true;
                                 info!(
+                                    target: "aionui_feedback_diagnostics",
+                                    diagnostic_event = "feedback.runtime.turn_first_visible_output",
+                                    conversation_id = %self.conversation_id,
+                                    turn_id = %self.turn_id,
+                                    msg_id = %self.msg_id,
                                     event_type = "Thinking",
                                     elapsed_ms = now_ms().saturating_sub(started_at),
-                                    "StreamRelay received first visible output"
+                                    "feedback.runtime.turn_first_visible_output"
                                 );
                             }
                             if !data.content.is_empty() {
@@ -315,9 +327,14 @@ impl StreamRelay {
                             if !first_visible_output_logged && !data.content.is_empty() {
                                 first_visible_output_logged = true;
                                 info!(
+                                    target: "aionui_feedback_diagnostics",
+                                    diagnostic_event = "feedback.runtime.turn_first_visible_output",
+                                    conversation_id = %self.conversation_id,
+                                    turn_id = %self.turn_id,
+                                    msg_id = %self.msg_id,
                                     event_type = "Text",
                                     elapsed_ms = now_ms().saturating_sub(started_at),
-                                    "StreamRelay received first visible output"
+                                    "feedback.runtime.turn_first_visible_output"
                                 );
                             }
                             if !data.content.is_empty() {
@@ -348,26 +365,22 @@ impl StreamRelay {
                                 "Error"
                             };
                             let terminal = Self::terminal_from_event(&event);
-                            match &terminal {
-                                RelayTerminal::Error { code, retryable } => {
-                                    info!(
-                                        event_type,
-                                        elapsed_ms,
-                                        text_len = full_text_buffer.len(),
-                                        error_code = ?code,
-                                        retryable = ?retryable,
-                                        "StreamRelay received terminal event"
-                                    );
-                                }
-                                RelayTerminal::Finish | RelayTerminal::ChannelClosed => {
-                                    info!(
-                                        event_type,
-                                        elapsed_ms,
-                                        text_len = full_text_buffer.len(),
-                                        "StreamRelay received terminal event"
-                                    );
-                                }
-                            }
+                            info!(
+                                target: "aionui_feedback_diagnostics",
+                                diagnostic_event = "feedback.runtime.turn_terminal",
+                                conversation_id = %self.conversation_id,
+                                turn_id = %self.turn_id,
+                                msg_id = %self.msg_id,
+                                event_type = %event_type,
+                                elapsed_ms,
+                                text_len = full_text_buffer.len(),
+                                error_code = ?terminal.code(),
+                                retryable = ?terminal.retryable(),
+                                saw_visible_output = attempt.saw_visible_output,
+                                saw_tool_or_side_effect = attempt.saw_tool_or_side_effect,
+                                persisted_assistant_output = !full_text_buffer.is_empty(),
+                                "feedback.runtime.turn_terminal"
+                            );
 
                             let defer_clean_error = self.defer_clean_terminal_errors
                                 && matches!(
@@ -482,9 +495,20 @@ impl StreamRelay {
                 Err(broadcast::error::RecvError::Closed) => {
                     let elapsed_ms = now_ms() - started_at;
                     warn!(
+                        target: "aionui_feedback_diagnostics",
+                        diagnostic_event = "feedback.runtime.turn_terminal",
+                        conversation_id = %self.conversation_id,
+                        turn_id = %self.turn_id,
+                        msg_id = %self.msg_id,
+                        event_type = "ChannelClosed",
                         elapsed_ms,
                         text_len = full_text_buffer.len(),
-                        "StreamRelay channel closed without terminal event"
+                        error_code = ?RelayTerminal::ChannelClosed.code(),
+                        retryable = ?RelayTerminal::ChannelClosed.retryable(),
+                        saw_visible_output = attempt.saw_visible_output,
+                        saw_tool_or_side_effect = attempt.saw_tool_or_side_effect,
+                        persisted_assistant_output = !full_text_buffer.is_empty(),
+                        "feedback.runtime.turn_terminal"
                     );
 
                     let deleting = self.is_deleting();
@@ -770,10 +794,43 @@ mod tests {
     use aionui_ai_agent::protocol::events::{ErrorEventData, FinishEventData, TextEventData, ThinkingEventData};
     use aionui_db::DbError;
     use aionui_db::models::MessageRow;
+    use std::io::Write;
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use tracing::Level;
+    use tracing_subscriber::fmt;
 
     // ── run() async tests ─────────────────────────────────────────
+
+    #[derive(Clone)]
+    struct SharedLogBuffer(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedLogBuffer {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().expect("log buffer lock").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn capture_logs(level: Level, f: impl FnOnce()) -> String {
+        let buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let make_writer = {
+            let buffer = Arc::clone(&buffer);
+            move || SharedLogBuffer(Arc::clone(&buffer))
+        };
+        let subscriber = fmt::Subscriber::builder()
+            .with_max_level(level)
+            .with_writer(make_writer)
+            .with_ansi(false)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, f);
+        String::from_utf8(buffer.lock().expect("log buffer lock").clone()).expect("utf8 logs")
+    }
 
     #[derive(Default)]
     struct RecordingSkillResolverForRelay {
@@ -971,6 +1028,47 @@ mod tests {
         let content: serde_json::Value = serde_json::from_str(&msg.content).unwrap();
         assert_eq!(content["content"], "Something went wrong");
         assert_eq!(content["type"], "error");
+    }
+
+    #[test]
+    fn stream_relay_emits_feedback_runtime_terminal_log() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let captured = capture_logs(Level::INFO, || {
+            runtime.block_on(async {
+                let repo = Arc::new(RecordingRepo::new());
+                let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+                let (tx, rx) = broadcast::channel(64);
+
+                let relay = StreamRelay::new(
+                    "conv-1".into(),
+                    "asst-1".into(),
+                    "turn-1".into(),
+                    "user-1".into(),
+                    repo,
+                    bus,
+                );
+
+                tx.send(AgentStreamEvent::Error(ErrorEventData::legacy(
+                    "Something went wrong",
+                    None,
+                )))
+                .unwrap();
+                drop(tx);
+
+                relay.consume(rx).await;
+            });
+        });
+
+        assert!(captured.contains("aionui_feedback_diagnostics"), "{captured}");
+        assert!(captured.contains("feedback.runtime.turn_terminal"), "{captured}");
+        assert!(captured.contains("conversation_id=conv-1"), "{captured}");
+        assert!(captured.contains("turn_id=turn-1"), "{captured}");
+        assert!(captured.contains("msg_id=asst-1"), "{captured}");
+        assert!(captured.contains("event_type=Error"), "{captured}");
+        assert!(captured.contains("text_len=0"), "{captured}");
     }
 
     #[tokio::test]

--- a/crates/aionui-db/src/repository/diagnostics.rs
+++ b/crates/aionui-db/src/repository/diagnostics.rs
@@ -11,6 +11,8 @@ pub enum FeedbackDiagnosticsProfile {
     ModelAuth,
     AgentTeam,
     McpTools,
+    ClientUiSettings,
+    WorkspaceSummary,
     GlobalSummary,
 }
 
@@ -21,6 +23,8 @@ impl FeedbackDiagnosticsProfile {
             Self::ModelAuth => "model-auth",
             Self::AgentTeam => "agent-team",
             Self::McpTools => "mcp-tools",
+            Self::ClientUiSettings => "client-ui-settings",
+            Self::WorkspaceSummary => "workspace-summary",
             Self::GlobalSummary => "global-summary",
         }
     }

--- a/crates/aionui-db/src/repository/sqlite_diagnostics.rs
+++ b/crates/aionui-db/src/repository/sqlite_diagnostics.rs
@@ -159,9 +159,11 @@ impl SqliteFeedbackDiagnosticsRepository {
                 (SELECT COUNT(*) FROM messages m WHERE m.conversation_id = c.id) AS message_count, \
                 (SELECT COUNT(*) FROM messages m WHERE m.conversation_id = c.id AND (m.status = 'error' OR m.type = 'tips' OR (json_valid(m.content) AND json_extract(m.content, '$.error.code') IS NOT NULL))) AS error_message_count, \
                 (SELECT CASE WHEN json_valid(m.content) THEN COALESCE(json_extract(m.content, '$.error.code'), json_extract(m.content, '$.code')) END \
-                   FROM messages m \
+                  FROM messages m \
                   WHERE m.conversation_id = c.id \
                     AND (m.status = 'error' OR m.type = 'tips' OR (json_valid(m.content) AND json_extract(m.content, '$.error.code') IS NOT NULL)) \
+                    AND json_valid(m.content) \
+                    AND COALESCE(json_extract(m.content, '$.error.code'), json_extract(m.content, '$.code')) IS NOT NULL \
                   ORDER BY m.created_at DESC, m.id DESC \
                   LIMIT 1) AS latest_error_code \
              FROM conversations c \
@@ -324,6 +326,55 @@ impl SqliteFeedbackDiagnosticsRepository {
             })
             .collect::<Result<Vec<_>, sqlx::Error>>()?;
 
+        let recent_error_detail_rows = sqlx::query(
+            "SELECT \
+                id, msg_id, type, status, position, hidden, created_at, length(content) AS content_bytes, content, \
+                CASE WHEN json_valid(content) THEN COALESCE(json_extract(content, '$.error.code'), json_extract(content, '$.code')) END AS code, \
+                CASE WHEN json_valid(content) THEN COALESCE(json_extract(content, '$.error.ownership'), json_extract(content, '$.ownership')) END AS ownership, \
+                CASE WHEN json_valid(content) THEN COALESCE(json_extract(content, '$.error.retryable'), json_extract(content, '$.retryable')) END AS retryable \
+             FROM messages \
+             WHERE conversation_id = ? \
+               AND (status = 'error' OR type = 'tips' OR (json_valid(content) AND json_extract(content, '$.error.code') IS NOT NULL)) \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT 10",
+        )
+        .bind(conversation_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let recent_error_details = recent_error_detail_rows
+            .into_iter()
+            .map(|row| {
+                let content = row.try_get::<String, _>("content")?;
+                let content = json_value_or_string(&content);
+                let failure_summary = message_failure_summary(&content);
+                Ok(json!({
+                    "id": row.try_get::<String, _>("id")?,
+                    "msg_id": row.try_get::<Option<String>, _>("msg_id")?,
+                    "type": row.try_get::<String, _>("type")?,
+                    "status": row.try_get::<Option<String>, _>("status")?,
+                    "position": row.try_get::<Option<String>, _>("position")?,
+                    "hidden": row.try_get::<bool, _>("hidden")?,
+                    "created_at": row.try_get::<i64, _>("created_at")?,
+                    "content_bytes": row.try_get::<Option<i64>, _>("content_bytes")?,
+                    "content": content,
+                    "code": row.try_get::<Option<String>, _>("code")?,
+                    "ownership": row.try_get::<Option<String>, _>("ownership")?,
+                    "retryable": sqlite_bool_value(row.try_get::<Option<i64>, _>("retryable")?),
+                    "failure_summary": failure_summary,
+                }))
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()?;
+
+        let failure_summaries = recent_error_details
+            .iter()
+            .filter_map(|item| {
+                item.get("failure_summary")
+                    .filter(|summary| !summary.is_null())
+                    .cloned()
+            })
+            .collect::<Vec<_>>();
+
         Ok(json!({
             "total_count": total_count,
             "total_content_bytes": total_content_bytes,
@@ -332,6 +383,8 @@ impl SqliteFeedbackDiagnosticsRepository {
             "hidden": hidden,
             "recent_messages": recent_messages,
             "recent_errors": recent_errors,
+            "recent_error_details": recent_error_details,
+            "failure_summaries": failure_summaries,
         }))
     }
 
@@ -721,6 +774,161 @@ impl SqliteFeedbackDiagnosticsRepository {
         ))
     }
 
+    async fn collect_client_ui_settings(&self) -> Result<FeedbackDiagnosticsProfileResult, DbError> {
+        let preference_rows = sqlx::query(
+            "SELECT key, value, updated_at \
+             FROM client_preferences \
+             WHERE key LIKE 'appearance.%' \
+                OR key LIKE 'window.%' \
+                OR key LIKE 'display.%' \
+                OR key LIKE 'workspace.%' \
+                OR key LIKE 'settings.%' \
+             ORDER BY updated_at DESC, key ASC \
+             LIMIT 50",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        let preferences = preference_rows
+            .into_iter()
+            .map(|row| {
+                let value = row.try_get::<String, _>("value")?;
+                Ok(json!({
+                    "key": row.try_get::<String, _>("key")?,
+                    "value": json_value_or_string(&value),
+                    "value_bytes": value.len(),
+                    "updated_at": row.try_get::<i64, _>("updated_at")?,
+                }))
+            })
+            .collect::<Result<Vec<_>, sqlx::Error>>()?;
+
+        let settings = sqlx::query(
+            "SELECT language, notification_enabled, cron_notification_enabled, command_queue_enabled, save_upload_to_workspace, updated_at \
+             FROM system_settings \
+             WHERE id = 1",
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let system_settings = if let Some(row) = settings {
+            Some(json!({
+                    "language": row.try_get::<String, _>("language")?,
+                    "notification_enabled": row.try_get::<bool, _>("notification_enabled")?,
+                    "cron_notification_enabled": row.try_get::<bool, _>("cron_notification_enabled")?,
+                    "command_queue_enabled": row.try_get::<bool, _>("command_queue_enabled")?,
+                    "save_upload_to_workspace": row.try_get::<bool, _>("save_upload_to_workspace")?,
+                    "updated_at": row.try_get::<i64, _>("updated_at")?,
+            }))
+        } else {
+            None
+        };
+
+        Ok(profile_result(
+            FeedbackDiagnosticsProfile::ClientUiSettings,
+            "summary",
+            json!({
+                "preferences": {
+                    "limit": 50,
+                    "items": preferences,
+                },
+                "system_settings": system_settings,
+            }),
+        ))
+    }
+
+    async fn collect_workspace_summary(
+        &self,
+        request: &FeedbackDiagnosticsRequest,
+    ) -> Result<FeedbackDiagnosticsProfileResult, DbError> {
+        let Some(conversation_id) = request.context.conversation_id.as_deref() else {
+            return Ok(profile_result(
+                FeedbackDiagnosticsProfile::WorkspaceSummary,
+                "summary",
+                json!({
+                    "conversation": Value::Null,
+                    "team": Value::Null,
+                    "runtime_checks": workspace_runtime_checks_boundary(),
+                }),
+            ));
+        };
+
+        let conversation = sqlx::query(
+            "SELECT \
+                id, name AS title, extra, model, status, source, updated_at, \
+                CASE WHEN json_valid(extra) THEN COALESCE(json_extract(extra, '$.teamId'), json_extract(extra, '$.team_id')) END AS extra_team_id, \
+                CASE WHEN json_valid(extra) THEN COALESCE(json_extract(extra, '$.workspace'), json_extract(extra, '$.workspacePath'), json_extract(extra, '$.workspace_path')) END AS extra_workspace \
+             FROM conversations \
+             WHERE id = ? AND user_id = ?",
+        )
+        .bind(conversation_id)
+        .bind(&request.user_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let Some(conversation) = conversation else {
+            return Ok(profile_result(
+                FeedbackDiagnosticsProfile::WorkspaceSummary,
+                "not_found",
+                json!({
+                    "conversation": Value::Null,
+                    "team": Value::Null,
+                    "runtime_checks": workspace_runtime_checks_boundary(),
+                }),
+            ));
+        };
+
+        let team_id = request.context.team_id.clone().or_else(|| {
+            conversation
+                .try_get::<Option<String>, _>("extra_team_id")
+                .ok()
+                .flatten()
+        });
+
+        let team = if let Some(team_id) = team_id.as_deref() {
+            sqlx::query(
+                "SELECT id, name, workspace, workspace_mode, session_mode, lead_agent_id, updated_at \
+                 FROM teams \
+                 WHERE id = ? AND user_id = ?",
+            )
+            .bind(team_id)
+            .bind(&request.user_id)
+            .fetch_optional(&self.pool)
+            .await?
+            .map(|row| {
+                Ok::<Value, sqlx::Error>(json!({
+                    "team_id": row.try_get::<String, _>("id")?,
+                    "name": row.try_get::<String, _>("name")?,
+                    "workspace": row.try_get::<String, _>("workspace")?,
+                    "workspace_mode": row.try_get::<String, _>("workspace_mode")?,
+                    "session_mode": row.try_get::<Option<String>, _>("session_mode")?,
+                    "lead_agent_id": row.try_get::<Option<String>, _>("lead_agent_id")?,
+                    "updated_at": row.try_get::<i64, _>("updated_at")?,
+                }))
+            })
+            .transpose()?
+        } else {
+            None
+        };
+
+        Ok(profile_result(
+            FeedbackDiagnosticsProfile::WorkspaceSummary,
+            "detail",
+            json!({
+                "conversation": {
+                    "id": conversation.try_get::<String, _>("id")?,
+                    "title": conversation.try_get::<String, _>("title")?,
+                    "status": conversation.try_get::<Option<String>, _>("status")?,
+                    "source": conversation.try_get::<Option<String>, _>("source")?,
+                    "updated_at": conversation.try_get::<i64, _>("updated_at")?,
+                    "extra_team_id": conversation.try_get::<Option<String>, _>("extra_team_id")?,
+                    "extra_workspace": conversation.try_get::<Option<String>, _>("extra_workspace")?,
+                },
+                "team": team,
+                "runtime_checks": workspace_runtime_checks_boundary(),
+            }),
+        ))
+    }
+
     async fn collect_global_summary(
         &self,
         request: &FeedbackDiagnosticsRequest,
@@ -872,9 +1080,11 @@ impl SqliteFeedbackDiagnosticsRepository {
                 (SELECT COUNT(*) FROM messages m WHERE m.conversation_id = c.id) AS message_count, \
                 (SELECT COUNT(*) FROM messages m WHERE m.conversation_id = c.id AND (m.status = 'error' OR m.type = 'tips' OR (json_valid(m.content) AND json_extract(m.content, '$.error.code') IS NOT NULL))) AS error_message_count, \
                 (SELECT CASE WHEN json_valid(m.content) THEN COALESCE(json_extract(m.content, '$.error.code'), json_extract(m.content, '$.code')) END \
-                   FROM messages m \
+                  FROM messages m \
                   WHERE m.conversation_id = c.id \
                     AND (m.status = 'error' OR m.type = 'tips' OR (json_valid(m.content) AND json_extract(m.content, '$.error.code') IS NOT NULL)) \
+                    AND json_valid(m.content) \
+                    AND COALESCE(json_extract(m.content, '$.error.code'), json_extract(m.content, '$.code')) IS NOT NULL \
                   ORDER BY m.created_at DESC, m.id DESC \
                   LIMIT 1) AS latest_error_code, \
                 t.id AS team_row_id, t.name AS team_name, t.workspace_mode AS team_workspace_mode, \
@@ -1058,6 +1268,8 @@ impl SqliteFeedbackDiagnosticsRepository {
             .into_iter()
             .map(|row| {
                 let content = row.try_get::<String, _>("content")?;
+                let content = json_value_or_string(&content);
+                let failure_summary = message_failure_summary(&content);
                 Ok(json!({
                     "id": row.try_get::<String, _>("id")?,
                     "msg_id": row.try_get::<Option<String>, _>("msg_id")?,
@@ -1067,13 +1279,14 @@ impl SqliteFeedbackDiagnosticsRepository {
                     "hidden": row.try_get::<bool, _>("hidden")?,
                     "created_at": row.try_get::<i64, _>("created_at")?,
                     "content_bytes": row.try_get::<Option<i64>, _>("content_bytes")?,
-                    "content": json_value_or_string(&content),
+                    "content": content,
                     "code": row.try_get::<Option<String>, _>("code")?,
                     "ownership": row.try_get::<Option<String>, _>("ownership")?,
                     "retryable": sqlite_bool_value(row.try_get::<Option<i64>, _>("retryable")?),
                     "resolution_kind": row.try_get::<Option<String>, _>("resolution_kind")?,
                     "resolution_target_id": row.try_get::<Option<String>, _>("resolution_target_id")?,
                     "feedback_recommended": sqlite_bool_value(row.try_get::<Option<i64>, _>("feedback_recommended")?),
+                    "failure_summary": failure_summary,
                 }))
             })
             .collect::<Result<Vec<_>, sqlx::Error>>()?;
@@ -1157,6 +1370,9 @@ impl SqliteFeedbackDiagnosticsRepository {
         let items = rows
             .into_iter()
             .map(|row| {
+                let content = row.try_get::<String, _>("content")?;
+                let content = json_value_or_string(&content);
+                let failure_summary = message_failure_summary(&content);
                 Ok(json!({
                     "conversation_id": row.try_get::<String, _>("conversation_id")?,
                     "conversation_title": row.try_get::<String, _>("conversation_title")?,
@@ -1170,13 +1386,14 @@ impl SqliteFeedbackDiagnosticsRepository {
                     "position": row.try_get::<Option<String>, _>("position")?,
                     "created_at": row.try_get::<i64, _>("created_at")?,
                     "content_bytes": row.try_get::<Option<i64>, _>("content_bytes")?,
-                    "content": json_value_or_string(&row.try_get::<String, _>("content")?),
+                    "content": content,
                     "code": row.try_get::<Option<String>, _>("code")?,
                     "ownership": row.try_get::<Option<String>, _>("ownership")?,
                     "retryable": sqlite_bool_value(row.try_get::<Option<i64>, _>("retryable")?),
                     "resolution_kind": row.try_get::<Option<String>, _>("resolution_kind")?,
                     "resolution_target_id": row.try_get::<Option<String>, _>("resolution_target_id")?,
                     "feedback_recommended": sqlite_bool_value(row.try_get::<Option<i64>, _>("feedback_recommended")?),
+                    "failure_summary": failure_summary,
                 }))
             })
             .collect::<Result<Vec<_>, sqlx::Error>>()?;
@@ -1297,6 +1514,8 @@ impl IFeedbackDiagnosticsRepository for SqliteFeedbackDiagnosticsRepository {
                 FeedbackDiagnosticsProfile::ModelAuth => self.collect_model_auth(request).await?,
                 FeedbackDiagnosticsProfile::AgentTeam => self.collect_agent_team(request).await?,
                 FeedbackDiagnosticsProfile::McpTools => self.collect_mcp_tools(request).await?,
+                FeedbackDiagnosticsProfile::ClientUiSettings => self.collect_client_ui_settings().await?,
+                FeedbackDiagnosticsProfile::WorkspaceSummary => self.collect_workspace_summary(request).await?,
                 FeedbackDiagnosticsProfile::GlobalSummary => self.collect_global_summary(request).await?,
             };
             profiles.push(result);
@@ -1329,6 +1548,72 @@ fn sqlite_bool_value(value: Option<i64>) -> Value {
 
 fn json_value_or_string(raw: &str) -> Value {
     serde_json::from_str::<Value>(raw).unwrap_or_else(|_| Value::String(raw.to_owned()))
+}
+
+fn message_failure_summary(content: &Value) -> Option<Value> {
+    let tool_name = content
+        .pointer("/_meta/claudeCode/toolName")
+        .and_then(Value::as_str)
+        .or_else(|| content.pointer("/raw_input/tool").and_then(Value::as_str))
+        .or_else(|| content.pointer("/update/title").and_then(Value::as_str));
+    let exit_code = content
+        .pointer("/_meta/terminal_exit/exit_code")
+        .and_then(Value::as_i64)
+        .or_else(|| extract_exit_code_from_text(content));
+    let error_code = content
+        .pointer("/error/code")
+        .and_then(Value::as_str)
+        .or_else(|| content.pointer("/code").and_then(Value::as_str));
+
+    if tool_name.is_none() && exit_code.is_none() && error_code.is_none() {
+        return None;
+    }
+
+    Some(json!({
+        "kind": if tool_name.is_some() || exit_code.is_some() { "tool" } else { "error" },
+        "tool_name": tool_name,
+        "exit_code": exit_code,
+        "error_code": error_code,
+        "stderr_class": classify_error_text(content),
+        "terminal_id": content.pointer("/_meta/terminal_exit/terminal_id").and_then(Value::as_str),
+        "cwd_present": content.pointer("/_meta/terminal_info/cwd").is_some(),
+    }))
+}
+
+fn extract_exit_code_from_text(value: &Value) -> Option<i64> {
+    let text = value.to_string().to_ascii_lowercase();
+    let marker = "exit code ";
+    let start = text.find(marker)? + marker.len();
+    let digits = text[start..]
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect::<String>();
+    digits.parse().ok()
+}
+
+fn classify_error_text(value: &Value) -> Option<&'static str> {
+    let text = value.to_string().to_ascii_lowercase();
+    if text.contains("command not found") || text.contains("not recognized") {
+        Some("command_not_found")
+    } else if text.contains("permission denied") || text.contains("access is denied") {
+        Some("permission_denied")
+    } else if text.contains("rate limit") || text.contains("too many requests") {
+        Some("rate_limited")
+    } else if text.contains("connection error") || text.contains("network") {
+        Some("network")
+    } else {
+        None
+    }
+}
+
+fn workspace_runtime_checks_boundary() -> Value {
+    json!({
+        "path_exists": Value::Null,
+        "os_errno": Value::Null,
+        "watcher_state": Value::Null,
+        "file_lock_owner": Value::Null,
+        "source": "not-db-backed",
+    })
 }
 
 fn sanitized_message_content(raw: &str) -> Value {

--- a/crates/aionui-db/tests/feedback_diagnostics_repository.rs
+++ b/crates/aionui-db/tests/feedback_diagnostics_repository.rs
@@ -280,9 +280,9 @@ async fn insert_feedback_fixture(db: &aionui_db::Database) {
         json!({
             "error": {
                 "code": "UserLlmProviderAuthFailed",
-                "ownership": "UserLlmProvider",
+                "message": "Provider auth failed",
+                "ownership": "user_llm_provider",
                 "retryable": false,
-                "message": "Missing Authentication header sk-error-secret"
             },
             "resolution": {
                 "kind": "provider_settings",
@@ -296,6 +296,38 @@ async fn insert_feedback_fixture(db: &aionui_db::Database) {
     .bind("error")
     .bind(false)
     .bind(4200_i64)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO messages \
+            (id, conversation_id, msg_id, type, content, position, status, hidden, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("msg-tool-failure")
+    .bind("conv-auth")
+    .bind("turn-tool-failure")
+    .bind("acp_tool_call")
+    .bind(
+        json!({
+            "_meta": {
+                "claudeCode": {"toolName": "Bash"},
+                "terminal_exit": {"exit_code": 127, "terminal_id": "call-tool-1"},
+                "terminal_info": {"cwd": "/tmp/workspace"}
+            },
+            "update": {
+                "content": [{
+                    "content": {"text": "Exit code 127\npython.exe: command not found"}
+                }]
+            }
+        })
+        .to_string(),
+    )
+    .bind("center")
+    .bind("error")
+    .bind(false)
+    .bind(ANCHOR_UPDATED_AT + 500)
     .execute(pool)
     .await
     .unwrap();
@@ -480,6 +512,39 @@ async fn insert_feedback_fixture(db: &aionui_db::Database) {
         .unwrap();
     }
 
+    sqlx::query(
+        "INSERT INTO client_preferences (key, value, updated_at) VALUES (?, ?, ?) \
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+    )
+    .bind("appearance.uiScale")
+    .bind("1.25")
+    .bind(ANCHOR_UPDATED_AT + 100)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO system_settings \
+            (id, language, notification_enabled, cron_notification_enabled, command_queue_enabled, save_upload_to_workspace, updated_at) \
+         VALUES (1, ?, ?, ?, ?, ?, ?) \
+         ON CONFLICT(id) DO UPDATE SET \
+            language = excluded.language, \
+            notification_enabled = excluded.notification_enabled, \
+            cron_notification_enabled = excluded.cron_notification_enabled, \
+            command_queue_enabled = excluded.command_queue_enabled, \
+            save_upload_to_workspace = excluded.save_upload_to_workspace, \
+            updated_at = excluded.updated_at",
+    )
+    .bind("zh-CN")
+    .bind(true)
+    .bind(false)
+    .bind(true)
+    .bind(true)
+    .bind(ANCHOR_UPDATED_AT + 101)
+    .execute(pool)
+    .await
+    .unwrap();
+
     for (conversation_id, definition_id, assistant_id, resolved_model_id, thought_level) in [
         (
             "conv-auth",
@@ -608,9 +673,24 @@ async fn collects_conversation_auth_signals_without_sensitive_payloads() {
     assert_eq!(conversation.data["conversation"]["model_provider_id"], "prov-secret");
     assert_eq!(conversation.data["messages"]["by_type"]["tips"], 1);
     assert_eq!(
-        conversation.data["messages"]["recent_errors"][0]["code"],
+        conversation.data["messages"]["recent_errors"][1]["code"],
         "UserLlmProviderAuthFailed"
     );
+    let selected_error_details = conversation.data["messages"]["recent_error_details"]
+        .as_array()
+        .expect("selected conversation raw error details should be included");
+    assert!(selected_error_details.iter().any(|item| {
+        item["code"] == "UserLlmProviderAuthFailed" && item["content"]["error"]["message"] == "Provider auth failed"
+    }));
+    let summaries = conversation.data["messages"]["failure_summaries"]
+        .as_array()
+        .expect("failure summaries should be included");
+    assert!(summaries.iter().any(|item| {
+        item["kind"] == "tool"
+            && item["tool_name"] == "Bash"
+            && item["exit_code"] == 127
+            && item["stderr_class"] == "command_not_found"
+    }));
     assert_eq!(conversation.data["acp_session"]["current_mode_id"], "build");
     assert_eq!(conversation.data["acp_session"]["config_selections"]["mode"], "plan");
     assert_eq!(
@@ -650,11 +730,9 @@ async fn collects_conversation_auth_signals_without_sensitive_payloads() {
         "sk-extra-secret",
         "sk-prompt-secret",
         "private content",
-        "sk-error-secret",
         "sk-session-secret",
         "sk-agent-args-secret",
         "sk-agent-env-secret",
-        "Missing Authentication header",
         "Nearby raw provider timeout",
         "Old conversation outside feedback window",
     ] {
@@ -776,7 +854,7 @@ async fn global_summary_includes_recent_diagnostics_without_sensitive_payloads()
         .expect("global summary profile should exist");
     assert_eq!(global.mode, "summary");
     assert_eq!(global.data["conversation_count"], 3);
-    assert_eq!(global.data["message_count"], 3);
+    assert_eq!(global.data["message_count"], 4);
     let status_count_total = global.data["conversation_status_counts"]
         .as_array()
         .expect("conversation status counts should be included")
@@ -823,8 +901,8 @@ async fn global_summary_includes_recent_diagnostics_without_sensitive_payloads()
     assert_eq!(teams[0]["lead_agent_id"], "opencode");
     assert_eq!(teams[0]["agent_count"], 2);
     assert_eq!(teams[0]["conversation_count"], 1);
-    assert_eq!(teams[0]["message_count"], 2);
-    assert_eq!(teams[0]["error_message_count"], 1);
+    assert_eq!(teams[0]["message_count"], 3);
+    assert_eq!(teams[0]["error_message_count"], 2);
 
     let team_conversations = teams[0]["conversations"]["items"]
         .as_array()
@@ -837,32 +915,55 @@ async fn global_summary_includes_recent_diagnostics_without_sensitive_payloads()
     assert_eq!(team_conversations[0]["slot_id"], "slot-1");
     assert_eq!(team_conversations[0]["assistant_id"], "assistant-team");
     assert_eq!(team_conversations[0]["latest_error_code"], "UserLlmProviderAuthFailed");
+    let team_recent_errors = team_conversations[0]["recent_errors"]
+        .as_array()
+        .expect("team conversation recent errors should be included");
+    assert!(team_recent_errors.iter().any(|item| {
+        item["failure_summary"]["kind"] == "tool"
+            && item["failure_summary"]["tool_name"] == "Bash"
+            && item["failure_summary"]["exit_code"] == 127
+    }));
     assert_eq!(
-        team_conversations[0]["recent_errors"][0]["content"]["error"]["message"],
-        "Missing Authentication header sk-error-secret"
+        team_recent_errors
+            .iter()
+            .find(|item| item["code"] == "UserLlmProviderAuthFailed")
+            .expect("provider auth error should be present")["content"]["error"]["message"],
+        "Provider auth failed"
     );
     assert_eq!(
         team_conversations[0]["recent_messages"][0]["content"]["text"]["redacted"],
         true
     );
-    assert_eq!(team_conversations[0]["message_count"], 2);
+    assert_eq!(team_conversations[0]["message_count"], 3);
 
     let recent_errors = global.data["recent_errors"]["items"]
         .as_array()
         .expect("recent errors should be included");
-    assert_eq!(recent_errors[0]["conversation_id"], "conv-nearby");
+    let nearby_error = recent_errors
+        .iter()
+        .find(|item| item["conversation_id"] == "conv-nearby")
+        .expect("nearby provider error should be included");
     assert_eq!(
-        recent_errors[0]["conversation_title"],
+        nearby_error["conversation_title"],
         "Nearby conversation shown in screenshot"
     );
-    assert_eq!(recent_errors[0]["code"], "NearbyProviderTimeout");
+    assert_eq!(nearby_error["code"], "NearbyProviderTimeout");
     assert_eq!(
-        recent_errors[0]["content"]["error"]["message"],
+        nearby_error["content"]["error"]["message"],
         "Nearby raw provider timeout should not leak"
     );
-    assert_eq!(recent_errors[1]["conversation_id"], "conv-auth");
-    assert_eq!(recent_errors[1]["code"], "UserLlmProviderAuthFailed");
-    assert_eq!(recent_errors[1]["resolution_target_id"], "prov-secret");
+    let tool_failure = recent_errors
+        .iter()
+        .find(|item| item["failure_summary"]["tool_name"] == "Bash")
+        .expect("tool failure summary should be included");
+    assert_eq!(tool_failure["conversation_id"], "conv-auth");
+    assert_eq!(tool_failure["failure_summary"]["stderr_class"], "command_not_found");
+    let auth_error = recent_errors
+        .iter()
+        .find(|item| item["code"] == "UserLlmProviderAuthFailed")
+        .expect("auth provider error should be included");
+    assert_eq!(auth_error["conversation_id"], "conv-auth");
+    assert_eq!(auth_error["resolution_target_id"], "prov-secret");
     assert!(
         recent_errors
             .iter()
@@ -910,4 +1011,62 @@ async fn global_summary_includes_recent_diagnostics_without_sensitive_payloads()
             "global diagnostics response leaked sensitive payload: {secret}"
         );
     }
+}
+
+#[tokio::test]
+async fn client_ui_settings_profile_exports_existing_preferences() {
+    let db = init_database_memory().await.unwrap();
+    insert_feedback_fixture(&db).await;
+    let repo = SqliteFeedbackDiagnosticsRepository::new(db.pool().clone());
+
+    let result = repo
+        .collect_feedback_diagnostics(&FeedbackDiagnosticsRequest {
+            user_id: "system_default_user".to_owned(),
+            profiles: vec![FeedbackDiagnosticsProfile::ClientUiSettings],
+            context: FeedbackDiagnosticsDbContext::default(),
+        })
+        .await
+        .unwrap();
+
+    let profile = result
+        .profiles
+        .iter()
+        .find(|profile| profile.name == "client-ui-settings")
+        .expect("client UI settings profile should exist");
+
+    assert_eq!(profile.mode, "summary");
+    assert_eq!(profile.data["preferences"]["items"][0]["key"], "appearance.uiScale");
+    assert_eq!(profile.data["system_settings"]["language"], "zh-CN");
+    assert_eq!(profile.data["system_settings"]["command_queue_enabled"], true);
+}
+
+#[tokio::test]
+async fn workspace_summary_uses_existing_conversation_and_team_context() {
+    let db = init_database_memory().await.unwrap();
+    insert_feedback_fixture(&db).await;
+    let repo = SqliteFeedbackDiagnosticsRepository::new(db.pool().clone());
+
+    let result = repo
+        .collect_feedback_diagnostics(&FeedbackDiagnosticsRequest {
+            user_id: "system_default_user".to_owned(),
+            profiles: vec![FeedbackDiagnosticsProfile::WorkspaceSummary],
+            context: FeedbackDiagnosticsDbContext {
+                conversation_id: Some("conv-auth".to_owned()),
+                ..FeedbackDiagnosticsDbContext::default()
+            },
+        })
+        .await
+        .unwrap();
+
+    let profile = result
+        .profiles
+        .iter()
+        .find(|profile| profile.name == "workspace-summary")
+        .expect("workspace summary profile should exist");
+
+    assert_eq!(profile.mode, "detail");
+    assert_eq!(profile.data["conversation"]["id"], "conv-auth");
+    assert_eq!(profile.data["team"]["team_id"], "team-1");
+    assert_eq!(profile.data["team"]["workspace"], "/tmp/team-workspace");
+    assert_eq!(profile.data["runtime_checks"]["path_exists"], serde_json::Value::Null);
 }

--- a/crates/aionui-mcp/Cargo.toml
+++ b/crates/aionui-mcp/Cargo.toml
@@ -29,3 +29,4 @@ axum.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
+tracing-subscriber.workspace = true

--- a/crates/aionui-mcp/src/connection_test/mod.rs
+++ b/crates/aionui-mcp/src/connection_test/mod.rs
@@ -17,7 +17,7 @@ use aionui_runtime::{
 };
 use serde::Serialize;
 use tokio::sync::mpsc;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use crate::types::McpServerTransport;
 use protocol::{
@@ -78,13 +78,18 @@ impl McpConnectionTestService {
         runtime_scope_id: Option<&str>,
     ) -> McpConnectionTestResult {
         debug!(name, ?transport, "starting MCP connection test");
-        match transport {
+        let transport_type = mcp_transport_type(transport);
+        let mcp_server_id = runtime_scope_id.unwrap_or(name);
+        log_mcp_transport_start(mcp_server_id, transport_type);
+        let result = match transport {
             McpServerTransport::Stdio { command, args, env } => {
                 self.test_stdio(command, args, env, runtime_scope_id).await
             }
             McpServerTransport::Http { url, headers } => self.test_http(url, headers).await,
             McpServerTransport::Sse { url, headers } => self.test_sse(url, headers).await,
-        }
+        };
+        log_mcp_transport_result(mcp_server_id, transport_type, &result);
+        result
     }
 
     // -- Stdio transport --------------------------------------------------
@@ -473,6 +478,51 @@ fn runtime_resolution_error(message: &str) -> std::io::Error {
     }
 }
 
+fn mcp_transport_type(transport: &McpServerTransport) -> &'static str {
+    match transport {
+        McpServerTransport::Stdio { .. } => "stdio",
+        McpServerTransport::Http { .. } => "http",
+        McpServerTransport::Sse { .. } => "sse",
+    }
+}
+
+fn log_mcp_transport_start(mcp_server_id: &str, transport_type: &str) {
+    info!(
+        target: "aionui_feedback_diagnostics",
+        diagnostic_event = "feedback.runtime.mcp_transport_start",
+        mcp_server_id = %mcp_server_id,
+        transport_type = %transport_type,
+        "feedback.runtime.mcp_transport_start"
+    );
+}
+
+fn log_mcp_transport_result(mcp_server_id: &str, transport_type: &str, result: &McpConnectionTestResult) {
+    let status = if result.success { "success" } else { "error" };
+    let tool_count = result.tools.as_ref().map_or(0, Vec::len);
+    let error_class = result.code.map(classify_mcp_error_code).unwrap_or("none");
+    warn!(
+        target: "aionui_feedback_diagnostics",
+        diagnostic_event = "feedback.runtime.mcp_transport_result",
+        mcp_server_id = %mcp_server_id,
+        transport_type = %transport_type,
+        status = %status,
+        error_class = %error_class,
+        tool_count,
+        "feedback.runtime.mcp_transport_result"
+    );
+}
+
+fn classify_mcp_error_code(code: McpConnectionTestErrorCode) -> &'static str {
+    match code {
+        McpConnectionTestErrorCode::CommandNotFound => "command_not_found",
+        McpConnectionTestErrorCode::CommandPermissionDenied => "permission_denied",
+        McpConnectionTestErrorCode::Timeout => "timeout",
+        McpConnectionTestErrorCode::ProtocolError | McpConnectionTestErrorCode::RpcError => "schema_error",
+        McpConnectionTestErrorCode::ConnectionFailed | McpConnectionTestErrorCode::HttpError => "network",
+        McpConnectionTestErrorCode::CommandStartFailed => "unknown",
+    }
+}
+
 /// Intermediate struct for HTTP transport response parsing.
 struct HttpMcpResponse {
     rpc: JsonRpcResponse,
@@ -483,6 +533,40 @@ struct HttpMcpResponse {
 mod tests {
     use super::*;
     use aionui_realtime::BroadcastEventBus;
+    use std::io::Write;
+    use std::sync::Mutex;
+    use tracing::Level;
+    use tracing_subscriber::fmt;
+
+    #[derive(Clone)]
+    struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn capture_logs(max_level: Level, f: impl FnOnce()) -> String {
+        let buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let make_writer = {
+            let buffer = Arc::clone(&buffer);
+            move || SharedBuf(Arc::clone(&buffer))
+        };
+        let subscriber = fmt::Subscriber::builder()
+            .with_max_level(max_level)
+            .with_writer(make_writer)
+            .with_ansi(false)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, f);
+        String::from_utf8(buffer.lock().unwrap().clone()).unwrap()
+    }
 
     #[test]
     fn service_clone() {
@@ -495,6 +579,36 @@ mod tests {
         let svc = McpConnectionTestService::new(reqwest::Client::new(), Arc::new(BroadcastEventBus::new(16)))
             .with_timeout(Duration::from_secs(5));
         assert_eq!(svc.timeout, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn mcp_transport_diagnostic_logs_use_redacted_contract() {
+        let result = McpConnectionTestResult {
+            success: false,
+            tools: None,
+            error: Some("raw command should not be logged".to_owned()),
+            code: Some(McpConnectionTestErrorCode::CommandNotFound),
+            details: Some(serde_json::json!({"command": "secret-command --token abc"})),
+            needs_auth: None,
+            auth_method: None,
+            www_authenticate: None,
+        };
+
+        let captured = capture_logs(Level::INFO, || {
+            log_mcp_transport_start("server-1", "stdio");
+            log_mcp_transport_result("server-1", "stdio", &result);
+        });
+
+        assert!(captured.contains("aionui_feedback_diagnostics"), "{captured}");
+        assert!(captured.contains("feedback.runtime.mcp_transport_start"), "{captured}");
+        assert!(captured.contains("feedback.runtime.mcp_transport_result"), "{captured}");
+        assert!(captured.contains("mcp_server_id=server-1"), "{captured}");
+        assert!(captured.contains("transport_type=stdio"), "{captured}");
+        assert!(captured.contains("status=error"), "{captured}");
+        assert!(captured.contains("error_class=command_not_found"), "{captured}");
+        assert!(captured.contains("tool_count=0"), "{captured}");
+        assert!(!captured.contains("secret-command"), "{captured}");
+        assert!(!captured.contains("token abc"), "{captured}");
     }
 
     #[cfg(unix)]

--- a/crates/aionui-system/Cargo.toml
+++ b/crates/aionui-system/Cargo.toml
@@ -28,4 +28,5 @@ tower = { workspace = true }
 http-body-util.workspace = true
 reqwest.workspace = true
 sqlx.workspace = true
+tracing-subscriber.workspace = true
 wiremock = "0.6"

--- a/crates/aionui-system/src/client_pref.rs
+++ b/crates/aionui-system/src/client_pref.rs
@@ -1,7 +1,9 @@
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use aionui_api_types::{ClientPreferencesResponse, UpdateClientPreferencesRequest};
 use aionui_db::IClientPreferenceRepository;
+use tracing::{debug, info};
 
 use crate::error::SystemError;
 
@@ -27,11 +29,31 @@ impl ClientPrefService {
         }
         .map_err(|e| SystemError::Internal(format!("Failed to get preferences: {e}")))?;
 
+        let mut found_keys = BTreeSet::new();
         let mut map = ClientPreferencesResponse::new();
         for row in rows {
             let value: serde_json::Value =
                 serde_json::from_str(&row.value).unwrap_or(serde_json::Value::String(row.value));
+            found_keys.insert(row.key.clone());
+            debug!(
+                target: "aionui_feedback_diagnostics",
+                diagnostic_event = "feedback.runtime.client_preference_read",
+                key = %row.key,
+                found = true,
+                "feedback.runtime.client_preference_read"
+            );
             map.insert(row.key, value);
+        }
+        if let Some(keys) = keys {
+            for key in keys.iter().filter(|key| !found_keys.contains(**key)) {
+                debug!(
+                    target: "aionui_feedback_diagnostics",
+                    diagnostic_event = "feedback.runtime.client_preference_read",
+                    key = %key,
+                    found = false,
+                    "feedback.runtime.client_preference_read"
+                );
+            }
         }
         Ok(map)
     }
@@ -45,13 +67,27 @@ impl ClientPrefService {
             validate_key(&key)?;
 
             if value.is_null() {
+                info!(
+                    target: "aionui_feedback_diagnostics",
+                    diagnostic_event = "feedback.runtime.client_preference_write",
+                    key = %key,
+                    value_type = %"null",
+                    value_bytes = 0,
+                    "feedback.runtime.client_preference_write"
+                );
                 deletes.push(key);
             } else {
-                upserts.push((
-                    key,
-                    serde_json::to_string(&value)
-                        .map_err(|e| SystemError::Internal(format!("Failed to serialize value: {e}")))?,
-                ));
+                let serialized = serde_json::to_string(&value)
+                    .map_err(|e| SystemError::Internal(format!("Failed to serialize value: {e}")))?;
+                info!(
+                    target: "aionui_feedback_diagnostics",
+                    diagnostic_event = "feedback.runtime.client_preference_write",
+                    key = %key,
+                    value_type = %json_value_type(&value),
+                    value_bytes = serialized.len(),
+                    "feedback.runtime.client_preference_write"
+                );
+                upserts.push((key, serialized));
             }
         }
 
@@ -75,6 +111,17 @@ impl ClientPrefService {
     }
 }
 
+fn json_value_type(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
 fn validate_key(key: &str) -> Result<(), SystemError> {
     if key.is_empty() {
         return Err(SystemError::BadRequest("Preference key must not be empty".into()));
@@ -92,6 +139,49 @@ mod tests {
     use super::*;
     use aionui_db::{SqliteClientPreferenceRepository, init_database_memory};
     use serde_json::json;
+    use std::io::Write;
+    use std::sync::{Mutex, Once, OnceLock};
+    use tracing::Level;
+    use tracing_subscriber::fmt;
+
+    #[derive(Clone)]
+    struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    static LOG_CAPTURE_INIT: Once = Once::new();
+    static LOG_CAPTURE_LOCK: Mutex<()> = Mutex::new(());
+    static LOG_CAPTURE_BUFFER: OnceLock<Arc<Mutex<Vec<u8>>>> = OnceLock::new();
+
+    fn capture_logs(max_level: Level, f: impl FnOnce()) -> String {
+        let _capture_guard = LOG_CAPTURE_LOCK.lock().unwrap();
+        let buffer = Arc::clone(LOG_CAPTURE_BUFFER.get_or_init(|| Arc::new(Mutex::new(Vec::<u8>::new()))));
+        buffer.lock().unwrap().clear();
+        let make_writer = {
+            let buffer = Arc::clone(&buffer);
+            move || SharedBuf(Arc::clone(&buffer))
+        };
+        LOG_CAPTURE_INIT.call_once(|| {
+            let subscriber = fmt::Subscriber::builder()
+                .with_max_level(max_level)
+                .with_writer(make_writer)
+                .with_ansi(false)
+                .finish();
+            tracing::subscriber::set_global_default(subscriber).expect("set global test subscriber");
+        });
+
+        f();
+        String::from_utf8(buffer.lock().unwrap().clone()).unwrap()
+    }
 
     async fn setup() -> ClientPrefService {
         let db = init_database_memory().await.unwrap();
@@ -188,6 +278,45 @@ mod tests {
         assert_eq!(prefs.len(), 2);
         assert_eq!(prefs["a"], json!(1));
         assert_eq!(prefs["c"], json!(3));
+    }
+
+    #[test]
+    fn client_preference_diagnostic_logs_do_not_include_values() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let captured = capture_logs(Level::DEBUG, || {
+            runtime.block_on(async {
+                let svc = setup().await;
+                let mut req = UpdateClientPreferencesRequest::new();
+                req.insert("appearance.secretTheme".into(), json!("super-secret-value"));
+                req.insert("appearance.deleted".into(), json!(null));
+                svc.update_preferences(req).await.unwrap();
+
+                let _ = svc
+                    .get_preferences(Some(&["appearance.secretTheme", "appearance.missing"]))
+                    .await
+                    .unwrap();
+            });
+        });
+
+        assert!(captured.contains("aionui_feedback_diagnostics"), "{captured}");
+        assert!(
+            captured.contains("feedback.runtime.client_preference_write"),
+            "{captured}"
+        );
+        assert!(
+            captured.contains("feedback.runtime.client_preference_read"),
+            "{captured}"
+        );
+        assert!(captured.contains("key=appearance.secretTheme"), "{captured}");
+        assert!(captured.contains("key=appearance.missing"), "{captured}");
+        assert!(captured.contains("value_type=string"), "{captured}");
+        assert!(captured.contains("value_type=null"), "{captured}");
+        assert!(captured.contains("found=true"), "{captured}");
+        assert!(captured.contains("found=false"), "{captured}");
+        assert!(!captured.contains("super-secret-value"), "{captured}");
     }
 
     #[tokio::test]

--- a/crates/aionui-system/src/diagnostics.rs
+++ b/crates/aionui-system/src/diagnostics.rs
@@ -154,6 +154,12 @@ fn push_route_profiles(
     if route.contains("provider") || route.contains("model") || route.contains("settings") || route.contains("agent") {
         push_profile(selected, seen, FeedbackDiagnosticsProfile::ModelAuth);
     }
+    if route.contains("appearance") || route.contains("display") || route.contains("settings") {
+        push_profile(selected, seen, FeedbackDiagnosticsProfile::ClientUiSettings);
+    }
+    if route.contains("workspace") || route.contains("project") || route.contains("preview") {
+        push_profile(selected, seen, FeedbackDiagnosticsProfile::WorkspaceSummary);
+    }
 }
 
 fn push_module_profiles(
@@ -167,10 +173,17 @@ fn push_module_profiles(
         | "assistant-preset"
         | "channel"
         | "search-history"
-        | "workspace-preview"
-        | "display-desktop"
         | "对话与会话" => {
             push_profile(selected, seen, FeedbackDiagnosticsProfile::ConversationSession);
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::ModelAuth);
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::McpTools);
+        }
+        "display-desktop" => {
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::ClientUiSettings);
+        }
+        "workspace-preview" => {
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::ConversationSession);
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::WorkspaceSummary);
             push_profile(selected, seen, FeedbackDiagnosticsProfile::ModelAuth);
             push_profile(selected, seen, FeedbackDiagnosticsProfile::McpTools);
         }
@@ -202,6 +215,8 @@ fn push_module_profiles(
             push_profile(selected, seen, FeedbackDiagnosticsProfile::AgentTeam);
         }
         "system-settings" | "settings" | "系统设置" => {
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::ClientUiSettings);
+            push_profile(selected, seen, FeedbackDiagnosticsProfile::WorkspaceSummary);
             push_profile(selected, seen, FeedbackDiagnosticsProfile::ModelAuth);
             push_profile(selected, seen, FeedbackDiagnosticsProfile::McpTools);
         }
@@ -225,6 +240,8 @@ fn parse_profile(value: &str) -> Option<FeedbackDiagnosticsProfile> {
         "model-auth" => Some(FeedbackDiagnosticsProfile::ModelAuth),
         "agent-team" => Some(FeedbackDiagnosticsProfile::AgentTeam),
         "mcp-tools" => Some(FeedbackDiagnosticsProfile::McpTools),
+        "client-ui-settings" => Some(FeedbackDiagnosticsProfile::ClientUiSettings),
+        "workspace-summary" => Some(FeedbackDiagnosticsProfile::WorkspaceSummary),
         "global-summary" => Some(FeedbackDiagnosticsProfile::GlobalSummary),
         _ => None,
     }
@@ -349,7 +366,12 @@ mod tests {
             ("search-history", vec![FeedbackDiagnosticsProfile::ConversationSession]),
             (
                 "workspace-preview",
-                vec![FeedbackDiagnosticsProfile::ConversationSession],
+                vec![
+                    FeedbackDiagnosticsProfile::ConversationSession,
+                    FeedbackDiagnosticsProfile::WorkspaceSummary,
+                    FeedbackDiagnosticsProfile::ModelAuth,
+                    FeedbackDiagnosticsProfile::McpTools,
+                ],
             ),
             (
                 "webui-remote",
@@ -372,10 +394,12 @@ mod tests {
                     FeedbackDiagnosticsProfile::ConversationSession,
                 ],
             ),
-            ("display-desktop", vec![FeedbackDiagnosticsProfile::ConversationSession]),
+            ("display-desktop", vec![FeedbackDiagnosticsProfile::ClientUiSettings]),
             (
                 "system-settings",
                 vec![
+                    FeedbackDiagnosticsProfile::ClientUiSettings,
+                    FeedbackDiagnosticsProfile::WorkspaceSummary,
                     FeedbackDiagnosticsProfile::ModelAuth,
                     FeedbackDiagnosticsProfile::McpTools,
                 ],

--- a/crates/aionui-system/tests/feedback_diagnostics_routes.rs
+++ b/crates/aionui-system/tests/feedback_diagnostics_routes.rs
@@ -245,3 +245,47 @@ async fn diagnostics_home_route_uses_module_and_global_summary_context() {
     assert!(!serialized.contains("sk-route-secret"));
     assert!(!serialized.contains("encrypted-sk-route-secret"));
 }
+
+#[tokio::test]
+async fn diagnostics_selects_existing_db_profiles_for_ui_and_workspace_modules() {
+    let (app, _db) = setup().await;
+    let resp = app
+        .clone()
+        .oneshot(diagnostics_request(
+            "/api/system/diagnostics/feedback-report?route_at_submit=%23%2Fsettings%2Fappearance&selected_module=display-desktop",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    let profile_names = json["data"]["profiles"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|profile| profile["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+
+    assert!(profile_names.contains(&"client-ui-settings"));
+    assert!(profile_names.contains(&"global-summary"));
+
+    let resp = app
+        .oneshot(diagnostics_request(
+            "/api/system/diagnostics/feedback-report?route_at_submit=%23%2Fconversation%2Fconv-route&selected_module=workspace-preview",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    let profile_names = json["data"]["profiles"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|profile| profile["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+
+    assert!(profile_names.contains(&"conversation-session"));
+    assert!(profile_names.contains(&"workspace-summary"));
+    assert!(profile_names.contains(&"global-summary"));
+}


### PR DESCRIPTION
## Summary
- Expand feedback diagnostics SQL profiles with client UI settings, workspace summary, recent error details, and failure summaries.
- Add redacted runtime diagnostic logs for stream relay, AionRS, ACP, MCP, client preferences, and workspace validation.
- Add focused repository, route, and log-contract tests for the new diagnostics evidence.

## Related
- Related: #585

## Test Plan
- cargo fmt --all -- --check
- cargo clippy -p aionui-db -p aionui-system -p aionui-conversation -p aionui-ai-agent -p aionui-mcp -- -D warnings
- cargo test -p aionui-db --test feedback_diagnostics_repository
- cargo test -p aionui-system
- cargo test -p aionui-conversation
- cargo test -p aionui-ai-agent
- cargo test -p aionui-mcp
- cargo test --workspace --exclude aionui-app
- just push