### PR TITLE
chore(cli): bump verified agy to 1.1.12

### DIFF
--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -37,7 +37,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// the verified release stops at 0.146.0 until upstream fixes it.
 pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.227";
 pub const VERIFIED_CODEX_VERSION: &str = "0.146.0";
-pub const VERIFIED_AGY_VERSION: &str = "1.1.11";
+pub const VERIFIED_AGY_VERSION: &str = "1.1.12";
 
 /// The verified release for a direct-CLI backend, keyed by the program name the
 /// backend spawns. `None` for anything not version-gated here.


### PR DESCRIPTION
> **Depends on #827 — do not merge first.** Gate B's cancel test fails without it, so merging this alone would leave the constant claiming a verification the tree cannot reproduce. Gate B was run on `main + #827`, which is the tree this constant will live in.

`VERIFIED_AGY_VERSION` 1.1.11 → 1.1.12. One line; nothing else pins the value.

## Gates

| gate | verdict | evidence |
|---|---|---|
| A — contract | DEGRADED | agy publishes no protocol schema; only codex does. Expected, and why B carries the decision. |
| B — live e2e | **PASS 6/6** | 112.57s against `/Users/zhoukai/.local/bin/agy` (1.1.12); cancel settles in 202ms |
| C — release notes | CLEAR | read by hand; 1 REVIEW item, resolved in writing |

## Gate C, and the item it raised

`release_notes.py` reports MANUAL for agy — the changelog is a rendered page a raw fetch cannot recover — so it was read with a fetch tool and intersected against the manifest by hand. The write-up is filed with the record as `gate-c-manual.md`.

In range: non-interactive answers for more read-only slash commands (we invoke none), `--output-format` added to `models`/`agents` (additive; we pass none), and **`models` moving its spinner and error text off stdout** — the one item touching a dependency, `agy.models.probe`.

Reading the real output is what mattered: `agy models` prints `id<TAB>Display Name`, and the old parser fed the whole line to a check allowing only `[A-Za-z0-9._-]`, so every row was dropped and the picker opened empty.

**That is not a 1.1.12 regression.** Dated from the dev logs: ``agy models` returned nothing` first appears 2026-08-07 with **1.1.11** installed and recurs on 08-10 and 08-11, while 1.1.12 self-installed on 2026-08-11 — four days later. The format moved during 1.1.11's life and the defect was already shipping. #797 fixed it and is on main; the captured 1.1.12 output is filed with the record and the merged parser yields the full catalog from it.

Not touched by anything in range: no flag removed or renamed, and the `init` / `step_update` / `result` frames are unchanged (structured output landed in 1.1.8 and was not revised).

## Record

`~/aion/protocols/samples/antigravity-cli/1.1.12/`

| file | what it answers |
|---|---|
| `qualification.json` | verdict PASS, zero blockers, the binary judged **and its own `--version`** (`1.1.12`), per-gate results, and that the operator's active CLIs were left untouched |
| `live-suite.log` | the gate B run, with its `FRAME-TYPES` lines |
| `gate-c-manual.md` | the hand-read release notes and the resolution of the REVIEW item |
| `models-stdout.txt` | the real `agy models` output the parser was verified against |

Gate B was run against the already-installed 1.1.12 — the operator's own binary happened to be the candidate, so no shim was needed and nothing was moved.

## Frame types produced

`acp_context_usage`, `content`, `finish`, `start`, `tips`, `tool_call` — 6 distinct types across the 6 tests. Worth stating plainly: agy produces no `thinking` and no `plan` frames in this suite, so those parts of the translation are unexercised for this backend.

Constants only, no source change.