### PR TITLE
chore(acp): bump dirac, grok, nova and pi registry pins to probed versions

### DIFF
--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -870,7 +870,7 @@ mod tests {
         )
         .await
         .expect("resolved release-pinned builtin command spec");
-        assert_eq!(spec.args, vec!["-y", "pi-acp@0.0.32"]);
+        assert_eq!(spec.args, vec!["-y", "pi-acp@0.0.33"]);
     }
 
     #[cfg(unix)]

--- a/crates/aionui-ai-agent/src/services/availability/mod.rs
+++ b/crates/aionui-ai-agent/src/services/availability/mod.rs
@@ -620,7 +620,7 @@ mod tests {
         pi.agent_source_info.binary_name = Some("pi".into());
         pi.agent_source_info.bridge_binary = Some("npx".into());
         pi.args = vec!["-y".into(), "pi-acp".into()];
-        assert_eq!(explicit_probe_args(&pi).unwrap(), ["-y", "pi-acp@0.0.32"]);
+        assert_eq!(explicit_probe_args(&pi).unwrap(), ["-y", "pi-acp@0.0.33"]);
     }
 
     // ---- #675: manual health check runs --version for direct CLIs and is

--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -24,7 +24,7 @@
     "dirac": {
       "registry_json_id": "dirac",
       "package": "dirac-cli",
-      "version": "0.4.29"
+      "version": "0.4.31"
     },
     "glm-acp-agent": {
       "registry_json_id": "glm-acp-agent",
@@ -34,7 +34,7 @@
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "0.2.116"
+      "version": "0.2.117"
     },
     "kilo": {
       "registry_json_id": "kilo",
@@ -48,7 +48,7 @@
     "nova": {
       "registry_json_id": "nova",
       "package": "@compass-ai/nova",
-      "version": "1.1.29"
+      "version": "1.1.30"
     },
     "omp": {
       "package": "@oh-my-pi/pi-coding-agent",
@@ -57,7 +57,7 @@
     "pi": {
       "registry_json_id": "pi-acp",
       "package": "pi-acp",
-      "version": "0.0.32"
+      "version": "0.0.33"
     },
     "sigit": {
       "registry_json_id": "sigit",

--- a/crates/aionui-runtime/src/registry_npx_lock.rs
+++ b/crates/aionui-runtime/src/registry_npx_lock.rs
@@ -105,7 +105,7 @@ mod tests {
     #[test]
     fn pins_direct_npx_package() {
         let args = pin_registry_npx_args("pi", &strings(&["-y", "pi-acp"])).unwrap();
-        assert_eq!(args, ["-y", "pi-acp@0.0.32"]);
+        assert_eq!(args, ["-y", "pi-acp@0.0.33"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Four npx pins drifted since #728; each bump is backed by a fresh serial ACP probe of the exact pinned version. Lock-only change plus the three lock-derived test assertions that embed pi's version — no metadata, migration or entrypoint edits.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| dirac | `dirac-cli` | 0.4.29 → **0.4.31** | ok (agentInfo dirac 0.4.31) | success (modes plan/act) |
| grok | `@xai-official/grok` | 0.2.116 → **0.2.117** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |
| nova | `@compass-ai/nova` | 1.1.29 → **1.1.30** | ok (protocolVersion 1) | config required (`-32000`, "Click Nova Setup to configure your API keys", advertising a `kore-terminal-auth` terminal method) |
| pi | `pi-acp` | 0.0.32 → **0.0.33** | ok (agentInfo pi-acp "pi ACP adapter" 0.0.33) | auth required (`-32000`, advertising `pi_terminal_login`) |

All four meet the release-lock criterion: `initialize` succeeds and `session/new` either succeeds or returns a clearly classified authentication/configuration requirement. Probes ran serially (cold npx downloads contend and produce false timeouts when parallelised), with no inherited HOME or credentials.

The other 7 Registry-pinned packages (autohand, codebuddy, deepagents, dimcode, glm-acp-agent, kilo, sigit) match the snapshot exactly — no drift. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. The `mimo-code` and `omp` entries are non-Registry builtins (no `registry_json_id`) and are correctly excluded from drift reconciliation.

**Observation, not a blocker:** nova 1.1.30 self-reports `agentInfo.name = "kore-cli"`, `version = "1.0.0"` — neither matches the product name nor the package version. The Registry/public-page identity (Nova by Compass AI) and the package are unchanged, and `initialize` succeeded, so the pin is still evidenced; recorded here in case the vendor's identity fields matter to a later audit.

## Registry snapshot

- Audit pinned to release tag [`v2026.07.31-19e2d4c`](https://cdn.agentclientprotocol.com/registry/v1/v2026.07.31-19e2d4c/registry.json) of `agentclientprotocol/registry` (newest release at audit time), fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the previous baseline (38 ids).

## Validation

- `cargo test -p aionui-runtime -p aionui-ai-agent` — pass
- Full `just push` gate (migration check, lint, fmt, `cargo nextest run --workspace`) — pass
- Gate run with the host-injected `AIONUI_LOG_DIR` unset (pre-existing environment sensitivity, see #695)
- Updated the three lock-derived assertions that pin pi's version (`registry_npx_lock.rs`, `factory/acp.rs`, `services/availability/mod.rs`). `npx_cache_repair.rs` keeps its `pi-acp@0.0.31` fixture literal: it exercises cache-path construction, not the release lock.

## Logging

No logging changes: lock-only version bumps; existing startup/session error paths already identify a failing agent by backend.