### PR TITLE
fix(conversation): tell the client when a turn is cancelled before its agent exists

### DIFF
--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -3578,6 +3578,39 @@ impl ConversationService {
         Ok(page.items.iter().rev().find_map(error_message_from_message_row))
     }
 
+    /// Emit the terminal frame for a turn that ended before any `StreamRelay`
+    /// existed.
+    ///
+    /// The relay owns every other terminal on the send path, so a turn that
+    /// returns before it is built settles on the server while the client keeps
+    /// spinning — there is no frame telling it otherwise. The only caller today
+    /// is the deferred-cancel branch in `TurnOrchestrator::run_attempt`.
+    ///
+    /// Frame shape matches `StreamRelay::broadcast_stream_payload` so the client
+    /// takes the same path it does for a normal finish. `data` is empty because
+    /// there is nothing to report: the agent never ran, so there is no usage, no
+    /// session id and no text.
+    pub(crate) fn broadcast_turn_settled_without_relay(
+        &self,
+        user_id: &str,
+        conversation_id: &str,
+        turn_id: &str,
+        msg_id: &str,
+    ) {
+        self.broadcaster.broadcast(WebSocketMessage::new(
+            "message.stream",
+            serde_json::json!({
+                "user_id": user_id,
+                "conversation_id": conversation_id,
+                "msg_id": msg_id,
+                "turn_id": turn_id,
+                "type": "finish",
+                "data": {},
+                "hidden": false,
+            }),
+        ));
+    }
+
     pub(crate) async fn persist_and_broadcast_send_failure_tip(
         &self,
         user_id: &str,

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -8392,6 +8392,41 @@ async fn cancel_during_the_build_is_recorded_instead_of_dropped() {
     );
 }
 
+/// Remembering the cancel is only half of it — the client has to be told.
+///
+/// The turn ends on the server, but every terminal frame on the send path comes
+/// from the `StreamRelay`, which the deferred-cancel branch returns before
+/// building. So the server settled and the UI kept spinning until the 15s
+/// watchdog. Live symptom (agy 1.1.12, 2026-08-12): the conversation produced no
+/// stream frames at all, not even `start`, and the live cancel test failed 4/4;
+/// with the frame it settles in ~200ms.
+///
+/// The sibling test above asserts only that the request is recorded, which is
+/// why it stayed green through all of that.
+#[tokio::test]
+async fn a_turn_cancelled_before_its_agent_exists_tells_the_client_it_ended() {
+    let (svc, broadcaster, _repo, _task_mgr) = make_service();
+
+    svc.broadcast_turn_settled_without_relay("user_1", "conv_1", "turn_1", "msg_1");
+
+    let events = broadcaster.take_events();
+    let finish = events
+        .iter()
+        .find(|e| e.name == "message.stream" && e.data["type"] == "finish")
+        .expect("a turn that ends before its relay exists must still emit a terminal frame");
+
+    assert_eq!(finish.data["conversation_id"], "conv_1");
+    assert_eq!(finish.data["turn_id"], "turn_1");
+    assert_eq!(
+        finish.data["msg_id"], "msg_1",
+        "the frame has to name the message the client is spinning on"
+    );
+    assert_eq!(
+        finish.data["hidden"], false,
+        "a hidden terminal would settle nothing the user can see"
+    );
+}
+
 #[tokio::test]
 async fn a_deferred_cancel_does_not_leak_into_a_later_turn() {
     // The record is keyed by turn: one left behind must never abort the next

--- a/crates/aionui-conversation/src/turn_orchestrator.rs
+++ b/crates/aionui-conversation/src/turn_orchestrator.rs
@@ -230,6 +230,24 @@ impl ConversationTurnOrchestrator {
                 turn_id = %input.turn_id,
                 "Applying a cancel that arrived while the agent was still being built"
             );
+            // Tell the UI the turn is over. Every OTHER terminal on this path is
+            // emitted by the `StreamRelay`, which is built further down — so
+            // returning here without a frame settles the turn on the server and
+            // leaves the client's spinner running until the 15s watchdog.
+            //
+            // Live symptom (agy, 2026-08-12): the conversation produced NO
+            // stream frames at all, not even `start`, and
+            // `live_antigravity_cancel_settles_and_recovers` failed 4/4. agy is
+            // where it shows up because its build is the slowest — probing
+            // models, checking the CLI version, installing the permission hook
+            // and writing the MCP config — so a cancel lands inside it rather
+            // than after it. Nothing about the bug is agy-specific.
+            self.service.broadcast_turn_settled_without_relay(
+                &input.user_id,
+                &input.conv_id,
+                &input.turn_id,
+                &input.msg_id,
+            );
             return Err(ConversationTurnResult {
                 status: ConversationTurnStatus::Completed,
                 error_message: None,


### PR DESCRIPTION
Pressing Stop shortly after sending leaves the turn spinning in the UI until the 15s watchdog, even though the server has already ended it.

## What is actually broken

A cancel that arrives before the agent has registered is **deferred**, and the orchestrator applies it once the build finishes. That part works and was covered by tests. What is missing is the frame that says so.

Every other terminal on the send path is emitted by the `StreamRelay` — which the deferred-cancel branch returns *before* building. So the turn settles server-side and nothing ever tells the client.

The existing test asserted only that the request was recorded:

```rust
assert!(svc.runtime_state().take_deferred_cancel(&conv.id, &send.turn_id));
```

which is exactly why it stayed green while the user-visible behaviour was broken.

## How it was located

Three layers instrumented in turn, and **two hypotheses discarded before the right one**:

1. **Not the antigravity backend.** A unit test with a silent process (`sh -c 'sleep 60'`, standing in for agy's 6.18s of silence) proves the backend emits a terminal for a turn killed before any output.
2. **Not a registration race in that backend.** A first attempt added a `cancel_pending` flag for a cancel landing between `spawn()` and `*self.current = Some(proc)`. The live test still failed and the probe on that branch never fired — the race does not occur. That change was reverted rather than kept as a plausible-looking fix.
3. **Here.** Probes fired in sequence and told the whole story:

```
service::cancel: no agent yet — deferring the cancel
orchestrator: agent ready, checking deferred cancel
orchestrator: DEFERRED CANCEL APPLIED — returning Completed with no relay
[antigravity] no finish within 14s of cancel
```

## Why agy exposed it

agy's build is the slowest — it probes models, checks the CLI version, installs the permission hook and writes the MCP config — so a cancel lands *inside* the build rather than after it. agy 1.1.12 takes 6.18s to emit its first byte (measured: `agy -p … --output-format stream-json`), which widened the window further.

Nothing about the defect is agy-specific. In the verification run **claude took the same path**, going from 8.1s to 202ms.

## Fix

`broadcast_turn_settled_without_relay` emits the terminal the relay would have. The frame shape matches `StreamRelay::broadcast_stream_payload` so the client takes its normal finish path; `data` is empty because there is nothing to report — the agent never ran, so there is no usage, no session id, no text.

## Verification

Against the real CLIs:

| | before | after |
|---|---|---|
| `live_antigravity_cancel_settles_and_recovers` | **failed 4/4** — no terminal within 14s | settles in **202ms** |
| full agy set + claude cancel + codex cancel | — | **8/8** |
| claude cancel | 8.1s | 202ms |

`cargo test -p aionui-conversation`: 393 passed. `clippy --all-targets -D warnings` and `cargo fmt --check` clean.

The new test asserts what the old one did not — that the client is told, not merely that the request was remembered.

## Follow-up

This was the sole blocker on gate B for agy. With it fixed the agy suite is 6/6 against 1.1.12, so `VERIFIED_AGY_VERSION` can move once this lands — as a separate constants-only change, per the merge policy that keeps a source fix from riding in on a version bump.