### PR TITLE
fix(cli-version): a drifting install should not read as an error

### DIFF
--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -101,6 +101,22 @@ pub const CODE_CLI_VERSION_NEWER: &str = "CLI_VERSION_NEWER";
 /// would strand users on an old release. It is reported once so that, if the
 /// session then misbehaves, the cause is already on screen.
 ///
+/// Both directions are `Info`, which is a statement about PRESENTATION, not
+/// about how much the two verdicts matter. `Warning` renders as a filled card
+/// with the same alarm glyph an error uses, and a drifting install is not an
+/// error: nothing has failed, the turn is running, and the user is being told
+/// something about their environment. Reported live 2026-08-11 — an `Older`
+/// codex read as a failure report. `Info` is the tier the frontend draws as a
+/// quiet centred line, and `MessageTips` documents it as the tier a backend
+/// picks when it deliberately wants a notice to be unobtrusive.
+///
+/// The severity difference survives where it is acted on rather than merely
+/// read: the two verdicts keep distinct i18n codes, distinct prose ("some
+/// features may be missing. Consider upgrading" vs "should still work"), and
+/// distinct diagnostic codes on the availability probe — which is the surface
+/// that reaches the user BEFORE a conversation exists, when they are still
+/// deciding whether to rely on this agent, and which keeps its own weight.
+///
 /// Returns the English text AND its translation handle: the text is the
 /// fallback shown when the locale has no entry for the code, so both travel
 /// together rather than the caller having to rebuild one from the other.
@@ -114,7 +130,7 @@ pub fn drift_notice(cli: &str, reported: &str, verified: &str) -> Option<(Notice
     match classify(reported, verified) {
         VersionVerdict::Verified | VersionVerdict::Unknown => None,
         VersionVerdict::Older => Some((
-            NoticeLevel::Warning,
+            NoticeLevel::Info,
             format!(
                 "The installed {cli} is older than the version AionUi verified; \
                  some features may be missing. Consider upgrading {cli}. \
@@ -290,11 +306,19 @@ mod tests {
         assert_eq!(parse_version("1.1.10"), Some(vec![1, 1, 10]));
     }
 
+    /// Both drift directions are `Info` — the tier the frontend draws as a quiet
+    /// centred line. `Warning` renders with the same alarm glyph as an error,
+    /// and a drifting install is not a failure. What must stay distinguishable
+    /// is what the user acts on: the code and the prose.
     #[test]
-    fn an_older_install_warns_and_a_newer_one_only_informs() {
+    fn an_older_install_is_told_apart_by_its_words_not_by_an_alarm() {
         let (level, text, localized) =
             drift_notice("claude", "2.1.100", VERIFIED_CLAUDE_VERSION).expect("older drifts");
-        assert_eq!(level, NoticeLevel::Warning);
+        assert_eq!(level, NoticeLevel::Info, "a drifting install must not read as an error");
+        assert!(
+            text.contains("older") && text.contains("Consider upgrading"),
+            "the older case must still say what to do: {text}"
+        );
         assert!(text.contains("2.1.100") && text.contains(VERIFIED_CLAUDE_VERSION));
         assert_eq!(localized.code, CODE_CLI_VERSION_OLDER);
         assert_eq!(localized.params.get("cli").and_then(|v| v.as_str()), Some("claude"));


### PR DESCRIPTION
An older-than-verified CLI was reported at `NoticeLevel::Warning`. Reported live on 2026-08-11 against codex: the notice reads as a failure report when nothing has failed — the turn is running fine and the user is being told something about their environment.

## What the two tiers actually look like

`MessageTips` draws them very differently:

```jsx
// info — a quiet centred line, no card, no icon
<div className='p-x-12px p-y-4px'>
  <div className='text-center text-13px text-t-secondary'>{body}</div>
</div>

// warning — filled card, rounded, collapsible, and the SAME Attention glyph
// an error uses, differing only in fill colour
<div className='bg-message-tips rd-8px p-x-12px p-y-8px'>
  {icon.warning}  // <Attention theme='filled' … />
  <CollapsibleContent …>
```

So the two halves of one advisory were rendered as two different kinds of event: a newer-than-verified CLI (agy, claude) as a quiet line, an older one as something that looks broken.

## Fix

Both directions are now `Info`. That is a statement about presentation, not about how much each verdict matters — and it is the mechanism this codebase already documents for the purpose. From `MessageTips` itself:

> `info` was missing, and the render falls back to `warning`, so every informational tip was drawn with the alarm icon — **a backend that deliberately downgrades a notice to Info** still reached the user as a warning.

The severity distinction survives where it is acted on rather than merely looked at:

- distinct i18n codes — `CLI_VERSION_OLDER` / `CLI_VERSION_NEWER`;
- distinct prose — "some features may be missing. Consider upgrading" vs "should still work; report anything that behaves oddly";
- distinct diagnostic codes on the **availability probe** (`version_drift_older` / `version_drift_newer`), which is the surface that reaches the user *before* any conversation exists — when they are still deciding whether to rely on this agent — and which keeps its own weight.

`version_drift` discards the level (`let (_, guidance, _)`), so that path is untouched by this change. Grepped for other consumers of the older verdict: none outside this module.

## Tests

The existing assertion was updated deliberately, not weakened. It previously pinned `Warning`; it now pins `Info` **and** adds what the old test never checked — that the older case still tells the user what to do:

```rust
assert_eq!(level, NoticeLevel::Info, "a drifting install must not read as an error");
assert!(text.contains("older") && text.contains("Consider upgrading"));
```

Renamed to `an_older_install_is_told_apart_by_its_words_not_by_an_alarm`, which is the actual contract.

`cargo test -p aionui-session`: 536 passed. `clippy --all-targets -D warnings` and `cargo fmt --check` clean.