### PR TITLE
chore(acp): bump dimcode registry pin to probed 0.3.9

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -19,7 +19,7 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.8"
+      "version": "0.3.9"
     },
     "dirac": {
       "registry_json_id": "dirac",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. One npx pin drifted since #810, backed by a fresh ACP probe of the exact pinned version. Lock-only change — one line; no metadata, migration, or entrypoint edits, and no lock-derived test assertion embeds this version.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| dimcode | `dimcode` | 0.3.8 → **0.3.9** | ok (protocolVersion 1, agentInfo version 0.3.9) | auth required (`-32000`, "Provider credentials are required") |

Meets the release-lock criterion: `initialize` succeeds and `session/new` returns a clearly classified authentication requirement. The probe ran with no inherited HOME or credentials.

The other 10 Registry-pinned packages match the snapshot exactly — no drift. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. The `mimo-code` and `omp` entries are non-Registry builtins (no `registry_json_id`) and are correctly excluded from drift reconciliation.

**Identity observation, no action taken:** 0.3.9's runtime handshake now self-reports `agentInfo.title` as "DimAgent", where 0.3.8 reported "DimCode". The identity authorities are unchanged — the public Registry card and the CDN entry both still say "DimCode", with the same `dimcode.dev` website — so the seeded display name stays "DimCode". Recorded here in case the vendor carries the rename through to its public listing later, which is what would justify a metadata change.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.10-8c835f4`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.10-8c835f4/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the previous baseline (38 ids).

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11, first applied in #810). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock-only version bump; existing startup/session error paths already identify a failing agent by backend.