### PR TITLE
fix(system): release keep-awake on shutdown

### DIFF
--- a/crates/aionui-app/src/commands/cmd_server.rs
+++ b/crates/aionui-app/src/commands/cmd_server.rs
@@ -293,6 +293,7 @@ pub(crate) async fn run_server(
     );
     let conversation_runtime_state = services.conversation_runtime_state.clone();
     let worker_task_manager = services.worker_task_manager.clone();
+    let client_pref_service = router_runtime.client_pref_service.clone();
 
     axum::serve(listener, router)
         .with_graceful_shutdown(async move {
@@ -320,6 +321,14 @@ pub(crate) async fn run_server(
                         Err(_) => warn!(active_task_count, "worker task manager shutdown timed out"),
                     }
                 }
+            }
+            if let Err(error) = client_pref_service.release_keep_awake_for_shutdown().await {
+                warn!(
+                    code = "BOOTSTRAP_DEGRADED_KEEP_AWAKE_RELEASE",
+                    stage = "shutdown.keep_awake.release",
+                    error = %error,
+                    "keep-awake shutdown release failed"
+                );
             }
             let _ = shutdown_tx.send(true);
         })

--- a/crates/aionui-app/src/router/routes.rs
+++ b/crates/aionui-app/src/router/routes.rs
@@ -32,7 +32,7 @@ use aionui_mcp::mcp_routes;
 use aionui_office::{office_proxy_routes, office_routes};
 use aionui_realtime::{WsHandlerState, ws_upgrade_handler};
 use aionui_shell::shell_routes;
-use aionui_system::{connection_test_routes, system_routes};
+use aionui_system::{ClientPrefService, connection_test_routes, system_routes};
 use aionui_team::{TeamSessionService, team_routes};
 
 use crate::services::AppServices;
@@ -43,6 +43,7 @@ use super::state::{ModuleStates, RouterBuildError, build_module_states, build_ws
 use super::trace::with_access_log;
 
 pub struct RouterRuntime {
+    pub client_pref_service: ClientPrefService,
     pub team_service: Arc<TeamSessionService>,
 }
 
@@ -74,6 +75,7 @@ pub async fn create_router_with_runtime(services: &AppServices) -> Result<(Route
     });
 
     let (states, channel_components) = build_module_states(services).await?;
+    let client_pref_service = states.system.client_pref_service.clone();
     let team_service = states.team.service.clone();
     tracing::info!(elapsed_ms = boot.elapsed().as_millis(), "startup: module states built");
 
@@ -115,7 +117,13 @@ pub async fn create_router_with_runtime(services: &AppServices) -> Result<(Route
         elapsed_ms = boot.elapsed().as_millis(),
         "startup: router assembly completed"
     );
-    Ok((router, RouterRuntime { team_service }))
+    Ok((
+        router,
+        RouterRuntime {
+            client_pref_service,
+            team_service,
+        },
+    ))
 }
 
 /// Create the application router with custom module states.

--- a/crates/aionui-system/src/client_pref.rs
+++ b/crates/aionui-system/src/client_pref.rs
@@ -152,6 +152,15 @@ impl ClientPrefService {
         Ok(())
     }
 
+    pub async fn release_keep_awake_for_shutdown(&self) -> Result<(), SystemError> {
+        self.keep_awake_controller.set_enabled(false).await.map_err(|error| {
+            warn!(error = %error, "Failed to release system keep-awake assertion during shutdown");
+            error
+        })?;
+        info!("System keep-awake assertion released during shutdown");
+        Ok(())
+    }
+
     async fn get_stored_keep_awake(&self) -> Result<bool, SystemError> {
         let rows = self
             .repo
@@ -535,6 +544,21 @@ mod tests {
         assert_eq!(*controller.calls.lock().unwrap(), vec![true, false]);
         let prefs = svc.get_preferences(Some(&[KEEP_AWAKE_KEY])).await.unwrap();
         assert!(!prefs.contains_key(KEEP_AWAKE_KEY));
+    }
+
+    #[tokio::test]
+    async fn keep_awake_shutdown_release_does_not_clear_persisted_preference() {
+        let controller = Arc::new(RecordingKeepAwakeController::default());
+        let svc = setup_with_keep_awake_controller(controller.clone()).await;
+        let mut req = UpdateClientPreferencesRequest::new();
+        req.insert(KEEP_AWAKE_KEY.into(), json!(true));
+        svc.update_preferences(req).await.unwrap();
+
+        svc.release_keep_awake_for_shutdown().await.unwrap();
+
+        assert_eq!(*controller.calls.lock().unwrap(), vec![true, false]);
+        let prefs = svc.get_preferences(Some(&[KEEP_AWAKE_KEY])).await.unwrap();
+        assert_eq!(prefs[KEEP_AWAKE_KEY], json!(true));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- release system keep-awake during aioncore graceful shutdown without clearing the persisted client preference
- carry the client preference service through router runtime handles so shutdown can release the OS assertion
- cover shutdown release preserving keepAwake=true so next startup can restore it

## Verification
- cargo fmt --all -- --check
- cargo test -p aionui-system
- cargo clippy -p aionui-system -p aionui-app -- -D warnings
- just push -u origin fix/keep-awake-shutdown (6920 passed, 18 skipped; nextest reported 2 slow and 2 leaky tests)