### PR TITLE
fix(team): dispatch native slash commands as bare command turns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "aionui-project",
  "aionui-realtime",
  "aionui-runtime",
+ "aionui-session",
  "aionui-shell",
  "aionui-system",
  "aionui-team",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,6 +933,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/aionui-app/Cargo.toml
+++ b/crates/aionui-app/Cargo.toml
@@ -27,6 +27,7 @@ aionui-file.workspace = true
 aionui-office.workspace = true
 aionui-shell.workspace = true
 aionui-ai-agent.workspace = true
+aionui-session.workspace = true
 aionui-mcp.workspace = true
 aionui-conversation.workspace = true
 aionui-extension.workspace = true

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -44,8 +44,9 @@ use aionui_system::{
     VersionCheckService,
 };
 use aionui_team::{
-    AgentTurnCancellationPort, AgentTurnExecutionPort, TeamAssistantCatalogEntry, TeamAssistantCatalogPort,
-    TeamConversationProvisioningPort, TeamProjectionMessageStore, TeamRouterState, TeamSessionService,
+    AgentTurnCancellationPort, AgentTurnExecutionPort, NativeSlashCommandPort, TeamAssistantCatalogEntry,
+    TeamAssistantCatalogPort, TeamConversationProvisioningPort, TeamProjectionMessageStore, TeamRouterState,
+    TeamSessionService,
 };
 
 use crate::config::derive_encryption_key;
@@ -650,11 +651,13 @@ pub fn build_team_state(
     let adapters = Arc::new(TeamConversationAdapters::new(
         conv_service,
         conv_repo,
+        Arc::new(SqliteAgentMetadataRepository::new(services.database.pool().clone())),
         services.worker_task_manager.clone(),
     ));
     let conversation_port: Arc<dyn TeamConversationProvisioningPort> = adapters.clone();
     let projection_store: Arc<dyn TeamProjectionMessageStore> = adapters.clone();
     let turn_port: Arc<dyn AgentTurnExecutionPort> = adapters.clone();
+    let slash_command_port: Arc<dyn NativeSlashCommandPort> = adapters.clone();
     let cancellation_port: Arc<dyn AgentTurnCancellationPort> = adapters;
     let service = TeamSessionService::new_with_prompt_dump(
         team_repo,
@@ -671,6 +674,7 @@ pub fn build_team_state(
         services.worker_task_manager.clone(),
         turn_port,
         cancellation_port,
+        slash_command_port,
         backend_binary_path,
         aionui_team::TeamPromptDumpConfig::from_data_dir(&services.data_dir, services.dump_prompts),
     );

--- a/crates/aionui-app/src/router/team_conversation_adapters.rs
+++ b/crates/aionui-app/src/router/team_conversation_adapters.rs
@@ -15,7 +15,7 @@ use aionui_team::{
     TeamConversationLookupPort, TeamConversationProvisioningPort, TeamError, TeamProjectionMessageStore,
 };
 use async_trait::async_trait;
-use tracing::info;
+use tracing::{debug, info, warn};
 
 /// Vendor label of the codex builtin backend (its `agent_metadata.backend`), used
 /// to decide when the static codex command catalog is the right fallback source.
@@ -160,6 +160,11 @@ impl NativeSlashCommandPort for TeamConversationAdapters {
         };
         let name = name.to_owned();
         match self.resolve_slash_catalog(conversation_id).await {
+            // A resolved-but-EMPTY catalog is an anomaly (e.g. a live backend
+            // returned no commands): it silently disables every team command, so
+            // surface it distinctly from a populated catalog that merely lacks
+            // this name (NotInCatalog). The team layer logs it at `warn`.
+            Some((catalog, _)) if catalog.is_empty() => SlashCommandRecognition::CatalogEmpty { name },
             Some((catalog, source)) => {
                 if catalog.iter().any(|command| command == &name) {
                     SlashCommandRecognition::Recognized { command: name, source }
@@ -180,23 +185,45 @@ impl TeamConversationAdapters {
     async fn resolve_slash_catalog(&self, conversation_id: &str) -> Option<(Vec<String>, SlashCatalogSource)> {
         // (a) live: a running backend session's current capabilities are the
         // freshest, authoritative source (even if the list happens to be empty).
-        if let Some(task) = self.task_manager.get_task(conversation_id)
-            && let Ok(items) = task.get_slash_commands().await
-        {
-            let names = items.into_iter().map(|item| item.command).collect();
-            return Some((names, SlashCatalogSource::Live));
+        if let Some(task) = self.task_manager.get_task(conversation_id) {
+            match task.get_slash_commands().await {
+                Ok(items) => {
+                    let names = items.into_iter().map(|item| item.command).collect();
+                    return Some((names, SlashCatalogSource::Live));
+                }
+                // A live fetch fault is caught only here (composition layer); the
+                // raw error exists nowhere else, so log it at `warn` before
+                // falling through to cached/static. Only `conversation_id` is
+                // available at this seam (no team_id/slot_id).
+                Err(error) => warn!(
+                    conversation_id = %conversation_id,
+                    %error,
+                    reason = "live_catalog_fetch_failed",
+                    "live slash-command catalog fetch failed; falling through to cached/static"
+                ),
+            }
         }
 
         // (b)/(c) require the conversation's agent_metadata row.
         let row = self.resolve_agent_metadata(conversation_id).await;
 
-        // (b) cached: a non-empty persisted discovery snapshot.
+        // (b) cached: a persisted discovery snapshot.
         if let Some(row) = &row
             && let Some(raw) = row.available_commands.as_deref()
         {
-            let names = parse_available_command_names(raw);
-            if !names.is_empty() {
-                return Some((names, SlashCatalogSource::Cached));
+            match parse_available_command_names(raw) {
+                // Non-empty snapshot → use it.
+                Some(names) if !names.is_empty() => return Some((names, SlashCatalogSource::Cached)),
+                // Genuinely empty snapshot (`[]`) → fall through quietly; an empty
+                // array is a legitimate "discovered, no commands" state, not a fault.
+                Some(_) => {}
+                // Malformed / unexpected-shape snapshot → safely handled bad data;
+                // log at `warn` (§14) before falling through.
+                None => warn!(
+                    conversation_id = %conversation_id,
+                    reason = "available_commands_malformed",
+                    "persisted available_commands snapshot is malformed; falling through to static/none"
+                ),
             }
         }
 
@@ -221,16 +248,44 @@ impl TeamConversationAdapters {
     /// assistant snapshot's `agent_id`, then `extra.agent_id`, then the builtin
     /// row for `extra.backend`. Any failure yields `None` (→ catalog unavailable).
     async fn resolve_agent_metadata(&self, conversation_id: &str) -> Option<AgentMetadataRow> {
-        if let Ok(Some(snapshot)) = self.conversation_repo.get_assistant_snapshot(conversation_id).await {
-            let agent_id = snapshot.agent_id.trim();
-            if !agent_id.is_empty()
-                && let Ok(Some(row)) = self.agent_metadata_repo.get(agent_id).await
-            {
-                return Some(row);
+        // A genuine repo `Err` (not `Ok(None)` — "not found" is the normal case
+        // for many conversations and must stay silent) is logged at `debug`: it is
+        // a development-detail fault on a best-effort path, not a production signal.
+        match self.conversation_repo.get_assistant_snapshot(conversation_id).await {
+            Ok(Some(snapshot)) => {
+                let agent_id = snapshot.agent_id.trim();
+                if !agent_id.is_empty() {
+                    match self.agent_metadata_repo.get(agent_id).await {
+                        Ok(Some(row)) => return Some(row),
+                        Ok(None) => {}
+                        Err(error) => debug!(
+                            conversation_id = %conversation_id, %error,
+                            reason = "agent_metadata_lookup_failed",
+                            "agent_metadata lookup by assistant agent_id failed"
+                        ),
+                    }
+                }
             }
+            Ok(None) => {}
+            Err(error) => debug!(
+                conversation_id = %conversation_id, %error,
+                reason = "assistant_snapshot_lookup_failed",
+                "assistant snapshot lookup failed while resolving agent_metadata"
+            ),
         }
 
-        let row = self.conversation_repo.get(conversation_id).await.ok().flatten()?;
+        let row = match self.conversation_repo.get(conversation_id).await {
+            Ok(Some(row)) => row,
+            Ok(None) => return None,
+            Err(error) => {
+                debug!(
+                    conversation_id = %conversation_id, %error,
+                    reason = "conversation_lookup_failed",
+                    "conversation lookup failed while resolving agent_metadata"
+                );
+                return None;
+            }
+        };
         let extra: serde_json::Value = serde_json::from_str(&row.extra).unwrap_or(serde_json::Value::Null);
 
         if let Some(agent_id) = extra
@@ -238,9 +293,16 @@ impl TeamConversationAdapters {
             .and_then(serde_json::Value::as_str)
             .map(str::trim)
             .filter(|value| !value.is_empty())
-            && let Ok(Some(row)) = self.agent_metadata_repo.get(agent_id).await
         {
-            return Some(row);
+            match self.agent_metadata_repo.get(agent_id).await {
+                Ok(Some(row)) => return Some(row),
+                Ok(None) => {}
+                Err(error) => debug!(
+                    conversation_id = %conversation_id, %error,
+                    reason = "agent_metadata_lookup_failed",
+                    "agent_metadata lookup by extra.agent_id failed"
+                ),
+            }
         }
 
         if let Some(backend) = extra
@@ -248,9 +310,16 @@ impl TeamConversationAdapters {
             .and_then(serde_json::Value::as_str)
             .map(str::trim)
             .filter(|value| !value.is_empty())
-            && let Ok(Some(row)) = self.agent_metadata_repo.find_builtin_by_backend(backend).await
         {
-            return Some(row);
+            match self.agent_metadata_repo.find_builtin_by_backend(backend).await {
+                Ok(Some(row)) => return Some(row),
+                Ok(None) => {}
+                Err(error) => debug!(
+                    conversation_id = %conversation_id, %error,
+                    reason = "agent_metadata_builtin_lookup_failed",
+                    "builtin agent_metadata lookup by backend failed"
+                ),
+            }
         }
 
         None
@@ -258,19 +327,22 @@ impl TeamConversationAdapters {
 }
 
 /// Extract the command NAMEs from a persisted `available_commands` snapshot
-/// (a JSON array of `{ "name", "description" }` objects). Malformed JSON yields
-/// an empty list so the caller falls through to the next catalog source.
-fn parse_available_command_names(raw: &str) -> Vec<String> {
-    serde_json::from_str::<serde_json::Value>(raw)
-        .ok()
-        .and_then(|value| value.as_array().cloned())
-        .map(|entries| {
-            entries
-                .iter()
-                .filter_map(|entry| entry.get("name").and_then(serde_json::Value::as_str).map(str::to_owned))
-                .collect()
-        })
-        .unwrap_or_default()
+/// (a JSON array of `{ "name", "description" }` objects).
+///
+/// - `Some(names)` — the snapshot parsed as a JSON array (`names` may be empty
+///   for `[]`, a legitimate "discovered, no commands" state).
+/// - `None` — the snapshot is not valid JSON, or is valid JSON of an unexpected
+///   shape (not an array). The caller treats this as malformed data, logs a
+///   `warn`, and falls through to the next catalog source.
+fn parse_available_command_names(raw: &str) -> Option<Vec<String>> {
+    let value = serde_json::from_str::<serde_json::Value>(raw).ok()?;
+    let entries = value.as_array()?;
+    Some(
+        entries
+            .iter()
+            .filter_map(|entry| entry.get("name").and_then(serde_json::Value::as_str).map(str::to_owned))
+            .collect(),
+    )
 }
 
 #[async_trait]
@@ -501,12 +573,17 @@ mod tests {
         // The persisted snapshot shape written by the registry:
         // a JSON array of `{ "name", "description" }` objects.
         let raw = r#"[{"name":"compact","description":"summarize"},{"name":"init","description":"agents.md"}]"#;
-        assert_eq!(parse_available_command_names(raw), vec!["compact", "init"]);
-        // Empty array → no names.
-        assert!(parse_available_command_names("[]").is_empty());
-        // Malformed JSON → empty (caller falls through to the next catalog source).
-        assert!(parse_available_command_names("not json").is_empty());
-        assert!(parse_available_command_names("{}").is_empty());
+        assert_eq!(
+            parse_available_command_names(raw),
+            Some(vec!["compact".to_owned(), "init".to_owned()])
+        );
+        // Empty array → parsed, empty list (a legitimate "no commands" snapshot;
+        // caller falls through QUIETLY, no warn).
+        assert_eq!(parse_available_command_names("[]"), Some(Vec::<String>::new()));
+        // Malformed JSON, or valid JSON of an unexpected (non-array) shape → `None`
+        // (caller logs a `warn` and falls through to the next catalog source).
+        assert_eq!(parse_available_command_names("not json"), None);
+        assert_eq!(parse_available_command_names("{}"), None);
     }
 
     #[test]

--- a/crates/aionui-app/src/router/team_conversation_adapters.rs
+++ b/crates/aionui-app/src/router/team_conversation_adapters.rs
@@ -6,20 +6,25 @@ use aionui_conversation::{
     ConversationAgentTurnRequest, ConversationAgentTurnStarted, ConversationAgentTurnStatus, ConversationError,
     ConversationService,
 };
-use aionui_db::IConversationRepository;
-use aionui_db::models::MessageRow;
+use aionui_db::models::{AgentMetadataRow, MessageRow};
+use aionui_db::{IAgentMetadataRepository, IConversationRepository};
 use aionui_team::{
     AgentTurnCancellationPort, AgentTurnExecutionError, AgentTurnExecutionPort, AgentTurnOutcome, AgentTurnRequest,
-    AgentTurnStarted, AgentTurnStatus, TeamConversationBindingLookup, TeamConversationCreateRequest,
-    TeamConversationCreateResult, TeamConversationLookupPort, TeamConversationProvisioningPort, TeamError,
-    TeamProjectionMessageStore,
+    AgentTurnStarted, AgentTurnStatus, NativeSlashCommandPort, SlashCatalogSource, SlashCommandRecognition,
+    TeamConversationBindingLookup, TeamConversationCreateRequest, TeamConversationCreateResult,
+    TeamConversationLookupPort, TeamConversationProvisioningPort, TeamError, TeamProjectionMessageStore,
 };
 use async_trait::async_trait;
 use tracing::info;
 
+/// Vendor label of the codex builtin backend (its `agent_metadata.backend`), used
+/// to decide when the static codex command catalog is the right fallback source.
+const CODEX_BACKEND: &str = "codex";
+
 pub struct TeamConversationAdapters {
     conversation_service: ConversationService,
     conversation_repo: Arc<dyn IConversationRepository>,
+    agent_metadata_repo: Arc<dyn IAgentMetadataRepository>,
     task_manager: Arc<dyn IWorkerTaskManager>,
 }
 
@@ -27,11 +32,13 @@ impl TeamConversationAdapters {
     pub fn new(
         conversation_service: ConversationService,
         conversation_repo: Arc<dyn IConversationRepository>,
+        agent_metadata_repo: Arc<dyn IAgentMetadataRepository>,
         task_manager: Arc<dyn IWorkerTaskManager>,
     ) -> Self {
         Self {
             conversation_service,
             conversation_repo,
+            agent_metadata_repo,
             task_manager,
         }
     }
@@ -136,6 +143,134 @@ impl AgentTurnCancellationPort for TeamConversationAdapters {
             .map(|_| ())
             .map_err(map_conversation_turn_error)
     }
+}
+
+#[async_trait]
+impl NativeSlashCommandPort for TeamConversationAdapters {
+    /// ELECTRON-3RN recognition predicate. Splits the leading command name with
+    /// the SHARED grammar owner (`aionui_session::slash_command_name`, same
+    /// function codex's `route_slash_command` uses) then tests membership against
+    /// the backend's self-advertised catalog via a live→cached→static degradation
+    /// chain. Never asserts anything about an external CLI's behaviour; a name the
+    /// backend does not advertise (or an unresolvable catalog) falls back to the
+    /// ordinary wrapped wake (zero regression).
+    async fn recognize(&self, conversation_id: &str, content: &str) -> SlashCommandRecognition {
+        let Some(name) = aionui_session::slash_command_name(content) else {
+            return SlashCommandRecognition::NotCommand;
+        };
+        let name = name.to_owned();
+        match self.resolve_slash_catalog(conversation_id).await {
+            Some((catalog, source)) => {
+                if catalog.iter().any(|command| command == &name) {
+                    SlashCommandRecognition::Recognized { command: name, source }
+                } else {
+                    SlashCommandRecognition::NotInCatalog { name }
+                }
+            }
+            None => SlashCommandRecognition::CatalogUnavailable { name },
+        }
+    }
+}
+
+impl TeamConversationAdapters {
+    /// Resolve the native slash-command NAME catalog for a conversation via the
+    /// degradation chain (spec §8-1): (a) live backend session capabilities,
+    /// (b) the persisted `agent_metadata.available_commands` snapshot, (c) the
+    /// static codex builtin catalog. Returns `None` when none resolve (chain (d)).
+    async fn resolve_slash_catalog(&self, conversation_id: &str) -> Option<(Vec<String>, SlashCatalogSource)> {
+        // (a) live: a running backend session's current capabilities are the
+        // freshest, authoritative source (even if the list happens to be empty).
+        if let Some(task) = self.task_manager.get_task(conversation_id)
+            && let Ok(items) = task.get_slash_commands().await
+        {
+            let names = items.into_iter().map(|item| item.command).collect();
+            return Some((names, SlashCatalogSource::Live));
+        }
+
+        // (b)/(c) require the conversation's agent_metadata row.
+        let row = self.resolve_agent_metadata(conversation_id).await;
+
+        // (b) cached: a non-empty persisted discovery snapshot.
+        if let Some(row) = &row
+            && let Some(raw) = row.available_commands.as_deref()
+        {
+            let names = parse_available_command_names(raw);
+            if !names.is_empty() {
+                return Some((names, SlashCatalogSource::Cached));
+            }
+        }
+
+        // (c) static: codex has a builtin catalog even before any discovery.
+        if let Some(row) = &row
+            && row.backend.as_deref() == Some(CODEX_BACKEND)
+        {
+            let names = aionui_session::codex_capabilities()
+                .slash_commands
+                .into_iter()
+                .map(|command| command.name)
+                .collect();
+            return Some((names, SlashCatalogSource::Static));
+        }
+
+        // (d) nothing resolvable → caller falls back to the wrapped wake.
+        None
+    }
+
+    /// Best-effort resolution of a conversation's `agent_metadata` row, reusing
+    /// the same identity sources the conversation layer uses: the persisted
+    /// assistant snapshot's `agent_id`, then `extra.agent_id`, then the builtin
+    /// row for `extra.backend`. Any failure yields `None` (→ catalog unavailable).
+    async fn resolve_agent_metadata(&self, conversation_id: &str) -> Option<AgentMetadataRow> {
+        if let Ok(Some(snapshot)) = self.conversation_repo.get_assistant_snapshot(conversation_id).await {
+            let agent_id = snapshot.agent_id.trim();
+            if !agent_id.is_empty()
+                && let Ok(Some(row)) = self.agent_metadata_repo.get(agent_id).await
+            {
+                return Some(row);
+            }
+        }
+
+        let row = self.conversation_repo.get(conversation_id).await.ok().flatten()?;
+        let extra: serde_json::Value = serde_json::from_str(&row.extra).unwrap_or(serde_json::Value::Null);
+
+        if let Some(agent_id) = extra
+            .get("agent_id")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            && let Ok(Some(row)) = self.agent_metadata_repo.get(agent_id).await
+        {
+            return Some(row);
+        }
+
+        if let Some(backend) = extra
+            .get("backend")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            && let Ok(Some(row)) = self.agent_metadata_repo.find_builtin_by_backend(backend).await
+        {
+            return Some(row);
+        }
+
+        None
+    }
+}
+
+/// Extract the command NAMEs from a persisted `available_commands` snapshot
+/// (a JSON array of `{ "name", "description" }` objects). Malformed JSON yields
+/// an empty list so the caller falls through to the next catalog source.
+fn parse_available_command_names(raw: &str) -> Vec<String> {
+    serde_json::from_str::<serde_json::Value>(raw)
+        .ok()
+        .and_then(|value| value.as_array().cloned())
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|entry| entry.get("name").and_then(serde_json::Value::as_str).map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 #[async_trait]
@@ -360,6 +495,19 @@ fn map_conversation_turn_error(error: ConversationError) -> AgentTurnExecutionEr
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_available_command_names_extracts_names() {
+        // The persisted snapshot shape written by the registry:
+        // a JSON array of `{ "name", "description" }` objects.
+        let raw = r#"[{"name":"compact","description":"summarize"},{"name":"init","description":"agents.md"}]"#;
+        assert_eq!(parse_available_command_names(raw), vec!["compact", "init"]);
+        // Empty array → no names.
+        assert!(parse_available_command_names("[]").is_empty());
+        // Malformed JSON → empty (caller falls through to the next catalog source).
+        assert!(parse_available_command_names("not json").is_empty());
+        assert!(parse_available_command_names("{}").is_empty());
+    }
 
     #[test]
     fn active_agent_missing_maps_to_team_runtime_not_ready() {

--- a/crates/aionui-session/src/backend/codex_conn.rs
+++ b/crates/aionui-session/src/backend/codex_conn.rs
@@ -3666,16 +3666,13 @@ enum SlashRoute {
     Logout,
 }
 
-/// Parse a leading slash command from the first Text block. Faithful port of the
-/// bridge's `extract_slash_command` (thread.rs:4195): the text must START with
-/// `/`, the name runs to the first whitespace, `rest` is the trimmed remainder.
-/// An unknown name (or `/review-branch`//`/review-commit` with no argument, per
-/// the bridge's `if !rest.is_empty()` guards) returns `None` → the text goes to
-/// codex verbatim as a plain turn, exactly like the bridge's `_ =>` arm.
-fn route_slash_command(content: &[ContentBlock]) -> Option<SlashRoute> {
-    let Some(ContentBlock::Text(text)) = content.first() else {
-        return None;
-    };
+/// Parse a leading slash command NAME from raw text. Sole grammar owner, shared
+/// by codex's `route_slash_command` and the team recognition predicate so the two
+/// never drift. Rules (byte-identical to the historical inline logic in
+/// `route_slash_command`): the text must START with `/` (no leading whitespace
+/// tolerated), the name runs to the first Unicode whitespace, and must be
+/// non-empty. Returns the name without the leading `/`.
+pub fn slash_command_name(text: &str) -> Option<&str> {
     let stripped = text.strip_prefix('/')?;
     let name_end = stripped
         .char_indices()
@@ -3686,7 +3683,26 @@ fn route_slash_command(content: &[ContentBlock]) -> Option<SlashRoute> {
     if name.is_empty() {
         return None;
     }
-    let rest = stripped[name_end..].trim_start();
+    Some(name)
+}
+
+/// Parse a leading slash command from the first Text block. Faithful port of the
+/// bridge's `extract_slash_command` (thread.rs:4195): the text must START with
+/// `/`, the name runs to the first whitespace, `rest` is the trimmed remainder.
+/// An unknown name (or `/review-branch`//`/review-commit` with no argument, per
+/// the bridge's `if !rest.is_empty()` guards) returns `None` → the text goes to
+/// codex verbatim as a plain turn, exactly like the bridge's `_ =>` arm.
+///
+/// The NAME segment is parsed by the shared [`slash_command_name`] so this table
+/// and the team recognition predicate always agree on the grammar.
+fn route_slash_command(content: &[ContentBlock]) -> Option<SlashRoute> {
+    let Some(ContentBlock::Text(text)) = content.first() else {
+        return None;
+    };
+    let name = slash_command_name(text)?;
+    // `rest` is everything after the name (name_end is the byte length of the
+    // name because the name never contains a multi-byte prefix split), trimmed.
+    let rest = text[1 + name.len()..].trim_start();
     match name {
         "compact" => Some(SlashRoute::Compact),
         "init" => Some(SlashRoute::Init),
@@ -5149,6 +5165,69 @@ mod tests {
         assert_eq!(route_slash_command(&text("hello")), None);
         assert_eq!(route_slash_command(&text("/")), None);
         assert_eq!(route_slash_command(&[]), None);
+    }
+
+    /// The shared name parser owns the slash grammar. Assert it matches the
+    /// exact rules `route_slash_command` used inline before the extraction:
+    /// must start with `/` (no leading whitespace), name runs to the first
+    /// Unicode whitespace, must be non-empty, and the `/` is stripped.
+    #[test]
+    fn slash_command_name_parses_leading_name() {
+        assert_eq!(slash_command_name("/compact"), Some("compact"));
+        assert_eq!(slash_command_name("/review focus on X"), Some("review"));
+        assert_eq!(slash_command_name("/review-branch main"), Some("review-branch"));
+        // Trailing content after the first whitespace is ignored; a newline also
+        // terminates the name (Unicode whitespace).
+        assert_eq!(slash_command_name("/init\nmore"), Some("init"));
+        // Not a command: no leading slash, leading whitespace, or empty name.
+        assert_eq!(slash_command_name("hello"), None);
+        assert_eq!(slash_command_name(" /compact"), None);
+        assert_eq!(slash_command_name("/"), None);
+        assert_eq!(slash_command_name("/ compact"), None);
+    }
+
+    /// AC10 (ELECTRON-3RN): the two independently hard-coded codex command-name
+    /// sets — `builtin_slash_commands()` (the advertised catalog / recognition
+    /// source) and `route_slash_command()`'s match arms (the real translation to
+    /// native ops) — MUST stay in lock-step. If either table gains or loses a
+    /// command without the other following, this fails immediately.
+    #[test]
+    fn builtin_slash_commands_match_route_table() {
+        use std::collections::BTreeSet;
+
+        // Names the advertised catalog claims codex supports.
+        let advertised: BTreeSet<String> = builtin_slash_commands().into_iter().map(|c| c.name).collect();
+
+        // Every advertised name must actually route to a native op. `review-branch`
+        // / `review-commit` need a non-empty argument to satisfy their guards, so
+        // probe with an argument; a bare name would false-negative on those two.
+        for name in &advertised {
+            let probe = format!("/{name} arg");
+            assert!(
+                route_slash_command(&[ContentBlock::Text(probe.clone())]).is_some(),
+                "advertised command `{name}` does not route to a native op"
+            );
+        }
+
+        // And the reverse: no name routes that the catalog fails to advertise.
+        // Enumerate the full universe the route table recognizes today; if a new
+        // arm is added to `route_slash_command`, add it here AND to the catalog.
+        let route_universe = ["review", "review-branch", "review-commit", "init", "compact", "logout"];
+        for name in route_universe {
+            assert!(
+                route_slash_command(&[ContentBlock::Text(format!("/{name} arg"))]).is_some(),
+                "route universe entry `{name}` unexpectedly does not route"
+            );
+            assert!(
+                advertised.contains(name),
+                "route table recognizes `{name}` but the advertised catalog omits it"
+            );
+        }
+        let route_universe_set: BTreeSet<String> = route_universe.iter().map(|s| s.to_string()).collect();
+        assert_eq!(
+            advertised, route_universe_set,
+            "advertised catalog and route table command-name sets diverged"
+        );
     }
 
     /// #101/ELECTRON-3PX: codex advertises the bridge's static 6-command table

--- a/crates/aionui-session/src/backend/mod.rs
+++ b/crates/aionui-session/src/backend/mod.rs
@@ -19,7 +19,7 @@ mod types;
 
 pub use acp_conn::{AcpConnection, AcpSessionBackend, acp_capabilities};
 pub use claude_conn::{ClaudeConnection, ClaudeSessionBackend};
-pub use codex_conn::{CodexConnection, CodexSessionBackend, codex_capabilities};
+pub use codex_conn::{CodexConnection, CodexSessionBackend, codex_capabilities, slash_command_name};
 pub use conversation_session::{ConversationSession, MsgStatus, PendingMessage};
 pub use orchestrator::Orchestrator;
 pub use rehydrate::rehydrate;

--- a/crates/aionui-session/src/lib.rs
+++ b/crates/aionui-session/src/lib.rs
@@ -58,7 +58,7 @@ pub use backend::{
     ConversationSession, McpServerSpec, McpTransport, MsgStatus, Orchestrator, PendingMessage, PendingPermissionView,
     PermissionDecision, QuestionAnswer, SessionBackend, SessionConfig, SessionEnvelope, SessionInfoKind, SessionInit,
     SessionSpec, StateSnapshot, Tier2Checkpoint, TransitionReason, acp_capabilities, codex_capabilities, command_name,
-    rehydrate,
+    rehydrate, slash_command_name,
 };
 pub use capability::{
     BlockSet, Capabilities, CapabilityTier, CommandSet, ModeInfo, ModelInfo, PromptAcceptedSource, SignalSet,

--- a/crates/aionui-team/Cargo.toml
+++ b/crates/aionui-team/Cargo.toml
@@ -30,6 +30,9 @@ tokio = { workspace = true, features = ["test-util"] }
 futures-util.workspace = true
 reqwest.workspace = true
 tempfile.workspace = true
+# Capture structured tracing fields so the AC11 recognition-log test can assert
+# the info log carries the command NAME/source but never the raw content/args.
+tracing-subscriber.workspace = true
 # Enable the `AgentInstance::Mock` variant so tests can build fake agents
 # through the trait-object escape hatch without spawning real CLI processes.
 aionui-ai-agent = { workspace = true, features = ["test-support"] }

--- a/crates/aionui-team/src/lib.rs
+++ b/crates/aionui-team/src/lib.rs
@@ -41,7 +41,8 @@ pub use message_projection::{
 };
 pub use ports::{
     AgentTurnCancellationPort, AgentTurnExecutionError, AgentTurnExecutionPort, AgentTurnOutcome, AgentTurnRequest,
-    AgentTurnSource, AgentTurnStarted, AgentTurnStartedCallback, AgentTurnStatus, TeamAssistantCatalogEntry,
+    AgentTurnSource, AgentTurnStarted, AgentTurnStartedCallback, AgentTurnStatus, NativeSlashCommandPort,
+    NoopNativeSlashCommandPort, SlashCatalogSource, SlashCommandRecognition, TeamAssistantCatalogEntry,
     TeamAssistantCatalogPort, TeamConversationBindingLookup, TeamConversationLookupPort,
 };
 

--- a/crates/aionui-team/src/ports.rs
+++ b/crates/aionui-team/src/ports.rs
@@ -25,6 +25,76 @@ pub trait TeamConversationLookupPort: Send + Sync {
     ) -> Result<Option<TeamConversationBindingLookup>, TeamError>;
 }
 
+/// Which tier of the recognition degradation chain produced a slash catalog.
+/// All three point at the same `capabilities().slash_commands` source; they
+/// differ only in freshness/liveness (see the fix spec §8-1 degradation chain).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlashCatalogSource {
+    /// Read from a live backend session's current capabilities.
+    Live,
+    /// Read from the persisted `agent_metadata.available_commands` snapshot.
+    Cached,
+    /// Read from a static backend catalog (e.g. codex builtin commands).
+    Static,
+}
+
+impl SlashCatalogSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Live => "live",
+            Self::Cached => "cached",
+            Self::Static => "static",
+        }
+    }
+}
+
+/// Result of asking whether a user message is a native backend slash command.
+///
+/// Carries the source tag (not a bare `bool`) so the team layer can emit the
+/// structured recognition log required by the fix spec (§14/AC11) while staying
+/// backend-agnostic — it only consumes this enum, never a concrete backend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlashCommandRecognition {
+    /// `content` is a single command this member's backend advertises. `command`
+    /// is the name without the leading `/`.
+    Recognized {
+        command: String,
+        source: SlashCatalogSource,
+    },
+    /// Leading `/` with a non-empty name, but the name is not in the advertised
+    /// catalog → ordinary body text (§14 debug: `not_in_catalog`).
+    NotInCatalog { name: String },
+    /// Leading `/` with a non-empty name, but the catalog could not be resolved
+    /// (degradation chain exhausted) → fall back to the wrapped wake turn
+    /// (§14 warn: `catalog_unavailable`).
+    CatalogUnavailable { name: String },
+    /// First character is not `/` (leading whitespace included) or the name is
+    /// empty → not a command at all.
+    NotCommand,
+}
+
+/// Recognizes whether a raw user message is a native backend slash command for a
+/// given conversation. Backend-agnostic contract owned by the team layer; the
+/// composition layer supplies an implementation that consults the backend's
+/// self-advertised command catalog (live → cached → static degradation chain).
+#[async_trait]
+pub trait NativeSlashCommandPort: Send + Sync {
+    async fn recognize(&self, conversation_id: &str, content: &str) -> SlashCommandRecognition;
+}
+
+/// No-op recognizer: every message is `NotCommand`, so team behaviour is
+/// byte-identical to the pre-fix wrapped-wake path. Used as the default when no
+/// composition-layer recognizer is wired (e.g. unit tests that don't exercise
+/// command recognition).
+pub struct NoopNativeSlashCommandPort;
+
+#[async_trait]
+impl NativeSlashCommandPort for NoopNativeSlashCommandPort {
+    async fn recognize(&self, _conversation_id: &str, _content: &str) -> SlashCommandRecognition {
+        SlashCommandRecognition::NotCommand
+    }
+}
+
 #[async_trait]
 pub trait TeamAssistantCatalogPort: Send + Sync {
     async fn list_team_selectable_assistants(&self) -> Result<Vec<TeamAssistantCatalogEntry>, TeamError>;

--- a/crates/aionui-team/src/ports.rs
+++ b/crates/aionui-team/src/ports.rs
@@ -64,6 +64,13 @@ pub enum SlashCommandRecognition {
     /// Leading `/` with a non-empty name, but the name is not in the advertised
     /// catalog → ordinary body text (§14 debug: `not_in_catalog`).
     NotInCatalog { name: String },
+    /// Leading `/` with a non-empty name, but the catalog RESOLVED to an EMPTY
+    /// list (e.g. a live backend returned no commands). Distinct from
+    /// `NotInCatalog` (a populated catalog that simply lacks this name): an empty
+    /// catalog is an anomaly that silently disables every team command, so it is
+    /// surfaced separately and logged at `warn` (§14 warn: `catalog_empty`).
+    /// Still falls back to the wrapped wake turn (zero regression).
+    CatalogEmpty { name: String },
     /// Leading `/` with a non-empty name, but the catalog could not be resolved
     /// (degradation chain exhausted) → fall back to the wrapped wake turn
     /// (§14 warn: `catalog_unavailable`).

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -33,7 +33,10 @@ use crate::member_runtime::{
     AttachLease, AttachOutcome, AttachWaiter, BeginRemove, MemberRuntimeFailure, MemberRuntimeSnapshot, ReserveAttach,
 };
 use crate::message_projection::TeamProjectionMessageStore;
-use crate::ports::{AgentTurnCancellationPort, AgentTurnExecutionPort, TeamAssistantCatalogPort};
+use crate::ports::{
+    AgentTurnCancellationPort, AgentTurnExecutionPort, NativeSlashCommandPort, NoopNativeSlashCommandPort,
+    TeamAssistantCatalogPort,
+};
 use crate::prompt_dump::TeamPromptDumpConfig;
 use crate::provisioning::{TeamAgentProvisioner, TeamConversationProvisioningPort};
 use crate::runtime_tools::{
@@ -99,6 +102,9 @@ pub struct TeamSessionService {
     task_manager: Arc<dyn IWorkerTaskManager>,
     turn_port: Arc<dyn AgentTurnExecutionPort>,
     cancellation_port: Arc<dyn AgentTurnCancellationPort>,
+    /// Native slash-command recognizer injected into each `TeamSession`
+    /// (ELECTRON-3RN). No-op by default (see `NoopNativeSlashCommandPort`).
+    slash_command_port: Arc<dyn NativeSlashCommandPort>,
     backend_binary_path: Arc<PathBuf>,
     prompt_dump: TeamPromptDumpConfig,
     sessions: Arc<DashMap<String, SessionEntry>>,
@@ -150,6 +156,7 @@ impl TeamSessionService {
             task_manager,
             turn_port,
             cancellation_port,
+            Arc::new(NoopNativeSlashCommandPort),
             backend_binary_path,
             TeamPromptDumpConfig::disabled(),
         )
@@ -169,6 +176,7 @@ impl TeamSessionService {
         task_manager: Arc<dyn IWorkerTaskManager>,
         turn_port: Arc<dyn AgentTurnExecutionPort>,
         cancellation_port: Arc<dyn AgentTurnCancellationPort>,
+        slash_command_port: Arc<dyn NativeSlashCommandPort>,
         backend_binary_path: Arc<PathBuf>,
         prompt_dump: TeamPromptDumpConfig,
     ) -> Arc<Self> {
@@ -185,6 +193,7 @@ impl TeamSessionService {
             task_manager,
             turn_port,
             cancellation_port,
+            slash_command_port,
             backend_binary_path,
             prompt_dump,
             sessions: Arc::new(DashMap::new()),
@@ -906,7 +915,7 @@ impl TeamSessionService {
         )
         .await
         {
-            Ok(session) => Arc::new(session),
+            Ok(session) => Arc::new(session.with_slash_command_port(self.slash_command_port.clone())),
             Err(e) => {
                 self.broadcast_session_status(
                     team_id,

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -25,7 +25,10 @@ use crate::member_runtime::{
 use crate::message_projection::{
     TeamMessageProjection, TeamProjectionMessageStore, TeamProjectionRequest, TeamProjectionSource, teammate_dedupe_key,
 };
-use crate::ports::{AgentTurnCancellationPort, AgentTurnExecutionPort};
+use crate::ports::{
+    AgentTurnCancellationPort, AgentTurnExecutionPort, NativeSlashCommandPort, NoopNativeSlashCommandPort,
+    SlashCommandRecognition,
+};
 use crate::prompt_dump::{TeamPromptDumpConfig, TeamWakePromptDump, dump_team_wake_prompt};
 use crate::prompts::{build_lead_prompt_for_transport, build_teammate_prompt_for_transport, build_wake_payload};
 use crate::provisioning::PersistSpawnedAgentRequest;
@@ -90,6 +93,11 @@ pub struct TeamSession {
     turn_port: Arc<dyn AgentTurnExecutionPort>,
     cancellation_port: Arc<dyn AgentTurnCancellationPort>,
     projection_store: Arc<dyn TeamProjectionMessageStore>,
+    /// Recognizes whether a user message is a native backend slash command
+    /// (ELECTRON-3RN). Defaults to a no-op recognizer (every message is ordinary
+    /// text) unless the composition layer injects a real one via
+    /// [`TeamSession::with_slash_command_port`].
+    slash_command_port: Arc<dyn NativeSlashCommandPort>,
     team_run_manager: Arc<TeamRunManager>,
     work_coordinator: Arc<SlotWorkCoordinator>,
     /// Owner user_id for this team — needed when spawn_agent creates a
@@ -217,6 +225,7 @@ impl TeamSession {
             turn_port,
             cancellation_port,
             projection_store,
+            slash_command_port: Arc::new(NoopNativeSlashCommandPort),
             team_run_manager,
             work_coordinator,
             user_id,
@@ -227,6 +236,16 @@ impl TeamSession {
             prompt_dump,
             recovery_scan_completed: AtomicBool::new(false),
         })
+    }
+
+    /// Inject the composition-layer slash-command recognizer. Called once right
+    /// after `start*` so live team sessions recognize native backend commands;
+    /// omitted in unit tests that don't exercise recognition (the no-op default
+    /// keeps behaviour identical to the pre-fix wrapped-wake path).
+    #[must_use]
+    pub fn with_slash_command_port(mut self, port: Arc<dyn NativeSlashCommandPort>) -> Self {
+        self.slash_command_port = port;
+        self
     }
 
     pub fn team_id(&self) -> &str {
@@ -355,26 +374,43 @@ impl TeamSession {
                     .into_iter()
                     .map(|member| member.slot_id)
                     .collect();
-                let wake_body = build_wake_payload(&agent, &tasks, &claimed_unread, &current_slot_ids);
-                let needs_role_prompt = self.scheduler.take_needs_role_prompt(slot_id).await;
-                let first_message = if needs_role_prompt {
-                    let tool_transport = self.team_tool_transport_for_agent(&agent).await?;
-                    let role_prompt = match agent.role {
-                        TeammateRole::Lead => build_lead_prompt_for_transport(
-                            &agent,
-                            &self.team.name,
-                            &self.scheduler.list_agents().await,
-                            &[],
-                            tool_transport,
-                        ),
-                        TeammateRole::Teammate => {
-                            let members = self.scheduler.list_agents().await;
-                            build_teammate_prompt_for_transport(&agent, &self.team.name, &members, tool_transport)
-                        }
-                    };
-                    format!("{role_prompt}\n\n{wake_body}")
+                let (first_message, needs_role_prompt) = if batch.is_command {
+                    // ELECTRON-3RN: a recognized slash command turn is sent bare —
+                    // the turn's first content block is the raw command so the
+                    // backend's native slash dispatch (e.g. codex
+                    // `route_slash_command` → `thread/compact/start`) matches,
+                    // byte-for-byte like a direct-session send (AC9). Skip
+                    // `build_wake_payload`'s `## New Messages` wrapping AND the
+                    // role-prompt prefix, and do NOT consume `needs_role_prompt` —
+                    // it belongs to the next real wake turn (AC2).
+                    let command = claimed_unread
+                        .first()
+                        .map(|message| message.content.clone())
+                        .unwrap_or_default();
+                    (command, false)
                 } else {
-                    wake_body
+                    let wake_body = build_wake_payload(&agent, &tasks, &claimed_unread, &current_slot_ids);
+                    let needs_role_prompt = self.scheduler.take_needs_role_prompt(slot_id).await;
+                    let first_message = if needs_role_prompt {
+                        let tool_transport = self.team_tool_transport_for_agent(&agent).await?;
+                        let role_prompt = match agent.role {
+                            TeammateRole::Lead => build_lead_prompt_for_transport(
+                                &agent,
+                                &self.team.name,
+                                &self.scheduler.list_agents().await,
+                                &[],
+                                tool_transport,
+                            ),
+                            TeammateRole::Teammate => {
+                                let members = self.scheduler.list_agents().await;
+                                build_teammate_prompt_for_transport(&agent, &self.team.name, &members, tool_transport)
+                            }
+                        };
+                        format!("{role_prompt}\n\n{wake_body}")
+                    } else {
+                        wake_body
+                    };
+                    (first_message, needs_role_prompt)
                 };
 
                 match dump_team_wake_prompt(
@@ -570,10 +606,59 @@ impl TeamSession {
         self.ensure_member_runtime_lazy(slot_id, false).await?;
         self.publish_runtime_constraint(slot_id).await?;
         let agent = self.scheduler.get_agent(slot_id).await?;
-        let source = if self.team_run_manager.current_active_run_id().is_some() {
+        // Fallback classification when the message is NOT a recognized command:
+        // an active team run makes it an intervention, otherwise an ordinary
+        // user message (unchanged pre-fix behaviour → zero regression).
+        let fallback_source = if self.team_run_manager.current_active_run_id().is_some() {
             WorkSource::UserIntervention
         } else {
             WorkSource::UserMessage
+        };
+        // ELECTRON-3RN: recognize native slash commands ONLY at this user entry
+        // point (`send_message` / `send_message_to_agent` both funnel here), so
+        // `send_agent_message_from_agent` (agent→agent) is never treated as a
+        // command (§9-7). `content` is passed and stored verbatim — never
+        // trimmed or rewritten — so the dispatched command is byte-identical to
+        // a direct send (AC9). Logs carry only the command NAME + source, never
+        // `content`/args (§14).
+        let source = match self.slash_command_port.recognize(&agent.conversation_id, content).await {
+            SlashCommandRecognition::Recognized { command, source } => {
+                info!(
+                    team_id = %self.team.id,
+                    slot_id,
+                    conversation_id = %agent.conversation_id,
+                    backend = %agent.backend,
+                    command = %command,
+                    source = source.as_str(),
+                    "team user slash command recognized; dispatching as bare command turn"
+                );
+                WorkSource::UserCommand
+            }
+            SlashCommandRecognition::CatalogUnavailable { name } => {
+                warn!(
+                    team_id = %self.team.id,
+                    slot_id,
+                    conversation_id = %agent.conversation_id,
+                    backend = %agent.backend,
+                    command = %name,
+                    reason = "catalog_unavailable",
+                    "team user message resembles a slash command but the backend command catalog is unavailable; falling back to wrapped wake"
+                );
+                fallback_source
+            }
+            SlashCommandRecognition::NotInCatalog { name } => {
+                tracing::debug!(
+                    team_id = %self.team.id,
+                    slot_id,
+                    conversation_id = %agent.conversation_id,
+                    backend = %agent.backend,
+                    command = %name,
+                    reason = "not_in_catalog",
+                    "team user message starts with '/' but name is not an advertised command; treating as ordinary text"
+                );
+                fallback_source
+            }
+            SlashCommandRecognition::NotCommand => fallback_source,
         };
         let lease = self.work_coordinator.acquire_enqueue(EnqueueRequest {
             slot_id: slot_id.to_owned(),

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -634,6 +634,18 @@ impl TeamSession {
                 );
                 WorkSource::UserCommand
             }
+            SlashCommandRecognition::CatalogEmpty { name } => {
+                warn!(
+                    team_id = %self.team.id,
+                    slot_id,
+                    conversation_id = %agent.conversation_id,
+                    backend = %agent.backend,
+                    command = %name,
+                    reason = "catalog_empty",
+                    "team user message resembles a slash command but the backend command catalog resolved EMPTY; falling back to wrapped wake"
+                );
+                fallback_source
+            }
             SlashCommandRecognition::CatalogUnavailable { name } => {
                 warn!(
                     team_id = %self.team.id,

--- a/crates/aionui-team/src/work_coordinator/coordinator.rs
+++ b/crates/aionui-team/src/work_coordinator/coordinator.rs
@@ -414,7 +414,8 @@ impl SlotWorkCoordinator {
         };
 
         let queued_ids = slot.queue(priority).iter().cloned().collect::<Vec<_>>();
-        let message_intent_ids = queued_ids
+        // Message intents (those carrying a mailbox row), in FIFO order.
+        let fifo_message_intent_ids = queued_ids
             .iter()
             .filter(|intent_id| {
                 state
@@ -424,9 +425,38 @@ impl SlotWorkCoordinator {
             })
             .cloned()
             .collect::<Vec<_>>();
-        if message_intent_ids.is_empty() {
+        if fifo_message_intent_ids.is_empty() {
             return ReconcileDecision::SettleSignals(queued_ids);
         }
+
+        // ELECTRON-3RN: isolate recognized slash commands into single-message
+        // batches (FIFO, no preemption). The queue head decides:
+        // - head is a `UserCommand` → this batch is exactly that one command, so
+        //   the native op is not fed the rest of the turn (the flaw that ruled
+        //   out option B);
+        // - head is an ordinary message → merge the leading run of ordinary
+        //   messages but STOP at the first `UserCommand` so a command is never
+        //   folded into a plain batch (existing multi-message merge, bounded).
+        let head_is_command = state
+            .intents
+            .get(&fifo_message_intent_ids[0])
+            .is_some_and(|intent| intent.source == WorkSource::UserCommand);
+        let (message_intent_ids, is_command) = if head_is_command {
+            (vec![fifo_message_intent_ids[0].clone()], true)
+        } else {
+            let mut selected = Vec::new();
+            for intent_id in &fifo_message_intent_ids {
+                let is_command_intent = state
+                    .intents
+                    .get(intent_id)
+                    .is_some_and(|intent| intent.source == WorkSource::UserCommand);
+                if is_command_intent {
+                    break;
+                }
+                selected.push(intent_id.clone());
+            }
+            (selected, false)
+        };
 
         state.next_operation_id = state.next_operation_id.saturating_add(1);
         let operation_id = state.next_operation_id;
@@ -457,6 +487,7 @@ impl SlotWorkCoordinator {
             highest_priority: priority,
             team_run_ids: team_run_ids.clone(),
             operation_id,
+            is_command,
         };
         let slot = state.slots.get_mut(slot_id).expect("selected slot exists");
         for intent_id in &message_intent_ids {
@@ -481,6 +512,7 @@ impl SlotWorkCoordinator {
             intent_count = batch.intent_ids.len(),
             message_count = batch.mailbox_message_ids.len(),
             priority = ?batch.highest_priority,
+            is_command = batch.is_command,
             "team work batch claimed"
         );
         ReconcileDecision::Claim(batch)

--- a/crates/aionui-team/src/work_coordinator/model.rs
+++ b/crates/aionui-team/src/work_coordinator/model.rs
@@ -129,6 +129,12 @@ pub(crate) struct WorkBatch {
     pub(crate) highest_priority: WorkPriority,
     pub(crate) team_run_ids: Vec<String>,
     pub(crate) operation_id: u64,
+    /// True when this batch is a single recognized user slash command
+    /// (`WorkSource::UserCommand`). The wake path sends the bare command as the
+    /// turn's first content block instead of wrapping it in a wake payload
+    /// (ELECTRON-3RN). A command is always batched alone (never merged with
+    /// other unread messages).
+    pub(crate) is_command: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/aionui-team/src/work_coordinator/tests.rs
+++ b/crates/aionui-team/src/work_coordinator/tests.rs
@@ -535,3 +535,104 @@ fn system_initiated_none_delegates_to_port() {
         "a None inherit must delegate to bind_system_enqueue"
     );
 }
+
+// ── ELECTRON-3RN: recognized slash commands batch alone (FIFO, no preempt) ──
+
+// AC3: when a command shares the queue with other unread messages, it is claimed
+// as a single-message batch (`is_command`), never merged with them — otherwise
+// the native op would swallow the rest of the turn (the flaw that ruled out B).
+#[test]
+fn command_intent_is_claimed_alone_not_merged() {
+    let coordinator = coordinator();
+    coordinator.set_runtime_constraint("lead-1", RuntimeConstraint::Ready);
+    enqueue(&coordinator, WorkSource::UserCommand, "c1");
+    enqueue(&coordinator, WorkSource::UserMessage, "m2");
+    enqueue(&coordinator, WorkSource::UserMessage, "m3");
+    coordinator.reconcile_mailbox(
+        "lead-1",
+        &["c1".into(), "m2".into(), "m3".into()],
+        TeamRunTargetRole::Lead,
+    );
+
+    let ReconcileDecision::Claim(batch) = coordinator.next("lead-1") else {
+        panic!("command must be claimable");
+    };
+    assert!(batch.is_command, "a command batch must be flagged is_command");
+    assert_eq!(
+        batch.mailbox_message_ids,
+        vec!["c1"],
+        "command must not merge later messages"
+    );
+    assert_eq!(coordinator.mark_started(&batch, "turn-1"), StartCommitResult::Accepted);
+    assert_eq!(coordinator.complete_batch(&batch), CommitResult::Committed);
+
+    // The trailing ordinary messages merge as usual once the command completes.
+    let ReconcileDecision::Claim(rest) = coordinator.next("lead-1") else {
+        panic!("ordinary messages must follow the command");
+    };
+    assert!(!rest.is_command);
+    assert_eq!(rest.mailbox_message_ids, vec!["m2", "m3"]);
+}
+
+// AC3: an ordinary batch merges the leading run of plain messages but STOPS at
+// the first command, so the command is never folded into a plain batch.
+#[test]
+fn plain_batch_merge_stops_at_command() {
+    let coordinator = coordinator();
+    coordinator.set_runtime_constraint("lead-1", RuntimeConstraint::Ready);
+    enqueue(&coordinator, WorkSource::UserMessage, "m1");
+    enqueue(&coordinator, WorkSource::UserMessage, "m2");
+    enqueue(&coordinator, WorkSource::UserCommand, "c3");
+    enqueue(&coordinator, WorkSource::UserMessage, "m4");
+    coordinator.reconcile_mailbox(
+        "lead-1",
+        &["m1".into(), "m2".into(), "c3".into(), "m4".into()],
+        TeamRunTargetRole::Lead,
+    );
+
+    let ReconcileDecision::Claim(first) = coordinator.next("lead-1") else {
+        panic!("plain messages must be claimable");
+    };
+    assert!(!first.is_command);
+    assert_eq!(
+        first.mailbox_message_ids,
+        vec!["m1", "m2"],
+        "merge must stop before the command"
+    );
+    assert_eq!(coordinator.mark_started(&first, "turn-1"), StartCommitResult::Accepted);
+    assert_eq!(coordinator.complete_batch(&first), CommitResult::Committed);
+
+    let ReconcileDecision::Claim(command) = coordinator.next("lead-1") else {
+        panic!("command must be claimed next, alone");
+    };
+    assert!(command.is_command);
+    assert_eq!(command.mailbox_message_ids, vec!["c3"]);
+}
+
+// AC3: a command sent while a batch is running queues in FIFO order and does not
+// preempt the active batch.
+#[test]
+fn command_during_running_batch_queues_without_preemption() {
+    let coordinator = coordinator();
+    coordinator.set_runtime_constraint("lead-1", RuntimeConstraint::Ready);
+    enqueue(&coordinator, WorkSource::UserMessage, "m1");
+    let ReconcileDecision::Claim(first) = coordinator.next("lead-1") else {
+        panic!("first message must be claimable");
+    };
+    assert!(!first.is_command);
+    assert_eq!(coordinator.mark_started(&first, "turn-1"), StartCommitResult::Accepted);
+
+    // Command arrives mid-turn: it must NOT preempt the running batch.
+    enqueue(&coordinator, WorkSource::UserCommand, "c2");
+    let active = coordinator.slot_snapshot("lead-1").unwrap();
+    assert_eq!(active.active_batch.unwrap().mailbox_message_ids, vec!["m1"]);
+    assert_eq!(coordinator.next("lead-1"), ReconcileDecision::WaitingForCompletion);
+
+    // Once the active batch completes, the command is claimed alone.
+    assert_eq!(coordinator.complete_batch(&first), CommitResult::Committed);
+    let ReconcileDecision::Claim(second) = coordinator.next("lead-1") else {
+        panic!("queued command must follow the active batch");
+    };
+    assert!(second.is_command);
+    assert_eq!(second.mailbox_message_ids, vec!["c2"]);
+}

--- a/crates/aionui-team/src/work_source.rs
+++ b/crates/aionui-team/src/work_source.rs
@@ -4,6 +4,11 @@ use std::fmt;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WorkSource {
     UserMessage,
+    /// A user message recognized as a native backend slash command (e.g.
+    /// `/compact`). Aligned with `UserMessage` semantics (same `Foreground`
+    /// lane → FIFO, no preemption) but flagged so the coordinator batches it as
+    /// a single-message turn and the wake path sends the bare command (ELECTRON-3RN).
+    UserCommand,
     UserIntervention,
     McpSendMessage,
     McpShutdownRequest,
@@ -19,7 +24,7 @@ pub(crate) enum WorkSource {
 impl WorkSource {
     pub(crate) fn priority(self) -> WorkPriority {
         match self {
-            Self::UserMessage | Self::UserIntervention => WorkPriority::Foreground,
+            Self::UserMessage | Self::UserCommand | Self::UserIntervention => WorkPriority::Foreground,
             Self::McpShutdownRequest | Self::ShutdownRejected => WorkPriority::Control,
             Self::McpSendMessage
             | Self::SpawnWelcome
@@ -32,13 +37,14 @@ impl WorkSource {
     }
 
     pub(crate) fn resumes_paused_slot(self) -> bool {
-        matches!(self, Self::UserMessage | Self::UserIntervention)
+        matches!(self, Self::UserMessage | Self::UserCommand | Self::UserIntervention)
     }
 
     pub(crate) fn requires_mailbox_message(self) -> bool {
         matches!(
             self,
             Self::UserMessage
+                | Self::UserCommand
                 | Self::UserIntervention
                 | Self::McpSendMessage
                 | Self::McpShutdownRequest
@@ -51,10 +57,28 @@ impl WorkSource {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// AC3 (ELECTRON-3RN): `UserCommand` is aligned with `UserMessage` so it
+    /// shares the Foreground lane (FIFO, no preemption) and mailbox/paused
+    /// semantics, but carries its own `as_str` for the recognition log.
+    #[test]
+    fn user_command_matches_user_message_semantics() {
+        assert_eq!(WorkSource::UserCommand.priority(), WorkPriority::Foreground);
+        assert_eq!(WorkSource::UserCommand.priority(), WorkSource::UserMessage.priority());
+        assert!(WorkSource::UserCommand.resumes_paused_slot());
+        assert!(WorkSource::UserCommand.requires_mailbox_message());
+        assert_eq!(WorkSource::UserCommand.to_string(), "user_command");
+    }
+}
+
 impl fmt::Display for WorkSource {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         let value = match self {
             Self::UserMessage => "user_message",
+            Self::UserCommand => "user_command",
             Self::UserIntervention => "user_intervention",
             Self::McpSendMessage => "mcp_send_message",
             Self::McpShutdownRequest => "mcp_shutdown_request",

--- a/crates/aionui-team/tests/e2e_team_flow.rs
+++ b/crates/aionui-team/tests/e2e_team_flow.rs
@@ -1910,6 +1910,10 @@ async fn s11_shutdown_approved_interception() {
 struct FakeSlashPort {
     recognized: Vec<String>,
     available: bool,
+    /// When true, any parsed `/name` resolves to `CatalogEmpty` — models a
+    /// backend whose catalog RESOLVED but is empty (e.g. a live fetch that
+    /// returned no commands). Distinct from `available=false` (CatalogUnavailable).
+    empty_catalog: bool,
     source: SlashCatalogSource,
 }
 
@@ -1918,6 +1922,7 @@ impl FakeSlashPort {
         Self {
             recognized: names.iter().map(|s| s.to_string()).collect(),
             available: true,
+            empty_catalog: false,
             source: SlashCatalogSource::Live,
         }
     }
@@ -1926,6 +1931,17 @@ impl FakeSlashPort {
         Self {
             recognized: Vec::new(),
             available: false,
+            empty_catalog: false,
+            source: SlashCatalogSource::Live,
+        }
+    }
+
+    /// The catalog resolved but is EMPTY → `CatalogEmpty` (§14 warn: `catalog_empty`).
+    fn empty() -> Self {
+        Self {
+            recognized: Vec::new(),
+            available: true,
+            empty_catalog: true,
             source: SlashCatalogSource::Live,
         }
     }
@@ -1945,6 +1961,9 @@ impl NativeSlashCommandPort for FakeSlashPort {
         };
         if !self.available {
             return SlashCommandRecognition::CatalogUnavailable { name };
+        }
+        if self.empty_catalog {
+            return SlashCommandRecognition::CatalogEmpty { name };
         }
         if self.recognized.contains(&name) {
             SlashCommandRecognition::Recognized {
@@ -2141,6 +2160,52 @@ async fn recognized_command_log_carries_name_and_source_not_content() {
     assert!(
         !logs.contains(SENSITIVE_ARG),
         "production log must NOT contain command args/content: {logs}"
+    );
+
+    session.stop();
+}
+
+/// A RESOLVED-but-EMPTY catalog (e.g. a live backend that returned no commands)
+/// must (1) fall back to the wrapped wake with zero regression, and (2) emit a
+/// production-visible `warn` (`reason=catalog_empty`) so the otherwise-silent
+/// "command list is empty → command silently ignored" boundary is diagnosable.
+/// `warn` is more severe than `info`, so the INFO-max capturing subscriber sees it.
+#[tokio::test]
+async fn empty_catalog_logs_warn_and_falls_back_to_wrapped_wake() {
+    install_ac11_capturing_subscriber();
+    AC11_LOG_BUF.with(|cell| cell.borrow_mut().clear());
+
+    let (session, _tm, _repo, _sent, turn_requests) =
+        setup_session_with_slash_recognizer(Arc::new(FakeSlashPort::empty())).await;
+
+    session
+        .send_message_to_agent("worker-1", "/compact", None)
+        .await
+        .expect("send must succeed");
+    wait_until_turn_count(&turn_requests, 1).await;
+
+    // (1) Zero regression: an empty catalog falls back to the wrapped wake.
+    let content = last_turn_content(&turn_requests, "worker-1");
+    assert!(
+        content.contains("## New Messages"),
+        "empty-catalog must fall back to the wrapped wake (zero regression): {content}"
+    );
+
+    // (2) The empty-catalog boundary is logged at a production-visible level.
+    let logs = AC11_LOG_BUF.with(|cell| String::from_utf8(cell.borrow().clone()).expect("utf8 logs"));
+    assert!(
+        logs.contains("catalog_empty"),
+        "empty catalog must emit a warn with reason=catalog_empty: {logs}"
+    );
+    // The command NAME correlates the log; the raw content is fine here (no args),
+    // but the field must be the NAME only.
+    assert!(
+        logs.contains("command=compact"),
+        "warn must carry the command NAME: {logs}"
+    );
+    assert!(
+        logs.contains("conversation_id="),
+        "warn must carry conversation_id: {logs}"
     );
 
     session.stop();

--- a/crates/aionui-team/tests/e2e_team_flow.rs
+++ b/crates/aionui-team/tests/e2e_team_flow.rs
@@ -2053,3 +2053,95 @@ async fn catalog_unavailable_falls_back_to_wrapped_wake() {
 
     session.stop();
 }
+
+// AC11 log capture. A thread-local subscriber cannot reliably capture a callsite
+// that other tests in the same binary also hit (tracing caches per-callsite
+// interest globally). So we install ONE process-global capturing subscriber
+// (which rebuilds the interest cache) that routes every event into a THREAD-LOCAL
+// buffer. Each `#[tokio::test]` runs its whole flow — including spawned tasks —
+// on its own current-thread runtime thread, so a test only ever sees its own
+// events; we clear the buffer at the start and read it at the end.
+thread_local! {
+    static AC11_LOG_BUF: std::cell::RefCell<Vec<u8>> = const { std::cell::RefCell::new(Vec::new()) };
+}
+
+struct Ac11ThreadLocalWriter;
+impl std::io::Write for Ac11ThreadLocalWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        AC11_LOG_BUF.with(|cell| cell.borrow_mut().extend_from_slice(buf));
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Ac11ThreadLocalWriter {
+    type Writer = Ac11ThreadLocalWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        Ac11ThreadLocalWriter
+    }
+}
+
+fn install_ac11_capturing_subscriber() {
+    static INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    INIT.get_or_init(|| {
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(Ac11ThreadLocalWriter)
+            .with_ansi(false)
+            .with_max_level(tracing::Level::INFO)
+            .finish();
+        // Setting a global default rebuilds tracing's interest cache, so the
+        // recognition callsite is re-evaluated against this subscriber even if a
+        // prior test already hit it under the no-op default. Ignore the error if
+        // some other harness already installed a global default.
+        let _ = tracing::subscriber::set_global_default(subscriber);
+    });
+}
+
+/// AC11 (§14): the recognition-hit `info` log must carry the command NAME +
+/// source correlation fields (`command`, `source`, `team_id`, `slot_id`,
+/// `conversation_id`) but NEVER the raw `content`/args (no sensitive payload).
+#[tokio::test]
+async fn recognized_command_log_carries_name_and_source_not_content() {
+    install_ac11_capturing_subscriber();
+    AC11_LOG_BUF.with(|cell| cell.borrow_mut().clear());
+
+    let (session, _tm, _repo, _sent, turn_requests) =
+        setup_session_with_slash_recognizer(Arc::new(FakeSlashPort::recognizing(&["compact"]))).await;
+
+    // The arg after the command name is a distinctive marker: it MUST NOT appear
+    // in any production-visible log (it is a stand-in for sensitive payload).
+    const SENSITIVE_ARG: &str = "sensitive-payload-should-not-log";
+    session
+        .send_message_to_agent("worker-1", &format!("/compact {SENSITIVE_ARG}"), None)
+        .await
+        .expect("send_message_to_agent must succeed");
+
+    wait_until_turn_count(&turn_requests, 1).await;
+
+    let logs = AC11_LOG_BUF.with(|cell| String::from_utf8(cell.borrow().clone()).expect("utf8 logs"));
+    assert!(
+        logs.contains("team user slash command recognized"),
+        "the recognition info log must be emitted: {logs}"
+    );
+    // Correlation fields present (AC11).
+    assert!(
+        logs.contains("command=compact"),
+        "log must carry the command NAME: {logs}"
+    );
+    assert!(logs.contains("source="), "log must carry the catalog source: {logs}");
+    assert!(logs.contains("team_id="), "log must carry team_id: {logs}");
+    assert!(logs.contains("slot_id="), "log must carry slot_id: {logs}");
+    assert!(
+        logs.contains("conversation_id="),
+        "log must carry conversation_id: {logs}"
+    );
+    // Sensitive payload absent (AC11 / §14): the command args / full content are
+    // never logged at a production-visible level.
+    assert!(
+        !logs.contains(SENSITIVE_ARG),
+        "production log must NOT contain command args/content: {logs}"
+    );
+
+    session.stop();
+}

--- a/crates/aionui-team/tests/e2e_team_flow.rs
+++ b/crates/aionui-team/tests/e2e_team_flow.rs
@@ -38,7 +38,8 @@ use aionui_team::event_loop::AgentLoopContext;
 use aionui_team::mcp::protocol::{read_frame, write_frame};
 use aionui_team::ports::{
     AgentTurnCancellationPort, AgentTurnExecutionError, AgentTurnExecutionPort, AgentTurnOutcome, AgentTurnRequest,
-    AgentTurnSource, AgentTurnStarted, AgentTurnStatus,
+    AgentTurnSource, AgentTurnStarted, AgentTurnStatus, NativeSlashCommandPort, NoopNativeSlashCommandPort,
+    SlashCatalogSource, SlashCommandRecognition,
 };
 use aionui_team::service::TeamSessionService;
 use aionui_team::{TeamAgent, TeamProjectionMessageStore, TeamSession, TeammateRole};
@@ -639,7 +640,7 @@ async fn setup_session_with_turn_recorder() -> (
     Arc<Mutex<Vec<SendMessageData>>>,
     Arc<Mutex<Vec<AgentTurnRequest>>>,
 ) {
-    setup_session_with_turn_recorder_inner(true).await
+    setup_session_with_turn_recorder_inner(true, Arc::new(NoopNativeSlashCommandPort)).await
 }
 
 async fn setup_session_with_turn_recorder_without_loops() -> (
@@ -649,11 +650,26 @@ async fn setup_session_with_turn_recorder_without_loops() -> (
     Arc<Mutex<Vec<SendMessageData>>>,
     Arc<Mutex<Vec<AgentTurnRequest>>>,
 ) {
-    setup_session_with_turn_recorder_inner(false).await
+    setup_session_with_turn_recorder_inner(false, Arc::new(NoopNativeSlashCommandPort)).await
+}
+
+/// Variant with a custom slash-command recognizer injected — for the
+/// ELECTRON-3RN command-path tests.
+async fn setup_session_with_slash_recognizer(
+    slash_port: Arc<dyn NativeSlashCommandPort>,
+) -> (
+    Arc<TeamSession>,
+    Arc<StubTaskManager>,
+    Arc<MockTeamRepo>,
+    Arc<Mutex<Vec<SendMessageData>>>,
+    Arc<Mutex<Vec<AgentTurnRequest>>>,
+) {
+    setup_session_with_turn_recorder_inner(true, slash_port).await
 }
 
 async fn setup_session_with_turn_recorder_inner(
     register_loops: bool,
+    slash_port: Arc<dyn NativeSlashCommandPort>,
 ) -> (
     Arc<TeamSession>,
     Arc<StubTaskManager>,
@@ -704,7 +720,7 @@ async fn setup_session_with_turn_recorder_inner(
     .await
     .expect("TeamSession::start failed");
 
-    let session = Arc::new(session);
+    let session = Arc::new(session.with_slash_command_port(slash_port));
     if register_loops {
         register_test_event_loops(&session);
     }
@@ -1878,6 +1894,161 @@ async fn s11_shutdown_approved_interception() {
     assert!(
         raw_sentinel.is_empty(),
         "raw shutdown_approved sentinel must not land in lead mailbox; got {raw_sentinel:?}"
+    );
+
+    session.stop();
+}
+
+// ===========================================================================
+// ELECTRON-3RN: native slash command path (bare command turn, no wrapping)
+// ===========================================================================
+
+/// Configurable recognizer stub. Parses the leading command name with the same
+/// grammar as the shared parser (start with `/`, name to first whitespace,
+/// non-empty), then answers per its configured catalog. `available=false`
+/// simulates the degradation-chain-exhausted case (catalog unavailable).
+struct FakeSlashPort {
+    recognized: Vec<String>,
+    available: bool,
+    source: SlashCatalogSource,
+}
+
+impl FakeSlashPort {
+    fn recognizing(names: &[&str]) -> Self {
+        Self {
+            recognized: names.iter().map(|s| s.to_string()).collect(),
+            available: true,
+            source: SlashCatalogSource::Live,
+        }
+    }
+
+    fn unavailable() -> Self {
+        Self {
+            recognized: Vec::new(),
+            available: false,
+            source: SlashCatalogSource::Live,
+        }
+    }
+
+    fn parse_name(content: &str) -> Option<String> {
+        let stripped = content.strip_prefix('/')?;
+        let name: String = stripped.chars().take_while(|c| !c.is_whitespace()).collect();
+        if name.is_empty() { None } else { Some(name) }
+    }
+}
+
+#[async_trait]
+impl NativeSlashCommandPort for FakeSlashPort {
+    async fn recognize(&self, _conversation_id: &str, content: &str) -> SlashCommandRecognition {
+        let Some(name) = Self::parse_name(content) else {
+            return SlashCommandRecognition::NotCommand;
+        };
+        if !self.available {
+            return SlashCommandRecognition::CatalogUnavailable { name };
+        }
+        if self.recognized.contains(&name) {
+            SlashCommandRecognition::Recognized {
+                command: name,
+                source: self.source,
+            }
+        } else {
+            SlashCommandRecognition::NotInCatalog { name }
+        }
+    }
+}
+
+fn last_turn_content(requests: &Arc<Mutex<Vec<AgentTurnRequest>>>, slot_id: &str) -> String {
+    let log = requests.lock().unwrap();
+    log.iter()
+        .rev()
+        .find(|r| r.slot_id == slot_id)
+        .unwrap_or_else(|| panic!("no turn request for slot {slot_id}; requests: {log:?}"))
+        .content
+        .clone()
+}
+
+/// AC1/AC2/AC9 + AC6 (member entry): a recognized `/compact` sent to a member
+/// produces a turn whose first content block is the BARE command — no
+/// `## New Messages` wrapping, byte-identical to a direct send.
+#[tokio::test]
+async fn recognized_command_is_sent_bare_to_member() {
+    let (session, _tm, _repo, _sent, turn_requests) =
+        setup_session_with_slash_recognizer(Arc::new(FakeSlashPort::recognizing(&["compact"]))).await;
+
+    session
+        .send_message_to_agent("worker-1", "/compact", None)
+        .await
+        .expect("send_message_to_agent must succeed");
+
+    wait_until_turn_count(&turn_requests, 1).await;
+    let content = last_turn_content(&turn_requests, "worker-1");
+    assert_eq!(
+        content, "/compact",
+        "command turn must send the bare command verbatim (AC2/AC9)"
+    );
+    assert!(!content.contains("## New Messages"), "command turn must NOT be wrapped");
+
+    session.stop();
+}
+
+/// AC6 (Lead entry): the Lead entry point (`send_message`) recognizes commands too.
+#[tokio::test]
+async fn recognized_command_is_sent_bare_to_lead() {
+    let (session, _tm, _repo, _sent, turn_requests) =
+        setup_session_with_slash_recognizer(Arc::new(FakeSlashPort::recognizing(&["compact"]))).await;
+
+    session
+        .send_message("/compact", None)
+        .await
+        .expect("send_message must succeed");
+
+    wait_until_turn_count(&turn_requests, 1).await;
+    let content = last_turn_content(&turn_requests, "lead-1");
+    assert_eq!(content, "/compact");
+    assert!(!content.contains("## New Messages"));
+
+    session.stop();
+}
+
+/// AC4 (negative): a `/`-prefixed message whose name is not in the catalog, and a
+/// plain message, both fall back to the ordinary WRAPPED wake turn.
+#[tokio::test]
+async fn unrecognized_slash_and_plain_text_fall_back_to_wrapped_wake() {
+    let (session, _tm, _repo, _sent, turn_requests) =
+        setup_session_with_slash_recognizer(Arc::new(FakeSlashPort::recognizing(&["compact"]))).await;
+
+    // `/etc/hosts ...` — name "etc" is not an advertised command → NotInCatalog.
+    session
+        .send_message_to_agent("worker-1", "/etc/hosts is broken", None)
+        .await
+        .expect("send must succeed");
+    wait_until_turn_count(&turn_requests, 1).await;
+    let content = last_turn_content(&turn_requests, "worker-1");
+    assert!(
+        content.contains("## New Messages"),
+        "unrecognized slash must use the wrapped wake"
+    );
+    assert_ne!(content, "/etc/hosts is broken");
+
+    session.stop();
+}
+
+/// AC7: when the command catalog is unavailable (degradation chain exhausted), a
+/// `/`-prefixed message falls back to the wrapped wake with zero regression.
+#[tokio::test]
+async fn catalog_unavailable_falls_back_to_wrapped_wake() {
+    let (session, _tm, _repo, _sent, turn_requests) =
+        setup_session_with_slash_recognizer(Arc::new(FakeSlashPort::unavailable())).await;
+
+    session
+        .send_message_to_agent("worker-1", "/compact", None)
+        .await
+        .expect("send must succeed");
+    wait_until_turn_count(&turn_requests, 1).await;
+    let content = last_turn_content(&turn_requests, "worker-1");
+    assert!(
+        content.contains("## New Messages"),
+        "catalog-unavailable must fall back to the wrapped wake (AC7)"
     );
 
     session.stop();


### PR DESCRIPTION
## Summary

Sentry `136741773` / `ELECTRON-3RN` (reported on AionUi `2.1.41`, `module=agent-team`, non-crash user feedback).

In team (agent-team) sessions, sending a bare `/compact` never compacted context. Every user input — including native slash commands — was wrapped into a `## New Messages` wake payload before being delivered as the turn prompt. The backend only translates a slash command into its native op (codex `route_slash_command` → `thread/compact/start`) when the **first** prompt content block starts with `/`. In the team path that block is always the orchestration wrapper, so `/compact` was never recognized as a command and silently degraded into an ordinary `user_input` turn.

## Fix

Keep command messages inside the existing mailbox → wake → `run_agent_turn` pipeline, but recognize a native backend slash command at the **user entry point** and dispatch it as a single, bare-command turn so it hits the backend's existing slash-dispatch path. Recognition is backend-agnostic: it depends only on the member session's self-advertised command catalog, and the delivered content is byte-identical to sending the same command in a direct session.

Key points:

- **Shared slash-name parser (DRY):** extract command-name parsing out of codex `route_slash_command` into a `pub` pure function `slash_command_name`, called by both the codex router and the team recognition predicate so the two grammars cannot drift.
- **Recognition port (backend-agnostic contract):** add `NativeSlashCommandPort` and a rich `SlashCommandRecognition` result enum (`Recognized{command, source}` / `NotInCatalog` / `CatalogEmpty` / `CatalogUnavailable` / `NotCommand`) plus a `SlashCatalogSource` label (Live/Cached/Static). A `NoopNativeSlashCommandPort` default preserves pre-fix behavior byte-for-byte.
- **Recognition adapter (degradation chain):** the composition layer resolves the command catalog via **live (`capabilities().slash_commands`) → cached (`agent_metadata.available_commands` snapshot) → static (codex fallback)**; when all are unavailable it returns `CatalogUnavailable` and falls back to the wrapped wake (zero regression). Injected via DI.
- **`WorkSource::UserCommand`:** new work-source variant aligned with `UserMessage` semantics (same `Foreground` lane, FIFO, no preemption).
- **Single-command batching:** a command intent is claimed alone as its own `WorkBatch` (in-memory `is_command` flag) and never merged with other unread messages; plain-message merging stops at a command; during an active run the command still queues FIFO without preemption.
- **Bare-command turn payload:** for a command batch, `first_message` uses the raw bare command content directly, skipping the `build_wake_payload` wrapper and the role-prompt prefix.
- **Entry-point-only recognition + structured logs:** recognition runs only at user entry points (`send_message` / `send_message_to_agent`); agent→agent messages are never treated as commands. Logs carry command name and correlation fields (`command`/`source`/`team_id`/`slot_id`/`conversation_id`) but never `content`, args, or prompts. A follow-up commit adds a `warn` for the previously-silent "catalog resolved but empty" boundary.
- **Codex double-table consistency test:** asserts `builtin_slash_commands()` name set == `route_slash_command()` recognizable name set, so a one-sided edit fails CI.

Direct (non-team) slash behavior is unchanged.

## Scope

- **AionCore only** — 17 files, +1042 / −53. Crates: `aionui-session` (shared parser + double-table test), `aionui-team` (recognition port, `WorkSource::UserCommand`, single-command batching, bare-command wake payload, structured logs), `aionui-app` (recognition adapter + DI wiring). Adds `tracing-subscriber` as an `aionui-team` dev-dependency for the AC11 log-redaction test (`Cargo.lock` touched).
- No DB schema change, no migration, no backfill. Recognition only **reads** the existing `agent_metadata.available_commands` column; `WorkSource::UserCommand` and `WorkBatch.is_command` are in-memory intent flags.
- **AionUi**: not modified. **aionrs**: not on the defect path (covered automatically by the generic mechanism when its advertised catalog is available).

## Testing

- `cargo test -p aionui-session` — pass (shared parser, double-table consistency AC10, direct-CLI regression baseline AC5).
- `cargo test -p aionui-team` — pass (413 lib + 28 e2e, including the AC11 recognition-log redaction test).
- `cargo test -p aionui-app --lib` and `cargo test -p aionui-app --test team_e2e` — pass.
- `just push` pre-push gate on this branch: migration-check, `lint-fix` (clippy `-D warnings`), `fmt`, and full-workspace `cargo nextest run` all passed — **7491 tests run, 7491 passed** (1 leaky, 18 skipped).

## Verification caveats (honest)

- End-to-end behavior against a **real codex CLI + real team session** has not been manually reproduced yet; automated coverage uses fake backends.
- For backends without native slash translation (e.g. claude), the fix only guarantees the delivered content is byte-identical to a direct session (AC9); it does not assert their compaction effect.
- Known boundary: an agent type recognized before its first-ever discovery (NULL `available_commands`, non-static backend) falls back to the wrapped wake for that one command (no regression).
- Out of scope: the screenshot's missing `/compact` in the right-pane command menu is an independent AionUi front-end app-level command list, not sourced from backend `capabilities().slash_commands` or `route_slash_command`.
