### PR TITLE
test(terminal): isolate default-cwd test with a private temp dir

### DIFF
--- a/crates/aionui-ai-agent/src/terminal.rs
+++ b/crates/aionui-ai-agent/src/terminal.rs
@@ -469,19 +469,22 @@ mod tests {
 
     #[tokio::test]
     async fn default_cwd_applies_when_agent_sends_none() {
-        let dir = std::env::temp_dir().join("aionui-term-cwd-test");
-        std::fs::create_dir_all(&dir).unwrap();
-        let reg = TerminalRegistry::new("conv-t", Some(dir.clone()));
+        // A private temp dir per run: the old fixed, shared path
+        // (`temp_dir()/aionui-term-cwd-test`) was raced by every parallel test
+        // process on the machine, which made this test flaky.
+        let dir = tempfile::TempDir::new().unwrap();
+        let reg = TerminalRegistry::new("conv-t", Some(dir.path().to_path_buf()));
         let id = reg.create(params("pwd", &[])).await.unwrap();
         reg.wait_for_exit(&id).await.unwrap();
         let snap = reg.output(&id).await.unwrap();
-        let canonical = std::fs::canonicalize(&dir).unwrap();
-        assert!(
-            snap.output
-                .trim()
-                .ends_with(canonical.file_name().unwrap().to_str().unwrap()),
-            "expected cwd {} in output: {}",
-            canonical.display(),
+        // `pwd` prints the resolved path (on macOS temp_dir lives under
+        // /var -> /private/var), so compare against the canonicalized full path
+        // rather than only the trailing directory name.
+        let canonical = std::fs::canonicalize(dir.path()).unwrap();
+        assert_eq!(
+            snap.output.trim(),
+            canonical.to_str().unwrap(),
+            "pwd should report the default cwd; output: {}",
             snap.output
         );
     }


### PR DESCRIPTION
## Summary

Fixes the flaky `default_cwd_applies_when_agent_sends_none` test in `crates/aionui-ai-agent/src/terminal.rs`. Test-only change; production logic untouched.

## Root cause

1. The test used a fixed, shared path — `std::env::temp_dir().join("aionui-term-cwd-test")` — so every parallel test process on the machine raced on the same directory. This is what tripped the #800 CI Test job once (green on rerun).
2. On macOS `temp_dir()` resolves under `/var/folders/...` (`/var` -> `/private/var`), so `pwd` prints the resolved path; the old assertion worked around this by canonicalizing and only comparing the trailing directory name, which is brittle.

## Fix

- Give the test its own unique `tempfile::TempDir` (already a dev-dependency) instead of the shared fixed path.
- Assert `pwd` output (trimmed) equals the full canonicalized path, dropping the `file_name().ends_with(...)` workaround.
- Test layout unchanged (inline `#[cfg(test)] mod tests`), no unrelated refactor.

## Testing

- `default_cwd_applies_when_agent_sends_none` run 5x in a row: all pass.
- `cargo test -p aionui-ai-agent`: 926 + integration suites all pass.
- `cargo fmt --all -- --check`: clean. `cargo clippy -p aionui-ai-agent -- -D warnings`: clean.
- `just push` full pre-push gate: workspace nextest 8362 passed (1 leaky), 24 skipped.