### PR TITLE
fix(system): apply keep-awake client preference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,6 +835,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "windows-sys 0.61.2",
  "wiremock",
 ]
 

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -359,7 +359,10 @@ pub fn build_system_state(services: &AppServices) -> SystemRouterState {
 
     SystemRouterState {
         settings_service: SettingsService::new(Arc::new(SqliteSettingsRepository::new(pool.clone()))),
-        client_pref_service: ClientPrefService::new(Arc::new(SqliteClientPreferenceRepository::new(pool.clone()))),
+        client_pref_service: ClientPrefService::with_keep_awake_controller(
+            Arc::new(SqliteClientPreferenceRepository::new(pool.clone())),
+            Arc::new(aionui_system::SystemKeepAwakeController::new()),
+        ),
         provider_service: ProviderService::new(provider_repo.clone(), encryption_key),
         model_fetch_service: ModelFetchService::new(provider_repo, encryption_key, http_client.clone()),
         protocol_detection_service: ProtocolDetectionService::new(http_client.clone()),

--- a/crates/aionui-system/Cargo.toml
+++ b/crates/aionui-system/Cargo.toml
@@ -23,6 +23,9 @@ aws-sdk-bedrock.workspace = true
 semver.workspace = true
 dirs.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_System_Power"] }
+
 [dev-dependencies]
 tower = { workspace = true }
 http-body-util.workspace = true

--- a/crates/aionui-system/src/client_pref.rs
+++ b/crates/aionui-system/src/client_pref.rs
@@ -3,9 +3,10 @@ use std::sync::Arc;
 
 use aionui_api_types::{ClientPreferencesResponse, UpdateClientPreferencesRequest};
 use aionui_db::IClientPreferenceRepository;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::error::SystemError;
+use crate::keep_awake::{DynKeepAwakeController, KEEP_AWAKE_KEY, NoopKeepAwakeController};
 
 /// Maximum allowed key length for client preferences.
 const MAX_KEY_LENGTH: usize = 255;
@@ -14,11 +15,27 @@ const MAX_KEY_LENGTH: usize = 255;
 #[derive(Clone)]
 pub struct ClientPrefService {
     repo: Arc<dyn IClientPreferenceRepository>,
+    keep_awake_controller: DynKeepAwakeController,
 }
 
 impl ClientPrefService {
     pub fn new(repo: Arc<dyn IClientPreferenceRepository>) -> Self {
-        Self { repo }
+        Self {
+            repo,
+            keep_awake_controller: Arc::new(NoopKeepAwakeController),
+        }
+    }
+
+    pub fn with_keep_awake_controller(
+        repo: Arc<dyn IClientPreferenceRepository>,
+        keep_awake_controller: DynKeepAwakeController,
+    ) -> Self {
+        let service = Self {
+            repo,
+            keep_awake_controller,
+        };
+        service.restore_keep_awake_from_preferences();
+        service
     }
 
     /// Get all client preferences, or only the specified keys.
@@ -62,6 +79,7 @@ impl ClientPrefService {
     pub async fn update_preferences(&self, req: UpdateClientPreferencesRequest) -> Result<(), SystemError> {
         let mut upserts: Vec<(String, String)> = Vec::new();
         let mut deletes: Vec<String> = Vec::new();
+        let keep_awake_update = resolve_keep_awake_update(&req)?;
 
         for (key, value) in req {
             validate_key(&key)?;
@@ -91,23 +109,95 @@ impl ClientPrefService {
             }
         }
 
+        let previous_keep_awake = if keep_awake_update.is_some() {
+            Some(self.get_stored_keep_awake().await?)
+        } else {
+            None
+        };
+
+        if let Some(enabled) = keep_awake_update {
+            self.apply_keep_awake(enabled).await?;
+        }
+
         if !upserts.is_empty() {
             let entries: Vec<(&str, &str)> = upserts.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
-            self.repo
+            if let Err(error) = self
+                .repo
                 .upsert_batch(&entries)
                 .await
-                .map_err(|e| SystemError::Internal(format!("Failed to upsert preferences: {e}")))?;
+                .map_err(|e| SystemError::Internal(format!("Failed to upsert preferences: {e}")))
+            {
+                if let Some(previous) = previous_keep_awake {
+                    let _ = self.apply_keep_awake(previous).await;
+                }
+                return Err(error);
+            }
         }
 
         if !deletes.is_empty() {
             let keys: Vec<&str> = deletes.iter().map(|k| k.as_str()).collect();
-            self.repo
+            if let Err(error) = self
+                .repo
                 .delete_keys(&keys)
                 .await
-                .map_err(|e| SystemError::Internal(format!("Failed to delete preferences: {e}")))?;
+                .map_err(|e| SystemError::Internal(format!("Failed to delete preferences: {e}")))
+            {
+                if let Some(previous) = previous_keep_awake {
+                    let _ = self.apply_keep_awake(previous).await;
+                }
+                return Err(error);
+            }
         }
 
         Ok(())
+    }
+
+    async fn get_stored_keep_awake(&self) -> Result<bool, SystemError> {
+        let rows = self
+            .repo
+            .get_by_keys(&[KEEP_AWAKE_KEY])
+            .await
+            .map_err(|e| SystemError::Internal(format!("Failed to get keep-awake preference: {e}")))?;
+
+        if let Some(row) = rows.iter().find(|row| row.key == KEEP_AWAKE_KEY) {
+            let value: serde_json::Value =
+                serde_json::from_str(&row.value).unwrap_or(serde_json::Value::String(row.value.clone()));
+            match parse_keep_awake_value(&value) {
+                Ok(enabled) => return Ok(enabled),
+                Err(error) => {
+                    warn!(key = KEEP_AWAKE_KEY, error = %error, "Ignoring invalid stored keep-awake preference")
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    async fn apply_keep_awake(&self, enabled: bool) -> Result<(), SystemError> {
+        self.keep_awake_controller.set_enabled(enabled).await.map_err(|error| {
+            warn!(enabled, error = %error, "Failed to update system keep-awake assertion");
+            error
+        })?;
+        info!(enabled, "System keep-awake preference applied");
+        Ok(())
+    }
+
+    fn restore_keep_awake_from_preferences(&self) {
+        let service = self.clone();
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            warn!("Cannot restore system keep-awake preference without a Tokio runtime");
+            return;
+        };
+        handle.spawn(async move {
+            match service.get_stored_keep_awake().await {
+                Ok(true) => {
+                    if let Err(error) = service.apply_keep_awake(true).await {
+                        warn!(error = %error, "Failed to restore system keep-awake assertion");
+                    }
+                }
+                Ok(false) => {}
+                Err(error) => warn!(error = %error, "Failed to read system keep-awake preference for restore"),
+            }
+        });
     }
 }
 
@@ -134,10 +224,25 @@ fn validate_key(key: &str) -> Result<(), SystemError> {
     Ok(())
 }
 
+fn resolve_keep_awake_update(req: &UpdateClientPreferencesRequest) -> Result<Option<bool>, SystemError> {
+    req.get(KEEP_AWAKE_KEY).map(parse_keep_awake_value).transpose()
+}
+
+fn parse_keep_awake_value(value: &serde_json::Value) -> Result<bool, SystemError> {
+    match value {
+        serde_json::Value::Bool(enabled) => Ok(*enabled),
+        serde_json::Value::Null => Ok(false),
+        _ => Err(SystemError::BadRequest(format!(
+            "{KEEP_AWAKE_KEY} must be a boolean or null"
+        ))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use aionui_db::{SqliteClientPreferenceRepository, init_database_memory};
+    use async_trait::async_trait;
     use serde_json::json;
     use std::io::Write;
     use std::sync::{Mutex, Once, OnceLock};
@@ -188,6 +293,34 @@ mod tests {
         let repo = Arc::new(SqliteClientPreferenceRepository::new(db.pool().clone()));
         std::mem::forget(db);
         ClientPrefService::new(repo)
+    }
+
+    async fn setup_with_keep_awake_controller(controller: DynKeepAwakeController) -> ClientPrefService {
+        let db = init_database_memory().await.unwrap();
+        let repo = Arc::new(SqliteClientPreferenceRepository::new(db.pool().clone()));
+        std::mem::forget(db);
+        ClientPrefService {
+            repo,
+            keep_awake_controller: controller,
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingKeepAwakeController {
+        calls: Mutex<Vec<bool>>,
+        fail: bool,
+    }
+
+    #[async_trait]
+    impl crate::keep_awake::KeepAwakeController for RecordingKeepAwakeController {
+        async fn set_enabled(&self, enabled: bool) -> Result<(), SystemError> {
+            self.calls.lock().unwrap().push(enabled);
+            if self.fail {
+                Err(SystemError::Internal("keep-awake failed".into()))
+            } else {
+                Ok(())
+            }
+        }
     }
 
     #[test]
@@ -371,5 +504,90 @@ mod tests {
         assert_eq!(prefs.len(), 2);
         assert_eq!(prefs["keep"], json!(1));
         assert_eq!(prefs["new"], json!(3));
+    }
+
+    #[tokio::test]
+    async fn keep_awake_true_enables_controller_and_persists_value() {
+        let controller = Arc::new(RecordingKeepAwakeController::default());
+        let svc = setup_with_keep_awake_controller(controller.clone()).await;
+        let mut req = UpdateClientPreferencesRequest::new();
+        req.insert(KEEP_AWAKE_KEY.into(), json!(true));
+
+        svc.update_preferences(req).await.unwrap();
+
+        assert_eq!(*controller.calls.lock().unwrap(), vec![true]);
+        let prefs = svc.get_preferences(Some(&[KEEP_AWAKE_KEY])).await.unwrap();
+        assert_eq!(prefs[KEEP_AWAKE_KEY], json!(true));
+    }
+
+    #[tokio::test]
+    async fn keep_awake_null_disables_controller_and_deletes_value() {
+        let controller = Arc::new(RecordingKeepAwakeController::default());
+        let svc = setup_with_keep_awake_controller(controller.clone()).await;
+        let mut setup_req = UpdateClientPreferencesRequest::new();
+        setup_req.insert(KEEP_AWAKE_KEY.into(), json!(true));
+        svc.update_preferences(setup_req).await.unwrap();
+
+        let mut req = UpdateClientPreferencesRequest::new();
+        req.insert(KEEP_AWAKE_KEY.into(), json!(null));
+        svc.update_preferences(req).await.unwrap();
+
+        assert_eq!(*controller.calls.lock().unwrap(), vec![true, false]);
+        let prefs = svc.get_preferences(Some(&[KEEP_AWAKE_KEY])).await.unwrap();
+        assert!(!prefs.contains_key(KEEP_AWAKE_KEY));
+    }
+
+    #[tokio::test]
+    async fn keep_awake_rejects_non_boolean_values() {
+        let controller = Arc::new(RecordingKeepAwakeController::default());
+        let svc = setup_with_keep_awake_controller(controller.clone()).await;
+        let mut req = UpdateClientPreferencesRequest::new();
+        req.insert(KEEP_AWAKE_KEY.into(), json!("yes"));
+
+        let err = svc.update_preferences(req).await.unwrap_err();
+
+        assert!(matches!(err, SystemError::BadRequest(_)));
+        assert!(controller.calls.lock().unwrap().is_empty());
+        let prefs = svc.get_preferences(Some(&[KEEP_AWAKE_KEY])).await.unwrap();
+        assert!(!prefs.contains_key(KEEP_AWAKE_KEY));
+    }
+
+    #[tokio::test]
+    async fn keep_awake_controller_failure_does_not_persist_value() {
+        let controller = Arc::new(RecordingKeepAwakeController {
+            fail: true,
+            ..Default::default()
+        });
+        let svc = setup_with_keep_awake_controller(controller.clone()).await;
+        let mut req = UpdateClientPreferencesRequest::new();
+        req.insert(KEEP_AWAKE_KEY.into(), json!(true));
+
+        let err = svc.update_preferences(req).await.unwrap_err();
+
+        assert!(matches!(err, SystemError::Internal(_)));
+        assert_eq!(*controller.calls.lock().unwrap(), vec![true]);
+        let prefs = svc.get_preferences(Some(&[KEEP_AWAKE_KEY])).await.unwrap();
+        assert!(!prefs.contains_key(KEEP_AWAKE_KEY));
+    }
+
+    #[tokio::test]
+    async fn keep_awake_restore_applies_persisted_value() {
+        let initial = setup().await;
+        let mut req = UpdateClientPreferencesRequest::new();
+        req.insert(KEEP_AWAKE_KEY.into(), json!(true));
+        initial.update_preferences(req).await.unwrap();
+
+        let controller = Arc::new(RecordingKeepAwakeController::default());
+        let service = ClientPrefService::with_keep_awake_controller(initial.repo.clone(), controller.clone());
+
+        for _ in 0..50 {
+            if !controller.calls.lock().unwrap().is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        assert_eq!(*controller.calls.lock().unwrap(), vec![true]);
+        drop(service);
     }
 }

--- a/crates/aionui-system/src/keep_awake.rs
+++ b/crates/aionui-system/src/keep_awake.rs
@@ -1,0 +1,142 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+#[cfg(any(target_os = "macos", target_os = "linux", windows))]
+use tokio::sync::Mutex;
+use tracing::info;
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+use std::process::Stdio;
+
+use crate::error::SystemError;
+
+pub const KEEP_AWAKE_KEY: &str = "keepAwake";
+
+#[async_trait]
+pub trait KeepAwakeController: Send + Sync {
+    async fn set_enabled(&self, enabled: bool) -> Result<(), SystemError>;
+}
+
+pub type DynKeepAwakeController = Arc<dyn KeepAwakeController>;
+
+#[derive(Debug, Default)]
+pub struct NoopKeepAwakeController;
+
+#[async_trait]
+impl KeepAwakeController for NoopKeepAwakeController {
+    async fn set_enabled(&self, _enabled: bool) -> Result<(), SystemError> {
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+pub struct SystemKeepAwakeController {
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    child: Mutex<Option<tokio::process::Child>>,
+    #[cfg(windows)]
+    enabled: Mutex<bool>,
+}
+
+impl SystemKeepAwakeController {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl KeepAwakeController for SystemKeepAwakeController {
+    async fn set_enabled(&self, enabled: bool) -> Result<(), SystemError> {
+        set_system_keep_awake(self, enabled).await
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+async fn set_system_keep_awake(controller: &SystemKeepAwakeController, enabled: bool) -> Result<(), SystemError> {
+    let mut child = controller.child.lock().await;
+    if !enabled {
+        if let Some(mut existing) = child.take() {
+            let _ = existing.kill().await;
+            let _ = existing.wait().await;
+            info!("System keep-awake assertion released");
+        }
+        return Ok(());
+    }
+
+    if child.is_some() {
+        return Ok(());
+    }
+
+    let spawned = spawn_keep_awake_process()?;
+    *child = Some(spawned);
+    info!("System keep-awake assertion acquired");
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn spawn_keep_awake_process() -> Result<tokio::process::Child, SystemError> {
+    let mut command = aionui_runtime::Builder::clean_cli("caffeinate");
+    command.args(["-dis"]).stdout(Stdio::null()).stderr(Stdio::null());
+    command
+        .spawn()
+        .map_err(|e| SystemError::Internal(format!("Failed to start macOS keep-awake assertion: {e}")))
+}
+
+#[cfg(target_os = "linux")]
+fn spawn_keep_awake_process() -> Result<tokio::process::Child, SystemError> {
+    let mut command = aionui_runtime::Builder::clean_cli("systemd-inhibit");
+    command
+        .args([
+            "--what=sleep",
+            "--why=AionUi scheduled tasks keep-awake is enabled",
+            "--mode=block",
+            "sleep",
+            "infinity",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    command
+        .spawn()
+        .map_err(|e| SystemError::Internal(format!("Failed to start Linux keep-awake assertion: {e}")))
+}
+
+#[cfg(windows)]
+async fn set_system_keep_awake(controller: &SystemKeepAwakeController, enabled: bool) -> Result<(), SystemError> {
+    use windows_sys::Win32::System::Power::{
+        ES_CONTINUOUS, ES_DISPLAY_REQUIRED, ES_SYSTEM_REQUIRED, SetThreadExecutionState,
+    };
+
+    let mut current = controller.enabled.lock().await;
+    if *current == enabled {
+        return Ok(());
+    }
+
+    let flags = if enabled {
+        ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED
+    } else {
+        ES_CONTINUOUS
+    };
+    let result = unsafe { SetThreadExecutionState(flags) };
+    if result == 0 {
+        return Err(SystemError::Internal(
+            "Failed to update Windows keep-awake assertion".into(),
+        ));
+    }
+
+    *current = enabled;
+    if enabled {
+        info!("System keep-awake assertion acquired");
+    } else {
+        info!("System keep-awake assertion released");
+    }
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+async fn set_system_keep_awake(_controller: &SystemKeepAwakeController, enabled: bool) -> Result<(), SystemError> {
+    if enabled {
+        return Err(SystemError::Internal(
+            "System keep-awake is not supported on this platform".into(),
+        ));
+    }
+    Ok(())
+}

--- a/crates/aionui-system/src/lib.rs
+++ b/crates/aionui-system/src/lib.rs
@@ -5,6 +5,7 @@ pub mod bedrock_probe;
 pub mod client_pref;
 pub mod diagnostics;
 pub mod error;
+pub mod keep_awake;
 pub mod model_fetcher;
 pub mod protocol;
 pub mod provider;
@@ -18,6 +19,7 @@ pub use bedrock_probe::{ConnectionTestRouterState, ConnectionTestService, connec
 pub use client_pref::ClientPrefService;
 pub use diagnostics::FeedbackDiagnosticsService;
 pub use error::SystemError;
+pub use keep_awake::{KeepAwakeController, NoopKeepAwakeController, SystemKeepAwakeController};
 pub use model_fetcher::ModelFetchService;
 pub use protocol::ProtocolDetectionService;
 pub use provider::ProviderService;


### PR DESCRIPTION
## Summary

- add a keep-awake controller abstraction to `aionui-system`
- apply and restore OS keep-awake assertions when the `keepAwake` client preference is updated
- intentionally do not accept or migrate `system.keepAwake`; users may need to toggle the setting off/on once after upgrade
- inject the system controller into app state and keep tests on mock/no-op controllers

## Companion PR

AionUi PR: https://github.com/iOfficeAI/AionUi/pull/3620

The AionUi PR removes the desktop main-process power blocker so AionCore is the only owner of the keep-awake OS assertion.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p aionui-system`
- `cargo clippy -p aionui-system -p aionui-app -- -D warnings`
- `cargo nextest run -p aionui-app`

Note: full `just push` was intentionally not re-run to completion after the package-level nextest verification, because it forces `nextest run --workspace` and would duplicate the already completed test run.
