### PR TITLE
fix(agent): reflect auth failures from real turns into agent availability

### DIFF
--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -5091,11 +5091,18 @@ async fn send_message_records_agent_availability_feedback_on_send_failure() {
     let failures = feedback.failures.lock().unwrap().clone();
     assert_eq!(
         failures,
-        vec![RecordedAvailabilityFailure {
-            agent_id: "agent-feedback-1".into(),
-            code: "session_send_failed".into(),
-            message: "provider returned 401 invalid api key".into(),
-        }]
+        vec![
+            RecordedAvailabilityFailure {
+                agent_id: "agent-feedback-1".into(),
+                code: "session_send_failed".into(),
+                message: "provider returned 401 invalid api key".into(),
+            },
+            RecordedAvailabilityFailure {
+                agent_id: "agent-feedback-1".into(),
+                code: "auth_required".into(),
+                message: "provider returned 401 invalid api key".into(),
+            },
+        ]
     );
 }
 

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -32,6 +32,11 @@ pub struct TurnAttemptSummary {
     pub persisted_assistant_output: bool,
     pub terminal_error: Option<ErrorEventData>,
     pub terminal_error_deferred: bool,
+    /// The turn ended benignly (a Finish, not an Error) but the agent signalled
+    /// that it needs sign-in — an `ACP_EMPTY_TURN_NEEDS_AUTH` tip. Lets the turn
+    /// orchestrator reflect "needs auth" into the agent's availability even
+    /// though the turn itself is not an error.
+    pub needs_auth: bool,
 }
 
 impl TurnAttemptSummary {
@@ -43,6 +48,7 @@ impl TurnAttemptSummary {
         self.saw_visible_output |= other.saw_visible_output;
         self.saw_tool_or_side_effect |= other.saw_tool_or_side_effect;
         self.persisted_assistant_output |= other.persisted_assistant_output;
+        self.needs_auth |= other.needs_auth;
         if other.terminal_error.is_some() {
             self.terminal_error = other.terminal_error.clone();
         }
@@ -475,6 +481,9 @@ impl StreamRelay {
                         AgentStreamEvent::Tips(data) => {
                             if matches!(data.tip_type, TipType::Success | TipType::Warning | TipType::Info) {
                                 attempt.saw_visible_output = true;
+                            }
+                            if data.code.as_deref() == Some("ACP_EMPTY_TURN_NEEDS_AUTH") {
+                                attempt.needs_auth = true;
                             }
                             self.forward_to_websocket(&event);
                             if matches!(data.tip_type, TipType::Success | TipType::Warning | TipType::Info) {
@@ -927,6 +936,77 @@ mod tests {
 
         let content: serde_json::Value = serde_json::from_str(&msg.content).unwrap();
         assert_eq!(content["content"], "Hello World");
+    }
+
+    #[tokio::test]
+    async fn needs_auth_tip_sets_summary_flag_on_finish() {
+        use aionui_ai_agent::protocol::events::{TipType, TipsEventData};
+
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let (tx, _) = broadcast::channel(64);
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "turn-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+        );
+        let rx = tx.subscribe();
+
+        // An agent that connected but isn't signed in: needs-auth tip, then a
+        // benign end_turn (Finish). Terminal stays non-error, but the summary
+        // must flag needs_auth so the orchestrator can reflect it into availability.
+        tx.send(AgentStreamEvent::Tips(TipsEventData {
+            content: String::new(),
+            tip_type: TipType::Info,
+            code: Some("ACP_EMPTY_TURN_NEEDS_AUTH".into()),
+            params: Some(serde_json::json!({ "hint": "Run `kilo auth login` in the terminal" })),
+        }))
+        .unwrap();
+        tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
+
+        let outcome = relay.consume(rx).await;
+        assert_eq!(
+            outcome.terminal,
+            RelayTerminal::Finish,
+            "needs-auth empty turn is a benign finish"
+        );
+        assert!(outcome.attempt.needs_auth, "needs-auth tip must set the summary flag");
+    }
+
+    #[tokio::test]
+    async fn plain_empty_turn_tip_does_not_set_needs_auth() {
+        use aionui_ai_agent::protocol::events::{TipType, TipsEventData};
+
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let (tx, _) = broadcast::channel(64);
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "turn-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+        );
+        let rx = tx.subscribe();
+
+        tx.send(AgentStreamEvent::Tips(TipsEventData {
+            content: String::new(),
+            tip_type: TipType::Info,
+            code: Some("ACP_EMPTY_TURN".into()),
+            params: None,
+        }))
+        .unwrap();
+        tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
+
+        let outcome = relay.consume(rx).await;
+        assert!(
+            !outcome.attempt.needs_auth,
+            "a plain empty turn must NOT be treated as needs-auth"
+        );
     }
 
     #[tokio::test]

--- a/crates/aionui-conversation/src/turn_orchestrator.rs
+++ b/crates/aionui-conversation/src/turn_orchestrator.rs
@@ -16,7 +16,7 @@ use crate::service::{
 use crate::stream_relay::{RelayOutcome, StreamRelay, TurnAttemptSummary};
 use crate::turn_continuation_policy::{ContinuationDecision, TurnContinuationPolicy};
 use crate::turn_recovery_policy::{TurnRecoveryDecision, TurnRecoveryPolicy};
-use aionui_api_types::SendMessageRequest;
+use aionui_api_types::{AgentErrorCode, SendMessageRequest};
 
 fn acp_backend_from_build_options(options: &BuildTaskOptions) -> Option<&str> {
     match &options.context.kind {
@@ -364,6 +364,7 @@ impl ConversationTurnOrchestrator {
         let mut replayed = false;
         let mut replay_started_at = None;
         let mut final_error_message;
+        let mut auth_failure = false;
 
         info!(conversation_id = %conv_id, turn_id = %turn_id, "conversation turn orchestrator started");
 
@@ -391,6 +392,10 @@ impl ConversationTurnOrchestrator {
                     break result.status == ConversationTurnStatus::Failed;
                 }
             };
+
+            // Track the final attempt's auth signal so the post-loop availability
+            // write-back can reflect "needs sign-in" (last iteration wins).
+            auth_failure = terminal_is_auth_failure(&attempt_result.outcome);
 
             let lifecycle = runtime_state.lifecycle_for(&conv_id);
             if !attempt_result.outcome.terminal.is_error() {
@@ -483,7 +488,20 @@ impl ConversationTurnOrchestrator {
             }
         };
 
-        if !final_failed {
+        if auth_failure {
+            // The agent connected (detection saw it online) but a real turn hit
+            // an explicit auth signal — write "needs sign-in" back to its
+            // availability so the list stops showing it as plainly usable.
+            record_agent_session_failure(
+                &self.service,
+                availability_agent_id(&input.build_options).as_deref(),
+                "auth_required",
+                final_error_message
+                    .as_deref()
+                    .unwrap_or("Agent requires sign-in to run."),
+            )
+            .await;
+        } else if !final_failed {
             record_agent_session_success(&self.service, availability_agent_id(&input.build_options).as_deref()).await;
         }
 
@@ -513,6 +531,28 @@ fn availability_agent_id(options: &BuildTaskOptions) -> Option<String> {
             .map(str::to_owned),
         AgentSessionKind::Aionrs(_) => None,
     }
+}
+
+/// True when the turn's terminal is an explicit authentication signal: an
+/// `ACP_EMPTY_TURN_NEEDS_AUTH` benign tip (the agent connected but isn't signed
+/// in and returned an empty end_turn), or an Error terminal carrying an
+/// auth/login error code. Used to reflect "needs sign-in" into the agent's
+/// availability even when detection (initialize + session/new, no prompt)
+/// showed it online. Non-auth outcomes — generic empty turns, billing,
+/// rate-limit, context, network — are deliberately excluded so we don't flip an
+/// agent to unavailable for transient or unrelated failures.
+fn terminal_is_auth_failure(outcome: &RelayOutcome) -> bool {
+    if outcome.attempt.needs_auth {
+        return true;
+    }
+    matches!(
+        outcome.terminal.code(),
+        Some(
+            AgentErrorCode::UserAgentAuthRequired
+                | AgentErrorCode::UserLlmProviderAuthFailed
+                | AgentErrorCode::UserLlmProviderAwsSsoExpired
+        )
+    )
 }
 
 async fn apply_required_runtime_mode(agent: &AgentInstance, mode: &str) -> Result<(), AgentError> {
@@ -574,5 +614,70 @@ async fn record_agent_session_success(service: &ConversationService, agent_id: O
             error = %ErrorChain(&error),
             "Failed to record agent availability session success"
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stream_relay::RelayTerminal;
+
+    fn finish_outcome(needs_auth: bool) -> RelayOutcome {
+        RelayOutcome {
+            system_responses: vec![],
+            terminal: RelayTerminal::Finish,
+            attempt: TurnAttemptSummary {
+                needs_auth,
+                ..Default::default()
+            },
+        }
+    }
+
+    fn error_outcome(code: AgentErrorCode) -> RelayOutcome {
+        RelayOutcome {
+            system_responses: vec![],
+            terminal: RelayTerminal::Error {
+                code: Some(code),
+                retryable: None,
+            },
+            attempt: TurnAttemptSummary::default(),
+        }
+    }
+
+    #[test]
+    fn needs_auth_empty_turn_is_auth_failure() {
+        assert!(terminal_is_auth_failure(&finish_outcome(true)));
+    }
+
+    #[test]
+    fn plain_finish_is_not_auth_failure() {
+        // A generic empty turn (or any normal finish) must NOT flip availability.
+        assert!(!terminal_is_auth_failure(&finish_outcome(false)));
+    }
+
+    #[test]
+    fn explicit_auth_error_codes_are_auth_failure() {
+        assert!(terminal_is_auth_failure(&error_outcome(
+            AgentErrorCode::UserAgentAuthRequired
+        )));
+        assert!(terminal_is_auth_failure(&error_outcome(
+            AgentErrorCode::UserLlmProviderAuthFailed
+        )));
+        assert!(terminal_is_auth_failure(&error_outcome(
+            AgentErrorCode::UserLlmProviderAwsSsoExpired
+        )));
+    }
+
+    #[test]
+    fn non_auth_errors_are_not_auth_failure() {
+        assert!(!terminal_is_auth_failure(&error_outcome(
+            AgentErrorCode::UnknownUpstreamError
+        )));
+        assert!(!terminal_is_auth_failure(&error_outcome(
+            AgentErrorCode::UserLlmProviderRateLimited
+        )));
+        assert!(!terminal_is_auth_failure(&error_outcome(
+            AgentErrorCode::UserLlmProviderBillingRequired
+        )));
     }
 }


### PR DESCRIPTION
## Problem

The connection check that determines agent availability only runs `initialize` + `session/new` — it never sends a prompt. This means an agent that is connectable but unusable is still reported as "available". The clearest case is an ACP agent (e.g. kilo) that isn't signed in: `session/new` succeeds, so the agent shows online, but the very first real prompt fails — returning an empty `end_turn` or an explicit auth error.

Worse, this real-usage failure was never written back into availability. The turn orchestrator recorded such a turn as a session **success**, because an empty `end_turn` is a benign `Finish` (not an error terminal). The agent therefore kept showing as "available" even after real usage had proven it wasn't.

## Fix

Reflect only **explicit** auth signals from real turns back into availability, recording a session failure (`auth_required`) so the agent surfaces "needs sign-in" instead of "available":

- a turn ending with an `ACP_EMPTY_TURN_NEEDS_AUTH` tip, or
- an `Error` terminal carrying `USER_AGENT_AUTH_REQUIRED`, `USER_LLM_PROVIDER_AUTH_FAILED`, or `USER_LLM_PROVIDER_AWS_SSO_EXPIRED`.

This self-heals: a later successful turn flips the agent back online. Non-auth failures — generic empty turns, billing, rate-limit, context-length, and network errors — are deliberately excluded so they don't mark an otherwise-usable agent as needing sign-in.

### Changes

- `stream_relay`: `TurnAttemptSummary.needs_auth`, set from the needs-auth tip.
- `turn_orchestrator`: `terminal_is_auth_failure()` gates the availability write-back.
- Unit tests for both.

## Related

Builds on iOfficeAI/AionCore#653, which emits the `ACP_EMPTY_TURN_NEEDS_AUTH` tip, and its AionUi companion iOfficeAI/AionUi#3644.