### PR TITLE
feat(fs): add /api/fs/reveal endpoint (resolve pe-ref + show in folder)

### DIFF
--- a/crates/aionui-api-types/src/file.rs
+++ b/crates/aionui-api-types/src/file.rs
@@ -75,6 +75,17 @@ pub struct CopyFilesRequest {
     pub source_root: Option<String>,
 }
 
+/// Request body for `POST /api/fs/reveal` — reveal a pe-addressed file/dir in
+/// the OS file manager ("open enclosing folder"). The backend resolves the
+/// identity to an absolute path via `resolve_reference`, then hands it to the
+/// shell reveal capability.
+#[derive(Debug, Deserialize)]
+pub struct RevealItemRequest {
+    pub pe_id: String,
+    /// Relative path under the pe's folder root (`""` = the root itself).
+    pub relative_path: String,
+}
+
 /// Request body for `POST /api/fs/remove` — remove file or directory.
 #[derive(Debug, Deserialize)]
 pub struct RemoveEntryRequest {

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -109,9 +109,9 @@ pub use file::{
     CopyFilesResponse, CopyTarget, CreateTempFileRequest, DirOrFileResponse, FetchRemoteImageRequest,
     FileChangeInfoResponse, FileMetadataResponse, FileWatchRequest, GetFileMetadataRequest, GetFilesByDirRequest,
     GetImageBase64Request, ListWorkspaceFilesRequest, ReadFileBufferRequest, ReadFileRequest, RemoveEntryRequest,
-    RenameRequest, RenameResponse, SnapshotBaselineRequest, SnapshotCompareResponse, SnapshotDiscardRequest,
-    SnapshotInfoResponse, SnapshotMode, SnapshotStageRequest, SnapshotWorkspaceRequest, WorkspaceFlatFileResponse,
-    WorkspaceOfficeWatchRequest, WriteFileRequest, ZipFileEntry, ZipRequest,
+    RenameRequest, RenameResponse, RevealItemRequest, SnapshotBaselineRequest, SnapshotCompareResponse,
+    SnapshotDiscardRequest, SnapshotInfoResponse, SnapshotMode, SnapshotStageRequest, SnapshotWorkspaceRequest,
+    WorkspaceFlatFileResponse, WorkspaceOfficeWatchRequest, WriteFileRequest, ZipFileEntry, ZipRequest,
 };
 pub use lifecycle::{GitHubReleaseAsset, SystemInfoResponse, UpdateCheckRequest, UpdateCheckResult, UpdateReleaseInfo};
 pub use mcp::{

--- a/crates/aionui-app/src/router/item_revealer.rs
+++ b/crates/aionui-app/src/router/item_revealer.rs
@@ -1,0 +1,40 @@
+//! Composition adapter: implements the file crate's [`IItemRevealer`] port over
+//! the shell service's `show_item_in_folder` capability. Lives here (not in
+//! `aionui-file`) so the file domain crate needs no dependency on the shell
+//! crate — the two domains are wired together only at the composition layer.
+
+use std::sync::Arc;
+
+use aionui_file::{FileError, IItemRevealer};
+use aionui_shell::{ShellError, ShellService};
+
+/// Reveals an absolute path in the OS file manager by delegating to the shell
+/// service, mapping shell errors onto the file crate's error taxonomy.
+pub struct ShellItemRevealer {
+    shell: Arc<ShellService>,
+}
+
+impl ShellItemRevealer {
+    pub fn new(shell: Arc<ShellService>) -> Self {
+        Self { shell }
+    }
+}
+
+#[async_trait::async_trait]
+impl IItemRevealer for ShellItemRevealer {
+    async fn reveal(&self, absolute_path: &str) -> Result<(), FileError> {
+        self.shell
+            .show_item_in_folder(absolute_path)
+            .await
+            .map_err(|err| match err {
+                // The target path is gone → NotFound, so the client distinguishes
+                // "item no longer exists" from "couldn't open the file manager".
+                ShellError::FileNotFound(path) | ShellError::DirectoryNotFound(path) => FileError::NotFound(path),
+                other => FileError::RevealFailed(other.to_string()),
+            })
+    }
+}
+
+#[cfg(test)]
+#[path = "item_revealer_test.rs"]
+mod item_revealer_test;

--- a/crates/aionui-app/src/router/item_revealer_test.rs
+++ b/crates/aionui-app/src/router/item_revealer_test.rs
@@ -1,0 +1,35 @@
+use std::sync::Arc;
+
+use aionui_file::{FileError, IItemRevealer};
+use aionui_shell::{NoopSystemOpener, ShellService};
+
+use super::ShellItemRevealer;
+
+fn revealer() -> ShellItemRevealer {
+    ShellItemRevealer::new(Arc::new(ShellService::new(Arc::new(NoopSystemOpener))))
+}
+
+#[tokio::test]
+async fn reveal_existing_path_succeeds() {
+    // The noop opener does not actually launch a file manager, so a real,
+    // existing path passes validation and the reveal resolves Ok.
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("doc.txt");
+    std::fs::write(&file, "x").unwrap();
+
+    let result = revealer().reveal(file.to_str().unwrap()).await;
+    assert!(
+        result.is_ok(),
+        "reveal of an existing path should succeed, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn reveal_missing_path_maps_to_not_found() {
+    // A missing target must surface as NotFound (item is gone), not RevealFailed.
+    let result = revealer().reveal("/nonexistent/path/xyz-12345").await;
+    assert!(
+        matches!(result, Err(FileError::NotFound(_))),
+        "missing path should map to NotFound, got {result:?}"
+    );
+}

--- a/crates/aionui-app/src/router/mod.rs
+++ b/crates/aionui-app/src/router/mod.rs
@@ -2,6 +2,7 @@
 
 mod fs_monitor;
 mod health;
+mod item_revealer;
 mod routes;
 mod runtime_team_tools;
 mod state;

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -477,11 +477,18 @@ pub fn build_file_state(services: &AppServices) -> Result<FileRouterState, Route
     // watch service, never a bootstrap abort. See ELECTRON-2PM.
     let watch_service = Arc::new(FileWatchService::new(broadcaster));
     let snapshot_service = Arc::new(SnapshotService::new());
+    // Reveal-in-file-manager for `/api/fs/reveal`: an adapter over the shell
+    // service, injected as the file crate's revealer port (keeps aionui-file
+    // free of a shell dependency).
+    let revealer: aionui_file::ItemRevealerRef = Arc::new(super::item_revealer::ShellItemRevealer::new(Arc::new(
+        aionui_shell::ShellService::new(Arc::new(aionui_shell::DefaultSystemOpener)),
+    )));
     Ok(FileRouterState {
         file_service,
         watch_service,
         snapshot_service,
         project: Arc::new(services.project_service.clone()),
+        revealer,
         allowed_roots,
         browse_roots,
     })

--- a/crates/aionui-file/src/error.rs
+++ b/crates/aionui-file/src/error.rs
@@ -27,4 +27,11 @@ pub enum FileError {
     /// `FILE_WATCH_UNAVAILABLE`.
     #[error("file watch service is unavailable")]
     WatchUnavailable { errno: Option<i32> },
+
+    /// Revealing an item in the OS file manager failed (the shell reveal command
+    /// errored). Distinct from `NotFound` (missing path) so the frontend can tell
+    /// "couldn't open the file manager" from "the item is gone". Maps to the
+    /// stable API code `REVEAL_FAILED`.
+    #[error("failed to reveal item: {0}")]
+    RevealFailed(String),
 }

--- a/crates/aionui-file/src/lib.rs
+++ b/crates/aionui-file/src/lib.rs
@@ -17,7 +17,8 @@ pub use routes::{BrowseRoots, FileRouterState, file_routes};
 pub use service::FileService;
 pub use snapshot_service::SnapshotService;
 pub use traits::{
-    FileServiceRef, FileWatchServiceRef, IFileService, IFileWatchService, ISnapshotService, SnapshotServiceRef,
+    FileServiceRef, FileWatchServiceRef, IFileService, IFileWatchService, IItemRevealer, ISnapshotService,
+    ItemRevealerRef, SnapshotServiceRef,
 };
 pub use types::{
     CompareResult, ContentUpdateEvent, ContentUpdateOperation, CopyResult, DirOrFile, FileChangeInfo, FileMetadata,

--- a/crates/aionui-file/src/routes.rs
+++ b/crates/aionui-file/src/routes.rs
@@ -12,9 +12,10 @@ use aionui_api_types::{
     ApiResponse, BrowseDirectoryQuery, BrowseDirectoryResponse, CancelZipRequest, CopyFilesRequest, CopyFilesResponse,
     CreateTempFileRequest, DirOrFileResponse, FetchRemoteImageRequest, FileChangeInfoResponse, FileMetadataResponse,
     FileWatchRequest, GetFileMetadataRequest, GetFilesByDirRequest, GetImageBase64Request, ListWorkspaceFilesRequest,
-    ReadFileBufferRequest, ReadFileRequest, RemoveEntryRequest, RenameRequest, RenameResponse, SnapshotBaselineRequest,
-    SnapshotCompareResponse, SnapshotDiscardRequest, SnapshotInfoResponse, SnapshotStageRequest,
-    SnapshotWorkspaceRequest, WorkspaceFlatFileResponse, WorkspaceOfficeWatchRequest, WriteFileRequest, ZipRequest,
+    ReadFileBufferRequest, ReadFileRequest, RemoveEntryRequest, RenameRequest, RenameResponse, RevealItemRequest,
+    SnapshotBaselineRequest, SnapshotCompareResponse, SnapshotDiscardRequest, SnapshotInfoResponse,
+    SnapshotStageRequest, SnapshotWorkspaceRequest, WorkspaceFlatFileResponse, WorkspaceOfficeWatchRequest,
+    WriteFileRequest, ZipRequest,
 };
 use aionui_auth::CurrentUser;
 use aionui_common::ApiError;
@@ -22,7 +23,7 @@ use aionui_common::constants::UPLOAD_MAX_SIZE;
 
 use crate::browse;
 use crate::error::FileError;
-use crate::traits::{FileServiceRef, FileWatchServiceRef, SnapshotServiceRef};
+use crate::traits::{FileServiceRef, FileWatchServiceRef, ItemRevealerRef, SnapshotServiceRef};
 use crate::types::{
     CompareResult, CopyResult, DirOrFile, FileChangeInfo, FileMetadata, SnapshotInfo, SnapshotMode, WorkspaceFlatFile,
     ZipEntry,
@@ -49,6 +50,12 @@ impl From<FileError> for ApiError {
                 "FILE_WATCH_UNAVAILABLE",
                 "File watching is unavailable on this system.",
                 errno.map(|n| serde_json::json!({ "errno": n })),
+            ),
+            FileError::RevealFailed(message) => ApiError::coded(
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "REVEAL_FAILED",
+                message,
+                None::<serde_json::Value>,
             ),
         }
     }
@@ -100,8 +107,12 @@ pub struct FileRouterState {
     pub file_service: FileServiceRef,
     pub watch_service: FileWatchServiceRef,
     pub snapshot_service: SnapshotServiceRef,
-    /// Resolves pe-addressed copy targets (`/api/fs/copy`) to absolute dirs.
+    /// Resolves pe-addressed copy/reveal targets (`/api/fs/copy`,
+    /// `/api/fs/reveal`) to absolute paths.
     pub project: Arc<aionui_project::ProjectService>,
+    /// Reveals a resolved absolute path in the OS file manager
+    /// (`/api/fs/reveal`). Injected by composition over the shell service.
+    pub revealer: ItemRevealerRef,
     pub allowed_roots: Vec<std::path::PathBuf>,
     /// Roots permitted by the shallow `/api/fs/browse` endpoint. This is
     /// typically wider than `allowed_roots` (it includes `cwd`, Windows
@@ -139,6 +150,7 @@ pub fn file_routes(state: FileRouterState) -> Router {
         .route("/api/fs/read-buffer", post(read_file_buffer))
         .route("/api/fs/write", post(write_file))
         .route("/api/fs/copy", post(copy_files))
+        .route("/api/fs/reveal", post(reveal_item))
         .route("/api/fs/remove", post(remove_entry))
         .route("/api/fs/rename", post(rename_entry))
         .route("/api/fs/temp", post(create_temp_file))
@@ -311,6 +323,43 @@ async fn copy_files(
         .copy_files_to_workspace(&req.file_paths, &dir, req.source_root.as_deref())
         .await?;
     Ok(Json(ApiResponse::ok(to_copy_response(result))))
+}
+
+/// `POST /api/fs/reveal` — reveal a pe-addressed file/dir in the OS file manager
+/// ("open enclosing folder"). Resolves the identity to an absolute path
+/// (containment-checked, op = Read) then hands it to the reveal capability.
+async fn reveal_item(
+    State(state): State<FileRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    body: Result<Json<RevealItemRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<()>>, ApiError> {
+    let Json(req) = body.map_err(ApiError::from)?;
+    let resolved = state
+        .project
+        .resolve_reference(
+            &user.id,
+            aionui_project::ReferenceInput {
+                pe_id: req.pe_id,
+                relative_path: req.relative_path,
+                op: aionui_project::FileOp::Read,
+            },
+        )
+        .await
+        .map_err(ApiError::from)?;
+    reveal_resolved(state.revealer.as_ref(), resolved.absolute_path).await?;
+    Ok(Json(ApiResponse::success()))
+}
+
+/// Reveal the resolved absolute path via the revealer port. Split from the
+/// handler so the resolve → reveal wiring (and its no-local-path / reveal-failed
+/// error mapping) is unit-testable with a mock revealer, independent of the
+/// project service (`resolve_reference` is covered in `aionui-project`).
+async fn reveal_resolved(
+    revealer: &dyn crate::traits::IItemRevealer,
+    absolute_path: Option<String>,
+) -> Result<(), FileError> {
+    let abs = absolute_path.ok_or_else(|| FileError::BadRequest("reveal target is not a local path".to_owned()))?;
+    revealer.reveal(&abs).await
 }
 
 async fn remove_entry(
@@ -829,6 +878,75 @@ mod tests {
         assert_eq!(api_err.error_code(), "FILE_WATCH_UNAVAILABLE");
         assert_eq!(api_err.status_code(), axum::http::StatusCode::SERVICE_UNAVAILABLE);
         assert!(api_err.error_details().is_none());
+    }
+
+    #[test]
+    fn reveal_failed_maps_to_stable_code() {
+        // Contract for the frontend: distinct from NOT_FOUND so it can tell
+        // "couldn't open the file manager" from "item gone".
+        let api_err = ApiError::from(FileError::RevealFailed("gdbus not available".into()));
+        assert_eq!(api_err.error_code(), "REVEAL_FAILED");
+        assert_eq!(api_err.status_code(), axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    // -- reveal_resolved: resolve → reveal wiring (mock revealer seam) ---------
+
+    /// Records the absolute paths handed to `reveal`, and optionally fails.
+    struct MockRevealer {
+        calls: std::sync::Mutex<Vec<String>>,
+        fail: bool,
+    }
+    impl MockRevealer {
+        fn new(fail: bool) -> Self {
+            Self {
+                calls: std::sync::Mutex::new(Vec::new()),
+                fail,
+            }
+        }
+    }
+    #[async_trait::async_trait]
+    impl crate::traits::IItemRevealer for MockRevealer {
+        async fn reveal(&self, absolute_path: &str) -> Result<(), FileError> {
+            self.calls.lock().unwrap().push(absolute_path.to_owned());
+            if self.fail {
+                Err(FileError::RevealFailed("mock reveal failed".to_owned()))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn reveal_resolved_passes_absolute_path_to_revealer() {
+        let mock = MockRevealer::new(false);
+        let result = reveal_resolved(&mock, Some("/abs/target.txt".to_owned())).await;
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+        assert_eq!(
+            *mock.calls.lock().unwrap(),
+            vec!["/abs/target.txt".to_owned()],
+            "revealer must receive the resolved absolute path"
+        );
+    }
+
+    #[tokio::test]
+    async fn reveal_resolved_without_local_path_is_bad_request_and_skips_reveal() {
+        let mock = MockRevealer::new(false);
+        let result = reveal_resolved(&mock, None).await;
+        assert!(
+            matches!(result, Err(FileError::BadRequest(_))),
+            "non-local target must be BadRequest, got {result:?}"
+        );
+        assert!(mock.calls.lock().unwrap().is_empty(), "revealer must not be called");
+    }
+
+    #[tokio::test]
+    async fn reveal_resolved_propagates_reveal_failure() {
+        let mock = MockRevealer::new(true);
+        let result = reveal_resolved(&mock, Some("/abs/x".to_owned())).await;
+        assert!(
+            matches!(result, Err(FileError::RevealFailed(_))),
+            "reveal failure must propagate, got {result:?}"
+        );
     }
 
     #[test]

--- a/crates/aionui-file/src/traits.rs
+++ b/crates/aionui-file/src/traits.rs
@@ -287,3 +287,17 @@ pub type FileWatchServiceRef = Arc<dyn IFileWatchService>;
 
 /// Convenience alias for an Arc-wrapped snapshot service.
 pub type SnapshotServiceRef = Arc<dyn ISnapshotService>;
+
+/// Reveal an absolute filesystem path in the OS file manager (a "show item in
+/// folder" / "open enclosing folder" capability). Defined here as the narrow
+/// port the `/api/fs/reveal` route depends on; the composition layer supplies an
+/// adapter over the shell service, so this crate needs no shell dependency.
+#[async_trait::async_trait]
+pub trait IItemRevealer: Send + Sync {
+    /// Reveal `absolute_path` in the OS file manager. The path is the resolved,
+    /// contained absolute path from `resolve_reference` — never client input.
+    async fn reveal(&self, absolute_path: &str) -> Result<(), FileError>;
+}
+
+/// Convenience alias for an Arc-wrapped item revealer.
+pub type ItemRevealerRef = Arc<dyn IItemRevealer>;

--- a/crates/aionui-office/src/routes.rs
+++ b/crates/aionui-office/src/routes.rs
@@ -260,6 +260,13 @@ fn file_error_to_api_error(error: FileError) -> ApiError {
             "File watching is unavailable on this system.",
             errno.map(|n| serde_json::json!({ "errno": n })),
         ),
+        // Not reachable from office path-validation; the mapping must be total.
+        FileError::RevealFailed(message) => ApiError::coded(
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            "REVEAL_FAILED",
+            message,
+            None::<serde_json::Value>,
+        ),
     }
 }
 


### PR DESCRIPTION
Backs the Project Explorer **"open enclosing folder"** action by wiring two
existing capabilities: pe-reference resolution + the shell reveal command.

## Endpoint

`POST /api/fs/reveal` — body `{ "pe_id": string, "relative_path": string }`.

- Resolves the identity to a contained absolute path via `resolve_reference`
  (op = `Read`), then reveals it in the OS file manager
  (`ShellService::show_item_in_folder`).
- **Success:** `200` `ApiResponse::success()`, consistent with sibling
  `/api/fs/*` endpoints (frontend keys on 2xx).
- **Errors (explicit codes, never panics):**
  - `REVEAL_FAILED` (500) — the shell reveal command itself failed; distinct
    from `NOT_FOUND` so the client can tell "couldn't open the file manager"
    from "item is gone".
  - `NOT_FOUND` (404) — target path missing / resolve not found.
  - `BAD_REQUEST` (400) — target is not a local path (no absolute path).
  - Containment/identity failures surface via the existing `ProjectError` →
    `ApiError` mapping (`RESOURCE_OUTSIDE_FOLDER` / `OUT_OF_SCOPE` /
    `INVALID_RELATIVE_PATH`).

## Layering

Shell coupling stays out of the file domain crate: `aionui-file` defines a
narrow `IItemRevealer` port; `aionui-app` supplies a `ShellItemRevealer`
adapter over `ShellService`, mapping `ShellError` → `FileError`. The reveal
orchestration is split into `reveal_resolved()` so the resolve→reveal wiring
and error mapping are unit-testable with a mock revealer, independent of the
project service.

## Tests

- **aionui-file (4):** `reveal_resolved` passes the resolved absolute path to
  the revealer; no-local-path → `BadRequest` and skips reveal; reveal failure
  propagates; `REVEAL_FAILED` code/status mapping.
- **aionui-app (2):** adapter reveals an existing path (Ok); maps a missing
  path to `NotFound`.
- Full pre-push gate green: **8007 tests passed**; clippy `-D warnings` and fmt clean.

## Scope

Backend only (`aionui-api-types`, `aionui-file`, `aionui-office`, `aionui-app`).
Frontend consumes `POST /api/fs/reveal` separately (confirmed 200-compatible).