### PR TITLE
fix(acp): harden grok startup environment and npx recovery

### DIFF
--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -7,9 +7,10 @@ use crate::error::AgentError;
 use crate::factory::acp_assembler::AcpSessionParams;
 use crate::manager::acp::{AcpSession, AcpSessionEvent, PermissionRouter, SessionNewPreludeHook};
 use crate::manager::process_registry::{register_session_process, unregister_agent_process};
-use crate::protocol::acp::AcpProtocol;
+use crate::protocol::acp::{AcpProtocol, PermissionRequest};
 use crate::protocol::error::{AcpError, CloseReason};
 use crate::protocol::events::AgentStreamEvent;
+use crate::protocol::npx_cache_repair::CorruptNpxCacheRepair;
 use crate::protocol::send_error::AgentSendError;
 use crate::registry::CatalogSender;
 use crate::shared_kernel::{ConfigKey, ConfigValue, ModeId, ModelId, SessionId as DomainSessionId};
@@ -83,6 +84,13 @@ use super::mode_normalize::normalize_requested_mode_for_available_values;
 const ACP_KILL_GRACE_MS: u64 = 500;
 const OBSERVED_CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(10);
 
+struct AcpStartupConnection {
+    process: Arc<CliAgentProcess>,
+    protocol: AcpProtocol,
+    permission_rx: mpsc::Receiver<PermissionRequest>,
+    notification_rx: mpsc::Receiver<SessionNotification>,
+}
+
 /// Decompose a child `ExitStatus` (or its absence) into the
 /// `(exit_code, signal)` pair that `AcpError::StartupCrash` /
 /// `AcpError::Disconnected` carry.
@@ -107,6 +115,139 @@ pub(super) fn exit_status_parts(exit: Option<std::process::ExitStatus>) -> (Opti
         }
     }
     (status.code(), None)
+}
+
+enum AcpStartupConnectError {
+    Agent(AgentError),
+    StartupCrash {
+        exit_code: Option<i32>,
+        signal: Option<String>,
+        stderr: String,
+    },
+}
+
+impl AcpStartupConnectError {
+    fn into_agent_error(self) -> AgentError {
+        match self {
+            Self::Agent(error) => error,
+            Self::StartupCrash {
+                exit_code,
+                signal,
+                stderr,
+            } => AgentError::from(AcpError::StartupCrash {
+                exit_code,
+                signal,
+                stderr,
+            }),
+        }
+    }
+}
+
+async fn spawn_and_connect_acp(
+    params: &AcpSessionParams,
+    runtime: &AgentRuntime,
+) -> Result<AcpStartupConnection, AgentError> {
+    let mut corrupt_npx_cache_repair = CorruptNpxCacheRepair::default();
+
+    loop {
+        match spawn_and_connect_acp_once(params, runtime).await {
+            Ok(connection) => return Ok(connection),
+            Err(AcpStartupConnectError::StartupCrash {
+                exit_code,
+                signal,
+                stderr,
+            }) => {
+                if let Some(cache_entry) = corrupt_npx_cache_repair.try_repair(&stderr) {
+                    info!(
+                        conversation_id = %params.conversation_id,
+                        backend = params.metadata.backend.as_deref().unwrap_or("-"),
+                        npm_npx_cache_entry = %cache_entry.display(),
+                        "Cleared corrupt npm npx cache after ACP startup crash; retrying startup once"
+                    );
+                    continue;
+                }
+
+                return Err(AgentError::from(AcpError::StartupCrash {
+                    exit_code,
+                    signal,
+                    stderr,
+                }));
+            }
+            Err(error) => return Err(error.into_agent_error()),
+        }
+    }
+}
+
+async fn spawn_and_connect_acp_once(
+    params: &AcpSessionParams,
+    runtime: &AgentRuntime,
+) -> Result<AcpStartupConnection, AcpStartupConnectError> {
+    let process = Arc::new(
+        CliAgentProcess::spawn_for_sdk(params.command_spec.clone())
+            .await
+            .map_err(AcpStartupConnectError::Agent)?,
+    );
+    register_session_process(
+        &params.data_dir,
+        Arc::clone(&process),
+        params.conversation_id.clone(),
+        AgentType::Acp,
+        params.metadata.backend.clone(),
+        Some(format!(
+            "{} {}",
+            params.command_spec.command.display(),
+            params.command_spec.args.join(" ")
+        )),
+    )
+    .map_err(AcpStartupConnectError::Agent)?;
+    let (stdin, stdout) = process.take_stdio().await.ok_or_else(|| {
+        error!(conversation_id = %params.conversation_id, "Failed to take stdio from CLI process");
+        let _ = unregister_agent_process(&params.data_dir, process.pid());
+        AcpStartupConnectError::Agent(AgentError::internal("Failed to take stdio from CLI process"))
+    })?;
+
+    let (notification_tx, notification_rx) = mpsc::channel::<SessionNotification>(256);
+    let (permission_tx, permission_rx) = mpsc::channel(32);
+
+    // Race the handshake against process exit. The SDK's stdout EOF
+    // detection can lag (observed: 30s on Windows when the agent dies
+    // 70ms in — ELECTRON-1BT), so we explicitly watch the child. If
+    // it dies before init completes, surface a `StartupCrash` carrying
+    // the buffered stderr instead of waiting out the timeout.
+    let connect_fut = AcpProtocol::connect(stdin, stdout, runtime.event_sender(), permission_tx, notification_tx);
+    tokio::pin!(connect_fut);
+    let protocol = tokio::select! {
+        biased;
+        exit = process.wait_for_exit() => {
+            let stderr = process.peek_stderr_tail(64).await;
+            let (exit_code, signal) = exit_status_parts(exit);
+            error!(
+                conversation_id = %params.conversation_id,
+                exit_code = ?exit_code,
+                signal = ?signal,
+                stderr = %stderr,
+                "Agent process exited before ACP handshake completed"
+            );
+            let _ = unregister_agent_process(&params.data_dir, process.pid());
+            return Err(AcpStartupConnectError::StartupCrash { exit_code, signal, stderr });
+        }
+        res = &mut connect_fut => res.map_err(|e| {
+            error!(
+                conversation_id = %params.conversation_id,
+                error = %ErrorChain(&e),
+                "Failed to establish ACP protocol connection"
+            );
+            let _ = unregister_agent_process(&params.data_dir, process.pid());
+            AcpStartupConnectError::Agent(AgentError::from(e))
+        })?,
+    };
+
+    Ok(AcpStartupConnection {
+        process,
+        protocol,
+        permission_rx,
+        notification_rx,
+    })
 }
 
 fn initial_mode_from_params(params: &AcpSessionParams) -> Option<ModeId> {
@@ -406,65 +547,19 @@ impl AcpAgentManager {
         ),
         AgentError,
     > {
-        let process = Arc::new(CliAgentProcess::spawn_for_sdk(params.command_spec.clone()).await?);
-        register_session_process(
-            &params.data_dir,
-            Arc::clone(&process),
-            params.conversation_id.clone(),
-            AgentType::Acp,
-            params.metadata.backend.clone(),
-            Some(format!(
-                "{} {}",
-                params.command_spec.command.display(),
-                params.command_spec.args.join(" ")
-            )),
-        )?;
-        let (stdin, stdout) = process.take_stdio().await.ok_or_else(|| {
-            error!(conversation_id = %params.conversation_id, "Failed to take stdio from CLI process");
-            let _ = unregister_agent_process(&params.data_dir, process.pid());
-            AgentError::internal("Failed to take stdio from CLI process")
-        })?;
-
         // Dedicated channel for raw SDK SessionNotifications → session tracker.
         // This channel is separate from event_tx so the tracker never re-applies
         // events that were broadcast for the UI (e.g. from emit_snapshot_events).
-        let (notification_tx, notification_rx) = mpsc::channel::<SessionNotification>(256);
         let (domain_event_tx, domain_event_rx) = mpsc::channel(256);
-        let (permission_tx, permission_rx) = mpsc::channel(32);
         let runtime = AgentRuntime::new(params.conversation_id.clone(), params.workspace.path.clone(), 256);
 
-        // Race the handshake against process exit. The SDK's stdout EOF
-        // detection can lag (observed: 30s on Windows when the agent dies
-        // 70ms in — ELECTRON-1BT), so we explicitly watch the child. If
-        // it dies before init completes, surface a `StartupCrash` carrying
-        // the buffered stderr instead of waiting out the timeout.
-        let connect_fut = AcpProtocol::connect(stdin, stdout, runtime.event_sender(), permission_tx, notification_tx);
-        tokio::pin!(connect_fut);
-        let protocol = tokio::select! {
-            biased;
-            exit = process.wait_for_exit() => {
-                let stderr = process.peek_stderr_tail(64).await;
-                let (exit_code, signal) = exit_status_parts(exit);
-                error!(
-                    conversation_id = %params.conversation_id,
-                    exit_code = ?exit_code,
-                    signal = ?signal,
-                    stderr = %stderr,
-                    "Agent process exited before ACP handshake completed"
-                );
-                let _ = unregister_agent_process(&params.data_dir, process.pid());
-                return Err(AgentError::from(AcpError::StartupCrash { exit_code, signal, stderr }));
-            }
-            res = &mut connect_fut => res.map_err(|e| {
-                error!(
-                    conversation_id = %params.conversation_id,
-                    error = %ErrorChain(&e),
-                    "Failed to establish ACP protocol connection"
-                );
-                let _ = unregister_agent_process(&params.data_dir, process.pid());
-                AgentError::from(e)
-            })?,
-        };
+        let startup = spawn_and_connect_acp(&params, &runtime).await?;
+        let AcpStartupConnection {
+            process,
+            protocol,
+            permission_rx,
+            notification_rx,
+        } = startup;
         let permission_router = Arc::new(PermissionRouter::new(permission_rx));
 
         let snapshot = params.session_snapshot.as_ref();

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -157,7 +157,7 @@ async fn spawn_and_connect_acp(
                 signal,
                 stderr,
             }) => {
-                if let Some(cache_entry) = corrupt_npx_cache_repair.try_repair(&stderr) {
+                if let Some(cache_entry) = corrupt_npx_cache_repair.try_repair(&params.command_spec, &stderr) {
                     info!(
                         conversation_id = %params.conversation_id,
                         backend = params.metadata.backend.as_deref().unwrap_or("-"),

--- a/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
+++ b/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
@@ -155,7 +155,7 @@ pub(crate) async fn acp_probe_command_spec(spec: CommandSpec) -> TryConnectCusto
     loop {
         match acp_probe_command_spec_once(spec.clone()).await {
             ProbeOutcome::Fail(error) => {
-                if let Some(cache_entry) = corrupt_npx_cache_repair.try_repair(&error) {
+                if let Some(cache_entry) = corrupt_npx_cache_repair.try_repair(&spec, &error) {
                     tracing::info!(
                         npm_npx_cache_entry = %cache_entry.display(),
                         "Cleared corrupt npm npx cache after ACP probe startup crash; retrying probe once"

--- a/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
+++ b/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
@@ -24,6 +24,7 @@ use tracing::{debug, warn};
 use crate::capability::cli_process::CliAgentProcess;
 use crate::protocol::acp::AcpProtocol;
 use crate::protocol::error::AcpError;
+use crate::protocol::npx_cache_repair::CorruptNpxCacheRepair;
 
 use agent_client_protocol::schema::NewSessionRequest;
 
@@ -149,20 +150,37 @@ impl Drop for ProbeProcessGuard<'_> {
 /// (e.g. gemini logged out) surface as [`TryConnectCustomAgentResponse::FailAuth`]
 /// rather than appearing online.
 pub(crate) async fn acp_probe_command_spec(spec: CommandSpec) -> TryConnectCustomAgentResponse {
+    let mut corrupt_npx_cache_repair = CorruptNpxCacheRepair::default();
+
+    loop {
+        match acp_probe_command_spec_once(spec.clone()).await {
+            ProbeOutcome::Fail(error) => {
+                if let Some(cache_entry) = corrupt_npx_cache_repair.try_repair(&error) {
+                    tracing::info!(
+                        npm_npx_cache_entry = %cache_entry.display(),
+                        "Cleared corrupt npm npx cache after ACP probe startup crash; retrying probe once"
+                    );
+                    continue;
+                }
+
+                return TryConnectCustomAgentResponse::FailAcp { error };
+            }
+            outcome => return outcome.into_response(),
+        }
+    }
+}
+
+async fn acp_probe_command_spec_once(spec: CommandSpec) -> ProbeOutcome {
     let proc = match CliAgentProcess::spawn_for_sdk(spec).await {
         Ok(proc) => proc,
-        Err(e) => {
-            return TryConnectCustomAgentResponse::FailAcp {
-                error: format!("spawn failed: {e}"),
-            };
-        }
+        Err(e) => return ProbeOutcome::Fail(format!("spawn failed: {e}")),
     };
 
     // From here on, the process tree is reaped on every exit path, including
     // cancellation when an outer timeout drops this future.
     let _guard = ProbeProcessGuard { proc: &proc };
 
-    run_handshake(&proc).await.into_response()
+    run_handshake(&proc).await
 }
 
 /// Result of the Step 2 probe (`initialize` + `session/new`).

--- a/crates/aionui-ai-agent/src/protocol/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/mod.rs
@@ -3,4 +3,5 @@ pub(crate) mod cli_detect;
 pub(crate) mod custom_agent_probe;
 pub(crate) mod error;
 pub mod events;
+pub(crate) mod npx_cache_repair;
 pub mod send_error;

--- a/crates/aionui-ai-agent/src/protocol/npx_cache_repair.rs
+++ b/crates/aionui-ai-agent/src/protocol/npx_cache_repair.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 
+use aionui_common::CommandSpec;
 use aionui_common::ErrorChain;
+use sha2::{Digest, Sha512};
 use tracing::warn;
 
 #[derive(Default)]
@@ -9,22 +11,170 @@ pub(crate) struct CorruptNpxCacheRepair {
 }
 
 impl CorruptNpxCacheRepair {
-    pub(crate) fn try_repair(&mut self, stderr: &str) -> Option<PathBuf> {
+    pub(crate) fn try_repair(&mut self, command_spec: &CommandSpec, stderr: &str) -> Option<PathBuf> {
         if self.repaired {
             return None;
         }
 
-        let cache_entry = repair_corrupt_npx_cache_from_stderr(stderr)?;
+        let cache_entry = repair_corrupt_npx_cache(command_spec, stderr)?;
         self.repaired = true;
         Some(cache_entry)
     }
 }
 
-pub(crate) fn repair_corrupt_npx_cache_from_stderr(stderr: &str) -> Option<PathBuf> {
+pub(crate) fn repair_corrupt_npx_cache(command_spec: &CommandSpec, stderr: &str) -> Option<PathBuf> {
+    if let Some(cache_entry) = computed_corrupt_npx_cache_entry(command_spec)
+        && clear_npx_cache_entry(&cache_entry, MissingEntryPolicy::Skip).is_some()
+    {
+        return Some(cache_entry);
+    }
+
     let cache_entry = corrupt_npx_cache_entry_from_stderr(stderr)?;
-    match std::fs::remove_dir_all(&cache_entry) {
-        Ok(()) => Some(cache_entry),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Some(cache_entry),
+    clear_npx_cache_entry(&cache_entry, MissingEntryPolicy::Repaired)
+}
+
+fn computed_corrupt_npx_cache_entry(command_spec: &CommandSpec) -> Option<PathBuf> {
+    let npx_cache_entry = computed_npx_cache_entry(command_spec)?;
+    if npx_cache_entry.join("package.json").exists() {
+        return None;
+    }
+    if !npx_cache_entry.exists() {
+        return None;
+    }
+    Some(npx_cache_entry)
+}
+
+fn computed_npx_cache_entry(command_spec: &CommandSpec) -> Option<PathBuf> {
+    let npm_cache = command_spec_env(command_spec, "npm_config_cache")?;
+    let packages = npx_package_specs(command_spec)?;
+    let hash = npm_npx_cache_hash(&packages);
+    Some(PathBuf::from(npm_cache).join("_npx").join(hash))
+}
+
+fn command_spec_env<'a>(command_spec: &'a CommandSpec, name: &str) -> Option<&'a str> {
+    command_spec
+        .env
+        .iter()
+        .rev()
+        .find(|entry| entry.name == name)
+        .map(|entry| entry.value.as_str())
+}
+
+fn npx_package_specs(command_spec: &CommandSpec) -> Option<Vec<String>> {
+    let npx_args = npx_cli_args(command_spec)?;
+    let packages = explicit_npx_package_specs(npx_args);
+    if !packages.is_empty() {
+        return Some(packages);
+    }
+
+    first_npx_positional_package(npx_args).map(|package| vec![package])
+}
+
+fn npx_cli_args(command_spec: &CommandSpec) -> Option<&[String]> {
+    let command_name = command_spec.command.file_name()?.to_string_lossy();
+    if is_npx_executable(&command_name) {
+        return Some(command_spec.args.as_slice());
+    }
+
+    let (first, rest) = command_spec.args.split_first()?;
+    if first.ends_with("npx-cli.js") || first.ends_with("npx-cli.cjs") {
+        return Some(rest);
+    }
+
+    None
+}
+
+fn is_npx_executable(command_name: &str) -> bool {
+    command_name == "npx" || command_name == "npx.cmd" || command_name == "npx.exe"
+}
+
+fn explicit_npx_package_specs(args: &[String]) -> Vec<String> {
+    let mut packages = Vec::new();
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            break;
+        }
+        if arg == "--package" || arg == "-p" {
+            if let Some(value) = iter.next()
+                && !value.trim().is_empty()
+            {
+                packages.push(value.clone());
+            }
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("--package=") {
+            if !value.trim().is_empty() {
+                packages.push(value.to_owned());
+            }
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("-p=")
+            && !value.trim().is_empty()
+        {
+            packages.push(value.to_owned());
+        }
+    }
+    packages
+}
+
+fn first_npx_positional_package(args: &[String]) -> Option<String> {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            return iter.next().filter(|value| !value.trim().is_empty()).cloned();
+        }
+        if arg == "--package"
+            || arg == "-p"
+            || arg == "--cache"
+            || arg == "--userconfig"
+            || arg == "--call"
+            || arg == "-c"
+            || arg == "--script-shell"
+            || arg == "--shell"
+        {
+            let _ = iter.next();
+            continue;
+        }
+        if arg.starts_with("--package=")
+            || arg.starts_with("-p=")
+            || arg.starts_with("--cache=")
+            || arg.starts_with("--userconfig=")
+            || arg.starts_with("--call=")
+            || arg.starts_with("-c=")
+            || arg.starts_with("--script-shell=")
+            || arg.starts_with("--shell=")
+        {
+            continue;
+        }
+        if arg.starts_with('-') {
+            continue;
+        }
+        return Some(arg.clone());
+    }
+    None
+}
+
+fn npm_npx_cache_hash(packages: &[String]) -> String {
+    let mut packages = packages.to_vec();
+    packages.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+    let input = packages.join("\n");
+    let digest = Sha512::digest(input.as_bytes());
+    hex::encode(digest)[..16].to_owned()
+}
+
+enum MissingEntryPolicy {
+    Repaired,
+    Skip,
+}
+
+fn clear_npx_cache_entry(cache_entry: &Path, missing_policy: MissingEntryPolicy) -> Option<PathBuf> {
+    match std::fs::remove_dir_all(cache_entry) {
+        Ok(()) => Some(cache_entry.to_path_buf()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => match missing_policy {
+            MissingEntryPolicy::Repaired => Some(cache_entry.to_path_buf()),
+            MissingEntryPolicy::Skip => None,
+        },
         Err(error) => {
             warn!(
                 npm_npx_cache_entry = %cache_entry.display(),
@@ -38,48 +188,169 @@ pub(crate) fn repair_corrupt_npx_cache_from_stderr(stderr: &str) -> Option<PathB
 
 fn corrupt_npx_cache_entry_from_stderr(stderr: &str) -> Option<PathBuf> {
     let lower = stderr.to_ascii_lowercase();
-    if !lower.contains("_npx") || !lower.contains("package.json") {
+    if !lower.contains("_npx") {
         return None;
     }
-    if !lower.contains("enoent") && !lower.contains("could not read package.json") {
+    if !has_corrupt_npx_cache_signal(&lower) {
         return None;
     }
 
-    stderr.lines().find_map(|line| {
-        let path = parse_npm_error_path(line)?;
-        npx_cache_entry_from_package_json_path(&path)
-    })
+    find_npx_cache_entry_path(stderr)
 }
 
-fn parse_npm_error_path(line: &str) -> Option<PathBuf> {
-    let trimmed = line.trim();
-    for marker in ["npm error path ", "npm ERR! path "] {
-        if let Some(path) = trimmed.strip_prefix(marker) {
-            let path = path.trim().trim_matches('"').trim_matches('\'');
-            if !path.is_empty() {
-                return Some(PathBuf::from(path));
-            }
+fn has_corrupt_npx_cache_signal(lower: &str) -> bool {
+    lower.contains("enoent")
+        || lower.contains("could not read package.json")
+        || lower.contains("cannot find module")
+        || lower.contains("no such file or directory")
+}
+
+fn find_npx_cache_entry_path(stderr: &str) -> Option<PathBuf> {
+    let bytes = stderr.as_bytes();
+    let lower = stderr.to_ascii_lowercase();
+    let mut offset = 0;
+
+    while let Some(relative_index) = lower[offset..].find("_npx") {
+        let marker_index = offset + relative_index;
+        if let Some(cache_entry) = npx_cache_entry_around_marker(stderr, bytes, marker_index) {
+            return Some(cache_entry);
         }
+        offset = marker_index + "_npx".len();
     }
+
     None
 }
 
-fn npx_cache_entry_from_package_json_path(path: &Path) -> Option<PathBuf> {
-    if path.file_name()? != "package.json" {
+fn npx_cache_entry_around_marker(stderr: &str, bytes: &[u8], marker_index: usize) -> Option<PathBuf> {
+    let start = path_start_before_marker(bytes, marker_index);
+    let end = path_end_after_marker(bytes, marker_index);
+    let candidate = stderr.get(start..end)?.trim_matches(path_quote_or_punctuation);
+    cache_entry_from_npx_path(candidate)
+}
+
+fn path_start_before_marker(bytes: &[u8], marker_index: usize) -> usize {
+    let mut start = marker_index;
+    while start > 0 {
+        let byte = bytes[start - 1];
+        if is_path_boundary(byte) {
+            break;
+        }
+        start -= 1;
+    }
+    start
+}
+
+fn path_end_after_marker(bytes: &[u8], marker_index: usize) -> usize {
+    let mut end = marker_index + "_npx".len();
+    while end < bytes.len() {
+        let byte = bytes[end];
+        if is_path_boundary(byte) {
+            break;
+        }
+        end += 1;
+    }
+    end
+}
+
+fn is_path_boundary(byte: u8) -> bool {
+    byte.is_ascii_whitespace()
+        || matches!(
+            byte,
+            b'"' | b'\'' | b'`' | b'<' | b'>' | b'(' | b')' | b'[' | b']' | b'{' | b'}'
+        )
+}
+
+fn path_quote_or_punctuation(ch: char) -> bool {
+    matches!(
+        ch,
+        '"' | '\'' | '`' | '<' | '>' | '(' | ')' | '[' | ']' | '{' | '}' | ',' | ';' | ':'
+    )
+}
+
+fn cache_entry_from_npx_path(path: &str) -> Option<PathBuf> {
+    let parts = split_path_with_separators(path);
+    let npx_index = parts
+        .iter()
+        .position(|part| part.segment.eq_ignore_ascii_case("_npx"))?;
+    if npx_index == 0 {
         return None;
     }
-    let cache_entry = path.parent()?;
-    let npx_dir = cache_entry.parent()?;
-    if npx_dir.file_name()?.to_string_lossy().eq_ignore_ascii_case("_npx") {
-        Some(cache_entry.to_path_buf())
-    } else {
-        None
+    let entry_index = npx_index + 1;
+    if parts.get(entry_index)?.segment.is_empty() {
+        return None;
     }
+
+    let end = parts[entry_index].end;
+    Some(PathBuf::from(path[..end].to_owned()))
+}
+
+#[derive(Debug)]
+struct PathPart<'a> {
+    segment: &'a str,
+    end: usize,
+}
+
+fn split_path_with_separators(path: &str) -> Vec<PathPart<'_>> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+
+    for (index, ch) in path.char_indices() {
+        if ch == '/' || ch == '\\' {
+            if start < index {
+                parts.push(PathPart {
+                    segment: &path[start..index],
+                    end: index,
+                });
+            }
+            start = index + ch.len_utf8();
+        }
+    }
+
+    if start < path.len() {
+        parts.push(PathPart {
+            segment: &path[start..],
+            end: path.len(),
+        });
+    }
+
+    parts
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{corrupt_npx_cache_entry_from_stderr, repair_corrupt_npx_cache_from_stderr};
+    use std::path::{Path, PathBuf};
+
+    use aionui_common::{CommandSpec, EnvVar};
+
+    use super::{
+        computed_npx_cache_entry, corrupt_npx_cache_entry_from_stderr, npm_npx_cache_hash, repair_corrupt_npx_cache,
+    };
+
+    fn npx_command_spec(cache: &Path, args: &[&str]) -> CommandSpec {
+        CommandSpec {
+            command: PathBuf::from("npx"),
+            args: args.iter().map(|arg| (*arg).to_owned()).collect(),
+            env: vec![EnvVar {
+                name: "npm_config_cache".to_owned(),
+                value: cache.display().to_string(),
+            }],
+            cwd: None,
+        }
+    }
+
+    fn node_npx_cli_command_spec(cache: &Path, args: &[&str]) -> CommandSpec {
+        let mut all_args = vec![r"C:\AionUi\runtime\node\node_modules\npm\bin\npx-cli.js".to_owned()];
+        all_args.extend(args.iter().map(|arg| (*arg).to_owned()));
+        CommandSpec {
+            command: PathBuf::from("node.exe"),
+            args: all_args,
+            env: vec![EnvVar {
+                name: "npm_config_cache".to_owned(),
+                value: cache.display().to_string(),
+            }],
+            cwd: None,
+        }
+    }
 
     #[test]
     fn detects_corrupt_npm_npx_cache_entry_from_startup_stderr() {
@@ -100,6 +371,48 @@ npm error enoent Could not read package.json
     }
 
     #[test]
+    fn detects_corrupt_npm_npx_cache_entry_from_quoted_enoent_path() {
+        let stderr = "\
+Error: ENOENT: no such file or directory, open '/tmp/aionui/runtime/node/cache/_npx/c16927192d2e8dc3/node_modules/@xai/grok-cli/package.json'
+";
+
+        let cache_entry = corrupt_npx_cache_entry_from_stderr(stderr).expect("cache entry");
+
+        assert_eq!(
+            cache_entry,
+            std::path::PathBuf::from("/tmp/aionui/runtime/node/cache/_npx/c16927192d2e8dc3")
+        );
+    }
+
+    #[test]
+    fn detects_corrupt_npm_npx_cache_entry_from_missing_bin_path() {
+        let stderr = "\
+sh: /tmp/aionui/runtime/node/cache/_npx/c16927192d2e8dc3/node_modules/.bin/grok: No such file or directory
+";
+
+        let cache_entry = corrupt_npx_cache_entry_from_stderr(stderr).expect("cache entry");
+
+        assert_eq!(
+            cache_entry,
+            std::path::PathBuf::from("/tmp/aionui/runtime/node/cache/_npx/c16927192d2e8dc3")
+        );
+    }
+
+    #[test]
+    fn detects_corrupt_npm_npx_cache_entry_from_windows_path() {
+        let stderr = r#"
+npm ERR! enoent ENOENT: no such file or directory, open 'C:\Users\Alice\AppData\Local\npm-cache\_npx\c16927192d2e8dc3\package.json'
+"#;
+
+        let cache_entry = corrupt_npx_cache_entry_from_stderr(stderr).expect("cache entry");
+
+        assert_eq!(
+            cache_entry,
+            std::path::PathBuf::from(r"C:\Users\Alice\AppData\Local\npm-cache\_npx\c16927192d2e8dc3")
+        );
+    }
+
+    #[test]
     fn ignores_non_npx_package_json_startup_stderr() {
         let stderr = "\
 npm error code ENOENT
@@ -111,8 +424,20 @@ npm error enoent Could not read package.json
     }
 
     #[test]
+    fn ignores_relative_npx_path() {
+        let stderr = "\
+npm error code ENOENT
+npm error path _npx/c16927192d2e8dc3/package.json
+npm error enoent Could not read package.json
+";
+
+        assert!(corrupt_npx_cache_entry_from_stderr(stderr).is_none());
+    }
+
+    #[test]
     fn repairs_corrupt_npm_npx_cache_entry_by_removing_entry_dir() {
         let temp = tempfile::tempdir().unwrap();
+        let spec = npx_command_spec(temp.path().join("cache").as_path(), &["-y", "other-package"]);
         let cache_entry = temp.path().join("cache").join("_npx").join("c16927192d2e8dc3");
         std::fs::create_dir_all(&cache_entry).unwrap();
         std::fs::write(cache_entry.join("package.json"), "{}").unwrap();
@@ -129,9 +454,83 @@ npm error enoent Could not read package.json
             cache_entry.display()
         );
 
-        let repaired = repair_corrupt_npx_cache_from_stderr(&stderr).expect("cache entry repaired");
+        let repaired = repair_corrupt_npx_cache(&spec, &stderr).expect("cache entry repaired");
 
         assert_eq!(repaired, cache_entry);
         assert!(!repaired.exists());
+    }
+
+    #[test]
+    fn computes_npx_cache_entry_from_direct_package_argument() {
+        let temp = tempfile::tempdir().unwrap();
+        let spec = npx_command_spec(temp.path(), &["-y", "@xai-official/grok@0.2.102", "agent", "stdio"]);
+
+        let cache_entry = computed_npx_cache_entry(&spec).expect("computed cache entry");
+
+        assert_eq!(cache_entry, temp.path().join("_npx").join("c16927192d2e8dc3"));
+    }
+
+    #[test]
+    fn computes_npx_cache_entry_from_package_flag() {
+        let temp = tempfile::tempdir().unwrap();
+        let spec = npx_command_spec(
+            temp.path(),
+            &[
+                "-y",
+                "--package",
+                "@tencent-ai/codebuddy-code@2.106.7",
+                "codebuddy",
+                "--acp",
+            ],
+        );
+
+        let cache_entry = computed_npx_cache_entry(&spec).expect("computed cache entry");
+
+        assert_eq!(cache_entry, temp.path().join("_npx").join("fc1de2abdabf8717"));
+    }
+
+    #[test]
+    fn computes_npx_cache_entry_from_node_wrapped_npx_cli() {
+        let temp = tempfile::tempdir().unwrap();
+        let spec = node_npx_cli_command_spec(temp.path(), &["-y", "pi-acp@0.0.31"]);
+
+        let cache_entry = computed_npx_cache_entry(&spec).expect("computed cache entry");
+
+        assert_eq!(cache_entry, temp.path().join("_npx").join("dc42e4d625bccf60"));
+    }
+
+    #[test]
+    fn computes_npx_cache_hash_from_sorted_package_specs() {
+        assert_eq!(
+            npm_npx_cache_hash(&["z-package@1.0.0".to_owned(), "@scope/package@2.0.0".to_owned(),]),
+            npm_npx_cache_hash(&["@scope/package@2.0.0".to_owned(), "z-package@1.0.0".to_owned(),])
+        );
+    }
+
+    #[test]
+    fn repairs_computed_corrupt_npx_cache_entry_without_stderr_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let spec = npx_command_spec(temp.path(), &["-y", "@xai-official/grok@0.2.102", "agent", "stdio"]);
+        let cache_entry = temp.path().join("_npx").join("c16927192d2e8dc3");
+        std::fs::create_dir_all(cache_entry.join("node_modules")).unwrap();
+
+        let repaired = repair_corrupt_npx_cache(&spec, "agent exited before initialize").expect("cache entry repaired");
+
+        assert_eq!(repaired, cache_entry);
+        assert!(!repaired.exists());
+    }
+
+    #[test]
+    fn does_not_repair_computed_npx_cache_entry_when_package_json_exists() {
+        let temp = tempfile::tempdir().unwrap();
+        let spec = npx_command_spec(temp.path(), &["-y", "@xai-official/grok@0.2.102", "agent", "stdio"]);
+        let cache_entry = temp.path().join("_npx").join("c16927192d2e8dc3");
+        std::fs::create_dir_all(&cache_entry).unwrap();
+        std::fs::write(cache_entry.join("package.json"), "{}").unwrap();
+
+        let repaired = repair_corrupt_npx_cache(&spec, "agent exited before initialize");
+
+        assert!(repaired.is_none());
+        assert!(cache_entry.exists());
     }
 }

--- a/crates/aionui-ai-agent/src/protocol/npx_cache_repair.rs
+++ b/crates/aionui-ai-agent/src/protocol/npx_cache_repair.rs
@@ -23,7 +23,7 @@ impl CorruptNpxCacheRepair {
 }
 
 pub(crate) fn repair_corrupt_npx_cache(command_spec: &CommandSpec, stderr: &str) -> Option<PathBuf> {
-    if let Some(cache_entry) = computed_corrupt_npx_cache_entry(command_spec)
+    if let Some(cache_entry) = computed_existing_npx_cache_entry(command_spec)
         && clear_npx_cache_entry(&cache_entry, MissingEntryPolicy::Skip).is_some()
     {
         return Some(cache_entry);
@@ -33,11 +33,8 @@ pub(crate) fn repair_corrupt_npx_cache(command_spec: &CommandSpec, stderr: &str)
     clear_npx_cache_entry(&cache_entry, MissingEntryPolicy::Repaired)
 }
 
-fn computed_corrupt_npx_cache_entry(command_spec: &CommandSpec) -> Option<PathBuf> {
+fn computed_existing_npx_cache_entry(command_spec: &CommandSpec) -> Option<PathBuf> {
     let npx_cache_entry = computed_npx_cache_entry(command_spec)?;
-    if npx_cache_entry.join("package.json").exists() {
-        return None;
-    }
     if !npx_cache_entry.exists() {
         return None;
     }
@@ -508,7 +505,7 @@ npm error enoent Could not read package.json
     }
 
     #[test]
-    fn repairs_computed_corrupt_npx_cache_entry_without_stderr_path() {
+    fn repairs_computed_npx_cache_entry_without_stderr_path() {
         let temp = tempfile::tempdir().unwrap();
         let spec = npx_command_spec(temp.path(), &["-y", "@xai-official/grok@0.2.102", "agent", "stdio"]);
         let cache_entry = temp.path().join("_npx").join("c16927192d2e8dc3");
@@ -521,7 +518,7 @@ npm error enoent Could not read package.json
     }
 
     #[test]
-    fn does_not_repair_computed_npx_cache_entry_when_package_json_exists() {
+    fn repairs_computed_npx_cache_entry_even_when_package_json_exists() {
         let temp = tempfile::tempdir().unwrap();
         let spec = npx_command_spec(temp.path(), &["-y", "@xai-official/grok@0.2.102", "agent", "stdio"]);
         let cache_entry = temp.path().join("_npx").join("c16927192d2e8dc3");
@@ -530,7 +527,7 @@ npm error enoent Could not read package.json
 
         let repaired = repair_corrupt_npx_cache(&spec, "agent exited before initialize");
 
-        assert!(repaired.is_none());
-        assert!(cache_entry.exists());
+        assert_eq!(repaired, Some(cache_entry.clone()));
+        assert!(!cache_entry.exists());
     }
 }

--- a/crates/aionui-ai-agent/src/protocol/npx_cache_repair.rs
+++ b/crates/aionui-ai-agent/src/protocol/npx_cache_repair.rs
@@ -1,0 +1,137 @@
+use std::path::{Path, PathBuf};
+
+use aionui_common::ErrorChain;
+use tracing::warn;
+
+#[derive(Default)]
+pub(crate) struct CorruptNpxCacheRepair {
+    repaired: bool,
+}
+
+impl CorruptNpxCacheRepair {
+    pub(crate) fn try_repair(&mut self, stderr: &str) -> Option<PathBuf> {
+        if self.repaired {
+            return None;
+        }
+
+        let cache_entry = repair_corrupt_npx_cache_from_stderr(stderr)?;
+        self.repaired = true;
+        Some(cache_entry)
+    }
+}
+
+pub(crate) fn repair_corrupt_npx_cache_from_stderr(stderr: &str) -> Option<PathBuf> {
+    let cache_entry = corrupt_npx_cache_entry_from_stderr(stderr)?;
+    match std::fs::remove_dir_all(&cache_entry) {
+        Ok(()) => Some(cache_entry),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Some(cache_entry),
+        Err(error) => {
+            warn!(
+                npm_npx_cache_entry = %cache_entry.display(),
+                error = %ErrorChain(&error),
+                "Failed to clear corrupt npm npx cache after ACP startup crash"
+            );
+            None
+        }
+    }
+}
+
+fn corrupt_npx_cache_entry_from_stderr(stderr: &str) -> Option<PathBuf> {
+    let lower = stderr.to_ascii_lowercase();
+    if !lower.contains("_npx") || !lower.contains("package.json") {
+        return None;
+    }
+    if !lower.contains("enoent") && !lower.contains("could not read package.json") {
+        return None;
+    }
+
+    stderr.lines().find_map(|line| {
+        let path = parse_npm_error_path(line)?;
+        npx_cache_entry_from_package_json_path(&path)
+    })
+}
+
+fn parse_npm_error_path(line: &str) -> Option<PathBuf> {
+    let trimmed = line.trim();
+    for marker in ["npm error path ", "npm ERR! path "] {
+        if let Some(path) = trimmed.strip_prefix(marker) {
+            let path = path.trim().trim_matches('"').trim_matches('\'');
+            if !path.is_empty() {
+                return Some(PathBuf::from(path));
+            }
+        }
+    }
+    None
+}
+
+fn npx_cache_entry_from_package_json_path(path: &Path) -> Option<PathBuf> {
+    if path.file_name()? != "package.json" {
+        return None;
+    }
+    let cache_entry = path.parent()?;
+    let npx_dir = cache_entry.parent()?;
+    if npx_dir.file_name()?.to_string_lossy().eq_ignore_ascii_case("_npx") {
+        Some(cache_entry.to_path_buf())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{corrupt_npx_cache_entry_from_stderr, repair_corrupt_npx_cache_from_stderr};
+
+    #[test]
+    fn detects_corrupt_npm_npx_cache_entry_from_startup_stderr() {
+        let stderr = "\
+npm error code ENOENT
+npm error syscall open
+npm error path /tmp/aionui/runtime/node/cache/_npx/c16927192d2e8dc3/package.json
+npm error errno -2
+npm error enoent Could not read package.json
+";
+
+        let cache_entry = corrupt_npx_cache_entry_from_stderr(stderr).expect("cache entry");
+
+        assert_eq!(
+            cache_entry,
+            std::path::PathBuf::from("/tmp/aionui/runtime/node/cache/_npx/c16927192d2e8dc3")
+        );
+    }
+
+    #[test]
+    fn ignores_non_npx_package_json_startup_stderr() {
+        let stderr = "\
+npm error code ENOENT
+npm error path /tmp/project/package.json
+npm error enoent Could not read package.json
+";
+
+        assert!(corrupt_npx_cache_entry_from_stderr(stderr).is_none());
+    }
+
+    #[test]
+    fn repairs_corrupt_npm_npx_cache_entry_by_removing_entry_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_entry = temp.path().join("cache").join("_npx").join("c16927192d2e8dc3");
+        std::fs::create_dir_all(&cache_entry).unwrap();
+        std::fs::write(cache_entry.join("package.json"), "{}").unwrap();
+        std::fs::create_dir_all(cache_entry.join("node_modules").join(".bin")).unwrap();
+
+        let stderr = format!(
+            "\
+npm error code ENOENT
+npm error syscall open
+npm error path {}/package.json
+npm error errno -2
+npm error enoent Could not read package.json
+",
+            cache_entry.display()
+        );
+
+        let repaired = repair_corrupt_npx_cache_from_stderr(&stderr).expect("cache entry repaired");
+
+        assert_eq!(repaired, cache_entry);
+        assert!(!repaired.exists());
+    }
+}

--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -838,8 +838,8 @@ fn classify_provider_text(lower: &str) -> Option<ClassifiedError> {
             "The model provider could not be reached",
             AgentErrorCode::UserLlmProviderNetworkError,
             true,
-            AgentErrorResolutionKind::CheckProviderBaseUrl,
-            Some(AgentErrorResolutionTarget::ProviderSettings),
+            AgentErrorResolutionKind::Retry,
+            None,
         ));
     }
     if contains_any(
@@ -1865,13 +1865,13 @@ mod tests {
             "Aionrs agent error: API error: Connection error: error decoding response body",
             AgentErrorCode::UserLlmProviderNetworkError,
             AgentErrorOwnership::UserLlmProvider,
-            AgentErrorResolutionKind::CheckProviderBaseUrl,
+            AgentErrorResolutionKind::Retry,
         );
         assert_classification(
             "Aionrs agent error: API error: error sending request for url",
             AgentErrorCode::UserLlmProviderNetworkError,
             AgentErrorOwnership::UserLlmProvider,
-            AgentErrorResolutionKind::CheckProviderBaseUrl,
+            AgentErrorResolutionKind::Retry,
         );
         assert_classification(
             "Autocompact failed: Empty response from LLM",

--- a/crates/aionui-conversation/src/turn_recovery_policy.rs
+++ b/crates/aionui-conversation/src/turn_recovery_policy.rs
@@ -1,4 +1,4 @@
-use aionui_api_types::AgentErrorCode;
+use aionui_api_types::{AgentErrorCode, AgentErrorOwnership};
 use aionui_common::{AgentKillReason, AgentType};
 use tracing::info;
 
@@ -41,6 +41,7 @@ impl TurnRecoveryPolicy {
             && outcome.terminal.is_error()
             && retryable == Some(true)
             && error_code != Some(AgentErrorCode::UserLlmProviderModelNotFound)
+            && (session_recovery_signal.is_some() || !is_provider_turn_error(error_code, outcome))
             && safe_to_auto_replay
             && !already_replayed
         {
@@ -71,6 +72,41 @@ impl TurnRecoveryPolicy {
 
         decision
     }
+}
+
+fn is_provider_turn_error(error_code: Option<AgentErrorCode>, outcome: &RelayOutcome) -> bool {
+    if matches!(
+        outcome
+            .attempt
+            .terminal_error
+            .as_ref()
+            .and_then(|error| error.ownership),
+        Some(AgentErrorOwnership::UserLlmProvider)
+    ) {
+        return true;
+    }
+
+    matches!(
+        error_code,
+        Some(
+            AgentErrorCode::UserLlmProviderAuthFailed
+                | AgentErrorCode::UserLlmProviderAwsSsoExpired
+                | AgentErrorCode::UserLlmProviderPermissionDenied
+                | AgentErrorCode::UserLlmProviderBillingRequired
+                | AgentErrorCode::UserLlmProviderConfigError
+                | AgentErrorCode::UserLlmProviderModelNotFound
+                | AgentErrorCode::UserLlmProviderUnsupportedModel
+                | AgentErrorCode::UserLlmProviderEndpointNotFound
+                | AgentErrorCode::UserLlmProviderInvalidRequest
+                | AgentErrorCode::UserLlmProviderInvalidToolSchema
+                | AgentErrorCode::UserLlmProviderContextTooLarge
+                | AgentErrorCode::UserLlmProviderRateLimited
+                | AgentErrorCode::UserLlmProviderTimeout
+                | AgentErrorCode::UserLlmProviderNetworkError
+                | AgentErrorCode::UserLlmProviderEmptyResponse
+                | AgentErrorCode::UserLlmProviderGatewayError
+        )
+    )
 }
 
 fn classify_session_recovery_signal(outcome: &RelayOutcome) -> Option<SessionRecoverySignal> {
@@ -157,6 +193,37 @@ mod tests {
                 session_recovery_signal: Some(SessionRecoverySignal::CompactFailed),
             }
         );
+    }
+
+    #[test]
+    fn provider_turn_network_error_does_not_auto_replay() {
+        let mut outcome = retryable_clean_error();
+        outcome.terminal = RelayTerminal::Error {
+            code: Some(AgentErrorCode::UserLlmProviderNetworkError),
+            retryable: Some(true),
+        };
+        outcome.attempt.terminal_error = Some(AgentStreamErrorData::classified(
+            "The model provider could not be reached",
+            AgentErrorCode::UserLlmProviderNetworkError,
+            AgentErrorOwnership::UserLlmProvider,
+            Some(
+                "Agent internal error (code -32603): reqwest error stream: error sending request for url (https://cli-chat-proxy.grok.com/v1/responses)"
+                    .into(),
+            ),
+            true,
+            false,
+            None,
+        ));
+
+        let decision = TurnRecoveryPolicy::decide(
+            AgentType::Acp,
+            Some("grok"),
+            &outcome,
+            RuntimeLifecycleState::Active,
+            false,
+        );
+
+        assert_eq!(decision, TurnRecoveryDecision::None);
     }
 
     #[test]

--- a/crates/aionui-runtime/src/agent_env.rs
+++ b/crates/aionui-runtime/src/agent_env.rs
@@ -20,7 +20,20 @@ static FULL_SHELL_ENV: OnceCell<Vec<(OsString, OsString)>> = OnceCell::const_new
 /// Electron `spawn(..., { env })` behavior without spreading shell variables to
 /// unrelated backend code.
 pub async fn agent_process_env() -> Vec<(OsString, OsString)> {
-    build_agent_process_env(std::env::vars_os().collect(), full_shell_env().await.to_vec())
+    let current_env: Vec<(OsString, OsString)> = std::env::vars_os().collect();
+    let shell_env = full_shell_env().await.to_vec();
+    let env = build_agent_process_env(current_env.clone(), shell_env.clone());
+    tracing::info!(
+        current_var_count = current_env.len(),
+        shell_var_count = shell_env.len(),
+        final_var_count = env.len(),
+        current_network_env_keys = ?present_network_env_keys(&current_env),
+        shell_network_env_keys = ?present_network_env_keys(&shell_env),
+        final_network_env_keys = ?present_network_env_keys(&env),
+        final_path_entry_count = path_entry_count(get_env_value(&env, "PATH").map(|value| value.as_os_str())),
+        "agent subprocess environment prepared"
+    );
+    env
 }
 
 async fn full_shell_env() -> &'static Vec<(OsString, OsString)> {
@@ -47,7 +60,14 @@ fn build_agent_process_env(
 }
 
 fn clean_agent_env(env: &mut BTreeMap<OsString, OsString>) {
-    for key in ["NODE_OPTIONS", "NODE_INSPECT", "NODE_DEBUG", "CLAUDECODE"] {
+    for key in [
+        "NODE_OPTIONS",
+        "NODE_INSPECT",
+        "NODE_DEBUG",
+        "CLAUDECODE",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+    ] {
         remove_env_key(env, key);
     }
     env.retain(|key, _| !env_key_starts_with(key, "npm_"));
@@ -105,13 +125,47 @@ fn merge_path_values(current: Option<&std::ffi::OsStr>, shell: Option<&std::ffi:
     }
 }
 
+const NETWORK_ENV_KEYS: &[&str] = &[
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy",
+    "NODE_EXTRA_CA_CERTS",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+];
+
+fn present_network_env_keys(env: &[(OsString, OsString)]) -> Vec<&'static str> {
+    NETWORK_ENV_KEYS
+        .iter()
+        .copied()
+        .filter(|key| get_env_value(env, key).is_some())
+        .collect()
+}
+
+fn path_entry_count(path: Option<&std::ffi::OsStr>) -> usize {
+    path.map(|value| {
+        std::env::split_paths(value)
+            .filter(|path| !path.as_os_str().is_empty())
+            .count()
+    })
+    .unwrap_or(0)
+}
+
 #[cfg(unix)]
 async fn load_full_shell_env() -> Vec<(OsString, OsString)> {
     let Some(shell) = std::env::var_os("SHELL") else {
+        tracing::info!("SHELL is not set; skipping full shell env probe for agent subprocesses");
         return Vec::new();
     };
     if !Path::new(&shell).is_absolute() {
-        tracing::debug!(shell = %shell.to_string_lossy(), "SHELL is not absolute, skipping full shell env probe");
+        tracing::info!(shell = %shell.to_string_lossy(), "SHELL is not absolute; skipping full shell env probe for agent subprocesses");
         return Vec::new();
     }
 
@@ -141,7 +195,12 @@ async fn load_full_shell_env() -> Vec<(OsString, OsString)> {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let parsed = parse_env_output(&stdout);
-    tracing::info!(var_count = parsed.len(), "full shell env loaded for agent subprocesses");
+    tracing::info!(
+        var_count = parsed.len(),
+        network_env_keys = ?present_network_env_keys(&parsed),
+        path_entry_count = path_entry_count(get_env_value(&parsed, "PATH").map(|value| value.as_os_str())),
+        "full shell env loaded for agent subprocesses"
+    );
     parsed
 }
 
@@ -220,6 +279,9 @@ printf '%s\n' \
   'PATH=/shell/bin:/current/bin' \
   'NODE_OPTIONS=--inspect' \
   'CLAUDECODE=1' \
+  'SSL_CERT_FILE=/tmp/shell-cert.pem' \
+  'SSL_CERT_DIR=/tmp/shell-certs' \
+  'NODE_EXTRA_CA_CERTS=/tmp/shell-node-extra.pem' \
   'npm_lifecycle_event=start'
 "#,
             );
@@ -235,6 +297,9 @@ printf '%s\n' \
                 .env("AIONUI_OVERLAY", "from-current")
                 .env("NODE_OPTIONS", "--require parent")
                 .env("CLAUDECODE", "1")
+                .env("SSL_CERT_FILE", "/tmp/current-cert.pem")
+                .env("SSL_CERT_DIR", "/tmp/current-certs")
+                .env("NODE_EXTRA_CA_CERTS", "/tmp/current-node-extra.pem")
                 .env("npm_config_cache", "/tmp/parent-cache")
                 .output()
                 .unwrap();
@@ -259,6 +324,12 @@ printf '%s\n' \
         assert_eq!(value("AIONUI_OVERLAY").as_deref(), Some("from-shell"));
         assert_eq!(value("NODE_OPTIONS"), None);
         assert_eq!(value("CLAUDECODE"), None);
+        assert_eq!(value("SSL_CERT_FILE"), None);
+        assert_eq!(value("SSL_CERT_DIR"), None);
+        assert_eq!(
+            value("NODE_EXTRA_CA_CERTS").as_deref(),
+            Some("/tmp/shell-node-extra.pem")
+        );
         assert_eq!(value("npm_config_cache"), None);
         assert_eq!(value("npm_lifecycle_event"), None);
 


### PR DESCRIPTION
## Summary
- strip SSL_CERT_FILE and SSL_CERT_DIR from agent subprocess environments while preserving NODE_EXTRA_CA_CERTS
- repair managed npm _npx cache entries after ACP startup/handshake failure by computing npm's package hash from the actual CommandSpec and deleting only that single entry when it exists
- keep stderr-based _npx path detection as a fallback for startup failures where the managed command cannot be computed
- classify provider send failures as retryable provider network errors without automatic conversation replay

## Verification
- cargo fmt --all -- --check
- cargo test -p aionui-ai-agent npx_cache_repair
- cargo clippy -p aionui-ai-agent -- -D warnings
- GitHub CI for PR #662 passed: Clippy, Format, Migration Immutability, Detect dependency changes, Test

## Notes
- AionUi changes were not included; this fix is contained in AionCore.
- ACP conversation startup and test-connection lifecycle remain separate; only npm _npx cache repair logic is shared.
- The _npx repair does not clear the whole _npx cache; it clears only the computed entry for the failed command, then retries once.