### PR TITLE
fix(ai-agent): resolve cron full-auto mode to backend-native YOLO (ELECTRON-3RQ)

### DIFF
--- a/crates/aionui-ai-agent/src/agent_task.rs
+++ b/crates/aionui-ai-agent/src/agent_task.rs
@@ -17,7 +17,7 @@ use aionui_common::{AgentKillReason, AgentType, ConversationStatus, TimestampMs}
 use tokio::sync::broadcast;
 
 use crate::error::AgentError;
-use crate::manager::acp::AcpAgentManager;
+use crate::manager::acp::{AcpAgentManager, RequiredFullAutoApplication};
 use crate::manager::aionrs::AionrsAgentManager;
 use crate::protocol::events::AgentStreamEvent;
 use crate::protocol::send_error::AgentSendError;
@@ -374,6 +374,19 @@ impl AgentInstance {
         }
     }
 
+    /// Apply cron's full-auto required-runtime-mode (a-pure, ELECTRON-3RQ) for
+    /// metadata-bearing ACP agents (Kimi et al.). Returns `Ok(None)` for
+    /// non-ACP variants (claude/codex `Session`, `Aionrs`, `Mock`) — the
+    /// `yolo_id` metadata this resolution needs is only visible on the ACP
+    /// manager, so the caller uses the retained legacy apply path (codex
+    /// ELECTRON-3Q0 catalog alignment + native pass-through) for the rest.
+    pub async fn apply_required_full_auto_mode(&self) -> Result<Option<RequiredFullAutoApplication>, AgentError> {
+        match self {
+            Self::Acp(m) => Ok(Some(m.apply_required_full_auto_mode().await?)),
+            _ => Ok(None),
+        }
+    }
+
     /// Returns the cached session usage as a snake_case JSON object. The
     /// structure mirrors the ACP SDK `UsageUpdate` schema
     /// (`used` / `size` / `cost` / `_meta`), normalised via
@@ -634,5 +647,64 @@ mod aionrs_config_option_tests {
             matches!(&error, AgentError::BadRequest(message) if message == "Config option 'thought_level' is not available"),
             "unexpected error: {error:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod required_full_auto_dispatch_tests {
+    use super::*;
+    use tokio::sync::broadcast;
+
+    /// Minimal non-ACP agent behind the `Mock` variant: exercises the
+    /// `apply_required_full_auto_mode` dispatch without a real CLI.
+    struct NoopMockAgent {
+        conversation_id: String,
+        event_tx: broadcast::Sender<AgentStreamEvent>,
+    }
+
+    #[async_trait::async_trait]
+    impl IAgentTask for NoopMockAgent {
+        fn agent_type(&self) -> AgentType {
+            AgentType::Acp
+        }
+        fn conversation_id(&self) -> &str {
+            &self.conversation_id
+        }
+        fn workspace(&self) -> &str {
+            "/tmp/test"
+        }
+        fn status(&self) -> Option<ConversationStatus> {
+            None
+        }
+        fn last_activity_at(&self) -> TimestampMs {
+            0
+        }
+        fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
+            self.event_tx.subscribe()
+        }
+        async fn send_message(&self, _data: SendMessageData) -> Result<(), AgentSendError> {
+            Ok(())
+        }
+        async fn cancel(&self) -> Result<(), AgentError> {
+            Ok(())
+        }
+        fn kill(&self, _reason: Option<AgentKillReason>) -> Result<(), AgentError> {
+            Ok(())
+        }
+    }
+
+    impl IMockAgent for NoopMockAgent {}
+
+    /// Non-ACP variants (proxy for claude/codex `Session`, `Aionrs`) never
+    /// enter the a-pure path — they signal `Ok(None)` so the caller falls back
+    /// to the retained legacy apply path.
+    #[tokio::test]
+    async fn non_acp_variant_returns_none_for_full_auto_apply() {
+        let (event_tx, _rx) = broadcast::channel(4);
+        let instance = AgentInstance::Mock(Arc::new(NoopMockAgent {
+            conversation_id: "conv-mock".into(),
+            event_tx,
+        }));
+        assert!(matches!(instance.apply_required_full_auto_mode().await, Ok(None)));
     }
 }

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -46,6 +46,7 @@ pub use factory::{AgentFactoryDeps, build_agent_factory};
 pub use idle_scanner::{
     IdleCleanupCoordinator, resolve_idle_config_from_env, start_idle_scanner, start_idle_scanner_with_coordinator,
 };
+pub use manager::acp::RequiredFullAutoApplication;
 pub use persistence::AcpSessionSyncService;
 pub use protocol::error::AcpError;
 pub use protocol::events::AgentStreamEvent;

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -79,6 +79,7 @@ use super::config_option_catalog::{extract_models_from_value, extract_modes_from
 use super::config_options::{ConfigSetPath, ConfigSetPathError, ConfigSnapshot, resolve_set_path};
 use super::mode_normalize::normalize_requested_mode;
 use super::mode_normalize::normalize_requested_mode_for_available_values;
+use super::mode_normalize::{RequiredFullAutoMode, resolve_required_full_auto_mode};
 
 /// Grace period before force-killing an ACP process (ms).
 const ACP_KILL_GRACE_MS: u64 = 500;
@@ -463,6 +464,16 @@ fn mark_session_opened_after_protocol_ready(
     Ok(sid)
 }
 
+/// Result of applying cron's full-auto required-runtime-mode (a-pure) for a
+/// metadata-bearing ACP agent. `Applied` set the backend-native YOLO id;
+/// `Skipped` left the session's already-resolved mode untouched because the
+/// resolved id was not selectable in the live catalog (look-before-leap).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RequiredFullAutoApplication {
+    Applied { effective: String },
+    Skipped { resolved: String },
+}
+
 pub struct AcpAgentManager {
     /// Pre-computed, immutable session parameters assembled by the factory.
     pub(super) params: Arc<AcpSessionParams>,
@@ -694,6 +705,65 @@ impl AcpAgentManager {
         Ok(GetConfigOptionsResponse {
             config_options: session.config_snapshot().options,
         })
+    }
+
+    /// Live `mode` option ids from this backend's catalog. `None` only on a
+    /// catalog read failure (caller then falls back to the pre-fix
+    /// unnormalized apply); a catalog with no `mode` option yields `Some([])`.
+    async fn live_mode_catalog_ids(&self) -> Option<Vec<String>> {
+        match self.config_options().await {
+            Ok(resp) => Some(
+                resp.config_options
+                    .into_iter()
+                    .find(|opt| opt.id == "mode")
+                    .map(|opt| opt.options.into_iter().map(|o| o.value).collect())
+                    .unwrap_or_default(),
+            ),
+            Err(err) => {
+                warn!(
+                    conversation_id = %self.params.conversation_id,
+                    agent_backend = ?self.params.metadata.backend,
+                    error = %err,
+                    "apply full-auto mode: live catalog read failed — applying resolved mode unnormalized"
+                );
+                None
+            }
+        }
+    }
+
+    /// Apply cron's full-auto required-runtime-mode (a-pure, ELECTRON-3RQ).
+    ///
+    /// A cron turn is ALWAYS a full-auto request, so the persisted literal is
+    /// ignored: resolve "yolo" to this backend's native YOLO id against its
+    /// live mode catalog. Look-before-leap — only set the mode when the
+    /// resolved id is actually selectable; otherwise `warn` and skip the
+    /// override, keeping the session's already-resolved mode (never fail the
+    /// turn). A catalog read failure falls back to the conservative pre-fix
+    /// behaviour: apply the resolved value and let `set_config_option`
+    /// reject it locally if unselectable.
+    pub(crate) async fn apply_required_full_auto_mode(&self) -> Result<RequiredFullAutoApplication, AgentError> {
+        match self.live_mode_catalog_ids().await {
+            Some(ids) => match resolve_required_full_auto_mode(&self.params.metadata, ids.iter().map(String::as_str)) {
+                RequiredFullAutoMode::Apply(mode) => {
+                    self.set_config_option_confirmed("mode", &mode).await?;
+                    Ok(RequiredFullAutoApplication::Applied { effective: mode })
+                }
+                RequiredFullAutoMode::Skip { resolved } => {
+                    warn!(
+                        conversation_id = %self.params.conversation_id,
+                        agent_backend = ?self.params.metadata.backend,
+                        resolved = %resolved,
+                        "apply full-auto mode: resolved YOLO not in live catalog — skipping override, keeping session mode"
+                    );
+                    Ok(RequiredFullAutoApplication::Skipped { resolved })
+                }
+            },
+            None => {
+                let resolved = normalize_requested_mode(&self.params.metadata, "yolo");
+                self.set_config_option_confirmed("mode", &resolved).await?;
+                Ok(RequiredFullAutoApplication::Applied { effective: resolved })
+            }
+        }
     }
 
     pub(crate) async fn set_config_option_confirmed(

--- a/crates/aionui-ai-agent/src/manager/acp/mod.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/mod.rs
@@ -14,6 +14,7 @@ pub mod session;
 mod stderr_error_extractor;
 
 pub use agent::AcpAgentManager;
+pub use agent::RequiredFullAutoApplication;
 pub use agent_event_tracker::AcpSessionEvent;
 pub use agent_reconcile::ReconcileAction;
 pub use catalog_forwarder::CatalogForwarder;

--- a/crates/aionui-ai-agent/src/manager/acp/mode_normalize.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/mode_normalize.rs
@@ -67,6 +67,35 @@ pub(crate) fn normalize_requested_mode_for_available_values<'a>(
     normalize_requested_mode(metadata, mode)
 }
 
+/// Outcome of resolving a cron full-auto request against a backend's live
+/// mode catalog. `Apply` carries the backend-native YOLO id to set; `Skip`
+/// carries the resolved id that was NOT selectable (look-before-leap: skip
+/// the override and keep the session's already-resolved mode).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RequiredFullAutoMode {
+    Apply(String),
+    Skip { resolved: String },
+}
+
+/// a-pure: a cron `required_runtime_mode` is ALWAYS a full-auto request
+/// (ELECTRON-3RQ). Ignore the incoming literal entirely; resolve "yolo" to
+/// the backend-native YOLO id (reusing the codex live-catalog alignment
+/// already in `normalize_requested_mode_for_available_values`), then
+/// look-before-leap: only `Apply` when the resolved id is actually in the
+/// advertised catalog, else `Skip`.
+pub(crate) fn resolve_required_full_auto_mode<'a>(
+    metadata: &AgentMetadata,
+    available_values: impl IntoIterator<Item = &'a str>,
+) -> RequiredFullAutoMode {
+    let values: Vec<String> = available_values.into_iter().map(ToOwned::to_owned).collect();
+    let resolved = normalize_requested_mode_for_available_values(metadata, "yolo", values.iter().map(String::as_str));
+    if values.iter().any(|v| v == &resolved) {
+        RequiredFullAutoMode::Apply(resolved)
+    } else {
+        RequiredFullAutoMode::Skip { resolved }
+    }
+}
+
 fn is_codex(metadata: &AgentMetadata) -> bool {
     matches!(metadata.backend.as_deref(), Some("codex"))
 }
@@ -300,5 +329,72 @@ mod tests {
     fn normalize_requested_mode_trims_and_returns_empty_for_blank() {
         let meta = metadata_with_yolo_id(Some("full-access"));
         assert_eq!(normalize_requested_mode(&meta, "   "), "");
+    }
+
+    // ── ELECTRON-3RQ: resolve_required_full_auto_mode (a-pure) ──────────
+    // All available-values are synthetic; no assertion depends on a real CLI.
+
+    /// Kimi (`yolo_id=NULL`, non-codex) resolves the full-auto request to the
+    /// generic `yolo` id and, when the catalog advertises it, applies it.
+    /// The function never receives the persisted literal — it always resolves
+    /// from "yolo", so a fossilised `bypassPermissions` cannot reach it.
+    #[test]
+    fn resolve_full_auto_kimi_applies_yolo_when_advertised() {
+        let meta = metadata_with_yolo_id(None);
+        assert_eq!(
+            resolve_required_full_auto_mode(&meta, ["yolo", "default", "read-only"]),
+            RequiredFullAutoMode::Apply("yolo".into())
+        );
+    }
+
+    /// Bad path: the resolved native YOLO is not in the live catalog →
+    /// look-before-leap `Skip` carrying the exact resolved id (specific
+    /// behaviour, not merely "not Apply").
+    #[test]
+    fn resolve_full_auto_skips_when_resolved_not_in_catalog() {
+        let meta = metadata_with_yolo_id(None);
+        assert_eq!(
+            resolve_required_full_auto_mode(&meta, ["default", "read-only"]),
+            RequiredFullAutoMode::Skip {
+                resolved: "yolo".into()
+            }
+        );
+    }
+
+    /// Regression (ELECTRON-3Q0): codex full-access alignment still holds when
+    /// resolving the full-auto request against a live catalog.
+    #[test]
+    fn resolve_full_auto_codex_aligns_to_live_catalog() {
+        let mut meta = metadata_with_yolo_id(Some("agent-full-access"));
+        meta.backend = Some("codex".into());
+
+        // Canonical id present → keep canonical.
+        assert_eq!(
+            resolve_required_full_auto_mode(&meta, ["agent-full-access", "read-only"]),
+            RequiredFullAutoMode::Apply("agent-full-access".into())
+        );
+        // Only the legacy token present → downgrade to legacy.
+        assert_eq!(
+            resolve_required_full_auto_mode(&meta, ["full-access", "read-only"]),
+            RequiredFullAutoMode::Apply("full-access".into())
+        );
+        // No full-access tier at all → resolved canonical id is unselectable → skip.
+        assert_eq!(
+            resolve_required_full_auto_mode(&meta, ["auto", "read-only"]),
+            RequiredFullAutoMode::Skip {
+                resolved: "agent-full-access".into()
+            }
+        );
+    }
+
+    /// Claude resolves the full-auto request to its native `bypassPermissions`
+    /// and applies it when advertised.
+    #[test]
+    fn resolve_full_auto_claude_applies_bypass_permissions() {
+        let meta = metadata_with_yolo_id(Some("bypassPermissions"));
+        assert_eq!(
+            resolve_required_full_auto_mode(&meta, ["bypassPermissions", "default"]),
+            RequiredFullAutoMode::Apply("bypassPermissions".into())
+        );
     }
 }

--- a/crates/aionui-conversation/src/turn_orchestrator.rs
+++ b/crates/aionui-conversation/src/turn_orchestrator.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use aionui_ai_agent::types::{BuildTaskOptions, SendMessageData};
-use aionui_ai_agent::{AgentError, AgentInstance, AgentSendError, AgentSessionKind, IWorkerTaskManager};
+use aionui_ai_agent::{
+    AgentError, AgentInstance, AgentSendError, AgentSessionKind, IWorkerTaskManager, RequiredFullAutoApplication,
+};
 use aionui_common::{AgentType, ConversationStatus, ErrorChain, now_ms};
 use aionui_db::models::ConversationRow;
 use tokio::sync::oneshot;
@@ -223,12 +225,35 @@ impl ConversationTurnOrchestrator {
                 .filter(|mode| !mode.is_empty())
             {
                 match apply_required_runtime_mode(&agent, backend.as_deref(), mode).await {
-                    Ok(()) => {
+                    Ok(RequiredFullAutoApplication::Applied { effective }) => {
                         info!(
                             conversation_id = %input.conv_id,
                             turn_id = %input.turn_id,
                             mode,
                             "Confirmed required runtime mode before agent turn"
+                        );
+                        if effective != mode {
+                            info!(
+                                requested = %mode,
+                                effective = %effective,
+                                backend = ?backend,
+                                conversation_id = %input.conv_id,
+                                "cron required mode remapped to backend-native full-auto"
+                            );
+                        }
+                    }
+                    Ok(RequiredFullAutoApplication::Skipped { resolved }) => {
+                        // look-before-leap: the resolved native YOLO is not
+                        // selectable on this backend. The sunk method already
+                        // logged a warn with backend/conversation_id/resolved;
+                        // keep the session's already-resolved mode and continue
+                        // this turn rather than failing the whole turn.
+                        info!(
+                            conversation_id = %input.conv_id,
+                            turn_id = %input.turn_id,
+                            mode,
+                            resolved = %resolved,
+                            "Skipped required runtime mode override — keeping session mode"
                         );
                     }
                     Err(err) => {
@@ -649,10 +674,19 @@ async fn apply_required_runtime_mode(
     agent: &AgentInstance,
     backend: Option<&str>,
     mode: &str,
-) -> Result<(), AgentError> {
+) -> Result<RequiredFullAutoApplication, AgentError> {
+    // a-pure (ELECTRON-3RQ): for metadata-bearing ACP agents (Kimi et al.),
+    // resolve cron's full-auto request to the backend-native YOLO id and apply
+    // it look-before-leap. This logic is sunk into aionui-ai-agent because the
+    // `yolo_id` it needs is only visible on the ACP manager's metadata.
+    if let Some(app) = agent.apply_required_full_auto_mode().await? {
+        return Ok(app);
+    }
+    // Retained legacy path for non-ACP variants (claude/codex Session, aionrs):
+    // codex ELECTRON-3Q0 catalog alignment + native pass-through.
     let effective = resolve_required_runtime_mode(agent, backend, mode).await;
     agent.set_config_option("mode", &effective).await?;
-    Ok(())
+    Ok(RequiredFullAutoApplication::Applied { effective })
 }
 
 fn send_error_display_message(error: &AgentSendError) -> String {


### PR DESCRIPTION
## Summary

Cron-triggered Kimi (and other non-Claude) agents always failed with a red error card — `UNKNOWN_UPSTREAM_ERROR` / `Value 'bypassPermissions' is not selectable for config option 'mode'` — while the same agent worked fine in interactive chat. This PR makes a cron turn's full-auto request resolve to the backend-native YOLO mode instead of applying a persisted, backend-specific literal. Fixes ELECTRON-3RQ (Sentry 136752556).

## Root cause

- On a cron run, the persisted `agent_config.mode` literal (here a legacy Claude-only `bypassPermissions`) was passed through as `required_runtime_mode` and applied per turn **without normalizing it for the target backend**.
- The normalization that shipped in v0.1.52 only covered `codex + agent-full-access` (ELECTRON-3Q0); it did not cover Kimi + `bypassPermissions`.
- Applying `set_config_option("mode", "bypassPermissions")` on a Kimi session hit a value that is not in Kimi's advertised selectable modes, so our own `resolve_set_path` rejected it as `ValueNotSelectable` and raised `bad_request` **before the request ever left the process**.
- `turn_orchestrator` escalated that error to a whole-turn `Failed`, which the frontend classified as `UNKNOWN_UPSTREAM_ERROR`.
- Interactive `send_message` and the team path pass `required_runtime_mode=None`, so they never entered this path — which is why direct chat was unaffected, and why only non-Claude backends broke (Claude natively supports `bypassPermissions`).

The failure happens entirely inside our code before egress, so it reproduces even when the Kimi provider is fully healthy.

## Approach

Single-point convergence in AionCore, with no schema change and no data migration:

- A cron turn is, by contract, always a full-auto request. The apply path now **ignores the persisted literal** and re-resolves to the current backend's native YOLO id via the existing `normalize_requested_mode_for_available_values` (reusing the codex ELECTRON-3Q0 live-catalog alignment).
- Look-before-leap: if the resolved YOLO id is in the backend's live catalog, apply it; if it is not, log a `warn` and **skip the override while keeping the session's resolved mode**, instead of failing the whole turn.
- If the live catalog cannot be read, fall back to the conservative pre-fix behavior (no error-swallowing is widened).
- This covers both fossilised (legacy literal) and newly created cron tasks at runtime.

## Changed files (AionCore only)

- `crates/aionui-ai-agent/src/manager/acp/mode_normalize.rs` — new `RequiredFullAutoMode` enum + `resolve_required_full_auto_mode` pure function + unit tests.
- `crates/aionui-ai-agent/src/manager/acp/agent.rs` — `RequiredFullAutoApplication` enum, `live_mode_catalog_ids`, `apply_required_full_auto_mode`.
- `crates/aionui-ai-agent/src/agent_task.rs` — `AgentInstance` forwarder (non-ACP variants return `Ok(None)` to keep the legacy path) + dispatch test.
- `crates/aionui-ai-agent/src/manager/acp/mod.rs`, `crates/aionui-ai-agent/src/lib.rs` — re-export the new enum.
- `crates/aionui-conversation/src/turn_orchestrator.rs` — call site dispatches to the new method; `Applied`/`Skipped` produce `info`/`warn` logs and continue the turn; the preserved ELECTRON-3Q0 codex logic stays in place.

`crates/aionui-cron/src/executor.rs` is intentionally unchanged.

## Observability

`remapped` is logged at `info`, `skip` at `warn`, both inside the new method. Neither log includes sensitive payloads, per the repository logging rules.

## Testing

Run in the AionCore worktree and again at the full pre-push gate:

- `cargo fmt --all -- --check` — pass.
- `cargo clippy -p aionui-ai-agent -p aionui-conversation -- -D warnings` — clean.
- `cargo test -p aionui-ai-agent -p aionui-conversation` — 0 failed. Adds 4 `resolve_required_full_auto_mode` cases (Kimi apply, skip-not-in-catalog, codex ELECTRON-3Q0 alignment, Claude `bypassPermissions`) and a non-ACP `Ok(None)` dispatch test; preserved ELECTRON-3Q0 catalog tests stay green.
- `just push` full workspace gate: `cargo nextest run --workspace` — 7483 passed, 0 failed.

### Verification caveats

- Not exercised: real Kimi/Claude/codex CLI end-to-end cron runs. All tests use synthetic available-values; "Kimi advertises `yolo`" is a diagnostics-snapshot inference, and per the repo's standing rule no assertion is made about real CLI behavior.
- The Claude cron control group (native `bypassPermissions` still succeeds) is inferred from reproduction logs and the baseline mechanism, not independently re-run with a live Claude session.

## Risk

- The apply path is shared by all backend cron turns; the preserved legacy branch plus new regression tests guard against regressing codex full-access (ELECTRON-3Q0) and the Claude native success path.
- Skip (non-failing) triggers only under the exact condition "catalog read succeeded AND resolved YOLO not selectable"; a catalog read failure keeps the conservative hard-fail path.
- `RequiredFullAutoApplication` is a new public API exported from `aionui-ai-agent` and consumed by `aionui-conversation` — a cross-crate contract addition (clippy verified no follow-on warnings).

## Out of scope

The AionUi source path where `canEditAgentConfig=false` lets a fossilised `agent_config.mode` survive is orthogonal to this runtime fix and is a candidate follow-up issue.
