### PR TITLE
chore(acp): bump grok registry pin to probed 0.2.118

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -34,7 +34,7 @@
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "0.2.117"
+      "version": "0.2.118"
     },
     "kilo": {
       "registry_json_id": "kilo",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. One npx pin drifted since #739, backed by a fresh ACP probe of the exact pinned version. Lock-only change — a single line; no metadata, migration, or entrypoint edits, and no lock-derived assertion embeds grok's version.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| grok | `@xai-official/grok` | 0.2.117 → **0.2.118** | ok (protocolVersion 1; loadSession true, promptCapabilities embeddedContext, mcpCapabilities http+sse, authMethods `grok.com`) | auth required (`-32000`, "no auth method id provided") |

This meets the release-lock criterion: `initialize` succeeds and `session/new` returns a clearly classified authentication requirement. The probe ran with no inherited HOME or credentials.

The other 10 Registry-pinned packages (autohand, codebuddy, deepagents, dimcode, dirac, glm-acp-agent, kilo, nova, pi, sigit) match the snapshot exactly — no drift. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. The `mimo-code` and `omp` entries are non-Registry builtins (no `registry_json_id`) and are correctly excluded from drift reconciliation.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.01-7c0b8bb`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.01-7c0b8bb/registry.json) of `agentclientprotocol/registry` (newest release at audit time), fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the previous baseline (38 ids).

## Validation

- `cargo test -p aionui-runtime -p aionui-ai-agent` — pass (831 lib + integration tests)
- Full `just push` gate (migration check, lint, fmt, `cargo nextest run --workspace`) — pass
- Gate run with the host-injected `AIONUI_LOG_DIR` unset (pre-existing environment sensitivity, see #695)
- `npx_cache_repair.rs` keeps its `@xai-official/grok@0.2.102` fixture literals: they exercise cache-path construction, not the release lock.

Note on validation history: an earlier gate run on this same commit failed while compiling `aionui-app`. That was a false failure — the host disk hit 0 bytes free mid-run. After reclaiming space the identical tree compiled clean and the full gate passed; no source change was needed.

## Logging

No logging changes: lock-only version bump; existing startup/session error paths already identify a failing agent by backend.