### PR TITLE
fix(process): allow whitespace in workspace cwd segments (#410 parity)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,6 +758,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -1178,9 +1178,15 @@ pub async fn build_session_instance(
         init,
         // Packaged app: resolve the bundled claude/codex binary and forward its
         // absolute path so the backend spawns OUR CLI, not the user's PATH one.
-        // `None` in dev / non-bundled runs → backend falls back to the bare name
-        // (PATH). Detection (cli_probe) stays PATH-only and is unaffected.
-        cli_program: aionui_runtime::resolve_bundled_cli(backend_label),
+        // Bundled-missing / dev falls back to a PATH lookup via
+        // `resolve_command_path` (NOT the bare name): on Windows, npm installs
+        // ship `claude.cmd`/`codex.cmd` shims which `CreateProcess` does not
+        // find from a bare name (#299 parity; Rust std runs `.cmd` via
+        // `cmd.exe` since the BatBadBut fix). `None` (nothing on PATH either)
+        // keeps the bare name so the spawn error stays diagnosable. Detection
+        // (cli_probe) stays PATH-only and is unaffected.
+        cli_program: aionui_runtime::resolve_bundled_cli(backend_label)
+            .or_else(|| aionui_runtime::resolve_command_path(backend_label)),
         ..Default::default()
     };
 
@@ -1282,7 +1288,17 @@ pub async fn build_session_instance(
     let backend = connection
         .open_session(spec, session_config)
         .await
-        .map_err(|e| AgentError::bad_gateway(format!("open {backend_label} session: {e}")))?;
+        .map_err(|e| match e {
+            // #410 parity: a missing/non-directory workspace keeps its dedicated
+            // error class end-to-end (ProcessError::WorkspaceUnavailable →
+            // BackendError::WorkspaceUnavailable → here), so the frontend gets
+            // WORKSPACE_PATH_RUNTIME_UNAVAILABLE exactly like the legacy spawn
+            // path — not an opaque 502.
+            aionui_session::BackendError::WorkspaceUnavailable(path) => {
+                AgentError::workspace_path_runtime_unavailable(path)
+            }
+            e => AgentError::bad_gateway(format!("open {backend_label} session: {e}")),
+        })?;
 
     // Re-apply the persisted effort now that the session is open. The backend validates
     // it against the current model's advertised catalog (permissive until the catalog

--- a/crates/aionui-process/Cargo.toml
+++ b/crates/aionui-process/Cargo.toml
@@ -39,3 +39,6 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_JobObjects",
     "Win32_System_Diagnostics_ToolHelp",
 ] }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/aionui-process/src/error.rs
+++ b/crates/aionui-process/src/error.rs
@@ -6,12 +6,9 @@
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum ProcessError {
-    /// Invalid caller input (e.g. a missing / non-directory / whitespace cwd).
+    /// Invalid caller input (e.g. a missing / non-directory cwd).
     #[error("bad request: {0}")]
     BadRequest(String),
-    /// Workspace path contains a whitespace segment the bundled runtime cannot handle.
-    #[error("workspace path contains whitespace (runtime unsupported): {0}")]
-    WorkspacePathContainsWhitespaceRuntimeUnsupported(String),
     /// An OS / runtime failure (spawn failed, pipe capture failed, kill failed, fs error).
     #[error("internal error: {0}")]
     Internal(String),
@@ -20,10 +17,6 @@ pub enum ProcessError {
 impl ProcessError {
     pub fn bad_request(message: impl Into<String>) -> Self {
         Self::BadRequest(message.into())
-    }
-
-    pub fn workspace_path_contains_whitespace_runtime_unsupported(path: impl Into<String>) -> Self {
-        Self::WorkspacePathContainsWhitespaceRuntimeUnsupported(path.into())
     }
 
     pub fn internal(message: impl Into<String>) -> Self {

--- a/crates/aionui-process/src/error.rs
+++ b/crates/aionui-process/src/error.rs
@@ -6,9 +6,16 @@
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum ProcessError {
-    /// Invalid caller input (e.g. a missing / non-directory cwd).
+    /// Invalid caller input (e.g. an empty cwd).
     #[error("bad request: {0}")]
     BadRequest(String),
+    /// The spawn cwd (workspace) is missing, not a directory, or not
+    /// accessible. Its own class (not `BadRequest`) so callers can carry the
+    /// legacy #410 workspace-unavailable UX across the seam instead of an
+    /// opaque transport error. Payload = the path (mirrors the legacy
+    /// `AgentError::WorkspacePathRuntimeUnavailable` contract).
+    #[error("workspace unavailable: {0}")]
+    WorkspaceUnavailable(String),
     /// An OS / runtime failure (spawn failed, pipe capture failed, kill failed, fs error).
     #[error("internal error: {0}")]
     Internal(String),
@@ -17,6 +24,10 @@ pub enum ProcessError {
 impl ProcessError {
     pub fn bad_request(message: impl Into<String>) -> Self {
         Self::BadRequest(message.into())
+    }
+
+    pub fn workspace_unavailable(path: impl Into<String>) -> Self {
+        Self::WorkspaceUnavailable(path.into())
     }
 
     pub fn internal(message: impl Into<String>) -> Self {

--- a/crates/aionui-process/src/process.rs
+++ b/crates/aionui-process/src/process.rs
@@ -448,20 +448,13 @@ pub(crate) fn prepare_command_cwd(cwd: &str) -> Result<PathBuf, ProcessError> {
         return Err(ProcessError::bad_request("workspace directory is empty"));
     }
     let path = PathBuf::from(cwd);
+    // Missing / not-a-directory / not-accessible all classify as
+    // `WorkspaceUnavailable` carrying just the path — the legacy
+    // `workspace_path_runtime_unavailable` contract (#410), which the app
+    // layer maps to the dedicated workspace-unavailable API error.
     match std::fs::metadata(&path) {
         Ok(m) if m.is_dir() => Ok(path),
-        Ok(_) => Err(ProcessError::bad_request(format!(
-            "workspace path is not a directory: {}",
-            path.display()
-        ))),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(ProcessError::bad_request(format!(
-            "workspace directory does not exist: {}",
-            path.display()
-        ))),
-        Err(e) => Err(ProcessError::bad_request(format!(
-            "workspace directory not accessible: {}: {e}",
-            path.display()
-        ))),
+        Ok(_) | Err(_) => Err(ProcessError::workspace_unavailable(path.display().to_string())),
     }
 }
 
@@ -676,26 +669,29 @@ mod tests {
         }
     }
 
+    /// Missing / non-directory cwds classify as `WorkspaceUnavailable` with the
+    /// PATH as payload — the legacy `workspace_path_runtime_unavailable`
+    /// contract (#410) the app layer maps to the dedicated API error.
     #[test]
-    fn prepare_command_cwd_rejects_missing_dir() {
+    fn prepare_command_cwd_rejects_missing_dir_as_workspace_unavailable() {
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("does-not-exist");
         let err = prepare_command_cwd(&missing.to_string_lossy()).unwrap_err();
         assert!(
-            matches!(err, ProcessError::BadRequest(ref m) if m.contains("does not exist")),
-            "expected BadRequest(does not exist), got {err:?}"
+            matches!(err, ProcessError::WorkspaceUnavailable(ref p) if p == &missing.display().to_string()),
+            "expected WorkspaceUnavailable(path), got {err:?}"
         );
     }
 
     #[test]
-    fn prepare_command_cwd_rejects_file_as_cwd() {
+    fn prepare_command_cwd_rejects_file_as_workspace_unavailable() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("plain-file");
         std::fs::write(&file, b"x").unwrap();
         let err = prepare_command_cwd(&file.to_string_lossy()).unwrap_err();
         assert!(
-            matches!(err, ProcessError::BadRequest(ref m) if m.contains("not a directory")),
-            "expected BadRequest(not a directory), got {err:?}"
+            matches!(err, ProcessError::WorkspaceUnavailable(ref p) if p == &file.display().to_string()),
+            "expected WorkspaceUnavailable(path), got {err:?}"
         );
     }
 }

--- a/crates/aionui-process/src/process.rs
+++ b/crates/aionui-process/src/process.rs
@@ -433,21 +433,21 @@ impl ManagedProcess {
     }
 }
 
-/// Validate a workspace cwd: non-empty, no whitespace segment (bundled runtime
-/// can't handle it), exists, is a directory.
+/// Validate a workspace cwd: non-empty, exists, is a directory.
+///
+/// Whitespace inside path segments is VALID (`#410` semantics): real user
+/// workspaces routinely contain spaces (iCloud Drive lives under
+/// `~/Library/Mobile Documents/…`), and the cwd is passed to the OS as a
+/// single argument — never through a shell — so no quoting hazard exists.
+/// An earlier revision rejected whitespace segments here, which made every
+/// claude/codex direct-CLI spawn fail instantly for such workspaces
+/// (Sentry ELECTRON-3PP); upstream removed the same check from the legacy
+/// spawn path in #410, and this port must stay aligned with it.
 pub(crate) fn prepare_command_cwd(cwd: &str) -> Result<PathBuf, ProcessError> {
     if cwd.trim().is_empty() {
         return Err(ProcessError::bad_request("workspace directory is empty"));
     }
     let path = PathBuf::from(cwd);
-    if path
-        .components()
-        .any(|c| c.as_os_str().to_string_lossy().contains(char::is_whitespace))
-    {
-        return Err(ProcessError::workspace_path_contains_whitespace_runtime_unsupported(
-            path.display().to_string(),
-        ));
-    }
     match std::fs::metadata(&path) {
         Ok(m) if m.is_dir() => Ok(path),
         Ok(_) => Err(ProcessError::bad_request(format!(
@@ -627,5 +627,75 @@ pub(crate) mod job_windows {
         // SAFETY: close the snapshot handle we created.
         unsafe { CloseHandle(snap) };
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression pin for Sentry ELECTRON-3PP / upstream #410: a workspace with
+    /// whitespace in ANY path segment (iCloud Drive lives under
+    /// `~/Library/Mobile Documents/…`) must pass the cwd guard. An earlier
+    /// revision rejected it, instantly failing every claude/codex direct-CLI
+    /// spawn for such workspaces.
+    #[test]
+    fn prepare_command_cwd_allows_whitespace_in_any_segment() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("Mobile Documents");
+        std::fs::create_dir(&parent).unwrap();
+        let cwd = parent.join("project");
+        std::fs::create_dir(&cwd).unwrap();
+
+        let resolved = prepare_command_cwd(&cwd.to_string_lossy()).unwrap();
+        assert_eq!(resolved, cwd);
+    }
+
+    /// #410 semantics: a trailing space in the LEAF name is also valid when the
+    /// directory really exists on disk (the guard checks availability, not
+    /// cosmetics). Unix-only — Windows strips trailing spaces from path names.
+    #[cfg(unix)]
+    #[test]
+    fn prepare_command_cwd_allows_existing_dir_with_trailing_whitespace() {
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = dir.path().join("workspace ");
+        std::fs::create_dir(&cwd).unwrap();
+
+        let resolved = prepare_command_cwd(&cwd.to_string_lossy()).unwrap();
+        assert_eq!(resolved, cwd);
+    }
+
+    #[test]
+    fn prepare_command_cwd_rejects_empty_and_blank() {
+        for blank in ["", "   ", "\t"] {
+            let err = prepare_command_cwd(blank).unwrap_err();
+            assert!(
+                matches!(err, ProcessError::BadRequest(ref m) if m.contains("empty")),
+                "{blank:?} → expected BadRequest(empty), got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn prepare_command_cwd_rejects_missing_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist");
+        let err = prepare_command_cwd(&missing.to_string_lossy()).unwrap_err();
+        assert!(
+            matches!(err, ProcessError::BadRequest(ref m) if m.contains("does not exist")),
+            "expected BadRequest(does not exist), got {err:?}"
+        );
+    }
+
+    #[test]
+    fn prepare_command_cwd_rejects_file_as_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("plain-file");
+        std::fs::write(&file, b"x").unwrap();
+        let err = prepare_command_cwd(&file.to_string_lossy()).unwrap_err();
+        assert!(
+            matches!(err, ProcessError::BadRequest(ref m) if m.contains("not a directory")),
+            "expected BadRequest(not a directory), got {err:?}"
+        );
     }
 }

--- a/crates/aionui-session/src/backend/acp_conn.rs
+++ b/crates/aionui-session/src/backend/acp_conn.rs
@@ -92,7 +92,7 @@ impl BackendConnection for AcpConnection {
             .spawner
             .spawn(cmd, &[], "aionui-session")
             .await
-            .map_err(|e| BackendError::Transport(format!("acp spawn failed: {e}")))?;
+            .map_err(|e| BackendError::from_spawn("acp spawn failed", e))?;
         let io: Box<dyn AgentIo> = Box::new(crate::adapter::ManagedProcessIo::new(proc));
         // F-4 wake recipe: a Dormant→dispatch wake re-spawns the ACP CLI and
         // replays the resume handshake (`session/load` against the bound sid).
@@ -816,7 +816,7 @@ impl AcpSessionBackend {
         let proc = spawner
             .spawn(cmd, &[], "aionui-session")
             .await
-            .map_err(|e| BackendError::Transport(format!("acp resume-spawn failed: {e}")))?;
+            .map_err(|e| BackendError::from_spawn("acp resume-spawn failed", e))?;
         let io: Arc<dyn AgentIo> = Arc::from(Box::new(crate::adapter::ManagedProcessIo::new(proc)) as Box<dyn AgentIo>);
         let (stdin, stdout) = match io.take_stdio().await {
             Some((stdin, stdout)) => (Some(stdin), Some(stdout)),

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -308,7 +308,7 @@ impl BackendConnection for ClaudeConnection {
                 config.cli_program.as_deref(),
             )
             .await
-            .map_err(|e| BackendError::Transport(format!("claude spawn failed: {e}")))?;
+            .map_err(|e| BackendError::from_spawn("claude spawn failed", e))?;
 
         // F-4 wake recipe: re-spawn on wake by RESUMING the SAME claude session id
         // we spawned with (`--session-id <claude_session_id>` on Fresh → `--resume
@@ -684,7 +684,7 @@ impl ClaudeSessionBackend {
                 self.wake.cli_program.as_deref(),
             )
             .await
-            .map_err(|e| BackendError::Transport(format!("claude resume-spawn failed: {e}")))?;
+            .map_err(|e| BackendError::from_spawn("claude resume-spawn failed", e))?;
         let io: Arc<dyn AgentIo> = Arc::from(io);
         let (stdin, stdout) = match io.take_stdio().await {
             Some((stdin, stdout)) => (Some(stdin), Some(stdout)),

--- a/crates/aionui-session/src/backend/codex_conn.rs
+++ b/crates/aionui-session/src/backend/codex_conn.rs
@@ -89,7 +89,7 @@ impl BackendConnection for CodexConnection {
             .spawner
             .spawn(cmd, &[], "aionui-session")
             .await
-            .map_err(|e| BackendError::Transport(format!("codex spawn failed: {e}")))?;
+            .map_err(|e| BackendError::from_spawn("codex spawn failed", e))?;
         let io: Box<dyn AgentIo> = Box::new(crate::adapter::ManagedProcessIo::new(proc));
         // F-4 wake recipe: a Dormant→dispatch wake re-spawns `codex app-server` and
         // replays the resume handshake against the bound threadId. Capture the
@@ -1081,7 +1081,7 @@ impl CodexSessionBackend {
         let proc = spawner
             .spawn(cmd, &[], "aionui-session")
             .await
-            .map_err(|e| BackendError::Transport(format!("codex resume-spawn failed: {e}")))?;
+            .map_err(|e| BackendError::from_spawn("codex resume-spawn failed", e))?;
         let io: Arc<dyn AgentIo> = Arc::from(Box::new(crate::adapter::ManagedProcessIo::new(proc)) as Box<dyn AgentIo>);
         let (stdin, stdout) = match io.take_stdio().await {
             Some((stdin, stdout)) => (Some(stdin), Some(stdout)),
@@ -5925,6 +5925,45 @@ mod tests {
             [("AIONUI_CONVERSATION_ID", "conv-1")],
             "spawn_env forwarded into CommandSpec.env"
         );
+    }
+
+    /// #410 parity wiring: a spawner failing with the classified
+    /// `ProcessError::WorkspaceUnavailable` surfaces from `open_session` as
+    /// `BackendError::WorkspaceUnavailable` (path intact), NOT a blanket
+    /// `Transport` — the app layer maps it to the dedicated
+    /// workspace-unavailable API error (Sentry ELECTRON-3PP follow-up).
+    #[tokio::test]
+    async fn open_session_classifies_workspace_unavailable_spawn_failure() {
+        struct WorkspaceGoneSpawner;
+        #[async_trait::async_trait]
+        impl aionui_process::Spawner for WorkspaceGoneSpawner {
+            async fn spawn(
+                &self,
+                _spec: aionui_common::CommandSpec,
+                _extra_env: &[(String, String)],
+                _opaque_owner_tag: &str,
+            ) -> Result<std::sync::Arc<aionui_process::ManagedProcess>, aionui_process::ProcessError> {
+                Err(aionui_process::ProcessError::workspace_unavailable("/gone/workspace"))
+            }
+        }
+
+        let conn = CodexConnection::new(std::sync::Arc::new(WorkspaceGoneSpawner));
+        let res = conn
+            .open_session(
+                SessionSpec::Fresh {
+                    session_id: "logical-1".into(),
+                },
+                SessionConfig {
+                    cwd: Some("/gone/workspace".into()),
+                    ..Default::default()
+                },
+            )
+            .await;
+        // `expect_err` needs `T: Debug` and `Arc<dyn SessionBackend>` has none.
+        let Err(err) = res else {
+            panic!("open_session must fail when the spawner reports workspace-unavailable");
+        };
+        assert_eq!(err, BackendError::WorkspaceUnavailable("/gone/workspace".into()));
     }
 
     // ===== B-CODEX-MODEL-LIST: discovery (model/list + permissionProfile/list) =====

--- a/crates/aionui-session/src/backend/types.rs
+++ b/crates/aionui-session/src/backend/types.rs
@@ -216,6 +216,12 @@ pub enum BackendError {
     CommandNotSupported { command: &'static str },
     #[error("backend transport error: {0}")]
     Transport(String),
+    /// The session workspace (spawn cwd) is missing, not a directory, or not
+    /// accessible. Carried as its own class (not `Transport`) so the app layer
+    /// can keep the legacy #410 workspace-unavailable UX instead of an opaque
+    /// 502; payload = the path.
+    #[error("workspace unavailable: {0}")]
+    WorkspaceUnavailable(String),
     #[error("session not found: {0}")]
     SessionNotFound(String),
     #[error("backend setup/handshake rejected: {0}")]
@@ -227,6 +233,20 @@ pub enum BackendError {
     /// please retry" (503-class) instead of an opaque 500 (bug-hunt codex-500).
     #[error("backend handshake timed out (agent still starting): {0}")]
     HandshakeTimeout(String),
+}
+
+impl BackendError {
+    /// Map a spawn-layer failure into the seam error. The classified
+    /// `WorkspaceUnavailable` passes through as its own class (the app layer
+    /// surfaces the legacy #410 workspace-unavailable UX from it); everything
+    /// else collapses to `Transport` under the caller's context prefix, as
+    /// before.
+    pub(crate) fn from_spawn(context: &'static str, e: aionui_process::ProcessError) -> Self {
+        match e {
+            aionui_process::ProcessError::WorkspaceUnavailable(path) => Self::WorkspaceUnavailable(path),
+            e => Self::Transport(format!("{context}: {e}")),
+        }
+    }
 }
 
 // ==========================================================================
@@ -400,5 +420,23 @@ mod tests {
     fn command_names_are_stable() {
         assert_eq!(command_name(&Command::Rewind { num_turns: 2 }), "rewind");
         assert_eq!(command_name(&Command::ListCheckpoints), "list_checkpoints");
+    }
+
+    /// #410 parity: the classified workspace-unavailable spawn failure crosses
+    /// the seam as its own `BackendError` class (path payload intact); every
+    /// other spawn failure collapses to `Transport` under the context prefix.
+    #[test]
+    fn from_spawn_keeps_workspace_unavailable_class() {
+        let err = BackendError::from_spawn(
+            "codex spawn failed",
+            aionui_process::ProcessError::workspace_unavailable("/gone/workspace"),
+        );
+        assert_eq!(err, BackendError::WorkspaceUnavailable("/gone/workspace".into()));
+
+        let err = BackendError::from_spawn("codex spawn failed", aionui_process::ProcessError::internal("boom"));
+        assert_eq!(
+            err,
+            BackendError::Transport("codex spawn failed: internal error: boom".into())
+        );
     }
 }

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -1643,6 +1643,22 @@ pub(crate) async fn attach_member_runtime(
             .cleanup_stale_member_runtime_task(&session, &agent.conversation_id)
             .await;
         let failure = sanitize_member_runtime_failure(&error);
+        // Log the RAW error before it is sanitized away: the broadcast/public
+        // reason is intentionally generic ("Agent runtime failed to start"),
+        // and without this line production logs carry no trace of the actual
+        // cause (Sentry ELECTRON-3PP was only diagnosable by timing forensics).
+        // TeamError texts here are runtime/spawn diagnostics (never prompts,
+        // tool payloads, or secrets), so info-level visibility is safe.
+        warn!(
+            team_id = session.team_id(),
+            slot_id = agent.slot_id,
+            conversation_id = agent.conversation_id,
+            operation_id,
+            generation,
+            error_classification = failure.classification,
+            error = %error,
+            "team member runtime attach failed"
+        );
         if session.member_runtimes.commit_failed(&lease, failure.clone()) {
             service.broadcast_agent_runtime_status(
                 session.team_id(),


### PR DESCRIPTION
## Summary

Fixes Sentry **ELECTRON-3PP** (AionUi 2.1.40): teams with a claude/codex leader fail with "Agent runtime failed to start" while aionrs leaders work — plus two sibling parity gaps found by auditing every upstream fix on the replaced spawn path against the session rewrite.

### Commit 1 — whitespace cwd regression (the P0)

- `aionui-process::prepare_command_cwd` rejected any cwd containing a whitespace path segment. Every claude/codex direct-CLI spawn goes through it (`RealSpawner → ManagedProcess::spawn`), so workspaces under iCloud Drive (`~/Library/Mobile Documents/…`) — or any folder with a space — failed instantly (µs-level, before posix_spawn). Non-team claude/codex conversations in such workspaces are equally affected; teams just mask the error hardest.
- Upstream already removed the same check from the legacy spawn path in #410 (with pinned regression tests); the rewritten crate kept the pre-#410 semantics and #609 carried it into production. The cwd is passed to the OS as a single argument (never through a shell), so no quoting hazard exists.
- Drop the check + its error variant; pin regression tests (whitespace in any segment / trailing whitespace must pass; empty, missing, non-directory still rejected).
- `attach_member_runtime` (aionui-team): log the raw `TeamError` at `warn` before `sanitize_member_runtime_failure` genericizes it — production logs previously carried no trace of the real cause.

### Commit 2 — two parity follow-ups from the same audit

- **#410 error-class parity**: a missing / non-directory workspace now keeps its dedicated class end-to-end instead of collapsing into an opaque 502: `ProcessError::WorkspaceUnavailable` → `BackendError::from_spawn` (all six conn spawn sites) → `AgentError::WorkspacePathRuntimeUnavailable` → the existing `WORKSPACE_PATH_RUNTIME_UNAVAILABLE` API error the frontend already renders.
- **#299 Windows CLI-resolution parity**: when `resolve_bundled_cli` finds no bundled binary, resolve the bare `claude`/`codex` through `resolve_command_path` (PATHEXT + npm `.cmd`/`.ps1`/`.bat` shim lookup) instead of handing a bare name to `CreateProcess`, which cannot resolve npm shims. Nothing-on-PATH still falls back to the bare name so the spawn error stays diagnosable.

## Root-cause evidence (commit 1)

- 07-22 (v2.1.39 legacy ACP): the same leader conversation spawned fine with `cwd=/Users/…/Library/Mobile Documents/com~apple~CloudDocs/…` (user logs, pid 2407).
- 07-23 (v2.1.40): same conversation fails 320µs after the `approval policy resolved` log — exactly the pre-spawn cwd guard; bundled CLI resolution succeeded (binaries verified present, +x, runnable in the 2.1.40 artifact).
- An aionrs-leader team on the SAME workspace works (in-process, no spawn) — matching the user report.

## Testing

- New tests: `prepare_command_cwd` classification + whitespace pins (aionui-process), `from_spawn` unit (types.rs), `open_session` wiring with a workspace-gone spawner (codex_conn)
- `cargo clippy -p aionui-process -p aionui-session -p aionui-ai-agent -p aionui-team -- -D warnings`
- `just push` full gate ×2 — workspace nextest 7429 passed / 18 skipped