### PR TITLE
feat(session): report a deferred mode switch as pending instead of observed

### DIFF
--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -15,7 +15,8 @@ use std::sync::atomic::{AtomicI64, Ordering};
 
 use aionui_common::{AgentKillReason, ConversationStatus, TimestampMs, now_ms};
 use aionui_session::{
-    BackendError, Command, CommandMeta, ContentBlock, SessionBackend, SessionEnvelope, SessionEvent, ToolResultContent,
+    BackendError, Command, CommandMeta, ContentBlock, ModeInfo, ModelInfo, SessionBackend, SessionEnvelope,
+    SessionEvent, ToolResultContent,
 };
 use futures_util::stream::BoxStream;
 use tokio::sync::broadcast;
@@ -108,6 +109,17 @@ struct SessionRuntime {
     /// (`get_config_options`) prefers this over the (synchronously-seeded) caps value so
     /// the observed re-read confirms the switch. `None` until the user picks a level.
     effort_override: std::sync::Mutex<Option<String>>,
+    /// Raw material from the last `CatalogUpdated`, kept so a later `ConfigChanged`
+    /// can re-project the WHOLE options snapshot.
+    ///
+    /// Needed because the two constraints collide: the frontend REPLACES its whole
+    /// snapshot on every `acp_config_option` frame (`useAcpConfigOptions` ->
+    /// `replaceSnapshot`), so a confirmation frame must carry every category or it
+    /// wipes the sibling pickers — yet the pump deliberately holds no backend Arc
+    /// (see `spawn_event_pump`) and therefore cannot rebuild the catalog itself.
+    /// Empty until the first catalog lands; a confirmation arriving before that
+    /// degrades to "update the override, emit nothing" (REST re-read still corrects).
+    last_catalog: std::sync::Mutex<Option<(Vec<ModeInfo>, Vec<ModelInfo>)>>,
 }
 
 impl SessionRuntime {
@@ -153,6 +165,14 @@ impl SessionRuntime {
     }
     fn effort_override(&self) -> Option<String> {
         self.effort_override.lock().ok().and_then(|g| g.clone())
+    }
+    fn set_last_catalog(&self, modes: Vec<ModeInfo>, models: Vec<ModelInfo>) {
+        if let Ok(mut g) = self.last_catalog.lock() {
+            *g = Some((modes, models));
+        }
+    }
+    fn last_catalog(&self) -> Option<(Vec<ModeInfo>, Vec<ModelInfo>)> {
+        self.last_catalog.lock().ok().and_then(|g| g.clone())
     }
 
     /// Atomic clean-converge frame: if not already `Finished`, set status ←
@@ -445,6 +465,7 @@ impl SessionAgentTask {
             mode_override: std::sync::Mutex::new(None),
             model_override: std::sync::Mutex::new(None),
             effort_override: std::sync::Mutex::new(None),
+            last_catalog: std::sync::Mutex::new(None),
         });
         // Subscribe to the backend's event stream HERE (sync), then hand ONLY the
         // stream to the pump — never a backend Arc (see `spawn_event_pump` for why
@@ -2328,6 +2349,95 @@ fn session_event_name(e: &SessionEvent) -> &'static str {
 }
 
 /// Drain the backend's `events()` and re-broadcast each as an `AgentStreamEvent`.
+/// Project the direct-CLI catalog into a WHOLE `acp_config_option` snapshot and
+/// broadcast it.
+///
+/// Emitted whole (mode + model + effort together) because the frontend REPLACES its
+/// entire snapshot on this frame (`useAcpConfigOptions` -> `replaceSnapshot`) — a
+/// partial frame would wipe the sibling pickers. Built here rather than in the
+/// stateless `translate_event` because every current-value highlight comes from the
+/// runtime's overrides.
+///
+/// Two callers, deliberately sharing one projection: the catalog arrival itself, and a
+/// later `ConfigChanged` confirming an agent-applied mode/model.
+fn emit_config_options_snapshot(modes: &[ModeInfo], models: &[ModelInfo], runtime: &SessionRuntime) {
+    let mut config_options: Vec<aionui_api_types::AcpConfigOptionDto> = Vec::new();
+    if !modes.is_empty() {
+        config_options.push(aionui_api_types::AcpConfigOptionDto {
+            id: "mode".into(),
+            name: Some("Mode".into()),
+            label: None,
+            description: None,
+            category: Some("mode".into()),
+            option_type: "select".into(),
+            current_value: runtime.mode_override(),
+            options: modes
+                .iter()
+                .map(|m| aionui_api_types::AcpConfigSelectOptionDto {
+                    value: m.id.clone(),
+                    name: Some(m.name.clone()),
+                    label: None,
+                    description: m.description.clone(),
+                })
+                .collect(),
+        });
+    }
+    if !models.is_empty() {
+        config_options.push(aionui_api_types::AcpConfigOptionDto {
+            id: "model".into(),
+            name: Some("Model".into()),
+            label: None,
+            description: None,
+            category: Some("model".into()),
+            option_type: "select".into(),
+            current_value: runtime.model_override(),
+            options: models
+                .iter()
+                .map(|m| aionui_api_types::AcpConfigSelectOptionDto {
+                    value: m.id.clone(),
+                    name: Some(m.name.clone()),
+                    label: None,
+                    description: m.description.clone(),
+                })
+                .collect(),
+        });
+    }
+    // Reasoning-effort axis (claude per-model `supportedEffortLevels`). Re-emitted here
+    // too — otherwise a push would wipe the effort option that `get_config_options`
+    // (REST) surfaced. The pump has no backend Arc, so the current model is resolved
+    // from the pushed catalog and the highlight comes from the runtime's optimistic
+    // effort override (claude emits no effort echo). Emitted only when the current model
+    // advertises efforts (union fallback when the current model is unknown).
+    let efforts = resolve_current_model_efforts(models, runtime.model_override().as_deref());
+    if !efforts.is_empty() {
+        config_options.push(aionui_api_types::AcpConfigOptionDto {
+            id: "reasoning_effort".into(),
+            name: Some("Thinking".into()),
+            label: None,
+            description: None,
+            category: Some("thought_level".into()),
+            option_type: "select".into(),
+            current_value: runtime.effort_override(),
+            options: efforts
+                .iter()
+                .map(|e| aionui_api_types::AcpConfigSelectOptionDto {
+                    value: e.clone(),
+                    name: Some(e.clone()),
+                    label: None,
+                    description: None,
+                })
+                .collect(),
+        });
+    }
+    // No categories → nothing to re-project; a spurious empty-snapshot frame would only
+    // clobber the frontend's picker.
+    if !config_options.is_empty()
+        && let Ok(v) = serde_json::to_value(serde_json::json!({ "config_options": config_options }))
+    {
+        let _ = runtime.tx.send(AgentStreamEvent::AcpConfigOption(v));
+    }
+}
+
 fn spawn_event_pump(
     mut events: BoxStream<'static, SessionEnvelope>,
     runtime: Arc<SessionRuntime>,
@@ -2592,83 +2702,10 @@ fn spawn_event_pump(
                 slash_commands,
             } = &env.event
             {
-                let mut config_options: Vec<aionui_api_types::AcpConfigOptionDto> = Vec::new();
-                if !modes.is_empty() {
-                    config_options.push(aionui_api_types::AcpConfigOptionDto {
-                        id: "mode".into(),
-                        name: Some("Mode".into()),
-                        label: None,
-                        description: None,
-                        category: Some("mode".into()),
-                        option_type: "select".into(),
-                        current_value: runtime.mode_override(),
-                        options: modes
-                            .iter()
-                            .map(|m| aionui_api_types::AcpConfigSelectOptionDto {
-                                value: m.id.clone(),
-                                name: Some(m.name.clone()),
-                                label: None,
-                                description: m.description.clone(),
-                            })
-                            .collect(),
-                    });
-                }
-                if !models.is_empty() {
-                    config_options.push(aionui_api_types::AcpConfigOptionDto {
-                        id: "model".into(),
-                        name: Some("Model".into()),
-                        label: None,
-                        description: None,
-                        category: Some("model".into()),
-                        option_type: "select".into(),
-                        current_value: runtime.model_override(),
-                        options: models
-                            .iter()
-                            .map(|m| aionui_api_types::AcpConfigSelectOptionDto {
-                                value: m.id.clone(),
-                                name: Some(m.name.clone()),
-                                label: None,
-                                description: m.description.clone(),
-                            })
-                            .collect(),
-                    });
-                }
-                // Reasoning-effort axis (claude per-model `supportedEffortLevels`). The
-                // frontend REPLACES its whole config-options snapshot on this frame, so we
-                // MUST re-emit effort here too — otherwise a late catalog push would wipe
-                // the effort option that `get_config_options` (REST) surfaced. The pump has
-                // no backend Arc, so the current model is resolved from the pushed catalog
-                // and the highlight comes from the runtime's optimistic effort override
-                // (claude emits no effort echo). Emitted only when the current model
-                // advertises efforts (union fallback when the current model is unknown).
-                let efforts = resolve_current_model_efforts(models, runtime.model_override().as_deref());
-                if !efforts.is_empty() {
-                    config_options.push(aionui_api_types::AcpConfigOptionDto {
-                        id: "reasoning_effort".into(),
-                        name: Some("Thinking".into()),
-                        label: None,
-                        description: None,
-                        category: Some("thought_level".into()),
-                        option_type: "select".into(),
-                        current_value: runtime.effort_override(),
-                        options: efforts
-                            .iter()
-                            .map(|e| aionui_api_types::AcpConfigSelectOptionDto {
-                                value: e.clone(),
-                                name: Some(e.clone()),
-                                label: None,
-                                description: None,
-                            })
-                            .collect(),
-                    });
-                }
-                // No categories (both lists empty) → nothing to re-project; a spurious
-                // empty-snapshot frame would only clobber the frontend's picker.
-                if !config_options.is_empty()
-                    && let Ok(v) = serde_json::to_value(serde_json::json!({ "config_options": config_options }))
-                {
-                    let _ = runtime.tx.send(AgentStreamEvent::AcpConfigOption(v));
-                }
+                // Retain the raw catalog so a later `ConfigChanged` can re-project the
+                // WHOLE snapshot (the pump cannot rebuild it — it holds no backend Arc).
+                runtime.set_last_catalog(modes.clone(), models.clone());
+                emit_config_options_snapshot(modes, models, &runtime);
                 // Slash-command catalog. claude advertises its command list in the
                 // async `initialize` response — the same late-catalog timing that
                 // strands the model/mode picker — and the frontend's mount-time REST
@@ -2694,6 +2731,32 @@ fn spawn_event_pump(
                         }));
                 }
                 continue;
+            }
+
+            // An agent-CONFIRMED mode/model switch: claude's `system/status{permissionMode}`
+            // (verified: samples/claude-cli/2.1.227/set_permission_mode/) or codex's
+            // `thread/settings/updated`. This is the only honest "it actually took effect"
+            // signal — unlike the optimistic override `set_config_option` writes at REQUEST
+            // time, which reads straight back and so always reports success. Adopt the
+            // confirmed value as the authoritative highlight and re-project the whole
+            // snapshot, so the picker stops showing a mode the agent has not applied (codex
+            // applies a settings update only from the NEXT turn; verified:
+            // samples/codex-cli/0.146.0/schema/v2/ThreadSettingsUpdateParams.json).
+            //
+            // Deliberately NO `continue`: the event must still reach `persist_side_effects`
+            // below, which is what writes `current_mode_id` for the next respawn/resume.
+            if let SessionEvent::ConfigChanged { mode, model } = &env.event {
+                if let Some(mode) = mode {
+                    runtime.set_mode_override(mode.clone());
+                }
+                if let Some(model) = model {
+                    runtime.set_model_override(model.clone());
+                }
+                // Nothing to re-project until a catalog has landed. The override is still
+                // updated, so the next REST read reports the confirmed value.
+                if let Some((modes, models)) = runtime.last_catalog() {
+                    emit_config_options_snapshot(&modes, &models, &runtime);
+                }
             }
 
             // Project a running workflow's roster to the UI. Everything a workflow
@@ -4138,14 +4201,14 @@ fn translate_event(event: SessionEvent, conversation_id: &str, terminal_result_s
             usage["output_tokens"] = serde_json::json!(output_tokens);
             vec![AgentStreamEvent::AcpContextUsage(usage)]
         }
-        // A confirmed mode/model switch is NOT forwarded as a stream frame. The origin
-        // frontend's mode/model pickers (AgentModeSelector / AcpModelSelector) track the
-        // selection in local state updated optimistically on the PUT /config-options
-        // call + its REST response — they do NOT consume a config stream frame. And the
-        // origin `useAcpMessage` has no `acp_config_option` case, so any such frame falls
-        // into its `default:` arm and lights the turn timer bar (`setRunning(true)`) —
-        // the "switching mode shows a spurious timer" regression. So emit nothing here;
-        // the selection persist is handled separately by `persist_side_effects`.
+        // Nothing HERE, because this function is stateless: the current-value highlight
+        // lives in the runtime's overrides, so all `translate_event` could build is a
+        // mode-only frame — and the frontend REPLACES its whole snapshot on
+        // `acp_config_option`, which would wipe the sibling model/effort pickers.
+        //
+        // The confirmation is surfaced by the EVENT PUMP instead, which holds the runtime
+        // and re-projects the full snapshot (`emit_config_options_snapshot`). Persisting
+        // the selection is handled separately by `persist_side_effects`.
         SessionEvent::ConfigChanged { .. } => Vec::new(),
         // Handled earlier in the pump (needs runtime overrides for the current-value
         // highlight; projected to an AcpConfigOption frame there). Never reaches this
@@ -5098,13 +5161,24 @@ mod translate_tests {
         }
     }
 
-    // A ConfigChanged must NOT produce any stream frame: the origin frontend's mode/
-    // model pickers track selection in local state (optimistic on the PUT + its REST
-    // response), and an `acp_config_option` frame would fall into origin useAcpMessage's
-    // `default:` arm and light a spurious turn timer bar. The selection is still
-    // persisted separately (see persist_tests::config_changed_persists_mode_and_model).
+    // A ConfigChanged produces no frame FROM `translate_event` — this function is
+    // stateless and cannot read the runtime's overrides, so it could only build a
+    // mode-only frame, and the frontend REPLACES its whole snapshot on
+    // `acp_config_option` (`useAcpConfigOptions` -> `replaceSnapshot`), which would wipe
+    // the model/effort pickers.
+    //
+    // The confirmation IS surfaced — by the event pump, which holds the runtime and
+    // re-projects the WHOLE snapshot (see
+    // pump_tests::config_changed_projects_confirmed_mode_to_frontend). The selection is
+    // persisted separately (persist_tests::config_changed_persists_mode_and_model).
+    //
+    // NOTE: an earlier version of this comment justified the suppression by claiming the
+    // frontend "does not consume a config stream frame" and that such a frame lands in
+    // `useAcpMessage`'s `default:` arm lighting a spurious timer. Both were fixed
+    // upstream: `useAcpConfigOptions` subscribes to `acp_config_option`, and
+    // `useAcpMessage` has an explicit no-op case for it.
     #[test]
-    fn config_changed_emits_no_frame() {
+    fn config_changed_emits_no_frame_from_stateless_translate() {
         let events = translate_event(
             SessionEvent::ConfigChanged {
                 mode: Some("plan".into()),
@@ -6780,6 +6854,92 @@ mod pump_tests {
             model_values,
             vec!["default", "opus"],
             "the parsed model ids ride the frame"
+        );
+    }
+
+    // An agent-CONFIRMED mode switch must reach the frontend as an `acp_config_option`
+    // frame carrying the confirmed value. This is the ONLY honest "it actually took
+    // effect" signal: for the direct-CLI backends the PUT response is optimistic —
+    // `set_config_option` caches the requested value as an override and reads it
+    // straight back — so without this frame the picker shows a mode the agent may not
+    // have applied. codex applies `thread/settings/update` only from the NEXT turn
+    // (verified: samples/codex-cli/0.146.0/schema/v2/ThreadSettingsUpdateParams.json,
+    // "Override the approval policy for subsequent turns"), and claude confirms
+    // asynchronously via `system/status{permissionMode}` (verified:
+    // samples/claude-cli/2.1.227/set_permission_mode/).
+    //
+    // The frame carries the WHOLE snapshot (mode + model together) because the frontend
+    // REPLACES its snapshot on this frame (`useAcpConfigOptions.ts` -> `replaceSnapshot`);
+    // a mode-only frame would wipe the model picker.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn config_changed_projects_confirmed_mode_to_frontend() {
+        use aionui_session::{ModeInfo, ModelInfo};
+        let script = vec![
+            // The catalog must land first: the pump holds no backend Arc (see
+            // `spawn_event_pump`) and so cannot rebuild the option list on its own.
+            env(SessionEvent::CatalogUpdated {
+                models: vec![ModelInfo {
+                    id: "opus".into(),
+                    name: "Opus".into(),
+                    description: None,
+                    reasoning_efforts: Vec::new(),
+                }],
+                modes: vec![
+                    ModeInfo {
+                        id: "default".into(),
+                        name: "Default".into(),
+                        description: None,
+                    },
+                    ModeInfo {
+                        id: "plan".into(),
+                        name: "Plan".into(),
+                        description: None,
+                    },
+                ],
+                slash_commands: Vec::new(),
+            }),
+            // The agent reports it really switched (claude `system/status`, codex
+            // `thread/settings/updated`).
+            env(SessionEvent::ConfigChanged {
+                mode: Some("plan".into()),
+                model: None,
+            }),
+        ];
+        let frames = drain_script(script).await;
+        let config_frames: Vec<&serde_json::Value> = frames
+            .iter()
+            .filter_map(|f| match f {
+                AgentStreamEvent::AcpConfigOption(v) => Some(v),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            config_frames.len() >= 2,
+            "the confirmation must project its own frame (catalog frame + confirmation frame), got {} frame(s)",
+            config_frames.len()
+        );
+        let options = config_frames
+            .last()
+            .unwrap()
+            .get("config_options")
+            .and_then(|v| v.as_array())
+            .expect("config_options array");
+        let mode_opt = options
+            .iter()
+            .find(|o| o.get("category").and_then(|c| c.as_str()) == Some("mode"))
+            .expect("mode category must ride the confirmation frame");
+        assert_eq!(
+            mode_opt.get("current_value").and_then(|v| v.as_str()),
+            Some("plan"),
+            "the picker must highlight the mode the AGENT confirmed, not the optimistic request"
+        );
+        let categories: Vec<&str> = options
+            .iter()
+            .filter_map(|o| o.get("category").and_then(|c| c.as_str()))
+            .collect();
+        assert!(
+            categories.contains(&"model"),
+            "the sibling model category must survive the confirmation frame (frontend REPLACES), got {categories:?}"
         );
     }
 

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -120,6 +120,25 @@ struct SessionRuntime {
     /// Empty until the first catalog lands; a confirmation arriving before that
     /// degrades to "update the override, emit nothing" (REST re-read still corrects).
     last_catalog: std::sync::Mutex<Option<(Vec<ModeInfo>, Vec<ModelInfo>)>>,
+    /// Last per-axis values the BACKEND reported (`capabilities().current_*`), as opposed
+    /// to values the user picked (the `*_override` fields above).
+    ///
+    /// The pump needs these because a pushed frame REPLACES the frontend's whole
+    /// snapshot, so every axis it re-sends overwrites the picker — including axes the
+    /// user never touched, whose override is `None`. Without this the effort level went
+    /// blank on every mode confirmation. Filled by `get_config_options`, which is the one
+    /// place holding both the backend handle and the same fallback order.
+    /// Order is `override → this`, identical to REST.
+    caps_fallback: std::sync::Mutex<CapsFallback>,
+}
+
+/// Backend-reported current values, mirrored out of `capabilities()` so the
+/// backend-Arc-free event pump can apply the same fallback REST applies.
+#[derive(Debug, Clone, Default)]
+struct CapsFallback {
+    mode: Option<String>,
+    model: Option<String>,
+    effort: Option<String>,
 }
 
 impl SessionRuntime {
@@ -173,6 +192,14 @@ impl SessionRuntime {
     }
     fn last_catalog(&self) -> Option<(Vec<ModeInfo>, Vec<ModelInfo>)> {
         self.last_catalog.lock().ok().and_then(|g| g.clone())
+    }
+    fn set_caps_fallback(&self, fallback: CapsFallback) {
+        if let Ok(mut g) = self.caps_fallback.lock() {
+            *g = fallback;
+        }
+    }
+    fn caps_fallback(&self) -> CapsFallback {
+        self.caps_fallback.lock().ok().map(|g| g.clone()).unwrap_or_default()
     }
 
     /// Atomic clean-converge frame: if not already `Finished`, set status ←
@@ -466,6 +493,7 @@ impl SessionAgentTask {
             model_override: std::sync::Mutex::new(None),
             effort_override: std::sync::Mutex::new(None),
             last_catalog: std::sync::Mutex::new(None),
+            caps_fallback: std::sync::Mutex::new(CapsFallback::default()),
         });
         // Subscribe to the backend's event stream HERE (sync), then hand ONLY the
         // stream to the pump — never a backend Arc (see `spawn_event_pump` for why
@@ -810,6 +838,13 @@ impl SessionAgentTask {
         })
     }
 
+    /// The session runtime, for tests that need to drive the pump's projection directly
+    /// (the pump is spawned internally and holds the only other handle).
+    #[cfg(test)]
+    fn runtime_for_test(&self) -> &SessionRuntime {
+        &self.runtime
+    }
+
     /// Config-options (mode + model selects). For each select the optimistic override
     /// (last set_config_option) wins over the capabilities snapshot's current_value —
     /// this is what makes set_config_option's observed re-read succeed (the snapshot
@@ -821,6 +856,16 @@ impl SessionAgentTask {
         // The effort catalog depends on the EFFECTIVE current model (override wins over the
         // snapshot's current_model), resolved before the model option consumes it below.
         let effective_model = self.runtime.model_override().or_else(|| current_model.clone());
+        // Mirror what the BACKEND reports into the runtime so the event pump can apply the
+        // same `override → caps` fallback when it re-projects this snapshot. The pump holds
+        // no backend Arc and would otherwise send `None` for every axis the user never
+        // picked — and since the frontend REPLACES its whole snapshot on that frame, those
+        // pickers would go blank (this is the one path that sees both sides).
+        self.runtime.set_caps_fallback(CapsFallback {
+            mode: current_mode.clone(),
+            model: current_model.clone(),
+            effort: self.backend.capabilities().current_effort,
+        });
         let mut config_options = Vec::new();
         if !modes.is_empty() {
             config_options.push(aionui_api_types::AcpConfigOptionDto {
@@ -2384,6 +2429,10 @@ fn session_event_name(e: &SessionEvent) -> &'static str {
 /// Two callers, deliberately sharing one projection: the catalog arrival itself, and a
 /// later `ConfigChanged` confirming an agent-applied mode/model.
 fn emit_config_options_snapshot(modes: &[ModeInfo], models: &[ModelInfo], runtime: &SessionRuntime) {
+    // Same fallback order REST uses (`override → backend-reported`). Without the second
+    // half, every axis the user never picked would go out as `None` and blank that picker,
+    // because the frontend replaces its whole snapshot on this frame.
+    let fallback = runtime.caps_fallback();
     let mut config_options: Vec<aionui_api_types::AcpConfigOptionDto> = Vec::new();
     if !modes.is_empty() {
         config_options.push(aionui_api_types::AcpConfigOptionDto {
@@ -2393,7 +2442,7 @@ fn emit_config_options_snapshot(modes: &[ModeInfo], models: &[ModelInfo], runtim
             description: None,
             category: Some("mode".into()),
             option_type: "select".into(),
-            current_value: runtime.mode_override(),
+            current_value: runtime.mode_override().or_else(|| fallback.mode.clone()),
             options: modes
                 .iter()
                 .map(|m| aionui_api_types::AcpConfigSelectOptionDto {
@@ -2413,7 +2462,7 @@ fn emit_config_options_snapshot(modes: &[ModeInfo], models: &[ModelInfo], runtim
             description: None,
             category: Some("model".into()),
             option_type: "select".into(),
-            current_value: runtime.model_override(),
+            current_value: runtime.model_override().or_else(|| fallback.model.clone()),
             options: models
                 .iter()
                 .map(|m| aionui_api_types::AcpConfigSelectOptionDto {
@@ -2440,7 +2489,7 @@ fn emit_config_options_snapshot(modes: &[ModeInfo], models: &[ModelInfo], runtim
             description: None,
             category: Some("thought_level".into()),
             option_type: "select".into(),
-            current_value: runtime.effort_override(),
+            current_value: runtime.effort_override().or_else(|| fallback.effort.clone()),
             options: efforts
                 .iter()
                 .map(|e| aionui_api_types::AcpConfigSelectOptionDto {
@@ -8647,6 +8696,129 @@ mod pump_tests {
             mode_opt.current_value.as_deref(),
             Some("plan"),
             "current_value reflects the switch"
+        );
+    }
+
+    /// A backend that advertises an effort axis with a current level, like claude does
+    /// once `system/init` lands. Mirrors `StaticCapsBackend` otherwise.
+    pub(super) struct EffortCapsBackend;
+
+    #[async_trait::async_trait]
+    impl SessionBackend for EffortCapsBackend {
+        async fn dispatch(&self, _c: Command) -> Result<CommandReceipt, BackendError> {
+            Ok(CommandReceipt {
+                accepted: true,
+                admission: Admission::NoTurn,
+                turn_gen: 0,
+            })
+        }
+        fn events(&self) -> BoxStream<'static, SessionEnvelope> {
+            use futures_util::StreamExt as _;
+            futures_util::stream::empty().boxed()
+        }
+        fn capabilities(&self) -> Capabilities {
+            use aionui_session::ModelInfo;
+            Capabilities {
+                available_models: vec![ModelInfo {
+                    id: "opus".into(),
+                    name: "Opus".into(),
+                    description: None,
+                    reasoning_efforts: vec!["low".into(), "high".into()],
+                }],
+                current_model: Some("opus".into()),
+                // The user never picked this explicitly — it is what the CLI reported.
+                current_effort: Some("high".into()),
+                ..StaticCapsBackend.capabilities()
+            }
+        }
+    }
+
+    /// A confirmation frame must not blank out the OTHER axes it re-sends.
+    ///
+    /// The frontend REPLACES its whole snapshot on `acp_config_option`, so every axis in
+    /// that frame overwrites what the picker had. The pump resolves each highlight from
+    /// the runtime's optimistic overrides, which are `None` for an axis the user never
+    /// touched — so re-projecting after a mode confirmation wiped the effort level that
+    /// REST had correctly reported from `capabilities().current_effort`, and the "思考强度"
+    /// picker went blank on every mode switch.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_confirmation_frame_preserves_the_effort_level() {
+        use aionui_session::{ModeInfo, ModelInfo};
+        let backend: Arc<dyn SessionBackend> = Arc::new(EffortCapsBackend);
+        let task = SessionAgentTask::new(
+            AgentType::Acp,
+            "conv-1".into(),
+            "user-1".into(),
+            "/w".into(),
+            backend,
+            None,
+        );
+        // The frontend always reads REST first; that is where the effort level becomes
+        // known, and it is the value the confirmation frame must not contradict.
+        let rest = task.get_config_options().await.unwrap();
+        assert_eq!(
+            rest.config_options
+                .iter()
+                .find(|o| o.category.as_deref() == Some("thought_level"))
+                .and_then(|o| o.current_value.as_deref()),
+            Some("high"),
+            "precondition: REST reports the effort level from capabilities"
+        );
+
+        let mut rx = crate::agent_task::IAgentTask::subscribe(task.as_ref());
+        task.runtime_for_test().set_last_catalog(
+            vec![ModeInfo {
+                id: "plan".into(),
+                name: "Plan".into(),
+                description: None,
+            }],
+            vec![ModelInfo {
+                id: "opus".into(),
+                name: "Opus".into(),
+                description: None,
+                reasoning_efforts: vec!["low".into(), "high".into()],
+            }],
+        );
+        emit_config_options_snapshot(
+            &[ModeInfo {
+                id: "plan".into(),
+                name: "Plan".into(),
+                description: None,
+            }],
+            &[ModelInfo {
+                id: "opus".into(),
+                name: "Opus".into(),
+                description: None,
+                reasoning_efforts: vec!["low".into(), "high".into()],
+            }],
+            task.runtime_for_test(),
+        );
+
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while let Ok(ev) = rx.recv().await {
+                if let AgentStreamEvent::AcpConfigOption(v) = ev {
+                    return Some(v);
+                }
+            }
+            None
+        })
+        .await
+        .ok()
+        .flatten()
+        .expect("a config-option frame");
+
+        let effort = frame
+            .get("config_options")
+            .and_then(|v| v.as_array())
+            .and_then(|a| {
+                a.iter()
+                    .find(|o| o.get("category").and_then(|c| c.as_str()) == Some("thought_level"))
+            })
+            .expect("the effort axis must ride the frame");
+        assert_eq!(
+            effort.get("current_value").and_then(|v| v.as_str()),
+            Some("high"),
+            "the pushed frame must not blank the effort level the user can see"
         );
     }
 

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -866,6 +866,15 @@ impl SessionAgentTask {
             model: current_model.clone(),
             effort: self.backend.capabilities().current_effort,
         });
+        // Same reason, for the catalog itself: a later confirmation has to re-project the
+        // WHOLE snapshot, and the pump can only do that from a catalog it was handed.
+        // `CatalogUpdated` is not a reliable supply — agy emits none at all (its modes are
+        // static), so gating on it left agy's picker stuck on "switching…" with no signal
+        // that could ever clear it. This path always runs first: the frontend reads
+        // config-options on mount, before any switch is possible.
+        if !modes.is_empty() || !models.is_empty() {
+            self.runtime.set_last_catalog(modes.clone(), models.clone());
+        }
         let mut config_options = Vec::new();
         if !modes.is_empty() {
             config_options.push(aionui_api_types::AcpConfigOptionDto {
@@ -8731,6 +8740,86 @@ mod pump_tests {
                 ..StaticCapsBackend.capabilities()
             }
         }
+    }
+
+    /// A backend that never announces a catalog, like agy: its modes are static, so it
+    /// has nothing to push and only ever exposes them through `capabilities()`.
+    pub(super) struct NoCatalogEventBackend;
+
+    #[async_trait::async_trait]
+    impl SessionBackend for NoCatalogEventBackend {
+        async fn dispatch(&self, _c: Command) -> Result<CommandReceipt, BackendError> {
+            Ok(CommandReceipt {
+                accepted: true,
+                admission: Admission::NoTurn,
+                turn_gen: 0,
+            })
+        }
+        fn events(&self) -> BoxStream<'static, SessionEnvelope> {
+            use futures_util::StreamExt as _;
+            futures_util::stream::empty().boxed()
+        }
+        fn capabilities(&self) -> Capabilities {
+            StaticCapsBackend.capabilities()
+        }
+    }
+
+    /// A confirmation must reach the frontend even when the backend never emits
+    /// `CatalogUpdated`.
+    ///
+    /// The pump re-projects the option snapshot from the last catalog it saw, but agy
+    /// emits none at all (its modes are static — zero `CatalogUpdated` in that backend).
+    /// Gating the confirmation on that catalog meant agy's frame was never sent, so the
+    /// picker sat on "switching…" forever with no signal that could ever clear it — the
+    /// user could not tell when, or whether, the switch had landed.
+    ///
+    /// REST is the missing supply: `get_config_options` holds the backend handle and the
+    /// full catalog, and the frontend always reads it before switching.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_backend_without_catalog_events_still_confirms() {
+        let backend: Arc<dyn SessionBackend> = Arc::new(NoCatalogEventBackend);
+        let task = SessionAgentTask::new(
+            AgentType::Acp,
+            "conv-1".into(),
+            "user-1".into(),
+            "/w".into(),
+            backend,
+            None,
+        );
+        // What the frontend does on mount — and the only place this backend's catalog
+        // is ever visible.
+        let _ = task.get_config_options().await.unwrap();
+
+        let mut rx = crate::agent_task::IAgentTask::subscribe(task.as_ref());
+        let runtime = task.runtime_for_test();
+        runtime.set_mode_override("plan".to_string());
+        let Some((modes, models)) = runtime.last_catalog() else {
+            panic!("reading config options must leave the pump a catalog to re-project");
+        };
+        emit_config_options_snapshot(&modes, &models, runtime);
+
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while let Ok(ev) = rx.recv().await {
+                if let AgentStreamEvent::AcpConfigOption(v) = ev {
+                    return Some(v);
+                }
+            }
+            None
+        })
+        .await
+        .ok()
+        .flatten()
+        .expect("a confirmation frame must be emitted");
+
+        let mode = frame
+            .get("config_options")
+            .and_then(|v| v.as_array())
+            .and_then(|a| {
+                a.iter()
+                    .find(|o| o.get("category").and_then(|c| c.as_str()) == Some("mode"))
+            })
+            .expect("the mode axis must ride the frame");
+        assert_eq!(mode.get("current_value").and_then(|v| v.as_str()), Some("plan"));
     }
 
     /// A confirmation frame must not blank out the OTHER axes it re-sends.

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -951,6 +951,14 @@ impl SessionAgentTask {
             .dispatch(cmd)
             .await
             .map_err(|e| AgentError::bad_request(e.to_string()))?;
+        // Where does this switch actually land? Asked of the LIVE backend rather than
+        // assumed, because the answer moves: claude queues a control frame raised
+        // mid-turn but writes an idle one straight out, so the same backend answers
+        // differently second to second. Read right after dispatch, the closest we can get
+        // to the instant the backend decided (the alternative, threading the verdict back
+        // through `CommandReceipt`, would touch ~58 construction sites for one bit).
+        let deferred = option_id == "mode"
+            && self.backend.capabilities().mode_switch_effect == aionui_session::ModeSwitchEffect::NextTurn;
         // Cache the requested value as an optimistic override for mode/model, then
         // re-read the config-options snapshot so the response satisfies the frontend's
         // `hasObservedValue` contract (confirmation == Observed AND the option's
@@ -965,7 +973,17 @@ impl SessionAgentTask {
         // observed re-read — the frontend's `hasObservedValue` requires Observed AND the
         // option's current_value == requested, same as mode/model.
         match option_id {
-            "mode" => self.runtime.set_mode_override(value.to_string()),
+            // Adopt the value as the picker highlight ONLY when it is really in force.
+            // Writing the override for a deferred switch is exactly what made the old
+            // response self-fulfilling — it read straight back and reported Observed
+            // while the agent still enforced the previous mode. Left unwritten, the
+            // snapshot keeps reporting the mode actually governing tool approvals, and
+            // the event pump adopts the new one when the agent confirms it.
+            "mode" => {
+                if !deferred {
+                    self.runtime.set_mode_override(value.to_string());
+                }
+            }
             "model" => self.runtime.set_model_override(value.to_string()),
             "effort" | "reasoning_effort" | "thought_level" => {
                 // Optimistic highlight: claude emits no effort echo, so the streaming
@@ -1004,7 +1022,12 @@ impl SessionAgentTask {
             .and_then(|o| o.current_value.as_deref())
             == Some(value);
         Ok(aionui_api_types::SetConfigOptionResponse {
-            confirmation: if observed {
+            // `deferred` first: a deferred switch deliberately leaves `current_value` on
+            // the old mode, so `observed` is false for the honest reason and must not be
+            // downgraded to the ambiguous `CommandAck`.
+            confirmation: if deferred {
+                aionui_api_types::ConfigOptionConfirmation::PendingNextTurn
+            } else if observed {
                 aionui_api_types::ConfigOptionConfirmation::Observed
             } else {
                 aionui_api_types::ConfigOptionConfirmation::CommandAck
@@ -8624,6 +8647,72 @@ mod pump_tests {
             mode_opt.current_value.as_deref(),
             Some("plan"),
             "current_value reflects the switch"
+        );
+    }
+
+    /// A backend that applies a mode switch only from the NEXT turn, e.g. codex
+    /// ("Override the approval policy for subsequent turns" —
+    /// samples/codex-cli/0.146.0/schema/v2/ThreadSettingsUpdateParams.json), or claude
+    /// while a turn is in flight (the control frame is queued and drained before the
+    /// next prompt).
+    pub(super) struct NextTurnEffectBackend;
+
+    #[async_trait::async_trait]
+    impl SessionBackend for NextTurnEffectBackend {
+        async fn dispatch(&self, _c: Command) -> Result<CommandReceipt, BackendError> {
+            Ok(CommandReceipt {
+                accepted: true,
+                admission: Admission::NoTurn,
+                turn_gen: 0,
+            })
+        }
+        fn events(&self) -> BoxStream<'static, SessionEnvelope> {
+            use futures_util::StreamExt as _;
+            futures_util::stream::empty().boxed()
+        }
+        fn capabilities(&self) -> Capabilities {
+            Capabilities {
+                mode_switch_effect: aionui_session::ModeSwitchEffect::NextTurn,
+                ..StaticCapsBackend.capabilities()
+            }
+        }
+    }
+
+    /// When the backend cannot apply the switch until the next turn, the response must
+    /// SAY so instead of reporting `Observed`.
+    ///
+    /// `Observed` here was self-fulfilling: the task cached the requested value as an
+    /// optimistic override and then read it straight back, so the frontend was told the
+    /// switch had landed while the agent was still enforcing the old mode — the whole
+    /// point of this change. The reported `current_value` must likewise stay on the mode
+    /// actually in force, because that is what the picker shows as "the permission you
+    /// have right now".
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_next_turn_backend_reports_pending_not_observed() {
+        let backend: Arc<dyn SessionBackend> = Arc::new(NextTurnEffectBackend);
+        let task = SessionAgentTask::new(
+            AgentType::Acp,
+            "conv-1".into(),
+            "user-1".into(),
+            "/w".into(),
+            backend,
+            None,
+        );
+        let resp = task.set_config_option("mode", "plan").await.unwrap();
+        assert!(
+            matches!(
+                resp.confirmation,
+                aionui_api_types::ConfigOptionConfirmation::PendingNextTurn
+            ),
+            "a next-turn backend must report PendingNextTurn, got {:?}",
+            resp.confirmation
+        );
+        let opts = resp.config_options.expect("config_options present");
+        let mode_opt = opts.iter().find(|o| o.id == "mode").expect("mode option");
+        assert_eq!(
+            mode_opt.current_value.as_deref(),
+            Some("default"),
+            "current_value must stay on the mode still in force, not jump to the request"
         );
     }
 

--- a/crates/aionui-api-types/src/acp.rs
+++ b/crates/aionui-api-types/src/acp.rs
@@ -95,7 +95,17 @@ pub struct AcpConfigOptionDto {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ConfigOptionConfirmation {
+    /// The agent applied it: the next tool-approval decision already uses the new value.
     Observed,
+    /// Accepted, but the agent applies it only from the NEXT turn — the in-flight turn
+    /// keeps the old value. The frontend must show the option as pending rather than
+    /// switched, and must NOT treat this as a failure.
+    ///
+    /// Exists because reporting `Observed` here was self-fulfilling: the task caches the
+    /// requested value as an optimistic override and reads it straight back, so the user
+    /// was told a switch had landed while the agent still enforced the old mode.
+    PendingNextTurn,
+    /// The command was accepted but no confirmation could be established either way.
     CommandAck,
 }
 

--- a/crates/aionui-api-types/src/acp.rs
+++ b/crates/aionui-api-types/src/acp.rs
@@ -353,4 +353,22 @@ mod tests {
         let req: ProbeModelRequest = serde_json::from_value(json).unwrap();
         assert_eq!(req.backend, "claude");
     }
+
+    /// The confirmation wire strings are a cross-repo contract: AionUi's
+    /// `AcpConfigOptionConfirmation` matches on these literals, and its picker branches on
+    /// them to decide between "switched", "pending" and "failed". A rename here that looked
+    /// harmless in Rust would silently push the frontend into its error path, so pin the
+    /// exact bytes rather than trusting the derive.
+    #[test]
+    fn config_option_confirmation_wire_strings_are_stable() {
+        for (variant, expected) in [
+            (ConfigOptionConfirmation::Observed, "observed"),
+            (ConfigOptionConfirmation::PendingNextTurn, "pending_next_turn"),
+            (ConfigOptionConfirmation::CommandAck, "command_ack"),
+        ] {
+            assert_eq!(serde_json::to_value(variant).unwrap(), json!(expected));
+            let round_tripped: ConfigOptionConfirmation = serde_json::from_value(json!(expected)).unwrap();
+            assert_eq!(round_tripped, variant);
+        }
+    }
 }

--- a/crates/aionui-conversation/src/background_stream.rs
+++ b/crates/aionui-conversation/src/background_stream.rs
@@ -153,6 +153,14 @@ impl BackgroundStreamWatcher {
             }
             match &ev {
                 AgentStreamEvent::WorkflowProgress(data) => self.handle_card_refresh(data).await,
+                // Config snapshots / mode confirmations arriving BETWEEN turns. These are
+                // exactly the frames that carry "the switch actually took effect" for the
+                // backends that apply one only from the next turn, plus an agent's own
+                // autonomous mode change — and by then no relay exists to carry them.
+                // Dropping them left the picker showing a mode the agent was not in.
+                AgentStreamEvent::AcpConfigOption(_) | AgentStreamEvent::AcpModeInfo(_) => {
+                    self.forward_out_of_turn_frame(&ev)
+                }
                 ev_ref if Self::is_orphan_turn_content(ev_ref) => {
                     self.run_orphan_turn(ev.clone(), &mut rx).await;
                 }
@@ -239,6 +247,36 @@ impl BackgroundStreamWatcher {
                 }),
             ));
         }
+    }
+
+    /// Forward an out-of-turn frame to the frontend, projected EXACTLY as the per-turn
+    /// relay would project it (`type`/`data` read off the event's own serde tag, keys
+    /// normalized to snake_case — see `StreamRelay::forward_to_websocket_with_msg_id`),
+    /// so the frontend cannot tell which path delivered it.
+    ///
+    /// `msg_id`/`turn_id` are empty: a config snapshot belongs to no message and no
+    /// turn — that is precisely why it has no relay to ride.
+    fn forward_out_of_turn_frame(&self, ev: &AgentStreamEvent) {
+        let mut event_data = match serde_json::to_value(ev) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(error = %ErrorChain(&e), "background stream: out-of-turn frame serialize failed");
+                return;
+            }
+        };
+        normalize_keys_to_snake_case(&mut event_data);
+        self.broadcaster.broadcast(aionui_api_types::WebSocketMessage::new(
+            "message.stream",
+            json!({
+                "conversation_id": self.conversation_id,
+                "user_id": self.user_id,
+                "msg_id": "",
+                "turn_id": "",
+                "type": event_data.get("type").cloned().unwrap_or(json!("unknown")),
+                "data": event_data.get("data").cloned().unwrap_or(json!({})),
+                "hidden": false,
+            }),
+        ));
     }
 
     /// Run a CLI-initiated turn through a REGULAR relay so it gets everything a
@@ -755,5 +793,83 @@ mod tests {
             }
         }
         assert!(saw_name_updated, "nameUpdated must be broadcast");
+    }
+
+    /// A config-options snapshot arriving BETWEEN turns must still reach the frontend.
+    ///
+    /// This is exactly when a mode confirmation lands for the backends that apply a
+    /// switch only from the next turn (codex: "for subsequent turns", verified in
+    /// samples/codex-cli/0.146.0/schema/v2/ThreadSettingsUpdateParams.json), and also
+    /// when an agent changes mode on its own (claude's autonomous plan-exit emits a
+    /// `system/status{permissionMode}` while idle). The per-turn relay is gone by then,
+    /// so the watcher is the only path left — dropping the frame here left the picker
+    /// showing a mode the agent was no longer in, with no way to notice.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn between_turns_config_option_snapshot_is_forwarded() {
+        let rig = rig().await;
+        let mut ws = rig.bus.subscribe();
+        rig.tx
+            .send(AgentStreamEvent::AcpConfigOption(serde_json::json!({
+                "config_options": [{
+                    "id": "mode",
+                    "category": "mode",
+                    "type": "select",
+                    "current_value": "plan",
+                    "options": [{"value": "plan"}, {"value": "default"}]
+                }]
+            })))
+            .unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        let mut forwarded: Option<aionui_api_types::WebSocketMessage<serde_json::Value>> = None;
+        while std::time::Instant::now() < deadline && forwarded.is_none() {
+            while let Ok(msg) = ws.try_recv() {
+                if msg.name == "message.stream" && msg.data["type"] == "acp_config_option" {
+                    forwarded = Some(msg);
+                    break;
+                }
+            }
+            if forwarded.is_none() {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        }
+        let msg = forwarded.expect("an out-of-turn acp_config_option must be forwarded to the frontend");
+        assert_eq!(msg.data["conversation_id"], "conv-1");
+        assert_eq!(
+            msg.data["data"]["config_options"][0]["current_value"], "plan",
+            "the confirmed value must survive the hop"
+        );
+    }
+
+    /// The ACP analogue of the test above. An ACP agent reports an applied mode via
+    /// `current_mode_update`, which translates to `AcpModeInfo` — and per the ACP schema
+    /// the agent may change mode on its own ("Agents may also change modes autonomously
+    /// and notify the client via `current_mode_update`",
+    /// agent-client-protocol-schema-1.5.0/src/v1/agent.rs), i.e. with no turn in flight.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn between_turns_acp_mode_info_is_forwarded() {
+        let rig = rig().await;
+        let mut ws = rig.bus.subscribe();
+        rig.tx
+            .send(AgentStreamEvent::AcpModeInfo(serde_json::json!({
+                "current_mode_id": "plan"
+            })))
+            .unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        let mut forwarded: Option<aionui_api_types::WebSocketMessage<serde_json::Value>> = None;
+        while std::time::Instant::now() < deadline && forwarded.is_none() {
+            while let Ok(msg) = ws.try_recv() {
+                if msg.name == "message.stream" && msg.data["type"] == "acp_mode_info" {
+                    forwarded = Some(msg);
+                    break;
+                }
+            }
+            if forwarded.is_none() {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        }
+        let msg = forwarded.expect("an out-of-turn acp_mode_info must be forwarded to the frontend");
+        assert_eq!(msg.data["data"]["current_mode_id"], "plan");
     }
 }

--- a/crates/aionui-conversation/src/service_ops.rs
+++ b/crates/aionui-conversation/src/service_ops.rs
@@ -76,12 +76,19 @@ impl ConversationService {
 
         // Mirror runtime model/mode/thought-level switches into the persisted assistant
         // snapshot + preference so the next conversation seeded from this
-        // assistant in `auto` mode reflects the latest pick. We only act on
-        // observed confirmations — `command_ack` means the agent merely
-        // accepted the request, not that the value is in effect. Persistence
-        // failures are logged but do not roll back the
-        // user-facing config switch.
-        if response.confirmation == ConfigOptionConfirmation::Observed {
+        // assistant in `auto` mode reflects the latest pick.
+        //
+        // `PendingNextTurn` counts: it means the agent WILL apply the value from the next
+        // turn, so it is the user's settled choice, merely not in force yet. codex reports
+        // every mode switch that way (its schema documents `permissions` as "for
+        // subsequent turns"), so excluding it would strip preference memory from every
+        // codex conversation. `CommandAck` still does NOT count — it means nothing could
+        // be established either way. Persistence failures are logged but do not roll back
+        // the user-facing config switch.
+        if matches!(
+            response.confirmation,
+            ConfigOptionConfirmation::Observed | ConfigOptionConfirmation::PendingNextTurn
+        ) {
             let category = response
                 .config_options
                 .as_ref()

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -4423,6 +4423,86 @@ async fn command_ack_does_not_persist_assistant_preference_in_core_service() {
     assert!(refreshed.extra.get("current_model_id").is_none());
 }
 
+/// A deferred switch is still the user's choice and must be remembered.
+///
+/// `PendingNextTurn` says "the agent applies this from the next turn", not "the request
+/// was refused" -- unlike `CommandAck`, which says nothing landed either way. Gating the
+/// preference write-back on `Observed` alone would silently strip preference memory from
+/// every codex conversation, since codex reports a mode switch as next-turn
+/// unconditionally (its schema documents `permissions` as being "for subsequent turns").
+#[tokio::test]
+async fn pending_next_turn_still_persists_the_users_choice() {
+    let task_mgr = Arc::new(MockTaskManager::new());
+    let (svc, _broadcaster, repo, definition_repo, overlay_repo, preference_repo) =
+        make_service_with_mock_task_manager_and_assistant_support(task_mgr.clone()).await;
+
+    upsert_test_assistant_definition(
+        &definition_repo,
+        "asstdef_acp_auto",
+        "assistant-acp-auto",
+        "codex",
+        "auto",
+        "auto",
+    )
+    .await;
+    overlay_repo
+        .upsert(&UpsertAssistantOverlayParams {
+            assistant_definition_id: "asstdef_acp_auto",
+            enabled: true,
+            sort_order: 0,
+            agent_id_override: None,
+            last_used_at: None,
+        })
+        .await
+        .unwrap();
+
+    let conv = create_assistant_backed_conversation(&svc, "user_1", Some("acp"), "codex", "assistant-acp-auto").await;
+    let agent = Arc::new(
+        MockAgent::new(&conv.id).with_set_config_option_response(SetConfigOptionResponse {
+            confirmation: ConfigOptionConfirmation::PendingNextTurn,
+            config_options: Some(vec![AcpConfigOptionDto {
+                id: "mode".to_owned(),
+                name: None,
+                label: None,
+                description: None,
+                category: Some("mode".to_owned()),
+                option_type: "select".to_owned(),
+                // Deliberately still the OLD mode: a deferred switch reports what is in
+                // force, not what was requested.
+                current_value: Some("default".to_owned()),
+                options: vec![],
+            }]),
+        }),
+    );
+    task_mgr.insert_agent(&conv.id, AgentInstance::Mock(agent));
+
+    let result = svc
+        .set_config_option(
+            "user_1",
+            &conv.id,
+            "mode",
+            SetConfigOptionRequest {
+                value: "plan".to_owned(),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.confirmation, ConfigOptionConfirmation::PendingNextTurn);
+
+    let pref = preference_repo
+        .get_for_user("user_1", "asstdef_acp_auto")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        pref.last_permission_value.as_deref(),
+        Some("plan"),
+        "a deferred switch is still the user's settled choice and must be remembered"
+    );
+    let snapshot = repo.get_assistant_snapshot("user_1", &conv.id).await.unwrap().unwrap();
+    assert_eq!(snapshot.resolved_permission_value.as_deref(), Some("plan"));
+}
+
 #[tokio::test]
 async fn set_config_option_persists_runtime_model_into_assistant_preference_when_observed() {
     let task_mgr = Arc::new(MockTaskManager::new());

--- a/crates/aionui-session/src/adapter/claude.rs
+++ b/crates/aionui-session/src/adapter/claude.rs
@@ -1171,6 +1171,12 @@ impl BackendAdapter for ClaudeAdapter {
         // CLI-static (filled by ClaudeConnection).
         Capabilities {
             tier: CapabilityTier::Parsed,
+            // Static default only. The live backend OVERRIDES this per call, because
+            // claude's answer depends on what it is doing: a `set_permission_mode` written
+            // while idle takes effect at once (verified:
+            // samples/claude-cli/2.1.227/set_permission_mode/), but one raised mid-turn is
+            // queued by `write_or_queue_control` and drained before the NEXT prompt.
+            mode_switch_effect: crate::capability::ModeSwitchEffect::Immediate,
             emits: SignalSet {
                 heartbeat: true,
                 tool_lifecycle: true,

--- a/crates/aionui-session/src/backend/acp_conn.rs
+++ b/crates/aionui-session/src/backend/acp_conn.rs
@@ -236,6 +236,14 @@ fn build_mcp_servers(servers: &[crate::backend::McpServerSpec]) -> Vec<Value> {
 pub fn acp_capabilities() -> Capabilities {
     Capabilities {
         tier: CapabilityTier::Parsed,
+        // ACP's schema explicitly allows `session/set_mode` "at any time during a session,
+        // whether the Agent is idle or actively generating a response"
+        // (agent-client-protocol-schema-1.5.0/src/v1/agent.rs). It says nothing about WHEN
+        // the new mode starts governing, and the `SetSessionModeResponse` is empty, so
+        // there is nothing to read either way. This path is not the one the ACP manager
+        // uses for confirmation — that one waits for an observed value — so `Immediate`
+        // here only reflects "the request is not deferred by us".
+        mode_switch_effect: crate::capability::ModeSwitchEffect::Immediate,
         emits: SignalSet {
             // ACP has no liveness heartbeat notification; the turn terminal is the
             // prompt response (no idle-timeout in AionCore anyway, post-007).

--- a/crates/aionui-session/src/backend/antigravity/argv.rs
+++ b/crates/aionui-session/src/backend/antigravity/argv.rs
@@ -2,8 +2,21 @@
 
 /// AionUi's sentinel mode id meaning "run without approval prompts".
 ///
-/// Not one of agy's modes (default / accept-edits / plan) and never sent to it.
+/// Not one of agy's modes and never sent to it; answered by removing the approval hook.
 pub(crate) const FULL_AUTO_SENTINEL: &str = "yolo";
+
+/// AionUi's mode id meaning "ask before sensitive things" — its counterpart to
+/// [`FULL_AUTO_SENTINEL`], answered by KEEPING the approval hook installed.
+///
+/// Also not an agy value: `agy --help` lists exactly two (verified:
+/// samples/antigravity-cli/1.1.8/agy_--help.txt:12 — "Set the agent execution mode for
+/// this session (accept-edits, plan)"). Passing `--mode default` makes agy print
+/// `warning: unrecognized --mode value "default" (valid: accept-edits, plan)` and drop
+/// the flag, leaving the session on whatever agy defaults to while the UI reports the
+/// switch as applied.
+///
+/// Omitting the flag is the correct translation anyway: agy's own default IS this mode.
+pub(crate) const HOST_DEFAULT_MODE: &str = "default";
 
 /// Everything one `agy` invocation needs. There is deliberately no `effort`
 /// field: agy's model ids already carry the effort suffix (see `model`).
@@ -19,7 +32,8 @@ pub(crate) struct ArgvInput {
     /// agy silently ignores anything else and falls back to its default model
     /// without reporting an error.
     pub model: Option<String>,
-    /// `default` | `accept-edits` | `plan`.
+    /// An AionUi mode id, not necessarily an agy one. `accept-edits` / `plan` reach agy;
+    /// `yolo` and `default` are host-side and filtered out (see the constants above).
     pub mode: Option<String>,
 }
 
@@ -73,14 +87,15 @@ pub(crate) fn build_argv(input: &ArgvInput) -> Vec<String> {
     }
     // No `--effort`: effort lives inside the model id, and a stripped id is
     // silently ignored by agy.
-    // `yolo` is AionUi's sentinel for "no approval prompts", not one of agy's
-    // modes (default / accept-edits / plan). agy tolerates unknown values
-    // silently, so forwarding it would look fine and quietly leave the session
-    // on whatever mode agy defaults to.
+    // agy takes exactly two values here: `accept-edits` and `plan`. AionUi's other two
+    // modes are host-side concepts expressed through the approval hook — `yolo` by
+    // removing it, `default` by keeping it — and agy rejects both by name, warning and
+    // discarding the flag. Sending either would look fine (exit 0) while silently
+    // leaving the session on agy's default. See the two constants above.
     let mode = input
         .mode
         .as_deref()
-        .filter(|m| !m.eq_ignore_ascii_case(FULL_AUTO_SENTINEL));
+        .filter(|m| !m.eq_ignore_ascii_case(FULL_AUTO_SENTINEL) && !m.eq_ignore_ascii_case(HOST_DEFAULT_MODE));
     let mode = mode.map(str::to_owned);
     for (flag, value) in [("--model", &input.model), ("--mode", &mode)] {
         if let Some(v) = non_blank(value) {
@@ -150,10 +165,8 @@ mod tests {
 
     #[test]
     fn the_full_auto_sentinel_is_never_sent_as_agys_mode() {
-        // `yolo` is AionUi's marker, not one of agy's modes. agy accepts unknown
-        // --mode values silently (verified: `--mode default` exits 0 even though
-        // --help lists only accept-edits/plan), so forwarding it would look fine
-        // and quietly leave the session on agy's default.
+        // `yolo` is AionUi's marker, not one of agy's modes. It is answered by NOT
+        // installing the approval hook, never by a `--mode` value.
         let mut i = base();
         i.mode = Some("yolo".to_owned());
         let a = build_argv(&i);
@@ -161,9 +174,41 @@ mod tests {
         assert!(!a.iter().any(|x| x == "yolo"), "argv={a:?}");
     }
 
+    /// `default` is AionUi's "ask before sensitive things" mode, NOT an agy value.
+    ///
+    /// agy takes only `accept-edits` and `plan` (verified:
+    /// samples/antigravity-cli/1.1.8/agy_--help.txt:12 — "Set the agent execution mode
+    /// for this session (accept-edits, plan)"). Sending `--mode default` makes agy print
+    /// `warning: unrecognized --mode value "default" (valid: accept-edits, plan)` and
+    /// DROP the flag, so the session silently stays on whatever agy defaults to while the
+    /// UI reports the switch as done.
+    ///
+    /// An earlier note claimed agy "accepts unknown --mode values silently (exits 0)".
+    /// Exit 0 is not acceptance: the observed run warns and discards the argument.
+    ///
+    /// Like `yolo`, this mode is expressed by the host — `yolo` by removing the approval
+    /// hook, `default` by keeping it — so neither belongs on agy's command line. Omitting
+    /// the flag is also exactly right semantically: agy's own default IS "default".
     #[test]
+    fn the_default_mode_is_host_side_and_never_sent_to_agy() {
+        let mut i = base();
+        i.mode = Some("default".to_owned());
+        let a = build_argv(&i);
+        assert!(
+            !a.contains(&"--mode".to_string()),
+            "agy rejects `--mode default`; the flag must be omitted, argv={a:?}"
+        );
+        assert!(!a.iter().any(|x| x == "default"), "argv={a:?}");
+    }
+
+    #[test]
+    /// Only the two values agy actually documents are forwarded.
+    ///
+    /// `default` used to be in this list, which is what put an unrecognized value on
+    /// agy's command line; it is host-side and covered by
+    /// `the_default_mode_is_host_side_and_never_sent_to_agy`.
     fn agys_real_modes_are_forwarded() {
-        for mode in ["default", "accept-edits", "plan"] {
+        for mode in ["accept-edits", "plan"] {
             let mut i = base();
             i.mode = Some(mode.to_owned());
             let a = build_argv(&i);

--- a/crates/aionui-session/src/backend/antigravity/conn.rs
+++ b/crates/aionui-session/src/backend/antigravity/conn.rs
@@ -535,6 +535,34 @@ impl AntigravitySessionBackend {
             .or_else(|| self.config.mode.clone())
     }
 
+    /// Mark the running turn as finished and release any switch it could not hear.
+    ///
+    /// The turn ending is what makes a deferred switch real: that agy process is gone, so
+    /// nothing is running under the old mode any more and the next spawn necessarily
+    /// reads the new one. Confirming here rather than at the next spawn matters because
+    /// the next spawn needs the user to send another message — until then the picker
+    /// would sit on "switching…" with no way to tell whether it had landed.
+    ///
+    /// `take()` makes this idempotent: a later turn boundary finds nothing to release.
+    async fn settle_turn_end(&self) {
+        self.in_flight.store(false, Ordering::SeqCst);
+        if let Some(mode) = self.deferred_mode_confirm.lock().await.take() {
+            let turn_gen = self.turn_gen.load(Ordering::SeqCst);
+            tracing::info!(
+                session_id = %self.session_id,
+                mode = %mode,
+                "antigravity: turn ended — releasing the held mode confirmation"
+            );
+            self.emit(
+                turn_gen,
+                SessionEvent::ConfigChanged {
+                    mode: Some(mode),
+                    model: None,
+                },
+            );
+        }
+    }
+
     /// Whether a mode switch made RIGHT NOW would govern the turn already running.
     ///
     /// Between turns: yes — the next spawn reads the new mode from argv either way.
@@ -622,20 +650,6 @@ impl AntigravitySessionBackend {
         // turn never calls back and only the next spawn can pick one up.
         self.turn_started_hooked.store(!self.is_full_auto(), Ordering::SeqCst);
         self.in_flight.store(true, Ordering::SeqCst);
-        // A switch deferred during the previous turn becomes real exactly here: this argv
-        // carries it. Confirm it now, which both clears the frontend's pending marker and
-        // persists `current_mode_id` (ConfigChanged is the only trigger for that).
-        if let Some(mode) = self.deferred_mode_confirm.lock().await.take() {
-            let turn_gen = self.turn_gen.load(Ordering::SeqCst);
-            self.emit(
-                turn_gen,
-                SessionEvent::ConfigChanged {
-                    mode: Some(mode),
-                    model: None,
-                },
-            );
-        }
-
         self.spawn_reader(Arc::clone(&proc), turn_gen);
         Ok(turn_gen)
     }
@@ -778,7 +792,7 @@ impl AntigravitySessionBackend {
                 // Session dropped; nothing left to run for.
                 return;
             };
-            backend.in_flight.store(false, Ordering::SeqCst);
+            backend.settle_turn_end().await;
             let next = backend.queued.lock().await.pop_front();
             if let Some(content) = next
                 && let Err(e) = backend.start_turn(content).await
@@ -1477,6 +1491,77 @@ mod tests {
         assert!(
             confirmed.is_err() || confirmed.as_ref().unwrap().is_none(),
             "a switch agy cannot see yet must not be confirmed, got {confirmed:?}"
+        );
+    }
+
+    /// A deferred switch confirms as soon as the turn that could not hear it ENDS.
+    ///
+    /// Waiting for the next spawn was too conservative: once that turn is over its agy
+    /// process is gone, so nothing is running under the old mode any more and the next
+    /// spawn necessarily reads the new one. Holding "switching…" until the user happens
+    /// to send another message left the picker stuck with no way to tell whether the
+    /// switch had landed — and made a second switch appear to work instantly while the
+    /// first still looked pending.
+    #[tokio::test]
+    async fn a_deferred_switch_confirms_when_the_turn_ends() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = backend_with_hook_body(dir.path(), Some("yolo"), Some("{\"stub\":true}"));
+        b.in_flight.store(true, Ordering::SeqCst);
+        b.turn_started_hooked.store(false, Ordering::SeqCst);
+        let mut events = b.events();
+
+        b.dispatch(Command::SetMode {
+            mode: "default".to_owned(),
+        })
+        .await
+        .unwrap();
+
+        b.settle_turn_end().await;
+
+        let confirmed = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            use futures_util::StreamExt as _;
+            while let Some(env) = events.next().await {
+                if let SessionEvent::ConfigChanged { mode, .. } = env.event {
+                    return mode;
+                }
+            }
+            None
+        })
+        .await
+        .expect("the turn ending must release the held confirmation");
+        assert_eq!(confirmed.as_deref(), Some("default"));
+    }
+
+    /// ...and only once: a second turn boundary must not re-announce it.
+    #[tokio::test]
+    async fn a_released_confirmation_is_not_repeated() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = backend_with_hook_body(dir.path(), Some("yolo"), Some("{\"stub\":true}"));
+        b.in_flight.store(true, Ordering::SeqCst);
+        b.turn_started_hooked.store(false, Ordering::SeqCst);
+
+        b.dispatch(Command::SetMode {
+            mode: "default".to_owned(),
+        })
+        .await
+        .unwrap();
+        b.settle_turn_end().await;
+
+        let mut events = b.events();
+        b.settle_turn_end().await;
+        let again = tokio::time::timeout(std::time::Duration::from_millis(300), async {
+            use futures_util::StreamExt as _;
+            while let Some(env) = events.next().await {
+                if let SessionEvent::ConfigChanged { .. } = env.event {
+                    return true;
+                }
+            }
+            false
+        })
+        .await;
+        assert!(
+            again.is_err() || !again.unwrap(),
+            "the held confirmation is released once, not on every turn boundary"
         );
     }
 

--- a/crates/aionui-session/src/backend/antigravity/conn.rs
+++ b/crates/aionui-session/src/backend/antigravity/conn.rs
@@ -832,10 +832,28 @@ impl SessionBackend for AntigravitySessionBackend {
                 // in-process check never runs — the user would think they had
                 // restored approval prompts while everything still ran freely.
                 self.sync_permission_hook();
+                let turn_gen = self.turn_gen.load(Ordering::SeqCst);
+                // Confirm the switch. Unlike the other backends this signal originates
+                // here rather than on the wire — agy runs one process per turn and there
+                // is nothing to reconfigure mid-flight — but it is not self-fulfilling:
+                // the permission decision is re-read per tool call (`is_full_auto` in
+                // `request_external_permission`) and the hook file has just been synced,
+                // so the host-side gate really has changed.
+                //
+                // It is also the ONLY trigger that persists `current_mode_id` (see
+                // session_agent's `persist_side_effects`); without it a task rebuild
+                // reverted the user to the stale create-time mode.
+                self.emit(
+                    turn_gen,
+                    SessionEvent::ConfigChanged {
+                        mode: Some(mode.clone()),
+                        model: None,
+                    },
+                );
                 Ok(CommandReceipt {
                     accepted: true,
                     admission: Admission::NoTurn,
-                    turn_gen: self.turn_gen.load(Ordering::SeqCst),
+                    turn_gen,
                 })
             }
             Command::SetModel { .. } => Ok(CommandReceipt {
@@ -1296,6 +1314,50 @@ mod tests {
         .unwrap();
 
         assert!(!hook.exists(), "full auto must not leave a hook agy would call");
+    }
+
+    /// A runtime mode switch must emit `ConfigChanged`.
+    ///
+    /// Two things ride on it, and both were broken by its absence:
+    ///   - PERSISTENCE. `ConfigChanged` is the ONLY trigger that writes
+    ///     `current_mode_id` (session_agent's `persist_side_effects`), so without it
+    ///     the switch lived only in this backend instance's `mode_override` and a task
+    ///     rebuild silently reverted the user to the stale create-time mode.
+    ///   - CONFIRMATION. It is what tells the frontend the switch really landed,
+    ///     instead of the self-fulfilling `Observed` the task layer synthesizes.
+    ///
+    /// Honest for agy specifically: the permission decision is re-read per tool call
+    /// (`is_full_auto` in `request_external_permission`), so once the override is
+    /// recorded and the hook file synced, the host-side gate HAS changed — regardless
+    /// of the already-spawned process's `--mode` flag.
+    #[tokio::test]
+    async fn a_runtime_mode_switch_emits_config_changed() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = backend_with_hook_body(dir.path(), Some("default"), Some("{}"));
+        let mut events = b.events();
+
+        b.dispatch(Command::SetMode {
+            mode: "yolo".to_owned(),
+        })
+        .await
+        .unwrap();
+
+        let confirmed = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            use futures_util::StreamExt as _;
+            while let Some(env) = events.next().await {
+                if let SessionEvent::ConfigChanged { mode, .. } = env.event {
+                    return mode;
+                }
+            }
+            None
+        })
+        .await
+        .expect("a mode switch must emit ConfigChanged within 2s");
+        assert_eq!(
+            confirmed.as_deref(),
+            Some("yolo"),
+            "the confirmation must carry the mode that is now in force"
+        );
     }
 
     #[test]

--- a/crates/aionui-session/src/backend/antigravity/conn.rs
+++ b/crates/aionui-session/src/backend/antigravity/conn.rs
@@ -888,6 +888,20 @@ impl SessionBackend for AntigravitySessionBackend {
             current_model: self.config.model.clone(),
             current_mode: self.config.mode.clone(),
             slash_commands: self.slash_commands.clone(),
+            // agy runs one process per turn and `--mode` is a spawn flag, so a turn
+            // already running keeps the mode it was spawned with; the switch reaches agy
+            // only when the next turn spawns.
+            //
+            // Reported as NextTurn even though the host-side gate does move at once (the
+            // hook bridge re-reads `is_full_auto` per tool call). That is the safe
+            // direction to be imprecise in: claiming "in force" while the tightening has
+            // not reached agy would be the dangerous lie, whereas under-promising a
+            // loosening costs the user nothing.
+            mode_switch_effect: if self.in_flight.load(Ordering::SeqCst) {
+                crate::capability::ModeSwitchEffect::NextTurn
+            } else {
+                crate::capability::ModeSwitchEffect::Immediate
+            },
             ..antigravity_capabilities()
         }
     }

--- a/crates/aionui-session/src/backend/antigravity/conn.rs
+++ b/crates/aionui-session/src/backend/antigravity/conn.rs
@@ -251,6 +251,8 @@ impl BackendConnection for AntigravityConnection {
             permission_seq: AtomicU64::new(0),
             weak_self: std::sync::OnceLock::new(),
             in_flight: Arc::new(AtomicBool::new(false)),
+            turn_started_hooked: Arc::new(AtomicBool::new(false)),
+            deferred_mode_confirm: Arc::new(Mutex::new(None)),
             queued: Arc::new(Mutex::new(VecDeque::new())),
         });
 
@@ -305,6 +307,22 @@ pub struct AntigravitySessionBackend {
     /// True while a turn's process is alive. agy has no way to accept input
     /// mid-turn, so a Send arriving now has to wait for the next process.
     in_flight: Arc<AtomicBool>,
+    /// Whether the CURRENTLY RUNNING turn was spawned with the approval hook on disk.
+    ///
+    /// This is what decides whether a mid-turn mode switch can reach agy at all. The
+    /// permission gate lives on the host — agy calls back per tool use and
+    /// `request_external_permission` re-reads the mode each time — so a hooked turn
+    /// honours a switch immediately, in both directions. A turn spawned in FULL AUTO has
+    /// no hook, never calls back, and therefore cannot learn about a tightening until the
+    /// next process starts; `sync_permission_hook` writes the file back, but nothing
+    /// proves a running agy re-reads it.
+    ///
+    /// Recorded at spawn rather than derived from the current mode, because the current
+    /// mode is exactly what the user just changed.
+    turn_started_hooked: Arc<AtomicBool>,
+    /// A mode switch accepted while the running turn could not hear it. Confirmed at the
+    /// next spawn, where argv finally carries it.
+    deferred_mode_confirm: Arc<Mutex<Option<String>>>,
     /// Skills provisioned into this workspace, exposed as slash commands. agy
     /// has no command-list interface, so this is read off the skill files.
     slash_commands: Vec<SlashCommandInfo>,
@@ -517,6 +535,17 @@ impl AntigravitySessionBackend {
             .or_else(|| self.config.mode.clone())
     }
 
+    /// Whether a mode switch made RIGHT NOW would govern the turn already running.
+    ///
+    /// Between turns: yes — the next spawn reads the new mode from argv either way.
+    /// During a hooked turn: yes — agy calls back per tool use and the host gate re-reads
+    /// the mode, so the switch governs the very next tool, in both directions.
+    /// During a full-auto turn: no — that process was spawned without a hook, never calls
+    /// back, and cannot be told; only the next spawn picks it up.
+    fn switch_reaches_current_turn(&self) -> bool {
+        !self.in_flight.load(Ordering::SeqCst) || self.turn_started_hooked.load(Ordering::SeqCst)
+    }
+
     /// Whether this session currently runs without approval prompts.
     fn is_full_auto(&self) -> bool {
         self.effective_mode()
@@ -588,7 +617,24 @@ impl AntigravitySessionBackend {
             .await
             .map_err(|e| BackendError::Transport(format!("spawn agy: {e}")))?;
         *self.current.lock().await = Some(Arc::clone(&proc));
+        // Freeze whether THIS turn can hear about a later mode switch. A hooked turn
+        // calls back per tool use, so the host gate applies a switch at once; a full-auto
+        // turn never calls back and only the next spawn can pick one up.
+        self.turn_started_hooked.store(!self.is_full_auto(), Ordering::SeqCst);
         self.in_flight.store(true, Ordering::SeqCst);
+        // A switch deferred during the previous turn becomes real exactly here: this argv
+        // carries it. Confirm it now, which both clears the frontend's pending marker and
+        // persists `current_mode_id` (ConfigChanged is the only trigger for that).
+        if let Some(mode) = self.deferred_mode_confirm.lock().await.take() {
+            let turn_gen = self.turn_gen.load(Ordering::SeqCst);
+            self.emit(
+                turn_gen,
+                SessionEvent::ConfigChanged {
+                    mode: Some(mode),
+                    model: None,
+                },
+            );
+        }
 
         self.spawn_reader(Arc::clone(&proc), turn_gen);
         Ok(turn_gen)
@@ -843,13 +889,26 @@ impl SessionBackend for AntigravitySessionBackend {
                 // It is also the ONLY trigger that persists `current_mode_id` (see
                 // session_agent's `persist_side_effects`); without it a task rebuild
                 // reverted the user to the stale create-time mode.
-                self.emit(
-                    turn_gen,
-                    SessionEvent::ConfigChanged {
-                        mode: Some(mode.clone()),
-                        model: None,
-                    },
-                );
+                // Confirm ONLY when the switch really reaches the running turn.
+                //
+                // `ConfigChanged` is what clears the frontend's pending marker, so
+                // emitting it for a deferred switch would flip the picker to "in force"
+                // for precisely the case that has not taken effect — telling the user
+                // their tightening had landed while the agent kept running unattended.
+                // The deferred case confirms itself when the next turn spawns, which is
+                // when agy actually reads the mode off argv.
+                if !self.switch_reaches_current_turn() {
+                    *self.deferred_mode_confirm.lock().await = Some(mode.clone());
+                }
+                if self.switch_reaches_current_turn() {
+                    self.emit(
+                        turn_gen,
+                        SessionEvent::ConfigChanged {
+                            mode: Some(mode.clone()),
+                            model: None,
+                        },
+                    );
+                }
                 Ok(CommandReceipt {
                     accepted: true,
                     admission: Admission::NoTurn,
@@ -897,10 +956,10 @@ impl SessionBackend for AntigravitySessionBackend {
             // direction to be imprecise in: claiming "in force" while the tightening has
             // not reached agy would be the dangerous lie, whereas under-promising a
             // loosening costs the user nothing.
-            mode_switch_effect: if self.in_flight.load(Ordering::SeqCst) {
-                crate::capability::ModeSwitchEffect::NextTurn
-            } else {
+            mode_switch_effect: if self.switch_reaches_current_turn() {
                 crate::capability::ModeSwitchEffect::Immediate
+            } else {
+                crate::capability::ModeSwitchEffect::NextTurn
             },
             ..antigravity_capabilities()
         }
@@ -1134,6 +1193,8 @@ mod tests {
             permission_seq: AtomicU64::new(0),
             weak_self: std::sync::OnceLock::new(),
             in_flight: Arc::new(AtomicBool::new(false)),
+            turn_started_hooked: Arc::new(AtomicBool::new(false)),
+            deferred_mode_confirm: Arc::new(Mutex::new(None)),
             queued: Arc::new(Mutex::new(VecDeque::new())),
         })
     }
@@ -1267,6 +1328,8 @@ mod tests {
             permission_seq: AtomicU64::new(0),
             weak_self: std::sync::OnceLock::new(),
             in_flight: Arc::new(AtomicBool::new(false)),
+            turn_started_hooked: Arc::new(AtomicBool::new(false)),
+            deferred_mode_confirm: Arc::new(Mutex::new(None)),
             queued: Arc::new(Mutex::new(VecDeque::new())),
         })
     }
@@ -1328,6 +1391,93 @@ mod tests {
         .unwrap();
 
         assert!(!hook.exists(), "full auto must not leave a hook agy would call");
+    }
+
+    /// A session whose turn is running WITH the approval hook installed applies a mode
+    /// switch at once, so it must not claim otherwise.
+    ///
+    /// The gate lives on the host: agy calls back per tool use and
+    /// `request_external_permission` re-reads the mode every time. So while those
+    /// callbacks are happening, a switch governs the very next tool — in both directions.
+    #[tokio::test]
+    async fn a_hooked_turn_applies_a_mode_switch_at_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = backend_with_hook_body(dir.path(), Some("default"), Some("{\"stub\":true}"));
+        b.in_flight.store(true, Ordering::SeqCst);
+        b.turn_started_hooked.store(true, Ordering::SeqCst);
+
+        assert_eq!(
+            b.capabilities().mode_switch_effect,
+            crate::capability::ModeSwitchEffect::Immediate,
+            "a hooked turn keeps calling back, so the new mode governs the next tool call"
+        );
+    }
+
+    /// The one case that genuinely has to wait: a turn that started in FULL AUTO has no
+    /// hook on disk, so agy never calls back and the host gate never runs. Tightening
+    /// cannot reach that already-spawned process; it lands when the next turn spawns.
+    ///
+    /// Claiming `Immediate` here would be the dangerous lie -- the user would be told the
+    /// permission was restored while the agent kept running unattended.
+    #[tokio::test]
+    async fn a_full_auto_turn_defers_a_tightening_switch() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = backend_with_hook_body(dir.path(), Some("yolo"), Some("{\"stub\":true}"));
+        b.in_flight.store(true, Ordering::SeqCst);
+        b.turn_started_hooked.store(false, Ordering::SeqCst);
+
+        assert_eq!(
+            b.capabilities().mode_switch_effect,
+            crate::capability::ModeSwitchEffect::NextTurn,
+            "no hook was installed for this turn, so agy cannot learn about the switch"
+        );
+    }
+
+    /// Between turns there is no agy process at all, so the next spawn necessarily reads
+    /// the new mode from argv.
+    #[tokio::test]
+    async fn an_idle_session_applies_a_mode_switch_at_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = backend_with_hook_body(dir.path(), Some("yolo"), Some("{\"stub\":true}"));
+        assert_eq!(
+            b.capabilities().mode_switch_effect,
+            crate::capability::ModeSwitchEffect::Immediate
+        );
+    }
+
+    /// A deferred switch must NOT announce itself as applied.
+    ///
+    /// `ConfigChanged` is what clears the frontend's pending marker, so emitting it here
+    /// would flip the picker to "in force" for exactly the case that has not taken effect
+    /// -- the contradiction this pair of rules exists to prevent.
+    #[tokio::test]
+    async fn a_deferred_switch_emits_no_premature_confirmation() {
+        let dir = tempfile::tempdir().unwrap();
+        let b = backend_with_hook_body(dir.path(), Some("yolo"), Some("{\"stub\":true}"));
+        b.in_flight.store(true, Ordering::SeqCst);
+        b.turn_started_hooked.store(false, Ordering::SeqCst);
+        let mut events = b.events();
+
+        b.dispatch(Command::SetMode {
+            mode: "default".to_owned(),
+        })
+        .await
+        .unwrap();
+
+        let confirmed = tokio::time::timeout(std::time::Duration::from_millis(400), async {
+            use futures_util::StreamExt as _;
+            while let Some(env) = events.next().await {
+                if let SessionEvent::ConfigChanged { mode, .. } = env.event {
+                    return mode;
+                }
+            }
+            None
+        })
+        .await;
+        assert!(
+            confirmed.is_err() || confirmed.as_ref().unwrap().is_none(),
+            "a switch agy cannot see yet must not be confirmed, got {confirmed:?}"
+        );
     }
 
     /// A runtime mode switch must emit `ConfigChanged`.
@@ -1396,6 +1546,8 @@ mod tests {
             permission_seq: AtomicU64::new(0),
             weak_self: std::sync::OnceLock::new(),
             in_flight: Arc::new(AtomicBool::new(false)),
+            turn_started_hooked: Arc::new(AtomicBool::new(false)),
+            deferred_mode_confirm: Arc::new(Mutex::new(None)),
             queued: Arc::new(Mutex::new(VecDeque::new())),
         };
         assert_eq!(b.effective_mode().as_deref(), Some("default"));
@@ -1469,6 +1621,8 @@ mod tests {
             permission_seq: AtomicU64::new(0),
             weak_self: std::sync::OnceLock::new(),
             in_flight: Arc::new(AtomicBool::new(false)),
+            turn_started_hooked: Arc::new(AtomicBool::new(false)),
+            deferred_mode_confirm: Arc::new(Mutex::new(None)),
             queued: Arc::new(Mutex::new(VecDeque::new())),
         };
 
@@ -1601,6 +1755,8 @@ mod tests {
             permission_seq: AtomicU64::new(0),
             weak_self: std::sync::OnceLock::new(),
             in_flight: Arc::new(AtomicBool::new(false)),
+            turn_started_hooked: Arc::new(AtomicBool::new(false)),
+            deferred_mode_confirm: Arc::new(Mutex::new(None)),
             queued: Arc::new(Mutex::new(VecDeque::new())),
         }
     }

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -429,14 +429,19 @@ pub struct ClaudeSessionBackend {
     /// into `available_models`/`slash_commands` on read. Empty until the response
     /// lands (a freshly-opened backend reads empty, like codex pre-`model/list`).
     discovered_caps: Arc<std::sync::Mutex<DiscoveredCaps>>,
-    /// G2 (in-band config switch): control_requests (`set_model` /
-    /// `set_permission_mode`) deferred because they arrived mid-turn. Writing one
-    /// while a turn is Running would reinitialize the CLI session and TRUNCATE the
-    /// in-flight turn (raw-CLI limitation), so `dispatch(SetMode/SetModel)` QUEUES
-    /// the frame here and `dispatch(Send)` drains it — in order, over the same
-    /// stdin lock, BEFORE the prompt — so a queued switch applies to the NEXT turn
-    /// and can never land after-and-truncate it. De-duped by subtype (last-write-
-    /// wins). Mirrors F1's `pending_controls`.
+    /// G2 (in-band config switch): control_requests deferred because they arrived
+    /// mid-turn. `dispatch(Send)` drains them — in order, over the same stdin lock,
+    /// BEFORE the prompt — so a queued switch applies to the NEXT turn. De-duped by
+    /// subtype (last-write-wins). Mirrors F1's `pending_controls`.
+    ///
+    /// Now holds only `set_model` / `apply_flag_settings`. `set_permission_mode` is
+    /// written straight through (see `write_or_queue_control`): a 2.1.227 probe
+    /// disproved the truncation theory this queue was built on, and because draining
+    /// only happens on the next prompt, queueing left a switch unsent — and unapplied —
+    /// for as long as the user did not send another message.
+    ///
+    /// The remaining two keep queueing only because no equivalent capture exists for
+    /// them yet, not because truncation is known to occur.
     pending_controls: Arc<Mutex<Vec<serde_json::Value>>>,
     /// Monotonic counter minting `control_request` request_ids (no uuid dep). The
     /// CLI echoes it in its success control_response (observed by the reader, not
@@ -1224,8 +1229,26 @@ impl ClaudeSessionBackend {
             "request_id": request_id,
             "request": request,
         });
-        if self.turn_in_flight.load(Ordering::SeqCst) {
-            let subtype = control_subtype(&frame);
+        let subtype = control_subtype(&frame);
+        // `set_permission_mode` is written straight through, even mid-turn.
+        //
+        // LIVE-PROBED 2.1.227 (samples/claude-cli/2.1.227/set_permission_mode/, harness
+        // scripts/probe-claude-set-permission-mode.py): switching mid-generation left the
+        // turn streaming to a normal `result{subtype:"success"}` with 18-32 assistant
+        // frames after the switch, and the new mode governed the very next tool approval
+        // in that SAME turn — proven against a no-switch control run, and symmetric
+        // (loosening skipped the approval prompt, tightening brought it back).
+        //
+        // Queueing it was worse than a delay: `drain_pending_controls` runs only at the
+        // head of `dispatch(Send)`, so a mid-turn switch sat unsent until the user
+        // happened to send another message. Observed live as a switch stuck "pending" for
+        // 3+ minutes with the agent still running under the OLD mode — a safety gap when
+        // the user was TIGHTENING permissions.
+        //
+        // Deliberately narrow: `set_model` and `apply_flag_settings` have no equivalent
+        // capture, so they keep the conservative queue until one exists.
+        let write_through = subtype.as_deref() == Some("set_permission_mode");
+        if !write_through && self.turn_in_flight.load(Ordering::SeqCst) {
             let mut q = self.pending_controls.lock().await;
             q.retain(|f| control_subtype(f) != subtype);
             q.push(frame);
@@ -2935,10 +2958,10 @@ impl SessionBackend for ClaudeSessionBackend {
             Command::Steer { .. } => Err(BackendError::CommandNotSupported { command: "steer" }),
             // G2: in-band config switch via control_request (probe-verified, mirrors
             // F1). set_permission_mode / set_model are written over the retained
-            // stdin WITHOUT restarting the process; the switch applies to the NEXT
-            // turn. Mid-turn writes would reinitialize + TRUNCATE the in-flight turn,
-            // so they QUEUE (drained before the next prompt). On a successful
-            // dispatch we emit ConfigChanged so the UI confirms immediately.
+            // stdin WITHOUT restarting the process. set_permission_mode goes out
+            // immediately, even mid-turn, and governs the very next tool approval
+            // (LIVE-PROBED 2.1.227 — see `write_or_queue_control`); set_model still
+            // queues to the next prompt for want of a capture.
             Command::SetMode { mode } => {
                 // DE-OPTIMISTIC (design §9.10.1 option A / README #10): we write the
                 // set_permission_mode request and STOP — no optimistic ConfigChanged, no
@@ -3112,19 +3135,13 @@ impl SessionBackend for ClaudeSessionBackend {
         // supply one (the snapshot's current_model is None in that case; the reader
         // fills discovered_model from the system/init frame). Read-only sync lock.
         let mut caps = self.capabilities.clone();
-        // A mode switch raised WHILE A TURN IS RUNNING does not reach the CLI now:
-        // `write_or_queue_control` parks it in `pending_controls` and `dispatch(Send)`
-        // drains it before the next prompt. Idle, the same write goes straight out and
-        // takes effect at once (verified: samples/claude-cli/2.1.227/set_permission_mode/
-        // — the ack and `system/status{permissionMode}` both land within a millisecond,
-        // and the switch governs the very next tool approval in that same turn).
-        //
-        // So the honest answer depends on right now, and only this live handle knows it.
-        caps.mode_switch_effect = if self.turn_in_flight.load(std::sync::atomic::Ordering::SeqCst) {
-            crate::capability::ModeSwitchEffect::NextTurn
-        } else {
-            crate::capability::ModeSwitchEffect::Immediate
-        };
+        // Immediate regardless of turn state: `write_or_queue_control` writes
+        // `set_permission_mode` straight through even mid-turn (see there for the probe),
+        // and 2.1.227 shows the ack plus `system/status{permissionMode}` landing within a
+        // millisecond, with the new mode governing the very next tool approval in that
+        // same turn. Left explicit rather than inherited from the static adapter caps so
+        // this stays next to the reason.
+        caps.mode_switch_effect = crate::capability::ModeSwitchEffect::Immediate;
         if caps.current_model.is_none()
             && let Some(model) = self.discovered_model.lock().unwrap_or_else(|e| e.into_inner()).clone()
         {
@@ -5005,10 +5022,66 @@ mod tests {
         );
     }
 
+    /// A SetMode raised WHILE A TURN IS IN FLIGHT goes out IMMEDIATELY.
+    ///
+    /// It used to be queued until the next prompt, on the theory that a mid-turn control
+    /// write "would reinitialize the CLI session and TRUNCATE the in-flight turn". That
+    /// was the one live-behaviour claim in this file with no captured evidence, and a
+    /// 2.1.227 probe disproved it: switching mid-generation left the turn streaming to a
+    /// normal `result{success}` and took effect within that same turn, in both directions
+    /// (samples/claude-cli/2.1.227/set_permission_mode/, harness
+    /// scripts/probe-claude-set-permission-mode.py).
+    ///
+    /// Queueing was not merely a delay. `drain_pending_controls` runs only at the head of
+    /// `dispatch(Send)`, so a switch made mid-turn sat unsent until the user happened to
+    /// send another message — observed live as a permission change stuck "pending" for
+    /// 3+ minutes while the agent kept running under the OLD mode. For a TIGHTENING
+    /// switch that is a safety gap, not just a stale label.
+    ///
+    /// Scope is deliberately `set_permission_mode` only: `set_model` and
+    /// `apply_flag_settings` have no such capture, so they keep queueing (asserted by
+    /// the test below).
+    #[tokio::test]
+    async fn set_mode_mid_turn_is_written_immediately() {
+        let fake = FakeAgentIo::never_exits(Vec::new());
+        let captured = fake.captured_stdin();
+        let backend = ClaudeSessionBackend::build_with_io("s", Box::new(fake)).await;
+
+        // First Send → turn_in_flight = true (no terminal ever arrives here).
+        backend
+            .dispatch(Command::Send {
+                content: vec![ContentBlock::Text("first".into())],
+                metadata: CommandMeta::default(),
+            })
+            .await
+            .expect("first Send accepted");
+
+        backend
+            .dispatch(Command::SetMode { mode: "plan".into() })
+            .await
+            .expect("SetMode accepted");
+
+        let mut written = String::new();
+        for _ in 0..40 {
+            written = String::from_utf8_lossy(&captured.lock().await.clone()).to_string();
+            if written.contains("set_permission_mode") {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            written.contains("set_permission_mode") && written.contains("\"mode\":\"plan\""),
+            "a mid-turn mode switch must reach the CLI without waiting for the next prompt, got: {written}"
+        );
+    }
+
     /// G2: a SetModel issued WHILE A TURN IS IN FLIGHT is QUEUED (not written
     /// mid-turn, which would truncate the turn) and drained over stdin BEFORE the
     /// next prompt — so the switch applies to the next turn. Proves the queue +
     /// drain ordering: the control_request bytes precede the next user prompt bytes.
+    ///
+    /// Unlike `set_permission_mode` (see above), set_model's mid-turn behaviour has NOT
+    /// been captured, so it keeps the conservative queue.
     #[tokio::test]
     async fn set_model_mid_turn_is_queued_and_drained_before_next_prompt() {
         let fake = FakeAgentIo::never_exits(Vec::new());

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -5939,10 +5939,14 @@ mod tests {
     /// sniff_mode: claude's AUTHORITATIVE mode signal is `permissionMode` on a
     /// `system/status` frame — emitted for BOTH a user-driven set AND an autonomous
     /// change (plan-exit). The reader adopts it (normal→default) as current_mode AND
-    /// emits ConfigChanged{mode} (design §9.10.1 option A; README #10). Wire shape from
-    /// protocols/samples/claude-cli/2.1.187/_all_autonomous_mode.jsonl (autonomous
-    /// plan-exit emitted exactly this system/status). MUTATION-PROVEN by the autonomous
-    /// scenario: without sniff_mode the autonomous mode change is silently dropped.
+    /// emits ConfigChanged{mode} (design §9.10.1 option A; README #10).
+    ///
+    /// This case uses a SYNTHETIC frame because `normal` (claude's internal name for our
+    /// `default`) is the one value the 2.1.227 capture never produced; the real-wire
+    /// counterpart is `sniff_mode_handles_real_capture_status_frames` below.
+    ///
+    /// NOTE: this doc used to cite samples/claude-cli/2.1.187/_all_autonomous_mode.jsonl,
+    /// which no longer exists on disk (only 2.1.221/226/227/228 remain).
     #[tokio::test]
     async fn sniff_mode_emits_config_changed_from_system_status() {
         // `normal` is claude's internal name for our `default` — covers the mapping too.
@@ -5970,6 +5974,64 @@ mod tests {
             backend.capabilities().current_mode.as_deref(),
             Some("default"),
             "the inbound applied mode becomes the authoritative current_mode"
+        );
+    }
+
+    /// The same path, driven by REAL captured bytes rather than a hand-written frame.
+    ///
+    /// Frames copied verbatim from
+    /// samples/claude-cli/2.1.227/set_permission_mode/s5.inbound.jsonl (a
+    /// `set_permission_mode` issued mid-generation; harness:
+    /// scripts/probe-claude-set-permission-mode.py). This matters because the real
+    /// stream interleaves a SECOND kind of `system/status` — `{"status":"requesting"}`
+    /// with NO `permissionMode` at all — which a synthetic single-frame test never
+    /// exercises. Reading such a frame as a mode change would hand the picker a bogus
+    /// value; the guard that prevents it has no other coverage.
+    ///
+    /// Also pins the two facts the capture established: a USER-DRIVEN set really does
+    /// emit `system/status{permissionMode}` (so this confirmation path is live, not
+    /// dead code), and the switch is confirmed while the turn is still streaming.
+    #[tokio::test]
+    async fn sniff_mode_handles_real_capture_status_frames() {
+        // All three `system/status` frames of that capture, in wire order. The trailing
+        // `requesting` one is the load-bearing case: it arrives AFTER the mode was
+        // confirmed, so a reader that mistook it for a mode change would drop the
+        // picker back to nothing.
+        let captured = concat!(
+            r#"{"type": "system", "subtype": "status", "status": "requesting", "uuid": "a2e3fd0c-bf39-41ac-a01f-716392d7b9b1", "session_id": "b1f38ca8-789b-4598-ba55-d96ea7e603d5"}"#,
+            "\n",
+            r#"{"type": "system", "subtype": "status", "status": null, "permissionMode": "acceptEdits", "uuid": "ebf5aac3-1de6-405f-bb23-95cbb75671af", "session_id": "b1f38ca8-789b-4598-ba55-d96ea7e603d5"}"#,
+            "\n",
+            r#"{"type": "system", "subtype": "status", "status": "requesting", "uuid": "3460b839-35bd-45e7-83b7-f79a9637ce57", "session_id": "b1f38ca8-789b-4598-ba55-d96ea7e603d5"}"#,
+            "\n",
+        );
+        let backend =
+            ClaudeSessionBackend::build_with_io("s", Box::new(FakeAgentIo::never_exits(captured.as_bytes().to_vec())))
+                .await;
+        let mut events = backend.events();
+
+        // Collect until the stream goes quiet rather than stopping at the first event:
+        // the point of the trailing frame is that it must produce NO second event, which
+        // an early return could never observe.
+        let mut confirmations: Vec<Option<String>> = Vec::new();
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(800), async {
+            while let Some(env) = events.next().await {
+                if let SessionEvent::ConfigChanged { mode, .. } = env.event {
+                    confirmations.push(mode);
+                }
+            }
+        })
+        .await;
+        assert_eq!(
+            confirmations,
+            vec![Some("acceptEdits".to_string())],
+            "exactly one confirmation, carrying the applied mode: the two `requesting` \
+             frames carry no permissionMode and must be ignored"
+        );
+        assert_eq!(
+            backend.capabilities().current_mode.as_deref(),
+            Some("acceptEdits"),
+            "a later status frame WITHOUT permissionMode must not disturb the applied mode"
         );
     }
 

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -3112,6 +3112,19 @@ impl SessionBackend for ClaudeSessionBackend {
         // supply one (the snapshot's current_model is None in that case; the reader
         // fills discovered_model from the system/init frame). Read-only sync lock.
         let mut caps = self.capabilities.clone();
+        // A mode switch raised WHILE A TURN IS RUNNING does not reach the CLI now:
+        // `write_or_queue_control` parks it in `pending_controls` and `dispatch(Send)`
+        // drains it before the next prompt. Idle, the same write goes straight out and
+        // takes effect at once (verified: samples/claude-cli/2.1.227/set_permission_mode/
+        // — the ack and `system/status{permissionMode}` both land within a millisecond,
+        // and the switch governs the very next tool approval in that same turn).
+        //
+        // So the honest answer depends on right now, and only this live handle knows it.
+        caps.mode_switch_effect = if self.turn_in_flight.load(std::sync::atomic::Ordering::SeqCst) {
+            crate::capability::ModeSwitchEffect::NextTurn
+        } else {
+            crate::capability::ModeSwitchEffect::Immediate
+        };
         if caps.current_model.is_none()
             && let Some(model) = self.discovered_model.lock().unwrap_or_else(|e| e.into_inner()).clone()
         {

--- a/crates/aionui-session/src/backend/codex_conn.rs
+++ b/crates/aionui-session/src/backend/codex_conn.rs
@@ -552,6 +552,13 @@ fn build_codex_mcp_servers(servers: &[crate::backend::McpServerSpec]) -> Value {
 pub fn codex_capabilities() -> Capabilities {
     Capabilities {
         tier: CapabilityTier::Hook,
+        // Unconditional, per codex's own schema: `thread/settings/update` documents
+        // `approvalPolicy`/`sandboxPolicy`/`permissions` as "for subsequent turns"
+        // (samples/codex-cli/0.146.0/schema/v2/ThreadSettingsUpdateParams.json, identical
+        // in 0.147.0). Only `turn/start` can carry a policy for the turn it opens, and
+        // aionCore sends `turn/start` with `{threadId, input}` alone. Not a defect — this
+        // is codex's contract; the UI just has to say so.
+        mode_switch_effect: crate::capability::ModeSwitchEffect::NextTurn,
         emits: SignalSet {
             heartbeat: true,
             tool_lifecycle: true,

--- a/crates/aionui-session/src/capability.rs
+++ b/crates/aionui-session/src/capability.rs
@@ -10,6 +10,21 @@
 /// discovery (handshake-filled open sets)" — these fields are the DISCOVERY
 /// half: which Commands a backend accepts, which input blocks, which models/
 /// modes it advertises, which auth methods (§0.5 panel).
+/// When an accepted mode switch starts governing tool approvals. See
+/// [`Capabilities::mode_switch_effect`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ModeSwitchEffect {
+    /// In force for the very next approval decision, even mid-turn.
+    ///
+    /// The default: a backend that reconfigures synchronously (aionrs mutates the shared
+    /// approval mode in-process) or writes straight to a live agent needs no ceremony,
+    /// and this keeps existing backends reporting what they already reported.
+    #[default]
+    Immediate,
+    /// The in-flight turn keeps the old mode; the switch governs from the next turn.
+    NextTurn,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Capabilities {
     /// Parse tier: Parsed (full-field, e.g. claude) / Hook (lifecycle hooks
@@ -72,6 +87,19 @@ pub struct Capabilities {
     /// it — a dead button (MX-QUEUE-3). `can_queue` MUST read this bit, never
     /// `caps.steer`. Default false; only claude sets it true.
     pub accepts_proactive_input: bool,
+    /// When a mode switch this backend ACCEPTS starts governing tool approvals.
+    ///
+    /// Reported per call rather than statically, because the same backend answers
+    /// differently depending on what it is doing: claude writes a `set_permission_mode`
+    /// straight to stdin while idle, but QUEUES one raised mid-turn until the next
+    /// prompt. codex is `NextTurn` unconditionally — its schema says so
+    /// ("Override the approval policy for subsequent turns",
+    /// samples/codex-cli/0.146.0/schema/v2/ThreadSettingsUpdateParams.json).
+    ///
+    /// Consumed by `set_config_option` to decide between `Observed` and
+    /// `PendingNextTurn`; without it the response was self-fulfilling (cache the request
+    /// as an override, read it straight back, report success).
+    pub mode_switch_effect: ModeSwitchEffect,
     /// NEW (#101): user-invokable slash commands the backend advertises (claude
     /// `control_request{initialize}` response `commands[]`; ACP `session/update`
     /// `available_commands_update`; incl. MCP/plugin/skill-derived). Open set,

--- a/crates/aionui-session/src/lib.rs
+++ b/crates/aionui-session/src/lib.rs
@@ -63,8 +63,8 @@ pub use backend::{
     slash_command_name, version_drift,
 };
 pub use capability::{
-    BlockSet, Capabilities, CapabilityTier, CommandSet, ModeInfo, ModelInfo, PromptAcceptedSource, SignalSet,
-    SlashCommandInfo, block_kind_name,
+    BlockSet, Capabilities, CapabilityTier, CommandSet, ModeInfo, ModeSwitchEffect, ModelInfo, PromptAcceptedSource,
+    SignalSet, SlashCommandInfo, block_kind_name,
 };
 pub use error::SessionError;
 pub use event::UsageBreakdown;

--- a/scripts/probe-claude-set-permission-mode.py
+++ b/scripts/probe-claude-set-permission-mode.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""Capture real claude-CLI wire traffic for `control_request{set_permission_mode}`.
+
+Settles three questions that aionCore currently answers from an uncited rationale:
+
+  Q1  Does a mid-turn set_permission_mode truncate / reinitialize the in-flight turn?
+      claude_conn.rs:432-440 asserts it does ("raw-CLI limitation") but cites no
+      fixture, while every other live-probed claim in that file cites a sample path.
+  Q2  Does a USER-DRIVEN set emit `{"type":"system",...,"permissionMode":...}`?
+      `sniff_mode` (claude_conn.rs:2024) is the ONLY mode-confirmation path and reads
+      exactly that frame. If a user-driven set does not emit one, mode switches are
+      never confirmed at the backend layer.
+  Q3  What does the success control_response literally contain? claude_conn.rs:1517
+      claims the ack echoes `response.mode`, yet no code reads it
+      (`sniff_set_mode_response` does not exist -- the name appears only in comments).
+
+Argv mirrors ClaudeAdapter::spawn (adapter/claude.rs:1015-1059) plus the
+`--permission-mode` appended by build_claude_init_args (claude_conn.rs:169-208).
+The can_use_tool auto-reply mirrors build_control_response (claude_conn.rs:1245-1285):
+`updatedInput` MUST be a record and `toolUseID` MUST be echoed, or claude's ZodError
+rejects the frame and the approved tool silently never runs -- which would look like
+a truncated turn and be misread as evidence for Q1.
+
+Usage:
+    python3 scripts/probe-claude-set-permission-mode.py --scenario all --outdir /tmp/cap
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import shutil
+import sys
+import time
+import uuid
+from pathlib import Path
+
+SPAWN_ARGS = [
+    "--print",
+    "--input-format", "stream-json",
+    "--output-format", "stream-json",
+    "--verbose",
+    "--include-partial-messages",
+    "--replay-user-messages",
+    "--permission-prompt-tool", "stdio",
+]
+
+# A prompt that streams for a while AND ends in a tool call, so one turn exercises
+# both the truncation question and the "did the new mode apply to this turn" question.
+TOOL_PROMPT = (
+    "Count from 1 to 30, one number per line. "
+    "Then create a file named probe.txt containing exactly the word hello."
+)
+
+
+class Probe:
+    def __init__(self, claude_bin: str, workdir: Path, outdir: Path, scenario: str):
+        self.claude_bin = claude_bin
+        self.workdir = workdir
+        self.outdir = outdir
+        self.scenario = scenario
+        self.proc: asyncio.subprocess.Process | None = None
+        self.trace = (outdir / f"{scenario}.trace.jsonl").open("w")
+        self.inbound = (outdir / f"{scenario}.inbound.jsonl").open("w")
+        self.ctl_seq = 0
+        self.t0 = time.monotonic()
+        # Observations feeding the verdict.
+        self.saw_first_delta = asyncio.Event()
+        self.deep_in_stream = asyncio.Event()   # set once generation is visibly flowing
+        self.delta_count = 0
+        # claude streams in coarse chunks (~15 content deltas for a 30-line answer),
+        # so this is deliberately low: it must land mid-generation, not never.
+        self.deep_delta_threshold = 5
+        self.mode_ctl_ids: dict[str, str] = {}   # request_id -> requested mode
+        self.control_responses: list[dict] = []
+        self.system_frames: list[dict] = []
+        self.can_use_tool_all: list[dict] = []
+        self.can_use_tool_after_switch: list[dict] = []
+        self.switch_sent_at: float | None = None
+        self.result_frame: dict | None = None
+        self.text_after_switch = 0
+        self.errors: list[str] = []
+
+    def _stamp(self) -> float:
+        return round(time.monotonic() - self.t0, 3)
+
+    def _log(self, direction: str, frame: dict) -> None:
+        rec = {"t": self._stamp(), "dir": direction, "frame": frame}
+        self.trace.write(json.dumps(rec) + "\n")
+        self.trace.flush()
+        if direction == "in":
+            self.inbound.write(json.dumps(frame) + "\n")
+            self.inbound.flush()
+
+    async def spawn(self, permission_mode: str) -> None:
+        args = [
+            *SPAWN_ARGS,
+            "--session-id", str(uuid.uuid4()),
+            "--permission-mode", permission_mode,
+        ]
+        print(f"[spawn] mode={permission_mode}", flush=True)
+        self.proc = await asyncio.create_subprocess_exec(
+            self.claude_bin, *args,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(self.workdir),
+        )
+
+    async def send(self, frame: dict) -> None:
+        assert self.proc and self.proc.stdin
+        self._log("out", frame)
+        self.proc.stdin.write((json.dumps(frame) + "\n").encode())
+        await self.proc.stdin.drain()
+
+    async def send_prompt(self, text: str) -> None:
+        await self.send({
+            "type": "user",
+            "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+        })
+
+    async def send_set_mode(self, mode: str) -> str:
+        self.ctl_seq += 1
+        request_id = f"ctl-{self.ctl_seq}"
+        self.mode_ctl_ids[request_id] = mode
+        self.switch_sent_at = self._stamp()
+        await self.send({
+            "type": "control_request",
+            "request_id": request_id,
+            "request": {"subtype": "set_permission_mode", "mode": mode},
+        })
+        print(f"[switch] t={self.switch_sent_at}s -> {mode} ({request_id})", flush=True)
+        return request_id
+
+    async def _answer_can_use_tool(self, frame: dict) -> None:
+        """Mirror build_control_response (claude_conn.rs:1245-1285) exactly."""
+        request_id = frame.get("request_id")
+        req = frame.get("request") or {}
+        tool_use_id = req.get("tool_use_id")
+        if not request_id or not tool_use_id:
+            self.errors.append(f"can_use_tool missing ids: {json.dumps(frame)[:300]}")
+            return
+        raw_input = req.get("input")
+        updated_input = raw_input if isinstance(raw_input, dict) else {}
+        await self.send({
+            "type": "control_response",
+            "response": {
+                "subtype": "success",
+                "request_id": request_id,
+                "response": {
+                    "behavior": "allow",
+                    "updatedInput": updated_input,
+                    "toolUseID": tool_use_id,
+                },
+            },
+        })
+
+    def _classify(self, frame: dict) -> None:
+        ftype = frame.get("type")
+        after_switch = self.switch_sent_at is not None
+
+        if ftype == "system":
+            self.system_frames.append(frame)
+            if "permissionMode" in frame:
+                print(f"[system] t={self._stamp()}s subtype={frame.get('subtype')} "
+                      f"permissionMode={frame.get('permissionMode')}", flush=True)
+        elif ftype == "result":
+            self.result_frame = frame
+        elif ftype == "control_response":
+            resp = frame.get("response") or {}
+            if resp.get("request_id") in self.mode_ctl_ids:
+                self.control_responses.append(frame)
+                print(f"[ack] t={self._stamp()}s {json.dumps(frame)}", flush=True)
+        elif ftype == "control_request":
+            if (frame.get("request") or {}).get("subtype") == "can_use_tool":
+                self.can_use_tool_all.append(frame)
+                if after_switch:
+                    self.can_use_tool_after_switch.append(frame)
+
+        # Any assistant text proves the turn is alive.
+        if ftype in ("stream_event", "assistant"):
+            if not self.saw_first_delta.is_set():
+                self.saw_first_delta.set()
+            if after_switch:
+                self.text_after_switch += 1
+        # `message_start` fires before any content exists; only a content_block_delta
+        # proves the model is actively emitting, which is what "mid-generation" means.
+        if ftype == "stream_event" and (frame.get("event") or {}).get("type") == "content_block_delta":
+            self.delta_count += 1
+            if self.delta_count >= self.deep_delta_threshold and not self.deep_in_stream.is_set():
+                self.deep_in_stream.set()
+
+    async def read_stdout(self) -> None:
+        assert self.proc and self.proc.stdout
+        async for raw in self.proc.stdout:
+            line = raw.decode("utf-8", "replace").strip()
+            if not line:
+                continue
+            try:
+                frame = json.loads(line)
+            except json.JSONDecodeError:
+                self.trace.write(json.dumps({"t": self._stamp(), "dir": "in-raw",
+                                             "line": line[:2000]}) + "\n")
+                continue
+            self._log("in", frame)
+            self._classify(frame)
+            if frame.get("type") == "control_request" and \
+               (frame.get("request") or {}).get("subtype") == "can_use_tool":
+                await self._answer_can_use_tool(frame)
+
+    async def read_stderr(self) -> None:
+        assert self.proc and self.proc.stderr
+        async for raw in self.proc.stderr:
+            msg = raw.decode("utf-8", "replace").rstrip()
+            if msg:
+                self.errors.append(msg)
+                print(f"[stderr] {msg}", file=sys.stderr, flush=True)
+
+    def verdict(self) -> dict:
+        mode_systems = [f for f in self.system_frames if "permissionMode" in f]
+        return {
+            "scenario": self.scenario,
+            "Q1_turn_survived_switch": {
+                "reached_result_frame": self.result_frame is not None,
+                "assistant_frames_after_switch": self.text_after_switch,
+                "result_subtype": (self.result_frame or {}).get("subtype"),
+                "is_error": (self.result_frame or {}).get("is_error"),
+            },
+            "Q2_system_frames_with_permissionMode": mode_systems,
+            "Q2_count": len(mode_systems),
+            "Q3_control_responses_for_our_set": self.control_responses,
+            "can_use_tool_total": len(self.can_use_tool_all),
+            "can_use_tool_after_switch": len(self.can_use_tool_after_switch),
+            "tools_prompted_after_switch": [
+                (f.get("request") or {}).get("tool_name")
+                for f in self.can_use_tool_after_switch
+            ],
+            "stderr": self.errors[:20],
+        }
+
+    async def finish(self) -> dict:
+        if self.proc and self.proc.stdin and not self.proc.stdin.is_closing():
+            try:
+                self.proc.stdin.close()
+            except Exception:
+                pass
+        if self.proc:
+            try:
+                await asyncio.wait_for(self.proc.wait(), timeout=10)
+            except asyncio.TimeoutError:
+                self.proc.kill()
+        v = self.verdict()
+        (self.outdir / f"{self.scenario}.verdict.json").write_text(json.dumps(v, indent=2))
+        self.trace.close()
+        self.inbound.close()
+        return v
+
+
+async def scenario_idle(p: Probe) -> None:
+    """S1 baseline: switch while NO turn is running. Isolates Q2/Q3 from turn state."""
+    await p.spawn("default")
+    reader = asyncio.create_task(p.read_stdout())
+    errs = asyncio.create_task(p.read_stderr())
+    await asyncio.sleep(3)          # let system/init land
+    await p.send_set_mode("plan")
+    await asyncio.sleep(8)          # watch for an ack and/or a system/status
+    reader.cancel()
+    errs.cancel()
+
+
+async def scenario_midturn(p: Probe) -> None:
+    """S2, the key one: switch WHILE a turn streams, then watch the turn's fate."""
+    await p.spawn("default")
+    reader = asyncio.create_task(p.read_stdout())
+    errs = asyncio.create_task(p.read_stderr())
+    await asyncio.sleep(2)
+    await p.send_prompt(TOOL_PROMPT)
+    try:
+        await asyncio.wait_for(p.saw_first_delta.wait(), timeout=90)
+    except asyncio.TimeoutError:
+        p.errors.append("no assistant delta within 90s -- turn never started")
+        reader.cancel()
+        errs.cancel()
+        return
+    print(f"[turn] first delta at t={p._stamp()}s; switching mid-stream", flush=True)
+    await p.send_set_mode("acceptEdits")
+    # Ride the turn to its natural end: a truncation shows up as a missing/errored
+    # result frame or a sudden stop in assistant frames.
+    for _ in range(180):
+        if p.result_frame is not None:
+            break
+        await asyncio.sleep(1)
+    await asyncio.sleep(3)
+    reader.cancel()
+    errs.cancel()
+
+
+async def scenario_plan_exit(p: Probe) -> None:
+    """S3 symmetry: start in plan, switch to default mid-turn."""
+    await p.spawn("plan")
+    reader = asyncio.create_task(p.read_stdout())
+    errs = asyncio.create_task(p.read_stderr())
+    await asyncio.sleep(2)
+    await p.send_prompt("Count from 1 to 20, one number per line.")
+    try:
+        await asyncio.wait_for(p.saw_first_delta.wait(), timeout=90)
+    except asyncio.TimeoutError:
+        p.errors.append("no assistant delta within 90s")
+        reader.cancel()
+        errs.cancel()
+        return
+    await p.send_set_mode("default")
+    for _ in range(120):
+        if p.result_frame is not None:
+            break
+        await asyncio.sleep(1)
+    await asyncio.sleep(3)
+    reader.cancel()
+    errs.cancel()
+
+
+async def scenario_control_no_switch(p: Probe) -> None:
+    """S4 CONTROL: identical prompt, NO switch. Establishes the baseline can_use_tool
+    count under `default`, without which S2's "zero prompts" proves nothing about
+    whether the switch took effect."""
+    await p.spawn("default")
+    reader = asyncio.create_task(p.read_stdout())
+    errs = asyncio.create_task(p.read_stderr())
+    await asyncio.sleep(2)
+    await p.send_prompt(TOOL_PROMPT)
+    for _ in range(180):
+        if p.result_frame is not None:
+            break
+        await asyncio.sleep(1)
+    await asyncio.sleep(3)
+    reader.cancel()
+    errs.cancel()
+
+
+async def scenario_deep_midturn(p: Probe) -> None:
+    """S5: switch only once the model is DEMONSTRABLY mid-generation (>=25 content
+    deltas emitted), closing S2's gap where the switch landed right after
+    message_start but before any content."""
+    await p.spawn("default")
+    reader = asyncio.create_task(p.read_stdout())
+    errs = asyncio.create_task(p.read_stderr())
+    await asyncio.sleep(2)
+    await p.send_prompt(TOOL_PROMPT)
+    try:
+        await asyncio.wait_for(p.deep_in_stream.wait(), timeout=120)
+    except asyncio.TimeoutError:
+        p.errors.append(f"only {p.delta_count} deltas in 120s -- never reached mid-generation")
+        reader.cancel()
+        errs.cancel()
+        return
+    print(f"[turn] {p.delta_count} deltas streamed at t={p._stamp()}s; switching mid-generation",
+          flush=True)
+    await p.send_set_mode("acceptEdits")
+    for _ in range(180):
+        if p.result_frame is not None:
+            break
+        await asyncio.sleep(1)
+    await asyncio.sleep(3)
+    reader.cancel()
+    errs.cancel()
+
+
+async def scenario_tighten_midturn(p: Probe) -> None:
+    """S6 SAFETY DIRECTION: start in acceptEdits (Write auto-runs), then tighten to
+    `default` mid-generation. If can_use_tool fires for the later Write, the gate is
+    restored WITHIN the turn; if not, loosening is honoured mid-turn but tightening
+    is not -- an asymmetry that matters far more than the loosening case."""
+    await p.spawn("acceptEdits")
+    reader = asyncio.create_task(p.read_stdout())
+    errs = asyncio.create_task(p.read_stderr())
+    await asyncio.sleep(2)
+    await p.send_prompt(TOOL_PROMPT)
+    try:
+        await asyncio.wait_for(p.deep_in_stream.wait(), timeout=120)
+    except asyncio.TimeoutError:
+        p.errors.append(f"only {p.delta_count} deltas in 120s")
+        reader.cancel()
+        errs.cancel()
+        return
+    print(f"[turn] {p.delta_count} deltas streamed at t={p._stamp()}s; TIGHTENING to default",
+          flush=True)
+    await p.send_set_mode("default")
+    for _ in range(180):
+        if p.result_frame is not None:
+            break
+        await asyncio.sleep(1)
+    await asyncio.sleep(3)
+    reader.cancel()
+    errs.cancel()
+
+
+SCENARIOS = {
+    "s1": scenario_idle,
+    "s2": scenario_midturn,
+    "s3": scenario_plan_exit,
+    "s4": scenario_control_no_switch,
+    "s5": scenario_deep_midturn,
+    "s6": scenario_tighten_midturn,
+}
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scenario", default="all", choices=[*SCENARIOS, "all"])
+    ap.add_argument("--outdir", default="/tmp/claude-mode-capture")
+    ap.add_argument("--claude-bin", default=shutil.which("claude") or "claude")
+    args = ap.parse_args()
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+    workdir = outdir / "scratch"
+    workdir.mkdir(exist_ok=True)
+
+    names = list(SCENARIOS) if args.scenario == "all" else [args.scenario]
+    summary = {}
+    for name in names:
+        print(f"\n{'=' * 60}\n{name}\n{'=' * 60}", flush=True)
+        p = Probe(args.claude_bin, workdir, outdir, name)
+        try:
+            await SCENARIOS[name](p)
+        except Exception as exc:  # keep partial capture on failure
+            p.errors.append(f"{type(exc).__name__}: {exc}")
+        summary[name] = await p.finish()
+        print(json.dumps(summary[name], indent=2), flush=True)
+
+    (outdir / "summary.json").write_text(json.dumps(summary, indent=2))
+    print(f"\nCaptures written to {outdir}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
## Problem

The mode picker told users a switch had landed while the agent was still enforcing the old mode.

The frontend was not being optimistic — it waits for the PUT and only moves once `confirmation == observed`. The backend was lying to it: `set_config_option` caches the requested value as an optimistic override and then reads it straight back, so `observed` was self-fulfilling for every direct-CLI backend.

Worse, for claude the switch often had not been *sent* at all. A control frame raised mid-turn was queued, and `drain_pending_controls` only runs at the head of `dispatch(Send)` — a turn ending triggers no drain. Observed live: a switch stayed pending for **3 minutes 17 seconds**, and only went out when the user happened to send another message. For a *tightening* switch that is a safety gap, not just a stale label.

## What changed

**Confirmation is now three-state.** `ConfigOptionConfirmation::PendingNextTurn` means "accepted, applies from the next turn". Driven by a new `Capabilities::mode_switch_effect`, answered by the *live* backend rather than assumed.

**claude no longer queues a mode switch.** `set_permission_mode` is written straight through, even mid-turn. Scope is deliberately that one subtype — `set_model` and `apply_flag_settings` have no equivalent capture and keep the conservative queue.

**Confirmations now reach the frontend.** The event pump adopts the confirmed value and re-projects the whole options snapshot; the background watcher forwards out-of-turn config frames through the same projection the per-turn relay uses.

**agy: four separate defects, found while verifying.**

1. *`--mode default` was rejected by agy.* It documents exactly two values (`accept-edits`, `plan`); `default` made it print `warning: unrecognized --mode value "default"` and **drop the flag**, leaving the session on whatever agy defaults to. `yolo` and `default` are both host-side concepts carried by the approval hook — `yolo` by removing it, `default` by keeping it — but only `yolo` was filtered.
2. *Confirmation could never be sent.* The pump re-projects from the last catalog it saw, but agy emits **no `CatalogUpdated` at all** (0 occurrences, against 4 in claude and 8 in codex). The picker sat on "switching…" forever. `get_config_options` now leaves the catalog on the runtime.
3. *Two rules contradicted each other.* `capabilities()` reported NextTurn for any mid-turn switch while `SetMode` immediately emitted `ConfigChanged` — which is exactly what clears the pending marker. The UI showed "in force" for every mid-turn switch, including the one case that genuinely had not taken effect.
4. *A deferred switch waited too long.* It was held until the next spawn, which needs the user to send another message. It is now released when the turn ends — that agy process is gone, so nothing runs under the old mode any more.

agy's gate lives on the **host**: agy calls back per tool use and `request_external_permission` re-reads the mode each time. So a hooked turn honours a switch at once, in both directions. The exception is a turn spawned in full auto: no hook on disk, never calls back, cannot be told — that one really does wait.

## Evidence

Three claims behind the old claude behaviour had no retained evidence, so the CLI was re-probed (v2.1.227, harness added as `scripts/probe-claude-set-permission-mode.py`, captures under `~/aion/protocols/samples/claude-cli/2.1.227/set_permission_mode/`):

- **A mid-turn `set_permission_mode` does NOT truncate the in-flight turn.** Three scenarios reach `result{success}` with 18–32 assistant frames after the switch. This disproves the rationale at `claude_conn.rs:432-440` — the one live-behaviour claim in that file with no sample path, while every neighbouring one cites a fixture.
- **A user-driven set DOES emit `system/status{permissionMode}`**, so `sniff_mode` is a live path, not dead code.
- **The mode takes effect within the same turn, both directions** — verified against a no-switch control run: loosening skipped the approval prompt, tightening brought it back.

Verified end-to-end in the running app, from its logs:

| backend | result |
|---|---|
| **claude** | Switch mid-turn: PUT → `ConfigChanged` in **1–2ms** (was 3m17s). In one turn, the two tool calls before the switch prompted for approval and the six after it did not — same turn, no restart. |
| **ACP** (omp, codebuddy) | 6–13ms, `observed_confirmed` — which waits until the agent's own value matches, not merely until the command is sent. |
| **agy** | A switch to full auto at `06:00:02` was auto-approving tool calls by `06:00:03`, in a turn that ran until `06:04:21`. |
| **codex** | **Not verified.** The local CLI is 0.144.6, below the 0.146.0 whose schema this relies on; no capture of its `thread/settings/update` exchange was obtained. |

## UI

The pill keeps naming the mode actually governing tool approvals, with the pending target alongside it. It must not show the target alone — that would tell the user a tightening had landed when it had not.

<img src="https://raw.githubusercontent.com/iOfficeAI/AionCore/assets/pr-846-screenshots/docs/pr-assets/mode-switch-pending.png" alt="Mode switch pending state: the pill still names the mode in force, with the pending target alongside it" width="380">

*Mid-turn switch on a full-auto agy turn — the only case that genuinely has to wait. The pill still names the mode in force (全自动) with the pending target alongside it (自动接受编辑); in the dropdown `✓` stays on what is governing and `⏱` marks what is queued.*

## Notes

- `PendingNextTurn` still persists the user's choice into the assistant preference. It means "the agent will apply this next turn", not "nothing happened" — gating that on `Observed` alone would have stripped preference memory from every codex conversation. `CommandAck` remains excluded.
- The confirmation wire strings are pinned by a test — AionUi matches on these literals and they come from a serde derive, so a rename would silently push the frontend into its error path with nothing failing here.
- A pushed frame replaces the frontend's whole snapshot, so it must carry every axis. Emitting it on `ConfigChanged` surfaced a latent bug where axes the user never touched went out as `null`, blanking the thinking-effort picker on every mode switch; the pump now applies the same `override → caps` fallback REST does.
- ACP's legacy `set_mode` still reports `Observed` despite its empty ack. Flipping it would trade an occasional optimism for a permanent "pending" state, since ACP does not require the agent to emit `current_mode_update`. Left as a separate follow-up.

## Follow-ups

- **codex is unverified on the local CLI.** 0.144.6 is below the 0.146.0 whose schema this relies on, and no capture of its `thread/settings/update` exchange was obtained. Its `NextTurn` classification rests on the schema wording alone.
- **ACP's legacy `set_mode` still reports `Observed`** despite an empty ack (see Notes).
- **`feat/midturn-interjection` carries a claim this PR disproves.** Its `Command::Steer` arm is commented "no drain_pending_controls (a mid-turn config write reinitializes the CLI and truncates the turn)" (`claude_conn.rs:2826`). The 2.1.227 capture shows that does not happen. Correcting it belongs to that branch — it is not in this diff because `Steer` is still a stub on main.

## Related

Requires iOfficeAI/AionUi#4031 — the third confirmation state must ship in the same version, or the frontend treats it as an error.

## Verification

- `cargo test -p aionui-ai-agent -p aionui-session -p aionui-conversation -p aionui-api-types` — all green (939 / 561 / 380 / 510)
- `cargo clippy` on those crates with `-D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Every change made test-first; three of them additionally mutation-checked (removing the fix makes the new test fail for the expected reason).
