### PR TITLE
fix(auth): make AionUi->AionPro data adoption a one-shot event

### DIFF
--- a/crates/aionui-auth/src/service.rs
+++ b/crates/aionui-auth/src/service.rs
@@ -92,16 +92,15 @@ impl AuthProvisionService {
         }
         // Move the corresponding on-disk files to the adopter's per-user roots
         // so the upgraded account can see its files (DB rows already point at
-        // it). Gated on the adoption window (sole external user), NOT on
-        // "rows moved this call": the on-disk move is idempotent and MUST be
-        // able to re-run after a partial failure — the first login may adopt
-        // the DB rows (adopted > 0) yet fail halfway through the file move, so
-        // a later login (adopted == 0, window still held) has to pick up the
-        // leftover files. The window predicate is false once a second external
-        // user exists, so files can never leak to a later account.
+        // it). Gated on the recorded one-shot adopter marker, NOT on "rows
+        // moved this call": the on-disk move is idempotent and MUST be able to
+        // re-run after a partial failure — the first login stamps the marker
+        // yet may fail halfway through the file move, so a later login of the
+        // SAME account has to pick up the leftover files. Only the stamped
+        // adopter matches, so files can never leak to any other account.
         // Best-effort; never fails provisioning.
         if let Some(fs_adopter) = &self.fs_adopter
-            && self.user_repo.is_sole_external_user(&user.id).await?
+            && self.user_repo.is_default_data_adopter(&user.id).await?
         {
             fs_adopter.adopt_filesystem(&user.id).await;
         }

--- a/crates/aionui-db/migrations/031_adoption_once_marker.sql
+++ b/crates/aionui-db/migrations/031_adoption_once_marker.sql
@@ -1,0 +1,20 @@
+-- Migration 031: one-shot marker for the AionUi -> AionPro data adoption.
+--
+-- The adoption window used to be a pure eligibility predicate ("exactly one
+-- external user, and it is the caller"), evaluated on EVERY provision call.
+-- That guards WHO may adopt (a second account can never inherit another
+-- user's data) but not HOW MANY TIMES: as long as the machine kept a single
+-- external account, every login re-swept whatever the local default user had
+-- accumulated since — new AionUi conversations were repeatedly re-owned.
+--
+-- These columns live on the `system_default_user` row and record that the
+-- one-time adoption has happened (by whom, when). The window predicate gains
+-- a third condition (`adopted_by IS NULL`), so adoption fires exactly once —
+-- on the first external account's first login — and later local-mode data
+-- stays local. Rows for other users keep NULL in both columns.
+--
+-- Existing databases are not backfilled: their next provision performs the
+-- final sweep under the old semantics and stamps the marker in the same
+-- transaction.
+ALTER TABLE users ADD COLUMN adopted_by TEXT;
+ALTER TABLE users ADD COLUMN adopted_at INTEGER;

--- a/crates/aionui-db/migrations/032_adoption_once_marker.sql
+++ b/crates/aionui-db/migrations/032_adoption_once_marker.sql
@@ -1,4 +1,4 @@
--- Migration 031: one-shot marker for the AionUi -> AionPro data adoption.
+-- Migration 032: one-shot marker for the AionUi -> AionPro data adoption.
 --
 -- The adoption window used to be a pure eligibility predicate ("exactly one
 -- external user, and it is the caller"), evaluated on EVERY provision call.

--- a/crates/aionui-db/src/repository/sqlite_user.rs
+++ b/crates/aionui-db/src/repository/sqlite_user.rs
@@ -209,6 +209,19 @@ impl IUserRepository for SqliteUserRepository {
         if is_owner != 1 {
             return Ok(0);
         }
+        // One-shot marker: adoption happens exactly once, on the first
+        // external account's first login. Eligibility alone used to be
+        // re-evaluated on every provision call, which kept re-sweeping data
+        // the local default user accumulated AFTER the first adoption (new
+        // AionUi conversations were repeatedly re-owned). A stamped marker
+        // closes the window permanently regardless of later data.
+        let already_adopted: Option<Option<String>> =
+            sqlx::query_scalar("SELECT adopted_by FROM users WHERE id = 'system_default_user'")
+                .fetch_optional(&mut *tx)
+                .await?;
+        if matches!(already_adopted, Some(Some(_))) {
+            return Ok(0);
+        }
 
         // Discover ownership tables from the live schema rather than a
         // hand-maintained list, so user-scoped tables added by future
@@ -247,24 +260,32 @@ impl IUserRepository for SqliteUserRepository {
             }
         }
 
+        // Stamp the one-shot marker in the same transaction: even a zero-row
+        // sweep (fresh machine with no local data) consumes the adoption
+        // opportunity — from now on local-mode data stays local.
+        sqlx::query(
+            "UPDATE users SET adopted_by = ?, adopted_at = ? \
+             WHERE id = 'system_default_user' AND adopted_by IS NULL",
+        )
+        .bind(owner_id)
+        .bind(aionui_common::now_ms())
+        .execute(&mut *tx)
+        .await?;
+
         tx.commit().await?;
         Ok(moved)
     }
 
-    async fn is_sole_external_user(&self, owner_id: &str) -> Result<bool, DbError> {
-        // Mirrors the adoption-window precondition in `adopt_system_default_data`:
-        // exactly one external user, and it is the caller.
-        let (external_count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM users WHERE user_type != 'local'")
-            .fetch_one(&self.pool)
-            .await?;
-        if external_count != 1 {
-            return Ok(false);
-        }
-        let (is_owner,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM users WHERE id = ? AND user_type != 'local'")
-            .bind(owner_id)
-            .fetch_one(&self.pool)
-            .await?;
-        Ok(is_owner == 1)
+    async fn is_default_data_adopter(&self, owner_id: &str) -> Result<bool, DbError> {
+        // The one-shot marker stamped by `adopt_system_default_data` is the
+        // single source of truth for "who adopted": only that account may
+        // re-run the on-disk file move.
+        let (matches,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM users WHERE id = 'system_default_user' AND adopted_by = ?")
+                .bind(owner_id)
+                .fetch_one(&self.pool)
+                .await?;
+        Ok(matches == 1)
     }
 
     async fn find_by_id(&self, id: &str) -> Result<Option<User>, DbError> {

--- a/crates/aionui-db/src/repository/user.rs
+++ b/crates/aionui-db/src/repository/user.rs
@@ -63,15 +63,14 @@ pub trait IUserRepository: Send + Sync {
     /// data authoritative.
     async fn adopt_system_default_data(&self, owner_id: &str) -> Result<u64, DbError>;
 
-    /// Whether `owner_id` currently holds the adoption window — i.e. it is the
-    /// ONLY external (aionpro) user in this database. This is the same
-    /// precondition `adopt_system_default_data` checks internally, exposed so
-    /// the on-disk file adoption can re-run after a partial move: once the DB
-    /// rows are adopted `adopt_system_default_data` returns 0, but leftover
-    /// files under `users/system_default_user/` may still need moving on a
-    /// later login. Returns `false` the moment a second external user exists,
-    /// so files can never leak to a later account.
-    async fn is_sole_external_user(&self, owner_id: &str) -> Result<bool, DbError>;
+    /// Whether `owner_id` is the recorded one-shot adopter of the local
+    /// default user's data (`users.adopted_by` on the `system_default_user`
+    /// row). Exposed so the on-disk file adoption can re-run after a partial
+    /// move: `adopt_system_default_data` fires only once, but leftover files
+    /// under `users/system_default_user/` may still need moving on a later
+    /// login. Only the stamped adopter ever matches, so files can never leak
+    /// to any other account — including after more accounts are provisioned.
+    async fn is_default_data_adopter(&self, owner_id: &str) -> Result<bool, DbError>;
 
     /// Finds a user by ID.
     async fn find_by_id(&self, id: &str) -> Result<Option<User>, DbError>;

--- a/crates/aionui-db/tests/adoption_coverage.rs
+++ b/crates/aionui-db/tests/adoption_coverage.rs
@@ -323,3 +323,96 @@ async fn adoption_window_closes_with_second_external_user() {
 
     db.close().await;
 }
+
+#[tokio::test]
+async fn adoption_fires_once_then_new_local_data_stays_local() {
+    let db = init_database_memory().await.unwrap();
+    let pool = db.pool();
+    let repo = SqliteUserRepository::new(pool.clone());
+
+    // Pre-upgrade local data.
+    sqlx::query(
+        "INSERT INTO conversations (id, user_id, name, type, extra, status, created_at, updated_at)
+         VALUES ('conv-old', 'system_default_user', 'Old', 'acp', '{}', 'pending', 1, 1)",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+
+    let user = repo
+        .ensure_external_user(UserType::Aionpro, "ext-once", ExternalUserProjection::default())
+        .await
+        .unwrap();
+
+    // First login: sweeps the old data and stamps the one-shot marker.
+    assert!(repo.adopt_system_default_data(&user.id).await.unwrap() >= 1);
+    let adopted_by: Option<String> =
+        sqlx::query_scalar("SELECT adopted_by FROM users WHERE id = 'system_default_user'")
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    assert_eq!(adopted_by.as_deref(), Some(user.id.as_str()), "marker must be stamped");
+    assert!(repo.is_default_data_adopter(&user.id).await.unwrap());
+
+    // AionUi keeps working locally: NEW data lands on the default user.
+    sqlx::query(
+        "INSERT INTO conversations (id, user_id, name, type, extra, status, created_at, updated_at)
+         VALUES ('conv-new', 'system_default_user', 'New', 'acp', '{}', 'pending', 2, 2)",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Later logins must NOT re-sweep it — the marker closes the window even
+    // though the account is still the machine's sole external user.
+    assert_eq!(repo.adopt_system_default_data(&user.id).await.unwrap(), 0);
+    let owner: String = sqlx::query_scalar("SELECT user_id FROM conversations WHERE id = 'conv-new'")
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    assert_eq!(owner, "system_default_user", "post-adoption local data must stay local");
+
+    db.close().await;
+}
+
+#[tokio::test]
+async fn empty_first_sweep_still_consumes_the_adoption_opportunity() {
+    let db = init_database_memory().await.unwrap();
+    let pool = db.pool();
+    let repo = SqliteUserRepository::new(pool.clone());
+
+    // Fresh machine: nothing to adopt on first login.
+    let user = repo
+        .ensure_external_user(UserType::Aionpro, "ext-fresh", ExternalUserProjection::default())
+        .await
+        .unwrap();
+    assert_eq!(repo.adopt_system_default_data(&user.id).await.unwrap(), 0);
+    assert!(
+        repo.is_default_data_adopter(&user.id).await.unwrap(),
+        "a zero-row sweep still stamps the marker"
+    );
+
+    // Local data created afterwards stays local forever.
+    sqlx::query(
+        "INSERT INTO conversations (id, user_id, name, type, extra, status, created_at, updated_at)
+         VALUES ('conv-later', 'system_default_user', 'Later', 'acp', '{}', 'pending', 3, 3)",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    assert_eq!(repo.adopt_system_default_data(&user.id).await.unwrap(), 0);
+    let owner: String = sqlx::query_scalar("SELECT user_id FROM conversations WHERE id = 'conv-later'")
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    assert_eq!(owner, "system_default_user");
+
+    // The marker is account-specific: nobody else counts as the adopter.
+    let other = repo
+        .ensure_external_user(UserType::Aionpro, "ext-other", ExternalUserProjection::default())
+        .await
+        .unwrap();
+    assert!(!repo.is_default_data_adopter(&other.id).await.unwrap());
+
+    db.close().await;
+}


### PR DESCRIPTION
## Problem

The adoption window was a pure eligibility predicate ("exactly one external user, and it is the caller") evaluated on **every** provision call. That guards **who** may adopt — a second account can never inherit another user's data — but not **how many times**: with a single external account on the machine, every AionPro login re-swept whatever the local default user had accumulated since. New AionUi conversations kept getting re-owned by the cloud account (reproduced on a dev database: 7 fresh local conversations swept on a later login).

## Fix

- **Migration 031**: `users.adopted_by` / `users.adopted_at`, stamped on the `system_default_user` row **inside the adoption transaction**.
- The window gains a third condition (`adopted_by IS NULL`): adoption fires exactly once — on the first external account's first login, even when there is nothing to sweep — and later local-mode data stays local forever.
- The on-disk file-move re-run predicate switches from "sole external user" to "is the recorded adopter" (`is_sole_external_user` → `is_default_data_adopter`): partial file moves still self-heal on the adopter's later logins, and can never fire for any other account.
- Existing databases are not backfilled: their next provision performs the final sweep under the old semantics and stamps the marker in the same transaction.

## Tests

- `adoption_fires_once_then_new_local_data_stays_local` — the core regression: post-adoption local data is never re-swept.
- `empty_first_sweep_still_consumes_the_adoption_opportunity` — zero-row first sweep still stamps; marker is account-specific.
- Existing window tests (`first_external_user_adopts_owner_user_id_tables_too`, `adoption_window_closes_with_second_external_user`) unchanged and green.
- db + auth: 869 passed; migration immutability passed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)