### PR TITLE
fix(team): derive team capability from probed MCP transports, not a stored veto

### DIFF
--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -791,9 +791,19 @@ fn decode_row(
     };
 
     let backend_str = row.backend.as_deref().unwrap_or("");
-    let inferred_team_capable = behavior_policy.supports_team
+    // Team MEMBERSHIP (may this agent be picked into a team) — distinct from the
+    // team TRANSPORT chosen later at provisioning time, which reads capabilities
+    // only. Whitelist first, inference second:
+    //   - `supports_team` is the known-good opt-in (migration 014). It carries
+    //     agents whose `agent_capabilities` are still NULL because they have never
+    //     handshaken on this machine (claude/codex/gemini on a fresh install), and
+    //     aionrs, whose NULL backend the inference cannot judge at all.
+    //   - otherwise infer from the advertised MCP transports / CLI eligibility.
+    // There is deliberately no veto flag on this path: a stored "false" could not
+    // be lifted once an agent proved itself, since builtin rows reject metadata
+    // edits through the agent API.
+    let team_capable = behavior_policy.supports_team
         || aionui_common::constants::is_team_capable(backend_str, handshake.agent_capabilities.as_ref());
-    let team_capable = behavior_policy.team_capable_override.unwrap_or(inferred_team_capable);
 
     let mut meta = AgentMetadata {
         id: row.id,
@@ -1631,7 +1641,13 @@ mod tests {
         assert_eq!(pi.agent_source_info.binary_name.as_deref(), Some("pi"));
         assert_eq!(pi.agent_source_info.bridge_binary.as_deref(), Some("npx"));
         assert_eq!(pi.native_skills_dirs.as_deref(), Some(&[".pi/skills".to_owned()][..]));
-        assert!(!pi.team_capable);
+        // Team-capable through the CLI transport. pi advertises no optional MCP
+        // transport and LIVE-probed does not load a stdio MCP server, so Team
+        // gives it the `$AIONUI_HELPER_BIN team ...` command surface instead of
+        // MCP tools — but that surface works, so the picker must not block it.
+        // (This asserted `false` while builtin rows carried a hard veto flag; the
+        // flag is gone, and blocking a CLI-coordinating agent was never right.)
+        assert!(pi.team_capable);
         assert_eq!(pi.yolo_id, None);
         assert_eq!(
             pi.handshake

--- a/crates/aionui-api-types/src/agent_discovery.rs
+++ b/crates/aionui-api-types/src/agent_discovery.rs
@@ -83,15 +83,6 @@ pub struct BehaviorPolicy {
 
     #[serde(default)]
     pub supports_team: bool,
-
-    /// Explicitly override team-mode inference for protocol outliers.
-    ///
-    /// ACP normally requires stdio MCP support, so the presence of
-    /// `mcp_capabilities` is enough to infer team support. Some adapters accept
-    /// `mcpServers` but do not wire them into the wrapped agent; those adapters
-    /// must set this to `Some(false)`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub team_capable_override: Option<bool>,
 }
 
 /// Handshake-derived fields captured from the ACP init/session-response.
@@ -453,22 +444,24 @@ mod behavior_policy_tests {
     fn supports_team_defaults_false_and_roundtrips() {
         let empty: BehaviorPolicy = serde_json::from_str("{}").unwrap();
         assert!(!empty.supports_team);
-        assert_eq!(empty.team_capable_override, None);
 
         let with_team: BehaviorPolicy = serde_json::from_str(r#"{"supports_team":true}"#).unwrap();
         assert!(with_team.supports_team);
 
         let serialized = serde_json::to_string(&with_team).unwrap();
         assert!(serialized.contains("\"supports_team\":true"));
-        assert!(!serialized.contains("team_capable_override"));
     }
 
+    /// A retired veto flag must not resurrect itself: older persisted rows still
+    /// carry `team_capable_override`, and deserializing them has to ignore the key
+    /// rather than fail (the field was removed together with its veto branch).
     #[test]
-    fn team_capable_override_roundtrips_explicit_false() {
-        let policy: BehaviorPolicy = serde_json::from_str(r#"{"team_capable_override":false}"#).unwrap();
-        assert_eq!(policy.team_capable_override, Some(false));
+    fn retired_team_capable_override_key_is_ignored() {
+        let policy: BehaviorPolicy =
+            serde_json::from_str(r#"{"supports_team":false,"team_capable_override":false}"#).unwrap();
+        assert!(!policy.supports_team);
 
         let serialized = serde_json::to_string(&policy).unwrap();
-        assert!(serialized.contains("\"team_capable_override\":false"));
+        assert!(!serialized.contains("team_capable_override"));
     }
 }

--- a/crates/aionui-app/tests/team_e2e.rs
+++ b/crates/aionui-app/tests/team_e2e.rs
@@ -89,8 +89,12 @@ async fn ensure_default_team_assistant(
 }
 
 async fn mark_claude_backend_team_mcp_stdio_capable(services: &aionui_app::AppServices) {
+    // Team injects a stdio MCP server, but an agent never ADVERTISES stdio: ACP
+    // makes that transport mandatory, so `mcpCapabilities` only carries the
+    // optional `http`/`sse` flags. This mirrors what real claude reports; the
+    // fixture used to claim `stdio: true`, a shape no ACP agent emits.
     let capabilities = json!({
-        "mcp_capabilities": { "stdio": true },
+        "mcp_capabilities": { "http": true, "sse": true },
         "shell": true
     })
     .to_string();

--- a/crates/aionui-common/src/constants.rs
+++ b/crates/aionui-common/src/constants.rs
@@ -80,11 +80,21 @@ pub fn has_mcp_capability(agent_capabilities: Option<&serde_json::Value>) -> boo
     mcp_capability_object(agent_capabilities).is_some()
 }
 
+/// Whether the agent actually implements MCP, judged from the transports it
+/// advertises in `mcpCapabilities`.
+///
+/// ACP declares stdio mandatory and therefore has no `stdio` flag to read — but
+/// LIVE evidence shows the declaration is not honoured uniformly: `omp`
+/// (`http:true,sse:true`) loads a stdio MCP server, while `pi`
+/// (`http:false,sse:false`) does not, both probed with the same stdio-launched
+/// Sentry MCP server. So an agent that advertises NO optional transport is
+/// treated as not implementing MCP at all, and Team falls back to the CLI
+/// transport for it.
 fn has_enabled_team_mcp_transport(agent_capabilities: Option<&serde_json::Value>) -> bool {
     let Some(caps) = mcp_capability_object(agent_capabilities) else {
         return false;
     };
-    bool_field(caps, "stdio") || bool_field(caps, "http")
+    bool_field(caps, "http") || bool_field(caps, "sse")
 }
 
 fn mcp_capability_object(agent_capabilities: Option<&serde_json::Value>) -> Option<&serde_json::Value> {
@@ -139,24 +149,33 @@ mod tests {
         assert!(supports_team_mcp("aionrs", Some(&json!({}))));
     }
 
+    /// LIVE-probed contract (2026-07-30, same stdio-launched Sentry MCP server on
+    /// both): `omp` advertises `http:true,sse:true` and loads the server; `pi`
+    /// advertises `http:false,sse:false` and does not. So an advertised optional
+    /// transport — EITHER one — is the signal that the agent implements MCP at
+    /// all, and advertising neither means Team must not route MCP to it. ACP has
+    /// no `stdio` flag (the transport is mandatory in the spec and therefore never
+    /// declared), so reading one only ever matched non-ACP payloads.
     #[test]
-    fn acp_backends_require_stdio_or_http_capability_for_team_mcp() {
-        assert!(supports_team_mcp(
-            "claude",
-            Some(&json!({ "mcp_capabilities": { "stdio": true } }))
-        ));
+    fn acp_backends_require_an_advertised_mcp_transport_for_team_mcp() {
         assert!(supports_team_mcp(
             "codex",
             Some(&json!({ "mcp_capabilities": { "http": true, "sse": false } }))
         ));
-
-        assert!(!supports_team_mcp(
+        assert!(supports_team_mcp(
             "gemini",
             Some(&json!({ "mcp_capabilities": { "http": false, "sse": true } }))
         ));
+
         assert!(!supports_team_mcp(
             "codebuddy",
             Some(&json!({ "mcp_capabilities": { "http": false, "sse": false } }))
+        ));
+        // A spec-mandatory transport is never advertised, so it can never be the
+        // evidence: claiming `stdio` must not by itself unlock Team MCP.
+        assert!(!supports_team_mcp(
+            "claude",
+            Some(&json!({ "mcp_capabilities": { "stdio": true } }))
         ));
         assert!(!supports_team_mcp("acp", None));
         assert!(!supports_team_mcp("claude", Some(&json!({ "mcp_capabilities": {} }))));

--- a/crates/aionui-db/migrations/033_team_capability_criteria.sql
+++ b/crates/aionui-db/migrations/033_team_capability_criteria.sql
@@ -1,0 +1,252 @@
+-- Migration 033: retire the team-capability veto flag and seed the handshake
+-- capabilities the ACP Registry sync captured but never persisted.
+--
+-- Two defects, one root: since 023/025 every Registry-synced builtin shipped
+-- `behavior_policy.team_capable_override = false`, a HARD veto that beat every
+-- inference, while `agent_capabilities` was left NULL even though the
+-- integration probe had already read it from `initialize`. The result was a
+-- permanently team-blocked agent whose block could not be lifted (builtin rows
+-- reject metadata edits) and whose real MCP capability was unknown to the
+-- backend until the agent first connected.
+--
+-- 1) Drop `team_capable_override` from every behavior_policy. The veto branch is
+--    gone from the hydrate path, so a leftover key would be silently ignored;
+--    removing it keeps the stored policy honest about what the code reads.
+--
+-- 2) Drop only the `supports_team: false` entries. The flag is an OR-term over
+--    the handshake inference, so `false` never denied anything — it just read
+--    like a decision. `true` entries STAY: they are the known-good whitelist
+--    (migration 014) and are load-bearing whenever `agent_capabilities` is still
+--    NULL, which on a fresh install is the case for claude/codex/gemini and for
+--    aionrs (whose backend is NULL, so the inference cannot judge it at all).
+--
+-- 3) Seed `agent_capabilities` for every agent the Registry-sync workflow added
+--    since 023 and left NULL: the 9 npx rows of 025, plus 029 (mimo-code) and 031
+--    (omp). 023 (pi) already seeded its own and needs nothing here.
+--
+--    All values come from a LIVE probe (2026-07-30): ACP `initialize` only — no
+--    session/new, so no login was required — run against the npx versions pinned
+--    in acp-registry-npx-lock.json and, for binary distributions, against the
+--    product CLIs the workflow requires installing at integration time. Only rows
+--    still NULL are written, so a value already learned from a real handshake is
+--    never clobbered; the runtime overwrites the seed on the next connect.
+--
+-- Rows are addressed by `agent_id`, the stable identity every install shares
+-- (builtin seeds set `agent_id = id`); `backend` is a display-adjacent field that
+-- earlier migrations have already renamed and normalized, so it is not a safe key.
+
+UPDATE agent_metadata
+SET behavior_policy = json_remove(behavior_policy, '$.team_capable_override'),
+    updated_at = unixepoch('now','subsec')*1000
+WHERE behavior_policy IS NOT NULL
+  AND json_valid(behavior_policy)
+  AND json_extract(behavior_policy, '$.team_capable_override') IS NOT NULL;
+
+UPDATE agent_metadata
+SET behavior_policy = json_remove(behavior_policy, '$.supports_team'),
+    updated_at = unixepoch('now','subsec')*1000
+WHERE behavior_policy IS NOT NULL
+  AND json_valid(behavior_policy)
+  AND json_extract(behavior_policy, '$.supports_team') = 0;
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"prompt_capabilities":{"image":true,"audio":false,"embedded_context":true},"mcp_capabilities":{"http":false,"sse":false},"session_capabilities":{"modes":true,"commands":true}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'a11632d4' AND agent_capabilities IS NULL;  -- deepagents
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"prompt_capabilities":{"image":true,"audio":false,"embedded_context":true},"mcp_capabilities":{"http":true,"sse":false},"session_capabilities":{"list":{},"resume":{},"close":{}}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'd14634b4' AND agent_capabilities IS NULL;  -- dimcode
+
+-- dirac advertises no `mcp_capabilities` object at all (its extensions ride in
+-- `_meta`), so Team keeps it on the CLI transport until a probe proves MCP. Its
+-- vendor `_meta` block is omitted here: nothing in the backend reads it, and the
+-- next real handshake restores it verbatim.
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"providers":{},"prompt_capabilities":{"image":true,"audio":false,"embedded_context":true},"session_capabilities":{"resume":{},"close":{},"delete":{}}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '6a95eb4f' AND agent_capabilities IS NULL;  -- dirac
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"mcp_capabilities":{"http":true},"prompt_capabilities":{"image":true,"embedded_context":true},"session_capabilities":{"list":{},"fork":{},"resume":{},"close":{}}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '5431c523' AND agent_capabilities IS NULL;  -- glm-acp-agent
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"mcp_capabilities":{"http":true,"sse":true},"prompt_capabilities":{"image":true,"embedded_context":true},"session_capabilities":{"list":{},"fork":{},"resume":{},"close":{}}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '54c5ccf0' AND agent_capabilities IS NULL;  -- kilo
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"mcp_capabilities":{"http":true,"sse":true},"prompt_capabilities":{"image":true,"embedded_context":true},"session_capabilities":{"list":{},"fork":{},"search":{},"resume":{},"close":{},"delete":{},"tools":{"list":{}}}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '19e05df6' AND agent_capabilities IS NULL;  -- nova
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"prompt_capabilities":{"image":false,"audio":false,"embedded_context":false},"mcp_capabilities":{"http":false,"sse":false},"session_capabilities":{"fork":{}},"auth":{}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '79767ac2' AND agent_capabilities IS NULL;  -- sigit
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"mcp_capabilities":{"http":true,"sse":true},"prompt_capabilities":{"image":true,"embedded_context":true},"session_capabilities":{"list":{},"fork":{},"resume":{}}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'b3252207' AND agent_capabilities IS NULL;  -- autohand
+
+-- grok's `_meta` carries x.ai hook/tool-override extensions; omitted for the same
+-- reason as dirac's (unread by the backend, restored by the next handshake).
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"mcp_capabilities":{"http":true,"sse":true},"prompt_capabilities":{"image":false,"audio":false,"embedded_context":true},"session_capabilities":{},"auth":{}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '145a4e5c' AND agent_capabilities IS NULL;  -- grok
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"mcp_capabilities":{"http":true,"sse":true},"prompt_capabilities":{"image":true,"embedded_context":true},"session_capabilities":{"list":{},"fork":{},"resume":{}}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '8f21c6d3' AND agent_capabilities IS NULL;  -- mimo-code
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"mcp_capabilities":{"http":true,"sse":true},"prompt_capabilities":{"image":true,"embedded_context":true},"session_capabilities":{"list":{},"fork":{},"resume":{},"close":{}}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'c9e8a2f4' AND agent_capabilities IS NULL;  -- omp
+
+-- Binary-distributed agents from 025, probed against the product CLIs this
+-- workspace has installed (the skill requires installing them at integration
+-- time). Vendor `_meta` extension blocks are omitted as above.
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"prompt_capabilities":{"image":true,"embedded_context":true},"mcp_capabilities":{"http":true,"sse":true}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'ca45e378' AND agent_capabilities IS NULL;  -- amp-acp
+-- cortex-code advertises no mcp_capabilities object at all.
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"session_capabilities":{"list":{}}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'd5fd9849' AND agent_capabilities IS NULL;  -- cortex-code
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":false,"prompt_capabilities":{"image":true,"audio":false,"embedded_context":false},"mcp_capabilities":{"http":false,"sse":false},"session_capabilities":{}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'e9bf0ab3' AND agent_capabilities IS NULL;  -- corust-agent
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"prompt_capabilities":{"image":true,"audio":false,"embedded_context":true},"mcp_capabilities":{"http":false,"sse":false},"session_capabilities":{"list":{},"additional_directories":{}}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '5792d298' AND agent_capabilities IS NULL;  -- devin
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"mcp_capabilities":{"http":true,"sse":true},"prompt_capabilities":{"audio":true,"embedded_context":true,"image":true},"session":{"inject":{"modes":["queue","steer"],"pending":{"replace":true}},"inject_host_event":{"delivery":["turn_boundary","immediate","after_next_tool_call"],"kinds":["host_tool_result","host_attachment"]},"remind":{"modes":["interrupt_immediate","finish_step","audit_only"],"pending":{"list":true,"revoke":true}}},"session_capabilities":{"cancel_tool_call":{},"close":{},"list":{},"redo":{},"restore_tool_call":{},"resume":{},"rollback":{}}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'ca2e896a' AND agent_capabilities IS NULL;  -- harn
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"prompt_capabilities":{"audio":false,"image":true,"embedded_context":true},"mcp_capabilities":{"http":true,"sse":true},"session_capabilities":{"fork":{},"list":{},"resume":{},"additional_directories":{}},"auth":{"logout":{}}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'edd2858a' AND agent_capabilities IS NULL;  -- junie
+-- poolside advertises an EMPTY mcp_capabilities object (neither transport).
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"auth":{"logout":{}},"load_session":true,"mcp_capabilities":{},"prompt_capabilities":{"image":true},"session_capabilities":{"close":{},"delete":{},"list":{}}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '0d1e478d' AND agent_capabilities IS NULL;  -- poolside
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"prompt_capabilities":{"image":true,"audio":false,"embedded_context":true},"mcp_capabilities":{"http":true,"sse":true},"session_capabilities":{}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'b6ba32f7' AND agent_capabilities IS NULL;  -- stakpak
+-- vtcode gates its ACP surface behind VT_ACP_ENABLED, which its row already
+-- carries in `env` (025); the probe had to pass the same variable explicitly.
+
+UPDATE agent_metadata
+SET agent_capabilities = '{"load_session":true,"prompt_capabilities":{"image":true,"audio":true,"embedded_context":true},"mcp_capabilities":{"http":true,"sse":false},"session_capabilities":{}}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '2ab86949' AND agent_capabilities IS NULL;  -- vtcode
+
+-- 4) Seed `auth_methods` from the same probe. Migration 003 pre-filled this
+--    column alongside `agent_capabilities` for exactly the same reason — the UI
+--    renders sign-in entry points from it — and 023 (pi) did too, but 025/029/031
+--    omitted it, so 20 rows shipped unable to offer a login until the agent's
+--    first successful start. `initialize` returns it without login, so it was
+--    available at integration time.
+--
+--    Not seeded: cortex-code, dimcode, poolside and vtcode advertise no auth
+--    methods at all; junie's advertise a JUNIE_HOME pointing at the probe host's
+--    home directory, so its blob cannot be captured host-independently and is
+--    left to the first real handshake. Per 003, a `_meta.terminal-auth.command`
+--    emitted as an absolute path is stored as the bare command name (amp-acp).
+
+UPDATE agent_metadata
+SET auth_methods = '[{"id":"autohand-login","name":"Login to Autohand","description":"Sign in with your Autohand account","_meta":{"terminal-auth":{"command":"autohand","args":["login"],"label":"Autohand Login"}}}]',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'b3252207' AND auth_methods IS NULL;  -- autohand
+
+UPDATE agent_metadata
+SET auth_methods = '[{"id":"anthropic","name":"Anthropic API Key","type":"env_var","vars":[{"name":"ANTHROPIC_API_KEY"}],"link":"https://console.anthropic.com/settings/keys"},{"id":"openai","name":"OpenAI API Key","type":"env_var","vars":[{"name":"OPENAI_API_KEY"}],"link":"https://platform.openai.com/api-keys"},{"id":"deepagents-setup","name":"DeepAgents Setup","description":"Configure LLM provider credentials via environment variables"}]',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'a11632d4' AND auth_methods IS NULL;  -- deepagents
+
+UPDATE agent_metadata
+SET auth_methods = '[{"id":"openai-codex-oauth","name":"Sign in with ChatGPT","description":"Authenticate with your ChatGPT Plus/Pro/Team subscription"}]',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '6a95eb4f' AND auth_methods IS NULL;  -- dirac
+
+UPDATE agent_metadata
+SET auth_methods = '[{"id":"z-ai-api-key","name":"Z.AI API key","description":"Set Z_AI_API_KEY in the environment, or run `glm-acp-agent --setup` once to store the key on disk. Generate one at https://z.ai/manage-apikey/apikey-list"},{"type":"env_var","id":"z_ai_api_key","name":"Z.AI API key","description":"API key for the Z.AI / Zhipu AI service. Generate one at https://z.ai/manage-apikey/apikey-list","link":"https://z.ai/manage-apikey/apikey-list","vars":[{"name":"Z_AI_API_KEY","label":"Z.AI API key","secret":true,"optional":false}]}]',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '5431c523' AND auth_methods IS NULL;  -- glm-acp-agent
+
+UPDATE agent_metadata
+SET auth_methods = '[{"id":"grok.com","name":"Grok","description":"Sign in with Grok"}]',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '145a4e5c' AND auth_methods IS NULL;  -- grok
+
+UPDATE agent_metadata
+SET auth_methods = '[{"description":"Run `kilo auth login` in the terminal","name":"Login with Kilo","id":"kilo-login"}]',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '54c5ccf0' AND auth_methods IS NULL;  -- kilo
+
+UPDATE agent_metadata
+SET auth_methods = '[{"description":"Run `opencode auth login` in the terminal","name":"Login with opencode","id":"opencode-login"}]',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '8f21c6d3' AND auth_methods IS NULL;  -- mimo-code
+
+UPDATE agent_metadata
+SET auth_methods = '[{"id":"kore-terminal-auth","type":"terminal","name":"Nova Setup","description":"Complete interactive setup in the terminal to configure API keys","args":["@compass-ai/nova","setup"],"env":{}}]',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '19e05df6' AND auth_methods IS NULL;  -- nova
+
+UPDATE agent_metadata
+SET auth_methods = '[{"id":"agent","name":"Use existing local credentials","description":"Authenticate via the provider keys/OAuth state already configured under ~/.omp."}]',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'c9e8a2f4' AND auth_methods IS NULL;  -- omp
+
+UPDATE agent_metadata
+SET auth_methods = '[{"id":"sigit","name":"Sign in to siGit Code","description":"Sign in with `/login <email> <password>` in the message box."}]',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '79767ac2' AND auth_methods IS NULL;  -- sigit
+
+UPDATE agent_metadata
+SET auth_methods = '[{"id":"setup","name":"Amp API Key Setup","description":"Run interactive setup to configure your Amp API key","_meta":{"terminal-auth":{"command":"amp-acp","args":["--setup"],"label":"Amp API Key Setup"}}}]',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'ca45e378' AND auth_methods IS NULL;  -- amp-acp
+
+UPDATE agent_metadata
+SET auth_methods = '[{"id":"oauth_browser","name":"Login via browser","description":"Open a browser and complete OAuth login"}]',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'e9bf0ab3' AND auth_methods IS NULL;  -- corust-agent
+
+UPDATE agent_metadata
+SET auth_methods = '[{"id":"devin-browser","name":"Log in with browser","description":"Sign in via your browser"}]',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = '5792d298' AND auth_methods IS NULL;  -- devin
+
+UPDATE agent_metadata
+SET auth_methods = '[{"_meta":{"harn":{"challenge":{"type":"none"},"scheme":"none"}},"description":"Connect without credentials. The agent runs locally and accepts the session as an anonymous principal.","id":"none","name":"Local (no authentication)","type":"agent"}]',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'ca2e896a' AND auth_methods IS NULL;  -- harn
+
+UPDATE agent_metadata
+SET auth_methods = '[{"id":"stakpak","name":"Login to Stakpak","description":"Authenticate via browser to get your Stakpak API key. A browser window will open for you to sign in."}]',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_id = 'b6ba32f7' AND auth_methods IS NULL;  -- stakpak

--- a/crates/aionui-db/src/models/agent_metadata.rs
+++ b/crates/aionui-db/src/models/agent_metadata.rs
@@ -33,9 +33,16 @@ pub struct AgentMetadataRow {
 
     pub behavior_policy: Option<String>,
     /// Native mode id that AionUi's legacy `yolo` / `yoloNoSandbox`
-    /// aliases resolve to before calling `session/set_mode`. `None`
-    /// means the backend has no yolo equivalent and the alias should
-    /// pass through unchanged.
+    /// aliases resolve to before calling `session/set_mode`.
+    ///
+    /// `None` does NOT mean "pass the alias through unchanged": every
+    /// DB-reading caller falls back to `AgentType::full_auto_mode_id`
+    /// (`aionui-common/src/enums.rs`), a hardcoded per-backend table whose
+    /// default arm is the literal `"yolo"` — see Team spawn
+    /// (`aionui-team/src/service/spawn_support.rs`) and cron
+    /// (`aionui-cron/src/service.rs`). So clearing this column silently hands
+    /// the agent that table's guess. Keep the two in sync: an agent whose
+    /// verified mode id is stored here should not also be listed there.
     pub yolo_id: Option<String>,
 
     pub agent_capabilities: Option<String>,

--- a/crates/aionui-db/tests/pi_acp_agent_migration.rs
+++ b/crates/aionui-db/tests/pi_acp_agent_migration.rs
@@ -22,7 +22,10 @@ async fn pi_acp_builtin_metadata_is_seeded() {
 
     let behavior_policy: serde_json::Value =
         serde_json::from_str(pi.behavior_policy.as_deref().expect("seeded behavior policy")).unwrap();
-    assert_eq!(behavior_policy["team_capable_override"], false);
+    // 033 strips the retired team veto keys: team capability is derived from the
+    // advertised MCP transports, never pinned in the stored policy.
+    assert!(behavior_policy.get("team_capable_override").is_none());
+    assert!(behavior_policy.get("supports_team").is_none());
 
     let capabilities: serde_json::Value =
         serde_json::from_str(pi.agent_capabilities.as_deref().expect("seeded capabilities")).unwrap();

--- a/crates/aionui-db/tests/registry_binary_agents_migration.rs
+++ b/crates/aionui-db/tests/registry_binary_agents_migration.rs
@@ -28,6 +28,9 @@ async fn verified_registry_binary_agents_store_stable_registry_identity() {
         assert!(source.get("distribution").is_none());
         assert!(source.get("version").is_none());
         let policy: serde_json::Value = serde_json::from_str(row.behavior_policy.as_deref().unwrap()).unwrap();
-        assert_eq!(policy["team_capable_override"], false);
+        // 033 retired both team veto keys; capability is derived from the agent's
+        // advertised MCP transports, never pinned in the stored policy.
+        assert!(policy.get("team_capable_override").is_none());
+        assert!(policy.get("supports_team").is_none());
     }
 }

--- a/crates/aionui-db/tests/registry_npx_agents_migration.rs
+++ b/crates/aionui-db/tests/registry_npx_agents_migration.rs
@@ -80,6 +80,13 @@ async fn verified_registry_npx_agents_use_stable_packages_and_conservative_team_
         assert_eq!(source["binary_name"], binary_name, "{backend} binary_name");
         assert_eq!(source["bridge_binary"], "npx", "{backend} bridge_binary");
         let policy: serde_json::Value = serde_json::from_str(row.behavior_policy.as_deref().unwrap()).unwrap();
-        assert_eq!(policy["team_capable_override"], false, "{backend} team policy");
+        // 033 retired the veto flag and the no-op `supports_team: false`; a
+        // Registry agent's team membership is inferred from its advertised MCP
+        // transports, never pinned in the stored policy.
+        assert!(
+            policy.get("team_capable_override").is_none(),
+            "{backend} team_capable_override"
+        );
+        assert!(policy.get("supports_team").is_none(), "{backend} supports_team");
     }
 }

--- a/crates/aionui-db/tests/team_capability_criteria_migration.rs
+++ b/crates/aionui-db/tests/team_capability_criteria_migration.rs
@@ -1,0 +1,205 @@
+use aionui_db::{IAgentMetadataRepository, SqliteAgentMetadataRepository, init_database_memory};
+
+/// 033 retires the keys the Registry-sync workflow wrote that never meant what
+/// they looked like: `team_capable_override` hard-vetoed team mode with no way to
+/// lift it (builtin rows reject metadata edits), and `supports_team: false` read
+/// like a denial while being a no-op inside an OR.
+#[tokio::test]
+async fn retired_team_policy_keys_are_stripped_from_every_seeded_policy() {
+    let db = init_database_memory().await.unwrap();
+    let repo = SqliteAgentMetadataRepository::new(db.pool().clone());
+
+    let rows = repo.list_all().await.unwrap();
+    assert!(!rows.is_empty(), "seeded agent metadata is present");
+
+    for row in rows {
+        let Some(policy) = row.behavior_policy.as_deref() else {
+            continue;
+        };
+        let policy: serde_json::Value = serde_json::from_str(policy).unwrap();
+        let backend = row.backend.as_deref().unwrap_or("<no backend>");
+        assert!(
+            policy.get("team_capable_override").is_none(),
+            "{backend} still carries the retired team_capable_override"
+        );
+        assert_ne!(
+            policy.get("supports_team"),
+            Some(&serde_json::Value::Bool(false)),
+            "{backend} still carries a no-op supports_team: false"
+        );
+    }
+}
+
+/// The known-good whitelist (migration 014) survives 033. These rows are
+/// load-bearing: on a fresh install claude/codex/gemini have NULL capabilities
+/// until their first handshake, and aionrs has a NULL backend the capability
+/// inference cannot judge at all — without the flag they would not be selectable.
+#[tokio::test]
+async fn known_good_team_whitelist_survives() {
+    let db = init_database_memory().await.unwrap();
+    let repo = SqliteAgentMetadataRepository::new(db.pool().clone());
+
+    for backend in ["claude", "codex", "gemini", "codebuddy"] {
+        let row = repo
+            .find_builtin_by_backend(backend)
+            .await
+            .unwrap()
+            .unwrap_or_else(|| panic!("{backend} is seeded"));
+        let policy: serde_json::Value = serde_json::from_str(row.behavior_policy.as_deref().unwrap()).unwrap();
+        assert_eq!(
+            policy.get("supports_team"),
+            Some(&serde_json::Value::Bool(true)),
+            "{backend} keeps its known-good team whitelist entry"
+        );
+    }
+
+    let aionrs = repo
+        .list_all()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|row| row.agent_type == "aionrs")
+        .expect("aionrs row is seeded");
+    let policy: serde_json::Value = serde_json::from_str(aionrs.behavior_policy.as_deref().unwrap()).unwrap();
+    assert_eq!(policy.get("supports_team"), Some(&serde_json::Value::Bool(true)));
+}
+
+/// `auth_methods` is the other half of the same omission: migration 003 pre-filled
+/// it next to `agent_capabilities` so the UI can offer a sign-in before the agent
+/// has ever started, and 023 (pi) did too, but 025/029/031 skipped it. Four agents
+/// advertise none at all, and junie's embed the probe host's home directory, so
+/// those five stay NULL by design rather than carry a doctored blob.
+#[tokio::test]
+async fn probed_registry_agents_carry_seeded_auth_methods() {
+    let db = init_database_memory().await.unwrap();
+    let repo = SqliteAgentMetadataRepository::new(db.pool().clone());
+
+    let seeded = [
+        "autohand",
+        "deepagents",
+        "dirac",
+        "glm-acp-agent",
+        "grok",
+        "kilo",
+        "mimo-code",
+        "nova",
+        "omp",
+        "sigit",
+        "amp-acp",
+        "corust-agent",
+        "devin",
+        "harn",
+        "stakpak",
+    ];
+    for backend in seeded {
+        let row = repo
+            .find_builtin_by_backend(backend)
+            .await
+            .unwrap()
+            .unwrap_or_else(|| panic!("{backend} is seeded"));
+        let raw = row
+            .auth_methods
+            .as_deref()
+            .unwrap_or_else(|| panic!("{backend} carries seeded auth_methods"));
+        let methods: serde_json::Value = serde_json::from_str(raw).unwrap();
+        assert!(
+            methods.as_array().is_some_and(|m| !m.is_empty()),
+            "{backend} auth_methods is a non-empty array"
+        );
+        // A seeded blob must never carry the probe host's install layout.
+        assert!(!raw.contains("/Users/"), "{backend} auth_methods leaks a host path");
+        assert!(!raw.contains("/home/"), "{backend} auth_methods leaks a host path");
+    }
+
+    for backend in ["cortex-code", "dimcode", "poolside", "vtcode", "junie"] {
+        let row = repo
+            .find_builtin_by_backend(backend)
+            .await
+            .unwrap()
+            .unwrap_or_else(|| panic!("{backend} is seeded"));
+        assert!(
+            row.auth_methods.is_none(),
+            "{backend} advertises no host-independent auth methods and stays NULL"
+        );
+    }
+}
+
+/// 033 also seeds the handshake capabilities the Registry-sync probe captured
+/// from ACP `initialize` but never persisted, so Team can pick a transport before
+/// the agent has ever connected. Values are LIVE-probed (2026-07-30) at the npx
+/// versions pinned in acp-registry-npx-lock.json, and against the installed
+/// product CLIs for binary distributions.
+#[tokio::test]
+async fn probed_registry_agents_carry_seeded_mcp_capabilities() {
+    let db = init_database_memory().await.unwrap();
+    let repo = SqliteAgentMetadataRepository::new(db.pool().clone());
+
+    // (backend, http, sse) — `None` means the agent advertises no usable
+    // mcp_capabilities (absent or empty object), which keeps Team on the CLI
+    // transport for it. Covers EVERY agent added by migrations 025/029/031.
+    let cases: [(&str, Option<(bool, bool)>); 20] = [
+        // npx distributions (025 + 029 + 031)
+        ("autohand", Some((true, true))),
+        ("deepagents", Some((false, false))),
+        ("dimcode", Some((true, false))),
+        ("dirac", None),
+        ("glm-acp-agent", Some((true, false))),
+        ("grok", Some((true, true))),
+        ("kilo", Some((true, true))),
+        ("mimo-code", Some((true, true))),
+        ("nova", Some((true, true))),
+        ("omp", Some((true, true))),
+        ("sigit", Some((false, false))),
+        // binary distributions (025)
+        ("amp-acp", Some((true, true))),
+        ("cortex-code", None),
+        ("corust-agent", Some((false, false))),
+        ("devin", Some((false, false))),
+        ("harn", Some((true, true))),
+        ("junie", Some((true, true))),
+        ("poolside", None),
+        ("stakpak", Some((true, true))),
+        ("vtcode", Some((true, false))),
+    ];
+
+    for (backend, expected) in cases {
+        let row = repo
+            .find_builtin_by_backend(backend)
+            .await
+            .unwrap()
+            .unwrap_or_else(|| panic!("{backend} is seeded"));
+        let capabilities: serde_json::Value =
+            serde_json::from_str(row.agent_capabilities.as_deref().unwrap_or_else(|| {
+                panic!("{backend} carries seeded agent_capabilities");
+            }))
+            .unwrap();
+
+        match expected {
+            Some((http, sse)) => {
+                let mcp = capabilities
+                    .get("mcp_capabilities")
+                    .unwrap_or_else(|| panic!("{backend} advertises mcp_capabilities"));
+                assert_eq!(
+                    mcp.get("http").and_then(serde_json::Value::as_bool),
+                    Some(http),
+                    "{backend} http"
+                );
+                assert_eq!(
+                    mcp.get("sse").and_then(serde_json::Value::as_bool).unwrap_or(false),
+                    sse,
+                    "{backend} sse"
+                );
+            }
+            // Either the object is absent (cortex-code, dirac) or present but
+            // empty (poolside); both mean no usable transport was advertised.
+            None => {
+                let advertises_transport = capabilities.get("mcp_capabilities").is_some_and(|mcp| {
+                    ["http", "sse"]
+                        .iter()
+                        .any(|k| mcp.get(k).and_then(serde_json::Value::as_bool) == Some(true))
+                });
+                assert!(!advertises_transport, "{backend} advertises no usable MCP transport");
+            }
+        }
+    }
+}

--- a/crates/aionui-team/src/capability.rs
+++ b/crates/aionui-team/src/capability.rs
@@ -31,18 +31,24 @@ mod tests {
     }
 
     #[test]
-    fn acp_backend_mcp_transport_requires_stdio_or_http_capabilities() {
-        let caps_stdio = json!({"mcp_capabilities": {"stdio": true}});
-        assert!(is_team_capable_backend("qwen", Some(&caps_stdio)));
-        assert!(supports_team_mcp_backend("qwen", Some(&caps_stdio)));
+    fn acp_backend_mcp_transport_requires_an_advertised_optional_transport() {
+        let caps_sse_only = json!({"mcp_capabilities": {"http": false, "sse": true}});
+        assert!(is_team_capable_backend("qwen", Some(&caps_sse_only)));
+        assert!(supports_team_mcp_backend("qwen", Some(&caps_sse_only)));
 
         let caps_http = json!({"mcpCapabilities": {"http": true, "sse": true}});
         assert!(is_team_capable_backend("droid", Some(&caps_http)));
         assert!(supports_team_mcp_backend("droid", Some(&caps_http)));
 
-        let caps_mcp = json!({"mcp": {"stdio": true}});
+        let caps_mcp = json!({"mcp": {"http": true}});
         assert!(is_team_capable_backend("goose", Some(&caps_mcp)));
         assert!(supports_team_mcp_backend("goose", Some(&caps_mcp)));
+
+        // Spec-mandatory stdio is never advertised, so a claimed `stdio` flag is
+        // not evidence that the agent wired MCP up: Team keeps it on CLI.
+        let caps_stdio = json!({"mcp_capabilities": {"stdio": true}});
+        assert!(is_team_capable_backend("zed", Some(&caps_stdio)));
+        assert!(!supports_team_mcp_backend("zed", Some(&caps_stdio)));
 
         let caps_disabled_transport = json!({"mcp_capabilities": {"http": false, "sse": false}});
         assert!(is_team_capable_backend("zed", Some(&caps_disabled_transport)));

--- a/crates/aionui-team/src/provisioning.rs
+++ b/crates/aionui-team/src/provisioning.rs
@@ -406,6 +406,24 @@ impl TeamAgentProvisioner {
         Ok(())
     }
 
+    /// Pick how team tools reach this agent. Deliberately a DIFFERENT question
+    /// from "may this agent join a team" (`AgentMetadata::team_capable`), and
+    /// deliberately judged from `agent_capabilities` ALONE:
+    ///
+    /// - The membership gate may say yes from `behavior_policy.supports_team` — a
+    ///   known-good whitelist that needs no probe evidence. That whitelist must
+    ///   NOT reach in here: which transport actually works is a property of the
+    ///   running agent, not of a policy row, and guessing MCP for an agent that
+    ///   silently ignores injected `mcpServers` loses every team tool with no
+    ///   error to show for it. CLI is the safe answer when unproven.
+    /// - `agent_capabilities` is only written by a live handshake (plus the seed
+    ///   backfills in migrations 003/033). So an agent that has never connected on
+    ///   this machine has NULL capabilities and lands on CLI even when it does
+    ///   support MCP — notably claude/codex/gemini on a fresh install. The next
+    ///   rebuild after its first handshake promotes it to MCP.
+    ///
+    /// Both transports coordinate a team; MCP exposes the tools natively, CLI
+    /// prompts the agent to shell out to `$AIONUI_HELPER_BIN team ...`.
     pub(crate) async fn team_tool_transport(
         &self,
         user_id: &str,


### PR DESCRIPTION
## Problem

The Team member picker greys out every agent integrated since 2026-07-14 with *"This assistant's agent does not support team mode."* — including agents that demonstrably work (omp loads a stdio MCP server fine). Reported for OMP in iOfficeAI/AionUi#3749.

Root cause is a stored policy flag, not a capability:

1. **`behavior_policy.team_capable_override` hard-vetoes the inference.** Introduced in #618 (alongside the Pi agent) as `team_capable_override.unwrap_or(inferred)`, so a stored `Some(false)` discards the inference entirely. The Registry-sync skill then mandated writing `false` on every new row, so **21 builtins shipped permanently team-blocked** — and unliftable: builtin rows reject metadata edits through the agent API (`services/custom.rs:75`), so only a migration can change them.
2. **`agent_capabilities` was left NULL on those same rows**, even though the integration probe already reads it from ACP `initialize`. Migration 023 (pi) seeded it; 025/029/031 did not. So the backend had no evidence to infer from either.

## Fix

**Membership** (`registry.rs`) — whitelist first, inference second, no way to store a "no":

```rust
let team_capable = behavior_policy.supports_team
    || is_team_capable(backend_str, handshake.agent_capabilities.as_ref());
```

`supports_team: true` stays: it is migration 014's known-good whitelist and is load-bearing while capabilities are NULL (claude/codex/gemini on a fresh install) and for aionrs, whose NULL backend the inference cannot judge at all.

**MCP signal** (`constants.rs`) — `has_enabled_team_mcp_transport` now reads `http || sse` instead of `stdio || http`. ACP mandates stdio and therefore never declares it (`agent-client-protocol-schema-0.12.0/src/agent.rs:2718` "All Agents MUST support this transport"; `McpCapabilities` at :4473 has only `http`/`sse`), so the old term matched nothing on an ACP payload.

LIVE evidence for treating an advertised optional transport as the signal that MCP is actually implemented — same stdio-launched Sentry MCP server on both:

| agent | `mcpCapabilities` | loads the MCP server |
|---|---|---|
| omp | `http:true, sse:true` | yes |
| pi | `http:false, sse:false` | no |

**Migration 033** — strips `team_capable_override` everywhere and the no-op `supports_team: false`; keeps the `true` whitelist; seeds `agent_capabilities` for **all 20 agents added by 025/029/031** from a live `initialize` probe (2026-07-30). Rows are keyed by `agent_id`, the identity every install shares. Only NULL rows are written, so real handshake data is never clobbered.

Probe coverage (npx at release-lock versions; binary distributions against the installed product CLIs the workflow requires):

- **MCP** (12): autohand, dimcode, glm-acp-agent, grok, kilo, nova, mimo-code, omp, amp-acp, harn, junie, stakpak, vtcode
- **CLI** (8): deepagents, sigit, dirac, cortex-code, corust-agent, devin, poolside

Three distinct "no MCP" shapes now all covered by one assertion: object absent (cortex-code, dirac), object present but empty (poolside), object with all transports false (deepagents, sigit, corust-agent, devin).

**`team_tool_transport` is unchanged** — but now documents why it stays capabilities-only: which transport works is a property of the running agent, and guessing MCP for one that ignores injected `mcpServers` loses every team tool with no error. It also records the known consequence: an agent that has never handshaken on this machine lands on the CLI transport until its next rebuild.

## Skill updates

`aioncore-acp-registry-sync` (not in git — `.gitignore:533`) caused defect 1 and failed to prevent defect 2:

- SKILL.md step 9 — never write a negative team flag; `false` denies nothing and the veto is gone.
- SKILL.md step 10 (new) — persist the probed `agentCapabilities` into the seed row, snake_case-normalized per migration 003's contract. `initialize` needs no login, so this is always available at integration time.
- gap-analysis — the "新增 agent 必须显式写入 `team_capable_override=false`" rule is struck through and marked retired, and the "cannot judge team support from `mcpCapabilities` alone" note is corrected for the membership gate (the end-to-end bar still applies to granting a `supports_team: true` whitelist entry).

## Tests

- `constants.rs` / `capability.rs` — advertised-transport contract, incl. that a claimed `stdio` flag alone does not unlock Team MCP
- `agent_discovery.rs` — a leftover `team_capable_override` key in older persisted rows deserializes and is dropped
- `team_capability_criteria_migration.rs` (new) — retired keys stripped from every seeded policy; whitelist survives; all 20 backends carry the expected seeded MCP flags
- `registry.rs` — pi is now team-capable through the CLI transport (was asserting the old veto)

Targeted runs green: team 321, db migrations 7, ai-agent registry 25. `cargo clippy` clean, `cargo fmt` clean. Full `cargo nextest` intentionally not run.

Closes iOfficeAI/AionUi#3749

## Follow-up in the same PR: three defects the skill audit surfaced

A review of the `aioncore-acp-registry-sync` skill (which caused the veto rule and failed to prevent the NULL capabilities) turned up three more issues of the same class, all verified against source and fixed here:

1. **A stale duplicate of the skill shadowed the fixed one.** `SKILL.md` steps 2 and 7 tell you to run `.codex/skills/aioncore-acp-registry-sync/scripts/...`, and that directory was a full second copy whose gap-analysis still carried the retired "must write `team_capable_override=false`" rule. Neither copy is in git (`.gitignore` covers `.claude/`, `.git/info/exclude` covers `.codex/`), so the two could never be reconciled. The `.codex/` copy is now a symlink to the `.claude/` one — the scripts were byte-identical, only the two docs I had edited differed.

2. **`auth_methods` was the other half of the NULL-capabilities defect.** The probe reads `initialize.result.authMethods` (`acp_probe.mjs:113`), migration 003 pre-fills it *next to* `agent_capabilities` for exactly the same reason ("so the UI can render auth buttons ... without requiring a round-trip"), and 023 (pi) seeded both — but 025/029/031 seeded neither, so all 20 rows also shipped unable to offer a sign-in until first successful start. 033 now seeds it for the 15 agents whose blob is host-independent. Deliberately left NULL: cortex-code / dimcode / poolside / vtcode advertise no auth methods, and junie's embed a `JUNIE_HOME` pointing at the probe host's home directory. Per 003's rule, amp-acp's absolute `_meta.terminal-auth.command` is stored as the bare command name; a test asserts no seeded blob contains a host path.

3. **`yolo_id = NULL` is not inert.** The column's own doc comment claimed NULL means "the alias should pass through unchanged", but both consumers — Team spawn (`spawn_support.rs:40-51`) and cron (`service.rs:2087-2102`) — fall back to `AgentType::full_auto_mode_id` (`enums.rs:108-120`), a hardcoded per-backend match whose default arm is the literal `"yolo"`. So clearing the column silently hands the agent that table's guess. Migration 025 cleared cursor's `yolo_id` on the gap-analysis's instruction while the table still returns `"agent"` for it. Comment corrected; the skill contract now requires keeping the column and that match arm in sync in the same change.

Skill edits beyond the team flags: step 10 now covers **both** handshake columns and the host-path rule; the contract's `yolo_id` section documents the fallback coupling.


Related: iOfficeAI/AionUi#3803 (Pi agent Team Mode support) — this PR removes the stored veto that blocked Pi from the Team picker, so Pi becomes selectable through the CLI transport. It does NOT give Pi MCP-based team tools: Pi advertises `mcpCapabilities {http:false, sse:false}` and LIVE-probed does not load a stdio MCP server, so Team routes it to the `$AIONUI_HELPER_BIN team ...` command surface. Whether that satisfies the request is for the issue to decide.
