### PR TITLE
feat(agent): multimodal prompt — native image/audio content blocks gated by promptCapabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,7 @@ dependencies = [
  "hex",
  "http 1.4.0",
  "libc",
+ "mime_guess",
  "regex",
  "rusqlite",
  "serde",

--- a/crates/aionui-ai-agent/Cargo.toml
+++ b/crates/aionui-ai-agent/Cargo.toml
@@ -20,6 +20,7 @@ aionui-system.workspace = true
 axum.workspace = true
 http.workspace = true
 base64.workspace = true
+mime_guess.workspace = true
 tokio.workspace = true
 tokio-tungstenite.workspace = true
 ed25519-dalek.workspace = true

--- a/crates/aionui-ai-agent/src/agent_task.rs
+++ b/crates/aionui-ai-agent/src/agent_task.rs
@@ -21,7 +21,7 @@ use crate::manager::acp::{AcpAgentManager, RequiredFullAutoApplication};
 use crate::manager::aionrs::AionrsAgentManager;
 use crate::protocol::events::AgentStreamEvent;
 use crate::protocol::send_error::AgentSendError;
-use crate::types::SendMessageData;
+use crate::types::{PromptMediaCaps, SendMessageData};
 
 use aionui_api_types::{
     GetConfigOptionsResponse, GetModelInfoResponse, ModelInfoEntry, ModelInfoPayload, SetConfigOptionResponse,
@@ -58,6 +58,12 @@ pub trait IAgentTask: Send + Sync {
 
     /// Subscribe to the agent's stream event channel.
     fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent>;
+
+    /// Prompt media capabilities the agent declared. Defaults to none —
+    /// callers must then deliver attachments as file paths, not blocks.
+    fn prompt_media_caps(&self) -> PromptMediaCaps {
+        PromptMediaCaps::default()
+    }
 
     /// Send a user message to the agent. Returns once the agent has
     /// accepted the turn; actual streaming proceeds on the broadcast

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -14,12 +14,12 @@ pub mod error;
 pub mod factory;
 pub(crate) mod idle_scanner;
 pub mod manager;
-pub mod media;
 /// Neutral MCP resolution for the session-model port (claude/codex). Ported from
 /// clean-slate `aionui-agent-context::mcp_resolve` — the SSOT that turns a
 /// conversation's configured MCP servers into the SDK-free `SessionMcpServer`
 /// shape the `SessionBackend` stack carries in `SessionConfig.init.mcp_servers`.
 pub(crate) mod mcp_resolve;
+pub mod media;
 pub(crate) mod persistence;
 pub mod protocol;
 pub mod registry;

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub mod factory;
 pub(crate) mod idle_scanner;
 pub mod manager;
+pub mod media;
 /// Neutral MCP resolution for the session-model port (claude/codex). Ported from
 /// clean-slate `aionui-agent-context::mcp_resolve` — the SSOT that turns a
 /// conversation's configured MCP servers into the SDK-free `SessionMcpServer`

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -1375,6 +1375,11 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
         self.runtime.subscribe()
     }
 
+    fn prompt_media_caps(&self) -> crate::types::PromptMediaCaps {
+        let caps = self.protocol.agent_capabilities().map(|c| c.prompt_capabilities).unwrap_or_default();
+        crate::types::PromptMediaCaps { image: caps.image, audio: caps.audio }
+    }
+
     #[tracing::instrument(skip_all, fields(conversation_id = %self.params.conversation_id, msg_id = %data.msg_id))]
     async fn send_message(&self, data: SendMessageData) -> Result<(), AgentSendError> {
         self.runtime.bump_activity();

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -1376,8 +1376,15 @@ impl crate::agent_task::IAgentTask for AcpAgentManager {
     }
 
     fn prompt_media_caps(&self) -> crate::types::PromptMediaCaps {
-        let caps = self.protocol.agent_capabilities().map(|c| c.prompt_capabilities).unwrap_or_default();
-        crate::types::PromptMediaCaps { image: caps.image, audio: caps.audio }
+        let caps = self
+            .protocol
+            .agent_capabilities()
+            .map(|c| c.prompt_capabilities)
+            .unwrap_or_default();
+        crate::types::PromptMediaCaps {
+            image: caps.image,
+            audio: caps.audio,
+        }
     }
 
     #[tracing::instrument(skip_all, fields(conversation_id = %self.params.conversation_id, msg_id = %data.msg_id))]

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -523,6 +523,18 @@ async fn build_prompt_blocks(data: &SendMessageData, caps: crate::types::PromptM
         });
     }
 
+    let (images, audios) = partition.media.iter().fold((0usize, 0usize), |(i, a), m| match m.kind {
+        crate::media::MediaKind::Image => (i + 1, a),
+        crate::media::MediaKind::Audio => (i, a + 1),
+    });
+    tracing::info!(
+        msg_id = %data.msg_id,
+        images,
+        audios,
+        path_files = partition.path_files.len(),
+        "ACP prompt carries native media content blocks"
+    );
+
     let mut blocks = Vec::with_capacity(media_blocks.len() + 1);
     blocks.push(ContentBlock::from(partition.content));
     blocks.extend(media_blocks);

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -788,7 +788,9 @@ mod tests {
     use crate::protocol::error::AcpError;
     use crate::shared_kernel::SessionId as DomainSessionId;
     use crate::types::SendMessageData;
-    use agent_client_protocol::schema::v1::{AgentCapabilities, ContentBlock, Cost, PromptResponse, Usage, UsageUpdate};
+    use agent_client_protocol::schema::v1::{
+        AgentCapabilities, ContentBlock, Cost, PromptResponse, Usage, UsageUpdate,
+    };
 
     use super::{end_turn_usage_frame, end_turn_usage_frame_from_response, preserve_known_window};
 
@@ -1523,10 +1525,7 @@ mod tests {
         let img = dir.join("plain.png");
         std::fs::write(&img, b"fakepng").unwrap();
         let img = img.to_string_lossy().into_owned();
-        let content = format!(
-            "hi\n\n{}\n{img}",
-            aionui_common::constants::AIONUI_FILES_MARKER
-        );
+        let content = format!("hi\n\n{}\n{img}", aionui_common::constants::AIONUI_FILES_MARKER);
         let data = SendMessageData {
             content: content.clone(),
             msg_id: "m1".into(),
@@ -1564,7 +1563,10 @@ mod tests {
             files: vec![img.clone(), pdf.clone()],
             inject_skills: vec![],
         };
-        let caps = crate::types::PromptMediaCaps { image: true, audio: false };
+        let caps = crate::types::PromptMediaCaps {
+            image: true,
+            audio: false,
+        };
         let blocks = super::build_prompt_blocks(&data, caps).await;
         assert_eq!(blocks.len(), 2);
         match &blocks[0] {
@@ -1580,10 +1582,7 @@ mod tests {
         match &blocks[1] {
             ContentBlock::Image(image) => {
                 assert_eq!(image.mime_type, "image/png");
-                assert_eq!(
-                    image.data,
-                    base64::engine::general_purpose::STANDARD.encode(b"fakepng")
-                );
+                assert_eq!(image.data, base64::engine::general_purpose::STANDARD.encode(b"fakepng"));
                 assert_eq!(image.uri.as_deref(), Some(format!("file://{img}").as_str()));
             }
             other => panic!("expected image block, got {other:?}"),
@@ -1597,10 +1596,7 @@ mod tests {
         let img = dir.join("vanishing.png");
         std::fs::write(&img, b"fakepng").unwrap();
         let img_path = img.to_string_lossy().into_owned();
-        let content = format!(
-            "gone\n\n{}\n{img_path}",
-            aionui_common::constants::AIONUI_FILES_MARKER
-        );
+        let content = format!("gone\n\n{}\n{img_path}", aionui_common::constants::AIONUI_FILES_MARKER);
         let data = SendMessageData {
             content: content.clone(),
             msg_id: "m3".into(),
@@ -1608,7 +1604,10 @@ mod tests {
             files: vec![img_path.clone()],
             inject_skills: vec![],
         };
-        let caps = crate::types::PromptMediaCaps { image: true, audio: false };
+        let caps = crate::types::PromptMediaCaps {
+            image: true,
+            audio: false,
+        };
         // Classification uses fs::metadata inside partition_media, which runs
         // inside build_prompt_blocks — so remove the file first and verify the
         // whole prompt degrades to the original text form.

--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -10,8 +10,8 @@ use crate::protocol::send_error::AgentSendError;
 use crate::shared_kernel::SessionId as DomainSessionId;
 use crate::types::SendMessageData;
 use agent_client_protocol::schema::v1::{
-    AuthMethod, ContentBlock, ForkSessionRequest, LoadSessionRequest, PromptRequest, PromptResponse, SessionId,
-    StopReason, Usage, UsageUpdate,
+    AudioContent, AuthMethod, ContentBlock, ForkSessionRequest, ImageContent, LoadSessionRequest, PromptRequest,
+    PromptResponse, SessionId, StopReason, Usage, UsageUpdate,
 };
 use aionui_api_types::SlashCommandItem;
 use serde_json::Value;
@@ -329,7 +329,10 @@ impl AcpAgentManager {
             .ok_or_else(|| AgentError::internal("Cannot prompt: no session ID available"))
             .map_err(AcpSendFailure::from)?;
 
-        let content = data.content.clone();
+        let prompt_blocks = {
+            use crate::agent_task::IAgentTask as _;
+            build_prompt_blocks(data, self.prompt_media_caps()).await
+        };
 
         // Subscribe BEFORE emitting Start so we can observe every event
         // produced during this turn. Used after `prompt()` returns to detect
@@ -348,10 +351,7 @@ impl AcpAgentManager {
 
         let prompt_response = self
             .protocol
-            .prompt(PromptRequest::new(
-                SessionId::new(sid),
-                vec![ContentBlock::from(content)],
-            ))
+            .prompt(PromptRequest::new(SessionId::new(sid), prompt_blocks))
             .await
             .map_err(AcpSendFailure::from)?;
 
@@ -489,6 +489,46 @@ impl AcpAgentManager {
 ///
 /// `Lagged` is treated as non-empty: the broadcast buffer overflowed,
 /// meaning many events flew by — definitely not an empty turn.
+/// Build the `session/prompt` content blocks: a text block plus one native
+/// Image/Audio block per attachment the agent's declared `promptCapabilities`
+/// accept. Attachments the agent cannot take (or that fail to read) stay in
+/// the text block's `[[AION_FILES]]` path list, byte-identical to the
+/// pre-multimodal wire form.
+async fn build_prompt_blocks(data: &SendMessageData, caps: crate::types::PromptMediaCaps) -> Vec<ContentBlock> {
+    use base64::Engine as _;
+
+    let partition = crate::media::partition_media(&data.content, &data.files, caps);
+    if partition.media.is_empty() {
+        return vec![ContentBlock::from(partition.content)];
+    }
+
+    let mut media_blocks = Vec::with_capacity(partition.media.len());
+    for attachment in &partition.media {
+        // Any read failure degrades the WHOLE prompt back to the plain text
+        // form: partial degradation would need the marker block rebuilt a
+        // second time, and a file vanishing between classify and read is too
+        // rare to warrant that complexity.
+        let Some(bytes) = crate::media::read_media_bytes(attachment).await else {
+            warn!(path = %attachment.path, "media attachment read failed; falling back to path-only prompt");
+            return vec![ContentBlock::from(data.content.clone())];
+        };
+        let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+        media_blocks.push(match attachment.kind {
+            crate::media::MediaKind::Image => {
+                let mut image = ImageContent::new(encoded, attachment.mime.clone());
+                image.uri = Some(format!("file://{}", attachment.path));
+                ContentBlock::Image(image)
+            }
+            crate::media::MediaKind::Audio => ContentBlock::Audio(AudioContent::new(encoded, attachment.mime.clone())),
+        });
+    }
+
+    let mut blocks = Vec::with_capacity(media_blocks.len() + 1);
+    blocks.push(ContentBlock::from(partition.content));
+    blocks.extend(media_blocks);
+    blocks
+}
+
 /// Thin wrapper retained for the existing empty-turn detection tests; the
 /// production path now uses [`drain_turn_observations`] to observe the dialect
 /// signal alongside emptiness in a single drain.
@@ -747,7 +787,8 @@ mod tests {
     use crate::manager::acp::{AcpSession, AcpSessionEvent};
     use crate::protocol::error::AcpError;
     use crate::shared_kernel::SessionId as DomainSessionId;
-    use agent_client_protocol::schema::v1::{AgentCapabilities, Cost, PromptResponse, Usage, UsageUpdate};
+    use crate::types::SendMessageData;
+    use agent_client_protocol::schema::v1::{AgentCapabilities, ContentBlock, Cost, PromptResponse, Usage, UsageUpdate};
 
     use super::{end_turn_usage_frame, end_turn_usage_frame_from_response, preserve_known_window};
 
@@ -1473,5 +1514,110 @@ mod tests {
         assert_eq!(error.code, Some(AgentErrorCode::UserLlmProviderBillingRequired));
         assert_eq!(error.retryable, Some(false));
         assert_eq!(error.feedback_recommended, Some(false));
+    }
+
+    #[tokio::test]
+    async fn prompt_blocks_stay_single_text_without_caps() {
+        let dir = std::env::temp_dir().join("aionui-acp-prompt-tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let img = dir.join("plain.png");
+        std::fs::write(&img, b"fakepng").unwrap();
+        let img = img.to_string_lossy().into_owned();
+        let content = format!(
+            "hi\n\n{}\n{img}",
+            aionui_common::constants::AIONUI_FILES_MARKER
+        );
+        let data = SendMessageData {
+            content: content.clone(),
+            msg_id: "m1".into(),
+            turn_id: None,
+            files: vec![img],
+            inject_skills: vec![],
+        };
+        let blocks = super::build_prompt_blocks(&data, crate::types::PromptMediaCaps::default()).await;
+        assert_eq!(blocks.len(), 1);
+        match &blocks[0] {
+            ContentBlock::Text(text) => assert_eq!(text.text, content),
+            other => panic!("expected text block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn prompt_blocks_carry_native_image_when_capable() {
+        use base64::Engine as _;
+        let dir = std::env::temp_dir().join("aionui-acp-prompt-tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let img = dir.join("native.png");
+        std::fs::write(&img, b"fakepng").unwrap();
+        let img = img.to_string_lossy().into_owned();
+        let pdf = dir.join("doc.pdf");
+        std::fs::write(&pdf, b"fakepdf").unwrap();
+        let pdf = pdf.to_string_lossy().into_owned();
+        let content = format!(
+            "look\n\n{}\n{img}\n{pdf}",
+            aionui_common::constants::AIONUI_FILES_MARKER
+        );
+        let data = SendMessageData {
+            content,
+            msg_id: "m2".into(),
+            turn_id: None,
+            files: vec![img.clone(), pdf.clone()],
+            inject_skills: vec![],
+        };
+        let caps = crate::types::PromptMediaCaps { image: true, audio: false };
+        let blocks = super::build_prompt_blocks(&data, caps).await;
+        assert_eq!(blocks.len(), 2);
+        match &blocks[0] {
+            ContentBlock::Text(text) => {
+                // Image path left the marker list; the pdf stays.
+                assert_eq!(
+                    text.text,
+                    format!("look\n\n{}\n{pdf}", aionui_common::constants::AIONUI_FILES_MARKER)
+                );
+            }
+            other => panic!("expected text block, got {other:?}"),
+        }
+        match &blocks[1] {
+            ContentBlock::Image(image) => {
+                assert_eq!(image.mime_type, "image/png");
+                assert_eq!(
+                    image.data,
+                    base64::engine::general_purpose::STANDARD.encode(b"fakepng")
+                );
+                assert_eq!(image.uri.as_deref(), Some(format!("file://{img}").as_str()));
+            }
+            other => panic!("expected image block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn prompt_blocks_fall_back_to_paths_when_read_fails() {
+        let dir = std::env::temp_dir().join("aionui-acp-prompt-tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let img = dir.join("vanishing.png");
+        std::fs::write(&img, b"fakepng").unwrap();
+        let img_path = img.to_string_lossy().into_owned();
+        let content = format!(
+            "gone\n\n{}\n{img_path}",
+            aionui_common::constants::AIONUI_FILES_MARKER
+        );
+        let data = SendMessageData {
+            content: content.clone(),
+            msg_id: "m3".into(),
+            turn_id: None,
+            files: vec![img_path.clone()],
+            inject_skills: vec![],
+        };
+        let caps = crate::types::PromptMediaCaps { image: true, audio: false };
+        // Classification uses fs::metadata inside partition_media, which runs
+        // inside build_prompt_blocks — so remove the file first and verify the
+        // whole prompt degrades to the original text form.
+        std::fs::remove_file(&img).unwrap();
+        let blocks = super::build_prompt_blocks(&data, caps).await;
+        assert_eq!(blocks.len(), 1);
+        match &blocks[0] {
+            ContentBlock::Text(text) => assert_eq!(text.text, content),
+            other => panic!("expected text block, got {other:?}"),
+        }
     }
 }

--- a/crates/aionui-ai-agent/src/media.rs
+++ b/crates/aionui-ai-agent/src/media.rs
@@ -104,7 +104,11 @@ fn classify(path: &str, caps: PromptMediaCaps) -> Option<MediaAttachment> {
             kind,
         }),
         Ok(meta) if meta.is_file() => {
-            warn!(path, bytes = meta.len(), "media attachment exceeds block size limit; sending as path");
+            warn!(
+                path,
+                bytes = meta.len(),
+                "media attachment exceeds block size limit; sending as path"
+            );
             None
         }
         _ => {
@@ -159,8 +163,14 @@ pub async fn read_media_bytes(attachment: &MediaAttachment) -> Option<Vec<u8>> {
 mod tests {
     use super::*;
 
-    const CAPS_IMAGE: PromptMediaCaps = PromptMediaCaps { image: true, audio: false };
-    const CAPS_ALL: PromptMediaCaps = PromptMediaCaps { image: true, audio: true };
+    const CAPS_IMAGE: PromptMediaCaps = PromptMediaCaps {
+        image: true,
+        audio: false,
+    };
+    const CAPS_ALL: PromptMediaCaps = PromptMediaCaps {
+        image: true,
+        audio: true,
+    };
 
     fn inline(content: &str, paths: &[&str]) -> String {
         format!("{content}\n\n{AIONUI_FILES_MARKER}\n{}", paths.join("\n"))

--- a/crates/aionui-ai-agent/src/media.rs
+++ b/crates/aionui-ai-agent/src/media.rs
@@ -1,0 +1,245 @@
+//! Capability-aware partition of message attachments into native media
+//! blocks vs path-text files.
+//!
+//! Applied at agent dispatch time — the only layer that knows the target
+//! agent's prompt capabilities. The persisted/broadcast message keeps the
+//! full `[[AION_FILES]]` form (UI chips and history are untouched); only
+//! the agent-bound copy is rewritten. Mirrors the aionrs precedent in
+//! `manager/aionrs/content.rs`: strip the trailing marker block when it
+//! matches `files` exactly, then rebuild.
+
+use std::path::Path;
+
+use aionui_common::constants::AIONUI_FILES_MARKER;
+use tracing::warn;
+
+use crate::types::PromptMediaCaps;
+
+/// Max bytes for a single attachment sent as an inline base64 content block.
+/// Above this the attachment degrades to a path (Claude's hard per-image API
+/// limit, and a sane ceiling for one wire frame).
+pub const MAX_MEDIA_BLOCK_BYTES: u64 = 5 * 1024 * 1024;
+
+/// Coarse media classification for prompt content blocks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediaKind {
+    Image,
+    Audio,
+}
+
+/// An attachment that should be delivered as a native content block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaAttachment {
+    /// Absolute path on the local filesystem.
+    pub path: String,
+    /// Full mime type (e.g. `image/png`, `audio/mpeg`).
+    pub mime: String,
+    pub kind: MediaKind,
+}
+
+/// Result of [`partition_media`].
+#[derive(Debug)]
+pub struct MediaPartition {
+    /// Agent-bound content: the user text with the `[[AION_FILES]]` block
+    /// re-appended containing only the non-media paths. Byte-identical to the
+    /// input when nothing partitions to media.
+    pub content: String,
+    /// Attachments that stay as path text / resource links, in order.
+    pub path_files: Vec<String>,
+    /// Attachments to send as native blocks, in order.
+    pub media: Vec<MediaAttachment>,
+}
+
+/// Split `files` into native-block media vs path attachments, honoring the
+/// agent's declared capabilities, and rewrite `content`'s trailing marker
+/// block to list only the path attachments.
+///
+/// Degradation rules (attachment stays a path): capability not declared,
+/// non-media mime, SVG (vision APIs reject it), file missing/unreadable, or
+/// larger than [`MAX_MEDIA_BLOCK_BYTES`]. With `caps == default()` the input
+/// passes through byte-identical.
+pub fn partition_media(content: &str, files: &[String], caps: PromptMediaCaps) -> MediaPartition {
+    if files.is_empty() || caps == PromptMediaCaps::default() {
+        return MediaPartition {
+            content: content.to_owned(),
+            path_files: files.to_vec(),
+            media: Vec::new(),
+        };
+    }
+
+    let mut path_files = Vec::new();
+    let mut media = Vec::new();
+    for path in files {
+        match classify(path, caps) {
+            Some(attachment) => media.push(attachment),
+            None => path_files.push(path.clone()),
+        }
+    }
+
+    let content = if media.is_empty() {
+        content.to_owned()
+    } else {
+        append_files_marker(strip_files_marker(content, files), &path_files)
+    };
+    MediaPartition {
+        content,
+        path_files,
+        media,
+    }
+}
+
+/// Classify one attachment; `Some` means "send as a native block".
+fn classify(path: &str, caps: PromptMediaCaps) -> Option<MediaAttachment> {
+    let mime = mime_guess::from_path(path).first()?;
+    let kind = match mime.type_().as_str() {
+        // SVG is source text, not a raster image — vision APIs reject it.
+        "image" if caps.image && mime.subtype() != "svg" => MediaKind::Image,
+        "audio" if caps.audio => MediaKind::Audio,
+        _ => return None,
+    };
+    match std::fs::metadata(path) {
+        Ok(meta) if meta.is_file() && meta.len() <= MAX_MEDIA_BLOCK_BYTES => Some(MediaAttachment {
+            path: path.to_owned(),
+            mime: mime.essence_str().to_owned(),
+            kind,
+        }),
+        Ok(meta) if meta.is_file() => {
+            warn!(path, bytes = meta.len(), "media attachment exceeds block size limit; sending as path");
+            None
+        }
+        _ => {
+            warn!(path, "media attachment unreadable; sending as path");
+            None
+        }
+    }
+}
+
+/// Strip the trailing `[[AION_FILES]]` block iff its path list matches
+/// `files` exactly (same validation as aionrs `strip_attachment_metadata`);
+/// otherwise return `content` unchanged.
+fn strip_files_marker<'a>(content: &'a str, files: &[String]) -> &'a str {
+    let Some((user_text, metadata)) = content.rsplit_once(AIONUI_FILES_MARKER) else {
+        return content;
+    };
+    let metadata_files = metadata.lines().map(str::trim).filter(|line| !line.is_empty());
+    if metadata_files.eq(files.iter().map(String::as_str)) {
+        user_text.strip_suffix("\n\n").unwrap_or(user_text)
+    } else {
+        content
+    }
+}
+
+/// Re-append the marker block in the exact `resolve_chat_message` format.
+fn append_files_marker(content: &str, paths: &[String]) -> String {
+    if paths.is_empty() {
+        content.to_owned()
+    } else {
+        format!("{content}\n\n{AIONUI_FILES_MARKER}\n{}", paths.join("\n"))
+    }
+}
+
+/// Read a media attachment's bytes, degrading to `None` (caller falls back to
+/// the path form) when the file vanished or grew past the limit between
+/// classification and read.
+pub async fn read_media_bytes(attachment: &MediaAttachment) -> Option<Vec<u8>> {
+    match tokio::fs::read(Path::new(&attachment.path)).await {
+        Ok(bytes) if bytes.len() as u64 <= MAX_MEDIA_BLOCK_BYTES => Some(bytes),
+        Ok(bytes) => {
+            warn!(path = %attachment.path, bytes = bytes.len(), "media attachment exceeds block size limit at read; sending as path");
+            None
+        }
+        Err(err) => {
+            warn!(path = %attachment.path, error = %err, "media attachment read failed; sending as path");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CAPS_IMAGE: PromptMediaCaps = PromptMediaCaps { image: true, audio: false };
+    const CAPS_ALL: PromptMediaCaps = PromptMediaCaps { image: true, audio: true };
+
+    fn inline(content: &str, paths: &[&str]) -> String {
+        format!("{content}\n\n{AIONUI_FILES_MARKER}\n{}", paths.join("\n"))
+    }
+
+    fn temp_file(name: &str, bytes: &[u8]) -> String {
+        let dir = std::env::temp_dir().join("aionui-media-tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(name);
+        std::fs::write(&path, bytes).unwrap();
+        path.to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn no_caps_is_byte_identical_passthrough() {
+        let img = temp_file("a.png", b"png");
+        let content = inline("hello", &[&img]);
+        let part = partition_media(&content, std::slice::from_ref(&img), PromptMediaCaps::default());
+        assert_eq!(part.content, content);
+        assert_eq!(part.path_files, vec![img]);
+        assert!(part.media.is_empty());
+    }
+
+    #[test]
+    fn image_partitions_to_media_and_marker_is_removed() {
+        let img = temp_file("b.png", b"png");
+        let content = inline("look at this", &[&img]);
+        let part = partition_media(&content, std::slice::from_ref(&img), CAPS_IMAGE);
+        assert_eq!(part.content, "look at this");
+        assert!(part.path_files.is_empty());
+        assert_eq!(part.media.len(), 1);
+        assert_eq!(part.media[0].mime, "image/png");
+        assert_eq!(part.media[0].kind, MediaKind::Image);
+    }
+
+    #[test]
+    fn mixed_files_keep_non_media_in_marker() {
+        let img = temp_file("c.jpg", b"jpg");
+        let doc = temp_file("c.pdf", b"pdf");
+        let content = inline("mix", &[&img, &doc]);
+        let part = partition_media(&content, &[img.clone(), doc.clone()], CAPS_IMAGE);
+        assert_eq!(part.content, inline("mix", &[&doc]));
+        assert_eq!(part.path_files, vec![doc]);
+        assert_eq!(part.media.len(), 1);
+        assert_eq!(part.media[0].path, img);
+    }
+
+    #[test]
+    fn audio_needs_audio_cap() {
+        let mp3 = temp_file("d.mp3", b"mp3");
+        let content = inline("song", &[&mp3]);
+        let no_audio = partition_media(&content, std::slice::from_ref(&mp3), CAPS_IMAGE);
+        assert!(no_audio.media.is_empty());
+        assert_eq!(no_audio.content, content);
+        let with_audio = partition_media(&content, std::slice::from_ref(&mp3), CAPS_ALL);
+        assert_eq!(with_audio.media.len(), 1);
+        assert_eq!(with_audio.media[0].kind, MediaKind::Audio);
+        assert_eq!(with_audio.media[0].mime, "audio/mpeg");
+    }
+
+    #[test]
+    fn svg_and_missing_and_oversized_stay_paths() {
+        let svg = temp_file("e.svg", b"<svg/>");
+        let missing = "/nonexistent/aionui-media-test.png".to_owned();
+        let big = temp_file("f.png", &vec![0u8; (MAX_MEDIA_BLOCK_BYTES + 1) as usize]);
+        let files = vec![svg, missing, big];
+        let content = inline("all degrade", &[&files[0], &files[1], &files[2]]);
+        let part = partition_media(&content, &files, CAPS_ALL);
+        assert!(part.media.is_empty());
+        assert_eq!(part.path_files, files);
+        assert_eq!(part.content, content);
+    }
+
+    #[test]
+    fn content_without_marker_still_partitions() {
+        let img = temp_file("g.webp", b"webp");
+        let part = partition_media("bare", std::slice::from_ref(&img), CAPS_IMAGE);
+        assert_eq!(part.content, "bare");
+        assert_eq!(part.media.len(), 1);
+        assert_eq!(part.media[0].mime, "image/webp");
+    }
+}

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -1044,17 +1044,43 @@ impl IAgentTask for SessionAgentTask {
 
     async fn send_message(&self, data: SendMessageData) -> Result<(), AgentSendError> {
         self.runtime.touch();
+        // Partition attachments by the backend's declared prompt blocks:
+        // capable media becomes native Image/Audio blocks; everything else
+        // keeps the pre-multimodal form (path in the [[AION_FILES]] text +
+        // resource link). A read failure degrades that attachment back to a
+        // resource link — the path also remains in the original text because
+        // partition already ran, which the adapters tolerate (they resolve
+        // links independently of the text).
+        let partition = crate::media::partition_media(&data.content, &data.files, self.prompt_media_caps());
         let mut content: Vec<ContentBlock> = Vec::new();
-        if !data.content.is_empty() {
-            content.push(ContentBlock::Text(data.content));
+        if !partition.content.is_empty() {
+            content.push(ContentBlock::Text(partition.content));
         }
-        for path in data.files {
+        for path in partition.path_files {
             // File paths ride as resource links; the claude/codex adapters resolve
             // them (Read tool / base64) at dispatch time.
             content.push(ContentBlock::ResourceLink {
                 uri: path,
                 mime_type: None,
             });
+        }
+        for attachment in &partition.media {
+            match crate::media::read_media_bytes(attachment).await {
+                Some(bytes) => content.push(match attachment.kind {
+                    crate::media::MediaKind::Image => ContentBlock::Image {
+                        data: bytes,
+                        media_type: attachment.mime.clone(),
+                    },
+                    crate::media::MediaKind::Audio => ContentBlock::Audio {
+                        data: bytes,
+                        media_type: attachment.mime.clone(),
+                    },
+                }),
+                None => content.push(ContentBlock::ResourceLink {
+                    uri: attachment.path.clone(),
+                    mime_type: Some(attachment.mime.clone()),
+                }),
+            }
         }
         // DEV (`--dump-prompts`): borrow the final blocks BEFORE they move into
         // Command::Send. No-op / best-effort — never affects the dispatch.
@@ -6008,6 +6034,106 @@ mod pump_tests {
         fn capabilities(&self) -> Capabilities {
             Capabilities::default()
         }
+    }
+
+    /// Backend that records every dispatched Command and advertises
+    /// image-capable prompt blocks — for asserting the media partition at
+    /// the Command::Send boundary.
+    struct RecordingBackend {
+        commands: std::sync::Mutex<Vec<Command>>,
+        blocks: aionui_session::BlockSet,
+    }
+
+    #[async_trait::async_trait]
+    impl SessionBackend for RecordingBackend {
+        async fn dispatch(&self, c: Command) -> Result<CommandReceipt, BackendError> {
+            let admission = match c {
+                Command::Send { .. } => Admission::Started,
+                _ => Admission::NoTurn,
+            };
+            self.commands.lock().unwrap().push(c);
+            Ok(CommandReceipt {
+                accepted: true,
+                admission,
+                turn_gen: 1,
+            })
+        }
+        fn events(&self) -> BoxStream<'static, SessionEnvelope> {
+            use futures_util::StreamExt as _;
+            futures_util::stream::iter(Vec::new()).boxed()
+        }
+        fn capabilities(&self) -> Capabilities {
+            Capabilities {
+                prompt_blocks: self.blocks,
+                ..Capabilities::default()
+            }
+        }
+    }
+
+    // Image-capable backend: an image attachment leaves the [[AION_FILES]]
+    // text and rides as a native Image block; non-media files keep the
+    // path-text + resource-link form.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn send_message_partitions_image_into_native_block() {
+        let dir = std::env::temp_dir().join("aionui-session-media-tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let img = dir.join("cat.png");
+        std::fs::write(&img, b"catbytes").unwrap();
+        let img = img.to_string_lossy().into_owned();
+        let pdf = dir.join("doc.pdf");
+        std::fs::write(&pdf, b"pdfbytes").unwrap();
+        let pdf = pdf.to_string_lossy().into_owned();
+
+        let backend = Arc::new(RecordingBackend {
+            commands: std::sync::Mutex::new(Vec::new()),
+            blocks: aionui_session::BlockSet {
+                text: true,
+                image: true,
+                audio: false,
+                resource: true,
+                at_mention: false,
+            },
+        });
+        let task = SessionAgentTask::new(
+            AgentType::Acp,
+            "conv-1".into(),
+            "user-1".into(),
+            "/w".into(),
+            backend.clone() as Arc<dyn SessionBackend>,
+            None,
+        );
+        let marker = aionui_common::constants::AIONUI_FILES_MARKER;
+        crate::agent_task::IAgentTask::send_message(
+            task.as_ref(),
+            SendMessageData {
+                content: format!("see\n\n{marker}\n{img}\n{pdf}"),
+                msg_id: "m-media".into(),
+                turn_id: None,
+                files: vec![img.clone(), pdf.clone()],
+                inject_skills: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let commands = backend.commands.lock().unwrap();
+        let Some(Command::Send { content, .. }) = commands.iter().find(|c| matches!(c, Command::Send { .. })) else {
+            panic!("expected a Send command");
+        };
+        assert_eq!(content.len(), 3, "text + pdf link + image block: {content:?}");
+        let ContentBlock::Text(text) = &content[0] else {
+            panic!("expected text first: {content:?}");
+        };
+        assert_eq!(text, &format!("see\n\n{marker}\n{pdf}"));
+        let ContentBlock::ResourceLink { uri, .. } = &content[1] else {
+            panic!("expected resource link second: {content:?}");
+        };
+        assert_eq!(uri, &pdf);
+        let ContentBlock::Image { data, media_type } = &content[2] else {
+            panic!("expected image block third: {content:?}");
+        };
+        assert_eq!(data, b"catbytes");
+        assert_eq!(media_type, "image/png");
     }
 
     fn env(event: SessionEvent) -> SessionEnvelope {

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -30,7 +30,7 @@ use crate::protocol::events::{
 };
 use crate::protocol::send_error::AgentSendError;
 use crate::shared_kernel::PersistedSessionState;
-use crate::types::SendMessageData;
+use crate::types::{PromptMediaCaps, SendMessageData};
 use aionui_api_types::AcpBuildExtra;
 use aionui_common::AgentType;
 use aionui_db::{IAcpSessionRepository, IMcpServerRepository, SaveRuntimeStateParams};
@@ -1032,6 +1032,14 @@ impl IAgentTask for SessionAgentTask {
 
     fn subscribe(&self) -> broadcast::Receiver<AgentStreamEvent> {
         self.runtime.tx.subscribe()
+    }
+
+    fn prompt_media_caps(&self) -> PromptMediaCaps {
+        let blocks = self.backend.capabilities().prompt_blocks;
+        PromptMediaCaps {
+            image: blocks.image,
+            audio: blocks.audio,
+        }
     }
 
     async fn send_message(&self, data: SendMessageData) -> Result<(), AgentSendError> {

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -1082,6 +1082,20 @@ impl IAgentTask for SessionAgentTask {
                 }),
             }
         }
+        if !partition.media.is_empty() {
+            let (images, audios) = content.iter().fold((0usize, 0usize), |(i, a), b| match b {
+                ContentBlock::Image { .. } => (i + 1, a),
+                ContentBlock::Audio { .. } => (i, a + 1),
+                _ => (i, a),
+            });
+            tracing::info!(
+                conversation_id = %self.conversation_id,
+                msg_id = %data.msg_id,
+                images,
+                audios,
+                "session prompt carries native media content blocks"
+            );
+        }
         // DEV (`--dump-prompts`): borrow the final blocks BEFORE they move into
         // Command::Send. No-op / best-effort — never affects the dispatch.
         self.dump_session_cli_final_input(&content, Some(data.msg_id.as_str()));

--- a/crates/aionui-ai-agent/src/types.rs
+++ b/crates/aionui-ai-agent/src/types.rs
@@ -25,6 +25,14 @@ pub struct SendMessageData {
     pub inject_skills: Vec<String>,
 }
 
+/// Prompt media capabilities an agent declared (ACP `promptCapabilities`
+/// or the session backend's `prompt_blocks` support).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PromptMediaCaps {
+    pub image: bool,
+    pub audio: bool,
+}
+
 /// Options for building (creating or resuming) an Agent task.
 #[derive(Debug, Clone)]
 pub struct BuildTaskOptions {

--- a/crates/aionui-api-types/src/conversation.rs
+++ b/crates/aionui-api-types/src/conversation.rs
@@ -80,6 +80,22 @@ pub struct ForkConversationRequest {
     pub name: Option<String>,
 }
 
+/// Prompt media capability projection for one conversation, sourced from
+/// `agent_metadata.agent_capabilities.prompt_capabilities` (ACP agents:
+/// handshake-persisted; claude/codex: migration-constructed, 037). `None` =
+/// unknown/unsupported — the UI then hints that media attachments are sent
+/// as file paths. Filled only on the single-conversation detail path (list
+/// responses omit it — no N+1).
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PromptCapabilityView {
+    /// Agent takes native image content blocks.
+    #[serde(default)]
+    pub image: bool,
+    /// Agent takes native audio content blocks.
+    #[serde(default)]
+    pub audio: bool,
+}
+
 /// Session-fork capability projection for one conversation, sourced from
 /// `agent_metadata.agent_capabilities.session_capabilities.fork` (ACP agents:
 /// handshake-persisted; claude/codex: migration-constructed). `Some` = the fork
@@ -274,6 +290,10 @@ pub struct ConversationResponse {
     /// `None` on list responses. See [`ForkCapabilityView`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fork_capability: Option<ForkCapabilityView>,
+    /// Service-layer post-fill on the DETAIL path only (like `runtime`);
+    /// `None` on list responses. See [`PromptCapabilityView`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_capability: Option<PromptCapabilityView>,
     pub created_at: TimestampMs,
     pub modified_at: TimestampMs,
     pub extra: serde_json::Value,
@@ -674,6 +694,7 @@ mod tests {
             modified_at: 1712345678000,
             extra: json!({ "workspace": "/project" }),
             fork_capability: None,
+            prompt_capability: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["id"], "conv_1");
@@ -715,6 +736,7 @@ mod tests {
             modified_at: 1,
             extra: json!({}),
             fork_capability: None,
+            prompt_capability: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert!(json.get("model").is_none(), "model None should be omitted");
@@ -750,6 +772,7 @@ mod tests {
             modified_at: 2000,
             extra: json!({}),
             fork_capability: None,
+            prompt_capability: None,
         };
         let serialized = serde_json::to_string(&resp).unwrap();
         let deserialized: ConversationResponse = serde_json::from_str(&serialized).unwrap();
@@ -839,6 +862,7 @@ mod tests {
                 modified_at: 1712345678000,
                 extra: json!({}),
                 fork_capability: None,
+                prompt_capability: None,
             },
         };
         let json = serde_json::to_value(&item).unwrap();
@@ -879,6 +903,7 @@ mod tests {
                 modified_at: 9000,
                 extra: json!({}),
                 fork_capability: None,
+                prompt_capability: None,
             },
         };
         let serialized = serde_json::to_string(&item).unwrap();
@@ -971,6 +996,7 @@ mod tests {
                 modified_at: 1000,
                 extra: json!({}),
                 fork_capability: None,
+                prompt_capability: None,
             }],
             total: 1,
             has_more: false,
@@ -1026,6 +1052,7 @@ mod tests {
                     modified_at: 5000,
                     extra: json!({}),
                     fork_capability: None,
+                    prompt_capability: None,
                 },
             }],
             total: 1,

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -92,6 +92,7 @@ pub use conversation::{
     ConversationNameUpdatedPayload, ConversationResponse, ConversationRuntimeStateKind, ConversationRuntimeSummary,
     CreateConversationRequest, EnsureConversationRuntimeResponse, ForkCapabilityView, ForkConversationRequest,
     ListConversationsQuery, ListMessagesQuery, MessageListResponse, MessageResponse, MessageSearchItem,
+    PromptCapabilityView,
     MessageSearchResponse, SearchMessagesQuery, SendMessageRequest, SendMessageResponse,
     UpdateConversationArtifactRequest, UpdateConversationRequest,
 };

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -92,8 +92,7 @@ pub use conversation::{
     ConversationNameUpdatedPayload, ConversationResponse, ConversationRuntimeStateKind, ConversationRuntimeSummary,
     CreateConversationRequest, EnsureConversationRuntimeResponse, ForkCapabilityView, ForkConversationRequest,
     ListConversationsQuery, ListMessagesQuery, MessageListResponse, MessageResponse, MessageSearchItem,
-    PromptCapabilityView,
-    MessageSearchResponse, SearchMessagesQuery, SendMessageRequest, SendMessageResponse,
+    MessageSearchResponse, PromptCapabilityView, SearchMessagesQuery, SendMessageRequest, SendMessageResponse,
     UpdateConversationArtifactRequest, UpdateConversationRequest,
 };
 pub use cron::{

--- a/crates/aionui-conversation/src/convert.rs
+++ b/crates/aionui-conversation/src/convert.rs
@@ -79,6 +79,7 @@ pub fn row_to_response_with_extra(
         // Detail-path post-fill only (see `attach_fork_capability`); convert
         // stays a pure mapper with no repo access.
         fork_capability: None,
+        prompt_capability: None,
         created_at: row.created_at,
         modified_at: row.updated_at,
         extra,

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -21,6 +21,7 @@ use aionui_api_types::{
     ConversationArtifactResponse, ConversationArtifactStatus, ConversationListResponse, ConversationMcpStatus,
     ConversationMcpStatusKind, ConversationNameUpdatedPayload, ConversationResponse, ConversationRuntimeSummary,
     CreateConversationRequest, EnsureConversationRuntimeResponse, ForkCapabilityView, ForkConversationRequest,
+    PromptCapabilityView,
     ListConversationsQuery, ListMessagesQuery, MessageListResponse, MessageResponse, MessageSearchResponse,
     SearchMessagesQuery, SendMessageRequest, SendMessageResponse, SessionMcpServer, SessionMcpTransport,
     TeamSessionBinding, UpdateConversationArtifactRequest, UpdateConversationRequest, WebSocketMessage,
@@ -2040,14 +2041,16 @@ impl ConversationService {
         let mut response = row_to_response_with_extra(row, extra, &self.workspace_root)?;
         self.attach_assistant_identity(user_id, &mut response).await?;
         response.runtime = Some(self.runtime_summary_for(id).await);
-        // Fork capability: detail-path-only post-fill (list stays N+1-free).
-        // Best-effort — a lookup failure just hides the fork entry point.
+        // Fork + prompt capabilities: detail-path-only post-fill (list stays
+        // N+1-free). Best-effort — a lookup failure just hides the fork entry
+        // point / media hint.
         if let Ok(Some(acp_row)) = self.acp_session_repo.get_for_user(user_id, id).await
-            && let Ok(capability) = self
-                .fork_capability_for_agent(user_id, &acp_row.agent_id, &response.extra.to_string())
+            && let Ok(capabilities) = self
+                .agent_capabilities_for_agent(user_id, &acp_row.agent_id, &response.extra.to_string())
                 .await
         {
-            response.fork_capability = capability;
+            response.fork_capability = capabilities.as_ref().and_then(fork_capability_view);
+            response.prompt_capability = capabilities.as_ref().and_then(prompt_capability_view);
         }
         if project_backfilled {
             self.broadcast_list_changed(user_id, id, "updated", response.source.as_ref());
@@ -2749,6 +2752,21 @@ impl ConversationService {
         agent_id: &str,
         parent_extra: &str,
     ) -> Result<Option<ForkCapabilityView>, ConversationError> {
+        Ok(self
+            .agent_capabilities_for_agent(user_id, agent_id, parent_extra)
+            .await?
+            .as_ref()
+            .and_then(fork_capability_view))
+    }
+
+    /// Load and parse `agent_metadata.agent_capabilities` for the
+    /// conversation's agent (by id, or by `extra.backend` for legacy rows).
+    async fn agent_capabilities_for_agent(
+        &self,
+        user_id: &str,
+        agent_id: &str,
+        parent_extra: &str,
+    ) -> Result<Option<serde_json::Value>, ConversationError> {
         let metadata_row = if !agent_id.is_empty() {
             self.agent_metadata_repo
                 .get_for_user(user_id, agent_id)
@@ -2771,19 +2789,7 @@ impl ConversationService {
         let Some(capabilities_json) = metadata_row.and_then(|row| row.agent_capabilities) else {
             return Ok(None);
         };
-        let capabilities: serde_json::Value = match serde_json::from_str(&capabilities_json) {
-            Ok(value) => value,
-            Err(_) => return Ok(None),
-        };
-        let Some(fork) = capabilities.get("session_capabilities").and_then(|s| s.get("fork")) else {
-            return Ok(None);
-        };
-        if fork.is_null() {
-            return Ok(None);
-        }
-        Ok(Some(ForkCapabilityView {
-            at_turn: fork.get("at_turn").and_then(|v| v.as_bool()).unwrap_or(false),
-        }))
+        Ok(serde_json::from_str(&capabilities_json).ok())
     }
 
     /// Reset a conversation: clear messages and set status back to pending.
@@ -4781,6 +4787,32 @@ fn legacy_cron_trigger_to_artifact(row: MessageRow) -> Result<ConversationArtifa
 }
 
 /// Merge `patch` into `base` (top-level key overwrite).
+/// Project `session_capabilities.fork` out of a parsed
+/// `agent_metadata.agent_capabilities` value. `None` = fork hidden.
+fn fork_capability_view(capabilities: &serde_json::Value) -> Option<ForkCapabilityView> {
+    let fork = capabilities.get("session_capabilities")?.get("fork")?;
+    if fork.is_null() {
+        return None;
+    }
+    Some(ForkCapabilityView {
+        at_turn: fork.get("at_turn").and_then(|v| v.as_bool()).unwrap_or(false),
+    })
+}
+
+/// Project `prompt_capabilities` out of a parsed
+/// `agent_metadata.agent_capabilities` value. `None` = unknown (UI treats
+/// media attachments as path-delivered).
+fn prompt_capability_view(capabilities: &serde_json::Value) -> Option<PromptCapabilityView> {
+    let prompt = capabilities.get("prompt_capabilities")?;
+    if !prompt.is_object() {
+        return None;
+    }
+    Some(PromptCapabilityView {
+        image: prompt.get("image").and_then(|v| v.as_bool()).unwrap_or(false),
+        audio: prompt.get("audio").and_then(|v| v.as_bool()).unwrap_or(false),
+    })
+}
+
 fn merge_json(base: &mut serde_json::Value, patch: &serde_json::Value) {
     if let (Some(base_obj), Some(patch_obj)) = (base.as_object_mut(), patch.as_object()) {
         for (key, value) in patch_obj {
@@ -5015,6 +5047,7 @@ mod tests {
             assistant: None,
             project_id: None,
             fork_capability: None,
+            prompt_capability: None,
             created_at: 0,
             modified_at: 0,
             extra: json!({}),

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -21,11 +21,10 @@ use aionui_api_types::{
     ConversationArtifactResponse, ConversationArtifactStatus, ConversationListResponse, ConversationMcpStatus,
     ConversationMcpStatusKind, ConversationNameUpdatedPayload, ConversationResponse, ConversationRuntimeSummary,
     CreateConversationRequest, EnsureConversationRuntimeResponse, ForkCapabilityView, ForkConversationRequest,
-    PromptCapabilityView,
     ListConversationsQuery, ListMessagesQuery, MessageListResponse, MessageResponse, MessageSearchResponse,
-    SearchMessagesQuery, SendMessageRequest, SendMessageResponse, SessionMcpServer, SessionMcpTransport,
-    TeamSessionBinding, UpdateConversationArtifactRequest, UpdateConversationRequest, WebSocketMessage,
-    assistant_avatar_response_value, assistant_avatar_response_value_with_version,
+    PromptCapabilityView, SearchMessagesQuery, SendMessageRequest, SendMessageResponse, SessionMcpServer,
+    SessionMcpTransport, TeamSessionBinding, UpdateConversationArtifactRequest, UpdateConversationRequest,
+    WebSocketMessage, assistant_avatar_response_value, assistant_avatar_response_value_with_version,
 };
 use aionui_common::{
     AgentKillReason, AgentType, ConversationSource, ConversationStatus, ErrorChain, MessageType, OnConversationDelete,

--- a/crates/aionui-conversation/tests/conversation_extended.rs
+++ b/crates/aionui-conversation/tests/conversation_extended.rs
@@ -1065,6 +1065,27 @@ async fn get_projects_fork_capability_on_detail_path() {
 }
 
 #[tokio::test]
+async fn get_projects_prompt_capability_on_detail_path() {
+    let (svc, _repo, _acp) = setup_fork().await;
+
+    // claude: migration 037 seeds image-only prompt capabilities.
+    let claude_conv = svc.create(USER_ID, fork_create_req("claude")).await.unwrap();
+    let got = svc.get(USER_ID, &claude_conv.id).await.unwrap();
+    assert_eq!(
+        got.prompt_capability,
+        Some(aionui_api_types::PromptCapabilityView { image: true, audio: false })
+    );
+
+    // qwen: 003 seeds image + audio.
+    let qwen_conv = svc.create(USER_ID, fork_create_req("qwen")).await.unwrap();
+    let got = svc.get(USER_ID, &qwen_conv.id).await.unwrap();
+    assert_eq!(
+        got.prompt_capability,
+        Some(aionui_api_types::PromptCapabilityView { image: true, audio: true })
+    );
+}
+
+#[tokio::test]
 async fn delete_parent_keeps_workspace_shared_with_fork() {
     let (svc, repo, acp_repo) = setup_fork().await;
     // No workspace in extra → create() auto-provisions one under

--- a/crates/aionui-conversation/tests/conversation_extended.rs
+++ b/crates/aionui-conversation/tests/conversation_extended.rs
@@ -1073,7 +1073,10 @@ async fn get_projects_prompt_capability_on_detail_path() {
     let got = svc.get(USER_ID, &claude_conv.id).await.unwrap();
     assert_eq!(
         got.prompt_capability,
-        Some(aionui_api_types::PromptCapabilityView { image: true, audio: false })
+        Some(aionui_api_types::PromptCapabilityView {
+            image: true,
+            audio: false
+        })
     );
 
     // qwen: 003 seeds image + audio.
@@ -1081,7 +1084,10 @@ async fn get_projects_prompt_capability_on_detail_path() {
     let got = svc.get(USER_ID, &qwen_conv.id).await.unwrap();
     assert_eq!(
         got.prompt_capability,
-        Some(aionui_api_types::PromptCapabilityView { image: true, audio: true })
+        Some(aionui_api_types::PromptCapabilityView {
+            image: true,
+            audio: true
+        })
     );
 }
 

--- a/crates/aionui-db/migrations/037_direct_agent_prompt_capabilities.sql
+++ b/crates/aionui-db/migrations/037_direct_agent_prompt_capabilities.sql
@@ -1,0 +1,38 @@
+-- Prompt capabilities for the direct-CLI agents (feature: multimodal prompt).
+--
+-- ACP agents carry `prompt_capabilities` inside the handshake-persisted
+-- `agent_metadata.agent_capabilities` (seeded by 003, refreshed live on every
+-- initialize), and the column is passed to the frontend verbatim — so the UI
+-- can already tell which ACP agents take native image/audio blocks. claude and
+-- codex are routed as direct CLI connections and never handshake over ACP, so
+-- their rows need the same key constructed here (exactly like 036 did for
+-- `session_capabilities.fork`):
+--
+--   * claude 2.1.x: native base64 image input block, no audio
+--     (adapter capability declaration; image frame pinned at
+--     protocols/samples/claude-cli/2.1.177/image_input_frame.OK.json).
+--   * codex 0.14x app-server: image input via turn input items, no audio.
+--   * antigravity (`agy -p`) is text-only — no key, absent reads as
+--     unsupported, which is correct.
+--
+-- `json_patch` merges into any pre-existing JSON instead of clobbering the
+-- column. Rows are addressed by their stable seed ids (001), never by display
+-- fields.
+
+-- Claude Code (2d23ff1c)
+UPDATE agent_metadata SET
+    agent_capabilities = json_patch(
+        COALESCE(agent_capabilities, '{}'),
+        '{"prompt_capabilities":{"image":true,"audio":false}}'
+    ),
+    updated_at = CAST(strftime('%s','now') AS INTEGER) * 1000
+WHERE id = '2d23ff1c';
+
+-- Codex CLI (8e1acf31)
+UPDATE agent_metadata SET
+    agent_capabilities = json_patch(
+        COALESCE(agent_capabilities, '{}'),
+        '{"prompt_capabilities":{"image":true,"audio":false}}'
+    ),
+    updated_at = CAST(strftime('%s','now') AS INTEGER) * 1000
+WHERE id = '8e1acf31';


### PR DESCRIPTION
## Summary

Attachments that the target agent can natively consume (per its declared `promptCapabilities`) are now delivered as protocol image/audio content blocks instead of file-path text. Agents without the capability keep the exact pre-existing path-based wire form, byte for byte. Frontend half: iOfficeAI/AionUi#3849.

### How it works

- **Dispatch-time partition** (`aionui-ai-agent/src/media.rs`): the only layer that knows the agent's capabilities splits `SendMessageData.files` into native-block media vs path files, stripping/rebuilding the `[[AION_FILES]]` block with the same validate-then-rebuild approach as the aionrs precedent (`manager/aionrs/content.rs`). Persisted/broadcast message content is untouched — UI chips and history render exactly as before. Degradation to path form: capability absent, non-media mime, SVG, unreadable, or >5MB (warn-logged).
- **Capability surface**: new `IAgentTask::prompt_media_caps()` (default none) — AcpAgentManager reads the initialize response's `promptCapabilities`; SessionAgentTask reads the backend's `prompt_blocks`.
- **ACP path** (`agent_session_flow`): `session/prompt` becomes a text block plus one base64 `ImageContent`/`AudioContent` per capable attachment (`uri: file://…`). Any read failure degrades the whole prompt back to the plain text form. Transport is `LinesCodec::new()` (unbounded) on both sides.
- **Session path** (`session_agent`): capable media rides as seam `ContentBlock::Image/Audio`; the claude/codex adapters' existing base64 encoders consume them unchanged.
- **Capability pipeline to the frontend**: ACP agents already persist `prompt_capabilities` inside `agent_metadata.agent_capabilities` (003 seeds + live handshake refresh). Migration 037 json_patches the same key onto the direct-CLI rows (claude/codex: image only), mirroring 036's fork pattern. The conversation detail response gains a `prompt_capability {image, audio}` projection next to `fork_capability` (one metadata load feeds both; lists stay N+1-free).

### Live verification

- claude 2.1.221 (`--input-format stream-json`): a generated 24px red-square-on-blue PNG sent as the adapter's `source`-wrapped base64 image block → "图中是蓝色背景上的一个红色正方形。"
- codebuddy `--acp`: `session/prompt` with `{type:"image", data, mimeType, uri}` → "A red square centered on a blue background." (`stopReason: end_turn`, no error with the `uri` field present)

### Testing (targeted; CI runs the full workspace suite)

- `aionui-ai-agent`: media partition (6), ACP prompt blocks (3), session send partition (1) — all pass
- `aionui-conversation`: lib 376 + `conversation_extended` 38 (incl. new `get_projects_prompt_capability_on_detail_path`) — all pass
- `aionui-db`: 330 pass with migration 037
- `cargo fmt --check` clean; targeted clippy (`-p` ai-agent/conversation/api-types) clean