### PR TITLE
feat(conversation): support forking aionrs conversations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,8 +116,8 @@ dependencies = [
 
 [[package]]
 name = "aion-agent"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "aion-compact",
  "aion-config",
@@ -147,8 +147,8 @@ dependencies = [
 
 [[package]]
 name = "aion-compact"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "regex",
  "serde",
@@ -159,8 +159,8 @@ dependencies = [
 
 [[package]]
 name = "aion-config"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "aion-compact",
  "aion-process",
@@ -184,8 +184,8 @@ dependencies = [
 
 [[package]]
 name = "aion-mcp"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "aion-config",
  "aion-protocol",
@@ -205,8 +205,8 @@ dependencies = [
 
 [[package]]
 name = "aion-memory"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "aion-config",
  "chrono",
@@ -219,8 +219,8 @@ dependencies = [
 
 [[package]]
 name = "aion-process"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "libc",
  "tokio",
@@ -230,8 +230,8 @@ dependencies = [
 
 [[package]]
 name = "aion-protocol"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "aion-types",
  "serde",
@@ -243,8 +243,8 @@ dependencies = [
 
 [[package]]
 name = "aion-providers"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "aion-config",
  "aion-types",
@@ -272,8 +272,8 @@ dependencies = [
 
 [[package]]
 name = "aion-skills"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "aion-config",
  "aion-mcp",
@@ -299,8 +299,8 @@ dependencies = [
 
 [[package]]
 name = "aion-tools"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "aion-config",
  "aion-process",
@@ -321,8 +321,8 @@ dependencies = [
 
 [[package]]
 name = "aion-types"
-version = "0.2.10"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+version = "0.2.11"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "async-trait",
  "base64",
@@ -3283,7 +3283,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6582,7 +6582,7 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
 dependencies = [
- "windows-core 0.56.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -6592,23 +6592,10 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
- "windows-implement 0.56.0",
- "windows-interface 0.56.0",
- "windows-result 0.1.2",
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
 ]
 
 [[package]]
@@ -6623,32 +6610,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6668,24 +6633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]
@@ -7063,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.10#4cf42f2d5d0a04d44462bda3df7c1ed66c03be81"
+source = "git+https://github.com/iOfficeAI/aionrs.git?tag=v0.2.11#8e61a90329fa9f67c4fdf7e97fe02c24dba33f75"
 dependencies = [
  "bitflags",
  "cc",
@@ -7072,8 +7019,8 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "futures-util",
+ "getrandom 0.2.17",
  "getrandom 0.3.4",
- "getrandom 0.4.2",
  "hyper",
  "hyper-rustls",
  "hyper-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,12 +59,12 @@ aionui-cron = { path = "crates/aionui-cron" }
 aionui-assistant = { path = "crates/aionui-assistant" }
 aionui-app = { path = "crates/aionui-app" }
 
-aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.10" }
-aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.10" }
-aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.10" }
-aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.10" }
-aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.10" }
-aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.10" }
+aion-agent = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.11" }
+aion-providers = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.11" }
+aion-types = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.11" }
+aion-protocol = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.11" }
+aion-config = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.11" }
+aion-mcp = { git = "https://github.com/iOfficeAI/aionrs.git", tag = "v0.2.11" }
 
 # Core framework
 tokio = { version = "1", features = ["full"] }
@@ -214,3 +214,4 @@ incremental = false
 debug = "line-tables-only"
 split-debuginfo = "unpacked"
 incremental = false
+

--- a/crates/aionui-ai-agent/src/factory/aionrs.rs
+++ b/crates/aionui-ai-agent/src/factory/aionrs.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 
-use aion_agent::session::SessionManager;
+use aion_agent::session::{ForkBoundary, Session, SessionManager};
 use aion_config::compat::OpenAiApiMode;
 use aion_config::config::{McpServerConfig, TransportType};
 use aion_types::message::ImageInputCapability;
 use aionui_api_types::{
-    AionrsBuildExtra, ModelImageInputCapability, ModelOpenAiApiMode, ModelSettings, SessionMcpServer,
+    AionrsBuildExtra, ForkSpec, ModelImageInputCapability, ModelOpenAiApiMode, ModelSettings, SessionMcpServer,
     SessionMcpTransport, TEAM_MCP_SERVER_NAME, TeamMcpStdioConfig,
 };
 use aionui_common::ProviderWithModel;
@@ -132,53 +133,12 @@ pub(super) async fn build(
 
     let session_directory = deps.data_dir.join("aionrs-sessions");
 
-    let resume_session = {
-        let session_mgr = SessionManager::new(session_directory.clone(), 100);
-        match session_mgr.load(&ctx.conversation_id) {
-            Ok(mut session) => {
-                // Drop orphaned assistant tool-calls left behind when the user
-                // pressed Stop mid-stream. Strict providers (Ollama-style,
-                // some OpenAI-compatible proxies) reject replayed assistants
-                // with `tool_calls != null` and `content == null` when no
-                // matching tool_result follows. See ELECTRON-1HV / ELECTRON-1J6.
-                let dropped = sanitize_session_messages(&mut session.messages);
-                info!(
-                    conversation_id = %ctx.conversation_id,
-                    session_id = %session.id,
-                    message_count = session.messages.len(),
-                    sanitized_dropped = dropped,
-                    "Loaded existing aionrs session for resume"
-                );
-                Some(session)
-            }
-            Err(_) => {
-                // Fallback: old architecture stored sessions inside the workspace
-                let legacy_dir = std::path::Path::new(&ctx.workspace).join(".aionrs/sessions");
-                let legacy_mgr = SessionManager::new(legacy_dir.clone(), 100);
-                match legacy_mgr.load(&ctx.conversation_id) {
-                    Ok(mut session) => {
-                        let dropped = sanitize_session_messages(&mut session.messages);
-                        info!(
-                            conversation_id = %ctx.conversation_id,
-                            session_id = %session.id,
-                            message_count = session.messages.len(),
-                            sanitized_dropped = dropped,
-                            "Loaded legacy aionrs session from workspace"
-                        );
-                        Some(session)
-                    }
-                    Err(e) => {
-                        debug!(
-                            conversation_id = %ctx.conversation_id,
-                            error = %e,
-                            "No existing aionrs session found, starting fresh"
-                        );
-                        None
-                    }
-                }
-            }
-        }
-    };
+    let resume_session = resolve_build_session(
+        &session_directory,
+        &ctx.workspace,
+        &ctx.conversation_id,
+        overrides.fork.as_ref(),
+    )?;
 
     let config = AionrsResolvedConfig {
         provider,
@@ -234,6 +194,113 @@ pub(super) async fn build(
 
     let agent = AionrsAgentManager::new(ctx.conversation_id, ctx.workspace, config, resume_session).await?;
     Ok(AgentInstance::Aionrs(Arc::new(agent)))
+}
+
+/// Resolve the session an aionrs build starts from.
+///
+/// Order: an existing session for this conversation (primary layout, then the
+/// legacy in-workspace layout) → a fork materialized from `extra.fork` (first
+/// open of a forked conversation) → none (fresh session).
+///
+/// Loaded histories are sanitized: orphaned assistant tool-calls left behind
+/// when the user pressed Stop mid-stream are dropped, because strict
+/// providers (Ollama-style, some OpenAI-compatible proxies) reject replayed
+/// assistants with `tool_calls != null` and `content == null` when no
+/// matching tool_result follows. See ELECTRON-1HV / ELECTRON-1J6.
+fn resolve_build_session(
+    session_directory: &Path,
+    workspace: &str,
+    conversation_id: &str,
+    fork: Option<&ForkSpec>,
+) -> Result<Option<Session>, AgentError> {
+    let session_mgr = SessionManager::new(session_directory.to_path_buf(), 100);
+    if let Ok(mut session) = session_mgr.load(conversation_id) {
+        let dropped = sanitize_session_messages(&mut session.messages);
+        info!(
+            conversation_id = %conversation_id,
+            session_id = %session.id,
+            message_count = session.messages.len(),
+            sanitized_dropped = dropped,
+            "Loaded existing aionrs session for resume"
+        );
+        return Ok(Some(session));
+    }
+
+    // Fallback: old architecture stored sessions inside the workspace.
+    let legacy_dir = Path::new(workspace).join(".aionrs/sessions");
+    let legacy_mgr = SessionManager::new(legacy_dir, 100);
+    if let Ok(mut session) = legacy_mgr.load(conversation_id) {
+        let dropped = sanitize_session_messages(&mut session.messages);
+        info!(
+            conversation_id = %conversation_id,
+            session_id = %session.id,
+            message_count = session.messages.len(),
+            sanitized_dropped = dropped,
+            "Loaded legacy aionrs session from workspace"
+        );
+        return Ok(Some(session));
+    }
+
+    // First open of a forked conversation: copy the parent's session (keyed
+    // by the parent conversation id — `ForkSpec.parent_session_id`) into this
+    // conversation's session id, cut at `fork.last_turn_id` when the fork was
+    // taken mid-history (None = fork at HEAD). The fork is persisted by
+    // `fork_from`, so later opens take the resume path above.
+    //
+    // Materialization failure is a hard error, never a silent fresh session:
+    // the visible history was already copied by the fork API, and an agent
+    // context that does not match it would silently answer from the wrong
+    // state. The error surfaces through the `runtime/ensure` call the
+    // frontend issues right after forking.
+    if let Some(fork) = fork {
+        let parent = session_mgr
+            .load(&fork.parent_session_id)
+            .or_else(|_| legacy_mgr.load(&fork.parent_session_id))
+            .map_err(|error| {
+                warn!(
+                    conversation_id = %conversation_id,
+                    parent_session_id = %fork.parent_session_id,
+                    error = %error,
+                    "Fork parent session not found"
+                );
+                AgentError::bad_request(format!(
+                    "Cannot fork: the parent conversation's session '{}' no longer exists",
+                    fork.parent_session_id
+                ))
+            })?;
+        let boundary = match fork.last_turn_id.as_deref() {
+            Some(anchor) => ForkBoundary::AtTurn(anchor),
+            None => ForkBoundary::Head,
+        };
+        let mut session = session_mgr
+            .fork_from(&parent, Some(conversation_id), boundary)
+            .map_err(|error| {
+                warn!(
+                    conversation_id = %conversation_id,
+                    parent_session_id = %fork.parent_session_id,
+                    last_turn_id = fork.last_turn_id.as_deref().unwrap_or("HEAD"),
+                    error = %error,
+                    "Failed to materialize aionrs fork session"
+                );
+                AgentError::bad_request(format!("Cannot fork the parent session: {error}"))
+            })?;
+        let dropped = sanitize_session_messages(&mut session.messages);
+        info!(
+            conversation_id = %conversation_id,
+            parent_session_id = %fork.parent_session_id,
+            last_turn_id = fork.last_turn_id.as_deref().unwrap_or("HEAD"),
+            message_count = session.messages.len(),
+            sanitized_dropped = dropped,
+            "Materialized aionrs fork session from parent"
+        );
+        return Ok(Some(session));
+    }
+
+    debug!(
+        conversation_id = %conversation_id,
+        "No existing aionrs session found, starting fresh"
+    );
+    Ok(None)
 }
 
 /// Map AionUi DB platform/protocol settings to the aionrs provider identifier.
@@ -1857,6 +1924,151 @@ mod tests {
             server.env.as_ref().and_then(|env| env.get("TOKEN")),
             Some(&"abc".to_owned())
         );
+    }
+
+    fn seeded_parent_session(dir: &Path, conversation_id: &str) -> Session {
+        use aion_types::message::{ContentBlock, Message, Role};
+
+        let mgr = SessionManager::new(dir.to_path_buf(), 100);
+        let mut session = mgr
+            .create("anthropic", "test-model", "/tmp", Some(conversation_id))
+            .expect("create parent session");
+        session.messages.push(Message::new(
+            Role::User,
+            vec![ContentBlock::Text { text: "hello".into() }],
+        ));
+        session.messages.push(Message::new(
+            Role::Assistant,
+            vec![ContentBlock::Text { text: "world".into() }],
+        ));
+        mgr.save(&session).expect("save parent session");
+        session
+    }
+
+    fn seeded_parent_session_with_turns(dir: &Path, conversation_id: &str) -> Session {
+        use aion_types::message::{ContentBlock, Message, Role};
+
+        let mgr = SessionManager::new(dir.to_path_buf(), 100);
+        let mut session = mgr
+            .create("anthropic", "test-model", "/tmp", Some(conversation_id))
+            .expect("create parent session");
+        for (turn, text) in [("turn_a", "u1"), ("turn_a", "a1"), ("turn_b", "u2"), ("turn_b", "a2")] {
+            let mut m = Message::now(Role::User, vec![ContentBlock::Text { text: text.into() }]);
+            m.turn_id = Some(turn.to_owned());
+            session.messages.push(m);
+        }
+        mgr.save(&session).expect("save parent session");
+        session
+    }
+
+    fn head_fork_spec(parent_conversation_id: &str) -> ForkSpec {
+        ForkSpec {
+            parent_conversation_id: parent_conversation_id.to_owned(),
+            parent_message_id: "m2".to_owned(),
+            parent_session_id: parent_conversation_id.to_owned(),
+            last_turn_id: None,
+        }
+    }
+
+    #[test]
+    fn resolve_build_session_materializes_fork_from_parent_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = seeded_parent_session(dir.path(), "parent-conv");
+        let spec = head_fork_spec("parent-conv");
+
+        let fork = resolve_build_session(dir.path(), "/nonexistent-workspace", "fork-conv", Some(&spec))
+            .expect("materialization must not error")
+            .expect("fork materialized");
+        assert_eq!(fork.id, "fork-conv");
+        assert_eq!(fork.forked_from.as_deref(), Some("parent-conv"));
+        assert_eq!(fork.messages.len(), parent.messages.len());
+
+        // The parent session is untouched and still loadable.
+        let mgr = SessionManager::new(dir.path().to_path_buf(), 100);
+        let reloaded_parent = mgr.load("parent-conv").expect("parent still loadable");
+        assert_eq!(reloaded_parent.messages.len(), parent.messages.len());
+        assert!(reloaded_parent.forked_from.is_none());
+
+        // Second open takes the resume path (the fork was persisted), not a
+        // second materialization.
+        let resumed = resolve_build_session(dir.path(), "/nonexistent-workspace", "fork-conv", Some(&spec))
+            .expect("resume must not error")
+            .expect("resume the materialized fork");
+        assert_eq!(resumed.id, "fork-conv");
+        assert_eq!(resumed.forked_from.as_deref(), Some("parent-conv"));
+    }
+
+    #[test]
+    fn resolve_build_session_at_turn_fork_truncates_at_anchor() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = seeded_parent_session_with_turns(dir.path(), "parent-conv");
+        let mut spec = head_fork_spec("parent-conv");
+        spec.last_turn_id = Some("turn_a".to_owned());
+
+        let fork = resolve_build_session(dir.path(), "/nonexistent-workspace", "fork-conv", Some(&spec))
+            .expect("materialization must not error")
+            .expect("fork materialized");
+        assert_eq!(fork.messages.len(), 2, "cut after the last turn_a message");
+        assert!(fork.messages.iter().all(|m| m.turn_id.as_deref() == Some("turn_a")));
+        assert!(fork.messages.len() < parent.messages.len());
+    }
+
+    #[test]
+    fn resolve_build_session_unresolvable_anchor_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        seeded_parent_session(dir.path(), "parent-conv");
+        let mut spec = head_fork_spec("parent-conv");
+        // Anchor matching no session message: pre-turn-tracking history or a
+        // compaction-folded turn. Must error, never silently fork elsewhere.
+        spec.last_turn_id = Some("turn_gone".to_owned());
+
+        let err = resolve_build_session(dir.path(), "/nonexistent-workspace", "fork-conv", Some(&spec))
+            .expect_err("unresolvable anchor must be a hard error");
+        assert!(err.to_string().contains("Cannot fork"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn resolve_build_session_missing_fork_parent_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let spec = head_fork_spec("never-existed");
+
+        let err = resolve_build_session(dir.path(), "/nonexistent-workspace", "fork-conv", Some(&spec))
+            .expect_err("missing parent must be a hard error, not a silent fresh session");
+        assert!(err.to_string().contains("no longer exists"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn resolve_build_session_existing_session_wins_over_fork_spec() {
+        let dir = tempfile::tempdir().unwrap();
+        seeded_parent_session(dir.path(), "parent-conv");
+        // The conversation already has its own session (e.g. the fork was
+        // materialized earlier and diverged): the fork spec must be ignored.
+        let mgr = SessionManager::new(dir.path().to_path_buf(), 100);
+        mgr.create("anthropic", "test-model", "/tmp", Some("fork-conv"))
+            .expect("existing session for the conversation");
+
+        let session = resolve_build_session(
+            dir.path(),
+            "/nonexistent-workspace",
+            "fork-conv",
+            Some(&head_fork_spec("parent-conv")),
+        )
+        .expect("resume must not error")
+        .expect("existing session returned");
+        assert_eq!(session.id, "fork-conv");
+        assert!(
+            session.forked_from.is_none(),
+            "the pre-existing session, not a re-fork of the parent"
+        );
+        assert!(session.messages.is_empty());
+    }
+
+    #[test]
+    fn resolve_build_session_no_session_no_fork_is_fresh() {
+        let dir = tempfile::tempdir().unwrap();
+        let resolved = resolve_build_session(dir.path(), "/nonexistent-workspace", "conv", None)
+            .expect("fresh path must not error");
+        assert!(resolved.is_none());
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/aionrs/agent.rs
@@ -18,7 +18,9 @@ use aionui_api_types::{
     AcpConfigOptionDto, AcpConfigSelectOptionDto, AgentModeResponse, ConfigOptionConfirmation,
     GetConfigOptionsResponse, SetConfigOptionResponse, SlashCommandItem,
 };
-use aionui_common::{AgentKillReason, AgentType, Confirmation, ConversationStatus, ErrorChain, TimestampMs, now_ms};
+use aionui_common::{
+    AgentKillReason, AgentType, Confirmation, ConversationStatus, ErrorChain, TimestampMs, generate_short_id, now_ms,
+};
 use serde_json::Value;
 use tokio::sync::{Mutex, Notify, broadcast};
 use tokio::time::timeout;
@@ -404,7 +406,22 @@ impl IAgentTask for AionrsAgentManager {
             "Built structured Aionrs content blocks"
         );
 
+        // One anchor for both history stores: the conversation-layer turn id
+        // is stamped onto this turn's DB message rows (BackendTurnBound →
+        // stream persistence, mirroring the codex reader) AND onto the
+        // engine's session messages, so an at-turn fork can cut both at the
+        // same point.
+        let turn_anchor = data
+            .turn_id
+            .clone()
+            .unwrap_or_else(|| format!("turn_{}", generate_short_id()));
+        let _ = self
+            .runtime
+            .event_sender()
+            .send(AgentStreamEvent::BackendTurnBound(turn_anchor.clone()));
+
         let mut engine = self.engine.lock().await;
+        engine.set_next_turn_id(Some(turn_anchor));
 
         let result = tokio::select! {
             res = engine.run_with_blocks(content_blocks, &data.msg_id) => Some(res),

--- a/crates/aionui-api-types/src/agent_build_extra.rs
+++ b/crates/aionui-api-types/src/agent_build_extra.rs
@@ -128,6 +128,14 @@ pub struct AionrsBuildExtra {
     pub backend: Option<String>,
     #[serde(default)]
     pub user_id: Option<String>,
+    /// Present only on a forked conversation (see [`ForkSpec`]). Consumed by
+    /// the aionrs factory on first open when no session exists for this
+    /// conversation yet: the parent's session (keyed by
+    /// `parent_session_id` = parent conversation id) is copied into this
+    /// conversation's session id, cut at `last_turn_id` when the fork was
+    /// taken mid-history (`None` = fork at HEAD).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork: Option<ForkSpec>,
 }
 
 /// ACP model information returned by the ACP backend.

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -2037,15 +2037,26 @@ impl ConversationService {
         } else {
             false
         };
+        let row_agent_type = parse_agent_type_from_row(&row);
         let mut response = row_to_response_with_extra(row, extra, &self.workspace_root)?;
         self.attach_assistant_identity(user_id, &mut response).await?;
         response.runtime = Some(self.runtime_summary_for(id).await);
         // Fork + prompt capabilities: detail-path-only post-fill (list stays
         // N+1-free). Best-effort — a lookup failure just hides the fork entry
-        // point / media hint.
-        if let Ok(Some(acp_row)) = self.acp_session_repo.get_for_user(user_id, id).await
+        // point / media hint. acp_session-backed agents resolve via their
+        // acp_session row; the builtin aionrs agent has no such row, so its
+        // identity comes from the assistant snapshot (same fallback fork()
+        // uses).
+        let capability_agent_id = match self.acp_session_repo.get_for_user(user_id, id).await {
+            Ok(Some(acp_row)) => Some(acp_row.agent_id),
+            Ok(None) if row_agent_type == Some(AgentType::Aionrs) => {
+                self.aionrs_capability_agent_id(user_id, id).await.ok()
+            }
+            _ => None,
+        };
+        if let Some(agent_id) = capability_agent_id
             && let Ok(capabilities) = self
-                .agent_capabilities_for_agent(user_id, &acp_row.agent_id, &response.extra.to_string())
+                .agent_capabilities_for_agent(user_id, &agent_id, &response.extra.to_string())
                 .await
         {
             response.fork_capability = capabilities.as_ref().and_then(fork_capability_view);
@@ -2499,9 +2510,12 @@ impl ConversationService {
     /// backend session id into `extra.fork`, creates the new row (same
     /// workspace — claude keys on-disk sessions by cwd), copies the visible
     /// history, and returns. The BACKEND session materializes lazily on the
-    /// fork's first open (`SessionSpec::Fork` / ACP `session/fork`); the
-    /// frontend calls `POST {new_id}/runtime/ensure` right after to surface
-    /// fork failures eagerly.
+    /// fork's first open (`SessionSpec::Fork` / ACP `session/fork` / for the
+    /// builtin aionrs agent, `SessionManager::fork_from` in the aionrs
+    /// factory — its session store is keyed by conversation id, so the parent
+    /// conversation id is the session anchor and no acp_session row exists);
+    /// the frontend calls `POST {new_id}/runtime/ensure` right after to
+    /// surface fork failures eagerly.
     ///
     /// Error contract (stable `reason` prefixes the frontend maps to i18n):
     /// 403 team / 404 conversation or message / 409 `FORK_TURN_IN_FLIGHT`,
@@ -2533,25 +2547,41 @@ impl ConversationService {
             });
         }
 
-        // Capability gate + parent session anchor, both from the acp_session
-        // row (claude/codex/ACP all share it; other agent types have none).
+        // Capability gate + parent session anchor. acp_session-backed agents
+        // (claude/codex/ACP) carry both on their acp_session row. The builtin
+        // aionrs agent owns no acp_session row: its session store is keyed by
+        // conversation id (the aionrs factory loads
+        // `SessionManager::load(<conversation_id>)`), so the parent
+        // conversation id IS the session anchor, and the agent identity comes
+        // from the assistant snapshot.
         let acp_row = self
             .acp_session_repo
             .get_for_user(user_id, id)
             .await
-            .map_err(|e| ConversationError::internal(format!("acp_session lookup: {e}")))?
-            .ok_or_else(|| ConversationError::Unprocessable {
-                reason: "FORK_UNSUPPORTED: this conversation type cannot be forked".into(),
-            })?;
+            .map_err(|e| ConversationError::internal(format!("acp_session lookup: {e}")))?;
+        let (capability_agent_id, parent_session_id) = match &acp_row {
+            Some(acp_row) => {
+                let session_id = acp_row.session_id.clone().ok_or_else(|| ConversationError::Busy {
+                    reason: "FORK_PARENT_UNBOUND: the conversation has no backend session to fork yet".into(),
+                })?;
+                (acp_row.agent_id.clone(), session_id)
+            }
+            None if parse_agent_type_from_row(&parent) == Some(AgentType::Aionrs) => {
+                let agent_id = self.aionrs_capability_agent_id(user_id, id).await?;
+                (agent_id, id.to_owned())
+            }
+            None => {
+                return Err(ConversationError::Unprocessable {
+                    reason: "FORK_UNSUPPORTED: this conversation type cannot be forked".into(),
+                });
+            }
+        };
         let fork_capability = self
-            .fork_capability_for_agent(user_id, &acp_row.agent_id, &parent.extra)
+            .fork_capability_for_agent(user_id, &capability_agent_id, &parent.extra)
             .await?
             .ok_or_else(|| ConversationError::Unprocessable {
                 reason: "FORK_UNSUPPORTED: this agent does not support session forking".into(),
             })?;
-        let parent_session_id = acp_row.session_id.clone().ok_or_else(|| ConversationError::Busy {
-            reason: "FORK_PARENT_UNBOUND: the conversation has no backend session to fork yet".into(),
-        })?;
 
         // Fork point: must be a message of the PARENT conversation. Cursor is
         // the display sort key (created_at, id), endpoint inclusive.
@@ -2694,31 +2724,34 @@ impl ConversationService {
         // acp_session row: same agent identity, session_id NULL ("fork
         // pending" — the first open materializes it); mode/model seeded from
         // the parent's live runtime state so the fork opens with the same
-        // selections.
-        let params = CreateAcpSessionParams {
-            user_id,
-            conversation_id: &new_id,
-            agent_source: &acp_row.agent_source,
-            agent_id: &acp_row.agent_id,
-        };
-        self.acp_session_repo
-            .create(&params)
-            .await
-            .map_err(|e| ConversationError::internal(format!("Failed to create acp_session row: {e}")))?;
-        if let Ok(Some(state)) = self.acp_session_repo.load_runtime_state_for_user(user_id, id).await {
-            let seed = SaveRuntimeStateParams {
-                current_mode_id: state.current_mode_id.as_deref().map(Some),
-                current_model_id: state.current_model_id.as_deref().map(Some),
-                config_selections_json: None,
-                context_usage_json: None,
+        // selections. aionrs conversations own no acp_session row (parity
+        // with create()): their fork materializes from `extra.fork` alone.
+        if let Some(acp_row) = &acp_row {
+            let params = CreateAcpSessionParams {
+                user_id,
+                conversation_id: &new_id,
+                agent_source: &acp_row.agent_source,
+                agent_id: &acp_row.agent_id,
             };
-            if (seed.current_mode_id.is_some() || seed.current_model_id.is_some())
-                && let Err(err) = self
-                    .acp_session_repo
-                    .save_runtime_state_for_user(user_id, &new_id, &seed)
-                    .await
-            {
-                warn!(error = %ErrorChain(&err), "fork: failed to seed runtime state (non-fatal)");
+            self.acp_session_repo
+                .create(&params)
+                .await
+                .map_err(|e| ConversationError::internal(format!("Failed to create acp_session row: {e}")))?;
+            if let Ok(Some(state)) = self.acp_session_repo.load_runtime_state_for_user(user_id, id).await {
+                let seed = SaveRuntimeStateParams {
+                    current_mode_id: state.current_mode_id.as_deref().map(Some),
+                    current_model_id: state.current_model_id.as_deref().map(Some),
+                    config_selections_json: None,
+                    context_usage_json: None,
+                };
+                if (seed.current_mode_id.is_some() || seed.current_model_id.is_some())
+                    && let Err(err) = self
+                        .acp_session_repo
+                        .save_runtime_state_for_user(user_id, &new_id, &seed)
+                        .await
+                {
+                    warn!(error = %ErrorChain(&err), "fork: failed to seed runtime state (non-fatal)");
+                }
             }
         }
 
@@ -2739,6 +2772,31 @@ impl ConversationService {
         response.fork_capability = Some(fork_capability);
         self.broadcast_list_changed(user_id, &new_id, "created", response.source.as_ref());
         Ok(response)
+    }
+
+    /// Agent identity owning capability metadata for an aionrs conversation
+    /// (which has no acp_session row): the assistant snapshot's agent binding
+    /// when present, else the builtin Aion CLI row resolved through the
+    /// standard id/backend/agent_type binding ladder (aionrs's backend column
+    /// is NULL, so it resolves by agent_type).
+    async fn aionrs_capability_agent_id(
+        &self,
+        user_id: &str,
+        conversation_id: &str,
+    ) -> Result<String, ConversationError> {
+        if let Some(snapshot) = self
+            .conversation_repo
+            .get_assistant_snapshot(user_id, conversation_id)
+            .await?
+            && !snapshot.agent_id.trim().is_empty()
+        {
+            return Ok(snapshot.agent_id);
+        }
+        Ok(self
+            .resolve_assistant_agent_binding(user_id, "aionrs")
+            .await?
+            .map(|binding| binding.agent_id)
+            .unwrap_or_default())
     }
 
     /// Resolve the fork capability for an agent from

--- a/crates/aionui-conversation/tests/conversation_extended.rs
+++ b/crates/aionui-conversation/tests/conversation_extended.rs
@@ -1163,3 +1163,113 @@ async fn fork_resolves_stream_msg_id_when_row_id_unknown() {
         "resolved to the real row"
     );
 }
+
+// ── Conversation fork: builtin aionrs agent (no acp_session row) ────
+
+fn aionrs_create_req() -> CreateConversationRequest {
+    let workspace = ensure_named_workspace_path("aionui-fork-test-aionrs");
+    serde_json::from_value(json!({
+        "type": "aionrs",
+        "extra": { "workspace": workspace, "backend": "aionrs" }
+    }))
+    .unwrap()
+}
+
+#[tokio::test]
+async fn fork_head_aionrs_uses_conversation_id_anchor_without_acp_row() {
+    let (svc, repo, acp_repo) = setup_fork().await;
+    let parent = svc.create(USER_ID, aionrs_create_req()).await.unwrap();
+    // aionrs conversations own no acp_session row (create() only makes one
+    // for ACP/antigravity) — the whole point of this path. The agent
+    // identity resolves through the builtin binding ladder (agent_type
+    // "aionrs" -> seed row), no assistant snapshot required.
+    assert!(acp_repo.get_for_user(USER_ID, &parent.id).await.unwrap().is_none());
+    let m1 = make_message(&parent.id, "hello", 0);
+    let m2 = make_message(&parent.id, "world", 10);
+    repo.insert_message(USER_ID, &m1).await.unwrap();
+    repo.insert_message(USER_ID, &m2).await.unwrap();
+
+    let fork = svc.fork(USER_ID, &parent.id, fork_req(&m2.id)).await.unwrap();
+    assert_ne!(fork.id, parent.id);
+    assert_eq!(
+        fork.fork_capability,
+        Some(aionui_api_types::ForkCapabilityView { at_turn: true }),
+        "aionrs declares an at-turn fork capability (migration 038)"
+    );
+    let spec = fork.extra.get("fork").expect("fork lineage in extra");
+    assert_eq!(spec["parent_conversation_id"], parent.id);
+    assert_eq!(spec["parent_message_id"], m2.id);
+    assert_eq!(
+        spec["parent_session_id"], parent.id,
+        "aionrs sessions are keyed by conversation id, so the parent conversation id is the session anchor"
+    );
+    assert!(spec.get("last_turn_id").is_none(), "aionrs forks only at HEAD");
+
+    // Copied history.
+    let page = repo
+        .list_messages_page(
+            USER_ID,
+            &fork.id,
+            &aionui_db::MessagePageParams {
+                limit: 50,
+                direction: aionui_db::MessagePageDirection::InitialLatest,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(page.items.len(), 2);
+
+    // The fork, like every aionrs conversation, owns no acp_session row.
+    assert!(acp_repo.get_for_user(USER_ID, &fork.id).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn fork_mid_history_without_anchor_is_refused_for_aionrs() {
+    let (svc, repo, _acp_repo) = setup_fork().await;
+    let parent = svc.create(USER_ID, aionrs_create_req()).await.unwrap();
+    // Rows without backend_turn_id: written before turn stamping existed.
+    let m1 = make_message(&parent.id, "one", 0);
+    let m2 = make_message(&parent.id, "two", 10);
+    repo.insert_message(USER_ID, &m1).await.unwrap();
+    repo.insert_message(USER_ID, &m2).await.unwrap();
+
+    let err = svc.fork(USER_ID, &parent.id, fork_req(&m1.id)).await.unwrap_err();
+    assert!(
+        matches!(&err, ConversationError::Unprocessable { reason } if reason.starts_with("FORK_POINT_UNSUPPORTED")),
+        "unanchored aionrs mid-history fork must be refused, not degraded to HEAD, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn fork_mid_history_resolves_aionrs_turn_anchor() {
+    let (svc, repo, _acp_repo) = setup_fork().await;
+    let parent = svc.create(USER_ID, aionrs_create_req()).await.unwrap();
+    // Rows stamped by the aionrs turn wiring (manager emits BackendTurnBound
+    // with the conversation-layer turn id).
+    let mut m1 = make_message(&parent.id, "one", 0);
+    m1.backend_turn_id = Some("turn_aion1".into());
+    let m2 = make_message(&parent.id, "two", 10);
+    repo.insert_message(USER_ID, &m1).await.unwrap();
+    repo.insert_message(USER_ID, &m2).await.unwrap();
+
+    let fork = svc.fork(USER_ID, &parent.id, fork_req(&m1.id)).await.unwrap();
+    let spec = fork.extra.get("fork").expect("fork lineage in extra");
+    assert_eq!(
+        spec["last_turn_id"], "turn_aion1",
+        "mid-history fork snapshots the resolved aionrs turn anchor"
+    );
+    assert_eq!(spec["parent_session_id"], parent.id);
+}
+
+#[tokio::test]
+async fn get_projects_fork_capability_for_aionrs_on_detail_path() {
+    let (svc, _repo, _acp_repo) = setup_fork().await;
+    let conv = svc.create(USER_ID, aionrs_create_req()).await.unwrap();
+
+    let detail = svc.get(USER_ID, &conv.id).await.unwrap();
+    assert_eq!(
+        detail.fork_capability,
+        Some(aionui_api_types::ForkCapabilityView { at_turn: true }),
+        "detail path projects the aionrs fork capability via the builtin binding ladder"
+    );
+}

--- a/crates/aionui-db/migrations/038_aionrs_fork_capability.sql
+++ b/crates/aionui-db/migrations/038_aionrs_fork_capability.sql
@@ -1,0 +1,33 @@
+-- Constructed fork capability for the builtin aionrs agent (Aion CLI).
+--
+-- Same pattern as migration 036 (claude/codex): aionrs is the in-process SDK
+-- integration path, never performs an ACP handshake, so its
+-- `agent_metadata.agent_capabilities` column is only ever written
+-- constructively (see also 015, which seeds its mode catalog the same way).
+--
+-- Capability shape, verified against the aionrs session store:
+--   * aionrs sessions are whole-file JSON state keyed by conversation id
+--     (verified: aionui-ai-agent factory loads `SessionManager::load(<conversation_id>)`
+--     from `<data_dir>/aionrs-sessions`); `SessionManager::fork_from` copies
+--     the parent session's history into a new session id, optionally cut at a
+--     turn anchor (`ForkBoundary::AtTurn`).
+--   * At-turn forks are supported ("at_turn": true, like codex in 036): the
+--     aionrs manager emits `BackendTurnBound` with the conversation-layer
+--     turn id at every turn start, the stream persistence layer stamps it
+--     onto that turn's message rows, and the aionrs engine stamps the same id
+--     onto its session messages — one anchor for both history stores. Rows
+--     written before this wiring existed stay NULL: they cannot anchor a
+--     mid-history fork and such requests are rejected explicitly
+--     (FORK_POINT_UNSUPPORTED), never silently degraded to a HEAD fork.
+--
+-- `json_patch` merges into any pre-existing JSON instead of clobbering the
+-- column. The row is addressed by its stable seed id (001), never by display
+-- fields.
+
+UPDATE agent_metadata SET
+    agent_capabilities = json_patch(
+        COALESCE(agent_capabilities, '{}'),
+        '{"session_capabilities":{"fork":{"at_turn":true}}}'
+    ),
+    updated_at = CAST(strftime('%s','now') AS INTEGER) * 1000
+WHERE id = '632f31d2';

--- a/crates/aionui-db/tests/aionrs_fork_capability_migration.rs
+++ b/crates/aionui-db/tests/aionrs_fork_capability_migration.rs
@@ -1,0 +1,22 @@
+use aionui_db::{IAgentMetadataRepository, SqliteAgentMetadataRepository, init_database_memory};
+
+/// Migration 038: the builtin aionrs agent (Aion CLI, seed id `632f31d2`)
+/// carries a constructed at-turn fork capability — the same shape 036 wrote
+/// for codex (turn anchors are stamped by the aionrs manager + engine).
+#[tokio::test]
+async fn aionrs_builtin_agent_declares_at_turn_fork_capability() {
+    let db = init_database_memory().await.unwrap();
+    let repo = SqliteAgentMetadataRepository::new(db.pool().clone());
+
+    let aionrs = repo.get("632f31d2").await.unwrap().expect("seeded Aion CLI row");
+    assert_eq!(aionrs.agent_type, "aionrs");
+    assert_eq!(aionrs.backend, None, "aionrs resolves by agent_type, not backend");
+
+    let capabilities: serde_json::Value =
+        serde_json::from_str(aionrs.agent_capabilities.as_deref().expect("constructed capabilities")).unwrap();
+    assert_eq!(
+        capabilities["session_capabilities"]["fork"],
+        serde_json::json!({"at_turn": true}),
+        "at-turn fork: anchors are stamped on aionrs rows and session messages"
+    );
+}


### PR DESCRIPTION
## Summary

- Extends the fork-as-new-conversation API (036) to the builtin aionrs agent. aionrs conversations own no acp_session row, so `fork()` resolves the agent identity via the assistant snapshot with a fallback to the builtin binding ladder (aionrs's `backend` column is NULL — it resolves by `agent_type`), and uses the parent conversation id itself as the session anchor (the aionrs session store is keyed by conversation id). Existing claude/codex/ACP fork paths are untouched.
- At-turn fork support, mirroring codex: `AionrsAgentManager` emits `BackendTurnBound` with the conversation-layer turn id at every turn start, so the shared stream-persistence layer stamps `backend_turn_id` onto that turn's message rows; the same id is passed into the engine (`set_next_turn_id`) so session-file messages carry the identical anchor. Migration 038 constructs `session_capabilities.fork = {"at_turn": true}` for the aionrs seed row (`632f31d2`), same pattern as 036 — a data-only `UPDATE`, no schema change.
- Backend session materialization: on the fork's first open the factory copies the parent session via `SessionManager::fork_from`, cut at `ForkSpec.last_turn_id` (`None` = HEAD). Materialization failure is a hard error surfaced through the `runtime/ensure` call the frontend issues right after forking — never a silent fresh session whose context would not match the copied visible history.
- Compatibility / migration: zero backfill. Old aionrs conversations fork at HEAD immediately; rows written before turn stamping have no anchor and mid-history forks on them are rejected explicitly (`FORK_POINT_UNSUPPORTED`), never silently degraded. Old session files (no `turn_id`/lineage fields) load unchanged via serde defaults.
- Includes the `aionrs v0.2.10 → v0.2.11` dependency bump as a separate first commit (v0.2.11 ships the fork primitive this branch consumes; supersedes #839).

## Why

Fork was live for claude/codex/ACP but the embedded AionCLI path had no support at all — no capability declaration, no session anchor source, no materialization. Since aionrs is the in-process SDK path we control both history stores, which is what lets it reach codex-level `at_turn` capability instead of claude's HEAD-only.

## Test Plan / Validation

- `cargo fmt --all -- --check` ✅
- `cargo clippy -p aionui-api-types -p aionui-db -p aionui-ai-agent -p aionui-conversation --all-targets -- -D warnings` ✅
- `cargo test -p aionui-ai-agent -p aionui-conversation -p aionui-db -p aionui-api-types` against the released v0.2.11 — 0 failed ✅
  - new: factory materialization (HEAD copy-once / at-turn truncation / unresolvable-anchor error / missing-parent error / existing-session-wins), migration 038 capability shape, conversation-level aionrs fork (HEAD lineage+copy without acp_session row, anchored mid-history success with `last_turn_id` snapshot, unanchored mid-history refusal, detail-path capability projection)
- `just push` full gate (migration check → lint → format → full workspace tests) ✅

## Non-goals

- No `backend_turn_id` stamping on user message rows (parity with codex: anchors live on agent-output rows; the resolver picks the nearest anchor at-or-before the fork point).
- No fork support for team conversations (unchanged 403) or antigravity (unchanged product decision).

## Related PRs

- iOfficeAI/aionrs#260 — session fork primitive + per-run turn ids (merged, released as v0.2.11)
- iOfficeAI/AionUi#4022 — frontend fork entry point for aionrs chats (inert until this PR is deployed: without `fork_capability` in the detail response the button stays hidden)
- Supersedes #839 (standalone bump, closed)

## Follow-up

- End-to-end runtime pass on the desktop app once merged: aionrs conversation → multi-turn → fork mid-history → forked conversation answers from the truncated context.