### PR TITLE
fix(agents): honor login PATH and validate builtin CLIs

### DIFF
--- a/crates/aionui-ai-agent/src/cli_probe.rs
+++ b/crates/aionui-ai-agent/src/cli_probe.rs
@@ -1,0 +1,116 @@
+use std::time::Duration;
+
+use aionui_api_types::AgentMetadata;
+use aionui_runtime::{Builder, resolve_command_path};
+#[cfg(test)]
+use std::path::PathBuf;
+
+const CLI_VERSION_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub(crate) fn command_name(meta: &AgentMetadata) -> Option<&str> {
+    if meta.has_command_override
+        && let Some(command) = meta.command.as_deref().filter(|command| !command.is_empty())
+    {
+        return Some(command);
+    }
+
+    meta.agent_source_info
+        .binary_name
+        .as_deref()
+        .or(meta.command.as_deref())
+}
+
+pub(crate) async fn validate(meta: &AgentMetadata) -> Result<(), String> {
+    let command = command_name(meta).ok_or_else(|| "agent has no CLI command to probe".to_owned())?;
+    let path = resolve_command_path(command).ok_or_else(|| format!("`{command}` not found on PATH"))?;
+    validate_version(&path).await
+}
+
+#[cfg(test)]
+async fn resolve_and_validate_command(command: &str) -> Result<PathBuf, String> {
+    let path = resolve_command_path(command).ok_or_else(|| format!("`{command}` not found on PATH"))?;
+    validate_version(&path).await?;
+    Ok(path)
+}
+
+async fn validate_version(path: &std::path::Path) -> Result<(), String> {
+    validate_version_with_timeout(path, CLI_VERSION_TIMEOUT).await
+}
+
+async fn validate_version_with_timeout(path: &std::path::Path, timeout: Duration) -> Result<(), String> {
+    let mut command = Builder::clean_cli(path);
+    command.arg("--version");
+
+    let output = tokio::time::timeout(timeout, command.output())
+        .await
+        .map_err(|_| {
+            format!(
+                "`{} --version` timed out after {}ms",
+                path.display(),
+                timeout.as_millis()
+            )
+        })?
+        .map_err(|error| format!("failed to run `{} --version`: {error}", path.display()))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let detail = first_nonempty_line(&output.stderr)
+        .or_else(|| first_nonempty_line(&output.stdout))
+        .unwrap_or_else(|| format!("exited with status {}", output.status));
+    Err(format!("`{} --version` failed: {detail}", path.display()))
+}
+
+fn first_nonempty_line(bytes: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(bytes)
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(|line| line.chars().take(500).collect())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    fn executable_script(name: &str, contents: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(name);
+        std::fs::write(&path, contents).unwrap();
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&path, permissions).unwrap();
+        (dir, path)
+    }
+
+    #[tokio::test]
+    async fn version_probe_accepts_runnable_cli() {
+        let (_dir, path) = executable_script("agent-cli", "#!/bin/sh\nprintf 'agent-cli 1.2.3\\n'\n");
+        assert_eq!(
+            resolve_and_validate_command(path.to_str().unwrap()).await.unwrap(),
+            path
+        );
+    }
+
+    #[tokio::test]
+    async fn version_probe_rejects_broken_cli_wrapper() {
+        let (_dir, path) = executable_script(
+            "agent-cli",
+            "#!/bin/sh\nprintf 'native binary missing\\n' >&2\nexit 1\n",
+        );
+        let error = resolve_and_validate_command(path.to_str().unwrap()).await.unwrap_err();
+        assert!(error.contains("native binary missing"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn version_probe_times_out_hung_cli() {
+        let (_dir, path) = executable_script("agent-cli", "#!/bin/sh\nsleep 10\n");
+        let error = validate_version_with_timeout(&path, Duration::from_millis(50))
+            .await
+            .unwrap_err();
+        assert!(error.contains("timed out after 50ms"), "{error}");
+    }
+}

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -6,6 +6,7 @@ pub(crate) mod agent_runtime;
 pub mod agent_task;
 pub mod capability;
 pub mod cc_switch;
+pub(crate) mod cli_probe;
 pub(crate) mod dev_prompt_dump;
 pub mod error;
 pub mod factory;

--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -27,6 +27,7 @@ use aionui_runtime::{
     ManagedAcpToolId, RuntimeCommandProbe, probe_managed_acp_tool_supported, probe_node_runtime_supported,
     probe_runtime_command, resolve_command_path,
 };
+use futures_util::StreamExt;
 use serde_json::{Value, json};
 use tokio::sync::{RwLock, mpsc};
 use tracing::{debug, info, warn};
@@ -40,6 +41,7 @@ use crate::manager::acp::config_option_catalog::{
 /// drains it serially, so the bound just sizes the burst we can absorb
 /// before producers start to back off.
 const CATALOG_SYNC_CHANNEL_CAPACITY: usize = 256;
+const CLI_PROBE_CONCURRENCY: usize = 8;
 
 /// One unit of work submitted to the catalog sync consumer task.
 #[derive(Debug)]
@@ -190,8 +192,8 @@ impl AgentRegistry {
     }
     /// Reload every row from the database and refresh installation state.
     ///
-    /// Startup remains side-effect free: this only checks whether the required
-    /// command / managed runtime can be resolved. It does not start agents,
+    /// Startup checks whether required commands / managed runtimes resolve and
+    /// runs a bounded `<primary-cli> --version` probe for builtin agents. It does not start sessions,
     /// perform handshakes, fetch models, or overwrite persisted health-check
     /// snapshots. User-facing health checks stay explicit.
     pub async fn hydrate(&self) -> Result<(), AgentError> {
@@ -201,12 +203,15 @@ impl AgentRegistry {
             .await
             .map_err(|e| AgentError::internal(format!("load agent_metadata: {e}")))?;
 
-        let mut map = HashMap::with_capacity(rows.len());
+        let candidates: Vec<_> = rows
+            .into_iter()
+            .filter_map(|row| decode_row(row, AvailabilityProjection::Probe))
+            .collect();
+        let validated = validate_cli_candidates(candidates).await;
+
+        let mut map = HashMap::with_capacity(validated.len());
         let mut reasons = HashMap::new();
-        for row in rows {
-            let Some((meta, reason)) = decode_row(row, AvailabilityProjection::Probe) else {
-                continue;
-            };
+        for (meta, reason) in validated {
             if let Some(reason) = reason {
                 reasons.insert(meta.id.clone(), reason);
             }
@@ -224,16 +229,33 @@ impl AgentRegistry {
     /// Re-probe every row's command without refetching from the DB.
     /// Useful after PATH has changed (e.g. `launchctl setenv`).
     pub async fn refresh_availability(&self) {
-        let mut guard = self.by_id.write().await;
+        let snapshot: Vec<AgentMetadata> = self.by_id.read().await.values().cloned().collect();
+        let candidates: Vec<_> = snapshot
+            .into_iter()
+            .map(|mut meta| {
+                let (path, reason) = probe_with_reason(&meta);
+                meta.resolved_command = path;
+                meta.available = meta.resolved_command.is_some() || is_internal_commandless_agent(&meta);
+                let reason = if meta.available { None } else { reason };
+                (meta, reason)
+            })
+            .collect();
+        let validated = validate_cli_candidates(candidates).await;
+
+        let mut results = Vec::with_capacity(validated.len());
         let mut reasons = HashMap::new();
-        for meta in guard.values_mut() {
-            let (path, reason) = probe_with_reason(meta);
-            meta.resolved_command = path;
-            meta.available = meta.resolved_command.is_some() || is_internal_commandless_agent(meta);
-            let reason = if meta.available { None } else { reason };
-            log_probe_result(meta, &reason);
+        for (meta, reason) in validated {
+            log_probe_result(&meta, &reason);
+            results.push((meta.id.clone(), meta.available, meta.resolved_command.clone()));
             if let Some(reason) = reason {
                 reasons.insert(meta.id.clone(), reason);
+            }
+        }
+        let mut guard = self.by_id.write().await;
+        for (id, available, resolved_command) in results {
+            if let Some(meta) = guard.get_mut(&id) {
+                meta.available = available;
+                meta.resolved_command = resolved_command;
             }
         }
         log_availability_summary(guard.values(), "AgentRegistry refresh_availability complete");
@@ -258,6 +280,7 @@ impl AgentRegistry {
             self.unavailable_reasons.write().await.remove(id);
             return Ok(None);
         };
+        let (meta, reason) = validate_cli_availability(meta, reason).await;
         log_probe_result(&meta, &reason);
         self.update_cached_unavailable_reason(&meta.id, reason).await;
         self.by_id.write().await.insert(meta.id.clone(), meta.clone());
@@ -638,6 +661,38 @@ fn apply_probe_availability(meta: &mut AgentMetadata) -> Option<UnavailableReaso
     if meta.available { None } else { reason }
 }
 
+async fn validate_cli_availability(
+    mut meta: AgentMetadata,
+    reason: Option<UnavailableReason>,
+) -> (AgentMetadata, Option<UnavailableReason>) {
+    if !meta.available || meta.agent_source != AgentSource::Builtin {
+        return (meta, reason);
+    }
+
+    let Some(binary) = crate::cli_probe::command_name(&meta).map(str::to_owned) else {
+        return (meta, reason);
+    };
+
+    match crate::cli_probe::validate(&meta).await {
+        Ok(()) => (meta, None),
+        Err(detail) => {
+            meta.available = false;
+            meta.resolved_command = None;
+            (meta, Some(UnavailableReason::PrimaryUnusable { binary, detail }))
+        }
+    }
+}
+
+async fn validate_cli_candidates(
+    candidates: Vec<(AgentMetadata, Option<UnavailableReason>)>,
+) -> Vec<(AgentMetadata, Option<UnavailableReason>)> {
+    futures_util::stream::iter(candidates)
+        .map(|(meta, reason)| validate_cli_availability(meta, reason))
+        .buffer_unordered(CLI_PROBE_CONCURRENCY)
+        .collect()
+        .await
+}
+
 fn apply_cached_availability(meta: &mut AgentMetadata) -> Option<UnavailableReason> {
     if !meta.enabled {
         meta.available = false;
@@ -672,6 +727,10 @@ fn is_builtin_managed_agent(meta: &AgentMetadata) -> bool {
             .as_deref()
             .and_then(ManagedAcpToolId::from_backend)
             .is_some()
+}
+
+fn is_builtin_codex(meta: &AgentMetadata) -> bool {
+    meta.agent_source == AgentSource::Builtin && meta.backend.as_deref() == Some("codex")
 }
 
 fn has_availability_snapshot(meta: &AgentMetadata) -> bool {
@@ -961,6 +1020,10 @@ fn diagnostic_details_for_unavailable_reason(reason: &UnavailableReason) -> Opti
             "code": "primary_missing",
             "command": binary,
         })),
+        UnavailableReason::PrimaryUnusable { binary, .. } => Some(json!({
+            "code": "primary_unusable",
+            "command": binary,
+        })),
         UnavailableReason::CommandMissing { command } => Some(json!({
             "code": "command_missing",
             "command": command,
@@ -978,6 +1041,7 @@ fn unavailable_reason_code(reason: &UnavailableReason) -> String {
         UnavailableReason::NoCommand => "no_command",
         UnavailableReason::BridgeMissing { .. } => "bridge_missing",
         UnavailableReason::PrimaryMissing { .. } => "primary_missing",
+        UnavailableReason::PrimaryUnusable { .. } => "primary_unusable",
         UnavailableReason::CommandMissing { .. } => "command_missing",
         UnavailableReason::ManagedRuntimeUnavailable { .. } => "managed_runtime_unavailable",
     }
@@ -995,6 +1059,9 @@ fn guidance_for_unavailable_reason(reason: &UnavailableReason) -> String {
         }
         UnavailableReason::PrimaryMissing { binary } => {
             format!("Install `{binary}` and make sure it is available on PATH, then run Test Connection again.")
+        }
+        UnavailableReason::PrimaryUnusable { binary, .. } => {
+            format!("Repair or reinstall `{binary}`, then run Test Connection again.")
         }
         UnavailableReason::CommandMissing { command } => {
             format!("Install `{command}` and make sure it is available on PATH, then run Test Connection again.")
@@ -1121,6 +1188,9 @@ pub enum UnavailableReason {
     /// Primary CLI (`agent_source_info.binary_name`, e.g. `claude`
     /// for the bridged Claude row) is not on `$PATH`.
     PrimaryMissing { binary: String },
+    /// Primary CLI resolves on `$PATH`, but its lightweight version probe
+    /// failed, so the wrapper cannot be treated as runnable.
+    PrimaryUnusable { binary: String, detail: String },
     /// Spawn command itself (`command` field) is not on `$PATH`. For
     /// direct-CLI rows this is the same binary as `binary_name`; for
     /// bridge rows it's the bridge.
@@ -1137,6 +1207,9 @@ impl std::fmt::Display for UnavailableReason {
             Self::NoCommand => f.write_str("no spawn command configured"),
             Self::BridgeMissing { bridge } => write!(f, "bridge binary `{bridge}` not on $PATH"),
             Self::PrimaryMissing { binary } => write!(f, "primary binary `{binary}` not on $PATH"),
+            Self::PrimaryUnusable { binary, detail } => {
+                write!(f, "primary binary `{binary}` is not runnable: {detail}")
+            }
             Self::CommandMissing { command } => write!(f, "spawn command `{command}` not on $PATH"),
             Self::ManagedRuntimeUnavailable { resource, detail } => {
                 write!(f, "managed `{resource}` unavailable: {detail}")
@@ -1159,6 +1232,13 @@ impl std::fmt::Display for UnavailableReason {
 fn probe_resolved_command(meta: &AgentMetadata) -> Result<PathBuf, UnavailableReason> {
     if !meta.enabled {
         return Err(UnavailableReason::Disabled);
+    }
+
+    if is_builtin_codex(meta) {
+        let primary = crate::cli_probe::command_name(meta).unwrap_or("codex");
+        return probe_command_candidate(primary).ok_or_else(|| UnavailableReason::PrimaryMissing {
+            binary: primary.to_owned(),
+        });
     }
 
     if meta.agent_source == AgentSource::Builtin

--- a/crates/aionui-ai-agent/src/registry_tests.rs
+++ b/crates/aionui-ai-agent/src/registry_tests.rs
@@ -4,13 +4,13 @@ use aionui_db::{
 };
 use std::sync::Arc;
 
-#[test]
-fn probe_resolved_command_accepts_bare_npx_when_managed_runtime_is_supported() {
+#[tokio::test]
+async fn probe_resolved_command_keeps_bridge_but_version_probe_targets_primary_cli() {
     if !probe_node_runtime_supported().is_supported() {
         return;
     }
 
-    let meta = AgentMetadata {
+    let mut meta = AgentMetadata {
         id: "agent-1".into(),
         icon: None,
         name: "Test ACP".into(),
@@ -19,8 +19,12 @@ fn probe_resolved_command_accepts_bare_npx_when_managed_runtime_is_supported() {
         description_i18n: None,
         backend: Some("custom".into()),
         agent_type: AgentType::Acp,
-        agent_source: AgentSource::Custom,
-        agent_source_info: AgentSourceInfo::default(),
+        agent_source: AgentSource::Builtin,
+        agent_source_info: AgentSourceInfo {
+            binary_name: Some("cargo".into()),
+            bridge_binary: Some("npx".into()),
+            ..Default::default()
+        },
         enabled: true,
         available: false,
         command: Some("npx".into()),
@@ -49,6 +53,13 @@ fn probe_resolved_command_accepts_bare_npx_when_managed_runtime_is_supported() {
 
     let resolved = probe_resolved_command(&meta).expect("probe");
     assert_eq!(resolved, PathBuf::from("npx"));
+    assert_eq!(crate::cli_probe::command_name(&meta), Some("cargo"));
+
+    meta.available = true;
+    meta.resolved_command = Some(resolved);
+    let (meta, reason) = validate_cli_availability(meta, None).await;
+    assert!(reason.is_none());
+    assert_eq!(meta.resolved_command, Some(PathBuf::from("npx")));
 }
 
 #[test]
@@ -222,6 +233,74 @@ async fn management_rows_derive_missing_diagnostics_from_probe_reason() {
     assert_eq!(
         row_json["last_check_error_details"]["command"].as_str(),
         Some("definitely-missing-cli")
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn builtin_non_codex_with_broken_wrapper_is_not_installed() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let db = init_database_memory().await.unwrap();
+    let repo: Arc<dyn IAgentMetadataRepository> = Arc::new(SqliteAgentMetadataRepository::new(db.pool().clone()));
+    let temp = tempfile::tempdir().unwrap();
+    let command_path = temp.path().join("gemini");
+    std::fs::write(
+        &command_path,
+        "#!/bin/sh\nprintf 'native binary missing\\n' >&2\nexit 1\n",
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&command_path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&command_path, permissions).unwrap();
+    let command = command_path.to_string_lossy().to_string();
+    let source_info = serde_json::json!({ "binary_name": command }).to_string();
+
+    repo.upsert(&UpsertAgentMetadataParams {
+        id: "agent-broken-gemini",
+        icon: None,
+        name: "Broken Gemini",
+        name_i18n: None,
+        description: None,
+        description_i18n: None,
+        backend: Some("gemini"),
+        agent_type: "acp",
+        agent_source: "builtin",
+        agent_source_info: Some(&source_info),
+        enabled: true,
+        command: Some(&command),
+        args: Some("[]"),
+        env: Some("[]"),
+        native_skills_dirs: None,
+        behavior_policy: None,
+        yolo_id: None,
+        agent_capabilities: None,
+        auth_methods: None,
+        config_options: None,
+        available_modes: None,
+        available_models: None,
+        available_commands: None,
+        sort_order: 100,
+    })
+    .await
+    .unwrap();
+
+    let registry = AgentRegistry::new(repo);
+    registry.hydrate().await.unwrap();
+
+    let row = registry
+        .list_management_rows()
+        .await
+        .into_iter()
+        .find(|item| item.id == "agent-broken-gemini")
+        .unwrap();
+    assert!(!row.installed);
+    assert_eq!(row.status, AgentManagementStatus::Missing);
+    assert_eq!(row.last_check_error_code.as_deref(), Some("primary_unusable"));
+    assert!(
+        row.last_check_error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("native binary missing"))
     );
 }
 

--- a/crates/aionui-app/src/commands/cmd_doctor.rs
+++ b/crates/aionui-app/src/commands/cmd_doctor.rs
@@ -139,7 +139,7 @@ fn print_snapshot(snapshot: &[(aionui_api_types::AgentMetadata, Option<Unavailab
 
     if unavailable > 0 {
         println!();
-        println!("Tip: rows marked `missing` could not resolve their CLI on $PATH from this shell.");
+        println!("Tip: rows marked `missing` could not resolve or run their CLI from this shell.");
         println!("     If a CLI is installed but missing here, the Electron app may inherit a different PATH —");
         println!("     reproduce by launching the app from this same shell or check launchctl/setenv setup.");
     }
@@ -151,6 +151,9 @@ fn describe_reason(reason: &UnavailableReason) -> String {
         UnavailableReason::NoCommand => "no spawn command configured (seed data bug)".to_owned(),
         UnavailableReason::BridgeMissing { bridge } => format!("bridge `{bridge}` not on $PATH"),
         UnavailableReason::PrimaryMissing { binary } => format!("CLI `{binary}` not on $PATH"),
+        UnavailableReason::PrimaryUnusable { binary, detail } => {
+            format!("CLI `{binary}` is not runnable: {detail}")
+        }
         UnavailableReason::CommandMissing { command } => format!("`{command}` not on $PATH"),
         UnavailableReason::ManagedRuntimeUnavailable { resource, detail } => {
             format!("managed `{resource}` unavailable: {detail}")

--- a/crates/aionui-runtime/src/shell_env.rs
+++ b/crates/aionui-runtime/src/shell_env.rs
@@ -5,10 +5,10 @@
 //! `std::env::var("PATH")` to include:
 //!
 //! 1. An explicit bun override directory, if configured.
-//! 2. Platform extra bins (`~/.bun/bin`, `~/.cargo/bin`, etc.).
-//! 3. The current `PATH` (inherited from the launching process).
-//! 4. The login-shell `PATH` (Unix only, 3s timeout) — fixes
+//! 2. The interactive login-shell `PATH` (Unix only, 3s timeout) — fixes
 //!    launchd / Finder / systemd-service starts.
+//! 3. The current `PATH` (inherited from the launching process).
+//! 4. Platform extra bins (`~/.bun/bin`, `~/.cargo/bin`, etc.) as fallbacks.
 //!
 //! After this runs, all downstream `which::which(...)` and
 //! `Command::new(...)` calls see the enhanced PATH with zero further
@@ -55,7 +55,9 @@ pub unsafe fn enhance_process_path() -> String {
 // Placeholder helpers — filled in by later tasks.
 
 fn merge_paths(bun_dir: Option<&Path>, extras: &[PathBuf], current: &str, login: Option<&str>) -> String {
-    // Order: bun_dir, extras, current, login. First-occurrence wins.
+    // Order: bun_dir, login, current, extras. First-occurrence wins.
+    // Scanned version-manager bins are fallbacks and must not override the
+    // Node version selected by the user's interactive login shell.
     // `env::split_paths` and `env::join_paths` honour the OS-specific
     // separator (':' on Unix, ';' on Windows) and handle quoting.
     let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
@@ -73,16 +75,16 @@ fn merge_paths(bun_dir: Option<&Path>, extras: &[PathBuf], current: &str, login:
     if let Some(p) = bun_dir {
         push(p.to_path_buf());
     }
-    for p in extras {
-        push(p.clone());
-    }
-    for p in std::env::split_paths(current) {
-        push(p);
-    }
     if let Some(l) = login {
         for p in std::env::split_paths(l) {
             push(p);
         }
+    }
+    for p in std::env::split_paths(current) {
+        push(p);
+    }
+    for p in extras {
+        push(p.clone());
     }
 
     std::env::join_paths(&parts)
@@ -177,7 +179,7 @@ fn login_shell_path() -> Option<String> {
     }
 
     let mut child = match Command::new(&shell)
-        .args(["-l", "-c", "printf %s \"$PATH\""])
+        .args(["-l", "-i", "-c", "printf %s \"$PATH\""])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -248,7 +250,24 @@ mod tests {
         let result = merge_paths(None, &extras, &current, Some(&login));
         let parts: Vec<&str> = result.split(s).collect();
 
-        assert_eq!(parts, vec!["/e", "/a", "/b", "/c", "/d"]);
+        assert_eq!(parts, vec!["/b", "/d", "/a", "/c", "/e"]);
+    }
+
+    #[test]
+    fn merge_paths_prefers_login_nvm_bin_over_inherited_and_scanned_versions() {
+        let s = sep();
+        let active = "/home/user/.nvm/versions/node/v22.22.0/bin";
+        let newer = PathBuf::from("/home/user/.nvm/versions/node/v25.1.0/bin");
+        let current = format!("/opt/homebrew/bin{s}/usr/bin");
+        let login = format!("{active}{s}/opt/homebrew/bin{s}/usr/bin");
+
+        let result = merge_paths(None, &[newer.clone(), PathBuf::from(active)], &current, Some(&login));
+        let parts: Vec<&str> = result.split(s).collect();
+
+        assert_eq!(
+            parts,
+            vec![active, "/opt/homebrew/bin", "/usr/bin", newer.to_str().unwrap()]
+        );
     }
 
     #[test]

--- a/crates/aionui-runtime/src/shell_env.rs
+++ b/crates/aionui-runtime/src/shell_env.rs
@@ -4,11 +4,10 @@
 //! is spawned** (including the tokio runtime). It rewrites
 //! `std::env::var("PATH")` to include:
 //!
-//! 1. An explicit bun override directory, if configured.
-//! 2. The interactive login-shell `PATH` (Unix only, 3s timeout) — fixes
+//! 1. The interactive login-shell `PATH` (Unix only, 3s timeout) — fixes
 //!    launchd / Finder / systemd-service starts.
-//! 3. The current `PATH` (inherited from the launching process).
-//! 4. Platform extra bins (`~/.bun/bin`, `~/.cargo/bin`, etc.) as fallbacks.
+//! 2. The current `PATH` (inherited from the launching process).
+//! 3. Platform extra bins (`~/.cargo/bin`, `~/.local/bin`, etc.) as fallbacks.
 //!
 //! After this runs, all downstream `which::which(...)` and
 //! `Command::new(...)` calls see the enhanced PATH with zero further
@@ -28,9 +27,8 @@ pub unsafe fn enhance_process_path() -> String {
     let current = std::env::var("PATH").unwrap_or_default();
     let login = login_shell_path();
     let extras = platform_extra_bins();
-    let bun_dir = crate::bun_bin_dir();
 
-    let merged = merge_paths(bun_dir.as_deref(), &extras, &current, login.as_deref());
+    let merged = merge_paths(&extras, &current, login.as_deref());
 
     if merged == current {
         tracing::warn!("PATH enhancement produced no changes; continuing with inherited PATH");
@@ -38,7 +36,6 @@ pub unsafe fn enhance_process_path() -> String {
         tracing::info!(
             login = login.is_some(),
             extra_bin_count = extras.len(),
-            bun_injected = bun_dir.is_some(),
             original_len = current.len(),
             merged_len = merged.len(),
             "PATH enhanced at startup"
@@ -54,8 +51,8 @@ pub unsafe fn enhance_process_path() -> String {
 
 // Placeholder helpers — filled in by later tasks.
 
-fn merge_paths(bun_dir: Option<&Path>, extras: &[PathBuf], current: &str, login: Option<&str>) -> String {
-    // Order: bun_dir, login, current, extras. First-occurrence wins.
+fn merge_paths(extras: &[PathBuf], current: &str, login: Option<&str>) -> String {
+    // Order: login, current, extras. First-occurrence wins.
     // Scanned version-manager bins are fallbacks and must not override the
     // Node version selected by the user's interactive login shell.
     // `env::split_paths` and `env::join_paths` honour the OS-specific
@@ -72,9 +69,6 @@ fn merge_paths(bun_dir: Option<&Path>, extras: &[PathBuf], current: &str, login:
         }
     };
 
-    if let Some(p) = bun_dir {
-        push(p.to_path_buf());
-    }
     if let Some(l) = login {
         for p in std::env::split_paths(l) {
             push(p);
@@ -105,7 +99,6 @@ fn platform_extra_bins_at(home: Option<&Path>) -> Vec<PathBuf> {
     };
 
     if let Some(h) = home {
-        push_if_dir(h.join(".bun").join("bin"));
         push_if_dir(h.join(".cargo").join("bin"));
         push_if_dir(h.join("go").join("bin"));
         push_if_dir(h.join(".deno").join("bin"));
@@ -247,7 +240,7 @@ mod tests {
         let login = format!("/b{s}/d");
         let extras: Vec<PathBuf> = vec![PathBuf::from("/e")];
 
-        let result = merge_paths(None, &extras, &current, Some(&login));
+        let result = merge_paths(&extras, &current, Some(&login));
         let parts: Vec<&str> = result.split(s).collect();
 
         assert_eq!(parts, vec!["/b", "/d", "/a", "/c", "/e"]);
@@ -261,7 +254,7 @@ mod tests {
         let current = format!("/opt/homebrew/bin{s}/usr/bin");
         let login = format!("{active}{s}/opt/homebrew/bin{s}/usr/bin");
 
-        let result = merge_paths(None, &[newer.clone(), PathBuf::from(active)], &current, Some(&login));
+        let result = merge_paths(&[newer.clone(), PathBuf::from(active)], &current, Some(&login));
         let parts: Vec<&str> = result.split(s).collect();
 
         assert_eq!(
@@ -271,23 +264,11 @@ mod tests {
     }
 
     #[test]
-    fn merge_paths_with_bun_dir_at_front() {
-        let s = sep();
-        let current = format!("/a{s}/b");
-        let bun = PathBuf::from("/bun");
-
-        let result = merge_paths(Some(&bun), &[], &current, None);
-        let parts: Vec<&str> = result.split(s).collect();
-
-        assert_eq!(parts, vec!["/bun", "/a", "/b"]);
-    }
-
-    #[test]
     fn merge_paths_drops_empty_segments() {
         let s = sep();
         let current = format!("{s}/a{s}{s}/b{s}");
 
-        let result = merge_paths(None, &[], &current, None);
+        let result = merge_paths(&[], &current, None);
         let parts: Vec<&str> = result.split(s).collect();
 
         assert_eq!(parts, vec!["/a", "/b"]);
@@ -295,22 +276,8 @@ mod tests {
 
     #[test]
     fn merge_paths_all_optional_none() {
-        let result = merge_paths(None, &[], "", None);
+        let result = merge_paths(&[], "", None);
         assert_eq!(result, "");
-    }
-
-    #[test]
-    fn merge_paths_bun_dir_deduplicates_if_already_in_current() {
-        let s = sep();
-        let current = format!("/bun{s}/a");
-        let bun = PathBuf::from("/bun");
-
-        let result = merge_paths(Some(&bun), &[], &current, None);
-        let parts: Vec<&str> = result.split(s).collect();
-
-        // /bun appears first (from bun_dir), then /a from current.
-        // Second /bun (inside current) is dedup'd.
-        assert_eq!(parts, vec!["/bun", "/a"]);
     }
 
     #[test]
@@ -320,18 +287,13 @@ mod tests {
 
         // 构造少量"存在"的 bin 目录，其他 candidate 仍会被 platform_extra_bins_at
         // 检查但应被过滤掉。
-        std::fs::create_dir_all(home.join(".bun/bin")).unwrap();
         std::fs::create_dir_all(home.join(".cargo/bin")).unwrap();
         std::fs::create_dir_all(home.join(".nvm/versions/node/v22.22.0/bin")).unwrap();
         std::fs::create_dir_all(home.join(".nvm/versions/node/v25.1.0/bin")).unwrap();
 
         let bins = platform_extra_bins_at(Some(home));
 
-        // 至少这两个应出现
-        assert!(
-            bins.iter().any(|p| p.ends_with(".bun/bin")),
-            "expected ~/.bun/bin in result"
-        );
+        // 至少这些目录应出现
         assert!(
             bins.iter().any(|p| p.ends_with(".cargo/bin")),
             "expected ~/.cargo/bin in result"


### PR DESCRIPTION
## Summary

- prefer the user's interactive login-shell `PATH` over the inherited process path and scanned version-manager fallbacks (`crates/aionui-runtime/src/shell_env.rs:27`, `crates/aionui-runtime/src/shell_env.rs:57`)
- validate available builtin agent CLIs by resolving the primary command and running `<cli> --version` with a five-second timeout; successful exit status is sufficient (`crates/aionui-ai-agent/src/cli_probe.rs:23`, `crates/aionui-ai-agent/src/cli_probe.rs:40`)
- mark a builtin agent unavailable when its primary CLI cannot execute, while leaving custom agents out of this startup version probe (`crates/aionui-ai-agent/src/registry.rs:664`)
- expose the same unavailable reason through the agent registry and `aioncore doctor`

## Root Cause

PATH enhancement previously placed scanned version-manager directories ahead of the PATH selected by the user's interactive login shell. A GUI-launched backend could therefore resolve a different Node-installed CLI wrapper than the same user gets in a terminal.

The installation check also stopped after resolving a command path. An executable wrapper whose underlying runtime or native binary could not start was consequently reported as installed.

## Scope

This PR does not change agent session startup, CodexConnection, ACP initialization, or session-port routing.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p aionui-ai-agent -p aionui-runtime -p aionui-app -- -D warnings`
- `cargo test -p aionui-ai-agent -p aionui-runtime -p aionui-app`
