### PR TITLE
build(just): split build from install

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ setup:
 _cargo *ARGS:
     @{{cargo_script}} {{ARGS}}
 
-# Build in release mode and install to cargo bin
+# Build in release mode (does not install; run `just install` for that)
 # Use `just build --force` to skip cache check
 build *FLAGS: lint-fix fmt
     @{{build_script}} release {{FLAGS}}
@@ -32,7 +32,8 @@ build *FLAGS: lint-fix fmt
 build-debug *FLAGS:
     @{{build_script}} debug {{FLAGS}}
 
-install:
+# Build (if needed) then install the release binary to cargo bin
+install: build
     @{{install_script}} release
 
 # Run all tests

--- a/scripts/just/build.ps1
+++ b/scripts/just/build.ps1
@@ -44,9 +44,6 @@ if ($newSum -eq $oldSum) {
     Write-Output ""
     Write-Output "$label unchanged (sha256: $($newSum.Substring(0, 16)))"
 } else {
-    if ($Mode -eq "release") {
-        Invoke-Native "powershell.exe" @("-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "scripts/just/install.ps1", "release")
-    }
     Set-Content -LiteralPath $sumFile -Value $newSum -NoNewline
     Write-Output ""
     Write-Output "$label complete (sha256: $($newSum.Substring(0, 16)))"

--- a/scripts/just/build.sh
+++ b/scripts/just/build.sh
@@ -50,9 +50,6 @@ if [[ "$new_sum" == "$old_sum" ]]; then
     echo
     echo "$label unchanged (sha256: ${new_sum:0:16})"
 else
-    if [[ "$mode" == "release" ]]; then
-        bash scripts/just/install.sh release
-    fi
     echo "$new_sum" > "$sum_file"
     echo
     echo "$label complete (sha256: ${new_sum:0:16})"


### PR DESCRIPTION
## What

Split `just build` and `just install` into distinct recipes.

- `just build` now only builds the release binary — the install side effect is removed from `scripts/just/build.sh` and `scripts/just/build.ps1`.
- `just install` gains a `build` dependency (cargo-install semantics): it builds if needed, then installs the release binary to the cargo bin dir.

## Why

`just build` previously also installed the binary to the cargo bin dir as a side effect, so a plain build mutated the developer's toolchain. Separating the two makes `build` a pure build and gives `install` an explicit, discoverable name.

## Test

`just push` full pre-push gate green (migration-check, lint-fix, fmt, test workspace).