### PR TITLE
feat(channel): support platform workspace setting for sessions

### DIFF
--- a/crates/aionui-api-types/src/channel.rs
+++ b/crates/aionui-api-types/src/channel.rs
@@ -124,6 +124,15 @@ pub struct ChannelDefaultModelSetting {
     pub use_model: String,
 }
 
+/// Default workspace path for a channel platform.
+///
+/// When set, new channel conversations use this path instead of an
+/// auto-provisioned temporary workspace.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChannelWorkspaceSetting {
+    pub path: String,
+}
+
 /// Aggregated settings payload for one channel platform.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ChannelPlatformSettingsResponse {
@@ -132,6 +141,8 @@ pub struct ChannelPlatformSettingsResponse {
     pub assistant: Option<ChannelAssistantSettingResponse>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_model: Option<ChannelDefaultModelSetting>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<ChannelWorkspaceSetting>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -79,9 +79,10 @@ pub use auth::{
 pub use channel::{
     ApprovePairingRequest, BridgeResponse, ChannelAssistantSettingRequest, ChannelAssistantSettingResponse,
     ChannelDefaultModelSetting, ChannelPlatformSettingsResponse, ChannelSessionResponse, ChannelUserResponse,
-    DisablePluginRequest, EnablePluginRequest, PairingRequestResponse, PairingRequestedPayload,
-    PluginStatusChangedPayload, PluginStatusResponse, RejectPairingRequest, RevokeUserRequest,
-    SyncChannelSettingsRequest, TestPluginExtraConfig, TestPluginRequest, TestPluginResponse, UserAuthorizedPayload,
+    ChannelWorkspaceSetting, DisablePluginRequest, EnablePluginRequest, PairingRequestResponse,
+    PairingRequestedPayload, PluginStatusChangedPayload, PluginStatusResponse, RejectPairingRequest,
+    RevokeUserRequest, SyncChannelSettingsRequest, TestPluginExtraConfig, TestPluginRequest, TestPluginResponse,
+    UserAuthorizedPayload,
 };
 pub use chat_file::ChatFileRef;
 pub use confirmation::{ApprovalCheckQuery, ApprovalCheckResponse, ConfirmRequest, ConfirmationListResponse};

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -80,9 +80,8 @@ pub use channel::{
     ApprovePairingRequest, BridgeResponse, ChannelAssistantSettingRequest, ChannelAssistantSettingResponse,
     ChannelDefaultModelSetting, ChannelPlatformSettingsResponse, ChannelSessionResponse, ChannelUserResponse,
     ChannelWorkspaceSetting, DisablePluginRequest, EnablePluginRequest, PairingRequestResponse,
-    PairingRequestedPayload, PluginStatusChangedPayload, PluginStatusResponse, RejectPairingRequest,
-    RevokeUserRequest, SyncChannelSettingsRequest, TestPluginExtraConfig, TestPluginRequest, TestPluginResponse,
-    UserAuthorizedPayload,
+    PairingRequestedPayload, PluginStatusChangedPayload, PluginStatusResponse, RejectPairingRequest, RevokeUserRequest,
+    SyncChannelSettingsRequest, TestPluginExtraConfig, TestPluginRequest, TestPluginResponse, UserAuthorizedPayload,
 };
 pub use chat_file::ChatFileRef;
 pub use confirmation::{ApprovalCheckQuery, ApprovalCheckResponse, ConfirmRequest, ConfirmationListResponse};

--- a/crates/aionui-channel/src/channel_settings.rs
+++ b/crates/aionui-channel/src/channel_settings.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use aionui_api_types::{
     ChannelAssistantSettingRequest, ChannelAssistantSettingResponse, ChannelDefaultModelSetting,
-    ChannelPlatformSettingsResponse,
+    ChannelPlatformSettingsResponse, ChannelWorkspaceSetting,
 };
 use aionui_common::ProviderWithModel;
 use aionui_db::{
@@ -16,11 +16,12 @@ use crate::types::PluginType;
 
 const DEFAULT_AGENT_TYPE: &str = "aionrs";
 
-/// Per-plugin agent/model configuration read from `client_preferences`.
+/// Per-plugin agent/model/workspace configuration read from `client_preferences`.
 ///
 /// Keys follow the pattern established by the old Electron frontend:
 /// - `assistant.{platform}.agent`       → JSON `{"backend":"claude","name":"Claude"}`
 /// - `assistant.{platform}.defaultModel` → JSON `{"id":"provider_id","use_model":"model_name"}`
+/// - `assistant.{platform}.workspace`   → JSON `{"path":"/abs/path"}`
 pub struct ChannelSettingsService {
     pref_repo: Arc<dyn IClientPreferenceRepository>,
     agent_metadata_repo: Option<Arc<dyn IAgentMetadataRepository>>,
@@ -208,10 +209,15 @@ impl ChannelSettingsService {
     ) -> Result<ChannelPlatformSettingsResponse, ChannelError> {
         let key_agent = agent_key(platform);
         let key_model = model_key(platform);
-        let prefs = self.pref_repo.get_by_keys(user_id, &[&key_agent, &key_model]).await?;
+        let key_workspace = workspace_key(platform);
+        let prefs = self
+            .pref_repo
+            .get_by_keys(user_id, &[&key_agent, &key_model, &key_workspace])
+            .await?;
 
         let mut assistant = None;
         let mut default_model = None;
+        let mut workspace = None;
 
         for pref in prefs {
             if pref.key == key_agent {
@@ -223,6 +229,8 @@ impl ChannelSettingsService {
                 }
             } else if pref.key == key_model {
                 default_model = parse_channel_model_setting(&pref.value);
+            } else if pref.key == key_workspace {
+                workspace = parse_channel_workspace_setting(&pref.value);
             }
         }
 
@@ -234,6 +242,7 @@ impl ChannelSettingsService {
             platform: platform.to_string(),
             assistant,
             default_model,
+            workspace,
         })
     }
 
@@ -284,6 +293,47 @@ impl ChannelSettingsService {
     ) -> Result<(), ChannelError> {
         let payload = serde_json::to_string(model).map_err(ChannelError::Json)?;
         let key = model_key(platform);
+        self.pref_repo
+            .upsert_batch(user_id, &[(&key, payload.as_str())])
+            .await?;
+        Ok(())
+    }
+
+    /// Returns the configured workspace path for a platform, if any.
+    pub async fn get_workspace_path(
+        &self,
+        user_id: &str,
+        platform: PluginType,
+    ) -> Result<Option<String>, ChannelError> {
+        let key = workspace_key(platform);
+        let prefs = self.pref_repo.get_by_keys(user_id, &[&key]).await?;
+        let Some(pref) = prefs.into_iter().next() else {
+            return Ok(None);
+        };
+        Ok(parse_channel_workspace_setting(&pref.value).map(|setting| setting.path))
+    }
+
+    /// Persists or clears the workspace path for a platform.
+    ///
+    /// Empty / whitespace-only paths clear the preference so new channel
+    /// conversations fall back to auto-provisioned temporary workspaces.
+    pub async fn set_workspace_setting(
+        &self,
+        user_id: &str,
+        platform: PluginType,
+        workspace: &ChannelWorkspaceSetting,
+    ) -> Result<(), ChannelError> {
+        let key = workspace_key(platform);
+        let trimmed = workspace.path.trim();
+        if trimmed.is_empty() {
+            self.pref_repo.delete_keys(user_id, &[&key]).await?;
+            return Ok(());
+        }
+
+        let payload = serde_json::to_string(&ChannelWorkspaceSetting {
+            path: trimmed.to_owned(),
+        })
+        .map_err(ChannelError::Json)?;
         self.pref_repo
             .upsert_batch(user_id, &[(&key, payload.as_str())])
             .await?;
@@ -482,6 +532,21 @@ fn agent_key(platform: PluginType) -> String {
 
 fn model_key(platform: PluginType) -> String {
     format!("assistant.{platform}.defaultModel")
+}
+
+fn workspace_key(platform: PluginType) -> String {
+    format!("assistant.{platform}.workspace")
+}
+
+fn parse_channel_workspace_setting(value: &str) -> Option<ChannelWorkspaceSetting> {
+    let parsed: ChannelWorkspaceSetting = serde_json::from_str(value).ok()?;
+    let path = parsed.path.trim();
+    if path.is_empty() {
+        return None;
+    }
+    Some(ChannelWorkspaceSetting {
+        path: path.to_owned(),
+    })
 }
 
 fn default_agent_config() -> ResolvedAgentConfig {
@@ -1314,6 +1379,73 @@ mod tests {
         assert!(assistant.backend.is_none());
         assert!(assistant.agent_type.is_none());
         assert_eq!(assistant.name.as_deref(), Some("Codex"));
+    }
+
+    #[tokio::test]
+    async fn workspace_setting_roundtrip_and_clear() {
+        let repo = Arc::new(MockPrefRepo::new());
+        let svc = ChannelSettingsService::new(repo);
+
+        assert!(svc
+            .get_workspace_path(TEST_USER_ID, PluginType::Telegram)
+            .await
+            .unwrap()
+            .is_none());
+
+        svc.set_workspace_setting(
+            TEST_USER_ID,
+            PluginType::Telegram,
+            &ChannelWorkspaceSetting {
+                path: "  /projects/demo  ".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            svc.get_workspace_path(TEST_USER_ID, PluginType::Telegram)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("/projects/demo")
+        );
+
+        let settings = svc
+            .get_platform_settings(TEST_USER_ID, PluginType::Telegram)
+            .await
+            .unwrap();
+        assert_eq!(
+            settings.workspace.as_ref().map(|ws| ws.path.as_str()),
+            Some("/projects/demo")
+        );
+
+        svc.set_workspace_setting(
+            TEST_USER_ID,
+            PluginType::Telegram,
+            &ChannelWorkspaceSetting { path: "   ".into() },
+        )
+        .await
+        .unwrap();
+
+        assert!(svc
+            .get_workspace_path(TEST_USER_ID, PluginType::Telegram)
+            .await
+            .unwrap()
+            .is_none());
+        let cleared = svc
+            .get_platform_settings(TEST_USER_ID, PluginType::Telegram)
+            .await
+            .unwrap();
+        assert!(cleared.workspace.is_none());
+    }
+
+    #[test]
+    fn parse_channel_workspace_setting_rejects_empty_path() {
+        assert!(parse_channel_workspace_setting(r#"{"path":"   "}"#).is_none());
+        assert_eq!(
+            parse_channel_workspace_setting(r#"{"path":"/tmp/work"}"#).map(|ws| ws.path),
+            Some("/tmp/work".into())
+        );
     }
 
     // ── resolved_model_to_provider ────────────────────────────────────

--- a/crates/aionui-channel/src/channel_settings.rs
+++ b/crates/aionui-channel/src/channel_settings.rs
@@ -544,9 +544,7 @@ fn parse_channel_workspace_setting(value: &str) -> Option<ChannelWorkspaceSettin
     if path.is_empty() {
         return None;
     }
-    Some(ChannelWorkspaceSetting {
-        path: path.to_owned(),
-    })
+    Some(ChannelWorkspaceSetting { path: path.to_owned() })
 }
 
 fn default_agent_config() -> ResolvedAgentConfig {
@@ -1386,11 +1384,12 @@ mod tests {
         let repo = Arc::new(MockPrefRepo::new());
         let svc = ChannelSettingsService::new(repo);
 
-        assert!(svc
-            .get_workspace_path(TEST_USER_ID, PluginType::Telegram)
-            .await
-            .unwrap()
-            .is_none());
+        assert!(
+            svc.get_workspace_path(TEST_USER_ID, PluginType::Telegram)
+                .await
+                .unwrap()
+                .is_none()
+        );
 
         svc.set_workspace_setting(
             TEST_USER_ID,
@@ -1427,11 +1426,12 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(svc
-            .get_workspace_path(TEST_USER_ID, PluginType::Telegram)
-            .await
-            .unwrap()
-            .is_none());
+        assert!(
+            svc.get_workspace_path(TEST_USER_ID, PluginType::Telegram)
+                .await
+                .unwrap()
+                .is_none()
+        );
         let cleared = svc
             .get_platform_settings(TEST_USER_ID, PluginType::Telegram)
             .await

--- a/crates/aionui-channel/src/message_service.rs
+++ b/crates/aionui-channel/src/message_service.rs
@@ -144,6 +144,11 @@ impl ChannelMessageService {
             .filter(|name| !name.is_empty())
             .map(ToOwned::to_owned);
         let model_config = self.settings.get_model_config(owner_user_id, platform).await?;
+        let workspace_path = self
+            .settings
+            .get_workspace_path(owner_user_id, platform)
+            .await
+            .map_err(|e| ChannelError::MessageSendFailed(e.to_string()))?;
         let agent_type = parse_agent_type(&agent_config.agent_type)?;
         let model = resolved_model_to_provider(model_config.as_ref());
         let mut extra = Self::build_channel_extra(if assistant_id.is_some() {
@@ -151,6 +156,11 @@ impl ChannelMessageService {
         } else {
             agent_config.backend.as_deref()
         });
+        // Prefer the platform-configured workspace over ConversationService's
+        // auto-provisioned temporary directory.
+        if let Some(path) = workspace_path {
+            extra["workspace"] = serde_json::Value::String(path);
+        }
         let name = assistant_name.unwrap_or_else(|| {
             channel_conversation_name(
                 platform,

--- a/crates/aionui-channel/src/routes.rs
+++ b/crates/aionui-channel/src/routes.rs
@@ -11,9 +11,9 @@ use tracing::warn;
 
 use aionui_api_types::{
     ApiResponse, ApprovePairingRequest, BridgeResponse, ChannelAssistantSettingRequest, ChannelDefaultModelSetting,
-    ChannelPlatformSettingsResponse, ChannelSessionResponse, ChannelUserResponse, DisablePluginRequest,
-    EnablePluginRequest, PairingRequestResponse, PluginStatusResponse, RejectPairingRequest, RevokeUserRequest,
-    SyncChannelSettingsRequest, TestPluginRequest, TestPluginResponse,
+    ChannelPlatformSettingsResponse, ChannelSessionResponse, ChannelUserResponse, ChannelWorkspaceSetting,
+    DisablePluginRequest, EnablePluginRequest, PairingRequestResponse, PluginStatusResponse, RejectPairingRequest,
+    RevokeUserRequest, SyncChannelSettingsRequest, TestPluginRequest, TestPluginResponse,
 };
 use aionui_auth::CurrentUser;
 use aionui_common::ApiError;
@@ -115,6 +115,10 @@ pub fn channel_routes(state: ChannelRouterState) -> Router {
         .route(
             "/api/channel/settings/{platform}/default-model",
             put(set_channel_default_model_setting),
+        )
+        .route(
+            "/api/channel/settings/{platform}/workspace",
+            put(set_channel_workspace_setting),
         )
         .route("/api/channel/settings/sync", post(sync_channel_settings))
         .with_state(state)
@@ -646,6 +650,32 @@ async fn set_channel_default_model_setting(
     Ok(Json(ApiResponse::ok(BridgeResponse {
         success: true,
         message: Some("Default model setting updated".into()),
+        error: None,
+    })))
+}
+
+/// `PUT /api/channel/settings/:platform/workspace` — persist default workspace for a platform.
+///
+/// Empty `path` clears the preference so new channel conversations use a temporary workspace.
+async fn set_channel_workspace_setting(
+    State(state): State<ChannelRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    Path(platform): Path<String>,
+    body: Result<Json<ChannelWorkspaceSetting>, JsonRejection>,
+) -> Result<Json<ApiResponse<BridgeResponse>>, ApiError> {
+    let platform = PluginType::from_str_opt(&platform)
+        .ok_or_else(|| ApiError::BadRequest(format!("Invalid platform: {}", platform)))?;
+    let Json(req) = body.map_err(ApiError::from)?;
+
+    state
+        .settings_service
+        .set_workspace_setting(&user.id, platform, &req)
+        .await?;
+    state.session_manager.clear_all_sessions(&user.id).await?;
+
+    Ok(Json(ApiResponse::ok(BridgeResponse {
+        success: true,
+        message: Some("Workspace setting updated".into()),
         error: None,
     })))
 }


### PR DESCRIPTION
## Summary

Add per-platform workspace configuration for channel sessions so IM-originated conversations can use a user-specified folder instead of auto-provisioned temporary workspaces.

### Changes
- `ChannelWorkspaceSetting` API type and `workspace` field on `ChannelPlatformSettingsResponse`
- Persist `assistant.{platform}.workspace` via client preferences
- `PUT /api/channel/settings/{platform}/workspace` (empty path clears setting)
- `create_conversation_for_session` injects configured path into `extra.workspace`
- Clears channel sessions when workspace setting changes (same pattern as assistant/model)

### Companion
AionUi branch `feat/channel-workspace-setting` consumes this API in Channels settings UI.

## Test plan
- [ ] Unit: `cargo test -p aionui-channel workspace_setting --lib`
- [ ] Unit: `cargo test -p aionui-channel parse_channel_workspace --lib`
- [ ] Manual: set workspace via PUT, send channel message, confirm conversation uses path (not `*-temp-*`)
- [ ] Manual: clear workspace (empty path), next session uses temp again
