### PR TITLE
fix(session): stop reporting still-running codex commands as cancelled

### DIFF
--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -2839,6 +2839,24 @@ fn spawn_event_pump(
                         let _ = runtime.tx.send(AgentStreamEvent::WorkflowProgress(data));
                     }
                     for (call_id, name) in open_tools.drain() {
+                        // codex's unified exec starts the command in a background PTY
+                        // and lets the model END ITS TURN while the process runs; the
+                        // completion item arrives later (verified live 0.145.0: every
+                        // commandExecution item carries `source: "unifiedExecStartup"`).
+                        // Cancelling such a card on a CLEAN turn end is a lie — the
+                        // command is still running and its own terminal will settle the
+                        // card — and it is exactly what users read as "the AI stopped by
+                        // itself". Same rule as background-task cards above: keep them on
+                        // a clean end, take them down on cancel/error/crash.
+                        if keep_background && is_detached_exec_call(tool_args.get(&call_id)) {
+                            tracing::info!(
+                                conv_id = %conversation_id,
+                                %call_id,
+                                tool = %name,
+                                "session-pump: leaving detached exec tool call open past turn end"
+                            );
+                            continue;
+                        }
                         tracing::info!(
                             conv_id = %conversation_id,
                             %call_id,
@@ -3630,6 +3648,21 @@ fn update_workflow_cards(
 /// long ago. Without this a killed or crashed workflow leaves its container card
 /// and every agent row spinning forever, and `hasRunningToolMessages` keeps the
 /// conversation's running indicator lit with nothing left to clear it.
+/// Does this tool call's recorded arguments identify a codex command that runs
+/// DETACHED from the prompt turn?
+///
+/// codex's `unified_exec` starts the process in a PTY with a background exit
+/// watcher, so the model may finish its turn long before the command's own
+/// completion item arrives. The item carries that provenance verbatim in
+/// `source: "unifiedExecStartup"` (a codex wire field passed through by
+/// `codex_conn`, live-captured 0.145.0); `unifiedExecInteraction` is the
+/// follow-up interaction shape of the same family.
+fn is_detached_exec_call(args: Option<&serde_json::Value>) -> bool {
+    args.and_then(|v| v.get("source"))
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|s| s.starts_with("unifiedExec"))
+}
+
 fn settle_workflow_cards(
     cards: &mut std::collections::HashMap<String, crate::workflow_progress::WorkflowCard>,
     status: crate::workflow_progress::CardStatus,
@@ -8843,5 +8876,28 @@ mod catalog_writeback_tests {
             nested_len(msg.handshake.available_modes.as_ref(), "available_modes") > 0,
             "expected the modes-only partial to be published"
         );
+    }
+
+    #[test]
+    fn detached_exec_calls_are_recognised_by_codex_item_source() {
+        use serde_json::json;
+        // Live-captured shape (codex 0.145.0): every commandExecution item the
+        // model launches carries `source: "unifiedExecStartup"`.
+        let startup = json!({
+            "type": "commandExecution",
+            "command": "/bin/zsh -lc 'bun run build'",
+            "status": "inProgress",
+            "source": "unifiedExecStartup"
+        });
+        assert!(super::is_detached_exec_call(Some(&startup)));
+        let interaction = json!({ "type": "commandExecution", "source": "unifiedExecInteraction" });
+        assert!(super::is_detached_exec_call(Some(&interaction)));
+
+        // Foreground/other sources and non-codex tools must still be cancelled
+        // at turn end (an orphaned card would otherwise spin forever).
+        assert!(!super::is_detached_exec_call(Some(&json!({ "source": "agent" }))));
+        assert!(!super::is_detached_exec_call(Some(&json!({ "source": "userShell" }))));
+        assert!(!super::is_detached_exec_call(Some(&json!({ "command": "ls" }))));
+        assert!(!super::is_detached_exec_call(None));
     }
 }

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -2838,6 +2838,9 @@ fn spawn_event_pump(
                     ) {
                         let _ = runtime.tx.send(AgentStreamEvent::WorkflowProgress(data));
                     }
+                    // Calls deliberately left running past this turn end (see below);
+                    // re-registered after the drain so their late frames still resolve.
+                    let mut kept_open: Vec<(String, String)> = Vec::new();
                     for (call_id, name) in open_tools.drain() {
                         // codex's unified exec starts the command in a background PTY
                         // and lets the model END ITS TURN while the process runs; the
@@ -2855,6 +2858,7 @@ fn spawn_event_pump(
                                 tool = %name,
                                 "session-pump: leaving detached exec tool call open past turn end"
                             );
+                            kept_open.push((call_id, name));
                             continue;
                         }
                         tracing::info!(
@@ -2872,6 +2876,9 @@ fn spawn_event_pump(
                             output: None,
                             description: None,
                         }));
+                    }
+                    for (call_id, name) in kept_open {
+                        open_tools.insert(call_id, name);
                     }
                     // A terminal TurnResult decided this turn; a later Detached is then
                     // an absorbed teardown, not a mid-turn crash (see `crash_outcome`).
@@ -2898,9 +2905,12 @@ fn spawn_event_pump(
                     }
                     // Live tool-output accumulators are per-turn; the authoritative
                     // full output already rode each ToolResult. Drop them so a long
-                    // session doesn't retain every turn's stdout.
-                    tool_output.clear();
-                    tool_name.clear();
+                    // session doesn't retain every turn's stdout — EXCEPT for calls
+                    // still open past this turn end (detached exec): their terminal
+                    // arrives minutes later and `stamp_tool_name` must still find the
+                    // name, or the card re-renders nameless.
+                    tool_output.retain(|call_id, _| open_tools.contains_key(call_id));
+                    tool_name.retain(|call_id, _| open_tools.contains_key(call_id));
                     // Reset the per-turn visibility flag for the next turn.
                     saw_visible_output = false;
                 }
@@ -6181,6 +6191,135 @@ mod pump_tests {
         };
         assert_eq!(data, b"catbytes");
         assert_eq!(media_type, "image/png");
+    }
+
+    /// A codex detached exec (`source: unifiedExecStartup`) is still RUNNING when
+    /// the model ends its prompt turn; the pump must not paint it Canceled — the
+    /// command's own completion settles it later. A foreground tool left open at
+    /// the same clean turn end must still be cancelled.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clean_turn_end_keeps_detached_exec_card_but_cancels_others() {
+        use aionui_session::TurnOutcome;
+        let detached = SessionEvent::ToolCall {
+            tool_use_id: "call-detached".into(),
+            name: "commandExecution".into(),
+            subagent: aionui_session::SubagentKind::Inline,
+            input: serde_json::json!({
+                "type": "commandExecution",
+                "command": "/bin/zsh -lc 'bun run build'",
+                "status": "inProgress",
+                "source": "unifiedExecStartup"
+            }),
+            parent_tool_use_id: None,
+        };
+        let foreground = SessionEvent::ToolCall {
+            tool_use_id: "call-plain".into(),
+            name: "fileChange".into(),
+            subagent: aionui_session::SubagentKind::Inline,
+            input: serde_json::json!({ "type": "fileChange" }),
+            parent_tool_use_id: None,
+        };
+        let clean_end = SessionEvent::TurnResult {
+            is_error: false,
+            api_error_status: None,
+            result_text: String::new(),
+            epoch: 0,
+            outcome: TurnOutcome::Completed {
+                stop_reason: aionui_session::StopReason::EndTurn,
+            },
+        };
+        let backend: Arc<dyn SessionBackend> =
+            Arc::new(ScriptBackend(vec![env(detached), env(foreground), env(clean_end)]));
+        let task = SessionAgentTask::new(
+            AgentType::Acp,
+            "conv-1".into(),
+            "user-1".into(),
+            "/w".into(),
+            backend,
+            None,
+        );
+        let mut rx = crate::agent_task::IAgentTask::subscribe(task.as_ref());
+        let _ = task;
+
+        let mut canceled: Vec<String> = Vec::new();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(1500);
+        while tokio::time::Instant::now() < deadline {
+            match tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await {
+                Ok(Ok(AgentStreamEvent::ToolCall(data))) if data.status == ToolCallStatus::Canceled => {
+                    canceled.push(data.call_id);
+                }
+                Ok(Ok(_)) => {}
+                _ => break,
+            }
+        }
+        assert!(
+            !canceled.iter().any(|id| id == "call-detached"),
+            "detached exec card must survive a clean turn end, got cancels: {canceled:?}"
+        );
+        assert!(
+            canceled.iter().any(|id| id == "call-plain"),
+            "a non-detached tool left open must still be cancelled, got: {canceled:?}"
+        );
+    }
+
+    /// The detached exec's terminal lands MINUTES after the turn ended. The
+    /// per-turn name map must keep the entry for calls left open, or the late
+    /// frame goes out nameless and the card re-renders with a blank title.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn late_terminal_of_a_kept_open_exec_still_carries_the_tool_name() {
+        use aionui_session::TurnOutcome;
+        let detached = SessionEvent::ToolCall {
+            tool_use_id: "call-detached".into(),
+            name: "commandExecution".into(),
+            subagent: aionui_session::SubagentKind::Inline,
+            input: serde_json::json!({ "type": "commandExecution", "source": "unifiedExecStartup" }),
+            parent_tool_use_id: None,
+        };
+        let clean_end = SessionEvent::TurnResult {
+            is_error: false,
+            api_error_status: None,
+            result_text: String::new(),
+            epoch: 0,
+            outcome: TurnOutcome::Completed {
+                stop_reason: aionui_session::StopReason::EndTurn,
+            },
+        };
+        let late_result = SessionEvent::ToolResult {
+            tool_use_id: "call-detached".into(),
+            is_error: false,
+            content: vec![],
+            parent_tool_use_id: None,
+        };
+        let backend: Arc<dyn SessionBackend> =
+            Arc::new(ScriptBackend(vec![env(detached), env(clean_end), env(late_result)]));
+        let task = SessionAgentTask::new(
+            AgentType::Acp,
+            "conv-1".into(),
+            "user-1".into(),
+            "/w".into(),
+            backend,
+            None,
+        );
+        let mut rx = crate::agent_task::IAgentTask::subscribe(task.as_ref());
+        let _ = task;
+
+        let mut terminal_names: Vec<String> = Vec::new();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(1500);
+        while tokio::time::Instant::now() < deadline {
+            match tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await {
+                Ok(Ok(AgentStreamEvent::ToolCall(data)))
+                    if data.call_id == "call-detached" && data.status == ToolCallStatus::Completed =>
+                {
+                    terminal_names.push(data.name.clone());
+                }
+                Ok(Ok(_)) => {}
+                _ => break,
+            }
+        }
+        assert!(
+            terminal_names.iter().any(|n| n == "commandExecution"),
+            "late terminal must keep the tool name, got: {terminal_names:?}"
+        );
     }
 
     fn env(event: SessionEvent) -> SessionEnvelope {

--- a/crates/aionui-session/src/backend/codex_conn.rs
+++ b/crates/aionui-session/src/backend/codex_conn.rs
@@ -1403,6 +1403,10 @@ async fn reader_task(
                 if line.is_empty() {
                     continue;
                 }
+                // Opt-in raw wire tap for turn-boundary forensics (never on by
+                // default — carries tool input/output; enable with
+                // `--log-level "info,codex_wire=debug"`).
+                tracing::debug!(target: "codex_wire", session_id = %session_id, frame = %line, "codex <- frame");
                 let Ok(frame): Result<Value, _> = serde_json::from_str(line) else {
                     // unparseable line → opaque, never panic
                     emit(


### PR DESCRIPTION
Fixes ELECTRON-3XC, ELECTRON-3XF, ELECTRON-3XG.

Frontend half: iOfficeAI/AionUi#3862.

## What users reported

Three feedback reports from one user on 2026-08-05, all on codex conversations, all describing the same thing in different words: "the agent replies one or two sentences and then stops working", "there's an obvious gap, the AI reply stops by itself", "another case of the session breaking".

## What actually happened

codex's `unified_exec` starts a command in a background PTY and hands the model a partial result while the process keeps running. The model can then **end its prompt turn with the command still executing** — it reports the first lines and stops talking. Every `commandExecution` item carries that provenance verbatim as `source: "unifiedExecStartup"` (live-captured against codex 0.145.0; the field is codex's own, passed through by `codex_conn.rs:2827-2837`).

Our session pump assumed the opposite: that a turn ending means every tool call it started is over. So at each turn terminal it painted **every** still-open tool call `Canceled`. The command was not cancelled — it was running fine, and its real result arrived minutes later. That is the "AI stopped by itself" the users saw.

Evidence from their own attachments:

- `source: "unifiedExecStartup"` appears 8 / 18 / 16 times across the three diagnostics packages; the commands are `bun run format && bunx tsc`, `playwright test`, `curl …` — exactly the long, output-streaming shape that triggers this.
- Their `aioncore.log` contains `session-pump: closing tool call left open at turn end as canceled` three times, each landing in the same second as the turn terminal.
- Every tool card in `recent_error_details` has `source: unifiedExecStartup` **and `exitCode: null`** — a command that had truly finished, even by failing, would carry an exit code. No exit code means the process was still alive when we marked it.

(Honest boundary: that user's E2E suite was genuinely failing at the time, so some of those red cards are real failures, not mislabels. This PR only removes the mislabels.)

## The fix

1. **Keep detached exec cards alive past a clean turn end.** A tool call whose item source starts with `unifiedExec` now follows the rule background-task cards already had: kept on a clean `TurnResult`, still taken down on cancel, error, or process death. Its own completion item settles it later — which already works, because PR #758's CLI-initiated-turn channel delivers post-turn frames.

2. **Keep the tool name for calls left open.** The per-turn name/output maps were cleared wholesale at turn end, so the terminal arriving minutes later found no name and went out nameless — the card re-rendered as a blank row, which looked like a second, empty card appearing. The maps now retain entries for calls still in `open_tools`, which is exactly the set kept alive by (1).

3. **An opt-in codex wire tap** (`target: codex_wire`, debug, off by default). Every frame-level fact in this PR had to be captured by hand because the codex reader logged nothing; enable with `--log-level "info,codex_wire=debug"`.

## Verification

Live, against real codex, in the dev app:

```
19:05:33  command starts (300s streaming loop)
19:05:56  turn ends → "leaving detached exec tool call open past turn end"
          card stays running — truthfully, the process is still alive
19:10:xx  command finishes → card settles: status=completed,
          name=commandExecution, 4379 bytes of output persisted
```

Before this change the same run painted the card cancelled at 19:05:56 while the command ran on for another four and a half minutes.

Tests: two pump regression tests (a clean turn end keeps the detached card while still cancelling a foreground tool; the late terminal of a kept-open call still carries its tool name) plus the source-detection matrix. `cargo test -p aionui-ai-agent --lib` 905 passed; `cargo fmt --check` and targeted clippy clean. The full workspace suite runs in CI.

## What this does not fix

The turn still ends silently while work continues in the background — the user sees a spinning card and no "still working" statement anywhere. That product-level gap is deliberately out of scope here and tracked separately.

## A wrong turn worth recording

I first hypothesised that we were terminating the turn prematurely (that `thread/status/changed → idle` was racing `turn/completed`). Reading `codex_conn.rs:3169-3184` disproved it: `idle` is deferred and only flushed at process EOF, so the terminal genuinely came from codex. The premise was wrong, not the symptom — codex really does end its turn early, by design, and the bug was on our side of the seam.