### PR TITLE
feat(acp): client-hosted terminals — declare clientCapabilities.terminal and serve terminal/*

### DIFF
--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -20,7 +20,6 @@ pub mod manager;
 /// shape the `SessionBackend` stack carries in `SessionConfig.init.mcp_servers`.
 pub(crate) mod mcp_resolve;
 pub mod media;
-pub mod terminal;
 pub(crate) mod persistence;
 pub mod protocol;
 pub mod registry;
@@ -32,6 +31,7 @@ pub mod session_agent;
 pub mod session_context;
 pub mod shared_kernel;
 pub mod task_manager;
+pub mod terminal;
 pub mod types;
 mod workflow_progress;
 

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -20,6 +20,7 @@ pub mod manager;
 /// shape the `SessionBackend` stack carries in `SessionConfig.init.mcp_servers`.
 pub(crate) mod mcp_resolve;
 pub mod media;
+pub mod terminal;
 pub(crate) mod persistence;
 pub mod protocol;
 pub mod registry;

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -664,6 +664,13 @@ impl AcpAgentManager {
         runtime.bump_activity();
     }
 
+    /// User-initiated stop of one client-hosted terminal (the terminal
+    /// card's stop button). Returns false when the id is unknown (already
+    /// released or never ours).
+    pub async fn kill_client_terminal(&self, terminal_id: &str) -> bool {
+        self.protocol.terminal_registry().kill(terminal_id, "user").await
+    }
+
     fn ensure_protocol_connected_for_operation(&self, operation: &'static str) -> Result<(), AgentError> {
         if self.protocol.is_connected() {
             return Ok(());

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -223,6 +223,7 @@ async fn spawn_and_connect_acp_once(
         permission_tx,
         notification_tx,
         &params.conversation_id,
+        Some(std::path::PathBuf::from(&params.workspace.path)),
     );
     tokio::pin!(connect_fut);
     let protocol = tokio::select! {

--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -216,7 +216,14 @@ async fn spawn_and_connect_acp_once(
     // 70ms in — ELECTRON-1BT), so we explicitly watch the child. If
     // it dies before init completes, surface a `StartupCrash` carrying
     // the buffered stderr instead of waiting out the timeout.
-    let connect_fut = AcpProtocol::connect(stdin, stdout, runtime.event_sender(), permission_tx, notification_tx);
+    let connect_fut = AcpProtocol::connect(
+        stdin,
+        stdout,
+        runtime.event_sender(),
+        permission_tx,
+        notification_tx,
+        &params.conversation_id,
+    );
     tokio::pin!(connect_fut);
     let protocol = tokio::select! {
         biased;

--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -27,10 +27,14 @@ use std::sync::{Arc, Mutex, RwLock};
 
 use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::schema::v1::{
-    AGENT_METHOD_NAMES, AuthenticateResponse, ClientNotification, ClientRequest, CloseSessionResponse, ExtResponse,
-    ForkSessionResponse, Implementation, InitializeRequest, LoadSessionResponse, PromptResponse,
-    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse, ResumeSessionResponse,
-    SelectedPermissionOutcome, SessionNotification, SetSessionConfigOptionResponse, SetSessionModeResponse,
+    AGENT_METHOD_NAMES, AuthenticateResponse, ClientCapabilities, ClientNotification, ClientRequest,
+    ClientSessionCapabilities, CloseSessionResponse, CreateTerminalRequest, CreateTerminalResponse, ExtResponse,
+    ForkSessionResponse, Implementation, InitializeRequest, KillTerminalRequest, KillTerminalResponse,
+    LoadSessionResponse, PromptResponse, ReleaseTerminalRequest, ReleaseTerminalResponse, RequestPermissionOutcome,
+    RequestPermissionRequest, RequestPermissionResponse, ResumeSessionResponse, SelectedPermissionOutcome,
+    SessionConfigOptionsCapabilities, SessionNotification, SetSessionConfigOptionResponse, SetSessionModeResponse,
+    TerminalExitStatus, TerminalOutputRequest, TerminalOutputResponse, WaitForTerminalExitRequest,
+    WaitForTerminalExitResponse,
 };
 use agent_client_protocol::{
     Agent, Client, ConnectionTo, Lines, Responder, UntypedMessage, on_receive_notification, on_receive_request,
@@ -91,8 +95,22 @@ enum AcpConnectionPhase {
 /// non-empty name and version so downstream agents that require client metadata
 /// (e.g. Mistral Vibe) accept the request. See issue #3326.
 fn build_initialize_request() -> InitializeRequest {
+    // Advertised client services:
+    // - terminal: full `terminal/*` suite backed by TerminalRegistry —
+    //   delegated commands run in OUR process tree (live output, per-command
+    //   kill, audit logging). Adoption probed 2026-08-05: codebuddy/grok/omp.
+    // - session.config_options: we already consume `config_option_update`
+    //   and render the options UI; declaring it stops strictly-capability-
+    //   gated agents from withholding their config options.
+    // fs stays undeclared (P2).
+    let mut session_caps = ClientSessionCapabilities::default();
+    session_caps.config_options = Some(SessionConfigOptionsCapabilities::default());
+    let mut caps = ClientCapabilities::default();
+    caps.terminal = true;
+    caps.session = Some(session_caps);
     InitializeRequest::new(ProtocolVersion::LATEST)
         .client_info(Implementation::new(ACP_CLIENT_NAME, ACP_CLIENT_VERSION))
+        .client_capabilities(caps)
 }
 
 /// A pending permission request from the agent, awaiting user decision.
@@ -139,6 +157,10 @@ pub struct AcpProtocol {
     /// Owned by the outer struct; an `Arc` clone is captured by the SDK
     /// background task's `on_receive_notification` closure.
     replay_suppression: Arc<AtomicBool>,
+    /// Client-hosted terminals for this connection (ACP `terminal/*`).
+    /// Shared with the SDK background task's request handlers; torn down
+    /// (all processes killed) when the protocol drops.
+    terminal_registry: Arc<crate::terminal::TerminalRegistry>,
 }
 
 #[allow(dead_code)] // Full ACP method set; some methods await wiring (fork, close, list, auth, ext).
@@ -154,9 +176,11 @@ impl AcpProtocol {
         event_tx: broadcast::Sender<AgentStreamEvent>,
         permission_tx: mpsc::Sender<PermissionRequest>,
         notification_tx: mpsc::Sender<SessionNotification>,
+        terminal_label: &str,
     ) -> Result<Self, AcpError> {
         let alive = Arc::new(AtomicBool::new(true));
         let replay_suppression = Arc::new(AtomicBool::new(false));
+        let terminal_registry = Arc::new(crate::terminal::TerminalRegistry::new(terminal_label));
         let started_at = std::time::Instant::now();
         log_acp_initialize_start();
 
@@ -182,6 +206,7 @@ impl AcpProtocol {
             shutdown_rx,
             Arc::clone(&alive),
             Arc::clone(&replay_suppression),
+            Arc::clone(&terminal_registry),
         ));
 
         // Wait for init to complete with timeout.
@@ -220,11 +245,17 @@ impl AcpProtocol {
             alive,
             initialize_response: Arc::new(RwLock::new(Some(init_response))),
             replay_suppression,
+            terminal_registry,
         })
     }
 
     pub fn initialize_response(&self) -> Option<InitializeResponse> {
         self.initialize_response.read().unwrap().clone()
+    }
+
+    /// Client-hosted terminals of this connection (for UI queries / kill).
+    pub fn terminal_registry(&self) -> Arc<crate::terminal::TerminalRegistry> {
+        Arc::clone(&self.terminal_registry)
     }
 
     pub fn agent_capabilities(&self) -> Option<AgentCapabilities> {
@@ -527,6 +558,11 @@ impl AcpProtocol {
 
 impl Drop for AcpProtocol {
     fn drop(&mut self) {
+        // Tear down every client-hosted terminal with the connection: an
+        // orphaned delegated command must not outlive its agent. Drop can't
+        // await, so hand the kill sweep to the runtime.
+        let registry = Arc::clone(&self.terminal_registry);
+        tokio::spawn(async move { registry.kill_all().await });
         // Releasing the oneshot wakes `main_fn` in the background task, which
         // returns, which drives SDK shutdown. The bg_task joins naturally
         // (we don't await it here — Drop can't be async; the task is
@@ -577,6 +613,7 @@ async fn run_sdk_background(
     shutdown_rx: oneshot::Receiver<()>,
     alive: Arc<AtomicBool>,
     replay_suppression: Arc<AtomicBool>,
+    terminal_registry: Arc<crate::terminal::TerminalRegistry>,
 ) {
     // Tolerant transport: intercept incoming lines *before* the SDK parses them
     // so CodeBuddy's non-standard dialect notifications (`session_end` /
@@ -658,6 +695,58 @@ async fn run_sdk_background(
             {
                 async move |request: RequestPermissionRequest, responder, _cx| {
                     handle_permission_request(request, responder, &permission_tx).await;
+                    Ok(())
+                }
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let registry = Arc::clone(&terminal_registry);
+                let event_tx = event_tx.clone();
+                async move |request: CreateTerminalRequest, responder, _cx| {
+                    handle_terminal_create(request, responder, &registry, &event_tx).await;
+                    Ok(())
+                }
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let registry = Arc::clone(&terminal_registry);
+                async move |request: TerminalOutputRequest, responder, _cx| {
+                    handle_terminal_output(request, responder, &registry).await;
+                    Ok(())
+                }
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let registry = Arc::clone(&terminal_registry);
+                let event_tx = event_tx.clone();
+                async move |request: WaitForTerminalExitRequest, responder, _cx| {
+                    handle_terminal_wait(request, responder, &registry, &event_tx).await;
+                    Ok(())
+                }
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let registry = Arc::clone(&terminal_registry);
+                async move |request: KillTerminalRequest, responder, _cx| {
+                    handle_terminal_kill(request, responder, &registry).await;
+                    Ok(())
+                }
+            },
+            on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let registry = Arc::clone(&terminal_registry);
+                async move |request: ReleaseTerminalRequest, responder, _cx| {
+                    handle_terminal_release(request, responder, &registry).await;
                     Ok(())
                 }
             },
@@ -764,6 +853,143 @@ async fn handle_permission_request(
 
     log_client_response("session/request_permission", &json_str(&response));
     let _ = responder.respond(response);
+}
+
+/// Convert a registry exit into the wire `TerminalExitStatus`.
+fn wire_exit_status(exit: crate::terminal::TerminalExit) -> TerminalExitStatus {
+    let mut status = TerminalExitStatus::new();
+    status.exit_code = exit.exit_code;
+    if exit.signaled {
+        status.signal = Some("SIGKILL".into());
+    }
+    status
+}
+
+/// Broadcast one terminal snapshot to the UI event channel.
+async fn emit_terminal_snapshot(
+    registry: &crate::terminal::TerminalRegistry,
+    terminal_id: &str,
+    event_tx: &broadcast::Sender<AgentStreamEvent>,
+) -> bool {
+    let Some(snap) = registry.output(terminal_id).await else {
+        return false;
+    };
+    let command = registry.command_line(terminal_id).await.unwrap_or_default();
+    let done = snap.exit.is_some();
+    let _ = event_tx.send(AgentStreamEvent::AcpTerminalOutput(serde_json::json!({
+        "terminal_id": terminal_id,
+        "command": command,
+        "output": snap.output,
+        "truncated": snap.truncated,
+        "exit_status": snap.exit.map(|e| serde_json::json!({
+            "exit_code": e.exit_code,
+            "signaled": e.signaled,
+        })),
+    })));
+    done
+}
+
+async fn handle_terminal_create(
+    request: CreateTerminalRequest,
+    responder: Responder<CreateTerminalResponse>,
+    registry: &Arc<crate::terminal::TerminalRegistry>,
+    event_tx: &broadcast::Sender<AgentStreamEvent>,
+) {
+    log_agent_request("terminal/create", &json_str(&request));
+    let params = crate::terminal::CreateTerminalParams {
+        command: request.command.clone(),
+        args: request.args.clone(),
+        env: request.env.iter().map(|v| (v.name.clone(), v.value.clone())).collect(),
+        cwd: request.cwd.clone(),
+        output_byte_limit: request.output_byte_limit,
+    };
+    match registry.create(params).await {
+        Ok(terminal_id) => {
+            // UI stream: push throttled snapshots until the command exits.
+            // The agent-side contract stays pull-based (`terminal/output`);
+            // this task only feeds our own frontend.
+            let poll_registry = Arc::clone(registry);
+            let poll_event_tx = event_tx.clone();
+            let poll_id = terminal_id.clone();
+            tokio::spawn(async move {
+                loop {
+                    let done = emit_terminal_snapshot(&poll_registry, &poll_id, &poll_event_tx).await;
+                    if done {
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                }
+            });
+            let response = CreateTerminalResponse::new(terminal_id);
+            log_client_response("terminal/create", &json_str(&response));
+            let _ = responder.respond(response);
+        }
+        Err(err) => {
+            warn!(error = %err, "terminal/create failed");
+            let _ = responder.respond_with_internal_error(err);
+        }
+    }
+}
+
+async fn handle_terminal_output(
+    request: TerminalOutputRequest,
+    responder: Responder<TerminalOutputResponse>,
+    registry: &Arc<crate::terminal::TerminalRegistry>,
+) {
+    match registry.output(&request.terminal_id.to_string()).await {
+        Some(snap) => {
+            let mut response = TerminalOutputResponse::new(snap.output, snap.truncated);
+            response.exit_status = snap.exit.map(wire_exit_status);
+            let _ = responder.respond(response);
+        }
+        None => {
+            let _ = responder.respond_with_internal_error(format!("unknown terminal: {}", request.terminal_id));
+        }
+    }
+}
+
+async fn handle_terminal_wait(
+    request: WaitForTerminalExitRequest,
+    responder: Responder<WaitForTerminalExitResponse>,
+    registry: &Arc<crate::terminal::TerminalRegistry>,
+    event_tx: &broadcast::Sender<AgentStreamEvent>,
+) {
+    let terminal_id = request.terminal_id.to_string();
+    match registry.wait_for_exit(&terminal_id).await {
+        Some(exit) => {
+            // Make sure the UI sees the terminal frame even if the poller
+            // lost a race with process exit.
+            emit_terminal_snapshot(registry, &terminal_id, event_tx).await;
+            let response = WaitForTerminalExitResponse::new(wire_exit_status(exit));
+            let _ = responder.respond(response);
+        }
+        None => {
+            let _ = responder.respond_with_internal_error(format!("unknown terminal: {terminal_id}"));
+        }
+    }
+}
+
+async fn handle_terminal_kill(
+    request: KillTerminalRequest,
+    responder: Responder<KillTerminalResponse>,
+    registry: &Arc<crate::terminal::TerminalRegistry>,
+) {
+    if registry.kill(&request.terminal_id.to_string(), "agent").await {
+        let _ = responder.respond(KillTerminalResponse::new());
+    } else {
+        let _ = responder.respond_with_internal_error(format!("unknown terminal: {}", request.terminal_id));
+    }
+}
+
+async fn handle_terminal_release(
+    request: ReleaseTerminalRequest,
+    responder: Responder<ReleaseTerminalResponse>,
+    registry: &Arc<crate::terminal::TerminalRegistry>,
+) {
+    registry.release(&request.terminal_id.to_string()).await;
+    // Release is idempotent on the wire: an unknown id still gets a success
+    // response (the agent's intent — "this terminal is gone" — holds).
+    let _ = responder.respond(ReleaseTerminalResponse::new());
 }
 
 /// Serialize a value to a compact JSON string, falling back to Debug on failure.
@@ -1330,5 +1556,19 @@ mod tests {
             completed.load(Ordering::SeqCst),
             "timed-out config RPC task must survive the timeout (detached, not aborted)"
         );
+    }
+
+    #[test]
+    fn initialize_request_declares_terminal_and_config_options_capabilities() {
+        let req = build_initialize_request();
+        let v = serde_json::to_value(&req).unwrap();
+        assert_eq!(v["clientCapabilities"]["terminal"], serde_json::json!(true));
+        assert!(
+            v["clientCapabilities"]["session"]["configOptions"].is_object(),
+            "session.configOptions must be declared: {v}"
+        );
+        // fs stays undeclared in P1 (read service is P2).
+        assert_eq!(v["clientCapabilities"]["fs"]["readTextFile"], serde_json::json!(false));
+        assert_eq!(v["clientCapabilities"]["fs"]["writeTextFile"], serde_json::json!(false));
     }
 }

--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -177,10 +177,11 @@ impl AcpProtocol {
         permission_tx: mpsc::Sender<PermissionRequest>,
         notification_tx: mpsc::Sender<SessionNotification>,
         terminal_label: &str,
+        terminal_cwd: Option<std::path::PathBuf>,
     ) -> Result<Self, AcpError> {
         let alive = Arc::new(AtomicBool::new(true));
         let replay_suppression = Arc::new(AtomicBool::new(false));
-        let terminal_registry = Arc::new(crate::terminal::TerminalRegistry::new(terminal_label));
+        let terminal_registry = Arc::new(crate::terminal::TerminalRegistry::new(terminal_label, terminal_cwd));
         let started_at = std::time::Instant::now();
         log_acp_initialize_start();
 

--- a/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
+++ b/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
@@ -196,7 +196,7 @@ async fn run_handshake(proc: &CliAgentProcess) -> ProbeOutcome {
     // almost immediately with a non-zero status; without this race the
     // `AcpProtocol::connect` call would block on its internal 30 s
     // timeout waiting for an `initialize` reply that will never arrive.
-    let connect = AcpProtocol::connect(stdin, stdout, event_tx, permission_tx, notification_tx);
+    let connect = AcpProtocol::connect(stdin, stdout, event_tx, permission_tx, notification_tx, "custom-agent-probe");
     let protocol = tokio::select! {
         biased;
         res = connect => match res {

--- a/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
+++ b/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
@@ -196,7 +196,14 @@ async fn run_handshake(proc: &CliAgentProcess) -> ProbeOutcome {
     // almost immediately with a non-zero status; without this race the
     // `AcpProtocol::connect` call would block on its internal 30 s
     // timeout waiting for an `initialize` reply that will never arrive.
-    let connect = AcpProtocol::connect(stdin, stdout, event_tx, permission_tx, notification_tx, "custom-agent-probe");
+    let connect = AcpProtocol::connect(
+        stdin,
+        stdout,
+        event_tx,
+        permission_tx,
+        notification_tx,
+        "custom-agent-probe",
+    );
     let protocol = tokio::select! {
         biased;
         res = connect => match res {

--- a/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
+++ b/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
@@ -203,6 +203,7 @@ async fn run_handshake(proc: &CliAgentProcess) -> ProbeOutcome {
         permission_tx,
         notification_tx,
         "custom-agent-probe",
+        None,
     );
     let protocol = tokio::select! {
         biased;

--- a/crates/aionui-ai-agent/src/protocol/events/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/events/mod.rs
@@ -45,6 +45,11 @@ pub enum AgentStreamEvent {
     AcpConfigOption(serde_json::Value),
     AcpSessionInfo(serde_json::Value),
     AcpContextUsage(serde_json::Value),
+    /// Live snapshot of a client-hosted terminal (ACP `terminal/*`):
+    /// `{terminal_id, command, output(cumulative), truncated, exit_status?}`.
+    /// Emitted throttled while the delegated command runs, plus one final
+    /// frame when it exits.
+    AcpTerminalOutput(serde_json::Value),
     AcpPromptHookWarning(serde_json::Value),
     SlashCommandsUpdated(serde_json::Value),
     AvailableCommands(AvailableCommandsEventData),

--- a/crates/aionui-ai-agent/src/terminal.rs
+++ b/crates/aionui-ai-agent/src/terminal.rs
@@ -1,0 +1,361 @@
+//! Client-hosted terminal service backing the ACP `terminal/*` methods.
+//!
+//! When the initialize handshake advertises `clientCapabilities.terminal`,
+//! an agent may delegate command execution to us: `terminal/create` spawns
+//! the process HERE (via the runtime spawn Builder), the agent polls
+//! `terminal/output` / awaits `terminal/wait_for_exit`, and either side can
+//! `terminal/kill`. We own the process and the output buffer, so the UI can
+//! stream output live and the user can stop a single command without
+//! killing the agent.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::io::AsyncReadExt;
+use tokio::process::Child;
+use tokio::sync::{Mutex, watch};
+use tracing::{info, warn};
+
+/// Default retained-output cap when the agent does not send
+/// `outputByteLimit` (protocol: truncate from the FRONT, at char boundary).
+pub const DEFAULT_OUTPUT_BYTE_LIMIT: u64 = 1024 * 1024;
+
+/// Terminal command exit outcome (mirrors ACP `TerminalExitStatus`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TerminalExit {
+    pub exit_code: Option<u32>,
+    /// Present when terminated by signal (e.g. user stop → SIGKILL).
+    pub signaled: bool,
+}
+
+/// Snapshot returned by [`TerminalRegistry::output`].
+#[derive(Debug, Clone)]
+pub struct TerminalOutputSnapshot {
+    pub output: String,
+    pub truncated: bool,
+    pub exit: Option<TerminalExit>,
+}
+
+struct TerminalEntry {
+    /// Held for kill; `None` after the reaper task consumed it on exit.
+    child: Arc<Mutex<Option<Child>>>,
+    buffer: Arc<Mutex<OutputBuffer>>,
+    exit_rx: watch::Receiver<Option<TerminalExit>>,
+    command_line: String,
+}
+
+struct OutputBuffer {
+    data: String,
+    truncated: bool,
+    limit: usize,
+}
+
+impl OutputBuffer {
+    fn push(&mut self, chunk: &str) {
+        self.data.push_str(chunk);
+        if self.data.len() > self.limit {
+            // Truncate from the beginning at a char boundary (protocol MUST).
+            let mut cut = self.data.len() - self.limit;
+            while !self.data.is_char_boundary(cut) {
+                cut += 1;
+            }
+            self.data.drain(..cut);
+            self.truncated = true;
+        }
+    }
+}
+
+/// All live terminals of ONE agent connection. Dropped/`kill_all`-ed with it.
+#[derive(Default)]
+pub struct TerminalRegistry {
+    entries: Mutex<HashMap<String, TerminalEntry>>,
+    next_id: AtomicU64,
+}
+
+/// Parameters for [`TerminalRegistry::create`] (decoded from
+/// `terminal/create`).
+pub struct CreateTerminalParams {
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
+    pub cwd: Option<std::path::PathBuf>,
+    pub output_byte_limit: Option<u64>,
+}
+
+impl TerminalRegistry {
+    /// Spawn the command and register a terminal for it.
+    pub async fn create(&self, conversation_id: &str, params: CreateTerminalParams) -> Result<String, String> {
+        let mut builder = aionui_runtime::Builder::new(&params.command);
+        builder
+            .args(&params.args)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        for (k, v) in &params.env {
+            builder.env(k, v);
+        }
+        if let Some(cwd) = &params.cwd {
+            builder.current_dir(cwd);
+        }
+        let mut child = builder.spawn().map_err(|e| format!("spawn failed: {e}"))?;
+
+        let id = format!("aionui-term-{}", self.next_id.fetch_add(1, Ordering::Relaxed) + 1);
+        let command_line = std::iter::once(params.command.as_str())
+            .chain(params.args.iter().map(String::as_str))
+            .collect::<Vec<_>>()
+            .join(" ");
+        info!(
+            conversation_id,
+            terminal_id = %id,
+            command = %command_line,
+            "client terminal created"
+        );
+
+        let limit = params.output_byte_limit.unwrap_or(DEFAULT_OUTPUT_BYTE_LIMIT) as usize;
+        let buffer = Arc::new(Mutex::new(OutputBuffer {
+            data: String::new(),
+            truncated: false,
+            limit: limit.max(1),
+        }));
+        let (exit_tx, exit_rx) = watch::channel(None);
+
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+        let child = Arc::new(Mutex::new(Some(child)));
+
+        // Reader + reaper task: drain both streams into the ring buffer,
+        // then reap the child and publish the exit status.
+        let task_buffer = Arc::clone(&buffer);
+        let task_child = Arc::clone(&child);
+        let task_id = id.clone();
+        tokio::spawn(async move {
+            let mut out = stdout;
+            let mut err = stderr;
+            let mut out_buf = [0u8; 8192];
+            let mut err_buf = [0u8; 8192];
+            let mut out_open = out.is_some();
+            let mut err_open = err.is_some();
+            while out_open || err_open {
+                tokio::select! {
+                    r = async { out.as_mut().unwrap().read(&mut out_buf).await }, if out_open => {
+                        match r {
+                            Ok(0) | Err(_) => out_open = false,
+                            Ok(n) => task_buffer.lock().await.push(&String::from_utf8_lossy(&out_buf[..n])),
+                        }
+                    }
+                    r = async { err.as_mut().unwrap().read(&mut err_buf).await }, if err_open => {
+                        match r {
+                            Ok(0) | Err(_) => err_open = false,
+                            Ok(n) => task_buffer.lock().await.push(&String::from_utf8_lossy(&err_buf[..n])),
+                        }
+                    }
+                }
+            }
+            // Streams closed — reap. Take the child out so kill() after exit
+            // is a no-op.
+            let taken = task_child.lock().await.take();
+            let exit = match taken {
+                Some(mut c) => match c.wait().await {
+                    Ok(status) => {
+                        #[cfg(unix)]
+                        let signaled = {
+                            use std::os::unix::process::ExitStatusExt as _;
+                            status.signal().is_some()
+                        };
+                        #[cfg(not(unix))]
+                        let signaled = false;
+                        TerminalExit {
+                            exit_code: status.code().map(|c| c as u32),
+                            signaled,
+                        }
+                    }
+                    Err(e) => {
+                        warn!(terminal_id = %task_id, error = %e, "terminal wait failed");
+                        TerminalExit {
+                            exit_code: None,
+                            signaled: false,
+                        }
+                    }
+                },
+                None => TerminalExit {
+                    exit_code: None,
+                    signaled: true,
+                },
+            };
+            let _ = exit_tx.send(Some(exit));
+        });
+
+        self.entries.lock().await.insert(
+            id.clone(),
+            TerminalEntry {
+                child,
+                buffer,
+                exit_rx,
+                command_line,
+            },
+        );
+        Ok(id)
+    }
+
+    /// Current output snapshot (protocol `terminal/output`).
+    pub async fn output(&self, terminal_id: &str) -> Option<TerminalOutputSnapshot> {
+        let entries = self.entries.lock().await;
+        let entry = entries.get(terminal_id)?;
+        let buf = entry.buffer.lock().await;
+        Some(TerminalOutputSnapshot {
+            output: buf.data.clone(),
+            truncated: buf.truncated,
+            exit: *entry.exit_rx.borrow(),
+        })
+    }
+
+    /// The command line a terminal is running (for UI display).
+    pub async fn command_line(&self, terminal_id: &str) -> Option<String> {
+        let entries = self.entries.lock().await;
+        Some(entries.get(terminal_id)?.command_line.clone())
+    }
+
+    /// Await command completion (protocol `terminal/wait_for_exit`).
+    pub async fn wait_for_exit(&self, terminal_id: &str) -> Option<TerminalExit> {
+        let mut rx = {
+            let entries = self.entries.lock().await;
+            entries.get(terminal_id)?.exit_rx.clone()
+        };
+        loop {
+            if let Some(exit) = *rx.borrow() {
+                return Some(exit);
+            }
+            if rx.changed().await.is_err() {
+                return (*rx.borrow()).or(Some(TerminalExit {
+                    exit_code: None,
+                    signaled: true,
+                }));
+            }
+        }
+    }
+
+    /// Force-kill the command (protocol `terminal/kill`, also the user's
+    /// stop button). The terminal stays registered so output/exit status
+    /// remain queryable until `release`.
+    pub async fn kill(&self, terminal_id: &str, source: &str) -> bool {
+        let child = {
+            let entries = self.entries.lock().await;
+            match entries.get(terminal_id) {
+                Some(e) => Arc::clone(&e.child),
+                None => return false,
+            }
+        };
+        let mut guard = child.lock().await;
+        if let Some(c) = guard.as_mut() {
+            info!(terminal_id, source, "client terminal killed");
+            let _ = aionui_runtime::kill_process_tree(c).await;
+        }
+        true
+    }
+
+    /// Kill (if still running) and forget the terminal (protocol
+    /// `terminal/release`).
+    pub async fn release(&self, terminal_id: &str) -> bool {
+        let entry = self.entries.lock().await.remove(terminal_id);
+        match entry {
+            Some(entry) => {
+                let mut guard = entry.child.lock().await;
+                if let Some(c) = guard.as_mut() {
+                    let _ = aionui_runtime::kill_process_tree(c).await;
+                }
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Tear down every terminal (agent kill / conversation delete).
+    pub async fn kill_all(&self) {
+        let ids: Vec<String> = self.entries.lock().await.keys().cloned().collect();
+        if !ids.is_empty() {
+            info!(count = ids.len(), "tearing down all client terminals");
+        }
+        for id in ids {
+            self.release(&id).await;
+        }
+    }
+
+    /// Ids of all live (not yet released) terminals.
+    pub async fn ids(&self) -> Vec<String> {
+        self.entries.lock().await.keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn params(cmd: &str, args: &[&str]) -> CreateTerminalParams {
+        CreateTerminalParams {
+            command: cmd.into(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            env: vec![],
+            cwd: None,
+            output_byte_limit: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn create_runs_command_and_reports_output_and_exit() {
+        let reg = TerminalRegistry::default();
+        let id = reg.create("conv-t", params("echo", &["hello_term"])).await.unwrap();
+        let exit = reg.wait_for_exit(&id).await.unwrap();
+        assert_eq!(exit.exit_code, Some(0));
+        assert!(!exit.signaled);
+        let snap = reg.output(&id).await.unwrap();
+        assert!(snap.output.contains("hello_term"));
+        assert!(!snap.truncated);
+        assert!(snap.exit.is_some());
+    }
+
+    #[tokio::test]
+    async fn output_byte_limit_truncates_from_front() {
+        let reg = TerminalRegistry::default();
+        let mut p = params("sh", &["-c", "printf 'AAAA'; printf 'BBBB'"]);
+        p.output_byte_limit = Some(4);
+        let id = reg.create("conv-t", p).await.unwrap();
+        reg.wait_for_exit(&id).await.unwrap();
+        let snap = reg.output(&id).await.unwrap();
+        assert_eq!(snap.output, "BBBB");
+        assert!(snap.truncated);
+    }
+
+    #[tokio::test]
+    async fn kill_terminates_long_command_with_signal() {
+        let reg = TerminalRegistry::default();
+        let id = reg.create("conv-t", params("sleep", &["30"])).await.unwrap();
+        assert!(reg.kill(&id, "test").await);
+        let exit = reg.wait_for_exit(&id).await.unwrap();
+        assert!(exit.signaled || exit.exit_code.is_none() || exit.exit_code != Some(0));
+        // Still queryable until release.
+        assert!(reg.output(&id).await.is_some());
+        assert!(reg.release(&id).await);
+        assert!(reg.output(&id).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn release_is_idempotent_and_kill_all_clears() {
+        let reg = TerminalRegistry::default();
+        let id1 = reg.create("conv-t", params("sleep", &["30"])).await.unwrap();
+        let _id2 = reg.create("conv-t", params("sleep", &["30"])).await.unwrap();
+        assert!(reg.release(&id1).await);
+        assert!(!reg.release(&id1).await);
+        reg.kill_all().await;
+        assert!(reg.ids().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn unknown_terminal_id_is_none_or_false() {
+        let reg = TerminalRegistry::default();
+        assert!(reg.output("nope").await.is_none());
+        assert!(reg.wait_for_exit("nope").await.is_none());
+        assert!(!reg.kill("nope", "test").await);
+        assert!(!reg.release("nope").await);
+    }
+}

--- a/crates/aionui-ai-agent/src/terminal.rs
+++ b/crates/aionui-ai-agent/src/terminal.rs
@@ -71,6 +71,17 @@ impl OutputBuffer {
 pub struct TerminalRegistry {
     entries: Mutex<HashMap<String, TerminalEntry>>,
     next_id: AtomicU64,
+    /// Log correlation label (the owning conversation id; empty for probes).
+    label: String,
+}
+
+impl TerminalRegistry {
+    pub fn new(label: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            ..Self::default()
+        }
+    }
 }
 
 /// Parameters for [`TerminalRegistry::create`] (decoded from
@@ -85,7 +96,7 @@ pub struct CreateTerminalParams {
 
 impl TerminalRegistry {
     /// Spawn the command and register a terminal for it.
-    pub async fn create(&self, conversation_id: &str, params: CreateTerminalParams) -> Result<String, String> {
+    pub async fn create(&self, params: CreateTerminalParams) -> Result<String, String> {
         let mut builder = aionui_runtime::Builder::new(&params.command);
         builder
             .args(&params.args)
@@ -106,7 +117,7 @@ impl TerminalRegistry {
             .collect::<Vec<_>>()
             .join(" ");
         info!(
-            conversation_id,
+            conversation_id = %self.label,
             terminal_id = %id,
             command = %command_line,
             "client terminal created"
@@ -303,8 +314,8 @@ mod tests {
 
     #[tokio::test]
     async fn create_runs_command_and_reports_output_and_exit() {
-        let reg = TerminalRegistry::default();
-        let id = reg.create("conv-t", params("echo", &["hello_term"])).await.unwrap();
+        let reg = TerminalRegistry::new("conv-t");
+        let id = reg.create(params("echo", &["hello_term"])).await.unwrap();
         let exit = reg.wait_for_exit(&id).await.unwrap();
         assert_eq!(exit.exit_code, Some(0));
         assert!(!exit.signaled);
@@ -316,10 +327,10 @@ mod tests {
 
     #[tokio::test]
     async fn output_byte_limit_truncates_from_front() {
-        let reg = TerminalRegistry::default();
+        let reg = TerminalRegistry::new("conv-t");
         let mut p = params("sh", &["-c", "printf 'AAAA'; printf 'BBBB'"]);
         p.output_byte_limit = Some(4);
-        let id = reg.create("conv-t", p).await.unwrap();
+        let id = reg.create(p).await.unwrap();
         reg.wait_for_exit(&id).await.unwrap();
         let snap = reg.output(&id).await.unwrap();
         assert_eq!(snap.output, "BBBB");
@@ -328,8 +339,8 @@ mod tests {
 
     #[tokio::test]
     async fn kill_terminates_long_command_with_signal() {
-        let reg = TerminalRegistry::default();
-        let id = reg.create("conv-t", params("sleep", &["30"])).await.unwrap();
+        let reg = TerminalRegistry::new("conv-t");
+        let id = reg.create(params("sleep", &["30"])).await.unwrap();
         assert!(reg.kill(&id, "test").await);
         let exit = reg.wait_for_exit(&id).await.unwrap();
         assert!(exit.signaled || exit.exit_code.is_none() || exit.exit_code != Some(0));
@@ -341,9 +352,9 @@ mod tests {
 
     #[tokio::test]
     async fn release_is_idempotent_and_kill_all_clears() {
-        let reg = TerminalRegistry::default();
-        let id1 = reg.create("conv-t", params("sleep", &["30"])).await.unwrap();
-        let _id2 = reg.create("conv-t", params("sleep", &["30"])).await.unwrap();
+        let reg = TerminalRegistry::new("conv-t");
+        let id1 = reg.create(params("sleep", &["30"])).await.unwrap();
+        let _id2 = reg.create(params("sleep", &["30"])).await.unwrap();
         assert!(reg.release(&id1).await);
         assert!(!reg.release(&id1).await);
         reg.kill_all().await;
@@ -352,7 +363,7 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_terminal_id_is_none_or_false() {
-        let reg = TerminalRegistry::default();
+        let reg = TerminalRegistry::new("conv-t");
         assert!(reg.output("nope").await.is_none());
         assert!(reg.wait_for_exit("nope").await.is_none());
         assert!(!reg.kill("nope", "test").await);

--- a/crates/aionui-ai-agent/src/terminal.rs
+++ b/crates/aionui-ai-agent/src/terminal.rs
@@ -38,10 +38,12 @@ pub struct TerminalOutputSnapshot {
 }
 
 struct TerminalEntry {
-    /// Held for kill; `None` after the reaper task consumed it on exit.
+    /// Held for kill; `None` once reaped (by the poller or by a kill).
     child: Arc<Mutex<Option<Child>>>,
     buffer: Arc<Mutex<OutputBuffer>>,
     exit_rx: watch::Receiver<Option<TerminalExit>>,
+    /// Kills publish the exit themselves — the reaper may be gone by then.
+    exit_tx: watch::Sender<Option<TerminalExit>>,
     command_line: String,
 }
 
@@ -66,19 +68,31 @@ impl OutputBuffer {
     }
 }
 
+/// Terminal ids are minted from a PROCESS-global counter, not a per-registry
+/// one: an agent restart builds a fresh registry, and a per-registry counter
+/// would hand out `aionui-term-1` again — colliding with the card the
+/// frontend still has on screen for the same conversation (cards are keyed by
+/// terminal id).
+static NEXT_TERMINAL_SEQ: AtomicU64 = AtomicU64::new(0);
+
 /// All live terminals of ONE agent connection. Dropped/`kill_all`-ed with it.
 #[derive(Default)]
 pub struct TerminalRegistry {
     entries: Mutex<HashMap<String, TerminalEntry>>,
-    next_id: AtomicU64,
     /// Log correlation label (the owning conversation id; empty for probes).
     label: String,
+    /// Fallback working directory when the agent sends no `cwd` — the
+    /// conversation's workspace. Without it a command would inherit the
+    /// aioncore process's cwd (the app bundle), which is never what the
+    /// agent means.
+    default_cwd: Option<std::path::PathBuf>,
 }
 
 impl TerminalRegistry {
-    pub fn new(label: impl Into<String>) -> Self {
+    pub fn new(label: impl Into<String>, default_cwd: Option<std::path::PathBuf>) -> Self {
         Self {
             label: label.into(),
+            default_cwd,
             ..Self::default()
         }
     }
@@ -129,12 +143,12 @@ impl TerminalRegistry {
         for (k, v) in &params.env {
             builder.env(k, v);
         }
-        if let Some(cwd) = &params.cwd {
+        if let Some(cwd) = params.cwd.as_ref().or(self.default_cwd.as_ref()) {
             builder.current_dir(cwd);
         }
         let mut child = builder.spawn().map_err(|e| format!("spawn failed: {e}"))?;
 
-        let id = format!("aionui-term-{}", self.next_id.fetch_add(1, Ordering::Relaxed) + 1);
+        let id = format!("aionui-term-{}", NEXT_TERMINAL_SEQ.fetch_add(1, Ordering::Relaxed) + 1);
         let command_line = std::iter::once(params.command.as_str())
             .chain(params.args.iter().map(String::as_str))
             .collect::<Vec<_>>()
@@ -158,11 +172,10 @@ impl TerminalRegistry {
         let stderr = child.stderr.take();
         let child = Arc::new(Mutex::new(Some(child)));
 
-        // Reader + reaper task: drain both streams into the ring buffer,
-        // then reap the child and publish the exit status.
+        // Reader task: drain both streams into the ring buffer. It may OUTLIVE
+        // the command — a backgrounded grandchild inherits the pipes and holds
+        // them open — so exit detection must not depend on it.
         let task_buffer = Arc::clone(&buffer);
-        let task_child = Arc::clone(&child);
-        let task_id = id.clone();
         tokio::spawn(async move {
             let mut out = stdout;
             let mut err = stderr;
@@ -186,38 +199,54 @@ impl TerminalRegistry {
                     }
                 }
             }
-            // Streams closed — reap. Take the child out so kill() after exit
-            // is a no-op.
-            let taken = task_child.lock().await.take();
-            let exit = match taken {
-                Some(mut c) => match c.wait().await {
-                    Ok(status) => {
-                        #[cfg(unix)]
-                        let signaled = {
-                            use std::os::unix::process::ExitStatusExt as _;
-                            status.signal().is_some()
-                        };
-                        #[cfg(not(unix))]
-                        let signaled = false;
-                        TerminalExit {
-                            exit_code: status.code().map(|c| c as u32),
-                            signaled,
-                        }
+        });
+
+        // Reaper: poll the DIRECT child. `sh -c 'sleep 30 &'` exits instantly
+        // while its backgrounded child keeps the stdout pipe open, so waiting
+        // on stream EOF would hang the terminal forever (live-reproduced).
+        // try_wait is polled rather than awaiting `wait()` under the lock so a
+        // concurrent kill can always take the mutex.
+        let reap_child = Arc::clone(&child);
+        let reap_tx = exit_tx.clone();
+        let reap_id = id.clone();
+        tokio::spawn(async move {
+            loop {
+                {
+                    let mut guard = reap_child.lock().await;
+                    match guard.as_mut() {
+                        Some(c) => match c.try_wait() {
+                            Ok(Some(status)) => {
+                                *guard = None;
+                                #[cfg(unix)]
+                                let signaled = {
+                                    use std::os::unix::process::ExitStatusExt as _;
+                                    status.signal().is_some()
+                                };
+                                #[cfg(not(unix))]
+                                let signaled = false;
+                                let _ = reap_tx.send(Some(TerminalExit {
+                                    exit_code: status.code().map(|c| c as u32),
+                                    signaled,
+                                }));
+                                return;
+                            }
+                            Ok(None) => {}
+                            Err(e) => {
+                                warn!(terminal_id = %reap_id, error = %e, "terminal wait failed");
+                                *guard = None;
+                                let _ = reap_tx.send(Some(TerminalExit {
+                                    exit_code: None,
+                                    signaled: false,
+                                }));
+                                return;
+                            }
+                        },
+                        // A kill (or release) already reaped and published.
+                        None => return,
                     }
-                    Err(e) => {
-                        warn!(terminal_id = %task_id, error = %e, "terminal wait failed");
-                        TerminalExit {
-                            exit_code: None,
-                            signaled: false,
-                        }
-                    }
-                },
-                None => TerminalExit {
-                    exit_code: None,
-                    signaled: true,
-                },
-            };
-            let _ = exit_tx.send(Some(exit));
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
         });
 
         self.entries.lock().await.insert(
@@ -226,6 +255,7 @@ impl TerminalRegistry {
                 child,
                 buffer,
                 exit_rx,
+                exit_tx,
                 command_line,
             },
         );
@@ -273,17 +303,25 @@ impl TerminalRegistry {
     /// stop button). The terminal stays registered so output/exit status
     /// remain queryable until `release`.
     pub async fn kill(&self, terminal_id: &str, source: &str) -> bool {
-        let child = {
+        let Some((child, exit_tx)) = ({
             let entries = self.entries.lock().await;
-            match entries.get(terminal_id) {
-                Some(e) => Arc::clone(&e.child),
-                None => return false,
-            }
+            entries
+                .get(terminal_id)
+                .map(|e| (Arc::clone(&e.child), e.exit_tx.clone()))
+        }) else {
+            return false;
         };
         let mut guard = child.lock().await;
         if let Some(c) = guard.as_mut() {
             info!(terminal_id, source, "client terminal killed");
+            // kill_process_tree reaps the child itself, so publish the signal
+            // exit here — the reaper sees `None` and stops without a status.
             let _ = aionui_runtime::kill_process_tree(c).await;
+            *guard = None;
+            let _ = exit_tx.send(Some(TerminalExit {
+                exit_code: None,
+                signaled: true,
+            }));
         }
         true
     }
@@ -297,6 +335,11 @@ impl TerminalRegistry {
                 let mut guard = entry.child.lock().await;
                 if let Some(c) = guard.as_mut() {
                     let _ = aionui_runtime::kill_process_tree(c).await;
+                    *guard = None;
+                    let _ = entry.exit_tx.send(Some(TerminalExit {
+                        exit_code: None,
+                        signaled: true,
+                    }));
                 }
                 true
             }
@@ -337,7 +380,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_runs_command_and_reports_output_and_exit() {
-        let reg = TerminalRegistry::new("conv-t");
+        let reg = TerminalRegistry::new("conv-t", None);
         let id = reg.create(params("echo", &["hello_term"])).await.unwrap();
         let exit = reg.wait_for_exit(&id).await.unwrap();
         assert_eq!(exit.exit_code, Some(0));
@@ -350,7 +393,7 @@ mod tests {
 
     #[tokio::test]
     async fn output_byte_limit_truncates_from_front() {
-        let reg = TerminalRegistry::new("conv-t");
+        let reg = TerminalRegistry::new("conv-t", None);
         let mut p = params("sh", &["-c", "printf 'AAAA'; printf 'BBBB'"]);
         p.output_byte_limit = Some(4);
         let id = reg.create(p).await.unwrap();
@@ -362,7 +405,7 @@ mod tests {
 
     #[tokio::test]
     async fn kill_terminates_long_command_with_signal() {
-        let reg = TerminalRegistry::new("conv-t");
+        let reg = TerminalRegistry::new("conv-t", None);
         let id = reg.create(params("sleep", &["30"])).await.unwrap();
         assert!(reg.kill(&id, "test").await);
         let exit = reg.wait_for_exit(&id).await.unwrap();
@@ -375,7 +418,7 @@ mod tests {
 
     #[tokio::test]
     async fn release_is_idempotent_and_kill_all_clears() {
-        let reg = TerminalRegistry::new("conv-t");
+        let reg = TerminalRegistry::new("conv-t", None);
         let id1 = reg.create(params("sleep", &["30"])).await.unwrap();
         let _id2 = reg.create(params("sleep", &["30"])).await.unwrap();
         assert!(reg.release(&id1).await);
@@ -386,7 +429,7 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_terminal_id_is_none_or_false() {
-        let reg = TerminalRegistry::new("conv-t");
+        let reg = TerminalRegistry::new("conv-t", None);
         assert!(reg.output("nope").await.is_none());
         assert!(reg.wait_for_exit("nope").await.is_none());
         assert!(!reg.kill("nope", "test").await);
@@ -395,7 +438,7 @@ mod tests {
 
     #[tokio::test]
     async fn bare_compound_command_runs_through_shell() {
-        let reg = TerminalRegistry::new("conv-t");
+        let reg = TerminalRegistry::new("conv-t", None);
         let mut p = params("true && echo shell_interpreted", &[]);
         p.args = vec![];
         let id = reg.create(p).await.unwrap();
@@ -403,5 +446,54 @@ mod tests {
         assert_eq!(exit.exit_code, Some(0));
         let snap = reg.output(&id).await.unwrap();
         assert!(snap.output.contains("shell_interpreted"), "got: {}", snap.output);
+    }
+
+    #[tokio::test]
+    async fn background_child_holding_stdout_does_not_hang_exit() {
+        // B6: `sh -c 'sleep 30 &'` — the parent exits immediately but the
+        // backgrounded child inherits the stdout pipe, so the read side never
+        // sees EOF. Waiting on stream close alone would hang forever.
+        let reg = TerminalRegistry::new("conv-t", None);
+        let id = reg
+            .create(params("sh", &["-c", "sleep 30 & echo parent_done"]))
+            .await
+            .unwrap();
+        let exit = tokio::time::timeout(std::time::Duration::from_secs(5), reg.wait_for_exit(&id))
+            .await
+            .expect("exit must be reported once the direct child exits, not when the pipe closes")
+            .unwrap();
+        assert_eq!(exit.exit_code, Some(0));
+        let snap = reg.output(&id).await.unwrap();
+        assert!(snap.output.contains("parent_done"), "got: {}", snap.output);
+    }
+
+    #[tokio::test]
+    async fn default_cwd_applies_when_agent_sends_none() {
+        let dir = std::env::temp_dir().join("aionui-term-cwd-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let reg = TerminalRegistry::new("conv-t", Some(dir.clone()));
+        let id = reg.create(params("pwd", &[])).await.unwrap();
+        reg.wait_for_exit(&id).await.unwrap();
+        let snap = reg.output(&id).await.unwrap();
+        let canonical = std::fs::canonicalize(&dir).unwrap();
+        assert!(
+            snap.output
+                .trim()
+                .ends_with(canonical.file_name().unwrap().to_str().unwrap()),
+            "expected cwd {} in output: {}",
+            canonical.display(),
+            snap.output
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_ids_are_unique_across_registries() {
+        // A rebuilt agent gets a fresh registry; ids must not restart at 1 or
+        // the frontend's terminal-id-keyed card collides with a stale one.
+        let a = TerminalRegistry::new("conv-a", None);
+        let b = TerminalRegistry::new("conv-b", None);
+        let id_a = a.create(params("true", &[])).await.unwrap();
+        let id_b = b.create(params("true", &[])).await.unwrap();
+        assert_ne!(id_a, id_b);
     }
 }

--- a/crates/aionui-ai-agent/src/terminal.rs
+++ b/crates/aionui-ai-agent/src/terminal.rs
@@ -97,9 +97,32 @@ pub struct CreateTerminalParams {
 impl TerminalRegistry {
     /// Spawn the command and register a terminal for it.
     pub async fn create(&self, params: CreateTerminalParams) -> Result<String, String> {
-        let mut builder = aionui_runtime::Builder::new(&params.command);
+        // Agents disagree on the `command` contract: grok wraps itself in
+        // `/bin/bash -lc '<line>'` (command + args), while codebuddy sends the
+        // whole compound line — `sleep 2 && echo hi` — as a bare `command`
+        // with no args, expecting shell interpretation (live-captured
+        // 2026-08-05: direct exec ENOENTs on the compound string). Rule:
+        // explicit args → exec verbatim; no args → run the line through the
+        // platform shell.
+        let mut builder = if params.args.is_empty() {
+            #[cfg(unix)]
+            {
+                let mut b = aionui_runtime::Builder::new("/bin/sh");
+                b.arg("-c").arg(&params.command);
+                b
+            }
+            #[cfg(windows)]
+            {
+                let mut b = aionui_runtime::Builder::new("cmd");
+                b.arg("/C").arg(&params.command);
+                b
+            }
+        } else {
+            let mut b = aionui_runtime::Builder::new(&params.command);
+            b.args(&params.args);
+            b
+        };
         builder
-            .args(&params.args)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
@@ -368,5 +391,17 @@ mod tests {
         assert!(reg.wait_for_exit("nope").await.is_none());
         assert!(!reg.kill("nope", "test").await);
         assert!(!reg.release("nope").await);
+    }
+
+    #[tokio::test]
+    async fn bare_compound_command_runs_through_shell() {
+        let reg = TerminalRegistry::new("conv-t");
+        let mut p = params("true && echo shell_interpreted", &[]);
+        p.args = vec![];
+        let id = reg.create(p).await.unwrap();
+        let exit = reg.wait_for_exit(&id).await.unwrap();
+        assert_eq!(exit.exit_code, Some(0));
+        let snap = reg.output(&id).await.unwrap();
+        assert!(snap.output.contains("shell_interpreted"), "got: {}", snap.output);
     }
 }

--- a/crates/aionui-ai-agent/tests/acp_agent_integration.rs
+++ b/crates/aionui-ai-agent/tests/acp_agent_integration.rs
@@ -188,6 +188,7 @@ fn event_type_name(event: &AgentStreamEvent) -> &'static str {
         AgentStreamEvent::AcpConfigOption(_) => "AcpConfigOption",
         AgentStreamEvent::AcpSessionInfo(_) => "AcpSessionInfo",
         AgentStreamEvent::AcpContextUsage(_) => "AcpContextUsage",
+        AgentStreamEvent::AcpTerminalOutput(_) => "AcpTerminalOutput",
         AgentStreamEvent::AcpPromptHookWarning(_) => "AcpPromptHookWarning",
         AgentStreamEvent::Finish(_) => "Finish",
         AgentStreamEvent::Error(_) => "Error",

--- a/crates/aionui-channel/src/message_service.rs
+++ b/crates/aionui-channel/src/message_service.rs
@@ -229,6 +229,9 @@ impl ChannelMessageService {
             | AgentStreamEvent::AcpConfigOption(_)
             | AgentStreamEvent::AcpSessionInfo(_)
             | AgentStreamEvent::AcpContextUsage(_)
+            // Live terminal snapshots are a web-UI card refresh; the final
+            // command outcome reaches the IM transcript via the tool result.
+            | AgentStreamEvent::AcpTerminalOutput(_)
             | AgentStreamEvent::AcpPromptHookWarning(_)
             | AgentStreamEvent::System(_)
             | AgentStreamEvent::RequestTrace(_)

--- a/crates/aionui-conversation/src/routes.rs
+++ b/crates/aionui-conversation/src/routes.rs
@@ -120,6 +120,10 @@ pub fn conversation_routes(state: ConversationRouterState) -> Router {
         .route("/api/conversations/{id}/artifacts", get(list_artifacts))
         .route("/api/conversations/{id}/artifacts/{artifactId}", patch(update_artifact))
         .route("/api/conversations/{id}/cancel", post(cancel))
+        .route(
+            "/api/conversations/{id}/terminals/{terminalId}/kill",
+            post(kill_terminal),
+        )
         .route("/api/conversations/{id}/runtime/ensure", post(ensure_runtime))
         .route("/api/conversations/{id}/active-lease", post(active_lease))
         // Confirmation system
@@ -315,6 +319,19 @@ async fn update_artifact(
         .await
         .map_err(ApiError::from)?;
     Ok(Json(ApiResponse::ok(artifact)))
+}
+
+async fn kill_terminal(
+    State(state): State<ConversationRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    Path((id, terminal_id)): Path<(String, String)>,
+) -> Result<Json<ApiResponse<()>>, ApiError> {
+    state
+        .service
+        .kill_terminal(&user.id, &id, &terminal_id, &state.task_manager)
+        .await
+        .map_err(ApiError::from)?;
+    Ok(Json(ApiResponse::ok(())))
 }
 
 async fn cancel(

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -3596,6 +3596,40 @@ impl ConversationService {
 
     /// Stop the current streaming response for a conversation.
     #[tracing::instrument(skip_all, fields(user_id = %user_id, conversation_id = %conversation_id))]
+    /// Stop ONE client-hosted terminal command (ACP `terminal/*`) without
+    /// touching the turn: the agent observes the signal exit and continues.
+    pub async fn kill_terminal(
+        &self,
+        user_id: &str,
+        conversation_id: &str,
+        terminal_id: &str,
+        task_manager: &Arc<dyn IWorkerTaskManager>,
+    ) -> Result<(), ConversationError> {
+        self.conversation_repo
+            .get(user_id, conversation_id)
+            .await?
+            .ok_or_else(|| ConversationError::NotFound {
+                id: conversation_id.to_owned(),
+            })?;
+        let Some(agent) = task_manager.get_task(conversation_id) else {
+            return Err(ConversationError::BadRequest {
+                reason: "no running agent for conversation".to_owned(),
+            });
+        };
+        let killed = match &agent {
+            AgentInstance::Acp(mgr) => mgr.kill_client_terminal(terminal_id).await,
+            // Client-hosted terminals only exist on the ACP path.
+            _ => false,
+        };
+        if !killed {
+            return Err(ConversationError::NotFound {
+                id: format!("terminal {terminal_id}"),
+            });
+        }
+        info!(conversation_id, terminal_id, "client terminal killed by user");
+        Ok(())
+    }
+
     pub async fn cancel(
         &self,
         user_id: &str,

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -674,6 +674,7 @@ impl StreamRelay {
             AgentStreamEvent::AcpConfigOption(_) => "AcpConfigOption",
             AgentStreamEvent::AcpSessionInfo(_) => "AcpSessionInfo",
             AgentStreamEvent::AcpContextUsage(_) => "AcpContextUsage",
+            AgentStreamEvent::AcpTerminalOutput(_) => "AcpTerminalOutput",
             AgentStreamEvent::AcpPromptHookWarning(_) => "AcpPromptHookWarning",
             AgentStreamEvent::SlashCommandsUpdated(_) => "SlashCommandsUpdated",
             AgentStreamEvent::AvailableCommands(_) => "AvailableCommands",


### PR DESCRIPTION
## Summary

ACP is a two-way protocol: the client also declares what services it offers agents. Our initialize handshake carried `clientInfo` only, so every agent assumed we provide nothing. This PR declares — and implements — the terminal service, so a delegated command runs in **our** process tree: output streams live to the UI, the user can stop one command without killing the agent, and every command is logged.

Frontend half: iOfficeAI/AionUi#3860.

### What changed

- **`TerminalRegistry`** (`aionui-ai-agent/src/terminal.rs`): spawns through the runtime spawn Builder (process-group kill), merges stdout+stderr into a front-truncating, char-boundary-safe buffer honoring `outputByteLimit`, and implements create/output/wait_for_exit/kill/release plus `kill_all` for teardown. The registry lives on the connection and is swept on `Drop`, so no delegated command outlives its agent.
- **Handshake** (`protocol/acp.rs`): declares `clientCapabilities.terminal` and `session.configOptions`. The latter is a long-standing gap — we already consume `config_option_update` and render the options UI, but never declared support, so a strictly capability-gated agent could withhold its config options.
- **Five request handlers** wired into the SDK background task; a throttled poller broadcasts `AcpTerminalOutput` snapshots (`{terminal_id, command, cumulative output, truncated, exit_status}`) that the stream relay forwards to the UI. IM channels ignore the live snapshots (the tool result carries the outcome).
- **Kill endpoint**: `POST /api/conversations/{id}/terminals/{terminalId}/kill` for the card's stop button.
- **Shell semantics fix**: agents disagree on the `command` contract — grok sends `/bin/bash -lc '<line>'` (command+args) while codebuddy sends a whole compound line as a bare command. Explicit args exec verbatim; an empty args list routes the line through `/bin/sh -c` (`cmd /C` on Windows).

### Adoption (probed 2026-08-05, all 37 ACP agents from `agent_metadata`)

Of the 10 agents that could complete a command turn in a bare probe environment, **3 delegate to the client terminal**: codebuddy (full create+output+wait+release; it also trusts our `fs/read_text_file` over reading the disk itself), grok, and omp. Six run commands themselves and ignore the declaration (verified with a random-token probe, so "answered correctly" cannot be faked). 13 more could not authenticate in the bare probe — their real adoption shows up once this ships. Full per-agent breakdown with exact errors: `docs/superpowers/specs/2026-08-05-client-capabilities-terminal-fs-design.md` §7.

Agents that do not adopt keep running commands themselves — unchanged behavior, no regression risk.

### Verification

- Live (codebuddy, local instance): `client terminal created … command=sleep 2 && echo terminal_e2e_done` → exact output returned; killing a long command via the REST endpoint logged `client terminal killed source=user` and the agent stayed alive and adapted.
- UI e2e (iOfficeAI/AionUi#3860): terminal card renders with live output; the stop button kills the command mid-stream (output never reaches the loop's tail) while the agent keeps replying.
- Unit: 6 registry tests (echo, front truncation, signal kill, idempotent release, kill_all, shell interpretation) + the handshake declaration assertion.
- `cargo clippy -p aionui-ai-agent -p aionui-conversation -- -D warnings` clean; `cargo fmt --check` clean; targeted crate tests pass (full workspace suite runs in CI).

### Not in scope

`fs/*` service (P2), `fs/write_text_file` (needs its own permission model), direct-CLI backends (claude/codex/antigravity have no protocol slot for delegated execution — see §4), and interactive stdin (the protocol models one-shot commands).