### PR TITLE
feat(agent): add Pi ACP support

### DIFF
--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -531,8 +531,9 @@ fn decode_row(
     };
 
     let backend_str = row.backend.as_deref().unwrap_or("");
-    let team_capable = behavior_policy.supports_team
+    let inferred_team_capable = behavior_policy.supports_team
         || aionui_common::constants::is_team_capable(backend_str, handshake.agent_capabilities.as_ref());
+    let team_capable = behavior_policy.team_capable_override.unwrap_or(inferred_team_capable);
 
     let mut meta = AgentMetadata {
         id: row.id,
@@ -1245,7 +1246,7 @@ mod tests {
         // when none of the CLIs are installed on the test host.
         let reg = registry().await;
         let all = reg.list_all_including_hidden().await;
-        assert_eq!(all.len(), 21);
+        assert_eq!(all.len(), 22);
     }
 
     #[tokio::test]
@@ -1285,6 +1286,28 @@ mod tests {
         assert_eq!(hermes.yolo_id, None);
     }
 
+    #[tokio::test]
+    async fn pi_builtin_uses_pinned_acp_adapter_and_requires_pi_cli() {
+        let reg = registry().await;
+        let pi = reg.find_builtin_by_backend("pi").await.unwrap();
+
+        assert_eq!(pi.command.as_deref(), Some("npx"));
+        assert_eq!(pi.args, ["-y", "pi-acp@0.0.31"]);
+        assert_eq!(pi.agent_source_info.binary_name.as_deref(), Some("pi"));
+        assert_eq!(pi.agent_source_info.bridge_binary.as_deref(), Some("npx"));
+        assert_eq!(pi.native_skills_dirs.as_deref(), Some(&[".pi/skills".to_owned()][..]));
+        assert!(!pi.team_capable);
+        assert_eq!(pi.yolo_id, None);
+        assert_eq!(
+            pi.handshake
+                .agent_capabilities
+                .as_ref()
+                .and_then(|capabilities| capabilities.get("load_session"))
+                .and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+    }
+
     /// On a host that has *none* of the seeded CLIs installed, the
     /// public listing collapses to the rows that don't need one
     /// (Aion CLI is `agent_source = internal` with no `command`).
@@ -1317,7 +1340,7 @@ mod tests {
         let reg = registry().await;
         let all = reg.list_all_including_hidden().await;
         let count = |t: AgentType| all.iter().filter(|m| m.agent_type == t).count();
-        assert_eq!(count(AgentType::Acp), 18);
+        assert_eq!(count(AgentType::Acp), 19);
         assert_eq!(count(AgentType::Nanobot), 1);
         assert_eq!(count(AgentType::OpenclawGateway), 1);
         assert_eq!(count(AgentType::Aionrs), 1);
@@ -1427,7 +1450,7 @@ mod tests {
     async fn diagnostic_snapshot_pairs_rows_with_reasons() {
         let reg = registry().await;
         let snapshot = reg.diagnostic_snapshot().await;
-        assert_eq!(snapshot.len(), 21, "every row appears once");
+        assert_eq!(snapshot.len(), 22, "every row appears once");
 
         for (meta, reason) in &snapshot {
             match (meta.available, reason) {

--- a/crates/aionui-api-types/src/agent_discovery.rs
+++ b/crates/aionui-api-types/src/agent_discovery.rs
@@ -83,6 +83,15 @@ pub struct BehaviorPolicy {
 
     #[serde(default)]
     pub supports_team: bool,
+
+    /// Explicitly override team-mode inference for protocol outliers.
+    ///
+    /// ACP normally requires stdio MCP support, so the presence of
+    /// `mcp_capabilities` is enough to infer team support. Some adapters accept
+    /// `mcpServers` but do not wire them into the wrapped agent; those adapters
+    /// must set this to `Some(false)`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team_capable_override: Option<bool>,
 }
 
 /// Handshake-derived fields captured from the ACP init/session-response.
@@ -207,8 +216,8 @@ pub struct AgentMetadata {
     pub sort_order: i64,
 
     /// Whether this agent supports team mode. Derived at hydrate time from
-    /// the hard whitelist + persisted `agent_capabilities` MCP declarations.
-    /// Not a persisted column.
+    /// the behavior policy, hard whitelist, and persisted `agent_capabilities`
+    /// MCP declarations. Not a persisted column.
     #[serde(default)]
     pub team_capable: bool,
 
@@ -444,11 +453,22 @@ mod behavior_policy_tests {
     fn supports_team_defaults_false_and_roundtrips() {
         let empty: BehaviorPolicy = serde_json::from_str("{}").unwrap();
         assert!(!empty.supports_team);
+        assert_eq!(empty.team_capable_override, None);
 
         let with_team: BehaviorPolicy = serde_json::from_str(r#"{"supports_team":true}"#).unwrap();
         assert!(with_team.supports_team);
 
         let serialized = serde_json::to_string(&with_team).unwrap();
         assert!(serialized.contains("\"supports_team\":true"));
+        assert!(!serialized.contains("team_capable_override"));
+    }
+
+    #[test]
+    fn team_capable_override_roundtrips_explicit_false() {
+        let policy: BehaviorPolicy = serde_json::from_str(r#"{"team_capable_override":false}"#).unwrap();
+        assert_eq!(policy.team_capable_override, Some(false));
+
+        let serialized = serde_json::to_string(&policy).unwrap();
+        assert!(serialized.contains("\"team_capable_override\":false"));
     }
 }

--- a/crates/aionui-assets/assets/logos/tools/coding/pi.svg
+++ b/crates/aionui-assets/assets/logos/tools/coding/pi.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M1 1H11.7692V7.9999H8.17942V11.4999H4.58982V15H1V1ZM4.58982 4.50005V7.9999H8.17942V4.50005H4.58982Z" fill="currentColor"/>
+  <path d="M11.7692 7.46154H15V15H11.7692V7.46154Z" fill="currentColor"/>
+</svg>

--- a/crates/aionui-db/migrations/023_add_pi_acp_agent.sql
+++ b/crates/aionui-db/migrations/023_add_pi_acp_agent.sql
@@ -1,0 +1,43 @@
+-- Add Pi through the pi-acp adapter listed in the official ACP Registry.
+--
+-- Registry distribution:
+-- https://github.com/agentclientprotocol/registry/blob/main/pi-acp/agent.json
+-- Verified initialization against pi-acp 0.0.31 and Pi 0.80.7:
+-- ~/aion/protocols/samples/pi-acp/0.0.31/initialize-list.ndjson
+-- Pi's lack of mcpServers support:
+-- https://github.com/svkozak/pi-acp/blob/v0.0.31/src/acp/agent.ts
+INSERT INTO agent_metadata
+    (id, icon, name, description, backend, agent_type, agent_source, agent_source_info,
+     enabled, command, args, env, native_skills_dirs, behavior_policy, yolo_id,
+     agent_capabilities, auth_methods, sort_order, created_at, updated_at)
+VALUES
+    ('c3f8a2b1', '/api/assets/logos/tools/coding/pi.svg', 'Pi',
+     'Pi coding agent through the pi-acp adapter',
+     'pi', 'acp', 'builtin', '{"binary_name":"pi","bridge_binary":"npx","version":"0.0.31"}',
+     1, 'npx', '["-y","pi-acp@0.0.31"]', '[]',
+     '[".pi/skills"]',
+     '{"supports_side_question":false,"supports_team":false,"team_capable_override":false}',
+     NULL,
+     '{"load_session":true,"mcp_capabilities":{"http":false,"sse":false},"prompt_capabilities":{"image":true,"audio":false,"embedded_context":false},"session_capabilities":{"list":{}}}',
+     '[{"id":"pi_terminal_login","name":"Launch pi in the terminal","description":"Start pi in an interactive terminal to configure API keys or login","type":"terminal","args":["--terminal-login"],"env":{}}]',
+     3130,
+     unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000)
+ON CONFLICT(id) DO UPDATE SET
+    icon = excluded.icon,
+    name = excluded.name,
+    description = excluded.description,
+    backend = excluded.backend,
+    agent_type = excluded.agent_type,
+    agent_source = excluded.agent_source,
+    agent_source_info = excluded.agent_source_info,
+    enabled = excluded.enabled,
+    command = excluded.command,
+    args = excluded.args,
+    env = excluded.env,
+    native_skills_dirs = excluded.native_skills_dirs,
+    behavior_policy = excluded.behavior_policy,
+    yolo_id = excluded.yolo_id,
+    agent_capabilities = excluded.agent_capabilities,
+    auth_methods = excluded.auth_methods,
+    sort_order = excluded.sort_order,
+    updated_at = unixepoch('now','subsec')*1000;

--- a/crates/aionui-db/src/repository/sqlite_agent_metadata.rs
+++ b/crates/aionui-db/src/repository/sqlite_agent_metadata.rs
@@ -644,8 +644,8 @@ mod tests {
     async fn seed_rows_populated_after_migrations() {
         let (repo, _db) = setup().await;
         let rows = repo.list_all().await.unwrap();
-        // 18 ACP vendors + 2 non-ACP builtins + 1 internal = 21.
-        assert_eq!(rows.len(), 21);
+        // 19 ACP vendors + 2 non-ACP builtins + 1 internal = 22.
+        assert_eq!(rows.len(), 22);
         assert!(
             rows.iter()
                 .any(|r| r.name == "Claude Code" && r.agent_source == "builtin")
@@ -674,6 +674,12 @@ mod tests {
             .find(|r| r.name == "Codex CLI" && r.backend.as_deref() == Some("codex") && r.agent_source == "builtin")
             .expect("seeded codex row");
         assert_eq!(codex.yolo_id.as_deref(), Some("agent-full-access"));
+        let pi = rows
+            .iter()
+            .find(|r| r.name == "Pi" && r.backend.as_deref() == Some("pi") && r.agent_source == "builtin")
+            .expect("seeded Pi ACP row");
+        assert_eq!(pi.command.as_deref(), Some("npx"));
+        assert_eq!(pi.args.as_deref(), Some(r#"["-y","pi-acp@0.0.31"]"#));
     }
 
     #[tokio::test]

--- a/crates/aionui-db/tests/pi_acp_agent_migration.rs
+++ b/crates/aionui-db/tests/pi_acp_agent_migration.rs
@@ -1,0 +1,38 @@
+use aionui_db::{IAgentMetadataRepository, SqliteAgentMetadataRepository, init_database_memory};
+
+#[tokio::test]
+async fn pi_acp_builtin_metadata_is_seeded() {
+    let db = init_database_memory().await.unwrap();
+    let repo = SqliteAgentMetadataRepository::new(db.pool().clone());
+
+    let pi = repo.get("c3f8a2b1").await.unwrap().expect("seeded Pi ACP row");
+
+    assert_eq!(pi.name, "Pi");
+    assert_eq!(pi.backend.as_deref(), Some("pi"));
+    assert_eq!(pi.agent_type, "acp");
+    assert_eq!(pi.agent_source, "builtin");
+    assert_eq!(pi.command.as_deref(), Some("npx"));
+    assert_eq!(pi.args.as_deref(), Some(r#"["-y","pi-acp@0.0.31"]"#));
+    assert_eq!(
+        pi.agent_source_info.as_deref(),
+        Some(r#"{"binary_name":"pi","bridge_binary":"npx","version":"0.0.31"}"#)
+    );
+    assert_eq!(pi.native_skills_dirs.as_deref(), Some(r#"[".pi/skills"]"#));
+    assert_eq!(pi.yolo_id, None);
+
+    let behavior_policy: serde_json::Value =
+        serde_json::from_str(pi.behavior_policy.as_deref().expect("seeded behavior policy")).unwrap();
+    assert_eq!(behavior_policy["team_capable_override"], false);
+
+    let capabilities: serde_json::Value =
+        serde_json::from_str(pi.agent_capabilities.as_deref().expect("seeded capabilities")).unwrap();
+    assert_eq!(capabilities["load_session"], true);
+    assert_eq!(capabilities["session_capabilities"]["list"], serde_json::json!({}));
+    assert_eq!(capabilities["mcp_capabilities"]["http"], false);
+    assert_eq!(capabilities["mcp_capabilities"]["sse"], false);
+
+    let auth_methods: serde_json::Value =
+        serde_json::from_str(pi.auth_methods.as_deref().expect("seeded auth methods")).unwrap();
+    assert_eq!(auth_methods[0]["id"], "pi_terminal_login");
+    assert_eq!(auth_methods[0]["type"], "terminal");
+}


### PR DESCRIPTION
## Summary

- add Pi as a built-in ACP agent through the official Registry adapter `pi-acp@0.0.31`
- detect both the `pi` CLI and the `npx` bridge before marking the agent available
- register Pi project skills from `.pi/skills` and add the official Pi logo
- preserve Pi's advertised ACP capabilities while disabling team mode because `pi-acp` does not connect `mcpServers`

## Verification

- `cargo nextest run -p aionui-api-types -p aionui-db -p aionui-ai-agent`
- `just push -u origin feat/pi-acp-support` (migration check, workspace clippy/fmt, and workspace nextest)
- live ACP `initialize` and `session/new` capture against `pi-acp@0.0.31` with Pi `0.80.7`

## Sources

- ACP Registry: https://github.com/agentclientprotocol/registry/blob/main/pi-acp/agent.json
- Adapter source: https://github.com/svkozak/pi-acp/tree/v0.0.31
- Pi skills documentation: `packages/coding-agent/docs/skills.md` from Pi `0.80.7`

## Known adapter behavior: thinking is also advertised as legacy modes

A live `session/new` response from `pi-acp@0.0.31` with Pi `0.80.7` contains both of the following:

```json
{
  "configOptions": [
    {
      "id": "thought_level",
      "category": "thought_level",
      "currentValue": "off",
      "options": ["off", "minimal", "low", "medium", "high", "xhigh"]
    }
  ],
  "modes": {
    "currentModeId": "off",
    "availableModes": [
      { "id": "off", "name": "Thinking: off" },
      { "id": "minimal", "name": "Thinking: minimal" },
      { "id": "low", "name": "Thinking: low" },
      { "id": "medium", "name": "Thinking: medium" },
      { "id": "high", "name": "Thinking: high" },
      { "id": "xhigh", "name": "Thinking: xhigh" }
    ]
  }
}
```

Consequently, an ACP client that renders legacy `modes` as authorization modes and `configOptions[category=thought_level]` as thought levels can show the same Thinking choices in both selectors. This is not caused by AionCore deriving `available_modes` from the `thought_level` config option: `pi-acp` itself builds and returns both fields (`src/acp/agent.ts`, `getThinkingState()` and `getSessionConfiguration()`).

After a selection, ACP `current_mode_update` contains only `currentModeId`, so the persisted `available_modes` snapshot may temporarily contain only `{ "current_mode_id": "medium" }`; that is the generic incremental catalog update shape, not a Pi metadata seed.

This PR deliberately preserves the upstream `pi-acp` wire contract and does not add a Pi-specific UI or protocol remapping in AionCore.

Addresses iOfficeAI/AionUi#3570.
