### PR TITLE
feat(channel): add Discord Gateway plugin

### DIFF
--- a/crates/aionui-app/Cargo.toml
+++ b/crates/aionui-app/Cargo.toml
@@ -9,12 +9,13 @@ name = "aioncore"
 path = "src/main.rs"
 
 [features]
-default = ["telegram", "lark", "dingtalk", "weixin", "slack"]
+default = ["telegram", "lark", "dingtalk", "weixin", "slack", "discord"]
 telegram = ["aionui-channel/telegram"]
 lark = ["aionui-channel/lark"]
 dingtalk = ["aionui-channel/dingtalk"]
 weixin = ["aionui-channel/weixin"]
 slack = ["aionui-channel/slack"]
+discord = ["aionui-channel/discord"]
 
 [dependencies]
 aionui-common.workspace = true

--- a/crates/aionui-channel/Cargo.toml
+++ b/crates/aionui-channel/Cargo.toml
@@ -10,6 +10,7 @@ lark = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures-util", "dep:prost",
 dingtalk = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures-util", "dep:rustls", "dep:rustls-native-certs"]
 weixin = ["dep:reqwest", "dep:futures-util", "dep:base64", "dep:uuid"]
 slack = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures-util", "dep:rustls", "dep:rustls-native-certs"]
+discord = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures-util", "dep:rustls", "dep:rustls-native-certs"]
 
 [dependencies]
 aionui-common.workspace = true

--- a/crates/aionui-channel/src/constants.rs
+++ b/crates/aionui-channel/src/constants.rs
@@ -40,6 +40,9 @@ pub const DINGTALK_MESSAGE_LIMIT: usize = 4000;
 /// Maximum characters per Slack message.
 pub const SLACK_MESSAGE_LIMIT: usize = 4000;
 
+/// Maximum characters per Discord message (`content` field limit).
+pub const DISCORD_MESSAGE_LIMIT: usize = 2000;
+
 // ---------------------------------------------------------------------------
 // Reconnection (Telegram long-polling)
 // ---------------------------------------------------------------------------
@@ -63,6 +66,13 @@ pub const LARK_EVENT_DEDUP_TTL: Duration = Duration::from_secs(5 * 60);
 
 /// TTL for Slack event deduplication cache.
 pub const SLACK_EVENT_DEDUP_TTL: Duration = Duration::from_secs(5 * 60);
+
+// ---------------------------------------------------------------------------
+// Discord
+// ---------------------------------------------------------------------------
+
+/// TTL for Discord message deduplication cache (guards RESUME replays).
+pub const DISCORD_EVENT_DEDUP_TTL: Duration = Duration::from_secs(5 * 60);
 
 // ---------------------------------------------------------------------------
 // DingTalk
@@ -150,6 +160,16 @@ mod tests {
     #[test]
     fn slack_event_dedup_ttl_is_five_minutes() {
         assert_eq!(SLACK_EVENT_DEDUP_TTL, Duration::from_secs(300));
+    }
+
+    #[test]
+    fn discord_message_limit() {
+        assert_eq!(DISCORD_MESSAGE_LIMIT, 2000);
+    }
+
+    #[test]
+    fn discord_event_dedup_ttl_is_five_minutes() {
+        assert_eq!(DISCORD_EVENT_DEDUP_TTL, Duration::from_secs(300));
     }
 
     #[test]

--- a/crates/aionui-channel/src/formatter.rs
+++ b/crates/aionui-channel/src/formatter.rs
@@ -9,15 +9,16 @@ use crate::types::PluginType;
 /// - Telegram: escape HTML, then convert markdown → HTML tags
 /// - Lark/DingTalk: convert HTML tags → markdown
 /// - Slack: escape `&<>`, then convert markdown → Slack mrkdwn
-/// - WeChat/WeCom: strip all HTML
-/// - Fallback: escape HTML special chars
+/// - Discord: pass markdown through unchanged (Discord renders it natively;
+///   accidental @mentions are suppressed at send time via `allowed_mentions`)
+/// - WeChat: strip all HTML
 pub fn format_text_for_platform(text: &str, platform: PluginType) -> String {
     match platform {
         PluginType::Telegram => markdown_to_telegram_html(text),
         PluginType::Lark | PluginType::Dingtalk => html_to_markdown(text),
         PluginType::Slack => markdown_to_slack_mrkdwn(text),
+        PluginType::Discord => text.to_string(),
         PluginType::Weixin => strip_html(text),
-        _ => escape_html(text),
     }
 }
 

--- a/crates/aionui-channel/src/formatter_test.rs
+++ b/crates/aionui-channel/src/formatter_test.rs
@@ -44,3 +44,11 @@ fn slack_not_plain_escape_fallback() {
     assert_ne!(out, "**x**");
     assert_eq!(out, "*x*");
 }
+
+// Discord renders markdown natively — text passes through unchanged (no HTML
+// escaping of `<`, `>`, `&`; the old fallback would have mangled them).
+#[test]
+fn discord_passes_markdown_through_unchanged() {
+    let input = "**bold** _i_ `code` <@123> a < b & c";
+    assert_eq!(format_text_for_platform(input, PluginType::Discord), input);
+}

--- a/crates/aionui-channel/src/plugins/discord/api.rs
+++ b/crates/aionui-channel/src/plugins/discord/api.rs
@@ -1,0 +1,193 @@
+use std::time::Duration;
+
+use reqwest::{Client, RequestBuilder, Response};
+use tracing::{debug, warn};
+
+use crate::error::ChannelError;
+
+use super::types::{
+    AllowedMentions, CurrentUser, GatewayBotResponse, MessageReference, MessageResponse, RateLimitBody,
+    SendMessageRequest,
+};
+
+const DISCORD_API_BASE: &str = "https://discord.com/api/v10";
+
+/// Cap on how long we honor a Discord 429 `retry_after` before giving up.
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(30);
+
+/// Bot identity from `GET /users/@me`.
+#[derive(Debug, Clone)]
+pub(super) struct DiscordIdentity {
+    /// Bot user id (snowflake) — used to filter self-echoes and strip mentions.
+    pub id: String,
+    pub display_name: Option<String>,
+}
+
+/// HTTP client for the Discord REST API (v10).
+///
+/// A single Bot Token authorizes every call via `Authorization: Bot <token>`.
+pub(super) struct DiscordApi {
+    client: Client,
+    token: String,
+}
+
+impl DiscordApi {
+    pub fn new(client: Client, token: &str) -> Self {
+        Self {
+            client,
+            token: token.to_string(),
+        }
+    }
+
+    fn auth_header(&self) -> String {
+        format!("Bot {}", self.token)
+    }
+
+    /// Fetch the Gateway WSS URL (`GET /gateway/bot`, validates the token too).
+    pub async fn get_gateway_bot(&self) -> Result<String, ChannelError> {
+        let url = format!("{DISCORD_API_BASE}/gateway/bot");
+        let resp = self
+            .send_with_retry(|| self.client.get(&url).header("Authorization", self.auth_header()))
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            return Err(ChannelError::ConnectionFailed(format!(
+                "Discord GET /gateway/bot failed: {status}"
+            )));
+        }
+        let data: GatewayBotResponse = resp
+            .json()
+            .await
+            .map_err(|e| ChannelError::ConnectionFailed(format!("Discord gateway/bot parse failed: {e}")))?;
+        Ok(data.url)
+    }
+
+    /// Validate the bot token and fetch identity (`GET /users/@me`).
+    pub async fn get_current_user(&self) -> Result<DiscordIdentity, ChannelError> {
+        let url = format!("{DISCORD_API_BASE}/users/@me");
+        let resp = self
+            .send_with_retry(|| self.client.get(&url).header("Authorization", self.auth_header()))
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            return Err(ChannelError::InvalidConfig(format!(
+                "Discord token validation failed: {status}"
+            )));
+        }
+        let user: CurrentUser = resp
+            .json()
+            .await
+            .map_err(|e| ChannelError::InvalidConfig(format!("Discord users/@me parse failed: {e}")))?;
+        Ok(DiscordIdentity {
+            id: user.id,
+            display_name: user.global_name.or(user.username),
+        })
+    }
+
+    /// Post a message to a channel. Returns the message id (for later edits).
+    pub async fn create_message(
+        &self,
+        channel_id: &str,
+        content: &str,
+        reply_to: Option<&str>,
+    ) -> Result<String, ChannelError> {
+        let url = format!("{DISCORD_API_BASE}/channels/{channel_id}/messages");
+        let body = SendMessageRequest {
+            content: content.to_string(),
+            allowed_mentions: AllowedMentions::none(),
+            message_reference: reply_to.map(|id| MessageReference {
+                message_id: id.to_string(),
+            }),
+        };
+
+        debug!(channel_id, "Discord create message");
+
+        let resp = self
+            .send_with_retry(|| {
+                self.client
+                    .post(&url)
+                    .header("Authorization", self.auth_header())
+                    .json(&body)
+            })
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            return Err(ChannelError::MessageSendFailed(format!(
+                "Discord create message failed: {status}"
+            )));
+        }
+        let data: MessageResponse = resp
+            .json()
+            .await
+            .map_err(|e| ChannelError::MessageSendFailed(format!("Discord create message parse failed: {e}")))?;
+        Ok(data.id)
+    }
+
+    /// Edit an existing message (`PATCH /channels/{id}/messages/{msg_id}`).
+    pub async fn edit_message(&self, channel_id: &str, message_id: &str, content: &str) -> Result<(), ChannelError> {
+        let url = format!("{DISCORD_API_BASE}/channels/{channel_id}/messages/{message_id}");
+        let body = SendMessageRequest {
+            content: content.to_string(),
+            allowed_mentions: AllowedMentions::none(),
+            message_reference: None,
+        };
+
+        debug!(channel_id, message_id, "Discord edit message");
+
+        let resp = self
+            .send_with_retry(|| {
+                self.client
+                    .patch(&url)
+                    .header("Authorization", self.auth_header())
+                    .json(&body)
+            })
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            return Err(ChannelError::MessageSendFailed(format!(
+                "Discord edit message failed: {status}"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Send a request, retrying once on HTTP 429 after honoring the body's
+    /// `retry_after` (float seconds). The builder closure produces a fresh
+    /// request for each attempt.
+    async fn send_with_retry(&self, build: impl Fn() -> RequestBuilder) -> Result<Response, ChannelError> {
+        let resp = build()
+            .send()
+            .await
+            .map_err(|e| ChannelError::ConnectionFailed(format!("Discord request failed: {e}")))?;
+        if resp.status().as_u16() != 429 {
+            return Ok(resp);
+        }
+
+        let body = resp.json::<RateLimitBody>().await.ok();
+        let is_global = body.as_ref().and_then(|b| b.global).unwrap_or(false);
+        let delay = retry_after_delay(body);
+        warn!(
+            delay_ms = delay.as_millis(),
+            global = is_global,
+            "Discord rate limited (429); retrying after retry_after"
+        );
+        tokio::time::sleep(delay).await;
+        build()
+            .send()
+            .await
+            .map_err(|e| ChannelError::ConnectionFailed(format!("Discord request failed: {e}")))
+    }
+}
+
+/// Turn a 429 body's `retry_after` (float seconds) into a capped delay.
+fn retry_after_delay(body: Option<RateLimitBody>) -> Duration {
+    let secs = body
+        .and_then(|b| b.retry_after)
+        .unwrap_or(1.0)
+        .clamp(0.0, MAX_RETRY_AFTER.as_secs_f64());
+    Duration::from_secs_f64(secs)
+}
+
+#[cfg(test)]
+#[path = "api_test.rs"]
+mod api_test;

--- a/crates/aionui-channel/src/plugins/discord/api_test.rs
+++ b/crates/aionui-channel/src/plugins/discord/api_test.rs
@@ -1,0 +1,46 @@
+use super::*;
+
+#[test]
+fn api_uses_bot_auth_header() {
+    let api = DiscordApi::new(Client::new(), "abc.def.ghi");
+    assert_eq!(api.auth_header(), "Bot abc.def.ghi");
+    assert_eq!(api.token, "abc.def.ghi");
+}
+
+#[test]
+fn retry_after_uses_body_seconds() {
+    let body = RateLimitBody {
+        retry_after: Some(1.5),
+        global: Some(false),
+    };
+    assert_eq!(retry_after_delay(Some(body)), Duration::from_secs_f64(1.5));
+}
+
+#[test]
+fn retry_after_defaults_when_absent() {
+    assert_eq!(retry_after_delay(None), Duration::from_secs_f64(1.0));
+    let body = RateLimitBody {
+        retry_after: None,
+        global: None,
+    };
+    assert_eq!(retry_after_delay(Some(body)), Duration::from_secs_f64(1.0));
+}
+
+#[test]
+fn retry_after_is_capped() {
+    let body = RateLimitBody {
+        retry_after: Some(999.0),
+        global: Some(true),
+    };
+    assert_eq!(retry_after_delay(Some(body)), Duration::from_secs(30));
+}
+
+#[test]
+fn discord_identity_holds_id() {
+    let id = DiscordIdentity {
+        id: "BOT1".into(),
+        display_name: Some("aion".into()),
+    };
+    assert_eq!(id.id, "BOT1");
+    assert_eq!(id.display_name.as_deref(), Some("aion"));
+}

--- a/crates/aionui-channel/src/plugins/discord/gateway.rs
+++ b/crates/aionui-channel/src/plugins/discord/gateway.rs
@@ -1,0 +1,356 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::{Mutex, mpsc, watch};
+use tracing::{debug, error, info, warn};
+
+use crate::constants::DISCORD_EVENT_DEDUP_TTL;
+use crate::error::ChannelError;
+use crate::types::UnifiedIncomingMessage;
+
+use super::api::DiscordApi;
+use super::types::{
+    GatewayFrame, Hello, MessageCreate, Ready, build_heartbeat, build_identify, build_resume, message_to_unified, op,
+};
+
+/// Maximum reconnect attempts before giving up.
+const MAX_RECONNECT_ATTEMPTS: u32 = 10;
+
+/// Maximum backoff delay between reconnection attempts.
+const MAX_RECONNECT_DELAY: Duration = Duration::from_secs(30);
+
+/// Shared message-deduplication cache: message id → first-seen instant.
+/// Guards against MESSAGE_CREATE replays after a RESUME.
+pub(super) type DedupCache = Arc<Mutex<HashMap<String, Instant>>>;
+
+/// What the connection asks the outer loop to do next.
+enum ConnResult {
+    /// Reconnect (resuming when a session is still cached).
+    Reconnect,
+    /// Shutdown requested — stop the loop.
+    Shutdown,
+}
+
+/// Session state carried across (re)connections.
+#[derive(Default)]
+struct Session {
+    id: Option<String>,
+    resume_url: Option<String>,
+    last_seq: Option<u64>,
+}
+
+/// Maintain the Discord Gateway connection: connect, IDENTIFY (or RESUME),
+/// heartbeat, dispatch MESSAGE_CREATE, and reconnect with backoff. Exits on
+/// shutdown or after `MAX_RECONNECT_ATTEMPTS` consecutive failures.
+pub(super) async fn gateway_loop(
+    api: Arc<DiscordApi>,
+    token: String,
+    bot_user_id: String,
+    message_tx: mpsc::Sender<UnifiedIncomingMessage>,
+    dedup_cache: DedupCache,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    let mut session = Session::default();
+    let mut consecutive_errors: u32 = 0;
+
+    loop {
+        if *shutdown_rx.borrow() {
+            break;
+        }
+
+        // Resume against the cached gateway URL when a session exists;
+        // otherwise fetch a fresh URL and do a full IDENTIFY.
+        let resume = session.id.is_some() && session.resume_url.is_some();
+        let base_url = if resume {
+            session.resume_url.clone().expect("resume_url present")
+        } else {
+            match api.get_gateway_bot().await {
+                Ok(url) => url,
+                Err(e) => {
+                    consecutive_errors += 1;
+                    warn!(error = %e, consecutive_errors, "Discord GET /gateway/bot failed");
+                    if consecutive_errors >= MAX_RECONNECT_ATTEMPTS {
+                        error!("Discord max reconnect attempts reached");
+                        break;
+                    }
+                    if sleep_or_shutdown(backoff_delay(consecutive_errors), &mut shutdown_rx).await {
+                        break;
+                    }
+                    continue;
+                }
+            }
+        };
+
+        match connect_and_run(
+            &gateway_ws_url(&base_url),
+            resume,
+            &token,
+            &bot_user_id,
+            &mut session,
+            &message_tx,
+            &dedup_cache,
+            &mut shutdown_rx,
+        )
+        .await
+        {
+            Ok(ConnResult::Shutdown) => break,
+            Ok(ConnResult::Reconnect) => {
+                consecutive_errors = 0;
+            }
+            Err(e) => {
+                consecutive_errors += 1;
+                warn!(error = %e, consecutive_errors, "Discord gateway connection error");
+                if consecutive_errors >= MAX_RECONNECT_ATTEMPTS {
+                    error!("Discord max reconnect attempts reached");
+                    break;
+                }
+                if sleep_or_shutdown(backoff_delay(consecutive_errors), &mut shutdown_rx).await {
+                    break;
+                }
+            }
+        }
+    }
+
+    debug!("Discord gateway loop exited");
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn connect_and_run(
+    ws_url: &str,
+    resume: bool,
+    token: &str,
+    bot_user_id: &str,
+    session: &mut Session,
+    message_tx: &mpsc::Sender<UnifiedIncomingMessage>,
+    dedup_cache: &DedupCache,
+    shutdown_rx: &mut watch::Receiver<bool>,
+) -> Result<ConnResult, ChannelError> {
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::connect_async_tls_with_config;
+    use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+    let connector = build_tls_connector()?;
+    let (ws_stream, _) = connect_async_tls_with_config(ws_url, None, false, Some(connector))
+        .await
+        .map_err(|e| ChannelError::ConnectionFailed(format!("Discord WS connect failed: {e}")))?;
+
+    let (mut write, mut read) = ws_stream.split();
+
+    // First frame must be Hello (op 10) carrying the heartbeat interval.
+    let heartbeat_interval = match read.next().await {
+        Some(Ok(WsMessage::Text(txt))) => {
+            let frame: GatewayFrame = serde_json::from_str(txt.as_str())
+                .map_err(|e| ChannelError::ConnectionFailed(format!("Discord Hello parse failed: {e}")))?;
+            if frame.op != op::HELLO {
+                return Err(ChannelError::ConnectionFailed(format!(
+                    "Discord expected Hello, got op {}",
+                    frame.op
+                )));
+            }
+            let hello: Hello = frame
+                .d
+                .and_then(|d| serde_json::from_value(d).ok())
+                .ok_or_else(|| ChannelError::ConnectionFailed("Discord Hello missing heartbeat_interval".into()))?;
+            hello.heartbeat_interval
+        }
+        _ => return Err(ChannelError::ConnectionFailed("Discord did not send Hello".into())),
+    };
+
+    // Resume an existing session, or identify anew.
+    let opening = if resume {
+        match (&session.id, session.last_seq) {
+            (Some(sid), Some(seq)) => build_resume(token, sid, seq),
+            _ => build_identify(token),
+        }
+    } else {
+        build_identify(token)
+    };
+    write
+        .send(WsMessage::Text(opening.into()))
+        .await
+        .map_err(|e| ChannelError::ConnectionFailed(format!("Discord IDENTIFY/RESUME send failed: {e}")))?;
+
+    info!(resume, "Discord gateway connected");
+
+    let mut interval = tokio::time::interval(Duration::from_millis(heartbeat_interval));
+    interval.tick().await; // consume the immediate first tick
+    let mut heartbeat_acked = true;
+
+    loop {
+        tokio::select! {
+            msg = read.next() => {
+                match msg {
+                    Some(Ok(WsMessage::Text(txt))) => {
+                        let frame: GatewayFrame = match serde_json::from_str(txt.as_str()) {
+                            Ok(f) => f,
+                            Err(e) => { warn!(error = %e, "Discord frame parse failed"); continue; }
+                        };
+                        if let Some(s) = frame.s {
+                            session.last_seq = Some(s);
+                        }
+                        match frame.op {
+                            op::HEARTBEAT => {
+                                let _ = write.send(WsMessage::Text(build_heartbeat(session.last_seq).into())).await;
+                            }
+                            op::HEARTBEAT_ACK => heartbeat_acked = true,
+                            op::RECONNECT => {
+                                debug!("Discord op 7 Reconnect; will resume");
+                                return Ok(ConnResult::Reconnect);
+                            }
+                            op::INVALID_SESSION => {
+                                let resumable = frame.d.as_ref().and_then(|d| d.as_bool()).unwrap_or(false);
+                                if !resumable {
+                                    debug!("Discord Invalid Session (not resumable); clearing session");
+                                    session.id = None;
+                                    session.resume_url = None;
+                                    session.last_seq = None;
+                                }
+                                return Ok(ConnResult::Reconnect);
+                            }
+                            op::DISPATCH => {
+                                handle_dispatch(&frame, bot_user_id, session, message_tx, dedup_cache).await;
+                            }
+                            other => debug!(op = other, "Discord unhandled opcode"),
+                        }
+                    }
+                    Some(Ok(WsMessage::Ping(data))) => { let _ = write.send(WsMessage::Pong(data)).await; }
+                    Some(Ok(WsMessage::Close(_))) => {
+                        debug!("Discord WS received close frame");
+                        return Ok(ConnResult::Reconnect);
+                    }
+                    Some(Err(e)) => return Err(ChannelError::ConnectionFailed(format!("Discord WS read error: {e}"))),
+                    None => return Err(ChannelError::ConnectionFailed("Discord WS stream ended".into())),
+                    _ => {}
+                }
+            }
+            _ = interval.tick() => {
+                if !heartbeat_acked {
+                    // No ACK since the last heartbeat — connection is a zombie.
+                    warn!("Discord heartbeat not acked; reconnecting");
+                    return Err(ChannelError::ConnectionFailed("Discord heartbeat ACK missing".into()));
+                }
+                heartbeat_acked = false;
+                let _ = write.send(WsMessage::Text(build_heartbeat(session.last_seq).into())).await;
+            }
+            _ = shutdown_rx.changed() => {
+                debug!("Discord gateway shutdown during listen");
+                return Ok(ConnResult::Shutdown);
+            }
+        }
+    }
+}
+
+/// Handle an op-0 dispatch: track session on READY, normalize MESSAGE_CREATE.
+async fn handle_dispatch(
+    frame: &GatewayFrame,
+    bot_user_id: &str,
+    session: &mut Session,
+    message_tx: &mpsc::Sender<UnifiedIncomingMessage>,
+    dedup_cache: &DedupCache,
+) {
+    match frame.t.as_deref() {
+        Some("READY") => {
+            if let Some(ready) = frame.d.clone().and_then(|d| serde_json::from_value::<Ready>(d).ok()) {
+                session.id = Some(ready.session_id);
+                // Store the RAW resume URL; the connect site wraps it with the
+                // `?v=10&encoding=json` query exactly once (same as the fresh
+                // identify path). Wrapping here too would double the query and
+                // make the resume connect URL invalid.
+                session.resume_url = Some(ready.resume_gateway_url);
+                info!(bot_user_id = %ready.user.id, "Discord gateway READY");
+            }
+        }
+        Some("RESUMED") => debug!("Discord gateway RESUMED"),
+        Some("MESSAGE_CREATE") => {
+            let Some(d) = frame.d.clone() else { return };
+            let msg: MessageCreate = match serde_json::from_value(d) {
+                Ok(m) => m,
+                Err(e) => {
+                    warn!(error = %e, "Discord MESSAGE_CREATE parse failed");
+                    return;
+                }
+            };
+            if is_duplicate(dedup_cache, &msg.id).await {
+                debug!(message_id = %msg.id, "Discord duplicate message, skipping");
+                return;
+            }
+            if let Some(unified) = message_to_unified(&msg, bot_user_id) {
+                let _ = message_tx.send(unified).await;
+            }
+        }
+        _ => {}
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Deduplication
+// ---------------------------------------------------------------------------
+
+pub(super) async fn is_duplicate(cache: &DedupCache, id: &str) -> bool {
+    let mut map = cache.lock().await;
+    if map.contains_key(id) {
+        return true;
+    }
+    map.insert(id.to_string(), Instant::now());
+    false
+}
+
+pub(super) async fn cleanup_expired_events(cache: &DedupCache) {
+    let mut map = cache.lock().await;
+    let before = map.len();
+    map.retain(|_, instant| instant.elapsed() < DISCORD_EVENT_DEDUP_TTL);
+    let removed = before - map.len();
+    if removed > 0 {
+        debug!(removed, remaining = map.len(), "Discord dedup cache cleanup");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Append the required `?v=10&encoding=json` query to a gateway base URL.
+fn gateway_ws_url(base: &str) -> String {
+    format!("{}/?v=10&encoding=json", base.trim_end_matches('/'))
+}
+
+/// Exponential backoff delay, capped at `MAX_RECONNECT_DELAY`.
+fn backoff_delay(attempt: u32) -> Duration {
+    let delay_secs = 2u64.saturating_pow(attempt).min(MAX_RECONNECT_DELAY.as_secs());
+    Duration::from_secs(delay_secs)
+}
+
+/// Sleep for `delay`, returning true if shutdown fired first.
+async fn sleep_or_shutdown(delay: Duration, shutdown_rx: &mut watch::Receiver<bool>) -> bool {
+    tokio::select! {
+        _ = tokio::time::sleep(delay) => false,
+        _ = shutdown_rx.changed() => true,
+    }
+}
+
+/// Build a TLS connector pinned to `http/1.1` ALPN (WebSocket upgrade needs it).
+fn build_tls_connector() -> Result<tokio_tungstenite::Connector, ChannelError> {
+    use tokio_tungstenite::Connector;
+
+    let certs = rustls_native_certs::load_native_certs();
+    let mut root_store = rustls::RootCertStore::empty();
+    root_store.add_parsable_certificates(certs.certs);
+
+    let provider = rustls::crypto::CryptoProvider::get_default()
+        .cloned()
+        .unwrap_or_else(|| Arc::new(rustls::crypto::ring::default_provider()));
+
+    let mut config = rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| ChannelError::ConnectionFailed(format!("TLS config error: {e}")))?
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    config.alpn_protocols = vec![b"http/1.1".to_vec()];
+
+    Ok(Connector::Rustls(Arc::new(config)))
+}
+
+#[cfg(test)]
+#[path = "gateway_test.rs"]
+mod gateway_test;

--- a/crates/aionui-channel/src/plugins/discord/gateway_test.rs
+++ b/crates/aionui-channel/src/plugins/discord/gateway_test.rs
@@ -1,0 +1,135 @@
+use super::*;
+use serde_json::json;
+
+// -- gateway_ws_url ----------------------------------------------------------
+
+#[test]
+fn ws_url_appends_query() {
+    assert_eq!(
+        gateway_ws_url("wss://gateway.discord.gg"),
+        "wss://gateway.discord.gg/?v=10&encoding=json"
+    );
+}
+
+#[test]
+fn ws_url_trims_trailing_slash() {
+    assert_eq!(
+        gateway_ws_url("wss://gateway.discord.gg/"),
+        "wss://gateway.discord.gg/?v=10&encoding=json"
+    );
+}
+
+// -- backoff -----------------------------------------------------------------
+
+#[test]
+fn backoff_exponential_and_capped() {
+    assert_eq!(backoff_delay(1), Duration::from_secs(2));
+    assert_eq!(backoff_delay(3), Duration::from_secs(8));
+    assert_eq!(backoff_delay(20), Duration::from_secs(30));
+}
+
+// -- dedup -------------------------------------------------------------------
+
+fn cache() -> DedupCache {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+
+#[tokio::test]
+async fn dedup_first_then_duplicate() {
+    let c = cache();
+    assert!(!is_duplicate(&c, "m1").await);
+    assert!(is_duplicate(&c, "m1").await);
+    assert!(!is_duplicate(&c, "m2").await);
+}
+
+#[tokio::test]
+async fn cleanup_removes_expired_only() {
+    let c = cache();
+    {
+        let mut map = c.lock().await;
+        map.insert(
+            "old".into(),
+            Instant::now() - DISCORD_EVENT_DEDUP_TTL - Duration::from_secs(1),
+        );
+        map.insert("new".into(), Instant::now());
+    }
+    cleanup_expired_events(&c).await;
+    let map = c.lock().await;
+    assert!(!map.contains_key("old"));
+    assert!(map.contains_key("new"));
+}
+
+// -- handle_dispatch ---------------------------------------------------------
+
+#[tokio::test]
+async fn dispatch_ready_sets_session() {
+    let (tx, _rx) = mpsc::channel(4);
+    let c = cache();
+    let mut session = Session::default();
+    let frame: GatewayFrame = serde_json::from_value(json!({
+        "op": 0, "t": "READY", "s": 1,
+        "d": { "session_id": "sess1", "resume_gateway_url": "wss://resume.example", "user": { "id": "BOT1" } }
+    }))
+    .unwrap();
+    handle_dispatch(&frame, "BOT1", &mut session, &tx, &c).await;
+    assert_eq!(session.id.as_deref(), Some("sess1"));
+    // READY stores the RAW resume URL (the connect site adds the query once).
+    assert_eq!(session.resume_url.as_deref(), Some("wss://resume.example"));
+}
+
+/// Regression (H1): the resume connect URL must carry exactly one
+/// `?v=10&encoding=json`. READY stores the raw URL, so wrapping it once at the
+/// connect site (as gateway_loop does) yields a valid single-query URL — not
+/// the `.../?v=10&encoding=json/?v=10&encoding=json` a double-wrap produced.
+#[tokio::test]
+async fn resume_connect_url_has_single_query() {
+    let (tx, _rx) = mpsc::channel(4);
+    let c = cache();
+    let mut session = Session::default();
+    let frame: GatewayFrame = serde_json::from_value(json!({
+        "op": 0, "t": "READY", "s": 1,
+        "d": { "session_id": "sess1", "resume_gateway_url": "wss://resume.example", "user": { "id": "BOT1" } }
+    }))
+    .unwrap();
+    handle_dispatch(&frame, "BOT1", &mut session, &tx, &c).await;
+
+    // Reproduce the reconnect composition: connect site wraps the stored URL.
+    let connect_url = gateway_ws_url(session.resume_url.as_deref().unwrap());
+    assert_eq!(connect_url, "wss://resume.example/?v=10&encoding=json");
+    assert_eq!(connect_url.matches("?v=10&encoding=json").count(), 1);
+}
+
+#[tokio::test]
+async fn dispatch_message_create_dm_forwards_once() {
+    let (tx, mut rx) = mpsc::channel(4);
+    let c = cache();
+    let mut session = Session::default();
+    let frame: GatewayFrame = serde_json::from_value(json!({
+        "op": 0, "t": "MESSAGE_CREATE", "s": 2,
+        "d": { "id": "175928847299117063", "channel_id": "D1", "author": { "id": "U1", "username": "a" }, "content": "hi" }
+    }))
+    .unwrap();
+
+    handle_dispatch(&frame, "BOT1", &mut session, &tx, &c).await;
+    let msg = rx.try_recv().expect("forwarded");
+    assert_eq!(msg.chat_id, "D1");
+    assert_eq!(msg.content.text, "hi");
+
+    // Same message id again → deduped.
+    handle_dispatch(&frame, "BOT1", &mut session, &tx, &c).await;
+    assert!(rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn dispatch_guild_without_mention_dropped() {
+    let (tx, mut rx) = mpsc::channel(4);
+    let c = cache();
+    let mut session = Session::default();
+    let frame: GatewayFrame = serde_json::from_value(json!({
+        "op": 0, "t": "MESSAGE_CREATE", "s": 3,
+        "d": { "id": "175928847299117064", "channel_id": "C1", "guild_id": "G1", "author": { "id": "U1" }, "content": "hello", "mentions": [] }
+    }))
+    .unwrap();
+    handle_dispatch(&frame, "BOT1", &mut session, &tx, &c).await;
+    assert!(rx.try_recv().is_err());
+}

--- a/crates/aionui-channel/src/plugins/discord/mod.rs
+++ b/crates/aionui-channel/src/plugins/discord/mod.rs
@@ -1,0 +1,6 @@
+mod api;
+mod gateway;
+mod plugin;
+mod types;
+
+pub use plugin::DiscordPlugin;

--- a/crates/aionui-channel/src/plugins/discord/plugin.rs
+++ b/crates/aionui-channel/src/plugins/discord/plugin.rs
@@ -1,0 +1,249 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::Client;
+use tokio::sync::{Mutex, watch};
+use tokio::task::JoinHandle;
+use tracing::info;
+
+use crate::constants::DISCORD_MESSAGE_LIMIT;
+use crate::error::ChannelError;
+use crate::plugin::{ChannelPlugin, PluginCallbacks};
+use crate::types::{BotInfo, PluginConfig, PluginStatus, PluginType, UnifiedOutgoingMessage};
+
+use super::api::DiscordApi;
+use super::gateway::{DedupCache, cleanup_expired_events, gateway_loop};
+
+/// Interval between dedup-cache cleanup sweeps.
+const DEDUP_CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Discord platform plugin (Gateway).
+///
+/// Connects to the Discord Gateway over a WebSocket, receives MESSAGE_CREATE
+/// events, and replies via the REST API (create/edit message). Editing is
+/// supported, so streaming responses use the standard editable relay path.
+pub struct DiscordPlugin {
+    // Lifecycle state
+    status: PluginStatus,
+    bot_info: Option<BotInfo>,
+    last_error: Option<String>,
+    /// Bot user id (snowflake), used to filter self-echoes and strip mentions.
+    bot_user_id: String,
+    /// Bot token, retained for the Gateway IDENTIFY/RESUME handshake.
+    token: String,
+
+    // Dependencies (set during `initialize`)
+    api: Option<Arc<DiscordApi>>,
+    callbacks: Option<PluginCallbacks>,
+
+    // Background tasks
+    gateway_handle: Option<JoinHandle<()>>,
+    cleanup_handle: Option<JoinHandle<()>>,
+    shutdown_tx: Option<watch::Sender<bool>>,
+
+    /// Shared message-deduplication cache.
+    dedup_cache: DedupCache,
+}
+
+impl Default for DiscordPlugin {
+    fn default() -> Self {
+        Self {
+            status: PluginStatus::Created,
+            bot_info: None,
+            last_error: None,
+            bot_user_id: String::new(),
+            token: String::new(),
+            api: None,
+            callbacks: None,
+            gateway_handle: None,
+            cleanup_handle: None,
+            shutdown_tx: None,
+            dedup_cache: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl DiscordPlugin {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait::async_trait]
+impl ChannelPlugin for DiscordPlugin {
+    async fn initialize(&mut self, config: PluginConfig, callbacks: PluginCallbacks) -> Result<(), ChannelError> {
+        self.status = PluginStatus::Initializing;
+
+        let token = config
+            .credentials
+            .token
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                self.status = PluginStatus::Error;
+                self.last_error = Some("Missing Discord bot token".into());
+                ChannelError::InvalidConfig("Missing Discord bot token".into())
+            })?
+            .to_string();
+
+        let http_client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|e| {
+                self.status = PluginStatus::Error;
+                self.last_error = Some(format!("HTTP client init failed: {e}"));
+                ChannelError::ConnectionFailed(format!("HTTP client init failed: {e}"))
+            })?;
+
+        let api = Arc::new(DiscordApi::new(http_client, &token));
+
+        // Validate the token and capture the bot identity.
+        let identity = api.get_current_user().await.map_err(|e| {
+            self.status = PluginStatus::Error;
+            self.last_error = Some(format!("Credential validation failed: {e}"));
+            e
+        })?;
+
+        self.bot_user_id = identity.id.clone();
+        self.bot_info = Some(BotInfo {
+            id: identity.id,
+            username: identity.display_name.clone(),
+            display_name: identity.display_name.unwrap_or_else(|| "Discord Bot".into()),
+        });
+
+        info!(bot_user_id = %self.bot_user_id, "Discord bot initialized");
+
+        self.token = token;
+        self.api = Some(api);
+        self.callbacks = Some(callbacks);
+        self.status = PluginStatus::Ready;
+        Ok(())
+    }
+
+    async fn start(&mut self) -> Result<(), ChannelError> {
+        self.status = PluginStatus::Starting;
+
+        let callbacks = self.callbacks.take().ok_or_else(|| {
+            self.status = PluginStatus::Error;
+            ChannelError::ConnectionFailed("Plugin not initialized".into())
+        })?;
+        // Discord MVP does not surface interactive tool confirmations; drop the
+        // confirm sender clone.
+        let PluginCallbacks {
+            message_tx,
+            confirm_tx: _,
+        } = callbacks;
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        self.shutdown_tx = Some(shutdown_tx);
+
+        let api = Arc::clone(self.api.as_ref().expect("api set in initialize"));
+        let token = self.token.clone();
+        let bot_user_id = self.bot_user_id.clone();
+        let dedup_cache = Arc::clone(&self.dedup_cache);
+
+        self.gateway_handle = Some(tokio::spawn(gateway_loop(
+            api,
+            token,
+            bot_user_id,
+            message_tx,
+            Arc::clone(&dedup_cache),
+            shutdown_rx,
+        )));
+
+        let mut cleanup_shutdown = self.shutdown_tx.as_ref().expect("shutdown_tx just set").subscribe();
+        self.cleanup_handle = Some(tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = tokio::time::sleep(DEDUP_CLEANUP_INTERVAL) => {
+                        cleanup_expired_events(&dedup_cache).await;
+                    }
+                    _ = cleanup_shutdown.changed() => break,
+                }
+            }
+        }));
+
+        self.status = PluginStatus::Running;
+        info!("Discord plugin started");
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<(), ChannelError> {
+        self.status = PluginStatus::Stopping;
+
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(true);
+        }
+        if let Some(handle) = self.gateway_handle.take() {
+            let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+        }
+        if let Some(handle) = self.cleanup_handle.take() {
+            let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
+        }
+
+        self.api = None;
+        self.status = PluginStatus::Stopped;
+        info!("Discord plugin stopped");
+        Ok(())
+    }
+
+    async fn send_message(&self, chat_id: &str, message: UnifiedOutgoingMessage) -> Result<String, ChannelError> {
+        let api = self
+            .api
+            .as_ref()
+            .ok_or_else(|| ChannelError::PlatformApi("Plugin not initialized".into()))?;
+
+        let text = truncate_message(message.text.as_deref().unwrap_or(""), DISCORD_MESSAGE_LIMIT);
+        api.create_message(chat_id, &text, message.reply_to_message_id.as_deref())
+            .await
+    }
+
+    async fn edit_message(
+        &self,
+        chat_id: &str,
+        message_id: &str,
+        message: UnifiedOutgoingMessage,
+    ) -> Result<(), ChannelError> {
+        let api = self
+            .api
+            .as_ref()
+            .ok_or_else(|| ChannelError::PlatformApi("Plugin not initialized".into()))?;
+
+        let text = truncate_message(message.text.as_deref().unwrap_or(""), DISCORD_MESSAGE_LIMIT);
+        api.edit_message(chat_id, message_id, &text).await
+    }
+
+    fn active_user_count(&self) -> usize {
+        0
+    }
+
+    fn bot_info(&self) -> Option<&BotInfo> {
+        self.bot_info.as_ref()
+    }
+
+    fn plugin_type(&self) -> PluginType {
+        PluginType::Discord
+    }
+
+    fn status(&self) -> PluginStatus {
+        self.status
+    }
+
+    fn last_error(&self) -> Option<&str> {
+        self.last_error.as_deref()
+    }
+}
+
+/// Truncate a message to the platform limit, appending "..." if truncated.
+fn truncate_message(text: &str, limit: usize) -> String {
+    if text.len() <= limit {
+        return text.to_string();
+    }
+    let truncated: String = text.chars().take(limit.saturating_sub(3)).collect();
+    format!("{truncated}...")
+}
+
+#[cfg(test)]
+#[path = "plugin_test.rs"]
+mod plugin_test;

--- a/crates/aionui-channel/src/plugins/discord/plugin_test.rs
+++ b/crates/aionui-channel/src/plugins/discord/plugin_test.rs
@@ -1,0 +1,70 @@
+use super::*;
+use crate::types::PluginCredentials;
+use serde_json::json;
+use tokio::sync::mpsc;
+
+fn make_config(token: Option<&str>) -> PluginConfig {
+    let mut obj = serde_json::Map::new();
+    if let Some(t) = token {
+        obj.insert("token".into(), json!(t));
+    }
+    let credentials: PluginCredentials = serde_json::from_value(serde_json::Value::Object(obj)).unwrap();
+    PluginConfig {
+        credentials,
+        config: None,
+    }
+}
+
+fn make_callbacks() -> PluginCallbacks {
+    let (message_tx, _mr) = mpsc::channel(4);
+    let (confirm_tx, _cr) = mpsc::channel(4);
+    PluginCallbacks { message_tx, confirm_tx }
+}
+
+// -- initialize bad paths (validated before any network call) ----------------
+
+#[tokio::test]
+async fn initialize_missing_token_fails() {
+    let mut plugin = DiscordPlugin::new();
+    let result = plugin.initialize(make_config(None), make_callbacks()).await;
+    assert!(matches!(result, Err(ChannelError::InvalidConfig(_))));
+    assert_eq!(plugin.status(), PluginStatus::Error);
+    assert!(plugin.last_error().unwrap().contains("token"));
+}
+
+#[tokio::test]
+async fn initialize_empty_token_fails() {
+    let mut plugin = DiscordPlugin::new();
+    let result = plugin.initialize(make_config(Some("")), make_callbacks()).await;
+    assert!(matches!(result, Err(ChannelError::InvalidConfig(_))));
+    assert_eq!(plugin.status(), PluginStatus::Error);
+}
+
+// -- accessors / defaults ----------------------------------------------------
+
+#[test]
+fn new_plugin_is_created_state() {
+    let plugin = DiscordPlugin::new();
+    assert_eq!(plugin.status(), PluginStatus::Created);
+    assert!(plugin.bot_info().is_none());
+    assert_eq!(plugin.plugin_type(), PluginType::Discord);
+    assert_eq!(plugin.active_user_count(), 0);
+    assert!(plugin.last_error().is_none());
+}
+
+// -- truncate_message --------------------------------------------------------
+
+#[test]
+fn truncate_within_limit() {
+    assert_eq!(truncate_message("hello", 100), "hello");
+}
+
+#[test]
+fn truncate_exceeds_limit() {
+    assert_eq!(truncate_message("Hello, world!", 10), "Hello, ...");
+}
+
+#[test]
+fn truncate_unicode() {
+    assert_eq!(truncate_message("你好世界测试文本", 5), "你好...");
+}

--- a/crates/aionui-channel/src/plugins/discord/types.rs
+++ b/crates/aionui-channel/src/plugins/discord/types.rs
@@ -1,0 +1,283 @@
+use serde::{Deserialize, Serialize};
+
+use crate::types::{MessageContentType, PluginType, UnifiedIncomingMessage, UnifiedMessageContent, UnifiedUser};
+
+// ---------------------------------------------------------------------------
+// Gateway intents (verified: docs.discord.com/developers/topics/gateway#gateway-intents)
+// ---------------------------------------------------------------------------
+
+/// Bitwise-combined intents the bot requests in IDENTIFY.
+///
+/// GUILDS (1<<0) + GUILD_MESSAGES (1<<9) + DIRECT_MESSAGES (1<<12) +
+/// MESSAGE_CONTENT (1<<15, privileged — must be enabled in the Developer
+/// Portal, otherwise `content` arrives empty).
+pub(super) const DISCORD_INTENTS: u64 = (1 << 0) | (1 << 9) | (1 << 12) | (1 << 15);
+
+/// Discord snowflake epoch in unix ms (2015-01-01T00:00:00Z).
+const DISCORD_EPOCH_MS: i64 = 1_420_070_400_000;
+
+// ---------------------------------------------------------------------------
+// Gateway opcodes (verified: docs.discord.com/developers/topics/opcodes-and-status-codes)
+// ---------------------------------------------------------------------------
+
+pub(super) mod op {
+    pub const DISPATCH: u8 = 0;
+    pub const HEARTBEAT: u8 = 1;
+    pub const IDENTIFY: u8 = 2;
+    pub const RESUME: u8 = 6;
+    pub const RECONNECT: u8 = 7;
+    pub const INVALID_SESSION: u8 = 9;
+    pub const HELLO: u8 = 10;
+    pub const HEARTBEAT_ACK: u8 = 11;
+}
+
+// ---------------------------------------------------------------------------
+// REST responses (https://discord.com/api/v10)
+// ---------------------------------------------------------------------------
+
+/// Response from `GET /gateway/bot` — the WSS URL to connect to.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct GatewayBotResponse {
+    pub url: String,
+}
+
+/// Response from `GET /users/@me` — the bot's own identity.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct CurrentUser {
+    pub id: String,
+    #[serde(default)]
+    pub username: Option<String>,
+    #[serde(default)]
+    pub global_name: Option<String>,
+}
+
+/// Request body for `POST /channels/{id}/messages` and `PATCH .../{msg_id}`.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct SendMessageRequest {
+    pub content: String,
+    /// Suppress accidental @everyone/@here/user pings coming from agent text.
+    pub allowed_mentions: AllowedMentions,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_reference: Option<MessageReference>,
+}
+
+/// `allowed_mentions` with an empty `parse` list disables all mentions.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct AllowedMentions {
+    pub parse: Vec<String>,
+}
+
+impl AllowedMentions {
+    pub fn none() -> Self {
+        Self { parse: Vec::new() }
+    }
+}
+
+/// Reference to a message being replied to.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct MessageReference {
+    pub message_id: String,
+}
+
+/// Response from create/edit message — we only need the message id.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct MessageResponse {
+    pub id: String,
+}
+
+/// Body of a 429 response (`retry_after` is float **seconds**).
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct RateLimitBody {
+    #[serde(default)]
+    pub retry_after: Option<f64>,
+    #[serde(default)]
+    pub global: Option<bool>,
+}
+
+// ---------------------------------------------------------------------------
+// Gateway payloads
+// ---------------------------------------------------------------------------
+
+/// A generic inbound Gateway frame: `{ op, d, s, t }`.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct GatewayFrame {
+    pub op: u8,
+    #[serde(default)]
+    pub d: Option<serde_json::Value>,
+    #[serde(default)]
+    pub s: Option<u64>,
+    #[serde(default)]
+    pub t: Option<String>,
+}
+
+/// `d` of a Hello (op 10) frame.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct Hello {
+    pub heartbeat_interval: u64,
+}
+
+/// `d` of a READY dispatch — session bookkeeping + bot identity.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct Ready {
+    pub session_id: String,
+    pub resume_gateway_url: String,
+    pub user: ReadyUser,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct ReadyUser {
+    pub id: String,
+}
+
+/// `d` of a MESSAGE_CREATE dispatch (only the fields we consume). MESSAGE_CREATE
+/// adds `guild_id` (absent for DMs) on top of the base message object.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct MessageCreate {
+    pub id: String,
+    pub channel_id: String,
+    #[serde(default)]
+    pub guild_id: Option<String>,
+    pub author: Author,
+    #[serde(default)]
+    pub content: String,
+    #[serde(default)]
+    pub mentions: Vec<MentionUser>,
+    #[serde(default)]
+    pub message_reference: Option<IncomingMessageReference>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct Author {
+    pub id: String,
+    #[serde(default)]
+    pub username: Option<String>,
+    #[serde(default)]
+    pub global_name: Option<String>,
+    #[serde(default)]
+    pub bot: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct MentionUser {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct IncomingMessageReference {
+    #[serde(default)]
+    pub message_id: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Outbound Gateway frame builders
+// ---------------------------------------------------------------------------
+
+/// Build a heartbeat frame (op 1, `d` = last sequence or null).
+pub(super) fn build_heartbeat(last_seq: Option<u64>) -> String {
+    serde_json::json!({ "op": op::HEARTBEAT, "d": last_seq }).to_string()
+}
+
+/// Build an IDENTIFY frame (op 2).
+pub(super) fn build_identify(token: &str) -> String {
+    serde_json::json!({
+        "op": op::IDENTIFY,
+        "d": {
+            "token": token,
+            "intents": DISCORD_INTENTS,
+            "properties": { "os": "linux", "browser": "aionui", "device": "aionui" }
+        }
+    })
+    .to_string()
+}
+
+/// Build a RESUME frame (op 6).
+pub(super) fn build_resume(token: &str, session_id: &str, seq: u64) -> String {
+    serde_json::json!({
+        "op": op::RESUME,
+        "d": { "token": token, "session_id": session_id, "seq": seq }
+    })
+    .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Normalization: MESSAGE_CREATE → UnifiedIncomingMessage
+// ---------------------------------------------------------------------------
+
+/// Extract a unix-ms timestamp from a Discord snowflake id
+/// (`(id >> 22) + DISCORD_EPOCH`). Avoids ISO-8601 parsing.
+pub(super) fn snowflake_to_ms(id: &str) -> i64 {
+    id.parse::<u64>()
+        .map(|n| ((n >> 22) as i64) + DISCORD_EPOCH_MS)
+        .unwrap_or(0)
+}
+
+/// Strip a leading bot mention (`<@id>` or `<@!id>`) from `@mention` text.
+pub(super) fn strip_bot_mention(text: &str, bot_user_id: &str) -> String {
+    let mut out = text.to_string();
+    if !bot_user_id.is_empty() {
+        out = out.replace(&format!("<@{bot_user_id}>"), "");
+        out = out.replace(&format!("<@!{bot_user_id}>"), "");
+    }
+    out.trim().to_string()
+}
+
+/// Convert a MESSAGE_CREATE into a `UnifiedIncomingMessage`, or `None` when it
+/// must be ignored. Accepts only DMs (no `guild_id`) or guild messages that
+/// @mention the bot — mirrors the Slack M1 DM/@mention gate — and never
+/// accepts messages authored by a bot (including the bot itself).
+pub(super) fn message_to_unified(msg: &MessageCreate, bot_user_id: &str) -> Option<UnifiedIncomingMessage> {
+    // Drop anything authored by a bot (including our own echoes) to avoid loops.
+    if msg.author.bot == Some(true) {
+        return None;
+    }
+    if !bot_user_id.is_empty() && msg.author.id == bot_user_id {
+        return None;
+    }
+
+    let is_dm = msg.guild_id.is_none();
+    let is_mention = !bot_user_id.is_empty() && msg.mentions.iter().any(|u| u.id == bot_user_id);
+    // DM/@mention gate: guild messages that do not mention the bot are ignored,
+    // so a broad GUILD_MESSAGES subscription cannot flood the agent.
+    if !is_dm && !is_mention {
+        return None;
+    }
+
+    let text = if is_mention {
+        strip_bot_mention(&msg.content, bot_user_id)
+    } else {
+        msg.content.clone()
+    };
+
+    let display_name = msg
+        .author
+        .global_name
+        .clone()
+        .or_else(|| msg.author.username.clone())
+        .unwrap_or_else(|| msg.author.id.clone());
+
+    Some(UnifiedIncomingMessage {
+        owner_user_id: None,
+        id: msg.id.clone(),
+        platform: PluginType::Discord,
+        chat_id: msg.channel_id.clone(),
+        user: UnifiedUser {
+            id: msg.author.id.clone(),
+            username: msg.author.username.clone(),
+            display_name,
+            avatar_url: None,
+        },
+        content: UnifiedMessageContent {
+            content_type: MessageContentType::Text,
+            text,
+            attachments: None,
+        },
+        timestamp: snowflake_to_ms(&msg.id),
+        reply_to_message_id: msg.message_reference.as_ref().and_then(|r| r.message_id.clone()),
+        action: None,
+        raw: None,
+    })
+}
+
+#[cfg(test)]
+#[path = "types_test.rs"]
+mod types_test;

--- a/crates/aionui-channel/src/plugins/discord/types_test.rs
+++ b/crates/aionui-channel/src/plugins/discord/types_test.rs
@@ -1,0 +1,217 @@
+use super::*;
+use crate::types::MessageContentType;
+use serde_json::json;
+
+// -- intents / builders ------------------------------------------------------
+
+#[test]
+fn intents_bitfield_is_expected_sum() {
+    // GUILDS(1) + GUILD_MESSAGES(512) + DIRECT_MESSAGES(4096) + MESSAGE_CONTENT(32768)
+    assert_eq!(DISCORD_INTENTS, 1 + 512 + 4096 + 32768);
+}
+
+#[test]
+fn identify_has_op_and_intents() {
+    let v: serde_json::Value = serde_json::from_str(&build_identify("tok")).unwrap();
+    assert_eq!(v["op"], op::IDENTIFY);
+    assert_eq!(v["d"]["token"], "tok");
+    assert_eq!(v["d"]["intents"], DISCORD_INTENTS);
+    assert_eq!(v["d"]["properties"]["browser"], "aionui");
+}
+
+#[test]
+fn heartbeat_carries_seq_or_null() {
+    let with = serde_json::from_str::<serde_json::Value>(&build_heartbeat(Some(42))).unwrap();
+    assert_eq!(with["op"], op::HEARTBEAT);
+    assert_eq!(with["d"], 42);
+    let without = serde_json::from_str::<serde_json::Value>(&build_heartbeat(None)).unwrap();
+    assert!(without["d"].is_null());
+}
+
+#[test]
+fn resume_has_op_and_fields() {
+    let v: serde_json::Value = serde_json::from_str(&build_resume("tok", "sess", 7)).unwrap();
+    assert_eq!(v["op"], op::RESUME);
+    assert_eq!(v["d"]["session_id"], "sess");
+    assert_eq!(v["d"]["seq"], 7);
+}
+
+// -- snowflake_to_ms ---------------------------------------------------------
+
+#[test]
+fn snowflake_matches_discord_documented_example() {
+    // Discord docs example: snowflake 175928847299117063 → 1462015105796 ms.
+    assert_eq!(snowflake_to_ms("175928847299117063"), 1_462_015_105_796);
+}
+
+#[test]
+fn snowflake_invalid_returns_zero() {
+    assert_eq!(snowflake_to_ms("not-a-snowflake"), 0);
+}
+
+// -- strip_bot_mention -------------------------------------------------------
+
+#[test]
+fn strip_plain_mention() {
+    assert_eq!(strip_bot_mention("<@123> hello", "123"), "hello");
+}
+
+#[test]
+fn strip_nick_mention() {
+    assert_eq!(strip_bot_mention("<@!123> hi there", "123"), "hi there");
+}
+
+#[test]
+fn strip_absent_is_noop() {
+    assert_eq!(strip_bot_mention("plain", "123"), "plain");
+}
+
+// -- REST / gateway serde ----------------------------------------------------
+
+#[test]
+fn gateway_bot_response_parses() {
+    let r: GatewayBotResponse = serde_json::from_value(json!({ "url": "wss://gateway.discord.gg" })).unwrap();
+    assert_eq!(r.url, "wss://gateway.discord.gg");
+}
+
+#[test]
+fn hello_parses() {
+    let h: Hello = serde_json::from_value(json!({ "heartbeat_interval": 41250 })).unwrap();
+    assert_eq!(h.heartbeat_interval, 41250);
+}
+
+#[test]
+fn ready_parses() {
+    let r: Ready = serde_json::from_value(json!({
+        "session_id": "s1",
+        "resume_gateway_url": "wss://resume.example",
+        "user": { "id": "BOT1" }
+    }))
+    .unwrap();
+    assert_eq!(r.session_id, "s1");
+    assert_eq!(r.resume_gateway_url, "wss://resume.example");
+    assert_eq!(r.user.id, "BOT1");
+}
+
+#[test]
+fn rate_limit_body_parses_float_seconds() {
+    let b: RateLimitBody =
+        serde_json::from_value(json!({ "message": "...", "retry_after": 1.462, "global": false })).unwrap();
+    assert_eq!(b.retry_after, Some(1.462));
+    assert_eq!(b.global, Some(false));
+}
+
+#[test]
+fn gateway_frame_dispatch_parses() {
+    let f: GatewayFrame = serde_json::from_value(json!({
+        "op": 0, "s": 5, "t": "MESSAGE_CREATE", "d": { "id": "1" }
+    }))
+    .unwrap();
+    assert_eq!(f.op, op::DISPATCH);
+    assert_eq!(f.s, Some(5));
+    assert_eq!(f.t.as_deref(), Some("MESSAGE_CREATE"));
+}
+
+// -- message_to_unified (gate) -----------------------------------------------
+
+fn dm_message() -> MessageCreate {
+    serde_json::from_value(json!({
+        "id": "175928847299117063",
+        "channel_id": "D1",
+        "author": { "id": "U1", "username": "alice", "global_name": "Alice" },
+        "content": "hi bot"
+    }))
+    .unwrap()
+}
+
+#[test]
+fn dm_is_accepted_and_normalized() {
+    let msg = message_to_unified(&dm_message(), "BOT1").unwrap();
+    assert_eq!(msg.platform, PluginType::Discord);
+    assert_eq!(msg.chat_id, "D1");
+    assert_eq!(msg.user.id, "U1");
+    assert_eq!(msg.user.display_name, "Alice");
+    assert_eq!(msg.content.content_type, MessageContentType::Text);
+    assert_eq!(msg.content.text, "hi bot");
+    assert_eq!(msg.timestamp, 1_462_015_105_796);
+}
+
+#[test]
+fn guild_mention_is_accepted_and_stripped() {
+    let m: MessageCreate = serde_json::from_value(json!({
+        "id": "175928847299117063",
+        "channel_id": "C1",
+        "guild_id": "G1",
+        "author": { "id": "U1", "username": "alice" },
+        "content": "<@BOT1> summarize",
+        "mentions": [ { "id": "BOT1" } ]
+    }))
+    .unwrap();
+    let msg = message_to_unified(&m, "BOT1").unwrap();
+    assert_eq!(msg.chat_id, "C1");
+    assert_eq!(msg.content.text, "summarize");
+}
+
+#[test]
+fn guild_without_mention_is_rejected() {
+    let m: MessageCreate = serde_json::from_value(json!({
+        "id": "175928847299117063",
+        "channel_id": "C1",
+        "guild_id": "G1",
+        "author": { "id": "U1" },
+        "content": "hello channel",
+        "mentions": []
+    }))
+    .unwrap();
+    assert!(message_to_unified(&m, "BOT1").is_none());
+}
+
+#[test]
+fn bot_authored_message_is_rejected() {
+    let m: MessageCreate = serde_json::from_value(json!({
+        "id": "175928847299117063",
+        "channel_id": "D1",
+        "author": { "id": "U9", "bot": true },
+        "content": "automated"
+    }))
+    .unwrap();
+    assert!(message_to_unified(&m, "BOT1").is_none());
+}
+
+#[test]
+fn own_message_is_rejected() {
+    let m: MessageCreate = serde_json::from_value(json!({
+        "id": "175928847299117063",
+        "channel_id": "D1",
+        "author": { "id": "BOT1", "username": "self" },
+        "content": "echo"
+    }))
+    .unwrap();
+    assert!(message_to_unified(&m, "BOT1").is_none());
+}
+
+#[test]
+fn reply_reference_maps_to_reply_to() {
+    let m: MessageCreate = serde_json::from_value(json!({
+        "id": "175928847299117063",
+        "channel_id": "D1",
+        "author": { "id": "U1" },
+        "content": "re",
+        "message_reference": { "message_id": "999" }
+    }))
+    .unwrap();
+    let msg = message_to_unified(&m, "BOT1").unwrap();
+    assert_eq!(msg.reply_to_message_id.as_deref(), Some("999"));
+}
+
+#[test]
+fn display_name_falls_back_to_username_then_id() {
+    let m: MessageCreate = serde_json::from_value(json!({
+        "id": "175928847299117063",
+        "channel_id": "D1",
+        "author": { "id": "U1", "username": "bob" },
+        "content": "x"
+    }))
+    .unwrap();
+    assert_eq!(message_to_unified(&m, "BOT1").unwrap().user.display_name, "bob");
+}

--- a/crates/aionui-channel/src/plugins/mod.rs
+++ b/crates/aionui-channel/src/plugins/mod.rs
@@ -13,6 +13,9 @@ pub mod weixin;
 #[cfg(feature = "slack")]
 pub mod slack;
 
+#[cfg(feature = "discord")]
+pub mod discord;
+
 use crate::plugin::ChannelPlugin;
 use crate::types::PluginType;
 
@@ -35,6 +38,9 @@ pub fn create_plugin(plugin_type: PluginType) -> Option<Box<dyn ChannelPlugin>> 
 
         #[cfg(feature = "slack")]
         PluginType::Slack => Some(Box::new(slack::SlackPlugin::new())),
+
+        #[cfg(feature = "discord")]
+        PluginType::Discord => Some(Box::new(discord::DiscordPlugin::new())),
 
         #[allow(unreachable_patterns)]
         _ => None,

--- a/crates/aionui-channel/src/stream_relay.rs
+++ b/crates/aionui-channel/src/stream_relay.rs
@@ -29,6 +29,7 @@ pub struct RelayConfig {
 pub fn throttle_ms_for_platform(platform: PluginType) -> u64 {
     match platform {
         PluginType::Slack => 1200,
+        PluginType::Discord => 1000,
         _ => 500,
     }
 }

--- a/crates/aionui-channel/tests/stream_relay_test.rs
+++ b/crates/aionui-channel/tests/stream_relay_test.rs
@@ -15,6 +15,7 @@ fn slack_uses_larger_throttle_than_others() {
     // Slack's chat.update is rate-limited harder, so it gets a wider interval;
     // the other editable platforms must stay at the original 500 ms.
     assert_eq!(throttle_ms_for_platform(PluginType::Slack), 1200);
+    assert_eq!(throttle_ms_for_platform(PluginType::Discord), 1000);
     assert_eq!(throttle_ms_for_platform(PluginType::Telegram), 500);
     assert_eq!(throttle_ms_for_platform(PluginType::Lark), 500);
     assert_eq!(throttle_ms_for_platform(PluginType::Dingtalk), 500);


### PR DESCRIPTION
# feat(channel): add Discord Gateway plugin

## Summary

Adds a native Discord channel plugin to `aioncore/crates/aionui-channel`, so Discord
users can talk to an AionUi assistant the same way the existing Telegram / Lark /
DingTalk / WeChat / Slack channels work. Backend only — the companion frontend
(config form + wiring) ships in the paired aionui PR.

Connection uses the **Discord Gateway (v10)** over WSS: a single **Bot token**
(`Authorization: Bot <token>`) authorizes both the Gateway and the REST API. The
plugin IDENTIFYs with the required intents, RESUMEs across reconnects, heartbeats
with zombie detection, and dispatches `MESSAGE_CREATE`. Discord supports message
edits, so streaming responses use the existing editable relay path.

## What's included

- **`plugins/discord/`** — new module (feature-gated `discord`):
  - `types.rs` — Gateway payloads + REST serde types, opcode constants, intents
    bitfield, `build_identify/build_resume/build_heartbeat`, `snowflake_to_ms`,
    `strip_bot_mention`, and the pure `message_to_unified` normalization + gate.
  - `api.rs` — `DiscordApi` (reqwest, single Bot token) for `GET /gateway/bot`,
    `GET /users/@me`, create/edit message, with a one-shot **HTTP 429
    `retry_after`** (float seconds, global flag) backoff wrapper.
  - `gateway.rs` — Gateway loop: Hello→IDENTIFY/RESUME, heartbeat interval + ACK
    zombie detection, op7 Reconnect / op9 Invalid Session handling, exponential
    reconnect backoff, and `MESSAGE_CREATE` dedup with TTL cleanup.
  - `plugin.rs` — `DiscordPlugin` implementing `ChannelPlugin` (full lifecycle;
    token validated on `initialize` via `/users/@me`).
  - each source file paired with a `*_test.rs` (per repo test-layout rule).
- **Intents** — `GUILDS | GUILD_MESSAGES | DIRECT_MESSAGES | MESSAGE_CONTENT`
  (`MESSAGE_CONTENT` is privileged, required to read message text).
- **M1 gate** — messages are accepted only from **DMs** (no `guild_id`) or when
  the bot is **@mentioned** in a guild channel; bot-authored and self-authored
  messages are filtered. Prevents whole-channel traffic leaking to the agent.
- **`create_plugin`** registers Discord behind the `discord` feature; `aionui-app`
  enables `discord` in its default feature set (same production path as `slack`).
- **`formatter.rs`** — Discord passthrough branch (Discord renders markdown
  natively, no HTML escaping); adds `DISCORD_MESSAGE_LIMIT` (2000) and Discord
  dedup TTL constants.
- **Per-platform stream throttle** — `throttle_ms_for_platform`: Discord 1000 ms;
  other platforms unchanged (test-guarded).

## Related

- iOfficeAI/AionUi#3956

## Testing

- `cargo test -p aionui-channel --features discord --lib` — **277 passed, 0 failed.**
  New coverage: intents bitfield, identify/resume/heartbeat builders, Gateway +
  REST serde, `snowflake_to_ms` (documented example), mention stripping,
  `message_to_unified` gate (DM accepted / guild-mention stripped / guild
  no-mention rejected / bot-self / other-bot rejected / reply mapping /
  display-name fallback), gateway dispatch (READY session tracking, MESSAGE_CREATE
  forward-once + dedup, guild-no-mention dropped), 429 `retry_after` parsing,
  reconnect backoff, and a resume-URL single-query regression.
- `cargo fmt --all -- --check` — clean.
- Full pre-push gate (`just push`) — passed.
- **Discord live e2e — verified by the team** against a real Discord bot
  (DM + @mention round-trip through the agent). Not a unit test in this repo.

## Fast-follow (not in this PR)

- Inbound file attachments (currently text-only).
- Interactive components (buttons / slash commands).
- Streaming replies threaded under the originating message.

## Companion PR

Frontend (config form + channel wiring): **aionui #3956**, branch
`boii/feat/channel-discord`.

## Checklist

- [x] Unit tests added and green
- [x] `fmt --check` clean
- [x] Full pre-push gate passed
- [x] New cross-module surface kept minimal (Discord module internals `pub(super)`)
- [x] Discord live e2e — team-verified against a real bot
