### PR TITLE
test(project): cover pe root chat ref with empty relative_path

### DIFF
--- a/crates/aionui-project/src/chat_files_test.rs
+++ b/crates/aionui-project/src/chat_files_test.rs
@@ -76,6 +76,38 @@ async fn resolves_project_directory_ref() {
 }
 
 #[tokio::test]
+async fn resolves_project_root_ref_empty_relative_path() {
+    // bug2 (add a pe ROOT to chat): the root node's relative_path is "", which
+    // must resolve to the pe root directory itself — not error, not resolve to
+    // some parent. Guards the empty-path root case specifically (the sibling
+    // test above only covers a named subdirectory).
+    let (service, pe_id, dir, upload_root) = setup().await;
+
+    let out = service
+        .resolve_chat_message(
+            "system_default_user",
+            "review this project",
+            &[ChatFileRef::Project {
+                pe_id,
+                relative_path: String::new(),
+            }],
+            upload_root.path(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(out.files.len(), 1);
+    let abs = std::path::Path::new(&out.files[0]);
+    assert!(abs.exists(), "root ref must resolve to an existing path");
+    assert!(abs.is_dir(), "a pe root resolves to a directory");
+    // The resolved path is the canonicalized pe root itself.
+    assert_eq!(
+        std::fs::canonicalize(abs).unwrap(),
+        std::fs::canonicalize(dir.path()).unwrap()
+    );
+}
+
+#[tokio::test]
 async fn empty_files_leaves_content_unchanged() {
     let (service, _pe, _dir, upload_root) = setup().await;
     let out = service


### PR DESCRIPTION
## Description

Regression guard for the backend half of bug2 ("add a pe ROOT / directory to chat", frontend fix in AionUi#3869).

A project chat ref whose `relative_path` is `""` (the Explorer pe ROOT) must resolve to the pe root directory itself. The `Project` arm of `resolve_chat_file_ref` already supports directories (requires only that the target exists, not that it is a regular file), and `containment::resolve_relative` maps an empty relative path to the root — but the existing `resolves_project_directory_ref` test only exercised a named subdirectory (`"sub"`), not the empty-path root case that bug2 actually hits.

Adds `resolves_project_root_ref_empty_relative_path`: resolves a `Project { relative_path: "" }` ref and asserts the result **exists**, **is a directory**, and is **canonically equal to the workspace root**.

Test-only; no production code change.

## Verification

- `cargo test -p aionui-project chat_files` — 11/11 pass.
- `just push` gate (with `AIONUI_LOG_DIR` unset to avoid the known local env flake in `sysinfo::test_env_override_log_dir`) — full workspace **8220 passed**, fmt/clippy clean.