### PR TITLE
fix(adoption): move legacy root assistant-rules to the adopter

### DIFF
--- a/crates/aionui-app/tests/adoption_assistant_rules_e2e.rs
+++ b/crates/aionui-app/tests/adoption_assistant_rules_e2e.rs
@@ -1,0 +1,213 @@
+//! End-to-end reproduction of the AionUi → AionPro adoption path for
+//! assistant rules, run against the REAL adoption code (no mocks):
+//! real migrations, real `ensure_external_user`, real
+//! `adopt_system_default_data` (one-shot stamp), real
+//! `fs_adopt::adopt_user_filesystem`, real `AssistantService` reads.
+//!
+//! Two on-disk layouts are exercised:
+//!  - `users/system_default_user/…` (post-user-scope writes)
+//!  - the LEGACY root layout `assistant-rules/<id>.<locale>.md` (pre-user-scope
+//!    installs upgraded in place, where no disk migration ever moved the files)
+
+use std::path::Path;
+use std::sync::Arc;
+
+use aionui_assistant::service::AssistantServiceDeps;
+use aionui_assistant::{AssistantService, BuiltinAssistantRegistry};
+use aionui_db::{
+    Database, ExternalUserProjection, IAssistantDefinitionRepository, IAssistantOverlayRepository,
+    IAssistantOverrideRepository, IAssistantPreferenceRepository, IAssistantRepository, IProviderRepository,
+    IUserRepository, SqliteAssistantDefinitionRepository, SqliteAssistantOverlayRepository,
+    SqliteAssistantOverrideRepository, SqliteAssistantPreferenceRepository, SqliteAssistantRepository,
+    SqliteProviderRepository, SqliteSkillRepository, SqliteUserRepository, UserType, init_database_memory,
+};
+use aionui_extension::{SkillPaths, fs_adopt};
+use tempfile::TempDir;
+
+const DEFAULT_USER_ID: &str = "system_default_user";
+const ASSISTANT_ID: &str = "my-helper";
+const RULE_BODY: &str = "act as my helper";
+
+fn paths_at(root: &Path) -> SkillPaths {
+    SkillPaths {
+        data_dir: root.to_path_buf(),
+        user_skills_dir: root.join("skills"),
+        cron_skills_dir: root.join("cron").join("skills"),
+        builtin_skills_dir: root.join("builtin-skills"),
+        builtin_rules_dir: root.join("builtin-rules"),
+        assistant_rules_dir: root.join("assistant-rules"),
+        assistant_skills_dir: root.join("assistant-skills"),
+    }
+}
+
+fn assistant_service(db: &Database, data_dir: &Path) -> AssistantService {
+    let pool = db.pool().clone();
+    let deps = AssistantServiceDeps {
+        definition_repo: Arc::new(SqliteAssistantDefinitionRepository::new(pool.clone()))
+            as Arc<dyn IAssistantDefinitionRepository>,
+        state_repo: Arc::new(SqliteAssistantOverlayRepository::new(pool.clone()))
+            as Arc<dyn IAssistantOverlayRepository>,
+        preference_repo: Arc::new(SqliteAssistantPreferenceRepository::new(pool.clone()))
+            as Arc<dyn IAssistantPreferenceRepository>,
+        repo: Arc::new(SqliteAssistantRepository::new(pool.clone())) as Arc<dyn IAssistantRepository>,
+        override_repo: Arc::new(SqliteAssistantOverrideRepository::new(pool.clone()))
+            as Arc<dyn IAssistantOverrideRepository>,
+        provider_repo: Arc::new(SqliteProviderRepository::new(pool.clone())) as Arc<dyn IProviderRepository>,
+        builtin: Arc::new(BuiltinAssistantRegistry::load_embedded()),
+        agent_catalog: None,
+    };
+    AssistantService::new(pool, deps, data_dir.to_path_buf())
+}
+
+/// Runs the REAL adoption sequence exactly as `ensure_external_user` in
+/// aionui-auth does: provision external user → DB adoption (stamps the
+/// one-shot marker) → filesystem adoption. Returns the adopter's user id.
+async fn run_real_adoption(db: &Database, paths: &SkillPaths) -> String {
+    let user_repo = SqliteUserRepository::new(db.pool().clone());
+    let adopter = user_repo
+        .ensure_external_user(UserType::Aionpro, "ext-user-1", ExternalUserProjection::default())
+        .await
+        .expect("provision external user");
+
+    let moved_rows = user_repo
+        .adopt_system_default_data(&adopter.id)
+        .await
+        .expect("db adoption");
+    assert!(
+        user_repo
+            .is_default_data_adopter(&adopter.id)
+            .await
+            .expect("marker query"),
+        "adopter must be stamped as the one-shot adopter (moved_rows={moved_rows})"
+    );
+
+    let skill_repo = SqliteSkillRepository::new(db.pool().clone());
+    fs_adopt::adopt_user_filesystem(paths, &skill_repo, &adopter.id).await;
+    adopter.id
+}
+
+/// Layout used by post-user-scope versions: the rule file lives under
+/// `assistant-rules/users/system_default_user/`.
+#[tokio::test]
+async fn adopted_user_reads_rule_written_under_default_user_dir() {
+    let tmp = TempDir::new().unwrap();
+    let paths = paths_at(tmp.path());
+    let db = init_database_memory().await.unwrap();
+    let service = assistant_service(&db, tmp.path());
+
+    let rules_dir = paths.assistant_rules_dir.join("users").join(DEFAULT_USER_ID);
+    std::fs::create_dir_all(&rules_dir).unwrap();
+    std::fs::write(rules_dir.join(format!("{ASSISTANT_ID}.zh-CN.md")), RULE_BODY).unwrap();
+
+    // Sanity: the local default user sees the rule before adoption.
+    let before = service
+        .read_rule_for_user(DEFAULT_USER_ID, ASSISTANT_ID, Some("zh-CN"))
+        .await
+        .unwrap();
+    assert_eq!(before, RULE_BODY, "default user must see the rule pre-adoption");
+
+    let adopter = run_real_adoption(&db, &paths).await;
+
+    let after = service
+        .read_rule_for_user(&adopter, ASSISTANT_ID, Some("zh-CN"))
+        .await
+        .unwrap();
+    assert_eq!(
+        after, RULE_BODY,
+        "adopter must see the adopted rule (users/system_default_user layout)"
+    );
+}
+
+/// Layout left behind by pre-user-scope installs upgraded in place: the rule
+/// file sits at the LEGACY root `assistant-rules/<id>.<locale>.md` with no
+/// `users/` segment. The default user still reads it through the legacy
+/// fallback — the question is whether the adopter does after adoption.
+#[tokio::test]
+async fn adopted_user_reads_rule_left_at_legacy_root() {
+    let tmp = TempDir::new().unwrap();
+    let paths = paths_at(tmp.path());
+    let db = init_database_memory().await.unwrap();
+    let service = assistant_service(&db, tmp.path());
+
+    std::fs::create_dir_all(&paths.assistant_rules_dir).unwrap();
+    std::fs::write(
+        paths.assistant_rules_dir.join(format!("{ASSISTANT_ID}.zh-CN.md")),
+        RULE_BODY,
+    )
+    .unwrap();
+
+    // Sanity: the local default user sees the legacy-root rule before adoption.
+    let before = service
+        .read_rule_for_user(DEFAULT_USER_ID, ASSISTANT_ID, Some("zh-CN"))
+        .await
+        .unwrap();
+    assert_eq!(
+        before, RULE_BODY,
+        "default user must see the legacy-root rule pre-adoption"
+    );
+
+    let adopter = run_real_adoption(&db, &paths).await;
+
+    let after = service
+        .read_rule_for_user(&adopter, ASSISTANT_ID, Some("zh-CN"))
+        .await
+        .unwrap();
+    assert_eq!(
+        after, RULE_BODY,
+        "adopter must see the adopted rule (legacy root layout, pre-user-scope upgrade)"
+    );
+}
+
+/// Users who already adopted on a build WITHOUT the legacy-root move are left
+/// with: stamp set, `users/system_default_user` swept, but the legacy root
+/// files still in place — and their rules unreadable. The auth layer re-runs
+/// the filesystem adoption on every login of the stamped adopter
+/// (best-effort catch-up for partial moves), so the next login on a fixed
+/// build must heal them without any manual intervention.
+#[tokio::test]
+async fn already_adopted_user_heals_on_next_login_rerun() {
+    let tmp = TempDir::new().unwrap();
+    let paths = paths_at(tmp.path());
+    let db = init_database_memory().await.unwrap();
+    let service = assistant_service(&db, tmp.path());
+
+    // State as left behind by the old build: adoption already happened (stamp
+    // set, DB rows moved) while the legacy-root rule file was NOT moved.
+    let user_repo = SqliteUserRepository::new(db.pool().clone());
+    let adopter = user_repo
+        .ensure_external_user(UserType::Aionpro, "ext-user-1", ExternalUserProjection::default())
+        .await
+        .expect("provision external user");
+    user_repo
+        .adopt_system_default_data(&adopter.id)
+        .await
+        .expect("db adoption");
+    assert!(user_repo.is_default_data_adopter(&adopter.id).await.unwrap());
+
+    std::fs::create_dir_all(&paths.assistant_rules_dir).unwrap();
+    std::fs::write(
+        paths.assistant_rules_dir.join(format!("{ASSISTANT_ID}.zh-CN.md")),
+        RULE_BODY,
+    )
+    .unwrap();
+
+    // Broken state: the adopter cannot read the rule.
+    let broken = service
+        .read_rule_for_user(&adopter.id, ASSISTANT_ID, Some("zh-CN"))
+        .await
+        .unwrap();
+    assert_eq!(broken, "", "pre-fix state: adopter must NOT see the legacy-root rule");
+
+    // Next login of the stamped adopter re-runs the filesystem adoption.
+    let skill_repo = SqliteSkillRepository::new(db.pool().clone());
+    fs_adopt::adopt_user_filesystem(&paths, &skill_repo, &adopter.id).await;
+
+    let healed = service
+        .read_rule_for_user(&adopter.id, ASSISTANT_ID, Some("zh-CN"))
+        .await
+        .unwrap();
+    assert_eq!(
+        healed, RULE_BODY,
+        "catch-up rerun on next login must heal the adopted rules"
+    );
+}

--- a/crates/aionui-extension/src/fs_adopt.rs
+++ b/crates/aionui-extension/src/fs_adopt.rs
@@ -54,6 +54,17 @@ pub async fn adopt_user_filesystem(
         moved += move_dir_contents(&src, &dst);
     }
 
+    // Pre-user-scope installs kept assistant rule files directly under
+    // `assistant-rules/` (no `users/` segment) and no upgrade migration ever
+    // moved them: the local default user still reads them through a
+    // default-user-only legacy fallback in AssistantService, but an adopter
+    // cannot reach that fallback — without this move the adopted account
+    // silently loses every rule authored before the user-scope upgrade.
+    moved += move_root_files(
+        &paths.assistant_rules_dir,
+        &paths.assistant_rules_dir.join("users").join(&adopter_dir),
+    );
+
     rewrite_adopted_skill_paths(paths, skill_repo, adopter_user_id, &adopter_dir).await;
 
     if moved > 0 {
@@ -79,6 +90,42 @@ fn move_dir_contents(src: &Path, dst: &Path) -> u64 {
         let to = dst.join(name);
         if to.exists() {
             continue; // idempotent: destination already has it
+        }
+        match std::fs::rename(&from, &to) {
+            Ok(()) => moved += 1,
+            Err(err) if is_cross_device(&err) => {
+                if copy_then_remove(&from, &to) {
+                    moved += 1;
+                }
+            }
+            Err(err) => {
+                warn!(from = %from.display(), to = %to.display(), error = %err, "fs adoption: move failed");
+            }
+        }
+    }
+    moved
+}
+
+/// Move only the regular files at the top level of `root` into `dst`,
+/// leaving subdirectories (`users/`, ...) untouched. Missing `root` -> 0.
+fn move_root_files(root: &Path, dst: &Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return 0;
+    };
+    let mut moved = 0u64;
+    for entry in entries.flatten() {
+        let from = entry.path();
+        if from.is_dir() {
+            continue; // the per-user tree (and any future subdir) stays put
+        }
+        let Some(name) = from.file_name() else { continue };
+        let to = dst.join(name);
+        if to.exists() {
+            continue; // idempotent: destination already has it
+        }
+        if let Err(err) = std::fs::create_dir_all(dst) {
+            warn!(dst = %dst.display(), error = %err, "fs adoption: create destination failed");
+            return moved;
         }
         match std::fs::rename(&from, &to) {
             Ok(()) => moved += 1,


### PR DESCRIPTION
## Problem

After adopting into an AionPro account, users upgraded from pre-user-scope versions find **all their assistant rules gone** (read back as empty). Reported by internal testers and users.

## Root cause (reproduced, not inferred)

- Pre-user-scope installs keep rule files directly at the **legacy root** `assistant-rules/<id>.<locale>.md` (no `users/` segment). No upgrade migration ever moved them — verified on a real upgraded profile: all rule files at the legacy root, `users/` empty.
- The local default user still reads them via a **default-user-only** legacy fallback in `AssistantService` (`user_id != DEFAULT_USER_ID` returns early), so AionUi looks fine.
- Filesystem adoption (`fs_adopt`) only moves `X/users/system_default_user/` — legacy root files stay behind, and the adopter cannot reach the fallback → rules silently read empty.

## Fix

During filesystem adoption, also move the **regular files at the `assistant-rules` root** (subdirectories like `users/` stay put) into the adopter's per-user dir. Idempotent, same-volume rename with EXDEV copy fallback, best-effort — same semantics as the existing moves.

Scope note: `assistant-skills` / `assistant-avatars` were checked against real profiles — no legacy-root data exists for them; `skills/` is path-column-based and unaffected.

## Already-adopted users heal automatically

The auth layer re-runs the idempotent filesystem adoption on **every login of the stamped adopter** (the #716 catch-up mechanism for partial moves). On the first login after this fix ships, the leftover legacy files get moved and the rules come back — no manual action.

## Verification

Real end-to-end test (`aionui-app/tests/adoption_assistant_rules_e2e.rs`) — real migrations, real `ensure_external_user`, real DB adoption + stamp, real `fs_adopt`, real `AssistantService` reads; no mocks:

1. `users/system_default_user` layout → adopter reads the rule (regression guard)
2. **legacy root layout → was RED before the fix (adopter read ""), GREEN after**
3. **already-adopted broken state + rerun → heals** (validates the login catch-up path)

Also green: `cargo test -p aionui-extension`, `clippy -p aionui-extension -p aionui-app --tests -D warnings`, `fmt --check`. Full workspace left to PR CI.