### PR TITLE
fix(acp): tolerate CodeBuddy dialect and stop misreporting empty turns as needs-auth

### DIFF
--- a/crates/aionui-ai-agent/Cargo.toml
+++ b/crates/aionui-ai-agent/Cargo.toml
@@ -43,7 +43,7 @@ aion-config.workspace = true
 aion-mcp.workspace = true
 uuid.workspace = true
 agent-client-protocol = { version = "0.11.1", features = ["unstable_session_model", "unstable_session_close", "unstable_session_usage", "unstable_session_fork", "unstable_session_additional_directories", "unstable_session_resume"] }
-tokio-util = { version = "0.7", features = ["compat"] }
+tokio-util = { version = "0.7", features = ["compat", "codec"] }
 rusqlite.workspace = true
 libc.workspace = true
 

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -265,7 +265,14 @@ impl AcpAgentManager {
             .await
             .map_err(AcpSendFailure::from)?;
 
-        let empty_turn = is_empty_turn(&mut probe_rx);
+        // Drain the turn-scoped receiver once: detect both the empty-turn
+        // condition and any CodeBuddy dialect signal (session_end / token
+        // pressure) the tolerant transport absorbed during this turn. Because
+        // `probe_rx` was subscribed just before this prompt and is drained here,
+        // the signal is correlated strictly to the turn/near-window — signals
+        // seen earlier in the session lifetime are never attributed here.
+        let observations = drain_turn_observations(&mut probe_rx);
+        let empty_turn = observations.empty;
         if empty_turn && let Some(error) = self.empty_turn_terminal_error().await {
             return Ok(PromptOutcome::TerminalError {
                 session_id: sid.to_owned(),
@@ -291,6 +298,7 @@ impl AcpAgentManager {
             empty_turn,
             matched_command,
             auth_hint,
+            observations.dialect_signal,
         ))
     }
 
@@ -369,20 +377,46 @@ impl AcpAgentManager {
 ///
 /// `Lagged` is treated as non-empty: the broadcast buffer overflowed,
 /// meaning many events flew by — definitely not an empty turn.
+/// Thin wrapper retained for the existing empty-turn detection tests; the
+/// production path now uses [`drain_turn_observations`] to observe the dialect
+/// signal alongside emptiness in a single drain.
+#[cfg(test)]
 fn is_empty_turn(rx: &mut tokio::sync::broadcast::Receiver<AgentStreamEvent>) -> bool {
+    drain_turn_observations(rx).empty
+}
+
+/// What a single drain of the turn-scoped receiver observed.
+struct TurnObservations {
+    /// The turn produced no user-visible output (see `is_empty_turn`).
+    empty: bool,
+    /// The tolerant transport absorbed at least one CodeBuddy dialect signal
+    /// (`session_end` or token-pressure/compaction) during this turn/near-window.
+    dialect_signal: bool,
+}
+
+/// Drain the turn-scoped receiver once, recording both the empty-turn condition
+/// and whether any `AcpDialectSignal` arrived. Preserves `is_empty_turn`'s
+/// original semantics for `empty` (visible output → not empty; `Lagged` → not
+/// empty) while additionally surfacing the dialect signal so the empty-turn
+/// judgment can prefer accurate token-limit attribution over the auth hint.
+fn drain_turn_observations(rx: &mut tokio::sync::broadcast::Receiver<AgentStreamEvent>) -> TurnObservations {
+    let mut empty = true;
+    let mut dialect_signal = false;
     loop {
         match rx.try_recv() {
+            Ok(AgentStreamEvent::AcpDialectSignal(_)) => dialect_signal = true,
             Ok(event) => {
                 if event_is_user_visible_output(&event) {
-                    return false;
+                    empty = false;
                 }
             }
-            Err(TryRecvError::Empty) => return true,
-            Err(TryRecvError::Closed) => return true,
+            Err(TryRecvError::Empty) | Err(TryRecvError::Closed) => break,
             // Buffer overflow: many events occurred — turn was clearly not empty.
-            Err(TryRecvError::Lagged(_)) => return false,
+            // Keep draining so a dialect signal later in the buffer is still seen.
+            Err(TryRecvError::Lagged(_)) => empty = false,
         }
     }
+    TurnObservations { empty, dialect_signal }
 }
 
 /// Whether a stream event represents user-visible output produced by the
@@ -407,6 +441,7 @@ fn prompt_outcome_from_stop_reason(
     empty_turn: bool,
     _matched_command: Option<&SlashCommandItem>,
     auth_hint: Option<Value>,
+    token_limit_signal: bool,
 ) -> PromptOutcome {
     if matches!(stop_reason, StopReason::Cancelled) {
         return PromptOutcome::Cancelled {
@@ -416,6 +451,18 @@ fn prompt_outcome_from_stop_reason(
 
     if empty_turn {
         if matches!(stop_reason, StopReason::EndTurn) {
+            // Priority 2 (B): a CodeBuddy dialect signal observed in this turn /
+            // near-window (session_end or emergency compaction / token pressure)
+            // attributes the empty turn to a likely context/token limit — taken
+            // *before* the auth hint so the accurate cause wins. Possibility
+            // wording only: the exact upstream cause is cross-boundary and not
+            // asserted here.
+            if token_limit_signal {
+                return PromptOutcome::InfoTip {
+                    session_id: session_id.to_owned(),
+                    tips: empty_turn_info_tip("ACP_EMPTY_TURN_TOKEN_LIMIT", None),
+                };
+            }
             // The agent ended the turn producing nothing. If it advertised a
             // login method at initialize, the most likely cause is that it
             // isn't signed in and silently returned an empty end_turn — point
@@ -812,7 +859,7 @@ mod tests {
 
     #[test]
     fn benign_empty_turn_returns_info_tip() {
-        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, None, None);
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, None, None, false);
 
         match outcome {
             super::PromptOutcome::InfoTip { session_id, tips } => {
@@ -835,7 +882,7 @@ mod tests {
             "hint": "Run `kilo auth login` in the terminal",
         });
         let outcome =
-            super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, None, Some(auth_hint));
+            super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, None, Some(auth_hint), false);
 
         match outcome {
             super::PromptOutcome::InfoTip { session_id, tips } => {
@@ -856,6 +903,113 @@ mod tests {
         assert!(super::auth_login_hint(Some(&[])).is_none());
     }
 
+    // -- token-limit signal priority (issue 136586749) ------------------------
+
+    /// B priority: a CodeBuddy dialect signal (session_end / compaction) observed
+    /// in the turn attributes the empty turn to a likely context limit — taken
+    /// *before* the auth hint even when authMethods were advertised.
+    #[test]
+    fn empty_end_turn_with_token_signal_prefers_token_limit_over_auth_hint() {
+        let auth_hint = serde_json::json!({
+            "methods": [{"id": "iOA", "name": "Login with iOA"}],
+            "hint": "Login with iOA",
+        });
+        let outcome =
+            super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, None, Some(auth_hint), true);
+        match outcome {
+            super::PromptOutcome::InfoTip { tips, .. } => {
+                assert_eq!(tips.code.as_deref(), Some("ACP_EMPTY_TURN_TOKEN_LIMIT"));
+                assert_eq!(tips.tip_type, TipType::Info);
+                assert_eq!(
+                    tips.params, None,
+                    "token-limit tip is a possibility hint, no hint params"
+                );
+            }
+            other => panic!("expected InfoTip, got {other:?}"),
+        }
+    }
+
+    /// The reported issue's clean empty end_turn: authMethods advertised but NO
+    /// dialect signal in the turn → needs-auth fallback (its copy is softened in
+    /// the UI). Guards against mis-attributing this case to a token limit.
+    #[test]
+    fn empty_end_turn_without_token_signal_but_auth_hint_falls_back_to_needs_auth() {
+        let auth_hint = serde_json::json!({
+            "methods": [{"id": "iOA", "name": "Login with iOA"}],
+            "hint": "Login with iOA",
+        });
+        let outcome =
+            super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, None, Some(auth_hint), false);
+        match outcome {
+            super::PromptOutcome::InfoTip { tips, .. } => {
+                assert_eq!(tips.code.as_deref(), Some("ACP_EMPTY_TURN_NEEDS_AUTH"));
+            }
+            other => panic!("expected InfoTip, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_end_turn_with_token_signal_and_no_auth_hint_is_token_limit() {
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, None, None, true);
+        match outcome {
+            super::PromptOutcome::InfoTip { tips, .. } => {
+                assert_eq!(tips.code.as_deref(), Some("ACP_EMPTY_TURN_TOKEN_LIMIT"));
+            }
+            other => panic!("expected InfoTip, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn drain_turn_observations_flags_dialect_signal_on_empty_turn() {
+        use crate::protocol::events::{AcpDialectSignalData, AcpDialectSignalKind};
+        let (tx, _) = broadcast::channel::<AgentStreamEvent>(8);
+        let mut rx = tx.subscribe();
+        tx.send(AgentStreamEvent::Start(StartEventData::default())).unwrap();
+        tx.send(AgentStreamEvent::AcpDialectSignal(AcpDialectSignalData {
+            kind: AcpDialectSignalKind::SessionEnd,
+        }))
+        .unwrap();
+        tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
+
+        let obs = super::drain_turn_observations(&mut rx);
+        assert!(obs.empty, "a dialect signal is not user-visible output");
+        assert!(obs.dialect_signal, "session_end signal must be flagged");
+    }
+
+    #[tokio::test]
+    async fn drain_turn_observations_no_signal_when_only_lifecycle() {
+        let (tx, _) = broadcast::channel::<AgentStreamEvent>(8);
+        let mut rx = tx.subscribe();
+        tx.send(AgentStreamEvent::Start(StartEventData::default())).unwrap();
+        tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
+
+        let obs = super::drain_turn_observations(&mut rx);
+        assert!(obs.empty);
+        assert!(!obs.dialect_signal);
+    }
+
+    #[tokio::test]
+    async fn drain_turn_observations_text_makes_turn_non_empty() {
+        let (tx, _) = broadcast::channel::<AgentStreamEvent>(8);
+        let mut rx = tx.subscribe();
+        tx.send(AgentStreamEvent::Text(TextEventData { content: "hi".into() }))
+            .unwrap();
+
+        let obs = super::drain_turn_observations(&mut rx);
+        assert!(!obs.empty);
+        assert!(!obs.dialect_signal);
+    }
+
+    #[test]
+    fn dialect_signal_is_not_user_visible_output() {
+        use crate::protocol::events::{AcpDialectSignalData, AcpDialectSignalKind};
+        assert!(!super::event_is_user_visible_output(
+            &AgentStreamEvent::AcpDialectSignal(AcpDialectSignalData {
+                kind: AcpDialectSignalKind::TokenPressure,
+            })
+        ));
+    }
+
     #[test]
     fn metadata_driven_command_empty_turn_uses_generic_tip_code() {
         let command = SlashCommandItem {
@@ -866,7 +1020,8 @@ mod tests {
             empty_turn_tip_params: Some(serde_json::json!({ "scope": "session" })),
         };
 
-        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, Some(&command), None);
+        let outcome =
+            super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, true, Some(&command), None, false);
 
         match outcome {
             super::PromptOutcome::InfoTip { session_id, tips } => {
@@ -882,7 +1037,7 @@ mod tests {
 
     #[test]
     fn non_benign_empty_turn_can_stay_warning_tip() {
-        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::MaxTokens, true, None, None);
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::MaxTokens, true, None, None, false);
 
         match outcome {
             super::PromptOutcome::WarningTip { session_id, tips } => {
@@ -897,7 +1052,7 @@ mod tests {
 
     #[test]
     fn prompt_outcome_cancelled_takes_priority_over_empty_response() {
-        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::Cancelled, true, None, None);
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::Cancelled, true, None, None, false);
 
         match outcome {
             super::PromptOutcome::Cancelled { session_id } => {
@@ -909,7 +1064,7 @@ mod tests {
 
     #[test]
     fn prompt_outcome_completed_when_visible_output_exists() {
-        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, false, None, None);
+        let outcome = super::prompt_outcome_from_stop_reason("sess-1", StopReason::EndTurn, false, None, None, false);
 
         match outcome {
             super::PromptOutcome::Completed { session_id } => {

--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -33,14 +33,16 @@ use agent_client_protocol::schema::{
     SetSessionModelResponse,
 };
 use agent_client_protocol::{
-    Agent, ByteStreams, Client, ConnectionTo, Responder, on_receive_notification, on_receive_request,
+    Agent, Client, ConnectionTo, Lines, Responder, on_receive_notification, on_receive_request,
 };
 use aionui_common::ErrorChain;
+use futures_util::{SinkExt, StreamExt, TryStreamExt};
 use tokio::process::{ChildStdin, ChildStdout};
 use tokio::sync::{broadcast, mpsc, oneshot};
-use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec};
 use tracing::{debug, info, warn};
 
+use crate::protocol::acp_dialect;
 use crate::protocol::error::AcpError;
 use crate::protocol::events::{self as stream_event, AgentStreamEvent};
 
@@ -514,7 +516,44 @@ async fn run_sdk_background(
     alive: Arc<AtomicBool>,
     replay_suppression: Arc<AtomicBool>,
 ) {
-    let transport = ByteStreams::new(stdin.compat_write(), stdout.compat());
+    // Tolerant transport: intercept incoming lines *before* the SDK parses them
+    // so CodeBuddy's non-standard dialect notifications (`session_end` /
+    // `compact-maxtoken`) are absorbed into an internal signal instead of
+    // surfacing a `-32602` deserialization error and being silently dropped.
+    // We use the vendored `Lines` transport — the crate's documented
+    // first-party interception point — whose newline framing is equivalent to
+    // `ByteStreams` (which internally splits stdout on `\n` and appends `\n` on
+    // writes). Only the two recognised shapes are absorbed; every other line,
+    // including genuinely malformed input, is forwarded unchanged.
+    let dialect_event_tx = event_tx.clone();
+    let incoming = FramedRead::new(stdout, LinesCodec::new())
+        .map_err(std::io::Error::other)
+        .filter_map(move |line: std::io::Result<String>| {
+            let dialect_event_tx = dialect_event_tx.clone();
+            async move {
+                match line {
+                    Ok(line) => match acp_dialect::classify_incoming_line(&line) {
+                        acp_dialect::LineDisposition::Forward(line) => Some(Ok(line)),
+                        acp_dialect::LineDisposition::Absorb(kind) => {
+                            log_acp_dialect_absorbed(kind, &line);
+                            // `broadcast::send` is synchronous and non-blocking; a
+                            // send error only means no active subscriber for this
+                            // turn (nothing to correlate against), which is fine.
+                            let _ = dialect_event_tx.send(AgentStreamEvent::AcpDialectSignal(
+                                stream_event::AcpDialectSignalData { kind },
+                            ));
+                            None
+                        }
+                    },
+                    Err(err) => Some(Err(err)),
+                }
+            }
+        });
+    // Pin the sink item type to `String` (LinesCodec encodes any `AsRef<str>`,
+    // so the item type would otherwise be ambiguous) — `Lines` requires a
+    // `Sink<String>`.
+    let outgoing = SinkExt::<String>::sink_map_err(FramedWrite::new(stdin, LinesCodec::new()), std::io::Error::other);
+    let transport = Lines::new(outgoing, incoming);
 
     // `init_tx` / `ready_tx` are consumed inside the main_fn closure; wrap
     // them in Option so we can .take() without moving out of captured state.
@@ -855,6 +894,26 @@ fn log_agent_notify(method: &str, body: &str) {
             "[ACP] <- ${method}"
         );
     }
+}
+
+/// Log that the tolerant transport layer absorbed a CodeBuddy dialect
+/// notification the stock ACP schema would otherwise `-32602`-reject.
+///
+/// Low-volume, production-diagnostic (`info`): once the layer absorbs a line
+/// the SDK never sees it, so the SDK's `-32602 warn` disappears — this restores
+/// that visibility. Records only the signal kind and non-sensitive correlation
+/// context (`session_id`, the sessionUpdate/compactType marker); never the
+/// compaction summary, prompt, tokens, or other payload.
+fn log_acp_dialect_absorbed(kind: stream_event::AcpDialectSignalKind, line: &str) {
+    let (session_id, marker) = acp_dialect::absorbed_log_context(line);
+    info!(
+        direction = "agent_notify",
+        method = "session/update",
+        dialect_signal = ?kind,
+        session_id = session_id.as_deref().unwrap_or("none"),
+        marker = marker.as_deref().unwrap_or("none"),
+        "[ACP] absorbed CodeBuddy dialect notification (tolerant layer); not forwarded to SDK"
+    );
 }
 
 /// Log an inbound request from the agent (e.g. session/request_permission).

--- a/crates/aionui-ai-agent/src/protocol/acp_dialect.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp_dialect.rs
@@ -1,0 +1,186 @@
+//! Local tolerant pre-parse layer for CodeBuddy's non-standard ACP dialect.
+//!
+//! The vendored `agent-client-protocol(-schema)` only accepts the canonical
+//! `SessionUpdate` variants and hard-rejects two CodeBuddy-specific
+//! `session/update` shapes with a `-32602 Invalid params` deserialization
+//! error, silently dropping signals we could otherwise use to attribute an
+//! empty turn:
+//!
+//!   (a) `session_end` — a terminal marker carrying `stopReason:"end_turn"`.
+//!   (b) `compact-maxtoken` / `codebuddy.ai/compactType:"emergency-auto"` — an
+//!       emergency auto-compaction notification emitted as the conversation
+//!       approaches the context/token limit.
+//!
+//! This module classifies a single raw newline-delimited JSON-RPC line at the
+//! transport boundary — *before* the SDK parses it — so those two shapes can be
+//! absorbed (and turned into an internal signal) instead of surfacing `-32602`.
+//! Every other line, including genuinely malformed input and any other unknown
+//! variant, is forwarded unchanged so the SDK still surfaces real errors.
+//!
+//! Wire shapes are grounded in captured real data from this issue's
+//! `attachments/extracted/logs.txt` (deserialization-rejection payloads at
+//! lines 8798 / 523), not inferred — see AGENTS.md "only assert what an
+//! approved source proves".
+
+use crate::protocol::events::AcpDialectSignalKind;
+use serde_json::Value;
+
+/// What the tolerant layer decides to do with one incoming JSON-RPC line.
+pub(crate) enum LineDisposition {
+    /// Hand the line to the SDK unchanged (canonical or unknown-but-not-ours).
+    Forward(String),
+    /// A recognised CodeBuddy dialect notification: absorb it (never reaches the
+    /// SDK, so no `-32602`) and raise the corresponding internal signal.
+    Absorb(AcpDialectSignalKind),
+}
+
+/// The `_meta` key CodeBuddy uses to tag an emergency-compaction notification.
+const COMPACT_TYPE_META_KEY: &str = "codebuddy.ai/compactType";
+/// Prefix of the `messageId` CodeBuddy stamps on max-token compaction chunks.
+const COMPACT_MESSAGE_ID_PREFIX: &str = "compact-maxtoken";
+
+/// Classify one raw newline-delimited JSON-RPC line per the wire criteria in
+/// `logs.txt`. Only the two recognised CodeBuddy shapes are absorbed; anything
+/// else (parse failure, other method, other/unknown variant) is forwarded.
+pub(crate) fn classify_incoming_line(line: &str) -> LineDisposition {
+    let Ok(value) = serde_json::from_str::<Value>(line) else {
+        // Genuinely malformed input must still reach the SDK (validation #4:
+        // never swallow real errors).
+        return LineDisposition::Forward(line.to_owned());
+    };
+
+    // Only `session/update` notifications are candidates.
+    if value.get("method").and_then(Value::as_str) != Some("session/update") {
+        return LineDisposition::Forward(line.to_owned());
+    }
+
+    let Some(update) = value.pointer("/params/update") else {
+        return LineDisposition::Forward(line.to_owned());
+    };
+
+    // (a) `session_end` terminal marker — an unknown `sessionUpdate` variant.
+    if update.get("sessionUpdate").and_then(Value::as_str) == Some("session_end") {
+        return LineDisposition::Absorb(AcpDialectSignalKind::SessionEnd);
+    }
+
+    // (b) emergency compaction: identified by the codebuddy compact markers, NOT
+    // by the `sessionUpdate` variant (it is the legal `agent_message_chunk`, so
+    // an "unknown variant" test would miss it). The internal compaction summary
+    // is `isCompactInternal:true` and is safely ignored — never rendered.
+    let has_compact_meta = update
+        .get("_meta")
+        .and_then(|meta| meta.get(COMPACT_TYPE_META_KEY))
+        .is_some();
+    let has_compact_message_id = update
+        .get("messageId")
+        .and_then(Value::as_str)
+        .is_some_and(|id| id.starts_with(COMPACT_MESSAGE_ID_PREFIX));
+    if has_compact_meta || has_compact_message_id {
+        return LineDisposition::Absorb(AcpDialectSignalKind::TokenPressure);
+    }
+
+    // (c) everything else — including other unknown variants and malformed
+    // messages — is forwarded so the SDK can surface `-32602` as before.
+    LineDisposition::Forward(line.to_owned())
+}
+
+/// Extract non-sensitive correlation context from an absorbed dialect line for
+/// `info`-level logging. Returns `(session_id, session_update_marker)`; never
+/// touches content/summary/prompt payloads.
+pub(crate) fn absorbed_log_context(line: &str) -> (Option<String>, Option<String>) {
+    let Ok(value) = serde_json::from_str::<Value>(line) else {
+        return (None, None);
+    };
+    let session_id = value
+        .pointer("/params/sessionId")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let update = value.pointer("/params/update");
+    // Prefer the explicit compactType marker; otherwise the sessionUpdate kind.
+    let marker = update
+        .and_then(|u| {
+            u.get("_meta")
+                .and_then(|meta| meta.get(COMPACT_TYPE_META_KEY))
+                .and_then(Value::as_str)
+        })
+        .or_else(|| update.and_then(|u| u.get("sessionUpdate").and_then(Value::as_str)))
+        .map(str::to_owned);
+    (session_id, marker)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn absorb_kind(line: &str) -> Option<AcpDialectSignalKind> {
+        match classify_incoming_line(line) {
+            LineDisposition::Absorb(kind) => Some(kind),
+            LineDisposition::Forward(forwarded) => {
+                // Forward must preserve the original line verbatim.
+                assert_eq!(forwarded, line);
+                None
+            }
+        }
+    }
+
+    // Real `session_end` payload shape (logs.txt:8798), wrapped in its JSON-RPC
+    // notification envelope as it appears on the wire.
+    const SESSION_END_LINE: &str = r#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"19c4b027-88cd-41d7-a8fb-29dea4208737","update":{"_meta":{"codebuddy.ai":{"timestamp":1785036577598},"timestamp":"2026-07-26T03:29:37.598Z"},"sessionUpdate":"session_end","stopReason":"end_turn"}}}"#;
+
+    // Real `compact-maxtoken` / `emergency-auto` payload (logs.txt:523).
+    const COMPACT_LINE: &str = r#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"20bffd06-7f7a-4548-af8e-eea0ea3504ae","update":{"_meta":{"codebuddy.ai":{"messageId":"compact-maxtoken-20bffd06-7f7a-4548-af8e-eea0ea3504ae-1785027303300","timestamp":1785027303301},"codebuddy.ai/compactType":"emergency-auto","codebuddy.ai/isCompactInternal":true,"timestamp":"2026-07-26T00:55:03.301Z"},"content":[{"text":"<conversation_history_summary><summary>","type":"text"}],"messageId":"compact-maxtoken-20bffd06-7f7a-4548-af8e-eea0ea3504ae-1785027303300","sessionUpdate":"agent_message_chunk"}}}"#;
+
+    #[test]
+    fn session_end_is_absorbed_as_session_end_signal() {
+        assert_eq!(absorb_kind(SESSION_END_LINE), Some(AcpDialectSignalKind::SessionEnd));
+    }
+
+    #[test]
+    fn compact_maxtoken_is_absorbed_as_token_pressure() {
+        assert_eq!(absorb_kind(COMPACT_LINE), Some(AcpDialectSignalKind::TokenPressure));
+    }
+
+    #[test]
+    fn compact_detected_by_message_id_prefix_alone() {
+        // Even without the compactType meta, a `compact-maxtoken` messageId marks it.
+        let line = r#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"messageId":"compact-maxtoken-s1-123","sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"x"}}}}"#;
+        assert_eq!(absorb_kind(line), Some(AcpDialectSignalKind::TokenPressure));
+    }
+
+    #[test]
+    fn normal_agent_message_chunk_is_forwarded() {
+        // A genuine streaming chunk (no compact markers) must reach the SDK.
+        let line = r#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello"}}}}"#;
+        assert_eq!(absorb_kind(line), None);
+    }
+
+    #[test]
+    fn other_unknown_variant_is_forwarded_for_sdk_to_reject() {
+        // An unknown variant that is NOT one of ours must still surface -32602.
+        let line = r#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"future_unknown_kind"}}}"#;
+        assert_eq!(absorb_kind(line), None);
+    }
+
+    #[test]
+    fn non_session_update_method_is_forwarded() {
+        let line = r#"{"jsonrpc":"2.0","id":7,"method":"session/request_permission","params":{"sessionId":"s1"}}"#;
+        assert_eq!(absorb_kind(line), None);
+    }
+
+    #[test]
+    fn malformed_json_is_forwarded() {
+        assert_eq!(absorb_kind("not json at all"), None);
+        assert_eq!(absorb_kind("{\"method\":"), None);
+    }
+
+    #[test]
+    fn absorbed_log_context_extracts_session_and_marker_without_content() {
+        let (sid, marker) = absorbed_log_context(COMPACT_LINE);
+        assert_eq!(sid.as_deref(), Some("20bffd06-7f7a-4548-af8e-eea0ea3504ae"));
+        assert_eq!(marker.as_deref(), Some("emergency-auto"));
+
+        let (sid, marker) = absorbed_log_context(SESSION_END_LINE);
+        assert_eq!(sid.as_deref(), Some("19c4b027-88cd-41d7-a8fb-29dea4208737"));
+        assert_eq!(marker.as_deref(), Some("session_end"));
+    }
+}

--- a/crates/aionui-ai-agent/src/protocol/events/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/events/mod.rs
@@ -64,6 +64,13 @@ pub enum AgentStreamEvent {
     /// under one turn). The relay consumes it internally and never forwards it
     /// to the WebSocket, so no frontend renderer is required.
     SegmentBreak,
+    /// Internal-only signal: the tolerant transport layer absorbed a CodeBuddy
+    /// dialect notification (`session_end` / `compact-maxtoken`) that the stock
+    /// ACP schema hard-rejects as `-32602`. Consumed by the empty-turn judgment
+    /// within the turn/near-window; never counts as user-visible output and is
+    /// never forwarded to the WebSocket. Mirrors `SegmentBreak`'s "relay consumes
+    /// internally, never forwards" contract.
+    AcpDialectSignal(AcpDialectSignalData),
 }
 
 /// Data for the `Start` event.
@@ -112,6 +119,24 @@ pub enum TipType {
 pub struct FinishEventData {
     #[serde(default)]
     pub session_id: Option<String>,
+}
+
+/// Kind of CodeBuddy ACP dialect signal absorbed by the tolerant transport
+/// layer before the stock ACP schema can hard-reject it as `-32602`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AcpDialectSignalKind {
+    /// Non-standard `session_end` terminal marker (carries `stopReason:"end_turn"`).
+    SessionEnd,
+    /// Emergency auto-compaction / max-token pressure notification
+    /// (`compact-maxtoken` message id or `codebuddy.ai/compactType` meta marker).
+    TokenPressure,
+}
+
+/// Data for the internal-only [`AgentStreamEvent::AcpDialectSignal`] event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcpDialectSignalData {
+    pub kind: AcpDialectSignalKind,
 }
 
 #[cfg(test)]

--- a/crates/aionui-ai-agent/src/protocol/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod acp;
+pub(crate) mod acp_dialect;
 
 pub(crate) mod custom_agent_probe;
 pub(crate) mod error;

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -194,6 +194,7 @@ fn event_type_name(event: &AgentStreamEvent) -> &'static str {
         AgentStreamEvent::SlashCommandsUpdated(_) => "SlashCommandsUpdated",
         AgentStreamEvent::SessionAssigned(_) => "SessionAssigned",
         AgentStreamEvent::SegmentBreak => "SegmentBreak",
+        AgentStreamEvent::AcpDialectSignal(_) => "AcpDialectSignal",
     }
 }
 

--- a/crates/aionui-channel/src/message_service.rs
+++ b/crates/aionui-channel/src/message_service.rs
@@ -232,7 +232,8 @@ impl ChannelMessageService {
             | AgentStreamEvent::RequestTrace(_)
             | AgentStreamEvent::SlashCommandsUpdated(_)
             | AgentStreamEvent::SessionAssigned(_)
-            | AgentStreamEvent::SegmentBreak => None,
+            | AgentStreamEvent::SegmentBreak
+            | AgentStreamEvent::AcpDialectSignal(_) => None,
         }
     }
 

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -304,6 +304,13 @@ impl StreamRelay {
                             self.close_active_text_segment(&mut active_text, &mut text_segments, "finish")
                                 .await;
                         }
+                        AgentStreamEvent::AcpDialectSignal(_) => {
+                            // Internal-only turn/near-window signal (see
+                            // AgentStreamEvent::AcpDialectSignal): consumed by the ACP
+                            // empty-turn judgment, never rendered. Explicitly dropped here so
+                            // the catch-all below does not forward it to the WebSocket, and
+                            // it is never persisted.
+                        }
                         AgentStreamEvent::Thinking(data) => {
                             if data.status.as_deref() == Some("done") {
                                 self.complete_active_thinking(&mut active_thinking).await;
@@ -613,6 +620,7 @@ impl StreamRelay {
             AgentStreamEvent::RequestTrace(_) => "RequestTrace",
             AgentStreamEvent::SessionAssigned(_) => "SessionAssigned",
             AgentStreamEvent::SegmentBreak => "SegmentBreak",
+            AgentStreamEvent::AcpDialectSignal(_) => "AcpDialectSignal",
         }
     }
 
@@ -1023,6 +1031,100 @@ mod tests {
         assert!(
             !outcome.attempt.needs_auth,
             "a plain empty turn must NOT be treated as needs-auth"
+        );
+    }
+
+    // issue 136586749 (F4): the new ACP_EMPTY_TURN_TOKEN_LIMIT tip is a
+    // token/context-class outcome. It must NOT reflect needs-auth (which would
+    // wrongly mark the agent unavailable), yet must still be forwarded + persisted
+    // like any other Info tip. Guards the relay's needs-auth attribution.
+    #[tokio::test]
+    async fn token_limit_tip_does_not_set_needs_auth_and_is_forwarded() {
+        use aionui_ai_agent::protocol::events::{TipType, TipsEventData};
+
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let mut ws_rx = bus.subscribe();
+        let (tx, _) = broadcast::channel(64);
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "turn-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+        );
+        let rx = tx.subscribe();
+
+        tx.send(AgentStreamEvent::Tips(TipsEventData {
+            content: String::new(),
+            tip_type: TipType::Info,
+            code: Some("ACP_EMPTY_TURN_TOKEN_LIMIT".into()),
+            params: None,
+        }))
+        .unwrap();
+        tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
+
+        let outcome = relay.consume(rx).await;
+        assert_eq!(outcome.terminal, RelayTerminal::Finish);
+        assert!(
+            !outcome.attempt.needs_auth,
+            "a token-limit tip must NOT be reflected as needs-auth (contrast ACP_EMPTY_TURN_NEEDS_AUTH)"
+        );
+
+        let inserts = repo.take_inserts();
+        assert!(
+            inserts.iter().any(|m| m.r#type == "tips"),
+            "the token-limit Info tip is persisted"
+        );
+
+        let mut saw_tip = false;
+        while let Ok(evt) = ws_rx.try_recv() {
+            if evt.name == "message.stream" && evt.data["type"] == "tips" {
+                saw_tip |= evt.data["data"]["code"] == "ACP_EMPTY_TURN_TOKEN_LIMIT";
+            }
+        }
+        assert!(saw_tip, "the token-limit tip must be forwarded to the WS");
+    }
+
+    // issue 136586749 (B-3): AcpDialectSignal is an internal-only turn/near-window
+    // signal. Like SegmentBreak it must never reach the WS and must not persist.
+    #[tokio::test]
+    async fn acp_dialect_signal_is_not_forwarded_or_persisted() {
+        use aionui_ai_agent::protocol::events::{AcpDialectSignalData, AcpDialectSignalKind};
+
+        let repo = Arc::new(RecordingRepo::new());
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let mut ws_rx = bus.subscribe();
+        let (tx, _) = broadcast::channel(64);
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "turn-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+        );
+        let rx = tx.subscribe();
+
+        tx.send(AgentStreamEvent::AcpDialectSignal(AcpDialectSignalData {
+            kind: AcpDialectSignalKind::TokenPressure,
+        }))
+        .unwrap();
+        tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
+
+        relay.consume(rx).await;
+
+        let mut saw_dialect_frame = false;
+        while let Ok(evt) = ws_rx.try_recv() {
+            if evt.name == "message.stream" && evt.data["type"] == "acp_dialect_signal" {
+                saw_dialect_frame = true;
+            }
+        }
+        assert!(!saw_dialect_frame, "AcpDialectSignal must never be forwarded to the WS");
+        assert!(
+            repo.take_inserts().is_empty(),
+            "AcpDialectSignal must not be persisted as a message"
         );
     }
 


### PR DESCRIPTION
## Description

Fix for Sentry `136586749` / ELECTRON-3R1.

Empty team-collaboration turns from the CodeBuddy ACP backend were surfaced as "the agent may need you to sign in (Login with iOA)" even when the channel was online and authenticated. CodeBuddy unconditionally advertises `authMethods`, so every empty `end_turn` fell through to the auth-hint fallback regardless of the real cause. Separately, CodeBuddy's non-standard `session_end` / `compact-maxtoken` notifications were hard-rejected as `-32602` and silently dropped, discarding a signal that could have attributed the empty turn correctly.

## Changes

- **Local tolerant pre-parse layer** (`protocol/acp_dialect.rs`, pure function): classifies each raw incoming JSON-RPC line and absorbs CodeBuddy's non-standard `session_end` and `compact-maxtoken` / `emergency-auto` notifications before the vendored `agent-client-protocol` schema hard-rejects them as `-32602`. Every other line — including genuinely malformed input and other unknown variants — is forwarded unchanged so the SDK still surfaces real errors. Wire criteria are grounded in this issue's captured `logs.txt` payloads. No vendored-crate edits.
- **Transport switch to first-party `Lines` interception**: the SDK transport moves from `ByteStreams` to a first-party `Lines` interception point (equivalent newline framing) and raises an internal-only `AcpDialectSignal` when a dialect line is absorbed. The signal never counts as visible output and is never forwarded to the WebSocket; the relay and `message_service` discard it like `SegmentBreak`. Enables the `tokio-util` `codec` feature.
- **Empty-turn judgment convergence**: a dialect signal observed within the turn / near-window now yields the new `ACP_EMPTY_TURN_TOKEN_LIMIT` tip (possibility wording) ahead of the auth hint, demoting `authMethods`-only empty turns to the last-resort `ACP_EMPTY_TURN_NEEDS_AUTH` fallback. The existing stderr terminal-error path is unchanged and the kilo-style `authMethods` fallback is kept (not deleted). The new tip does not set `needs_auth`, so it never reflects the agent as unavailable.

## Tests

Adds unit / contract tests for line classification, the judgment priority (token signal beats auth hint; the reported clean empty turn still falls back to needs-auth), the turn-observation drain, and relay forwarding / `needs_auth` guardrails.

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy -p aionui-ai-agent -p aionui-conversation -- -D warnings` — exit 0
- `cargo test -p aionui-ai-agent -p aionui-conversation` — exit 0 (779 `aionui-ai-agent` lib tests + `aionui-conversation` relay guardrails, 0 failed)

## Reviewer notes

- **Highest-attention point:** the `ByteStreams → Lines` transport switch touches the incoming framing path shared by **all** ACP backends, not just CodeBuddy. Please confirm equivalent framing and no regression for other ACP CLIs (claude / codex / gemini).
- **Over-absorption guard:** only exact-criteria `session_end` / `compact-maxtoken` lines are absorbed; everything else (including truly malformed messages) is forwarded and still surfaces `-32602` as before.
- **Observability:** absorbed dialect lines no longer produce the SDK's `-32602` warn; a local `info`-level structured log records the absorption (kind / session_id / marker only, no sensitive payload).
- CodeBuddy's internal reason for the empty `end_turn` is cross-boundary and intentionally not asserted.
- No database / schema / migration changes.

## Related

- Sentry `136586749` / ELECTRON-3R1 (reported on AionUi 2.1.41, production, module `agent-team`)
- Frontend counterpart PR in iOfficeAI/AionUi provides the localized copy for the softened `ACP_EMPTY_TURN_NEEDS_AUTH` and the new `ACP_EMPTY_TURN_TOKEN_LIMIT` tips.

## Pending manual verification

- Live end-to-end CodeBuddy reproduction: empty `EndTurn` no longer shows the hard "Login with iOA" assertion.
- Dialect absorption in the running app (`session_end` / `compact-maxtoken` no longer `-32602`), and `ACP_EMPTY_TURN_TOKEN_LIMIT` produced when a real token-pressure signal is present.
- kilo-style unauthenticated login-guidance non-regression.
