### PR TITLE
fix(agent): reject and clear launch-path override for npx-bridged agents

### DIFF
--- a/crates/aionui-ai-agent/src/services/agent.rs
+++ b/crates/aionui-ai-agent/src/services/agent.rs
@@ -140,6 +140,17 @@ impl AgentService {
             return Err(AgentError::bad_request("Internal Aion CLI does not support overrides"));
         }
 
+        // Launch-path overrides only make sense for direct-CLI rows. Bridge-launched
+        // rows (e.g. `npx`) keep the bridge's own arguments in `args` (such as
+        // `-y <package> acp`); swapping `command` for a launch path would feed those
+        // bridge arguments to the target binary and break startup. Reject the write so
+        // the stored spawn command stays coherent (env overrides remain allowed).
+        if command_override.is_some() && is_bridge_launched_row(&row) {
+            return Err(AgentError::bad_request(
+                "This agent launches through a package runner (npx); its launch path cannot be overridden. Use environment variables instead.",
+            ));
+        }
+
         let env_json = match req.env_override {
             Some(entries) if !entries.is_empty() => Some(
                 serde_json::to_string(&entries)
@@ -178,6 +189,25 @@ impl AgentService {
             },
             env_override,
         })
+    }
+}
+
+/// True when the row is launched through a bridge binary (e.g. `npx`) rather
+/// than a direct CLI. Such rows store the bridge's own arguments in `args`
+/// (e.g. `-y <package> acp`), so replacing `command` with a launch path would
+/// forward those bridge arguments to the target binary. Launch-path overrides
+/// are therefore only valid for direct-CLI rows (`command == binary_name`, no
+/// bridge). Unparseable or absent `agent_source_info` is treated as direct.
+fn is_bridge_launched_row(row: &aionui_db::AgentMetadataRow) -> bool {
+    let Some(raw) = row.agent_source_info.as_deref() else {
+        return false;
+    };
+    let Ok(info) = serde_json::from_str::<aionui_api_types::AgentSourceInfo>(raw) else {
+        return false;
+    };
+    match info.bridge_binary.as_deref() {
+        Some(bridge) => info.binary_name.as_deref() != Some(bridge),
+        None => false,
     }
 }
 

--- a/crates/aionui-app/tests/agent_integration_e2e.rs
+++ b/crates/aionui-app/tests/agent_integration_e2e.rs
@@ -671,6 +671,77 @@ async fn agent_overrides_roundtrip_and_management_summary() {
 }
 
 #[tokio::test]
+async fn npx_bridged_agent_rejects_command_override() {
+    let (mut app, services, _mock_tm) = build_app_with_mock_tasks().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "Pass123!").await;
+
+    // Seed a builtin npx-bridged ACP row (command == "npx", bridge_binary != binary_name),
+    // mirroring the ACP Registry agents such as Kilo.
+    services
+        .agent_registry
+        .repo_handle()
+        .upsert(&UpsertAgentMetadataParams {
+            id: "npx-agent",
+            icon: None,
+            name: "npx-agent",
+            name_i18n: None,
+            description: None,
+            description_i18n: None,
+            backend: Some("kilo"),
+            agent_type: "acp",
+            agent_source: "builtin",
+            agent_source_info: Some(r#"{"binary_name":"kilo","bridge_binary":"npx"}"#),
+            enabled: true,
+            command: Some("npx"),
+            args: Some(r#"["-y","@kilocode/cli","acp"]"#),
+            env: Some("[]"),
+            native_skills_dirs: None,
+            behavior_policy: Some("{}"),
+            yolo_id: None,
+            agent_capabilities: None,
+            auth_methods: None,
+            config_options: None,
+            available_modes: None,
+            available_models: None,
+            available_commands: None,
+            sort_order: 1,
+        })
+        .await
+        .unwrap();
+    services.agent_registry.hydrate().await.unwrap();
+    services.agent_registry.refresh_availability().await;
+
+    // A launch-path (command) override must be rejected for bridge-launched rows,
+    // otherwise the npx wrapper args get forwarded to the resolved binary.
+    let command_body = json!({
+        "command_override": "C:\\Users\\aixux\\AppData\\Roaming\\npm\\kilo.cmd"
+    });
+    let req = json_with_token("PUT", "/api/agents/npx-agent/overrides", command_body, &token, &csrf);
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+    // Env-only overrides remain allowed for the same npx agent (API keys, proxies, …).
+    let env_body = json!({
+        "env_override": [{"name": "ANTHROPIC_API_KEY", "value": "sk-x"}]
+    });
+    let req = json_with_token("PUT", "/api/agents/npx-agent/overrides", env_body, &token, &csrf);
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // The rejected command override must not have been persisted.
+    let greq = get_with_token("/api/agents/npx-agent/overrides", &token);
+    let gbody = body_json(app.clone().oneshot(greq).await.unwrap()).await;
+    assert!(gbody["data"]["command_override"].is_null());
+    assert!(
+        gbody["data"]["env_override"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|e| e["name"] == "ANTHROPIC_API_KEY")
+    );
+}
+
+#[tokio::test]
 async fn internal_aion_cli_rejects_overrides() {
     let (mut app, services, _mock_tm) = build_app_with_mock_tasks().await;
     let (token, csrf) = setup_and_login(&mut app, &services, "admin", "Pass123!").await;

--- a/crates/aionui-db/migrations/026_clear_bridge_agent_command_override.sql
+++ b/crates/aionui-db/migrations/026_clear_bridge_agent_command_override.sql
@@ -1,0 +1,15 @@
+-- Bridge-launched rows (e.g. `npx`) keep the bridge's own arguments
+-- (`-y <package> ...`) in `args`. A launch-path (command) override replaced the
+-- bridge command with a bare binary path while retaining those bridge args,
+-- producing broken invocations like `kilo.cmd -y @kilocode/cli acp` that fail
+-- ACP initialization. Such overrides are never valid for bridge-launched rows,
+-- so clear any already-persisted value. Only command_override is cleared;
+-- env_override (API keys/proxies) and the base command stay intact.
+UPDATE agent_metadata
+SET command_override = NULL,
+    updated_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+WHERE command_override IS NOT NULL
+  AND agent_source_info IS NOT NULL
+  AND json_valid(agent_source_info)
+  AND json_extract(agent_source_info, '$.bridge_binary') IS NOT NULL
+  AND json_extract(agent_source_info, '$.bridge_binary') <> COALESCE(json_extract(agent_source_info, '$.binary_name'), '');


### PR DESCRIPTION
## Symptom

Reported via Sentry **ELECTRON-3N2** and user reports: after updating, the builtin **Kilo** agent (id `54c5ccf0`) became unusable — "Test Connection" failed and sessions never started. The user had set a launch-path (command) override on the agent, which caused it to be launched as:

```
kilo.cmd -y @kilocode/cli acp
```

The CLI cannot parse those arguments, so ACP initialization timed out (`acp_init_failed`).

## Root cause

npx-bridged builtin agents keep the bridge wrapper arguments (`-y <package> ...`) in `args`, with `command` set to `npx`. Applying a launch-path (command) override replaced `command` with the resolved binary path **but left the npx wrapper args in `args`**. The factory then invoked the resolved binary with those bridge args (e.g. `kilo.cmd -y @kilocode/cli acp`) — arguments meant for npx, not the CLI — so the agent could never complete ACP init.

A launch-path override is only meaningful for direct-CLI rows (`command == binary_name`, no bridge).

## Fix (two parts)

1. **Write-time rejection** — `set_agent_overrides` now rejects a `command_override` when the row is bridge-launched (`agent_source_info.bridge_binary` present and `!= binary_name`). Env-only overrides (API keys/proxies) remain allowed.
2. **Dirty-data cleanup** — migration `026_clear_bridge_agent_command_override.sql` clears any already-persisted `command_override` on bridge-launched rows, so installs that already saved a bad override self-heal on upgrade. Only `command_override` is cleared; `env_override` and the base command are untouched.

## Tests

- Added an integration test covering the rejection path (`npx_bridged_agent_rejects_command_override`) in `agent_integration_e2e`.
- `cargo test -p aionui-db` validates migration 026 applies cleanly alongside all existing migrations.

## Companion

The companion AionUi PR (iOfficeAI/AionUi#3641) hides the launch-path field in the UI for npx-bridged agents, so users can no longer set an override that would break these agents.
