### PR TITLE
feat(fs): pdf stream endpoint + office ChatFileRef resolve + retire fs/resolve & WS fs/read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
  "walkdir",
@@ -740,7 +741,9 @@ dependencies = [
  "aionui-api-types",
  "aionui-auth",
  "aionui-common",
+ "aionui-db",
  "aionui-file",
+ "aionui-project",
  "aionui-realtime",
  "aionui-runtime",
  "async-trait",
@@ -3122,6 +3125,12 @@ dependencies = [
  "http-body 1.0.1",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -5844,11 +5853,19 @@ checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.8" }
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8", features = ["multipart", "ws"] }
 tower = { version = "0.5" }
-tower-http = { version = "0.6", features = ["cors", "trace", "limit"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "limit", "fs"] }
 http = "1"
 
 # Serialization

--- a/crates/aionui-api-types/src/file.rs
+++ b/crates/aionui-api-types/src/file.rs
@@ -48,6 +48,46 @@ pub struct ContentMetadataRequest {
     pub file: ChatFileRef,
 }
 
+/// Query parameters for `GET /api/fs/stream` — a flattened [`ChatFileRef`].
+///
+/// The stream endpoint is a raw byte range server for `<webview src>` / `<embed>`
+/// (pdf), which can only issue a GET with no body, so the identity travels in the
+/// query string. `kind` selects the variant; the other fields carry its payload.
+#[derive(Debug, Deserialize)]
+pub struct StreamQuery {
+    pub kind: String,
+    #[serde(default)]
+    pub pe_id: Option<String>,
+    #[serde(default)]
+    pub relative_path: Option<String>,
+    #[serde(default)]
+    pub path: Option<String>,
+}
+
+impl StreamQuery {
+    /// Rebuild the [`ChatFileRef`] from the flattened query, or return a message
+    /// naming the missing/invalid field.
+    pub fn to_chat_file_ref(&self) -> Result<ChatFileRef, &'static str> {
+        match self.kind.as_str() {
+            "project" => match (self.pe_id.clone(), self.relative_path.clone()) {
+                (Some(pe_id), Some(relative_path)) => Ok(ChatFileRef::Project { pe_id, relative_path }),
+                _ => Err("project stream requires pe_id and relative_path"),
+            },
+            "upload" => self
+                .path
+                .clone()
+                .map(|path| ChatFileRef::Upload { path })
+                .ok_or("upload stream requires path"),
+            "local" => self
+                .path
+                .clone()
+                .map(|path| ChatFileRef::Local { path })
+                .ok_or("local stream requires path"),
+            _ => Err("unknown stream kind (expected project|upload|local)"),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // A. Core file operations — Request DTOs
 // ---------------------------------------------------------------------------

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -114,8 +114,8 @@ pub use file::{
     DirOrFileResponse, FetchRemoteImageRequest, FileChangeInfoResponse, FileMetadataResponse, FileWatchRequest,
     GetFileMetadataRequest, GetFilesByDirRequest, GetImageBase64Request, ListWorkspaceFilesRequest, ReadContentRequest,
     ReadFileRequest, RevealItemRequest, SnapshotBaselineRequest, SnapshotCompareResponse, SnapshotDiscardRequest,
-    SnapshotInfoResponse, SnapshotMode, SnapshotStageRequest, SnapshotWorkspaceRequest, WorkspaceFlatFileResponse,
-    WorkspaceOfficeWatchRequest, WriteContentRequest, WriteFileRequest,
+    SnapshotInfoResponse, SnapshotMode, SnapshotStageRequest, SnapshotWorkspaceRequest, StreamQuery,
+    WorkspaceFlatFileResponse, WorkspaceOfficeWatchRequest, WriteContentRequest, WriteFileRequest,
 };
 pub use lifecycle::{GitHubReleaseAsset, SystemInfoResponse, UpdateCheckRequest, UpdateCheckResult, UpdateReleaseInfo};
 pub use mcp::{

--- a/crates/aionui-api-types/src/office.rs
+++ b/crates/aionui-api-types/src/office.rs
@@ -1,15 +1,24 @@
 use aionui_common::PreviewContentType;
 use serde::{Deserialize, Serialize};
 
+use crate::chat_file::ChatFileRef;
+
 // ---------------------------------------------------------------------------
 // A. Preview requests
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct StartPreviewRequest {
+    /// Legacy device-path identity. Retained for the frontend migration window;
+    /// used when `file` is absent. Remove once all callers send `file`.
     pub file_path: String,
     #[serde(default)]
     pub workspace: Option<String>,
+    /// Preferred identity: a [`ChatFileRef`] the backend resolves to an absolute
+    /// path (keeps pe→path resolution server-side). When present it takes
+    /// precedence over `file_path`.
+    #[serde(default)]
+    pub file: Option<ChatFileRef>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/aionui-api-types/src/office.rs
+++ b/crates/aionui-api-types/src/office.rs
@@ -23,7 +23,15 @@ pub struct StartPreviewRequest {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct StopPreviewRequest {
+    /// Legacy device-path identity. Retained for the frontend migration window;
+    /// used when `file` is absent. Remove once all callers send `file`.
     pub file_path: String,
+    /// Preferred identity: a [`ChatFileRef`] the backend resolves to an absolute
+    /// path (keeps pe→path resolution server-side). When present it takes
+    /// precedence over `file_path`. Must resolve to the same path `start` used,
+    /// so the watch session is stopped by the same key.
+    #[serde(default)]
+    pub file: Option<ChatFileRef>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -870,6 +870,7 @@ pub fn build_office_state(services: &AppServices) -> OfficeRouterState {
         conversion_service,
         proxy_service,
         allowed_roots,
+        project: Arc::new(services.project_service.clone()),
     }
 }
 

--- a/crates/aionui-app/tests/file_e2e.rs
+++ b/crates/aionui-app/tests/file_e2e.rs
@@ -1177,7 +1177,11 @@ async fn stream_serves_full_file_with_content_type() {
     std::fs::write(&fp, bytes).unwrap();
 
     let uri = format!("/api/fs/stream?kind=local&path={}", fp.to_str().unwrap());
-    let resp = app.clone().oneshot(get_with_token(&uri, &token, &csrf, None)).await.unwrap();
+    let resp = app
+        .clone()
+        .oneshot(get_with_token(&uri, &token, &csrf, None))
+        .await
+        .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     assert_eq!(
         resp.headers().get("content-type").unwrap().to_str().unwrap(),

--- a/crates/aionui-app/tests/file_e2e.rs
+++ b/crates/aionui-app/tests/file_e2e.rs
@@ -1147,3 +1147,84 @@ async fn content_write_if_match_matches_and_conflicts() {
     // File is unchanged by the rejected write.
     assert_eq!(std::fs::read_to_string(&fp).unwrap(), "v1");
 }
+
+// ===========================================================================
+// GET /api/fs/stream — raw byte range server (ChatFileRef via query)
+// ===========================================================================
+
+/// GET request with auth headers and an optional `Range`.
+fn get_with_token(uri: &str, token: &str, csrf: &str, range: Option<&str>) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .header("x-csrf-token", csrf)
+        .header("cookie", format!("aionui-csrf-token={csrf}"));
+    if let Some(r) = range {
+        builder = builder.header("range", r);
+    }
+    builder.body(Body::empty()).unwrap()
+}
+
+#[tokio::test]
+async fn stream_serves_full_file_with_content_type() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let fp = dir.path().join("doc.pdf");
+    let bytes = b"%PDF-1.4 hello stream body";
+    std::fs::write(&fp, bytes).unwrap();
+
+    let uri = format!("/api/fs/stream?kind=local&path={}", fp.to_str().unwrap());
+    let resp = app.clone().oneshot(get_with_token(&uri, &token, &csrf, None)).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get("content-type").unwrap().to_str().unwrap(),
+        "application/pdf"
+    );
+    assert_eq!(
+        resp.headers().get("accept-ranges").map(|v| v.to_str().unwrap()),
+        Some("bytes")
+    );
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(body.as_ref(), bytes);
+}
+
+#[tokio::test]
+async fn stream_honors_range_returns_206_partial() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "admin", "StrongP@ss1").await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let fp = dir.path().join("range.bin");
+    let bytes: &[u8] = b"0123456789";
+    std::fs::write(&fp, bytes).unwrap();
+
+    let uri = format!("/api/fs/stream?kind=local&path={}", fp.to_str().unwrap());
+    let resp = app
+        .clone()
+        .oneshot(get_with_token(&uri, &token, &csrf, Some("bytes=0-3")))
+        .await
+        .unwrap();
+    // ServeFile answers a Range request with 206 Partial Content.
+    assert_eq!(resp.status(), StatusCode::PARTIAL_CONTENT);
+    let content_range = resp.headers().get("content-range").unwrap().to_str().unwrap();
+    assert_eq!(content_range, "bytes 0-3/10");
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(body.as_ref(), b"0123");
+}
+
+#[tokio::test]
+async fn stream_requires_auth() {
+    let (app, _services) = build_app().await;
+    let dir = tempfile::tempdir().unwrap();
+    let fp = dir.path().join("x.pdf");
+    std::fs::write(&fp, b"x").unwrap();
+    let uri = format!("/api/fs/stream?kind=local&path={}", fp.to_str().unwrap());
+    let req = Request::builder().method("GET").uri(&uri).body(Body::empty()).unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    // GET has no CSRF layer (unlike the POST endpoints, which 403 on missing
+    // CSRF); the auth middleware rejects the missing token with 401.
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}

--- a/crates/aionui-app/tests/office_e2e.rs
+++ b/crates/aionui-app/tests/office_e2e.rs
@@ -49,13 +49,21 @@ async fn build_office_app_with_roots(
     let services = AppServices::from_config(db, &config).await.unwrap();
     let (mut states, _) = build_module_states(&services).await.expect("build module states");
 
-    states.office = build_test_office_state(tmp.path(), allowed_roots);
+    states.office = build_test_office_state(
+        tmp.path(),
+        allowed_roots,
+        std::sync::Arc::new(services.project_service.clone()),
+    );
 
     let router = create_router_with_states(&services, states);
     (router, services, tmp)
 }
 
-fn build_test_office_state(data_dir: &std::path::Path, allowed_roots: Vec<std::path::PathBuf>) -> OfficeRouterState {
+fn build_test_office_state(
+    data_dir: &std::path::Path,
+    allowed_roots: Vec<std::path::PathBuf>,
+    project: std::sync::Arc<aionui_project::ProjectService>,
+) -> OfficeRouterState {
     use aionui_office::error::OfficeError;
     use aionui_office::types::DocType;
     use aionui_office::{ProcessHandle, ProcessSpawner};
@@ -102,6 +110,7 @@ fn build_test_office_state(data_dir: &std::path::Path, allowed_roots: Vec<std::p
         conversion_service: conversion,
         proxy_service: proxy,
         allowed_roots,
+        project,
     }
 }
 

--- a/crates/aionui-file/Cargo.toml
+++ b/crates/aionui-file/Cargo.toml
@@ -12,6 +12,7 @@ aionui-realtime.workspace = true
 async-trait.workspace = true
 axum.workspace = true
 tokio.workspace = true
+tower.workspace = true
 tower-http.workspace = true
 walkdir.workspace = true
 ignore.workspace = true

--- a/crates/aionui-file/src/routes.rs
+++ b/crates/aionui-file/src/routes.rs
@@ -2,18 +2,21 @@
 
 use axum::Router;
 use axum::extract::rejection::JsonRejection;
-use axum::extract::{DefaultBodyLimit, Extension, Json, Multipart, State};
-use axum::routing::post;
+use axum::extract::{DefaultBodyLimit, Extension, Json, Multipart, Query, Request, State};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use tower::ServiceExt;
 use tower_http::limit::RequestBodyLimitLayer;
+use tower_http::services::ServeFile;
 
 use aionui_api_types::{
     ApiResponse, ContentMetadataRequest, CopyFilesRequest, CopyFilesResponse, DirOrFileResponse,
     FetchRemoteImageRequest, FileChangeInfoResponse, FileMetadataResponse, FileWatchRequest, GetFileMetadataRequest,
     GetFilesByDirRequest, GetImageBase64Request, ListWorkspaceFilesRequest, ReadContentRequest, ReadFileRequest,
     RevealItemRequest, SnapshotBaselineRequest, SnapshotCompareResponse, SnapshotDiscardRequest, SnapshotInfoResponse,
-    SnapshotStageRequest, SnapshotWorkspaceRequest, WorkspaceFlatFileResponse, WorkspaceOfficeWatchRequest,
+    SnapshotStageRequest, SnapshotWorkspaceRequest, StreamQuery, WorkspaceFlatFileResponse, WorkspaceOfficeWatchRequest,
     WriteContentRequest, WriteFileRequest,
 };
 use aionui_auth::CurrentUser;
@@ -115,6 +118,7 @@ pub fn file_routes(state: FileRouterState) -> Router {
     Router::new()
         // A. Core file operations
         .route("/api/fs/content/metadata", post(content_metadata))
+        .route("/api/fs/stream", get(stream_file))
         .route("/api/fs/dir", post(get_files_by_dir))
         .route("/api/fs/list", post(list_workspace_files))
         .route("/api/fs/metadata", post(get_file_metadata))
@@ -397,6 +401,36 @@ async fn content_metadata(
         .map_err(ApiError::from)?;
     let meta = state.file_service.resolved_metadata(Path::new(&abs)).await?;
     Ok(Json(ApiResponse::ok(to_metadata_response(meta))))
+}
+
+/// `GET /api/fs/stream` — raw byte range server for a `ChatFileRef`-addressed
+/// file, for `<webview src>` / `<embed>` consumers (pdf) that can only GET.
+///
+/// The identity is a flattened [`StreamQuery`] in the query string (webview src
+/// has no request body). Resolves per-variant (op = Read) to a trusted absolute
+/// path, then hands the request to `tower_http`'s `ServeFile`, which supplies
+/// `Content-Type` (from the extension), `Accept-Ranges`, and full `Range` /
+/// `If-Range` handling (206 Partial Content) — including large-file byte ranges.
+async fn stream_file(
+    State(state): State<FileRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    request: Request,
+) -> Result<Response, ApiError> {
+    let Query(params) =
+        Query::<StreamQuery>::try_from_uri(request.uri()).map_err(|e| ApiError::BadRequest(e.to_string()))?;
+    let file_ref = params.to_chat_file_ref().map_err(|m| ApiError::BadRequest(m.to_owned()))?;
+    let abs = state
+        .project
+        .resolve_chat_file_ref(&user.id, &file_ref, &content_upload_root(), aionui_project::FileOp::Read)
+        .await
+        .map_err(ApiError::from)?;
+    // ServeFile owns Range/If-Range/Content-Type; the path is already
+    // containment-checked by resolve_chat_file_ref, so no re-sandbox here.
+    let response = ServeFile::new(&abs)
+        .oneshot(request)
+        .await
+        .map_err(|e| ApiError::Internal(format!("stream task failed: {e}")))?;
+    Ok(response.into_response())
 }
 
 /// Fields extracted from a `/api/fs/upload` multipart request.

--- a/crates/aionui-file/src/routes.rs
+++ b/crates/aionui-file/src/routes.rs
@@ -16,8 +16,8 @@ use aionui_api_types::{
     FetchRemoteImageRequest, FileChangeInfoResponse, FileMetadataResponse, FileWatchRequest, GetFileMetadataRequest,
     GetFilesByDirRequest, GetImageBase64Request, ListWorkspaceFilesRequest, ReadContentRequest, ReadFileRequest,
     RevealItemRequest, SnapshotBaselineRequest, SnapshotCompareResponse, SnapshotDiscardRequest, SnapshotInfoResponse,
-    SnapshotStageRequest, SnapshotWorkspaceRequest, StreamQuery, WorkspaceFlatFileResponse, WorkspaceOfficeWatchRequest,
-    WriteContentRequest, WriteFileRequest,
+    SnapshotStageRequest, SnapshotWorkspaceRequest, StreamQuery, WorkspaceFlatFileResponse,
+    WorkspaceOfficeWatchRequest, WriteContentRequest, WriteFileRequest,
 };
 use aionui_auth::CurrentUser;
 use aionui_common::ApiError;
@@ -418,10 +418,17 @@ async fn stream_file(
 ) -> Result<Response, ApiError> {
     let Query(params) =
         Query::<StreamQuery>::try_from_uri(request.uri()).map_err(|e| ApiError::BadRequest(e.to_string()))?;
-    let file_ref = params.to_chat_file_ref().map_err(|m| ApiError::BadRequest(m.to_owned()))?;
+    let file_ref = params
+        .to_chat_file_ref()
+        .map_err(|m| ApiError::BadRequest(m.to_owned()))?;
     let abs = state
         .project
-        .resolve_chat_file_ref(&user.id, &file_ref, &content_upload_root(), aionui_project::FileOp::Read)
+        .resolve_chat_file_ref(
+            &user.id,
+            &file_ref,
+            &content_upload_root(),
+            aionui_project::FileOp::Read,
+        )
         .await
         .map_err(ApiError::from)?;
     // ServeFile owns Range/If-Range/Content-Type; the path is already

--- a/crates/aionui-office/Cargo.toml
+++ b/crates/aionui-office/Cargo.toml
@@ -9,6 +9,7 @@ aionui-api-types.workspace = true
 aionui-realtime.workspace = true
 aionui-auth.workspace = true
 aionui-file.workspace = true
+aionui-project.workspace = true
 aionui-runtime.workspace = true
 axum.workspace = true
 tokio.workspace = true
@@ -26,4 +27,5 @@ async-trait.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 rust_xlsxwriter.workspace = true
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
+aionui-db.workspace = true

--- a/crates/aionui-office/src/routes.rs
+++ b/crates/aionui-office/src/routes.rs
@@ -137,8 +137,22 @@ async fn start_preview(
     doc_type: DocType,
 ) -> Result<Json<ApiResponse<PreviewUrlResponse>>, ApiError> {
     let Json(req) = body.map_err(ApiError::from)?;
-    let validated_path = validate_office_path(&state, &req.file_path, req.workspace.as_deref())?;
-    let validated_path = validated_path.to_string_lossy().into_owned();
+    // Prefer the ChatFileRef identity (resolved server-side, already
+    // containment-checked per variant); fall back to the legacy device path +
+    // office sandbox validation for callers that have not migrated yet.
+    let validated_path = match &req.file {
+        Some(file) => {
+            let upload_root = std::env::temp_dir().join("aionui");
+            state
+                .project
+                .resolve_chat_file_ref(user_id, file, &upload_root, aionui_project::FileOp::Read)
+                .await
+                .map_err(ApiError::from)?
+        }
+        None => validate_office_path(&state, &req.file_path, req.workspace.as_deref())?
+            .to_string_lossy()
+            .into_owned(),
+    };
 
     let result = state
         .watch_manager
@@ -371,15 +385,15 @@ mod tests {
 
     use super::{ApiError, file_error_to_api_error, office_proxy_routes, office_routes};
 
-    #[test]
-    fn office_routes_builds_without_panic() {
-        let state = build_test_state();
+    #[tokio::test]
+    async fn office_routes_builds_without_panic() {
+        let state = build_test_state().await;
         let _router = office_routes(state);
     }
 
-    #[test]
-    fn office_proxy_routes_builds_without_panic() {
-        let state = build_test_state();
+    #[tokio::test]
+    async fn office_proxy_routes_builds_without_panic() {
+        let state = build_test_state().await;
         let _router = office_proxy_routes(state);
     }
 
@@ -468,7 +482,7 @@ mod tests {
         assert!(matches!(err, ApiError::BadGateway(_)));
     }
 
-    fn build_test_state() -> OfficeRouterState {
+    async fn build_test_state() -> OfficeRouterState {
         struct NoopSpawner;
 
         #[async_trait::async_trait]
@@ -505,12 +519,17 @@ mod tests {
         let conversion = Arc::new(ConversionService::new(None));
         let proxy = Arc::new(ProxyService::new(wm.clone()));
 
+        let db = aionui_db::init_database_memory().await.unwrap();
+        let store: Arc<dyn aionui_db::IProjectStore> = Arc::new(aionui_db::SqliteProjectStore::new(db.pool().clone()));
+        let project = Arc::new(aionui_project::ProjectService::new(store, std::env::temp_dir()));
+
         OfficeRouterState {
             watch_manager: wm,
             snapshot_service: snapshot,
             conversion_service: conversion,
             proxy_service: proxy,
             allowed_roots: vec![std::env::temp_dir()],
+            project,
         }
     }
 }

--- a/crates/aionui-office/src/routes.rs
+++ b/crates/aionui-office/src/routes.rs
@@ -180,10 +180,23 @@ async fn stop_preview(
     doc_type: DocType,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
     let Json(req) = body.map_err(ApiError::from)?;
-    state
-        .watch_manager
-        .stop_for_user(user_id, &req.file_path, doc_type)
-        .await;
+    // Resolve the same identity `start_preview` used so `stop_for_user` derives
+    // the same session key (watch_manager re-canonicalizes internally). Prefer
+    // the ChatFileRef; fall back to the legacy device path. Post-migration the
+    // explorer office tab has only a ChatFileRef (no device path), so without
+    // this branch stop can't match the watch and the officecli subprocess leaks.
+    let target_path = match &req.file {
+        Some(file) => {
+            let upload_root = std::env::temp_dir().join("aionui");
+            state
+                .project
+                .resolve_chat_file_ref(user_id, file, &upload_root, aionui_project::FileOp::Read)
+                .await
+                .map_err(ApiError::from)?
+        }
+        None => req.file_path.clone(),
+    };
+    state.watch_manager.stop_for_user(user_id, &target_path, doc_type).await;
     Ok(Json(ApiResponse::success()))
 }
 

--- a/crates/aionui-office/src/state.rs
+++ b/crates/aionui-office/src/state.rs
@@ -13,4 +13,7 @@ pub struct OfficeRouterState {
     pub conversion_service: Arc<ConversionService>,
     pub proxy_service: Arc<ProxyService>,
     pub allowed_roots: Vec<PathBuf>,
+    /// Resolves a `ChatFileRef` preview target to an absolute path server-side
+    /// (`start_preview`), so pe→path resolution stays on the backend.
+    pub project: Arc<aionui_project::ProjectService>,
 }

--- a/crates/aionui-project/src/monitor/actor_test.rs
+++ b/crates/aionui-project/src/monitor/actor_test.rs
@@ -223,142 +223,6 @@ async fn subscribe_parent_escape_is_invalid_relative_path() {
 }
 
 #[tokio::test]
-async fn read_existing_file_returns_utf8() {
-    let (mut actor, _rx, push, pe, dir, _db) = setup().await;
-    std::fs::write(dir.path().join("a.txt"), b"hello").unwrap();
-
-    actor
-        .dispatch_frame(
-            "1",
-            "system_default_user",
-            request(4, "fs/read", json!({"file":dir_ref(&pe, "a.txt")})),
-        )
-        .await;
-    let reply = push.last_for("1").unwrap();
-    assert_eq!(reply["result"]["content"], "hello");
-    assert_eq!(reply["result"]["encoding"], "utf-8");
-}
-
-#[tokio::test]
-async fn read_missing_file_is_resource_not_found() {
-    let (mut actor, _rx, push, pe, _dir, _db) = setup().await;
-    actor
-        .dispatch_frame(
-            "1",
-            "system_default_user",
-            request(5, "fs/read", json!({"file":dir_ref(&pe, "missing.txt")})),
-        )
-        .await;
-    let reply = push.last_for("1").unwrap();
-    assert_eq!(reply["error"]["code"], -32002);
-    assert_eq!(reply["error"]["message"], "resource_not_found");
-    assert_eq!(reply["error"]["data"]["relative_path"], "missing.txt");
-}
-
-#[tokio::test]
-async fn read_non_utf8_falls_back_to_base64() {
-    let (mut actor, _rx, push, pe, dir, _db) = setup().await;
-    std::fs::write(dir.path().join("bin"), [0xff, 0xfe, 0x00]).unwrap();
-    actor
-        .dispatch_frame(
-            "1",
-            "system_default_user",
-            request(6, "fs/read", json!({"file":dir_ref(&pe, "bin")})),
-        )
-        .await;
-    let reply = push.last_for("1").unwrap();
-    assert_eq!(reply["result"]["encoding"], "base64");
-    assert!(!reply["result"]["content"].as_str().unwrap().is_empty());
-}
-
-// PATCH(ELECTRON-3SZ): tests for the temporary `fs/resolve` command. Remove
-// together with `handle_resolve` when preview no longer needs absolute paths.
-#[tokio::test]
-async fn resolve_existing_file_returns_absolute_and_workspace_root() {
-    let (mut actor, _rx, push, pe, dir, _db) = setup().await;
-    std::fs::write(dir.path().join("a.txt"), b"x").unwrap();
-
-    actor
-        .dispatch_frame(
-            "1",
-            "system_default_user",
-            request(40, "fs/resolve", json!({"file":dir_ref(&pe, "a.txt")})),
-        )
-        .await;
-    let reply = push.last_for("1").unwrap();
-    assert_eq!(reply["id"], 40);
-    let abs = reply["result"]["absolute_path"].as_str().unwrap();
-    let root = reply["result"]["workspace_root"].as_str().unwrap();
-    // Contract: absolute_path is the file under workspace_root. Asserted
-    // relationally (not against a hardcoded path) because the root carries the
-    // dedupe key's platform case-folding — the same folding fs/read uses.
-    assert!(!root.is_empty());
-    assert_eq!(
-        abs,
-        format!("{root}/a.txt"),
-        "absolute_path must be workspace_root + rel"
-    );
-    // The path is the same `absolute` PathBuf fs/read reads from, so it must open
-    // here too — proves resolve hands back a usable filesystem path.
-    assert_eq!(std::fs::read(abs).unwrap(), b"x");
-}
-
-#[tokio::test]
-async fn resolve_unknown_pe_is_out_of_scope() {
-    let (mut actor, _rx, push, _pe, _dir, _db) = setup().await;
-    actor
-        .dispatch_frame(
-            "1",
-            "system_default_user",
-            request(41, "fs/resolve", json!({"file":dir_ref("pe-nope", "a.txt")})),
-        )
-        .await;
-    let reply = push.last_for("1").unwrap();
-    assert_eq!(reply["error"]["code"], -32000);
-    assert_eq!(reply["error"]["message"], "out_of_scope");
-    assert_eq!(reply["error"]["data"]["pe_id"], "pe-nope");
-}
-
-#[tokio::test]
-async fn resolve_parent_escape_is_invalid_relative_path() {
-    let (mut actor, _rx, push, pe, _dir, _db) = setup().await;
-    actor
-        .dispatch_frame(
-            "1",
-            "system_default_user",
-            request(42, "fs/resolve", json!({"file":dir_ref(&pe, "../escape")})),
-        )
-        .await;
-    let reply = push.last_for("1").unwrap();
-    assert_eq!(reply["error"]["code"], -32004);
-    assert_eq!(reply["error"]["message"], "invalid_relative_path");
-}
-
-/// PATCH(ELECTRON-3SZ): resolve must run the same realpath containment guard as
-/// the other file commands — a symlink escaping the folder root is rejected
-/// before any path is handed back. Unix-only (symlink creation needs privilege
-/// on Windows); the `realpath_within` logic itself is platform-agnostic.
-#[cfg(unix)]
-#[tokio::test]
-async fn resolve_symlink_escape_is_resource_outside_folder() {
-    let (mut actor, _rx, push, pe, dir, _db) = setup().await;
-    let outside = tempfile::tempdir().unwrap();
-    std::fs::write(outside.path().join("secret.txt"), b"top secret").unwrap();
-    std::os::unix::fs::symlink(outside.path(), dir.path().join("link")).unwrap();
-
-    actor
-        .dispatch_frame(
-            "1",
-            "system_default_user",
-            request(44, "fs/resolve", json!({"file":dir_ref(&pe, "link/secret.txt")})),
-        )
-        .await;
-    let reply = push.last_for("1").unwrap();
-    assert_eq!(reply["error"]["code"], -32003);
-    assert_eq!(reply["error"]["message"], "resource_outside_folder");
-}
-
-#[tokio::test]
 async fn mkdir_then_remove_roundtrip() {
     let (mut actor, _rx, push, pe, dir, _db) = setup().await;
     actor
@@ -482,6 +346,7 @@ async fn unsubscribe_is_notification_no_reply() {
 /// IO. Unix-only — creating a symlink on Windows needs elevated privilege; the
 /// `realpath_within` logic itself is platform-agnostic (walks the deepest
 /// existing ancestor), exercised on unix here and noted in the test report.
+/// Driven through `fs/mkdir` — any resolve-guarded command shares the guard.
 #[cfg(unix)]
 #[tokio::test]
 async fn command_symlink_escape_is_resource_outside_folder() {
@@ -495,7 +360,7 @@ async fn command_symlink_escape_is_resource_outside_folder() {
         .dispatch_frame(
             "1",
             "system_default_user",
-            request(20, "fs/read", json!({"file":dir_ref(&pe, "link/secret.txt")})),
+            request(20, "fs/mkdir", json!({"dir":dir_ref(&pe, "link/secret.txt")})),
         )
         .await;
     let reply = push.last_for("1").unwrap();

--- a/crates/aionui-project/src/monitor/dispatch.rs
+++ b/crates/aionui-project/src/monitor/dispatch.rs
@@ -3,7 +3,7 @@
 //! Parses one inner frame, routes by `method`, and drives the runtime:
 //! `initialize` handshakes; `fs/subscribe`/`fs/unsubscribe` go through the shard
 //! (identity resolved via [`ProjectService::resolve_reference`]); the file
-//! commands (`fs/read|write|mkdir|remove|rename`) resolve + realpath-guard, then
+//! commands (`fs/mkdir|remove|rename`) resolve + realpath-guard, then
 //! hit the provider directly. Responses/notifications go out via the actor's
 //! push port. Errors map to protocol codes ([`wire`]) with `pe_id`/`relative_path`
 //! context in `error.data`.
@@ -12,8 +12,6 @@
 
 use std::path::Path;
 
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD;
 use serde_json::{Value, json};
 
 use crate::canonical;
@@ -23,8 +21,8 @@ use crate::types::{FileOp, ReferenceInput, ResolvedResource};
 use super::actor::FsMonitorActor;
 use super::search::{self, ActiveSearch, SearchRoot};
 use super::wire::{
-    self, Encoding, InitializeParams, MkdirParams, ReadParams, RemoveParams, RenameParams, ResolveParams, ResourceRef,
-    SearchCancelParams, SearchParams, SubscribeParams, UnsubscribeParams,
+    self, InitializeParams, MkdirParams, RemoveParams, RenameParams, ResourceRef, SearchCancelParams, SearchParams,
+    SubscribeParams, UnsubscribeParams,
 };
 
 impl FsMonitorActor {
@@ -49,10 +47,6 @@ impl FsMonitorActor {
             "initialize" => self.handle_initialize(session, id, params),
             "fs/subscribe" => self.handle_subscribe(session, user_id, id, params).await,
             "fs/unsubscribe" => self.handle_unsubscribe(session, user_id, params).await,
-            "fs/read" => self.handle_read(session, user_id, id, params).await,
-            // PATCH(ELECTRON-3SZ): remove with `handle_resolve` when preview no
-            // longer needs absolute paths (see handler doc).
-            "fs/resolve" => self.handle_resolve(session, user_id, id, params).await,
             "fs/mkdir" => self.handle_mkdir(session, user_id, id, params).await,
             "fs/remove" => self.handle_remove(session, user_id, id, params).await,
             "fs/rename" => self.handle_rename(session, user_id, id, params).await,
@@ -203,114 +197,6 @@ impl FsMonitorActor {
     }
 
     // ── file commands ───────────────────────────────────────────────────────
-
-    async fn handle_read(&mut self, session: &str, user_id: &str, id: Option<Value>, params: Value) {
-        let Ok(p) = serde_json::from_value::<ReadParams>(params) else {
-            self.push(session, invalid_params(id));
-            return;
-        };
-        let resolved = match self.resolve_guarded(user_id, &p.file, FileOp::Read).await {
-            Ok(r) => r,
-            Err((code, message)) => {
-                self.push(session, wire::error(id, code, message, ref_data(&p.file)));
-                return;
-            }
-        };
-        match self.runtime().provider().read(&resolved.resource_uri).await {
-            Ok(bytes) => {
-                // Byte count only — never the content itself.
-                tracing::info!(session, op = "read", pe_id = %p.file.pe_id, rel = %p.file.relative_path, bytes = bytes.len(), "fs command ok");
-                let (content, encoding) = encode_content(bytes, p.encoding.unwrap_or_default());
-                self.push(
-                    session,
-                    wire::success(id, json!({ "content": content, "encoding": encoding })),
-                );
-            }
-            Err(err) => {
-                let (code, message) = wire::fs_error_to_rpc(&err);
-                tracing::warn!(session, op = "read", pe_id = %p.file.pe_id, rel = %p.file.relative_path, code = message, "fs command failed");
-                self.push(session, wire::error(id, code, message, ref_data(&p.file)));
-            }
-        }
-    }
-
-    /// PATCH(ELECTRON-3SZ): resolve `{pe_id, relative_path}` to the underlying
-    /// absolute path + the pe root's absolute path.
-    ///
-    /// This deliberately violates the pe_id identity boundary — the backend is
-    /// not supposed to expose absolute paths and the frontend is not supposed to
-    /// know them. It exists only as an emergency line fix so preview's office
-    /// (officecli watch needs an on-disk `file_path` + sandbox `workspace`) and
-    /// pdf (`file://` webview) viewers can render again after the project-scoped
-    /// Explorer stopped passing `file_path`. REMOVE this handler, its
-    /// `wire::ResolveParams` (and the `ResolveParams` name in this file's
-    /// `use super::wire::{…}` import), and the `fs/resolve` dispatch arm once
-    /// preview is redesigned to consume content over the wire.
-    ///
-    /// Reuses the same identity + realpath containment guard as the other file
-    /// commands (`FileOp::Read`); resolution is lexical (no read IO).
-    ///
-    /// `absolute_path` is `resolved.absolute_path` — the exact same `absolute`
-    /// PathBuf `fs/read` derives its `resource_uri` from (`containment.rs`:
-    /// `absolute` is computed once, then turned into both the read URI and this
-    /// string). So on any machine where `fs/read` opens the file, this path opens
-    /// it too — resolve introduces no new open-failure surface over read. (The
-    /// dedupe-key case-folding of the root — `canonical::IGNORE_PATH_CASING`,
-    /// macOS/Windows only, filename segment never folded — is shared with read,
-    /// so a case-sensitive-volume mismatch is a pre-existing whole-`fs/*` concern
-    /// tracked separately, NOT something this patch introduces.)
-    /// `workspace_root` is the pe root's absolute path (officecli sandbox needs it).
-    async fn handle_resolve(&mut self, session: &str, user_id: &str, id: Option<Value>, params: Value) {
-        let Ok(p) = serde_json::from_value::<ResolveParams>(params) else {
-            self.push(session, invalid_params(id));
-            return;
-        };
-        let resolved = match self.resolve_guarded(user_id, &p.file, FileOp::Read).await {
-            Ok(r) => r,
-            Err((code, message)) => {
-                self.push(session, wire::error(id, code, message, ref_data(&p.file)));
-                return;
-            }
-        };
-        // Non-file schemes carry no absolute path; treat as provider-unavailable.
-        // Unreachable with the current file-only provider (resolve_reference
-        // rejects non-file at canonicalize → unsupported_resource_scheme before
-        // here); kept as a defensive fail-closed.
-        let Some(absolute_path) = resolved.absolute_path.clone() else {
-            self.push(
-                session,
-                wire::error(
-                    id,
-                    wire::CODE_PROVIDER_UNAVAILABLE,
-                    "provider_unavailable",
-                    ref_data(&p.file),
-                ),
-            );
-            return;
-        };
-        let Ok(workspace_root) = canonical::uri_to_path(&resolved.root_resource_canonical) else {
-            self.push(
-                session,
-                wire::error(
-                    id,
-                    wire::CODE_PROVIDER_UNAVAILABLE,
-                    "provider_unavailable",
-                    ref_data(&p.file),
-                ),
-            );
-            return;
-        };
-        let workspace_root = workspace_root.to_string_lossy().into_owned();
-        // Log identity only — never the resolved absolute paths (sensitive).
-        tracing::info!(session, op = "resolve", pe_id = %p.file.pe_id, rel = %p.file.relative_path, "fs command ok");
-        self.push(
-            session,
-            wire::success(
-                id,
-                json!({ "absolute_path": absolute_path, "workspace_root": workspace_root }),
-            ),
-        );
-    }
 
     async fn handle_mkdir(&mut self, session: &str, user_id: &str, id: Option<Value>, params: Value) {
         let Ok(p) = serde_json::from_value::<MkdirParams>(params) else {
@@ -533,19 +419,6 @@ fn invalid_params(id: Option<Value>) -> Value {
 /// `error.data` context for a reference.
 fn ref_data(target: &ResourceRef) -> Value {
     json!({ "pe_id": target.pe_id, "relative_path": target.relative_path })
-}
-
-/// Encode file bytes for the wire, honoring the requested encoding. A utf-8
-/// request over non-utf-8 bytes falls back to base64 (the `encoding` field in
-/// the result tells the client what it actually got).
-fn encode_content(bytes: Vec<u8>, requested: Encoding) -> (String, Encoding) {
-    match requested {
-        Encoding::Base64 => (STANDARD.encode(&bytes), Encoding::Base64),
-        Encoding::Utf8 => match String::from_utf8(bytes) {
-            Ok(text) => (text, Encoding::Utf8),
-            Err(err) => (STANDARD.encode(err.as_bytes()), Encoding::Base64),
-        },
-    }
 }
 
 /// Realpath containment: the access-time symlink/alias escape guard that stage 0

--- a/crates/aionui-project/src/monitor/wire.rs
+++ b/crates/aionui-project/src/monitor/wire.rs
@@ -58,16 +58,6 @@ pub struct ResourceRef {
     pub relative_path: String,
 }
 
-/// Content encoding for `fs/read`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum Encoding {
-    #[serde(rename = "utf-8")]
-    #[default]
-    Utf8,
-    Base64,
-}
-
 // ── Method params ─────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Deserialize)]
@@ -83,23 +73,6 @@ pub struct SubscribeParams {
 #[derive(Debug, Clone, Deserialize)]
 pub struct UnsubscribeParams {
     pub targets: Vec<ResourceRef>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct ReadParams {
-    pub file: ResourceRef,
-    #[serde(default)]
-    pub encoding: Option<Encoding>,
-}
-
-// PATCH(ELECTRON-3SZ): `fs/resolve` params. Violates the pe_id identity boundary
-// (the backend must not expose absolute paths, the frontend must not know them).
-// Added only as an emergency line fix so preview's office/pdf viewers can obtain
-// an absolute `file_path`. REMOVE together with `handle_resolve` once preview is
-// redesigned to consume content over the wire.
-#[derive(Debug, Clone, Deserialize)]
-pub struct ResolveParams {
-    pub file: ResourceRef,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/aionui-project/src/monitor/wire_test.rs
+++ b/crates/aionui-project/src/monitor/wire_test.rs
@@ -17,8 +17,7 @@ fn fact(kind: Kind) -> EntryFact {
 
 #[test]
 fn incoming_request_parses_id_method_params() {
-    let v =
-        json!({"jsonrpc":"2.0","id":3,"method":"fs/mkdir","params":{"dir":{"pe_id":"pe1","relative_path":"a"}}});
+    let v = json!({"jsonrpc":"2.0","id":3,"method":"fs/mkdir","params":{"dir":{"pe_id":"pe1","relative_path":"a"}}});
     let frame: IncomingFrame = serde_json::from_value(v).unwrap();
     assert_eq!(frame.id, Some(json!(3)));
     assert_eq!(frame.method, "fs/mkdir");

--- a/crates/aionui-project/src/monitor/wire_test.rs
+++ b/crates/aionui-project/src/monitor/wire_test.rs
@@ -18,11 +18,11 @@ fn fact(kind: Kind) -> EntryFact {
 #[test]
 fn incoming_request_parses_id_method_params() {
     let v =
-        json!({"jsonrpc":"2.0","id":3,"method":"fs/read","params":{"file":{"pe_id":"pe1","relative_path":"a.txt"}}});
+        json!({"jsonrpc":"2.0","id":3,"method":"fs/mkdir","params":{"dir":{"pe_id":"pe1","relative_path":"a"}}});
     let frame: IncomingFrame = serde_json::from_value(v).unwrap();
     assert_eq!(frame.id, Some(json!(3)));
-    assert_eq!(frame.method, "fs/read");
-    assert_eq!(frame.params["file"]["pe_id"], "pe1");
+    assert_eq!(frame.method, "fs/mkdir");
+    assert_eq!(frame.params["dir"]["pe_id"], "pe1");
 }
 
 #[test]
@@ -46,7 +46,7 @@ fn incoming_missing_method_is_error() {
     assert!(serde_json::from_value::<IncomingFrame>(v).is_err());
 }
 
-// ── params / encoding ─────────────────────────────────────────────────────
+// ── params ──────────────────────────────────────────────────────────────
 
 #[test]
 fn subscribe_params_parse_targets() {
@@ -54,19 +54,6 @@ fn subscribe_params_parse_targets() {
     let p: SubscribeParams = serde_json::from_value(v).unwrap();
     assert_eq!(p.targets.len(), 2);
     assert_eq!(p.targets[1].relative_path, "src");
-}
-
-#[test]
-fn encoding_parses_utf8_and_base64_and_defaults() {
-    assert_eq!(
-        serde_json::from_value::<Encoding>(json!("utf-8")).unwrap(),
-        Encoding::Utf8
-    );
-    assert_eq!(
-        serde_json::from_value::<Encoding>(json!("base64")).unwrap(),
-        Encoding::Base64
-    );
-    assert_eq!(Encoding::default(), Encoding::Utf8);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Preview PDF streaming + Office `ChatFileRef` resolve, then retirement of the now-unused WS `fs/resolve` and WS `fs/read` monitor commands.

**Rebased onto `main`** now that PR-2 (#757, ChatFileRef content endpoints) has merged — base is `main`, and this PR carries only the PR-3 delta (4 commits; the PR-2 content commit dropped out into main).

## Related Issues

- Paired with iOfficeAI/AionUI#3837


## New capability (additive)

- **`GET /api/fs/stream`** — raw byte-range server for a flattened `ChatFileRef` query (`kind=project|upload|local`), resolved via `resolve_chat_file_ref` (op = Read), served by `tower_http` `ServeFile`: `Content-Type` + `Accept-Ranges` + full `Range`/`If-Range` (206 Partial Content). For `<webview src>`/`<embed>` (pdf) which can only GET with no body. Auth via the existing middleware (unauth GET → 401).
- **Office `start_preview` / `stop_preview`** additively accept an optional `ChatFileRef`, resolved server-side (op = Read). Start and stop resolve the **same** ref → same watch key, so the officecli subprocess is not leaked. Legacy `file_path` retained as fallback (non-breaking).

## Retirement (safe — frontend migrated in the paired FE PR)

- Removed WS `fs/resolve` and WS `fs/read`. The Explorer now reads via HTTP `/api/fs/content` (PR-2, in main) and streams pdf via `/api/fs/stream`; no frontend WS `fs/read`/`fs/resolve` caller remains. HTTP `/api/fs/read` is **kept**.
- WS survivors: `subscribe`/`unsubscribe`/`mkdir`/`remove`/`rename`/`search`/`searchCancel`.

## Verification

- `/api/fs/stream` e2e: full GET (`Content-Type: application/pdf`, `Accept-Ranges: bytes`), `Range: bytes=0-3` → **206 Partial + `Content-Range: bytes 0-3/10`** + body `0123`, unauth GET → 401 — all pass.
- Full pre-push gate (`just push`) — **8124 passed, 24 skipped, 0 failed**.

## Commits

1. `dea4f64a` — /api/fs/stream + office ChatFileRef resolve
2. `20d484b2` — resolve StopPreviewRequest.file to stop the right watch
3. `ff9b23b6` — retire WS fs/read and fs/resolve
4. `3867178d` — auto-fixes (fmt + clippy), gate-generated

Paired with the frontend PR (pdf via stream URL + office ChatFileRef + drop fs/resolve).