### PR TITLE
fix(runtime): retry transient bundled-node activation copy and reclassify persistent I/O failures

### DIFF
--- a/crates/aionui-ai-agent/src/runtime_status.rs
+++ b/crates/aionui-ai-agent/src/runtime_status.rs
@@ -79,6 +79,7 @@ fn map_failure_kind(kind: NodeRuntimeFailureKind) -> RuntimeFailureKind {
         NodeRuntimeFailureKind::UnsupportedPlatform => RuntimeFailureKind::UnsupportedPlatform,
         NodeRuntimeFailureKind::BundledResourceMissing => RuntimeFailureKind::BundledResourceMissing,
         NodeRuntimeFailureKind::BundledResourceInvalid => RuntimeFailureKind::BundledResourceInvalid,
+        NodeRuntimeFailureKind::ActivationIoFailed => RuntimeFailureKind::ActivationIoFailed,
         NodeRuntimeFailureKind::Unknown => RuntimeFailureKind::Unknown,
     }
 }

--- a/crates/aionui-api-types/src/runtime.rs
+++ b/crates/aionui-api-types/src/runtime.rs
@@ -42,6 +42,7 @@ pub enum RuntimeFailureKind {
     UnsupportedPlatform,
     BundledResourceMissing,
     BundledResourceInvalid,
+    ActivationIoFailed,
     Unknown,
 }
 
@@ -107,6 +108,14 @@ mod tests {
 
         assert_eq!(missing, "bundled_resource_missing");
         assert_eq!(invalid, "bundled_resource_invalid");
+    }
+
+    #[test]
+    fn activation_io_failed_serializes_to_snake_case() {
+        let json = serde_json::to_string(&RuntimeFailureKind::ActivationIoFailed).unwrap();
+        assert_eq!(json, "\"activation_io_failed\"");
+        let parsed: RuntimeFailureKind = serde_json::from_str("\"activation_io_failed\"").unwrap();
+        assert_eq!(parsed, RuntimeFailureKind::ActivationIoFailed);
     }
 
     #[test]

--- a/crates/aionui-mcp/src/connection_test/mod.rs
+++ b/crates/aionui-mcp/src/connection_test/mod.rs
@@ -456,6 +456,7 @@ fn map_failure_kind(kind: NodeRuntimeFailureKind) -> RuntimeFailureKind {
         NodeRuntimeFailureKind::UnsupportedPlatform => RuntimeFailureKind::UnsupportedPlatform,
         NodeRuntimeFailureKind::BundledResourceMissing => RuntimeFailureKind::BundledResourceMissing,
         NodeRuntimeFailureKind::BundledResourceInvalid => RuntimeFailureKind::BundledResourceInvalid,
+        NodeRuntimeFailureKind::ActivationIoFailed => RuntimeFailureKind::ActivationIoFailed,
         NodeRuntimeFailureKind::Unknown => RuntimeFailureKind::Unknown,
     }
 }

--- a/crates/aionui-runtime/Cargo.toml
+++ b/crates/aionui-runtime/Cargo.toml
@@ -26,6 +26,9 @@ tempfile.workspace = true
 sha2.workspace = true
 hex.workspace = true
 tracing-subscriber.workspace = true
+# test-util enables tokio paused-time (`start_paused = true`) so activation-copy
+# retry/backoff tests exercise the real sleep path without wall-clock delay.
+tokio = { workspace = true, features = ["test-util"] }
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/crates/aionui-runtime/src/node_runtime/managed.rs
+++ b/crates/aionui-runtime/src/node_runtime/managed.rs
@@ -862,6 +862,12 @@ fn http_status_error(stage: &str, url: &str, status: reqwest::StatusCode) -> Nod
 }
 
 fn classify_error(error: &NodeRuntimeError) -> (NodeRuntimeFailureKind, Option<u16>) {
+    // An explicitly tagged failure kind is decided at the io::Error layer (e.g. a
+    // retry-exhausted transient copy failure) and must not be re-derived from the
+    // stringified message, which cannot distinguish copy vs validation failures.
+    if let Some(kind) = error.failure_kind() {
+        return (kind, None);
+    }
     let message = error.to_string().to_ascii_lowercase();
     if message.contains("timed out") {
         return (NodeRuntimeFailureKind::Timeout, None);

--- a/crates/aionui-runtime/src/node_runtime/managed.rs
+++ b/crates/aionui-runtime/src/node_runtime/managed.rs
@@ -25,6 +25,16 @@ const MANAGED_NODE_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
 const MANAGED_NODE_DOWNLOAD_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 const MANAGED_NODE_DOWNLOAD_ATTEMPTS: usize = 2;
 const MANAGED_NODE_PROGRESS_STEP_BYTES: u64 = 5 * 1024 * 1024;
+// Local-copy activation retry budget. Kept separate from MANAGED_NODE_DOWNLOAD_ATTEMPTS:
+// download retries rely on HTTP reconnect delay, whereas a local copy retried with no
+// backoff would just re-hit the same file lock. 3 attempts with 250/500/1000ms backoff
+// adds worst-case ~1.75s before the final failure verdict.
+const MANAGED_NODE_ACTIVATION_COPY_ATTEMPTS: usize = 3;
+const MANAGED_NODE_ACTIVATION_COPY_BACKOFFS: [Duration; 3] = [
+    Duration::from_millis(250),
+    Duration::from_millis(500),
+    Duration::from_millis(1000),
+];
 
 #[derive(Debug, Clone, Copy)]
 struct PlatformSpec {
@@ -412,22 +422,45 @@ async fn activate_local_runtime_source(
             )),
         );
 
-        if let Err(error) = managed_resources::materialize_directory(&source.root, &version_dir) {
-            warn!(
-                source = source_kind_label(source.kind),
-                source_root = %source.root.display(),
-                target_root = %version_dir.display(),
-                error = %error,
-                "failed to activate local node runtime source"
-            );
-            if matches!(source.kind, ManagedResourceSourceKind::Bundled) {
-                return Err(NodeRuntimeError::managed_invalid(format!(
-                    "bundled Node runtime is invalid under {}: {}",
-                    source.root.display(),
-                    error
-                )));
+        match activate_copy_with_retry(|| managed_resources::materialize_directory(&source.root, &version_dir)).await {
+            Ok(()) => {}
+            Err(ActivationCopyError::NonTransient(error)) => {
+                warn!(
+                    source = source_kind_label(source.kind),
+                    source_root = %source.root.display(),
+                    target_root = %version_dir.display(),
+                    error = %error,
+                    "failed to activate local node runtime source"
+                );
+                if matches!(source.kind, ManagedResourceSourceKind::Bundled) {
+                    // Non-transient copy failure (e.g. PermissionDenied) keeps the
+                    // existing hard-failure semantics so real problems still surface.
+                    return Err(NodeRuntimeError::managed_invalid(format!(
+                        "bundled Node runtime is invalid under {}: {}",
+                        source.root.display(),
+                        error
+                    )));
+                }
+                continue;
             }
-            continue;
+            Err(ActivationCopyError::Transient(error)) => {
+                warn!(
+                    source = source_kind_label(source.kind),
+                    source_root = %source.root.display(),
+                    target_root = %version_dir.display(),
+                    error = %error,
+                    "node activation copy failed after bounded retries; classifying as transient I/O"
+                );
+                if matches!(source.kind, ManagedResourceSourceKind::Bundled) {
+                    return Err(NodeRuntimeError::activation_io_failed(format!(
+                        "bundled Node runtime activation copy failed after {} attempts under {}: {}",
+                        MANAGED_NODE_ACTIVATION_COPY_ATTEMPTS,
+                        source.root.display(),
+                        error
+                    )));
+                }
+                continue;
+            }
         }
 
         match validate_managed_runtime(&version_dir, reporter).await {
@@ -859,6 +892,59 @@ fn download_progress_message(url: &str, downloaded_bytes: u64, total_bytes: Opti
 
 fn http_status_error(stage: &str, url: &str, status: reqwest::StatusCode) -> NodeRuntimeError {
     NodeRuntimeError::managed_invalid(format!("{stage} returned HTTP {} for {url}", status.as_u16()))
+}
+
+fn is_transient_activation_io_error(error: &std::io::Error) -> bool {
+    if error.kind() == std::io::ErrorKind::Interrupted {
+        return true;
+    }
+    // Windows-only transient copy errors: ERROR_NO_SYSTEM_RESOURCES (1450),
+    // ERROR_SHARING_VIOLATION (32), ERROR_LOCK_VIOLATION (33). These raw codes
+    // are meaningful only on Windows; do not treat the same integers as transient
+    // on other platforms.
+    #[cfg(windows)]
+    if let Some(code) = error.raw_os_error() {
+        return matches!(code, 1450 | 32 | 33);
+    }
+    false
+}
+
+enum ActivationCopyError {
+    /// All attempts failed with whitelisted transient errors (retries exhausted).
+    Transient(std::io::Error),
+    /// A non-whitelisted error stopped retries immediately.
+    NonTransient(std::io::Error),
+}
+
+/// Run the activation copy up to `MANAGED_NODE_ACTIVATION_COPY_ATTEMPTS` times.
+/// Retries only whitelisted transient I/O errors, sleeping the backoff between
+/// attempts. Non-transient errors return immediately without retry.
+async fn activate_copy_with_retry<C>(mut copy: C) -> Result<(), ActivationCopyError>
+where
+    C: FnMut() -> std::io::Result<()>,
+{
+    for attempt in 1..=MANAGED_NODE_ACTIVATION_COPY_ATTEMPTS {
+        match copy() {
+            Ok(()) => return Ok(()),
+            Err(error) if !is_transient_activation_io_error(&error) => {
+                return Err(ActivationCopyError::NonTransient(error));
+            }
+            Err(error) => {
+                warn!(
+                    attempt,
+                    max_attempts = MANAGED_NODE_ACTIVATION_COPY_ATTEMPTS,
+                    error = %error,
+                    "transient node activation copy failure; will retry after backoff"
+                );
+                tokio::time::sleep(MANAGED_NODE_ACTIVATION_COPY_BACKOFFS[attempt - 1]).await;
+                if attempt == MANAGED_NODE_ACTIVATION_COPY_ATTEMPTS {
+                    return Err(ActivationCopyError::Transient(error));
+                }
+            }
+        }
+    }
+    // The loop always returns on the final attempt.
+    unreachable!("activation copy retry loop always returns on the final attempt")
 }
 
 fn classify_error(error: &NodeRuntimeError) -> (NodeRuntimeFailureKind, Option<u16>) {

--- a/crates/aionui-runtime/src/node_runtime/managed/tests.rs
+++ b/crates/aionui-runtime/src/node_runtime/managed/tests.rs
@@ -46,6 +46,24 @@ fn classify_error_detects_bundled_node_runtime_missing() {
     assert_eq!(status, None);
 }
 
+#[test]
+fn classify_error_prefers_explicit_activation_io_failed() {
+    let err = NodeRuntimeError::activation_io_failed(
+        "bundled Node runtime activation copy failed after retries under X: os error 1450",
+    );
+    let (kind, status) = classify_error(&err);
+    assert_eq!(kind, NodeRuntimeFailureKind::ActivationIoFailed);
+    assert_eq!(status, None);
+}
+
+#[test]
+fn classify_error_still_detects_bundled_invalid_by_message() {
+    // Post-copy validation failure keeps its existing semantics (spec 12 acceptance 4).
+    let err = NodeRuntimeError::managed_invalid("bundled Node runtime failed validation under X: boom");
+    let (kind, _status) = classify_error(&err);
+    assert_eq!(kind, NodeRuntimeFailureKind::BundledResourceInvalid);
+}
+
 #[tokio::test]
 async fn bundled_runtime_missing_reports_bundled_resource_missing() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/aionui-runtime/src/node_runtime/managed/tests.rs
+++ b/crates/aionui-runtime/src/node_runtime/managed/tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use std::cell::Cell;
+use std::io::{Error as IoError, ErrorKind};
 
 fn write_file(path: &Path) {
     if let Some(parent) = path.parent() {
@@ -44,6 +46,69 @@ fn classify_error_detects_bundled_node_runtime_missing() {
 
     assert_eq!(kind, NodeRuntimeFailureKind::BundledResourceMissing);
     assert_eq!(status, None);
+}
+
+#[test]
+fn transient_classifier_matches_only_whitelist() {
+    assert!(is_transient_activation_io_error(&IoError::from(ErrorKind::Interrupted)));
+    assert!(!is_transient_activation_io_error(&IoError::from(ErrorKind::NotFound)));
+    assert!(!is_transient_activation_io_error(&IoError::from(ErrorKind::PermissionDenied)));
+    #[cfg(windows)]
+    {
+        assert!(is_transient_activation_io_error(&IoError::from_raw_os_error(1450)));
+        assert!(is_transient_activation_io_error(&IoError::from_raw_os_error(32)));
+        assert!(is_transient_activation_io_error(&IoError::from_raw_os_error(33)));
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn activation_copy_retries_then_succeeds() {
+    let calls = Cell::new(0);
+    let result = activate_copy_with_retry(|| {
+        calls.set(calls.get() + 1);
+        if calls.get() == 1 {
+            Err(IoError::from(ErrorKind::Interrupted))
+        } else {
+            Ok(())
+        }
+    })
+    .await;
+    assert!(result.is_ok());
+    assert_eq!(calls.get(), 2);
+}
+
+#[tokio::test(start_paused = true)]
+async fn activation_copy_persistent_transient_exhausts_to_transient() {
+    let calls = Cell::new(0);
+    let result = activate_copy_with_retry(|| {
+        calls.set(calls.get() + 1);
+        Err(IoError::from(ErrorKind::Interrupted))
+    })
+    .await;
+    assert!(matches!(result, Err(ActivationCopyError::Transient(_))));
+    assert_eq!(calls.get(), MANAGED_NODE_ACTIVATION_COPY_ATTEMPTS); // exactly 3 attempts
+}
+
+#[tokio::test(start_paused = true)]
+async fn activation_copy_non_whitelisted_is_not_retried() {
+    let calls = Cell::new(0);
+    let result = activate_copy_with_retry(|| {
+        calls.set(calls.get() + 1);
+        Err(IoError::from(ErrorKind::PermissionDenied))
+    })
+    .await;
+    assert!(matches!(result, Err(ActivationCopyError::NonTransient(_))));
+    assert_eq!(calls.get(), 1); // stops immediately, no retry, no ActivationIoFailed
+}
+
+#[test]
+fn activation_copy_backoff_schedule_is_local_specific() {
+    use std::time::Duration;
+    assert_eq!(MANAGED_NODE_ACTIVATION_COPY_ATTEMPTS, 3);
+    assert_eq!(
+        MANAGED_NODE_ACTIVATION_COPY_BACKOFFS,
+        [Duration::from_millis(250), Duration::from_millis(500), Duration::from_millis(1000)]
+    );
 }
 
 #[test]

--- a/crates/aionui-runtime/src/node_runtime/managed/tests.rs
+++ b/crates/aionui-runtime/src/node_runtime/managed/tests.rs
@@ -52,7 +52,9 @@ fn classify_error_detects_bundled_node_runtime_missing() {
 fn transient_classifier_matches_only_whitelist() {
     assert!(is_transient_activation_io_error(&IoError::from(ErrorKind::Interrupted)));
     assert!(!is_transient_activation_io_error(&IoError::from(ErrorKind::NotFound)));
-    assert!(!is_transient_activation_io_error(&IoError::from(ErrorKind::PermissionDenied)));
+    assert!(!is_transient_activation_io_error(&IoError::from(
+        ErrorKind::PermissionDenied
+    )));
     #[cfg(windows)]
     {
         assert!(is_transient_activation_io_error(&IoError::from_raw_os_error(1450)));
@@ -107,7 +109,11 @@ fn activation_copy_backoff_schedule_is_local_specific() {
     assert_eq!(MANAGED_NODE_ACTIVATION_COPY_ATTEMPTS, 3);
     assert_eq!(
         MANAGED_NODE_ACTIVATION_COPY_BACKOFFS,
-        [Duration::from_millis(250), Duration::from_millis(500), Duration::from_millis(1000)]
+        [
+            Duration::from_millis(250),
+            Duration::from_millis(500),
+            Duration::from_millis(1000)
+        ]
     );
 }
 

--- a/crates/aionui-runtime/src/node_runtime/types.rs
+++ b/crates/aionui-runtime/src/node_runtime/types.rs
@@ -92,6 +92,10 @@ pub enum NodeRuntimeFailureKind {
     UnsupportedPlatform,
     BundledResourceMissing,
     BundledResourceInvalid,
+    /// Transient copy/activation I/O failure that persisted past the bounded
+    /// retry budget. Distinct from a missing/corrupt bundled resource: the
+    /// resource is present and may self-heal, so this must NOT drive a reinstall.
+    ActivationIoFailed,
     Unknown,
 }
 

--- a/crates/aionui-runtime/src/node_runtime/types.rs
+++ b/crates/aionui-runtime/src/node_runtime/types.rs
@@ -210,30 +210,47 @@ pub struct DoctorRow {
 #[error("{message}")]
 pub struct NodeRuntimeError {
     message: String,
+    failure_kind: Option<NodeRuntimeFailureKind>,
 }
 
 impl NodeRuntimeError {
     pub fn system_invalid(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
+            failure_kind: None,
         }
     }
 
     pub fn managed_invalid(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
+            failure_kind: None,
         }
     }
 
     pub fn unsupported_platform(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
+            failure_kind: None,
         }
     }
 
     pub fn io_system(error: std::io::Error) -> Self {
         Self {
             message: error.to_string(),
+            failure_kind: None,
         }
+    }
+
+    /// Persistent transient copy/activation I/O failure (retries exhausted).
+    pub fn activation_io_failed(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            failure_kind: Some(NodeRuntimeFailureKind::ActivationIoFailed),
+        }
+    }
+
+    pub fn failure_kind(&self) -> Option<NodeRuntimeFailureKind> {
+        self.failure_kind
     }
 }

--- a/crates/aionui-system/src/runtime_prepare.rs
+++ b/crates/aionui-system/src/runtime_prepare.rs
@@ -94,6 +94,7 @@ fn map_failure_kind(kind: NodeRuntimeFailureKind) -> RuntimeFailureKind {
         NodeRuntimeFailureKind::UnsupportedPlatform => RuntimeFailureKind::UnsupportedPlatform,
         NodeRuntimeFailureKind::BundledResourceMissing => RuntimeFailureKind::BundledResourceMissing,
         NodeRuntimeFailureKind::BundledResourceInvalid => RuntimeFailureKind::BundledResourceInvalid,
+        NodeRuntimeFailureKind::ActivationIoFailed => RuntimeFailureKind::ActivationIoFailed,
         NodeRuntimeFailureKind::Unknown => RuntimeFailureKind::Unknown,
     }
 }


### PR DESCRIPTION
## Summary

Fixes the root cause of a misleading "AionUi installation is incomplete — please reinstall" alert (Sentry issue [ELECTRON-2QS](https://iofficeai.sentry.io/issues/ELECTRON-2QS), 95 users / 152 events).

A **transient** Windows file-copy error (`os error 1450`, `ERROR_NO_SYSTEM_RESOURCES`) raised while recursively copying the bundled Node runtime into the user's AppData directory was unconditionally wrapped as "bundled Node runtime is invalid" and classified as the permanent `BundledResourceInvalid` install-integrity failure. Logs show the same runtime self-healed and activated ~10.7s later, so the resource was intact — the failure was a recoverable, retryable I/O condition, not corruption.

This change distinguishes transient copy I/O from a missing/corrupt resource at the `io::Error` layer, adds a bounded retry with backoff on a conservative transient whitelist, and introduces a new failure kind `ActivationIoFailed` so persistent transient failures are no longer reported as `BundledResourceInvalid`. Real-corruption detection is preserved.

This is the root-cause half of a coordinated two-repository fix. The companion AionUi PR adds defense-in-depth reconciliation on the renderer side and consumes the new `activation_io_failed` wire value. AionUi degrades gracefully if this PR is not yet merged (unknown failure-kind strings render via the generic path).

## Changes

- **New failure kind `ActivationIoFailed`** threaded across the failure-kind wire contract:
  - internal enum `NodeRuntimeFailureKind` (`aionui-runtime`)
  - wire enum `RuntimeFailureKind` (`aionui-api-types`, serde `snake_case` → `activation_io_failed`)
  - the three compiler-enforced exhaustive `map_failure_kind` mappers (`aionui-ai-agent`, `aionui-system`, and `aionui-mcp` connection test)
- **Explicit failure kind carried on `NodeRuntimeError`**: added a `failure_kind` field, an `activation_io_failed(..)` constructor, and a `failure_kind()` accessor. `classify_error` now prefers the explicit kind instead of relying on error-message substrings to tell a copy failure from a validation failure.
- **Bounded retry + backoff for the local activation copy**: dedicated constants (`MANAGED_NODE_ACTIVATION_COPY_ATTEMPTS = 3`, backoff `[250ms, 500ms, 1000ms]`, separate from the download constants), a conservative transient classifier `is_transient_activation_io_error` (`ErrorKind::Interrupted` + Windows `raw_os_error ∈ {1450, 32, 33}` only), an `ActivationCopyError { Transient, NonTransient }` split, and an async retry helper.
  - Retry succeeds → normal activation, no `failed` event broadcast.
  - Whitelisted transient error, retries exhausted → `ActivationIoFailed` (not `BundledResourceInvalid`).
  - Non-whitelisted error (`PermissionDenied`, source `NotFound`, …) → stop immediately, preserving existing hard-failure / `BundledResourceMissing` semantics.
- **Real-corruption detection preserved**: a missing source directory still maps to `BundledResourceMissing`; a post-copy `validate_managed_runtime` failure still maps to `BundledResourceInvalid` / `ValidationFailed`.
- **`Cargo.toml`**: `aionui-runtime` enables the tokio `test-util` feature (dev) so `start_paused = true` retry/backoff tests run without wall-clock delay.
- **Logging**: retry attempts, the final transient decision, and non-transient failures all emit production-visible `warn`-level logs.

No database/schema change. No new user-facing strings.

## Testing

All checks judged by exit code (see archived `test-runs.json`):

- `cargo test -p aionui-api-types` — PASS (incl. new `activation_io_failed_serializes_to_snake_case`)
- `cargo test -p aionui-ai-agent -p aionui-system -p aionui-mcp` — PASS (three exhaustive mappers compile)
- `cargo test -p aionui-runtime` — PASS (90 passed; incl. new `transient_classifier_matches_only_whitelist`, `activation_copy_retries_then_succeeds`, `activation_copy_persistent_transient_exhausts_to_transient`, `activation_copy_non_whitelisted_is_not_retried`, `activation_copy_backoff_schedule_is_local_specific`, `classify_error_prefers_explicit_activation_io_failed`, `classify_error_still_detects_bundled_invalid_by_message`)
- `cargo fmt --all -- --check` — PASS
- `cargo clippy --workspace --all-targets -- -D warnings` — PASS
- `cargo nextest run --workspace --no-run` — PASS (entire workspace test set compiles)
- `cargo nextest run -p aionui-runtime -p aionui-api-types -p aionui-ai-agent -p aionui-system` — PASS (1764 tests, 0 failed)
- migration immutability check — PASS

## Caveats

- The Windows-only transient branch (`#[cfg(windows)]`, codes `1450/32/33`) does not compile on non-Windows CI; a Windows smoke test to exercise it is recommended.
- End-to-end transient-then-self-heal acceptance was manually confirmed on macOS (using `ErrorKind::Interrupted` to drive the same retry/classification path, since `os error 1450` is not reproducible off Windows) but is not automated.
- Retry adds at most ~1.75s to worst-case startup (3 attempts + `250/500/1000ms` backoff); the upper bound is deliberately capped.
