### PR TITLE
fix(project/monitor): attribute watched-subdir events to parent so tree reflects dir delete/rename

### DIFF
--- a/crates/aionui-project/src/runtime/local_watcher.rs
+++ b/crates/aionui-project/src/runtime/local_watcher.rs
@@ -58,18 +58,31 @@ fn canonical_of(path: &Path) -> Option<String> {
     canonical::canonicalize(&uri).ok().map(|c| c.as_str().to_owned())
 }
 
-/// Attribute an event path to a watched directory's lexical canonical: the path
-/// itself (event on the directory) or its parent (event on a child), matched by
-/// reported canonical against the watched keys.
-fn resolve_owner(watched: &HashMap<String, WatchEntry>, path: &Path) -> Option<String> {
+/// Attribute an event path to the watched directories that must reconcile it,
+/// as lexical canonicals. A create/delete/rename of an entry changes the listing
+/// of its **parent** directory, so the parent (when watched) is always an owner.
+/// When the path is **itself** a watched directory (an event on the directory
+/// entry), that directory is an owner too. Both are returned so a removed/renamed
+/// watched subdir emits a change on its parent — not only on itself — which is
+/// what keeps the parent's listing from going stale. Matched by reported
+/// canonical against the watched keys; the returned order is self-then-parent.
+fn resolve_owner(watched: &HashMap<String, WatchEntry>, path: &Path) -> Vec<String> {
+    let mut owners = Vec::new();
+    // The path itself, when it is a watched directory.
     if let Some(c) = canonical_of(path)
         && let Some(entry) = watched.get(&c)
     {
-        return Some(entry.lexical.clone());
+        owners.push(entry.lexical.clone());
     }
-    let parent = path.parent()?;
-    let c = canonical_of(parent)?;
-    watched.get(&c).map(|entry| entry.lexical.clone())
+    // The path's parent — the directory whose listing contains this entry.
+    if let Some(parent) = path.parent()
+        && let Some(c) = canonical_of(parent)
+        && let Some(entry) = watched.get(&c)
+        && !owners.contains(&entry.lexical)
+    {
+        owners.push(entry.lexical.clone());
+    }
+    owners
 }
 
 impl LocalWatcher {

--- a/crates/aionui-project/src/runtime/local_watcher_test.rs
+++ b/crates/aionui-project/src/runtime/local_watcher_test.rs
@@ -52,6 +52,32 @@ async fn watch_emits_changed_on_child_create() {
     );
 }
 
+#[tokio::test]
+async fn removing_watched_subdir_emits_change_on_parent() {
+    // Regression (filetree-stale): with both a directory and its subdir watched
+    // (the subdir was expanded in the tree), deleting the subdir must surface as
+    // a change on the PARENT — that is what removes the stale subdir node from
+    // the parent's listing. Before the fix the event attributed only to the
+    // subdir itself, so the parent never learned it was gone.
+    let root = tempdir().unwrap();
+    let sub_path = root.path().join("a");
+    std::fs::create_dir(&sub_path).unwrap();
+
+    let (watcher, mut rx) = LocalWatcher::new().unwrap();
+    let root_c = canon(root.path());
+    let sub_c = canon(&sub_path);
+    watcher.watch(root_c.as_str()).unwrap();
+    watcher.watch(sub_c.as_str()).unwrap();
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    std::fs::remove_dir_all(&sub_path).unwrap();
+
+    assert!(
+        saw_change(&mut rx, root_c.as_str(), "a", Duration::from_secs(5)).await,
+        "parent root must observe a Changed mentioning the removed subdir `a`"
+    );
+}
+
 // ── Event-path attribution: the realpath double-key fold (pure, all platforms)
 //
 // FSEvents delivers realpath'd paths (macOS `/var` → `/private/var`); `watch`
@@ -88,8 +114,9 @@ fn resolve_owner_folds_realpath_alias_back_to_lexical() {
     watched.insert(lexical.as_str().to_owned(), entry.clone());
     watched.insert(alias.as_str().to_owned(), entry);
 
-    let want = Some(lexical.as_str().to_owned());
-    // Alias'd child path (as macOS FSEvents reports) attributes to the lexical id.
+    let want = vec![lexical.as_str().to_owned()];
+    // Alias'd child path (as macOS FSEvents reports) attributes to the lexical id
+    // via its parent (the child file itself is not a watched directory).
     assert_eq!(resolve_owner(&watched, &alias_dir.join("child.txt")), want);
     // Lexical child path (as Linux inotify reports) attributes to the same id.
     assert_eq!(resolve_owner(&watched, &lex_dir.join("child.txt")), want);
@@ -99,7 +126,39 @@ fn resolve_owner_folds_realpath_alias_back_to_lexical() {
     let unrelated = PathBuf::from(r"C:\other\x.txt");
     #[cfg(not(windows))]
     let unrelated = PathBuf::from("/other/x.txt");
-    assert_eq!(resolve_owner(&watched, &unrelated), None);
+    assert_eq!(resolve_owner(&watched, &unrelated), Vec::<String>::new());
+}
+
+#[test]
+fn resolve_owner_attributes_watched_subdir_to_both_self_and_parent() {
+    // The stale-tree fix: when a watched subdirectory's own path is the event
+    // path (delete/rename of the subdir), it must attribute to BOTH the subdir
+    // (self) AND its watched parent — the parent is the directory whose listing
+    // must drop the removed entry. Old behavior returned self only (exact-match
+    // precedence), so the parent never reconciled and the tree went stale.
+    let (parent_dir, _) = alias_dirs();
+    let sub_dir = parent_dir.join("a");
+    let parent = canon(&parent_dir);
+    let sub = canon(&sub_dir);
+
+    let parent_entry = WatchEntry {
+        lexical: parent.as_str().to_owned(),
+        notify_path: parent_dir.clone(),
+    };
+    let sub_entry = WatchEntry {
+        lexical: sub.as_str().to_owned(),
+        notify_path: sub_dir.clone(),
+    };
+    let mut watched: HashMap<String, WatchEntry> = HashMap::new();
+    watched.insert(parent.as_str().to_owned(), parent_entry);
+    watched.insert(sub.as_str().to_owned(), sub_entry);
+
+    // Self first, then parent — a removed watched subdir reconciles both.
+    assert_eq!(
+        resolve_owner(&watched, &sub_dir),
+        vec![sub.as_str().to_owned(), parent.as_str().to_owned()],
+        "a watched subdir's own path must attribute to self AND its watched parent"
+    );
 }
 
 #[test]
@@ -124,13 +183,13 @@ fn resolve_owner_case_folding_is_platform_relative() {
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     assert_eq!(
         resolve_owner(&watched, &child),
-        Some(lexical.as_str().to_owned()),
+        vec![lexical.as_str().to_owned()],
         "case-insensitive platform folds the cased path back to the watched id"
     );
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     assert_eq!(
         resolve_owner(&watched, &child),
-        None,
+        Vec::<String>::new(),
         "case-sensitive platform treats the cased path as a different directory"
     );
 }

--- a/crates/aionui-project/src/runtime/tree_model_test.rs
+++ b/crates/aionui-project/src/runtime/tree_model_test.rs
@@ -94,6 +94,66 @@ async fn apply_child_names_stats_only_named_children() {
 }
 
 #[tokio::test]
+async fn apply_child_names_removes_deleted_subdir() {
+    // The parent-reconcile half of the filetree-stale fix: once the watcher
+    // attributes a subdir deletion to the PARENT (see local_watcher_test), the
+    // parent applies `ChildNames([sub])` and must emit `Removed{sub}` so the
+    // stale subdir node drops out of the listing.
+    let (mut tree, dir) = real_tree();
+    std::fs::create_dir(dir.path().join("a")).unwrap();
+    std::fs::write(dir.path().join("keep.txt"), b"x").unwrap();
+    let c = canon(dir.path());
+    tree.mount(c.as_str()).await.unwrap();
+
+    std::fs::remove_dir_all(dir.path().join("a")).unwrap();
+
+    let delta = tree
+        .apply(c.as_str(), Hint::ChildNames(vec!["a".to_owned()]))
+        .await
+        .unwrap()
+        .expect("changes");
+    assert_eq!(delta.changes, vec![Change::Removed { name: "a".to_owned() }]);
+}
+
+#[tokio::test]
+async fn apply_child_names_renamed_subdir_surfaces_on_parent() {
+    // Renaming an expanded subdir a→a2: the watcher attributes events on both
+    // paths to the parent, which applies `ChildNames([a, a2])`. A real rename
+    // preserves the inode, so the parent's diff coalesces removed+added into a
+    // single `Renamed{a→a2}` (the frontend applies it in place) — the parent's
+    // listing is reconciled either way, never left showing a stale `a`.
+    let (mut tree, dir) = real_tree();
+    std::fs::create_dir(dir.path().join("a")).unwrap();
+    let c = canon(dir.path());
+    tree.mount(c.as_str()).await.unwrap();
+
+    std::fs::rename(dir.path().join("a"), dir.path().join("a2")).unwrap();
+
+    let delta = tree
+        .apply(c.as_str(), Hint::ChildNames(vec!["a".to_owned(), "a2".to_owned()]))
+        .await
+        .unwrap()
+        .expect("changes");
+    // Real-FS inode is preserved across rename → synthesized Renamed. On any
+    // platform that reports inode 0 (e.g. Windows) this degrades to
+    // Removed{a}+Added{a2}; both leave the parent listing correct, so assert the
+    // stale `a` is gone rather than pinning one representation.
+    let has_stale_a = delta.changes.iter().any(|ch| {
+        matches!(ch, Change::Added { name, .. } if name == "a") || matches!(ch, Change::Renamed { to, .. } if to == "a")
+    });
+    let drops_a = delta.changes.iter().any(|ch| {
+        matches!(ch, Change::Removed { name } if name == "a")
+            || matches!(ch, Change::Renamed { from, .. } if from == "a")
+    });
+    assert!(drops_a, "parent must drop the old `a` entry, got {:?}", delta.changes);
+    assert!(
+        !has_stale_a,
+        "parent must not keep a stale `a`, got {:?}",
+        delta.changes
+    );
+}
+
+#[tokio::test]
 async fn apply_is_idempotent_when_nothing_changed() {
     let (mut tree, dir) = real_tree();
     std::fs::write(dir.path().join("a.txt"), b"x").unwrap();

--- a/crates/aionui-project/src/runtime/watcher.rs
+++ b/crates/aionui-project/src/runtime/watcher.rs
@@ -41,23 +41,27 @@ pub trait Watcher: Send + Sync {
 }
 
 /// Translate one `notify` event into zero or more [`RawEvent`]s, attributing
-/// each affected path to a watched canonical via `resolve`.
+/// each affected path to the watched canonical(s) via `resolve`.
 ///
-/// `resolve(path)` returns the watched canonical that owns `path` (an OS event
-/// path is a child of a watched directory, or the directory itself), or `None`
-/// if no watched directory owns it. Pure and deterministic — the concurrency-
-/// free core of event mapping, unit-tested without a real filesystem.
-pub fn map_event(event: &notify::Event, resolve: &dyn Fn(&Path) -> Option<String>) -> Vec<RawEvent> {
+/// `resolve(path)` returns every watched canonical that owns `path`. A path can
+/// have more than one owner: the directory whose *listing* contains it (its
+/// parent) and — when the path is itself a watched directory — that directory
+/// too. Both must reconcile, so a create/delete/rename of a watched subdir emits
+/// a change on its parent (fixing stale listings) as well as on itself. Returns
+/// an empty vec when no watched directory owns the path. Pure and deterministic
+/// — the concurrency-free core of event mapping, unit-tested without a real
+/// filesystem.
+pub fn map_event(event: &notify::Event, resolve: &dyn Fn(&Path) -> Vec<String>) -> Vec<RawEvent> {
     // Kernel dropped events (inotify IN_Q_OVERFLOW / RDCW buffer / FSEvents
     // must-rescan): the node's facts are stale → one Overflow per affected
     // canonical, deduped and order-stable.
     if event.need_rescan() {
         let mut seen: Vec<String> = Vec::new();
         for path in &event.paths {
-            if let Some(c) = resolve(path)
-                && !seen.contains(&c)
-            {
-                seen.push(c);
+            for c in resolve(path) {
+                if !seen.contains(&c) {
+                    seen.push(c);
+                }
             }
         }
         return seen
@@ -66,15 +70,17 @@ pub fn map_event(event: &notify::Event, resolve: &dyn Fn(&Path) -> Option<String
             .collect();
     }
 
-    // Group changed paths under their owning canonical, preserving first-seen
-    // canonical order and per-canonical path order.
+    // Group changed paths under each owning canonical, preserving first-seen
+    // canonical order and per-canonical path order. A path owned by both its
+    // parent and itself is added to both groups.
     let mut groups: Vec<(String, Vec<String>)> = Vec::new();
     for path in &event.paths {
-        let Some(canonical) = resolve(path) else { continue };
         let path_str = path.to_string_lossy().into_owned();
-        match groups.iter_mut().find(|(c, _)| *c == canonical) {
-            Some((_, paths)) => paths.push(path_str),
-            None => groups.push((canonical, vec![path_str])),
+        for canonical in resolve(path) {
+            match groups.iter_mut().find(|(c, _)| *c == canonical) {
+                Some((_, paths)) => paths.push(path_str.clone()),
+                None => groups.push((canonical, vec![path_str.clone()])),
+            }
         }
     }
     groups

--- a/crates/aionui-project/src/runtime/watcher_test.rs
+++ b/crates/aionui-project/src/runtime/watcher_test.rs
@@ -5,12 +5,12 @@ use notify::{Event, EventKind};
 
 use super::{RawEvent, map_event};
 
-/// Resolve any path under `/root` to the fixed canonical, everything else None.
-fn resolve_root(p: &Path) -> Option<String> {
+/// Resolve any path under `/root` to the fixed canonical, everything else empty.
+fn resolve_root(p: &Path) -> Vec<String> {
     if p.starts_with("/root") {
-        Some("file:///root".to_owned())
+        vec!["file:///root".to_owned()]
     } else {
-        None
+        vec![]
     }
 }
 
@@ -48,14 +48,14 @@ fn map_event_drops_unresolved_paths() {
     );
 }
 
-/// Resolve `/root` and `/lib` to distinct canonicals, everything else None.
-fn resolve_two(p: &Path) -> Option<String> {
+/// Resolve `/root` and `/lib` to distinct canonicals, everything else empty.
+fn resolve_two(p: &Path) -> Vec<String> {
     if p.starts_with("/root") {
-        Some("file:///root".to_owned())
+        vec!["file:///root".to_owned()]
     } else if p.starts_with("/lib") {
-        Some("file:///lib".to_owned())
+        vec!["file:///lib".to_owned()]
     } else {
-        None
+        vec![]
     }
 }
 
@@ -107,6 +107,47 @@ fn map_event_rescan_dedups_overflow_per_canonical() {
                 canonical: "file:///lib".to_owned()
             },
         ]
+    );
+}
+
+/// Resolve a watched subdir path to BOTH the subdir itself and its parent root
+/// (the self-then-parent shape `resolve_owner` returns for a watched subdir);
+/// any other path under `/root` resolves to root only.
+fn resolve_self_and_parent(p: &Path) -> Vec<String> {
+    if p == Path::new("/root/a") {
+        vec!["file:///root/a".to_owned(), "file:///root".to_owned()]
+    } else if p.starts_with("/root") {
+        vec!["file:///root".to_owned()]
+    } else {
+        vec![]
+    }
+}
+
+#[test]
+fn map_event_fans_watched_subdir_to_both_self_and_parent() {
+    // Deleting a watched subdir `a`: the event path is `/root/a`, which is both a
+    // watched directory (self) and a child of watched root (parent). map_event
+    // must emit a Changed for the PARENT root mentioning `a` — that is the change
+    // that reconciles root's listing and removes the stale `a`. Reverting
+    // resolve to self-only (the old exact-match precedence) drops the root group
+    // and this assertion fails — the regression tripwire.
+    let event = Event::new(EventKind::Remove(notify::event::RemoveKind::Folder)).add_path(PathBuf::from("/root/a"));
+
+    let out = map_event(&event, &resolve_self_and_parent);
+
+    assert_eq!(
+        out,
+        vec![
+            RawEvent::Changed {
+                canonical: "file:///root/a".to_owned(),
+                paths: vec!["/root/a".to_owned()],
+            },
+            RawEvent::Changed {
+                canonical: "file:///root".to_owned(),
+                paths: vec!["/root/a".to_owned()],
+            },
+        ],
+        "a watched subdir's event must reconcile its parent, not only itself"
     );
 }
 


### PR DESCRIPTION
## Background

User-reported bug (self-tested, not Sentry).

**Symptom:** In the Project Explorer, after expanding a nested dir `a → b → c`, running `rm -rf ./a` on disk leaves the file tree still showing the (now gone) `a/b/c` nodes. Disk is correct; only the UI is stale. Collapsing/re-expanding root or restarting the app works around it.

## Root cause

`runtime::local_watcher::resolve_owner` attributed each filesystem event path to a **single** owner, preferring the exact-match branch (the path is itself a watched directory) over the parent branch. When an **expanded** (therefore watched) subdirectory `a` is deleted/renamed, the `notify` event path equals `a`'s own watched canonical, so the event was attributed to `a` itself — **never to its parent (root)**. The parent's node therefore never reconciled, no `Removed{a}` delta was emitted on root, and the parent kept the stale child. The same shadowing recurred at every watched level, so the whole subtree stayed. (Only leaf **file** deletions propagated, because a file is not a watched key → parent attribution worked — matching the observed "the file inside `c` disappears but `a/b/c` nodes remain".)

The frontend (`explorerModel.applyDelta` + lazy projection from root) is correct and needs no change: once the backend emits `Removed{a}` on root, the subtree drops.

## Fix (approach A)

`resolve_owner` now returns **every** watched owner of an event path — the directory itself (when watched) **and** its watched parent — and `map_event` fans the path to all its owners. A create/delete/rename of a watched subdir now also reconciles the parent. `apply` is idempotent (re-reads the fs), so the extra parent apply has no side effects and produces the missing `Removed{a}` (delete) / `Added` (create).

Rename is fixed as a side effect: a real-inode rename `a→a2` coalesces in the tree diff to a single `Renamed{a→a2}` (frontend renames in place); on inode-0 platforms (Windows) it degrades to `Removed+Added`. Either way the parent listing is reconciled — never left with a stale `a`.

## Evidence

- **Tripwires (3 core + 2 tree_model):**
  - `local_watcher_test::resolve_owner_attributes_watched_subdir_to_both_self_and_parent` (pure, all platforms)
  - `local_watcher_test::removing_watched_subdir_emits_change_on_parent` — **real `notify`/FSEvents on a real tempdir** (the exact failing OS-event path)
  - `watcher_test::map_event_fans_watched_subdir_to_both_self_and_parent`
  - `tree_model_test::apply_child_names_removes_deleted_subdir` and `..._renamed_subdir_surfaces_on_parent`
- **Mutation-checked:** reverting `resolve_owner` to self-only makes both resolve_owner tripwires fail.
- **Gate:** `cargo test -p aionui-project` → 186 passed; full pre-push gate → 7968 passed, 0 failed; clippy `-D warnings` and fmt clean.

## Scope

Backend only (`aionui-project` monitor runtime). No frontend change. No protocol/wire-shape change.