### PR TITLE
chore(deps): update aionrs to v0.2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,8 +116,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.2.8"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
+version = "0.2.9"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.9#1581f4096b598109a0daf3d44261b9790cc2a30d"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -147,8 +147,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.2.8"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
+version = "0.2.9"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.9#1581f4096b598109a0daf3d44261b9790cc2a30d"
 dependencies = [
  "regex",
  "serde",
@@ -159,8 +159,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.2.8"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
+version = "0.2.9"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.9#1581f4096b598109a0daf3d44261b9790cc2a30d"
 dependencies = [
  "aion-compact",
  "aion-process",
@@ -184,8 +184,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.2.8"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
+version = "0.2.9"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.9#1581f4096b598109a0daf3d44261b9790cc2a30d"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -205,8 +205,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.2.8"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
+version = "0.2.9"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.9#1581f4096b598109a0daf3d44261b9790cc2a30d"
 dependencies = [
  "aion-config",
  "chrono",
@@ -219,8 +219,8 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.2.8"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
+version = "0.2.9"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.9#1581f4096b598109a0daf3d44261b9790cc2a30d"
 dependencies = [
  "libc",
  "tokio",
@@ -230,8 +230,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.2.8"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
+version = "0.2.9"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.9#1581f4096b598109a0daf3d44261b9790cc2a30d"
 dependencies = [
  "aion-types",
  "serde",
@@ -243,8 +243,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.2.8"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
+version = "0.2.9"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.9#1581f4096b598109a0daf3d44261b9790cc2a30d"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -272,8 +272,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.2.8"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
+version = "0.2.9"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.9#1581f4096b598109a0daf3d44261b9790cc2a30d"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -299,8 +299,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.2.8"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
+version = "0.2.9"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.9#1581f4096b598109a0daf3d44261b9790cc2a30d"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -321,8 +321,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.2.8"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
+version = "0.2.9"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.9#1581f4096b598109a0daf3d44261b9790cc2a30d"
 dependencies = [
  "async-trait",
  "base64",
@@ -6846,7 +6846,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.8#4bd4f3254f6d875f122b648dd55116516c380d31"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.9#1581f4096b598109a0daf3d44261b9790cc2a30d"
 dependencies = [
  "bitflags",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,12 +59,12 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.8" }
-aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.8" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.8" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.8" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.8" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.8" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.9" }
+aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.9" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.9" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.9" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.9" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.9" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Bumps embedded engine aionrs v0.2.8 → v0.2.9.
https://github.com/iOfficeAI/aionrs/compare/v0.2.8...v0.2.9

fix(engine): fail chat streams on embedded errors and missing terminals
fix(engine): keep tools available on first empty-final retry
fix(engine): address review findings on error mapping and retry semantics
fix(engine): default to max_completion_tokens for official openai endpoint