### PR TITLE
feat(team): support multiple working sessions per team

### DIFF
--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -157,14 +157,15 @@ pub use system::{
     UpdateClientPreferencesRequest, UpdateSettingsRequest,
 };
 pub use team::{
-    AddAgentRequest, CancelTeamChildTurnRequest, CancelTeamRunRequest, CreateTeamRequest, PauseTeamSlotRequest,
-    RenameAgentRequest, RenameTeamRequest, SendAgentMessageRequest, SendTeamMessageRequest, TeamAgentInput,
-    TeamAgentRemovedPayload, TeamAgentRenamedPayload, TeamAgentResponse, TeamAgentRuntimeStatus,
-    TeamAgentRuntimeStatusPayload, TeamAgentSpawnedPayload, TeamAgentStatusPayload, TeamChildTurnPayload,
-    TeamListResponse, TeamMcpRuntimeConfig, TeamMessageEnqueueStatus, TeamResponse, TeamRunAckResponse, TeamRunPayload,
-    TeamRunSource, TeamRunStateResponse, TeamRunStatus, TeamRunTargetRole, TeamRuntimeSeed,
-    TeamSendMessageQueuedResponse, TeamSessionBinding, TeamSessionPhase, TeamSessionStatus, TeamSessionStatusPayload,
-    TeamSlotBlockedReason, TeamSlotWorkChangedPayload, TeamSlotWorkPayload, TeamSlotWorkState, TeammateMessagePayload,
+    AddAgentRequest, CancelTeamChildTurnRequest, CancelTeamRunRequest, CreateTeamRequest, CreateTeamSessionRequest,
+    PauseTeamSlotRequest, RenameAgentRequest, RenameTeamRequest, RenameTeamSessionRequest, SendAgentMessageRequest,
+    SendTeamMessageRequest, TeamAgentInput, TeamAgentRemovedPayload, TeamAgentRenamedPayload, TeamAgentResponse,
+    TeamAgentRuntimeStatus, TeamAgentRuntimeStatusPayload, TeamAgentSpawnedPayload, TeamAgentStatusPayload,
+    TeamChildTurnPayload, TeamListResponse, TeamMcpRuntimeConfig, TeamMessageEnqueueStatus, TeamResponse,
+    TeamRunAckResponse, TeamRunPayload, TeamRunSource, TeamRunStateResponse, TeamRunStatus, TeamRunTargetRole,
+    TeamRuntimeSeed, TeamSendMessageQueuedResponse, TeamSessionAgentResponse, TeamSessionBinding, TeamSessionPhase,
+    TeamSessionResponse, TeamSessionStatus, TeamSessionStatusPayload, TeamSlotBlockedReason,
+    TeamSlotWorkChangedPayload, TeamSlotWorkPayload, TeamSlotWorkState, TeammateMessagePayload,
 };
 pub use team_mcp::{TEAM_MCP_SERVER_NAME, TeamMcpStdioConfig};
 pub use team_tools::{

--- a/crates/aionui-api-types/src/team.rs
+++ b/crates/aionui-api-types/src/team.rs
@@ -171,6 +171,11 @@ pub struct TeamSessionBinding {
     pub slot_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub role: Option<String>,
+    /// Working session id (migration 030). Absent on conversations written
+    /// before multi-session support; the service treats absence as the team's
+    /// primary session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
     #[serde(default)]
     pub runtime_seed: TeamRuntimeSeed,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -199,6 +204,7 @@ impl TeamSessionBinding {
             team_id,
             slot_id: extra_string_field(extra, "slot_id"),
             role: extra_string_field(extra, "role"),
+            session_id: extra_string_field(extra, "sessionId").or_else(|| extra_string_field(extra, "session_id")),
             runtime_seed: TeamRuntimeSeed {
                 backend: extra_string_field(extra, "backend"),
                 session_mode: extra_string_field(extra, "session_mode"),
@@ -468,6 +474,11 @@ pub struct TeamResponse {
     pub leader_assistant_id: Option<String>,
     pub created_at: TimestampMs,
     pub updated_at: TimestampMs,
+    /// Currently active working session id (migration 030). Absent for
+    /// legacy responses that predate multi-session support; the client
+    /// treats absence as "the team's single/primary session".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_session_id: Option<String>,
 }
 
 /// Type alias for team list responses.
@@ -593,6 +604,59 @@ pub struct TeammateMessagePayload {
     pub content: String,
     pub from_slot_id: String,
     pub from_name: String,
+}
+
+// ---------------------------------------------------------------------------
+// Team working sessions (migration 030)
+// ---------------------------------------------------------------------------
+
+/// A single per-slot conversation binding within a session response.
+///
+/// Maps each roster `slot_id` to the concrete `conversation_id` minted for
+/// this session. The primary session mirrors the ids already in the team
+/// roster; secondary sessions carry fresh ids.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TeamSessionAgentResponse {
+    pub slot_id: String,
+    pub conversation_id: String,
+}
+
+/// A working session owned by a team.
+///
+/// Each session has its own per-slot conversations, mailbox messages, and
+/// task board, isolated by `session_id`. The team roster and `session_mode`
+/// stay shared at the team level. `is_primary` marks the auto-created default
+/// session that every team owns and that cannot be deleted.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TeamSessionResponse {
+    pub id: String,
+    pub team_id: String,
+    pub name: String,
+    pub is_primary: bool,
+    /// Per-slot conversation bindings for this session. Populated by the
+    /// `GET /api/teams/{id}/sessions/{sid}` and
+    /// `POST /api/teams/{id}/sessions` endpoints; the list endpoint may omit
+    /// it for brevity.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agents: Vec<TeamSessionAgentResponse>,
+    pub created_at: TimestampMs,
+    pub updated_at: TimestampMs,
+}
+
+/// Request body for `POST /api/teams/{id}/sessions` (create a new session).
+///
+/// `name` defaults to a localized "Session N" chosen by the client; the
+/// server rejects a name that duplicates an existing session in the team.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateTeamSessionRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// Request body for `PATCH /api/teams/{id}/sessions/{sid}` (rename a session).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RenameTeamSessionRequest {
+    pub name: String,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aionui-app/src/router/team_conversation_adapters.rs
+++ b/crates/aionui-app/src/router/team_conversation_adapters.rs
@@ -517,6 +517,12 @@ impl TeamConversationProvisioningPort for TeamConversationAdapters {
                 .and_then(serde_json::Value::as_str)
                 .filter(|s| !s.is_empty())
                 .map(str::to_owned),
+            session_id: extra
+                .get("sessionId")
+                .or_else(|| extra.get("session_id"))
+                .and_then(serde_json::Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(str::to_owned),
         }))
     }
 }

--- a/crates/aionui-db/migrations/030_team_sessions.sql
+++ b/crates/aionui-db/migrations/030_team_sessions.sql
@@ -1,0 +1,150 @@
+------------------------------------------------------------------------
+-- Team multi-session: a team may own multiple working sessions, each
+-- with its own per-slot conversations, mailbox messages, and task board.
+-- The team roster (backend / model / name / role) and `session_mode` stay
+-- shared at the team level; only the conversational state is partitioned
+-- by `session_id`.
+--
+-- Backward compatibility: every existing team gets exactly one "primary"
+-- session row (`is_primary = 1`), and its historical mailbox / task rows
+-- are backfilled onto that primary session. All callers that do not pass
+-- a `session_id` keep operating on the primary session, so pre-feature
+-- behaviour is preserved byte-for-byte.
+--
+-- Constraints intentionally omitted (per project convention, see 028):
+--   - no FOREIGN KEY
+--   - no CHECK constraint
+-- Enum / flag semantics live in SQL comments and are validated in the
+-- service layer (aionui-team). Business identities are TEXT; the INTEGER
+-- AUTOINCREMENT `id` on team_session_agents is an internal-only surrogate.
+--
+-- `session_id` naming note: the unrelated `team_agent_bindings.session_id`
+-- column is the ACP protocol session; this migration's `session_id` is the
+-- team working-session. They never co-occur on the same table.
+------------------------------------------------------------------------
+
+-- teams: current active working session pointer. NULL on legacy rows is
+-- resolved lazily to the primary session by the service layer, and is
+-- backfilled below for every existing team so it is never NULL in practice.
+ALTER TABLE teams ADD COLUMN active_session_id TEXT;
+
+-- A working session owned by a team. `is_primary = 1` marks the one
+-- session auto-created with the team; it cannot be deleted (service-layer
+-- guard) and is the fallback target for session_id-less callers.
+CREATE TABLE IF NOT EXISTS team_sessions (
+    id         TEXT    PRIMARY KEY NOT NULL,   -- stable identity (UUID v7 in app; 'primary_<team_id>' for backfill)
+    team_id    TEXT    NOT NULL,
+    name       TEXT    NOT NULL,               -- user-visible name
+    is_primary INTEGER NOT NULL DEFAULT 0,     -- 1 = auto-created default session, undeletable
+    created_at INTEGER NOT NULL,               -- epoch ms
+    updated_at INTEGER NOT NULL                -- epoch ms
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_sessions_team_id ON team_sessions(team_id);
+-- A team may have at most one primary session.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_team_sessions_one_primary ON team_sessions(team_id) WHERE is_primary = 1;
+-- Session names are unique within a team.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_team_sessions_team_name_unique ON team_sessions(team_id, name);
+
+-- Per-session, per-slot conversation binding. The team roster
+-- (`teams.agents` JSON) is the configuration template; this table holds
+-- the concrete conversation_id minted for each (session, slot) pair.
+-- The primary session's rows mirror the conversation_ids already present
+-- in `teams.agents` (backfilled below); secondary sessions get fresh ones.
+CREATE TABLE IF NOT EXISTS team_session_agents (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT, -- internal surrogate, not a business identity
+    session_id      TEXT    NOT NULL,
+    team_id         TEXT    NOT NULL,
+    slot_id         TEXT    NOT NULL,
+    conversation_id TEXT    NOT NULL,
+    created_at      INTEGER NOT NULL                          -- epoch ms
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_session_agents_session ON team_session_agents(session_id);
+CREATE INDEX IF NOT EXISTS idx_team_session_agents_team_slot ON team_session_agents(team_id, slot_id);
+CREATE INDEX IF NOT EXISTS idx_team_session_agents_conversation ON team_session_agents(conversation_id);
+-- One conversation per (session, slot).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_team_session_agents_session_slot_unique ON team_session_agents(session_id, slot_id);
+
+-- mailbox / team_tasks gain a session dimension. Nullable: NULL marks
+-- legacy rows the backfill below assigns to the primary session. After
+-- backfill, no row should remain NULL, but the column stays nullable so
+-- future schema evolution and tests can mint rows before session binding.
+ALTER TABLE mailbox ADD COLUMN session_id TEXT;
+ALTER TABLE team_tasks ADD COLUMN session_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_mailbox_team_session_to_read ON mailbox(team_id, session_id, to_agent_id, read);
+CREATE INDEX IF NOT EXISTS idx_team_tasks_team_session ON team_tasks(team_id, session_id);
+
+------------------------------------------------------------------------
+-- Backfill: seed one primary session per existing team, bind its slots'
+-- conversations into team_session_agents, point the team's
+-- active_session_id at it, and assign legacy mailbox / task rows to it.
+--
+-- The primary session id is deterministic ('primary_' || team_id) so the
+-- migration is idempotent: re-running the INSERT...WHERE NOT EXISTS and
+-- UPDATEs is a no-op. New teams created after this migration get a
+-- random UUID v7 id from the service layer instead.
+------------------------------------------------------------------------
+
+INSERT INTO team_sessions (id, team_id, name, is_primary, created_at, updated_at)
+SELECT
+    'primary_' || t.id,
+    t.id,
+    'Main',
+    1,
+    t.created_at,
+    t.updated_at
+FROM teams t
+WHERE NOT EXISTS (
+    SELECT 1 FROM team_sessions ts WHERE ts.team_id = t.id AND ts.is_primary = 1
+);
+
+-- Set the active session pointer for every team that does not yet have one.
+UPDATE teams
+SET active_session_id = 'primary_' || teams.id
+WHERE active_session_id IS NULL
+  AND teams.id IN (SELECT team_id FROM team_sessions WHERE is_primary = 1);
+
+-- Backfill per-slot conversation bindings for primary sessions from the
+-- roster JSON. `teams.agents` is a JSON array of objects each carrying a
+-- `slot_id` and a `conversation_id`. sqlite's json_each walks the array;
+-- the composite SELECT filters out pairs already bound (idempotent).
+-- `json_valid(...)` guards against a corrupted roster row: a malformed
+-- `agents` value skips this backfill for that team (its primary session
+-- still exists; the service layer reconciles bindings lazily) instead of
+-- aborting the whole migration and blocking app startup.
+INSERT INTO team_session_agents (session_id, team_id, slot_id, conversation_id, created_at)
+SELECT
+    ts.id,
+    ts.team_id,
+    je.value ->> '$.slot_id'           AS slot_id,
+    je.value ->> '$.conversation_id'   AS conversation_id,
+    ts.created_at
+FROM team_sessions ts
+JOIN teams t ON t.id = ts.team_id
+JOIN json_each(t.agents) AS je
+WHERE ts.is_primary = 1
+  AND json_valid(t.agents)
+  AND je.value ->> '$.slot_id' IS NOT NULL
+  AND je.value ->> '$.conversation_id' IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1
+      FROM team_session_agents tsa
+      WHERE tsa.session_id = ts.id
+        AND tsa.slot_id = je.value ->> '$.slot_id'
+  );
+
+-- Assign legacy mailbox rows to the owning team's primary session.
+-- Rows that already carry a session_id (written by new code paths) are
+-- left untouched.
+UPDATE mailbox
+SET session_id = 'primary_' || mailbox.team_id
+WHERE session_id IS NULL
+  AND mailbox.team_id IN (SELECT team_id FROM team_sessions WHERE is_primary = 1);
+
+-- Same for legacy task rows.
+UPDATE team_tasks
+SET session_id = 'primary_' || team_tasks.team_id
+WHERE session_id IS NULL
+  AND team_tasks.team_id IN (SELECT team_id FROM team_sessions WHERE is_primary = 1);

--- a/crates/aionui-db/src/lib.rs
+++ b/crates/aionui-db/src/lib.rs
@@ -43,7 +43,7 @@ pub use repository::oauth_token::UpsertOAuthTokenParams;
 pub use repository::provider::{CreateProviderParams, UpdateProviderParams};
 pub use repository::remote_agent::{CreateRemoteAgentParams, UpdateRemoteAgentParams};
 pub use repository::skill::{CreateSkillImportRecordParams, UpsertSkillParams};
-pub use repository::team::{UpdateTaskParams, UpdateTeamParams};
+pub use repository::team::{UpdateTaskParams, UpdateTeamParams, UpdateTeamSessionParams};
 pub use repository::{
     CreateAcpSessionParams, FeedbackDiagnosticsDbContext, FeedbackDiagnosticsProfile, FeedbackDiagnosticsProfileResult,
     FeedbackDiagnosticsRequest, FeedbackDiagnosticsResult, IAcpSessionRepository, IAgentMetadataRepository,

--- a/crates/aionui-db/src/models/mod.rs
+++ b/crates/aionui-db/src/models/mod.rs
@@ -39,5 +39,5 @@ pub use provider::Provider;
 pub use remote_agent::RemoteAgentRow;
 pub use skill::{SkillImportRecordRow, SkillRow};
 pub use system_settings::SystemSettings;
-pub use team::{MailboxMessageRow, TeamRow, TeamTaskRow};
+pub use team::{MailboxMessageRow, TeamRow, TeamSessionAgentRow, TeamSessionRow, TeamTaskRow};
 pub use user::User;

--- a/crates/aionui-db/src/models/team.rs
+++ b/crates/aionui-db/src/models/team.rs
@@ -22,6 +22,42 @@ pub struct TeamRow {
     pub project_id: Option<String>,
     /// Workspace folder binding; NULL until bound/backfilled.
     pub folder_id: Option<String>,
+    /// Currently active working session id. NULL only on legacy rows written
+    /// before migration 030; the service layer resolves it to the team's
+    /// primary session. Migration 030 backfills it for every existing team.
+    pub active_session_id: Option<String>,
+}
+
+/// Row mapping for the `team_sessions` table (migration 030).
+///
+/// A working session owned by a team. Each session has its own per-slot
+/// conversations (`team_session_agents`), mailbox messages, and task board.
+/// `is_primary = true` marks the one session auto-created with the team;
+/// it is undeletable and is the fallback target for session_id-less callers.
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct TeamSessionRow {
+    pub id: String,
+    pub team_id: String,
+    pub name: String,
+    /// SQLite stores booleans as INTEGER 0/1; sqlx maps this transparently.
+    pub is_primary: bool,
+    pub created_at: TimestampMs,
+    pub updated_at: TimestampMs,
+}
+
+/// Row mapping for the `team_session_agents` table (migration 030).
+///
+/// The concrete `conversation_id` minted for a `(session, slot)` pair. The
+/// team roster (`teams.agents` JSON) is the configuration template; this
+/// table holds the session-specific bindings.
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct TeamSessionAgentRow {
+    pub id: i64,
+    pub session_id: String,
+    pub team_id: String,
+    pub slot_id: String,
+    pub conversation_id: String,
+    pub created_at: TimestampMs,
 }
 
 /// Row mapping for the `mailbox` table.
@@ -43,6 +79,9 @@ pub struct MailboxMessageRow {
     pub files: Option<String>,
     pub read: bool,
     pub created_at: TimestampMs,
+    /// Owning team working session (migration 030). NULL only on legacy rows
+    /// not yet backfilled; new writes always carry it.
+    pub session_id: Option<String>,
 }
 
 /// Row mapping for the `team_tasks` table.
@@ -66,6 +105,9 @@ pub struct TeamTaskRow {
     pub metadata: Option<String>,
     pub created_at: TimestampMs,
     pub updated_at: TimestampMs,
+    /// Owning team working session (migration 030). NULL only on legacy rows
+    /// not yet backfilled; new writes always carry it.
+    pub session_id: Option<String>,
 }
 
 #[cfg(test)]
@@ -88,6 +130,7 @@ mod tests {
             updated_at: 0,
             project_id: None,
             folder_id: None,
+            active_session_id: None,
         };
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&row.agents).expect("agents should be valid JSON");
         assert!(parsed.is_empty());
@@ -106,6 +149,7 @@ mod tests {
             files: None,
             read: false,
             created_at: 0,
+            session_id: None,
         };
         assert_eq!(row.msg_type, "message");
     }
@@ -145,6 +189,7 @@ mod tests {
             metadata: Some(r#"{"priority":"high"}"#.into()),
             created_at: 1000,
             updated_at: 2000,
+            session_id: None,
         };
         let json = serde_json::to_string(&row).expect("serialize");
         let restored: TeamTaskRow = serde_json::from_str(&json).expect("deserialize");

--- a/crates/aionui-db/src/repository/sqlite_team.rs
+++ b/crates/aionui-db/src/repository/sqlite_team.rs
@@ -2,7 +2,7 @@ use aionui_common::now_ms;
 use sqlx::SqlitePool;
 
 use crate::error::DbError;
-use crate::models::{MailboxMessageRow, TeamRow, TeamTaskRow};
+use crate::models::{MailboxMessageRow, TeamRow, TeamSessionAgentRow, TeamSessionRow, TeamTaskRow};
 use crate::repository::team::{ITeamRepository, UpdateTaskParams, UpdateTeamParams};
 
 /// SQLite-backed implementation of [`ITeamRepository`].
@@ -23,8 +23,8 @@ impl ITeamRepository for SqliteTeamRepository {
 
     async fn create_team(&self, row: &TeamRow) -> Result<(), DbError> {
         sqlx::query(
-            "INSERT INTO teams (id, user_id, name, workspace, workspace_mode, agents, lead_agent_id, session_mode, agents_version, created_at, updated_at, project_id, folder_id) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO teams (id, user_id, name, workspace, workspace_mode, agents, lead_agent_id, session_mode, agents_version, created_at, updated_at, project_id, folder_id, active_session_id) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&row.id)
         .bind(&row.user_id)
@@ -39,6 +39,7 @@ impl ITeamRepository for SqliteTeamRepository {
         .bind(row.updated_at)
         .bind(&row.project_id)
         .bind(&row.folder_id)
+        .bind(&row.active_session_id)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -90,6 +91,9 @@ impl ITeamRepository for SqliteTeamRepository {
         if params.folder_id.is_some() {
             set_clauses.push("folder_id = ?");
         }
+        if params.active_session_id.is_some() {
+            set_clauses.push("active_session_id = ?");
+        }
 
         if set_clauses.is_empty() {
             return Ok(());
@@ -120,6 +124,9 @@ impl ITeamRepository for SqliteTeamRepository {
         if let Some(ref folder_id) = params.folder_id {
             query = query.bind(folder_id);
         }
+        if let Some(ref active_session_id) = params.active_session_id {
+            query = query.bind(active_session_id);
+        }
         query = query.bind(now_ms());
         query = query.bind(team_id);
 
@@ -146,8 +153,8 @@ impl ITeamRepository for SqliteTeamRepository {
     async fn write_message(&self, row: &MailboxMessageRow) -> Result<(), DbError> {
         sqlx::query(
             "INSERT INTO mailbox \
-                (id, team_id, to_agent_id, from_agent_id, type, content, summary, files, read, created_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (id, team_id, to_agent_id, from_agent_id, type, content, summary, files, read, created_at, session_id) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&row.id)
         .bind(&row.team_id)
@@ -159,12 +166,18 @@ impl ITeamRepository for SqliteTeamRepository {
         .bind(&row.files)
         .bind(row.read)
         .bind(row.created_at)
+        .bind(&row.session_id)
         .execute(&self.pool)
         .await?;
         Ok(())
     }
 
-    async fn read_unread_and_mark(&self, team_id: &str, to_agent_id: &str) -> Result<Vec<MailboxMessageRow>, DbError> {
+    async fn read_unread_and_mark(
+        &self,
+        team_id: &str,
+        session_id: &str,
+        to_agent_id: &str,
+    ) -> Result<Vec<MailboxMessageRow>, DbError> {
         // Use BEGIN IMMEDIATE for atomicity: prevents concurrent readers
         // from seeing the same unread messages.
         let mut tx = self.pool.begin().await?;
@@ -175,12 +188,13 @@ impl ITeamRepository for SqliteTeamRepository {
 
         let rows = sqlx::query_as::<_, MailboxMessageRow>(
             "SELECT id, team_id, to_agent_id, from_agent_id, \
-                    type, content, summary, files, read, created_at \
+                    type, content, summary, files, read, created_at, session_id \
              FROM mailbox \
-             WHERE team_id = ? AND to_agent_id = ? AND read = 0 \
+             WHERE team_id = ? AND session_id = ? AND to_agent_id = ? AND read = 0 \
              ORDER BY created_at ASC",
         )
         .bind(team_id)
+        .bind(session_id)
         .bind(to_agent_id)
         .fetch_all(&mut *tx)
         .await?;
@@ -188,9 +202,10 @@ impl ITeamRepository for SqliteTeamRepository {
         if !rows.is_empty() {
             sqlx::query(
                 "UPDATE mailbox SET read = 1 \
-                 WHERE team_id = ? AND to_agent_id = ? AND read = 0",
+                 WHERE team_id = ? AND session_id = ? AND to_agent_id = ? AND read = 0",
             )
             .bind(team_id)
+            .bind(session_id)
             .bind(to_agent_id)
             .execute(&mut *tx)
             .await?;
@@ -200,15 +215,21 @@ impl ITeamRepository for SqliteTeamRepository {
         Ok(rows)
     }
 
-    async fn peek_unread(&self, team_id: &str, to_agent_id: &str) -> Result<Vec<MailboxMessageRow>, DbError> {
+    async fn peek_unread(
+        &self,
+        team_id: &str,
+        session_id: &str,
+        to_agent_id: &str,
+    ) -> Result<Vec<MailboxMessageRow>, DbError> {
         let rows = sqlx::query_as::<_, MailboxMessageRow>(
             "SELECT id, team_id, to_agent_id, from_agent_id, \
-                    type, content, summary, files, read, created_at \
+                    type, content, summary, files, read, created_at, session_id \
              FROM mailbox \
-             WHERE team_id = ? AND to_agent_id = ? AND read = 0 \
+             WHERE team_id = ? AND session_id = ? AND to_agent_id = ? AND read = 0 \
              ORDER BY created_at ASC",
         )
         .bind(team_id)
+        .bind(session_id)
         .bind(to_agent_id)
         .fetch_all(&self.pool)
         .await?;
@@ -235,19 +256,21 @@ impl ITeamRepository for SqliteTeamRepository {
     async fn get_history(
         &self,
         team_id: &str,
+        session_id: &str,
         to_agent_id: &str,
         limit: Option<i64>,
     ) -> Result<Vec<MailboxMessageRow>, DbError> {
         let rows = if let Some(limit) = limit {
             sqlx::query_as::<_, MailboxMessageRow>(
                 "SELECT id, team_id, to_agent_id, from_agent_id, \
-                        type, content, summary, files, read, created_at \
+                        type, content, summary, files, read, created_at, session_id \
                  FROM mailbox \
-                 WHERE team_id = ? AND to_agent_id = ? \
+                 WHERE team_id = ? AND session_id = ? AND to_agent_id = ? \
                  ORDER BY created_at ASC \
                  LIMIT ?",
             )
             .bind(team_id)
+            .bind(session_id)
             .bind(to_agent_id)
             .bind(limit)
             .fetch_all(&self.pool)
@@ -255,12 +278,13 @@ impl ITeamRepository for SqliteTeamRepository {
         } else {
             sqlx::query_as::<_, MailboxMessageRow>(
                 "SELECT id, team_id, to_agent_id, from_agent_id, \
-                        type, content, summary, files, read, created_at \
+                        type, content, summary, files, read, created_at, session_id \
                  FROM mailbox \
-                 WHERE team_id = ? AND to_agent_id = ? \
+                 WHERE team_id = ? AND session_id = ? AND to_agent_id = ? \
                  ORDER BY created_at ASC",
             )
             .bind(team_id)
+            .bind(session_id)
             .bind(to_agent_id)
             .fetch_all(&self.pool)
             .await?
@@ -276,14 +300,23 @@ impl ITeamRepository for SqliteTeamRepository {
         Ok(())
     }
 
+    async fn delete_mailbox_by_session(&self, team_id: &str, session_id: &str) -> Result<(), DbError> {
+        sqlx::query("DELETE FROM mailbox WHERE team_id = ? AND session_id = ?")
+            .bind(team_id)
+            .bind(session_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     // ── Tasks ────────────────────────────────────────────────────────
 
     async fn create_task(&self, row: &TeamTaskRow) -> Result<(), DbError> {
         sqlx::query(
             "INSERT INTO team_tasks \
                 (id, team_id, subject, description, status, owner, \
-                 blocked_by, blocks, metadata, created_at, updated_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                 blocked_by, blocks, metadata, created_at, updated_at, session_id) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&row.id)
         .bind(&row.team_id)
@@ -296,17 +329,25 @@ impl ITeamRepository for SqliteTeamRepository {
         .bind(&row.metadata)
         .bind(row.created_at)
         .bind(row.updated_at)
+        .bind(&row.session_id)
         .execute(&self.pool)
         .await?;
         Ok(())
     }
 
-    async fn find_task_by_id(&self, team_id: &str, task_id: &str) -> Result<Option<TeamTaskRow>, DbError> {
-        let row = sqlx::query_as::<_, TeamTaskRow>("SELECT * FROM team_tasks WHERE team_id = ? AND id = ?")
-            .bind(team_id)
-            .bind(task_id)
-            .fetch_optional(&self.pool)
-            .await?;
+    async fn find_task_by_id(
+        &self,
+        team_id: &str,
+        session_id: &str,
+        task_id: &str,
+    ) -> Result<Option<TeamTaskRow>, DbError> {
+        let row =
+            sqlx::query_as::<_, TeamTaskRow>("SELECT * FROM team_tasks WHERE team_id = ? AND session_id = ? AND id = ?")
+                .bind(team_id)
+                .bind(session_id)
+                .bind(task_id)
+                .fetch_optional(&self.pool)
+                .await?;
         Ok(row)
     }
 
@@ -361,12 +402,14 @@ impl ITeamRepository for SqliteTeamRepository {
         Ok(())
     }
 
-    async fn list_tasks(&self, team_id: &str) -> Result<Vec<TeamTaskRow>, DbError> {
-        let rows =
-            sqlx::query_as::<_, TeamTaskRow>("SELECT * FROM team_tasks WHERE team_id = ? ORDER BY created_at ASC")
-                .bind(team_id)
-                .fetch_all(&self.pool)
-                .await?;
+    async fn list_tasks(&self, team_id: &str, session_id: &str) -> Result<Vec<TeamTaskRow>, DbError> {
+        let rows = sqlx::query_as::<_, TeamTaskRow>(
+            "SELECT * FROM team_tasks WHERE team_id = ? AND session_id = ? ORDER BY created_at ASC",
+        )
+        .bind(team_id)
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
         Ok(rows)
     }
 
@@ -424,6 +467,165 @@ impl ITeamRepository for SqliteTeamRepository {
 
     async fn delete_tasks_by_team(&self, team_id: &str) -> Result<(), DbError> {
         sqlx::query("DELETE FROM team_tasks WHERE team_id = ?")
+            .bind(team_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn delete_tasks_by_session(&self, team_id: &str, session_id: &str) -> Result<(), DbError> {
+        sqlx::query("DELETE FROM team_tasks WHERE team_id = ? AND session_id = ?")
+            .bind(team_id)
+            .bind(session_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    // ── Team Sessions (migration 030) ──────────────────────────────────
+
+    async fn create_team_session(&self, row: &TeamSessionRow) -> Result<(), DbError> {
+        sqlx::query(
+            "INSERT INTO team_sessions (id, team_id, name, is_primary, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&row.id)
+        .bind(&row.team_id)
+        .bind(&row.name)
+        .bind(row.is_primary)
+        .bind(row.created_at)
+        .bind(row.updated_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn list_team_sessions(&self, team_id: &str) -> Result<Vec<TeamSessionRow>, DbError> {
+        // Primary first (is_primary DESC), then by creation time — stable,
+        // predictable ordering for UI lists.
+        let rows = sqlx::query_as::<_, TeamSessionRow>(
+            "SELECT id, team_id, name, is_primary, created_at, updated_at \
+             FROM team_sessions \
+             WHERE team_id = ? \
+             ORDER BY is_primary DESC, created_at ASC",
+        )
+        .bind(team_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    async fn get_team_session(&self, session_id: &str) -> Result<Option<TeamSessionRow>, DbError> {
+        let row = sqlx::query_as::<_, TeamSessionRow>(
+            "SELECT id, team_id, name, is_primary, created_at, updated_at FROM team_sessions WHERE id = ?",
+        )
+        .bind(session_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    async fn update_team_session(
+        &self,
+        session_id: &str,
+        params: &crate::repository::team::UpdateTeamSessionParams,
+    ) -> Result<(), DbError> {
+        let mut set_clauses = Vec::new();
+        if params.name.is_some() {
+            set_clauses.push("name = ?");
+        }
+
+        if set_clauses.is_empty() {
+            return Ok(());
+        }
+
+        set_clauses.push("updated_at = ?");
+        let sql = format!("UPDATE team_sessions SET {} WHERE id = ?", set_clauses.join(", "));
+
+        let mut query = sqlx::query(&sql);
+        if let Some(ref name) = params.name {
+            query = query.bind(name);
+        }
+        query = query.bind(now_ms());
+        query = query.bind(session_id);
+
+        let result = query.execute(&self.pool).await?;
+        if result.rows_affected() == 0 {
+            return Err(DbError::NotFound(format!("team_session {session_id}")));
+        }
+        Ok(())
+    }
+
+    async fn delete_team_session(&self, session_id: &str) -> Result<(), DbError> {
+        let result = sqlx::query("DELETE FROM team_sessions WHERE id = ?")
+            .bind(session_id)
+            .execute(&self.pool)
+            .await?;
+        if result.rows_affected() == 0 {
+            return Err(DbError::NotFound(format!("team_session {session_id}")));
+        }
+        Ok(())
+    }
+
+    async fn delete_team_sessions_by_team(&self, team_id: &str) -> Result<(), DbError> {
+        sqlx::query("DELETE FROM team_sessions WHERE team_id = ?")
+            .bind(team_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    // ── Team Session Agents (migration 030) ────────────────────────────
+
+    async fn bind_session_conversation(&self, row: &TeamSessionAgentRow) -> Result<(), DbError> {
+        sqlx::query(
+            "INSERT INTO team_session_agents (session_id, team_id, slot_id, conversation_id, created_at) \
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(&row.session_id)
+        .bind(&row.team_id)
+        .bind(&row.slot_id)
+        .bind(&row.conversation_id)
+        .bind(row.created_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn list_session_agents(&self, session_id: &str) -> Result<Vec<TeamSessionAgentRow>, DbError> {
+        let rows = sqlx::query_as::<_, TeamSessionAgentRow>(
+            "SELECT id, session_id, team_id, slot_id, conversation_id, created_at \
+             FROM team_session_agents \
+             WHERE session_id = ?",
+        )
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    async fn list_session_agents_by_team(&self, team_id: &str) -> Result<Vec<TeamSessionAgentRow>, DbError> {
+        let rows = sqlx::query_as::<_, TeamSessionAgentRow>(
+            "SELECT id, session_id, team_id, slot_id, conversation_id, created_at \
+             FROM team_session_agents \
+             WHERE team_id = ?",
+        )
+        .bind(team_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    async fn delete_session_agents_by_session(&self, session_id: &str) -> Result<(), DbError> {
+        sqlx::query("DELETE FROM team_session_agents WHERE session_id = ?")
+            .bind(session_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn delete_session_agents_by_team(&self, team_id: &str) -> Result<(), DbError> {
+        sqlx::query("DELETE FROM team_session_agents WHERE team_id = ?")
             .bind(team_id)
             .execute(&self.pool)
             .await?;

--- a/crates/aionui-db/src/repository/team.rs
+++ b/crates/aionui-db/src/repository/team.rs
@@ -1,5 +1,5 @@
 use crate::error::DbError;
-use crate::models::{MailboxMessageRow, TeamRow, TeamTaskRow};
+use crate::models::{MailboxMessageRow, TeamRow, TeamSessionAgentRow, TeamSessionRow, TeamTaskRow};
 
 /// Parameters for updating a team record.
 #[derive(Debug, Clone, Default)]
@@ -12,6 +12,14 @@ pub struct UpdateTeamParams {
     /// Project binding (project-bind side branch); `Some` sets the column.
     pub project_id: Option<String>,
     pub folder_id: Option<String>,
+    /// Active working session pointer (migration 030); `Some` sets the column.
+    pub active_session_id: Option<String>,
+}
+
+/// Parameters for updating a team session's mutable fields.
+#[derive(Debug, Clone, Default)]
+pub struct UpdateTeamSessionParams {
+    pub name: Option<String>,
 }
 
 /// Parameters for updating a task record.
@@ -58,41 +66,60 @@ pub trait ITeamRepository: Send + Sync {
     async fn write_message(&self, row: &MailboxMessageRow) -> Result<(), DbError>;
 
     /// Atomically reads all unread messages for `to_agent_id` in a team
-    /// and marks them as read. Uses `BEGIN IMMEDIATE` for atomicity.
-    async fn read_unread_and_mark(&self, team_id: &str, to_agent_id: &str) -> Result<Vec<MailboxMessageRow>, DbError>;
+    /// session and marks them as read. Uses `BEGIN IMMEDIATE` for atomicity.
+    async fn read_unread_and_mark(
+        &self,
+        team_id: &str,
+        session_id: &str,
+        to_agent_id: &str,
+    ) -> Result<Vec<MailboxMessageRow>, DbError>;
 
     /// Reads all unread messages for `to_agent_id` without marking them as read.
-    async fn peek_unread(&self, team_id: &str, to_agent_id: &str) -> Result<Vec<MailboxMessageRow>, DbError>;
+    async fn peek_unread(
+        &self,
+        team_id: &str,
+        session_id: &str,
+        to_agent_id: &str,
+    ) -> Result<Vec<MailboxMessageRow>, DbError>;
 
     /// Marks the given message IDs as read. IDs that don't exist are silently ignored.
     async fn mark_read_batch(&self, ids: &[String]) -> Result<(), DbError>;
 
-    /// Returns message history for an agent, optionally limited.
+    /// Returns message history for an agent in a team session, optionally limited.
     /// Messages are ordered by `created_at` ascending.
     async fn get_history(
         &self,
         team_id: &str,
+        session_id: &str,
         to_agent_id: &str,
         limit: Option<i64>,
     ) -> Result<Vec<MailboxMessageRow>, DbError>;
 
-    /// Deletes all mailbox messages belonging to a team.
+    /// Deletes all mailbox messages belonging to a team (all sessions).
     async fn delete_mailbox_by_team(&self, team_id: &str) -> Result<(), DbError>;
+
+    /// Deletes all mailbox messages belonging to a specific team session.
+    async fn delete_mailbox_by_session(&self, team_id: &str, session_id: &str) -> Result<(), DbError>;
 
     // ── Tasks ────────────────────────────────────────────────────────
 
     /// Creates a new task.
     async fn create_task(&self, row: &TeamTaskRow) -> Result<(), DbError>;
 
-    /// Finds a task by exact id within a team.
-    async fn find_task_by_id(&self, team_id: &str, task_id: &str) -> Result<Option<TeamTaskRow>, DbError>;
+    /// Finds a task by exact id within a team session.
+    async fn find_task_by_id(
+        &self,
+        team_id: &str,
+        session_id: &str,
+        task_id: &str,
+    ) -> Result<Option<TeamTaskRow>, DbError>;
 
     /// Updates a task by id with the provided fields.
     /// Returns `DbError::NotFound` if absent.
     async fn update_task(&self, task_id: &str, params: &UpdateTaskParams) -> Result<(), DbError>;
 
-    /// Returns all tasks for a team, ordered by `created_at` ascending.
-    async fn list_tasks(&self, team_id: &str) -> Result<Vec<TeamTaskRow>, DbError>;
+    /// Returns all tasks for a team session, ordered by `created_at` ascending.
+    async fn list_tasks(&self, team_id: &str, session_id: &str) -> Result<Vec<TeamTaskRow>, DbError>;
 
     /// Appends `blocked_task_id` to the `blocks` JSON array of `task_id`.
     /// This is a transactional JSON array append operation.
@@ -102,6 +129,52 @@ pub trait ITeamRepository: Send + Sync {
     /// This is a transactional JSON array removal operation.
     async fn remove_from_blocked_by(&self, task_id: &str, unblocked_task_id: &str) -> Result<(), DbError>;
 
-    /// Deletes all tasks belonging to a team.
+    /// Deletes all tasks belonging to a team (all sessions).
     async fn delete_tasks_by_team(&self, team_id: &str) -> Result<(), DbError>;
+
+    /// Deletes all tasks belonging to a specific team session.
+    async fn delete_tasks_by_session(&self, team_id: &str, session_id: &str) -> Result<(), DbError>;
+
+    // ── Team Sessions (migration 030) ──────────────────────────────────
+
+    /// Inserts a new team session record.
+    async fn create_team_session(&self, row: &TeamSessionRow) -> Result<(), DbError>;
+
+    /// Returns all sessions for a team, ordered by creation time ascending
+    /// (primary session first among ties).
+    async fn list_team_sessions(&self, team_id: &str) -> Result<Vec<TeamSessionRow>, DbError>;
+
+    /// Returns a single session by id, or `None` if not found.
+    async fn get_team_session(&self, session_id: &str) -> Result<Option<TeamSessionRow>, DbError>;
+
+    /// Updates a session's mutable fields. Returns `DbError::NotFound` if absent.
+    async fn update_team_session(
+        &self,
+        session_id: &str,
+        params: &UpdateTeamSessionParams,
+    ) -> Result<(), DbError>;
+
+    /// Deletes a session by id. Returns `DbError::NotFound` if absent.
+    async fn delete_team_session(&self, session_id: &str) -> Result<(), DbError>;
+
+    /// Deletes all sessions belonging to a team (used on team deletion).
+    async fn delete_team_sessions_by_team(&self, team_id: &str) -> Result<(), DbError>;
+
+    // ── Team Session Agents (migration 030) ────────────────────────────
+
+    /// Binds one conversation to a (session, slot) pair.
+    async fn bind_session_conversation(&self, row: &TeamSessionAgentRow) -> Result<(), DbError>;
+
+    /// Returns all (slot → conversation) bindings for a session.
+    async fn list_session_agents(&self, session_id: &str) -> Result<Vec<TeamSessionAgentRow>, DbError>;
+
+    /// Returns the (session → conversation) bindings for every session of a
+    /// team, in one query (used to populate the team view without N+1).
+    async fn list_session_agents_by_team(&self, team_id: &str) -> Result<Vec<TeamSessionAgentRow>, DbError>;
+
+    /// Deletes all session-agent bindings for a session.
+    async fn delete_session_agents_by_session(&self, session_id: &str) -> Result<(), DbError>;
+
+    /// Deletes all session-agent bindings for a team (used on team deletion).
+    async fn delete_session_agents_by_team(&self, team_id: &str) -> Result<(), DbError>;
 }

--- a/crates/aionui-team/src/mailbox.rs
+++ b/crates/aionui-team/src/mailbox.rs
@@ -17,16 +17,18 @@ impl Mailbox {
         Self { repo }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn write(
         &self,
         team_id: &str,
+        session_id: &str,
         to_agent_id: &str,
         from_agent_id: &str,
         msg_type: MailboxMessageType,
         content: &str,
         summary: Option<&str>,
     ) -> Result<MailboxMessage, TeamError> {
-        self.write_with_files(team_id, to_agent_id, from_agent_id, msg_type, content, summary, None)
+        self.write_with_files(team_id, session_id, to_agent_id, from_agent_id, msg_type, content, summary, None)
             .await
     }
 
@@ -34,6 +36,7 @@ impl Mailbox {
     pub async fn write_with_files(
         &self,
         team_id: &str,
+        session_id: &str,
         to_agent_id: &str,
         from_agent_id: &str,
         msg_type: MailboxMessageType,
@@ -55,12 +58,14 @@ impl Mailbox {
             files: files_json,
             read: false,
             created_at: now_ms(),
+            session_id: Some(session_id.to_owned()),
         };
 
         self.repo.write_message(&row).await?;
 
         debug!(
             team_id,
+            session_id,
             to = to_agent_id,
             from = from_agent_id,
             msg_type = %msg_type,
@@ -71,10 +76,15 @@ impl Mailbox {
             .ok_or_else(|| TeamError::InvalidRequest(format!("invalid message type: {msg_type}")))
     }
 
-    pub async fn read_unread(&self, team_id: &str, agent_id: &str) -> Result<Vec<MailboxMessage>, TeamError> {
-        let rows = self.repo.read_unread_and_mark(team_id, agent_id).await?;
+    pub async fn read_unread(
+        &self,
+        team_id: &str,
+        session_id: &str,
+        agent_id: &str,
+    ) -> Result<Vec<MailboxMessage>, TeamError> {
+        let rows = self.repo.read_unread_and_mark(team_id, session_id, agent_id).await?;
 
-        debug!(team_id, agent_id, count = rows.len(), "mailbox unread messages read");
+        debug!(team_id, session_id, agent_id, count = rows.len(), "mailbox unread messages read");
 
         let messages = rows.iter().filter_map(MailboxMessage::from_row).collect();
         Ok(messages)
@@ -82,9 +92,14 @@ impl Mailbox {
 
     /// Reads all unread messages without marking them as read.
     /// Used by the drain_mailbox pattern: peek → prompt → mark_read on success.
-    pub async fn peek_unread(&self, team_id: &str, agent_id: &str) -> Result<Vec<MailboxMessage>, TeamError> {
-        let rows = self.repo.peek_unread(team_id, agent_id).await?;
-        debug!(team_id, agent_id, count = rows.len(), "mailbox peek_unread");
+    pub async fn peek_unread(
+        &self,
+        team_id: &str,
+        session_id: &str,
+        agent_id: &str,
+    ) -> Result<Vec<MailboxMessage>, TeamError> {
+        let rows = self.repo.peek_unread(team_id, session_id, agent_id).await?;
+        debug!(team_id, session_id, agent_id, count = rows.len(), "mailbox peek_unread");
         let messages = rows.iter().filter_map(MailboxMessage::from_row).collect();
         Ok(messages)
     }
@@ -100,11 +115,12 @@ impl Mailbox {
     pub async fn mark_all_unread_for_agents_read(
         &self,
         team_id: &str,
+        session_id: &str,
         agent_ids: &[String],
     ) -> Result<usize, TeamError> {
         let mut ids = Vec::new();
         for agent_id in agent_ids {
-            let unread = self.peek_unread(team_id, agent_id).await?;
+            let unread = self.peek_unread(team_id, session_id, agent_id).await?;
             ids.extend(unread.into_iter().map(|message| message.id));
         }
         let count = ids.len();
@@ -117,22 +133,29 @@ impl Mailbox {
     pub async fn get_history(
         &self,
         team_id: &str,
+        session_id: &str,
         agent_id: &str,
         limit: Option<i64>,
     ) -> Result<Vec<MailboxMessage>, TeamError> {
-        let rows = self.repo.get_history(team_id, agent_id, limit).await?;
+        let rows = self.repo.get_history(team_id, session_id, agent_id, limit).await?;
         let messages = rows.iter().filter_map(MailboxMessage::from_row).collect();
         Ok(messages)
     }
 
-    pub async fn has_unread(&self, team_id: &str, agent_id: &str) -> Result<bool, TeamError> {
-        let rows = self.repo.get_history(team_id, agent_id, None).await?;
+    pub async fn has_unread(&self, team_id: &str, session_id: &str, agent_id: &str) -> Result<bool, TeamError> {
+        let rows = self.repo.get_history(team_id, session_id, agent_id, None).await?;
         Ok(rows.iter().any(|r| !r.read))
     }
 
     pub async fn delete_by_team(&self, team_id: &str) -> Result<(), TeamError> {
         self.repo.delete_mailbox_by_team(team_id).await?;
         debug!(team_id, "mailbox messages deleted for team");
+        Ok(())
+    }
+
+    pub async fn delete_by_session(&self, team_id: &str, session_id: &str) -> Result<(), TeamError> {
+        self.repo.delete_mailbox_by_session(team_id, session_id).await?;
+        debug!(team_id, session_id, "mailbox messages deleted for session");
         Ok(())
     }
 }
@@ -150,20 +173,20 @@ mod tests {
         let mailbox = Mailbox::new(repo);
 
         mailbox
-            .write("t1", "a1", "user", MailboxMessageType::Message, "hi", None)
+            .write("t1", "s1", "a1", "user", MailboxMessageType::Message, "hi", None)
             .await
             .unwrap();
         mailbox
-            .write("t1", "a1", "a2", MailboxMessageType::Message, "hello", None)
+            .write("t1", "s1", "a1", "a2", MailboxMessageType::Message, "hello", None)
             .await
             .unwrap();
 
-        let unread = mailbox.read_unread("t1", "a1").await.unwrap();
+        let unread = mailbox.read_unread("t1", "s1", "a1").await.unwrap();
         assert_eq!(unread.len(), 2);
         assert_eq!(unread[0].content, "hi");
         assert_eq!(unread[1].content, "hello");
 
-        let unread_again = mailbox.read_unread("t1", "a1").await.unwrap();
+        let unread_again = mailbox.read_unread("t1", "s1", "a1").await.unwrap();
         assert!(unread_again.is_empty());
     }
 
@@ -175,6 +198,7 @@ mod tests {
         let msg = mailbox
             .write(
                 "t1",
+                "s1",
                 "lead",
                 "a1",
                 MailboxMessageType::IdleNotification,
@@ -194,17 +218,17 @@ mod tests {
         let mailbox = Mailbox::new(repo);
 
         mailbox
-            .write("t1", "a1", "user", MailboxMessageType::Message, "m1", None)
+            .write("t1", "s1", "a1", "user", MailboxMessageType::Message, "m1", None)
             .await
             .unwrap();
         mailbox
-            .write("t1", "a1", "user", MailboxMessageType::Message, "m2", None)
+            .write("t1", "s1", "a1", "user", MailboxMessageType::Message, "m2", None)
             .await
             .unwrap();
 
-        mailbox.read_unread("t1", "a1").await.unwrap();
+        mailbox.read_unread("t1", "s1", "a1").await.unwrap();
 
-        let history = mailbox.get_history("t1", "a1", None).await.unwrap();
+        let history = mailbox.get_history("t1", "s1", "a1", None).await.unwrap();
         assert_eq!(history.len(), 2);
     }
 
@@ -217,6 +241,7 @@ mod tests {
             mailbox
                 .write(
                     "t1",
+                    "s1",
                     "a1",
                     "user",
                     MailboxMessageType::Message,
@@ -227,7 +252,7 @@ mod tests {
                 .unwrap();
         }
 
-        let history = mailbox.get_history("t1", "a1", Some(3)).await.unwrap();
+        let history = mailbox.get_history("t1", "s1", "a1", Some(3)).await.unwrap();
         assert_eq!(history.len(), 3);
     }
 
@@ -237,20 +262,20 @@ mod tests {
         let mailbox = Mailbox::new(repo);
 
         mailbox
-            .write("t1", "a1", "user", MailboxMessageType::Message, "x", None)
+            .write("t1", "s1", "a1", "user", MailboxMessageType::Message, "x", None)
             .await
             .unwrap();
         mailbox
-            .write("t2", "a1", "user", MailboxMessageType::Message, "y", None)
+            .write("t2", "s1", "a1", "user", MailboxMessageType::Message, "y", None)
             .await
             .unwrap();
 
         mailbox.delete_by_team("t1").await.unwrap();
 
-        let h1 = mailbox.get_history("t1", "a1", None).await.unwrap();
+        let h1 = mailbox.get_history("t1", "s1", "a1", None).await.unwrap();
         assert!(h1.is_empty());
 
-        let h2 = mailbox.get_history("t2", "a1", None).await.unwrap();
+        let h2 = mailbox.get_history("t2", "s1", "a1", None).await.unwrap();
         assert_eq!(h2.len(), 1);
     }
 
@@ -259,7 +284,7 @@ mod tests {
         let repo = Arc::new(MockTeamRepo::new());
         let mailbox = Mailbox::new(repo);
 
-        let unread = mailbox.read_unread("t1", "a1").await.unwrap();
+        let unread = mailbox.read_unread("t1", "s1", "a1").await.unwrap();
         assert!(unread.is_empty());
     }
 
@@ -269,19 +294,19 @@ mod tests {
         let mailbox = Mailbox::new(repo);
 
         mailbox
-            .write("t1", "a1", "user", MailboxMessageType::Message, "for-a1", None)
+            .write("t1", "s1", "a1", "user", MailboxMessageType::Message, "for-a1", None)
             .await
             .unwrap();
         mailbox
-            .write("t1", "a2", "user", MailboxMessageType::Message, "for-a2", None)
+            .write("t1", "s1", "a2", "user", MailboxMessageType::Message, "for-a2", None)
             .await
             .unwrap();
 
-        let unread_a1 = mailbox.read_unread("t1", "a1").await.unwrap();
+        let unread_a1 = mailbox.read_unread("t1", "s1", "a1").await.unwrap();
         assert_eq!(unread_a1.len(), 1);
         assert_eq!(unread_a1[0].content, "for-a1");
 
-        let unread_a2 = mailbox.read_unread("t1", "a2").await.unwrap();
+        let unread_a2 = mailbox.read_unread("t1", "s1", "a2").await.unwrap();
         assert_eq!(unread_a2.len(), 1);
         assert_eq!(unread_a2[0].content, "for-a2");
     }

--- a/crates/aionui-team/src/ports.rs
+++ b/crates/aionui-team/src/ports.rs
@@ -15,6 +15,7 @@ pub struct TeamConversationBindingLookup {
     pub team_id: Option<String>,
     pub slot_id: Option<String>,
     pub role: Option<String>,
+    pub session_id: Option<String>,
 }
 
 #[async_trait]

--- a/crates/aionui-team/src/provisioning.rs
+++ b/crates/aionui-team/src/provisioning.rs
@@ -33,14 +33,15 @@ pub(crate) struct InitialProvisioningResult {
     pub team_workspace: String,
 }
 
-struct ProvisionedConversation {
-    conversation_id: String,
-    workspace: Option<String>,
+pub(crate) struct ProvisionedConversation {
+    pub(crate) conversation_id: String,
+    pub(crate) workspace: Option<String>,
 }
 
 struct NewAgentProvisioning {
     user_id: String,
     team_id: String,
+    session_id: String,
     slot_id: String,
     name: String,
     role: TeammateRole,
@@ -151,6 +152,7 @@ impl TeamAgentProvisioner {
         &self,
         user_id: &str,
         team_id: &str,
+        session_id: &str,
         inputs: &[TeamAgentInput],
         shared_workspace: Option<&str>,
     ) -> Result<InitialProvisioningResult, TeamError> {
@@ -184,6 +186,7 @@ impl TeamAgentProvisioner {
             .create_team_conversation_for_agent(
                 user_id,
                 team_id,
+                session_id,
                 &leader_slot_id,
                 leader_role,
                 &leader_input.name,
@@ -235,6 +238,7 @@ impl TeamAgentProvisioner {
                 .create_team_conversation_for_agent(
                     user_id,
                     team_id,
+                    session_id,
                     &slot_id,
                     *role,
                     &input.name,
@@ -296,10 +300,16 @@ impl TeamAgentProvisioner {
         let backend = self
             .resolve_requested_backend(req.backend.as_deref(), assistant_id.as_deref())
             .await?;
+        // New roster agents join the team's currently active session.
+        let session_id = row
+            .active_session_id
+            .clone()
+            .ok_or_else(|| TeamError::InvalidRequest("team has no active session".into()))?;
         let agent = self
             .provision_new_agent(NewAgentProvisioning {
                 user_id: user_id.to_owned(),
                 team_id: team.id.clone(),
+                session_id,
                 slot_id: generate_id(),
                 name: req.name,
                 role,
@@ -312,7 +322,29 @@ impl TeamAgentProvisioner {
             .await?;
         team.agents.push(agent.clone());
         self.persist_agents(&team.id, &team.agents).await?;
+        // Bind the new agent's conversation into the active session.
+        self.bind_agent_to_active_session(row, &agent).await?;
         Ok(agent)
+    }
+
+    /// Persist a `(session, slot) -> conversation` binding for a freshly added
+    /// agent, mirroring what `create_team` does for the initial roster.
+    async fn bind_agent_to_active_session(&self, row: &TeamRow, agent: &TeamAgent) -> Result<(), TeamError> {
+        let session_id = row
+            .active_session_id
+            .as_deref()
+            .ok_or_else(|| TeamError::InvalidRequest("team has no active session".into()))?;
+        self.repo
+            .bind_session_conversation(&aionui_db::models::TeamSessionAgentRow {
+                id: 0,
+                session_id: session_id.to_owned(),
+                team_id: row.id.clone(),
+                slot_id: agent.slot_id.clone(),
+                conversation_id: agent.conversation_id.clone(),
+                created_at: aionui_common::now_ms(),
+            })
+            .await?;
+        Ok(())
     }
 
     async fn resolve_requested_backend(
@@ -348,10 +380,16 @@ impl TeamAgentProvisioner {
             .ok_or_else(|| TeamError::TeamNotFound(req.team_id.clone()))?;
         let mut team = Team::from_row(&row)?;
         let workspace = self.workspace_resolver().resolve_for_new_agent(&row, &team).await?;
+        // Spawned agents join the team's currently active session.
+        let session_id = row
+            .active_session_id
+            .clone()
+            .ok_or_else(|| TeamError::InvalidRequest("team has no active session".into()))?;
         let agent = self
             .provision_new_agent(NewAgentProvisioning {
                 user_id: req.user_id,
                 team_id: req.team_id.clone(),
+                session_id,
                 slot_id: req.slot_id,
                 name: req.name,
                 role: TeammateRole::Teammate,
@@ -364,6 +402,7 @@ impl TeamAgentProvisioner {
             .await?;
         team.agents.push(agent.clone());
         self.persist_agents(&req.team_id, &team.agents).await?;
+        self.bind_agent_to_active_session(&row, &agent).await?;
         Ok(agent)
     }
 
@@ -496,11 +535,42 @@ impl TeamAgentProvisioner {
         Ok(())
     }
 
+    /// Mint a fresh conversation for an EXISTING roster agent under a NEW
+    /// working session. Used by `create_team_session` to give every slot its
+    /// own conversation per session. Unlike `provision_new_agent`, this does
+    /// not create a new roster entry — the roster `TeamAgent` is the input,
+    /// and only a new conversation (carrying the session id in its `extra`)
+    /// is produced.
+    pub(crate) async fn provision_session_agent_conversation(
+        &self,
+        user_id: &str,
+        team_id: &str,
+        session_id: &str,
+        agent: &TeamAgent,
+        session_mode: Option<&str>,
+    ) -> Result<ProvisionedConversation, TeamError> {
+        self.create_team_conversation_for_agent(
+            user_id,
+            team_id,
+            session_id,
+            &agent.slot_id,
+            agent.role,
+            &agent.name,
+            &agent.backend,
+            &agent.model,
+            agent.assistant_id.as_deref(),
+            None,
+            session_mode,
+        )
+        .await
+    }
+
     async fn provision_new_agent(&self, input: NewAgentProvisioning) -> Result<TeamAgent, TeamError> {
         let conversation = self
             .create_team_conversation_for_agent(
                 &input.user_id,
                 &input.team_id,
+                &input.session_id,
                 &input.slot_id,
                 input.role,
                 &input.name,
@@ -530,6 +600,7 @@ impl TeamAgentProvisioner {
         &self,
         user_id: &str,
         team_id: &str,
+        session_id: &str,
         slot_id: &str,
         role: TeammateRole,
         name: &str,
@@ -547,6 +618,7 @@ impl TeamAgentProvisioner {
         };
         let extra = self.build_team_extra(
             team_id,
+            session_id,
             slot_id,
             role,
             backend,
@@ -649,6 +721,7 @@ impl TeamAgentProvisioner {
     fn build_team_extra(
         &self,
         team_id: &str,
+        session_id: &str,
         slot_id: &str,
         role: TeammateRole,
         backend: &str,
@@ -666,6 +739,7 @@ impl TeamAgentProvisioner {
             .unwrap_or_else(|| session_mode_for_backend(backend, agent_type, acp_metadata));
         let mut extra = serde_json::json!({
             "teamId": team_id,
+            "sessionId": session_id,
             "slot_id": slot_id,
             "role": role.to_string(),
             "backend": backend,

--- a/crates/aionui-team/src/routes.rs
+++ b/crates/aionui-team/src/routes.rs
@@ -11,9 +11,9 @@ use axum::routing::{get, post};
 use aionui_ai_agent::ActiveLeaseRegistry;
 use aionui_api_types::{
     AddAgentRequest, ApiResponse, CancelTeamChildTurnRequest, CancelTeamRunRequest, CreateTeamRequest,
-    GetConfigOptionsResponse, PauseTeamSlotRequest, RenameAgentRequest, RenameTeamRequest, SendAgentMessageRequest,
-    SendTeamMessageRequest, SetModeRequest, TeamAgentResponse, TeamListResponse, TeamResponse, TeamRunAckResponse,
-    TeamRunStateResponse,
+    CreateTeamSessionRequest, GetConfigOptionsResponse, PauseTeamSlotRequest, RenameAgentRequest, RenameTeamRequest,
+    RenameTeamSessionRequest, SendAgentMessageRequest, SendTeamMessageRequest, SetModeRequest, TeamAgentResponse,
+    TeamListResponse, TeamResponse, TeamRunAckResponse, TeamRunStateResponse, TeamSessionResponse,
 };
 use aionui_auth::CurrentUser;
 use aionui_common::ApiError;
@@ -118,8 +118,22 @@ pub fn team_routes(state: TeamRouterState) -> Router {
         .route("/api/teams/{id}/session", post(ensure_session).delete(stop_session))
         .route("/api/teams/{id}/active-lease", post(active_lease))
         .route("/api/teams/{id}/session-mode", post(set_session_mode))
+        // Working sessions (migration 030). Plural /sessions CRUD is
+        // additive; the singular /session routes above keep working as the
+        // "active session" shorthand for pre-multi-session clients.
+        .route(
+            "/api/teams/{id}/sessions",
+            get(list_team_sessions).post(create_team_session),
+        )
+        .route(
+            "/api/teams/{id}/sessions/{session_id}",
+            axum::routing::get(get_team_session)
+                .patch(rename_team_session)
+                .delete(delete_team_session),
+        )
+        .route("/api/teams/{id}/sessions/{session_id}/active", post(set_active_session))
         .with_state(state)
-}
+    }
 
 async fn create_team(
     State(state): State<TeamRouterState>,
@@ -375,6 +389,78 @@ async fn stop_session(
     Path(id): Path<String>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
     state.service.stop_session(&user.id, &id).await?;
+    Ok(Json(ApiResponse::success()))
+}
+
+// ── Working sessions (migration 030) ─────────────────────────────────────
+
+async fn list_team_sessions(
+    State(state): State<TeamRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+) -> Result<Json<ApiResponse<Vec<TeamSessionResponse>>>, ApiError> {
+    Ok(Json(ApiResponse::ok(
+        state.service.list_team_sessions(&user.id, &id).await?,
+    )))
+}
+
+async fn create_team_session(
+    State(state): State<TeamRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+    body: Result<Json<CreateTeamSessionRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<TeamSessionResponse>>, ApiError> {
+    let Json(req) = body.map_err(ApiError::from)?;
+    Ok(Json(ApiResponse::ok(
+        state.service.create_team_session(&user.id, &id, req.name.as_deref()).await?,
+    )))
+}
+
+async fn get_team_session(
+    State(state): State<TeamRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    Path((id, session_id)): Path<(String, String)>,
+) -> Result<Json<ApiResponse<TeamSessionResponse>>, ApiError> {
+    Ok(Json(ApiResponse::ok(
+        state.service.get_team_session(&user.id, &id, &session_id).await?,
+    )))
+}
+
+async fn rename_team_session(
+    State(state): State<TeamRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    Path((id, session_id)): Path<(String, String)>,
+    body: Result<Json<RenameTeamSessionRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<()>>, ApiError> {
+    let Json(req) = body.map_err(ApiError::from)?;
+    state
+        .service
+        .rename_team_session(&user.id, &id, &session_id, &req.name)
+        .await?;
+    Ok(Json(ApiResponse::success()))
+}
+
+async fn delete_team_session(
+    State(state): State<TeamRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    Path((id, session_id)): Path<(String, String)>,
+) -> Result<Json<ApiResponse<()>>, ApiError> {
+    state
+        .service
+        .delete_team_session(&user.id, &id, &session_id)
+        .await?;
+    Ok(Json(ApiResponse::success()))
+}
+
+async fn set_active_session(
+    State(state): State<TeamRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    Path((id, session_id)): Path<(String, String)>,
+) -> Result<Json<ApiResponse<()>>, ApiError> {
+    state
+        .service
+        .set_active_session(&user.id, &id, &session_id)
+        .await?;
     Ok(Json(ApiResponse::success()))
 }
 

--- a/crates/aionui-team/src/scheduler/actions.rs
+++ b/crates/aionui-team/src/scheduler/actions.rs
@@ -51,7 +51,7 @@ impl TeammateManager {
         blocked_by: &[String],
     ) -> Result<crate::types::TeamTask, TeamError> {
         self.task_board
-            .create_task(&self.team_id, subject, description, owner, blocked_by)
+            .create_task(&self.team_id, &self.session_id, subject, description, owner, blocked_by)
             .await
     }
 
@@ -73,7 +73,9 @@ impl TeammateManager {
             blocked_by,
             ..Default::default()
         };
-        self.task_board.update_task(&self.team_id, task_id, &update).await
+        self.task_board
+            .update_task(&self.team_id, &self.session_id, task_id, &update)
+            .await
     }
 
     pub async fn execute_action(
@@ -168,6 +170,7 @@ impl TeammateManager {
                 self.mailbox
                     .write_with_files(
                         &self.team_id,
+                        &self.session_id,
                         target,
                         from_slot_id,
                         MailboxMessageType::Message,
@@ -181,6 +184,7 @@ impl TeammateManager {
             self.mailbox
                 .write_with_files(
                     &self.team_id,
+                    &self.session_id,
                     to,
                     from_slot_id,
                     MailboxMessageType::Message,
@@ -232,6 +236,7 @@ impl TeammateManager {
         self.mailbox
             .write(
                 &self.team_id,
+                &self.session_id,
                 target_slot_id,
                 from_slot_id,
                 MailboxMessageType::ShutdownRequest,

--- a/crates/aionui-team/src/scheduler/crash_recovery.rs
+++ b/crates/aionui-team/src/scheduler/crash_recovery.rs
@@ -92,6 +92,7 @@ impl TeammateManager {
         self.mailbox
             .write(
                 &self.team_id,
+                &self.session_id,
                 &lead_slot_id,
                 slot_id,
                 MailboxMessageType::Message,
@@ -119,6 +120,7 @@ impl TeammateManager {
         self.mailbox
             .write(
                 &self.team_id,
+                &self.session_id,
                 &lead_slot_id,
                 slot_id,
                 MailboxMessageType::Message,
@@ -145,6 +147,7 @@ impl TeammateManager {
         self.mailbox
             .write(
                 &self.team_id,
+                &self.session_id,
                 &lead_slot_id,
                 from_slot_id,
                 MailboxMessageType::Message,

--- a/crates/aionui-team/src/scheduler/mod.rs
+++ b/crates/aionui-team/src/scheduler/mod.rs
@@ -115,6 +115,7 @@ pub(crate) struct AgentSlot {
 
 pub struct TeammateManager {
     pub(crate) team_id: String,
+    pub(crate) session_id: String,
     pub(crate) slots: Mutex<HashMap<String, AgentSlot>>,
     pub(crate) mailbox: Arc<Mailbox>,
     pub(crate) task_board: Arc<TaskBoard>,
@@ -130,6 +131,7 @@ pub struct TeammateManager {
 impl TeammateManager {
     pub fn new(
         team_id: String,
+        session_id: String,
         agents: &[TeamAgent],
         mailbox: Arc<Mailbox>,
         task_board: Arc<TaskBoard>,
@@ -151,6 +153,7 @@ impl TeammateManager {
         let events = TeamEventEmitter::new(team_id.clone(), broadcaster);
         Self {
             team_id,
+            session_id,
             slots: Mutex::new(slots),
             mailbox,
             task_board,
@@ -175,7 +178,7 @@ impl TeammateManager {
     }
 
     pub async fn list_tasks(&self) -> Result<Vec<TeamTask>, TeamError> {
-        self.task_board.list_tasks(&self.team_id).await
+        self.task_board.list_tasks(&self.team_id, &self.session_id).await
     }
 
     pub async fn find_lead_slot_id(&self) -> Option<String> {

--- a/crates/aionui-team/src/scheduler/state.rs
+++ b/crates/aionui-team/src/scheduler/state.rs
@@ -64,6 +64,7 @@ impl TeammateManager {
             self.mailbox
                 .write(
                     &self.team_id,
+                    &self.session_id,
                     &lead_slot_id,
                     slot_id,
                     MailboxMessageType::IdleNotification,

--- a/crates/aionui-team/src/scheduler/tests.rs
+++ b/crates/aionui-team/src/scheduler/tests.rs
@@ -94,7 +94,7 @@ fn make_manager(agents: &[TeamAgent]) -> (TeammateManager, Arc<RecordingBroadcas
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), agents, mailbox, task_board, broadcaster.clone());
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), agents, mailbox, task_board, broadcaster.clone());
     (mgr, broadcaster)
 }
 
@@ -463,7 +463,7 @@ async fn execute_send_message_writes_to_mailbox() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     let action = SchedulerAction::SendMessage {
         to: "worker-1".into(),
@@ -472,7 +472,7 @@ async fn execute_send_message_writes_to_mailbox() {
     };
     mgr.execute_action("lead-1", &action).await.unwrap();
 
-    let unread = mailbox.read_unread("t1", "worker-1").await.unwrap();
+    let unread = mailbox.read_unread("t1", "s1", "worker-1").await.unwrap();
     assert_eq!(unread.len(), 1);
     assert_eq!(unread[0].content, "Do task X");
     assert_eq!(unread[0].from_agent_id, "lead-1");
@@ -486,7 +486,7 @@ async fn execute_broadcast_message_writes_to_all_others() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     let action = SchedulerAction::SendMessage {
         to: "*".into(),
@@ -495,11 +495,11 @@ async fn execute_broadcast_message_writes_to_all_others() {
     };
     mgr.execute_action("lead-1", &action).await.unwrap();
 
-    let u1 = mailbox.read_unread("t1", "worker-1").await.unwrap();
+    let u1 = mailbox.read_unread("t1", "s1", "worker-1").await.unwrap();
     assert_eq!(u1.len(), 1);
-    let u2 = mailbox.read_unread("t1", "worker-2").await.unwrap();
+    let u2 = mailbox.read_unread("t1", "s1", "worker-2").await.unwrap();
     assert_eq!(u2.len(), 1);
-    let u_lead = mailbox.read_unread("t1", "lead-1").await.unwrap();
+    let u_lead = mailbox.read_unread("t1", "s1", "lead-1").await.unwrap();
     assert!(u_lead.is_empty());
 }
 
@@ -512,7 +512,7 @@ async fn execute_task_create() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox, task_board.clone(), broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox, task_board.clone(), broadcaster);
 
     let action = SchedulerAction::TaskCreate {
         subject: "Implement feature".into(),
@@ -522,7 +522,7 @@ async fn execute_task_create() {
     };
     mgr.execute_action("lead-1", &action).await.unwrap();
 
-    let tasks = task_board.list_tasks("t1").await.unwrap();
+    let tasks = task_board.list_tasks("t1", "s1").await.unwrap();
     assert_eq!(tasks.len(), 1);
     assert_eq!(tasks[0].subject, "Implement feature");
     assert_eq!(tasks[0].owner.as_deref(), Some("worker-1"));
@@ -537,9 +537,9 @@ async fn execute_task_update() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox, task_board.clone(), broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox, task_board.clone(), broadcaster);
 
-    let task = task_board.create_task("t1", "Work", None, None, &[]).await.unwrap();
+    let task = task_board.create_task("t1", "s1", "Work", None, None, &[]).await.unwrap();
 
     let action = SchedulerAction::TaskUpdate {
         task_id: task.id.clone(),
@@ -550,7 +550,7 @@ async fn execute_task_update() {
     };
     mgr.execute_action("worker-1", &action).await.unwrap();
 
-    let tasks = task_board.list_tasks("t1").await.unwrap();
+    let tasks = task_board.list_tasks("t1", "s1").await.unwrap();
     assert_eq!(tasks[0].status, crate::types::TaskStatus::InProgress);
 }
 
@@ -563,7 +563,7 @@ async fn execute_idle_notification_writes_to_lead_mailbox() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     mgr.set_status("worker-1", TeammateStatus::Working).await.unwrap();
 
@@ -574,7 +574,7 @@ async fn execute_idle_notification_writes_to_lead_mailbox() {
 
     assert_eq!(mgr.get_status("worker-1").await.unwrap(), TeammateStatus::Idle);
 
-    let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+    let lead_msgs = mailbox.read_unread("t1", "s1", "lead-1").await.unwrap();
     assert_eq!(lead_msgs.len(), 1);
     assert_eq!(lead_msgs[0].msg_type, MailboxMessageType::IdleNotification);
     assert_eq!(lead_msgs[0].from_agent_id, "worker-1");
@@ -587,7 +587,7 @@ async fn lead_idle_notification_does_not_write_to_self() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     mgr.set_status("lead-1", TeammateStatus::Working).await.unwrap();
 
@@ -596,7 +596,7 @@ async fn lead_idle_notification_does_not_write_to_self() {
     };
     mgr.execute_action("lead-1", &action).await.unwrap();
 
-    let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+    let lead_msgs = mailbox.read_unread("t1", "s1", "lead-1").await.unwrap();
     assert!(lead_msgs.is_empty());
 }
 
@@ -609,7 +609,7 @@ async fn execute_shutdown_agent_writes_shutdown_request() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     let action = SchedulerAction::ShutdownAgent {
         slot_id: "worker-1".into(),
@@ -617,7 +617,7 @@ async fn execute_shutdown_agent_writes_shutdown_request() {
     };
     mgr.execute_action("lead-1", &action).await.unwrap();
 
-    let msgs = mailbox.read_unread("t1", "worker-1").await.unwrap();
+    let msgs = mailbox.read_unread("t1", "s1", "worker-1").await.unwrap();
     assert_eq!(msgs.len(), 1);
     assert_eq!(msgs[0].msg_type, MailboxMessageType::ShutdownRequest);
     assert_eq!(msgs[0].content, "No longer needed");
@@ -643,7 +643,7 @@ async fn lead_cannot_shutdown_lead() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     let action = SchedulerAction::ShutdownAgent {
         slot_id: "lead-1".into(),
@@ -656,7 +656,7 @@ async fn lead_cannot_shutdown_lead() {
     );
 
     // No ShutdownRequest message should have been written to the lead's mailbox.
-    let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+    let lead_msgs = mailbox.read_unread("t1", "s1", "lead-1").await.unwrap();
     assert!(lead_msgs.is_empty());
 }
 
@@ -669,7 +669,7 @@ async fn lead_can_shutdown_worker() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     let action = SchedulerAction::ShutdownAgent {
         slot_id: "worker-1".into(),
@@ -677,7 +677,7 @@ async fn lead_can_shutdown_worker() {
     };
     mgr.execute_action("lead-1", &action).await.unwrap();
 
-    let msgs = mailbox.read_unread("t1", "worker-1").await.unwrap();
+    let msgs = mailbox.read_unread("t1", "s1", "worker-1").await.unwrap();
     assert_eq!(msgs.len(), 1);
     assert_eq!(msgs[0].msg_type, MailboxMessageType::ShutdownRequest);
 }
@@ -715,7 +715,7 @@ async fn finalize_turn_executes_actions_and_marks_idle() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board.clone(), broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board.clone(), broadcaster);
 
     mgr.set_status("worker-1", TeammateStatus::Working).await.unwrap();
     mgr.set_status("worker-2", TeammateStatus::Working).await.unwrap();
@@ -738,13 +738,13 @@ async fn finalize_turn_executes_actions_and_marks_idle() {
 
     assert_eq!(mgr.get_status("worker-1").await.unwrap(), TeammateStatus::Idle);
 
-    let tasks = task_board.list_tasks("t1").await.unwrap();
+    let tasks = task_board.list_tasks("t1", "s1").await.unwrap();
     assert_eq!(tasks.len(), 1);
 
     // Two messages arrive at the lead:
     // 1. the explicit SendMessage from the action list ("Done with sub-task")
     // 2. the IdleNotification that mark_idle now writes automatically
-    let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+    let lead_msgs = mailbox.read_unread("t1", "s1", "lead-1").await.unwrap();
     assert_eq!(lead_msgs.len(), 2);
     assert!(
         lead_msgs
@@ -767,7 +767,7 @@ async fn finalize_turn_with_idle_notification_skips_double_idle() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox, task_board, broadcaster.clone());
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox, task_board, broadcaster.clone());
 
     mgr.set_status("worker-1", TeammateStatus::Working).await.unwrap();
 
@@ -794,7 +794,7 @@ async fn finalize_turn_all_teammates_done_signals_leader_wake() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox, task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox, task_board, broadcaster);
 
     mgr.set_status("worker-1", TeammateStatus::Working).await.unwrap();
     mgr.set_status("worker-2", TeammateStatus::Working).await.unwrap();
@@ -814,13 +814,14 @@ async fn wake_payload_includes_tasks_and_unread() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board.clone(), broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board.clone(), broadcaster);
 
-    task_board.create_task("t1", "Task A", None, None, &[]).await.unwrap();
+    task_board.create_task("t1", "s1", "Task A", None, None, &[]).await.unwrap();
 
     mailbox
         .write(
             "t1",
+            "s1",
             "worker-1",
             "lead-1",
             MailboxMessageType::Message,
@@ -845,12 +846,12 @@ async fn mark_idle_with_summary_writes_idle_notification_to_lead() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     mgr.set_status("worker-1", TeammateStatus::Working).await.unwrap();
     mgr.mark_idle("worker-1", Some("sub-task done")).await.unwrap();
 
-    let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+    let lead_msgs = mailbox.read_unread("t1", "s1", "lead-1").await.unwrap();
     assert_eq!(lead_msgs.len(), 1);
     assert_eq!(lead_msgs[0].msg_type, MailboxMessageType::IdleNotification);
     assert_eq!(lead_msgs[0].from_agent_id, "worker-1");
@@ -865,12 +866,12 @@ async fn mark_idle_without_summary_still_writes_fallback_content() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     mgr.set_status("worker-1", TeammateStatus::Working).await.unwrap();
     mgr.mark_idle("worker-1", None).await.unwrap();
 
-    let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+    let lead_msgs = mailbox.read_unread("t1", "s1", "lead-1").await.unwrap();
     assert_eq!(lead_msgs.len(), 1);
     assert_eq!(lead_msgs[0].content, "idle");
     assert!(lead_msgs[0].summary.is_none());
@@ -883,12 +884,12 @@ async fn mark_idle_from_lead_does_not_write_notification() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     mgr.set_status("lead-1", TeammateStatus::Working).await.unwrap();
     mgr.mark_idle("lead-1", Some("done")).await.unwrap();
 
-    let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+    let lead_msgs = mailbox.read_unread("t1", "s1", "lead-1").await.unwrap();
     assert!(lead_msgs.is_empty());
 }
 
@@ -1304,13 +1305,13 @@ async fn write_crash_testament_delivers_to_lead_mailbox() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     mgr.write_crash_testament("worker-1", "Worker1", &CrashReason::ProcessExited, None)
         .await
         .unwrap();
 
-    let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+    let lead_msgs = mailbox.read_unread("t1", "s1", "lead-1").await.unwrap();
     assert_eq!(lead_msgs.len(), 1);
     assert_eq!(lead_msgs[0].from_agent_id, "worker-1");
     assert!(lead_msgs[0].content.contains("ProcessExited"));
@@ -1330,7 +1331,7 @@ async fn write_crash_testament_noop_when_no_lead() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     // Should not panic or error
     mgr.write_crash_testament("worker-1", "Worker1", &CrashReason::SessionNotFound, Some("last words"))
@@ -1338,8 +1339,8 @@ async fn write_crash_testament_noop_when_no_lead() {
         .unwrap();
 
     // No messages delivered to anyone
-    let msgs1 = mailbox.read_unread("t1", "worker-1").await.unwrap();
-    let msgs2 = mailbox.read_unread("t1", "worker-2").await.unwrap();
+    let msgs1 = mailbox.read_unread("t1", "s1", "worker-1").await.unwrap();
+    let msgs2 = mailbox.read_unread("t1", "s1", "worker-2").await.unwrap();
     assert!(msgs1.is_empty());
     assert!(msgs2.is_empty());
 }
@@ -1353,14 +1354,14 @@ async fn write_crash_testament_noop_when_lead_crashes() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     // Lead crashing should not write to itself
     mgr.write_crash_testament("lead-1", "Lead", &CrashReason::ProcessExited, None)
         .await
         .unwrap();
 
-    let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+    let lead_msgs = mailbox.read_unread("t1", "s1", "lead-1").await.unwrap();
     assert!(lead_msgs.is_empty());
 }
 
@@ -1410,13 +1411,13 @@ async fn handle_agent_crash_writes_testament_to_lead() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     mgr.handle_agent_crash("worker-1", CrashReason::Unknown("segfault".into()), Some("cleaning up"))
         .await
         .unwrap();
 
-    let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+    let lead_msgs = mailbox.read_unread("t1", "s1", "lead-1").await.unwrap();
     assert_eq!(lead_msgs.len(), 1);
     assert_eq!(lead_msgs[0].from_agent_id, "worker-1");
     assert!(lead_msgs[0].content.contains("Worker1"));
@@ -1454,7 +1455,7 @@ async fn handle_agent_crash_leader_branch_returns_none() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     mgr.set_status("lead-1", TeammateStatus::Working).await.unwrap();
     assert!(mgr.acquire_wake_lock("lead-1"));
@@ -1474,7 +1475,7 @@ async fn handle_agent_crash_leader_branch_returns_none() {
     // Leader cannot write a testament to itself — the mailbox must be
     // empty, otherwise the leader would read its own death notice on a
     // future resume.
-    let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+    let lead_msgs = mailbox.read_unread("t1", "s1", "lead-1").await.unwrap();
     assert!(
         lead_msgs.is_empty(),
         "leader crash must not produce a self-addressed testament"
@@ -1564,7 +1565,7 @@ async fn handle_inactivity_timeout_teammate_marks_error_and_wakes_lead() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     mgr.set_status("worker-1", TeammateStatus::Working).await.unwrap();
 
@@ -1577,7 +1578,7 @@ async fn handle_inactivity_timeout_teammate_marks_error_and_wakes_lead() {
     );
     assert_eq!(wake_target, Some("lead-1".to_string()));
 
-    let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+    let lead_msgs = mailbox.read_unread("t1", "s1", "lead-1").await.unwrap();
     assert_eq!(lead_msgs.len(), 1);
     assert_eq!(lead_msgs[0].from_agent_id, "worker-1");
     assert_eq!(lead_msgs[0].msg_type, MailboxMessageType::Message);
@@ -1592,7 +1593,7 @@ async fn handle_inactivity_timeout_leader_returns_none_no_mailbox_write() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     mgr.set_status("lead-1", TeammateStatus::Working).await.unwrap();
     assert!(mgr.acquire_wake_lock("lead-1"));
@@ -1606,7 +1607,7 @@ async fn handle_inactivity_timeout_leader_returns_none_no_mailbox_write() {
         "lock must be released even when leader stuck"
     );
 
-    let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+    let lead_msgs = mailbox.read_unread("t1", "s1", "lead-1").await.unwrap();
     assert!(
         lead_msgs.is_empty(),
         "leader must not receive a self-addressed timeout message"
@@ -1669,14 +1670,14 @@ async fn handle_inactivity_timeout_no_lead_returns_none() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     let wake_target = mgr.handle_inactivity_timeout("worker-1").await.unwrap();
 
     assert_eq!(wake_target, None);
     assert_eq!(mgr.get_status("worker-1").await.unwrap(), TeammateStatus::Error);
 
-    let msgs2 = mailbox.read_unread("t1", "worker-2").await.unwrap();
+    let msgs2 = mailbox.read_unread("t1", "s1", "worker-2").await.unwrap();
     assert!(msgs2.is_empty());
 }
 
@@ -1689,13 +1690,13 @@ async fn notify_shutdown_rejected_delivers_to_lead_mailbox() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     mgr.notify_shutdown_rejected("worker-1", "still working on task X")
         .await
         .unwrap();
 
-    let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+    let lead_msgs = mailbox.read_unread("t1", "s1", "lead-1").await.unwrap();
     assert_eq!(lead_msgs.len(), 1);
     assert_eq!(lead_msgs[0].from_agent_id, "worker-1");
     assert!(lead_msgs[0].content.contains("Worker1"));
@@ -1716,12 +1717,12 @@ async fn notify_shutdown_rejected_noop_when_no_lead() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     mgr.notify_shutdown_rejected("worker-1", "busy").await.unwrap();
 
-    let msgs1 = mailbox.read_unread("t1", "worker-1").await.unwrap();
-    let msgs2 = mailbox.read_unread("t1", "worker-2").await.unwrap();
+    let msgs1 = mailbox.read_unread("t1", "s1", "worker-1").await.unwrap();
+    let msgs2 = mailbox.read_unread("t1", "s1", "worker-2").await.unwrap();
     assert!(msgs1.is_empty());
     assert!(msgs2.is_empty());
 }
@@ -1733,10 +1734,10 @@ async fn notify_shutdown_rejected_noop_when_sender_is_lead() {
     let mailbox = Arc::new(Mailbox::new(repo.clone()));
     let task_board = Arc::new(TaskBoard::new(repo));
     let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(RecordingBroadcaster::new());
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox.clone(), task_board, broadcaster);
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox.clone(), task_board, broadcaster);
 
     mgr.notify_shutdown_rejected("lead-1", "irrelevant").await.unwrap();
 
-    let lead_msgs = mailbox.read_unread("t1", "lead-1").await.unwrap();
+    let lead_msgs = mailbox.read_unread("t1", "s1", "lead-1").await.unwrap();
     assert!(lead_msgs.is_empty());
 }

--- a/crates/aionui-team/src/scheduler/wake.rs
+++ b/crates/aionui-team/src/scheduler/wake.rs
@@ -10,8 +10,8 @@ use crate::error::TeamError;
 impl TeammateManager {
     pub async fn build_wake_payload(&self, slot_id: &str) -> Result<WakePayload, TeamError> {
         let agent = self.get_agent(slot_id).await?;
-        let tasks = self.task_board.list_tasks(&self.team_id).await?;
-        let unread = self.mailbox.read_unread(&self.team_id, slot_id).await?;
+        let tasks = self.task_board.list_tasks(&self.team_id, &self.session_id).await?;
+        let unread = self.mailbox.read_unread(&self.team_id, &self.session_id, slot_id).await?;
         Ok(WakePayload {
             agent,
             tasks,

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -9,12 +9,12 @@ use std::sync::{Arc, RwLock, Weak};
 use aionui_ai_agent::{ActiveLeaseRegistry, AgentError, AgentInstance, IWorkerTaskManager, IdleCleanupCoordinator};
 use aionui_api_types::{
     AddAgentRequest, CreateTeamRequest, GetConfigOptionsResponse, TeamAgentResponse, TeamAgentRuntimeStatus,
-    TeamResponse, TeamRunAckResponse, TeamRunStateResponse, TeamSessionBinding, TeamSessionPhase, TeamSessionStatus,
-    TeamSessionStatusPayload, TeamToolCall, TeamToolContextResponse, TeamToolErrorCode, TeamToolErrorPayload,
-    TeamToolTransport, WebSocketMessage,
+    TeamResponse, TeamRunAckResponse, TeamRunStateResponse, TeamSessionAgentResponse, TeamSessionBinding,
+    TeamSessionPhase, TeamSessionResponse, TeamSessionStatus, TeamSessionStatusPayload, TeamToolCall,
+    TeamToolContextResponse, TeamToolErrorCode, TeamToolErrorPayload, TeamToolTransport, WebSocketMessage,
 };
 use aionui_common::{AgentKillReason, ConversationStatus, TimestampMs, generate_id, now_ms};
-use aionui_db::models::TeamRow;
+use aionui_db::models::{TeamRow, TeamSessionRow};
 use aionui_db::{
     IAgentMetadataRepository, IAssistantDefinitionRepository, IAssistantOverlayRepository, IProviderRepository,
     ITeamRepository, UpdateTeamParams,
@@ -269,6 +269,13 @@ impl TeamSessionService {
     }
 
     async fn load_owned_team(&self, user_id: &str, team_id: &str) -> Result<Team, TeamError> {
+        let row = self.load_owned_team_row(user_id, team_id).await?;
+        Ok(Team::from_row(&row)?)
+    }
+
+    /// Like [`load_owned_team`] but returns the raw DB row (needed by callers
+    /// that read `active_session_id` / `session_mode` directly).
+    async fn load_owned_team_row(&self, user_id: &str, team_id: &str) -> Result<TeamRow, TeamError> {
         let row = self
             .repo
             .get_team(team_id)
@@ -279,7 +286,7 @@ impl TeamSessionService {
                 "team {team_id} is not owned by current user"
             )));
         }
-        Ok(Team::from_row(&row)?)
+        Ok(row)
     }
 
     pub async fn renew_active_lease(
@@ -370,9 +377,21 @@ impl TeamSessionService {
         let team_id = generate_id();
         let now = now_ms();
 
+        // Provision the team's primary working session id FIRST (migration
+        // 030) so each freshly-minted conversation carries it in its `extra`
+        // and is bound to it. The session row is persisted after the
+        // conversations exist (below).
+        let primary_session_id = generate_id();
+
         let provisioned = self
             .provisioner()
-            .provision_initial_agents(user_id, &team_id, &req.agents, shared_workspace.as_deref())
+            .provision_initial_agents(
+                user_id,
+                &team_id,
+                &primary_session_id,
+                &req.agents,
+                shared_workspace.as_deref(),
+            )
             .await?;
         let agents = provisioned.agents;
         let lead_agent_id = provisioned.lead_agent_id;
@@ -381,6 +400,33 @@ impl TeamSessionService {
 
         // Project-bind side branch (best-effort; never affects team creation).
         let (project_id, folder_id) = self.resolve_binding_best_effort(&team_workspace).await;
+
+        // Persist the primary session row and bind each roster slot's
+        // conversation to it. Every team owns at least one session; the
+        // primary is the default active session and the fallback target for
+        // session_id-less callers.
+        self.repo
+            .create_team_session(&TeamSessionRow {
+                id: primary_session_id.clone(),
+                team_id: team_id.clone(),
+                name: "Main".to_owned(),
+                is_primary: true,
+                created_at: now,
+                updated_at: now,
+            })
+            .await?;
+        for agent in &agents {
+            self.repo
+                .bind_session_conversation(&aionui_db::models::TeamSessionAgentRow {
+                    id: 0,
+                    session_id: primary_session_id.clone(),
+                    team_id: team_id.clone(),
+                    slot_id: agent.slot_id.clone(),
+                    conversation_id: agent.conversation_id.clone(),
+                    created_at: now,
+                })
+                .await?;
+        }
 
         let row = TeamRow {
             id: team_id.clone(),
@@ -396,6 +442,7 @@ impl TeamSessionService {
             updated_at: now,
             project_id,
             folder_id,
+            active_session_id: Some(primary_session_id.clone()),
         };
         self.repo.create_team(&row).await?;
 
@@ -407,6 +454,7 @@ impl TeamSessionService {
             lead_agent_id,
             created_at: now,
             updated_at: now,
+            active_session_id: Some(primary_session_id.clone()),
         };
 
         info!(
@@ -858,6 +906,13 @@ impl TeamSessionService {
         let team = Team::from_row(&row)?;
         let agents_snapshot: Vec<TeamAgent> = team.agents.clone();
 
+        // Resolve the active working session for this team. Pre-feature teams
+        // have a single (primary) session backfilled by migration 030; the
+        // active pointer is read first, falling back to the team's primary
+        // session row, and finally lazily provisioning one if neither exists
+        // (defensive — migration 030 backfills every team, so this is rare).
+        let session_id = self.resolve_active_session_id(team_id, &row).await?;
+
         if let Some(session) = self.sessions.get(team_id).map(|entry| Arc::clone(&entry.session)) {
             let work = self
                 .reserve_member_runtime_reconciliation(&session, &agents_snapshot)
@@ -902,6 +957,7 @@ impl TeamSessionService {
 
         let session = match TeamSession::start_with_prompt_dump(
             team,
+            session_id,
             self.repo.clone(),
             self.broadcaster.clone(),
             self.backend_binary_path.clone(),
@@ -1614,6 +1670,7 @@ impl TeamSessionService {
             team_id: team_id.clone(),
             slot_id: binding_lookup.slot_id,
             role: binding_lookup.role,
+            session_id: binding_lookup.session_id,
             runtime_seed: Default::default(),
             mcp: None,
         };
@@ -1676,6 +1733,73 @@ impl TeamSessionService {
         self.load_owned_team(user_id, team_id).await?;
         self.stop_session_unchecked(team_id);
         Ok(())
+    }
+
+    /// Resolve the active working-session id for a team.
+    ///
+    /// Order: (1) the team's persisted `active_session_id` pointer, (2) the
+    /// team's primary session row (migration 030 backfills one for every
+    /// pre-existing team), (3) lazily create a primary session row if neither
+    /// exists (defensive — should not happen post-migration, but keeps startup
+    /// robust). The pointer is also persisted so subsequent calls skip the
+    /// lookup.
+    async fn resolve_active_session_id(&self, team_id: &str, row: &TeamRow) -> Result<String, TeamError> {
+        if let Some(id) = row.active_session_id.as_deref()
+            && self.repo.get_team_session(id).await?.is_some()
+        {
+            return Ok(id.to_owned());
+        }
+
+        let sessions = self.repo.list_team_sessions(team_id).await?;
+        if let Some(primary) = sessions.iter().find(|s| s.is_primary) {
+            let id = primary.id.clone();
+            self.persist_active_session_id(team_id, &id).await;
+            return Ok(id);
+        }
+        if let Some(first) = sessions.first() {
+            let id = first.id.clone();
+            self.persist_active_session_id(team_id, &id).await;
+            return Ok(id);
+        }
+
+        // No session row at all: provision a primary one. This mirrors what
+        // migration 030 does for pre-existing teams and what team creation
+        // (post-this-feature) will do explicitly.
+        let now = now_ms();
+        let id = format!("primary_{team_id}");
+        self.repo
+            .create_team_session(&TeamSessionRow {
+                id: id.clone(),
+                team_id: team_id.to_owned(),
+                name: "Main".to_owned(),
+                is_primary: true,
+                created_at: now,
+                updated_at: now,
+            })
+            .await?;
+        self.persist_active_session_id(team_id, &id).await;
+        Ok(id)
+    }
+
+    async fn persist_active_session_id(&self, team_id: &str, session_id: &str) {
+        if let Err(error) = self
+            .repo
+            .update_team(
+                team_id,
+                &UpdateTeamParams {
+                    active_session_id: Some(session_id.to_owned()),
+                    ..Default::default()
+                },
+            )
+            .await
+        {
+            warn!(
+                team_id,
+                session_id,
+                %error,
+                "failed to persist team active_session_id (non-fatal)"
+            );
+        }
     }
 
     fn stop_session_unchecked(&self, team_id: &str) {
@@ -1950,6 +2074,265 @@ impl TeamSessionService {
             }
         }
 
+        Ok(())
+    }
+
+    // ── Team working sessions (migration 030) ──────────────────────────────
+
+    /// List all working sessions for a team. The primary session is ordered
+    /// first by the repository. Per-slot conversation bindings are NOT
+    /// populated here (use [`get_team_session`] for a single session with
+    /// bindings); the list endpoint favours brevity.
+    pub async fn list_team_sessions(
+        &self,
+        user_id: &str,
+        team_id: &str,
+    ) -> Result<Vec<TeamSessionResponse>, TeamError> {
+        self.load_owned_team(user_id, team_id).await?;
+        let rows = self.repo.list_team_sessions(team_id).await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| TeamSessionResponse {
+                id: row.id,
+                team_id: row.team_id,
+                name: row.name,
+                is_primary: row.is_primary,
+                agents: Vec::new(),
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+            })
+            .collect())
+    }
+
+    /// Create a new working session under an existing team. Each roster slot
+    /// gets a freshly-minted conversation bound to the new session; the team
+    /// roster/config itself is unchanged. The new session does NOT become
+    /// active automatically — the client calls [`set_active_session`] to
+    /// switch to it.
+    pub async fn create_team_session(
+        &self,
+        user_id: &str,
+        team_id: &str,
+        name: Option<&str>,
+    ) -> Result<TeamSessionResponse, TeamError> {
+        let row = self.load_owned_team_row(user_id, team_id).await?;
+        let team = Team::from_row(&row)?;
+
+        // Default name: "Session N" where N = current count + 1.
+        let existing = self.repo.list_team_sessions(team_id).await?;
+        let name = name
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+            .unwrap_or_else(|| format!("Session {}", existing.len() + 1));
+        if existing.iter().any(|s| s.name == name) {
+            return Err(TeamError::InvalidRequest(format!(
+                "session name already exists in this team: {name}"
+            )));
+        }
+
+        let now = now_ms();
+        let session_id = generate_id();
+        self.repo
+            .create_team_session(&TeamSessionRow {
+                id: session_id.clone(),
+                team_id: team_id.to_owned(),
+                name: name.clone(),
+                is_primary: false,
+                created_at: now,
+                updated_at: now,
+            })
+            .await?;
+
+        // Mint a fresh conversation for every roster slot, bound to this
+        // session. Reuses the same provisioning path as initial agents so
+        // each conversation carries the right `extra` (teamId/sessionId/
+        // slot_id/role/backend/session_mode).
+        let provisioner = self.provisioner();
+        let mut bindings = Vec::with_capacity(team.agents.len());
+        for agent in &team.agents {
+            let conversation = provisioner
+                .provision_session_agent_conversation(
+                    user_id,
+                    team_id,
+                    &session_id,
+                    agent,
+                    row.session_mode.as_deref(),
+                )
+                .await?;
+            self.repo
+                .bind_session_conversation(&aionui_db::models::TeamSessionAgentRow {
+                    id: 0,
+                    session_id: session_id.clone(),
+                    team_id: team_id.to_owned(),
+                    slot_id: agent.slot_id.clone(),
+                    conversation_id: conversation.conversation_id.clone(),
+                    created_at: now,
+                })
+                .await?;
+            bindings.push(TeamSessionAgentResponse {
+                slot_id: agent.slot_id.clone(),
+                conversation_id: conversation.conversation_id,
+            });
+        }
+
+        info!(team_id, session_id = %session_id, name = %name, "team session created");
+
+        Ok(TeamSessionResponse {
+            id: session_id,
+            team_id: team_id.to_owned(),
+            name,
+            is_primary: false,
+            agents: bindings,
+            created_at: now,
+            updated_at: now,
+        })
+    }
+
+    /// Get a single session with its per-slot conversation bindings.
+    pub async fn get_team_session(
+        &self,
+        user_id: &str,
+        team_id: &str,
+        session_id: &str,
+    ) -> Result<TeamSessionResponse, TeamError> {
+        let row = self.load_owned_team_row(user_id, team_id).await?;
+        let session = self
+            .repo
+            .get_team_session(session_id)
+            .await?
+            .ok_or_else(|| TeamError::SessionNotFound(session_id.to_owned()))?;
+        if session.team_id != team_id {
+            return Err(TeamError::SessionNotFound(session_id.to_owned()));
+        }
+        let bindings = self
+            .repo
+            .list_session_agents(session_id)
+            .await?
+            .into_iter()
+            .map(|b| TeamSessionAgentResponse {
+                slot_id: b.slot_id,
+                conversation_id: b.conversation_id,
+            })
+            .collect();
+        // Touch row to silence unused-var lint while documenting the ownership
+        // check already performed above.
+        let _ = &row;
+        Ok(TeamSessionResponse {
+            id: session.id,
+            team_id: session.team_id,
+            name: session.name,
+            is_primary: session.is_primary,
+            agents: bindings,
+            created_at: session.created_at,
+            updated_at: session.updated_at,
+        })
+    }
+
+    /// Rename a session. The primary session can be renamed too (its
+    /// `is_primary` flag is what makes it the default, not its name).
+    pub async fn rename_team_session(
+        &self,
+        user_id: &str,
+        team_id: &str,
+        session_id: &str,
+        name: &str,
+    ) -> Result<(), TeamError> {
+        self.load_owned_team(user_id, team_id).await?;
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(TeamError::InvalidRequest("session name cannot be empty".into()));
+        }
+        // Enforce per-team name uniqueness.
+        let existing = self.repo.list_team_sessions(team_id).await?;
+        if existing
+            .iter()
+            .any(|s| s.id != session_id && s.name == name)
+        {
+            return Err(TeamError::InvalidRequest(format!(
+                "session name already exists in this team: {name}"
+            )));
+        }
+        self.repo
+            .update_team_session(
+                session_id,
+                &aionui_db::UpdateTeamSessionParams {
+                    name: Some(name.to_owned()),
+                },
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Delete a session. The primary session cannot be deleted. Deleting a
+    /// session removes its per-slot conversation bindings and its mailbox/
+    /// task rows; the underlying conversations are left in place (the user
+    /// may still reach them via the team's other sessions or history).
+    pub async fn delete_team_session(
+        &self,
+        user_id: &str,
+        team_id: &str,
+        session_id: &str,
+    ) -> Result<(), TeamError> {
+        self.load_owned_team(user_id, team_id).await?;
+        let session = self
+            .repo
+            .get_team_session(session_id)
+            .await?
+            .ok_or_else(|| TeamError::SessionNotFound(session_id.to_owned()))?;
+        if session.team_id != team_id {
+            return Err(TeamError::SessionNotFound(session_id.to_owned()));
+        }
+        if session.is_primary {
+            return Err(TeamError::InvalidRequest(
+                "the primary session cannot be deleted".into(),
+            ));
+        }
+        // If the deleted session is the active one, repoint active to primary.
+        let team_row = self.repo.get_team(team_id).await?.ok_or_else(|| TeamError::TeamNotFound(team_id.into()))?;
+        if team_row.active_session_id.as_deref() == Some(session_id)
+            && let Some(primary) = self
+                .repo
+                .list_team_sessions(team_id)
+                .await?
+                .into_iter()
+                .find(|s| s.is_primary)
+        {
+            self.persist_active_session_id(team_id, &primary.id).await;
+        }
+        // Stop the in-memory session if it is currently running for this id.
+        self.stop_session_unchecked(team_id);
+        self.repo.delete_mailbox_by_session(team_id, session_id).await?;
+        self.repo.delete_tasks_by_session(team_id, session_id).await?;
+        self.repo.delete_session_agents_by_session(session_id).await?;
+        self.repo.delete_team_session(session_id).await?;
+        info!(team_id, session_id, "team session deleted");
+        Ok(())
+    }
+
+    /// Set the team's active working session pointer. Subsequent
+    /// `ensure_session` / `send_message` calls without an explicit session
+    /// target operate on this session.
+    pub async fn set_active_session(
+        &self,
+        user_id: &str,
+        team_id: &str,
+        session_id: &str,
+    ) -> Result<(), TeamError> {
+        self.load_owned_team(user_id, team_id).await?;
+        let session = self
+            .repo
+            .get_team_session(session_id)
+            .await?
+            .ok_or_else(|| TeamError::SessionNotFound(session_id.to_owned()))?;
+        if session.team_id != team_id {
+            return Err(TeamError::SessionNotFound(session_id.to_owned()));
+        }
+        // Stop any currently-running in-memory session for this team so the
+        // next ensure rebuilds it against the new active session id.
+        self.stop_session_unchecked(team_id);
+        self.persist_active_session_id(team_id, session_id).await;
+        info!(team_id, session_id, "team active session set");
         Ok(())
     }
 

--- a/crates/aionui-team/src/service/response_builder.rs
+++ b/crates/aionui-team/src/service/response_builder.rs
@@ -15,6 +15,7 @@ impl TeamSessionService {
             leader_assistant_id: team.lead_agent_id.clone(),
             created_at: team.created_at,
             updated_at: team.updated_at,
+            active_session_id: team.active_session_id.clone(),
         })
     }
 

--- a/crates/aionui-team/src/session.rs
+++ b/crates/aionui-team/src/session.rs
@@ -84,6 +84,7 @@ pub struct SpawnAgentRequest {
 
 pub struct TeamSession {
     team: Team,
+    session_id: String,
     scheduler: Arc<TeammateManager>,
     mailbox: Arc<Mailbox>,
     task_board: Arc<TaskBoard>,
@@ -134,6 +135,7 @@ impl TeamSession {
     #[allow(clippy::too_many_arguments)]
     pub async fn start(
         team: Team,
+        session_id: String,
         repo: Arc<dyn ITeamRepository>,
         broadcaster: Arc<dyn EventBroadcaster>,
         backend_binary_path: Arc<PathBuf>,
@@ -146,6 +148,7 @@ impl TeamSession {
     ) -> Result<Self, TeamError> {
         Self::start_with_prompt_dump(
             team,
+            session_id,
             repo,
             broadcaster,
             backend_binary_path,
@@ -163,6 +166,7 @@ impl TeamSession {
     #[allow(clippy::too_many_arguments)]
     pub async fn start_with_prompt_dump(
         team: Team,
+        session_id: String,
         repo: Arc<dyn ITeamRepository>,
         broadcaster: Arc<dyn EventBroadcaster>,
         backend_binary_path: Arc<PathBuf>,
@@ -189,6 +193,7 @@ impl TeamSession {
 
         let scheduler = Arc::new(TeammateManager::new(
             team.id.clone(),
+            session_id.clone(),
             &team.agents,
             mailbox.clone(),
             task_board.clone(),
@@ -216,6 +221,7 @@ impl TeamSession {
 
         Ok(Self {
             team,
+            session_id,
             scheduler,
             mailbox,
             task_board,
@@ -250,6 +256,10 @@ impl TeamSession {
 
     pub fn team_id(&self) -> &str {
         &self.team.id
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.session_id
     }
 
     pub fn user_id(&self) -> &str {
@@ -340,7 +350,7 @@ impl TeamSession {
 
         let unread = self
             .mailbox
-            .peek_unread(&self.team.id, slot_id)
+            .peek_unread(&self.team.id, &self.session_id, slot_id)
             .await?
             .into_iter()
             .filter(|message| message.from_agent_id != slot_id)
@@ -507,7 +517,7 @@ impl TeamSession {
         // working (e.g. shutdown_request). Mirrors Claude's useMailboxBridge:
         // when isLoading becomes false, poll mailbox and submit if non-empty.
         if wake_target.as_deref() != Some(&slot_id) {
-            let has_unread = self.mailbox.has_unread(&self.team.id, &slot_id).await.unwrap_or(false);
+            let has_unread = self.mailbox.has_unread(&self.team.id, &self.session_id, &slot_id).await.unwrap_or(false);
             if has_unread {
                 return Ok(Some(slot_id));
             }
@@ -682,6 +692,7 @@ impl TeamSession {
             .mailbox
             .write_with_files(
                 &self.team.id,
+                &self.session_id,
                 slot_id,
                 "user",
                 MailboxMessageType::Message,
@@ -781,6 +792,7 @@ impl TeamSession {
             .mailbox
             .write_with_files(
                 &self.team.id,
+                &self.session_id,
                 to_slot_id,
                 from_slot_id,
                 MailboxMessageType::Message,
@@ -995,7 +1007,7 @@ impl TeamSession {
             }
             let unread = self
                 .mailbox
-                .peek_unread(&self.team.id, &agent.slot_id)
+                .peek_unread(&self.team.id, &self.session_id, &agent.slot_id)
                 .await?
                 .into_iter()
                 .filter(|message| message.from_agent_id != agent.slot_id)
@@ -1227,6 +1239,7 @@ impl TeamSession {
             self.mailbox
                 .write(
                     &self.team.id,
+                    &self.session_id,
                     &lead_slot_id,
                     slot_id,
                     MailboxMessageType::IdleNotification,
@@ -1252,6 +1265,7 @@ impl TeamSession {
         self.mailbox
             .write(
                 &self.team.id,
+                &self.session_id,
                 &lead_slot_id,
                 failed_slot_id,
                 MailboxMessageType::Message,
@@ -1275,7 +1289,7 @@ impl TeamSession {
             .ok_or_else(|| TeamError::AgentNotFound("lead".into()))?;
         let message_id = self
             .mailbox
-            .peek_unread(&self.team.id, &lead_slot_id)
+            .peek_unread(&self.team.id, &self.session_id, &lead_slot_id)
             .await?
             .into_iter()
             .rev()
@@ -1310,6 +1324,7 @@ impl TeamSession {
             .mailbox
             .write(
                 &self.team.id,
+                &self.session_id,
                 &agent.slot_id,
                 "team_system",
                 MailboxMessageType::Message,
@@ -1321,6 +1336,7 @@ impl TeamSession {
             .mailbox
             .write(
                 &self.team.id,
+                &self.session_id,
                 &lead_slot_id,
                 "team_system",
                 MailboxMessageType::Message,
@@ -1367,6 +1383,7 @@ impl TeamSession {
             .mailbox
             .write(
                 &self.team.id,
+                &self.session_id,
                 &lead_slot_id,
                 "team_system",
                 MailboxMessageType::Message,
@@ -1548,6 +1565,7 @@ impl TeamSession {
             .mailbox
             .write(
                 &self.team.id,
+                &self.session_id,
                 &new_agent.slot_id,
                 caller_slot_id,
                 MailboxMessageType::Message,
@@ -2219,6 +2237,7 @@ mod tests {
             lead_agent_id: Some("lead-1".into()),
             created_at: 1000,
             updated_at: 1000,
+            active_session_id: None,
         }
     }
 
@@ -2231,6 +2250,7 @@ mod tests {
         let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
         TeamSession::start_with_prompt_dump(
             make_team(),
+            "s1".to_owned(),
             repo,
             broadcaster,
             backend_path(),
@@ -2327,6 +2347,7 @@ mod tests {
         let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
         let session = TeamSession::start(
             make_team(),
+            "s1".to_owned(),
             repo_dyn,
             broadcaster,
             backend_path(),
@@ -2356,6 +2377,7 @@ mod tests {
         let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
         let session = TeamSession::start(
             make_team(),
+            "s1".to_owned(),
             repo_dyn,
             broadcaster,
             backend_path(),
@@ -2397,7 +2419,7 @@ mod tests {
             .await
             .expect("leader may shut down a teammate");
 
-        let unread = session.mailbox().peek_unread("t1", "worker-1").await.unwrap();
+        let unread = session.mailbox().peek_unread("t1", "s1", "worker-1").await.unwrap();
         assert_eq!(unread.len(), 1);
         // A run-scoped shutdown wake with no inheritable run now converges into a
         // SystemLifecycle run at the enqueue choke-point instead of enqueuing
@@ -2450,6 +2472,7 @@ mod tests {
         let stub_dyn: Arc<dyn IWorkerTaskManager> = stub.clone();
         let session = TeamSession::start(
             make_team(),
+            "s1".to_owned(),
             repo,
             broadcaster,
             backend_path(),
@@ -2483,6 +2506,7 @@ mod tests {
         let stub_dyn: Arc<dyn IWorkerTaskManager> = stub.clone();
         let session = TeamSession::start(
             make_team(),
+            "s1".to_owned(),
             repo,
             broadcaster,
             backend_path(),
@@ -2579,6 +2603,7 @@ mod tests {
             .mailbox()
             .write(
                 session.team_id(),
+                session.session_id(),
                 &lead,
                 "worker-1",
                 MailboxMessageType::Message,
@@ -2591,6 +2616,7 @@ mod tests {
             .mailbox()
             .write(
                 session.team_id(),
+                session.session_id(),
                 &lead,
                 "worker-2",
                 MailboxMessageType::Message,
@@ -2603,6 +2629,7 @@ mod tests {
             .mailbox()
             .write(
                 session.team_id(),
+                session.session_id(),
                 &worker,
                 &worker,
                 MailboxMessageType::Message,
@@ -2651,6 +2678,7 @@ mod tests {
             .mailbox()
             .write(
                 session.team_id(),
+                session.session_id(),
                 &lead,
                 "worker-1",
                 MailboxMessageType::Message,
@@ -2722,6 +2750,7 @@ mod tests {
         let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
         let session = TeamSession::start(
             make_team(),
+            "s1".to_owned(),
             repo_dyn,
             broadcaster,
             backend_path(),
@@ -2746,7 +2775,7 @@ mod tests {
             .await
             .unwrap();
 
-        let unread = session.mailbox.peek_unread("t1", "lead-1").await.unwrap();
+        let unread = session.mailbox.peek_unread("t1", "s1", "lead-1").await.unwrap();
         assert_eq!(unread.len(), 1);
         assert_eq!(
             unread[0].files.as_deref(),
@@ -2775,6 +2804,7 @@ mod tests {
             .mailbox
             .write(
                 "t1",
+                "s1",
                 "lead-1",
                 "user",
                 MailboxMessageType::Message,
@@ -2792,7 +2822,7 @@ mod tests {
 
         assert!(matches!(error, TeamError::InvalidRequest(_)));
         assert!(session.team_run_manager.current_active_run_id().is_none());
-        assert!(session.mailbox.peek_unread("t1", "lead-1").await.unwrap().is_empty());
+        assert!(session.mailbox.peek_unread("t1", "s1", "lead-1").await.unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -2824,6 +2854,7 @@ mod tests {
         let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
         let session = TeamSession::start(
             make_team(),
+            "s1".to_owned(),
             repo,
             broadcaster,
             backend_path(),
@@ -2874,6 +2905,7 @@ mod tests {
         let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
         let session = TeamSession::start(
             make_team(),
+            "s1".to_owned(),
             repo_dyn,
             broadcaster,
             backend_path(),
@@ -2901,7 +2933,7 @@ mod tests {
         assert!(
             session
                 .mailbox
-                .peek_unread("t1", "lead-1")
+                .peek_unread("t1", "s1", "lead-1")
                 .await
                 .unwrap()
                 .iter()
@@ -3063,7 +3095,7 @@ mod tests {
             .await
             .unwrap();
 
-        let unread = session.mailbox.peek_unread("t1", "worker-1").await.unwrap();
+        let unread = session.mailbox.peek_unread("t1", "s1", "worker-1").await.unwrap();
         assert_eq!(unread.len(), 1);
         assert_eq!(unread[0].files.as_deref(), Some(&["/tmp/x.md".into()][..]));
         assert_eq!(unread[0].content, "do X");
@@ -3076,7 +3108,7 @@ mod tests {
 
         session.send_message("", None).await.unwrap();
 
-        let unread = session.mailbox.peek_unread("t1", "lead-1").await.unwrap();
+        let unread = session.mailbox.peek_unread("t1", "s1", "lead-1").await.unwrap();
         assert_eq!(unread.len(), 1);
         assert_eq!(unread[0].content, "");
         session.stop();
@@ -3089,6 +3121,7 @@ mod tests {
         let broadcaster: Arc<dyn EventBroadcaster> = Arc::new(NullBroadcaster);
         TeamSession::start(
             team,
+            "s1".to_owned(),
             repo,
             broadcaster,
             backend_path(),
@@ -3111,6 +3144,7 @@ mod tests {
         let broadcaster: Arc<dyn EventBroadcaster> = recorder.clone();
         let session = TeamSession::start(
             team,
+            "s1".to_owned(),
             repo,
             broadcaster,
             backend_path(),

--- a/crates/aionui-team/src/task_board.rs
+++ b/crates/aionui-team/src/task_board.rs
@@ -31,13 +31,14 @@ impl TaskBoard {
     pub async fn create_task(
         &self,
         team_id: &str,
+        session_id: &str,
         subject: &str,
         description: Option<&str>,
         owner: Option<&str>,
         blocked_by: &[String],
     ) -> Result<TeamTask, TeamError> {
         for dep_id in blocked_by {
-            let dep = self.repo.find_task_by_id(team_id, dep_id).await?;
+            let dep = self.repo.find_task_by_id(team_id, session_id, dep_id).await?;
             if dep.is_none() {
                 return Err(TeamError::BlockedTaskNotFound(dep_id.clone()));
             }
@@ -59,6 +60,7 @@ impl TaskBoard {
             metadata: None,
             created_at: now,
             updated_at: now,
+            session_id: Some(session_id.to_owned()),
         };
 
         self.repo.create_task(&row).await?;
@@ -67,15 +69,21 @@ impl TaskBoard {
             self.repo.append_to_blocks(dep_id, &task_id).await?;
         }
 
-        debug!(team_id, task_id = %task_id, subject, "task created");
+        debug!(team_id, session_id, task_id = %task_id, subject, "task created");
 
         TeamTask::from_row(&row).map_err(TeamError::Json)
     }
 
-    pub async fn update_task(&self, team_id: &str, task_id: &str, update: &TaskUpdate) -> Result<TeamTask, TeamError> {
+    pub async fn update_task(
+        &self,
+        team_id: &str,
+        session_id: &str,
+        task_id: &str,
+        update: &TaskUpdate,
+    ) -> Result<TeamTask, TeamError> {
         let existing = self
             .repo
-            .find_task_by_id(team_id, task_id)
+            .find_task_by_id(team_id, session_id, task_id)
             .await?
             .ok_or_else(|| TeamError::TaskNotFound(task_id.to_owned()))?;
 
@@ -95,17 +103,17 @@ impl TaskBoard {
 
         let updated = self
             .repo
-            .find_task_by_id(team_id, task_id)
+            .find_task_by_id(team_id, session_id, task_id)
             .await?
             .ok_or_else(|| TeamError::TaskNotFound(task_id.to_owned()))?;
 
-        debug!(team_id, task_id, "task updated");
+        debug!(team_id, session_id, task_id, "task updated");
 
         TeamTask::from_row(&updated).map_err(TeamError::Json)
     }
 
-    pub async fn list_tasks(&self, team_id: &str) -> Result<Vec<TeamTask>, TeamError> {
-        let rows = self.repo.list_tasks(team_id).await?;
+    pub async fn list_tasks(&self, team_id: &str, session_id: &str) -> Result<Vec<TeamTask>, TeamError> {
+        let rows = self.repo.list_tasks(team_id, session_id).await?;
         let tasks = rows.iter().filter_map(|r| TeamTask::from_row(r).ok()).collect();
         Ok(tasks)
     }
@@ -134,7 +142,7 @@ mod tests {
     // -- Helper ---------------------------------------------------------------
 
     async fn create_simple_task(board: &TaskBoard, team_id: &str, subject: &str) -> TeamTask {
-        board.create_task(team_id, subject, None, None, &[]).await.unwrap()
+        board.create_task(team_id, "s1", subject, None, None, &[]).await.unwrap()
     }
 
     // -- Tests ----------------------------------------------------------------
@@ -157,7 +165,7 @@ mod tests {
         let board = TaskBoard::new(repo);
 
         let task = board
-            .create_task("t1", "Design API", Some("REST endpoints"), Some("a1"), &[])
+            .create_task("t1", "s1", "Design API", Some("REST endpoints"), Some("a1"), &[])
             .await
             .unwrap();
         assert_eq!(task.description.as_deref(), Some("REST endpoints"));
@@ -171,13 +179,13 @@ mod tests {
 
         let task_a = create_simple_task(&board, "t1", "Task A").await;
         let task_b = board
-            .create_task("t1", "Task B", None, None, std::slice::from_ref(&task_a.id))
+            .create_task("t1", "s1", "Task B", None, None, std::slice::from_ref(&task_a.id))
             .await
             .unwrap();
 
         assert_eq!(task_b.blocked_by, vec![task_a.id.clone()]);
 
-        let updated_a = repo.find_task_by_id("t1", &task_a.id).await.unwrap().unwrap();
+        let updated_a = repo.find_task_by_id("t1", "s1", &task_a.id).await.unwrap().unwrap();
         let blocks_a: Vec<String> = serde_json::from_str(&updated_a.blocks).unwrap();
         assert_eq!(blocks_a, vec![task_b.id]);
     }
@@ -187,7 +195,7 @@ mod tests {
         let repo = Arc::new(MockTeamRepo::new());
         let board = TaskBoard::new(repo);
 
-        let result = board.create_task("t1", "X", None, None, &["nonexistent".into()]).await;
+        let result = board.create_task("t1", "s1", "X", None, None, &["nonexistent".into()]).await;
         assert!(matches!(result, Err(TeamError::BlockedTaskNotFound(_))));
     }
 
@@ -200,6 +208,7 @@ mod tests {
         let updated = board
             .update_task(
                 "t1",
+                "s1",
                 &task.id,
                 &TaskUpdate {
                     status: Some(TaskStatus::InProgress),
@@ -220,6 +229,7 @@ mod tests {
         let updated = board
             .update_task(
                 "t1",
+                "s1",
                 &task.id,
                 &TaskUpdate {
                     description: Some("New desc".into()),
@@ -238,7 +248,7 @@ mod tests {
         let repo = Arc::new(MockTeamRepo::new());
         let board = TaskBoard::new(repo);
 
-        let result = board.update_task("t1", "nonexistent", &TaskUpdate::default()).await;
+        let result = board.update_task("t1", "s1", "nonexistent", &TaskUpdate::default()).await;
         assert!(matches!(result, Err(TeamError::TaskNotFound(_))));
     }
 
@@ -249,7 +259,7 @@ mod tests {
 
         let task_a = create_simple_task(&board, "t1", "A").await;
         let task_b = board
-            .create_task("t1", "B", None, None, std::slice::from_ref(&task_a.id))
+            .create_task("t1", "s1", "B", None, None, std::slice::from_ref(&task_a.id))
             .await
             .unwrap();
 
@@ -258,6 +268,7 @@ mod tests {
         board
             .update_task(
                 "t1",
+                "s1",
                 &task_a.id,
                 &TaskUpdate {
                     status: Some(TaskStatus::Completed),
@@ -267,7 +278,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tasks = board.list_tasks("t1").await.unwrap();
+        let tasks = board.list_tasks("t1", "s1").await.unwrap();
         let b = tasks.iter().find(|t| t.id == task_b.id).unwrap();
         assert!(b.blocked_by.is_empty());
     }
@@ -279,17 +290,18 @@ mod tests {
 
         let task_a = create_simple_task(&board, "t1", "A").await;
         let task_b = board
-            .create_task("t1", "B", None, None, std::slice::from_ref(&task_a.id))
+            .create_task("t1", "s1", "B", None, None, std::slice::from_ref(&task_a.id))
             .await
             .unwrap();
         let task_c = board
-            .create_task("t1", "C", None, None, std::slice::from_ref(&task_a.id))
+            .create_task("t1", "s1", "C", None, None, std::slice::from_ref(&task_a.id))
             .await
             .unwrap();
 
         board
             .update_task(
                 "t1",
+                "s1",
                 &task_a.id,
                 &TaskUpdate {
                     status: Some(TaskStatus::Completed),
@@ -299,7 +311,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tasks = board.list_tasks("t1").await.unwrap();
+        let tasks = board.list_tasks("t1", "s1").await.unwrap();
         let b = tasks.iter().find(|t| t.id == task_b.id).unwrap();
         let c = tasks.iter().find(|t| t.id == task_c.id).unwrap();
         assert!(b.blocked_by.is_empty());
@@ -314,7 +326,7 @@ mod tests {
         let task_a = create_simple_task(&board, "t1", "A").await;
         let task_x = create_simple_task(&board, "t1", "X").await;
         let task_b = board
-            .create_task("t1", "B", None, None, &[task_a.id.clone(), task_x.id.clone()])
+            .create_task("t1", "s1", "B", None, None, &[task_a.id.clone(), task_x.id.clone()])
             .await
             .unwrap();
 
@@ -323,6 +335,7 @@ mod tests {
         board
             .update_task(
                 "t1",
+                "s1",
                 &task_a.id,
                 &TaskUpdate {
                     status: Some(TaskStatus::Completed),
@@ -332,7 +345,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tasks = board.list_tasks("t1").await.unwrap();
+        let tasks = board.list_tasks("t1", "s1").await.unwrap();
         let b = tasks.iter().find(|t| t.id == task_b.id).unwrap();
         assert_eq!(b.blocked_by, vec![task_x.id]);
     }
@@ -346,6 +359,7 @@ mod tests {
         let updated = board
             .update_task(
                 "t1",
+                "s1",
                 &task.id,
                 &TaskUpdate {
                     status: Some(TaskStatus::Completed),
@@ -362,7 +376,7 @@ mod tests {
         let repo = Arc::new(MockTeamRepo::new());
         let board = TaskBoard::new(repo);
 
-        let tasks = board.list_tasks("t1").await.unwrap();
+        let tasks = board.list_tasks("t1", "s1").await.unwrap();
         assert!(tasks.is_empty());
     }
 
@@ -375,7 +389,7 @@ mod tests {
         create_simple_task(&board, "t1", "B").await;
         create_simple_task(&board, "t2", "C").await;
 
-        let tasks = board.list_tasks("t1").await.unwrap();
+        let tasks = board.list_tasks("t1", "s1").await.unwrap();
         assert_eq!(tasks.len(), 2);
     }
 }

--- a/crates/aionui-team/src/test_utils.rs
+++ b/crates/aionui-team/src/test_utils.rs
@@ -57,11 +57,20 @@ impl ITeamRepository for MockTeamRepo {
         Ok(())
     }
 
-    async fn read_unread_and_mark(&self, team_id: &str, to_agent_id: &str) -> Result<Vec<MailboxMessageRow>, DbError> {
+    async fn read_unread_and_mark(
+        &self,
+        team_id: &str,
+        session_id: &str,
+        to_agent_id: &str,
+    ) -> Result<Vec<MailboxMessageRow>, DbError> {
         let mut state = self.state.lock().unwrap();
         let mut result = vec![];
         for msg in &mut state.messages {
-            if msg.team_id == team_id && msg.to_agent_id == to_agent_id && !msg.read {
+            if msg.team_id == team_id
+                && msg.session_id.as_deref() == Some(session_id)
+                && msg.to_agent_id == to_agent_id
+                && !msg.read
+            {
                 msg.read = true;
                 result.push(msg.clone());
             }
@@ -69,12 +78,19 @@ impl ITeamRepository for MockTeamRepo {
         Ok(result)
     }
 
-    async fn peek_unread(&self, team_id: &str, to_agent_id: &str) -> Result<Vec<MailboxMessageRow>, DbError> {
+    async fn peek_unread(
+        &self,
+        team_id: &str,
+        session_id: &str,
+        to_agent_id: &str,
+    ) -> Result<Vec<MailboxMessageRow>, DbError> {
         let state = self.state.lock().unwrap();
         let result = state
             .messages
             .iter()
-            .filter(|m| m.team_id == team_id && m.to_agent_id == to_agent_id && !m.read)
+            .filter(|m| {
+                m.team_id == team_id && m.session_id.as_deref() == Some(session_id) && m.to_agent_id == to_agent_id && !m.read
+            })
             .cloned()
             .collect();
         Ok(result)
@@ -93,14 +109,14 @@ impl ITeamRepository for MockTeamRepo {
     async fn get_history(
         &self,
         team_id: &str,
+        session_id: &str,
         to_agent_id: &str,
         limit: Option<i64>,
     ) -> Result<Vec<MailboxMessageRow>, DbError> {
         let state = self.state.lock().unwrap();
-        let iter = state
-            .messages
-            .iter()
-            .filter(|m| m.team_id == team_id && m.to_agent_id == to_agent_id);
+        let iter = state.messages.iter().filter(|m| {
+            m.team_id == team_id && m.session_id.as_deref() == Some(session_id) && m.to_agent_id == to_agent_id
+        });
         let msgs: Vec<_> = match limit {
             Some(n) => iter.take(n as usize).cloned().collect(),
             None => iter.cloned().collect(),
@@ -113,6 +129,13 @@ impl ITeamRepository for MockTeamRepo {
         Ok(())
     }
 
+    async fn delete_mailbox_by_session(&self, team_id: &str, session_id: &str) -> Result<(), DbError> {
+        self.state.lock().unwrap().messages.retain(|m| {
+            !(m.team_id == team_id && m.session_id.as_deref() == Some(session_id))
+        });
+        Ok(())
+    }
+
     // ── TaskBoard ───────────────────────────────────────────────────
 
     async fn create_task(&self, row: &TeamTaskRow) -> Result<(), DbError> {
@@ -120,12 +143,19 @@ impl ITeamRepository for MockTeamRepo {
         Ok(())
     }
 
-    async fn find_task_by_id(&self, team_id: &str, task_id: &str) -> Result<Option<TeamTaskRow>, DbError> {
+    async fn find_task_by_id(
+        &self,
+        team_id: &str,
+        session_id: &str,
+        task_id: &str,
+    ) -> Result<Option<TeamTaskRow>, DbError> {
         let state = self.state.lock().unwrap();
         let found = state
             .tasks
             .iter()
-            .find(|t| t.team_id == team_id && t.id == task_id)
+            .find(|t| {
+                t.team_id == team_id && t.session_id.as_deref() == Some(session_id) && t.id == task_id
+            })
             .cloned();
         Ok(found)
     }
@@ -156,12 +186,17 @@ impl ITeamRepository for MockTeamRepo {
         Ok(())
     }
 
-    async fn list_tasks(&self, team_id: &str) -> Result<Vec<TeamTaskRow>, DbError> {
+    async fn list_tasks(&self, team_id: &str, session_id: &str) -> Result<Vec<TeamTaskRow>, DbError> {
         let state = self.state.lock().unwrap();
         if state.fail_task_lists {
             return Err(DbError::Init("forced task list failure".into()));
         }
-        let tasks = state.tasks.iter().filter(|t| t.team_id == team_id).cloned().collect();
+        let tasks = state
+            .tasks
+            .iter()
+            .filter(|t| t.team_id == team_id && t.session_id.as_deref() == Some(session_id))
+            .cloned()
+            .collect();
         Ok(tasks)
     }
 
@@ -193,6 +228,78 @@ impl ITeamRepository for MockTeamRepo {
 
     async fn delete_tasks_by_team(&self, team_id: &str) -> Result<(), DbError> {
         self.state.lock().unwrap().tasks.retain(|t| t.team_id != team_id);
+        Ok(())
+    }
+
+    async fn delete_tasks_by_session(&self, team_id: &str, session_id: &str) -> Result<(), DbError> {
+        self.state.lock().unwrap().tasks.retain(|t| {
+            !(t.team_id == team_id && t.session_id.as_deref() == Some(session_id))
+        });
+        Ok(())
+    }
+
+    // ── Team Sessions (migration 030) — in-memory stubs ───────────────
+
+    async fn create_team_session(
+        &self,
+        _row: &aionui_db::models::TeamSessionRow,
+    ) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn list_team_sessions(&self, _team_id: &str) -> Result<Vec<aionui_db::models::TeamSessionRow>, DbError> {
+        Ok(vec![])
+    }
+
+    async fn get_team_session(
+        &self,
+        _session_id: &str,
+    ) -> Result<Option<aionui_db::models::TeamSessionRow>, DbError> {
+        Ok(None)
+    }
+
+    async fn update_team_session(
+        &self,
+        _session_id: &str,
+        _params: &aionui_db::UpdateTeamSessionParams,
+    ) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn delete_team_session(&self, _session_id: &str) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn delete_team_sessions_by_team(&self, _team_id: &str) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn bind_session_conversation(
+        &self,
+        _row: &aionui_db::models::TeamSessionAgentRow,
+    ) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn list_session_agents(
+        &self,
+        _session_id: &str,
+    ) -> Result<Vec<aionui_db::models::TeamSessionAgentRow>, DbError> {
+        Ok(vec![])
+    }
+
+    async fn list_session_agents_by_team(
+        &self,
+        _team_id: &str,
+    ) -> Result<Vec<aionui_db::models::TeamSessionAgentRow>, DbError> {
+        Ok(vec![])
+    }
+
+    async fn delete_session_agents_by_session(&self, _session_id: &str) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn delete_session_agents_by_team(&self, _team_id: &str) -> Result<(), DbError> {
         Ok(())
     }
 }
@@ -459,6 +566,7 @@ pub(crate) mod workspace_harness {
         async fn read_unread_and_mark(
             &self,
             _team_id: &str,
+            _session_id: &str,
             _to_agent_id: &str,
         ) -> Result<Vec<aionui_db::models::MailboxMessageRow>, DbError> {
             Ok(vec![])
@@ -467,6 +575,7 @@ pub(crate) mod workspace_harness {
         async fn peek_unread(
             &self,
             _team_id: &str,
+            _session_id: &str,
             _to_agent_id: &str,
         ) -> Result<Vec<aionui_db::models::MailboxMessageRow>, DbError> {
             Ok(vec![])
@@ -479,6 +588,7 @@ pub(crate) mod workspace_harness {
         async fn get_history(
             &self,
             _team_id: &str,
+            _session_id: &str,
             _to_agent_id: &str,
             _limit: Option<i64>,
         ) -> Result<Vec<aionui_db::models::MailboxMessageRow>, DbError> {
@@ -489,11 +599,20 @@ pub(crate) mod workspace_harness {
             Ok(())
         }
 
+        async fn delete_mailbox_by_session(&self, _team_id: &str, _session_id: &str) -> Result<(), DbError> {
+            Ok(())
+        }
+
         async fn create_task(&self, _row: &TeamTaskRow) -> Result<(), DbError> {
             Ok(())
         }
 
-        async fn find_task_by_id(&self, _team_id: &str, _task_id: &str) -> Result<Option<TeamTaskRow>, DbError> {
+        async fn find_task_by_id(
+            &self,
+            _team_id: &str,
+            _session_id: &str,
+            _task_id: &str,
+        ) -> Result<Option<TeamTaskRow>, DbError> {
             Ok(None)
         }
 
@@ -501,7 +620,7 @@ pub(crate) mod workspace_harness {
             Ok(())
         }
 
-        async fn list_tasks(&self, _team_id: &str) -> Result<Vec<TeamTaskRow>, DbError> {
+        async fn list_tasks(&self, _team_id: &str, _session_id: &str) -> Result<Vec<TeamTaskRow>, DbError> {
             Ok(vec![])
         }
 
@@ -514,6 +633,78 @@ pub(crate) mod workspace_harness {
         }
 
         async fn delete_tasks_by_team(&self, _team_id: &str) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn delete_tasks_by_session(&self, _team_id: &str, _session_id: &str) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        // ── Team Sessions (migration 030) — in-memory stubs ───────────
+
+        async fn create_team_session(
+            &self,
+            _row: &aionui_db::models::TeamSessionRow,
+        ) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn list_team_sessions(
+            &self,
+            _team_id: &str,
+        ) -> Result<Vec<aionui_db::models::TeamSessionRow>, DbError> {
+            Ok(vec![])
+        }
+
+        async fn get_team_session(
+            &self,
+            _session_id: &str,
+        ) -> Result<Option<aionui_db::models::TeamSessionRow>, DbError> {
+            Ok(None)
+        }
+
+        async fn update_team_session(
+            &self,
+            _session_id: &str,
+            _params: &aionui_db::UpdateTeamSessionParams,
+        ) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn delete_team_session(&self, _session_id: &str) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn delete_team_sessions_by_team(&self, _team_id: &str) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn bind_session_conversation(
+            &self,
+            _row: &aionui_db::models::TeamSessionAgentRow,
+        ) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn list_session_agents(
+            &self,
+            _session_id: &str,
+        ) -> Result<Vec<aionui_db::models::TeamSessionAgentRow>, DbError> {
+            Ok(vec![])
+        }
+
+        async fn list_session_agents_by_team(
+            &self,
+            _team_id: &str,
+        ) -> Result<Vec<aionui_db::models::TeamSessionAgentRow>, DbError> {
+            Ok(vec![])
+        }
+
+        async fn delete_session_agents_by_session(&self, _session_id: &str) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        async fn delete_session_agents_by_team(&self, _team_id: &str) -> Result<(), DbError> {
             Ok(())
         }
     }

--- a/crates/aionui-team/src/types.rs
+++ b/crates/aionui-team/src/types.rs
@@ -152,6 +152,11 @@ pub struct Team {
     pub lead_agent_id: Option<String>,
     pub created_at: TimestampMs,
     pub updated_at: TimestampMs,
+    /// Currently active working session id (migration 030). `None` only on
+    /// legacy rows written before multi-session support; the service layer
+    /// resolves it to the team's primary session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_session_id: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -283,6 +288,7 @@ impl Team {
             lead_agent_id: row.lead_agent_id.clone(),
             created_at: row.created_at,
             updated_at: row.updated_at,
+            active_session_id: row.active_session_id.clone(),
         })
     }
 
@@ -295,6 +301,7 @@ impl Team {
             leader_assistant_id: self.lead_agent_id.clone(),
             created_at: self.created_at,
             updated_at: self.updated_at,
+            active_session_id: self.active_session_id.clone(),
         }
     }
 }
@@ -645,6 +652,7 @@ mod tests {
             updated_at: 2000,
             project_id: None,
             folder_id: None,
+            active_session_id: None,
         };
         let team = Team::from_row(&row).unwrap();
         assert_eq!(team.id, "t1");
@@ -674,6 +682,7 @@ mod tests {
             lead_agent_id: Some("s1".into()),
             created_at: 1000,
             updated_at: 2000,
+            active_session_id: None,
         };
         let resp = team.to_response();
         assert_eq!(resp.id, "t1");
@@ -701,6 +710,7 @@ mod tests {
             updated_at: 0,
             project_id: None,
             folder_id: None,
+            active_session_id: None,
         };
         assert!(Team::from_row(&row).is_err());
     }
@@ -741,6 +751,7 @@ mod tests {
             files: None,
             read: false,
             created_at: 1000,
+                    session_id: None,
         };
         let msg = MailboxMessage::from_row(&row).unwrap();
         assert_eq!(msg.msg_type, MailboxMessageType::Message);
@@ -760,6 +771,7 @@ mod tests {
             files: None,
             read: false,
             created_at: 2000,
+                    session_id: None,
         };
         let msg = MailboxMessage::from_row(&row).unwrap();
         assert_eq!(msg.msg_type, MailboxMessageType::IdleNotification);
@@ -779,6 +791,7 @@ mod tests {
             files: None,
             read: false,
             created_at: 0,
+                    session_id: None,
         };
         assert!(MailboxMessage::from_row(&row).is_none());
     }
@@ -819,6 +832,7 @@ mod tests {
             metadata: Some(r#"{"priority":"high"}"#.into()),
             created_at: 1000,
             updated_at: 2000,
+                    session_id: None,
         };
         let task = TeamTask::from_row(&row).unwrap();
         assert_eq!(task.status, TaskStatus::InProgress);
@@ -841,6 +855,7 @@ mod tests {
             metadata: None,
             created_at: 0,
             updated_at: 0,
+                    session_id: None,
         };
         let task = TeamTask::from_row(&row).unwrap();
         assert_eq!(task.status, TaskStatus::Pending);
@@ -863,6 +878,7 @@ mod tests {
             metadata: None,
             created_at: 0,
             updated_at: 0,
+                    session_id: None,
         };
         let task = TeamTask::from_row(&row).unwrap();
         assert_eq!(task.status, TaskStatus::Pending);
@@ -882,6 +898,7 @@ mod tests {
             metadata: None,
             created_at: 0,
             updated_at: 0,
+                    session_id: None,
         };
         assert!(TeamTask::from_row(&row).is_err());
     }

--- a/crates/aionui-team/tests/common/mod.rs
+++ b/crates/aionui-team/tests/common/mod.rs
@@ -47,11 +47,20 @@ impl ITeamRepository for MockTeamRepo {
         Ok(())
     }
 
-    async fn read_unread_and_mark(&self, team_id: &str, to_agent_id: &str) -> Result<Vec<MailboxMessageRow>, DbError> {
+    async fn read_unread_and_mark(
+        &self,
+        team_id: &str,
+        session_id: &str,
+        to_agent_id: &str,
+    ) -> Result<Vec<MailboxMessageRow>, DbError> {
         let mut state = self.state.lock().unwrap();
         let mut result = vec![];
         for msg in &mut state.messages {
-            if msg.team_id == team_id && msg.to_agent_id == to_agent_id && !msg.read {
+            if msg.team_id == team_id
+                && msg.session_id.as_deref() == Some(session_id)
+                && msg.to_agent_id == to_agent_id
+                && !msg.read
+            {
                 msg.read = true;
                 result.push(msg.clone());
             }
@@ -59,12 +68,19 @@ impl ITeamRepository for MockTeamRepo {
         Ok(result)
     }
 
-    async fn peek_unread(&self, team_id: &str, to_agent_id: &str) -> Result<Vec<MailboxMessageRow>, DbError> {
+    async fn peek_unread(
+        &self,
+        team_id: &str,
+        session_id: &str,
+        to_agent_id: &str,
+    ) -> Result<Vec<MailboxMessageRow>, DbError> {
         let state = self.state.lock().unwrap();
         let result = state
             .messages
             .iter()
-            .filter(|m| m.team_id == team_id && m.to_agent_id == to_agent_id && !m.read)
+            .filter(|m| {
+                m.team_id == team_id && m.session_id.as_deref() == Some(session_id) && m.to_agent_id == to_agent_id && !m.read
+            })
             .cloned()
             .collect();
         Ok(result)
@@ -83,14 +99,14 @@ impl ITeamRepository for MockTeamRepo {
     async fn get_history(
         &self,
         team_id: &str,
+        session_id: &str,
         to_agent_id: &str,
         limit: Option<i64>,
     ) -> Result<Vec<MailboxMessageRow>, DbError> {
         let state = self.state.lock().unwrap();
-        let iter = state
-            .messages
-            .iter()
-            .filter(|m| m.team_id == team_id && m.to_agent_id == to_agent_id);
+        let iter = state.messages.iter().filter(|m| {
+            m.team_id == team_id && m.session_id.as_deref() == Some(session_id) && m.to_agent_id == to_agent_id
+        });
         let msgs: Vec<_> = match limit {
             Some(n) => iter.take(n as usize).cloned().collect(),
             None => iter.cloned().collect(),
@@ -108,12 +124,19 @@ impl ITeamRepository for MockTeamRepo {
         Ok(())
     }
 
-    async fn find_task_by_id(&self, team_id: &str, task_id: &str) -> Result<Option<TeamTaskRow>, DbError> {
+    async fn find_task_by_id(
+        &self,
+        team_id: &str,
+        session_id: &str,
+        task_id: &str,
+    ) -> Result<Option<TeamTaskRow>, DbError> {
         let state = self.state.lock().unwrap();
         let found = state
             .tasks
             .iter()
-            .find(|t| t.team_id == team_id && t.id == task_id)
+            .find(|t| {
+                t.team_id == team_id && t.session_id.as_deref() == Some(session_id) && t.id == task_id
+            })
             .cloned();
         Ok(found)
     }
@@ -144,9 +167,14 @@ impl ITeamRepository for MockTeamRepo {
         Ok(())
     }
 
-    async fn list_tasks(&self, team_id: &str) -> Result<Vec<TeamTaskRow>, DbError> {
+    async fn list_tasks(&self, team_id: &str, session_id: &str) -> Result<Vec<TeamTaskRow>, DbError> {
         let state = self.state.lock().unwrap();
-        let tasks = state.tasks.iter().filter(|t| t.team_id == team_id).cloned().collect();
+        let tasks = state
+            .tasks
+            .iter()
+            .filter(|t| t.team_id == team_id && t.session_id.as_deref() == Some(session_id))
+            .cloned()
+            .collect();
         Ok(tasks)
     }
 
@@ -178,6 +206,85 @@ impl ITeamRepository for MockTeamRepo {
 
     async fn delete_tasks_by_team(&self, team_id: &str) -> Result<(), DbError> {
         self.state.lock().unwrap().tasks.retain(|t| t.team_id != team_id);
+        Ok(())
+    }
+
+    async fn delete_mailbox_by_session(&self, team_id: &str, session_id: &str) -> Result<(), DbError> {
+        self.state.lock().unwrap().messages.retain(|m| {
+            !(m.team_id == team_id && m.session_id.as_deref() == Some(session_id))
+        });
+        Ok(())
+    }
+
+    async fn delete_tasks_by_session(&self, team_id: &str, session_id: &str) -> Result<(), DbError> {
+        self.state.lock().unwrap().tasks.retain(|t| {
+            !(t.team_id == team_id && t.session_id.as_deref() == Some(session_id))
+        });
+        Ok(())
+    }
+
+    // ── Team Sessions (migration 030) — in-memory stubs ───────────────
+
+    async fn create_team_session(
+        &self,
+        _row: &aionui_db::models::TeamSessionRow,
+    ) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn list_team_sessions(&self, _team_id: &str) -> Result<Vec<aionui_db::models::TeamSessionRow>, DbError> {
+        Ok(vec![])
+    }
+
+    async fn get_team_session(
+        &self,
+        _session_id: &str,
+    ) -> Result<Option<aionui_db::models::TeamSessionRow>, DbError> {
+        Ok(None)
+    }
+
+    async fn update_team_session(
+        &self,
+        _session_id: &str,
+        _params: &aionui_db::UpdateTeamSessionParams,
+    ) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn delete_team_session(&self, _session_id: &str) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn delete_team_sessions_by_team(&self, _team_id: &str) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn bind_session_conversation(
+        &self,
+        _row: &aionui_db::models::TeamSessionAgentRow,
+    ) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn list_session_agents(
+        &self,
+        _session_id: &str,
+    ) -> Result<Vec<aionui_db::models::TeamSessionAgentRow>, DbError> {
+        Ok(vec![])
+    }
+
+    async fn list_session_agents_by_team(
+        &self,
+        _team_id: &str,
+    ) -> Result<Vec<aionui_db::models::TeamSessionAgentRow>, DbError> {
+        Ok(vec![])
+    }
+
+    async fn delete_session_agents_by_session(&self, _session_id: &str) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn delete_session_agents_by_team(&self, _team_id: &str) -> Result<(), DbError> {
         Ok(())
     }
 }

--- a/crates/aionui-team/tests/e2e_smoke.rs
+++ b/crates/aionui-team/tests/e2e_smoke.rs
@@ -101,6 +101,7 @@ async fn setup_team_with_lead() -> SmokeEnv {
     ];
     let scheduler = Arc::new(TeammateManager::new(
         team_id.clone(),
+        "s1".to_owned(),
         &agents,
         mailbox.clone(),
         task_board.clone(),
@@ -309,7 +310,7 @@ async fn smoke_mcp_tool_execution_not_noop() {
         !is_error_response(&task_resp),
         "team_task_create returned error: {task_resp}"
     );
-    let tasks = env.task_board.list_tasks(&env.team_id).await.unwrap();
+    let tasks = env.task_board.list_tasks(&env.team_id, "s1").await.unwrap();
     assert!(
         tasks.iter().any(|t| t.subject == "Smoke test subject"),
         "team_task_create did not persist task, got {tasks:?}"

--- a/crates/aionui-team/tests/e2e_team_flow.rs
+++ b/crates/aionui-team/tests/e2e_team_flow.rs
@@ -703,10 +703,12 @@ async fn setup_session_with_turn_recorder_inner(
         lead_agent_id: Some("lead-1".into()),
         created_at: 1000,
         updated_at: 1000,
+        active_session_id: None,
     };
 
     let session = TeamSession::start(
         team,
+        "s1".to_owned(),
         repo_dyn,
         broadcaster,
         backend_path(),
@@ -761,10 +763,12 @@ async fn setup_session_with_runtime_ports(
         lead_agent_id: Some("lead-1".into()),
         created_at: 1000,
         updated_at: 1000,
+        active_session_id: None,
     };
 
     let session = TeamSession::start(
         team,
+        "s1".to_owned(),
         repo_dyn,
         broadcaster_dyn,
         backend_path(),
@@ -1093,6 +1097,7 @@ async fn s3c_finish_triggers_lead_wake_with_idle_notification() {
         .mailbox()
         .write(
             "e2e-team",
+            "s1",
             "worker-1",
             "lead-1",
             aionui_team::MailboxMessageType::Message,
@@ -1109,7 +1114,7 @@ async fn s3c_finish_triggers_lead_wake_with_idle_notification() {
         .set_status("worker-1", aionui_team::TeammateStatus::Working)
         .await
         .unwrap();
-    let _ = session.mailbox().read_unread("e2e-team", "worker-1").await;
+    let _ = session.mailbox().read_unread("e2e-team", "s1", "worker-1").await;
 
     // Worker finishes → IdleNotification → lead returned
     let wake_target = session.on_agent_finish("conv-worker", false).await.unwrap();
@@ -1205,6 +1210,7 @@ async fn s4_dynamic_agent_added_then_finish_propagates() {
         .mailbox()
         .write(
             "e2e-team",
+            "s1",
             "helper-1",
             "lead-1",
             aionui_team::MailboxMessageType::Message,
@@ -1535,6 +1541,7 @@ async fn turn_completion_reconciles_without_another_notify() {
         .mailbox()
         .write(
             "e2e-team",
+            "s1",
             "lead-1",
             "worker-1",
             aionui_team::MailboxMessageType::Message,
@@ -1653,7 +1660,7 @@ async fn one_notify_drains_five_intents_after_busy_turn() {
     assert!(
         session
             .mailbox()
-            .peek_unread("e2e-team", "lead-1")
+            .peek_unread("e2e-team", "s1", "lead-1")
             .await
             .unwrap()
             .is_empty()
@@ -1711,7 +1718,7 @@ async fn nonretryable_start_failure_is_terminal_and_not_recovered() {
     assert!(
         session
             .mailbox()
-            .peek_unread("e2e-team", "lead-1")
+            .peek_unread("e2e-team", "s1", "lead-1")
             .await
             .unwrap()
             .is_empty()
@@ -1754,7 +1761,7 @@ async fn retryable_start_requeues_without_marking_mailbox_read() {
         "run should remain active for a state-driven retry"
     );
     assert_eq!(
-        session.mailbox().peek_unread("e2e-team", "lead-1").await.unwrap().len(),
+        session.mailbox().peek_unread("e2e-team", "s1", "lead-1").await.unwrap().len(),
         1
     );
 

--- a/crates/aionui-team/tests/mailbox_integration.rs
+++ b/crates/aionui-team/tests/mailbox_integration.rs
@@ -25,7 +25,7 @@ async fn setup() -> (Mailbox, aionui_db::Database) {
 async fn mw1_write_text_message() {
     let (mailbox, _db) = setup().await;
     let msg = mailbox
-        .write("t1", "a1", "user", MailboxMessageType::Message, "hello", None)
+        .write("t1", "s1", "a1", "user", MailboxMessageType::Message, "hello", None)
         .await
         .unwrap();
     assert_eq!(msg.msg_type, MailboxMessageType::Message);
@@ -41,18 +41,19 @@ async fn mw1b_write_text_message_preserves_files_in_mailbox() {
     let msg = mailbox
         .write_with_files(
             "t1",
+            "s1",
             "a1",
             "user",
             MailboxMessageType::Message,
             "hello",
             None,
-            Some(&files),
+            Some(files.as_slice()),
         )
         .await
         .unwrap();
 
     assert_eq!(msg.files.as_deref(), Some(files.as_slice()));
-    let unread = mailbox.peek_unread("t1", "a1").await.unwrap();
+    let unread = mailbox.peek_unread("t1", "s1", "a1").await.unwrap();
     assert_eq!(unread.len(), 1);
     assert_eq!(unread[0].files.as_deref(), Some(files.as_slice()));
 }
@@ -63,6 +64,7 @@ async fn mw2_write_idle_notification_with_summary() {
     let msg = mailbox
         .write(
             "t1",
+            "s1",
             "lead",
             "a1",
             MailboxMessageType::IdleNotification,
@@ -81,6 +83,7 @@ async fn mw3_write_shutdown_request() {
     let msg = mailbox
         .write(
             "t1",
+            "s1",
             "a1",
             "lead",
             MailboxMessageType::ShutdownRequest,
@@ -101,6 +104,7 @@ async fn mr1_read_unread_returns_all_and_marks() {
         mailbox
             .write(
                 "t1",
+                "s1",
                 "a1",
                 "user",
                 MailboxMessageType::Message,
@@ -110,7 +114,7 @@ async fn mr1_read_unread_returns_all_and_marks() {
             .await
             .unwrap();
     }
-    let unread = mailbox.read_unread("t1", "a1").await.unwrap();
+    let unread = mailbox.read_unread("t1", "s1", "a1").await.unwrap();
     assert_eq!(unread.len(), 3);
 }
 
@@ -118,18 +122,18 @@ async fn mr1_read_unread_returns_all_and_marks() {
 async fn mr2_second_read_returns_empty() {
     let (mailbox, _db) = setup().await;
     mailbox
-        .write("t1", "a1", "user", MailboxMessageType::Message, "x", None)
+        .write("t1", "s1", "a1", "user", MailboxMessageType::Message, "x", None)
         .await
         .unwrap();
-    mailbox.read_unread("t1", "a1").await.unwrap();
-    let second = mailbox.read_unread("t1", "a1").await.unwrap();
+    mailbox.read_unread("t1", "s1", "a1").await.unwrap();
+    let second = mailbox.read_unread("t1", "s1", "a1").await.unwrap();
     assert!(second.is_empty());
 }
 
 #[tokio::test]
 async fn mr4_no_unread_messages() {
     let (mailbox, _db) = setup().await;
-    let unread = mailbox.read_unread("t1", "a1").await.unwrap();
+    let unread = mailbox.read_unread("t1", "s1", "a1").await.unwrap();
     assert!(unread.is_empty());
 }
 
@@ -140,12 +144,12 @@ async fn mh1_get_history_no_limit() {
     let (mailbox, _db) = setup().await;
     for i in 0..5 {
         mailbox
-            .write("t1", "a1", "user", MailboxMessageType::Message, &format!("m{i}"), None)
+            .write("t1", "s1", "a1", "user", MailboxMessageType::Message, &format!("m{i}"), None)
             .await
             .unwrap();
     }
-    mailbox.read_unread("t1", "a1").await.unwrap();
-    let history = mailbox.get_history("t1", "a1", None).await.unwrap();
+    mailbox.read_unread("t1", "s1", "a1").await.unwrap();
+    let history = mailbox.get_history("t1", "s1", "a1", None).await.unwrap();
     assert_eq!(history.len(), 5);
 }
 
@@ -154,18 +158,18 @@ async fn mh2_get_history_with_limit() {
     let (mailbox, _db) = setup().await;
     for i in 0..10 {
         mailbox
-            .write("t1", "a1", "user", MailboxMessageType::Message, &format!("m{i}"), None)
+            .write("t1", "s1", "a1", "user", MailboxMessageType::Message, &format!("m{i}"), None)
             .await
             .unwrap();
     }
-    let history = mailbox.get_history("t1", "a1", Some(5)).await.unwrap();
+    let history = mailbox.get_history("t1", "s1", "a1", Some(5)).await.unwrap();
     assert_eq!(history.len(), 5);
 }
 
 #[tokio::test]
 async fn mh3_empty_history() {
     let (mailbox, _db) = setup().await;
-    let history = mailbox.get_history("t1", "a1", None).await.unwrap();
+    let history = mailbox.get_history("t1", "s1", "a1", None).await.unwrap();
     assert!(history.is_empty());
 }
 
@@ -175,16 +179,16 @@ async fn mh3_empty_history() {
 async fn md1_delete_by_team_removes_all_messages() {
     let (mailbox, _db) = setup().await;
     mailbox
-        .write("t1", "a1", "user", MailboxMessageType::Message, "x", None)
+        .write("t1", "s1", "a1", "user", MailboxMessageType::Message, "x", None)
         .await
         .unwrap();
     mailbox
-        .write("t1", "a2", "user", MailboxMessageType::Message, "y", None)
+        .write("t1", "s1", "a2", "user", MailboxMessageType::Message, "y", None)
         .await
         .unwrap();
     mailbox.delete_by_team("t1").await.unwrap();
-    let h1 = mailbox.get_history("t1", "a1", None).await.unwrap();
-    let h2 = mailbox.get_history("t1", "a2", None).await.unwrap();
+    let h1 = mailbox.get_history("t1", "s1", "a1", None).await.unwrap();
+    let h2 = mailbox.get_history("t1", "s1", "a2", None).await.unwrap();
     assert!(h1.is_empty());
     assert!(h2.is_empty());
 }
@@ -193,15 +197,15 @@ async fn md1_delete_by_team_removes_all_messages() {
 async fn md2_delete_by_team_does_not_affect_other_teams() {
     let (mailbox, _db) = setup().await;
     mailbox
-        .write("t1", "a1", "user", MailboxMessageType::Message, "x", None)
+        .write("t1", "s1", "a1", "user", MailboxMessageType::Message, "x", None)
         .await
         .unwrap();
     mailbox
-        .write("t2", "a1", "user", MailboxMessageType::Message, "y", None)
+        .write("t2", "s1", "a1", "user", MailboxMessageType::Message, "y", None)
         .await
         .unwrap();
     mailbox.delete_by_team("t1").await.unwrap();
-    let h2 = mailbox.get_history("t2", "a1", None).await.unwrap();
+    let h2 = mailbox.get_history("t2", "s1", "a1", None).await.unwrap();
     assert_eq!(h2.len(), 1);
 }
 
@@ -211,17 +215,17 @@ async fn md2_delete_by_team_does_not_affect_other_teams() {
 async fn read_unread_scoped_to_target_agent() {
     let (mailbox, _db) = setup().await;
     mailbox
-        .write("t1", "a1", "user", MailboxMessageType::Message, "for-a1", None)
+        .write("t1", "s1", "a1", "user", MailboxMessageType::Message, "for-a1", None)
         .await
         .unwrap();
     mailbox
-        .write("t1", "a2", "user", MailboxMessageType::Message, "for-a2", None)
+        .write("t1", "s1", "a2", "user", MailboxMessageType::Message, "for-a2", None)
         .await
         .unwrap();
-    let a1_msgs = mailbox.read_unread("t1", "a1").await.unwrap();
+    let a1_msgs = mailbox.read_unread("t1", "s1", "a1").await.unwrap();
     assert_eq!(a1_msgs.len(), 1);
     assert_eq!(a1_msgs[0].content, "for-a1");
-    let a2_msgs = mailbox.read_unread("t1", "a2").await.unwrap();
+    let a2_msgs = mailbox.read_unread("t1", "s1", "a2").await.unwrap();
     assert_eq!(a2_msgs.len(), 1);
     assert_eq!(a2_msgs[0].content, "for-a2");
 }

--- a/crates/aionui-team/tests/mcp_server_integration.rs
+++ b/crates/aionui-team/tests/mcp_server_integration.rs
@@ -83,6 +83,7 @@ async fn setup_with_prompt_dump(prompt_dump: Option<TeamPromptDumpConfig>) -> Te
     let agents = make_agents();
     let scheduler = Arc::new(TeammateManager::new(
         "team-1".into(),
+        "s1".into(),
         &agents,
         mailbox,
         task_board,

--- a/crates/aionui-team/tests/prompts_events_integration.rs
+++ b/crates/aionui-team/tests/prompts_events_integration.rs
@@ -522,7 +522,7 @@ async fn we1_agent_status_change_event() {
         make_agent("lead-1", "Lead", TeammateRole::Lead),
         make_agent("w1", "Worker", TeammateRole::Teammate),
     ];
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox, task_board, bc.clone());
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox, task_board, bc.clone());
 
     mgr.set_status("w1", TeammateStatus::Working).await.unwrap();
 
@@ -545,7 +545,7 @@ async fn we2_agent_spawned_event() {
     let task_board = Arc::new(TaskBoard::new(repo));
     let bc = Arc::new(RecordingBroadcaster::new());
     let agents = vec![make_agent("lead-1", "Lead", TeammateRole::Lead)];
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox, task_board, bc.clone());
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox, task_board, bc.clone());
 
     let new_agent = make_agent("w2", "NewWorker", TeammateRole::Teammate);
     mgr.add_agent(&new_agent).await;
@@ -575,7 +575,7 @@ async fn we3_agent_removed_event() {
         make_agent("lead-1", "Lead", TeammateRole::Lead),
         make_agent("w1", "Worker", TeammateRole::Teammate),
     ];
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox, task_board, bc.clone());
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox, task_board, bc.clone());
 
     mgr.remove_agent("w1").await.unwrap();
 
@@ -603,7 +603,7 @@ async fn we4_agent_renamed_event() {
         make_agent("lead-1", "Lead", TeammateRole::Lead),
         make_agent("w1", "Worker", TeammateRole::Teammate),
     ];
-    let mgr = TeammateManager::new("t1".into(), &agents, mailbox, task_board, bc.clone());
+    let mgr = TeammateManager::new("t1".into(), "s1".into(), &agents, mailbox, task_board, bc.clone());
 
     mgr.rename_agent("w1", "SuperWorker").await.unwrap();
 

--- a/crates/aionui-team/tests/scheduler_integration.rs
+++ b/crates/aionui-team/tests/scheduler_integration.rs
@@ -71,6 +71,7 @@ fn setup_team(agents: &[TeamAgent]) -> TestHarness {
     let broadcaster = Arc::new(RecordingBroadcaster::new());
     let mgr = TeammateManager::new(
         "team-1".into(),
+        "sess-1".into(),
         agents,
         mailbox.clone(),
         task_board.clone(),
@@ -99,12 +100,20 @@ async fn aw1_wake_idle_agent_transitions_to_working_with_payload() {
     let h = setup_team(&agents);
 
     h.task_board
-        .create_task("team-1", "Task A", None, Some("w1"), &[])
+        .create_task("team-1", "sess-1", "Task A", None, Some("w1"), &[])
         .await
         .unwrap();
 
     h.mailbox
-        .write("team-1", "w1", "lead", MailboxMessageType::Message, "Do it", None)
+        .write(
+            "team-1",
+            "sess-1",
+            "w1",
+            "lead",
+            MailboxMessageType::Message,
+            "Do it",
+            None,
+        )
         .await
         .unwrap();
 
@@ -151,11 +160,11 @@ async fn aw2_wake_complete_finalize_executes_actions() {
 
     h.mgr.finalize_turn("w1", &actions).await.unwrap();
 
-    let tasks = h.task_board.list_tasks("team-1").await.unwrap();
+    let tasks = h.task_board.list_tasks("team-1", "sess-1").await.unwrap();
     assert_eq!(tasks.len(), 1);
     assert_eq!(tasks[0].subject, "Write tests");
 
-    let w2_msgs = h.mailbox.read_unread("team-1", "w2").await.unwrap();
+    let w2_msgs = h.mailbox.read_unread("team-1", "sess-1", "w2").await.unwrap();
     assert_eq!(w2_msgs.len(), 1);
     assert_eq!(w2_msgs[0].content, "Please review when done");
 
@@ -267,7 +276,7 @@ async fn ae1_send_message_action_writes_mailbox() {
         .await
         .unwrap();
 
-    let msgs = h.mailbox.read_unread("team-1", "w1").await.unwrap();
+    let msgs = h.mailbox.read_unread("team-1", "sess-1", "w1").await.unwrap();
     assert_eq!(msgs.len(), 1);
     assert_eq!(msgs[0].content, "Hello worker");
     assert_eq!(msgs[0].from_agent_id, "lead");
@@ -293,7 +302,7 @@ async fn ae2_task_create_action() {
         .await
         .unwrap();
 
-    let tasks = h.task_board.list_tasks("team-1").await.unwrap();
+    let tasks = h.task_board.list_tasks("team-1", "sess-1").await.unwrap();
     assert_eq!(tasks.len(), 1);
     assert_eq!(tasks[0].subject, "Build feature");
 }
@@ -323,7 +332,7 @@ async fn ae3_idle_notification_marks_idle_and_notifies_lead() {
 
     assert_eq!(h.mgr.get_status("w1").await.unwrap(), TeammateStatus::Idle);
 
-    let lead_msgs = h.mailbox.read_unread("team-1", "lead").await.unwrap();
+    let lead_msgs = h.mailbox.read_unread("team-1", "sess-1", "lead").await.unwrap();
     assert_eq!(lead_msgs.len(), 1);
     assert_eq!(lead_msgs[0].msg_type, MailboxMessageType::IdleNotification);
 
@@ -434,7 +443,15 @@ async fn full_workflow_lead_delegate_workers_idle_lead_rewake() {
 
     // 1. Wake lead with user message
     h.mailbox
-        .write("team-1", "lead", "user", MailboxMessageType::Message, "Build X", None)
+        .write(
+            "team-1",
+            "sess-1",
+            "lead",
+            "user",
+            MailboxMessageType::Message,
+            "Build X",
+            None,
+        )
         .await
         .unwrap();
 
@@ -486,7 +503,7 @@ async fn full_workflow_lead_delegate_workers_idle_lead_rewake() {
     assert_eq!(wake.as_deref(), Some("lead"), "all teammates idle → wake leader");
 
     // 6. Verify lead has idle notifications from both workers
-    let lead_msgs = h.mailbox.read_unread("team-1", "lead").await.unwrap();
+    let lead_msgs = h.mailbox.read_unread("team-1", "sess-1", "lead").await.unwrap();
     assert_eq!(lead_msgs.len(), 2);
 
     let summaries: Vec<_> = lead_msgs.iter().map(|m| m.content.as_str()).collect();
@@ -517,7 +534,7 @@ async fn shutdown_flow_lead_sends_request_to_target() {
         .await
         .unwrap();
 
-    let msgs = h.mailbox.read_unread("team-1", "w1").await.unwrap();
+    let msgs = h.mailbox.read_unread("team-1", "sess-1", "w1").await.unwrap();
     assert_eq!(msgs.len(), 1);
     assert_eq!(msgs[0].msg_type, MailboxMessageType::ShutdownRequest);
     assert_eq!(msgs[0].content, "No longer needed");
@@ -570,9 +587,9 @@ async fn broadcast_message_sends_to_all_except_sender() {
         .await
         .unwrap();
 
-    let w1_msgs = h.mailbox.read_unread("team-1", "w1").await.unwrap();
-    let w2_msgs = h.mailbox.read_unread("team-1", "w2").await.unwrap();
-    let lead_msgs = h.mailbox.read_unread("team-1", "lead").await.unwrap();
+    let w1_msgs = h.mailbox.read_unread("team-1", "sess-1", "w1").await.unwrap();
+    let w2_msgs = h.mailbox.read_unread("team-1", "sess-1", "w2").await.unwrap();
+    let lead_msgs = h.mailbox.read_unread("team-1", "sess-1", "lead").await.unwrap();
 
     assert_eq!(w1_msgs.len(), 1);
     assert_eq!(w2_msgs.len(), 1);

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -649,6 +649,11 @@ impl TeamConversationLookupPort for FakeConversationPorts {
                 .and_then(serde_json::Value::as_str)
                 .map(str::to_owned),
             role: extra.get("role").and_then(serde_json::Value::as_str).map(str::to_owned),
+            session_id: extra
+                .get("sessionId")
+                .or_else(|| extra.get("session_id"))
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned),
         }))
     }
 }
@@ -783,16 +788,18 @@ impl ITeamRepository for FullMockTeamRepo {
     async fn read_unread_and_mark(
         &self,
         team_id: &str,
+        session_id: &str,
         to_agent_id: &str,
     ) -> Result<Vec<aionui_db::models::MailboxMessageRow>, DbError> {
-        self.inner.read_unread_and_mark(team_id, to_agent_id).await
+        self.inner.read_unread_and_mark(team_id, session_id, to_agent_id).await
     }
     async fn peek_unread(
         &self,
         team_id: &str,
+        session_id: &str,
         to_agent_id: &str,
     ) -> Result<Vec<aionui_db::models::MailboxMessageRow>, DbError> {
-        self.inner.peek_unread(team_id, to_agent_id).await
+        self.inner.peek_unread(team_id, session_id, to_agent_id).await
     }
     async fn mark_read_batch(&self, ids: &[String]) -> Result<(), DbError> {
         self.inner.mark_read_batch(ids).await
@@ -800,13 +807,17 @@ impl ITeamRepository for FullMockTeamRepo {
     async fn get_history(
         &self,
         team_id: &str,
+        session_id: &str,
         to_agent_id: &str,
         limit: Option<i64>,
     ) -> Result<Vec<aionui_db::models::MailboxMessageRow>, DbError> {
-        self.inner.get_history(team_id, to_agent_id, limit).await
+        self.inner.get_history(team_id, session_id, to_agent_id, limit).await
     }
     async fn delete_mailbox_by_team(&self, team_id: &str) -> Result<(), DbError> {
         self.inner.delete_mailbox_by_team(team_id).await
+    }
+    async fn delete_mailbox_by_session(&self, team_id: &str, session_id: &str) -> Result<(), DbError> {
+        self.inner.delete_mailbox_by_session(team_id, session_id).await
     }
 
     async fn create_task(&self, row: &aionui_db::models::TeamTaskRow) -> Result<(), DbError> {
@@ -815,15 +826,16 @@ impl ITeamRepository for FullMockTeamRepo {
     async fn find_task_by_id(
         &self,
         team_id: &str,
+        session_id: &str,
         task_id: &str,
     ) -> Result<Option<aionui_db::models::TeamTaskRow>, DbError> {
-        self.inner.find_task_by_id(team_id, task_id).await
+        self.inner.find_task_by_id(team_id, session_id, task_id).await
     }
     async fn update_task(&self, task_id: &str, params: &aionui_db::UpdateTaskParams) -> Result<(), DbError> {
         self.inner.update_task(task_id, params).await
     }
-    async fn list_tasks(&self, team_id: &str) -> Result<Vec<aionui_db::models::TeamTaskRow>, DbError> {
-        self.inner.list_tasks(team_id).await
+    async fn list_tasks(&self, team_id: &str, session_id: &str) -> Result<Vec<aionui_db::models::TeamTaskRow>, DbError> {
+        self.inner.list_tasks(team_id, session_id).await
     }
     async fn append_to_blocks(&self, task_id: &str, blocked_task_id: &str) -> Result<(), DbError> {
         self.inner.append_to_blocks(task_id, blocked_task_id).await
@@ -833,6 +845,77 @@ impl ITeamRepository for FullMockTeamRepo {
     }
     async fn delete_tasks_by_team(&self, team_id: &str) -> Result<(), DbError> {
         self.inner.delete_tasks_by_team(team_id).await
+    }
+    async fn delete_tasks_by_session(&self, team_id: &str, session_id: &str) -> Result<(), DbError> {
+        self.inner.delete_tasks_by_session(team_id, session_id).await
+    }
+
+    // ── Team Sessions (migration 030) — in-memory stubs ───────────────
+
+    async fn create_team_session(
+        &self,
+        _row: &aionui_db::models::TeamSessionRow,
+    ) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn list_team_sessions(
+        &self,
+        _team_id: &str,
+    ) -> Result<Vec<aionui_db::models::TeamSessionRow>, DbError> {
+        Ok(vec![])
+    }
+
+    async fn get_team_session(
+        &self,
+        _session_id: &str,
+    ) -> Result<Option<aionui_db::models::TeamSessionRow>, DbError> {
+        Ok(None)
+    }
+
+    async fn update_team_session(
+        &self,
+        _session_id: &str,
+        _params: &aionui_db::UpdateTeamSessionParams,
+    ) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn delete_team_session(&self, _session_id: &str) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn delete_team_sessions_by_team(&self, _team_id: &str) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn bind_session_conversation(
+        &self,
+        _row: &aionui_db::models::TeamSessionAgentRow,
+    ) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn list_session_agents(
+        &self,
+        _session_id: &str,
+    ) -> Result<Vec<aionui_db::models::TeamSessionAgentRow>, DbError> {
+        Ok(vec![])
+    }
+
+    async fn list_session_agents_by_team(
+        &self,
+        _team_id: &str,
+    ) -> Result<Vec<aionui_db::models::TeamSessionAgentRow>, DbError> {
+        Ok(vec![])
+    }
+
+    async fn delete_session_agents_by_session(&self, _session_id: &str) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    async fn delete_session_agents_by_team(&self, _team_id: &str) -> Result<(), DbError> {
+        Ok(())
     }
 }
 
@@ -1678,6 +1761,7 @@ async fn recovery_creates_system_run_intents_without_restoring_old_memory_run() 
             files: None,
             read: false,
             created_at: aionui_common::now_ms(),
+            session_id: None,
         })
         .await
         .expect("seed orphan mailbox");
@@ -1799,6 +1883,7 @@ async fn ensure_session_does_not_run_self_message_only_recovery_turn() {
             files: None,
             read: false,
             created_at: aionui_common::now_ms(),
+            session_id: None,
         })
         .await
         .expect("seed self mailbox");
@@ -2155,6 +2240,7 @@ async fn renew_active_lease_allows_empty_team_without_unrelated_lease() {
             updated_at: aionui_common::now_ms(),
             project_id: None,
             folder_id: None,
+            active_session_id: None,
         })
         .await
         .expect("insert empty team");
@@ -3863,7 +3949,17 @@ async fn manual_add_agent_attach_failure_marks_slot_error_without_leader_notice(
     );
 
     let lead_slot_id = created.leader_assistant_id.as_deref().expect("leader slot");
-    let leader_messages = team_repo.get_history(&created.id, lead_slot_id, None).await.unwrap();
+    let active_session_id = team_repo
+        .get_team(&created.id)
+        .await
+        .expect("team exists")
+        .expect("team row")
+        .active_session_id
+        .expect("team has an active session");
+    let leader_messages = team_repo
+        .get_history(&created.id, &active_session_id, lead_slot_id, None)
+        .await
+        .unwrap();
     assert!(
         !leader_messages
             .iter()
@@ -6834,7 +6930,17 @@ async fn lazy_attach_failure_preserves_unread_and_skips_leader_on_human_delivery
 
     // Preserve-unread (spec 5.4b): the delivered message must remain unread so a
     // retry re-drains it via reconcile_mailbox.
-    let worker_unread = team_repo.peek_unread(&created.id, &worker.slot_id).await.unwrap();
+    let active_session_id = team_repo
+        .get_team(&created.id)
+        .await
+        .expect("team exists")
+        .expect("team row")
+        .active_session_id
+        .expect("team has an active session");
+    let worker_unread = team_repo
+        .peek_unread(&created.id, &active_session_id, &worker.slot_id)
+        .await
+        .unwrap();
     assert!(
         worker_unread.iter().any(|message| message.content == "please do X"),
         "a failed lazy attach must not mark the pending delivery read"
@@ -6842,7 +6948,10 @@ async fn lazy_attach_failure_preserves_unread_and_skips_leader_on_human_delivery
 
     // Human-direct failure must NOT wake the leader (spec 5.4c): the failure is
     // surfaced inline to the user instead.
-    let lead_unread = team_repo.peek_unread(&created.id, &lead.slot_id).await.unwrap();
+    let lead_unread = team_repo
+        .peek_unread(&created.id, &active_session_id, &lead.slot_id)
+        .await
+        .unwrap();
     assert!(
         !lead_unread
             .iter()
@@ -6898,6 +7007,13 @@ async fn agent_triggered_attach_failure_notifies_leader() {
         .unwrap();
     let lead_slot_id = created.leader_assistant_id.clone().expect("leader slot");
     svc.ensure_session("user1", &created.id).await.unwrap();
+    let active_session_id = team_repo
+        .get_team(&created.id)
+        .await
+        .expect("team exists")
+        .expect("team row")
+        .active_session_id
+        .expect("team has an active session");
 
     // Arm the failure, then have the leader spawn a teammate whose attach fails.
     fail_next.store(true, Ordering::SeqCst);
@@ -6918,7 +7034,10 @@ async fn agent_triggered_attach_failure_notifies_leader() {
     // re-delegate.
     tokio::time::timeout(std::time::Duration::from_secs(2), async {
         loop {
-            let leader_messages = team_repo.get_history(&created.id, &lead_slot_id, None).await.unwrap();
+            let leader_messages = team_repo
+                .get_history(&created.id, &active_session_id, &lead_slot_id, None)
+                .await
+                .unwrap();
             if leader_messages.iter().any(|message| {
                 message.from_agent_id == spawned.slot_id && message.content.contains("failed to start its runtime")
             }) {

--- a/crates/aionui-team/tests/task_board_integration.rs
+++ b/crates/aionui-team/tests/task_board_integration.rs
@@ -26,7 +26,7 @@ async fn setup() -> (TaskBoard, aionui_db::Database) {
 async fn tk1_create_task_no_dependencies() {
     let (board, _db) = setup().await;
     let task = board
-        .create_task("t1", "Implement feature", None, None, &[])
+        .create_task("t1", "s1", "Implement feature", None, None, &[])
         .await
         .unwrap();
     assert_eq!(task.subject, "Implement feature");
@@ -38,14 +38,14 @@ async fn tk1_create_task_no_dependencies() {
 #[tokio::test]
 async fn tk2_create_task_with_single_dependency() {
     let (board, _db) = setup().await;
-    let task_a = board.create_task("t1", "Task A", None, None, &[]).await.unwrap();
+    let task_a = board.create_task("t1", "s1", "Task A", None, None, &[]).await.unwrap();
     let task_b = board
-        .create_task("t1", "Task B", None, None, std::slice::from_ref(&task_a.id))
+        .create_task("t1", "s1", "Task B", None, None, std::slice::from_ref(&task_a.id))
         .await
         .unwrap();
     assert_eq!(task_b.blocked_by, vec![task_a.id.clone()]);
 
-    let tasks = board.list_tasks("t1").await.unwrap();
+    let tasks = board.list_tasks("t1", "s1").await.unwrap();
     let a = tasks.iter().find(|t| t.id == task_a.id).unwrap();
     assert_eq!(a.blocks, vec![task_b.id]);
 }
@@ -53,15 +53,15 @@ async fn tk2_create_task_with_single_dependency() {
 #[tokio::test]
 async fn tk3_create_task_with_multiple_dependencies() {
     let (board, _db) = setup().await;
-    let a = board.create_task("t1", "A", None, None, &[]).await.unwrap();
-    let b = board.create_task("t1", "B", None, None, &[]).await.unwrap();
+    let a = board.create_task("t1", "s1", "A", None, None, &[]).await.unwrap();
+    let b = board.create_task("t1", "s1", "B", None, None, &[]).await.unwrap();
     let c = board
-        .create_task("t1", "C", None, None, &[a.id.clone(), b.id.clone()])
+        .create_task("t1", "s1", "C", None, None, &[a.id.clone(), b.id.clone()])
         .await
         .unwrap();
     assert_eq!(c.blocked_by.len(), 2);
 
-    let tasks = board.list_tasks("t1").await.unwrap();
+    let tasks = board.list_tasks("t1", "s1").await.unwrap();
     let a_updated = tasks.iter().find(|t| t.id == a.id).unwrap();
     let b_updated = tasks.iter().find(|t| t.id == b.id).unwrap();
     assert!(a_updated.blocks.contains(&c.id));
@@ -71,7 +71,7 @@ async fn tk3_create_task_with_multiple_dependencies() {
 #[tokio::test]
 async fn tk4_create_task_nonexistent_dependency_fails() {
     let (board, _db) = setup().await;
-    let result = board.create_task("t1", "X", None, None, &["nonexistent".into()]).await;
+    let result = board.create_task("t1", "s1", "X", None, None, &["nonexistent".into()]).await;
     assert!(result.is_err());
 }
 
@@ -80,10 +80,11 @@ async fn tk4_create_task_nonexistent_dependency_fails() {
 #[tokio::test]
 async fn tu1_update_status_pending_to_in_progress() {
     let (board, _db) = setup().await;
-    let task = board.create_task("t1", "Work", None, None, &[]).await.unwrap();
+    let task = board.create_task("t1", "s1", "Work", None, None, &[]).await.unwrap();
     let updated = board
         .update_task(
             "t1",
+            "s1",
             &task.id,
             &TaskUpdate {
                 status: Some(TaskStatus::InProgress),
@@ -98,15 +99,16 @@ async fn tu1_update_status_pending_to_in_progress() {
 #[tokio::test]
 async fn tu2_update_status_to_completed_triggers_unblock() {
     let (board, _db) = setup().await;
-    let a = board.create_task("t1", "A", None, None, &[]).await.unwrap();
+    let a = board.create_task("t1", "s1", "A", None, None, &[]).await.unwrap();
     let b = board
-        .create_task("t1", "B", None, None, std::slice::from_ref(&a.id))
+        .create_task("t1", "s1", "B", None, None, std::slice::from_ref(&a.id))
         .await
         .unwrap();
 
     board
         .update_task(
             "t1",
+            "s1",
             &a.id,
             &TaskUpdate {
                 status: Some(TaskStatus::Completed),
@@ -116,7 +118,7 @@ async fn tu2_update_status_to_completed_triggers_unblock() {
         .await
         .unwrap();
 
-    let tasks = board.list_tasks("t1").await.unwrap();
+    let tasks = board.list_tasks("t1", "s1").await.unwrap();
     let b_updated = tasks.iter().find(|t| t.id == b.id).unwrap();
     assert!(b_updated.blocked_by.is_empty());
 }
@@ -124,10 +126,11 @@ async fn tu2_update_status_to_completed_triggers_unblock() {
 #[tokio::test]
 async fn tu3_update_description() {
     let (board, _db) = setup().await;
-    let task = board.create_task("t1", "Work", None, None, &[]).await.unwrap();
+    let task = board.create_task("t1", "s1", "Work", None, None, &[]).await.unwrap();
     let updated = board
         .update_task(
             "t1",
+            "s1",
             &task.id,
             &TaskUpdate {
                 description: Some("Updated description".into()),
@@ -142,10 +145,11 @@ async fn tu3_update_description() {
 #[tokio::test]
 async fn tu4_update_owner() {
     let (board, _db) = setup().await;
-    let task = board.create_task("t1", "Work", None, None, &[]).await.unwrap();
+    let task = board.create_task("t1", "s1", "Work", None, None, &[]).await.unwrap();
     let updated = board
         .update_task(
             "t1",
+            "s1",
             &task.id,
             &TaskUpdate {
                 owner: Some("agent-2".into()),
@@ -160,7 +164,7 @@ async fn tu4_update_owner() {
 #[tokio::test]
 async fn tu5_update_nonexistent_task_fails() {
     let (board, _db) = setup().await;
-    let result = board.update_task("t1", "nonexistent", &TaskUpdate::default()).await;
+    let result = board.update_task("t1", "s1", "nonexistent", &TaskUpdate::default()).await;
     assert!(result.is_err());
 }
 
@@ -169,15 +173,16 @@ async fn tu5_update_nonexistent_task_fails() {
 #[tokio::test]
 async fn cu1_complete_unblocks_single_downstream() {
     let (board, _db) = setup().await;
-    let a = board.create_task("t1", "A", None, None, &[]).await.unwrap();
+    let a = board.create_task("t1", "s1", "A", None, None, &[]).await.unwrap();
     let b = board
-        .create_task("t1", "B", None, None, std::slice::from_ref(&a.id))
+        .create_task("t1", "s1", "B", None, None, std::slice::from_ref(&a.id))
         .await
         .unwrap();
 
     board
         .update_task(
             "t1",
+            "s1",
             &a.id,
             &TaskUpdate {
                 status: Some(TaskStatus::Completed),
@@ -187,7 +192,7 @@ async fn cu1_complete_unblocks_single_downstream() {
         .await
         .unwrap();
 
-    let tasks = board.list_tasks("t1").await.unwrap();
+    let tasks = board.list_tasks("t1", "s1").await.unwrap();
     let b_updated = tasks.iter().find(|t| t.id == b.id).unwrap();
     assert!(b_updated.blocked_by.is_empty());
 }
@@ -195,19 +200,20 @@ async fn cu1_complete_unblocks_single_downstream() {
 #[tokio::test]
 async fn cu2_complete_unblocks_multiple_downstream() {
     let (board, _db) = setup().await;
-    let a = board.create_task("t1", "A", None, None, &[]).await.unwrap();
+    let a = board.create_task("t1", "s1", "A", None, None, &[]).await.unwrap();
     let b = board
-        .create_task("t1", "B", None, None, std::slice::from_ref(&a.id))
+        .create_task("t1", "s1", "B", None, None, std::slice::from_ref(&a.id))
         .await
         .unwrap();
     let c = board
-        .create_task("t1", "C", None, None, std::slice::from_ref(&a.id))
+        .create_task("t1", "s1", "C", None, None, std::slice::from_ref(&a.id))
         .await
         .unwrap();
 
     board
         .update_task(
             "t1",
+            "s1",
             &a.id,
             &TaskUpdate {
                 status: Some(TaskStatus::Completed),
@@ -217,7 +223,7 @@ async fn cu2_complete_unblocks_multiple_downstream() {
         .await
         .unwrap();
 
-    let tasks = board.list_tasks("t1").await.unwrap();
+    let tasks = board.list_tasks("t1", "s1").await.unwrap();
     let b_updated = tasks.iter().find(|t| t.id == b.id).unwrap();
     let c_updated = tasks.iter().find(|t| t.id == c.id).unwrap();
     assert!(b_updated.blocked_by.is_empty());
@@ -227,16 +233,17 @@ async fn cu2_complete_unblocks_multiple_downstream() {
 #[tokio::test]
 async fn cu3_partial_unblock_preserves_other_deps() {
     let (board, _db) = setup().await;
-    let a = board.create_task("t1", "A", None, None, &[]).await.unwrap();
-    let x = board.create_task("t1", "X", None, None, &[]).await.unwrap();
+    let a = board.create_task("t1", "s1", "A", None, None, &[]).await.unwrap();
+    let x = board.create_task("t1", "s1", "X", None, None, &[]).await.unwrap();
     let b = board
-        .create_task("t1", "B", None, None, &[a.id.clone(), x.id.clone()])
+        .create_task("t1", "s1", "B", None, None, &[a.id.clone(), x.id.clone()])
         .await
         .unwrap();
 
     board
         .update_task(
             "t1",
+            "s1",
             &a.id,
             &TaskUpdate {
                 status: Some(TaskStatus::Completed),
@@ -246,7 +253,7 @@ async fn cu3_partial_unblock_preserves_other_deps() {
         .await
         .unwrap();
 
-    let tasks = board.list_tasks("t1").await.unwrap();
+    let tasks = board.list_tasks("t1", "s1").await.unwrap();
     let b_updated = tasks.iter().find(|t| t.id == b.id).unwrap();
     assert_eq!(b_updated.blocked_by, vec![x.id]);
 }
@@ -254,10 +261,11 @@ async fn cu3_partial_unblock_preserves_other_deps() {
 #[tokio::test]
 async fn cu4_complete_no_downstream_is_noop() {
     let (board, _db) = setup().await;
-    let task = board.create_task("t1", "Solo", None, None, &[]).await.unwrap();
+    let task = board.create_task("t1", "s1", "Solo", None, None, &[]).await.unwrap();
     let updated = board
         .update_task(
             "t1",
+            "s1",
             &task.id,
             &TaskUpdate {
                 status: Some(TaskStatus::Completed),
@@ -274,28 +282,28 @@ async fn cu4_complete_no_downstream_is_noop() {
 #[tokio::test]
 async fn tt1_list_all_tasks() {
     let (board, _db) = setup().await;
-    board.create_task("t1", "A", None, None, &[]).await.unwrap();
-    board.create_task("t1", "B", None, None, &[]).await.unwrap();
-    let tasks = board.list_tasks("t1").await.unwrap();
+    board.create_task("t1", "s1", "A", None, None, &[]).await.unwrap();
+    board.create_task("t1", "s1", "B", None, None, &[]).await.unwrap();
+    let tasks = board.list_tasks("t1", "s1").await.unwrap();
     assert_eq!(tasks.len(), 2);
 }
 
 #[tokio::test]
 async fn tt2_list_empty() {
     let (board, _db) = setup().await;
-    let tasks = board.list_tasks("t1").await.unwrap();
+    let tasks = board.list_tasks("t1", "s1").await.unwrap();
     assert!(tasks.is_empty());
 }
 
 #[tokio::test]
 async fn tt3_list_includes_dependency_info() {
     let (board, _db) = setup().await;
-    let a = board.create_task("t1", "A", None, None, &[]).await.unwrap();
+    let a = board.create_task("t1", "s1", "A", None, None, &[]).await.unwrap();
     let b = board
-        .create_task("t1", "B", None, None, std::slice::from_ref(&a.id))
+        .create_task("t1", "s1", "B", None, None, std::slice::from_ref(&a.id))
         .await
         .unwrap();
-    let tasks = board.list_tasks("t1").await.unwrap();
+    let tasks = board.list_tasks("t1", "s1").await.unwrap();
     let b_found = tasks.iter().find(|t| t.id == b.id).unwrap();
     assert_eq!(b_found.blocked_by, vec![a.id.clone()]);
     let a_found = tasks.iter().find(|t| t.id == a.id).unwrap();
@@ -307,13 +315,13 @@ async fn tt3_list_includes_dependency_info() {
 #[tokio::test]
 async fn dc4_blocked_by_blocks_bidirectional_consistency() {
     let (board, _db) = setup().await;
-    let a = board.create_task("t1", "A", None, None, &[]).await.unwrap();
+    let a = board.create_task("t1", "s1", "A", None, None, &[]).await.unwrap();
     let b = board
-        .create_task("t1", "B", None, None, std::slice::from_ref(&a.id))
+        .create_task("t1", "s1", "B", None, None, std::slice::from_ref(&a.id))
         .await
         .unwrap();
 
-    let tasks = board.list_tasks("t1").await.unwrap();
+    let tasks = board.list_tasks("t1", "s1").await.unwrap();
     let a_found = tasks.iter().find(|t| t.id == a.id).unwrap();
     let b_found = tasks.iter().find(|t| t.id == b.id).unwrap();
     assert!(a_found.blocks.contains(&b.id));


### PR DESCRIPTION
> Supersedes #713 (that one was auto-closed when I force-pushed the branch to fix a CRLF line-ending diff explosion; the code is identical).

## Summary

Adds the ability to open **multiple working sessions** under a single team, so users can run parallel work lines (e.g. a "research" thread and an "implementation" thread) without losing the conversation history of either. Today every team is locked to exactly one session (enforced by an in-memory `DashMap` keyed by `team_id`); this lifts that limit while keeping the single-session default byte-for-byte backward compatible.

## What changed

**Schema (migration 030)** — `crates/aionui-db/migrations/030_team_sessions.sql`
- New `team_sessions` table (id, team_id, name, is_primary, timestamps). Each team owns at least one session; `is_primary` marks the auto-created default that cannot be deleted.
- New `team_session_agents` table binding each `(session, slot)` pair to a concrete `conversation_id`.
- `mailbox` and `team_tasks` gain a nullable `session_id` column.
- **Backward-compatible backfill**: every existing team gets a primary session (`is_primary=1`, deterministic id `primary_<team_id>`), its roster slots are bound from the `teams.agents` JSON, and legacy mailbox/task rows are assigned to that primary session. `teams.active_session_id` is set to it. The backfill is idempotent (`WHERE NOT EXISTS` / `json_valid` guards) and never aborts on a corrupted roster row.

**Runtime threading** — `session_id` is threaded through `Mailbox` / `TaskBoard` facades, `TeammateManager`, `TeamSession`, and the provisioning layer. Team creation mints the primary session **before** provisioning conversations so each conversation carries `sessionId` in its `extra`. `ensure_session` resolves the active session id (pointer → primary → lazy create). Added/spawned roster agents bind to the team's active session.

**API (additive)** — `crates/aionui-team/src/routes.rs`
| Method | Path | Purpose |
|---|---|---|
| GET | `/api/teams/{id}/sessions` | List sessions |
| POST | `/api/teams/{id}/sessions` | Create a session (mints fresh per-slot conversations) |
| GET | `/api/teams/{id}/sessions/{sid}` | Get a session with per-slot bindings |
| PATCH | `/api/teams/{id}/sessions/{sid}` | Rename |
| DELETE | `/api/teams/{id}/sessions/{sid}` | Delete (primary undeletable) |
| POST | `/api/teams/{id}/sessions/{sid}/active` | Set as active |

The pre-existing singular `/api/teams/{id}/session` routes keep working as the "active session" shorthand for existing clients.

## Isolation model

Each session gets its **own** per-slot conversations, mailbox messages, and task board, isolated by `session_id`. The team roster (backend/model/name/role), `session_mode`, and workspace stay shared. Switching the active session stops the running in-memory session so the next `ensure_session` rebuilds it against the new session id.

## Verification

- `cargo check --workspace` — clean
- `cargo clippy -p aionui-team -p aionui-api-types -p aionui-db` — clean
- `cargo test -p aionui-team` — **414 lib + 231 integration tests pass**. 6 integration tests in `session_service_integration.rs` fail, but they fail **identically on the unmodified v0.1.53 baseline** (confirmed via `git stash`): they assert `workspace.contains("/conversations/acp-temp-")` with a forward slash, which never matches the Windows backslash path separator. They are pre-existing, OS-specific, and unrelated to this change.
- Migration validated standalone with `sqlite3` against: happy path (correct backfill of sessions/bindings/mailbox/tasks), empty roster, **malformed `agents` JSON** (the `json_valid` guard prevents the migration from aborting), and idempotency.

## Out of scope

- The frontend (AionUi) changes that consume these endpoints will follow as a separate PR against `iOfficeAI/AionUi`.
- No changes to the normal (non-team) conversation list or the team roster editing flow.