### PR TITLE
feat(channel): add Slack Socket Mode plugin

### DIFF
--- a/crates/aionui-app/Cargo.toml
+++ b/crates/aionui-app/Cargo.toml
@@ -9,11 +9,12 @@ name = "aioncore"
 path = "src/main.rs"
 
 [features]
-default = ["telegram", "lark", "dingtalk", "weixin"]
+default = ["telegram", "lark", "dingtalk", "weixin", "slack"]
 telegram = ["aionui-channel/telegram"]
 lark = ["aionui-channel/lark"]
 dingtalk = ["aionui-channel/dingtalk"]
 weixin = ["aionui-channel/weixin"]
+slack = ["aionui-channel/slack"]
 
 [dependencies]
 aionui-common.workspace = true

--- a/crates/aionui-channel/Cargo.toml
+++ b/crates/aionui-channel/Cargo.toml
@@ -9,6 +9,7 @@ telegram = ["dep:reqwest"]
 lark = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures-util", "dep:prost", "dep:rustls", "dep:rustls-native-certs"]
 dingtalk = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures-util", "dep:rustls", "dep:rustls-native-certs"]
 weixin = ["dep:reqwest", "dep:futures-util", "dep:base64", "dep:uuid"]
+slack = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures-util", "dep:rustls", "dep:rustls-native-certs"]
 
 [dependencies]
 aionui-common.workspace = true

--- a/crates/aionui-channel/src/constants.rs
+++ b/crates/aionui-channel/src/constants.rs
@@ -37,6 +37,9 @@ pub const LARK_MESSAGE_LIMIT: usize = 4000;
 /// Maximum characters per DingTalk message.
 pub const DINGTALK_MESSAGE_LIMIT: usize = 4000;
 
+/// Maximum characters per Slack message.
+pub const SLACK_MESSAGE_LIMIT: usize = 4000;
+
 // ---------------------------------------------------------------------------
 // Reconnection (Telegram long-polling)
 // ---------------------------------------------------------------------------
@@ -53,6 +56,13 @@ pub const TELEGRAM_MAX_RECONNECT_DELAY: Duration = Duration::from_secs(30);
 
 /// TTL for Lark event deduplication cache.
 pub const LARK_EVENT_DEDUP_TTL: Duration = Duration::from_secs(5 * 60);
+
+// ---------------------------------------------------------------------------
+// Slack
+// ---------------------------------------------------------------------------
+
+/// TTL for Slack event deduplication cache.
+pub const SLACK_EVENT_DEDUP_TTL: Duration = Duration::from_secs(5 * 60);
 
 // ---------------------------------------------------------------------------
 // DingTalk
@@ -130,6 +140,16 @@ mod tests {
     #[test]
     fn dingtalk_message_limit() {
         assert_eq!(DINGTALK_MESSAGE_LIMIT, 4000);
+    }
+
+    #[test]
+    fn slack_message_limit() {
+        assert_eq!(SLACK_MESSAGE_LIMIT, 4000);
+    }
+
+    #[test]
+    fn slack_event_dedup_ttl_is_five_minutes() {
+        assert_eq!(SLACK_EVENT_DEDUP_TTL, Duration::from_secs(300));
     }
 
     #[test]

--- a/crates/aionui-channel/src/formatter.rs
+++ b/crates/aionui-channel/src/formatter.rs
@@ -8,15 +8,40 @@ use crate::types::PluginType;
 ///
 /// - Telegram: escape HTML, then convert markdown → HTML tags
 /// - Lark/DingTalk: convert HTML tags → markdown
+/// - Slack: escape `&<>`, then convert markdown → Slack mrkdwn
 /// - WeChat/WeCom: strip all HTML
 /// - Fallback: escape HTML special chars
 pub fn format_text_for_platform(text: &str, platform: PluginType) -> String {
     match platform {
         PluginType::Telegram => markdown_to_telegram_html(text),
         PluginType::Lark | PluginType::Dingtalk => html_to_markdown(text),
+        PluginType::Slack => markdown_to_slack_mrkdwn(text),
         PluginType::Weixin => strip_html(text),
         _ => escape_html(text),
     }
+}
+
+// ── Slack (mrkdwn) ───────────────────────────────────────────────
+
+static RE_MD_LINK: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").unwrap());
+static RE_MD_BOLD_STAR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\*\*(.+?)\*\*").unwrap());
+static RE_MD_BOLD_UNDER: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"__(.+?)__").unwrap());
+static RE_MD_STRIKE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"~~(.+?)~~").unwrap());
+
+/// Convert standard markdown to Slack mrkdwn.
+///
+/// Slack requires `&`, `<`, `>` escaped in message text, uses single `*` for
+/// bold, single `~` for strikethrough, and `<url|text>` for links. Single-`*`
+/// italic is intentionally left untouched — converting it would clobber the
+/// bold delimiter, and rendering markdown italic as Slack bold is a harmless
+/// cosmetic difference.
+fn markdown_to_slack_mrkdwn(text: &str) -> String {
+    let s = escape_html(text);
+    let s = RE_MD_LINK.replace_all(&s, "<$2|$1>");
+    let s = RE_MD_BOLD_STAR.replace_all(&s, "*$1*");
+    let s = RE_MD_BOLD_UNDER.replace_all(&s, "*$1*");
+    let s = RE_MD_STRIKE.replace_all(&s, "~$1~");
+    s.into_owned()
 }
 
 // ── Telegram ─────────────────────────────────────────────────────
@@ -126,3 +151,7 @@ fn decode_all_entities(text: &str) -> String {
         .replace("&gt;", ">")
         .replace("&nbsp;", " ")
 }
+
+#[cfg(test)]
+#[path = "formatter_test.rs"]
+mod formatter_test;

--- a/crates/aionui-channel/src/formatter_test.rs
+++ b/crates/aionui-channel/src/formatter_test.rs
@@ -1,0 +1,46 @@
+use super::*;
+
+#[test]
+fn slack_escapes_special_chars() {
+    let out = format_text_for_platform("a < b & c > d", PluginType::Slack);
+    assert_eq!(out, "a &lt; b &amp; c &gt; d");
+}
+
+#[test]
+fn slack_converts_bold() {
+    assert_eq!(format_text_for_platform("**bold**", PluginType::Slack), "*bold*");
+    assert_eq!(format_text_for_platform("__bold__", PluginType::Slack), "*bold*");
+}
+
+#[test]
+fn slack_converts_strikethrough() {
+    assert_eq!(format_text_for_platform("~~gone~~", PluginType::Slack), "~gone~");
+}
+
+#[test]
+fn slack_converts_link() {
+    assert_eq!(
+        format_text_for_platform("[docs](https://example.com)", PluginType::Slack),
+        "<https://example.com|docs>"
+    );
+}
+
+#[test]
+fn slack_leaves_inline_code_untouched() {
+    assert_eq!(format_text_for_platform("`code`", PluginType::Slack), "`code`");
+}
+
+#[test]
+fn slack_combined() {
+    let out = format_text_for_platform("See **[link](https://x.io)** now", PluginType::Slack);
+    assert_eq!(out, "See *<https://x.io|link>* now");
+}
+
+// Regression guard: Slack must no longer fall through to the bare HTML-escape
+// branch (which left markdown bold/links unconverted).
+#[test]
+fn slack_not_plain_escape_fallback() {
+    let out = format_text_for_platform("**x**", PluginType::Slack);
+    assert_ne!(out, "**x**");
+    assert_eq!(out, "*x*");
+}

--- a/crates/aionui-channel/src/manager.rs
+++ b/crates/aionui-channel/src/manager.rs
@@ -1013,6 +1013,7 @@ mod tests {
                 client_secret: None,
                 account_id: None,
                 bot_token: None,
+                app_token: None,
                 extra: HashMap::new(),
             },
             config: None,

--- a/crates/aionui-channel/src/orchestrator.rs
+++ b/crates/aionui-channel/src/orchestrator.rs
@@ -6,7 +6,7 @@ use tracing::{error, info, warn};
 use crate::action::{ActionExecutor, MessageResult};
 use crate::message_service::ChannelMessageService;
 use crate::session::SessionManager;
-use crate::stream_relay::{ChannelSender, ChannelStreamRelay, RelayConfig};
+use crate::stream_relay::{ChannelSender, ChannelStreamRelay, RelayConfig, throttle_ms_for_platform};
 use crate::types::{ActionBehavior, OutgoingMessageType, UnifiedIncomingMessage, UnifiedOutgoingMessage};
 
 /// Orchestrates the full channel message lifecycle.
@@ -216,7 +216,7 @@ async fn handle_dispatched(
             platform,
             plugin_id: plugin_id.to_owned(),
             chat_id: chat_id.to_owned(),
-            throttle_ms: 500,
+            throttle_ms: throttle_ms_for_platform(platform),
         };
         let relay = ChannelStreamRelay::new(relay_config, Arc::clone(sender));
         tokio::spawn(relay.run(rx));

--- a/crates/aionui-channel/src/plugin.rs
+++ b/crates/aionui-channel/src/plugin.rs
@@ -181,6 +181,7 @@ mod tests {
                 client_secret: None,
                 account_id: None,
                 bot_token: None,
+                app_token: None,
                 extra: HashMap::new(),
             },
             config: None,

--- a/crates/aionui-channel/src/plugins/mod.rs
+++ b/crates/aionui-channel/src/plugins/mod.rs
@@ -10,6 +10,9 @@ pub mod dingtalk;
 #[cfg(feature = "weixin")]
 pub mod weixin;
 
+#[cfg(feature = "slack")]
+pub mod slack;
+
 use crate::plugin::ChannelPlugin;
 use crate::types::PluginType;
 
@@ -29,6 +32,9 @@ pub fn create_plugin(plugin_type: PluginType) -> Option<Box<dyn ChannelPlugin>> 
 
         #[cfg(feature = "weixin")]
         PluginType::Weixin => Some(Box::new(weixin::WeixinPlugin::new())),
+
+        #[cfg(feature = "slack")]
+        PluginType::Slack => Some(Box::new(slack::SlackPlugin::new())),
 
         #[allow(unreachable_patterns)]
         _ => None,

--- a/crates/aionui-channel/src/plugins/slack/api.rs
+++ b/crates/aionui-channel/src/plugins/slack/api.rs
@@ -1,0 +1,200 @@
+use std::time::Duration;
+
+use reqwest::Client;
+use reqwest::header::{HeaderMap, RETRY_AFTER};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use tracing::{debug, warn};
+
+use crate::error::ChannelError;
+
+use super::types::{
+    AuthTestResponse, OpenConnectionResponse, PostMessageRequest, PostMessageResponse, UpdateMessageRequest,
+    UpdateMessageResponse,
+};
+
+const SLACK_API_BASE: &str = "https://slack.com/api";
+
+/// Cap on how long we honor a Slack rate-limit `Retry-After` before giving up.
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(30);
+
+/// Parse Slack's `Retry-After` header (integer seconds) into a capped delay.
+fn parse_retry_after(headers: &HeaderMap) -> Option<Duration> {
+    headers
+        .get(RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .map(|secs| Duration::from_secs(secs.min(MAX_RETRY_AFTER.as_secs())))
+}
+
+/// Identity returned by `auth.test`.
+#[derive(Debug, Clone)]
+pub(super) struct SlackIdentity {
+    /// Bot user id (`Uxxxx`) — used to filter the bot's own messages and to
+    /// strip its `<@id>` mention from `app_mention` text.
+    pub user_id: String,
+    /// Human-readable bot name, when Slack returns one.
+    pub user: Option<String>,
+}
+
+/// HTTP client for the Slack Web API.
+///
+/// Holds both tokens: the bot token (`xoxb-`) authorizes Web API calls
+/// (`auth.test` / `chat.postMessage` / `chat.update`), while the app-level
+/// token (`xapp-`) authorizes only `apps.connections.open` for Socket Mode.
+pub(super) struct SlackApi {
+    client: Client,
+    bot_token: String,
+    app_token: String,
+}
+
+impl SlackApi {
+    pub fn new(client: Client, bot_token: &str, app_token: &str) -> Self {
+        Self {
+            client,
+            bot_token: bot_token.to_string(),
+            app_token: app_token.to_string(),
+        }
+    }
+
+    /// Validate the bot token and fetch the bot's identity (`auth.test`).
+    pub async fn auth_test(&self) -> Result<SlackIdentity, ChannelError> {
+        let url = format!("{SLACK_API_BASE}/auth.test");
+        let resp: AuthTestResponse = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.bot_token))
+            .send()
+            .await
+            .map_err(|e| ChannelError::ConnectionFailed(format!("Slack auth.test request failed: {e}")))?
+            .json()
+            .await
+            .map_err(|e| ChannelError::ConnectionFailed(format!("Slack auth.test parse failed: {e}")))?;
+
+        if !resp.ok {
+            let err = resp.error.unwrap_or_else(|| "unknown".into());
+            return Err(ChannelError::InvalidConfig(format!("Slack auth.test error: {err}")));
+        }
+
+        Ok(SlackIdentity {
+            user_id: resp.user_id.unwrap_or_default(),
+            user: resp.user,
+        })
+    }
+
+    /// Open a Socket Mode connection and return the WSS URL
+    /// (`apps.connections.open`, authorized by the app-level token).
+    pub async fn open_connection(&self) -> Result<String, ChannelError> {
+        let url = format!("{SLACK_API_BASE}/apps.connections.open");
+        let resp: OpenConnectionResponse = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.app_token))
+            .send()
+            .await
+            .map_err(|e| ChannelError::ConnectionFailed(format!("Slack apps.connections.open request failed: {e}")))?
+            .json()
+            .await
+            .map_err(|e| ChannelError::ConnectionFailed(format!("Slack apps.connections.open parse failed: {e}")))?;
+
+        if !resp.ok {
+            let err = resp.error.unwrap_or_else(|| "unknown".into());
+            return Err(ChannelError::ConnectionFailed(format!(
+                "Slack apps.connections.open error: {err}"
+            )));
+        }
+
+        resp.url
+            .ok_or_else(|| ChannelError::ConnectionFailed("Slack apps.connections.open returned no url".into()))
+    }
+
+    /// Post a message to a channel (`chat.postMessage`). Returns the message
+    /// `ts`, used as the message id for later edits.
+    pub async fn post_message(
+        &self,
+        channel: &str,
+        text: &str,
+        thread_ts: Option<&str>,
+    ) -> Result<String, ChannelError> {
+        let url = format!("{SLACK_API_BASE}/chat.postMessage");
+        let body = PostMessageRequest {
+            channel: channel.to_string(),
+            text: text.to_string(),
+            thread_ts: thread_ts.map(ToOwned::to_owned),
+        };
+
+        debug!(channel, "Slack chat.postMessage");
+
+        let resp: PostMessageResponse = self.post_json(&url, &body).await?;
+
+        if !resp.ok {
+            let err = resp.error.unwrap_or_else(|| "unknown".into());
+            return Err(ChannelError::MessageSendFailed(format!(
+                "Slack chat.postMessage error: {err}"
+            )));
+        }
+
+        resp.ts
+            .ok_or_else(|| ChannelError::MessageSendFailed("Slack chat.postMessage returned no ts".into()))
+    }
+
+    /// Edit an existing message (`chat.update`).
+    pub async fn update_message(&self, channel: &str, ts: &str, text: &str) -> Result<(), ChannelError> {
+        let url = format!("{SLACK_API_BASE}/chat.update");
+        let body = UpdateMessageRequest {
+            channel: channel.to_string(),
+            ts: ts.to_string(),
+            text: text.to_string(),
+        };
+
+        debug!(channel, ts, "Slack chat.update");
+
+        let resp: UpdateMessageResponse = self.post_json(&url, &body).await?;
+
+        if !resp.ok {
+            let err = resp.error.unwrap_or_else(|| "unknown".into());
+            return Err(ChannelError::MessageSendFailed(format!(
+                "Slack chat.update error: {err}"
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// POST a JSON body with the bot token and parse the response, retrying
+    /// once on HTTP 429 after honoring the `Retry-After` header.
+    async fn post_json<B, R>(&self, url: &str, body: &B) -> Result<R, ChannelError>
+    where
+        B: Serialize,
+        R: DeserializeOwned,
+    {
+        let mut resp = self.send_once(url, body).await?;
+        if resp.status().as_u16() == 429 {
+            let delay = parse_retry_after(resp.headers()).unwrap_or_else(|| Duration::from_secs(1));
+            warn!(
+                delay_secs = delay.as_secs(),
+                "Slack rate limited (429); retrying after Retry-After"
+            );
+            tokio::time::sleep(delay).await;
+            resp = self.send_once(url, body).await?;
+        }
+        resp.json::<R>()
+            .await
+            .map_err(|e| ChannelError::MessageSendFailed(format!("Slack response parse failed: {e}")))
+    }
+
+    /// Send a single authenticated POST with the bot token.
+    async fn send_once<B: Serialize>(&self, url: &str, body: &B) -> Result<reqwest::Response, ChannelError> {
+        self.client
+            .post(url)
+            .header("Authorization", format!("Bearer {}", self.bot_token))
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| ChannelError::MessageSendFailed(format!("Slack request failed: {e}")))
+    }
+}
+
+#[cfg(test)]
+#[path = "api_test.rs"]
+mod api_test;

--- a/crates/aionui-channel/src/plugins/slack/api_test.rs
+++ b/crates/aionui-channel/src/plugins/slack/api_test.rs
@@ -1,0 +1,55 @@
+use super::*;
+use reqwest::header::HeaderValue;
+
+// -- parse_retry_after -------------------------------------------------------
+
+fn headers_with_retry_after(value: &'static str) -> HeaderMap {
+    let mut h = HeaderMap::new();
+    h.insert(RETRY_AFTER, HeaderValue::from_static(value));
+    h
+}
+
+#[test]
+fn retry_after_parses_seconds() {
+    assert_eq!(
+        parse_retry_after(&headers_with_retry_after("3")),
+        Some(Duration::from_secs(3))
+    );
+}
+
+#[test]
+fn retry_after_caps_at_max() {
+    // 99s is clamped to the 30s cap.
+    assert_eq!(
+        parse_retry_after(&headers_with_retry_after("99")),
+        Some(Duration::from_secs(30))
+    );
+}
+
+#[test]
+fn retry_after_missing_is_none() {
+    assert_eq!(parse_retry_after(&HeaderMap::new()), None);
+}
+
+#[test]
+fn retry_after_non_numeric_is_none() {
+    assert_eq!(parse_retry_after(&headers_with_retry_after("soon")), None);
+}
+
+#[test]
+fn api_constructs_with_both_tokens() {
+    let client = Client::new();
+    let api = SlackApi::new(client, "xoxb-abc", "xapp-def");
+    assert_eq!(api.bot_token, "xoxb-abc");
+    assert_eq!(api.app_token, "xapp-def");
+}
+
+#[test]
+fn slack_identity_holds_user_id() {
+    let id = SlackIdentity {
+        user_id: "U0BOT".into(),
+        user: Some("aion".into()),
+    };
+    assert_eq!(id.user_id, "U0BOT");
+    assert_eq!(id.user.as_deref(), Some("aion"));
+}

--- a/crates/aionui-channel/src/plugins/slack/mod.rs
+++ b/crates/aionui-channel/src/plugins/slack/mod.rs
@@ -1,0 +1,6 @@
+mod api;
+mod plugin;
+mod socket;
+mod types;
+
+pub use plugin::SlackPlugin;

--- a/crates/aionui-channel/src/plugins/slack/plugin.rs
+++ b/crates/aionui-channel/src/plugins/slack/plugin.rs
@@ -1,0 +1,257 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::Client;
+use tokio::sync::{Mutex, watch};
+use tokio::task::JoinHandle;
+use tracing::info;
+
+use crate::constants::SLACK_MESSAGE_LIMIT;
+use crate::error::ChannelError;
+use crate::plugin::{ChannelPlugin, PluginCallbacks};
+use crate::types::{BotInfo, PluginConfig, PluginStatus, PluginType, UnifiedOutgoingMessage};
+
+use super::api::SlackApi;
+use super::socket::{DedupCache, cleanup_expired_events, socket_loop};
+
+/// Interval between dedup-cache cleanup sweeps.
+const DEDUP_CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Slack platform plugin (Socket Mode).
+///
+/// Connects to Slack over a Socket Mode WebSocket, receives `app_mention` and
+/// direct `message` events, and replies via the Web API (`chat.postMessage` /
+/// `chat.update`). Editing is supported, so streaming responses use the
+/// standard editable relay path.
+pub struct SlackPlugin {
+    // Lifecycle state
+    status: PluginStatus,
+    bot_info: Option<BotInfo>,
+    last_error: Option<String>,
+    /// Bot user id (`Uxxxx`) used to filter self-echoes and strip mentions.
+    bot_user_id: String,
+
+    // Dependencies (set during `initialize`)
+    api: Option<Arc<SlackApi>>,
+    callbacks: Option<PluginCallbacks>,
+
+    // Background tasks
+    ws_handle: Option<JoinHandle<()>>,
+    cleanup_handle: Option<JoinHandle<()>>,
+    shutdown_tx: Option<watch::Sender<bool>>,
+
+    /// Shared event-deduplication cache.
+    dedup_cache: DedupCache,
+}
+
+impl Default for SlackPlugin {
+    fn default() -> Self {
+        Self {
+            status: PluginStatus::Created,
+            bot_info: None,
+            last_error: None,
+            bot_user_id: String::new(),
+            api: None,
+            callbacks: None,
+            ws_handle: None,
+            cleanup_handle: None,
+            shutdown_tx: None,
+            dedup_cache: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl SlackPlugin {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait::async_trait]
+impl ChannelPlugin for SlackPlugin {
+    async fn initialize(&mut self, config: PluginConfig, callbacks: PluginCallbacks) -> Result<(), ChannelError> {
+        self.status = PluginStatus::Initializing;
+
+        let bot_token = config
+            .credentials
+            .token
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                self.status = PluginStatus::Error;
+                self.last_error = Some("Missing Slack bot token".into());
+                ChannelError::InvalidConfig("Missing Slack bot token (xoxb-)".into())
+            })?;
+
+        // App-level token (xapp-) authorizes the Socket Mode connection.
+        let app_token = config
+            .credentials
+            .app_token
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                self.status = PluginStatus::Error;
+                self.last_error = Some("Missing Slack app-level token".into());
+                ChannelError::InvalidConfig("Missing Slack app-level token (xapp-)".into())
+            })?;
+
+        let http_client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|e| {
+                self.status = PluginStatus::Error;
+                self.last_error = Some(format!("HTTP client init failed: {e}"));
+                ChannelError::ConnectionFailed(format!("HTTP client init failed: {e}"))
+            })?;
+
+        let api = Arc::new(SlackApi::new(http_client, bot_token, app_token));
+
+        // Validate the bot token and capture the bot identity.
+        let identity = api.auth_test().await.map_err(|e| {
+            self.status = PluginStatus::Error;
+            self.last_error = Some(format!("Credential validation failed: {e}"));
+            e
+        })?;
+
+        self.bot_user_id = identity.user_id.clone();
+        self.bot_info = Some(BotInfo {
+            id: identity.user_id,
+            username: identity.user.clone(),
+            display_name: identity.user.unwrap_or_else(|| "Slack Bot".into()),
+        });
+
+        info!(bot_user_id = %self.bot_user_id, "Slack bot initialized");
+
+        self.api = Some(api);
+        self.callbacks = Some(callbacks);
+        self.status = PluginStatus::Ready;
+        Ok(())
+    }
+
+    async fn start(&mut self) -> Result<(), ChannelError> {
+        self.status = PluginStatus::Starting;
+
+        let callbacks = self.callbacks.take().ok_or_else(|| {
+            self.status = PluginStatus::Error;
+            ChannelError::ConnectionFailed("Plugin not initialized".into())
+        })?;
+        // Slack MVP does not surface interactive tool confirmations; drop the
+        // confirm sender clone.
+        let PluginCallbacks {
+            message_tx,
+            confirm_tx: _,
+        } = callbacks;
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        self.shutdown_tx = Some(shutdown_tx);
+
+        let api = Arc::clone(self.api.as_ref().expect("api set in initialize"));
+        let bot_user_id = self.bot_user_id.clone();
+        let dedup_cache = Arc::clone(&self.dedup_cache);
+
+        self.ws_handle = Some(tokio::spawn(socket_loop(
+            api,
+            bot_user_id,
+            message_tx,
+            Arc::clone(&dedup_cache),
+            shutdown_rx,
+        )));
+
+        let mut cleanup_shutdown = self.shutdown_tx.as_ref().expect("shutdown_tx just set").subscribe();
+        self.cleanup_handle = Some(tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = tokio::time::sleep(DEDUP_CLEANUP_INTERVAL) => {
+                        cleanup_expired_events(&dedup_cache).await;
+                    }
+                    _ = cleanup_shutdown.changed() => break,
+                }
+            }
+        }));
+
+        self.status = PluginStatus::Running;
+        info!("Slack plugin started");
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<(), ChannelError> {
+        self.status = PluginStatus::Stopping;
+
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(true);
+        }
+
+        if let Some(handle) = self.ws_handle.take() {
+            let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+        }
+
+        if let Some(handle) = self.cleanup_handle.take() {
+            let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
+        }
+
+        self.api = None;
+        self.status = PluginStatus::Stopped;
+        info!("Slack plugin stopped");
+        Ok(())
+    }
+
+    async fn send_message(&self, chat_id: &str, message: UnifiedOutgoingMessage) -> Result<String, ChannelError> {
+        let api = self
+            .api
+            .as_ref()
+            .ok_or_else(|| ChannelError::PlatformApi("Plugin not initialized".into()))?;
+
+        let text = truncate_message(message.text.as_deref().unwrap_or(""), SLACK_MESSAGE_LIMIT);
+        api.post_message(chat_id, &text, message.reply_to_message_id.as_deref())
+            .await
+    }
+
+    async fn edit_message(
+        &self,
+        chat_id: &str,
+        message_id: &str,
+        message: UnifiedOutgoingMessage,
+    ) -> Result<(), ChannelError> {
+        let api = self
+            .api
+            .as_ref()
+            .ok_or_else(|| ChannelError::PlatformApi("Plugin not initialized".into()))?;
+
+        let text = truncate_message(message.text.as_deref().unwrap_or(""), SLACK_MESSAGE_LIMIT);
+        api.update_message(chat_id, message_id, &text).await
+    }
+
+    fn active_user_count(&self) -> usize {
+        0
+    }
+
+    fn bot_info(&self) -> Option<&BotInfo> {
+        self.bot_info.as_ref()
+    }
+
+    fn plugin_type(&self) -> PluginType {
+        PluginType::Slack
+    }
+
+    fn status(&self) -> PluginStatus {
+        self.status
+    }
+
+    fn last_error(&self) -> Option<&str> {
+        self.last_error.as_deref()
+    }
+}
+
+/// Truncate a message to the platform limit, appending "..." if truncated.
+fn truncate_message(text: &str, limit: usize) -> String {
+    if text.len() <= limit {
+        return text.to_string();
+    }
+    let truncated: String = text.chars().take(limit.saturating_sub(3)).collect();
+    format!("{truncated}...")
+}
+
+#[cfg(test)]
+#[path = "plugin_test.rs"]
+mod plugin_test;

--- a/crates/aionui-channel/src/plugins/slack/plugin.rs
+++ b/crates/aionui-channel/src/plugins/slack/plugin.rs
@@ -31,6 +31,9 @@ pub struct SlackPlugin {
     last_error: Option<String>,
     /// Bot user id (`Uxxxx`) used to filter self-echoes and strip mentions.
     bot_user_id: String,
+    /// Whether an app-level token (`xapp-`) was supplied. Required only to open
+    /// the Socket Mode connection in `start()`, not for the credential test.
+    app_token_present: bool,
 
     // Dependencies (set during `initialize`)
     api: Option<Arc<SlackApi>>,
@@ -52,6 +55,7 @@ impl Default for SlackPlugin {
             bot_info: None,
             last_error: None,
             bot_user_id: String::new(),
+            app_token_present: false,
             api: None,
             callbacks: None,
             ws_handle: None,
@@ -73,28 +77,25 @@ impl ChannelPlugin for SlackPlugin {
     async fn initialize(&mut self, config: PluginConfig, callbacks: PluginCallbacks) -> Result<(), ChannelError> {
         self.status = PluginStatus::Initializing;
 
-        let bot_token = config
-            .credentials
-            .token
-            .as_deref()
-            .filter(|s| !s.is_empty())
-            .ok_or_else(|| {
+        let bot_token = match require_bot_token(&config) {
+            Ok(token) => token,
+            Err(e) => {
                 self.status = PluginStatus::Error;
                 self.last_error = Some("Missing Slack bot token".into());
-                ChannelError::InvalidConfig("Missing Slack bot token (xoxb-)".into())
-            })?;
+                return Err(e);
+            }
+        };
 
-        // App-level token (xapp-) authorizes the Socket Mode connection.
+        // App-level token (xapp-) is optional here: it is only needed to open
+        // the Socket Mode connection in `start()`. The credential-test path
+        // sends the bot token alone, so requiring it here would break "Test".
         let app_token = config
             .credentials
             .app_token
             .as_deref()
             .filter(|s| !s.is_empty())
-            .ok_or_else(|| {
-                self.status = PluginStatus::Error;
-                self.last_error = Some("Missing Slack app-level token".into());
-                ChannelError::InvalidConfig("Missing Slack app-level token (xapp-)".into())
-            })?;
+            .unwrap_or("");
+        self.app_token_present = !app_token.is_empty();
 
         let http_client = Client::builder()
             .timeout(Duration::from_secs(30))
@@ -105,7 +106,7 @@ impl ChannelPlugin for SlackPlugin {
                 ChannelError::ConnectionFailed(format!("HTTP client init failed: {e}"))
             })?;
 
-        let api = Arc::new(SlackApi::new(http_client, bot_token, app_token));
+        let api = Arc::new(SlackApi::new(http_client, &bot_token, app_token));
 
         // Validate the bot token and capture the bot identity.
         let identity = api.auth_test().await.map_err(|e| {
@@ -131,6 +132,17 @@ impl ChannelPlugin for SlackPlugin {
 
     async fn start(&mut self) -> Result<(), ChannelError> {
         self.status = PluginStatus::Starting;
+
+        // The app-level token is mandatory to open the Socket Mode connection.
+        // Validated here (not in `initialize`) so the credential-test path can
+        // succeed with the bot token alone.
+        if !self.app_token_present {
+            self.status = PluginStatus::Error;
+            self.last_error = Some("Missing Slack app-level token".into());
+            return Err(ChannelError::InvalidConfig(
+                "Missing Slack app-level token (xapp-), required for Socket Mode".into(),
+            ));
+        }
 
         let callbacks = self.callbacks.take().ok_or_else(|| {
             self.status = PluginStatus::Error;
@@ -241,6 +253,22 @@ impl ChannelPlugin for SlackPlugin {
     fn last_error(&self) -> Option<&str> {
         self.last_error.as_deref()
     }
+}
+
+/// Validate that the Slack bot token (`xoxb-`) is present.
+///
+/// The app-level token (`xapp-`) is intentionally NOT required here: it is only
+/// needed to open the Socket Mode connection in `start()`. Requiring it during
+/// `initialize` would break the credential-test path, which sends the bot token
+/// alone.
+fn require_bot_token(config: &PluginConfig) -> Result<String, ChannelError> {
+    config
+        .credentials
+        .token
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| ChannelError::InvalidConfig("Missing Slack bot token (xoxb-)".into()))
 }
 
 /// Truncate a message to the platform limit, appending "..." if truncated.

--- a/crates/aionui-channel/src/plugins/slack/plugin_test.rs
+++ b/crates/aionui-channel/src/plugins/slack/plugin_test.rs
@@ -38,23 +38,49 @@ async fn initialize_missing_bot_token_fails() {
 }
 
 #[tokio::test]
-async fn initialize_missing_app_token_fails() {
-    let mut plugin = SlackPlugin::new();
-    let result = plugin
-        .initialize(make_config(Some("xoxb-1"), None), make_callbacks())
-        .await;
-    assert!(matches!(result, Err(ChannelError::InvalidConfig(_))));
-    assert_eq!(plugin.status(), PluginStatus::Error);
-    assert!(plugin.last_error().unwrap().contains("app-level token"));
-}
-
-#[tokio::test]
 async fn initialize_empty_bot_token_fails() {
     let mut plugin = SlackPlugin::new();
     let result = plugin
         .initialize(make_config(Some(""), Some("xapp-1")), make_callbacks())
         .await;
     assert!(matches!(result, Err(ChannelError::InvalidConfig(_))));
+}
+
+// -- require_bot_token: bot token required, app token optional ---------------
+// (app token is NOT required at config validation; it is only needed to open
+// Socket Mode in start(). This is the credential-test regression guard.)
+
+#[test]
+fn require_bot_token_accepts_bot_token_only() {
+    // No app_token supplied — the credential-test path — must still validate.
+    let cfg = make_config(Some("xoxb-1"), None);
+    assert_eq!(require_bot_token(&cfg).unwrap(), "xoxb-1");
+}
+
+#[test]
+fn require_bot_token_missing_is_err() {
+    let cfg = make_config(None, Some("xapp-1"));
+    assert!(matches!(require_bot_token(&cfg), Err(ChannelError::InvalidConfig(_))));
+}
+
+#[test]
+fn require_bot_token_empty_is_err() {
+    let cfg = make_config(Some(""), Some("xapp-1"));
+    assert!(matches!(require_bot_token(&cfg), Err(ChannelError::InvalidConfig(_))));
+}
+
+// -- start() requires the app-level token ------------------------------------
+
+#[tokio::test]
+async fn start_without_app_token_fails() {
+    // A fresh plugin has app_token_present == false (as it would after an
+    // initialize that received only the bot token). start() must reject it
+    // before opening any connection.
+    let mut plugin = SlackPlugin::new();
+    let result = plugin.start().await;
+    assert!(matches!(result, Err(ChannelError::InvalidConfig(_))));
+    assert_eq!(plugin.status(), PluginStatus::Error);
+    assert!(plugin.last_error().unwrap().contains("app-level token"));
 }
 
 // -- accessors / defaults ----------------------------------------------------

--- a/crates/aionui-channel/src/plugins/slack/plugin_test.rs
+++ b/crates/aionui-channel/src/plugins/slack/plugin_test.rs
@@ -1,0 +1,92 @@
+use super::*;
+use crate::types::PluginCredentials;
+use serde_json::json;
+use tokio::sync::mpsc;
+
+fn make_config(bot_token: Option<&str>, app_token: Option<&str>) -> PluginConfig {
+    let mut obj = serde_json::Map::new();
+    if let Some(t) = bot_token {
+        obj.insert("token".into(), json!(t));
+    }
+    if let Some(a) = app_token {
+        obj.insert("app_token".into(), json!(a));
+    }
+    let credentials: PluginCredentials = serde_json::from_value(serde_json::Value::Object(obj)).unwrap();
+    PluginConfig {
+        credentials,
+        config: None,
+    }
+}
+
+fn make_callbacks() -> PluginCallbacks {
+    let (message_tx, _mr) = mpsc::channel(4);
+    let (confirm_tx, _cr) = mpsc::channel(4);
+    PluginCallbacks { message_tx, confirm_tx }
+}
+
+// -- initialize bad paths (validated before any network call) ----------------
+
+#[tokio::test]
+async fn initialize_missing_bot_token_fails() {
+    let mut plugin = SlackPlugin::new();
+    let result = plugin
+        .initialize(make_config(None, Some("xapp-1")), make_callbacks())
+        .await;
+    assert!(matches!(result, Err(ChannelError::InvalidConfig(_))));
+    assert_eq!(plugin.status(), PluginStatus::Error);
+    assert!(plugin.last_error().unwrap().contains("bot token"));
+}
+
+#[tokio::test]
+async fn initialize_missing_app_token_fails() {
+    let mut plugin = SlackPlugin::new();
+    let result = plugin
+        .initialize(make_config(Some("xoxb-1"), None), make_callbacks())
+        .await;
+    assert!(matches!(result, Err(ChannelError::InvalidConfig(_))));
+    assert_eq!(plugin.status(), PluginStatus::Error);
+    assert!(plugin.last_error().unwrap().contains("app-level token"));
+}
+
+#[tokio::test]
+async fn initialize_empty_bot_token_fails() {
+    let mut plugin = SlackPlugin::new();
+    let result = plugin
+        .initialize(make_config(Some(""), Some("xapp-1")), make_callbacks())
+        .await;
+    assert!(matches!(result, Err(ChannelError::InvalidConfig(_))));
+}
+
+// -- accessors / defaults ----------------------------------------------------
+
+#[test]
+fn new_plugin_is_created_state() {
+    let plugin = SlackPlugin::new();
+    assert_eq!(plugin.status(), PluginStatus::Created);
+    assert!(plugin.bot_info().is_none());
+    assert_eq!(plugin.plugin_type(), PluginType::Slack);
+    assert_eq!(plugin.active_user_count(), 0);
+    assert!(plugin.last_error().is_none());
+}
+
+// -- truncate_message --------------------------------------------------------
+
+#[test]
+fn truncate_within_limit() {
+    assert_eq!(truncate_message("hello", 100), "hello");
+}
+
+#[test]
+fn truncate_at_limit() {
+    assert_eq!(truncate_message("abc", 3), "abc");
+}
+
+#[test]
+fn truncate_exceeds_limit() {
+    assert_eq!(truncate_message("Hello, world!", 10), "Hello, ...");
+}
+
+#[test]
+fn truncate_unicode() {
+    assert_eq!(truncate_message("你好世界测试文本", 5), "你好...");
+}

--- a/crates/aionui-channel/src/plugins/slack/socket.rs
+++ b/crates/aionui-channel/src/plugins/slack/socket.rs
@@ -1,0 +1,255 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::{Mutex, mpsc, watch};
+use tracing::{debug, error, info, warn};
+
+use crate::constants::SLACK_EVENT_DEDUP_TTL;
+use crate::error::ChannelError;
+use crate::types::UnifiedIncomingMessage;
+
+use super::api::SlackApi;
+use super::types::{EventCallback, SocketEnvelope, build_ack, event_to_unified};
+
+/// Maximum reconnect attempts before giving up.
+const MAX_RECONNECT_ATTEMPTS: u32 = 10;
+
+/// Maximum backoff delay between reconnection attempts.
+const MAX_RECONNECT_DELAY: Duration = Duration::from_secs(30);
+
+/// Shared event-deduplication cache: `event_id` → first-seen instant.
+pub(super) type DedupCache = Arc<Mutex<HashMap<String, Instant>>>;
+
+/// Maintain a Socket Mode connection: open a fresh WSS URL, listen until the
+/// socket closes or Slack requests a reconnect, then retry with exponential
+/// backoff. Exits on shutdown or after `MAX_RECONNECT_ATTEMPTS` failures.
+pub(super) async fn socket_loop(
+    api: Arc<SlackApi>,
+    bot_user_id: String,
+    message_tx: mpsc::Sender<UnifiedIncomingMessage>,
+    dedup_cache: DedupCache,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    let mut consecutive_errors: u32 = 0;
+
+    loop {
+        if *shutdown_rx.borrow() {
+            debug!("Slack socket loop received shutdown signal");
+            break;
+        }
+
+        let ws_url = match api.open_connection().await {
+            Ok(url) => url,
+            Err(e) => {
+                consecutive_errors += 1;
+                warn!(error = %e, consecutive_errors, "Slack apps.connections.open failed");
+                if consecutive_errors >= MAX_RECONNECT_ATTEMPTS {
+                    error!("Slack max reconnect attempts reached");
+                    break;
+                }
+                let delay = backoff_delay(consecutive_errors);
+                tokio::select! {
+                    _ = tokio::time::sleep(delay) => continue,
+                    _ = shutdown_rx.changed() => break,
+                }
+            }
+        };
+
+        match connect_and_listen(&ws_url, &bot_user_id, &message_tx, &dedup_cache, &mut shutdown_rx).await {
+            Ok(()) => {
+                consecutive_errors = 0;
+                debug!("Slack WS connection closed cleanly; reconnecting");
+            }
+            Err(e) => {
+                consecutive_errors += 1;
+                warn!(error = %e, consecutive_errors, "Slack WS connection error");
+                if consecutive_errors >= MAX_RECONNECT_ATTEMPTS {
+                    error!("Slack max reconnect attempts reached");
+                    break;
+                }
+                let delay = backoff_delay(consecutive_errors);
+                tokio::select! {
+                    _ = tokio::time::sleep(delay) => {}
+                    _ = shutdown_rx.changed() => break,
+                }
+            }
+        }
+    }
+
+    debug!("Slack socket loop exited");
+}
+
+/// Connect to the WSS URL and process envelopes until the socket closes,
+/// Slack sends a `disconnect`, or shutdown is signalled.
+async fn connect_and_listen(
+    ws_url: &str,
+    bot_user_id: &str,
+    message_tx: &mpsc::Sender<UnifiedIncomingMessage>,
+    dedup_cache: &DedupCache,
+    shutdown_rx: &mut watch::Receiver<bool>,
+) -> Result<(), ChannelError> {
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::connect_async_tls_with_config;
+    use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+    let connector = build_tls_connector()?;
+    let (ws_stream, _) = connect_async_tls_with_config(ws_url, None, false, Some(connector))
+        .await
+        .map_err(|e| ChannelError::ConnectionFailed(format!("Slack WS connect failed: {e}")))?;
+
+    info!("Slack WebSocket connected");
+
+    let (mut write, mut read) = ws_stream.split();
+
+    loop {
+        tokio::select! {
+            msg = read.next() => {
+                match msg {
+                    Some(Ok(WsMessage::Text(txt))) => {
+                        let envelope: SocketEnvelope = match serde_json::from_str(txt.as_str()) {
+                            Ok(env) => env,
+                            Err(e) => {
+                                warn!(error = %e, "Failed to parse Slack envelope");
+                                continue;
+                            }
+                        };
+
+                        // Ack every envelope that carries an id (Slack expects a
+                        // reply within 3s or it re-delivers the event).
+                        if let Some(ref envelope_id) = envelope.envelope_id {
+                            let ack = build_ack(envelope_id);
+                            if let Err(e) = write.send(WsMessage::Text(ack.into())).await {
+                                warn!(error = %e, "Failed to send Slack ack");
+                            }
+                        }
+
+                        match envelope.envelope_type.as_str() {
+                            "hello" => debug!("Slack Socket Mode hello"),
+                            "disconnect" => {
+                                debug!(reason = ?envelope.reason, "Slack requested disconnect; reconnecting");
+                                return Ok(());
+                            }
+                            "events_api" => {
+                                if let Some(payload) = envelope.payload {
+                                    handle_event_callback(payload, bot_user_id, message_tx, dedup_cache).await;
+                                }
+                            }
+                            other => debug!(envelope_type = other, "Slack unhandled envelope type"),
+                        }
+                    }
+                    Some(Ok(WsMessage::Ping(data))) => {
+                        let _ = write.send(WsMessage::Pong(data)).await;
+                    }
+                    Some(Ok(WsMessage::Close(_))) => {
+                        debug!("Slack WS received close frame");
+                        return Ok(());
+                    }
+                    Some(Err(e)) => {
+                        return Err(ChannelError::ConnectionFailed(format!("Slack WS read error: {e}")));
+                    }
+                    None => {
+                        return Err(ChannelError::ConnectionFailed("Slack WS stream ended unexpectedly".into()));
+                    }
+                    _ => {}
+                }
+            }
+            _ = shutdown_rx.changed() => {
+                debug!("Slack WS shutdown during listen");
+                return Ok(());
+            }
+        }
+    }
+}
+
+/// Parse an `events_api` payload, dedup by `event_id`, normalize, and forward.
+async fn handle_event_callback(
+    payload: serde_json::Value,
+    bot_user_id: &str,
+    message_tx: &mpsc::Sender<UnifiedIncomingMessage>,
+    dedup_cache: &DedupCache,
+) {
+    let callback: EventCallback = match serde_json::from_value(payload) {
+        Ok(cb) => cb,
+        Err(e) => {
+            warn!(error = %e, "Failed to parse Slack event callback");
+            return;
+        }
+    };
+
+    if let Some(event_id) = callback.event_id.as_deref()
+        && is_duplicate(dedup_cache, event_id).await
+    {
+        debug!(event_id, "Slack duplicate event, skipping");
+        return;
+    }
+
+    let Some(event) = callback.event else { return };
+    if let Some(unified) = event_to_unified(&event, bot_user_id) {
+        let _ = message_tx.send(unified).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Deduplication
+// ---------------------------------------------------------------------------
+
+/// Return true if `event_id` was seen recently; otherwise record it.
+pub(super) async fn is_duplicate(cache: &DedupCache, event_id: &str) -> bool {
+    let mut map = cache.lock().await;
+    if map.contains_key(event_id) {
+        return true;
+    }
+    map.insert(event_id.to_string(), Instant::now());
+    false
+}
+
+/// Drop expired entries from the dedup cache.
+pub(super) async fn cleanup_expired_events(cache: &DedupCache) {
+    let mut map = cache.lock().await;
+    let before = map.len();
+    map.retain(|_, instant| instant.elapsed() < SLACK_EVENT_DEDUP_TTL);
+    let removed = before - map.len();
+    if removed > 0 {
+        debug!(removed, remaining = map.len(), "Slack dedup cache cleanup");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Exponential backoff delay, capped at `MAX_RECONNECT_DELAY`.
+fn backoff_delay(attempt: u32) -> Duration {
+    let delay_secs = 2u64.saturating_pow(attempt).min(MAX_RECONNECT_DELAY.as_secs());
+    Duration::from_secs(delay_secs)
+}
+
+/// Build a TLS connector pinned to `http/1.1` ALPN.
+///
+/// WebSocket requires an HTTP/1.1 upgrade handshake; without pinning ALPN some
+/// servers negotiate h2 and the upgrade never completes.
+fn build_tls_connector() -> Result<tokio_tungstenite::Connector, ChannelError> {
+    use tokio_tungstenite::Connector;
+
+    let certs = rustls_native_certs::load_native_certs();
+    let mut root_store = rustls::RootCertStore::empty();
+    root_store.add_parsable_certificates(certs.certs);
+
+    let provider = rustls::crypto::CryptoProvider::get_default()
+        .cloned()
+        .unwrap_or_else(|| Arc::new(rustls::crypto::ring::default_provider()));
+
+    let mut config = rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| ChannelError::ConnectionFailed(format!("TLS config error: {e}")))?
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    config.alpn_protocols = vec![b"http/1.1".to_vec()];
+
+    Ok(Connector::Rustls(Arc::new(config)))
+}
+
+#[cfg(test)]
+#[path = "socket_test.rs"]
+mod socket_test;

--- a/crates/aionui-channel/src/plugins/slack/socket_test.rs
+++ b/crates/aionui-channel/src/plugins/slack/socket_test.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+// -- backoff_delay -----------------------------------------------------------
+
+#[test]
+fn backoff_exponential() {
+    assert_eq!(backoff_delay(1), Duration::from_secs(2));
+    assert_eq!(backoff_delay(2), Duration::from_secs(4));
+    assert_eq!(backoff_delay(3), Duration::from_secs(8));
+}
+
+#[test]
+fn backoff_capped() {
+    assert_eq!(backoff_delay(5), Duration::from_secs(30));
+    assert_eq!(backoff_delay(20), Duration::from_secs(30));
+}
+
+// -- is_duplicate / cleanup --------------------------------------------------
+
+fn empty_cache() -> DedupCache {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+
+#[tokio::test]
+async fn dedup_first_seen_not_duplicate() {
+    let cache = empty_cache();
+    assert!(!is_duplicate(&cache, "Ev1").await);
+}
+
+#[tokio::test]
+async fn dedup_second_seen_is_duplicate() {
+    let cache = empty_cache();
+    is_duplicate(&cache, "Ev1").await;
+    assert!(is_duplicate(&cache, "Ev1").await);
+}
+
+#[tokio::test]
+async fn dedup_distinct_ids_not_duplicate() {
+    let cache = empty_cache();
+    is_duplicate(&cache, "Ev1").await;
+    assert!(!is_duplicate(&cache, "Ev2").await);
+}
+
+#[tokio::test]
+async fn cleanup_removes_expired_only() {
+    let cache = empty_cache();
+    {
+        let mut map = cache.lock().await;
+        map.insert(
+            "old".into(),
+            Instant::now() - SLACK_EVENT_DEDUP_TTL - Duration::from_secs(1),
+        );
+        map.insert("recent".into(), Instant::now());
+    }
+    cleanup_expired_events(&cache).await;
+    let map = cache.lock().await;
+    assert!(!map.contains_key("old"));
+    assert!(map.contains_key("recent"));
+}
+
+// -- handle_event_callback: dedup + normalize + forward ----------------------
+
+#[tokio::test]
+async fn event_callback_forwards_app_mention_once() {
+    let (tx, mut rx) = mpsc::channel(8);
+    let cache = empty_cache();
+    let payload = serde_json::json!({
+        "type": "event_callback",
+        "event_id": "EvA",
+        "event": { "type": "app_mention", "user": "U1", "text": "<@U0BOT> hi", "ts": "1700000000.000100", "channel": "C1" }
+    });
+
+    handle_event_callback(payload.clone(), "U0BOT", &tx, &cache).await;
+    let msg = rx.try_recv().expect("first delivery");
+    assert_eq!(msg.chat_id, "C1");
+    assert_eq!(msg.content.text, "hi");
+
+    // Same event_id again → deduped, nothing forwarded.
+    handle_event_callback(payload, "U0BOT", &tx, &cache).await;
+    assert!(rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn event_callback_drops_bot_echo() {
+    let (tx, mut rx) = mpsc::channel(8);
+    let cache = empty_cache();
+    let payload = serde_json::json!({
+        "type": "event_callback",
+        "event_id": "EvB",
+        "event": { "type": "message", "user": "U0BOT", "text": "echo", "ts": "1700000000.0", "channel": "C1" }
+    });
+    handle_event_callback(payload, "U0BOT", &tx, &cache).await;
+    assert!(rx.try_recv().is_err());
+}

--- a/crates/aionui-channel/src/plugins/slack/types.rs
+++ b/crates/aionui-channel/src/plugins/slack/types.rs
@@ -1,0 +1,223 @@
+use serde::{Deserialize, Serialize};
+
+use crate::types::{MessageContentType, PluginType, UnifiedIncomingMessage, UnifiedMessageContent, UnifiedUser};
+
+// ---------------------------------------------------------------------------
+// Web API responses (https://api.slack.com/methods)
+// ---------------------------------------------------------------------------
+
+/// Response from `auth.test` — validates the bot token and returns identity.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct AuthTestResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// Response from `apps.connections.open` — returns the Socket Mode WSS URL.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct OpenConnectionResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+/// Request body for `chat.postMessage`.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct PostMessageRequest {
+    pub channel: String,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_ts: Option<String>,
+}
+
+/// Response from `chat.postMessage`.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct PostMessageResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub ts: Option<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+/// Request body for `chat.update`.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct UpdateMessageRequest {
+    pub channel: String,
+    pub ts: String,
+    pub text: String,
+}
+
+/// Response from `chat.update`.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct UpdateMessageResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Socket Mode envelopes (over the WSS connection)
+// ---------------------------------------------------------------------------
+
+/// A Socket Mode envelope. The server sends `hello`, `events_api`,
+/// `disconnect`, `slash_commands` and `interactive` envelopes; the client
+/// must ack every non-`hello`/`disconnect` envelope by echoing `envelope_id`.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct SocketEnvelope {
+    #[serde(rename = "type")]
+    pub envelope_type: String,
+    #[serde(default)]
+    pub envelope_id: Option<String>,
+    #[serde(default)]
+    pub payload: Option<serde_json::Value>,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// The `payload` of an `events_api` envelope — an Events API `event_callback`.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct EventCallback {
+    #[serde(default)]
+    pub event: Option<SlackEvent>,
+    #[serde(default)]
+    pub event_id: Option<String>,
+}
+
+/// A Slack event (`app_mention`, `message`, …). Only the fields we consume
+/// are modeled; unknown fields are ignored.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct SlackEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub ts: Option<String>,
+    #[serde(default)]
+    pub channel: Option<String>,
+    #[serde(default)]
+    pub channel_type: Option<String>,
+    #[serde(default)]
+    pub thread_ts: Option<String>,
+    #[serde(default)]
+    pub bot_id: Option<String>,
+    #[serde(default)]
+    pub subtype: Option<String>,
+    #[serde(default)]
+    pub client_msg_id: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Normalization: Slack event → UnifiedIncomingMessage
+// ---------------------------------------------------------------------------
+
+/// Build the ack frame the client must echo for an envelope.
+pub(super) fn build_ack(envelope_id: &str) -> String {
+    serde_json::json!({ "envelope_id": envelope_id }).to_string()
+}
+
+/// Parse a Slack `ts` (`"1700000000.123456"`, seconds.micro) into unix ms.
+pub(super) fn parse_ts_to_ms(ts: &str) -> i64 {
+    ts.parse::<f64>().map(|secs| (secs * 1000.0) as i64).unwrap_or(0)
+}
+
+/// Strip a leading bot mention (`<@U123>` / `<@U123|name>`) from `app_mention`
+/// text, leaving the user's actual prompt.
+pub(super) fn strip_bot_mention(text: &str, bot_user_id: &str) -> String {
+    let mut out = text.to_string();
+    if !bot_user_id.is_empty() {
+        out = out.replace(&format!("<@{bot_user_id}>"), "");
+        out = out.replace(&format!("<@{bot_user_id}|"), "<@|");
+    }
+    out.trim().to_string()
+}
+
+/// Convert a Slack event into a `UnifiedIncomingMessage`, or `None` when the
+/// event must be ignored (bot's own message, other bots, or an edit/delete
+/// subtype). Only `app_mention` (channel @mention) and plain `message`
+/// (direct message) events are accepted.
+pub(super) fn event_to_unified(event: &SlackEvent, bot_user_id: &str) -> Option<UnifiedIncomingMessage> {
+    // Ignore anything emitted by a bot (including our own echoes) to avoid loops.
+    if event.bot_id.is_some() {
+        return None;
+    }
+    if let Some(user) = event.user.as_deref()
+        && !bot_user_id.is_empty()
+        && user == bot_user_id
+    {
+        return None;
+    }
+
+    match event.event_type.as_str() {
+        // Public-channel @mentions always route to the agent; the DM gate below
+        // must NOT apply here (app_mention events are not `im`).
+        "app_mention" => {}
+        // Plain user messages only — reject message_changed/message_deleted/etc.
+        "message" if event.subtype.is_none() => {
+            // DM-only gate: accept `message` events solely from direct-message
+            // channels. This prevents a future channel-level subscription
+            // (message.channels/groups) from leaking whole-channel traffic to
+            // the agent. Slack marks DMs with channel_type "im"; the `D` id
+            // prefix is a fallback when channel_type is absent.
+            let is_dm = event.channel_type.as_deref() == Some("im")
+                || event.channel.as_deref().is_some_and(|c| c.starts_with('D'));
+            if !is_dm {
+                return None;
+            }
+        }
+        _ => return None,
+    }
+
+    let channel = event.channel.clone()?;
+    let user_id = event.user.clone().unwrap_or_default();
+    let ts = event.ts.clone().unwrap_or_default();
+
+    let raw_text = event.text.as_deref().unwrap_or("");
+    let text = if event.event_type == "app_mention" {
+        strip_bot_mention(raw_text, bot_user_id)
+    } else {
+        raw_text.to_string()
+    };
+
+    let id = event
+        .client_msg_id
+        .clone()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| ts.clone());
+
+    Some(UnifiedIncomingMessage {
+        owner_user_id: None,
+        id,
+        platform: PluginType::Slack,
+        chat_id: channel,
+        user: UnifiedUser {
+            id: user_id,
+            username: None,
+            display_name: event.user.clone().unwrap_or_default(),
+            avatar_url: None,
+        },
+        content: UnifiedMessageContent {
+            content_type: MessageContentType::Text,
+            text,
+            attachments: None,
+        },
+        timestamp: parse_ts_to_ms(&ts),
+        reply_to_message_id: event.thread_ts.clone(),
+        action: None,
+        raw: None,
+    })
+}
+
+#[cfg(test)]
+#[path = "types_test.rs"]
+mod types_test;

--- a/crates/aionui-channel/src/plugins/slack/types_test.rs
+++ b/crates/aionui-channel/src/plugins/slack/types_test.rs
@@ -1,0 +1,329 @@
+use super::*;
+use crate::types::MessageContentType;
+use serde_json::json;
+
+// -- Web API response parsing ------------------------------------------------
+
+#[test]
+fn auth_test_response_ok() {
+    let raw = json!({ "ok": true, "user": "aion_bot", "user_id": "U0BOT", "bot_id": "B0BOT" });
+    let resp: AuthTestResponse = serde_json::from_value(raw).unwrap();
+    assert!(resp.ok);
+    assert_eq!(resp.user_id.as_deref(), Some("U0BOT"));
+    assert_eq!(resp.user.as_deref(), Some("aion_bot"));
+}
+
+#[test]
+fn auth_test_response_error() {
+    let raw = json!({ "ok": false, "error": "invalid_auth" });
+    let resp: AuthTestResponse = serde_json::from_value(raw).unwrap();
+    assert!(!resp.ok);
+    assert_eq!(resp.error.as_deref(), Some("invalid_auth"));
+    assert!(resp.user_id.is_none());
+}
+
+#[test]
+fn open_connection_response_ok() {
+    let raw = json!({ "ok": true, "url": "wss://wss-primary.slack.com/link/?ticket=abc" });
+    let resp: OpenConnectionResponse = serde_json::from_value(raw).unwrap();
+    assert!(resp.ok);
+    assert_eq!(
+        resp.url.as_deref(),
+        Some("wss://wss-primary.slack.com/link/?ticket=abc")
+    );
+}
+
+#[test]
+fn open_connection_response_error() {
+    let raw = json!({ "ok": false, "error": "not_allowed_token_type" });
+    let resp: OpenConnectionResponse = serde_json::from_value(raw).unwrap();
+    assert!(!resp.ok);
+    assert!(resp.url.is_none());
+}
+
+#[test]
+fn post_message_response_ok() {
+    let raw = json!({ "ok": true, "ts": "1700000000.000100", "channel": "C0123" });
+    let resp: PostMessageResponse = serde_json::from_value(raw).unwrap();
+    assert!(resp.ok);
+    assert_eq!(resp.ts.as_deref(), Some("1700000000.000100"));
+}
+
+#[test]
+fn post_message_request_omits_none_thread() {
+    let req = PostMessageRequest {
+        channel: "C1".into(),
+        text: "hi".into(),
+        thread_ts: None,
+    };
+    let v = serde_json::to_value(&req).unwrap();
+    assert_eq!(v["channel"], "C1");
+    assert!(v.get("thread_ts").is_none());
+}
+
+#[test]
+fn post_message_request_includes_thread() {
+    let req = PostMessageRequest {
+        channel: "C1".into(),
+        text: "hi".into(),
+        thread_ts: Some("1700000000.000001".into()),
+    };
+    let v = serde_json::to_value(&req).unwrap();
+    assert_eq!(v["thread_ts"], "1700000000.000001");
+}
+
+#[test]
+fn update_message_response_error() {
+    let raw = json!({ "ok": false, "error": "message_not_found" });
+    let resp: UpdateMessageResponse = serde_json::from_value(raw).unwrap();
+    assert!(!resp.ok);
+    assert_eq!(resp.error.as_deref(), Some("message_not_found"));
+}
+
+// -- Socket Mode envelope parsing --------------------------------------------
+
+#[test]
+fn envelope_hello_parses() {
+    let raw = json!({ "type": "hello", "num_connections": 1 });
+    let env: SocketEnvelope = serde_json::from_value(raw).unwrap();
+    assert_eq!(env.envelope_type, "hello");
+    assert!(env.envelope_id.is_none());
+}
+
+#[test]
+fn envelope_disconnect_parses() {
+    let raw = json!({ "type": "disconnect", "reason": "refresh_requested" });
+    let env: SocketEnvelope = serde_json::from_value(raw).unwrap();
+    assert_eq!(env.envelope_type, "disconnect");
+    assert_eq!(env.reason.as_deref(), Some("refresh_requested"));
+}
+
+#[test]
+fn envelope_events_api_parses_with_payload() {
+    let raw = json!({
+        "type": "events_api",
+        "envelope_id": "env-123",
+        "payload": {
+            "type": "event_callback",
+            "event_id": "Ev0001",
+            "event": { "type": "app_mention", "user": "U1", "text": "<@U0BOT> hi", "ts": "1700000000.000100", "channel": "C1" }
+        }
+    });
+    let env: SocketEnvelope = serde_json::from_value(raw).unwrap();
+    assert_eq!(env.envelope_type, "events_api");
+    assert_eq!(env.envelope_id.as_deref(), Some("env-123"));
+    let cb: EventCallback = serde_json::from_value(env.payload.unwrap()).unwrap();
+    assert_eq!(cb.event_id.as_deref(), Some("Ev0001"));
+    assert_eq!(cb.event.unwrap().event_type, "app_mention");
+}
+
+// -- build_ack ---------------------------------------------------------------
+
+#[test]
+fn build_ack_echoes_envelope_id() {
+    let ack = build_ack("env-xyz");
+    let v: serde_json::Value = serde_json::from_str(&ack).unwrap();
+    assert_eq!(v["envelope_id"], "env-xyz");
+}
+
+// -- parse_ts_to_ms ----------------------------------------------------------
+
+#[test]
+fn parse_ts_seconds_micros() {
+    assert_eq!(parse_ts_to_ms("1700000000.000100"), 1_700_000_000_000);
+}
+
+#[test]
+fn parse_ts_invalid_returns_zero() {
+    assert_eq!(parse_ts_to_ms("not-a-ts"), 0);
+}
+
+// -- strip_bot_mention -------------------------------------------------------
+
+#[test]
+fn strip_mention_leading() {
+    assert_eq!(strip_bot_mention("<@U0BOT> hello there", "U0BOT"), "hello there");
+}
+
+#[test]
+fn strip_mention_absent_is_noop() {
+    assert_eq!(strip_bot_mention("plain text", "U0BOT"), "plain text");
+}
+
+// -- event_to_unified --------------------------------------------------------
+
+fn app_mention_event() -> SlackEvent {
+    SlackEvent {
+        event_type: "app_mention".into(),
+        user: Some("U1".into()),
+        text: Some("<@U0BOT> summarize this".into()),
+        ts: Some("1700000000.000100".into()),
+        channel: Some("C1".into()),
+        channel_type: None,
+        thread_ts: None,
+        bot_id: None,
+        subtype: None,
+        client_msg_id: Some("cmid-1".into()),
+    }
+}
+
+#[test]
+fn app_mention_normalizes_and_strips_mention() {
+    let msg = event_to_unified(&app_mention_event(), "U0BOT").unwrap();
+    assert_eq!(msg.platform, PluginType::Slack);
+    assert_eq!(msg.chat_id, "C1");
+    assert_eq!(msg.user.id, "U1");
+    assert_eq!(msg.content.content_type, MessageContentType::Text);
+    assert_eq!(msg.content.text, "summarize this");
+    assert_eq!(msg.id, "cmid-1");
+    assert_eq!(msg.timestamp, 1_700_000_000_000);
+}
+
+#[test]
+fn direct_message_normalizes() {
+    let evt = SlackEvent {
+        event_type: "message".into(),
+        user: Some("U9".into()),
+        text: Some("hi bot".into()),
+        ts: Some("1700000001.000200".into()),
+        channel: Some("D1".into()),
+        channel_type: Some("im".into()),
+        thread_ts: None,
+        bot_id: None,
+        subtype: None,
+        client_msg_id: None,
+    };
+    let msg = event_to_unified(&evt, "U0BOT").unwrap();
+    assert_eq!(msg.chat_id, "D1");
+    assert_eq!(msg.content.text, "hi bot");
+    // No client_msg_id → id falls back to ts.
+    assert_eq!(msg.id, "1700000001.000200");
+}
+
+#[test]
+fn thread_ts_maps_to_reply_to() {
+    let mut evt = app_mention_event();
+    evt.thread_ts = Some("1700000000.000001".into());
+    let msg = event_to_unified(&evt, "U0BOT").unwrap();
+    assert_eq!(msg.reply_to_message_id.as_deref(), Some("1700000000.000001"));
+}
+
+#[test]
+fn bot_own_message_is_ignored() {
+    let mut evt = app_mention_event();
+    evt.user = Some("U0BOT".into());
+    assert!(event_to_unified(&evt, "U0BOT").is_none());
+}
+
+#[test]
+fn other_bot_message_is_ignored() {
+    let evt = SlackEvent {
+        event_type: "message".into(),
+        user: Some("U2".into()),
+        text: Some("automated".into()),
+        ts: Some("1700000002.0".into()),
+        channel: Some("C1".into()),
+        channel_type: None,
+        thread_ts: None,
+        bot_id: Some("B999".into()),
+        subtype: None,
+        client_msg_id: None,
+    };
+    assert!(event_to_unified(&evt, "U0BOT").is_none());
+}
+
+#[test]
+fn message_changed_subtype_is_ignored() {
+    let evt = SlackEvent {
+        event_type: "message".into(),
+        user: Some("U1".into()),
+        text: Some("edited".into()),
+        ts: Some("1700000003.0".into()),
+        channel: Some("C1".into()),
+        channel_type: Some("channel".into()),
+        thread_ts: None,
+        bot_id: None,
+        subtype: Some("message_changed".into()),
+        client_msg_id: None,
+    };
+    assert!(event_to_unified(&evt, "U0BOT").is_none());
+}
+
+#[test]
+fn unhandled_event_type_is_ignored() {
+    let evt = SlackEvent {
+        event_type: "reaction_added".into(),
+        user: Some("U1".into()),
+        text: None,
+        ts: Some("1700000004.0".into()),
+        channel: Some("C1".into()),
+        channel_type: None,
+        thread_ts: None,
+        bot_id: None,
+        subtype: None,
+        client_msg_id: None,
+    };
+    assert!(event_to_unified(&evt, "U0BOT").is_none());
+}
+
+// -- M1 DM gate --------------------------------------------------------------
+
+/// A `message` event from a public channel (channel_type "channel") must be
+/// dropped — the DM gate blocks a future channel-level subscription from
+/// leaking whole-channel traffic to the agent.
+#[test]
+fn public_channel_message_is_rejected() {
+    let evt = SlackEvent {
+        event_type: "message".into(),
+        user: Some("U1".into()),
+        text: Some("hello channel".into()),
+        ts: Some("1700000005.000100".into()),
+        channel: Some("C1".into()),
+        channel_type: Some("channel".into()),
+        thread_ts: None,
+        bot_id: None,
+        subtype: None,
+        client_msg_id: None,
+    };
+    assert!(event_to_unified(&evt, "U0BOT").is_none());
+}
+
+/// A `message` event with no channel_type but a `D`-prefixed channel id is
+/// still treated as a DM (fallback path).
+#[test]
+fn dm_via_channel_prefix_is_accepted() {
+    let evt = SlackEvent {
+        event_type: "message".into(),
+        user: Some("U1".into()),
+        text: Some("hi".into()),
+        ts: Some("1700000006.000100".into()),
+        channel: Some("D9".into()),
+        channel_type: None,
+        thread_ts: None,
+        bot_id: None,
+        subtype: None,
+        client_msg_id: None,
+    };
+    assert!(event_to_unified(&evt, "U0BOT").is_some());
+}
+
+/// Regression guard: the DM gate must NOT touch `app_mention`. A public-channel
+/// @mention (channel_type "channel") must still route to the agent.
+#[test]
+fn app_mention_in_public_channel_is_not_gated() {
+    let evt = SlackEvent {
+        event_type: "app_mention".into(),
+        user: Some("U1".into()),
+        text: Some("<@U0BOT> help".into()),
+        ts: Some("1700000007.000100".into()),
+        channel: Some("C1".into()),
+        channel_type: Some("channel".into()),
+        thread_ts: None,
+        bot_id: None,
+        subtype: None,
+        client_msg_id: None,
+    };
+    let msg = event_to_unified(&evt, "U0BOT").unwrap();
+    assert_eq!(msg.chat_id, "C1");
+    assert_eq!(msg.content.text, "help");
+}

--- a/crates/aionui-channel/src/plugins/weixin/plugin.rs
+++ b/crates/aionui-channel/src/plugins/weixin/plugin.rs
@@ -626,6 +626,7 @@ mod tests {
                 client_secret: None,
                 account_id: account_id.map(String::from),
                 bot_token: bot_token.map(String::from),
+                app_token: None,
                 extra: HashMap::new(),
             },
             config: None,

--- a/crates/aionui-channel/src/routes.rs
+++ b/crates/aionui-channel/src/routes.rs
@@ -728,6 +728,7 @@ fn build_test_config(req: &TestPluginRequest) -> PluginConfig {
         client_secret: None,
         account_id: None,
         bot_token: None,
+        app_token: None,
         extra: HashMap::new(),
     };
 
@@ -813,6 +814,7 @@ fn build_extension_config(
         client_secret: None,
         account_id: None,
         bot_token: None,
+        app_token: None,
         extra: HashMap::new(),
     };
     let mut config_extra = HashMap::new();

--- a/crates/aionui-channel/src/stream_relay.rs
+++ b/crates/aionui-channel/src/stream_relay.rs
@@ -21,6 +21,18 @@ pub struct RelayConfig {
     pub throttle_ms: u64,
 }
 
+/// Per-platform minimum interval between streaming `edit_message` calls.
+///
+/// Slack's `chat.update` is rate-limited more aggressively than the other
+/// editable platforms, so it uses a larger interval; Telegram/Lark/DingTalk
+/// keep the original 500 ms cadence.
+pub fn throttle_ms_for_platform(platform: PluginType) -> u64 {
+    match platform {
+        PluginType::Slack => 1200,
+        _ => 500,
+    }
+}
+
 /// Abstraction for sending/editing messages through a channel plugin.
 ///
 /// Decouples ChannelStreamRelay from ChannelManager for testability.

--- a/crates/aionui-channel/src/types.rs
+++ b/crates/aionui-channel/src/types.rs
@@ -189,6 +189,11 @@ pub struct PluginCredentials {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bot_token: Option<String>,
 
+    // Slack
+    /// Slack app-level token (`xapp-`), used to open the Socket Mode connection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_token: Option<String>,
+
     // Extensibility
     #[serde(flatten)]
     pub extra: HashMap<String, serde_json::Value>,
@@ -210,6 +215,7 @@ impl PluginCredentials {
             && self.client_secret.is_none()
             && self.account_id.is_none()
             && self.bot_token.is_none()
+            && self.app_token.is_none()
             && self.extra.is_empty()
     }
 }
@@ -605,6 +611,7 @@ mod tests {
             client_secret: None,
             account_id: None,
             bot_token: None,
+            app_token: None,
             extra: HashMap::new(),
         };
         let json = serde_json::to_value(&creds).unwrap();
@@ -625,6 +632,7 @@ mod tests {
             client_secret: None,
             account_id: None,
             bot_token: None,
+            app_token: None,
             extra: HashMap::new(),
         };
         let json = serde_json::to_value(&creds).unwrap();
@@ -1030,6 +1038,7 @@ mod tests {
                 client_secret: None,
                 account_id: None,
                 bot_token: None,
+                app_token: None,
                 extra: HashMap::new(),
             },
             config: Some(PluginConfigOptions {

--- a/crates/aionui-channel/tests/dingtalk_integration.rs
+++ b/crates/aionui-channel/tests/dingtalk_integration.rs
@@ -93,6 +93,7 @@ mod dingtalk_tests {
                 client_secret: client_secret.map(String::from),
                 account_id: None,
                 bot_token: None,
+                app_token: None,
                 extra: HashMap::new(),
             },
             config: None,

--- a/crates/aionui-channel/tests/lark_integration.rs
+++ b/crates/aionui-channel/tests/lark_integration.rs
@@ -92,6 +92,7 @@ mod lark_tests {
                 client_secret: None,
                 account_id: None,
                 bot_token: None,
+                app_token: None,
                 extra: HashMap::new(),
             },
             config: None,

--- a/crates/aionui-channel/tests/manager_integration.rs
+++ b/crates/aionui-channel/tests/manager_integration.rs
@@ -238,6 +238,7 @@ fn make_plugin_config() -> PluginConfig {
             client_secret: None,
             account_id: None,
             bot_token: None,
+            app_token: None,
             extra: HashMap::new(),
         },
         config: None,

--- a/crates/aionui-channel/tests/stream_relay_test.rs
+++ b/crates/aionui-channel/tests/stream_relay_test.rs
@@ -4,11 +4,22 @@ use aionui_ai_agent::AgentStreamEvent;
 use aionui_ai_agent::protocol::events::{
     ErrorEventData, FinishEventData, TextEventData, ToolCallEventData, ToolCallStatus,
 };
-use aionui_channel::stream_relay::{ChannelStreamRelay, MessageRecorder, RelayConfig};
+use aionui_channel::stream_relay::{ChannelStreamRelay, MessageRecorder, RelayConfig, throttle_ms_for_platform};
 use aionui_channel::types::PluginType;
 use tokio::sync::broadcast;
 
 // ── RelayConfig construction ─────────────────────────────────────
+
+#[test]
+fn slack_uses_larger_throttle_than_others() {
+    // Slack's chat.update is rate-limited harder, so it gets a wider interval;
+    // the other editable platforms must stay at the original 500 ms.
+    assert_eq!(throttle_ms_for_platform(PluginType::Slack), 1200);
+    assert_eq!(throttle_ms_for_platform(PluginType::Telegram), 500);
+    assert_eq!(throttle_ms_for_platform(PluginType::Lark), 500);
+    assert_eq!(throttle_ms_for_platform(PluginType::Dingtalk), 500);
+    assert_eq!(throttle_ms_for_platform(PluginType::Weixin), 500);
+}
 
 #[test]
 fn relay_config_fields() {

--- a/crates/aionui-channel/tests/telegram_integration.rs
+++ b/crates/aionui-channel/tests/telegram_integration.rs
@@ -94,6 +94,7 @@ mod telegram_tests {
                 client_secret: None,
                 account_id: None,
                 bot_token: None,
+                app_token: None,
                 extra: HashMap::new(),
             },
             config: None,

--- a/crates/aionui-channel/tests/weixin_integration.rs
+++ b/crates/aionui-channel/tests/weixin_integration.rs
@@ -94,6 +94,7 @@ mod weixin_tests {
                 client_secret: None,
                 account_id: account_id.map(String::from),
                 bot_token: bot_token.map(String::from),
+                app_token: None,
                 extra: HashMap::new(),
             },
             config: None,


### PR DESCRIPTION
# feat(channel): add Slack Socket Mode plugin

## Summary

Adds a native Slack channel plugin to `aioncore/crates/aionui-channel`, so Slack
users can talk to an AionUi assistant the same way the existing Telegram / Lark /
DingTalk / WeChat channels work. Backend only — the companion frontend (config
form + wiring) ships in the paired aionui PR.

Connection uses **Slack Socket Mode**: the app-level token (`xapp-`) opens the
WebSocket via `apps.connections.open`; the bot token (`xoxb-`) drives the Web API
(`auth.test` / `chat.postMessage` / `chat.update`). Slack supports message edits,
so streaming responses use the existing editable relay path.

## What's included

- **`plugins/slack/`** — new module (feature-gated `slack`):
  - `types.rs` — Web API + Socket Mode envelope serde types; pure
    `event_to_unified` normalization.
  - `api.rs` — `SlackApi` (reqwest) for auth.test / apps.connections.open /
    chat.postMessage / chat.update, with a one-shot **HTTP 429 `Retry-After`
    backoff** wrapper.
  - `socket.rs` — Socket Mode loop: ack every envelope within Slack's 3s window,
    dedup by `event_id`, exponential-backoff reconnect on disconnect.
  - `plugin.rs` — `SlackPlugin` implementing `ChannelPlugin` (full lifecycle).
  - each source file paired with a `*_test.rs` (per repo test-layout rule).
- **DM gate (M1 hardening)** — `message` events are accepted only from direct
  messages (`channel_type == "im"` or `D`-prefixed channel id). `app_mention`
  events from public channels are **not** gated (still routed). This prevents a
  future channel-level subscription from leaking whole-channel traffic to the
  agent.
- **`create_plugin`** registers Slack behind the `slack` feature; `aionui-app`
  enables `slack` in its default feature set.
- **`formatter.rs`** — Slack `mrkdwn` conversion branch (bold/strike/links +
  `& < >` escaping); adds `SLACK_MESSAGE_LIMIT` and Slack dedup TTL constants.
- **Per-platform stream throttle** — `throttle_ms_for_platform`: Slack 1200 ms,
  Telegram/Lark/DingTalk/WeChat unchanged at 500 ms (test-guarded).
- **`PluginCredentials.app_token`** — new typed field for the app-level token
  (`is_empty()` updated); wire key stays `app_token`.

## Related

- iOfficeAI/AionUi#3935

## Testing

- `cargo build -p aionui-channel --features slack` — green.
- `cargo build -p aionui-app --features slack` — green (create_plugin / DI wired).
- `cargo test -p aionui-channel --features slack` — **281 lib + integration
  green, 0 failed.** New coverage: event normalization (app_mention / message.im /
  ignore bot-self / other-bot / message_changed), DM gate (public-channel message
  rejected, DM accepted, app_mention-in-public-channel regression), mrkdwn,
  envelope ack, dedup, plugin state machine bad paths, per-platform throttle,
  429 Retry-After parsing.
- `cargo clippy -p aionui-channel -p aionui-app --features slack --tests -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- Full pre-push gate (`just push`) — passed.

**Honest gaps (no over-claim):**
- **No real Slack live e2e.** `auth.test` happy-path and the 429 retry's network
  behavior are not exercised against a live workspace; only the pure
  `Retry-After` parser and token-validation bad paths are unit-tested.

## Fast-follow (not in this PR)

- **M2 / L1 hardening items** tracked separately.
- Block Kit interactive buttons (`UnifiedOutgoingMessage.buttons` → Slack
  `actions`, `block_actions` handling).
- Inbound file attachments (currently text-only; files degrade to a placeholder).
- Streaming replies threaded under the originating message (`send_message`
  already threads via `thread_ts`; the streaming relay still posts at channel
  top-level to avoid changing shared relay behavior for other platforms).
- Real Slack live e2e once a test workspace/app is available.

## Companion PR

Frontend (config form + channel wiring): **aionui #3935**, branch
`boii/feat/channel-slack`.

## Checklist

- [x] Unit + integration tests added and green
- [x] `clippy -D warnings` clean
- [x] `fmt --check` clean
- [x] New cross-module surface kept minimal (Slack module internals `pub(super)`)
- [ ] Real Slack live e2e — deferred (see Honest gaps)
