### PR TITLE
fix(skills): repair butler cron and doc drift (2026-07-22 audit)

### DIFF
--- a/crates/aionui-app/assets/builtin-skills/aionui-troubleshooting/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/aionui-troubleshooting/SKILL.md
@@ -65,7 +65,9 @@ Use the overview to decide where to drill in:
 
 - `providers.unhealthy` means inspect provider health.
 - `mcp.enabled_but_no_tools` means inspect MCP startup/tool registration.
-- `cron.failing` means inspect scheduled task state.
+- `cron.failing` means inspect scheduled task state. If `cron.failing` is empty
+  but cron issues are suspected, fall back to `diagnose cron summary` and check
+  `all[].state.last_status` directly.
 - `running_conversations` means inspect the conversation runtime repeatedly.
 
 ## Commands By Symptom
@@ -127,8 +129,10 @@ the named command is insufficient.
 "$AIONUI_HELPER_BIN" diagnose cron summary
 ```
 
-Check `enabled`, `last_status`, `last_error`, `next_run_at`, `last_run_at`,
-`run_count`, and `retry_count` when present.
+Top-level fields: `enabled`, `name`, `id`.
+Run-state fields are nested under `state`: `state.last_status`, `state.last_error`,
+`state.run_count`, `state.retry_count`, `state.next_run_at_ms`, `state.last_run_at_ms`
+(timestamps are millisecond epoch integers, not human dates).
 
 ### MCP Server Has No Tools
 

--- a/crates/aionui-app/assets/builtin-skills/auto-inject/aionui-config/SKILL.md
+++ b/crates/aionui-app/assets/builtin-skills/auto-inject/aionui-config/SKILL.md
@@ -146,8 +146,9 @@ JSON
 
 For `name`, `description`, `avatar`, or recommended prompt changes, report that
 the change is saved and may require refreshing or reopening the UI to see. For
-`agent_id`, `defaults`, `enabled_skills`, `default_mcp_ids`, or other runtime
-defaults, report that the saved change applies to new conversations only.
+`agent_id`, `defaults`, `enabled_skills`, or other runtime defaults (MCP
+defaults are set via `defaults.mcps`, not `default_mcp_ids`), report that the
+saved change applies to new conversations only.
 
 Enable, disable, or reorder an assistant:
 
@@ -477,7 +478,7 @@ JSON
 JSON
 ```
 
-Create, update, delete, or test a custom agent:
+Create, update, delete, or try-connect a custom agent:
 
 ```bash
 "$AIONUI_HELPER_BIN" config agents custom create <<'JSON'
@@ -493,6 +494,16 @@ JSON
 {
   "agent_id": "custom_agent_123",
   "name": "Custom Agent",
+  "command": "/absolute/path/to/agent-cli"
+}
+JSON
+```
+
+Test whether a custom agent binary is reachable (does not persist anything):
+
+```bash
+"$AIONUI_HELPER_BIN" config agents custom try-connect <<'JSON'
+{
   "command": "/absolute/path/to/agent-cli"
 }
 JSON
@@ -572,12 +583,15 @@ Use `"conversation_id": "current"` to attach the job to the current conversation
 
 Update, run, or manage a cron job skill:
 
+Note: `cron jobs` uses the tagged `schedule` object (same shape as create). This
+is different from `cron current`, where `schedule` is a flat cron string.
+
 ```bash
 "$AIONUI_HELPER_BIN" config cron jobs update <<'JSON'
 {
   "job_id": "cron_123",
   "name": "Weekly Report",
-  "schedule": "0 10 * * MON"
+  "schedule": { "kind": "cron", "expr": "0 10 * * MON" }
 }
 JSON
 ```


### PR DESCRIPTION
## Summary

Daily drift audit (2026-07-22) found two breaking issues and two doc
problems in the butler's built-in skills. This PR fixes all four.
Changes are asset-only — no `.rs` changes — and ship to users via
`include_dir!` on the next binary build.

### Fixes

**B1 — `aionui-config`: `cron jobs update` schedule field type (BREAKING)**

The update example used `"schedule": "0 10 * * MON"` (flat string). The
backend `UpdateCronJobRequest.schedule` is `Option<CronScheduleDto>`
(`crates/aionui-api-types/src/cron.rs:203-204`) — the same internally-tagged
object as create. A plain string fails to deserialize and the request
errors out. Fixed the example to `{ "kind": "cron", "expr": "0 10 * * MON" }`
and added a note distinguishing the two cron families (`cron jobs` uses
tagged object; `cron current` uses flat string).

**B2 — `aionui-troubleshooting`: cron field names/paths (BREAKING → misdiagnosis)**

The skill told the reading agent to look at top-level `last_status`,
`next_run_at`, `last_run_at` etc. These don't exist there. All run-state
fields are nested under `state` in `CronJobResponse`
(`crates/aionui-api-types/src/cron.rs:113-140`), and the timestamp fields
carry `_ms` suffixes. The agent would silently find nothing and misreport
cron state. Corrected to `state.last_status`, `state.last_error`,
`state.next_run_at_ms`, `state.last_run_at_ms`, etc.
Also added a fallback hint for the `cron.failing` overview field being
empty (see backend bug report linked below).

**D1 — `aionui-config`: `default_mcp_ids` → `defaults.mcps`**

Prose at line 149 named `default_mcp_ids` as a settable field on assistant
update. No such field exists on `UpdateAssistantRequest`; MCP defaults are
set via `defaults.mcps` (`assistant.rs:164`). Without `deny_unknown_fields`,
the old name was silently ignored. Corrected the prose.

**D2 — `aionui-config`: `agents custom test` → `try-connect`**

The prose said "test a custom agent" but the actual subcommand is
`try-connect` (`cmd_config.rs:800-808`). Renamed and added a minimal
example.

## How verified

Every fix was verified against `file:line` in the freshly-pulled `main`
(`10cdd579`) before editing:
- `UpdateCronJobRequest`: `cron.rs:203-204`
- `CronJobStateDto` nesting: `cron.rs:113-140`
- `AssistantDefaultsRequest.mcps`: `assistant.rs:164`
- `try-connect` dispatch: `cmd_config.rs:800-808`

## Related

Backend bug (not in this PR): `diagnose cron summary` / `overview` read
`last_status` at the wrong depth (`cmd_diagnose.rs:764, 783`), so
`cron.failing` is always empty. A separate issue is filed for that `.rs`
fix.

## Deploy path

Asset-only change. Ships via `include_dir!` in `aionui-app` when the
binary is rebuilt. No migration, no schema change.