### PR TITLE
fix(team): fall through to cached catalog when live slash-command list is empty

### DIFF
--- a/crates/aionui-app/src/router/team_conversation_adapters.rs
+++ b/crates/aionui-app/src/router/team_conversation_adapters.rs
@@ -184,12 +184,28 @@ impl TeamConversationAdapters {
     /// static codex builtin catalog. Returns `None` when none resolve (chain (d)).
     async fn resolve_slash_catalog(&self, conversation_id: &str) -> Option<(Vec<String>, SlashCatalogSource)> {
         // (a) live: a running backend session's current capabilities are the
-        // freshest, authoritative source (even if the list happens to be empty).
+        // freshest, authoritative source. A NON-EMPTY list is authoritative and
+        // short-circuits the chain. An EMPTY live list is NOT treated as
+        // authoritative here: a backend's live `slash_commands` can be transiently
+        // empty before its discovery handshake completes (e.g. claude's
+        // `control_request{initialize}` response has not landed yet, so
+        // `discovered_caps.slash_commands` is still `[]`), yet the same commands
+        // are already present in the persisted snapshot (b). Returning the empty
+        // live list would yield `CatalogEmpty`, disable every team slash command
+        // (e.g. `/compact`), and force the wrapped-wake fallback — masking
+        // commands the backend genuinely supports. So an empty live list falls
+        // through to cached/static instead of short-circuiting.
         if let Some(task) = self.task_manager.get_task(conversation_id) {
             match task.get_slash_commands().await {
                 Ok(items) => {
-                    let names = items.into_iter().map(|item| item.command).collect();
-                    return Some((names, SlashCatalogSource::Live));
+                    let names: Vec<String> = items.into_iter().map(|item| item.command).collect();
+                    if let Some(adopted) = live_catalog_or_none(names) {
+                        return Some((adopted, SlashCatalogSource::Live));
+                    }
+                    // Empty live list: fall through to cached/static. A backend
+                    // that genuinely advertises no commands surfaces as an empty
+                    // cached snapshot or a final `None`, both of which correctly
+                    // degrade to the wrapped wake.
                 }
                 // A live fetch fault is caught only here (composition layer); the
                 // raw error exists nowhere else, so log it at `warn` before
@@ -323,6 +339,32 @@ impl TeamConversationAdapters {
         }
 
         None
+    }
+}
+
+/// Decide whether a live-fetched slash-command catalog should be adopted as the
+/// authoritative result, or whether the degradation chain should keep falling
+/// through to cached/static.
+///
+/// Returns:
+/// - `Some(names)` when the live list is non-empty — a populated live catalog is
+///   the freshest, authoritative source and short-circuits the chain.
+/// - `None` when the live list is empty — a backend's live `slash_commands` can
+///   be transiently empty before its discovery handshake completes (e.g. the
+///   claude backend's `control_request{initialize}` response has not landed yet,
+///   so `discovered_caps.slash_commands` is still `[]`), yet the same commands
+///   may already be present in the persisted snapshot. Treating the empty live
+///   list as authoritative would yield `CatalogEmpty`, disable every team slash
+///   command (e.g. `/compact`), and force the wrapped-wake fallback — masking
+///   commands the backend genuinely supports. Returning `None` lets the chain
+///   reach the cached snapshot instead. A backend that genuinely advertises no
+///   commands surfaces as an empty cached snapshot or a final unresolved `None`,
+///   both of which correctly degrade to the wrapped wake.
+fn live_catalog_or_none(names: Vec<String>) -> Option<Vec<String>> {
+    if names.is_empty() {
+        None
+    } else {
+        Some(names)
     }
 }
 
@@ -584,6 +626,28 @@ mod tests {
         // (caller logs a `warn` and falls through to the next catalog source).
         assert_eq!(parse_available_command_names("not json"), None);
         assert_eq!(parse_available_command_names("{}"), None);
+    }
+
+    #[test]
+    fn live_catalog_adopted_only_when_non_empty() {
+        // A populated live catalog is adopted as authoritative and short-circuits
+        // the degradation chain.
+        assert_eq!(
+            live_catalog_or_none(vec!["compact".to_owned(), "init".to_owned()]),
+            Some(vec!["compact".to_owned(), "init".to_owned()])
+        );
+        // A single command is still a valid live catalog.
+        assert_eq!(
+            live_catalog_or_none(vec!["compact".to_owned()]),
+            Some(vec!["compact".to_owned()])
+        );
+        // An EMPTY live list is NOT adopted: it must fall through to cached/static
+        // so a backend whose live `slash_commands` is transiently empty (e.g. the
+        // claude backend before its `initialize` discovery response lands) can
+        // still be served from the persisted snapshot. Returning the empty list
+        // here would yield `CatalogEmpty` and mask supported commands (regression
+        // fixed for `/compact` in team mode, issue #3750).
+        assert_eq!(live_catalog_or_none(Vec::<String>::new()), None);
     }
 
     #[test]


### PR DESCRIPTION
## Root cause

In team mode, a backend-native slash command such as `/compact` is silently treated as ordinary text and wrapped in the `## New Messages` wake payload, so the agent never receives the bare command and replies conversationally instead of executing it.

`resolve_slash_catalog` degrades live → cached → static. The **live** arm short-circuits on **any** `Ok` result from the session, **including an empty list**:

```rust
Ok(items) => {
    let names = items.into_iter().map(|item| item.command).collect();
    return Some((names, SlashCatalogSource::Live));   // returns even when empty
}
```

A backend's live `slash_commands` can be transiently empty before its discovery handshake completes. For the claude backend, `ClaudeSessionBackend::capabilities()` merges `discovered_caps.slash_commands` only once the `control_request{initialize}` control response lands (`sniff_control_initialize`); until then it is `[]`. Returning that empty live list yields `CatalogEmpty`, which disables **every** team slash command and forces the wrapped-wake fallback — even though the same commands are already present in the persisted `agent_metadata.available_commands` snapshot (chain arm b).

## Evidence (real captured data, not inference)

Reproduced on v2.1.41+ with a team whose Leader is claude (`transport: CliAssumed`) and a member is codex.

**1. The failure reply is generated by the agent, not AionCore.** The string `` `/compact` 是内置命令… `` does not exist anywhere in this repo. The persisted claude `thinking` block shows the agent reasoning about it but not executing:

> "The user typed `/compact` which is a built-in CLI command… I should acknowledge this is a built-in command and not invoke any skill…"

**2. The same backend executes `/compact` correctly when sent bare (non-team).** A direct (non-team) claude conversation returns `Not enough messages to compact.` — i.e. the native compact path ran. The team path differs only in that the command is wrapped, so claude never sees a bare `/compact`.

**3. The persisted snapshot already advertises `compact`.** `agent_metadata.available_commands` for the claude agent (`2d23ff1c`) contains `{"name":"compact","description":"Free up context by summarizing the conversation so far"}`. So arm (b) of the chain would resolve the command — it is never reached because arm (a) returns the empty live list first.

## Fix

Adopt the live catalog **only when non-empty**. An empty live list falls through to cached/static. The decision is extracted into `live_catalog_or_none` so the degradation boundary has a unit test (the chain previously had none — which is how this slipped in). A backend that genuinely advertises no commands still degrades correctly: the cached snapshot is empty or the chain ends at `None`, both yielding the wrapped wake.

This makes no claim about any external CLI's behavior — it only stops a transiently-empty live list from masking a populated persisted snapshot.

## Verification

- `cargo check -p aionui-app` ✅
- `cargo test -p aionui-app --lib` → 18 passed (incl. new `live_catalog_adopted_only_when_non_empty`) ✅
- `cargo test -p aionui-team --test e2e_team_flow` → 29 passed, 0 failed — all existing catalog tests (`recognized_command_is_sent_bare_to_member/lead`, `unrecognized_slash_and_plain_text_fall_back_to_wrapped_wake`, `catalog_unavailable_falls_back_to_wrapped_wake`, `empty_catalog_logs_warn_and_falls_back_to_wrapped_wake`) still green ✅

Closes #3750.