### PR TITLE
feat(session): claude attachment --add-dir + settings-derived spawn mode (ELECTRON-3R4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,6 +842,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -1119,6 +1119,33 @@ fn spec_mode_model(
     (spec, mode, model)
 }
 
+/// Feature 015 F2: settings-derived spawn-mode fallback, claude-only. Applies
+/// ONLY when the `spec_mode_model` precedence chain resolved nothing (no
+/// interactive switch persisted, no create-time seed) — an explicit choice is
+/// never overridden. `resolve` is lazy (file IO happens only on the fallback
+/// path) and injected so the wiring is unit-testable without touching the real
+/// machine's claude settings. Its output is always a valid `--permission-mode`
+/// wire value by construction (`claude_settings` normalizes via the adapter's
+/// alias table), so no re-normalization here.
+fn apply_claude_mode_fallback(
+    backend_label: &str,
+    conversation_id: &str,
+    mode: Option<String>,
+    resolve: impl FnOnce() -> aionui_session::claude_settings::ResolvedDefaultMode,
+) -> Option<String> {
+    if backend_label != "claude" || mode.is_some() {
+        return mode;
+    }
+    let resolved = resolve();
+    tracing::info!(
+        conv_id = %conversation_id,
+        mode = %resolved.mode,
+        source = ?resolved.source,
+        "claude: no persisted/create-time mode; spawn mode seeded from claude settings defaultMode"
+    );
+    Some(resolved.mode)
+}
+
 /// Build a claude/codex `SessionAgentTask` (the session-model port's `IAgentTask`)
 /// from a resolved ACP build request, or `Ok(None)` for a non-session backend.
 ///
@@ -1162,6 +1189,22 @@ pub async fn build_session_instance(
     // snapshot-wins precedence). Extracted so it is unit-testable in isolation, the
     // exact sibling of clean-slate's `spec_and_config`.
     let (spec, mode, model) = spec_mode_model(&conversation_id, backend_session_id, config, session_snapshot, metadata);
+
+    // Feature 015 F2 (ELECTRON-3R4): a claude conversation with NO persisted or
+    // create-time mode selection used to harden into the fail-closed
+    // `--permission-mode default`, silently overriding the user's machine-level
+    // claude-settings `permissions.defaultMode` — a regression against the legacy
+    // ACP adapter, which resolved that setting per session. Restore it as the LAST
+    // step of the precedence chain (snapshot > config > settings), still passed as
+    // an explicit flag downstream (fail-closed: an absent/unparsable settings chain
+    // resolves to "default", byte-identical to the previous hard-code). No bespoke
+    // persist or UI write is needed: open_session seeds `caps.current_mode` from
+    // `config.mode` (picker truth from the first `runtime/ensure`), and claude
+    // echoes the flag on `system/init` → `sniff_mode` → `ConfigChanged{mode}` →
+    // the event pump's `save_runtime_state` lands it in `current_mode_id`.
+    let mode = apply_claude_mode_fallback(backend_label, &conversation_id, mode, || {
+        aionui_session::claude_settings::resolve_claude_default_mode(Some(std::path::Path::new(&workspace)))
+    });
 
     // GAP #3 — MCP init surface: resolve user-configured servers to the neutral
     // spec (clean-slate resolve_session_init), fold in the inline snapshot, then
@@ -2920,6 +2963,34 @@ mod build_mapping_tests {
         };
         let (_s, mode, _m) = spec_mode_model("c", None, &plan_cfg, None, &test_metadata(Some("claude"), None));
         assert_eq!(mode.as_deref(), Some("plan"), "non-alias mode unchanged");
+    }
+
+    // Feature 015 F2 (T6 wiring axis): the settings fallback fires ONLY for
+    // claude AND only when the snapshot/config precedence chain resolved nothing.
+    // An explicit choice must never be overridden, and no settings IO may happen
+    // off the fallback path (the resolver closure panics if invoked).
+    #[test]
+    fn claude_mode_fallback_applies_only_when_unset() {
+        use aionui_session::claude_settings::{DefaultModeSource, ResolvedDefaultMode};
+
+        // claude + no mode → resolver consulted, its value adopted.
+        let mode = apply_claude_mode_fallback("claude", "conv_1", None, || ResolvedDefaultMode {
+            mode: "bypassPermissions".into(),
+            source: DefaultModeSource::User,
+        });
+        assert_eq!(mode.as_deref(), Some("bypassPermissions"));
+
+        // claude + explicit mode → untouched, resolver never invoked.
+        let mode = apply_claude_mode_fallback("claude", "conv_1", Some("plan".into()), || {
+            panic!("resolver must not run when a mode is already resolved")
+        });
+        assert_eq!(mode.as_deref(), Some("plan"));
+
+        // non-claude backend → untouched (None stays None), resolver never invoked.
+        let mode = apply_claude_mode_fallback("codex", "conv_1", None, || {
+            panic!("resolver must not run for a non-claude backend")
+        });
+        assert_eq!(mode, None);
     }
 
     /// G5: a discovered catalog projects mode/model as ACP `configOptions[]` + slash

--- a/crates/aionui-common/src/lib.rs
+++ b/crates/aionui-common/src/lib.rs
@@ -2,6 +2,7 @@
 
 //! Shared primitives: error types, enums, ID generation, crypto, timestamps, and pagination.
 pub mod constants;
+pub mod paths;
 
 mod case_convert;
 mod crypto;

--- a/crates/aionui-common/src/paths.rs
+++ b/crates/aionui-common/src/paths.rs
@@ -1,0 +1,42 @@
+//! Shared filesystem locations.
+//!
+//! The HTTP upload staging area (`POST /api/fs/upload`, `POST /api/fs/temp`)
+//! and the agent spawn path (claude `--add-dir`) must agree on where uploaded
+//! attachments live. Every expression of that layout goes through these
+//! helpers — hand-rolling `temp_dir().join("aionui")` elsewhere reintroduces
+//! the drift this module exists to prevent.
+
+use std::path::PathBuf;
+
+/// Root of the upload staging area: `<OS temp>/aionui`.
+pub fn uploads_root() -> PathBuf {
+    std::env::temp_dir().join("aionui")
+}
+
+/// Per-conversation upload directory: `<OS temp>/aionui/<conversation_id>`,
+/// or `<OS temp>/aionui/general` when no conversation exists yet (uploads
+/// from the home/guid page happen before the conversation is created).
+pub fn uploads_dir(conversation_id: Option<&str>) -> PathBuf {
+    let mut dir = uploads_root();
+    match conversation_id {
+        Some(id) if !id.is_empty() => dir.push(id),
+        _ => dir.push("general"),
+    }
+    dir
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uploads_dir_scopes_by_conversation() {
+        assert_eq!(uploads_dir(Some("conv-1")), uploads_root().join("conv-1"));
+    }
+
+    #[test]
+    fn uploads_dir_falls_back_to_general() {
+        assert_eq!(uploads_dir(None), uploads_root().join("general"));
+        assert_eq!(uploads_dir(Some("")), uploads_root().join("general"));
+    }
+}

--- a/crates/aionui-file/src/service.rs
+++ b/crates/aionui-file/src/service.rs
@@ -897,7 +897,7 @@ impl crate::traits::IFileService for FileService {
         let name = file_name.to_owned();
 
         tokio::task::spawn_blocking(move || {
-            let tmp_dir = std::env::temp_dir().join("aionui");
+            let tmp_dir = aionui_common::paths::uploads_root();
             std::fs::create_dir_all(&tmp_dir)
                 .map_err(|e| FileError::Internal(format!("cannot create temp directory: {e}")))?;
 
@@ -951,12 +951,9 @@ impl crate::traits::IFileService for FileService {
         let bytes = data.to_vec();
 
         tokio::task::spawn_blocking(move || {
-            let mut dir = std::env::temp_dir().join("aionui");
-            if let Some(conv_id) = conv_id.as_deref() {
-                dir = dir.join(conv_id);
-            } else {
-                dir = dir.join("general");
-            }
+            // Same layout the claude spawn path grants via `--add-dir`
+            // (uploads_dir): drifting apart makes uploads unreadable to the agent.
+            let dir = aionui_common::paths::uploads_dir(conv_id.as_deref());
             std::fs::create_dir_all(&dir)
                 .map_err(|e| FileError::Internal(format!("cannot create upload directory: {e}")))?;
 

--- a/crates/aionui-session/Cargo.toml
+++ b/crates/aionui-session/Cargo.toml
@@ -41,3 +41,6 @@ proptest.workspace = true
 # constructing a production RealSpawner without touching the real data dir.
 # Workspace-pinned; dev-only (never shipped). (uuid is a normal dep above.)
 tempfile.workspace = true
+# S5 drift-WARN test (feature 015): capture tracing output to assert the WARN
+# fires; the tripwire has no other observable effect by design.
+tracing-subscriber.workspace = true

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -150,15 +150,22 @@ pub(crate) fn build_claude_init_args(config: &SessionConfig) -> Vec<String> {
         args.push("--strict-mcp-config".to_string());
     }
 
-    // SECURITY (fail-CLOSED): ALWAYS pass --permission-mode. Omitting it makes claude
-    // headless default to `bypassPermissions` — LIVE-PROBED: `system/init` reports
-    // `permissionMode: bypassPermissions` and Write/Bash auto-run with NO `can_use_tool`
-    // prompt. config.mode is `None` for an ordinary claude session (the create path
-    // does not seed it; an interactive switch is in-band + persisted to extra, read
-    // back into config.mode on the next spawn), so gating the flag on `Some` silently
-    // downgraded every default session to the most-permissive mode. Default to
-    // "default" (standard prompts) so a session with no explicit choice is gated, not
-    // bypassed. `default`/`acceptEdits`/`bypassPermissions`/`plan`/`dontAsk`/`auto` are
+    // SECURITY (fail-CLOSED): ALWAYS pass --permission-mode, so the spawn mode is
+    // deterministic and UI-visible. Omitting the flag makes the CLI resolve its own
+    // settings hierarchy `permissions.defaultMode` (managed > local project >
+    // project > user; fallback "default") — LIVE-PROBED 2.1.220: a clean
+    // `CLAUDE_CONFIG_DIR` inits `permissionMode: default`, while a user
+    // settings.json carrying `defaultMode: bypassPermissions` inits bypass. (An
+    // earlier revision of this comment claimed omission hard-defaults to
+    // `bypassPermissions`; that probe read a dev machine whose settings.json set
+    // exactly that — the CLI was honoring settings, not defaulting open.)
+    // config.mode arrives here already resolved by `build_session_instance`:
+    // persisted switch > create-time seed > the SAME settings hierarchy
+    // (`claude_settings::resolve_claude_default_mode`, feature 015 F2) — so an
+    // explicit flag no longer overrides the user's configured default; it ECHOES
+    // it. A still-empty mode (non-session callers, tests) falls back to "default"
+    // (standard prompts): gated, not bypassed.
+    // `default`/`acceptEdits`/`bypassPermissions`/`plan`/`dontAsk`/`auto` are
     // claude's exact accepted wire values — the whitelist is a SUPERSET of the advertised
     // picker (which omits `auto`; see `claude_permission_modes`) so a resumed session that
     // carries `auto` is not downgraded/crashed.
@@ -172,23 +179,7 @@ pub(crate) fn build_claude_init_args(config: &SessionConfig) -> Vec<String> {
     // "default" (a WARN records the drop) rather than crashing the process. Mirrors
     // the ACP path's `clear_invalid_desired_mode` (drop-if-not-in-catalog) — a
     // protection the port had wired but never called.
-    let mode = config
-        .mode
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .filter(|m| {
-            let ok = crate::adapter::is_valid_claude_permission_mode(m);
-            if !ok {
-                tracing::warn!(
-                    requested_mode = %m,
-                    "claude: ignoring unrecognized --permission-mode (would crash spawn); \
-                     falling back to \"default\""
-                );
-            }
-            ok
-        })
-        .unwrap_or("default");
+    let mode = effective_permission_mode(config.mode.as_deref());
     args.push("--permission-mode".to_string());
     args.push(mode.to_string());
 
@@ -233,6 +224,60 @@ pub(crate) fn build_claude_init_args(config: &SessionConfig) -> Vec<String> {
         args.push(model.to_string());
     }
 
+    args
+}
+
+/// The exact value `build_claude_init_args` puts on `--permission-mode`:
+/// `config.mode` when non-empty AND spawn-safe per the whitelist, else the
+/// fail-closed "default". Also consumed by `spawn` as the reference value for
+/// the S5 drift tripwire (claude's `system/init` echo is compared against it),
+/// so the flag and the tripwire can never disagree.
+fn effective_permission_mode(requested: Option<&str>) -> &str {
+    requested
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .filter(|m| {
+            let ok = crate::adapter::is_valid_claude_permission_mode(m);
+            if !ok {
+                tracing::warn!(
+                    requested_mode = %m,
+                    "claude: ignoring unrecognized --permission-mode (would crash spawn); \
+                     falling back to \"default\""
+                );
+            }
+            ok
+        })
+        .unwrap_or("default")
+}
+
+/// Append `--add-dir` grants for the HTTP-upload staging dirs. Pasted images /
+/// uploaded attachments land in `<tmp>/aionui/<conversation_id>` (home-page
+/// uploads in `<tmp>/aionui/general`) — both OUTSIDE the workspace cwd, so under
+/// the fail-closed `--permission-mode default` the model's Read of an attachment
+/// raises a `can_use_tool` permission prompt (denied → "the pasted image displays
+/// but is never recognized", ELECTRON-3R4). Scoping the grant to exactly these
+/// two dirs keeps the fail-closed posture for everything else. Both dirs are
+/// created up-front (idempotent); a create failure is WARN-only — an unwritable
+/// temp dir already breaks uploads themselves, the spawn must not die with it
+/// (claude tolerates a missing `--add-dir` target — live-probed 2.1.220).
+///
+/// Appended to the init args so ALL spawn paths inherit the grant: Fresh,
+/// Resume, and the wake-recipe respawn (which carries `spawn_args` verbatim).
+async fn with_upload_add_dirs(mut args: Vec<String>, conversation_id: &str) -> Vec<String> {
+    for dir in [
+        aionui_common::paths::uploads_dir(Some(conversation_id)),
+        aionui_common::paths::uploads_dir(None),
+    ] {
+        if let Err(e) = tokio::fs::create_dir_all(&dir).await {
+            tracing::warn!(
+                dir = %dir.display(),
+                error = %e,
+                "upload staging dir create failed; passing --add-dir anyway"
+            );
+        }
+        args.push("--add-dir".to_string());
+        args.push(dir.to_string_lossy().into_owned());
+    }
     args
 }
 
@@ -294,6 +339,11 @@ impl BackendConnection for ClaudeConnection {
         // by position. The SAME args are threaded into the wake recipe so a
         // crash/idle-reap respawn re-applies them (R16 continuity).
         let init_args = build_claude_init_args(&config);
+        // ELECTRON-3R4: grant read access to the upload staging dirs (out-of-cwd
+        // temp) so attachment Reads don't dead-end on a permission prompt. See
+        // `with_upload_add_dirs`. logical_id == the conversation id (the upload
+        // dir key) on both Fresh and Resume.
+        let init_args = with_upload_add_dirs(init_args, &logical_id).await;
         let spawn_args = prepend_args(&init_args, &config.extra_args);
 
         // Spawn the persistent process via the legacy adapter (reuses the exact
@@ -524,6 +574,12 @@ struct ClaudeReaderState {
     /// `sniff_set_config_reject` can surface a rejection as a `Notice{Warning}`
     /// (shared Arc with `ClaudeSessionBackend.pending_set_config`).
     pending_set_config: Arc<std::sync::Mutex<std::collections::HashMap<String, String>>>,
+    /// S5 (feature 015): the exact `--permission-mode` value this session was
+    /// spawned with (`effective_permission_mode`). `sniff_mode` compares the FIRST
+    /// observed `permissionMode` (claude's init echo) against it and WARNs on a
+    /// mismatch — the tripwire for a silently overridden flag (managed policy,
+    /// root bypass-refusal, CLI behavior change). Behavior otherwise unchanged.
+    requested_mode: String,
 }
 
 /// Spawn a claude stdout reader over `stdout`/`io` using the shared state. Used
@@ -549,6 +605,7 @@ fn start_claude_reader(
             state.turn_in_flight,
             state.current_mode_override,
             state.pending_set_config,
+            state.requested_mode,
         )
         .await;
     })
@@ -607,6 +664,10 @@ impl ClaudeSessionBackend {
             turn_in_flight: turn_in_flight.clone(),
             current_mode_override: current_mode_override.clone(),
             pending_set_config: pending_set_config.clone(),
+            // S5: the same value `build_claude_init_args` put on the flag. A
+            // post-wake reader reuses it — harmless, since the drift check only
+            // fires on the first-ever observation (override is Some by then).
+            requested_mode: effective_permission_mode(config.mode.as_deref()).to_string(),
         };
         let reader = start_claude_reader(&reader_state, stdout, io.clone());
 
@@ -1083,6 +1144,7 @@ async fn reader_task(
     turn_in_flight: Arc<std::sync::atomic::AtomicBool>,
     current_mode_override: Arc<std::sync::Mutex<Option<String>>>,
     pending_set_config: Arc<std::sync::Mutex<std::collections::HashMap<String, String>>>,
+    requested_mode: String,
 ) {
     use std::sync::atomic::Ordering;
     use tokio::io::AsyncReadExt;
@@ -1160,7 +1222,14 @@ async fn reader_task(
                 // exits plan mode on its own → emits ONLY system/status). It replaces the
                 // old optimistic dispatch emit (de-optimistic'd). normal→default normalized;
                 // dedups so a repeated init/status echo of the same mode is silent.
-                sniff_mode(v, &current_mode_override, &event_tx, &session_id, cur_gen);
+                sniff_mode(
+                    v,
+                    &current_mode_override,
+                    &event_tx,
+                    &session_id,
+                    cur_gen,
+                    &requested_mode,
+                );
                 // The ONE case system/status can't cover: a REJECTED set_permission_mode
                 // (claude refused → no status, only a control_response error). Clears the
                 // stale override + surfaces mode_switch_rejected.
@@ -1638,6 +1707,7 @@ fn sniff_mode(
     event_tx: &broadcast::Sender<SessionEnvelope>,
     session_id: &str,
     turn_gen: u64,
+    requested_mode: &str,
 ) {
     use serde_json::Value;
     if frame.get("type").and_then(Value::as_str) != Some("system") {
@@ -1653,6 +1723,20 @@ fn sniff_mode(
         let mut cur = current_mode_override.lock().unwrap_or_else(|e| e.into_inner());
         if cur.as_deref() == Some(mode) {
             return;
+        }
+        // S5 drift tripwire (feature 015): the FIRST observation is claude's init
+        // echo of the spawn's `--permission-mode` flag; a mismatch means the flag
+        // was overridden out-of-band (managed settings policy, root refusing
+        // bypass, a CLI behavior change). Later transitions are legitimate in-band
+        // switches, never compared. WARN-only — the observed value stays
+        // authoritative either way.
+        if cur.is_none() && mode != requested_mode {
+            tracing::warn!(
+                conversation_id = %session_id,
+                requested = %requested_mode,
+                effective = %mode,
+                "claude: initial permissionMode differs from the spawn-requested --permission-mode"
+            );
         }
         *cur = Some(mode.to_string());
     }
@@ -5002,6 +5086,76 @@ mod tests {
         assert_eq!(tok.map(|e| e.value.as_str()), Some("tok-123"));
     }
 
+    /// ELECTRON-3R4 (feature 015 S1/T1): every claude spawn grants `--add-dir` for
+    /// the two upload staging dirs — `<tmp>/aionui/<conversation_id>` (in-conversation
+    /// uploads) and `<tmp>/aionui/general` (home-page uploads) — in that fixed order,
+    /// and creates both dirs up-front so the grant never points at a missing path.
+    #[tokio::test]
+    async fn open_session_grants_add_dir_for_upload_dirs() {
+        use crate::testing::FakeSpawner;
+        let spawner = Arc::new(FakeSpawner::new());
+        let conn = ClaudeConnection::new(spawner.clone());
+        let sid = "33333333-3333-4333-8333-333333333333";
+        let _ = conn
+            .open_session(SessionSpec::Fresh { session_id: sid.into() }, SessionConfig::default())
+            .await;
+        let spec = spawner.last_command().await.expect("a spawn was recorded");
+        let conv_dir = aionui_common::paths::uploads_dir(Some(sid));
+        let general_dir = aionui_common::paths::uploads_dir(None);
+        let pairs: Vec<&str> = spec
+            .args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| *a == "--add-dir")
+            .map(|(i, _)| spec.args[i + 1].as_str())
+            .collect();
+        assert_eq!(
+            pairs,
+            vec![
+                conv_dir.to_string_lossy().as_ref(),
+                general_dir.to_string_lossy().as_ref()
+            ],
+            "exactly two --add-dir grants, conversation dir first, got args {:?}",
+            spec.args
+        );
+        assert!(conv_dir.is_dir(), "conversation upload dir created before spawn");
+        assert!(general_dir.is_dir(), "general upload dir created before spawn");
+    }
+
+    /// ELECTRON-3R4 (feature 015 S1): the Resume spawn path carries the same
+    /// `--add-dir` grants — the upload-dir key is the LOGICAL conversation id,
+    /// not the claude backend session id being resumed.
+    #[tokio::test]
+    async fn open_session_resume_grants_same_add_dirs() {
+        use crate::testing::FakeSpawner;
+        let spawner = Arc::new(FakeSpawner::new());
+        let conn = ClaudeConnection::new(spawner.clone());
+        let sid = "44444444-4444-4444-8444-444444444444";
+        let _ = conn
+            .open_session(
+                SessionSpec::Resume {
+                    session_id: sid.into(),
+                    backend_session_id: Some("55555555-5555-4555-8555-555555555555".into()),
+                },
+                SessionConfig::default(),
+            )
+            .await;
+        let spec = spawner.last_command().await.expect("a spawn was recorded");
+        assert!(
+            spec.args.iter().any(|a| a == "--resume"),
+            "resume spec routes --resume, got {:?}",
+            spec.args
+        );
+        let conv_dir = aionui_common::paths::uploads_dir(Some(sid));
+        assert!(
+            spec.args
+                .windows(2)
+                .any(|w| w[0] == "--add-dir" && w[1] == conv_dir.to_string_lossy()),
+            "resume spawn grants the conversation upload dir (keyed by LOGICAL id), got {:?}",
+            spec.args
+        );
+    }
+
     /// #103 parity: an empty `spawn_env` (no cc-switch config, or a non-claude backend
     /// the app never fills) yields an empty `CommandSpec.env` — byte-identical to the
     /// pre-#103 spawn (inherit the parent env only).
@@ -5198,6 +5352,141 @@ mod tests {
             modes,
             vec!["plan".to_string(), "bypassPermissions".to_string()],
             "two distinct modes emit (incl the autonomous plan→bypass exit); the repeat is deduped"
+        );
+    }
+
+    /// S5 drift tripwire (feature 015 / T7): the FIRST observed `permissionMode`
+    /// is claude's init echo of the spawn's `--permission-mode`; a mismatch WARNs
+    /// (flag silently overridden — managed policy, root bypass-refusal, CLI
+    /// change), a match stays silent, and a LATER change (in-band switch) never
+    /// re-fires. Behavior (override adoption + ConfigChanged) is unchanged either
+    /// way. `build_with_io` spawns with a default config → requested = "default".
+    #[tokio::test]
+    async fn sniff_mode_warns_when_first_observed_mode_differs_from_requested() {
+        #[derive(Clone, Default)]
+        struct VecWriter(Arc<std::sync::Mutex<Vec<u8>>>);
+        impl std::io::Write for VecWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        let captured = VecWriter::default();
+        let sink = captured.clone();
+        // Thread-local default: the reader task runs on this same thread under the
+        // current-thread test runtime, so its WARN lands in this subscriber.
+        let _guard = tracing::subscriber::set_default(
+            tracing_subscriber::fmt()
+                .with_writer(move || sink.clone())
+                .with_max_level(tracing::Level::WARN)
+                .finish(),
+        );
+        let drift_msg = "initial permissionMode differs from the spawn-requested";
+
+        // Frame 1: first observation bypassPermissions ≠ requested "default" → WARN.
+        // Frame 2: a later in-band-style change ("plan") must NOT re-fire the tripwire.
+        let frames = concat!(
+            r#"{"type":"system","subtype":"init","permissionMode":"bypassPermissions","session_id":"s"}"#,
+            "\n",
+            r#"{"type":"system","subtype":"status","permissionMode":"plan","session_id":"s"}"#,
+            "\n",
+        );
+        let backend =
+            ClaudeSessionBackend::build_with_io("s", Box::new(FakeAgentIo::never_exits(frames.as_bytes().to_vec())))
+                .await;
+        let mut events = backend.events();
+        let mut modes: Vec<String> = Vec::new();
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(600), async {
+            while let Some(env) = events.next().await {
+                if let SessionEvent::ConfigChanged { mode: Some(m), .. } = env.event {
+                    modes.push(m);
+                }
+            }
+        })
+        .await;
+        assert_eq!(
+            modes,
+            vec!["bypassPermissions".to_string(), "plan".to_string()],
+            "drift changes nothing about adoption/emission"
+        );
+        let logs = String::from_utf8_lossy(&captured.0.lock().unwrap()).to_string();
+        assert_eq!(
+            logs.matches(drift_msg).count(),
+            1,
+            "exactly one drift WARN (first observation only, later switches exempt): {logs}"
+        );
+        assert!(
+            logs.contains("bypassPermissions") && logs.contains("default"),
+            "WARN carries requested + effective: {logs}"
+        );
+
+        // Control: first observation MATCHING the requested mode ("normal" is
+        // claude's alias for "default") → no WARN at all.
+        let captured = VecWriter::default();
+        let sink = captured.clone();
+        let _guard = tracing::subscriber::set_default(
+            tracing_subscriber::fmt()
+                .with_writer(move || sink.clone())
+                .with_max_level(tracing::Level::WARN)
+                .finish(),
+        );
+        let frame = r#"{"type":"system","subtype":"init","permissionMode":"normal","session_id":"s"}"#;
+        let backend = ClaudeSessionBackend::build_with_io(
+            "s",
+            Box::new(FakeAgentIo::never_exits(format!("{frame}\n").into_bytes())),
+        )
+        .await;
+        let mut events = backend.events();
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(600), async {
+            while let Some(env) = events.next().await {
+                if matches!(env.event, SessionEvent::ConfigChanged { .. }) {
+                    return;
+                }
+            }
+        })
+        .await;
+        let logs = String::from_utf8_lossy(&captured.0.lock().unwrap()).to_string();
+        assert!(
+            !logs.contains(drift_msg),
+            "matching init echo must not trip the drift WARN: {logs}"
+        );
+    }
+
+    /// Feature 015 F2 (T5 link): the mode `build_session_instance` resolved into
+    /// `config.mode` (persisted switch > create seed > claude-settings fallback)
+    /// becomes `capabilities().current_mode` AT OPEN — before any wire frame — so
+    /// the first `runtime/ensure` → `get_config_options` already serves the
+    /// settings-seeded value (no "default, then flips after the first message"
+    /// picker flicker).
+    #[tokio::test]
+    async fn open_seeds_current_mode_from_config_before_any_wire_frame() {
+        let wake = ClaudeWakeRecipe {
+            spawner: Arc::new(crate::testing::FakeSpawner::new()),
+            claude_session_id: "s".into(),
+            cwd: None,
+            extra_args: Vec::new(),
+            env: Vec::new(),
+            cli_program: None,
+        };
+        let config = SessionConfig {
+            mode: Some("bypassPermissions".into()),
+            ..Default::default()
+        };
+        let backend = ClaudeSessionBackend::spawn(
+            "s".to_string(),
+            ClaudeAdapter::new(),
+            Box::new(FakeAgentIo::never_exits(Vec::new())),
+            config,
+            wake,
+        )
+        .await;
+        assert_eq!(
+            backend.capabilities().current_mode.as_deref(),
+            Some("bypassPermissions"),
+            "config.mode must seed the picker's current_mode synchronously at open"
         );
     }
 

--- a/crates/aionui-session/src/claude_settings.rs
+++ b/crates/aionui-session/src/claude_settings.rs
@@ -1,0 +1,323 @@
+//! Resolve claude's settings-file default permission mode (ELECTRON-3R4, feature 015 F2).
+//!
+//! A conversation with no explicit mode choice used to spawn hard-coded
+//! `--permission-mode default`, silently overriding the user's machine-level
+//! `permissions.defaultMode` in the claude settings files — a behavior
+//! regression against the legacy ACP path, whose adapter resolved that setting
+//! (`@agentclientprotocol/claude-agent-acp` `settings.js`/`resolvePermissionMode`).
+//! This module restores the settings-derived default WITHOUT giving up the
+//! explicit flag: the caller resolves here, then still passes `--permission-mode
+//! <resolved>` (fail-closed, deterministic, UI-visible).
+//!
+//! Scope is intentionally ONE field: `permissions.defaultMode`. Precedence and
+//! alias table are copied verbatim from the official adapter (0.29.2/0.33.1) —
+//! managed policy > `<workspace>/.claude/settings.local.json` >
+//! `<workspace>/.claude/settings.json` > `$CLAUDE_CONFIG_DIR/settings.json`
+//! (default `~/.claude`). The highest-precedence file that HAS the key decides;
+//! an unreadable/malformed file is treated as absent (the adapter's read
+//! failure behaves the same); a present-but-invalid value resolves to
+//! `"default"` (the adapter's `resolvePermissionMode` fallback), it does NOT
+//! fall through to a lower layer.
+
+use std::path::{Path, PathBuf};
+
+/// Which settings layer produced the resolved mode. `Fallback` = no layer had
+/// `permissions.defaultMode` (or the winning layer's value was invalid).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefaultModeSource {
+    Managed,
+    LocalProject,
+    Project,
+    User,
+    Fallback,
+}
+
+/// The resolved spawn-time default mode. `mode` is always one of claude's
+/// accepted `--permission-mode` wire values (the alias table maps onto them),
+/// so it passes `is_valid_claude_permission_mode` by construction.
+#[derive(Debug, Clone)]
+pub struct ResolvedDefaultMode {
+    pub mode: String,
+    pub source: DefaultModeSource,
+}
+
+const FALLBACK_MODE: &str = "default";
+
+/// Verbatim from the official adapter's `PERMISSION_MODE_ALIASES` (0.33.1):
+/// lowercase alias → claude wire value. Input is trimmed + lowercased first
+/// (the adapter does `trim().toLowerCase()`).
+fn normalize_mode_alias(raw: &str) -> Option<&'static str> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "auto" => Some("auto"),
+        "default" => Some("default"),
+        "acceptedits" => Some("acceptEdits"),
+        "dontask" => Some("dontAsk"),
+        "plan" => Some("plan"),
+        "bypasspermissions" | "bypass" => Some("bypassPermissions"),
+        _ => None,
+    }
+}
+
+/// Pure resolution over already-loaded settings layers, ordered highest
+/// precedence first. Split from the file IO so the precedence/alias matrix is
+/// unit-testable without a filesystem.
+pub fn resolve_from_layers(layers: &[(DefaultModeSource, Option<serde_json::Value>)]) -> ResolvedDefaultMode {
+    for (source, value) in layers {
+        let Some(v) = value else { continue };
+        let Some(dm) = v.get("permissions").and_then(|p| p.get("defaultMode")) else {
+            continue;
+        };
+        // The highest-precedence PRESENT key decides. Mirror the adapter's
+        // resolve-once semantics: a non-string or unknown value falls back to
+        // "default" instead of consulting lower layers.
+        let normalized = dm.as_str().and_then(normalize_mode_alias);
+        return match normalized {
+            Some(mode) => ResolvedDefaultMode {
+                mode: mode.to_string(),
+                source: *source,
+            },
+            None => {
+                tracing::warn!(
+                    source = ?source,
+                    value = %dm,
+                    "claude settings permissions.defaultMode is not a recognized mode; using \"default\""
+                );
+                ResolvedDefaultMode {
+                    mode: FALLBACK_MODE.to_string(),
+                    source: DefaultModeSource::Fallback,
+                }
+            }
+        };
+    }
+    ResolvedDefaultMode {
+        mode: FALLBACK_MODE.to_string(),
+        source: DefaultModeSource::Fallback,
+    }
+}
+
+/// Fully injectable variant (tests pass temp dirs). `workspace` scopes the two
+/// project layers; `None` (no workspace) skips them.
+pub fn resolve_claude_default_mode_at(
+    workspace: Option<&Path>,
+    user_config_dir: &Path,
+    managed_settings_path: &Path,
+) -> ResolvedDefaultMode {
+    let layers = vec![
+        (DefaultModeSource::Managed, read_settings_json(managed_settings_path)),
+        (
+            DefaultModeSource::LocalProject,
+            workspace.and_then(|w| read_settings_json(&w.join(".claude").join("settings.local.json"))),
+        ),
+        (
+            DefaultModeSource::Project,
+            workspace.and_then(|w| read_settings_json(&w.join(".claude").join("settings.json"))),
+        ),
+        (
+            DefaultModeSource::User,
+            read_settings_json(&user_config_dir.join("settings.json")),
+        ),
+    ];
+    resolve_from_layers(&layers)
+}
+
+/// Production entry: user layer honors `CLAUDE_CONFIG_DIR` (else `~/.claude`),
+/// managed layer uses the per-OS policy path (verbatim from the adapter).
+pub fn resolve_claude_default_mode(workspace: Option<&Path>) -> ResolvedDefaultMode {
+    resolve_claude_default_mode_at(workspace, &claude_user_config_dir(), &managed_settings_path())
+}
+
+/// `$CLAUDE_CONFIG_DIR`, else `<home>/.claude` — the same lookup the CLI and
+/// the official adapter use for user settings.
+pub fn claude_user_config_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("CLAUDE_CONFIG_DIR") {
+        let dir = dir.trim();
+        if !dir.is_empty() {
+            return PathBuf::from(dir);
+        }
+    }
+    home_dir().join(".claude")
+}
+
+fn home_dir() -> PathBuf {
+    #[cfg(windows)]
+    let var = "USERPROFILE";
+    #[cfg(not(windows))]
+    let var = "HOME";
+    std::env::var(var)
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("."))
+}
+
+/// Enterprise managed-policy path per OS — verbatim from the adapter's
+/// `settings.js` (macOS `/Library/Application Support/ClaudeCode/…`,
+/// Windows `C:\Program Files\ClaudeCode\…`, else `/etc/claude-code/…`).
+fn managed_settings_path() -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        PathBuf::from("/Library/Application Support/ClaudeCode/managed-settings.json")
+    }
+    #[cfg(target_os = "windows")]
+    {
+        PathBuf::from(r"C:\Program Files\ClaudeCode\managed-settings.json")
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        PathBuf::from("/etc/claude-code/managed-settings.json")
+    }
+}
+
+/// Read + parse one settings file. Missing file → `None` silently (the normal
+/// case); unreadable/malformed → `None` with a WARN (treated as absent, the
+/// layer falls through — same effective behavior as the adapter's failed read).
+fn read_settings_json(path: &Path) -> Option<serde_json::Value> {
+    let text = std::fs::read_to_string(path).ok()?;
+    match serde_json::from_str(&text) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "claude settings file is not valid JSON; ignoring this layer"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn layer(src: DefaultModeSource, mode: &str) -> (DefaultModeSource, Option<serde_json::Value>) {
+        (src, Some(json!({ "permissions": { "defaultMode": mode } })))
+    }
+
+    #[test]
+    fn no_layer_present_falls_back_to_default() {
+        let r = resolve_from_layers(&[(DefaultModeSource::User, None)]);
+        assert_eq!(r.mode, "default");
+        assert_eq!(r.source, DefaultModeSource::Fallback);
+    }
+
+    #[test]
+    fn user_bypass_resolves() {
+        let r = resolve_from_layers(&[layer(DefaultModeSource::User, "bypassPermissions")]);
+        assert_eq!(r.mode, "bypassPermissions");
+        assert_eq!(r.source, DefaultModeSource::User);
+    }
+
+    #[test]
+    fn precedence_managed_over_local_over_project_over_user() {
+        let r = resolve_from_layers(&[
+            layer(DefaultModeSource::Managed, "default"),
+            layer(DefaultModeSource::LocalProject, "plan"),
+            layer(DefaultModeSource::Project, "acceptEdits"),
+            layer(DefaultModeSource::User, "bypassPermissions"),
+        ]);
+        assert_eq!((r.mode.as_str(), r.source), ("default", DefaultModeSource::Managed));
+
+        let r = resolve_from_layers(&[
+            (DefaultModeSource::Managed, None),
+            layer(DefaultModeSource::LocalProject, "plan"),
+            layer(DefaultModeSource::Project, "acceptEdits"),
+            layer(DefaultModeSource::User, "bypassPermissions"),
+        ]);
+        assert_eq!((r.mode.as_str(), r.source), ("plan", DefaultModeSource::LocalProject));
+
+        let r = resolve_from_layers(&[
+            (DefaultModeSource::Managed, None),
+            (DefaultModeSource::LocalProject, None),
+            layer(DefaultModeSource::Project, "acceptEdits"),
+            layer(DefaultModeSource::User, "bypassPermissions"),
+        ]);
+        assert_eq!((r.mode.as_str(), r.source), ("acceptEdits", DefaultModeSource::Project));
+    }
+
+    #[test]
+    fn aliases_normalize_like_the_adapter() {
+        for (raw, want) in [
+            ("bypass", "bypassPermissions"),
+            ("BypassPermissions", "bypassPermissions"),
+            ("  acceptedits  ", "acceptEdits"),
+            ("DontAsk", "dontAsk"),
+            ("auto", "auto"),
+        ] {
+            let r = resolve_from_layers(&[layer(DefaultModeSource::User, raw)]);
+            assert_eq!(r.mode, want, "alias {raw:?}");
+        }
+    }
+
+    #[test]
+    fn unknown_or_nonstring_value_falls_back_without_consulting_lower_layers() {
+        let r = resolve_from_layers(&[
+            layer(DefaultModeSource::Project, "yolo"),
+            layer(DefaultModeSource::User, "bypassPermissions"),
+        ]);
+        assert_eq!((r.mode.as_str(), r.source), ("default", DefaultModeSource::Fallback));
+
+        let r = resolve_from_layers(&[
+            (
+                DefaultModeSource::Project,
+                Some(json!({ "permissions": { "defaultMode": 3 } })),
+            ),
+            layer(DefaultModeSource::User, "bypassPermissions"),
+        ]);
+        assert_eq!((r.mode.as_str(), r.source), ("default", DefaultModeSource::Fallback));
+    }
+
+    #[test]
+    fn resolved_mode_always_passes_the_spawn_whitelist() {
+        for raw in ["auto", "default", "acceptedits", "dontask", "plan", "bypass", "junk"] {
+            let r = resolve_from_layers(&[layer(DefaultModeSource::User, raw)]);
+            assert!(
+                crate::is_valid_claude_permission_mode(&r.mode),
+                "resolver output {:?} must be spawn-safe",
+                r.mode
+            );
+        }
+    }
+
+    #[test]
+    fn file_layers_read_from_disk_with_precedence_and_bad_json_falls_through() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let ws = tmp.path().join("ws");
+        let cfg = tmp.path().join("cfg");
+        std::fs::create_dir_all(ws.join(".claude")).unwrap();
+        std::fs::create_dir_all(&cfg).unwrap();
+        let managed = tmp.path().join("managed-settings.json"); // absent
+
+        // user says bypass
+        std::fs::write(
+            cfg.join("settings.json"),
+            r#"{ "permissions": { "defaultMode": "bypassPermissions" } }"#,
+        )
+        .unwrap();
+        let r = resolve_claude_default_mode_at(Some(&ws), &cfg, &managed);
+        assert_eq!(
+            (r.mode.as_str(), r.source),
+            ("bypassPermissions", DefaultModeSource::User)
+        );
+
+        // project overrides user
+        std::fs::write(
+            ws.join(".claude").join("settings.json"),
+            r#"{ "permissions": { "defaultMode": "plan" } }"#,
+        )
+        .unwrap();
+        let r = resolve_claude_default_mode_at(Some(&ws), &cfg, &managed);
+        assert_eq!((r.mode.as_str(), r.source), ("plan", DefaultModeSource::Project));
+
+        // corrupt local layer is treated as absent → project still wins
+        std::fs::write(ws.join(".claude").join("settings.local.json"), "{ not json").unwrap();
+        let r = resolve_claude_default_mode_at(Some(&ws), &cfg, &managed);
+        assert_eq!((r.mode.as_str(), r.source), ("plan", DefaultModeSource::Project));
+
+        // no workspace → project layers skipped, user wins again
+        let r = resolve_claude_default_mode_at(None, &cfg, &managed);
+        assert_eq!(
+            (r.mode.as_str(), r.source),
+            ("bypassPermissions", DefaultModeSource::User)
+        );
+    }
+}

--- a/crates/aionui-session/src/lib.rs
+++ b/crates/aionui-session/src/lib.rs
@@ -35,6 +35,7 @@
 mod adapter;
 mod backend;
 mod capability;
+pub mod claude_settings;
 mod error;
 mod event;
 mod reducer;

--- a/crates/aionui-session/tests/live_attachment_e2e.rs
+++ b/crates/aionui-session/tests/live_attachment_e2e.rs
@@ -1,0 +1,129 @@
+//! LIVE e2e (feature 015 T8, ELECTRON-3R4): probe E productionized.
+//!
+//! Drives the REAL `ClaudeConnection::open_session` + `dispatch(Send)` path
+//! against the real `claude` CLI: a fail-closed default-mode session must read
+//! an image staged in the out-of-cwd upload dir (`$TMPDIR/aionui/<conv>`,
+//! granted via the spawn's `--add-dir`) with ZERO permission prompts and
+//! answer from its content. Before the fix, this exact frame dead-ends on a
+//! `can_use_tool(Read)` permission ask.
+//!
+//! `#[ignore]`: needs a `claude` binary + working credentials on PATH. Run:
+//! `cargo test -p aionui-session --test live_attachment_e2e -- --ignored --nocapture`
+
+use std::sync::Arc;
+
+use aionui_session::{
+    BackendConnection, ClaudeConnection, Command, CommandMeta, ContentBlock, SessionConfig, SessionEvent, SessionSpec,
+};
+use futures_util::StreamExt;
+
+/// 32x32 solid-red PNG (generated offline; embedded so the test is hermetic on
+/// the input side — only the CLI + credentials are external).
+const RED_PNG: &[u8] = &[
+    137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 32, 0, 0, 0, 32, 8, 2, 0, 0, 0, 252, 24,
+    237, 163, 0, 0, 0, 40, 73, 68, 65, 84, 120, 156, 237, 205, 177, 13, 0, 0, 12, 194, 48, 254, 127, 186, 125, 2, 54,
+    75, 153, 227, 92, 50, 109, 123, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 197, 30, 50, 195, 252, 46, 60, 190, 144, 144, 0, 0,
+    0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+];
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "LIVE: requires claude CLI + credentials on PATH"]
+async fn live_t8_default_mode_reads_temp_attachment_without_permission_prompt() {
+    // Unique conversation id → unique upload staging dir (cleaned up at the end).
+    let conv_id = format!("live-t8-{}", uuid::Uuid::new_v4());
+    let upload_dir = aionui_common::paths::uploads_dir(Some(&conv_id));
+    std::fs::create_dir_all(&upload_dir).expect("create upload staging dir");
+    let image_path = upload_dir.join("image-1.png");
+    std::fs::write(&image_path, RED_PNG).expect("stage pasted image");
+
+    // Empty temp workspace — the attachment is OUTSIDE this cwd by construction.
+    let workspace = tempfile::tempdir().expect("workspace");
+    let registry_dir = tempfile::tempdir().expect("registry");
+    let spawner: Arc<dyn aionui_process::Spawner> = Arc::new(aionui_process::RealSpawner::new(
+        Arc::new(aionui_process::FileRegistryStore::new(registry_dir.path())),
+        uuid::Uuid::new_v4(),
+        aionui_process::local_machine_id(registry_dir.path()),
+    ));
+
+    // Blank production config: mode None → the spawn's fail-closed
+    // `--permission-mode default`. THE point of the test — the read must
+    // succeed through the `--add-dir` grant, not through a permissive mode.
+    let config = SessionConfig {
+        cwd: Some(workspace.path().to_string_lossy().into_owned()),
+        ..Default::default()
+    };
+    let backend = ClaudeConnection::new(spawner)
+        .open_session(
+            SessionSpec::Fresh {
+                session_id: conv_id.clone(),
+            },
+            config,
+        )
+        .await
+        .expect("open live claude session");
+
+    // Subscribe BEFORE dispatch so no event can be missed.
+    let mut events = backend.events();
+
+    // The exact production lowering of a pasted attachment (session_agent
+    // send_message): user text + a raw-path ResourceLink, which the claude
+    // adapter turns into an `[Attached file: <path>]` text reference.
+    let receipt = backend
+        .dispatch(Command::Send {
+            content: vec![
+                ContentBlock::Text(
+                    "What is the dominant color of the attached image? Reply with just the color name.".to_string(),
+                ),
+                ContentBlock::ResourceLink {
+                    uri: image_path.to_string_lossy().into_owned(),
+                    mime_type: None,
+                },
+            ],
+            metadata: CommandMeta {
+                command_id: 1,
+                cwd: None,
+                extra_args: Vec::new(),
+                client_msg_id: None,
+            },
+        })
+        .await
+        .expect("dispatch Send");
+    assert!(receipt.accepted, "send must be accepted");
+
+    let mut permissions: Vec<String> = Vec::new();
+    let mut streamed_text = String::new();
+    let mut turn_result: Option<(bool, String)> = None;
+    let drained = tokio::time::timeout(std::time::Duration::from_secs(180), async {
+        while let Some(env) = events.next().await {
+            match env.event {
+                SessionEvent::Permission { ref request_id, .. } => permissions.push(request_id.clone()),
+                SessionEvent::MessageDelta { ref text, .. } => streamed_text.push_str(text),
+                SessionEvent::TurnResult {
+                    is_error, result_text, ..
+                } => {
+                    turn_result = Some((is_error, result_text));
+                    return;
+                }
+                SessionEvent::Detached { .. } => return,
+                _ => {}
+            }
+        }
+    })
+    .await;
+
+    // Best-effort cleanup before asserting.
+    let _ = std::fs::remove_dir_all(&upload_dir);
+
+    assert!(drained.is_ok(), "turn must terminate within 180s (no permission hang)");
+    let (is_error, result_text) = turn_result.expect("turn must end in a TurnResult, not a process exit");
+    assert!(!is_error, "turn errored: {result_text}");
+    assert!(
+        permissions.is_empty(),
+        "attachment read must not raise permission prompts (ELECTRON-3R4), got: {permissions:?}"
+    );
+    let answer = format!("{streamed_text} {result_text}").to_ascii_lowercase();
+    assert!(
+        answer.contains("red"),
+        "model must answer from the attachment's content, got: {answer}"
+    );
+}


### PR DESCRIPTION
## Problem

Sentry ELECTRON-3R4 (user feedback, 2.1.41): a pasted image displays in the UI but the agent never recognizes it, while absolute-path images work.

Root cause: pasted/uploaded attachments are staged in `$TMPDIR/aionui/<conv>/` (home-page uploads in `.../general`) — **outside the workspace cwd** — and delivered to the model as a path reference. Under the fail-closed `--permission-mode default`, the model's out-of-cwd `Read` of that path raises a permission prompt; denied/unanswered, the attachment is simply "unreadable". Live-probed end to end (claude 2.1.220): the identical frame succeeds with `--add-dir` and dead-ends without it.

A second, related regression: the direct-CLI path hard-coded `--permission-mode default` whenever no mode was persisted, silently overriding the user's machine-level claude settings `permissions.defaultMode` — the legacy ACP adapter resolved that setting per session.

## Fix

**F1 — grant exactly the two upload staging dirs at spawn**
- New `aionui_common::paths::uploads_dir(Option<&str>)`: single source of the upload layout; `aionui-file` rewired onto it (byte-identical layout).
- The claude open path appends `--add-dir <tmp>/aionui/<conv>` + `--add-dir <tmp>/aionui/general` (mkdir-before-spawn, WARN-only on failure). Fresh, Resume and the wake-recipe respawn all inherit the grant (shared init args). Everything else stays fail-closed.

**F2 — spawn mode honors claude settings `permissions.defaultMode`**
- New `aionui_session::claude_settings` resolver — precedence + alias table verbatim from the official adapter 0.33.1 (managed > local project > project > user; fallback `"default"`).
- `build_session_instance` applies it as the LAST precedence step (persisted switch > create-time seed > settings), still passing an explicit flag.
- No bespoke persist/UI writes needed: open seeds `caps.current_mode` from `config.mode` (picker shows the value from the first `runtime/ensure`), and claude's init echo persists via the existing `sniff_mode` → `ConfigChanged` → `save_runtime_state` chain.
- Drift tripwire: WARN when the first observed `permissionMode` differs from the spawn-requested flag value.
- Clean-env probe (2.1.220): omitting the flag makes the CLI resolve its own settings hierarchy — NOT a hard `bypassPermissions` default; the stale comment claiming otherwise is rewritten with corrected evidence.

With no settings present, emitted spawn args are byte-identical to before except the two `--add-dir` pairs (pinned-args golden test re-pinned).

## Tests

- `claude_settings`: 7 unit tests (precedence matrix, alias normalization, bad JSON fall-through, on-disk layering, spawn-whitelist invariant).
- `open_session_grants_add_dir_for_upload_dirs` / `..._resume_grants_same_add_dirs`: both spawn branches emit the two pairs, dirs created up-front.
- `claude_mode_fallback_applies_only_when_unset`: fallback fires only for claude with no resolved mode; resolver provably not invoked otherwise.
- `open_seeds_current_mode_from_config_before_any_wire_frame`: picker truth at open, before any wire frame.
- `sniff_mode_warns_when_first_observed_mode_differs_from_requested`: exactly one drift WARN on first-observation mismatch, none on match, behavior unchanged.
- Full pre-push gate green: 7492 tests passed, clippy `-D warnings`, fmt.