### PR TITLE
fix(session): keep claude session cost cumulative across process respawns

### DIFF
--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -1287,6 +1287,15 @@ pub(crate) fn resolved_effort(
         .filter(|value| !value.is_empty())
 }
 
+/// The persisted session-cumulative cost (USD) that seeds the claude backend's
+/// cost ledger (`SessionConfig.initial_cost_usd`) on a rebuild. USD only:
+/// claude's own `total_cost_usd` counter is USD, and silently adding a
+/// foreign-currency figure to it would corrupt both.
+pub(crate) fn initial_cost_usd_from_snapshot(session_snapshot: Option<&PersistedSessionState>) -> Option<f64> {
+    let cost = session_snapshot?.context_usage.as_ref()?.cost.as_ref()?;
+    (cost.currency.eq_ignore_ascii_case("usd") && cost.amount > 0.0).then_some(cost.amount)
+}
+
 pub(crate) fn resolved_session_mode(
     config: &AcpBuildExtra,
     session_snapshot: Option<&PersistedSessionState>,
@@ -1567,6 +1576,15 @@ pub async fn build_session_instance(
     // Version-gated on the binary we actually resolved above: the flag is hidden
     // (absent from `--help`) and older builds reject it at argument-parse time, so
     // an ungated flag would make every session unspawnable. See `claude_flags`.
+    // Cost-ledger seed (claude only): claude's `total_cost_usd` is
+    // process-cumulative, so a rebuilt backend (app restart / conversation
+    // reopen) must start its ledger from the conversation's persisted
+    // cumulative cost — otherwise the "session cost" falls back to the new
+    // process's own spend. codex reports no cost; other backends ignore it.
+    if backend_label == "claude" {
+        session_config.initial_cost_usd = initial_cost_usd_from_snapshot(session_snapshot);
+    }
+
     if backend_label == "claude"
         && let Some(program) = session_config.cli_program.clone()
         && crate::claude_flags::supports_thinking_display(&program).await
@@ -3941,6 +3959,37 @@ mod build_mapping_tests {
             thought_level: level.map(str::to_owned),
             ..Default::default()
         }
+    }
+
+    /// The claude cost ledger's app-restart seed: the persisted cumulative cost
+    /// must map into `SessionConfig.initial_cost_usd` — but ONLY a USD figure
+    /// (claude's own counter is USD; a foreign-currency figure persisted by some
+    /// other path must not be silently added to it).
+    #[test]
+    fn initial_cost_seed_reads_the_persisted_usd_cost_only() {
+        use agent_client_protocol::schema::v1::{Cost, UsageUpdate};
+        let usd = PersistedSessionState {
+            context_usage: Some(UsageUpdate::new(12_600, 262_144).cost(Cost::new(6.4294, "USD"))),
+            ..Default::default()
+        };
+        assert_eq!(initial_cost_usd_from_snapshot(Some(&usd)), Some(6.4294));
+
+        let eur = PersistedSessionState {
+            context_usage: Some(UsageUpdate::new(1, 2).cost(Cost::new(1.0, "EUR"))),
+            ..Default::default()
+        };
+        assert_eq!(
+            initial_cost_usd_from_snapshot(Some(&eur)),
+            None,
+            "non-USD must not seed"
+        );
+
+        assert_eq!(initial_cost_usd_from_snapshot(None), None);
+        assert_eq!(
+            initial_cost_usd_from_snapshot(Some(&PersistedSessionState::default())),
+            None,
+            "a snapshot without a cost figure must not seed"
+        );
     }
 
     #[test]

--- a/crates/aionui-session/src/adapter/claude.rs
+++ b/crates/aionui-session/src/adapter/claude.rs
@@ -574,7 +574,11 @@ impl ClaudeAdapter {
         // omitting them under-reported the total ~10x on a cache-heavy turn (and was
         // inconsistent with codex, whose native `last.totalTokens` already includes
         // cache). `input_tokens`/`output_tokens` stay the wire's base counts; only
-        // `total_tokens` becomes the genuine total. cost from total_cost_usd.
+        // `total_tokens` becomes the genuine total. cost from total_cost_usd —
+        // the RAW wire value, which is only PROCESS-cumulative (a `--resume`
+        // respawn restarts it); the wrapping conn's CostLedger re-bases it to
+        // session-cumulative before broadcast. The adapter stays a pure frame
+        // parser with no cross-process state.
         if let Some(usage) = v.get("usage").and_then(Value::as_object) {
             let get = |k: &str| usage.get(k).and_then(Value::as_u64).unwrap_or(0);
             let input_tokens = get("input_tokens");

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -496,6 +496,24 @@ struct DiscoveredCaps {
     slash_commands: Vec<crate::capability::SlashCommandInfo>,
 }
 
+/// Session-cumulative cost ledger. claude's `result.total_cost_usd` is
+/// PROCESS-cumulative (live-captured 2.1.221: a `--resume` respawn restarts the
+/// counter at the new process's own spend), so reporting it raw makes the
+/// "session cost" fall back to one process's spend after every F-4 wake / app
+/// restart. The ledger re-baselines at each process (re)start — `base` absorbs
+/// the finished process's final counter (or, on a fresh backend, the persisted
+/// cumulative seeded via `SessionConfig.initial_cost_usd`) — and every costed
+/// `UsageDelta` is rewritten to `base + raw` before broadcast, so downstream
+/// consumers (the usage indicator, the persisted snapshot's overwrite-merge)
+/// only ever see a monotonic session-cumulative figure.
+#[derive(Debug, Default)]
+struct CostLedger {
+    /// USD the conversation had already spent BEFORE the current process run.
+    base: f64,
+    /// The current process's latest raw `total_cost_usd` report.
+    last_raw: f64,
+}
+
 /// Shared state the reader task drains into — held by the backend, cloned into
 /// each reader (the live one + every post-wake one). Grouped so `spawn` and
 /// `wake_handle` start identical readers without a 7-arg call duplicated twice.
@@ -524,6 +542,10 @@ struct ClaudeReaderState {
     /// `sniff_set_config_reject` can surface a rejection as a `Notice{Warning}`
     /// (shared Arc with `ClaudeSessionBackend.pending_set_config`).
     pending_set_config: Arc<std::sync::Mutex<std::collections::HashMap<String, String>>>,
+    /// Session-cumulative cost ledger (see [`CostLedger`]): survives F-4 wake
+    /// respawns so a new process's restarted `total_cost_usd` counter is reported
+    /// as `base + raw`, never raw alone.
+    cost_ledger: Arc<std::sync::Mutex<CostLedger>>,
 }
 
 /// Spawn a claude stdout reader over `stdout`/`io` using the shared state. Used
@@ -535,6 +557,22 @@ fn start_claude_reader(
     io: Arc<dyn AgentIo>,
 ) -> tokio::task::JoinHandle<()> {
     let state = state.clone();
+    // Every reader start is a process (re)start, where claude's PROCESS-cumulative
+    // `total_cost_usd` counter restarts at zero — fold the finished process's final
+    // counter into the session base so subsequent reports stay session-cumulative.
+    // The initial spawn is a harmless no-op (last_raw is still 0).
+    {
+        let mut ledger = state.cost_ledger.lock().unwrap_or_else(|e| e.into_inner());
+        if ledger.last_raw > 0.0 {
+            ledger.base += ledger.last_raw;
+            ledger.last_raw = 0.0;
+            tracing::debug!(
+                session_id = %state.session_id,
+                cost_base_usd = ledger.base,
+                "claude cost ledger re-baselined for a process respawn"
+            );
+        }
+    }
     tokio::spawn(async move {
         reader_task(
             state.session_id,
@@ -549,6 +587,7 @@ fn start_claude_reader(
             state.turn_in_flight,
             state.current_mode_override,
             state.pending_set_config,
+            state.cost_ledger,
         )
         .await;
     })
@@ -596,6 +635,24 @@ impl ClaudeSessionBackend {
             None => (None, None),
         };
 
+        // Seed the cost ledger with the conversation's persisted cumulative cost
+        // (a resumed conversation on a FRESH backend instance — app restart /
+        // conversation reopen — where the in-memory ledger of the previous
+        // instance is gone). Production-diagnosable at info: one line per open,
+        // and "the indicator jumped down after a restart" hinges on this seed.
+        let initial_cost_usd = config.initial_cost_usd.unwrap_or(0.0);
+        if initial_cost_usd > 0.0 {
+            tracing::info!(
+                session_id = %session_id,
+                cost_base_usd = initial_cost_usd,
+                "claude cost ledger seeded from the persisted session cost"
+            );
+        }
+        let cost_ledger = Arc::new(std::sync::Mutex::new(CostLedger {
+            base: initial_cost_usd,
+            last_raw: 0.0,
+        }));
+
         let reader_state = ClaudeReaderState {
             session_id: session_id.clone(),
             turn_gen: turn_gen.clone(),
@@ -607,6 +664,7 @@ impl ClaudeSessionBackend {
             turn_in_flight: turn_in_flight.clone(),
             current_mode_override: current_mode_override.clone(),
             pending_set_config: pending_set_config.clone(),
+            cost_ledger,
         };
         let reader = start_claude_reader(&reader_state, stdout, io.clone());
 
@@ -1090,6 +1148,7 @@ async fn reader_task(
     turn_in_flight: Arc<std::sync::atomic::AtomicBool>,
     current_mode_override: Arc<std::sync::Mutex<Option<String>>>,
     pending_set_config: Arc<std::sync::Mutex<std::collections::HashMap<String, String>>>,
+    cost_ledger: Arc<std::sync::Mutex<CostLedger>>,
 ) {
     use std::sync::atomic::Ordering;
     use tokio::io::AsyncReadExt;
@@ -1227,7 +1286,22 @@ async fn reader_task(
                 // apart at the wire. Done on the RAW frame.
                 sniff_replay_prompt_ack(v, &event_tx, &session_id, cur_gen);
             }
-            for ev in events {
+            for mut ev in events {
+                // Cost ledger: claude's `total_cost_usd` is PROCESS-cumulative, so a
+                // costed report is rewritten to the SESSION-cumulative `base + raw`
+                // (see CostLedger). `last_raw` is recorded on EVERY costed frame —
+                // even ones downstream discards (a zero-token /compact turn) — so the
+                // re-baseline at the next respawn folds in the true final counter.
+                // A frame that carried no cost stays `None`: fabricating `Some(base)`
+                // would masquerade as a fresh agent report downstream.
+                if let SessionEvent::UsageDelta {
+                    cost_usd: Some(raw), ..
+                } = &mut ev
+                {
+                    let mut ledger = cost_ledger.lock().unwrap_or_else(|e| e.into_inner());
+                    ledger.last_raw = *raw;
+                    *raw += ledger.base;
+                }
                 // F-4: a terminal clears the turn-active flag so the idle
                 // timer may suspend the now-idle process (it was held
                 // resident for the whole turn). Cleared BEFORE the broadcast
@@ -2653,6 +2727,26 @@ impl ClaudeSessionBackend {
             cli_program: None,
         };
         Self::spawn(session_id, ClaudeAdapter::new(), io, SessionConfig::default(), wake).await
+    }
+
+    /// Test-support seam: `build_with_io` with a caller-supplied `SessionConfig`
+    /// (e.g. `initial_cost_usd` for the cost-ledger seed tests).
+    #[cfg(any(test, feature = "test-support"))]
+    pub async fn build_with_io_config(
+        session_id: impl Into<String>,
+        io: Box<dyn AgentIo>,
+        config: SessionConfig,
+    ) -> Self {
+        let session_id = session_id.into();
+        let wake = ClaudeWakeRecipe {
+            spawner: Arc::new(crate::testing::FakeSpawner::new()),
+            claude_session_id: session_id.clone(),
+            cwd: None,
+            extra_args: Vec::new(),
+            env: Vec::new(),
+            cli_program: None,
+        };
+        Self::spawn(session_id, ClaudeAdapter::new(), io, config, wake).await
     }
 
     /// Test-support seam: build a SUSPENDABLE backend over an injected `AgentIo`,
@@ -5040,6 +5134,107 @@ mod tests {
             spec.args
         );
         drop(backend); // idle timer + (Dormant) controller tear down cleanly
+    }
+
+    /// Await the next `UsageDelta` on the event stream and return its `cost_usd`.
+    async fn next_usage_cost(events: &mut BoxStream<'static, SessionEnvelope>) -> Option<f64> {
+        tokio::time::timeout(std::time::Duration::from_secs(3), async {
+            while let Some(env) = events.next().await {
+                if let SessionEvent::UsageDelta { cost_usd, .. } = env.event {
+                    return cost_usd;
+                }
+            }
+            panic!("event stream closed before a UsageDelta arrived");
+        })
+        .await
+        .expect("timed out waiting for a UsageDelta")
+    }
+
+    /// claude's `total_cost_usd` is PROCESS-cumulative, not session-cumulative
+    /// (live-captured 2.1.221: two turns in one process report 0.250686 →
+    /// 0.278994, then a `--resume` respawn reports 0.028596 — the counter
+    /// restarts at the new process's own spend). The backend must re-baseline its
+    /// cost ledger on every process (re)start so the broadcast UsageDelta stays
+    /// SESSION-cumulative — otherwise a wake respawn makes the usage indicator
+    /// (and the persisted snapshot, which merges cost by overwrite) fall from the
+    /// real total to the last turn's own cost.
+    #[tokio::test]
+    async fn usage_cost_accumulates_across_process_respawn() {
+        let frame1 = concat!(
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"ok","#,
+            r#""usage":{"input_tokens":2,"output_tokens":23},"total_cost_usd":0.25}"#,
+            "\n"
+        );
+        // Gate the fixture so the subscription is wired before the frame flows
+        // (broadcast does not replay to late subscribers).
+        let fake1 = FakeAgentIo::never_exits(Vec::new()).with_gated_tail(frame1.as_bytes().to_vec());
+        let release1 = fake1.stdout_releaser();
+        let backend = ClaudeSessionBackend::build_with_io("cost-accum", Box::new(fake1)).await;
+        let mut events = backend.events();
+        release1();
+        let first = next_usage_cost(&mut events).await.expect("first turn carries a cost");
+        assert!(
+            (first - 0.25).abs() < 1e-9,
+            "process 1 reports its own cumulative cost, got {first}"
+        );
+
+        // Simulate the F-4 wake respawn: a NEW process whose counter restarts at
+        // its own spend. Drives the exact reader entry point `wake_handle` uses
+        // (start_claude_reader over the SAME shared reader_state).
+        let frame2 = concat!(
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"ok","#,
+            r#""usage":{"input_tokens":2,"output_tokens":18},"total_cost_usd":0.03}"#,
+            "\n"
+        );
+        let fake2 = FakeAgentIo::never_exits(Vec::new()).with_gated_tail(frame2.as_bytes().to_vec());
+        let release2 = fake2.stdout_releaser();
+        let io2: Arc<dyn AgentIo> = Arc::from(Box::new(fake2) as Box<dyn AgentIo>);
+        let (_stdin2, stdout2) = io2.take_stdio().await.expect("fake stdio");
+        let _reader2 = start_claude_reader(&backend.reader_state, Some(stdout2), io2);
+        release2();
+        let second = next_usage_cost(&mut events).await.expect("second turn carries a cost");
+        assert!(
+            (second - 0.28).abs() < 1e-9,
+            "a respawned process restarts claude's counter; the ledger must report base+raw (0.25+0.03), got {second}"
+        );
+    }
+
+    /// App restart loses the in-memory ledger, so the orchestration layer seeds
+    /// `SessionConfig.initial_cost_usd` from the persisted usage snapshot. The
+    /// backend must (a) add that base to every costed report and (b) NEVER
+    /// fabricate a cost onto a frame that carried none (a fabricated
+    /// `Some(base)` would masquerade as a fresh agent report downstream).
+    #[tokio::test]
+    async fn initial_cost_seed_offsets_reports_and_is_not_fabricated() {
+        let frames = concat!(
+            // frame 1: no total_cost_usd → cost must stay None even with a base
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"a","#,
+            r#""usage":{"input_tokens":2,"output_tokens":3}}"#,
+            "\n",
+            // frame 2: the process's own cumulative cost rides on top of the seed
+            r#"{"type":"result","subtype":"success","is_error":false,"result":"b","#,
+            r#""usage":{"input_tokens":2,"output_tokens":4},"total_cost_usd":0.1}"#,
+            "\n"
+        );
+        let fake = FakeAgentIo::never_exits(Vec::new()).with_gated_tail(frames.as_bytes().to_vec());
+        let release = fake.stdout_releaser();
+        let config = SessionConfig {
+            initial_cost_usd: Some(6.0),
+            ..Default::default()
+        };
+        let backend = ClaudeSessionBackend::build_with_io_config("cost-seed", Box::new(fake), config).await;
+        let mut events = backend.events();
+        release();
+        let first = next_usage_cost(&mut events).await;
+        assert_eq!(
+            first, None,
+            "a costless frame must not have a cost fabricated from the base"
+        );
+        let second = next_usage_cost(&mut events).await.expect("costed frame");
+        assert!(
+            (second - 6.1).abs() < 1e-9,
+            "resume seed must offset the process-local counter (6.0+0.1), got {second}"
+        );
     }
 
     /// #103: `config.spawn_env` (the cc-switch provider env the app registry fills for

--- a/crates/aionui-session/src/backend/mod.rs
+++ b/crates/aionui-session/src/backend/mod.rs
@@ -290,4 +290,13 @@ pub struct SessionConfig {
     /// into the F-4 wake recipe (rides the cloned `config`) so a resume re-spawn
     /// uses the same binary (R16 continuity).
     pub cli_program: Option<std::path::PathBuf>,
+    /// The conversation's cumulative cost (USD) BEFORE this backend instance
+    /// existed, read back from the persisted usage snapshot by the orchestration
+    /// layer on resume. claude only: its `result.total_cost_usd` is
+    /// PROCESS-cumulative (live-captured 2.1.221 — a `--resume` respawn restarts
+    /// the counter at zero), so the backend seeds its cost ledger with this base
+    /// and reports `base + raw`, keeping the broadcast/persisted cost
+    /// SESSION-cumulative across process recycles and app restarts. `None`
+    /// (default) = fresh conversation, base 0. Other backends ignore it.
+    pub initial_cost_usd: Option<f64>,
 }

--- a/crates/aionui-session/src/event.rs
+++ b/crates/aionui-session/src/event.rs
@@ -296,7 +296,10 @@ pub enum SessionEvent {
     /// Per-turn typed usage/cost (Addendum 5 / U15). Adapter normalizes a
     /// cumulative wire counter to a per-turn DELTA (G6). Reducer no-op (pure
     /// consumer signal). codex `thread/tokenUsage/updated.last`; claude
-    /// `result.usage`; cost_usd may be None.
+    /// `result.usage`; cost_usd may be None. When present, `cost_usd` is the
+    /// SESSION-cumulative spend: claude's wire value (`total_cost_usd`) is only
+    /// process-cumulative, so its conn re-bases it through a cost ledger before
+    /// broadcast (see `claude_conn::CostLedger`).
     UsageDelta {
         input_tokens: u64,
         output_tokens: u64,


### PR DESCRIPTION
Follow-up to #733, which surfaced claude's `total_cost_usd` as the conversation's session cost.

## Defect

claude's `result.total_cost_usd` is **process-cumulative, not session-cumulative**. Live-probed (claude CLI 2.1.221, two turns in one process + a `--resume` turn in a fresh process):

| turn | process | `total_cost_usd` |
|---|---|---|
| 1 | A | 0.250686 |
| 2 | A | 0.278994 (= 0.250686 + own ~0.0283 — cumulative within the process) |
| 3 | B (`--resume`) | **0.028596 — the counter restarts at the new process's own spend** |

The value was broadcast raw and persisted by overwrite-merge (`persist_context_usage`), so every process recycle — F-4 idle reap + wake, app restart, conversation reopen — made the usage indicator and the stored snapshot fall from the real session total (e.g. \$6.43) to the next process's own spend (e.g. \$0.03). In practice, with idle reaping, the displayed "session cost" degraded to roughly "the last turn's cost".

## Fix

Treat the wire value as a resettable counter and re-base it to session-cumulative at the claude conn layer:

- **`claude_conn::CostLedger`** (`base` + `last_raw`) lives on the shared reader state, so it survives process recycles. Every costed `UsageDelta` is rewritten to `base + raw` before broadcast; `last_raw` is recorded on every costed frame — including ones downstream discards (zero-token `/compact` turns) — so the re-baseline is exact. Each reader (re)start (the single entry point both the initial spawn and `wake_handle` use) folds the finished process's final counter into `base`.
- **`SessionConfig.initial_cost_usd`** covers the app-restart case, where the in-memory ledger is gone: the orchestration layer seeds it from the persisted `runtime.context_usage.cost` snapshot (USD only — claude's own counter is USD, and adding a foreign-currency figure to it would corrupt both). No migration: the snapshot sink/shape is exactly what #733 already persists.
- **The adapter stays a pure frame parser**: `adapter/claude.rs` still emits the raw wire value; re-basing lives in the conn only. Costless frames stay `None` — never fabricate a cost from the base alone (it would masquerade as a fresh agent report downstream).

Other backends are untouched: codex and antigravity report no cost, and the ACP contract's `UsageUpdate.cost` is already defined as cumulative session cost (`agent-client-protocol-schema` 1.5.0 `v1/client.rs`).

## Tests

All written first and watched fail against the unfixed code:

- `usage_cost_accumulates_across_process_respawn` — a second reader over the same shared state (the exact `wake_handle` entry point) reports `0.25 + 0.03`, not the raw `0.03` the wire carries
- `initial_cost_seed_offsets_reports_and_is_not_fabricated` — a seeded backend offsets costed reports (`6.0 + 0.1`) and leaves costless frames `None`
- `initial_cost_seed_reads_the_persisted_usd_cost_only` — the snapshot→seed mapping takes a USD figure, rejects non-USD, absent cost, and absent snapshot

## Verification

- `cargo test -p aionui-session --lib` (514 passed) and `cargo test -p aionui-ai-agent --lib` (883 passed)
- `cargo clippy -p aionui-session -p aionui-ai-agent --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean
- Pre-push gate run without the full-workspace nextest at the maintainer's request (migration check + lint-fix + fmt passed); CI covers the rest

## Out of scope

Frontend (consumes the same `cost:{amount,currency}` frame — the number is just correct now), the ACP path, codex/antigravity, and the `get_session_cost` on-demand query wire (claude answers it with its own preformatted text).