### PR TITLE
chore(cli): bump verified claude to 2.1.228

### DIFF
--- a/crates/aionui-ai-agent/src/claude_flags.rs
+++ b/crates/aionui-ai-agent/src/claude_flags.rs
@@ -126,7 +126,7 @@ mod tests {
         assert!(!supported("2.1.0"), "2.1.0 hard-errors on --thinking-display");
         assert!(!supported("2.1.190"), "below the verified floor stays off");
         assert!(supported("2.1.191"), "lowest live-probed OK version");
-        assert!(supported("2.1.227"), "the release this integration is verified against");
+        assert!(supported("2.1.228"), "the release this integration is verified against");
         assert!(supported("2.1.220"));
         assert!(supported("3.0.0"), "a future major must not regress the gate");
     }

--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -35,7 +35,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// turn (its response stream disconnects with `httpStatusCode: null`, observed
 /// three times including a back-to-back control after three clean versions), so
 /// the verified release stops at 0.146.0 until upstream fixes it.
-pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.227";
+pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.228";
 pub const VERIFIED_CODEX_VERSION: &str = "0.146.0";
 pub const VERIFIED_AGY_VERSION: &str = "1.1.12";
 
@@ -449,8 +449,8 @@ mod tests {
     fn the_verified_release_says_nothing() {
         // Literal on purpose: this is the exact string a user on the verified
         // release reports, so the test breaks if a bump forgets to re-verify.
-        assert_eq!(classify("2.1.227", VERIFIED_CLAUDE_VERSION), VersionVerdict::Verified);
-        assert!(drift_notice("claude", "2.1.227", VERIFIED_CLAUDE_VERSION).is_none());
+        assert_eq!(classify("2.1.228", VERIFIED_CLAUDE_VERSION), VersionVerdict::Verified);
+        assert!(drift_notice("claude", "2.1.228", VERIFIED_CLAUDE_VERSION).is_none());
     }
 
     #[test]


### PR DESCRIPTION
`VERIFIED_CLAUDE_VERSION` 2.1.227 → 2.1.228, plus the three assertions pinned to it.

## Gates

| gate | verdict | evidence |
|---|---|---|
| A — contract | DEGRADED | claude publishes no protocol schema; only codex does |
| B — live e2e | **PASS 13/13** | 268.50s, 9 distinct WS frame types |
| C — release notes | CLEAR | 18 notes in range; 2 carried a risk verb, none touched our 31 dependency tokens |

## Getting the candidate without touching the operator's CLI

2.1.228 was not installed on this machine — `~/.local/share/claude/versions/` stopped at 2.1.227 — so it was fetched into a temp dir and reached through a PATH shim:

```bash
npm install @anthropic-ai/claude-code@2.1.228   # into a scratch dir
ln -sf <that>/node_modules/.bin/claude /tmp/shim228/claude
PATH="/tmp/shim228:$PATH" cargo test … live_claude -- --ignored
```

`~/.local/bin/claude` still points at `2.1.227`, verified before and after, and the record's `machine` block states it independently.

**That the suite really ran the candidate was confirmed from its own logs**, not assumed from the shim being on `PATH`:

```
direct CLI version detected  cli=claude  version=2.1.228
direct CLI version drift
```

The drift line is a second signal — the suite compared 2.1.228 against the then-current constant and disagreed, which is exactly what it should do before this PR lands.

## Record

`~/aion/protocols/samples/claude-cli/2.1.228/` — `qualification.json` (verdict PASS, zero blockers, the binary judged and its own `--version`) and the live-suite log with its `FRAME-TYPES` lines.

`THINKING_DISPLAY_MIN_VERSION` stays at 2.1.191, below the new constant, so a user on exactly the verified release is not told "you match" while thinking display is silently off.

## The other two

- **codex** — latest is still 0.147.0, which never completes a turn (response stream disconnects with `httpStatusCode: null`, three observations including a control). Stays at 0.146.0; nothing newer has shipped.
- **agy** — **no drift**. 1.1.12 is both the verified constant and the latest release, so no gate was run.

Constants only, no source change.