### PR TITLE
fix(server): emit AIONCORE_READY marker once serving begins

### DIFF
--- a/crates/aionui-app/src/commands/cmd_server.rs
+++ b/crates/aionui-app/src/commands/cmd_server.rs
@@ -18,6 +18,12 @@ use aionui_team::TeamIdleCleanupCoordinator;
 use crate::bootstrap::{BootstrapError, BootstrapErrorCode, ParentExitSignal, ServerEnvironment};
 
 const LISTENING_EVENT_PREFIX: &str = "AIONCORE_LISTENING";
+// Bare, payload-less readiness marker emitted once `axum::serve` actually begins
+// serving. The port is already known from the earlier AIONCORE_LISTENING line,
+// so this marker only signals the "now serving" edge. AionUi treats it as the
+// authoritative ready signal, eliminating the "listening early, serving late"
+// false gap.
+const READY_EVENT_MARKER: &str = "AIONCORE_READY";
 const DYNAMIC_BACKEND_BIND_MAX_ATTEMPTS: usize = 50;
 const WORKER_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -199,6 +205,15 @@ fn emit_listening_event(addr: SocketAddr) {
     let _ = io::stdout().flush();
 }
 
+fn format_ready_event() -> String {
+    READY_EVENT_MARKER.to_string()
+}
+
+fn emit_ready_event() {
+    println!("{}", format_ready_event());
+    let _ = io::stdout().flush();
+}
+
 /// Start the HTTP server with fully constructed services.
 pub(crate) async fn run_server(
     env: ServerEnvironment,
@@ -288,6 +303,12 @@ pub(crate) async fn run_server(
     let conversation_runtime_state = services.conversation_runtime_state.clone();
     let worker_task_manager = services.worker_task_manager.clone();
     let client_pref_service = router_runtime.client_pref_service.clone();
+
+    // All initialization is complete and we are about to begin serving. Emit the
+    // authoritative readiness marker now (never at bind time) so AionUi can treat
+    // it as "ready" without racing the /health poll against the startup clock.
+    emit_ready_event();
+    info!("startup: server ready, emitted AIONCORE_READY");
 
     axum::serve(listener, router)
         .with_graceful_shutdown(async move {
@@ -440,6 +461,19 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(payload).expect("payload should be valid JSON");
         assert_eq!(parsed["host"], "127.0.0.1");
         assert_eq!(parsed["port"], 49153);
+    }
+
+    #[test]
+    fn ready_event_line_is_bare_marker() {
+        let line = format_ready_event();
+
+        // Bare marker: exactly the constant, no payload and no whitespace.
+        assert_eq!(line, READY_EVENT_MARKER);
+        assert_eq!(line, "AIONCORE_READY");
+        assert!(!line.contains(' '));
+        // Distinct from the listening event prefix, which carries a JSON payload.
+        assert_ne!(line, LISTENING_EVENT_PREFIX);
+        assert!(!line.starts_with(&format!("{LISTENING_EVENT_PREFIX} ")));
     }
 
     #[test]


### PR DESCRIPTION
## Description

AionCore printed the `AIONCORE_LISTENING` marker at bind time — before
`axum::serve` actually began serving requests (the data layer, services, and
router are built after bind). The AionUi desktop client started its ~30s backend
health clock from that premature signal, producing a false "listening early,
serving late" gap that could trip a health-check timeout and surface a
misleading "incomplete installation / please reinstall" dialog to users
(Sentry ELECTRON-2PM, issue 127971136).

This change adds a new authoritative readiness marker, `AIONCORE_READY`, emitted
exactly once — after all initialization completes and immediately before
`axum::serve`. `AIONCORE_LISTENING` is retained for the port report at bind time
and does not emit readiness.

### Changes

- `crates/aionui-app/src/commands/cmd_server.rs`:
  - Add `READY_EVENT_MARKER = "AIONCORE_READY"` plus `format_ready_event` /
    `emit_ready_event`.
  - Emit the bare `AIONCORE_READY` marker (whole line, no payload) at the single
    point after initialization and before `axum::serve`, with an accompanying
    `info!` lifecycle log on the ready edge (no sensitive payload).
  - Unit test `ready_event_line_is_bare_marker` pins the bare marker format and
    its distinction from `AIONCORE_LISTENING`; the existing
    `listening_event_line_is_machine_readable` test is retained.

The marker is consumed by the companion AionUi change of the same version. It is
a new protocol marker with no fallback shim, so the two repositories must ship
bundled together.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Local Checks

- [x] `cargo fmt --all -- --check` — passes
- [x] `cargo clippy -p aionui-app -- -D warnings` — clean
- [x] `cargo test -p aionui-app --lib --bins` — passes (includes
      `ready_event_line_is_bare_marker`)

## Additional Context

- No database migration; no schema change.
- Info-level lifecycle log added on the ready edge, consistent with the project
  Logging rules (no sensitive payload).
- Sentry ELECTRON-2PM (127971136). No GitHub issue number.
- Must be released bundled with the same-version AionUi change.
