### PR TITLE
fix(conversation): rebuild aionrs sessions from persisted runtime permission

### DIFF
--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -50,7 +50,7 @@ use crate::convert::{
     row_to_message_response_compact, row_to_response, row_to_response_with_extra, search_row_to_item, string_to_enum,
 };
 use crate::error::ConversationError;
-use crate::session_context::SessionContextBuilder;
+use crate::session_context::{AionrsRuntimePermissionSeed, SessionContextBuilder};
 use crate::skill_resolver::SkillResolver;
 use crate::skill_snapshot::{backfill_skills_if_missing, compute_initial_skills};
 use crate::turn_orchestrator::{ConversationTurnOrchestrator, ConversationTurnStatus, TurnStartInput};
@@ -3222,13 +3222,42 @@ impl ConversationService {
     /// Raw `conversation.extra` parsing lives in [`SessionContextBuilder`]
     /// so the task manager and concrete agent factories consume typed
     /// session context instead of the DB envelope.
+    /// Loads the persisted runtime permission gate inputs for an aionrs
+    /// rebuild. Returns `None` for non-aionrs conversations and for aionrs
+    /// conversations without a persisted assistant snapshot (assistant-less
+    /// sessions are out of scope — spec §5). This is the only place a
+    /// `conversation_repo` handle is needed, so the seed is computed here and
+    /// threaded into `SessionContextBuilder` (spec §7.3, A-2).
+    async fn load_aionrs_permission_seed(
+        &self,
+        row: &aionui_db::models::ConversationRow,
+    ) -> Result<Option<AionrsRuntimePermissionSeed>, ConversationError> {
+        if row.r#type != AgentType::Aionrs.serde_name() {
+            return Ok(None);
+        }
+        let snapshot = self
+            .conversation_repo
+            .get_assistant_snapshot(&row.id)
+            .await
+            .map_err(|e| {
+                ConversationError::internal(format!(
+                    "Failed to load assistant snapshot for aionrs permission seed: {e}"
+                ))
+            })?;
+        Ok(snapshot.map(|snapshot| AionrsRuntimePermissionSeed {
+            default_permission_mode: snapshot.default_permission_mode,
+            resolved_permission_value: snapshot.resolved_permission_value,
+        }))
+    }
+
     pub(crate) async fn build_task_options(
         &self,
         row: &aionui_db::models::ConversationRow,
     ) -> Result<BuildTaskOptions, ConversationError> {
         reject_deprecated_runtime_row(row)?;
+        let seed = self.load_aionrs_permission_seed(row).await?;
         SessionContextBuilder::new(&self.workspace_root, &self.agent_metadata_repo, &self.acp_session_repo)
-            .build_options(row)
+            .build_options(row, seed)
             .await
     }
 
@@ -3238,8 +3267,9 @@ impl ConversationService {
         workspace_override: Option<&str>,
     ) -> Result<BuildTaskOptions, ConversationError> {
         reject_deprecated_runtime_row(row)?;
+        let seed = self.load_aionrs_permission_seed(row).await?;
         SessionContextBuilder::new(&self.workspace_root, &self.agent_metadata_repo, &self.acp_session_repo)
-            .build_options_with_workspace_override(row, workspace_override)
+            .build_options_with_workspace_override(row, workspace_override, seed)
             .await
     }
 

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -3217,11 +3217,6 @@ pub(crate) fn agent_error_top_level_code(error: &AgentError) -> &'static str {
 }
 
 impl ConversationService {
-    /// Build typed agent runtime context from a conversation database row.
-    ///
-    /// Raw `conversation.extra` parsing lives in [`SessionContextBuilder`]
-    /// so the task manager and concrete agent factories consume typed
-    /// session context instead of the DB envelope.
     /// Loads the persisted runtime permission gate inputs for an aionrs
     /// rebuild. Returns `None` for non-aionrs conversations and for aionrs
     /// conversations without a persisted assistant snapshot (assistant-less
@@ -3250,6 +3245,11 @@ impl ConversationService {
         }))
     }
 
+    /// Build typed agent runtime context from a conversation database row.
+    ///
+    /// Raw `conversation.extra` parsing lives in [`SessionContextBuilder`]
+    /// so the task manager and concrete agent factories consume typed
+    /// session context instead of the DB envelope.
     pub(crate) async fn build_task_options(
         &self,
         row: &aionui_db::models::ConversationRow,

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -7465,3 +7465,54 @@ async fn aionrs_rebuild_fixed_mode_blocks_runtime_escalation() {
 
     assert_eq!(aionrs_session_mode(&options).as_deref(), Some("default"));
 }
+
+#[tokio::test]
+async fn cron_required_runtime_mode_wins_over_resolved_permission_seed() {
+    // AC#5 (hard): the per-turn `required_runtime_mode` override runs AFTER
+    // rebuild and MUST keep priority over the rebuild permission seed. Even for
+    // an `auto` aionrs session whose snapshot resolved value is yolo, a cron
+    // turn pinned to "default" applies "default" to the agent — the seed must
+    // not bypass or reorder this override.
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let (svc, broadcaster, repo) = make_service_with_mock_task_manager(task_mgr.clone());
+    let row = seed_aionrs_conversation_with_snapshot(&repo, "default", "auto", Some("yolo")).await;
+    broadcaster.take_events();
+
+    let agent = Arc::new(
+        MockAgent::new(&row.id)
+            .with_mode("yolo")
+            .with_config_options(vec![AcpConfigOptionDto {
+                id: "mode".to_owned(),
+                name: Some("Mode".to_owned()),
+                label: None,
+                description: None,
+                category: Some("mode".to_owned()),
+                option_type: "select".to_owned(),
+                current_value: Some("yolo".to_owned()),
+                options: Vec::new(),
+            }]),
+    );
+    task_mgr.insert_agent(&row.id, AgentInstance::Mock(agent.clone()));
+
+    let outcome = svc
+        .run_agent_turn(ConversationAgentTurnRequest {
+            user_id: "user_1".to_owned(),
+            conversation_id: row.id.clone(),
+            content: "run scheduled task".to_owned(),
+            files: Vec::new(),
+            inject_skills: Vec::new(),
+            required_runtime_mode: Some("default".to_owned()),
+            persist_user_message: true,
+            user_message_hidden: true,
+            on_started: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.status, ConversationAgentTurnStatus::Completed);
+    assert_eq!(
+        agent.set_config_option_calls.lock().unwrap().as_slice(),
+        &[("mode".to_owned(), "default".to_owned())],
+        "cron required-runtime-mode must override the rebuild permission seed"
+    );
+}

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -7367,3 +7367,101 @@ async fn insert_raw_message_persists_row_and_broadcasts_stream() {
     assert_eq!(data["data"]["content"], "from teammate");
     assert_eq!(data["data"]["teammate_message"], true);
 }
+
+// ── aionrs rebuild permission seed (Sentry 135525584) ──────────────
+
+/// Inserts an aionrs conversation whose `extra.session_mode` is the create-time
+/// value and persists an assistant snapshot carrying the runtime permission
+/// gate inputs (`default_permission_mode` / `resolved_permission_value`).
+async fn seed_aionrs_conversation_with_snapshot(
+    repo: &Arc<MockRepo>,
+    session_mode: &str,
+    default_permission_mode: &str,
+    resolved_permission_value: Option<&str>,
+) -> ConversationRow {
+    let row = ConversationRow {
+        id: format!("aionrs-seed-{}", aionui_common::generate_short_id()),
+        user_id: "user_1".into(),
+        name: "aionrs seed".into(),
+        r#type: "aionrs".into(),
+        extra: json!({
+            "session_mode": session_mode,
+            "workspace": ensure_test_workspace_path()
+        })
+        .to_string(),
+        model: None,
+        status: Some("finished".into()),
+        source: Some("aionui".into()),
+        channel_chat_id: None,
+        pinned: false,
+        pinned_at: None,
+        created_at: 1,
+        updated_at: 1,
+    };
+    repo.create(&row).await.unwrap();
+    repo.upsert_assistant_snapshot(&UpsertConversationAssistantSnapshotParams {
+        conversation_id: &row.id,
+        assistant_definition_id: "asstdef-seed",
+        assistant_id: "assistant-seed",
+        assistant_source: "builtin",
+        agent_id: "agent-seed",
+        rules_content: "",
+        default_model_mode: "auto",
+        resolved_model_id: None,
+        default_permission_mode,
+        resolved_permission_value,
+        default_thought_level_mode: "auto",
+        resolved_thought_level_value: None,
+        default_skills_mode: "auto",
+        resolved_skill_ids: "[]",
+        resolved_disabled_builtin_skill_ids: "[]",
+        default_mcps_mode: "auto",
+        resolved_mcp_ids: "[]",
+    })
+    .await
+    .unwrap();
+    row
+}
+
+fn aionrs_session_mode(options: &BuildTaskOptions) -> Option<String> {
+    match &options.context.kind {
+        AgentSessionKind::Aionrs(ctx) => ctx.config.session_mode.clone(),
+        AgentSessionKind::Acp(_) => panic!("expected Aionrs build options"),
+    }
+}
+
+#[tokio::test]
+async fn aionrs_rebuild_auto_mode_preserves_runtime_yolo() {
+    // AC#1: an `auto` aionrs session that was switched to yolo at runtime must
+    // keep yolo after a rebuild (model switch / agent restart).
+    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let row = seed_aionrs_conversation_with_snapshot(&repo, "default", "auto", Some("yolo")).await;
+
+    let options = svc.build_task_options(&row).await.unwrap();
+
+    assert_eq!(aionrs_session_mode(&options).as_deref(), Some("yolo"));
+}
+
+#[tokio::test]
+async fn aionrs_rebuild_existing_data_auto_overrides_create_time_seed() {
+    // AC#2: existing data — create-time non-yolo seed is overridden by the
+    // authoritative resolved runtime value.
+    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let row = seed_aionrs_conversation_with_snapshot(&repo, "auto_edit", "auto", Some("yolo")).await;
+
+    let options = svc.build_task_options(&row).await.unwrap();
+
+    assert_eq!(aionrs_session_mode(&options).as_deref(), Some("yolo"));
+}
+
+#[tokio::test]
+async fn aionrs_rebuild_fixed_mode_blocks_runtime_escalation() {
+    // AC#3 (hard safety gate): a `fixed` assistant must NOT adopt the runtime
+    // residue, even if `resolved_permission_value` was written to yolo.
+    let (svc, _broadcaster, repo, _task_mgr) = make_service();
+    let row = seed_aionrs_conversation_with_snapshot(&repo, "default", "fixed", Some("yolo")).await;
+
+    let options = svc.build_task_options(&row).await.unwrap();
+
+    assert_eq!(aionrs_session_mode(&options).as_deref(), Some("default"));
+}

--- a/crates/aionui-conversation/src/session_context.rs
+++ b/crates/aionui-conversation/src/session_context.rs
@@ -58,7 +58,8 @@ impl<'a> SessionContextBuilder<'a> {
         seed: Option<AionrsRuntimePermissionSeed>,
     ) -> Result<BuildTaskOptions, ConversationError> {
         Ok(BuildTaskOptions::new(
-            self.build_with_workspace_override(row, workspace_override, seed).await?,
+            self.build_with_workspace_override(row, workspace_override, seed)
+                .await?,
         ))
     }
 
@@ -390,9 +391,7 @@ fn build_aionrs_context(
     // resolved permission is intentionally NOT read back (centralized team
     // governance — same safety principle as `fixed`). Only non-team sessions
     // consult the persisted runtime permission.
-    if !belongs_to_team
-        && let Some(seed) = permission_seed
-    {
+    if !belongs_to_team && let Some(seed) = permission_seed {
         apply_runtime_permission_seed(seed, row, &mut config);
     }
     AionrsSessionBuildContext {
@@ -410,25 +409,20 @@ fn apply_runtime_permission_seed(
     row: &ConversationRow,
     config: &mut AionrsBuildExtra,
 ) {
-    match seed.default_permission_mode.as_str() {
-        // `auto`: remember and reuse the runtime selection. The resolved value
-        // is authoritative and MUST override the create-time seed.
-        "auto" => {
-            if let Some(resolved) = seed
-                .resolved_permission_value
-                .filter(|value| !value.is_empty())
-            {
-                debug!(
-                    conversation_id = %row.id,
-                    "session_context: aionrs rebuild seeded from resolved runtime permission"
-                );
-                config.session_mode = Some(resolved);
-            }
-        }
-        // `fixed` (and any unknown mode): keep the create-time seed
-        // (== create-time default_permission_value); never adopt the runtime
-        // residue — anti-privilege-escalation gate.
-        _ => {}
+    // `fixed` (and any unknown mode): keep the create-time seed
+    // (== create-time default_permission_value); never adopt the runtime
+    // residue — anti-privilege-escalation gate.
+    if seed.default_permission_mode != "auto" {
+        return;
+    }
+    // `auto`: remember and reuse the runtime selection. The resolved value is
+    // authoritative and MUST override the create-time seed.
+    if let Some(resolved) = seed.resolved_permission_value.filter(|value| !value.is_empty()) {
+        debug!(
+            conversation_id = %row.id,
+            "session_context: aionrs rebuild seeded from resolved runtime permission"
+        );
+        config.session_mode = Some(resolved);
     }
 }
 

--- a/crates/aionui-conversation/src/session_context.rs
+++ b/crates/aionui-conversation/src/session_context.rs
@@ -41,28 +41,40 @@ impl<'a> SessionContextBuilder<'a> {
         }
     }
 
-    pub(crate) async fn build_options(&self, row: &ConversationRow) -> Result<BuildTaskOptions, ConversationError> {
-        Ok(BuildTaskOptions::new(self.build(row).await?))
+    pub(crate) async fn build_options(
+        &self,
+        row: &ConversationRow,
+        seed: Option<AionrsRuntimePermissionSeed>,
+    ) -> Result<BuildTaskOptions, ConversationError> {
+        Ok(BuildTaskOptions::new(
+            self.build_with_workspace_override(row, None, seed).await?,
+        ))
     }
 
     pub(crate) async fn build_options_with_workspace_override(
         &self,
         row: &ConversationRow,
         workspace_override: Option<&str>,
+        seed: Option<AionrsRuntimePermissionSeed>,
     ) -> Result<BuildTaskOptions, ConversationError> {
         Ok(BuildTaskOptions::new(
-            self.build_with_workspace_override(row, workspace_override).await?,
+            self.build_with_workspace_override(row, workspace_override, seed).await?,
         ))
     }
 
+    /// Test-only convenience wrapper. Production entry points thread a real
+    /// permission seed via `build_options*`; tests exercise the default
+    /// (no-seed) path.
+    #[cfg(test)]
     async fn build(&self, row: &ConversationRow) -> Result<AgentSessionContext, ConversationError> {
-        self.build_with_workspace_override(row, None).await
+        self.build_with_workspace_override(row, None, None).await
     }
 
     async fn build_with_workspace_override(
         &self,
         row: &ConversationRow,
         workspace_override: Option<&str>,
+        seed: Option<AionrsRuntimePermissionSeed>,
     ) -> Result<AgentSessionContext, ConversationError> {
         let agent_type: AgentType = string_to_enum(&row.r#type)?;
         reject_deprecated_runtime_kind(row, &agent_type)?;
@@ -73,7 +85,7 @@ impl<'a> SessionContextBuilder<'a> {
         let team = TeamSessionBinding::from_extra_value(&extra).map_err(|e| ConversationError::BadRequest {
             reason: format!("Invalid Team runtime context: {e}"),
         })?;
-        let kind = self.build_kind(row, &agent_type, extra, team.clone()).await?;
+        let kind = self.build_kind(row, &agent_type, extra, team.clone(), seed).await?;
 
         Ok(AgentSessionContext {
             conversation: ConversationContext {
@@ -162,6 +174,7 @@ impl<'a> SessionContextBuilder<'a> {
         agent_type: &AgentType,
         extra: serde_json::Value,
         team: Option<TeamSessionBinding>,
+        seed: Option<AionrsRuntimePermissionSeed>,
     ) -> Result<AgentSessionKind, ConversationError> {
         match agent_type {
             AgentType::Acp => self
@@ -169,7 +182,7 @@ impl<'a> SessionContextBuilder<'a> {
                 .await
                 .map(|context| AgentSessionKind::Acp(Box::new(context))),
             AgentType::Aionrs => Ok(AgentSessionKind::Aionrs(Box::new(build_aionrs_context(
-                row, extra, team,
+                row, extra, team, seed,
             )))),
             AgentType::Gemini
             | AgentType::Codex

--- a/crates/aionui-conversation/src/session_context.rs
+++ b/crates/aionui-conversation/src/session_context.rs
@@ -337,10 +337,27 @@ impl<'a> SessionContextBuilder<'a> {
     }
 }
 
+/// Runtime permission gate inputs for an aionrs rebuild, loaded from the
+/// conversation's persisted assistant snapshot in the service layer
+/// (`ConversationService::load_aionrs_permission_seed`) and threaded down so
+/// `SessionContextBuilder` needs no `conversation_repo` handle.
+///
+/// - `default_permission_mode`: the assistant's permission mode (`auto` /
+///   `fixed`), decides whether the runtime value may be adopted.
+/// - `resolved_permission_value`: the last runtime-selected permission
+///   persisted on the snapshot; only honored under `auto` for non-team
+///   sessions.
+#[derive(Debug, Clone)]
+pub(crate) struct AionrsRuntimePermissionSeed {
+    pub default_permission_mode: String,
+    pub resolved_permission_value: Option<String>,
+}
+
 fn build_aionrs_context(
     row: &ConversationRow,
     extra: serde_json::Value,
     team: Option<TeamSessionBinding>,
+    permission_seed: Option<AionrsRuntimePermissionSeed>,
 ) -> AionrsSessionBuildContext {
     let mut config: AionrsBuildExtra = match serde_json::from_value(extra.clone()) {
         Ok(config) => config,
@@ -356,10 +373,49 @@ fn build_aionrs_context(
     config.user_id.get_or_insert_with(|| row.user_id.clone());
     apply_team_seed_to_aionrs_config(&team, &mut config);
     let belongs_to_team = team.is_some();
+    // Team-bound sessions keep the team seed / create-time value; runtime
+    // resolved permission is intentionally NOT read back (centralized team
+    // governance — same safety principle as `fixed`). Only non-team sessions
+    // consult the persisted runtime permission.
+    if !belongs_to_team
+        && let Some(seed) = permission_seed
+    {
+        apply_runtime_permission_seed(seed, row, &mut config);
+    }
     AionrsSessionBuildContext {
         config,
         team,
         belongs_to_team,
+    }
+}
+
+/// Applies the persisted runtime permission to the rebuild seed, honoring
+/// `default_permission_mode` semantics (spec §7.1/§7.2). Callers must ensure
+/// team-bound sessions never reach here.
+fn apply_runtime_permission_seed(
+    seed: AionrsRuntimePermissionSeed,
+    row: &ConversationRow,
+    config: &mut AionrsBuildExtra,
+) {
+    match seed.default_permission_mode.as_str() {
+        // `auto`: remember and reuse the runtime selection. The resolved value
+        // is authoritative and MUST override the create-time seed.
+        "auto" => {
+            if let Some(resolved) = seed
+                .resolved_permission_value
+                .filter(|value| !value.is_empty())
+            {
+                debug!(
+                    conversation_id = %row.id,
+                    "session_context: aionrs rebuild seeded from resolved runtime permission"
+                );
+                config.session_mode = Some(resolved);
+            }
+        }
+        // `fixed` (and any unknown mode): keep the create-time seed
+        // (== create-time default_permission_value); never adopt the runtime
+        // residue — anti-privilege-escalation gate.
+        _ => {}
     }
 }
 
@@ -1052,5 +1108,71 @@ mod tests {
             let err = repos.builder().build(&row).await.unwrap_err();
             assert_archived(err, "conv-1");
         }
+    }
+
+    fn aionrs_seed(mode: &str, resolved: Option<&str>) -> AionrsRuntimePermissionSeed {
+        AionrsRuntimePermissionSeed {
+            default_permission_mode: mode.to_owned(),
+            resolved_permission_value: resolved.map(ToOwned::to_owned),
+        }
+    }
+
+    #[test]
+    fn aionrs_auto_mode_rebuild_adopts_resolved_permission_value() {
+        // AC#1: auto happy path — runtime yolo survives rebuild.
+        let row = row("aionrs", serde_json::json!({ "session_mode": "default" }), None);
+        let ctx = build_aionrs_context(
+            &row,
+            serde_json::json!({ "session_mode": "default" }),
+            None,
+            Some(aionrs_seed("auto", Some("yolo"))),
+        );
+        assert_eq!(ctx.config.session_mode.as_deref(), Some("yolo"));
+    }
+
+    #[test]
+    fn aionrs_auto_mode_resolved_overrides_create_time_seed() {
+        // AC#2: existing-data compat — create-time non-yolo seed is overridden.
+        let row = row("aionrs", serde_json::json!({ "session_mode": "auto_edit" }), None);
+        let ctx = build_aionrs_context(
+            &row,
+            serde_json::json!({ "session_mode": "auto_edit" }),
+            None,
+            Some(aionrs_seed("auto", Some("yolo"))),
+        );
+        assert_eq!(ctx.config.session_mode.as_deref(), Some("yolo"));
+    }
+
+    #[test]
+    fn aionrs_fixed_mode_ignores_resolved_permission_value() {
+        // AC#3: fixed safety gate — runtime residue must NOT escalate.
+        let row = row("aionrs", serde_json::json!({ "session_mode": "default" }), None);
+        let ctx = build_aionrs_context(
+            &row,
+            serde_json::json!({ "session_mode": "default" }),
+            None,
+            Some(aionrs_seed("fixed", Some("yolo"))),
+        );
+        assert_eq!(ctx.config.session_mode.as_deref(), Some("default"));
+    }
+
+    #[test]
+    fn aionrs_team_bound_session_ignores_resolved_permission_value() {
+        // Team-bound governance: keep team seed, never read resolved runtime value.
+        let team = TeamSessionBinding::from_extra_value(&serde_json::json!({
+            "teamId": "team-1",
+            "slot_id": "worker-1",
+            "role": "teammate",
+            "session_mode": "auto_edit"
+        }))
+        .unwrap();
+        let row = row("aionrs", serde_json::json!({ "session_mode": "auto_edit" }), None);
+        let ctx = build_aionrs_context(
+            &row,
+            serde_json::json!({ "session_mode": "auto_edit" }),
+            team,
+            Some(aionrs_seed("auto", Some("yolo"))),
+        );
+        assert_eq!(ctx.config.session_mode.as_deref(), Some("auto_edit"));
     }
 }


### PR DESCRIPTION
## Summary

Within a single aionrs conversation, switching the model reset the user-selected permission mode (e.g. "yolo" / full-auto), forcing the user to re-pick the permission mode on every switch. This is a repeated interaction defect (Sentry 135525584 / ELECTRON-3MQ) — not a crash or data loss.

**Root cause:** two persistence channels were disconnected. The runtime permission selection was persisted to `assistant_snapshot.resolved_permission_value`, but on session rebuild `build_aionrs_context` seeded the permission mode only from the create-time `extra.session_mode` (and the team seed) and never read back the persisted runtime value. Switching the model kills the running agent (expected AionUi behavior); the next message rebuilds the aionrs session and the seed falls back to the create-time mode, presenting as "the permission mode was reset". Model switching is just the most common forced-rebuild trigger; any agent restart reproduces it.

## Changes

Adopts the confirmed approach: read back the persisted runtime permission on the rebuild path and apply it as the seed under a safety gate. **AionCore only** — AionUi is not modified.

1. **Service layer loads the seed** (`service.rs`): new `ConversationService::load_aionrs_permission_seed` reads `conversation_repo.get_assistant_snapshot(&row.id)` for aionrs sessions only and packages `(default_permission_mode, resolved_permission_value)` into a new `AionrsRuntimePermissionSeed` value object; non-aionrs or snapshot-less sessions return `None`. `build_task_options` / `build_task_options_for_runtime` compute the seed and inject it into the build entry points.
2. **Build chain threading** (`session_context.rs`): `build_options` / `build_options_with_workspace_override` / `build_with_workspace_override` / `build_kind` take a new `seed: Option<AionrsRuntimePermissionSeed>` parameter, threaded into the aionrs branch's `build_aionrs_context`. The old private `build` becomes a `#[cfg(test)]` convenience wrapper (passing `None`). No repository dependency was added to `SessionContextBuilder::new`; the seed is a threaded parameter only.
3. **Gated application** (`session_context.rs`): new `apply_runtime_permission_seed`. The gate is entered only for non-team-bound sessions; for `auto` mode with a non-empty `resolved_permission_value` it overrides the create-time `session_mode` (with an added `debug!` state-transition log); `fixed` and any unknown mode keep the create-time seed (structurally cannot adopt runtime residue); team-bound sessions skip the read-back and keep the team seed.

## Safety / anti-privilege-escalation

- `fixed` mode never adopts runtime residue (AC#3, covered by unit + integration tests).
- Team-bound sessions always keep the team seed (team-bound gate test).
- The per-turn cron `required_runtime_mode` override still takes priority over the rebuild seed (AC#5 — `turn_orchestrator::apply_required_runtime_mode` untouched).

## No schema impact

No DB schema change, migration, or backfill. The rebuild path performs one additional **read-only** `get_assistant_snapshot`, reusing the existing `default_permission_mode` / `resolved_permission_value` columns. No new columns/tables/indexes and no write-contract changes.

## Testing

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace -- -D warnings` — zero warnings.
- `cargo test -p aionui-conversation` — 319 lib tests + integration suites, 0 failures. Includes 4 new gate unit tests, 3 rebuild integration tests (AC#1 auto preserves yolo / AC#2 auto overrides create-time seed / AC#3 fixed blocks escalation), and 1 cron priority regression test (AC#5).
- Consume-side regression: `cargo test -p aionui-ai-agent` — 654 passed, 0 failed (confirms `session_mode` value space and `parse_session_mode` fallback are unaffected; that crate is unchanged).
- Full push gate: `just push` (migration-check → lint-fix → fmt → test) — `cargo nextest run --workspace` reported 6855 passed, 18 skipped, 0 failures.

## Reviewer notes

- The gate ships as an early-return `if default_permission_mode != "auto" { return; }` guard rather than a two-arm `match` — semantics are identical; rewritten to satisfy clippy `match_like_matches`.
- Known limitation (out of scope): assistant-less aionrs sessions have no persisted `resolved_permission_value`; the seed returns `None` and behavior is unchanged. Not reachable in the current version chain.
- Manual verification still recommended: in a real app, set yolo in an aionrs conversation → switch model → send the next message → confirm the permission capsule and actual execution mode remain yolo.
