### PR TITLE
fix(team): restrict leader runtime tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
-      - uses: rustsec/audit-check@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --version 0.22.2 --locked
+      - name: Run security audit
+        run: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,8 +117,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.4#cb4a10fdbaa0e4d5c5e767b96081cc21eb476a2a"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -148,8 +148,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.4#cb4a10fdbaa0e4d5c5e767b96081cc21eb476a2a"
 dependencies = [
  "regex",
  "serde",
@@ -160,8 +160,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.4#cb4a10fdbaa0e4d5c5e767b96081cc21eb476a2a"
 dependencies = [
  "aion-compact",
  "aion-process",
@@ -185,8 +185,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.4#cb4a10fdbaa0e4d5c5e767b96081cc21eb476a2a"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -206,8 +206,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.4#cb4a10fdbaa0e4d5c5e767b96081cc21eb476a2a"
 dependencies = [
  "aion-config",
  "chrono",
@@ -220,8 +220,8 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.4#cb4a10fdbaa0e4d5c5e767b96081cc21eb476a2a"
 dependencies = [
  "libc",
  "tokio",
@@ -231,8 +231,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.4#cb4a10fdbaa0e4d5c5e767b96081cc21eb476a2a"
 dependencies = [
  "aion-types",
  "serde",
@@ -244,8 +244,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.4#cb4a10fdbaa0e4d5c5e767b96081cc21eb476a2a"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -272,8 +272,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.4#cb4a10fdbaa0e4d5c5e767b96081cc21eb476a2a"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -299,8 +299,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.4#cb4a10fdbaa0e4d5c5e767b96081cc21eb476a2a"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -320,8 +320,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.4#cb4a10fdbaa0e4d5c5e767b96081cc21eb476a2a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6548,7 +6548,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.4#cb4a10fdbaa0e4d5c5e767b96081cc21eb476a2a"
 dependencies = [
  "bitflags",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,12 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
-aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.4" }
+aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.4" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.4" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.4" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.4" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.4" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }

--- a/crates/aionui-ai-agent/src/agent_task.rs
+++ b/crates/aionui-ai-agent/src/agent_task.rs
@@ -534,6 +534,7 @@ mod aionrs_config_option_tests {
             bedrock_config: None,
             runtime_env: Vec::new(),
             prompt_dump_dir: None,
+            tool_policy: Default::default(),
         }
     }
 

--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -17,7 +17,7 @@ use tracing::{debug, info, warn};
 use crate::agent_task::AgentInstance;
 use crate::error::AgentError;
 use crate::factory::AgentFactoryDeps;
-use crate::factory::aionrs_policy::apply_team_runtime_policy;
+use crate::factory::aionrs_policy::team_runtime_tool_policy;
 use crate::factory::context::FactoryContext;
 use crate::manager::aionrs::{AionrsAgentManager, sanitize_session_messages};
 use crate::runtime_status::conversation_runtime_reporter;
@@ -34,7 +34,7 @@ pub(super) async fn build(
         team,
         ..
     } = build_context;
-    let tool_policy = apply_team_runtime_policy(team.as_ref(), &mut overrides);
+    let tool_policy = team_runtime_tool_policy(team.as_ref());
     let resolved_skills = overrides.skills.clone();
 
     // Merge preset assistant rules into system_prompt (used as custom_prompt

--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -17,6 +17,7 @@ use tracing::{debug, info, warn};
 use crate::agent_task::AgentInstance;
 use crate::error::AgentError;
 use crate::factory::AgentFactoryDeps;
+use crate::factory::aionrs_policy::apply_team_runtime_policy;
 use crate::factory::context::FactoryContext;
 use crate::manager::aionrs::{AionrsAgentManager, sanitize_session_messages};
 use crate::runtime_status::conversation_runtime_reporter;
@@ -28,7 +29,12 @@ pub(super) async fn build(
     model: ProviderWithModel,
     ctx: FactoryContext,
 ) -> Result<AgentInstance, AgentError> {
-    let mut overrides = build_context.config;
+    let AionrsSessionBuildContext {
+        config: mut overrides,
+        team,
+        ..
+    } = build_context;
+    let tool_policy = apply_team_runtime_policy(team.as_ref(), &mut overrides);
     let resolved_skills = overrides.skills.clone();
 
     // Merge preset assistant rules into system_prompt (used as custom_prompt
@@ -172,6 +178,7 @@ pub(super) async fn build(
         bedrock_config,
         runtime_env: ctx.runtime_env,
         prompt_dump_dir: crate::dev_prompt_dump::dump_dir_for_data_dir(&deps.data_dir, deps.dump_prompts),
+        tool_policy,
     };
 
     if let Some(system_prompt) = config.system_prompt.as_deref()

--- a/crates/aionui-ai-agent/src/factory/aionrs_policy.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs_policy.rs
@@ -10,7 +10,7 @@ pub(super) fn team_runtime_tool_policy(team: Option<&TeamSessionBinding>) -> Too
         binding
             .role
             .as_deref()
-            .is_some_and(|role| role.eq_ignore_ascii_case("lead"))
+            .is_some_and(|role| role.eq_ignore_ascii_case("lead") || role.eq_ignore_ascii_case("leader"))
     }) else {
         return ToolPolicy::Unrestricted;
     };

--- a/crates/aionui-ai-agent/src/factory/aionrs_policy.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs_policy.rs
@@ -1,0 +1,44 @@
+use aion_agent::tool_policy::ToolPolicy;
+use aionui_api_types::{AionrsBuildExtra, TeamSessionBinding};
+use aionui_team_prompts::visible_team_tool_descriptors;
+use tracing::info;
+
+const TEAM_LEAD_MAX_TURNS: usize = 20;
+const TEAM_LEAD_READ_ONLY_TOOLS: [&str; 3] = ["Read", "Grep", "Glob"];
+
+pub(super) fn apply_team_runtime_policy(
+    team: Option<&TeamSessionBinding>,
+    config: &mut AionrsBuildExtra,
+) -> ToolPolicy {
+    let Some(binding) = team.filter(|binding| {
+        binding
+            .role
+            .as_deref()
+            .is_some_and(|role| role.eq_ignore_ascii_case("lead"))
+    }) else {
+        return ToolPolicy::Unrestricted;
+    };
+
+    config.max_turns = Some(match config.max_turns {
+        Some(limit) if limit > 0 => limit.min(TEAM_LEAD_MAX_TURNS),
+        _ => TEAM_LEAD_MAX_TURNS,
+    });
+    info!(
+        target: "aionui_feedback_diagnostics",
+        event = "feedback.team.lead_runtime_policy_applied",
+        team_id = %binding.team_id,
+        slot_id = binding.slot_id.as_deref().unwrap_or("none"),
+        max_turns = config.max_turns.unwrap_or(TEAM_LEAD_MAX_TURNS),
+        "Applied Team Leader coordination-only runtime policy"
+    );
+
+    let tool_names = TEAM_LEAD_READ_ONLY_TOOLS
+        .into_iter()
+        .map(str::to_owned)
+        .chain(visible_team_tool_descriptors(true).into_iter().map(|tool| tool.name));
+    ToolPolicy::allow_only(tool_names)
+}
+
+#[cfg(test)]
+#[path = "aionrs_policy_test.rs"]
+mod aionrs_policy_test;

--- a/crates/aionui-ai-agent/src/factory/aionrs_policy.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs_policy.rs
@@ -1,15 +1,11 @@
 use aion_agent::tool_policy::ToolPolicy;
-use aionui_api_types::{AionrsBuildExtra, TeamSessionBinding};
+use aionui_api_types::TeamSessionBinding;
 use aionui_team_prompts::visible_team_tool_descriptors;
 use tracing::info;
 
-const TEAM_LEAD_MAX_TURNS: usize = 20;
 const TEAM_LEAD_READ_ONLY_TOOLS: [&str; 3] = ["Read", "Grep", "Glob"];
 
-pub(super) fn apply_team_runtime_policy(
-    team: Option<&TeamSessionBinding>,
-    config: &mut AionrsBuildExtra,
-) -> ToolPolicy {
+pub(super) fn team_runtime_tool_policy(team: Option<&TeamSessionBinding>) -> ToolPolicy {
     let Some(binding) = team.filter(|binding| {
         binding
             .role
@@ -19,16 +15,11 @@ pub(super) fn apply_team_runtime_policy(
         return ToolPolicy::Unrestricted;
     };
 
-    config.max_turns = Some(match config.max_turns {
-        Some(limit) if limit > 0 => limit.min(TEAM_LEAD_MAX_TURNS),
-        _ => TEAM_LEAD_MAX_TURNS,
-    });
     info!(
         target: "aionui_feedback_diagnostics",
         event = "feedback.team.lead_runtime_policy_applied",
         team_id = %binding.team_id,
         slot_id = binding.slot_id.as_deref().unwrap_or("none"),
-        max_turns = config.max_turns.unwrap_or(TEAM_LEAD_MAX_TURNS),
         "Applied Team Leader coordination-only runtime policy"
     );
 

--- a/crates/aionui-ai-agent/src/factory/aionrs_policy.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs_policy.rs
@@ -3,7 +3,7 @@ use aionui_api_types::TeamSessionBinding;
 use aionui_team_prompts::visible_team_tool_descriptors;
 use tracing::info;
 
-const TEAM_LEAD_READ_ONLY_TOOLS: [&str; 3] = ["Read", "Grep", "Glob"];
+const TEAM_LEAD_WORKSPACE_TOOLS: [&str; 5] = ["Read", "Grep", "Glob", "Edit", "Write"];
 
 pub(super) fn team_runtime_tool_policy(team: Option<&TeamSessionBinding>) -> ToolPolicy {
     let Some(binding) = team.filter(|binding| {
@@ -20,10 +20,10 @@ pub(super) fn team_runtime_tool_policy(team: Option<&TeamSessionBinding>) -> Too
         event = "feedback.team.lead_runtime_policy_applied",
         team_id = %binding.team_id,
         slot_id = binding.slot_id.as_deref().unwrap_or("none"),
-        "Applied Team Leader coordination-only runtime policy"
+        "Applied Team Leader coordination-first runtime policy"
     );
 
-    let tool_names = TEAM_LEAD_READ_ONLY_TOOLS
+    let tool_names = TEAM_LEAD_WORKSPACE_TOOLS
         .into_iter()
         .map(str::to_owned)
         .chain(visible_team_tool_descriptors(true).into_iter().map(|tool| tool.name));

--- a/crates/aionui-ai-agent/src/factory/aionrs_policy_test.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs_policy_test.rs
@@ -1,0 +1,67 @@
+use aion_agent::tool_policy::ToolPolicy;
+use aionui_api_types::{AionrsBuildExtra, TeamRuntimeSeed, TeamSessionBinding};
+
+use super::{TEAM_LEAD_MAX_TURNS, apply_team_runtime_policy};
+
+fn team_binding(role: Option<&str>) -> TeamSessionBinding {
+    TeamSessionBinding {
+        team_id: "team-1".to_string(),
+        slot_id: Some("slot-1".to_string()),
+        role: role.map(str::to_owned),
+        runtime_seed: TeamRuntimeSeed::default(),
+        mcp: None,
+    }
+}
+
+#[test]
+fn team_lead_can_only_coordinate_and_inspect() {
+    let mut config = AionrsBuildExtra::default();
+
+    let policy = apply_team_runtime_policy(Some(&team_binding(Some("lead"))), &mut config);
+
+    assert!(policy.allows("Read"));
+    assert!(policy.allows("Grep"));
+    assert!(policy.allows("Glob"));
+    assert!(policy.allows("team_members"));
+    assert!(policy.allows("team_send_message"));
+    assert!(policy.allows("team_spawn_agent"));
+    assert!(!policy.allows("ExecCommand"));
+    assert!(!policy.allows("Write"));
+    assert!(!policy.allows("Edit"));
+    assert!(!policy.allows("Skill"));
+    assert_eq!(config.max_turns, Some(TEAM_LEAD_MAX_TURNS));
+}
+
+#[test]
+fn team_lead_preserves_lower_turn_limit_and_caps_higher_limit() {
+    let team = team_binding(Some("lead"));
+    let mut lower = AionrsBuildExtra {
+        max_turns: Some(8),
+        ..Default::default()
+    };
+    let mut higher = AionrsBuildExtra {
+        max_turns: Some(100),
+        ..Default::default()
+    };
+
+    apply_team_runtime_policy(Some(&team), &mut lower);
+    apply_team_runtime_policy(Some(&team), &mut higher);
+
+    assert_eq!(lower.max_turns, Some(8));
+    assert_eq!(higher.max_turns, Some(TEAM_LEAD_MAX_TURNS));
+}
+
+#[test]
+fn non_leader_sessions_remain_unrestricted() {
+    for team in [None, Some(team_binding(Some("teammate"))), Some(team_binding(None))] {
+        let mut config = AionrsBuildExtra {
+            max_turns: None,
+            ..Default::default()
+        };
+
+        let policy = apply_team_runtime_policy(team.as_ref(), &mut config);
+
+        assert_eq!(policy, ToolPolicy::Unrestricted);
+        assert_eq!(config.max_turns, None);
+    }
+}

--- a/crates/aionui-ai-agent/src/factory/aionrs_policy_test.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs_policy_test.rs
@@ -31,6 +31,17 @@ fn team_lead_can_coordinate_and_make_workspace_edits() {
 }
 
 #[test]
+fn legacy_team_leader_alias_uses_restricted_policy() {
+    let policy = team_runtime_tool_policy(Some(&team_binding(Some("leader"))));
+
+    assert!(policy.allows("Edit"));
+    assert!(policy.allows("Write"));
+    assert!(policy.allows("team_spawn_agent"));
+    assert!(!policy.allows("ExecCommand"));
+    assert!(!policy.allows("Spawn"));
+}
+
+#[test]
 fn non_leader_sessions_remain_unrestricted() {
     for team in [None, Some(team_binding(Some("teammate"))), Some(team_binding(None))] {
         let policy = team_runtime_tool_policy(team.as_ref());

--- a/crates/aionui-ai-agent/src/factory/aionrs_policy_test.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs_policy_test.rs
@@ -1,7 +1,7 @@
 use aion_agent::tool_policy::ToolPolicy;
-use aionui_api_types::{AionrsBuildExtra, TeamRuntimeSeed, TeamSessionBinding};
+use aionui_api_types::{TeamRuntimeSeed, TeamSessionBinding};
 
-use super::{TEAM_LEAD_MAX_TURNS, apply_team_runtime_policy};
+use super::team_runtime_tool_policy;
 
 fn team_binding(role: Option<&str>) -> TeamSessionBinding {
     TeamSessionBinding {
@@ -15,9 +15,7 @@ fn team_binding(role: Option<&str>) -> TeamSessionBinding {
 
 #[test]
 fn team_lead_can_only_coordinate_and_inspect() {
-    let mut config = AionrsBuildExtra::default();
-
-    let policy = apply_team_runtime_policy(Some(&team_binding(Some("lead"))), &mut config);
+    let policy = team_runtime_tool_policy(Some(&team_binding(Some("lead"))));
 
     assert!(policy.allows("Read"));
     assert!(policy.allows("Grep"));
@@ -29,39 +27,13 @@ fn team_lead_can_only_coordinate_and_inspect() {
     assert!(!policy.allows("Write"));
     assert!(!policy.allows("Edit"));
     assert!(!policy.allows("Skill"));
-    assert_eq!(config.max_turns, Some(TEAM_LEAD_MAX_TURNS));
-}
-
-#[test]
-fn team_lead_preserves_lower_turn_limit_and_caps_higher_limit() {
-    let team = team_binding(Some("lead"));
-    let mut lower = AionrsBuildExtra {
-        max_turns: Some(8),
-        ..Default::default()
-    };
-    let mut higher = AionrsBuildExtra {
-        max_turns: Some(100),
-        ..Default::default()
-    };
-
-    apply_team_runtime_policy(Some(&team), &mut lower);
-    apply_team_runtime_policy(Some(&team), &mut higher);
-
-    assert_eq!(lower.max_turns, Some(8));
-    assert_eq!(higher.max_turns, Some(TEAM_LEAD_MAX_TURNS));
 }
 
 #[test]
 fn non_leader_sessions_remain_unrestricted() {
     for team in [None, Some(team_binding(Some("teammate"))), Some(team_binding(None))] {
-        let mut config = AionrsBuildExtra {
-            max_turns: None,
-            ..Default::default()
-        };
-
-        let policy = apply_team_runtime_policy(team.as_ref(), &mut config);
+        let policy = team_runtime_tool_policy(team.as_ref());
 
         assert_eq!(policy, ToolPolicy::Unrestricted);
-        assert_eq!(config.max_turns, None);
     }
 }

--- a/crates/aionui-ai-agent/src/factory/aionrs_policy_test.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs_policy_test.rs
@@ -14,7 +14,7 @@ fn team_binding(role: Option<&str>) -> TeamSessionBinding {
 }
 
 #[test]
-fn team_lead_can_only_coordinate_and_inspect() {
+fn team_lead_can_coordinate_and_make_workspace_edits() {
     let policy = team_runtime_tool_policy(Some(&team_binding(Some("lead"))));
 
     assert!(policy.allows("Read"));
@@ -23,9 +23,9 @@ fn team_lead_can_only_coordinate_and_inspect() {
     assert!(policy.allows("team_members"));
     assert!(policy.allows("team_send_message"));
     assert!(policy.allows("team_spawn_agent"));
+    assert!(policy.allows("Write"));
+    assert!(policy.allows("Edit"));
     assert!(!policy.allows("ExecCommand"));
-    assert!(!policy.allows("Write"));
-    assert!(!policy.allows("Edit"));
     assert!(!policy.allows("Skill"));
     assert!(!policy.allows("Spawn"));
 }

--- a/crates/aionui-ai-agent/src/factory/aionrs_policy_test.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs_policy_test.rs
@@ -27,6 +27,7 @@ fn team_lead_can_only_coordinate_and_inspect() {
     assert!(!policy.allows("Write"));
     assert!(!policy.allows("Edit"));
     assert!(!policy.allows("Skill"));
+    assert!(!policy.allows("Spawn"));
 }
 
 #[test]
@@ -36,4 +37,14 @@ fn non_leader_sessions_remain_unrestricted() {
 
         assert_eq!(policy, ToolPolicy::Unrestricted);
     }
+}
+
+#[test]
+fn team_teammate_retains_execution_and_spawn_tools() {
+    let policy = team_runtime_tool_policy(Some(&team_binding(Some("teammate"))));
+
+    assert!(policy.allows("ExecCommand"));
+    assert!(policy.allows("Write"));
+    assert!(policy.allows("Edit"));
+    assert!(policy.allows("Spawn"));
 }

--- a/crates/aionui-ai-agent/src/factory/mod.rs
+++ b/crates/aionui-ai-agent/src/factory/mod.rs
@@ -3,6 +3,7 @@ pub mod acp_assembler;
 mod acp;
 mod acp_launch_policy;
 pub(crate) mod aionrs;
+mod aionrs_policy;
 mod context;
 
 use std::path::PathBuf;

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -118,6 +118,7 @@ impl AionrsAgentManager {
         let runtime = AgentRuntime::new(conversation_id.clone(), workspace.clone(), 128);
         let sink: Arc<dyn OutputSink> = Arc::new(BackendOutputSink::new(runtime.event_sender()));
         let runtime_env = config_extra.runtime_env.clone();
+        let tool_policy = config_extra.tool_policy.clone();
         let final_input_dump = config_extra
             .prompt_dump_dir
             .clone()
@@ -172,7 +173,9 @@ impl AionrsAgentManager {
         let is_resume = resume_session.is_some();
         let provider_label = config.provider_label.clone();
 
-        let mut bootstrap = AgentBootstrap::new(config, &workspace, sink).runtime_env(runtime_env);
+        let mut bootstrap = AgentBootstrap::new(config, &workspace, sink)
+            .runtime_env(runtime_env)
+            .tool_policy(tool_policy);
         if let Some(session) = resume_session {
             info!(
                 conversation_id = %conversation_id,
@@ -623,6 +626,7 @@ mod tests {
             bedrock_config: None,
             runtime_env: Vec::new(),
             prompt_dump_dir: None,
+            tool_policy: Default::default(),
         }
     }
 

--- a/crates/aionui-ai-agent/src/services/provider_health.rs
+++ b/crates/aionui-ai-agent/src/services/provider_health.rs
@@ -93,6 +93,7 @@ impl ProviderHealthCheckService {
             bedrock_config,
             runtime_env: Vec::new(),
             prompt_dump_dir: None,
+            tool_policy: Default::default(),
         })
     }
 }

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use aion_agent::tool_policy::ToolPolicy;
 use serde::{Deserialize, Serialize};
 
 use crate::session_context::AgentSessionContext;
@@ -133,6 +134,8 @@ pub struct AionrsResolvedConfig {
     pub session_mode: Option<String>,
     /// Resolved skill names from the conversation snapshot.
     pub skills: Vec<String>,
+    /// Runtime authorization policy for registered Aionrs tools.
+    pub tool_policy: ToolPolicy,
     /// Extra MCP servers to inject (team coordination or guide).
     pub extra_mcp_servers: HashMap<String, aion_config::config::McpServerConfig>,
     /// AWS Bedrock credentials (region + access key or profile).

--- a/crates/aionui-ai-agent/tests/agent_types_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_types_integration.rs
@@ -107,6 +107,7 @@ fn make_aionrs_config() -> AionrsResolvedConfig {
         bedrock_config: None,
         runtime_env: Vec::new(),
         prompt_dump_dir: None,
+        tool_policy: Default::default(),
     }
 }
 

--- a/crates/aionui-team-prompts/src/role_prompt.rs
+++ b/crates/aionui-team-prompts/src/role_prompt.rs
@@ -10,9 +10,9 @@ Slot ID: {{AGENT_SLOT_ID}}
 Role: lead
 
 ## Your Role
-You coordinate a team of AI agents. You do NOT do implementation work
-yourself. You break down tasks, assign them to teammates, and synthesize
-results.${workspaceSection}
+You are a coordination-only Team Leader. You break down tasks, inspect the
+shared workspace when that helps you plan or review work, assign implementation
+and validation to teammates, and synthesize results.${workspaceSection}
 
 ## Conversation Style
 - If the user greets you, starts a new chat, or asks what you can do without giving a concrete task yet, reply warmly and naturally
@@ -346,6 +346,10 @@ mod tests {
         assert!(!prompt.contains("## Available Assistants for Spawning"));
         assert!(!prompt.contains("- Worker (claude, status: unknown)"));
         assert!(prompt.to_lowercase().contains("first team turn"));
+        assert!(prompt.contains("coordination-only Team Leader"));
+        assert!(prompt.contains("inspect the\nshared workspace"));
+        assert!(prompt.contains("assign implementation\nand validation to teammates"));
+        assert!(!prompt.contains("## Runtime Tool Boundary"));
         assert!(prompt.contains("team_members"));
         assert!(prompt.contains("team_list_assistants"));
         assert!(!prompt.contains("${"));

--- a/crates/aionui-team-prompts/src/role_prompt.rs
+++ b/crates/aionui-team-prompts/src/role_prompt.rs
@@ -10,9 +10,10 @@ Slot ID: {{AGENT_SLOT_ID}}
 Role: lead
 
 ## Your Role
-You are a coordination-only Team Leader. You break down tasks, inspect the
-shared workspace when that helps you plan or review work, assign implementation
-and validation to teammates, and synthesize results.${workspaceSection}
+You are a coordination-first Team Leader. You break down tasks, inspect the
+shared workspace, make small targeted edits when they help you plan, integrate,
+or review work, delegate substantive implementation and validation to teammates,
+and synthesize results.${workspaceSection}
 
 ## Conversation Style
 - If the user greets you, starts a new chat, or asks what you can do without giving a concrete task yet, reply warmly and naturally
@@ -104,6 +105,7 @@ When the user explicitly asks to dismiss/fire/shut down teammates:
 - When a teammate completes a task, review the result and decide next steps
 - If a teammate fails, reassign or adjust the plan
 - Use teammate display names in natural-language replies, but use `slot_id` for all tool arguments
+- Keep direct workspace edits small and targeted; delegate substantive implementation and validation to teammates
 - Do NOT duplicate work that teammates are already doing
 - Be patient with idle teammates — idle means waiting for input, not done"#;
 
@@ -346,9 +348,10 @@ mod tests {
         assert!(!prompt.contains("## Available Assistants for Spawning"));
         assert!(!prompt.contains("- Worker (claude, status: unknown)"));
         assert!(prompt.to_lowercase().contains("first team turn"));
-        assert!(prompt.contains("coordination-only Team Leader"));
-        assert!(prompt.contains("inspect the\nshared workspace"));
-        assert!(prompt.contains("assign implementation\nand validation to teammates"));
+        assert!(prompt.contains("coordination-first Team Leader"));
+        assert!(prompt.contains("make small targeted edits"));
+        assert!(prompt.contains("delegate substantive implementation and validation to teammates"));
+        assert!(prompt.contains("Keep direct workspace edits small and targeted"));
         assert!(!prompt.contains("## Runtime Tool Boundary"));
         assert!(prompt.contains("team_members"));
         assert!(prompt.contains("team_list_assistants"));


### PR DESCRIPTION
## Summary

- Apply an enforceable runtime `ToolPolicy` to AionRS sessions whose Team binding role is `lead`.
- Allow Team Leaders to inspect and make small, targeted workspace changes with `Read`, `Grep`, `Glob`, `Edit`, and `Write`, together with the visible `team_*` coordination tools.
- Deny `ExecCommand`, `Skill`, and the built-in AionRS `Spawn` tool for Team Leaders at the execution boundary.
- Keep teammate, non-Team, provider-health, and other AionRS sessions unrestricted.
- Update the Leader prompt from coordination-only to coordination-first guidance and pin AionRS `v0.2.4`.

## Why

The Team Leader is responsible for planning, delegation, integration, review, and synthesis. Prompt guidance alone did not enforce that boundary and could still lead to repeated `ExecCommand` attempts, which surfaced as tool-call failure loops and an `UnknownUpstreamError` in feedback diagnostics.

This change makes the role boundary deterministic in the runtime. Leaders can still perform small integration edits when useful, while substantive implementation and validation remain delegated to teammates.

## Runtime behavior

| Session | Read / search | Edit / Write | ExecCommand | Skill / built-in Spawn | Team coordination |
| --- | --- | --- | --- | --- | --- |
| Team Leader | Allowed | Allowed | Denied | Denied | Visible `team_*` tools allowed |
| Teammate | Unrestricted | Unrestricted | Unrestricted | Unrestricted | Role-authorized `team_*` tools |
| Non-Team AionRS | Unrestricted | Unrestricted | Unrestricted | Unrestricted | No Team binding |

`team_spawn_agent` is a Team coordination tool and remains available to the Leader. It creates a separately bound teammate session; it is distinct from the denied built-in AionRS `Spawn` tool.

## Diagnostics

The structured `feedback.team.lead_runtime_policy_applied` log records `team_id` and `slot_id`. This makes future feedback and Sentry reports easier to correlate without logging prompts, commands, tool inputs, or tool outputs.

## Compatibility

- No database migration or schema change.
- Existing Team records continue to work; the policy is derived from the existing Team session role binding.
- Existing teammates and non-Team conversations retain their previous unrestricted AionRS behavior.
- Team Leader turn budgets are unchanged; no max-turn limit is introduced.
- The runtime policy is the authorization boundary; prompt text only describes the intended coordination behavior.

## Dependency

- Requires the tool-policy support released in [iOfficeAI/aionrs#226](https://github.com/iOfficeAI/aionrs/pull/226).
- `Cargo.toml` and `Cargo.lock` are pinned to AionRS `v0.2.4` at `cb4a10fd`.

## Validation

- `cargo fmt --all -- --check` — passed.
- `cargo check --workspace --locked` — passed against the published AionRS `v0.2.4` tag.
- `just push` — migration check, clippy, formatting, and the complete workspace test gate passed without a local AionRS override.
- Complete workspace result: 6,763 passed, 18 skipped.
- Policy coverage verifies that Team Leaders allow `Edit` and `Write` while denying `ExecCommand`, `Skill`, and built-in `Spawn`.

## Non-goals

- Restricting teammate or non-Team tool access.
- Persisting tool policies in the database.
- Adding a Team Leader max-turn limit.
- Treating prompt text as the security boundary.
