### PR TITLE
feat(conversation): fork a conversation into a new one at a chosen message

### DIFF
--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -68,6 +68,14 @@ pub(super) async fn build(
     }
 
     if matches!(route_for_backend(config.backend.as_deref()), BackendRoute::Antigravity) {
+        // Product decision: antigravity has no fork surface. The fork API's
+        // capability gate already refuses agy; this is defense in depth so a
+        // hand-crafted fork spec can never open a context-free session.
+        if config.fork.is_some() {
+            return Err(AgentError::Conflict(
+                "antigravity conversations cannot be forked".into(),
+            ));
+        }
         return super::antigravity::build(
             deps,
             crate::session_context::AntigravitySessionBuildContext {

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -1175,7 +1175,14 @@ impl AcpAgentManager {
         };
 
         let sid = match (session_id, opened) {
-            (None, _) => self.open_session_new().await?,
+            // Unbound + fork spec: the forked conversation's backend session
+            // has not materialized yet → session/fork against the parent sid
+            // (never session/new — that would silently drop the parent
+            // context the user forked for).
+            (None, _) => match self.params.config.fork.as_ref() {
+                Some(fork) => self.open_session_fork(fork).await?,
+                None => self.open_session_new().await?,
+            },
             (Some(sid), false) => self.open_session_resume(&sid).await?,
             (Some(sid), true) => sid,
         };

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -10,8 +10,8 @@ use crate::protocol::send_error::AgentSendError;
 use crate::shared_kernel::SessionId as DomainSessionId;
 use crate::types::SendMessageData;
 use agent_client_protocol::schema::v1::{
-    AuthMethod, ContentBlock, LoadSessionRequest, PromptRequest, PromptResponse, SessionId, StopReason, Usage,
-    UsageUpdate,
+    AuthMethod, ContentBlock, ForkSessionRequest, LoadSessionRequest, PromptRequest, PromptResponse, SessionId,
+    StopReason, Usage, UsageUpdate,
 };
 use aionui_api_types::SlashCommandItem;
 use serde_json::Value;
@@ -235,6 +235,85 @@ impl AcpAgentManager {
         match self.reconcile_session(session_id).await {
             Ok(()) => Ok(session_id.to_owned()),
             Err(e) if is_acp_session_not_found(&e) => self.rebuild_after_session_not_found(session_id, &e).await,
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Materialize a forked conversation's backend session: `session/fork`
+    /// against the PARENT sid, absorbing the response exactly like
+    /// `session/load` and persisting the NEW sid via `SessionAssigned`.
+    ///
+    /// Deliberately different failure contract from resume: an initial fork
+    /// NEVER falls back to `session/new` — the user asked for the parent's
+    /// context, and a silent fresh session would drop it. Both a missing
+    /// capability and a `SessionNotFound` (the agent does not persist the
+    /// parent session across processes) surface as explicit errors; the fork
+    /// conversation stays unbound (sid NULL) so a later attempt may retry.
+    pub(super) async fn open_session_fork(&self, fork: &aionui_api_types::ForkSpec) -> Result<String, AgentError> {
+        // Live capability gate (second line of defense behind the fork API's
+        // agent_metadata check — the DB declaration can lag the installed CLI).
+        let supports_fork = {
+            let session = self.session.read().await;
+            session
+                .agent_capabilities()
+                .map(|c| c.session_capabilities.fork.is_some())
+                .unwrap_or(false)
+        };
+        if !supports_fork {
+            return Err(AgentError::Conflict(format!(
+                "agent '{}' does not advertise session/fork; cannot materialize the forked conversation",
+                self.backend().unwrap_or("<unknown>")
+            )));
+        }
+
+        let mut req = ForkSessionRequest::new(
+            SessionId::new(fork.parent_session_id.as_str()),
+            &self.params.workspace.path,
+        );
+        if !self.params.mcp_servers.is_empty() {
+            req = req.mcp_servers(self.params.mcp_servers.clone());
+        }
+        let fork_response = match self.protocol.fork_session(req).await {
+            Ok(r) => r,
+            Err(e) if is_acp_session_not_found(&e) => {
+                // NOT rebuild_after_session_not_found: an initial fork must not
+                // silently degrade to a fresh, context-free session.
+                return Err(AgentError::NotFound(format!(
+                    "session/fork: the parent session '{}' is gone on the agent side ({e}); \
+                     the agent may not persist sessions across restarts",
+                    fork.parent_session_id
+                )));
+            }
+            Err(e) => return Err(e.into()),
+        };
+        let new_sid = fork_response.session_id.to_string();
+
+        {
+            let mut session = self.session.write().await;
+            if let Some(modes) = fork_response.modes {
+                session.apply_advertised_modes(modes);
+            }
+            if let Some(config_options) = fork_response.config_options {
+                session.apply_advertised_config_options(config_options);
+            }
+            session.set_session_id(DomainSessionId::new(new_sid.clone()));
+            self.commit_session_changes(&mut session).await;
+        }
+        self.emit_snapshot_events().await;
+
+        // Persist the NEW sid (acp_session.session_id): from here on every
+        // rebuild takes the plain resume path and the fork spec degrades to
+        // lineage display data.
+        self.runtime
+            .emit(AgentStreamEvent::SessionAssigned(SessionAssignedEventData {
+                session_id: new_sid.clone(),
+            }));
+
+        match self.reconcile_session(&new_sid).await {
+            Ok(()) => Ok(new_sid),
+            // Post-fork reconcile hiccups keep the normal resume-era semantics
+            // (the fork itself succeeded and is persisted).
+            Err(e) if is_acp_session_not_found(&e) => self.rebuild_after_session_not_found(&new_sid, &e).await,
             Err(e) => Err(e.into()),
         }
     }
@@ -872,6 +951,46 @@ mod tests {
         session.apply_advertised_capabilities(caps);
         let supports_load = session.agent_capabilities().map(|c| c.load_session).unwrap_or(false);
         assert!(!supports_load);
+    }
+
+    /// `open_session_fork`'s live gate reads `session_capabilities.fork`
+    /// key-presence (ACP spec semantics: `Some({})` = supported). The three
+    /// cases mirror the session/load trio above.
+    #[test]
+    fn advertised_fork_capability_drives_supports_fork() {
+        let mut session = make_session();
+        let mut caps = AgentCapabilities::new();
+        caps.session_capabilities.fork = Some(Default::default());
+        session.apply_advertised_capabilities(caps);
+        let supports_fork = session
+            .agent_capabilities()
+            .map(|c| c.session_capabilities.fork.is_some())
+            .unwrap_or(false);
+        assert!(
+            supports_fork,
+            "`sessionCapabilities.fork: {{}}` must enable session/fork"
+        );
+    }
+
+    #[test]
+    fn missing_handshake_means_no_fork() {
+        let session = make_session();
+        let supports_fork = session
+            .agent_capabilities()
+            .map(|c| c.session_capabilities.fork.is_some())
+            .unwrap_or(false);
+        assert!(!supports_fork, "without an init handshake fork must be refused");
+    }
+
+    #[test]
+    fn absent_fork_capability_means_no_fork() {
+        let mut session = make_session();
+        session.apply_advertised_capabilities(AgentCapabilities::new());
+        let supports_fork = session
+            .agent_capabilities()
+            .map(|c| c.session_capabilities.fork.is_some())
+            .unwrap_or(false);
+        assert!(!supports_fork, "a handshake without the fork key must be refused");
     }
 
     /// Simulate the aggregate-state effect of a successful warmup that

--- a/crates/aionui-ai-agent/src/protocol/events/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/events/mod.rs
@@ -64,6 +64,13 @@ pub enum AgentStreamEvent {
     /// under one turn). The relay consumes it internally and never forwards it
     /// to the WebSocket, so no frontend renderer is required.
     SegmentBreak,
+    /// Internal-only: the backend's OWN id for the turn that just started
+    /// (codex `turn/started` → `Turn.id`). The relay consumes it to stamp
+    /// `messages.backend_turn_id` on every row it persists for this turn — the
+    /// lookup key for `thread/fork`'s `lastTurnId` when forking mid-history.
+    /// Never forwarded to the WebSocket; never user-visible output. Only the
+    /// direct-CLI codex pump emits it.
+    BackendTurnBound(String),
     /// Internal-only: one snapshot of a running workflow's progress.
     ///
     /// NOT forwarded to the WebSocket as-is. The relay projects it into the two

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -1328,12 +1328,26 @@ fn spec_mode_model(
 ) -> (aionui_session::SessionSpec, Option<String>, Option<String>) {
     use aionui_session::SessionSpec;
     let spec = match &backend_session_id {
+        // A bound session ALWAYS resumes — even on a forked conversation
+        // (its fork completed; the spec is now pure lineage data).
         Some(_) => SessionSpec::Resume {
             session_id: conversation_id.to_owned(),
             backend_session_id,
         },
-        None => SessionSpec::Fresh {
-            session_id: conversation_id.to_owned(),
+        // Unbound + fork spec = the fork has not materialized yet → open in
+        // Fork mode against the parent's snapshotted sid. This also makes a
+        // post-fork dead-anchor self-heal (clear_session_id) RE-FORK back to
+        // the fork point instead of silently opening Fresh — strictly better
+        // than the plain conversation's lost-anchor behavior.
+        None => match &config.fork {
+            Some(fork) => SessionSpec::Fork {
+                session_id: conversation_id.to_owned(),
+                parent_backend_session_id: fork.parent_session_id.clone(),
+                at_turn_id: fork.last_turn_id.clone(),
+            },
+            None => SessionSpec::Fresh {
+                session_id: conversation_id.to_owned(),
+            },
         },
     };
     // Normalize the resolved mode alias into the backend-native id — the SAME
@@ -3683,6 +3697,12 @@ fn translate_event(event: SessionEvent, conversation_id: &str, terminal_result_s
         // `TurnStarted` (never reaches this stream) — are therefore NOT re-projected
         // to Start here, or the frontend would see a late/duplicate turn boundary.
         SessionEvent::PromptAccepted { .. } | SessionEvent::TurnStarted { .. } => Vec::new(),
+        // Fork anchoring: forward the backend's own turn id as an internal-only
+        // relay frame so message rows persisted during this turn carry it
+        // (`messages.backend_turn_id`). Never reaches the WebSocket.
+        SessionEvent::BackendTurnBound { backend_turn_id } => {
+            vec![AgentStreamEvent::BackendTurnBound(backend_turn_id)]
+        }
         SessionEvent::MessageDelta { text, .. } => {
             vec![AgentStreamEvent::Text(TextEventData { content: text })]
         }
@@ -4277,6 +4297,48 @@ mod build_mapping_tests {
         ));
         assert_eq!(mode.as_deref(), Some("plan"));
         assert_eq!(model.as_deref(), Some("claude-x"));
+    }
+
+    /// Fork-spec quadrant matrix (sid x fork): a bound sid ALWAYS resumes (the
+    /// fork completed; the spec is lineage data); unbound + fork spec opens in
+    /// Fork mode against the parent's snapshotted sid; unbound + no spec stays
+    /// Fresh.
+    #[test]
+    fn spec_fork_quadrants() {
+        let fork_cfg = AcpBuildExtra {
+            fork: Some(aionui_api_types::ForkSpec {
+                parent_conversation_id: "conv_parent".into(),
+                parent_message_id: "msg_9".into(),
+                parent_session_id: "parent-sid".into(),
+                last_turn_id: Some("turn-4".into()),
+            }),
+            ..Default::default()
+        };
+        let plain_cfg = AcpBuildExtra::default();
+        let md = test_metadata(Some("codex"), None);
+
+        // (None, fork) -> Fork with the parent anchor + turn id.
+        let (spec, _, _) = spec_mode_model("conv_f", None, &fork_cfg, None, &md);
+        assert!(matches!(
+            spec,
+            SessionSpec::Fork { ref parent_backend_session_id, ref at_turn_id, .. }
+                if parent_backend_session_id == "parent-sid" && at_turn_id.as_deref() == Some("turn-4")
+        ));
+
+        // (Some, fork) -> Resume (fork already materialized; never re-fork).
+        let (spec, _, _) = spec_mode_model("conv_f", Some("own-sid".into()), &fork_cfg, None, &md);
+        assert!(matches!(
+            spec,
+            SessionSpec::Resume { backend_session_id: Some(ref b), .. } if b == "own-sid"
+        ));
+
+        // (None, no fork) -> Fresh.
+        let (spec, _, _) = spec_mode_model("conv_f", None, &plain_cfg, None, &md);
+        assert!(matches!(spec, SessionSpec::Fresh { .. }));
+
+        // (Some, no fork) -> Resume (unchanged baseline).
+        let (spec, _, _) = spec_mode_model("conv_f", Some("own-sid".into()), &plain_cfg, None, &md);
+        assert!(matches!(spec, SessionSpec::Resume { .. }));
     }
 
     // The interactive-switch-persisted snapshot selection MUST win over the

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -1564,17 +1564,17 @@ pub async fn build_session_instance(
         model,
         mode,
         init,
-        // Packaged app: resolve the bundled claude/codex binary and forward its
-        // absolute path so the backend spawns OUR CLI, not the user's PATH one.
-        // Bundled-missing / dev falls back to a PATH lookup via
+        // A user-selected launch path wins so the process uses the same binary
+        // that the registry health check accepted. Otherwise the packaged app
+        // resolves the bundled claude/codex binary and forwards its absolute
+        // path. Bundled-missing / dev falls back to a PATH lookup via
         // `resolve_command_path` (NOT the bare name): on Windows, npm installs
         // ship `claude.cmd`/`codex.cmd` shims which `CreateProcess` does not
         // find from a bare name (#299 parity; Rust std runs `.cmd` via
         // `cmd.exe` since the BatBadBut fix). `None` (nothing on PATH either)
         // keeps the bare name so the spawn error stays diagnosable. Detection
         // (cli_probe) stays PATH-only and is unaffected.
-        cli_program: aionui_runtime::resolve_bundled_cli(backend_label)
-            .or_else(|| aionui_runtime::resolve_command_path(backend_label)),
+        cli_program: resolve_session_cli_program(backend_label, metadata),
         ..Default::default()
     };
 
@@ -1767,6 +1767,24 @@ pub async fn build_session_instance(
         Some(broadcaster),
     );
     Ok(Some(crate::agent_task::AgentInstance::Session(task)))
+}
+
+fn resolve_session_cli_program(
+    backend_label: &str,
+    metadata: &aionui_api_types::AgentMetadata,
+) -> Option<std::path::PathBuf> {
+    if metadata.has_command_override {
+        return metadata.resolved_command.clone().or_else(|| {
+            metadata
+                .command
+                .as_deref()
+                .map(str::trim)
+                .filter(|command| !command.is_empty())
+                .map(std::path::PathBuf::from)
+        });
+    }
+
+    aionui_runtime::resolve_bundled_cli(backend_label).or_else(|| aionui_runtime::resolve_command_path(backend_label))
 }
 
 /// Assemble the direct-CLI spawn env (legacy spawn-surface parity; order
@@ -4266,6 +4284,19 @@ mod build_mapping_tests {
             has_command_override: false,
             env_override_key_count: 0,
         }
+    }
+
+    #[test]
+    fn session_cli_program_prefers_explicit_command_override() {
+        let mut metadata = test_metadata(Some("claude"), None);
+        metadata.has_command_override = true;
+        metadata.command = Some("claude".into());
+        metadata.resolved_command = Some(std::path::PathBuf::from("/custom/claude"));
+
+        assert_eq!(
+            resolve_session_cli_program("claude", &metadata),
+            Some(std::path::PathBuf::from("/custom/claude"))
+        );
     }
 
     #[test]

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -75,6 +75,7 @@ async fn make_mock_agent(script: &str, backend: &str) -> (Arc<AcpAgentManager>, 
         mcp_server_ids: None,
         session_mcp_servers: vec![],
         user_id: None,
+        fork: None,
     };
 
     let tmp_skills = tempfile::TempDir::new().unwrap();
@@ -195,6 +196,7 @@ fn event_type_name(event: &AgentStreamEvent) -> &'static str {
         AgentStreamEvent::SlashCommandsUpdated(_) => "SlashCommandsUpdated",
         AgentStreamEvent::SessionAssigned(_) => "SessionAssigned",
         AgentStreamEvent::SegmentBreak => "SegmentBreak",
+        AgentStreamEvent::BackendTurnBound(_) => "BackendTurnBound",
         AgentStreamEvent::WorkflowProgress(_) => "WorkflowProgress",
         AgentStreamEvent::AcpDialectSignal(_) => "AcpDialectSignal",
     }

--- a/crates/aionui-ai-agent/tests/prompt_pipeline_integration.rs
+++ b/crates/aionui-ai-agent/tests/prompt_pipeline_integration.rs
@@ -51,6 +51,7 @@ async fn fixture_params(
         mcp_server_ids: None,
         session_mcp_servers: vec![],
         user_id: None,
+        fork: None,
     };
 
     Arc::new(

--- a/crates/aionui-api-types/src/agent_build_extra.rs
+++ b/crates/aionui-api-types/src/agent_build_extra.rs
@@ -38,6 +38,28 @@ pub struct SessionMcpServer {
     pub transport: SessionMcpTransport,
 }
 
+/// The fork spec a forked conversation carries in `conversations.extra.fork`
+/// until its backend session materializes: the parent lineage (UI display) plus
+/// the snapshot the first open needs to fork the backend session. Written ONLY
+/// by the server-side fork API (`create()` strips a client-supplied `fork` key);
+/// once the fork completes and a session id is persisted, this degrades to pure
+/// lineage display data.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForkSpec {
+    /// The conversation this one was forked from (lineage display; soft
+    /// reference — the parent may be deleted later).
+    pub parent_conversation_id: String,
+    /// The fork-point message in the PARENT conversation (inclusive).
+    pub parent_message_id: String,
+    /// The parent's backend session id, snapshotted AT FORK TIME (the parent
+    /// may rotate/advance afterwards; the fork must not chase it).
+    pub parent_session_id: String,
+    /// Backend turn anchor for an at-turn fork (codex `lastTurnId`); `None` =
+    /// fork at HEAD.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_turn_id: Option<String>,
+}
+
 /// ACP-specific fields extracted from `extra` in build task options.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AcpBuildExtra {
@@ -73,6 +95,10 @@ pub struct AcpBuildExtra {
     pub session_mcp_servers: Vec<SessionMcpServer>,
     #[serde(default)]
     pub user_id: Option<String>,
+    /// Present only on a forked conversation (see [`ForkSpec`]). Consumed by
+    /// the first session open when no backend session id is bound yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork: Option<ForkSpec>,
 }
 
 /// Aionrs-specific fields extracted from `extra` in build task options.

--- a/crates/aionui-api-types/src/conversation.rs
+++ b/crates/aionui-api-types/src/conversation.rs
@@ -66,6 +66,34 @@ pub struct CreateConversationRequest {
     pub extra: serde_json::Value,
 }
 
+/// Body for `POST /api/conversations/{id}/fork`.
+///
+/// Forks the conversation at `message_id` (inclusive) into a NEW conversation
+/// that inherits the parent's workspace/agent/history. The backend session
+/// materializes lazily on the fork's first open (see `AcpBuildExtra.fork`).
+#[derive(Debug, Deserialize)]
+pub struct ForkConversationRequest {
+    /// The fork point: a message in the parent conversation (inclusive).
+    pub message_id: String,
+    /// Optional name for the forked conversation; defaults to the parent's.
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+/// Session-fork capability projection for one conversation, sourced from
+/// `agent_metadata.agent_capabilities.session_capabilities.fork` (ACP agents:
+/// handshake-persisted; claude/codex: migration-constructed). `Some` = the fork
+/// entry point may be shown; `None` = hidden. Filled only on the single-
+/// conversation detail path (list responses omit it — no N+1).
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForkCapabilityView {
+    /// Whether the backend can fork at an ARBITRARY turn (codex
+    /// `thread/fork.lastTurnId`). `false` = HEAD fork only → the UI shows the
+    /// entry point only on the last turn's messages.
+    #[serde(default)]
+    pub at_turn: bool,
+}
+
 /// Body for `PATCH /api/conversations/:id`.
 ///
 /// All fields optional — only supplied fields are applied.
@@ -242,6 +270,10 @@ pub struct ConversationResponse {
     pub assistant: Option<ConversationAssistantIdentityResponse>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub project_id: Option<String>,
+    /// Service-layer post-fill on the DETAIL path only (like `runtime`);
+    /// `None` on list responses. See [`ForkCapabilityView`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_capability: Option<ForkCapabilityView>,
     pub created_at: TimestampMs,
     pub modified_at: TimestampMs,
     pub extra: serde_json::Value,
@@ -635,6 +667,7 @@ mod tests {
             created_at: 1712345678000,
             modified_at: 1712345678000,
             extra: json!({ "workspace": "/project" }),
+            fork_capability: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["id"], "conv_1");
@@ -675,6 +708,7 @@ mod tests {
             created_at: 1,
             modified_at: 1,
             extra: json!({}),
+            fork_capability: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert!(json.get("model").is_none(), "model None should be omitted");
@@ -709,6 +743,7 @@ mod tests {
             created_at: 1000,
             modified_at: 2000,
             extra: json!({}),
+            fork_capability: None,
         };
         let serialized = serde_json::to_string(&resp).unwrap();
         let deserialized: ConversationResponse = serde_json::from_str(&serialized).unwrap();
@@ -795,6 +830,7 @@ mod tests {
                 created_at: 1712345678000,
                 modified_at: 1712345678000,
                 extra: json!({}),
+                fork_capability: None,
             },
         };
         let json = serde_json::to_value(&item).unwrap();
@@ -834,6 +870,7 @@ mod tests {
                 created_at: 9000,
                 modified_at: 9000,
                 extra: json!({}),
+                fork_capability: None,
             },
         };
         let serialized = serde_json::to_string(&item).unwrap();
@@ -925,6 +962,7 @@ mod tests {
                 created_at: 1000,
                 modified_at: 1000,
                 extra: json!({}),
+                fork_capability: None,
             }],
             total: 1,
             has_more: false,
@@ -979,6 +1017,7 @@ mod tests {
                     created_at: 5000,
                     modified_at: 5000,
                     extra: json!({}),
+                    fork_capability: None,
                 },
             }],
             total: 1,

--- a/crates/aionui-api-types/src/conversation.rs
+++ b/crates/aionui-api-types/src/conversation.rs
@@ -294,6 +294,12 @@ pub struct MessageResponse {
     pub status: Option<MessageStatus>,
     pub hidden: bool,
     pub created_at: TimestampMs,
+    /// Backend turn anchor (codex `Turn.id`) stamped on rows persisted while
+    /// that turn streamed. Presence tells the UI a mid-history fork can anchor
+    /// at (or after) this message; absent on legacy/copied rows and on
+    /// backends without turn-anchored forks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend_turn_id: Option<String>,
 }
 
 /// Cursor-paginated list of messages.
@@ -767,6 +773,7 @@ mod tests {
             status: Some(MessageStatus::Finish),
             hidden: false,
             created_at: 1712345678000,
+            backend_turn_id: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["id"], "msg_1");
@@ -795,6 +802,7 @@ mod tests {
             status: None,
             hidden: true,
             created_at: 5000,
+            backend_turn_id: None,
         };
         let serialized = serde_json::to_string(&resp).unwrap();
         let deserialized: MessageResponse = serde_json::from_str(&serialized).unwrap();

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -43,7 +43,7 @@ pub use acp::{
 };
 pub use acp_prompt_hook::AcpPromptHookWarningPayload;
 pub use agent_build_extra::{
-    AcpBuildExtra, AcpModelInfo, AionrsBuildExtra, SessionMcpServer, SessionMcpTransport,
+    AcpBuildExtra, AcpModelInfo, AionrsBuildExtra, ForkSpec, SessionMcpServer, SessionMcpTransport,
     SlashCommandCompletionBehavior, SlashCommandItem,
 };
 pub use agent_discovery::{

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -89,11 +89,11 @@ pub use conversation::{
     CancelConversationRequest, CancelConversationResponse, CloneConversationRequest, ConversationArtifactKind,
     ConversationArtifactListResponse, ConversationArtifactResponse, ConversationArtifactStatus,
     ConversationAssistantIdentityResponse, ConversationListResponse, ConversationMcpStatus, ConversationMcpStatusKind,
-    ConversationNameUpdatedPayload, ConversationResponse, ConversationRuntimeStateKind,
-    ConversationRuntimeSummary, CreateConversationRequest, EnsureConversationRuntimeResponse,
-    ForkCapabilityView, ForkConversationRequest, ListConversationsQuery, ListMessagesQuery,
-    MessageListResponse, MessageResponse, MessageSearchItem, MessageSearchResponse, SearchMessagesQuery,
-    SendMessageRequest, SendMessageResponse, UpdateConversationArtifactRequest, UpdateConversationRequest,
+    ConversationNameUpdatedPayload, ConversationResponse, ConversationRuntimeStateKind, ConversationRuntimeSummary,
+    CreateConversationRequest, EnsureConversationRuntimeResponse, ForkCapabilityView, ForkConversationRequest,
+    ListConversationsQuery, ListMessagesQuery, MessageListResponse, MessageResponse, MessageSearchItem,
+    MessageSearchResponse, SearchMessagesQuery, SendMessageRequest, SendMessageResponse,
+    UpdateConversationArtifactRequest, UpdateConversationRequest,
 };
 pub use cron::{
     CreateConversationCronRequest, CreateConversationCronResponse, CreateCronJobRequest, CronAgentConfigReadDto,

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -89,8 +89,9 @@ pub use conversation::{
     CancelConversationRequest, CancelConversationResponse, CloneConversationRequest, ConversationArtifactKind,
     ConversationArtifactListResponse, ConversationArtifactResponse, ConversationArtifactStatus,
     ConversationAssistantIdentityResponse, ConversationListResponse, ConversationMcpStatus, ConversationMcpStatusKind,
-    ConversationNameUpdatedPayload, ConversationResponse, ConversationRuntimeStateKind, ConversationRuntimeSummary,
-    CreateConversationRequest, EnsureConversationRuntimeResponse, ListConversationsQuery, ListMessagesQuery,
+    ConversationNameUpdatedPayload, ConversationResponse, ConversationRuntimeStateKind,
+    ConversationRuntimeSummary, CreateConversationRequest, EnsureConversationRuntimeResponse,
+    ForkCapabilityView, ForkConversationRequest, ListConversationsQuery, ListMessagesQuery,
     MessageListResponse, MessageResponse, MessageSearchItem, MessageSearchResponse, SearchMessagesQuery,
     SendMessageRequest, SendMessageResponse, UpdateConversationArtifactRequest, UpdateConversationRequest,
 };

--- a/crates/aionui-app/tests/conversation_e2e.rs
+++ b/crates/aionui-app/tests/conversation_e2e.rs
@@ -888,6 +888,7 @@ async fn t7_1_reset_conversation() {
         status: None,
         hidden: false,
         created_at: 1000,
+        backend_turn_id: None,
     };
     let user_id = repo.owner_user_id(&id).await.unwrap().unwrap();
     aionui_db::IConversationRepository::insert_message(&repo, &user_id, &msg)
@@ -980,6 +981,7 @@ async fn team_owned_conversation_rejects_ordinary_send_but_allows_history_reads(
         status: Some("finish".into()),
         hidden: false,
         created_at: 1000,
+        backend_turn_id: None,
     };
     let user_id = repo.owner_user_id(&id).await.unwrap().unwrap();
     aionui_db::IConversationRepository::insert_message(&repo, &user_id, &msg)

--- a/crates/aionui-app/tests/message_e2e.rs
+++ b/crates/aionui-app/tests/message_e2e.rs
@@ -46,6 +46,7 @@ async fn insert_message(
         status: Some("finish".into()),
         hidden: false,
         created_at,
+        backend_turn_id: None,
     };
     aionui_db::IConversationRepository::insert_message(&repo, &user_id, &msg)
         .await
@@ -102,6 +103,7 @@ async fn insert_acp_tool_message(
         status: Some("finish".into()),
         hidden: false,
         created_at,
+        backend_turn_id: None,
     };
     aionui_db::IConversationRepository::insert_message(&repo, &user_id, &msg)
         .await
@@ -428,6 +430,7 @@ async fn t8_7_messages_exclude_legacy_cron_rows() {
             status: Some("finish".into()),
             hidden: false,
             created_at: 2000,
+            backend_turn_id: None,
         };
         let user_id = repo.owner_user_id(&conv_id).await.unwrap().unwrap();
         aionui_db::IConversationRepository::insert_message(&repo, &user_id, &msg)

--- a/crates/aionui-channel/src/message_service.rs
+++ b/crates/aionui-channel/src/message_service.rs
@@ -235,6 +235,7 @@ impl ChannelMessageService {
             | AgentStreamEvent::SlashCommandsUpdated(_)
             | AgentStreamEvent::SessionAssigned(_)
             | AgentStreamEvent::SegmentBreak
+            | AgentStreamEvent::BackendTurnBound(_)
             // A workflow progress refresh is a live re-render of a card in the
             // web UI; an IM transcript has no card to update, and streaming one
             // message per refresh would spam the channel.

--- a/crates/aionui-conversation/src/convert.rs
+++ b/crates/aionui-conversation/src/convert.rs
@@ -161,6 +161,7 @@ pub fn row_to_message_response(row: MessageRow) -> Result<MessageResponse, Conve
         status,
         hidden: row.hidden,
         created_at: row.created_at,
+        backend_turn_id: row.backend_turn_id,
     })
 }
 

--- a/crates/aionui-conversation/src/convert.rs
+++ b/crates/aionui-conversation/src/convert.rs
@@ -76,6 +76,9 @@ pub fn row_to_response_with_extra(
         channel_chat_id: row.channel_chat_id,
         assistant: None,
         project_id: row.project_id,
+        // Detail-path post-fill only (see `attach_fork_capability`); convert
+        // stays a pure mapper with no repo access.
+        fork_capability: None,
         created_at: row.created_at,
         modified_at: row.updated_at,
         extra,

--- a/crates/aionui-conversation/src/message_persistence.rs
+++ b/crates/aionui-conversation/src/message_persistence.rs
@@ -53,6 +53,7 @@ impl ConversationService {
             status: Some("error".into()),
             hidden: false,
             created_at: now_ms(),
+            backend_turn_id: None,
         };
 
         if let Err(store_err) = self.conversation_repo().insert_message(user_id, &row).await {

--- a/crates/aionui-conversation/src/routes.rs
+++ b/crates/aionui-conversation/src/routes.rs
@@ -10,9 +10,9 @@ use aionui_api_types::{
     ActiveCountResponse, ApiResponse, ApprovalCheckQuery, ApprovalCheckResponse, CancelConversationRequest,
     CancelConversationResponse, CloneConversationRequest, ConfirmRequest, ConfirmationListResponse,
     ConversationArtifactListResponse, ConversationArtifactResponse, ConversationListResponse, ConversationResponse,
-    CreateConversationRequest, EnsureConversationRuntimeResponse, ListConversationsQuery, ListMessagesQuery,
-    MessageListResponse, MessageResponse, MessageSearchResponse, SearchMessagesQuery, SendMessageRequest,
-    SendMessageResponse, UpdateConversationArtifactRequest, UpdateConversationRequest,
+    CreateConversationRequest, EnsureConversationRuntimeResponse, ForkConversationRequest, ListConversationsQuery,
+    ListMessagesQuery, MessageListResponse, MessageResponse, MessageSearchResponse, SearchMessagesQuery,
+    SendMessageRequest, SendMessageResponse, UpdateConversationArtifactRequest, UpdateConversationRequest,
 };
 use aionui_auth::CurrentUser;
 use aionui_common::ApiError;
@@ -113,6 +113,7 @@ pub fn conversation_routes(state: ConversationRouterState) -> Router {
         .route("/api/conversations", post(create).get(list))
         .route("/api/conversations/{id}", get(get_one).patch(update).delete(delete_one))
         .route("/api/conversations/{id}/reset", post(reset))
+        .route("/api/conversations/{id}/fork", post(fork))
         .route("/api/conversations/{id}/associated", get(associated))
         .route("/api/conversations/{id}/messages", get(list_msg).post(send_msg))
         .route("/api/conversations/{id}/messages/{messageId}", get(get_msg))
@@ -206,6 +207,17 @@ async fn reset(
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
     state.service.reset(&user.id, &id).await.map_err(ApiError::from)?;
     Ok(Json(ApiResponse::success()))
+}
+
+async fn fork(
+    State(state): State<ConversationRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    Path(id): Path<String>,
+    body: Result<Json<ForkConversationRequest>, JsonRejection>,
+) -> Result<(StatusCode, Json<ApiResponse<ConversationResponse>>), ApiError> {
+    let Json(req) = body.map_err(ApiError::from)?;
+    let conversation = state.service.fork(&user.id, &id, req).await.map_err(ApiError::from)?;
+    Ok((StatusCode::CREATED, Json(ApiResponse::ok(conversation))))
 }
 
 async fn associated(

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -2701,14 +2701,13 @@ impl ConversationService {
                 config_selections_json: None,
                 context_usage_json: None,
             };
-            if seed.current_mode_id.is_some() || seed.current_model_id.is_some() {
-                if let Err(err) = self
+            if (seed.current_mode_id.is_some() || seed.current_model_id.is_some())
+                && let Err(err) = self
                     .acp_session_repo
                     .save_runtime_state_for_user(user_id, &new_id, &seed)
                     .await
-                {
-                    warn!(error = %ErrorChain(&err), "fork: failed to seed runtime state (non-fatal)");
-                }
+            {
+                warn!(error = %ErrorChain(&err), "fork: failed to seed runtime state (non-fatal)");
             }
         }
 

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -19,14 +19,12 @@ use aionui_api_types::{
     ApprovalCheckResponse, AssistantConversationOverridesRequest, CancelConversationResponse, CloneConversationRequest,
     ConfirmRequest, ConfirmationListResponse, ConversationArtifactKind, ConversationArtifactListResponse,
     ConversationArtifactResponse, ConversationArtifactStatus, ConversationListResponse, ConversationMcpStatus,
-    ConversationMcpStatusKind, ConversationNameUpdatedPayload, ConversationResponse,
-    ConversationRuntimeSummary, CreateConversationRequest, EnsureConversationRuntimeResponse,
-    ForkCapabilityView, ForkConversationRequest, ListConversationsQuery, ListMessagesQuery,
-    MessageListResponse, MessageResponse, MessageSearchResponse, SearchMessagesQuery, SendMessageRequest,
-    SendMessageResponse, SessionMcpServer, SessionMcpTransport, TeamSessionBinding,
-    UpdateConversationArtifactRequest, UpdateConversationRequest, WebSocketMessage,
-    assistant_avatar_response_value,
-    assistant_avatar_response_value_with_version,
+    ConversationMcpStatusKind, ConversationNameUpdatedPayload, ConversationResponse, ConversationRuntimeSummary,
+    CreateConversationRequest, EnsureConversationRuntimeResponse, ForkCapabilityView, ForkConversationRequest,
+    ListConversationsQuery, ListMessagesQuery, MessageListResponse, MessageResponse, MessageSearchResponse,
+    SearchMessagesQuery, SendMessageRequest, SendMessageResponse, SessionMcpServer, SessionMcpTransport,
+    TeamSessionBinding, UpdateConversationArtifactRequest, UpdateConversationRequest, WebSocketMessage,
+    assistant_avatar_response_value, assistant_avatar_response_value_with_version,
 };
 use aionui_common::{
     AgentKillReason, AgentType, ConversationSource, ConversationStatus, ErrorChain, MessageType, OnConversationDelete,
@@ -2625,13 +2623,19 @@ impl ConversationService {
             );
         }
 
+        let explicit_name = req.name.filter(|n| !n.is_empty());
+        // Caller-chosen name = user intent (auto-titling must not overwrite it);
+        // an inherited parent name keeps the parent's provenance marker.
+        let name_source = if explicit_name.is_some() {
+            Some("user".to_owned())
+        } else {
+            parent.name_source.clone()
+        };
         let row = aionui_db::models::ConversationRow {
             id: new_id.clone(),
             user_id: user_id.to_owned(),
-            name: req
-                .name
-                .filter(|n| !n.is_empty())
-                .unwrap_or_else(|| parent.name.clone()),
+            name: explicit_name.unwrap_or_else(|| parent.name.clone()),
+            name_source,
             r#type: parent.r#type.clone(),
             extra: serde_json::to_string(&extra)
                 .map_err(|e| ConversationError::internal(format!("Failed to serialize extra: {e}")))?,

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -19,11 +19,13 @@ use aionui_api_types::{
     ApprovalCheckResponse, AssistantConversationOverridesRequest, CancelConversationResponse, CloneConversationRequest,
     ConfirmRequest, ConfirmationListResponse, ConversationArtifactKind, ConversationArtifactListResponse,
     ConversationArtifactResponse, ConversationArtifactStatus, ConversationListResponse, ConversationMcpStatus,
-    ConversationMcpStatusKind, ConversationNameUpdatedPayload, ConversationResponse, ConversationRuntimeSummary,
-    CreateConversationRequest, EnsureConversationRuntimeResponse, ListConversationsQuery, ListMessagesQuery,
+    ConversationMcpStatusKind, ConversationNameUpdatedPayload, ConversationResponse,
+    ConversationRuntimeSummary, CreateConversationRequest, EnsureConversationRuntimeResponse,
+    ForkCapabilityView, ForkConversationRequest, ListConversationsQuery, ListMessagesQuery,
     MessageListResponse, MessageResponse, MessageSearchResponse, SearchMessagesQuery, SendMessageRequest,
-    SendMessageResponse, SessionMcpServer, SessionMcpTransport, TeamSessionBinding, UpdateConversationArtifactRequest,
-    UpdateConversationRequest, WebSocketMessage, assistant_avatar_response_value,
+    SendMessageResponse, SessionMcpServer, SessionMcpTransport, TeamSessionBinding,
+    UpdateConversationArtifactRequest, UpdateConversationRequest, WebSocketMessage,
+    assistant_avatar_response_value,
     assistant_avatar_response_value_with_version,
 };
 use aionui_common::{
@@ -915,6 +917,10 @@ impl ConversationService {
 
         let mut extra = req.extra;
         strip_request_owner_user_id(&mut extra);
+        // `extra.fork` is server-minted by the fork API only. A client-supplied
+        // value would let anyone fork an arbitrary `parent_session_id` they do
+        // not own — strip it unconditionally on the create path.
+        strip_request_fork_spec(&mut extra);
 
         let assistant_id = req
             .assistant
@@ -2036,6 +2042,15 @@ impl ConversationService {
         let mut response = row_to_response_with_extra(row, extra, &self.workspace_root)?;
         self.attach_assistant_identity(user_id, &mut response).await?;
         response.runtime = Some(self.runtime_summary_for(id).await);
+        // Fork capability: detail-path-only post-fill (list stays N+1-free).
+        // Best-effort — a lookup failure just hides the fork entry point.
+        if let Ok(Some(acp_row)) = self.acp_session_repo.get_for_user(user_id, id).await
+            && let Ok(capability) = self
+                .fork_capability_for_agent(user_id, &acp_row.agent_id, &response.extra.to_string())
+                .await
+        {
+            response.fork_capability = capability;
+        }
         if project_backfilled {
             self.broadcast_list_changed(user_id, id, "updated", response.source.as_ref());
         }
@@ -2375,7 +2390,33 @@ impl ConversationService {
             .source
             .as_deref()
             .and_then(|s| string_to_enum::<ConversationSource>(s).ok());
-        let auto_workspace_to_delete = auto_provisioned_workspace_to_delete(&self.workspace_root, &existing, id);
+        let mut auto_workspace_to_delete = auto_provisioned_workspace_to_delete(&self.workspace_root, &existing, id);
+        // Shared-workspace guard: a forked conversation inherits the parent's
+        // auto workspace verbatim (claude keys on-disk sessions by cwd), so
+        // deleting the parent must not rip the directory out from under the
+        // fork. Checked BEFORE the row delete (`list_associated` reads the
+        // source row). Fails closed: an error keeps the workspace.
+        if auto_workspace_to_delete.is_some() {
+            match self.conversation_repo.list_associated(user_id, id).await {
+                Ok(rows) if !rows.is_empty() => {
+                    info!(
+                        conversation_id = %id,
+                        remaining_references = rows.len(),
+                        "Skipping auto-workspace removal: other conversations still share it"
+                    );
+                    auto_workspace_to_delete = None;
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    warn!(
+                        conversation_id = %id,
+                        error = %ErrorChain(&err),
+                        "Shared-workspace check failed; keeping the workspace to be safe"
+                    );
+                    auto_workspace_to_delete = None;
+                }
+            }
+        }
 
         let had_active_turn = self.runtime_state.mark_deleting(id);
 
@@ -2450,6 +2491,291 @@ impl ConversationService {
         req: CloneConversationRequest,
     ) -> Result<ConversationResponse, ConversationError> {
         self.create(user_id, req.conversation).await
+    }
+
+    /// Fork a conversation at a message (inclusive) into a NEW conversation.
+    ///
+    /// The fork API is pure bookkeeping: it validates, snapshots the parent's
+    /// backend session id into `extra.fork`, creates the new row (same
+    /// workspace — claude keys on-disk sessions by cwd), copies the visible
+    /// history, and returns. The BACKEND session materializes lazily on the
+    /// fork's first open (`SessionSpec::Fork` / ACP `session/fork`); the
+    /// frontend calls `POST {new_id}/runtime/ensure` right after to surface
+    /// fork failures eagerly.
+    ///
+    /// Error contract (stable `reason` prefixes the frontend maps to i18n):
+    /// 403 team / 404 conversation or message / 409 `FORK_TURN_IN_FLIGHT`,
+    /// `FORK_PARENT_UNBOUND` / 422 `FORK_UNSUPPORTED`, `FORK_POINT_UNSUPPORTED`.
+    #[tracing::instrument(skip_all, fields(user_id = %user_id, conversation_id = %id))]
+    pub async fn fork(
+        &self,
+        user_id: &str,
+        id: &str,
+        req: ForkConversationRequest,
+    ) -> Result<ConversationResponse, ConversationError> {
+        let parent = self
+            .conversation_repo
+            .get(user_id, id)
+            .await?
+            .ok_or_else(|| ConversationError::NotFound { id: id.to_owned() })?;
+
+        if team_id_from_extra(&parent.extra).is_some() {
+            return Err(ConversationError::Forbidden {
+                reason: "team conversations cannot be forked".into(),
+            });
+        }
+        // A turn in flight means the parent's backend session is advancing
+        // right now — the snapshotted sid would race the stream (and claude's
+        // HEAD-fork point would be mid-sentence).
+        if self.runtime_state.active_turn_id_for(id).is_some() {
+            return Err(ConversationError::Busy {
+                reason: "FORK_TURN_IN_FLIGHT: wait for the current reply to finish before forking".into(),
+            });
+        }
+
+        // Capability gate + parent session anchor, both from the acp_session
+        // row (claude/codex/ACP all share it; other agent types have none).
+        let acp_row = self
+            .acp_session_repo
+            .get_for_user(user_id, id)
+            .await
+            .map_err(|e| ConversationError::internal(format!("acp_session lookup: {e}")))?
+            .ok_or_else(|| ConversationError::Unprocessable {
+                reason: "FORK_UNSUPPORTED: this conversation type cannot be forked".into(),
+            })?;
+        let fork_capability = self
+            .fork_capability_for_agent(user_id, &acp_row.agent_id, &parent.extra)
+            .await?
+            .ok_or_else(|| ConversationError::Unprocessable {
+                reason: "FORK_UNSUPPORTED: this agent does not support session forking".into(),
+            })?;
+        let parent_session_id = acp_row.session_id.clone().ok_or_else(|| ConversationError::Busy {
+            reason: "FORK_PARENT_UNBOUND: the conversation has no backend session to fork yet".into(),
+        })?;
+
+        // Fork point: must be a message of the PARENT conversation. Cursor is
+        // the display sort key (created_at, id), endpoint inclusive.
+        let fork_point = self
+            .conversation_repo
+            .get_message(user_id, id, &req.message_id)
+            .await?
+            .ok_or_else(|| ConversationError::MessageNotFound {
+                id: req.message_id.clone(),
+            })?;
+        let cursor = (fork_point.created_at, fork_point.id.as_str());
+
+        // HEAD detection against the visible timeline (the same filtered view
+        // the UI renders and the copy uses).
+        let latest = self
+            .conversation_repo
+            .list_messages_page(
+                user_id,
+                id,
+                &aionui_db::MessagePageParams {
+                    limit: 1,
+                    direction: aionui_db::MessagePageDirection::InitialLatest,
+                },
+            )
+            .await?;
+        let is_head = latest.items.last().is_none_or(|m| m.id == fork_point.id);
+
+        let last_turn_id = if is_head {
+            // HEAD fork: every backend supports it and no anchor is needed
+            // (codex `lastTurnId` omitted = fork at HEAD).
+            None
+        } else if fork_capability.at_turn {
+            // Mid-history fork (codex): resolve the backend turn anchor from
+            // the stamped rows. Refuse explicitly when unresolvable (rows
+            // predating the anchor column) — never silently fork at HEAD.
+            match self
+                .conversation_repo
+                .resolve_backend_turn_anchor(user_id, id, cursor)
+                .await?
+            {
+                Some(anchor) => Some(anchor),
+                None => {
+                    return Err(ConversationError::Unprocessable {
+                        reason: "FORK_POINT_UNSUPPORTED: this message predates turn tracking; \
+                                 fork from the latest message instead"
+                            .into(),
+                    });
+                }
+            }
+        } else {
+            return Err(ConversationError::Unprocessable {
+                reason: "FORK_POINT_UNSUPPORTED: this agent only supports forking from the latest message".into(),
+            });
+        };
+
+        // ── All checks passed: build the fork row ──────────────────────
+        let new_id = generate_short_id();
+        let now = now_ms();
+        let mut extra: serde_json::Value = serde_json::from_str(&parent.extra)
+            .map_err(|e| ConversationError::internal(format!("Invalid parent extra JSON: {e}")))?;
+        if let Some(obj) = extra.as_object_mut() {
+            obj.insert(
+                "fork".to_owned(),
+                serde_json::to_value(aionui_api_types::ForkSpec {
+                    parent_conversation_id: id.to_owned(),
+                    parent_message_id: fork_point.id.clone(),
+                    parent_session_id,
+                    last_turn_id,
+                })
+                .map_err(|e| ConversationError::internal(format!("Failed to serialize fork spec: {e}")))?,
+            );
+        }
+
+        let row = aionui_db::models::ConversationRow {
+            id: new_id.clone(),
+            user_id: user_id.to_owned(),
+            name: req
+                .name
+                .filter(|n| !n.is_empty())
+                .unwrap_or_else(|| parent.name.clone()),
+            r#type: parent.r#type.clone(),
+            extra: serde_json::to_string(&extra)
+                .map_err(|e| ConversationError::internal(format!("Failed to serialize extra: {e}")))?,
+            model: parent.model.clone(),
+            status: Some(enum_to_db(&ConversationStatus::Pending)?),
+            source: parent.source.clone(),
+            // Channel bindings are 1:1 with the parent chat — never duplicated.
+            channel_chat_id: None,
+            pinned: false,
+            pinned_at: None,
+            created_at: now,
+            updated_at: now,
+            // Direct inheritance (the create() heuristics re-derive from the
+            // workspace, which is shared anyway — copying is exact and cheap).
+            project_id: parent.project_id.clone(),
+            folder_id: parent.folder_id.clone(),
+        };
+        self.conversation_repo.create(&row).await?;
+
+        // Assistant snapshot: copy the parent's so rules/skills resolution is
+        // identical in the fork.
+        if let Some(snapshot) = self.conversation_repo.get_assistant_snapshot(user_id, id).await? {
+            self.conversation_repo
+                .upsert_assistant_snapshot(
+                    user_id,
+                    &UpsertConversationAssistantSnapshotParams {
+                        conversation_id: &new_id,
+                        assistant_definition_id: &snapshot.assistant_definition_id,
+                        assistant_id: &snapshot.assistant_id,
+                        assistant_source: &snapshot.assistant_source,
+                        agent_id: &snapshot.agent_id,
+                        rules_content: &snapshot.rules_content,
+                        default_model_mode: &snapshot.default_model_mode,
+                        resolved_model_id: snapshot.resolved_model_id.as_deref(),
+                        default_permission_mode: &snapshot.default_permission_mode,
+                        resolved_permission_value: snapshot.resolved_permission_value.as_deref(),
+                        default_thought_level_mode: &snapshot.default_thought_level_mode,
+                        resolved_thought_level_value: snapshot.resolved_thought_level_value.as_deref(),
+                        default_skills_mode: &snapshot.default_skills_mode,
+                        resolved_skill_ids: &snapshot.resolved_skill_ids,
+                        resolved_disabled_builtin_skill_ids: &snapshot.resolved_disabled_builtin_skill_ids,
+                        default_mcps_mode: &snapshot.default_mcps_mode,
+                        resolved_mcp_ids: &snapshot.resolved_mcp_ids,
+                    },
+                )
+                .await?;
+        }
+
+        // acp_session row: same agent identity, session_id NULL ("fork
+        // pending" — the first open materializes it); mode/model seeded from
+        // the parent's live runtime state so the fork opens with the same
+        // selections.
+        let params = CreateAcpSessionParams {
+            user_id,
+            conversation_id: &new_id,
+            agent_source: &acp_row.agent_source,
+            agent_id: &acp_row.agent_id,
+        };
+        self.acp_session_repo
+            .create(&params)
+            .await
+            .map_err(|e| ConversationError::internal(format!("Failed to create acp_session row: {e}")))?;
+        if let Ok(Some(state)) = self.acp_session_repo.load_runtime_state_for_user(user_id, id).await {
+            let seed = SaveRuntimeStateParams {
+                current_mode_id: state.current_mode_id.as_deref().map(Some),
+                current_model_id: state.current_model_id.as_deref().map(Some),
+                config_selections_json: None,
+                context_usage_json: None,
+            };
+            if seed.current_mode_id.is_some() || seed.current_model_id.is_some() {
+                if let Err(err) = self
+                    .acp_session_repo
+                    .save_runtime_state_for_user(user_id, &new_id, &seed)
+                    .await
+                {
+                    warn!(error = %ErrorChain(&err), "fork: failed to seed runtime state (non-fatal)");
+                }
+            }
+        }
+
+        // Copy the visible history up to (and including) the fork point.
+        let copied = self
+            .conversation_repo
+            .copy_messages_up_to(user_id, id, &new_id, cursor)
+            .await?;
+        info!(
+            parent_conversation_id = %id,
+            fork_conversation_id = %new_id,
+            copied_messages = copied,
+            "Conversation forked"
+        );
+
+        let mut response = row_to_response(row, &self.workspace_root)?;
+        self.attach_assistant_identity(user_id, &mut response).await?;
+        response.fork_capability = Some(fork_capability);
+        self.broadcast_list_changed(user_id, &new_id, "created", response.source.as_ref());
+        Ok(response)
+    }
+
+    /// Resolve the fork capability for an agent from
+    /// `agent_metadata.agent_capabilities.session_capabilities.fork`
+    /// (snake_case, the shape `apply_handshake` persists and migrations
+    /// 003/033/036 seed). `Ok(None)` = no fork support declared.
+    async fn fork_capability_for_agent(
+        &self,
+        user_id: &str,
+        agent_id: &str,
+        parent_extra: &str,
+    ) -> Result<Option<ForkCapabilityView>, ConversationError> {
+        let metadata_row = if !agent_id.is_empty() {
+            self.agent_metadata_repo
+                .get_for_user(user_id, agent_id)
+                .await
+                .map_err(|e| ConversationError::internal(format!("agent_metadata lookup: {e}")))?
+        } else {
+            // Defensive fallback for legacy rows that only carry `backend`.
+            let backend = serde_json::from_str::<serde_json::Value>(parent_extra)
+                .ok()
+                .and_then(|v| v.get("backend").and_then(|b| b.as_str()).map(str::to_owned));
+            match backend {
+                Some(backend) if !backend.is_empty() => self
+                    .agent_metadata_repo
+                    .find_builtin_by_backend_for_user(user_id, &backend)
+                    .await
+                    .map_err(|e| ConversationError::internal(format!("agent_metadata lookup: {e}")))?,
+                _ => None,
+            }
+        };
+        let Some(capabilities_json) = metadata_row.and_then(|row| row.agent_capabilities) else {
+            return Ok(None);
+        };
+        let capabilities: serde_json::Value = match serde_json::from_str(&capabilities_json) {
+            Ok(value) => value,
+            Err(_) => return Ok(None),
+        };
+        let Some(fork) = capabilities.get("session_capabilities").and_then(|s| s.get("fork")) else {
+            return Ok(None);
+        };
+        if fork.is_null() {
+            return Ok(None);
+        }
+        Ok(Some(ForkCapabilityView {
+            at_turn: fork.get("at_turn").and_then(|v| v.as_bool()).unwrap_or(false),
+        }))
     }
 
     /// Reset a conversation: clear messages and set status back to pending.
@@ -3905,6 +4231,16 @@ fn strip_request_owner_user_id(extra: &mut serde_json::Value) {
     }
 }
 
+/// See the call site in `create`: `extra.fork` may only be minted by the
+/// server-side fork API, never accepted from a client payload.
+fn strip_request_fork_spec(extra: &mut serde_json::Value) {
+    if let Some(obj) = extra.as_object_mut()
+        && obj.remove("fork").is_some()
+    {
+        warn!("create: stripped client-supplied `extra.fork` (server-minted only)");
+    }
+}
+
 fn team_id_from_extra(extra: &str) -> Option<String> {
     TeamSessionBinding::team_id_marker_from_extra_str(extra)
 }
@@ -4670,6 +5006,7 @@ mod tests {
             channel_chat_id: None,
             assistant: None,
             project_id: None,
+            fork_capability: None,
             created_at: 0,
             modified_at: 0,
             extra: json!({}),

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -2959,6 +2959,7 @@ impl ConversationService {
             status: Some("finish".into()),
             hidden: req.hidden,
             created_at: now_ms(),
+            backend_turn_id: None,
         };
         if !self
             .runtime_persistence()
@@ -3085,6 +3086,7 @@ impl ConversationService {
                 status: Some("finish".into()),
                 hidden: request.user_message_hidden,
                 created_at: now_ms(),
+                backend_turn_id: None,
             };
             if self
                 .runtime_persistence()

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -2553,13 +2553,18 @@ impl ConversationService {
 
         // Fork point: must be a message of the PARENT conversation. Cursor is
         // the display sort key (created_at, id), endpoint inclusive.
-        let fork_point = self
-            .conversation_repo
-            .get_message(user_id, id, &req.message_id)
-            .await?
-            .ok_or_else(|| ConversationError::MessageNotFound {
-                id: req.message_id.clone(),
-            })?;
+        // Row-id first (history-loaded messages), then stream msg_id (live
+        // messages carry a frontend-local `id` that is never persisted).
+        let fork_point = match self.conversation_repo.get_message(user_id, id, &req.message_id).await? {
+            Some(row) => row,
+            None => self
+                .conversation_repo
+                .get_message_by_msg_id_any(user_id, id, &req.message_id)
+                .await?
+                .ok_or_else(|| ConversationError::MessageNotFound {
+                    id: req.message_id.clone(),
+                })?,
+        };
         let cursor = (fork_point.created_at, fork_point.id.as_str());
 
         // HEAD detection against the visible timeline (the same filtered view

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -2911,6 +2911,7 @@ async fn list_artifacts_includes_legacy_cron_trigger_messages() {
             status: Some("finish".into()),
             hidden: false,
             created_at: 1234,
+            backend_turn_id: None,
         },
     )
     .await
@@ -5267,6 +5268,7 @@ async fn latest_conversation_error_message_prefers_error_detail() {
             status: Some("error".into()),
             hidden: false,
             created_at: 10,
+            backend_turn_id: None,
         },
     )
     .await
@@ -5587,6 +5589,7 @@ async fn startup_recovery_closes_stale_runtime_messages_without_failure_tip() {
             status: Some("work".into()),
             hidden: false,
             created_at: 1,
+            backend_turn_id: None,
         },
     )
     .await
@@ -5603,6 +5606,7 @@ async fn startup_recovery_closes_stale_runtime_messages_without_failure_tip() {
             status: Some("pending".into()),
             hidden: false,
             created_at: 2,
+            backend_turn_id: None,
         },
     )
     .await
@@ -8146,6 +8150,7 @@ async fn insert_raw_message_persists_row_and_broadcasts_stream() {
         status: Some("finish".into()),
         hidden: false,
         created_at: 1234,
+        backend_turn_id: None,
     };
 
     svc.insert_raw_message("user_1", &row).await.unwrap();

--- a/crates/aionui-conversation/src/startup_recovery.rs
+++ b/crates/aionui-conversation/src/startup_recovery.rs
@@ -165,6 +165,7 @@ mod tests {
             status: Some("work".into()),
             hidden: false,
             created_at: 1,
+            backend_turn_id: None,
         };
 
         assert_eq!(
@@ -186,6 +187,7 @@ mod tests {
                 status: Some("work".into()),
                 hidden: false,
                 created_at: 1,
+                backend_turn_id: None,
             };
             assert_eq!(classify_recovery_action(&row), StartupRecoveryAction::SettleToolRow);
         }
@@ -236,6 +238,7 @@ mod tests {
             status: Some("work".into()),
             hidden: false,
             created_at: 1,
+            backend_turn_id: None,
         };
 
         assert_eq!(

--- a/crates/aionui-conversation/src/stream_persistence.rs
+++ b/crates/aionui-conversation/src/stream_persistence.rs
@@ -71,6 +71,12 @@ pub(crate) struct StreamPersistenceAdapter {
     msg_id: String,
     repo: Arc<dyn IConversationRepository>,
     persistence: Option<RuntimePersistenceCoordinator>,
+    /// The backend's own id for the in-flight turn (codex `Turn.id`), stamped
+    /// onto every message row this adapter persists — the lookup key for
+    /// `thread/fork`'s `lastTurnId`. Set by the relay on the internal
+    /// `BackendTurnBound` frame; `None` for backends without one (claude/ACP).
+    /// Shared across clones (the relay and its helpers clone the adapter).
+    backend_turn_id: Arc<std::sync::Mutex<Option<String>>>,
 }
 
 impl StreamPersistenceAdapter {
@@ -87,7 +93,18 @@ impl StreamPersistenceAdapter {
             msg_id,
             repo,
             persistence,
+            backend_turn_id: Arc::new(std::sync::Mutex::new(None)),
         }
+    }
+
+    /// Record the backend's turn id for the in-flight turn (relay-only).
+    pub(crate) fn set_backend_turn_id(&self, backend_turn_id: String) {
+        *self.backend_turn_id.lock().unwrap_or_else(|e| e.into_inner()) = Some(backend_turn_id);
+    }
+
+    /// The stamp every persisted message row of the current turn carries.
+    fn current_backend_turn_id(&self) -> Option<String> {
+        self.backend_turn_id.lock().unwrap_or_else(|e| e.into_inner()).clone()
     }
 
     pub fn with_persistence(mut self, persistence: RuntimePersistenceCoordinator) -> Self {
@@ -178,7 +195,7 @@ impl StreamPersistenceAdapter {
                 status: Some("work".into()),
                 hidden: false,
                 created_at: segment.created_at,
-                backend_turn_id: None,
+                backend_turn_id: self.current_backend_turn_id(),
             };
             if let Err(e) = self.repo.insert_message(&self.user_id, &row).await {
                 log_persist_error(&e, "Failed to create streaming text segment");
@@ -222,7 +239,7 @@ impl StreamPersistenceAdapter {
                 status: Some(status.to_owned()),
                 hidden: false,
                 created_at: segment.created_at,
-                backend_turn_id: None,
+                backend_turn_id: self.current_backend_turn_id(),
             };
             if let Err(e) = self.repo.insert_message(&self.user_id, &row).await {
                 log_persist_error(&e, "Failed to create finalized text segment");
@@ -314,7 +331,7 @@ impl StreamPersistenceAdapter {
                 status: Some(status.to_owned()),
                 hidden: false,
                 created_at: now_ms(),
-                backend_turn_id: None,
+                backend_turn_id: self.current_backend_turn_id(),
             };
             if let Err(e) = self.repo.insert_message(&self.user_id, &row).await {
                 log_persist_error(&e, "Failed to create final fallback message");
@@ -341,7 +358,7 @@ impl StreamPersistenceAdapter {
             status: Some("error".into()),
             hidden: false,
             created_at: now_ms(),
-            backend_turn_id: None,
+            backend_turn_id: self.current_backend_turn_id(),
         };
         if let Err(e) = self.repo.insert_message(&self.user_id, &row).await {
             log_persist_error(&e, "Failed to store error message");
@@ -375,7 +392,7 @@ impl StreamPersistenceAdapter {
             status: Some(status.into()),
             hidden: false,
             created_at: now_ms(),
-            backend_turn_id: None,
+            backend_turn_id: self.current_backend_turn_id(),
         };
         if let Err(e) = self.repo.insert_message(&self.user_id, &row).await {
             log_persist_error(&e, "Failed to store tip message");
@@ -412,7 +429,7 @@ impl StreamPersistenceAdapter {
             status: Some("finish".into()),
             hidden: false,
             created_at: segment.started_at,
-            backend_turn_id: None,
+            backend_turn_id: self.current_backend_turn_id(),
         };
         if let Err(e) = self.repo.insert_message(&self.user_id, &row).await {
             log_persist_error(&e, "Failed to persist thinking message");
@@ -454,7 +471,7 @@ impl StreamPersistenceAdapter {
             status: Some(status.to_owned()),
             hidden: false,
             created_at: now_ms(),
-            backend_turn_id: None,
+            backend_turn_id: self.current_backend_turn_id(),
         };
         if let Err(e) = self.repo.upsert_message(&self.user_id, &row).await {
             error!(
@@ -505,7 +522,7 @@ impl StreamPersistenceAdapter {
             status: Some(status.to_owned()),
             hidden: false,
             created_at: now_ms(),
-            backend_turn_id: None,
+            backend_turn_id: self.current_backend_turn_id(),
         };
         if let Err(e) = self.repo.upsert_message(&self.user_id, &row).await {
             error!(error = %ErrorChain(&e), "Failed to upsert acp_tool_call message");
@@ -581,7 +598,7 @@ impl StreamPersistenceAdapter {
                 status: Some(status.to_owned()),
                 hidden: false,
                 created_at: now_ms(),
-                backend_turn_id: None,
+                backend_turn_id: self.current_backend_turn_id(),
             };
             if let Err(e) = self.repo.insert_message(&self.user_id, &row).await {
                 error!(error = %ErrorChain(&e), "Failed to persist tool_group message");

--- a/crates/aionui-conversation/src/stream_persistence.rs
+++ b/crates/aionui-conversation/src/stream_persistence.rs
@@ -103,7 +103,9 @@ impl StreamPersistenceAdapter {
     }
 
     /// The stamp every persisted message row of the current turn carries.
-    fn current_backend_turn_id(&self) -> Option<String> {
+    /// Also read by the relay so live `message.stream` frames carry the anchor
+    /// (without it, mid-history fork entries only appear after a reload).
+    pub(crate) fn current_backend_turn_id(&self) -> Option<String> {
         self.backend_turn_id.lock().unwrap_or_else(|e| e.into_inner()).clone()
     }
 

--- a/crates/aionui-conversation/src/stream_persistence.rs
+++ b/crates/aionui-conversation/src/stream_persistence.rs
@@ -178,6 +178,7 @@ impl StreamPersistenceAdapter {
                 status: Some("work".into()),
                 hidden: false,
                 created_at: segment.created_at,
+                backend_turn_id: None,
             };
             if let Err(e) = self.repo.insert_message(&self.user_id, &row).await {
                 log_persist_error(&e, "Failed to create streaming text segment");
@@ -221,6 +222,7 @@ impl StreamPersistenceAdapter {
                 status: Some(status.to_owned()),
                 hidden: false,
                 created_at: segment.created_at,
+                backend_turn_id: None,
             };
             if let Err(e) = self.repo.insert_message(&self.user_id, &row).await {
                 log_persist_error(&e, "Failed to create finalized text segment");
@@ -312,6 +314,7 @@ impl StreamPersistenceAdapter {
                 status: Some(status.to_owned()),
                 hidden: false,
                 created_at: now_ms(),
+                backend_turn_id: None,
             };
             if let Err(e) = self.repo.insert_message(&self.user_id, &row).await {
                 log_persist_error(&e, "Failed to create final fallback message");
@@ -338,6 +341,7 @@ impl StreamPersistenceAdapter {
             status: Some("error".into()),
             hidden: false,
             created_at: now_ms(),
+            backend_turn_id: None,
         };
         if let Err(e) = self.repo.insert_message(&self.user_id, &row).await {
             log_persist_error(&e, "Failed to store error message");
@@ -371,6 +375,7 @@ impl StreamPersistenceAdapter {
             status: Some(status.into()),
             hidden: false,
             created_at: now_ms(),
+            backend_turn_id: None,
         };
         if let Err(e) = self.repo.insert_message(&self.user_id, &row).await {
             log_persist_error(&e, "Failed to store tip message");
@@ -407,6 +412,7 @@ impl StreamPersistenceAdapter {
             status: Some("finish".into()),
             hidden: false,
             created_at: segment.started_at,
+            backend_turn_id: None,
         };
         if let Err(e) = self.repo.insert_message(&self.user_id, &row).await {
             log_persist_error(&e, "Failed to persist thinking message");
@@ -448,6 +454,7 @@ impl StreamPersistenceAdapter {
             status: Some(status.to_owned()),
             hidden: false,
             created_at: now_ms(),
+            backend_turn_id: None,
         };
         if let Err(e) = self.repo.upsert_message(&self.user_id, &row).await {
             error!(
@@ -498,6 +505,7 @@ impl StreamPersistenceAdapter {
             status: Some(status.to_owned()),
             hidden: false,
             created_at: now_ms(),
+            backend_turn_id: None,
         };
         if let Err(e) = self.repo.upsert_message(&self.user_id, &row).await {
             error!(error = %ErrorChain(&e), "Failed to upsert acp_tool_call message");
@@ -573,6 +581,7 @@ impl StreamPersistenceAdapter {
                 status: Some(status.to_owned()),
                 hidden: false,
                 created_at: now_ms(),
+                backend_turn_id: None,
             };
             if let Err(e) = self.repo.insert_message(&self.user_id, &row).await {
                 error!(error = %ErrorChain(&e), "Failed to persist tool_group message");

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -901,6 +901,13 @@ impl StreamRelay {
                 .or_insert_with(|| serde_json::Value::String(self.user_id.clone()));
             obj.entry("turn_id")
                 .or_insert_with(|| serde_json::Value::String(self.turn_id.clone()));
+            // Fork anchoring parity with persistence: live frames carry the
+            // backend turn anchor so the UI can show mid-history fork entries
+            // during the session, not only after a history reload.
+            if let Some(anchor) = self.adapter.current_backend_turn_id() {
+                obj.entry("backend_turn_id")
+                    .or_insert_with(|| serde_json::Value::String(anchor));
+            }
         }
         let msg = WebSocketMessage::new("message.stream", payload);
         self.broadcaster.broadcast(msg);

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -312,6 +312,14 @@ impl StreamRelay {
                             // the catch-all below does not forward it to the WebSocket, and
                             // it is never persisted.
                         }
+                        AgentStreamEvent::BackendTurnBound(backend_turn_id) => {
+                            // Internal-only fork anchor (codex Turn.id): stamp it on the
+                            // adapter so every message row persisted for this turn carries
+                            // `messages.backend_turn_id` — the `thread/fork` lastTurnId
+                            // lookup key. Never forwarded to the WS, never persisted as an
+                            // event itself.
+                            self.adapter.set_backend_turn_id(backend_turn_id.clone());
+                        }
                         AgentStreamEvent::Thinking(data) => {
                             if data.status.as_deref() == Some("done") {
                                 self.complete_active_thinking(&mut active_thinking).await;
@@ -675,6 +683,7 @@ impl StreamRelay {
             AgentStreamEvent::RequestTrace(_) => "RequestTrace",
             AgentStreamEvent::SessionAssigned(_) => "SessionAssigned",
             AgentStreamEvent::SegmentBreak => "SegmentBreak",
+            AgentStreamEvent::BackendTurnBound(_) => "BackendTurnBound",
             AgentStreamEvent::WorkflowProgress(_) => "WorkflowProgress",
             AgentStreamEvent::AcpDialectSignal(_) => "AcpDialectSignal",
         }

--- a/crates/aionui-conversation/tests/conversation_extended.rs
+++ b/crates/aionui-conversation/tests/conversation_extended.rs
@@ -1112,3 +1112,27 @@ async fn delete_parent_keeps_workspace_shared_with_fork() {
     );
     std::fs::remove_dir_all(&workspace).ok();
 }
+
+#[tokio::test]
+async fn fork_resolves_stream_msg_id_when_row_id_unknown() {
+    let (svc, repo, acp_repo) = setup_fork().await;
+    let parent = svc.create(USER_ID, fork_create_req("claude")).await.unwrap();
+    acp_repo
+        .update_session_id_for_user(USER_ID, &parent.id, "parent-sid-msgid")
+        .await
+        .unwrap();
+    // make_message mints msg_id ("client_...") distinct from the row id — the
+    // shape a live-streamed frontend message sends (its local `id` is never
+    // persisted, only the stream msg_id matches anything in the DB).
+    let m = make_message(&parent.id, "hello", 0);
+    repo.insert_message(USER_ID, &m).await.unwrap();
+
+    let fork = svc
+        .fork(USER_ID, &parent.id, fork_req(m.msg_id.as_deref().unwrap()))
+        .await
+        .expect("msg_id fallback resolves the fork point");
+    assert_eq!(
+        fork.extra["fork"]["parent_message_id"], m.id,
+        "resolved to the real row"
+    );
+}

--- a/crates/aionui-conversation/tests/conversation_extended.rs
+++ b/crates/aionui-conversation/tests/conversation_extended.rs
@@ -816,3 +816,299 @@ async fn reset_wrong_user_returns_not_found() {
     let err = svc.reset("other_user", &conv.id).await.unwrap_err();
     assert!(matches!(err, ConversationError::NotFound { .. }));
 }
+
+// ── Conversation fork ───────────────────────────────────────────────
+
+async fn setup_fork() -> (
+    ConversationService,
+    Arc<SqliteConversationRepository>,
+    Arc<dyn aionui_db::IAcpSessionRepository>,
+) {
+    let db = init_database_memory().await.unwrap();
+    let repo = Arc::new(SqliteConversationRepository::new(db.pool().clone()));
+    let broadcaster = Arc::new(TestBroadcaster::new());
+    let agent_metadata_repo: Arc<dyn aionui_db::IAgentMetadataRepository> =
+        Arc::new(aionui_db::SqliteAgentMetadataRepository::new(db.pool().clone()));
+    let acp_session_repo: Arc<dyn aionui_db::IAcpSessionRepository> =
+        Arc::new(aionui_db::SqliteAcpSessionRepository::new(db.pool().clone()));
+    let task_mgr: Arc<dyn IWorkerTaskManager> = Arc::new(NoopTaskManager);
+    let svc = ConversationService::new(
+        std::env::temp_dir(),
+        broadcaster,
+        Arc::new(EmptySkillResolver),
+        task_mgr,
+        repo.clone(),
+        agent_metadata_repo,
+        acp_session_repo.clone(),
+    );
+    (svc, repo, acp_session_repo)
+}
+
+fn fork_create_req(backend: &str) -> CreateConversationRequest {
+    let workspace = ensure_named_workspace_path(&format!("aionui-fork-test-{backend}"));
+    serde_json::from_value(json!({
+        "type": "acp",
+        "extra": { "workspace": workspace, "backend": backend }
+    }))
+    .unwrap()
+}
+
+fn fork_req(message_id: &str) -> aionui_api_types::ForkConversationRequest {
+    serde_json::from_value(json!({ "message_id": message_id })).unwrap()
+}
+
+#[tokio::test]
+async fn fork_head_creates_lineage_row_and_copies_messages() {
+    let (svc, repo, acp_repo) = setup_fork().await;
+    let parent = svc.create(USER_ID, fork_create_req("claude")).await.unwrap();
+    acp_repo
+        .update_session_id_for_user(USER_ID, &parent.id, "parent-sid-1")
+        .await
+        .unwrap();
+    let m1 = make_message(&parent.id, "hello", 0);
+    let m2 = make_message(&parent.id, "world", 10);
+    repo.insert_message(USER_ID, &m1).await.unwrap();
+    repo.insert_message(USER_ID, &m2).await.unwrap();
+
+    // HEAD fork (claude is seeded with a head-only fork capability by 036).
+    let fork = svc.fork(USER_ID, &parent.id, fork_req(&m2.id)).await.unwrap();
+    assert_ne!(fork.id, parent.id);
+    assert_eq!(fork.name, parent.name, "name defaults to the parent's");
+    assert_eq!(
+        fork.fork_capability,
+        Some(aionui_api_types::ForkCapabilityView { at_turn: false }),
+        "claude declares a HEAD-only fork capability"
+    );
+    let spec = fork.extra.get("fork").expect("fork lineage in extra");
+    assert_eq!(spec["parent_conversation_id"], parent.id);
+    assert_eq!(spec["parent_message_id"], m2.id);
+    assert_eq!(spec["parent_session_id"], "parent-sid-1");
+    assert!(spec.get("last_turn_id").is_none(), "HEAD fork carries no turn anchor");
+
+    // Copied history, reminted ids, same workspace.
+    let page = repo
+        .list_messages_page(
+            USER_ID,
+            &fork.id,
+            &aionui_db::MessagePageParams {
+                limit: 50,
+                direction: aionui_db::MessagePageDirection::InitialLatest,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(page.items.len(), 2);
+    assert_eq!(
+        fork.extra.get("workspace"),
+        // The response extra echoes the parent's workspace verbatim.
+        svc.get(USER_ID, &parent.id).await.unwrap().extra.get("workspace"),
+        "fork shares the parent workspace (claude cwd constraint)"
+    );
+
+    // The fork's acp_session row exists, same agent identity, UNBOUND sid.
+    let fork_session = acp_repo.get_for_user(USER_ID, &fork.id).await.unwrap().unwrap();
+    assert_eq!(fork_session.session_id, None, "fork pending until first open");
+    let parent_session = acp_repo.get_for_user(USER_ID, &parent.id).await.unwrap().unwrap();
+    assert_eq!(fork_session.agent_id, parent_session.agent_id);
+    assert_eq!(
+        parent_session.session_id.as_deref(),
+        Some("parent-sid-1"),
+        "the parent's binding is untouched"
+    );
+}
+
+#[tokio::test]
+async fn fork_mid_history_is_refused_for_head_only_backends() {
+    let (svc, repo, acp_repo) = setup_fork().await;
+    let parent = svc.create(USER_ID, fork_create_req("claude")).await.unwrap();
+    acp_repo
+        .update_session_id_for_user(USER_ID, &parent.id, "parent-sid-2")
+        .await
+        .unwrap();
+    let m1 = make_message(&parent.id, "one", 0);
+    let m2 = make_message(&parent.id, "two", 10);
+    repo.insert_message(USER_ID, &m1).await.unwrap();
+    repo.insert_message(USER_ID, &m2).await.unwrap();
+
+    let err = svc.fork(USER_ID, &parent.id, fork_req(&m1.id)).await.unwrap_err();
+    assert!(
+        matches!(&err, ConversationError::Unprocessable { reason } if reason.starts_with("FORK_POINT_UNSUPPORTED")),
+        "claude mid-history fork must be refused, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn fork_mid_history_resolves_codex_turn_anchor() {
+    let (svc, repo, acp_repo) = setup_fork().await;
+    let parent = svc.create(USER_ID, fork_create_req("codex")).await.unwrap();
+    acp_repo
+        .update_session_id_for_user(USER_ID, &parent.id, "th-parent")
+        .await
+        .unwrap();
+    let mut m1 = make_message(&parent.id, "one", 0);
+    m1.backend_turn_id = Some("turn-1".into());
+    let m2 = make_message(&parent.id, "two", 10);
+    repo.insert_message(USER_ID, &m1).await.unwrap();
+    repo.insert_message(USER_ID, &m2).await.unwrap();
+
+    let fork = svc.fork(USER_ID, &parent.id, fork_req(&m1.id)).await.unwrap();
+    assert_eq!(
+        fork.fork_capability,
+        Some(aionui_api_types::ForkCapabilityView { at_turn: true }),
+        "codex declares an at-turn fork capability"
+    );
+    assert_eq!(
+        fork.extra["fork"]["last_turn_id"], "turn-1",
+        "the mid-history fork resolved the stamped codex turn anchor"
+    );
+    // And only the pre-fork-point message was copied.
+    let page = repo
+        .list_messages_page(
+            USER_ID,
+            &fork.id,
+            &aionui_db::MessagePageParams {
+                limit: 50,
+                direction: aionui_db::MessagePageDirection::InitialLatest,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(page.items.len(), 1);
+}
+
+#[tokio::test]
+async fn fork_mid_history_without_anchor_is_refused_not_degraded() {
+    let (svc, repo, acp_repo) = setup_fork().await;
+    let parent = svc.create(USER_ID, fork_create_req("codex")).await.unwrap();
+    acp_repo
+        .update_session_id_for_user(USER_ID, &parent.id, "th-parent")
+        .await
+        .unwrap();
+    // Legacy rows: no backend_turn_id anywhere.
+    let m1 = make_message(&parent.id, "one", 0);
+    let m2 = make_message(&parent.id, "two", 10);
+    repo.insert_message(USER_ID, &m1).await.unwrap();
+    repo.insert_message(USER_ID, &m2).await.unwrap();
+
+    let err = svc.fork(USER_ID, &parent.id, fork_req(&m1.id)).await.unwrap_err();
+    assert!(
+        matches!(&err, ConversationError::Unprocessable { reason } if reason.starts_with("FORK_POINT_UNSUPPORTED")),
+        "an unresolvable anchor must refuse, never silently fork at HEAD, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn fork_rejects_unbound_parent_and_unsupported_agent() {
+    let (svc, repo, acp_repo) = setup_fork().await;
+
+    // Unbound parent (never had a backend session).
+    let unbound = svc.create(USER_ID, fork_create_req("claude")).await.unwrap();
+    let m = make_message(&unbound.id, "hello", 0);
+    repo.insert_message(USER_ID, &m).await.unwrap();
+    let err = svc.fork(USER_ID, &unbound.id, fork_req(&m.id)).await.unwrap_err();
+    assert!(
+        matches!(&err, ConversationError::Busy { reason } if reason.starts_with("FORK_PARENT_UNBOUND")),
+        "got {err:?}"
+    );
+
+    // Agent without a fork declaration (qwen's seeded capabilities carry no fork key).
+    let unsupported = svc.create(USER_ID, fork_create_req("qwen")).await.unwrap();
+    acp_repo
+        .update_session_id_for_user(USER_ID, &unsupported.id, "sid-x")
+        .await
+        .unwrap();
+    let m = make_message(&unsupported.id, "hello", 0);
+    repo.insert_message(USER_ID, &m).await.unwrap();
+    let err = svc.fork(USER_ID, &unsupported.id, fork_req(&m.id)).await.unwrap_err();
+    assert!(
+        matches!(&err, ConversationError::Unprocessable { reason } if reason.starts_with("FORK_UNSUPPORTED")),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn create_strips_client_supplied_fork_spec() {
+    let (svc, _repo, _acp) = setup_fork().await;
+    let workspace = ensure_named_workspace_path("aionui-fork-test-strip");
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "extra": {
+            "workspace": workspace,
+            "backend": "claude",
+            "fork": { "parent_conversation_id": "x", "parent_message_id": "y", "parent_session_id": "stolen" }
+        }
+    }))
+    .unwrap();
+    let created = svc.create(USER_ID, req).await.unwrap();
+    assert!(
+        created.extra.get("fork").is_none(),
+        "a client-supplied fork spec must be stripped on the create path"
+    );
+}
+
+#[tokio::test]
+async fn get_projects_fork_capability_on_detail_path() {
+    let (svc, _repo, _acp) = setup_fork().await;
+    let claude_conv = svc.create(USER_ID, fork_create_req("claude")).await.unwrap();
+    let got = svc.get(USER_ID, &claude_conv.id).await.unwrap();
+    assert_eq!(
+        got.fork_capability,
+        Some(aionui_api_types::ForkCapabilityView { at_turn: false })
+    );
+
+    let codex_conv = svc.create(USER_ID, fork_create_req("codex")).await.unwrap();
+    let got = svc.get(USER_ID, &codex_conv.id).await.unwrap();
+    assert_eq!(
+        got.fork_capability,
+        Some(aionui_api_types::ForkCapabilityView { at_turn: true })
+    );
+}
+
+#[tokio::test]
+async fn delete_parent_keeps_workspace_shared_with_fork() {
+    let (svc, repo, acp_repo) = setup_fork().await;
+    // No workspace in extra → create() auto-provisions one under
+    // workspace_root/conversations/... — the deletable kind.
+    let req: CreateConversationRequest = serde_json::from_value(json!({
+        "type": "acp",
+        "extra": { "backend": "claude" }
+    }))
+    .unwrap();
+    let parent = svc.create(USER_ID, req).await.unwrap();
+    let workspace = parent
+        .extra
+        .get("workspace")
+        .and_then(|v| v.as_str())
+        .expect("auto-provisioned workspace")
+        .to_owned();
+    assert!(std::path::Path::new(&workspace).is_dir());
+
+    acp_repo
+        .update_session_id_for_user(USER_ID, &parent.id, "parent-sid-ws")
+        .await
+        .unwrap();
+    let m = make_message(&parent.id, "hello", 0);
+    repo.insert_message(USER_ID, &m).await.unwrap();
+    let fork = svc.fork(USER_ID, &parent.id, fork_req(&m.id)).await.unwrap();
+    assert_eq!(
+        fork.extra.get("workspace").and_then(|v| v.as_str()),
+        Some(workspace.as_str()),
+        "the fork shares the parent's auto workspace"
+    );
+
+    svc.delete(USER_ID, &parent.id).await.unwrap();
+    assert!(
+        std::path::Path::new(&workspace).is_dir(),
+        "deleting the parent must NOT remove the workspace the fork still uses"
+    );
+
+    // Deleting the fork leaves the directory too: the auto-workspace removal
+    // is keyed on the `-temp-{id}` name suffix, which only the PARENT matches.
+    // An orphaned directory is the accepted trade-off (safety over cleanup).
+    svc.delete(USER_ID, &fork.id).await.unwrap();
+    assert!(
+        std::path::Path::new(&workspace).is_dir(),
+        "the fork's delete never removes a workspace named after the parent"
+    );
+    std::fs::remove_dir_all(&workspace).ok();
+}

--- a/crates/aionui-conversation/tests/conversation_extended.rs
+++ b/crates/aionui-conversation/tests/conversation_extended.rs
@@ -145,6 +145,7 @@ fn make_message(conv_id: &str, content: &str, offset_ms: i64) -> MessageRow {
         status: Some("finish".to_string()),
         hidden: false,
         created_at: now_ms() + offset_ms,
+        backend_turn_id: None,
     }
 }
 
@@ -174,6 +175,7 @@ fn make_acp_tool_message(conv_id: &str, id: &str, output: &str, offset_ms: i64) 
         status: Some("finish".to_string()),
         hidden: false,
         created_at: now_ms() + offset_ms,
+        backend_turn_id: None,
     }
 }
 
@@ -637,6 +639,7 @@ async fn t9_5_preview_text_extracts_from_json_content() {
         status: Some("finish".to_string()),
         hidden: false,
         created_at: now_ms(),
+        backend_turn_id: None,
     };
     repo.insert_message(USER_ID, &complex_msg).await.unwrap();
 

--- a/crates/aionui-cron/src/executor.rs
+++ b/crates/aionui-cron/src/executor.rs
@@ -324,6 +324,7 @@ impl JobExecutor {
             status: Some("finish".into()),
             hidden: false,
             created_at: aionui_common::now_ms(),
+            backend_turn_id: None,
         };
 
         let user_id = self.resolve_target_conversation_user_id(conversation_id).await?;

--- a/crates/aionui-db/migrations/036_conversation_fork.sql
+++ b/crates/aionui-db/migrations/036_conversation_fork.sql
@@ -1,0 +1,65 @@
+-- Conversation fork groundwork (feature: fork-as-new-conversation).
+--
+-- Two independent pieces, shipped together because both are prerequisites for
+-- the fork API and neither changes runtime behavior on its own:
+--
+-- 1) `messages.backend_turn_id` — the backend-side turn anchor. codex's
+--    `thread/fork` accepts an optional `lastTurnId` (fork at a specific turn,
+--    dropping later history). Our runtime `turn_<shortid>` ids are minted by
+--    the conversation layer and have NO relation to codex's internal Turn.id,
+--    so the codex reader will start emitting the backend turn id when a turn
+--    starts and the stream persistence layer stamps it onto every message row
+--    it writes for that turn. Fork-point resolution is then a pure DB lookup
+--    ("nearest non-NULL at or before the fork point"). Rows written before
+--    this column existed stay NULL: HEAD forks never need the anchor
+--    (`lastTurnId` omitted = fork at HEAD), and a mid-history fork request
+--    that cannot resolve an anchor is rejected explicitly rather than
+--    silently degraded to a HEAD fork. claude / ACP backends never emit the
+--    event, so their rows remain NULL by design.
+--
+-- 2) Constructed fork capability for the two direct-CLI builtin agents.
+--    ACP vendors advertise `sessionCapabilities.fork` in the `initialize`
+--    handshake, which `registry::apply_handshake` persists into
+--    `agent_metadata.agent_capabilities` (snake_cased, see
+--    `normalize_keys_to_snake_case` and the pre-seeded shapes in migrations
+--    003/033). claude and codex are routed as direct CLI connections and
+--    never perform an ACP handshake, so their column stays NULL forever —
+--    which is exactly why a constructed value here is safe: nothing will
+--    overwrite it. Writing the SAME column in the SAME shape lets every
+--    consumer (fork API validation, `ConversationResponse.fork_capability`
+--    projection) read one uniform source regardless of backend kind.
+--    CLI ground truth, verified 2026-08-04:
+--      * codex 0.145.x app-server: `thread/fork {threadId, lastTurnId?}` —
+--        supports forking at an arbitrary turn, hence `"at_turn": true`
+--        (an aionui extension key inside the fork object; the ACP RFD
+--        reserves the fork object for exactly this kind of extension).
+--      * claude 2.1.x: `--resume <sid> --fork-session` — HEAD fork only,
+--        hence an empty fork object.
+--    Antigravity (agy) deliberately gets NO fork key: per product decision it
+--    is not supported (its only fork surface is an internal RPC / TUI
+--    command, not reachable from headless spawns).
+--
+-- `json_patch` merges into any pre-existing JSON instead of clobbering the
+-- column (defensive: historical bridge builds may have written other keys).
+-- Rows are addressed by their stable seed ids (001), never by display fields.
+
+ALTER TABLE messages ADD COLUMN backend_turn_id TEXT;
+
+-- Claude Code (2d23ff1c): HEAD-only fork via `--resume <sid> --fork-session`.
+UPDATE agent_metadata SET
+    agent_capabilities = json_patch(
+        COALESCE(agent_capabilities, '{}'),
+        '{"session_capabilities":{"fork":{}}}'
+    ),
+    updated_at = CAST(strftime('%s','now') AS INTEGER) * 1000
+WHERE id = '2d23ff1c';
+
+-- Codex CLI (8e1acf31): app-server `thread/fork` with optional `lastTurnId`,
+-- i.e. fork at an arbitrary turn.
+UPDATE agent_metadata SET
+    agent_capabilities = json_patch(
+        COALESCE(agent_capabilities, '{}'),
+        '{"session_capabilities":{"fork":{"at_turn":true}}}'
+    ),
+    updated_at = CAST(strftime('%s','now') AS INTEGER) * 1000
+WHERE id = '8e1acf31';

--- a/crates/aionui-db/src/models/message.rs
+++ b/crates/aionui-db/src/models/message.rs
@@ -26,4 +26,9 @@ pub struct MessageRow {
     /// Whether this message is hidden (SQLite INTEGER 0/1).
     pub hidden: bool,
     pub created_at: TimestampMs,
+    /// Backend-side turn anchor (codex `Turn.id`), stamped on rows persisted
+    /// while that turn streams. Unrelated to the runtime `turn_<shortid>` ids;
+    /// used to resolve `thread/fork`'s `lastTurnId` when forking mid-history.
+    /// NULL for claude/ACP rows and for rows predating the column.
+    pub backend_turn_id: Option<String>,
 }

--- a/crates/aionui-db/src/repository/conversation.rs
+++ b/crates/aionui-db/src/repository/conversation.rs
@@ -155,7 +155,9 @@ pub trait IConversationRepository: Send + Sync {
         _target_conversation_id: &str,
         _cursor: (TimestampMs, &str),
     ) -> Result<u64, DbError> {
-        Err(DbError::Init("copy_messages_up_to is not supported by this repository".into()))
+        Err(DbError::Init(
+            "copy_messages_up_to is not supported by this repository".into(),
+        ))
     }
 
     /// Resolves the backend turn anchor for a fork point: the `backend_turn_id`

--- a/crates/aionui-db/src/repository/conversation.rs
+++ b/crates/aionui-db/src/repository/conversation.rs
@@ -138,6 +138,39 @@ pub trait IConversationRepository: Send + Sync {
     /// Deletes all messages belonging to a conversation.
     async fn delete_messages_by_conversation(&self, user_id: &str, conv_id: &str) -> Result<(), DbError>;
 
+    /// Copies every source message at or before the fork point — `(created_at,
+    /// id)` cursor, endpoint inclusive — into the target conversation inside a
+    /// single transaction, reminting primary keys with time-ordered ids so the
+    /// copies keep their relative `(created_at, id)` display order. `msg_id`
+    /// and `created_at` are preserved verbatim; `backend_turn_id` is dropped
+    /// (it anchors the SOURCE conversation's backend thread and would poison
+    /// fork-point resolution in the copy). Returns the number of copied rows.
+    ///
+    /// Both conversations must belong to `user_id`. Default is unsupported so
+    /// test doubles that never fork don't have to implement it.
+    async fn copy_messages_up_to(
+        &self,
+        _user_id: &str,
+        _source_conversation_id: &str,
+        _target_conversation_id: &str,
+        _cursor: (TimestampMs, &str),
+    ) -> Result<u64, DbError> {
+        Err(DbError::Init("copy_messages_up_to is not supported by this repository".into()))
+    }
+
+    /// Resolves the backend turn anchor for a fork point: the `backend_turn_id`
+    /// of the nearest row at or before the `(created_at, id)` cursor that has
+    /// one. `Ok(None)` when no row up to the fork point carries an anchor
+    /// (HEAD forks never need one; mid-history forks must then be refused).
+    async fn resolve_backend_turn_anchor(
+        &self,
+        _user_id: &str,
+        _conv_id: &str,
+        _cursor: (TimestampMs, &str),
+    ) -> Result<Option<String>, DbError> {
+        Ok(None)
+    }
+
     /// Finds a message by (conversation_id, msg_id, type) triple.
     async fn get_message_by_msg_id(
         &self,

--- a/crates/aionui-db/src/repository/conversation.rs
+++ b/crates/aionui-db/src/repository/conversation.rs
@@ -173,6 +173,19 @@ pub trait IConversationRepository: Send + Sync {
         Ok(None)
     }
 
+    /// Finds a message by (conversation_id, msg_id) regardless of type — the
+    /// fork API's fallback: live-streamed frontend messages only know their
+    /// stream `msg_id` (their local `id` is never persisted). Returns the
+    /// EARLIEST match so a fork lands at the segment that opened the bubble.
+    async fn get_message_by_msg_id_any(
+        &self,
+        _user_id: &str,
+        _conv_id: &str,
+        _msg_id: &str,
+    ) -> Result<Option<MessageRow>, DbError> {
+        Ok(None)
+    }
+
     /// Finds a message by (conversation_id, msg_id, type) triple.
     async fn get_message_by_msg_id(
         &self,

--- a/crates/aionui-db/src/repository/sqlite_conversation.rs
+++ b/crates/aionui-db/src/repository/sqlite_conversation.rs
@@ -1,6 +1,6 @@
 use sqlx::{Row, SqlitePool};
 
-use aionui_common::PaginatedResult;
+use aionui_common::{PaginatedResult, TimestampMs};
 
 use crate::error::DbError;
 use crate::models::{
@@ -75,8 +75,8 @@ impl SqliteConversationRepository {
             sqlx::query(
                 "INSERT INTO messages \
                     (id, conversation_id, msg_id, type, content, position, \
-                     status, hidden, created_at) \
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                     status, hidden, created_at, backend_turn_id) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(&message.id)
             .bind(&message.conversation_id)
@@ -87,6 +87,7 @@ impl SqliteConversationRepository {
             .bind(&message.status)
             .bind(message.hidden)
             .bind(message.created_at)
+            .bind(&message.backend_turn_id)
             .execute(&mut *connection)
             .await?;
 
@@ -123,8 +124,8 @@ impl SqliteConversationRepository {
             let result = sqlx::query(
                 "INSERT INTO messages \
                 (id, conversation_id, msg_id, type, content, position, \
-                 status, hidden, created_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) \
+                 status, hidden, created_at, backend_turn_id) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
              ON CONFLICT(id) DO UPDATE SET \
                 content = CASE \
                     WHEN messages.status IN ('finish', 'error') AND excluded.status = 'work' THEN \
@@ -148,7 +149,8 @@ impl SqliteConversationRepository {
                 END, \
                 position = COALESCE(messages.position, excluded.position), \
                 hidden = excluded.hidden, \
-                created_at = MIN(messages.created_at, excluded.created_at) \
+                created_at = MIN(messages.created_at, excluded.created_at), \
+                backend_turn_id = COALESCE(messages.backend_turn_id, excluded.backend_turn_id) \
              WHERE messages.conversation_id = excluded.conversation_id \
                AND EXISTS ( \
                     SELECT 1 FROM conversations c \
@@ -164,6 +166,7 @@ impl SqliteConversationRepository {
             .bind(&message.status)
             .bind(message.hidden)
             .bind(message.created_at)
+            .bind(&message.backend_turn_id)
             .bind(user_id)
             .execute(&mut *connection)
             .await?;
@@ -928,6 +931,127 @@ impl IConversationRepository for SqliteConversationRepository {
         Ok(())
     }
 
+    async fn copy_messages_up_to(
+        &self,
+        user_id: &str,
+        source_conversation_id: &str,
+        target_conversation_id: &str,
+        cursor: (TimestampMs, &str),
+    ) -> Result<u64, DbError> {
+        let (cursor_created_at, cursor_id) = cursor;
+
+        // Writer-lock-first transaction; see `insert_message_once` for why.
+        let mut connection = self.pool.acquire().await?;
+        sqlx::query("BEGIN IMMEDIATE").execute(&mut *connection).await?;
+
+        let result: Result<u64, DbError> = async {
+            // Both endpoints must belong to the caller; checked inside the
+            // transaction so authorization and the copy are atomic.
+            for conv_id in [source_conversation_id, target_conversation_id] {
+                let exists: i64 =
+                    sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM conversations WHERE user_id = ? AND id = ?)")
+                        .bind(user_id)
+                        .bind(conv_id)
+                        .fetch_one(&mut *connection)
+                        .await?;
+                if exists == 0 {
+                    return Err(DbError::NotFound(format!("Conversation '{conv_id}' not found")));
+                }
+            }
+
+            let rows = sqlx::query_as::<_, MessageRow>(
+                "SELECT m.* FROM messages m \
+                 WHERE m.conversation_id = ? \
+                   AND (m.created_at < ? OR (m.created_at = ? AND m.id <= ?)) \
+                 ORDER BY m.created_at ASC, m.id ASC",
+            )
+            .bind(source_conversation_id)
+            .bind(cursor_created_at)
+            .bind(cursor_created_at)
+            .bind(cursor_id)
+            .fetch_all(&mut *connection)
+            .await?;
+
+            let mut copied: u64 = 0;
+            let mut latest_created_at: Option<TimestampMs> = None;
+            for row in &rows {
+                // `generate_id()` is a monotonic UUIDv7, so reminting in
+                // display order keeps the `(created_at, id)` sort stable for
+                // rows sharing a timestamp.
+                sqlx::query(
+                    "INSERT INTO messages \
+                        (id, conversation_id, msg_id, type, content, position, \
+                         status, hidden, created_at, backend_turn_id) \
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)",
+                )
+                .bind(aionui_common::generate_id())
+                .bind(target_conversation_id)
+                .bind(&row.msg_id)
+                .bind(&row.r#type)
+                .bind(&row.content)
+                .bind(&row.position)
+                .bind(&row.status)
+                .bind(row.hidden)
+                .bind(row.created_at)
+                .execute(&mut *connection)
+                .await?;
+                copied += 1;
+                latest_created_at = Some(row.created_at);
+            }
+
+            // One recency bump for the whole batch (mirrors the per-insert
+            // bump contract of `insert_message_once`).
+            if let Some(bump) = latest_created_at {
+                sqlx::query("UPDATE conversations SET updated_at = MAX(updated_at, ?) WHERE id = ?")
+                    .bind(bump)
+                    .bind(target_conversation_id)
+                    .execute(&mut *connection)
+                    .await?;
+            }
+
+            Ok(copied)
+        }
+        .await;
+
+        match result {
+            Ok(copied) => {
+                sqlx::query("COMMIT").execute(&mut *connection).await?;
+                Ok(copied)
+            }
+            Err(error) => {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *connection).await;
+                Err(error)
+            }
+        }
+    }
+
+    async fn resolve_backend_turn_anchor(
+        &self,
+        user_id: &str,
+        conv_id: &str,
+        cursor: (TimestampMs, &str),
+    ) -> Result<Option<String>, DbError> {
+        let (cursor_created_at, cursor_id) = cursor;
+        let anchor: Option<String> = sqlx::query_scalar(
+            "SELECT m.backend_turn_id FROM messages m \
+             INNER JOIN conversations c ON c.id = m.conversation_id \
+             WHERE c.user_id = ? AND m.conversation_id = ? \
+               AND m.backend_turn_id IS NOT NULL \
+               AND (m.created_at < ? OR (m.created_at = ? AND m.id <= ?)) \
+             ORDER BY m.created_at DESC, m.id DESC \
+             LIMIT 1",
+        )
+        .bind(user_id)
+        .bind(conv_id)
+        .bind(cursor_created_at)
+        .bind(cursor_created_at)
+        .bind(cursor_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(anchor)
+    }
+
     async fn get_message_by_msg_id(
         &self,
         user_id: &str,
@@ -977,6 +1101,7 @@ impl IConversationRepository for SqliteConversationRepository {
                         status: row.try_get("status")?,
                         hidden: row.try_get("hidden")?,
                         created_at: row.try_get("created_at")?,
+                        backend_turn_id: row.try_get("backend_turn_id")?,
                     },
                 })
             })
@@ -1371,6 +1496,7 @@ mod tests {
             status: Some("finish".to_string()),
             hidden: false,
             created_at: now,
+            backend_turn_id: None,
         }
     }
 

--- a/crates/aionui-db/src/repository/sqlite_conversation.rs
+++ b/crates/aionui-db/src/repository/sqlite_conversation.rs
@@ -1052,6 +1052,27 @@ impl IConversationRepository for SqliteConversationRepository {
         Ok(anchor)
     }
 
+    async fn get_message_by_msg_id_any(
+        &self,
+        user_id: &str,
+        conv_id: &str,
+        msg_id: &str,
+    ) -> Result<Option<MessageRow>, DbError> {
+        let row = sqlx::query_as::<_, MessageRow>(
+            "SELECT m.* FROM messages m \
+             INNER JOIN conversations c ON c.id = m.conversation_id \
+             WHERE c.user_id = ? AND m.conversation_id = ? AND m.msg_id = ? \
+             ORDER BY m.created_at ASC, m.id ASC LIMIT 1",
+        )
+        .bind(user_id)
+        .bind(conv_id)
+        .bind(msg_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
     async fn get_message_by_msg_id(
         &self,
         user_id: &str,

--- a/crates/aionui-db/tests/conversation_repository.rs
+++ b/crates/aionui-db/tests/conversation_repository.rs
@@ -1338,7 +1338,10 @@ async fn copy_messages_up_to_is_inclusive_reminted_and_order_preserving() {
         .list_messages_page(
             USER_ID,
             &target.id,
-            &MessagePageParams { limit: 50, direction: MessagePageDirection::InitialLatest },
+            &MessagePageParams {
+                limit: 50,
+                direction: MessagePageDirection::InitialLatest,
+            },
         )
         .await
         .unwrap();
@@ -1347,15 +1350,30 @@ async fn copy_messages_up_to_is_inclusive_reminted_and_order_preserving() {
     let contents: Vec<&str> = page
         .items
         .iter()
-        .map(|m| if m.content.contains("one") { "one" } else if m.content.contains("two") { "two" } else { "three" })
+        .map(|m| {
+            if m.content.contains("one") {
+                "one"
+            } else if m.content.contains("two") {
+                "two"
+            } else {
+                "three"
+            }
+        })
         .collect();
-    assert_eq!(contents, vec!["one", "two", "three"], "display order must match the source order");
+    assert_eq!(
+        contents,
+        vec!["one", "two", "three"],
+        "display order must match the source order"
+    );
 
     for (copy, original) in page.items.iter().zip([&m1, &m2, &m3]) {
         assert_ne!(copy.id, original.id, "primary keys must be reminted");
         assert_eq!(copy.msg_id, original.msg_id, "msg_id is preserved");
         assert_eq!(copy.created_at, original.created_at, "created_at is preserved");
-        assert_eq!(copy.backend_turn_id, None, "source turn anchors must not leak into the fork");
+        assert_eq!(
+            copy.backend_turn_id, None,
+            "source turn anchors must not leak into the fork"
+        );
     }
 }
 
@@ -1365,7 +1383,9 @@ async fn copy_messages_up_to_rejects_foreign_target_without_partial_copy() {
     create_user_2(&db).await;
     let source = make_conversation("fork-src-own");
     repo.create(&source).await.unwrap();
-    repo.insert_message(USER_ID, &make_message_at(&source.id, "one", 1000, None)).await.unwrap();
+    repo.insert_message(USER_ID, &make_message_at(&source.id, "one", 1000, None))
+        .await
+        .unwrap();
 
     let mut foreign = make_conversation("fork-dst-foreign");
     foreign.user_id = "user_2".to_string();
@@ -1381,7 +1401,10 @@ async fn copy_messages_up_to_rejects_foreign_target_without_partial_copy() {
         .list_messages_page(
             "user_2",
             &foreign.id,
-            &MessagePageParams { limit: 50, direction: MessagePageDirection::InitialLatest },
+            &MessagePageParams {
+                limit: 50,
+                direction: MessagePageDirection::InitialLatest,
+            },
         )
         .await
         .unwrap();
@@ -1402,15 +1425,24 @@ async fn resolve_backend_turn_anchor_picks_nearest_at_or_before_cursor() {
     }
 
     // Cursor on a row without an anchor → nearest earlier anchor wins.
-    let anchor = repo.resolve_backend_turn_anchor(USER_ID, &conv.id, (2000, &m2.id)).await.unwrap();
+    let anchor = repo
+        .resolve_backend_turn_anchor(USER_ID, &conv.id, (2000, &m2.id))
+        .await
+        .unwrap();
     assert_eq!(anchor.as_deref(), Some("turn_a"));
 
     // Cursor at HEAD → the latest anchor.
-    let anchor = repo.resolve_backend_turn_anchor(USER_ID, &conv.id, (3000, &m3.id)).await.unwrap();
+    let anchor = repo
+        .resolve_backend_turn_anchor(USER_ID, &conv.id, (3000, &m3.id))
+        .await
+        .unwrap();
     assert_eq!(anchor.as_deref(), Some("turn_b"));
 
     // Cursor before every anchored row → None.
-    let anchor = repo.resolve_backend_turn_anchor(USER_ID, &conv.id, (500, "aaa")).await.unwrap();
+    let anchor = repo
+        .resolve_backend_turn_anchor(USER_ID, &conv.id, (500, "aaa"))
+        .await
+        .unwrap();
     assert_eq!(anchor, None);
 }
 
@@ -1425,6 +1457,9 @@ async fn resolve_backend_turn_anchor_is_user_scoped() {
     msg.conversation_id = conv.id.clone();
     repo.insert_message("user_2", &msg).await.unwrap();
 
-    let anchor = repo.resolve_backend_turn_anchor(USER_ID, &conv.id, (2000, "zzz")).await.unwrap();
+    let anchor = repo
+        .resolve_backend_turn_anchor(USER_ID, &conv.id, (2000, "zzz"))
+        .await
+        .unwrap();
     assert_eq!(anchor, None, "foreign conversations must resolve to nothing");
 }

--- a/crates/aionui-db/tests/conversation_repository.rs
+++ b/crates/aionui-db/tests/conversation_repository.rs
@@ -56,6 +56,7 @@ fn make_message(conv_id: &str, content: &str) -> MessageRow {
         status: Some("finish".to_string()),
         hidden: false,
         created_at: now,
+        backend_turn_id: None,
     }
 }
 
@@ -696,6 +697,7 @@ async fn anchor_rejects_legacy_artifact_rows() {
             status: Some("finish".into()),
             hidden: false,
             created_at: 1000,
+            backend_turn_id: None,
         },
     )
     .await
@@ -1071,6 +1073,7 @@ async fn get_messages_excludes_legacy_cron_and_skill_suggest_rows() {
                 status: Some("finish".into()),
                 hidden: false,
                 created_at: 2000,
+                backend_turn_id: None,
             },
         )
         .await
@@ -1110,6 +1113,7 @@ async fn list_legacy_cron_trigger_messages_returns_only_trigger_rows() {
             status: Some("finish".into()),
             hidden: false,
             created_at: 1000,
+            backend_turn_id: None,
         },
     )
     .await
@@ -1284,4 +1288,143 @@ async fn upsert_artifact_rejects_cross_user_id_takeover() {
 
     let user_1_artifacts = repo.list_artifacts(USER_ID, &c1.id).await.unwrap();
     assert!(user_1_artifacts.is_empty());
+}
+
+// ── Fork support: copy_messages_up_to / resolve_backend_turn_anchor ─────
+
+fn make_message_at(conv_id: &str, content: &str, created_at: i64, backend_turn_id: Option<&str>) -> MessageRow {
+    MessageRow {
+        id: aionui_common::generate_prefixed_id("msg"),
+        conversation_id: conv_id.to_string(),
+        msg_id: Some(aionui_common::generate_prefixed_id("cmsg")),
+        r#type: "text".to_string(),
+        content: format!(r#"{{"content":"{content}"}}"#),
+        position: Some("left".to_string()),
+        status: Some("finish".to_string()),
+        hidden: false,
+        created_at,
+        backend_turn_id: backend_turn_id.map(str::to_string),
+    }
+}
+
+#[tokio::test]
+async fn copy_messages_up_to_is_inclusive_reminted_and_order_preserving() {
+    let (repo, _db) = setup().await;
+    let source = make_conversation("fork-src");
+    let target = make_conversation("fork-dst");
+    repo.create(&source).await.unwrap();
+    repo.create(&target).await.unwrap();
+
+    // Two rows share created_at=2000 to exercise same-timestamp ordering.
+    let m1 = make_message_at(&source.id, "one", 1000, Some("turn_a"));
+    let mut m2 = make_message_at(&source.id, "two", 2000, None);
+    let mut m3 = make_message_at(&source.id, "three", 2000, Some("turn_b"));
+    // Force a known (created_at, id) order for the shared timestamp.
+    m2.id = "2000-a".to_string();
+    m3.id = "2000-b".to_string();
+    let m4 = make_message_at(&source.id, "four", 3000, None);
+    for m in [&m1, &m2, &m3, &m4] {
+        repo.insert_message(USER_ID, m).await.unwrap();
+    }
+
+    // Fork at m3 (inclusive): m4 must not be copied.
+    let copied = repo
+        .copy_messages_up_to(USER_ID, &source.id, &target.id, (2000, &m3.id))
+        .await
+        .unwrap();
+    assert_eq!(copied, 3);
+
+    let page = repo
+        .list_messages_page(
+            USER_ID,
+            &target.id,
+            &MessagePageParams { limit: 50, direction: MessagePageDirection::InitialLatest },
+        )
+        .await
+        .unwrap();
+    assert_eq!(page.items.len(), 3);
+
+    let contents: Vec<&str> = page
+        .items
+        .iter()
+        .map(|m| if m.content.contains("one") { "one" } else if m.content.contains("two") { "two" } else { "three" })
+        .collect();
+    assert_eq!(contents, vec!["one", "two", "three"], "display order must match the source order");
+
+    for (copy, original) in page.items.iter().zip([&m1, &m2, &m3]) {
+        assert_ne!(copy.id, original.id, "primary keys must be reminted");
+        assert_eq!(copy.msg_id, original.msg_id, "msg_id is preserved");
+        assert_eq!(copy.created_at, original.created_at, "created_at is preserved");
+        assert_eq!(copy.backend_turn_id, None, "source turn anchors must not leak into the fork");
+    }
+}
+
+#[tokio::test]
+async fn copy_messages_up_to_rejects_foreign_target_without_partial_copy() {
+    let (repo, db) = setup().await;
+    create_user_2(&db).await;
+    let source = make_conversation("fork-src-own");
+    repo.create(&source).await.unwrap();
+    repo.insert_message(USER_ID, &make_message_at(&source.id, "one", 1000, None)).await.unwrap();
+
+    let mut foreign = make_conversation("fork-dst-foreign");
+    foreign.user_id = "user_2".to_string();
+    repo.create(&foreign).await.unwrap();
+
+    let err = repo
+        .copy_messages_up_to(USER_ID, &source.id, &foreign.id, (9999, "zzz"))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, DbError::NotFound(_)));
+
+    let page = repo
+        .list_messages_page(
+            "user_2",
+            &foreign.id,
+            &MessagePageParams { limit: 50, direction: MessagePageDirection::InitialLatest },
+        )
+        .await
+        .unwrap();
+    assert!(page.items.is_empty(), "failed copy must not leave partial rows");
+}
+
+#[tokio::test]
+async fn resolve_backend_turn_anchor_picks_nearest_at_or_before_cursor() {
+    let (repo, _db) = setup().await;
+    let conv = make_conversation("anchor");
+    repo.create(&conv).await.unwrap();
+
+    let m1 = make_message_at(&conv.id, "one", 1000, Some("turn_a"));
+    let m2 = make_message_at(&conv.id, "two", 2000, None);
+    let m3 = make_message_at(&conv.id, "three", 3000, Some("turn_b"));
+    for m in [&m1, &m2, &m3] {
+        repo.insert_message(USER_ID, m).await.unwrap();
+    }
+
+    // Cursor on a row without an anchor → nearest earlier anchor wins.
+    let anchor = repo.resolve_backend_turn_anchor(USER_ID, &conv.id, (2000, &m2.id)).await.unwrap();
+    assert_eq!(anchor.as_deref(), Some("turn_a"));
+
+    // Cursor at HEAD → the latest anchor.
+    let anchor = repo.resolve_backend_turn_anchor(USER_ID, &conv.id, (3000, &m3.id)).await.unwrap();
+    assert_eq!(anchor.as_deref(), Some("turn_b"));
+
+    // Cursor before every anchored row → None.
+    let anchor = repo.resolve_backend_turn_anchor(USER_ID, &conv.id, (500, "aaa")).await.unwrap();
+    assert_eq!(anchor, None);
+}
+
+#[tokio::test]
+async fn resolve_backend_turn_anchor_is_user_scoped() {
+    let (repo, db) = setup().await;
+    create_user_2(&db).await;
+    let mut conv = make_conversation("anchor-foreign");
+    conv.user_id = "user_2".to_string();
+    repo.create(&conv).await.unwrap();
+    let mut msg = make_message_at(&conv.id, "one", 1000, Some("turn_a"));
+    msg.conversation_id = conv.id.clone();
+    repo.insert_message("user_2", &msg).await.unwrap();
+
+    let anchor = repo.resolve_backend_turn_anchor(USER_ID, &conv.id, (2000, "zzz")).await.unwrap();
+    assert_eq!(anchor, None, "foreign conversations must resolve to nothing");
 }

--- a/crates/aionui-session/src/adapter.rs
+++ b/crates/aionui-session/src/adapter.rs
@@ -32,6 +32,12 @@ pub enum SessionSpec {
     /// 0-frame-exits (`No conversation found`); the manager detects that and
     /// falls back to `Fresh` (R16/S17).
     Resume(String),
+    /// Fork off an existing session: resume the PARENT id but have the backend
+    /// copy it into a NEW session instead of appending (claude: `--resume <id>
+    /// --fork-session`; the new id is backend-minted and learned from
+    /// `system/init`). Unlike `Resume`, a missing parent must FAIL, never fall
+    /// back to `Fresh` — the user asked for the parent's context.
+    ForkFrom(String),
 }
 
 /// Narrow process-I/O seam (D2). Exposes only the two methods P0 uses: the

--- a/crates/aionui-session/src/adapter/claude.rs
+++ b/crates/aionui-session/src/adapter/claude.rs
@@ -1001,6 +1001,15 @@ impl BackendAdapter for ClaudeAdapter {
                 args.push("--resume".to_string());
                 args.push(id.clone());
             }
+            SessionSpec::ForkFrom(id) => {
+                // Resume the PARENT session but copy it into a NEW one instead
+                // of appending (`--fork-session`, live help 2.1.221). claude
+                // mints the new id itself and echoes it in `system/init` —
+                // `--session-id` must NOT be combined here.
+                args.push("--resume".to_string());
+                args.push(id.clone());
+                args.push("--fork-session".to_string());
+            }
         }
         // Manager-supplied flags (S18: --system-prompt / --mcp-config /
         // --strict-mcp-config). Kept backend-neutral: the adapter does not build
@@ -2051,6 +2060,42 @@ mod tests {
             .position(|a| a == "--thinking-display")
             .expect("a manager-supplied flag must reach the spawn");
         assert_eq!(gated.get(at + 1).map(String::as_str), Some("summarized"));
+    }
+
+    /// Fork spawn: `ForkFrom(parent)` resumes the PARENT session with
+    /// `--fork-session` so claude copies it into a NEW session — and never
+    /// passes `--session-id` (unsupported combination, live help 2.1.221; the
+    /// new id is backend-minted and learned from `system/init`).
+    #[tokio::test]
+    async fn fork_from_spawns_resume_with_fork_session_flag() {
+        use crate::testing::FakeSpawner;
+        let spawner = FakeSpawner::new();
+        let adapter = ClaudeAdapter::new();
+        let _ = adapter
+            .start_turn(
+                &spawner,
+                &SessionSpec::ForkFrom("22222222-2222-4222-8222-222222222222".into()),
+                None,
+                &[],
+                &[],
+                None,
+            )
+            .await;
+        let args = spawner.last_command().await.expect("a spawn was recorded").args;
+        let at = args
+            .iter()
+            .position(|a| a == "--resume")
+            .expect("fork resumes the parent");
+        assert_eq!(
+            args.get(at + 1).map(String::as_str),
+            Some("22222222-2222-4222-8222-222222222222"),
+            "--resume targets the PARENT session id"
+        );
+        assert!(args.iter().any(|a| a == "--fork-session"), "fork adds --fork-session");
+        assert!(
+            !args.iter().any(|a| a == "--session-id"),
+            "--session-id must not be combined with --fork-session, got: {args:?}"
+        );
     }
 
     /// Helper: drive one `result` NDJSON line through the adapter and return the

--- a/crates/aionui-session/src/backend/acp_conn.rs
+++ b/crates/aionui-session/src/backend/acp_conn.rs
@@ -77,6 +77,14 @@ impl BackendConnection for AcpConnection {
         let logical_id = match &spec {
             SessionSpec::Fresh { session_id } => session_id.clone(),
             SessionSpec::Resume { session_id, .. } => session_id.clone(),
+            // Clean-slate ACP backend is not factory-wired yet; the live ACP
+            // fork path is AcpAgentManager's `session/fork`. Explicit reject —
+            // never silently open fresh under a fork spec.
+            SessionSpec::Fork { .. } => {
+                return Err(BackendError::Transport(
+                    "acp_conn does not support SessionSpec::Fork (use the ACP manager fork path)".into(),
+                ));
+            }
         };
 
         // Live spawn via the injected Spawner (records into the unified registry
@@ -118,6 +126,8 @@ impl BackendConnection for AcpConnection {
             SessionSpec::Fresh { .. } => None,
             // lost backend session → fresh under the same logical id (§4.1).
             SessionSpec::Resume { backend_session_id, .. } => backend_session_id.clone(),
+            // Unreachable: the logical-id match above already rejected Fork.
+            SessionSpec::Fork { .. } => unreachable!("acp_conn rejects SessionSpec::Fork at open"),
         };
         backend.run_handshake(resume_sid.as_deref()).await?;
 

--- a/crates/aionui-session/src/backend/antigravity/conn.rs
+++ b/crates/aionui-session/src/backend/antigravity/conn.rs
@@ -213,6 +213,14 @@ impl BackendConnection for AntigravityConnection {
                 session_id,
                 backend_session_id,
             } => (session_id, backend_session_id),
+            // Product decision: antigravity has no headless fork surface (its
+            // only fork is the interactive TUI `/fork`). Defensive reject — the
+            // fork API already refuses agy via the capability gate.
+            SessionSpec::Fork { .. } => {
+                return Err(BackendError::Transport(
+                    "antigravity does not support session forking".into(),
+                ));
+            }
         };
         // agy reads MCP servers from files only — there is no per-run flag — so
         // the session's servers (team coordination first, then the user's) have

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -2994,7 +2994,7 @@ impl ClaudeSessionBackend {
         let session_id = session_id.into();
         let wake = ClaudeWakeRecipe {
             spawner: Arc::new(crate::testing::FakeSpawner::new()),
-            claude_session_id: session_id.clone(),
+            claude_session_id: Arc::new(std::sync::Mutex::new(session_id.clone())),
             cwd: None,
             extra_args: Vec::new(),
             env: Vec::new(),

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -79,6 +79,22 @@ impl ClaudeConnection {
                     )
                 }
             },
+            SessionSpec::Fork {
+                session_id,
+                parent_backend_session_id,
+                ..
+            } => (
+                session_id.clone(),
+                // The wake slot's INITIAL value is the parent sid — but a wake
+                // can only fire after an idle turn, by which point `system/init`
+                // reported the fork's OWN sid and `sniff_init` updated the slot
+                // (never `--resume <parent>` twice, which would fork again).
+                // `--fork-session` makes claude mint the new id itself; pairing
+                // it with `--session-id` is unsupported (live help 2.1.221), so
+                // the new id is learned, not chosen.
+                parent_backend_session_id.clone(),
+                LegacySessionSpec::ForkFrom(parent_backend_session_id.clone()),
+            ),
         }
     }
 }
@@ -319,7 +335,7 @@ impl BackendConnection for ClaudeConnection {
         // mode AND the same provider env (#103).
         let wake = ClaudeWakeRecipe {
             spawner: self.spawner.clone(),
-            claude_session_id,
+            claude_session_id: Arc::new(std::sync::Mutex::new(claude_session_id)),
             cwd: config.cwd.clone(),
             extra_args: spawn_args,
             env: config.spawn_env.clone(),
@@ -556,7 +572,13 @@ struct PendingPerm {
 /// enabled, so it is never consulted.
 struct ClaudeWakeRecipe {
     spawner: Arc<dyn Spawner>,
-    claude_session_id: String,
+    /// SHARED MUTABLE resume anchor. Open seeds it (Fresh/Resume: the id we
+    /// spawned with; Fork: the PARENT id), and `sniff_init` overwrites it with
+    /// whatever sid claude actually reports — claude can rotate the on-disk id
+    /// (`--fork-session` always does; plain runs may), and a wake that resumes
+    /// the STALE id re-forks / resurrects the parent session. The slot makes
+    /// every wake resume the session claude last said we are attached to.
+    claude_session_id: Arc<std::sync::Mutex<String>>,
     cwd: Option<String>,
     extra_args: Vec<String>,
     /// #103: the spawn env captured at open time (e.g. cc-switch provider env) so
@@ -631,6 +653,10 @@ struct ClaudeReaderState {
     cost_ledger: Arc<std::sync::Mutex<CostLedger>>,
     /// One-shot first-turn title generation (shared Arc with the backend).
     title_gen: Arc<TitleGenState>,
+    /// The wake recipe's SHARED resume-anchor slot (see `ClaudeWakeRecipe`): the
+    /// reader overwrites it from `system/init` so a post-fork / post-rotation
+    /// wake resumes the sid claude actually reported, never the stale spawn id.
+    wake_session_slot: Arc<std::sync::Mutex<String>>,
 }
 
 /// Spawn a claude stdout reader over `stdout`/`io` using the shared state. Used
@@ -674,6 +700,7 @@ fn start_claude_reader(
             state.pending_set_config,
             state.cost_ledger,
             state.title_gen,
+            state.wake_session_slot,
         )
         .await;
     })
@@ -764,6 +791,7 @@ impl ClaudeSessionBackend {
             pending_set_config: pending_set_config.clone(),
             cost_ledger,
             title_gen: title_gen.clone(),
+            wake_session_slot: wake.claude_session_id.clone(),
         };
         let reader = start_claude_reader(&reader_state, stdout, io.clone());
 
@@ -830,7 +858,17 @@ impl ClaudeSessionBackend {
     /// the controller's slot. Only reached when `idle_ttl` is set AND the slot was
     /// suspended (a test backend has no spawner → never enabled).
     async fn wake_handle(&self) -> Result<ProcHandle, BackendError> {
-        let legacy_spec = LegacySessionSpec::Resume(self.wake.claude_session_id.clone());
+        // Read the SHARED slot, not an open-time snapshot: after a fork (or any
+        // claude-side id rotation) `sniff_init` updated it to the sid claude
+        // actually reported — resuming a stale id would re-fork / resurrect the
+        // parent session. A wake NEVER replays `--fork-session`.
+        let resume_sid = self
+            .wake
+            .claude_session_id
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        let legacy_spec = LegacySessionSpec::Resume(resume_sid);
         let io = self
             .adapter
             .start_turn(
@@ -1250,6 +1288,7 @@ async fn reader_task(
     pending_set_config: Arc<std::sync::Mutex<std::collections::HashMap<String, String>>>,
     cost_ledger: Arc<std::sync::Mutex<CostLedger>>,
     title_gen: Arc<TitleGenState>,
+    wake_session_slot: Arc<std::sync::Mutex<String>>,
 ) {
     use std::sync::atomic::Ordering;
     use tokio::io::AsyncReadExt;
@@ -1313,7 +1352,15 @@ async fn reader_task(
                 // parse_system drops). Done on the RAW frame so parse_chunk's
                 // event stream stays zero-diff. Emits Provisioning per MCP
                 // server (parity with codex mcpServerStatus→Provisioning).
-                sniff_init(v, want_init_model, &discovered_model, &event_tx, &session_id, cur_gen);
+                sniff_init(
+                    v,
+                    want_init_model,
+                    &discovered_model,
+                    &event_tx,
+                    &session_id,
+                    cur_gen,
+                    &wake_session_slot,
+                );
                 // #98/#101: sniff the `control_request{initialize}` RESPONSE for the
                 // selectable model list + slash commands (claude's only catalog
                 // channel — the data init frame above carries neither). Fills
@@ -1769,6 +1816,7 @@ fn sniff_init(
     event_tx: &broadcast::Sender<SessionEnvelope>,
     session_id: &str,
     turn_gen: u64,
+    wake_session_slot: &Arc<std::sync::Mutex<String>>,
 ) {
     use serde_json::Value;
     if frame.get("type").and_then(Value::as_str) != Some("system")
@@ -1786,16 +1834,32 @@ fn sniff_init(
     // common case where claude was started with `--session-id <logical_id>`); a
     // DIFFERENT id means claude rotated/resumed under another on-disk id, which is
     // the value a later `--resume` must target.
-    if let Some(sid) = frame.get("session_id").and_then(Value::as_str)
-        && sid != session_id
-    {
-        let _ = event_tx.send(SessionEnvelope {
-            session_id: session_id.to_string(),
-            turn_gen,
-            event: SessionEvent::BackendBound {
-                backend_session_id: Some(sid.to_string()),
-            },
-        });
+    if let Some(sid) = frame.get("session_id").and_then(Value::as_str) {
+        // Keep the wake recipe's resume anchor in lock-step with claude's own
+        // report (fork rotation `--fork-session`, or any plain rotation): a wake
+        // that resumed the STALE spawn id would re-fork / resurrect the parent
+        // session. Written unconditionally-on-change, independent of the
+        // BackendBound gate below (which compares against the LOGICAL id).
+        {
+            let mut slot = wake_session_slot.lock().unwrap_or_else(|e| e.into_inner());
+            if *slot != sid {
+                tracing::debug!(
+                    session_id = %session_id,
+                    reported_sid = %sid,
+                    "claude reported a rotated session id — updating the wake resume anchor"
+                );
+                *slot = sid.to_string();
+            }
+        }
+        if sid != session_id {
+            let _ = event_tx.send(SessionEnvelope {
+                session_id: session_id.to_string(),
+                turn_gen,
+                event: SessionEvent::BackendBound {
+                    backend_session_id: Some(sid.to_string()),
+                },
+            });
+        }
     }
     if let Some(servers) = frame.get("mcp_servers").and_then(Value::as_array) {
         for s in servers {
@@ -2905,7 +2969,7 @@ impl ClaudeSessionBackend {
         // recipe is never consulted — but `spawn` needs one. Use a FakeSpawner.
         let wake = ClaudeWakeRecipe {
             spawner: Arc::new(crate::testing::FakeSpawner::new()),
-            claude_session_id: session_id.clone(),
+            claude_session_id: Arc::new(std::sync::Mutex::new(session_id.clone())),
             cwd: None,
             extra_args: Vec::new(),
             env: Vec::new(),
@@ -2958,7 +3022,7 @@ impl ClaudeSessionBackend {
         let session_id = session_id.into();
         let wake = ClaudeWakeRecipe {
             spawner: Arc::new(crate::testing::FakeSpawner::new()),
-            claude_session_id: session_id.clone(),
+            claude_session_id: Arc::new(std::sync::Mutex::new(session_id.clone())),
             cwd: None,
             extra_args: Vec::new(),
             env: Vec::new(),
@@ -2985,7 +3049,7 @@ impl ClaudeSessionBackend {
         // `--resume <session_id>`), so it is NOT routed through claude_session_id_for.
         let wake = ClaudeWakeRecipe {
             spawner,
-            claude_session_id: session_id.clone(),
+            claude_session_id: Arc::new(std::sync::Mutex::new(session_id.clone())),
             cwd: None,
             extra_args: Vec::new(),
             env: Vec::new(),
@@ -6294,5 +6358,91 @@ mod tests {
             .flatten();
             assert_eq!(got, Some(expected), "task_notification status={wire} → {expected:?}");
         }
+    }
+
+    /// Fork seam mapping: `SessionSpec::Fork` resumes the PARENT sid with a
+    /// ForkFrom legacy spec, and seeds the wake slot with the parent id (the
+    /// init sniffer rotates it to the fork's own sid before any wake can fire).
+    #[tokio::test]
+    async fn to_legacy_spec_fork_maps_to_fork_from_parent() {
+        let (logical, claude_id, legacy) = ClaudeConnection::to_legacy_spec(&SessionSpec::Fork {
+            session_id: "conv_fork_1".into(),
+            parent_backend_session_id: "8cd37cd6-2e88-4c8d-847a-7b237ffa9710".into(),
+            at_turn_id: None,
+        });
+        assert_eq!(logical, "conv_fork_1");
+        assert_eq!(claude_id, "8cd37cd6-2e88-4c8d-847a-7b237ffa9710");
+        assert!(
+            matches!(legacy, LegacySessionSpec::ForkFrom(ref id) if id == "8cd37cd6-2e88-4c8d-847a-7b237ffa9710"),
+            "fork resumes the parent id with --fork-session"
+        );
+    }
+
+    /// 陷阱 B regression: `system/init` reporting a DIFFERENT sid must rotate the
+    /// wake recipe's resume anchor — for a fork (claude always mints a new id)
+    /// AND for a plain resume rotation. Without the rotation, the next idle-wake
+    /// `--resume <stale>` re-forks / resurrects the parent session.
+    #[test]
+    fn sniff_init_rotates_wake_session_slot() {
+        let slot = Arc::new(std::sync::Mutex::new("parent-sid".to_string()));
+        let discovered_model = Arc::new(std::sync::Mutex::new(None));
+        let (event_tx, mut event_rx) = broadcast::channel(8);
+        let frame = serde_json::json!({
+            "type": "system", "subtype": "init",
+            "session_id": "33333333-3333-4333-8333-333333333333"
+        });
+        sniff_init(&frame, false, &discovered_model, &event_tx, "conv_fork_1", 0, &slot);
+        assert_eq!(
+            slot.lock().unwrap().as_str(),
+            "33333333-3333-4333-8333-333333333333",
+            "the wake anchor follows claude's reported sid"
+        );
+        // And the rotation is still lowered as BackendBound for persistence.
+        let env = event_rx.try_recv().expect("BackendBound lowered");
+        assert!(
+            matches!(env.event, SessionEvent::BackendBound { backend_session_id: Some(ref sid) }
+                if sid == "33333333-3333-4333-8333-333333333333")
+        );
+    }
+
+    /// 陷阱 B end-to-end: after the slot rotates, a wake resumes the ROTATED sid,
+    /// not the open-time one.
+    #[tokio::test]
+    async fn wake_after_rotation_resumes_the_rotated_sid() {
+        use crate::testing::FakeSpawner;
+        let spawner = Arc::new(FakeSpawner::new());
+        let backend = ClaudeSessionBackend::build_with_io_suspending(
+            "logical-fork-wake",
+            Box::new(FakeAgentIo::never_exits(Vec::new())),
+            spawner.clone(),
+            40,
+        )
+        .await;
+        // Simulate the init sniffer's rotation (same shared Arc the reader holds).
+        *backend.wake.claude_session_id.lock().unwrap() = "44444444-4444-4444-8444-444444444444".to_string();
+
+        let suspended = backend
+            .suspend
+            .suspend_if_idle(aionui_common::now_ms() + 10_000, false)
+            .await;
+        assert!(suspended, "idle past ttl → suspended");
+        let _ = backend
+            .dispatch(Command::Send {
+                content: vec![ContentBlock::Text("wake".into())],
+                metadata: CommandMeta::default(),
+            })
+            .await
+            .expect_err("FakeSpawner cannot make a real process → wake Errs");
+        let spec = spawner.last_command().await.expect("a spawn was recorded");
+        let at = spec.args.iter().position(|a| a == "--resume").expect("wake resumes");
+        assert_eq!(
+            spec.args.get(at + 1).map(String::as_str),
+            Some("44444444-4444-4444-8444-444444444444"),
+            "wake resumes the ROTATED sid, never the stale open-time id"
+        );
+        assert!(
+            !spec.args.iter().any(|a| a == "--fork-session"),
+            "a wake never replays the fork"
+        );
     }
 }

--- a/crates/aionui-session/src/backend/codex_conn.rs
+++ b/crates/aionui-session/src/backend/codex_conn.rs
@@ -3946,7 +3946,32 @@ impl SessionBackend for CodexSessionBackend {
 
     fn events(&self) -> BoxStream<'static, SessionEnvelope> {
         let rx = self.event_tx.subscribe();
-        futures_util::stream::unfold(rx, |mut rx| async move {
+        // Replay the current thread binding to every NEW subscriber. codex
+        // answers `thread/start` with `thread/started` in single-digit ms
+        // (local bookkeeping, no LLM call), so on a fresh open the live
+        // BackendBound routinely lands BEFORE the orchestration layer's
+        // subscription and is lost — the conversation then never persists its
+        // resume anchor (and the fork API refuses with FORK_PARENT_UNBOUND).
+        // A synthetic BackendBound is idempotent downstream (same-value
+        // set_session_id + same-value DB write), so replaying to an already-
+        // caught-up subscriber is harmless. try_lock: the binding mutex is
+        // held only for point writes/reads; on contention we just skip the
+        // preface (the caller is racing the live event, which it will get).
+        let preface: Vec<SessionEnvelope> = self
+            .thread_binding
+            .try_lock()
+            .ok()
+            .and_then(|guard| guard.clone())
+            .map(|tid| SessionEnvelope {
+                session_id: self.session_id.clone(),
+                turn_gen: self.turn_gen.load(Ordering::SeqCst),
+                event: SessionEvent::BackendBound {
+                    backend_session_id: Some(tid),
+                },
+            })
+            .into_iter()
+            .collect();
+        let live = futures_util::stream::unfold(rx, |mut rx| async move {
             loop {
                 match rx.recv().await {
                     Ok(env) => return Some((env, rx)),
@@ -3954,8 +3979,8 @@ impl SessionBackend for CodexSessionBackend {
                     Err(broadcast::error::RecvError::Closed) => return None,
                 }
             }
-        })
-        .boxed()
+        });
+        futures_util::stream::iter(preface).chain(live).boxed()
     }
 
     fn capabilities(&self) -> Capabilities {
@@ -8646,5 +8671,45 @@ mod tests {
         .ok()
         .flatten();
         assert_eq!(bound.as_deref(), Some("turn-7"), "turn/started lowers codex's turn id");
+    }
+
+    /// Late-subscriber self-heal: `thread/started` can land BEFORE the
+    /// orchestration layer subscribes (codex answers thread/start in
+    /// single-digit ms), which used to lose BackendBound forever — the
+    /// conversation never persisted its resume anchor and the fork API
+    /// refused with FORK_PARENT_UNBOUND. `events()` must replay the current
+    /// binding as a synthetic BackendBound to every new subscriber.
+    #[tokio::test]
+    async fn events_replays_binding_to_late_subscribers() {
+        use futures_util::StreamExt as _;
+        let prefix = format!(
+            "{}\n",
+            r#"{"jsonrpc":"2.0","method":"thread/started","params":{"thread":{"id":"th-late-bind"}}}"#
+        )
+        .into_bytes();
+        let fake = FakeAgentIo::never_exits(prefix);
+        let backend = CodexSessionBackend::build_with_io("codex-late-sub", Box::new(fake)).await;
+        // Let the reader consume thread/started BEFORE anyone subscribes —
+        // the live BackendBound broadcast goes to zero receivers.
+        tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+        assert_eq!(
+            backend.thread_binding.lock().await.as_deref(),
+            Some("th-late-bind"),
+            "precondition: the reader already bound the thread"
+        );
+
+        let mut events = backend.events();
+        let first = tokio::time::timeout(std::time::Duration::from_secs(1), events.next())
+            .await
+            .expect("the synthetic preface arrives immediately")
+            .expect("stream open");
+        assert!(
+            matches!(
+                first.event,
+                SessionEvent::BackendBound { backend_session_id: Some(ref tid) } if tid == "th-late-bind"
+            ),
+            "a late subscriber's first event is the replayed binding, got {:?}",
+            first.event
+        );
     }
 }

--- a/crates/aionui-session/src/backend/codex_conn.rs
+++ b/crates/aionui-session/src/backend/codex_conn.rs
@@ -71,6 +71,7 @@ impl BackendConnection for CodexConnection {
         let logical_id = match &spec {
             SessionSpec::Fresh { session_id } => session_id.clone(),
             SessionSpec::Resume { session_id, .. } => session_id.clone(),
+            SessionSpec::Fork { session_id, .. } => session_id.clone(),
         };
         let mut args = vec!["app-server".to_string()];
         args.extend(config.extra_args.iter().cloned());
@@ -148,7 +149,10 @@ impl BackendConnection for CodexConnection {
             SessionSpec::Fresh { .. } => {
                 normalized_config_mode.or_else(|| Some(codex_perm::profile_id_to_legacy_value(":workspace")))
             }
-            SessionSpec::Resume { .. } => normalized_config_mode,
+            // Fork inherits the forked thread's own tier exactly like Resume
+            // (codex restores it and surfaces `thread/settings/updated`), so no
+            // fresh-default seed either.
+            SessionSpec::Resume { .. } | SessionSpec::Fork { .. } => normalized_config_mode,
         };
 
         // JSON-RPC handshake over the retained stdin (the reader task is already
@@ -162,12 +166,23 @@ impl BackendConnection for CodexConnection {
         // run_handshake pre-seeds the binding so the first `turn/start` has a
         // threadId without waiting on the wire. Same wire frames as a wake re-attach
         // (run_handshake is shared with wake_handle).
-        let resume_tid = match &spec {
-            SessionSpec::Fresh { .. } => None,
+        let handshake_mode = match &spec {
+            SessionSpec::Fresh { .. } => HandshakeMode::Fresh,
             // lost backend session → start fresh under the same logical id (§4.1)
-            SessionSpec::Resume { backend_session_id, .. } => backend_session_id.clone(),
+            SessionSpec::Resume { backend_session_id, .. } => match backend_session_id.as_deref() {
+                Some(tid) => HandshakeMode::Resume(tid),
+                None => HandshakeMode::Fresh,
+            },
+            SessionSpec::Fork {
+                parent_backend_session_id,
+                at_turn_id,
+                ..
+            } => HandshakeMode::Fork {
+                parent_thread_id: parent_backend_session_id,
+                last_turn_id: at_turn_id.as_deref(),
+            },
         };
-        backend.run_handshake(resume_tid.as_deref()).await?;
+        backend.run_handshake(handshake_mode).await?;
 
         // codex-model-gating: `thread/start` intentionally did NOT bind `config.model`
         // (see `thread_start_params`), nor a permission tier (`thread/start` carries no
@@ -469,6 +484,34 @@ fn thread_resume_params(config: &SessionConfig, thread_id: &str) -> HandshakePar
     HandshakeParams(params)
 }
 
+/// `thread/fork` params: the same override surface as resume (fork creates a NEW
+/// thread, which needs its MCP servers / approvalPolicy just like a resumed one),
+/// plus the PARENT threadId as the fork source and an optional `lastTurnId` —
+/// copy history only through that turn (inclusive) and drop later turns
+/// (app-server ThreadForkParams, exported from codex 0.145.0). Omitting
+/// `lastTurnId` forks at HEAD.
+fn thread_fork_params(config: &SessionConfig, parent_thread_id: &str, last_turn_id: Option<&str>) -> HandshakeParams {
+    let HandshakeParams(mut params) = thread_start_params(config);
+    params["threadId"] = json!(parent_thread_id);
+    if let Some(turn_id) = last_turn_id {
+        params["lastTurnId"] = json!(turn_id);
+    }
+    HandshakeParams(params)
+}
+
+/// How `run_handshake` opens the thread: shared by `open_session` (all three
+/// modes) and `wake_handle` (Resume against the bound threadId, or Fresh when
+/// no binding survived — a wake NEVER replays a fork: by the time a session can
+/// idle-suspend its fork has completed and its own thread is bound).
+enum HandshakeMode<'a> {
+    Fresh,
+    Resume(&'a str),
+    Fork {
+        parent_thread_id: &'a str,
+        last_turn_id: Option<&'a str>,
+    },
+}
+
 /// Serialize neutral [`McpServerSpec`]s into codex's `config.mcp_servers` MAP
 /// (keyed by name), the shape codex's config loader expects (verified live +
 /// against `codex mcp add` TOML output). DISTINCT from the ACP wire: codex stdio
@@ -655,6 +698,13 @@ pub struct CodexSessionBackend {
     /// and the conversation's recovery (anchor clear + auto-replay) takes over.
     /// Reset at the start of every handshake (a re-spawn is a fresh chance).
     resume_poison: Arc<Mutex<Option<String>>>,
+    /// The rpc id of the in-flight `thread/fork` (Fork handshakes only,
+    /// `pending_resume`'s sibling). The reader claims the response: an ERROR
+    /// (parent rollout gone, parent turn in flight, …) poisons the bound-thread
+    /// wait — a Fork handshake pre-seeds NO binding, so without the poison the
+    /// first Send would poll forever for a `thread/started` that never comes.
+    /// A success needs no action (`thread/started` for the NEW thread binds it).
+    pending_fork: Arc<Mutex<Option<u64>>>,
     /// The id of the in-flight turn (codex `turn/started.turn.id`), needed by
     /// `turn/interrupt{turnId}` and `turn/steer{expectedTurnId}` (optimistic
     /// concurrency token). Set on `turn/started`, cleared on terminal.
@@ -792,6 +842,7 @@ struct CodexReaderState {
     pending_set: Arc<Mutex<HashMap<u64, String>>>,
     pending_resume: Arc<Mutex<Option<u64>>>,
     resume_poison: Arc<Mutex<Option<String>>>,
+    pending_fork: Arc<Mutex<Option<u64>>>,
     discovered: Arc<std::sync::Mutex<Discovered>>,
     stdin: Arc<Mutex<Option<aionui_process::BoxedStdin>>>,
     /// F-4 turn-active flag: set on dispatch(Send), cleared by the reader at a turn
@@ -824,6 +875,7 @@ fn start_codex_reader(
             state.pending_set,
             state.pending_resume,
             state.resume_poison,
+            state.pending_fork,
             state.discovered,
             state.stdin,
             state.turn_in_flight,
@@ -952,6 +1004,7 @@ impl CodexSessionBackend {
         let pending_set = Arc::new(Mutex::new(HashMap::new()));
         let pending_resume = Arc::new(Mutex::new(None));
         let resume_poison = Arc::new(Mutex::new(None));
+        let pending_fork = Arc::new(Mutex::new(None));
         let discovered = Arc::new(std::sync::Mutex::new(Discovered::default()));
         let turn_in_flight = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let (event_tx, _) = broadcast::channel(1024);
@@ -975,6 +1028,7 @@ impl CodexSessionBackend {
             pending_set: pending_set.clone(),
             pending_resume: pending_resume.clone(),
             resume_poison: resume_poison.clone(),
+            pending_fork: pending_fork.clone(),
             discovered: discovered.clone(),
             stdin: stdin.clone(),
             turn_in_flight: turn_in_flight.clone(),
@@ -1031,6 +1085,7 @@ impl CodexSessionBackend {
             pending_set,
             pending_resume,
             resume_poison,
+            pending_fork,
             discovered,
         }
     }
@@ -1106,14 +1161,14 @@ impl CodexSessionBackend {
     /// so the reader fills `discovered`). Shared by `open_session` (the initial
     /// open) and `wake_handle` (an idle-wake re-attach), so the wire shape lives in
     /// one place.
-    async fn run_handshake(&self, resume_thread_id: Option<&str>) -> Result<(), BackendError> {
+    async fn run_handshake(&self, mode: HandshakeMode<'_>) -> Result<(), BackendError> {
         // A handshake is a fresh chance: any prior resume rejection belonged to
         // the previous process/attempt.
         *self.resume_poison.lock().await = None;
         self.write_frame(initialize_params().into_frame(self.next_rpc_id(), "initialize"))
             .await?;
-        match resume_thread_id {
-            Some(tid) => {
+        match mode {
+            HandshakeMode::Resume(tid) => {
                 *self.thread_binding.lock().await = Some(tid.to_string());
                 // Resume re-sends the full thread/start override surface — a bare
                 // {threadId} resume silently drops the user's MCP servers and
@@ -1130,7 +1185,28 @@ impl CodexSessionBackend {
                 self.write_frame(thread_resume_params(&self.wake.config, tid).into_frame(resume_id, "thread/resume"))
                     .await?;
             }
-            None => {
+            HandshakeMode::Fork {
+                parent_thread_id,
+                last_turn_id,
+            } => {
+                // Deliberately NO thread_binding pre-seed: the parent threadId is
+                // only the fork SOURCE. codex answers with `thread/started` for
+                // the NEW thread, and the reader's existing handler binds it —
+                // on this session's own connection that binding is exactly the
+                // one we want (the parent conversation has its own connection
+                // and is never touched). Register the rpc id so the reader can
+                // claim an ERROR response (parent rollout gone, in-flight turn,
+                // …) and poison the bound-thread wait — otherwise the first
+                // Send would poll for a binding that will never arrive.
+                let fork_id = self.next_rpc_id();
+                *self.pending_fork.lock().await = Some(fork_id);
+                self.write_frame(
+                    thread_fork_params(&self.wake.config, parent_thread_id, last_turn_id)
+                        .into_frame(fork_id, "thread/fork"),
+                )
+                .await?;
+            }
+            HandshakeMode::Fresh => {
                 self.write_frame(thread_start_params(&self.wake.config).into_frame(self.next_rpc_id(), "thread/start"))
                     .await?;
             }
@@ -1206,8 +1282,15 @@ impl CodexSessionBackend {
         // handshake failure, abort the just-started reader so its AgentIo clone
         // releases and the freshly-spawned child is reaped (kill_on_drop) — else it
         // leaks (the controller never takes ownership of a failed wake's handle).
+        // A wake NEVER replays a fork: by the time a session can idle-suspend,
+        // its fork completed and `thread_binding` holds the NEW thread — resume
+        // against it (or Fresh if the binding was lost, the pre-fork behavior).
         let resume_tid = self.thread_binding.lock().await.clone();
-        if let Err(e) = self.run_handshake(resume_tid.as_deref()).await {
+        let mode = match resume_tid.as_deref() {
+            Some(tid) => HandshakeMode::Resume(tid),
+            None => HandshakeMode::Fresh,
+        };
+        if let Err(e) = self.run_handshake(mode).await {
             reader.abort();
             return Err(e);
         }
@@ -1236,6 +1319,7 @@ async fn reader_task(
     pending_set: Arc<Mutex<HashMap<u64, String>>>,
     pending_resume: Arc<Mutex<Option<u64>>>,
     resume_poison: Arc<Mutex<Option<String>>>,
+    pending_fork: Arc<Mutex<Option<u64>>>,
     discovered: Arc<std::sync::Mutex<Discovered>>,
     stdin: Arc<Mutex<Option<aionui_process::BoxedStdin>>>,
     turn_in_flight: Arc<std::sync::atomic::AtomicBool>,
@@ -1386,6 +1470,18 @@ async fn reader_task(
                             // turn/interrupt{turnId} + turn/steer{expectedTurnId}).
                             if let Some(tid) = params.get("turn").and_then(|t| t.get("id")).and_then(Value::as_str) {
                                 *active_turn_id.lock().await = Some(tid.to_string());
+                                // Fork anchoring: lower codex's OWN turn id so the
+                                // conversation layer stamps it onto this turn's
+                                // message rows (`messages.backend_turn_id`) — the
+                                // lookup key for `thread/fork`'s `lastTurnId`.
+                                emit(
+                                    &event_tx,
+                                    &session_id,
+                                    cur,
+                                    SessionEvent::BackendTurnBound {
+                                        backend_turn_id: tid.to_string(),
+                                    },
+                                );
                             }
                         }
                         // R8 dual-terminal reconcile: codex sends status→idle FIRST
@@ -1533,6 +1629,34 @@ async fn reader_task(
                                 );
                                 *thread_binding.lock().await = None;
                                 *resume_poison.lock().await = Some(format!("codex thread/resume failed: {msg}"));
+                                continue;
+                            }
+                            // Claim the thread/fork response (pending_resume's
+                            // sibling). A Fork handshake pre-seeds NO binding, so
+                            // an ERROR (parent rollout gone, …) must poison the
+                            // bound-thread wait or the first Send polls forever.
+                            // NEVER fall back to a fresh/HEAD thread here — the
+                            // user asked for the parent's context, and silently
+                            // dropping it is worse than failing (§G). A success
+                            // needs nothing: `thread/started` for the NEW thread
+                            // binds it via the notification handler above.
+                            let is_fork = {
+                                let mut pending = pending_fork.lock().await;
+                                match *pending {
+                                    Some(pfid) if pfid == rid => {
+                                        *pending = None;
+                                        true
+                                    }
+                                    _ => false,
+                                }
+                            };
+                            if is_fork && let Some(msg) = error_message.as_deref() {
+                                tracing::warn!(
+                                    conversation_id = %session_id,
+                                    error = %msg,
+                                    "codex thread/fork rejected — poisoning bound-thread wait (no silent fallback)"
+                                );
+                                *resume_poison.lock().await = Some(format!("codex thread/fork failed: {msg}"));
                                 continue;
                             }
                             let pending_send = pending_sends.lock().await.remove(&rid);
@@ -7052,7 +7176,10 @@ mod tests {
         let fake = FakeAgentIo::never_exits(Vec::new());
         let captured = fake.captured_stdin();
         let backend = CodexSessionBackend::build_with_io("codex-hs", Box::new(fake)).await;
-        backend.run_handshake(None).await.expect("handshake writes");
+        backend
+            .run_handshake(HandshakeMode::Fresh)
+            .await
+            .expect("handshake writes");
         let written = captured_str(&captured).await;
         assert!(
             written.contains(r#""method":"model/list""#),
@@ -8390,5 +8517,134 @@ mod tests {
             tid, "th-late",
             "the late-arriving threadId binds (no premature timeout)"
         );
+    }
+
+    /// Fork handshake down-leg: `run_handshake(Fork)` writes `thread/fork` with
+    /// the PARENT threadId + `lastTurnId`, and — unlike Resume — pre-seeds NO
+    /// thread binding (the NEW thread's id arrives via `thread/started`).
+    #[tokio::test]
+    async fn fork_handshake_writes_thread_fork_without_preseeding_binding() {
+        use futures_util::StreamExt as _;
+        // Gated tail: the `thread/started` for the forked (NEW) thread, released
+        // only after the down-leg assertions.
+        let tail = format!(
+            "{}\n",
+            r#"{"jsonrpc":"2.0","method":"thread/started","params":{"thread":{"id":"th-child"}}}"#
+        )
+        .into_bytes();
+        let fake = FakeAgentIo::new(Vec::new(), None).with_gated_tail(tail);
+        let release = fake.stdout_releaser();
+        let captured = fake.captured_stdin();
+        let backend = CodexSessionBackend::build_with_io("codex-fork", Box::new(fake)).await;
+        let mut events = backend.events();
+
+        backend
+            .run_handshake(HandshakeMode::Fork {
+                parent_thread_id: "th-parent",
+                last_turn_id: Some("turn-3"),
+            })
+            .await
+            .expect("fork handshake writes");
+
+        let written = captured_str(&captured).await;
+        assert!(
+            written.contains(r#""method":"thread/fork""#),
+            "wrote thread/fork, got: {written}"
+        );
+        assert!(
+            written.contains(r#""threadId":"th-parent""#) && written.contains(r#""lastTurnId":"turn-3""#),
+            "fork targets the parent thread at the anchor turn, got: {written}"
+        );
+        assert!(
+            backend.thread_binding.lock().await.is_none(),
+            "Fork must NOT pre-seed the binding — the parent id is only the fork source"
+        );
+
+        // Release the thread/started for the NEW thread: the reader binds it and
+        // lowers BackendBound{th-child} (the fork conversation's resume anchor).
+        release();
+        let bound = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while let Some(env) = events.next().await {
+                if let SessionEvent::BackendBound { backend_session_id } = env.event {
+                    return backend_session_id;
+                }
+            }
+            None
+        })
+        .await
+        .ok()
+        .flatten();
+        assert_eq!(bound.as_deref(), Some("th-child"), "the NEW thread id is lowered");
+        assert_eq!(
+            backend.thread_binding.lock().await.as_deref(),
+            Some("th-child"),
+            "the reader bound the forked thread"
+        );
+    }
+
+    /// Fork handshake error-leg: a `thread/fork` ERROR (parent rollout gone)
+    /// poisons the bound-thread wait so the first Send fails fast with the real
+    /// cause — never a silent fresh/HEAD fallback, never an opaque timeout.
+    #[tokio::test]
+    async fn fork_handshake_error_poisons_bound_thread_wait() {
+        // rpc ids: initialize=1, thread/fork=2 → the error must carry id 2.
+        let tail = format!(
+            "{}\n",
+            r#"{"jsonrpc":"2.0","id":2,"error":{"code":-32603,"message":"no rollout found for thread id th-parent"}}"#
+        )
+        .into_bytes();
+        let fake = FakeAgentIo::new(Vec::new(), None).with_gated_tail(tail);
+        let release = fake.stdout_releaser();
+        let backend = CodexSessionBackend::build_with_io("codex-fork-err", Box::new(fake)).await;
+
+        backend
+            .run_handshake(HandshakeMode::Fork {
+                parent_thread_id: "th-parent",
+                last_turn_id: None,
+            })
+            .await
+            .expect("the down-leg write itself succeeds");
+        release();
+        // Give the reader a beat to claim the error response.
+        tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+
+        let err = backend
+            .bound_thread_within(std::time::Duration::from_millis(200))
+            .await
+            .expect_err("poisoned wait fails fast");
+        assert!(
+            matches!(&err, BackendError::SessionNotFound(m) if m.contains("thread/fork failed") && m.contains("no rollout")),
+            "fork rejection surfaces as SessionNotFound with the codex cause, got {err:?}"
+        );
+    }
+
+    /// Fork anchoring: `turn/started` lowers codex's OWN turn id as
+    /// BackendTurnBound so the conversation layer can stamp it onto the turn's
+    /// message rows (the `thread/fork` lastTurnId lookup key).
+    #[tokio::test]
+    async fn turn_started_emits_backend_turn_bound() {
+        use futures_util::StreamExt as _;
+        let tail = format!(
+            "{}\n",
+            r#"{"jsonrpc":"2.0","method":"turn/started","params":{"turn":{"id":"turn-7"}}}"#
+        )
+        .into_bytes();
+        let fake = FakeAgentIo::new(Vec::new(), None).with_gated_tail(tail);
+        let release = fake.stdout_releaser();
+        let backend = CodexSessionBackend::build_with_io("codex-turnid", Box::new(fake)).await;
+        let mut events = backend.events();
+        release();
+        let bound = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while let Some(env) = events.next().await {
+                if let SessionEvent::BackendTurnBound { backend_turn_id } = env.event {
+                    return Some(backend_turn_id);
+                }
+            }
+            None
+        })
+        .await
+        .ok()
+        .flatten();
+        assert_eq!(bound.as_deref(), Some("turn-7"), "turn/started lowers codex's turn id");
     }
 }

--- a/crates/aionui-session/src/backend/types.rs
+++ b/crates/aionui-session/src/backend/types.rs
@@ -329,6 +329,20 @@ pub enum SessionSpec {
         session_id: String,
         backend_session_id: Option<String>,
     },
+    /// Open by forking an EXISTING backend session into a new one: the parent's
+    /// transport id is only the fork SOURCE, never this session's binding. The
+    /// adapter learns its own binding from the backend (codex `thread/started`,
+    /// claude `system/init`) and reports it via `BackendBound`. Used exactly
+    /// once per forked conversation — as soon as a binding is persisted, later
+    /// opens go back to `Resume`.
+    Fork {
+        session_id: String,
+        /// The parent conversation's backend session id (fork source).
+        parent_backend_session_id: String,
+        /// Backend turn to fork at (inclusive); `None` = fork at HEAD. Only
+        /// codex (`thread/fork`'s `lastTurnId`) consumes this today.
+        at_turn_id: Option<String>,
+    },
 }
 
 // ==========================================================================

--- a/crates/aionui-session/src/event.rs
+++ b/crates/aionui-session/src/event.rs
@@ -561,6 +561,17 @@ pub enum SessionEvent {
     /// re-attach, fork, or backend-session loss. `None` = backend session lost /
     /// not yet established.
     BackendBound { backend_session_id: Option<String> },
+
+    /// Fork anchoring (BackendBound's turn-scoped sibling): the adapter lowers
+    /// the backend's OWN id for the turn that just started (codex
+    /// `turn/started` → `Turn.id`) so the conversation layer can stamp it onto
+    /// every message row it persists for that turn. That stamp is what later
+    /// resolves `thread/fork`'s `lastTurnId` when the user forks mid-history —
+    /// the runtime `turn_<shortid>` ids are aionui-minted and mean nothing to
+    /// the backend. Same contract as BackendBound: orchestration-lowered
+    /// pass-through, reducer no-op, never persisted as an event. Only codex
+    /// emits it today; backends without a turn-anchored fork never do.
+    BackendTurnBound { backend_turn_id: String },
 }
 
 // ==========================================================================
@@ -875,6 +886,7 @@ pub fn classify(event: &SessionEvent) -> EventClass {
         | Snapshot { .. }
         | Lagged { .. }
         | BackendBound { .. }
+        | BackendTurnBound { .. }
         | BackendSuspended => EventClass::OrchestrationLowered,
         // backend-produced (self-describing; PERSISTED — tier decided separately, §7.2)
         MessageDelta { .. }
@@ -965,6 +977,7 @@ pub fn persist_tier(event: &SessionEvent) -> PersistTier {
             | Snapshot { .. }
             | Lagged { .. }
             | BackendBound { .. }
+            | BackendTurnBound { .. }
             | BackendSuspended => PersistTier::Ephemeral,
         },
     }

--- a/crates/aionui-session/src/reducer.rs
+++ b/crates/aionui-session/src/reducer.rs
@@ -421,6 +421,9 @@ pub fn step(state: &SessionState, event: SessionEvent) -> (SessionState, Vec<Tra
         // (persist backend_session_id). The reducer NEVER touches SessionState for
         // it — it is not a turn signal, not a requires-action, not a roster update.
         | SessionEvent::BackendBound { .. }
+        // BackendTurnBound is BackendBound's turn-scoped sibling (fork anchor
+        // pass-through for message stamping). Same contract: reducer no-op.
+        | SessionEvent::BackendTurnBound { .. }
         // 009 R6: BackendSuspended is FSM-invisible (the wake re-spawns on the
         // same event_tx). The orchestrator clears the roster on it; the reducer
         // does NOT move SessionState (suspend ≠ a turn boundary).

--- a/crates/aionui-session/src/testing.rs
+++ b/crates/aionui-session/src/testing.rs
@@ -491,6 +491,7 @@ impl BackendConnection for ScriptedConnection {
         let session_id = match &spec {
             SessionSpec::Fresh { session_id } => session_id.clone(),
             SessionSpec::Resume { session_id, .. } => session_id.clone(),
+            SessionSpec::Fork { session_id, .. } => session_id.clone(),
         };
         // Gate the NDJSON bytes so the reader does NOT emit events before the
         // orchestrator subscribes to `backend.events()` (a late-subscriber drop).

--- a/crates/aionui-team/src/message_projection.rs
+++ b/crates/aionui-team/src/message_projection.rs
@@ -314,6 +314,7 @@ where
             status: Some("finish".into()),
             hidden: request.visibility.allow_hidden_conversation_message,
             created_at,
+            backend_turn_id: None,
         })
     }
 }


### PR DESCRIPTION
Closes #770

## What

Message-level conversation fork: `POST /api/conversations/{id}/fork {message_id, name?}` branches a conversation into a NEW one that inherits the agent-side context, per backend mechanism:

| backend | mechanism | fork point |
|---|---|---|
| codex | app-server `thread/fork` + `lastTurnId` | any turn |
| claude (direct CLI) | `--resume <parent> --fork-session` | HEAD |
| ACP vendors | `session/fork` (capability-gated via `sessionCapabilities.fork`) | HEAD |
| antigravity | refused (no headless fork surface) | — |

## How

- **Lazy "fork as an open mode"** — the fork API is pure bookkeeping (validate → create row with `extra.fork` lineage + parent-sid snapshot → copy visible history up to the fork point inclusive). The backend session materializes on the fork's FIRST open, on the fork's own connection/process: `SessionSpec::Fork` (direct CLI) / `open_session_fork` (ACP manager). The existing `runtime/ensure` endpoint gives callers eager failure surfacing.
- **codex**: `run_handshake` three-mode (`Fresh/Resume/Fork`); Fork sends `thread/fork` with the full `thread/start` override surface, pre-seeds NO thread binding (the NEW thread's id arrives via `thread/started`), and a rejection poisons the bound-thread wait via a `pending_fork` slot — fail fast, never a silent fresh/HEAD fallback. `turn/started` now lowers `BackendTurnBound` (codex's own `Turn.id`) which the relay stamps onto `messages.backend_turn_id` — the lookup key for mid-history fork anchors; unresolvable anchors are refused with 422.
- **claude**: `LegacySessionSpec::ForkFrom` → `--resume <parent> --fork-session` (no `--session-id`; the new sid is learned from `system/init`). Also fixes a pre-existing wake-recipe bug fork would have made fatal: the resume anchor is now a shared slot the init sniffer rotates, so an idle-wake resumes the sid claude actually reported instead of re-forking / resurrecting the parent.
- **ACP**: `open_session_fork` mirrors the `session/load` flow (cwd/mcp_servers/response absorption/`SessionAssigned`), with a live `sessionCapabilities.fork` gate as the second line of defense behind the `agent_metadata` check. `SessionNotFound` and missing capability are explicit errors — an initial fork never silently degrades to `session/new`.
- **Capability declaration**: migration 036 seeds `session_capabilities.fork` for the builtin claude (`{}`) / codex (`{"at_turn":true}`) rows via `json_patch`; ACP agents get it from the persisted handshake. Projected as `ConversationResponse.fork_capability` on the detail path only (no list N+1).
- **Guard rails**: `create()` strips a client-supplied `extra.fork` (server-minted only); deleting a parent keeps an auto-provisioned workspace other conversations still share (`list_associated` guard, fails closed); team conversations and in-flight turns are refused (409).
- Error contract with stable reason prefixes: 409 `FORK_TURN_IN_FLIGHT` / `FORK_PARENT_UNBOUND`, 422 `FORK_UNSUPPORTED` / `FORK_POINT_UNSUPPORTED`.

## Tests

- 4 repository tests: inclusive copy with monotonic-UUIDv7 id reminting, transaction atomicity, anchor resolution
- codex fork handshake down/up/error legs, `BackendTurnBound` emission (hermetic FakeAgentIo)
- claude `ForkFrom` argv, wake-slot rotation unit + wake-after-rotation end-to-end (also covers the pre-existing rotation bug)
- `spec_mode_model` sid×fork quadrant matrix; ACP fork-capability gate trio
- 8 service integration tests over the real in-memory DB (036 seeds included): HEAD/mid-history forks, anchor refusal, error matrix, create-strip, shared-workspace delete protection
- Full targeted suites green: aionui-db 329 / aionui-session 526 / aionui-ai-agent 891 / aionui-conversation 376 (+ integration)

Frontend counterpart: iOfficeAI/AionUi#3841

## Verified capability landscape (dev DB, post-036)

Queried `agent_metadata.agent_capabilities.session_capabilities.fork` on a live dev database after this branch's backend ran (migration 036 applied, `json_patch` correctly merged into pre-existing handshake blobs instead of clobbering them):

**Fork supported (14):**
- **Codex CLI** — `fork {at_turn: true}` (only backend with arbitrary-turn forks; migration-constructed)
- **Claude Code** — `fork {}` HEAD-only (migration-merged; the row already carried historical ACP-bridge handshake data incl. `_meta.claudeCode.promptQueueing`, all preserved)
- OpenCode, Qoder, Vibe, Hermes, Junie, Kilo, Nova, MiMo Code, GLM Agent, Autohand, omp, siGit Code — HEAD-only via their own ACP handshake / registry seeds advertising `sessionCapabilities.fork`

**No fork (entry hidden):** Antigravity (by product decision), and ~20 handshaked vendors without the capability (Gemini CLI, Qwen, Copilot, Kimi, Goose, Droid, Auggie, CodeBuddy, Kiro, Amp, Devin, Pi, …) plus never-handshaked rows (Cursor, Snow, Aion CLI, Nanobot, OpenClaw Gateway).

**Live fork smoke (codex):** two HEAD forks of a real codex conversation created lineage rows + copied history correctly; new turns after the fork got `messages.backend_turn_id` stamped (15 rows, one turn id), while copied/legacy rows stayed NULL and are refused with `FORK_POINT_UNSUPPORTED` — matching the no-silent-degradation contract (the frontend now hides those entries preemptively via the exposed `backend_turn_id`).
