### PR TITLE
fix: make team creation API fields optional

### DIFF
--- a/crates/aionui-api-types/src/team.rs
+++ b/crates/aionui-api-types/src/team.rs
@@ -34,6 +34,9 @@ struct TeamAgentInputCompat {
     pub assistant_id: Option<String>,
     pub name: String,
     pub role: String,
+    #[serde(default)]
+    pub backend: Option<String>,
+    #[serde(default)]
     pub model: String,
     #[serde(default)]
     pub conversation_id: Option<String>,
@@ -51,15 +54,13 @@ impl<'de> Deserialize<'de> for TeamAgentInput {
         D: Deserializer<'de>,
     {
         let raw = TeamAgentInputCompat::deserialize(deserializer)?;
-        let assistant_id =
-            normalize_assistant_id(raw.assistant_id).ok_or_else(|| serde::de::Error::missing_field("assistant_id"))?;
 
         Ok(Self {
             name: raw.name,
             role: raw.role,
-            backend: None,
+            backend: raw.backend,
             model: raw.model,
-            assistant_id: Some(assistant_id),
+            assistant_id: normalize_assistant_id(raw.assistant_id),
             conversation_id: raw.conversation_id,
         })
     }


### PR DESCRIPTION
## Problem

POST /api/teams returns Invalid JSON request body for any payload where agent objects omit model or assistant_id, and silently rejects backend due to deny_unknown_fields on TeamAgentInputCompat.

## Fix (3 changes)

1. Added backend field to TeamAgentInputCompat
2. Made model optional with serde(default)
3. Made assistant_id optional in custom deserializer