### PR TITLE
fix(session): settle cards through teardown and resume so no stored row spins forever

### DIFF
--- a/crates/aionui-ai-agent/src/protocol/events/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/events/mod.rs
@@ -168,6 +168,16 @@ pub struct WorkflowProgressData {
     /// partial list would erase the agents left out, and a reordered list would
     /// insert a second row.
     pub agents: Vec<ToolGroupEntry>,
+    /// A status-only settle for a card THIS pump never opened — the CLI reported
+    /// a task terminal after a resume/rebuild wiped the ledger (live 2026-08-04:
+    /// an idle-killed conversation's load-gate bash finished its work, and the
+    /// resumed session's `Interrupted` report found no card — the stored row
+    /// spun forever). Consumers must apply it ONLY to an EXISTING stored row
+    /// (update, never insert, never a fresh UI card): the same unknown-terminal
+    /// shape also fires for workflow-INTERNAL refs that never had a row, and
+    /// inserting for those would conjure junk cards.
+    #[serde(default)]
+    pub settle_only: bool,
 }
 
 /// Data for the internal-only [`AgentStreamEvent::AcpDialectSignal`] event.

--- a/crates/aionui-ai-agent/src/protocol/events/tool_call.rs
+++ b/crates/aionui-ai-agent/src/protocol/events/tool_call.rs
@@ -6,8 +6,14 @@ use serde_json::Value;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolCallEventData {
     pub call_id: String,
+    /// Skipped when empty: downstream storage merges frames with RFC 7396
+    /// merge-patch, so an empty name would ERASE the stored one (the terminal
+    /// ToolResult and turn-end closes legitimately carry no name).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub name: String,
-    #[serde(default)]
+    /// Skipped when null for the same reason: a null would DELETE the stored
+    /// arguments under merge-patch semantics.
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
     pub args: serde_json::Value,
     pub status: ToolCallStatus,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -2290,6 +2290,7 @@ fn spawn_event_pump(
                         let data = crate::protocol::events::WorkflowProgressData {
                             card: card_frame,
                             agents,
+                            settle_only: false,
                         };
                         // Delivery is uniform: in-turn the per-turn relay consumes
                         // this, between turns the conversation's background stream
@@ -2894,6 +2895,23 @@ fn spawn_event_pump(
                 let _ = runtime.tx.send(ev);
             }
         }
+
+        // The event stream ended: the backend (and its process group) is being
+        // torn down. Settle every card still open and push the frames NOW —
+        // the out-of-turn watcher is still subscribed at this instant and drains
+        // buffered frames before it observes the channel close. Without this an
+        // idle-kill left cards' stored rows on `running` forever (live
+        // 2026-08-04: a load-gate bash's card spun for hours after the reaper
+        // removed the task mid-flight).
+        for data in settle_workflow_cards(
+            &mut workflow_cards,
+            crate::workflow_progress::CardStatus::Cancelled,
+            false,
+            aionui_common::now_ms(),
+            &conversation_id,
+        ) {
+            let _ = runtime.tx.send(AgentStreamEvent::WorkflowProgress(data));
+        }
     });
 }
 
@@ -3373,6 +3391,7 @@ fn update_workflow_cards(
                         out.push(WorkflowProgressData {
                             card: card_frame,
                             agents,
+                            settle_only: false,
                         });
                     }
                     cards.insert(r#ref.clone(), card);
@@ -3380,6 +3399,45 @@ fn update_workflow_cards(
             }
             terminal => {
                 let Some(mut card) = cards.remove(r#ref) else {
+                    // A terminal for a card THIS pump never opened. Real case
+                    // (live 2026-08-04): the conversation was idle-killed while a
+                    // background bash kept working; the RESUMED session reported
+                    // the task terminal, but the rebuilt pump's ledger was empty —
+                    // and the stored row spun forever. Synthesize a STATUS-ONLY
+                    // settle keyed to the launching call. `settle_only` makes the
+                    // consumers update-only: the same unknown-terminal shape also
+                    // fires for workflow-INTERNAL refs that never had a row (the
+                    // 2.1.176 capture's inner bashes), and those must stay
+                    // invisible.
+                    if let Some(call_id) = parent_ref.clone() {
+                        let status = match terminal {
+                            SubagentStatus::Completed => crate::protocol::events::ToolCallStatus::Completed,
+                            SubagentStatus::Errored => crate::protocol::events::ToolCallStatus::Error,
+                            _ => crate::protocol::events::ToolCallStatus::Canceled,
+                        };
+                        tracing::info!(
+                            conv_id = %conversation_id,
+                            task_id = %r#ref,
+                            %call_id,
+                            ?status,
+                            "session-pump: terminal for unknown card — emitting status-only settle"
+                        );
+                        out.push(WorkflowProgressData {
+                            card: crate::protocol::events::ToolCallEventData {
+                                call_id,
+                                // Empty name / null args are SKIPPED at
+                                // serialization, so the stored row keeps its own.
+                                name: String::new(),
+                                args: serde_json::Value::Null,
+                                status,
+                                input: None,
+                                output: None,
+                                description: None,
+                            },
+                            agents: Vec::new(),
+                            settle_only: true,
+                        });
+                    }
                     return out;
                 };
                 let status = match terminal {
@@ -3398,7 +3456,11 @@ fn update_workflow_cards(
                     "session-pump: workflow progress card settled"
                 );
                 if let Some((card, agents)) = card.take_emission(now_ms, true) {
-                    out.push(WorkflowProgressData { card, agents });
+                    out.push(WorkflowProgressData {
+                        card,
+                        agents,
+                        settle_only: false,
+                    });
                 }
             }
         },
@@ -3437,7 +3499,11 @@ fn update_workflow_cards(
                 },
             );
             if let Some((card, agents)) = card.take_emission(now_ms, forced) {
-                out.push(WorkflowProgressData { card, agents });
+                out.push(WorkflowProgressData {
+                    card,
+                    agents,
+                    settle_only: false,
+                });
             }
         }
         SessionEvent::WorkflowPhase { task_id, index, title } => {
@@ -3446,7 +3512,11 @@ fn update_workflow_cards(
             };
             let forced = card.declare_phase(*index, title.clone());
             if let Some((card, agents)) = card.take_emission(now_ms, forced) {
-                out.push(WorkflowProgressData { card, agents });
+                out.push(WorkflowProgressData {
+                    card,
+                    agents,
+                    settle_only: false,
+                });
             }
         }
         _ => {}
@@ -3498,7 +3568,11 @@ fn settle_workflow_cards(
             let mut card = cards.remove(&k)?;
             card.settle(status);
             card.take_emission(now_ms, true)
-                .map(|(card, agents)| WorkflowProgressData { card, agents })
+                .map(|(card, agents)| WorkflowProgressData {
+                    card,
+                    agents,
+                    settle_only: false,
+                })
         })
         .collect()
 }
@@ -6812,6 +6886,104 @@ mod pump_tests {
         assert_eq!(texts, 2, "launch reply AND report both stream, got {seq:?}");
     }
 
+    /// The stream ending (idle-kill teardown, crash) must settle every open
+    /// card ON THE WAY OUT: the ledger dies with the pump, so this is the last
+    /// chance to stop the stored row spinning forever (live 2026-08-04: a
+    /// load-gate bash card spun for hours after the idle reaper removed the
+    /// task mid-flight).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stream_teardown_settles_open_cards() {
+        use aionui_session::{SubagentStatus, SubagentTaskKind};
+        let script = vec![
+            env(SessionEvent::ToolCall {
+                tool_use_id: "toolu_bg".into(),
+                name: "Bash".into(),
+                subagent: aionui_session::SubagentKind::Inline,
+                input: serde_json::json!({"command": "until ...; do sleep 30; done"}),
+                parent_tool_use_id: None,
+            }),
+            env(SessionEvent::SubagentUpdate {
+                r#ref: "task-bg".into(),
+                label: None,
+                status: SubagentStatus::Running,
+                parent_ref: Some("toolu_bg".into()),
+                kind: Some(SubagentTaskKind::Other),
+            }),
+            // No terminal, no TurnResult — the stream just ends (teardown).
+        ];
+        let frames = drain_script(script).await;
+        let settled = wf_frames(&frames)
+            .into_iter()
+            .rev()
+            .find(|p| p.card.status == ToolCallStatus::Canceled)
+            .unwrap_or_else(|| {
+                panic!(
+                    "teardown must settle the open card, got {:?}",
+                    frames.iter().map(frame_name).collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(settled.card.call_id, "toolu_bg");
+    }
+
+    /// A terminal for a task this pump never opened (post-resume: the old pump —
+    /// and its ledger — died with an idle-kill) synthesizes a STATUS-ONLY settle
+    /// keyed to the launching call, marked `settle_only` so consumers update an
+    /// existing row and never insert.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unknown_terminal_synthesizes_a_settle_only_frame() {
+        use aionui_session::SubagentStatus;
+        let script = vec![
+            env(SessionEvent::SubagentUpdate {
+                r#ref: "task-old".into(),
+                label: None,
+                status: SubagentStatus::Interrupted,
+                parent_ref: Some("toolu_old".into()),
+                kind: None, // task_notification carries no kind
+            }),
+            env(SessionEvent::TurnResult {
+                is_error: false,
+                api_error_status: None,
+                result_text: String::new(),
+                epoch: 0,
+                outcome: aionui_session::TurnOutcome::EndTurn,
+            }),
+        ];
+        let frames = drain_script(script).await;
+        let synth = wf_frames(&frames)
+            .into_iter()
+            .find(|p| p.settle_only)
+            .unwrap_or_else(|| {
+                panic!(
+                    "unknown terminal must synthesize a settle-only frame, got {:?}",
+                    frames.iter().map(frame_name).collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(synth.card.call_id, "toolu_old", "keyed to the launching call");
+        assert_eq!(synth.card.status, ToolCallStatus::Canceled);
+        // Status-only on the wire: empty name / null args are skipped at
+        // serialization so merge-patch keeps the stored row's own fields.
+        let wire = serde_json::to_value(&synth.card).unwrap();
+        assert!(wire.get("name").is_none(), "empty name must not serialize: {wire}");
+        assert!(wire.get("args").is_none(), "null args must not serialize: {wire}");
+        assert!(synth.agents.is_empty());
+    }
+
+    /// An unknown terminal WITHOUT a parent link has nowhere to settle — silence,
+    /// not a junk frame.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unknown_terminal_without_parent_stays_silent() {
+        use aionui_session::SubagentStatus;
+        let script = vec![env(SessionEvent::SubagentUpdate {
+            r#ref: "task-old".into(),
+            label: None,
+            status: SubagentStatus::Completed,
+            parent_ref: None,
+            kind: None,
+        })];
+        let frames = drain_script(script).await;
+        assert!(wf_frames(&frames).is_empty());
+    }
+
     /// A killed workflow emits NO result frame — only task frames. Its container
     /// card is NOT in `open_tools` (a Workflow's tool_result lands at launch), so
     /// the turn-end drain cannot close it. Without an explicit settle the card and
@@ -6979,8 +7151,16 @@ mod pump_tests {
             finish_count, 1,
             "the Interrupted drain settles the owed Finish exactly once, got {seq:?}"
         );
+        // "Last" among TURN frames: out-of-band WorkflowProgress settles (the
+        // teardown/unknown-terminal bookkeeping added later) legitimately trail
+        // the Finish — the relay is done with the turn and the out-of-turn
+        // watcher owns them.
+        let last_turn_frame = frames
+            .iter()
+            .filter(|f| !matches!(f, AgentStreamEvent::WorkflowProgress(_)))
+            .next_back();
         assert!(
-            matches!(frames.last(), Some(AgentStreamEvent::Finish(_))),
+            matches!(last_turn_frame, Some(AgentStreamEvent::Finish(_))),
             "the settled Finish is the turn's terminal frame, got {seq:?}"
         );
         // The Task tool call left open by the kill is closed as Canceled BEFORE the
@@ -7048,7 +7228,11 @@ mod pump_tests {
         let frames = drain_script(script).await;
         let seq: Vec<&str> = frames.iter().map(frame_name).collect();
         assert!(
-            matches!(frames.last(), Some(AgentStreamEvent::Finish(_))),
+            frames
+                .iter()
+                .filter(|f| !matches!(f, AgentStreamEvent::WorkflowProgress(_)))
+                .next_back()
+                .is_some_and(|f| matches!(f, AgentStreamEvent::Finish(_))),
             "the clean result's Finish must flow while a background bash is alive, got {seq:?}"
         );
         assert!(

--- a/crates/aionui-conversation/src/background_stream.rs
+++ b/crates/aionui-conversation/src/background_stream.rs
@@ -120,6 +120,40 @@ impl BackgroundStreamWatcher {
     /// renders, and persist them so a reload shows the truth (the un-persisted
     /// settle was exactly the "View Steps spinner never ends" bug).
     async fn handle_card_refresh(&self, data: &WorkflowProgressData) {
+        if data.settle_only {
+            // Update-only settle for a card the pump has no memory of (see the
+            // field's docs): apply to an EXISTING stored row and forward, or
+            // drop silently. Never insert — the same unknown-terminal shape
+            // fires for workflow-internal refs that never had a row, and
+            // inserting for those would conjure junk cards.
+            let adapter = StreamPersistenceAdapter::new(
+                self.user_id.clone(),
+                self.conversation_id.clone(),
+                String::new(),
+                self.repo.clone(),
+                Some(self.persistence.clone()),
+            );
+            if adapter.settle_tool_call_if_present(&data.card).await {
+                self.forward_card_frames(data);
+            }
+            return;
+        }
+        self.forward_card_frames(data);
+        let adapter = StreamPersistenceAdapter::new(
+            self.user_id.clone(),
+            self.conversation_id.clone(),
+            // Only text segments read the adapter's msg_id; tool rows key by call_id.
+            String::new(),
+            self.repo.clone(),
+            Some(self.persistence.clone()),
+        );
+        adapter.persist_tool_call(&data.card).await;
+        if !data.agents.is_empty() {
+            adapter.persist_tool_group(&data.agents).await;
+        }
+    }
+
+    fn forward_card_frames(&self, data: &WorkflowProgressData) {
         for (kind, msg_id, body) in [
             ("tool_call", data.card.call_id.clone(), serde_json::to_value(&data.card)),
             (
@@ -153,18 +187,6 @@ impl BackgroundStreamWatcher {
                     "hidden": false,
                 }),
             ));
-        }
-        let adapter = StreamPersistenceAdapter::new(
-            self.user_id.clone(),
-            self.conversation_id.clone(),
-            // Only text segments read the adapter's msg_id; tool rows key by call_id.
-            String::new(),
-            self.repo.clone(),
-            Some(self.persistence.clone()),
-        );
-        adapter.persist_tool_call(&data.card).await;
-        if !data.agents.is_empty() {
-            adapter.persist_tool_group(&data.agents).await;
         }
     }
 
@@ -368,6 +390,22 @@ mod tests {
         None
     }
 
+    fn settled_card_with(call_id: &str, status: ToolCallStatus) -> AgentStreamEvent {
+        AgentStreamEvent::WorkflowProgress(WorkflowProgressData {
+            card: ToolCallEventData {
+                call_id: call_id.into(),
+                name: "Bash".into(),
+                args: serde_json::json!({"command": "sleep 30"}),
+                status,
+                input: None,
+                output: None,
+                description: Some("sleep 30 · bg task b1 · 00:01".into()),
+            },
+            agents: vec![],
+            settle_only: false,
+        })
+    }
+
     fn settled_card() -> AgentStreamEvent {
         AgentStreamEvent::WorkflowProgress(WorkflowProgressData {
             card: ToolCallEventData {
@@ -385,6 +423,7 @@ mod tests {
                 status: ToolGroupStatus::Success,
                 description: None,
             }],
+            settle_only: false,
         })
     }
 
@@ -461,6 +500,91 @@ mod tests {
         }
         assert!(saw_content, "the report streams to the live view");
         assert!(saw_completed, "the orphan turn is book-kept like a real turn");
+    }
+
+    /// A `settle_only` frame updates an EXISTING row and forwards; for an
+    /// unknown row it is dropped silently — never inserted, never forwarded
+    /// (the same unknown-terminal shape fires for workflow-internal refs that
+    /// never had a row; inserting would conjure junk cards).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn settle_only_updates_existing_rows_and_drops_unknown_ones() {
+        let rig = rig().await;
+        // Seed a live card row the normal way.
+        rig.tx
+            .send(settled_card_with("toolu_seed", ToolCallStatus::Running))
+            .unwrap();
+        eventually(async || {
+            rows_of_type(&rig, "tool_call")
+                .await
+                .into_iter()
+                .find(|m| m.id == "toolu_seed" && m.status.as_deref() == Some("work"))
+        })
+        .await
+        .expect("seed row persisted as running");
+
+        let mut ws = rig.bus.subscribe();
+        // Status-only settle for the seeded row…
+        rig.tx
+            .send(AgentStreamEvent::WorkflowProgress(WorkflowProgressData {
+                card: ToolCallEventData {
+                    call_id: "toolu_seed".into(),
+                    name: String::new(),
+                    args: serde_json::Value::Null,
+                    status: ToolCallStatus::Canceled,
+                    input: None,
+                    output: None,
+                    description: None,
+                },
+                agents: vec![],
+                settle_only: true,
+            }))
+            .unwrap();
+        // …and one for a row that never existed.
+        rig.tx
+            .send(AgentStreamEvent::WorkflowProgress(WorkflowProgressData {
+                card: ToolCallEventData {
+                    call_id: "toolu_ghost".into(),
+                    name: String::new(),
+                    args: serde_json::Value::Null,
+                    status: ToolCallStatus::Canceled,
+                    input: None,
+                    output: None,
+                    description: None,
+                },
+                agents: vec![],
+                settle_only: true,
+            }))
+            .unwrap();
+
+        let row = eventually(async || {
+            rows_of_type(&rig, "tool_call")
+                .await
+                .into_iter()
+                .find(|m| m.id == "toolu_seed" && m.status.as_deref() == Some("finish"))
+        })
+        .await
+        .expect("the existing row must settle to finish");
+        // Merge-patch kept the row's own identity: name survives a status-only frame.
+        assert!(row.content.contains("\"name\":\"Bash\""), "name kept: {}", row.content);
+
+        // The ghost never materialized — no row, no WS frame.
+        assert!(
+            !rows_of_type(&rig, "tool_call")
+                .await
+                .iter()
+                .any(|m| m.id == "toolu_ghost"),
+            "a settle-only frame must never insert"
+        );
+        let mut ghost_forwarded = false;
+        while let Ok(evt) = ws.try_recv() {
+            if evt.name == "message.stream" && evt.data["data"]["call_id"] == "toolu_ghost" {
+                ghost_forwarded = true;
+            }
+        }
+        assert!(
+            !ghost_forwarded,
+            "a settle-only frame for an unknown row must not reach the UI"
+        );
     }
 
     /// While a USER turn is active, its own relay owns every frame — the watcher

--- a/crates/aionui-conversation/src/startup_recovery.rs
+++ b/crates/aionui-conversation/src/startup_recovery.rs
@@ -10,6 +10,14 @@ use crate::service::ConversationService;
 enum StartupRecoveryAction {
     FinishVisibleOutput,
     FinishEmptyPlaceholder,
+    /// A tool_call/tool_group row left on `work` by a previous process. At
+    /// startup this is dead BY DEFINITION — the CLI process group died with the
+    /// old aioncore, so no terminal will ever be reported (a hard kill runs
+    /// neither the pump's teardown settle nor leaves anyone to resume). The
+    /// row's CONTENT status must be rewritten too: the frontend renders the
+    /// embedded status, and `hasRunningToolMessages` would keep the View Steps
+    /// spinner alive off a `finish` row whose content still says running.
+    SettleToolRow,
 }
 
 impl ConversationService {
@@ -36,8 +44,12 @@ impl ConversationService {
             }
 
             let action = classify_recovery_action(&row);
+            let content = match action {
+                StartupRecoveryAction::SettleToolRow => settle_tool_row_content(&row.r#type, &row.content),
+                _ => None,
+            };
             let update = MessageRowUpdate {
-                content: None,
+                content,
                 status: Some(Some("finish".to_owned())),
                 hidden: Some(matches!(action, StartupRecoveryAction::FinishEmptyPlaceholder)),
             };
@@ -75,10 +87,52 @@ impl ConversationService {
 }
 
 fn classify_recovery_action(row: &MessageRow) -> StartupRecoveryAction {
+    if matches!(row.r#type.as_str(), "tool_call" | "tool_group") {
+        return StartupRecoveryAction::SettleToolRow;
+    }
     if message_has_visible_content(row) {
         StartupRecoveryAction::FinishVisibleOutput
     } else {
         StartupRecoveryAction::FinishEmptyPlaceholder
+    }
+}
+
+/// Rewrite a stale tool row's embedded status to its terminal form. Returns
+/// `None` when the content needs no change (already terminal, or unparsable —
+/// the row-level `finish` still applies either way).
+///
+/// The two channels speak different status vocabularies (see `ToolGroupStatus`):
+/// `tool_call` content is snake_case, `tool_group` entries are PascalCase.
+fn settle_tool_row_content(row_type: &str, content: &str) -> Option<String> {
+    let mut value: serde_json::Value = serde_json::from_str(content).ok()?;
+    match row_type {
+        "tool_call" => {
+            let stale = value
+                .get("status")
+                .and_then(|s| s.as_str())
+                .is_none_or(|s| !matches!(s, "completed" | "error" | "canceled"));
+            if !stale {
+                return None;
+            }
+            value["status"] = serde_json::Value::String("canceled".into());
+            Some(value.to_string())
+        }
+        "tool_group" => {
+            let entries = value.as_array_mut()?;
+            let mut changed = false;
+            for entry in entries {
+                let stale = entry
+                    .get("status")
+                    .and_then(|s| s.as_str())
+                    .is_none_or(|s| !matches!(s, "Success" | "Error" | "Canceled"));
+                if stale {
+                    entry["status"] = serde_json::Value::String("Canceled".into());
+                    changed = true;
+                }
+            }
+            changed.then(|| value.to_string())
+        }
+        _ => None,
     }
 }
 
@@ -117,6 +171,57 @@ mod tests {
             classify_recovery_action(&row),
             StartupRecoveryAction::FinishVisibleOutput
         );
+    }
+
+    #[test]
+    fn stale_tool_rows_classify_as_settle() {
+        for ty in ["tool_call", "tool_group"] {
+            let row = MessageRow {
+                id: "m".into(),
+                conversation_id: "c".into(),
+                msg_id: Some("m".into()),
+                r#type: ty.into(),
+                content: "{}".into(),
+                position: Some("left".into()),
+                status: Some("work".into()),
+                hidden: false,
+                created_at: 1,
+            };
+            assert_eq!(classify_recovery_action(&row), StartupRecoveryAction::SettleToolRow);
+        }
+    }
+
+    /// The hard-kill residue (audit 2026-08-04): rows whose CONTENT still says
+    /// running must be rewritten — the frontend renders the embedded status, so
+    /// a row-level `finish` alone leaves the View Steps spinner alive.
+    #[test]
+    fn settle_rewrites_running_content_and_leaves_terminal_content_alone() {
+        // tool_call: snake_case vocabulary.
+        let card = serde_json::json!({"call_id": "t1", "name": "Bash", "status": "running"}).to_string();
+        let out = settle_tool_row_content("tool_call", &card).expect("running → rewritten");
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["status"], "canceled");
+        assert_eq!(v["name"], "Bash", "only the status changes");
+
+        let done = serde_json::json!({"call_id": "t1", "status": "completed"}).to_string();
+        assert!(
+            settle_tool_row_content("tool_call", &done).is_none(),
+            "terminal content is left untouched"
+        );
+
+        // tool_group: PascalCase vocabulary, per entry.
+        let group = serde_json::json!([
+            {"call_id": "a", "name": "run:A", "status": "Executing"},
+            {"call_id": "b", "name": "run:B", "status": "Success"}
+        ])
+        .to_string();
+        let out = settle_tool_row_content("tool_group", &group).expect("one executing entry");
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v[0]["status"], "Canceled");
+        assert_eq!(v[1]["status"], "Success", "terminal entries keep their outcome");
+
+        let all_done = serde_json::json!([{"call_id": "a", "status": "Success"}]).to_string();
+        assert!(settle_tool_row_content("tool_group", &all_done).is_none());
     }
 
     #[test]

--- a/crates/aionui-conversation/src/stream_persistence.rs
+++ b/crates/aionui-conversation/src/stream_persistence.rs
@@ -504,6 +504,30 @@ impl StreamPersistenceAdapter {
         }
     }
 
+    /// Apply a STATUS-ONLY settle to an EXISTING tool_call row, if any.
+    ///
+    /// Returns whether the row existed. Never inserts: a `settle_only` frame is
+    /// the pump settling a card it has no memory of (post-resume), and the same
+    /// unknown-terminal shape also fires for workflow-internal refs that never
+    /// had a row — inserting for those would conjure junk cards.
+    #[tracing::instrument(skip_all)]
+    pub async fn settle_tool_call_if_present(
+        &self,
+        data: &aionui_ai_agent::protocol::events::tool_call::ToolCallEventData,
+    ) -> bool {
+        let existing = self
+            .repo
+            .get_message_by_msg_id(&self.user_id, &self.conversation_id, &data.call_id, "tool_call")
+            .await
+            .unwrap_or(None);
+        if existing.is_none() {
+            debug!(call_id = %data.call_id, "settle-only frame for a row that does not exist; dropped");
+            return false;
+        }
+        self.persist_tool_call(data).await;
+        true
+    }
+
     /// Persist a tool_group event (array of tool summaries).
     #[tracing::instrument(skip_all)]
     pub async fn persist_tool_group(&self, entries: &[aionui_ai_agent::protocol::events::tool_call::ToolGroupEntry]) {

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -514,6 +514,16 @@ impl StreamRelay {
                             self.forward_to_websocket(&event);
                             self.adapter.persist_tool_group(entries).await;
                         }
+                        AgentStreamEvent::WorkflowProgress(data) if data.settle_only => {
+                            // Update-only settle for a card this pump never
+                            // opened (post-resume terminal). Forward ONLY if the
+                            // stored row existed — otherwise the frontend would
+                            // append a junk nameless card for a workflow-internal
+                            // ref that never had one.
+                            if self.adapter.settle_tool_call_if_present(&data.card).await {
+                                self.forward_workflow_progress(data);
+                            }
+                        }
                         AgentStreamEvent::WorkflowProgress(data) => {
                             // A running workflow refreshes its progress roughly once a
                             // second, WHILE the assistant is still streaming its "workflow
@@ -1246,6 +1256,7 @@ mod tests {
                     status: ToolGroupStatus::Executing,
                     description: Some("[P1 Run] · opus-4-8".into()),
                 }],
+                settle_only: false,
             })
         }
 

--- a/crates/aionui-db/src/repository/sqlite_conversation.rs
+++ b/crates/aionui-db/src/repository/sqlite_conversation.rs
@@ -952,7 +952,7 @@ impl IConversationRepository for SqliteConversationRepository {
              INNER JOIN conversations c ON c.id = m.conversation_id \
              WHERE m.position = 'left' \
                AND m.status IN ('work', 'pending') \
-               AND m.type IN ('text', 'thinking') \
+               AND m.type IN ('text', 'thinking', 'tool_call', 'tool_group') \
              ORDER BY m.created_at ASC",
         )
         .fetch_all(&self.pool)


### PR DESCRIPTION
## Problem

Follow-up to #758, found live (2026-08-04, a cron conversation's load-gate bash): the card machinery still leaked through one lifecycle. The idle reaper removed the task mid-flight — pump, ledger and watcher died together, nothing settled the card — while the bash itself survived and finished its work. When a later message resumed the session, the CLI dutifully reported the old task's terminal, but the rebuilt pump's ledger was empty, so the report was dropped. The stored row stayed `running`, and the View Steps spinner span for hours over a task that had long since succeeded.

## Fix — two closures, either alone would have saved that card

1. **Teardown settle.** When the event stream ends (idle-kill, crash), the pump settles every open card on the way out and pushes the frames before dropping the channel — the out-of-turn watcher is still subscribed at that instant and drains buffered frames before it observes `Closed`.

2. **Status-only settle for unknown terminals.** A task terminal whose card is not in the ledger (post-resume) synthesizes a `settle_only` `WorkflowProgress` keyed to the launching call. Consumers apply it **update-only** — relay and watcher check the stored row exists before persisting or forwarding — because the same unknown-terminal shape also fires for workflow-internal refs that never had a row, and inserting for those would conjure junk cards.

Supporting serialization change: `ToolCallEventData` now skips an empty `name` and a null `args`. Both storage layers merge frames with RFC 7396 merge-patch, so those values ERASED the stored ones — a latent clobber that already bit the turn-end Canceled closes, and that made a status-only frame impossible to express. Wire-compatible: real frames always populate both fields, and the frontend merge keeps prior values for absent keys.

## Verification

- New tests: teardown settles open cards; unknown terminal synthesizes a settle-only frame (asserting the wire carries neither `name` nor `args` keys); no parent → silence; watcher applies settle-only to an existing row and leaves an unknown row without a trace (real in-memory DB).
- Two turn-shape tests updated intentionally: "Finish is the last frame" → "the last TURN frame" — out-of-band card settles legitimately trail the Finish, where the relay is done and the watcher owns delivery.
- `aionui-ai-agent` 885 passed, `aionui-conversation` 362 passed, clippy clean.