### PR TITLE
fix(db): route open-stage corruption into the recoverable recovery path

### DIFF
--- a/crates/aionui-db/src/database.rs
+++ b/crates/aionui-db/src/database.rs
@@ -141,11 +141,11 @@ pub async fn init_database_staged_with_options(
             );
             recover_and_retry(path, e.into_source()).await
         }
-        Err(e) if path.exists() && is_recoverable_migration_corruption(e.source()) => {
+        Err(e) if path.exists() && should_attempt_recovery(e.source()) => {
             warn!(
                 code = "BOOTSTRAP_DATABASE_CORRUPTION_REQUIRES_USER_CONFIRMATION",
                 stage = e.stage(),
-                "Database corruption-like migration failure requires user confirmation before rebuild"
+                "Database corruption-like startup failure requires user confirmation before rebuild"
             );
             Err(DatabaseInitError::new(
                 RECOVERABLE_DATABASE_CORRUPTION_STAGE,
@@ -711,14 +711,6 @@ fn should_attempt_recovery(err: &DbError) -> bool {
     }
 }
 
-fn is_recoverable_migration_corruption(err: &DbError) -> bool {
-    match err {
-        DbError::Migration(sqlx::migrate::MigrateError::VersionMismatch(_)) => false,
-        DbError::Migration(_) => is_corruption_like_error(err),
-        _ => false,
-    }
-}
-
 fn is_corruption_like_error(err: &DbError) -> bool {
     let message = err.to_string().to_ascii_lowercase();
 
@@ -775,7 +767,6 @@ mod tests {
         ));
 
         assert!(should_attempt_recovery(&err));
-        assert!(is_recoverable_migration_corruption(&err));
     }
 
     #[test]
@@ -786,7 +777,6 @@ mod tests {
         ));
 
         assert!(!should_attempt_recovery(&err));
-        assert!(!is_recoverable_migration_corruption(&err));
     }
 
     #[tokio::test]

--- a/crates/aionui-db/tests/db_lifecycle.rs
+++ b/crates/aionui-db/tests/db_lifecycle.rs
@@ -1,5 +1,6 @@
 use aionui_db::{
-    DatabaseInitOptions, init_database, init_database_memory, init_database_with_options, maybe_copy_legacy_database,
+    DatabaseInitOptions, init_database, init_database_memory, init_database_staged_with_options,
+    init_database_with_options, maybe_copy_legacy_database,
 };
 use sqlx::Row;
 
@@ -275,6 +276,36 @@ async fn corruption_without_recovery_authorization_preserves_original_file() {
         .filter_map(|e| e.ok())
         .any(|e| e.file_name().to_string_lossy().contains("backup"));
     assert!(!has_backup, "unconfirmed startup must not create a backup file");
+}
+
+#[tokio::test]
+async fn unauthorized_open_stage_corruption_upgrades_to_recoverable_stage() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.db");
+    // Corruption-like on-disk content: "file is not a database".
+    std::fs::write(&path, b"not a valid sqlite database").unwrap();
+
+    // Unauthorized startup (recover_corrupted_database = false).
+    let err = init_database_staged_with_options(
+        &path,
+        DatabaseInitOptions {
+            recover_corrupted_database: false,
+        },
+    )
+    .await
+    .expect_err("unauthorized corruption must not rebuild, must surface a staged error");
+
+    // The fix: corruption-like failure must upgrade to the recoverable stage,
+    // NOT the generic database.open stage (which AionUi maps to restart-only).
+    assert_eq!(err.stage(), "database.recoverable_corruption");
+
+    // Original corrupt file untouched, no backup created (no rebuild without auth).
+    assert_eq!(std::fs::read(&path).unwrap(), b"not a valid sqlite database");
+    let has_backup = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .any(|e| e.file_name().to_string_lossy().contains("backup"));
+    assert!(!has_backup, "unauthorized startup must not create a backup file");
 }
 
 // -- Directory creation --


### PR DESCRIPTION
## Description

A corrupted on-disk SQLite database that failed at the `database.open` stage was misclassified as a generic startup exit (restart-only, no recovery UI), trapping users in a permanent restart loop. This PR routes open/query/init-stage corruption into the same recoverable recovery path that migration-stage corruption already used, so all corruption stages can reach the recovery flow.

## Root Cause

`init_database_staged_with_options` classified corruption asymmetrically between its two branches:

- The authorized branch used `should_attempt_recovery`.
- The unauthorized branch only matched `is_recoverable_migration_corruption`, so **only migration-stage** corruption was upgraded to the `database.recoverable_corruption` stage. Open-stage corruption (`DbError::Query`, e.g. `database disk image is malformed` / `file is not a database`) fell through to `_ => false` and was returned as the generic `database.open` stage.

Downstream, the AionUi launcher classifier maps `database.open` (with the server socket already bound) to `backend_startup_exited` — a restart-only state with no recovery UI — so a self-healable corruption became a permanent restart loop.

## Changes

- In the unauthorized branch of `init_database_staged_with_options`, use `should_attempt_recovery(e.source())` instead of `is_recoverable_migration_corruption(e.source())`. This branch is only reachable when the authorized branch does not match, so the semantics are "unauthorized start + corruption-like error → upgrade to `database.recoverable_corruption`", making the two branches symmetric across open/query/init/migration stages.
- Update that branch's `warn!` wording from "corruption-like migration failure" to "corruption-like startup failure". The `code` and `stage` fields are unchanged; no new logs and no level changes.
- Remove `is_recoverable_migration_corruption`, which is now unused in production (it duplicated `should_attempt_recovery` line-for-line for the migration case), along with its two dedicated test assertions (the co-located `should_attempt_recovery` assertions are kept).
- Add an on-disk integration test `unauthorized_open_stage_corruption_upgrades_to_recoverable_stage` in `crates/aionui-db/tests/db_lifecycle.rs`: it writes corruption-like bytes, and after an unauthorized call asserts `err.stage() == "database.recoverable_corruption"`, that the original file bytes are unchanged, and that no backup was created.

Non-corruption errors (`database is locked`, migration `VersionMismatch`) remain guarded by `should_attempt_recovery` and are still not upgraded, covered by existing regression tests.

## Schema / Migration

No schema change, no new migration, no backfill. Recovery reuses the existing `recover_and_retry` backup-and-rebuild path unchanged; this PR only routes more corruption cases into it.

## Testing

- `cargo fmt --all -- --check` — pass
- `cargo clippy --workspace -- -D warnings` — pass (no dead-code warning after removing the unused helper)
- `cargo nextest run --workspace` — pass (validated across the full workspace; includes `unauthorized_open_stage_corruption_upgrades_to_recoverable_stage`, `corruption_recovery_creates_backup`, and the lock-contention / version-mismatch regressions)
- `grep -rn is_recoverable_migration_corruption crates/aionui-db/` — no remaining references

## Related

Paired with the AionUi change `fix(renderer): gate database rebuild behind a second confirmation`, which consumes the newly-emitted `database.recoverable_corruption` stage and hardens the recovery modal. The behavior is only end-to-end correct with both changes: AionCore emits the recoverable stage, AionUi maps it to the recovery UI. AionUi v2.1.46 already pins AionCore v0.1.57, so the two land on aligned baselines.

Fixes Sentry ELECTRON-3WP (138624711).
