### PR TITLE
fix: preserve active team run across session restart

### DIFF
--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -891,6 +891,11 @@ impl TeamSessionService {
             |_| {},
         );
 
+        let carried_run_id = self
+            .sessions
+            .get(team_id)
+            .and_then(|entry| entry.session.team_run_manager().current_active_run_id());
+
         let session = match TeamSession::start_with_prompt_dump(
             team,
             self.repo.clone(),
@@ -965,6 +970,14 @@ impl TeamSessionService {
             slow_monitor_handle,
         };
         self.sessions.insert(team_id.to_owned(), entry);
+        // If the previous session had an active team run, carry it forward so
+        // team tools (e.g. team_send_message) don't fail with "no active team
+        // run for run-scoped wake" after a session restart.
+        if let Some(ref run_id) = carried_run_id {
+            if let Err(e) = session.team_run_manager().resume_run(run_id.clone()) {
+                tracing::warn!(team_id, error = %e, "failed to resume team run after session restart");
+            }
+        }
         drop(membership_guard);
         drop(ensure_guard);
 

--- a/crates/aionui-team/src/team_run/manager.rs
+++ b/crates/aionui-team/src/team_run/manager.rs
@@ -150,6 +150,34 @@ impl TeamRunManager {
             .map(|run| run.team_run_id.clone())
     }
 
+    /// Restore a run carried over from a session that was just replaced
+    /// (e.g. after `ensure_session_inner` recreates the `TeamSession` and its
+    /// `TeamRunManager`). Without this, `team_send_message` fails with
+    /// "no active team run for run-scoped wake" because the fresh manager
+    /// has no run state even though the previous session had one active.
+    pub(crate) fn resume_run(&self, run_id: String) -> Result<(), TeamError> {
+        let mut state = self.lock_state();
+        if state.is_some() {
+            return Err(TeamError::InvalidRequest(
+                "cannot resume: a run is already active".into(),
+            ));
+        }
+        *state = Some(TeamRunRecord {
+            team_run_id: run_id,
+            source: TeamRunSource::SystemLifecycle,
+            has_user_intervention: false,
+            target_slot_id: String::new(),
+            target_role: TeamRunTargetRole::Lead,
+            status: TeamRunStatus::Accepted,
+            started_at_ms: None,
+            completed_at_ms: None,
+            cancel_reason: None,
+            summary: None,
+            accepted_emitted: false,
+        });
+        Ok(())
+    }
+
     pub(crate) fn apply_work_summary(&self, summary: RunWorkSummary) {
         let event = {
             let mut state = self.lock_state();


### PR DESCRIPTION
## Problem

When a team session is restarted (e.g., after adding agents to an existing team), the `TeamRunManager` is recreated with no active run state. This causes `team_send_message` to fail with:

```
error=Invalid request: no active team run for run-scoped wake
error_code=RuntimeContextMissing
```

Which propagates through the MCP bridge as `"local team tool returned an error"`.

## Root Cause

`ensure_session_inner` in `service.rs` creates a new `TeamSession` (and thus a new `TeamRunManager`) when the session needs to be restarted. The fresh `TeamRunManager` starts with `state: None`, so any subsequent `team_send_message` call fails because `require_active_team_run_for_team_work` finds no active run.

## Fix

1. **`manager.rs`**: Added `TeamRunManager::resume_run(run_id)` — restores a carried-over run record in `Accepted` status on a fresh manager.

2. **`service.rs`**: In `ensure_session_inner`, before creating a new session, capture `carried_run_id` from any existing session's `current_active_run_id()`. After the new session is published in `self.sessions`, call `resume_run` to restore the run.

## Verification

- `cargo test -p aionui-team`: 409 passed, 0 failed
- No existing test assertions modified
- Binary built, deployed, and verified on live AionUi instance