### PR TITLE
chore(acp): bump dirac-cli registry pin to 0.4.28

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -24,7 +24,7 @@
     "dirac": {
       "registry_json_id": "dirac",
       "package": "dirac-cli",
-      "version": "0.4.27"
+      "version": "0.4.28"
     },
     "glm-acp-agent": {
       "registry_json_id": "glm-acp-agent",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Single drift since #695: `dirac-cli` 0.4.27 -> 0.4.28 in `crates/aionui-runtime/resources/acp-registry-npx-lock.json`. Lock-only change, backed by a fresh ACP probe of the exact pinned version.

| backend | package | old | new | initialize | session/new |
|---|---|---|---|---|---|
| dirac | dirac-cli | 0.4.27 | 0.4.28 | ok (agentInfo 0.4.28) | success (plan/act modes) |

All other 10 pinned packages match the audited snapshot — no drift. Drifted but not upgraded: none.

## Registry snapshot

- Audit pinned to release tag [`v2026.07.27-888cd13`](https://cdn.agentclientprotocol.com/registry/v1/v2026.07.27-888cd13/registry.json) of `agentclientprotocol/registry` (the newest release at audit time), fetched via the versioned CDN path for reproducibility.
- This is the same post-#695 snapshot already flagged in #695's body: dirac moved to 0.4.28 hours after that audit; this PR picks it up as promised.

## Changes

- Lock file: one version bump (release lock only; no metadata or migration changes). No lock-derived test assertions reference the dirac version, so no test changes are needed.

## Validation

- `cargo test -p aionui-runtime -p aionui-ai-agent` — pass
- Full `just push` gate (migration check, lint, fmt, `cargo nextest run --workspace`) — pass (run with the host-injected `AIONUI_LOG_DIR` unset; see #695 for the pre-existing `test_env_override_log_dir` environment sensitivity)

## Logging

No logging changes: lock-only version bump; existing startup/session error paths already identify a failing agent by backend.