### PR TITLE
fix: prevent silent encryption-key rotation on migration upgrade (ELECTRON-3T0)

### DIFF
--- a/crates/aionui-app/src/services.rs
+++ b/crates/aionui-app/src/services.rs
@@ -119,6 +119,26 @@ impl AppServices {
 
         let (secret, is_new) = resolve_jwt_secret(env_secret.as_deref(), db_secret);
 
+        // Defense-in-depth for the encryption key: generating a NEW secret is
+        // only legitimate on a genuinely fresh install. If the read path
+        // claimed "no system user" while the row actually exists (as happened
+        // when a stale post-migration connection mis-decoded the users table,
+        // ELECTRON-3T0), deriving a fresh key would silently break decryption
+        // of every stored credential. Verify absence with an independent
+        // query and fail startup instead of corrupting.
+        if is_new
+            && system_user.is_none()
+            && user_repo
+                .find_by_id("system_default_user")
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to verify system user absence: {e}"))?
+                .is_some()
+        {
+            anyhow::bail!(
+                "system user row exists but could not be read; refusing to generate a new                  JWT secret (would break decryption of stored credentials)"
+            );
+        }
+
         // Persist newly generated secret to database
         if is_new && let Some(user) = &system_user {
             user_repo

--- a/crates/aionui-app/tests/open_repro_db.rs
+++ b/crates/aionui-app/tests/open_repro_db.rs
@@ -1,0 +1,28 @@
+//! Manual gold-standard probe for ELECTRON-3T0 (env-gated; skipped in CI).
+//! Open a REAL v0.1.52-created database (REPRO_DB) through the production
+//! startup path and assert the pre-upgrade credential still decrypts.
+use aionui_app::{AppConfig, AppServices};
+use aionui_db::SqliteProviderRepository;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn open_old_db_and_decrypt_provider() {
+    let Ok(path) = std::env::var("REPRO_DB") else {
+        eprintln!("REPRO_DB not set; skipping");
+        return;
+    };
+    let db = aionui_db::init_database(std::path::Path::new(&path)).await.unwrap();
+    let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
+    let key = aionui_app::derive_encryption_key(&services.jwt_secret_raw);
+    eprintln!("[cur] secret prefix: {}", &services.jwt_secret_raw[..12]);
+    let repo = Arc::new(SqliteProviderRepository::new(services.database.pool().clone()));
+    let svc = aionui_system::ProviderService::new(repo, key);
+    let list = svc.list("system_default_user").await.expect("list must not fail");
+    let p = list.iter().find(|p| p.id == "repro-prov-1").expect("provider present");
+    assert_eq!(
+        p.api_key, "sk-repro-XYZ-123",
+        "REPRO: pre-upgrade credential must decrypt (empty means key rotated)"
+    );
+    eprintln!("[cur] DECRYPTION OK");
+    services.database.close().await;
+}

--- a/crates/aionui-app/tests/upgrade_encryption_survives.rs
+++ b/crates/aionui-app/tests/upgrade_encryption_survives.rs
@@ -1,0 +1,110 @@
+//! Regression for ELECTRON-3T0: upgrading a pre-user-scope database must not
+//! rotate the encryption key.
+//!
+//! Reproduces the field failure end-to-end inside one test, no old binary
+//! needed: build a database migrated only up to 028 (the last pre-user-scope
+//! version) with the CURRENT migration files, store a provider through the
+//! real secret-resolution + encryption path, then reopen it through the real
+//! `init_database` (which applies 029+, rebuilding `users`) and assert the
+//! stored API key still decrypts.
+//!
+//! Before the fix, connections opened prior to the DDL served a stale `users`
+//! layout after migration 030's table rebuild; startup then saw "no system
+//! user", silently derived a brand-new key, and every stored credential
+//! failed with "Decryption failed: invalid key or corrupted data".
+use aionui_app::{AppConfig, AppServices};
+use aionui_db::SqliteProviderRepository;
+use sqlx::migrate::Migrator;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use std::str::FromStr;
+use std::sync::Arc;
+
+const LAST_PRE_USER_SCOPE_MIGRATION: i64 = 28;
+
+#[tokio::test]
+async fn upgrade_from_pre_user_scope_keeps_encryption_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("upgrade.db");
+
+    // ── Phase 1: a genuine pre-user-scope (≤028) database ────────────────
+    {
+        let opts = SqliteConnectOptions::from_str(&format!("sqlite://{}", db_path.display()))
+            .unwrap()
+            .create_if_missing(true);
+        // Single connection: mirrors run_migrations_staged's PRAGMA setup for
+        // the legacy table rebuilds inside the early migrations.
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(opts)
+            .await
+            .unwrap();
+        sqlx::query("PRAGMA foreign_keys = OFF; PRAGMA legacy_alter_table = ON")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let mut migrator: Migrator = sqlx::migrate!("../aionui-db/migrations");
+        migrator.migrations = migrator
+            .migrations
+            .iter()
+            .filter(|m| m.version <= LAST_PRE_USER_SCOPE_MIGRATION)
+            .cloned()
+            .collect::<Vec<_>>()
+            .into();
+        migrator.run(&pool).await.unwrap();
+
+        // Old-shape system user with a persisted jwt_secret (what a real
+        // pre-upgrade install has after its first boot).
+        sqlx::query(
+            "INSERT INTO users (id, username, password_hash, jwt_secret, created_at, updated_at) \
+             VALUES ('system_default_user', 'admin', '', 'legacy-secret-0123456789', 1, 1)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Store a provider exactly as the OLD install did: encrypt with the
+        // key derived from the persisted secret and write the 028-era row
+        // shape directly (the current ProviderService writes user-scope
+        // columns that do not exist yet at 028).
+        let key = aionui_app::derive_encryption_key("legacy-secret-0123456789");
+        let enc = aionui_common::encrypt_string("sk-upgrade-SECRET", &key).unwrap();
+        sqlx::query(
+            "INSERT INTO providers                 (id, platform, name, base_url, api_key_encrypted, models, enabled, capabilities, created_at, updated_at)              VALUES ('upgrade-prov-1', 'custom', 'Upgrade', 'http://localhost:1', ?, '[\"m\"]', 1, '[]', 1, 1)",
+        )
+        .bind(&enc)
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool.close().await;
+    }
+
+    // ── Phase 2: the upgrade — real init_database applies 029+ ───────────
+    let db = aionui_db::init_database(&db_path).await.unwrap();
+    let services = AppServices::from_config(db, &AppConfig::default())
+        .await
+        .expect("startup must not fail on an upgraded database");
+
+    // The secret must be the one persisted before the upgrade — never a
+    // freshly generated replacement.
+    assert_eq!(
+        services.jwt_secret_raw, "legacy-secret-0123456789",
+        "upgrade must keep reading the persisted jwt_secret"
+    );
+
+    // And the pre-upgrade credential must still decrypt.
+    let key = aionui_app::derive_encryption_key(&services.jwt_secret_raw);
+    let repo = Arc::new(SqliteProviderRepository::new(services.database.pool().clone()));
+    let svc = aionui_system::ProviderService::new(repo, key);
+    let list = svc
+        .list("system_default_user")
+        .await
+        .expect("provider list must not fail after upgrade");
+    let p = list
+        .iter()
+        .find(|p| p.id == "upgrade-prov-1")
+        .expect("provider present");
+    assert_eq!(p.api_key, "sk-upgrade-SECRET", "decryption must survive the upgrade");
+
+    services.database.close().await;
+}

--- a/crates/aionui-db/src/database.rs
+++ b/crates/aionui-db/src/database.rs
@@ -265,11 +265,30 @@ async fn try_init_file_staged(path: &Path) -> Result<Database, DatabaseInitError
 
     let pool = PoolOptions::<Sqlite>::new()
         .max_connections(MAX_CONNECTIONS)
-        .connect_with(opts)
+        .connect_with(opts.clone())
         .await
         .map_err(|e| DatabaseInitError::new("database.open", DbError::Query(e)))?;
 
     run_migrations_staged(&pool).await?;
+
+    // Discard the bootstrap pool and reconnect on a FRESH pool before any
+    // business query runs. Migrations DROP+rebuild tables (e.g. 030 rebuilt
+    // `users` from 9 to 16 columns); connections opened before the DDL can
+    // still serve stale schema through sqlx's per-connection statement cache
+    // and SQLite's connection-level schema snapshot. On a real upgraded
+    // database this made the first post-migration `SELECT * FROM users`
+    // return the OLD column layout: row decoding panicked in the sqlx
+    // worker, the startup secret resolution saw "no system user", silently
+    // derived a brand-new encryption key, and every previously encrypted
+    // credential (provider API keys, channel configs) failed to decrypt for
+    // that session (ELECTRON-3T0). A fresh pool has no pre-DDL state.
+    pool.close().await;
+    let pool = PoolOptions::<Sqlite>::new()
+        .max_connections(MAX_CONNECTIONS)
+        .connect_with(opts)
+        .await
+        .map_err(|e| DatabaseInitError::new("database.reopen", DbError::Query(e)))?;
+
     ensure_system_user(&pool)
         .await
         .map_err(|e| DatabaseInitError::new("database.seed", e))?;

--- a/crates/aionui-system/src/provider.rs
+++ b/crates/aionui-system/src/provider.rs
@@ -128,7 +128,24 @@ impl ProviderService {
     /// frontend can migrate its local store to the backend without losing
     /// the key on re-read. Storage remains encrypted at rest.
     fn row_to_response(&self, row: Provider) -> Result<ProviderResponse, SystemError> {
-        let api_key = decrypt_string(&row.api_key_encrypted, &self.encryption_key)?;
+        // Lenient on decryption: a credential encrypted under a rotated/lost
+        // key (e.g. one saved during the ELECTRON-3T0 broken session, whose
+        // in-memory-only key is gone forever) must not take the whole
+        // provider list down. Surface the row with an empty api_key so the
+        // user can see it and re-enter the key; log at warn for production
+        // diagnosability.
+        let api_key = match decrypt_string(&row.api_key_encrypted, &self.encryption_key) {
+            Ok(key) => key,
+            Err(error) => {
+                tracing::warn!(
+                    provider_id = %row.id,
+                    provider_name = %row.name,
+                    %error,
+                    "provider api_key failed to decrypt; returning empty key so the row stays visible for re-entry"
+                );
+                String::new()
+            }
+        };
 
         let models: Vec<String> = serde_json::from_str(&row.models)
             .map_err(|e| SystemError::Internal(format!("Failed to parse models JSON: {e}")))?;
@@ -681,5 +698,91 @@ mod tests {
         let svc = setup().await;
         let err = svc.delete(TEST_USER_ID, "no_such_id").await.unwrap_err();
         assert!(matches!(err, SystemError::NotFound(_)));
+    }
+}
+
+#[cfg(test)]
+mod undecryptable_row_tests {
+    use super::*;
+    use aionui_db::{SqliteProviderRepository, init_database_memory};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    const KEY: [u8; 32] = [7u8; 32];
+    const USER: &str = "system_default_user";
+
+    /// ELECTRON-3T0 scenario 2: a credential encrypted under a lost key (the
+    /// broken session's in-memory-only key) must not take the whole provider
+    /// list down. The row stays visible with an empty api_key so the user can
+    /// re-enter it; healthy rows keep decrypting.
+    #[tokio::test]
+    async fn undecryptable_api_key_degrades_to_empty_instead_of_failing_the_list() {
+        let db = init_database_memory().await.unwrap();
+        let pool = db.pool().clone();
+        let repo = Arc::new(SqliteProviderRepository::new(pool.clone()));
+        std::mem::forget(db);
+        let svc = ProviderService::new(repo, KEY);
+
+        let good = svc
+            .create(
+                USER,
+                CreateProviderRequest {
+                    id: Some("prov-good".into()),
+                    platform: "custom".into(),
+                    name: "Good".into(),
+                    base_url: "http://localhost:1".into(),
+                    api_key: "sk-good".into(),
+                    models: vec![],
+                    enabled: true,
+                    capabilities: vec![],
+                    context_limit: None,
+                    model_protocols: None,
+                    model_enabled: None,
+                    model_health: None,
+                    model_settings: HashMap::new(),
+                    bedrock_config: None,
+                    is_full_url: false,
+                },
+            )
+            .await
+            .unwrap();
+        let bad = svc
+            .create(
+                USER,
+                CreateProviderRequest {
+                    id: Some("prov-bad".into()),
+                    platform: "custom".into(),
+                    name: "Bad".into(),
+                    base_url: "http://localhost:2".into(),
+                    api_key: "sk-bad".into(),
+                    models: vec![],
+                    enabled: true,
+                    capabilities: vec![],
+                    context_limit: None,
+                    model_protocols: None,
+                    model_enabled: None,
+                    model_health: None,
+                    model_settings: HashMap::new(),
+                    bedrock_config: None,
+                    is_full_url: false,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Corrupt the bad row's ciphertext as if it were written under a key
+        // that no longer exists.
+        sqlx::query("UPDATE providers SET api_key_encrypted = 'AAAAgarbage-not-decryptable' WHERE id = ?")
+            .bind(&bad.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let list = svc.list(USER).await.expect("one bad row must not fail the list");
+        assert_eq!(list.len(), 2);
+        let good_row = list.iter().find(|p| p.id == good.id).unwrap();
+        let bad_row = list.iter().find(|p| p.id == bad.id).unwrap();
+        assert_eq!(good_row.api_key, "sk-good", "healthy rows keep decrypting");
+        assert_eq!(bad_row.api_key, "", "undecryptable row degrades to an empty key");
     }
 }


### PR DESCRIPTION
## Field failure

Sentry [ELECTRON-3T0](https://iofficeai.sentry.io/issues/137477235/) — AionUi 2.1.43 (aioncore 0.1.54, first boot running the user-scope migration): every stored credential failed with **"Decryption failed: invalid key or corrupted data"**. Custom model providers "disappeared" (list 400 ×32) and re-adding failed. Attachment forensics: migration 030 succeeded, the data and the persisted `jwt_secret` were intact, the previous version (0.1.52, two days of logs) decrypted everything fine — and the sqlx worker panicked with `index out of bounds: the len is 9 but the index is 9` on the first post-migration `users` read.

## Mechanism

Migration 030 DROP+rebuilds `users` (9 → 16 columns) on the same pool that then serves startup. A connection carrying pre-DDL state (sqlx per-connection statement cache / SQLite connection-level schema snapshot) mis-decoded the first `SELECT * FROM users …`; startup secret resolution saw "no system user", **silently generated a brand-new JWT secret** (unpersisted — the row "didn't exist"), derived the wrong AES key, and every credential written before failed to decrypt: provider API keys, channel bot configs, remote-agent credentials — plus WebUI JWT validation. Worse, credentials saved during the broken session were encrypted under that in-memory-only key, so they became permanently undecryptable after the next (self-healed) restart.

Honest reproducibility note: the window is timing/environment sensitive (the field case is Windows with a 26s migration on a large DB). We reproduced the exact failure once locally against a real v0.1.52-created database (same panic text, same error, rotated secret prefix), but could not make it deterministic on a fast macOS dev box — so no in-CI reproduction of the trigger itself. The fix removes the entire class regardless of timing.

## Fix (three layers)

1. **db**: after migrations complete, close the bootstrap pool and reconnect on a fresh pool before any business query — no pre-DDL connection state can leak into serving (`database.rs`).
2. **app**: generating a NEW jwt secret is only legitimate on a fresh install; if the read path claims "no system user" while the row exists (independent lookup), **fail startup** instead of silently rotating the key (`services.rs`).
3. **system**: provider list no longer fail-fasts on one undecryptable row — it degrades to an empty `api_key` with a warn log so already-affected users (scenario 2: credentials saved during a broken session) can see the row and re-enter the key (`provider.rs`).

## Tests

- `upgrade_encryption_survives.rs`: builds a genuine pre-user-scope DB (current migrations truncated at 028), stores a credential through the real encryption path, reopens through the real `init_database` (029+), asserts the secret is preserved and the credential decrypts. Locks the upgrade semantics.
- `undecryptable_api_key_degrades_to_empty_instead_of_failing_the_list`: scenario-2 regression.
- `open_repro_db.rs`: env-gated manual gold-standard probe against a real 0.1.52 database (skipped in CI).
- Targeted runs green (db/system/app), migration immutability passed, clippy clean; full suite on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)