### PR TITLE
fix(channel): quiet WeChat poll log noise with state-transition logging and exponential backoff

### DIFF
--- a/crates/aionui-channel/src/constants.rs
+++ b/crates/aionui-channel/src/constants.rs
@@ -88,6 +88,9 @@ pub const WEIXIN_RETRY_DELAY: Duration = Duration::from_secs(2);
 /// Longer backoff delay after max consecutive failures.
 pub const WEIXIN_BACKOFF_DELAY: Duration = Duration::from_secs(30);
 
+/// Maximum backoff delay between WeChat poll retries (10 minutes).
+pub const WEIXIN_MAX_BACKOFF: Duration = Duration::from_secs(600);
+
 /// Long-polling timeout for WeChat getupdates (matches iLink API).
 pub const WEIXIN_POLL_TIMEOUT: Duration = Duration::from_secs(35);
 
@@ -169,5 +172,6 @@ mod tests {
         assert_eq!(WEIXIN_BACKOFF_DELAY, Duration::from_secs(30));
         assert_eq!(WEIXIN_POLL_TIMEOUT, Duration::from_secs(35));
         assert_eq!(WEIXIN_API_TIMEOUT, Duration::from_secs(15));
+        assert_eq!(WEIXIN_MAX_BACKOFF, Duration::from_secs(600));
     }
 }

--- a/crates/aionui-channel/src/constants.rs
+++ b/crates/aionui-channel/src/constants.rs
@@ -79,15 +79,6 @@ pub const WEIXIN_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 /// Maximum file size for WeChat file handling (200 MB).
 pub const WEIXIN_MAX_FILE_SIZE: u64 = 200 * 1024 * 1024;
 
-/// Maximum consecutive failures before WeChat applies longer backoff.
-pub const WEIXIN_MAX_RETRIES: u32 = 3;
-
-/// Short retry delay between WeChat poll attempts on failure.
-pub const WEIXIN_RETRY_DELAY: Duration = Duration::from_secs(2);
-
-/// Longer backoff delay after max consecutive failures.
-pub const WEIXIN_BACKOFF_DELAY: Duration = Duration::from_secs(30);
-
 /// Maximum backoff delay between WeChat poll retries (10 minutes).
 pub const WEIXIN_MAX_BACKOFF: Duration = Duration::from_secs(600);
 
@@ -167,9 +158,6 @@ mod tests {
     fn weixin_constants() {
         assert_eq!(WEIXIN_RESPONSE_TIMEOUT, Duration::from_secs(300));
         assert_eq!(WEIXIN_MAX_FILE_SIZE, 200 * 1024 * 1024);
-        assert_eq!(WEIXIN_MAX_RETRIES, 3);
-        assert_eq!(WEIXIN_RETRY_DELAY, Duration::from_secs(2));
-        assert_eq!(WEIXIN_BACKOFF_DELAY, Duration::from_secs(30));
         assert_eq!(WEIXIN_POLL_TIMEOUT, Duration::from_secs(35));
         assert_eq!(WEIXIN_API_TIMEOUT, Duration::from_secs(15));
         assert_eq!(WEIXIN_MAX_BACKOFF, Duration::from_secs(600));

--- a/crates/aionui-channel/src/plugins/weixin/plugin.rs
+++ b/crates/aionui-channel/src/plugins/weixin/plugin.rs
@@ -7,7 +7,9 @@ use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
-use crate::constants::{WEIXIN_BACKOFF_DELAY, WEIXIN_MAX_RETRIES, WEIXIN_POLL_TIMEOUT, WEIXIN_RETRY_DELAY};
+use crate::constants::{
+    WEIXIN_BACKOFF_DELAY, WEIXIN_MAX_BACKOFF, WEIXIN_MAX_RETRIES, WEIXIN_POLL_TIMEOUT, WEIXIN_RETRY_DELAY,
+};
 use crate::error::ChannelError;
 use crate::plugin::{ChannelPlugin, PluginCallbacks};
 use crate::types::{
@@ -289,6 +291,42 @@ async fn poll_loop(
     debug!("WeChat poll loop exited");
 }
 
+/// Exponential backoff delay for WeChat poll failures: `2^n` seconds,
+/// capped at `WEIXIN_MAX_BACKOFF` (10 minutes). `saturating_pow` guards
+/// against overflow on long failure streaks.
+#[allow(dead_code)] // wired into poll_loop in Task 2
+fn backoff_delay(consecutive_failures: u32) -> Duration {
+    let secs = 2u64
+        .saturating_pow(consecutive_failures)
+        .min(WEIXIN_MAX_BACKOFF.as_secs());
+    Duration::from_secs(secs)
+}
+
+/// What to log for a single WeChat poll outcome, decided from the failure
+/// streak *before* this outcome is applied. Keeps the log-level policy in
+/// one pure, testable place; the loop performs the actual logging.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PollLogAction {
+    /// Success while healthy — log nothing.
+    Silent,
+    /// First failure after a healthy streak (0 -> 1) — log once at warn.
+    StartedFailing,
+    /// Repeated failure while already failing — log at debug only.
+    StillFailing,
+    /// First success after one or more failures — log once at info.
+    Recovered,
+}
+
+#[allow(dead_code)] // wired into poll_loop in Task 2
+fn poll_log_action(prev_failures: u32, succeeded: bool) -> PollLogAction {
+    match (succeeded, prev_failures) {
+        (true, 0) => PollLogAction::Silent,
+        (true, _) => PollLogAction::Recovered,
+        (false, 0) => PollLogAction::StartedFailing,
+        (false, _) => PollLogAction::StillFailing,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Message handling
 // ---------------------------------------------------------------------------
@@ -410,6 +448,50 @@ mod tests {
     use super::*;
     use crate::types::PluginCredentials;
     use std::collections::HashMap;
+
+    // -- backoff_delay ---------------------------------------------------------
+
+    #[test]
+    fn backoff_delay_exponential_curve() {
+        assert_eq!(backoff_delay(1), Duration::from_secs(2));
+        assert_eq!(backoff_delay(2), Duration::from_secs(4));
+        assert_eq!(backoff_delay(3), Duration::from_secs(8));
+        assert_eq!(backoff_delay(4), Duration::from_secs(16));
+        assert_eq!(backoff_delay(5), Duration::from_secs(32));
+        assert_eq!(backoff_delay(9), Duration::from_secs(512));
+    }
+
+    #[test]
+    fn backoff_delay_caps_at_ten_minutes() {
+        assert_eq!(backoff_delay(10), Duration::from_secs(600));
+        assert_eq!(backoff_delay(20), Duration::from_secs(600));
+        // Must not overflow on large counts.
+        assert_eq!(backoff_delay(u32::MAX), Duration::from_secs(600));
+    }
+
+    // -- poll_log_action -------------------------------------------------------
+
+    #[test]
+    fn log_action_silent_when_healthy_success() {
+        assert_eq!(poll_log_action(0, true), PollLogAction::Silent);
+    }
+
+    #[test]
+    fn log_action_started_failing_on_first_failure() {
+        assert_eq!(poll_log_action(0, false), PollLogAction::StartedFailing);
+    }
+
+    #[test]
+    fn log_action_still_failing_on_repeat_failure() {
+        assert_eq!(poll_log_action(1, false), PollLogAction::StillFailing);
+        assert_eq!(poll_log_action(9, false), PollLogAction::StillFailing);
+    }
+
+    #[test]
+    fn log_action_recovered_after_failures() {
+        assert_eq!(poll_log_action(1, true), PollLogAction::Recovered);
+        assert_eq!(poll_log_action(5, true), PollLogAction::Recovered);
+    }
 
     // -- extract_content -------------------------------------------------------
 

--- a/crates/aionui-channel/src/plugins/weixin/plugin.rs
+++ b/crates/aionui-channel/src/plugins/weixin/plugin.rs
@@ -7,9 +7,7 @@ use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
-use crate::constants::{
-    WEIXIN_BACKOFF_DELAY, WEIXIN_MAX_BACKOFF, WEIXIN_MAX_RETRIES, WEIXIN_POLL_TIMEOUT, WEIXIN_RETRY_DELAY,
-};
+use crate::constants::{WEIXIN_MAX_BACKOFF, WEIXIN_POLL_TIMEOUT};
 use crate::error::ChannelError;
 use crate::plugin::{ChannelPlugin, PluginCallbacks};
 use crate::types::{
@@ -218,70 +216,61 @@ async fn poll_loop(
             break;
         }
 
-        match api.get_updates(&buf).await {
+        // Reduce each round to success or a failure reason. On success we also
+        // advance the buffer and dispatch messages; on API error / transport
+        // error we only record the reason.
+        let outcome: Result<(), String> = match api.get_updates(&buf).await {
             Ok(resp) => {
                 let is_api_error = resp.ret.unwrap_or(0) != 0 || resp.errcode.unwrap_or(0) != 0;
-
                 if is_api_error {
-                    consecutive_failures += 1;
-                    warn!(
-                        ret = resp.ret,
-                        errcode = resp.errcode,
-                        consecutive_failures,
-                        "WeChat getupdates API error"
-                    );
-
-                    if consecutive_failures >= WEIXIN_MAX_RETRIES {
-                        consecutive_failures = 0;
-                        tokio::select! {
-                            _ = tokio::time::sleep(WEIXIN_BACKOFF_DELAY) => {}
-                            _ = shutdown_rx.changed() => {
-                                debug!("WeChat poll loop shutdown during backoff");
-                                break;
-                            }
-                        }
-                    } else {
-                        tokio::select! {
-                            _ = tokio::time::sleep(WEIXIN_RETRY_DELAY) => {}
-                            _ = shutdown_rx.changed() => {
-                                debug!("WeChat poll loop shutdown during retry");
-                                break;
-                            }
-                        }
+                    Err(format!(
+                        "getupdates API error ret={:?} errcode={:?}",
+                        resp.ret, resp.errcode
+                    ))
+                } else {
+                    if let Some(new_buf) = resp.get_updates_buf {
+                        buf = new_buf;
                     }
-                    continue;
-                }
-
-                consecutive_failures = 0;
-
-                if let Some(new_buf) = resp.get_updates_buf {
-                    buf = new_buf;
-                }
-
-                for msg in resp.msgs.unwrap_or_default() {
-                    handle_message(&msg, &message_tx, &context_tokens).await;
+                    for msg in resp.msgs.unwrap_or_default() {
+                        handle_message(&msg, &message_tx, &context_tokens).await;
+                    }
+                    Ok(())
                 }
             }
-            Err(e) => {
-                consecutive_failures += 1;
-                warn!(error = %e, consecutive_failures, "WeChat poll error");
+            Err(e) => Err(e.to_string()),
+        };
 
-                if consecutive_failures >= WEIXIN_MAX_RETRIES {
-                    consecutive_failures = 0;
-                    tokio::select! {
-                        _ = tokio::time::sleep(WEIXIN_BACKOFF_DELAY) => {}
-                        _ = shutdown_rx.changed() => {
-                            debug!("WeChat poll loop shutdown during backoff");
-                            break;
-                        }
+        match outcome {
+            Ok(()) => {
+                if poll_log_action(consecutive_failures, true) == PollLogAction::Recovered {
+                    info!(consecutive_failures, "WeChat poll recovered");
+                }
+                consecutive_failures = 0;
+            }
+            Err(reason) => {
+                let action = poll_log_action(consecutive_failures, false);
+                consecutive_failures += 1;
+                let delay = backoff_delay(consecutive_failures);
+                match action {
+                    PollLogAction::StartedFailing => {
+                        warn!(error = %reason, "WeChat poll started failing");
                     }
-                } else {
-                    tokio::select! {
-                        _ = tokio::time::sleep(WEIXIN_RETRY_DELAY) => {}
-                        _ = shutdown_rx.changed() => {
-                            debug!("WeChat poll loop shutdown during retry");
-                            break;
-                        }
+                    PollLogAction::StillFailing => {
+                        debug!(
+                            error = %reason,
+                            consecutive_failures,
+                            next_backoff_secs = delay.as_secs(),
+                            "WeChat poll still failing"
+                        );
+                    }
+                    // Silent / Recovered are not reachable on the failure branch.
+                    _ => {}
+                }
+                tokio::select! {
+                    _ = tokio::time::sleep(delay) => {}
+                    _ = shutdown_rx.changed() => {
+                        debug!("WeChat poll loop shutdown during backoff");
+                        break;
                     }
                 }
             }
@@ -294,7 +283,6 @@ async fn poll_loop(
 /// Exponential backoff delay for WeChat poll failures: `2^n` seconds,
 /// capped at `WEIXIN_MAX_BACKOFF` (10 minutes). `saturating_pow` guards
 /// against overflow on long failure streaks.
-#[allow(dead_code)] // wired into poll_loop in Task 2
 fn backoff_delay(consecutive_failures: u32) -> Duration {
     let secs = 2u64
         .saturating_pow(consecutive_failures)
@@ -317,7 +305,6 @@ enum PollLogAction {
     Recovered,
 }
 
-#[allow(dead_code)] // wired into poll_loop in Task 2
 fn poll_log_action(prev_failures: u32, succeeded: bool) -> PollLogAction {
     match (succeeded, prev_failures) {
         (true, 0) => PollLogAction::Silent,


### PR DESCRIPTION
## Summary

WeChat uses HTTP long-polling to receive messages. When the upstream (`ilink/bot/getupdates`) is unavailable, the poll loop logged a `warn` on **every** attempt and retried on a tight `2s × 3 + 30s` cadence forever. In production (`level=info`) this produced ~5 warn lines/minute per bound account, indefinitely — pure noise that also buried any real signal.

This PR makes the WeChat poll loop quiet and self-throttling, with no change to Telegram / DingTalk / Lark, no `PluginStatus`/UI change, and no new dependencies.

## Problem

- Every transient failure logged at `warn` (production-visible), with no de-duplication or rate limiting.
- Retry cadence (`2s × 3` then `30s`, reset, repeat) was both noisy and wasteful, and never backed off further.

## Changes

Two orthogonal levers, both scoped to `crates/aionui-channel`:

1. **State-transition logging.** The failure stream now logs only on transitions:
   - first failure → one `warn` (`"WeChat poll started failing"`)
   - subsequent failures → `debug` only (invisible in production)
   - recovery → one `info` (`"WeChat poll recovered"`, with the failure count)
   - normal success → silent (unchanged)
2. **Exponential backoff.** Replaces the `2s × 3 + 30s` scheme with `2^n` seconds capped at 10 minutes (`2, 4, 8, 16, 32, 64, 128, 256, 512, 600, 600…`). Retries are unbounded and self-healing — a single success resets the streak.

Both API-error (`ret`/`errcode`) and transport-error paths now share one failure counter, one backoff function, and one logging policy. The log-level decision (`poll_log_action`) and the backoff curve (`backoff_delay`) are extracted as pure functions for unit testing.

The now-unused constants `WEIXIN_MAX_RETRIES`, `WEIXIN_RETRY_DELAY`, and `WEIXIN_BACKOFF_DELAY` are removed; `WEIXIN_MAX_BACKOFF` (600s) is added.

## Behavior (upstream down for 1 hour, single account)

| | Before | After |
|---|---|---|
| Production logs (`info`) | ~300 `warn` | **2** (start `warn` + recover `info`) |
| Retry attempts | thousands | ~a dozen |
| Recovery | automatic | automatic (≤10 min to notice) |

## Testing

- Unit tests for `backoff_delay` (exponential curve + 10-minute cap + overflow guard) and `poll_log_action` (all four transitions).
- `cargo test -p aionui-channel --features weixin` → 256 passed / 0 failed.
- `cargo clippy -p aionui-channel --features weixin -- -D warnings` and default-feature clippy both clean.
- Full pre-push gate (`just push`) passed.
- Verified against a real upstream outage in the dev environment: exactly one `warn` on start, followed by `debug` lines whose intervals matched the backoff curve (`2 → 4 → 8 → 16 → 32 → 64 → 128 s`); the old per-2s `warn` spam is gone.

## Non-goals

- Telegram / DingTalk / Lark behavior is untouched (Telegram's separate silent-give-up + stale-status issue is noted but out of scope).
- No `PluginStatus`/UI change; the loop's fix is fully internal.

## Logging compliance

New `warn`/`info` lines carry only the network/HTTP error string, numeric error codes, failure counts, and backoff seconds — no prompts, message bodies, tokens, or secrets.
