### PR TITLE
chore(deps): update aionrs to v0.2.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,8 +116,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -147,8 +147,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "regex",
  "serde",
@@ -159,8 +159,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "aion-compact",
  "aion-process",
@@ -184,8 +184,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -205,8 +205,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "aion-config",
  "chrono",
@@ -219,8 +219,8 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "libc",
  "tokio",
@@ -230,8 +230,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "aion-types",
  "serde",
@@ -243,8 +243,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -272,8 +272,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -299,8 +299,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -321,8 +321,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "async-trait",
  "base64",
@@ -7063,7 +7063,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "bitflags",
  "cc",
@@ -7072,8 +7072,8 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "futures-util",
+ "getrandom 0.2.17",
  "getrandom 0.3.4",
- "getrandom 0.4.2",
  "hyper",
  "hyper-rustls",
  "hyper-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,12 +59,12 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.10" }
-aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.10" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.10" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.10" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.10" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.10" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.11" }
+aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.11" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.11" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.11" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.11" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.11" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Bumps embedded engine aionrs v0.2.10 → v0.2.11.
https://github.com/iOfficeAI/aionrs/compare/v0.2.10...v0.2.11

feat(engine): stamp per-run turn ids onto conversation messages
feat(engine): add session forking with lineage and turn-anchored boundaries