### PR TITLE
chore(deps): update aionrs to v0.2.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,8 +117,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.2.7"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.7#445a18e1625cc68ded3a647ee99332195fbe8508"
+version = "0.2.8"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -148,8 +148,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.2.7"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.7#445a18e1625cc68ded3a647ee99332195fbe8508"
+version = "0.2.8"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
 dependencies = [
  "regex",
  "serde",
@@ -160,8 +160,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.2.7"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.7#445a18e1625cc68ded3a647ee99332195fbe8508"
+version = "0.2.8"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
 dependencies = [
  "aion-compact",
  "aion-process",
@@ -185,8 +185,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.2.7"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.7#445a18e1625cc68ded3a647ee99332195fbe8508"
+version = "0.2.8"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -206,8 +206,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.2.7"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.7#445a18e1625cc68ded3a647ee99332195fbe8508"
+version = "0.2.8"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
 dependencies = [
  "aion-config",
  "chrono",
@@ -220,8 +220,8 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.2.7"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.7#445a18e1625cc68ded3a647ee99332195fbe8508"
+version = "0.2.8"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
 dependencies = [
  "libc",
  "tokio",
@@ -231,8 +231,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.2.7"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.7#445a18e1625cc68ded3a647ee99332195fbe8508"
+version = "0.2.8"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
 dependencies = [
  "aion-types",
  "serde",
@@ -244,8 +244,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.2.7"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.7#445a18e1625cc68ded3a647ee99332195fbe8508"
+version = "0.2.8"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -273,8 +273,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.2.7"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.7#445a18e1625cc68ded3a647ee99332195fbe8508"
+version = "0.2.8"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -300,8 +300,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.2.7"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.7#445a18e1625cc68ded3a647ee99332195fbe8508"
+version = "0.2.8"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -322,8 +322,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.2.7"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.7#445a18e1625cc68ded3a647ee99332195fbe8508"
+version = "0.2.8"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
 dependencies = [
  "async-trait",
  "base64",
@@ -6685,7 +6685,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.7#445a18e1625cc68ded3a647ee99332195fbe8508"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
 dependencies = [
  "bitflags",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,12 +59,12 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.7" }
-aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.7" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.7" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.7" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.7" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.7" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.8" }
+aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.8" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.8" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.8" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.8" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.8" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## Summary

- update all six direct aionrs Git dependencies from `v0.2.7` to `v0.2.8`
- regenerate `Cargo.lock` so all transitive aionrs workspace crates resolve to tag commit `4bd4f3254f6d875f122b648dd55116516c380d31`
- preserve the existing AionCore integration contract; this dependency-only change adds no API, configuration, or logging changes

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p aionui-ai-agent`
- `cargo test -p aionui-ai-agent` (764 unit tests passed; integration and doc tests passed, with configured ignored tests unchanged)
- `just push -u origin jiahe/chore/update-aionrs-0.2.8` (migration immutability check passed; workspace checks passed; 7,478 nextest tests passed, 18 skipped)
- `git diff --check`
