### PR TITLE
chore(cli): bump verified claude to 2.1.231

### DIFF
--- a/crates/aionui-ai-agent/src/claude_flags.rs
+++ b/crates/aionui-ai-agent/src/claude_flags.rs
@@ -126,7 +126,7 @@ mod tests {
         assert!(!supported("2.1.0"), "2.1.0 hard-errors on --thinking-display");
         assert!(!supported("2.1.190"), "below the verified floor stays off");
         assert!(supported("2.1.191"), "lowest live-probed OK version");
-        assert!(supported("2.1.228"), "the release this integration is verified against");
+        assert!(supported("2.1.231"), "the release this integration is verified against");
         assert!(supported("2.1.220"));
         assert!(supported("3.0.0"), "a future major must not regress the gate");
     }

--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -35,7 +35,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// turn (its response stream disconnects with `httpStatusCode: null`, observed
 /// three times including a back-to-back control after three clean versions), so
 /// the verified release stops at 0.146.0 until upstream fixes it.
-pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.228";
+pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.231";
 pub const VERIFIED_CODEX_VERSION: &str = "0.146.0";
 pub const VERIFIED_AGY_VERSION: &str = "1.1.12";
 
@@ -449,8 +449,8 @@ mod tests {
     fn the_verified_release_says_nothing() {
         // Literal on purpose: this is the exact string a user on the verified
         // release reports, so the test breaks if a bump forgets to re-verify.
-        assert_eq!(classify("2.1.228", VERIFIED_CLAUDE_VERSION), VersionVerdict::Verified);
-        assert!(drift_notice("claude", "2.1.228", VERIFIED_CLAUDE_VERSION).is_none());
+        assert_eq!(classify("2.1.231", VERIFIED_CLAUDE_VERSION), VersionVerdict::Verified);
+        assert!(drift_notice("claude", "2.1.231", VERIFIED_CLAUDE_VERSION).is_none());
     }
 
     #[test]


### PR DESCRIPTION
`VERIFIED_CLAUDE_VERSION` 2.1.228 → 2.1.231, plus the three assertions pinned to it.

## Gates

| gate | verdict | evidence |
|---|---|---|
| A — contract | DEGRADED | claude publishes no protocol schema; only codex does |
| B — live e2e | **PASS 13/13** | 260.05s, 9 distinct WS frame types |
| C — release notes | CLEAR | 33 notes across the range; 2 carried a risk verb, none touched the 31 dependency tokens |

Three releases in one hop, so gate C covered `(2.1.228, 2.1.231]` rather than a single bump.

## Notes worth naming

Four entries in range **do** touch surfaces this integration consumes. All are fixes rather than removals, and all sit on paths gate B exercises:

- SSE keepalive pings on gateway streaming during long thinking pauses, preventing idle-timeout disconnects on Vertex and Bedrock;
- two `--resume` crash fixes — a non-string `glob`/`file_path` in a tool call, and a `RangeError` when a progress bar or markdown table renders in a narrow terminal;
- a 400 on whitespace-only messages under `--input-format stream-json`.

They are listed here rather than filtered silently: gate C's job is triage, and "informational" is a verdict about risk, not a reason to hide that the release touched `thinking`, `--resume` and `stream-json`.

## The candidate was already installed

The operator's claude had self-updated to 2.1.231, so no shim was needed and no symlink was moved — `~/.local/bin/claude` pointed at `2.1.231` before the run and still does.

**That the suite ran the candidate was confirmed from its own logs**, not assumed:

```
direct CLI version detected  cli=claude  version=2.1.231
```

## Record

`~/aion/protocols/samples/claude-cli/2.1.231/` — `qualification.json` (verdict PASS, zero blockers, the binary judged and its own `--version`) and the live-suite log with its `FRAME-TYPES` lines.

`THINKING_DISPLAY_MIN_VERSION` stays at 2.1.191, below the new constant.

## The other two

- **codex** — latest is still 0.147.0, the release that never completes a turn (`httpStatusCode: null`, three observations including a control). Stays at 0.146.0.
- **agy** — **no drift**: 1.1.12 is both the constant and the latest release, so no gate was run.

Constants only, no source change.