### PR TITLE
chore(acp): bump dimcode and sigit registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -19,7 +19,7 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.2.36"
+      "version": "0.2.38"
     },
     "dirac": {
       "registry_json_id": "dirac",
@@ -58,7 +58,7 @@
     "sigit": {
       "registry_json_id": "sigit",
       "package": "@smbcloud/sigit",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "skip_version_probe": true
     }
   }


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Two drifts since #697: `dimcode` 0.2.36 -> 0.2.38 and `@smbcloud/sigit` 1.5.0 -> 1.5.1 in `crates/aionui-runtime/resources/acp-registry-npx-lock.json`. Lock-only change, each bump backed by a fresh ACP probe of the exact pinned version.

| backend | package | old | new | initialize | session/new |
|---|---|---|---|---|---|
| dimcode | dimcode | 0.2.36 | 0.2.38 | ok (agentInfo 0.2.38) | auth required (-32000, provider credentials) |
| sigit | @smbcloud/sigit | 1.5.0 | 1.5.1 | ok (agentInfo 1.5.1) | success (local-inference model options) |

Other 9 Registry-pinned packages match the audited snapshot — no drift. Drifted but not upgraded: none. No newly listed Registry agents vs the 2026-07-28 baseline. The `mimo-code` lock entry (non-Registry builtin, #700) has no Registry counterpart and is correctly excluded from drift auditing.

## Registry snapshot

- Audit pinned to release tag [`v2026.07.28-05772e9`](https://cdn.agentclientprotocol.com/registry/v1/v2026.07.28-05772e9/registry.json) of `agentclientprotocol/registry` (newest release at audit time), fetched via the versioned CDN path for reproducibility.

## Validation

- `cargo test -p aionui-runtime -p aionui-ai-agent` — pass
- Full `just push` gate (migration check, lint, fmt, `cargo nextest run --workspace`) — pass on re-run. The first gate attempt failed on two `prompt_pipeline_integration` tests due to disk exhaustion (`no space left on device` mid-run); after freeing stale build caches both tests pass in isolation and the full gate passes. Gate run with the host-injected `AIONUI_LOG_DIR` unset (see #695 for that pre-existing environment sensitivity).

## Logging

No logging changes: lock-only version bumps; existing startup/session error paths already identify a failing agent by backend.