### PR TITLE
fix(conversation): make temp-workspace check root-agnostic

### DIFF
--- a/crates/aionui-conversation/src/convert.rs
+++ b/crates/aionui-conversation/src/convert.rs
@@ -8,6 +8,7 @@ use aionui_db::MessageSearchRow;
 use aionui_db::models::{ConversationArtifactRow, ConversationRow, MessageRow};
 
 use crate::ConversationError;
+use crate::service::is_temp_session_workspace;
 
 pub(crate) const TOOL_CONTENT_COMPACT_THRESHOLD_BYTES: usize = 64 * 1024;
 const TOOL_CONTENT_PREVIEW_CHARS: usize = 4096;
@@ -29,19 +30,26 @@ pub fn row_to_response(row: ConversationRow, data_dir: &Path) -> Result<Conversa
 /// before building the response DTO.
 ///
 /// Injects a derived `is_temporary_workspace: bool` into the returned
-/// `extra` blob by checking whether `extra.workspace` sits under the
-/// backend-managed `data_dir`. The flag is not persisted — it is
-/// computed on every read so the frontend never has to pattern-match
-/// the directory name. Old rows that have no such flag on disk
-/// automatically gain it on read, which means no migration is needed.
+/// `extra` blob by testing whether `extra.workspace` is a backend
+/// auto-generated temp session directory (see
+/// [`is_temp_session_workspace`]). This is root-agnostic: rows migrated
+/// from an earlier data-dir root are still recognized, so historical temp
+/// sessions are not mislabeled as user projects. The flag is not persisted
+/// — it is computed on every read so the frontend never has to pattern-match
+/// the directory name. Old rows that have no such flag on disk automatically
+/// gain it on read, which means no migration is needed.
+///
+/// `_data_dir` is retained for call-site symmetry across the response builders
+/// (`row_to_response` / `search_row_to_item` thread it uniformly); the temp
+/// judgment is now root-agnostic and no longer depends on it.
 pub fn row_to_response_with_extra(
     row: ConversationRow,
     mut extra: serde_json::Value,
-    data_dir: &Path,
+    _data_dir: &Path,
 ) -> Result<ConversationResponse, ConversationError> {
     let is_temporary_workspace = {
         let ws = extra.get("workspace").and_then(|v| v.as_str()).unwrap_or("");
-        !ws.is_empty() && Path::new(ws).starts_with(data_dir)
+        !ws.is_empty() && is_temp_session_workspace(Path::new(ws))
     };
     if let Some(obj) = extra.as_object_mut() {
         obj.remove("preset_context");
@@ -495,6 +503,41 @@ mod tests {
     #[test]
     fn row_to_response_marks_missing_workspace_as_non_temporary() {
         let row = make_row("acp", "pending", Some("aionui"), None, r#"{}"#);
+        let resp = row_to_response(row, Path::new("/srv/aionui-data")).unwrap();
+        assert_eq!(resp.extra["is_temporary_workspace"], false);
+    }
+
+    // Historical-debt regression: a temp workspace persisted under a PREVIOUS
+    // data-dir root (user migrated their conversation directory across
+    // releases) must still be flagged temporary, even though it no longer sits
+    // under the current `data_dir`. The `-temp-` leaf marker is what makes this
+    // root-agnostic recognition safe.
+    #[test]
+    fn row_to_response_marks_migrated_root_temp_workspace_as_temporary() {
+        let row = make_row(
+            "acp",
+            "pending",
+            Some("aionui"),
+            None,
+            r#"{"workspace":"/old-data/aionui/conversations/users/u1/2025/01/02/acp-temp-conv-1"}"#,
+        );
+        // Current data_dir differs from the old root the workspace lives under.
+        let resp = row_to_response(row, Path::new("/srv/aionui-data")).unwrap();
+        assert_eq!(resp.extra["is_temporary_workspace"], true);
+    }
+
+    // Negative guard for the root-agnostic match: a user project that merely
+    // happens to sit under some `conversations/` ancestor must NOT be flagged
+    // temporary, because its leaf carries no `-temp-` marker.
+    #[test]
+    fn row_to_response_does_not_mark_user_project_under_conversations_as_temporary() {
+        let row = make_row(
+            "acp",
+            "pending",
+            Some("aionui"),
+            None,
+            r#"{"workspace":"/home/me/conversations/myproj"}"#,
+        );
         let resp = row_to_response(row, Path::new("/srv/aionui-data")).unwrap();
         assert_eq!(resp.extra["is_temporary_workspace"], false);
     }

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -4448,32 +4448,52 @@ fn is_auto_workspace_relative_path(relative: &Path) -> bool {
             && day.chars().all(|ch| ch.is_ascii_digit())
     };
 
+    // Auto/temp workspace leaves are always `{label}-temp-{id}` (conversations)
+    // or `team-temp-{team_id}` (teams); the `-temp-` marker has been stable
+    // across every historical layout. Requiring it keeps the root-agnostic
+    // match (see [`is_temp_session_workspace`]) from misclassifying a user
+    // directory that merely sits under some `conversations/` ancestor.
+    let is_temp_leaf = |leaf: &str| leaf.contains("-temp-");
+
     match parts.as_slice() {
         // legacy: bare leaf, or {Y}/{M}/{D}/leaf
-        [_file_name] => true,
-        [year, month, day, _file_name] => dated(year, month, day),
+        [leaf] => is_temp_leaf(leaf),
+        [year, month, day, leaf] => dated(year, month, day) && is_temp_leaf(leaf),
         // per-user, type-first: users/{user_dir}/{Y}/{M}/{D}/leaf
-        ["users", _user_dir, year, month, day, _file_name] => dated(year, month, day),
+        ["users", _user_dir, year, month, day, leaf] => dated(year, month, day) && is_temp_leaf(leaf),
         _ => false,
     }
 }
 
-/// True when `workspace` is a backend auto-generated temp session directory
-/// under `{work_dir}/conversations` — the sidebar read model's "temp path" test.
+/// True when `workspace` is a backend auto-generated temp session directory —
+/// the sidebar read model's "temp path" test.
 ///
-/// Pure lexical prefix strip + [`is_auto_workspace_relative_path`]; performs no
-/// filesystem access, so it is safe on the side-effect-free sidebar read path
-/// (dead/removed workspaces classify correctly rather than failing an fs probe).
-/// This is the same judgment the conversation service applies per row; it is
-/// exposed only so the sidebar can classify a conversation's `extra.workspace`
-/// (or a team's `workspace` column) without duplicating the rule. `work_dir` is
-/// the application data directory (`ConversationService`'s `workspace_root`),
-/// injected from the same source on both sides.
-pub fn is_temp_session_workspace(work_dir: &Path, workspace: &Path) -> bool {
-    match workspace.strip_prefix(work_dir.join("conversations")) {
-        Ok(relative) => is_auto_workspace_relative_path(relative),
-        Err(_) => false,
-    }
+/// Root-agnostic: matches the auto-workspace layout after the LAST
+/// `conversations` path segment, regardless of which data-dir root precedes
+/// it. This is deliberate. Users who migrated their conversation directory
+/// across releases carry `extra.workspace` values baked under a *previous*
+/// root; anchoring on the current `work_dir` would strip-fail on those and
+/// misclassify historical temp sessions as projects. The layout after
+/// `conversations/` has always ended in a `-temp-` leaf, so
+/// [`is_auto_workspace_relative_path`] keys on that marker rather than the
+/// (mutable) root prefix.
+///
+/// Pure lexical (no filesystem access), so it is safe on the side-effect-free
+/// sidebar read path — dead/removed workspaces classify correctly rather than
+/// failing an fs probe. Exposed so the sidebar can classify a conversation's
+/// `extra.workspace` (or a team's `workspace` column) without duplicating the
+/// rule.
+pub fn is_temp_session_workspace(workspace: &Path) -> bool {
+    let parts = workspace.iter().map(|part| part.to_str()).collect::<Option<Vec<_>>>();
+    let Some(parts) = parts else {
+        return false;
+    };
+    // Classify the tail after the LAST `conversations` segment (root-agnostic).
+    let Some(idx) = parts.iter().rposition(|part| *part == "conversations") else {
+        return false;
+    };
+    let relative: PathBuf = parts[idx + 1..].iter().collect();
+    is_auto_workspace_relative_path(&relative)
 }
 
 async fn cleanup_empty_date_workspace_parents(workspace_root: &Path, workspace_path: &Path) {

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -51,6 +51,7 @@ use serde_json::json;
 use tokio::sync::{Notify, broadcast};
 
 use crate::service::ConversationService;
+use crate::service::is_temp_session_workspace;
 use crate::skill_resolver::{FixedSkillResolver, ResolvedAgentSkill, SkillResolver};
 use crate::{ConversationAgentTurnRequest, ConversationAgentTurnStatus, ConversationError};
 
@@ -8403,4 +8404,75 @@ async fn a_deferred_cancel_does_not_leak_into_a_later_turn() {
     assert!(svc.runtime_state().take_deferred_cancel(&conv.id, "turn_old"));
     // Consumed exactly once.
     assert!(!svc.runtime_state().take_deferred_cancel(&conv.id, "turn_old"));
+}
+
+// --- is_temp_session_workspace: root-agnostic temp-directory judgment ---
+//
+// These lock the historical-debt fix: a temp workspace is recognized by the
+// auto-workspace layout after the LAST `conversations` segment plus a `-temp-`
+// leaf marker, regardless of which data-dir root precedes it. Users who
+// migrated their conversation directory across releases carry workspaces baked
+// under a *previous* root; those must still classify as temp.
+
+#[test]
+fn temp_workspace_current_root_is_recognized() {
+    // No regression for workspaces under the live root.
+    assert!(is_temp_session_workspace(Path::new(
+        "/srv/aionui-data/conversations/users/u1/2026/08/11/acp-temp-conv-1"
+    )));
+}
+
+#[test]
+fn temp_workspace_migrated_old_root_is_recognized() {
+    // Core fix: a different (older) root prefix must not defeat the judgment.
+    assert!(is_temp_session_workspace(Path::new(
+        "/old-data/aionui/conversations/users/u1/2025/01/02/acp-temp-conv-1"
+    )));
+}
+
+#[test]
+fn temp_workspace_team_leaf_is_recognized() {
+    assert!(is_temp_session_workspace(Path::new(
+        "/srv/aionui-data/conversations/users/u1/2026/08/11/team-temp-team_1"
+    )));
+}
+
+#[test]
+fn temp_workspace_legacy_bare_leaf_is_recognized() {
+    // Earliest layout: no dated dirs, just a `-temp-` leaf under conversations.
+    assert!(is_temp_session_workspace(Path::new(
+        "/old/conversations/claude-temp-xyz"
+    )));
+}
+
+#[test]
+fn temp_workspace_legacy_dated_leaf_is_recognized() {
+    assert!(is_temp_session_workspace(Path::new(
+        "/old/conversations/2025/01/02/acp-temp-conv-1"
+    )));
+}
+
+#[test]
+fn user_project_under_conversations_is_not_temp() {
+    // Negative guard: a user directory that merely sits under some
+    // `conversations/` ancestor lacks the `-temp-` marker → not temp.
+    assert!(!is_temp_session_workspace(Path::new("/home/me/conversations/myproj")));
+}
+
+#[test]
+fn workspace_without_conversations_segment_is_not_temp() {
+    assert!(!is_temp_session_workspace(Path::new("/home/me/work/proj")));
+}
+
+#[test]
+fn temp_workspace_with_bad_date_is_not_temp() {
+    // Dated arm still requires numeric YYYY/MM/DD.
+    assert!(!is_temp_session_workspace(Path::new(
+        "/srv/aionui-data/conversations/users/u1/YY/MM/DD/acp-temp-1"
+    )));
+}
+
+#[test]
+fn bare_conversations_dir_is_not_temp() {
+    assert!(!is_temp_session_workspace(Path::new("/srv/aionui-data/conversations")));
 }

--- a/crates/aionui-sidebar/src/service.rs
+++ b/crates/aionui-sidebar/src/service.rs
@@ -630,7 +630,7 @@ impl SidebarService {
             _ => return GroupKey::Chats,
         };
         let ws_path = Path::new(ws);
-        if is_temp_session_workspace(&self.work_dir, ws_path) {
+        if is_temp_session_workspace(ws_path) {
             return GroupKey::Chats;
         }
         let uri = match canonical::to_file_uri(ws_path) {

--- a/crates/aionui-sidebar/src/service_test.rs
+++ b/crates/aionui-sidebar/src/service_test.rs
@@ -36,10 +36,18 @@ impl Fixture {
         self.db.pool()
     }
 
-    /// A temp-session workspace path under `work_dir/conversations/<leaf>` — the
-    /// same shape the write side auto-assigns, which classifies to chats (case 5).
+    /// A temp-session workspace path under
+    /// `work_dir/conversations/<label>-temp-<leaf>` — the same shape the write
+    /// side auto-assigns (`{label}-temp-{id}`), which classifies to chats
+    /// (case 5). The `-temp-` marker is required: it is what
+    /// `is_temp_session_workspace` keys on to stay root-agnostic.
     fn temp_workspace(&self, leaf: &str) -> String {
-        self._tmp.path().join("conversations").join(leaf).display().to_string()
+        self._tmp
+            .path()
+            .join("conversations")
+            .join(format!("acp-temp-{leaf}"))
+            .display()
+            .to_string()
     }
 }
 
@@ -264,6 +272,32 @@ async fn classifies_five_cases_for_conversations() {
             .groups
             .iter()
             .any(|g| matches!(&g.scope, SidebarScope::Project { project_id, .. } if project_id == "proj-temp"))
+    );
+}
+
+// Historical-debt regression: a conversation whose temp workspace was baked
+// under a PREVIOUS data-dir root (user migrated their conversation directory
+// across releases) must still land in chats — not spawn a pseudo-dir project
+// group. Before the root-agnostic fix, the old root failed the temp check
+// (it != the current work_dir) so the path fell through to `GroupKey::Dir`,
+// rendering the temp session as a project. The stable `-temp-` leaf marker is
+// what lets us recognize it regardless of the root prefix.
+#[tokio::test]
+async fn migrated_root_temp_workspace_still_classifies_to_chats() {
+    let fx = fixture().await;
+    let pool = fx.pool();
+
+    // Absolute temp path under a DIFFERENT (older) root than the fixture
+    // work_dir, carrying the `-temp-` leaf marker.
+    let migrated = "/old-data/aionui/conversations/users/u1/2025/01/02/acp-temp-migrated";
+    insert_conv_ws(pool, USER, "c-mig", migrated, 60).await;
+
+    let resp = fx.service.first_screen(USER, Some(50), &[]).await.unwrap();
+
+    assert_eq!(conv_ids(&find_chats(&resp).items), vec!["c-mig"]);
+    assert!(
+        !resp.groups.iter().any(|g| matches!(g.scope, SidebarScope::Dir { .. })),
+        "migrated temp workspace must not spawn a pseudo-dir group"
     );
 }
 


### PR DESCRIPTION
## Description

Make the "is this a temporary/auto-provisioned session workspace?" check **root-agnostic**, fixing a historical-debt bug where long-time users — whose conversation directories were migrated across data-dir layouts — had their temporary sessions wrongly rendered as **projects** in the sidebar.

### Root cause

Both backends that decide "is this a temp workspace?" anchored on the *current* `data_dir` / `work_dir` root:

1. `aionui-conversation/src/service.rs` `is_temp_session_workspace` did `workspace.strip_prefix(work_dir.join("conversations"))` — after a migration `extra.workspace` holds an **absolute path under the old root**, so the strip failed and it returned `false`.
2. `aionui-conversation/src/convert.rs` badge `is_temporary_workspace` did `Path::new(ws).starts_with(data_dir)` — same current-root anchor, same false negative for old-root workspaces.

Symptom chain (new sidebar `classify_unit`): a temp session with no `project_id` → path branch → `is_temp_session_workspace` false → not folded into Chats → `canonicalize` misses (old dir may still exist physically) → `GroupKey::Dir` → **rendered as a project**.

### Fix

The auto/temp directory leaf has carried a `-temp-` marker across **every** historical layout (`{agent}-temp-{ts}`, dated `YYYY/MM/DD/{label}-temp-{id}`, `team-temp-{team_id}`). That marker is root-agnostic, so:

- `is_temp_session_workspace` now scans the path components for the **last** `conversations` segment and matches the relative tail, dropping the `work_dir` prefix dependency. Each `is_auto_workspace_relative_path` arm is **tightened** to additionally require `leaf.contains("-temp-")`, so a real user project like `/x/conversations/myproj` is not misclassified.
- The `convert.rs` badge now delegates to the same `is_temp_session_workspace` predicate instead of a raw `starts_with(data_dir)`.
- The sidebar call site drops the now-removed `work_dir` argument.

This covers the migration case with negligible false-positive risk (user projects almost never have a `-temp-` leaf) and keeps the heuristic as the foundation — no schema migration / backfill needed.

## Testing

```bash
cargo fmt --all
cargo test -p aionui-conversation -p aionui-sidebar
```

Added regression tests deliberately mixing an **old-root temp workspace** with a **user project**, per our verification discipline:

- `is_temp_session_workspace`: current-root temp → true (no regression); **migrated old-root** temp → true (the fix); team temp → true; legacy bare leaf → true; user project `/home/me/conversations/myproj` → **false**; no `conversations` segment → false; bad date → false.
- `convert.rs` badge: old-root workspace → `is_temporary_workspace=true`; user project under data_dir → false.
- sidebar `classify_unit`: no `project_id` + old-root temp workspace → `GroupKey::Chats`, no longer `GroupKey::Dir`.

All green.

## Cross-platform

Path handling uses component iteration (no hardcoded separators); tests exercise Unix-style absolute paths. No platform-specific branches introduced.
