### PR TITLE
docs: refresh architecture crate catalog

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,7 +39,7 @@ and aionui-common has zero internal dependencies.
 
 ## Crate Hierarchy
 
-The project is organized as a Cargo workspace with 20 crates across four layers:
+The project is organized as a Cargo workspace with 24 crates across four layers:
 
 ### Foundation
 
@@ -52,6 +52,7 @@ Depended on by nearly all other crates. Changes require careful impact assessmen
 | `aionui-db` | SQLite database layer, defines Repository traits and implementations |
 | `aionui-assets` | Embedded static assets (agent metadata, prompts) |
 | `aionui-runtime` | Managed Node, subprocess spawning, PATH enhancement |
+| `aionui-process` | Supervised subprocess lifecycle, containment, and startup cleanup for direct CLI sessions |
 
 ### Capability
 
@@ -69,10 +70,13 @@ Each crate owns an independent business domain. They remain loosely coupled from
 | Crate | Responsibility |
 |-------|----------------|
 | `aionui-conversation` | Conversation management, messaging, confirmations, streaming responses |
+| `aionui-session` | Unified session state, capabilities, commands, and events across direct CLI and ACP backends |
 | `aionui-channel` | Multi-channel integration (WeChat, DingTalk, Lark), plugin system, pairing sessions |
 | `aionui-team` | Team collaboration, task scheduling, mailbox system |
+| `aionui-team-prompts` | Shared team role prompts, governance rules, and tool authorization metadata |
 | `aionui-cron` | Scheduled job execution, cron expressions, event triggering |
 | `aionui-file` | File operations, watching, snapshots, git operations, compression |
+| `aionui-project` | Project/folder bindings, Project Explorer, filesystem monitoring, and resource containment |
 | `aionui-office` | Office document handling (Excel, PPT, Word), preview, conversion |
 | `aionui-system` | System settings, provider management, version checking, model fetching |
 | `aionui-mcp` | MCP protocol integration, OAuth, multi-platform adapters |
@@ -255,6 +259,20 @@ Note: JSON field names use camelCase (via `#[serde(rename_all = "camelCase")]`).
 or three-level naming (e.g., `team.agent.status`). These are historical artifacts.
 New events must follow the two-level camelCase convention above.
 Existing inconsistencies will be unified incrementally during related module iterations.
+
+### ACP Tool Output Sanitization
+
+ACP agent tool-call events enter the unified `AgentStreamEvent` stream through
+the `aionui-ai-agent` translation boundary. That boundary keeps WebSocket and
+SQLite message payloads bounded instead of forwarding large binary or inline
+base64 results unchanged.
+
+For example, Codex image generation may return both `saved_path` and PNG/JPEG/WebP
+base64 in `raw_output.result`. Before forwarding and persistence, the translation
+layer removes the inline `result` while retaining small structured fields such as
+`saved_path`, `image.path`, `result_omitted`, and `result_bytes`. When the image is
+already stored on disk, the tool status is normalized to `completed`. Clients load
+the image from its file path on demand and must not depend on inline base64.
 
 ## Data Layer
 

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -39,7 +39,7 @@ aionui-common 没有任何内部依赖。
 
 ## Crate 层级
 
-项目采用 Cargo workspace 组织，共 20 个 crate，分为四层：
+项目采用 Cargo workspace 组织，共 24 个 crate，分为四层：
 
 ### 基础层（Foundation）
 
@@ -52,6 +52,7 @@ aionui-common 没有任何内部依赖。
 | `aionui-db` | SQLite 数据库层，定义 Repository trait 和实现 |
 | `aionui-assets` | 嵌入式静态资源（Agent 元数据、提示词） |
 | `aionui-runtime` | 托管 Node、子进程管理、PATH 增强 |
+| `aionui-process` | 直连 CLI 会话的子进程监管、隔离和启动清理 |
 
 ### 能力层（Capability）
 
@@ -69,10 +70,13 @@ aionui-common 没有任何内部依赖。
 | Crate | 职责 |
 |-------|------|
 | `aionui-conversation` | 对话管理、消息收发、确认机制、流式响应 |
+| `aionui-session` | 统一直连 CLI 与 ACP 后端的会话状态、能力、命令和事件 |
 | `aionui-channel` | 多渠道集成（微信、钉钉、飞书）、插件系统、配对会话 |
 | `aionui-team` | 团队协作、任务调度、邮箱系统 |
+| `aionui-team-prompts` | 团队角色提示词、治理规则和工具授权元数据 |
 | `aionui-cron` | 定时任务执行、Cron 表达式、事件触发 |
 | `aionui-file` | 文件操作、监听、快照、Git 操作、压缩 |
+| `aionui-project` | 项目/文件夹绑定、项目浏览器、文件系统监听和资源边界校验 |
 | `aionui-office` | Office 文档处理（Excel、PPT、Word）、预览、转换 |
 | `aionui-system` | 系统设置、提供商管理、版本检查、模型获取 |
 | `aionui-mcp` | MCP 协议集成、OAuth、多平台适配器 |

--- a/crates/aionui-system/src/sysinfo.rs
+++ b/crates/aionui-system/src/sysinfo.rs
@@ -131,6 +131,9 @@ mod tests {
     #[test]
     fn test_env_override_log_dir() {
         let dir = resolve_log_dir();
-        assert!(dir.contains("aionui"), "log_dir should contain 'aionui': {dir}");
+        assert!(
+            dir.to_ascii_lowercase().contains("aionui"),
+            "log_dir should contain 'aionui' (case-insensitive): {dir}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- update the documented workspace size from 20 to 24 crates
- add the missing process, session, team prompts, and project crates to both architecture guides
- align the English architecture guide with the existing ACP tool-output sanitization documentation
- make the macOS log-directory test accept the platform's canonical `AionUi` capitalization

## Validation

- `just push -u origin docs/refresh-docs-20260806`
- 8,198 tests passed; 24 skipped
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- documentation link scan passed
- rendered Markdown and Playwright DOM checks passed