### PR TITLE
chore(cli): bump verified claude to 2.1.227

### DIFF
--- a/crates/aionui-ai-agent/src/claude_flags.rs
+++ b/crates/aionui-ai-agent/src/claude_flags.rs
@@ -126,7 +126,7 @@ mod tests {
         assert!(!supported("2.1.0"), "2.1.0 hard-errors on --thinking-display");
         assert!(!supported("2.1.190"), "below the verified floor stays off");
         assert!(supported("2.1.191"), "lowest live-probed OK version");
-        assert!(supported("2.1.226"), "the release this integration is verified against");
+        assert!(supported("2.1.227"), "the release this integration is verified against");
         assert!(supported("2.1.220"));
         assert!(supported("3.0.0"), "a future major must not regress the gate");
     }

--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -35,7 +35,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// turn (its response stream disconnects with `httpStatusCode: null`, observed
 /// three times including a back-to-back control after three clean versions), so
 /// the verified release stops at 0.146.0 until upstream fixes it.
-pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.226";
+pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.227";
 pub const VERIFIED_CODEX_VERSION: &str = "0.146.0";
 pub const VERIFIED_AGY_VERSION: &str = "1.1.11";
 
@@ -449,8 +449,8 @@ mod tests {
     fn the_verified_release_says_nothing() {
         // Literal on purpose: this is the exact string a user on the verified
         // release reports, so the test breaks if a bump forgets to re-verify.
-        assert_eq!(classify("2.1.226", VERIFIED_CLAUDE_VERSION), VersionVerdict::Verified);
-        assert!(drift_notice("claude", "2.1.226", VERIFIED_CLAUDE_VERSION).is_none());
+        assert_eq!(classify("2.1.227", VERIFIED_CLAUDE_VERSION), VersionVerdict::Verified);
+        assert!(drift_notice("claude", "2.1.227", VERIFIED_CLAUDE_VERSION).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Nightly version sync, 2026-08-12.

## Gate results

| gate | verdict | evidence |
|---|---|---|
| A — contract | degraded | claude publishes no protocol schema; this is the documented arrangement, and it is why B carries the weight |
| **B — live e2e** | **PASS 13/13**, 304.68s | `~/aion/protocols/samples/claude-cli/2.1.227/live-suite.log` |
| C — release notes | CLEAR | 1 release, 5 notes, 0 touching any of the 31 claude manifest tokens |

Gate B ran against the exact binary at `~/.local/share/claude/versions/2.1.227`, whose own `--version` reports `2.1.227 (Claude Code)`. The full record — which binary was judged, each gate's verdict, and whether the operator's active CLIs were left untouched — is at `~/aion/protocols/samples/claude-cli/2.1.227/qualification.json` (`verdict: PASS`).

WS frame types produced by the run: `acp_config_option`, `acp_context_usage`, `acp_session_info`, `available_commands`, `content`, `finish`, `start`, `tips`, `tool_call`.

## Gate C detail

The single `usage`-tagged note in 2.1.227 fixes feature flags being evaluated without the user's subscription tier when a session started with an expired login token. Nothing in it touches a surface this repo reads.

## Floor check

`THINKING_DISPLAY_MIN_VERSION` stays at `2.1.191`, below the new constant. That matters because a floor above the verified release would tell a user on exactly the verified version "you match" while thinking display was silently off.

## Scope

Constants and their pinned assertions only — four lines, no behaviour change:

- `VERIFIED_CLAUDE_VERSION` 2.1.226 → 2.1.227
- the `classify` / `drift_notice` assertions that pin the verified release
- `claude_flags.rs`'s `supported(...)` assertion

`cargo test -p aionui-session --lib backend::cli_version`: 13 passed. `cargo test -p aionui-ai-agent --lib claude_flags`: 5 passed. `clippy --all-targets -D warnings` and `cargo fmt --check` clean.

## Not in this PR

- **codex stays at 0.146.0.** Upstream's latest is still 0.147.0, which never completes a turn (`responseStreamDisconnected`, `httpStatusCode: null`, three runs). No newer release has appeared since.
- **agy stays at 1.1.11**, for two independent reasons.

  The model catalog is broken **on 1.1.11 itself** — this is a live defect, not an upgrade hazard, and an earlier draft of this description wrongly blamed 1.1.12. `agy models` prints `id<TAB>Display Name`; the parser fed the whole line to a check allowing only `[A-Za-z0-9._-]`, so every row was dropped and the picker opened empty. Dated from the dev logs: ``antigravity: `agy models` returned nothing`` first appears 2026-08-07 with 1.1.11 installed and recurs on 08-10 and 08-11, while 1.1.12 only self-installed on 2026-08-11 — four days later. #797 fixes it and should land regardless of any version bump.

  Separately, `live_antigravity_cancel_settles_and_recovers` fails reproducibly against 1.1.12 (3 runs: once in the full suite, twice in isolation) with no terminal frame within 14s of the cancel, against this backend's recorded 2.2s baseline. The failing conversation records zero frame types — not even `start` — while the pre-cancel `is_processing == true` assertion passes. **Undiagnosed, and deliberately not attributed to the release:** agy self-updates in place and no 1.1.11 binary survives, so the control cannot be run.


