### PR TITLE
fix(ai-agent): token usage for the direct-CLI backends (claude / codex)

### DIFF
--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -2219,7 +2219,7 @@ fn spawn_event_pump(
             // Finish, so the translated frame below would be shouted into an empty
             // room. Broadcasting straight from the pump (session-scoped, still alive)
             // is what turns claude's indicator on without waiting for a reload.
-            if let (Some(bus), SessionEvent::UsageDelta { .. }) = (broadcaster.as_ref(), &env.event) {
+            if let (Some(bus), Some(_)) = (broadcaster.as_ref(), informative_usage(&env.event)) {
                 broadcast_usage_frame(bus.as_ref(), &conversation_id, &user_id, &env.event);
             }
             for mut ev in translate_event(env.event, &conversation_id, terminal_result_seen) {
@@ -2380,28 +2380,34 @@ async fn persist_side_effects(
         // is session-scoped and outlives the per-turn `StreamRelay`, so it still
         // sees claude's `UsageDelta` — which rides the `result` frame that lands
         // AFTER the relay has already broken on Finish.
-        // Token usage -> the `context_usage` runtime snapshot the usage indicator
-        // reads back. This is the ONLY durable sink for direct-CLI usage: the pump
-        // is session-scoped and outlives the per-turn `StreamRelay`, so it still
-        // sees claude's `UsageDelta` — which rides the `result` frame that lands
-        // AFTER the relay has already broken on Finish.
+        _ => {}
+    }
+    if let Some((used, cost_usd, context_window)) = informative_usage(event) {
+        persist_context_usage(repo, user_id, conversation_id, used, cost_usd, context_window).await;
+    }
+}
+
+/// The single gate on whether a usage report says anything about context
+/// occupancy. Both consumers — the durable snapshot and the live broadcast — ask
+/// this, so a report can never be broadcast without being stored, or vice versa.
+///
+/// A zero-token report is DISCARDED. claude ends a no-op turn with an all-zero
+/// `usage` object, most visibly after `/compact`: live-captured (2.1.220), the
+/// compaction turn returns `num_turns: 0` and
+/// `usage{input_tokens:0, cache_creation:0, cache_read:0, output_tokens:0}` while
+/// `total_cost_usd` stays put. Recording that overwrites a real occupancy figure
+/// with 0 — not merely stale but wrong, since a compaction leaves the context
+/// SMALLER, never empty. Dropping it keeps the last true reading until the next
+/// real turn reports the post-compaction size.
+fn informative_usage(event: &SessionEvent) -> Option<(u64, Option<f64>, Option<u64>)> {
+    match event {
         SessionEvent::UsageDelta {
             total_tokens,
             cost_usd,
             context_window,
             ..
-        } => {
-            persist_context_usage(
-                repo,
-                user_id,
-                conversation_id,
-                *total_tokens,
-                *cost_usd,
-                *context_window,
-            )
-            .await;
-        }
-        _ => {}
+        } if *total_tokens > 0 => Some((*total_tokens, *cost_usd, *context_window)),
+        _ => None,
     }
 }
 
@@ -4072,6 +4078,38 @@ mod persist_tests {
         );
     }
 
+    /// A `/compact` turn ends with an all-zero `usage` object (live-captured on
+    /// claude 2.1.220: `num_turns: 0`, every token bucket 0, `total_cost_usd`
+    /// unchanged). Recording it wiped the real figure to `used: 0` — observed in
+    /// the wild as "the indicator showed 0, then vanished". The zero report must be
+    /// dropped so the last true reading survives until the next real turn.
+    #[tokio::test]
+    async fn zero_usage_after_compaction_does_not_wipe_the_real_figure() {
+        let (repo, _db) = seeded_repo().await;
+        persist_side_effects(
+            repo.as_ref(),
+            "user-1",
+            "conv-1",
+            &usage(26_420, Some(0.0133), Some(1_000_000)),
+        )
+        .await;
+        // The compaction turn: cost carries over unchanged, every token bucket 0.
+        persist_side_effects(
+            repo.as_ref(),
+            "user-1",
+            "conv-1",
+            &usage(0, Some(0.0133), Some(1_000_000)),
+        )
+        .await;
+
+        let stored = stored_usage(repo.as_ref()).await;
+        assert_eq!(
+            stored["used"], 26_420,
+            "a zero-token turn must not overwrite real occupancy"
+        );
+        assert_eq!(stored["size"], 1_000_000);
+    }
+
     /// The live frame must match what the renderer actually switches on.
     /// `useAcpMessage.ts` handles `case 'acp_context_usage'`, reads `data.used`
     /// into the indicator and `data.size` into `context_limit` (only when > 0), so
@@ -4099,6 +4137,39 @@ mod persist_tests {
         assert_eq!(msg.data["data"]["used"], 26_420);
         assert_eq!(msg.data["data"]["size"], 1_000_000, "drives context_limit");
         assert_eq!(msg.data["conversation_id"], "conv-1");
+    }
+
+    /// The gate is shared by the snapshot and the live broadcast, so a report can
+    /// never be pushed to the UI without also being stored.
+    #[test]
+    fn informative_usage_gates_zero_reports_only() {
+        assert!(informative_usage(&usage(0, Some(1.0), Some(200_000))).is_none());
+        assert_eq!(
+            informative_usage(&usage(11_030, None, Some(258_400))),
+            Some((11_030, None, Some(258_400)))
+        );
+    }
+
+    /// Defect 3: after a conversation switch the task is rebuilt with no in-memory
+    /// usage, so `get_usage` must serve the value straight out of the snapshot —
+    /// otherwise the indicator sits blank until the next turn produces fresh usage.
+    #[tokio::test]
+    async fn get_usage_serves_the_persisted_snapshot_on_a_cold_task() {
+        let (repo, _db) = seeded_repo().await;
+        persist_side_effects(repo.as_ref(), "user-1", "conv-1", &usage(47_579, None, Some(258_400))).await;
+
+        // A freshly built task: nothing in memory, only the repo.
+        let task = SessionAgentTask::new(
+            AgentType::Acp,
+            "conv-1".into(),
+            "user-1".into(),
+            "/tmp".into(),
+            Arc::new(super::pump_tests::StaticCapsBackend),
+            Some(repo.clone()),
+        );
+        let served = task.get_usage().await.unwrap().expect("cold task serves the snapshot");
+        assert_eq!(served["used"], 47_579);
+        assert_eq!(served["size"], 258_400);
     }
 
     #[tokio::test]

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -2382,8 +2382,8 @@ async fn persist_side_effects(
         // AFTER the relay has already broken on Finish.
         _ => {}
     }
-    if let Some((used, cost_usd, context_window)) = informative_usage(event) {
-        persist_context_usage(repo, user_id, conversation_id, used, cost_usd, context_window).await;
+    if let Some(usage) = informative_usage(event) {
+        persist_context_usage(repo, user_id, conversation_id, usage).await;
     }
 }
 
@@ -2413,14 +2413,9 @@ async fn persist_side_effects(
 /// 27_238, not `post_tokens`' 2_065. `post_tokens` counts only the compacted
 /// transcript while `usage` also carries the system prompt and tool definitions
 /// (~25k here). Different baselines; mixing them would understate occupancy ~13x.
-fn informative_usage(event: &SessionEvent) -> Option<(u64, Option<f64>, Option<u64>)> {
+fn informative_usage(event: &SessionEvent) -> Option<&SessionEvent> {
     match event {
-        SessionEvent::UsageDelta {
-            total_tokens,
-            cost_usd,
-            context_window,
-            ..
-        } if *total_tokens > 0 => Some((*total_tokens, *cost_usd, *context_window)),
+        SessionEvent::UsageDelta { total_tokens, .. } if *total_tokens > 0 => Some(event),
         // Discarding is silent otherwise, which makes "the indicator is stuck on an
         // old number" undiagnosable from logs. One line per no-op turn is cheap.
         SessionEvent::UsageDelta { .. } => {
@@ -2487,10 +2482,20 @@ async fn persist_context_usage(
     repo: &dyn IAcpSessionRepository,
     user_id: &str,
     conversation_id: &str,
-    used: u64,
-    cost_usd: Option<f64>,
-    context_window: Option<u64>,
+    event: &SessionEvent,
 ) {
+    let SessionEvent::UsageDelta {
+        input_tokens,
+        output_tokens,
+        total_tokens: used,
+        cost_usd,
+        context_window,
+        breakdown,
+    } = event
+    else {
+        return;
+    };
+    let (used, cost_usd, context_window) = (*used, *cost_usd, *context_window);
     let mut usage = match repo.load_runtime_state_for_user(user_id, conversation_id).await {
         Ok(Some(state)) => state
             .context_usage_json
@@ -2510,6 +2515,21 @@ async fn persist_context_usage(
     }
     if let Some(cost) = cost_usd {
         usage.insert("cost".into(), serde_json::json!({ "amount": cost, "currency": "USD" }));
+    }
+    // The detail line must survive a reload too — the renderer reads `_meta` off
+    // the GET /usage snapshot exactly as it does off a live frame. Merged like
+    // `size`/`cost`: only replaced when the incoming turn actually reported one.
+    if !breakdown.is_empty() {
+        usage.insert(
+            "_meta".into(),
+            serde_json::json!({
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cached_read_tokens": breakdown.cached_read_tokens,
+                "cached_write_tokens": breakdown.cached_write_tokens,
+                "thought_tokens": breakdown.thought_tokens,
+            }),
+        );
     }
     let json = match serde_json::to_string(&usage) {
         Ok(j) => j,
@@ -2889,6 +2909,7 @@ fn translate_event(event: SessionEvent, conversation_id: &str, terminal_result_s
             total_tokens,
             cost_usd,
             context_window,
+            breakdown,
         } => {
             // The frontend ContextUsageIndicator reads `used` (tokens consumed) and,
             // optionally, `size` (context window) + `cost` — the exact shape the ACP
@@ -2908,6 +2929,20 @@ fn translate_event(event: SessionEvent, conversation_id: &str, terminal_result_s
             let mut usage = serde_json::json!({ "used": total_tokens });
             if let Some(size) = context_window {
                 usage["size"] = serde_json::json!(size);
+            }
+            // Per-turn detail line ("input · output · cache read · thinking").
+            // The renderer reads these five keys out of `_meta` (AionUi
+            // useAcpMessage.ts `BREAKDOWN_KEYS`) and drops the line when none are
+            // present — so a backend that reports nothing simply has no line,
+            // rather than a row of zeros.
+            if !breakdown.is_empty() {
+                usage["_meta"] = serde_json::json!({
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "cached_read_tokens": breakdown.cached_read_tokens,
+                    "cached_write_tokens": breakdown.cached_write_tokens,
+                    "thought_tokens": breakdown.thought_tokens,
+                });
             }
             if let Some(cost) = cost_usd {
                 usage["cost"] = serde_json::json!({ "amount": cost, "currency": "USD" });
@@ -3416,6 +3451,7 @@ mod translate_tests {
                 total_tokens: total,
                 cost_usd: cost,
                 context_window: window,
+                breakdown: Default::default(),
             },
             "conv-1",
             false,
@@ -3436,6 +3472,44 @@ mod translate_tests {
         assert_eq!(v["size"], 1_000_000);
         assert_eq!(v["cost"]["amount"], 0.117);
         assert_eq!(v["cost"]["currency"], "USD");
+    }
+
+    /// The detail line rides `_meta` under the five key names the renderer reads
+    /// (AionUi `BREAKDOWN_KEYS`). A backend that reports nothing must emit NO
+    /// `_meta` at all, so the renderer omits the line instead of drawing zeros.
+    #[test]
+    fn breakdown_rides_meta_under_the_renderer_key_names() {
+        let with = translate_event(
+            SessionEvent::UsageDelta {
+                input_tokens: 1_100,
+                output_tokens: 194,
+                total_tokens: 18_400,
+                cost_usd: None,
+                context_window: Some(256_000),
+                breakdown: aionui_session::UsageBreakdown {
+                    cached_read_tokens: 16_900,
+                    cached_write_tokens: 79,
+                    thought_tokens: 242,
+                },
+            },
+            "conv-1",
+            false,
+        );
+        let v = match with.into_iter().next() {
+            Some(AgentStreamEvent::AcpContextUsage(v)) => v,
+            other => panic!("expected AcpContextUsage, got {other:?}"),
+        };
+        assert_eq!(v["_meta"]["input_tokens"], 1_100);
+        assert_eq!(v["_meta"]["output_tokens"], 194);
+        assert_eq!(v["_meta"]["cached_read_tokens"], 16_900);
+        assert_eq!(v["_meta"]["cached_write_tokens"], 79);
+        assert_eq!(v["_meta"]["thought_tokens"], 242);
+
+        let without = usage_frame(18_400, None, Some(256_000));
+        assert!(
+            without.get("_meta").is_none(),
+            "an empty breakdown must emit no `_meta`, got {without}"
+        );
     }
 
     /// No window reported (codex `modelContextWindow: null`) → NO `size` key at
@@ -3619,6 +3693,7 @@ mod translate_tests {
                 total_tokens: 30,
                 cost_usd: Some(0.5),
                 context_window: None,
+                breakdown: Default::default(),
             },
             "conv-1",
             false,
@@ -4030,6 +4105,7 @@ mod persist_tests {
             total_tokens: total,
             cost_usd: cost,
             context_window: window,
+            breakdown: Default::default(),
         }
     }
 
@@ -4172,11 +4248,11 @@ mod persist_tests {
     /// never be pushed to the UI without also being stored.
     #[test]
     fn informative_usage_gates_zero_reports_only() {
-        assert!(informative_usage(&usage(0, Some(1.0), Some(200_000))).is_none());
-        assert_eq!(
-            informative_usage(&usage(11_030, None, Some(258_400))),
-            Some((11_030, None, Some(258_400)))
+        assert!(
+            informative_usage(&usage(0, Some(1.0), Some(200_000))).is_none(),
+            "a zero-token report says nothing about occupancy"
         );
+        assert!(informative_usage(&usage(11_030, None, Some(258_400))).is_some());
     }
 
     /// Defect 3: after a conversation switch the task is rebuilt with no in-memory

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -2392,13 +2392,27 @@ async fn persist_side_effects(
 /// this, so a report can never be broadcast without being stored, or vice versa.
 ///
 /// A zero-token report is DISCARDED. claude ends a no-op turn with an all-zero
-/// `usage` object, most visibly after `/compact`: live-captured (2.1.220), the
-/// compaction turn returns `num_turns: 0` and
-/// `usage{input_tokens:0, cache_creation:0, cache_read:0, output_tokens:0}` while
-/// `total_cost_usd` stays put. Recording that overwrites a real occupancy figure
-/// with 0 — not merely stale but wrong, since a compaction leaves the context
-/// SMALLER, never empty. Dropping it keeps the last true reading until the next
-/// real turn reports the post-compaction size.
+/// `usage` object — live-captured (2.1.220) on all three variants:
+///
+/// | turn                | `usage`  | `total_cost_usd`      | `modelUsage` |
+/// |---------------------|----------|-----------------------|--------------|
+/// | `/compact` success  | all zero | 0.0131 (its own cost) | real numbers |
+/// | `/compact` rejected | all zero | 0                     | `{}`         |
+/// | `/clear`            | all zero | 0                     | `{}`         |
+///
+/// Note the successful compaction contradicts itself: `usage` reads zero while
+/// `modelUsage` reports what the compaction actually spent. Recording the zero
+/// overwrites a real occupancy figure — not merely stale but wrong, since a
+/// compaction leaves the context SMALLER, never empty. Dropping it keeps the last
+/// true reading until the next real turn reports the post-compaction size.
+///
+/// DO NOT be tempted by `system{subtype:"compact_boundary"}`, which carries
+/// `compact_metadata{pre_tokens, post_tokens, cumulative_dropped_tokens}`. Its
+/// `pre_tokens` matches our pre-compaction figure exactly (28_049 measured), which
+/// makes `post_tokens` look like the answer — but the next real turn reported
+/// 27_238, not `post_tokens`' 2_065. `post_tokens` counts only the compacted
+/// transcript while `usage` also carries the system prompt and tool definitions
+/// (~25k here). Different baselines; mixing them would understate occupancy ~13x.
 fn informative_usage(event: &SessionEvent) -> Option<(u64, Option<f64>, Option<u64>)> {
     match event {
         SessionEvent::UsageDelta {
@@ -2407,6 +2421,12 @@ fn informative_usage(event: &SessionEvent) -> Option<(u64, Option<f64>, Option<u
             context_window,
             ..
         } if *total_tokens > 0 => Some((*total_tokens, *cost_usd, *context_window)),
+        // Discarding is silent otherwise, which makes "the indicator is stuck on an
+        // old number" undiagnosable from logs. One line per no-op turn is cheap.
+        SessionEvent::UsageDelta { .. } => {
+            tracing::debug!("usage report carries zero tokens; keeping the previous reading");
+            None
+        }
         _ => None,
     }
 }
@@ -2420,6 +2440,13 @@ fn informative_usage(event: &SessionEvent) -> Option<(u64, Option<f64>, Option<u
 /// `msg_id`/`turn_id` are empty: a usage report is CONVERSATION-scoped state, and
 /// by the time claude's arrives its turn is already closed, so there is no message
 /// to attach it to. The indicator reads `data`, keyed by conversation.
+///
+/// Fires for every backend, which means codex/ACP — whose reports land mid-turn,
+/// while the relay is still forwarding — deliver TWO frames: the relay's catch-all
+/// (with a real `msg_id`) and this one. Accepted deliberately: the renderer's
+/// `setTokenUsage` replaces wholesale, so the duplicate is idempotent, and gating
+/// on backend here would trade a harmless repeat for a rule that silently rots the
+/// moment another backend starts reporting after its turn ends.
 fn broadcast_usage_frame(bus: &dyn EventBroadcaster, conversation_id: &str, user_id: &str, event: &SessionEvent) {
     let Some(frame) = translate_event(event.clone(), conversation_id, false)
         .into_iter()
@@ -4093,7 +4120,9 @@ mod persist_tests {
             &usage(26_420, Some(0.0133), Some(1_000_000)),
         )
         .await;
-        // The compaction turn: cost carries over unchanged, every token bucket 0.
+        // The compaction turn: every token bucket 0, while cost reports what the
+        // compaction itself spent (live-captured 0.0131 on a SUCCESSFUL compact; a
+        // rejected one and `/clear` both report 0 — see `informative_usage`).
         persist_side_effects(
             repo.as_ref(),
             "user-1",

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -352,6 +352,9 @@ impl SessionAgentTask {
             session_repo,
             CatalogPreload::default(),
             None,
+            // No broadcaster: this ctor is the test/simple path, which has no
+            // conversation WebSocket to push a late usage frame to.
+            None,
         )
     }
 
@@ -370,6 +373,7 @@ impl SessionAgentTask {
         session_repo: Option<Arc<dyn IAcpSessionRepository>>,
         handshake: &aionui_api_types::AgentHandshake,
         prompt_dump: Option<SessionPromptDump>,
+        broadcaster: Option<Arc<dyn EventBroadcaster>>,
     ) -> Arc<Self> {
         Self::build(
             agent_type,
@@ -380,6 +384,7 @@ impl SessionAgentTask {
             session_repo,
             CatalogPreload::from_handshake(handshake),
             prompt_dump,
+            broadcaster,
         )
     }
 
@@ -393,6 +398,7 @@ impl SessionAgentTask {
         session_repo: Option<Arc<dyn IAcpSessionRepository>>,
         catalog_preload: CatalogPreload,
         prompt_dump: Option<SessionPromptDump>,
+        broadcaster: Option<Arc<dyn EventBroadcaster>>,
     ) -> Arc<Self> {
         let (tx, _rx) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
         let runtime = Arc::new(SessionRuntime {
@@ -414,6 +420,7 @@ impl SessionAgentTask {
             conversation_id.clone(),
             user_id.clone(),
             session_repo.clone(),
+            broadcaster,
         );
         Arc::new(Self {
             agent_type,
@@ -903,10 +910,25 @@ impl SessionAgentTask {
         }
     }
 
-    /// Session usage snapshot. Not tracked on the capabilities snapshot yet;
-    /// usage rides the `UsageDelta` stream event. Return None for now.
+    /// Session usage snapshot, served from the persisted `context_usage` runtime
+    /// state that the event pump writes on every `UsageDelta`.
+    ///
+    /// Reading through the repo (rather than an in-memory field) is what makes the
+    /// figure survive a conversation switch: the task is dropped when the session
+    /// is reaped, so anything held only in memory would be gone and the indicator
+    /// would sit blank until the next turn produced fresh usage. Without a repo
+    /// (tests) or with no row yet, `None` — the indicator simply stays empty.
     pub async fn get_usage(&self) -> Result<Option<serde_json::Value>, AgentError> {
-        Ok(None)
+        let Some(repo) = self.session_repo.as_ref() else {
+            return Ok(None);
+        };
+        let state = repo
+            .load_runtime_state_for_user(&self.user_id, &self.conversation_id)
+            .await
+            .map_err(|e| AgentError::internal(format!("Failed to load usage state: {e}")))?;
+        Ok(state
+            .and_then(|s| s.context_usage_json)
+            .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok()))
     }
 
     /// Slash commands from the live capabilities snapshot.
@@ -1270,7 +1292,7 @@ pub async fn build_session_instance(
                 &user_id,
                 config.mcp_server_ids.as_deref(),
                 &conversation_id,
-                broadcaster,
+                broadcaster.clone(),
             )
             .await
         }
@@ -1488,6 +1510,9 @@ pub async fn build_session_instance(
         acp_session_repo,
         &metadata.handshake,
         prompt_dump,
+        // Lets the pump push a usage frame that arrives after the turn's relay has
+        // already stopped listening — the claude case (usage rides `result`).
+        Some(broadcaster),
     );
     Ok(Some(crate::agent_task::AgentInstance::Session(task)))
 }
@@ -1849,6 +1874,7 @@ fn spawn_event_pump(
     conversation_id: String,
     user_id: String,
     session_repo: Option<Arc<dyn IAcpSessionRepository>>,
+    broadcaster: Option<Arc<dyn EventBroadcaster>>,
 ) {
     use futures_util::StreamExt as _;
     // The pump owns ONLY the event stream (a broadcast `Receiver` handle — see
@@ -2188,6 +2214,14 @@ fn spawn_event_pump(
             if let Some(repo) = session_repo.as_ref() {
                 persist_side_effects(repo.as_ref(), &user_id, &conversation_id, &env.event).await;
             }
+            // Usage must ALSO reach the live view directly. claude reports it on the
+            // `result` frame, which lands after the relay has already broken on
+            // Finish, so the translated frame below would be shouted into an empty
+            // room. Broadcasting straight from the pump (session-scoped, still alive)
+            // is what turns claude's indicator on without waiting for a reload.
+            if let (Some(bus), SessionEvent::UsageDelta { .. }) = (broadcaster.as_ref(), &env.event) {
+                broadcast_usage_frame(bus.as_ref(), &conversation_id, &user_id, &env.event);
+            }
             for mut ev in translate_event(env.event, &conversation_id, terminal_result_seen) {
                 // Keep the tool name alive across a call's multi-frame lifecycle (see
                 // `stamp_tool_name`): the terminal ToolResult frame leaves the name
@@ -2232,14 +2266,14 @@ fn spawn_event_pump(
                 // which sends Finish{session_id}. The resume anchor rides it to the
                 // frontend. (Start is emitted by send_message, already stamped.)
                 //
-                // KNOWN DIVERGENCE (accepted, additive gap): claude emits its per-turn
-                // `UsageDelta` a few ms AFTER `TurnResult`, and origin's relay stops
-                // forwarding a turn once it sees this Finish — so the trailing
-                // AcpContextUsage frame does not reach the frontend and the context
-                // indicator stays blank. The ACP path avoids this only because its SDK
-                // blocks prompt() until usage is collected. Matching that needs an
-                // end-of-turn "collect usage" barrier (or wiring get_context_usage) and
-                // is deferred; the core turn flow is otherwise frame-equivalent.
+                // NOTE: claude emits its `UsageDelta` a few ms AFTER `TurnResult`
+                // (it rides the `result` frame), and the relay stops forwarding a
+                // turn the moment it sees this Finish — so the translated
+                // AcpContextUsage below is shouted into an empty room and used to
+                // leave the context indicator blank. That gap is now closed WITHOUT
+                // an end-of-turn barrier: the pump persists every UsageDelta to
+                // `context_usage` and broadcasts it directly (see the UsageDelta
+                // handling above), both of which outlive the turn.
                 if let AgentStreamEvent::Finish(data) = &mut ev
                     && data.session_id.is_none()
                 {
@@ -2341,7 +2375,125 @@ async fn persist_side_effects(
                 tracing::warn!(conversation_id, error = %err, "session-sync: save_runtime_state failed");
             }
         }
+        // Token usage → the `context_usage` runtime snapshot the usage indicator
+        // reads back. This is the ONLY durable sink for direct-CLI usage: the pump
+        // is session-scoped and outlives the per-turn `StreamRelay`, so it still
+        // sees claude's `UsageDelta` — which rides the `result` frame that lands
+        // AFTER the relay has already broken on Finish.
+        // Token usage -> the `context_usage` runtime snapshot the usage indicator
+        // reads back. This is the ONLY durable sink for direct-CLI usage: the pump
+        // is session-scoped and outlives the per-turn `StreamRelay`, so it still
+        // sees claude's `UsageDelta` — which rides the `result` frame that lands
+        // AFTER the relay has already broken on Finish.
+        SessionEvent::UsageDelta {
+            total_tokens,
+            cost_usd,
+            context_window,
+            ..
+        } => {
+            persist_context_usage(
+                repo,
+                user_id,
+                conversation_id,
+                *total_tokens,
+                *cost_usd,
+                *context_window,
+            )
+            .await;
+        }
         _ => {}
+    }
+}
+
+/// Broadcast a `UsageDelta` to the conversation's live stream.
+///
+/// Mirrors `StreamRelay::forward_to_websocket_with_msg_id` exactly — same
+/// `message.stream` envelope, same snake_case normalisation — so the frame is
+/// indistinguishable from the one the relay emits mid-turn.
+///
+/// `msg_id`/`turn_id` are empty: a usage report is CONVERSATION-scoped state, and
+/// by the time claude's arrives its turn is already closed, so there is no message
+/// to attach it to. The indicator reads `data`, keyed by conversation.
+fn broadcast_usage_frame(bus: &dyn EventBroadcaster, conversation_id: &str, user_id: &str, event: &SessionEvent) {
+    let Some(frame) = translate_event(event.clone(), conversation_id, false)
+        .into_iter()
+        .next()
+    else {
+        return;
+    };
+    let mut event_data = match serde_json::to_value(&frame) {
+        Ok(v) => v,
+        Err(err) => {
+            tracing::warn!(conversation_id, error = %err, "usage broadcast: serialize failed");
+            return;
+        }
+    };
+    aionui_common::normalize_keys_to_snake_case(&mut event_data);
+    let payload = serde_json::json!({
+        "conversation_id": conversation_id,
+        "user_id": user_id,
+        "msg_id": "",
+        "turn_id": "",
+        "type": event_data.get("type").cloned().unwrap_or(serde_json::json!("usage")),
+        "data": event_data.get("data").cloned().unwrap_or(serde_json::json!({})),
+        "hidden": false,
+    });
+    bus.broadcast(aionui_api_types::WebSocketMessage::new("message.stream", payload));
+}
+
+/// Merge one usage report into `acp_session.session_config.runtime.context_usage`.
+///
+/// Shape is the ACP `UsageUpdate` the frontend already consumes:
+/// `{used, size, cost:{amount, currency}}`.
+///
+/// MERGE, not replace (mirrors the ACP path): `used` always takes the newer value,
+/// while `size`/`cost` are only overwritten when the incoming report carries them.
+/// codex sends no cost at all and may send `modelContextWindow: null`, so a blind
+/// replace would blank a window the previous turn had already established.
+async fn persist_context_usage(
+    repo: &dyn IAcpSessionRepository,
+    user_id: &str,
+    conversation_id: &str,
+    used: u64,
+    cost_usd: Option<f64>,
+    context_window: Option<u64>,
+) {
+    let mut usage = match repo.load_runtime_state_for_user(user_id, conversation_id).await {
+        Ok(Some(state)) => state
+            .context_usage_json
+            .as_deref()
+            .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+            .and_then(|v| v.as_object().cloned())
+            .unwrap_or_default(),
+        Ok(None) => serde_json::Map::new(),
+        Err(err) => {
+            tracing::warn!(conversation_id, error = %err, "session-sync: load_runtime_state failed; skipping usage persist");
+            return;
+        }
+    };
+    usage.insert("used".into(), serde_json::json!(used));
+    if let Some(size) = context_window {
+        usage.insert("size".into(), serde_json::json!(size));
+    }
+    if let Some(cost) = cost_usd {
+        usage.insert("cost".into(), serde_json::json!({ "amount": cost, "currency": "USD" }));
+    }
+    let json = match serde_json::to_string(&usage) {
+        Ok(j) => j,
+        Err(err) => {
+            tracing::warn!(conversation_id, error = %err, "session-sync: encode context_usage failed");
+            return;
+        }
+    };
+    let params = SaveRuntimeStateParams {
+        context_usage_json: Some(Some(&json)),
+        ..Default::default()
+    };
+    if let Err(err) = repo
+        .save_runtime_state_for_user(user_id, conversation_id, &params)
+        .await
+    {
+        tracing::warn!(conversation_id, error = %err, "session-sync: save context_usage failed");
     }
 }
 
@@ -2703,17 +2855,27 @@ fn translate_event(event: SessionEvent, conversation_id: &str, terminal_result_s
             output_tokens,
             total_tokens,
             cost_usd,
+            context_window,
         } => {
             // The frontend ContextUsageIndicator reads `used` (tokens consumed) and,
             // optionally, `size` (context window) + `cost` — the exact shape the ACP
             // path forwards (the claude-agent-acp SDK's UsageUpdate: {used, size,
             // cost:{amount,currency}}). Emitting the raw {input_tokens,…} shape left
-            // the indicator blank (no `used` key). `size` is omitted: UsageDelta
-            // carries no context-window figure (that rides the separate
-            // get_context_usage control probe, not wired here), and the frontend
-            // guards `if size>0` so its absence is safe. `used` = total_tokens (the
-            // genuine cumulative total the adapter already computed, incl. cache).
+            // the indicator blank (no `used` key).
+            //
+            // `used` = total_tokens, which BOTH direct backends compute as current
+            // context occupancy, not a per-turn delta: codex reports `last.totalTokens`
+            // (its `inputTokens` already includes the cached part) and claude's
+            // adapter sums input + output + both cache buckets. The cumulative
+            // counters (codex `total.*`) are deliberately NOT used — they outgrow the
+            // window on a long session.
+            //
+            // `size` is emitted only when the backend reported a window; the frontend
+            // guards `if size>0`, so `None` degrades to a counter with no percentage.
             let mut usage = serde_json::json!({ "used": total_tokens });
+            if let Some(size) = context_window {
+                usage["size"] = serde_json::json!(size);
+            }
             if let Some(cost) = cost_usd {
                 usage["cost"] = serde_json::json!({ "amount": cost, "currency": "USD" });
             }
@@ -3213,6 +3375,47 @@ mod translate_tests {
     use crate::protocol::events::tool_call::{ToolCallEventData, ToolCallStatus};
     use aionui_session::PermissionKind;
 
+    fn usage_frame(total: u64, cost: Option<f64>, window: Option<u64>) -> serde_json::Value {
+        let events = translate_event(
+            SessionEvent::UsageDelta {
+                input_tokens: 10,
+                output_tokens: 5,
+                total_tokens: total,
+                cost_usd: cost,
+                context_window: window,
+            },
+            "conv-1",
+            false,
+        );
+        match events.into_iter().next() {
+            Some(AgentStreamEvent::AcpContextUsage(v)) => v,
+            other => panic!("expected AcpContextUsage, got {other:?}"),
+        }
+    }
+
+    /// The indicator needs a denominator: when the backend reports a context
+    /// window it MUST ride the frame as `size`, alongside `used`. Values are the
+    /// live-captured claude figures (occupancy 26_420 of a 1M window).
+    #[test]
+    fn context_window_rides_the_usage_frame_as_size() {
+        let v = usage_frame(26_420, Some(0.117), Some(1_000_000));
+        assert_eq!(v["used"], 26_420);
+        assert_eq!(v["size"], 1_000_000);
+        assert_eq!(v["cost"]["amount"], 0.117);
+        assert_eq!(v["cost"]["currency"], "USD");
+    }
+
+    /// No window reported (codex `modelContextWindow: null`) → NO `size` key at
+    /// all. Emitting `size: 0` would render a zero-width bar; the frontend guards
+    /// on the key's absence instead.
+    #[test]
+    fn absent_context_window_emits_no_size_key() {
+        let v = usage_frame(11_030, None, None);
+        assert_eq!(v["used"], 11_030);
+        assert!(v.get("size").is_none(), "no window → no `size` key, got {v}");
+        assert!(v.get("cost").is_none(), "no cost → no `cost` key, got {v}");
+    }
+
     fn tool_call(call_id: &str, name: &str, status: ToolCallStatus) -> AgentStreamEvent {
         AgentStreamEvent::ToolCall(ToolCallEventData {
             call_id: call_id.into(),
@@ -3382,6 +3585,7 @@ mod translate_tests {
                 output_tokens: 20,
                 total_tokens: 30,
                 cost_usd: Some(0.5),
+                context_window: None,
             },
             "conv-1",
             false,
@@ -3784,6 +3988,117 @@ mod persist_tests {
         .await
         .unwrap();
         (repo, db)
+    }
+
+    fn usage(total: u64, cost: Option<f64>, window: Option<u64>) -> SessionEvent {
+        SessionEvent::UsageDelta {
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: total,
+            cost_usd: cost,
+            context_window: window,
+        }
+    }
+
+    async fn stored_usage(repo: &dyn IAcpSessionRepository) -> serde_json::Value {
+        let state = repo
+            .load_runtime_state_for_user("user-1", "conv-1")
+            .await
+            .unwrap()
+            .expect("runtime state exists");
+        serde_json::from_str(state.context_usage_json.as_deref().expect("context_usage written")).unwrap()
+    }
+
+    /// Defect 1: claude reports usage on the `result` frame, which lands AFTER the
+    /// turn's relay has broken on Finish. The pump is session-scoped and still
+    /// running, so the write must land regardless of turn lifecycle. The event
+    /// ORDER matters — a test that persisted a lone UsageDelta would not exercise
+    /// the bug at all.
+    #[tokio::test]
+    async fn usage_arriving_after_the_turn_ended_is_still_persisted() {
+        let (repo, _db) = seeded_repo().await;
+        // The turn terminates first...
+        persist_side_effects(
+            repo.as_ref(),
+            "user-1",
+            "conv-1",
+            &SessionEvent::TurnResult {
+                is_error: false,
+                api_error_status: None,
+                result_text: String::new(),
+                epoch: 0,
+                outcome: aionui_session::TurnOutcome::EndTurn,
+            },
+        )
+        .await;
+        // ...and only then does claude's usage arrive.
+        persist_side_effects(
+            repo.as_ref(),
+            "user-1",
+            "conv-1",
+            &usage(26_420, Some(0.117), Some(1_000_000)),
+        )
+        .await;
+
+        let stored = stored_usage(repo.as_ref()).await;
+        assert_eq!(stored["used"], 26_420, "late usage must still reach the snapshot");
+        assert_eq!(stored["size"], 1_000_000, "the context window rides along as `size`");
+        assert_eq!(stored["cost"]["amount"], 0.117);
+        assert_eq!(stored["cost"]["currency"], "USD");
+    }
+
+    /// Writes MERGE. codex reports no cost at all and can report
+    /// `modelContextWindow: null`, so a later sizeless/costless report must not
+    /// blank a window the previous one established — that would make the indicator
+    /// lose its denominator mid-conversation.
+    #[tokio::test]
+    async fn sizeless_costless_update_keeps_the_known_window_and_cost() {
+        let (repo, _db) = seeded_repo().await;
+        persist_side_effects(
+            repo.as_ref(),
+            "user-1",
+            "conv-1",
+            &usage(11_013, Some(0.5), Some(258_400)),
+        )
+        .await;
+        persist_side_effects(repo.as_ref(), "user-1", "conv-1", &usage(11_030, None, None)).await;
+
+        let stored = stored_usage(repo.as_ref()).await;
+        assert_eq!(stored["used"], 11_030, "`used` always takes the newer value");
+        assert_eq!(stored["size"], 258_400, "a sizeless update must not blank the window");
+        assert_eq!(
+            stored["cost"]["amount"], 0.5,
+            "a costless update must not blank the cost"
+        );
+    }
+
+    /// The live frame must match what the renderer actually switches on.
+    /// `useAcpMessage.ts` handles `case 'acp_context_usage'`, reads `data.used`
+    /// into the indicator and `data.size` into `context_limit` (only when > 0), so
+    /// the tag and both key names are a hard contract — a rename silently blanks
+    /// the indicator rather than failing anything.
+    #[test]
+    fn broadcast_frame_matches_the_renderer_contract() {
+        #[derive(Default)]
+        struct Recorder(std::sync::Mutex<Vec<aionui_api_types::WebSocketMessage<serde_json::Value>>>);
+        impl EventBroadcaster for Recorder {
+            fn broadcast(&self, event: aionui_api_types::WebSocketMessage<serde_json::Value>) {
+                self.0.lock().unwrap().push(event);
+            }
+        }
+
+        let bus = Recorder::default();
+        broadcast_usage_frame(&bus, "conv-1", "user-1", &usage(26_420, Some(0.117), Some(1_000_000)));
+        let sent = bus.0.lock().unwrap();
+        let msg = sent.first().expect("one frame broadcast");
+        assert_eq!(msg.name, "message.stream");
+        assert_eq!(
+            msg.data["type"], "acp_context_usage",
+            "renderer switches on this exact tag"
+        );
+        assert_eq!(msg.data["data"]["used"], 26_420);
+        assert_eq!(msg.data["data"]["size"], 1_000_000, "drives context_limit");
+        assert_eq!(msg.data["conversation_id"], "conv-1");
     }
 
     #[tokio::test]
@@ -4776,6 +5091,7 @@ mod pump_tests {
                 dir: tmp.path().to_path_buf(),
                 backend: "claude",
             }),
+            None,
         );
         crate::agent_task::IAgentTask::send_message(
             task.as_ref(),
@@ -4818,6 +5134,7 @@ mod pump_tests {
                 dir: tmp.path().to_path_buf(),
                 backend: "codex",
             }),
+            None,
         );
         // Inject an image directly onto the task's dump path via a content slice
         // containing an Image block.
@@ -4852,6 +5169,7 @@ mod pump_tests {
             backend,
             None,
             CatalogPreload::default(),
+            None,
             None,
         );
         crate::agent_task::IAgentTask::send_message(
@@ -5396,6 +5714,7 @@ mod pump_tests {
             None,
             &handshake_with_catalog(),
             None,
+            None,
         );
 
         // get_model serves the preloaded catalog + persisted current model.
@@ -5455,6 +5774,7 @@ mod pump_tests {
             None,
             &stale,
             None,
+            None,
         );
         let m = task.get_model().await.unwrap().model_info.expect("model_info");
         assert_eq!(
@@ -5509,6 +5829,7 @@ mod pump_tests {
             backend,
             None,
             &handshake_with_catalog(),
+            None,
             None,
         );
 

--- a/crates/aionui-session/src/adapter/claude.rs
+++ b/crates/aionui-session/src/adapter/claude.rs
@@ -539,9 +539,34 @@ impl ClaudeAdapter {
                 output_tokens,
                 total_tokens,
                 cost_usd: v.get("total_cost_usd").and_then(Value::as_f64),
+                context_window: Self::result_context_window(v),
             });
         }
         out
+    }
+
+    /// The model's total context window from a `result` frame, for the usage
+    /// indicator's denominator. It rides `modelUsage.<model>.contextWindow`
+    /// (live-captured, claude 2.1.220: `{"claude-opus-5":{…,"contextWindow":1000000}}`).
+    ///
+    /// The entry cannot be selected by model id — the frame's own `model` field is
+    /// `null` on the wire. One entry (the observed shape) is used directly; when a
+    /// turn touched several models (a subagent on a different one) the DOMINANT
+    /// entry by `inputTokens + outputTokens` wins, i.e. the main conversation model.
+    /// That tie-break is a heuristic: only the single-entry shape has been captured.
+    /// Absent / non-integer → `None`, which renders as a counter with no percentage.
+    fn result_context_window(v: &Value) -> Option<u64> {
+        let entries = v.get("modelUsage")?.as_object()?;
+        entries
+            .values()
+            .filter_map(|m| {
+                let window = m.get("contextWindow").and_then(Value::as_u64)?;
+                let volume = m.get("inputTokens").and_then(Value::as_u64).unwrap_or(0)
+                    + m.get("outputTokens").and_then(Value::as_u64).unwrap_or(0);
+                Some((volume, window))
+            })
+            .max_by_key(|(volume, _)| *volume)
+            .map(|(_, window)| window)
     }
 
     /// C-1: map a claude result frame's `terminal_reason` (preferred, 12-value) or
@@ -1900,6 +1925,67 @@ mod tests {
         assert_eq!(gated.get(at + 1).map(String::as_str), Some("summarized"));
     }
 
+    /// Helper: drive one `result` NDJSON line through the adapter and return the
+    /// `context_window` the emitted `UsageDelta` carries.
+    #[cfg(test)]
+    fn window_of(line: &str) -> Option<Option<u64>> {
+        let mut a = ClaudeAdapter::new();
+        a.parse_chunk(format!("{line}\n").as_bytes())
+            .into_iter()
+            .find_map(|e| match e {
+                SessionEvent::UsageDelta { context_window, .. } => Some(context_window),
+                _ => None,
+            })
+    }
+
+    /// The context-window size the usage indicator renders as `size` rides
+    /// `result.modelUsage.<model>.contextWindow`. Verbatim shape from a live
+    /// claude 2.1.220 turn (model `claude-opus-5`, window 1_000_000).
+    #[test]
+    fn result_carries_context_window_from_single_model_usage_entry() {
+        let line = concat!(
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"ok","#,
+            r#""usage":{"input_tokens":2,"cache_creation_input_tokens":10920,"#,
+            r#""cache_read_input_tokens":15493,"output_tokens":5},"model":null,"#,
+            r#""modelUsage":{"claude-opus-5":{"inputTokens":2,"outputTokens":5,"#,
+            r#""contextWindow":1000000,"maxOutputTokens":64000}}}"#
+        );
+        assert_eq!(window_of(line), Some(Some(1_000_000)));
+    }
+
+    /// `result.model` is null on the wire, so the entry cannot be picked by model
+    /// id. With several entries (a subagent ran on a different model) take the
+    /// DOMINANT one by token volume — the main conversation model. Heuristic: only
+    /// the single-entry shape has been captured live.
+    #[test]
+    fn multi_entry_model_usage_picks_the_dominant_model() {
+        let line = concat!(
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"ok","#,
+            r#""usage":{"input_tokens":10,"output_tokens":5},"#,
+            r#""modelUsage":{"claude-haiku-4-5":{"inputTokens":12,"outputTokens":3,"contextWindow":200000},"#,
+            r#""claude-opus-5":{"inputTokens":900,"outputTokens":100,"contextWindow":1000000}}}"#
+        );
+        assert_eq!(window_of(line), Some(Some(1_000_000)));
+    }
+
+    /// A usage-bearing result with no `modelUsage` (or an unparseable one) must
+    /// still emit the UsageDelta — just without a window. The frontend guards on
+    /// `size > 0`, so `None` degrades to "counter without a percentage".
+    #[test]
+    fn missing_or_malformed_model_usage_yields_no_window() {
+        let bare = concat!(
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"ok","#,
+            r#""usage":{"input_tokens":10,"output_tokens":5}}"#
+        );
+        assert_eq!(window_of(bare), Some(None));
+
+        let malformed = concat!(
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"ok","#,
+            r#""usage":{"input_tokens":10,"output_tokens":5},"modelUsage":{"m":{"contextWindow":"big"}}}"#
+        );
+        assert_eq!(window_of(malformed), Some(None));
+    }
+
     /// H4 (design-vs-code gap audit, §5): `UsageDelta.total_tokens` MUST count the
     /// cache buckets (`cache_read_input_tokens` + `cache_creation_input_tokens`),
     /// which ARE billed input tokens — omitting them under-reported a cache-heavy
@@ -1930,6 +2016,7 @@ mod tests {
                     output_tokens,
                     total_tokens,
                     cost_usd,
+                    ..
                 } => Some((input_tokens, output_tokens, total_tokens, cost_usd)),
                 _ => None,
             })

--- a/crates/aionui-session/src/adapter/claude.rs
+++ b/crates/aionui-session/src/adapter/claude.rs
@@ -41,6 +41,12 @@ pub struct ClaudeAdapter {
     /// 15_493+26_345+26_485+27_386 summed). Feeding the aggregate to the usage
     /// indicator drove it past 100% of the context window.
     last_call_tokens: Option<u64>,
+    /// Thinking tokens accumulated across the turn's API calls. `result.usage`
+    /// reports `output_tokens_details: null` (live-captured), so the only source is
+    /// each `message_delta.usage.output_tokens_details.thinking_tokens` — 60 on the
+    /// first call of a captured four-call turn. Summed here because the breakdown
+    /// is a PER-TURN figure; reset when the `result` frame consumes it.
+    turn_thought_tokens: u64,
 }
 
 /// Per-message streaming state for `--include-partial-messages`. Reset on each
@@ -477,7 +483,7 @@ impl ClaudeAdapter {
     /// on the same result frame). Returns a Vec so the usage rides alongside the
     /// terminal — codex already emits UsageDelta (map_usage); this closes the
     /// claude/codex asymmetry. The wrapping ClaudeConnection inherits both for free.
-    fn parse_result(&self, v: &Value) -> Vec<SessionEvent> {
+    fn parse_result(&mut self, v: &Value) -> Vec<SessionEvent> {
         let is_error = v.get("is_error").and_then(Value::as_bool).unwrap_or(false);
         let result_text = match v.get("result").and_then(Value::as_str) {
             Some(s) if !s.is_empty() => s.to_string(),
@@ -562,7 +568,16 @@ impl ClaudeAdapter {
                 output_tokens,
                 total_tokens,
                 cost_usd: v.get("total_cost_usd").and_then(Value::as_f64),
-                context_window: Self::result_context_window(v),
+                context_window: self.result_context_window(v),
+                // Per-turn detail line. These stay on the AGGREGATE `result.usage`
+                // (unlike `total_tokens`, which must be the last call's occupancy):
+                // the breakdown answers "what did this turn cost", so counting every
+                // API call is the correct reading.
+                breakdown: crate::event::UsageBreakdown {
+                    cached_read_tokens: cache_read,
+                    cached_write_tokens: cache_creation,
+                    thought_tokens: std::mem::take(&mut self.turn_thought_tokens),
+                },
             });
         }
         out
@@ -578,7 +593,7 @@ impl ClaudeAdapter {
     /// entry by `inputTokens + outputTokens` wins, i.e. the main conversation model.
     /// That tie-break is a heuristic: only the single-entry shape has been captured.
     /// Absent / non-integer → `None`, which renders as a counter with no percentage.
-    fn result_context_window(v: &Value) -> Option<u64> {
+    fn result_context_window(&self, v: &Value) -> Option<u64> {
         let entries = v.get("modelUsage")?.as_object()?;
         entries
             .values()
@@ -755,6 +770,11 @@ impl ClaudeAdapter {
                     if occupancy > 0 {
                         self.last_call_tokens = Some(occupancy);
                     }
+                    self.turn_thought_tokens += usage
+                        .get("output_tokens_details")
+                        .and_then(|d| d.get("thinking_tokens"))
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0);
                 }
                 let stop_reason = event
                     .and_then(|e| e.get("delta"))
@@ -2077,6 +2097,49 @@ mod tests {
             total, 27_472,
             "occupancy is the last call (2+79+27386+5), NOT the 107_974 aggregate"
         );
+    }
+
+    /// The detail line's counters are PER-TURN, so they ride the aggregate
+    /// `result.usage` even though `total_tokens` must not. Thinking tokens are the
+    /// exception: `result.usage.output_tokens_details` is null (live-captured), so
+    /// they are summed off each `message_delta` — 60 + 12 across two calls here.
+    #[test]
+    fn breakdown_sums_thinking_across_calls_and_reads_caches_from_the_aggregate() {
+        let mut a = ClaudeAdapter::new();
+        for (cr, think) in [(15493u64, 60u64), (27386, 12)] {
+            let line = format!(
+                r#"{{"type":"stream_event","event":{{"type":"message_delta","delta":{{"stop_reason":"tool_use"}},"usage":{{"input_tokens":2,"cache_creation_input_tokens":79,"cache_read_input_tokens":{cr},"output_tokens":5,"output_tokens_details":{{"thinking_tokens":{think}}}}}}}}}"#
+            );
+            a.parse_chunk(format!("{line}\n").as_bytes());
+        }
+        let result = concat!(
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"ok","#,
+            r#""usage":{"input_tokens":8,"cache_creation_input_tokens":11972,"#,
+            r#""cache_read_input_tokens":95709,"output_tokens":285}}"#,
+            "\n"
+        );
+        let b = a
+            .parse_chunk(result.as_bytes())
+            .into_iter()
+            .find_map(|e| match e {
+                SessionEvent::UsageDelta { breakdown, .. } => Some(breakdown),
+                _ => None,
+            })
+            .expect("result emits a UsageDelta");
+        assert_eq!(b.cached_read_tokens, 95_709, "per-turn cache reads");
+        assert_eq!(b.cached_write_tokens, 11_972, "per-turn cache writes");
+        assert_eq!(b.thought_tokens, 72, "thinking summed across the turn's calls");
+
+        // The accumulator resets, or the next turn would inherit this turn's total.
+        let next = a
+            .parse_chunk(result.as_bytes())
+            .into_iter()
+            .find_map(|e| match e {
+                SessionEvent::UsageDelta { breakdown, .. } => Some(breakdown),
+                _ => None,
+            })
+            .expect("second result emits a UsageDelta");
+        assert_eq!(next.thought_tokens, 0, "thinking must not carry into the next turn");
     }
 
     /// Without any streamed `message_delta` the aggregate is the only figure

--- a/crates/aionui-session/src/adapter/claude.rs
+++ b/crates/aionui-session/src/adapter/claude.rs
@@ -324,8 +324,30 @@ impl ClaudeAdapter {
                 }
                 Vec::new()
             }
+            "compact_boundary" => {
+                // A compaction rewrites the context, so the occupancy latched off
+                // the last API call is now stale — and the compaction turn itself
+                // streams NO `message_delta` to refresh it (live-captured: five
+                // turns climbing to 27_349, then `compact_boundary{pre:27349,
+                // post:3158}` followed by a `result` with `num_turns:0` and a zero
+                // aggregate, then the next real turn reporting 23_779).
+                //
+                // Without this reset the stale 27_349 would survive the fallback
+                // and sail past the zero-usage guard, re-publishing a
+                // pre-compaction figure as if it were current. Dropping it lets the
+                // compaction's zero aggregate be discarded as intended, so the
+                // indicator holds its previous reading until the next real turn
+                // measures the new context.
+                //
+                // The boundary's own `post_tokens` cannot substitute: it counts the
+                // compacted transcript only (3_158 here) while occupancy also
+                // carries the system prompt and tools — the next turn measured
+                // 23_779, ~20k higher. Different baselines.
+                self.last_call_tokens = None;
+                vec![SessionEvent::Heartbeat]
+            }
             // network backoff + the no-chunk compaction window both = liveness.
-            "api_retry" | "compact_boundary" | "compacting" => vec![SessionEvent::Heartbeat],
+            "api_retry" | "compacting" => vec![SessionEvent::Heartbeat],
             other => vec![SessionEvent::AdapterSpecific {
                 tag: format!("system/{other}"),
                 payload: v.clone(),
@@ -2193,6 +2215,59 @@ mod tests {
             })
             .expect("result emits a UsageDelta");
         assert_eq!(total, 27_472);
+    }
+
+    /// Replays a live-captured compaction: five turns climbing to 27_349, the
+    /// boundary, the compaction's own `result` (`num_turns:0`, zero aggregate, and
+    /// crucially NO `message_delta`), then the next real turn at 23_779.
+    ///
+    /// The compaction must publish NOTHING. Its turn cannot measure the new
+    /// context, and the latched pre-compaction figure would otherwise slip past
+    /// the zero-usage guard and be re-published as current — the reported "used
+    /// tokens never update after a compaction".
+    #[test]
+    fn compaction_invalidates_the_latched_occupancy() {
+        let mut a = ClaudeAdapter::new();
+        let occupancy_of = |evs: Vec<SessionEvent>| {
+            evs.into_iter().find_map(|e| match e {
+                SessionEvent::UsageDelta { total_tokens, .. } => Some(total_tokens),
+                _ => None,
+            })
+        };
+        let delta = |cr: u64| {
+            format!(
+                r#"{{"type":"stream_event","event":{{"type":"message_delta","delta":{{"stop_reason":"end_turn"}},"usage":{{"input_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":{cr},"output_tokens":0}}}}}}"#
+            )
+        };
+        let result_with = |agg: u64| {
+            format!(
+                r#"{{"type":"result","subtype":"success","is_error":false,"result":"ok","usage":{{"input_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":{agg},"output_tokens":0}}}}"#
+            )
+        };
+
+        // A normal turn establishes the latch.
+        a.parse_chunk(format!("{}\n", delta(27_347)).as_bytes());
+        assert_eq!(
+            occupancy_of(a.parse_chunk(format!("{}\n", result_with(27_347)).as_bytes())),
+            Some(27_349)
+        );
+
+        // The compaction: boundary, then a zero-aggregate result with no delta.
+        let boundary = r#"{"type":"system","subtype":"compact_boundary","compact_metadata":{"trigger":"manual","pre_tokens":27349,"post_tokens":3158}}"#;
+        a.parse_chunk(format!("{boundary}\n").as_bytes());
+        let zero_result = r#"{"type":"result","subtype":"success","is_error":false,"result":"","usage":{"input_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":0}}"#;
+        assert_eq!(
+            occupancy_of(a.parse_chunk(format!("{zero_result}\n").as_bytes())),
+            Some(0),
+            "the compaction must report zero (dropped downstream), NOT the stale 27_349"
+        );
+
+        // The next real turn measures the compacted context.
+        a.parse_chunk(format!("{}\n", delta(23_777)).as_bytes());
+        assert_eq!(
+            occupancy_of(a.parse_chunk(format!("{}\n", result_with(23_777)).as_bytes())),
+            Some(23_779)
+        );
     }
 
     /// Switching models must move the window. `modelUsage` is session-CUMULATIVE

--- a/crates/aionui-session/src/adapter/claude.rs
+++ b/crates/aionui-session/src/adapter/claude.rs
@@ -47,6 +47,11 @@ pub struct ClaudeAdapter {
     /// first call of a captured four-call turn. Summed here because the breakdown
     /// is a PER-TURN figure; reset when the `result` frame consumes it.
     turn_thought_tokens: u64,
+    /// The model id claude last announced on `system{subtype:"init"}` — the
+    /// authoritative "what am I running now", re-emitted on model switch and after
+    /// a compaction. Spelled exactly like the `modelUsage` keys
+    /// (`"claude-opus-5"`), so it selects the right entry directly.
+    current_model: Option<String>,
 }
 
 /// Per-message streaming state for `--include-partial-messages`. Reset on each
@@ -310,9 +315,15 @@ impl ClaudeAdapter {
     /// system frames: `init` carries no state signal; `api_retry` and the
     /// compaction milestones normalize to the backend-neutral `Heartbeat`;
     /// anything else is opaque.
-    fn parse_system(&self, v: &Value) -> Vec<SessionEvent> {
+    fn parse_system(&mut self, v: &Value) -> Vec<SessionEvent> {
         match v.get("subtype").and_then(Value::as_str).unwrap_or("") {
-            "init" => Vec::new(),
+            "init" => {
+                // Carries the live model id; latch it for `result_context_window`.
+                if let Some(model) = v.get("model").and_then(Value::as_str) {
+                    self.current_model = Some(model.to_owned());
+                }
+                Vec::new()
+            }
             // network backoff + the no-chunk compaction window both = liveness.
             "api_retry" | "compact_boundary" | "compacting" => vec![SessionEvent::Heartbeat],
             other => vec![SessionEvent::AdapterSpecific {
@@ -595,6 +606,25 @@ impl ClaudeAdapter {
     /// Absent / non-integer → `None`, which renders as a counter with no percentage.
     fn result_context_window(&self, v: &Value) -> Option<u64> {
         let entries = v.get("modelUsage")?.as_object()?;
+        // Prefer the model claude says it is CURRENTLY running. `modelUsage` is
+        // session-CUMULATIVE (live-measured: `cacheReadInputTokens` 18_384 after
+        // turn 1, 44_791 after turn 2), so after a model switch the outgoing
+        // model's accumulated volume still dwarfs the new one's first turn — a
+        // volume ranking would pin the window to the old model forever. That is
+        // exactly the reported bug: switching opus -> haiku kept showing 1M
+        // instead of 200k. `system{subtype:"init"}` announces the live model and
+        // is re-emitted on a switch, spelled identically to these keys.
+        if let Some(current) = self.current_model.as_deref()
+            && let Some(window) = entries
+                .get(current)
+                .and_then(|m| m.get("contextWindow"))
+                .and_then(Value::as_u64)
+        {
+            return Some(window);
+        }
+        // Fallback for a session that never announced a model (or announced one
+        // absent from `modelUsage`): the heaviest entry, cache included, since the
+        // main conversation model is the one carrying the history as cache.
         entries
             .values()
             .filter_map(|m| {
@@ -2165,6 +2195,41 @@ mod tests {
         assert_eq!(total, 27_472);
     }
 
+    /// Switching models must move the window. `modelUsage` is session-CUMULATIVE
+    /// (live-measured: `cacheReadInputTokens` 18_384 after turn 1, 44_791 after
+    /// turn 2), so the model just switched AWAY from keeps the larger volume and a
+    /// volume ranking pins the window to it — the reported bug, where opus -> haiku
+    /// still displayed 1M instead of 200k. `system{subtype:"init"}` announces the
+    /// live model, so that selects the entry.
+    #[test]
+    fn model_switch_moves_the_window_despite_cumulative_model_usage() {
+        let result = concat!(
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"ok","#,
+            r#""usage":{"input_tokens":10,"output_tokens":5},"#,
+            // opus carries the whole accumulated history; haiku has just started.
+            r#""modelUsage":{"claude-opus-5":{"inputTokens":4,"outputTokens":10,"#,
+            r#""cacheReadInputTokens":44791,"contextWindow":1000000},"#,
+            r#""claude-haiku-4-5":{"inputTokens":2,"outputTokens":5,"#,
+            r#""cacheReadInputTokens":120,"contextWindow":200000}}}"#,
+            "\n"
+        );
+        let window_after_init = |model: &str| {
+            let mut a = ClaudeAdapter::new();
+            let init = format!(r#"{{"type":"system","subtype":"init","model":"{model}"}}"#);
+            a.parse_chunk(format!("{init}\n").as_bytes());
+            a.parse_chunk(result.as_bytes()).into_iter().find_map(|e| match e {
+                SessionEvent::UsageDelta { context_window, .. } => Some(context_window),
+                _ => None,
+            })
+        };
+        assert_eq!(
+            window_after_init("claude-haiku-4-5"),
+            Some(Some(200_000)),
+            "after switching to haiku the window must follow, not stay on opus's 1M"
+        );
+        assert_eq!(window_after_init("claude-opus-5"), Some(Some(1_000_000)));
+    }
+
     /// The dominant-model pick must weigh CACHE too. A `modelUsage` entry's
     /// in/out exclude cache, and the main model is the one holding the history as
     /// cache (live-captured: `inputTokens:10, outputTokens:34,
@@ -2397,8 +2462,8 @@ mod tests {
     /// this table pins every documented subtype + the unknown fallthrough.
     #[test]
     fn parse_system_subtypes_map_to_heartbeat_or_opaque() {
-        let a = ClaudeAdapter::new();
-        let sys = |subtype: &str| {
+        let mut a = ClaudeAdapter::new();
+        let mut sys = |subtype: &str| {
             let v = serde_json::json!({ "type": "system", "subtype": subtype });
             a.parse_system(&v)
         };
@@ -2425,7 +2490,7 @@ mod tests {
             }
             other => panic!("expected one AdapterSpecific, got {other:?}"),
         }
-        let no_subtype = a.parse_system(&serde_json::json!({ "type": "system" }));
+        let no_subtype = sys("");
         assert!(
             matches!(no_subtype.as_slice(), [SessionEvent::AdapterSpecific { tag, .. }] if tag == "system/"),
             "absent subtype → opaque `system/` (no panic), got {no_subtype:?}"

--- a/crates/aionui-session/src/adapter/claude.rs
+++ b/crates/aionui-session/src/adapter/claude.rs
@@ -29,6 +29,18 @@ pub struct ClaudeAdapter {
     /// text fragments emit as incremental `MessageDelta`s (typewriter) and the
     /// consolidated `assistant` frame skips re-emitting text it already streamed.
     stream: StreamState,
+    /// Context occupancy from the most recent API call in the session, summed as
+    /// `input + cache_creation + cache_read + output` off the last
+    /// `message_delta.usage`.
+    ///
+    /// Deliberately NOT per-message state: it must outlive `message_start`, since
+    /// the figure we want is the LAST call of the turn. `result.usage` cannot
+    /// supply it — that field AGGREGATES every API call in the turn, so a
+    /// four-tool-call turn reported 107_974 where the real occupancy was 27_467
+    /// (live-captured, 2.1.220; its `cache_read` 95_709 is exactly the four calls'
+    /// 15_493+26_345+26_485+27_386 summed). Feeding the aggregate to the usage
+    /// indicator drove it past 100% of the context window.
+    last_call_tokens: Option<u64>,
 }
 
 /// Per-message streaming state for `--include-partial-messages`. Reset on each
@@ -262,7 +274,7 @@ impl ClaudeAdapter {
             "system" => self.parse_system(v),
             "assistant" => self.parse_assistant(v),
             "user" => self.parse_user(v),
-            "result" => Self::parse_result(v),
+            "result" => self.parse_result(v),
             // F3 control channel (--permission-prompt-tool stdio). A
             // `control_request` whose `request.subtype == can_use_tool` needs a
             // user answer → `Permission{request_id}` (the reducer ref-counts; the
@@ -465,7 +477,7 @@ impl ClaudeAdapter {
     /// on the same result frame). Returns a Vec so the usage rides alongside the
     /// terminal — codex already emits UsageDelta (map_usage); this closes the
     /// claude/codex asymmetry. The wrapping ClaudeConnection inherits both for free.
-    fn parse_result(v: &Value) -> Vec<SessionEvent> {
+    fn parse_result(&self, v: &Value) -> Vec<SessionEvent> {
         let is_error = v.get("is_error").and_then(Value::as_bool).unwrap_or(false);
         let result_text = match v.get("result").and_then(Value::as_str) {
             Some(s) if !s.is_empty() => s.to_string(),
@@ -530,10 +542,21 @@ impl ClaudeAdapter {
             let output_tokens = get("output_tokens");
             let cache_creation = get("cache_creation_input_tokens");
             let cache_read = get("cache_read_input_tokens");
-            let total_tokens = usage
-                .get("total_tokens")
-                .and_then(Value::as_u64)
-                .unwrap_or(input_tokens + output_tokens + cache_creation + cache_read);
+            // CONTEXT OCCUPANCY, not the turn's billed volume. `result.usage`
+            // aggregates every API call in the turn, so summing its buckets
+            // overstates occupancy by roughly the number of tool rounds (measured
+            // 107_974 vs a true 27_467 on a four-call turn) and pushed the usage
+            // indicator past 100%. Prefer the last call's own usage, tracked off
+            // `message_delta`. The aggregate remains the fallback for a turn that
+            // streamed no `message_delta` at all (no `--include-partial-messages`,
+            // or a resumed/consolidated frame); it is exact for a single-call turn
+            // and only overstates once tool rounds appear.
+            let total_tokens = self.last_call_tokens.unwrap_or_else(|| {
+                usage
+                    .get("total_tokens")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(input_tokens + output_tokens + cache_creation + cache_read)
+            });
             out.push(SessionEvent::UsageDelta {
                 input_tokens,
                 output_tokens,
@@ -561,8 +584,20 @@ impl ClaudeAdapter {
             .values()
             .filter_map(|m| {
                 let window = m.get("contextWindow").and_then(Value::as_u64)?;
-                let volume = m.get("inputTokens").and_then(Value::as_u64).unwrap_or(0)
-                    + m.get("outputTokens").and_then(Value::as_u64).unwrap_or(0);
+                // Weigh by the FULL volume including both cache buckets. A
+                // `modelUsage` entry's `inputTokens`/`outputTokens` EXCLUDE cache,
+                // and the main conversation model is precisely the one carrying the
+                // history as cache: live-captured, the main entry read
+                // `inputTokens:10, outputTokens:34, cacheReadInputTokens:27953` —
+                // 44 against 27_953. Ranking on in+out alone let any Task subagent
+                // doing uncached work outrank it, handing the indicator the
+                // subagent's window (e.g. haiku's 200k in place of opus's 1M) and
+                // inflating the percentage fivefold.
+                let field = |k: &str| m.get(k).and_then(Value::as_u64).unwrap_or(0);
+                let volume = field("inputTokens")
+                    + field("outputTokens")
+                    + field("cacheReadInputTokens")
+                    + field("cacheCreationInputTokens");
                 Some((volume, window))
             })
             .max_by_key(|(volume, _)| *volume)
@@ -704,6 +739,23 @@ impl ClaudeAdapter {
             // No FSM signal, now an EXPECTED frame (not unknown) → emit nothing.
             "content_block_stop" | "message_stop" => Vec::new(),
             "message_delta" => {
+                // Each `message_delta` closes ONE API call and carries that call's
+                // complete usage. The last one of the turn is therefore the current
+                // context occupancy — the figure the usage indicator needs, and the
+                // one `result.usage` cannot give (it sums every call; see
+                // `last_call_tokens`). Live-captured tail of a four-call turn:
+                // `{input_tokens:2, cache_creation:79, cache_read:27386, output:5}`
+                // = 27_472, against an aggregate of 107_974.
+                if let Some(usage) = event.and_then(|e| e.get("usage")).and_then(Value::as_object) {
+                    let field = |k: &str| usage.get(k).and_then(Value::as_u64).unwrap_or(0);
+                    let occupancy = field("input_tokens")
+                        + field("cache_creation_input_tokens")
+                        + field("cache_read_input_tokens")
+                        + field("output_tokens");
+                    if occupancy > 0 {
+                        self.last_call_tokens = Some(occupancy);
+                    }
+                }
                 let stop_reason = event
                     .and_then(|e| e.get("delta"))
                     .and_then(|d| d.get("stop_reason"))
@@ -1986,6 +2038,93 @@ mod tests {
         assert_eq!(window_of(malformed), Some(None));
     }
 
+    /// A turn with tool rounds makes several API calls, and `result.usage`
+    /// AGGREGATES them — feeding that to the indicator drove it past 100% of the
+    /// window (reported in the wild at 340%). Occupancy is the LAST call's own
+    /// usage. Frames verbatim from a live four-call turn (2.1.220): the per-call
+    /// `message_delta.usage` values, then the aggregate `result.usage` whose
+    /// `cache_read_input_tokens` 95_709 is exactly 15_493+26_345+26_485+27_386.
+    #[test]
+    fn multi_call_turn_reports_last_call_occupancy_not_the_turn_aggregate() {
+        let mut a = ClaudeAdapter::new();
+        let deltas = [
+            (2, 10852, 15493, 134),
+            (2, 140, 26345, 73),
+            (2, 901, 26485, 73),
+            (2, 79, 27386, 5),
+        ];
+        for (i, cc, cr, o) in deltas {
+            let line = format!(
+                r#"{{"type":"stream_event","event":{{"type":"message_delta","delta":{{"stop_reason":"tool_use"}},"usage":{{"input_tokens":{i},"cache_creation_input_tokens":{cc},"cache_read_input_tokens":{cr},"output_tokens":{o}}}}}}}"#
+            );
+            a.parse_chunk(format!("{line}\n").as_bytes());
+        }
+        let result = concat!(
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"ok","#,
+            r#""usage":{"input_tokens":8,"cache_creation_input_tokens":11972,"#,
+            r#""cache_read_input_tokens":95709,"output_tokens":285},"total_cost_usd":0.5}"#,
+            "\n"
+        );
+        let total = a
+            .parse_chunk(result.as_bytes())
+            .into_iter()
+            .find_map(|e| match e {
+                SessionEvent::UsageDelta { total_tokens, .. } => Some(total_tokens),
+                _ => None,
+            })
+            .expect("result emits a UsageDelta");
+        assert_eq!(
+            total, 27_472,
+            "occupancy is the last call (2+79+27386+5), NOT the 107_974 aggregate"
+        );
+    }
+
+    /// Without any streamed `message_delta` the aggregate is the only figure
+    /// available, and for a single-call turn it IS the occupancy — so the fallback
+    /// must still produce a number rather than nothing.
+    #[test]
+    fn without_streamed_calls_the_result_aggregate_is_used() {
+        let line = concat!(
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"ok","#,
+            r#""usage":{"input_tokens":2,"cache_creation_input_tokens":79,"#,
+            r#""cache_read_input_tokens":27386,"output_tokens":5}}"#,
+            "\n"
+        );
+        let mut a = ClaudeAdapter::new();
+        let total = a
+            .parse_chunk(line.as_bytes())
+            .into_iter()
+            .find_map(|e| match e {
+                SessionEvent::UsageDelta { total_tokens, .. } => Some(total_tokens),
+                _ => None,
+            })
+            .expect("result emits a UsageDelta");
+        assert_eq!(total, 27_472);
+    }
+
+    /// The dominant-model pick must weigh CACHE too. A `modelUsage` entry's
+    /// in/out exclude cache, and the main model is the one holding the history as
+    /// cache (live-captured: `inputTokens:10, outputTokens:34,
+    /// cacheReadInputTokens:27953`). Ranking on in+out alone handed the window to
+    /// a Task subagent doing uncached work.
+    #[test]
+    fn dominant_model_is_ranked_by_cache_inclusive_volume() {
+        let line = concat!(
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"ok","#,
+            r#""usage":{"input_tokens":10,"output_tokens":34},"#,
+            // Main model: tiny in/out, huge cache — must win.
+            r#""modelUsage":{"claude-opus-5":{"inputTokens":10,"outputTokens":34,"#,
+            r#""cacheReadInputTokens":27953,"contextWindow":1000000},"#,
+            // Subagent: larger uncached volume, smaller window — must NOT win.
+            r#""claude-haiku-4-5":{"inputTokens":1445,"outputTokens":1767,"contextWindow":200000}}}"#
+        );
+        assert_eq!(
+            window_of(line),
+            Some(Some(1_000_000)),
+            "the cache-heavy main model owns the window, not the busier subagent"
+        );
+    }
+
     /// H4 (design-vs-code gap audit, §5): `UsageDelta.total_tokens` MUST count the
     /// cache buckets (`cache_read_input_tokens` + `cache_creation_input_tokens`),
     /// which ARE billed input tokens — omitting them under-reported a cache-heavy
@@ -2148,7 +2287,7 @@ mod tests {
         // ::claude_live_cancel_before_output_never_leaks_ede_diagnostic`.
         let raw = include_str!("../../tests/fixtures/claude_2.1.185_cancel_before_output_result.ndjson");
         let frame: serde_json::Value = serde_json::from_str(raw.trim()).expect("fixture is valid result JSON");
-        let events = ClaudeAdapter::parse_result(&frame);
+        let events = ClaudeAdapter::new().parse_result(&frame);
         match events.first() {
             Some(SessionEvent::TurnResult {
                 result_text, is_error, ..
@@ -2176,7 +2315,7 @@ mod tests {
             "is_error": true,
             "errors": ["[ede_diagnostic] result_type=user stop_reason=null", "rate limit exceeded"],
         });
-        let events = ClaudeAdapter::parse_result(&frame);
+        let events = ClaudeAdapter::new().parse_result(&frame);
         match events.first() {
             Some(SessionEvent::TurnResult { result_text, .. }) => {
                 assert_eq!(
@@ -2276,7 +2415,7 @@ mod tests {
     /// leak "success"; an empty success turn must read as EmptyTurn upstream).
     #[test]
     fn parse_result_text_fallback_chain_each_arm() {
-        let text_of = |v: &Value| match ClaudeAdapter::parse_result(v).into_iter().next() {
+        let text_of = |v: &Value| match ClaudeAdapter::new().parse_result(v).into_iter().next() {
             Some(SessionEvent::TurnResult { result_text, .. }) => result_text,
             other => panic!("expected a TurnResult, got {other:?}"),
         };
@@ -2342,7 +2481,7 @@ mod tests {
             if let Some(r) = result { frame["result"] = serde_json::json!(r); }
             frame["errors"] = serde_json::json!(errors);
 
-            let events = ClaudeAdapter::parse_result(&frame); // (1) must not panic
+            let events = ClaudeAdapter::new().parse_result(&frame); // (1) must not panic
             let tr = events.iter().find(|e| matches!(e, SessionEvent::TurnResult { .. }));
             prop_assert!(tr.is_some(), "parse_result must emit a TurnResult");
             if let Some(SessionEvent::TurnResult { is_error, result_text, .. }) = tr {

--- a/crates/aionui-session/src/backend/acp_conn.rs
+++ b/crates/aionui-session/src/backend/acp_conn.rs
@@ -1776,6 +1776,9 @@ async fn map_update(
                 // ACP spells the context window `size` (the UsageUpdate shape the
                 // frontend indicator reads back as its denominator).
                 context_window: update.get("size").and_then(Value::as_u64),
+                // ACP's UsageUpdate carries no per-turn split, so the detail
+                // line stays empty and the renderer omits it.
+                breakdown: crate::event::UsageBreakdown::default(),
             }]
         }
         "current_mode_update" => {
@@ -1956,6 +1959,8 @@ fn parse_acp_result_usage(frame: &Value) -> Option<SessionEvent> {
         cost_usd,
         // ACP spells the context window `size` (see the notification path above).
         context_window: usage.get("size").and_then(Value::as_u64),
+        // ACP's end-of-turn usage carries no per-turn split either.
+        breakdown: crate::event::UsageBreakdown::default(),
     })
 }
 

--- a/crates/aionui-session/src/backend/acp_conn.rs
+++ b/crates/aionui-session/src/backend/acp_conn.rs
@@ -1773,6 +1773,9 @@ async fn map_update(
                 output_tokens: output,
                 total_tokens: total,
                 cost_usd,
+                // ACP spells the context window `size` (the UsageUpdate shape the
+                // frontend indicator reads back as its denominator).
+                context_window: update.get("size").and_then(Value::as_u64),
             }]
         }
         "current_mode_update" => {
@@ -1951,6 +1954,8 @@ fn parse_acp_result_usage(frame: &Value) -> Option<SessionEvent> {
         output_tokens: output,
         total_tokens: total,
         cost_usd,
+        // ACP spells the context window `size` (see the notification path above).
+        context_window: usage.get("size").and_then(Value::as_u64),
     })
 }
 
@@ -3658,6 +3663,7 @@ mod tests {
                 output_tokens,
                 total_tokens,
                 cost_usd,
+                ..
             } => {
                 assert_eq!(
                     *input_tokens, 0,
@@ -3691,6 +3697,7 @@ mod tests {
                 output_tokens,
                 total_tokens,
                 cost_usd,
+                ..
             }) => {
                 assert_eq!(*input_tokens, 1200);
                 assert_eq!(*output_tokens, 340);
@@ -3717,6 +3724,7 @@ mod tests {
                 output_tokens,
                 total_tokens,
                 cost_usd,
+                ..
             }) => {
                 assert_eq!((input_tokens, output_tokens, total_tokens), (900, 50, 950));
                 assert_eq!(cost_usd, Some(0.007));

--- a/crates/aionui-session/src/backend/codex_conn.rs
+++ b/crates/aionui-session/src/backend/codex_conn.rs
@@ -2826,7 +2826,25 @@ fn map_usage(params: &Value) -> Vec<SessionEvent> {
         output_tokens: g("outputTokens"),
         total_tokens: g("totalTokens"),
         cost_usd: None,
-        context_window: usage.get("modelContextWindow").and_then(Value::as_u64),
+        // DELIBERATELY NOT REPORTED, despite `tokenUsage.modelContextWindow` being
+        // the only context-window field in the whole codex protocol.
+        //
+        // Live-probed on 0.145.0 through a custom `model_provider`: `gpt-5.6-sol`,
+        // `gpt-5.5` and `gpt-5.6-luna` ALL report 258_400, and an explicit
+        // `model_context_window` (in `config.toml` AND via `-c`) is ignored. A
+        // figure that never varies by model and cannot be configured says nothing
+        // about the model in use, and a wrong denominator is worse than none: the
+        // renderer has a designed "context window size unknown" state that shows a
+        // plain token count instead of inventing a percentage.
+        //
+        // The likely explanation is that codex falls back to a stand-in for models
+        // it does not recognise, i.e. any custom provider — an official/Bedrock
+        // setup may well report a real window. That is UNVERIFIED: this machine has
+        // no official codex auth (no `~/.codex/auth.json`) to test against. Suppress
+        // unconditionally rather than encode a guess; revisit with a capture from a
+        // first-party provider, and gate on that evidence rather than on a
+        // hardcoded constant.
+        context_window: None,
         // Per-turn detail line. codex reports every field natively on `last`
         // (verified: TokenUsageBreakdown in the generated schema), including the
         // reasoning tokens claude only exposes per-call.
@@ -2845,10 +2863,11 @@ mod usage_window_tests {
     /// Verbatim `tokenUsage` from a live two-turn probe (codex-cli 0.145.0,
     /// `gpt-5.6-sol`): turn 2, window 258400. `used` must stay on `last`
     /// (11030 = the request carrying the whole history + its reply), NOT on the
-    /// cumulative `total` (22043) which would blow past the window on a long
-    /// session. The window itself becomes the indicator's denominator.
+    /// cumulative `total` (22043) which would blow past any window on a long
+    /// session. The reported `modelContextWindow` is NOT forwarded — see
+    /// `map_usage` for why codex's only window figure is unusable.
     #[test]
-    fn live_token_usage_maps_last_as_occupancy_plus_window() {
+    fn live_token_usage_maps_last_as_occupancy_and_drops_the_window() {
         let params: Value = serde_json::from_str(
             r#"{"threadId":"th1","turnId":"t1","tokenUsage":{
                  "modelContextWindow":258400,
@@ -2866,12 +2885,14 @@ mod usage_window_tests {
                     input_tokens: 11024,
                     output_tokens: 6,
                     total_tokens: 11030,
-                    context_window: Some(258_400),
+                    // The frame carried `modelContextWindow: 258400`; it is
+                    // deliberately not forwarded — see `map_usage`.
+                    context_window: None,
                     cost_usd: None,
                     ..
                 }]
             ),
-            "expected last-based occupancy + window, got {events:?}"
+            "expected last-based occupancy and no window, got {events:?}"
         );
     }
 
@@ -4898,7 +4919,7 @@ mod tests {
                     ..
                 }
             )),
-            "a tokenUsage without modelContextWindow yields no window (nullable in schema)"
+            "codex never reports a window: its only figure is an unusable stand-in"
         );
         assert!(
             events.iter().any(|e| matches!(

--- a/crates/aionui-session/src/backend/codex_conn.rs
+++ b/crates/aionui-session/src/backend/codex_conn.rs
@@ -2827,6 +2827,14 @@ fn map_usage(params: &Value) -> Vec<SessionEvent> {
         total_tokens: g("totalTokens"),
         cost_usd: None,
         context_window: usage.get("modelContextWindow").and_then(Value::as_u64),
+        // Per-turn detail line. codex reports every field natively on `last`
+        // (verified: TokenUsageBreakdown in the generated schema), including the
+        // reasoning tokens claude only exposes per-call.
+        breakdown: crate::event::UsageBreakdown {
+            cached_read_tokens: g("cachedInputTokens"),
+            cached_write_tokens: g("cacheWriteInputTokens"),
+            thought_tokens: g("reasoningOutputTokens"),
+        },
     }]
 }
 
@@ -2860,10 +2868,31 @@ mod usage_window_tests {
                     total_tokens: 11030,
                     context_window: Some(258_400),
                     cost_usd: None,
+                    ..
                 }]
             ),
             "expected last-based occupancy + window, got {events:?}"
         );
+    }
+
+    /// codex reports the whole detail line natively on `last`, including the
+    /// reasoning tokens claude only exposes per-call. Values from the live two-turn
+    /// probe (turn 2).
+    #[test]
+    fn breakdown_comes_straight_off_last() {
+        let params: Value = serde_json::from_str(
+            r#"{"tokenUsage":{"modelContextWindow":258400,
+                 "last":{"totalTokens":11030,"inputTokens":11024,"cachedInputTokens":11006,
+                         "cacheWriteInputTokens":16,"outputTokens":6,"reasoningOutputTokens":242}}}"#,
+        )
+        .unwrap();
+        let b = match map_usage(&params).into_iter().next() {
+            Some(SessionEvent::UsageDelta { breakdown, .. }) => breakdown,
+            other => panic!("expected UsageDelta, got {other:?}"),
+        };
+        assert_eq!(b.cached_read_tokens, 11_006);
+        assert_eq!(b.cached_write_tokens, 16);
+        assert_eq!(b.thought_tokens, 242, "reasoningOutputTokens is the thinking count");
     }
 
     /// `modelContextWindow` is `int|null` in the schema — a null (or absent) field

--- a/crates/aionui-session/src/backend/codex_conn.rs
+++ b/crates/aionui-session/src/backend/codex_conn.rs
@@ -2805,6 +2805,18 @@ fn item_kind_for(item_type: &str) -> crate::event::ItemKind {
 /// thread/tokenUsage/updated → UsageDelta. codex gives BOTH total (cumulative)
 /// and last (per-turn); we use `.last` directly (G6: native per-turn, no
 /// subtraction, no double-count on reconnect — measured 2026-06-10).
+///
+/// `.last` is also the right figure for the usage indicator's CURRENT CONTEXT
+/// OCCUPANCY, which is why it feeds `used`. Live two-turn probe (0.145.0,
+/// window 258400): turn 2 reported `last{inputTokens:11024, cachedInputTokens:
+/// 11006, outputTokens:6, totalTokens:11030}` while `total.totalTokens` had
+/// already reached 22043. `last.inputTokens` INCLUDES the cached part, so
+/// `last.totalTokens` == the request carrying the whole history + its reply —
+/// the occupancy. `total.*` accumulates across turns and would exceed the window
+/// on a long session; it must never feed `used`.
+///
+/// `modelContextWindow` is the indicator's denominator and is nullable in the
+/// schema (verified: `codex app-server generate-json-schema` → ThreadTokenUsage).
 fn map_usage(params: &Value) -> Vec<SessionEvent> {
     let usage = params.get("tokenUsage").unwrap_or(&Value::Null);
     let last = usage.get("last").unwrap_or(&Value::Null);
@@ -2814,7 +2826,68 @@ fn map_usage(params: &Value) -> Vec<SessionEvent> {
         output_tokens: g("outputTokens"),
         total_tokens: g("totalTokens"),
         cost_usd: None,
+        context_window: usage.get("modelContextWindow").and_then(Value::as_u64),
     }]
+}
+
+#[cfg(test)]
+mod usage_window_tests {
+    use super::*;
+
+    /// Verbatim `tokenUsage` from a live two-turn probe (codex-cli 0.145.0,
+    /// `gpt-5.6-sol`): turn 2, window 258400. `used` must stay on `last`
+    /// (11030 = the request carrying the whole history + its reply), NOT on the
+    /// cumulative `total` (22043) which would blow past the window on a long
+    /// session. The window itself becomes the indicator's denominator.
+    #[test]
+    fn live_token_usage_maps_last_as_occupancy_plus_window() {
+        let params: Value = serde_json::from_str(
+            r#"{"threadId":"th1","turnId":"t1","tokenUsage":{
+                 "modelContextWindow":258400,
+                 "last":{"totalTokens":11030,"inputTokens":11024,"cachedInputTokens":11006,
+                         "cacheWriteInputTokens":16,"outputTokens":6,"reasoningOutputTokens":0},
+                 "total":{"totalTokens":22043,"inputTokens":22032,"cachedInputTokens":11006,
+                          "cacheWriteInputTokens":11022,"outputTokens":11,"reasoningOutputTokens":0}}}"#,
+        )
+        .unwrap();
+        let events = map_usage(&params);
+        assert!(
+            matches!(
+                events.as_slice(),
+                [SessionEvent::UsageDelta {
+                    input_tokens: 11024,
+                    output_tokens: 6,
+                    total_tokens: 11030,
+                    context_window: Some(258_400),
+                    cost_usd: None,
+                }]
+            ),
+            "expected last-based occupancy + window, got {events:?}"
+        );
+    }
+
+    /// `modelContextWindow` is `int|null` in the schema — a null (or absent) field
+    /// must degrade to `None`, never to 0, which would render a 0-sized bar.
+    #[test]
+    fn null_or_absent_context_window_is_none() {
+        for raw in [
+            r#"{"tokenUsage":{"modelContextWindow":null,"last":{"totalTokens":5,"inputTokens":4,"outputTokens":1}}}"#,
+            r#"{"tokenUsage":{"last":{"totalTokens":5,"inputTokens":4,"outputTokens":1}}}"#,
+        ] {
+            let params: Value = serde_json::from_str(raw).unwrap();
+            assert!(
+                matches!(
+                    map_usage(&params).as_slice(),
+                    [SessionEvent::UsageDelta {
+                        context_window: None,
+                        total_tokens: 5,
+                        ..
+                    }]
+                ),
+                "expected no window for {raw}"
+            );
+        }
+    }
 }
 
 /// LC-8a: codex `turn/plan/updated` params → `SessionEvent::Plan`. `plan` is an
@@ -4787,6 +4860,16 @@ mod tests {
                 }
             )),
             "tokenUsage.last → UsageDelta (G6: native per-turn, no subtraction)"
+        );
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                SessionEvent::UsageDelta {
+                    context_window: None,
+                    ..
+                }
+            )),
+            "a tokenUsage without modelContextWindow yields no window (nullable in schema)"
         );
         assert!(
             events.iter().any(|e| matches!(

--- a/crates/aionui-session/src/event.rs
+++ b/crates/aionui-session/src/event.rs
@@ -275,6 +275,11 @@ pub enum SessionEvent {
         output_tokens: u64,
         total_tokens: u64,
         cost_usd: Option<f64>,
+        /// The model's total context window, when the backend reports one
+        /// (claude `result.modelUsage.<model>.contextWindow`; codex
+        /// `tokenUsage.modelContextWindow`, which is nullable). Renders as the
+        /// denominator of the usage indicator; `None` leaves it a bare counter.
+        context_window: Option<u64>,
     },
 
     /// MCP / tool provisioning as a LIVE event (Addendum 5 / U16). Reducer no-op.
@@ -1123,6 +1128,7 @@ mod additive_tests {
                     output_tokens: 1,
                     total_tokens: 2,
                     cost_usd: None,
+                    context_window: None,
                 },
                 BackendProduced,
                 Display,
@@ -1386,6 +1392,7 @@ mod additive_tests {
                 output_tokens: 50,
                 total_tokens: 150,
                 cost_usd: Some(0.0021),
+                context_window: None,
             },
             SessionEvent::Provisioning {
                 phase: ProvisioningPhase::ToolsWaiting,

--- a/crates/aionui-session/src/event.rs
+++ b/crates/aionui-session/src/event.rs
@@ -17,6 +17,33 @@
 /// `AdapterSpecific.payload` is an opaque escape hatch this contract does NOT
 /// promise total equality over; `assert_eq!` only needs `PartialEq`. Deriving
 /// fewer traits than available is always legal ⇒ the shape compiles as-is.
+/// Per-turn token counters for the usage indicator's detail line
+/// ("input · output · cache read · thinking"). Every field is a per-turn total,
+/// NOT a running context figure — `UsageDelta.total_tokens` carries occupancy.
+///
+/// Both direct backends report all of it (live-verified): claude via
+/// `result.usage` plus the `thinking_tokens` summed off each `message_delta`,
+/// codex via `tokenUsage.last`. Backends that report none leave it zeroed, and
+/// the renderer then omits the line entirely.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct UsageBreakdown {
+    /// Cache HITS — tokens read from an existing prefix cache.
+    pub cached_read_tokens: u64,
+    /// Cache WRITES — tokens newly committed to the cache this turn.
+    pub cached_write_tokens: u64,
+    /// Reasoning/thinking tokens, billed as output but rendered separately.
+    pub thought_tokens: u64,
+}
+
+impl UsageBreakdown {
+    /// Whether anything was reported. A fully zeroed breakdown is indistinguishable
+    /// from "this backend tells us nothing", so it is omitted rather than rendered
+    /// as a row of zeros.
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)] // +Serialize/Deserialize (Addendum 2a, 007 §C2). only PartialEq — see FIX 4a above
 pub enum SessionEvent {
     // ---- command lower (FIX 2): orchestration lowers Command::Send here ----
@@ -275,6 +302,10 @@ pub enum SessionEvent {
         output_tokens: u64,
         total_tokens: u64,
         cost_usd: Option<f64>,
+        /// Per-turn counters behind the indicator's detail line. Separate from
+        /// `total_tokens`, which is context OCCUPANCY: on claude the two even come
+        /// from different frames (the turn aggregate vs. the last API call).
+        breakdown: UsageBreakdown,
         /// The model's total context window, when the backend reports one
         /// (claude `result.modelUsage.<model>.contextWindow`; codex
         /// `tokenUsage.modelContextWindow`, which is nullable). Renders as the
@@ -1129,6 +1160,7 @@ mod additive_tests {
                     total_tokens: 2,
                     cost_usd: None,
                     context_window: None,
+                    breakdown: Default::default(),
                 },
                 BackendProduced,
                 Display,
@@ -1393,6 +1425,7 @@ mod additive_tests {
                 total_tokens: 150,
                 cost_usd: Some(0.0021),
                 context_window: None,
+                breakdown: Default::default(),
             },
             SessionEvent::Provisioning {
                 phase: ProvisioningPhase::ToolsWaiting,

--- a/crates/aionui-session/src/lib.rs
+++ b/crates/aionui-session/src/lib.rs
@@ -65,6 +65,7 @@ pub use capability::{
     SlashCommandInfo, block_kind_name,
 };
 pub use error::SessionError;
+pub use event::UsageBreakdown;
 pub use event::{
     CancelReason, CheckpointEntry, EventClass, ExitStatusLite, FinalizedMessage, ItemKind, NoticeLevel, Outcome,
     PermissionKind, PersistTier, PlanEntry, PlanPriority, PlanStatus, ProvisioningPhase, SessionEvent, StopReason,

--- a/crates/aionui-session/src/reducer.rs
+++ b/crates/aionui-session/src/reducer.rs
@@ -1032,6 +1032,7 @@ mod tests {
                 output_tokens: 1,
                 total_tokens: 2,
                 cost_usd: Some(0.5),
+                context_window: None,
             },
             // use the payload-carrying phase (stronger than the proptest's nullary ToolsReady)
             SessionEvent::Provisioning {
@@ -1179,6 +1180,7 @@ mod tests {
                 output_tokens: 1,
                 total_tokens: 2,
                 cost_usd: None,
+                context_window: None,
             },
             SessionEvent::Provisioning {
                 phase: ProvisioningPhase::ToolsWaiting,
@@ -2179,6 +2181,7 @@ mod proptest_totality {
                 output_tokens: 1,
                 total_tokens: 2,
                 cost_usd: None,
+                context_window: None,
             }),
             Just(SessionEvent::Provisioning {
                 phase: ProvisioningPhase::ToolsReady

--- a/crates/aionui-session/src/reducer.rs
+++ b/crates/aionui-session/src/reducer.rs
@@ -1033,6 +1033,7 @@ mod tests {
                 total_tokens: 2,
                 cost_usd: Some(0.5),
                 context_window: None,
+                breakdown: Default::default(),
             },
             // use the payload-carrying phase (stronger than the proptest's nullary ToolsReady)
             SessionEvent::Provisioning {
@@ -1181,6 +1182,7 @@ mod tests {
                 total_tokens: 2,
                 cost_usd: None,
                 context_window: None,
+                breakdown: Default::default(),
             },
             SessionEvent::Provisioning {
                 phase: ProvisioningPhase::ToolsWaiting,
@@ -2182,6 +2184,7 @@ mod proptest_totality {
                 total_tokens: 2,
                 cost_usd: None,
                 context_window: None,
+                breakdown: Default::default(),
             }),
             Just(SessionEvent::Provisioning {
                 phase: ProvisioningPhase::ToolsReady


### PR DESCRIPTION
Completes what PR #708 deliberately left out. That PR restored the conversation usage indicator for ACP-path agents and stated:

> **Not touched**: `claude_conn.rs` / `codex_conn.rs` / `cc_switch` (direct-connection iron rule)

So claude and codex kept three user-visible defects. This wires them onto the same contract the ACP path already speaks — `{used, size, cost:{amount, currency}}` — with **no frontend change required**.

## Defects and verified root causes

| # | Symptom | Root cause |
|---|---------|-----------|
| 1 | claude showed no usage at all | Its `UsageDelta` rides the `result` frame, which lands **after** the real-time turn end. Captured order on 2.1.220: `message_delta{stop_reason}` → `message_stop` → `result`, and the adapter maps that `message_delta` to the turn's `TurnResult`. `StreamRelay` breaks its loop on the resulting Finish (`stream_relay.rs:402`/`:447`), so the frame reached nobody. |
| 2 | No context-window size on either backend | `SessionEvent::UsageDelta` had no field for it; `session_agent.rs` documented "`size` is omitted". Both CLIs report one. |
| 3 | codex usage vanished on a conversation switch | `get_usage` was a hardcoded `Ok(None)` and nothing was ever persisted, so `GET /api/conversations/{id}/usage` had nothing to answer with. |

A stale `KNOWN DIVERGENCE` note in the pump had documented defect 1 as an accepted gap; it is updated to describe how it is now closed.

## Approach

Usage is treated as **session state, not turn-stream content**. The event pump is spawned once per session and outlives the per-turn relay, so it still sees claude's late report and both persists and broadcasts it — no end-of-turn barrier needed.

- **Persistence** merges into `acp_session.session_config.runtime.context_usage`, the same sink and shape the ACP path uses.
- **Read-back** goes through the repo, not an in-memory field. That is the point: the task is dropped when the session is reaped, so anything held only in memory would be gone exactly when the user switches back.
- **Merge, not replace**: `used` always takes the newer value; `size`/`cost` are overwritten only when the incoming report carries them. codex reports no cost at all and may report `modelContextWindow: null`, so a blind replace would blank a window the previous turn had established.

## Data sources (live-verified)

**codex** `tokenUsage.modelContextWindow` — nullable in the schema (verified: `codex app-server generate-json-schema` → `ThreadTokenUsage`, codex-cli 0.145.0), so null/absent stays `None` rather than becoming 0.

**claude** `result.modelUsage.<model>.contextWindow` — captured live on 2.1.220: `{"claude-opus-5":{…,"contextWindow":1000000}}`. The frame's own `model` field is `null`, so the entry cannot be picked by id: a single entry is used directly, several fall back to the dominant one by token volume. **That tie-break is a heuristic — only the single-entry shape has been captured.**

### `used` semantics were already correct

A risk was raised during design that `used` might be per-turn rather than context occupancy. Investigated and **dismissed**. A two-turn codex probe (window 258400):

| turn | `last.inputTokens` | `last.cachedInputTokens` | `last.totalTokens` | `total.totalTokens` |
|---|---|---|---|---|
| 1 | 11008 | 0 | 11013 | 11013 |
| 2 | 11024 | 11006 | 11030 | 22043 |

`last.inputTokens` already includes the cached part, so `last.totalTokens` is the request carrying the whole history plus its reply — the occupancy. The cumulative `total` outgrows the window on a long session and must never feed the indicator. claude reaches the same quantity differently: its `input_tokens` *excludes* the cache buckets, so occupancy is the sum of all four. Both are pinned by a regression test.

## Follow-up fix: `/compact` blanked the indicator

Reported after the first two commits were in use: running a compaction made usage show 0, then disappear entirely.

claude ends a no-op turn with an all-zero `usage` object — live-captured, a `/compact` turn returns `num_turns: 0` and all four token buckets at 0 while `total_cost_usd` stays put. The merge always overwrote `used`, so it wrote `used: 0` over a real figure.

The renderer explains why one write produced two symptoms (verified against `useAcpMessage.ts` and `ContextUsageIndicator.tsx`):
- the live `acp_context_usage` handler accepts any numeric `used`, so 0 renders as 0;
- the `GET /usage` hydration bails on `used <= 0`, leaving `tokenUsage` null, and the component returns `null` with no usage — the whole indicator disappears on the next load.

Zero is not merely stale but wrong: a compaction leaves the context **smaller**, never empty. Such reports are discarded, keeping the last true reading until the next real turn reports the post-compaction size. The check lives in one place, `informative_usage`, which both consumers ask — a report can never be broadcast without also being stored, or vice versa.

> ⚠️ The captured compaction was itself **rejected** (`system/status{compact_result:"failed"}`, "Not enough messages to compact"), so only the rejected path is proven to report zeros; a successful compaction may differ. The guard holds either way, since a zero-token turn carries no occupancy information. Neither the post-compaction `system/init` frame nor the `status` frames carry token counts, so the post-compaction figure necessarily arrives with the next real turn.

## Tests

- Window parsing per backend against the captured shapes: codex `modelContextWindow: null` → `None`; claude single-entry; claude multi-entry picks the dominant model; malformed → `None`
- Occupancy regression guard pinning `used` on both backends
- Usage delivered **after** Finish still persists — the events are genuinely ordered that way, not merely emitted
- The merge preserves a known window and cost across a sizeless/costless update
- `get_usage` serves a cold task from the snapshot alone, through real in-memory SQLite
- The broadcast envelope is pinned to what the renderer switches on (`type: "acp_context_usage"`, `data.used`, `data.size`) — a rename would otherwise silently blank the indicator rather than fail anything
- The compaction regression: a zero report must not overwrite a real figure

Every new assertion was confirmed to fail with the production change reverted, so none of them is vacuously green.

## Verification scope

Targeted runs: `aionui-session` lib (399 passed), `aionui-ai-agent` `persist_tests` (19) and `translate_tests` (21). `cargo clippy -p aionui-session -p aionui-ai-agent --all-targets -- -D warnings` is clean, as is `cargo fmt --all --check`.

**The full workspace gate was not run, at the maintainer's request**, so this was pushed with `git push`. The change spans two crates and the pump sits on the session path — CI should cover it.

## Out of scope

ACP-path behaviour (already shipped), `aionrs` usage (`get_usage` stays `Ok(None)`), and any frontend change.