### PR TITLE
feat(session): AskUserQuestion as a first-class capability (own event, command, counter and endpoint)

### DIFF
--- a/crates/aionui-ai-agent/src/agent_task.rs
+++ b/crates/aionui-ai-agent/src/agent_task.rs
@@ -107,6 +107,19 @@ pub trait IMockAgent: IAgentTask {
     ) -> Result<(), AgentError> {
         Ok(())
     }
+    /// Answer a structured question card (AskUserQuestion) — the DEDICATED
+    /// channel, separate from the permission confirm path (2026-08-05 ruling).
+    /// `answers: None` = the user dismissed the card (a deny on the wire).
+    /// Default: not a question-capable agent.
+    fn answer_ask(
+        &self,
+        _request_id: &str,
+        _answers: Option<Vec<aionui_api_types::AskQuestionAnswer>>,
+    ) -> Result<(), AgentError> {
+        Err(AgentError::BadRequest(
+            "answer_ask is not supported by this agent".into(),
+        ))
+    }
     fn get_session_key(&self) -> Option<String> {
         None
     }
@@ -297,6 +310,24 @@ impl AgentInstance {
             Self::Session(m) => m.confirm(msg_id, call_id, data, always_allow),
             #[cfg(any(test, feature = "test-support"))]
             Self::Mock(m) => m.confirm(msg_id, call_id, data, always_allow),
+        }
+    }
+
+    /// Answer a structured question card via the dedicated channel.
+    pub fn answer_ask(
+        &self,
+        request_id: &str,
+        answers: Option<Vec<aionui_api_types::AskQuestionAnswer>>,
+    ) -> Result<(), AgentError> {
+        match self {
+            // Only the direct-CLI session path has a question channel today
+            // (claude AskUserQuestion); ACP/aionrs have none to answer on.
+            Self::Acp(_) | Self::Aionrs(_) => Err(AgentError::BadRequest(
+                "answer_ask is not supported by this agent".into(),
+            )),
+            Self::Session(m) => m.answer_ask(request_id, answers),
+            #[cfg(any(test, feature = "test-support"))]
+            Self::Mock(m) => m.answer_ask(request_id, answers),
         }
     }
 

--- a/crates/aionui-ai-agent/src/capability/backend_protocol_sink.rs
+++ b/crates/aionui-ai-agent/src/capability/backend_protocol_sink.rs
@@ -38,6 +38,7 @@ impl BackendProtocolSink {
             title: Some(title),
             action: Some(tool_name.to_string()),
             description: description.to_string(),
+            questions: None,
             command_type,
             options: vec![
                 ConfirmationOption {

--- a/crates/aionui-ai-agent/src/manager/acp/permission_router.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/permission_router.rs
@@ -284,6 +284,7 @@ mod tests {
         Confirmation {
             id: call_id.to_owned(),
             call_id: call_id.to_owned(),
+            questions: None,
             title: Some("Write file".to_owned()),
             action: None,
             description: "Write /tmp/current_time.txt".to_owned(),

--- a/crates/aionui-ai-agent/src/protocol/events/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/events/mod.rs
@@ -38,6 +38,15 @@ pub enum AgentStreamEvent {
     Plan(PlanEventData),
     Permission(serde_json::Value),
     AcpPermission(AcpPermissionEventData),
+    /// Structured question card (claude AskUserQuestion — `SessionEvent::Ask`).
+    /// Its own frame, NOT an `AcpPermission`: asking is not authorizing
+    /// (2026-08-04 spec). Payload: `{ session_id, request_id, questions }` where
+    /// `questions` is the raw claude `questions[]` array — the cross-vendor shape
+    /// (claude/qwen/grok all converged on it, 2026-08-04 captures):
+    /// `[{question, header?, options:[{label, description?}], multiSelect?}]`.
+    /// Answered via the confirm channel with the FULL per-question answer set;
+    /// wire tag `ask`.
+    Ask(serde_json::Value),
     SkillSuggest(SkillSuggestEventData),
     CronTrigger(CronTriggerEventData),
     AcpModelInfo(serde_json::Value),

--- a/crates/aionui-ai-agent/src/protocol/events/permission.rs
+++ b/crates/aionui-ai-agent/src/protocol/events/permission.rs
@@ -101,7 +101,27 @@ impl AcpPermissionRequestData {
                 AcpToolCallKind::Edit => "edit".to_owned(),
                 AcpToolCallKind::Execute => "execute".to_owned(),
             }),
-            questions: None,
+            // Recovery carries the structured questions when the agent put them
+            // in raw_input (qwen/kimi smuggle ask_user_question through the
+            // permission channel). Without this the recovered card has NO source
+            // for the question text at all — `Confirmation` has no raw_input
+            // field, so the frontend's raw-input fallback cannot run on the
+            // recovery path. Shape-keyed only, no per-agent branching: an array
+            // under `questions` whose entries carry `question` + `options`.
+            questions: self
+                .tool_call
+                .raw_input
+                .as_ref()
+                .and_then(|raw| raw.get("questions"))
+                .filter(|qs| {
+                    qs.as_array().is_some_and(|arr| {
+                        !arr.is_empty()
+                            && arr
+                                .iter()
+                                .all(|q| q.get("question").is_some() && q.get("options").is_some())
+                    })
+                })
+                .cloned(),
             options: self
                 .options
                 .iter()
@@ -112,5 +132,84 @@ impl AcpPermissionRequestData {
                 })
                 .collect(),
         }
+    }
+}
+
+#[cfg(test)]
+mod to_confirmation_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn request(raw_input: serde_json::Value) -> AcpPermissionRequestData {
+        AcpPermissionRequestData {
+            session_id: "s1".into(),
+            tool_call: AcpPermissionToolCall {
+                tool_call_id: "call-1".into(),
+                status: None,
+                title: Some("Ask user 1 question".into()),
+                kind: None,
+                raw_input: Some(raw_input),
+                raw_output: None,
+                content: None,
+                locations: None,
+                meta: None,
+            },
+            options: Vec::new(),
+            meta: None,
+        }
+    }
+
+    /// The old fallback stringified the WHOLE raw_input into `description`,
+    /// rendering a wall of one-line JSON on the card (user report 2026-08-05).
+    #[test]
+    fn description_is_empty_without_a_real_description_string() {
+        let conf = request(json!({ "questions": [{ "question": "Q?", "options": [] }] })).to_confirmation();
+        assert_eq!(
+            conf.description, "",
+            "raw_input must never be dumped as the description"
+        );
+    }
+
+    #[test]
+    fn description_keeps_a_real_description_string() {
+        let conf = request(json!({ "description": "Write /tmp/a.txt" })).to_confirmation();
+        assert_eq!(conf.description, "Write /tmp/a.txt");
+    }
+
+    /// Recovery source for the question text: `Confirmation` has no raw_input
+    /// field, so without this the recovered card shows no question at all.
+    #[test]
+    fn questions_ride_along_for_structured_asks() {
+        let conf = request(json!({
+            "questions": [{ "question": "早餐吃什么？", "options": [{ "label": "包子" }] }]
+        }))
+        .to_confirmation();
+        let qs = conf.questions.expect("structured questions are carried into recovery");
+        assert_eq!(qs[0]["question"], "早餐吃什么？");
+    }
+
+    /// Shape-keyed, not agent-keyed: a `questions` value that is not a list of
+    /// {question, options} entries must not be mistaken for an ask.
+    #[test]
+    fn malformed_questions_are_not_carried() {
+        assert!(
+            request(json!({ "questions": "nope" }))
+                .to_confirmation()
+                .questions
+                .is_none()
+        );
+        assert!(
+            request(json!({ "questions": [] }))
+                .to_confirmation()
+                .questions
+                .is_none()
+        );
+        assert!(
+            request(json!({ "questions": [{ "question": "Q?" }] }))
+                .to_confirmation()
+                .questions
+                .is_none(),
+            "an entry without options is not an answerable question"
+        );
     }
 }

--- a/crates/aionui-ai-agent/src/protocol/events/permission.rs
+++ b/crates/aionui-ai-agent/src/protocol/events/permission.rs
@@ -100,6 +100,7 @@ impl AcpPermissionRequestData {
                 AcpToolCallKind::Edit => "edit".to_owned(),
                 AcpToolCallKind::Execute => "execute".to_owned(),
             }),
+            questions: None,
             options: self
                 .options
                 .iter()

--- a/crates/aionui-ai-agent/src/protocol/events/permission.rs
+++ b/crates/aionui-ai-agent/src/protocol/events/permission.rs
@@ -82,19 +82,20 @@ impl AcpPermissionRequestData {
             call_id: self.tool_call.tool_call_id.clone(),
             title: self.tool_call.title.clone(),
             action: None,
+            // Only a real `description` string. The old fallback dumped the
+            // WHOLE raw_input via `Value::to_string()` into this field, so an
+            // agent that smuggles structured data through the permission
+            // channel (qwen/kimi AskUserQuestion) rendered a wall of one-line
+            // JSON as the card's description (user report, 2026-08-05). The
+            // card's own detail block already shows raw_input readably; an
+            // empty description simply omits the line.
             description: self
                 .tool_call
                 .raw_input
                 .as_ref()
                 .and_then(|raw| raw.get("description").and_then(Value::as_str))
                 .map(ToOwned::to_owned)
-                .unwrap_or_else(|| {
-                    self.tool_call
-                        .raw_input
-                        .as_ref()
-                        .map(Value::to_string)
-                        .unwrap_or_default()
-                }),
+                .unwrap_or_default(),
             command_type: self.tool_call.kind.map(|kind| match kind {
                 AcpToolCallKind::Read => "read".to_owned(),
                 AcpToolCallKind::Edit => "edit".to_owned(),

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -562,6 +562,10 @@ impl SessionAgentTask {
                     action: None,
                     description: String::new(),
                     command_type: None,
+                    // The full question payload rides along so the frontend
+                    // recovery rebuilds the REAL question card; the flattened
+                    // options above stay as the fallback for older frontends.
+                    questions: if is_ask { p.questions.clone() } else { None },
                     options: options
                         .into_iter()
                         .map(|o| aionui_common::ConfirmationOption {

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -589,6 +589,54 @@ impl SessionAgentTask {
     ///     (claude keys the AskUserQuestion answer by the chosen label — see
     ///     claude_conn `build_control_response`; single-select single-question path).
     ///
+    /// Answer a structured question card (AskUserQuestion) — the DEDICATED
+    /// typed channel (2026-08-05 ruling: question answers do not ride the
+    /// permission confirm endpoint). `answers: None` = the user dismissed the
+    /// card; the claude adapter maps that to a deny (an allow with no answers
+    /// is silent data loss — claude drops unanswered questions, live 2.1.178).
+    pub fn answer_ask(
+        &self,
+        request_id: &str,
+        answers: Option<Vec<aionui_api_types::AskQuestionAnswer>>,
+    ) -> Result<(), AgentError> {
+        // api-types is the conversation layer's currency; convert to the
+        // session command's own type at this boundary.
+        let answers = answers.map(|list| {
+            list.into_iter()
+                .map(|a| aionui_session::QuestionAnswer {
+                    question: a.question,
+                    labels: a.labels,
+                })
+                .collect::<Vec<_>>()
+        });
+        let backend = self.backend.clone();
+        let request_id = request_id.to_string();
+        let conv_id = self.conversation_id.clone();
+        // Same fire-and-forget shape as confirm(): the REST reply has already
+        // returned by the time the dispatch runs, so a failure here MUST be
+        // surfaced in the log or a wedged ask is undiagnosable in production.
+        tokio::spawn(async move {
+            let command = aionui_session::Command::AnswerAsk {
+                request_id: request_id.clone(),
+                answers,
+            };
+            match backend.dispatch(command).await {
+                Ok(_) => tracing::info!(
+                    conv_id = %conv_id,
+                    request_id = %request_id,
+                    "ask answer delivered to backend (dedicated channel)"
+                ),
+                Err(e) => tracing::error!(
+                    conv_id = %conv_id,
+                    request_id = %request_id,
+                    error = %e,
+                    "ask answer FAILED after REST reply already returned success — claude stays blocked on can_use_tool"
+                ),
+            }
+        });
+        Ok(())
+    }
+
     /// `always_allow` (legacy flag) forces AllowAlways regardless.
     pub fn confirm(
         &self,
@@ -598,34 +646,6 @@ impl SessionAgentTask {
         always_allow: bool,
     ) -> Result<(), AgentError> {
         use aionui_session::PermissionDecision;
-        // Structured question card (`ask` frame): its confirm payload carries the
-        // FULL per-question answer set (`{answers:[{question, labels[]}]}`) or an
-        // explicit decline (`{ask_decline:true}`) — route to AnswerAsk, which the
-        // claude backend maps to allow+updatedInput.answers / deny. This is keyed
-        // on payload SHAPE, not a pending-ask registry: only the question card
-        // produces these keys, and a decline must reach claude as a deny (an
-        // allow with no answers is silent data loss, live 2.1.178).
-        if let Some(command) = ask_answer_command(call_id, &data) {
-            let backend = self.backend.clone();
-            let request_id = call_id.to_string();
-            let conv_id = self.conversation_id.clone();
-            tokio::spawn(async move {
-                match backend.dispatch(command).await {
-                    Ok(_) => tracing::info!(
-                        conv_id = %conv_id,
-                        request_id = %request_id,
-                        "ask answer delivered to backend"
-                    ),
-                    Err(e) => tracing::error!(
-                        conv_id = %conv_id,
-                        request_id = %request_id,
-                        error = %e,
-                        "ask answer FAILED after REST confirm already returned success — claude stays blocked on can_use_tool"
-                    ),
-                }
-            });
-            return Ok(());
-        }
         let picked = confirm_option_id(&data);
         let (decision, selected) = if always_allow {
             (PermissionDecision::AllowAlways, None)
@@ -3322,42 +3342,6 @@ async fn persist_context_usage(
 /// Extract the picked option id from the confirm `data` payload. The frontend sends
 /// either a bare string (the option_id) or an object `{option_id|optionId|value}`.
 /// Mirrors the ACP path's `confirm_option_id`.
-/// Parse a question-card confirm payload into `Command::AnswerAsk`, or `None`
-/// when the payload is not from the question card (generic permission confirms
-/// carry an option id, never `answers[]` / `ask_decline`). An `answers` array
-/// that fails to parse or is empty yields `None` too — falling through to the
-/// legacy single-label path is safer than sending claude an empty answer set.
-fn ask_answer_command(call_id: &str, data: &serde_json::Value) -> Option<aionui_session::Command> {
-    // The frontend confirm bridge sends `data` as a STRING (ipcBridge:
-    // `data: p.confirm_key`), so the question card's JSON payload arrives
-    // stringified. Parse it back to an object first; a non-JSON string (the
-    // legacy option-id confirms: "allow", a label, …) simply fails the parse
-    // and falls through to the legacy path via `None` below.
-    let parsed;
-    let data = match data {
-        serde_json::Value::String(s) => {
-            parsed = serde_json::from_str::<serde_json::Value>(s).ok()?;
-            &parsed
-        }
-        other => other,
-    };
-    if data.get("ask_decline").and_then(serde_json::Value::as_bool) == Some(true) {
-        return Some(aionui_session::Command::AnswerAsk {
-            request_id: call_id.to_string(),
-            answers: None,
-        });
-    }
-    let answers = data.get("answers")?.clone();
-    let parsed: Vec<aionui_session::QuestionAnswer> = serde_json::from_value(answers).ok()?;
-    if parsed.is_empty() {
-        return None;
-    }
-    Some(aionui_session::Command::AnswerAsk {
-        request_id: call_id.to_string(),
-        answers: Some(parsed),
-    })
-}
-
 fn confirm_option_id(data: &serde_json::Value) -> Option<String> {
     match data {
         serde_json::Value::String(v) => Some(v.clone()),

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -7572,8 +7572,7 @@ mod pump_tests {
         // watcher owns them.
         let last_turn_frame = frames
             .iter()
-            .filter(|f| !matches!(f, AgentStreamEvent::WorkflowProgress(_)))
-            .next_back();
+            .rfind(|f| !matches!(f, AgentStreamEvent::WorkflowProgress(_)));
         assert!(
             matches!(last_turn_frame, Some(AgentStreamEvent::Finish(_))),
             "the settled Finish is the turn's terminal frame, got {seq:?}"
@@ -7645,8 +7644,7 @@ mod pump_tests {
         assert!(
             frames
                 .iter()
-                .filter(|f| !matches!(f, AgentStreamEvent::WorkflowProgress(_)))
-                .next_back()
+                .rfind(|f| !matches!(f, AgentStreamEvent::WorkflowProgress(_)))
                 .is_some_and(|f| matches!(f, AgentStreamEvent::Finish(_))),
             "the clean result's Finish must flow while a background bash is alive, got {seq:?}"
         );

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -539,7 +539,14 @@ impl SessionAgentTask {
             .map(|p| {
                 let is_ask = p.tool_name == "AskUserQuestion";
                 let options = if is_ask {
-                    ask_user_question_options(p.questions.as_ref())
+                    // `p.questions` is the bare `questions[]` ARRAY, but the
+                    // projector expects the whole tool input and does its own
+                    // `.get("questions")` — passing the array straight through
+                    // made recovery silently degrade to the generic
+                    // Allow/AllowAlways/Reject card (live e2e catch, 2026-08-04).
+                    // Re-wrap to the input shape the live path uses.
+                    let input = p.questions.as_ref().map(|qs| serde_json::json!({ "questions": qs }));
+                    ask_user_question_options(input.as_ref())
                 } else {
                     Vec::new()
                 };
@@ -7968,12 +7975,16 @@ mod pump_tests {
         let backend: Arc<dyn SessionBackend> = Arc::new(PendingPermBackend(aionui_session::PendingPermissionView {
             request_id: "req-recover".into(),
             tool_name: "AskUserQuestion".into(),
-            questions: Some(serde_json::json!({
-                "questions": [{
-                    "question": "Which?",
-                    "options": [{"label": "A"}, {"label": "B"}]
-                }]
-            })),
+            // The BARE questions[] array — matching what claude_conn's
+            // pending_permission_requests() actually stores
+            // (`perm.input.get("questions").cloned()`). The old fixture carried
+            // the {questions:[…]} wrapper, so the projection passed here while
+            // silently degrading to Allow/Reject against the real backend
+            // (caught live in the 2026-08-04 e2e).
+            questions: Some(serde_json::json!([{
+                "question": "Which?",
+                "options": [{"label": "A"}, {"label": "B"}]
+            }])),
         }));
         let task = SessionAgentTask::new(
             AgentType::Acp,

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -2223,6 +2223,8 @@ fn session_event_name(e: &SessionEvent) -> &'static str {
         SessionEvent::Detached { .. } => "Detached",
         SessionEvent::Permission { .. } => "Permission",
         SessionEvent::PermissionResolved { .. } => "PermissionResolved",
+        SessionEvent::Ask { .. } => "Ask",
+        SessionEvent::AskResolved { .. } => "AskResolved",
         SessionEvent::UsageDelta { .. } => "UsageDelta",
         SessionEvent::ConfigChanged { .. } => "ConfigChanged",
         SessionEvent::BackendBound { .. } => "BackendBound",
@@ -2454,7 +2456,8 @@ fn spawn_event_pump(
                     | SessionEvent::ThoughtDelta { .. }
                     | SessionEvent::ToolCall { .. }
                     | SessionEvent::ToolResult { .. }
-                    | SessionEvent::Permission { .. } => {
+                    | SessionEvent::Permission { .. }
+                    | SessionEvent::Ask { .. } => {
                         tracing::info!(
                             conv_id = %conversation_id,
                             event = session_event_name(&env.event),
@@ -3942,6 +3945,22 @@ fn translate_event(event: SessionEvent, conversation_id: &str, terminal_result_s
                 ),
             )]
         }
+        // Structured question (claude AskUserQuestion) → its own `ask` frame; the
+        // frontend renders a multi-question card and answers via confirm with the
+        // full per-question set. Deliberately NOT projected into AcpPermission
+        // options anymore — that flattening dropped every question after the first
+        // (the reason the tool was disabled at spawn until 2026-08-04).
+        SessionEvent::Ask { request_id, questions } => {
+            vec![AgentStreamEvent::Ask(serde_json::json!({
+                "session_id": conversation_id,
+                "request_id": request_id,
+                "questions": questions,
+            }))]
+        }
+        // The FSM counter side is handled by the reducer; the frontend closes the
+        // card on its own answer. A cross-client "someone else answered" push is a
+        // follow-up (the recovery REST path re-lists open asks on reload).
+        SessionEvent::AskResolved { .. } => Vec::new(),
         // Per-turn usage/cost → the AcpContextUsage passthrough frame the frontend
         // usage indicator reads (shape: cumulative token counters).
         SessionEvent::UsageDelta {

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -587,6 +587,34 @@ impl SessionAgentTask {
         always_allow: bool,
     ) -> Result<(), AgentError> {
         use aionui_session::PermissionDecision;
+        // Structured question card (`ask` frame): its confirm payload carries the
+        // FULL per-question answer set (`{answers:[{question, labels[]}]}`) or an
+        // explicit decline (`{ask_decline:true}`) — route to AnswerAsk, which the
+        // claude backend maps to allow+updatedInput.answers / deny. This is keyed
+        // on payload SHAPE, not a pending-ask registry: only the question card
+        // produces these keys, and a decline must reach claude as a deny (an
+        // allow with no answers is silent data loss, live 2.1.178).
+        if let Some(command) = ask_answer_command(call_id, &data) {
+            let backend = self.backend.clone();
+            let request_id = call_id.to_string();
+            let conv_id = self.conversation_id.clone();
+            tokio::spawn(async move {
+                match backend.dispatch(command).await {
+                    Ok(_) => tracing::info!(
+                        conv_id = %conv_id,
+                        request_id = %request_id,
+                        "ask answer delivered to backend"
+                    ),
+                    Err(e) => tracing::error!(
+                        conv_id = %conv_id,
+                        request_id = %request_id,
+                        error = %e,
+                        "ask answer FAILED after REST confirm already returned success — claude stays blocked on can_use_tool"
+                    ),
+                }
+            });
+            return Ok(());
+        }
         let picked = confirm_option_id(&data);
         let (decision, selected) = if always_allow {
             (PermissionDecision::AllowAlways, None)
@@ -3283,6 +3311,29 @@ async fn persist_context_usage(
 /// Extract the picked option id from the confirm `data` payload. The frontend sends
 /// either a bare string (the option_id) or an object `{option_id|optionId|value}`.
 /// Mirrors the ACP path's `confirm_option_id`.
+/// Parse a question-card confirm payload into `Command::AnswerAsk`, or `None`
+/// when the payload is not from the question card (generic permission confirms
+/// carry an option id, never `answers[]` / `ask_decline`). An `answers` array
+/// that fails to parse or is empty yields `None` too — falling through to the
+/// legacy single-label path is safer than sending claude an empty answer set.
+fn ask_answer_command(call_id: &str, data: &serde_json::Value) -> Option<aionui_session::Command> {
+    if data.get("ask_decline").and_then(serde_json::Value::as_bool) == Some(true) {
+        return Some(aionui_session::Command::AnswerAsk {
+            request_id: call_id.to_string(),
+            answers: None,
+        });
+    }
+    let answers = data.get("answers")?.clone();
+    let parsed: Vec<aionui_session::QuestionAnswer> = serde_json::from_value(answers).ok()?;
+    if parsed.is_empty() {
+        return None;
+    }
+    Some(aionui_session::Command::AnswerAsk {
+        request_id: call_id.to_string(),
+        answers: Some(parsed),
+    })
+}
+
 fn confirm_option_id(data: &serde_json::Value) -> Option<String> {
     match data {
         serde_json::Value::String(v) => Some(v.clone()),

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -3317,6 +3317,19 @@ async fn persist_context_usage(
 /// that fails to parse or is empty yields `None` too — falling through to the
 /// legacy single-label path is safer than sending claude an empty answer set.
 fn ask_answer_command(call_id: &str, data: &serde_json::Value) -> Option<aionui_session::Command> {
+    // The frontend confirm bridge sends `data` as a STRING (ipcBridge:
+    // `data: p.confirm_key`), so the question card's JSON payload arrives
+    // stringified. Parse it back to an object first; a non-JSON string (the
+    // legacy option-id confirms: "allow", a label, …) simply fails the parse
+    // and falls through to the legacy path via `None` below.
+    let parsed;
+    let data = match data {
+        serde_json::Value::String(s) => {
+            parsed = serde_json::from_str::<serde_json::Value>(s).ok()?;
+            &parsed
+        }
+        other => other,
+    };
     if data.get("ask_decline").and_then(serde_json::Value::as_bool) == Some(true) {
         return Some(aionui_session::Command::AnswerAsk {
             request_id: call_id.to_string(),

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -179,6 +179,7 @@ fn event_type_name(event: &AgentStreamEvent) -> &'static str {
         AgentStreamEvent::Plan(_) => "Plan",
         AgentStreamEvent::Permission(_) => "Permission",
         AgentStreamEvent::AcpPermission(_) => "AcpPermission",
+        AgentStreamEvent::Ask(_) => "Ask",
         AgentStreamEvent::AcpToolCall(_) => "AcpToolCall",
         AgentStreamEvent::AvailableCommands(_) => "AvailableCommands",
         AgentStreamEvent::SkillSuggest(_) => "SkillSuggest",

--- a/crates/aionui-api-types/src/ask.rs
+++ b/crates/aionui-api-types/src/ask.rs
@@ -1,0 +1,53 @@
+use serde::Deserialize;
+
+/// Body for `POST /api/conversations/:id/asks/:requestId/answer` — the
+/// structured-question card's DEDICATED answer channel (2026-08-05 ruling:
+/// question answers must not ride the permission confirm endpoint).
+///
+/// Exactly one of the two shapes is valid:
+/// - answered: `answers` non-empty, `decline` false/absent
+/// - dismissed: `decline: true`, `answers` absent
+///
+/// A decline MUST stay distinguishable from an empty answer set — claude
+/// silently drops unanswered questions on an allow (live 2.1.178), so an
+/// "empty allow" is silent data loss, not a re-ask.
+#[derive(Debug, Deserialize)]
+pub struct AskAnswerRequest {
+    #[serde(default)]
+    pub answers: Vec<AskQuestionAnswer>,
+    #[serde(default)]
+    pub decline: bool,
+}
+
+/// One answered question: `question` is the exact question TEXT (claude keys
+/// its answers map by it), `labels` the chosen option labels (one for a
+/// single-select, one-or-more for multiSelect; free text rides as a label).
+#[derive(Debug, Deserialize)]
+pub struct AskQuestionAnswer {
+    pub question: String,
+    pub labels: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn deserialize_answered() {
+        let req: AskAnswerRequest = serde_json::from_value(json!({
+            "answers": [{ "question": "Which?", "labels": ["A", "B"] }]
+        }))
+        .unwrap();
+        assert!(!req.decline);
+        assert_eq!(req.answers.len(), 1);
+        assert_eq!(req.answers[0].labels, vec!["A", "B"]);
+    }
+
+    #[test]
+    fn deserialize_decline() {
+        let req: AskAnswerRequest = serde_json::from_value(json!({ "decline": true })).unwrap();
+        assert!(req.decline);
+        assert!(req.answers.is_empty());
+    }
+}

--- a/crates/aionui-api-types/src/confirmation.rs
+++ b/crates/aionui-api-types/src/confirmation.rs
@@ -111,6 +111,7 @@ mod tests {
     #[test]
     fn confirmation_list_response_is_vec() {
         let list: ConfirmationListResponse = vec![Confirmation {
+            questions: None,
             id: "c1".into(),
             call_id: "call-1".into(),
             title: Some("Test".into()),

--- a/crates/aionui-api-types/src/lib.rs
+++ b/crates/aionui-api-types/src/lib.rs
@@ -7,6 +7,7 @@ mod agent_build_extra;
 mod agent_discovery;
 mod agent_error;
 mod antigravity_hook;
+mod ask;
 mod assistant;
 mod auth;
 mod channel;
@@ -58,6 +59,7 @@ pub use antigravity_hook::{
     AntigravityHookConfig, AntigravityHookDecision, AntigravityHookInput, AntigravityHookOutput,
     AntigravityHookToolCall,
 };
+pub use ask::{AskAnswerRequest, AskQuestionAnswer};
 pub use assistant::{
     AssistantAgentResponse, AssistantCapabilitiesResponse, AssistantDefaultListRequest, AssistantDefaultListResponse,
     AssistantDefaultScalarRequest, AssistantDefaultScalarResponse, AssistantDefaultsRequest, AssistantDefaultsResponse,

--- a/crates/aionui-app/tests/agent_integration_e2e.rs
+++ b/crates/aionui-app/tests/agent_integration_e2e.rs
@@ -523,6 +523,7 @@ async fn confirm_and_check_approval() {
 
     // Pre-populate a pending confirmation so the confirm endpoint can find it
     agent.confirmations.lock().unwrap().push(Confirmation {
+        questions: None,
         id: "conf-1".into(),
         call_id: "call-42".into(),
         title: Some("Allow file edit".into()),

--- a/crates/aionui-app/tests/auxiliary_e2e.rs
+++ b/crates/aionui-app/tests/auxiliary_e2e.rs
@@ -297,6 +297,64 @@ async fn confirm_call_no_task() {
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
+// ── Dedicated ask-answer route (2026-08-05: question answers do not ride
+// the permission confirm endpoint) ─────
+
+#[tokio::test]
+async fn answer_ask_no_task_is_404() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "user1", "pass123").await;
+    let conv_id = create_conversation(&mut app, &token, &csrf, "Ask Test", "acp").await;
+
+    let req = json_with_token(
+        "POST",
+        &format!("/api/conversations/{conv_id}/asks/req-1/answer"),
+        json!({ "answers": [{ "question": "Which?", "labels": ["A"] }] }),
+        &token,
+        &csrf,
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    // No active agent behind the conversation → the ask cannot be answered.
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn answer_ask_rejects_empty_answers() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "user1", "pass123").await;
+    let conv_id = create_conversation(&mut app, &token, &csrf, "Ask Test", "acp").await;
+
+    // Neither answers nor decline: an "empty allow" would be silent data loss
+    // (claude drops unanswered questions), so the route must reject it before
+    // any dispatch.
+    let req = json_with_token(
+        "POST",
+        &format!("/api/conversations/{conv_id}/asks/req-1/answer"),
+        json!({}),
+        &token,
+        &csrf,
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn answer_ask_rejects_decline_with_answers() {
+    let (mut app, services) = build_app().await;
+    let (token, csrf) = setup_and_login(&mut app, &services, "user1", "pass123").await;
+    let conv_id = create_conversation(&mut app, &token, &csrf, "Ask Test", "acp").await;
+
+    let req = json_with_token(
+        "POST",
+        &format!("/api/conversations/{conv_id}/asks/req-1/answer"),
+        json!({ "decline": true, "answers": [{ "question": "Which?", "labels": ["A"] }] }),
+        &token,
+        &csrf,
+    );
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
 #[tokio::test]
 async fn check_approval_no_task() {
     let (mut app, services) = build_app().await;

--- a/crates/aionui-channel/src/message_service.rs
+++ b/crates/aionui-channel/src/message_service.rs
@@ -220,6 +220,9 @@ impl ChannelMessageService {
             | AgentStreamEvent::Plan(_)
             | AgentStreamEvent::Permission(_)
             | AgentStreamEvent::AcpPermission(_)
+            // IM channels have no interactive question card; the ask stays
+            // pending in the app UI (same treatment as Permission).
+            | AgentStreamEvent::Ask(_)
             | AgentStreamEvent::AcpToolCall(_)
             | AgentStreamEvent::AvailableCommands(_)
             | AgentStreamEvent::SkillSuggest(_)

--- a/crates/aionui-common/src/types.rs
+++ b/crates/aionui-common/src/types.rs
@@ -150,6 +150,7 @@ mod tests {
             action: None,
             description: "Execute shell command".into(),
             command_type: Some("bash".into()),
+            questions: None,
             options: vec![ConfirmationOption {
                 label: "Allow".into(),
                 value: serde_json::json!(true),
@@ -159,6 +160,10 @@ mod tests {
         let json = serde_json::to_value(&c).unwrap();
         assert_eq!(json["call_id"], "call1");
         assert_eq!(json["command_type"], "bash");
+        assert!(
+            json.get("questions").is_none(),
+            "an ordinary approval must not put a null questions key on the wire"
+        );
     }
 
     #[test]

--- a/crates/aionui-common/src/types.rs
+++ b/crates/aionui-common/src/types.rs
@@ -57,6 +57,14 @@ pub struct Confirmation {
     pub description: String,
     pub command_type: Option<String>,
     pub options: Vec<ConfirmationOption>,
+    /// Structured-question recovery (AskUserQuestion): the bare `questions[]`
+    /// array when this pending confirmation is a question, so the REST
+    /// `/confirmations` recovery path can rebuild the REAL question card
+    /// (title/multi-question/multiSelect) instead of degrading to a
+    /// title-less permission card whose options can only carry flat labels.
+    /// `None` for ordinary tool approvals; skipped on the wire when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub questions: Option<serde_json::Value>,
 }
 
 /// A single option within a confirmation dialog.

--- a/crates/aionui-conversation/src/background_stream.rs
+++ b/crates/aionui-conversation/src/background_stream.rs
@@ -71,6 +71,7 @@ impl BackgroundStreamWatcher {
                 | AgentStreamEvent::Plan(_)
                 | AgentStreamEvent::Permission(_)
                 | AgentStreamEvent::AcpPermission(_)
+                | AgentStreamEvent::Ask(_)
                 | AgentStreamEvent::Error(_)
         )
         // Deliberately absent: Tips. Tips are OUR pump-side diagnostics, never
@@ -330,6 +331,7 @@ fn frame_kind(ev: &AgentStreamEvent) -> &'static str {
         AgentStreamEvent::Plan(_) => "plan",
         AgentStreamEvent::Permission(_) => "permission",
         AgentStreamEvent::AcpPermission(_) => "acp_permission",
+        AgentStreamEvent::Ask(_) => "ask",
         AgentStreamEvent::Tips(_) => "tips",
         AgentStreamEvent::Error(_) => "error",
         _ => "other",

--- a/crates/aionui-conversation/src/routes.rs
+++ b/crates/aionui-conversation/src/routes.rs
@@ -125,6 +125,7 @@ pub fn conversation_routes(state: ConversationRouterState) -> Router {
         // Confirmation system
         .route("/api/conversations/{id}/confirmations", get(list_confirmations))
         .route("/api/conversations/{id}/confirmations/{callId}/confirm", post(confirm))
+        .route("/api/conversations/{id}/asks/{requestId}/answer", post(answer_ask))
         .route("/api/conversations/{id}/approvals/check", get(check_approval))
         .route("/api/conversations/active-count", get(active_count))
         .route("/api/conversations/clone", post(clone))
@@ -403,6 +404,51 @@ async fn confirm(
     state
         .service
         .confirm(&user.id, &params.id, &params.call_id, req, &state.task_manager)
+        .await
+        .map_err(ApiError::from)?;
+    Ok(Json(ApiResponse::success()))
+}
+
+#[derive(serde::Deserialize)]
+struct AskPathParams {
+    id: String,
+    #[serde(rename = "requestId")]
+    request_id: String,
+}
+
+/// Dedicated answer channel for the structured question card (AskUserQuestion).
+/// Body: `{answers:[{question, labels[]}]}` to answer, `{decline:true}` to
+/// dismiss. Exactly one shape must be present — an empty answer set is
+/// rejected rather than forwarded (claude silently drops unanswered questions
+/// on an allow, so an "empty allow" is silent data loss).
+async fn answer_ask(
+    State(state): State<ConversationRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    Path(params): Path<AskPathParams>,
+    body: Result<Json<aionui_api_types::AskAnswerRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<()>>, ApiError> {
+    let Json(req) = body.map_err(ApiError::from)?;
+    let answers = if req.decline {
+        if !req.answers.is_empty() {
+            return Err(ApiError::BadRequest(
+                "decline and answers are mutually exclusive".into(),
+            ));
+        }
+        None
+    } else {
+        if req.answers.is_empty() {
+            return Err(ApiError::BadRequest(
+                "answers must not be empty unless decline is true".into(),
+            ));
+        }
+        if req.answers.iter().any(|a| a.question.trim().is_empty()) {
+            return Err(ApiError::BadRequest("every answer must name its question".into()));
+        }
+        Some(req.answers)
+    };
+    state
+        .service
+        .answer_ask(&user.id, &params.id, &params.request_id, answers, &state.task_manager)
         .await
         .map_err(ApiError::from)?;
     Ok(Json(ApiResponse::success()))

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -3200,6 +3200,54 @@ impl ConversationService {
         Ok(())
     }
 
+    /// Answer a pending structured question (AskUserQuestion) over its
+    /// DEDICATED channel (2026-08-05 ruling: not the permission confirm path).
+    /// `answers: None` = the user dismissed the card (deny on the wire).
+    pub async fn answer_ask(
+        &self,
+        user_id: &str,
+        conversation_id: &str,
+        request_id: &str,
+        answers: Option<Vec<aionui_api_types::AskQuestionAnswer>>,
+        task_manager: &Arc<dyn IWorkerTaskManager>,
+    ) -> Result<(), ConversationError> {
+        self.conversation_repo
+            .get(user_id, conversation_id)
+            .await?
+            .ok_or_else(|| ConversationError::NotFound {
+                id: conversation_id.to_owned(),
+            })?;
+
+        let agent = task_manager
+            .get_task(conversation_id)
+            .ok_or_else(|| ConversationError::ActiveAgentNotFound {
+                conversation_id: conversation_id.to_owned(),
+            })?;
+
+        // Same recovery-card cleanup contract as confirm(): if this request is
+        // also surfaced as a pending confirmation, broadcast its removal so
+        // every connected client drops the recovered card.
+        let conf_id = agent
+            .get_confirmations()
+            .iter()
+            .find(|c| c.call_id == request_id)
+            .map(|c| c.id.clone());
+
+        agent.answer_ask(request_id, answers)?;
+
+        if let Some(conf_id) = conf_id {
+            let payload = serde_json::json!({
+                "user_id": user_id,
+                "conversation_id": conversation_id,
+                "id": conf_id,
+            });
+            let msg = WebSocketMessage::new("confirmation.remove", payload);
+            self.broadcaster.broadcast(msg);
+        }
+
+        Ok(())
+    }
+
     /// Check whether an action has been auto-approved in the current session.
     pub async fn check_approval(
         &self,

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -6615,6 +6615,7 @@ fn make_test_confirmations() -> Vec<Confirmation> {
             action: Some("edit_file".into()),
             description: "Edit main.rs".into(),
             command_type: Some("bash".into()),
+            questions: None,
             options: vec![],
         },
         Confirmation {
@@ -6624,6 +6625,7 @@ fn make_test_confirmations() -> Vec<Confirmation> {
             action: Some("read_file".into()),
             description: "Read config.toml".into(),
             command_type: None,
+            questions: None,
             options: vec![],
         },
     ]

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -572,7 +572,11 @@ impl StreamRelay {
                         }
                         AgentStreamEvent::CronTrigger(_)
                         | AgentStreamEvent::Permission(_)
-                        | AgentStreamEvent::AcpPermission(_) => {
+                        | AgentStreamEvent::AcpPermission(_)
+                        // Ask rides the permission lane: a raised question is a
+                        // side-effect (blocks auto-replay) and must reach the ws
+                        // live for the card to pop mid-turn.
+                        | AgentStreamEvent::Ask(_) => {
                             attempt.saw_tool_or_side_effect = true;
                             self.forward_to_websocket(&event);
                         }
@@ -667,6 +671,7 @@ impl StreamRelay {
             AgentStreamEvent::Plan(_) => "Plan",
             AgentStreamEvent::Permission(_) => "Permission",
             AgentStreamEvent::AcpPermission(_) => "AcpPermission",
+            AgentStreamEvent::Ask(_) => "Ask",
             AgentStreamEvent::SkillSuggest(_) => "SkillSuggest",
             AgentStreamEvent::CronTrigger(_) => "CronTrigger",
             AgentStreamEvent::AcpModelInfo(_) => "AcpModelInfo",

--- a/crates/aionui-session/src/adapter/claude.rs
+++ b/crates/aionui-session/src/adapter/claude.rs
@@ -52,6 +52,15 @@ pub struct ClaudeAdapter {
     /// a compaction. Spelled exactly like the `modelUsage` keys
     /// (`"claude-opus-5"`), so it selects the right entry directly.
     current_model: Option<String>,
+    /// request_ids of outstanding `AskUserQuestion` can_use_tool requests, so a
+    /// `control_cancel_request` resolves to the RIGHT event: `AskResolved` for a
+    /// question, `PermissionResolved` for a tool approval. The reducer keeps two
+    /// separate counters and a cancel that decrements the wrong one wedges the
+    /// other at >0 (requires-action never clears). Entries are removed on cancel;
+    /// answered requests are cleared by the conn layer's own pending map — a
+    /// stale leftover here is harmless (set membership only biases WHICH resolve
+    /// event a cancel emits, and ids are unique per control request).
+    ask_requests: std::collections::HashSet<String>,
 }
 
 /// Per-message streaming state for `--include-partial-messages`. Reset on each
@@ -293,8 +302,8 @@ impl ClaudeAdapter {
             // retracts a pending one → `PermissionResolved{request_id}`. Other
             // control subtypes (keep_alive / streamlined_* / elicitation) carry no
             // FSM signal → opaque (the manager declines elicitation on the a-side).
-            "control_request" => Self::parse_control_request(v),
-            "control_cancel_request" => Self::parse_control_cancel_request(v),
+            "control_request" => self.parse_control_request(v),
+            "control_cancel_request" => self.parse_control_cancel_request(v),
             // R5 (009): `--include-partial-messages` wraps the streaming Anthropic
             // events in `stream_event`. The ONE we read is `message_delta`, whose
             // `delta.stop_reason` is the REAL-TIME per-turn boundary — it lands as
@@ -869,7 +878,7 @@ impl ClaudeAdapter {
     /// control frame. `request_id` is the TOP-LEVEL field (distinct from the
     /// nested `request.tool_use_id`); a frame missing it cannot be answered, so
     /// it degrades to opaque rather than wedging a request we can't resolve.
-    fn parse_control_request(v: &Value) -> Vec<SessionEvent> {
+    fn parse_control_request(&mut self, v: &Value) -> Vec<SessionEvent> {
         let subtype = v
             .get("request")
             .and_then(|r| r.get("subtype"))
@@ -883,6 +892,23 @@ impl ClaudeAdapter {
                     .and_then(|r| r.get("tool_name"))
                     .and_then(Value::as_str)
                     .map(str::to_string);
+                // AskUserQuestion is NOT a permission — it is the agent asking the
+                // USER a structured question. Route it to its own `Ask` event
+                // (own counter, own answer command; 2026-08-04 ruling). Remember
+                // the request_id so a later control_cancel_request resolves the
+                // matching counter, not the approval one.
+                if tool_name.as_deref() == Some("AskUserQuestion") {
+                    let questions = request
+                        .and_then(|r| r.get("input"))
+                        .and_then(|i| i.get("questions"))
+                        .cloned()
+                        .unwrap_or(Value::Null);
+                    self.ask_requests.insert(request_id.to_string());
+                    return vec![SessionEvent::Ask {
+                        request_id: request_id.to_string(),
+                        questions,
+                    }];
+                }
                 // Carry the raw `input` for EVERY tool. The permission card must show
                 // the user WHAT they are approving (a Bash `command`, a Write target)
                 // — with only `tool_name` the card reads "命令: Bash" and the user
@@ -919,8 +945,13 @@ impl ClaudeAdapter {
     /// requires-action sub-state can clear without a user answer. The host sends
     /// NO control_response for a cancel (the request is gone); the manager drops
     /// the pending card on the a-side.
-    fn parse_control_cancel_request(v: &Value) -> Vec<SessionEvent> {
+    fn parse_control_cancel_request(&mut self, v: &Value) -> Vec<SessionEvent> {
         match v.get("request_id").and_then(Value::as_str) {
+            // A retracted AskUserQuestion resolves the QUESTION counter — emitting
+            // PermissionResolved here would wedge waiting_on_question at >0 forever.
+            Some(id) if !id.is_empty() && self.ask_requests.remove(id) => {
+                vec![SessionEvent::AskResolved { request_id: id.to_string() }]
+            }
             Some(id) if !id.is_empty() => vec![SessionEvent::PermissionResolved {
                 request_id: id.to_string(),
                 // claude control_cancel_request retracts a TOOL approval (§9.17).

--- a/crates/aionui-session/src/adapter/claude.rs
+++ b/crates/aionui-session/src/adapter/claude.rs
@@ -2505,25 +2505,31 @@ mod tests {
                 }
             }
         });
-        let events = ClaudeAdapter::parse_control_request(&frame);
+        // 2026-08-04 spec: AskUserQuestion is its OWN Ask event now — asking is
+        // not authorizing. The adapter must route it away from Permission, carry
+        // the bare questions[] array, and remember the request_id so a later
+        // control_cancel_request resolves the QUESTION counter.
+        let mut adapter = ClaudeAdapter::new();
+        let events = adapter.parse_control_request(&frame);
         match events.as_slice() {
-            [
-                SessionEvent::Permission {
-                    request_id,
-                    tool_name,
-                    input,
-                    ..
-                },
-            ] => {
+            [SessionEvent::Ask { request_id, questions }] => {
                 assert_eq!(request_id, "req-q1");
-                assert_eq!(tool_name.as_deref(), Some("AskUserQuestion"));
-                let questions = input.as_ref().expect("AskUserQuestion carries input");
                 assert_eq!(
-                    questions["questions"][0]["question"], "Pick a color",
+                    questions[0]["question"], "Pick a color",
                     "the question text is projected, not dropped"
                 );
+                assert_eq!(
+                    questions[0]["multiSelect"], false,
+                    "multiSelect survives verbatim (the ws relay snake_cases later)"
+                );
             }
-            other => panic!("expected one Permission, got {other:?}"),
+            other => panic!("expected one Ask, got {other:?}"),
+        }
+        // The retract path must resolve the question counter, not the approval one.
+        let cancel = serde_json::json!({ "type": "control_cancel_request", "request_id": "req-q1" });
+        match adapter.parse_control_cancel_request(&cancel).as_slice() {
+            [SessionEvent::AskResolved { request_id }] => assert_eq!(request_id, "req-q1"),
+            other => panic!("expected AskResolved for a retracted ask, got {other:?}"),
         }
     }
 
@@ -2544,7 +2550,7 @@ mod tests {
                 "input": { "command": "rm -rf /" }
             }
         });
-        let events = ClaudeAdapter::parse_control_request(&frame);
+        let events = ClaudeAdapter::new().parse_control_request(&frame);
         match events.as_slice() {
             [SessionEvent::Permission { tool_name, input, .. }] => {
                 assert_eq!(tool_name.as_deref(), Some("Bash"));
@@ -2663,7 +2669,7 @@ mod tests {
     fn parse_control_cancel_request_resolves_permission_or_degrades() {
         // Valid retraction → PermissionResolved.
         let frame = serde_json::json!({ "type": "control_cancel_request", "request_id": "req-9" });
-        match ClaudeAdapter::parse_control_cancel_request(&frame).as_slice() {
+        match ClaudeAdapter::new().parse_control_cancel_request(&frame).as_slice() {
             [SessionEvent::PermissionResolved { request_id, kind }] => {
                 assert_eq!(request_id, "req-9");
                 assert_eq!(
@@ -2681,7 +2687,7 @@ mod tests {
             serde_json::json!({ "type": "control_cancel_request" }),
             serde_json::json!({ "type": "control_cancel_request", "request_id": "" }),
         ] {
-            match ClaudeAdapter::parse_control_cancel_request(&frame).as_slice() {
+            match ClaudeAdapter::new().parse_control_cancel_request(&frame).as_slice() {
                 [SessionEvent::AdapterSpecific { tag, .. }] => {
                     assert_eq!(tag, "control_cancel_request", "unidentifiable cancel stays opaque");
                 }

--- a/crates/aionui-session/src/adapter/claude.rs
+++ b/crates/aionui-session/src/adapter/claude.rs
@@ -950,7 +950,9 @@ impl ClaudeAdapter {
             // A retracted AskUserQuestion resolves the QUESTION counter — emitting
             // PermissionResolved here would wedge waiting_on_question at >0 forever.
             Some(id) if !id.is_empty() && self.ask_requests.remove(id) => {
-                vec![SessionEvent::AskResolved { request_id: id.to_string() }]
+                vec![SessionEvent::AskResolved {
+                    request_id: id.to_string(),
+                }]
             }
             Some(id) if !id.is_empty() => vec![SessionEvent::PermissionResolved {
                 request_id: id.to_string(),

--- a/crates/aionui-session/src/backend/acp_conn.rs
+++ b/crates/aionui-session/src/backend/acp_conn.rs
@@ -2479,6 +2479,10 @@ impl SessionBackend for AcpSessionBackend {
                     turn_gen: self.turn_gen.load(Ordering::SeqCst),
                 })
             }
+            // ACP has no structured-question channel (elicitation unimplemented,
+            // 0/24 live agents emit it — 2026-08-04 sweep); Ask is never raised
+            // here, so an answer has nothing to land on.
+            Command::AnswerAsk { .. } => Err(BackendError::CommandNotSupported { command: "answer_ask" }),
             Command::AnswerAuth { method_id, .. } => {
                 // D2: only when the agent advertised authMethods at initialize
                 // (answer_auth cap dynamically true) do we honor this. ACP auth is a

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -231,18 +231,12 @@ pub(crate) fn build_claude_init_args(config: &SessionConfig) -> Vec<String> {
     // syscall-free fn.
     args.push("--allow-dangerously-skip-permissions".to_string());
 
-    // TEMPORARY: disable AskUserQuestion until the multi-question interactive card is
-    // ported to the current frontend. claude's AskUserQuestion can ask several
-    // questions at once (`{questions:[…]}`), but the active frontend only renders a
-    // single-question permission card, so a multi-question ask would silently drop all
-    // but the first. Rather than ship that half-answer behaviour, deny the tool at
-    // spawn time — claude then falls back to plain-text questions, which render fully.
-    // Mirrors the official @agentclientprotocol/claude-agent-acp adapter, which
-    // likewise lists `AskUserQuestion` in `disallowedTools` for the same reason
-    // ("not a great way to expose this over ACP at the moment"). Remove once the
-    // frontend gains a multi-question renderer.
-    args.push("--disallowed-tools".to_string());
-    args.push("AskUserQuestion".to_string());
+    // AskUserQuestion is ENABLED: the frontend now renders a real multi-question
+    // card fed by `SessionEvent::Ask` and answers through `Command::AnswerAsk`
+    // (2026-08-04 spec 2026-08-04-askuserquestion-统一问询设计.md). This used to be
+    // `--disallowed-tools AskUserQuestion` while the active frontend could only
+    // show a single-question permission card — removing the flag is the claude
+    // half of P0; the adapter routes the tool to `Ask`, never to `Permission`.
 
     if let Some(model) = config.model.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
         args.push("--model".to_string());
@@ -943,6 +937,69 @@ impl ClaudeSessionBackend {
             event: SessionEvent::PermissionResolved {
                 request_id: request_id.to_string(),
                 kind: crate::event::PermissionKind::Tool,
+            },
+        });
+        Ok(CommandReceipt {
+            accepted: true,
+            admission: Admission::NoTurn,
+            turn_gen: cur_gen,
+        })
+    }
+
+    /// Wire an AskUserQuestion answer (`Command::AnswerAsk`) to claude's blocking
+    /// `can_use_tool` request. Same pending map + keyed `control_response` as
+    /// `answer_permission` — on the WIRE this is still can_use_tool — but the
+    /// b-side event is `AskResolved` (the question counter), and the decision is
+    /// derived from `answers`: `Some` → allow with `updatedInput.answers`
+    /// (build_control_response's existing AskUserQuestion path), `None` (user
+    /// dismissed the card) → deny. `None` MUST NOT become an allow: claude
+    /// silently drops unanswered questions on allow (live 2.1.178) — that would
+    /// be silent data loss, not a re-ask.
+    async fn answer_ask(
+        &self,
+        request_id: &str,
+        answers: Option<Vec<super::types::QuestionAnswer>>,
+    ) -> Result<CommandReceipt, BackendError> {
+        use std::sync::atomic::Ordering;
+        let pending = self
+            .pending_perms
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(request_id);
+        let Some(pending) = pending else {
+            return Err(BackendError::Transport(format!(
+                "no pending ask for request_id {request_id}"
+            )));
+        };
+        let (decision, answer_slice) = match &answers {
+            Some(list) => (super::types::PermissionDecision::Approved, list.as_slice()),
+            None => (super::types::PermissionDecision::Denied, &[][..]),
+        };
+        let response = build_control_response(request_id, &pending, decision, None, answer_slice);
+        {
+            let mut guard = self.stdin.lock().await;
+            let stdin = guard
+                .as_mut()
+                .ok_or_else(|| BackendError::Transport("claude stdin unavailable".into()))?;
+            self.adapter
+                .write_control_response(stdin, &response)
+                .await
+                .map_err(|e| BackendError::Transport(format!("write control_response: {e}")))?;
+        }
+        // Lifecycle marker, same wedge class as permission answers: "user answered
+        // but claude never resumed" hinges on whether this write happened.
+        tracing::info!(
+            conversation_id = %self.session_id,
+            request_id = %request_id,
+            answered = answers.is_some(),
+            "claude control_response (ask answer) written to stdin"
+        );
+        let cur_gen = self.turn_gen.load(Ordering::SeqCst);
+        let _ = self.event_tx.send(SessionEnvelope {
+            session_id: self.session_id.clone(),
+            turn_gen: cur_gen,
+            event: SessionEvent::AskResolved {
+                request_id: request_id.to_string(),
             },
         });
         Ok(CommandReceipt {
@@ -2840,6 +2897,9 @@ impl SessionBackend for ClaudeSessionBackend {
                 self.answer_permission(&request_id, decision, selected.as_deref(), &answers)
                     .await
             }
+            // AnswerAsk: the structured-question twin (wire = same can_use_tool
+            // control_response; b-side event = AskResolved on its own counter).
+            Command::AnswerAsk { request_id, answers } => self.answer_ask(&request_id, answers).await,
             // Acknowledge: a conversation-side fold (done-unseen → seen). NO claude
             // wire; accept as a local no-op (§C1).
             Command::Acknowledge { .. } => {

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -929,15 +929,28 @@ impl ClaudeSessionBackend {
             request_id = %request_id,
             "claude control_response (permission answer) written to stdin"
         );
-        // RA -1: the reducer leaves requires-action only on PermissionResolved.
+        // RA -1: resolve the SAME counter the originating event incremented. An
+        // AskUserQuestion raised `Ask` (waiting_on_question), and the REST
+        // recovery card answers it through THIS legacy AnswerPermission path
+        // (Confirmation options carry the answer labels) — emitting
+        // PermissionResolved here would decrement waiting_on_approval instead,
+        // leaving waiting_on_question pinned at >0 and the session locked out of
+        // can_send forever after a recovered ask is answered.
         let cur_gen = self.turn_gen.load(Ordering::SeqCst);
+        let resolve_event = if pending.tool_name == "AskUserQuestion" {
+            SessionEvent::AskResolved {
+                request_id: request_id.to_string(),
+            }
+        } else {
+            SessionEvent::PermissionResolved {
+                request_id: request_id.to_string(),
+                kind: crate::event::PermissionKind::Tool,
+            }
+        };
         let _ = self.event_tx.send(SessionEnvelope {
             session_id: self.session_id.clone(),
             turn_gen: cur_gen,
-            event: SessionEvent::PermissionResolved {
-                request_id: request_id.to_string(),
-                kind: crate::event::PermissionKind::Tool,
-            },
+            event: resolve_event,
         });
         Ok(CommandReceipt {
             accepted: true,
@@ -3176,12 +3189,10 @@ mod tests {
                 "--permission-mode".to_string(),
                 "default".to_string(),
                 "--allow-dangerously-skip-permissions".to_string(),
-                "--disallowed-tools".to_string(),
-                "AskUserQuestion".to_string(),
             ],
             "an unconfigured claude session is gated as `default` (never silently bypassed), \
-             with runtime-bypass UNLOCKED but not activated, and AskUserQuestion denied \
-             (temporary — no multi-question frontend renderer yet)"
+             with runtime-bypass UNLOCKED but not activated, and AskUserQuestion ENABLED \
+             (the Ask card renders multi-question payloads)"
         );
         assert_eq!(build_claude_mcp_config(&[]), None, "no servers → no --mcp-config");
     }
@@ -3285,12 +3296,10 @@ mod tests {
                 "--permission-mode".to_string(),
                 "default".to_string(),
                 "--allow-dangerously-skip-permissions".to_string(),
-                "--disallowed-tools".to_string(),
-                "AskUserQuestion".to_string(),
             ],
             "a blank mode is gated as `default` (never silently bypassed); the unlock flag \
              is always present so a later in-band switch to bypass is accepted; \
-             AskUserQuestion is denied (temporary)"
+             AskUserQuestion is enabled (the Ask card renders multi-question payloads)"
         );
     }
 

--- a/crates/aionui-session/src/backend/codex_conn.rs
+++ b/crates/aionui-session/src/backend/codex_conn.rs
@@ -3718,6 +3718,9 @@ impl SessionBackend for CodexSessionBackend {
                     turn_gen: self.turn_gen.load(Ordering::SeqCst),
                 })
             }
+            // codex has no AskUserQuestion (its MCP elicitation degrades to a
+            // Permission with ELICIT_PREFIX); Ask is never raised here.
+            Command::AnswerAsk { .. } => Err(BackendError::CommandNotSupported { command: "answer_ask" }),
             Command::AnswerAuth { method_id, credentials } => {
                 // Mid-session re-auth (R6/R15): the server raised
                 // `account/chatgptAuthTokens/refresh` (a blocking ServerRequest the

--- a/crates/aionui-session/src/backend/conversation_session.rs
+++ b/crates/aionui-session/src/backend/conversation_session.rs
@@ -989,6 +989,7 @@ mod tests {
                     requires_action: crate::state::RequiresActionSet {
                         waiting_on_approval: if can_queue { 0 } else { 1 },
                         waiting_on_auth: 0,
+                waiting_on_question: 0,
                     },
                     subagents: Vec::new(),
                 }

--- a/crates/aionui-session/src/backend/conversation_session.rs
+++ b/crates/aionui-session/src/backend/conversation_session.rs
@@ -989,7 +989,7 @@ mod tests {
                     requires_action: crate::state::RequiresActionSet {
                         waiting_on_approval: if can_queue { 0 } else { 1 },
                         waiting_on_auth: 0,
-                waiting_on_question: 0,
+                        waiting_on_question: 0,
                     },
                     subagents: Vec::new(),
                 }

--- a/crates/aionui-session/src/backend/types.rs
+++ b/crates/aionui-session/src/backend/types.rs
@@ -176,7 +176,9 @@ pub struct PendingPermissionView {
     /// The tool the permission gates (used as the recovered card's title). May be
     /// empty if the backend did not name it.
     pub tool_name: String,
-    /// AskUserQuestion recovery: the question payload (`{questions:[…]}`) when
+    /// AskUserQuestion recovery: the BARE `questions[]` array (NOT the
+    /// `{questions:[…]}` wrapper — claude_conn stores `input.get("questions")`;
+    /// consumers re-wrap if they need the tool-input shape) when
     /// `tool_name == "AskUserQuestion"`, else `None`. Lets the REST `/confirmations`
     /// recovery path rebuild a question card symmetric to the live `ConfirmationAdded`
     /// frame (rather than degrading to an Allow/Deny permission card). Only

--- a/crates/aionui-session/src/backend/types.rs
+++ b/crates/aionui-session/src/backend/types.rs
@@ -57,6 +57,20 @@ pub enum Command {
         selected: Option<String>,
         answers: Vec<QuestionAnswer>,
     },
+    /// Answer an `Ask{request_id}` (structured question card — its own command,
+    /// NOT AnswerPermission: asking is not authorizing, 2026-08-04 ruling).
+    ///
+    /// `answers: Some(...)` = the user's per-question picks (claude wire shape,
+    /// see [`QuestionAnswer`]); `None` = the user dismissed the card without
+    /// answering. `None` MUST reach the claude adapter as a deny — claude
+    /// silently DROPS unanswered questions on an allow (not a re-ask, live
+    /// 2.1.178), so an allow-with-empty-answers is silent data loss. The
+    /// `Option` makes "declined" and "answered" unconfusable at the type level.
+    /// Backends without a question channel reject with `CommandNotSupported`.
+    AnswerAsk {
+        request_id: String,
+        answers: Option<Vec<QuestionAnswer>>,
+    },
     /// Answer a mid-session re-auth challenge (waiting_on_auth). Gated by
     /// `supported_commands.answer_auth`.
     AnswerAuth {
@@ -387,6 +401,7 @@ pub fn command_name(cmd: &Command) -> &'static str {
         Command::Cancel { .. } => "cancel",
         Command::Steer { .. } => "steer",
         Command::AnswerPermission { .. } => "answer_permission",
+        Command::AnswerAsk { .. } => "answer_ask",
         Command::AnswerAuth { .. } => "answer_auth",
         Command::Acknowledge { .. } => "acknowledge",
         Command::SetMode { .. } => "set_mode",

--- a/crates/aionui-session/src/event.rs
+++ b/crates/aionui-session/src/event.rs
@@ -280,6 +280,28 @@ pub enum SessionEvent {
         kind: PermissionKind,
     },
 
+    /// A structured question the agent asks the USER (claude `AskUserQuestion`
+    /// via `control_request{can_use_tool}`): its own event, deliberately NOT a
+    /// `Permission` — asking is not authorizing (2026-08-04 design ruling, spec
+    /// `docs/superpowers/specs/2026-08-04-askuserquestion-统一问询设计.md`).
+    /// Enters requires-action via its OWN counter (`waiting_on_question` +1),
+    /// answered by `Command::AnswerAsk` keyed on the same `request_id` (the
+    /// claude control correlation key). `questions` is the tool's raw
+    /// `{questions:[{question, header?, options:[{label, description?}],
+    /// multiSelect?}]}` payload — the SAME shape three independent vendors
+    /// converged on (claude 2.1.178 samples; qwen/grok live captures 2026-08-04),
+    /// so it doubles as the cross-backend contract without a re-mapping layer.
+    /// The reducer never reads it (ref-count on request_id only, §R9).
+    /// ⚠️ TIO-13: question text is user-facing card content, never log at info.
+    Ask {
+        request_id: String,
+        questions: serde_json::Value,
+    },
+    /// The matching resolve for `Ask` (symmetric with `PermissionResolved`,
+    /// counter `waiting_on_question` -1): emitted when the user answers
+    /// (`AnswerAsk`) or claude retracts via `control_cancel_request`.
+    AskResolved { request_id: String },
+
     // ======================================================================
     // ADDITIVE backend-produced / orchestration variants (007 §C2 / §9.0).
     // The reducer takes explicit no-op arms for ALL of these EXCEPT SubagentUpdate
@@ -899,6 +921,8 @@ pub fn classify(event: &SessionEvent) -> EventClass {
         | Plan { .. }
         | Permission { .. }
         | PermissionResolved { .. }
+        | Ask { .. }
+        | AskResolved { .. }
         | PromptAccepted { .. }
         | UsageDelta { .. }
         | Provisioning { .. }
@@ -965,6 +989,9 @@ pub fn persist_tier(event: &SessionEvent) -> PersistTier {
             Permission { .. } | PermissionResolved { .. } | Detached { .. } | PromptAccepted { .. } => {
                 PersistTier::DisplayAndState
             }
+            // same routing as Permission: the question card is history (display)
+            // AND an open-request the rebuild must re-raise (state).
+            Ask { .. } | AskResolved { .. } => PersistTier::DisplayAndState,
             SubagentUpdate { .. } => PersistTier::DisplayAndState, // roster→display; resumable→Tier2.last_subagents
             Rewound { .. } => PersistTier::State,                  // turn-truncation anchor
             AdapterSpecific { tag, .. } if is_raw_timing(tag) => PersistTier::Ephemeral,

--- a/crates/aionui-session/src/reducer.rs
+++ b/crates/aionui-session/src/reducer.rs
@@ -2101,7 +2101,7 @@ mod proptest_totality {
                     requires_action: RequiresActionSet {
                         waiting_on_approval: appr,
                         waiting_on_auth: auth,
-                waiting_on_question: 0,
+                        waiting_on_question: 0,
                     },
                     subagents: sub
                         .map(|st| {

--- a/crates/aionui-session/src/reducer.rs
+++ b/crates/aionui-session/src/reducer.rs
@@ -367,6 +367,26 @@ pub fn step(state: &SessionState, event: SessionEvent) -> (SessionState, Vec<Tra
             settle(state.clone(), to, epoch)
         }
 
+        // Ask/AskResolved: the structured-question twin of Permission/Resolved,
+        // on its OWN counter (asking is not authorizing — 2026-08-04 ruling).
+        // Mechanically identical: saturating ±1, payload never read (§R9).
+        SessionEvent::Ask { .. } => {
+            let mut to = state.clone();
+            let epoch = anchor_epoch(state);
+            if let SessionState::Running { requires_action, .. } = &mut to {
+                requires_action.waiting_on_question = requires_action.waiting_on_question.saturating_add(1);
+            }
+            settle(state.clone(), to, epoch)
+        }
+        SessionEvent::AskResolved { .. } => {
+            let mut to = state.clone();
+            let epoch = anchor_epoch(state);
+            if let SessionState::Running { requires_action, .. } = &mut to {
+                requires_action.waiting_on_question = requires_action.waiting_on_question.saturating_sub(1);
+            }
+            settle(state.clone(), to, epoch)
+        }
+
         // Opaque escape hatch (I13): count or ignore only; never inspect
         // tag/payload. P0 = ignore (no state change, no Transition).
         SessionEvent::AdapterSpecific { .. } => (state.clone(), Vec::new()),
@@ -920,6 +940,7 @@ mod tests {
             requires_action: RequiresActionSet {
                 waiting_on_approval: 1, // non-default: a rebuild would reset to 0
                 waiting_on_auth: 0,
+                waiting_on_question: 0,
             },
             subagents: Vec::new(),
         }
@@ -2080,6 +2101,7 @@ mod proptest_totality {
                     requires_action: RequiresActionSet {
                         waiting_on_approval: appr,
                         waiting_on_auth: auth,
+                waiting_on_question: 0,
                     },
                     subagents: sub
                         .map(|st| {

--- a/crates/aionui-session/src/state.rs
+++ b/crates/aionui-session/src/state.rs
@@ -68,6 +68,12 @@ pub struct RequiresActionSet {
     /// is an adapter-behavior question; the reducer structure (just a counter)
     /// accommodates both outcomes unchanged.
     pub waiting_on_auth: u32,
+    /// Pending structured questions to the user (`Ask` +1 / `AskResolved` -1,
+    /// 2026-08-04 AskUserQuestion spec). SEPARATE counter for the same reason
+    /// `waiting_on_auth` is one: "answer the agent's question" is neither a tool
+    /// approval nor a re-auth, and the UI badges them differently. Mechanically a
+    /// copy of `waiting_on_approval` — the reducer never reads the payload.
+    pub waiting_on_question: u32,
 }
 
 /// ⭐ 007 §6b b1/§9.12/§9.13: a subagent's live state in `Running.subagents`.
@@ -274,7 +280,9 @@ pub fn is_requires_action(state: &SessionState) -> bool {
     matches!(
         state,
         SessionState::Running { requires_action, .. }
-            if requires_action.waiting_on_approval > 0 || requires_action.waiting_on_auth > 0
+            if requires_action.waiting_on_approval > 0
+                || requires_action.waiting_on_auth > 0
+                || requires_action.waiting_on_question > 0
     )
 }
 
@@ -388,6 +396,7 @@ mod tests {
             requires_action: RequiresActionSet {
                 waiting_on_approval: count,
                 waiting_on_auth: 0,
+                waiting_on_question: 0,
             },
             subagents: Vec::new(),
         }
@@ -401,6 +410,7 @@ mod tests {
             requires_action: RequiresActionSet {
                 waiting_on_approval: count,
                 waiting_on_auth: 0,
+                waiting_on_question: 0,
             },
             subagents: vec![SubagentState {
                 r#ref: "sub-1".into(),

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -1334,6 +1334,7 @@ fn confirmations_factory(count: usize) -> AgentFactory {
                 action: None,
                 description: format!("Confirm tool {idx}"),
                 command_type: None,
+                questions: None,
                 options: vec![],
             })
             .collect::<Vec<_>>();


### PR DESCRIPTION
## What

Makes claude's `AskUserQuestion` a first-class capability end to end: the agent asks, the user answers a real question card, the answer reaches claude.

**Asking is not authorizing** — questions get their own event, command, FSM counter and HTTP endpoint rather than riding the permission plumbing.

| layer | contract |
|---|---|
| session event | `SessionEvent::Ask { request_id, questions }` / `AskResolved` |
| FSM | `RequiresActionSet.waiting_on_question` (saturating ±1, payload never read — §R9) |
| command | `Command::AnswerAsk { request_id, answers: Option<Vec<QuestionAnswer>> }` |
| stream frame | `AgentStreamEvent::Ask` (wire tag `ask`) |
| HTTP | `POST /api/conversations/:id/asks/:requestId/answer` |

`answers: None` means the user dismissed the card and MUST reach claude as a deny: claude silently DROPS unanswered questions on an allow (live 2.1.178), so an "empty allow" is silent data loss, not a re-ask. The `Option` makes the two unconfusable at the type level, and the route rejects an empty answer set before any dispatch.

The spawn-time `--disallowed-tools AskUserQuestion` is removed — it existed only because the frontend had no multi-question renderer, which the companion PR adds.

Backends without a question channel (ACP, codex) reject `answer_ask` with `CommandNotSupported`.

## Recovery path

`Confirmation` gains an optional `questions` field (skipped on the wire when absent, so ordinary approvals and older frontends are unaffected) so a pending question survives a reload as a real question card instead of a title-less permission card.

Two defects fixed along the way:

- `get_confirmations` fed the bare `questions[]` array to a projector that expects the whole tool input and does its own `.get("questions")`, so recovery degraded to generic Allow/AllowAlways/Reject. The old unit test passed because its fixture carried a `{questions:[…]}` wrapper `claude_conn` never stores — self-consistent green against an unreal shape.
- `answer_permission` unconditionally emitted `PermissionResolved`. A recovered ask is answered through that path, so `waiting_on_approval` was decremented while the ask's `waiting_on_question` stayed pinned above zero — locking `can_send` forever after a recovered ask was answered. It now resolves by pending `tool_name`.

`to_confirmation()` also stopped dumping the whole `raw_input` through `Value::to_string()` into a card's description (a wall of one-line JSON for agents that smuggle structured data through the permission channel); the structured `questions` ride along instead, shape-keyed — only a non-empty array whose entries all carry `question` + `options` qualifies, so no per-agent branching.

## Verification

- `cargo nextest -p aionui-session`: 531 passed
- `cargo nextest -p aionui-ai-agent`: 930 passed
- `cargo nextest -p aionui-app -E 'test(answer_ask) or test(confirm)'`: 10 passed — bad paths: 404 without an active agent, 400 for an empty answer set, 400 for decline+answers together
- `cargo clippy --all-targets -D warnings` on every touched crate, `cargo fmt --all`, migration-check: clean
- **Full-workspace `cargo nextest` intentionally skipped** at the requester's instruction; every other `just push` gate step ran.

Live e2e through the real AionUi UI (claude 2.1.x, isolated instance), each verified by claude restating the answer back:

- single-select, multi-question mixed single/multi (three questions answered in one submit, all three restated — no silent drop), dismissal (claude received the deny and said so)
- e2e also caught two of the defects above plus a `multiSelect` loss fixed in the companion PR

## Logging

`info` lifecycle markers on both answer paths (dispatch written to stdin / dispatch failed after the REST reply already returned success) — the "user answered but claude never resumed" wedge class is undiagnosable without them. Question text is user-facing card content and is never logged (TIO-13).

## Companion

Frontend: iOfficeAI/AionUi#3856 — the multi-question card, the dedicated answer channel client, and the readable raw-input fallback.