### PR TITLE
feat(project): hide OS-junk and VCS-internal noise from listings

### DIFF
--- a/crates/aionui-project/src/monitor/actor_test.rs
+++ b/crates/aionui-project/src/monitor/actor_test.rs
@@ -655,6 +655,42 @@ async fn live_change_fans_delta_to_subscriber_only() {
 }
 
 #[tokio::test]
+async fn noise_file_change_produces_no_delta() {
+    // Creating a noise file in a subscribed dir must not fan any delta (the
+    // precise-event stat path and the coarse read_dir rescan both hide noise),
+    // while a real sibling file still fans its delta.
+    let (actor, raw_rx, push, pe, dir, _db) = setup().await;
+    let (tx, rx) = unbounded_channel();
+    let handle = tokio::spawn(actor.run(rx, raw_rx));
+
+    tx.send(FsInbound::Frame {
+        session: "1".to_owned(),
+        user_id: "system_default_user".to_owned(),
+        frame: request(1, "fs/subscribe", json!({"targets":[dir_ref(&pe, "")]})),
+    })
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    // A noise file and a real file land together.
+    std::fs::write(dir.path().join(".DS_Store"), b"x").unwrap();
+    std::fs::write(dir.path().join("real.ts"), b"x").unwrap();
+
+    // The real file's delta arrives (control) — proving the watch is live.
+    assert!(
+        wait_until(&push, Duration::from_secs(5), |f| has_delta_adding(f, "1", "real.ts")).await,
+        "the real file must fan a delta"
+    );
+    // The noise file must never appear in any pushed frame.
+    assert!(
+        !push.frames().iter().any(|(_, f)| f.to_string().contains(".DS_Store")),
+        "noise file must not appear in any delta/snapshot"
+    );
+
+    drop(tx);
+    let _ = handle.await;
+}
+
+#[tokio::test]
 async fn overflow_fans_full_snapshot_through_event_loop() {
     // Drive a real event loop, but feed the raw-event channel ourselves (ignore
     // the watcher's) so we can inject a synthetic kernel overflow deterministically.

--- a/crates/aionui-project/src/runtime/local_provider.rs
+++ b/crates/aionui-project/src/runtime/local_provider.rs
@@ -19,6 +19,7 @@ use ignore::WalkBuilder;
 use crate::canonical;
 
 use super::error::FsError;
+use super::noise::should_hide;
 use super::provider::{EntryFact, IFsProvider, Kind};
 use super::search::{Budget, CancellationToken, IFsSearchProvider, NameMatcher, SearchSink};
 
@@ -126,6 +127,12 @@ impl IFsProvider for LocalFsProvider {
         let mut out = Vec::new();
         while let Some(entry) = rd.next_entry().await.map_err(|e| map_io(uri, &e))? {
             let name = entry.file_name().to_string_lossy().into_owned();
+            // Hide OS-junk / VCS-internal noise from the tree listing (same gate
+            // the search walk and precise-event apply use — keeps all three
+            // pipelines consistent).
+            if should_hide(&name) {
+                continue;
+            }
             let child = entry.path();
             let child_uri = canonical::to_file_uri(&child).unwrap_or_else(|_| uri.to_owned());
             let fact = fact_of(&child_uri, &child).await?;
@@ -250,6 +257,10 @@ fn walk_names(
         .git_global(false)
         .git_exclude(true)
         .require_git(false)
+        // Hide OS-junk / VCS-internal noise, matching the tree listing. On a
+        // directory this also prevents descent, so `.git` internals never leak
+        // into search results (the `ignore` crate does not skip `.git` itself).
+        .filter_entry(|entry| entry.file_name().to_str().map(|n| !should_hide(n)).unwrap_or(true))
         .build();
 
     for (seen, entry) in walker.enumerate() {

--- a/crates/aionui-project/src/runtime/local_provider_test.rs
+++ b/crates/aionui-project/src/runtime/local_provider_test.rs
@@ -220,6 +220,29 @@ async fn read_dir_populates_inode() {
     assert!(entries[0].1.inode != 0);
 }
 
+// ── noise filtering (read_dir) ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn read_dir_hides_os_junk_and_vcs_but_keeps_real_dotfiles() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    // Noise — must be hidden.
+    std::fs::write(root.join(".DS_Store"), b"x").unwrap();
+    std::fs::create_dir(root.join(".git")).unwrap();
+    std::fs::write(root.join("Thumbs.db"), b"x").unwrap();
+    std::fs::write(root.join("._resource"), b"x").unwrap();
+    // Kept — real files including user-meaningful dotfiles.
+    std::fs::write(root.join("README.md"), b"x").unwrap();
+    std::fs::write(root.join(".env"), b"x").unwrap();
+    std::fs::create_dir(root.join("src")).unwrap();
+
+    let provider = LocalFsProvider::new();
+    let mut entries = provider.read_dir(canon(root).as_str()).await.unwrap();
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    let names: Vec<&str> = entries.iter().map(|(n, _)| n.as_str()).collect();
+    assert_eq!(names, vec![".env", "README.md", "src"]);
+}
+
 // ── filename search (IFsSearchProvider) ──────────────────────────────────────
 
 /// Test sink: collects `(relative_path, name)` hits under a mutex.
@@ -316,6 +339,26 @@ async fn search_stops_at_budget_and_reports_limit_reached() {
     // Budget caps total emitted hits; the cap is reported.
     assert_eq!(hits.len(), 3);
     assert!(capped);
+}
+
+#[tokio::test]
+async fn search_hides_git_internals_and_os_junk() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(root.join(".git")).unwrap();
+    std::fs::write(root.join(".git").join("HEAD"), b"ref: x").unwrap();
+    std::fs::write(root.join(".git").join("config"), b"x").unwrap();
+    std::fs::write(root.join(".DS_Store"), b"x").unwrap();
+    std::fs::write(root.join("main.rs"), b"x").unwrap();
+
+    let (hits, _) = search_collect(root, "", MatchMode::Substring, 100).await;
+    let names: Vec<&str> = hits.iter().map(|(_, n)| n.as_str()).collect();
+    // Only the real file — no `.git` internals, no `.DS_Store`.
+    assert_eq!(names, vec!["main.rs"]);
+    assert!(
+        !hits.iter().any(|(rel, _)| rel.contains(".git")),
+        "search must not descend into .git: {hits:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/aionui-project/src/runtime/mod.rs
+++ b/crates/aionui-project/src/runtime/mod.rs
@@ -13,6 +13,7 @@ mod error;
 mod fs_runtime;
 mod local_provider;
 mod local_watcher;
+mod noise;
 mod provider;
 mod search;
 mod subscription;

--- a/crates/aionui-project/src/runtime/noise.rs
+++ b/crates/aionui-project/src/runtime/noise.rs
@@ -1,0 +1,56 @@
+//! Noise-file predicate — OS-junk and VCS-internal entries hidden from *every*
+//! listing so the tree, search, and incremental-delta pipelines stay consistent.
+//!
+//! The same [`should_hide`] gate is applied at all three entry points that turn
+//! filesystem names into tree/search results: the provider's `read_dir` (tree
+//! baseline + rescan), the search `ignore` walk (`filter_entry`), and the
+//! precise-event apply path (per-name `stat`). Hidden means the entry is never
+//! emitted at all (no wire change; distinct from the protocol's `excluded`
+//! marker, which is a visible-but-not-expanded directory).
+//!
+//! v1 uses a hardcoded default set (mirrors how ripgrep ships built-in
+//! defaults). A user-configurable overlay can layer on later without changing
+//! call sites — they only depend on [`should_hide`].
+
+/// Names hidden by exact match (compared case-insensitively). Covers VCS
+/// internals plus the common macOS / Windows / Linux junk files.
+const HIDDEN_EXACT: &[&str] = &[
+    // VCS internals — hiding `.git` also stops its objects/refs leaking into
+    // search results (the `ignore` crate does not skip `.git` on its own).
+    ".git",
+    // macOS
+    ".ds_store",
+    ".spotlight-v100",
+    ".trashes",
+    ".fseventsd",
+    ".appledouble",
+    ".apdisk",
+    // Windows
+    "thumbs.db",
+    "ehthumbs.db",
+    "desktop.ini",
+    "$recycle.bin",
+    // Linux
+    ".directory",
+];
+
+/// Names hidden by (case-insensitive) prefix.
+const HIDDEN_PREFIX: &[&str] = &[
+    "._",      // macOS AppleDouble resource-fork sidecars (`._file`)
+    ".trash-", // Linux trash directories (`.Trash-1000`)
+];
+
+/// Whether `name` is a noise entry to hide entirely from listings.
+///
+/// Case-insensitive: Windows and macOS fold case, and a case-sensitive Linux
+/// filesystem can still carry these names (synced/mounted volumes), so folding
+/// everywhere is the safe superset. `name` is a single path segment (file name),
+/// never a full path.
+pub(crate) fn should_hide(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    HIDDEN_EXACT.contains(&lower.as_str()) || HIDDEN_PREFIX.iter().any(|p| lower.starts_with(p))
+}
+
+#[cfg(test)]
+#[path = "noise_test.rs"]
+mod noise_test;

--- a/crates/aionui-project/src/runtime/noise_test.rs
+++ b/crates/aionui-project/src/runtime/noise_test.rs
@@ -1,0 +1,46 @@
+use super::should_hide;
+
+#[test]
+fn hides_vcs_internals() {
+    assert!(should_hide(".git"));
+}
+
+#[test]
+fn hides_macos_junk_case_insensitively() {
+    assert!(should_hide(".DS_Store"));
+    assert!(should_hide(".ds_store"));
+    assert!(should_hide(".Spotlight-V100"));
+    assert!(should_hide(".Trashes"));
+    assert!(should_hide(".fseventsd"));
+    // AppleDouble sidecars match by prefix.
+    assert!(should_hide("._resource"));
+    assert!(should_hide("._DS_Store"));
+}
+
+#[test]
+fn hides_windows_junk_case_insensitively() {
+    assert!(should_hide("Thumbs.db"));
+    assert!(should_hide("thumbs.db"));
+    assert!(should_hide("desktop.ini"));
+    assert!(should_hide("Desktop.ini"));
+    assert!(should_hide("$RECYCLE.BIN"));
+}
+
+#[test]
+fn hides_linux_trash_by_prefix() {
+    assert!(should_hide(".Trash-1000"));
+    assert!(should_hide(".directory"));
+}
+
+#[test]
+fn keeps_real_dotfiles_users_want() {
+    // Neither exact nor prefix noise — must stay visible.
+    assert!(!should_hide(".env"));
+    assert!(!should_hide(".github"));
+    assert!(!should_hide(".gitignore"));
+    assert!(!should_hide(".gitmodules"));
+    assert!(!should_hide("git")); // no leading dot
+    assert!(!should_hide("README.md"));
+    assert!(!should_hide("src"));
+    assert!(!should_hide("Button.tsx"));
+}

--- a/crates/aionui-project/src/runtime/tree_model.rs
+++ b/crates/aionui-project/src/runtime/tree_model.rs
@@ -19,6 +19,7 @@ use crate::canonical;
 
 use super::error::FsError;
 use super::fs_runtime::{FsRuntimeRegistry, IFsRuntime};
+use super::noise::should_hide;
 use super::provider::{EntryFact, Kind};
 use super::watcher::WatchHandle;
 
@@ -210,6 +211,12 @@ impl TreeModel {
             Hint::ChildNames(child_names) => {
                 let mut map = old.clone();
                 for name in child_names {
+                    // Noise never enters the tree — a watcher event for a hidden
+                    // name (e.g. `.DS_Store` written mid-session) is ignored, so
+                    // the tree stays consistent with `read_dir`/search.
+                    if should_hide(&name) {
+                        continue;
+                    }
                     let uri = child_uri(canonical, &name)?;
                     match runtime.provider().stat(&uri).await? {
                         Some(fact) => {


### PR DESCRIPTION
## What

Hide OS-junk and VCS-internal noise from every project-file listing, so `.DS_Store`, `.git`, Windows/macOS/Linux junk, etc. never clutter the explorer tree or filename search.

- Add a shared `should_hide(name)` predicate (`runtime/noise.rs`), case-insensitive, hardcoded v1 default set (config hook deferred):
  - macOS: `.DS_Store`, `._*` (AppleDouble), `.Spotlight-V100`, `.Trashes`, `.fseventsd`, `.AppleDouble`, `.apdisk`
  - Windows: `Thumbs.db`, `ehthumbs.db`, `desktop.ini`, `$RECYCLE.BIN`
  - Linux: `.Trash-*`, `.directory`
  - VCS: `.git`
- Apply the same gate at all **three** listing paths so the tree, search, and incremental deltas stay consistent:
  - provider `read_dir` (tree baseline + rescan) — `local_provider.rs`
  - the search `ignore` walk via `WalkBuilder::filter_entry` — `local_provider.rs`
  - the precise-event apply `stat` path — `tree_model.rs`
- **Bug fix:** hiding `.git` via `filter_entry` also stops `.git` internals (objects/refs/HEAD) leaking into search results — the `ignore` crate does not skip `.git` on its own, so `hidden(false)` was recursing into it.
- Keep user-meaningful dotfiles visible (`.env`, `.github`, `.gitignore`, `.gitmodules`) — a targeted name set, not a blanket `hidden()` filter.
- Hidden = entry is never emitted; no wire change, the protocol `excluded` placeholder is untouched.

## Testing

- `cargo test -p aionui-project` green; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt` clean.
- New coverage: the `should_hide` predicate (VCS/macOS/Windows/Linux + keeps real dotfiles), `read_dir` hiding junk while keeping real dotfiles, the search walk hiding `.git` internals + `.DS_Store`, and a real-event-loop test that a noise file creation fans **no** delta while a real sibling still does.
- Full `just push` workspace gate green (7949 passed). The pre-existing `aionui-system … test_env_override_log_dir` `AIONUI_LOG_DIR` env-casing flake is unrelated to this diff and passes with the env var unset.
- Verified live over the real WS runtime (frontend-driven), alongside the fs/search stack.

## Notes

Follow-up to the merged fs/search backend vertical (#720); this branch is rebased on current `main`. Companion frontend behavior lives with the AionUi tree/search UI.
