### PR TITLE
feat(db): dedicated startup stage for database created by a newer app (downgrade)

### DIFF
--- a/crates/aionui-app/src/bootstrap/environment.rs
+++ b/crates/aionui-app/src/bootstrap/environment.rs
@@ -134,19 +134,33 @@ pub async fn init_data_layer(config: &AppConfig) -> Result<Database, BootstrapEr
         },
     )
     .await
-    .map_err(|e| {
-        let stage = e.stage();
-        BootstrapError::new(
-            BootstrapErrorCode::DataInitFailed,
-            stage,
-            "failed to initialize application data",
-        )
-        .with_source(e.into_source())
-        .with_field("databasePath", db_path.display().to_string())
-    })?;
+    .map_err(|e| database_init_bootstrap_error(e, &db_path))?;
     info!(elapsed_ms = boot.elapsed().as_millis(), "startup: database initialized");
 
     Ok(database)
+}
+
+/// Map a database init failure to the bootstrap boundary error.
+///
+/// For the downgrade stage (`database.newer_than_app`) the stderr line carries
+/// both migration versions so the host and production logs can tell the user
+/// which release the database requires, without exposing the raw source error.
+fn database_init_bootstrap_error(error: aionui_db::DatabaseInitError, db_path: &std::path::Path) -> BootstrapError {
+    let stage = error.stage();
+    let source = error.into_source();
+    let mut bootstrap_error = BootstrapError::new(
+        BootstrapErrorCode::DataInitFailed,
+        stage,
+        "failed to initialize application data",
+    )
+    .with_field("databasePath", db_path.display().to_string());
+    if let Some(db_version) = source.missing_migration_version() {
+        bootstrap_error = bootstrap_error.with_field("dbMigrationVersion", db_version.to_string());
+        if let Some(app_version) = aionui_db::latest_known_migration_version() {
+            bootstrap_error = bootstrap_error.with_field("appMigrationVersion", app_version.to_string());
+        }
+    }
+    bootstrap_error.with_source(source)
 }
 
 #[cfg(test)]
@@ -184,6 +198,42 @@ mod tests {
         );
 
         assert_eq!(err.stage(), "database.recoverable_corruption");
+    }
+
+    #[test]
+    fn newer_than_app_stage_carries_migration_versions_on_stderr() {
+        let err = aionui_db::DatabaseInitError::new(
+            aionui_db::DATABASE_NEWER_THAN_APP_STAGE,
+            aionui_db::DbError::Migration(sqlx::migrate::MigrateError::VersionMissing(39)),
+        );
+
+        let bootstrap = database_init_bootstrap_error(err, std::path::Path::new("/db/path/aionui-backend.db"));
+        let line = bootstrap.stderr_line();
+        assert!(
+            line.starts_with("BOOTSTRAP_DATA_INIT_FAILED stage=database.newer_than_app"),
+            "{line}"
+        );
+        assert!(line.contains("dbMigrationVersion=39"), "{line}");
+        let app_version = aionui_db::latest_known_migration_version().unwrap();
+        assert!(line.contains(&format!("appMigrationVersion={app_version}")), "{line}");
+        // The raw sqlx message stays out of stderr (boundary contract).
+        assert!(!line.contains("previously applied"), "{line}");
+    }
+
+    #[test]
+    fn generic_database_failures_do_not_carry_migration_versions() {
+        let err = aionui_db::DatabaseInitError::new(
+            "database.migration",
+            aionui_db::DbError::Migration(sqlx::migrate::MigrateError::VersionMismatch(7)),
+        );
+
+        let bootstrap = database_init_bootstrap_error(err, std::path::Path::new("/db/path/aionui-backend.db"));
+        let line = bootstrap.stderr_line();
+        assert!(
+            line.starts_with("BOOTSTRAP_DATA_INIT_FAILED stage=database.migration"),
+            "{line}"
+        );
+        assert!(!line.contains("MigrationVersion"), "{line}");
     }
 
     #[test]

--- a/crates/aionui-db/src/database.rs
+++ b/crates/aionui-db/src/database.rs
@@ -30,6 +30,19 @@ static DB_MIGRATOR: Migrator = sqlx::migrate!();
 // Keep this pinned to migration version 7 even as newer migrations land.
 const MCP_SCHEMA_RECONCILIATION_MIGRATION_VERSION: i64 = 7;
 const RECOVERABLE_DATABASE_CORRUPTION_STAGE: &str = "database.recoverable_corruption";
+/// Stage reported when the database was created by a NEWER app version than
+/// this binary: `_sqlx_migrations` contains a version the embedded migrator
+/// does not know (sqlx `MigrateError::VersionMissing`). This is a downgrade
+/// scenario, not a broken migration — the fix is upgrading the app, so hosts
+/// (AionUi) surface a dedicated "upgrade required" dialog instead of the
+/// generic migration-failure one (Sentry ELECTRON-31Z).
+pub const DATABASE_NEWER_THAN_APP_STAGE: &str = "database.newer_than_app";
+
+/// Highest migration version embedded in this binary, i.e. the newest schema
+/// this build can open. `None` only if the migrations directory is empty.
+pub fn latest_known_migration_version() -> Option<i64> {
+    DB_MIGRATOR.iter().map(|m| m.version).max()
+}
 
 /// Wraps a SQLite connection pool with lifecycle management.
 #[derive(Clone, Debug)]
@@ -392,9 +405,22 @@ async fn run_migrations_staged(pool: &SqlitePool) -> Result<(), DatabaseInitErro
         .await
         .map_err(|e| DatabaseInitError::new("database.migration", e))?;
 
-    let result = run_migrations_with_retry(&mut conn)
-        .await
-        .map_err(|e| DatabaseInitError::new("database.migration", e));
+    let result = run_migrations_with_retry(&mut conn).await.map_err(|e| {
+        if let Some(db_version) = e.missing_migration_version() {
+            // Downgrade: the DB holds a migration this binary doesn't ship.
+            // warn (not error) — the database is intact; the app is just older
+            // than the data. Versions are needed at info+ to diagnose from
+            // production logs which release the user must return to.
+            warn!(
+                db_migration_version = db_version,
+                app_migration_version = latest_known_migration_version(),
+                "Database was created by a newer app version; refusing to open (downgrade detected)"
+            );
+            DatabaseInitError::new(DATABASE_NEWER_THAN_APP_STAGE, e)
+        } else {
+            DatabaseInitError::new("database.migration", e)
+        }
+    });
 
     sqlx::query("PRAGMA foreign_keys = ON; PRAGMA legacy_alter_table = OFF")
         .execute(&mut *conn)

--- a/crates/aionui-db/src/error.rs
+++ b/crates/aionui-db/src/error.rs
@@ -53,6 +53,16 @@ impl DbError {
         }
     }
 
+    /// The `_sqlx_migrations` version this binary does not know about, when the
+    /// error is sqlx's `VersionMissing` — the database was written by a newer
+    /// app version (downgrade scenario). `None` for every other error.
+    pub fn missing_migration_version(&self) -> Option<i64> {
+        match self {
+            DbError::Migration(sqlx::migrate::MigrateError::VersionMissing(version)) => Some(*version),
+            _ => None,
+        }
+    }
+
     /// True when this error is a UNIQUE constraint violation — either the
     /// explicit [`DbError::Conflict`] variant or a UNIQUE message from the
     /// underlying database error. Bootstrap treats these as "already done".
@@ -90,6 +100,16 @@ mod tests {
         ));
         assert!(message_indicates_unique_violation("unique constraint failed"));
         assert!(!message_indicates_unique_violation("no such column"));
+    }
+
+    #[test]
+    fn missing_migration_version_only_matches_version_missing() {
+        let downgrade = DbError::Migration(sqlx::migrate::MigrateError::VersionMissing(39));
+        assert_eq!(downgrade.missing_migration_version(), Some(39));
+
+        let mismatch = DbError::Migration(sqlx::migrate::MigrateError::VersionMismatch(7));
+        assert_eq!(mismatch.missing_migration_version(), None);
+        assert_eq!(DbError::Init("boom".into()).missing_migration_version(), None);
     }
 
     #[test]

--- a/crates/aionui-db/src/lib.rs
+++ b/crates/aionui-db/src/lib.rs
@@ -15,8 +15,9 @@ pub use agent_binding::{
     resolve_agent_binding_from_rows, runtime_backend_for_agent,
 };
 pub use database::{
-    Database, DatabaseInitError, DatabaseInitOptions, init_database, init_database_memory, init_database_staged,
-    init_database_staged_with_options, init_database_with_options, maybe_copy_legacy_database,
+    DATABASE_NEWER_THAN_APP_STAGE, Database, DatabaseInitError, DatabaseInitOptions, init_database,
+    init_database_memory, init_database_staged, init_database_staged_with_options, init_database_with_options,
+    latest_known_migration_version, maybe_copy_legacy_database,
 };
 pub use error::{
     DbError, SQLITE_BUSY_MESSAGE_MARKERS, SQLITE_UNIQUE_VIOLATION_MARKER, message_indicates_busy,

--- a/crates/aionui-db/tests/database_newer_than_app.rs
+++ b/crates/aionui-db/tests/database_newer_than_app.rs
@@ -1,0 +1,109 @@
+//! Downgrade detection: opening a database written by a NEWER app version.
+//!
+//! When `_sqlx_migrations` contains a version this binary's embedded migrator
+//! does not know, sqlx fails with `MigrateError::VersionMissing`. Startup must
+//! surface the dedicated `database.newer_than_app` stage (Sentry ELECTRON-31Z)
+//! instead of the generic `database.migration` one, and must NOT treat the
+//! intact-but-newer database as corruption to back up and rebuild.
+
+use aionui_db::{
+    DATABASE_NEWER_THAN_APP_STAGE, DatabaseInitOptions, DbError, init_database_staged,
+    init_database_staged_with_options, latest_known_migration_version,
+};
+
+/// A migration version far above anything this binary will ever ship.
+const FUTURE_MIGRATION_VERSION: i64 = 999_999;
+
+async fn seed_future_migration_row(path: &std::path::Path) {
+    let db = init_database_staged(path).await.unwrap();
+    sqlx::query(
+        "INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time)
+         VALUES (?, 'from a newer app version', CURRENT_TIMESTAMP, TRUE, x'00', 0)",
+    )
+    .bind(FUTURE_MIGRATION_VERSION)
+    .execute(db.pool())
+    .await
+    .unwrap();
+    db.close().await;
+}
+
+#[tokio::test]
+async fn newer_database_fails_with_dedicated_stage() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("aionui-backend.db");
+    seed_future_migration_row(&path).await;
+
+    let err = init_database_staged(&path).await.expect_err("downgrade must fail");
+    assert_eq!(err.stage(), DATABASE_NEWER_THAN_APP_STAGE);
+
+    let source = err.into_source();
+    assert_eq!(source.missing_migration_version(), Some(FUTURE_MIGRATION_VERSION));
+    assert!(
+        matches!(
+            &source,
+            DbError::Migration(sqlx::migrate::MigrateError::VersionMissing(v)) if *v == FUTURE_MIGRATION_VERSION
+        ),
+        "unexpected source error: {source}"
+    );
+}
+
+#[tokio::test]
+async fn newer_database_is_not_recovered_as_corruption() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("aionui-backend.db");
+    seed_future_migration_row(&path).await;
+
+    // Even with the rebuild flag authorized, an intact newer database must not
+    // be backed up and replaced — that would destroy the user's data when the
+    // actual fix is upgrading the app.
+    let err = init_database_staged_with_options(
+        &path,
+        DatabaseInitOptions {
+            recover_corrupted_database: true,
+        },
+    )
+    .await
+    .expect_err("downgrade must fail even with recovery authorized");
+    assert_eq!(err.stage(), DATABASE_NEWER_THAN_APP_STAGE);
+    assert!(path.exists(), "database file must be left in place");
+
+    let backups: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_name().to_string_lossy().contains(".backup."))
+        .collect();
+    assert!(backups.is_empty(), "no backup/rebuild for a newer database");
+}
+
+#[tokio::test]
+async fn genuine_migration_failures_keep_generic_stage() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("aionui-backend.db");
+
+    // Tamper with an applied migration's checksum: sqlx reports
+    // VersionMismatch, which is not a downgrade and must keep the generic
+    // migration stage.
+    let db = init_database_staged(&path).await.unwrap();
+    sqlx::query(
+        "UPDATE _sqlx_migrations SET checksum = x'00' WHERE version = (SELECT MAX(version) FROM _sqlx_migrations)",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+    db.close().await;
+
+    let err = init_database_staged(&path)
+        .await
+        .expect_err("checksum mismatch must fail");
+    assert_eq!(err.stage(), "database.migration");
+    assert_eq!(err.into_source().missing_migration_version(), None);
+}
+
+#[test]
+fn latest_known_migration_version_is_present_and_sane() {
+    let version = latest_known_migration_version().expect("embedded migrations must not be empty");
+    // 037 is the newest migration at the time this test was written; the
+    // constant only moves forward.
+    assert!(version >= 37, "unexpectedly low migration version: {version}");
+    assert!(version < FUTURE_MIGRATION_VERSION);
+}


### PR DESCRIPTION
## Problem

When a user downgrades AionUi (installs an older version after having run a newer one), aioncore cannot open the local database: `_sqlx_migrations` contains versions the older binary does not ship, and sqlx's migrator fails with `MigrateError::VersionMissing` before any business query runs (`validate_applied_migrations`, sqlx-core 0.8.6).

Today this surfaces as the generic `database.migration` stage, so AionUi shows the misleading **"Local data migration failed"** dialog (reinstall may not help / send diagnostics / contact support) — while the actual fix is simply updating the app.

Sentry evidence (ELECTRON-31Z, 141 users / 264 events, ongoing): all 7 sampled diagnostics attachments contain `migration N was previously applied but is missing in the resolved migrations` (N = 22–37). The new platform (pionex/aionui-desktop) shows the same pattern, including a user who failed on 2.1.50, reinstalled repeatedly, and still failed on 2.1.52 because the DB was newer than both.

## Change

- `run_migrations_staged` maps `VersionMissing` to a new boundary stage `database.newer_than_app` and logs both migration versions at `warn` (production-diagnosable at default level).
- New `DbError::missing_migration_version()` and `aionui_db::latest_known_migration_version()` accessors.
- The bootstrap stderr line now carries `dbMigrationVersion`/`appMigrationVersion` fields, e.g.
  `BOOTSTRAP_DATA_INIT_FAILED stage=database.newer_than_app databasePath=... dbMigrationVersion=39 appMigrationVersion=37: failed to initialize application data`.
  The raw sqlx message stays off stderr per the boundary contract.
- Downgrade remains excluded from corruption recovery (`should_attempt_recovery` is untouched): the database is intact and must not be backed up and rebuilt.
- `VersionMismatch` (same version, different content) intentionally stays in the generic `database.migration` stage — it is ambiguous (edited/forked migrations), not a clear downgrade.

Companion AionUi PR maps the new stage to a dedicated "update AionUi" dialog with a download button: iOfficeAI/AionUi#3998. Older AionUi builds fall back to their generic startup-failed dialog for the new stage (no worse than today).

## Tests

- `crates/aionui-db/tests/database_newer_than_app.rs`: downgrade yields the dedicated stage and `VersionMissing` source; not recovered even with `--recover-corrupted-database` (file left in place, no backup created); checksum tampering (`VersionMismatch`) keeps the generic stage; `latest_known_migration_version` sanity.
- `bootstrap::environment` unit tests: stderr line carries both version fields for the new stage and omits them otherwise; raw source never rendered.
- Targeted `cargo test -p aionui-db -p aionui-app` (affected suites), `cargo clippy -p aionui-db -p aionui-app -D warnings`, and `cargo fmt --check` pass.