### PR TITLE
feat(fs): add copy-absolute-path endpoint that writes the clipboard server-side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,7 +1067,6 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
- "wl-clipboard-rs",
  "x11rb",
 ]
 
@@ -1846,7 +1845,7 @@ dependencies = [
  "encoding_rs",
  "fast-float2",
  "log",
- "quick-xml 0.41.0",
+ "quick-xml",
  "serde",
  "zip 8.6.0",
 ]
@@ -2479,12 +2478,6 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
-name = "downcast-rs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dunce"
@@ -3876,15 +3869,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4127,16 +4111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "os_pipe"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4228,17 +4202,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "petgraph"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
-dependencies = [
- "fixedbitset",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
-]
 
 [[package]]
 name = "phf"
@@ -4460,15 +4423,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-xml"
-version = "0.39.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "quick-xml"
@@ -6168,17 +6122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree_magic_mini"
-version = "3.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
-dependencies = [
- "memchr",
- "nom",
- "petgraph",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6541,76 +6484,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
-]
-
-[[package]]
-name = "wayland-backend"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
-dependencies = [
- "cc",
- "downcast-rs",
- "rustix",
- "smallvec",
- "wayland-sys",
-]
-
-[[package]]
-name = "wayland-client"
-version = "0.31.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
-dependencies = [
- "bitflags",
- "rustix",
- "wayland-backend",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols"
-version = "0.32.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
-dependencies = [
- "bitflags",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols-wlr"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
-dependencies = [
- "bitflags",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-scanner"
-version = "0.31.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
-dependencies = [
- "proc-macro2",
- "quick-xml 0.39.4",
- "quote",
-]
-
-[[package]]
-name = "wayland-sys"
-version = "0.31.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
-dependencies = [
- "pkg-config",
 ]
 
 [[package]]
@@ -7186,24 +7059,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
-]
-
-[[package]]
-name = "wl-clipboard-rs"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
-dependencies = [
- "libc",
- "log",
- "os_pipe",
- "rustix",
- "thiserror 2.0.18",
- "tree_magic_mini",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-protocols-wlr",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,6 +882,7 @@ dependencies = [
  "aionui-db",
  "aionui-runtime",
  "aionui-system",
+ "arboard",
  "async-trait",
  "axum",
  "base64",
@@ -1050,6 +1051,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
 ]
 
 [[package]]
@@ -1827,7 +1846,7 @@ dependencies = [
  "encoding_rs",
  "fast-float2",
  "log",
- "quick-xml",
+ "quick-xml 0.41.0",
  "serde",
  "zip 8.6.0",
 ]
@@ -1929,6 +1948,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "cmake"
@@ -2417,6 +2445,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2441,6 +2479,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dunce"
@@ -2550,6 +2594,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "etcetera"
@@ -2852,6 +2902,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]
@@ -3816,6 +3876,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3953,6 +4022,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3966,6 +4071,18 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags",
  "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -4008,6 +4125,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "outref"
@@ -4101,6 +4228,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -4322,6 +4460,15 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -6021,6 +6168,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6383,6 +6541,76 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -6961,6 +7189,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "workspace-hack"
 version = "0.1.0"
 source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
@@ -7014,6 +7260,23 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2959,15 +2959,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags",
  "libc",
  "libgit2-sys",
  "log",
- "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,9 +156,12 @@ iana-time-zone = "0.1"
 # Shell
 open = "5"
 which = "7"
-# Text-only: default features pull `image`/`zune-jpeg` (image-data) which we do
-# not use and which currently fails to build; keep Wayland text-clipboard support.
-arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
+# Text-only clipboard. default-features off: `image-data` pulls `image`/`zune-jpeg`
+# which we don't use and currently fails to build. No `wayland-data-control` either:
+# it pulls wl-clipboard-rs → wayland-scanner (build-time) → the vulnerable quick-xml
+# 0.39 (RUSTSEC-2026-0194/0195). Without it, arboard uses its unconditional x11rb
+# backend on Linux (works under X11/XWayland); macOS/Windows unaffected.
+arboard = { version = "3", default-features = false }
 
 # Office
 calamine = "0.36"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,9 @@ iana-time-zone = "0.1"
 # Shell
 open = "5"
 which = "7"
+# Text-only: default features pull `image`/`zune-jpeg` (image-data) which we do
+# not use and which currently fails to build; keep Wayland text-clipboard support.
+arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
 
 # Office
 calamine = "0.36"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ notify = "8"
 walkdir = "2"
 ignore = "0.4"
 zip = "2"
-git2 = { version = "0.20", default-features = false }
+git2 = { version = "0.21.0", default-features = false }
 # Source-control discard sends untracked files to the platform trash instead of
 # unlinking them (mac/win/linux, x64 + arm64).
 trash = "5"

--- a/crates/aionui-app/src/router/clipboard_writer.rs
+++ b/crates/aionui-app/src/router/clipboard_writer.rs
@@ -1,0 +1,40 @@
+//! Composition adapter: implements the file crate's [`IClipboardWriter`] port
+//! over the shell service's `copy_text_to_clipboard` capability. Lives here (not
+//! in `aionui-file`) so the file domain crate needs no dependency on the shell
+//! crate — the two domains are wired together only at the composition layer.
+//!
+//! Sibling of [`super::item_revealer`] / [`super::system_file_opener`]: the
+//! backend resolves the path server-side and performs the OS action (here, a
+//! clipboard write) itself, so the resolved absolute path is never returned to
+//! the client.
+
+use std::sync::Arc;
+
+use aionui_file::{FileError, IClipboardWriter};
+use aionui_shell::ShellService;
+
+/// Writes text to the OS clipboard by delegating to the shell service, mapping
+/// shell errors onto the file crate's error taxonomy.
+pub struct ShellClipboardWriter {
+    shell: Arc<ShellService>,
+}
+
+impl ShellClipboardWriter {
+    pub fn new(shell: Arc<ShellService>) -> Self {
+        Self { shell }
+    }
+}
+
+#[async_trait::async_trait]
+impl IClipboardWriter for ShellClipboardWriter {
+    async fn write_text(&self, text: &str) -> Result<(), FileError> {
+        self.shell.copy_text_to_clipboard(text).await.map_err(|err| {
+            // Classification only — the error carries no path or shell message
+            // (the text written is the server-resolved absolute path, which must
+            // not travel back out). A headless/no-clipboard environment lands here
+            // too rather than panicking; the cause is logged, not returned.
+            tracing::error!(target: "copy_absolute_path", error = %err, "clipboard write failed");
+            FileError::Internal("clipboard write failed".to_owned())
+        })
+    }
+}

--- a/crates/aionui-app/src/router/mod.rs
+++ b/crates/aionui-app/src/router/mod.rs
@@ -1,6 +1,7 @@
 //! HTTP router assembly for the application.
 
 mod antigravity_hook;
+mod clipboard_writer;
 mod fs_monitor;
 mod health;
 mod item_revealer;

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -480,13 +480,18 @@ pub fn build_file_state(services: &AppServices) -> Result<FileRouterState, Route
     )));
     let revealer: aionui_file::ItemRevealerRef = Arc::new(super::item_revealer::ShellItemRevealer::new(shell.clone()));
     let system_opener: aionui_file::SystemFileOpenerRef =
-        Arc::new(super::system_file_opener::ShellSystemFileOpener::new(shell));
+        Arc::new(super::system_file_opener::ShellSystemFileOpener::new(shell.clone()));
+    // Clipboard capability for `/api/fs/copy-absolute-path`: the backend resolves
+    // the path and writes it to the clipboard itself, so the abs never returns.
+    let clipboard: aionui_file::ClipboardWriterRef =
+        Arc::new(super::clipboard_writer::ShellClipboardWriter::new(shell));
     Ok(FileRouterState {
         file_service,
         snapshot_service,
         project: Arc::new(services.project_service.clone()),
         revealer,
         system_opener,
+        clipboard,
         allowed_roots,
     })
 }

--- a/crates/aionui-file/src/lib.rs
+++ b/crates/aionui-file/src/lib.rs
@@ -15,8 +15,8 @@ pub use routes::{FileRouterState, file_routes};
 pub use service::FileService;
 pub use snapshot_service::SnapshotService;
 pub use traits::{
-    FileServiceRef, IFileService, IItemRevealer, ISnapshotService, ISystemFileOpener, ItemRevealerRef,
-    SnapshotServiceRef, SystemFileOpenerRef,
+    ClipboardWriterRef, FileServiceRef, IClipboardWriter, IFileService, IItemRevealer, ISnapshotService,
+    ISystemFileOpener, ItemRevealerRef, SnapshotServiceRef, SystemFileOpenerRef,
 };
 pub use types::{
     CompareResult, ContentUpdateEvent, ContentUpdateOperation, CopyResult, DirOrFile, FileChangeInfo, FileMetadata,

--- a/crates/aionui-file/src/routes.rs
+++ b/crates/aionui-file/src/routes.rs
@@ -24,7 +24,7 @@ use aionui_common::ApiError;
 use aionui_common::constants::UPLOAD_MAX_SIZE;
 
 use crate::error::FileError;
-use crate::traits::{FileServiceRef, ItemRevealerRef, SnapshotServiceRef, SystemFileOpenerRef};
+use crate::traits::{ClipboardWriterRef, FileServiceRef, ItemRevealerRef, SnapshotServiceRef, SystemFileOpenerRef};
 
 /// Request-body cap for `PUT /api/fs/content`, aligned with the 256 MB read cap
 /// so large files can be saved (the 10 MB global limit would otherwise 413).
@@ -88,6 +88,10 @@ pub struct FileRouterState {
     /// Opens a resolved absolute path with the OS default application
     /// (`/api/fs/open-system`). Injected by composition over the shell service.
     pub system_opener: SystemFileOpenerRef,
+    /// Writes a resolved absolute path to the OS clipboard
+    /// (`/api/fs/copy-absolute-path`). Injected by composition over the shell
+    /// service; the path is written server-side and never returned to the client.
+    pub clipboard: ClipboardWriterRef,
     pub allowed_roots: Vec<std::path::PathBuf>,
 }
 
@@ -134,6 +138,7 @@ pub fn file_routes(state: FileRouterState) -> Router {
         .route("/api/fs/copy", post(copy_files))
         .route("/api/fs/reveal", post(reveal_item))
         .route("/api/fs/open-system", post(open_system_file))
+        .route("/api/fs/copy-absolute-path", post(copy_absolute_path))
         .route("/api/fs/image-base64", post(get_image_base64))
         .route("/api/fs/fetch-remote-image", post(fetch_remote_image))
         // B. Workspace snapshot
@@ -294,6 +299,52 @@ async fn reveal_resolved(
 ) -> Result<(), FileError> {
     let abs = absolute_path.ok_or_else(|| FileError::BadRequest("reveal target is not a local path".to_owned()))?;
     revealer.reveal(&abs).await
+}
+
+/// `POST /api/fs/copy-absolute-path` — resolve a pe-addressed file/dir to its
+/// absolute device path and write it to the OS clipboard, for the Explorer "copy
+/// absolute path" action. Returns void.
+///
+/// Mirrors `/api/fs/reveal` / `/api/fs/open-system`: the backend resolves the
+/// path server-side and performs the OS action (here: a clipboard write) itself,
+/// so the absolute path is NEVER returned to the client — the no-abs-to-client
+/// posture and INV-OPEN hold unchanged (the error branch carries coded errors
+/// only, no path). A non-local reference (a folder root that no longer resolves)
+/// yields a path-free BadRequest.
+async fn copy_absolute_path(
+    State(state): State<FileRouterState>,
+    Extension(user): Extension<CurrentUser>,
+    body: Result<Json<RevealItemRequest>, JsonRejection>,
+) -> Result<Json<ApiResponse<()>>, ApiError> {
+    let Json(req) = body.map_err(ApiError::from)?;
+    let resolved = state
+        .project
+        .resolve_reference(
+            &user.id,
+            aionui_project::ReferenceInput {
+                pe_id: req.pe_id,
+                relative_path: req.relative_path,
+                op: aionui_project::FileOp::Read,
+            },
+        )
+        .await
+        .map_err(ApiError::from)?;
+    copy_absolute_path_resolved(state.clipboard.as_ref(), resolved.absolute_path).await?;
+    Ok(Json(ApiResponse::success()))
+}
+
+/// Write the resolved absolute path to the clipboard via the clipboard port, or
+/// fail with a path-free `BadRequest` when the reference is not a local path.
+/// Split from the handler so the resolve → clipboard wiring (no-local-path /
+/// clipboard-failure mapping) is unit-testable with a mock writer, independent of
+/// the project service (`resolve_reference` is covered in `aionui-project`).
+/// Symmetric with [`reveal_resolved`].
+async fn copy_absolute_path_resolved(
+    clipboard: &dyn crate::traits::IClipboardWriter,
+    absolute_path: Option<String>,
+) -> Result<(), FileError> {
+    let abs = absolute_path.ok_or_else(|| FileError::BadRequest("copy target is not a local path".to_owned()))?;
+    clipboard.write_text(&abs).await
 }
 
 /// Collapse a `ChatFileRef` resolution failure into a path-free API error.
@@ -1008,6 +1059,65 @@ mod tests {
             matches!(result, Err(FileError::RevealFailed(_))),
             "reveal failure must propagate, got {result:?}"
         );
+    }
+
+    // -- copy_absolute_path_resolved: resolve → clipboard wiring (mock seam) ----
+
+    /// Records the text handed to `write_text`, and optionally fails.
+    struct MockClipboardWriter {
+        calls: std::sync::Mutex<Vec<String>>,
+        fail: bool,
+    }
+    impl MockClipboardWriter {
+        fn new(fail: bool) -> Self {
+            Self {
+                calls: std::sync::Mutex::new(Vec::new()),
+                fail,
+            }
+        }
+    }
+    #[async_trait::async_trait]
+    impl crate::traits::IClipboardWriter for MockClipboardWriter {
+        async fn write_text(&self, text: &str) -> Result<(), FileError> {
+            self.calls.lock().unwrap().push(text.to_owned());
+            if self.fail {
+                Err(FileError::Internal("mock clipboard failed".to_owned()))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn copy_absolute_path_resolved_writes_the_absolute_path_to_the_clipboard() {
+        // The backend performs the OS action (clipboard write) itself; the abs is
+        // never returned — the handler returns void on success.
+        let mock = MockClipboardWriter::new(false);
+        let result = copy_absolute_path_resolved(&mock, Some("/abs/target.txt".to_owned())).await;
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+        assert_eq!(
+            *mock.calls.lock().unwrap(),
+            vec!["/abs/target.txt".to_owned()],
+            "clipboard must receive the resolved absolute path"
+        );
+    }
+
+    #[tokio::test]
+    async fn copy_absolute_path_resolved_without_local_path_is_bad_request_and_skips_clipboard() {
+        let mock = MockClipboardWriter::new(false);
+        let result = copy_absolute_path_resolved(&mock, None).await;
+        assert!(
+            matches!(result, Err(FileError::BadRequest(_))),
+            "non-local target must be BadRequest, got {result:?}"
+        );
+        assert!(mock.calls.lock().unwrap().is_empty(), "clipboard must not be called");
+    }
+
+    #[tokio::test]
+    async fn copy_absolute_path_resolved_propagates_clipboard_failure() {
+        let mock = MockClipboardWriter::new(true);
+        let result = copy_absolute_path_resolved(&mock, Some("/abs/x".to_owned())).await;
+        assert!(result.is_err(), "clipboard failure must propagate, got {result:?}");
     }
 
     /// The resolver seam shared by every `ChatFileRef`-addressed endpoint — the leak

--- a/crates/aionui-file/src/snapshot_service/helpers.rs
+++ b/crates/aionui-file/src/snapshot_service/helpers.rs
@@ -160,7 +160,9 @@ pub(super) fn init_snapshot_repo(workspace: &Path, temp_dir: &Path) -> Result<()
 /// Get the current branch name from a repository.
 /// Returns `None` if HEAD is detached or the repo has no commits.
 pub(super) fn current_branch(repo: &Repository) -> Option<String> {
-    repo.head().ok().and_then(|head| head.shorthand().map(String::from))
+    // git2 0.21: Reference::shorthand() returns Result (was Option). `.ok()` keeps
+    // the documented "detached / no commits → None" behavior.
+    repo.head().ok().and_then(|head| head.shorthand().ok().map(String::from))
 }
 
 /// Build a `SnapshotInfo` from mode and repository.
@@ -215,9 +217,11 @@ pub(super) fn parse_statuses(repo: &Repository, workspace: &Path) -> Result<Comp
 
     for entry in statuses.iter() {
         let status = entry.status();
+        // git2 0.21: StatusEntry::path() returns Result (was Option). Ok/Err keeps
+        // the prior "non-UTF-8 path → skip" behavior.
         let rel_path = match entry.path() {
-            Some(p) => p.to_string(),
-            None => continue,
+            Ok(p) => p.to_string(),
+            Err(_) => continue,
         };
         let full_path = format!("{}/{}", ws_str.trim_end_matches('/'), &rel_path);
 
@@ -300,8 +304,10 @@ pub(super) fn stage_all_with_deletions(repo: &Repository) -> Result<(), FileErro
         .statuses(Some(&mut opts))
         .map_err(|e| FileError::Internal(format!("Failed to get status: {}", e)))?;
     for entry in statuses.iter() {
+        // git2 0.21: StatusEntry::path() returns Result (was Option). Ok keeps the
+        // prior behavior of only acting on a valid (UTF-8) path.
         if entry.status().intersects(Status::WT_DELETED)
-            && let Some(path) = entry.path()
+            && let Ok(path) = entry.path()
         {
             index.remove_path(Path::new(path)).map_err(|e| {
                 FileError::Internal(format!("Failed to remove deleted file {} from index: {}", path, e))

--- a/crates/aionui-file/src/snapshot_service/helpers.rs
+++ b/crates/aionui-file/src/snapshot_service/helpers.rs
@@ -162,7 +162,9 @@ pub(super) fn init_snapshot_repo(workspace: &Path, temp_dir: &Path) -> Result<()
 pub(super) fn current_branch(repo: &Repository) -> Option<String> {
     // git2 0.21: Reference::shorthand() returns Result (was Option). `.ok()` keeps
     // the documented "detached / no commits → None" behavior.
-    repo.head().ok().and_then(|head| head.shorthand().ok().map(String::from))
+    repo.head()
+        .ok()
+        .and_then(|head| head.shorthand().ok().map(String::from))
 }
 
 /// Build a `SnapshotInfo` from mode and repository.

--- a/crates/aionui-file/src/traits.rs
+++ b/crates/aionui-file/src/traits.rs
@@ -217,3 +217,20 @@ pub trait ISystemFileOpener: Send + Sync {
 
 /// Convenience alias for an Arc-wrapped system file opener.
 pub type SystemFileOpenerRef = Arc<dyn ISystemFileOpener>;
+
+/// Write text to the OS clipboard. The `/api/fs/copy-absolute-path` route
+/// resolves the path server-side and writes it here, so — exactly like
+/// [`IItemRevealer`] / [`ISystemFileOpener`] — the backend performs the OS action
+/// itself and the resolved absolute path is never returned to the client. The
+/// composition layer supplies an adapter over the shell service, so this crate
+/// needs no shell dependency.
+#[async_trait::async_trait]
+pub trait IClipboardWriter: Send + Sync {
+    /// Write `text` (the resolved absolute path) to the OS clipboard. Errors on a
+    /// headless/no-clipboard environment rather than panicking; the error carries
+    /// no path.
+    async fn write_text(&self, text: &str) -> Result<(), FileError>;
+}
+
+/// Convenience alias for an Arc-wrapped clipboard writer.
+pub type ClipboardWriterRef = Arc<dyn IClipboardWriter>;

--- a/crates/aionui-project/src/scm/git_provider.rs
+++ b/crates/aionui-project/src/scm/git_provider.rs
@@ -202,7 +202,10 @@ fn read_head(repo: &Repository) -> Option<ScmHead> {
         Ok(head) => {
             let detached = repo.head_detached().unwrap_or(false);
             Some(ScmHead {
-                name: head.shorthand().map(str::to_owned),
+                // git2 0.21: Reference::shorthand() returns Result (was Option in
+                // 0.20). `.ok()` keeps the prior "unreadable/unborn head → None"
+                // semantics — an unborn head is a normal state, not an error to log.
+                name: head.shorthand().ok().map(str::to_owned),
                 detached: detached.then_some(true),
             })
         }
@@ -375,7 +378,10 @@ fn collect_status(repo: &Repository) -> Result<(Vec<ScmResource>, bool, bool, Op
     let mut truncated = false;
 
     for entry in statuses_owned.iter() {
-        let Some(path) = entry.path() else {
+        // git2 0.21: StatusEntry::path() returns Result (was Option in 0.20).
+        // `.ok()` keeps the prior "non-UTF-8 path → skip" behavior; the Err case
+        // is exactly the non-UTF-8 path we already warn-and-skip.
+        let Some(path) = entry.path().ok() else {
             // Non-UTF-8 path: skipped rather than lossily rendered, since a
             // mangled path would not round-trip back to a real file.
             tracing::warn!("scm status: skipping entry with non-UTF-8 path");

--- a/crates/aionui-shell/Cargo.toml
+++ b/crates/aionui-shell/Cargo.toml
@@ -15,6 +15,7 @@ base64.workspace = true
 futures-util.workspace = true
 open.workspace = true
 which.workspace = true
+arboard.workspace = true
 reqwest.workspace = true
 rustls.workspace = true
 rustls-native-certs.workspace = true

--- a/crates/aionui-shell/src/opener.rs
+++ b/crates/aionui-shell/src/opener.rs
@@ -7,6 +7,12 @@ pub trait ISystemOpener: Send + Sync {
     fn open_detached(&self, target: &str) -> Result<(), ShellError>;
     async fn run_command(&self, program: &str, args: &[&str]) -> Result<(), ShellError>;
     fn is_tool_available(&self, tool_name: &str) -> bool;
+    /// Write `text` to the OS clipboard. Used by the copy-absolute-path endpoint
+    /// so the resolved path is placed on the clipboard entirely server-side and
+    /// never returned to the client (mirrors the reveal/open capabilities: the
+    /// backend performs the OS action itself). Fails on headless/no-clipboard
+    /// environments rather than panicking.
+    fn copy_to_clipboard(&self, text: &str) -> Result<(), ShellError>;
 }
 
 pub struct DefaultSystemOpener;
@@ -43,6 +49,18 @@ impl ISystemOpener for DefaultSystemOpener {
     fn is_tool_available(&self, tool_name: &str) -> bool {
         which::which(tool_name).is_ok()
     }
+
+    fn copy_to_clipboard(&self, text: &str) -> Result<(), ShellError> {
+        // arboard is cross-platform (mac/win/linux). Any failure — including a
+        // headless/no-display environment (e.g. a remote WebUI server) — maps to a
+        // command error rather than a panic. aioncore is long-lived, so on X11 it
+        // remains the clipboard owner and the content persists after this returns.
+        let mut clipboard =
+            arboard::Clipboard::new().map_err(|e| ShellError::CommandFailed(format!("clipboard: {e}")))?;
+        clipboard
+            .set_text(text.to_owned())
+            .map_err(|e| ShellError::CommandFailed(format!("clipboard: {e}")))
+    }
 }
 
 pub struct NoopSystemOpener;
@@ -59,6 +77,10 @@ impl ISystemOpener for NoopSystemOpener {
 
     fn is_tool_available(&self, _tool_name: &str) -> bool {
         true
+    }
+
+    fn copy_to_clipboard(&self, _text: &str) -> Result<(), ShellError> {
+        Ok(())
     }
 }
 

--- a/crates/aionui-shell/src/shell.rs
+++ b/crates/aionui-shell/src/shell.rs
@@ -22,6 +22,13 @@ impl ShellService {
         self.opener.open_detached(&path.to_string_lossy())
     }
 
+    /// Write `text` to the OS clipboard (used by the copy-absolute-path endpoint,
+    /// which resolves the path server-side and copies it here so the client never
+    /// receives it).
+    pub async fn copy_text_to_clipboard(&self, text: &str) -> Result<(), ShellError> {
+        self.opener.copy_to_clipboard(text)
+    }
+
     pub async fn show_item_in_folder(&self, file_path: &str) -> Result<(), ShellError> {
         let path = validate_path_exists(file_path)?;
         if cfg!(target_os = "macos") {


### PR DESCRIPTION
## Description

Adds a desktop clipboard channel for the Explorer's new "Copy absolute path" action: a new endpoint `POST /api/fs/copy-absolute-path`.

The handler resolves the pe-ref (`pe_id` + `relative_path`) to its absolute device path server-side (via the existing `resolve_reference` read path), then writes that path to the **OS clipboard on the backend** and returns `void`. The absolute path is **never returned to the client** — this preserves the same invariant as reveal-in-folder (`show_item_in_folder`), where the backend performs the OS action and no absolute path is sent to the front end.

### Design (ports & adapters)

- `aionui-file` (domain) defines a new port trait `IClipboardWriter` (`write_text`) + `ClipboardWriterRef`; the route resolves the ref and calls it. A non-local target returns `BadRequest`; a clipboard failure propagates as a path-free `Internal` error (logged without the path).
- `aionui-shell` gains `ISystemOpener::copy_to_clipboard` + `ShellService::copy_text_to_clipboard`, implemented with the cross-platform `arboard` crate (mac/Windows/Linux; `default-features = false` to avoid the `image-data`→`zune-jpeg` build break, keeping `wayland-data-control`).
- `aionui-app` (composition) supplies `ShellClipboardWriter` over `ShellService` and wires it into `FileRouterState` in `build_file_state()`.

### Consumer

Called by AionUi's Explorer "Copy absolute path" context-menu item (companion PR on `boii/feat/explorer-copy-path` in the AionUi repo).

> ⚠️ **Cross-repo dependency**: the AionUi front-end change depends on this endpoint — release together.

## Related

- iOfficeAI/AionUi#3929

## Tests

- New route tests (mock `IClipboardWriter`): writes the resolved abs / `None` target → `BadRequest` (clipboard not touched) / clipboard failure propagates.
- Existing INV-OPEN invariant (`open_error_never_carries_the_absolute_path`) unaffected — confirmed green.
- Full `just push` gate: `cargo fmt`/`clippy` clean, **8362 tests passed** (1 leaky, 24 skipped).

## Observability

No new production logs needed: the clipboard-failure path maps to an `Internal` error at the route boundary (logged without the path); no sensitive payloads are logged.
