### PR TITLE
feat(aionrs): expose GLM-5.2 thinking mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,8 +117,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/GodfatherPacino/aionrs.git?rev=d91f2b2b70983ef4425f855543c627d4be9e3c0d#d91f2b2b70983ef4425f855543c627d4be9e3c0d"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -148,8 +148,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/GodfatherPacino/aionrs.git?rev=d91f2b2b70983ef4425f855543c627d4be9e3c0d#d91f2b2b70983ef4425f855543c627d4be9e3c0d"
 dependencies = [
  "regex",
  "serde",
@@ -160,8 +160,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/GodfatherPacino/aionrs.git?rev=d91f2b2b70983ef4425f855543c627d4be9e3c0d#d91f2b2b70983ef4425f855543c627d4be9e3c0d"
 dependencies = [
  "aion-compact",
  "aion-process",
@@ -185,8 +185,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/GodfatherPacino/aionrs.git?rev=d91f2b2b70983ef4425f855543c627d4be9e3c0d#d91f2b2b70983ef4425f855543c627d4be9e3c0d"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -206,8 +206,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/GodfatherPacino/aionrs.git?rev=d91f2b2b70983ef4425f855543c627d4be9e3c0d#d91f2b2b70983ef4425f855543c627d4be9e3c0d"
 dependencies = [
  "aion-config",
  "chrono",
@@ -220,8 +220,8 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/GodfatherPacino/aionrs.git?rev=d91f2b2b70983ef4425f855543c627d4be9e3c0d#d91f2b2b70983ef4425f855543c627d4be9e3c0d"
 dependencies = [
  "libc",
  "tokio",
@@ -231,8 +231,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/GodfatherPacino/aionrs.git?rev=d91f2b2b70983ef4425f855543c627d4be9e3c0d#d91f2b2b70983ef4425f855543c627d4be9e3c0d"
 dependencies = [
  "aion-types",
  "serde",
@@ -244,8 +244,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/GodfatherPacino/aionrs.git?rev=d91f2b2b70983ef4425f855543c627d4be9e3c0d#d91f2b2b70983ef4425f855543c627d4be9e3c0d"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -272,8 +272,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/GodfatherPacino/aionrs.git?rev=d91f2b2b70983ef4425f855543c627d4be9e3c0d#d91f2b2b70983ef4425f855543c627d4be9e3c0d"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -299,8 +299,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/GodfatherPacino/aionrs.git?rev=d91f2b2b70983ef4425f855543c627d4be9e3c0d#d91f2b2b70983ef4425f855543c627d4be9e3c0d"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -320,8 +320,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.2.3"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+version = "0.2.4"
+source = "git+https://github.com/GodfatherPacino/aionrs.git?rev=d91f2b2b70983ef4425f855543c627d4be9e3c0d#d91f2b2b70983ef4425f855543c627d4be9e3c0d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6547,7 +6547,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.3#e884400a8d8629f22531f132facd6dca195701c6"
+source = "git+https://github.com/GodfatherPacino/aionrs.git?rev=d91f2b2b70983ef4425f855543c627d4be9e3c0d#d91f2b2b70983ef4425f855543c627d4be9e3c0d"
 dependencies = [
  "bitflags",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,12 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
-aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.3" }
+aion-agent = { git = "https://github.com/GodfatherPacino/aionrs.git", rev = "d91f2b2b70983ef4425f855543c627d4be9e3c0d" }
+aion-providers = { git = "https://github.com/GodfatherPacino/aionrs.git", rev = "d91f2b2b70983ef4425f855543c627d4be9e3c0d" }
+aion-types = { git = "https://github.com/GodfatherPacino/aionrs.git", rev = "d91f2b2b70983ef4425f855543c627d4be9e3c0d" }
+aion-protocol = { git = "https://github.com/GodfatherPacino/aionrs.git", rev = "d91f2b2b70983ef4425f855543c627d4be9e3c0d" }
+aion-config = { git = "https://github.com/GodfatherPacino/aionrs.git", rev = "d91f2b2b70983ef4425f855543c627d4be9e3c0d" }
+aion-mcp = { git = "https://github.com/GodfatherPacino/aionrs.git", rev = "d91f2b2b70983ef4425f855543c627d4be9e3c0d" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }

--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -95,8 +95,9 @@ pub(super) async fn build(
 
     let provider = map_aionrs_provider(&row.platform, &model_id, row.model_protocols.as_deref())?;
 
-    let (base_url, compat_overrides) =
+    let (base_url, mut compat_overrides) =
         resolve_aionrs_url_and_compat(&row.platform, &row.base_url, &provider, row.is_full_url);
+    compat_overrides.thinking_mode = glm_52_default_thinking_mode(&model_id);
 
     let bedrock_config = if row.platform == "bedrock" {
         resolve_bedrock_config(row.bedrock_config.as_deref())
@@ -208,6 +209,11 @@ pub(super) async fn build(
 
     let agent = AionrsAgentManager::new(ctx.conversation_id, ctx.workspace, config, resume_session).await?;
     Ok(AgentInstance::Aionrs(Arc::new(agent)))
+}
+
+fn glm_52_default_thinking_mode(model_id: &str) -> Option<String> {
+    let normalized = model_id.trim().to_ascii_lowercase();
+    (normalized == "glm-5.2" || normalized.starts_with("glm-5.2-")).then(|| "enabled".to_owned())
 }
 
 /// Map AionUi DB platform/protocol settings to the aionrs provider identifier.
@@ -1706,5 +1712,20 @@ mod tests {
         }
 
         assert_eq!(overrides.system_prompt.as_deref(), Some("Be concise."));
+    }
+
+    #[test]
+    fn glm_52_defaults_to_enabled_thinking() {
+        assert_eq!(glm_52_default_thinking_mode("glm-5.2").as_deref(), Some("enabled"));
+        assert_eq!(
+            glm_52_default_thinking_mode("GLM-5.2-20260701").as_deref(),
+            Some("enabled")
+        );
+    }
+
+    #[test]
+    fn non_glm_52_models_do_not_receive_a_thinking_override() {
+        assert!(glm_52_default_thinking_mode("glm-5.1").is_none());
+        assert!(glm_52_default_thinking_mode("claude-sonnet-4").is_none());
     }
 }

--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -213,7 +213,8 @@ pub(super) async fn build(
 
 fn glm_52_default_thinking_mode(model_id: &str) -> Option<String> {
     let normalized = model_id.trim().to_ascii_lowercase();
-    (normalized == "glm-5.2" || normalized.starts_with("glm-5.2-")).then(|| "enabled".to_owned())
+    let model_name = normalized.rsplit('/').next().unwrap_or(&normalized);
+    (model_name == "glm-5.2" || model_name.starts_with("glm-5.2-")).then(|| "enabled".to_owned())
 }
 
 /// Map AionUi DB platform/protocol settings to the aionrs provider identifier.
@@ -1719,6 +1720,14 @@ mod tests {
         assert_eq!(glm_52_default_thinking_mode("glm-5.2").as_deref(), Some("enabled"));
         assert_eq!(
             glm_52_default_thinking_mode("GLM-5.2-20260701").as_deref(),
+            Some("enabled")
+        );
+        assert_eq!(
+            glm_52_default_thinking_mode("zhanlu/glm-5.2").as_deref(),
+            Some("enabled")
+        );
+        assert_eq!(
+            glm_52_default_thinking_mode("z-ai/glm-5.2-20260701").as_deref(),
             Some("enabled")
         );
     }

--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -97,7 +97,7 @@ pub(super) async fn build(
 
     let (base_url, mut compat_overrides) =
         resolve_aionrs_url_and_compat(&row.platform, &row.base_url, &provider, row.is_full_url);
-    compat_overrides.thinking_mode = glm_52_default_thinking_mode(&model_id);
+    configure_glm_52_thinking_compat(&mut compat_overrides, &provider, &model_id);
 
     let bedrock_config = if row.platform == "bedrock" {
         resolve_bedrock_config(row.bedrock_config.as_deref())
@@ -215,6 +215,11 @@ fn glm_52_default_thinking_mode(model_id: &str) -> Option<String> {
     let normalized = model_id.trim().to_ascii_lowercase();
     let model_name = normalized.rsplit('/').next().unwrap_or(&normalized);
     (model_name == "glm-5.2" || model_name.starts_with("glm-5.2-")).then(|| "enabled".to_owned())
+}
+
+fn configure_glm_52_thinking_compat(compat_overrides: &mut AionrsCompatOverrides, provider: &str, model_id: &str) {
+    compat_overrides.thinking_mode = glm_52_default_thinking_mode(model_id);
+    compat_overrides.emit_disabled_thinking = provider == "anthropic" && compat_overrides.thinking_mode.is_some();
 }
 
 /// Map AionUi DB platform/protocol settings to the aionrs provider identifier.
@@ -1736,5 +1741,25 @@ mod tests {
     fn non_glm_52_models_do_not_receive_a_thinking_override() {
         assert!(glm_52_default_thinking_mode("glm-5.1").is_none());
         assert!(glm_52_default_thinking_mode("claude-sonnet-4").is_none());
+    }
+
+    #[test]
+    fn anthropic_glm_52_emits_explicit_disabled_thinking() {
+        let mut compat = AionrsCompatOverrides::default();
+
+        configure_glm_52_thinking_compat(&mut compat, "anthropic", "zhanlu/glm-5.2-anthropic");
+
+        assert_eq!(compat.thinking_mode.as_deref(), Some("enabled"));
+        assert!(compat.emit_disabled_thinking);
+    }
+
+    #[test]
+    fn openai_glm_52_keeps_default_disabled_serialization() {
+        let mut compat = AionrsCompatOverrides::default();
+
+        configure_glm_52_thinking_compat(&mut compat, "openai", "glm-5.2");
+
+        assert_eq!(compat.thinking_mode.as_deref(), Some("enabled"));
+        assert!(!compat.emit_disabled_thinking);
     }
 }

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -89,6 +89,8 @@ pub struct AionrsAgentManager {
     #[allow(dead_code)] // intentional: lifetime-extension only; see Drop impl
     mcp_managers: Vec<Arc<McpManager>>,
     approval_manager: Arc<ToolApprovalManager>,
+    /// Request-level thinking mode for models that expose the option.
+    thinking_mode: Option<Mutex<String>>,
     confirmations: Arc<std::sync::RwLock<Vec<Confirmation>>>,
     final_input_dump: Option<AionrsFinalInputDumpContext>,
     /// Signalled by `cancel()` to abort an in-flight `engine.run()` via
@@ -118,6 +120,7 @@ impl AionrsAgentManager {
         let runtime = AgentRuntime::new(conversation_id.clone(), workspace.clone(), 128);
         let sink: Arc<dyn OutputSink> = Arc::new(BackendOutputSink::new(runtime.event_sender()));
         let runtime_env = config_extra.runtime_env.clone();
+        let thinking_mode = config_extra.compat_overrides.thinking_mode.clone();
         let final_input_dump = config_extra
             .prompt_dump_dir
             .clone()
@@ -145,7 +148,7 @@ impl AionrsAgentManager {
             system_prompt: config_extra.system_prompt.clone(),
             profile: None,
             auto_approve: config_extra.session_mode.as_deref() == Some("yolo"),
-            thinking: None,
+            thinking: thinking_mode.clone(),
             thinking_budget: None,
             project_dir: Some(PathBuf::from(&workspace)),
         };
@@ -233,6 +236,7 @@ impl AionrsAgentManager {
             slash_commands,
             mcp_managers: result.mcp_managers,
             approval_manager,
+            thinking_mode: thinking_mode.map(Mutex::new),
             confirmations,
             final_input_dump,
             cancel_notify: Arc::new(Notify::new()),
@@ -515,27 +519,54 @@ impl AionrsAgentManager {
     }
 
     pub async fn config_options(&self) -> Result<GetConfigOptionsResponse, AgentError> {
-        Ok(GetConfigOptionsResponse {
-            config_options: vec![aionrs_mode_config_option(self.approval_manager.current_mode())],
-        })
+        let mut config_options = vec![aionrs_mode_config_option(self.approval_manager.current_mode())];
+        if let Some(thinking_mode) = &self.thinking_mode {
+            config_options.push(aionrs_thinking_config_option(thinking_mode.lock().await.clone()));
+        }
+        Ok(GetConfigOptionsResponse { config_options })
     }
 
     pub async fn set_config_option(&self, option_id: &str, value: &str) -> Result<SetConfigOptionResponse, AgentError> {
         let option_id = option_id.trim();
         let value = value.trim();
 
-        if option_id != AIONRS_MODE_OPTION_ID {
-            return Err(AgentError::bad_request(format!(
-                "Config option '{option_id}' is not available"
-            )));
+        match option_id {
+            AIONRS_MODE_OPTION_ID => {
+                if !is_aionrs_session_mode(value) {
+                    return Err(AgentError::bad_request(format!(
+                        "Value '{value}' is not selectable for config option '{option_id}'"
+                    )));
+                }
+                self.set_mode(value).await?;
+            }
+            AIONRS_THINKING_OPTION_ID => {
+                if !is_aionrs_thinking_mode(value) {
+                    return Err(AgentError::bad_request(format!(
+                        "Value '{value}' is not selectable for config option '{option_id}'"
+                    )));
+                }
+                let Some(thinking_mode) = &self.thinking_mode else {
+                    return Err(AgentError::bad_request(format!(
+                        "Config option '{option_id}' is not available"
+                    )));
+                };
+                self.engine
+                    .lock()
+                    .await
+                    .apply_config_update(None, Some(value.to_owned()), None, None, None);
+                *thinking_mode.lock().await = value.to_owned();
+                info!(
+                    conversation_id = %self.runtime.conversation_id(),
+                    thinking_mode = value,
+                    "Aionrs thinking mode switched"
+                );
+            }
+            _ => {
+                return Err(AgentError::bad_request(format!(
+                    "Config option '{option_id}' is not available"
+                )));
+            }
         }
-        if !is_aionrs_session_mode(value) {
-            return Err(AgentError::bad_request(format!(
-                "Value '{value}' is not selectable for config option '{option_id}'"
-            )));
-        }
-
-        self.set_mode(value).await?;
         Ok(SetConfigOptionResponse {
             confirmation: ConfigOptionConfirmation::Observed,
             config_options: Some(self.config_options().await?.config_options),
@@ -548,9 +579,14 @@ impl AionrsAgentManager {
 }
 
 const AIONRS_MODE_OPTION_ID: &str = "mode";
+const AIONRS_THINKING_OPTION_ID: &str = "thinking";
 
 fn is_aionrs_session_mode(s: &str) -> bool {
     matches!(s, "default" | "auto_edit" | "yolo")
+}
+
+fn is_aionrs_thinking_mode(s: &str) -> bool {
+    matches!(s, "enabled" | "disabled")
 }
 
 fn aionrs_mode_config_option(current_value: String) -> AcpConfigOptionDto {
@@ -576,6 +612,22 @@ fn aionrs_mode_select_option(value: &str, name: &str) -> AcpConfigSelectOptionDt
         name: Some(name.to_owned()),
         label: None,
         description: None,
+    }
+}
+
+fn aionrs_thinking_config_option(current_value: String) -> AcpConfigOptionDto {
+    AcpConfigOptionDto {
+        id: AIONRS_THINKING_OPTION_ID.to_owned(),
+        name: Some("Thinking".to_owned()),
+        label: None,
+        description: None,
+        category: Some("thought_level".to_owned()),
+        option_type: "select".to_owned(),
+        current_value: Some(current_value),
+        options: vec![
+            aionrs_mode_select_option("enabled", "Enabled"),
+            aionrs_mode_select_option("disabled", "Disabled"),
+        ],
     }
 }
 
@@ -624,6 +676,74 @@ mod tests {
             runtime_env: Vec::new(),
             prompt_dump_dir: None,
         }
+    }
+
+    fn make_glm_52_test_config() -> AionrsResolvedConfig {
+        let mut config = make_test_config();
+        config.provider = "openai".into();
+        config.model = "glm-5.2".into();
+        config.base_url = Some("https://open.bigmodel.cn/api/paas/v4".into());
+        config.compat_overrides.thinking_mode = Some("enabled".into());
+        config
+    }
+
+    #[tokio::test]
+    async fn glm_52_exposes_enabled_thinking_by_default() {
+        let agent = AionrsAgentManager::new("conv-glm".into(), "/project".into(), make_glm_52_test_config(), None)
+            .await
+            .unwrap();
+
+        let options = agent.config_options().await.unwrap().config_options;
+        let thinking = options
+            .iter()
+            .find(|option| option.id == AIONRS_THINKING_OPTION_ID)
+            .unwrap();
+
+        assert_eq!(thinking.category.as_deref(), Some("thought_level"));
+        assert_eq!(thinking.current_value.as_deref(), Some("enabled"));
+        assert_eq!(
+            thinking
+                .options
+                .iter()
+                .map(|option| option.value.as_str())
+                .collect::<Vec<_>>(),
+            vec!["enabled", "disabled"]
+        );
+    }
+
+    #[tokio::test]
+    async fn glm_52_thinking_can_be_disabled_for_the_next_request() {
+        let agent = AionrsAgentManager::new("conv-glm".into(), "/project".into(), make_glm_52_test_config(), None)
+            .await
+            .unwrap();
+
+        let response = agent
+            .set_config_option(AIONRS_THINKING_OPTION_ID, "disabled")
+            .await
+            .unwrap();
+        assert_eq!(response.confirmation, ConfigOptionConfirmation::Observed);
+        let thinking = response
+            .config_options
+            .unwrap()
+            .into_iter()
+            .find(|option| option.id == AIONRS_THINKING_OPTION_ID)
+            .unwrap();
+
+        assert_eq!(thinking.current_value.as_deref(), Some("disabled"));
+    }
+
+    #[tokio::test]
+    async fn unsupported_thinking_values_are_rejected() {
+        let agent = AionrsAgentManager::new("conv-glm".into(), "/project".into(), make_glm_52_test_config(), None)
+            .await
+            .unwrap();
+
+        let error = agent
+            .set_config_option(AIONRS_THINKING_OPTION_ID, "auto")
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("is not selectable"));
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -26,7 +26,7 @@ use crate::capability::backend_protocol_sink::BackendProtocolSink;
 use crate::error::AgentError;
 use crate::protocol::events::AgentStreamEvent;
 use crate::protocol::send_error::AgentSendError;
-use crate::types::{AionrsResolvedConfig, SendMessageData};
+use crate::types::{AionrsCompatOverrides, AionrsResolvedConfig, SendMessageData};
 
 use super::error::{aionrs_engine_error_to_send_error, aionrs_runtime_error_summary};
 
@@ -161,12 +161,7 @@ impl AionrsAgentManager {
         config.session.enabled = true;
         config.session.directory = config_extra.session_directory.to_string_lossy().into_owned();
 
-        if let Some(field) = config_extra.compat_overrides.max_tokens_field {
-            config.compat.transport.max_tokens_field = Some(field);
-        }
-        if let Some(path) = config_extra.compat_overrides.api_path {
-            config.compat.transport.api_path = Some(path);
-        }
+        apply_aionrs_compat_overrides(&mut config, &config_extra.compat_overrides);
 
         if !config_extra.extra_mcp_servers.is_empty() {
             config.mcp.servers.extend(config_extra.extra_mcp_servers.clone());
@@ -310,6 +305,18 @@ impl AionrsAgentManager {
                 );
             }
         }
+    }
+}
+
+fn apply_aionrs_compat_overrides(config: &mut Config, overrides: &AionrsCompatOverrides) {
+    if let Some(field) = &overrides.max_tokens_field {
+        config.compat.transport.max_tokens_field = Some(field.clone());
+    }
+    if let Some(path) = &overrides.api_path {
+        config.compat.transport.api_path = Some(path.clone());
+    }
+    if overrides.emit_disabled_thinking {
+        config.compat.reasoning.emit_disabled_thinking = Some(true);
     }
 }
 
@@ -685,6 +692,34 @@ mod tests {
         config.base_url = Some("https://open.bigmodel.cn/api/paas/v4".into());
         config.compat_overrides.thinking_mode = Some("enabled".into());
         config
+    }
+
+    #[test]
+    fn glm_52_anthropic_compat_enables_explicit_disabled_thinking() {
+        let mut config = make_glm_52_test_config();
+        config.provider = "anthropic".into();
+        config.compat_overrides.emit_disabled_thinking = true;
+
+        let cli_args = CliArgs {
+            provider: Some(config.provider.clone()),
+            api_key: Some(config.api_key.clone()),
+            base_url: config.base_url.clone(),
+            model: Some(config.model.clone()),
+            max_tokens: config.max_tokens,
+            max_turns: config.max_turns,
+            max_tool_call_malformed_turns: config.max_tool_call_malformed_turns,
+            max_tool_call_failure_turns: config.max_tool_call_failure_turns,
+            system_prompt: config.system_prompt.clone(),
+            profile: None,
+            auto_approve: false,
+            thinking: config.compat_overrides.thinking_mode.clone(),
+            thinking_budget: None,
+            project_dir: Some(PathBuf::from("/project")),
+        };
+        let mut resolved = Config::resolve(&cli_args).unwrap();
+        apply_aionrs_compat_overrides(&mut resolved, &config.compat_overrides);
+
+        assert!(resolved.compat.emit_disabled_thinking());
     }
 
     #[tokio::test]

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -104,6 +104,8 @@ pub struct AionrsCompatOverrides {
     pub api_path: Option<String>,
     /// Initial request-level thinking mode for models with a compatible API.
     pub thinking_mode: Option<String>,
+    /// Emit an explicit disabled thinking block instead of omitting it.
+    pub emit_disabled_thinking: bool,
 }
 
 /// Fully resolved Aionrs configuration passed to the agent manager.

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -102,6 +102,8 @@ impl RuntimeCapabilities {
 pub struct AionrsCompatOverrides {
     pub max_tokens_field: Option<String>,
     pub api_path: Option<String>,
+    /// Initial request-level thinking mode for models with a compatible API.
+    pub thinking_mode: Option<String>,
 }
 
 /// Fully resolved Aionrs configuration passed to the agent manager.


### PR DESCRIPTION
## Description

Adds request-level GLM-5.2 thinking-mode support to the Aionrs runtime and fixes explicit disabling for Anthropic-compatible endpoints.

- Detects bare and provider-qualified GLM-5.2 model IDs and defaults `thinking` to `enabled`.
- Exposes `thinking` as a runtime `thought_level` configuration option with `enabled` and `disabled` values.
- Applies configuration updates to subsequent Aionrs requests without restarting the conversation.
- Enables explicit `{"thinking":{"type":"disabled"}}` serialization for Anthropic-compatible GLM-5.2 providers, where omitting the field leaves thinking enabled by default.
- Keeps OpenAI-compatible GLM-5.2 behavior and third-party ACP runtimes unchanged.
- Adds focused coverage for model detection, protocol scoping, defaults, option discovery, runtime updates, and validation.

This is the backend counterpart of [iOfficeAI/AionUi#3597](https://github.com/iOfficeAI/AionUi/pull/3597) and currently depends on [iOfficeAI/aionrs#228](https://github.com/iOfficeAI/aionrs/pull/228).

> Dependency note: while the Aionrs PR is under review, this draft pins the exact fork commit `d91f2b2`. It should be switched to the merged upstream revision or release before this PR is marked ready.

## Related Issues

No linked issue.

## Type of Change

- [x] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `docs`: Documentation only
- [ ] `test`: Tests only
- [ ] `chore`: Maintenance

## Verification

- [x] Migration immutability check
- [x] Formatting check
- [x] Clippy with warnings denied
- [x] Affected crate tests: 624 unit tests passed; 33 integration tests passed; 12 ignored by repository configuration
- [x] Full workspace suite via `just push`: 6,778 passed; 18 skipped
- [x] Aionrs projector regression tests verify the exact disabled Anthropic request block and default omission behavior

## Additional Context

Manual testing of the previous package confirmed that the UI and runtime state changed to `disabled`, but the GLM-5.2 Anthropic request still produced thinking output. The root cause was the Anthropic projector omitting the disabled block. The linked Aionrs fix makes that serialization opt-in so providers and models that rely on omission remain unaffected.

Official references:

- GLM thinking mode: https://docs.bigmodel.cn/cn/guide/capabilities/thinking-mode
- Anthropic Messages API: https://platform.claude.com/docs/en/api/messages/create
