### PR TITLE
fix(session): carry tool input on permission events so the approval card shows what is being approved

### DIFF
--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -2622,8 +2622,10 @@ fn translate_event(event: SessionEvent, conversation_id: &str, terminal_result_s
         // frontend renders the allow/deny card. The `tool_call_id` MUST equal the
         // `request_id` — `SessionAgentTask::confirm` dispatches `AnswerPermission`
         // keyed on the same id (the frontend echoes the `call_id` it received here).
-        // `input` (AskUserQuestion question content) rides as `raw_input`; the
-        // generic `Approved`/`Denied` options let the reducer + card render.
+        // `input` (the raised tool's raw input — a Bash `command`, AskUserQuestion
+        // `{questions:[…]}`) rides as `raw_input` so the card can show the approver
+        // what they are approving (AionUi issue #3779); the generic
+        // `Approved`/`Denied` options let the reducer + card render.
         SessionEvent::Permission {
             request_id,
             tool_name,

--- a/crates/aionui-session/src/adapter/claude.rs
+++ b/crates/aionui-session/src/adapter/claude.rs
@@ -717,19 +717,16 @@ impl ClaudeAdapter {
                     .and_then(|r| r.get("tool_name"))
                     .and_then(Value::as_str)
                     .map(str::to_string);
-                // Carry the raw `input` ONLY for AskUserQuestion — its
-                // `{questions:[…]}` is question CONTENT meant for the user, so the
-                // frontend can render a real question card. For every other tool the
-                // `input` is a command body / file contents (TIO-13 sensitive) and is
-                // deliberately dropped here — the generic allow/deny card needs no
-                // payload. `tool_name` itself is non-sensitive (a tool label) and is
-                // always carried so the conversation layer can tell AskUserQuestion
-                // apart from an ordinary approval.
-                let input = if tool_name.as_deref() == Some("AskUserQuestion") {
-                    request.and_then(|r| r.get("input")).cloned()
-                } else {
-                    None
-                };
+                // Carry the raw `input` for EVERY tool. The permission card must show
+                // the user WHAT they are approving (a Bash `command`, a Write target)
+                // — with only `tool_name` the card reads "命令: Bash" and the user
+                // approves blind (AionUi issue #3779). This is display-to-the-approver,
+                // not logging: TIO-13 ("never log tool input at info") still holds, and
+                // the SAME `input` already reaches the frontend via the assistant
+                // tool_use block (ToolBegin carries it), so the card adds no new
+                // exposure. For AskUserQuestion the `{questions:[…]}` payload
+                // additionally drives the real question card.
+                let input = request.and_then(|r| r.get("input")).cloned();
                 vec![SessionEvent::Permission {
                     request_id: request_id.to_string(),
                     // 007 §9.17: claude can_use_tool is a TOOL approval (not auth).
@@ -1890,11 +1887,13 @@ mod tests {
         }
     }
 
-    /// An ORDINARY tool permission (Bash) carries `tool_name` but NOT `input` — the
-    /// command body is TIO-13 sensitive and is deliberately dropped (the generic
-    /// allow/deny card needs no payload). Distinguishes it from AskUserQuestion.
+    /// An ORDINARY tool permission (Bash) carries `tool_name` AND `input` — the
+    /// permission card must show the approver what command they are approving
+    /// (AionUi issue #3779: with input dropped the card read "命令: Bash" and the
+    /// user approved blind). Display-to-the-approver is not logging, so TIO-13
+    /// (never log tool input at info) is unaffected.
     #[test]
-    fn ordinary_tool_permission_drops_input_keeps_tool_name() {
+    fn ordinary_tool_permission_carries_input_and_tool_name() {
         let frame = serde_json::json!({
             "type": "control_request",
             "request_id": "req-b1",
@@ -1909,9 +1908,10 @@ mod tests {
         match events.as_slice() {
             [SessionEvent::Permission { tool_name, input, .. }] => {
                 assert_eq!(tool_name.as_deref(), Some("Bash"));
-                assert!(
-                    input.is_none(),
-                    "ordinary tool input (command body) is NOT projected (TIO-13)"
+                let input = input.as_ref().expect("ordinary tool input is projected for the card");
+                assert_eq!(
+                    input["command"], "rm -rf /",
+                    "the command body reaches the permission card so the user reviews it"
                 );
             }
             other => panic!("expected one Permission, got {other:?}"),

--- a/crates/aionui-session/src/backend/acp_conn.rs
+++ b/crates/aionui-session/src/backend/acp_conn.rs
@@ -3489,7 +3489,11 @@ mod tests {
         .expect("Permission surfaced");
         // AionUi issue #3779: the card must show what is being approved — the
         // toolCall's title and rawInput ride on the Permission event.
-        assert_eq!(perm_tool_name.as_deref(), Some("Bash"), "toolCall.title rides as tool_name");
+        assert_eq!(
+            perm_tool_name.as_deref(),
+            Some("Bash"),
+            "toolCall.title rides as tool_name"
+        );
         let perm_input = perm_input.expect("toolCall.rawInput rides as input");
         assert_eq!(perm_input["command"], "rm -rf /", "rawInput reaches the card verbatim");
 

--- a/crates/aionui-session/src/backend/acp_conn.rs
+++ b/crates/aionui-session/src/backend/acp_conn.rs
@@ -1561,6 +1561,14 @@ async fn handle_reverse_rpc(
                     pending_perm_options.lock().await.insert(id.to_string(), parsed);
                 }
             }
+            // Carry the raised toolCall's `title` and `rawInput` so the permission
+            // card can show the approver WHAT they are approving (AionUi issue
+            // #3779 — a title-less card read as a bare "Permission request" and the
+            // user approved blind). Same wire fields `parse_permission_metadata`
+            // already reads (`toolCall.title` / `toolCall.rawInput`, ACP
+            // session/request_permission params). Display-to-the-approver, not
+            // logging — TIO-13 still applies to log output.
+            let perm_tool_call = frame.get("params").and_then(|p| p.get("toolCall"));
             emit(
                 event_tx,
                 session_id,
@@ -1569,10 +1577,11 @@ async fn handle_reverse_rpc(
                     request_id: id.to_string(),
                     kind: PermissionKind::Tool,
                     metadata,
-                    // AskUserQuestion projection is claude-direct only; ACP permission
-                    // requests carry MCP context via `metadata`, not a question payload.
-                    tool_name: None,
-                    input: None,
+                    tool_name: perm_tool_call
+                        .and_then(|tc| tc.get("title"))
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                    input: perm_tool_call.and_then(|tc| tc.get("rawInput")).cloned(),
                 },
             );
         }
@@ -3447,7 +3456,7 @@ mod tests {
             r#"{"optionId":"ok","kind":"allow_once","name":"Allow"},"#,
             r#"{"optionId":"ok_always","kind":"allow_always","name":"Always Allow"},"#,
             r#"{"optionId":"no","kind":"reject_once","name":"Reject"}],"#,
-            r#""toolCall":{"title":"Bash","rawInput":{}}}}"#,
+            r#""toolCall":{"title":"Bash","rawInput":{"command":"rm -rf /"}}}}"#,
             "\n",
         )
         .as_bytes()
@@ -3461,10 +3470,16 @@ mod tests {
 
         // Wait for the Permission event so its request_id (the wire "501") is surfaced
         // and the offered options are stashed.
-        let req_id = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        let (req_id, perm_tool_name, perm_input) = tokio::time::timeout(std::time::Duration::from_secs(5), async {
             while let Some(env) = events.next().await {
-                if let SessionEvent::Permission { request_id, .. } = env.event {
-                    return Some(request_id);
+                if let SessionEvent::Permission {
+                    request_id,
+                    tool_name,
+                    input,
+                    ..
+                } = env.event
+                {
+                    return Some((request_id, tool_name, input));
                 }
             }
             None
@@ -3472,6 +3487,11 @@ mod tests {
         .await
         .expect("must not hang")
         .expect("Permission surfaced");
+        // AionUi issue #3779: the card must show what is being approved — the
+        // toolCall's title and rawInput ride on the Permission event.
+        assert_eq!(perm_tool_name.as_deref(), Some("Bash"), "toolCall.title rides as tool_name");
+        let perm_input = perm_input.expect("toolCall.rawInput rides as input");
+        assert_eq!(perm_input["command"], "rm -rf /", "rawInput reaches the card verbatim");
 
         // AllowAlways → must echo the real allow_always optionId "ok_always".
         backend

--- a/crates/aionui-session/src/backend/codex_conn.rs
+++ b/crates/aionui-session/src/backend/codex_conn.rs
@@ -2225,9 +2225,14 @@ async fn handle_reverse_rpc(
                     // G3 auto-approval is ACP-only (acp_conn). The native codex
                     // app-server command/file approval is not a team-MCP path.
                     metadata: None,
-                    // AskUserQuestion projection is claude-direct only.
-                    tool_name: None,
-                    input: None,
+                    // The approval class as the card title, and the request `params`
+                    // as an UNPARSED passthrough so the card can show the approver
+                    // what they are approving (AionUi issue #3779 — approving blind).
+                    // No shape is asserted: the frontend reads `command` when present
+                    // and falls back to the title otherwise, so an unprobed params
+                    // shape degrades to the previous title-only card.
+                    tool_name: Some(title.to_string()),
+                    input: frame.get("params").cloned(),
                 },
             );
         }
@@ -4145,25 +4150,33 @@ mod tests {
     #[tokio::test]
     async fn approval_reverse_rpc_surfaces_as_permission() {
         // commandExecution/fileChange approval ServerRequests (response = {decision},
-        // which is what AnswerPermission writes) → user-facing Permission (Tool).
-        for m in [
-            "item/commandExecution/requestApproval",
-            "item/fileChange/requestApproval",
+        // which is what AnswerPermission writes) → user-facing Permission (Tool),
+        // carrying the approval class as `tool_name` and the wire `params` verbatim
+        // as `input` (unparsed passthrough) so the permission card can show the
+        // approver what they are approving (AionUi issue #3779).
+        for (m, title) in [
+            ("item/commandExecution/requestApproval", "CommandExecution"),
+            ("item/fileChange/requestApproval", "FileChange"),
         ] {
             let events = drive_codex(&[&format!(
                 r#"{{"jsonrpc":"2.0","id":7,"method":"{m}","params":{{"command":"rm -rf /"}}}}"#
             )])
             .await;
-            assert!(
-                events.iter().any(|e| matches!(
-                    e,
+            let perm = events
+                .iter()
+                .find_map(|e| match e {
                     SessionEvent::Permission {
                         kind: PermissionKind::Tool,
+                        tool_name,
+                        input,
                         ..
-                    }
-                )),
-                "{m} surfaces as Permission(Tool), got {events:?}"
-            );
+                    } => Some((tool_name.clone(), input.clone())),
+                    _ => None,
+                })
+                .unwrap_or_else(|| panic!("{m} surfaces as Permission(Tool), got {events:?}"));
+            assert_eq!(perm.0.as_deref(), Some(title), "{m} carries the approval class");
+            let input = perm.1.expect("params ride as input for the card");
+            assert_eq!(input["command"], "rm -rf /", "{m} passes the wire params through");
         }
     }
 

--- a/crates/aionui-session/src/event.rs
+++ b/crates/aionui-session/src/event.rs
@@ -220,22 +220,22 @@ pub enum SessionEvent {
         /// ⚠️ TIO-13: may carry a tool title — never log at info level.
         #[serde(default)]
         metadata: Option<serde_json::Value>,
-        /// AskUserQuestion projection: the raised tool's name, so the conversation
-        /// layer can recognize an `AskUserQuestion` permission and render it as a
-        /// question card (not a generic allow/deny). `None` for every other path
-        /// (ordinary tool approvals, ACP MCP, auth). The reducer NEVER reads it
-        /// (ref-counts on request_id only — §R9). `#[serde(default)]` so older
-        /// persisted frames deserialize as `None`.
+        /// The raised tool's name (claude-direct: every `can_use_tool`), used as
+        /// the permission card's title and to recognize an `AskUserQuestion`
+        /// permission (rendered as a question card, not a generic allow/deny).
+        /// `None` for paths that name no tool (ACP MCP, auth). The reducer NEVER
+        /// reads it (ref-counts on request_id only — §R9). `#[serde(default)]` so
+        /// older persisted frames deserialize as `None`.
         #[serde(default)]
         tool_name: Option<String>,
-        /// AskUserQuestion projection: the raised tool's raw `input`
-        /// (`{questions:[{question, header, options:[{label,description}], multiSelect}]}`).
-        /// This is QUESTION CONTENT meant to be shown to the user — NOT a sensitive
-        /// tool body, so TIO-13's redaction does not apply (`detail` still stays
-        /// `None` for ordinary tools). Carried so the question text/options reach the
-        /// frontend, which cannot synthesize text that exists on no transport. `None`
-        /// for non-AskUserQuestion paths. Reducer no-op. `#[serde(default)]` for
-        /// back-compat.
+        /// The raised tool's raw `input`, shown on the permission card so the
+        /// approver can review WHAT they are approving (a Bash `command`, an
+        /// AskUserQuestion `{questions:[…]}` — AionUi issue #3779: without it the
+        /// card showed only the tool name and the user approved blind). This is
+        /// display-to-the-approver, NOT logging — TIO-13 (never log tool input at
+        /// info) still applies to log output. `None` for paths that carry no tool
+        /// input (auth, codex approvals until their params are probed). Reducer
+        /// no-op. `#[serde(default)]` for back-compat.
         #[serde(default)]
         input: Option<serde_json::Value>,
     },


### PR DESCRIPTION
## Problem

The permission approval card showed no detail of the operation being approved (iOfficeAI/AionUi#3779):

- **claude direct**: the card read `命令: Bash` — the tool name, not the command. The claude adapter deliberately dropped the `can_use_tool` `input` for every tool except AskUserQuestion (TIO-13 redaction extended from "never log" to "never display").
- **ACP backends**: worse — `tool_name`/`input` were both `None`, so the card was a bare "Permission request" with no tool name at all.
- **codex direct**: same — neither a tool name nor the request params were surfaced.

The user had to approve blind.

## Fix

Carry the tool detail on `SessionEvent::Permission`; the downstream translator (`session_agent.rs`) already rides `input` as the AcpPermission `raw_input`, and the AionUi frontend card already renders `raw_input.command || title` — **no frontend change is needed**.

- **claude adapter** (`adapter/claude.rs`): project `request.input` for EVERY tool, not only AskUserQuestion. Display-to-the-approver is not logging: TIO-13 (never log tool input at info) is unaffected, and the same `input` already reaches the frontend via the assistant `tool_use` block (`ToolBegin` carries it), so the card adds no new exposure.
- **acp conn** (`acp_conn.rs`): carry `toolCall.title` as `tool_name` and `toolCall.rawInput` as `input` on `session/request_permission` — the same wire fields `parse_permission_metadata` already reads (verified: existing G3 parser + its test fixtures).
- **codex conn** (`codex_conn.rs`): carry the approval class (`CommandExecution`/`FileChange`) as `tool_name` and the wire `params` as an **unparsed passthrough** `input`. No shape is asserted — the frontend falls back to the title when `command` is absent, so an unprobed params shape degrades to the previous title-only card.
- **event docs** (`event.rs`): update the `Permission.tool_name`/`input` docs to the actual (display-oriented) contract.

## Tests

- `adapter::claude::tests::ordinary_tool_permission_carries_input_and_tool_name` (rewritten from the old drops-input test)
- `backend::codex_conn::tests::approval_reverse_rpc_surfaces_as_permission` (strengthened: asserts class + params passthrough)
- `backend::acp_conn::tests::acp_answer_permission_echoes_real_offered_option_id_by_kind` (strengthened: asserts title + rawInput ride the event)
- Full permission-related selection (58 tests across aionui-session / aionui-ai-agent) passing; clippy + fmt clean.

## Known remaining gap

The REST recovery path (`GET /confirmations` after a page reload) still rebuilds a title-only card from `PendingPermissionView` (claude's pending map already stores `input`, but the view deliberately exposes only `request_id`/`tool_name`). The live-frame path this issue reports is fixed; extending recovery is a follow-up.

Fixes iOfficeAI/AionUi#3779
Fixes iOfficeAI/AionUi#3781
