### PR TITLE
feat(provider): add per-model capability settings

### DIFF
--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -4,8 +4,10 @@ use std::sync::Arc;
 use aion_agent::session::SessionManager;
 use aion_config::compat::OpenAiApiMode;
 use aion_config::config::{McpServerConfig, TransportType};
+use aion_types::message::ImageInputCapability;
 use aionui_api_types::{
-    AionrsBuildExtra, SessionMcpServer, SessionMcpTransport, TEAM_MCP_SERVER_NAME, TeamMcpStdioConfig,
+    AionrsBuildExtra, ModelImageInputCapability, ModelOpenAiApiMode, ModelSettings, SessionMcpServer,
+    SessionMcpTransport, TEAM_MCP_SERVER_NAME, TeamMcpStdioConfig,
 };
 use aionui_common::ProviderWithModel;
 use aionui_db::IMcpServerRepository;
@@ -95,18 +97,27 @@ pub(super) async fn build(
         .to_owned();
 
     let provider = map_aionrs_provider(&row.platform, &model_id, row.model_protocols.as_deref())?;
+    let model_overrides = resolve_model_compat_overrides(&model_id, &row.model_settings)?;
 
-    let (base_url, compat_overrides) =
-        resolve_aionrs_url_and_compat(&row.platform, &row.base_url, &provider, &model_id, row.is_full_url);
+    let (base_url, mut compat_overrides) = resolve_aionrs_url_and_compat_with_mode(
+        &row.platform,
+        &row.base_url,
+        &provider,
+        &model_id,
+        row.is_full_url,
+        model_overrides.openai_api_mode,
+    );
+    compat_overrides.image_input = model_overrides.image_input;
 
-    if compat_overrides.openai_api_mode == Some(OpenAiApiMode::Responses) {
+    if provider == "openai" {
         info!(
             conversation_id = %ctx.conversation_id,
             platform = %row.platform,
             provider = %provider,
             model = %model_id,
             is_full_url = row.is_full_url,
-            api_mode = "responses",
+            api_mode = ?compat_overrides.openai_api_mode.unwrap_or_default(),
+            api_mode_source = if model_overrides.openai_api_mode.is_some() { "user" } else { "automatic" },
             "Resolved Aionrs OpenAI transport"
         );
     }
@@ -253,26 +264,49 @@ pub(crate) fn map_aionrs_provider(
 /// OpenAI-compatible providers use Chat Completions by default; official
 /// OpenAI GPT-5.6 models use Responses. Anthropic-compatible providers append
 /// `/v1/messages`.
-pub(crate) fn resolve_aionrs_url_and_compat(
+#[cfg(test)]
+fn resolve_aionrs_url_and_compat(
     platform: &str,
     raw_base_url: &str,
     mapped_provider: &str,
     model_id: &str,
     is_full_url: bool,
 ) -> (Option<String>, AionrsCompatOverrides) {
+    resolve_aionrs_url_and_compat_with_mode(platform, raw_base_url, mapped_provider, model_id, is_full_url, None)
+}
+
+pub(crate) fn resolve_aionrs_url_and_compat_with_mode(
+    platform: &str,
+    raw_base_url: &str,
+    mapped_provider: &str,
+    model_id: &str,
+    is_full_url: bool,
+    openai_api_mode_override: Option<OpenAiApiMode>,
+) -> (Option<String>, AionrsCompatOverrides) {
     let mut compat = AionrsCompatOverrides::default();
-    let use_responses = uses_openai_responses_api(platform, mapped_provider, model_id);
+    let openai_api_mode = resolve_openai_api_mode(platform, mapped_provider, model_id, openai_api_mode_override);
+    let use_responses = openai_api_mode == Some(OpenAiApiMode::Responses);
 
     if is_full_url {
         let trimmed = raw_base_url.trim_end_matches('/');
-        if use_responses && let Some(responses_url) = rewrite_chat_completions_url_to_responses(trimmed) {
-            compat.openai_api_mode = Some(OpenAiApiMode::Responses);
+        if let Some(mode) = openai_api_mode
+            && let Some(resolved_url) = rewrite_openai_api_url(trimmed, mode)
+        {
+            compat.openai_api_mode = Some(mode);
             compat.api_path = Some(String::new());
-            return (Some(responses_url), compat);
+            return (Some(resolved_url), compat);
+        }
+        // Automatic detection must not change the request body for an
+        // unrecognized complete endpoint. An explicit user selection still
+        // controls the wire format while preserving the user-owned URL.
+        if openai_api_mode_override.is_some() {
+            compat.openai_api_mode = openai_api_mode;
         }
         compat.api_path = Some(String::new());
         return (Some(trimmed.to_owned()), compat);
     }
+
+    compat.openai_api_mode = openai_api_mode;
 
     if platform == "gemini" {
         let trimmed = raw_base_url.trim_end_matches('/');
@@ -283,10 +317,6 @@ pub(crate) fn resolve_aionrs_url_and_compat(
 
     let trimmed = raw_base_url.trim_end_matches('/');
     let base_url = Some(trimmed.to_owned()).filter(|u| !u.is_empty());
-
-    if use_responses {
-        compat.openai_api_mode = Some(OpenAiApiMode::Responses);
-    }
 
     match mapped_provider {
         "openai" if base_url.is_some() => {
@@ -309,6 +339,20 @@ pub(crate) fn resolve_aionrs_url_and_compat(
     (base_url, compat)
 }
 
+fn resolve_openai_api_mode(
+    platform: &str,
+    mapped_provider: &str,
+    model_id: &str,
+    openai_api_mode_override: Option<OpenAiApiMode>,
+) -> Option<OpenAiApiMode> {
+    if mapped_provider != "openai" || platform == "gemini" {
+        return None;
+    }
+
+    openai_api_mode_override
+        .or_else(|| uses_openai_responses_api(platform, mapped_provider, model_id).then_some(OpenAiApiMode::Responses))
+}
+
 fn uses_openai_responses_api(platform: &str, mapped_provider: &str, model_id: &str) -> bool {
     if mapped_provider != "openai" || platform == "gemini" {
         return false;
@@ -318,10 +362,49 @@ fn uses_openai_responses_api(platform: &str, mapped_provider: &str, model_id: &s
     model == "gpt-5.6" || model.starts_with("gpt-5.6-")
 }
 
-fn rewrite_chat_completions_url_to_responses(url: &str) -> Option<String> {
-    url.strip_suffix("/chat/completions")
-        .map(|prefix| format!("{prefix}/responses"))
-        .or_else(|| url.ends_with("/responses").then(|| url.to_owned()))
+fn rewrite_openai_api_url(url: &str, mode: OpenAiApiMode) -> Option<String> {
+    match mode {
+        OpenAiApiMode::ChatCompletions => url
+            .strip_suffix("/responses")
+            .map(|prefix| format!("{prefix}/chat/completions"))
+            .or_else(|| url.ends_with("/chat/completions").then(|| url.to_owned())),
+        OpenAiApiMode::Responses => url
+            .strip_suffix("/chat/completions")
+            .map(|prefix| format!("{prefix}/responses"))
+            .or_else(|| url.ends_with("/responses").then(|| url.to_owned())),
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ModelCompatOverrides {
+    pub(crate) image_input: Option<ImageInputCapability>,
+    pub(crate) openai_api_mode: Option<OpenAiApiMode>,
+}
+
+pub(crate) fn resolve_model_compat_overrides(
+    model_id: &str,
+    model_settings_json: &str,
+) -> Result<ModelCompatOverrides, AgentError> {
+    let settings = serde_json::from_str::<HashMap<String, ModelSettings>>(model_settings_json).map_err(|error| {
+        AgentError::bad_request(format!("Invalid model settings config for model '{model_id}': {error}"))
+    })?;
+    let Some(settings) = settings.get(model_id) else {
+        return Ok(ModelCompatOverrides {
+            image_input: Some(ImageInputCapability::Unsupported),
+            ..Default::default()
+        });
+    };
+
+    Ok(ModelCompatOverrides {
+        image_input: Some(match settings.image_input {
+            ModelImageInputCapability::Supported => ImageInputCapability::Supported,
+            ModelImageInputCapability::Unsupported => ImageInputCapability::Unsupported,
+        }),
+        openai_api_mode: settings.openai_api_mode.map(|value| match value {
+            ModelOpenAiApiMode::ChatCompletions => OpenAiApiMode::ChatCompletions,
+            ModelOpenAiApiMode::Responses => OpenAiApiMode::Responses,
+        }),
+    })
 }
 
 fn resolve_model_protocol(model_id: &str, model_protocols: Option<&str>) -> Result<String, AgentError> {
@@ -665,6 +748,10 @@ fn team_mcp_to_config(cfg: &TeamMcpStdioConfig) -> HashMap<String, McpServerConf
 
     HashMap::from([(TEAM_MCP_SERVER_NAME.to_owned(), server)])
 }
+
+#[cfg(test)]
+#[path = "aionrs_model_settings_test.rs"]
+mod model_settings_test;
 
 #[cfg(test)]
 mod tests {

--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -389,14 +389,11 @@ pub(crate) fn resolve_model_compat_overrides(
         AgentError::bad_request(format!("Invalid model settings config for model '{model_id}': {error}"))
     })?;
     let Some(settings) = settings.get(model_id) else {
-        return Ok(ModelCompatOverrides {
-            image_input: Some(ImageInputCapability::Unsupported),
-            ..Default::default()
-        });
+        return Ok(ModelCompatOverrides::default());
     };
 
     Ok(ModelCompatOverrides {
-        image_input: Some(match settings.image_input {
+        image_input: settings.image_input.map(|value| match value {
             ModelImageInputCapability::Supported => ImageInputCapability::Supported,
             ModelImageInputCapability::Unsupported => ImageInputCapability::Unsupported,
         }),

--- a/crates/aionui-ai-agent/src/factory/aionrs_model_settings_test.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs_model_settings_test.rs
@@ -1,6 +1,8 @@
 use aion_config::compat::OpenAiApiMode;
 use aion_types::message::ImageInputCapability;
 
+use crate::capability::image_input::resolve_image_input_capability;
+
 use super::{resolve_aionrs_url_and_compat_with_mode, resolve_model_compat_overrides};
 
 #[test]
@@ -21,11 +23,21 @@ fn model_settings_resolve_explicit_vision_and_api_overrides() {
 }
 
 #[test]
-fn missing_model_settings_disable_vision_and_keep_api_automatic() {
+fn missing_model_settings_keep_vision_and_api_automatic() {
     let overrides = resolve_model_compat_overrides("gpt-5.6-sol", r#"{"gpt-4o":{"image_input":"supported"}}"#).unwrap();
 
-    assert_eq!(overrides.image_input, Some(ImageInputCapability::Unsupported));
+    assert_eq!(overrides.image_input, None);
     assert_eq!(overrides.openai_api_mode, None);
+}
+
+#[test]
+fn empty_model_settings_preserve_catalog_vision_support() {
+    let overrides = resolve_model_compat_overrides("gpt-4o", "{}").unwrap();
+    let capability = overrides
+        .image_input
+        .unwrap_or_else(|| resolve_image_input_capability("openai", Some("https://api.openai.com/v1"), "gpt-4o"));
+
+    assert_eq!(capability, ImageInputCapability::Supported);
 }
 
 #[test]
@@ -36,10 +48,10 @@ fn unsupported_image_input_explicitly_disables_vision() {
 }
 
 #[test]
-fn omitted_image_input_in_a_model_entry_defaults_to_unsupported() {
+fn omitted_image_input_in_a_model_entry_keeps_catalog_automatic() {
     let overrides = resolve_model_compat_overrides("gpt-4o", r#"{"gpt-4o":{"openai_api_mode":"responses"}}"#).unwrap();
 
-    assert_eq!(overrides.image_input, Some(ImageInputCapability::Unsupported));
+    assert_eq!(overrides.image_input, None);
     assert_eq!(overrides.openai_api_mode, Some(OpenAiApiMode::Responses));
 }
 

--- a/crates/aionui-ai-agent/src/factory/aionrs_model_settings_test.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs_model_settings_test.rs
@@ -1,0 +1,126 @@
+use aion_config::compat::OpenAiApiMode;
+use aion_types::message::ImageInputCapability;
+
+use super::{resolve_aionrs_url_and_compat_with_mode, resolve_model_compat_overrides};
+
+#[test]
+fn model_settings_resolve_explicit_vision_and_api_overrides() {
+    let overrides = resolve_model_compat_overrides(
+        "gpt-5.6-sol",
+        r#"{
+            "gpt-5.6-sol": {
+                "image_input": "supported",
+                "openai_api_mode": "chat_completions"
+            }
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(overrides.image_input, Some(ImageInputCapability::Supported));
+    assert_eq!(overrides.openai_api_mode, Some(OpenAiApiMode::ChatCompletions));
+}
+
+#[test]
+fn missing_model_settings_disable_vision_and_keep_api_automatic() {
+    let overrides = resolve_model_compat_overrides("gpt-5.6-sol", r#"{"gpt-4o":{"image_input":"supported"}}"#).unwrap();
+
+    assert_eq!(overrides.image_input, Some(ImageInputCapability::Unsupported));
+    assert_eq!(overrides.openai_api_mode, None);
+}
+
+#[test]
+fn unsupported_image_input_explicitly_disables_vision() {
+    let overrides = resolve_model_compat_overrides("gpt-4o", r#"{"gpt-4o":{"image_input":"unsupported"}}"#).unwrap();
+
+    assert_eq!(overrides.image_input, Some(ImageInputCapability::Unsupported));
+}
+
+#[test]
+fn omitted_image_input_in_a_model_entry_defaults_to_unsupported() {
+    let overrides = resolve_model_compat_overrides("gpt-4o", r#"{"gpt-4o":{"openai_api_mode":"responses"}}"#).unwrap();
+
+    assert_eq!(overrides.image_input, Some(ImageInputCapability::Unsupported));
+    assert_eq!(overrides.openai_api_mode, Some(OpenAiApiMode::Responses));
+}
+
+#[test]
+fn invalid_model_settings_are_rejected() {
+    let result = resolve_model_compat_overrides("gpt-5.6-sol", "not-json");
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn explicit_chat_completions_overrides_gpt_5_6_responses_default() {
+    let (base_url, compat) = resolve_aionrs_url_and_compat_with_mode(
+        "openai",
+        "https://api.openai.com/v1",
+        "openai",
+        "gpt-5.6-sol",
+        false,
+        Some(OpenAiApiMode::ChatCompletions),
+    );
+
+    assert_eq!(base_url.as_deref(), Some("https://api.openai.com/v1"));
+    assert_eq!(compat.api_path.as_deref(), Some("/chat/completions"));
+    assert_eq!(compat.openai_api_mode, Some(OpenAiApiMode::ChatCompletions));
+}
+
+#[test]
+fn explicit_responses_overrides_non_responses_model_default() {
+    let (_, compat) = resolve_aionrs_url_and_compat_with_mode(
+        "custom",
+        "https://proxy.example.com/v1",
+        "openai",
+        "gpt-4o",
+        false,
+        Some(OpenAiApiMode::Responses),
+    );
+
+    assert_eq!(compat.api_path.as_deref(), Some("/responses"));
+    assert_eq!(compat.openai_api_mode, Some(OpenAiApiMode::Responses));
+}
+
+#[test]
+fn explicit_api_mode_rewrites_known_complete_endpoints_in_both_directions() {
+    let (chat_url, chat_compat) = resolve_aionrs_url_and_compat_with_mode(
+        "custom",
+        "https://proxy.example.com/v1/responses",
+        "openai",
+        "gpt-5.6-sol",
+        true,
+        Some(OpenAiApiMode::ChatCompletions),
+    );
+    let (responses_url, responses_compat) = resolve_aionrs_url_and_compat_with_mode(
+        "custom",
+        "https://proxy.example.com/v1/chat/completions",
+        "openai",
+        "gpt-4o",
+        true,
+        Some(OpenAiApiMode::Responses),
+    );
+
+    assert_eq!(
+        chat_url.as_deref(),
+        Some("https://proxy.example.com/v1/chat/completions")
+    );
+    assert_eq!(chat_compat.openai_api_mode, Some(OpenAiApiMode::ChatCompletions));
+    assert_eq!(responses_url.as_deref(), Some("https://proxy.example.com/v1/responses"));
+    assert_eq!(responses_compat.openai_api_mode, Some(OpenAiApiMode::Responses));
+}
+
+#[test]
+fn explicit_api_mode_keeps_unrecognized_complete_url_but_controls_wire_format() {
+    let (base_url, compat) = resolve_aionrs_url_and_compat_with_mode(
+        "custom",
+        "https://proxy.example.com/generate",
+        "openai",
+        "gpt-4o",
+        true,
+        Some(OpenAiApiMode::Responses),
+    );
+
+    assert_eq!(base_url.as_deref(), Some("https://proxy.example.com/generate"));
+    assert_eq!(compat.api_path.as_deref(), Some(""));
+    assert_eq!(compat.openai_api_mode, Some(OpenAiApiMode::Responses));
+}

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -144,16 +144,20 @@ impl AionrsAgentManager {
         let runtime = AgentRuntime::new(conversation_id.clone(), workspace.clone(), 128);
         let sink: Arc<dyn OutputSink> = Arc::new(BackendOutputSink::new(runtime.event_sender()));
         let runtime_env = config_extra.runtime_env.clone();
-        let image_input_capability = resolve_image_input_capability(
-            &config_extra.provider,
-            config_extra.base_url.as_deref(),
-            &config_extra.model,
-        );
+        let image_input_override = config_extra.compat_overrides.image_input;
+        let image_input_capability = image_input_override.unwrap_or_else(|| {
+            resolve_image_input_capability(
+                &config_extra.provider,
+                config_extra.base_url.as_deref(),
+                &config_extra.model,
+            )
+        });
         info!(
             conversation_id = %conversation_id,
             provider = %config_extra.provider,
             model = %config_extra.model,
             image_input_capability = ?image_input_capability,
+            image_input_source = if image_input_override.is_some() { "provider_settings" } else { "catalog" },
             "Resolved image input capability for Aionrs model"
         );
         let final_input_dump = config_extra

--- a/crates/aionui-ai-agent/src/services/availability/mod.rs
+++ b/crates/aionui-ai-agent/src/services/availability/mod.rs
@@ -404,6 +404,7 @@ mod tests {
             model_protocols: None,
             model_enabled: None,
             model_health: None,
+            model_settings: "{}",
             bedrock_config: None,
             is_full_url: false,
         }

--- a/crates/aionui-ai-agent/src/services/provider_health.rs
+++ b/crates/aionui-ai-agent/src/services/provider_health.rs
@@ -16,7 +16,10 @@ use aionui_db::{IProviderRepository, models::Provider};
 use regex::Regex;
 use tracing::{info, warn};
 
-use crate::factory::aionrs::{map_aionrs_provider, resolve_aionrs_url_and_compat, resolve_bedrock_config};
+use crate::factory::aionrs::{
+    map_aionrs_provider, resolve_aionrs_url_and_compat_with_mode, resolve_bedrock_config,
+    resolve_model_compat_overrides,
+};
 use crate::types::AionrsResolvedConfig;
 
 const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(30);
@@ -67,8 +70,16 @@ impl ProviderHealthCheckService {
         let api_key = aionui_common::decrypt_string(&row.api_key_encrypted, &self.encryption_key)
             .map_err(|e| AgentError::internal(e.to_string()))?;
         let provider = map_aionrs_provider(&row.platform, model_id, row.model_protocols.as_deref())?;
-        let (base_url, compat_overrides) =
-            resolve_aionrs_url_and_compat(&row.platform, &row.base_url, &provider, model_id, row.is_full_url);
+        let model_overrides = resolve_model_compat_overrides(model_id, &row.model_settings)?;
+        let (base_url, mut compat_overrides) = resolve_aionrs_url_and_compat_with_mode(
+            &row.platform,
+            &row.base_url,
+            &provider,
+            model_id,
+            row.is_full_url,
+            model_overrides.openai_api_mode,
+        );
+        compat_overrides.image_input = model_overrides.image_input;
         let bedrock_config = if row.platform == "bedrock" {
             resolve_bedrock_config(row.bedrock_config.as_deref())
         } else {
@@ -216,6 +227,9 @@ async fn build_probe_engine(config_extra: AionrsResolvedConfig) -> Result<AgentE
     config.session.enabled = false;
     config.mcp.servers.clear();
     config.file_cache.enabled = false;
+    if let Some(image_input) = config_extra.compat_overrides.image_input {
+        config.compat.image_input = Some(image_input);
+    }
     if let Some(mode) = config_extra.compat_overrides.openai_api_mode {
         config.compat.transport.openai_api_mode = Some(mode);
     }
@@ -372,6 +386,7 @@ mod tests {
             model_protocols: None,
             model_enabled: None,
             model_health: None,
+            model_settings: "{}".into(),
             bedrock_config: None,
             is_full_url: false,
             created_at: 0,

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use aion_config::compat::OpenAiApiMode;
+use aion_types::message::ImageInputCapability;
 use serde::{Deserialize, Serialize};
 
 use crate::session_context::AgentSessionContext;
@@ -113,6 +114,7 @@ impl RuntimeCapabilities {
 #[derive(Debug, Clone, Default)]
 pub struct AionrsCompatOverrides {
     pub(crate) openai_api_mode: Option<OpenAiApiMode>,
+    pub(crate) image_input: Option<ImageInputCapability>,
     pub max_tokens_field: Option<String>,
     pub api_path: Option<String>,
 }

--- a/crates/aionui-ai-agent/tests/factory_provider_integration.rs
+++ b/crates/aionui-ai-agent/tests/factory_provider_integration.rs
@@ -53,6 +53,7 @@ async fn insert_test_provider(repo: &dyn IProviderRepository, id: &str, platform
         model_protocols: None,
         model_enabled: None,
         model_health: None,
+        model_settings: "{}",
         bedrock_config: None,
         is_full_url: false,
     })

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -124,8 +124,9 @@ pub use office::{
 pub use provider::{
     BedrockAuthMethod, BedrockConfig, CreateProviderRequest, DetectProtocolRequest, DetectionSuggestion,
     FetchModelsAnonymousRequest, FetchModelsRequest, FetchModelsResponse, HealthStatus, KeyTestResult, ModelCapability,
-    ModelHealthStatus, ModelInfo, ModelType, MultiKeyResult, ProtocolDetectionResponse, ProviderHealthCheckErrorKind,
-    ProviderHealthCheckRequest, ProviderHealthCheckResponse, ProviderResponse, SuggestionType, UpdateProviderRequest,
+    ModelHealthStatus, ModelImageInputCapability, ModelInfo, ModelOpenAiApiMode, ModelSettings, ModelType,
+    MultiKeyResult, ProtocolDetectionResponse, ProviderHealthCheckErrorKind, ProviderHealthCheckRequest,
+    ProviderHealthCheckResponse, ProviderResponse, SuggestionType, UpdateProviderRequest,
 };
 pub use remote_agent::{
     CreateRemoteAgentRequest, HandshakeResponse, RemoteAgentListItem, RemoteAgentResponse,

--- a/crates/aionui-api-types/src/provider.rs
+++ b/crates/aionui-api-types/src/provider.rs
@@ -38,22 +38,20 @@ pub enum ModelOpenAiApiMode {
 }
 
 /// Explicit image-input support configured for one model.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ModelImageInputCapability {
     Supported,
-    #[default]
     Unsupported,
 }
 
 /// User-configured overrides for one model.
 ///
-/// Image input is unsupported by default. A missing OpenAI API mode retains
-/// automatic protocol resolution.
+/// Missing values retain automatic capability and protocol resolution.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ModelSettings {
-    #[serde(default)]
-    pub image_input: ModelImageInputCapability,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_input: Option<ModelImageInputCapability>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub openai_api_mode: Option<ModelOpenAiApiMode>,
 }

--- a/crates/aionui-api-types/src/provider.rs
+++ b/crates/aionui-api-types/src/provider.rs
@@ -29,6 +29,35 @@ pub struct ModelCapability {
     pub is_user_selected: Option<bool>,
 }
 
+/// Explicit OpenAI wire API override for one model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelOpenAiApiMode {
+    ChatCompletions,
+    Responses,
+}
+
+/// Explicit image-input support configured for one model.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ModelImageInputCapability {
+    Supported,
+    #[default]
+    Unsupported,
+}
+
+/// User-configured overrides for one model.
+///
+/// Image input is unsupported by default. A missing OpenAI API mode retains
+/// automatic protocol resolution.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelSettings {
+    #[serde(default)]
+    pub image_input: ModelImageInputCapability,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub openai_api_mode: Option<ModelOpenAiApiMode>,
+}
+
 /// Health status values for a model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -139,6 +168,8 @@ pub struct ProviderResponse {
     pub model_enabled: Option<HashMap<String, bool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_health: Option<HashMap<String, ModelHealthStatus>>,
+    /// Per-model explicit overrides. An absent entry uses automatic resolution.
+    pub model_settings: HashMap<String, ModelSettings>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bedrock_config: Option<BedrockConfig>,
     #[serde(default)]
@@ -174,6 +205,8 @@ pub struct CreateProviderRequest {
     pub model_enabled: Option<HashMap<String, bool>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_health: Option<HashMap<String, ModelHealthStatus>>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub model_settings: HashMap<String, ModelSettings>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bedrock_config: Option<BedrockConfig>,
     #[serde(default)]
@@ -200,6 +233,7 @@ pub struct UpdateProviderRequest {
     pub model_protocols: Option<HashMap<String, String>>,
     pub model_enabled: Option<HashMap<String, bool>>,
     pub model_health: Option<HashMap<String, ModelHealthStatus>>,
+    pub model_settings: Option<HashMap<String, ModelSettings>>,
     pub bedrock_config: Option<BedrockConfig>,
     pub is_full_url: Option<bool>,
 }
@@ -470,6 +504,7 @@ mod tests {
             model_protocols: None,
             model_enabled: Some(HashMap::from([("claude-sonnet-4-20250514".into(), true)])),
             model_health: None,
+            model_settings: HashMap::new(),
             bedrock_config: None,
             is_full_url: false,
             created_at: 1712345678000,
@@ -503,6 +538,7 @@ mod tests {
             model_protocols: None,
             model_enabled: None,
             model_health: None,
+            model_settings: HashMap::new(),
             bedrock_config: None,
             is_full_url: false,
             created_at: 0,
@@ -624,6 +660,7 @@ mod tests {
             model_protocols: None,
             model_enabled: None,
             model_health: None,
+            model_settings: HashMap::new(),
             bedrock_config: None,
             is_full_url: false,
         };

--- a/crates/aionui-app/tests/assistants_e2e.rs
+++ b/crates/aionui-app/tests/assistants_e2e.rs
@@ -301,6 +301,7 @@ async fn fixture() -> Fixture {
             model_protocols: None,
             model_enabled: None,
             model_health: None,
+            model_settings: "{}",
             bedrock_config: None,
             is_full_url: false,
         })

--- a/crates/aionui-assistant/src/service.rs
+++ b/crates/aionui-assistant/src/service.rs
@@ -3124,6 +3124,7 @@ mod tests {
             model_protocols: None,
             model_enabled: None,
             model_health: None,
+            model_settings: "{}",
             bedrock_config: None,
             is_full_url: false,
         })
@@ -6015,6 +6016,7 @@ mod tests {
                 model_protocols: None,
                 model_enabled: None,
                 model_health: None,
+                model_settings: "{}",
                 bedrock_config: None,
                 is_full_url: false,
             })

--- a/crates/aionui-db/migrations/026_provider_model_settings.sql
+++ b/crates/aionui-db/migrations/026_provider_model_settings.sql
@@ -1,0 +1,3 @@
+ALTER TABLE providers
+ADD COLUMN model_settings TEXT NOT NULL DEFAULT '{}'
+CHECK (json_valid(model_settings));

--- a/crates/aionui-db/src/models/provider.rs
+++ b/crates/aionui-db/src/models/provider.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 /// Row mapping for the `providers` table.
 ///
 /// JSON fields (models, capabilities, model_protocols, model_enabled,
-/// model_health, bedrock_config) are stored as TEXT in SQLite and
+/// model_health, model_settings, bedrock_config) are stored as TEXT in SQLite and
 /// deserialized by the service layer.
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct Provider {
@@ -25,6 +25,8 @@ pub struct Provider {
     pub model_enabled: Option<String>,
     /// JSON object: model_id -> health status object.
     pub model_health: Option<String>,
+    /// JSON object: model_id -> explicit model settings.
+    pub model_settings: String,
     /// JSON object: Bedrock-specific configuration.
     pub bedrock_config: Option<String>,
     /// When true, base_url is treated as a complete endpoint URL.

--- a/crates/aionui-db/src/repository/provider.rs
+++ b/crates/aionui-db/src/repository/provider.rs
@@ -39,6 +39,7 @@ pub struct CreateProviderParams<'a> {
     pub model_protocols: Option<&'a str>,
     pub model_enabled: Option<&'a str>,
     pub model_health: Option<&'a str>,
+    pub model_settings: &'a str,
     pub bedrock_config: Option<&'a str>,
     pub is_full_url: bool,
 }
@@ -59,6 +60,7 @@ pub struct UpdateProviderParams<'a> {
     pub model_protocols: Option<Option<&'a str>>,
     pub model_enabled: Option<Option<&'a str>>,
     pub model_health: Option<Option<&'a str>>,
+    pub model_settings: Option<&'a str>,
     pub bedrock_config: Option<Option<&'a str>>,
     pub is_full_url: Option<bool>,
 }

--- a/crates/aionui-db/src/repository/sqlite_provider.rs
+++ b/crates/aionui-db/src/repository/sqlite_provider.rs
@@ -47,8 +47,8 @@ impl IProviderRepository for SqliteProviderRepository {
             "INSERT INTO providers \
                 (id, platform, name, base_url, api_key_encrypted, models, enabled, \
                  capabilities, context_limit, model_protocols, model_enabled, \
-                 model_health, bedrock_config, is_full_url, created_at, updated_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                 model_health, model_settings, bedrock_config, is_full_url, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&id)
         .bind(params.platform)
@@ -62,6 +62,7 @@ impl IProviderRepository for SqliteProviderRepository {
         .bind(params.model_protocols)
         .bind(params.model_enabled)
         .bind(params.model_health)
+        .bind(params.model_settings)
         .bind(params.bedrock_config)
         .bind(params.is_full_url)
         .bind(now)
@@ -88,6 +89,7 @@ impl IProviderRepository for SqliteProviderRepository {
             model_protocols: params.model_protocols.map(String::from),
             model_enabled: params.model_enabled.map(String::from),
             model_health: params.model_health.map(String::from),
+            model_settings: params.model_settings.to_string(),
             bedrock_config: params.bedrock_config.map(String::from),
             is_full_url: params.is_full_url,
             created_at: now,
@@ -108,7 +110,7 @@ impl IProviderRepository for SqliteProviderRepository {
                 platform = ?, name = ?, base_url = ?, api_key_encrypted = ?, \
                 models = ?, enabled = ?, capabilities = ?, context_limit = ?, \
                 model_protocols = ?, model_enabled = ?, model_health = ?, \
-                bedrock_config = ?, is_full_url = ?, updated_at = ? \
+                model_settings = ?, bedrock_config = ?, is_full_url = ?, updated_at = ? \
              WHERE id = ?",
         )
         .bind(&merged.platform)
@@ -122,6 +124,7 @@ impl IProviderRepository for SqliteProviderRepository {
         .bind(&merged.model_protocols)
         .bind(&merged.model_enabled)
         .bind(&merged.model_health)
+        .bind(&merged.model_settings)
         .bind(&merged.bedrock_config)
         .bind(merged.is_full_url)
         .bind(merged.updated_at)
@@ -176,6 +179,7 @@ fn merge_update(existing: Provider, params: UpdateProviderParams<'_>) -> Provide
         model_health: params
             .model_health
             .map_or(existing.model_health, |v| v.map(String::from)),
+        model_settings: params.model_settings.unwrap_or(&existing.model_settings).to_string(),
         bedrock_config: params
             .bedrock_config
             .map_or(existing.bedrock_config, |v| v.map(String::from)),
@@ -210,6 +214,7 @@ mod tests {
             model_protocols: None,
             model_enabled: None,
             model_health: None,
+            model_settings: "{}",
             bedrock_config: None,
             is_full_url: false,
         }

--- a/crates/aionui-db/tests/provider_model_settings_migration.rs
+++ b/crates/aionui-db/tests/provider_model_settings_migration.rs
@@ -1,0 +1,72 @@
+use std::borrow::Cow;
+use std::path::Path;
+
+use sqlx::migrate::Migrator;
+use sqlx::sqlite::SqlitePoolOptions;
+
+async fn run_migrations_through(pool: &sqlx::SqlitePool, max_version: i64) {
+    let full = Migrator::new(Path::new("migrations")).await.unwrap();
+    let migrations = full
+        .migrations
+        .iter()
+        .filter(|migration| migration.version <= max_version)
+        .cloned()
+        .collect::<Vec<_>>();
+    Migrator {
+        migrations: Cow::Owned(migrations),
+        ignore_missing: false,
+        locking: true,
+        no_tx: false,
+    }
+    .run(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn migration_026_adds_model_settings_without_losing_existing_providers() {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+    run_migrations_through(&pool, 25).await;
+
+    sqlx::query(
+        "INSERT INTO providers (
+            id, platform, name, base_url, api_key_encrypted, created_at, updated_at
+         ) VALUES ('provider-1', 'openai', 'OpenAI', 'https://api.openai.com/v1', 'encrypted', 1, 1)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    run_migrations_through(&pool, 26).await;
+
+    let row: (String, String) = sqlx::query_as("SELECT name, model_settings FROM providers WHERE id = 'provider-1'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.0, "OpenAI");
+    assert_eq!(row.1, "{}");
+}
+
+#[tokio::test]
+async fn migration_026_rejects_invalid_model_settings_json() {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+    run_migrations_through(&pool, 26).await;
+
+    let result = sqlx::query(
+        "INSERT INTO providers (
+            id, platform, name, base_url, api_key_encrypted, model_settings, created_at, updated_at
+         ) VALUES ('provider-1', 'openai', 'OpenAI', 'https://api.openai.com/v1', 'encrypted', 'invalid', 1, 1)",
+    )
+    .execute(&pool)
+    .await;
+
+    assert!(result.is_err());
+}

--- a/crates/aionui-db/tests/provider_repository.rs
+++ b/crates/aionui-db/tests/provider_repository.rs
@@ -28,6 +28,7 @@ fn sample_params() -> CreateProviderParams<'static> {
         model_protocols: None,
         model_enabled: None,
         model_health: None,
+        model_settings: "{}",
         bedrock_config: None,
         is_full_url: false,
     }
@@ -74,6 +75,7 @@ async fn create_with_all_optional_fields() {
             model_protocols: Some(r#"{"m1":"openai"}"#),
             model_enabled: Some(r#"{"m1":true}"#),
             model_health: Some(r#"{"m1":{"status":"healthy"}}"#),
+            model_settings: r#"{"m1":{"image_input":"supported"}}"#,
             bedrock_config: Some(r#"{"region":"us-east-1"}"#),
             ..sample_params()
         })
@@ -83,6 +85,7 @@ async fn create_with_all_optional_fields() {
     assert_eq!(p.model_protocols.as_deref(), Some(r#"{"m1":"openai"}"#));
     assert_eq!(p.model_enabled.as_deref(), Some(r#"{"m1":true}"#));
     assert!(p.model_health.is_some());
+    assert_eq!(p.model_settings, r#"{"m1":{"image_input":"supported"}}"#);
     assert!(p.bedrock_config.is_some());
 }
 
@@ -167,6 +170,28 @@ async fn update_api_key_changes_encrypted_value() {
         .unwrap();
 
     assert_eq!(updated.api_key_encrypted, "new_encrypted");
+}
+
+#[tokio::test]
+async fn update_model_settings_replaces_per_model_overrides() {
+    let r = repo().await;
+    let created = r.create(sample_params()).await.unwrap();
+
+    let updated = r
+        .update(
+            &created.id,
+            UpdateProviderParams {
+                model_settings: Some(r#"{"gpt-5.6-sol":{"openai_api_mode":"responses"}}"#),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        updated.model_settings,
+        r#"{"gpt-5.6-sol":{"openai_api_mode":"responses"}}"#
+    );
 }
 
 #[tokio::test]

--- a/crates/aionui-system/src/model_fetcher/mod.rs
+++ b/crates/aionui-system/src/model_fetcher/mod.rs
@@ -168,6 +168,7 @@ mod tests {
                 model_protocols: None,
                 model_enabled: None,
                 model_health: None,
+                model_settings: "{}",
                 bedrock_config: None,
                 is_full_url: false,
             })

--- a/crates/aionui-system/src/provider.rs
+++ b/crates/aionui-system/src/provider.rs
@@ -41,6 +41,7 @@ impl ProviderService {
         let model_protocols_json = serialize_opt(&req.model_protocols, "model_protocols")?;
         let model_enabled_json = serialize_opt(&req.model_enabled, "model_enabled")?;
         let model_health_json = serialize_opt(&req.model_health, "model_health")?;
+        let model_settings_json = serialize_json(&req.model_settings, "model_settings")?;
         let bedrock_json = serialize_opt(&req.bedrock_config, "bedrock_config")?;
         let trimmed_id = req.id.as_deref().map(str::trim);
 
@@ -57,6 +58,7 @@ impl ProviderService {
             model_protocols: model_protocols_json.as_deref(),
             model_enabled: model_enabled_json.as_deref(),
             model_health: model_health_json.as_deref(),
+            model_settings: &model_settings_json,
             bedrock_config: bedrock_json.as_deref(),
             is_full_url: req.is_full_url,
         };
@@ -79,6 +81,7 @@ impl ProviderService {
         let model_protocols_json = serialize_opt(&req.model_protocols, "model_protocols")?;
         let model_enabled_json = serialize_opt(&req.model_enabled, "model_enabled")?;
         let model_health_json = serialize_opt(&req.model_health, "model_health")?;
+        let model_settings_json = serialize_opt(&req.model_settings, "model_settings")?;
         let bedrock_json = serialize_opt(&req.bedrock_config, "bedrock_config")?;
 
         let params = UpdateProviderParams {
@@ -93,6 +96,7 @@ impl ProviderService {
             model_protocols: model_protocols_json.as_ref().map(|s| Some(s.as_str())),
             model_enabled: model_enabled_json.as_ref().map(|s| Some(s.as_str())),
             model_health: model_health_json.as_ref().map(|s| Some(s.as_str())),
+            model_settings: model_settings_json.as_deref(),
             bedrock_config: bedrock_json.as_ref().map(|s| Some(s.as_str())),
             is_full_url: req.is_full_url,
         };
@@ -128,6 +132,8 @@ impl ProviderService {
             deserialize_opt(&row.model_protocols, "model_protocols")?;
         let model_enabled: Option<HashMap<String, bool>> = deserialize_opt(&row.model_enabled, "model_enabled")?;
         let model_health = deserialize_opt(&row.model_health, "model_health")?;
+        let model_settings = serde_json::from_str(&row.model_settings)
+            .map_err(|e| SystemError::Internal(format!("Failed to parse model_settings JSON: {e}")))?;
         let bedrock_config = deserialize_opt(&row.bedrock_config, "bedrock_config")?;
 
         Ok(ProviderResponse {
@@ -143,6 +149,7 @@ impl ProviderService {
             model_protocols,
             model_enabled,
             model_health,
+            model_settings,
             bedrock_config,
             is_full_url: row.is_full_url,
             created_at: row.created_at,
@@ -297,6 +304,7 @@ mod tests {
             model_protocols: None,
             model_enabled: None,
             model_health: None,
+            model_settings: HashMap::new(),
             bedrock_config: None,
             is_full_url: false,
         }

--- a/crates/aionui-system/tests/model_fetch_routes.rs
+++ b/crates/aionui-system/tests/model_fetch_routes.rs
@@ -70,6 +70,7 @@ async fn create_provider(db: &aionui_db::Database, platform: &str, base_url: &st
             model_protocols: None,
             model_enabled: None,
             model_health: None,
+            model_settings: "{}",
             bedrock_config: None,
             is_full_url: false,
         })

--- a/crates/aionui-system/tests/provider_routes.rs
+++ b/crates/aionui-system/tests/provider_routes.rs
@@ -257,6 +257,49 @@ async fn create_provider_with_optional_fields() {
 }
 
 #[tokio::test]
+async fn create_provider_persists_model_settings() {
+    let (_app, db) = setup().await;
+    let mut body = sample_create_body();
+    body["models"] = json!(["gpt-5.6-sol"]);
+    body["model_settings"] = json!({
+        "gpt-5.6-sol": {
+            "image_input": "supported",
+            "openai_api_mode": "responses"
+        }
+    });
+
+    let create_app = system_routes(build_state(&db));
+    let create_resp = create_app
+        .oneshot(json_request("POST", "/api/providers", body))
+        .await
+        .unwrap();
+    assert_eq!(create_resp.status(), StatusCode::CREATED);
+
+    let list_app = system_routes(build_state(&db));
+    let list_resp = list_app.oneshot(get_request("/api/providers")).await.unwrap();
+    let list_json = body_json(list_resp).await;
+    assert_eq!(
+        list_json["data"][0]["model_settings"]["gpt-5.6-sol"]["image_input"],
+        "supported"
+    );
+    assert_eq!(
+        list_json["data"][0]["model_settings"]["gpt-5.6-sol"]["openai_api_mode"],
+        "responses"
+    );
+}
+
+#[tokio::test]
+async fn create_provider_rejects_unknown_model_setting_value() {
+    let (app, _db) = setup().await;
+    let mut body = sample_create_body();
+    body["model_settings"] = json!({"gpt-5.6-sol": {"image_input": "sometimes"}});
+
+    let resp = app.oneshot(json_request("POST", "/api/providers", body)).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn create_provider_missing_platform() {
     let (app, _db) = setup().await;
     let body = json!({
@@ -361,6 +404,37 @@ async fn update_provider_api_key_returns_plaintext() {
     let json = body_json(resp).await;
     let api_key = json["data"]["api_key"].as_str().unwrap();
     assert_eq!(api_key, "new-key-abcdefgh");
+}
+
+#[tokio::test]
+async fn update_provider_replaces_model_settings() {
+    let (_app, db) = setup().await;
+    let (_, id) = create_one(&db).await;
+
+    let update_app = system_routes(build_state(&db));
+    let resp = update_app
+        .oneshot(json_request(
+            "PUT",
+            &format!("/api/providers/{id}"),
+            json!({
+                "model_settings": {
+                    "gpt-4o": {
+                        "image_input": "unsupported",
+                        "openai_api_mode": "chat_completions"
+                    }
+                }
+            }),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["data"]["model_settings"]["gpt-4o"]["image_input"], "unsupported");
+    assert_eq!(
+        json["data"]["model_settings"]["gpt-4o"]["openai_api_mode"],
+        "chat_completions"
+    );
 }
 
 #[tokio::test]

--- a/crates/aionui-team/src/service/spawn_support.rs
+++ b/crates/aionui-team/src/service/spawn_support.rs
@@ -438,6 +438,7 @@ mod tests {
             model_protocols: None,
             model_enabled: None,
             model_health: None,
+            model_settings: "{}".into(),
             bedrock_config: None,
             is_full_url: false,
             created_at: 0,


### PR DESCRIPTION
## Summary

- add a `model_settings` JSON column to the existing `providers` table through migration 026
- expose explicit per-model image input overrides as `supported` / `unsupported` while preserving catalog detection when unset
- expose an optional OpenAI API mode override for Chat Completions or Responses
- apply model overrides consistently to AionCLI sessions and provider health checks
- preserve automatic OpenAI transport resolution when no API mode override is configured

## Why

Users need to explicitly configure whether each model accepts image input and whether OpenAI-compatible requests use Chat Completions or Responses, without regressing existing catalog-detected Vision support.

## Migration and compatibility

- no new table is introduced
- existing provider rows receive `model_settings = '{}'`
- missing image input settings resolve to `None` and continue through catalog capability detection
- explicit `supported` / `unsupported` values override the catalog
- missing OpenAI API mode settings keep the existing automatic resolution behavior

## Validation

- `just push`
- workspace migration immutability, format, check, clippy, and test gates passed
- 6,864 tests passed; 18 skipped

## Related PRs

- AionUi counterpart: https://github.com/iOfficeAI/AionUi/pull/3639

## Merge order

1. Merge and release this AionCore change.
2. Merge the AionUi counterpart after it can consume the new provider contract.
