### PR TITLE
feat(project): fs/search filename search vertical

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,7 @@ dependencies = [
  "base64",
  "chrono",
  "http-body-util",
+ "ignore",
  "notify",
  "serde",
  "serde_json",

--- a/crates/aionui-project/Cargo.toml
+++ b/crates/aionui-project/Cargo.toml
@@ -20,6 +20,9 @@ tracing.workspace = true
 tokio.workspace = true
 async-trait.workspace = true
 notify.workspace = true
+# Filename search: in-process tree walk honoring .gitignore/excludes (same walker
+# ripgrep is built on) — no ripgrep subprocess, since filename search reads no content.
+ignore.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/aionui-project/src/monitor/actor.rs
+++ b/crates/aionui-project/src/monitor/actor.rs
@@ -9,10 +9,11 @@
 //!
 //! Request dispatch (initialize / fs commands) lives in [`super::dispatch`].
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::time::{Interval, interval};
 
 use crate::ProjectService;
@@ -20,7 +21,8 @@ use crate::runtime::{
     Command, Debouncer, FsError, FsRuntimeRegistry, IFsRuntime, LocalFsRuntime, RawEvent, Shard, ShardOutput, TreeModel,
 };
 
-use super::port::{FsInbound, FsWirePush};
+use super::port::{FsInbound, FsWirePush, SessionId};
+use super::search::{ActiveSearch, SearchDone};
 use super::wire;
 
 /// Debounce-flush cadence: a burst of watcher events within this window
@@ -43,6 +45,20 @@ pub struct FsMonitorActor {
     push: Arc<dyn FsWirePush>,
     /// Monotonic origin; `now()` is elapsed millis (immune to wall-clock jumps).
     clock: Instant,
+    /// In-flight filename search per connection (at most one; a new search on the
+    /// same session supersedes the previous). Keyed by session so cancel /
+    /// supersede / disconnect can reach the running search's cancel token.
+    active_searches: HashMap<SessionId, ActiveSearch>,
+    /// Spawned search coordinators signal natural completion here so the loop can
+    /// clear the finished `active_searches` entry. Sender is cloned into each
+    /// coordinator; receiver is taken by `run`.
+    search_done_tx: UnboundedSender<SearchDone>,
+    search_done_rx: Option<UnboundedReceiver<SearchDone>>,
+    /// Test-only override for the filename-search provider, letting tests inject a
+    /// barrier/scripted provider (the real runtime is built internally and cannot
+    /// otherwise be swapped). Never set outside tests.
+    #[cfg(test)]
+    search_provider_override: Option<Arc<dyn crate::runtime::IFsSearchProvider>>,
 }
 
 impl FsMonitorActor {
@@ -58,6 +74,7 @@ impl FsMonitorActor {
         let mut registry = FsRuntimeRegistry::new();
         registry.register("file", Arc::clone(&runtime));
         let shard = Shard::new(TreeModel::new(registry), warm_budget);
+        let (search_done_tx, search_done_rx) = unbounded_channel();
         let actor = Self {
             shard,
             debouncer: Debouncer::new(),
@@ -65,6 +82,11 @@ impl FsMonitorActor {
             project,
             push,
             clock: Instant::now(),
+            active_searches: HashMap::new(),
+            search_done_tx,
+            search_done_rx: Some(search_done_rx),
+            #[cfg(test)]
+            search_provider_override: None,
         };
         Ok((actor, raw_rx))
     }
@@ -87,6 +109,75 @@ impl FsMonitorActor {
     /// Current logical time: monotonic millis since actor start.
     pub(super) fn now(&self) -> u64 {
         self.clock.elapsed().as_millis() as u64
+    }
+
+    /// Clonable outbound push handle (moved into the spawned search coordinator).
+    pub(super) fn push_handle(&self) -> Arc<dyn FsWirePush> {
+        Arc::clone(&self.push)
+    }
+
+    /// The `file:` runtime's filename-search provider, if the scheme supports it.
+    pub(super) fn search_provider(&self) -> Option<Arc<dyn crate::runtime::IFsSearchProvider>> {
+        #[cfg(test)]
+        if let Some(provider) = &self.search_provider_override {
+            return Some(Arc::clone(provider));
+        }
+        self.runtime.search_provider()
+    }
+
+    /// Test-only: swap the filename-search provider for a barrier/scripted double.
+    #[cfg(test)]
+    pub(super) fn set_search_provider_override(&mut self, provider: Arc<dyn crate::runtime::IFsSearchProvider>) {
+        self.search_provider_override = Some(provider);
+    }
+
+    /// Register a newly-started search for `session`, superseding (cancelling)
+    /// any previous in-flight search on the same connection.
+    pub(super) fn register_search(&mut self, session: &str, active: ActiveSearch) {
+        if let Some(prev) = self.active_searches.insert(session.to_owned(), active) {
+            prev.cancel.cancel();
+        }
+    }
+
+    /// Cancel the in-flight search for `session` iff it matches `search_id`
+    /// (explicit `fs/searchCancel`). Returns whether a search was cancelled.
+    pub(super) fn cancel_search(&mut self, session: &str, search_id: &serde_json::Value) -> bool {
+        if self
+            .active_searches
+            .get(session)
+            .is_some_and(|a| &a.search_id == search_id)
+        {
+            let active = self.active_searches.remove(session).expect("just checked present");
+            active.cancel.cancel();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Drop any in-flight search for a disconnected session, cascading cancel.
+    pub(super) fn drop_session_search(&mut self, session: &str) {
+        if let Some(active) = self.active_searches.remove(session) {
+            active.cancel.cancel();
+        }
+    }
+
+    /// Clonable completion-signal sender, moved into a spawned search coordinator.
+    pub(super) fn search_done_handle(&self) -> UnboundedSender<SearchDone> {
+        self.search_done_tx.clone()
+    }
+
+    /// A coordinator finished naturally: clear its `active_searches` entry, but
+    /// only if it is still the current search for that session — a superseding
+    /// search may have replaced it (different id) before this signal arrived.
+    fn on_search_done(&mut self, done: SearchDone) {
+        if self
+            .active_searches
+            .get(&done.session)
+            .is_some_and(|a| a.search_id == done.search_id)
+        {
+            self.active_searches.remove(&done.session);
+        }
     }
 
     /// Feed a command through the shard and return its raw outputs (no fan-out).
@@ -120,6 +211,10 @@ impl FsMonitorActor {
     pub async fn run(mut self, mut inbound: UnboundedReceiver<FsInbound>, mut raw_rx: UnboundedReceiver<RawEvent>) {
         let mut flush: Interval = interval(Duration::from_millis(DEBOUNCE_FLUSH_MS));
         let mut reap: Interval = interval(Duration::from_millis(REAP_INTERVAL_MS));
+        // Search coordinators (spawned tasks) report natural completion here; the
+        // sender clone lives on in `self.search_done_tx`, so the channel never
+        // closes for the actor's life.
+        let mut search_done = self.search_done_rx.take().expect("search_done_rx taken once in run");
         loop {
             tokio::select! {
                 inbound_event = inbound.recv() => match inbound_event {
@@ -131,6 +226,9 @@ impl FsMonitorActor {
                 // receiver stays open for the actor's whole life.
                 raw = raw_rx.recv() => if let Some(raw) = raw {
                     self.debouncer.push(raw);
+                },
+                done = search_done.recv() => if let Some(done) = done {
+                    self.on_search_done(done);
                 },
                 _ = flush.tick() => self.flush_debounced().await,
                 _ = reap.tick() => self.drive(Command::ReapTick { now: self.now() }).await,
@@ -148,8 +246,10 @@ impl FsMonitorActor {
             } => self.dispatch_frame(&session, &user_id, frame).await,
             FsInbound::Disconnect { session } => {
                 // Connection teardown — lifecycle boundary; releases the session's
-                // subscriptions (nodes go warm, reaper unmounts later).
+                // subscriptions (nodes go warm, reaper unmounts later) and cancels
+                // any in-flight search on the gone connection.
                 tracing::info!(session = %session, "fs session disconnect");
+                self.drop_session_search(&session);
                 let now = self.now();
                 self.drive(Command::DropSession { session, now }).await;
             }

--- a/crates/aionui-project/src/monitor/actor_test.rs
+++ b/crates/aionui-project/src/monitor/actor_test.rs
@@ -2,14 +2,21 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use aionui_db::{Database, IProjectStore, SqliteProjectStore, init_database_memory};
+use async_trait::async_trait;
 use serde_json::{Value, json};
 use tempfile::TempDir;
+use tokio::sync::Notify;
 use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
 
 use crate::ProjectService;
 use crate::canonical::to_file_uri;
 use crate::monitor::{FsInbound, FsMonitorActor, FsWirePush};
-use crate::runtime::{EntryFact, Kind, RawEvent, ShardOutput, Snapshot, Subscriber};
+use crate::runtime::{
+    Budget, CancellationToken, EntryFact, FsError, IFsRuntime, IFsSearchProvider, Kind, LocalFsRuntime, MatchMode,
+    NameMatcher, RawEvent, SearchSink, ShardOutput, Snapshot, Subscriber,
+};
+
+use super::super::search::{ActiveSearch, SearchDone, SearchJob, SearchRoot, run_search};
 
 // ── recording push port ────────────────────────────────────────────────────
 
@@ -638,4 +645,304 @@ async fn disconnect_drops_session_subscriptions() {
 
     drop(tx);
     let _ = handle.await;
+}
+
+// ══ filename search — actor state machine (deterministic helpers) ═════════════
+
+fn active(id: i64) -> (ActiveSearch, CancellationToken) {
+    let cancel = CancellationToken::new();
+    (
+        ActiveSearch {
+            search_id: json!(id),
+            cancel: cancel.clone(),
+        },
+        cancel,
+    )
+}
+
+#[tokio::test]
+async fn register_search_supersedes_and_cancels_previous() {
+    let (mut actor, _rx, _push, _pe, _dir, _db) = setup().await;
+    let (first, first_cancel) = active(1);
+    let (second, _second_cancel) = active(2);
+
+    actor.register_search("1", first);
+    actor.register_search("1", second);
+
+    // Superseded search's token is cancelled; the current entry is the new id.
+    assert!(first_cancel.is_cancelled());
+    assert_eq!(actor.active_searches.get("1").unwrap().search_id, json!(2));
+}
+
+#[tokio::test]
+async fn cancel_search_only_when_id_matches() {
+    let (mut actor, _rx, _push, _pe, _dir, _db) = setup().await;
+    let (search, cancel) = active(7);
+    actor.register_search("1", search);
+
+    // Non-matching id → no cancel, entry stays.
+    assert!(!actor.cancel_search("1", &json!(8)));
+    assert!(!cancel.is_cancelled());
+    assert!(actor.active_searches.contains_key("1"));
+
+    // Matching id → cancelled + removed.
+    assert!(actor.cancel_search("1", &json!(7)));
+    assert!(cancel.is_cancelled());
+    assert!(!actor.active_searches.contains_key("1"));
+}
+
+#[tokio::test]
+async fn disconnect_cascades_cancel_to_running_search() {
+    let (mut actor, _rx, _push, _pe, _dir, _db) = setup().await;
+    let (search, cancel) = active(1);
+    actor.register_search("1", search);
+
+    actor.drop_session_search("1");
+
+    assert!(cancel.is_cancelled());
+    assert!(!actor.active_searches.contains_key("1"));
+}
+
+#[tokio::test]
+async fn on_search_done_clears_only_the_current_search() {
+    let (mut actor, _rx, _push, _pe, _dir, _db) = setup().await;
+    let (search, _c) = active(7);
+    actor.register_search("1", search);
+
+    // Completion of the current search clears its entry.
+    actor.on_search_done(SearchDone {
+        session: "1".to_owned(),
+        search_id: json!(7),
+    });
+    assert!(!actor.active_searches.contains_key("1"));
+
+    // A stale done (id 7) arriving after a superseding search (id 8) must NOT
+    // clobber the newer entry.
+    let (newer, _c2) = active(8);
+    actor.register_search("1", newer);
+    actor.on_search_done(SearchDone {
+        session: "1".to_owned(),
+        search_id: json!(7),
+    });
+    assert_eq!(
+        actor.active_searches.get("1").unwrap().search_id,
+        json!(8),
+        "stale done must not clobber the superseding search"
+    );
+}
+
+// ══ filename search — end-to-end through the real event loop ══════════════════
+
+/// A `fs/searchMatch` hit for `session` naming `file` with `pe_id`.
+fn has_search_hit(frames: &[(String, Value)], session: &str, pe_id: &str, name: &str) -> bool {
+    frames.iter().any(|(s, f)| {
+        s == session
+            && f["method"] == "fs/searchMatch"
+            && f["params"]["matches"]
+                .as_array()
+                .map(|ms| ms.iter().any(|m| m["pe_id"] == pe_id && m["name"] == name))
+                .unwrap_or(false)
+    })
+}
+
+/// The terminal `fs/search` response (a `result` for `id`) delivered to `session`.
+fn search_terminal(frames: &[(String, Value)], session: &str, id: i64) -> Option<Value> {
+    frames
+        .iter()
+        .find(|(s, f)| s == session && f["id"] == id && f.get("result").is_some())
+        .map(|(_, f)| f["result"].clone())
+}
+
+#[tokio::test]
+async fn search_streams_matches_and_terminal_through_loop() {
+    let (actor, raw_rx, push, pe, dir, _db) = setup().await;
+    std::fs::create_dir(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src").join("Button.tsx"), b"x").unwrap();
+    std::fs::write(dir.path().join("Widget.tsx"), b"x").unwrap();
+
+    let (tx, rx) = unbounded_channel();
+    let handle = tokio::spawn(actor.run(rx, raw_rx));
+
+    tx.send(FsInbound::Frame {
+        session: "1".to_owned(),
+        user_id: "system_default_user".to_owned(),
+        frame: request(7, "fs/search", json!({"roots":[dir_ref(&pe, "")],"query":"button"})),
+    })
+    .unwrap();
+
+    // Terminal arrives (search is spawned off the loop, then streams + finishes).
+    let got_terminal = wait_until(&push, Duration::from_secs(5), |f| search_terminal(f, "1", 7).is_some()).await;
+    assert!(got_terminal, "search must send a terminal response");
+
+    let frames = push.frames();
+    // The matching file streamed with the root's pe_id stamped; the non-match did not.
+    assert!(has_search_hit(&frames, "1", &pe, "Button.tsx"));
+    assert!(!has_search_hit(&frames, "1", &pe, "Widget.tsx"));
+    let result = search_terminal(&frames, "1", 7).unwrap();
+    assert_eq!(result["limit_reached"], false);
+    assert_eq!(result["total"], 1);
+
+    drop(tx);
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn search_unknown_pe_is_out_of_scope() {
+    // Resolve failure replies synchronously (before any coordinator spawn).
+    let (mut actor, _rx, push, _pe, _dir, _db) = setup().await;
+    actor
+        .dispatch_frame(
+            "1",
+            "system_default_user",
+            request(8, "fs/search", json!({"roots":[dir_ref("pe-nope", "")],"query":"x"})),
+        )
+        .await;
+    let reply = push.last_for("1").unwrap();
+    assert_eq!(reply["id"], 8);
+    assert_eq!(reply["error"]["code"], -32000);
+    assert_eq!(reply["error"]["message"], "out_of_scope");
+    assert_eq!(reply["error"]["data"]["pe_id"], "pe-nope");
+}
+
+/// A search provider that parks in `search_names` until released, so a test can
+/// hold a search provably in-flight. `entered` fires when the walk begins;
+/// `release` unblocks it.
+struct BarrierSearchProvider {
+    entered: Notify,
+    release: Notify,
+}
+
+#[async_trait]
+impl IFsSearchProvider for BarrierSearchProvider {
+    async fn search_names(
+        &self,
+        _root_uri: &str,
+        _matcher: &NameMatcher,
+        sink: &Arc<dyn SearchSink>,
+        budget: &Budget,
+        _cancel: &CancellationToken,
+    ) -> Result<(), FsError> {
+        self.entered.notify_one(); // tell the test the search is in-flight
+        self.release.notified().await; // park until released
+        if budget.try_take() {
+            sink.emit("hit.txt".to_owned(), "hit.txt".to_owned());
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn search_running_keeps_event_loop_responsive() {
+    // Inject a barrier provider so the search is provably parked in-flight when
+    // the initialize arrives — proving the loop is not blocked by a running walk.
+    let (mut actor, raw_rx, push, pe, _dir, _db) = setup().await;
+    let barrier = Arc::new(BarrierSearchProvider {
+        entered: Notify::new(),
+        release: Notify::new(),
+    });
+    actor.set_search_provider_override(Arc::clone(&barrier) as Arc<dyn IFsSearchProvider>);
+    let (tx, rx) = unbounded_channel();
+    let handle = tokio::spawn(actor.run(rx, raw_rx));
+
+    // Kick off the search; it will park inside the barrier provider.
+    tx.send(FsInbound::Frame {
+        session: "1".to_owned(),
+        user_id: "system_default_user".to_owned(),
+        frame: request(7, "fs/search", json!({"roots":[dir_ref(&pe, "")],"query":""})),
+    })
+    .unwrap();
+    // Wait until the walk has actually started (search is in-flight).
+    tokio::time::timeout(Duration::from_secs(2), barrier.entered.notified())
+        .await
+        .expect("search must enter the provider (be in-flight)");
+
+    // With the search parked, send an initialize on the same connection.
+    tx.send(FsInbound::Frame {
+        session: "1".to_owned(),
+        user_id: "system_default_user".to_owned(),
+        frame: request(99, "initialize", json!({"protocol_version": 1})),
+    })
+    .unwrap();
+
+    // The initialize is answered while the search is still parked in-flight.
+    let responsive = wait_until(&push, Duration::from_secs(2), |f| {
+        f.iter()
+            .any(|(s, m)| s == "1" && m["id"] == 99 && m["result"]["protocol_version"] == 1)
+    })
+    .await;
+    assert!(responsive, "event loop must stay responsive during a running search");
+    // Prove the search had NOT completed when initialize was served (still parked).
+    assert!(
+        search_terminal(&push.frames(), "1", 7).is_none(),
+        "search must still be in-flight (no terminal) when initialize was answered"
+    );
+
+    // Release the barrier → the search finishes and its terminal lands.
+    barrier.release.notify_one();
+    assert!(
+        wait_until(&push, Duration::from_secs(3), |f| search_terminal(f, "1", 7).is_some()).await,
+        "search terminal must arrive once released"
+    );
+
+    drop(tx);
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn completion_signals_done_actor_clears_and_later_cancel_is_noop() {
+    // End-to-end of the clear-on-done path: a real `run_search` completing sends a
+    // SearchDone; the actor clears its active-search entry; a later same-id
+    // fs/searchCancel is then a no-op (the completed search is not "in-flight").
+    let (mut actor, _rx, _push, pe, dir, _db) = setup().await;
+    std::fs::write(dir.path().join("a.txt"), b"x").unwrap();
+
+    // Register the search exactly as dispatch would.
+    let cancel = CancellationToken::new();
+    actor.register_search(
+        "1",
+        ActiveSearch {
+            search_id: json!(5),
+            cancel,
+        },
+    );
+
+    // Drive a real walk (real LocalFsProvider) over the workspace root to natural
+    // completion, capturing the done signal it emits.
+    let (runtime, _watch_rx) = LocalFsRuntime::new().unwrap();
+    let provider = runtime.search_provider().expect("file scheme supports search");
+    let sink_push: Arc<dyn FsWirePush> = Arc::new(RecordingPush::default());
+    let (done_tx, mut done_rx) = unbounded_channel();
+    run_search(
+        provider,
+        sink_push,
+        SearchJob {
+            session: "1".to_owned(),
+            search_id: json!(5),
+            roots: vec![SearchRoot {
+                root_uri: to_file_uri(dir.path()).unwrap(),
+                pe_id: pe.clone(),
+            }],
+            matcher: NameMatcher::new("", MatchMode::Substring),
+            budget: Budget::new(100),
+            cancel: CancellationToken::new(),
+        },
+        done_tx,
+    )
+    .await;
+
+    // Natural completion emitted a done for this session + id.
+    let done = done_rx.try_recv().expect("done signal on natural completion");
+    assert_eq!(done.session, "1");
+    assert_eq!(done.search_id, json!(5));
+
+    // Actor clears the entry; a later same-id cancel finds nothing in-flight.
+    actor.on_search_done(done);
+    assert!(
+        !actor.active_searches.contains_key("1"),
+        "completed search entry cleared"
+    );
+    assert!(
+        !actor.cancel_search("1", &json!(5)),
+        "a completed search must not be treated as in-flight by fs/searchCancel"
+    );
 }

--- a/crates/aionui-project/src/monitor/dispatch.rs
+++ b/crates/aionui-project/src/monitor/dispatch.rs
@@ -17,13 +17,14 @@ use base64::engine::general_purpose::STANDARD;
 use serde_json::{Value, json};
 
 use crate::canonical;
-use crate::runtime::{Command, ShardOutput, Subscriber};
+use crate::runtime::{Budget, CancellationToken, Command, MatchMode, NameMatcher, ShardOutput, Subscriber};
 use crate::types::{FileOp, ReferenceInput, ResolvedResource};
 
 use super::actor::FsMonitorActor;
+use super::search::{self, ActiveSearch, SearchRoot};
 use super::wire::{
     self, Encoding, InitializeParams, MkdirParams, ReadParams, RemoveParams, RenameParams, ResourceRef,
-    SubscribeParams, UnsubscribeParams, WriteParams,
+    SearchCancelParams, SearchParams, SubscribeParams, UnsubscribeParams, WriteParams,
 };
 
 impl FsMonitorActor {
@@ -53,6 +54,8 @@ impl FsMonitorActor {
             "fs/mkdir" => self.handle_mkdir(session, user_id, id, params).await,
             "fs/remove" => self.handle_remove(session, user_id, id, params).await,
             "fs/rename" => self.handle_rename(session, user_id, id, params).await,
+            "fs/search" => self.handle_search(session, user_id, id, params).await,
+            "fs/searchCancel" => self.handle_search_cancel(session, params),
             other => {
                 tracing::warn!(session, method = %other, "fs dispatch: unknown method");
                 self.push(
@@ -313,6 +316,98 @@ impl FsMonitorActor {
             .rename(&from.resource_uri, &to.resource_uri)
             .await;
         self.reply_unit(session, id, "rename", &p.from, outcome);
+    }
+
+    // ── filename search ───────────────────────────────────────────────────
+
+    /// `fs/search` (request): resolve every root atomically, then hand off to a
+    /// spawned coordinator that walks all roots concurrently and streams
+    /// `fs/searchMatch` batches + a terminal response. Superseding a prior
+    /// in-flight search on this connection is done inside `register_search`.
+    async fn handle_search(&mut self, session: &str, user_id: &str, id: Option<Value>, params: Value) {
+        // A search is a request: without an id there is no `search_id` to key
+        // matches/terminal on, so a search-shaped notification is ignored.
+        let Some(search_id) = id else {
+            tracing::warn!(session, "fs/search missing id (not a request); ignoring");
+            return;
+        };
+        let Ok(p) = serde_json::from_value::<SearchParams>(params) else {
+            self.push(session, invalid_params(Some(search_id)));
+            return;
+        };
+
+        // Atomic resolve: each root via resolve_reference(Browse); any failure →
+        // whole request errors, no partial search started (mirrors subscribe).
+        let mut roots: Vec<SearchRoot> = Vec::with_capacity(p.roots.len());
+        for root in &p.roots {
+            match self.resolve(user_id, root, FileOp::Browse).await {
+                Ok(resolved) => roots.push(SearchRoot {
+                    root_uri: resolved.resource_uri,
+                    pe_id: root.pe_id.clone(),
+                }),
+                Err((code, message)) => {
+                    tracing::warn!(session, code = message, pe_id = %root.pe_id, "fs search rejected");
+                    self.push(session, wire::error(Some(search_id), code, message, ref_data(root)));
+                    return;
+                }
+            }
+        }
+
+        let Some(provider) = self.search_provider() else {
+            self.push(
+                session,
+                wire::error(
+                    Some(search_id),
+                    wire::CODE_PROVIDER_UNAVAILABLE,
+                    "provider_unavailable",
+                    Value::Null,
+                ),
+            );
+            return;
+        };
+
+        let matcher = NameMatcher::new(&p.query, MatchMode::Substring);
+        let budget = Budget::new(p.limit.unwrap_or(search::DEFAULT_SEARCH_LIMIT));
+        let cancel = CancellationToken::new();
+        // Supersede any prior in-flight search on this connection (cancels it).
+        self.register_search(
+            session,
+            ActiveSearch {
+                search_id: search_id.clone(),
+                cancel: cancel.clone(),
+            },
+        );
+        // Lifecycle boundary — low volume; root count only (no query/paths).
+        tracing::info!(session, roots = roots.len(), "fs search start");
+
+        // Spawn the coordinator so the walks never block the actor event loop —
+        // it must stay responsive to fs/searchCancel and superseding searches.
+        let push = self.push_handle();
+        let done = self.search_done_handle();
+        tokio::spawn(search::run_search(
+            provider,
+            push,
+            search::SearchJob {
+                session: session.to_owned(),
+                search_id,
+                roots,
+                matcher,
+                budget,
+                cancel,
+            },
+            done,
+        ));
+    }
+
+    /// `fs/searchCancel` (notification): cancel the in-flight search iff its
+    /// `search_id` matches. Fire-and-forget; the coordinator then sends no
+    /// terminal frame (the client discards the cancelled search's matches).
+    fn handle_search_cancel(&mut self, session: &str, params: Value) {
+        let Ok(p) = serde_json::from_value::<SearchCancelParams>(params) else {
+            return;
+        };
+        let cancelled = self.cancel_search(session, &p.search_id);
+        tracing::info!(session, cancelled, "fs search cancel");
     }
 
     // ── helpers ───────────────────────────────────────────────────────────

--- a/crates/aionui-project/src/monitor/mod.rs
+++ b/crates/aionui-project/src/monitor/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod wire;
 mod actor;
 mod dispatch;
 mod port;
+mod search;
 
 pub use actor::FsMonitorActor;
 pub use port::{FsInbound, FsWirePush, SessionId};

--- a/crates/aionui-project/src/monitor/search.rs
+++ b/crates/aionui-project/src/monitor/search.rs
@@ -1,0 +1,248 @@
+//! Filename-search orchestration — the layer above the provider that turns one
+//! `fs/search` request into a merged, budgeted, cancellable stream.
+//!
+//! The actor resolves every root atomically, then hands off to [`run_search`],
+//! spawned as its own task so the walks never block the actor event loop (which
+//! must stay responsive to `fs/searchCancel` and superseding searches). The
+//! coordinator drives every root's [`IFsSearchProvider::search_names`]
+//! concurrently, all sharing one [`Budget`] + one [`CancellationToken`]; each
+//! root's hits flow through a per-root [`RootSink`] that stamps the folder's
+//! `pe_id` and merges into one [`MatchCollector`], batched onto `fs/searchMatch`.
+//! When every root finishes (or the budget is spent) the terminal response is
+//! sent — unless the search was cancelled/superseded, in which case no terminal
+//! frame goes out (per protocol.md).
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde_json::Value;
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::runtime::{Budget, CancellationToken, IFsSearchProvider, NameMatcher, SearchSink};
+
+use super::port::FsWirePush;
+use super::wire::{self, SearchHit};
+
+/// Default global hit budget when the request omits `limit`.
+pub(super) const DEFAULT_SEARCH_LIMIT: usize = 1000;
+
+/// How many hits accumulate before a `fs/searchMatch` batch is flushed. Bounds
+/// frame count without holding hits back long enough to hurt streaming feel.
+const SEARCH_MATCH_BATCH: usize = 64;
+
+/// One in-flight search tracked by the actor, so it can be cancelled explicitly
+/// (`fs/searchCancel`) or superseded by a newer search on the same connection.
+#[derive(Debug, Clone)]
+pub(super) struct ActiveSearch {
+    /// The originating request `id`, echoed as `search_id`; used to match an
+    /// incoming `fs/searchCancel`.
+    pub(super) search_id: Value,
+    /// Shared cancel signal cascaded to every root walk of this search.
+    pub(super) cancel: CancellationToken,
+}
+
+/// A resolved search root: the concrete provider URI to walk plus the `pe_id`
+/// the orchestration stamps onto every hit found under it.
+pub(super) struct SearchRoot {
+    pub(super) root_uri: String,
+    pub(super) pe_id: String,
+}
+
+/// One search's coordinator inputs (beyond the shared provider/push handles):
+/// the connection, the correlating `search_id`, the resolved roots, and the
+/// shared matcher/budget/cancel that gate every root walk.
+pub(super) struct SearchJob {
+    pub(super) session: String,
+    pub(super) search_id: Value,
+    pub(super) roots: Vec<SearchRoot>,
+    pub(super) matcher: NameMatcher,
+    pub(super) budget: Budget,
+    pub(super) cancel: CancellationToken,
+}
+
+/// Signalled by a coordinator to the actor when a search finishes *naturally*
+/// (not cancelled/superseded), so the actor can clear its `active_searches`
+/// entry — guarded on `search_id` so a superseding search is not clobbered.
+#[derive(Debug, Clone)]
+pub(super) struct SearchDone {
+    pub(super) session: String,
+    pub(super) search_id: Value,
+}
+
+/// Merges every root's hits into one `fs/searchMatch` stream, batched, and emits
+/// the terminal response. Owns the outbound push handle + the search identity.
+struct MatchCollector {
+    push: Arc<dyn FsWirePush>,
+    session: String,
+    search_id: Value,
+    buf: Mutex<Vec<SearchHit>>,
+    total: AtomicUsize,
+}
+
+impl MatchCollector {
+    fn new(push: Arc<dyn FsWirePush>, session: String, search_id: Value) -> Self {
+        Self {
+            push,
+            session,
+            search_id,
+            buf: Mutex::new(Vec::new()),
+            total: AtomicUsize::new(0),
+        }
+    }
+
+    /// Buffer one hit; flush a full batch to the wire when the threshold is hit.
+    /// Sync — called from the blocking walk thread through [`RootSink::emit`].
+    fn push_hit(&self, hit: SearchHit) {
+        self.total.fetch_add(1, Ordering::Relaxed);
+        let batch = {
+            let mut buf = self.buf.lock().expect("search buffer mutex poisoned");
+            buf.push(hit);
+            if buf.len() >= SEARCH_MATCH_BATCH {
+                Some(std::mem::take(&mut *buf))
+            } else {
+                None
+            }
+        };
+        if let Some(batch) = batch {
+            self.emit_batch(batch);
+        }
+    }
+
+    /// Flush any buffered hits (called once every root walk has finished).
+    fn flush(&self) {
+        let batch = {
+            let mut buf = self.buf.lock().expect("search buffer mutex poisoned");
+            if buf.is_empty() {
+                return;
+            }
+            std::mem::take(&mut *buf)
+        };
+        self.emit_batch(batch);
+    }
+
+    /// Push one `fs/searchMatch` notification carrying `batch`.
+    fn emit_batch(&self, batch: Vec<SearchHit>) {
+        let params = wire::search_match_params(&self.search_id, &batch);
+        self.push
+            .push(&self.session, wire::notification("fs/searchMatch", params));
+    }
+
+    fn total(&self) -> usize {
+        self.total.load(Ordering::Relaxed)
+    }
+
+    /// Push the terminal `fs/search` response for the originating request `id`.
+    fn emit_terminal(&self, limit_reached: bool) {
+        let result = wire::search_result(limit_reached, self.total());
+        self.push
+            .push(&self.session, wire::success(Some(self.search_id.clone()), result));
+    }
+}
+
+/// Per-root hit outlet: stamps the root's `pe_id` and forwards into the shared
+/// collector. `emit` is sync (called from the blocking walk), so it hands the
+/// hit to the async collector via `blocking_lock` on its buffer mutex.
+struct RootSink {
+    pe_id: String,
+    collector: Arc<MatchCollector>,
+}
+
+impl SearchSink for RootSink {
+    fn emit(&self, relative_path: String, name: String) {
+        self.collector.push_hit(SearchHit {
+            pe_id: self.pe_id.clone(),
+            relative_path,
+            name,
+        });
+    }
+}
+
+/// Drive one search to completion: walk every root concurrently under a shared
+/// budget + cancel, streaming batched `fs/searchMatch`, then the terminal frame
+/// (unless cancelled/superseded). Spawned by the actor so it never blocks the
+/// event loop. `total` counts hits emitted; `limit_reached` reflects the budget.
+pub(super) async fn run_search(
+    provider: Arc<dyn IFsSearchProvider>,
+    push: Arc<dyn FsWirePush>,
+    job: SearchJob,
+    done: UnboundedSender<SearchDone>,
+) {
+    let SearchJob {
+        session,
+        search_id,
+        roots,
+        matcher,
+        budget,
+        cancel,
+    } = job;
+    let collector = Arc::new(MatchCollector::new(push, session.clone(), search_id.clone()));
+    let matcher = Arc::new(matcher);
+
+    // Each root walks concurrently; the walk itself is a `spawn_blocking` inside
+    // `search_names`, so N roots occupy N blocking threads in parallel.
+    let mut handles = Vec::with_capacity(roots.len());
+    for root in roots {
+        let provider = Arc::clone(&provider);
+        let matcher = Arc::clone(&matcher);
+        let budget = budget.clone();
+        let cancel = cancel.clone();
+        let sink: Arc<dyn SearchSink> = Arc::new(RootSink {
+            pe_id: root.pe_id,
+            collector: Arc::clone(&collector),
+        });
+        let root_uri = root.root_uri;
+        handles.push(tokio::spawn(async move {
+            provider
+                .search_names(&root_uri, &matcher, &sink, &budget, &cancel)
+                .await
+        }));
+    }
+
+    for handle in handles {
+        match handle.await {
+            Ok(Ok(())) => {}
+            // A single root failing (unreadable, provider error) must not sink
+            // the others or the terminal frame — surface and continue.
+            Ok(Err(err)) => tracing::warn!(error = %err, "fs search: root walk failed"),
+            Err(join) => tracing::warn!(error = %join, "fs search: root task join failed"),
+        }
+    }
+
+    // Contract (protocol.md): on cancel/supersede, DROP the un-pushed buffer and
+    // send neither more matches nor a terminal frame. Checked BEFORE `flush` so
+    // the buffered remainder is discarded rather than pushed — do not rely on the
+    // frontend's stale-search_id guard to swallow a late batch.
+    if cancel.is_cancelled() {
+        tracing::debug!(session = %session, "fs search cancelled/superseded: dropping buffered matches, no terminal frame");
+        return;
+    }
+
+    collector.flush();
+    let limit_reached = budget.limit_reached();
+    tracing::info!(session = %session, total = collector.total(), limit_reached, "fs search complete");
+
+    // Signal completion to the actor BEFORE the terminal frame: the actor clears
+    // its active-search entry first, so a client that reacts to the terminal by
+    // sending fs/searchCancel cannot race a not-yet-cleared entry. The actor
+    // drops the signal if a superseding search already replaced this id (its id
+    // differs), so the ordering does not weaken the anti-clobber guard.
+    //
+    // KNOWN, HARMLESS RESIDUAL RACE: `done` only enqueues onto the actor's mpsc;
+    // the actor processes it in a separate `select!` arm with no ordering barrier
+    // against the wire, so there is still a window where the terminal has been
+    // pushed but `active_searches` is not yet cleared. Enqueuing before the
+    // terminal only narrows this window; it does not close it. This is
+    // deliberately accepted (not covered by a scheduling test) because it is
+    // observably harmless: (1) `search_id` is monotonic per connection and a
+    // completed id is never reused, so a stale entry can never clobber a newer
+    // search; (2) `fs/searchCancel` is a notification with no reply, so a client
+    // hitting the window sees no erroneous response; (3) cancelling an
+    // already-finished search is a no-op and `active_searches` removal is
+    // idempotent.
+    let _ = done.send(SearchDone { session, search_id });
+    collector.emit_terminal(limit_reached);
+}
+
+#[cfg(test)]
+#[path = "search_test.rs"]
+mod search_test;

--- a/crates/aionui-project/src/monitor/search_test.rs
+++ b/crates/aionui-project/src/monitor/search_test.rs
@@ -1,0 +1,286 @@
+//! Unit tests for the search orchestration coordinator ([`run_search`]): merge
+//! across roots with per-root `pe_id` stamping, batched `fs/searchMatch`, the
+//! terminal frame, global-budget cap, the natural-completion done signal, and
+//! the cancel contract — drop the un-pushed buffer and send no terminal frame,
+//! whether cancelled before start or mid-run.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tokio::sync::mpsc::unbounded_channel;
+
+use crate::runtime::{FsError, MatchMode};
+
+use super::*;
+
+/// Collects every pushed frame as `(session, frame)`.
+#[derive(Default)]
+struct CapturePush(Mutex<Vec<(String, Value)>>);
+
+impl FsWirePush for CapturePush {
+    fn push(&self, session: &str, frame: Value) {
+        self.0.lock().unwrap().push((session.to_owned(), frame));
+    }
+}
+
+impl CapturePush {
+    fn frames(&self) -> Vec<Value> {
+        self.0.lock().unwrap().iter().map(|(_, f)| f.clone()).collect()
+    }
+}
+
+/// A scripted search provider: per root URI, a fixed list of `(rel, name)` hits.
+/// Honors matcher/budget/cancel exactly like the real provider's inner loop.
+/// `cancel_after` (if set) flips the shared token after that many *emitted* hits
+/// to simulate an external cancel arriving mid-walk.
+struct ScriptedProvider {
+    by_root: HashMap<String, Vec<(String, String)>>,
+    cancel_after: Option<usize>,
+}
+
+#[async_trait]
+impl IFsSearchProvider for ScriptedProvider {
+    async fn search_names(
+        &self,
+        root_uri: &str,
+        matcher: &NameMatcher,
+        sink: &Arc<dyn SearchSink>,
+        budget: &Budget,
+        cancel: &CancellationToken,
+    ) -> Result<(), FsError> {
+        let Some(hits) = self.by_root.get(root_uri) else {
+            return Ok(());
+        };
+        let mut emitted = 0usize;
+        for (rel, name) in hits {
+            if cancel.is_cancelled() {
+                return Ok(());
+            }
+            if !matcher.matches(name) {
+                continue;
+            }
+            if !budget.try_take() {
+                return Ok(());
+            }
+            sink.emit(rel.clone(), name.clone());
+            emitted += 1;
+            if self.cancel_after == Some(emitted) {
+                cancel.cancel();
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Collect all `fs/searchMatch` hits across every emitted batch frame.
+fn collected_hits(frames: &[Value]) -> Vec<Value> {
+    frames
+        .iter()
+        .filter(|f| f["method"] == "fs/searchMatch")
+        .flat_map(|f| f["params"]["matches"].as_array().cloned().unwrap_or_default())
+        .collect()
+}
+
+/// The single terminal response frame (a `result` for the request id), if any.
+fn terminal(frames: &[Value]) -> Option<Value> {
+    frames.iter().find(|f| f.get("result").is_some()).cloned()
+}
+
+fn provider(by_root: HashMap<String, Vec<(String, String)>>) -> Arc<dyn IFsSearchProvider> {
+    Arc::new(ScriptedProvider {
+        by_root,
+        cancel_after: None,
+    })
+}
+
+fn one_root(uri: &str, pe_id: &str) -> Vec<SearchRoot> {
+    vec![SearchRoot {
+        root_uri: uri.to_owned(),
+        pe_id: pe_id.to_owned(),
+    }]
+}
+
+#[tokio::test]
+async fn merges_roots_stamps_pe_id_sends_terminal_and_signals_done() {
+    let mut by_root = HashMap::new();
+    by_root.insert(
+        "file:///a".to_owned(),
+        vec![("Button.tsx".to_owned(), "Button.tsx".to_owned())],
+    );
+    by_root.insert(
+        "file:///b".to_owned(),
+        vec![("widgets/iconButton.ts".to_owned(), "iconButton.ts".to_owned())],
+    );
+    let push = Arc::new(CapturePush::default());
+    let (done_tx, mut done_rx) = unbounded_channel();
+    let roots = vec![
+        SearchRoot {
+            root_uri: "file:///a".to_owned(),
+            pe_id: "pe1".to_owned(),
+        },
+        SearchRoot {
+            root_uri: "file:///b".to_owned(),
+            pe_id: "pe2".to_owned(),
+        },
+    ];
+
+    run_search(
+        provider(by_root),
+        push.clone(),
+        SearchJob {
+            session: "sess".to_owned(),
+            search_id: json!(7),
+            roots,
+            matcher: NameMatcher::new("button", MatchMode::Substring),
+            budget: Budget::new(100),
+            cancel: CancellationToken::new(),
+        },
+        done_tx,
+    )
+    .await;
+
+    let frames = push.frames();
+    let hits = collected_hits(&frames);
+    assert_eq!(hits.len(), 2);
+    // Each hit carries the pe_id of the root it came from (backend-stamped).
+    let by_pe: HashMap<&str, &str> = hits
+        .iter()
+        .map(|h| (h["pe_id"].as_str().unwrap(), h["name"].as_str().unwrap()))
+        .collect();
+    assert_eq!(by_pe.get("pe1"), Some(&"Button.tsx"));
+    assert_eq!(by_pe.get("pe2"), Some(&"iconButton.ts"));
+
+    // Terminal response for the originating id, total = hits, not capped.
+    let term = terminal(&frames).expect("terminal frame");
+    assert_eq!(term["id"], 7);
+    assert_eq!(term["result"], json!({"limit_reached": false, "total": 2}));
+
+    // Natural completion signals done for exactly this session + search_id.
+    let done = done_rx.try_recv().expect("done signal");
+    assert_eq!(done.session, "sess");
+    assert_eq!(done.search_id, json!(7));
+}
+
+#[tokio::test]
+async fn multi_root_shares_one_global_budget() {
+    // Two roots, five candidate hits each, but a global budget of 3 → exactly 3
+    // hits total across both roots, and the cap is reported.
+    let mut by_root = HashMap::new();
+    for root in ["file:///a", "file:///b"] {
+        by_root.insert(
+            root.to_owned(),
+            (0..5).map(|i| (format!("{root}-f{i}"), format!("f{i}.txt"))).collect(),
+        );
+    }
+    let push = Arc::new(CapturePush::default());
+    let (done_tx, _done_rx) = unbounded_channel();
+
+    run_search(
+        provider(by_root),
+        push.clone(),
+        SearchJob {
+            session: "sess".to_owned(),
+            search_id: json!(1),
+            roots: vec![
+                SearchRoot {
+                    root_uri: "file:///a".to_owned(),
+                    pe_id: "pe1".to_owned(),
+                },
+                SearchRoot {
+                    root_uri: "file:///b".to_owned(),
+                    pe_id: "pe2".to_owned(),
+                },
+            ],
+            matcher: NameMatcher::new("", MatchMode::Substring),
+            budget: Budget::new(3),
+            cancel: CancellationToken::new(),
+        },
+        done_tx,
+    )
+    .await;
+
+    let frames = push.frames();
+    assert_eq!(
+        collected_hits(&frames).len(),
+        3,
+        "global budget caps total across roots"
+    );
+    assert_eq!(
+        terminal(&frames).unwrap()["result"],
+        json!({"limit_reached": true, "total": 3})
+    );
+}
+
+#[tokio::test]
+async fn cancelled_before_start_sends_no_terminal_and_no_done() {
+    let mut by_root = HashMap::new();
+    by_root.insert("file:///a".to_owned(), vec![("a.txt".to_owned(), "a.txt".to_owned())]);
+    let push = Arc::new(CapturePush::default());
+    let (done_tx, mut done_rx) = unbounded_channel();
+    let cancel = CancellationToken::new();
+    cancel.cancel(); // superseded / explicitly cancelled before running
+
+    run_search(
+        provider(by_root),
+        push.clone(),
+        SearchJob {
+            session: "sess".to_owned(),
+            search_id: json!(2),
+            roots: one_root("file:///a", "pe1"),
+            matcher: NameMatcher::new("", MatchMode::Substring),
+            budget: Budget::new(100),
+            cancel,
+        },
+        done_tx,
+    )
+    .await;
+
+    // No terminal for a cancelled search, and no done signal (nothing to clear
+    // via this path — the canceller already removed the entry).
+    assert!(terminal(&push.frames()).is_none());
+    assert!(done_rx.try_recv().is_err(), "cancelled search must not signal done");
+}
+
+#[tokio::test]
+async fn cancel_during_run_drops_buffered_matches_and_no_terminal() {
+    // Provider emits 3 hits (well under the batch threshold, so none is flushed
+    // mid-walk) then flips the shared cancel token. The coordinator must DROP the
+    // buffered remainder — not flush it — and send no terminal frame.
+    let mut by_root = HashMap::new();
+    by_root.insert(
+        "file:///a".to_owned(),
+        (0..10).map(|i| (format!("f{i}"), format!("f{i}.txt"))).collect(),
+    );
+    let provider: Arc<dyn IFsSearchProvider> = Arc::new(ScriptedProvider {
+        by_root,
+        cancel_after: Some(3),
+    });
+    let push = Arc::new(CapturePush::default());
+    let (done_tx, mut done_rx) = unbounded_channel();
+
+    run_search(
+        provider,
+        push.clone(),
+        SearchJob {
+            session: "sess".to_owned(),
+            search_id: json!(3),
+            roots: one_root("file:///a", "pe1"),
+            matcher: NameMatcher::new("", MatchMode::Substring),
+            budget: Budget::new(100),
+            cancel: CancellationToken::new(),
+        },
+        done_tx,
+    )
+    .await;
+
+    let frames = push.frames();
+    // The 3 buffered (sub-threshold) hits were dropped, not pushed.
+    assert!(
+        collected_hits(&frames).is_empty(),
+        "un-pushed buffer must be dropped on cancel, got {frames:?}"
+    );
+    assert!(terminal(&frames).is_none(), "cancelled mid-run must send no terminal");
+    assert!(done_rx.try_recv().is_err(), "cancelled mid-run must not signal done");
+}

--- a/crates/aionui-project/src/monitor/wire.rs
+++ b/crates/aionui-project/src/monitor/wire.rs
@@ -118,6 +118,52 @@ pub struct RenameParams {
     pub to: ResourceRef,
 }
 
+// ── Filename search (fs/search) ───────────────────────────────────────────
+
+/// `fs/search` request params (protocol.md). `roots` = the project's bound
+/// folders (or narrowed subdirs); `query` empty = browse; `limit` is the global
+/// hit budget shared across all roots (server default when omitted).
+#[derive(Debug, Clone, Deserialize)]
+pub struct SearchParams {
+    pub roots: Vec<ResourceRef>,
+    pub query: String,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+/// `fs/searchCancel` notification params. `search_id` echoes the originating
+/// `fs/search` request `id` (any JSON value the client used as its id).
+#[derive(Debug, Clone, Deserialize)]
+pub struct SearchCancelParams {
+    pub search_id: Value,
+}
+
+/// One filename hit — the chat-ref `project` identity (files only). `pe_id` is
+/// stamped by the orchestration layer from the root the hit came from.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SearchHit {
+    pub pe_id: String,
+    pub relative_path: String,
+    pub name: String,
+}
+
+/// Build the `fs/searchMatch` notification params: a batch of hits keyed to the
+/// originating search's `id` (echoed as `search_id`).
+pub fn search_match_params(search_id: &Value, matches: &[SearchHit]) -> Value {
+    json!({
+        "search_id": search_id,
+        "matches": matches,
+    })
+}
+
+/// Build the `fs/search` terminal response `result` (`{ limit_reached, total }`).
+pub fn search_result(limit_reached: bool, total: usize) -> Value {
+    json!({
+        "limit_reached": limit_reached,
+        "total": total,
+    })
+}
+
 // ── Outward entry / snapshot / delta ──────────────────────────────────────
 
 /// Entry kind on the wire (`protocol.md` `Entry.kind`).

--- a/crates/aionui-project/src/monitor/wire_test.rs
+++ b/crates/aionui-project/src/monitor/wire_test.rs
@@ -195,6 +195,60 @@ fn notification_frame_has_no_id() {
     assert!(v.get("id").is_none());
 }
 
+// ── filename search params / builders ─────────────────────────────────────
+
+#[test]
+fn search_params_parse_roots_query_and_default_limit() {
+    let v = json!({"roots":[{"pe_id":"pe1","relative_path":""}],"query":"button","limit":200});
+    let p: SearchParams = serde_json::from_value(v).unwrap();
+    assert_eq!(p.roots.len(), 1);
+    assert_eq!(p.query, "button");
+    assert_eq!(p.limit, Some(200));
+
+    // limit is optional (server picks a default when omitted).
+    let p2: SearchParams = serde_json::from_value(json!({"roots":[],"query":""})).unwrap();
+    assert_eq!(p2.limit, None);
+}
+
+#[test]
+fn search_cancel_params_echo_search_id_value() {
+    let p: SearchCancelParams = serde_json::from_value(json!({"search_id":8})).unwrap();
+    assert_eq!(p.search_id, json!(8));
+}
+
+#[test]
+fn search_hit_serializes_project_identity() {
+    let hit = SearchHit {
+        pe_id: "pe1".to_owned(),
+        relative_path: "src/components/Button.tsx".to_owned(),
+        name: "Button.tsx".to_owned(),
+    };
+    let v = serde_json::to_value(&hit).unwrap();
+    assert_eq!(
+        v,
+        json!({"pe_id":"pe1","relative_path":"src/components/Button.tsx","name":"Button.tsx"})
+    );
+}
+
+#[test]
+fn search_match_params_batches_hits_under_search_id() {
+    let hits = vec![SearchHit {
+        pe_id: "pe2".to_owned(),
+        relative_path: "widgets/iconButton.ts".to_owned(),
+        name: "iconButton.ts".to_owned(),
+    }];
+    let v = search_match_params(&json!(7), &hits);
+    assert_eq!(v["search_id"], 7);
+    assert_eq!(v["matches"][0]["pe_id"], "pe2");
+    assert_eq!(v["matches"][0]["name"], "iconButton.ts");
+}
+
+#[test]
+fn search_result_carries_limit_reached_and_total() {
+    assert_eq!(search_result(false, 2), json!({"limit_reached":false,"total":2}));
+    assert_eq!(search_result(true, 200), json!({"limit_reached":true,"total":200}));
+}
+
 // ── error mapping ─────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/aionui-project/src/runtime/fs_runtime.rs
+++ b/crates/aionui-project/src/runtime/fs_runtime.rs
@@ -14,6 +14,7 @@ use super::error::FsError;
 use super::local_provider::LocalFsProvider;
 use super::local_watcher::LocalWatcher;
 use super::provider::IFsProvider;
+use super::search::IFsSearchProvider;
 use super::watcher::{RawEvent, Watcher};
 
 /// How a provider's `read_dir`/`stat` IO is executed on the shard worker.
@@ -31,11 +32,18 @@ pub trait IFsRuntime: Send + Sync {
     fn provider(&self) -> &dyn IFsProvider;
     fn watcher(&self) -> &dyn Watcher;
     fn io_dispatch(&self) -> IoDispatch;
+
+    /// The filename-search capability, when this scheme supports it. Returned as
+    /// an owned `Arc` so the search orchestration can move it into a spawned
+    /// coordinator task. `None` = scheme does not support search.
+    fn search_provider(&self) -> Option<Arc<dyn IFsSearchProvider>>;
 }
 
 /// `file:` runtime: local provider + non-recursive local watcher, `Inline` IO.
 pub struct LocalFsRuntime {
-    provider: LocalFsProvider,
+    /// `Arc`-wrapped so it can serve both the borrowed `provider()` view and an
+    /// owned `search_provider()` handle without a second construction.
+    provider: Arc<LocalFsProvider>,
     watcher: LocalWatcher,
 }
 
@@ -46,7 +54,7 @@ impl LocalFsRuntime {
         let (watcher, rx) = LocalWatcher::new()?;
         Ok((
             Self {
-                provider: LocalFsProvider::new(),
+                provider: Arc::new(LocalFsProvider::new()),
                 watcher,
             },
             rx,
@@ -56,7 +64,7 @@ impl LocalFsRuntime {
 
 impl IFsRuntime for LocalFsRuntime {
     fn provider(&self) -> &dyn IFsProvider {
-        &self.provider
+        self.provider.as_ref()
     }
 
     fn watcher(&self) -> &dyn Watcher {
@@ -65,6 +73,10 @@ impl IFsRuntime for LocalFsRuntime {
 
     fn io_dispatch(&self) -> IoDispatch {
         IoDispatch::Inline
+    }
+
+    fn search_provider(&self) -> Option<Arc<dyn IFsSearchProvider>> {
+        Some(Arc::clone(&self.provider) as Arc<dyn IFsSearchProvider>)
     }
 }
 

--- a/crates/aionui-project/src/runtime/local_provider.rs
+++ b/crates/aionui-project/src/runtime/local_provider.rs
@@ -10,14 +10,21 @@
 //! stage. This provider currently performs no realpath containment.
 
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
 
 use async_trait::async_trait;
+use ignore::WalkBuilder;
 
 use crate::canonical;
 
 use super::error::FsError;
 use super::provider::{EntryFact, IFsProvider, Kind};
+use super::search::{Budget, CancellationToken, IFsSearchProvider, NameMatcher, SearchSink};
+
+/// How often, in walked entries, the blocking walk re-checks the cancel token
+/// (checking every entry would be needless overhead on a large tree).
+const CANCEL_CHECK_STRIDE: usize = 128;
 
 /// Local-disk provider for the `file:` scheme.
 #[derive(Debug, Default, Clone)]
@@ -201,6 +208,98 @@ impl IFsProvider for LocalFsProvider {
                 .map_err(|e| map_io(from, &e))
         }
     }
+}
+
+#[async_trait]
+impl IFsSearchProvider for LocalFsProvider {
+    async fn search_names(
+        &self,
+        root_uri: &str,
+        matcher: &NameMatcher,
+        sink: &Arc<dyn SearchSink>,
+        budget: &Budget,
+        cancel: &CancellationToken,
+    ) -> Result<(), FsError> {
+        let root = path_of(root_uri)?;
+        // The `ignore` walk is synchronous and CPU/IO-bound; run it off the async
+        // worker so it never blocks the actor's event loop. Shared budget/cancel
+        // are cheap Arc handles moved into the blocking task.
+        let (matcher, sink, budget, cancel) = (matcher.clone(), Arc::clone(sink), budget.clone(), cancel.clone());
+        tokio::task::spawn_blocking(move || walk_names(&root, &matcher, &sink, &budget, &cancel))
+            .await
+            .map_err(|e| FsError::Io {
+                uri: root_uri.to_owned(),
+                message: format!("search walk task join failed: {e}"),
+            })
+    }
+}
+
+/// The blocking `ignore` tree walk backing [`LocalFsProvider::search_names`].
+/// Honors `.gitignore` / git excludes (same walker ripgrep uses); emits only
+/// files whose name matches, stopping on budget exhaustion or cancellation.
+fn walk_names(
+    root: &Path,
+    matcher: &NameMatcher,
+    sink: &Arc<dyn SearchSink>,
+    budget: &Budget,
+    cancel: &CancellationToken,
+) {
+    let walker = WalkBuilder::new(root)
+        .hidden(false)
+        .git_ignore(true)
+        .git_global(false)
+        .git_exclude(true)
+        .require_git(false)
+        .build();
+
+    for (seen, entry) in walker.enumerate() {
+        // Periodic cancel check so a large no-hit subtree still bails promptly.
+        if seen.is_multiple_of(CANCEL_CHECK_STRIDE) && cancel.is_cancelled() {
+            return;
+        }
+        let entry = match entry {
+            Ok(e) => e,
+            // Unreadable entry (permissions, race) — skip, safely handled.
+            Err(err) => {
+                tracing::debug!(error = %err, "fs search: skipping unreadable entry");
+                continue;
+            }
+        };
+        // Filename search returns files only (SearchHit is files-only); the root
+        // dir itself and every subdirectory are traversed but never emitted.
+        if entry.file_type().is_none_or(|ft| ft.is_dir()) {
+            continue;
+        }
+        let path = entry.path();
+        let Some(name) = path.file_name().map(|n| n.to_string_lossy().into_owned()) else {
+            continue;
+        };
+        if !matcher.matches(&name) {
+            continue;
+        }
+        if cancel.is_cancelled() {
+            return;
+        }
+        // Reserve a hit slot from the shared global budget; failure = cap reached
+        // (budget records `limit_reached`) → stop this root's walk.
+        if !budget.try_take() {
+            return;
+        }
+        sink.emit(rel_path(root, path), name);
+    }
+}
+
+/// Root-relative path, forward-slash normalized, no leading slash (wire form).
+fn rel_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .components()
+        .filter_map(|c| match c {
+            Component::Normal(seg) => Some(seg.to_string_lossy().into_owned()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 #[cfg(test)]

--- a/crates/aionui-project/src/runtime/local_provider_test.rs
+++ b/crates/aionui-project/src/runtime/local_provider_test.rs
@@ -1,10 +1,12 @@
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 use tempfile::tempdir;
 
 use crate::canonical::{self, Canonical};
 use crate::runtime::error::FsError;
 use crate::runtime::provider::{IFsProvider, Kind};
+use crate::runtime::search::{Budget, CancellationToken, IFsSearchProvider, MatchMode, NameMatcher, SearchSink};
 
 use super::LocalFsProvider;
 
@@ -216,4 +218,124 @@ async fn read_dir_populates_inode() {
     let provider = LocalFsProvider::new();
     let entries = provider.read_dir(canon(dir.path()).as_str()).await.unwrap();
     assert!(entries[0].1.inode != 0);
+}
+
+// ── filename search (IFsSearchProvider) ──────────────────────────────────────
+
+/// Test sink: collects `(relative_path, name)` hits under a mutex.
+#[derive(Default)]
+struct CollectSink(Mutex<Vec<(String, String)>>);
+
+impl SearchSink for CollectSink {
+    fn emit(&self, relative_path: String, name: String) {
+        self.0.lock().unwrap().push((relative_path, name));
+    }
+}
+
+impl CollectSink {
+    fn hits(&self) -> Vec<(String, String)> {
+        self.0.lock().unwrap().clone()
+    }
+}
+
+/// Search helper that keeps the concrete sink so hits can be read back.
+async fn search_collect(root: &Path, query: &str, mode: MatchMode, limit: usize) -> (Vec<(String, String)>, bool) {
+    let provider = LocalFsProvider::new();
+    let collect = Arc::new(CollectSink::default());
+    let sink: Arc<dyn SearchSink> = collect.clone();
+    let matcher = NameMatcher::new(query, mode);
+    let budget = Budget::new(limit);
+    let cancel = CancellationToken::new();
+    provider
+        .search_names(canon(root).as_str(), &matcher, &sink, &budget, &cancel)
+        .await
+        .unwrap();
+    let mut hits = collect.hits();
+    hits.sort();
+    (hits, budget.limit_reached())
+}
+
+#[tokio::test]
+async fn search_matches_files_by_name_substring() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir(root.join("src")).unwrap();
+    std::fs::write(root.join("src").join("Button.tsx"), b"x").unwrap();
+    std::fs::write(root.join("Widget.tsx"), b"x").unwrap();
+    std::fs::write(root.join("iconButton.ts"), b"x").unwrap();
+
+    let (hits, capped) = search_collect(root, "button", MatchMode::Substring, 100).await;
+    let mut names: Vec<&str> = hits.iter().map(|(_, n)| n.as_str()).collect();
+    names.sort_unstable();
+    assert_eq!(names, vec!["Button.tsx", "iconButton.ts"]);
+    // Relative paths are forward-slash, root-relative.
+    assert!(hits.iter().any(|(rel, _)| rel == "src/Button.tsx"));
+    assert!(!capped);
+}
+
+#[tokio::test]
+async fn search_empty_query_returns_all_files_not_dirs() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir(root.join("sub")).unwrap();
+    std::fs::write(root.join("sub").join("a.txt"), b"x").unwrap();
+    std::fs::write(root.join("b.txt"), b"x").unwrap();
+
+    let (hits, _) = search_collect(root, "", MatchMode::Substring, 100).await;
+    let mut names: Vec<&str> = hits.iter().map(|(_, n)| n.as_str()).collect();
+    names.sort_unstable();
+    // Files only — directories ("sub") are traversed but never emitted.
+    assert_eq!(names, vec!["a.txt", "b.txt"]);
+}
+
+#[tokio::test]
+async fn search_respects_gitignore() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join(".gitignore"), "ignored.txt\n").unwrap();
+    std::fs::write(root.join("ignored.txt"), b"x").unwrap();
+    std::fs::write(root.join("kept.txt"), b"x").unwrap();
+
+    let (hits, _) = search_collect(root, "", MatchMode::Substring, 100).await;
+    let names: Vec<&str> = hits.iter().map(|(_, n)| n.as_str()).collect();
+    assert!(names.contains(&"kept.txt"));
+    assert!(names.contains(&".gitignore"));
+    // The gitignored file is excluded by the walker.
+    assert!(!names.contains(&"ignored.txt"), "got {names:?}");
+}
+
+#[tokio::test]
+async fn search_stops_at_budget_and_reports_limit_reached() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    for i in 0..10 {
+        std::fs::write(root.join(format!("f{i}.txt")), b"x").unwrap();
+    }
+
+    let (hits, capped) = search_collect(root, "", MatchMode::Substring, 3).await;
+    // Budget caps total emitted hits; the cap is reported.
+    assert_eq!(hits.len(), 3);
+    assert!(capped);
+}
+
+#[tokio::test]
+async fn search_cancelled_before_start_emits_nothing() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    for i in 0..300 {
+        std::fs::write(root.join(format!("f{i}.txt")), b"x").unwrap();
+    }
+    let provider = LocalFsProvider::new();
+    let collect = Arc::new(CollectSink::default());
+    let sink: Arc<dyn SearchSink> = collect.clone();
+    let matcher = NameMatcher::new("", MatchMode::Substring);
+    let budget = Budget::new(10_000);
+    let cancel = CancellationToken::new();
+    cancel.cancel(); // cancelled up front
+    provider
+        .search_names(canon(root).as_str(), &matcher, &sink, &budget, &cancel)
+        .await
+        .unwrap();
+    // The very first stride check (index 0) sees the cancel and returns.
+    assert!(collect.hits().is_empty());
 }

--- a/crates/aionui-project/src/runtime/mod.rs
+++ b/crates/aionui-project/src/runtime/mod.rs
@@ -14,6 +14,7 @@ mod fs_runtime;
 mod local_provider;
 mod local_watcher;
 mod provider;
+mod search;
 mod subscription;
 mod tree_model;
 mod watcher;
@@ -22,6 +23,7 @@ pub use actor::{Command, Debouncer, Shard, ShardOutput, raw_to_command};
 pub use error::FsError;
 pub use fs_runtime::{FsRuntimeRegistry, IFsRuntime, IoDispatch, LocalFsRuntime};
 pub use provider::{EntryFact, IFsProvider, Kind};
+pub use search::{Budget, CancellationToken, IFsSearchProvider, MatchMode, NameMatcher, SearchSink};
 // Note: the concrete `file:` impls `LocalFsProvider` / `LocalWatcher` are
 // `pub(crate)` (internal) — external callers build via `LocalFsRuntime` and see
 // only the trait objects it returns, so they are not re-exported here.

--- a/crates/aionui-project/src/runtime/search.rs
+++ b/crates/aionui-project/src/runtime/search.rs
@@ -1,0 +1,174 @@
+//! `IFsSearchProvider` — the filename-search capability of a filesystem runtime.
+//!
+//! Kept a separate trait from [`super::provider::IFsProvider`] so the single-level
+//! non-recursive data-op contract is not polluted by the recursive/streaming shape
+//! of search. A provider walks its own subtree the most efficient way it can
+//! (`LocalFsProvider` = in-process `ignore` walk; a future remote provider = one
+//! request + a frame stream), emitting each filename hit through a [`SearchSink`].
+//! The provider only *produces* `(relative_path, name)`; batching, pe-id stamping,
+//! merging into one `fs/search` stream, and pushing to the wire are the
+//! orchestration layer's job (see `monitor::search`).
+//!
+//! Feature semantics / engine / chat-ref identity: `formal/runtime/search.md`;
+//! protocol: `formal/runtime/protocol.md` `fs/search`.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+
+use super::error::FsError;
+
+/// How the cheap backend filename predicate matches a candidate name against the
+/// query. Backend only *bounds* the hit set cheaply; final fuzzy ranking is the
+/// frontend's job (see `search.md` "backend filters, frontend ranks").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchMode {
+    /// Case-insensitive substring — `query` appears contiguously in the name.
+    Substring,
+    /// Case-insensitive subsequence — `query`'s chars appear in order, gaps ok.
+    Subsequence,
+}
+
+/// A precompiled, cheap filename predicate derived from the search `query`.
+/// Case-insensitive. An empty query matches every file (panel browse mode).
+#[derive(Debug, Clone)]
+pub struct NameMatcher {
+    /// Lowercased query needle; empty = match-all.
+    needle: String,
+    mode: MatchMode,
+}
+
+impl NameMatcher {
+    /// Compile a matcher from the raw query and mode.
+    pub fn new(query: &str, mode: MatchMode) -> Self {
+        Self {
+            needle: query.to_lowercase(),
+            mode,
+        }
+    }
+
+    /// Whether `name` matches. Empty query always matches (browse).
+    pub fn matches(&self, name: &str) -> bool {
+        if self.needle.is_empty() {
+            return true;
+        }
+        let hay = name.to_lowercase();
+        match self.mode {
+            MatchMode::Substring => hay.contains(&self.needle),
+            MatchMode::Subsequence => is_subsequence(&self.needle, &hay),
+        }
+    }
+}
+
+/// Whether every char of `needle` appears in `hay` in order (both prelowered).
+fn is_subsequence(needle: &str, hay: &str) -> bool {
+    let mut needle_chars = needle.chars().peekable();
+    for c in hay.chars() {
+        match needle_chars.peek() {
+            Some(&n) if n == c => {
+                needle_chars.next();
+            }
+            Some(_) => {}
+            None => return true,
+        }
+    }
+    needle_chars.peek().is_none()
+}
+
+/// A hit budget shared across all roots of one search: a global cap on how many
+/// files may be emitted before the walk stops. Cloning shares the same counter
+/// (cheap `Arc` handle) so concurrent per-root walks draw from one pool.
+#[derive(Debug, Clone, Default)]
+pub struct Budget(Arc<BudgetInner>);
+
+#[derive(Debug, Default)]
+struct BudgetInner {
+    /// Remaining emit slots; reaching 0 ends the walk.
+    remaining: AtomicUsize,
+    /// Set once a walk tried to emit while `remaining == 0` — distinguishes
+    /// "hit exactly the cap and there were more" from "found fewer than cap".
+    hit_cap: AtomicBool,
+}
+
+impl Budget {
+    /// A budget allowing at most `limit` total hits across all roots.
+    pub fn new(limit: usize) -> Self {
+        Self(Arc::new(BudgetInner {
+            remaining: AtomicUsize::new(limit),
+            hit_cap: AtomicBool::new(false),
+        }))
+    }
+
+    /// Reserve one emit slot. Returns `true` if a slot was taken; `false` when
+    /// the budget is exhausted (and records that the cap forced a stop).
+    pub fn try_take(&self) -> bool {
+        let taken = self
+            .0
+            .remaining
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| cur.checked_sub(1))
+            .is_ok();
+        if !taken {
+            self.0.hit_cap.store(true, Ordering::Relaxed);
+        }
+        taken
+    }
+
+    /// Whether any walk was forced to stop because the cap was reached.
+    pub fn limit_reached(&self) -> bool {
+        self.0.hit_cap.load(Ordering::Relaxed)
+    }
+}
+
+/// Cooperative cancel signal, cascaded to every per-root walk of a search.
+/// Explicit `fs/searchCancel` or a superseding new search flips it; each walk
+/// checks it and stops (a future remote provider kills its remote request).
+#[derive(Debug, Clone, Default)]
+pub struct CancellationToken(Arc<AtomicBool>);
+
+impl CancellationToken {
+    /// A fresh, un-cancelled token.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Request cancellation. Idempotent.
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+
+    /// Whether cancellation has been requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+/// Hit outlet. The provider calls [`SearchSink::emit`] per matching file with the
+/// root-relative path (forward-slash normalized, no leading slash) and file name;
+/// the orchestration layer stamps `pe_id`, batches, and pushes `fs/searchMatch`.
+pub trait SearchSink: Send + Sync {
+    /// Emit one filename hit within the current root.
+    fn emit(&self, relative_path: String, name: String);
+}
+
+/// Filename-search capability for one provider scheme. Distinct from
+/// [`IFsProvider`](super::provider::IFsProvider): recursive + streaming.
+#[async_trait]
+pub trait IFsSearchProvider: Send + Sync {
+    /// Walk `root_uri`'s subtree, emitting each file whose name satisfies
+    /// `matcher` through `sink`, until the subtree is exhausted, `budget` runs
+    /// out, or `cancel` fires. `budget` and `cancel` are shared across all roots
+    /// of the search; the sink merges every root into one stream.
+    async fn search_names(
+        &self,
+        root_uri: &str,
+        matcher: &NameMatcher,
+        sink: &Arc<dyn SearchSink>,
+        budget: &Budget,
+        cancel: &CancellationToken,
+    ) -> Result<(), FsError>;
+}
+
+#[cfg(test)]
+#[path = "search_test.rs"]
+mod search_test;

--- a/crates/aionui-project/src/runtime/search_test.rs
+++ b/crates/aionui-project/src/runtime/search_test.rs
@@ -1,0 +1,85 @@
+//! Unit tests for the search provider primitives: `NameMatcher`, `Budget`,
+//! `CancellationToken`. The `LocalFsProvider` walk itself is covered against a
+//! real temp tree in `local_provider_test.rs`.
+
+use super::*;
+
+// ── NameMatcher ────────────────────────────────────────────────────────────
+
+#[test]
+fn matcher_empty_query_matches_everything() {
+    let m = NameMatcher::new("", MatchMode::Substring);
+    assert!(m.matches("anything.rs"));
+    assert!(m.matches(""));
+}
+
+#[test]
+fn matcher_substring_is_case_insensitive() {
+    let m = NameMatcher::new("button", MatchMode::Substring);
+    assert!(m.matches("Button.tsx"));
+    assert!(m.matches("iconButton.ts"));
+    assert!(!m.matches("Widget.tsx"));
+}
+
+#[test]
+fn matcher_substring_requires_contiguous() {
+    let m = NameMatcher::new("btn", MatchMode::Substring);
+    // "btn" is not a contiguous run inside "button".
+    assert!(!m.matches("Button.tsx"));
+    assert!(m.matches("my_btn.tsx"));
+}
+
+#[test]
+fn matcher_subsequence_allows_gaps() {
+    let m = NameMatcher::new("btn", MatchMode::Subsequence);
+    // b..t..n appear in order within "Button".
+    assert!(m.matches("Button.tsx"));
+    assert!(!m.matches("nbt.rs")); // wrong order
+}
+
+// ── Budget ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn budget_takes_up_to_limit_then_records_cap() {
+    let b = Budget::new(2);
+    assert!(b.try_take());
+    assert!(b.try_take());
+    assert!(!b.limit_reached()); // exactly consumed, no over-attempt yet
+    assert!(!b.try_take()); // third attempt fails
+    assert!(b.limit_reached());
+}
+
+#[test]
+fn budget_zero_limit_immediately_caps() {
+    let b = Budget::new(0);
+    assert!(!b.try_take());
+    assert!(b.limit_reached());
+}
+
+#[test]
+fn budget_is_shared_across_clones() {
+    let a = Budget::new(1);
+    let b = a.clone();
+    assert!(a.try_take());
+    // The clone draws from the same pool — no slots left.
+    assert!(!b.try_take());
+    assert!(a.limit_reached());
+}
+
+// ── CancellationToken ────────────────────────────────────────────────────────
+
+#[test]
+fn token_starts_uncancelled_and_flips_once_cancelled() {
+    let t = CancellationToken::new();
+    assert!(!t.is_cancelled());
+    t.cancel();
+    assert!(t.is_cancelled());
+}
+
+#[test]
+fn token_cancel_is_visible_through_clones() {
+    let a = CancellationToken::new();
+    let b = a.clone();
+    a.cancel();
+    assert!(b.is_cancelled());
+}

--- a/crates/aionui-project/src/runtime/tree_model_test.rs
+++ b/crates/aionui-project/src/runtime/tree_model_test.rs
@@ -9,6 +9,7 @@ use crate::canonical::{self, Canonical};
 use crate::runtime::error::FsError;
 use crate::runtime::fs_runtime::{FsRuntimeRegistry, IFsRuntime, IoDispatch};
 use crate::runtime::provider::{EntryFact, IFsProvider, Kind};
+use crate::runtime::search::IFsSearchProvider;
 use crate::runtime::watcher::{WatchHandle, Watcher};
 
 use super::{Change, Hint, TreeModel, diff};
@@ -338,6 +339,10 @@ impl IFsRuntime for FakeRuntime {
     }
     fn io_dispatch(&self) -> IoDispatch {
         IoDispatch::Inline
+    }
+    fn search_provider(&self) -> Option<Arc<dyn IFsSearchProvider>> {
+        // The tree model never uses search; this fake need not provide it.
+        None
     }
 }
 


### PR DESCRIPTION
## What

Backend vertical for project-scoped **filename search** (`fs/search`) — the shared identity layer behind both the search panel and `@`-mention (see `feat-project-design/formal/runtime/search.md` / `protocol.md` v4).

- **Provider capability** — new `IFsSearchProvider` trait (kept separate from the single-level `IFsProvider` so its recursive/streaming shape doesn't pollute that contract). `LocalFsProvider` implements it as an in-process `ignore` tree walk (honors `.gitignore` / git excludes — the same walker ripgrep is built on; **no ripgrep subprocess**, since filename search reads no content), files-only, forward-slash relative paths, run off the async worker via `spawn_blocking`.
- **Primitives** — `NameMatcher` (case-insensitive substring; a subsequence mode is implemented but kept internal until the frontend adopts fuzzy), a shared `Budget` (global hit cap across all roots), and a `CancellationToken`.
- **Protocol** — `fs/search` request / `fs/searchMatch` notification / `fs/searchCancel` + the terminal `{ limit_reached, total }` response, matching `protocol.md` v4 (reuses the existing `fs` envelope; no new endpoint).
- **Orchestration** (monitor) — atomic per-root resolve via `resolve_reference` (user-scoped; any root failing errors the whole request, no partial search), then a coordinator **spawned off the actor event loop** so the loop stays responsive to `fs/searchCancel` and superseding searches. Roots walk concurrently under one shared budget + cancel; each root's hits are stamped with its `pe_id` and merged into one batched `fs/searchMatch` stream; terminal on completion.
- **Lifecycle** — supersede-on-new-search (per connection), explicit cancel, and disconnect all cascade the cancel token. On cancel the un-pushed buffer is dropped and **no terminal frame** is sent (per protocol). On natural completion the active-search entry is cleared (guarded by `search_id` so a superseding search is never clobbered).

## Testing

- `cargo test -p aionui-project` — **192 tests pass** (169 lib + 23 integration), `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt` clean.
- Coverage: matcher / budget / cancellation primitives; the real `ignore` walk (substring, empty-query files-only, `.gitignore` respected, budget cap, cancel); protocol wire shapes; coordinator merge + per-root `pe_id` stamping + global budget + cancel-drops-buffer + completion done-signal; actor state machine (supersede-cancels-previous, cancel-only-when-id-matches, disconnect cascade, clear-on-done-guarded-by-id); a **barrier provider test that holds a search provably in-flight** and asserts the event loop still answers `initialize`; and an **end-to-end test** that a real completing walk signals done → the actor clears its entry → a later same-id `fs/searchCancel` is a no-op.
- `just push` full workspace gate is green (7916 tests). The one local flake `aionui-system ... test_env_override_log_dir` is a pre-existing `AIONUI_LOG_DIR` env-casing flake unrelated to this diff (not in these changes, not importing this module); it passes with the env var unset.

## Notes

- A residual terminal-before-done scheduling race is documented in `monitor/search.rs` as **known-harmless** (monotonic per-connection `search_id` that is never reused → no clobber; `fs/searchCancel` is a notification with no reply → no observable client error; cancel-of-completed is a no-op + idempotent removal). Deliberately not covered by a scheduling test.
- **Live WS runtime verified** (not just crate/unit green): a frontend-driven dev backend running this exact code (`5c96e42e`, `strings`-confirmed to carry the full `fs/search` surface) was exercised end-to-end with CDP capturing the real WS frames — the `@` three-phase stream (`fs/search` → `fs/searchMatch` carrying `pe_id`/`relative_path`/`name` → terminal `total`), supersede, the SearchPanel, deep-hit `fs/subscribe` array back-filling the ancestor chain, `limit_reached=true` / `total=1000` / 16 batches, and the add-to-chat project-ref payload. A reviewer independently re-drove via CDP to capture the `fs/searchCancel` frame and close the cancel gap. Frames ↔ protocol ↔ code agreed across six dimensions. (The GUI run was driven by the frontend owner, not this PR's owner.)
- Companion frontend PR (wiring, depends on this backend): **iOfficeAI/AionUi#3784**.
