### PR TITLE
fix(ai-agent): enable official kimi k2.7 code image input

### DIFF
--- a/crates/aionui-ai-agent/assets/model-capabilities/image_input_models.json
+++ b/crates/aionui-ai-agent/assets/model-capabilities/image_input_models.json
@@ -466,6 +466,7 @@
     "moonshot-cn": {
       "api": "https://api.moonshot.cn/v1",
       "models": [
+        "kimi-k2.7-code",
         "kimi-k2.6",
         "kimi-k2.5",
         "moonshot-v1-8k-vision-preview",
@@ -476,6 +477,7 @@
     "moonshot-global": {
       "api": "https://api.moonshot.ai/v1",
       "models": [
+        "kimi-k2.7-code",
         "kimi-k2.6",
         "kimi-k2.5",
         "moonshot-v1-8k-vision-preview",

--- a/crates/aionui-ai-agent/src/capability/image_input_test.rs
+++ b/crates/aionui-ai-agent/src/capability/image_input_test.rs
@@ -80,6 +80,16 @@ fn embedded_allowlist_resolves_regression_models_without_network() {
 }
 
 #[test]
+fn embedded_allowlist_resolves_official_kimi_k2_7_code() {
+    for base_url in ["https://api.moonshot.cn/v1", "https://api.moonshot.ai/v1"] {
+        assert_eq!(
+            resolve_image_input_capability("openai", Some(base_url), "kimi-k2.7-code"),
+            ImageInputCapability::Supported
+        );
+    }
+}
+
+#[test]
 fn resolves_supported_and_unlisted_models_on_the_same_provider() {
     let catalog = catalog();
 


### PR DESCRIPTION
## Why

AionCore's static image-input catalog omitted `kimi-k2.7-code` for the official Moonshot API roots, so the embedded aionrs runtime resolved the model as `Unknown` and did not forward image attachments. Moonshot's official documentation lists Kimi K2.7 Code as supporting visual input through the OpenAI-compatible multimodal request format.

## Summary

- add `kimi-k2.7-code` to the official Moonshot China and global image-input allowlists
- add regression coverage for both `api.moonshot.cn` and `api.moonshot.ai`
- keep provider API root and exact model ID matching unchanged

## Non-goals

- this PR does not add the `kimi-k2.7-code-highspeed` variant

## Validation

- `jq empty crates/aionui-ai-agent/assets/model-capabilities/image_input_models.json`
- `cargo fmt --all -- --check`
- `cargo test -p aionui-ai-agent embedded_allowlist_resolves_official_kimi_k2_7_code`
- `cargo clippy -p aionui-ai-agent -- -D warnings`
- `cargo test -p aionui-ai-agent`
- `just push -u origin jiahe/fix/kimi-k2-7-code-image-input`
