### PR TITLE
fix(session): settle cancelled workflows and stop per-turn pump state leaking across turns

### DIFF
--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -5521,6 +5521,122 @@ mod pump_tests {
         );
     }
 
+    // Cross-gen guard for the empty-turn Tip. The interrupt-vs-completion race can
+    // leave a trailing real `TurnResult{is_error:false}` on the OLD gen AFTER the
+    // synthetic settlement — with `saw_visible_output` already reset to false, that
+    // terminal arms `pending_empty_turn_tip`, and the swallow guard `continue`s past
+    // its Finish without draining it. This asserts that a Some(tip) so armed on gen 1
+    // can never surface on the NEXT (real, output-bearing) turn's Finish as a spurious
+    // ACP_EMPTY_TURN. The guarantee is structural: `pending_empty_turn_tip` is a
+    // per-iteration binding (dropped at the end of each envelope), so it cannot cross
+    // the gen boundary — this test pins that invariant against future refactors that
+    // might hoist the binding out of the loop.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn empty_turn_tip_armed_on_trailing_result_does_not_leak_to_next_turn() {
+        use aionui_session::SubagentStatus;
+        let script = vec![
+            env_gen(
+                1,
+                SessionEvent::SubagentUpdate {
+                    r#ref: "task-wf".into(),
+                    label: Some("wf".into()),
+                    status: SubagentStatus::Running,
+                    parent_ref: None,
+                    kind: Some(aionui_session::SubagentTaskKind::WorkflowContainer),
+                },
+            ),
+            env_gen(
+                1,
+                SessionEvent::MessageDelta {
+                    item_id: "m1".into(),
+                    text: "launching workflow".into(),
+                },
+            ),
+            // Launch result — suppressed while the workflow is in flight.
+            env_gen(
+                1,
+                SessionEvent::TurnResult {
+                    is_error: false,
+                    api_error_status: None,
+                    result_text: String::new(),
+                    epoch: 0,
+                    outcome: aionui_session::TurnOutcome::EndTurn,
+                },
+            ),
+            // User cancel → kill drain → synthetic settlement Finish. Arms the swallow
+            // guard AND resets `saw_visible_output` to false.
+            env_gen(
+                1,
+                SessionEvent::SubagentUpdate {
+                    r#ref: "task-wf".into(),
+                    label: Some("wf".into()),
+                    status: SubagentStatus::Interrupted,
+                    parent_ref: None,
+                    kind: None,
+                },
+            ),
+            // Trailing real terminal (the race): with `saw_visible_output` false this
+            // ARMS `pending_empty_turn_tip`, but the guard swallows its Finish — so the
+            // tip is never drained on THIS turn. It must be dropped, not carried over.
+            env_gen(
+                1,
+                SessionEvent::TurnResult {
+                    is_error: false,
+                    api_error_status: None,
+                    result_text: String::new(),
+                    epoch: 0,
+                    outcome: aionui_session::TurnOutcome::EndTurn,
+                },
+            ),
+            // ── Follow-up turn on the NEXT gen: it DOES produce visible output, so it
+            // must never receive an empty-turn Tip. ──
+            env_gen(
+                2,
+                SessionEvent::PromptAccepted {
+                    client_msg_id: "u-2".into(),
+                },
+            ),
+            env_gen(
+                2,
+                SessionEvent::MessageDelta {
+                    item_id: "m2".into(),
+                    text: "follow-up answer".into(),
+                },
+            ),
+            env_gen(
+                2,
+                SessionEvent::TurnResult {
+                    is_error: false,
+                    api_error_status: None,
+                    result_text: String::new(),
+                    epoch: 0,
+                    outcome: aionui_session::TurnOutcome::EndTurn,
+                },
+            ),
+        ];
+        let frames = drain_script(script).await;
+        let seq: Vec<&str> = frames.iter().map(frame_name).collect();
+        assert!(
+            !frames.iter().any(|f| matches!(f, AgentStreamEvent::Tips(_))),
+            "an empty-turn Tip armed on the trailing gen-1 result must not leak onto \
+             the output-bearing gen-2 turn's Finish, got {seq:?}"
+        );
+        // Sanity: the follow-up turn's real Finish still flows after its content, so
+        // the assertion above is testing a turn that actually reached a terminal.
+        let last_content = seq
+            .iter()
+            .rposition(|f| *f == "content")
+            .expect("follow-up turn text present");
+        let last_finish = seq
+            .iter()
+            .rposition(|f| *f == "finish")
+            .expect("follow-up turn Finish present");
+        assert!(
+            last_finish > last_content,
+            "follow-up turn's Finish must flow after its content, got {seq:?}"
+        );
+    }
+
     /// Backend that reports one scripted pending permission — models a permission
     /// raised before the client subscribed, which the REST /confirmations recovery
     /// path must be able to rebuild.

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -553,17 +553,35 @@ impl SessionAgentTask {
         };
         let backend = self.backend.clone();
         let request_id = call_id.to_string();
+        let conv_id = self.conversation_id.clone();
         // dispatch is async; confirm() is sync in IAgentTask's sibling API, so
-        // fire-and-forget on the runtime (the answer rides the stdin FIFO).
+        // fire-and-forget on the runtime (the answer rides the stdin FIFO). The
+        // REST confirm has already returned success by the time this runs, so a
+        // dispatch failure here is INVISIBLE to the caller — it MUST be surfaced
+        // in the log or a wedged permission (claude blocked forever on
+        // can_use_tool) is undiagnosable in production.
         tokio::spawn(async move {
-            let _ = backend
+            match backend
                 .dispatch(Command::AnswerPermission {
-                    request_id,
+                    request_id: request_id.clone(),
                     decision,
                     selected,
                     answers: Vec::new(),
                 })
-                .await;
+                .await
+            {
+                Ok(_) => tracing::info!(
+                    conv_id = %conv_id,
+                    request_id = %request_id,
+                    "permission answer delivered to backend"
+                ),
+                Err(e) => tracing::error!(
+                    conv_id = %conv_id,
+                    request_id = %request_id,
+                    error = %e,
+                    "permission answer FAILED after REST confirm already returned success — claude stays blocked on can_use_tool"
+                ),
+            }
         });
         Ok(())
     }
@@ -1879,6 +1897,25 @@ fn spawn_event_pump(
         // would terminate the relay and drop the workflow's completion message, so
         // we suppress the intermediate Finish until this set drains.
         let mut workflow_inflight: std::collections::HashSet<String> = std::collections::HashSet::new();
+        // Is a suppressed launch Finish still OWED for the current turn? While true,
+        // the relay is held open on credit: the turn's real Finish was swallowed
+        // (branch below), betting on the 2.1.176 invariant that a terminal `result`
+        // follows natural workflow completion. The bet only pays on NATURAL
+        // completion — an interrupt kills the workflow with task frames and NO
+        // result frame (verified: samples/claude-cli/2.1.220/
+        // _all_workflow_interrupt.jsonl, scenario A), so the `Interrupted` drain
+        // below must settle the debt itself or the turn never drains and the 15s
+        // UserCancelTimeout watchdog force-kills a healthy session (ELECTRON-3RP).
+        // Settled by the drain, by a real (unsuppressed) terminal, or when the
+        // envelope `turn_gen` advances (see `last_seen_turn_gen`).
+        let mut finish_suppressed_pending = false;
+        // Did the pump already close the current turn with a synthetic Finish (the
+        // cancel-drain settlement below)? A real terminal `result` can still trail
+        // it in an interrupt-vs-natural-completion race; its Finish must then be
+        // swallowed — the relay/persistence contract is ONE Finish per turn.
+        // Reset when `turn_gen` advances: the trailing-result window is bounded by
+        // the turn itself, and the next turn's real Finish must NOT be eaten.
+        let mut synthetic_finish_emitted = false;
         // Remembered `tool_use_id` → tool name, learned from each `ToolCall` frame.
         // A tool's lifecycle emits SEVERAL frames sharing one call_id — the initial
         // ToolCall (name known), any codex `ToolOutputDelta` (name absent on the wire),
@@ -1911,11 +1948,45 @@ fn spawn_event_pump(
         // Detached AFTER the turn's result → absorbed (I10) — it must track this
         // itself. Without it, a Detached that trails a completed turn (idle-kill,
         // clean shutdown) would be misread as a mid-turn crash. Set on the terminal
-        // TurnResult, reset on the next TurnStarted.
+        // TurnResult, reset when `turn_gen` advances (new turn).
         let mut terminal_result_seen = false;
+        // The `turn_gen` of the last envelope processed. This — not `TurnStarted` —
+        // is the per-turn reset boundary that actually fires on EVERY backend:
+        // claude_conn never emits `TurnStarted` (only the codex/acp adapters
+        // synthesize it), but its reader stamps every envelope with the current
+        // turn_gen, bumping it per accepted Send and deliberately NOT bumping it
+        // for a mid-turn injection. A reset keyed only on the TurnStarted arm is
+        // therefore dead code on the claude stream: the swallow guard armed by a
+        // cancel-drain settlement in turn N leaked into turn N+1 and ate its real
+        // Finish, leaving the turn open forever (live: dev 2026-07-31, conv
+        // ee61bd05, turn_7c5c89fd stuck "processing" after workflow-cancel +
+        // follow-up message). Gen-advance also bounds the trailing-result swallow
+        // window precisely: a trailing result rides the OLD gen (FIFO stdout), the
+        // next turn's frames ride the new gen.
+        let mut last_seen_turn_gen: u64 = 0;
         while let Some(env) = events.next().await {
             runtime.touch();
             tracing::debug!(conv_id = %conversation_id, event = session_event_name(&env.event), "session-pump: backend event");
+
+            if env.turn_gen > last_seen_turn_gen {
+                if last_seen_turn_gen > 0 {
+                    tracing::debug!(
+                        conv_id = %conversation_id,
+                        from = last_seen_turn_gen,
+                        to = env.turn_gen,
+                        "session-pump: turn gen advanced; per-turn suppression state reset"
+                    );
+                }
+                last_seen_turn_gen = env.turn_gen;
+                runtime.set_status(ConversationStatus::Running);
+                terminal_result_seen = false;
+                // Per-turn workflow-suppression state must not leak across turns —
+                // same rationale as the TurnStarted arm below, which claude never
+                // reaches.
+                workflow_inflight.clear();
+                finish_suppressed_pending = false;
+                synthetic_finish_emitted = false;
+            }
 
             // Empty-turn diagnostic Tip to emit for THIS terminal, if the turn was a
             // clean blank reply. Computed in the terminal match arm below (while
@@ -2071,17 +2142,108 @@ fn spawn_event_pump(
             // Mirrors `state::background_active`: a ref is in-flight while its status
             // is non-terminal ({PendingInit, Running}); a terminal status
             // ({Interrupted, Completed, Errored, Shutdown}) removes it.
-            if let SessionEvent::SubagentUpdate { r#ref, status, .. } = &env.event {
-                use aionui_session::SubagentStatus;
+            if let SessionEvent::SubagentUpdate {
+                r#ref, status, kind, ..
+            } = &env.event
+            {
+                use aionui_session::{SubagentStatus, SubagentTaskKind};
                 match status {
                     SubagentStatus::PendingInit | SubagentStatus::Running => {
-                        workflow_inflight.insert(r#ref.clone());
+                        // Suppression-roster admission is WORKFLOW-ONLY. The multi-result
+                        // invariant this roster bets on (launch result suppressed, terminal
+                        // result follows completion) is proven ONLY for `local_workflow`
+                        // tasks. A background bash (`local_bash`) outlives its turn with NO
+                        // later terminal result, so admitting it wedges the turn until the
+                        // 15s watchdog (live 2026-07-30: user's `sleep 60 &` cancel hang).
+                        // `kind` rides only `task_started`; a kind-less `task_updated`
+                        // re-assert therefore can't insert — which also retires the
+                        // "task_updated re-inserts a dead ref" oscillation by construction.
+                        if matches!(kind, Some(SubagentTaskKind::WorkflowContainer)) {
+                            workflow_inflight.insert(r#ref.clone());
+                            tracing::debug!(
+                                conv_id = %conversation_id,
+                                subagent_ref = %r#ref,
+                                ?status,
+                                inflight = workflow_inflight.len(),
+                                "session-pump: workflow container in-flight"
+                            );
+                        }
                     }
-                    SubagentStatus::Interrupted
+                    terminal @ (SubagentStatus::Interrupted
                     | SubagentStatus::Completed
                     | SubagentStatus::Errored
-                    | SubagentStatus::Shutdown => {
+                    | SubagentStatus::Shutdown) => {
                         workflow_inflight.remove(r#ref);
+                        tracing::debug!(
+                            conv_id = %conversation_id,
+                            subagent_ref = %r#ref,
+                            status = ?terminal,
+                            inflight = workflow_inflight.len(),
+                            "session-pump: subagent terminal"
+                        );
+                        // The roster just drained while a launch Finish is owed: decide
+                        // how the turn ends by HOW the LAST ref drained.
+                        //  - `Completed`: keep waiting — after natural completion the
+                        //    CLI still sends the terminal `result` (fixture invariant:
+                        //    samples/claude-cli/2.1.176 + 2.1.220), and settling here
+                        //    would break the relay before the completion message lands.
+                        //  - `Interrupted`: the workflow was KILLED (user interrupt).
+                        //    No result frame ever follows (verified: samples/claude-cli/
+                        //    2.1.220/_all_workflow_interrupt.jsonl — a kill emits only
+                        //    task_updated{killed}+task_notification{stopped} per task),
+                        //    so the owed Finish must be paid NOW or the relay never
+                        //    breaks and `cancelling` never clears.
+                        //  - `Errored`/`Shutdown`: whether a result trails is UNSAMPLED;
+                        //    settle like `Interrupted` (a hung turn costs more than a
+                        //    raced double Finish, which the swallow guard below absorbs)
+                        //    and warn so a live capture can pin the real contract.
+                        // Keying on the LAST removal (not "any Interrupted seen") is
+                        // deliberate: a workflow that survives one killed child still
+                        // completes naturally, and its roster drains via `Completed`.
+                        if workflow_inflight.is_empty()
+                            && finish_suppressed_pending
+                            && !matches!(terminal, SubagentStatus::Completed)
+                        {
+                            if matches!(terminal, SubagentStatus::Interrupted) {
+                                tracing::info!(
+                                    conv_id = %conversation_id,
+                                    "session-pump: workflow interrupted while its launch Finish was suppressed; emitting the owed Finish (cancel drain)"
+                                );
+                            } else {
+                                tracing::warn!(
+                                    conv_id = %conversation_id,
+                                    status = ?terminal,
+                                    "session-pump: workflow drained via unsampled terminal while its launch Finish was suppressed; settling to avoid a hung turn"
+                                );
+                            }
+                            finish_suppressed_pending = false;
+                            synthetic_finish_emitted = true;
+                            // The kill decided this turn: a later Detached is an
+                            // absorbed teardown, not a mid-turn crash (see
+                            // `crash_outcome`).
+                            terminal_result_seen = true;
+                            // Same per-turn closure the real terminal arm performs:
+                            // close every tool call left open as Canceled BEFORE the
+                            // Finish (the relay stops forwarding the turn at Finish).
+                            for (call_id, name) in open_tools.drain() {
+                                let _ = runtime.tx.send(AgentStreamEvent::ToolCall(ToolCallEventData {
+                                    call_id,
+                                    name,
+                                    args: serde_json::Value::Null,
+                                    status: ToolCallStatus::Canceled,
+                                    input: None,
+                                    output: None,
+                                    description: None,
+                                }));
+                            }
+                            tool_output.clear();
+                            tool_name.clear();
+                            saw_visible_output = false;
+                            // Idempotent clean-converge shared with the watchdog kill
+                            // path: sets status Finished + broadcasts the Finish that
+                            // drives relay break → turn release → `cancelling` cleared.
+                            runtime.emit_finish_once();
+                        }
                     }
                 }
             }
@@ -2110,6 +2272,13 @@ fn spawn_event_pump(
                     runtime.set_status(ConversationStatus::Running);
                     // New turn: the prior turn's terminal no longer applies.
                     terminal_result_seen = false;
+                    // Per-turn workflow-suppression state must not leak across turns:
+                    // a stale in-flight ref (e.g. a `task_updated` re-insert racing a
+                    // cancelled workflow's teardown) would re-arm suppression and
+                    // swallow THIS turn's Finish. A new turn starts unsuppressed.
+                    workflow_inflight.clear();
+                    finish_suppressed_pending = false;
+                    synthetic_finish_emitted = false;
                 }
                 // Track the call's open/closed lifecycle. Also remember the name for
                 // `stamp_tool_name` — the map was previously never populated, so
@@ -2122,6 +2291,9 @@ fn spawn_event_pump(
                     open_tools.remove(tool_use_id);
                 }
                 SessionEvent::TurnResult { .. } | SessionEvent::Detached { .. } if !suppress_intermediate_finish => {
+                    // A real (unsuppressed) terminal settles any owed launch Finish —
+                    // its own Finish/Error closes the turn.
+                    finish_suppressed_pending = false;
                     runtime.set_status(ConversationStatus::Finished);
                     // Close every tool call the turn left open (cancel/crash/dropped
                     // result): emit a terminal `Canceled` frame per call so the
@@ -2202,6 +2374,19 @@ fn spawn_event_pump(
                 if event_is_user_visible_output(&ev) {
                     saw_visible_output = true;
                 }
+                // The pump already closed this turn with a synthetic Finish (cancel
+                // drain above); a real terminal trailing it in the interrupt-vs-
+                // completion race must not emit a SECOND Finish — and must not fire
+                // the empty-turn Tip below either (the relay already broke; per-turn
+                // output accumulators were reset at settlement, so the tip would be
+                // spurious).
+                if synthetic_finish_emitted && matches!(ev, AgentStreamEvent::Finish(_)) {
+                    tracing::info!(
+                        conv_id = %conversation_id,
+                        "session-pump: swallowing trailing real Finish after synthetic cancel-drain Finish"
+                    );
+                    continue;
+                }
                 // Emit the empty-turn diagnostic Tip immediately BEFORE the Finish it
                 // was computed for. It MUST precede Finish: the relay breaks the turn on
                 // Finish (stream_relay.rs), so a Tips sent afterwards would never be
@@ -2225,6 +2410,9 @@ fn spawn_event_pump(
                 // the relay (never forwarded to the WS), so it changes only bubble
                 // boundaries, not the wire contract.
                 if suppress_intermediate_finish && matches!(ev, AgentStreamEvent::Finish(_)) {
+                    // The turn now owes this Finish; the workflow drain (or a later
+                    // real terminal) must settle it — see `finish_suppressed_pending`.
+                    finish_suppressed_pending = true;
                     let _ = runtime.tx.send(AgentStreamEvent::SegmentBreak);
                     continue;
                 }
@@ -4353,9 +4541,13 @@ mod pump_tests {
     }
 
     fn env(event: SessionEvent) -> SessionEnvelope {
+        env_gen(1, event)
+    }
+
+    fn env_gen(turn_gen: u64, event: SessionEvent) -> SessionEnvelope {
         SessionEnvelope {
             session_id: "conv-1".into(),
-            turn_gen: 1,
+            turn_gen,
             event,
         }
     }
@@ -4889,12 +5081,14 @@ mod pump_tests {
                 input: serde_json::Value::Null,
                 parent_tool_use_id: None,
             }),
-            // Workflow starts running (in-flight).
+            // Workflow starts running (in-flight; task_started declares the
+            // container kind → admitted to the suppression roster).
             env(SessionEvent::SubagentUpdate {
                 r#ref: "task-1".into(),
                 label: Some("wf".into()),
                 status: SubagentStatus::Running,
                 parent_ref: Some("toolu_wf".into()),
+                kind: Some(aionui_session::SubagentTaskKind::WorkflowContainer),
             }),
             env(SessionEvent::MessageDelta {
                 item_id: "m".into(),
@@ -4910,12 +5104,13 @@ mod pump_tests {
                 outcome: aionui_session::TurnOutcome::EndTurn,
             }),
             // Workflow completes (matches the fixture invariant: completed precedes
-            // the terminal result).
+            // the terminal result; task_notification carries no task_type).
             env(SessionEvent::SubagentUpdate {
                 r#ref: "task-1".into(),
                 label: Some("wf".into()),
                 status: SubagentStatus::Completed,
                 parent_ref: Some("toolu_wf".into()),
+                kind: None,
             }),
             env(SessionEvent::MessageDelta {
                 item_id: "m2".into(),
@@ -4986,6 +5181,7 @@ mod pump_tests {
                 label: Some("wf".into()),
                 status: SubagentStatus::Running,
                 parent_ref: None,
+                kind: Some(aionui_session::SubagentTaskKind::WorkflowContainer),
             }),
             env(SessionEvent::TurnResult {
                 is_error: true,
@@ -5000,6 +5196,328 @@ mod pump_tests {
             frames.iter().any(|f| matches!(f, AgentStreamEvent::Error(_))),
             "an error result terminates the turn even while a workflow is in flight, got {:?}",
             frames.iter().map(frame_name).collect::<Vec<_>>()
+        );
+    }
+
+    // A user interrupt KILLS an in-flight workflow and the CLI emits NO result
+    // frame afterwards — only task frames (verified: samples/claude-cli/2.1.220/
+    // _all_workflow_interrupt.jsonl, scenario A: task_updated{killed} +
+    // task_notification{stopped} per task, then silence). The suppressed launch
+    // Finish is the turn's ONLY possible terminal, so the pump must emit it when
+    // the roster drains via `Interrupted` — else the relay never breaks,
+    // `cancelling` never clears, and the 15s UserCancelTimeout watchdog
+    // force-kills a healthy session (ELECTRON-3RP/3RW).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn interrupted_workflow_drain_settles_suppressed_finish() {
+        use aionui_session::{SubagentStatus, SubagentTaskKind};
+        // `kind` mirrors the wire: only `task_started` declares task_type
+        // (workflow container vs bash child); `task_updated`/`task_notification`
+        // frames carry None.
+        let wf_update = |status: SubagentStatus, kind: Option<SubagentTaskKind>| {
+            env(SessionEvent::SubagentUpdate {
+                r#ref: "task-wf".into(),
+                label: Some("wf".into()),
+                status,
+                parent_ref: Some("toolu_wf".into()),
+                kind,
+            })
+        };
+        let bash_update = |status: SubagentStatus, kind: Option<SubagentTaskKind>| {
+            env(SessionEvent::SubagentUpdate {
+                r#ref: "task-bash".into(),
+                label: Some("local_bash".into()),
+                status,
+                parent_ref: Some("task-wf".into()),
+                kind,
+            })
+        };
+        let script = vec![
+            env(SessionEvent::ToolCall {
+                tool_use_id: "toolu_wf".into(),
+                name: "Task".into(),
+                subagent: aionui_session::SubagentKind::Workflow,
+                input: serde_json::Value::Null,
+                parent_tool_use_id: None,
+            }),
+            wf_update(SubagentStatus::Running, Some(SubagentTaskKind::WorkflowContainer)),
+            env(SessionEvent::MessageDelta {
+                item_id: "m".into(),
+                text: "launching workflow".into(),
+            }),
+            // LAUNCH result — suppressed (workflow in flight): the turn now OWES
+            // this Finish.
+            env(SessionEvent::TurnResult {
+                is_error: false,
+                api_error_status: None,
+                result_text: String::new(),
+                epoch: 0,
+                outcome: aionui_session::TurnOutcome::EndTurn,
+            }),
+            // The workflow's child bash is `local_bash` — visible in the display
+            // roster but NOT admitted to the suppression roster.
+            bash_update(SubagentStatus::Running, Some(SubagentTaskKind::Other)),
+            // Interrupt kill sequence, frame-faithful to the 2.1.220 fixture:
+            // task_updated{killed} maps to Running with NO task_type (kind None —
+            // cannot re-insert), each followed by its task_notification{stopped}
+            // → Interrupted. No result frame ever follows.
+            wf_update(SubagentStatus::Running, None),
+            wf_update(SubagentStatus::Interrupted, None),
+            bash_update(SubagentStatus::Running, None),
+            bash_update(SubagentStatus::Interrupted, None),
+        ];
+        let frames = drain_script(script).await;
+        let seq: Vec<&str> = frames.iter().map(frame_name).collect();
+        let finish_count = frames
+            .iter()
+            .filter(|f| matches!(f, AgentStreamEvent::Finish(_)))
+            .count();
+        assert_eq!(
+            finish_count, 1,
+            "the Interrupted drain settles the owed Finish exactly once, got {seq:?}"
+        );
+        assert!(
+            matches!(frames.last(), Some(AgentStreamEvent::Finish(_))),
+            "the settled Finish is the turn's terminal frame, got {seq:?}"
+        );
+        // The Task tool call left open by the kill is closed as Canceled BEFORE the
+        // Finish, so the persisted row leaves "work" and the frontend spinner stops.
+        let cancel_idx = frames
+            .iter()
+            .position(|f| matches!(f, AgentStreamEvent::ToolCall(d) if d.status == ToolCallStatus::Canceled && d.call_id == "toolu_wf"))
+            .unwrap_or_else(|| panic!("open Task call must be closed as Canceled, got {seq:?}"));
+        let finish_idx = frames
+            .iter()
+            .position(|f| matches!(f, AgentStreamEvent::Finish(_)))
+            .unwrap();
+        assert!(
+            cancel_idx < finish_idx,
+            "the Canceled tool close must precede the Finish (relay breaks at Finish), got {seq:?}"
+        );
+    }
+
+    // A background bash (`local_bash`, e.g. Bash{run_in_background}) is NOT a
+    // workflow container: it outlives the turn with no later terminal result, so
+    // it must NEVER hold the turn open. Regression (live 2026-07-30): a bash-only
+    // roster suppressed the launch Finish → turn wedged until the 15s watchdog,
+    // and the user's Stop clicks could not drain it (interrupt emits no task
+    // frames for a plain background bash).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn background_bash_does_not_suppress_turn_finish() {
+        use aionui_session::{SubagentStatus, SubagentTaskKind};
+        let script = vec![
+            env(SessionEvent::ToolCall {
+                tool_use_id: "toolu_bash".into(),
+                name: "Bash".into(),
+                subagent: aionui_session::SubagentKind::Inline,
+                input: serde_json::Value::Null,
+                parent_tool_use_id: None,
+            }),
+            env(SessionEvent::ToolResult {
+                tool_use_id: "toolu_bash".into(),
+                is_error: false,
+                content: Vec::new(),
+                parent_tool_use_id: None,
+            }),
+            // task_started for the background bash: kind = Other.
+            env(SessionEvent::SubagentUpdate {
+                r#ref: "task-bash".into(),
+                label: Some("bash".into()),
+                status: SubagentStatus::Running,
+                parent_ref: Some("toolu_bash".into()),
+                kind: Some(SubagentTaskKind::Other),
+            }),
+            env(SessionEvent::MessageDelta {
+                item_id: "m".into(),
+                text: "已启动，60 秒后完成".into(),
+            }),
+            // The turn's clean result: with only a bash in the roster this is the
+            // turn's REAL terminal and its Finish must flow immediately — the
+            // bash keeps running in the CLI, unrelated to turn lifecycle.
+            env(SessionEvent::TurnResult {
+                is_error: false,
+                api_error_status: None,
+                result_text: String::new(),
+                epoch: 0,
+                outcome: aionui_session::TurnOutcome::EndTurn,
+            }),
+        ];
+        let frames = drain_script(script).await;
+        let seq: Vec<&str> = frames.iter().map(frame_name).collect();
+        assert!(
+            matches!(frames.last(), Some(AgentStreamEvent::Finish(_))),
+            "the clean result's Finish must flow while a background bash is alive, got {seq:?}"
+        );
+        assert!(
+            !frames.iter().any(|f| matches!(f, AgentStreamEvent::SegmentBreak)),
+            "no suppression SegmentBreak for a bash-only roster, got {seq:?}"
+        );
+    }
+
+    // Interrupt-vs-natural-completion race: if a real terminal result trails the
+    // synthetic settlement, its Finish must be swallowed (ONE Finish per turn —
+    // the relay already broke) and no spurious empty-turn Tip may fire.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn trailing_real_finish_after_synthetic_settlement_is_swallowed() {
+        use aionui_session::SubagentStatus;
+        let script = vec![
+            env(SessionEvent::SubagentUpdate {
+                r#ref: "task-wf".into(),
+                label: Some("wf".into()),
+                status: SubagentStatus::Running,
+                parent_ref: None,
+                kind: Some(aionui_session::SubagentTaskKind::WorkflowContainer),
+            }),
+            env(SessionEvent::MessageDelta {
+                item_id: "m".into(),
+                text: "launching workflow".into(),
+            }),
+            // Launch result — suppressed.
+            env(SessionEvent::TurnResult {
+                is_error: false,
+                api_error_status: None,
+                result_text: String::new(),
+                epoch: 0,
+                outcome: aionui_session::TurnOutcome::EndTurn,
+            }),
+            // Kill drain → synthetic settlement (task_notification: no task_type).
+            env(SessionEvent::SubagentUpdate {
+                r#ref: "task-wf".into(),
+                label: Some("wf".into()),
+                status: SubagentStatus::Interrupted,
+                parent_ref: None,
+                kind: None,
+            }),
+            // Trailing real terminal (the race) — must NOT produce a second Finish.
+            env(SessionEvent::TurnResult {
+                is_error: false,
+                api_error_status: None,
+                result_text: String::new(),
+                epoch: 0,
+                outcome: aionui_session::TurnOutcome::EndTurn,
+            }),
+        ];
+        let frames = drain_script(script).await;
+        let seq: Vec<&str> = frames.iter().map(frame_name).collect();
+        let finish_count = frames
+            .iter()
+            .filter(|f| matches!(f, AgentStreamEvent::Finish(_)))
+            .count();
+        assert_eq!(finish_count, 1, "trailing real Finish is swallowed, got {seq:?}");
+        assert!(
+            !frames.iter().any(|f| matches!(f, AgentStreamEvent::Tips(_))),
+            "no spurious empty-turn Tip after the synthetic settlement, got {seq:?}"
+        );
+    }
+
+    // THE FIX (live: dev 2026-07-31, conv ee61bd05 stuck "processing"): the
+    // swallow guard armed by a cancel-drain settlement must disarm when the
+    // envelope `turn_gen` advances. claude_conn NEVER emits `TurnStarted` (only
+    // the codex/acp adapters synthesize it), so a reset keyed on that arm alone
+    // is dead code on the claude stream — the guard leaked into the follow-up
+    // turn and ate its real Finish, so the relay never broke and the turn stayed
+    // open forever. The script mirrors the live log: gen 1 = workflow launch
+    // (suppressed result) + kill drain (synthetic Finish); gen 2 = follow-up
+    // message answered with claude's usual double terminal result.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn swallow_guard_disarms_when_turn_gen_advances() {
+        use aionui_session::SubagentStatus;
+        let script = vec![
+            env_gen(
+                1,
+                SessionEvent::SubagentUpdate {
+                    r#ref: "task-wf".into(),
+                    label: Some("wf".into()),
+                    status: SubagentStatus::Running,
+                    parent_ref: None,
+                    kind: Some(aionui_session::SubagentTaskKind::WorkflowContainer),
+                },
+            ),
+            env_gen(
+                1,
+                SessionEvent::MessageDelta {
+                    item_id: "m1".into(),
+                    text: "launching workflow".into(),
+                },
+            ),
+            // Launch result — suppressed while the workflow is in flight.
+            env_gen(
+                1,
+                SessionEvent::TurnResult {
+                    is_error: false,
+                    api_error_status: None,
+                    result_text: String::new(),
+                    epoch: 0,
+                    outcome: aionui_session::TurnOutcome::EndTurn,
+                },
+            ),
+            // User cancel → kill drain → synthetic settlement Finish (arms the guard).
+            env_gen(
+                1,
+                SessionEvent::SubagentUpdate {
+                    r#ref: "task-wf".into(),
+                    label: Some("wf".into()),
+                    status: SubagentStatus::Interrupted,
+                    parent_ref: None,
+                    kind: None,
+                },
+            ),
+            // ── Follow-up message: the reader bumps turn_gen on the accepted Send. ──
+            env_gen(
+                2,
+                SessionEvent::PromptAccepted {
+                    client_msg_id: "u-2".into(),
+                },
+            ),
+            env_gen(
+                2,
+                SessionEvent::MessageDelta {
+                    item_id: "m2".into(),
+                    text: "follow-up answer".into(),
+                },
+            ),
+            // claude's double terminal per turn (known-benign duplicate).
+            env_gen(
+                2,
+                SessionEvent::TurnResult {
+                    is_error: false,
+                    api_error_status: None,
+                    result_text: String::new(),
+                    epoch: 0,
+                    outcome: aionui_session::TurnOutcome::EndTurn,
+                },
+            ),
+            env_gen(
+                2,
+                SessionEvent::TurnResult {
+                    is_error: false,
+                    api_error_status: None,
+                    result_text: String::new(),
+                    epoch: 0,
+                    outcome: aionui_session::TurnOutcome::EndTurn,
+                },
+            ),
+        ];
+        let frames = drain_script(script).await;
+        let seq: Vec<&str> = frames.iter().map(frame_name).collect();
+        let last_content = seq
+            .iter()
+            .rposition(|f| *f == "content")
+            .expect("follow-up turn text present");
+        let last_finish = seq
+            .iter()
+            .rposition(|f| *f == "finish")
+            .unwrap_or_else(|| panic!("no Finish at all — guard ate the follow-up turn's terminal, got {seq:?}"));
+        assert!(
+            last_finish > last_content,
+            "the follow-up turn's real Finish must flow after its content (guard must disarm on gen advance), got {seq:?}"
+        );
+        let finish_count = frames
+            .iter()
+            .filter(|f| matches!(f, AgentStreamEvent::Finish(_)))
+            .count();
+        assert!(
+            finish_count >= 2,
+            "expected the settlement Finish AND the follow-up turn's Finish, got {seq:?}"
         );
     }
 

--- a/crates/aionui-app/tests/live_ws_http_parity_e2e.rs
+++ b/crates/aionui-app/tests/live_ws_http_parity_e2e.rs
@@ -152,9 +152,11 @@ async fn run_backend_parity(backend: &str, prompt: &str) {
                 terminal = Some(ftype.to_owned());
             }
             // Best-effort auto-approval so a permission request can't wedge the turn.
+            // call_id contract = `tool_call.tool_call_id` (see auto_confirm_permissions).
             if ftype.contains("permission") {
-                let call_id = f["data"]["data"]["call_id"]
+                let call_id = f["data"]["data"]["tool_call"]["tool_call_id"]
                     .as_str()
+                    .or_else(|| f["data"]["data"]["call_id"].as_str())
                     .or_else(|| f["data"]["data"]["request_id"].as_str())
                     .or_else(|| f["data"]["msg_id"].as_str())
                     .unwrap_or_default()
@@ -370,4 +372,395 @@ async fn live_claude_ws_http_parity() {
 #[ignore = "spawns the real codex CLI; needs credentials"]
 async fn live_codex_ws_http_parity() {
     run_backend_parity("codex", PROMPT).await;
+}
+
+/// The prompt shape the 2.1.220 interrupt probe proved launches a non-blocking
+/// background workflow whose launch turn ends while the workflow flies (RUN A,
+/// samples/claude-cli/2.1.220/_probe_workflow_interrupt.py) — exactly the state
+/// where the pump suppresses the launch Finish and holds the turn open.
+const WORKFLOW_PROMPT: &str = "用 Workflow 工具启动一个 workflow：一个 phase，一个 agent，\
+    单纯执行 sleep 90（睡 90 秒）。用后台方式启动（run_in_background），\
+    启动拿到 task id 后立刻回复我「已启动」，不要等待它完成。";
+
+/// Auto-approve every permission frame in `snapshot` not already confirmed —
+/// same best-effort logic as `run_backend_parity`, so a default-mode Workflow
+/// launch (or its Bash) can't wedge the flight phase.
+async fn auto_confirm_permissions(app: &LiveApp, conv_id: &str, snapshot: &[Value], confirmed: &mut BTreeSet<String>) {
+    for f in stream_frames_for(snapshot, conv_id) {
+        let ftype = f["data"]["type"].as_str().unwrap_or("");
+        if !ftype.contains("permission") {
+            continue;
+        }
+        // The confirm contract (MessageAcpPermission.tsx): call_id = the acp_permission
+        // frame's `tool_call.tool_call_id` — the claude control_request id the backend
+        // keyed the pending permission by. The msg_id fallback exists only for exotic
+        // frames; answering with it yields "no pending permission" and wedges the turn.
+        let call_id = f["data"]["data"]["tool_call"]["tool_call_id"]
+            .as_str()
+            .or_else(|| f["data"]["data"]["call_id"].as_str())
+            .or_else(|| f["data"]["data"]["request_id"].as_str())
+            .or_else(|| f["data"]["msg_id"].as_str())
+            .unwrap_or_default()
+            .to_owned();
+        if call_id.is_empty() || !confirmed.insert(call_id.clone()) {
+            continue;
+        }
+        let option = f["data"]["data"]["options"][0].clone();
+        println!("[wf-cancel] auto-confirming permission {call_id}: {option}");
+        let resp = http_json(
+            app,
+            "POST",
+            &format!("/api/conversations/{conv_id}/confirmations/{call_id}/confirm"),
+            json!({
+                "msg_id": f["data"]["msg_id"],
+                "data": option.get("optionId").cloned().unwrap_or(option),
+            }),
+        )
+        .await;
+        println!("[wf-cancel] confirm response: {resp}");
+    }
+}
+
+/// LIVE guard for the OTHER side of the cancel-drain settlement branch: a
+/// workflow left to complete NATURALLY must still deliver its completion
+/// message and terminal Finish (`Completed` drain waits for the CLI's real
+/// terminal result — settling there would break the relay before the
+/// completion message lands), and the conversation must answer a follow-up.
+/// Companion to `live_claude_workflow_cancel_recovers_conversation`.
+#[tokio::test]
+#[ignore = "spawns the real claude CLI; needs credentials"]
+async fn live_claude_workflow_natural_completion_still_finishes() {
+    // Pump-level diagnostics (suppression / roster / settlement) — the WS stream
+    // drops SubagentUpdate, so the roster story is only visible in tracing.
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::new(
+            "aionui_ai_agent=debug,aionui_session=info",
+        ))
+        .try_init();
+    let app = start_live_app().await;
+
+    let ws_dir = std::env::temp_dir().join(format!("live-wf-natural-{}", aionui_common::now_ms()));
+    std::fs::create_dir_all(&ws_dir).unwrap();
+
+    let created = http_json(
+        &app,
+        "POST",
+        "/api/conversations",
+        json!({
+            "type": "acp",
+            "extra": {"workspace": ws_dir.to_string_lossy(), "backend": "claude"}
+        }),
+    )
+    .await;
+    let conv_id = created["data"]["id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("conversation create failed: {created}"))
+        .to_owned();
+    println!("[wf-natural] conversation {conv_id} workspace {}", ws_dir.display());
+
+    let frames = connect_ws_recorder(app.addr, &app.token).await;
+
+    // Short sleep so natural completion lands well inside the pump window.
+    let sent = http_json(
+        &app,
+        "POST",
+        &format!("/api/conversations/{conv_id}/messages"),
+        json!({"content": "用 Workflow 工具启动一个 workflow：一个 phase，一个 agent，\
+            单纯执行 sleep 20（睡 20 秒）。用后台方式启动（run_in_background），\
+            启动拿到 task id 后立刻回复我「已启动」，不要等待它完成。"}),
+    )
+    .await;
+    assert!(sent["data"]["turn_id"].is_string(), "send failed: {sent}");
+
+    let mut confirmed: BTreeSet<String> = BTreeSet::new();
+
+    // Flight must establish first (suppression engaged): tool + text, no finish.
+    let started = Instant::now();
+    let (mut saw_text, mut saw_tool) = (false, false);
+    while started.elapsed() < Duration::from_secs(150) {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let snapshot = frames.lock().unwrap().clone();
+        auto_confirm_permissions(&app, &conv_id, &snapshot, &mut confirmed).await;
+        for f in stream_frames_for(&snapshot, &conv_id) {
+            match f["data"]["type"].as_str().unwrap_or("") {
+                "text" | "content" => saw_text = true,
+                "tool_call" | "acp_tool_call" => saw_tool = true,
+                "finish" => panic!("[wf-natural] finish before flight established — suppression did not engage"),
+                _ => {}
+            }
+        }
+        if saw_text && saw_tool {
+            break;
+        }
+    }
+    assert!(
+        saw_text && saw_tool,
+        "[wf-natural] no workflow flight within 150s (text={saw_text} tool={saw_tool})"
+    );
+    let text_bytes_at_flight: usize = {
+        let snapshot = frames.lock().unwrap().clone();
+        stream_frames_for(&snapshot, &conv_id)
+            .iter()
+            .filter(|f| matches!(f["data"]["type"].as_str(), Some("text") | Some("content")))
+            .map(|f| f["data"]["data"]["content"].as_str().unwrap_or("").len())
+            .sum()
+    };
+    println!(
+        "[wf-natural] flight established after {:?}; waiting for NATURAL completion",
+        started.elapsed()
+    );
+
+    // No cancel: the workflow sleeps 20s, completes, and the CLI's terminal
+    // result must close the turn (2.1.176 invariant, unbroken by the fix).
+    let mut finished: Option<Duration> = None;
+    while started.elapsed() < Duration::from_secs(240) {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let snapshot = frames.lock().unwrap().clone();
+        auto_confirm_permissions(&app, &conv_id, &snapshot, &mut confirmed).await;
+        if stream_frames_for(&snapshot, &conv_id)
+            .iter()
+            .any(|f| f["data"]["type"] == "finish")
+        {
+            finished = Some(started.elapsed());
+            break;
+        }
+    }
+    if finished.is_none() {
+        // Dump the full stream trace before failing so the wedge is diagnosable.
+        let snapshot = frames.lock().unwrap().clone();
+        for f in stream_frames_for(&snapshot, &conv_id) {
+            let d = &f["data"];
+            println!(
+                "  [{}] msg_id={} {}",
+                d["type"].as_str().unwrap_or("?"),
+                d["msg_id"].as_str().unwrap_or("?"),
+                d["data"].to_string().chars().take(160).collect::<String>()
+            );
+        }
+        panic!("[wf-natural] workflow turn never finished naturally within 240s");
+    }
+    let finished = finished.unwrap();
+    let text_bytes_at_end: usize = {
+        let snapshot = frames.lock().unwrap().clone();
+        stream_frames_for(&snapshot, &conv_id)
+            .iter()
+            .filter(|f| matches!(f["data"]["type"].as_str(), Some("text") | Some("content")))
+            .map(|f| f["data"]["data"]["content"].as_str().unwrap_or("").len())
+            .sum()
+    };
+    assert!(
+        text_bytes_at_end > text_bytes_at_flight,
+        "[wf-natural] no completion message streamed after the launch reply \
+         ({text_bytes_at_flight}B → {text_bytes_at_end}B) — the relay closed too early"
+    );
+    println!(
+        "[wf-natural] ✅ natural completion finished in {finished:?} (launch {text_bytes_at_flight}B → total {text_bytes_at_end}B)"
+    );
+
+    // Next turn must open normally (TurnStarted state reset is per-turn only).
+    let pre = frames.lock().unwrap().len();
+    let follow_at = Instant::now();
+    let sent2 = http_json(
+        &app,
+        "POST",
+        &format!("/api/conversations/{conv_id}/messages"),
+        json!({"content": "只回两个字：在的"}),
+    )
+    .await;
+    assert!(sent2["data"]["turn_id"].is_string(), "follow-up rejected: {sent2}");
+    let mut follow_done = false;
+    while follow_at.elapsed() < Duration::from_secs(90) {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let snapshot = frames.lock().unwrap().clone();
+        if stream_frames_for(&snapshot[pre..], &conv_id)
+            .iter()
+            .any(|f| f["data"]["type"] == "finish")
+        {
+            follow_done = true;
+            break;
+        }
+    }
+    assert!(follow_done, "[wf-natural] follow-up turn did not finish within 90s");
+    println!("[wf-natural] ✅ follow-up turn finished in {:?}", follow_at.elapsed());
+}
+
+/// LIVE regression test for ELECTRON-3RP/3RW: cancelling a turn held open by an
+/// in-flight workflow must settle the suppressed launch Finish from the
+/// `Interrupted` drain (seconds), NOT via the 15s UserCancelTimeout watchdog —
+/// and the conversation must accept and answer a follow-up message afterwards.
+/// Drives the app exactly as the frontend does: REST send → WS stream → REST
+/// cancel (turn_id from the send response) → REST send again.
+#[tokio::test]
+#[ignore = "spawns the real claude CLI; needs credentials"]
+async fn live_claude_workflow_cancel_recovers_conversation() {
+    // Pump + backend diagnostics (suppression / roster / permission answers).
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::new(
+            "aionui_ai_agent=debug,aionui_session=debug",
+        ))
+        .try_init();
+    let app = start_live_app().await;
+
+    let ws_dir = std::env::temp_dir().join(format!("live-wf-cancel-{}", aionui_common::now_ms()));
+    std::fs::create_dir_all(&ws_dir).unwrap();
+
+    let created = http_json(
+        &app,
+        "POST",
+        "/api/conversations",
+        json!({
+            "type": "acp",
+            "extra": {"workspace": ws_dir.to_string_lossy(), "backend": "claude"}
+        }),
+    )
+    .await;
+    let conv_id = created["data"]["id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("conversation create failed: {created}"))
+        .to_owned();
+    println!("[wf-cancel] conversation {conv_id} workspace {}", ws_dir.display());
+
+    let frames = connect_ws_recorder(app.addr, &app.token).await;
+
+    let sent = http_json(
+        &app,
+        "POST",
+        &format!("/api/conversations/{conv_id}/messages"),
+        json!({"content": WORKFLOW_PROMPT}),
+    )
+    .await;
+    let turn_id = sent["data"]["turn_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("send failed: {sent}"))
+        .to_owned();
+    println!("[wf-cancel] workflow prompt sent, turn {turn_id}");
+
+    let mut confirmed: BTreeSet<String> = BTreeSet::new();
+
+    // ---- Phase 1: wait until the workflow flight is established ----
+    // Evidence: a tool_call streamed (the Workflow launch) AND launch reply text
+    // streamed, with NO finish — the turn is being held open by the suppressed
+    // launch Finish. A finish here means no workflow launched (model variance /
+    // launch failure) and the scenario precondition is not met.
+    let started = Instant::now();
+    let (mut saw_text, mut saw_tool) = (false, false);
+    while started.elapsed() < Duration::from_secs(150) {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let snapshot = frames.lock().unwrap().clone();
+        auto_confirm_permissions(&app, &conv_id, &snapshot, &mut confirmed).await;
+        for f in stream_frames_for(&snapshot, &conv_id) {
+            match f["data"]["type"].as_str().unwrap_or("") {
+                "text" | "content" => saw_text = true,
+                "tool_call" | "acp_tool_call" => saw_tool = true,
+                "finish" => panic!(
+                    "[wf-cancel] turn finished BEFORE cancel — the workflow did not hold the turn open \
+                     (launch failed or model declined); scenario precondition not met"
+                ),
+                _ => {}
+            }
+        }
+        if saw_text && saw_tool {
+            break;
+        }
+    }
+    assert!(
+        saw_text && saw_tool,
+        "[wf-cancel] no workflow flight within 150s (text={saw_text} tool={saw_tool})"
+    );
+    println!(
+        "[wf-cancel] flight established after {:?}; consolidating 8s",
+        started.elapsed()
+    );
+    // Let the workflow's sub-agent actually start (2.1.176: ~6s after the task),
+    // still asserting the turn stays open.
+    let consolidate = Instant::now();
+    while consolidate.elapsed() < Duration::from_secs(8) {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let snapshot = frames.lock().unwrap().clone();
+        auto_confirm_permissions(&app, &conv_id, &snapshot, &mut confirmed).await;
+        if stream_frames_for(&snapshot, &conv_id)
+            .iter()
+            .any(|f| f["data"]["type"] == "finish")
+        {
+            panic!("[wf-cancel] turn finished during flight consolidation — precondition not met");
+        }
+    }
+
+    // ---- Phase 2: cancel, exactly as the frontend does ----
+    let pre_cancel = frames.lock().unwrap().len();
+    let cancel_at = Instant::now();
+    let resp = http_json(
+        &app,
+        "POST",
+        &format!("/api/conversations/{conv_id}/cancel"),
+        json!({"turn_id": turn_id}),
+    )
+    .await;
+    println!("[wf-cancel] cancel response: {resp}");
+    assert_eq!(resp["success"], json!(true), "cancel must be accepted: {resp}");
+
+    // The Interrupted drain must settle the owed Finish on the MAIN path. Before
+    // the fix this frame only arrived via the 15s UserCancelTimeout force-kill;
+    // the 12s deadline is deliberately INSIDE the watchdog window so a watchdog
+    // rescue cannot masquerade as a pass.
+    let mut settle: Option<Duration> = None;
+    while cancel_at.elapsed() < Duration::from_secs(12) {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let snapshot = frames.lock().unwrap().clone();
+        if stream_frames_for(&snapshot[pre_cancel..], &conv_id)
+            .iter()
+            .any(|f| f["data"]["type"] == "finish")
+        {
+            settle = Some(cancel_at.elapsed());
+            break;
+        }
+    }
+    let settle = settle.unwrap_or_else(|| {
+        panic!("[wf-cancel] no finish within 12s of cancel — turn is wedged (watchdog would fire at 15s)")
+    });
+    println!("[wf-cancel] ✅ cancel settled the turn in {settle:?} (main path, not the 15s watchdog)");
+
+    // ---- Phase 3: the conversation must answer a follow-up ----
+    let pre_recovery = frames.lock().unwrap().len();
+    let recovery_at = Instant::now();
+    let sent2 = http_json(
+        &app,
+        "POST",
+        &format!("/api/conversations/{conv_id}/messages"),
+        json!({"content": "只回两个字：在的"}),
+    )
+    .await;
+    assert!(
+        sent2["data"]["turn_id"].is_string(),
+        "follow-up send must be admitted (gate recovered): {sent2}"
+    );
+    let mut reply_text = String::new();
+    let mut recovered: Option<Duration> = None;
+    while recovery_at.elapsed() < Duration::from_secs(90) {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let snapshot = frames.lock().unwrap().clone();
+        let mut finished = false;
+        for f in stream_frames_for(&snapshot[pre_recovery..], &conv_id) {
+            match f["data"]["type"].as_str().unwrap_or("") {
+                "text" | "content" => reply_text.push_str(f["data"]["data"]["content"].as_str().unwrap_or("")),
+                "finish" => finished = true,
+                _ => {}
+            }
+        }
+        if finished {
+            recovered = Some(recovery_at.elapsed());
+            break;
+        }
+        reply_text.clear(); // re-aggregated from the snapshot each round
+    }
+    let recovered =
+        recovered.unwrap_or_else(|| panic!("[wf-cancel] follow-up turn did not finish within 90s — not recovered"));
+    assert!(
+        !reply_text.is_empty(),
+        "[wf-cancel] follow-up finished but streamed no reply text"
+    );
+    println!(
+        "[wf-cancel] ✅ follow-up answered in {recovered:?}: {:?}",
+        reply_text.chars().take(60).collect::<String>()
+    );
 }

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -732,6 +732,13 @@ impl ClaudeSessionBackend {
                 .await
                 .map_err(|e| BackendError::Transport(format!("write control_response: {e}")))?;
         }
+        // Production-diagnosable lifecycle marker: the wedge class "user approved
+        // but claude never resumed" hinges on whether this write happened.
+        tracing::info!(
+            conversation_id = %self.session_id,
+            request_id = %request_id,
+            "claude control_response (permission answer) written to stdin"
+        );
         // RA -1: the reducer leaves requires-action only on PermissionResolved.
         let cur_gen = self.turn_gen.load(Ordering::SeqCst);
         let _ = self.event_tx.send(SessionEnvelope {
@@ -1524,15 +1531,22 @@ fn register_or_clear_pending(
             if tool_use_id.is_empty() {
                 return; // can't echo toolUseID → can't answer; parse degrades it to opaque too
             }
+            let tool_name = request
+                .get("tool_name")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            tracing::debug!(
+                request_id = %request_id,
+                tool_use_id = %tool_use_id,
+                tool_name = %tool_name,
+                "claude can_use_tool registered as pending permission"
+            );
             pending.lock().unwrap_or_else(|e| e.into_inner()).insert(
                 request_id.to_string(),
                 PendingPerm {
                     tool_use_id: tool_use_id.to_string(),
-                    tool_name: request
-                        .get("tool_name")
-                        .and_then(Value::as_str)
-                        .unwrap_or("")
-                        .to_string(),
+                    tool_name,
                     input: request.get("input").cloned().unwrap_or(Value::Null),
                 },
             );
@@ -2069,6 +2083,16 @@ fn sniff_task(
         .and_then(Value::as_str)
         .map(str::to_string);
     let parent_ref = frame.get("tool_use_id").and_then(Value::as_str).map(str::to_string);
+    // Container kind, declared ONLY on `task_started` (`task_type`:
+    // "local_workflow" for a Workflow container, "local_bash" for a background
+    // bash — verified: samples/claude-cli/2.1.176/workflow_*.ndjson +
+    // 2.1.220/_all_workflow_interrupt.jsonl; progress/updated/notification
+    // frames carry no task_type → None). The pump admits ONLY WorkflowContainer
+    // refs into its Finish-suppression roster.
+    let kind = frame.get("task_type").and_then(Value::as_str).map(|t| match t {
+        "local_workflow" => crate::event::SubagentTaskKind::WorkflowContainer,
+        _ => crate::event::SubagentTaskKind::Other,
+    });
     let _ = event_tx.send(SessionEnvelope {
         session_id: session_id.to_string(),
         turn_gen,
@@ -2077,6 +2101,7 @@ fn sniff_task(
             label,
             status,
             parent_ref,
+            kind,
         },
     });
 
@@ -5081,8 +5106,13 @@ mod tests {
         // parent = tool_use_id, label = subagent_type/workflow_name). task_started →
         // Running; task_notification{status} → terminal. The reducer upserts these
         // into Running.subagents, which drives has_foreground_activity.
+        // `kind` is learned ONLY from task_started.task_type: local_workflow →
+        // WorkflowContainer, local_bash (or any other value) → Other, absent
+        // (progress/notification frames) → None — the pump admits only
+        // WorkflowContainer refs into its Finish-suppression roster.
         let frames = [
-            r#"{"type":"system","subtype":"task_started","task_id":"tk-1","tool_use_id":"toolu-9","subagent_type":"general-purpose"}"#,
+            r#"{"type":"system","subtype":"task_started","task_id":"tk-1","tool_use_id":"toolu-9","subagent_type":"general-purpose","task_type":"local_workflow"}"#,
+            r#"{"type":"system","subtype":"task_started","task_id":"tk-2","tool_use_id":"toolu-8","subagent_type":"bash","task_type":"local_bash"}"#,
             r#"{"type":"system","subtype":"task_notification","task_id":"tk-1","tool_use_id":"toolu-9","status":"completed"}"#,
         ];
         let bytes = format!("{}\n", frames.join("\n")).into_bytes();
@@ -5097,10 +5127,11 @@ mod tests {
                     status,
                     parent_ref,
                     label,
+                    kind,
                 } = env.event
                 {
-                    updates.push((r#ref, status, parent_ref, label));
-                    if updates.len() == 2 {
+                    updates.push((r#ref, status, parent_ref, label, kind));
+                    if updates.len() == 3 {
                         return;
                     }
                 }
@@ -5110,8 +5141,8 @@ mod tests {
 
         assert_eq!(
             updates.len(),
-            2,
-            "task_started + task_notification → 2 SubagentUpdate, got {updates:?}"
+            3,
+            "2 task_started + task_notification → 3 SubagentUpdate, got {updates:?}"
         );
         // started → Running, keyed by task_id, parent = tool_use_id, label = subagent_type.
         assert_eq!(updates[0].0, "tk-1", "ref = task_id");
@@ -5126,13 +5157,27 @@ mod tests {
             Some("general-purpose"),
             "label = subagent_type"
         );
-        // notification completed → Completed, SAME ref (lifecycle upsert).
-        assert_eq!(updates[1].0, "tk-1", "same ref across the lifecycle");
         assert_eq!(
-            updates[1].1,
+            updates[0].4,
+            Some(crate::event::SubagentTaskKind::WorkflowContainer),
+            "task_type=local_workflow → WorkflowContainer"
+        );
+        // A background bash task is NOT a workflow container (the user-facing
+        // regression: its ref must never hold a turn open).
+        assert_eq!(
+            updates[1].4,
+            Some(crate::event::SubagentTaskKind::Other),
+            "task_type=local_bash → Other"
+        );
+        // notification completed → Completed, SAME ref (lifecycle upsert); the
+        // frame carries no task_type → kind None.
+        assert_eq!(updates[2].0, "tk-1", "same ref across the lifecycle");
+        assert_eq!(
+            updates[2].1,
             crate::event::SubagentStatus::Completed,
             "status=completed → Completed"
         );
+        assert_eq!(updates[2].4, None, "task_notification carries no task_type → kind None");
     }
 
     /// sniff_mode: claude's AUTHORITATIVE mode signal is `permissionMode` on a

--- a/crates/aionui-session/src/backend/codex_conn.rs
+++ b/crates/aionui-session/src/backend/codex_conn.rs
@@ -2747,6 +2747,10 @@ fn map_item(params: &Value, completed: bool) -> Vec<SessionEvent> {
                             label: label.clone(),
                             status,
                             parent_ref: parent_ref.clone(),
+                            // codex collab threads declare no container kind, and no
+                            // sample proves a codex turn emits a post-completion
+                            // terminal result — so they must not hold a turn open.
+                            kind: None,
                         });
                     }
                 }
@@ -2765,6 +2769,8 @@ fn map_item(params: &Value, completed: bool) -> Vec<SessionEvent> {
                             SubagentStatus::Running
                         },
                         parent_ref,
+                        // Same as the agentsStates branch: no declared kind.
+                        kind: None,
                     });
                 }
             }
@@ -5221,6 +5227,7 @@ mod tests {
                     status: SubagentStatus::PendingInit,
                     parent_ref: Some(p),
                     label: Some(l),
+                    kind: None,
                 } if r#ref == "019eabea-child" && p == "019eabe9-parent" && l == "openai.gpt-5.5"
             )),
             "real collab frame → SubagentUpdate keyed by CHILD thread, status from agentsStates, parent edge from senderThreadId, got {events:?}"

--- a/crates/aionui-session/src/backend/orchestrator.rs
+++ b/crates/aionui-session/src/backend/orchestrator.rs
@@ -932,6 +932,7 @@ mod tests {
                         label: Some("Build".into()),
                         status: SubagentStatus::Running,
                         parent_ref: Some("toolu-1".into()),
+                        kind: None,
                     },
                 ),
                 // per-agent child detail (agentId ref) — task_status defaults Running,
@@ -962,6 +963,7 @@ mod tests {
                         label: None,
                         status: SubagentStatus::Completed,
                         parent_ref: Some("toolu-1".into()),
+                        kind: None,
                     },
                 ),
                 env(
@@ -1502,6 +1504,7 @@ mod tests {
                         label: Some("research".into()),
                         status: SubagentStatus::Running,
                         parent_ref: None,
+                        kind: None,
                     },
                 ),
             ]),
@@ -1568,6 +1571,7 @@ mod tests {
                         label: Some("build".into()),
                         status: SubagentStatus::Running,
                         parent_ref: None,
+                        kind: None,
                     },
                 ),
                 // the foreground turn finishes — folds Idle.
@@ -1591,6 +1595,7 @@ mod tests {
                         label: Some("build".into()),
                         status: SubagentStatus::Completed,
                         parent_ref: None,
+                        kind: None,
                     },
                 ),
             ]),
@@ -1644,6 +1649,7 @@ mod tests {
                         label: Some("Build".into()),
                         status: SubagentStatus::Running,
                         parent_ref: Some("toolu-1".into()),
+                        kind: None,
                     },
                 ),
                 // The per-agent child detail (agentId ref, distinct from the container)
@@ -1682,6 +1688,7 @@ mod tests {
                         label: Some("Build".into()),
                         status: SubagentStatus::Completed,
                         parent_ref: Some("toolu-1".into()),
+                        kind: None,
                     },
                 ),
             ]),
@@ -1723,6 +1730,7 @@ mod tests {
                         label: None,
                         status: SubagentStatus::Running,
                         parent_ref: None,
+                        kind: None,
                     },
                 ),
                 env(
@@ -1778,6 +1786,7 @@ mod tests {
                         label: None,
                         status: SubagentStatus::Running,
                         parent_ref: None,
+                        kind: None,
                     },
                 ),
                 // The background workflow is running (has_activity true) ...
@@ -1852,6 +1861,7 @@ mod tests {
                             label: None,
                             status: SubagentStatus::Running,
                             parent_ref: None,
+                            kind: None,
                         },
                     ),
                     // The turn ends but the workflow OUTLIVES it (background_active →
@@ -1935,6 +1945,7 @@ mod tests {
                     label: None,
                     status,
                     parent_ref: None,
+                    kind: None,
                 },
             )
         };
@@ -2032,6 +2043,7 @@ mod tests {
                         label: None,
                         status: SubagentStatus::Running,
                         parent_ref: None,
+                        kind: None,
                     },
                 ),
                 env(
@@ -2042,6 +2054,7 @@ mod tests {
                         label: None,
                         status: SubagentStatus::Completed,
                         parent_ref: None,
+                        kind: None,
                     },
                 ),
                 env(
@@ -2064,6 +2077,7 @@ mod tests {
                         label: None,
                         status: SubagentStatus::Running,
                         parent_ref: None,
+                        kind: None,
                     },
                 ),
             ]),
@@ -2097,6 +2111,7 @@ mod tests {
                         label: Some("worker".into()),
                         status: SubagentStatus::Running,
                         parent_ref: None,
+                        kind: None,
                     },
                 ),
                 // park on a permission while the subagent is still running.
@@ -2121,6 +2136,7 @@ mod tests {
                         label: Some("worker".into()),
                         status: SubagentStatus::Completed,
                         parent_ref: None,
+                        kind: None,
                     },
                 ),
             ]),
@@ -2178,6 +2194,7 @@ mod tests {
                         label: None,
                         status: SubagentStatus::Running,
                         parent_ref: None,
+                        kind: None,
                     },
                 ),
                 env(
@@ -2188,6 +2205,7 @@ mod tests {
                         label: None,
                         status: SubagentStatus::Interrupted,
                         parent_ref: None,
+                        kind: None,
                     },
                 ),
             ]),
@@ -2239,6 +2257,7 @@ mod tests {
                         label: None,
                         status: SubagentStatus::Running,
                         parent_ref: None,
+                        kind: None,
                     },
                 ),
             ]),

--- a/crates/aionui-session/src/event.rs
+++ b/crates/aionui-session/src/event.rs
@@ -332,6 +332,18 @@ pub enum SessionEvent {
         label: Option<String>,
         status: SubagentStatus,
         parent_ref: Option<String>,
+        /// Container kind of this roster entry, learned from the spawning wire
+        /// frame (claude `task_started.task_type`; only that frame carries it —
+        /// `task_progress`/`task_updated`/`task_notification` do not, and codex
+        /// collab threads never declare one → `None`). `WorkflowContainer` marks
+        /// the ONE kind whose turn emits multiple `result` frames (launch +
+        /// terminal after completion, fixture invariant 2.1.176/2.1.220), so it
+        /// alone may hold a turn open via the pump's Finish-suppression roster.
+        /// A background bash (`local_bash`) or unknown kind must never suppress:
+        /// its turn gets no later terminal result, so suppression == a wedged
+        /// turn that only the 15s watchdog can end (live 2026-07-30).
+        #[serde(default)]
+        kind: Option<SubagentTaskKind>,
     },
 
     /// 009 R6b / §3 / H1: RICH per-agent workflow detail for the background-plane
@@ -517,6 +529,18 @@ pub enum SubagentKind {
         session_id: String,
     },
     Workflow,
+}
+
+/// Container kind of a `SubagentUpdate` roster entry (see that variant's `kind`
+/// field). Normalized from the claude wire's `task_started.task_type`:
+/// `"local_workflow"` → `WorkflowContainer`, any other declared value (e.g.
+/// `"local_bash"`) → `Other`. Deliberately two-valued: the only consumer is the
+/// pump's suppression-roster admission, which needs exactly the bit "may this
+/// ref hold the turn open".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum SubagentTaskKind {
+    WorkflowContainer,
+    Other,
 }
 
 /// 007 §9.17/§6b b3: a `Permission` request's class. Default `Tool` (existing
@@ -900,7 +924,8 @@ mod additive_tests {
                 r#ref: "a1".into(),
                 label: None,
                 status: SubagentStatus::Running,
-                parent_ref: None
+                parent_ref: None,
+                kind: None
             }),
             EventClass::BackendProduced
         );
@@ -1223,6 +1248,7 @@ mod additive_tests {
                     label: None,
                     status: SubagentStatus::Running,
                     parent_ref: None,
+                    kind: None,
                 },
                 BackendProduced,
                 DisplayAndState,
@@ -1275,7 +1301,8 @@ mod additive_tests {
                 r#ref: "a".into(),
                 label: None,
                 status: SubagentStatus::Completed,
-                parent_ref: None
+                parent_ref: None,
+                kind: None
             }),
             PersistTier::DisplayAndState
         );
@@ -1321,6 +1348,7 @@ mod additive_tests {
                 label: None,
                 status: SubagentStatus::Running,
                 parent_ref: None, // top-level boundary
+                kind: None,
             },
             SessionEvent::BackendBound {
                 backend_session_id: None, // lost-binding boundary
@@ -1400,6 +1428,7 @@ mod additive_tests {
                 label: Some("reviewer".into()),
                 status: SubagentStatus::Interrupted,
                 parent_ref: Some("wf-root".into()),
+                kind: None,
             },
             SessionEvent::Notice {
                 level: NoticeLevel::Info,

--- a/crates/aionui-session/src/lib.rs
+++ b/crates/aionui-session/src/lib.rs
@@ -68,8 +68,8 @@ pub use error::SessionError;
 pub use event::{
     CancelReason, CheckpointEntry, EventClass, ExitStatusLite, FinalizedMessage, ItemKind, NoticeLevel, Outcome,
     PermissionKind, PersistTier, PlanEntry, PlanPriority, PlanStatus, ProvisioningPhase, SessionEvent, StopReason,
-    SubagentKind, SubagentStatus, ToolResultContent, TruncationInfo, TruncationKind, TurnOutcome, classify,
-    persist_tier,
+    SubagentKind, SubagentStatus, SubagentTaskKind, ToolResultContent, TruncationInfo, TruncationKind, TurnOutcome,
+    classify, persist_tier,
 };
 pub use reducer::{Transition, crash_outcome, step};
 pub use state::{

--- a/crates/aionui-session/src/reducer.rs
+++ b/crates/aionui-session/src/reducer.rs
@@ -434,6 +434,9 @@ pub fn step(state: &SessionState, event: SessionEvent) -> (SessionState, Vec<Tra
             label,
             status,
             parent_ref,
+            // Container kind is a pump-side (suppression-roster) concern; the
+            // reducer's display roster tracks every subagent regardless of kind.
+            kind: _,
         } => {
             let mut to = state.clone();
             if let SessionState::Running { subagents, .. } = &mut to {
@@ -1787,6 +1790,7 @@ mod tests {
             label: None,
             status,
             parent_ref: parent.map(Into::into),
+            kind: None,
         }
     }
 
@@ -2193,6 +2197,7 @@ mod proptest_totality {
                 label: None,
                 status,
                 parent_ref: None,
+                kind: None,
             }),
             Just(SessionEvent::ItemStarted {
                 item_id: "i".into(),


### PR DESCRIPTION
## Problem

Cancelling a turn held open by an in-flight Workflow left the conversation wedged until the 15s `UserCancelTimeout` watchdog force-kill — and after the fix for that, the **next** turn could still get stuck "processing" forever. A plain background Bash task could wedge the turn the same way.

## Root causes (all in the session pump)

1. **Interrupted drain never paid the suppressed launch Finish.** The pump suppresses a workflow-launch `TurnResult`'s Finish to hold the relay turn open, betting on the CLI's terminal result after natural completion — but an interrupt kills the workflow with task frames only and **no result frame** (`samples/claude-cli/2.1.220/_all_workflow_interrupt.jsonl`). Now the debt is tracked (`finish_suppressed_pending`) and settled from the `Interrupted` roster drain: open tools closed as Canceled, then `emit_finish_once()`. `Completed` still waits for the real terminal result; `Errored`/`Shutdown` settle with a warn (unsampled).

2. **The suppression roster was task-kind blind.** A `Bash{run_in_background}` task's `task_started` also entered `workflow_inflight` — but the CLI emits no task frames at all for a plain background bash on interrupt, so only the watchdog could ever close such a turn. `SubagentUpdate` gains `kind: Option<SubagentTaskKind>` (from `task_started.task_type`: `local_workflow` → `WorkflowContainer`, other → `Other`, absent → `None`); only workflow containers enter the roster. Side effect: kind-less `task_updated` frames can no longer re-insert dead refs.

3. **Per-turn pump state reset was keyed on `TurnStarted`, which claude_conn never emits** (only the codex/acp adapters synthesize it) — the swallow guard armed by a cancel settlement leaked into the follow-up turn and ate its real Finish, leaving it stuck forever. Per-turn state now resets when the envelope `turn_gen` advances (bumped per accepted Send; deliberately not bumped for mid-turn injection), which is exact on every backend.

Also: permission-answer dispatch failures in `confirm()` are now logged instead of silently swallowed, and claude_conn logs `can_use_tool` registration/answers.

## Verification

- Unit: fixture-faithful pump tests for all three causes (incl. a claude-shaped stream with no `TurnStarted`); `aionui-ai-agent` 820 + `aionui-session` green; full pre-push gate 7967 passed.
- Live (claude 2.1.220): cancel settles in **~210ms** (was 15s watchdog); follow-up turn completes (4.5s); natural workflow completion still delivers its completion message; background bash no longer holds turns open.
- New `#[ignore]` live e2e: `live_claude_workflow_cancel_recovers_conversation`, `live_claude_workflow_natural_completion_still_finishes`.