### PR TITLE
fix(file-watch): degrade gracefully when watcher init fails instead of killing backend

### DIFF
--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -473,7 +473,9 @@ pub fn build_file_state(services: &AppServices) -> Result<FileRouterState, Route
     let allowed_roots = default_allowed_roots(Some(services.work_dir.as_path()));
     let browse_roots = BrowseRoots::new();
     let file_service = Arc::new(FileService::new(broadcaster.clone(), allowed_roots.clone()));
-    let watch_service = Arc::new(FileWatchService::new(broadcaster).map_err(file_watch_init_error)?);
+    // Non-fatal: watcher creation failure (e.g. inotify limit) yields a disabled
+    // watch service, never a bootstrap abort. See ELECTRON-2PM.
+    let watch_service = Arc::new(FileWatchService::new(broadcaster));
     let snapshot_service = Arc::new(SnapshotService::new());
     Ok(FileRouterState {
         file_service,
@@ -483,10 +485,6 @@ pub fn build_file_state(services: &AppServices) -> Result<FileRouterState, Route
         allowed_roots,
         browse_roots,
     })
-}
-
-fn file_watch_init_error(error: aionui_file::FileError) -> RouterBuildError {
-    RouterBuildError::new("router.file_watch", "failed to initialize file watch service").with_source(error)
 }
 
 /// Build the project control-plane router state from application services.
@@ -1363,12 +1361,10 @@ mod tests {
         services.database.close().await;
     }
 
-    #[test]
-    fn file_watch_init_error_maps_to_bootstrap_server_failed() {
-        let err = file_watch_init_error(aionui_file::FileError::Internal("watch backend unavailable".into()));
-
-        assert_eq!(err.stage(), "router.file_watch");
-        assert_eq!(err.message(), "failed to initialize file watch service");
-        assert!(!err.to_string().contains("watch backend unavailable"));
-    }
+    // NOTE (ELECTRON-2PM): the former `file_watch_init_error_maps_to_bootstrap_server_failed`
+    // test was removed intentionally. File-watch init is no longer a fatal
+    // bootstrap stage — `FileWatchService::new` is infallible and degrades to a
+    // disabled state, so there is no error-to-BOOTSTRAP_SERVER_FAILED mapping to
+    // assert here. Disabled-state behavior is covered in `aionui-file`
+    // (watch_service disabled-path tests + the `FILE_WATCH_UNAVAILABLE` mapping).
 }

--- a/crates/aionui-file/src/error.rs
+++ b/crates/aionui-file/src/error.rs
@@ -19,4 +19,12 @@ pub enum FileError {
 
     #[error("{0}")]
     Internal(String),
+
+    /// The file-watch backend is unavailable (the platform watcher could not be
+    /// created, e.g. the inotify instance/watch limit was reached). Non-fatal:
+    /// the server runs without file watching. `errno` carries the originating OS
+    /// error when known, for telemetry attribution. Maps to the stable API code
+    /// `FILE_WATCH_UNAVAILABLE`.
+    #[error("file watch service is unavailable")]
+    WatchUnavailable { errno: Option<i32> },
 }

--- a/crates/aionui-file/src/routes.rs
+++ b/crates/aionui-file/src/routes.rs
@@ -44,6 +44,12 @@ impl From<FileError> for ApiError {
             },
             FileError::NotFound(message) => ApiError::NotFound(message),
             FileError::Internal(message) => ApiError::Internal(message),
+            FileError::WatchUnavailable { errno } => ApiError::coded(
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                "FILE_WATCH_UNAVAILABLE",
+                "File watching is unavailable on this system.",
+                errno.map(|n| serde_json::json!({ "errno": n })),
+            ),
         }
     }
 }
@@ -805,6 +811,24 @@ mod tests {
         assert_eq!(api_err.error_code(), "PATH_OUTSIDE_SANDBOX");
         assert_eq!(api_err.error_details().unwrap()["field"], "path");
         assert_eq!(api_err.error_details().unwrap()["operation"], "access");
+    }
+
+    #[test]
+    fn watch_unavailable_maps_to_stable_code_with_errno_details() {
+        // The A contract: the frontend recognizes this exact code to render an
+        // accurate "file watching unavailable" notice (never a reinstall prompt).
+        let api_err = ApiError::from(FileError::WatchUnavailable { errno: Some(24) });
+        assert_eq!(api_err.error_code(), "FILE_WATCH_UNAVAILABLE");
+        assert_eq!(api_err.status_code(), axum::http::StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(api_err.error_details().unwrap()["errno"], 24);
+    }
+
+    #[test]
+    fn watch_unavailable_without_errno_omits_details() {
+        let api_err = ApiError::from(FileError::WatchUnavailable { errno: None });
+        assert_eq!(api_err.error_code(), "FILE_WATCH_UNAVAILABLE");
+        assert_eq!(api_err.status_code(), axum::http::StatusCode::SERVICE_UNAVAILABLE);
+        assert!(api_err.error_details().is_none());
     }
 
     #[test]

--- a/crates/aionui-file/src/watch_service.rs
+++ b/crates/aionui-file/src/watch_service.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
-use tracing::warn;
+use tracing::{error, warn};
 
 use crate::error::FileError;
 use aionui_api_types::WebSocketMessage;
@@ -71,8 +71,16 @@ fn should_emit(debounce: &DashMap<String, Instant>, key: &str) -> bool {
 ///   creation events.
 pub struct FileWatchService {
     broadcaster: Arc<dyn EventBroadcaster>,
-    /// Shared watcher for all single-file watches.
-    file_watcher: Mutex<RecommendedWatcher>,
+    /// Shared watcher for all single-file watches. `None` means the platform
+    /// watcher could not be created (e.g. inotify instance/watch limit reached
+    /// on Linux) — the service runs in a *disabled* state: the backend stays up
+    /// and every watch operation returns [`FileError::WatchUnavailable`] instead
+    /// of failing bootstrap.
+    file_watcher: Option<Mutex<RecommendedWatcher>>,
+    /// OS errno captured when watcher creation failed (`None` when enabled, or
+    /// when the failure carried no OS error). Surfaced in the unavailable error
+    /// so clients/telemetry can distinguish the real cause (EMFILE/ENFILE/…).
+    watch_init_errno: Option<i32>,
     /// Canonical watched paths and the users subscribed to each path.
     watched_files: Arc<DashMap<String, BTreeSet<String>>>,
     /// Per-workspace Office watchers, keyed by canonical workspace path.
@@ -84,8 +92,11 @@ pub struct FileWatchService {
 }
 
 impl FileWatchService {
-    /// Create a new watch service backed by the platform's recommended watcher.
-    pub fn new(broadcaster: Arc<dyn EventBroadcaster>) -> Result<Self, FileError> {
+    /// Create a new watch service. Never fails: if the platform watcher cannot
+    /// be created (e.g. inotify limit reached), the service is constructed in a
+    /// *disabled* state — the backend keeps running and watch operations return
+    /// [`FileError::WatchUnavailable`] rather than aborting bootstrap.
+    pub fn new(broadcaster: Arc<dyn EventBroadcaster>) -> Self {
         let watched_files: Arc<DashMap<String, BTreeSet<String>>> = Arc::new(DashMap::new());
         let office_watch_users: Arc<DashMap<String, BTreeSet<String>>> = Arc::new(DashMap::new());
         let debounce: Arc<DashMap<String, Instant>> = Arc::new(DashMap::new());
@@ -94,7 +105,7 @@ impl FileWatchService {
         let wf = watched_files.clone();
         let db = debounce.clone();
 
-        let file_watcher = notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| {
+        let watcher_result = notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| {
             let event = match res {
                 Ok(e) => e,
                 Err(e) => {
@@ -126,17 +137,65 @@ impl FileWatchService {
                     bc.broadcast(WebSocketMessage::new("fileWatch.fileChanged", json));
                 }
             }
-        })
-        .map_err(|e| FileError::Internal(format!("failed to create file watcher: {e}")))?;
+        });
 
-        Ok(Self {
+        Self::from_watcher_result(broadcaster, watched_files, office_watch_users, debounce, watcher_result)
+    }
+
+    /// Assemble the service from an already-attempted watcher creation. On `Ok`
+    /// the service is enabled; on `Err` it logs the failure (with the OS errno
+    /// when available) and constructs the disabled state. Split out from [`new`]
+    /// so the disabled path is unit-testable via an injected failure.
+    fn from_watcher_result(
+        broadcaster: Arc<dyn EventBroadcaster>,
+        watched_files: Arc<DashMap<String, BTreeSet<String>>>,
+        office_watch_users: Arc<DashMap<String, BTreeSet<String>>>,
+        debounce: Arc<DashMap<String, Instant>>,
+        watcher_result: Result<RecommendedWatcher, notify::Error>,
+    ) -> Self {
+        let (file_watcher, watch_init_errno) = match watcher_result {
+            Ok(watcher) => (Some(Mutex::new(watcher)), None),
+            Err(err) => {
+                let errno = watcher_init_errno(&err);
+                // Contract violation for the file-watch feature (it cannot run),
+                // but intentionally non-fatal to the server → error level with the
+                // OS errno so telemetry can attribute the true cause (EMFILE/ENFILE/
+                // ENOSPC) instead of a generic bootstrap failure.
+                error!(
+                    error = %err,
+                    errno = ?errno,
+                    "file watcher creation failed; file watch DISABLED (single-file and office watch unavailable, server continues)"
+                );
+                (None, errno)
+            }
+        };
+
+        Self {
             broadcaster,
-            file_watcher: Mutex::new(file_watcher),
+            file_watcher,
+            watch_init_errno,
             watched_files,
             office_watchers: Mutex::new(HashMap::new()),
             office_watch_users,
             debounce,
-        })
+        }
+    }
+
+    /// The error returned by every watch operation while the service is disabled.
+    fn unavailable(&self) -> FileError {
+        FileError::WatchUnavailable {
+            errno: self.watch_init_errno,
+        }
+    }
+}
+
+/// Extract the OS errno from a watcher-creation failure, when it carries one.
+/// Only `notify::ErrorKind::Io` surfaces a raw OS error (the inotify_init /
+/// instance-limit failures we care about); other kinds have no errno.
+fn watcher_init_errno(err: &notify::Error) -> Option<i32> {
+    match &err.kind {
+        notify::ErrorKind::Io(io) => io.raw_os_error(),
+        _ => None,
     }
 }
 
@@ -147,6 +206,11 @@ impl crate::traits::IFileWatchService for FileWatchService {
     }
 
     async fn start_watch_for_user(&self, user_id: &str, file_path: &str) -> Result<(), FileError> {
+        // Disabled state (watcher creation failed): fail fast with the stable
+        // unavailable error before any filesystem work, so the client gets a
+        // clear signal rather than a masked NotFound.
+        let file_watcher = self.file_watcher.as_ref().ok_or_else(|| self.unavailable())?;
+
         let canonical = std::fs::canonicalize(file_path)
             .map_err(|e| FileError::NotFound(format!("cannot resolve path {file_path}: {e}")))?;
         let key = canonical.to_string_lossy().into_owned();
@@ -156,8 +220,7 @@ impl crate::traits::IFileWatchService for FileWatchService {
             return Ok(());
         }
 
-        let mut watcher = self
-            .file_watcher
+        let mut watcher = file_watcher
             .lock()
             .map_err(|e| FileError::Internal(format!("file watcher lock poisoned: {e}")))?;
         watcher
@@ -184,12 +247,14 @@ impl crate::traits::IFileWatchService for FileWatchService {
 
         if should_unwatch {
             self.watched_files.remove(&key);
-            let mut watcher = self
-                .file_watcher
-                .lock()
-                .map_err(|e| FileError::Internal(format!("file watcher lock poisoned: {e}")))?;
-            // Ignore unwatch errors because the file may have been deleted.
-            let _ = watcher.unwatch(&canonical);
+            // Disabled state has no watcher and no live watches — stop is a no-op.
+            if let Some(file_watcher) = self.file_watcher.as_ref() {
+                let mut watcher = file_watcher
+                    .lock()
+                    .map_err(|e| FileError::Internal(format!("file watcher lock poisoned: {e}")))?;
+                // Ignore unwatch errors because the file may have been deleted.
+                let _ = watcher.unwatch(&canonical);
+            }
             self.debounce.remove(&key);
         }
 
@@ -197,8 +262,11 @@ impl crate::traits::IFileWatchService for FileWatchService {
     }
 
     async fn stop_all_watches(&self) -> Result<(), FileError> {
-        let mut watcher = self
-            .file_watcher
+        // Disabled state: nothing was ever watched — cleanup is a no-op.
+        let Some(file_watcher) = self.file_watcher.as_ref() else {
+            return Ok(());
+        };
+        let mut watcher = file_watcher
             .lock()
             .map_err(|e| FileError::Internal(format!("file watcher lock poisoned: {e}")))?;
 
@@ -225,6 +293,13 @@ impl crate::traits::IFileWatchService for FileWatchService {
     }
 
     async fn start_office_watch_for_user(&self, user_id: &str, workspace: &str) -> Result<(), FileError> {
+        // Office watches allocate their own platform watcher; if the shared one
+        // could not be created (inotify limit), a new one won't either. Refuse
+        // with the same stable unavailable signal rather than trying and failing.
+        if self.file_watcher.is_none() {
+            return Err(self.unavailable());
+        }
+
         let canonical = std::fs::canonicalize(workspace)
             .map_err(|e| FileError::NotFound(format!("cannot resolve workspace {workspace}: {e}")))?;
         let key = canonical.to_string_lossy().into_owned();
@@ -349,6 +424,7 @@ impl crate::traits::IFileWatchService for FileWatchService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::traits::IFileWatchService;
     use notify::event::{AccessKind, CreateKind, ModifyKind, RemoveKind};
     use std::path::PathBuf;
 
@@ -475,5 +551,79 @@ mod tests {
     #[test]
     fn empty_path() {
         assert!(!is_office_file(&PathBuf::new()));
+    }
+
+    // -- disabled state (watcher creation failed → non-fatal) ---------------
+
+    /// No-op broadcaster for constructing a service in tests.
+    struct NoopBroadcaster;
+    impl aionui_realtime::EventBroadcaster for NoopBroadcaster {
+        fn broadcast(&self, _event: WebSocketMessage<serde_json::Value>) {}
+    }
+
+    /// Build a service whose watcher creation was forced to fail with the given
+    /// OS errno — the fault-injection seam for the disabled path.
+    fn disabled_service(errno: i32) -> FileWatchService {
+        let err = notify::Error::new(notify::ErrorKind::Io(std::io::Error::from_raw_os_error(errno)));
+        FileWatchService::from_watcher_result(
+            Arc::new(NoopBroadcaster),
+            Arc::new(DashMap::new()),
+            Arc::new(DashMap::new()),
+            Arc::new(DashMap::new()),
+            Err(err),
+        )
+    }
+
+    #[test]
+    fn disabled_service_captures_errno_and_has_no_watcher() {
+        let svc = disabled_service(24); // EMFILE
+        assert!(svc.file_watcher.is_none(), "disabled service holds no watcher");
+        assert_eq!(svc.watch_init_errno, Some(24), "OS errno is captured for diagnostics");
+    }
+
+    #[tokio::test]
+    async fn disabled_start_watch_returns_unavailable_with_errno() {
+        let svc = disabled_service(24);
+        let err = svc
+            .start_watch_for_user("u", "/anything")
+            .await
+            .expect_err("disabled watch must not succeed");
+        assert!(
+            matches!(err, FileError::WatchUnavailable { errno: Some(24) }),
+            "expected WatchUnavailable{{errno:24}}, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_start_office_watch_returns_unavailable_with_errno() {
+        let svc = disabled_service(23); // ENFILE
+        let err = svc
+            .start_office_watch_for_user("u", "/anything")
+            .await
+            .expect_err("disabled office watch must not succeed");
+        assert!(
+            matches!(err, FileError::WatchUnavailable { errno: Some(23) }),
+            "expected WatchUnavailable{{errno:23}}, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_stop_paths_are_noops_not_errors() {
+        // Teardown on a disabled service must never error (frontend cleanup path).
+        let svc = disabled_service(24);
+        svc.stop_watch_for_user("u", "/anything").await.unwrap();
+        svc.stop_all_watches().await.unwrap();
+        svc.stop_all_watches_for_user("u").await.unwrap();
+        svc.stop_all_office_watches_for_user("u").await.unwrap();
+    }
+
+    #[test]
+    fn new_is_infallible_and_enabled_on_supported_platform() {
+        // `new` returns `Self` (never a fatal Result): on a normal test host the
+        // platform watcher is created, so the service is enabled. This is the
+        // structural guarantee that bootstrap can no longer die on watcher init.
+        let svc = FileWatchService::new(Arc::new(NoopBroadcaster));
+        assert!(svc.file_watcher.is_some());
+        assert_eq!(svc.watch_init_errno, None);
     }
 }

--- a/crates/aionui-file/tests/file_watching.rs
+++ b/crates/aionui-file/tests/file_watching.rs
@@ -41,7 +41,7 @@ impl EventBroadcaster for RecordingBroadcaster {
 
 fn make_service() -> (Arc<dyn IFileWatchService>, Arc<RecordingBroadcaster>) {
     let recorder = Arc::new(RecordingBroadcaster::new());
-    let svc = FileWatchService::new(recorder.clone()).unwrap();
+    let svc = FileWatchService::new(recorder.clone());
     (Arc::new(svc), recorder)
 }
 

--- a/crates/aionui-office/src/routes.rs
+++ b/crates/aionui-office/src/routes.rs
@@ -252,6 +252,14 @@ fn file_error_to_api_error(error: FileError) -> ApiError {
         },
         FileError::NotFound(message) => ApiError::NotFound(message),
         FileError::Internal(message) => ApiError::Internal(message),
+        // Not reachable from office path-validation, but the mapping must be
+        // total; mirror the file crate's stable unavailable contract.
+        FileError::WatchUnavailable { errno } => ApiError::coded(
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "FILE_WATCH_UNAVAILABLE",
+            "File watching is unavailable on this system.",
+            errno.map(|n| serde_json::json!({ "errno": n })),
+        ),
     }
 }
 


### PR DESCRIPTION
Fixes **ELECTRON-2PM** (185 users / 6 weeks).

## Symptom

On some hosts (notably ARM Linux with the inotify **instance** limit
exhausted), the backend exited at startup with a fatal
`BOOTSTRAP_SERVER_FAILED`. The desktop app then mis-flagged this as a broken
install and prompted the user to reinstall.

## Root cause

`FileWatchService::new` eagerly created the platform watcher
(`notify::recommended_watcher`, i.e. `inotify_init` on Linux) and propagated
any failure with `?`. In `build_file_state` that error was mapped to the fatal
`router.file_watch` bootstrap stage → `BOOTSTRAP_SERVER_FAILED` → the whole
backend went down, even though file watching is a non-critical feature.

## Fix

- **Non-fatal disabled state (①):** `FileWatchService::new` is now infallible
  (`-> Self`). If the platform watcher can't be created it constructs a
  *disabled* service (`file_watcher = None`) and the backend keeps running.
  `build_file_state` no longer gates bootstrap on watcher init. Core file APIs
  are unaffected.
- **Preserve errno + diagnostics (②):** the OS errno from notify's io error
  (EMFILE / ENFILE / ENOSPC / …) is captured and logged at `error` level with a
  `file watch DISABLED` marker, so telemetry can attribute the real cause
  instead of a generic bootstrap failure.
- **Frontend contract (A):** while disabled, `POST /api/fs/watch/start` and
  `POST /api/fs/office-watch/start` return a stable **`503` code
  `FILE_WATCH_UNAVAILABLE`** (errno in `details`) rather than panicking or a
  generic 500; stop paths are no-ops. The frontend consumes this code to show an
  accurate "file watching unavailable" notice instead of a reinstall prompt.
- Watcher assembly split into `from_watcher_result()` as a fault-injection seam
  for unit tests; the obsolete fatal-mapping test was removed.

No changes to `aionui-common`; the stable code reuses the existing
`ApiError::Coded` path. Watcher consolidation (fewer inotify instances) is
tracked separately as a follow-up.

## Evidence

- `cargo test -p aionui-app -p aionui-office -p aionui-file` → **679 passed, 0 failed**, incl. 7 new tests:
  disabled-state behavior, errno capture, the `FILE_WATCH_UNAVAILABLE` mapping (503 + errno details), and infallible `new`.
- Fault injection via an injected watcher-creation error (no need to exhaust real inotify).
- Mutation-checked: forcing the disabled branch fatal makes the disabled-state tests fail.
- Full pre-push gate green: **8001 tests passed**; clippy `-D warnings` and fmt clean.

## Scope

Backend only (`aionui-file`, `aionui-office`, `aionui-app`). Frontend consumes the `FILE_WATCH_UNAVAILABLE` code separately.