### PR TITLE
fix(team): converge system/lifecycle wakes into a team run

### DIFF
--- a/crates/aionui-api-types/src/team.rs
+++ b/crates/aionui-api-types/src/team.rs
@@ -288,6 +288,11 @@ pub enum TeamRunStatus {
 #[serde(rename_all = "snake_case")]
 pub enum TeamRunSource {
     UserMessage,
+    /// A team run opened by a system/lifecycle wake (member add/remove,
+    /// recovery drain, idle settle, spawn welcome) rather than a user message,
+    /// so every agent turn runs inside exactly one run and run-scoped tools are
+    /// always permitted. Distinguished from `UserMessage` for observability.
+    SystemLifecycle,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -816,6 +816,27 @@ impl TeamSession {
         Ok(commit.team_run_id)
     }
 
+    /// Enqueue a system/lifecycle wake so the woken agent's turn always runs
+    /// inside a team run (attaching to the caller's or team's active run, or
+    /// opening a `SystemLifecycle` run when idle). This upholds the invariant
+    /// that every agent turn is run-scoped, so run-scoped tools like
+    /// `team_send_message` are never rejected for a run-less system wake.
+    async fn enqueue_system_work(
+        &self,
+        slot_id: &str,
+        source: WorkSource,
+        mailbox_message_id: Option<String>,
+        inherit_from: Option<String>,
+    ) -> Result<Option<String>, TeamError> {
+        self.enqueue_existing_work(
+            slot_id,
+            source,
+            mailbox_message_id,
+            CausalBinding::SystemInitiated { inherit_from },
+        )
+        .await
+    }
+
     async fn commit_persisted_enqueue(
         &self,
         lease: &EnqueueLease,
@@ -852,8 +873,7 @@ impl TeamSession {
         slot_id: &str,
         source: WorkSource,
     ) -> Result<(), TeamError> {
-        self.enqueue_existing_work(slot_id, source, None, CausalBinding::ActiveRunOrBackground)
-            .await?;
+        self.enqueue_system_work(slot_id, source, None, None).await?;
         Ok(())
     }
 
@@ -888,13 +908,8 @@ impl TeamSession {
                 continue;
             }
             for message_id in unread {
-                self.enqueue_existing_work(
-                    &agent.slot_id,
-                    WorkSource::RecoveryDrain,
-                    Some(message_id),
-                    CausalBinding::Background,
-                )
-                .await?;
+                self.enqueue_system_work(&agent.slot_id, WorkSource::RecoveryDrain, Some(message_id), None)
+                    .await?;
             }
             recovered_slots.push(agent.slot_id);
         }
@@ -1172,15 +1187,8 @@ impl TeamSession {
         let Some(message_id) = message_id else {
             return Ok(());
         };
-        self.enqueue_existing_work(
-            &lead_slot_id,
-            source,
-            Some(message_id),
-            CausalBinding::InheritRunningBatch {
-                caller_slot_id: source_slot_id.to_owned(),
-            },
-        )
-        .await?;
+        self.enqueue_system_work(&lead_slot_id, source, Some(message_id), Some(source_slot_id.to_owned()))
+            .await?;
         Ok(())
     }
 
@@ -1240,18 +1248,13 @@ impl TeamSession {
         )
         .await;
 
-        self.enqueue_existing_work(
-            &agent.slot_id,
-            WorkSource::SpawnWelcome,
-            Some(welcome.id),
-            CausalBinding::ActiveRunOrBackground,
-        )
-        .await?;
-        self.enqueue_existing_work(
+        self.enqueue_system_work(&agent.slot_id, WorkSource::SpawnWelcome, Some(welcome.id), None)
+            .await?;
+        self.enqueue_system_work(
             &lead_slot_id,
             WorkSource::TeamMembershipChanged,
             Some(leader_notice.id),
-            CausalBinding::ActiveRunOrBackground,
+            None,
         )
         .await?;
         Ok(())
@@ -1284,13 +1287,8 @@ impl TeamSession {
         self.project_team_system_message(&lead_slot_id, &lead_agent.conversation_id, &notice.id, &notice.content)
             .await;
 
-        self.enqueue_existing_work(
-            &lead_slot_id,
-            WorkSource::TeamMembershipChanged,
-            Some(notice.id),
-            CausalBinding::ActiveRunOrBackground,
-        )
-        .await?;
+        self.enqueue_system_work(&lead_slot_id, WorkSource::TeamMembershipChanged, Some(notice.id), None)
+            .await?;
 
         Ok(())
     }
@@ -1474,13 +1472,11 @@ impl TeamSession {
             }
         };
 
-        self.enqueue_existing_work(
+        self.enqueue_system_work(
             &new_agent.slot_id,
             WorkSource::SpawnWelcome,
             Some(welcome_message.id),
-            CausalBinding::InheritRunningBatch {
-                caller_slot_id: caller_slot_id.to_owned(),
-            },
+            Some(caller_slot_id.to_owned()),
         )
         .await?;
 
@@ -2500,7 +2496,21 @@ mod tests {
             .expect("scan should not fail");
 
         assert_eq!(result, vec![lead.clone()]);
-        assert!(session.team_run_manager().current_active_run_id().is_none());
+        // Recovery drain now runs the recovered work inside a SystemLifecycle
+        // run instead of run-less background, upholding the invariant that every
+        // recovered turn is run-scoped. The lead's non-self unread drains into
+        // exactly one such run (not one per message).
+        let run_id = session
+            .team_run_manager()
+            .current_active_run_id()
+            .expect("recovery drain must open a system run");
+        let payload = session
+            .team_run_manager()
+            .current_payload(&session.work_coordinator().snapshot())
+            .expect("the recovery system run must be observable");
+        assert_eq!(payload.team_run_id, run_id);
+        assert_eq!(payload.source, aionui_api_types::TeamRunSource::SystemLifecycle);
+        assert!(!payload.has_user_intervention);
     }
 
     #[tokio::test]

--- a/crates/aionui-team/src/team_run/manager.rs
+++ b/crates/aionui-team/src/team_run/manager.rs
@@ -98,6 +98,51 @@ impl TeamRunManager {
         }
     }
 
+    /// Bind a system/lifecycle enqueue. Mirrors `bind_user_enqueue` but never
+    /// marks the run as user-intervened: attach to the active run if one exists,
+    /// otherwise open a new `SystemLifecycle` run. Like `bind_user_enqueue`, this
+    /// only creates the record and logs `team run accepted`; the
+    /// `TEAM_RUN_ACCEPTED` event is emitted by `apply_work_summary` via the
+    /// `accepted_emitted` flag, so we must not broadcast here.
+    pub(crate) fn bind_system_enqueue(&self, target_slot_id: &str, target_role: TeamRunTargetRole) -> RunBinding {
+        let mut state = self.lock_state();
+        if let Some(run) = state.as_ref().filter(|run| run.is_active()) {
+            return RunBinding {
+                team_run_id: Some(run.team_run_id.clone()),
+                created_new_run: false,
+                user_intervention: false,
+            };
+        }
+
+        let run = TeamRunRecord {
+            team_run_id: generate_id(),
+            source: TeamRunSource::SystemLifecycle,
+            has_user_intervention: false,
+            target_slot_id: target_slot_id.to_owned(),
+            target_role,
+            status: TeamRunStatus::Accepted,
+            started_at_ms: None,
+            completed_at_ms: None,
+            cancel_reason: None,
+            summary: None,
+            accepted_emitted: false,
+        };
+        let run_id = run.team_run_id.clone();
+        *state = Some(run);
+        drop(state);
+        info!(
+            team_id = %self.team_id,
+            team_run_id = %run_id,
+            target_slot_id,
+            "team run accepted"
+        );
+        RunBinding {
+            team_run_id: Some(run_id),
+            created_new_run: true,
+            user_intervention: false,
+        }
+    }
+
     pub fn current_active_run_id(&self) -> Option<String> {
         self.lock_state()
             .as_ref()
@@ -278,7 +323,12 @@ impl RunCausalityPort for TeamRunManager {
                 created_new_run: false,
                 user_intervention: false,
             },
+            CausalBinding::SystemInitiated { .. } => self.bind_system_enqueue(&request.slot_id, request.role.clone()),
         }
+    }
+
+    fn bind_system_enqueue(&self, request: &EnqueueRequest) -> RunBinding {
+        self.bind_system_enqueue(&request.slot_id, request.role.clone())
     }
 
     fn abort_binding(&self, binding: &RunBinding) {

--- a/crates/aionui-team/src/team_run/tests.rs
+++ b/crates/aionui-team/src/team_run/tests.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use aionui_api_types::{TeamRunStatus, TeamRunTargetRole};
+use aionui_api_types::{TeamRunSource, TeamRunStatus, TeamRunTargetRole};
 
 use crate::events::TeamEventEmitter;
 use crate::team_run::TeamRunManager;
@@ -287,4 +287,192 @@ fn manual_or_leader_add_during_run_inherits_run_causality() {
 
     assert_eq!(manual.team_run_id.as_deref(), Some(run_id.as_str()));
     assert_eq!(leader_spawn.team_run_id.as_deref(), Some(run_id.as_str()));
+}
+
+fn acquire_system(
+    coordinator: &SlotWorkCoordinator,
+    slot_id: &str,
+    role: TeamRunTargetRole,
+    source: WorkSource,
+    inherit_from: Option<String>,
+) -> crate::work_coordinator::EnqueueLease {
+    coordinator
+        .acquire_enqueue(EnqueueRequest {
+            slot_id: slot_id.into(),
+            role,
+            source,
+            binding: CausalBinding::SystemInitiated { inherit_from },
+        })
+        .unwrap()
+}
+
+#[test]
+fn system_initiated_without_active_run_opens_system_lifecycle_run() {
+    let (coordinator, manager) = coordinator_and_manager();
+    let lease = acquire_system(
+        &coordinator,
+        "lead-1",
+        TeamRunTargetRole::Lead,
+        WorkSource::SpawnWelcome,
+        None,
+    );
+    assert!(lease.team_run_id.is_some(), "a system wake must open a run when idle");
+    coordinator.commit_enqueue(&lease, Some("m1".into())).unwrap();
+    let ReconcileDecision::Claim(_batch) = coordinator.next("lead-1") else {
+        panic!("system intent must be claimable");
+    };
+
+    assert!(manager.current_active_run_id().is_some());
+    let payload = manager.current_payload(&coordinator.snapshot()).unwrap();
+    assert_eq!(payload.source, TeamRunSource::SystemLifecycle);
+    assert!(
+        !payload.has_user_intervention,
+        "a system run must not be flagged as user-intervened"
+    );
+}
+
+#[test]
+fn system_initiated_attaches_to_existing_user_run() {
+    let (coordinator, manager) = coordinator_and_manager();
+    let user = acquire(&coordinator, CausalBinding::UserVisible);
+    let run_id = user.team_run_id.clone().unwrap();
+    coordinator.commit_enqueue(&user, Some("m-user".into())).unwrap();
+    assert_eq!(manager.current_active_run_id().as_deref(), Some(run_id.as_str()));
+
+    let system = acquire_system(
+        &coordinator,
+        "lead-1",
+        TeamRunTargetRole::Lead,
+        WorkSource::TeamMembershipChanged,
+        None,
+    );
+    assert_eq!(
+        system.team_run_id.as_deref(),
+        Some(run_id.as_str()),
+        "a system wake must attach to the active user run"
+    );
+    coordinator.commit_enqueue(&system, Some("m-system".into())).unwrap();
+
+    assert_eq!(
+        manager.current_active_run_id().as_deref(),
+        Some(run_id.as_str()),
+        "attaching must not open a second run"
+    );
+    let payload = manager.current_payload(&coordinator.snapshot()).unwrap();
+    assert_eq!(
+        payload.source,
+        TeamRunSource::UserMessage,
+        "attaching keeps the original user run"
+    );
+    assert!(
+        !payload.has_user_intervention,
+        "a system attach must not flag user intervention"
+    );
+}
+
+#[test]
+fn system_initiated_inherits_callers_running_run() {
+    let (coordinator, manager) = coordinator_and_manager();
+    coordinator.set_runtime_constraint("worker-1", RuntimeConstraint::Ready);
+    let user = acquire(&coordinator, CausalBinding::UserVisible);
+    let run_id = user.team_run_id.clone().unwrap();
+    coordinator.commit_enqueue(&user, Some("m-user".into())).unwrap();
+    let ReconcileDecision::Claim(batch) = coordinator.next("lead-1") else {
+        panic!("caller batch must be claimable");
+    };
+    coordinator.mark_started(&batch, "turn-lead");
+
+    let inherited = acquire_system(
+        &coordinator,
+        "worker-1",
+        TeamRunTargetRole::Teammate,
+        WorkSource::SpawnWelcome,
+        Some("lead-1".into()),
+    );
+    assert_eq!(
+        inherited.team_run_id.as_deref(),
+        Some(run_id.as_str()),
+        "a system wake must inherit the caller's running run"
+    );
+    assert_eq!(
+        manager.current_active_run_id().as_deref(),
+        Some(run_id.as_str()),
+        "inheriting must not open a second run"
+    );
+    coordinator.abort_enqueue(&inherited, "test_complete");
+}
+
+#[test]
+fn system_initiated_inherit_miss_falls_back_to_new_system_run() {
+    let (coordinator, manager) = coordinator_and_manager();
+    // Caller slot has no active batch and the team has no active run, so the
+    // inherit lookup misses and we open a fresh system run.
+    let lease = acquire_system(
+        &coordinator,
+        "lead-1",
+        TeamRunTargetRole::Lead,
+        WorkSource::SpawnWelcome,
+        Some("worker-unknown".into()),
+    );
+    assert!(lease.team_run_id.is_some());
+    coordinator.commit_enqueue(&lease, Some("m1".into())).unwrap();
+
+    let payload = manager.current_payload(&coordinator.snapshot()).unwrap();
+    assert_eq!(payload.source, TeamRunSource::SystemLifecycle);
+    assert!(!payload.has_user_intervention);
+}
+
+#[test]
+fn system_run_completes_after_single_batch_no_dangling() {
+    let (coordinator, manager) = coordinator_and_manager();
+    let lease = acquire_system(
+        &coordinator,
+        "lead-1",
+        TeamRunTargetRole::Lead,
+        WorkSource::SpawnWelcome,
+        None,
+    );
+    coordinator.commit_enqueue(&lease, Some("m1".into())).unwrap();
+    let ReconcileDecision::Claim(batch) = coordinator.next("lead-1") else {
+        panic!("system intent must be claimable");
+    };
+    coordinator.complete_batch(&batch);
+
+    let payload = manager.current_payload(&coordinator.snapshot()).unwrap();
+    assert_eq!(payload.status, TeamRunStatus::Completed);
+    assert_eq!(
+        manager.current_active_run_id(),
+        None,
+        "an idle-settle system run must not dangle after its only batch completes"
+    );
+}
+
+#[test]
+fn recovery_drain_multiple_messages_reuse_single_system_run() {
+    let (coordinator, manager) = coordinator_and_manager();
+    let first = acquire_system(
+        &coordinator,
+        "lead-1",
+        TeamRunTargetRole::Lead,
+        WorkSource::RecoveryDrain,
+        None,
+    );
+    let run_id = first.team_run_id.clone().expect("the first drain opens a system run");
+    coordinator.commit_enqueue(&first, Some("m1".into())).unwrap();
+
+    let second = acquire_system(
+        &coordinator,
+        "lead-1",
+        TeamRunTargetRole::Lead,
+        WorkSource::RecoveryDrain,
+        None,
+    );
+    coordinator.commit_enqueue(&second, Some("m2".into())).unwrap();
+
+    assert_eq!(
+        second.team_run_id.as_deref(),
+        Some(run_id.as_str()),
+        "subsequent drains must attach to the single system run, not open new ones"
+    );
+    assert_eq!(manager.current_active_run_id().as_deref(), Some(run_id.as_str()));
 }

--- a/crates/aionui-team/src/work_coordinator/coordinator.rs
+++ b/crates/aionui-team/src/work_coordinator/coordinator.rs
@@ -132,6 +132,23 @@ impl SlotWorkCoordinator {
             CausalBinding::UserVisible | CausalBinding::ActiveRunOrBackground => {
                 self.run_causality.bind_enqueue(&request)
             }
+            CausalBinding::SystemInitiated { inherit_from } => {
+                let inherited = inherit_from.as_ref().and_then(|caller_slot_id| {
+                    state
+                        .slots
+                        .get(caller_slot_id)
+                        .and_then(|caller| caller.active.as_ref())
+                        .and_then(|active| active.batch.team_run_ids.first().cloned())
+                });
+                match inherited {
+                    Some(team_run_id) => RunBinding {
+                        team_run_id: Some(team_run_id),
+                        created_new_run: false,
+                        user_intervention: false,
+                    },
+                    None => self.run_causality.bind_system_enqueue(&request),
+                }
+            }
         };
         let lease = EnqueueLease {
             lease_id: generate_id(),

--- a/crates/aionui-team/src/work_coordinator/model.rs
+++ b/crates/aionui-team/src/work_coordinator/model.rs
@@ -80,9 +80,25 @@ pub(crate) struct WorkIntent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CausalBinding {
     UserVisible,
-    InheritRunningBatch { caller_slot_id: String },
+    InheritRunningBatch {
+        caller_slot_id: String,
+    },
+    // `ActiveRunOrBackground` and `Background` no longer have production
+    // callers now that all system/lifecycle wakes go through `SystemInitiated`
+    // (which never leaves a turn run-less). They are intentionally retained as
+    // documented binding semantics and remain exercised by regression tests, so
+    // silence the lib-only dead-code lint rather than dropping the variants.
+    #[allow(dead_code)]
     ActiveRunOrBackground,
+    #[allow(dead_code)]
     Background,
+    /// System/lifecycle wake that must still run inside a team run. Resolution
+    /// order: inherit the caller's running batch run (when `inherit_from` is
+    /// set and that caller has one) → attach to the team's active run → open a
+    /// new `SystemLifecycle` run. Never leaves the turn run-less.
+    SystemInitiated {
+        inherit_from: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -235,6 +251,10 @@ pub(crate) struct RunBinding {
 
 pub(crate) trait RunCausalityPort: Send + Sync {
     fn bind_enqueue(&self, request: &EnqueueRequest) -> RunBinding;
+    /// Bind a system/lifecycle enqueue: attach to the team's active run when one
+    /// exists, otherwise open a new `SystemLifecycle` run. Never sets
+    /// `user_intervention` (the key difference from a user enqueue).
+    fn bind_system_enqueue(&self, request: &EnqueueRequest) -> RunBinding;
     fn abort_binding(&self, binding: &RunBinding);
     fn apply_work_summary(&self, summary: RunWorkSummary);
     /// Broadcast a single slot's current work snapshot, independent of any team

--- a/crates/aionui-team/src/work_coordinator/tests.rs
+++ b/crates/aionui-team/src/work_coordinator/tests.rs
@@ -9,6 +9,7 @@ use crate::{TeamError, work_source::WorkSource};
 struct RecordingRunCausality {
     summaries: Mutex<Vec<RunWorkSummary>>,
     slot_work: Mutex<Vec<SlotWorkSnapshot>>,
+    system_binds: Mutex<Vec<EnqueueRequest>>,
 }
 
 impl RunCausalityPort for RecordingRunCausality {
@@ -17,6 +18,15 @@ impl RunCausalityPort for RecordingRunCausality {
         RunBinding {
             team_run_id: user_visible.then(|| "run-1".to_owned()),
             created_new_run: user_visible,
+            user_intervention: false,
+        }
+    }
+
+    fn bind_system_enqueue(&self, request: &EnqueueRequest) -> RunBinding {
+        self.system_binds.lock().unwrap().push(request.clone());
+        RunBinding {
+            team_run_id: Some("system-run-1".to_owned()),
+            created_new_run: true,
             user_intervention: false,
         }
     }
@@ -466,4 +476,62 @@ fn late_terminal_after_cancel_is_rejected() {
     coordinator.cancel_run("run-1");
 
     assert_eq!(coordinator.complete_batch(&batch), CommitResult::StaleOwner);
+}
+
+#[test]
+fn system_initiated_inherit_uses_caller_batch_run() {
+    let (coordinator, recorder) = coordinator_with_recorder();
+    coordinator.set_runtime_constraint("lead-1", RuntimeConstraint::Ready);
+    // The caller runs a user batch that carries a team run id.
+    let caller = coordinator
+        .acquire_enqueue(EnqueueRequest {
+            slot_id: "lead-1".into(),
+            role: TeamRunTargetRole::Lead,
+            source: WorkSource::UserMessage,
+            binding: CausalBinding::UserVisible,
+        })
+        .unwrap();
+    let run_id = caller.team_run_id.clone().expect("user enqueue must carry a run");
+    coordinator.commit_enqueue(&caller, Some("m-user".into())).unwrap();
+    let ReconcileDecision::Claim(batch) = coordinator.next("lead-1") else {
+        panic!("caller batch must be claimable");
+    };
+    assert_eq!(batch.team_run_ids, vec![run_id.clone()]);
+
+    // A system wake targeting a teammate inherits the caller's running run
+    // via the inline lookup, never falling back to the causality port.
+    let inherited = coordinator
+        .acquire_enqueue(EnqueueRequest {
+            slot_id: "worker-1".into(),
+            role: TeamRunTargetRole::Teammate,
+            source: WorkSource::SpawnWelcome,
+            binding: CausalBinding::SystemInitiated {
+                inherit_from: Some("lead-1".into()),
+            },
+        })
+        .unwrap();
+    assert_eq!(inherited.team_run_id.as_deref(), Some(run_id.as_str()));
+    assert!(
+        recorder.system_binds.lock().unwrap().is_empty(),
+        "an inherit hit must not delegate to bind_system_enqueue"
+    );
+}
+
+#[test]
+fn system_initiated_none_delegates_to_port() {
+    let (coordinator, recorder) = coordinator_with_recorder();
+    let lease = coordinator
+        .acquire_enqueue(EnqueueRequest {
+            slot_id: "lead-1".into(),
+            role: TeamRunTargetRole::Lead,
+            source: WorkSource::SpawnWelcome,
+            binding: CausalBinding::SystemInitiated { inherit_from: None },
+        })
+        .unwrap();
+    assert_eq!(lease.team_run_id.as_deref(), Some("system-run-1"));
+    assert_eq!(
+        recorder.system_binds.lock().unwrap().len(),
+        1,
+        "a None inherit must delegate to bind_system_enqueue"
+    );
 }

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -13,7 +13,7 @@ use aionui_ai_agent::types::BuildTaskOptions;
 use aionui_ai_agent::{ActiveLeaseRegistry, AgentError, IWorkerTaskManager, WorkerTaskManagerImpl};
 use aionui_api_types::{
     AcpBuildExtra, AcpConfigOptionDto, AcpConfigSelectOptionDto, AddAgentRequest, CreateTeamRequest,
-    GetConfigOptionsResponse, TeamAgentInput, WebSocketMessage,
+    GetConfigOptionsResponse, TeamAgentInput, TeamRunSource, WebSocketMessage,
 };
 use aionui_common::{AgentKillReason, AgentType, PaginatedResult, ProviderWithModel};
 use aionui_db::models::{
@@ -1644,7 +1644,7 @@ fn setup() -> Arc<TeamSessionService> {
 }
 
 #[tokio::test]
-async fn recovery_creates_background_intents_without_restoring_old_memory_run() {
+async fn recovery_creates_system_run_intents_without_restoring_old_memory_run() {
     let (svc, team_repo, turn_port, _conv_repo) = setup_with_recording_turn_port();
     let created = svc
         .create_team(
@@ -1694,9 +1694,12 @@ async fn recovery_creates_background_intents_without_restoring_old_memory_run() 
     let requests = turn_port.requests.lock().unwrap();
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0].slot_id, lead_slot_id);
-    assert_eq!(
-        requests[0].team_run_id, None,
-        "recovery work must not synthesize a user-visible TeamRun"
+    // Recovery drain now runs the recovered turn inside a freshly opened
+    // SystemLifecycle run (not run-less background, and not a restored
+    // pre-restart run), so the recovered turn carries a run id.
+    assert!(
+        requests[0].team_run_id.is_some(),
+        "recovery work must run inside a system run, not run-less background"
     );
 }
 
@@ -3464,7 +3467,7 @@ async fn aa1_add_agent_to_team() {
 }
 
 #[tokio::test]
-async fn manual_add_without_active_run_queues_background_welcome_without_creating_run() {
+async fn manual_add_without_active_run_opens_system_lifecycle_run() {
     let (svc, _, conv_repo) = setup_with_factory_and_metadata_and_conversation_repo(
         success_factory(),
         Arc::new(StubAgentMetadataRepo::empty()),
@@ -3528,7 +3531,12 @@ async fn manual_add_without_active_run_queues_background_welcome_without_creatin
     assert!(added_content["content"].as_str().unwrap().contains("manually added"));
 
     let run_state = svc.get_run_state("user1", &created.id).await.unwrap();
-    assert!(run_state.active_run.is_none());
+    // Manual add during an idle team now opens a SystemLifecycle run so the
+    // welcome and membership-change turns run inside a run (invariant: no
+    // run-less turn), rather than falling to run-less background as before.
+    let active_run = run_state.active_run.expect("manual add must open a system run");
+    assert_eq!(active_run.source, TeamRunSource::SystemLifecycle);
+    assert!(!active_run.has_user_intervention);
     assert!(run_state.slot_work.iter().any(|slot| slot.slot_id == added.slot_id));
 }
 


### PR DESCRIPTION
## Summary

Enforces the invariant that **every agent turn runs inside exactly one team run**, closing a bug class where system/lifecycle wakes enqueued run-less work.

When a team was idle (no in-progress run) and a member was added manually (e.g. opencode / hermes), the new member's first turn calling a team tool failed:

- MCP path: `team_send_message` → `Invalid request: no active team run for run-scoped wake`
- CLI path (hermes via the aioncore team CLI): `runtime_context_missing`

Restarting AionUi and resuming the team appeared to "fix" it, because the restart flow sent a user message that opened an active run — masking the real defect.

## Root cause

`send_agent_message_from_agent` is gated by `require_active_team_run_for_team_work`, which only passes when an active team run exists. Team run state is purely in-memory (`Mutex<Option<TeamRunRecord>>`) and was only ever created by user-visible enqueue (`bind_user_enqueue`).

Lifecycle kickoffs (manual-add `SpawnWelcome` / `TeamMembershipChanged`, and others) used a binding that never opened a run (`ActiveRunOrBackground`), so on an idle team the work landed in `background` (`team_run_id: None`). The woken member/leader then ran a turn with no active run and hit the gate. `add_manual_agent` was the reported symptom, but the same gap existed at every system/lifecycle enqueue site that can run an agent turn.

## Changes

Converge at the enqueue layer:

1. **Data model** — add `TeamRunSource::SystemLifecycle` (serialized as `"system_lifecycle"`) to distinguish system runs from user runs in events/logs. Lockstep release; no backward-compat layer.
2. **Causal binding** — add `CausalBinding::SystemInitiated { inherit_from }` and `RunCausalityPort::bind_system_enqueue`. Resolution: inherited caller batch run → team active run → otherwise open a new `SystemLifecycle` run. Mirrors `bind_user_enqueue` but never sets `user_intervention`, and only creates the record — it does **not** broadcast; `TEAM_RUN_ACCEPTED` still flows through the existing `apply_work_summary` (`accepted_emitted`) path, identical to user runs.
3. **Coordinator dispatch** — `SlotWorkCoordinator` gains a `SystemInitiated` arm; inherit lookup is inlined in the coordinator (needs `state.slots`), otherwise it delegates to `bind_system_enqueue`.
4. **Single enqueue helper** — `TeamSession::enqueue_system_work` reuses the existing `enqueue_existing_work` skeleton and failure-compensation path. Seven lifecycle sites are converged onto it: manual-add `SpawnWelcome` / `TeamMembershipChanged`, remove-member leader notification, recovery drain, leader idle settle, recovery-message leader wake, and `team_spawn_agent` welcome.
5. **Gate as safety net** — `require_active_team_run_for_team_work` is retained (not removed) as a regression probe.

The two `CausalBinding` variants that lost their production constructors (`ActiveRunOrBackground`, `Background`) are now test-only and kept deliberately (documented semantics + regression tests) under `#[allow(dead_code)]`.

## Schema / migration

None. Team run state is in-memory; no DB schema change and no migration.

## Testing

- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace -- -D warnings` — pass
- `cargo nextest run --workspace` — pass (7430 passed, 18 skipped), including 6 new `team_run` `SystemInitiated` unit tests, 2 new coordinator tests, and 3 updated regression tests (renamed for honesty: `manual_add_without_active_run_opens_system_lifecycle_run`, `recovery_creates_system_run_intents_without_restoring_old_memory_run`, and the session inline recovery test).

Three pre-existing tests were updated (not weakened) because the fix intentionally inverts their old run-less assertions.

## Manual verification still recommended (end-to-end, not driven by automated tests)

- Idle team + manual member add: the member's first turn `team_send_message` is allowed (no `no active team run`).
- hermes CLI path no longer reports `runtime_context_missing`.
- Frontend visibility of system runs via the existing event chain (zero rendering changes).

## Related

Ships lockstep with the AionUi type-sync PR that widens `ITeamRunEvent.source` to include `system_lifecycle`. Both must land together.
