### PR TITLE
chore(acp): bump dimcode, dirac, grok and nova registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -19,12 +19,12 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.10"
+      "version": "0.3.11"
     },
     "dirac": {
       "registry_json_id": "dirac",
       "package": "dirac-cli",
-      "version": "0.4.34"
+      "version": "0.4.35"
     },
     "glm-acp-agent": {
       "registry_json_id": "glm-acp-agent",
@@ -34,7 +34,7 @@
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "1.0.1"
+      "version": "1.0.3"
     },
     "kilo": {
       "registry_json_id": "kilo",
@@ -48,7 +48,7 @@
     "nova": {
       "registry_json_id": "nova",
       "package": "@compass-ai/nova",
-      "version": "1.1.31"
+      "version": "1.1.32"
     },
     "omp": {
       "package": "@oh-my-pi/pi-coding-agent",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Four npx pins drifted since #822, each backed by a fresh serial ACP probe of the exact pinned version. Lock-only change — four lines; no metadata, migration, or entrypoint edits, and no lock-derived test assertion embeds any of these versions.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| dimcode | `dimcode` | 0.3.10 → **0.3.11** | ok (agentInfo version 0.3.11) | auth required (`-32000`, "Provider credentials are required") |
| dirac | `dirac-cli` | 0.4.34 → **0.4.35** | ok (agentInfo dirac 0.4.35) | success (modes plan/act) |
| grok | `@xai-official/grok` | 1.0.1 → **1.0.3** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |
| nova | `@compass-ai/nova` | 1.1.31 → **1.1.32** | ok (protocolVersion 1) | config required (`-32000`, "Click Nova Setup to configure your API keys", advertising `kore-terminal-auth`) |

All four meet the release-lock criterion: `initialize` succeeds and `session/new` either succeeds or returns a clearly classified authentication/configuration requirement. Probes ran serially with no inherited HOME or credentials. Grok skips 1.0.2 — the Registry advertises 1.0.3 directly, and that is the version probed and pinned.

The other 7 Registry-pinned packages (autohand, codebuddy, deepagents, glm-acp-agent, kilo, pi, sigit) match the snapshot exactly. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. The `mimo-code` and `omp` entries are non-Registry builtins (no `registry_json_id`) and are correctly excluded from drift reconciliation.

**Two recurring vendor self-report quirks, neither actionable:**
- dimcode's handshake reports `agentInfo.title` as "DimAgent" (third sighting, see #814/#822), while the public Registry card and CDN entry both still say "DimCode" with the same `dimcode.dev` website. The seeded display name follows the public listing, so it stays "DimCode".
- nova reports `agentInfo` as `kore-cli` version `1.0.0`, matching neither the product name nor the package version 1.1.32 (also seen at 1.1.30 in #739). Unchanged behaviour; `initialize` succeeded, so the pin is evidenced.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.12-921b987`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.12-921b987/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the previous baseline (38 ids).

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11; #810, #814 and #822 all merged green under it). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock-only version bumps; existing startup/session error paths already identify a failing agent by backend.