### PR TITLE
fix(db): widen migration-030 pre-repair gate to any pre-030 start point

### DIFF
--- a/crates/aionui-db/src/migrate_repair.rs
+++ b/crates/aionui-db/src/migrate_repair.rs
@@ -28,9 +28,25 @@ pub(crate) struct GuardViolation {
     pub count: i64,
 }
 
-/// True iff migrations 001–029 are all applied and 030 is the next pending
-/// migration (`max applied version == 29`). Returns false when the
-/// `_sqlx_migrations` table does not exist (fresh install) — spec §7 H1.
+/// True iff the database has a migration history (`_sqlx_migrations` exists) and
+/// migration 030 has NOT yet succeeded — i.e. 030 is still pending, so the raw
+/// data must be normalized before the migrator runs it.
+///
+/// Returns false for:
+/// - **fresh installs** (no `_sqlx_migrations` table): the migrator builds the
+///   schema from empty and applies 001–030 on data-free tables, so there is
+///   nothing to repair. At this point in staged init the migrator has not yet
+///   created `_sqlx_migrations`, so this reads false.
+/// - **already-migrated DBs** (030 present with `success = 1`): structurally
+///   excludes migrated databases, so no `VersionMismatch` path exists (F2) and
+///   the irreversible repair never re-runs on a DB already past 030.
+///
+/// Unlike the previous `MAX(version) == 29` gate, this fires for ANY pre-030
+/// start point (e.g. v28 from AionCore 0.1.52 — the ELECTRON-31Z one-step
+/// upgrade that jumped over v29 and so skipped the repair). Repair statements
+/// referencing tables/columns absent from an older schema are skipped as
+/// not-applicable (see [`is_missing_object_error`]); such tables hold no dirty
+/// data yet, and later migrations create them empty.
 async fn should_run_user_scope_repair(conn: &mut sqlx::SqliteConnection) -> Result<bool, DbError> {
     let has_table: bool =
         sqlx::query_scalar("SELECT COUNT(*) > 0 FROM sqlite_master WHERE type = 'table' AND name = '_sqlx_migrations'")
@@ -40,11 +56,13 @@ async fn should_run_user_scope_repair(conn: &mut sqlx::SqliteConnection) -> Resu
     if !has_table {
         return Ok(false);
     }
-    let max_version: Option<i64> = sqlx::query_scalar("SELECT MAX(version) FROM _sqlx_migrations WHERE success = 1")
-        .fetch_one(&mut *conn)
-        .await
-        .map_err(DbError::Query)?;
-    Ok(max_version == Some(USER_SCOPE_MIGRATION_VERSION - 1))
+    let migration_030_applied: bool =
+        sqlx::query_scalar("SELECT COUNT(*) > 0 FROM _sqlx_migrations WHERE version = ? AND success = 1")
+            .bind(USER_SCOPE_MIGRATION_VERSION)
+            .fetch_one(&mut *conn)
+            .await
+            .map_err(DbError::Query)?;
+    Ok(!migration_030_applied)
 }
 
 /// Evaluate every named 030 invariant on the raw (pre-030) schema and return
@@ -373,14 +391,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gate_false_at_version_28_and_30() {
-        let mut c = conn().await;
-        seed_sqlx_migrations(&mut c, 28).await;
-        assert!(!should_run_user_scope_repair(&mut c).await.unwrap());
+    async fn gate_true_at_pre_030_start_points() {
+        // The widened gate fires for ANY pre-030 history, not just v29. v28 is
+        // the ELECTRON-31Z upgrade path (a one-step jump from AionCore 0.1.52,
+        // whose DB stops at 28) that the old `== 29` gate skipped; v20 covers an
+        // even older start point.
+        for v in [20, 28] {
+            let mut c = conn().await;
+            seed_sqlx_migrations(&mut c, v).await;
+            assert!(
+                should_run_user_scope_repair(&mut c).await.unwrap(),
+                "030 is still pending at v{v}; the pre-migration repair must run"
+            );
+        }
+    }
 
-        let mut c2 = conn().await;
-        seed_sqlx_migrations(&mut c2, 30).await;
-        assert!(!should_run_user_scope_repair(&mut c2).await.unwrap());
+    #[tokio::test]
+    async fn gate_false_when_030_already_applied() {
+        // A DB whose 030 already succeeded must skip the repair: this preserves
+        // F2 (no sqlx VersionMismatch on migrated DBs) and never re-runs the
+        // irreversible data repair on a DB that is already past 030.
+        let mut c = conn().await;
+        seed_sqlx_migrations(&mut c, 30).await;
+        assert!(!should_run_user_scope_repair(&mut c).await.unwrap());
     }
 
     async fn create_min_v29_aggregate_tables(c: &mut sqlx::SqliteConnection) {

--- a/crates/aionui-db/tests/user_scope_pre_migration_repair.rs
+++ b/crates/aionui-db/tests/user_scope_pre_migration_repair.rs
@@ -44,6 +44,36 @@ async fn build_v29_db(path: &Path, seed: &[&str]) {
     pool.close().await;
 }
 
+/// Like [`build_v29_db`] but stops at `through_version` (< 29), leaving BOTH 029
+/// and 030 pending. This is the ELECTRON-31Z one-step upgrade: a DB that never
+/// stopped at v29 (AionCore 0.1.52 stops at 28) jumps straight to a build with
+/// 030. Staged init must run the repair before the migrator applies 029 + 030 in
+/// a single pass — the path the old `== 29` gate skipped entirely.
+async fn build_db_through(path: &Path, through_version: i64, seed: &[&str]) {
+    let url = format!("sqlite://{}?mode=rwc", path.display());
+    let pool = SqlitePoolOptions::new().max_connections(1).connect(&url).await.unwrap();
+    sqlx::query("PRAGMA foreign_keys = OFF").execute(&pool).await.unwrap();
+    let full = Migrator::new(Path::new("migrations")).await.unwrap();
+    let subset = full
+        .migrations
+        .iter()
+        .filter(|m| m.version <= through_version)
+        .cloned()
+        .collect::<Vec<_>>();
+    let migrator = Migrator {
+        migrations: Cow::Owned(subset),
+        ignore_missing: false,
+        locking: true,
+        no_tx: false,
+    };
+    migrator.run(&pool).await.unwrap();
+    for sql in seed {
+        sqlx::query(sql).execute(&pool).await.unwrap();
+    }
+    sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)").execute(&pool).await.ok();
+    pool.close().await;
+}
+
 async fn max_applied_version(db: &aionui_db::Database) -> i64 {
     sqlx::query_scalar("SELECT MAX(version) FROM _sqlx_migrations WHERE success = 1")
         .fetch_one(db.pool())
@@ -103,6 +133,66 @@ async fn stuck_user_with_orphans_self_heals_and_030_applies() {
         .await
         .unwrap();
     assert_eq!(orphan, 0, "orphan message removed");
+    db.close().await;
+}
+
+#[tokio::test]
+async fn v28_start_point_self_heals_across_029_and_030() {
+    // ELECTRON-31Z root case: a DB stopped at v28 (AionCore 0.1.52) upgrades in
+    // one step, so the migrator must apply BOTH 029 and 030. The widened gate
+    // runs the pre-migration repair before that pass, so 030's CHECK(ok=1)
+    // guards see normalized data. The old `== 29` gate skipped v28 and 030
+    // aborted here (SQLite 275). Same dirty-data shape as the v29 case, but from
+    // a start point that never passes through v29.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("aionui-backend.db");
+    build_db_through(
+        &path,
+        28,
+        &[
+            "INSERT INTO conversations (id, user_id, name, type, extra, status, created_at, updated_at) \
+             VALUES ('c_valid','system_default_user','Valid','acp','{}','pending',1,1)",
+            "INSERT INTO messages (id, conversation_id, type, content, created_at) \
+             VALUES ('m_valid','c_valid','user','{}',1)",
+            "INSERT INTO messages (id, conversation_id, type, content, created_at) \
+             VALUES ('m_orphan','c_missing','user','{}',1)",
+            "INSERT INTO acp_session (conversation_id, agent_source, agent_id, session_status, session_config) \
+             VALUES ('c_missing','builtin','a','idle','{}')",
+        ],
+    )
+    .await;
+
+    // Precondition: this really is a pre-029 start point (029 + 030 both pending).
+    {
+        let url = format!("sqlite://{}?mode=rwc", path.display());
+        let pool = SqlitePoolOptions::new().max_connections(1).connect(&url).await.unwrap();
+        let max: i64 = sqlx::query_scalar("SELECT MAX(version) FROM _sqlx_migrations WHERE success = 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(max, 28, "fixture must start at v28 so 029 and 030 are both pending");
+        pool.close().await;
+    }
+
+    let db = init_database_staged(&path)
+        .await
+        .expect("v28 stuck DB must self-heal across 029 + 030");
+    assert_eq!(
+        max_applied_version(&db).await,
+        latest_bundled_version().await,
+        "029 and 030 both applied after repair"
+    );
+
+    let valid: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM messages WHERE id='m_valid'")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(valid, 1, "valid message preserved");
+    let orphan: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM messages WHERE id='m_orphan'")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(orphan, 0, "orphan message removed before 030");
     db.close().await;
 }
 


### PR DESCRIPTION
## Summary

Fixes a startup-blocking regression that the pre-migration repair added in #724 only partially covered. Migration `030_user_scope.sql` has fail-hard `CHECK (ok = 1)` guards that abort on benign historical dirty data (SQLite 275, `CHECK constraint failed: ok = 1`, stage `database.migration`). #724 added a Rust-side idempotent pre-migration repair to normalize the data **before** the migrator runs 030 — but gated it on `MAX(version) == 29`, so it only ran for databases stopped exactly at v29.

A user upgrading in one step from a pre-029 database (e.g. **v28**, the DB level of AionCore `0.1.52`) jumps over v29: the gate sees `28 != 29`, skips the repair, and the migrator then applies 029 + 030 in a single pass. 030's guards abort on the unrepaired data and the backend is permanently stuck at `BOOTSTRAP_DATA_INIT_FAILED` on every launch. Because the database lives in the OS app-data directory, reinstalling does not clear it.

Sentry issues (same regression, split by platform fingerprint):
- `130567853` (ELECTRON-31Z)
- `130557438` (ELECTRON-31X)

## Root cause

The gate condition was too narrow. `should_run_user_scope_repair` returned true only when `MAX(version) == 29` (031–029 applied, 030 next), and a unit test pinned "v28 → skip". Any upgrade path that never stops at v29 — every jump from a DB at v≤28 — bypassed the repair entirely, so 030 ran on unrepaired data exactly as it did before #724.

## Approach

Widen the gate to run whenever `_sqlx_migrations` exists **and** migration 030 has not yet succeeded (i.e. 030 is still pending), instead of only at `== 29`. This covers any pre-030 start point while structurally preserving the two invariants the old gate relied on:

- **Fresh installs** (no `_sqlx_migrations` at pre-repair time) are skipped — the migrator builds the schema from empty and applies 001–030 on data-free tables.
- **Already-migrated DBs** (030 present, `success = 1`) are skipped — no sqlx `VersionMismatch` path exists (030 is byte-for-byte unchanged) and the irreversible repair never re-runs past 030.

Repair statements referencing tables/columns absent from an older schema are skipped as not-applicable (`is_missing_object_error`); such tables hold no dirty data yet and later migrations create them empty, so there is no lower version bound.

The diagnostic-only B-class `assistant_sessions_cross_scope_owner` guard is unchanged: it is still named + counted in the post-repair residual re-check but not actively repaired (accepted named-residual tradeoff). A user whose 030 failure is caused specifically by that guard is not fixed by widening alone, but the residual is attributable by name in the logs for a follow-up.

## Files changed

- `crates/aionui-db/src/migrate_repair.rs` — widen the gate condition + doc; split the gate unit test into `gate_true_at_pre_030_start_points` (v20/v28) and `gate_false_when_030_already_applied` (v30).
- `crates/aionui-db/tests/user_scope_pre_migration_repair.rs` — add `build_db_through` helper and the `v28_start_point_self_heals_across_029_and_030` integration test.

No migration SQL is added or modified; `030_user_scope.sql` is byte-for-byte unchanged.

## Test plan

- [x] RED confirmed: the widened-semantics gate unit test fails against the old `== 29` gate.
- [x] RED confirmed at integration level: with the old gate emulated, `v28_start_point_self_heals_across_029_and_030` aborts with the exact field error — `SqliteError { code: 275, message: "CHECK constraint failed: ok = 1" }` at migration 30, stage `database.migration`.
- [x] GREEN: `cargo test -p aionui-db` — lib unit tests + `user_scope_migration` (12) + `user_scope_pre_migration_repair` (5, incl. new v28 test) all pass.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy -p aionui-db --all-targets -- -D warnings` — 0 warnings.
- [x] `just push` full pre-push gate: migration-check, fmt, lint, workspace tests — `7997 passed, 22 skipped, 0 failed`.

## Notes

- Widening broadens irreversible DELETE/dedup/UPDATE to older DBs; the `is_missing_object_error` safety on very old schemas is covered by the new pre-v29 integration test rather than left as an inference.
- Release/rollback path for the self-heal-on-upgrade rollout is tracked as a separate human-confirmation item.