### PR TITLE
feat(fs): add ChatFileRef content endpoints

### DIFF
--- a/crates/aionui-api-types/src/file.rs
+++ b/crates/aionui-api-types/src/file.rs
@@ -1,6 +1,53 @@
 use aionui_common::FileChangeOperation;
 use serde::{Deserialize, Serialize};
 
+use crate::chat_file::ChatFileRef;
+
+// ---------------------------------------------------------------------------
+// Content endpoint (ChatFileRef identity) — Request DTOs
+// ---------------------------------------------------------------------------
+
+/// How `POST /api/fs/content` encodes the returned file content.
+///
+/// Mirrors the WS `fs/read` encoding split: `utf8` for text, `base64`/`dataurl`
+/// for binary (dataurl prepends a guessed `data:<mime>;base64,` prefix).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ContentEncoding {
+    /// UTF-8 text (fails on non-UTF-8 input); returned as the raw string.
+    #[default]
+    Utf8,
+    /// Raw bytes, base64-encoded, no data-URL prefix.
+    Base64,
+    /// Base64 data URL with a guessed MIME type: `data:<mime>;base64,<...>`.
+    DataUrl,
+}
+
+/// Request body for `POST /api/fs/content` — read a file addressed by
+/// [`ChatFileRef`] identity (collapses the old `read` + `image-base64`).
+#[derive(Debug, Deserialize)]
+pub struct ReadContentRequest {
+    pub file: ChatFileRef,
+    #[serde(default)]
+    pub encoding: ContentEncoding,
+}
+
+/// Request body for `PUT /api/fs/content` — write a file addressed by
+/// [`ChatFileRef`] identity. Optimistic-concurrency `If-Match` (last-modified
+/// ms) travels in the request header, not this body.
+#[derive(Debug, Deserialize)]
+pub struct WriteContentRequest {
+    pub file: ChatFileRef,
+    pub data: String,
+}
+
+/// Request body for `POST /api/fs/content/metadata` — metadata for a file
+/// addressed by [`ChatFileRef`] identity.
+#[derive(Debug, Deserialize)]
+pub struct ContentMetadataRequest {
+    pub file: ChatFileRef,
+}
+
 // ---------------------------------------------------------------------------
 // A. Core file operations — Request DTOs
 // ---------------------------------------------------------------------------

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -111,11 +111,11 @@ pub use extension::{
 };
 pub use file::{
     ContentEncoding, ContentMetadataRequest, CopyFailure, CopyFilesRequest, CopyFilesResponse, CopyTarget,
-    DirOrFileResponse, FetchRemoteImageRequest, ReadContentRequest, WriteContentRequest,
-    FileChangeInfoResponse, FileMetadataResponse, FileWatchRequest, GetFileMetadataRequest, GetFilesByDirRequest,
-    GetImageBase64Request, ListWorkspaceFilesRequest, ReadFileRequest, RevealItemRequest, SnapshotBaselineRequest,
-    SnapshotCompareResponse, SnapshotDiscardRequest, SnapshotInfoResponse, SnapshotMode, SnapshotStageRequest,
-    SnapshotWorkspaceRequest, WorkspaceFlatFileResponse, WorkspaceOfficeWatchRequest, WriteFileRequest,
+    DirOrFileResponse, FetchRemoteImageRequest, FileChangeInfoResponse, FileMetadataResponse, FileWatchRequest,
+    GetFileMetadataRequest, GetFilesByDirRequest, GetImageBase64Request, ListWorkspaceFilesRequest, ReadContentRequest,
+    ReadFileRequest, RevealItemRequest, SnapshotBaselineRequest, SnapshotCompareResponse, SnapshotDiscardRequest,
+    SnapshotInfoResponse, SnapshotMode, SnapshotStageRequest, SnapshotWorkspaceRequest, WorkspaceFlatFileResponse,
+    WorkspaceOfficeWatchRequest, WriteContentRequest, WriteFileRequest,
 };
 pub use lifecycle::{GitHubReleaseAsset, SystemInfoResponse, UpdateCheckRequest, UpdateCheckResult, UpdateReleaseInfo};
 pub use mcp::{

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -110,7 +110,8 @@ pub use extension::{
     InstallExtensionRequest, PermissionDetailResponse, PermissionSummaryResponse,
 };
 pub use file::{
-    CopyFailure, CopyFilesRequest, CopyFilesResponse, CopyTarget, DirOrFileResponse, FetchRemoteImageRequest,
+    ContentEncoding, ContentMetadataRequest, CopyFailure, CopyFilesRequest, CopyFilesResponse, CopyTarget,
+    DirOrFileResponse, FetchRemoteImageRequest, ReadContentRequest, WriteContentRequest,
     FileChangeInfoResponse, FileMetadataResponse, FileWatchRequest, GetFileMetadataRequest, GetFilesByDirRequest,
     GetImageBase64Request, ListWorkspaceFilesRequest, ReadFileRequest, RevealItemRequest, SnapshotBaselineRequest,
     SnapshotCompareResponse, SnapshotDiscardRequest, SnapshotInfoResponse, SnapshotMode, SnapshotStageRequest,

--- a/crates/aionui-app/tests/file_e2e.rs
+++ b/crates/aionui-app/tests/file_e2e.rs
@@ -2,7 +2,8 @@
 
 mod common;
 
-use axum::http::StatusCode;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
 use serde_json::json;
 use tower::ServiceExt;
 
@@ -16,6 +17,8 @@ use common::{body_json, build_app, build_app_with_file_roots, json_with_token, s
 async fn fs_endpoints_require_auth() {
     let (app, _services) = build_app().await;
     let endpoints = [
+        "/api/fs/content",
+        "/api/fs/content/metadata",
         "/api/fs/dir",
         "/api/fs/list",
         "/api/fs/metadata",
@@ -949,4 +952,198 @@ async fn upload_body_exceeding_30mb_returns_413() {
     assert_eq!(json["success"], false);
     assert_eq!(json["code"], "PAYLOAD_TOO_LARGE");
     assert!(json["error"].is_string());
+}
+
+// ===========================================================================
+// Content endpoint (ChatFileRef identity) — POST read / PUT write / metadata
+// ===========================================================================
+
+/// Build a `local` ChatFileRef JSON value for an absolute path.
+fn local_ref(path: &std::path::Path) -> serde_json::Value {
+    json!({ "kind": "local", "path": path.to_str().unwrap() })
+}
+
+#[tokio::test]
+async fn content_read_utf8_local_ref() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let fp = dir.path().join("note.txt");
+    std::fs::write(&fp, "hello content").unwrap();
+
+    let req = json_with_token(
+        "POST",
+        "/api/fs/content",
+        json!({ "file": local_ref(&fp), "encoding": "utf8" }),
+        &token,
+        &csrf,
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let j = body_json(resp).await;
+    assert_eq!(j["data"], "hello content");
+}
+
+#[tokio::test]
+async fn content_read_base64_local_ref() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let fp = dir.path().join("blob.bin");
+    let bytes = [0x00u8, 0xFF, 0x42, 0x89, 0x50];
+    std::fs::write(&fp, bytes).unwrap();
+
+    let req = json_with_token(
+        "POST",
+        "/api/fs/content",
+        json!({ "file": local_ref(&fp), "encoding": "base64" }),
+        &token,
+        &csrf,
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let j = body_json(resp).await;
+    use base64::Engine;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(j["data"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(decoded, bytes);
+}
+
+#[tokio::test]
+async fn content_read_dataurl_local_ref() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let fp = dir.path().join("pixel.png");
+    let png: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00,
+        0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xDE, 0x00, 0x00, 0x00,
+        0x0C, 0x49, 0x44, 0x41, 0x54, 0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xE2,
+        0x21, 0xBC, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
+    std::fs::write(&fp, png).unwrap();
+
+    let req = json_with_token(
+        "POST",
+        "/api/fs/content",
+        json!({ "file": local_ref(&fp), "encoding": "dataurl" }),
+        &token,
+        &csrf,
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let j = body_json(resp).await;
+    assert!(
+        j["data"].as_str().unwrap().starts_with("data:image/png;base64,"),
+        "expected png data URL, got {:?}",
+        j["data"]
+    );
+}
+
+#[tokio::test]
+async fn content_write_then_read_roundtrip_local_ref() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let fp = dir.path().join("editme.txt");
+    std::fs::write(&fp, "original").unwrap();
+
+    let put = json_with_token(
+        "PUT",
+        "/api/fs/content",
+        json!({ "file": local_ref(&fp), "data": "edited body" }),
+        &token,
+        &csrf,
+    );
+    let resp = app.clone().oneshot(put).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(body_json(resp).await["data"], true);
+    assert_eq!(std::fs::read_to_string(&fp).unwrap(), "edited body");
+
+    let get = json_with_token(
+        "POST",
+        "/api/fs/content",
+        json!({ "file": local_ref(&fp), "encoding": "utf8" }),
+        &token,
+        &csrf,
+    );
+    let resp = app.clone().oneshot(get).await.unwrap();
+    assert_eq!(body_json(resp).await["data"], "edited body");
+}
+
+#[tokio::test]
+async fn content_metadata_local_ref() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let fp = dir.path().join("meta.txt");
+    std::fs::write(&fp, "12345").unwrap();
+
+    let req = json_with_token(
+        "POST",
+        "/api/fs/content/metadata",
+        json!({ "file": local_ref(&fp) }),
+        &token,
+        &csrf,
+    );
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let j = body_json(resp).await;
+    assert_eq!(j["data"]["size"], 5);
+    assert_eq!(j["data"]["name"], "meta.txt");
+}
+
+/// Build a `PUT /api/fs/content` request with an `If-Match` header.
+fn put_content_if_match(path: &std::path::Path, data: &str, if_match: i64, token: &str, csrf: &str) -> Request<Body> {
+    let body = json!({ "file": local_ref(path), "data": data });
+    Request::builder()
+        .method("PUT")
+        .uri("/api/fs/content")
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {token}"))
+        .header("x-csrf-token", csrf)
+        .header("cookie", format!("aionui-csrf-token={csrf}"))
+        .header("if-match", if_match.to_string())
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn content_write_if_match_matches_and_conflicts() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let fp = dir.path().join("concurrent.txt");
+    std::fs::write(&fp, "v0").unwrap();
+
+    // Read the current mtime via the metadata endpoint.
+    let meta_req = json_with_token(
+        "POST",
+        "/api/fs/content/metadata",
+        json!({ "file": local_ref(&fp) }),
+        &token,
+        &csrf,
+    );
+    let resp = app.clone().oneshot(meta_req).await.unwrap();
+    let mtime = body_json(resp).await["data"]["last_modified"].as_i64().unwrap();
+
+    // Matching If-Match → write succeeds.
+    let ok = put_content_if_match(&fp, "v1", mtime, &token, &csrf);
+    let resp = app.clone().oneshot(ok).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(std::fs::read_to_string(&fp).unwrap(), "v1");
+
+    // Stale If-Match (a value that cannot match the current mtime) → 409 Conflict.
+    let stale = put_content_if_match(&fp, "v2", mtime - 1, &token, &csrf);
+    let resp = app.clone().oneshot(stale).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    // File is unchanged by the rejected write.
+    assert_eq!(std::fs::read_to_string(&fp).unwrap(), "v1");
 }

--- a/crates/aionui-file/src/routes.rs
+++ b/crates/aionui-file/src/routes.rs
@@ -4,16 +4,17 @@ use axum::Router;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{DefaultBodyLimit, Extension, Json, Multipart, State};
 use axum::routing::post;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tower_http::limit::RequestBodyLimitLayer;
 
 use aionui_api_types::{
-    ApiResponse, CopyFilesRequest, CopyFilesResponse, DirOrFileResponse, FetchRemoteImageRequest,
-    FileChangeInfoResponse, FileMetadataResponse, FileWatchRequest, GetFileMetadataRequest, GetFilesByDirRequest,
-    GetImageBase64Request, ListWorkspaceFilesRequest, ReadFileRequest, RevealItemRequest, SnapshotBaselineRequest,
-    SnapshotCompareResponse, SnapshotDiscardRequest, SnapshotInfoResponse, SnapshotStageRequest,
-    SnapshotWorkspaceRequest, WorkspaceFlatFileResponse, WorkspaceOfficeWatchRequest, WriteFileRequest,
+    ApiResponse, ContentMetadataRequest, CopyFilesRequest, CopyFilesResponse, DirOrFileResponse,
+    FetchRemoteImageRequest, FileChangeInfoResponse, FileMetadataResponse, FileWatchRequest, GetFileMetadataRequest,
+    GetFilesByDirRequest, GetImageBase64Request, ListWorkspaceFilesRequest, ReadContentRequest, ReadFileRequest,
+    RevealItemRequest, SnapshotBaselineRequest, SnapshotCompareResponse, SnapshotDiscardRequest, SnapshotInfoResponse,
+    SnapshotStageRequest, SnapshotWorkspaceRequest, WorkspaceFlatFileResponse, WorkspaceOfficeWatchRequest,
+    WriteContentRequest, WriteFileRequest,
 };
 use aionui_auth::CurrentUser;
 use aionui_common::ApiError;
@@ -21,6 +22,10 @@ use aionui_common::constants::UPLOAD_MAX_SIZE;
 
 use crate::error::FileError;
 use crate::traits::{FileServiceRef, FileWatchServiceRef, ItemRevealerRef, SnapshotServiceRef};
+
+/// Request-body cap for `PUT /api/fs/content`, aligned with the 256 MB read cap
+/// so large files can be saved (the 10 MB global limit would otherwise 413).
+const CONTENT_MAX_SIZE: usize = 256 * 1024 * 1024;
 use crate::types::{
     CompareResult, CopyResult, DirOrFile, FileChangeInfo, FileMetadata, SnapshotInfo, SnapshotMode, WorkspaceFlatFile,
 };
@@ -95,8 +100,21 @@ pub fn file_routes(state: FileRouterState) -> Router {
         .layer(RequestBodyLimitLayer::new(UPLOAD_MAX_SIZE))
         .with_state(state.clone());
 
+    // Content endpoint (ChatFileRef identity). PUT carries the full file body,
+    // so — like upload — it disables the 10 MB global `DefaultBodyLimit` and
+    // applies its own `CONTENT_MAX_SIZE` cap aligned with the 256 MB read cap
+    // (otherwise saving a large file would 413 before reaching the handler).
+    // POST (read) shares the sub-router; its body is a tiny ChatFileRef so the
+    // wider limit is harmless.
+    let content_router = Router::new()
+        .route("/api/fs/content", post(read_content).put(write_content))
+        .layer(DefaultBodyLimit::disable())
+        .layer(RequestBodyLimitLayer::new(CONTENT_MAX_SIZE))
+        .with_state(state.clone());
+
     Router::new()
         // A. Core file operations
+        .route("/api/fs/content/metadata", post(content_metadata))
         .route("/api/fs/dir", post(get_files_by_dir))
         .route("/api/fs/list", post(list_workspace_files))
         .route("/api/fs/metadata", post(get_file_metadata))
@@ -127,6 +145,7 @@ pub fn file_routes(state: FileRouterState) -> Router {
         .route("/api/fs/snapshot/dispose", post(snapshot_dispose))
         .with_state(state)
         .merge(upload_router)
+        .merge(content_router)
 }
 
 // ---------------------------------------------------------------------------
@@ -269,6 +288,97 @@ async fn reveal_resolved(
 ) -> Result<(), FileError> {
     let abs = absolute_path.ok_or_else(|| FileError::BadRequest("reveal target is not a local path".to_owned()))?;
     revealer.reveal(&abs).await
+}
+
+// ---------------------------------------------------------------------------
+// Content endpoint (ChatFileRef identity) — handlers
+// ---------------------------------------------------------------------------
+
+/// Managed upload directory (`<tmp>/aionui`) used to validate `Upload`
+/// ChatFileRef variants — mirrors the chat send-boundary convention.
+fn content_upload_root() -> PathBuf {
+    std::env::temp_dir().join("aionui")
+}
+
+/// Parse the optional `If-Match` header as a last-modified-millisecond stamp.
+fn parse_if_match(headers: &axum::http::HeaderMap) -> Option<i64> {
+    headers
+        .get(axum::http::header::IF_MATCH)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse::<i64>()
+        .ok()
+}
+
+/// `POST /api/fs/content` — read a file addressed by `ChatFileRef` identity.
+/// Collapses the old `read` + `image-base64`: body carries the ref plus an
+/// `encoding` (utf8|base64|dataurl). Resolves per-variant (op = Read) then reads
+/// the trusted absolute path.
+async fn read_content(
+    State(state): State<FileRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    body: Result<Json<ReadContentRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<String>>, ApiError> {
+    let Json(req) = body.map_err(ApiError::from)?;
+    let abs = state
+        .project
+        .resolve_chat_file_ref(&user.id, &req.file, &content_upload_root(), aionui_project::FileOp::Read)
+        .await
+        .map_err(ApiError::from)?;
+    let content = state
+        .file_service
+        .read_resolved_content(Path::new(&abs), req.encoding)
+        .await?;
+    Ok(Json(ApiResponse::ok(content)))
+}
+
+/// `PUT /api/fs/content` — write a file addressed by `ChatFileRef` identity
+/// (op = Write for the Project arm). Optimistic concurrency: when the client
+/// sends `If-Match: <last-modified ms>`, a mismatch against the current on-disk
+/// mtime returns 409 Conflict (guards the "external change silently overwritten"
+/// case). Body cap is `CONTENT_MAX_SIZE` (see the router builder).
+async fn write_content(
+    State(state): State<FileRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    headers: axum::http::HeaderMap,
+    body: Result<Json<WriteContentRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<bool>>, ApiError> {
+    let Json(req) = body.map_err(ApiError::from)?;
+    let abs = state
+        .project
+        .resolve_chat_file_ref(&user.id, &req.file, &content_upload_root(), aionui_project::FileOp::Write)
+        .await
+        .map_err(ApiError::from)?;
+    let path = Path::new(&abs);
+
+    if let Some(expected) = parse_if_match(&headers) {
+        let current = state.file_service.resolved_metadata(path).await?.last_modified;
+        if current != expected {
+            return Err(ApiError::Conflict(format!(
+                "file changed on disk since last read (expected mtime {expected}, found {current})"
+            )));
+        }
+    }
+
+    state.file_service.write_resolved_content(path, req.data.as_bytes()).await?;
+    Ok(Json(ApiResponse::ok(true)))
+}
+
+/// `POST /api/fs/content/metadata` — metadata for a `ChatFileRef`-addressed file.
+async fn content_metadata(
+    State(state): State<FileRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    body: Result<Json<ContentMetadataRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<FileMetadataResponse>>, ApiError> {
+    let Json(req) = body.map_err(ApiError::from)?;
+    let abs = state
+        .project
+        .resolve_chat_file_ref(&user.id, &req.file, &content_upload_root(), aionui_project::FileOp::Read)
+        .await
+        .map_err(ApiError::from)?;
+    let meta = state.file_service.resolved_metadata(Path::new(&abs)).await?;
+    Ok(Json(ApiResponse::ok(to_metadata_response(meta))))
 }
 
 /// Fields extracted from a `/api/fs/upload` multipart request.

--- a/crates/aionui-file/src/routes.rs
+++ b/crates/aionui-file/src/routes.rs
@@ -323,7 +323,12 @@ async fn read_content(
     let Json(req) = body.map_err(ApiError::from)?;
     let abs = state
         .project
-        .resolve_chat_file_ref(&user.id, &req.file, &content_upload_root(), aionui_project::FileOp::Read)
+        .resolve_chat_file_ref(
+            &user.id,
+            &req.file,
+            &content_upload_root(),
+            aionui_project::FileOp::Read,
+        )
         .await
         .map_err(ApiError::from)?;
     let content = state
@@ -347,7 +352,12 @@ async fn write_content(
     let Json(req) = body.map_err(ApiError::from)?;
     let abs = state
         .project
-        .resolve_chat_file_ref(&user.id, &req.file, &content_upload_root(), aionui_project::FileOp::Write)
+        .resolve_chat_file_ref(
+            &user.id,
+            &req.file,
+            &content_upload_root(),
+            aionui_project::FileOp::Write,
+        )
         .await
         .map_err(ApiError::from)?;
     let path = Path::new(&abs);
@@ -361,7 +371,10 @@ async fn write_content(
         }
     }
 
-    state.file_service.write_resolved_content(path, req.data.as_bytes()).await?;
+    state
+        .file_service
+        .write_resolved_content(path, req.data.as_bytes())
+        .await?;
     Ok(Json(ApiResponse::ok(true)))
 }
 
@@ -374,7 +387,12 @@ async fn content_metadata(
     let Json(req) = body.map_err(ApiError::from)?;
     let abs = state
         .project
-        .resolve_chat_file_ref(&user.id, &req.file, &content_upload_root(), aionui_project::FileOp::Read)
+        .resolve_chat_file_ref(
+            &user.id,
+            &req.file,
+            &content_upload_root(),
+            aionui_project::FileOp::Read,
+        )
         .await
         .map_err(ApiError::from)?;
     let meta = state.file_service.resolved_metadata(Path::new(&abs)).await?;

--- a/crates/aionui-file/src/service.rs
+++ b/crates/aionui-file/src/service.rs
@@ -9,7 +9,7 @@ use ignore::WalkBuilder;
 use tracing::warn;
 
 use crate::error::FileError;
-use aionui_api_types::WebSocketMessage;
+use aionui_api_types::{ContentEncoding, WebSocketMessage};
 use aionui_realtime::EventBroadcaster;
 
 use crate::path_safety::{
@@ -404,6 +404,26 @@ fn get_image_base64_sync(path: &Path) -> Result<String, FileError> {
     Ok(format!("data:{mime};base64,{encoded}"))
 }
 
+/// Encode a file's content for the `/api/fs/content` endpoint per `encoding`.
+/// `Utf8` → text (errors on non-UTF-8); `Base64` → raw bytes base64 (no prefix);
+/// `DataUrl` → `data:<mime>;base64,<...>`. The 256 MB read cap applies to all.
+fn read_resolved_content_sync(path: &Path, encoding: ContentEncoding) -> Result<String, FileError> {
+    match encoding {
+        ContentEncoding::Utf8 => {
+            read_file_sync(path)?.ok_or_else(|| FileError::NotFound(format!("file not found: {}", path.display())))
+        }
+        ContentEncoding::Base64 => {
+            if validate_file_for_read(path)?.is_none() {
+                return Err(FileError::NotFound(format!("file not found: {}", path.display())));
+            }
+            let bytes = std::fs::read(path)
+                .map_err(|e| FileError::Internal(format!("cannot read file '{}': {e}", path.display())))?;
+            Ok(base64::engine::general_purpose::STANDARD.encode(bytes))
+        }
+        ContentEncoding::DataUrl => get_image_base64_sync(path),
+    }
+}
+
 /// Build a placeholder SVG Data URL for failed remote image fetches.
 fn placeholder_svg_data_url() -> String {
     let encoded = base64::engine::general_purpose::STANDARD.encode(PLACEHOLDER_SVG);
@@ -443,6 +463,41 @@ fn validate_remote_image_url(raw_url: &str) -> Result<reqwest::Url, String> {
 
 #[async_trait::async_trait]
 impl crate::traits::IFileService for FileService {
+    // -- Content endpoint (pre-resolved absolute paths) --
+    //
+    // These operate on a path already resolved + containment-checked upstream by
+    // `ProjectService::resolve_chat_file_ref` (per-variant guards). They do NOT
+    // re-apply the `allowed_roots` sandbox — otherwise a `Local` host-picker file
+    // (legitimately outside any workspace) would be rejected. Mirrors the
+    // `/api/fs/reveal` pattern: resolve the identity, then operate on the path.
+
+    async fn read_resolved_content(
+        &self,
+        absolute_path: &Path,
+        encoding: ContentEncoding,
+    ) -> Result<String, FileError> {
+        let path = absolute_path.to_path_buf();
+        tokio::task::spawn_blocking(move || read_resolved_content_sync(&path, encoding))
+            .await
+            .map_err(|e| FileError::Internal(format!("read content task failed: {e}")))?
+    }
+
+    async fn write_resolved_content(&self, absolute_path: &Path, data: &[u8]) -> Result<(), FileError> {
+        let path = absolute_path.to_path_buf();
+        let data = data.to_vec();
+        tokio::task::spawn_blocking(move || write_file_sync(&path, &data))
+            .await
+            .map_err(|e| FileError::Internal(format!("write content task failed: {e}")))??;
+        Ok(())
+    }
+
+    async fn resolved_metadata(&self, absolute_path: &Path) -> Result<FileMetadata, FileError> {
+        let path = absolute_path.to_path_buf();
+        tokio::task::spawn_blocking(move || get_file_metadata_sync(&path))
+            .await
+            .map_err(|e| FileError::Internal(format!("metadata task failed: {e}")))?
+    }
+
     async fn get_files_by_dir(&self, dir: &str, root: &str) -> Result<Vec<DirOrFile>, FileError> {
         let roots = self.allowed_roots_refs();
         let extra_root = Path::new(root);

--- a/crates/aionui-file/src/traits.rs
+++ b/crates/aionui-file/src/traits.rs
@@ -5,6 +5,8 @@ use aionui_common::FileChangeOperation;
 
 use crate::error::FileError;
 
+use aionui_api_types::ContentEncoding;
+
 use crate::types::{CompareResult, CopyResult, DirOrFile, FileMetadata, SnapshotInfo, WorkspaceFlatFile};
 
 /// Core file operations: directory browsing, file read/write, management,
@@ -14,6 +16,27 @@ use crate::types::{CompareResult, CopyResult, DirOrFile, FileMetadata, SnapshotI
 /// `path_safety` module) before reaching this trait's implementations.
 #[async_trait::async_trait]
 pub trait IFileService: Send + Sync {
+    // -- Content endpoint (pre-resolved absolute paths) --
+    //
+    // The caller (preview content endpoint) has already resolved a `ChatFileRef`
+    // to an absolute path via `ProjectService::resolve_chat_file_ref` with the
+    // matching per-variant containment guard, so these operate on the trusted
+    // path directly and do NOT re-apply the `allowed_roots` sandbox.
+
+    /// Read a pre-resolved absolute path and encode it per `encoding`
+    /// (utf8 text / base64 / data URL). `NotFound` if the file is gone.
+    async fn read_resolved_content(
+        &self,
+        absolute_path: &Path,
+        encoding: ContentEncoding,
+    ) -> Result<String, FileError>;
+
+    /// Write `data` to a pre-resolved absolute path (full overwrite).
+    async fn write_resolved_content(&self, absolute_path: &Path, data: &[u8]) -> Result<(), FileError>;
+
+    /// Metadata for a pre-resolved absolute path.
+    async fn resolved_metadata(&self, absolute_path: &Path) -> Result<FileMetadata, FileError>;
+
     // -- Directory browsing --
 
     /// List the immediate children of `dir`, returning a tree with one level

--- a/crates/aionui-file/src/traits.rs
+++ b/crates/aionui-file/src/traits.rs
@@ -25,11 +25,8 @@ pub trait IFileService: Send + Sync {
 
     /// Read a pre-resolved absolute path and encode it per `encoding`
     /// (utf8 text / base64 / data URL). `NotFound` if the file is gone.
-    async fn read_resolved_content(
-        &self,
-        absolute_path: &Path,
-        encoding: ContentEncoding,
-    ) -> Result<String, FileError>;
+    async fn read_resolved_content(&self, absolute_path: &Path, encoding: ContentEncoding)
+    -> Result<String, FileError>;
 
     /// Write `data` to a pre-resolved absolute path (full overwrite).
     async fn write_resolved_content(&self, absolute_path: &Path, data: &[u8]) -> Result<(), FileError>;

--- a/crates/aionui-project/src/chat_files.rs
+++ b/crates/aionui-project/src/chat_files.rs
@@ -45,7 +45,10 @@ impl ProjectService {
     ) -> Result<ResolvedChatMessage, ProjectError> {
         let mut paths = Vec::with_capacity(files.len());
         for file in files {
-            paths.push(self.resolve_chat_file_ref(user_id, file, upload_root).await?);
+            paths.push(
+                self.resolve_chat_file_ref(user_id, file, upload_root, FileOp::Read)
+                    .await?,
+            );
         }
 
         let content = if paths.is_empty() {
@@ -61,16 +64,21 @@ impl ProjectService {
     /// The per-ref identity→path core shared by [`resolve_chat_message`](Self::resolve_chat_message)
     /// (send boundary) and the preview content endpoint (`aionui-file`, cross-crate — hence `pub`).
     /// Guards differ by variant:
-    /// - `Project` → [`resolve_reference`](Self::resolve_reference) with `op = Read` (lexical +
-    ///   realpath containment); must exist (file or folder).
+    /// - `Project` → [`resolve_reference`](Self::resolve_reference) with the caller's `op` (lexical +
+    ///   realpath containment; read paths pass `Read`, the write endpoint passes `Write`); must exist
+    ///   (file or folder).
     /// - `Upload` → an existing regular file under the managed `upload_root` (D2 invariant).
     /// - `Local` → a canonicalized existing regular file; **no sandbox** (the host picker that
     ///   produced it already exposes the whole filesystem).
+    ///
+    /// `op` only affects the `Project` arm's containment mode; `Upload`/`Local` are path-based and
+    /// identical regardless of op.
     pub async fn resolve_chat_file_ref(
         &self,
         user_id: &str,
         file: &ChatFileRef,
         upload_root: &Path,
+        op: FileOp,
     ) -> Result<String, ProjectError> {
         match file {
             ChatFileRef::Project { pe_id, relative_path } => {
@@ -80,7 +88,7 @@ impl ProjectService {
                         ReferenceInput {
                             pe_id: pe_id.clone(),
                             relative_path: relative_path.clone(),
-                            op: FileOp::Read,
+                            op,
                         },
                     )
                     .await?;

--- a/crates/aionui-project/src/chat_files.rs
+++ b/crates/aionui-project/src/chat_files.rs
@@ -45,52 +45,7 @@ impl ProjectService {
     ) -> Result<ResolvedChatMessage, ProjectError> {
         let mut paths = Vec::with_capacity(files.len());
         for file in files {
-            match file {
-                ChatFileRef::Project { pe_id, relative_path } => {
-                    let resolved = self
-                        .resolve_reference(
-                            user_id,
-                            ReferenceInput {
-                                pe_id: pe_id.clone(),
-                                relative_path: relative_path.clone(),
-                                op: FileOp::Read,
-                            },
-                        )
-                        .await?;
-                    let abs = resolved.absolute_path.ok_or_else(|| ProjectError::ChatFileMissing {
-                        path: relative_path.clone(),
-                    })?;
-                    // A project ref may point at a file or a folder (the tree
-                    // allows attaching a directory); require only that it exists.
-                    if !Path::new(&abs).exists() {
-                        return Err(ProjectError::ChatFileMissing { path: abs });
-                    }
-                    paths.push(abs);
-                }
-                ChatFileRef::Upload { path } => {
-                    let candidate = Path::new(path);
-                    if !candidate.is_file() {
-                        return Err(ProjectError::ChatFileMissing { path: path.clone() });
-                    }
-                    if !path_within(upload_root, candidate) {
-                        return Err(ProjectError::UploadPathOutsideRoot { path: path.clone() });
-                    }
-                    paths.push(path.clone());
-                }
-                ChatFileRef::Local { path } => {
-                    // A path the user explicitly picked in the host-file browser,
-                    // which already exposes the whole filesystem. No managed-root
-                    // restriction (that is the upload channel's D2 invariant only);
-                    // just canonicalize (collapsing `..`/symlinks) and require an
-                    // existing regular file.
-                    let canonical = std::fs::canonicalize(path)
-                        .map_err(|_| ProjectError::LocalPathNotReadable { path: path.clone() })?;
-                    if !canonical.is_file() {
-                        return Err(ProjectError::LocalPathNotReadable { path: path.clone() });
-                    }
-                    paths.push(canonical.to_string_lossy().into_owned());
-                }
-            }
+            paths.push(self.resolve_chat_file_ref(user_id, file, upload_root).await?);
         }
 
         let content = if paths.is_empty() {
@@ -99,6 +54,70 @@ impl ProjectService {
             format!("{content}\n\n{AIONUI_FILES_MARKER}\n{}", paths.join("\n"))
         };
         Ok(ResolvedChatMessage { content, files: paths })
+    }
+
+    /// Resolve a single [`ChatFileRef`] to an absolute device path.
+    ///
+    /// The per-ref identity→path core shared by [`resolve_chat_message`](Self::resolve_chat_message)
+    /// (send boundary) and the preview content endpoint (`aionui-file`, cross-crate — hence `pub`).
+    /// Guards differ by variant:
+    /// - `Project` → [`resolve_reference`](Self::resolve_reference) with `op = Read` (lexical +
+    ///   realpath containment); must exist (file or folder).
+    /// - `Upload` → an existing regular file under the managed `upload_root` (D2 invariant).
+    /// - `Local` → a canonicalized existing regular file; **no sandbox** (the host picker that
+    ///   produced it already exposes the whole filesystem).
+    pub async fn resolve_chat_file_ref(
+        &self,
+        user_id: &str,
+        file: &ChatFileRef,
+        upload_root: &Path,
+    ) -> Result<String, ProjectError> {
+        match file {
+            ChatFileRef::Project { pe_id, relative_path } => {
+                let resolved = self
+                    .resolve_reference(
+                        user_id,
+                        ReferenceInput {
+                            pe_id: pe_id.clone(),
+                            relative_path: relative_path.clone(),
+                            op: FileOp::Read,
+                        },
+                    )
+                    .await?;
+                let abs = resolved.absolute_path.ok_or_else(|| ProjectError::ChatFileMissing {
+                    path: relative_path.clone(),
+                })?;
+                // A project ref may point at a file or a folder (the tree
+                // allows attaching a directory); require only that it exists.
+                if !Path::new(&abs).exists() {
+                    return Err(ProjectError::ChatFileMissing { path: abs });
+                }
+                Ok(abs)
+            }
+            ChatFileRef::Upload { path } => {
+                let candidate = Path::new(path);
+                if !candidate.is_file() {
+                    return Err(ProjectError::ChatFileMissing { path: path.clone() });
+                }
+                if !path_within(upload_root, candidate) {
+                    return Err(ProjectError::UploadPathOutsideRoot { path: path.clone() });
+                }
+                Ok(path.clone())
+            }
+            ChatFileRef::Local { path } => {
+                // A path the user explicitly picked in the host-file browser,
+                // which already exposes the whole filesystem. No managed-root
+                // restriction (that is the upload channel's D2 invariant only);
+                // just canonicalize (collapsing `..`/symlinks) and require an
+                // existing regular file.
+                let canonical = std::fs::canonicalize(path)
+                    .map_err(|_| ProjectError::LocalPathNotReadable { path: path.clone() })?;
+                if !canonical.is_file() {
+                    return Err(ProjectError::LocalPathNotReadable { path: path.clone() });
+                }
+                Ok(canonical.to_string_lossy().into_owned())
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Adds `ChatFileRef`-addressed content endpoints for the preview feature. **Additive** — the existing `{path, workspace}` endpoints are kept untouched for the frontend migration phase (removed in a later PR).

## New endpoints

- **`POST /api/fs/content`** — read by `ChatFileRef` identity + `encoding` (`utf8` | `base64` | `dataurl`), collapsing the old `read` + `image-base64` into one endpoint. Returns `ApiResponse<String>`.
- **`PUT /api/fs/content`** — write by `ChatFileRef` + `data`, with optional **`If-Match: <last-modified ms>`** optimistic-concurrency check: a mismatch against the current on-disk mtime returns **409 Conflict**, guarding against silently overwriting an externally-changed file. Own 256 MB body cap (aligned with the read cap) so large saves don't 413 on the 10 MB global limit.
- **`POST /api/fs/content/metadata`** — metadata by `ChatFileRef` identity.

## Supporting changes

- `resolve_chat_file_ref` gained an `op` param so the write path resolves Project refs with **Write** containment; the read/metadata paths pass **Read**.
- `IFileService` gained `read_resolved_content` / `write_resolved_content` / `resolved_metadata`, operating on the pre-resolved, per-variant-guarded absolute path (mirrors `/api/fs/reveal`) — Local host files stay reachable.
- New DTOs: `ContentEncoding`, `ReadContentRequest`, `WriteContentRequest`, `ContentMetadataRequest`.

## Additive guarantee

All existing endpoints remain registered: `read`, `read-buffer`, `write`, `metadata`, `image-base64`, `copy`, `dir`, `list`, `upload`, `reveal`, `snapshot/*`, etc. Frontend migration to the new content endpoints is a follow-up PR.

## Verification

- **rebased onto `origin/main`** (picked up #741, #756); `git range-diff` confirms both feature commits are byte-identical post-rebase (`=`), no lost/overwritten changes; the rebased commits touch no files that #741/#756 changed.
- `cargo test -p aionui-app -p aionui-file -p aionui-project` — green (incl. aionui-app e2e: 3 encodings + write roundtrip + If-Match match/409 + metadata + auth guard).
- Full pre-push gate (`just push`) — **8162 passed, 22 skipped, 0 failed**.

## Commits

1. `b06b6a8c` — extract `resolve_chat_file_ref`
2. `e78d738a` — add ChatFileRef content endpoints
3. `66c8a57a` — auto-fixes (fmt + clippy), generated by the `just push` gate
