### PR TITLE
fix(team): broadcast Stopped status on idle-cleanup team reclaim

### DIFF
--- a/crates/aionui-api-types/src/team.rs
+++ b/crates/aionui-api-types/src/team.rs
@@ -527,6 +527,7 @@ pub enum TeamSessionStatus {
     Starting,
     Ready,
     Failed,
+    Stopped,
 }
 
 /// Diagnostic phase for team session startup.
@@ -1254,6 +1255,7 @@ mod tests {
         assert_session_status_roundtrip(TeamSessionStatus::Starting, "starting");
         assert_session_status_roundtrip(TeamSessionStatus::Ready, "ready");
         assert_session_status_roundtrip(TeamSessionStatus::Failed, "failed");
+        assert_session_status_roundtrip(TeamSessionStatus::Stopped, "stopped");
     }
 
     #[test]

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -1881,6 +1881,8 @@ impl TeamSessionService {
                 member_count = agents.len(),
                 "team idle cleanup stopping idle team session"
             );
+            info!(team_id, reason = "idle_cleanup", "broadcasting team session stopped");
+            self.broadcast_session_status(&team_id, TeamSessionStatus::Stopped, None, |_| {});
             self.stop_session_unchecked(&team_id);
             for agent in agents {
                 self.task_manager
@@ -2629,6 +2631,76 @@ mod tests {
         assert!(unhandled.is_empty());
         assert_eq!(svc.session_count_for_test(), 0);
         assert_eq!(task_manager.active_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn idle_cleanup_broadcasts_team_session_stopped() {
+        let task_manager = Arc::new(MutableTaskManager::new());
+        let (svc, _repo, _task_manager, _conv_repo, broadcaster) =
+            setup_with_factory_metadata_team_repo_conversation_repo_broadcaster_and_task_manager(task_manager.clone());
+        let created = svc
+            .create_team("user-test", two_agent_team_request("Idle Cleanup Stopped Broadcast"))
+            .await
+            .unwrap();
+        let lead = created.assistants.iter().find(|agent| agent.role == "lead").unwrap();
+        let worker = created
+            .assistants
+            .iter()
+            .find(|agent| agent.role == "teammate")
+            .unwrap();
+        task_manager.insert_idle_finished_agent(&lead.conversation_id);
+        task_manager.insert_idle_finished_agent(&worker.conversation_id);
+
+        svc.ensure_session("user-test", &created.id).await.unwrap();
+
+        let unhandled = svc
+            .cleanup_idle_team_runtime_tasks(vec![lead.conversation_id.clone()], &ActiveLeaseRegistry::new(), 300_000)
+            .await;
+
+        assert!(unhandled.is_empty());
+        assert_eq!(svc.session_count_for_test(), 0);
+        assert_eq!(task_manager.active_count(), 0);
+
+        let stopped_events: Vec<_> = broadcaster
+            .events_by_name("team.sessionStatusChanged")
+            .into_iter()
+            .filter(|event| event.data.get("status").and_then(serde_json::Value::as_str) == Some("stopped"))
+            .collect();
+        assert_eq!(
+            stopped_events.len(),
+            1,
+            "idle cleanup must broadcast exactly one stopped status"
+        );
+        assert_eq!(
+            stopped_events[0]
+                .data
+                .get("team_id")
+                .and_then(serde_json::Value::as_str),
+            Some(created.id.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_stop_session_does_not_broadcast_team_session_stopped() {
+        let (svc, _repo, _task_manager, _conv_repo, broadcaster) =
+            setup_with_factory_metadata_team_repo_conversation_repo_and_broadcaster();
+        let created = svc
+            .create_team(
+                "user-test",
+                single_agent_team_request("Explicit Stop No Stopped Broadcast"),
+            )
+            .await
+            .unwrap();
+        svc.ensure_session("user-test", &created.id).await.unwrap();
+
+        svc.stop_session("user-test", &created.id).await.unwrap();
+
+        let stopped_count = broadcaster
+            .events_by_name("team.sessionStatusChanged")
+            .into_iter()
+            .filter(|event| event.data.get("status").and_then(serde_json::Value::as_str) == Some("stopped"))
+            .count();
+        assert_eq!(stopped_count, 0, "explicit stop must not broadcast a stopped status");
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes a team-mode deadlock where, after an idle-clean pass reclaims a team's runtime, the next message is routed to the draft box and never drained.

The idle-cleanup stop path was silent: there was no WebSocket signal that a team session had been reclaimed, and `TeamSessionStatus` had no `Stopped` variant. Without a reliable signal, the frontend could not distinguish "stopped-and-recoverable" from a fatal send-block and got stuck.

This PR adds the backend half of the fix:

- `crates/aionui-api-types/src/team.rs`: add a `Stopped` variant to `TeamSessionStatus` (serialized as `"stopped"` via the existing `snake_case` rule), plus a serde roundtrip assertion.
- `crates/aionui-team/src/service.rs`: in `cleanup_idle_team_runtime_tasks`, broadcast `TeamSessionStatus::Stopped` (and emit an `info`-level lifecycle log with no sensitive payload) immediately before `stop_session_unchecked(&team_id)`.

The broadcast is scoped **strictly** to the idle-cleanup loop. It is not added to `stop_session_unchecked` or any other stop path (explicit stop, spawn cleanup, team switch), so explicit stops do not emit the new status. `runtime_failed` and `removing` remain fatal; only the idle-cleanup path is affected.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Schema / Migration

None. The new `Stopped` status is transient runtime state and is not persisted. No database schema change and no migration files.

## Coupling

This is the backend half of a two-repo change. The AionUi frontend consumes the new `stopped` status to treat an idle-stopped session as recoverable-and-sendable. The two PRs are coupled and should land together, backend first.

## Local Checks

- [x] `cargo fmt --all -- --check` — passes
- [x] `cargo clippy -p aionui-api-types -p aionui-team -- -D warnings` — passes
- [x] `cargo test -p aionui-api-types -p aionui-team` — passes, including new `team_session_status_roundtrips` (Stopped), `idle_cleanup_broadcasts_team_session_stopped`, and `explicit_stop_session_does_not_broadcast_team_session_stopped`

## Additional Context

`explicit_stop_session_does_not_broadcast_team_session_stopped` is a regression guard ensuring the broadcast stays confined to the idle-cleanup path.
