### PR TITLE
feat(ai-agent): use responses api for gpt-5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "aion-agent"
 version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.5#8fa397b2437c686ae7245a2673b9a78c7e9e527e"
+source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -149,7 +149,7 @@ dependencies = [
 [[package]]
 name = "aion-compact"
 version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.5#8fa397b2437c686ae7245a2673b9a78c7e9e527e"
+source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
 dependencies = [
  "regex",
  "serde",
@@ -161,7 +161,7 @@ dependencies = [
 [[package]]
 name = "aion-config"
 version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.5#8fa397b2437c686ae7245a2673b9a78c7e9e527e"
+source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
 dependencies = [
  "aion-compact",
  "aion-process",
@@ -186,7 +186,7 @@ dependencies = [
 [[package]]
 name = "aion-mcp"
 version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.5#8fa397b2437c686ae7245a2673b9a78c7e9e527e"
+source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -207,7 +207,7 @@ dependencies = [
 [[package]]
 name = "aion-memory"
 version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.5#8fa397b2437c686ae7245a2673b9a78c7e9e527e"
+source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
 dependencies = [
  "aion-config",
  "chrono",
@@ -221,7 +221,7 @@ dependencies = [
 [[package]]
 name = "aion-process"
 version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.5#8fa397b2437c686ae7245a2673b9a78c7e9e527e"
+source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
 dependencies = [
  "libc",
  "tokio",
@@ -232,7 +232,7 @@ dependencies = [
 [[package]]
 name = "aion-protocol"
 version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.5#8fa397b2437c686ae7245a2673b9a78c7e9e527e"
+source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
 dependencies = [
  "aion-types",
  "serde",
@@ -245,7 +245,7 @@ dependencies = [
 [[package]]
 name = "aion-providers"
 version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.5#8fa397b2437c686ae7245a2673b9a78c7e9e527e"
+source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "aion-skills"
 version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.5#8fa397b2437c686ae7245a2673b9a78c7e9e527e"
+source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 name = "aion-tools"
 version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.5#8fa397b2437c686ae7245a2673b9a78c7e9e527e"
+source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -322,7 +322,7 @@ dependencies = [
 [[package]]
 name = "aion-types"
 version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.5#8fa397b2437c686ae7245a2673b9a78c7e9e527e"
+source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
 dependencies = [
  "async-trait",
  "base64",
@@ -6551,7 +6551,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.5#8fa397b2437c686ae7245a2673b9a78c7e9e527e"
+source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
 dependencies = [
  "bitflags",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,8 +117,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
+version = "0.2.6"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.6#3cb928d451f278e3f88a9664c39ea3db5d13129a"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -148,8 +148,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
+version = "0.2.6"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.6#3cb928d451f278e3f88a9664c39ea3db5d13129a"
 dependencies = [
  "regex",
  "serde",
@@ -160,8 +160,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
+version = "0.2.6"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.6#3cb928d451f278e3f88a9664c39ea3db5d13129a"
 dependencies = [
  "aion-compact",
  "aion-process",
@@ -185,8 +185,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
+version = "0.2.6"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.6#3cb928d451f278e3f88a9664c39ea3db5d13129a"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -206,8 +206,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
+version = "0.2.6"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.6#3cb928d451f278e3f88a9664c39ea3db5d13129a"
 dependencies = [
  "aion-config",
  "chrono",
@@ -220,8 +220,8 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
+version = "0.2.6"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.6#3cb928d451f278e3f88a9664c39ea3db5d13129a"
 dependencies = [
  "libc",
  "tokio",
@@ -231,8 +231,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
+version = "0.2.6"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.6#3cb928d451f278e3f88a9664c39ea3db5d13129a"
 dependencies = [
  "aion-types",
  "serde",
@@ -244,8 +244,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
+version = "0.2.6"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.6#3cb928d451f278e3f88a9664c39ea3db5d13129a"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -272,8 +272,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
+version = "0.2.6"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.6#3cb928d451f278e3f88a9664c39ea3db5d13129a"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -299,8 +299,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
+version = "0.2.6"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.6#3cb928d451f278e3f88a9664c39ea3db5d13129a"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -321,8 +321,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.2.5"
-source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
+version = "0.2.6"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.6#3cb928d451f278e3f88a9664c39ea3db5d13129a"
 dependencies = [
  "async-trait",
  "base64",
@@ -6108,7 +6108,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6551,7 +6551,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?rev=3185442df3d164f4d249c4fa4d21f94d05cc4ffe#3185442df3d164f4d249c4fa4d21f94d05cc4ffe"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.6#3cb928d451f278e3f88a9664c39ea3db5d13129a"
 dependencies = [
  "bitflags",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,12 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.5" }
-aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.5" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.5" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.5" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.5" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.5" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", rev = "3185442df3d164f4d249c4fa4d21f94d05cc4ffe" }
+aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", rev = "3185442df3d164f4d249c4fa4d21f94d05cc4ffe" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", rev = "3185442df3d164f4d249c4fa4d21f94d05cc4ffe" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", rev = "3185442df3d164f4d249c4fa4d21f94d05cc4ffe" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", rev = "3185442df3d164f4d249c4fa4d21f94d05cc4ffe" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", rev = "3185442df3d164f4d249c4fa4d21f94d05cc4ffe" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,12 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", rev = "3185442df3d164f4d249c4fa4d21f94d05cc4ffe" }
-aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", rev = "3185442df3d164f4d249c4fa4d21f94d05cc4ffe" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", rev = "3185442df3d164f4d249c4fa4d21f94d05cc4ffe" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", rev = "3185442df3d164f4d249c4fa4d21f94d05cc4ffe" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", rev = "3185442df3d164f4d249c4fa4d21f94d05cc4ffe" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", rev = "3185442df3d164f4d249c4fa4d21f94d05cc4ffe" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.6" }
+aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.6" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.6" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.6" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.6" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.6" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }

--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use aion_agent::session::SessionManager;
+use aion_config::compat::OpenAiApiMode;
 use aion_config::config::{McpServerConfig, TransportType};
 use aionui_api_types::{
     AionrsBuildExtra, SessionMcpServer, SessionMcpTransport, TEAM_MCP_SERVER_NAME, TeamMcpStdioConfig,
@@ -96,7 +97,19 @@ pub(super) async fn build(
     let provider = map_aionrs_provider(&row.platform, &model_id, row.model_protocols.as_deref())?;
 
     let (base_url, compat_overrides) =
-        resolve_aionrs_url_and_compat(&row.platform, &row.base_url, &provider, row.is_full_url);
+        resolve_aionrs_url_and_compat(&row.platform, &row.base_url, &provider, &model_id, row.is_full_url);
+
+    if compat_overrides.openai_api_mode == Some(OpenAiApiMode::Responses) {
+        info!(
+            conversation_id = %ctx.conversation_id,
+            platform = %row.platform,
+            provider = %provider,
+            model = %model_id,
+            is_full_url = row.is_full_url,
+            api_mode = "responses",
+            "Resolved Aionrs OpenAI transport"
+        );
+    }
 
     let bedrock_config = if row.platform == "bedrock" {
         resolve_bedrock_config(row.bedrock_config.as_deref())
@@ -237,18 +250,26 @@ pub(crate) fn map_aionrs_provider(
 /// Resolve base_url and compat overrides for the aionrs provider.
 ///
 /// The stored base_url is treated as the user-controlled endpoint prefix.
-/// OpenAI-compatible providers append `/chat/completions`; Anthropic-compatible
-/// providers append `/v1/messages`.
+/// OpenAI-compatible providers use Chat Completions by default; official
+/// OpenAI GPT-5.6 models use Responses. Anthropic-compatible providers append
+/// `/v1/messages`.
 pub(crate) fn resolve_aionrs_url_and_compat(
     platform: &str,
     raw_base_url: &str,
     mapped_provider: &str,
+    model_id: &str,
     is_full_url: bool,
 ) -> (Option<String>, AionrsCompatOverrides) {
     let mut compat = AionrsCompatOverrides::default();
+    let use_responses = uses_openai_responses_api(platform, mapped_provider, model_id);
 
     if is_full_url {
         let trimmed = raw_base_url.trim_end_matches('/');
+        if use_responses && let Some(responses_url) = rewrite_chat_completions_url_to_responses(trimmed) {
+            compat.openai_api_mode = Some(OpenAiApiMode::Responses);
+            compat.api_path = Some(String::new());
+            return (Some(responses_url), compat);
+        }
         compat.api_path = Some(String::new());
         return (Some(trimmed.to_owned()), compat);
     }
@@ -263,9 +284,17 @@ pub(crate) fn resolve_aionrs_url_and_compat(
     let trimmed = raw_base_url.trim_end_matches('/');
     let base_url = Some(trimmed.to_owned()).filter(|u| !u.is_empty());
 
+    if use_responses {
+        compat.openai_api_mode = Some(OpenAiApiMode::Responses);
+    }
+
     match mapped_provider {
         "openai" if base_url.is_some() => {
-            compat.api_path = Some("/chat/completions".to_owned());
+            compat.api_path = Some(if use_responses {
+                "/responses".to_owned()
+            } else {
+                "/chat/completions".to_owned()
+            });
         }
         "anthropic" if base_url.is_some() && platform != "anthropic" => {
             compat.api_path = Some("/v1/messages".to_owned());
@@ -278,6 +307,21 @@ pub(crate) fn resolve_aionrs_url_and_compat(
     }
 
     (base_url, compat)
+}
+
+fn uses_openai_responses_api(platform: &str, mapped_provider: &str, model_id: &str) -> bool {
+    if mapped_provider != "openai" || platform == "gemini" {
+        return false;
+    }
+
+    let model = model_id.to_ascii_lowercase();
+    model == "gpt-5.6" || model.starts_with("gpt-5.6-")
+}
+
+fn rewrite_chat_completions_url_to_responses(url: &str) -> Option<String> {
+    url.strip_suffix("/chat/completions")
+        .map(|prefix| format!("{prefix}/responses"))
+        .or_else(|| url.ends_with("/responses").then(|| url.to_owned()))
 }
 
 fn resolve_model_protocol(model_id: &str, model_protocols: Option<&str>) -> Result<String, AgentError> {
@@ -1038,6 +1082,75 @@ mod tests {
         assert!(!is_openai_host("not-a-url"));
     }
 
+    #[test]
+    fn openai_protocol_gpt_5_6_family_uses_responses() {
+        let cases = [
+            ("openai", "https://api.openai.com/v1", "gpt-5.6"),
+            ("custom", "https://api.openai.com/v1", "gpt-5.6-sol"),
+            ("new-api", "https://proxy.example.com/v1", "GPT-5.6-SOL-2026-07-01"),
+        ];
+
+        for (platform, raw_base_url, model_id) in cases {
+            let (base_url, compat) = resolve_aionrs_url_and_compat(platform, raw_base_url, "openai", model_id, false);
+
+            assert_eq!(base_url.as_deref(), Some(raw_base_url), "{model_id}");
+            assert_eq!(compat.openai_api_mode, Some(OpenAiApiMode::Responses), "{model_id}");
+            assert_eq!(compat.api_path.as_deref(), Some("/responses"), "{model_id}");
+        }
+    }
+
+    #[test]
+    fn responses_selection_does_not_leak_to_other_providers_or_full_urls() {
+        let cases = [
+            ("gemini", "openai", "gpt-5.6-sol", false),
+            ("bedrock", "bedrock", "openai.gpt-5.6-sol", false),
+            ("openai", "openai", "gpt-5.60-sol", false),
+        ];
+
+        for (platform, provider, model_id, is_full_url) in cases {
+            let (_, compat) = resolve_aionrs_url_and_compat(
+                platform,
+                "https://example.test/v1/chat/completions",
+                provider,
+                model_id,
+                is_full_url,
+            );
+
+            assert_eq!(compat.openai_api_mode, None, "{platform}/{model_id}");
+        }
+    }
+
+    #[test]
+    fn openai_protocol_gpt_5_6_full_url_is_rewritten_to_responses() {
+        for raw_base_url in [
+            "https://api.openai.com/v1/chat/completions",
+            "https://proxy.example.com/v1/chat/completions/",
+            "https://api.openai.com/v1/responses",
+        ] {
+            let (base_url, compat) =
+                resolve_aionrs_url_and_compat("custom", raw_base_url, "openai", "gpt-5.6-sol", true);
+
+            assert!(base_url.as_deref().unwrap().ends_with("/responses"), "{raw_base_url}");
+            assert_eq!(compat.openai_api_mode, Some(OpenAiApiMode::Responses), "{raw_base_url}");
+            assert_eq!(compat.api_path.as_deref(), Some(""), "{raw_base_url}");
+        }
+    }
+
+    #[test]
+    fn unrelated_full_url_is_not_rewritten_for_gpt_5_6() {
+        let (base_url, compat) = resolve_aionrs_url_and_compat(
+            "custom",
+            "https://proxy.example.com/generate",
+            "openai",
+            "gpt-5.6-sol",
+            true,
+        );
+
+        assert_eq!(base_url.as_deref(), Some("https://proxy.example.com/generate"));
+        assert_eq!(compat.openai_api_mode, None);
+        assert_eq!(compat.api_path.as_deref(), Some(""));
+    }
+
     struct UrlCompatCase<'a> {
         name: &'a str,
         platform: &'a str,
@@ -1205,8 +1318,13 @@ mod tests {
         ];
 
         for case in cases {
-            let (base_url, compat) =
-                resolve_aionrs_url_and_compat(case.platform, case.raw_base_url, case.mapped_provider, case.is_full_url);
+            let (base_url, compat) = resolve_aionrs_url_and_compat(
+                case.platform,
+                case.raw_base_url,
+                case.mapped_provider,
+                "gpt-4o",
+                case.is_full_url,
+            );
             assert_eq!(base_url.as_deref(), case.expected_base_url, "{}", case.name);
             assert_eq!(compat.api_path.as_deref(), case.expected_api_path, "{}", case.name);
             assert_eq!(
@@ -1348,7 +1466,7 @@ mod tests {
             let provider = map_aionrs_provider("custom", "m", None).expect(case.name);
             assert_eq!(provider, "openai", "{}", case.name);
 
-            let (base_url, compat) = resolve_aionrs_url_and_compat("custom", case.base_url, &provider, false);
+            let (base_url, compat) = resolve_aionrs_url_and_compat("custom", case.base_url, &provider, "m", false);
             assert_eq!(base_url.as_deref(), Some(case.base_url), "{}", case.name);
             assert_eq!(compat.api_path.as_deref(), Some("/chat/completions"), "{}", case.name);
             assert_eq!(
@@ -1439,7 +1557,7 @@ mod tests {
             let provider = map_aionrs_provider(case.platform, "m", None).expect(case.name);
             assert_eq!(provider, case.expected_provider, "{}", case.name);
 
-            let (base_url, compat) = resolve_aionrs_url_and_compat(case.platform, case.base_url, &provider, false);
+            let (base_url, compat) = resolve_aionrs_url_and_compat(case.platform, case.base_url, &provider, "m", false);
             assert_eq!(base_url.as_deref(), case.expected_base_url, "{}", case.name);
             assert_eq!(compat.api_path.as_deref(), case.expected_api_path, "{}", case.name);
 

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -178,6 +178,9 @@ impl AionrsAgentManager {
         config.session.directory = config_extra.session_directory.to_string_lossy().into_owned();
         config.compat.image_input = Some(image_input_capability);
 
+        if let Some(mode) = config_extra.compat_overrides.openai_api_mode {
+            config.compat.transport.openai_api_mode = Some(mode);
+        }
         if let Some(field) = config_extra.compat_overrides.max_tokens_field {
             config.compat.transport.max_tokens_field = Some(field);
         }

--- a/crates/aionui-ai-agent/src/manager/aionrs/history_sanitize.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/history_sanitize.rs
@@ -85,7 +85,10 @@ fn strip_malformed_tool_calls(messages: &mut Vec<Message>) -> usize {
         msg.content.retain(|block| match block {
             ContentBlock::ToolUse { name, .. } => !name.trim().is_empty(),
             ContentBlock::ToolResult { tool_use_id, .. } => !malformed_tool_use_ids.contains(tool_use_id),
-            ContentBlock::Text { .. } | ContentBlock::Thinking { .. } | ContentBlock::Image { .. } => true,
+            ContentBlock::Text { .. }
+            | ContentBlock::Thinking { .. }
+            | ContentBlock::Image { .. }
+            | ContentBlock::ProviderItem { .. } => true,
         });
     }
 
@@ -119,10 +122,13 @@ fn is_orphaned_assistant_tool_call(msg: &Message, answered: &HashSet<String>) ->
                     has_text = true;
                 }
             }
-            // Thinking, ToolResult, and Image blocks do not change the orphan
-            // determination. ToolResult should not appear on assistant
-            // messages, but if it does we ignore it here.
-            ContentBlock::Thinking { .. } | ContentBlock::ToolResult { .. } | ContentBlock::Image { .. } => {}
+            // Thinking, provider-owned items, ToolResult, and Image blocks do
+            // not change the orphan determination. ToolResult should not
+            // appear on assistant messages, but if it does we ignore it here.
+            ContentBlock::Thinking { .. }
+            | ContentBlock::ProviderItem { .. }
+            | ContentBlock::ToolResult { .. }
+            | ContentBlock::Image { .. } => {}
         }
     }
 

--- a/crates/aionui-ai-agent/src/manager/aionrs/history_sanitize_test.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/history_sanitize_test.rs
@@ -93,6 +93,25 @@ fn keeps_regular_assistant_text_message() {
 }
 
 #[test]
+fn keeps_provider_owned_reasoning_item() {
+    let mut messages = vec![Message::new(
+        Role::Assistant,
+        vec![ContentBlock::ProviderItem {
+            provider: "openai_responses".to_owned(),
+            item: json!({"id": "rs_1", "type": "reasoning", "encrypted_content": "encrypted"}),
+        }],
+    )];
+
+    let removed = sanitize_session_messages(&mut messages);
+
+    assert_eq!(removed, 0);
+    assert!(matches!(
+        messages[0].content.as_slice(),
+        [ContentBlock::ProviderItem { .. }]
+    ));
+}
+
+#[test]
 fn keeps_assistant_with_text_and_orphan_tool_call() {
     // Assistant emitted some streamed text before the tool was cancelled.
     // Provider will accept this because content is non-null even though

--- a/crates/aionui-ai-agent/src/services/provider_health.rs
+++ b/crates/aionui-ai-agent/src/services/provider_health.rs
@@ -68,7 +68,7 @@ impl ProviderHealthCheckService {
             .map_err(|e| AgentError::internal(e.to_string()))?;
         let provider = map_aionrs_provider(&row.platform, model_id, row.model_protocols.as_deref())?;
         let (base_url, compat_overrides) =
-            resolve_aionrs_url_and_compat(&row.platform, &row.base_url, &provider, row.is_full_url);
+            resolve_aionrs_url_and_compat(&row.platform, &row.base_url, &provider, model_id, row.is_full_url);
         let bedrock_config = if row.platform == "bedrock" {
             resolve_bedrock_config(row.bedrock_config.as_deref())
         } else {
@@ -216,6 +216,9 @@ async fn build_probe_engine(config_extra: AionrsResolvedConfig) -> Result<AgentE
     config.session.enabled = false;
     config.mcp.servers.clear();
     config.file_cache.enabled = false;
+    if let Some(mode) = config_extra.compat_overrides.openai_api_mode {
+        config.compat.transport.openai_api_mode = Some(mode);
+    }
     if let Some(field) = config_extra.compat_overrides.max_tokens_field {
         config.compat.transport.max_tokens_field = Some(field);
     }
@@ -316,6 +319,7 @@ pub(crate) fn extract_http_status(message: &str) -> Option<u16> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aion_config::compat::OpenAiApiMode;
     use aionui_common::encrypt_string;
     use aionui_db::{CreateProviderParams, DbError, UpdateProviderParams};
 
@@ -383,6 +387,18 @@ mod tests {
 
         assert_eq!(config.max_tokens, Some(HEALTH_CHECK_MAX_TOKENS));
         assert_eq!(config.max_turns, Some(1));
+    }
+
+    #[test]
+    fn resolve_probe_config_uses_responses_for_openai_gpt_5_6() {
+        let mut provider = test_provider();
+        provider.platform = "openai".to_owned();
+        provider.base_url = "https://api.openai.com/v1".to_owned();
+
+        let config = test_service().resolve_probe_config(&provider, "gpt-5.6-sol").unwrap();
+
+        assert_eq!(config.compat_overrides.openai_api_mode, Some(OpenAiApiMode::Responses));
+        assert_eq!(config.compat_overrides.api_path.as_deref(), Some("/responses"));
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use aion_config::compat::OpenAiApiMode;
 use serde::{Deserialize, Serialize};
 
 use crate::session_context::AgentSessionContext;
@@ -111,6 +112,7 @@ impl RuntimeCapabilities {
 /// Provider-specific compat overrides resolved in the factory.
 #[derive(Debug, Clone, Default)]
 pub struct AionrsCompatOverrides {
+    pub(crate) openai_api_mode: Option<OpenAiApiMode>,
     pub max_tokens_field: Option<String>,
     pub api_path: Option<String>,
 }


### PR DESCRIPTION
## Motivation

GPT-5.6 tool-enabled requests with `reasoning_effort` fail when sent to `/v1/chat/completions`. AionUi's OpenAI preset is stored internally as `platform=custom`, so matching only the raw `openai` platform misses the actual OpenAI configuration and leaves these requests on Chat Completions.

## Summary

- select the Responses API for `gpt-5.6` and `gpt-5.6-*` after resolving the provider to the OpenAI protocol
- cover OpenAI presets stored as `custom` and compatible gateway presets while excluding Gemini, Anthropic, Bedrock, and Vertex transports
- rewrite an explicit GPT-5.6 `/chat/completions` full URL to `/responses`; keep other full URLs unchanged
- apply the transport override to both regular Aionrs sessions and provider health checks
- preserve provider-owned reasoning items during AionCore session-history sanitization
- add a production-safe transport-resolution log and pin the required aionrs commit for reproducible builds

## Compatibility / Non-goals

- other OpenAI models continue to use Chat Completions by default
- Anthropic, Gemini/Vertex, and Bedrock behavior is unchanged
- no user-facing protocol setting or AionUi change is required

## Validation

- `cargo test -p aionui-ai-agent`
- `cargo clippy -p aionui-ai-agent -- -D warnings`
- `cargo fmt --all -- --check`
- `just push -u origin jiahe/feat/openai-responses`
- runtime verification with the actual configuration: `platform=custom provider=openai model=gpt-5.6-sol api_mode=responses`; the request emitted visible output and completed successfully

## Dependency / Merge Order

1. Merge and release [iOfficeAI/aionrs#231](https://github.com/iOfficeAI/aionrs/pull/231) at commit `3185442df3d164f4d249c4fa4d21f94d05cc4ffe`.
2. Replace the temporary commit pin with the released aionrs tag.
3. Merge this PR.
