### PR TITLE
feat(config): add conversation rename command

### DIFF
--- a/crates/aionui-app/src/cli.rs
+++ b/crates/aionui-app/src/cli.rs
@@ -274,6 +274,8 @@ pub(crate) enum ConfigCommand {
     Capabilities,
     /// Print the current agent runtime context.
     Context,
+    /// Manage conversations.
+    Conversation(ConfigConversationArgs),
     /// Manage assistants and assistant-owned behavior.
     Assistants(ConfigAssistantsArgs),
     /// Manage AionUi skills.
@@ -566,6 +568,17 @@ pub(crate) enum ConfigCronCurrentCommand {
 }
 
 #[derive(Args, Debug, Clone)]
+pub(crate) struct ConfigConversationArgs {
+    #[command(subcommand)]
+    pub command: ConfigConversationCommand,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(crate) enum ConfigConversationCommand {
+    Rename,
+}
+
+#[derive(Args, Debug, Clone)]
 pub(crate) struct PrepareManagedResourcesArgs {
     /// Bundle output root. Aioncore writes the managed resources under
     /// `<bundle-out>/{node,acp}/...` for packaging.
@@ -715,6 +728,7 @@ mod tests {
         let commands: &[&[&str]] = &[
             &["aioncore", "config", "capabilities"],
             &["aioncore", "config", "context"],
+            &["aioncore", "config", "conversation", "rename"],
             &["aioncore", "config", "assistants", "list"],
             &["aioncore", "config", "assistants", "get"],
             &["aioncore", "config", "assistants", "create"],

--- a/crates/aionui-app/src/commands/cmd_config.rs
+++ b/crates/aionui-app/src/commands/cmd_config.rs
@@ -9,12 +9,12 @@ use serde_json::{Map, Value, json};
 
 use crate::cli::{
     ConfigAgentCustomCommand, ConfigAgentOverridesCommand, ConfigAgentsArgs, ConfigAgentsCommand, ConfigArgs,
-    ConfigAssistantTextCommand, ConfigAssistantsArgs, ConfigAssistantsCommand, ConfigCommand, ConfigCronArgs,
-    ConfigCronCommand, ConfigCronCurrentArgs, ConfigCronCurrentCommand, ConfigCronJobSkillCommand, ConfigCronJobsArgs,
-    ConfigCronJobsCommand, ConfigMcpArgs, ConfigMcpCommand, ConfigMcpOauthCommand, ConfigMcpServersCommand,
-    ConfigProviderModelsCommand, ConfigProvidersArgs, ConfigProvidersCommand, ConfigSettingsArgs,
-    ConfigSettingsClientCommand, ConfigSettingsCommand, ConfigSkillsArgs, ConfigSkillsCommand,
-    ConfigSkillsExternalPathsCommand, ConfigSkillsMarketCommand,
+    ConfigAssistantTextCommand, ConfigAssistantsArgs, ConfigAssistantsCommand, ConfigCommand, ConfigConversationArgs,
+    ConfigConversationCommand, ConfigCronArgs, ConfigCronCommand, ConfigCronCurrentArgs, ConfigCronCurrentCommand,
+    ConfigCronJobSkillCommand, ConfigCronJobsArgs, ConfigCronJobsCommand, ConfigMcpArgs, ConfigMcpCommand,
+    ConfigMcpOauthCommand, ConfigMcpServersCommand, ConfigProviderModelsCommand, ConfigProvidersArgs,
+    ConfigProvidersCommand, ConfigSettingsArgs, ConfigSettingsClientCommand, ConfigSettingsCommand, ConfigSkillsArgs,
+    ConfigSkillsCommand, ConfigSkillsExternalPathsCommand, ConfigSkillsMarketCommand,
 };
 use crate::commands::config_capabilities;
 
@@ -38,6 +38,7 @@ async fn run(args: ConfigArgs) -> Result<(), ConfigError> {
     match args.command {
         ConfigCommand::Capabilities => print_envelope(config_capabilities::data(), meta(None), "config capabilities"),
         ConfigCommand::Context => run_context(&client).await,
+        ConfigCommand::Conversation(args) => run_conversation(&client, args).await,
         ConfigCommand::Assistants(args) => run_assistants(&client, args).await,
         ConfigCommand::Skills(args) => run_skills(&client, args).await,
         ConfigCommand::Mcp(args) => run_mcp(&client, args).await,
@@ -63,6 +64,22 @@ async fn run_context(client: &reqwest::Client) -> Result<(), ConfigError> {
         meta(None),
         command,
     )
+}
+
+async fn run_conversation(client: &reqwest::Client, args: ConfigConversationArgs) -> Result<(), ConfigError> {
+    match args.command {
+        ConfigConversationCommand::Rename => {
+            run_id_payload_request_with_resource_readback(
+                client,
+                "config conversation rename",
+                Method::PATCH,
+                IdRoute::new("/api/conversations", "", "conversation_id"),
+                IdRoute::new("/api/conversations", "", "conversation_id"),
+                false,
+            )
+            .await
+        }
+    }
 }
 
 async fn run_assistants(client: &reqwest::Client, args: ConfigAssistantsArgs) -> Result<(), ConfigError> {

--- a/crates/aionui-app/src/commands/config_capabilities.rs
+++ b/crates/aionui-app/src/commands/config_capabilities.rs
@@ -58,6 +58,9 @@ pub(crate) fn data() -> Value {
                 no_input(&["capabilities"], "Print this agent-readable capability contract.", false),
                 no_input(&["context"], "Read the current runtime context and current conversation assistant.", false),
             ]),
+            domain("conversation", &[
+                stdin(&["conversation", "rename"], "Rename a conversation.", &["conversation_id", "name"], &["conversation_id"], true, false),
+            ]),
             domain("assistants", &[
                 no_input(&["assistants", "list"], "List assistants.", false),
                 stdin(&["assistants", "get"], "Read one assistant.", &["assistant_id", "locale"], &["assistant_id"], false, false),

--- a/crates/aionui-app/tests/config_cli_e2e.rs
+++ b/crates/aionui-app/tests/config_cli_e2e.rs
@@ -45,6 +45,26 @@ async fn fake_context_conversation(Path(id): Path<String>) -> axum::Json<serde_j
     }))
 }
 
+async fn fake_conversation_rename(
+    State(capture): State<SharedCapture>,
+    Path(id): Path<String>,
+    axum::Json(payload): axum::Json<serde_json::Value>,
+) -> axum::Json<serde_json::Value> {
+    *capture.lock().unwrap() = Some(Capture {
+        resource_id: Some(id.clone()),
+        payload: Some(payload),
+        ..Capture::default()
+    });
+    axum::Json(json!({
+        "success": true,
+        "data": {
+            "id": id,
+            "name": "Renamed conversation",
+            "extra": {}
+        }
+    }))
+}
+
 async fn fake_assistant_rule_read(
     State(capture): State<SharedCapture>,
     axum::Json(payload): axum::Json<serde_json::Value>,
@@ -341,7 +361,10 @@ async fn spawn_config_probe_server(capture: SharedCapture) -> (String, tokio::ta
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let app = axum::Router::new()
-        .route("/api/conversations/{id}", get(fake_context_conversation))
+        .route(
+            "/api/conversations/{id}",
+            get(fake_context_conversation).patch(fake_conversation_rename),
+        )
         .route("/api/skills/assistant-rule/read", post(fake_assistant_rule_read))
         .route("/api/skills/assistant-rule/write", post(fake_assistant_rule_write))
         .route("/api/internal/conversation-cron/list", get(fake_conversation_cron_list))
@@ -521,6 +544,55 @@ async fn config_provider_update_reads_collection_before_and_after_write() {
     let stdout: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert!(stdout["meta"]["before"].is_array());
     assert!(stdout["meta"]["after"].is_array());
+}
+
+#[tokio::test]
+async fn config_conversation_rename_patches_name_and_reads_resource_before_and_after() {
+    let capture = Arc::new(Mutex::new(None));
+    let (base_url, handle) = spawn_config_probe_server(capture.clone()).await;
+
+    let mut child = config_command()
+        .args(["conversation", "rename"])
+        .env("AIONUI_BASE_URL", &base_url)
+        .env("AIONUI_CONVERSATION_ID", "conv-current")
+        .env("AIONUI_USER_ID", "user-rename")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(br#"{ "conversation_id": "conv-target", "name": "New Title" }"#)
+        .await
+        .unwrap();
+    drop(child.stdin.take());
+
+    let output = child.wait_with_output().await.unwrap();
+
+    handle.abort();
+    assert!(
+        output.status.success(),
+        "conversation rename failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let captured = capture
+        .lock()
+        .unwrap()
+        .take()
+        .expect("server should receive conversation rename");
+    // The id selector is extracted from the payload and moved into the path,
+    // leaving only the update body forwarded to PATCH.
+    assert_eq!(captured.resource_id.as_deref(), Some("conv-target"));
+    let payload = captured.payload.unwrap();
+    assert_eq!(payload.get("name").and_then(|v| v.as_str()), Some("New Title"));
+    assert!(payload.get("conversation_id").is_none());
+    let stdout: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(stdout["meta"]["before"].is_object());
+    assert!(stdout["meta"]["after"].is_object());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Adds a `config conversation rename` subcommand to the agent-facing `aioncore config` CLI.

```bash
echo '{ "conversation_id": "conv-x", "name": "New Title" }' | aioncore config conversation rename
```

`conversation_id` accepts the `"current"` selector, resolving from `AIONUI_CONVERSATION_ID`.

## Why

The agent-facing config CLI could manage assistants, skills, MCP, providers, settings, agents and cron, but had no path to rename a conversation. Agents had to fall back to the raw HTTP escape hatch.

## How

- No backend changes — the endpoint `PATCH /api/conversations/{id}` already exists (`UpdateConversationRequest { name }`).
- Wires the new subcommand to the existing `run_id_payload_request_with_resource_readback` helper (same pattern as `cron`/`provider`/`assistant` updates): reads `{conversation_id, name}` from stdin, moves the id selector into the path, forwards the remaining body to PATCH, and emits `meta.before` / `meta.after` readback.
- Advertised in `config capabilities` under a new `conversation` domain.

## Tests

- `config_cli.rs` parse test extended with `config conversation rename`.
- New e2e `config_conversation_rename_patches_name_and_reads_resource_before_and_after`: asserts the id is extracted from stdin into the path, `name` is forwarded in the PATCH body (id stripped), and before/after readback objects are present.
- Full workspace `just push` gate green (6818 passed).