### PR TITLE
chore(acp): bump dimcode, dirac, grok and kilo registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -19,12 +19,12 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.2"
+      "version": "0.3.8"
     },
     "dirac": {
       "registry_json_id": "dirac",
       "package": "dirac-cli",
-      "version": "0.4.32"
+      "version": "0.4.34"
     },
     "glm-acp-agent": {
       "registry_json_id": "glm-acp-agent",
@@ -34,12 +34,12 @@
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "0.2.120"
+      "version": "1.0.0"
     },
     "kilo": {
       "registry_json_id": "kilo",
       "package": "@kilocode/cli",
-      "version": "7.4.19"
+      "version": "7.4.20"
     },
     "mimo-code": {
       "package": "@mimo-ai/cli",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Four npx pins drifted since #776, each backed by a serial ACP probe of the exact pinned version. Lock-only change — four lines; no metadata, migration, or entrypoint edits, and no lock-derived test assertion embeds any of these versions.

| backend | package | old → new | initialize | session/new | probed |
|---|---|---|---|---|---|
| dimcode | `dimcode` | 0.3.2 → **0.3.8** | ok (agentInfo dimcode "DimCode" 0.3.8) | auth required (`-32000`, "Provider credentials are required") | 2026-08-10 |
| dirac | `dirac-cli` | 0.4.32 → **0.4.34** | ok (agentInfo dirac 0.4.34) | success (modes plan/act) | 2026-08-09 |
| grok | `@xai-official/grok` | 0.2.120 → **1.0.0** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") | 2026-08-08 |
| kilo | `@kilocode/cli` | 7.4.19 → **7.4.20** | ok (agentInfo Kilo 7.4.20) | success | 2026-08-08 |

All four meet the release-lock criterion: `initialize` succeeds and `session/new` either succeeds or returns a clearly classified authentication requirement. Probes ran serially with no inherited HOME or credentials. Where a probe predates this PR, the Registry has advertised that exact version unchanged on every audit since (npm versions are immutable, so the evidence still describes the pinned artifact).

**grok crosses a major version** (0.2.x → 1.0.0). The Registry entrypoint is unchanged (`agent stdio`) and the handshake behaves as it did on 0.2.120 — same protocolVersion, same auth-required classification — so no metadata change follows from the bump.

The other 7 Registry-pinned packages (autohand, codebuddy, deepagents, glm-acp-agent, nova, pi, sigit) match the snapshot exactly. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. The `mimo-code` and `omp` entries are non-Registry builtins (no `registry_json_id`) and are correctly excluded from drift reconciliation.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.09-03f0254`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.09-03f0254/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the previous baseline (38 ids).

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps.** The Test check on this PR is the authority for this change. Rationale: the merge decision already depends on CI rather than the local run, and this host's load manufactures timeout-shaped test failures that are not signal — three consecutive nightly attempts (2026-08-09/10/11) failed or could not start on a busy 12-core host (249 runnable processes; peak load 744) for this same four-line diff, each time on a different timeout-bound test. Nothing load-sensitive remains in the local steps above: clippy and fmt slow down under load but still return correct results.

## Logging

No logging changes: lock-only version bumps; existing startup/session error paths already identify a failing agent by backend.