### PR TITLE
chore(acp): bump dimcode and nova registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -19,7 +19,7 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.11"
+      "version": "0.3.12"
     },
     "dirac": {
       "registry_json_id": "dirac",
@@ -48,7 +48,7 @@
     "nova": {
       "registry_json_id": "nova",
       "package": "@compass-ai/nova",
-      "version": "1.1.32"
+      "version": "1.1.34"
     },
     "omp": {
       "package": "@oh-my-pi/pi-coding-agent",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Two npx pins drifted since #837, each backed by a fresh serial ACP probe of the exact pinned version. Lock-only change — two lines; no metadata, migration, or entrypoint edits, and no lock-derived test assertion embeds either version.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| dimcode | `dimcode` | 0.3.11 → **0.3.12** | ok (agentInfo version 0.3.12) | auth required (`-32000`, "Provider credentials are required") |
| nova | `@compass-ai/nova` | 1.1.32 → **1.1.34** | ok (protocolVersion 1) | config required (`-32000`, "Click Nova Setup to configure your API keys", advertising `kore-terminal-auth`) |

Both meet the release-lock criterion: `initialize` succeeds and `session/new` returns a clearly classified authentication/configuration requirement. Probes ran serially with no inherited HOME or credentials. Nova skips 1.1.33 — the Registry advertises 1.1.34 directly, and that is the version probed and pinned.

The other 9 Registry-pinned packages (autohand, codebuddy, deepagents, dirac, glm-acp-agent, grok, kilo, pi, sigit) match the snapshot exactly. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. The `mimo-code` and `omp` entries are non-Registry builtins (no `registry_json_id`) and are correctly excluded from drift reconciliation.

**Both vendor self-report quirks persist, still not actionable** (see #837): dimcode's handshake reports `agentInfo.title` as "DimAgent" while the public Registry card and CDN entry say "DimCode" (`dimcode.dev` unchanged); nova reports `agentInfo` as `kore-cli` version `1.0.0`, matching neither its product name nor package version 1.1.34. Identity follows the public listing, so no metadata changes.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.13-02b629a`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.13-02b629a/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the previous baseline (38 ids).

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11; #810, #814, #822 and #837 all merged green under it). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock-only version bumps; existing startup/session error paths already identify a failing agent by backend.