### PR TITLE
feat(agents): bump pi-acp release pin to 0.0.32

### DIFF
--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -749,7 +749,7 @@ mod tests {
         )
         .await
         .expect("resolved release-pinned builtin command spec");
-        assert_eq!(spec.args, vec!["-y", "pi-acp@0.0.31"]);
+        assert_eq!(spec.args, vec!["-y", "pi-acp@0.0.32"]);
     }
 
     #[cfg(unix)]

--- a/crates/aionui-ai-agent/src/services/availability/mod.rs
+++ b/crates/aionui-ai-agent/src/services/availability/mod.rs
@@ -557,7 +557,7 @@ mod tests {
         pi.agent_source_info.binary_name = Some("pi".into());
         pi.agent_source_info.bridge_binary = Some("npx".into());
         pi.args = vec!["-y".into(), "pi-acp".into()];
-        assert_eq!(explicit_probe_args(&pi).unwrap(), ["-y", "pi-acp@0.0.31"]);
+        assert_eq!(explicit_probe_args(&pi).unwrap(), ["-y", "pi-acp@0.0.32"]);
     }
 
     // ---- #675: manual health check runs --version for direct CLIs and is

--- a/crates/aionui-db/migrations/029_bump_pi_acp_session_delete_capability.sql
+++ b/crates/aionui-db/migrations/029_bump_pi_acp_session_delete_capability.sql
@@ -1,0 +1,23 @@
+-- Migration 029: Advertise session/delete for the Pi ACP builtin.
+--
+-- pi-acp v0.0.32 (svkozak/pi-acp#76) implements session/delete and advertises
+-- agentCapabilities.sessionCapabilities.delete in the ACP handshake. The
+-- release pin itself lives in crates/aionui-runtime/resources/acp-registry-npx-lock.json
+-- (DB args stay unversioned: `["-y","pi-acp"]`; runtime injects @0.0.32).
+-- Keep seeded agent_capabilities aligned with the live handshake so clients
+-- that read metadata before probing still see the capability.
+
+UPDATE agent_metadata
+SET agent_capabilities = json_set(
+        COALESCE(agent_capabilities, '{}'),
+        '$.session_capabilities.delete',
+        json('{}')
+    ),
+    updated_at = unixepoch('now', 'subsec') * 1000
+WHERE agent_source = 'builtin'
+  AND agent_type = 'acp'
+  AND backend = 'pi'
+  AND (
+      agent_capabilities IS NULL
+      OR json_extract(agent_capabilities, '$.session_capabilities.delete') IS NULL
+  );

--- a/crates/aionui-db/tests/pi_acp_agent_migration.rs
+++ b/crates/aionui-db/tests/pi_acp_agent_migration.rs
@@ -28,6 +28,8 @@ async fn pi_acp_builtin_metadata_is_seeded() {
         serde_json::from_str(pi.agent_capabilities.as_deref().expect("seeded capabilities")).unwrap();
     assert_eq!(capabilities["load_session"], true);
     assert_eq!(capabilities["session_capabilities"]["list"], serde_json::json!({}));
+    // pi-acp >= 0.0.32 advertises session/delete (migration 029).
+    assert_eq!(capabilities["session_capabilities"]["delete"], serde_json::json!({}));
     assert_eq!(capabilities["mcp_capabilities"]["http"], false);
     assert_eq!(capabilities["mcp_capabilities"]["sse"], false);
 

--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -49,7 +49,7 @@
     "pi": {
       "registry_json_id": "pi-acp",
       "package": "pi-acp",
-      "version": "0.0.31"
+      "version": "0.0.32"
     },
     "sigit": {
       "registry_json_id": "sigit",

--- a/crates/aionui-runtime/src/registry_npx_lock.rs
+++ b/crates/aionui-runtime/src/registry_npx_lock.rs
@@ -105,7 +105,7 @@ mod tests {
     #[test]
     fn pins_direct_npx_package() {
         let args = pin_registry_npx_args("pi", &strings(&["-y", "pi-acp"])).unwrap();
-        assert_eq!(args, ["-y", "pi-acp@0.0.31"]);
+        assert_eq!(args, ["-y", "pi-acp@0.0.32"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Bump the ACP Registry npx **release pin** for Pi from `pi-acp@0.0.31` → **`pi-acp@0.0.32`** in `crates/aionui-runtime/resources/acp-registry-npx-lock.json`.
- Runtime still resolves DB args `["-y","pi-acp"]` to the locked version via `pin_registry_npx_args` (migration 025 left args unversioned on purpose).
- Migration `029`: advertise `session_capabilities.delete: {}` on the Pi builtin row so seeded `agent_capabilities` match the live ACP handshake from [pi-acp#76](https://github.com/svkozak/pi-acp/pull/76) (released in [v0.0.32](https://github.com/svkozak/pi-acp/releases/tag/v0.0.32)).

This unblocks AionUi users of the builtin Pi agent from getting `session/delete` (and the rest of the 0.0.32 fixes) without manual agent setup.

### Why not edit migration 023?

Historical seed stays intact. The pin of record is the release lock; DB command/args remain the stable package identity.

### Behavior notes from pi-acp 0.0.32 (for QA)

Beyond `session/delete`:
- Startup info can include project-level packages in the extensions list
- Bash tools render as terminals in ACP clients
- Extension notifications can carry severity via `_meta`

The long “available skills” list on first turn is intentional **pi-acp startup info** (disable with `quietStartup: true` in pi settings), not an AionUi bug.

## Test plan

- [x] `cargo test -p aionui-runtime registry_npx_lock`
- [x] `cargo test -p aionui-db --test pi_acp_agent_migration`
- [x] `cargo test -p aionui-ai-agent --lib resolve_agent_command_spec_flattens_bare_npx_command`
- [x] `cargo test -p aionui-ai-agent --lib manual_check_persists_command_not_found`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p aionui-runtime -p aionui-db -- -D warnings`
- [x] CI green on this draft
- [ ] Optional: live smoke against `npx -y pi-acp@0.0.32` + Pi CLI handshake

## Related

- Prior: AionCore [#618](https://github.com/iOfficeAI/AionCore/pull/618) (Pi builtin @ 0.0.31)
- Upstream feature: [svkozak/pi-acp#76](https://github.com/svkozak/pi-acp/pull/76) / [v0.0.32](https://github.com/svkozak/pi-acp/releases/tag/v0.0.32)

Thanks for maintaining AionCore — happy to adjust the migration or PR shape if you prefer a lock-only change.