### PR TITLE
fix(db): pre-migration repair for migration-030 startup-blocking CHECK failures

### DIFF
--- a/crates/aionui-db/src/database.rs
+++ b/crates/aionui-db/src/database.rs
@@ -363,6 +363,16 @@ async fn run_migrations_staged(pool: &SqlitePool) -> Result<(), DatabaseInitErro
         .await
         .map_err(|e| DatabaseInitError::new("database.migration", DbError::Query(e)))?;
 
+    // Idempotent pre-migration repair for migration 030 (`user_scope`): normalize
+    // benign historical inconsistencies so 030's fail-hard CHECK(ok=1) assertions
+    // do not abort startup (Sentry ELECTRON-31Z / ELECTRON-31X). No-op unless the
+    // gate (max applied version == 29) holds. Runs on the migrator's own
+    // connection, inside the caller's cross-process startup lock, with
+    // foreign_keys already OFF.
+    crate::migrate_repair::repair_user_scope_preconditions(&mut conn)
+        .await
+        .map_err(|e| DatabaseInitError::new("database.migration", e))?;
+
     let result = run_migrations_with_retry(&mut conn)
         .await
         .map_err(|e| DatabaseInitError::new("database.migration", e));

--- a/crates/aionui-db/src/lib.rs
+++ b/crates/aionui-db/src/lib.rs
@@ -6,6 +6,7 @@ mod database;
 mod error;
 mod instance_lock;
 mod legacy_handoff;
+mod migrate_repair;
 pub mod models;
 mod repository;
 

--- a/crates/aionui-db/src/migrate_repair.rs
+++ b/crates/aionui-db/src/migrate_repair.rs
@@ -69,7 +69,27 @@ async fn evaluate_user_scope_guards(
 
 /// (check_name, COUNT(*) query) pairs mirroring 030's guard predicates.
 /// Filled in by Task 2 (A-class) and Task 3 (C-class + system_settings).
-const GUARD_COUNT_QUERIES: &[(&str, &str)] = &[];
+const GUARD_COUNT_QUERIES: &[(&str, &str)] = &[
+    // --- A-class: orphan child rows (030_user_scope.sql:75-158, 787-810) ---
+    ("messages_orphaned_conversation",
+     "SELECT COUNT(*) FROM messages m WHERE NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = m.conversation_id)"),
+    ("conversation_artifacts_orphaned_conversation",
+     "SELECT COUNT(*) FROM conversation_artifacts a WHERE NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = a.conversation_id)"),
+    ("conversation_assistant_snapshots_orphaned_conversation",
+     "SELECT COUNT(*) FROM conversation_assistant_snapshots s WHERE NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = s.conversation_id)"),
+    ("acp_session_orphaned_conversation",
+     "SELECT COUNT(*) FROM acp_session s WHERE NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = s.conversation_id)"),
+    ("cron_jobs_orphaned_conversation",
+     "SELECT COUNT(*) FROM cron_jobs j WHERE COALESCE(j.conversation_id,'') <> '' AND NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = j.conversation_id)"),
+    ("mailbox_orphaned_team",
+     "SELECT COUNT(*) FROM mailbox m WHERE NOT EXISTS (SELECT 1 FROM teams t WHERE t.id = m.team_id)"),
+    ("team_tasks_orphaned_team",
+     "SELECT COUNT(*) FROM team_tasks tt WHERE NOT EXISTS (SELECT 1 FROM teams t WHERE t.id = tt.team_id)"),
+    ("assistant_sessions_missing_owner",
+     "SELECT COUNT(*) FROM assistant_sessions s WHERE NOT EXISTS (SELECT 1 FROM assistant_users u WHERE u.id = s.user_id)"),
+    ("assistant_sessions_orphaned_conversation",
+     "SELECT COUNT(*) FROM assistant_sessions s WHERE s.conversation_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = s.conversation_id)"),
+];
 
 /// Gate → preflight (log names+counts) → idempotent repair. No-op off-gate.
 pub(crate) async fn repair_user_scope_preconditions(
@@ -100,9 +120,43 @@ pub(crate) async fn repair_user_scope_preconditions(
     Ok(())
 }
 
-/// Apply the idempotent repairs. Filled in by Task 2 (A-class) and Task 3
-/// (C-class + system_settings).
-async fn apply_user_scope_repairs(_conn: &mut sqlx::SqliteConnection) -> Result<(), DbError> {
+/// Apply the idempotent repairs. Extended by Task 3 (C-class + system_settings).
+async fn apply_user_scope_repairs(conn: &mut sqlx::SqliteConnection) -> Result<(), DbError> {
+    // A-class deletes — orphan child rows whose parent no longer exists.
+    // Order: delete ownerless sessions BEFORE nulling orphan-conversation
+    // sessions so we don't null a session we are about to delete anyway.
+    for delete_sql in [
+        "DELETE FROM messages WHERE NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = messages.conversation_id)",
+        "DELETE FROM conversation_artifacts WHERE NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = conversation_artifacts.conversation_id)",
+        "DELETE FROM conversation_assistant_snapshots WHERE NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = conversation_assistant_snapshots.conversation_id)",
+        "DELETE FROM acp_session WHERE NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = acp_session.conversation_id)",
+        "DELETE FROM mailbox WHERE NOT EXISTS (SELECT 1 FROM teams t WHERE t.id = mailbox.team_id)",
+        "DELETE FROM team_tasks WHERE NOT EXISTS (SELECT 1 FROM teams t WHERE t.id = team_tasks.team_id)",
+        "DELETE FROM assistant_sessions WHERE NOT EXISTS (SELECT 1 FROM assistant_users u WHERE u.id = assistant_sessions.user_id)",
+    ] {
+        sqlx::query(delete_sql).execute(&mut *conn).await.map_err(DbError::Query)?;
+    }
+
+    // A-class FK-null normalization — preserve user-created top-level assets.
+    // cron_jobs: guard tolerates '' and NULL; use '' (codebase unanchored sentinel).
+    sqlx::query(
+        "UPDATE cron_jobs SET conversation_id = '' \
+         WHERE COALESCE(conversation_id,'') <> '' \
+           AND NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = cron_jobs.conversation_id)",
+    )
+    .execute(&mut *conn)
+    .await
+    .map_err(DbError::Query)?;
+    // assistant_sessions: guard checks IS NOT NULL, so must be NULL (not '').
+    sqlx::query(
+        "UPDATE assistant_sessions SET conversation_id = NULL \
+         WHERE conversation_id IS NOT NULL \
+           AND NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = assistant_sessions.conversation_id)",
+    )
+    .execute(&mut *conn)
+    .await
+    .map_err(DbError::Query)?;
+
     Ok(())
 }
 
@@ -154,5 +208,96 @@ mod tests {
         let mut c2 = conn().await;
         seed_sqlx_migrations(&mut c2, 30).await;
         assert!(!should_run_user_scope_repair(&mut c2).await.unwrap());
+    }
+
+    async fn create_min_v29_aggregate_tables(c: &mut sqlx::SqliteConnection) {
+        for ddl in [
+            "CREATE TABLE conversations (id TEXT PRIMARY KEY, user_id TEXT)",
+            "CREATE TABLE teams (id TEXT PRIMARY KEY)",
+            "CREATE TABLE assistant_users (id TEXT PRIMARY KEY)",
+            "CREATE TABLE messages (id TEXT PRIMARY KEY, conversation_id TEXT)",
+            "CREATE TABLE conversation_artifacts (id TEXT PRIMARY KEY, conversation_id TEXT)",
+            "CREATE TABLE conversation_assistant_snapshots (conversation_id TEXT)",
+            "CREATE TABLE acp_session (conversation_id TEXT)",
+            "CREATE TABLE cron_jobs (id TEXT PRIMARY KEY, conversation_id TEXT)",
+            "CREATE TABLE mailbox (id TEXT PRIMARY KEY, team_id TEXT)",
+            "CREATE TABLE team_tasks (id TEXT PRIMARY KEY, team_id TEXT)",
+            "CREATE TABLE assistant_sessions (id TEXT PRIMARY KEY, user_id TEXT, conversation_id TEXT)",
+        ] {
+            sqlx::query(ddl).execute(&mut *c).await.unwrap();
+        }
+        sqlx::query("INSERT INTO conversations (id, user_id) VALUES ('c1','system_default_user')").execute(&mut *c).await.unwrap();
+        sqlx::query("INSERT INTO teams (id) VALUES ('t1')").execute(&mut *c).await.unwrap();
+        sqlx::query("INSERT INTO assistant_users (id) VALUES ('u1')").execute(&mut *c).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_class_deletes_orphans_and_keeps_valid() {
+        let mut c = conn().await;
+        create_min_v29_aggregate_tables(&mut c).await;
+        // valid + orphan messages
+        sqlx::query("INSERT INTO messages (id, conversation_id) VALUES ('m_ok','c1'),('m_orphan','missing')")
+            .execute(&mut c).await.unwrap();
+        sqlx::query("INSERT INTO mailbox (id, team_id) VALUES ('mb_ok','t1'),('mb_orphan','missing')")
+            .execute(&mut c).await.unwrap();
+        sqlx::query("INSERT INTO assistant_sessions (id, user_id, conversation_id) VALUES ('s_noowner','missing',NULL)")
+            .execute(&mut c).await.unwrap();
+
+        apply_user_scope_repairs(&mut c).await.unwrap();
+
+        let msgs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM messages").fetch_one(&mut c).await.unwrap();
+        assert_eq!(msgs, 1, "orphan message deleted, valid kept");
+        let mbs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM mailbox").fetch_one(&mut c).await.unwrap();
+        assert_eq!(mbs, 1, "orphan mailbox deleted, valid kept");
+        let sess: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM assistant_sessions").fetch_one(&mut c).await.unwrap();
+        assert_eq!(sess, 0, "ownerless session deleted");
+    }
+
+    #[tokio::test]
+    async fn a_class_nulls_fk_for_top_level_assets() {
+        let mut c = conn().await;
+        create_min_v29_aggregate_tables(&mut c).await;
+        sqlx::query("INSERT INTO cron_jobs (id, conversation_id) VALUES ('j_orphan','missing')")
+            .execute(&mut c).await.unwrap();
+        sqlx::query("INSERT INTO assistant_sessions (id, user_id, conversation_id) VALUES ('s_orphanconv','u1','missing')")
+            .execute(&mut c).await.unwrap();
+
+        apply_user_scope_repairs(&mut c).await.unwrap();
+
+        let cron_conv: String = sqlx::query_scalar("SELECT conversation_id FROM cron_jobs WHERE id='j_orphan'")
+            .fetch_one(&mut c).await.unwrap();
+        assert_eq!(cron_conv, "", "cron job preserved, conversation_id emptied");
+        let cron_kept: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM cron_jobs WHERE id='j_orphan'")
+            .fetch_one(&mut c).await.unwrap();
+        assert_eq!(cron_kept, 1, "cron job row preserved");
+        let sess_conv: Option<String> =
+            sqlx::query_scalar("SELECT conversation_id FROM assistant_sessions WHERE id='s_orphanconv'")
+                .fetch_one(&mut c).await.unwrap();
+        assert_eq!(sess_conv, None, "session preserved, conversation_id nulled");
+    }
+
+    #[tokio::test]
+    async fn a_class_repair_is_idempotent() {
+        let mut c = conn().await;
+        create_min_v29_aggregate_tables(&mut c).await;
+        sqlx::query("INSERT INTO messages (id, conversation_id) VALUES ('m_orphan','missing')")
+            .execute(&mut c).await.unwrap();
+        apply_user_scope_repairs(&mut c).await.unwrap();
+        apply_user_scope_repairs(&mut c).await.unwrap(); // second run must be a no-op
+        let msgs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM messages").fetch_one(&mut c).await.unwrap();
+        assert_eq!(msgs, 0);
+    }
+
+    #[tokio::test]
+    async fn preflight_names_the_specific_violated_check() {
+        let mut c = conn().await;
+        create_min_v29_aggregate_tables(&mut c).await;
+        sqlx::query("INSERT INTO messages (id, conversation_id) VALUES ('m_orphan','missing')")
+            .execute(&mut c).await.unwrap();
+        let violations = evaluate_user_scope_guards(&mut c).await.unwrap();
+        assert!(
+            violations.iter().any(|v| v.check == "messages_orphaned_conversation" && v.count == 1),
+            "preflight must pinpoint the specific check by name + count, got {violations:?}"
+        );
     }
 }

--- a/crates/aionui-db/src/migrate_repair.rs
+++ b/crates/aionui-db/src/migrate_repair.rs
@@ -56,15 +56,47 @@ async fn evaluate_user_scope_guards(
 ) -> Result<Vec<GuardViolation>, DbError> {
     let mut violations = Vec::new();
     for (check, count_sql) in GUARD_COUNT_QUERIES {
-        let count: i64 = sqlx::query_scalar(count_sql)
-            .fetch_one(&mut *conn)
-            .await
-            .map_err(DbError::Query)?;
-        if count > 0 {
-            violations.push(GuardViolation { check, count });
+        match sqlx::query_scalar::<_, i64>(count_sql).fetch_one(&mut *conn).await {
+            Ok(count) => {
+                if count > 0 {
+                    violations.push(GuardViolation { check, count });
+                }
+            }
+            // A guard whose table/column is absent in this schema cannot be
+            // violated (the object it protects does not exist yet). On a real
+            // v29 database every referenced object exists (migrations 001–029),
+            // so this only skips guards on isolated unit-test schemas.
+            Err(e) if is_missing_object_error(&e) => continue,
+            Err(e) => return Err(DbError::Query(e)),
         }
     }
     Ok(violations)
+}
+
+/// True when a SQLite error reports a missing schema object (the table or column
+/// a guard/repair references does not exist in the current schema). On a genuine
+/// v29 database every referenced object exists (migrations 001–029), so this
+/// only lets the repair skip statements on isolated unit-test schemas that
+/// create a subset of tables; production behavior is unchanged.
+fn is_missing_object_error(err: &sqlx::Error) -> bool {
+    match err.as_database_error() {
+        Some(db) => {
+            let message = db.message().to_ascii_lowercase();
+            message.contains("no such table") || message.contains("no such column")
+        }
+        None => false,
+    }
+}
+
+/// Execute one idempotent repair statement, tolerating a missing-object error
+/// (the statement is not applicable to the current schema). See
+/// [`is_missing_object_error`].
+async fn exec_repair(conn: &mut sqlx::SqliteConnection, sql: &str) -> Result<(), DbError> {
+    match sqlx::query(sql).execute(&mut *conn).await {
+        Ok(_) => Ok(()),
+        Err(e) if is_missing_object_error(&e) => Ok(()),
+        Err(e) => Err(DbError::Query(e)),
+    }
 }
 
 /// (check_name, COUNT(*) query) pairs mirroring 030's guard predicates.
@@ -89,6 +121,27 @@ const GUARD_COUNT_QUERIES: &[(&str, &str)] = &[
      "SELECT COUNT(*) FROM assistant_sessions s WHERE NOT EXISTS (SELECT 1 FROM assistant_users u WHERE u.id = s.user_id)"),
     ("assistant_sessions_orphaned_conversation",
      "SELECT COUNT(*) FROM assistant_sessions s WHERE s.conversation_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = s.conversation_id)"),
+    // --- C-class: duplicate composite-UNIQUE identities (030:225-263, 741-783) ---
+    ("mcp_servers_duplicate_scope_name",
+     "SELECT COUNT(*) FROM mcp_servers WHERE rowid NOT IN \
+        (SELECT MIN(rowid) FROM mcp_servers GROUP BY name)"),
+    ("assistant_users_duplicate_identity",
+     "SELECT COUNT(*) FROM assistant_users WHERE rowid NOT IN \
+        (SELECT MIN(rowid) FROM assistant_users GROUP BY platform_user_id, platform_type)"),
+    // --- L4: system_settings row not keyed at id=1 would be dropped by 030 (030:318) ---
+    ("system_settings_non_primary_id",
+     "SELECT COUNT(*) FROM system_settings WHERE (SELECT COUNT(*) FROM system_settings) = 1 AND id <> 1"),
+    // --- B-class (DIAGNOSTIC-ONLY, no active repair): assistant_sessions cross-scope owner (030:812-824). ---
+    // 030 forces assistant_users.owner_user_id='system_default_user' (030:768) but never normalizes
+    // conversations.user_id, so 030's `c.user_id != u.owner_user_id` guard fails for a session-linked
+    // conversation whose user_id <> 'system_default_user'. Data-dependent (spec §7.1 "不得假设一定为空"):
+    // must be NAMED if it fires (spec §10 item 6 "含前置修复未覆盖的形态", §6 目标 5), even though this fix
+    // performs NO active repair for it (spec §7.1 B "覆盖到即可" is soft; §7.1 L3 diagnose-if-uncovered).
+    ("assistant_sessions_cross_scope_owner",
+     "SELECT COUNT(*) FROM assistant_sessions s \
+        JOIN assistant_users u ON u.id = s.user_id \
+        JOIN conversations c ON c.id = s.conversation_id \
+        WHERE s.conversation_id IS NOT NULL AND c.user_id <> 'system_default_user'"),
 ];
 
 /// Gate → preflight (log names+counts) → idempotent repair. No-op off-gate.
@@ -120,7 +173,11 @@ pub(crate) async fn repair_user_scope_preconditions(
     Ok(())
 }
 
-/// Apply the idempotent repairs. Extended by Task 3 (C-class + system_settings).
+/// Apply the idempotent repairs (A-class orphan cleanup / FK-null + C-class
+/// dedup + system_settings id normalization). Every statement goes through
+/// [`exec_repair`], so a statement referencing a table/column absent from the
+/// current schema is skipped as not-applicable (see [`is_missing_object_error`]).
+/// On a real v29 database every referenced object exists, so nothing is skipped.
 async fn apply_user_scope_repairs(conn: &mut sqlx::SqliteConnection) -> Result<(), DbError> {
     // A-class deletes — orphan child rows whose parent no longer exists.
     // Order: delete ownerless sessions BEFORE nulling orphan-conversation
@@ -134,28 +191,93 @@ async fn apply_user_scope_repairs(conn: &mut sqlx::SqliteConnection) -> Result<(
         "DELETE FROM team_tasks WHERE NOT EXISTS (SELECT 1 FROM teams t WHERE t.id = team_tasks.team_id)",
         "DELETE FROM assistant_sessions WHERE NOT EXISTS (SELECT 1 FROM assistant_users u WHERE u.id = assistant_sessions.user_id)",
     ] {
-        sqlx::query(delete_sql).execute(&mut *conn).await.map_err(DbError::Query)?;
+        exec_repair(conn, delete_sql).await?;
     }
 
     // A-class FK-null normalization — preserve user-created top-level assets.
     // cron_jobs: guard tolerates '' and NULL; use '' (codebase unanchored sentinel).
-    sqlx::query(
+    exec_repair(
+        conn,
         "UPDATE cron_jobs SET conversation_id = '' \
          WHERE COALESCE(conversation_id,'') <> '' \
            AND NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = cron_jobs.conversation_id)",
     )
-    .execute(&mut *conn)
-    .await
-    .map_err(DbError::Query)?;
+    .await?;
     // assistant_sessions: guard checks IS NOT NULL, so must be NULL (not '').
-    sqlx::query(
+    exec_repair(
+        conn,
         "UPDATE assistant_sessions SET conversation_id = NULL \
          WHERE conversation_id IS NOT NULL \
            AND NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = assistant_sessions.conversation_id)",
     )
-    .execute(&mut *conn)
-    .await
-    .map_err(DbError::Query)?;
+    .await?;
+
+    // C-class dedup — keep the most-recently-updated row per composite-UNIQUE
+    // key so 030's full-table rebuild INSERT does not hit UNIQUE(user_id,name)
+    // / UNIQUE(owner_user_id,platform_user_id,platform_type). (030:241, 763.)
+    // mcp_servers: all legacy rows get user_id=system_default_user in 030, so
+    // the effective collision key here is `name`.
+    exec_repair(
+        conn,
+        "DELETE FROM mcp_servers WHERE rowid NOT IN ( \
+             SELECT rowid FROM ( \
+                 SELECT rowid, ROW_NUMBER() OVER ( \
+                     PARTITION BY name ORDER BY COALESCE(updated_at, 0) DESC, rowid DESC \
+                 ) AS rn FROM mcp_servers \
+             ) WHERE rn = 1 \
+         )",
+    )
+    .await?;
+
+    // assistant_users: collision key is (platform_user_id, platform_type).
+    // Re-point dependent sessions from removed duplicates to the kept row so
+    // no valid session is orphaned, THEN delete the duplicates.
+    exec_repair(
+        conn,
+        "UPDATE assistant_sessions SET user_id = ( \
+             SELECT keep.id FROM assistant_users keep \
+             JOIN assistant_users dup ON dup.id = assistant_sessions.user_id \
+                AND keep.platform_user_id IS dup.platform_user_id \
+                AND keep.platform_type IS dup.platform_type \
+             WHERE keep.rowid = ( \
+                 SELECT k2.rowid FROM assistant_users k2 \
+                 WHERE k2.platform_user_id IS dup.platform_user_id \
+                   AND k2.platform_type IS dup.platform_type \
+                 ORDER BY COALESCE(k2.authorized_at,0) DESC, k2.rowid DESC LIMIT 1 \
+             ) \
+         ) \
+         WHERE EXISTS ( \
+             SELECT 1 FROM assistant_users dup WHERE dup.id = assistant_sessions.user_id \
+               AND dup.rowid <> ( \
+                 SELECT k3.rowid FROM assistant_users k3 \
+                 WHERE k3.platform_user_id IS dup.platform_user_id \
+                   AND k3.platform_type IS dup.platform_type \
+                 ORDER BY COALESCE(k3.authorized_at,0) DESC, k3.rowid DESC LIMIT 1 \
+               ) \
+         )",
+    )
+    .await?;
+    exec_repair(
+        conn,
+        "DELETE FROM assistant_users WHERE rowid NOT IN ( \
+             SELECT rowid FROM ( \
+                 SELECT rowid, ROW_NUMBER() OVER ( \
+                     PARTITION BY platform_user_id, platform_type \
+                     ORDER BY COALESCE(authorized_at,0) DESC, rowid DESC \
+                 ) AS rn FROM assistant_users \
+             ) WHERE rn = 1 \
+         )",
+    )
+    .await?;
+
+    // L4: if exactly one system_settings row exists and it is not id=1, 030's
+    // `INSERT ... WHERE id = 1` would silently drop it. Promote it to id=1.
+    exec_repair(
+        conn,
+        "UPDATE system_settings SET id = 1 \
+         WHERE (SELECT COUNT(*) FROM system_settings) = 1 AND id <> 1",
+    )
+    .await?;
 
     Ok(())
 }
@@ -299,5 +421,83 @@ mod tests {
             violations.iter().any(|v| v.check == "messages_orphaned_conversation" && v.count == 1),
             "preflight must pinpoint the specific check by name + count, got {violations:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn c_class_dedupes_mcp_servers_by_scope_name() {
+        let mut c = conn().await;
+        sqlx::query("CREATE TABLE mcp_servers (id TEXT PRIMARY KEY, name TEXT, updated_at INTEGER)")
+            .execute(&mut c).await.unwrap();
+        // Two rows share name; keep the most-recently-updated.
+        sqlx::query("INSERT INTO mcp_servers (id, name, updated_at) VALUES ('old','dup',10),('new','dup',20),('solo','unique',5)")
+            .execute(&mut c).await.unwrap();
+
+        apply_user_scope_repairs(&mut c).await.unwrap();
+
+        let kept: Vec<String> = sqlx::query_scalar("SELECT id FROM mcp_servers ORDER BY id")
+            .fetch_all(&mut c).await.unwrap();
+        assert_eq!(kept, vec!["new".to_string(), "solo".to_string()], "duplicate name deduped, newest kept");
+    }
+
+    #[tokio::test]
+    async fn c_class_dedupes_assistant_users_and_repoints_sessions() {
+        let mut c = conn().await;
+        sqlx::query("CREATE TABLE assistant_users (id TEXT PRIMARY KEY, platform_user_id TEXT, platform_type TEXT, authorized_at INTEGER)")
+            .execute(&mut c).await.unwrap();
+        sqlx::query("CREATE TABLE assistant_sessions (id TEXT PRIMARY KEY, user_id TEXT, conversation_id TEXT)")
+            .execute(&mut c).await.unwrap();
+        sqlx::query("INSERT INTO assistant_users (id, platform_user_id, platform_type, authorized_at) VALUES ('au_old','p','telegram',10),('au_new','p','telegram',20)")
+            .execute(&mut c).await.unwrap();
+        sqlx::query("INSERT INTO assistant_sessions (id, user_id, conversation_id) VALUES ('sess','au_old',NULL)")
+            .execute(&mut c).await.unwrap();
+
+        apply_user_scope_repairs(&mut c).await.unwrap();
+
+        let users: Vec<String> = sqlx::query_scalar("SELECT id FROM assistant_users").fetch_all(&mut c).await.unwrap();
+        assert_eq!(users, vec!["au_new".to_string()], "duplicate identity deduped, newest kept");
+        let sess_owner: String = sqlx::query_scalar("SELECT user_id FROM assistant_sessions WHERE id='sess'")
+            .fetch_one(&mut c).await.unwrap();
+        assert_eq!(sess_owner, "au_new", "session re-pointed to kept owner (not orphaned)");
+    }
+
+    #[tokio::test]
+    async fn c_class_promotes_lone_system_settings_row_to_id_1() {
+        let mut c = conn().await;
+        sqlx::query("CREATE TABLE system_settings (id INTEGER PRIMARY KEY, language TEXT, updated_at INTEGER)")
+            .execute(&mut c).await.unwrap();
+        sqlx::query("INSERT INTO system_settings (id, language, updated_at) VALUES (5,'zh-CN',1)")
+            .execute(&mut c).await.unwrap();
+
+        apply_user_scope_repairs(&mut c).await.unwrap();
+
+        let id: i64 = sqlx::query_scalar("SELECT id FROM system_settings").fetch_one(&mut c).await.unwrap();
+        assert_eq!(id, 1, "lone settings row promoted to id=1 so 030 WHERE id=1 copy preserves it");
+    }
+
+    #[tokio::test]
+    async fn preflight_names_uncovered_cross_scope_guard() {
+        // spec §10 item 6: a DELIBERATELY-UNCOVERED (B-class) guard failure must still be NAMED.
+        let mut c = conn().await;
+        create_min_v29_aggregate_tables(&mut c).await;
+        // A conversation owned by a non-default user, linked by a session with a valid owner.
+        sqlx::query("INSERT INTO conversations (id, user_id) VALUES ('c_other','user-abc')")
+            .execute(&mut c).await.unwrap();
+        sqlx::query("INSERT INTO assistant_sessions (id, user_id, conversation_id) VALUES ('s_x','u1','c_other')")
+            .execute(&mut c).await.unwrap();
+
+        let violations = evaluate_user_scope_guards(&mut c).await.unwrap();
+        assert!(
+            violations.iter().any(|v| v.check == "assistant_sessions_cross_scope_owner" && v.count == 1),
+            "uncovered cross-scope guard must be named in the preflight, got {violations:?}"
+        );
+
+        // B-class is diagnostic-only: apply_user_scope_repairs must NOT mutate it away.
+        apply_user_scope_repairs(&mut c).await.unwrap();
+        let still: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM assistant_sessions s JOIN conversations c ON c.id = s.conversation_id \
+             WHERE c.user_id <> 'system_default_user'",
+        )
+        .fetch_one(&mut c).await.unwrap();
+        assert_eq!(still, 1, "B-class cross-scope divergence is named but not repaired in this fix");
     }
 }

--- a/crates/aionui-db/src/migrate_repair.rs
+++ b/crates/aionui-db/src/migrate_repair.rs
@@ -172,24 +172,55 @@ pub(crate) async fn repair_user_scope_preconditions(conn: &mut sqlx::SqliteConne
         return Ok(());
     }
 
+    // Pre-repair preflight: record which named invariants are violated (check
+    // name + offending-row count only, never row content) so the field-observed
+    // dirty-data distribution is captured before we touch anything.
     let violations = evaluate_user_scope_guards(conn).await?;
     if violations.is_empty() {
         info!(
             migration = USER_SCOPE_MIGRATION_VERSION,
             "user_scope pre-migration preflight: no invariant violations detected"
         );
+        // Nothing to repair; the repair statements are strict no-ops here. Skip
+        // the post-repair re-check to avoid emitting a redundant log line.
+        apply_user_scope_repairs(conn).await?;
+        return Ok(());
+    }
+    for v in &violations {
+        warn!(
+            migration = USER_SCOPE_MIGRATION_VERSION,
+            check = v.check,
+            count = v.count,
+            "user_scope pre-migration preflight detected an invariant violation"
+        );
+    }
+
+    apply_user_scope_repairs(conn).await?;
+
+    // Post-repair re-check: re-evaluate the same invariants so a subsequent 030
+    // failure can be attributed to a specific STILL-violated guard (the
+    // diagnostic-only B-class cross-scope owner, or a form the repair did not
+    // fully cover) instead of 030's generic `CHECK constraint failed: ok = 1`.
+    // This closes the "repaired vs. never-covered" ambiguity the pre-check alone
+    // cannot resolve: a residual named here is exactly what will trip 030 next.
+    // Reuses the same COUNT queries; runs once, on the gated upgrade only. Check
+    // names + counts only (production logging rule; no user row content).
+    let residual = evaluate_user_scope_guards(conn).await?;
+    if residual.is_empty() {
+        info!(
+            migration = USER_SCOPE_MIGRATION_VERSION,
+            "user_scope pre-migration repair: all detected invariant violations cleared"
+        );
     } else {
-        for v in &violations {
+        for v in &residual {
             warn!(
                 migration = USER_SCOPE_MIGRATION_VERSION,
                 check = v.check,
                 count = v.count,
-                "user_scope pre-migration preflight detected an invariant violation"
+                "user_scope invariant still violated after repair; migration 030 may fail"
             );
         }
     }
-
-    apply_user_scope_repairs(conn).await?;
     Ok(())
 }
 
@@ -569,6 +600,54 @@ mod tests {
         assert_eq!(
             id, 1,
             "lone settings row promoted to id=1 so 030 WHERE id=1 copy preserves it"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_repair_recheck_reports_residual_after_clearing_repaired_guards() {
+        // The post-repair re-check re-evaluates the same guards after repair so a
+        // residual (e.g. diagnostic-only B-class) stays attributable while a
+        // repaired A-class guard reads clean. This asserts that exact sequence —
+        // the logic the "still violated after repair" warn / "all cleared" info
+        // lines report — without needing a log-capture harness.
+        let mut c = conn().await;
+        create_min_v29_aggregate_tables(&mut c).await;
+        // A-class orphan (repaired) + B-class cross-scope session (diagnostic-only).
+        sqlx::query("INSERT INTO messages (id, conversation_id) VALUES ('m_orphan','missing')")
+            .execute(&mut c)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO conversations (id, user_id) VALUES ('c_other','user-abc')")
+            .execute(&mut c)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO assistant_sessions (id, user_id, conversation_id) VALUES ('s_x','u1','c_other')")
+            .execute(&mut c)
+            .await
+            .unwrap();
+
+        let pre = evaluate_user_scope_guards(&mut c).await.unwrap();
+        assert!(
+            pre.iter().any(|v| v.check == "messages_orphaned_conversation"),
+            "A-class orphan must be detected pre-repair, got {pre:?}"
+        );
+        assert!(
+            pre.iter().any(|v| v.check == "assistant_sessions_cross_scope_owner"),
+            "B-class must be detected pre-repair, got {pre:?}"
+        );
+
+        apply_user_scope_repairs(&mut c).await.unwrap();
+
+        let residual = evaluate_user_scope_guards(&mut c).await.unwrap();
+        assert!(
+            !residual.iter().any(|v| v.check == "messages_orphaned_conversation"),
+            "repaired A-class orphan must NOT appear in the post-repair residual, got {residual:?}"
+        );
+        assert!(
+            residual
+                .iter()
+                .any(|v| v.check == "assistant_sessions_cross_scope_owner" && v.count == 1),
+            "diagnostic-only B-class must remain a named residual after repair, got {residual:?}"
         );
     }
 

--- a/crates/aionui-db/src/migrate_repair.rs
+++ b/crates/aionui-db/src/migrate_repair.rs
@@ -1,0 +1,158 @@
+//! Idempotent pre-migration repair for migration 030 (`user_scope`).
+//!
+//! Migration 030 asserts several data-integrity invariants via fail-hard
+//! `CHECK (ok = 1)` temp tables. Historical local databases can carry benign
+//! inconsistencies (orphan child rows, duplicate identities) that older
+//! versions tolerated; those trip the assertions and abort startup with
+//! SQLite error 275, permanently blocking the app (Sentry ELECTRON-31Z /
+//! ELECTRON-31X).
+//!
+//! We cannot rewrite the shipped 030 (sqlx checksum / VersionMismatch) and a
+//! forward catch-up migration cannot run (the migrator stops at the first
+//! failing migration), so we normalize the raw database to satisfy 030's
+//! invariants *before* the migrator runs 030 — reusing the migrator's
+//! connection and the caller's cross-process startup lock.
+
+use tracing::{info, warn};
+
+use crate::error::DbError;
+
+/// The migration this repair prepares for.
+pub(crate) const USER_SCOPE_MIGRATION_VERSION: i64 = 30;
+
+/// One violated invariant: a stable check name plus the count of offending
+/// rows. Never carries user row content (production logging rule).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GuardViolation {
+    pub check: &'static str,
+    pub count: i64,
+}
+
+/// True iff migrations 001–029 are all applied and 030 is the next pending
+/// migration (`max applied version == 29`). Returns false when the
+/// `_sqlx_migrations` table does not exist (fresh install) — spec §7 H1.
+async fn should_run_user_scope_repair(conn: &mut sqlx::SqliteConnection) -> Result<bool, DbError> {
+    let has_table: bool = sqlx::query_scalar(
+        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type = 'table' AND name = '_sqlx_migrations'",
+    )
+    .fetch_one(&mut *conn)
+    .await
+    .map_err(DbError::Query)?;
+    if !has_table {
+        return Ok(false);
+    }
+    let max_version: Option<i64> =
+        sqlx::query_scalar("SELECT MAX(version) FROM _sqlx_migrations WHERE success = 1")
+            .fetch_one(&mut *conn)
+            .await
+            .map_err(DbError::Query)?;
+    Ok(max_version == Some(USER_SCOPE_MIGRATION_VERSION - 1))
+}
+
+/// Evaluate every named 030 invariant on the raw (pre-030) schema and return
+/// the violated ones with counts. Task 2/3 fills in the guard list.
+async fn evaluate_user_scope_guards(
+    conn: &mut sqlx::SqliteConnection,
+) -> Result<Vec<GuardViolation>, DbError> {
+    let mut violations = Vec::new();
+    for (check, count_sql) in GUARD_COUNT_QUERIES {
+        let count: i64 = sqlx::query_scalar(count_sql)
+            .fetch_one(&mut *conn)
+            .await
+            .map_err(DbError::Query)?;
+        if count > 0 {
+            violations.push(GuardViolation { check, count });
+        }
+    }
+    Ok(violations)
+}
+
+/// (check_name, COUNT(*) query) pairs mirroring 030's guard predicates.
+/// Filled in by Task 2 (A-class) and Task 3 (C-class + system_settings).
+const GUARD_COUNT_QUERIES: &[(&str, &str)] = &[];
+
+/// Gate → preflight (log names+counts) → idempotent repair. No-op off-gate.
+pub(crate) async fn repair_user_scope_preconditions(
+    conn: &mut sqlx::SqliteConnection,
+) -> Result<(), DbError> {
+    if !should_run_user_scope_repair(conn).await? {
+        return Ok(());
+    }
+
+    let violations = evaluate_user_scope_guards(conn).await?;
+    if violations.is_empty() {
+        info!(
+            migration = USER_SCOPE_MIGRATION_VERSION,
+            "user_scope pre-migration preflight: no invariant violations detected"
+        );
+    } else {
+        for v in &violations {
+            warn!(
+                migration = USER_SCOPE_MIGRATION_VERSION,
+                check = v.check,
+                count = v.count,
+                "user_scope pre-migration preflight detected an invariant violation"
+            );
+        }
+    }
+
+    apply_user_scope_repairs(conn).await?;
+    Ok(())
+}
+
+/// Apply the idempotent repairs. Filled in by Task 2 (A-class) and Task 3
+/// (C-class + system_settings).
+async fn apply_user_scope_repairs(_conn: &mut sqlx::SqliteConnection) -> Result<(), DbError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::Connection;
+
+    async fn conn() -> sqlx::SqliteConnection {
+        sqlx::SqliteConnection::connect("sqlite::memory:").await.unwrap()
+    }
+
+    async fn seed_sqlx_migrations(c: &mut sqlx::SqliteConnection, max_version: i64) {
+        sqlx::query(
+            "CREATE TABLE _sqlx_migrations (version BIGINT PRIMARY KEY, description TEXT, \
+             installed_on TIMESTAMP, success BOOLEAN, checksum BLOB, execution_time BIGINT)",
+        )
+        .execute(&mut *c)
+        .await
+        .unwrap();
+        for v in 1..=max_version {
+            sqlx::query("INSERT INTO _sqlx_migrations (version, success) VALUES (?, 1)")
+                .bind(v)
+                .execute(&mut *c)
+                .await
+                .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn gate_false_when_no_migrations_table() {
+        let mut c = conn().await;
+        assert!(!should_run_user_scope_repair(&mut c).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn gate_true_at_version_29() {
+        let mut c = conn().await;
+        seed_sqlx_migrations(&mut c, 29).await;
+        assert!(should_run_user_scope_repair(&mut c).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn gate_false_at_version_28_and_30() {
+        let mut c = conn().await;
+        seed_sqlx_migrations(&mut c, 28).await;
+        assert!(!should_run_user_scope_repair(&mut c).await.unwrap());
+
+        let mut c2 = conn().await;
+        seed_sqlx_migrations(&mut c2, 30).await;
+        assert!(!should_run_user_scope_repair(&mut c2).await.unwrap());
+    }
+}

--- a/crates/aionui-db/src/migrate_repair.rs
+++ b/crates/aionui-db/src/migrate_repair.rs
@@ -32,28 +32,24 @@ pub(crate) struct GuardViolation {
 /// migration (`max applied version == 29`). Returns false when the
 /// `_sqlx_migrations` table does not exist (fresh install) — spec §7 H1.
 async fn should_run_user_scope_repair(conn: &mut sqlx::SqliteConnection) -> Result<bool, DbError> {
-    let has_table: bool = sqlx::query_scalar(
-        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type = 'table' AND name = '_sqlx_migrations'",
-    )
-    .fetch_one(&mut *conn)
-    .await
-    .map_err(DbError::Query)?;
-    if !has_table {
-        return Ok(false);
-    }
-    let max_version: Option<i64> =
-        sqlx::query_scalar("SELECT MAX(version) FROM _sqlx_migrations WHERE success = 1")
+    let has_table: bool =
+        sqlx::query_scalar("SELECT COUNT(*) > 0 FROM sqlite_master WHERE type = 'table' AND name = '_sqlx_migrations'")
             .fetch_one(&mut *conn)
             .await
             .map_err(DbError::Query)?;
+    if !has_table {
+        return Ok(false);
+    }
+    let max_version: Option<i64> = sqlx::query_scalar("SELECT MAX(version) FROM _sqlx_migrations WHERE success = 1")
+        .fetch_one(&mut *conn)
+        .await
+        .map_err(DbError::Query)?;
     Ok(max_version == Some(USER_SCOPE_MIGRATION_VERSION - 1))
 }
 
 /// Evaluate every named 030 invariant on the raw (pre-030) schema and return
 /// the violated ones with counts. Task 2/3 fills in the guard list.
-async fn evaluate_user_scope_guards(
-    conn: &mut sqlx::SqliteConnection,
-) -> Result<Vec<GuardViolation>, DbError> {
+async fn evaluate_user_scope_guards(conn: &mut sqlx::SqliteConnection) -> Result<Vec<GuardViolation>, DbError> {
     let mut violations = Vec::new();
     for (check, count_sql) in GUARD_COUNT_QUERIES {
         match sqlx::query_scalar::<_, i64>(count_sql).fetch_one(&mut *conn).await {
@@ -103,51 +99,75 @@ async fn exec_repair(conn: &mut sqlx::SqliteConnection, sql: &str) -> Result<(),
 /// Filled in by Task 2 (A-class) and Task 3 (C-class + system_settings).
 const GUARD_COUNT_QUERIES: &[(&str, &str)] = &[
     // --- A-class: orphan child rows (030_user_scope.sql:75-158, 787-810) ---
-    ("messages_orphaned_conversation",
-     "SELECT COUNT(*) FROM messages m WHERE NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = m.conversation_id)"),
-    ("conversation_artifacts_orphaned_conversation",
-     "SELECT COUNT(*) FROM conversation_artifacts a WHERE NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = a.conversation_id)"),
-    ("conversation_assistant_snapshots_orphaned_conversation",
-     "SELECT COUNT(*) FROM conversation_assistant_snapshots s WHERE NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = s.conversation_id)"),
-    ("acp_session_orphaned_conversation",
-     "SELECT COUNT(*) FROM acp_session s WHERE NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = s.conversation_id)"),
-    ("cron_jobs_orphaned_conversation",
-     "SELECT COUNT(*) FROM cron_jobs j WHERE COALESCE(j.conversation_id,'') <> '' AND NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = j.conversation_id)"),
-    ("mailbox_orphaned_team",
-     "SELECT COUNT(*) FROM mailbox m WHERE NOT EXISTS (SELECT 1 FROM teams t WHERE t.id = m.team_id)"),
-    ("team_tasks_orphaned_team",
-     "SELECT COUNT(*) FROM team_tasks tt WHERE NOT EXISTS (SELECT 1 FROM teams t WHERE t.id = tt.team_id)"),
-    ("assistant_sessions_missing_owner",
-     "SELECT COUNT(*) FROM assistant_sessions s WHERE NOT EXISTS (SELECT 1 FROM assistant_users u WHERE u.id = s.user_id)"),
-    ("assistant_sessions_orphaned_conversation",
-     "SELECT COUNT(*) FROM assistant_sessions s WHERE s.conversation_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = s.conversation_id)"),
+    (
+        "messages_orphaned_conversation",
+        "SELECT COUNT(*) FROM messages m WHERE NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = m.conversation_id)",
+    ),
+    (
+        "conversation_artifacts_orphaned_conversation",
+        "SELECT COUNT(*) FROM conversation_artifacts a WHERE NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = a.conversation_id)",
+    ),
+    (
+        "conversation_assistant_snapshots_orphaned_conversation",
+        "SELECT COUNT(*) FROM conversation_assistant_snapshots s WHERE NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = s.conversation_id)",
+    ),
+    (
+        "acp_session_orphaned_conversation",
+        "SELECT COUNT(*) FROM acp_session s WHERE NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = s.conversation_id)",
+    ),
+    (
+        "cron_jobs_orphaned_conversation",
+        "SELECT COUNT(*) FROM cron_jobs j WHERE COALESCE(j.conversation_id,'') <> '' AND NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = j.conversation_id)",
+    ),
+    (
+        "mailbox_orphaned_team",
+        "SELECT COUNT(*) FROM mailbox m WHERE NOT EXISTS (SELECT 1 FROM teams t WHERE t.id = m.team_id)",
+    ),
+    (
+        "team_tasks_orphaned_team",
+        "SELECT COUNT(*) FROM team_tasks tt WHERE NOT EXISTS (SELECT 1 FROM teams t WHERE t.id = tt.team_id)",
+    ),
+    (
+        "assistant_sessions_missing_owner",
+        "SELECT COUNT(*) FROM assistant_sessions s WHERE NOT EXISTS (SELECT 1 FROM assistant_users u WHERE u.id = s.user_id)",
+    ),
+    (
+        "assistant_sessions_orphaned_conversation",
+        "SELECT COUNT(*) FROM assistant_sessions s WHERE s.conversation_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM conversations c WHERE c.id = s.conversation_id)",
+    ),
     // --- C-class: duplicate composite-UNIQUE identities (030:225-263, 741-783) ---
-    ("mcp_servers_duplicate_scope_name",
-     "SELECT COUNT(*) FROM mcp_servers WHERE rowid NOT IN \
-        (SELECT MIN(rowid) FROM mcp_servers GROUP BY name)"),
-    ("assistant_users_duplicate_identity",
-     "SELECT COUNT(*) FROM assistant_users WHERE rowid NOT IN \
-        (SELECT MIN(rowid) FROM assistant_users GROUP BY platform_user_id, platform_type)"),
+    (
+        "mcp_servers_duplicate_scope_name",
+        "SELECT COUNT(*) FROM mcp_servers WHERE rowid NOT IN \
+        (SELECT MIN(rowid) FROM mcp_servers GROUP BY name)",
+    ),
+    (
+        "assistant_users_duplicate_identity",
+        "SELECT COUNT(*) FROM assistant_users WHERE rowid NOT IN \
+        (SELECT MIN(rowid) FROM assistant_users GROUP BY platform_user_id, platform_type)",
+    ),
     // --- L4: system_settings row not keyed at id=1 would be dropped by 030 (030:318) ---
-    ("system_settings_non_primary_id",
-     "SELECT COUNT(*) FROM system_settings WHERE (SELECT COUNT(*) FROM system_settings) = 1 AND id <> 1"),
+    (
+        "system_settings_non_primary_id",
+        "SELECT COUNT(*) FROM system_settings WHERE (SELECT COUNT(*) FROM system_settings) = 1 AND id <> 1",
+    ),
     // --- B-class (DIAGNOSTIC-ONLY, no active repair): assistant_sessions cross-scope owner (030:812-824). ---
     // 030 forces assistant_users.owner_user_id='system_default_user' (030:768) but never normalizes
     // conversations.user_id, so 030's `c.user_id != u.owner_user_id` guard fails for a session-linked
     // conversation whose user_id <> 'system_default_user'. Data-dependent (spec §7.1 "不得假设一定为空"):
     // must be NAMED if it fires (spec §10 item 6 "含前置修复未覆盖的形态", §6 目标 5), even though this fix
     // performs NO active repair for it (spec §7.1 B "覆盖到即可" is soft; §7.1 L3 diagnose-if-uncovered).
-    ("assistant_sessions_cross_scope_owner",
-     "SELECT COUNT(*) FROM assistant_sessions s \
+    (
+        "assistant_sessions_cross_scope_owner",
+        "SELECT COUNT(*) FROM assistant_sessions s \
         JOIN assistant_users u ON u.id = s.user_id \
         JOIN conversations c ON c.id = s.conversation_id \
-        WHERE s.conversation_id IS NOT NULL AND c.user_id <> 'system_default_user'"),
+        WHERE s.conversation_id IS NOT NULL AND c.user_id <> 'system_default_user'",
+    ),
 ];
 
 /// Gate → preflight (log names+counts) → idempotent repair. No-op off-gate.
-pub(crate) async fn repair_user_scope_preconditions(
-    conn: &mut sqlx::SqliteConnection,
-) -> Result<(), DbError> {
+pub(crate) async fn repair_user_scope_preconditions(conn: &mut sqlx::SqliteConnection) -> Result<(), DbError> {
     if !should_run_user_scope_repair(conn).await? {
         return Ok(());
     }
@@ -348,9 +368,18 @@ mod tests {
         ] {
             sqlx::query(ddl).execute(&mut *c).await.unwrap();
         }
-        sqlx::query("INSERT INTO conversations (id, user_id) VALUES ('c1','system_default_user')").execute(&mut *c).await.unwrap();
-        sqlx::query("INSERT INTO teams (id) VALUES ('t1')").execute(&mut *c).await.unwrap();
-        sqlx::query("INSERT INTO assistant_users (id) VALUES ('u1')").execute(&mut *c).await.unwrap();
+        sqlx::query("INSERT INTO conversations (id, user_id) VALUES ('c1','system_default_user')")
+            .execute(&mut *c)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO teams (id) VALUES ('t1')")
+            .execute(&mut *c)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO assistant_users (id) VALUES ('u1')")
+            .execute(&mut *c)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -359,19 +388,36 @@ mod tests {
         create_min_v29_aggregate_tables(&mut c).await;
         // valid + orphan messages
         sqlx::query("INSERT INTO messages (id, conversation_id) VALUES ('m_ok','c1'),('m_orphan','missing')")
-            .execute(&mut c).await.unwrap();
+            .execute(&mut c)
+            .await
+            .unwrap();
         sqlx::query("INSERT INTO mailbox (id, team_id) VALUES ('mb_ok','t1'),('mb_orphan','missing')")
-            .execute(&mut c).await.unwrap();
-        sqlx::query("INSERT INTO assistant_sessions (id, user_id, conversation_id) VALUES ('s_noowner','missing',NULL)")
-            .execute(&mut c).await.unwrap();
+            .execute(&mut c)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO assistant_sessions (id, user_id, conversation_id) VALUES ('s_noowner','missing',NULL)",
+        )
+        .execute(&mut c)
+        .await
+        .unwrap();
 
         apply_user_scope_repairs(&mut c).await.unwrap();
 
-        let msgs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM messages").fetch_one(&mut c).await.unwrap();
+        let msgs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM messages")
+            .fetch_one(&mut c)
+            .await
+            .unwrap();
         assert_eq!(msgs, 1, "orphan message deleted, valid kept");
-        let mbs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM mailbox").fetch_one(&mut c).await.unwrap();
+        let mbs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM mailbox")
+            .fetch_one(&mut c)
+            .await
+            .unwrap();
         assert_eq!(mbs, 1, "orphan mailbox deleted, valid kept");
-        let sess: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM assistant_sessions").fetch_one(&mut c).await.unwrap();
+        let sess: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM assistant_sessions")
+            .fetch_one(&mut c)
+            .await
+            .unwrap();
         assert_eq!(sess, 0, "ownerless session deleted");
     }
 
@@ -380,21 +426,33 @@ mod tests {
         let mut c = conn().await;
         create_min_v29_aggregate_tables(&mut c).await;
         sqlx::query("INSERT INTO cron_jobs (id, conversation_id) VALUES ('j_orphan','missing')")
-            .execute(&mut c).await.unwrap();
-        sqlx::query("INSERT INTO assistant_sessions (id, user_id, conversation_id) VALUES ('s_orphanconv','u1','missing')")
-            .execute(&mut c).await.unwrap();
+            .execute(&mut c)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO assistant_sessions (id, user_id, conversation_id) VALUES ('s_orphanconv','u1','missing')",
+        )
+        .execute(&mut c)
+        .await
+        .unwrap();
 
         apply_user_scope_repairs(&mut c).await.unwrap();
 
         let cron_conv: String = sqlx::query_scalar("SELECT conversation_id FROM cron_jobs WHERE id='j_orphan'")
-            .fetch_one(&mut c).await.unwrap();
+            .fetch_one(&mut c)
+            .await
+            .unwrap();
         assert_eq!(cron_conv, "", "cron job preserved, conversation_id emptied");
         let cron_kept: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM cron_jobs WHERE id='j_orphan'")
-            .fetch_one(&mut c).await.unwrap();
+            .fetch_one(&mut c)
+            .await
+            .unwrap();
         assert_eq!(cron_kept, 1, "cron job row preserved");
         let sess_conv: Option<String> =
             sqlx::query_scalar("SELECT conversation_id FROM assistant_sessions WHERE id='s_orphanconv'")
-                .fetch_one(&mut c).await.unwrap();
+                .fetch_one(&mut c)
+                .await
+                .unwrap();
         assert_eq!(sess_conv, None, "session preserved, conversation_id nulled");
     }
 
@@ -403,10 +461,15 @@ mod tests {
         let mut c = conn().await;
         create_min_v29_aggregate_tables(&mut c).await;
         sqlx::query("INSERT INTO messages (id, conversation_id) VALUES ('m_orphan','missing')")
-            .execute(&mut c).await.unwrap();
+            .execute(&mut c)
+            .await
+            .unwrap();
         apply_user_scope_repairs(&mut c).await.unwrap();
         apply_user_scope_repairs(&mut c).await.unwrap(); // second run must be a no-op
-        let msgs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM messages").fetch_one(&mut c).await.unwrap();
+        let msgs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM messages")
+            .fetch_one(&mut c)
+            .await
+            .unwrap();
         assert_eq!(msgs, 0);
     }
 
@@ -415,10 +478,14 @@ mod tests {
         let mut c = conn().await;
         create_min_v29_aggregate_tables(&mut c).await;
         sqlx::query("INSERT INTO messages (id, conversation_id) VALUES ('m_orphan','missing')")
-            .execute(&mut c).await.unwrap();
+            .execute(&mut c)
+            .await
+            .unwrap();
         let violations = evaluate_user_scope_guards(&mut c).await.unwrap();
         assert!(
-            violations.iter().any(|v| v.check == "messages_orphaned_conversation" && v.count == 1),
+            violations
+                .iter()
+                .any(|v| v.check == "messages_orphaned_conversation" && v.count == 1),
             "preflight must pinpoint the specific check by name + count, got {violations:?}"
         );
     }
@@ -427,7 +494,9 @@ mod tests {
     async fn c_class_dedupes_mcp_servers_by_scope_name() {
         let mut c = conn().await;
         sqlx::query("CREATE TABLE mcp_servers (id TEXT PRIMARY KEY, name TEXT, updated_at INTEGER)")
-            .execute(&mut c).await.unwrap();
+            .execute(&mut c)
+            .await
+            .unwrap();
         // Two rows share name; keep the most-recently-updated.
         sqlx::query("INSERT INTO mcp_servers (id, name, updated_at) VALUES ('old','dup',10),('new','dup',20),('solo','unique',5)")
             .execute(&mut c).await.unwrap();
@@ -435,8 +504,14 @@ mod tests {
         apply_user_scope_repairs(&mut c).await.unwrap();
 
         let kept: Vec<String> = sqlx::query_scalar("SELECT id FROM mcp_servers ORDER BY id")
-            .fetch_all(&mut c).await.unwrap();
-        assert_eq!(kept, vec!["new".to_string(), "solo".to_string()], "duplicate name deduped, newest kept");
+            .fetch_all(&mut c)
+            .await
+            .unwrap();
+        assert_eq!(
+            kept,
+            vec!["new".to_string(), "solo".to_string()],
+            "duplicate name deduped, newest kept"
+        );
     }
 
     #[tokio::test]
@@ -445,18 +520,31 @@ mod tests {
         sqlx::query("CREATE TABLE assistant_users (id TEXT PRIMARY KEY, platform_user_id TEXT, platform_type TEXT, authorized_at INTEGER)")
             .execute(&mut c).await.unwrap();
         sqlx::query("CREATE TABLE assistant_sessions (id TEXT PRIMARY KEY, user_id TEXT, conversation_id TEXT)")
-            .execute(&mut c).await.unwrap();
+            .execute(&mut c)
+            .await
+            .unwrap();
         sqlx::query("INSERT INTO assistant_users (id, platform_user_id, platform_type, authorized_at) VALUES ('au_old','p','telegram',10),('au_new','p','telegram',20)")
             .execute(&mut c).await.unwrap();
         sqlx::query("INSERT INTO assistant_sessions (id, user_id, conversation_id) VALUES ('sess','au_old',NULL)")
-            .execute(&mut c).await.unwrap();
+            .execute(&mut c)
+            .await
+            .unwrap();
 
         apply_user_scope_repairs(&mut c).await.unwrap();
 
-        let users: Vec<String> = sqlx::query_scalar("SELECT id FROM assistant_users").fetch_all(&mut c).await.unwrap();
-        assert_eq!(users, vec!["au_new".to_string()], "duplicate identity deduped, newest kept");
+        let users: Vec<String> = sqlx::query_scalar("SELECT id FROM assistant_users")
+            .fetch_all(&mut c)
+            .await
+            .unwrap();
+        assert_eq!(
+            users,
+            vec!["au_new".to_string()],
+            "duplicate identity deduped, newest kept"
+        );
         let sess_owner: String = sqlx::query_scalar("SELECT user_id FROM assistant_sessions WHERE id='sess'")
-            .fetch_one(&mut c).await.unwrap();
+            .fetch_one(&mut c)
+            .await
+            .unwrap();
         assert_eq!(sess_owner, "au_new", "session re-pointed to kept owner (not orphaned)");
     }
 
@@ -464,14 +552,24 @@ mod tests {
     async fn c_class_promotes_lone_system_settings_row_to_id_1() {
         let mut c = conn().await;
         sqlx::query("CREATE TABLE system_settings (id INTEGER PRIMARY KEY, language TEXT, updated_at INTEGER)")
-            .execute(&mut c).await.unwrap();
+            .execute(&mut c)
+            .await
+            .unwrap();
         sqlx::query("INSERT INTO system_settings (id, language, updated_at) VALUES (5,'zh-CN',1)")
-            .execute(&mut c).await.unwrap();
+            .execute(&mut c)
+            .await
+            .unwrap();
 
         apply_user_scope_repairs(&mut c).await.unwrap();
 
-        let id: i64 = sqlx::query_scalar("SELECT id FROM system_settings").fetch_one(&mut c).await.unwrap();
-        assert_eq!(id, 1, "lone settings row promoted to id=1 so 030 WHERE id=1 copy preserves it");
+        let id: i64 = sqlx::query_scalar("SELECT id FROM system_settings")
+            .fetch_one(&mut c)
+            .await
+            .unwrap();
+        assert_eq!(
+            id, 1,
+            "lone settings row promoted to id=1 so 030 WHERE id=1 copy preserves it"
+        );
     }
 
     #[tokio::test]
@@ -481,13 +579,19 @@ mod tests {
         create_min_v29_aggregate_tables(&mut c).await;
         // A conversation owned by a non-default user, linked by a session with a valid owner.
         sqlx::query("INSERT INTO conversations (id, user_id) VALUES ('c_other','user-abc')")
-            .execute(&mut c).await.unwrap();
+            .execute(&mut c)
+            .await
+            .unwrap();
         sqlx::query("INSERT INTO assistant_sessions (id, user_id, conversation_id) VALUES ('s_x','u1','c_other')")
-            .execute(&mut c).await.unwrap();
+            .execute(&mut c)
+            .await
+            .unwrap();
 
         let violations = evaluate_user_scope_guards(&mut c).await.unwrap();
         assert!(
-            violations.iter().any(|v| v.check == "assistant_sessions_cross_scope_owner" && v.count == 1),
+            violations
+                .iter()
+                .any(|v| v.check == "assistant_sessions_cross_scope_owner" && v.count == 1),
             "uncovered cross-scope guard must be named in the preflight, got {violations:?}"
         );
 
@@ -497,7 +601,12 @@ mod tests {
             "SELECT COUNT(*) FROM assistant_sessions s JOIN conversations c ON c.id = s.conversation_id \
              WHERE c.user_id <> 'system_default_user'",
         )
-        .fetch_one(&mut c).await.unwrap();
-        assert_eq!(still, 1, "B-class cross-scope divergence is named but not repaired in this fix");
+        .fetch_one(&mut c)
+        .await
+        .unwrap();
+        assert_eq!(
+            still, 1,
+            "B-class cross-scope divergence is named but not repaired in this fix"
+        );
     }
 }

--- a/crates/aionui-db/tests/user_scope_pre_migration_repair.rs
+++ b/crates/aionui-db/tests/user_scope_pre_migration_repair.rs
@@ -30,7 +30,12 @@ async fn build_v29_db(path: &Path, seed: &[&str]) {
         .filter(|m| m.version <= 29)
         .cloned()
         .collect::<Vec<_>>();
-    let migrator = Migrator { migrations: Cow::Owned(subset), ignore_missing: false, locking: true, no_tx: false };
+    let migrator = Migrator {
+        migrations: Cow::Owned(subset),
+        ignore_missing: false,
+        locking: true,
+        no_tx: false,
+    };
     migrator.run(&pool).await.unwrap();
     for sql in seed {
         sqlx::query(sql).execute(&pool).await.unwrap();
@@ -65,14 +70,20 @@ async fn stuck_user_with_orphans_self_heals_and_030_applies() {
     )
     .await;
 
-    let db = init_database_staged(&path).await.expect("stuck DB must self-heal and finish 030");
+    let db = init_database_staged(&path)
+        .await
+        .expect("stuck DB must self-heal and finish 030");
     assert_eq!(max_applied_version(&db).await, 30, "migration 030 applied after repair");
 
     let valid: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM messages WHERE id='m_valid'")
-        .fetch_one(db.pool()).await.unwrap();
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
     assert_eq!(valid, 1, "valid message preserved");
     let orphan: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM messages WHERE id='m_orphan'")
-        .fetch_one(db.pool()).await.unwrap();
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
     assert_eq!(orphan, 0, "orphan message removed");
     db.close().await;
 }
@@ -86,12 +97,19 @@ async fn already_applied_030_upgrades_without_version_mismatch() {
         let url = format!("sqlite://{}?mode=rwc", path.display());
         let pool = SqlitePoolOptions::new().max_connections(1).connect(&url).await.unwrap();
         sqlx::query("PRAGMA foreign_keys = OFF").execute(&pool).await.unwrap();
-        Migrator::new(Path::new("migrations")).await.unwrap().run(&pool).await.unwrap();
+        Migrator::new(Path::new("migrations"))
+            .await
+            .unwrap()
+            .run(&pool)
+            .await
+            .unwrap();
         sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)").execute(&pool).await.ok();
         pool.close().await;
     }
 
-    let db = init_database_staged(&path).await.expect("already-migrated DB must open without VersionMismatch");
+    let db = init_database_staged(&path)
+        .await
+        .expect("already-migrated DB must open without VersionMismatch");
     assert_eq!(max_applied_version(&db).await, 30);
     db.close().await;
 }
@@ -102,8 +120,10 @@ async fn repair_then_startup_is_idempotent() {
     let path = dir.path().join("aionui-backend.db");
     build_v29_db(
         &path,
-        &["INSERT INTO mailbox (id, team_id, to_agent_id, from_agent_id, type, content, created_at) \
-           VALUES ('mb_orphan','t_missing','a1','a2','message','x',1)"],
+        &[
+            "INSERT INTO mailbox (id, team_id, to_agent_id, from_agent_id, type, content, created_at) \
+           VALUES ('mb_orphan','t_missing','a1','a2','message','x',1)",
+        ],
     )
     .await;
 
@@ -147,10 +167,14 @@ async fn defensive_dedup_prevents_unique_family_failure() {
     )
     .await;
 
-    let db = init_database_staged(&path).await.expect("duplicate mcp name must be deduped, not abort 030");
+    let db = init_database_staged(&path)
+        .await
+        .expect("duplicate mcp name must be deduped, not abort 030");
     assert_eq!(max_applied_version(&db).await, 30);
     let kept: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM mcp_servers WHERE name='dup'")
-        .fetch_one(db.pool()).await.unwrap();
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
     assert_eq!(kept, 1, "one row kept after dedup");
     db.close().await;
 }

--- a/crates/aionui-db/tests/user_scope_pre_migration_repair.rs
+++ b/crates/aionui-db/tests/user_scope_pre_migration_repair.rs
@@ -51,6 +51,20 @@ async fn max_applied_version(db: &aionui_db::Database) -> i64 {
         .unwrap()
 }
 
+/// Highest migration version bundled in `migrations/`. Staged init runs the
+/// full migrator, so a healed DB must reach exactly this version — asserting a
+/// hardcoded literal (e.g. 30) breaks whenever a later migration is added.
+async fn latest_bundled_version() -> i64 {
+    Migrator::new(Path::new("migrations"))
+        .await
+        .unwrap()
+        .migrations
+        .iter()
+        .map(|m| m.version)
+        .max()
+        .expect("bundled migrations are non-empty")
+}
+
 #[tokio::test]
 async fn stuck_user_with_orphans_self_heals_and_030_applies() {
     let dir = tempfile::tempdir().unwrap();
@@ -73,7 +87,11 @@ async fn stuck_user_with_orphans_self_heals_and_030_applies() {
     let db = init_database_staged(&path)
         .await
         .expect("stuck DB must self-heal and finish 030");
-    assert_eq!(max_applied_version(&db).await, 30, "migration 030 applied after repair");
+    assert_eq!(
+        max_applied_version(&db).await,
+        latest_bundled_version().await,
+        "migration 030+ applied after repair"
+    );
 
     let valid: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM messages WHERE id='m_valid'")
         .fetch_one(db.pool())
@@ -110,7 +128,7 @@ async fn already_applied_030_upgrades_without_version_mismatch() {
     let db = init_database_staged(&path)
         .await
         .expect("already-migrated DB must open without VersionMismatch");
-    assert_eq!(max_applied_version(&db).await, 30);
+    assert_eq!(max_applied_version(&db).await, latest_bundled_version().await);
     db.close().await;
 }
 
@@ -127,12 +145,14 @@ async fn repair_then_startup_is_idempotent() {
     )
     .await;
 
+    let latest = latest_bundled_version().await;
     let db1 = init_database_staged(&path).await.unwrap();
-    assert_eq!(max_applied_version(&db1).await, 30);
+    assert_eq!(max_applied_version(&db1).await, latest);
     db1.close().await;
-    // Second startup on the healed DB must also succeed (gate now max==30 → skip).
+    // Second startup on the healed DB must also succeed (gate now sees the DB
+    // already past 030 → skips the repair).
     let db2 = init_database_staged(&path).await.unwrap();
-    assert_eq!(max_applied_version(&db2).await, 30);
+    assert_eq!(max_applied_version(&db2).await, latest);
     db2.close().await;
 }
 
@@ -170,7 +190,7 @@ async fn defensive_dedup_prevents_unique_family_failure() {
     let db = init_database_staged(&path)
         .await
         .expect("duplicate mcp name must be deduped, not abort 030");
-    assert_eq!(max_applied_version(&db).await, 30);
+    assert_eq!(max_applied_version(&db).await, latest_bundled_version().await);
     let kept: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM mcp_servers WHERE name='dup'")
         .fetch_one(db.pool())
         .await

--- a/crates/aionui-db/tests/user_scope_pre_migration_repair.rs
+++ b/crates/aionui-db/tests/user_scope_pre_migration_repair.rs
@@ -1,0 +1,156 @@
+//! End-to-end v29-fixture upgrade tests for the migration-030 pre-migration
+//! repair (Sentry ELECTRON-31Z / ELECTRON-31X).
+//!
+//! The bundled `DB_MIGRATOR` runs straight to 030 and `init_database_memory()`
+//! starts from an empty DB, so neither enters the repair branch. These tests
+//! hand-build a file-backed v29 database (migrations 001..=029 applied, so
+//! `_sqlx_migrations` max version == 29) plus dirty data, then trigger
+//! `init_database_staged` so the repair runs on the migrator's connection
+//! immediately before 030.
+
+use std::borrow::Cow;
+use std::path::Path;
+
+use aionui_db::init_database_staged;
+use sqlx::migrate::Migrator;
+use sqlx::sqlite::SqlitePoolOptions;
+
+/// Build a file-backed DB with migrations 001..=29 applied (leaving 030
+/// pending, so `_sqlx_migrations` max version == 29), then run each `seed`
+/// statement in order. Closes the pool before returning so the caller can open
+/// it via the staged-init path.
+async fn build_v29_db(path: &Path, seed: &[&str]) {
+    let url = format!("sqlite://{}?mode=rwc", path.display());
+    let pool = SqlitePoolOptions::new().max_connections(1).connect(&url).await.unwrap();
+    sqlx::query("PRAGMA foreign_keys = OFF").execute(&pool).await.unwrap();
+    let full = Migrator::new(Path::new("migrations")).await.unwrap();
+    let subset = full
+        .migrations
+        .iter()
+        .filter(|m| m.version <= 29)
+        .cloned()
+        .collect::<Vec<_>>();
+    let migrator = Migrator { migrations: Cow::Owned(subset), ignore_missing: false, locking: true, no_tx: false };
+    migrator.run(&pool).await.unwrap();
+    for sql in seed {
+        sqlx::query(sql).execute(&pool).await.unwrap();
+    }
+    sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)").execute(&pool).await.ok();
+    pool.close().await;
+}
+
+async fn max_applied_version(db: &aionui_db::Database) -> i64 {
+    sqlx::query_scalar("SELECT MAX(version) FROM _sqlx_migrations WHERE success = 1")
+        .fetch_one(db.pool())
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn stuck_user_with_orphans_self_heals_and_030_applies() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("aionui-backend.db");
+    build_v29_db(
+        &path,
+        &[
+            "INSERT INTO conversations (id, user_id, name, type, extra, status, created_at, updated_at) \
+             VALUES ('c_valid','system_default_user','Valid','acp','{}','pending',1,1)",
+            "INSERT INTO messages (id, conversation_id, type, content, created_at) \
+             VALUES ('m_valid','c_valid','user','{}',1)",
+            "INSERT INTO messages (id, conversation_id, type, content, created_at) \
+             VALUES ('m_orphan','c_missing','user','{}',1)",
+            "INSERT INTO acp_session (conversation_id, agent_source, agent_id, session_status, session_config) \
+             VALUES ('c_missing','builtin','a','idle','{}')",
+        ],
+    )
+    .await;
+
+    let db = init_database_staged(&path).await.expect("stuck DB must self-heal and finish 030");
+    assert_eq!(max_applied_version(&db).await, 30, "migration 030 applied after repair");
+
+    let valid: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM messages WHERE id='m_valid'")
+        .fetch_one(db.pool()).await.unwrap();
+    assert_eq!(valid, 1, "valid message preserved");
+    let orphan: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM messages WHERE id='m_orphan'")
+        .fetch_one(db.pool()).await.unwrap();
+    assert_eq!(orphan, 0, "orphan message removed");
+    db.close().await;
+}
+
+#[tokio::test]
+async fn already_applied_030_upgrades_without_version_mismatch() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("aionui-backend.db");
+    // Apply the FULL migrator (through 030) to simulate an already-migrated user.
+    {
+        let url = format!("sqlite://{}?mode=rwc", path.display());
+        let pool = SqlitePoolOptions::new().max_connections(1).connect(&url).await.unwrap();
+        sqlx::query("PRAGMA foreign_keys = OFF").execute(&pool).await.unwrap();
+        Migrator::new(Path::new("migrations")).await.unwrap().run(&pool).await.unwrap();
+        sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)").execute(&pool).await.ok();
+        pool.close().await;
+    }
+
+    let db = init_database_staged(&path).await.expect("already-migrated DB must open without VersionMismatch");
+    assert_eq!(max_applied_version(&db).await, 30);
+    db.close().await;
+}
+
+#[tokio::test]
+async fn repair_then_startup_is_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("aionui-backend.db");
+    build_v29_db(
+        &path,
+        &["INSERT INTO mailbox (id, team_id, to_agent_id, from_agent_id, type, content, created_at) \
+           VALUES ('mb_orphan','t_missing','a1','a2','message','x',1)"],
+    )
+    .await;
+
+    let db1 = init_database_staged(&path).await.unwrap();
+    assert_eq!(max_applied_version(&db1).await, 30);
+    db1.close().await;
+    // Second startup on the healed DB must also succeed (gate now max==30 → skip).
+    let db2 = init_database_staged(&path).await.unwrap();
+    assert_eq!(max_applied_version(&db2).await, 30);
+    db2.close().await;
+}
+
+#[tokio::test]
+async fn defensive_dedup_prevents_unique_family_failure() {
+    // spec §10 item 4: a DB whose 030 full-table rebuild would abort with the
+    // UNIQUE/NOT-NULL family (not `ok = 1`) must be repaired so 030 succeeds.
+    //
+    // A pristine v29 chain CANNOT hold duplicate mcp_servers names: `mcp_servers`
+    // carries `UNIQUE(name)` since migration 001 (`verified`:
+    // 001_initial_schema.sql:381), and 030's rebuild key `UNIQUE(user_id,name)`
+    // with a single owner is no wider. So the only way a real database reaches
+    // 030 with duplicate names is a legacy/damaged DB whose UNIQUE was absent.
+    // We simulate exactly that state: rebuild `mcp_servers` without constraints
+    // via `CREATE TABLE ... AS SELECT` (which drops PK/UNIQUE), then seed the
+    // duplicates. This drives the real staged-init path (pre-migration dedup →
+    // 030 rebuild) and proves the defensive dedup keeps 030 from aborting.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("aionui-backend.db");
+    build_v29_db(
+        &path,
+        &[
+            // Drop the 001-era UNIQUE(name) by recreating the table constraint-free.
+            "CREATE TABLE mcp_servers_legacy AS SELECT * FROM mcp_servers",
+            "DROP TABLE mcp_servers",
+            "ALTER TABLE mcp_servers_legacy RENAME TO mcp_servers",
+            "INSERT INTO mcp_servers (id, name, enabled, transport_type, transport_config, last_test_status, builtin, created_at, updated_at) \
+             VALUES ('mcp_a','dup',1,'stdio','{}','disconnected',0,1,10)",
+            "INSERT INTO mcp_servers (id, name, enabled, transport_type, transport_config, last_test_status, builtin, created_at, updated_at) \
+             VALUES ('mcp_b','dup',1,'stdio','{}','disconnected',0,1,20)",
+        ],
+    )
+    .await;
+
+    let db = init_database_staged(&path).await.expect("duplicate mcp name must be deduped, not abort 030");
+    assert_eq!(max_applied_version(&db).await, 30);
+    let kept: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM mcp_servers WHERE name='dup'")
+        .fetch_one(db.pool()).await.unwrap();
+    assert_eq!(kept, 1, "one row kept after dedup");
+    db.close().await;
+}


### PR DESCRIPTION
## Summary

Fixes a critical, batch, startup-blocking regression introduced in v0.1.54. Migration `030_user_scope.sql` (multi-account user-scope isolation) contains fail-hard `CHECK (ok = 1)` integrity assertions that abort on benign historical data inconsistencies (SQLite error 275, `CHECK constraint failed: ok = 1`). Affected users are permanently stalled at `database.migration` with `BOOTSTRAP_DATA_INIT_FAILED`; because the database lives in the OS app-data directory, reinstalling AionUi does not clear it, so every restart re-runs migration 030 and fails again.

This change adds a Rust-side, idempotent **pre-migration repair** that normalizes the raw database to satisfy migration 030's invariants **before** the migrator runs 030, on the migrator's own connection inside the existing cross-process startup lock. The shipped `030_user_scope.sql` is **byte-for-byte unchanged**.

Sentry issues:
- `130567853` (ELECTRON-31Z, Windows/x64)
- `130557438` (ELECTRON-31X, macOS/arm64)

These are the same regression split into two by platform fingerprint; both share `backend_boundary_code=BOOTSTRAP_DATA_INIT_FAILED` and `backend_boundary_stage=database.migration`. This single fix covers both.

## Root cause

Migration 030 builds temporary tables with `CHECK (ok = 1)` plus `INSERT ... SELECT CASE WHEN <consistency condition> THEN 1 ELSE 0 END`. Historical local databases tolerated by older versions can hold minor inconsistencies (orphan child rows, cross-scope mismatches, duplicate identifiers) that make an assertion insert `0`, hit SQLite 275, and roll back the whole migration transaction. The failure does not match the "disk corruption" signature, so recovery returns false — the app neither self-rebuilds nor prompts for recovery, it just fast-fails and stays stuck on every launch.

Two constraints bound the viable fix:

- **F1** — The sqlx migrator stops at the first failing migration, so a forward `031` catch-up migration cannot rescue a user already stuck at 030 (030 aborts first, 031 never runs). The repair must run *before* 030.
- **F2** — sqlx checksums migration content, so rewriting the released 030 would trip `VersionMismatch` for already-migrated users. 030 is therefore left untouched.

## Approach

A new module `crates/aionui-db/src/migrate_repair.rs` performs an idempotent pre-migration repair, wired into `run_migrations_staged` after `PRAGMA foreign_keys = OFF` and before the migrator runs:

- **Gate** `should_run_user_scope_repair` — runs only when `_sqlx_migrations` exists and `MAX(version) == 29` (001–029 applied, 030 is next). Fresh installs (no `_sqlx_migrations`) and databases already at `>= 30` are skipped. This structurally excludes migrated DBs, so no `VersionMismatch` path exists (F2).
- **Named preflight** `evaluate_user_scope_guards` — evaluates each 030 invariant and returns `check name + violating-row count`. Logged at `warn` with names and counts only, never user row content (per repository logging rules).
- **Idempotent repair** `apply_user_scope_repairs`:
  - **A-class (primary, matches the field 275)** — delete orphan child rows whose parent no longer exists; for user-created top-level assets, null the dangling foreign key and keep the record (`cron_jobs.conversation_id = ''`, `assistant_sessions.conversation_id = NULL`).
  - **C-class (defensive)** — dedup `mcp_servers` by name and `assistant_users` by `(platform_user_id, platform_type)`, re-pointing dependent sessions to the retained row before deleting duplicates; keep the most recent `updated_at`/`authorized_at`.
  - **L4** — promote a lone `system_settings` row with `id != 1` to `id = 1` so 030's `WHERE id = 1` copy does not silently drop settings.
  - **B-class (diagnostic-only)** — cross-scope owner mismatch is named and counted but intentionally not repaired in this fix.
- **Post-repair re-check** — after repair, re-evaluates the guards and logs any still-violated guard by name at `warn`, or `info` when all cleared, so residual field shapes remain attributable rather than silently looping.

## Files changed

- `crates/aionui-db/src/migrate_repair.rs` — new module: gate, named preflight, idempotent repair, post-repair re-check, with in-module unit tests.
- `crates/aionui-db/src/database.rs` — wire the pre-migration repair call into staged init.
- `crates/aionui-db/src/lib.rs` — declare `mod migrate_repair;`.
- `crates/aionui-db/tests/user_scope_pre_migration_repair.rs` — new v29-fixture upgrade integration tests.

No migration SQL is added or modified; `git diff --stat <baseline>..HEAD -- crates/aionui-db/migrations/` is empty.

## Test plan

All gates run in the fix worktree.

- [x] `cargo test -p aionui-db migrate_repair` — 11 unit tests (gate, A-class, C-class dedup + session re-point, `system_settings` promotion, diagnostic-only B-class, post-repair residual re-check).
- [x] `cargo test -p aionui-db --test user_scope_pre_migration_repair` — 4 integration tests: stuck user self-heals and 030 applies; already-applied 030 upgrades without `VersionMismatch`; repair is idempotent; C-class dedup prevents UNIQUE-family failure.
- [x] Regression: `user_scope_migration` (21) and `db_lifecycle` (12) unchanged.
- [x] `just migration-check` — migration immutability check passed (030 byte-for-byte unchanged).
- [x] `cargo clippy --workspace -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Full workspace tests via `cargo nextest run --workspace` (run in 4 partitions to fit the CI/tooling time window) — all partitions passed, 0 failures.

## Coverage caveat

The exact field dirty-data shape is objectively unreachable pre-release (no real user database is available), so real-population coverage could not be verified before shipping. This is mitigated by the named-check diagnostic preflight plus the post-repair residual re-check (names and counts only, no user payloads), so the next batch of production logs can confirm the field distribution and attribute any residual failure. A recovery-UX path is deliberately deferred.

## Notes

- No AI attribution.
