### PR TITLE
fix(project): emit real-case absolute path to agents, not folded canonical

### DIFF
--- a/crates/aionui-project/src/chat_files_test.rs
+++ b/crates/aionui-project/src/chat_files_test.rs
@@ -107,6 +107,59 @@ async fn resolves_project_root_ref_empty_relative_path() {
     );
 }
 
+/// bug2 regression: the path emitted to the agent (inlined into `[[AION_FILES]]`)
+/// must keep the folder's REAL on-disk casing, not the case-folded canonical.
+/// `canonical::canonicalize` ASCII-lowercases the path on macOS/Windows
+/// (`IGNORE_PATH_CASING`) for dedupe identity; before the fix that folded root
+/// leaked to the agent (`…/mixedcaseroot/Brief.md`), which a case-sensitive gate
+/// or display can reject. The relative segment was never folded, so the ROOT
+/// casing is the discriminating check. On Linux nothing folds, so real == given.
+#[tokio::test]
+async fn emitted_absolute_path_keeps_real_root_casing() {
+    let db = init_database_memory().await.unwrap();
+    let store: Arc<dyn IProjectStore> = Arc::new(SqliteProjectStore::new(db.pool().clone()));
+    let service = Arc::new(ProjectService::new(Arc::clone(&store), std::env::temp_dir()));
+
+    // A mixed-case root directory; only OUR segment's casing is asserted, so the
+    // tempdir parent's own casing is irrelevant.
+    let base = tempfile::tempdir().unwrap();
+    let mixed_root = base.path().join("MixedCaseRoot");
+    std::fs::create_dir(&mixed_root).unwrap();
+    std::fs::write(mixed_root.join("Brief.md"), b"content").unwrap();
+
+    let created = service
+        .create_standard("system_default_user", to_file_uri(&mixed_root).unwrap())
+        .await
+        .unwrap();
+    let upload_root = tempfile::tempdir().unwrap();
+
+    let out = service
+        .resolve_chat_message(
+            "system_default_user",
+            "read this",
+            &[ChatFileRef::Project {
+                pe_id: created.project_explorer.pe_id,
+                relative_path: "Brief.md".into(),
+            }],
+            upload_root.path(),
+        )
+        .await
+        .unwrap();
+
+    let abs = &out.files[0];
+    // Real root casing preserved — folded would be `mixedcaseroot` on macOS/Windows.
+    assert!(
+        abs.contains("MixedCaseRoot"),
+        "root casing must be preserved, got {abs}"
+    );
+    assert!(abs.ends_with("Brief.md"), "file casing must be preserved, got {abs}");
+    // The emitted path physically resolves to the real file.
+    assert!(
+        std::path::Path::new(abs).is_file(),
+        "emitted path must exist, got {abs}"
+    );
+}
+
 #[tokio::test]
 async fn empty_files_leaves_content_unchanged() {
     let (service, _pe, _dir, upload_root) = setup().await;

--- a/crates/aionui-project/src/service.rs
+++ b/crates/aionui-project/src/service.rs
@@ -321,6 +321,28 @@ impl ProjectService {
         let root = canonical::canonicalize(&folder.resource_canonical)?;
         let resolved = containment::resolve_relative(&root, &input.relative_path, input.op)?;
 
+        // The agent-facing absolute path must preserve the real on-disk casing.
+        // Derive it from the folder's stored real-case URI (`resource_uri`), NOT
+        // the case-folded canonical: `canonical::canonicalize` ASCII-lowercases the
+        // path on macOS/Windows (`IGNORE_PATH_CASING`) for dedupe/containment
+        // identity, so `resolved.absolute_path` carries a lowercased root. That
+        // folded form stays the containment + dedupe key (unchanged); only the
+        // outward path handed to agents / clipboard / reveal switches to real
+        // casing. The relative segment is already validated (no `..`, contained)
+        // by `resolve_relative`, so joining it onto the real root cannot escape.
+        let absolute_path = match resolved.absolute_path {
+            Some(_) => {
+                let real_root = canonical::uri_to_path(&folder.resource_uri)?;
+                let abs = if resolved.relative_path.is_empty() {
+                    real_root
+                } else {
+                    real_root.join(&resolved.relative_path)
+                };
+                Some(abs.to_string_lossy().into_owned())
+            }
+            None => None,
+        };
+
         Ok(ResolvedResource {
             project_id: entry.project_id,
             pe_id: entry.pe_id,
@@ -329,7 +351,7 @@ impl ProjectService {
             root_resource_canonical: folder.resource_canonical,
             relative_path: resolved.relative_path,
             resource_uri: resolved.resource_uri,
-            absolute_path: resolved.absolute_path.map(|p| p.to_string_lossy().into_owned()),
+            absolute_path,
         })
     }
 


### PR DESCRIPTION
## Description

The absolute path handed to agents for a project file/folder reference was derived from the **case-folded canonical** URI. `canonical::canonicalize` ASCII-lowercases the path on macOS/Windows (`IGNORE_PATH_CASING`) to serve folder **dedupe/containment identity** — so the outward path leaked a lowercased root (e.g. `/users/…/MyProject/Brief.md` → `/users/…/myproject/Brief.md`).

This changes `resolve_reference` to derive the agent-facing `absolute_path` from the folder's stored **real-case URI** (`resource_uri`) instead, joining the already-validated relative segment onto the real root.

### Red line respected

- The **folded canonical is untouched** — it remains the containment guard (`resolve_relative`) and the dedupe/identity key (`resource_canonical`). Only the *outward* path handed to consumers switches to real casing (same principle as the reveal / copy-path work: change the output, never the canonical key).
- The relative segment is already validated (no `..`, contained) before being joined onto the real root, so containment is unchanged.

### One fix point, all outward consumers

`resolve_reference.absolute_path` feeds every outward path, so this single change covers:
- the `[[AION_FILES]]` inlined-attachment text,
- the DirectCli `ResourceLink` uri (claude/codex),
- `copy-absolute-path`,
- reveal-in-folder.

### Tests

Adds a regression test (`chat_files_test.rs::emitted_absolute_path_keeps_real_root_casing`): a mixed-case root `MixedCaseRoot/Brief.md`, asserting the emitted path keeps `MixedCaseRoot` (the folded form would be `mixedcaseroot`) and resolves to the real file. `aionui-project` suite + `clippy -D warnings` + `fmt` all green.

## Scope note — this is NOT the bug2 fix

This is an **orthogonal path-casing hygiene fix**. It is **not** the root-cause fix for "the agent didn't read the project file/folder I added to chat". Live CLI probing showed that symptom is gated by the agent's **tool-use permission prompt** (the agent decides to read but blocks on a `can_use_tool` approval), not by path casing or reachability — that is tracked separately and intentionally **not** addressed here. Please don't read this PR as resolving that behavior.

## Related

- Context (front-end half of "project added to chat"): iOfficeAI/AionUi#3869 — this backend path-casing fix is adjacent but independent.
