### PR TITLE
fix(ai-agent): ignore max token limits for aionui requests

### DIFF
--- a/crates/aionui-ai-agent/src/agent_task.rs
+++ b/crates/aionui-ai-agent/src/agent_task.rs
@@ -522,7 +522,7 @@ mod aionrs_config_option_tests {
             model: "claude-sonnet-4-20250514".into(),
             base_url: None,
             system_prompt: None,
-            max_tokens: Some(4096),
+            max_tokens: None,
             max_turns: None,
             max_tool_call_malformed_turns: None,
             max_tool_call_failure_turns: None,

--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -173,7 +173,7 @@ pub(super) async fn build(
         model: model_id,
         base_url,
         system_prompt: overrides.system_prompt,
-        max_tokens: overrides.max_tokens,
+        max_tokens: None,
         max_turns: overrides.max_turns,
         max_tool_call_malformed_turns: overrides.max_tool_call_malformed_turns,
         max_tool_call_failure_turns: overrides.max_tool_call_failure_turns,

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -9,7 +9,8 @@ use aion_agent::bootstrap::AgentBootstrap;
 use aion_agent::engine::AgentEngine;
 use aion_agent::output::OutputSink;
 use aion_agent::session::Session;
-use aion_config::config::{CliArgs, Config, McpServerConfig};
+use aion_config::compat::ProviderCompat;
+use aion_config::config::{CliArgs, Config, McpServerConfig, ProviderType};
 use aion_mcp::manager::McpManager;
 use aion_protocol::commands::{ApprovalScope, SessionMode};
 use aion_protocol::{ToolApprovalManager, ToolApprovalResult};
@@ -36,6 +37,24 @@ use crate::types::{AionrsResolvedConfig, SendMessageData};
 
 use super::content::build_content_blocks;
 use super::error::{aionrs_engine_error_to_send_error, aionrs_runtime_error_summary};
+
+fn resolve_aionui_config(cli_args: &CliArgs) -> Result<Config, AgentError> {
+    let mut config =
+        Config::resolve(cli_args).map_err(|e| AgentError::internal(format!("Config resolve failed: {e}")))?;
+
+    // AionUi owns the embedded runtime policy. Standalone aionrs max-token
+    // settings must not leak in from global or workspace config files.
+    config.max_tokens = None;
+    let default_transport = match config.provider {
+        ProviderType::Anthropic | ProviderType::Vertex => ProviderCompat::anthropic_defaults().transport,
+        ProviderType::OpenAI => ProviderCompat::openai_defaults().transport,
+        ProviderType::Bedrock => ProviderCompat::bedrock_defaults().transport,
+    };
+    config.compat.transport.default_max_tokens = default_transport.default_max_tokens;
+    config.compat.transport.model_max_tokens = default_transport.model_max_tokens;
+
+    Ok(config)
+}
 
 #[derive(Clone, Debug)]
 struct AionrsFinalInputDumpContext {
@@ -157,7 +176,7 @@ impl AionrsAgentManager {
             api_key: Some(config_extra.api_key.clone()),
             base_url: config_extra.base_url.clone(),
             model: Some(config_extra.model.clone()),
-            max_tokens: config_extra.max_tokens,
+            max_tokens: None,
             max_turns: config_extra.max_turns,
             max_tool_call_malformed_turns: config_extra.max_tool_call_malformed_turns,
             max_tool_call_failure_turns: config_extra.max_tool_call_failure_turns,
@@ -169,8 +188,7 @@ impl AionrsAgentManager {
             project_dir: Some(PathBuf::from(&workspace)),
         };
 
-        let mut config =
-            Config::resolve(&cli_args).map_err(|e| AgentError::internal(format!("Config resolve failed: {e}")))?;
+        let mut config = resolve_aionui_config(&cli_args)?;
 
         // Backend-specific overrides
         config.bedrock = config_extra.bedrock_config;

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent_test.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent_test.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::env;
+use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -28,7 +29,7 @@ fn make_test_config() -> AionrsResolvedConfig {
         model: "claude-sonnet-4-20250514".into(),
         base_url: None,
         system_prompt: None,
-        max_tokens: Some(4096),
+        max_tokens: None,
         max_turns: None,
         max_tool_call_malformed_turns: None,
         max_tool_call_failure_turns: None,
@@ -41,6 +42,79 @@ fn make_test_config() -> AionrsResolvedConfig {
         runtime_env: Vec::new(),
         prompt_dump_dir: None,
     }
+}
+
+fn make_cli_args(project_dir: PathBuf, provider: &str, model: &str) -> CliArgs {
+    CliArgs {
+        provider: Some(provider.to_owned()),
+        api_key: Some("sk-test-key".to_owned()),
+        base_url: None,
+        model: Some(model.to_owned()),
+        max_tokens: None,
+        thinking: None,
+        thinking_budget: None,
+        max_turns: None,
+        max_tool_call_malformed_turns: None,
+        max_tool_call_failure_turns: None,
+        system_prompt: None,
+        profile: None,
+        auto_approve: false,
+        project_dir: Some(project_dir),
+    }
+}
+
+#[test]
+fn resolve_aionui_config_discards_standalone_max_token_settings() {
+    let project = tempfile::tempdir().unwrap();
+    fs::write(
+        project.path().join(".aionrs.toml"),
+        r#"
+[default]
+max_tokens = 1234
+
+[providers.openai.compat]
+default_max_tokens = 2345
+
+[[providers.openai.compat.model_max_tokens]]
+pattern = "gpt-test"
+max_tokens = 3456
+"#,
+    )
+    .unwrap();
+    let cli_args = make_cli_args(project.path().to_path_buf(), "openai", "gpt-test");
+
+    let standalone = Config::resolve(&cli_args).unwrap();
+    assert_eq!(standalone.max_tokens, Some(1234));
+    assert_eq!(standalone.compat.default_max_tokens_for_model("gpt-test"), Some(3456));
+
+    let embedded = resolve_aionui_config(&cli_args).unwrap();
+    assert_eq!(embedded.max_tokens, None);
+    assert_eq!(embedded.compat.default_max_tokens_for_model("gpt-test"), None);
+}
+
+#[test]
+fn resolve_aionui_config_keeps_builtin_provider_max_token_policy() {
+    let project = tempfile::tempdir().unwrap();
+    fs::write(
+        project.path().join(".aionrs.toml"),
+        r#"
+[providers.anthropic.compat]
+default_max_tokens = 42
+
+[[providers.anthropic.compat.model_max_tokens]]
+pattern = "claude-sonnet-4-6"
+max_tokens = 42
+"#,
+    )
+    .unwrap();
+    let cli_args = make_cli_args(project.path().to_path_buf(), "anthropic", "claude-sonnet-4-6");
+
+    let embedded = resolve_aionui_config(&cli_args).unwrap();
+    assert_eq!(embedded.max_tokens, None);
+    assert_eq!(
+        embedded.compat.default_max_tokens_for_model("claude-sonnet-4-6"),
+        Some(128_000)
+    );
 }
 
 #[test]

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -130,7 +130,8 @@ pub struct AionrsResolvedConfig {
     pub base_url: Option<String>,
     /// System prompt override.
     pub system_prompt: Option<String>,
-    /// Optional max tokens per response.
+    /// Internal response cap for specialized flows such as provider health probes.
+    /// Normal AionUi conversations leave this unset.
     pub max_tokens: Option<u32>,
     /// Max agentic turns.
     pub max_turns: Option<usize>,
@@ -375,7 +376,6 @@ mod tests {
         let extra: AionrsBuildExtra = serde_json::from_value(json).unwrap();
         assert!(extra.system_prompt.is_none());
         assert!(extra.preset_rules.is_none());
-        assert_eq!(extra.max_tokens, None);
         assert!(extra.max_turns.is_none());
         assert!(extra.max_tool_call_malformed_turns.is_none());
         assert!(extra.max_tool_call_failure_turns.is_none());
@@ -391,18 +391,17 @@ mod tests {
             "max_tool_call_failure_turns": 3
         });
         let extra: AionrsBuildExtra = serde_json::from_value(json).unwrap();
-        assert_eq!(extra.system_prompt.unwrap(), "You are a helpful assistant.");
-        assert_eq!(extra.max_tokens, Some(4096));
+        assert_eq!(extra.system_prompt.as_deref(), Some("You are a helpful assistant."));
         assert_eq!(extra.max_turns.unwrap(), 10);
         assert_eq!(extra.max_tool_call_malformed_turns.unwrap(), 2);
         assert_eq!(extra.max_tool_call_failure_turns.unwrap(), 3);
+        assert!(serde_json::to_value(extra).unwrap().get("max_tokens").is_none());
     }
 
     #[test]
     fn aionrs_build_extra_serde_with_preset_rules() {
         let json = json!({
-            "preset_rules": "You are a data analyst.",
-            "max_tokens": 8192
+            "preset_rules": "You are a data analyst."
         });
         let extra: AionrsBuildExtra = serde_json::from_value(json).unwrap();
         assert!(extra.system_prompt.is_none());

--- a/crates/aionui-ai-agent/tests/agent_types_integration.rs
+++ b/crates/aionui-ai-agent/tests/agent_types_integration.rs
@@ -95,7 +95,7 @@ fn make_aionrs_config() -> AionrsResolvedConfig {
         model: "claude-sonnet-4-20250514".into(),
         base_url: None,
         system_prompt: None,
-        max_tokens: Some(4096),
+        max_tokens: None,
         max_turns: None,
         max_tool_call_malformed_turns: None,
         max_tool_call_failure_turns: None,

--- a/crates/aionui-ai-agent/tests/factory_provider_integration.rs
+++ b/crates/aionui-ai-agent/tests/factory_provider_integration.rs
@@ -154,10 +154,7 @@ async fn aionrs_factory_resolves_provider_from_db() {
             model: "gpt-4o".into(),
             use_model: None,
         },
-        AionrsBuildExtra {
-            max_tokens: Some(2048),
-            ..Default::default()
-        },
+        AionrsBuildExtra::default(),
     );
 
     let result = factory(options).await;

--- a/crates/aionui-api-types/src/agent_build_extra.rs
+++ b/crates/aionui-api-types/src/agent_build_extra.rs
@@ -85,8 +85,6 @@ pub struct AionrsBuildExtra {
     #[serde(default)]
     pub skills: Vec<String>,
     #[serde(default)]
-    pub max_tokens: Option<u32>,
-    #[serde(default)]
     pub max_turns: Option<usize>,
     #[serde(default)]
     pub max_tool_call_malformed_turns: Option<usize>,
@@ -169,10 +167,11 @@ mod tests {
     }
 
     #[test]
-    fn aionrs_build_extra_ignores_legacy_guide_config_field() {
+    fn aionrs_build_extra_ignores_legacy_fields() {
         let legacy_key = concat!("guide", "_mcp_config");
         let parsed: AionrsBuildExtra = serde_json::from_value(serde_json::json!({
             "backend": "aionrs",
+            "max_tokens": 8192,
             legacy_key: {"port": 1234, "token": "legacy", "binary_path": "/bin/aioncore"}
         }))
         .unwrap();
@@ -182,6 +181,10 @@ mod tests {
         assert!(
             serialized.get(legacy_key).is_none(),
             "legacy guide config must be ignored, not re-serialized"
+        );
+        assert!(
+            serialized.get("max_tokens").is_none(),
+            "legacy max_tokens must be ignored, not re-serialized"
         );
     }
 }


### PR DESCRIPTION
## Why

AionUi intentionally no longer exposes a response `max_tokens` setting for normal conversations. However, the embedded aionrs SDK still calls `Config::resolve`, which also loads standalone aionrs configuration from global and workspace files.

As a result, an existing `max_tokens`, `default_max_tokens`, or `model_max_tokens` value in `.aionrs.toml` could silently cap an AionUi request even when AionUi omitted the field. This was especially confusing after upgrading from an older version because a stale standalone setting could continue to affect AionUi behavior.

AionUi should own the policy for its embedded runtime, while standalone aionrs should continue to honor its own configuration when run directly.

## Summary

- Remove `max_tokens` from `AionrsBuildExtra`; legacy values in conversation `extra` are ignored and are no longer serialized.
- Keep `max_tokens` unset when AionUi builds the normal embedded aionrs runtime.
- After aionrs resolves its configuration, discard max-token limits inherited from global or workspace standalone config files.
- Reset compatibility token settings to the selected provider's built-in aionrs defaults. This removes user-defined standalone overrides without losing the provider compatibility policy required for request shaping.
- Add regression coverage for legacy `extra` values, project config overrides, and preservation of built-in provider defaults.

## Non-goals

- Standalone aionrs configuration behavior is unchanged.
- Explicit internal caps used by specialized flows, such as provider health probes, are unchanged.

## Validation

- `just push -u origin jiahe/fix/aionui-ignore-max-tokens`
  - migration immutability check passed
  - full workspace Clippy passed
  - 6,838 tests passed; 18 skipped
- Verified with a local AionUi request.
