### PR TITLE
fix(runtime): add bounded retry to managed node version probe

### DIFF
--- a/crates/aionui-runtime/src/node_runtime/managed/tests.rs
+++ b/crates/aionui-runtime/src/node_runtime/managed/tests.rs
@@ -9,6 +9,215 @@ fn write_file(path: &Path) {
     std::fs::write(path, b"").expect("write file");
 }
 
+/// Resolve the bundled root the parent process handed down. The fixture must be
+/// built at exactly this path — the child gets a fresh `tempfile::tempdir()`, so
+/// re-deriving the path locally would point somewhere the env var never named.
+/// The directory itself lives under the parent's tempdir, so the parent's
+/// `TempDir` drop removes the fixture once the child exits.
+#[cfg(unix)]
+fn bundled_root_from_parent() -> PathBuf {
+    PathBuf::from(
+        std::env::var_os("AIONUI_BUNDLED_MANAGED_RESOURCES").expect("parent must pass the bundled resources root"),
+    )
+}
+
+/// Build a minimal bundled managed-Node source tree under `bundled_root` whose
+/// `bin/npm` reproduces the exact transient failure this issue latched: the
+/// first `fail_times` invocations exit 7 (as the real npm did on the reporter's
+/// machine), every later one prints the version. `node` and `npx` always
+/// succeed, so the verdict is driven solely by the npm probe.
+///
+/// Pass `fail_times` larger than `VERSION_PROBE_ATTEMPTS` to model a persistent
+/// failure instead of a transient one.
+///
+/// The failure counter lives in a file (not a process-local variable) because
+/// each probe attempt is a fresh `node.exe`-equivalent process — exactly like
+/// production, where nothing in-process survives between attempts.
+#[cfg(unix)]
+fn write_bundled_node_source_with_flaky_npm(bundled_root: &Path, directory_name: &str, fail_times: u32) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let source_root = bundled_root.join("node").join(directory_name);
+    let bin = source_root.join("bin");
+    std::fs::create_dir_all(&bin).expect("create bundled bin");
+    let counter = source_root.join("npm-attempts");
+
+    let write_script = |path: PathBuf, body: String| {
+        std::fs::write(&path, body).expect("write script");
+        let mut perms = std::fs::metadata(&path).expect("script metadata").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).expect("chmod script");
+    };
+
+    write_script(bin.join("node"), "#!/bin/sh\necho v24.11.0\n".to_string());
+    write_script(bin.join("npx"), "#!/bin/sh\necho 11.6.2\n".to_string());
+    // `attempts` is read-modify-written per invocation; the probe is sequential
+    // (one command at a time in validate_runtime) so no locking is needed.
+    write_script(
+        bin.join("npm"),
+        format!(
+            "#!/bin/sh\n\
+             counter='{counter}'\n\
+             attempts=$(cat \"$counter\" 2>/dev/null || echo 0)\n\
+             attempts=$((attempts + 1))\n\
+             echo \"$attempts\" > \"$counter\"\n\
+             if [ \"$attempts\" -le {fail_times} ]; then\n\
+             \x20 exit 7\n\
+             fi\n\
+             echo 11.6.2\n",
+            counter = counter.display(),
+            fail_times = fail_times,
+        ),
+    );
+
+    counter
+}
+
+/// A transient `npm --version` failure inside the retry budget must be absorbed:
+/// `install_and_validate_with_reporter` succeeds and never reports a `Failed`
+/// phase, so AionUi is never told the installation is broken (spec AC1).
+///
+/// Unlike the `version_probe_*` unit tests — which inject a closure and so never
+/// execute `command_version_once` — this drives the real chain: spawn a real
+/// process, get a real exit code 7, through `command_version` →
+/// `validate_runtime` → `validate_managed_runtime` → the bundled activation path.
+///
+/// Unix-only: the fixture needs executable shell scripts as stand-ins for
+/// node/npm/npx. The retry logic itself is platform-independent, and the
+/// `version_probe_*` tests cover it on every platform.
+#[cfg(unix)]
+#[tokio::test]
+async fn transient_npm_version_failure_is_absorbed_without_failed_report() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bundled_root = tmp.path().join("bundled");
+    if !crate::test_support::run_in_env_child(
+        "node_runtime::managed::tests::transient_npm_version_failure_is_absorbed_without_failed_report",
+        |command| {
+            command.env("AIONUI_BUNDLED_MANAGED_RESOURCES", &bundled_root);
+        },
+    ) {
+        return;
+    }
+
+    let spec = platform_spec().expect("supported platform");
+    // Two failures then success: inside the 3-attempt budget.
+    let bundled_root = bundled_root_from_parent();
+    let counter = write_bundled_node_source_with_flaky_npm(&bundled_root, &spec.directory_name(), 2);
+
+    crate::cache::init(tmp.path().join("data"));
+    managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Bundled);
+
+    let updates = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let reporter_updates = updates.clone();
+    let reporter = move |update: NodeRuntimeProgress| {
+        reporter_updates.lock().unwrap().push(update);
+    };
+
+    let result = install_and_validate_with_reporter(Some(&reporter)).await;
+    managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Download);
+
+    let runtime = result.expect("transient npm exit 7 must be absorbed by the probe retry");
+    assert_eq!(runtime.version, semver::Version::new(24, 11, 0));
+    assert_eq!(runtime.source, ResolvedNodeSource::Bundled);
+
+    // The activated copy carries its own counter file; the probe must really
+    // have failed before succeeding, otherwise this test would also pass
+    // against a build with no retry at all.
+    let activated_counter = runtime.root.join("npm-attempts");
+    let attempts: u32 = std::fs::read_to_string(&activated_counter)
+        .or_else(|_| std::fs::read_to_string(&counter))
+        .expect("npm attempt counter")
+        .trim()
+        .parse()
+        .expect("counter is a number");
+    assert_eq!(attempts, 3, "expected 2 failed npm probes then 1 success");
+
+    let updates = updates.lock().unwrap();
+    let failed: Vec<_> = updates
+        .iter()
+        .filter(|update| update.phase == crate::NodeRuntimeProgressPhase::Failed)
+        .map(|update| format!("{:?}/{:?}", update.failure_kind, update.message))
+        .collect();
+    assert!(
+        failed.is_empty(),
+        "a transient probe failure must not surface any Failed phase, got: {failed:?}"
+    );
+}
+
+/// The mirror of the test above: once the failure outlasts the retry budget it
+/// is a real failure and must still be reported as `bundled_resource_invalid`,
+/// so the fix cannot silently swallow a genuinely broken install (spec AC2/AC3).
+///
+/// `classify_error_still_detects_bundled_invalid_by_message` asserts the same
+/// classification from a hand-built error string; this one earns it through the
+/// real subprocess chain and checks what the reporter actually emits.
+#[cfg(unix)]
+#[tokio::test]
+async fn persistent_npm_version_failure_still_reports_bundled_resource_invalid() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bundled_root = tmp.path().join("bundled");
+    if !crate::test_support::run_in_env_child(
+        "node_runtime::managed::tests::persistent_npm_version_failure_still_reports_bundled_resource_invalid",
+        |command| {
+            command.env("AIONUI_BUNDLED_MANAGED_RESOURCES", &bundled_root);
+        },
+    ) {
+        return;
+    }
+
+    let spec = platform_spec().expect("supported platform");
+    // Far beyond the 3-attempt budget: every probe fails.
+    let bundled_root = bundled_root_from_parent();
+    let counter = write_bundled_node_source_with_flaky_npm(&bundled_root, &spec.directory_name(), 1_000);
+
+    crate::cache::init(tmp.path().join("data"));
+    managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Bundled);
+
+    let updates = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let reporter_updates = updates.clone();
+    let reporter = move |update: NodeRuntimeProgress| {
+        reporter_updates.lock().unwrap().push(update);
+    };
+
+    let result = install_and_validate_with_reporter(Some(&reporter)).await;
+    managed_resources::set_managed_resources_mode(managed_resources::ManagedResourcesMode::Download);
+
+    let error = result.expect_err("a persistent npm failure must still fail");
+    let message = error.to_string();
+    assert!(
+        message.contains("bundled Node runtime failed validation"),
+        "unexpected error: {message}"
+    );
+    assert!(
+        message.contains("exit"),
+        "error should carry npm's exit status: {message}"
+    );
+
+    let attempts: u32 = std::fs::read_to_string(&counter)
+        .expect("npm attempt counter")
+        .trim()
+        .parse()
+        .expect("counter is a number");
+    assert_eq!(
+        attempts,
+        crate::node_runtime::VERSION_PROBE_ATTEMPTS as u32,
+        "a persistent failure must spend exactly the probe budget, no more"
+    );
+
+    let updates = updates.lock().unwrap();
+    assert!(
+        updates.iter().any(|update| {
+            update.phase == crate::NodeRuntimeProgressPhase::Failed
+                && update.failure_kind == Some(NodeRuntimeFailureKind::BundledResourceInvalid)
+        }),
+        "a persistent failure must still report bundled_resource_invalid, got: {:?}",
+        updates
+            .iter()
+            .map(|update| (update.phase, update.failure_kind))
+            .collect::<Vec<_>>()
+    );
+}
+
 #[tokio::test]
 async fn managed_runtime_validation_uses_real_commands() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/aionui-runtime/src/node_runtime/mod.rs
+++ b/crates/aionui-runtime/src/node_runtime/mod.rs
@@ -3,6 +3,7 @@ mod system;
 mod types;
 
 use std::sync::OnceLock;
+use std::time::Duration;
 
 use tracing::{debug, info, warn};
 
@@ -247,7 +248,69 @@ async fn install_managed_runtime_with_reporter(
     managed::install_and_validate_with_reporter(reporter).await
 }
 
+// Bounded retry budget for the managed Node `--version` validation probe.
+// A single transient external-process failure (process fails to start, a non-zero
+// exit such as npm exit code 7, or non-semver output) must not be latched into a
+// permanent bundled_resource_invalid failure event. Kept as its own constants
+// (not reused from the copy-activation budget) so probe and copy tuning stay
+// independent; initial values intentionally match MANAGED_NODE_ACTIVATION_COPY_*
+// (managed.rs), covering a worst-case ~1.75s interference window per command.
+const VERSION_PROBE_ATTEMPTS: usize = 3;
+const VERSION_PROBE_BACKOFFS: [Duration; 3] = [
+    Duration::from_millis(250),
+    Duration::from_millis(500),
+    Duration::from_millis(1000),
+];
+
 async fn command_version(command: ResolvedCommand, label: &str) -> Result<semver::Version, NodeRuntimeError> {
+    probe_command_version_with_retry(label, VERSION_PROBE_ATTEMPTS, &VERSION_PROBE_BACKOFFS, || {
+        command_version_once(command.clone(), label)
+    })
+    .await
+}
+
+/// Run the `--version` probe up to `attempts` times, sleeping the matching backoff
+/// after every failed attempt (including the last, so a persistent failure spends
+/// the full ~1.75s window before the verdict — matching `activate_copy_with_retry`
+/// in managed.rs). Every error `command_version_once` can produce is a transient
+/// external-process failure, so all are retried. A `warn` is logged only when a
+/// retry will follow; the final, budget-exhausted failure is intentionally NOT
+/// logged here — its caller (`activate_local_runtime_source`, managed.rs) already
+/// warns on the validation failure, so re-logging would duplicate it.
+async fn probe_command_version_with_retry<F, Fut>(
+    label: &str,
+    attempts: usize,
+    backoffs: &[Duration],
+    mut probe_once: F,
+) -> Result<semver::Version, NodeRuntimeError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<semver::Version, NodeRuntimeError>>,
+{
+    for attempt in 1..=attempts {
+        match probe_once().await {
+            Ok(version) => return Ok(version),
+            Err(error) => {
+                let backoff = backoffs.get(attempt - 1).copied().unwrap_or_default();
+                if attempt == attempts {
+                    tokio::time::sleep(backoff).await;
+                    return Err(error);
+                }
+                warn!(
+                    label,
+                    attempt,
+                    max_attempts = attempts,
+                    error = %error,
+                    "transient node --version probe failure; will retry after backoff"
+                );
+                tokio::time::sleep(backoff).await;
+            }
+        }
+    }
+    unreachable!("version probe retry loop always returns on the final attempt")
+}
+
+async fn command_version_once(command: ResolvedCommand, label: &str) -> Result<semver::Version, NodeRuntimeError> {
     let mut builder = crate::Builder::from_resolved(&command);
     builder.arg("--version");
     let output = builder
@@ -454,6 +517,105 @@ mod tests {
                 .to_string()
                 .contains("npm returned ambiguous semver version output"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn version_probe_retries_until_success() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let calls = Arc::new(AtomicUsize::new(0));
+        let probe_calls = calls.clone();
+        let result = probe_command_version_with_retry(
+            "npm",
+            VERSION_PROBE_ATTEMPTS,
+            &[Duration::ZERO, Duration::ZERO, Duration::ZERO],
+            move || {
+                let probe_calls = probe_calls.clone();
+                async move {
+                    let n = probe_calls.fetch_add(1, Ordering::SeqCst) + 1;
+                    if n < 3 {
+                        // The exact transient failure this issue latched: npm exit 7.
+                        Err(NodeRuntimeError::managed_invalid("npm exited with exit code: 7"))
+                    } else {
+                        Ok(semver::Version::new(24, 11, 0))
+                    }
+                }
+            },
+        )
+        .await;
+        assert_eq!(
+            result.expect("probe should succeed after transient failures"),
+            semver::Version::new(24, 11, 0)
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            3,
+            "expected 2 transient failures then 1 success"
+        );
+    }
+
+    #[tokio::test]
+    async fn version_probe_succeeds_without_retry_on_first_attempt() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let calls = Arc::new(AtomicUsize::new(0));
+        let probe_calls = calls.clone();
+        let result =
+            probe_command_version_with_retry("node", VERSION_PROBE_ATTEMPTS, &VERSION_PROBE_BACKOFFS, move || {
+                let probe_calls = probe_calls.clone();
+                async move {
+                    probe_calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(semver::Version::new(24, 11, 0))
+                }
+            })
+            .await;
+        assert!(result.is_ok(), "first-attempt success must return Ok");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "success on first attempt must not retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn version_probe_returns_last_error_after_budget_exhausted() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let calls = Arc::new(AtomicUsize::new(0));
+        let probe_calls = calls.clone();
+        let result = probe_command_version_with_retry(
+            "npm",
+            VERSION_PROBE_ATTEMPTS,
+            &[Duration::ZERO, Duration::ZERO, Duration::ZERO],
+            move || {
+                let probe_calls = probe_calls.clone();
+                async move {
+                    probe_calls.fetch_add(1, Ordering::SeqCst);
+                    Err::<semver::Version, _>(NodeRuntimeError::managed_invalid("npm exited with exit code: 7"))
+                }
+            },
+        )
+        .await;
+        let error = result.expect_err("exhausted budget must return the final Err");
+        assert!(
+            error.to_string().contains("npm exited with exit code: 7"),
+            "final error must be the last probe error, got: {error}"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            VERSION_PROBE_ATTEMPTS,
+            "must attempt exactly the full budget"
+        );
+    }
+
+    #[test]
+    fn version_probe_budget_matches_spec() {
+        assert_eq!(VERSION_PROBE_ATTEMPTS, 3);
+        assert_eq!(
+            VERSION_PROBE_BACKOFFS,
+            [
+                Duration::from_millis(250),
+                Duration::from_millis(500),
+                Duration::from_millis(1000),
+            ]
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes a false "AionUi installation incomplete / reinstall / check antivirus" alert triggered by a single transient external-process failure during managed Node validation. In the reported incident, `npm --version` exited with code 7 once; the bundled runtime was actually healthy and activated ~38.8s later, so the alert was misleading and the reinstall/antivirus guidance was useless to the user.

**Root cause:** `command_version` ran the managed Node `--version` probe once with no retry, so a transient exit was latched into a permanent `bundled_resource_invalid` failure event that AionUi surfaced to the user and reported to Sentry.

**Fix:** Bounded retry on the `--version` probe, scoped entirely to AionCore. On retry success, `install_and_validate_with_reporter` returns `Ok` and never broadcasts `phase=Failed`, so the UI never shows the alert and never reports. `classify_error` and AionUi are intentionally untouched — this is Option 1 from the approved fix spec.

## Changes

- `crates/aionui-runtime/src/node_runtime/mod.rs`: split `command_version` into a thin wrapper plus `probe_command_version_with_retry` (generic, closure-injected, unit-testable, no process spawn) and `command_version_once` (the original body, verbatim). The public signature of `command_version` is unchanged, so all node/npm/npx call sites are untouched. New private constants `VERSION_PROBE_ATTEMPTS = 3` and `VERSION_PROBE_BACKOFFS = [250, 500, 1000]ms` (~1.75s worst case), independent of the existing copy-activation retry budget. Adds 4 inline unit tests that inject a closure and never exercise `command_version_once`.
- `crates/aionui-runtime/src/node_runtime/managed/tests.rs`: adds two `#[cfg(unix)]` tests that spawn real shell-script stand-ins for node/npm/npx (npm exits 7 for the first N invocations, then prints a version) and drive the real call chain `command_version -> validate_runtime -> validate_managed_runtime -> bundled activation path`. One covers a transient failure inside the retry budget (expects success, zero `Failed` phases reported); the other covers a persistent failure beyond the budget (expects `bundled_resource_invalid` still reported). Test-only, no product code changes.

## Scope boundaries (intentional)

- `classify_error` (managed.rs) and all AionUi files are deliberately unchanged. Persistent failures (probe failing for the full ~1.75s budget) still classify as `bundled_resource_invalid` and still alert/report, to avoid under-reporting real failures.
- Retry semantics: every failed attempt (including the last) sleeps its backoff, matching `activate_copy_with_retry`; a persistent failure spends the full ~1.75s before the verdict. Only transient error classes (process fails to start, non-zero exit, non-semver output) reach the retry loop — "node major too low" is decided in `validate_runtime`, outside the probe, and is never retried.
- Logging: one `warn` only when a retry will follow (fields `label`/`attempt`/`max_attempts`/`error`); the budget-exhausted final failure is left to the existing caller warn in `managed.rs` to avoid duplicate logging; no `info` on retry-success; no sensitive payloads.
- Known residual (accepted, documented in the fix spec): the false alert is not fully eliminated — 3 consecutive probe failures within ~1.75s plus no node `ready` within AionUi's 15s reconcile window will still alert/report. Further reduction is out of scope for this fix.

## Related repositories

- AionUi: no changes required for this fix. The existing reconciler, alert allowlist, and `RuntimeFailureKind` type are intentionally untouched.
- aionrs: not involved.

## Test plan

- [x] `cargo test -p aionui-runtime version_probe` — 4 new closure-injected unit tests pass (RED before implementation, GREEN after).
- [x] `cargo test -p aionui-runtime` — full crate regression, 94 passed / 0 failed, including unchanged classification tests (`classify_error_still_detects_bundled_invalid_by_message`, `classify_error_detects_bundled_node_runtime_missing`, `bundled_runtime_missing_reports_bundled_resource_missing`).
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p aionui-runtime -- -D warnings` — clean.
- [x] `just push` — full pre-push gate (migration check, lint, format, workspace test suite: 8119 tests run, 8119 passed) — clean.
- [ ] The two new `#[cfg(unix)]` subprocess-driven tests (added in the second commit) are not yet covered by a logged CI run against this exact HEAD in the fix archive; they ran as part of the `just push` workspace suite above but are worth a second look in CI given they are Unix-only and won't run on Windows, where the original incident occurred. The retry logic itself is platform-independent and is covered on every platform by the `version_probe_*` unit tests.
- [ ] End-to-end confirmation that the user-facing alert and the Sentry `runtime-installation-integrity-failure` report no longer fire on a transient-but-recoverable probe failure in a real/packaged environment is out of automated scope for this fix and has not been executed.
