### PR TITLE
fix(mcp): honour deferred flag from transport_config

### DIFF
--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -501,6 +501,11 @@ async fn row_to_mcp_server_config(
     let value: serde_json::Value =
         serde_json::from_str(&row.transport_config).map_err(|e| format!("invalid transport_config JSON: {e}"))?;
 
+    // Whether this server's tools are sent to the LLM as name-only stubs, to be
+    // loaded on demand via ToolSearch. Absent key preserves the previous
+    // behaviour (all schemas eager); an explicit `true` opts the server in.
+    let deferred = value.get("deferred").and_then(|v| v.as_bool()).unwrap_or(false);
+
     match row.transport_type.as_str() {
         "stdio" => {
             let command = value
@@ -531,7 +536,7 @@ async fn row_to_mcp_server_config(
                 env: Some(env),
                 url: None,
                 headers: None,
-                deferred: Some(false),
+                deferred: Some(deferred),
                 startup_timeout_ms: None,
             })
         }
@@ -557,7 +562,7 @@ async fn row_to_mcp_server_config(
                 env: None,
                 url: Some(url.to_owned()),
                 headers: Some(headers),
-                deferred: Some(false),
+                deferred: Some(deferred),
                 startup_timeout_ms: None,
             })
         }
@@ -583,7 +588,7 @@ async fn row_to_mcp_server_config(
                 env: None,
                 url: Some(url.to_owned()),
                 headers: Some(headers),
-                deferred: Some(false),
+                deferred: Some(deferred),
                 startup_timeout_ms: None,
             })
         }
@@ -1016,6 +1021,34 @@ mod tests {
             config.args.as_ref(),
             Some(&vec!["-y".to_owned(), "@upstash/context7-mcp".to_owned()])
         );
+    }
+
+    #[tokio::test]
+    async fn row_to_mcp_server_config_defaults_deferred_to_false() {
+        let row = make_row("docs", "http", r#"{"url":"https://example.test/mcp"}"#, true, false);
+
+        let config = row_to_mcp_server_config(&row, "user-row", "conv-row", test_broadcaster())
+            .await
+            .expect("convert");
+
+        assert_eq!(config.deferred, Some(false));
+    }
+
+    #[tokio::test]
+    async fn row_to_mcp_server_config_honours_explicit_deferred() {
+        let row = make_row(
+            "docs",
+            "http",
+            r#"{"url":"https://example.test/mcp","deferred":true}"#,
+            true,
+            false,
+        );
+
+        let config = row_to_mcp_server_config(&row, "user-row", "conv-row", test_broadcaster())
+            .await
+            .expect("convert");
+
+        assert_eq!(config.deferred, Some(true));
     }
 
     struct ProviderMappingCase<'a> {


### PR DESCRIPTION
Fixes #793.

## Problem

`ToolSearch` can never return a result. `crates/aion-tools/src/tool_search.rs` filters on `.filter(|d| d.deferred)`, but every MCP server is built with `deferred: Some(false)`, so the set is always empty — while `aionrs` still registers `ToolSearchTool` unconditionally (`crates/aion-agent/src/bootstrap.rs:361`) and the system prompt still tells the model that deferred tools exist.

Models that follow that instruction loop on it. Measured across ~20 sessions on 2.1.50: glm-5.2 made **204 ToolSearch calls for 17 real tool calls**; gpt-5.5 made 0.

`aionrs` supports the flag per server (`McpServerConfig::deferred`, defaulting to `true` when omitted) and honours it in `crates/aion-mcp/src/tool_proxy.rs:135`. The capability is fully implemented in the engine — the host just never lets a value through.

## Change

Read `deferred` from the same `transport_config` JSON that `command` / `args` / `env` / `url` / `headers` already come from:

```rust
let deferred = value.get("deferred").and_then(|v| v.as_bool()).unwrap_or(false);
```

and use it in the three `McpServerConfig` constructions inside `row_to_mcp_server_config`.

- **No default change.** An absent key still yields `false`, so current behaviour is byte-identical for every existing server. Nothing is opted in implicitly.
- **Scoped deliberately.** Only `row_to_mcp_server_config` (DB-configured servers). `session_server_to_mcp_server_config` takes a typed transport enum with nowhere to carry the flag, and `team_mcp_to_config` is an internal server where non-deferred looks intentional — both left untouched.

## Tests

Two added next to the existing `row_to_mcp_server_config` test:

- `row_to_mcp_server_config_defaults_deferred_to_false` — absent key stays `false`
- `row_to_mcp_server_config_honours_explicit_deferred` — `"deferred": true` comes through

## Why it matters

With this, an operator can defer large MCP servers so their tools become name-only stubs retrievable through `ToolSearch`, instead of every schema entering the system prompt on every turn. On a deployment with ~1,300 tools across 12 servers, that is the difference between a subset being reachable and all of them.

## Note

I don't have a Rust toolchain on this machine, so this has **not been compiled or tested locally** — the diff is mechanical and the tests reuse the existing `make_row` / `test_broadcaster` helpers, but please let CI confirm. Happy to adjust scope (e.g. plumb the flag through the session/team paths too) if you'd prefer.
