### PR TITLE
feat(shell): open workspace folders in Zed when installed

### DIFF
--- a/crates/aionui-api-types/src/shell.rs
+++ b/crates/aionui-api-types/src/shell.rs
@@ -10,6 +10,7 @@ pub enum ToolType {
     Vscode,
     Terminal,
     Explorer,
+    Zed,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -147,6 +148,7 @@ mod tests {
         assert_eq!(serde_json::to_value(ToolType::Vscode).unwrap(), "vscode");
         assert_eq!(serde_json::to_value(ToolType::Terminal).unwrap(), "terminal");
         assert_eq!(serde_json::to_value(ToolType::Explorer).unwrap(), "explorer");
+        assert_eq!(serde_json::to_value(ToolType::Zed).unwrap(), "zed");
     }
 
     #[test]
@@ -157,6 +159,8 @@ mod tests {
         assert_eq!(t, ToolType::Terminal);
         let e: ToolType = serde_json::from_str(r#""explorer""#).unwrap();
         assert_eq!(e, ToolType::Explorer);
+        let z: ToolType = serde_json::from_str(r#""zed""#).unwrap();
+        assert_eq!(z, ToolType::Zed);
     }
 
     #[test]
@@ -199,6 +203,13 @@ mod tests {
         let raw = json!({ "tool": "vscode" });
         let req: CheckToolInstalledRequest = serde_json::from_value(raw).unwrap();
         assert_eq!(req.tool, ToolType::Vscode);
+    }
+
+    #[test]
+    fn check_tool_installed_request_parses_zed() {
+        let raw = json!({ "tool": "zed" });
+        let req: CheckToolInstalledRequest = serde_json::from_value(raw).unwrap();
+        assert_eq!(req.tool, ToolType::Zed);
     }
 
     #[test]

--- a/crates/aionui-shell/src/shell.rs
+++ b/crates/aionui-shell/src/shell.rs
@@ -52,6 +52,7 @@ impl ShellService {
         match tool {
             ToolType::Terminal | ToolType::Explorer => true,
             ToolType::Vscode => self.detect_vscode(),
+            ToolType::Zed => self.detect_zed(),
         }
     }
 
@@ -61,6 +62,7 @@ impl ShellService {
             ToolType::Vscode => self.open_folder_vscode(&path).await,
             ToolType::Terminal => self.open_folder_terminal(&path).await,
             ToolType::Explorer => self.open_folder_explorer(&path).await,
+            ToolType::Zed => self.open_folder_zed(&path).await,
         }
     }
 
@@ -80,6 +82,41 @@ impl ShellService {
             return Err(ShellError::ToolNotInstalled("vscode".to_owned()));
         }
         self.opener.run_command("code", &[&path.to_string_lossy()]).await
+    }
+
+    /// Resolve an invokable Zed CLI binary.
+    ///
+    /// Prefers `zed` on PATH (after "Zed → Install CLI"). Falls back to the
+    /// macOS app CLI path so detection works when the symlink is missing.
+    /// Avoids spawning bare Windows `.cmd` shims (see AionUi#2210).
+    fn zed_cli_program(&self) -> Option<String> {
+        if self.opener.is_tool_available("zed") {
+            return Some("zed".to_owned());
+        }
+        if cfg!(target_os = "macos") {
+            let app_cli = "/Applications/Zed.app/Contents/MacOS/cli";
+            if Path::new(app_cli).exists() {
+                return Some(app_cli.to_owned());
+            }
+        }
+        if cfg!(target_os = "windows") {
+            // Prefer a real .exe on PATH only — never spawn .cmd without shell.
+            if self.opener.is_tool_available("zed.exe") {
+                return Some("zed.exe".to_owned());
+            }
+        }
+        None
+    }
+
+    fn detect_zed(&self) -> bool {
+        self.zed_cli_program().is_some()
+    }
+
+    async fn open_folder_zed(&self, path: &Path) -> Result<(), ShellError> {
+        let Some(program) = self.zed_cli_program() else {
+            return Err(ShellError::ToolNotInstalled("zed".to_owned()));
+        };
+        self.opener.run_command(&program, &[&path.to_string_lossy()]).await
     }
 
     async fn open_folder_terminal(&self, path: &Path) -> Result<(), ShellError> {
@@ -345,6 +382,22 @@ mod tests {
     async fn check_tool_explorer_always_true() {
         let svc = ShellService::new(Arc::new(NoopSystemOpener));
         assert!(svc.check_tool_installed(ToolType::Explorer).await);
+    }
+
+    #[tokio::test]
+    async fn check_tool_zed_returns_bool_with_noop() {
+        // NoopSystemOpener reports every tool available → zed appears installed.
+        let svc = ShellService::new(Arc::new(NoopSystemOpener));
+        assert!(svc.check_tool_installed(ToolType::Zed).await);
+    }
+
+    #[tokio::test]
+    async fn open_folder_zed_succeeds_with_noop_when_dir_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let svc = ShellService::new(Arc::new(NoopSystemOpener));
+        svc.open_folder_with(dir.path().to_str().unwrap(), ToolType::Zed)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/crates/aionui-shell/src/shell.rs
+++ b/crates/aionui-shell/src/shell.rs
@@ -258,7 +258,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::opener::NoopSystemOpener;
+    use crate::opener::{ISystemOpener, NoopSystemOpener};
     use std::fs;
 
     #[test]
@@ -398,6 +398,82 @@ mod tests {
         svc.open_folder_with(dir.path().to_str().unwrap(), ToolType::Zed)
             .await
             .unwrap();
+    }
+
+    /// Recording opener: captures the program/args of the last run_command.
+    struct RecordingOpener {
+        available: std::collections::HashSet<&'static str>,
+        last: std::sync::Mutex<Option<(String, Vec<String>)>>,
+    }
+
+    impl RecordingOpener {
+        fn with_tools(tools: &[&'static str]) -> Self {
+            Self {
+                available: tools.iter().copied().collect(),
+                last: std::sync::Mutex::new(None),
+            }
+        }
+
+        fn last_command(&self) -> Option<(String, Vec<String>)> {
+            self.last.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ISystemOpener for RecordingOpener {
+        fn open_detached(&self, _target: &str) -> Result<(), ShellError> {
+            Ok(())
+        }
+
+        async fn run_command(&self, program: &str, args: &[&str]) -> Result<(), ShellError> {
+            *self.last.lock().unwrap() = Some((program.to_owned(), args.iter().map(|s| (*s).to_owned()).collect()));
+            Ok(())
+        }
+
+        fn is_tool_available(&self, tool_name: &str) -> bool {
+            self.available.contains(tool_name)
+        }
+    }
+
+    #[tokio::test]
+    async fn open_folder_zed_invokes_zed_cli_with_folder_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let opener = Arc::new(RecordingOpener::with_tools(&["zed"]));
+        let svc = ShellService::new(opener.clone());
+        svc.open_folder_with(dir.path().to_str().unwrap(), ToolType::Zed)
+            .await
+            .unwrap();
+        let (program, args) = opener.last_command().expect("run_command should be called");
+        assert_eq!(program, "zed");
+        assert_eq!(args.len(), 1);
+        // Canonicalized path may differ by OS separators; ensure the folder is the arg.
+        let opened = std::path::Path::new(&args[0]);
+        assert_eq!(opened.canonicalize().unwrap(), dir.path().canonicalize().unwrap());
+    }
+
+    #[tokio::test]
+    async fn check_tool_zed_false_when_cli_unavailable() {
+        let opener = Arc::new(RecordingOpener::with_tools(&[])); // nothing on PATH
+        let svc = ShellService::new(opener);
+        // On CI macOS without Zed.app this is false; if Zed.app exists on the
+        // developer machine the macOS app CLI fallback may still detect it.
+        // Assert only the PATH-empty + no-app path via the recording opener's
+        // available set: detect_zed also checks the filesystem for the app CLI.
+        // So we only assert that when PATH has no zed and we're not relying on
+        // app fallback for this unit (filesystem is env-dependent).
+        let _ = svc.check_tool_installed(ToolType::Zed).await;
+        // Stronger assertion: open fails with ToolNotInstalled when both PATH
+        // and (if present) app CLI are missing. Skip hard false assert when
+        // local machine has /Applications/Zed.app.
+        if !std::path::Path::new("/Applications/Zed.app/Contents/MacOS/cli").exists() {
+            assert!(!svc.check_tool_installed(ToolType::Zed).await);
+            let dir = tempfile::tempdir().unwrap();
+            let err = svc
+                .open_folder_with(dir.path().to_str().unwrap(), ToolType::Zed)
+                .await
+                .unwrap_err();
+            assert!(matches!(err, ShellError::ToolNotInstalled(ref name) if name == "zed"));
+        }
     }
 
     #[tokio::test]

--- a/crates/aionui-shell/tests/shell_integration.rs
+++ b/crates/aionui-shell/tests/shell_integration.rs
@@ -83,6 +83,14 @@ async fn sh10_check_tool_vscode_returns_bool() {
 }
 
 // ---------------------------------------------------------------------------
+// SH-11: check_tool_installed — zed (environment-dependent)
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn sh11_check_tool_zed_returns_bool() {
+    let _installed = service().check_tool_installed(ToolType::Zed).await;
+}
+
+// ---------------------------------------------------------------------------
 // SH-12: open_folder_with — directory does not exist
 // ---------------------------------------------------------------------------
 #[tokio::test]


### PR DESCRIPTION
## Summary

Adds **Zed** as an optional target for workspace open-with shell APIs, matching the existing VS Code path.

- `ToolType::Zed` (`"zed"`) in `aionui-api-types`
- Detect: `zed` on PATH, or macOS `/Applications/Zed.app/Contents/MacOS/cli`
- Open: `zed <folder>` (or absolute CLI path when PATH symlink is missing)
- Windows: only invoke real `zed` / `zed.exe` on PATH (no bare `.cmd` spawn)

**Refs:** https://github.com/iOfficeAI/AionUi/issues/3733  
**Related:** https://github.com/iOfficeAI/AionUi/issues/2210 (Windows open-workspace spawn lessons)

### Non-goals

- Not registering Zed as an ACP **agent** (Zed is an ACP **client**, like AionUi)
- Not a generic multi-editor registry (design question lives on the AionUi issue)

AionUi UI PR will follow and use `tool: "zed"` against this API.

## Test plan

- [x] `cargo test -p aionui-api-types -p aionui-shell`
- [x] `cargo clippy -p aionui-api-types -p aionui-shell -- -D warnings`
- [x] `cargo fmt` on touched crates
- [ ] Manual: with Zed + CLI installed, `check-tool-installed` → true; `open-folder-with` opens project
- [ ] Manual: without Zed, check → false; open returns ToolNotInstalled
- [ ] Regression: vscode / terminal / explorer unchanged

Thanks for maintaining AionCore!