### PR TITLE
fix(acp): confirm legacy mode/model on ACK instead of awaiting observed update

### DIFF
--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -777,8 +777,14 @@ impl AcpAgentManager {
                     method,
                     "acp_config_option_command_ack"
                 );
-                self.apply_legacy_config_ack(&session_id, &ConfigSetPath::LegacyMode, option_id, &resolved_value, method)
-                    .await
+                self.apply_legacy_config_ack(
+                    &session_id,
+                    &ConfigSetPath::LegacyMode,
+                    option_id,
+                    &resolved_value,
+                    method,
+                )
+                .await
             }
             ConfigSetPath::LegacyModel => {
                 self.protocol
@@ -809,8 +815,14 @@ impl AcpAgentManager {
                     method,
                     "acp_config_option_command_ack"
                 );
-                self.apply_legacy_config_ack(&session_id, &ConfigSetPath::LegacyModel, option_id, &resolved_value, method)
-                    .await
+                self.apply_legacy_config_ack(
+                    &session_id,
+                    &ConfigSetPath::LegacyModel,
+                    option_id,
+                    &resolved_value,
+                    method,
+                )
+                .await
             }
         }
         .map(|snapshot| SetConfigOptionResponse {

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -682,11 +682,16 @@ impl AcpAgentManager {
             );
         }
 
+        let set_path_label = set_path.log_label();
+        let method = set_path.acp_method();
+
         tracing::info!(
             conversation_id = %self.params.conversation_id,
             agent_backend = ?self.params.metadata.backend,
             config_id = %option_id,
             requested = %resolved_value,
+            set_path = set_path_label,
+            method,
             "acp_config_option_set_requested"
         );
 
@@ -706,6 +711,8 @@ impl AcpAgentManager {
                             agent_backend = ?self.params.metadata.backend,
                             config_id = %config_id,
                             requested = %resolved_value,
+                            set_path = set_path_label,
+                            method,
                             error = %err,
                             "acp_config_option_command_failed"
                         );
@@ -717,7 +724,8 @@ impl AcpAgentManager {
                     agent_backend = ?self.params.metadata.backend,
                     config_id = %config_id,
                     requested = %resolved_value,
-                    method = "session/set_config_option",
+                    set_path = set_path_label,
+                    method,
                     "acp_config_option_command_ack"
                 );
 
@@ -731,8 +739,14 @@ impl AcpAgentManager {
                     session.apply_advertised_config_options(response.config_options);
                     self.commit_session_changes(&mut session).await;
                 }
-                self.wait_for_observed_config_option(&config_id, &resolved_value, OBSERVED_CONFIRMATION_TIMEOUT)
-                    .await
+                self.wait_for_observed_config_option(
+                    &config_id,
+                    &resolved_value,
+                    OBSERVED_CONFIRMATION_TIMEOUT,
+                    set_path_label,
+                    method,
+                )
+                .await
             }
             ConfigSetPath::LegacyMode => {
                 self.protocol
@@ -747,6 +761,8 @@ impl AcpAgentManager {
                             agent_backend = ?self.params.metadata.backend,
                             config_id = %option_id,
                             requested = %resolved_value,
+                            set_path = set_path_label,
+                            method,
                             error = %err,
                             "acp_config_option_command_failed"
                         );
@@ -757,11 +773,11 @@ impl AcpAgentManager {
                     agent_backend = ?self.params.metadata.backend,
                     config_id = %option_id,
                     requested = %resolved_value,
-                    method = "session/set_mode",
+                    set_path = set_path_label,
+                    method,
                     "acp_config_option_command_ack"
                 );
-                self.ensure_session_unchanged(&session_id, "mode").await?;
-                self.wait_for_observed_config_option("mode", &resolved_value, OBSERVED_CONFIRMATION_TIMEOUT)
+                self.apply_legacy_config_ack(&session_id, &ConfigSetPath::LegacyMode, option_id, &resolved_value, method)
                     .await
             }
             ConfigSetPath::LegacyModel => {
@@ -777,6 +793,8 @@ impl AcpAgentManager {
                             agent_backend = ?self.params.metadata.backend,
                             config_id = %option_id,
                             requested = %resolved_value,
+                            set_path = set_path_label,
+                            method,
                             error = %err,
                             "acp_config_option_command_failed"
                         );
@@ -787,11 +805,11 @@ impl AcpAgentManager {
                     agent_backend = ?self.params.metadata.backend,
                     config_id = %option_id,
                     requested = %resolved_value,
-                    method = "session/set_model",
+                    set_path = set_path_label,
+                    method,
                     "acp_config_option_command_ack"
                 );
-                self.ensure_session_unchanged(&session_id, "model").await?;
-                self.wait_for_observed_config_option("model", &resolved_value, OBSERVED_CONFIRMATION_TIMEOUT)
+                self.apply_legacy_config_ack(&session_id, &ConfigSetPath::LegacyModel, option_id, &resolved_value, method)
                     .await
             }
         }
@@ -801,22 +819,71 @@ impl AcpAgentManager {
         })
     }
 
-    async fn ensure_session_unchanged(&self, session_id: &str, field: &str) -> Result<(), AgentError> {
-        let session = self.session.read().await;
-        if session.session_id() == Some(session_id) {
-            return Ok(());
+    /// Apply a successful legacy `set_mode` / `set_model` ACK to the local
+    /// aggregate. Call ONLY after the protocol RPC returned success.
+    ///
+    /// Runs the whole confirm sequence inside a single session write lock so
+    /// no notification-driven update can interleave between the session-id
+    /// re-check and the confirm:
+    ///   validate active session_id -> confirm_mode/confirm_model
+    ///   -> snapshot -> commit_session_changes.
+    ///
+    /// The protocol RPC itself runs WITHOUT the write lock held, so agent
+    /// notification processing is never blocked during the round-trip.
+    ///
+    /// Returns the post-confirm [`ConfigSnapshot`], or a conflict error when
+    /// the active session changed between the RPC ACK and acquiring the lock.
+    async fn apply_legacy_config_ack(
+        &self,
+        session_id: &str,
+        set_path: &ConfigSetPath,
+        config_id: &str,
+        resolved_value: &str,
+        method: &'static str,
+    ) -> Result<ConfigSnapshot, AgentError> {
+        let mut session = self.session.write().await;
+        if session.session_id() != Some(session_id) {
+            warn!(
+                conversation_id = %self.params.conversation_id,
+                agent_backend = ?self.params.metadata.backend,
+                config_id = %config_id,
+                set_path = set_path.log_label(),
+                method,
+                confirmed_session_id = %session_id,
+                active_session_id = ?session.session_id(),
+                "acp_config_option_session_changed"
+            );
+            return Err(AgentError::conflict(
+                "Active ACP session changed while applying config option",
+            ));
         }
-        warn!(
+
+        match set_path {
+            ConfigSetPath::LegacyMode => session.confirm_mode(ModeId::new(resolved_value.to_owned())),
+            ConfigSetPath::LegacyModel => session.confirm_model(ModelId::new(resolved_value.to_owned())),
+            // Guarded rather than panicking: this helper is only ever called
+            // from the two legacy arms above.
+            ConfigSetPath::ConfigOption { .. } => {
+                return Err(AgentError::conflict(
+                    "apply_legacy_config_ack invoked for a non-legacy set path",
+                ));
+            }
+        }
+
+        let snapshot = session.config_snapshot();
+        self.commit_session_changes(&mut session).await;
+        drop(session);
+
+        tracing::info!(
             conversation_id = %self.params.conversation_id,
             agent_backend = ?self.params.metadata.backend,
-            config_id = %field,
-            confirmed_session_id = %session_id,
-            active_session_id = ?session.session_id(),
-            "acp_config_option_session_changed"
+            config_id = %config_id,
+            resolved_value = %resolved_value,
+            set_path = set_path.log_label(),
+            method,
+            "acp_legacy_config_ack_applied"
         );
-        Err(AgentError::conflict(
-            "Active ACP session changed while applying config option",
-        ))
+        Ok(snapshot)
     }
 
     async fn wait_for_observed_config_option(
@@ -824,6 +891,8 @@ impl AcpAgentManager {
         option_id: &str,
         requested: &str,
         timeout: Duration,
+        set_path_label: &'static str,
+        method: &'static str,
     ) -> Result<ConfigSnapshot, AgentError> {
         let started = Instant::now();
         loop {
@@ -837,6 +906,8 @@ impl AcpAgentManager {
                     agent_backend = ?self.params.metadata.backend,
                     config_id = %option_id,
                     requested = %requested,
+                    set_path = set_path_label,
+                    method,
                     elapsed_ms = started.elapsed().as_millis(),
                     "acp_config_option_observed_confirmed"
                 );
@@ -848,6 +919,8 @@ impl AcpAgentManager {
                     agent_backend = ?self.params.metadata.backend,
                     config_id = %option_id,
                     requested = %requested,
+                    set_path = set_path_label,
+                    method,
                     timeout_ms = timeout.as_millis(),
                     last_observed = ?snapshot.option_current(option_id),
                     "acp_config_option_confirmation_timeout"

--- a/crates/aionui-ai-agent/src/manager/acp/config_options.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/config_options.rs
@@ -147,6 +147,28 @@ pub(crate) enum ConfigSetPath {
     LegacyModel,
 }
 
+impl ConfigSetPath {
+    /// Stable structured-log label so a single log line identifies which
+    /// write path handled the request (avoids inferring the path from a
+    /// sequence of events). Values are a logging contract — do not rename.
+    pub(crate) fn log_label(&self) -> &'static str {
+        match self {
+            ConfigSetPath::ConfigOption { .. } => "config_option",
+            ConfigSetPath::LegacyMode => "legacy_mode",
+            ConfigSetPath::LegacyModel => "legacy_model",
+        }
+    }
+
+    /// The ACP RPC method this path invokes. Logged alongside `log_label`.
+    pub(crate) fn acp_method(&self) -> &'static str {
+        match self {
+            ConfigSetPath::ConfigOption { .. } => "session/set_config_option",
+            ConfigSetPath::LegacyMode => "session/set_mode",
+            ConfigSetPath::LegacyModel => "session/set_model",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ConfigSetPathError {
     OptionNotFound,
@@ -292,6 +314,21 @@ mod tests {
         ModelInfo, SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption, SessionMode,
         SessionModeState, SessionModelState,
     };
+
+    #[test]
+    fn config_set_path_log_label_and_method_are_stable() {
+        let config_option = ConfigSetPath::ConfigOption {
+            option_id: "mode".to_owned(),
+        };
+        assert_eq!(config_option.log_label(), "config_option");
+        assert_eq!(config_option.acp_method(), "session/set_config_option");
+
+        assert_eq!(ConfigSetPath::LegacyMode.log_label(), "legacy_mode");
+        assert_eq!(ConfigSetPath::LegacyMode.acp_method(), "session/set_mode");
+
+        assert_eq!(ConfigSetPath::LegacyModel.log_label(), "legacy_model");
+        assert_eq!(ConfigSetPath::LegacyModel.acp_method(), "session/set_model");
+    }
 
     #[test]
     fn dto_uses_snake_case_current_value() {

--- a/crates/aionui-ai-agent/src/manager/acp/session_tests.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/session_tests.rs
@@ -239,6 +239,53 @@ fn confirm_model_aligns_desired_and_current() {
 }
 
 #[test]
+fn confirm_mode_preserves_available_mode_catalog() {
+    let mut session = make_session();
+    session.apply_advertised_modes(SessionModeState::new(
+        "default",
+        vec![SessionMode::new("default", "Default"), SessionMode::new("plan", "Plan")],
+    ));
+    session.drain_events();
+
+    session.confirm_mode(ModeId::new("plan"));
+
+    let snapshot = session.config_snapshot();
+    let mode = snapshot
+        .options
+        .iter()
+        .find(|option| option.id == "mode")
+        .expect("mode option present");
+    assert_eq!(mode.current_value.as_deref(), Some("plan"));
+    // Confirming a value must not shrink the advertised catalog.
+    assert_eq!(mode.options.len(), 2);
+}
+
+#[test]
+fn confirm_model_preserves_available_model_catalog() {
+    use agent_client_protocol::schema::ModelInfo;
+    let mut session = AcpSession::new(None, None, HashMap::new());
+    session.apply_advertised_models(SessionModelState::new(
+        "claude-sonnet-4",
+        vec![
+            ModelInfo::new("claude-sonnet-4", "Sonnet 4"),
+            ModelInfo::new("claude-opus-4", "Opus 4"),
+        ],
+    ));
+    session.drain_events();
+
+    session.confirm_model(ModelId::new("claude-opus-4"));
+
+    let snapshot = session.config_snapshot();
+    let model = snapshot
+        .options
+        .iter()
+        .find(|option| option.id == "model")
+        .expect("model option present");
+    assert_eq!(model.current_value.as_deref(), Some("claude-opus-4"));
+    assert_eq!(model.options.len(), 2);
+}
+
+#[test]
 fn apply_observed_config_emits_on_change_and_is_idempotent() {
     let mut session = make_session();
     session.apply_observed_config(ConfigKey::new("reasoning"), ConfigValue::new("high"));

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -3892,6 +3892,75 @@ async fn set_config_option_persists_runtime_model_into_assistant_preference_when
 }
 
 #[tokio::test]
+async fn set_config_option_does_not_persist_preference_on_error() {
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let (svc, _broadcaster, _repo, definition_repo, overlay_repo, preference_repo) =
+        make_service_with_mock_task_manager_and_assistant_support(task_mgr.clone()).await;
+
+    upsert_test_assistant_definition(
+        &definition_repo,
+        "asstdef_acp_auto",
+        "assistant-acp-auto",
+        "codex",
+        "auto",
+        "auto",
+    )
+    .await;
+    overlay_repo
+        .upsert(&UpsertAssistantOverlayParams {
+            assistant_definition_id: "asstdef_acp_auto",
+            enabled: true,
+            sort_order: 0,
+            agent_id_override: None,
+            last_used_at: None,
+        })
+        .await
+        .unwrap();
+    preference_repo
+        .upsert(&UpsertAssistantPreferenceParams {
+            assistant_definition_id: "asstdef_acp_auto",
+            last_model_id: Some("original-model"),
+            last_permission_value: Some("original-mode"),
+            last_thought_level_value: Some("original-low"),
+            last_skill_ids: "[]",
+            last_disabled_builtin_skill_ids: "[]",
+            last_mcp_ids: "[]",
+        })
+        .await
+        .unwrap();
+
+    let conv = create_assistant_backed_conversation(&svc, "user_1", Some("acp"), "codex", "assistant-acp-auto").await;
+
+    // Agent reports a session-change conflict (mirrors the legacy ACK-then-
+    // session-changed race): the service must return the error and leave the
+    // persisted preference untouched.
+    let agent = Arc::new(
+        MockAgent::new(&conv.id).with_set_config_option_error(AgentError::conflict(
+            "Active ACP session changed while applying config option",
+        )),
+    );
+    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(agent));
+
+    let result = svc
+        .set_config_option(
+            &conv.id,
+            "model",
+            SetConfigOptionRequest {
+                value: "gpt-5.5".to_owned(),
+            },
+        )
+        .await;
+    assert!(result.is_err(), "conflict from agent must surface as error");
+
+    let pref_after = preference_repo.get("asstdef_acp_auto").await.unwrap().unwrap();
+    assert_eq!(
+        pref_after.last_model_id.as_deref(),
+        Some("original-model"),
+        "preference must not be written when set_config_option errors"
+    );
+}
+
+#[tokio::test]
 async fn set_config_option_skips_preference_write_back_when_default_mode_is_fixed() {
     let task_mgr = Arc::new(MockTaskManager::new());
     let (svc, _broadcaster, repo, definition_repo, overlay_repo, preference_repo) =


### PR DESCRIPTION
## Summary

Hermes-style legacy ACP agents switch mode/model via `session/set_mode` / `session/set_model`. They persist the change and return a success ACK, but never report the new value back (no `CurrentModeUpdate`, and legacy ACP has no model-update notification). AionCore's observed-confirmation loop kept polling its own stale aggregate and returned a 10s timeout (504) even though the switch had already succeeded on the agent side.

This treats a successful legacy RPC ACK as completion: AionCore confirms the value into its own aggregate and returns immediately. The `ConfigOption` (new-protocol) path is unchanged and still waits for the agent to report observed state. The difference is expressed through the already-resolved `ConfigSetPath`, not by branching on `backend == "hermes"`.

## Changes

- Add `ConfigSetPath::log_label()` / `acp_method()` helpers for structured logging.
- `LegacyMode` / `LegacyModel`: after a successful ACK, atomically (within a single session write lock) re-validate the active session, run `confirm_mode` / `confirm_model`, snapshot, and commit — then return `Observed` without waiting.
- Add `apply_legacy_config_ack` helper; remove the now-dead `ensure_session_unchanged`.
- Every config-option log event now carries `set_path` + `method`; add `acp_legacy_config_ack_applied` to mark the local-confirm lifecycle boundary.
- No `AcpAgentManager` fields added; no Hermes, API schema, or DB schema changes.

## Behavior

- Legacy ACK → immediate 200 (no fixed 10s wait); desired / observed / advertised current unified; runtime persisted via the existing debounce.
- `ConfigOption` path keeps real observed-confirmation (still times out at 10s if the agent only ACKs).
- RPC failure, session-change conflict, or non-selectable value never write local state.

## Tests

- `aionui-ai-agent`: `ConfigSetPath` label/method unit test; catalog-preservation tests for `confirm_mode` / `confirm_model`.
- `aionui-conversation`: `set_config_option` error path leaves the persisted preference untouched.
- Existing tests already cover confirm/observed/reconcile aggregate semantics and the `Observed` → assistant snapshot/preference write-back.
- Full workspace suite green (`just push`: 6816 passed).

## Manual verification (dev — Hermes v0.18.0, Codex, Claude)

- Hermes mode `default → dont_ask` and model `gpt-5.5-pro → gpt-5.5`: HTTP returns within RPC round-trip time (no 10s wait), no UI rollback; log chain `set_requested → command_ack → legacy_config_ack_applied` with `set_path=legacy_mode|legacy_model`; zero `confirmation_timeout`.
- Codex / Claude (`ConfigOption`): unchanged, `observed_confirmed` with `elapsed_ms=0`.
- `acp_session.session_config.runtime` persisted the final requested mode/model for every conversation.

Not exercised manually: `accept_edits` (identical `legacy_mode` code path as `dont_ask`).
