### PR TITLE
fix(agent): surface sign-in hint on empty ACP turns from auth-gated agents

### DIFF
--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -9,7 +9,9 @@ use crate::protocol::events::{
 use crate::protocol::send_error::AgentSendError;
 use crate::shared_kernel::SessionId as DomainSessionId;
 use crate::types::SendMessageData;
-use agent_client_protocol::schema::{ContentBlock, LoadSessionRequest, PromptRequest, SessionId, StopReason};
+use agent_client_protocol::schema::{
+    AuthMethod, ContentBlock, LoadSessionRequest, PromptRequest, SessionId, StopReason,
+};
 use aionui_api_types::SlashCommandItem;
 use serde_json::Value;
 use tokio::sync::broadcast::error::TryRecvError;
@@ -271,11 +273,24 @@ impl AcpAgentManager {
             });
         }
 
+        // On an empty end-of-turn, surface the agent's advertised login method
+        // (if any). ACP defines no auth-failure stop reason, so an agent that
+        // isn't signed in can swallow the failure and return `end_turn` with no
+        // content (observed with kilo: the model call 401s, yet ACP reports a
+        // clean empty turn). The stable `authMethods` from `initialize` lets us
+        // turn that blank tip into an actionable "you may need to sign in" hint.
+        let auth_hint = if empty_turn {
+            auth_login_hint(self.session.read().await.auth_methods())
+        } else {
+            None
+        };
+
         Ok(prompt_outcome_from_stop_reason(
             sid,
             prompt_response.stop_reason,
             empty_turn,
             matched_command,
+            auth_hint,
         ))
     }
 
@@ -391,6 +406,7 @@ fn prompt_outcome_from_stop_reason(
     stop_reason: StopReason,
     empty_turn: bool,
     _matched_command: Option<&SlashCommandItem>,
+    auth_hint: Option<Value>,
 ) -> PromptOutcome {
     if matches!(stop_reason, StopReason::Cancelled) {
         return PromptOutcome::Cancelled {
@@ -400,6 +416,18 @@ fn prompt_outcome_from_stop_reason(
 
     if empty_turn {
         if matches!(stop_reason, StopReason::EndTurn) {
+            // The agent ended the turn producing nothing. If it advertised a
+            // login method at initialize, the most likely cause is that it
+            // isn't signed in and silently returned an empty end_turn — point
+            // the user at the login step instead of a blank tip. (Presence of
+            // authMethods is not proof of being logged out, so the client copy
+            // must stay a soft "may need sign-in" hint, not an assertion.)
+            if let Some(params) = auth_hint {
+                return PromptOutcome::InfoTip {
+                    session_id: session_id.to_owned(),
+                    tips: empty_turn_info_tip("ACP_EMPTY_TURN_NEEDS_AUTH", Some(params)),
+                };
+            }
             return PromptOutcome::InfoTip {
                 session_id: session_id.to_owned(),
                 tips: empty_turn_info_tip("ACP_EMPTY_TURN", None),
@@ -415,6 +443,28 @@ fn prompt_outcome_from_stop_reason(
     PromptOutcome::Completed {
         session_id: session_id.to_owned(),
     }
+}
+
+/// Build empty-turn tip params from the agent's advertised ACP auth methods,
+/// or `None` when the agent advertised none. `hint` is the first
+/// human-readable description/name (e.g. "Run `kilo auth login` in the
+/// terminal"); `methods` carries the full advertised list so the client can
+/// render every option. Uses the stable `authMethods` from the `initialize`
+/// handshake — no agent-specific flags or stderr scraping.
+fn auth_login_hint(methods: Option<&[AuthMethod]>) -> Option<Value> {
+    let methods = methods?;
+    let entries: Vec<Value> = methods.iter().filter_map(|m| serde_json::to_value(m).ok()).collect();
+    if entries.is_empty() {
+        return None;
+    }
+    let hint = entries.iter().find_map(|m| {
+        m.get("description")
+            .and_then(Value::as_str)
+            .or_else(|| m.get("name").and_then(Value::as_str))
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+    });
+    Some(serde_json::json!({ "methods": entries, "hint": hint }))
 }
 
 fn empty_turn_info_tip(code: &str, params: Option<Value>) -> TipsEventData {
@@ -762,7 +812,7 @@ mod tests {
 
     #[test]
     fn benign_empty_turn_returns_info_tip() {
-        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, None);
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, None, None);
 
         match outcome {
             super::PromptOutcome::InfoTip { session_id, tips } => {
@@ -776,6 +826,37 @@ mod tests {
     }
 
     #[test]
+    fn empty_turn_with_auth_methods_emits_needs_auth_hint() {
+        // Mirrors the kilo case: the agent advertised a login method at
+        // `initialize` and then returned an empty end_turn (swallowed 401).
+        let auth_hint = serde_json::json!({
+            "methods": [{"id": "kilo-login", "name": "Login with Kilo",
+                         "description": "Run `kilo auth login` in the terminal"}],
+            "hint": "Run `kilo auth login` in the terminal",
+        });
+        let outcome =
+            super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, None, Some(auth_hint));
+
+        match outcome {
+            super::PromptOutcome::InfoTip { session_id, tips } => {
+                assert_eq!(session_id, "sess-1");
+                assert_eq!(tips.tip_type, TipType::Info);
+                assert_eq!(tips.code.as_deref(), Some("ACP_EMPTY_TURN_NEEDS_AUTH"));
+                let params = tips.params.expect("needs-auth tip carries params");
+                assert_eq!(params["hint"], "Run `kilo auth login` in the terminal");
+                assert!(params["methods"].is_array());
+            }
+            other => panic!("expected InfoTip, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn auth_login_hint_returns_none_without_methods() {
+        assert!(super::auth_login_hint(None).is_none());
+        assert!(super::auth_login_hint(Some(&[])).is_none());
+    }
+
+    #[test]
     fn metadata_driven_command_empty_turn_uses_generic_tip_code() {
         let command = SlashCommandItem {
             command: "ctx-flush".into(),
@@ -785,7 +866,7 @@ mod tests {
             empty_turn_tip_params: Some(serde_json::json!({ "scope": "session" })),
         };
 
-        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, Some(&command));
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, Some(&command), None);
 
         match outcome {
             super::PromptOutcome::InfoTip { session_id, tips } => {
@@ -801,7 +882,7 @@ mod tests {
 
     #[test]
     fn non_benign_empty_turn_can_stay_warning_tip() {
-        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::MaxTokens, true, None);
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::MaxTokens, true, None, None);
 
         match outcome {
             super::PromptOutcome::WarningTip { session_id, tips } => {
@@ -816,7 +897,7 @@ mod tests {
 
     #[test]
     fn prompt_outcome_cancelled_takes_priority_over_empty_response() {
-        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::Cancelled, true, None);
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::Cancelled, true, None, None);
 
         match outcome {
             super::PromptOutcome::Cancelled { session_id } => {
@@ -828,7 +909,7 @@ mod tests {
 
     #[test]
     fn prompt_outcome_completed_when_visible_output_exists() {
-        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, false, None);
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, false, None, None);
 
         match outcome {
             super::PromptOutcome::Completed { session_id } => {


### PR DESCRIPTION
## Symptom

A user sends a message to an ACP agent (observed with `kilo`) and gets no visible reply — the client shows a blank "no visible reply" tip. The underlying cause is that the agent is not signed in: its model call returns a `401`, but that failure is swallowed and reported to us as a clean, empty turn.

## Root cause

ACP defines no auth-failure stop reason. When an auth-gated agent isn't signed in, it can absorb the failure internally and return `stopReason=end_turn` with no content. From our side the turn looks completed and simply empty, so we surface a generic blank-response tip that gives the user nothing actionable.

## Fix

When a turn ends empty with `stopReason=end_turn` **and** the agent advertised `authMethods` during `initialize` (a stable ACP field), emit an `ACP_EMPTY_TURN_NEEDS_AUTH` tip carrying the advertised login method(s). The client can then render an actionable "you may need to sign in - <description>" hint instead of a blank message.

Design notes:
- Agent-agnostic: no per-agent flags and no stderr scraping.
- The presence of `authMethods` is not proof that the user is logged out, so the copy stays a soft hint rather than a hard error.
- Adds unit tests for the needs-auth branch and the hint builder.

## Companion frontend

Companion AionUi PR: iOfficeAI/AionUi#3644 — renders the ACP_EMPTY_TURN_NEEDS_AUTH tip (13-locale i18n).
