### PR TITLE
fix(managed-resources): emit bundled resource manifest

### DIFF
--- a/crates/aionui-app/src/commands/cmd_prepare_managed_resources.rs
+++ b/crates/aionui-app/src/commands/cmd_prepare_managed_resources.rs
@@ -3,7 +3,12 @@ use std::process::ExitCode;
 use crate::cli::PrepareManagedResourcesArgs;
 use crate::commands::error::{CliBoundaryCode, CliBoundaryError};
 use aionui_runtime::acp_tool_runtime::ManagedAcpToolId;
+use aionui_runtime::acp_tool_runtime::managed_acp_tool_contract_for_export;
 use aionui_runtime::managed_resources::export_node_runtime_to_root;
+use aionui_runtime::managed_resources_contract::{
+    MANAGED_RESOURCES_CONTRACT_SCHEMA_VERSION, ManagedResourcesContract, validate_contract, write_contract,
+};
+use aionui_runtime::node_runtime::managed_node_contract_for_export;
 use aionui_runtime::{ensure_node_runtime, prepare_managed_acp_tool_to_root};
 
 const SUBCOMMAND: &str = "prepare-managed-resources";
@@ -26,12 +31,43 @@ pub async fn run_prepare_managed_resources(args: PrepareManagedResourcesArgs) ->
     println!("Prepared managed resources under {}", output_root.display());
     println!("  node   -> {}", exported_node.display());
 
+    let mut prepared_tools = Vec::new();
     for tool in [ManagedAcpToolId::CodexAcp, ManagedAcpToolId::ClaudeAgentAcp] {
         let prepared = prepare_managed_acp_tool_to_root(tool, &output_root)
             .await
             .map_err(|error| prepare_managed_resources_error_with_detail("acp.prepare", error))?;
         println!("  {:<6} -> {}", tool.slug(), prepared.root.display());
+        prepared_tools.push(prepared);
     }
+
+    let node = managed_node_contract_for_export(&output_root, &exported_node)
+        .map_err(|error| prepare_managed_resources_error_with_detail("contract.write", error))?;
+    let mut acp_tools = Vec::new();
+    for tool in [ManagedAcpToolId::CodexAcp, ManagedAcpToolId::ClaudeAgentAcp] {
+        let prepared = prepared_tools
+            .iter()
+            .find(|prepared| prepared.id == tool)
+            .ok_or_else(|| prepare_managed_resources_error("contract.write"))?;
+        acp_tools.push(
+            managed_acp_tool_contract_for_export(tool, &output_root, prepared)
+                .map_err(|error| prepare_managed_resources_error_with_detail("contract.write", error))?,
+        );
+    }
+    let runtime_key = acp_tools
+        .first()
+        .map(|tool| tool.platform_directory.clone())
+        .ok_or_else(|| prepare_managed_resources_error("contract.write"))?;
+    let contract = ManagedResourcesContract {
+        schema_version: MANAGED_RESOURCES_CONTRACT_SCHEMA_VERSION,
+        runtime_key,
+        node,
+        acp_tools,
+    };
+    let manifest_path = write_contract(&output_root, &contract)
+        .map_err(|error| prepare_managed_resources_error_with_detail("contract.write", error))?;
+    validate_contract(&output_root, &contract)
+        .map_err(|error| prepare_managed_resources_error_with_detail("contract.validate", error))?;
+    println!("  manifest -> {}", manifest_path.display());
 
     Ok(ExitCode::SUCCESS)
 }
@@ -63,5 +99,14 @@ mod tests {
             "CLI_PREPARE_MANAGED_RESOURCES_FAILED subcommand=prepare-managed-resources stage=node.export"
         ));
         assert!(!err.stderr_line().contains("/Users/secret/bundle"));
+    }
+
+    #[test]
+    fn prepare_error_accepts_contract_write_and_validate_stages() {
+        for stage in ["contract.write", "contract.validate"] {
+            let err = prepare_managed_resources_error(stage);
+            assert_eq!(err.code(), CliBoundaryCode::CliPrepareManagedResourcesFailed);
+            assert!(err.stderr_line().contains(stage));
+        }
     }
 }

--- a/crates/aionui-runtime/src/acp_tool_runtime/mod.rs
+++ b/crates/aionui-runtime/src/acp_tool_runtime/mod.rs
@@ -12,6 +12,7 @@ use tracing::{info, warn};
 use crate::Builder;
 use crate::cache;
 use crate::managed_resources;
+use crate::managed_resources_contract::{ManagedAcpToolResourceContract, relative_contract_path};
 use crate::node_runtime::DoctorRow;
 use crate::node_runtime::ensure_node_runtime_with_reporter;
 
@@ -652,19 +653,7 @@ fn validate_platform_binary(
     project_dir: &Path,
     spec: PlatformSpec,
 ) -> Result<(), ManagedAcpToolError> {
-    let expected = match tool {
-        ManagedAcpToolId::CodexAcp => codex_platform_binary_path(project_dir, spec)?,
-        ManagedAcpToolId::ClaudeAgentAcp => {
-            let mut path = project_dir
-                .join("node_modules")
-                .join(format!("@anthropic-ai/claude-agent-sdk-{}", spec.manifest_key))
-                .join("claude");
-            if spec.manifest_key.starts_with("win32-") {
-                path.set_extension("exe");
-            }
-            path
-        }
-    };
+    let expected = project_dir.join(platform_binary_relative_path(tool, spec)?);
 
     if expected.is_file() {
         Ok(())
@@ -677,7 +666,22 @@ fn validate_platform_binary(
     }
 }
 
-fn codex_platform_binary_path(project_dir: &Path, spec: PlatformSpec) -> Result<PathBuf, ManagedAcpToolError> {
+fn platform_binary_relative_path(tool: ManagedAcpToolId, spec: PlatformSpec) -> Result<PathBuf, ManagedAcpToolError> {
+    match tool {
+        ManagedAcpToolId::CodexAcp => codex_platform_binary_relative_path(spec),
+        ManagedAcpToolId::ClaudeAgentAcp => {
+            let mut path = PathBuf::from("node_modules")
+                .join(format!("@anthropic-ai/claude-agent-sdk-{}", spec.manifest_key))
+                .join("claude");
+            if spec.manifest_key.starts_with("win32-") {
+                path.set_extension("exe");
+            }
+            Ok(path)
+        }
+    }
+}
+
+fn codex_platform_binary_relative_path(spec: PlatformSpec) -> Result<PathBuf, ManagedAcpToolError> {
     let vendor_triple = match spec.manifest_key {
         "darwin-arm64" => "aarch64-apple-darwin",
         "darwin-x64" => "x86_64-apple-darwin",
@@ -693,8 +697,7 @@ fn codex_platform_binary_path(project_dir: &Path, spec: PlatformSpec) -> Result<
         }
     };
 
-    let mut path = project_dir
-        .join("node_modules")
+    let mut path = PathBuf::from("node_modules")
         .join(format!("@openai/codex-{}", spec.manifest_key))
         .join("vendor")
         .join(vendor_triple)
@@ -704,6 +707,45 @@ fn codex_platform_binary_path(project_dir: &Path, spec: PlatformSpec) -> Result<
         path.set_extension("exe");
     }
     Ok(path)
+}
+
+pub fn managed_acp_tool_contract_for_export(
+    tool: ManagedAcpToolId,
+    bundle_root: &Path,
+    resolved: &ResolvedManagedAcpTool,
+) -> Result<ManagedAcpToolResourceContract, ManagedAcpToolError> {
+    managed_acp_tool_contract_for_export_with_spec(tool, platform_spec()?, bundle_root, resolved)
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn managed_acp_tool_contract_for_export_with_spec(
+    tool: ManagedAcpToolId,
+    spec: PlatformSpec,
+    bundle_root: &Path,
+    resolved: &ResolvedManagedAcpTool,
+) -> Result<ManagedAcpToolResourceContract, ManagedAcpToolError> {
+    if resolved.id != tool {
+        return Err(ManagedAcpToolError::invalid(format!(
+            "resolved managed ACP tool id {:?} does not match requested {:?}",
+            resolved.id, tool
+        )));
+    }
+    let manifest = read_local_manifest(&resolved.root)?;
+    let root = relative_contract_path(bundle_root, &resolved.root)
+        .map_err(|error| ManagedAcpToolError::invalid(format!("managed ACP contract path: {error}")))?;
+    Ok(ManagedAcpToolResourceContract {
+        slug: tool.slug().into(),
+        version: resolved.version.clone(),
+        package_name: tool.package_name().into(),
+        root,
+        platform_directory: spec.manifest_key.into(),
+        manifest: "manifest.json".into(),
+        entrypoint: manifest.entrypoint,
+        path_entries: manifest.path_entries,
+        required_files: vec!["package.json".into(), "package-lock.json".into()],
+        required_directories: vec!["node_modules".into()],
+        platform_executable: normalize_slashes(&platform_binary_relative_path(tool, spec)?),
+    })
 }
 
 async fn validate_dependency_tree(
@@ -1044,6 +1086,63 @@ mod tests {
             .map(|(_, value)| value.clone())
             .unwrap();
         assert!(path.to_string_lossy().contains("/tmp/tool/bin"));
+    }
+
+    #[test]
+    fn managed_acp_contract_uses_package_version_manifest_and_platform_binary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle_root = tmp.path().join("managed-resources");
+        let root = bundle_root
+            .join("acp")
+            .join("codex-acp")
+            .join("1.1.2")
+            .join("win32-x64");
+        std::fs::create_dir_all(root.join("node_modules/@agentclientprotocol/codex-acp/dist")).unwrap();
+        std::fs::create_dir_all(root.join("node_modules/@openai/codex-win32-x64/vendor/x86_64-pc-windows-msvc/bin"))
+            .unwrap();
+        std::fs::create_dir_all(root.join("node_modules")).unwrap();
+        std::fs::write(
+            root.join("manifest.json"),
+            br#"{"entrypoint":"node_modules/@agentclientprotocol/codex-acp/dist/index.js","path_entries":["node_modules/.bin"]}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("node_modules/@agentclientprotocol/codex-acp/dist/index.js"),
+            b"",
+        )
+        .unwrap();
+        std::fs::write(root.join("package.json"), b"{}").unwrap();
+        std::fs::write(root.join("package-lock.json"), b"{}").unwrap();
+        std::fs::write(
+            root.join("node_modules/@openai/codex-win32-x64/vendor/x86_64-pc-windows-msvc/bin/codex.exe"),
+            b"",
+        )
+        .unwrap();
+        let resolved = ResolvedManagedAcpTool {
+            id: ManagedAcpToolId::CodexAcp,
+            version: "1.1.2".into(),
+            root: root.clone(),
+            entrypoint: root.join("node_modules/@agentclientprotocol/codex-acp/dist/index.js"),
+            env_path_entries: vec![root.join("node_modules/.bin")],
+        };
+        let spec = PlatformSpec {
+            manifest_key: "win32-x64",
+            npm_os: "win32",
+            npm_cpu: "x64",
+        };
+
+        let contract =
+            managed_acp_tool_contract_for_export_with_spec(ManagedAcpToolId::CodexAcp, spec, &bundle_root, &resolved)
+                .expect("contract");
+
+        assert_eq!(contract.slug, "codex-acp");
+        assert_eq!(contract.version, "1.1.2");
+        assert_eq!(contract.package_name, "@agentclientprotocol/codex-acp");
+        assert_eq!(contract.root, "acp/codex-acp/1.1.2/win32-x64");
+        assert_eq!(
+            contract.platform_executable,
+            "node_modules/@openai/codex-win32-x64/vendor/x86_64-pc-windows-msvc/bin/codex.exe"
+        );
     }
 
     #[test]

--- a/crates/aionui-runtime/src/lib.rs
+++ b/crates/aionui-runtime/src/lib.rs
@@ -14,6 +14,7 @@ mod embed;
 mod extract;
 mod http_client;
 pub mod managed_resources;
+pub mod managed_resources_contract;
 pub mod node_runtime;
 mod resolver;
 mod shell_env;

--- a/crates/aionui-runtime/src/managed_resources_contract.rs
+++ b/crates/aionui-runtime/src/managed_resources_contract.rs
@@ -1,0 +1,466 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+pub const MANAGED_RESOURCES_CONTRACT_FILE: &str = "manifest.json";
+pub const MANAGED_RESOURCES_CONTRACT_SCHEMA_VERSION: u8 = 1;
+const REQUIRED_ACP_TOOL_SLUGS: [&str; 2] = ["codex-acp", "claude-agent-acp"];
+const SUPPORTED_RUNTIME_KEYS: [&str; 6] = [
+    "win32-x64",
+    "win32-arm64",
+    "darwin-x64",
+    "darwin-arm64",
+    "linux-x64",
+    "linux-arm64",
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagedResourcesContract {
+    pub schema_version: u8,
+    pub runtime_key: String,
+    pub node: ManagedNodeResourceContract,
+    pub acp_tools: Vec<ManagedAcpToolResourceContract>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagedNodeResourceContract {
+    pub version: String,
+    pub root: String,
+    pub executable: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagedAcpToolResourceContract {
+    pub slug: String,
+    pub version: String,
+    pub package_name: String,
+    pub root: String,
+    pub platform_directory: String,
+    pub manifest: String,
+    pub entrypoint: String,
+    pub path_entries: Vec<String>,
+    pub required_files: Vec<String>,
+    pub required_directories: Vec<String>,
+    pub platform_executable: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+pub struct ManagedResourcesContractError {
+    message: String,
+}
+
+impl ManagedResourcesContractError {
+    fn invalid(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    fn io(action: &str, path: &Path, error: std::io::Error) -> Self {
+        Self::invalid(format!("{action} {}: {error}", path.display()))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolLocalManifest {
+    entrypoint: String,
+    #[serde(default)]
+    path_entries: Vec<String>,
+}
+
+pub fn validate_contract(
+    root: &Path,
+    contract: &ManagedResourcesContract,
+) -> Result<(), ManagedResourcesContractError> {
+    validate_schema(contract)?;
+    validate_node_schema(&contract.node)?;
+    validate_acp_tools_schema(contract)?;
+    validate_node_paths(root, &contract.node)?;
+    for tool in &contract.acp_tools {
+        validate_acp_tool_paths(root, tool)?;
+    }
+    Ok(())
+}
+
+pub fn write_contract(
+    root: &Path,
+    contract: &ManagedResourcesContract,
+) -> Result<PathBuf, ManagedResourcesContractError> {
+    validate_contract(root, contract)?;
+    let path = root.join(MANAGED_RESOURCES_CONTRACT_FILE);
+    let mut contents = serde_json::to_string_pretty(contract).map_err(|error| {
+        ManagedResourcesContractError::invalid(format!("serialize managed resources contract: {error}"))
+    })?;
+    contents.push('\n');
+    fs::write(&path, contents).map_err(|error| ManagedResourcesContractError::io("write contract", &path, error))?;
+    Ok(path)
+}
+
+pub fn relative_contract_path(base: &Path, path: &Path) -> Result<String, ManagedResourcesContractError> {
+    let relative = path.strip_prefix(base).map_err(|_| {
+        ManagedResourcesContractError::invalid(format!(
+            "path {} is not under managed resources root {}",
+            path.display(),
+            base.display()
+        ))
+    })?;
+    let value = relative.to_string_lossy().replace('\\', "/");
+    validate_contract_relative_path(&value)?;
+    Ok(value)
+}
+
+fn validate_schema(contract: &ManagedResourcesContract) -> Result<(), ManagedResourcesContractError> {
+    if contract.schema_version != MANAGED_RESOURCES_CONTRACT_SCHEMA_VERSION {
+        return Err(ManagedResourcesContractError::invalid(format!(
+            "unsupported schemaVersion {}",
+            contract.schema_version
+        )));
+    }
+    require_non_empty("runtimeKey", &contract.runtime_key)?;
+    if !SUPPORTED_RUNTIME_KEYS.contains(&contract.runtime_key.as_str()) {
+        return Err(ManagedResourcesContractError::invalid(format!(
+            "unsupported runtimeKey {}",
+            contract.runtime_key
+        )));
+    }
+    Ok(())
+}
+
+fn validate_node_schema(node: &ManagedNodeResourceContract) -> Result<(), ManagedResourcesContractError> {
+    require_non_empty("node.version", &node.version)?;
+    validate_contract_relative_path_field("node.root", &node.root)?;
+    validate_contract_relative_path_field("node.executable", &node.executable)?;
+    Ok(())
+}
+
+fn validate_acp_tools_schema(contract: &ManagedResourcesContract) -> Result<(), ManagedResourcesContractError> {
+    let mut slugs = HashSet::new();
+
+    for tool in &contract.acp_tools {
+        require_non_empty("acpTools[].slug", &tool.slug)?;
+        if !slugs.insert(tool.slug.as_str()) {
+            return Err(ManagedResourcesContractError::invalid(format!(
+                "duplicate acpTools slug {}",
+                tool.slug
+            )));
+        }
+
+        let label = format!("acpTools[{}]", tool.slug);
+        require_non_empty(format!("{label}.version"), &tool.version)?;
+        require_non_empty(format!("{label}.packageName"), &tool.package_name)?;
+        validate_contract_relative_path_field(format!("{label}.root"), &tool.root)?;
+        require_non_empty(format!("{label}.platformDirectory"), &tool.platform_directory)?;
+        if tool.platform_directory != contract.runtime_key {
+            return Err(ManagedResourcesContractError::invalid(format!(
+                "acpTools[{}].platformDirectory {} does not match runtimeKey {}",
+                tool.slug, tool.platform_directory, contract.runtime_key
+            )));
+        }
+        validate_contract_relative_path_field(format!("{label}.manifest"), &tool.manifest)?;
+        validate_contract_relative_path_field(format!("{label}.entrypoint"), &tool.entrypoint)?;
+        for (index, entry) in tool.path_entries.iter().enumerate() {
+            validate_contract_relative_path_field(format!("{label}.pathEntries[{index}]"), entry)?;
+        }
+        if tool.required_files.is_empty() {
+            return Err(ManagedResourcesContractError::invalid(format!(
+                "{label}.requiredFiles must not be empty"
+            )));
+        }
+        for (index, entry) in tool.required_files.iter().enumerate() {
+            validate_contract_relative_path_field(format!("{label}.requiredFiles[{index}]"), entry)?;
+        }
+        if tool.required_directories.is_empty() {
+            return Err(ManagedResourcesContractError::invalid(format!(
+                "{label}.requiredDirectories must not be empty"
+            )));
+        }
+        for (index, entry) in tool.required_directories.iter().enumerate() {
+            validate_contract_relative_path_field(format!("{label}.requiredDirectories[{index}]"), entry)?;
+        }
+        validate_contract_relative_path_field(format!("{label}.platformExecutable"), &tool.platform_executable)?;
+    }
+
+    for required_slug in REQUIRED_ACP_TOOL_SLUGS {
+        if !slugs.contains(required_slug) {
+            return Err(ManagedResourcesContractError::invalid(format!(
+                "missing required acpTools slug {required_slug}"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_node_paths(root: &Path, node: &ManagedNodeResourceContract) -> Result<(), ManagedResourcesContractError> {
+    let node_root = root.join(&node.root);
+    if !node_root.is_dir() {
+        return Err(ManagedResourcesContractError::invalid(format!(
+            "required directory missing: {}",
+            node_root.display()
+        )));
+    }
+    let executable = node_root.join(&node.executable);
+    if !executable.is_file() {
+        return Err(ManagedResourcesContractError::invalid(format!(
+            "required file missing: {}",
+            executable.display()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_acp_tool_paths(
+    root: &Path,
+    tool: &ManagedAcpToolResourceContract,
+) -> Result<(), ManagedResourcesContractError> {
+    let tool_root = root.join(&tool.root);
+    if !tool_root.is_dir() {
+        return Err(ManagedResourcesContractError::invalid(format!(
+            "required directory missing: {}",
+            tool_root.display()
+        )));
+    }
+
+    let manifest_path = tool_root.join(&tool.manifest);
+    if !manifest_path.is_file() {
+        return Err(ManagedResourcesContractError::invalid(format!(
+            "required file missing: {}",
+            manifest_path.display()
+        )));
+    }
+    let local_manifest = read_tool_local_manifest(&manifest_path)?;
+    if local_manifest.entrypoint != tool.entrypoint {
+        return Err(ManagedResourcesContractError::invalid(format!(
+            "local manifest entrypoint mismatch for {}: expected {}, got {}",
+            tool.slug, tool.entrypoint, local_manifest.entrypoint
+        )));
+    }
+    if local_manifest.path_entries != tool.path_entries {
+        return Err(ManagedResourcesContractError::invalid(format!(
+            "local manifest path_entries mismatch for {}",
+            tool.slug
+        )));
+    }
+
+    let entrypoint = tool_root.join(&tool.entrypoint);
+    if !entrypoint.is_file() {
+        return Err(ManagedResourcesContractError::invalid(format!(
+            "required file missing: {}",
+            entrypoint.display()
+        )));
+    }
+
+    for required_file in &tool.required_files {
+        let path = tool_root.join(required_file);
+        if !path.is_file() {
+            return Err(ManagedResourcesContractError::invalid(format!(
+                "required file missing: {}",
+                path.display()
+            )));
+        }
+    }
+    for required_directory in &tool.required_directories {
+        let path = tool_root.join(required_directory);
+        if !path.is_dir() {
+            return Err(ManagedResourcesContractError::invalid(format!(
+                "required directory missing: {}",
+                path.display()
+            )));
+        }
+    }
+
+    let executable = tool_root.join(&tool.platform_executable);
+    if !executable.is_file() {
+        return Err(ManagedResourcesContractError::invalid(format!(
+            "required file missing: {}",
+            executable.display()
+        )));
+    }
+
+    Ok(())
+}
+
+fn read_tool_local_manifest(path: &Path) -> Result<ToolLocalManifest, ManagedResourcesContractError> {
+    let contents = fs::read_to_string(path)
+        .map_err(|error| ManagedResourcesContractError::io("read local manifest", path, error))?;
+    serde_json::from_str(&contents).map_err(|error| {
+        ManagedResourcesContractError::invalid(format!(
+            "parse local managed ACP manifest failed for {}: {error}",
+            path.display()
+        ))
+    })
+}
+
+fn require_non_empty(field: impl std::fmt::Display, value: &str) -> Result<(), ManagedResourcesContractError> {
+    if value.is_empty() {
+        return Err(ManagedResourcesContractError::invalid(format!("{field} is required")));
+    }
+    Ok(())
+}
+
+fn validate_contract_relative_path_field(
+    field: impl std::fmt::Display,
+    value: &str,
+) -> Result<(), ManagedResourcesContractError> {
+    validate_contract_relative_path(value)
+        .map_err(|error| ManagedResourcesContractError::invalid(format!("{field}: {error}")))
+}
+
+fn validate_contract_relative_path(value: &str) -> Result<(), ManagedResourcesContractError> {
+    if value.is_empty()
+        || value.contains('\\')
+        || Path::new(value).is_absolute()
+        || Path::new(value)
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(ManagedResourcesContractError::invalid(format!(
+            "invalid relative contract path {value:?}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn example_contract(runtime_key: &str) -> ManagedResourcesContract {
+        ManagedResourcesContract {
+            schema_version: MANAGED_RESOURCES_CONTRACT_SCHEMA_VERSION,
+            runtime_key: runtime_key.into(),
+            node: ManagedNodeResourceContract {
+                version: "24.11.0".into(),
+                root: "node/node-v24.11.0-win-x64".into(),
+                executable: "node.exe".into(),
+            },
+            acp_tools: vec![
+                ManagedAcpToolResourceContract {
+                    slug: "codex-acp".into(),
+                    version: "1.1.2".into(),
+                    package_name: "@agentclientprotocol/codex-acp".into(),
+                    root: "acp/codex-acp/1.1.2/win32-x64".into(),
+                    platform_directory: "win32-x64".into(),
+                    manifest: "manifest.json".into(),
+                    entrypoint: "node_modules/@agentclientprotocol/codex-acp/dist/index.js".into(),
+                    path_entries: vec!["node_modules/.bin".into()],
+                    required_files: vec!["package.json".into(), "package-lock.json".into()],
+                    required_directories: vec!["node_modules".into()],
+                    platform_executable:
+                        "node_modules/@openai/codex-win32-x64/vendor/x86_64-pc-windows-msvc/bin/codex.exe".into(),
+                },
+                ManagedAcpToolResourceContract {
+                    slug: "claude-agent-acp".into(),
+                    version: "0.58.1".into(),
+                    package_name: "@agentclientprotocol/claude-agent-acp".into(),
+                    root: "acp/claude-agent-acp/0.58.1/win32-x64".into(),
+                    platform_directory: "win32-x64".into(),
+                    manifest: "manifest.json".into(),
+                    entrypoint: "node_modules/@agentclientprotocol/claude-agent-acp/dist/index.js".into(),
+                    path_entries: vec!["node_modules/.bin".into()],
+                    required_files: vec!["package.json".into(), "package-lock.json".into()],
+                    required_directories: vec!["node_modules".into()],
+                    platform_executable: "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64/claude.exe".into(),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn contract_serializes_v1_camel_case_schema() {
+        let contract = example_contract("win32-x64");
+        let value = serde_json::to_value(&contract).expect("serialize");
+
+        assert_eq!(value["schemaVersion"], 1);
+        assert_eq!(value["runtimeKey"], "win32-x64");
+        assert!(value.get("schema_version").is_none());
+        assert_eq!(value["acpTools"][0]["packageName"], "@agentclientprotocol/codex-acp");
+        assert_eq!(
+            value["acpTools"][0]["requiredFiles"],
+            serde_json::json!(["package.json", "package-lock.json"])
+        );
+        assert_eq!(
+            value["acpTools"][0]["requiredDirectories"],
+            serde_json::json!(["node_modules"])
+        );
+    }
+
+    #[test]
+    fn validate_contract_rejects_duplicate_tool_slugs() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut contract = example_contract("win32-x64");
+        contract.acp_tools[1].slug = "codex-acp".into();
+
+        let error = validate_contract(temp.path(), &contract).expect_err("duplicate slug should fail");
+
+        assert!(error.to_string().contains("duplicate acpTools slug codex-acp"));
+    }
+
+    #[test]
+    fn validate_contract_rejects_missing_required_tool_slug() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut contract = example_contract("win32-x64");
+        contract.acp_tools.retain(|tool| tool.slug != "claude-agent-acp");
+
+        let error = validate_contract(temp.path(), &contract).expect_err("missing required slug should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("missing required acpTools slug claude-agent-acp")
+        );
+    }
+
+    #[test]
+    fn validate_contract_rejects_unsafe_relative_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        for bad in ["/abs/path", "acp\\codex-acp", "", "../escape", "acp/../escape"] {
+            let mut contract = example_contract("win32-x64");
+            contract.acp_tools[0].root = bad.into();
+
+            let error = validate_contract(temp.path(), &contract).expect_err("unsafe path should fail");
+
+            assert!(error.to_string().contains("invalid relative contract path"), "{error}");
+        }
+    }
+
+    #[test]
+    fn validate_contract_rejects_empty_required_strings_and_platform_mismatch() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut contract = example_contract("win32-x64");
+        contract.acp_tools[0].package_name.clear();
+
+        let error = validate_contract(temp.path(), &contract).expect_err("empty package name should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("acpTools[codex-acp].packageName is required")
+        );
+
+        let mut contract = example_contract("win32-x64");
+        contract.acp_tools[0].platform_directory = "linux-x64".into();
+
+        let error = validate_contract(temp.path(), &contract).expect_err("platform mismatch should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("platformDirectory linux-x64 does not match runtimeKey win32-x64")
+        );
+    }
+
+    #[test]
+    fn validate_contract_rejects_missing_required_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let contract = example_contract("win32-x64");
+        std::fs::create_dir_all(temp.path().join("node").join("node-v24.11.0-win-x64")).expect("create node root");
+
+        let error = validate_contract(temp.path(), &contract).expect_err("missing paths should fail");
+
+        assert!(error.to_string().contains("required file missing"));
+    }
+}

--- a/crates/aionui-runtime/src/node_runtime/managed.rs
+++ b/crates/aionui-runtime/src/node_runtime/managed.rs
@@ -12,6 +12,7 @@ use tracing::{info, warn};
 use crate::cache;
 use crate::http_client;
 use crate::managed_resources::{self, ManagedResourceSourceKind};
+use crate::managed_resources_contract::{ManagedNodeResourceContract, relative_contract_path};
 
 use super::types::{
     NodeRuntimeError, NodeRuntimeFailureKind, NodeRuntimeProgress, NodeRuntimeProgressReporter, NodeRuntimeSupport,
@@ -29,6 +30,8 @@ const MANAGED_NODE_PROGRESS_STEP_BYTES: u64 = 5 * 1024 * 1024;
 struct PlatformSpec {
     folder_suffix: &'static str,
     archive_ext: &'static str,
+    runtime_key: &'static str,
+    executable: &'static str,
 }
 
 impl PlatformSpec {
@@ -198,31 +201,74 @@ fn platform_spec() -> Result<PlatformSpec, NodeRuntimeError> {
         ("macos", "aarch64") => Ok(PlatformSpec {
             folder_suffix: "darwin-arm64",
             archive_ext: "tar.gz",
+            runtime_key: "darwin-arm64",
+            executable: "bin/node",
         }),
         ("macos", "x86_64") => Ok(PlatformSpec {
             folder_suffix: "darwin-x64",
             archive_ext: "tar.gz",
+            runtime_key: "darwin-x64",
+            executable: "bin/node",
         }),
         ("linux", "aarch64") => Ok(PlatformSpec {
             folder_suffix: "linux-arm64",
             archive_ext: "tar.gz",
+            runtime_key: "linux-arm64",
+            executable: "bin/node",
         }),
         ("linux", "x86_64") => Ok(PlatformSpec {
             folder_suffix: "linux-x64",
             archive_ext: "tar.gz",
+            runtime_key: "linux-x64",
+            executable: "bin/node",
         }),
         ("windows", "x86_64") => Ok(PlatformSpec {
             folder_suffix: "win-x64",
             archive_ext: "zip",
+            runtime_key: "win32-x64",
+            executable: "node.exe",
         }),
         ("windows", "aarch64") => Ok(PlatformSpec {
             folder_suffix: "win-arm64",
             archive_ext: "zip",
+            runtime_key: "win32-arm64",
+            executable: "node.exe",
         }),
         (os, arch) => Err(NodeRuntimeError::unsupported_platform(format!(
             "managed node runtime unsupported on {os}/{arch}"
         ))),
     }
+}
+
+pub fn managed_node_contract_for_export(
+    bundle_root: &Path,
+    exported_node_root: &Path,
+) -> Result<ManagedNodeResourceContract, NodeRuntimeError> {
+    managed_node_contract_for_export_with_spec(bundle_root, exported_node_root, platform_spec()?)
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn managed_node_contract_for_export_with_spec(
+    bundle_root: &Path,
+    exported_node_root: &Path,
+    spec: PlatformSpec,
+) -> Result<ManagedNodeResourceContract, NodeRuntimeError> {
+    let root = relative_contract_path(bundle_root, exported_node_root)
+        .map_err(|error| NodeRuntimeError::managed_invalid(format!("managed Node contract path: {error}")))?;
+    let expected_suffix = spec.directory_name();
+    if !root.ends_with(&expected_suffix) {
+        return Err(NodeRuntimeError::managed_invalid(format!(
+            "exported managed Node root {} does not match expected {} for {}",
+            exported_node_root.display(),
+            expected_suffix,
+            spec.runtime_key
+        )));
+    }
+    Ok(ManagedNodeResourceContract {
+        version: MANAGED_NODE_VERSION.into(),
+        root,
+        executable: spec.executable.into(),
+    })
 }
 
 fn runtime_from_root(root: &Path, source: ResolvedNodeSource) -> Result<ResolvedNodeRuntime, NodeRuntimeError> {

--- a/crates/aionui-runtime/src/node_runtime/managed/tests.rs
+++ b/crates/aionui-runtime/src/node_runtime/managed/tests.rs
@@ -115,6 +115,8 @@ fn managed_runtime_official_source_uses_nodejs_org() {
     let source = ManagedNodeDownloadSource::official(PlatformSpec {
         folder_suffix: "darwin-arm64",
         archive_ext: "tar.gz",
+        runtime_key: "darwin-arm64",
+        executable: "bin/node",
     });
 
     assert_eq!(source.source, "nodejs.org");
@@ -123,6 +125,28 @@ fn managed_runtime_official_source_uses_nodejs_org() {
         "https://nodejs.org/dist/v24.11.0/node-v24.11.0-darwin-arm64.tar.gz"
     );
     assert_eq!(source.sha256, None);
+}
+
+#[test]
+fn managed_node_contract_uses_runtime_key_and_exported_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bundle_root = tmp.path().join("managed-resources");
+    let exported = bundle_root.join("node").join("node-v24.11.0-darwin-arm64");
+    std::fs::create_dir_all(exported.join("bin")).unwrap();
+    write_file(&exported.join("bin").join("node"));
+
+    let spec = PlatformSpec {
+        folder_suffix: "darwin-arm64",
+        archive_ext: "tar.gz",
+        runtime_key: "darwin-arm64",
+        executable: "bin/node",
+    };
+
+    let contract = managed_node_contract_for_export_with_spec(&bundle_root, &exported, spec).expect("contract");
+
+    assert_eq!(contract.version, "24.11.0");
+    assert_eq!(contract.root, "node/node-v24.11.0-darwin-arm64");
+    assert_eq!(contract.executable, "bin/node");
 }
 
 #[test]
@@ -213,6 +237,8 @@ async fn bundled_runtime_validation_failure_does_not_fallback_to_remote_download
         PlatformSpec {
             folder_suffix: "darwin-arm64",
             archive_ext: "tar.gz",
+            runtime_key: "darwin-arm64",
+            executable: "bin/node",
         },
         None,
     )

--- a/crates/aionui-runtime/src/node_runtime/mod.rs
+++ b/crates/aionui-runtime/src/node_runtime/mod.rs
@@ -6,7 +6,10 @@ use std::sync::OnceLock;
 
 use tracing::{debug, info, warn};
 
-pub use managed::{install_and_validate as install_managed_runtime, probe_support as probe_node_runtime_supported};
+pub use managed::{
+    install_and_validate as install_managed_runtime, managed_node_contract_for_export,
+    probe_support as probe_node_runtime_supported,
+};
 pub use system::{derive_runtime_root, tool_command, validate_same_root};
 pub use types::{
     DoctorRow, NodeRuntimeError, NodeRuntimeFailureKind, NodeRuntimeProgress, NodeRuntimeProgressPhase,


### PR DESCRIPTION
## Summary

This PR adds a v1 `managed-resources/manifest.json` contract for bundled managed resources. The manifest is generated from AionCore runtime facts for managed Node and ACP tools, then validated after the bundle is written so packaging cannot silently ship an incomplete or stale resource layout.

The contract records the runtime key, managed Node version/root/executable, and each required ACP tool's slug, package name, version, root, local tool manifest, entrypoint, path entries, required files, required directories, and platform executable path.

## Why

Sentry issue `128134003` showed a Windows x64 install where AionUi could start, but bundled managed resources were missing the exact Codex ACP runtime path required at runtime:

```text
managed-resources/acp/codex-acp/1.1.2/win32-x64
```

The previous verification path could accept any structurally complete existing ACP version directory. This change makes AionCore publish the exact runtime-owned contract that downstream packaging and installation gates can consume.

## Validation

- `just push -u origin aionissue/fix-2.1.33-128134003-001`
- `cargo fmt --all -- --check`
- `cargo test -p aionui-runtime managed_resources_contract -- --nocapture`
- `cargo test -p aionui-runtime managed_node_contract -- --nocapture`
- `cargo test -p aionui-runtime managed_acp_contract -- --nocapture`
- `cargo test -p aionui-runtime bundled_runtime_missing_reports_bundled_resource_missing -- --nocapture`
- `cargo test -p aionui-runtime bundled_acp_tool_missing_reports_bundled_resource_missing -- --nocapture`
- `cargo test -p aionui-app prepare_error -- --nocapture`
- `cargo clippy -p aionui-runtime -p aionui-app -- -D warnings`

## Release Notes

AionUi packaging must use an AionCore build or tag that includes this manifest producer before the matching AionUi consumer change is released.

Real six-runtime release artifact smoke coverage and actual Windows installer execution still need to be run against generated or unpacked release artifacts.
