### PR TITLE
fix(cli-version): deliver the version-drift notice, and stop it reading as an error

### DIFF
--- a/crates/aionui-session/src/backend/antigravity/conn.rs
+++ b/crates/aionui-session/src/backend/antigravity/conn.rs
@@ -413,15 +413,24 @@ impl AntigravitySessionBackend {
                 return;
             };
             if let Some(backend) = weak.and_then(|w| w.upgrade()) {
-                backend.emit(
-                    backend.turn_gen.load(Ordering::SeqCst),
-                    SessionEvent::Notice {
-                        level,
-                        message,
-                        localized: Some(localized),
-                        supersedes_key: None,
+                // Not `emit`: that drops the value when nobody is subscribed
+                // yet, which is fine for a turn frame (another one follows) but
+                // loses this notice outright — the check runs once per session.
+                crate::backend::cli_version::broadcast_notice(
+                    &backend.event_tx,
+                    SessionEnvelope {
+                        session_id: backend.session_id.clone(),
+                        turn_gen: backend.turn_gen.load(Ordering::SeqCst),
+                        event: SessionEvent::Notice {
+                            level,
+                            message,
+                            localized: Some(localized),
+                            supersedes_key: None,
+                        },
                     },
-                );
+                    "agy",
+                )
+                .await;
             }
         });
     }

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -1050,16 +1050,23 @@ impl ClaudeSessionBackend {
             else {
                 return;
             };
-            let _ = event_tx.send(SessionEnvelope {
-                session_id: session_id.clone(),
-                turn_gen: turn_gen.load(Ordering::SeqCst),
-                event: SessionEvent::Notice {
-                    level,
-                    message,
-                    localized: Some(localized),
-                    supersedes_key: None,
+            // Retry until subscribed: a broadcast send with no receiver is
+            // discarded, and this notice has no second chance.
+            crate::backend::cli_version::broadcast_notice(
+                &event_tx,
+                SessionEnvelope {
+                    session_id: session_id.clone(),
+                    turn_gen: turn_gen.load(Ordering::SeqCst),
+                    event: SessionEvent::Notice {
+                        level,
+                        message,
+                        localized: Some(localized),
+                        supersedes_key: None,
+                    },
                 },
-            });
+                "claude",
+            )
+            .await;
         });
     }
 

--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -101,6 +101,22 @@ pub const CODE_CLI_VERSION_NEWER: &str = "CLI_VERSION_NEWER";
 /// would strand users on an old release. It is reported once so that, if the
 /// session then misbehaves, the cause is already on screen.
 ///
+/// Both directions are `Info`, which is a statement about PRESENTATION, not
+/// about how much the two verdicts matter. `Warning` renders as a filled card
+/// with the same alarm glyph an error uses, and a drifting install is not an
+/// error: nothing has failed, the turn is running, and the user is being told
+/// something about their environment. Reported live 2026-08-11 — an `Older`
+/// codex read as a failure report. `Info` is the tier the frontend draws as a
+/// quiet centred line, and `MessageTips` documents it as the tier a backend
+/// picks when it deliberately wants a notice to be unobtrusive.
+///
+/// The severity difference survives where it is acted on rather than merely
+/// read: the two verdicts keep distinct i18n codes, distinct prose ("some
+/// features may be missing. Consider upgrading" vs "should still work"), and
+/// distinct diagnostic codes on the availability probe — which is the surface
+/// that reaches the user BEFORE a conversation exists, when they are still
+/// deciding whether to rely on this agent, and which keeps its own weight.
+///
 /// Returns the English text AND its translation handle: the text is the
 /// fallback shown when the locale has no entry for the code, so both travel
 /// together rather than the caller having to rebuild one from the other.
@@ -114,7 +130,7 @@ pub fn drift_notice(cli: &str, reported: &str, verified: &str) -> Option<(Notice
     match classify(reported, verified) {
         VersionVerdict::Verified | VersionVerdict::Unknown => None,
         VersionVerdict::Older => Some((
-            NoticeLevel::Warning,
+            NoticeLevel::Info,
             format!(
                 "The installed {cli} is older than the version AionUi verified; \
                  some features may be missing. Consider upgrading {cli}. \
@@ -444,11 +460,19 @@ mod tests {
         assert_eq!(parse_version("1.1.10"), Some(vec![1, 1, 10]));
     }
 
+    /// Both drift directions are `Info` — the tier the frontend draws as a quiet
+    /// centred line. `Warning` renders with the same alarm glyph as an error,
+    /// and a drifting install is not a failure. What must stay distinguishable
+    /// is what the user acts on: the code and the prose.
     #[test]
-    fn an_older_install_warns_and_a_newer_one_only_informs() {
+    fn an_older_install_is_told_apart_by_its_words_not_by_an_alarm() {
         let (level, text, localized) =
             drift_notice("claude", "2.1.100", VERIFIED_CLAUDE_VERSION).expect("older drifts");
-        assert_eq!(level, NoticeLevel::Warning);
+        assert_eq!(level, NoticeLevel::Info, "a drifting install must not read as an error");
+        assert!(
+            text.contains("older") && text.contains("Consider upgrading"),
+            "the older case must still say what to do: {text}"
+        );
         assert!(text.contains("2.1.100") && text.contains(VERIFIED_CLAUDE_VERSION));
         assert_eq!(localized.code, CODE_CLI_VERSION_OLDER);
         assert_eq!(localized.params.get("cli").and_then(|v| v.as_str()), Some("claude"));

--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -264,9 +264,163 @@ pub async fn session_drift_notice(
     Some(notice)
 }
 
+/// How long to keep trying to hand the notice to a subscriber.
+///
+/// Sized against the gap that produced the bug — codex broadcast at
+/// `02:18:02.863` and the session pump attached at `02:18:05.036`, 2.2s later —
+/// with room for a slower machine. A conversation that has attracted no
+/// subscriber in 30s has no one left to tell.
+const NOTICE_DELIVERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const NOTICE_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// Broadcast a session notice, retrying until someone is subscribed.
+///
+/// `event_tx` is a `broadcast` channel, so a send with zero receivers is
+/// DISCARDED, not queued — and the version notice is one-shot: unlike a turn
+/// frame there is no later event carrying the same information, and
+/// `already_reported` guarantees the check will not run again for this session.
+///
+/// The three backends all spawn their version probe as a detached task, so
+/// whether the notice wins the race against the orchestration layer's
+/// `events()` subscription is pure timing. claude happens to win (its check is
+/// the last statement in `open_session`); codex reliably loses, because its
+/// check is deliberately placed early — before model discovery, so the
+/// reconcile path cannot skip it — and that discovery keeps `open_session`
+/// busy for seconds while `codex --version` returns in ~60ms.
+///
+/// Measured on 2026-08-11 dev logs: 13 codex drifts detected, 13 notices
+/// broadcast, 0 delivered — every one dropped by an empty channel, and every
+/// one logged as if it had been sent, because the send result was discarded
+/// with `let _ =`.
+///
+/// Retrying is free here: the caller is already a detached task whose only job
+/// is this notice.
+pub async fn broadcast_notice(
+    event_tx: &tokio::sync::broadcast::Sender<crate::backend::types::SessionEnvelope>,
+    envelope: crate::backend::types::SessionEnvelope,
+    cli: &str,
+) {
+    broadcast_notice_within(event_tx, envelope, cli, NOTICE_DELIVERY_TIMEOUT).await
+}
+
+/// [`broadcast_notice`] with an injectable deadline, so a test does not wait 30s
+/// to observe the give-up path.
+async fn broadcast_notice_within(
+    event_tx: &tokio::sync::broadcast::Sender<crate::backend::types::SessionEnvelope>,
+    envelope: crate::backend::types::SessionEnvelope,
+    cli: &str,
+    timeout: std::time::Duration,
+) {
+    let session_id = envelope.session_id.clone();
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut waited = false;
+    loop {
+        // `send` fails ONLY when there is no receiver, which is precisely the
+        // condition worth retrying — a subscriber that is merely slow still
+        // takes the value into the ring buffer.
+        if event_tx.send(envelope.clone()).is_ok() {
+            if waited {
+                tracing::info!(session_id = %session_id, cli = %cli, "session notice delivered to a late subscriber");
+            }
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            tracing::warn!(
+                session_id = %session_id,
+                cli = %cli,
+                timeout_ms = timeout.as_millis(),
+                "session notice dropped: nothing ever subscribed to this session's events"
+            );
+            return;
+        }
+        waited = true;
+        tokio::time::sleep(NOTICE_RETRY_INTERVAL).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn notice_envelope(session_id: &str) -> crate::backend::types::SessionEnvelope {
+        crate::backend::types::SessionEnvelope {
+            session_id: session_id.to_string(),
+            turn_gen: 0,
+            event: crate::event::SessionEvent::Notice {
+                level: NoticeLevel::Warning,
+                message: "drift".into(),
+                localized: None,
+                supersedes_key: None,
+            },
+        }
+    }
+
+    /// The bug this function exists for: the notice is produced BEFORE the
+    /// orchestration layer subscribes, which is what codex does every time — its
+    /// version check is placed early (so the reconcile path cannot skip it) and
+    /// `open_session` then spends seconds on model discovery. A plain
+    /// `send` drops the value on an empty channel, and 13 of 13 codex drift
+    /// notices were lost that way.
+    #[tokio::test]
+    async fn a_notice_broadcast_before_anyone_subscribes_still_arrives() {
+        let (tx, _) = tokio::sync::broadcast::channel(16);
+        // Proof the send would have been LOST as written before: no receiver
+        // exists, so the one-shot send fails outright.
+        assert!(
+            tx.send(notice_envelope("s1")).is_err(),
+            "precondition: an empty channel drops the value"
+        );
+
+        let sender = tx.clone();
+        let task = tokio::spawn(async move {
+            broadcast_notice(&sender, notice_envelope("s1"), "codex").await;
+        });
+
+        // Subscribe late, the way the session pump does (measured: 2.2s after
+        // the codex notice was broadcast).
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        let mut rx = tx.subscribe();
+
+        task.await.expect("delivery task");
+        let env = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("the notice must still be waiting for a late subscriber")
+            .expect("channel open");
+        assert_eq!(env.session_id, "s1");
+        assert!(matches!(env.event, crate::event::SessionEvent::Notice { .. }));
+    }
+
+    /// The claude timing — a subscriber is already attached — must not regress
+    /// into waiting for anything.
+    #[tokio::test]
+    async fn an_already_subscribed_session_gets_the_notice_immediately() {
+        let (tx, mut rx) = tokio::sync::broadcast::channel(16);
+        let started = tokio::time::Instant::now();
+        broadcast_notice(&tx, notice_envelope("s2"), "claude").await;
+        assert!(
+            started.elapsed() < NOTICE_RETRY_INTERVAL,
+            "a live subscriber must be served without a retry sleep"
+        );
+        assert_eq!(rx.recv().await.expect("delivered").session_id, "s2");
+    }
+
+    /// A session nobody ever listens to must not keep a task alive forever.
+    #[tokio::test]
+    async fn delivery_gives_up_once_the_deadline_passes() {
+        let (tx, rx) = tokio::sync::broadcast::channel(16);
+        drop(rx);
+        let started = tokio::time::Instant::now();
+        broadcast_notice_within(&tx, notice_envelope("s3"), "agy", std::time::Duration::from_millis(120)).await;
+        let waited = started.elapsed();
+        assert!(
+            waited >= std::time::Duration::from_millis(120),
+            "must honour the deadline: {waited:?}"
+        );
+        assert!(
+            waited < std::time::Duration::from_secs(2),
+            "must not hang past it: {waited:?}"
+        );
+    }
 
     #[test]
     fn the_verified_release_says_nothing() {

--- a/crates/aionui-session/src/backend/codex_conn.rs
+++ b/crates/aionui-session/src/backend/codex_conn.rs
@@ -924,16 +924,23 @@ impl CodexSessionBackend {
             else {
                 return;
             };
-            let _ = event_tx.send(SessionEnvelope {
-                session_id: session_id.clone(),
-                turn_gen: turn_gen.load(std::sync::atomic::Ordering::SeqCst),
-                event: SessionEvent::Notice {
-                    level,
-                    message,
-                    localized: Some(localized),
-                    supersedes_key: None,
+            // Retry until subscribed: a broadcast send with no receiver is
+            // discarded, and this notice has no second chance.
+            crate::backend::cli_version::broadcast_notice(
+                &event_tx,
+                SessionEnvelope {
+                    session_id: session_id.clone(),
+                    turn_gen: turn_gen.load(std::sync::atomic::Ordering::SeqCst),
+                    event: SessionEvent::Notice {
+                        level,
+                        message,
+                        localized: Some(localized),
+                        supersedes_key: None,
+                    },
                 },
-            });
+                "codex",
+            )
+            .await;
         });
     }
 


### PR DESCRIPTION
Two defects in the same notice, found one after the other: it never arrived, and once it did, it looked like a crash report. Both surfaced while verifying #812, which is what first made codex drift at all.

---

# 1. The notice never reached the UI for codex

Not once.

| CLI | drifts detected (logs) | notices persisted (messages table) |
|---|---|---|
| claude | 18 | 5 |
| agy | 3 | 4 |
| **codex** | **13** | **0** |

Every one of the 13 was logged as `direct CLI version drift`, exactly as if it had been delivered.

## Cause

`event_tx` is a `broadcast` channel: a send with zero receivers is **discarded, not queued**. Every call site wrote

```rust
let _ = event_tx.send(SessionEnvelope { /* Notice */ });
```

which throws that failure away — so the only trace left is a log line claiming success.

Whether the notice wins the race against the orchestration layer's `events()` subscription is pure timing:

- **claude wins.** `spawn_version_check()` is the last statement in `open_session`, so the function returns immediately and the pump subscribes while the probe is still running.
- **codex loses every time.** Its check is placed early on purpose — before model discovery, so the reconcile path cannot skip it (`codex_conn.rs`, "Placed here rather than at the two return sites") — and that discovery keeps `open_session` busy for seconds while `codex --version` returns in ~60ms.

From the failing session (dev logs, 2026-08-11, conversation `7eb599e8`):

```
02:18:02.863  WARN   direct CLI version drift        ← broadcast, nobody subscribed
02:18:05.036  DEBUG  session-pump: backend event     ← subscriber attaches, 2.2s late
```

And the succeeding claude session (`7e99c63d`) for contrast — same millisecond, right order:

```
04:02:05.242  DEBUG  session-pump: backend event
04:02:05.242  WARN   direct CLI version drift
```

## Fix

Fixed at the send rather than per backend. `broadcast_notice` retries until a receiver exists, bounded by a 30s deadline, and logs when it gives up instead of failing silently.

A version notice is **one-shot**: unlike a turn frame there is no later event carrying the same information, and `already_reported` guarantees the check will not run again for this session. Retrying costs nothing — the caller is already a detached task whose only job is this notice.

codex already carries a `preface` replay in `events()` for `BackendBound`, added for this same race ("the live BackendBound routinely lands BEFORE the orchestration layer's subscription and is lost"). Extending that would have meant adding a preface to claude and agy, which have none; fixing the send covers all three in one place.

agy keeps using `emit` for turn frames, where dropping on an empty channel is correct. Only the notice takes the retrying path.

## Tests

All three timings:

- notice broadcast first, subscriber attaches 150ms later → still delivered (this one **fails against the old fire-and-forget send**, verified);
- subscriber already attached → served with no retry sleep, so the claude path does not regress into waiting;
- nobody ever subscribes → gives up at the deadline rather than leaking a task.

---

# 2. Once it arrived, it read as an error

An older-than-verified CLI was reported at `NoticeLevel::Warning`. Reported live the moment the first fix made it visible: the notice reads as a failure report when nothing has failed — the turn is running fine and the user is being told something about their environment.

## What the two tiers actually look like

`MessageTips` draws them very differently:

```jsx
// info — a quiet centred line, no card, no icon
<div className='p-x-12px p-y-4px'>
  <div className='text-center text-13px text-t-secondary'>{body}</div>
</div>

// warning — filled card, rounded, collapsible, and the SAME Attention glyph
// an error uses, differing only in fill colour
<div className='bg-message-tips rd-8px p-x-12px p-y-8px'>
  {icon.warning}  // <Attention theme='filled' … />
  <CollapsibleContent …>
```

So the two halves of one advisory were rendered as two different kinds of event: a newer-than-verified CLI (agy, claude) as a quiet line, an older one as something that looks broken.

## Fix

Both directions are now `Info`. That is a statement about presentation, not about how much each verdict matters — and it is the mechanism this codebase already documents for the purpose. From `MessageTips` itself:

> `info` was missing, and the render falls back to `warning`, so every informational tip was drawn with the alarm icon — **a backend that deliberately downgrades a notice to Info** still reached the user as a warning.

The severity distinction survives where it is acted on rather than merely looked at:

- distinct i18n codes — `CLI_VERSION_OLDER` / `CLI_VERSION_NEWER`;
- distinct prose — "some features may be missing. Consider upgrading" vs "should still work; report anything that behaves oddly";
- distinct diagnostic codes on the **availability probe** (`version_drift_older` / `version_drift_newer`), which is the surface that reaches the user *before* any conversation exists — when they are still deciding whether to rely on this agent — and which keeps its own weight.

`version_drift` discards the level (`let (_, guidance, _)`), so that path is untouched. Grepped for other consumers of the older verdict: none outside this module.

## Tests

The existing assertion was updated deliberately, not weakened. It previously pinned `Warning`; it now pins `Info` **and** adds what the old test never checked — that the older case still tells the user what to do:

```rust
assert_eq!(level, NoticeLevel::Info, "a drifting install must not read as an error");
assert!(text.contains("older") && text.contains("Consider upgrading"));
```

Renamed to `an_older_install_is_told_apart_by_its_words_not_by_an_alarm`, which is the actual contract.

---

`cargo test -p aionui-session`: 539 passed. `clippy --all-targets -D warnings` and `cargo fmt --check` clean.
