### PR TITLE
chore(acp): bump grok and kilo registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -34,12 +34,12 @@
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "0.2.119"
+      "version": "0.2.120"
     },
     "kilo": {
       "registry_json_id": "kilo",
       "package": "@kilocode/cli",
-      "version": "7.4.17"
+      "version": "7.4.19"
     },
     "mimo-code": {
       "package": "@mimo-ai/cli",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Two npx pins drifted since #765, each backed by a fresh serial ACP probe of the exact pinned version. Lock-only change — two lines; no metadata, migration, or entrypoint edits, and no lock-derived test assertion embeds either version.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| grok | `@xai-official/grok` | 0.2.119 → **0.2.120** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |
| kilo | `@kilocode/cli` | 7.4.17 → **7.4.19** | ok (agentInfo Kilo 7.4.19) | success |

Both meet the release-lock criterion: `initialize` succeeds and `session/new` either succeeds or returns a clearly classified authentication requirement. Probes ran serially with no inherited HOME or credentials.

The other 9 Registry-pinned packages (autohand, codebuddy, deepagents, dimcode, dirac, glm-acp-agent, nova, pi, sigit) match the snapshot exactly — no drift. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. The `mimo-code` and `omp` entries are non-Registry builtins (no `registry_json_id`) and are correctly excluded from drift reconciliation.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.04-c23c1ec`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.04-c23c1ec/registry.json) of `agentclientprotocol/registry` (newest release at audit time), fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the previous baseline (38 ids).

## Validation

- `cargo test -p aionui-runtime -p aionui-ai-agent` — pass (902 lib + integration tests)
- Full `just push` gate (migration check, lint, fmt, `cargo nextest run --workspace`) — pass
- Gate run with the host-injected `AIONUI_LOG_DIR` unset (pre-existing environment sensitivity, see #695)
- Gate started only after host load fell below the pre-flight threshold; the targeted test run had pushed the 12-core host to load 69, the condition that produced spurious subprocess-spawn timeouts in #750's history.

## Logging

No logging changes: lock-only version bumps; existing startup/session error paths already identify a failing agent by backend.