### PR TITLE
chore(acp): bump dimcode and grok registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -19,7 +19,7 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.1"
+      "version": "0.3.2"
     },
     "dirac": {
       "registry_json_id": "dirac",
@@ -34,7 +34,7 @@
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "0.2.118"
+      "version": "0.2.119"
     },
     "kilo": {
       "registry_json_id": "kilo",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Two npx pins drifted since #750, each backed by a fresh serial ACP probe of the exact pinned version. Lock-only change — two lines; no metadata, migration, or entrypoint edits, and no lock-derived test assertion embeds either version.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| dimcode | `dimcode` | 0.3.1 → **0.3.2** | ok (agentInfo dimcode "DimCode" 0.3.2) | auth required (`-32000`, "Provider credentials are required") |
| grok | `@xai-official/grok` | 0.2.118 → **0.2.119** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |

Both meet the release-lock criterion: `initialize` succeeds and `session/new` returns a clearly classified authentication requirement. Probes ran serially with no inherited HOME or credentials.

The other 9 Registry-pinned packages (autohand, codebuddy, deepagents, dirac, glm-acp-agent, kilo, nova, pi, sigit) match the snapshot exactly — no drift. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. The `mimo-code` and `omp` entries are non-Registry builtins (no `registry_json_id`) and are correctly excluded from drift reconciliation.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.03-e5290cd`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.03-e5290cd/registry.json) of `agentclientprotocol/registry` (newest release at audit time), fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the previous baseline (38 ids).

## Validation

- `cargo test -p aionui-runtime -p aionui-ai-agent` — pass (882 lib + integration tests)
- Full `just push` gate (migration check, lint, fmt, `cargo nextest run --workspace`) — pass
- Gate run with the host-injected `AIONUI_LOG_DIR` unset (pre-existing environment sensitivity, see #695)
- Gate started only after host load fell below the pre-flight threshold; the targeted test run had pushed the 12-core host to load 79, which is the condition that produced spurious subprocess-spawn timeouts in #750's history.

## Logging

No logging changes: lock-only version bumps; existing startup/session error paths already identify a failing agent by backend.