### PR TITLE
feat(agents): add omp (Oh My Pi) builtin ACP agent

### DIFF
--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -1581,7 +1581,7 @@ mod tests {
         // when none of the CLIs are installed on the test host.
         let reg = registry().await;
         let all = reg.list_all_including_hidden().await;
-        assert_eq!(all.len(), 41);
+        assert_eq!(all.len(), 42);
     }
 
     #[tokio::test]
@@ -1657,7 +1657,7 @@ mod tests {
                 .unwrap_or_else(|error| panic!("missing release lock for {backend}: {error}"));
             locked += 1;
         }
-        assert_eq!(locked, 12);
+        assert_eq!(locked, 13);
     }
 
     /// On a host that has *none* of the seeded CLIs installed, the
@@ -1692,7 +1692,7 @@ mod tests {
         let reg = registry().await;
         let all = reg.list_all_including_hidden().await;
         let count = |t: AgentType| all.iter().filter(|m| m.agent_type == t).count();
-        assert_eq!(count(AgentType::Acp), 38);
+        assert_eq!(count(AgentType::Acp), 39);
         assert_eq!(count(AgentType::Nanobot), 1);
         assert_eq!(count(AgentType::OpenclawGateway), 1);
         assert_eq!(count(AgentType::Aionrs), 1);
@@ -1904,7 +1904,7 @@ mod tests {
     async fn diagnostic_snapshot_pairs_rows_with_reasons() {
         let reg = registry().await;
         let snapshot = reg.diagnostic_snapshot().await;
-        assert_eq!(snapshot.len(), 41, "every row appears once");
+        assert_eq!(snapshot.len(), 42, "every row appears once");
 
         for (meta, reason) in &snapshot {
             match (meta.available, reason) {

--- a/crates/aionui-assets/assets/logos/acp-registry/omp.svg
+++ b/crates/aionui-assets/assets/logos/acp-registry/omp.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 64 64" preserveAspectRatio="xMidYMid meet">
+<path fill="currentColor" d="M14 16h36v8H40v32h-8V24h-6v22h-8V24h-4z"/>
+</svg>

--- a/crates/aionui-assets/src/service.rs
+++ b/crates/aionui-assets/src/service.rs
@@ -129,6 +129,7 @@ mod tests {
             "kilo",
             "mimo-code",
             "nova",
+            "omp",
             "sigit",
             "amp-acp",
             "cortex-code",

--- a/crates/aionui-db/migrations/031_add_omp_builtin_acp_agent.sql
+++ b/crates/aionui-db/migrations/031_add_omp_builtin_acp_agent.sql
@@ -20,6 +20,8 @@
 -- permission gate (src/session/acp-permission-gate.ts) always gates
 -- bash/edit/delete/move; `--yolo`/`--auto-approve` are CLI launch flags,
 -- which must not be recorded as an ACP mode id.
+-- Display name is the product brand "omp" (omp.sh, CLI `omp`) rather than
+-- the ACP agentInfo.title "Oh My Pi", so users searching the CLI name find it.
 -- Post-030 seed shape: builtin rows use agent_id = id and user_id NULL
 -- (agents are machine-level; see 030_user_scope.sql backfill).
 INSERT INTO agent_metadata
@@ -27,7 +29,7 @@ INSERT INTO agent_metadata
      enabled, command, args, env, native_skills_dirs, behavior_policy, yolo_id,
      sort_order, created_at, updated_at)
 VALUES
-    ('c9e8a2f4', 'c9e8a2f4', '/api/assets/logos/acp-registry/omp.svg', 'Oh My Pi',
+    ('c9e8a2f4', 'c9e8a2f4', '/api/assets/logos/acp-registry/omp.svg', 'omp',
      'omp', 'acp', 'builtin', '{"binary_name":"omp","bridge_binary":"npx"}',
      1, 'npx', '["-y","@oh-my-pi/pi-coding-agent","acp"]', '[]',
      '[".omp/skills",".claude/skills"]',

--- a/crates/aionui-db/migrations/031_add_omp_builtin_acp_agent.sql
+++ b/crates/aionui-db/migrations/031_add_omp_builtin_acp_agent.sql
@@ -1,0 +1,54 @@
+-- Add omp (Oh My Pi) as a builtin ACP agent.
+--
+-- omp is a terminal coding agent (pi-mono fork) with a native ACP
+-- entrypoint (`omp acp`, launched here via
+-- `npx -y @oh-my-pi/pi-coding-agent acp`): https://github.com/can1357/oh-my-pi
+--   packages/coding-agent/src/commands/acp.ts  (ACP server over stdio)
+--   packages/coding-agent/src/modes/acp/       (agent, event mapper, client bridge)
+-- Not listed on the public ACP Registry as of 2026-07-29; integrated from
+-- product/source evidence plus a local ACP probe of
+-- @oh-my-pi/pi-coding-agent@17.1.8: initialize ok (protocolVersion 1,
+-- agentInfo oh-my-pi "Oh My Pi" 17.1.8), session/new ok unauthenticated
+-- with the default/plan mode catalog. `omp --version` prints omp/17.1.8,
+-- so the default PATH probe applies.
+-- Skills: discovery/builtin.ts scans project `<root>/.omp/skills`
+-- (CONFIG_DIR_NAME ".omp", packages/utils/src/dirs.ts) and user
+-- `~/.omp/agent/skills`; discovery/claude.ts scans `.claude/skills`.
+-- Persist the omp-native project dir first with the Claude-compat dir as
+-- fallback.
+-- yolo_id stays NULL: ACP session modes are default/plan only, and the ACP
+-- permission gate (src/session/acp-permission-gate.ts) always gates
+-- bash/edit/delete/move; `--yolo`/`--auto-approve` are CLI launch flags,
+-- which must not be recorded as an ACP mode id.
+-- Post-030 seed shape: builtin rows use agent_id = id and user_id NULL
+-- (agents are machine-level; see 030_user_scope.sql backfill).
+INSERT INTO agent_metadata
+    (id, agent_id, icon, name, backend, agent_type, agent_source, agent_source_info,
+     enabled, command, args, env, native_skills_dirs, behavior_policy, yolo_id,
+     sort_order, created_at, updated_at)
+VALUES
+    ('c9e8a2f4', 'c9e8a2f4', '/api/assets/logos/acp-registry/omp.svg', 'Oh My Pi',
+     'omp', 'acp', 'builtin', '{"binary_name":"omp","bridge_binary":"npx"}',
+     1, 'npx', '["-y","@oh-my-pi/pi-coding-agent","acp"]', '[]',
+     '[".omp/skills",".claude/skills"]',
+     '{"supports_side_question":false,"supports_team":false,"team_capable_override":false}',
+     NULL, 3330,
+     unixepoch('now','subsec')*1000, unixepoch('now','subsec')*1000)
+ON CONFLICT(id) DO UPDATE SET
+    agent_id = excluded.agent_id,
+    icon = excluded.icon,
+    name = excluded.name,
+    description = NULL,
+    backend = excluded.backend,
+    agent_type = excluded.agent_type,
+    agent_source = excluded.agent_source,
+    agent_source_info = excluded.agent_source_info,
+    enabled = excluded.enabled,
+    command = excluded.command,
+    args = excluded.args,
+    env = excluded.env,
+    native_skills_dirs = excluded.native_skills_dirs,
+    behavior_policy = excluded.behavior_policy,
+    yolo_id = excluded.yolo_id,
+    sort_order = excluded.sort_order,
+    updated_at = unixepoch('now','subsec')*1000;

--- a/crates/aionui-db/src/repository/sqlite_agent_metadata.rs
+++ b/crates/aionui-db/src/repository/sqlite_agent_metadata.rs
@@ -856,8 +856,8 @@ mod tests {
     async fn seed_rows_populated_after_migrations() {
         let (repo, _db) = setup().await;
         let rows = repo.list_all().await.unwrap();
-        // 38 ACP vendors + 2 non-ACP builtins + 1 internal = 41.
-        assert_eq!(rows.len(), 41);
+        // 39 ACP vendors + 2 non-ACP builtins + 1 internal = 42.
+        assert_eq!(rows.len(), 42);
         assert!(
             rows.iter()
                 .any(|r| r.name == "Claude Code" && r.agent_source == "builtin")

--- a/crates/aionui-db/tests/registry_npx_agents_migration.rs
+++ b/crates/aionui-db/tests/registry_npx_agents_migration.rs
@@ -57,6 +57,13 @@ async fn verified_registry_npx_agents_use_stable_packages_and_conservative_team_
             Some(r#"[".compass/skills"]"#),
             None,
         ),
+        (
+            "omp",
+            "omp",
+            r#"["-y","@oh-my-pi/pi-coding-agent","acp"]"#,
+            Some(r#"[".omp/skills",".claude/skills"]"#),
+            None,
+        ),
         ("sigit", "sigit", r#"["-y","@smbcloud/sigit"]"#, None, None),
     ];
 

--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -50,6 +50,10 @@
       "package": "@compass-ai/nova",
       "version": "1.1.29"
     },
+    "omp": {
+      "package": "@oh-my-pi/pi-coding-agent",
+      "version": "17.1.8"
+    },
     "pi": {
       "registry_json_id": "pi-acp",
       "package": "pi-acp",

--- a/crates/aionui-runtime/src/registry_npx_lock.rs
+++ b/crates/aionui-runtime/src/registry_npx_lock.rs
@@ -130,7 +130,7 @@ mod tests {
     #[test]
     fn every_lock_entry_has_an_exact_version() {
         let lock = registry_npx_lock().unwrap();
-        assert_eq!(lock.agents.len(), 12);
+        assert_eq!(lock.agents.len(), 13);
         for package in lock.agents.values() {
             assert!(semver::Version::parse(&package.version).is_ok());
         }


### PR DESCRIPTION
## Summary

Adds **omp (Oh My Pi)** — https://omp.sh, [can1357/oh-my-pi](https://github.com/can1357/oh-my-pi), a terminal coding agent (pi-mono fork) — as a builtin ACP agent, launched via `npx -y @oh-my-pi/pi-coding-agent acp` with the exact version pinned in the release lock (17.1.8).

omp is **not listed on the public ACP Registry** as of 2026-07-29 (page: no match; CDN `v1/latest`: 38 ids, none oh-my-pi — only the upstream `pi-acp` is listed). It is integrated as a user-approved non-Registry builtin, mirroring the mimo-code precedent (#700): the lock entry deliberately carries no `registry_json_id`, and no AionUi issues are linked (Registry listing is a hard precondition for issue linking).

## Evidence

| claim | source |
|---|---|
| ACP entrypoint `omp acp` (server over stdio, forces `mode: "acp"`) | `packages/coding-agent/src/commands/acp.ts`; README § Four entry points |
| initialize ok | local probe of `@oh-my-pi/pi-coding-agent@17.1.8`: protocolVersion 1, agentInfo `oh-my-pi` / "Oh My Pi" / 17.1.8, promptCapabilities embeddedContext+image, mcpCapabilities http+sse, loadSession true |
| session/new ok **unauthenticated** in a clean env | same probe: sessionId present, modes `default`/`plan` (current `default`), configOptions `mode` + `thinking`; authMethods advertises local-credentials (`~/.omp`) only |
| `binary_name` "omp" PATH probe | `npx -y @oh-my-pi/pi-coding-agent@17.1.8 --version` → `omp/17.1.8` (default `--version` probe applies; no `skip_version_probe`) |
| `native_skills_dirs` `[".omp/skills",".claude/skills"]` (provisional, source-verified scan dirs) | `discovery/builtin.ts:277` (project `<root>/.omp/skills`; `CONFIG_DIR_NAME=".omp"` in `packages/utils/src/dirs.ts:23`), `discovery/claude.ts:168` (`.claude/skills`) |
| `yolo_id` NULL | ACP modes are default/plan only; the ACP permission gate always gates `bash`/`edit`/`delete`/`move` (`src/session/acp-permission-gate.ts`); `--yolo`/`--auto-approve` are CLI launch flags and must not be recorded as an ACP mode id (Grok ruling, 2026-07-23) |
| team support / side question | conservative false; `mcpCapabilities` alone is insufficient evidence |

Logo: `omp.svg` is the official omp.sh favicon π glyph reduced to `currentColor` house style (omp-original asset — upstream pi-mono ships no SVG, no inherited-branding risk).

## Migration note

`031_add_omp_builtin_acp_agent.sql` is the **first seed migration after 030_user_scope**: `agent_metadata.agent_id` is now NOT NULL + UNIQUE, so the seed supplies `agent_id = id` with `user_id` NULL per the 030 backfill convention for machine-level builtin rows. Future agent seed migrations must do the same (the 029 template predates this column).

## Validation

- `cargo test -p aionui-db -p aionui-runtime -p aionui-assets -p aionui-ai-agent` — pass (first run caught the missing `agent_id`; fixed, all green)
- Full `just push` gate (migration check, lint, fmt, `cargo nextest run --workspace`) — pass
- Gate run with host-injected `AIONUI_LOG_DIR` unset (pre-existing environment sensitivity, see #695)

## Logging

No logging changes: metadata + lock-only addition; existing startup/session error paths already identify a failing agent by backend.

## Related AionUi issues

Related to iOfficeAI/AionUi#3749 (Unable to add/register Team with OMP agent) — this PR makes omp a builtin ACP agent for regular conversations, which is the prerequisite that issue is blocked on, but it does **not** close it: `supports_team` ships conservative-`false` (mcpCapabilities alone is insufficient evidence of team capability), so Team registration with omp remains gated until team support is probed and flipped. See also iOfficeAI/AionUi#3681 (`_meta.aionui.supports_team` spec compliance), which would let omp advertise team capability instead of requiring a lock override.
