### PR TITLE
feat(scm): live repository-set changes + pe_name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,7 @@ dependencies = [
  "axum",
  "base64",
  "chrono",
+ "git2",
  "http-body-util",
  "ignore",
  "notify",
@@ -806,6 +807,7 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+ "trash",
  "url",
 ]
 
@@ -3229,7 +3231,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3939,6 +3941,31 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -5976,6 +6003,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "trash"
+version = "5.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7602e0c7d66ec2d92a8c917219fbc7894039efa2063b9064260110828a356f46"
+dependencies = [
+ "chrono",
+ "libc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "once_cell",
+ "percent-encoding",
+ "scopeguard",
+ "urlencoding",
+ "windows",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6432,16 +6477,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+dependencies = [
+ "windows-core 0.56.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+dependencies = [
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6449,6 +6527,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6471,6 +6560,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,9 @@ walkdir = "2"
 ignore = "0.4"
 zip = "2"
 git2 = { version = "0.20", default-features = false }
+# Source-control discard sends untracked files to the platform trash instead of
+# unlinking them (mac/win/linux, x64 + arm64).
+trash = "5"
 mime_guess = "2"
 rust-embed = "8"
 

--- a/crates/aionui-app/src/router/mod.rs
+++ b/crates/aionui-app/src/router/mod.rs
@@ -6,6 +6,7 @@ mod health;
 mod item_revealer;
 mod routes;
 mod runtime_team_tools;
+mod scm_monitor;
 mod state;
 mod system_file_opener;
 mod team_conversation_adapters;

--- a/crates/aionui-app/src/router/routes.rs
+++ b/crates/aionui-app/src/router/routes.rs
@@ -44,6 +44,7 @@ use crate::services::AppServices;
 use super::fs_monitor::spawn_fs_monitor;
 use super::health::health_check;
 use super::runtime_team_tools::{RuntimeTeamToolsState, runtime_team_tools_routes};
+use super::scm_monitor::{CompositeMessageRouter, spawn_scm_monitor};
 use super::state::{ModuleStates, RouterBuildError, build_module_states, build_ws_state};
 use super::trace::with_access_log;
 
@@ -144,7 +145,14 @@ pub async fn create_router_with_runtime(services: &AppServices) -> Result<(Route
     // router (fs/* frames). Built here — inside the runtime — because the actor
     // runs as a background task. The sync test-only assembly path keeps a no-op.
     let fs_router = spawn_fs_monitor(Arc::new(services.project_service.clone()), services.ws_manager.clone());
-    let ws_state = build_ws_state(services, fs_router);
+    // Source control shares the connection but owns its own envelope name, so the
+    // two inbound routers are composed behind the realtime layer's single slot.
+    let scm_router = spawn_scm_monitor(Arc::new(services.project_service.clone()), services.ws_manager.clone());
+    let inbound_router: Arc<dyn aionui_realtime::MessageRouter> = match scm_router {
+        Some(scm) => Arc::new(CompositeMessageRouter::new(vec![fs_router, scm])),
+        None => fs_router,
+    };
+    let ws_state = build_ws_state(services, inbound_router);
     let router = create_router_with_all_state(services, states, ws_state);
     tracing::info!(
         elapsed_ms = boot.elapsed().as_millis(),

--- a/crates/aionui-app/src/router/scm_monitor.rs
+++ b/crates/aionui-app/src/router/scm_monitor.rs
@@ -72,9 +72,17 @@ pub fn spawn_scm_monitor(
     manager: Arc<WebSocketManager>,
 ) -> Option<Arc<dyn MessageRouter>> {
     let push: Arc<dyn ScmWirePush> = Arc::new(WsManagerPush { manager });
-    match ScmActor::new(project, push) {
+    let (inbound, inbound_rx) = tokio::sync::mpsc::unbounded_channel();
+    match ScmActor::new(Arc::clone(&project), push) {
         Ok(actor) => {
-            let (inbound, inbound_rx) = tokio::sync::mpsc::unbounded_channel();
+            // Direct wiring (乙), not an event bus (甲): source control is the only
+            // subscriber to project-explorer root changes, so feeding the service's
+            // attach/detach notifications straight into this actor's inbound is
+            // cheaper and clearer than a general bus. All `ProjectService` handles
+            // are clones of one instance, so the sender installed here is the same
+            // one the HTTP attach/detach handlers observe. Revisit if a second
+            // subscriber to root changes ever appears.
+            project.set_scm_roots_sender(inbound.clone());
             tokio::spawn(actor.run(inbound_rx));
             Some(Arc::new(ScmMessageRouter { inbound }))
         }

--- a/crates/aionui-app/src/router/scm_monitor.rs
+++ b/crates/aionui-app/src/router/scm_monitor.rs
@@ -1,0 +1,134 @@
+//! Composition wiring for the source-control monitor.
+//!
+//! Adapts the transport-agnostic [`ScmActor`] (in `aionui-project`) to the
+//! realtime WebSocket layer, mirroring the explorer's `fs_monitor` wiring: an
+//! inbound router forwards `scm` frames and disconnects into the actor's channel,
+//! and an outbound adapter implements the actor's push port over the manager's
+//! unicast, wrapping each inner JSON-RPC frame in `{ name: "scm", data }`.
+
+use std::sync::Arc;
+
+use aionui_api_types::WebSocketMessage;
+use aionui_project::ProjectService;
+use aionui_project::scm::{ScmActor, ScmInbound, ScmWirePush};
+use aionui_realtime::{ConnectionId, MessageRouter, WebSocketManager};
+use serde_json::Value;
+use tokio::sync::mpsc::UnboundedSender;
+
+/// Inbound adapter: routes outer-envelope `scm` frames to the actor.
+struct ScmMessageRouter {
+    inbound: UnboundedSender<ScmInbound>,
+}
+
+impl MessageRouter for ScmMessageRouter {
+    fn route(&self, conn_id: ConnectionId, user_id: &str, name: &str, data: Value) -> bool {
+        if name != "scm" {
+            return false;
+        }
+        // A closed channel means the actor stopped; the frame is dropped and the
+        // connection observes silence (it can reconnect and re-subscribe).
+        let _ = self.inbound.send(ScmInbound::Frame {
+            session: conn_id.0.to_string(),
+            user_id: user_id.to_owned(),
+            frame: data,
+        });
+        true
+    }
+
+    fn on_disconnect(&self, conn_id: ConnectionId) {
+        // Load-bearing: without this, a reconnect churn would leave one armed
+        // metadata watch per dropped connection with nothing to release it.
+        let _ = self.inbound.send(ScmInbound::Disconnect {
+            session: conn_id.0.to_string(),
+        });
+    }
+}
+
+/// Outbound adapter: unicast one inner frame inside the `scm` envelope.
+struct WsManagerPush {
+    manager: Arc<WebSocketManager>,
+}
+
+impl ScmWirePush for WsManagerPush {
+    fn push(&self, session: &str, frame: Value) {
+        if let Ok(id) = session.parse::<u64>() {
+            // Same backpressure policy as the explorer link: drop the connection
+            // rather than silently drop a frame, since a client that missed a
+            // status frame would keep showing a stale change list with no way to
+            // notice. It reconnects and re-subscribes.
+            self.manager
+                .send_to_or_disconnect(ConnectionId(id), WebSocketMessage::new("scm", frame));
+        }
+    }
+}
+
+/// Spawn the source-control actor and return its inbound router.
+///
+/// `None` when initialisation fails (e.g. no filesystem watcher available): the
+/// caller then installs only the other routers, so a source-control failure never
+/// takes the rest of the WebSocket surface down with it.
+pub fn spawn_scm_monitor(
+    project: Arc<ProjectService>,
+    manager: Arc<WebSocketManager>,
+) -> Option<Arc<dyn MessageRouter>> {
+    let push: Arc<dyn ScmWirePush> = Arc::new(WsManagerPush { manager });
+    match ScmActor::new(project, push) {
+        Ok(actor) => {
+            let (inbound, inbound_rx) = tokio::sync::mpsc::unbounded_channel();
+            tokio::spawn(actor.run(inbound_rx));
+            Some(Arc::new(ScmMessageRouter { inbound }))
+        }
+        Err(err) => {
+            tracing::error!(error = %err, "scm monitor init failed; source-control protocol disabled");
+            None
+        }
+    }
+}
+
+/// Routes a message to the first sub-router that claims it.
+///
+/// The realtime layer holds exactly one router, while each feature owns its own
+/// envelope name and already declines names it does not serve — so composing them
+/// is just "ask in turn". Disconnects go to **all** of them: every stateful
+/// router has per-connection state to release.
+pub struct CompositeMessageRouter {
+    routers: Vec<Arc<dyn MessageRouter>>,
+}
+
+impl CompositeMessageRouter {
+    pub fn new(routers: Vec<Arc<dyn MessageRouter>>) -> Self {
+        Self { routers }
+    }
+}
+
+impl MessageRouter for CompositeMessageRouter {
+    fn route(&self, conn_id: ConnectionId, user_id: &str, name: &str, data: Value) -> bool {
+        for router in &self.routers {
+            // `data` is cloned per attempt because a declining router must leave
+            // the value intact for the next one; only the claiming router uses it.
+            if router.route(conn_id, user_id, name, data.clone()) {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn on_disconnect(&self, conn_id: ConnectionId) {
+        for router in &self.routers {
+            // Isolated per router: disconnect is the only signal that frees a
+            // connection's resources, so one subsystem failing here must not stop
+            // the others from being told — that would leak their watches and
+            // subscriptions for the lifetime of the process.
+            if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| router.on_disconnect(conn_id))).is_err() {
+                tracing::error!(
+                    conn_id = conn_id.0,
+                    "a message router panicked while releasing a connection; continuing with the rest"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "scm_monitor_test.rs"]
+mod scm_monitor_test;

--- a/crates/aionui-app/src/router/scm_monitor_test.rs
+++ b/crates/aionui-app/src/router/scm_monitor_test.rs
@@ -1,0 +1,189 @@
+//! Wiring tests: envelope routing, disconnect propagation, and composition.
+
+use aionui_realtime::{PER_CONNECTION_BUFFER, WsOutbound};
+use serde_json::json;
+use tokio::sync::mpsc;
+
+use super::*;
+
+#[test]
+fn router_claims_scm_frames_with_a_stringified_session() {
+    let (inbound, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let router = ScmMessageRouter { inbound };
+
+    let handled = router.route(ConnectionId(5), "user-1", "scm", json!({"method": "scm/status"}));
+    assert!(handled, "scm frames are claimed");
+
+    match rx.try_recv().expect("frame forwarded") {
+        ScmInbound::Frame {
+            session,
+            user_id,
+            frame,
+        } => {
+            assert_eq!(session, "5", "the connection id becomes the session id");
+            assert_eq!(user_id, "user-1", "the connection's user is threaded through");
+            assert_eq!(frame["method"], "scm/status");
+        }
+        other => panic!("expected Frame, got {other:?}"),
+    }
+}
+
+#[test]
+fn router_declines_other_envelopes() {
+    let (inbound, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let router = ScmMessageRouter { inbound };
+
+    // Declining is what lets several feature routers share one slot.
+    assert!(!router.route(ConnectionId(1), "user-1", "fs", json!({})));
+    assert!(rx.try_recv().is_err(), "nothing is forwarded for another feature");
+}
+
+#[test]
+fn router_forwards_disconnect() {
+    let (inbound, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let router = ScmMessageRouter { inbound };
+
+    // Load-bearing: this is the only signal that releases a connection's watches.
+    router.on_disconnect(ConnectionId(9));
+    match rx.try_recv().expect("disconnect forwarded") {
+        ScmInbound::Disconnect { session } => assert_eq!(session, "9"),
+        other => panic!("expected Disconnect, got {other:?}"),
+    }
+}
+
+#[test]
+fn push_wraps_frames_in_the_scm_envelope() {
+    let manager = Arc::new(WebSocketManager::new());
+    let (tx, mut rx) = mpsc::channel::<WsOutbound>(PER_CONNECTION_BUFFER);
+    let conn = manager.add_client("tok".to_owned(), tx);
+
+    let push = WsManagerPush {
+        manager: Arc::clone(&manager),
+    };
+    push.push(&conn.0.to_string(), json!({"result": {}}));
+
+    match rx.try_recv().expect("frame delivered") {
+        WsOutbound::Text(text) => {
+            let parsed: Value = serde_json::from_str(&text).expect("valid json");
+            // The name is what routes it back to the source-control client, and it
+            // must not collide with the explorer's own envelope.
+            assert_eq!(parsed["name"], "scm");
+            assert!(parsed["data"]["result"].is_object());
+        }
+        other => panic!("expected Text, got {other:?}"),
+    }
+}
+
+#[test]
+fn push_to_an_unparseable_session_is_a_noop() {
+    let manager = Arc::new(WebSocketManager::new());
+    let push = WsManagerPush { manager };
+    // Must not panic: session ids arrive as strings from the transport.
+    push.push("not-a-number", json!({}));
+}
+
+/// Records which envelope names it was offered, claiming only the one it owns.
+struct SpyRouter {
+    name: &'static str,
+    seen: std::sync::Mutex<Vec<String>>,
+    disconnects: std::sync::Mutex<Vec<u64>>,
+}
+
+impl SpyRouter {
+    fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            seen: std::sync::Mutex::new(Vec::new()),
+            disconnects: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl MessageRouter for SpyRouter {
+    fn route(&self, _conn_id: ConnectionId, _user_id: &str, name: &str, _data: Value) -> bool {
+        self.seen.lock().expect("spy poisoned").push(name.to_owned());
+        name == self.name
+    }
+
+    fn on_disconnect(&self, conn_id: ConnectionId) {
+        self.disconnects.lock().expect("spy poisoned").push(conn_id.0);
+    }
+}
+
+#[test]
+fn composite_routes_each_envelope_to_its_owner() {
+    let fs = Arc::new(SpyRouter::new("fs"));
+    let scm = Arc::new(SpyRouter::new("scm"));
+    let composite = CompositeMessageRouter::new(vec![
+        Arc::clone(&fs) as Arc<dyn MessageRouter>,
+        Arc::clone(&scm) as Arc<dyn MessageRouter>,
+    ]);
+
+    assert!(composite.route(ConnectionId(1), "u", "scm", json!({"a": 1})));
+    assert!(composite.route(ConnectionId(1), "u", "fs", json!({})));
+    assert_eq!(
+        scm.seen.lock().expect("spy").len(),
+        1,
+        "the scm router is only consulted for the frame fs declined"
+    );
+}
+
+#[test]
+fn composite_reports_unclaimed_envelopes_as_unhandled() {
+    let fs = Arc::new(SpyRouter::new("fs"));
+    let composite = CompositeMessageRouter::new(vec![fs as Arc<dyn MessageRouter>]);
+
+    // Returning false is what lets the realtime layer answer "unsupported message"
+    // instead of silently swallowing it.
+    assert!(!composite.route(ConnectionId(1), "u", "something-else", json!({})));
+}
+
+#[test]
+fn composite_broadcasts_disconnect_to_every_router() {
+    // Each stateful router has its own per-connection state to release, so a
+    // disconnect must reach all of them — not just the one that last claimed a
+    // frame.
+    let fs = Arc::new(SpyRouter::new("fs"));
+    let scm = Arc::new(SpyRouter::new("scm"));
+    let composite = CompositeMessageRouter::new(vec![
+        Arc::clone(&fs) as Arc<dyn MessageRouter>,
+        Arc::clone(&scm) as Arc<dyn MessageRouter>,
+    ]);
+
+    composite.on_disconnect(ConnectionId(7));
+    assert_eq!(*fs.disconnects.lock().expect("spy"), vec![7]);
+    assert_eq!(*scm.disconnects.lock().expect("spy"), vec![7]);
+}
+
+/// A router that panics on disconnect, standing in for a sub-router with a bug.
+struct PanickingRouter;
+
+impl MessageRouter for PanickingRouter {
+    fn route(&self, _conn_id: ConnectionId, _user_id: &str, _name: &str, _data: Value) -> bool {
+        false
+    }
+
+    fn on_disconnect(&self, _conn_id: ConnectionId) {
+        panic!("sub-router failed while releasing");
+    }
+}
+
+#[test]
+fn one_failing_router_does_not_block_the_others_release() {
+    // Disconnect is the only signal that frees per-connection resources. If one
+    // sub-router panics partway through the broadcast, every router after it would
+    // never be told — one subsystem's bug would leak another subsystem's watches.
+    let scm = Arc::new(SpyRouter::new("scm"));
+    let composite = CompositeMessageRouter::new(vec![
+        Arc::new(PanickingRouter) as Arc<dyn MessageRouter>,
+        Arc::clone(&scm) as Arc<dyn MessageRouter>,
+    ]);
+
+    composite.on_disconnect(ConnectionId(3));
+
+    assert_eq!(
+        *scm.disconnects.lock().expect("spy"),
+        vec![3],
+        "the router after the failing one still got its disconnect"
+    );
+}

--- a/crates/aionui-project/Cargo.toml
+++ b/crates/aionui-project/Cargo.toml
@@ -23,6 +23,10 @@ notify.workspace = true
 # Filename search: in-process tree walk honoring .gitignore/excludes (same walker
 # ripgrep is built on) — no ripgrep subprocess, since filename search reads no content.
 ignore.workspace = true
+# Source control: in-process git (no external binary, headless/cross-platform),
+# plus platform trash for discarding untracked files non-destructively.
+git2.workspace = true
+trash.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/aionui-project/src/lib.rs
+++ b/crates/aionui-project/src/lib.rs
@@ -14,6 +14,7 @@ pub mod containment;
 pub mod monitor;
 pub mod routes;
 pub mod runtime;
+pub mod scm;
 mod service;
 pub mod types;
 

--- a/crates/aionui-project/src/scm/actor.rs
+++ b/crates/aionui-project/src/scm/actor.rs
@@ -1,0 +1,500 @@
+//! The source-control actor: one event loop owning the runtime.
+//!
+//! Mirrors the explorer monitor's shape — a single task consumes inbound frames
+//! and watch signals, and pushes outbound frames through a narrow port, so the
+//! domain never depends on a concrete transport.
+//!
+//! It exists to serialize three otherwise-racing inputs: client requests, watch
+//! signals, and action completions. Refresh and sequence allocation happen inside
+//! [`ScmRuntime`]'s per-repository critical section; this loop's job is to decide
+//! *when* to refresh and *who* to tell.
+
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::time::{Instant, interval};
+
+use crate::service::ProjectService;
+use crate::types::{FileOp, ProjectError, ReferenceInput};
+
+use super::debounce::{DirtyDebouncer, flush_interval};
+use super::error::ScmError;
+use super::provider::IScmProvider;
+use super::runtime::ScmRuntime;
+use super::types::{FileRef, RepoRef, ResolvedRoot};
+use super::watch::ScmDirty;
+use super::wire;
+
+/// Identifies one connection. A string mirroring the transport's connection id,
+/// so the domain does not depend on the realtime crate's type.
+pub type ScmSessionId = String;
+
+/// Narrow outbound port: deliver one inner JSON-RPC frame to a connection.
+///
+/// The composition layer implements this over the WS manager's unicast, wrapping
+/// each frame in the `{ name: "scm", data }` envelope.
+pub trait ScmWirePush: Send + Sync {
+    fn push(&self, session: &str, frame: Value);
+}
+
+/// An inbound event from the transport layer.
+#[derive(Debug, Clone)]
+pub enum ScmInbound {
+    /// One `scm` frame's payload (the inner JSON-RPC value).
+    Frame {
+        session: ScmSessionId,
+        user_id: String,
+        frame: Value,
+    },
+    /// The connection closed — release its subscriptions and watches.
+    Disconnect { session: ScmSessionId },
+}
+
+/// Source-control protocol actor.
+pub struct ScmActor {
+    project: Arc<ProjectService>,
+    runtime: Arc<ScmRuntime>,
+    push: Arc<dyn ScmWirePush>,
+    debouncer: DirtyDebouncer,
+    started: Instant,
+    /// Watch signals, taken by `run`. Held here so `new` does not expose the
+    /// internal signal type in its signature.
+    dirty_rx: Option<UnboundedReceiver<ScmDirty>>,
+}
+
+impl ScmActor {
+    /// Build the actor.
+    ///
+    /// The watch-signal channel stays internal: it is an implementation detail of
+    /// how dirt reaches the loop, and the composition layer has no use for it.
+    pub fn new(project: Arc<ProjectService>, push: Arc<dyn ScmWirePush>) -> Result<Self, ScmError> {
+        let (runtime, dirty_rx) = ScmRuntime::new()?;
+        Ok(Self {
+            project,
+            runtime: Arc::new(runtime),
+            push,
+            debouncer: DirtyDebouncer::default(),
+            started: Instant::now(),
+            dirty_rx: Some(dirty_rx),
+        })
+    }
+
+    /// Run the loop until every inbound sender is dropped.
+    pub async fn run(mut self, mut inbound: UnboundedReceiver<ScmInbound>) {
+        let mut dirty_rx = self.dirty_rx.take().expect("scm dirty receiver taken once in run");
+        let mut flush = interval(flush_interval());
+        loop {
+            tokio::select! {
+                event = inbound.recv() => match event {
+                    Some(event) => self.on_inbound(event).await,
+                    // All senders gone (router dropped, app shutting down).
+                    None => break,
+                },
+                // The sender lives inside the runtime's watcher, so this stays
+                // open for the actor's whole life.
+                dirty = dirty_rx.recv() => if let Some(dirty) = dirty {
+                    self.debouncer.mark(dirty.repo_id, self.now_ms());
+                },
+                _ = flush.tick() => self.flush_dirty().await,
+            }
+        }
+    }
+
+    fn now_ms(&self) -> u64 {
+        self.started.elapsed().as_millis() as u64
+    }
+
+    /// Recompute the repositories whose signal bursts have gone quiet and push
+    /// the new frames to their subscribers.
+    async fn flush_dirty(&mut self) {
+        if self.debouncer.is_idle() {
+            return;
+        }
+        for repo_id in self.debouncer.take_ready(self.now_ms()) {
+            let repo = RepoRef {
+                repo_id: repo_id.clone(),
+            };
+            // Recompute once, then fan out the same frame: computing per
+            // subscriber would waste work and could hand out differing statuses.
+            match self.runtime.refresh(&repo).await {
+                Ok(status) => {
+                    let frame = wire::notification(
+                        "scm/statusChanged",
+                        serde_json::to_value(&status).unwrap_or_else(|_| json!({})),
+                    );
+                    for session in self.runtime.subscribers_of(&repo_id).await {
+                        self.push.push(&session, frame.clone());
+                    }
+                }
+                // A repository released between the signal and the flush is
+                // ordinary; nothing to tell anyone.
+                Err(err) => tracing::debug!(repo_id, error = %err, "scm refresh after dirty signal failed"),
+            }
+        }
+    }
+
+    async fn on_inbound(&mut self, event: ScmInbound) {
+        match event {
+            ScmInbound::Frame {
+                session,
+                user_id,
+                frame,
+            } => self.on_frame(&session, &user_id, frame).await,
+            ScmInbound::Disconnect { session } => self.runtime.drop_session(&session).await,
+        }
+    }
+
+    async fn on_frame(&mut self, session: &str, user_id: &str, frame: Value) {
+        let Ok(incoming) = serde_json::from_value::<wire::IncomingFrame>(frame) else {
+            self.push.push(
+                session,
+                wire::error(None, wire::CODE_INVALID_REQUEST, "invalid_request", Value::Null),
+            );
+            return;
+        };
+        let id = incoming.id.clone();
+        let params = incoming.params.clone();
+
+        let outcome = match incoming.method.as_str() {
+            "scm/listRepositories" => self.list_repositories(user_id, params).await,
+            "scm/subscribe" => self.subscribe(session, user_id, params).await,
+            "scm/unsubscribe" => {
+                self.unsubscribe(session, params).await;
+                return; // notification: no reply
+            }
+            "scm/status" => self.status(user_id, params).await,
+            "scm/diff" => self.diff(user_id, params).await,
+            "scm/original" => self.original(user_id, params).await,
+            "scm/stage" => self.stage(user_id, params, true).await,
+            "scm/unstage" => self.stage(user_id, params, false).await,
+            "scm/discard" => self.discard(user_id, params).await,
+            other => {
+                tracing::warn!(session, method = %other, "scm dispatch: unknown method");
+                self.push.push(
+                    session,
+                    wire::error(id, wire::CODE_METHOD_NOT_FOUND, "method_not_found", Value::Null),
+                );
+                return;
+            }
+        };
+
+        match outcome {
+            Ok(result) => self.push.push(session, wire::success(id, result)),
+            Err(err) => self.push.push(session, wire::error_from(id, &err)),
+        }
+    }
+
+    // ── methods ───────────────────────────────────────────────────────────
+
+    async fn list_repositories(&self, user_id: &str, params: Value) -> Result<Value, ScmError> {
+        let project_id = params
+            .get("project_id")
+            .and_then(Value::as_str)
+            .ok_or(ScmError::InvalidParams { what: "project_id" })?;
+
+        let roots = self.roots_of(user_id, project_id).await?;
+        let repositories = self.runtime.discover(&roots).await;
+        Ok(json!({ "repositories": repositories }))
+    }
+
+    async fn subscribe(&self, session: &str, user_id: &str, params: Value) -> Result<Value, ScmError> {
+        let repo_ids = params
+            .get("repositories")
+            .and_then(Value::as_array)
+            .map(|ids| {
+                ids.iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_owned)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        // Per repository, like the multi-file actions: subscribing to several
+        // repositories in one request is the same shape of problem, and failing the
+        // whole call would leave the two sides disagreeing about what is
+        // subscribed — the server has already armed a watch and recorded the
+        // subscriber for the ones that succeeded, while the client, seeing only an
+        // error, never unsubscribes them and then receives pushes it does not
+        // expect.
+        let mut statuses = Vec::new();
+        let mut failed: Vec<Value> = Vec::new();
+        for repo_id in repo_ids {
+            let repo = RepoRef {
+                repo_id: repo_id.clone(),
+            };
+            let outcome = match self.authorize(user_id, &repo, FileOp::Browse).await {
+                Ok(()) => self.runtime.subscribe(session, &repo).await,
+                Err(err) => Err(err),
+            };
+            match outcome {
+                Ok(status) => statuses.push(status),
+                Err(err) => failed.push(json!({ "repo_id": repo_id, "reason": err.to_string() })),
+            }
+        }
+        // Absent when everything succeeded, so a client written before per-item
+        // reporting sees exactly the frame it saw before.
+        if failed.is_empty() {
+            Ok(json!({ "statuses": statuses }))
+        } else {
+            Ok(json!({ "statuses": statuses, "failed": failed }))
+        }
+    }
+
+    async fn unsubscribe(&self, session: &str, params: Value) {
+        let repo_ids = params
+            .get("repositories")
+            .and_then(Value::as_array)
+            .map(|ids| {
+                ids.iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_owned)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        for repo_id in repo_ids {
+            self.runtime.unsubscribe(session, &RepoRef { repo_id }).await;
+        }
+    }
+
+    async fn status(&self, user_id: &str, params: Value) -> Result<Value, ScmError> {
+        let repo = Self::repo_of(&params)?;
+        self.authorize(user_id, &repo, FileOp::Browse).await?;
+        let status = self.runtime.refresh(&repo).await?;
+        Ok(serde_json::to_value(&status).unwrap_or_else(|_| json!({})))
+    }
+
+    async fn diff(&self, user_id: &str, params: Value) -> Result<Value, ScmError> {
+        let repo = Self::repo_of(&params)?;
+        let file = Self::file_of(&params)?;
+        let from = wire::parse_content_ref(params.get("from").unwrap_or(&Value::Null))
+            .ok_or(ScmError::InvalidParams { what: "from" })?;
+        let to = wire::parse_content_ref(params.get("to").unwrap_or(&Value::Null))
+            .ok_or(ScmError::InvalidParams { what: "to" })?;
+
+        let file = self.authorize_file(user_id, &file, FileOp::Read).await?;
+        let diff = self.runtime.provider().diff(&repo, &file, from, to).await?;
+        Ok(serde_json::to_value(&diff).unwrap_or_else(|_| json!({})))
+    }
+
+    async fn original(&self, user_id: &str, params: Value) -> Result<Value, ScmError> {
+        let repo = Self::repo_of(&params)?;
+        let file = Self::file_of(&params)?;
+        let at = wire::parse_content_ref(params.get("at").unwrap_or(&Value::Null))
+            .ok_or(ScmError::InvalidParams { what: "at" })?;
+
+        let file = self.authorize_file(user_id, &file, FileOp::Read).await?;
+        let content = self.runtime.provider().original(&repo, &file, at).await?;
+        Ok(match content {
+            // Text when it decodes, base64 otherwise: the wire carries either
+            // form, and guessing wrong would corrupt content.
+            Some(bytes) => match String::from_utf8(bytes.clone()) {
+                Ok(text) => json!({ "content": text, "encoding": "utf-8" }),
+                Err(_) => json!({
+                    "content": base64_encode(&bytes),
+                    "encoding": "base64",
+                }),
+            },
+            None => json!({}),
+        })
+    }
+
+    async fn stage(&self, user_id: &str, params: Value, stage: bool) -> Result<Value, ScmError> {
+        let repo = Self::repo_of(&params)?;
+        let requested = Self::files_of(&params)?;
+        // Collected per file: every entry must be replaced by its normalized form,
+        // not just the first one.
+        let mut files = Vec::with_capacity(requested.len());
+        for file in &requested {
+            files.push(self.authorize_file(user_id, file, FileOp::Write).await?);
+        }
+
+        let provider = self.runtime.provider();
+        let staging = provider
+            .staging()
+            .ok_or(ScmError::CapabilityUnsupported { capability: "staging" })?;
+
+        // Inside the repository's critical section, so the published status
+        // cannot describe a half-applied action.
+        let (outcome, status) = self
+            .runtime
+            .act(&repo, || async {
+                if stage {
+                    staging.stage(&repo, &files).await
+                } else {
+                    staging.unstage(&repo, &files).await
+                }
+            })
+            .await?;
+        self.broadcast(&status).await;
+        Ok(serde_json::to_value(&outcome).unwrap_or_else(|_| json!({})))
+    }
+
+    async fn discard(&self, user_id: &str, params: Value) -> Result<Value, ScmError> {
+        let repo = Self::repo_of(&params)?;
+        let requested = Self::files_of(&params)?;
+        let mut files = Vec::with_capacity(requested.len());
+        for file in &requested {
+            files.push(self.authorize_file(user_id, file, FileOp::Remove).await?);
+        }
+
+        let provider = self.runtime.provider();
+        let (outcome, status) = self
+            .runtime
+            .act(&repo, || async { provider.revert(&repo, &files).await })
+            .await?;
+        self.broadcast(&status).await;
+        // Successful files are not listed; an absent `failed` means all of them.
+        Ok(serde_json::to_value(&outcome).unwrap_or_else(|_| json!({})))
+    }
+
+    /// Push a freshly computed status to everyone subscribed to its repository.
+    async fn broadcast(&self, status: &super::types::ScmStatus) {
+        let frame = wire::notification(
+            "scm/statusChanged",
+            serde_json::to_value(status).unwrap_or_else(|_| json!({})),
+        );
+        for session in self.runtime.subscribers_of(&status.repository.repo_id).await {
+            self.push.push(&session, frame.clone());
+        }
+    }
+
+    // ── guards & params ───────────────────────────────────────────────────
+
+    /// Check the repository's root belongs to this user, via the same
+    /// identity/containment authority the explorer link uses.
+    async fn authorize(&self, user_id: &str, repo: &RepoRef, op: FileOp) -> Result<(), ScmError> {
+        let pe_id = self.runtime.pe_id_of_public(repo).await?;
+        self.authorize_file(
+            user_id,
+            &FileRef {
+                pe_id,
+                relative_path: String::new(),
+            },
+            op,
+        )
+        .await
+        .map(|_| ())
+    }
+
+    /// Check the reference is in scope **and return it normalized**.
+    ///
+    /// The returned path is what every downstream call must use. Authorizing one
+    /// spelling and then operating on another is not merely untidy: several
+    /// lexically equivalent spellings of the same file (`dir/./f`, `dir/sub/../f`,
+    /// `./dir/f`) all pass containment, yet the engine treats them differently —
+    /// some silently fail to match an index entry, and a leading `./` makes it
+    /// reject the path outright. Normalizing once here, at the layer that owns
+    /// identity resolution, keeps the engine from ever seeing those forms, and
+    /// keeps "the path we checked" and "the path we used" the same value.
+    async fn authorize_file(&self, user_id: &str, file: &FileRef, op: FileOp) -> Result<FileRef, ScmError> {
+        self.project
+            .resolve_reference(
+                user_id,
+                ReferenceInput {
+                    pe_id: file.pe_id.clone(),
+                    relative_path: file.relative_path.clone(),
+                    op,
+                },
+            )
+            .await
+            .map(|resolved| FileRef {
+                pe_id: file.pe_id.clone(),
+                relative_path: resolved.relative_path,
+            })
+            .map_err(|err| match err {
+                // A pe the user cannot reach, or a path escaping its root: both
+                // are scope violations, not engine failures.
+                ProjectError::ProjectExplorerNotFound { pe_id } => ScmError::OutOfScope { pe_id },
+                ProjectError::ResourceOutsideFolder { .. } | ProjectError::InvalidRelativePath { .. } => {
+                    ScmError::OutOfScope {
+                        pe_id: file.pe_id.clone(),
+                    }
+                }
+                other => ScmError::OperationFailed {
+                    context: "authorize",
+                    message: other.to_string(),
+                },
+            })
+    }
+
+    /// Resolve a project's roots into the form discovery consumes.
+    async fn roots_of(&self, user_id: &str, project_id: &str) -> Result<Vec<ResolvedRoot>, ScmError> {
+        let view = self
+            .project
+            .get_project(user_id, project_id)
+            .await
+            .map_err(|err| ScmError::OperationFailed {
+                context: "list_repositories",
+                message: err.to_string(),
+            })?;
+
+        let mut roots = Vec::new();
+        for entry in view.explorer.entries {
+            let resolved = self
+                .project
+                .resolve_reference(
+                    user_id,
+                    ReferenceInput {
+                        pe_id: entry.pe_id.clone(),
+                        relative_path: String::new(),
+                        op: FileOp::Browse,
+                    },
+                )
+                .await;
+            match resolved {
+                Ok(resolved) => {
+                    // Only local paths can host a repository; a root without one
+                    // is simply not a candidate.
+                    if let Some(absolute_path) = resolved.absolute_path {
+                        // Same precedence the rest of the project surface uses:
+                        // an explicit entry name wins, else the folder's derived
+                        // one, else the opaque id rather than an empty label.
+                        let label = entry
+                            .display_name
+                            .clone()
+                            .or_else(|| entry.folder.default_display_name.clone())
+                            .unwrap_or_else(|| entry.pe_id.clone());
+                        roots.push(ResolvedRoot {
+                            pe_id: entry.pe_id,
+                            absolute_path,
+                            label,
+                        });
+                    }
+                }
+                Err(err) => tracing::warn!(pe_id = %entry.pe_id, error = %err, "scm: root resolve failed"),
+            }
+        }
+        Ok(roots)
+    }
+
+    fn repo_of(params: &Value) -> Result<RepoRef, ScmError> {
+        params
+            .get("repository")
+            .and_then(Value::as_str)
+            .map(|repo_id| RepoRef {
+                repo_id: repo_id.to_owned(),
+            })
+            .ok_or(ScmError::InvalidParams { what: "repository" })
+    }
+
+    fn file_of(params: &Value) -> Result<FileRef, ScmError> {
+        let file = params.get("file").ok_or(ScmError::InvalidParams { what: "file" })?;
+        serde_json::from_value(file.clone()).map_err(|_| ScmError::InvalidParams { what: "file" })
+    }
+
+    fn files_of(params: &Value) -> Result<Vec<FileRef>, ScmError> {
+        let files = params.get("files").ok_or(ScmError::InvalidParams { what: "files" })?;
+        serde_json::from_value(files.clone()).map_err(|_| ScmError::InvalidParams { what: "files" })
+    }
+}
+
+/// Minimal base64 for binary blob transport (the wire's `base64` encoding).
+fn base64_encode(bytes: &[u8]) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+#[cfg(test)]
+#[path = "actor_test.rs"]
+mod actor_test;

--- a/crates/aionui-project/src/scm/actor.rs
+++ b/crates/aionui-project/src/scm/actor.rs
@@ -49,6 +49,11 @@ pub enum ScmInbound {
     },
     /// The connection closed — release its subscriptions and watches.
     Disconnect { session: ScmSessionId },
+    /// A project's attached-folder set changed (a folder was attached or
+    /// detached). Recompute its repositories and tell interested sessions what was
+    /// added or removed. `user_id` authorizes the root resolution and is internal
+    /// only — it never reaches the wire.
+    RootsChanged { project_id: String, user_id: String },
 }
 
 /// Source-control protocol actor.
@@ -142,6 +147,7 @@ impl ScmActor {
                 frame,
             } => self.on_frame(&session, &user_id, frame).await,
             ScmInbound::Disconnect { session } => self.runtime.drop_session(&session).await,
+            ScmInbound::RootsChanged { project_id, user_id } => self.on_roots_changed(&project_id, &user_id).await,
         }
     }
 
@@ -157,7 +163,7 @@ impl ScmActor {
         let params = incoming.params.clone();
 
         let outcome = match incoming.method.as_str() {
-            "scm/listRepositories" => self.list_repositories(user_id, params).await,
+            "scm/listRepositories" => self.list_repositories(session, user_id, params).await,
             "scm/subscribe" => self.subscribe(session, user_id, params).await,
             "scm/unsubscribe" => {
                 self.unsubscribe(session, params).await;
@@ -187,15 +193,48 @@ impl ScmActor {
 
     // ── methods ───────────────────────────────────────────────────────────
 
-    async fn list_repositories(&self, user_id: &str, params: Value) -> Result<Value, ScmError> {
+    async fn list_repositories(&self, session: &str, user_id: &str, params: Value) -> Result<Value, ScmError> {
         let project_id = params
             .get("project_id")
             .and_then(Value::as_str)
             .ok_or(ScmError::InvalidParams { what: "project_id" })?;
 
+        // Listing a project's repositories is also how a connection registers its
+        // interest in them: from now until it disconnects it receives that
+        // project's `repositoriesChanged` frames. Registering before discovery
+        // closes the window where an attach lands between the two.
+        self.runtime.register_interest(session, project_id).await;
         let roots = self.roots_of(user_id, project_id).await?;
-        let repositories = self.runtime.discover(&roots).await;
+        let repositories = self.runtime.discover(project_id, &roots).await;
         Ok(json!({ "repositories": repositories }))
+    }
+
+    /// Recompute a project's repositories after its attached folders changed, and
+    /// push the added/removed delta to every session interested in the project.
+    ///
+    /// Wired directly (乙), not through an event bus (甲): source control is the
+    /// only subscriber to project-explorer root changes, so a dedicated inbound
+    /// message is cheaper and clearer than a general bus. Revisit if a second
+    /// subscriber ever appears.
+    async fn on_roots_changed(&self, project_id: &str, user_id: &str) {
+        let roots = match self.roots_of(user_id, project_id).await {
+            Ok(roots) => roots,
+            // The project was deleted, or the user can no longer reach it: there is
+            // nothing to recompute and nobody to tell.
+            Err(err) => {
+                tracing::debug!(project_id, error = %err, "scm: roots recompute skipped");
+                return;
+            }
+        };
+        let (added, removed) = self.runtime.recompute_project(project_id, &roots).await;
+        // An empty delta is not a change — do not wake clients for nothing.
+        if added.is_empty() && removed.is_empty() {
+            return;
+        }
+        let frame = wire::repositories_changed(project_id, &added, &removed);
+        for session in self.runtime.project_subscribers_of(project_id).await {
+            self.push.push(&session, frame.clone());
+        }
     }
 
     async fn subscribe(&self, session: &str, user_id: &str, params: Value) -> Result<Value, ScmError> {
@@ -447,18 +486,28 @@ impl ScmActor {
                     // Only local paths can host a repository; a root without one
                     // is simply not a candidate.
                     if let Some(absolute_path) = resolved.absolute_path {
-                        // Same precedence the rest of the project surface uses:
-                        // an explicit entry name wins, else the folder's derived
-                        // one, else the opaque id rather than an empty label.
-                        let label = entry
-                            .display_name
+                        // The entry's own name, if it has a non-blank one. A blank
+                        // (empty or whitespace-only) name counts as no name at all:
+                        // it must survive as neither `label` nor `pe_name`, because
+                        // the client's `pe_name || label` would otherwise render
+                        // whitespace (a blank string is truthy in JS).
+                        let named = entry.display_name.clone().filter(|name| !name.trim().is_empty());
+                        // Same precedence the rest of the project surface uses: an
+                        // explicit name wins, else the folder's derived one, else the
+                        // opaque id. Filtering blanks above makes "label is never
+                        // blank" a backend contract the client can lean on.
+                        let label = named
                             .clone()
                             .or_else(|| entry.folder.default_display_name.clone())
                             .unwrap_or_else(|| entry.pe_id.clone());
+                        // Carried raw and separate from the fallback chain; `None`
+                        // means the entry has no name of its own (never `Some("")`).
+                        let pe_name = named;
                         roots.push(ResolvedRoot {
                             pe_id: entry.pe_id,
                             absolute_path,
                             label,
+                            pe_name,
                         });
                     }
                 }

--- a/crates/aionui-project/src/scm/actor_test.rs
+++ b/crates/aionui-project/src/scm/actor_test.rs
@@ -1,0 +1,82 @@
+//! Actor tests: frame decoding, dispatch, and parameter validation.
+//!
+//! These cover the parts that need no database: a malformed frame, an unknown
+//! method, and the parameter extraction every method depends on. Method behaviour
+//! against real repositories is covered by the runtime and provider suites; the
+//! full request path (which needs a project store) is exercised by integration
+//! tests.
+
+use serde_json::json;
+
+use super::*;
+
+#[test]
+fn a_malformed_frame_is_rejected_as_an_invalid_request() {
+    // A frame without `method` cannot be dispatched; answering with a framing
+    // error beats silently dropping it, which would leave a client waiting.
+    let decoded = serde_json::from_value::<wire::IncomingFrame>(json!({"jsonrpc": "2.0", "id": 1}));
+    assert!(decoded.is_err(), "a frame with no method does not decode");
+}
+
+#[test]
+fn repository_parameter_is_required() {
+    let missing = ScmActor::repo_of(&json!({}));
+    assert!(
+        matches!(missing, Err(ScmError::InvalidParams { what: "repository" })),
+        "a missing repository is a malformed request, not an unsupported capability"
+    );
+
+    let present = ScmActor::repo_of(&json!({ "repository": "scm:pe1" })).expect("parses");
+    assert_eq!(present.repo_id, "scm:pe1");
+}
+
+#[test]
+fn repository_parameter_must_be_a_string() {
+    // A structured value here would otherwise be silently ignored.
+    assert!(ScmActor::repo_of(&json!({ "repository": { "repo_id": "scm:pe1" } })).is_err());
+    assert!(ScmActor::repo_of(&json!({ "repository": 42 })).is_err());
+}
+
+#[test]
+fn file_parameter_decodes_the_pe_relative_identity() {
+    let file = ScmActor::file_of(&json!({
+        "file": { "pe_id": "pe1", "relative_path": "src/a.ts" }
+    }))
+    .expect("parses");
+    assert_eq!(file.pe_id, "pe1");
+    assert_eq!(file.relative_path, "src/a.ts");
+}
+
+#[test]
+fn a_file_missing_its_identity_is_rejected() {
+    // Half an identity cannot be resolved, and guessing the other half would
+    // address the wrong file.
+    assert!(ScmActor::file_of(&json!({ "file": { "pe_id": "pe1" } })).is_err());
+    assert!(ScmActor::file_of(&json!({ "file": "src/a.ts" })).is_err());
+    assert!(ScmActor::file_of(&json!({})).is_err());
+}
+
+#[test]
+fn files_parameter_accepts_a_batch_and_rejects_a_bare_value() {
+    let files = ScmActor::files_of(&json!({
+        "files": [
+            { "pe_id": "pe1", "relative_path": "a.txt" },
+            { "pe_id": "pe1", "relative_path": "b.txt" }
+        ]
+    }))
+    .expect("parses");
+    assert_eq!(files.len(), 2);
+
+    assert!(
+        ScmActor::files_of(&json!({ "files": { "pe_id": "pe1", "relative_path": "a.txt" } })).is_err(),
+        "a single object is not a batch"
+    );
+    assert!(ScmActor::files_of(&json!({})).is_err());
+}
+
+#[test]
+fn an_empty_batch_is_accepted_as_a_no_op() {
+    // Nothing to do is not an error: a client may send an empty selection.
+    let files = ScmActor::files_of(&json!({ "files": [] })).expect("parses");
+    assert!(files.is_empty());
+}

--- a/crates/aionui-project/src/scm/debounce.rs
+++ b/crates/aionui-project/src/scm/debounce.rs
@@ -1,0 +1,76 @@
+//! Debounce for repository dirty signals.
+//!
+//! A single version-control command produces a burst of metadata events spread
+//! over hundreds of milliseconds — a checkout rewrites the index, moves `HEAD`,
+//! updates refs, each through lock files. Recomputing on the first event would
+//! recompute several times per user action and publish intermediate states, so
+//! signals are collected and flushed once the burst has gone quiet.
+//!
+//! Coalescing is per repository: two repositories going dirty together each get
+//! one recompute, and ten signals for one repository still get one.
+
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+/// How long a repository must stay quiet before its status is recomputed.
+///
+/// Chosen from measured burst behaviour: a bulk checkout's metadata events span
+/// several hundred milliseconds with gaps approaching that, so a shorter window
+/// splits one user action into multiple recomputes. Recomputing is itself
+/// milliseconds, so the wait — not the work — is what a user perceives; this is a
+/// starting value worth re-measuring per platform rather than a tuned constant.
+pub(super) const DEBOUNCE_MS: u64 = 1000;
+
+/// Flush-check cadence. Fine enough that the effective wait stays close to
+/// [`DEBOUNCE_MS`], coarse enough not to wake the loop needlessly.
+pub(super) const FLUSH_TICK_MS: u64 = 100;
+
+/// Accumulates dirty repositories and releases them once quiet.
+#[derive(Default)]
+pub(super) struct DirtyDebouncer {
+    /// Repositories awaiting recompute, with the tick they last went dirty on.
+    pending: Vec<(String, u64)>,
+}
+
+impl DirtyDebouncer {
+    /// Record that a repository is dirty as of `now_ms`.
+    ///
+    /// Re-arms the window: a repository that keeps signalling is recomputed after
+    /// it settles, not while it is still churning.
+    pub(super) fn mark(&mut self, repo_id: String, now_ms: u64) {
+        match self.pending.iter_mut().find(|(id, _)| *id == repo_id) {
+            Some((_, at)) => *at = now_ms,
+            None => self.pending.push((repo_id, now_ms)),
+        }
+    }
+
+    /// Take the repositories that have been quiet for [`DEBOUNCE_MS`].
+    ///
+    /// Returned sorted so behaviour is deterministic regardless of signal order.
+    pub(super) fn take_ready(&mut self, now_ms: u64) -> Vec<String> {
+        let mut ready = BTreeSet::new();
+        self.pending.retain(|(repo_id, at)| {
+            if now_ms.saturating_sub(*at) >= DEBOUNCE_MS {
+                ready.insert(repo_id.clone());
+                false
+            } else {
+                true
+            }
+        });
+        ready.into_iter().collect()
+    }
+
+    /// Whether anything is waiting (lets a caller skip work when idle).
+    pub(super) fn is_idle(&self) -> bool {
+        self.pending.is_empty()
+    }
+}
+
+/// The flush cadence as a [`Duration`], for building an interval timer.
+pub(super) fn flush_interval() -> Duration {
+    Duration::from_millis(FLUSH_TICK_MS)
+}
+
+#[cfg(test)]
+#[path = "debounce_test.rs"]
+mod debounce_test;

--- a/crates/aionui-project/src/scm/debounce_test.rs
+++ b/crates/aionui-project/src/scm/debounce_test.rs
@@ -1,0 +1,85 @@
+//! Debounce tests: coalescing and the quiet-window rule.
+//!
+//! Time is passed in explicitly rather than slept, so these are deterministic and
+//! do not depend on a clock.
+
+use super::*;
+
+#[test]
+fn nothing_is_ready_before_the_window_elapses() {
+    let mut debouncer = DirtyDebouncer::default();
+    debouncer.mark("scm:pe1".to_owned(), 0);
+
+    assert!(
+        debouncer.take_ready(DEBOUNCE_MS - 1).is_empty(),
+        "still within the window"
+    );
+    assert!(!debouncer.is_idle(), "and it is still pending");
+}
+
+#[test]
+fn a_repository_is_released_once_quiet() {
+    let mut debouncer = DirtyDebouncer::default();
+    debouncer.mark("scm:pe1".to_owned(), 0);
+
+    assert_eq!(debouncer.take_ready(DEBOUNCE_MS), vec!["scm:pe1".to_owned()]);
+    assert!(debouncer.is_idle(), "taking it clears the pending set");
+}
+
+#[test]
+fn repeated_signals_coalesce_into_one_recompute() {
+    let mut debouncer = DirtyDebouncer::default();
+    for tick in 0..5 {
+        debouncer.mark("scm:pe1".to_owned(), tick);
+    }
+
+    // One burst of five signals must not become five recomputes.
+    assert_eq!(debouncer.take_ready(4 + DEBOUNCE_MS).len(), 1);
+}
+
+#[test]
+fn a_continuing_burst_re_arms_the_window() {
+    let mut debouncer = DirtyDebouncer::default();
+    debouncer.mark("scm:pe1".to_owned(), 0);
+    // A later signal while still churning pushes the deadline out, so the
+    // recompute happens after things settle rather than mid-burst.
+    debouncer.mark("scm:pe1".to_owned(), DEBOUNCE_MS - 10);
+
+    assert!(
+        debouncer.take_ready(DEBOUNCE_MS).is_empty(),
+        "the window restarted from the newer signal"
+    );
+    assert_eq!(debouncer.take_ready(DEBOUNCE_MS * 2), vec!["scm:pe1".to_owned()]);
+}
+
+#[test]
+fn repositories_are_tracked_independently() {
+    let mut debouncer = DirtyDebouncer::default();
+    debouncer.mark("scm:pe1".to_owned(), 0);
+    debouncer.mark("scm:pe2".to_owned(), DEBOUNCE_MS);
+
+    // Only the settled one is released; the other keeps its own deadline.
+    assert_eq!(debouncer.take_ready(DEBOUNCE_MS), vec!["scm:pe1".to_owned()]);
+    assert_eq!(debouncer.take_ready(DEBOUNCE_MS * 2), vec!["scm:pe2".to_owned()]);
+}
+
+#[test]
+fn ready_repositories_come_back_in_a_stable_order() {
+    let mut debouncer = DirtyDebouncer::default();
+    debouncer.mark("scm:pe9".to_owned(), 0);
+    debouncer.mark("scm:pe1".to_owned(), 0);
+    debouncer.mark("scm:pe5".to_owned(), 0);
+
+    // Order must not depend on signal arrival order.
+    assert_eq!(
+        debouncer.take_ready(DEBOUNCE_MS),
+        vec!["scm:pe1".to_owned(), "scm:pe5".to_owned(), "scm:pe9".to_owned()]
+    );
+}
+
+#[test]
+fn an_idle_debouncer_has_nothing_to_release() {
+    let mut debouncer = DirtyDebouncer::default();
+    assert!(debouncer.is_idle());
+    assert!(debouncer.take_ready(u64::MAX).is_empty());
+}

--- a/crates/aionui-project/src/scm/error.rs
+++ b/crates/aionui-project/src/scm/error.rs
@@ -1,0 +1,65 @@
+//! Source-control operation errors.
+//!
+//! Distinct from [`crate::runtime::FsError`] (filesystem provider IO) and from
+//! [`crate::types::ProjectError`] (bind domain): these describe outcomes of
+//! version-control operations. Mapping to JSON-RPC protocol codes
+//! (`not_a_repository` / `scm_operation_failed` / `capability_unsupported`)
+//! belongs to the WS handler, not here.
+
+/// A source-control operation error.
+#[derive(Debug, thiserror::Error)]
+pub enum ScmError {
+    /// The root is not a repository of this provider. Discovery reports this as
+    /// `Ok(None)`; this variant is for operations invoked on a non-repository.
+    #[error("not a repository: {root}")]
+    NotARepository { root: String },
+
+    /// The referenced resource is outside what this connection may access — a
+    /// stale or forged pe reference. Distinct from "not found" so the client is
+    /// not sent looking for a file it was never allowed to name.
+    #[error("out of scope: {pe_id}")]
+    OutOfScope { pe_id: String },
+
+    /// A required parameter is missing or malformed. Distinct from an unsupported
+    /// capability: the method exists and is allowed, the request is just not
+    /// well-formed.
+    #[error("invalid params: {what}")]
+    InvalidParams { what: &'static str },
+
+    /// Unknown repository id (never discovered, or already released).
+    #[error("unknown repository: {repo_id}")]
+    UnknownRepository { repo_id: String },
+
+    /// The file does not exist at the requested anchor.
+    #[error("resource not found: {path}")]
+    NotFound { path: String },
+
+    /// A capability the provider does not declare was requested — e.g. staging
+    /// on a provider without an index, or [`super::types::ContentRef::Staged`] against one.
+    /// Backstop only: the primary gate is the declared capability set plus the
+    /// absent staging sub-trait.
+    #[error("capability unsupported: {capability}")]
+    CapabilityUnsupported { capability: &'static str },
+
+    /// The operation is refused because the resource is opaque (a conflicted
+    /// resource in stage 1) — a policy refusal, not an engine failure.
+    #[error("operation refused on opaque resource: {path}")]
+    OpaqueResource { path: String },
+
+    /// The underlying engine failed. `context` names the operation so the WS
+    /// layer can attach it without re-deriving it.
+    #[error("scm operation failed during {context}: {message}")]
+    OperationFailed { context: &'static str, message: String },
+
+    /// Local IO failed outside the engine (e.g. moving a file to the trash).
+    #[error("io error on {path}: {message}")]
+    Io { path: String, message: String },
+}
+
+impl ScmError {
+    /// Build a [`ScmError::CapabilityUnsupported`] for [`super::types::ContentRef::Staged`]
+    /// against a provider that has no staging area.
+    pub(super) fn unsupported_staged_anchor() -> Self {
+        Self::CapabilityUnsupported { capability: "staging" }
+    }
+}

--- a/crates/aionui-project/src/scm/git_provider.rs
+++ b/crates/aionui-project/src/scm/git_provider.rs
@@ -101,6 +101,13 @@ impl GitScmProvider {
             .map(|entry| entry.git_dir.clone())
     }
 
+    /// Drop a repository's cached workdir / git-dir handle. Called when the runtime
+    /// releases a repository that has left every project, so a stale entry cannot
+    /// outlive the repository it describes.
+    pub(super) fn forget(&self, repo_id: &str) {
+        self.repos.write().expect("scm repo registry poisoned").remove(repo_id);
+    }
+
     fn entry(&self, repo: &RepoRef) -> Result<RepoEntry, ScmError> {
         self.repos
             .read()
@@ -752,6 +759,10 @@ impl IScmProvider for GitScmProvider {
                 relative_path: String::new(),
             },
             label: root.label.clone(),
+            // Passed through untouched: identity resolution already decided
+            // whether the entry has a name of its own, and the provider must not
+            // second-guess it.
+            pe_name: root.pe_name.clone(),
             head,
             capabilities: caps,
             state: ScmRepositoryState::Idle,

--- a/crates/aionui-project/src/scm/git_provider.rs
+++ b/crates/aionui-project/src/scm/git_provider.rs
@@ -1,0 +1,924 @@
+//! `GitScmProvider` — the git implementation of [`IScmProvider`], in-process
+//! via git2 (no external binary, so headless and cross-platform).
+//!
+//! Written against the git2 public API only; it shares no code with the
+//! checkpoint snapshot service in `aionui-file`, which models a single
+//! workspace and a temp-repo mode neither of which fits source control.
+//!
+//! git2 handles are synchronous and not `Send`, so every repository access runs
+//! inside `spawn_blocking` and the handle never crosses an await point (the same
+//! shape the filename-search walk uses).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use git2::{Delta, DiffOptions, ErrorClass, ErrorCode, Repository, Status, StatusOptions, StatusShow};
+
+use super::error::ScmError;
+use super::provider::{IScmProvider, IScmStaging};
+use super::trash_sink::{PlatformTrash, TrashSink};
+use super::types::{
+    ContentRef, DiffContent, FileRef, RepoRef, ResolvedRoot, ScmActionFailure, ScmActionOutcome, ScmCapabilities,
+    ScmHead, ScmRepository, ScmRepositoryState, ScmResource, ScmResourceState, ScmStatus,
+};
+
+/// Cap on resources in one status result.
+///
+/// Applies to untracked entries too, deliberately: scan cost tracks the number
+/// of non-ignored files (tracked ∪ untracked), and an agent creating files in
+/// bulk goes down exactly that path, so counting only tracked changes would
+/// leave the real growth uncapped.
+pub(super) const STATUS_RESOURCE_LIMIT: usize = 10_000;
+
+/// Largest blob inlined into a diff before it is reported as truncated.
+const DIFF_CONTENT_LIMIT: usize = 1 << 20;
+
+/// Largest number of add/delete candidates for which rename detection is run.
+///
+/// Rename detection compares content similarity across every delete × add pair,
+/// so its cost grows super-linearly in the number of candidates: measured on
+/// this workspace at ~12ms for 100 renames, 109ms for 500, 366ms for 1000 and
+/// ~1.0s for 3000, against ~12ms with detection off. Bulk moves are exactly the
+/// case that would stall the panel, so past this many candidates the pass is
+/// skipped and those files are reported as a delete plus a create — accurate,
+/// just less informative than a rename.
+const RENAME_DETECTION_CANDIDATE_LIMIT: usize = 400;
+
+/// Registry entry: what the provider remembers per discovered repository.
+///
+/// Only the on-disk locations. Repository handles are reopened per operation
+/// rather than cached, so nothing non-`Send` is held across awaits and a repo
+/// replaced on disk cannot leave a stale handle behind.
+#[derive(Debug, Clone)]
+struct RepoEntry {
+    /// Work-tree root (the pe root itself: one repo per pe at most).
+    workdir: PathBuf,
+    /// The **real** git directory. For a linked worktree or a submodule the
+    /// `.git` entry beside the work tree is a file pointing elsewhere, so this is
+    /// what a metadata watch must be armed on.
+    git_dir: PathBuf,
+}
+
+/// git source-control provider.
+pub struct GitScmProvider {
+    /// Discovered repositories by opaque `repo_id`.
+    repos: std::sync::RwLock<HashMap<String, RepoEntry>>,
+    /// Where discarded untracked files go. Injectable so the "never delete
+    /// outright" guarantee is testable; production always uses the platform trash.
+    trash: Arc<dyn TrashSink>,
+}
+
+impl GitScmProvider {
+    pub fn new() -> Self {
+        Self::with_trash(Arc::new(PlatformTrash))
+    }
+
+    /// Build with a specific trash sink. Crate-internal: the outward contract
+    /// takes no sink argument, so this exists for tests (and for a future
+    /// platform override) without widening the public API.
+    pub(super) fn with_trash(trash: Arc<dyn TrashSink>) -> Self {
+        Self {
+            repos: std::sync::RwLock::new(HashMap::new()),
+            trash,
+        }
+    }
+
+    /// Opaque `repo_id` for a pe root. Generation rule only — consumers must
+    /// not parse it back into a `pe_id`.
+    fn repo_id_for(pe_id: &str) -> String {
+        format!("scm:{pe_id}")
+    }
+
+    /// The real git directory of a discovered repository, for arming a metadata
+    /// watch. `None` when the repository is not known.
+    pub(super) fn git_dir_of(&self, repo: &RepoRef) -> Option<PathBuf> {
+        self.repos
+            .read()
+            .expect("scm repo registry poisoned")
+            .get(&repo.repo_id)
+            .map(|entry| entry.git_dir.clone())
+    }
+
+    fn entry(&self, repo: &RepoRef) -> Result<RepoEntry, ScmError> {
+        self.repos
+            .read()
+            .expect("scm repo registry poisoned")
+            .get(&repo.repo_id)
+            .cloned()
+            .ok_or_else(|| ScmError::UnknownRepository {
+                repo_id: repo.repo_id.clone(),
+            })
+    }
+}
+
+impl Default for GitScmProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Map a git2 failure into the neutral taxonomy, tagged with the operation.
+fn engine_error(context: &'static str, err: &git2::Error) -> ScmError {
+    ScmError::OperationFailed {
+        context,
+        message: format!("{} (class={:?}, code={:?})", err.message(), err.class(), err.code()),
+    }
+}
+
+/// Whether a failed `statuses()` call is the known stale-index writeback
+/// failure, i.e. worth retrying without index writeback.
+///
+/// Two real causes: a read-only `.git` whose index is stale, and an
+/// `index.lock` held by a concurrent git command. Both surface as a failure of
+/// the whole call rather than a silent downgrade, so they must be caught
+/// explicitly instead of being reported to the user as "source control broke".
+fn is_index_writeback_failure(err: &git2::Error) -> bool {
+    matches!(err.code(), ErrorCode::Locked)
+        || matches!(err.class(), ErrorClass::Index | ErrorClass::Os | ErrorClass::Filesystem)
+}
+
+/// Classify one git status flag set into the neutral state plus its staged side.
+///
+/// Order matters and encodes the data-safety rule: conflicted and renamed are
+/// recognized before the regular create/modify/delete folding, because folding
+/// them into `modified` invites a user to stage or discard a conflict
+/// resolution, or hides that a path changed.
+fn classify(status: Status) -> Vec<(ScmResourceState, Option<bool>)> {
+    if status.contains(Status::CONFLICTED) {
+        return vec![(ScmResourceState::Conflicted, None)];
+    }
+
+    let mut out = Vec::new();
+
+    // Index side (staged).
+    if status.contains(Status::INDEX_RENAMED) {
+        out.push((ScmResourceState::Renamed, Some(true)));
+    } else if status.contains(Status::INDEX_NEW) {
+        out.push((ScmResourceState::Created, Some(true)));
+    } else if status.contains(Status::INDEX_DELETED) {
+        out.push((ScmResourceState::Deleted, Some(true)));
+    } else if status.intersects(Status::INDEX_MODIFIED | Status::INDEX_TYPECHANGE) {
+        out.push((ScmResourceState::Modified, Some(true)));
+    }
+
+    // Work-tree side (unstaged). A file can appear on both sides at once — it
+    // then yields two resources, which is how "staged and further edited" is
+    // represented without a nested shape.
+    if status.contains(Status::WT_RENAMED) {
+        out.push((ScmResourceState::Renamed, Some(false)));
+    } else if status.contains(Status::WT_NEW) {
+        out.push((ScmResourceState::Created, Some(false)));
+    } else if status.contains(Status::WT_DELETED) {
+        out.push((ScmResourceState::Deleted, Some(false)));
+    } else if status.intersects(Status::WT_MODIFIED | Status::WT_TYPECHANGE) {
+        out.push((ScmResourceState::Modified, Some(false)));
+    }
+
+    out
+}
+
+/// Read head as the neutral model sees it: branch name, or detached.
+fn read_head(repo: &Repository) -> Option<ScmHead> {
+    match repo.head() {
+        Ok(head) => {
+            let detached = repo.head_detached().unwrap_or(false);
+            Some(ScmHead {
+                name: head.shorthand().map(str::to_owned),
+                detached: detached.then_some(true),
+            })
+        }
+        // Unborn head (fresh repo, no commit yet) is a normal state, not an
+        // error: the repository exists and has a change list.
+        Err(_) => Some(ScmHead::default()),
+    }
+}
+
+/// Run one `statuses()` pass, with the stale-index fallback.
+///
+/// Index writeback is on by default because without it a single external
+/// mtime-churning pass (touch, build output, unpack, rsync) makes every later
+/// recompute read all file contents, and that does not self-heal. When
+/// writeback itself is impossible, the call is retried read-only: the resource
+/// list is identical, only the timing degrades, and the degradation is logged
+/// and reported rather than hidden.
+fn collect_status(repo: &Repository) -> Result<(Vec<ScmResource>, bool, bool), ScmError> {
+    // First pass without rename detection: it is the cheap one, and its
+    // add/delete count is exactly the input size rename detection would work on.
+    let (probe, degraded) = match run_statuses(repo, true, false) {
+        Ok(s) => (s, false),
+        Err(err) if is_index_writeback_failure(&err) => {
+            tracing::warn!(
+                error = %err.message(),
+                class = ?err.class(),
+                code = ?err.code(),
+                "scm status: index writeback failed, retrying without it (degraded: recompute stays slow \
+                 until the index can be refreshed — read-only .git or a concurrent git holding index.lock)"
+            );
+            (
+                run_statuses(repo, false, false).map_err(|e| engine_error("status", &e))?,
+                true,
+            )
+        }
+        Err(err) => return Err(engine_error("status", &err)),
+    };
+
+    // Rename detection only has work to do when something was added and
+    // something removed; running it on a bulk move is what costs seconds.
+    let candidates = probe
+        .iter()
+        .filter(|e| {
+            e.status()
+                .intersects(Status::INDEX_NEW | Status::INDEX_DELETED | Status::WT_NEW | Status::WT_DELETED)
+        })
+        .count();
+    let detect_renames = candidates > 0 && candidates <= RENAME_DETECTION_CANDIDATE_LIMIT;
+    if candidates > RENAME_DETECTION_CANDIDATE_LIMIT {
+        tracing::info!(
+            candidates,
+            limit = RENAME_DETECTION_CANDIDATE_LIMIT,
+            "scm status: skipping rename detection, too many add/delete candidates \
+             (renames surface as delete + create)"
+        );
+    }
+
+    let statuses_owned = if detect_renames {
+        // Writeback already happened (or was proven impossible) in the probe, so
+        // this pass never needs it again.
+        run_statuses(repo, false, true).map_err(|e| engine_error("status", &e))?
+    } else {
+        probe
+    };
+
+    let mut resources = Vec::new();
+    let mut truncated = false;
+
+    for entry in statuses_owned.iter() {
+        let Some(path) = entry.path() else {
+            // Non-UTF-8 path: skipped rather than lossily rendered, since a
+            // mangled path would not round-trip back to a real file.
+            tracing::warn!("scm status: skipping entry with non-UTF-8 path");
+            continue;
+        };
+        // The wire contract says `relative_path` is `/`-separated, and libgit2
+        // stores repo paths that way on every platform (it converts `\` to `/` on
+        // input, see git2's `path_to_repo_path`). So this is reported, not
+        // rewritten: a blind `\` → `/` substitution would corrupt the identity of
+        // files whose *name* legitimately contains a backslash, which is valid on
+        // Linux and macOS. If this ever fires, the fix belongs at whichever layer
+        // actually produced the separator — not silently here.
+        if path.contains('\\') {
+            tracing::warn!(
+                repo_relative_path = %path,
+                "scm status: path contains a backslash where the contract expects `/`-separated \
+                 segments; reporting as-is (see cross-platform checklist)"
+            );
+        }
+        // For a rename, `entry.path()` is the OLD path; the current path lives in
+        // the delta's new_file. Reporting the old path as the resource identity
+        // would point the UI at a file that no longer exists, so the two are
+        // taken from the delta explicitly.
+        //
+        // Each side is filtered **before** choosing between them: a file can carry a
+        // non-rename change on the index side and a rename on the work-tree side
+        // (stage an edit, then move the file). Selecting first and filtering after
+        // would take the index delta merely because it exists, then discard it for
+        // not being a rename — losing the rename sitting on the other side, and with
+        // it the file's real current path.
+        let rename_of = |delta: git2::DiffDelta<'_>| {
+            let from = delta.old_file().path()?.to_string_lossy().into_owned();
+            let to = delta.new_file().path()?.to_string_lossy().into_owned();
+            Some((from, to))
+        };
+        let rename_pair = entry
+            .head_to_index()
+            .filter(|d| d.status() == Delta::Renamed)
+            .and_then(rename_of)
+            .or_else(|| {
+                entry
+                    .index_to_workdir()
+                    .filter(|d| d.status() == Delta::Renamed)
+                    .and_then(rename_of)
+            });
+        let current_path = rename_pair.as_ref().map_or(path, |(_, to)| to.as_str());
+        let rename_from = rename_pair.as_ref().map(|(from, _)| from.clone());
+
+        for (state, staged) in classify(entry.status()) {
+            if resources.len() >= STATUS_RESOURCE_LIMIT {
+                truncated = true;
+                break;
+            }
+            resources.push(ScmResource {
+                file: FileRef {
+                    pe_id: String::new(), // filled by the caller, which owns identity
+                    relative_path: current_path.to_owned(),
+                },
+                repo_relative_path: current_path.to_owned(),
+                state,
+                staged,
+                rename_from: matches!(state, ScmResourceState::Renamed)
+                    .then(|| rename_from.clone())
+                    .flatten(),
+            });
+        }
+        if truncated {
+            break;
+        }
+    }
+
+    Ok((resources, truncated, degraded))
+}
+
+fn run_statuses(
+    repo: &Repository,
+    update_index: bool,
+    detect_renames: bool,
+) -> Result<git2::Statuses<'_>, git2::Error> {
+    let mut opts = StatusOptions::new();
+    opts.show(StatusShow::IndexAndWorkdir)
+        .include_untracked(true)
+        .recurse_untracked_dirs(true)
+        .include_ignored(false)
+        .include_unmodified(false)
+        .renames_head_to_index(detect_renames)
+        .renames_index_to_workdir(detect_renames)
+        .update_index(update_index);
+    repo.statuses(Some(&mut opts))
+}
+
+/// Read a blob at one anchor. `None` = the file has no version there.
+fn read_at(repo: &Repository, rel: &str, at: ContentRef) -> Result<Option<Vec<u8>>, ScmError> {
+    let path = Path::new(rel);
+    match at {
+        ContentRef::Working => {
+            let Some(workdir) = repo.workdir() else {
+                return Err(ScmError::OperationFailed {
+                    context: "original",
+                    message: "bare repository has no work tree".to_owned(),
+                });
+            };
+            match std::fs::read(workdir.join(path)) {
+                Ok(bytes) => Ok(Some(bytes)),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+                Err(err) => Err(ScmError::Io {
+                    path: rel.to_owned(),
+                    message: err.to_string(),
+                }),
+            }
+        }
+        ContentRef::Staged => {
+            let index = repo.index().map_err(|e| engine_error("original", &e))?;
+            if let Some(entry) = index.get_path(path, 0) {
+                let blob = repo.find_blob(entry.id).map_err(|e| engine_error("original", &e))?;
+                return Ok(Some(blob.content().to_vec()));
+            }
+            // No resolved entry. Two very different situations share that shape, and
+            // conflating them produces wrong output rather than an error:
+            //
+            //  * the file simply is not staged — "no content here" is the truthful
+            //    answer, and callers render it as an addition;
+            //  * the file is **conflicted**, so the index holds the three sides of
+            //    the conflict instead of one resolved version. There is no "staged
+            //    version" to return, and answering "no content" would let a diff
+            //    against it read as *the whole file was deleted* while the file sits
+            //    intact on disk.
+            //
+            // The second case is therefore refused, with the same meaning the
+            // actions use for conflicted resources: not now, resolve the conflict
+            // first.
+            let conflicted = [1, 2, 3].iter().any(|stage| index.get_path(path, *stage).is_some());
+            if conflicted {
+                return Err(ScmError::OpaqueResource { path: rel.to_owned() });
+            }
+            Ok(None)
+        }
+        ContentRef::Committed => {
+            let Ok(head) = repo.head() else {
+                return Ok(None); // unborn head: nothing committed yet
+            };
+            let tree = head.peel_to_tree().map_err(|e| engine_error("original", &e))?;
+            match tree.get_path(path) {
+                Ok(entry) => {
+                    let blob = repo.find_blob(entry.id()).map_err(|e| engine_error("original", &e))?;
+                    Ok(Some(blob.content().to_vec()))
+                }
+                Err(err) if err.code() == ErrorCode::NotFound => Ok(None),
+                Err(err) => Err(engine_error("original", &err)),
+            }
+        }
+    }
+}
+
+/// Build a unified patch between two anchors for one file.
+fn diff_between(repo: &Repository, rel: &str, from: ContentRef, to: ContentRef) -> Result<DiffContent, ScmError> {
+    let old = read_at(repo, rel, from)?;
+    let new = read_at(repo, rel, to)?;
+
+    let is_binary = |b: &Vec<u8>| b.contains(&0);
+    if old.as_ref().is_some_and(is_binary) || new.as_ref().is_some_and(is_binary) {
+        return Ok(DiffContent {
+            binary: true,
+            ..DiffContent::default()
+        });
+    }
+    if old.as_ref().is_some_and(|b| b.len() > DIFF_CONTENT_LIMIT)
+        || new.as_ref().is_some_and(|b| b.len() > DIFF_CONTENT_LIMIT)
+    {
+        return Ok(DiffContent {
+            truncated: true,
+            ..DiffContent::default()
+        });
+    }
+
+    let mut patch = String::new();
+    let mut opts = DiffOptions::new();
+    git2::Patch::from_buffers(
+        old.as_deref().unwrap_or_default(),
+        Some(Path::new(rel)),
+        new.as_deref().unwrap_or_default(),
+        Some(Path::new(rel)),
+        Some(&mut opts),
+    )
+    .and_then(|mut p| {
+        p.print(&mut |_, _, line| {
+            match line.origin() {
+                '+' | '-' | ' ' => patch.push(line.origin()),
+                _ => {}
+            }
+            patch.push_str(&String::from_utf8_lossy(line.content()));
+            true
+        })
+    })
+    .map_err(|e| engine_error("diff", &e))?;
+
+    Ok(DiffContent {
+        patch: Some(patch),
+        ..DiffContent::default()
+    })
+}
+
+/// Restore tracked files to their committed content and send untracked ones to
+/// the system trash.
+///
+/// Untracked files are never unlinked: a discard that permanently destroys a
+/// file the version-control system has no copy of is unrecoverable, so the
+/// platform trash is the floor.
+fn revert_paths(repo: &Repository, rels: &[String], trash: &dyn TrashSink) -> Result<Vec<(usize, String)>, ScmError> {
+    let Some(workdir) = repo.workdir().map(Path::to_path_buf) else {
+        return Err(ScmError::OperationFailed {
+            context: "revert",
+            message: "bare repository has no work tree".to_owned(),
+        });
+    };
+
+    // One scan for the whole request; consulted per file below.
+    let rename_sources = rename_sources(repo);
+
+    // Indices into `rels`, so a failure can be reported against the exact request
+    // item it came from.
+    let mut tracked: Vec<(usize, &String)> = Vec::new();
+    let mut to_trash: Vec<(usize, PathBuf)> = Vec::new();
+    // Renames: (request index, path it came from, absolute path it moved to).
+    let mut renamed: Vec<(usize, String, PathBuf)> = Vec::new();
+
+    for (index, rel) in rels.iter().enumerate() {
+        let status = repo
+            .status_file(Path::new(rel.as_str()))
+            .map_err(|e| engine_error("revert", &e))?;
+
+        // Same opaque rule the status model states: a conflicted resource offers
+        // no action, because acting on it can destroy a half-finished resolution.
+        if classify(status).first().is_some_and(|(state, _)| state.is_opaque()) {
+            return Err(ScmError::OpaqueResource { path: rel.clone() });
+        }
+
+        // A rename is reported to clients as **one** resource, so discarding it has
+        // to undo the whole move: bring back the path the file came from, and send
+        // the path it moved to through the trash. Treating the new path as a plain
+        // untracked creation — which is what its raw flags look like — would trash
+        // it and leave the old path missing, i.e. lose the file from both places
+        // while reporting success.
+        if let Some(from) = rename_sources.get(rel.as_str()) {
+            renamed.push((index, from.clone(), workdir.join(rel)));
+            continue;
+        }
+
+        if status.contains(Status::WT_NEW) && !status.intersects(Status::INDEX_NEW) {
+            to_trash.push((index, workdir.join(rel)));
+        } else {
+            tracked.push((index, rel));
+        }
+    }
+
+    // Failures are collected, not returned early: the files in one request are
+    // independent, and stopping midway would leave earlier ones already changed
+    // while telling the caller only "failed".
+    let mut failed: Vec<(usize, String)> = Vec::new();
+
+    if !tracked.is_empty() {
+        // Restored from the **index**, not from the last commit.
+        //
+        // This is what discarding a working-tree change means, and it matches the
+        // version-control system's own behaviour: restoring from the index drops
+        // the unstaged edit and keeps whatever was staged, whereas restoring from
+        // the last commit would additionally throw away the staged version — and
+        // doing that *without* also updating the index produces a state the engine
+        // itself never creates: work tree at the commit, index still holding the
+        // staged version, so the file shows changes on **both** sides and the
+        // change count does not go down even though the user asked to discard.
+        //
+        // For a file whose staged version equals the committed one — the common
+        // case — the two sources are identical, so this needs no special casing.
+        //
+        // Checked out one at a time so one unreadable path does not cost the other
+        // files their restore.
+        for (index, rel) in &tracked {
+            let mut builder = git2::build::CheckoutBuilder::new();
+            builder.force().remove_untracked(false).update_index(false);
+            builder.path(rel.as_str());
+            // `None` = the repository's own index.
+            if let Err(err) = repo.checkout_index(None, Some(&mut builder)) {
+                failed.push((*index, err.message().to_owned()));
+            }
+        }
+    }
+
+    // Undo each rename as the pair it is: restore the source, then remove the
+    // destination. Source first, so a failure to restore leaves the file present at
+    // its new path rather than at neither.
+    for (index, from, to) in renamed {
+        let mut builder = git2::build::CheckoutBuilder::new();
+        builder.force().remove_untracked(false).update_index(false);
+        builder.path(from.as_str());
+        // From HEAD, not the index: a staged rename has removed the source from the
+        // index, so the index has nothing to restore it from.
+        let restored = match repo.head().and_then(|h| h.peel(git2::ObjectType::Commit)) {
+            Ok(obj) => repo
+                .checkout_tree(&obj, Some(&mut builder))
+                .map_err(|err| err.message().to_owned()),
+            Err(err) => Err(err.message().to_owned()),
+        };
+        if let Err(message) = restored {
+            failed.push((index, format!("restoring {from} failed: {message}")));
+            continue;
+        }
+        if let Err(message) = trash.trash(&to) {
+            failed.push((index, format!("move to trash failed: {message}")));
+        }
+    }
+
+    for (index, path) in to_trash {
+        // Never swallowed and never followed by a delete: a failed trash move must
+        // leave the file in place.
+        if let Err(message) = trash.trash(&path) {
+            failed.push((index, format!("move to trash failed: {message}")));
+        }
+    }
+
+    Ok(failed)
+}
+
+/// Every rename in the repository, as `destination -> source`.
+///
+/// Built in **one** pass and consulted from memory afterwards. Two reasons, and
+/// both matter:
+///
+///  * Correctness. Scanning per file invites the mistake of aborting the scan on
+///    the first entry that is not a rename — `?` inside such a loop returns from
+///    the whole function, not just that iteration, so a single unrelated modified
+///    file would hide every rename behind it. Here non-renames are simply skipped.
+///  * Cost. A repository-wide status is not cheap, and doing one per requested
+///    file turns a multi-file discard into as many full scans as there are files.
+fn rename_sources(repo: &Repository) -> HashMap<String, String> {
+    let mut opts = StatusOptions::new();
+    opts.show(StatusShow::IndexAndWorkdir)
+        .include_untracked(true)
+        .recurse_untracked_dirs(true)
+        .renames_head_to_index(true)
+        .renames_index_to_workdir(true);
+    let Ok(statuses) = repo.statuses(Some(&mut opts)) else {
+        return HashMap::new();
+    };
+
+    let mut sources = HashMap::new();
+    for entry in statuses.iter() {
+        // Each side is checked independently, and anything that is not a rename is
+        // skipped rather than ending the scan.
+        let pair = entry
+            .head_to_index()
+            .filter(|d| d.status() == Delta::Renamed)
+            .or_else(|| entry.index_to_workdir().filter(|d| d.status() == Delta::Renamed));
+        let Some(pair) = pair else { continue };
+        let (Some(from), Some(to)) = (pair.old_file().path(), pair.new_file().path()) else {
+            continue;
+        };
+        sources.insert(to.to_string_lossy().into_owned(), from.to_string_lossy().into_owned());
+    }
+    sources
+}
+
+/// Pair per-file failures back with the identities the caller passed in.
+///
+/// The engine works in repository-relative paths; the outward result must speak
+/// the same `{ pe_id, relative_path }` identity the caller used, so failures are
+/// carried back by **position** in the request rather than re-derived or matched
+/// by path.
+///
+/// Position, not path, because the identity must be exactly the one the caller
+/// sent: a path-based lookup can miss (duplicate entries, any normalisation the
+/// engine applies) and would then have to invent something, and an invented
+/// identity — a blank `pe_id`, say — matches nothing on the client and silently
+/// turns "this file failed" into "something failed, unclear what". Every engine
+/// site derives its index from the same request slice, so an out-of-range index
+/// means an internal invariant broke; that is reported as a whole-request failure
+/// instead of being papered over.
+fn outcome_of(files: &[FileRef], failed: Vec<(usize, String)>) -> Result<ScmActionOutcome, ScmError> {
+    let mut failures = Vec::with_capacity(failed.len());
+    for (index, reason) in failed {
+        let Some(file) = files.get(index) else {
+            debug_assert!(false, "failure index {index} out of range for {} files", files.len());
+            return Err(ScmError::OperationFailed {
+                context: "action_result",
+                message: format!(
+                    "internal: failure index {index} out of range for {} requested files",
+                    files.len()
+                ),
+            });
+        };
+        failures.push(ScmActionFailure {
+            file: file.clone(),
+            reason,
+        });
+    }
+    Ok(ScmActionOutcome { failed: failures })
+}
+
+/// Open the repository for one operation, on a blocking thread.
+///
+/// Every git2 access funnels through here so no `Repository` (not `Send`) is
+/// ever held across an await.
+async fn with_repo<T, F>(workdir: PathBuf, context: &'static str, f: F) -> Result<T, ScmError>
+where
+    T: Send + 'static,
+    F: FnOnce(&Repository) -> Result<T, ScmError> + Send + 'static,
+{
+    tokio::task::spawn_blocking(move || {
+        let repo = Repository::open(&workdir).map_err(|e| engine_error(context, &e))?;
+        f(&repo)
+    })
+    .await
+    .map_err(|err| ScmError::OperationFailed {
+        context,
+        message: format!("blocking task failed: {err}"),
+    })?
+}
+
+/// Validate the requested anchors against this provider's capabilities.
+///
+/// git has a staging area, so `Staged` is always allowed here; the check exists
+/// so the rule lives with the contract rather than only in a provider that
+/// happens to support it.
+fn check_anchor(caps: ScmCapabilities, anchor: ContentRef) -> Result<(), ScmError> {
+    if matches!(anchor, ContentRef::Staged) && !caps.staging {
+        return Err(ScmError::unsupported_staged_anchor());
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl IScmProvider for GitScmProvider {
+    fn provider_id(&self) -> &str {
+        "git"
+    }
+
+    fn capabilities(&self) -> ScmCapabilities {
+        ScmCapabilities {
+            staging: true,
+            local_branches: true,
+            // Stage 2: the engine could serve these (revwalk / network), but the
+            // contract must not advertise what the protocol does not expose yet.
+            history_graph: false,
+            remote_ops: false,
+        }
+    }
+
+    async fn discover(&self, root: &ResolvedRoot) -> Result<Option<ScmRepository>, ScmError> {
+        let path = PathBuf::from(&root.absolute_path);
+        let caps = self.capabilities();
+
+        // `open` (not `discover`): one pe root is at most one repo — never walk
+        // up to a parent repository, never enumerate nested ones.
+        let opened = tokio::task::spawn_blocking(move || match Repository::open(&path) {
+            Ok(repo) => {
+                let workdir = repo.workdir().map(Path::to_path_buf);
+                // `path()` is the real git dir, which is what a watch must be
+                // armed on: for a linked worktree or a submodule the `.git`
+                // entry beside the work tree is a file pointing elsewhere.
+                let git_dir = repo.path().to_path_buf();
+                Ok(Some((workdir, git_dir, read_head(&repo))))
+            }
+            Err(err) if matches!(err.code(), ErrorCode::NotFound) => Ok(None),
+            Err(err) => Err(err),
+        })
+        .await
+        .map_err(|err| ScmError::OperationFailed {
+            context: "discover",
+            message: format!("blocking task failed: {err}"),
+        })?
+        .map_err(|e| engine_error("discover", &e))?;
+
+        let Some((workdir, git_dir, head)) = opened else {
+            return Ok(None);
+        };
+        // A bare repository has no work tree, so it has no change list to show;
+        // treating it as "not a repository" here beats surfacing a repo whose
+        // every operation would fail.
+        let Some(workdir) = workdir else {
+            tracing::debug!(pe_id = %root.pe_id, "scm discover: bare repository has no work tree, not surfaced");
+            return Ok(None);
+        };
+        let repo_id = Self::repo_id_for(&root.pe_id);
+        self.repos
+            .write()
+            .expect("scm repo registry poisoned")
+            .insert(repo_id.clone(), RepoEntry { workdir, git_dir });
+
+        Ok(Some(ScmRepository {
+            repo_id,
+            provider_id: self.provider_id().to_owned(),
+            root: FileRef {
+                pe_id: root.pe_id.clone(),
+                relative_path: String::new(),
+            },
+            label: root.label.clone(),
+            head,
+            capabilities: caps,
+            state: ScmRepositoryState::Idle,
+        }))
+    }
+
+    async fn status(&self, repo: &RepoRef) -> Result<ScmStatus, ScmError> {
+        let entry = self.entry(repo)?;
+        // Identity is deliberately left unassembled: a provider knows only
+        // repository-relative paths, and pe identity comes from the resolved root,
+        // so the orchestration layer owns it (`formal/runtime/source-control.md`).
+        // Resources therefore carry an empty `pe_id` until that layer fills it.
+        let (resources, truncated, degraded) = with_repo(entry.workdir, "status", collect_status).await?;
+
+        if truncated {
+            tracing::info!(
+                repo_id = %repo.repo_id,
+                limit = STATUS_RESOURCE_LIMIT,
+                "scm status: resource list truncated at limit"
+            );
+        }
+
+        Ok(ScmStatus {
+            repository: repo.clone(),
+            resources,
+            // Left at zero: allocating the sequence is the orchestration layer's
+            // job, inside the critical section that serializes recomputes.
+            seq: 0,
+            truncated,
+            degraded,
+        })
+    }
+
+    async fn diff(
+        &self,
+        repo: &RepoRef,
+        file: &FileRef,
+        from: ContentRef,
+        to: ContentRef,
+    ) -> Result<DiffContent, ScmError> {
+        check_anchor(self.capabilities(), from)?;
+        check_anchor(self.capabilities(), to)?;
+        let entry = self.entry(repo)?;
+        let rel = file.relative_path.clone();
+        with_repo(entry.workdir, "diff", move |r| diff_between(r, &rel, from, to)).await
+    }
+
+    async fn original(&self, repo: &RepoRef, file: &FileRef, at: ContentRef) -> Result<Option<Vec<u8>>, ScmError> {
+        check_anchor(self.capabilities(), at)?;
+        let entry = self.entry(repo)?;
+        let rel = file.relative_path.clone();
+        with_repo(entry.workdir, "original", move |r| read_at(r, &rel, at)).await
+    }
+
+    async fn revert(&self, repo: &RepoRef, files: &[FileRef]) -> Result<ScmActionOutcome, ScmError> {
+        let entry = self.entry(repo)?;
+        let rels: Vec<String> = files.iter().map(|f| f.relative_path.clone()).collect();
+        let trash = Arc::clone(&self.trash);
+        let failed = with_repo(entry.workdir, "revert", move |r| revert_paths(r, &rels, trash.as_ref())).await?;
+        outcome_of(files, failed)
+    }
+
+    fn staging(&self) -> Option<&dyn IScmStaging> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl IScmStaging for GitScmProvider {
+    async fn stage(&self, repo: &RepoRef, files: &[FileRef]) -> Result<ScmActionOutcome, ScmError> {
+        let entry = self.entry(repo)?;
+        let rels: Vec<String> = files.iter().map(|f| f.relative_path.clone()).collect();
+
+        let failed = with_repo(entry.workdir, "stage", move |r| {
+            let mut index = r.index().map_err(|e| engine_error("stage", &e))?;
+            // Pre-check every file before touching the index, so a conflicted
+            // selection is refused without half-staging the rest.
+            for rel in &rels {
+                let status = r
+                    .status_file(Path::new(rel.as_str()))
+                    .map_err(|e| engine_error("stage", &e))?;
+                if classify(status).first().is_some_and(|(state, _)| state.is_opaque()) {
+                    return Err(ScmError::OpaqueResource { path: rel.clone() });
+                }
+            }
+
+            let mut failed: Vec<(usize, String)> = Vec::new();
+            for (slot, rel) in rels.iter().enumerate() {
+                let path = Path::new(rel.as_str());
+                // A deletion must be recorded as a removal: `add_path` on a
+                // missing file fails, which would make staging a delete error.
+                let exists = r.workdir().is_some_and(|w| w.join(path).exists());
+                let res = if exists {
+                    index.add_path(path)
+                } else {
+                    index.remove_path(path)
+                };
+                if let Err(err) = res {
+                    failed.push((slot, err.message().to_owned()));
+                }
+            }
+            // Written once: the files that were added stay staged even though a
+            // sibling failed, which is what best effort means here.
+            index.write().map_err(|e| engine_error("stage", &e))?;
+            Ok(failed)
+        })
+        .await?;
+        outcome_of(files, failed)
+    }
+
+    async fn unstage(&self, repo: &RepoRef, files: &[FileRef]) -> Result<ScmActionOutcome, ScmError> {
+        let entry = self.entry(repo)?;
+        let rels: Vec<String> = files.iter().map(|f| f.relative_path.clone()).collect();
+
+        let failed = with_repo(entry.workdir, "unstage", move |r| {
+            // Same pre-check as stage and discard: a conflicted selection is
+            // refused before the index is touched, so all three actions offer the
+            // identical all-or-nothing guarantee for blocked resources.
+            for rel in &rels {
+                let status = r
+                    .status_file(Path::new(rel.as_str()))
+                    .map_err(|e| engine_error("unstage", &e))?;
+                if classify(status).first().is_some_and(|(state, _)| state.is_opaque()) {
+                    return Err(ScmError::OpaqueResource { path: rel.clone() });
+                }
+            }
+
+            match r.head().and_then(|h| h.peel(git2::ObjectType::Commit)) {
+                Ok(obj) => {
+                    // Fast path first: resetting the whole selection in one call is
+                    // dramatically cheaper than one call per file — measured at
+                    // roughly 15× for a hundred files and 35× for a few thousand,
+                    // which is the difference between instant and a visible stall.
+                    // Only when it fails is the batch retried file by file, to find
+                    // out *which* entries are at fault; correctness of the per-file
+                    // report is preserved without paying for it on every request.
+                    let mut failed: Vec<(usize, String)> = Vec::new();
+                    if r.reset_default(Some(&obj), rels.iter().map(String::as_str)).is_err() {
+                        for (index, rel) in rels.iter().enumerate() {
+                            if let Err(err) = r.reset_default(Some(&obj), [rel.as_str()].iter()) {
+                                failed.push((index, err.message().to_owned()));
+                            }
+                        }
+                    }
+                    Ok(failed)
+                }
+                // Unborn head: there is no committed version to reset to, so
+                // unstaging means dropping the entry from the index entirely.
+                Err(err) if err.code() == ErrorCode::UnbornBranch => {
+                    let mut index = r.index().map_err(|e| engine_error("unstage", &e))?;
+                    let mut failed: Vec<(usize, String)> = Vec::new();
+                    for (index_of, rel) in rels.iter().enumerate() {
+                        if let Err(err) = index.remove_path(Path::new(rel.as_str())) {
+                            failed.push((index_of, err.message().to_owned()));
+                        }
+                    }
+                    index.write().map_err(|e| engine_error("unstage", &e))?;
+                    Ok(failed)
+                }
+                Err(err) => Err(engine_error("unstage", &err)),
+            }
+        })
+        .await?;
+        outcome_of(files, failed)
+    }
+}
+
+#[cfg(test)]
+#[path = "git_provider_test.rs"]
+mod git_provider_test;

--- a/crates/aionui-project/src/scm/git_provider.rs
+++ b/crates/aionui-project/src/scm/git_provider.rs
@@ -210,7 +210,12 @@ fn read_head(repo: &Repository) -> Option<ScmHead> {
 /// writeback itself is impossible, the call is retried read-only: the resource
 /// list is identical, only the timing degrades, and the degradation is logged
 /// and reported rather than hidden.
-fn collect_status(repo: &Repository) -> Result<(Vec<ScmResource>, bool, bool), ScmError> {
+fn collect_status(repo: &Repository) -> Result<(Vec<ScmResource>, bool, bool, Option<ScmHead>), ScmError> {
+    // Read head in the same blocking pass that computes the change list: a
+    // checkout moves head, and the status frame is the only frame the refresh
+    // path emits, so head must ride along with it or a branch switch never
+    // reaches the client (see `ScmStatus::head`).
+    let head = read_head(repo);
     // First pass without rename detection: it is the cheap one, and its
     // add/delete count is exactly the input size rename detection would work on.
     let (probe, degraded) = match run_statuses(repo, true, false) {
@@ -334,7 +339,7 @@ fn collect_status(repo: &Repository) -> Result<(Vec<ScmResource>, bool, bool), S
         }
     }
 
-    Ok((resources, truncated, degraded))
+    Ok((resources, truncated, degraded, head))
 }
 
 fn run_statuses(
@@ -775,7 +780,7 @@ impl IScmProvider for GitScmProvider {
         // repository-relative paths, and pe identity comes from the resolved root,
         // so the orchestration layer owns it (`formal/runtime/source-control.md`).
         // Resources therefore carry an empty `pe_id` until that layer fills it.
-        let (resources, truncated, degraded) = with_repo(entry.workdir, "status", collect_status).await?;
+        let (resources, truncated, degraded, head) = with_repo(entry.workdir, "status", collect_status).await?;
 
         if truncated {
             tracing::info!(
@@ -788,6 +793,7 @@ impl IScmProvider for GitScmProvider {
         Ok(ScmStatus {
             repository: repo.clone(),
             resources,
+            head,
             // Left at zero: allocating the sequence is the orchestration layer's
             // job, inside the critical section that serializes recomputes.
             seq: 0,

--- a/crates/aionui-project/src/scm/git_provider_test.rs
+++ b/crates/aionui-project/src/scm/git_provider_test.rs
@@ -54,6 +54,7 @@ async fn discovered(dir: &Path) -> (GitScmProvider, RepoRef) {
         pe_id: "pe1".to_owned(),
         absolute_path: dir.to_string_lossy().into_owned(),
         label: "fixture".to_owned(),
+        pe_name: None,
     };
     let repo = provider
         .discover(&root)
@@ -78,6 +79,7 @@ async fn discover_reports_none_for_plain_directory() {
         pe_id: "pe1".to_owned(),
         absolute_path: tmp.path().to_string_lossy().into_owned(),
         label: "plain".to_owned(),
+        pe_name: None,
     };
 
     // Not a repository is a normal outcome, never a fabricated repo.
@@ -96,6 +98,7 @@ async fn discover_does_not_walk_up_to_parent_repository() {
         pe_id: "pe-child".to_owned(),
         absolute_path: child.to_string_lossy().into_owned(),
         label: "child".to_owned(),
+        pe_name: None,
     };
 
     // One pe root is at most one repo: a subdirectory of a repo is not itself a
@@ -115,6 +118,7 @@ async fn discover_reports_identity_capabilities_and_head() {
         pe_id: "pe1".to_owned(),
         absolute_path: tmp.path().to_string_lossy().into_owned(),
         label: "fixture".to_owned(),
+        pe_name: None,
     };
     let found = provider
         .discover(&root)
@@ -776,6 +780,7 @@ async fn discovered_with_trash(dir: &Path, trash: Arc<dyn TrashSink>) -> (GitScm
         pe_id: "pe1".to_owned(),
         absolute_path: dir.to_string_lossy().into_owned(),
         label: "fixture".to_owned(),
+        pe_name: None,
     };
     let repo = provider
         .discover(&root)
@@ -2318,4 +2323,27 @@ async fn staging_several_distinct_files_stages_every_one_of_them() {
             after.resources
         );
     }
+}
+
+/// `repo_id` is a pure `scm:{pe_id}` mapping: deterministic, and derived from the
+/// pe identity rather than a path. This is the premise the roots diff relies on —
+/// it compares repositories by `repo_id`, not by path. Because the project layer
+/// canonicalizes a folder's path (folding case on a case-insensitive filesystem)
+/// before it ever becomes a `pe_id`, one physical directory resolves to exactly
+/// one `pe_id`, hence one `repo_id`; two case-different spellings can never split
+/// it into two. (The fold itself is covered by `canonical_test::casing_folds_per_platform`
+/// and the identity-level dedup by the project service suite.)
+#[test]
+fn repo_id_is_a_deterministic_scm_prefix_over_the_pe_id() {
+    assert_eq!(GitScmProvider::repo_id_for("pe1"), "scm:pe1");
+    assert_eq!(
+        GitScmProvider::repo_id_for("pe1"),
+        GitScmProvider::repo_id_for("pe1"),
+        "the same pe id always yields the same repo id"
+    );
+    assert_ne!(
+        GitScmProvider::repo_id_for("pe1"),
+        GitScmProvider::repo_id_for("pe2"),
+        "distinct pe ids stay distinct"
+    );
 }

--- a/crates/aionui-project/src/scm/git_provider_test.rs
+++ b/crates/aionui-project/src/scm/git_provider_test.rs
@@ -1,0 +1,2321 @@
+//! `GitScmProvider` tests over real temporary repositories.
+//!
+//! Repositories are built with git2 itself (no `git` CLI dependency) so the
+//! suite runs the same way on mac / windows / linux. Paths are always joined,
+//! never written as literals, and assertions compare pe-relative paths that git
+//! reports with `/` separators on every platform.
+
+use tempfile::TempDir;
+
+use super::super::trash_sink::TrashSink;
+use super::*;
+
+/// Committer identity for test commits: repo-local config, so a machine without
+/// a global git identity still runs the suite.
+fn init_repo(dir: &Path) -> Repository {
+    let repo = Repository::init(dir).expect("init repo");
+    let mut cfg = repo.config().expect("config");
+    cfg.set_str("user.name", "scm test").expect("set name");
+    cfg.set_str("user.email", "scm@test.local").expect("set email");
+    repo
+}
+
+fn write(dir: &Path, rel: &str, body: &str) {
+    let path = dir.join(rel);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("mkdir parent");
+    }
+    std::fs::write(path, body).expect("write file");
+}
+
+/// Commit everything currently in the work tree, returning the new commit.
+fn commit_all(repo: &Repository, message: &str) -> git2::Oid {
+    let mut index = repo.index().expect("index");
+    index
+        .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+        .expect("add all");
+    index.write().expect("write index");
+    let tree_id = index.write_tree().expect("write tree");
+    let tree = repo.find_tree(tree_id).expect("find tree");
+    let sig = repo.signature().expect("signature");
+    let parents = match repo.head().ok().and_then(|h| h.peel_to_commit().ok()) {
+        Some(parent) => vec![parent],
+        None => vec![],
+    };
+    let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+    repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parent_refs)
+        .expect("commit")
+}
+
+/// A discovered repository plus the provider that owns it.
+async fn discovered(dir: &Path) -> (GitScmProvider, RepoRef) {
+    let provider = GitScmProvider::new();
+    let root = ResolvedRoot {
+        pe_id: "pe1".to_owned(),
+        absolute_path: dir.to_string_lossy().into_owned(),
+        label: "fixture".to_owned(),
+    };
+    let repo = provider
+        .discover(&root)
+        .await
+        .expect("discover ok")
+        .expect("is a repository");
+    (provider, RepoRef { repo_id: repo.repo_id })
+}
+
+fn find<'a>(status: &'a ScmStatus, rel: &str, staged: Option<bool>) -> Option<&'a ScmResource> {
+    status
+        .resources
+        .iter()
+        .find(|r| r.repo_relative_path == rel && r.staged == staged)
+}
+
+#[tokio::test]
+async fn discover_reports_none_for_plain_directory() {
+    let tmp = TempDir::new().expect("tempdir");
+    let provider = GitScmProvider::new();
+    let root = ResolvedRoot {
+        pe_id: "pe1".to_owned(),
+        absolute_path: tmp.path().to_string_lossy().into_owned(),
+        label: "plain".to_owned(),
+    };
+
+    // Not a repository is a normal outcome, never a fabricated repo.
+    assert!(provider.discover(&root).await.expect("discover ok").is_none());
+}
+
+#[tokio::test]
+async fn discover_does_not_walk_up_to_parent_repository() {
+    let tmp = TempDir::new().expect("tempdir");
+    init_repo(tmp.path());
+    let child = tmp.path().join("sub");
+    std::fs::create_dir_all(&child).expect("mkdir child");
+
+    let provider = GitScmProvider::new();
+    let root = ResolvedRoot {
+        pe_id: "pe-child".to_owned(),
+        absolute_path: child.to_string_lossy().into_owned(),
+        label: "child".to_owned(),
+    };
+
+    // One pe root is at most one repo: a subdirectory of a repo is not itself a
+    // repo, and discovery must not surface the parent (decision "1 pe : 1 repo").
+    assert!(provider.discover(&root).await.expect("discover ok").is_none());
+}
+
+#[tokio::test]
+async fn discover_reports_identity_capabilities_and_head() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "a.txt", "hello\n");
+    commit_all(&repo, "base");
+
+    let provider = GitScmProvider::new();
+    let root = ResolvedRoot {
+        pe_id: "pe1".to_owned(),
+        absolute_path: tmp.path().to_string_lossy().into_owned(),
+        label: "fixture".to_owned(),
+    };
+    let found = provider
+        .discover(&root)
+        .await
+        .expect("discover ok")
+        .expect("is a repository");
+
+    assert_eq!(found.provider_id, "git");
+    assert_eq!(found.root.pe_id, "pe1");
+    assert_eq!(found.root.relative_path, "", "repo root is the pe root itself");
+    assert!(found.repo_id.starts_with("scm:"), "repo_id: {}", found.repo_id);
+    assert!(found.capabilities.staging, "git has a staging area");
+    assert!(found.capabilities.local_branches);
+    assert!(!found.capabilities.history_graph, "stage 2, not advertised yet");
+    assert!(!found.capabilities.remote_ops, "stage 2, not advertised yet");
+    assert_eq!(found.state, ScmRepositoryState::Idle);
+}
+
+#[tokio::test]
+async fn status_reports_untracked_as_created_unstaged() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "a.txt", "hello\n");
+    commit_all(&repo, "base");
+    // Nested so the recursive-untracked setting is actually exercised: without
+    // it this collapses to a single directory entry.
+    write(tmp.path(), "fresh/new.txt", "new\n");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let status = provider.status(&repo_ref).await.expect("status ok");
+
+    let res = find(&status, "fresh/new.txt", Some(false)).expect("untracked file listed per file");
+    assert_eq!(res.state, ScmResourceState::Created);
+    assert!(
+        res.file.pe_id.is_empty(),
+        "a provider does not assemble pe identity — the orchestration layer owns it"
+    );
+    assert!(!status.truncated);
+}
+
+#[tokio::test]
+async fn status_is_not_degraded_when_the_index_can_be_written() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "a.txt", "hello\n");
+    commit_all(&repo, "base");
+    write(tmp.path(), "a.txt", "changed\n");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let status = provider.status(&repo_ref).await.expect("status ok");
+
+    // Guards the degraded flag against being trivially always-true.
+    assert!(!status.degraded, "a writable repository takes the normal path");
+}
+
+#[tokio::test]
+async fn status_reports_modified_and_deleted() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "m.txt", "one\n");
+    write(tmp.path(), "d.txt", "two\n");
+    commit_all(&repo, "base");
+
+    write(tmp.path(), "m.txt", "one changed\n");
+    std::fs::remove_file(tmp.path().join("d.txt")).expect("remove");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let status = provider.status(&repo_ref).await.expect("status ok");
+
+    assert_eq!(
+        find(&status, "m.txt", Some(false)).expect("modified listed").state,
+        ScmResourceState::Modified
+    );
+    assert_eq!(
+        find(&status, "d.txt", Some(false)).expect("deleted listed").state,
+        ScmResourceState::Deleted
+    );
+}
+
+#[tokio::test]
+async fn status_splits_one_file_staged_and_unstaged() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "both.txt", "base\n");
+    commit_all(&repo, "base");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let file = FileRef {
+        pe_id: "pe1".to_owned(),
+        relative_path: "both.txt".to_owned(),
+    };
+
+    write(tmp.path(), "both.txt", "staged\n");
+    provider
+        .staging()
+        .expect("git declares staging")
+        .stage(&repo_ref, std::slice::from_ref(&file))
+        .await
+        .expect("stage ok");
+    // Edit again after staging: the same path now differs on both sides.
+    write(tmp.path(), "both.txt", "staged then edited\n");
+
+    let status = provider.status(&repo_ref).await.expect("status ok");
+    assert!(
+        find(&status, "both.txt", Some(true)).is_some(),
+        "staged side present: {:?}",
+        status.resources
+    );
+    assert!(
+        find(&status, "both.txt", Some(false)).is_some(),
+        "unstaged side present: {:?}",
+        status.resources
+    );
+}
+
+#[tokio::test]
+async fn status_reports_conflicted_as_opaque_not_modified() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "c.txt", "base\n");
+    commit_all(&repo, "base");
+    let base = repo.head().unwrap().peel_to_commit().unwrap();
+
+    // Two divergent branches touching the same line, then merge → conflict.
+    repo.branch("other", &base, false).expect("branch");
+    write(tmp.path(), "c.txt", "main side\n");
+    commit_all(&repo, "main change");
+
+    let other = repo.find_branch("other", git2::BranchType::Local).expect("find branch");
+    let other_commit = other.get().peel_to_commit().expect("peel");
+    repo.set_head("refs/heads/other").expect("set head");
+    repo.reset(other_commit.as_object(), git2::ResetType::Hard, None)
+        .expect("reset hard");
+    write(tmp.path(), "c.txt", "other side\n");
+    commit_all(&repo, "other change");
+
+    let main_commit = repo
+        .find_branch("main", git2::BranchType::Local)
+        .or_else(|_| repo.find_branch("master", git2::BranchType::Local))
+        .expect("find default branch")
+        .get()
+        .peel_to_commit()
+        .expect("peel");
+    let their = repo.find_annotated_commit(main_commit.id()).expect("annotated");
+    // Conflicts are the expected outcome here, so a merge error is not a failure.
+    let _ = repo.merge(&[&their], None, None);
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let status = provider.status(&repo_ref).await.expect("status ok");
+
+    let conflicted = status
+        .resources
+        .iter()
+        .find(|r| r.repo_relative_path == "c.txt")
+        .expect("conflicted file listed");
+    assert_eq!(
+        conflicted.state,
+        ScmResourceState::Conflicted,
+        "must not fold into modified: acting on it can destroy a resolution"
+    );
+    assert!(conflicted.state.is_opaque());
+    assert_eq!(conflicted.staged, None, "no staged side for an opaque resource");
+}
+
+#[tokio::test]
+async fn stage_records_a_deletion() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "gone.txt", "bye\n");
+    commit_all(&repo, "base");
+    std::fs::remove_file(tmp.path().join("gone.txt")).expect("remove");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let file = FileRef {
+        pe_id: "pe1".to_owned(),
+        relative_path: "gone.txt".to_owned(),
+    };
+    provider
+        .staging()
+        .expect("staging")
+        .stage(&repo_ref, std::slice::from_ref(&file))
+        .await
+        .expect("staging a deletion must not error");
+
+    let status = provider.status(&repo_ref).await.expect("status ok");
+    assert_eq!(
+        find(&status, "gone.txt", Some(true)).expect("deletion staged").state,
+        ScmResourceState::Deleted
+    );
+}
+
+#[tokio::test]
+async fn unstage_returns_change_to_the_work_tree_side() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "u.txt", "base\n");
+    commit_all(&repo, "base");
+    write(tmp.path(), "u.txt", "changed\n");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let staging = provider.staging().expect("staging");
+    let file = FileRef {
+        pe_id: "pe1".to_owned(),
+        relative_path: "u.txt".to_owned(),
+    };
+
+    staging
+        .stage(&repo_ref, std::slice::from_ref(&file))
+        .await
+        .expect("stage ok");
+    assert!(
+        find(&provider.status(&repo_ref).await.unwrap(), "u.txt", Some(true)).is_some(),
+        "staged after stage"
+    );
+
+    staging
+        .unstage(&repo_ref, std::slice::from_ref(&file))
+        .await
+        .expect("unstage ok");
+    let after = provider.status(&repo_ref).await.expect("status ok");
+    assert!(find(&after, "u.txt", Some(true)).is_none(), "no longer staged");
+    assert_eq!(
+        find(&after, "u.txt", Some(false))
+            .expect("back on the work-tree side")
+            .state,
+        ScmResourceState::Modified,
+        "unstage keeps the working-tree edit"
+    );
+}
+
+#[tokio::test]
+async fn revert_restores_a_tracked_file() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "r.txt", "original\n");
+    commit_all(&repo, "base");
+    write(tmp.path(), "r.txt", "scribbled\n");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    provider
+        .revert(
+            &repo_ref,
+            &[FileRef {
+                pe_id: "pe1".to_owned(),
+                relative_path: "r.txt".to_owned(),
+            }],
+        )
+        .await
+        .expect("revert ok");
+
+    let body = std::fs::read_to_string(tmp.path().join("r.txt")).expect("read back");
+    assert_eq!(body, "original\n", "tracked file restored to its committed content");
+}
+
+#[tokio::test]
+async fn revert_refuses_a_conflicted_resource() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "c.txt", "base\n");
+    commit_all(&repo, "base");
+    let base = repo.head().unwrap().peel_to_commit().unwrap();
+    repo.branch("other", &base, false).expect("branch");
+    write(tmp.path(), "c.txt", "main side\n");
+    commit_all(&repo, "main change");
+    let other_commit = repo
+        .find_branch("other", git2::BranchType::Local)
+        .unwrap()
+        .get()
+        .peel_to_commit()
+        .unwrap();
+    repo.set_head("refs/heads/other").unwrap();
+    repo.reset(other_commit.as_object(), git2::ResetType::Hard, None)
+        .unwrap();
+    write(tmp.path(), "c.txt", "other side\n");
+    commit_all(&repo, "other change");
+    let main_commit = repo
+        .find_branch("main", git2::BranchType::Local)
+        .or_else(|_| repo.find_branch("master", git2::BranchType::Local))
+        .unwrap()
+        .get()
+        .peel_to_commit()
+        .unwrap();
+    let their = repo.find_annotated_commit(main_commit.id()).unwrap();
+    let _ = repo.merge(&[&their], None, None);
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let err = provider
+        .revert(
+            &repo_ref,
+            &[FileRef {
+                pe_id: "pe1".to_owned(),
+                relative_path: "c.txt".to_owned(),
+            }],
+        )
+        .await
+        .expect_err("conflicted resources are opaque in stage 1");
+
+    assert!(
+        matches!(err, ScmError::OpaqueResource { .. }),
+        "expected an opaque-resource refusal, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn original_reads_each_anchor() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "a.txt", "committed\n");
+    commit_all(&repo, "base");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let file = FileRef {
+        pe_id: "pe1".to_owned(),
+        relative_path: "a.txt".to_owned(),
+    };
+
+    write(tmp.path(), "a.txt", "staged\n");
+    provider
+        .staging()
+        .expect("staging")
+        .stage(&repo_ref, std::slice::from_ref(&file))
+        .await
+        .expect("stage ok");
+    write(tmp.path(), "a.txt", "working\n");
+
+    let at = |anchor| {
+        let provider = &provider;
+        let repo_ref = &repo_ref;
+        let file = &file;
+        async move {
+            String::from_utf8(
+                provider
+                    .original(repo_ref, file, anchor)
+                    .await
+                    .expect("original ok")
+                    .expect("content present"),
+            )
+            .expect("utf-8")
+        }
+    };
+
+    assert_eq!(at(ContentRef::Working).await, "working\n");
+    assert_eq!(at(ContentRef::Staged).await, "staged\n");
+    assert_eq!(at(ContentRef::Committed).await, "committed\n");
+}
+
+#[tokio::test]
+async fn original_is_none_for_a_file_absent_at_that_anchor() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "seed.txt", "seed\n");
+    commit_all(&repo, "base");
+    write(tmp.path(), "brand-new.txt", "fresh\n");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let file = FileRef {
+        pe_id: "pe1".to_owned(),
+        relative_path: "brand-new.txt".to_owned(),
+    };
+
+    // An added file has no committed version — `None`, not an error.
+    assert!(
+        provider
+            .original(&repo_ref, &file, ContentRef::Committed)
+            .await
+            .expect("original ok")
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn diff_between_anchors_reports_both_sides() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "d.txt", "before\n");
+    commit_all(&repo, "base");
+    write(tmp.path(), "d.txt", "after\n");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let diff = provider
+        .diff(
+            &repo_ref,
+            &FileRef {
+                pe_id: "pe1".to_owned(),
+                relative_path: "d.txt".to_owned(),
+            },
+            ContentRef::Working,
+            ContentRef::Committed,
+        )
+        .await
+        .expect("diff ok");
+
+    let patch = diff.patch.expect("patch present");
+    assert!(patch.contains("-after") || patch.contains("+after"), "patch: {patch}");
+    assert!(patch.contains("before"), "patch mentions the other side: {patch}");
+    assert!(!diff.binary);
+}
+
+#[tokio::test]
+async fn diff_flags_binary_content() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    std::fs::write(tmp.path().join("b.bin"), [0x00, 0x01, 0x02]).expect("write binary");
+    commit_all(&repo, "base");
+    std::fs::write(tmp.path().join("b.bin"), [0x00, 0x03]).expect("rewrite binary");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let diff = provider
+        .diff(
+            &repo_ref,
+            &FileRef {
+                pe_id: "pe1".to_owned(),
+                relative_path: "b.bin".to_owned(),
+            },
+            ContentRef::Working,
+            ContentRef::Committed,
+        )
+        .await
+        .expect("diff ok");
+
+    assert!(diff.binary, "binary content is flagged, not inlined");
+    assert!(diff.patch.is_none());
+}
+
+#[tokio::test]
+async fn unknown_repository_is_rejected() {
+    let provider = GitScmProvider::new();
+    let err = provider
+        .status(&RepoRef {
+            repo_id: "scm:never-discovered".to_owned(),
+        })
+        .await
+        .expect_err("unknown repo must not be served");
+
+    assert!(matches!(err, ScmError::UnknownRepository { .. }), "got {err:?}");
+}
+
+/// A provider without a staging area must refuse the staged anchor rather than
+/// serve a meaningless answer. Exercised through the shared gate, since the git
+/// provider itself always has staging.
+#[test]
+fn staged_anchor_is_refused_without_the_staging_capability() {
+    let caps = ScmCapabilities {
+        staging: false,
+        local_branches: false,
+        history_graph: false,
+        remote_ops: false,
+    };
+
+    let err = check_anchor(caps, ContentRef::Staged).expect_err("staged anchor needs staging");
+    assert!(
+        matches!(err, ScmError::CapabilityUnsupported { capability: "staging" }),
+        "got {err:?}"
+    );
+
+    // The anchors every provider has must stay available.
+    check_anchor(caps, ContentRef::Working).expect("working is universal");
+    check_anchor(caps, ContentRef::Committed).expect("committed is universal");
+}
+
+/// The stale-index fallback: with a read-only `.git` and a stale index, index
+/// writeback fails and the whole `statuses()` call errors out. The provider must
+/// retry without writeback and still return the full list, degraded but usable.
+///
+/// Unix-only: the test needs POSIX mode bits to make `.git` unwritable.
+#[cfg(unix)]
+#[tokio::test]
+async fn status_falls_back_when_index_writeback_is_impossible() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    for i in 0..40 {
+        write(tmp.path(), &format!("f{i}.txt"), "body\n");
+    }
+    commit_all(&repo, "base");
+    write(tmp.path(), "f0.txt", "edited\n");
+
+    // Staleness: every mtime changes while contents mostly do not, which is what
+    // an external touch / build / unpack does.
+    let later = std::time::SystemTime::now() + std::time::Duration::from_secs(2);
+    for i in 0..40 {
+        let f = std::fs::File::options()
+            .write(true)
+            .open(tmp.path().join(format!("f{i}.txt")))
+            .expect("open for touch");
+        f.set_modified(later).expect("set mtime");
+    }
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+
+    let git_dir = tmp.path().join(".git");
+    let original = std::fs::metadata(&git_dir).expect("stat .git").permissions();
+    let mut readonly = original.clone();
+    readonly.set_mode(0o500); // r-x: traversable, not writable
+    std::fs::set_permissions(&git_dir, readonly).expect("make .git read-only");
+
+    let status = provider.status(&repo_ref).await;
+
+    // Restore before asserting so a failure cannot leave an unwritable tempdir.
+    std::fs::set_permissions(&git_dir, original).expect("restore .git permissions");
+
+    let status = status.expect("status must succeed via fallback, never surface as an SCM error");
+    assert!(
+        status.degraded,
+        "the fallback must actually have fired, otherwise this test proves nothing"
+    );
+    assert_eq!(
+        find(&status, "f0.txt", Some(false))
+            .expect("edited file still listed")
+            .state,
+        ScmResourceState::Modified,
+        "the fallback result is complete, only slower"
+    );
+}
+
+/// A body long enough for git's similarity scoring to match the two sides.
+fn renameable_body(tag: &str) -> String {
+    (0..40).map(|i| format!("line {i} of {tag}\n")).collect()
+}
+
+#[tokio::test]
+async fn status_reports_a_worktree_rename_with_both_paths() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "old-name.txt", &renameable_body("subject"));
+    commit_all(&repo, "base");
+    std::fs::rename(tmp.path().join("old-name.txt"), tmp.path().join("new-name.txt")).expect("rename");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let status = provider.status(&repo_ref).await.expect("status ok");
+
+    // Rename detection is off by default in git2: without it this shows up as a
+    // delete plus a create, which the neutral model must not report as a rename.
+    let renamed = status
+        .resources
+        .iter()
+        .find(|r| r.state == ScmResourceState::Renamed)
+        .unwrap_or_else(|| panic!("expected a renamed resource, got {:?}", status.resources));
+
+    // The resource must be identified by the path that exists now; the old path
+    // belongs in `rename_from`.
+    assert_eq!(
+        renamed.repo_relative_path, "new-name.txt",
+        "identity is the current path, not the vanished one"
+    );
+    assert_eq!(renamed.file.relative_path, "new-name.txt");
+    assert_eq!(renamed.rename_from.as_deref(), Some("old-name.txt"));
+    assert_eq!(
+        status.resources.len(),
+        1,
+        "one rename, not a delete + create pair: {:?}",
+        status.resources
+    );
+}
+
+#[tokio::test]
+async fn status_reports_a_staged_rename() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "before.txt", &renameable_body("subject"));
+    commit_all(&repo, "base");
+
+    std::fs::rename(tmp.path().join("before.txt"), tmp.path().join("after.txt")).expect("rename");
+    let mut index = repo.index().expect("index");
+    index.remove_path(Path::new("before.txt")).expect("remove old");
+    index.add_path(Path::new("after.txt")).expect("add new");
+    index.write().expect("write index");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let status = provider.status(&repo_ref).await.expect("status ok");
+
+    let renamed = status
+        .resources
+        .iter()
+        .find(|r| r.state == ScmResourceState::Renamed)
+        .unwrap_or_else(|| panic!("expected a renamed resource, got {:?}", status.resources));
+    assert_eq!(renamed.repo_relative_path, "after.txt");
+    assert_eq!(renamed.rename_from.as_deref(), Some("before.txt"));
+    assert_eq!(renamed.staged, Some(true), "the rename is staged");
+}
+
+/// Past the candidate limit, rename detection is skipped for cost reasons and
+/// the moves degrade to delete + create. Accuracy is preserved; only the rename
+/// label is lost.
+#[tokio::test]
+async fn bulk_moves_skip_rename_detection_and_stay_accurate() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    let count = RENAME_DETECTION_CANDIDATE_LIMIT + 20;
+    for i in 0..count {
+        write(tmp.path(), &format!("f{i}.txt"), &renameable_body(&format!("body {i}")));
+    }
+    commit_all(&repo, "base");
+
+    std::fs::create_dir_all(tmp.path().join("moved")).expect("mkdir");
+    for i in 0..count {
+        std::fs::rename(
+            tmp.path().join(format!("f{i}.txt")),
+            tmp.path().join("moved").join(format!("f{i}.txt")),
+        )
+        .expect("rename");
+    }
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let status = provider.status(&repo_ref).await.expect("status ok");
+
+    assert!(
+        !status.resources.iter().any(|r| r.state == ScmResourceState::Renamed),
+        "detection is skipped past the limit"
+    );
+    let created = status
+        .resources
+        .iter()
+        .filter(|r| r.state == ScmResourceState::Created)
+        .count();
+    let deleted = status
+        .resources
+        .iter()
+        .filter(|r| r.state == ScmResourceState::Deleted)
+        .count();
+    assert_eq!(created, count, "every new path is reported");
+    assert_eq!(deleted, count, "every vanished path is reported");
+}
+
+/// A sink that always refuses, standing in for "the trash move cannot be
+/// performed" (read-only or missing trash location, a shell that rejects the
+/// item, a vanished parent directory).
+struct RefusingTrash;
+
+impl TrashSink for RefusingTrash {
+    fn trash(&self, _path: &Path) -> Result<(), String> {
+        Err("refused by test double".to_owned())
+    }
+}
+
+/// A sink that records what it was asked to trash and then removes the file, so
+/// a test can tell "went through the trash" apart from "was unlinked directly" —
+/// both of which leave the work tree looking identical.
+#[derive(Default)]
+struct RecordingTrash {
+    seen: std::sync::Mutex<Vec<std::path::PathBuf>>,
+}
+
+impl TrashSink for RecordingTrash {
+    fn trash(&self, path: &Path) -> Result<(), String> {
+        self.seen
+            .lock()
+            .expect("recording sink poisoned")
+            .push(path.to_path_buf());
+        std::fs::remove_file(path).map_err(|err| err.to_string())
+    }
+}
+
+/// Build a provider with an injected sink and discover the fixture repo through it.
+async fn discovered_with_trash(dir: &Path, trash: Arc<dyn TrashSink>) -> (GitScmProvider, RepoRef) {
+    let provider = GitScmProvider::with_trash(trash);
+    let root = ResolvedRoot {
+        pe_id: "pe1".to_owned(),
+        absolute_path: dir.to_string_lossy().into_owned(),
+        label: "fixture".to_owned(),
+    };
+    let repo = provider
+        .discover(&root)
+        .await
+        .expect("discover ok")
+        .expect("is a repository");
+    (provider, RepoRef { repo_id: repo.repo_id })
+}
+
+/// Fixture: a committed seed plus one untracked file, which is the discard case
+/// that routes through the trash.
+fn repo_with_untracked_victim(tmp: &TempDir) -> Repository {
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "seed.txt", "seed\n");
+    commit_all(&repo, "base");
+    write(tmp.path(), "fresh/victim.txt", "irreplaceable\n");
+    repo
+}
+
+/// **Data-safety floor.** When the trash move fails, discard must report that
+/// file as failed and leave it exactly where it was. Falling through to a delete
+/// would turn a recoverable failure into permanent data loss — the
+/// version-control system has no copy of an untracked file.
+#[tokio::test]
+async fn discard_keeps_the_file_when_the_trash_move_fails() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _repo = repo_with_untracked_victim(&tmp);
+    let (provider, repo_ref) = discovered_with_trash(tmp.path(), Arc::new(RefusingTrash)).await;
+
+    let file = FileRef {
+        pe_id: "pe1".to_owned(),
+        relative_path: "fresh/victim.txt".to_owned(),
+    };
+    // A per-file IO failure is reported in the outcome, not as a whole-request
+    // error: the request itself was valid and other files would have been done.
+    let outcome = provider
+        .revert(&repo_ref, std::slice::from_ref(&file))
+        .await
+        .expect("the request is valid, so it is not a whole-request error");
+    assert!(!outcome.is_complete(), "the failure is reported");
+    assert_eq!(outcome.failed.len(), 1);
+    assert_eq!(outcome.failed[0].file, file, "reported against the identity passed in");
+    assert!(
+        outcome.failed[0].reason.contains("trash"),
+        "the reason names what went wrong, got {:?}",
+        outcome.failed[0].reason
+    );
+
+    let victim = tmp.path().join("fresh").join("victim.txt");
+    assert!(victim.exists(), "the file must survive a failed discard");
+    assert_eq!(
+        std::fs::read_to_string(&victim).expect("read survivor"),
+        "irreplaceable\n",
+        "content must be untouched"
+    );
+}
+
+/// **Data-safety floor.** Discarding an untracked file must go *through the
+/// trash*, not unlink it. The work tree looks the same either way, so the sink
+/// itself is the only place the difference is observable.
+#[tokio::test]
+async fn discard_of_an_untracked_file_goes_through_the_trash() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _repo = repo_with_untracked_victim(&tmp);
+    let recorder = Arc::new(RecordingTrash::default());
+    let (provider, repo_ref) = discovered_with_trash(tmp.path(), Arc::clone(&recorder) as Arc<dyn TrashSink>).await;
+
+    provider
+        .revert(
+            &repo_ref,
+            &[FileRef {
+                pe_id: "pe1".to_owned(),
+                relative_path: "fresh/victim.txt".to_owned(),
+            }],
+        )
+        .await
+        .expect("discard succeeds");
+
+    let seen = recorder.seen.lock().expect("recording sink poisoned").clone();
+    assert_eq!(seen.len(), 1, "exactly one file was handed to the trash, got {seen:?}");
+    assert!(
+        seen[0].ends_with(Path::new("fresh").join("victim.txt")),
+        "the discarded file is the one handed over, got {:?}",
+        seen[0]
+    );
+    assert!(
+        !tmp.path().join("fresh").join("victim.txt").exists(),
+        "and it did leave the work tree"
+    );
+}
+
+/// Tracked files must not reach the trash at all: they are restored from the
+/// committed version in place.
+#[tokio::test]
+async fn discard_of_a_tracked_file_does_not_touch_the_trash() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "tracked.txt", "original\n");
+    commit_all(&repo, "base");
+    write(tmp.path(), "tracked.txt", "scribbled\n");
+
+    let recorder = Arc::new(RecordingTrash::default());
+    let (provider, repo_ref) = discovered_with_trash(tmp.path(), Arc::clone(&recorder) as Arc<dyn TrashSink>).await;
+
+    provider
+        .revert(
+            &repo_ref,
+            &[FileRef {
+                pe_id: "pe1".to_owned(),
+                relative_path: "tracked.txt".to_owned(),
+            }],
+        )
+        .await
+        .expect("discard succeeds");
+
+    assert!(
+        recorder.seen.lock().expect("recording sink poisoned").is_empty(),
+        "a tracked file is restored, never trashed"
+    );
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("tracked.txt")).expect("read restored"),
+        "original\n",
+    );
+}
+
+/// A sink that refuses only the paths it was told to, so a batch can be made to
+/// fail partway without failing entirely.
+struct SelectiveTrash {
+    refuse: Vec<String>,
+    seen: std::sync::Mutex<Vec<String>>,
+}
+
+impl SelectiveTrash {
+    fn refusing(names: &[&str]) -> Self {
+        Self {
+            refuse: names.iter().map(|n| (*n).to_owned()).collect(),
+            seen: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl TrashSink for SelectiveTrash {
+    fn trash(&self, path: &Path) -> Result<(), String> {
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        self.seen.lock().expect("sink poisoned").push(name.clone());
+        if self.refuse.contains(&name) {
+            return Err(format!("refusing {name}"));
+        }
+        std::fs::remove_file(path).map_err(|err| err.to_string())
+    }
+}
+
+/// Two tracked edits plus three untracked files — the mixed batch a user gets
+/// when selecting "discard all".
+fn mixed_batch(tmp: &TempDir) -> (Repository, Vec<FileRef>) {
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "t1.txt", "committed-1\n");
+    write(tmp.path(), "t2.txt", "committed-2\n");
+    commit_all(&repo, "base");
+    write(tmp.path(), "t1.txt", "edited-1\n");
+    write(tmp.path(), "t2.txt", "edited-2\n");
+    write(tmp.path(), "u1.txt", "new-1\n");
+    write(tmp.path(), "u2.txt", "new-2\n");
+    write(tmp.path(), "u3.txt", "new-3\n");
+
+    let files = ["t1.txt", "t2.txt", "u1.txt", "u2.txt", "u3.txt"]
+        .iter()
+        .map(|p| FileRef {
+            pe_id: "pe1".to_owned(),
+            relative_path: (*p).to_owned(),
+        })
+        .collect();
+    (repo, files)
+}
+
+/// One file failing must not abandon the rest. Before this was best effort, a
+/// mid-batch failure returned "failed" while leaving earlier files already
+/// changed and later ones untouched — the caller could not tell which.
+#[tokio::test]
+async fn a_partial_failure_still_processes_every_other_file() {
+    let tmp = TempDir::new().expect("tempdir");
+    let (_repo, files) = mixed_batch(&tmp);
+    let sink = Arc::new(SelectiveTrash::refusing(&["u2.txt"]));
+    let (provider, repo_ref) = discovered_with_trash(tmp.path(), Arc::clone(&sink) as Arc<dyn TrashSink>).await;
+
+    let outcome = provider.revert(&repo_ref, &files).await.expect("request is valid");
+
+    // Exactly the refused file is reported.
+    assert_eq!(outcome.failed.len(), 1, "one failure, got {:?}", outcome.failed);
+    assert_eq!(outcome.failed[0].file.relative_path, "u2.txt");
+
+    // Everything else really happened: tracked files restored, other untracked
+    // files gone, and the failed one left untouched.
+    for tracked in ["t1.txt", "t2.txt"] {
+        assert!(
+            std::fs::read_to_string(tmp.path().join(tracked))
+                .expect("read tracked")
+                .starts_with("committed"),
+            "{tracked} was restored"
+        );
+    }
+    assert!(!tmp.path().join("u1.txt").exists(), "u1 was discarded");
+    assert!(
+        !tmp.path().join("u3.txt").exists(),
+        "u3 was still attempted after the failure — this is the whole point of best effort"
+    );
+    assert!(tmp.path().join("u2.txt").exists(), "the failed file survives");
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("u2.txt")).expect("read survivor"),
+        "new-2\n"
+    );
+}
+
+#[tokio::test]
+async fn every_file_failing_is_reported_per_file() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "seed.txt", "seed\n");
+    commit_all(&repo, "base");
+    write(tmp.path(), "a.txt", "a\n");
+    write(tmp.path(), "b.txt", "b\n");
+
+    let files: Vec<FileRef> = ["a.txt", "b.txt"]
+        .iter()
+        .map(|p| FileRef {
+            pe_id: "pe1".to_owned(),
+            relative_path: (*p).to_owned(),
+        })
+        .collect();
+    let (provider, repo_ref) = discovered_with_trash(tmp.path(), Arc::new(RefusingTrash)).await;
+
+    let outcome = provider.revert(&repo_ref, &files).await.expect("request is valid");
+
+    // All failing is still not a whole-request error: the request was valid, and
+    // the caller needs the per-file reasons.
+    assert_eq!(outcome.failed.len(), 2, "both reported, got {:?}", outcome.failed);
+    assert!(
+        tmp.path().join("a.txt").exists() && tmp.path().join("b.txt").exists(),
+        "nothing lost"
+    );
+}
+
+/// The conflicted pre-check runs over the whole selection **before** anything is
+/// touched, so selecting a conflicted file leaves the batch untouched. Without
+/// that ordering, a user who picked one conflicted file among many would find the
+/// others already discarded.
+#[tokio::test]
+async fn a_conflicted_file_in_the_batch_makes_the_whole_request_a_no_op() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "c.txt", "base\n");
+    write(tmp.path(), "other.txt", "committed\n");
+    commit_all(&repo, "base");
+    let base = repo.head().unwrap().peel_to_commit().unwrap();
+
+    // Produce a real conflict on c.txt.
+    repo.branch("other", &base, false).expect("branch");
+    write(tmp.path(), "c.txt", "main side\n");
+    commit_all(&repo, "main change");
+    let other_commit = repo
+        .find_branch("other", git2::BranchType::Local)
+        .unwrap()
+        .get()
+        .peel_to_commit()
+        .unwrap();
+    repo.set_head("refs/heads/other").unwrap();
+    repo.reset(other_commit.as_object(), git2::ResetType::Hard, None)
+        .unwrap();
+    write(tmp.path(), "c.txt", "other side\n");
+    commit_all(&repo, "other change");
+    let main_commit = repo
+        .find_branch("main", git2::BranchType::Local)
+        .or_else(|_| repo.find_branch("master", git2::BranchType::Local))
+        .unwrap()
+        .get()
+        .peel_to_commit()
+        .unwrap();
+    let their = repo.find_annotated_commit(main_commit.id()).unwrap();
+    let _ = repo.merge(&[&their], None, None);
+
+    // An untracked file alongside it, which must survive untouched.
+    write(tmp.path(), "bystander.txt", "keep me\n");
+    let recorder = Arc::new(RecordingTrash::default());
+    let (provider, repo_ref) = discovered_with_trash(tmp.path(), Arc::clone(&recorder) as Arc<dyn TrashSink>).await;
+
+    let files: Vec<FileRef> = ["bystander.txt", "c.txt"]
+        .iter()
+        .map(|p| FileRef {
+            pe_id: "pe1".to_owned(),
+            relative_path: (*p).to_owned(),
+        })
+        .collect();
+    let err = provider
+        .revert(&repo_ref, &files)
+        .await
+        .expect_err("a conflicted selection is refused outright");
+    assert!(
+        matches!(err, ScmError::OpaqueResource { .. }),
+        "refused as opaque, got {err:?}"
+    );
+
+    // Whole-request refusal means untouched — not "some already discarded".
+    assert!(
+        tmp.path().join("bystander.txt").exists(),
+        "the pre-check runs before any file is touched"
+    );
+    assert!(
+        recorder.seen.lock().expect("sink").is_empty(),
+        "and nothing reached the trash at all"
+    );
+}
+
+/// All three multi-file actions must offer the same guarantee for blocked
+/// resources: a conflicted file anywhere in the selection refuses the whole
+/// request before anything is touched. Without the pre-check, `unstage` would
+/// reach a conflicted entry only partway through and leave earlier files already
+/// unstaged.
+#[tokio::test]
+async fn stage_and_unstage_refuse_a_conflicted_selection_atomically() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "c.txt", "base\n");
+    write(tmp.path(), "clean.txt", "committed\n");
+    commit_all(&repo, "base");
+    let base = repo.head().unwrap().peel_to_commit().unwrap();
+
+    repo.branch("other", &base, false).expect("branch");
+    write(tmp.path(), "c.txt", "main side\n");
+    commit_all(&repo, "main change");
+    let other_commit = repo
+        .find_branch("other", git2::BranchType::Local)
+        .unwrap()
+        .get()
+        .peel_to_commit()
+        .unwrap();
+    repo.set_head("refs/heads/other").unwrap();
+    repo.reset(other_commit.as_object(), git2::ResetType::Hard, None)
+        .unwrap();
+    write(tmp.path(), "c.txt", "other side\n");
+    commit_all(&repo, "other change");
+    let main_commit = repo
+        .find_branch("main", git2::BranchType::Local)
+        .or_else(|_| repo.find_branch("master", git2::BranchType::Local))
+        .unwrap()
+        .get()
+        .peel_to_commit()
+        .unwrap();
+    let their = repo.find_annotated_commit(main_commit.id()).unwrap();
+    let _ = repo.merge(&[&their], None, None);
+
+    // A clean edit alongside the conflict, which must stay untouched.
+    write(tmp.path(), "clean.txt", "edited\n");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let staging = provider.staging().expect("git declares staging");
+    let files: Vec<FileRef> = ["clean.txt", "c.txt"]
+        .iter()
+        .map(|p| FileRef {
+            pe_id: "pe1".to_owned(),
+            relative_path: (*p).to_owned(),
+        })
+        .collect();
+
+    for (label, result) in [
+        ("stage", staging.stage(&repo_ref, &files).await),
+        ("unstage", staging.unstage(&repo_ref, &files).await),
+    ] {
+        let err = result.unwrap_err_or_else_msg(label);
+        assert!(
+            matches!(err, ScmError::OpaqueResource { .. }),
+            "{label} must refuse a conflicted selection, got {err:?}"
+        );
+    }
+
+    // Refused means untouched: the clean file was never staged.
+    let status = provider.status(&repo_ref).await.expect("status ok");
+    assert!(
+        find(&status, "clean.txt", Some(true)).is_none(),
+        "the clean file must not have been staged by a refused request: {:?}",
+        status.resources
+    );
+}
+
+/// Small helper so the loop above reads clearly.
+trait UnwrapErrMsg<T> {
+    fn unwrap_err_or_else_msg(self, label: &str) -> ScmError;
+}
+
+impl<T: std::fmt::Debug> UnwrapErrMsg<T> for Result<T, ScmError> {
+    fn unwrap_err_or_else_msg(self, label: &str) -> ScmError {
+        match self {
+            Ok(value) => panic!("{label} should have been refused, got Ok({value:?})"),
+            Err(err) => err,
+        }
+    }
+}
+
+/// A failure must come back carrying **the exact identity the caller sent**, so a
+/// client can match it to the row it rendered. Reporting a blank or re-derived
+/// `pe_id` would match nothing and silently degrade "this file failed" into
+/// "something failed".
+#[tokio::test]
+async fn a_failure_carries_back_the_identity_that_was_requested() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _repo = repo_with_untracked_victim(&tmp);
+    let (provider, repo_ref) = discovered_with_trash(tmp.path(), Arc::new(RefusingTrash)).await;
+
+    // A pe id distinct from the fixtures' usual one: if anything re-derived the
+    // identity instead of carrying it, this is what would go missing.
+    let requested = FileRef {
+        pe_id: "pe-distinctive-42".to_owned(),
+        relative_path: "fresh/victim.txt".to_owned(),
+    };
+
+    let outcome = provider
+        .revert(&repo_ref, std::slice::from_ref(&requested))
+        .await
+        .expect("request is valid");
+
+    assert_eq!(outcome.failed.len(), 1);
+    assert_eq!(
+        outcome.failed[0].file, requested,
+        "the failure carries the requested identity verbatim"
+    );
+    assert!(
+        !outcome.failed[0].file.pe_id.is_empty(),
+        "never a blank identity: it would match no row on the client"
+    );
+}
+
+/// Duplicate entries in one request each keep their own identity, which a
+/// path-based lookup could not guarantee.
+#[tokio::test]
+async fn duplicate_paths_in_a_request_each_report_their_own_identity() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _repo = repo_with_untracked_victim(&tmp);
+    let (provider, repo_ref) = discovered_with_trash(tmp.path(), Arc::new(RefusingTrash)).await;
+
+    let files = vec![
+        FileRef {
+            pe_id: "pe-first".to_owned(),
+            relative_path: "fresh/victim.txt".to_owned(),
+        },
+        FileRef {
+            pe_id: "pe-second".to_owned(),
+            relative_path: "fresh/victim.txt".to_owned(),
+        },
+    ];
+
+    let outcome = provider.revert(&repo_ref, &files).await.expect("request is valid");
+
+    assert_eq!(outcome.failed.len(), 2, "each request item is reported");
+    let reported: Vec<&str> = outcome.failed.iter().map(|f| f.file.pe_id.as_str()).collect();
+    assert_eq!(
+        reported,
+        vec!["pe-first", "pe-second"],
+        "each keeps the identity it was sent with, in request order"
+    );
+}
+
+/// Discarding a working-tree change restores the **staged** version, not the
+/// committed one.
+///
+/// This is the behaviour the version-control system itself has, and getting it
+/// wrong is user-visible: restoring from the last commit while leaving the index
+/// alone produces a state the engine never creates — work tree at the commit,
+/// index still holding the staged version — so the file keeps showing changes on
+/// both sides and the change count does not drop even though the user asked to
+/// discard.
+#[tokio::test]
+async fn discard_restores_the_staged_version_and_drops_only_the_unstaged_change() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "f.txt", "committed\n");
+    commit_all(&repo, "base");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let file = FileRef {
+        pe_id: "pe1".to_owned(),
+        relative_path: "f.txt".to_owned(),
+    };
+
+    // Stage one version, then edit again: both sides now differ.
+    write(tmp.path(), "f.txt", "staged-version\n");
+    provider
+        .staging()
+        .expect("staging")
+        .stage(&repo_ref, std::slice::from_ref(&file))
+        .await
+        .expect("stage ok");
+    write(tmp.path(), "f.txt", "worktree-version\n");
+
+    let before = provider.status(&repo_ref).await.expect("status ok");
+    assert_eq!(before.resources.len(), 2, "both sides present: {:?}", before.resources);
+
+    provider
+        .revert(&repo_ref, std::slice::from_ref(&file))
+        .await
+        .expect("discard ok");
+
+    // The staged version survives in the work tree — the staged edit was not asked
+    // to be discarded.
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("f.txt")).expect("read back"),
+        "staged-version\n",
+        "restored from the index, not from the last commit"
+    );
+
+    let after = provider.status(&repo_ref).await.expect("status ok");
+    assert_eq!(
+        after.resources.len(),
+        1,
+        "the change count drops: only the staged side remains, got {:?}",
+        after.resources
+    );
+    assert!(
+        find(&after, "f.txt", Some(true)).is_some(),
+        "the staged side is untouched: {:?}",
+        after.resources
+    );
+    assert!(
+        find(&after, "f.txt", Some(false)).is_none(),
+        "the unstaged side is gone: {:?}",
+        after.resources
+    );
+}
+
+/// The common case: nothing staged, so the index version *is* the committed one
+/// and discarding restores the committed content. No special casing needed.
+#[tokio::test]
+async fn discard_restores_committed_content_when_nothing_is_staged() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "f.txt", "committed\n");
+    commit_all(&repo, "base");
+    write(tmp.path(), "f.txt", "scribbled\n");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    provider
+        .revert(
+            &repo_ref,
+            &[FileRef {
+                pe_id: "pe1".to_owned(),
+                relative_path: "f.txt".to_owned(),
+            }],
+        )
+        .await
+        .expect("discard ok");
+
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("f.txt")).expect("read back"),
+        "committed\n",
+    );
+    assert!(
+        provider
+            .status(&repo_ref)
+            .await
+            .expect("status ok")
+            .resources
+            .is_empty(),
+        "the file is clean again"
+    );
+}
+
+/// In a repository with no commits yet there is no committed version, but the
+/// index may still hold a staged one — and the same rule applies, so discard
+/// restores that staged version rather than doing nothing.
+#[tokio::test]
+async fn discard_in_a_repository_without_commits_restores_the_staged_version() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    // Never committed; staged addition, then edited again.
+    write(tmp.path(), "s.txt", "staged-content\n");
+    let mut index = repo.index().expect("index");
+    index.add_path(Path::new("s.txt")).expect("add");
+    index.write().expect("write index");
+    write(tmp.path(), "s.txt", "worktree-content\n");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    provider
+        .revert(
+            &repo_ref,
+            &[FileRef {
+                pe_id: "pe1".to_owned(),
+                relative_path: "s.txt".to_owned(),
+            }],
+        )
+        .await
+        .expect("discard ok");
+
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("s.txt")).expect("read back"),
+        "staged-content\n",
+        "restored from the index even with no commits to fall back on"
+    );
+}
+
+/// A file can carry a non-rename change on the index side **and** a rename on the
+/// work-tree side: stage an edit, then move the file. Both deltas exist, and the
+/// rename is the one that determines where the file actually lives now.
+///
+/// Getting this wrong is not a cosmetic mislabel. The resource's identity would be
+/// the vanished old path, so every follow-up acts on a file that is not there:
+/// reading its content yields nothing, and discarding it reports success while
+/// restoring the old path instead — a claim of "done" with the work not done,
+/// which is exactly what the per-file failure reporting exists to prevent.
+#[tokio::test]
+async fn a_rename_is_detected_even_when_the_index_side_has_a_different_change() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "a.txt", &renameable_body("subject"));
+    commit_all(&repo, "base");
+
+    // Index side: a staged edit (a *non-rename* delta).
+    write(
+        tmp.path(),
+        "a.txt",
+        &format!("{}extra line\n", renameable_body("subject")),
+    );
+    let mut index = repo.index().expect("index");
+    index.add_path(Path::new("a.txt")).expect("stage the edit");
+    index.write().expect("write index");
+
+    // Work-tree side: the same file is then moved.
+    std::fs::rename(tmp.path().join("a.txt"), tmp.path().join("b.txt")).expect("rename");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let status = provider.status(&repo_ref).await.expect("status ok");
+
+    let renamed = status
+        .resources
+        .iter()
+        .find(|r| r.state == ScmResourceState::Renamed)
+        .unwrap_or_else(|| {
+            panic!(
+                "the work-tree rename must be seen despite the index-side edit, got {:?}",
+                status.resources
+            )
+        });
+
+    // Identity must be where the file now is, with the previous path recorded.
+    assert_eq!(renamed.repo_relative_path, "b.txt", "identity is the current path");
+    assert_eq!(
+        renamed.rename_from.as_deref(),
+        Some("a.txt"),
+        "and the old path is kept"
+    );
+
+    // The identity has to be usable: content readable, and no resource points at a
+    // path that no longer exists on disk.
+    let content = provider
+        .original(
+            &repo_ref,
+            &FileRef {
+                pe_id: "pe1".to_owned(),
+                relative_path: renamed.repo_relative_path.clone(),
+            },
+            ContentRef::Working,
+        )
+        .await
+        .expect("original ok");
+    assert!(
+        content.is_some(),
+        "the reported identity must resolve to real content, not a vanished path"
+    );
+    assert!(
+        !tmp.path().join("a.txt").exists(),
+        "the old path is gone from the work tree — nothing may still report it"
+    );
+}
+
+/// Unstaging a batch takes a single engine call, falling back to one call per file
+/// only if that fails. Both routes must agree, so the shortcut is verified against
+/// the outcome it is supposed to be equivalent to.
+#[tokio::test]
+async fn unstaging_a_batch_matches_unstaging_one_by_one() {
+    let build = |tmp: &TempDir| {
+        let repo = init_repo(tmp.path());
+        for i in 0..5 {
+            write(tmp.path(), &format!("f{i}.txt"), "committed\n");
+        }
+        commit_all(&repo, "base");
+        for i in 0..5 {
+            write(tmp.path(), &format!("f{i}.txt"), "edited\n");
+        }
+    };
+    let refs: Vec<FileRef> = (0..5)
+        .map(|i| FileRef {
+            pe_id: "pe1".to_owned(),
+            relative_path: format!("f{i}.txt"),
+        })
+        .collect();
+
+    // Batch: one call for all five.
+    let batched = TempDir::new().expect("tempdir");
+    build(&batched);
+    let (provider, repo_ref) = discovered(batched.path()).await;
+    let staging = provider.staging().expect("staging");
+    staging.stage(&repo_ref, &refs).await.expect("stage ok");
+    let outcome = staging.unstage(&repo_ref, &refs).await.expect("unstage ok");
+    let after_batch = provider.status(&repo_ref).await.expect("status ok");
+
+    // One at a time: the fallback route.
+    let single = TempDir::new().expect("tempdir");
+    build(&single);
+    let (provider2, repo_ref2) = discovered(single.path()).await;
+    let staging2 = provider2.staging().expect("staging");
+    staging2.stage(&repo_ref2, &refs).await.expect("stage ok");
+    for one in &refs {
+        staging2
+            .unstage(&repo_ref2, std::slice::from_ref(one))
+            .await
+            .expect("unstage ok");
+    }
+    let after_single = provider2.status(&repo_ref2).await.expect("status ok");
+
+    assert!(outcome.is_complete(), "the batch reported no failures");
+    let sides = |s: &ScmStatus| {
+        let mut v: Vec<(String, Option<bool>)> = s
+            .resources
+            .iter()
+            .map(|r| (r.repo_relative_path.clone(), r.staged))
+            .collect();
+        v.sort();
+        v
+    };
+    assert_eq!(
+        sides(&after_batch),
+        sides(&after_single),
+        "the shortcut must land in the same state as unstaging individually"
+    );
+    assert!(
+        after_batch.resources.iter().all(|r| r.staged == Some(false)),
+        "everything is back on the work-tree side: {:?}",
+        after_batch.resources
+    );
+}
+
+/// An empty selection must do nothing at all. The batch call receives an empty
+/// pathspec, and a pathspec-less reset would mean "reset everything" — which would
+/// silently unstage work the user never selected.
+#[tokio::test]
+async fn an_empty_selection_leaves_the_staging_area_untouched() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "a.txt", "committed\n");
+    write(tmp.path(), "b.txt", "committed\n");
+    commit_all(&repo, "base");
+    write(tmp.path(), "a.txt", "edited\n");
+    write(tmp.path(), "b.txt", "edited\n");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let staging = provider.staging().expect("staging");
+    let all: Vec<FileRef> = ["a.txt", "b.txt"]
+        .iter()
+        .map(|p| FileRef {
+            pe_id: "pe1".to_owned(),
+            relative_path: (*p).to_owned(),
+        })
+        .collect();
+    staging.stage(&repo_ref, &all).await.expect("stage ok");
+    let staged_before = provider
+        .status(&repo_ref)
+        .await
+        .expect("status ok")
+        .resources
+        .iter()
+        .filter(|r| r.staged == Some(true))
+        .count();
+    assert_eq!(staged_before, 2);
+
+    for outcome in [
+        staging.unstage(&repo_ref, &[]).await.expect("empty unstage ok"),
+        staging.stage(&repo_ref, &[]).await.expect("empty stage ok"),
+        provider.revert(&repo_ref, &[]).await.expect("empty discard ok"),
+    ] {
+        assert!(outcome.is_complete(), "nothing to do is not a failure");
+    }
+
+    let staged_after = provider
+        .status(&repo_ref)
+        .await
+        .expect("status ok")
+        .resources
+        .iter()
+        .filter(|r| r.staged == Some(true))
+        .count();
+    assert_eq!(
+        staged_after, staged_before,
+        "an empty selection must not touch anything, least of all everything"
+    );
+}
+
+/// Build a real merge conflict on `c.txt`, leaving `other.txt` clean.
+fn conflicted_fixture(tmp: &TempDir) {
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "c.txt", "base\n");
+    write(tmp.path(), "other.txt", "committed\n");
+    commit_all(&repo, "base");
+    let base = repo.head().unwrap().peel_to_commit().unwrap();
+
+    repo.branch("other", &base, false).expect("branch");
+    write(tmp.path(), "c.txt", "main side\n");
+    commit_all(&repo, "main change");
+    let other_commit = repo
+        .find_branch("other", git2::BranchType::Local)
+        .unwrap()
+        .get()
+        .peel_to_commit()
+        .unwrap();
+    repo.set_head("refs/heads/other").unwrap();
+    repo.reset(other_commit.as_object(), git2::ResetType::Hard, None)
+        .unwrap();
+    write(tmp.path(), "c.txt", "other side\n");
+    commit_all(&repo, "other change");
+    let main_commit = repo
+        .find_branch("main", git2::BranchType::Local)
+        .or_else(|_| repo.find_branch("master", git2::BranchType::Local))
+        .unwrap()
+        .get()
+        .peel_to_commit()
+        .unwrap();
+    let their = repo.find_annotated_commit(main_commit.id()).unwrap();
+    let _ = repo.merge(&[&their], None, None);
+}
+
+/// A conflicted file has no single staged version — the index holds the three
+/// sides of the conflict instead. Asking for its staged content must be refused,
+/// not answered with "nothing".
+///
+/// Answering "nothing" is what makes this dangerous: a diff against an empty side
+/// reads as **the entire file was deleted**, while the file sits intact on disk.
+/// That is a fabricated result, not a missing one, and no client-side workaround
+/// can fix it — every other consumer would get the same fiction.
+#[tokio::test]
+async fn the_staged_anchor_is_refused_for_a_conflicted_file() {
+    let tmp = TempDir::new().expect("tempdir");
+    conflicted_fixture(&tmp);
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let conflicted = FileRef {
+        pe_id: "pe1".to_owned(),
+        relative_path: "c.txt".to_owned(),
+    };
+
+    let err = provider
+        .original(&repo_ref, &conflicted, ContentRef::Staged)
+        .await
+        .expect_err("a conflicted file has no staged version to return");
+    assert!(
+        matches!(err, ScmError::OpaqueResource { .. }),
+        "refused the way conflicted resources are refused elsewhere, got {err:?}"
+    );
+
+    // A diff involving that anchor must fail too, rather than fabricate a patch
+    // that claims the file was emptied.
+    let diff_err = provider
+        .diff(&repo_ref, &conflicted, ContentRef::Working, ContentRef::Staged)
+        .await
+        .expect_err("no patch can be produced against a version that does not exist");
+    assert!(matches!(diff_err, ScmError::OpaqueResource { .. }), "got {diff_err:?}");
+}
+
+/// The refusal must be specific to conflicted files: the universal anchors still
+/// work, and an unstaged-but-unconflicted file still reports "nothing staged"
+/// rather than being refused.
+#[tokio::test]
+async fn the_other_anchors_still_work_for_a_conflicted_file() {
+    let tmp = TempDir::new().expect("tempdir");
+    conflicted_fixture(&tmp);
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let conflicted = FileRef {
+        pe_id: "pe1".to_owned(),
+        relative_path: "c.txt".to_owned(),
+    };
+
+    // Working shows the conflict markers; committed shows the last commit. Both are
+    // meaningful and must remain available — the client needs them to render the
+    // conflict at all.
+    let working = provider
+        .original(&repo_ref, &conflicted, ContentRef::Working)
+        .await
+        .expect("working anchor ok")
+        .expect("working content present");
+    assert!(
+        String::from_utf8_lossy(&working).contains("<<<<<<<"),
+        "the work tree carries the conflict markers"
+    );
+    assert!(
+        provider
+            .original(&repo_ref, &conflicted, ContentRef::Committed)
+            .await
+            .expect("committed anchor ok")
+            .is_some(),
+        "the committed side is still readable"
+    );
+
+    // A merely-untracked file is absent from the index, not conflicted: that is
+    // "nothing staged", which is an answer rather than a refusal.
+    write(tmp.path(), "fresh.txt", "new\n");
+    let fresh = FileRef {
+        pe_id: "pe1".to_owned(),
+        relative_path: "fresh.txt".to_owned(),
+    };
+    assert!(
+        provider
+            .original(&repo_ref, &fresh, ContentRef::Staged)
+            .await
+            .expect("an unstaged file is not an error")
+            .is_none(),
+        "absent from the index means no content, not a refusal"
+    );
+}
+
+/// The resource cap counts untracked entries too. Scan cost is driven by the
+/// number of non-ignored files, and creating files in bulk goes down exactly that
+/// path — so exempting untracked entries would leave the real growth uncapped
+/// while still reporting a complete list.
+#[tokio::test]
+async fn the_resource_cap_counts_untracked_entries() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "seed.txt", "seed\n");
+    commit_all(&repo, "base");
+
+    // Only untracked files, more than the cap allows.
+    let count = STATUS_RESOURCE_LIMIT + 25;
+    for i in 0..count {
+        write(tmp.path(), &format!("gen/f{i}.txt"), "x\n");
+    }
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let status = provider.status(&repo_ref).await.expect("status ok");
+
+    assert!(
+        status.truncated,
+        "a list of only untracked entries must still be truncated at the cap"
+    );
+    assert_eq!(
+        status.resources.len(),
+        STATUS_RESOURCE_LIMIT,
+        "and it is capped at the limit, not returned in full"
+    );
+}
+
+/// A file staged as deleted and then recreated in the work tree shows up as two
+/// resources: the staged deletion, and the recreated file as an untracked
+/// creation. That matches what the version-control system itself reports.
+///
+/// Pinned deliberately, because the routing this exercises is shared with the
+/// rename case: discarding the recreated file treats it as the untracked file it
+/// is and sends it to the trash, leaving the staged deletion alone. A change to
+/// rename handling must not quietly alter this.
+#[tokio::test]
+async fn a_staged_deletion_with_a_recreated_file_reports_both_sides() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "f.txt", "committed\n");
+    commit_all(&repo, "base");
+    std::fs::remove_file(tmp.path().join("f.txt")).expect("remove");
+    let mut index = repo.index().expect("index");
+    index.remove_path(Path::new("f.txt")).expect("stage the deletion");
+    index.write().expect("write index");
+    write(tmp.path(), "f.txt", "recreated\n");
+
+    let recorder = Arc::new(RecordingTrash::default());
+    let (provider, repo_ref) = discovered_with_trash(tmp.path(), Arc::clone(&recorder) as Arc<dyn TrashSink>).await;
+
+    let status = provider.status(&repo_ref).await.expect("status ok");
+    assert_eq!(
+        status.resources.len(),
+        2,
+        "both sides are reported: {:?}",
+        status.resources
+    );
+    assert_eq!(
+        find(&status, "f.txt", Some(true)).expect("staged side").state,
+        ScmResourceState::Deleted,
+        "the staged deletion is one resource"
+    );
+    assert_eq!(
+        find(&status, "f.txt", Some(false)).expect("work-tree side").state,
+        ScmResourceState::Created,
+        "and the recreated file is the other"
+    );
+
+    // Discarding it routes through the trash, because in the work tree it really is
+    // an untracked file.
+    provider
+        .revert(
+            &repo_ref,
+            &[FileRef {
+                pe_id: "pe1".to_owned(),
+                relative_path: "f.txt".to_owned(),
+            }],
+        )
+        .await
+        .expect("discard ok");
+    assert_eq!(
+        recorder.seen.lock().expect("sink").len(),
+        1,
+        "the recreated file went to the trash rather than being unlinked"
+    );
+    assert!(!tmp.path().join("f.txt").exists(), "and it left the work tree");
+}
+
+/// Move a committed file, leaving the rename unstaged.
+fn worktree_rename(tmp: &TempDir) -> Repository {
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "old.txt", &renameable_body("subject"));
+    commit_all(&repo, "base");
+    std::fs::rename(tmp.path().join("old.txt"), tmp.path().join("new.txt")).expect("rename");
+    repo
+}
+
+/// Discarding a rename undoes the whole move: the file comes back where it was,
+/// and the path it had moved to goes through the trash.
+///
+/// A rename is presented to the client as **one** resource, so one discard has to
+/// undo one move. Handling only the new path — which on its own looks like an
+/// untracked file — would trash it and never restore the source, leaving the file
+/// present at neither path while the call reported success.
+#[tokio::test]
+async fn discarding_a_worktree_rename_restores_the_old_path_and_trashes_the_new_one() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _repo = worktree_rename(&tmp);
+    let recorder = Arc::new(RecordingTrash::default());
+    let (provider, repo_ref) = discovered_with_trash(tmp.path(), Arc::clone(&recorder) as Arc<dyn TrashSink>).await;
+
+    // Precondition: one resource, identified by the new path, carrying the old one.
+    let status = provider.status(&repo_ref).await.expect("status ok");
+    let renamed = status
+        .resources
+        .iter()
+        .find(|r| r.state == ScmResourceState::Renamed)
+        .unwrap_or_else(|| panic!("expected a rename, got {:?}", status.resources));
+    assert_eq!(renamed.repo_relative_path, "new.txt");
+    assert_eq!(renamed.rename_from.as_deref(), Some("old.txt"));
+
+    let outcome = provider
+        .revert(
+            &repo_ref,
+            &[FileRef {
+                pe_id: "pe1".to_owned(),
+                relative_path: "new.txt".to_owned(),
+            }],
+        )
+        .await
+        .expect("discard ok");
+    assert!(outcome.is_complete(), "reported no failures: {:?}", outcome.failed);
+
+    assert!(
+        tmp.path().join("old.txt").exists(),
+        "the file is back where it came from — losing it from both paths is the bug this prevents"
+    );
+    assert!(
+        !tmp.path().join("new.txt").exists(),
+        "and it is gone from where it moved to"
+    );
+    assert_eq!(
+        recorder.seen.lock().expect("sink").len(),
+        1,
+        "the destination went through the trash, not an unlink"
+    );
+
+    // And the change list is actually clean again, rather than showing a leftover.
+    assert!(
+        provider
+            .status(&repo_ref)
+            .await
+            .expect("status ok")
+            .resources
+            .is_empty(),
+        "the repository is clean after undoing the move"
+    );
+}
+
+/// The same for a staged rename. Its source is no longer in the index, so the
+/// restore has to come from the last commit — restoring "from the index" would find
+/// nothing and silently do nothing while reporting success.
+#[tokio::test]
+async fn discarding_a_staged_rename_also_undoes_the_whole_move() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "old.txt", &renameable_body("subject"));
+    commit_all(&repo, "base");
+    std::fs::rename(tmp.path().join("old.txt"), tmp.path().join("new.txt")).expect("rename");
+    let mut index = repo.index().expect("index");
+    index.remove_path(Path::new("old.txt")).expect("remove source");
+    index.add_path(Path::new("new.txt")).expect("add destination");
+    index.write().expect("write index");
+
+    let recorder = Arc::new(RecordingTrash::default());
+    let (provider, repo_ref) = discovered_with_trash(tmp.path(), Arc::clone(&recorder) as Arc<dyn TrashSink>).await;
+    let outcome = provider
+        .revert(
+            &repo_ref,
+            &[FileRef {
+                pe_id: "pe1".to_owned(),
+                relative_path: "new.txt".to_owned(),
+            }],
+        )
+        .await
+        .expect("discard ok");
+
+    assert!(outcome.is_complete(), "reported no failures: {:?}", outcome.failed);
+    assert!(
+        tmp.path().join("old.txt").exists(),
+        "the source is restored from the commit"
+    );
+    assert!(!tmp.path().join("new.txt").exists(), "the destination is gone");
+    assert_eq!(recorder.seen.lock().expect("sink").len(), 1, "through the trash");
+}
+
+/// If the trash cannot take the destination, the file must be reported as failed —
+/// not reported as a success that silently did half the work.
+#[tokio::test]
+async fn a_rename_discard_reports_failure_when_the_trash_refuses() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _repo = worktree_rename(&tmp);
+    let (provider, repo_ref) = discovered_with_trash(tmp.path(), Arc::new(RefusingTrash)).await;
+
+    let file = FileRef {
+        pe_id: "pe1".to_owned(),
+        relative_path: "new.txt".to_owned(),
+    };
+    let outcome = provider
+        .revert(&repo_ref, std::slice::from_ref(&file))
+        .await
+        .expect("the request itself is valid");
+
+    assert!(!outcome.is_complete(), "the failure is reported rather than swallowed");
+    assert_eq!(outcome.failed.len(), 1);
+    assert_eq!(outcome.failed[0].file, file, "against the identity that was requested");
+    assert!(
+        tmp.path().join("new.txt").exists(),
+        "and the file the trash refused is still there"
+    );
+}
+
+/// A rename never appears alone in a real repository — there is always other work
+/// in progress alongside it. This is the case the earlier tests missed: they each
+/// built a repository containing *only* the rename, so a scan that gave up on the
+/// first non-rename entry still looked correct.
+#[tokio::test]
+async fn a_rename_is_undone_even_when_other_changes_coexist() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "old.txt", &renameable_body("subject"));
+    // ⚠️ These names are load-bearing — do not "tidy" them into matching names.
+    //
+    // The rename is reported under `new.txt`, and coexisting entries are placed
+    // deliberately on **both** sides of that in sort order (`aaa_*` before,
+    // `zzz_*` after). An implementation that walks the repository's entries and
+    // stops early on the first non-rename is only caught when a non-rename comes
+    // *first*, so a test with only later-sorting neighbours passes while the defect
+    // is live. Covering both sides makes the test independent of iteration order —
+    // which matters because that order is not a guarantee we should rely on, and
+    // has only ever been observed on one platform.
+    // The neighbours must straddle the target in sort order, and "the target" is two
+    // different paths depending on what is being checked: the repository reports a
+    // rename under the path it came *from*, so that is what the scan order follows,
+    // while the lookup it builds is keyed by the path it moved *to*. Both
+    // relationships are asserted below rather than left to the reader to verify.
+    const BEFORE: &str = "aaa_modified.txt";
+    const AFTER: &str = "zzz_modified.txt";
+    const OLD_PATH: &str = "old.txt";
+    const NEW_PATH: &str = "new.txt";
+    assert!(
+        BEFORE < OLD_PATH && OLD_PATH < AFTER,
+        "neighbours must straddle the *source* path — entries are visited in that order"
+    );
+    assert!(
+        BEFORE < NEW_PATH && NEW_PATH < AFTER,
+        "and straddle the *destination* path — that is what the rename lookup is keyed by"
+    );
+
+    write(tmp.path(), BEFORE, "committed\n");
+    write(tmp.path(), AFTER, "committed\n");
+    commit_all(&repo, "base");
+
+    std::fs::rename(tmp.path().join(OLD_PATH), tmp.path().join(NEW_PATH)).expect("rename");
+    write(tmp.path(), BEFORE, "edited\n"); // coexisting, sorts before both paths
+    write(tmp.path(), AFTER, "edited\n"); // coexisting, sorts after both paths
+    write(tmp.path(), "aaa_untracked.txt", "fresh\n"); // untracked, sorts before
+
+    let recorder = Arc::new(RecordingTrash::default());
+    let (provider, repo_ref) = discovered_with_trash(tmp.path(), Arc::clone(&recorder) as Arc<dyn TrashSink>).await;
+
+    let outcome = provider
+        .revert(
+            &repo_ref,
+            &[FileRef {
+                pe_id: "pe1".to_owned(),
+                relative_path: "new.txt".to_owned(),
+            }],
+        )
+        .await
+        .expect("discard ok");
+    assert!(outcome.is_complete(), "no failures: {:?}", outcome.failed);
+
+    assert!(
+        tmp.path().join("old.txt").exists(),
+        "the rename is undone despite unrelated changes being scanned first"
+    );
+    assert!(!tmp.path().join("new.txt").exists(), "and the destination is gone");
+
+    // The unrelated changes are untouched — discarding one resource must not reach
+    // the others.
+    for neighbour in ["aaa_modified.txt", "zzz_modified.txt"] {
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join(neighbour)).expect("read"),
+            "edited\n",
+            "{neighbour} is left alone"
+        );
+    }
+    assert!(
+        tmp.path().join("aaa_untracked.txt").exists(),
+        "and so is the coexisting untracked file"
+    );
+    assert_eq!(
+        recorder.seen.lock().expect("sink").len(),
+        1,
+        "only the rename destination went to the trash"
+    );
+}
+
+/// Two renames at once: the lookup must hold every pair, not just the first one it
+/// happened to see.
+#[tokio::test]
+async fn two_simultaneous_renames_are_each_undone_correctly() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "first.txt", &renameable_body("first subject"));
+    write(tmp.path(), "second.txt", &renameable_body("second subject"));
+    commit_all(&repo, "base");
+    std::fs::rename(tmp.path().join("first.txt"), tmp.path().join("first-moved.txt")).expect("rename");
+    std::fs::rename(tmp.path().join("second.txt"), tmp.path().join("second-moved.txt")).expect("rename");
+
+    let recorder = Arc::new(RecordingTrash::default());
+    let (provider, repo_ref) = discovered_with_trash(tmp.path(), Arc::clone(&recorder) as Arc<dyn TrashSink>).await;
+
+    // Discard the *second* one only: if the lookup kept just one pair, this is the
+    // one that would be missing.
+    provider
+        .revert(
+            &repo_ref,
+            &[FileRef {
+                pe_id: "pe1".to_owned(),
+                relative_path: "second-moved.txt".to_owned(),
+            }],
+        )
+        .await
+        .expect("discard ok");
+
+    assert!(tmp.path().join("second.txt").exists(), "the second rename is undone");
+    assert!(!tmp.path().join("second-moved.txt").exists());
+    // The first rename is still pending, untouched.
+    assert!(
+        tmp.path().join("first-moved.txt").exists() && !tmp.path().join("first.txt").exists(),
+        "the other rename is left as it was"
+    );
+}
+
+/// Both renames in one request, alongside unrelated changes.
+#[tokio::test]
+async fn a_batch_of_renames_is_undone_in_one_request() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    for i in 0..6 {
+        write(tmp.path(), &format!("f{i}.txt"), &renameable_body(&format!("body {i}")));
+    }
+    write(tmp.path(), "a_noise.txt", "committed\n");
+    commit_all(&repo, "base");
+
+    for i in 0..6 {
+        std::fs::rename(
+            tmp.path().join(format!("f{i}.txt")),
+            tmp.path().join(format!("moved{i}.txt")),
+        )
+        .expect("rename");
+    }
+    write(tmp.path(), "a_noise.txt", "edited\n");
+
+    let recorder = Arc::new(RecordingTrash::default());
+    let (provider, repo_ref) = discovered_with_trash(tmp.path(), Arc::clone(&recorder) as Arc<dyn TrashSink>).await;
+
+    let files: Vec<FileRef> = (0..6)
+        .map(|i| FileRef {
+            pe_id: "pe1".to_owned(),
+            relative_path: format!("moved{i}.txt"),
+        })
+        .collect();
+    let outcome = provider.revert(&repo_ref, &files).await.expect("discard ok");
+    assert!(outcome.is_complete(), "no failures: {:?}", outcome.failed);
+
+    for i in 0..6 {
+        assert!(tmp.path().join(format!("f{i}.txt")).exists(), "f{i}.txt is restored");
+        assert!(!tmp.path().join(format!("moved{i}.txt")).exists());
+    }
+    assert_eq!(
+        recorder.seen.lock().expect("sink").len(),
+        6,
+        "each destination trashed once"
+    );
+}
+
+/// The reporting path must recognise a rename regardless of what else the
+/// repository contains, and regardless of the order entries are visited in.
+///
+/// Same file naming rationale as the discard-side test: neighbours are placed on
+/// both sides of `new.txt` in sort order, so the test cannot pass merely because a
+/// non-rename happened to be visited last.
+#[tokio::test]
+async fn status_reports_a_rename_regardless_of_neighbouring_changes() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "old.txt", &renameable_body("subject"));
+    write(tmp.path(), "aaa_modified.txt", "committed\n");
+    write(tmp.path(), "zzz_modified.txt", "committed\n");
+    commit_all(&repo, "base");
+    std::fs::rename(tmp.path().join("old.txt"), tmp.path().join("new.txt")).expect("rename");
+    write(tmp.path(), "aaa_modified.txt", "edited\n");
+    write(tmp.path(), "zzz_modified.txt", "edited\n");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let status = provider.status(&repo_ref).await.expect("status ok");
+
+    let renamed = status
+        .resources
+        .iter()
+        .find(|r| r.state == ScmResourceState::Renamed)
+        .unwrap_or_else(|| panic!("the rename must be reported, got {:?}", status.resources));
+    assert_eq!(renamed.repo_relative_path, "new.txt");
+    assert_eq!(renamed.rename_from.as_deref(), Some("old.txt"));
+    // And the neighbours are still reported as their own resources.
+    assert!(
+        find(&status, "aaa_modified.txt", Some(false)).is_some()
+            && find(&status, "zzz_modified.txt", Some(false)).is_some(),
+        "neighbouring changes are reported too: {:?}",
+        status.resources
+    );
+}
+
+/// Selecting the same file more than once in a single request is idempotent, and
+/// leaves everything else alone.
+///
+/// Duplicates arise naturally: a file with both a staged and an unstaged change is
+/// two rows in the UI, and selecting both sends the same path twice. The request
+/// may also carry the same path under different pe identities.
+///
+/// ⚠️ Neighbour names are load-bearing (`aaa_*` / `zzz_*`): they sit on both sides
+/// of the target in sort order, so this cannot pass merely because the target
+/// happened to be visited before anything else. Do not rename them to match.
+#[tokio::test]
+async fn staging_the_same_path_twice_is_idempotent_and_leaves_neighbours_alone() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "dup.txt", "committed\n");
+    write(tmp.path(), "aaa_other.txt", "committed\n");
+    write(tmp.path(), "zzz_other.txt", "committed\n");
+    commit_all(&repo, "base");
+    for name in ["dup.txt", "aaa_other.txt", "zzz_other.txt"] {
+        write(tmp.path(), name, "edited\n");
+    }
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let staging = provider.staging().expect("staging");
+    let duplicated = |pe: &str| FileRef {
+        pe_id: pe.to_owned(),
+        relative_path: "dup.txt".to_owned(),
+    };
+    // The same path three times, including under a second identity.
+    let files = vec![duplicated("pe1"), duplicated("pe1"), duplicated("pe-other")];
+
+    let staged_outcome = staging.stage(&repo_ref, &files).await.expect("stage ok");
+    assert!(
+        staged_outcome.is_complete(),
+        "repeating a path is not a failure: {:?}",
+        staged_outcome.failed
+    );
+    let after_stage = provider.status(&repo_ref).await.expect("status ok");
+    assert!(
+        find(&after_stage, "dup.txt", Some(true)).is_some(),
+        "the file is staged once: {:?}",
+        after_stage.resources
+    );
+    assert_eq!(
+        after_stage
+            .resources
+            .iter()
+            .filter(|r| r.repo_relative_path == "dup.txt" && r.staged == Some(true))
+            .count(),
+        1,
+        "and appears once, not once per duplicate: {:?}",
+        after_stage.resources
+    );
+
+    let unstaged_outcome = staging.unstage(&repo_ref, &files).await.expect("unstage ok");
+    assert!(unstaged_outcome.is_complete(), "{:?}", unstaged_outcome.failed);
+    let after_unstage = provider.status(&repo_ref).await.expect("status ok");
+    assert!(
+        find(&after_unstage, "dup.txt", Some(true)).is_none(),
+        "and unstaging it once is enough: {:?}",
+        after_unstage.resources
+    );
+
+    // The neighbours on both sides were never selected, so they must be untouched.
+    for neighbour in ["aaa_other.txt", "zzz_other.txt"] {
+        assert_eq!(
+            find(&after_unstage, neighbour, Some(false)).map(|r| r.state),
+            Some(ScmResourceState::Modified),
+            "{neighbour} is still an unstaged modification"
+        );
+        assert!(
+            find(&after_unstage, neighbour, Some(true)).is_none(),
+            "{neighbour} was never staged"
+        );
+    }
+}
+
+/// In a repository with no commits, the committed anchor has nothing to offer and
+/// says so, while the other two keep working.
+///
+/// "Nothing committed" is a truthful answer here, unlike the conflicted case where
+/// the same shape would have been a fabrication — the distinction that decides
+/// whether absence may be reported as absence.
+#[tokio::test]
+async fn anchors_in_a_repository_without_commits_report_absence_truthfully() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "staged.txt", "staged-body\n");
+    let mut index = repo.index().expect("index");
+    index.add_path(Path::new("staged.txt")).expect("add");
+    index.write().expect("write index");
+    write(tmp.path(), "untracked.txt", "untracked-body\n");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let read = |rel: &'static str, anchor| {
+        let provider = &provider;
+        let repo_ref = &repo_ref;
+        async move {
+            provider
+                .original(
+                    repo_ref,
+                    &FileRef {
+                        pe_id: "pe1".to_owned(),
+                        relative_path: rel.to_owned(),
+                    },
+                    anchor,
+                )
+                .await
+                .expect("anchor read is not an error")
+        }
+    };
+
+    // A staged addition: readable in the work tree and in the index, absent from a
+    // history that does not exist yet.
+    assert!(read("staged.txt", ContentRef::Working).await.is_some());
+    assert!(read("staged.txt", ContentRef::Staged).await.is_some());
+    assert!(
+        read("staged.txt", ContentRef::Committed).await.is_none(),
+        "no commit exists, so there is no committed version — reported as absent, not as an error"
+    );
+
+    // An untracked file: only the work tree has it.
+    assert!(read("untracked.txt", ContentRef::Working).await.is_some());
+    assert!(read("untracked.txt", ContentRef::Staged).await.is_none());
+    assert!(read("untracked.txt", ContentRef::Committed).await.is_none());
+
+    // And a diff against the missing side renders as an addition rather than failing.
+    let diff = provider
+        .diff(
+            &repo_ref,
+            &FileRef {
+                pe_id: "pe1".to_owned(),
+                relative_path: "staged.txt".to_owned(),
+            },
+            ContentRef::Working,
+            ContentRef::Committed,
+        )
+        .await
+        .expect("diff against an unborn history still produces a patch");
+    assert!(diff.patch.is_some(), "a patch is produced");
+    assert!(!diff.binary);
+}
+
+/// Staging several *distinct* files must stage all of them.
+///
+/// The duplicate-path test cannot show this: when every entry names the same file,
+/// processing only the first one is indistinguishable from processing all three.
+/// This one uses distinct paths so that "stops after the first" is visible, and
+/// asserts against the repository rather than the returned outcome — an
+/// implementation that skipped work could still report no failures.
+#[tokio::test]
+async fn staging_several_distinct_files_stages_every_one_of_them() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    let names = ["a_first.txt", "m_middle.txt", "z_last.txt"];
+    for name in names {
+        write(tmp.path(), name, "committed\n");
+    }
+    commit_all(&repo, "base");
+    for name in names {
+        write(tmp.path(), name, "edited\n");
+    }
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let staging = provider.staging().expect("staging");
+    let files: Vec<FileRef> = names
+        .iter()
+        .map(|name| FileRef {
+            pe_id: "pe1".to_owned(),
+            relative_path: (*name).to_owned(),
+        })
+        .collect();
+
+    let outcome = staging.stage(&repo_ref, &files).await.expect("stage ok");
+    assert!(outcome.is_complete(), "no failures: {:?}", outcome.failed);
+
+    let status = provider.status(&repo_ref).await.expect("status ok");
+    for name in names {
+        assert!(
+            find(&status, name, Some(true)).is_some(),
+            "{name} is staged — not just the first entry: {:?}",
+            status.resources
+        );
+    }
+
+    // And the mirror direction: unstaging the batch clears every one of them.
+    let outcome = staging.unstage(&repo_ref, &files).await.expect("unstage ok");
+    assert!(outcome.is_complete(), "no failures: {:?}", outcome.failed);
+    let after = provider.status(&repo_ref).await.expect("status ok");
+    for name in names {
+        assert!(
+            find(&after, name, Some(true)).is_none(),
+            "{name} is no longer staged: {:?}",
+            after.resources
+        );
+    }
+}

--- a/crates/aionui-project/src/scm/git_provider_test.rs
+++ b/crates/aionui-project/src/scm/git_provider_test.rs
@@ -174,6 +174,96 @@ async fn status_is_not_degraded_when_the_index_can_be_written() {
     assert!(!status.degraded, "a writable repository takes the normal path");
 }
 
+/// Create a branch at head and check it out (updates HEAD + work tree), so the
+/// test exercises the exact head move a terminal `git checkout <branch>` makes.
+fn checkout_new_branch(repo: &Repository, name: &str) {
+    let head_commit = repo.head().expect("head").peel_to_commit().expect("commit");
+    repo.branch(name, &head_commit, false).expect("create branch");
+    let refname = format!("refs/heads/{name}");
+    let obj = repo.revparse_single(&refname).expect("revparse branch");
+    repo.checkout_tree(&obj, None).expect("checkout tree");
+    repo.set_head(&refname).expect("set head");
+}
+
+#[tokio::test]
+async fn status_carries_head_branch_name() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "a.txt", "hello\n");
+    commit_all(&repo, "base");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let status = provider.status(&repo_ref).await.expect("status ok");
+
+    // The status frame is the only frame the refresh path emits; the branch name
+    // has to be on it or a client subscribed to status alone never learns head.
+    let head = status.head.expect("status carries head");
+    let name = head.name.expect("branch name present");
+    // git2 defaults to `master` on init; either is acceptable across git versions.
+    assert!(name == "master" || name == "main", "branch name: {name}");
+    assert!(head.detached.is_none(), "an ordinary branch head is not detached");
+}
+
+#[tokio::test]
+async fn status_head_name_changes_after_checkout() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "a.txt", "hello\n");
+    commit_all(&repo, "base");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let before = provider.status(&repo_ref).await.expect("status ok");
+    let before_name = before.head.expect("head before").name.expect("name before");
+
+    // Simulate the terminal `git checkout feature/x` that motivated this frame.
+    checkout_new_branch(&repo, "feature/x");
+    let after = provider.status(&repo_ref).await.expect("status ok");
+    let after_name = after.head.expect("head after").name.expect("name after");
+
+    assert_ne!(before_name, after_name, "checkout must move the reported head");
+    assert_eq!(after_name, "feature/x");
+}
+
+#[tokio::test]
+async fn status_head_reports_detached() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "a.txt", "hello\n");
+    let oid = commit_all(&repo, "base");
+
+    // Detach: point HEAD directly at the commit, no branch.
+    repo.set_head_detached(oid).expect("detach head");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let status = provider.status(&repo_ref).await.expect("status ok");
+
+    let head = status.head.expect("status carries head");
+    // `detached` is the load-bearing signal here; `name` mirrors git2's
+    // shorthand (the short commit id when detached), same as `ScmRepository.head`.
+    assert_eq!(head.detached, Some(true), "detached head is flagged");
+    assert_ne!(
+        head.name.as_deref(),
+        Some("master"),
+        "a detached head reports the commit, not the abandoned branch"
+    );
+}
+
+#[tokio::test]
+async fn status_head_reports_unborn() {
+    let tmp = TempDir::new().expect("tempdir");
+    init_repo(tmp.path());
+    // No commit yet: HEAD is unborn. A fresh repo still has a change list.
+    write(tmp.path(), "a.txt", "hello\n");
+
+    let (provider, repo_ref) = discovered(tmp.path()).await;
+    let status = provider.status(&repo_ref).await.expect("status ok");
+
+    // Unborn is a normal state, not an error: head is present but empty.
+    let head = status.head.expect("status carries head even when unborn");
+    assert!(head.name.is_none(), "unborn head has no branch name yet");
+    assert!(head.detached.is_none(), "unborn head is not detached");
+}
+
 #[tokio::test]
 async fn status_reports_modified_and_deleted() {
     let tmp = TempDir::new().expect("tempdir");

--- a/crates/aionui-project/src/scm/mod.rs
+++ b/crates/aionui-project/src/scm/mod.rs
@@ -1,0 +1,35 @@
+//! Source control (runtime link).
+//!
+//! Provider-neutral source control: repository discovery, a flat change list,
+//! file diff, and local staging/discard actions. A peer of the explorer fs
+//! runtime, not part of it — source control has its own identity, lifecycle and
+//! refresh semantics ("repo dirty → recompute status → replace", never a file
+//! tree delta). See `formal/runtime/source-control.md`.
+//!
+//! Stage 0 is this backend floor: contract plus the git implementation. Watch,
+//! debounce, orchestration and the `scm/*` protocol are later stages.
+//!
+//! Module files hold implementation; this file only declares and re-exports.
+
+mod actor;
+mod debounce;
+mod error;
+mod git_provider;
+mod provider;
+mod runtime;
+mod trash_sink;
+mod types;
+mod watch;
+mod wire;
+
+pub use actor::{ScmActor, ScmInbound, ScmSessionId, ScmWirePush};
+pub use error::ScmError;
+pub use provider::{IScmHistory, IScmProvider, IScmStaging};
+pub use types::{
+    ContentRef, DiffContent, FileRef, RepoRef, ResolvedRoot, ScmActionFailure, ScmActionOutcome, ScmCapabilities,
+    ScmHead, ScmRepository, ScmRepositoryState, ScmResource, ScmResourceState, ScmStatus,
+};
+// The concrete git implementation stays module-private: callers will build it
+// through the stage-1 orchestration layer and consume only the trait objects it
+// hands back, mirroring how `LocalFsProvider` stays behind `LocalFsRuntime`. The
+// re-export lands with that first consumer rather than ahead of it.

--- a/crates/aionui-project/src/scm/provider.rs
+++ b/crates/aionui-project/src/scm/provider.rs
@@ -1,0 +1,97 @@
+//! `IScmProvider` — the provider-neutral source-control contract.
+//!
+//! Peer of [`crate::runtime::IFsProvider`] (filesystem data ops), not a
+//! specialization of it: source control has its own identity and lifecycle. The
+//! core methods are the ones that generalize across version-control systems;
+//! anything one system may lack is an optional capability, either a flag on
+//! [`ScmCapabilities`] or a sub-trait obtained through [`IScmProvider::staging`]
+//! / [`IScmProvider::history`], so an unsupported call fails to compile rather
+//! than at runtime.
+
+use async_trait::async_trait;
+
+use super::error::ScmError;
+use super::types::{
+    ContentRef, DiffContent, FileRef, RepoRef, ResolvedRoot, ScmActionOutcome, ScmCapabilities, ScmRepository,
+    ScmStatus,
+};
+
+/// Neutral source-control operations. Every method here must be expressible for
+/// any version-control system; engine-specific types must not appear in a
+/// signature.
+///
+/// **Precondition on every path.** Implementations assume each [`FileRef`] has
+/// already been resolved by the orchestration layer: in scope for the caller, and
+/// normalized to a plain repository-relative path (no `.` or `..` segments, not
+/// absolute). They deliberately do **not** re-validate it — identity resolution
+/// has a single owner, and a second check here would be a copy of it that can
+/// drift. Callers that reach a provider directly are responsible for that
+/// guarantee themselves.
+#[async_trait]
+pub trait IScmProvider: Send + Sync {
+    /// Stable provider identifier (`"git"`, ...).
+    fn provider_id(&self) -> &str;
+
+    /// Which optional capabilities this provider supports.
+    fn capabilities(&self) -> ScmCapabilities;
+
+    /// Decide whether an already-resolved root is a repository of this
+    /// provider. `Ok(None)` means "not a repository" — a normal outcome, not an
+    /// error, and never a fabricated repository.
+    async fn discover(&self, root: &ResolvedRoot) -> Result<Option<ScmRepository>, ScmError>;
+
+    /// Full flat change list for a repository (no pre-grouping).
+    async fn status(&self, repo: &RepoRef) -> Result<ScmStatus, ScmError>;
+
+    /// Diff one file between two neutral content anchors.
+    async fn diff(
+        &self,
+        repo: &RepoRef,
+        file: &FileRef,
+        from: ContentRef,
+        to: ContentRef,
+    ) -> Result<DiffContent, ScmError>;
+
+    /// Read one file's content at a neutral anchor; `None` when the file does
+    /// not exist there (e.g. an added file has no committed version).
+    async fn original(&self, repo: &RepoRef, file: &FileRef, at: ContentRef) -> Result<Option<Vec<u8>>, ScmError>;
+
+    /// Discard working-tree changes, restoring the committed version. Files the
+    /// version-control system does not track are moved to the system trash
+    /// rather than deleted outright.
+    ///
+    /// Best effort per file: every file is attempted and the ones that could not
+    /// be processed come back in the outcome (see [`ScmActionOutcome`]). An `Err`
+    /// means the request as a whole was refused, before anything was touched.
+    async fn revert(&self, repo: &RepoRef, files: &[FileRef]) -> Result<ScmActionOutcome, ScmError>;
+
+    /// Staging operations, or `None` when this provider has no staging area.
+    fn staging(&self) -> Option<&dyn IScmStaging> {
+        None
+    }
+
+    /// History/commit-graph operations, or `None` when unsupported. Stage 2;
+    /// every stage-0 provider returns `None`.
+    fn history(&self) -> Option<&dyn IScmHistory> {
+        None
+    }
+}
+
+/// Staging-area operations, available only from providers that declare
+/// [`ScmCapabilities::staging`].
+#[async_trait]
+pub trait IScmStaging: Send + Sync {
+    /// Move working-tree changes into the staging area.
+    ///
+    /// Best effort per file, with the same semantics as
+    /// [`IScmProvider::revert`] — the three multi-file actions behave alike so a
+    /// client handles one shape, not three.
+    async fn stage(&self, repo: &RepoRef, files: &[FileRef]) -> Result<ScmActionOutcome, ScmError>;
+
+    /// Remove changes from the staging area, keeping the working tree as-is.
+    async fn unstage(&self, repo: &RepoRef, files: &[FileRef]) -> Result<ScmActionOutcome, ScmError>;
+}
+
+/// Commit-graph / history reads. Stage 2 — declared here so adding it later is
+/// an added capability rather than a change to the core contract.
+pub trait IScmHistory: Send + Sync {}

--- a/crates/aionui-project/src/scm/runtime.rs
+++ b/crates/aionui-project/src/scm/runtime.rs
@@ -1,0 +1,315 @@
+//! `ScmRuntime` — orchestration between the provider, the watch, and the wire.
+//!
+//! Holds the little state source control needs and nothing more: per repository
+//! the last computed status, the monotonic sequence number, the set of
+//! subscribed connections, and the watch registration. There is no incremental
+//! tree and no reconciliation machinery — status is a derived quantity that is
+//! cheap to recompute and has no stable per-item identity, so the model is
+//! "something is dirty → recompute in full → replace the frame"
+//! (`formal/runtime/source-control.md`).
+//!
+//! Two responsibilities are load-bearing and easy to get wrong:
+//!
+//! **Sequence allocation.** Two refresh sources run concurrently — an action
+//! finishing, and a debounced watch signal — so their results can arrive out of
+//! order. Every recompute therefore happens inside one per-repository critical
+//! section that also allocates the sequence number, which is what makes the
+//! numbers monotonic and lets a client drop a frame that is older than what it
+//! already applied. Allocating outside that section would hand out numbers whose
+//! order does not match the order the statuses were computed in.
+//!
+//! **Identity.** The provider deals in repository-relative paths; the pe identity
+//! belongs to the resolved root. Assembling `{ pe_id, relative_path }` is this
+//! layer's job, so a provider can never invent identity.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::{Mutex, RwLock};
+
+use super::error::ScmError;
+use super::git_provider::GitScmProvider;
+use super::provider::IScmProvider;
+use super::types::{FileRef, RepoRef, ResolvedRoot, ScmRepository, ScmStatus};
+use super::watch::GitWatcher;
+
+/// Per-repository state. Thin by design (see module docs).
+struct RepoState {
+    /// Descriptor handed to clients.
+    repository: ScmRepository,
+    /// Real git directory, for arming and releasing the watch.
+    git_dir: PathBuf,
+    /// Last computed status, if it has been computed at least once.
+    last: Option<ScmStatus>,
+    /// Highest sequence number handed out for this repository.
+    seq: u64,
+    /// Connections currently subscribed. The watch lives exactly as long as this
+    /// is non-empty, so a repository nobody is looking at costs nothing.
+    subscribers: Vec<String>,
+}
+
+/// Guards one repository's recompute-and-publish critical section.
+///
+/// A separate lock per repository: work on unrelated repositories proceeds
+/// concurrently, while everything touching one repository — actions and refreshes
+/// alike — is serialized so sequence numbers and statuses stay in agreement.
+type RepoLock = Arc<Mutex<()>>;
+
+/// Orchestration layer for source control.
+pub struct ScmRuntime {
+    provider: Arc<GitScmProvider>,
+    watcher: Arc<GitWatcher>,
+    repos: RwLock<HashMap<String, RepoState>>,
+    locks: RwLock<HashMap<String, RepoLock>>,
+}
+
+impl ScmRuntime {
+    /// Build the runtime, returning it together with the dirty-signal receiver
+    /// the caller must drive (debounce then [`ScmRuntime::refresh`]).
+    pub(super) fn new() -> Result<(Self, tokio::sync::mpsc::UnboundedReceiver<super::watch::ScmDirty>), ScmError> {
+        let (watcher, dirty_rx) = GitWatcher::new()?;
+        Ok((
+            Self {
+                provider: Arc::new(GitScmProvider::new()),
+                watcher: Arc::new(watcher),
+                repos: RwLock::new(HashMap::new()),
+                locks: RwLock::new(HashMap::new()),
+            },
+            dirty_rx,
+        ))
+    }
+
+    /// Discover which of a project's roots are repositories.
+    ///
+    /// Roots that are not repositories are simply absent from the result — never
+    /// represented as an empty repository.
+    pub(super) async fn discover(&self, roots: &[ResolvedRoot]) -> Vec<ScmRepository> {
+        let mut found = Vec::new();
+        for root in roots {
+            match self.provider.discover(root).await {
+                Ok(Some(repository)) => {
+                    let git_dir = self.provider.git_dir_of(&RepoRef {
+                        repo_id: repository.repo_id.clone(),
+                    });
+                    let mut repos = self.repos.write().await;
+                    let entry = repos.entry(repository.repo_id.clone());
+                    match entry {
+                        std::collections::hash_map::Entry::Occupied(mut slot) => {
+                            // Re-discovery of a known repository refreshes its
+                            // descriptor (head may have moved) but must not drop
+                            // subscribers or the sequence it has already handed out.
+                            slot.get_mut().repository = repository.clone();
+                        }
+                        std::collections::hash_map::Entry::Vacant(slot) => {
+                            slot.insert(RepoState {
+                                repository: repository.clone(),
+                                git_dir: git_dir.unwrap_or_default(),
+                                last: None,
+                                seq: 0,
+                                subscribers: Vec::new(),
+                            });
+                        }
+                    }
+                    found.push(repository);
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    // One unreadable root must not hide the project's other
+                    // repositories.
+                    tracing::warn!(pe_id = %root.pe_id, error = %err, "scm discover failed for root");
+                }
+            }
+        }
+        found
+    }
+
+    /// Subscribe `session` to a repository and return its current status.
+    ///
+    /// The watch is armed **before** the first status is computed, so a change
+    /// landing during that computation still produces a signal instead of being
+    /// lost in the gap.
+    pub(super) async fn subscribe(&self, session: &str, repo: &RepoRef) -> Result<ScmStatus, ScmError> {
+        let git_dir = {
+            let mut repos = self.repos.write().await;
+            let state = repos
+                .get_mut(&repo.repo_id)
+                .ok_or_else(|| ScmError::UnknownRepository {
+                    repo_id: repo.repo_id.clone(),
+                })?;
+            let first = state.subscribers.is_empty();
+            if !state.subscribers.iter().any(|s| s == session) {
+                state.subscribers.push(session.to_owned());
+            }
+            first.then(|| state.git_dir.clone())
+        };
+
+        if let Some(git_dir) = git_dir
+            && let Err(err) = self.watcher.watch(&repo.repo_id, &git_dir)
+        {
+            // Losing live refresh degrades to manual refresh; it must not fail
+            // the subscription, which still returns a correct first frame.
+            tracing::warn!(repo_id = %repo.repo_id, error = %err, "scm watch arm failed; live refresh unavailable");
+        }
+
+        self.refresh(repo).await
+    }
+
+    /// Unsubscribe `session`. The watch is released once nobody is subscribed —
+    /// reference counted, since several connections may observe one repository.
+    pub(super) async fn unsubscribe(&self, session: &str, repo: &RepoRef) {
+        let release = {
+            let mut repos = self.repos.write().await;
+            match repos.get_mut(&repo.repo_id) {
+                Some(state) => {
+                    state.subscribers.retain(|s| s != session);
+                    let empty = state.subscribers.is_empty();
+                    if empty {
+                        // Drop the cached frame with the watch: without a watch it
+                        // would go stale unnoticed, and recomputing is cheap.
+                        state.last = None;
+                    }
+                    empty
+                }
+                None => false,
+            }
+        };
+        if release {
+            self.watcher.unwatch(&repo.repo_id);
+        }
+    }
+
+    /// Release everything a closed connection held.
+    ///
+    /// Without this a reconnect churn would leak one watch per dropped
+    /// connection, since nothing else ever tells us that session is gone.
+    pub(super) async fn drop_session(&self, session: &str) {
+        let orphaned: Vec<String> = {
+            let mut repos = self.repos.write().await;
+            let mut orphaned = Vec::new();
+            for (repo_id, state) in repos.iter_mut() {
+                let before = state.subscribers.len();
+                state.subscribers.retain(|s| s != session);
+                if before != state.subscribers.len() && state.subscribers.is_empty() {
+                    state.last = None;
+                    orphaned.push(repo_id.clone());
+                }
+            }
+            orphaned
+        };
+        for repo_id in orphaned {
+            self.watcher.unwatch(&repo_id);
+        }
+    }
+
+    /// Recompute a repository's status and publish it as the current frame.
+    ///
+    /// The recompute and the sequence allocation share one critical section (see
+    /// module docs): that is what keeps sequence order equal to computation
+    /// order when an action-triggered refresh races a watch-triggered one.
+    pub(super) async fn refresh(&self, repo: &RepoRef) -> Result<ScmStatus, ScmError> {
+        let lock = self.lock_for(&repo.repo_id).await;
+        let _guard = lock.lock().await;
+
+        let pe_id = self.pe_id_of(repo).await?;
+        let mut status = self.provider.status(repo).await?;
+
+        // Identity is assembled here, not in the provider: the provider knows
+        // repository-relative paths, the pe identity comes from the resolved root.
+        for resource in &mut status.resources {
+            resource.file = FileRef {
+                pe_id: pe_id.clone(),
+                relative_path: resource.repo_relative_path.clone(),
+            };
+        }
+
+        // Monotonicity rests on **two** guards, and both are deliberate:
+        //   1. the per-repository critical section entered above, which serializes
+        //      whole recomputes (and actions) against each other, and
+        //   2. this single write guard, which makes read-increment-store atomic.
+        // Removing either one alone still looks correct and keeps the tests green,
+        // because the other masks it — but removing both lets concurrent refreshes
+        // hand out duplicate sequences, and a client then discards a newer frame as
+        // "older". Do not "simplify" one away.
+        let mut repos = self.repos.write().await;
+        let state = repos
+            .get_mut(&repo.repo_id)
+            .ok_or_else(|| ScmError::UnknownRepository {
+                repo_id: repo.repo_id.clone(),
+            })?;
+        state.seq += 1;
+        status.seq = state.seq;
+        state.last = Some(status.clone());
+        Ok(status)
+    }
+
+    /// Connections that should receive a repository's frame.
+    pub(super) async fn subscribers_of(&self, repo_id: &str) -> Vec<String> {
+        self.repos
+            .read()
+            .await
+            .get(repo_id)
+            .map(|state| state.subscribers.clone())
+            .unwrap_or_default()
+    }
+
+    /// The provider, for read-only calls that need no orchestration (diff,
+    /// original) and for actions, which the caller wraps in [`ScmRuntime::act`].
+    pub(super) fn provider(&self) -> &GitScmProvider {
+        &self.provider
+    }
+
+    /// Run a mutating action inside the repository's critical section, then
+    /// recompute so the published frame reflects it.
+    ///
+    /// Actions and refreshes share the lock deliberately: a status computed
+    /// halfway through a staging operation would describe a state that never
+    /// existed.
+    pub(super) async fn act<T, F, Fut>(&self, repo: &RepoRef, action: F) -> Result<(T, ScmStatus), ScmError>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T, ScmError>>,
+    {
+        let lock = self.lock_for(&repo.repo_id).await;
+        let guard = lock.lock().await;
+        let produced = action().await?;
+        drop(guard);
+        let status = self.refresh(repo).await?;
+        Ok((produced, status))
+    }
+
+    /// Whether a repository's metadata watch is armed. For tests that must verify
+    /// release, not merely that the subscriber list emptied.
+    #[cfg(test)]
+    pub(super) fn is_watching(&self, repo_id: &str) -> bool {
+        self.watcher.is_watching(repo_id)
+    }
+
+    async fn lock_for(&self, repo_id: &str) -> RepoLock {
+        if let Some(lock) = self.locks.read().await.get(repo_id) {
+            return Arc::clone(lock);
+        }
+        let mut locks = self.locks.write().await;
+        Arc::clone(locks.entry(repo_id.to_owned()).or_default())
+    }
+
+    /// pe identity of a repository's root, for the authorization guard.
+    pub(super) async fn pe_id_of_public(&self, repo: &RepoRef) -> Result<String, ScmError> {
+        self.pe_id_of(repo).await
+    }
+
+    async fn pe_id_of(&self, repo: &RepoRef) -> Result<String, ScmError> {
+        self.repos
+            .read()
+            .await
+            .get(&repo.repo_id)
+            .map(|state| state.repository.root.pe_id.clone())
+            .ok_or_else(|| ScmError::UnknownRepository {
+                repo_id: repo.repo_id.clone(),
+            })
+    }
+}
+
+#[cfg(test)]
+#[path = "runtime_test.rs"]
+mod runtime_test;

--- a/crates/aionui-project/src/scm/runtime.rs
+++ b/crates/aionui-project/src/scm/runtime.rs
@@ -22,7 +22,7 @@
 //! belongs to the resolved root. Assembling `{ pe_id, relative_path }` is this
 //! layer's job, so a provider can never invent identity.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -62,6 +62,17 @@ pub struct ScmRuntime {
     watcher: Arc<GitWatcher>,
     repos: RwLock<HashMap<String, RepoState>>,
     locks: RwLock<HashMap<String, RepoLock>>,
+    /// The set of repositories each project last resolved to, keyed by project
+    /// id. A roots recompute diffs the fresh set against this to decide which
+    /// repositories were added or removed — by `repo_id`, never by path, since a
+    /// case-insensitive filesystem makes path comparison unsound.
+    project_repos: RwLock<HashMap<String, HashSet<String>>>,
+    /// Which connections have expressed interest in each project's repositories,
+    /// by listing them. A project's `repositoriesChanged` frame fans out to these.
+    /// Session-persistent: an entry is cleared only when the connection drops, not
+    /// when it unsubscribes from a repository, so a client that navigates away and
+    /// back keeps receiving changes without re-registering.
+    project_interest: RwLock<HashMap<String, HashSet<String>>>,
 }
 
 impl ScmRuntime {
@@ -75,16 +86,20 @@ impl ScmRuntime {
                 watcher: Arc::new(watcher),
                 repos: RwLock::new(HashMap::new()),
                 locks: RwLock::new(HashMap::new()),
+                project_repos: RwLock::new(HashMap::new()),
+                project_interest: RwLock::new(HashMap::new()),
             },
             dirty_rx,
         ))
     }
 
-    /// Discover which of a project's roots are repositories.
+    /// Discover which of a set of roots are repositories.
     ///
     /// Roots that are not repositories are simply absent from the result — never
-    /// represented as an empty repository.
-    pub(super) async fn discover(&self, roots: &[ResolvedRoot]) -> Vec<ScmRepository> {
+    /// represented as an empty repository. Registers each discovered repository in
+    /// the runtime and provider, but does not touch any project's tracked set;
+    /// that is the two project-aware callers' job.
+    async fn discover_roots(&self, roots: &[ResolvedRoot]) -> Vec<ScmRepository> {
         let mut found = Vec::new();
         for root in roots {
             match self.provider.discover(root).await {
@@ -122,6 +137,84 @@ impl ScmRuntime {
             }
         }
         found
+    }
+
+    /// Discover a project's repositories and record the result as the project's
+    /// baseline, so a later roots recompute can diff against it.
+    pub(super) async fn discover(&self, project_id: &str, roots: &[ResolvedRoot]) -> Vec<ScmRepository> {
+        let found = self.discover_roots(roots).await;
+        let ids = found.iter().map(|r| r.repo_id.clone()).collect();
+        self.project_repos.write().await.insert(project_id.to_owned(), ids);
+        found
+    }
+
+    /// Recompute a project's repositories after its attached-folder set changed,
+    /// returning what was added (full descriptors) and removed (ids) against the
+    /// last known set.
+    ///
+    /// Removed repositories are released here (watch dropped, state and provider
+    /// entry forgotten): nothing else would, and a repository no project can reach
+    /// would otherwise keep its metadata watch armed for the process's lifetime.
+    ///
+    /// Order is load-bearing. Discovery runs *first* and re-registers every
+    /// repository still present; only then is `removed` computed as "was in the
+    /// old set, is not in the fresh one". A repository removed and re-added within
+    /// one recompute is thus in the fresh set and never released — so a quick
+    /// remove-then-re-add cannot tear down the watch the re-add just implied.
+    pub(super) async fn recompute_project(
+        &self,
+        project_id: &str,
+        roots: &[ResolvedRoot],
+    ) -> (Vec<ScmRepository>, Vec<String>) {
+        let now = self.discover_roots(roots).await;
+        let now_ids: HashSet<String> = now.iter().map(|r| r.repo_id.clone()).collect();
+
+        let previous = self
+            .project_repos
+            .read()
+            .await
+            .get(project_id)
+            .cloned()
+            .unwrap_or_default();
+        let added: Vec<ScmRepository> = now.iter().filter(|r| !previous.contains(&r.repo_id)).cloned().collect();
+        let removed: Vec<String> = previous.difference(&now_ids).cloned().collect();
+
+        self.project_repos.write().await.insert(project_id.to_owned(), now_ids);
+        for repo_id in &removed {
+            self.release_repo(repo_id).await;
+        }
+        (added, removed)
+    }
+
+    /// Release a repository that has left every project: drop its watch, its cached
+    /// state (and with it its subscriber list), and the provider's handle to it.
+    async fn release_repo(&self, repo_id: &str) {
+        // Unwatch first, so no further dirty signal can arrive for a repository we
+        // are in the middle of forgetting.
+        self.watcher.unwatch(repo_id);
+        self.repos.write().await.remove(repo_id);
+        self.provider.forget(repo_id);
+    }
+
+    /// Record that `session` is interested in a project's repositories, so it
+    /// receives that project's `repositoriesChanged` frames until it disconnects.
+    pub(super) async fn register_interest(&self, session: &str, project_id: &str) {
+        self.project_interest
+            .write()
+            .await
+            .entry(project_id.to_owned())
+            .or_default()
+            .insert(session.to_owned());
+    }
+
+    /// Connections that should receive a project's `repositoriesChanged` frame.
+    pub(super) async fn project_subscribers_of(&self, project_id: &str) -> Vec<String> {
+        self.project_interest
+            .read()
+            .await
+            .get(project_id)
+            .map(|sessions| sessions.iter().cloned().collect())
+            .unwrap_or_default()
     }
 
     /// Subscribe `session` to a repository and return its current status.
@@ -179,10 +272,15 @@ impl ScmRuntime {
         }
     }
 
-    /// Release everything a closed connection held.
+    /// Release everything a closed connection held: its repository subscriptions
+    /// (and the watches they alone kept armed) and its project interest.
     ///
-    /// Without this a reconnect churn would leak one watch per dropped
-    /// connection, since nothing else ever tells us that session is gone.
+    /// Without the subscription cleanup a reconnect churn would leak one watch per
+    /// dropped connection. Without the interest cleanup a dropped connection would
+    /// linger in every project it listed — leaking unboundedly and, worse,
+    /// receiving `repositoriesChanged` frames pushed to a session that is gone.
+    /// This is the sole release point for `project_interest` (it is
+    /// session-persistent, never dropped on repo unsubscribe).
     pub(super) async fn drop_session(&self, session: &str) {
         let orphaned: Vec<String> = {
             let mut repos = self.repos.write().await;
@@ -200,6 +298,12 @@ impl ScmRuntime {
         for repo_id in orphaned {
             self.watcher.unwatch(&repo_id);
         }
+
+        let mut interest = self.project_interest.write().await;
+        for sessions in interest.values_mut() {
+            sessions.remove(session);
+        }
+        interest.retain(|_, sessions| !sessions.is_empty());
     }
 
     /// Recompute a repository's status and publish it as the current frame.

--- a/crates/aionui-project/src/scm/runtime_test.rs
+++ b/crates/aionui-project/src/scm/runtime_test.rs
@@ -1,0 +1,399 @@
+//! Orchestration tests: identity assembly, sequence allocation, and the
+//! subscription lifecycle that owns the watch.
+//!
+//! These use real temporary repositories (built with git2, so no `git` binary is
+//! required and the suite runs the same on every platform).
+
+use git2::Repository;
+use tempfile::TempDir;
+
+use super::*;
+
+fn init_repo(dir: &std::path::Path) -> Repository {
+    let repo = Repository::init(dir).expect("init repo");
+    let mut cfg = repo.config().expect("config");
+    cfg.set_str("user.name", "scm test").expect("set name");
+    cfg.set_str("user.email", "scm@test.local").expect("set email");
+    repo
+}
+
+fn write(dir: &std::path::Path, rel: &str, body: &str) {
+    let path = dir.join(rel);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("mkdir parent");
+    }
+    std::fs::write(path, body).expect("write file");
+}
+
+fn commit_all(repo: &Repository, message: &str) {
+    let mut index = repo.index().expect("index");
+    index
+        .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+        .expect("add all");
+    index.write().expect("write index");
+    let tree_id = index.write_tree().expect("write tree");
+    let tree = repo.find_tree(tree_id).expect("find tree");
+    let sig = repo.signature().expect("signature");
+    let parents = match repo.head().ok().and_then(|h| h.peel_to_commit().ok()) {
+        Some(parent) => vec![parent],
+        None => vec![],
+    };
+    let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+    repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parent_refs)
+        .expect("commit");
+}
+
+fn root_of(tmp: &TempDir, pe_id: &str) -> ResolvedRoot {
+    ResolvedRoot {
+        pe_id: pe_id.to_owned(),
+        absolute_path: tmp.path().to_string_lossy().into_owned(),
+        label: "fixture".to_owned(),
+    }
+}
+
+/// A repository with one committed file and one uncommitted edit.
+fn fixture(tmp: &TempDir) -> Repository {
+    let repo = init_repo(tmp.path());
+    write(tmp.path(), "a.txt", "base\n");
+    commit_all(&repo, "base");
+    write(tmp.path(), "a.txt", "edited\n");
+    repo
+}
+
+#[tokio::test]
+async fn discovery_lists_repositories_and_skips_plain_directories() {
+    let repo_dir = TempDir::new().expect("tempdir");
+    let _repo = fixture(&repo_dir);
+    let plain_dir = TempDir::new().expect("tempdir");
+
+    let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
+    let found = runtime
+        .discover(&[root_of(&repo_dir, "pe-repo"), root_of(&plain_dir, "pe-plain")])
+        .await;
+
+    assert_eq!(found.len(), 1, "only the repository is listed, got {found:?}");
+    assert_eq!(found[0].root.pe_id, "pe-repo");
+}
+
+#[tokio::test]
+async fn a_root_that_is_not_a_repository_does_not_hide_the_others() {
+    // One unusable root must not cost a project its other repositories.
+    let plain_dir = TempDir::new().expect("tempdir");
+    let repo_dir = TempDir::new().expect("tempdir");
+    let _repo = fixture(&repo_dir);
+
+    let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
+    let found = runtime
+        .discover(&[root_of(&plain_dir, "pe-plain"), root_of(&repo_dir, "pe-repo")])
+        .await;
+
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].root.pe_id, "pe-repo");
+}
+
+#[tokio::test]
+async fn the_orchestration_layer_assembles_pe_identity() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _repo = fixture(&tmp);
+
+    let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
+    let found = runtime.discover(&[root_of(&tmp, "pe-42")]).await;
+    let repo = RepoRef {
+        repo_id: found[0].repo_id.clone(),
+    };
+
+    let status = runtime.refresh(&repo).await.expect("refresh ok");
+    assert!(!status.resources.is_empty(), "the edit is reported");
+    for resource in &status.resources {
+        // The provider only knows repository-relative paths; identity is this
+        // layer's to assemble from the resolved root.
+        assert_eq!(resource.file.pe_id, "pe-42", "pe identity is filled in here");
+        assert_eq!(
+            resource.file.relative_path, resource.repo_relative_path,
+            "and the path mirrors the repository-relative one"
+        );
+    }
+}
+
+#[tokio::test]
+async fn sequence_numbers_increase_with_every_recompute() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _repo = fixture(&tmp);
+
+    let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
+    let found = runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    let repo = RepoRef {
+        repo_id: found[0].repo_id.clone(),
+    };
+
+    let first = runtime.refresh(&repo).await.expect("refresh ok").seq;
+    let second = runtime.refresh(&repo).await.expect("refresh ok").seq;
+    let third = runtime.refresh(&repo).await.expect("refresh ok").seq;
+
+    assert!(first >= 1, "a published frame is never sequence zero, got {first}");
+    assert!(
+        second > first && third > second,
+        "sequences must strictly increase: {first}, {second}, {third}"
+    );
+}
+
+#[tokio::test]
+async fn concurrent_refreshes_hand_out_distinct_ordered_sequences() {
+    // Two refresh sources (an action finishing, a debounced signal) can race. If
+    // the sequence were allocated outside the critical section they could collide
+    // or invert, and a client would then drop a newer frame as "older".
+    let tmp = TempDir::new().expect("tempdir");
+    let _repo = fixture(&tmp);
+
+    let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
+    let found = runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    let repo = RepoRef {
+        repo_id: found[0].repo_id.clone(),
+    };
+    let runtime = std::sync::Arc::new(runtime);
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let runtime = std::sync::Arc::clone(&runtime);
+        let repo = repo.clone();
+        handles.push(tokio::spawn(async move { runtime.refresh(&repo).await.map(|s| s.seq) }));
+    }
+
+    let mut seqs = Vec::new();
+    for handle in handles {
+        seqs.push(handle.await.expect("task joins").expect("refresh ok"));
+    }
+    seqs.sort_unstable();
+    seqs.dedup();
+    assert_eq!(seqs.len(), 8, "every recompute got its own sequence, got {seqs:?}");
+    assert_eq!(seqs, (1..=8).collect::<Vec<u64>>(), "and they form one ordered run");
+}
+
+#[tokio::test]
+async fn an_action_publishes_a_newer_frame_than_before_it() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _repo = fixture(&tmp);
+
+    let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
+    let found = runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    let repo = RepoRef {
+        repo_id: found[0].repo_id.clone(),
+    };
+
+    let before = runtime.refresh(&repo).await.expect("refresh ok").seq;
+    let (_, status) = runtime
+        .act(&repo, || async { Ok::<(), ScmError>(()) })
+        .await
+        .expect("action ok");
+    let after = status.seq;
+    assert!(after > before, "the post-action frame supersedes the earlier one");
+}
+
+#[tokio::test]
+async fn a_failing_action_does_not_publish_a_frame() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _repo = fixture(&tmp);
+
+    let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
+    let found = runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    let repo = RepoRef {
+        repo_id: found[0].repo_id.clone(),
+    };
+    let before = runtime.refresh(&repo).await.expect("refresh ok").seq;
+
+    let failed = runtime
+        .act(&repo, || async {
+            Err::<(), ScmError>(ScmError::OperationFailed {
+                context: "test",
+                message: "deliberate".to_owned(),
+            })
+        })
+        .await;
+    assert!(failed.is_err(), "the failure propagates");
+
+    // A failed action must not consume a sequence or replace the frame, otherwise
+    // clients would see a "new" status that reflects nothing.
+    let after = runtime.refresh(&repo).await.expect("refresh ok").seq;
+    assert_eq!(after, before + 1, "only the explicit recompute advanced it");
+}
+
+#[tokio::test]
+async fn subscribing_returns_a_first_frame_and_records_the_subscriber() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _repo = fixture(&tmp);
+
+    let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
+    let found = runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    let repo = RepoRef {
+        repo_id: found[0].repo_id.clone(),
+    };
+
+    let status = runtime.subscribe("conn-1", &repo).await.expect("subscribe ok");
+    assert!(status.seq >= 1, "the first frame carries a sequence");
+    assert_eq!(runtime.subscribers_of(&repo.repo_id).await, vec!["conn-1".to_owned()]);
+}
+
+#[tokio::test]
+async fn subscribing_twice_from_one_connection_counts_once() {
+    let tmp = TempDir::new().expect("tempdir");
+    let _repo = fixture(&tmp);
+
+    let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
+    let found = runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    let repo = RepoRef {
+        repo_id: found[0].repo_id.clone(),
+    };
+
+    runtime.subscribe("conn-1", &repo).await.expect("subscribe ok");
+    runtime.subscribe("conn-1", &repo).await.expect("re-subscribe ok");
+    assert_eq!(
+        runtime.subscribers_of(&repo.repo_id).await.len(),
+        1,
+        "a repeated subscribe must not double-count, or the watch would never release"
+    );
+}
+
+#[tokio::test]
+async fn the_watch_is_released_only_when_the_last_subscriber_leaves() {
+    // Reference counted: several connections may observe one repository, and the
+    // first one leaving must not blind the others.
+    let tmp = TempDir::new().expect("tempdir");
+    let _repo = fixture(&tmp);
+
+    let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
+    let found = runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    let repo = RepoRef {
+        repo_id: found[0].repo_id.clone(),
+    };
+
+    runtime.subscribe("conn-1", &repo).await.expect("subscribe ok");
+    runtime.subscribe("conn-2", &repo).await.expect("subscribe ok");
+    assert!(runtime.is_watching(&repo.repo_id), "the watch is armed while observed");
+
+    runtime.unsubscribe("conn-1", &repo).await;
+    assert_eq!(
+        runtime.subscribers_of(&repo.repo_id).await,
+        vec!["conn-2".to_owned()],
+        "the remaining connection keeps its subscription"
+    );
+    assert!(
+        runtime.is_watching(&repo.repo_id),
+        "and the watch stays armed — releasing it here would blind the other connection"
+    );
+
+    runtime.unsubscribe("conn-2", &repo).await;
+    assert!(
+        runtime.subscribers_of(&repo.repo_id).await.is_empty(),
+        "now it is released"
+    );
+    assert!(
+        !runtime.is_watching(&repo.repo_id),
+        "and the watch goes with the last subscriber, so nothing leaks"
+    );
+}
+
+#[tokio::test]
+async fn a_closed_connection_releases_everything_it_held() {
+    // Without this a reconnect churn leaks one armed watch per dropped connection:
+    // nothing else ever tells the runtime that session is gone.
+    let repo_a = TempDir::new().expect("tempdir");
+    let _a = fixture(&repo_a);
+    let repo_b = TempDir::new().expect("tempdir");
+    let _b = fixture(&repo_b);
+
+    let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
+    let found = runtime
+        .discover(&[root_of(&repo_a, "pe-a"), root_of(&repo_b, "pe-b")])
+        .await;
+    assert_eq!(found.len(), 2);
+    let first = RepoRef {
+        repo_id: found[0].repo_id.clone(),
+    };
+    let second = RepoRef {
+        repo_id: found[1].repo_id.clone(),
+    };
+
+    runtime.subscribe("conn-1", &first).await.expect("subscribe ok");
+    runtime.subscribe("conn-1", &second).await.expect("subscribe ok");
+    runtime.subscribe("conn-2", &second).await.expect("subscribe ok");
+
+    runtime.drop_session("conn-1").await;
+    assert!(
+        runtime.subscribers_of(&first.repo_id).await.is_empty(),
+        "the repository only that connection watched is released"
+    );
+    assert!(
+        !runtime.is_watching(&first.repo_id),
+        "its watch is released too — otherwise a reconnect churn leaks one per connection"
+    );
+    assert!(
+        runtime.is_watching(&second.repo_id),
+        "the shared repository keeps its watch for the surviving connection"
+    );
+    assert_eq!(
+        runtime.subscribers_of(&second.repo_id).await,
+        vec!["conn-2".to_owned()],
+        "the shared repository stays subscribed for the other connection"
+    );
+}
+
+#[tokio::test]
+async fn unsubscribing_an_unknown_repository_is_harmless() {
+    let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
+    // Arrives after a release, or for a repository that never existed — must not
+    // panic, since a client can always send a stale id.
+    runtime
+        .unsubscribe(
+            "conn-1",
+            &RepoRef {
+                repo_id: "scm:never".to_owned(),
+            },
+        )
+        .await;
+    runtime.drop_session("conn-1").await;
+}
+
+#[tokio::test]
+async fn operating_on_an_unknown_repository_is_rejected() {
+    let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
+    let unknown = RepoRef {
+        repo_id: "scm:never-discovered".to_owned(),
+    };
+
+    assert!(matches!(
+        runtime.refresh(&unknown).await,
+        Err(ScmError::UnknownRepository { .. })
+    ));
+    assert!(matches!(
+        runtime.subscribe("conn-1", &unknown).await,
+        Err(ScmError::UnknownRepository { .. })
+    ));
+}
+
+#[tokio::test]
+async fn re_discovery_keeps_subscribers_and_sequence() {
+    // Discovery runs again whenever a project lists its repositories; that must not
+    // silently drop live subscriptions or rewind the sequence a client is tracking.
+    let tmp = TempDir::new().expect("tempdir");
+    let _repo = fixture(&tmp);
+
+    let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
+    let found = runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    let repo = RepoRef {
+        repo_id: found[0].repo_id.clone(),
+    };
+    let seq_before = runtime.subscribe("conn-1", &repo).await.expect("subscribe ok").seq;
+
+    runtime.discover(&[root_of(&tmp, "pe1")]).await;
+
+    assert_eq!(
+        runtime.subscribers_of(&repo.repo_id).await,
+        vec!["conn-1".to_owned()],
+        "the subscription survives re-discovery"
+    );
+    let seq_after = runtime.refresh(&repo).await.expect("refresh ok").seq;
+    assert!(
+        seq_after > seq_before,
+        "and the sequence continues rather than resetting"
+    );
+}

--- a/crates/aionui-project/src/scm/runtime_test.rs
+++ b/crates/aionui-project/src/scm/runtime_test.rs
@@ -48,6 +48,7 @@ fn root_of(tmp: &TempDir, pe_id: &str) -> ResolvedRoot {
         pe_id: pe_id.to_owned(),
         absolute_path: tmp.path().to_string_lossy().into_owned(),
         label: "fixture".to_owned(),
+        pe_name: None,
     }
 }
 
@@ -68,7 +69,10 @@ async fn discovery_lists_repositories_and_skips_plain_directories() {
 
     let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
     let found = runtime
-        .discover(&[root_of(&repo_dir, "pe-repo"), root_of(&plain_dir, "pe-plain")])
+        .discover(
+            "proj-test",
+            &[root_of(&repo_dir, "pe-repo"), root_of(&plain_dir, "pe-plain")],
+        )
         .await;
 
     assert_eq!(found.len(), 1, "only the repository is listed, got {found:?}");
@@ -84,7 +88,10 @@ async fn a_root_that_is_not_a_repository_does_not_hide_the_others() {
 
     let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
     let found = runtime
-        .discover(&[root_of(&plain_dir, "pe-plain"), root_of(&repo_dir, "pe-repo")])
+        .discover(
+            "proj-test",
+            &[root_of(&plain_dir, "pe-plain"), root_of(&repo_dir, "pe-repo")],
+        )
         .await;
 
     assert_eq!(found.len(), 1);
@@ -97,7 +104,7 @@ async fn the_orchestration_layer_assembles_pe_identity() {
     let _repo = fixture(&tmp);
 
     let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
-    let found = runtime.discover(&[root_of(&tmp, "pe-42")]).await;
+    let found = runtime.discover("proj-test", &[root_of(&tmp, "pe-42")]).await;
     let repo = RepoRef {
         repo_id: found[0].repo_id.clone(),
     };
@@ -121,7 +128,7 @@ async fn sequence_numbers_increase_with_every_recompute() {
     let _repo = fixture(&tmp);
 
     let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
-    let found = runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    let found = runtime.discover("proj-test", &[root_of(&tmp, "pe1")]).await;
     let repo = RepoRef {
         repo_id: found[0].repo_id.clone(),
     };
@@ -146,7 +153,7 @@ async fn concurrent_refreshes_hand_out_distinct_ordered_sequences() {
     let _repo = fixture(&tmp);
 
     let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
-    let found = runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    let found = runtime.discover("proj-test", &[root_of(&tmp, "pe1")]).await;
     let repo = RepoRef {
         repo_id: found[0].repo_id.clone(),
     };
@@ -175,7 +182,7 @@ async fn an_action_publishes_a_newer_frame_than_before_it() {
     let _repo = fixture(&tmp);
 
     let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
-    let found = runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    let found = runtime.discover("proj-test", &[root_of(&tmp, "pe1")]).await;
     let repo = RepoRef {
         repo_id: found[0].repo_id.clone(),
     };
@@ -195,7 +202,7 @@ async fn a_failing_action_does_not_publish_a_frame() {
     let _repo = fixture(&tmp);
 
     let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
-    let found = runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    let found = runtime.discover("proj-test", &[root_of(&tmp, "pe1")]).await;
     let repo = RepoRef {
         repo_id: found[0].repo_id.clone(),
     };
@@ -223,7 +230,7 @@ async fn subscribing_returns_a_first_frame_and_records_the_subscriber() {
     let _repo = fixture(&tmp);
 
     let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
-    let found = runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    let found = runtime.discover("proj-test", &[root_of(&tmp, "pe1")]).await;
     let repo = RepoRef {
         repo_id: found[0].repo_id.clone(),
     };
@@ -239,7 +246,7 @@ async fn subscribing_twice_from_one_connection_counts_once() {
     let _repo = fixture(&tmp);
 
     let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
-    let found = runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    let found = runtime.discover("proj-test", &[root_of(&tmp, "pe1")]).await;
     let repo = RepoRef {
         repo_id: found[0].repo_id.clone(),
     };
@@ -261,7 +268,7 @@ async fn the_watch_is_released_only_when_the_last_subscriber_leaves() {
     let _repo = fixture(&tmp);
 
     let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
-    let found = runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    let found = runtime.discover("proj-test", &[root_of(&tmp, "pe1")]).await;
     let repo = RepoRef {
         repo_id: found[0].repo_id.clone(),
     };
@@ -303,7 +310,7 @@ async fn a_closed_connection_releases_everything_it_held() {
 
     let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
     let found = runtime
-        .discover(&[root_of(&repo_a, "pe-a"), root_of(&repo_b, "pe-b")])
+        .discover("proj-test", &[root_of(&repo_a, "pe-a"), root_of(&repo_b, "pe-b")])
         .await;
     assert_eq!(found.len(), 2);
     let first = RepoRef {
@@ -378,13 +385,13 @@ async fn re_discovery_keeps_subscribers_and_sequence() {
     let _repo = fixture(&tmp);
 
     let (runtime, _dirty) = ScmRuntime::new().expect("runtime builds");
-    let found = runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    let found = runtime.discover("proj-test", &[root_of(&tmp, "pe1")]).await;
     let repo = RepoRef {
         repo_id: found[0].repo_id.clone(),
     };
     let seq_before = runtime.subscribe("conn-1", &repo).await.expect("subscribe ok").seq;
 
-    runtime.discover(&[root_of(&tmp, "pe1")]).await;
+    runtime.discover("proj-test", &[root_of(&tmp, "pe1")]).await;
 
     assert_eq!(
         runtime.subscribers_of(&repo.repo_id).await,

--- a/crates/aionui-project/src/scm/trash_sink.rs
+++ b/crates/aionui-project/src/scm/trash_sink.rs
@@ -1,0 +1,43 @@
+//! Where discarded untracked files go.
+//!
+//! Discarding an untracked change is the one destructive operation in stage 0:
+//! the version-control system holds no copy, so an unlink is unrecoverable. The
+//! floor is therefore the platform trash, never a delete.
+//!
+//! That rule needs a test seam. The real implementation talks to the desktop
+//! platform (Finder on macOS, the shell's recycle bin on Windows, the
+//! Freedesktop trash spec on Linux), and a test cannot make it fail on demand,
+//! nor observe where a file landed — the destination is platform-chosen and not
+//! reliably readable. So the operation sits behind this trait: production uses
+//! [`PlatformTrash`], tests inject implementations that fail deterministically or
+//! record what they were asked to do.
+
+use std::path::Path;
+
+/// Sends a file to the platform trash.
+///
+/// Deliberately one method and no knowledge of source control: implementations
+/// must not decide *whether* a file may be discarded, only carry out the move.
+pub(super) trait TrashSink: Send + Sync {
+    /// Move `path` to the platform trash.
+    ///
+    /// An error must mean **the file was left alone** — implementations must
+    /// never fall back to deleting it, which would turn a recoverable failure
+    /// into data loss.
+    fn trash(&self, path: &Path) -> Result<(), String>;
+}
+
+/// The production sink: the platform's own trash.
+pub(super) struct PlatformTrash;
+
+impl TrashSink for PlatformTrash {
+    fn trash(&self, path: &Path) -> Result<(), String> {
+        // `trash` fails before touching the file when the path cannot be
+        // resolved, so a failure here leaves the work tree untouched.
+        trash::delete(path).map_err(|err| err.to_string())
+    }
+}
+
+#[cfg(test)]
+#[path = "trash_sink_test.rs"]
+mod trash_sink_test;

--- a/crates/aionui-project/src/scm/trash_sink_test.rs
+++ b/crates/aionui-project/src/scm/trash_sink_test.rs
@@ -1,0 +1,37 @@
+//! Trash-sink tests: the "discard never deletes outright" guarantee.
+//!
+//! These exercise the seam itself. The provider-level counterparts (a failing
+//! sink leaves the file in place; discard routes through the sink rather than an
+//! unlink) live in `git_provider_test.rs`, which can inject these doubles.
+
+use std::path::Path;
+
+use super::*;
+
+#[test]
+fn platform_trash_reports_failure_instead_of_deleting() {
+    // A path whose parent does not exist cannot be resolved, so the platform
+    // sink rejects it before touching the filesystem. This is the one failure
+    // mode that is deterministic and fast on every platform (no desktop-shell
+    // round trip), which is why it stands in for "the move cannot be performed".
+    let missing_parent = Path::new("/this-path-does-not-exist-scm-test/nested/file.txt");
+
+    let err = PlatformTrash
+        .trash(missing_parent)
+        .expect_err("an unresolvable path must be rejected");
+    assert!(!err.is_empty(), "the failure must carry a reason");
+}
+
+#[test]
+fn platform_trash_moves_a_real_file_out_of_the_work_tree() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let victim = tmp.path().join("discard-me.txt");
+    std::fs::write(&victim, "content").expect("write victim");
+
+    // Where it lands is the platform's business (per-volume trash on macOS,
+    // `$XDG_DATA_HOME/Trash` on Linux, the recycle bin on Windows), so this only
+    // asserts it left — the "not an unlink" half is pinned by the recording sink
+    // in the provider tests.
+    PlatformTrash.trash(&victim).expect("trashing a real file succeeds");
+    assert!(!victim.exists(), "the file left its original location");
+}

--- a/crates/aionui-project/src/scm/types.rs
+++ b/crates/aionui-project/src/scm/types.rs
@@ -44,8 +44,16 @@ pub struct ResolvedRoot {
     pub pe_id: String,
     /// Local absolute path of the pe root.
     pub absolute_path: String,
-    /// Display label, derived from the pe by the caller.
+    /// Display label, derived from the pe by the caller. Always present: falls
+    /// back through the folder's derived name to the opaque id, so it never
+    /// empties out.
     pub label: String,
+    /// The pe entry's own explicit display name, carried raw for the outward
+    /// model. `None` when the entry has no name of its own (the derived `label`
+    /// is then the only sensible thing to show). Never `Some("")`: the caller
+    /// filters an empty/blank name to `None`, so a consumer can treat "present"
+    /// as "meaningful".
+    pub pe_name: Option<String>,
 }
 
 /// Neutral content anchor: which version of a file to read or compare.
@@ -112,6 +120,11 @@ pub struct ScmRepository {
     /// (`relative_path: ""`), one repo per pe at most.
     pub root: FileRef,
     pub label: String,
+    /// The pe entry's own explicit name, when it has one. The client prefers it
+    /// over `label` for display and falls back to `label` otherwise; absent
+    /// (never empty) when the entry carries no name of its own.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pe_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub head: Option<ScmHead>,
     pub capabilities: ScmCapabilities,

--- a/crates/aionui-project/src/scm/types.rs
+++ b/crates/aionui-project/src/scm/types.rs
@@ -188,6 +188,15 @@ pub struct ScmStatus {
     pub repository: RepoRef,
     /// Flat resource list; grouping is the presentation layer's derivation.
     pub resources: Vec<ScmResource>,
+    /// Head position at the moment this status was computed, same shape as
+    /// [`ScmRepository::head`]. Carried on the status frame — not only on the
+    /// repository descriptor — because a `git checkout` in the work tree moves
+    /// head and is picked up by the watch → debounce → refresh path, which only
+    /// emits a status frame; the descriptor (and its `head`) is re-sent solely on
+    /// `repositoriesChanged` (attach/detach). Without it a branch switch never
+    /// reaches a subscribed client. `None` only when head could not be read.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head: Option<ScmHead>,
     /// Monotonic per repository, allocated by the orchestration layer inside the
     /// same critical section that computes the status. Two refresh sources (an
     /// action completing, a debounced watch signal) can deliver out of order, so

--- a/crates/aionui-project/src/scm/types.rs
+++ b/crates/aionui-project/src/scm/types.rs
@@ -1,0 +1,252 @@
+//! Neutral source-control data model.
+//!
+//! Provider-agnostic by construction: no engine-specific type (raw commit SHA,
+//! DAG, index entry) appears here. Engine concepts that cannot be generalized
+//! are expressed either as an optional capability (see [`ScmCapabilities`]) or
+//! as a capability-relative field ([`ScmResource::staged`]).
+//!
+//! Shapes mirror the wire types in `formal/runtime/protocol.md`; serialization
+//! to the `scm/*` protocol is the WS handler's job, not this module's.
+
+use serde::{Deserialize, Serialize};
+
+/// A file's identity across features: pe-relative, never an absolute path.
+///
+/// Same identity authority as the explorer link (`formal/bind/data-model.md`):
+/// `project_id` / `folder_id` / `absolute_path` are all derived from `pe_id`
+/// and stay out of the identity itself.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct FileRef {
+    pub pe_id: String,
+    /// Normalized path relative to the folder root (`""` is the root itself).
+    pub relative_path: String,
+}
+
+/// Reference to one repository.
+///
+/// `repo_id` is an **opaque token**: consumers must not parse it to recover a
+/// `pe_id` (use [`ScmRepository::root`] / [`FileRef::pe_id`], both carried
+/// separately). The current generation rule is a `scm:` prefix over the pe id,
+/// but that is a generation rule, not a parsing contract.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RepoRef {
+    pub repo_id: String,
+}
+
+/// A root already resolved by the bind layer (identity + containment done),
+/// handed to a provider for repository discovery.
+///
+/// Carries the pe identity for the outward model plus the local absolute path
+/// the engine needs to open the repository. Providers must not re-derive
+/// identity from the path.
+#[derive(Debug, Clone)]
+pub struct ResolvedRoot {
+    pub pe_id: String,
+    /// Local absolute path of the pe root.
+    pub absolute_path: String,
+    /// Display label, derived from the pe by the caller.
+    pub label: String,
+}
+
+/// Neutral content anchor: which version of a file to read or compare.
+///
+/// Providers map these onto their own version concepts (git: `Working` → work
+/// tree, `Committed` → HEAD, `Staged` → index). `Working` and `Committed` exist
+/// for every provider; `Staged` is only meaningful when
+/// [`ScmCapabilities::staging`] is set, and providers without a staging area
+/// must reject it (see [`super::error::ScmError::CapabilityUnsupported`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ContentRef {
+    Working,
+    Committed,
+    Staged,
+}
+
+/// Optional capabilities a provider declares support for.
+///
+/// Core operations (discover / status / diff / original / revert) are mandatory
+/// and therefore absent here. Everything a version-control system may lack is a
+/// flag, so neither the protocol nor the UI hard-codes one engine's model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScmCapabilities {
+    /// Has a staging area (index) — gates [`ContentRef::Staged`] and
+    /// `IScmStaging`.
+    pub staging: bool,
+    /// Local branch switching (git yes; svn models branches as paths).
+    pub local_branches: bool,
+    /// Commit graph / DAG history (stage 2).
+    pub history_graph: bool,
+    /// Remote operations: push / pull / fetch (stage 2).
+    pub remote_ops: bool,
+}
+
+/// Head position of a repository, as far as the neutral model cares.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScmHead {
+    /// Branch name; `None` when detached or unborn.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Whether head points directly at a revision rather than a branch.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detached: Option<bool>,
+}
+
+/// Lifecycle state of a repository as surfaced to the UI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ScmRepositoryState {
+    Idle,
+    Refreshing,
+    Operation,
+    Error,
+}
+
+/// One discovered repository.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScmRepository {
+    pub repo_id: String,
+    /// Which provider serves it (`"git"`, ...).
+    pub provider_id: String,
+    /// Repository root; stage 0 discovery makes this the pe root itself
+    /// (`relative_path: ""`), one repo per pe at most.
+    pub root: FileRef,
+    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head: Option<ScmHead>,
+    pub capabilities: ScmCapabilities,
+    pub state: ScmRepositoryState,
+}
+
+/// Neutral per-resource change state.
+///
+/// **Open set.** Stage 2 may add values (e.g. a merge state); consumers must
+/// tolerate unknown ones and treat them as opaque/blocked (display only, no
+/// actions) rather than coercing them into a regular state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ScmResourceState {
+    Created,
+    Modified,
+    Deleted,
+    /// Conflict from an external merge/rebase. Opaque: no stage/discard in
+    /// stage 1 — folding it into `Modified` would let a user stage or discard a
+    /// half-finished conflict resolution.
+    Conflicted,
+    /// Rename, carrying the previous path. Folding it into `Modified` would be
+    /// semantically wrong (the path changed).
+    Renamed,
+}
+
+impl ScmResourceState {
+    /// Whether stage/unstage/discard must be refused for this state.
+    ///
+    /// Data-safety gate, not a UI preference: acting on a conflicted resource
+    /// can destroy a conflict resolution.
+    pub(crate) fn is_opaque(self) -> bool {
+        matches!(self, Self::Conflicted)
+    }
+}
+
+/// One changed resource. Flat: no pre-grouping into staged/unstaged, so a
+/// provider without a staging area produces a single clean list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScmResource {
+    pub file: FileRef,
+    /// Path relative to the repository root. Equal to
+    /// [`FileRef::relative_path`] while a repo is the pe root itself, but kept
+    /// distinct because the two roots are different concepts.
+    pub repo_relative_path: String,
+    pub state: ScmResourceState,
+    /// Capability-relative: `Some` only for providers with a staging area
+    /// (`true` = staged, `false` = unstaged); `None` when the concept does not
+    /// apply.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub staged: Option<bool>,
+    /// Previous path when `state` is [`ScmResourceState::Renamed`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rename_from: Option<String>,
+}
+
+/// A repository's full change list. Replacement semantics: a newer status
+/// wholly replaces an older one (no delta).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScmStatus {
+    pub repository: RepoRef,
+    /// Flat resource list; grouping is the presentation layer's derivation.
+    pub resources: Vec<ScmResource>,
+    /// Monotonic per repository, allocated by the orchestration layer inside the
+    /// same critical section that computes the status. Two refresh sources (an
+    /// action completing, a debounced watch signal) can deliver out of order, so
+    /// consumers keep the highest sequence they have applied and drop anything
+    /// older — otherwise a slow earlier recompute could overwrite a newer one.
+    ///
+    /// A provider leaves this at `0`; it has no business allocating it.
+    pub seq: u64,
+    /// Whether the list was cut off by the resource cap. Applies to untracked
+    /// entries too: scan cost is driven by non-ignored files
+    /// (tracked ∪ untracked), and bulk file creation goes down that path.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
+    /// Whether this status was computed in the degraded no-index-writeback mode
+    /// (see [`crate::scm::ScmError`] docs on stale-index fallback). Observability
+    /// only — the resource list is complete either way.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub degraded: bool,
+}
+
+/// One file a multi-file action could not complete.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScmActionFailure {
+    pub file: FileRef,
+    /// Why this file was not processed, in terms a user can act on.
+    pub reason: String,
+}
+
+/// Outcome of a multi-file action (discard / stage / unstage).
+///
+/// **Best effort per file.** The files in one request have no transactional
+/// relationship — each is an independent filesystem or index operation — so the
+/// action attempts every one and reports those it could not complete, rather than
+/// stopping at the first failure. Stopping midway is the one behaviour nobody
+/// would choose: it leaves earlier files already changed while reporting only
+/// "failed", with no way to tell which.
+///
+/// All-or-nothing is not on the table: discarding an untracked file moves it to
+/// the platform trash, and on macOS the trash offers no programmatic restore (the
+/// `trash` crate gates its restore API to Windows and Freedesktop platforms), so
+/// a rollback could not be honoured. Restoring a tracked file is equally
+/// irreversible — the user's edit is already overwritten.
+///
+/// Failures **of the whole request** (unknown repository, out-of-scope reference,
+/// malformed parameters, an unsupported capability, or the conflicted-resource
+/// pre-check) are not represented here: those are errors, and they happen before
+/// anything is touched.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScmActionOutcome {
+    /// Files that could not be processed. Empty means every file succeeded;
+    /// successful files are never listed.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub failed: Vec<ScmActionFailure>,
+}
+
+impl ScmActionOutcome {
+    /// Whether every file in the request was processed.
+    pub fn is_complete(&self) -> bool {
+        self.failed.is_empty()
+    }
+}
+
+/// Content of a diff between two [`ContentRef`] anchors.
+///
+/// Either a unified patch or a content pair, per the wire shape; binary and
+/// oversized files are reported as such instead of inlining bytes.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiffContent {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub patch: Option<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub binary: bool,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
+}

--- a/crates/aionui-project/src/scm/watch.rs
+++ b/crates/aionui-project/src/scm/watch.rs
@@ -1,0 +1,264 @@
+//! `.git`-aware watch: the "should we recompute?" signal for source control.
+//!
+//! Deliberately **not** a work-tree watch. Watching a project tree recursively
+//! costs one descriptor per directory on Linux and drowns in events during a
+//! build or a dependency install, while telling us nothing a recompute would not
+//! (see `formal/runtime/source-control.md`). Instead this watches only the
+//! repository's own metadata, which is what every version-control command
+//! touches: staging, committing, checking out, merging and resetting all rewrite
+//! `.git/index` or a ref.
+//!
+//! Two registrations per repository:
+//! - the git directory itself, **non-recursively** — covers `index`, `HEAD`,
+//!   `MERGE_HEAD`, `ORIG_HEAD`, `FETCH_HEAD`, …
+//! - `refs/`, **recursively** — branch and stash ref updates.
+//!
+//! A separate `notify` instance from the explorer's: that one is a non-recursive
+//! stream keyed on observed directories, and mixing a recursive subtree into it
+//! would deliver events its attribution logic does not expect.
+//!
+//! Events are signals, never facts. Nothing here interprets *what* changed —
+//! platforms replay stale events and coalesce unpredictably, so the only sound
+//! reading is "something moved, recompute the whole status".
+
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use notify::{RecommendedWatcher, RecursiveMode, Watcher as NotifyWatcher};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+
+use super::error::ScmError;
+
+/// One repository's watch registration.
+struct WatchEntry {
+    /// Every repository reporting dirt for this path.
+    ///
+    /// A set, not a single id: one git directory can back **several**
+    /// repositories at once — the same checkout opened under two projects yields
+    /// two repo ids over one path. Keeping a single id there means the second
+    /// registration silently replaces the first, and the first repository's
+    /// subscribers then stop receiving refreshes with no error anywhere.
+    repo_ids: BTreeSet<String>,
+    /// Paths handed to `notify`, needed to unwatch them again.
+    registered: Vec<PathBuf>,
+}
+
+/// Registrations keyed by every path prefix an event might be reported under.
+///
+/// A single repository contributes several keys: the git directory as passed in
+/// and, when it differs, its realpath. macOS reports FSEvents paths with symlinks
+/// resolved (`/tmp` → `/private/tmp`), while Linux reports them as registered, so
+/// matching only one form would silently attribute nothing on one platform.
+type Registry = Arc<Mutex<HashMap<String, WatchEntry>>>;
+
+/// Signal that a repository's metadata changed and its status must be recomputed.
+///
+/// Carries no detail on purpose: consumers recompute in full.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ScmDirty {
+    pub(super) repo_id: String,
+}
+
+/// Watches repository metadata and emits [`ScmDirty`] per affected repository.
+pub(super) struct GitWatcher {
+    inner: Mutex<RecommendedWatcher>,
+    registry: Registry,
+}
+
+/// Whether an event path is churn that never changes what a status would report.
+///
+/// Git writes through lock files and temporary index copies: `index.lock`,
+/// `HEAD.lock`, `packed-refs.lock`, `index.stash.<pid>`. They appear and vanish
+/// around every real change, so keeping them would mostly re-arm the debounce
+/// window without adding information — measured as roughly two thirds of all
+/// events during ordinary git usage.
+fn is_noise(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        // A non-UTF-8 name cannot be one of git's own metadata files, so treat it
+        // as a real signal rather than filtering it out silently.
+        return false;
+    };
+    name.ends_with(".lock") || name.starts_with("index.stash.")
+}
+
+/// Key a path is registered/looked-up under: the path as a string, plus its
+/// realpath form when that differs.
+fn keys_for(path: &Path) -> Vec<String> {
+    let mut keys = vec![path.to_string_lossy().into_owned()];
+    if let Ok(real) = std::fs::canonicalize(path) {
+        let real = real.to_string_lossy().into_owned();
+        if !keys.contains(&real) {
+            keys.push(real);
+        }
+    }
+    keys
+}
+
+/// Find which repository an event path belongs to, by longest matching prefix.
+///
+/// Longest-first so a nested registration (`.git/refs`) is preferred over its
+/// parent (`.git`) — either resolves to the same repository, but matching the
+/// most specific key keeps attribution stable if that ever stops being true.
+fn attribute(registry: &HashMap<String, WatchEntry>, path: &Path) -> BTreeSet<String> {
+    let candidates = keys_for(path);
+    let mut best: Option<(usize, &WatchEntry)> = None;
+    for (key, entry) in registry.iter() {
+        for candidate in &candidates {
+            if candidate.starts_with(key.as_str())
+                && let Some(rest) = candidate.get(key.len()..)
+                // Either the path is the registered path itself, or it sits
+                // beneath it — never a sibling sharing a name prefix.
+                && (rest.is_empty() || rest.starts_with(std::path::MAIN_SEPARATOR) || rest.starts_with('/'))
+                && best.as_ref().is_none_or(|(len, _)| key.len() > *len)
+            {
+                best = Some((key.len(), entry));
+            }
+        }
+    }
+    // Every repository behind that path, not just one: a shared git directory
+    // must wake all of its repositories, or the ones left out go stale silently.
+    best.map(|(_, entry)| entry.repo_ids.clone()).unwrap_or_default()
+}
+
+impl GitWatcher {
+    /// Create the watcher and the channel its signals arrive on.
+    pub(super) fn new() -> Result<(Self, UnboundedReceiver<ScmDirty>), ScmError> {
+        let (tx, rx) = unbounded_channel();
+        let registry: Registry = Arc::new(Mutex::new(HashMap::new()));
+        let watcher = build_watcher(Arc::clone(&registry), tx)?;
+        Ok((
+            Self {
+                inner: Mutex::new(watcher),
+                registry,
+            },
+            rx,
+        ))
+    }
+
+    /// Start watching one repository's metadata.
+    ///
+    /// `git_dir` must be the **real** git directory, which for a linked worktree
+    /// or a submodule is not the `.git` entry beside the work tree (that one is a
+    /// file pointing elsewhere) — callers get it from the provider, which asks
+    /// the engine.
+    pub(super) fn watch(&self, repo_id: &str, git_dir: &Path) -> Result<(), ScmError> {
+        let refs_dir = git_dir.join("refs");
+        let mut registered = Vec::new();
+        {
+            let mut watcher = self.inner.lock().expect("scm watcher poisoned");
+            watcher
+                .watch(git_dir, RecursiveMode::NonRecursive)
+                .map_err(|err| ScmError::Io {
+                    path: git_dir.to_string_lossy().into_owned(),
+                    message: format!("watch git dir failed: {err}"),
+                })?;
+            registered.push(git_dir.to_path_buf());
+            // A repository with no refs yet (freshly initialised) has no `refs`
+            // directory; branch signals then arrive once it appears, and `index`
+            // already covers the staging changes that can happen meanwhile.
+            match watcher.watch(&refs_dir, RecursiveMode::Recursive) {
+                Ok(()) => registered.push(refs_dir),
+                Err(err) => tracing::debug!(
+                    repo_id,
+                    error = %err,
+                    "scm watch: refs directory not watchable yet, continuing with the git dir only"
+                ),
+            }
+        }
+
+        let mut registry = self.registry.lock().expect("scm watch registry poisoned");
+        for path in &registered {
+            for key in keys_for(path) {
+                // Merged, never replaced: another repository may already be
+                // registered under this exact path.
+                registry
+                    .entry(key)
+                    .or_insert_with(|| WatchEntry {
+                        repo_ids: BTreeSet::new(),
+                        registered: registered.clone(),
+                    })
+                    .repo_ids
+                    .insert(repo_id.to_owned());
+            }
+        }
+        Ok(())
+    }
+
+    /// Whether a repository currently has an armed registration. Lets the
+    /// orchestration layer's tests assert that release actually happened, which
+    /// the subscriber list alone cannot show.
+    #[cfg(test)]
+    pub(super) fn is_watching(&self, repo_id: &str) -> bool {
+        self.registry
+            .lock()
+            .expect("scm watch registry poisoned")
+            .values()
+            .any(|entry| entry.repo_ids.contains(repo_id))
+    }
+
+    /// Stop watching a repository. Idempotent: unwatching an unknown repository
+    /// is a no-op, so release paths need not check first.
+    pub(super) fn unwatch(&self, repo_id: &str) {
+        let released = {
+            let mut registry = self.registry.lock().expect("scm watch registry poisoned");
+            let mut released: Vec<PathBuf> = Vec::new();
+            for entry in registry.values_mut() {
+                entry.repo_ids.remove(repo_id);
+            }
+            // Only the paths nobody is left watching are handed back to `notify`.
+            // Dropping a path still claimed by another repository would blind that
+            // repository — the failure mode this whole set exists to prevent.
+            registry.retain(|_, entry| {
+                if entry.repo_ids.is_empty() {
+                    released.extend(entry.registered.iter().cloned());
+                    false
+                } else {
+                    true
+                }
+            });
+            released
+        };
+
+        if released.is_empty() {
+            return;
+        }
+        let mut watcher = self.inner.lock().expect("scm watcher poisoned");
+        for path in released {
+            // Already-gone paths (repository deleted) report an error we do not
+            // care about: the registration is being dropped either way.
+            let _ = watcher.unwatch(&path);
+        }
+    }
+}
+
+/// Build the `notify` instance whose callback attributes events to repositories.
+fn build_watcher(registry: Registry, tx: UnboundedSender<ScmDirty>) -> Result<RecommendedWatcher, ScmError> {
+    notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+        let Ok(event) = res else { return };
+        let registry = registry.lock().expect("scm watch registry poisoned");
+        let mut emitted: Vec<String> = Vec::new();
+        for path in &event.paths {
+            if is_noise(path) {
+                continue;
+            }
+            for repo_id in attribute(&registry, path) {
+                if emitted.contains(&repo_id) {
+                    continue;
+                }
+                emitted.push(repo_id.clone());
+                // A closed receiver means the runtime is gone; the signal is
+                // dropped rather than panicking inside a watcher callback.
+                let _ = tx.send(ScmDirty { repo_id });
+            }
+        }
+    })
+    .map_err(|err| ScmError::Io {
+        path: String::new(),
+        message: format!("scm watcher init failed: {err}"),
+    })
+}
+
+#[cfg(test)]
+#[path = "watch_test.rs"]
+mod watch_test;

--- a/crates/aionui-project/src/scm/watch_test.rs
+++ b/crates/aionui-project/src/scm/watch_test.rs
@@ -1,0 +1,425 @@
+//! Watch tests: noise filtering and event attribution.
+//!
+//! The pure parts are tested directly — they decide whether a signal is raised at
+//! all, and getting them wrong is either a storm of pointless recomputes or a
+//! panel that never updates. Live filesystem delivery is covered by the
+//! registration test, which uses a real repository directory.
+
+use std::collections::HashMap;
+
+use super::*;
+
+fn entry(repo_id: &str, paths: &[&str]) -> WatchEntry {
+    WatchEntry {
+        repo_ids: [repo_id.to_owned()].into_iter().collect(),
+        registered: paths.iter().map(PathBuf::from).collect(),
+    }
+}
+
+/// An entry several repositories share, which is what a single git directory
+/// backing two projects produces.
+fn shared_entry(repo_ids: &[&str], paths: &[&str]) -> WatchEntry {
+    WatchEntry {
+        repo_ids: repo_ids.iter().map(|id| (*id).to_owned()).collect(),
+        registered: paths.iter().map(PathBuf::from).collect(),
+    }
+}
+
+/// Expected attribution of exactly one repository.
+fn only(repo_id: &str) -> std::collections::BTreeSet<String> {
+    [repo_id.to_owned()].into_iter().collect()
+}
+
+fn registry_of(pairs: &[(&str, WatchEntry)]) -> HashMap<String, WatchEntry> {
+    pairs
+        .iter()
+        .map(|(key, value)| {
+            (
+                (*key).to_owned(),
+                WatchEntry {
+                    repo_ids: value.repo_ids.clone(),
+                    registered: value.registered.clone(),
+                },
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn git_lock_churn_is_filtered_out() {
+    // Git writes through lock files around every real change; keeping them would
+    // re-arm the debounce window without adding information.
+    for noise in [
+        "/repo/.git/index.lock",
+        "/repo/.git/HEAD.lock",
+        "/repo/.git/packed-refs.lock",
+        "/repo/.git/refs/heads/main.lock",
+        "/repo/.git/index.stash.12345",
+        "/repo/.git/index.stash.12345.lock",
+    ] {
+        assert!(is_noise(Path::new(noise)), "{noise} is churn");
+    }
+}
+
+#[test]
+fn real_metadata_changes_are_not_filtered() {
+    // These are precisely the files whose changes mean "recompute".
+    for signal in [
+        "/repo/.git/index",
+        "/repo/.git/HEAD",
+        "/repo/.git/MERGE_HEAD",
+        "/repo/.git/ORIG_HEAD",
+        "/repo/.git/FETCH_HEAD",
+        "/repo/.git/COMMIT_EDITMSG",
+        "/repo/.git/refs/heads/main",
+        "/repo/.git/refs/stash",
+    ] {
+        assert!(!is_noise(Path::new(signal)), "{signal} is a signal");
+    }
+}
+
+#[test]
+fn a_file_merely_containing_lock_is_not_treated_as_churn() {
+    // Only the `.lock` suffix and the stash-copy prefix are churn; a tracked file
+    // called `lockfile.json` must not silence its repository.
+    assert!(!is_noise(Path::new("/repo/.git/lockfile.json")));
+    assert!(!is_noise(Path::new("/repo/.git/my.lock.txt")));
+}
+
+#[test]
+fn an_event_is_attributed_to_the_repository_that_registered_its_directory() {
+    let registry = registry_of(&[("/w/repo/.git", entry("scm:pe1", &["/w/repo/.git"]))]);
+
+    assert_eq!(attribute(&registry, Path::new("/w/repo/.git/index")), only("scm:pe1"));
+    // The registered directory itself is also attributed.
+    assert_eq!(attribute(&registry, Path::new("/w/repo/.git")), only("scm:pe1"));
+}
+
+#[test]
+fn an_unrelated_path_is_attributed_to_nobody() {
+    let registry = registry_of(&[("/w/repo/.git", entry("scm:pe1", &["/w/repo/.git"]))]);
+
+    assert!(attribute(&registry, Path::new("/w/other/.git/index")).is_empty());
+    assert!(attribute(&registry, Path::new("/w/repo/src/main.rs")).is_empty());
+}
+
+#[test]
+fn a_sibling_sharing_a_name_prefix_is_not_attributed() {
+    // Plain string prefixing would match `/w/repo-backup/...` against `/w/repo`;
+    // that would make one repository's churn recompute another's status.
+    let registry = registry_of(&[("/w/repo/.git", entry("scm:pe1", &["/w/repo/.git"]))]);
+
+    assert!(attribute(&registry, Path::new("/w/repo-backup/.git/index")).is_empty());
+}
+
+#[test]
+fn each_repository_gets_its_own_signal() {
+    let registry = registry_of(&[
+        ("/w/a/.git", entry("scm:pe-a", &["/w/a/.git"])),
+        ("/w/b/.git", entry("scm:pe-b", &["/w/b/.git"])),
+    ]);
+
+    assert_eq!(attribute(&registry, Path::new("/w/a/.git/index")), only("scm:pe-a"));
+    assert_eq!(
+        attribute(&registry, Path::new("/w/b/.git/refs/heads/main")),
+        only("scm:pe-b")
+    );
+}
+
+#[test]
+fn the_most_specific_registration_wins() {
+    // `.git` and `.git/refs` are both registered for the same repository; matching
+    // the longer key keeps attribution stable rather than order-dependent.
+    let registry = registry_of(&[
+        ("/w/repo/.git", entry("scm:pe1", &["/w/repo/.git"])),
+        ("/w/repo/.git/refs", entry("scm:pe1", &["/w/repo/.git/refs"])),
+    ]);
+
+    assert_eq!(
+        attribute(&registry, Path::new("/w/repo/.git/refs/heads/main")),
+        only("scm:pe1")
+    );
+}
+
+#[test]
+fn registration_keys_include_the_realpath_form() {
+    // macOS reports FSEvents paths with symlinks resolved, so a watch registered
+    // through a symlinked path would never match its own events unless both forms
+    // are keys. Uses a real directory so the realpath is genuine.
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let keys = keys_for(tmp.path());
+
+    assert!(
+        keys.contains(&tmp.path().to_string_lossy().into_owned()),
+        "the path as given is always a key"
+    );
+    let real = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+    assert!(
+        keys.contains(&real.to_string_lossy().into_owned()),
+        "and so is its realpath form, got {keys:?}"
+    );
+}
+
+#[test]
+fn keys_are_not_duplicated_when_the_path_is_already_real() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let real = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+    assert_eq!(keys_for(&real).len(), 1, "no redundant duplicate key");
+}
+
+#[tokio::test]
+async fn watching_a_repository_then_releasing_it_is_clean() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let git_dir = tmp.path().join(".git");
+    std::fs::create_dir_all(git_dir.join("refs")).expect("mkdir git dir");
+
+    let (watcher, _rx) = GitWatcher::new().expect("watcher builds");
+    watcher.watch("scm:pe1", &git_dir).expect("watch arms");
+    assert!(
+        !watcher.registry.lock().expect("registry").is_empty(),
+        "registration is recorded"
+    );
+
+    watcher.unwatch("scm:pe1");
+    assert!(
+        watcher.registry.lock().expect("registry").is_empty(),
+        "releasing clears every key for that repository"
+    );
+
+    // Idempotent: releasing again must not panic, so callers need not track state.
+    watcher.unwatch("scm:pe1");
+}
+
+#[tokio::test]
+async fn a_repository_without_a_refs_directory_still_watches() {
+    // A freshly initialised repository has no `refs` yet; index signals must still
+    // arm rather than the whole registration failing.
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let git_dir = tmp.path().join(".git");
+    std::fs::create_dir_all(&git_dir).expect("mkdir git dir");
+
+    let (watcher, _rx) = GitWatcher::new().expect("watcher builds");
+    watcher.watch("scm:pe1", &git_dir).expect("watch arms without refs");
+    assert!(!watcher.registry.lock().expect("registry").is_empty());
+}
+
+/// Wait for a dirty signal naming `repo_id`, draining unrelated ones.
+///
+/// Bounded wait rather than a fixed sleep: platforms coalesce and deliver
+/// filesystem events on their own schedule, so betting on a duration is what
+/// makes such tests flaky. A generous ceiling costs nothing when the signal
+/// arrives promptly, and on failure the caller reports what did arrive.
+async fn saw_dirty(
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<ScmDirty>,
+    repo_id: &str,
+    within: std::time::Duration,
+) -> Result<(), Vec<String>> {
+    let mut seen = Vec::new();
+    let outcome = tokio::time::timeout(within, async {
+        loop {
+            match rx.recv().await {
+                Some(dirty) if dirty.repo_id == repo_id => return true,
+                Some(other) => seen.push(other.repo_id),
+                None => return false,
+            }
+        }
+    })
+    .await;
+
+    match outcome {
+        Ok(true) => Ok(()),
+        // Either the channel closed or the deadline passed with nothing matching.
+        Ok(false) | Err(_) => Err(seen),
+    }
+}
+
+/// Give the OS a moment to arm the watch before mutating, so the write is not
+/// missed simply because registration had not taken effect yet.
+async fn settle() {
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+}
+
+/// End-to-end: writing the index — what every staging/commit/checkout does — must
+/// actually reach us as a signal. The pure tests above prove filtering and
+/// attribution are right; this proves a real filesystem write arrives at all.
+#[tokio::test]
+async fn writing_the_index_produces_a_dirty_signal() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let git_dir = tmp.path().join(".git");
+    std::fs::create_dir_all(git_dir.join("refs")).expect("mkdir git dir");
+
+    let (watcher, mut rx) = GitWatcher::new().expect("watcher builds");
+    watcher.watch("scm:pe1", &git_dir).expect("watch arms");
+    settle().await;
+
+    std::fs::write(git_dir.join("index"), b"index-v1").expect("write index");
+
+    if let Err(seen) = saw_dirty(&mut rx, "scm:pe1", std::time::Duration::from_secs(10)).await {
+        panic!("no dirty signal for the index write; signals seen instead: {seen:?}");
+    }
+}
+
+/// A ref update (branch move, commit, stash) lands under `refs/`, which is
+/// watched recursively — a nested path must still be attributed.
+#[tokio::test]
+async fn updating_a_nested_ref_produces_a_dirty_signal() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let git_dir = tmp.path().join(".git");
+    std::fs::create_dir_all(git_dir.join("refs").join("heads")).expect("mkdir refs/heads");
+
+    let (watcher, mut rx) = GitWatcher::new().expect("watcher builds");
+    watcher.watch("scm:pe1", &git_dir).expect("watch arms");
+    settle().await;
+
+    std::fs::write(git_dir.join("refs").join("heads").join("main"), b"deadbeef\n").expect("write ref");
+
+    if let Err(seen) = saw_dirty(&mut rx, "scm:pe1", std::time::Duration::from_secs(10)).await {
+        panic!("no dirty signal for the nested ref update; signals seen instead: {seen:?}");
+    }
+}
+
+/// Two repositories must not be confused: a write in one is attributed to that
+/// one only, or an unrelated panel would recompute on someone else's churn.
+#[tokio::test]
+async fn a_write_is_attributed_to_its_own_repository() {
+    let one = tempfile::TempDir::new().expect("tempdir");
+    let two = tempfile::TempDir::new().expect("tempdir");
+    let git_one = one.path().join(".git");
+    let git_two = two.path().join(".git");
+    std::fs::create_dir_all(git_one.join("refs")).expect("mkdir");
+    std::fs::create_dir_all(git_two.join("refs")).expect("mkdir");
+
+    let (watcher, mut rx) = GitWatcher::new().expect("watcher builds");
+    watcher.watch("scm:pe-one", &git_one).expect("watch arms");
+    watcher.watch("scm:pe-two", &git_two).expect("watch arms");
+    settle().await;
+
+    std::fs::write(git_two.join("index"), b"only-two").expect("write index");
+
+    if let Err(seen) = saw_dirty(&mut rx, "scm:pe-two", std::time::Duration::from_secs(10)).await {
+        panic!("no dirty signal for the repository that changed; seen: {seen:?}");
+    }
+}
+
+/// After release, writes must stop producing signals — otherwise an unsubscribed
+/// repository would keep waking the runtime, which is the leak the reference
+/// counting exists to prevent.
+#[tokio::test]
+async fn a_released_repository_stops_signalling() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let git_dir = tmp.path().join(".git");
+    std::fs::create_dir_all(git_dir.join("refs")).expect("mkdir git dir");
+
+    let (watcher, mut rx) = GitWatcher::new().expect("watcher builds");
+    watcher.watch("scm:pe1", &git_dir).expect("watch arms");
+    settle().await;
+
+    // Prove the watch works before releasing it, so a later silence cannot be
+    // mistaken for "the write never happened".
+    std::fs::write(git_dir.join("index"), b"before").expect("write index");
+    saw_dirty(&mut rx, "scm:pe1", std::time::Duration::from_secs(10))
+        .await
+        .expect("baseline signal arrives while watched");
+
+    watcher.unwatch("scm:pe1");
+    settle().await;
+    while rx.try_recv().is_ok() {} // drain anything already queued
+
+    std::fs::write(git_dir.join("index"), b"after").expect("write index again");
+    // A short window is right here: the assertion is absence, and the baseline
+    // above already established signals arrive quickly when armed.
+    assert!(
+        saw_dirty(&mut rx, "scm:pe1", std::time::Duration::from_millis(1500))
+            .await
+            .is_err(),
+        "a released repository must not keep signalling"
+    );
+}
+
+#[test]
+fn one_path_can_be_attributed_to_several_repositories() {
+    // The same checkout opened under two projects yields two repo ids over one
+    // git directory. Both must be attributed, or the one left out goes stale.
+    let registry = registry_of(&[(
+        "/w/repo/.git",
+        shared_entry(&["scm:pe-a", "scm:pe-b"], &["/w/repo/.git"]),
+    )]);
+
+    let attributed = attribute(&registry, Path::new("/w/repo/.git/index"));
+    assert_eq!(
+        attributed,
+        ["scm:pe-a".to_owned(), "scm:pe-b".to_owned()].into_iter().collect(),
+        "a shared path wakes every repository behind it"
+    );
+}
+
+/// Registering a second repository over a git directory must not displace the
+/// first. Before the registry held a set, the later registration replaced the
+/// earlier one and the first repository's subscribers simply stopped receiving
+/// refreshes — no error, no log, just a change list that never updates.
+#[tokio::test]
+async fn two_repositories_sharing_a_git_dir_both_receive_signals() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let git_dir = tmp.path().join(".git");
+    std::fs::create_dir_all(git_dir.join("refs")).expect("mkdir git dir");
+
+    let (watcher, mut rx) = GitWatcher::new().expect("watcher builds");
+    watcher.watch("scm:pe-a", &git_dir).expect("first repo arms");
+    watcher.watch("scm:pe-b", &git_dir).expect("second repo arms");
+    assert!(
+        watcher.is_watching("scm:pe-a") && watcher.is_watching("scm:pe-b"),
+        "both registrations survive"
+    );
+    settle().await;
+
+    std::fs::write(git_dir.join("index"), b"index-v1").expect("write index");
+
+    // Both must be notified by the one write.
+    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let deadline = std::time::Duration::from_secs(10);
+    let collected = tokio::time::timeout(deadline, async {
+        while seen.len() < 2 {
+            match rx.recv().await {
+                Some(dirty) => {
+                    seen.insert(dirty.repo_id);
+                }
+                None => break,
+            }
+        }
+    })
+    .await;
+    assert!(
+        collected.is_ok() && seen.len() == 2,
+        "one write must wake both repositories, saw {seen:?}"
+    );
+}
+
+/// Releasing one of two repositories sharing a git directory must leave the other
+/// watching. The registry entry is shared, so a release that drops the whole entry
+/// would silently blind the survivor.
+#[tokio::test]
+async fn releasing_one_shared_repository_leaves_the_other_watching() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let git_dir = tmp.path().join(".git");
+    std::fs::create_dir_all(git_dir.join("refs")).expect("mkdir git dir");
+
+    let (watcher, mut rx) = GitWatcher::new().expect("watcher builds");
+    watcher.watch("scm:pe-a", &git_dir).expect("first arms");
+    watcher.watch("scm:pe-b", &git_dir).expect("second arms");
+    settle().await;
+
+    watcher.unwatch("scm:pe-a");
+    assert!(!watcher.is_watching("scm:pe-a"), "the released one is gone");
+    assert!(
+        watcher.is_watching("scm:pe-b"),
+        "the other keeps its registration after a sibling is released"
+    );
+    while rx.try_recv().is_ok() {} // drain anything already queued
+
+    std::fs::write(git_dir.join("index"), b"index-v2").expect("write index");
+
+    // The survivor must still receive signals, and the released one must not.
+    if let Err(seen) = saw_dirty(&mut rx, "scm:pe-b", std::time::Duration::from_secs(10)).await {
+        panic!("the surviving repository stopped receiving signals; saw instead: {seen:?}");
+    }
+}

--- a/crates/aionui-project/src/scm/wire.rs
+++ b/crates/aionui-project/src/scm/wire.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use super::error::ScmError;
-use super::types::ContentRef;
+use super::types::{ContentRef, ScmRepository};
 
 const JSONRPC_VERSION: &str = "2.0";
 
@@ -66,6 +66,35 @@ pub(super) fn error(id: Option<Value>, code: i64, message: &str, data: Value) ->
 /// A server-initiated notification.
 pub(super) fn notification(method: &str, params: Value) -> Value {
     json!({ "jsonrpc": JSONRPC_VERSION, "method": method, "params": params })
+}
+
+/// The `scm/repositoriesChanged` notification: a project's repository set gained
+/// and/or lost members.
+///
+/// `project_id` is always present so a client that holds one store across several
+/// projects (and receives every project's frame on its shared connection) can
+/// discard the ones that are not the project it is looking at — the server pushes
+/// to a session as long as it once listed *any* of the projects it is interested
+/// in, and does not itself know which project that session currently shows.
+/// `user_id` is deliberately absent: it is an internal authorization detail, not
+/// part of the outward contract.
+///
+/// `added` carries whole repository descriptors (the client splices them in);
+/// `removed` carries only ids (there is nothing left to describe). Each is omitted
+/// when empty, and the caller does not emit the frame at all when both are — an
+/// empty change is not a change.
+pub(super) fn repositories_changed(project_id: &str, added: &[ScmRepository], removed: &[String]) -> Value {
+    let mut params = json!({ "project_id": project_id });
+    if !added.is_empty() {
+        // Infallible in practice (ScmRepository is a plain data struct); an empty
+        // array on the impossible error keeps the frame well-formed rather than
+        // dropping the whole notification.
+        params["added"] = serde_json::to_value(added).unwrap_or_else(|_| json!([]));
+    }
+    if !removed.is_empty() {
+        params["removed"] = json!(removed);
+    }
+    notification("scm/repositoriesChanged", params)
 }
 
 /// Map a domain error onto its wire code, name and context.

--- a/crates/aionui-project/src/scm/wire.rs
+++ b/crates/aionui-project/src/scm/wire.rs
@@ -1,0 +1,133 @@
+//! `scm/*` wire layer: JSON-RPC payload shapes and error mapping.
+//!
+//! The outer transport envelope (`WebSocketMessage { name: "scm", data }`) is the
+//! composition layer's concern; this module models only the inner frame. A
+//! separate router from the explorer's `name: "fs"` because the two protocols are
+//! shaped differently — that one is directory-subscription oriented, this one is
+//! repository oriented (`formal/runtime/protocol.md`).
+//!
+//! Pure: no filesystem, no engine, no transport.
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::error::ScmError;
+use super::types::ContentRef;
+
+const JSONRPC_VERSION: &str = "2.0";
+
+// Standard JSON-RPC framing codes.
+pub(super) const CODE_INVALID_REQUEST: i64 = -32600;
+pub(super) const CODE_METHOD_NOT_FOUND: i64 = -32601;
+pub(super) const CODE_INVALID_PARAMS: i64 = -32602;
+
+// Protocol-semantic codes shared with the explorer link.
+pub(super) const CODE_OUT_OF_SCOPE: i64 = -32000;
+pub(super) const CODE_RESOURCE_NOT_FOUND: i64 = -32002;
+pub(super) const CODE_PROVIDER_UNAVAILABLE: i64 = -32006;
+
+// Source-control specific codes. Distinct from the shared range above so a
+// client can tell "this root is not a repository" from a generic failure.
+pub(super) const CODE_NOT_A_REPOSITORY: i64 = -32050;
+pub(super) const CODE_SCM_OPERATION_FAILED: i64 = -32051;
+pub(super) const CODE_CAPABILITY_UNSUPPORTED: i64 = -32052;
+/// The request was refused because a resource's current state does not allow the
+/// action — distinct from `scm_operation_failed`, which means the action ran and
+/// broke. Retrying a refusal can never succeed until the resource changes (the
+/// user resolves a conflict), so a client must be able to tell the two apart
+/// without parsing messages.
+pub(super) const CODE_RESOURCE_BLOCKED: i64 = -32053;
+
+/// A decoded inbound frame. `id` is absent for notifications (`scm/unsubscribe`).
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct IncomingFrame {
+    #[serde(default)]
+    pub(super) id: Option<Value>,
+    pub(super) method: String,
+    #[serde(default)]
+    pub(super) params: Value,
+}
+
+/// A JSON-RPC success response.
+pub(super) fn success(id: Option<Value>, result: Value) -> Value {
+    json!({ "jsonrpc": JSONRPC_VERSION, "id": id, "result": result })
+}
+
+/// A JSON-RPC error response. `data` carries UI context; pass `Value::Null` when
+/// there is none.
+pub(super) fn error(id: Option<Value>, code: i64, message: &str, data: Value) -> Value {
+    let mut err = json!({ "code": code, "message": message });
+    if !data.is_null() {
+        err["data"] = data;
+    }
+    json!({ "jsonrpc": JSONRPC_VERSION, "id": id, "error": err })
+}
+
+/// A server-initiated notification.
+pub(super) fn notification(method: &str, params: Value) -> Value {
+    json!({ "jsonrpc": JSONRPC_VERSION, "method": method, "params": params })
+}
+
+/// Map a domain error onto its wire code, name and context.
+///
+/// Kept in one place so every method reports the same failure the same way, and
+/// so the mapping is reviewable against the protocol's error table.
+pub(super) fn map_error(err: &ScmError) -> (i64, &'static str, Value) {
+    match err {
+        ScmError::OutOfScope { pe_id } => (CODE_OUT_OF_SCOPE, "out_of_scope", json!({ "pe_id": pe_id })),
+        ScmError::InvalidParams { what } => (CODE_INVALID_PARAMS, "invalid_params", json!({ "param": what })),
+        ScmError::NotARepository { root } => (CODE_NOT_A_REPOSITORY, "not_a_repository", json!({ "root": root })),
+        // An unknown repository id is a stale client reference (the repository was
+        // released or never discovered), which is a lookup failure, not an engine
+        // one.
+        ScmError::UnknownRepository { repo_id } => (
+            CODE_RESOURCE_NOT_FOUND,
+            "resource_not_found",
+            json!({ "repo_id": repo_id }),
+        ),
+        ScmError::NotFound { path } => (CODE_RESOURCE_NOT_FOUND, "resource_not_found", json!({ "path": path })),
+        ScmError::CapabilityUnsupported { capability } => (
+            CODE_CAPABILITY_UNSUPPORTED,
+            "capability_unsupported",
+            json!({ "capability": capability }),
+        ),
+        // A refusal, not a malfunction: the resource is conflicted and stage 1
+        // deliberately offers no action on it. Retrying cannot help until the
+        // user resolves it, which is why this is not an operation failure.
+        ScmError::OpaqueResource { path } => (
+            CODE_RESOURCE_BLOCKED,
+            "resource_blocked",
+            json!({ "path": path, "reason": "conflicted" }),
+        ),
+        ScmError::OperationFailed { context, message } => (
+            CODE_SCM_OPERATION_FAILED,
+            "scm_operation_failed",
+            json!({ "context": context, "message": message }),
+        ),
+        ScmError::Io { path, message } => (
+            CODE_PROVIDER_UNAVAILABLE,
+            "provider_unavailable",
+            json!({ "path": path, "message": message }),
+        ),
+    }
+}
+
+/// Build an error response straight from a domain error.
+pub(super) fn error_from(id: Option<Value>, err: &ScmError) -> Value {
+    let (code, name, data) = map_error(err);
+    error(id, code, name, data)
+}
+
+/// Parse a `ContentRef` from its wire spelling.
+pub(super) fn parse_content_ref(value: &Value) -> Option<ContentRef> {
+    match value.as_str()? {
+        "working" => Some(ContentRef::Working),
+        "committed" => Some(ContentRef::Committed),
+        "staged" => Some(ContentRef::Staged),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+#[path = "wire_test.rs"]
+mod wire_test;

--- a/crates/aionui-project/src/scm/wire_test.rs
+++ b/crates/aionui-project/src/scm/wire_test.rs
@@ -4,8 +4,63 @@
 //! repository reference, a refusal to act on a conflict, and an engine
 //! malfunction must not arrive looking the same.
 
-use super::super::types::{FileRef, ScmActionFailure, ScmActionOutcome};
+use super::super::types::{FileRef, RepoRef, ScmActionFailure, ScmActionOutcome, ScmHead, ScmStatus};
 use super::*;
+
+/// Build the notification a status broadcast puts on the wire, so the assertions
+/// exercise the exact serialization a client receives (see `ScmActor` refresh).
+fn status_frame(head: Option<ScmHead>) -> serde_json::Value {
+    let status = ScmStatus {
+        repository: RepoRef {
+            repo_id: "scm:pe1".into(),
+        },
+        resources: vec![],
+        head,
+        seq: 3,
+        truncated: false,
+        degraded: false,
+    };
+    notification(
+        "scm/statusChanged",
+        serde_json::to_value(&status).expect("serialize status"),
+    )
+}
+
+#[test]
+fn status_frame_carries_head_branch_name() {
+    // The branch name reaches a status-only subscriber solely through this field;
+    // a terminal `git checkout` produces exactly this shape.
+    let frame = status_frame(Some(ScmHead {
+        name: Some("feature/x".into()),
+        detached: None,
+    }));
+    let params = &frame["params"];
+    assert_eq!(params["head"]["name"], "feature/x");
+    // `detached: None` is omitted, not serialized as null.
+    assert!(params["head"].get("detached").is_none(), "absent detached is omitted");
+}
+
+#[test]
+fn status_frame_carries_detached_head() {
+    let frame = status_frame(Some(ScmHead {
+        name: None,
+        detached: Some(true),
+    }));
+    let head = &frame["params"]["head"];
+    assert_eq!(head["detached"], true);
+    assert!(head.get("name").is_none(), "a detached head serializes no name");
+}
+
+#[test]
+fn status_frame_omits_head_when_unreadable() {
+    // `None` head is a distinct wire state from a present-but-empty head; the
+    // client must not see a null branch and mistake it for detached/unborn.
+    let frame = status_frame(None);
+    assert!(
+        frame["params"].get("head").is_none(),
+        "an unreadable head is omitted from the frame entirely"
+    );
+}
 
 #[test]
 fn frames_carry_the_jsonrpc_envelope() {

--- a/crates/aionui-project/src/scm/wire_test.rs
+++ b/crates/aionui-project/src/scm/wire_test.rs
@@ -1,0 +1,212 @@
+//! Wire tests: frame shapes and the error mapping.
+//!
+//! The mapping matters because it is what a client branches on: a stale
+//! repository reference, a refusal to act on a conflict, and an engine
+//! malfunction must not arrive looking the same.
+
+use super::super::types::{FileRef, ScmActionFailure, ScmActionOutcome};
+use super::*;
+
+#[test]
+fn frames_carry_the_jsonrpc_envelope() {
+    let ok = success(Some(json!(7)), json!({ "statuses": [] }));
+    assert_eq!(ok["jsonrpc"], "2.0");
+    assert_eq!(ok["id"], 7);
+    assert_eq!(ok["result"]["statuses"], json!([]));
+
+    let note = notification("scm/statusChanged", json!({ "seq": 3 }));
+    assert_eq!(note["jsonrpc"], "2.0");
+    assert_eq!(note["method"], "scm/statusChanged");
+    assert!(note.get("id").is_none(), "notifications carry no id");
+}
+
+#[test]
+fn errors_omit_data_when_there_is_none() {
+    let err = error(Some(json!(1)), CODE_INVALID_PARAMS, "invalid_params", Value::Null);
+    assert_eq!(err["error"]["code"], CODE_INVALID_PARAMS);
+    assert_eq!(err["error"]["message"], "invalid_params");
+    assert!(
+        err["error"].get("data").is_none(),
+        "a null context is left out rather than sent as null"
+    );
+}
+
+#[test]
+fn a_scope_violation_is_distinct_from_not_found() {
+    // A pe the connection may not reach must not look like a missing file: the
+    // client should not go hunting for something it was never allowed to name.
+    let (code, name, data) = map_error(&ScmError::OutOfScope {
+        pe_id: "pe-other".to_owned(),
+    });
+    assert_eq!(code, CODE_OUT_OF_SCOPE);
+    assert_eq!(name, "out_of_scope");
+    assert_eq!(data["pe_id"], "pe-other");
+    assert_ne!(code, CODE_RESOURCE_NOT_FOUND);
+}
+
+#[test]
+fn a_malformed_request_is_distinct_from_an_unsupported_capability() {
+    // "You sent no repository" and "this provider has no staging area" are
+    // different problems with different fixes.
+    let (code, name, data) = map_error(&ScmError::InvalidParams { what: "repository" });
+    assert_eq!(code, CODE_INVALID_PARAMS);
+    assert_eq!(name, "invalid_params");
+    assert_eq!(data["param"], "repository");
+    assert_ne!(code, CODE_CAPABILITY_UNSUPPORTED);
+}
+
+#[test]
+fn a_missing_repository_maps_to_not_a_repository() {
+    let (code, name, data) = map_error(&ScmError::NotARepository {
+        root: "/tmp/plain".to_owned(),
+    });
+    assert_eq!(code, CODE_NOT_A_REPOSITORY);
+    assert_eq!(name, "not_a_repository");
+    assert_eq!(data["root"], "/tmp/plain");
+}
+
+#[test]
+fn a_stale_repository_reference_is_a_lookup_failure_not_an_engine_failure() {
+    // The client is holding an id for a repository that was released or never
+    // existed; conflating this with an operation failure would send clients
+    // hunting for a git problem that is not there.
+    let (code, name, _) = map_error(&ScmError::UnknownRepository {
+        repo_id: "scm:gone".to_owned(),
+    });
+    assert_eq!(code, CODE_RESOURCE_NOT_FOUND);
+    assert_eq!(name, "resource_not_found");
+}
+
+#[test]
+fn an_unsupported_capability_reports_which_one() {
+    let (code, name, data) = map_error(&ScmError::CapabilityUnsupported { capability: "staging" });
+    assert_eq!(code, CODE_CAPABILITY_UNSUPPORTED);
+    assert_eq!(name, "capability_unsupported");
+    assert_eq!(data["capability"], "staging");
+}
+
+#[test]
+fn refusing_a_blocked_resource_is_not_an_operation_failure() {
+    let (code, name, data) = map_error(&ScmError::OpaqueResource {
+        path: "c.txt".to_owned(),
+    });
+    // A policy refusal (nothing ran) must be distinguishable from an action that
+    // ran and broke: retrying the former can never succeed until the user resolves
+    // the conflict, so a client needs to branch on the code, not parse a message.
+    assert_eq!(code, CODE_RESOURCE_BLOCKED);
+    assert_eq!(name, "resource_blocked");
+    assert_ne!(code, CODE_SCM_OPERATION_FAILED, "a refusal is not an operation failure");
+    assert_eq!(data["reason"], "conflicted");
+    assert_eq!(data["path"], "c.txt");
+}
+
+#[test]
+fn an_engine_failure_carries_its_operation_context() {
+    let (code, name, data) = map_error(&ScmError::OperationFailed {
+        context: "stage",
+        message: "index locked".to_owned(),
+    });
+    assert_eq!(code, CODE_SCM_OPERATION_FAILED);
+    assert_eq!(name, "scm_operation_failed");
+    assert_eq!(data["context"], "stage");
+}
+
+#[test]
+fn local_io_failure_maps_to_provider_unavailable() {
+    let (code, name, _) = map_error(&ScmError::Io {
+        path: "a.txt".to_owned(),
+        message: "move to trash failed".to_owned(),
+    });
+    assert_eq!(code, CODE_PROVIDER_UNAVAILABLE);
+    assert_eq!(name, "provider_unavailable");
+}
+
+#[test]
+fn scm_codes_do_not_collide_with_the_shared_protocol_codes() {
+    // The scm-specific codes sit apart from the codes the explorer link already
+    // defines, so a client can tell feature-specific failures from shared ones.
+    let shared = [
+        CODE_INVALID_REQUEST,
+        CODE_METHOD_NOT_FOUND,
+        CODE_INVALID_PARAMS,
+        CODE_OUT_OF_SCOPE,
+        CODE_RESOURCE_NOT_FOUND,
+        CODE_PROVIDER_UNAVAILABLE,
+    ];
+    for code in [
+        CODE_NOT_A_REPOSITORY,
+        CODE_SCM_OPERATION_FAILED,
+        CODE_CAPABILITY_UNSUPPORTED,
+    ] {
+        assert!(!shared.contains(&code), "{code} must be unique to scm");
+    }
+}
+
+#[test]
+fn content_refs_parse_from_their_wire_spelling() {
+    assert_eq!(parse_content_ref(&json!("working")), Some(ContentRef::Working));
+    assert_eq!(parse_content_ref(&json!("committed")), Some(ContentRef::Committed));
+    assert_eq!(parse_content_ref(&json!("staged")), Some(ContentRef::Staged));
+}
+
+#[test]
+fn an_unknown_content_ref_is_rejected_rather_than_guessed() {
+    // Defaulting an unrecognised anchor would silently diff the wrong pair of
+    // versions, so it must be refused.
+    assert_eq!(parse_content_ref(&json!("head")), None);
+    assert_eq!(parse_content_ref(&json!("")), None);
+    assert_eq!(parse_content_ref(&json!(null)), None);
+    assert_eq!(parse_content_ref(&json!(3)), None);
+}
+
+#[test]
+fn an_inbound_frame_decodes_with_optional_id_and_params() {
+    let request: IncomingFrame = serde_json::from_value(json!({
+        "jsonrpc": "2.0", "id": 4, "method": "scm/status", "params": { "repository": "scm:pe1" }
+    }))
+    .expect("request decodes");
+    assert_eq!(request.id, Some(json!(4)));
+    assert_eq!(request.method, "scm/status");
+
+    let note: IncomingFrame = serde_json::from_value(json!({
+        "jsonrpc": "2.0", "method": "scm/unsubscribe"
+    }))
+    .expect("notification decodes");
+    assert!(note.id.is_none(), "no id on a notification");
+    assert!(note.params.is_null(), "absent params default to null");
+}
+
+#[test]
+fn an_all_success_action_serializes_to_the_old_shape() {
+    // Back-compatibility: a client written before per-file results existed sees
+    // exactly what it saw before, so nothing breaks by adding the field.
+    let outcome = ScmActionOutcome::default();
+    let value = serde_json::to_value(&outcome).expect("serializes");
+    assert_eq!(value, json!({}), "no `failed` key at all when everything succeeded");
+    assert!(outcome.is_complete());
+}
+
+#[test]
+fn a_partial_failure_lists_only_the_failures() {
+    let outcome = ScmActionOutcome {
+        failed: vec![ScmActionFailure {
+            file: FileRef {
+                pe_id: "pe1".to_owned(),
+                relative_path: "u2.txt".to_owned(),
+            },
+            reason: "move to trash failed: refused".to_owned(),
+        }],
+    };
+    let value = serde_json::to_value(&outcome).expect("serializes");
+
+    // Successful files are implied by absence — listing them would grow the frame
+    // with information the client already has from the status it gets pushed.
+    assert_eq!(value["failed"].as_array().expect("array").len(), 1);
+    assert_eq!(value["failed"][0]["file"]["pe_id"], "pe1");
+    assert_eq!(value["failed"][0]["file"]["relative_path"], "u2.txt");
+    assert!(
+        value["failed"][0]["reason"].as_str().expect("reason").contains("trash"),
+        "the reason travels to the client"
+    );
+    assert!(!outcome.is_complete());
+}

--- a/crates/aionui-project/src/service.rs
+++ b/crates/aionui-project/src/service.rs
@@ -1,12 +1,14 @@
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use aionui_common::generate_short_id;
 use aionui_db::{FolderRow, IProjectStore, ProjectExplorerRow, ProjectKind, Role};
 use chrono::{Datelike, Local};
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::canonical::{self, Canonical};
 use crate::containment;
+use crate::scm::ScmInbound;
 use crate::types::{
     AttachInput, FolderDto, ProjectDetail, ProjectError, ProjectExplorerEntry, ProjectExplorerView, ReferenceInput,
     ResolveOutput, ResolvedResource, RuntimeStatus,
@@ -19,11 +21,44 @@ use crate::types::{
 pub struct ProjectService {
     store: Arc<dyn IProjectStore>,
     temp_root: PathBuf,
+    /// Sink for project-root changes to the source-control actor. Shared across
+    /// clones (behind `Arc`) so the one instance the scm monitor installs the
+    /// sender on is the same one the HTTP handlers see. Set once at startup;
+    /// `None` in tests and the HTTP-only assembly path, where a root change simply
+    /// notifies nobody.
+    scm_roots_tx: Arc<OnceLock<UnboundedSender<ScmInbound>>>,
 }
 
 impl ProjectService {
     pub fn new(store: Arc<dyn IProjectStore>, temp_root: PathBuf) -> Self {
-        Self { store, temp_root }
+        Self {
+            store,
+            temp_root,
+            scm_roots_tx: Arc::new(OnceLock::new()),
+        }
+    }
+
+    /// Install the sink that carries project-root changes to the source-control
+    /// actor. Called once, at startup, by the scm monitor's composition wiring;
+    /// later calls are ignored (set-once). Because the field is shared across
+    /// clones, setting it on any clone makes it visible to all of them.
+    pub fn set_scm_roots_sender(&self, tx: UnboundedSender<ScmInbound>) {
+        let _ = self.scm_roots_tx.set(tx);
+    }
+
+    /// Tell the source-control actor that a project's attached-folder set changed,
+    /// so it can recompute repositories and push a `repositoriesChanged` frame.
+    ///
+    /// Best effort: if no actor is wired, or it has stopped, source control simply
+    /// misses the live update (a manual refresh still recovers) — this never fails
+    /// the attach or detach that already succeeded.
+    fn notify_roots_changed(&self, project_id: &str, user_id: &str) {
+        if let Some(tx) = self.scm_roots_tx.get() {
+            let _ = tx.send(ScmInbound::RootsChanged {
+                project_id: project_id.to_owned(),
+                user_id: user_id.to_owned(),
+            });
+        }
     }
 
     // ── creation / backfill ────────────────────────────────────────────
@@ -159,7 +194,8 @@ impl ProjectService {
         }
 
         let order_index = entries.len() as i64;
-        self.store
+        let row = self
+            .store
             .insert_attached_entry(
                 user_id,
                 &input.project_id,
@@ -167,8 +203,12 @@ impl ProjectService {
                 input.display_name.as_deref(),
                 order_index,
             )
-            .await
-            .map_err(Into::into)
+            .await?;
+        // A newly attached folder can bring a repository into view. The
+        // focus-in-place branches above return early without notifying — they add
+        // no root, so the repository set is unchanged.
+        self.notify_roots_changed(&input.project_id, user_id);
+        Ok(row)
     }
 
     /// Remove an attached entry. The workspace entry cannot be removed here.
@@ -186,6 +226,8 @@ impl ProjectService {
             });
         }
         self.store.remove_entry(user_id, pe_id).await?;
+        // Detaching a folder can drop a repository from the project's set.
+        self.notify_roots_changed(&entry.project_id, user_id);
         Ok(())
     }
 
@@ -378,10 +420,15 @@ impl ProjectService {
     }
 
     fn build_folder_dto(&self, folder: &FolderRow) -> FolderDto {
+        // Blank (empty or whitespace-only) basenames collapse to `None`, matching
+        // the source-control seam's `pe_name`/`label` filter. A folder literally
+        // named "   " would otherwise surface a whitespace default name, and the
+        // scm label fallback (`display_name || default_display_name || pe_id`)
+        // would render it blank — breaking the "label is never blank" contract.
         let default_display_name = canonical::canonicalize(&folder.resource_canonical)
             .ok()
             .map(|c| canonical::basename(&c))
-            .filter(|name| !name.is_empty());
+            .filter(|name| !name.trim().is_empty());
         let (runtime_status, runtime_error) = runtime_status_of(folder);
         FolderDto {
             folder_id: folder.folder_id.clone(),

--- a/crates/aionui-project/tests/scm_request_path.rs
+++ b/crates/aionui-project/tests/scm_request_path.rs
@@ -12,17 +12,22 @@ use aionui_db::{Database, IProjectStore, SqliteProjectStore, init_database_memor
 use aionui_project::ProjectService;
 use aionui_project::canonical::to_file_uri;
 use aionui_project::scm::{ScmActor, ScmInbound, ScmWirePush};
+use aionui_project::types::AttachInput;
 use serde_json::{Value, json};
 use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
 
-/// Collects the frames the actor pushes, so a test can read its replies.
+/// Collects `(session, frame)` pairs the actor pushes, so a test can read its
+/// replies and assert *which* connection each frame went to.
 struct CollectingPush {
-    sent: std::sync::Mutex<Vec<Value>>,
+    sent: std::sync::Mutex<Vec<(String, Value)>>,
 }
 
 impl ScmWirePush for CollectingPush {
-    fn push(&self, _session: &str, frame: Value) {
-        self.sent.lock().expect("push sink poisoned").push(frame);
+    fn push(&self, session: &str, frame: Value) {
+        self.sent
+            .lock()
+            .expect("push sink poisoned")
+            .push((session.to_owned(), frame));
     }
 }
 
@@ -30,6 +35,7 @@ impl ScmWirePush for CollectingPush {
 struct Fixture {
     _db: Database,
     _repo_dir: tempfile::TempDir,
+    service: Arc<ProjectService>,
     push: Arc<CollectingPush>,
     inbound: tokio::sync::mpsc::UnboundedSender<ScmInbound>,
     pe_id: String,
@@ -77,10 +83,15 @@ async fn fixture() -> Fixture {
     let actor = ScmActor::new(Arc::clone(&service), Arc::clone(&push) as Arc<dyn ScmWirePush>).expect("actor");
     let (inbound, inbound_rx) = unbounded_channel();
     tokio::spawn(actor.run(inbound_rx));
+    // Wire the service's root-change notifications into the same actor inbound, so
+    // an attach/detach through the service drives a `repositoriesChanged` push —
+    // exactly the composition the app installs at startup.
+    service.set_scm_roots_sender(inbound.clone());
 
     Fixture {
         _db: db,
         _repo_dir: repo_dir,
+        service,
         push,
         inbound,
         pe_id,
@@ -89,31 +100,80 @@ async fn fixture() -> Fixture {
 }
 
 impl Fixture {
-    /// Send one request and wait for the actor's reply.
+    /// Send one request as `conn-1` and wait for the actor's reply.
     async fn call(&self, id: u64, method: &str, params: Value) -> Value {
+        self.call_as("conn-1", id, method, params).await
+    }
+
+    /// Send one request as `session` and wait for the actor's reply to it.
+    async fn call_as(&self, session: &str, id: u64, method: &str, params: Value) -> Value {
         let before = self.push.sent.lock().expect("sink").len();
         self.inbound
             .send(ScmInbound::Frame {
-                session: "conn-1".to_owned(),
+                session: session.to_owned(),
                 user_id: "system_default_user".to_owned(),
                 frame: json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params }),
             })
             .expect("actor alive");
 
         // Bounded wait: the reply is asynchronous, and a fixed sleep would either
-        // be slow or flaky.
+        // be slow or flaky. Match on session too, so a reply meant for another
+        // connection cannot be mistaken for this one's.
         for _ in 0..200 {
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
             let sent = self.push.sent.lock().expect("sink");
-            if let Some(frame) = sent
+            if let Some((_, frame)) = sent
                 .iter()
                 .skip(before)
-                .find(|f| f.get("id").and_then(Value::as_u64) == Some(id))
+                .find(|(sess, f)| sess == session && f.get("id").and_then(Value::as_u64) == Some(id))
             {
                 return frame.clone();
             }
         }
-        panic!("no reply for {method} within the deadline");
+        panic!("no reply for {method} to {session} within the deadline");
+    }
+
+    /// Enqueue a `Disconnect` for `session`. The single-consumer actor processes it
+    /// in FIFO order relative to later inbound events, so anything sent afterwards
+    /// (e.g. an attach's `RootsChanged`) observes the session as already gone.
+    fn disconnect(&self, session: &str) {
+        self.inbound
+            .send(ScmInbound::Disconnect {
+                session: session.to_owned(),
+            })
+            .expect("actor alive");
+    }
+
+    /// Wait for a server-initiated notification (no `id`) with `method`, delivered
+    /// to `session`, appearing after index `before`. Returns its `params`.
+    async fn wait_for_notification(&self, session: &str, method: &str, before: usize) -> Value {
+        for _ in 0..200 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            let sent = self.push.sent.lock().expect("sink");
+            if let Some((_, frame)) = sent
+                .iter()
+                .skip(before)
+                .find(|(sess, f)| sess == session && f.get("id").is_none() && f["method"] == method)
+            {
+                return frame["params"].clone();
+            }
+        }
+        panic!("no {method} notification to {session} within the deadline");
+    }
+
+    /// How many frames have been pushed so far — a `before` cursor for the waits.
+    fn frame_count(&self) -> usize {
+        self.push.sent.lock().expect("sink").len()
+    }
+
+    /// Whether any frame with `method` was ever pushed to `session`.
+    fn pushed_to(&self, session: &str, method: &str) -> bool {
+        self.push
+            .sent
+            .lock()
+            .expect("sink")
+            .iter()
+            .any(|(sess, f)| sess == session && f["method"] == method)
     }
 
     async fn repo_id(&self) -> String {
@@ -124,6 +184,17 @@ impl Fixture {
             .as_str()
             .unwrap_or_else(|| panic!("no repository discovered: {listed}"))
             .to_owned()
+    }
+
+    /// The first discovered repository's wire object, so a test can inspect the
+    /// fields `scm/listRepositories` actually serialized (not just the id).
+    async fn first_repository(&self, id: u64) -> Value {
+        let listed = self
+            .call(id, "scm/listRepositories", json!({ "project_id": self.project_id }))
+            .await;
+        let repo = &listed["result"]["repositories"][0];
+        assert!(repo.is_object(), "one repository is discovered: {listed}");
+        repo.clone()
     }
 }
 
@@ -280,6 +351,395 @@ async fn a_path_escaping_the_root_is_still_refused() {
             .await;
         assert!(reply.get("error").is_some(), "{escape:?} must be refused, got {reply}");
     }
+}
+
+/// An entry with no name of its own carries no `pe_name`: the field is absent
+/// from the wire, not an empty string, so the client's `pe_name || label`
+/// falls straight through to `label`.
+#[tokio::test]
+async fn pe_name_is_absent_when_the_entry_has_no_name_of_its_own() {
+    let fx = fixture().await;
+    // The workspace root created by `create_standard` has no explicit entry name.
+    let repo = fx.first_repository(70).await;
+
+    assert_eq!(
+        repo["root"]["pe_id"].as_str(),
+        Some(fx.pe_id.as_str()),
+        "the discovered repository is the workspace root: {repo}"
+    );
+    assert!(
+        repo.get("pe_name").is_none(),
+        "no name of its own means the field is omitted, not empty: {repo}"
+    );
+    assert!(
+        repo["label"].as_str().is_some_and(|l| !l.is_empty()),
+        "label always has a value to fall back to: {repo}"
+    );
+}
+
+/// When the entry has an explicit name, it is carried through to the wire as
+/// `pe_name`, distinct from the always-present `label`.
+#[tokio::test]
+async fn pe_name_is_carried_when_the_entry_has_a_name() {
+    let fx = fixture().await;
+    fx.service
+        .rename_entry("system_default_user", &fx.pe_id, Some("My Repo".to_owned()))
+        .await
+        .expect("rename");
+
+    let repo = fx.first_repository(71).await;
+    assert_eq!(
+        repo["pe_name"].as_str(),
+        Some("My Repo"),
+        "the entry's own name reaches the repository wire: {repo}"
+    );
+}
+
+/// A blank name is dropped to absent, not carried as whitespace — otherwise the
+/// client's `pe_name || label` would pick a blank string over the real label.
+/// Removing the blank filter turns this red (the field comes back as `"   "`).
+#[tokio::test]
+async fn a_blank_entry_name_is_dropped_rather_than_carried() {
+    let fx = fixture().await;
+    fx.service
+        .rename_entry("system_default_user", &fx.pe_id, Some("   ".to_owned()))
+        .await
+        .expect("rename");
+
+    let repo = fx.first_repository(72).await;
+    assert!(
+        repo.get("pe_name").is_none(),
+        "a whitespace-only name is filtered to absent: {repo}"
+    );
+}
+
+/// A blank explicit name never survives as the label either: it falls through to
+/// the folder's derived name (or the id). This pins "label is never blank" as a
+/// backend contract, which is what makes the client's `pe_name || label` safe.
+/// Removing the label's blank filter turns this red (label comes back `"   "`).
+#[tokio::test]
+async fn a_blank_entry_name_does_not_become_a_blank_label() {
+    let fx = fixture().await;
+    fx.service
+        .rename_entry("system_default_user", &fx.pe_id, Some("   ".to_owned()))
+        .await
+        .expect("rename");
+
+    let repo = fx.first_repository(73).await;
+    let label = repo["label"].as_str().expect("label present");
+    assert!(!label.trim().is_empty(), "label must not be blank, got {label:?}");
+    assert!(
+        repo.get("pe_name").is_none(),
+        "and the blank pe_name is dropped too: {repo}"
+    );
+}
+
+/// Initialise a git repository with one committed file (git2 only, no CLI), so it
+/// runs identically on every platform.
+fn init_committed_repo(dir: &std::path::Path) {
+    let repo = git2::Repository::init(dir).expect("init repo");
+    {
+        let mut cfg = repo.config().expect("config");
+        cfg.set_str("user.name", "scm test").expect("name");
+        cfg.set_str("user.email", "scm@test.local").expect("email");
+    }
+    std::fs::write(dir.join("readme.txt"), "hi\n").expect("write");
+    let mut index = repo.index().expect("index");
+    index
+        .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+        .expect("add");
+    index.write().expect("write index");
+    let tree = repo.find_tree(index.write_tree().expect("tree")).expect("find tree");
+    let sig = repo.signature().expect("sig");
+    repo.commit(Some("HEAD"), &sig, &sig, "base", &tree, &[])
+        .expect("commit");
+}
+
+/// Attaching a repository then detaching it drives a `repositoriesChanged` frame
+/// each way, carrying `project_id`, the added descriptor, and (on detach) the
+/// removed id — the whole 乙-wired path from service mutation to actor push.
+#[tokio::test]
+async fn attaching_and_detaching_a_repo_pushes_repositories_changed() {
+    let fx = fixture().await;
+    // conn-1 lists the project: registers interest and seeds the baseline (the one
+    // workspace repository).
+    let _ = fx.repo_id().await;
+
+    // A second git repo outside the workspace root, so it attaches as a new root.
+    let second_dir = tempfile::tempdir().expect("tempdir");
+    init_committed_repo(second_dir.path());
+
+    let before = fx.frame_count();
+    let row = fx
+        .service
+        .attach_folder(
+            "system_default_user",
+            AttachInput {
+                project_id: fx.project_id.clone(),
+                uri: to_file_uri(second_dir.path()).expect("uri"),
+                display_name: Some("Second".to_owned()),
+            },
+        )
+        .await
+        .expect("attach");
+    let added_repo_id = format!("scm:{}", row.pe_id);
+
+    let params = fx
+        .wait_for_notification("conn-1", "scm/repositoriesChanged", before)
+        .await;
+    assert_eq!(
+        params["project_id"].as_str(),
+        Some(fx.project_id.as_str()),
+        "the frame carries project_id for client-side filtering: {params}"
+    );
+    let added = params["added"].as_array().expect("added present on attach");
+    let added_obj = added
+        .iter()
+        .find(|r| r["repo_id"] == json!(added_repo_id))
+        .unwrap_or_else(|| panic!("the new repo is in added: {params}"));
+    assert_eq!(
+        added_obj["pe_name"].as_str(),
+        Some("Second"),
+        "pe_name flows through the delta too"
+    );
+    assert!(
+        params.get("removed").is_none(),
+        "nothing removed on a pure attach: {params}"
+    );
+
+    // Detach → removed carries the id, added is absent.
+    let before = fx.frame_count();
+    fx.service
+        .remove_attached("system_default_user", &row.pe_id)
+        .await
+        .expect("detach");
+    let params = fx
+        .wait_for_notification("conn-1", "scm/repositoriesChanged", before)
+        .await;
+    let removed: Vec<&str> = params["removed"]
+        .as_array()
+        .expect("removed present on detach")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert!(
+        removed.contains(&added_repo_id.as_str()),
+        "the detached repo is reported removed: {params}"
+    );
+    assert!(
+        params.get("added").is_none(),
+        "nothing added on a pure detach: {params}"
+    );
+}
+
+/// A `repositoriesChanged` frame reaches only sessions that expressed interest by
+/// listing the project — never a connection that did not (no leakage).
+#[tokio::test]
+async fn repositories_changed_reaches_only_interested_sessions() {
+    let fx = fixture().await;
+    // conn-1 registers interest; conn-2 never lists this project.
+    let _ = fx.repo_id().await;
+
+    let second_dir = tempfile::tempdir().expect("tempdir");
+    init_committed_repo(second_dir.path());
+    let before = fx.frame_count();
+    fx.service
+        .attach_folder(
+            "system_default_user",
+            AttachInput {
+                project_id: fx.project_id.clone(),
+                uri: to_file_uri(second_dir.path()).expect("uri"),
+                display_name: None,
+            },
+        )
+        .await
+        .expect("attach");
+
+    // conn-1 receives it...
+    let _ = fx
+        .wait_for_notification("conn-1", "scm/repositoriesChanged", before)
+        .await;
+    // ...and conn-2, uninterested, never does.
+    assert!(
+        !fx.pushed_to("conn-2", "scm/repositoriesChanged"),
+        "an uninterested connection receives no repositoriesChanged frame"
+    );
+}
+
+/// Removing a repository then re-adding the same folder re-discovers it. This is
+/// the race the release-on-remove could break: because a recompute discovers
+/// *before* it releases, a folder that is present again is never torn down, so the
+/// re-add surfaces normally instead of vanishing behind a stale release.
+#[tokio::test]
+async fn a_removed_repo_can_be_re_added() {
+    let fx = fixture().await;
+    let _ = fx.repo_id().await;
+
+    let second_dir = tempfile::tempdir().expect("tempdir");
+    init_committed_repo(second_dir.path());
+    let uri = to_file_uri(second_dir.path()).expect("uri");
+
+    // Attach, wait for the add.
+    let before = fx.frame_count();
+    let row = fx
+        .service
+        .attach_folder(
+            "system_default_user",
+            AttachInput {
+                project_id: fx.project_id.clone(),
+                uri: uri.clone(),
+                display_name: None,
+            },
+        )
+        .await
+        .expect("attach");
+    let _ = fx
+        .wait_for_notification("conn-1", "scm/repositoriesChanged", before)
+        .await;
+
+    // Detach, wait for the removal.
+    let before = fx.frame_count();
+    fx.service
+        .remove_attached("system_default_user", &row.pe_id)
+        .await
+        .expect("detach");
+    let _ = fx
+        .wait_for_notification("conn-1", "scm/repositoriesChanged", before)
+        .await;
+
+    // Re-attach the same folder (a fresh entry, hence a fresh repo_id) and confirm
+    // it re-appears rather than staying released.
+    let before = fx.frame_count();
+    let row2 = fx
+        .service
+        .attach_folder(
+            "system_default_user",
+            AttachInput {
+                project_id: fx.project_id.clone(),
+                uri,
+                display_name: None,
+            },
+        )
+        .await
+        .expect("re-attach");
+    let repo_id2 = format!("scm:{}", row2.pe_id);
+    let params = fx
+        .wait_for_notification("conn-1", "scm/repositoriesChanged", before)
+        .await;
+    let added: Vec<&str> = params["added"]
+        .as_array()
+        .expect("added present on re-attach")
+        .iter()
+        .filter_map(|r| r["repo_id"].as_str())
+        .collect();
+    assert!(
+        added.contains(&repo_id2.as_str()),
+        "the re-added repository re-appears: {params}"
+    );
+}
+
+/// Interest is released when a connection drops: a session that listed a project
+/// then disconnected must not keep receiving its `repositoriesChanged` frames.
+///
+/// A second, still-connected session proves the change actually fired, so the
+/// disconnected one's silence is conclusive rather than a race. The single-
+/// consumer actor processes the `Disconnect` before the attach's `RootsChanged`
+/// (both enter one FIFO channel, disconnect first), so interest is already gone
+/// by the time the recompute fans out. Removing the drop_session interest cleanup
+/// turns this red (the dead session receives the frame).
+#[tokio::test]
+async fn repositories_changed_stops_after_the_session_disconnects() {
+    let fx = fixture().await;
+    // conn-1 and conn-2 both register interest by listing the project.
+    let _ = fx
+        .call_as(
+            "conn-1",
+            1,
+            "scm/listRepositories",
+            json!({ "project_id": fx.project_id }),
+        )
+        .await;
+    let _ = fx
+        .call_as(
+            "conn-2",
+            2,
+            "scm/listRepositories",
+            json!({ "project_id": fx.project_id }),
+        )
+        .await;
+
+    // conn-1 drops.
+    fx.disconnect("conn-1");
+
+    // A repository is attached: the change must reach the still-connected conn-2
+    // and never the dropped conn-1.
+    let second_dir = tempfile::tempdir().expect("tempdir");
+    init_committed_repo(second_dir.path());
+    let before = fx.frame_count();
+    fx.service
+        .attach_folder(
+            "system_default_user",
+            AttachInput {
+                project_id: fx.project_id.clone(),
+                uri: to_file_uri(second_dir.path()).expect("uri"),
+                display_name: None,
+            },
+        )
+        .await
+        .expect("attach");
+
+    // conn-2 receives it (this also proves the recompute ran)...
+    let _ = fx
+        .wait_for_notification("conn-2", "scm/repositoriesChanged", before)
+        .await;
+    // ...and conn-1, disconnected, never did.
+    assert!(
+        !fx.pushed_to("conn-1", "scm/repositoriesChanged"),
+        "a disconnected session must not keep receiving repositoriesChanged"
+    );
+}
+
+/// A folder whose directory basename is blank (literally named "   ") must not
+/// yield a blank label. The derived `default_display_name` has to filter blanks
+/// the same way the scm seam does, or `display_name || default_display_name ||
+/// pe_id` renders whitespace. Reverting `build_folder_dto` to a non-trim filter
+/// turns this red — which is also what proves the defect was real.
+#[tokio::test]
+async fn a_blank_basename_folder_does_not_become_a_blank_label() {
+    let fx = fixture().await;
+
+    // A git repo whose own directory name is three spaces.
+    let base = tempfile::tempdir().expect("tempdir");
+    let blank_dir = base.path().join("   ");
+    std::fs::create_dir(&blank_dir).expect("mkdir blank");
+    init_committed_repo(&blank_dir);
+
+    let row = fx
+        .service
+        .attach_folder(
+            "system_default_user",
+            AttachInput {
+                project_id: fx.project_id.clone(),
+                uri: to_file_uri(&blank_dir).expect("uri"),
+                display_name: None,
+            },
+        )
+        .await
+        .expect("attach");
+
+    let listed = fx
+        .call(90, "scm/listRepositories", json!({ "project_id": fx.project_id }))
+        .await;
+    let repos = listed["result"]["repositories"].as_array().expect("repositories");
+    let repo = repos
+        .iter()
+        .find(|r| r["root"]["pe_id"] == json!(row.pe_id))
+        .unwrap_or_else(|| panic!("the attached repo is listed: {listed}"));
+    let label = repo["label"].as_str().expect("label present");
+    assert!(
+        !label.trim().is_empty(),
+        "a whitespace-basename folder must not yield a blank label, got {label:?}"
+    );
 }
 
 /// Silence the unused-field warnings for handles kept only to own their lifetime.

--- a/crates/aionui-project/tests/scm_request_path.rs
+++ b/crates/aionui-project/tests/scm_request_path.rs
@@ -1,0 +1,341 @@
+//! Source-control request-path tests.
+//!
+//! These go through the actor, not the provider, because the behaviour under test
+//! belongs to the seam between them: the orchestration layer resolves a reference
+//! and the engine consumes the result. A provider-level test cannot show whether
+//! the path that was authorized is the path that got used.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use aionui_db::{Database, IProjectStore, SqliteProjectStore, init_database_memory};
+use aionui_project::ProjectService;
+use aionui_project::canonical::to_file_uri;
+use aionui_project::scm::{ScmActor, ScmInbound, ScmWirePush};
+use serde_json::{Value, json};
+use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
+
+/// Collects the frames the actor pushes, so a test can read its replies.
+struct CollectingPush {
+    sent: std::sync::Mutex<Vec<Value>>,
+}
+
+impl ScmWirePush for CollectingPush {
+    fn push(&self, _session: &str, frame: Value) {
+        self.sent.lock().expect("push sink poisoned").push(frame);
+    }
+}
+
+/// A project with one attached repository, plus a live actor over it.
+struct Fixture {
+    _db: Database,
+    _repo_dir: tempfile::TempDir,
+    push: Arc<CollectingPush>,
+    inbound: tokio::sync::mpsc::UnboundedSender<ScmInbound>,
+    pe_id: String,
+    project_id: String,
+}
+
+async fn fixture() -> Fixture {
+    let db = init_database_memory().await.expect("db");
+    let store: Arc<dyn IProjectStore> = Arc::new(SqliteProjectStore::new(db.pool().clone()));
+    let service = Arc::new(ProjectService::new(Arc::clone(&store), std::env::temp_dir()));
+
+    // A real repository with a file one directory deep, so `dir/sub/../file`-style
+    // spellings have something to resolve against.
+    let repo_dir = tempfile::tempdir().expect("tempdir");
+    let repo = git2::Repository::init(repo_dir.path()).expect("init repo");
+    {
+        let mut cfg = repo.config().expect("config");
+        cfg.set_str("user.name", "scm test").expect("name");
+        cfg.set_str("user.email", "scm@test.local").expect("email");
+    }
+    std::fs::create_dir_all(repo_dir.path().join("dir").join("sub")).expect("mkdir");
+    std::fs::write(repo_dir.path().join("dir").join("file.txt"), "content\n").expect("write");
+    std::fs::write(repo_dir.path().join("dir").join("sub").join("other.txt"), "x\n").expect("write");
+    let mut index = repo.index().expect("index");
+    index
+        .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+        .expect("add");
+    index.write().expect("write index");
+    let tree = repo.find_tree(index.write_tree().expect("tree")).expect("find tree");
+    let sig = repo.signature().expect("sig");
+    repo.commit(Some("HEAD"), &sig, &sig, "base", &tree, &[])
+        .expect("commit");
+    // Binding it as a project creates the explorer entry we need, so there is
+    // nothing further to attach.
+    let created = service
+        .create_standard("system_default_user", to_file_uri(repo_dir.path()).expect("uri"))
+        .await
+        .expect("create project");
+    let pe_id = created.project_explorer.pe_id.clone();
+    let project_id = created.project.project_id.clone();
+
+    let push = Arc::new(CollectingPush {
+        sent: std::sync::Mutex::new(Vec::new()),
+    });
+    let actor = ScmActor::new(Arc::clone(&service), Arc::clone(&push) as Arc<dyn ScmWirePush>).expect("actor");
+    let (inbound, inbound_rx) = unbounded_channel();
+    tokio::spawn(actor.run(inbound_rx));
+
+    Fixture {
+        _db: db,
+        _repo_dir: repo_dir,
+        push,
+        inbound,
+        pe_id,
+        project_id,
+    }
+}
+
+impl Fixture {
+    /// Send one request and wait for the actor's reply.
+    async fn call(&self, id: u64, method: &str, params: Value) -> Value {
+        let before = self.push.sent.lock().expect("sink").len();
+        self.inbound
+            .send(ScmInbound::Frame {
+                session: "conn-1".to_owned(),
+                user_id: "system_default_user".to_owned(),
+                frame: json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params }),
+            })
+            .expect("actor alive");
+
+        // Bounded wait: the reply is asynchronous, and a fixed sleep would either
+        // be slow or flaky.
+        for _ in 0..200 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            let sent = self.push.sent.lock().expect("sink");
+            if let Some(frame) = sent
+                .iter()
+                .skip(before)
+                .find(|f| f.get("id").and_then(Value::as_u64) == Some(id))
+            {
+                return frame.clone();
+            }
+        }
+        panic!("no reply for {method} within the deadline");
+    }
+
+    async fn repo_id(&self) -> String {
+        let listed = self
+            .call(1, "scm/listRepositories", json!({ "project_id": self.project_id }))
+            .await;
+        listed["result"]["repositories"][0]["repo_id"]
+            .as_str()
+            .unwrap_or_else(|| panic!("no repository discovered: {listed}"))
+            .to_owned()
+    }
+}
+
+/// Spellings of one path that all denote `dir/file.txt`. Containment accepts every
+/// one of them, so all of them reach the engine — and the engine treats them
+/// differently, which is why the orchestration layer must normalize first.
+const EQUIVALENT_SPELLINGS: &[&str] = &[
+    "dir/file.txt",
+    "dir/./file.txt",
+    "dir/sub/../file.txt",
+    "./dir/file.txt",
+];
+
+/// Every spelling of the same file must read the same content, at every anchor.
+///
+/// Before the orchestration layer passed on its normalized path, these diverged:
+/// one spelling silently returned "nothing" for the staged anchor, another failed
+/// to match at all, and a leading `./` reached a library call that rejects such
+/// paths — surfacing as an opaque internal failure rather than a result.
+#[tokio::test]
+async fn every_spelling_of_a_path_reads_the_same_content_at_every_anchor() {
+    let fx = fixture().await;
+    let repo_id = fx.repo_id().await;
+
+    for anchor in ["working", "committed", "staged"] {
+        let mut answers = Vec::new();
+        for spelling in EQUIVALENT_SPELLINGS {
+            let reply = fx
+                .call(
+                    10,
+                    "scm/original",
+                    json!({
+                        "repository": repo_id,
+                        "file": { "pe_id": fx.pe_id, "relative_path": spelling },
+                        "at": anchor,
+                    }),
+                )
+                .await;
+            assert!(
+                reply.get("error").is_none(),
+                "anchor {anchor} rejected {spelling:?}: {reply}"
+            );
+            answers.push((*spelling, reply["result"]["content"].as_str().map(str::to_owned)));
+        }
+
+        let (_, first) = &answers[0];
+        assert!(
+            first.is_some(),
+            "the plain spelling reads content at {anchor}: {answers:?}"
+        );
+        for (spelling, content) in &answers {
+            assert_eq!(
+                content, first,
+                "{spelling:?} must read the same content as the plain spelling at {anchor}: {answers:?}"
+            );
+        }
+    }
+}
+
+/// A leading `./` used to reach a library call that rejects it outright, so the
+/// request came back as an internal failure. It must simply work.
+#[tokio::test]
+async fn a_leading_dot_slash_is_normalized_rather_than_reaching_the_engine() {
+    let fx = fixture().await;
+    let repo_id = fx.repo_id().await;
+
+    let reply = fx
+        .call(
+            20,
+            "scm/original",
+            json!({
+                "repository": repo_id,
+                "file": { "pe_id": fx.pe_id, "relative_path": "./dir/file.txt" },
+                "at": "staged",
+            }),
+        )
+        .await;
+
+    assert!(reply.get("error").is_none(), "no failure for a `./` spelling: {reply}");
+    assert_eq!(
+        reply["result"]["content"].as_str(),
+        Some("content\n"),
+        "and it resolves to the real file: {reply}"
+    );
+}
+
+/// The same normalization must apply to actions, and to **every** entry in a
+/// batch — not just the first one.
+#[tokio::test]
+async fn staging_normalizes_every_entry_in_the_batch() {
+    let fx = fixture().await;
+    let repo_id = fx.repo_id().await;
+
+    // Two files, each named in a form the engine would not match verbatim.
+    std::fs::write(fx._repo_dir.path().join("dir").join("file.txt"), "edited\n").expect("edit");
+    std::fs::write(
+        fx._repo_dir.path().join("dir").join("sub").join("other.txt"),
+        "edited\n",
+    )
+    .expect("edit");
+
+    let reply = fx
+        .call(
+            30,
+            "scm/stage",
+            json!({
+                "repository": repo_id,
+                "files": [
+                    { "pe_id": fx.pe_id, "relative_path": "./dir/file.txt" },
+                    { "pe_id": fx.pe_id, "relative_path": "dir/sub/./other.txt" },
+                ],
+            }),
+        )
+        .await;
+
+    assert!(reply.get("error").is_none(), "the batch is accepted: {reply}");
+    assert!(
+        reply["result"]["failed"].is_null(),
+        "and every entry succeeded — a batch must normalize all of them, not only the first: {reply}"
+    );
+
+    // Confirm against the repository itself: both files are staged.
+    let status = fx.call(31, "scm/status", json!({ "repository": repo_id })).await;
+    let staged: Vec<&str> = status["result"]["resources"]
+        .as_array()
+        .expect("resources")
+        .iter()
+        .filter(|r| r["staged"].as_bool() == Some(true))
+        .filter_map(|r| r["repo_relative_path"].as_str())
+        .collect();
+    assert!(
+        staged.contains(&"dir/file.txt") && staged.contains(&"dir/sub/other.txt"),
+        "both files are staged under their normalized paths, got {staged:?}"
+    );
+}
+
+/// Escaping the root is still refused — normalizing must not become a way in.
+#[tokio::test]
+async fn a_path_escaping_the_root_is_still_refused() {
+    let fx = fixture().await;
+    let repo_id = fx.repo_id().await;
+
+    for escape in ["../outside.txt", "dir/../../outside.txt"] {
+        let reply = fx
+            .call(
+                40,
+                "scm/original",
+                json!({
+                    "repository": repo_id,
+                    "file": { "pe_id": fx.pe_id, "relative_path": escape },
+                    "at": "working",
+                }),
+            )
+            .await;
+        assert!(reply.get("error").is_some(), "{escape:?} must be refused, got {reply}");
+    }
+}
+
+/// Silence the unused-field warnings for handles kept only to own their lifetime.
+#[allow(dead_code)]
+fn _lifetimes_are_owned(_: &Fixture, _: &UnboundedReceiver<ScmInbound>, _: PathBuf) {}
+
+/// Subscribing to several repositories reports per repository, like the multi-file
+/// actions do.
+///
+/// The point is agreement about state: the server arms a watch and records a
+/// subscriber for each one that works. Failing the whole call would hide those from
+/// the client, which would then never unsubscribe them and would receive pushes for
+/// repositories it does not believe it subscribed to.
+#[tokio::test]
+async fn subscribing_reports_per_repository_and_keeps_the_ones_that_worked() {
+    let fx = fixture().await;
+    let good = fx.repo_id().await;
+
+    let reply = fx
+        .call(
+            50,
+            "scm/subscribe",
+            json!({ "repositories": [good, "scm:does-not-exist"] }),
+        )
+        .await;
+
+    assert!(
+        reply.get("error").is_none(),
+        "one bad entry must not fail the whole request: {reply}"
+    );
+    let statuses = reply["result"]["statuses"].as_array().expect("statuses");
+    assert_eq!(statuses.len(), 1, "the good repository is subscribed: {reply}");
+    assert_eq!(statuses[0]["repository"]["repo_id"].as_str(), Some(good.as_str()));
+
+    let failed = reply["result"]["failed"].as_array().expect("failed listed");
+    assert_eq!(failed.len(), 1, "and the bad one is reported: {reply}");
+    assert_eq!(failed[0]["repo_id"].as_str(), Some("scm:does-not-exist"));
+    assert!(
+        failed[0]["reason"].as_str().is_some_and(|r| !r.is_empty()),
+        "with a reason to show: {reply}"
+    );
+}
+
+/// When every repository subscribes, the frame is exactly what it was before
+/// per-item reporting existed — a client that ignores `failed` is unaffected.
+#[tokio::test]
+async fn a_fully_successful_subscribe_omits_the_failure_list() {
+    let fx = fixture().await;
+    let good = fx.repo_id().await;
+
+    let reply = fx.call(60, "scm/subscribe", json!({ "repositories": [good] })).await;
+
+    assert!(reply.get("error").is_none(), "{reply}");
+    assert_eq!(reply["result"]["statuses"].as_array().expect("statuses").len(), 1);
+    assert!(
+        reply["result"]["failed"].is_null(),
+        "no `failed` key when nothing failed: {reply}"
+    );
+}

--- a/crates/aionui-project/tests/service.rs
+++ b/crates/aionui-project/tests/service.rs
@@ -648,3 +648,64 @@ async fn resolve_chat_file_ref_project_variant_rejects_missing_and_escaping_path
         err.code()
     );
 }
+
+/// A case-only difference in a folder path resolves to one repository identity on
+/// a case-insensitive filesystem — the premise the source-control roots diff
+/// relies on when it keys by `repo_id` (= `scm:{pe_id}`) instead of by path.
+///
+/// Load-bearing: if path canonicalization stopped folding case, the variant would
+/// mint a second folder — hence a second `pe_id`, hence a second `repo_id` — for
+/// one physical directory, and the diff would report a phantom add/remove. This
+/// test goes red in exactly that case on macOS / Windows.
+#[tokio::test]
+async fn a_case_variant_folder_resolves_to_one_repo_identity() {
+    use aionui_project::canonical::IGNORE_PATH_CASING;
+
+    let base = tempfile::tempdir().unwrap();
+    // A real mixed-case directory, and a case-only variant that denotes the same
+    // directory on macOS / Windows and a different (non-existent) one on Linux.
+    let real = base.path().join("RepoRoot");
+    std::fs::create_dir(&real).unwrap();
+    let variant = base.path().join("reporoot");
+
+    let (svc, _db) = service().await;
+    let created = svc.create_standard("system_default_user", uri_of(&real)).await.unwrap();
+    let project_id = created.project.project_id;
+    let ws_pe = created.project_explorer.pe_id;
+
+    let second = svc
+        .attach_folder(
+            "system_default_user",
+            AttachInput {
+                project_id: project_id.clone(),
+                uri: uri_of(&variant),
+                display_name: None,
+            },
+        )
+        .await;
+
+    if IGNORE_PATH_CASING {
+        // Same physical directory: the variant folds to the workspace root's
+        // canonical identity and is refused as a duplicate, never added as a
+        // second entry. One directory => one pe_id => one repo_id.
+        assert_eq!(
+            second.unwrap_err().code(),
+            "project_explorer_duplicate",
+            "a case variant of the same dir must dedup to one identity"
+        );
+        let detail = svc.get_project("system_default_user", &project_id).await.unwrap();
+        assert_eq!(detail.explorer.entries.len(), 1, "no second entry was created");
+        assert_eq!(
+            detail.explorer.entries[0].pe_id, ws_pe,
+            "the one entry is the workspace root"
+        );
+    } else {
+        // Case-sensitive filesystem: the variant path genuinely does not exist,
+        // so it is rejected before any identity question — correctly two dirs.
+        assert_eq!(
+            second.unwrap_err().code(),
+            "folder_not_found",
+            "on a case-sensitive fs the variant path does not exist"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Project-Explorer source control, backend. This branch is two commits ahead of `main`: the source-control backend base (`feat(scm): add source-control backend with capability-neutral provider`) plus this round's live repository-set changes.

Pairs with frontend PR #3894 (multi-repo switch / `pe_name` display / dark-mode + a `project_id` guard on the client's `applyRepositoriesChanged`). Backend side of that pair: `pe_name` on the wire, `repositoriesChanged` push (direct-wired), `repo_id` canonicalization test, clippy.

## What's here

- **`pe_name`**: carry each explorer entry's own name on the repository wire beside the derived `label`. Blank (empty/whitespace) names collapse to `None`, so the client's `pe_name || label` never renders whitespace. The `label` fallback and the folder's default name apply the same trim — pinning "label is never blank" as a backend contract.
- **`scm/repositoriesChanged` (direct wiring, no event bus)**: pushed when a project's attached-folder set changes. The project service notifies the scm actor directly — source control is the sole subscriber, so a general bus is not worth it (revisit if a second appears). The frame carries `project_id` so a client holding one store across projects can filter; `user_id` stays internal, never on the wire. Interest is per-session (registered on `listRepositories`, session-persistent, released only on disconnect); the frame fans out only to interested connections. The repository set is diffed by `repo_id`, not path (case-insensitive filesystems make path comparison unsound), and removed repositories are released (watch dropped, state and provider entry forgotten).
- **`repo_id` canonicalization**: tests pinning that a case-only path difference resolves to one `repo_id` on case-insensitive filesystems — the premise the diff relies on.
- **clippy**: `.filter(..).next_back()` → `.rfind(..)`.

## Testing

- `cargo test -p aionui-project`: lib 317 / scm_request_path 15 / service 27 — all pass.
- Full pre-push gate (`just push`): 8343 passed, 0 failed, 24 skipped.
- `clippy -D warnings` clean (aionui-project / aionui-ai-agent / aionui-app); `fmt --all --check` clean.
- New/updated tests include adversarial-review fixes: session-disconnect interest cleanup (no push to a dead session) and blank-basename label fallback — both mutation-verified.