### PR TITLE
chore(acp): bump dirac and nova registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -24,7 +24,7 @@
     "dirac": {
       "registry_json_id": "dirac",
       "package": "dirac-cli",
-      "version": "0.4.31"
+      "version": "0.4.32"
     },
     "glm-acp-agent": {
       "registry_json_id": "glm-acp-agent",
@@ -48,7 +48,7 @@
     "nova": {
       "registry_json_id": "nova",
       "package": "@compass-ai/nova",
-      "version": "1.1.30"
+      "version": "1.1.31"
     },
     "omp": {
       "package": "@oh-my-pi/pi-coding-agent",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Two npx pins drifted since #749, each backed by a fresh serial ACP probe of the exact pinned version. Lock-only change — two lines; no metadata, migration, or entrypoint edits, and no lock-derived test assertion embeds either version.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| dirac | `dirac-cli` | 0.4.31 → **0.4.32** | ok (agentInfo dirac 0.4.32) | success (modes plan/act) |
| nova | `@compass-ai/nova` | 1.1.30 → **1.1.31** | ok (protocolVersion 1) | config required (`-32000`, "Click Nova Setup to configure your API keys", advertising a `kore-terminal-auth` terminal method) |

Both meet the release-lock criterion: `initialize` succeeds and `session/new` either succeeds or returns a clearly classified authentication/configuration requirement. Probes ran serially with no inherited HOME or credentials.

The other 9 Registry-pinned packages (autohand, codebuddy, deepagents, dimcode, glm-acp-agent, grok, kilo, pi, sigit) match the snapshot exactly — no drift. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. The `mimo-code` and `omp` entries are non-Registry builtins (no `registry_json_id`) and are correctly excluded from drift reconciliation.

Carried forward from #739: nova still self-reports `agentInfo.name = "kore-cli"`, `version = "1.0.0"`, matching neither the product name nor the package version. Unchanged behaviour, not a blocker — the Registry/public-page identity and package are stable and `initialize` succeeded.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.02-27d86f5`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.02-27d86f5/registry.json) of `agentclientprotocol/registry` (newest release at audit time), fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the previous baseline (38 ids).

## Validation

- `cargo test -p aionui-runtime -p aionui-ai-agent` — pass (831 lib + integration tests)
- Full `just push` gate (migration check, lint, fmt, `cargo nextest run --workspace`) — pass
- Gate run with the host-injected `AIONUI_LOG_DIR` unset (pre-existing environment sensitivity, see #695)

Note on validation history: four earlier gate attempts on this same commit failed, each on a different subprocess-spawning test (`aionui-mcp` PATH resolution, `aionui-extension` lifecycle hooks ×2, `aionui-app` websocket e2e) and each landing exactly on that test's own timeout (30s / 120s / 26.8s). Those were host-contention artifacts, not defects: macOS `syspolicyd`, `XProtect` and `StorageManagement` held the 12-core host near load average 300 for over an hour, stalling every `exec()`, and the same tests pass isolated in 0.44s and 1.9s. The gate passed unchanged once load fell to ~5; no source change was needed.

## Logging

No logging changes: lock-only version bumps; existing startup/session error paths already identify a failing agent by backend.