### PR TITLE
chore(acp): bump registry npx lock to probed versions

### DIFF
--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -749,7 +749,7 @@ mod tests {
         )
         .await
         .expect("resolved release-pinned builtin command spec");
-        assert_eq!(spec.args, vec!["-y", "pi-acp@0.0.31"]);
+        assert_eq!(spec.args, vec!["-y", "pi-acp@0.0.32"]);
     }
 
     #[cfg(unix)]

--- a/crates/aionui-ai-agent/src/services/availability/mod.rs
+++ b/crates/aionui-ai-agent/src/services/availability/mod.rs
@@ -557,7 +557,7 @@ mod tests {
         pi.agent_source_info.binary_name = Some("pi".into());
         pi.agent_source_info.bridge_binary = Some("npx".into());
         pi.args = vec!["-y".into(), "pi-acp".into()];
-        assert_eq!(explicit_probe_args(&pi).unwrap(), ["-y", "pi-acp@0.0.31"]);
+        assert_eq!(explicit_probe_args(&pi).unwrap(), ["-y", "pi-acp@0.0.32"]);
     }
 
     // ---- #675: manual health check runs --version for direct CLIs and is

--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -19,42 +19,42 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.2.31"
+      "version": "0.2.36"
     },
     "dirac": {
       "registry_json_id": "dirac",
       "package": "dirac-cli",
-      "version": "0.4.17"
+      "version": "0.4.27"
     },
     "glm-acp-agent": {
       "registry_json_id": "glm-acp-agent",
       "package": "glm-acp-agent",
-      "version": "1.1.4"
+      "version": "1.3.0"
     },
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "0.2.102"
+      "version": "0.2.112"
     },
     "kilo": {
       "registry_json_id": "kilo",
       "package": "@kilocode/cli",
-      "version": "7.4.11"
+      "version": "7.4.16"
     },
     "nova": {
       "registry_json_id": "nova",
       "package": "@compass-ai/nova",
-      "version": "1.1.27"
+      "version": "1.1.29"
     },
     "pi": {
       "registry_json_id": "pi-acp",
       "package": "pi-acp",
-      "version": "0.0.31"
+      "version": "0.0.32"
     },
     "sigit": {
       "registry_json_id": "sigit",
       "package": "@smbcloud/sigit",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "skip_version_probe": true
     }
   }

--- a/crates/aionui-runtime/src/registry_npx_lock.rs
+++ b/crates/aionui-runtime/src/registry_npx_lock.rs
@@ -105,7 +105,7 @@ mod tests {
     #[test]
     fn pins_direct_npx_package() {
         let args = pin_registry_npx_args("pi", &strings(&["-y", "pi-acp"])).unwrap();
-        assert_eq!(args, ["-y", "pi-acp@0.0.31"]);
+        assert_eq!(args, ["-y", "pi-acp@0.0.32"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Bumps 8 of 11 pinned Registry npx packages in `crates/aionui-runtime/resources/acp-registry-npx-lock.json` to the versions currently published on the ACP Registry. Every bump is backed by a fresh ACP probe of the exact pinned version before the lock change, per the release-lock policy (probe evidence required; versions never stored in `agent_metadata`).

| backend | package | old | new | initialize | session/new |
|---|---|---|---|---|---|
| dimcode | dimcode | 0.2.31 | 0.2.36 | ok (agentInfo 0.2.36) | auth required (-32000, provider credentials) |
| dirac | dirac-cli | 0.4.17 | 0.4.27 | ok (agentInfo 0.4.27) | success (plan/act modes) |
| glm-acp-agent | glm-acp-agent | 1.1.4 | 1.3.0 | ok | success (modes, models, thought_level option) |
| grok | @xai-official/grok | 0.2.102 | 0.2.112 | ok (capabilities + authMethods; adapter omits agentInfo) | auth required (-32000) |
| kilo | @kilocode/cli | 7.4.11 | 7.4.16 | ok (agentInfo 7.4.16) | success (model/effort/mode config options) |
| nova | @compass-ai/nova | 1.1.27 | 1.1.29 | ok (agentInfo kore-cli) | auth required (-32000, terminal-setup authMethods) |
| pi | pi-acp | 0.0.31 | 0.0.32 | ok (agentInfo 0.0.32) | auth required (-32000, terminal-login authMethods) |
| sigit | @smbcloud/sigit | 1.4.1 | 1.5.0 | ok (agentInfo 1.5.0) | success (local-inference model options) |

No drift: autohand 0.2.1, codebuddy 2.106.7, deepagents 0.1.7. Drifted but not upgraded: none of the audited snapshot — all 8 passed probes.

## Registry snapshot

- Audit source: ACP Registry CDN `registry/v1/latest/registry.json`, fetched 2026-07-27 ~12:35 UTC. All 11 pinned package versions match the tagged snapshot [`v2026.07.27-6a4e802`](https://cdn.agentclientprotocol.com/registry/v1/v2026.07.27-6a4e802/registry.json), the newest release of `agentclientprotocol/registry` at audit time.
- CDN tagged paths, CDN `latest`, and GitHub release assets are published from the same build artifact by the registry's `build-registry.yml` (verified: the `registry.json` release asset of `v2026.07.27-888cd13` is SHA-256-identical to both CDN copies).
- Post-audit drift: `dirac-cli` has since moved 0.4.27 -> 0.4.28 (release `v2026.07.27-888cd13`, published 22:56 UTC). Intentionally not bumped here — no probe evidence for 0.4.28 in this PR; the next scheduled sync will pick it up.

## Changes

- Lock file: 8 version bumps (release lock only; no metadata or migration changes).
- `registry_npx_lock.rs`, `factory/acp.rs`, `services/availability/mod.rs`: lock-derived test assertions for the pi pin updated 0.0.31 -> 0.0.32. The `npx_cache_repair.rs` fixtures intentionally keep their literal version inputs — they assert cache-hash derivation from given strings, not lock state.

## Validation

- `cargo test -p aionui-runtime` — pass
- `cargo test -p aionui-ai-agent` — pass (779 unit tests + integration suites)
- Full `just push` gate (migration check, lint, fmt, `cargo nextest run --workspace`) — pass
- Note: the first gate run failed on `aionui-system sysinfo::tests::test_env_override_log_dir` because the dev host app injects `AIONUI_LOG_DIR=~/Library/Logs/AionUi-Dev`, whose case-sensitive path does not contain `aionui`. Verified as a pre-existing environment sensitivity via an A/B single-test run (fails with the injected var, passes without); the gate was re-run with that variable unset. Not addressed in this PR.

## Logging

No logging changes: lock-only version bumps; existing startup/session error paths already identify a failing agent by backend.

## Related

- Overlaps #686 (external PR, pi-acp 0.0.31 -> 0.0.32): the pin bump and the same three lock-derived assertion updates land here. We suggested closing #686 in its comments — its migration 029 (seeding `session_capabilities.delete`) is not needed because `agent_capabilities` is runtime-synced from the live ACP handshake; release-pin updates stay lock-only by design.