### PR TITLE
feat(idle): extend idle-cleanup timeouts and make them env-configurable

### DIFF
--- a/crates/aionui-ai-agent/src/idle_scanner.rs
+++ b/crates/aionui-ai-agent/src/idle_scanner.rs
@@ -3,15 +3,25 @@ use std::time::Duration;
 
 use aionui_common::{AgentKillReason, now_ms};
 use async_trait::async_trait;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::task_manager::IWorkerTaskManager;
 
-/// Default idle timeout for ACP agents (5 minutes).
-const DEFAULT_IDLE_TIMEOUT_SECS: i64 = 5 * 60;
+/// Default idle timeout for solo (single-chat) ACP agents (10 minutes).
+const DEFAULT_SOLO_IDLE_TIMEOUT_SECS: i64 = 10 * 60;
 
-/// Scan interval for idle agent cleanup (1 minute).
-const SCAN_INTERVAL_SECS: u64 = 60;
+/// Default idle timeout for team sessions (30 minutes).
+const DEFAULT_TEAM_IDLE_TIMEOUT_SECS: i64 = 30 * 60;
+
+/// Default scan interval for idle agent cleanup (1 minute).
+const DEFAULT_SCAN_INTERVAL_SECS: u64 = 60;
+
+/// Environment variable overriding the solo (single-chat) idle timeout, in seconds.
+const ENV_SOLO_IDLE_TIMEOUT_SECS: &str = "AIONUI_IDLE_TIMEOUT_SECS";
+/// Environment variable overriding the team idle timeout, in seconds.
+const ENV_TEAM_IDLE_TIMEOUT_SECS: &str = "AIONUI_TEAM_IDLE_TIMEOUT_SECS";
+/// Environment variable overriding the idle scan interval, in seconds.
+const ENV_IDLE_SCAN_INTERVAL_SECS: &str = "AIONUI_IDLE_SCAN_INTERVAL_SECS";
 
 #[async_trait]
 pub trait IdleCleanupCoordinator: Send + Sync {
@@ -50,8 +60,8 @@ pub fn start_idle_scanner_with_coordinator(
     scan_interval_secs: Option<u64>,
     idle_cleanup_coordinator: Option<Arc<dyn IdleCleanupCoordinator>>,
 ) -> tokio::task::JoinHandle<()> {
-    let threshold = idle_timeout_secs.unwrap_or(DEFAULT_IDLE_TIMEOUT_SECS);
-    let scan_interval = scan_interval_secs.unwrap_or(SCAN_INTERVAL_SECS);
+    let threshold = idle_timeout_secs.unwrap_or(DEFAULT_SOLO_IDLE_TIMEOUT_SECS);
+    let scan_interval = scan_interval_secs.unwrap_or(DEFAULT_SCAN_INTERVAL_SECS);
     info!(
         threshold_secs = threshold,
         scan_interval_secs = scan_interval,
@@ -141,6 +151,60 @@ async fn scan_and_cleanup(
         elapsed_ms = now_ms().saturating_sub(started_at),
         "Idle scan: cleanup completed"
     );
+}
+
+/// Parse a positive `i64` seconds value, falling back to `default` on
+/// missing/invalid input (non-numeric, empty, or `<= 0`).
+fn parse_positive_i64(raw: Option<String>, var: &str, default: i64) -> i64 {
+    match raw {
+        None => default,
+        Some(value) => match value.trim().parse::<i64>() {
+            Ok(parsed) if parsed > 0 => parsed,
+            _ => {
+                warn!(env_var = var, value = %value, default, "invalid idle-cleanup env value; using default");
+                default
+            }
+        },
+    }
+}
+
+/// Parse a positive `u64` seconds value, falling back to `default` on
+/// missing/invalid input (non-numeric, empty, or `== 0`).
+fn parse_positive_u64(raw: Option<String>, var: &str, default: u64) -> u64 {
+    match raw {
+        None => default,
+        Some(value) => match value.trim().parse::<u64>() {
+            Ok(parsed) if parsed > 0 => parsed,
+            _ => {
+                warn!(env_var = var, value = %value, default, "invalid idle-cleanup env value; using default");
+                default
+            }
+        },
+    }
+}
+
+/// Resolve idle-cleanup config from raw env values. Pure — takes the raw
+/// `Option<String>` values and does not read the environment, so it is unit
+/// testable. Returns `(solo_timeout_secs, team_timeout_secs, scan_interval_secs)`.
+fn resolve_idle_config(
+    solo_raw: Option<String>,
+    team_raw: Option<String>,
+    scan_raw: Option<String>,
+) -> (i64, i64, u64) {
+    let solo = parse_positive_i64(solo_raw, ENV_SOLO_IDLE_TIMEOUT_SECS, DEFAULT_SOLO_IDLE_TIMEOUT_SECS);
+    let team = parse_positive_i64(team_raw, ENV_TEAM_IDLE_TIMEOUT_SECS, DEFAULT_TEAM_IDLE_TIMEOUT_SECS);
+    let scan = parse_positive_u64(scan_raw, ENV_IDLE_SCAN_INTERVAL_SECS, DEFAULT_SCAN_INTERVAL_SECS);
+    (solo, team, scan)
+}
+
+/// Read the idle-cleanup env vars and resolve the effective config.
+/// Returns `(solo_timeout_secs, team_timeout_secs, scan_interval_secs)`.
+pub fn resolve_idle_config_from_env() -> (i64, i64, u64) {
+    resolve_idle_config(
+        std::env::var(ENV_SOLO_IDLE_TIMEOUT_SECS).ok(),
+        std::env::var(ENV_TEAM_IDLE_TIMEOUT_SECS).ok(),
+        std::env::var(ENV_IDLE_SCAN_INTERVAL_SECS).ok(),
+    )
 }
 
 #[cfg(test)]
@@ -239,5 +303,41 @@ mod tests {
 
         assert_eq!(seen.lock().unwrap().clone(), vec!["team-lead", "solo"]);
         assert_eq!(manager_impl.killed(), vec!["solo"]);
+    }
+
+    #[test]
+    fn resolve_idle_config_defaults_when_absent() {
+        let (solo, team, scan) = resolve_idle_config(None, None, None);
+        assert_eq!(solo, 600);
+        assert_eq!(team, 1800);
+        assert_eq!(scan, 60);
+    }
+
+    #[test]
+    fn resolve_idle_config_parses_valid_values() {
+        let (solo, team, scan) = resolve_idle_config(
+            Some("300".to_string()),
+            Some("300".to_string()),
+            Some("10".to_string()),
+        );
+        assert_eq!(solo, 300);
+        assert_eq!(team, 300);
+        assert_eq!(scan, 10);
+    }
+
+    #[test]
+    fn resolve_idle_config_falls_back_on_invalid_values() {
+        // negative, zero, non-numeric, empty -> defaults
+        let (solo, team, scan) = resolve_idle_config(
+            Some("-5".to_string()),
+            Some("0".to_string()),
+            Some("abc".to_string()),
+        );
+        assert_eq!(solo, 600);
+        assert_eq!(team, 1800);
+        assert_eq!(scan, 60);
+
+        let (solo2, _, _) = resolve_idle_config(Some("".to_string()), None, None);
+        assert_eq!(solo2, 600);
     }
 }

--- a/crates/aionui-ai-agent/src/idle_scanner.rs
+++ b/crates/aionui-ai-agent/src/idle_scanner.rs
@@ -116,7 +116,9 @@ async fn scan_and_cleanup(
 
     if let Some(coordinator) = idle_cleanup_coordinator {
         let before_count = idle_ids.len();
-        idle_ids = coordinator.cleanup_idle_conversations(idle_ids, team_threshold_ms).await;
+        idle_ids = coordinator
+            .cleanup_idle_conversations(idle_ids, team_threshold_ms)
+            .await;
         let handled_count = before_count.saturating_sub(idle_ids.len());
         if handled_count > 0 {
             info!(
@@ -350,11 +352,8 @@ mod tests {
 
     #[test]
     fn resolve_idle_config_parses_valid_values() {
-        let (solo, team, scan) = resolve_idle_config(
-            Some("300".to_string()),
-            Some("300".to_string()),
-            Some("10".to_string()),
-        );
+        let (solo, team, scan) =
+            resolve_idle_config(Some("300".to_string()), Some("300".to_string()), Some("10".to_string()));
         assert_eq!(solo, 300);
         assert_eq!(team, 300);
         assert_eq!(scan, 10);
@@ -363,11 +362,8 @@ mod tests {
     #[test]
     fn resolve_idle_config_falls_back_on_invalid_values() {
         // negative, zero, non-numeric, empty -> defaults
-        let (solo, team, scan) = resolve_idle_config(
-            Some("-5".to_string()),
-            Some("0".to_string()),
-            Some("abc".to_string()),
-        );
+        let (solo, team, scan) =
+            resolve_idle_config(Some("-5".to_string()), Some("0".to_string()), Some("abc".to_string()));
         assert_eq!(solo, 600);
         assert_eq!(team, 1800);
         assert_eq!(scan, 60);

--- a/crates/aionui-ai-agent/src/idle_scanner.rs
+++ b/crates/aionui-ai-agent/src/idle_scanner.rs
@@ -41,13 +41,15 @@ pub trait IdleCleanupCoordinator: Send + Sync {
 pub fn start_idle_scanner(
     worker_task_manager: Arc<dyn IWorkerTaskManager>,
     shutdown: tokio::sync::watch::Receiver<bool>,
-    idle_timeout_secs: Option<i64>,
+    solo_timeout_secs: Option<i64>,
+    team_timeout_secs: Option<i64>,
     scan_interval_secs: Option<u64>,
 ) -> tokio::task::JoinHandle<()> {
     start_idle_scanner_with_coordinator(
         worker_task_manager,
         shutdown,
-        idle_timeout_secs,
+        solo_timeout_secs,
+        team_timeout_secs,
         scan_interval_secs,
         None,
     )
@@ -56,14 +58,17 @@ pub fn start_idle_scanner(
 pub fn start_idle_scanner_with_coordinator(
     worker_task_manager: Arc<dyn IWorkerTaskManager>,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
-    idle_timeout_secs: Option<i64>,
+    solo_timeout_secs: Option<i64>,
+    team_timeout_secs: Option<i64>,
     scan_interval_secs: Option<u64>,
     idle_cleanup_coordinator: Option<Arc<dyn IdleCleanupCoordinator>>,
 ) -> tokio::task::JoinHandle<()> {
-    let threshold = idle_timeout_secs.unwrap_or(DEFAULT_SOLO_IDLE_TIMEOUT_SECS);
+    let solo_threshold = solo_timeout_secs.unwrap_or(DEFAULT_SOLO_IDLE_TIMEOUT_SECS);
+    let team_threshold = team_timeout_secs.unwrap_or(DEFAULT_TEAM_IDLE_TIMEOUT_SECS);
     let scan_interval = scan_interval_secs.unwrap_or(DEFAULT_SCAN_INTERVAL_SECS);
     info!(
-        threshold_secs = threshold,
+        solo_timeout_secs = solo_threshold,
+        team_timeout_secs = team_threshold,
         scan_interval_secs = scan_interval,
         "Starting idle agent scanner"
     );
@@ -76,7 +81,8 @@ pub fn start_idle_scanner_with_coordinator(
                 _ = interval.tick() => {
                     scan_and_cleanup(
                         &worker_task_manager,
-                        threshold*1000,
+                        solo_threshold * 1000,
+                        team_threshold * 1000,
                         idle_cleanup_coordinator.clone(),
                     ).await;
                 }
@@ -96,11 +102,12 @@ pub fn start_idle_scanner_with_coordinator(
 /// Perform one scan: find idle tasks and kill them.
 async fn scan_and_cleanup(
     manager: &Arc<dyn IWorkerTaskManager>,
-    threshold_ms: i64,
+    solo_threshold_ms: i64,
+    team_threshold_ms: i64,
     idle_cleanup_coordinator: Option<Arc<dyn IdleCleanupCoordinator>>,
 ) {
     let started_at = now_ms();
-    let mut idle_ids = manager.collect_idle(threshold_ms);
+    let mut idle_ids = manager.collect_idle(solo_threshold_ms);
 
     if idle_ids.is_empty() {
         debug!(active_count = manager.active_count(), "Idle scan: no idle agents found");
@@ -109,7 +116,7 @@ async fn scan_and_cleanup(
 
     if let Some(coordinator) = idle_cleanup_coordinator {
         let before_count = idle_ids.len();
-        idle_ids = coordinator.cleanup_idle_conversations(idle_ids, threshold_ms).await;
+        idle_ids = coordinator.cleanup_idle_conversations(idle_ids, team_threshold_ms).await;
         let handled_count = before_count.saturating_sub(idle_ids.len());
         if handled_count > 0 {
             info!(
@@ -222,6 +229,7 @@ mod tests {
     struct RecordingTaskManager {
         idle_ids: Vec<String>,
         killed: Arc<Mutex<Vec<String>>>,
+        collect_threshold: Arc<Mutex<Option<i64>>>,
     }
 
     impl RecordingTaskManager {
@@ -229,11 +237,16 @@ mod tests {
             Self {
                 idle_ids: idle_ids.into_iter().map(str::to_owned).collect(),
                 killed: Arc::new(Mutex::new(Vec::new())),
+                collect_threshold: Arc::new(Mutex::new(None)),
             }
         }
 
         fn killed(&self) -> Vec<String> {
             self.killed.lock().unwrap().clone()
+        }
+
+        fn collect_threshold(&self) -> Option<i64> {
+            *self.collect_threshold.lock().unwrap()
         }
     }
 
@@ -271,13 +284,15 @@ mod tests {
             self.idle_ids.len()
         }
 
-        fn collect_idle(&self, _idle_threshold_ms: i64) -> Vec<String> {
+        fn collect_idle(&self, idle_threshold_ms: i64) -> Vec<String> {
+            *self.collect_threshold.lock().unwrap() = Some(idle_threshold_ms);
             self.idle_ids.clone()
         }
     }
 
     struct RecordingCoordinator {
         seen: Arc<Mutex<Vec<String>>>,
+        threshold: Arc<Mutex<Option<i64>>>,
     }
 
     #[async_trait]
@@ -285,8 +300,9 @@ mod tests {
         async fn cleanup_idle_conversations(
             &self,
             idle_conversation_ids: Vec<String>,
-            _idle_threshold_ms: i64,
+            idle_threshold_ms: i64,
         ) -> Vec<String> {
+            *self.threshold.lock().unwrap() = Some(idle_threshold_ms);
             self.seen.lock().unwrap().extend(idle_conversation_ids);
             vec!["solo".to_owned()]
         }
@@ -297,12 +313,31 @@ mod tests {
         let manager_impl = Arc::new(RecordingTaskManager::new(vec!["team-lead", "solo"]));
         let manager: Arc<dyn IWorkerTaskManager> = manager_impl.clone();
         let seen = Arc::new(Mutex::new(Vec::new()));
-        let coordinator: Arc<dyn IdleCleanupCoordinator> = Arc::new(RecordingCoordinator { seen: seen.clone() });
+        let coordinator: Arc<dyn IdleCleanupCoordinator> = Arc::new(RecordingCoordinator {
+            seen: seen.clone(),
+            threshold: Arc::new(Mutex::new(None)),
+        });
 
-        scan_and_cleanup(&manager, 300_000, Some(coordinator)).await;
+        scan_and_cleanup(&manager, 600_000, 1_800_000, Some(coordinator)).await;
 
         assert_eq!(seen.lock().unwrap().clone(), vec!["team-lead", "solo"]);
         assert_eq!(manager_impl.killed(), vec!["solo"]);
+    }
+
+    #[tokio::test]
+    async fn scan_passes_solo_to_collect_and_team_to_coordinator() {
+        let manager_impl = Arc::new(RecordingTaskManager::new(vec!["team-lead", "solo"]));
+        let manager: Arc<dyn IWorkerTaskManager> = manager_impl.clone();
+        let coordinator_impl = Arc::new(RecordingCoordinator {
+            seen: Arc::new(Mutex::new(Vec::new())),
+            threshold: Arc::new(Mutex::new(None)),
+        });
+        let coordinator: Arc<dyn IdleCleanupCoordinator> = coordinator_impl.clone();
+
+        scan_and_cleanup(&manager, 600_000, 1_800_000, Some(coordinator)).await;
+
+        assert_eq!(manager_impl.collect_threshold(), Some(600_000));
+        assert_eq!(*coordinator_impl.threshold.lock().unwrap(), Some(1_800_000));
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -38,8 +38,7 @@ pub use capability::skill_manager::{
 pub use error::AgentError;
 pub use factory::{AgentFactoryDeps, build_agent_factory};
 pub use idle_scanner::{
-    IdleCleanupCoordinator, resolve_idle_config_from_env, start_idle_scanner,
-    start_idle_scanner_with_coordinator,
+    IdleCleanupCoordinator, resolve_idle_config_from_env, start_idle_scanner, start_idle_scanner_with_coordinator,
 };
 pub use persistence::AcpSessionSyncService;
 pub use protocol::error::AcpError;

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -37,7 +37,10 @@ pub use capability::skill_manager::{
 };
 pub use error::AgentError;
 pub use factory::{AgentFactoryDeps, build_agent_factory};
-pub use idle_scanner::{IdleCleanupCoordinator, start_idle_scanner, start_idle_scanner_with_coordinator};
+pub use idle_scanner::{
+    IdleCleanupCoordinator, resolve_idle_config_from_env, start_idle_scanner,
+    start_idle_scanner_with_coordinator,
+};
 pub use persistence::AcpSessionSyncService;
 pub use protocol::error::AcpError;
 pub use protocol::events::AgentStreamEvent;

--- a/crates/aionui-app/src/commands/cmd_server.rs
+++ b/crates/aionui-app/src/commands/cmd_server.rs
@@ -282,8 +282,7 @@ pub(crate) async fn run_server(
             router_runtime.team_service.clone(),
             services.active_lease_registry.clone(),
         ));
-    let (solo_timeout_secs, team_timeout_secs, scan_interval_secs) =
-        aionui_ai_agent::resolve_idle_config_from_env();
+    let (solo_timeout_secs, team_timeout_secs, scan_interval_secs) = aionui_ai_agent::resolve_idle_config_from_env();
     let idle_scanner_handle = aionui_ai_agent::start_idle_scanner_with_coordinator(
         services.worker_task_manager.clone(),
         shutdown_rx,

--- a/crates/aionui-app/src/commands/cmd_server.rs
+++ b/crates/aionui-app/src/commands/cmd_server.rs
@@ -267,10 +267,14 @@ pub(crate) async fn run_server(
     });
 
     // Kick off the idle-ACP-agent reaper. `start_idle_scanner` returns
-    // immediately with a `JoinHandle`; the scanner task polls every 60 s
-    // and kills ACP agents whose `status == Finished` + last_activity
-    // exceeds the default 5-minute idle threshold. The watch channel
-    // propagates graceful-shutdown so the scanner exits on SIGINT/SIGTERM.
+    // immediately with a `JoinHandle`; the scanner task polls on the scan
+    // interval and kills ACP agents idle beyond their timeout — solo
+    // (single-chat) agents at the solo threshold, team sessions cleaned as a
+    // whole at the team threshold. Thresholds and scan interval default to
+    // 10 min / 30 min / 60 s and are overridable via AIONUI_IDLE_TIMEOUT_SECS,
+    // AIONUI_TEAM_IDLE_TIMEOUT_SECS, and AIONUI_IDLE_SCAN_INTERVAL_SECS. The
+    // watch channel propagates graceful-shutdown so the scanner exits on
+    // SIGINT/SIGTERM.
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     let (shutdown_error_tx, shutdown_error_rx) = tokio::sync::oneshot::channel::<BootstrapError>();
     let idle_cleanup_coordinator: Arc<dyn aionui_ai_agent::IdleCleanupCoordinator> =
@@ -278,11 +282,14 @@ pub(crate) async fn run_server(
             router_runtime.team_service.clone(),
             services.active_lease_registry.clone(),
         ));
+    let (solo_timeout_secs, team_timeout_secs, scan_interval_secs) =
+        aionui_ai_agent::resolve_idle_config_from_env();
     let idle_scanner_handle = aionui_ai_agent::start_idle_scanner_with_coordinator(
         services.worker_task_manager.clone(),
         shutdown_rx,
-        None,
-        None,
+        Some(solo_timeout_secs),
+        Some(team_timeout_secs),
+        Some(scan_interval_secs),
         Some(idle_cleanup_coordinator),
     );
     let conversation_runtime_state = services.conversation_runtime_state.clone();


### PR DESCRIPTION
## Summary

Splits the single 5-minute idle-cleanup threshold into separate solo (single-chat) and team timeouts, and makes all timing knobs overridable via environment variables. This gives longer, mode-appropriate grace periods in production while letting developers dial the timeouts back down for easier debugging.

| | Before | After (default) | Env override |
|---|---|---|---|
| Solo (single-chat) idle timeout | 5 min | **10 min** | `AIONUI_IDLE_TIMEOUT_SECS` |
| Team idle timeout | 5 min | **30 min** | `AIONUI_TEAM_IDLE_TIMEOUT_SECS` |
| Scan interval | 60 s | 60 s | `AIONUI_IDLE_SCAN_INTERVAL_SECS` |

Debugging tip — restore the old 5-minute behaviour:
```
export AIONUI_IDLE_TIMEOUT_SECS=300 AIONUI_TEAM_IDLE_TIMEOUT_SECS=300
```

## Behaviour

- The scanner collects idle candidates using the **solo** threshold; the team coordinator re-gates team sessions with the **team** threshold. Because `solo (10m) <= team (30m)`, team members surfaced between 10–30 min are re-checked and kept alive (recorded as handled, never mis-killed via the solo path), then cleaned as a whole once the team threshold is reached.
- Missing or invalid env values (non-numeric, empty, `<= 0`) fall back to the defaults and emit a `warn`.
- Startup `info` log now reports the three effective values (`solo_timeout_secs`, `team_timeout_secs`, `scan_interval_secs`) for production diagnosability.

## Changes

- `aionui-ai-agent/src/idle_scanner.rs`: split `DEFAULT_IDLE_TIMEOUT_SECS` into solo/team constants; rename `SCAN_INTERVAL_SECS` -> `DEFAULT_SCAN_INTERVAL_SECS`; add pure `resolve_idle_config` + `resolve_idle_config_from_env`; `scan_and_cleanup` and `start_idle_scanner*` take separate solo/team thresholds.
- `aionui-ai-agent/src/lib.rs`: export `resolve_idle_config_from_env`.
- `aionui-app/src/commands/cmd_server.rs`: resolve env config at startup and pass the thresholds into the scanner.

## Test plan

- [x] `cargo test -p aionui-ai-agent -p aionui-app` — pass
- [x] `just push` full gate — `cargo fmt`, `clippy --workspace -D warnings`, workspace `nextest` (6840 passed)
- [x] Unit tests for `resolve_idle_config`: defaults when absent, parses valid values, falls back on invalid values
- [x] Scanner tests assert the solo threshold reaches `collect_idle` and the team threshold reaches the coordinator
- [x] Verified in the dev environment via logs: solo conversation cleaned at ~10 min, team session cleaned as a whole at ~30 min, scan interval steady at 60 s