### PR TITLE
fix(project): add temporary fs/resolve command for preview file paths

### DIFF
--- a/crates/aionui-project/src/monitor/actor_test.rs
+++ b/crates/aionui-project/src/monitor/actor_test.rs
@@ -271,6 +271,93 @@ async fn read_non_utf8_falls_back_to_base64() {
     assert!(!reply["result"]["content"].as_str().unwrap().is_empty());
 }
 
+// PATCH(ELECTRON-3SZ): tests for the temporary `fs/resolve` command. Remove
+// together with `handle_resolve` when preview no longer needs absolute paths.
+#[tokio::test]
+async fn resolve_existing_file_returns_absolute_and_workspace_root() {
+    let (mut actor, _rx, push, pe, dir, _db) = setup().await;
+    std::fs::write(dir.path().join("a.txt"), b"x").unwrap();
+
+    actor
+        .dispatch_frame(
+            "1",
+            "system_default_user",
+            request(40, "fs/resolve", json!({"file":dir_ref(&pe, "a.txt")})),
+        )
+        .await;
+    let reply = push.last_for("1").unwrap();
+    assert_eq!(reply["id"], 40);
+    let abs = reply["result"]["absolute_path"].as_str().unwrap();
+    let root = reply["result"]["workspace_root"].as_str().unwrap();
+    // Contract: absolute_path is the file under workspace_root. Asserted
+    // relationally (not against a hardcoded path) because the root carries the
+    // dedupe key's platform case-folding — the same folding fs/read uses.
+    assert!(!root.is_empty());
+    assert_eq!(
+        abs,
+        format!("{root}/a.txt"),
+        "absolute_path must be workspace_root + rel"
+    );
+    // The path is the same `absolute` PathBuf fs/read reads from, so it must open
+    // here too — proves resolve hands back a usable filesystem path.
+    assert_eq!(std::fs::read(abs).unwrap(), b"x");
+}
+
+#[tokio::test]
+async fn resolve_unknown_pe_is_out_of_scope() {
+    let (mut actor, _rx, push, _pe, _dir, _db) = setup().await;
+    actor
+        .dispatch_frame(
+            "1",
+            "system_default_user",
+            request(41, "fs/resolve", json!({"file":dir_ref("pe-nope", "a.txt")})),
+        )
+        .await;
+    let reply = push.last_for("1").unwrap();
+    assert_eq!(reply["error"]["code"], -32000);
+    assert_eq!(reply["error"]["message"], "out_of_scope");
+    assert_eq!(reply["error"]["data"]["pe_id"], "pe-nope");
+}
+
+#[tokio::test]
+async fn resolve_parent_escape_is_invalid_relative_path() {
+    let (mut actor, _rx, push, pe, _dir, _db) = setup().await;
+    actor
+        .dispatch_frame(
+            "1",
+            "system_default_user",
+            request(42, "fs/resolve", json!({"file":dir_ref(&pe, "../escape")})),
+        )
+        .await;
+    let reply = push.last_for("1").unwrap();
+    assert_eq!(reply["error"]["code"], -32004);
+    assert_eq!(reply["error"]["message"], "invalid_relative_path");
+}
+
+/// PATCH(ELECTRON-3SZ): resolve must run the same realpath containment guard as
+/// the other file commands — a symlink escaping the folder root is rejected
+/// before any path is handed back. Unix-only (symlink creation needs privilege
+/// on Windows); the `realpath_within` logic itself is platform-agnostic.
+#[cfg(unix)]
+#[tokio::test]
+async fn resolve_symlink_escape_is_resource_outside_folder() {
+    let (mut actor, _rx, push, pe, dir, _db) = setup().await;
+    let outside = tempfile::tempdir().unwrap();
+    std::fs::write(outside.path().join("secret.txt"), b"top secret").unwrap();
+    std::os::unix::fs::symlink(outside.path(), dir.path().join("link")).unwrap();
+
+    actor
+        .dispatch_frame(
+            "1",
+            "system_default_user",
+            request(44, "fs/resolve", json!({"file":dir_ref(&pe, "link/secret.txt")})),
+        )
+        .await;
+    let reply = push.last_for("1").unwrap();
+    assert_eq!(reply["error"]["code"], -32003);
+    assert_eq!(reply["error"]["message"], "resource_outside_folder");
+}
+
 #[tokio::test]
 async fn write_then_read_roundtrip() {
     let (mut actor, _rx, push, pe, _dir, _db) = setup().await;

--- a/crates/aionui-project/src/monitor/dispatch.rs
+++ b/crates/aionui-project/src/monitor/dispatch.rs
@@ -23,7 +23,7 @@ use crate::types::{FileOp, ReferenceInput, ResolvedResource};
 use super::actor::FsMonitorActor;
 use super::search::{self, ActiveSearch, SearchRoot};
 use super::wire::{
-    self, Encoding, InitializeParams, MkdirParams, ReadParams, RemoveParams, RenameParams, ResourceRef,
+    self, Encoding, InitializeParams, MkdirParams, ReadParams, RemoveParams, RenameParams, ResolveParams, ResourceRef,
     SearchCancelParams, SearchParams, SubscribeParams, UnsubscribeParams, WriteParams,
 };
 
@@ -50,6 +50,9 @@ impl FsMonitorActor {
             "fs/subscribe" => self.handle_subscribe(session, user_id, id, params).await,
             "fs/unsubscribe" => self.handle_unsubscribe(session, user_id, params).await,
             "fs/read" => self.handle_read(session, user_id, id, params).await,
+            // PATCH(ELECTRON-3SZ): remove with `handle_resolve` when preview no
+            // longer needs absolute paths (see handler doc).
+            "fs/resolve" => self.handle_resolve(session, user_id, id, params).await,
             "fs/write" => self.handle_write(session, user_id, id, params).await,
             "fs/mkdir" => self.handle_mkdir(session, user_id, id, params).await,
             "fs/remove" => self.handle_remove(session, user_id, id, params).await,
@@ -230,6 +233,84 @@ impl FsMonitorActor {
                 self.push(session, wire::error(id, code, message, ref_data(&p.file)));
             }
         }
+    }
+
+    /// PATCH(ELECTRON-3SZ): resolve `{pe_id, relative_path}` to the underlying
+    /// absolute path + the pe root's absolute path.
+    ///
+    /// This deliberately violates the pe_id identity boundary — the backend is
+    /// not supposed to expose absolute paths and the frontend is not supposed to
+    /// know them. It exists only as an emergency line fix so preview's office
+    /// (officecli watch needs an on-disk `file_path` + sandbox `workspace`) and
+    /// pdf (`file://` webview) viewers can render again after the project-scoped
+    /// Explorer stopped passing `file_path`. REMOVE this handler, its
+    /// `wire::ResolveParams` (and the `ResolveParams` name in this file's
+    /// `use super::wire::{…}` import), and the `fs/resolve` dispatch arm once
+    /// preview is redesigned to consume content over the wire.
+    ///
+    /// Reuses the same identity + realpath containment guard as the other file
+    /// commands (`FileOp::Read`); resolution is lexical (no read IO).
+    ///
+    /// `absolute_path` is `resolved.absolute_path` — the exact same `absolute`
+    /// PathBuf `fs/read` derives its `resource_uri` from (`containment.rs`:
+    /// `absolute` is computed once, then turned into both the read URI and this
+    /// string). So on any machine where `fs/read` opens the file, this path opens
+    /// it too — resolve introduces no new open-failure surface over read. (The
+    /// dedupe-key case-folding of the root — `canonical::IGNORE_PATH_CASING`,
+    /// macOS/Windows only, filename segment never folded — is shared with read,
+    /// so a case-sensitive-volume mismatch is a pre-existing whole-`fs/*` concern
+    /// tracked separately, NOT something this patch introduces.)
+    /// `workspace_root` is the pe root's absolute path (officecli sandbox needs it).
+    async fn handle_resolve(&mut self, session: &str, user_id: &str, id: Option<Value>, params: Value) {
+        let Ok(p) = serde_json::from_value::<ResolveParams>(params) else {
+            self.push(session, invalid_params(id));
+            return;
+        };
+        let resolved = match self.resolve_guarded(user_id, &p.file, FileOp::Read).await {
+            Ok(r) => r,
+            Err((code, message)) => {
+                self.push(session, wire::error(id, code, message, ref_data(&p.file)));
+                return;
+            }
+        };
+        // Non-file schemes carry no absolute path; treat as provider-unavailable.
+        // Unreachable with the current file-only provider (resolve_reference
+        // rejects non-file at canonicalize → unsupported_resource_scheme before
+        // here); kept as a defensive fail-closed.
+        let Some(absolute_path) = resolved.absolute_path.clone() else {
+            self.push(
+                session,
+                wire::error(
+                    id,
+                    wire::CODE_PROVIDER_UNAVAILABLE,
+                    "provider_unavailable",
+                    ref_data(&p.file),
+                ),
+            );
+            return;
+        };
+        let Ok(workspace_root) = canonical::uri_to_path(&resolved.root_resource_canonical) else {
+            self.push(
+                session,
+                wire::error(
+                    id,
+                    wire::CODE_PROVIDER_UNAVAILABLE,
+                    "provider_unavailable",
+                    ref_data(&p.file),
+                ),
+            );
+            return;
+        };
+        let workspace_root = workspace_root.to_string_lossy().into_owned();
+        // Log identity only — never the resolved absolute paths (sensitive).
+        tracing::info!(session, op = "resolve", pe_id = %p.file.pe_id, rel = %p.file.relative_path, "fs command ok");
+        self.push(
+            session,
+            wire::success(
+                id,
+                json!({ "absolute_path": absolute_path, "workspace_root": workspace_root }),
+            ),
+        );
     }
 
     async fn handle_write(&mut self, session: &str, user_id: &str, id: Option<Value>, params: Value) {

--- a/crates/aionui-project/src/monitor/wire.rs
+++ b/crates/aionui-project/src/monitor/wire.rs
@@ -92,6 +92,16 @@ pub struct ReadParams {
     pub encoding: Option<Encoding>,
 }
 
+// PATCH(ELECTRON-3SZ): `fs/resolve` params. Violates the pe_id identity boundary
+// (the backend must not expose absolute paths, the frontend must not know them).
+// Added only as an emergency line fix so preview's office/pdf viewers can obtain
+// an absolute `file_path`. REMOVE together with `handle_resolve` once preview is
+// redesigned to consume content over the wire.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ResolveParams {
+    pub file: ResourceRef,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct WriteParams {
     pub file: ResourceRef,


### PR DESCRIPTION
## What

Adds a temporary WebSocket command `fs/resolve` to the project monitor protocol, mapping a `{pe_id, relative_path}` reference to `{absolute_path, workspace_root}`.

- Reuses the same identity + realpath sandbox guard as the other file commands (`resolve_guarded`, `FileOp::Read`).
- `absolute_path` is the exact same `absolute` PathBuf `fs/read` derives its read URI from, so any file `fs/read` can open resolves here too — no new open-failure surface.
- `workspace_root` = the pe root's absolute path (officecli sandbox validation needs it).

## Why (ELECTRON-3SZ)

The project-scoped Explorer opens files by `{pe_id, relative_path}` and reads content over `fs/read`, but stopped passing an absolute `file_path`. Preview viewers that require a real on-disk path broke: **pdf** (`file://` webview) and **office** (officecli watch needs an on-disk `file_path` + sandbox `workspace`). This command lets the frontend obtain those paths again.

## ⚠️ Temporary patch

This deliberately violates the pe_id identity boundary (the backend should not expose absolute paths, the frontend should not know them). It exists only as an emergency line fix and is to be **removed entirely once preview is redesigned** to consume content over the wire.

- Every site is tagged `PATCH(ELECTRON-3SZ)` (grep to find them).
- `handle_resolve`'s doc comment carries explicit removal guidance (handler, `wire::ResolveParams`, the `ResolveParams` name in the dispatch `use`, and the `fs/resolve` dispatch arm).

## Paired PR

Frontend counterpart on the same-named branch `boii/fix/preview-explorer-filepath` in AionUi (Explorer `handleOpenFile` fix for the image/pdf/office viewers).

## Tests

- New: `fs/resolve` happy path (returns absolute + workspace_root, path opens), unknown pe → `out_of_scope`, `..` escape → `invalid_relative_path`, symlink escape → `resource_outside_folder`.
- `cargo test -p aionui-project` green; full `just push` gate (7920 tests) passed; clippy `-D warnings` and fmt clean.

## Merge order

- Paired frontend PR: https://github.com/iOfficeAI/AionUi/pull/3786
- **Merge this backend PR BEFORE the frontend #3786.** The frontend office/pdf preview depends on `fs/resolve`; if the frontend merges first while this is not yet in, office/pdf preview stays broken.
