### PR TITLE
fix(ci): restore main migration immutability guard

### DIFF
--- a/scripts/migration/check-immutability.ps1
+++ b/scripts/migration/check-immutability.ps1
@@ -37,16 +37,6 @@ if ($env:AIONCORE_ALLOW_MAIN_MIGRATION_EDIT -eq "1") {
 
 $baseRef = $env:AIONCORE_MIGRATION_BASE_REF
 if ([string]::IsNullOrWhiteSpace($baseRef)) {
-    $releaseTags = git tag --merged HEAD --list "v*" --sort=-version:refname
-    if ($LASTEXITCODE -ne 0) {
-        exit $LASTEXITCODE
-    }
-    $baseRef = $releaseTags |
-        Where-Object { $_ -match '^v[0-9]+\.[0-9]+\.[0-9]+$' } |
-        Select-Object -First 1
-}
-
-if ([string]::IsNullOrWhiteSpace($baseRef)) {
     git rev-parse --verify --quiet origin/main | Out-Null
     if ($LASTEXITCODE -eq 0) {
         $baseRef = "origin/main"
@@ -74,12 +64,12 @@ if ($LASTEXITCODE -ne 0) {
 
 $changed = git diff --name-status --diff-filter=DMR $baseCommit -- "crates/aionui-db/migrations/*.sql"
 if (-not [string]::IsNullOrWhiteSpace(($changed -join "`n"))) {
-    [Console]::Error.WriteLine("Released migration files must not be modified or deleted.")
+    [Console]::Error.WriteLine("Existing migration files from main must not be modified or deleted.")
     [Console]::Error.WriteLine("")
     [Console]::Error.WriteLine("Fix this by reverting changes to existing migration files and adding a new next-numbered migration instead.")
     [Console]::Error.WriteLine("If this is an intentional high-risk exception, rerun with AIONCORE_ALLOW_MAIN_MIGRATION_EDIT=1.")
     [Console]::Error.WriteLine("")
-    [Console]::Error.WriteLine("Changed released migrations:")
+    [Console]::Error.WriteLine("Changed existing migrations:")
     [Console]::Error.WriteLine(($changed -join "`n"))
     exit 1
 }

--- a/scripts/migration/check-immutability.sh
+++ b/scripts/migration/check-immutability.sh
@@ -47,13 +47,6 @@ fi
 
 base_ref="${AIONCORE_MIGRATION_BASE_REF:-}"
 if [[ -z "$base_ref" ]]; then
-    base_ref="$(
-        git tag --merged HEAD --list 'v*' --sort=-version:refname \
-            | awk '/^v[0-9]+\.[0-9]+\.[0-9]+$/ { print; exit }'
-    )"
-fi
-
-if [[ -z "$base_ref" ]]; then
     if git rev-parse --verify --quiet origin/main >/dev/null; then
         base_ref="origin/main"
     elif git rev-parse --verify --quiet main >/dev/null; then
@@ -76,12 +69,12 @@ changed="$(
 
 if [[ -n "$changed" ]]; then
     cat >&2 <<'EOF'
-Released migration files must not be modified or deleted.
+Existing migration files from main must not be modified or deleted.
 
 Fix this by reverting changes to existing migration files and adding a new next-numbered migration instead.
 If this is an intentional high-risk exception, rerun with AIONCORE_ALLOW_MAIN_MIGRATION_EDIT=1.
 
-Changed released migrations:
+Changed existing migrations:
 EOF
     echo "$changed" >&2
     exit 1

--- a/scripts/migration/check-immutability.test.ps1
+++ b/scripts/migration/check-immutability.test.ps1
@@ -98,7 +98,6 @@ function New-CaseRepo {
         Set-Content -LiteralPath "crates/aionui-db/migrations/manual_fixture.sql" -Value "-- auxiliary sql"
         Invoke-Native git add crates/aionui-db/migrations
         Invoke-Native git commit -q -m "seed migrations"
-        Invoke-Native git tag v1.0.0
         Invoke-Native git checkout -q -b feature
     } finally {
         Pop-Location
@@ -110,40 +109,30 @@ function New-CaseRepo {
 try {
     $modifiedRepo = New-CaseRepo "modified"
     Add-Content -LiteralPath (Join-Path $modifiedRepo "crates/aionui-db/migrations/001_initial_schema.sql") -Value "-- modified"
-    Invoke-InRepo $modifiedRepo 1 "Released migration files must not be modified or deleted" @{}
+    Invoke-InRepo $modifiedRepo 1 "Existing migration files from main must not be modified or deleted" @{ AIONCORE_MIGRATION_BASE_REF = "main" }
 
     $deletedRepo = New-CaseRepo "deleted"
     Remove-Item -LiteralPath (Join-Path $deletedRepo "crates/aionui-db/migrations/002_data_fix.sql")
-    Invoke-InRepo $deletedRepo 1 "Released migration files must not be modified or deleted" @{}
+    Invoke-InRepo $deletedRepo 1 "Existing migration files from main must not be modified or deleted" @{ AIONCORE_MIGRATION_BASE_REF = "main" }
 
     $auxiliaryRepo = New-CaseRepo "auxiliary"
     Add-Content -LiteralPath (Join-Path $auxiliaryRepo "crates/aionui-db/migrations/manual_fixture.sql") -Value "-- modified auxiliary sql"
-    Invoke-InRepo $auxiliaryRepo 1 "Released migration files must not be modified or deleted" @{}
+    Invoke-InRepo $auxiliaryRepo 1 "Existing migration files from main must not be modified or deleted" @{ AIONCORE_MIGRATION_BASE_REF = "main" }
 
     $addedRepo = New-CaseRepo "added"
     Set-Content -LiteralPath (Join-Path $addedRepo "crates/aionui-db/migrations/003_new_change.sql") -Value "-- 003 new migration"
-    Invoke-InRepo $addedRepo 0 "Migration immutability check passed" @{}
-
-    $unshippedRepo = New-CaseRepo "unshipped"
-    Set-Content -LiteralPath (Join-Path $unshippedRepo "crates/aionui-db/migrations/003_unshipped_change.sql") -Value "-- 003 unshipped migration"
-    Push-Location $unshippedRepo
-    try {
-        Invoke-Native git add crates/aionui-db/migrations/003_unshipped_change.sql
-        Invoke-Native git commit -q -m "add unshipped migration"
-        Invoke-Native git tag v1.1.0-rc.1
-        Invoke-Native git mv crates/aionui-db/migrations/003_unshipped_change.sql crates/aionui-db/migrations/004_unshipped_change.sql
-    } finally {
-        Pop-Location
-    }
-    Invoke-InRepo $unshippedRepo 0 "Migration immutability check passed" @{}
+    Invoke-InRepo $addedRepo 0 "Migration immutability check passed" @{ AIONCORE_MIGRATION_BASE_REF = "main" }
 
     $duplicateRepo = New-CaseRepo "duplicate"
     Set-Content -LiteralPath (Join-Path $duplicateRepo "crates/aionui-db/migrations/002_duplicate_change.sql") -Value "-- duplicate 002 migration"
-    Invoke-InRepo $duplicateRepo 1 "Duplicate database migration versions are not allowed" @{}
+    Invoke-InRepo $duplicateRepo 1 "Duplicate database migration versions are not allowed" @{ AIONCORE_MIGRATION_BASE_REF = "main" }
 
     $overrideRepo = New-CaseRepo "override"
     Add-Content -LiteralPath (Join-Path $overrideRepo "crates/aionui-db/migrations/001_initial_schema.sql") -Value "-- modified with explicit override"
-    Invoke-InRepo $overrideRepo 0 "skipping migration immutability check" @{ AIONCORE_ALLOW_MAIN_MIGRATION_EDIT = "1" }
+    Invoke-InRepo $overrideRepo 0 "skipping migration immutability check" @{
+        AIONCORE_MIGRATION_BASE_REF = "main"
+        AIONCORE_ALLOW_MAIN_MIGRATION_EDIT = "1"
+    }
 
     Write-Output "Migration immutability script tests passed"
 } finally {

--- a/scripts/migration/check-immutability.test.sh
+++ b/scripts/migration/check-immutability.test.sh
@@ -47,7 +47,6 @@ init_case_repo() {
         printf '%s\n' '-- auxiliary sql' > crates/aionui-db/migrations/manual_fixture.sql
         git add crates/aionui-db/migrations
         git commit -q -m "seed migrations"
-        git tag v1.0.0
         git checkout -q -b feature
     )
 
@@ -56,45 +55,32 @@ init_case_repo() {
 
 modified_repo="$(init_case_repo modified)"
 printf '%s\n' '-- modified' >> "$modified_repo/crates/aionui-db/migrations/001_initial_schema.sql"
-run_in_repo "$modified_repo" 1 "Released migration files must not be modified or deleted" \
-    bash "$script"
+run_in_repo "$modified_repo" 1 "Existing migration files from main must not be modified or deleted" \
+    env AIONCORE_MIGRATION_BASE_REF=main bash "$script"
 
 deleted_repo="$(init_case_repo deleted)"
 rm "$deleted_repo/crates/aionui-db/migrations/002_data_fix.sql"
-run_in_repo "$deleted_repo" 1 "Released migration files must not be modified or deleted" \
-    bash "$script"
+run_in_repo "$deleted_repo" 1 "Existing migration files from main must not be modified or deleted" \
+    env AIONCORE_MIGRATION_BASE_REF=main bash "$script"
 
 auxiliary_repo="$(init_case_repo auxiliary)"
 printf '%s\n' '-- modified auxiliary sql' >> "$auxiliary_repo/crates/aionui-db/migrations/manual_fixture.sql"
-run_in_repo "$auxiliary_repo" 1 "Released migration files must not be modified or deleted" \
-    bash "$script"
+run_in_repo "$auxiliary_repo" 1 "Existing migration files from main must not be modified or deleted" \
+    env AIONCORE_MIGRATION_BASE_REF=main bash "$script"
 
 added_repo="$(init_case_repo added)"
 printf '%s\n' '-- 003 new migration' > "$added_repo/crates/aionui-db/migrations/003_new_change.sql"
 run_in_repo "$added_repo" 0 "Migration immutability check passed" \
-    bash "$script"
-
-unshipped_repo="$(init_case_repo unshipped)"
-printf '%s\n' '-- 003 unshipped migration' > "$unshipped_repo/crates/aionui-db/migrations/003_unshipped_change.sql"
-(
-    cd "$unshipped_repo"
-    git add crates/aionui-db/migrations/003_unshipped_change.sql
-    git commit -q -m "add unshipped migration"
-    git tag v1.1.0-rc.1
-    git mv crates/aionui-db/migrations/003_unshipped_change.sql \
-        crates/aionui-db/migrations/004_unshipped_change.sql
-)
-run_in_repo "$unshipped_repo" 0 "Migration immutability check passed" \
-    bash "$script"
+    env AIONCORE_MIGRATION_BASE_REF=main bash "$script"
 
 duplicate_repo="$(init_case_repo duplicate)"
 printf '%s\n' '-- duplicate 002 migration' > "$duplicate_repo/crates/aionui-db/migrations/002_duplicate_change.sql"
 run_in_repo "$duplicate_repo" 1 "Duplicate database migration versions are not allowed" \
-    bash "$script"
+    env AIONCORE_MIGRATION_BASE_REF=main bash "$script"
 
 override_repo="$(init_case_repo override)"
 printf '%s\n' '-- modified with explicit override' >> "$override_repo/crates/aionui-db/migrations/001_initial_schema.sql"
 run_in_repo "$override_repo" 0 "skipping migration immutability check" \
-    env AIONCORE_ALLOW_MAIN_MIGRATION_EDIT=1 bash "$script"
+    env AIONCORE_MIGRATION_BASE_REF=main AIONCORE_ALLOW_MAIN_MIGRATION_EDIT=1 bash "$script"
 
 echo "Migration immutability script tests passed"


### PR DESCRIPTION
## Summary

- restore migration immutability checks to compare existing migrations against `origin/main` / `main`
- remove the temporary latest-release-tag baseline and its release-tag-specific test cases
- retain migration 027 and duplicate migration version detection in both Shell and PowerShell guards

## Why

PR #656 temporarily used the latest stable release tag as the immutability baseline so the duplicate migration number could be corrected before merge. Now that migration 027 is on `main`, the stricter main-based guard can be restored.

## Validation

- `bash scripts/migration/check-immutability.test.sh`
- `bash scripts/migration/check-immutability.sh`
- `git diff --check`
- `just push -u origin jiahe/fix/restore-main-migration-guard`

All available checks passed. PowerShell is not installed locally, so the paired PowerShell self-test is left to CI.

## Related PRs

- #656