### PR TITLE
chore(acp): bump dimcode, grok, kilo and sigit registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -19,7 +19,7 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.9"
+      "version": "0.3.10"
     },
     "dirac": {
       "registry_json_id": "dirac",
@@ -34,12 +34,12 @@
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     "kilo": {
       "registry_json_id": "kilo",
       "package": "@kilocode/cli",
-      "version": "7.4.20"
+      "version": "7.4.21"
     },
     "mimo-code": {
       "package": "@mimo-ai/cli",
@@ -62,7 +62,7 @@
     "sigit": {
       "registry_json_id": "sigit",
       "package": "@smbcloud/sigit",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "skip_version_probe": true
     }
   }


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Four npx pins drifted since #814, each backed by a fresh serial ACP probe of the exact pinned version. Lock-only change — four lines; no metadata, migration, or entrypoint edits, and no lock-derived test assertion embeds any of these versions.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| dimcode | `dimcode` | 0.3.9 → **0.3.10** | ok (agentInfo version 0.3.10) | auth required (`-32000`, "Provider credentials are required") |
| grok | `@xai-official/grok` | 1.0.0 → **1.0.1** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |
| kilo | `@kilocode/cli` | 7.4.20 → **7.4.21** | ok (agentInfo Kilo 7.4.21) | success |
| sigit | `@smbcloud/sigit` | 1.5.1 → **1.5.2** | ok (agentInfo sigit "siGit Code - AI Coding Agent" 1.5.2) | success |

All four meet the release-lock criterion: `initialize` succeeds and `session/new` either succeeds or returns a clearly classified authentication requirement. Probes ran serially with no inherited HOME or credentials.

`sigit` keeps its `skip_version_probe: true` flag, untouched. That flag exempts only the runtime `<binary_name> --version` check; it never exempts the ACP probe, and this bump carries full probe evidence like the rest.

The other 7 Registry-pinned packages (autohand, codebuddy, deepagents, dirac, glm-acp-agent, nova, pi) match the snapshot exactly. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. The `mimo-code` and `omp` entries are non-Registry builtins (no `registry_json_id`) and are correctly excluded from drift reconciliation.

**Identity observation, no action taken (second sighting, see #814):** dimcode's runtime handshake keeps self-reporting `agentInfo.title` as "DimAgent". The identity authorities are still unchanged — the public Registry card and CDN entry both say "DimCode", same `dimcode.dev` website — so the seeded display name stays "DimCode". A rename would follow the public listing, not the handshake field.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.11-8ca2777`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.11-8ca2777/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the previous baseline (38 ids).

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11; #810 and #814 both merged green under it). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock-only version bumps; existing startup/session error paths already identify a failing agent by backend.