### PR TITLE
chore(acp): bump dimcode, dirac, grok and kilo registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -19,12 +19,12 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.2.38"
+      "version": "0.3.1"
     },
     "dirac": {
       "registry_json_id": "dirac",
       "package": "dirac-cli",
-      "version": "0.4.28"
+      "version": "0.4.29"
     },
     "glm-acp-agent": {
       "registry_json_id": "glm-acp-agent",
@@ -34,12 +34,12 @@
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "0.2.112"
+      "version": "0.2.116"
     },
     "kilo": {
       "registry_json_id": "kilo",
       "package": "@kilocode/cli",
-      "version": "7.4.16"
+      "version": "7.4.17"
     },
     "mimo-code": {
       "package": "@mimo-ai/cli",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Four npx pins drifted since #710; each bump is backed by a fresh serial ACP probe of the exact pinned version. Lock-only change — no metadata, migration or entrypoint edits.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| dimcode | `dimcode` | 0.2.38 → **0.3.1** | ok (agentInfo dimcode "DimCode" 0.3.1) | auth required (`-32000`, "Provider credentials are required") |
| dirac | `dirac-cli` | 0.4.28 → **0.4.29** | ok (agentInfo dirac 0.4.29) | success (modes plan/act) |
| grok | `@xai-official/grok` | 0.2.112 → **0.2.116** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |
| kilo | `@kilocode/cli` | 7.4.16 → **7.4.17** | ok (agentInfo Kilo 7.4.17) | success |

All four meet the release-lock criterion: `initialize` succeeds and `session/new` either succeeds or returns a clearly classified authentication requirement. Probes ran serially (cold npx downloads contend and produce false timeouts when parallelised), with no inherited HOME or credentials.

The other 7 Registry-pinned packages (autohand, codebuddy, deepagents, glm-acp-agent, nova, pi, sigit) match the snapshot exactly — no drift. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. The `mimo-code` and `omp` lock entries are non-Registry builtins (no `registry_json_id`) and are correctly excluded from drift reconciliation.

## Registry snapshot

- Audit pinned to release tag [`v2026.07.30-7cbe777`](https://cdn.agentclientprotocol.com/registry/v1/v2026.07.30-7cbe777/registry.json) of `agentclientprotocol/registry` (newest release at audit time), fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the 2026-07-30 baseline (38 ids).

## Validation

- `cargo test -p aionui-runtime -p aionui-ai-agent` — pass
- Full `just push` gate (migration check, lint, fmt, `cargo nextest run --workspace`) — pass
- Gate run with the host-injected `AIONUI_LOG_DIR` unset (pre-existing environment sensitivity, see #695)
- No `.rs` version literals needed updating: the lock-derived assertions count entries rather than pin version strings.

## Logging

No logging changes: lock-only version bumps; existing startup/session error paths already identify a failing agent by backend.