### PR TITLE
fix(conversation): bind canonical ACP resume sessions

### DIFF
--- a/crates/aionui-api-types/src/conversation.rs
+++ b/crates/aionui-api-types/src/conversation.rs
@@ -62,6 +62,10 @@ pub struct CreateConversationRequest {
     pub assistant: Option<AssistantConversationRequest>,
     pub source: Option<ConversationSource>,
     pub channel_chat_id: Option<String>,
+    /// Existing backend session to resume when materializing an externally
+    /// discovered ACP conversation. Ordinary new conversations leave this unset.
+    #[serde(default)]
+    pub resume_session_id: Option<String>,
     pub extra: serde_json::Value,
 }
 
@@ -339,6 +343,7 @@ mod tests {
             },
             "source": "aionui",
             "channel_chat_id": "user:123",
+            "resume_session_id": "thread-existing",
             "extra": { "workspace": "/project" }
         });
         let req: CreateConversationRequest = serde_json::from_value(raw).unwrap();
@@ -362,6 +367,7 @@ mod tests {
         );
         assert_eq!(req.source, Some(ConversationSource::Aionui));
         assert_eq!(req.channel_chat_id.as_deref(), Some("user:123"));
+        assert_eq!(req.resume_session_id.as_deref(), Some("thread-existing"));
         assert_eq!(req.extra["workspace"], "/project");
     }
 
@@ -378,6 +384,7 @@ mod tests {
         assert!(req.assistant.is_none());
         assert!(req.source.is_none());
         assert!(req.channel_chat_id.is_none());
+        assert!(req.resume_session_id.is_none());
     }
 
     #[test]

--- a/crates/aionui-app/src/router/team_conversation_adapters.rs
+++ b/crates/aionui-app/src/router/team_conversation_adapters.rs
@@ -392,6 +392,7 @@ impl TeamConversationProvisioningPort for TeamConversationAdapters {
                     }),
                     source: None,
                     channel_chat_id: None,
+                    resume_session_id: None,
                     extra: request.extra,
                 },
             )

--- a/crates/aionui-app/tests/work_dir_e2e.rs
+++ b/crates/aionui-app/tests/work_dir_e2e.rs
@@ -26,6 +26,7 @@ async fn conversation_workspace_uses_work_dir() {
         assistant: None,
         source: None,
         channel_chat_id: None,
+        resume_session_id: None,
         extra: serde_json::json!({}),
     };
     let response = state.service.create("system_default_user", request).await.unwrap();
@@ -64,6 +65,7 @@ async fn user_specified_workspace_is_not_overridden() {
         assistant: None,
         source: None,
         channel_chat_id: None,
+        resume_session_id: None,
         extra: serde_json::json!({
             "workspace": custom_workspace.path().to_str().unwrap()
         }),
@@ -98,6 +100,7 @@ async fn workspace_defaults_to_data_dir_when_work_dir_equals_data_dir() {
         assistant: None,
         source: None,
         channel_chat_id: None,
+        resume_session_id: None,
         extra: serde_json::json!({}),
     };
     let response = state.service.create("system_default_user", request).await.unwrap();

--- a/crates/aionui-channel/src/message_service.rs
+++ b/crates/aionui-channel/src/message_service.rs
@@ -177,6 +177,7 @@ impl ChannelMessageService {
             }),
             source: Some(source),
             channel_chat_id: session.chat_id.clone(),
+            resume_session_id: None,
             extra,
         };
 

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -744,6 +744,15 @@ impl ConversationService {
         let id = generate_short_id();
         let now = now_ms();
         let source = req.source.unwrap_or(ConversationSource::Aionui);
+        let resume_session_id = match req.resume_session_id.as_deref() {
+            Some(value) if value.trim().is_empty() => {
+                return Err(ConversationError::BadRequest {
+                    reason: "resume_session_id must not be empty".into(),
+                });
+            }
+            Some(value) => Some(value.trim().to_owned()),
+            None => None,
+        };
 
         let mut extra = req.extra;
 
@@ -773,6 +782,12 @@ impl ConversationService {
         };
         let explicit_type = req.r#type;
         let effective_type = resolve_create_agent_type(explicit_type, assistant_snapshot.as_ref())?;
+
+        if resume_session_id.is_some() && effective_type != AgentType::Acp {
+            return Err(ConversationError::BadRequest {
+                reason: "resume_session_id is only accepted for ACP conversations".into(),
+            });
+        }
 
         if !effective_type.supports_new_conversation() {
             info!(
@@ -1220,6 +1235,19 @@ impl ConversationService {
         if effective_type == AgentType::Acp {
             self.create_acp_session_row(&id, &extra, assistant_snapshot.as_ref())
                 .await?;
+            if let Some(session_id) = resume_session_id.as_deref() {
+                let updated = self
+                    .acp_session_repo
+                    .update_session_id(&id, session_id)
+                    .await
+                    .map_err(|e| ConversationError::internal(format!("Failed to bind resumed ACP session: {e}")))?;
+                if !updated {
+                    return Err(ConversationError::internal(
+                        "Failed to bind resumed ACP session: acp_session row was not found",
+                    ));
+                }
+                info!("Bound conversation to an existing ACP session");
+            }
         }
 
         if let Some(snapshot) = assistant_snapshot.as_ref() {

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -908,6 +908,10 @@ impl StubAcpSessionRepo {
         self.runtime_state_saves.lock().unwrap().clone()
     }
 
+    fn session_id(&self) -> Option<String> {
+        self.session_id.lock().unwrap().clone()
+    }
+
     fn row_for(&self, conversation_id: &str) -> AcpSessionRow {
         AcpSessionRow {
             conversation_id: conversation_id.to_owned(),
@@ -2419,6 +2423,47 @@ async fn clone_without_source_creates_new() {
     let events = broadcaster.take_events();
     assert_eq!(events.len(), 1);
     assert_eq!(events[0].data["action"], "created");
+}
+
+#[tokio::test]
+async fn create_binds_an_explicit_acp_resume_session_before_returning() {
+    let acp_repo = Arc::new(StubAcpSessionRepo::default());
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service_with_resolver_and_acp_session_repo(
+        Arc::new(FixedSkillResolver { names: vec![] }),
+        acp_repo.clone(),
+    );
+    let workspace = ensure_test_workspace_path();
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "name": "Canonical task",
+        "resume_session_id": "thread-existing",
+        "extra": {
+            "workspace": workspace,
+            "backend": "codex"
+        }
+    }))
+    .unwrap();
+
+    let response = svc.create("user_1", req).await.unwrap();
+
+    assert_eq!(response.name, "Canonical task");
+    assert_eq!(acp_repo.session_id().as_deref(), Some("thread-existing"));
+}
+
+#[tokio::test]
+async fn create_rejects_resume_session_for_non_acp_conversation() {
+    let (svc, _broadcaster, _repo, _task_mgr) = make_service();
+    let workspace = ensure_test_workspace_path();
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "aionrs",
+        "resume_session_id": "thread-existing",
+        "extra": { "workspace": workspace }
+    }))
+    .unwrap();
+
+    let error = svc.create("user_1", req).await.unwrap_err();
+
+    assert!(matches!(error, ConversationError::BadRequest { reason } if reason.contains("only accepted for ACP")));
 }
 
 // ── Reset tests ───────────────────────────────────────────────────

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -556,6 +556,7 @@ impl JobExecutor {
             assistant,
             source: None,
             channel_chat_id: None,
+            resume_session_id: None,
             extra,
         };
 


### PR DESCRIPTION
## What changed

- accept an optional `resume_session_id` when creating a conversation
- reject empty values and non-ACP conversation types
- bind the existing ACP session immediately after creating the conversation session row
- keep ordinary team, channel, cron, and work-directory callers explicitly unbound
- cover request deserialization, successful ACP binding, and non-ACP rejection

## Why

Canonical conversations discovered outside AionCore already have a backend session identity. The create API previously had no way to persist that identity while materializing the conversation, so a later resume could target a different session. This change carries the existing session through the create boundary and binds it before the response is returned.

## Impact

Imported canonical ACP conversations resume their original backend session. Ordinary new conversations are unchanged because the new field defaults to `None`.

## Validation

- `just push -u fork codex/fix-canonical-resume-session-20260729` (repository full pre-push gate)
