### PR TITLE
fix: restore direct CLI Team MCP capabilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,22 @@ Supports the same arguments as `git push` (e.g. `just push -u origin feat/branch
 2. Emit via `event_bus.broadcast()` in service
 3. Naming: `domain.camelCaseAction`
 
+### Add a Direct CLI Backend
+
+Before a direct CLI backend is considered complete:
+
+1. Implement the session/backend connection contract.
+2. Register a constructed backend capability descriptor.
+3. Declare only MCP transports verified by an approved source; leave unverified transports disabled.
+4. Implement and contract-test serialization for every declared MCP transport.
+5. Implement the vendor-specific policy that propagates runtime environment into tool subprocesses.
+6. Cite CLI self-description, official adapter/documentation, or captured real traffic for every capability claim.
+7. Add descriptor-to-serializer consistency tests.
+8. Add a real ignored/live E2E that observes an MCP `tools/call`.
+9. Add a real ignored/live E2E that reads a sentinel from a CLI fallback tool subprocess.
+
+Team transport selection must consume the unified capability resolver. Do not add backend-name branches to the Team domain.
+
 ## Test Organization
 
 | Location                                 | What goes there                        |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,22 +169,6 @@ Supports the same arguments as `git push` (e.g. `just push -u origin feat/branch
 2. Emit via `event_bus.broadcast()` in service
 3. Naming: `domain.camelCaseAction`
 
-### Add a Direct CLI Backend
-
-Before a direct CLI backend is considered complete:
-
-1. Implement the session/backend connection contract.
-2. Register a constructed backend capability descriptor.
-3. Declare only MCP transports verified by an approved source; leave unverified transports disabled.
-4. Implement and contract-test serialization for every declared MCP transport.
-5. Implement the vendor-specific policy that propagates runtime environment into tool subprocesses.
-6. Cite CLI self-description, official adapter/documentation, or captured real traffic for every capability claim.
-7. Add descriptor-to-serializer consistency tests.
-8. Add a real ignored/live E2E that observes an MCP `tools/call`.
-9. Add a real ignored/live E2E that reads a sentinel from a CLI fallback tool subprocess.
-
-Team transport selection must consume the unified capability resolver. Do not add backend-name branches to the Team domain.
-
 ## Test Organization
 
 | Location                                 | What goes there                        |

--- a/crates/aionui-ai-agent/src/factory/acp.rs
+++ b/crates/aionui-ai-agent/src/factory/acp.rs
@@ -28,7 +28,7 @@ use crate::runtime_status::conversation_runtime_reporter;
 /// talks: the frontend renders every non-aionrs agent through the ACP chat
 /// surface, so the backend label is the only thing that says which runtime a
 /// row really needs.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BackendRoute {
     /// claude/codex — direct-CLI via `build_session_instance`.
     DirectCli,
@@ -38,12 +38,25 @@ pub(crate) enum BackendRoute {
     AcpManager,
 }
 
+const CONFIGURED_NON_ACP_ROUTES: &[(&str, BackendRoute)] = &[
+    ("antigravity", BackendRoute::Antigravity),
+    ("claude", BackendRoute::DirectCli),
+    ("codex", BackendRoute::DirectCli),
+];
+
+fn configured_non_acp_routes() -> &'static [(&'static str, BackendRoute)] {
+    CONFIGURED_NON_ACP_ROUTES
+}
+
 pub(crate) fn route_for_backend(backend: Option<&str>) -> BackendRoute {
-    match backend {
-        Some("antigravity") => BackendRoute::Antigravity,
-        Some("claude" | "codex") => BackendRoute::DirectCli,
-        _ => BackendRoute::AcpManager,
-    }
+    backend
+        .and_then(|backend| {
+            configured_non_acp_routes()
+                .iter()
+                .find(|(registered, _)| *registered == backend)
+                .map(|(_, route)| *route)
+        })
+        .unwrap_or(BackendRoute::AcpManager)
 }
 
 pub(super) async fn build(
@@ -1213,6 +1226,37 @@ mod tests {
     fn claude_and_codex_keep_the_direct_cli_route() {
         assert_eq!(route_for_backend(Some("claude")), BackendRoute::DirectCli);
         assert_eq!(route_for_backend(Some("codex")), BackendRoute::DirectCli);
+    }
+
+    #[test]
+    fn every_registered_direct_descriptor_has_a_non_acp_factory_route() {
+        for descriptor in aionui_session::backend_capability_descriptors()
+            .iter()
+            .filter(|descriptor| descriptor.origin == aionui_common::CapabilityOrigin::DirectDescriptor)
+        {
+            assert_ne!(
+                route_for_backend(Some(descriptor.backend_id)),
+                BackendRoute::AcpManager,
+                "direct backend {} has a capability descriptor but no direct factory route; register its runtime before declaring the descriptor",
+                descriptor.backend_id
+            );
+        }
+    }
+
+    #[test]
+    fn every_non_acp_factory_route_has_a_direct_descriptor() {
+        for (backend, _) in configured_non_acp_routes() {
+            let descriptor = aionui_session::backend_capability_descriptor(backend).unwrap_or_else(|| {
+                panic!(
+                    "direct factory backend {backend} has no capability descriptor; register its verified capabilities before routing it outside ACP"
+                )
+            });
+            assert_eq!(
+                descriptor.origin,
+                aionui_common::CapabilityOrigin::DirectDescriptor,
+                "non-ACP factory backend {backend} must use a direct capability descriptor"
+            );
+        }
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/factory/acp_launch_policy.rs
+++ b/crates/aionui-ai-agent/src/factory/acp_launch_policy.rs
@@ -4,9 +4,6 @@ use crate::shared_kernel::PersistedSessionState;
 use aionui_api_types::{AcpBuildExtra, AgentMetadata};
 use aionui_common::CommandSpec;
 
-const CODEX_CONFIG_FLAG: &str = "-c";
-const CODEX_ENV_POLICY_INHERIT_ALL: &str = "shell_environment_policy.inherit=all";
-const CODEX_ENV_POLICY_CLEAR_INCLUDE_ONLY: &str = "shell_environment_policy.include_only=[]";
 const CODEX_WINDOWS_UNELEVATED_SANDBOX: &str = "windows.sandbox=\"unelevated\"";
 
 pub(super) struct AcpLaunchPolicyInput<'a> {
@@ -81,8 +78,9 @@ fn apply_codex_runtime_config_args(
         return;
     }
 
-    push_codex_config_arg(command_spec, CODEX_ENV_POLICY_INHERIT_ALL);
-    push_codex_config_arg(command_spec, CODEX_ENV_POLICY_CLEAR_INCLUDE_ONLY);
+    command_spec
+        .args
+        .extend(aionui_session::codex_shell_environment_policy_args().map(str::to_owned));
 
     let sandbox_mode = codex_sandbox_mode_for_requested_mode(initial_mode);
     push_codex_config_arg(command_spec, &format!("sandbox_mode=\"{sandbox_mode}\""));
@@ -92,7 +90,7 @@ fn apply_codex_runtime_config_args(
 }
 
 fn push_codex_config_arg(command_spec: &mut CommandSpec, value: &str) {
-    command_spec.args.push(CODEX_CONFIG_FLAG.to_owned());
+    command_spec.args.push("-c".to_owned());
     command_spec.args.push(value.to_owned());
 }
 

--- a/crates/aionui-ai-agent/src/lib.rs
+++ b/crates/aionui-ai-agent/src/lib.rs
@@ -41,6 +41,7 @@ pub use agent_runtime::AgentRuntime;
 pub use agent_task::IMockAgent;
 pub use agent_task::{AgentInstance, IAgentTask};
 pub use aionui_api_types::{AcpBuildExtra, AcpModelInfo, AionrsBuildExtra, SlashCommandItem};
+pub use aionui_session::effective_agent_capabilities;
 pub use capability::skill_manager::{
     AcpSkillManager, SkillDefinition, SkillIndex, build_skills_index_text, build_system_instructions,
     build_system_instructions_with_skills_index, detect_skill_load_request, prepare_first_message,

--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -789,8 +789,14 @@ fn decode_row(
     let behavior_policy =
         decode_json_field(row.behavior_policy.as_deref(), "behavior_policy").unwrap_or_else(BehaviorPolicy::default);
 
+    let persisted_backend = row.backend.as_deref().unwrap_or("");
+    let runtime_backend = aionui_db::runtime_backend_for_agent(&row);
+    let persisted_agent_capabilities = parse_json(row.agent_capabilities.as_deref(), "agent_capabilities");
     let handshake = AgentHandshake {
-        agent_capabilities: parse_json(row.agent_capabilities.as_deref(), "agent_capabilities"),
+        agent_capabilities: crate::effective_agent_capabilities(
+            &runtime_backend,
+            persisted_agent_capabilities.as_ref(),
+        ),
         auth_methods: parse_json(row.auth_methods.as_deref(), "auth_methods"),
         config_options: parse_json(row.config_options.as_deref(), "config_options"),
         available_modes: parse_json(row.available_modes.as_deref(), "available_modes"),
@@ -798,20 +804,19 @@ fn decode_row(
         available_commands: parse_json(row.available_commands.as_deref(), "available_commands"),
     };
 
-    let backend_str = row.backend.as_deref().unwrap_or("");
     // Team MEMBERSHIP (may this agent be picked into a team) — distinct from the
-    // team TRANSPORT chosen later at provisioning time, which reads capabilities
-    // only. Whitelist first, inference second:
-    //   - `supports_team` is the known-good opt-in (migration 014). It carries
-    //     agents whose `agent_capabilities` are still NULL because they have never
-    //     handshaken on this machine (claude/codex/gemini on a fresh install), and
-    //     aionrs, whose NULL backend the inference cannot judge at all.
-    //   - otherwise infer from the advertised MCP transports / CLI eligibility.
+    // transport chosen later at provisioning time. Constructed descriptors are
+    // authoritative for direct/internal backends; ACP agents retain the persisted
+    // handshake plus conservative CLI eligibility inference.
     // There is deliberately no veto flag on this path: a stored "false" could not
     // be lifted once an agent proved itself, since builtin rows reject metadata
     // edits through the agent API.
+    let descriptor_team_capable = aionui_session::backend_capability_descriptor(&runtime_backend)
+        .map(aionui_session::BackendCapabilityDescriptor::resolved)
+        .is_some_and(|capabilities| capabilities.mcp.stdio || capabilities.cli_fallback);
     let team_capable = behavior_policy.supports_team
-        || aionui_common::constants::is_team_capable(backend_str, handshake.agent_capabilities.as_ref());
+        || descriptor_team_capable
+        || aionui_common::constants::is_team_capable(persisted_backend, handshake.agent_capabilities.as_ref());
 
     let mut meta = AgentMetadata {
         id: row.id,
@@ -1633,6 +1638,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn direct_cli_metadata_projects_constructed_mcp_capabilities() {
+        let reg = registry().await;
+        for (backend, sse, http) in [
+            ("claude", true, true),
+            ("codex", false, true),
+            ("antigravity", true, false),
+        ] {
+            let meta = reg.find_builtin_by_backend(backend).await.unwrap();
+            assert!(meta.team_capable, "{backend} descriptor makes it Team-selectable");
+            let mcp = meta
+                .handshake
+                .agent_capabilities
+                .as_ref()
+                .and_then(|caps| caps.get("mcp_capabilities"))
+                .unwrap_or_else(|| panic!("{backend} effective MCP projection"));
+            assert_eq!(mcp["stdio"], true, "{backend}");
+            assert_eq!(mcp["sse"], sse, "{backend}");
+            assert_eq!(mcp["http"], http, "{backend}");
+        }
+    }
+
+    #[tokio::test]
+    async fn internal_metadata_projects_constructed_mcp_capabilities_when_backend_is_null() {
+        let reg = registry().await;
+        let aionrs = reg.get("632f31d2").await.expect("seeded aionrs metadata");
+        let mcp = aionrs
+            .handshake
+            .agent_capabilities
+            .as_ref()
+            .and_then(|caps| caps.get("mcp_capabilities"))
+            .expect("aionrs effective MCP projection");
+
+        assert_eq!(mcp["stdio"], true);
+        assert_eq!(mcp["sse"], false);
+        assert_eq!(mcp["http"], false);
+    }
+
+    #[tokio::test]
     async fn hermes_builtin_does_not_advertise_a_yolo_id() {
         let reg = registry().await;
         let hermes = reg.find_builtin_by_backend("hermes").await.unwrap();
@@ -1903,11 +1946,21 @@ mod tests {
         .await
         .unwrap();
 
+        let persisted = reg.repo.get(&claude.id).await.unwrap().unwrap();
+        assert_eq!(
+            parse_json(persisted.agent_capabilities.as_deref(), "agent_capabilities"),
+            Some(serde_json::json!({"load_session": true})),
+            "persisted agent_capabilities must survive later partial writes"
+        );
         let refreshed = reg.get(&claude.id).await.unwrap();
         assert_eq!(
-            refreshed.handshake.agent_capabilities,
-            Some(serde_json::json!({"load_session": true})),
-            "agent_capabilities must survive later partial writes"
+            refreshed
+                .handshake
+                .agent_capabilities
+                .as_ref()
+                .and_then(|capabilities| capabilities.get("load_session")),
+            Some(&serde_json::Value::Bool(true)),
+            "effective projection must retain persisted handshake fields"
         );
         assert!(
             refreshed.handshake.auth_methods.is_some(),
@@ -1975,10 +2028,21 @@ mod tests {
             .await
             .unwrap();
 
+        let persisted = reg.repo.get(&claude.id).await.unwrap().unwrap();
+        assert_eq!(
+            parse_json(persisted.agent_capabilities.as_deref(), "agent_capabilities"),
+            Some(serde_json::json!({"x": 1}))
+        );
         let refreshed = reg.get(&claude.id).await.unwrap();
         assert_eq!(
-            refreshed.handshake.agent_capabilities,
-            Some(serde_json::json!({"x": 1}))
+            refreshed
+                .handshake
+                .agent_capabilities
+                .as_ref()
+                .and_then(|capabilities| capabilities.get("x"))
+                .and_then(serde_json::Value::as_i64),
+            Some(1),
+            "effective projection must retain the unchanged persisted field"
         );
     }
 

--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -1640,22 +1640,30 @@ mod tests {
     #[tokio::test]
     async fn direct_cli_metadata_projects_constructed_mcp_capabilities() {
         let reg = registry().await;
-        for (backend, sse, http) in [
-            ("claude", true, true),
-            ("codex", false, true),
-            ("antigravity", true, false),
-        ] {
-            let meta = reg.find_builtin_by_backend(backend).await.unwrap();
-            assert!(meta.team_capable, "{backend} descriptor makes it Team-selectable");
+        for descriptor in aionui_session::backend_capability_descriptors()
+            .iter()
+            .filter(|descriptor| descriptor.origin == aionui_common::CapabilityOrigin::DirectDescriptor)
+        {
+            let backend = descriptor.backend_id;
+            let meta = reg.find_builtin_by_backend(backend).await.unwrap_or_else(|| {
+                panic!(
+                    "direct backend {backend} has a capability descriptor but no builtin registry entry; register both together"
+                )
+            });
+            assert_eq!(
+                meta.team_capable,
+                descriptor.mcp.stdio || descriptor.cli_fallback,
+                "direct backend {backend} Team eligibility must come from its constructed descriptor"
+            );
             let mcp = meta
                 .handshake
                 .agent_capabilities
                 .as_ref()
                 .and_then(|caps| caps.get("mcp_capabilities"))
                 .unwrap_or_else(|| panic!("{backend} effective MCP projection"));
-            assert_eq!(mcp["stdio"], true, "{backend}");
-            assert_eq!(mcp["sse"], sse, "{backend}");
-            assert_eq!(mcp["http"], http, "{backend}");
+            assert_eq!(mcp["stdio"], descriptor.mcp.stdio, "{backend}");
+            assert_eq!(mcp["sse"], descriptor.mcp.sse, "{backend}");
+            assert_eq!(mcp["http"], descriptor.mcp.streamable_http, "{backend}");
         }
     }
 

--- a/crates/aionui-api-types/src/conversation.rs
+++ b/crates/aionui-api-types/src/conversation.rs
@@ -81,8 +81,8 @@ pub struct ForkConversationRequest {
 }
 
 /// Prompt media capability projection for one conversation, sourced from
-/// `agent_metadata.agent_capabilities.prompt_capabilities` (ACP agents:
-/// handshake-persisted; claude/codex: migration-constructed, 037). `None` =
+/// the effective `prompt_capabilities` projection (ACP handshake or constructed
+/// backend descriptor). `None` =
 /// unknown/unsupported — the UI then hints that media attachments are sent
 /// as file paths. Filled only on the single-conversation detail path (list
 /// responses omit it — no N+1).
@@ -97,8 +97,8 @@ pub struct PromptCapabilityView {
 }
 
 /// Session-fork capability projection for one conversation, sourced from
-/// `agent_metadata.agent_capabilities.session_capabilities.fork` (ACP agents:
-/// handshake-persisted; claude/codex: migration-constructed). `Some` = the fork
+/// the effective `session_capabilities.fork` projection (ACP handshake or
+/// constructed backend descriptor). `Some` = the fork
 /// entry point may be shown; `None` = hidden. Filled only on the single-
 /// conversation detail path (list responses omit it — no N+1).
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/aionui-app/src/router/mod.rs
+++ b/crates/aionui-app/src/router/mod.rs
@@ -10,6 +10,7 @@ mod runtime_team_tools;
 mod scm_monitor;
 mod state;
 mod system_file_opener;
+mod team_capability_resolver;
 mod team_conversation_adapters;
 mod trace;
 

--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -49,6 +49,7 @@ use aionui_team::{
 };
 
 use crate::config::{IdentityMode, derive_encryption_key};
+use crate::router::team_capability_resolver::TeamCapabilityResolver;
 use crate::router::team_conversation_adapters::TeamConversationAdapters;
 use crate::services::AppServices;
 
@@ -262,12 +263,7 @@ pub async fn build_module_states(
     .await;
     tracing::info!(elapsed_ms = boot.elapsed().as_millis(), "startup: channel state built");
 
-    let backend_binary_path = Arc::new(
-        std::env::current_exe()
-            .ok()
-            .and_then(|p| p.canonicalize().ok())
-            .unwrap_or_else(|| std::path::PathBuf::from("aioncore")),
-    );
+    let backend_binary_path = services.backend_binary_path();
     tracing::info!(
         elapsed_ms = boot.elapsed().as_millis(),
         "startup: backend binary path resolved"
@@ -679,9 +675,9 @@ pub async fn build_channel_state(
 
 /// Build the default `TeamRouterState` from application services.
 ///
-/// `backend_binary_path` is resolved once in `build_module_states` via
-/// `std::env::current_exe()` and cloned into each builder that needs it,
-/// per `docs/teams/phase1/interface-contracts.md` §10.
+/// `backend_binary_path` is resolved once while constructing `AppServices` and
+/// cloned into each builder that needs it, per
+/// `docs/teams/phase1/interface-contracts.md` §10.
 pub fn build_team_state(
     services: &AppServices,
     _cron_service: Option<Arc<aionui_cron::service::CronService>>,
@@ -742,6 +738,9 @@ pub fn build_team_state(
     let turn_port: Arc<dyn AgentTurnExecutionPort> = adapters.clone();
     let slash_command_port: Arc<dyn NativeSlashCommandPort> = adapters.clone();
     let cancellation_port: Arc<dyn AgentTurnCancellationPort> = adapters;
+    let capability_port: Arc<dyn aionui_team::TeamToolCapabilityPort> = Arc::new(TeamCapabilityResolver::new(
+        Arc::new(SqliteAgentMetadataRepository::new(services.database.pool().clone())),
+    ));
     let service = TeamSessionService::new_with_prompt_dump(
         team_repo,
         Arc::new(SqliteAgentMetadataRepository::new(services.database.pool().clone())),
@@ -758,6 +757,7 @@ pub fn build_team_state(
         turn_port,
         cancellation_port,
         slash_command_port,
+        capability_port,
         backend_binary_path,
         aionui_team::TeamPromptDumpConfig::from_data_dir(&services.data_dir, services.dump_prompts),
     );

--- a/crates/aionui-app/src/router/team_capability_resolver.rs
+++ b/crates/aionui-app/src/router/team_capability_resolver.rs
@@ -1,0 +1,182 @@
+use std::sync::Arc;
+
+use aionui_common::{CapabilityOrigin, McpTransportCapabilities, ResolvedBackendCapabilities};
+use aionui_db::{IAgentMetadataRepository, resolve_agent_binding_from_rows};
+use aionui_team::{TeamError, TeamToolCapabilityPort};
+
+pub(crate) struct TeamCapabilityResolver {
+    repo: Arc<dyn IAgentMetadataRepository>,
+}
+
+impl TeamCapabilityResolver {
+    pub(crate) fn new(repo: Arc<dyn IAgentMetadataRepository>) -> Self {
+        Self { repo }
+    }
+}
+
+fn bool_field(value: &serde_json::Value, key: &str) -> bool {
+    value.get(key).and_then(serde_json::Value::as_bool) == Some(true)
+}
+
+fn explicit_false(value: &serde_json::Value, path: &[&str]) -> bool {
+    let mut cursor = value;
+    for key in path {
+        let Some(next) = cursor.get(*key) else {
+            return false;
+        };
+        cursor = next;
+    }
+    cursor.as_bool() == Some(false)
+}
+
+fn resolve_acp_handshake(capabilities: Option<&serde_json::Value>) -> ResolvedBackendCapabilities {
+    let Some(capabilities) = capabilities else {
+        return ResolvedBackendCapabilities {
+            cli_fallback: true,
+            ..Default::default()
+        };
+    };
+    let mcp = capabilities
+        .get("mcp_capabilities")
+        .or_else(|| capabilities.get("mcpCapabilities"))
+        .or_else(|| capabilities.get("mcp"));
+    let streamable_http = mcp.is_some_and(|mcp| bool_field(mcp, "http"));
+    let sse = mcp.is_some_and(|mcp| bool_field(mcp, "sse"));
+    let cli_fallback = ![
+        &["shell"][..],
+        &["cli"][..],
+        &["supports_shell"][..],
+        &["supportsShell"][..],
+        &["supports_cli"][..],
+        &["supportsCli"][..],
+        &["execution", "shell"][..],
+        &["execution", "cli"][..],
+    ]
+    .iter()
+    .any(|path| explicit_false(capabilities, path));
+    ResolvedBackendCapabilities {
+        // ACP's stdio support is conservatively inferred only when at least one
+        // optional MCP transport was positively advertised, preserving the
+        // existing live-probed compatibility heuristic.
+        mcp: McpTransportCapabilities {
+            stdio: streamable_http || sse,
+            sse,
+            streamable_http,
+        },
+        cli_fallback,
+        origin: CapabilityOrigin::AcpHandshake,
+    }
+}
+
+#[async_trait::async_trait]
+impl TeamToolCapabilityPort for TeamCapabilityResolver {
+    async fn resolve(
+        &self,
+        user_id: &str,
+        backend: &str,
+        agent_id: Option<&str>,
+    ) -> Result<ResolvedBackendCapabilities, TeamError> {
+        if let Some(descriptor) = aionui_session::backend_capability_descriptor(backend) {
+            return Ok(descriptor.resolved());
+        }
+
+        let rows = self.repo.list_all_for_user(user_id).await?;
+        let selected_id = agent_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+            .or_else(|| resolve_agent_binding_from_rows(&rows, backend).map(|binding| binding.agent_id));
+        let Some(row) = selected_id.and_then(|id| rows.into_iter().find(|row| row.id == id)) else {
+            return Ok(ResolvedBackendCapabilities {
+                cli_fallback: true,
+                ..Default::default()
+            });
+        };
+        let Some(raw) = row
+            .agent_capabilities
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return Ok(ResolvedBackendCapabilities {
+                cli_fallback: true,
+                ..Default::default()
+            });
+        };
+        let capabilities = match serde_json::from_str::<serde_json::Value>(raw) {
+            Ok(capabilities) => capabilities,
+            Err(error) => {
+                tracing::warn!(
+                    backend,
+                    agent_id = %row.id,
+                    error = %error,
+                    "ignoring malformed persisted backend capability snapshot"
+                );
+                return Ok(ResolvedBackendCapabilities {
+                    cli_fallback: true,
+                    ..Default::default()
+                });
+            }
+        };
+        Ok(resolve_acp_handshake(Some(&capabilities)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aionui_db::{SqliteAgentMetadataRepository, init_database_memory};
+
+    async fn direct_matrix(snapshot: Option<&str>) -> Vec<ResolvedBackendCapabilities> {
+        let db = init_database_memory().await.unwrap();
+        if let Some(snapshot) = snapshot {
+            for id in ["2d23ff1c", "8e1acf31", "a9f3c21e"] {
+                sqlx::query("UPDATE agent_metadata SET agent_capabilities = ? WHERE agent_id = ?")
+                    .bind(snapshot)
+                    .bind(id)
+                    .execute(db.pool())
+                    .await
+                    .unwrap();
+            }
+        }
+        let resolver = TeamCapabilityResolver::new(Arc::new(SqliteAgentMetadataRepository::new(db.pool().clone())));
+        let mut resolved = Vec::new();
+        for backend in ["claude", "codex", "antigravity"] {
+            resolved.push(resolver.resolve("system_default_user", backend, None).await.unwrap());
+        }
+        resolved
+    }
+
+    #[tokio::test]
+    async fn direct_capabilities_are_identical_for_fresh_and_historical_databases() {
+        let fresh = direct_matrix(None).await;
+        let historical_true = direct_matrix(Some(r#"{"mcp_capabilities":{"http":true,"sse":true}}"#)).await;
+        let historical_false = direct_matrix(Some(r#"{"mcp_capabilities":{}}"#)).await;
+
+        assert_eq!(fresh, historical_true);
+        assert_eq!(fresh, historical_false);
+        assert!(
+            fresh.iter().all(|caps| {
+                caps.origin == CapabilityOrigin::DirectDescriptor && caps.mcp.stdio && caps.cli_fallback
+            })
+        );
+    }
+
+    #[test]
+    fn acp_resolution_preserves_positive_unknown_and_explicit_no_shell_cases() {
+        let positive = serde_json::json!({"mcp_capabilities": {"http": true, "sse": false}});
+        let positive = resolve_acp_handshake(Some(&positive));
+        assert_eq!(positive.origin, CapabilityOrigin::AcpHandshake);
+        assert!(positive.mcp.stdio);
+
+        let unknown = resolve_acp_handshake(None);
+        assert_eq!(unknown.origin, CapabilityOrigin::Unknown);
+        assert!(unknown.cli_fallback);
+
+        let no_shell = serde_json::json!({"mcp_capabilities": {}, "execution": {"shell": false}});
+        let no_shell = resolve_acp_handshake(Some(&no_shell));
+        assert_eq!(no_shell.origin, CapabilityOrigin::AcpHandshake);
+        assert!(!no_shell.mcp.stdio);
+        assert!(!no_shell.cli_fallback);
+    }
+}

--- a/crates/aionui-app/src/router/team_capability_resolver.rs
+++ b/crates/aionui-app/src/router/team_capability_resolver.rs
@@ -141,8 +141,26 @@ mod tests {
         }
         let resolver = TeamCapabilityResolver::new(Arc::new(SqliteAgentMetadataRepository::new(db.pool().clone())));
         let mut resolved = Vec::new();
-        for backend in ["claude", "codex", "antigravity"] {
-            resolved.push(resolver.resolve("system_default_user", backend, None).await.unwrap());
+        for descriptor in aionui_session::backend_capability_descriptors()
+            .iter()
+            .filter(|descriptor| descriptor.origin == CapabilityOrigin::DirectDescriptor)
+        {
+            let capabilities = resolver
+                .resolve("system_default_user", descriptor.backend_id, None)
+                .await
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "registered direct backend {} did not resolve its constructed capabilities: {error}",
+                        descriptor.backend_id
+                    )
+                });
+            assert_eq!(
+                capabilities,
+                descriptor.resolved(),
+                "registered direct backend {} bypassed its constructed descriptor",
+                descriptor.backend_id
+            );
+            resolved.push(capabilities);
         }
         resolved
     }
@@ -156,9 +174,9 @@ mod tests {
         assert_eq!(fresh, historical_true);
         assert_eq!(fresh, historical_false);
         assert!(
-            fresh.iter().all(|caps| {
-                caps.origin == CapabilityOrigin::DirectDescriptor && caps.mcp.stdio && caps.cli_fallback
-            })
+            fresh
+                .iter()
+                .all(|caps| caps.origin == CapabilityOrigin::DirectDescriptor)
         );
     }
 

--- a/crates/aionui-app/src/services.rs
+++ b/crates/aionui-app/src/services.rs
@@ -60,6 +60,7 @@ pub struct AppServices {
     pub skill_paths: Arc<aionui_extension::SkillPaths>,
     /// User skill metadata and import history repository.
     pub skill_repo: Arc<dyn ISkillRepository>,
+    backend_binary_path: Arc<PathBuf>,
     runtime_helper_bin: String,
     runtime_base_url: String,
     /// Shared with the Antigravity hook endpoint so it can authenticate callbacks.
@@ -73,6 +74,10 @@ impl AppServices {
 
     pub(crate) fn runtime_base_url(&self) -> String {
         self.runtime_base_url.clone()
+    }
+
+    pub(crate) fn backend_binary_path(&self) -> Arc<PathBuf> {
+        self.backend_binary_path.clone()
     }
 
     /// Replace the worker task manager after construction.
@@ -99,6 +104,21 @@ impl AppServices {
     }
 
     pub async fn from_config(database: Database, config: &AppConfig) -> anyhow::Result<Self> {
+        let backend_binary_path = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("aioncore"));
+        Self::from_config_with_backend_binary_path(database, config, backend_binary_path).await
+    }
+
+    /// Construct application services with an explicitly resolved backend binary.
+    ///
+    /// Runtime entry points should use [`Self::from_config`]. This variant lets
+    /// integration tests run the real `aioncore` MCP/helper subcommands instead
+    /// of accidentally respawning the test harness returned by `current_exe()`.
+    pub async fn from_config_with_backend_binary_path(
+        database: Database,
+        config: &AppConfig,
+        backend_binary_path: PathBuf,
+    ) -> anyhow::Result<Self> {
+        let backend_binary_path = backend_binary_path.canonicalize().unwrap_or(backend_binary_path);
         let data_dir = config.data_dir.clone();
         let work_dir = config.work_dir.clone();
         let identity_mode = config.effective_identity_mode();
@@ -210,8 +230,7 @@ impl AppServices {
         // Absolute path to this process's binary. Reused as the `command` for
         // the stdio MCP bridge spawned by ACP CLIs when a team session is
         // attached to a conversation (phase1 mcp.md §4.6 single-binary model).
-        let backend_binary_path =
-            Arc::new(std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("aioncore")));
+        let backend_binary_path = Arc::new(backend_binary_path);
         let runtime_helper_bin = backend_binary_path.to_string_lossy().into_owned();
         let runtime_base_url = config.local_base_url();
         let antigravity_hook_tokens = Arc::new(aionui_ai_agent::antigravity_hook::HookTokenRegistry::new());
@@ -305,6 +324,7 @@ impl AppServices {
             app_version,
             skill_paths,
             skill_repo,
+            backend_binary_path,
             runtime_helper_bin,
             runtime_base_url,
         })

--- a/crates/aionui-app/tests/live_ws_http_parity_e2e.rs
+++ b/crates/aionui-app/tests/live_ws_http_parity_e2e.rs
@@ -45,11 +45,21 @@ async fn start_live_app() -> LiveApp {
 /// exists in the shared database and `setup_and_login` panics trying to create
 /// it again.
 async fn start_live_app_on(db: aionui_db::Database, create_user: bool) -> LiveApp {
-    let services = AppServices::from_config(db, &AppConfig::default()).await.unwrap();
-    let mut router = create_router(&services).await.expect("build router");
-
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
+    let config = AppConfig {
+        port: addr.port(),
+        ..AppConfig::default()
+    };
+    let services = AppServices::from_config_with_backend_binary_path(
+        db,
+        &config,
+        std::path::PathBuf::from(env!("CARGO_BIN_EXE_aioncore")),
+    )
+    .await
+    .unwrap();
+    let mut router = create_router(&services).await.expect("build router");
+
     let serve_router = router.clone();
     tokio::spawn(async move {
         axum::serve(listener, serve_router).await.unwrap();
@@ -995,6 +1005,175 @@ async fn run_backend_mcp_provisioning(backend: &str) {
     record_frame_types(backend, &frames.lock().unwrap().clone());
 }
 
+/// Release-gate probe for direct CLI Team MCP plus tool-shell environment.
+///
+/// This deliberately requires a real `tools/call`, not merely MCP startup, and
+/// requires a real command-execution child to read the sentinel. A final text
+/// answer by itself is insufficient: the streamed tool cards must also name the
+/// Team MCP tool and a shell tool.
+async fn run_direct_backend_team_mcp_and_runtime_env(backend: &str, agent_id: &str) {
+    const SENTINEL: &str = "AIONUI_DIRECT_CLI_E2E_42";
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::new(
+            "aionui_app=info,aionui_ai_agent=info,aionui_session=info,aionui_team=info",
+        ))
+        .with_test_writer()
+        .try_init();
+    assert_eq!(
+        std::env::var("AIONUI_E2E_SENTINEL").as_deref(),
+        Ok(SENTINEL),
+        "run this ignored release gate with AIONUI_E2E_SENTINEL={SENTINEL}"
+    );
+
+    let app = start_live_app().await;
+    let suffix = aionui_common::now_ms();
+    let assistant_id = format!("live-team-{backend}-{suffix}");
+    let assistant = http_json(
+        &app,
+        "POST",
+        "/api/assistants",
+        json!({
+            "id": assistant_id,
+            "name": format!("Live Team {backend}"),
+            "agent_id": agent_id,
+        }),
+    )
+    .await;
+    assert_eq!(
+        assistant["success"], true,
+        "[{backend}] assistant create failed: {assistant}"
+    );
+
+    let workspace = std::env::temp_dir().join(format!("live-team-{backend}-{suffix}"));
+    std::fs::create_dir_all(&workspace).unwrap();
+    let created = http_json(
+        &app,
+        "POST",
+        "/api/teams",
+        json!({
+            "name": format!("Live {backend} Team"),
+            "workspace": workspace,
+            "agents": [{
+                "name": "Lead",
+                "role": "lead",
+                "model": "",
+                "assistant_id": assistant_id,
+            }]
+        }),
+    )
+    .await;
+    let team = &created["data"];
+    let team_id = team["id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("[{backend}] team create failed: {created}"));
+    let conversation_id = team["assistants"][0]["conversation_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("[{backend}] team lead has no conversation: {created}"));
+
+    let ensured = http_json(&app, "POST", &format!("/api/teams/{team_id}/session"), json!({})).await;
+    assert_eq!(
+        ensured["success"], true,
+        "[{backend}] Team session ensure failed: {ensured}"
+    );
+
+    let messages_uri = format!("/api/teams/{team_id}/messages");
+    // Exercise the CLI fallback first. Besides proving the tool-child runtime
+    // environment on a fresh session, this establishes the vendor conversation
+    // anchor before the independent MCP assertion below.
+    let shell_frames = drive_and_collect_from_uri(
+        &app,
+        conversation_id,
+        &messages_uri,
+        "Now use your real shell/command-execution tool to run exactly: \
+         printf '{}\\n' | \"$AIONUI_HELPER_BIN\" team members >/dev/null && \
+         test \"$AIONUI_E2E_SENTINEL\" = \"AIONUI_DIRECT_CLI_E2E_42\" && echo AIONUI_ENV_OK. \
+         Only after the Team CLI fallback helper and sentinel check both succeed, reply with exactly: AIONUI_ENV_OK",
+        300,
+    )
+    .await;
+    let is_tool_frame = |frame: &&Value| {
+        matches!(
+            frame["data"]["type"].as_str(),
+            Some("tool_call") | Some("acp_tool_call")
+        )
+    };
+    let mcp_prompt = "Call the team_members MCP tool from the aionui-team MCP server now. \
+         Do not use AIONUI_HELPER_BIN or any CLI fallback for that call. \
+         Only after the MCP tool succeeds, reply with exactly: TEAM_MCP_OK";
+    let mut mcp_frames = Vec::new();
+    for _attempt in 0..3 {
+        mcp_frames.extend(drive_and_collect_from_uri(&app, conversation_id, &messages_uri, mcp_prompt, 300).await);
+        let evidence = serde_json::to_string(&mcp_frames.iter().filter(is_tool_frame).collect::<Vec<_>>()).unwrap();
+        if evidence.contains("team_members") {
+            break;
+        }
+    }
+
+    let mcp_tool_frames = mcp_frames.iter().filter(is_tool_frame).collect::<Vec<_>>();
+    let shell_tool_frames = shell_frames.iter().filter(is_tool_frame).collect::<Vec<_>>();
+    let tool_frames = mcp_tool_frames
+        .iter()
+        .chain(shell_tool_frames.iter())
+        .copied()
+        .collect::<Vec<_>>();
+    let mcp_tool_evidence = serde_json::to_string(&mcp_tool_frames).unwrap();
+    let shell_tool_evidence = serde_json::to_string(&shell_tool_frames).unwrap();
+    let tool_names = tool_frames
+        .iter()
+        .filter_map(|frame| {
+            frame["data"]["data"]["name"]
+                .as_str()
+                .or_else(|| frame["data"]["data"]["update"]["name"].as_str())
+        })
+        .collect::<BTreeSet<_>>();
+    assert!(
+        mcp_tool_evidence.contains("team_members"),
+        "[{backend}] no streamed Team MCP tools/call evidence; tool names={tool_names:?}"
+    );
+    assert!(
+        shell_tool_evidence.contains("AIONUI_HELPER_BIN")
+            && (shell_tool_evidence.contains("AIONUI_E2E_SENTINEL") || shell_tool_evidence.contains("AIONUI_ENV_OK")),
+        "[{backend}] no streamed shell/command-execution evidence for the Team CLI fallback and sentinel check; \
+         tool names={tool_names:?}"
+    );
+    let tool_call_ids = tool_frames
+        .iter()
+        .filter_map(|frame| {
+            frame["data"]["data"]["call_id"]
+                .as_str()
+                .or_else(|| frame["data"]["data"]["tool_call_id"].as_str())
+                .or_else(|| frame["data"]["data"]["update"]["tool_call_id"].as_str())
+        })
+        .collect::<BTreeSet<_>>();
+    assert!(
+        tool_call_ids.len() >= 2,
+        "[{backend}] expected distinct Team MCP and shell tool calls, got {tool_call_ids:?}; \
+         tool names={tool_names:?}"
+    );
+    let mcp_reply = mcp_frames
+        .iter()
+        .filter_map(|frame| match frame["data"]["type"].as_str() {
+            Some("text" | "content") => frame["data"]["data"]["content"].as_str(),
+            _ => None,
+        })
+        .collect::<String>();
+    assert!(
+        mcp_reply.contains("TEAM_MCP_OK"),
+        "[{backend}] MCP call failed; reply={mcp_reply:?}"
+    );
+    let shell_reply = shell_frames
+        .iter()
+        .filter_map(|frame| match frame["data"]["type"].as_str() {
+            Some("text" | "content") => frame["data"]["data"]["content"].as_str(),
+            _ => None,
+        })
+        .collect::<String>();
+    assert!(
+        shell_reply.contains("AIONUI_ENV_OK"),
+        "[{backend}] Team CLI fallback or tool-shell sentinel failed; reply={shell_reply:?}"
+    );
+}
+
 /// The approval card, actually raised and actually answered.
 ///
 /// The full-access test asserts a permission frame does NOT appear; nothing
@@ -1135,16 +1314,32 @@ fn record_frame_types(label: &str, frames: &[Value]) {
 }
 
 async fn drive_and_collect(app: &LiveApp, conv_id: &str, prompt: &str, timeout_s: u64) -> Vec<Value> {
-    let frames = connect_ws_recorder(app.addr, &app.token).await;
-    http_json(
+    drive_and_collect_from_uri(
         app,
-        "POST",
+        conv_id,
         &format!("/api/conversations/{conv_id}/messages"),
-        json!({ "content": prompt }),
+        prompt,
+        timeout_s,
     )
-    .await;
+    .await
+}
+
+async fn drive_and_collect_from_uri(
+    app: &LiveApp,
+    conv_id: &str,
+    uri: &str,
+    prompt: &str,
+    timeout_s: u64,
+) -> Vec<Value> {
+    let frames = connect_ws_recorder(app.addr, &app.token).await;
+    let sent = http_json(app, "POST", uri, json!({ "content": prompt })).await;
+    assert_eq!(
+        sent["success"], true,
+        "message send was rejected before the live CLI turn started: {sent}"
+    );
 
     let started = Instant::now();
+    let mut terminal = false;
     while started.elapsed() < Duration::from_secs(timeout_s) {
         tokio::time::sleep(Duration::from_millis(300)).await;
         let snapshot = frames.lock().unwrap().clone();
@@ -1152,8 +1347,35 @@ async fn drive_and_collect(app: &LiveApp, conv_id: &str, prompt: &str, timeout_s
             .iter()
             .any(|f| matches!(f["data"]["type"].as_str(), Some("finish") | Some("error")))
         {
+            terminal = true;
             break;
         }
+    }
+    if !terminal {
+        let snapshot = frames.lock().unwrap().clone();
+        let collected: Vec<Value> = stream_frames_for(&snapshot, conv_id).into_iter().cloned().collect();
+        record_frame_types(conv_id, &collected);
+        let tool_summary = collected
+            .iter()
+            .filter_map(|frame| {
+                let frame_type = frame["data"]["type"].as_str()?;
+                if !matches!(frame_type, "tool_call" | "acp_tool_call") {
+                    return None;
+                }
+                Some(format!(
+                    "{}:{}",
+                    frame_type,
+                    frame["data"]["data"]["name"]
+                        .as_str()
+                        .or_else(|| frame["data"]["data"]["update"]["name"].as_str())
+                        .unwrap_or("unknown")
+                ))
+            })
+            .collect::<Vec<_>>();
+        panic!(
+            "live CLI turn for conversation {conv_id} did not emit finish/error within {timeout_s}s; \
+             tool frames={tool_summary:?}"
+        );
     }
     // A short grace period: trailing frames (usage, late tool settles) land
     // just after the terminal and are part of what the UI renders.
@@ -1562,6 +1784,24 @@ async fn live_codex_survives_a_broken_mcp_server() {
 #[ignore = "spawns the real agy CLI; needs credentials"]
 async fn live_antigravity_survives_a_broken_mcp_server() {
     run_backend_mcp_provisioning("antigravity").await;
+}
+
+#[tokio::test]
+#[ignore = "spawns the real claude CLI; needs credentials"]
+async fn live_claude_team_mcp_tools_call_and_runtime_env() {
+    run_direct_backend_team_mcp_and_runtime_env("claude", "2d23ff1c").await;
+}
+
+#[tokio::test]
+#[ignore = "spawns the real codex CLI; needs credentials"]
+async fn live_codex_team_mcp_tools_call_and_runtime_env() {
+    run_direct_backend_team_mcp_and_runtime_env("codex", "8e1acf31").await;
+}
+
+#[tokio::test]
+#[ignore = "spawns the real agy CLI; needs credentials"]
+async fn live_antigravity_team_mcp_tools_call_and_runtime_env() {
+    run_direct_backend_team_mcp_and_runtime_env("antigravity", "a9f3c21e").await;
 }
 
 // Resume across an app restart, for every backend.

--- a/crates/aionui-common/src/backend_capabilities.rs
+++ b/crates/aionui-common/src/backend_capabilities.rs
@@ -1,0 +1,38 @@
+//! Backend capability values shared across domain ports.
+
+/// MCP transports a backend has been verified to configure and use.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct McpTransportCapabilities {
+    pub stdio: bool,
+    pub sse: bool,
+    pub streamable_http: bool,
+}
+
+/// Evidence source used to resolve an effective backend capability.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CapabilityOrigin {
+    DirectDescriptor,
+    InternalDescriptor,
+    AcpHandshake,
+    #[default]
+    Unknown,
+}
+
+impl CapabilityOrigin {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::DirectDescriptor => "direct_descriptor",
+            Self::InternalDescriptor => "internal_descriptor",
+            Self::AcpHandshake => "acp_handshake",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Unified capability conclusion consumed by Team without knowing any vendor.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ResolvedBackendCapabilities {
+    pub mcp: McpTransportCapabilities,
+    pub cli_fallback: bool,
+    pub origin: CapabilityOrigin,
+}

--- a/crates/aionui-common/src/lib.rs
+++ b/crates/aionui-common/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod constants;
 pub mod user_paths;
 
+mod backend_capabilities;
 mod case_convert;
 mod crypto;
 mod enums;
@@ -15,6 +16,7 @@ mod pagination;
 mod timestamp;
 mod types;
 
+pub use backend_capabilities::{CapabilityOrigin, McpTransportCapabilities, ResolvedBackendCapabilities};
 pub use case_convert::{camel_to_snake, normalize_keys_to_snake_case};
 pub use crypto::{CryptoError, decrypt_string, encrypt_string};
 pub use enums::{

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -2843,10 +2843,18 @@ impl ConversationService {
                 _ => None,
             }
         };
-        let Some(capabilities_json) = metadata_row.and_then(|row| row.agent_capabilities) else {
+        let Some(metadata_row) = metadata_row else {
             return Ok(None);
         };
-        Ok(serde_json::from_str(&capabilities_json).ok())
+        let backend = aionui_db::runtime_backend_for_agent(&metadata_row);
+        let persisted = metadata_row
+            .agent_capabilities
+            .as_deref()
+            .and_then(|capabilities| serde_json::from_str::<serde_json::Value>(capabilities).ok());
+        Ok(aionui_ai_agent::effective_agent_capabilities(
+            &backend,
+            persisted.as_ref(),
+        ))
     }
 
     /// Reset a conversation: clear messages and set status back to pending.
@@ -4728,11 +4736,18 @@ async fn resolve_acp_mcp_support_policy(
         None => None,
     };
 
-    let capabilities = row
+    let persisted = row
         .as_ref()
         .and_then(|row| row.agent_capabilities.as_deref())
-        .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
-        .map(|value| parse_acp_mcp_capabilities(&value))
+        .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok());
+    let effective_backend = row
+        .as_ref()
+        .map(aionui_db::runtime_backend_for_agent)
+        .or_else(|| backend.map(str::to_owned))
+        .unwrap_or_default();
+    let capabilities = aionui_ai_agent::effective_agent_capabilities(&effective_backend, persisted.as_ref())
+        .as_ref()
+        .map(parse_acp_mcp_capabilities)
         .unwrap_or_default();
 
     Ok(McpSupportPolicy::from_acp_capabilities(capabilities))
@@ -4960,7 +4975,7 @@ fn legacy_cron_trigger_to_artifact(row: MessageRow) -> Result<ConversationArtifa
 
 /// Merge `patch` into `base` (top-level key overwrite).
 /// Project `session_capabilities.fork` out of a parsed
-/// `agent_metadata.agent_capabilities` value. `None` = fork hidden.
+/// effective agent capability value. `None` = fork hidden.
 fn fork_capability_view(capabilities: &serde_json::Value) -> Option<ForkCapabilityView> {
     let fork = capabilities.get("session_capabilities")?.get("fork")?;
     if fork.is_null() {
@@ -4972,7 +4987,7 @@ fn fork_capability_view(capabilities: &serde_json::Value) -> Option<ForkCapabili
 }
 
 /// Project `prompt_capabilities` out of a parsed
-/// `agent_metadata.agent_capabilities` value. `None` = unknown (UI treats
+/// effective agent capability value. `None` = unknown (UI treats
 /// media attachments as path-delivered).
 fn prompt_capability_view(capabilities: &serde_json::Value) -> Option<PromptCapabilityView> {
     let prompt = capabilities.get("prompt_capabilities")?;
@@ -5346,5 +5361,25 @@ mod tests {
         );
 
         assert_eq!(status.status, ConversationMcpStatusKind::Failed);
+    }
+
+    #[tokio::test]
+    async fn direct_cli_mcp_policy_uses_effective_descriptor_on_a_fresh_database() {
+        let db = aionui_db::init_database_memory().await.unwrap();
+        let repo: Arc<dyn IAgentMetadataRepository> =
+            Arc::new(aionui_db::SqliteAgentMetadataRepository::new(db.pool().clone()));
+
+        let policy = resolve_acp_mcp_support_policy(
+            &repo,
+            "system_default_user",
+            &json!({"backend": "codex", "agent_source": "builtin"}),
+        )
+        .await
+        .unwrap();
+
+        assert!(policy.stdio);
+        assert!(policy.http);
+        assert!(policy.streamable_http);
+        assert!(!policy.sse);
     }
 }

--- a/crates/aionui-session/src/backend/antigravity/argv.rs
+++ b/crates/aionui-session/src/backend/antigravity/argv.rs
@@ -66,6 +66,13 @@ pub(crate) fn build_argv(input: &ArgvInput) -> Vec<String> {
     if let Some(id) = non_blank(&input.resume_conversation_id) {
         a.push("--conversation".into());
         a.push(id.to_owned());
+    } else {
+        // A fresh print invocation otherwise reuses agy's globally active
+        // project, so workspace plugins can be scanned from an unrelated cwd.
+        // `agy --help` 1.1.13 defines this flag as creating a project for the
+        // current CLI session; a real probe bound the primary workspace to cwd
+        // (verified: ~/.gemini/antigravity-cli/log/cli-20260814_144215.log:52,54,66).
+        a.push("--new-project".into());
     }
     if let Some(w) = non_blank(&input.workspace) {
         a.push("--add-dir".into());
@@ -116,6 +123,10 @@ mod tests {
         assert!(a.contains(&"hello".to_string()));
         assert_eq!(flag_value(&a, "--output-format"), Some("stream-json"));
         assert!(!a.contains(&"--conversation".to_string()));
+        assert!(
+            a.contains(&"--new-project".to_string()),
+            "a fresh agy turn must bind its primary customization workspace to the session cwd"
+        );
     }
 
     #[test]
@@ -196,6 +207,7 @@ mod tests {
         i.resume_conversation_id = Some("conv-9".into());
         let a = build_argv(&i);
         assert_eq!(flag_value(&a, "--conversation"), Some("conv-9"));
+        assert!(!a.contains(&"--new-project".to_string()));
     }
 
     #[test]

--- a/crates/aionui-session/src/backend/antigravity/conn.rs
+++ b/crates/aionui-session/src/backend/antigravity/conn.rs
@@ -571,6 +571,18 @@ impl AntigravitySessionBackend {
             model: self.effective_model(),
             mode: self.effective_mode(),
         };
+        let mut spawn_env = self.config.spawn_env.clone();
+        if let Some(cwd) = self.config.cwd.as_deref() {
+            // agy 1.1.13 resolves its primary customization workspace from PWD,
+            // not only the process cwd/--add-dir. A stale inherited PWD made it
+            // scan the host app directory and skip this session's MCP plugin
+            // (verified: ~/.gemini/antigravity-cli/log/cli-20260814_135824.log:48,51).
+            spawn_env.retain(|entry| entry.name != "PWD");
+            spawn_env.push(aionui_common::EnvVar {
+                name: "PWD".to_owned(),
+                value: cwd.to_owned(),
+            });
+        }
         let spec = CommandSpec {
             command: self
                 .config
@@ -578,7 +590,7 @@ impl AntigravitySessionBackend {
                 .clone()
                 .unwrap_or_else(|| std::path::PathBuf::from("agy")),
             args: build_argv(&input),
-            env: self.config.spawn_env.clone(),
+            env: spawn_env,
             cwd: self.config.cwd.clone(),
         };
 
@@ -1041,6 +1053,14 @@ mod tests {
         assert!(spec.args.contains(&"hello".to_string()));
         assert!(spec.args.contains(&"--dangerously-skip-permissions".to_string()));
         assert_eq!(spec.cwd.as_deref(), Some("/w"));
+        assert_eq!(
+            spec.env
+                .iter()
+                .filter(|entry| entry.name == "PWD")
+                .map(|entry| entry.value.as_str())
+                .collect::<Vec<_>>(),
+            vec!["/w"]
+        );
     }
 
     #[tokio::test]

--- a/crates/aionui-session/src/backend/antigravity/mcp_config.rs
+++ b/crates/aionui-session/src/backend/antigravity/mcp_config.rs
@@ -2,12 +2,14 @@
 //!
 //! agy has no per-run flag for MCP configuration — it only reads files — and
 //! the workspace-level file is what gives each conversation its own set of
-//! servers (verified: a workspace `mcp_config.json` is honoured in headless
-//! runs). This is also how the team coordination server reaches an Antigravity
+//! servers (verified: `crates/aionui-app/tests/live_ws_http_parity_e2e.rs`,
+//! `live_antigravity_team_mcp_tools_call_and_runtime_env`, against agy 1.1.13).
+//! This is also how the team coordination server reaches an Antigravity
 //! teammate.
 //!
-//! agy supports exactly two transports, Stdio and SSE
-//! (`agy-customizations/docs/mcp_servers.md`), so an HTTP server is dropped
+//! agy supports exactly two transports, Stdio and SSE (verified:
+//! `~/.gemini/antigravity-cli/builtin/skills/agy-customizations/docs/mcp_servers.md`),
+//! so an HTTP server is dropped
 //! rather than mistranslated.
 
 use std::path::Path;
@@ -43,13 +45,14 @@ pub(crate) fn write_mcp_config(workspace: &Path, servers: &[McpServerSpec]) -> s
                 "serverUrl": url,
                 "headers": pairs_to_object(headers),
             }),
-            McpTransport::Http { url, .. } => {
+            McpTransport::Http { .. } => {
                 // Emitting this as `serverUrl` would write a config that looks
                 // valid and then never connects — SSE and streamable-HTTP are
                 // different protocols.
                 tracing::warn!(
+                    backend = "antigravity",
                     server = %server.name,
-                    url = %url,
+                    transport = "streamable_http",
                     "antigravity: skipping MCP server — agy supports stdio and SSE only"
                 );
                 continue;
@@ -82,6 +85,12 @@ mod tests {
 
     #[test]
     fn stdio_spec_maps_to_agys_command_shape() {
+        assert!(
+            crate::backend::backend_capability_descriptor("antigravity")
+                .unwrap()
+                .mcp
+                .stdio
+        );
         let dir = tempfile::tempdir().unwrap();
         let servers = vec![McpServerSpec {
             name: "aionui-team".into(),
@@ -106,6 +115,12 @@ mod tests {
 
     #[test]
     fn sse_spec_maps_to_server_url_and_headers() {
+        assert!(
+            crate::backend::backend_capability_descriptor("antigravity")
+                .unwrap()
+                .mcp
+                .sse
+        );
         let dir = tempfile::tempdir().unwrap();
         let servers = vec![McpServerSpec {
             name: "remote".into(),
@@ -123,6 +138,12 @@ mod tests {
 
     #[test]
     fn http_transport_is_skipped_rather_than_passed_off_as_sse() {
+        assert!(
+            !crate::backend::backend_capability_descriptor("antigravity")
+                .unwrap()
+                .mcp
+                .streamable_http
+        );
         // agy supports stdio and SSE only. Writing an HTTP server as
         // `serverUrl` produces a config that looks fine and then fails at
         // runtime with an opaque timeout, because the protocols differ.

--- a/crates/aionui-session/src/backend/claude_conn.rs
+++ b/crates/aionui-session/src/backend/claude_conn.rs
@@ -3365,6 +3365,12 @@ mod tests {
     /// stdio carrying command/args/env.
     #[test]
     fn build_claude_init_args_mcp_emits_strict_and_map_json() {
+        assert!(
+            crate::backend::backend_capability_descriptor("claude")
+                .unwrap()
+                .mcp
+                .stdio
+        );
         let config = SessionConfig {
             init: SessionInit {
                 mcp_servers: vec![McpServerSpec {
@@ -3511,6 +3517,12 @@ mod tests {
     /// http/sse MCP transports map to claude's `{type,url,headers}` entry shape.
     #[test]
     fn build_claude_mcp_config_http_carries_type_and_headers() {
+        assert!(
+            crate::backend::backend_capability_descriptor("claude")
+                .unwrap()
+                .mcp
+                .streamable_http
+        );
         let json_str = build_claude_mcp_config(&[McpServerSpec {
             name: "api".into(),
             transport: McpTransport::Http {
@@ -3523,6 +3535,27 @@ mod tests {
         assert_eq!(json["mcpServers"]["api"]["type"], "http");
         assert_eq!(json["mcpServers"]["api"]["url"], "https://example.com/mcp");
         assert_eq!(json["mcpServers"]["api"]["headers"]["Authorization"], "Bearer x");
+    }
+
+    /// The official claude-code ACP adapter preserves SSE as a distinct
+    /// transport (`type: "sse"`); it must not be collapsed into HTTP.
+    /// verified: ~/.npm/_npx/ca6c9a6e3c4cc822/node_modules/
+    /// @agentclientprotocol/claude-agent-acp/dist/acp-agent.js:1872-1896
+    #[test]
+    fn build_claude_mcp_config_sse_carries_type_and_headers() {
+        assert!(crate::backend::backend_capability_descriptor("claude").unwrap().mcp.sse);
+        let json_str = build_claude_mcp_config(&[McpServerSpec {
+            name: "events".into(),
+            transport: McpTransport::Sse {
+                url: "https://example.com/events".into(),
+                headers: vec![("Authorization".into(), "Bearer x".into())],
+            },
+        }])
+        .expect("sse server -> some json");
+        let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(json["mcpServers"]["events"]["type"], "sse");
+        assert_eq!(json["mcpServers"]["events"]["url"], "https://example.com/events");
+        assert_eq!(json["mcpServers"]["events"]["headers"]["Authorization"], "Bearer x");
     }
 
     /// SESS-INIT-17 (audit): duplicate MCP server NAMES collapse by construction.

--- a/crates/aionui-session/src/backend/codex_conn.rs
+++ b/crates/aionui-session/src/backend/codex_conn.rs
@@ -41,6 +41,48 @@ use crate::capability::{BlockSet, Capabilities, CapabilityTier, CommandSet, Prom
 use crate::event::{CancelReason, ProvisioningPhase, SessionEvent, StopReason, SubagentStatus, TurnOutcome};
 use futures_util::stream::{BoxStream, StreamExt};
 
+const CODEX_CONFIG_FLAG: &str = "-c";
+const CODEX_ENV_POLICY_INHERIT_ALL: &str = "shell_environment_policy.inherit=all";
+const CODEX_ENV_POLICY_CLEAR_INCLUDE_ONLY: &str = "shell_environment_policy.include_only=[]";
+
+/// Config overrides that make Codex command-execution children inherit the
+/// runtime environment injected into the app-server process.
+pub fn codex_shell_environment_policy_args() -> [&'static str; 4] {
+    [
+        CODEX_CONFIG_FLAG,
+        CODEX_ENV_POLICY_INHERIT_ALL,
+        CODEX_CONFIG_FLAG,
+        CODEX_ENV_POLICY_CLEAR_INCLUDE_ONLY,
+    ]
+}
+
+/// Build the process-level app-server argv shared by initial open and idle
+/// wake. `codex app-server --help` documents the config override and uses
+/// `shell_environment_policy.inherit=all` as its example.
+fn codex_app_server_args(extra_args: &[String]) -> Vec<String> {
+    let mut args = vec!["app-server".to_owned()];
+    args.extend(extra_args.iter().cloned());
+    // Append the compatibility policy after user/configured extras, matching
+    // the former ACP launch policy and making these final overrides authoritative.
+    args.extend(codex_shell_environment_policy_args().map(str::to_owned));
+    args
+}
+
+fn log_codex_runtime_policy(spawn_env: &[aionui_common::EnvVar]) {
+    let mut runtime_env_keys = spawn_env
+        .iter()
+        .filter_map(|entry| entry.name.starts_with("AIONUI_").then_some(entry.name.as_str()))
+        .collect::<Vec<_>>();
+    runtime_env_keys.sort_unstable();
+    runtime_env_keys.dedup();
+    tracing::info!(
+        backend = "codex",
+        shell_env_policy_explicit = true,
+        ?runtime_env_keys,
+        "starting Codex app-server with explicit tool-shell environment policy"
+    );
+}
+
 /// Connection-level factory for codex. Holds the injected `Spawner`. Unlike
 /// claude (1:1), codex's app-server CAN multiplex threads on one process — but
 /// P1 opens one process per logical session (multiplexing is a later refinement;
@@ -73,8 +115,8 @@ impl BackendConnection for CodexConnection {
             SessionSpec::Resume { session_id, .. } => session_id.clone(),
             SessionSpec::Fork { session_id, .. } => session_id.clone(),
         };
-        let mut args = vec!["app-server".to_string()];
-        args.extend(config.extra_args.iter().cloned());
+        let args = codex_app_server_args(&config.extra_args);
+        log_codex_runtime_policy(&config.spawn_env);
         let cmd = aionui_common::CommandSpec {
             // Orchestration-resolved bundled CLI (packaged app) or bare "codex"
             // (dev → PATH). See SessionConfig.cli_program.
@@ -536,8 +578,15 @@ fn build_codex_mcp_servers(servers: &[crate::backend::McpServerSpec]) -> Value {
             // neutral spec carries headers; codex takes a bearer_token_env_var, so we
             // pass the url and let codex's own auth/oauth path handle credentials
             // (inline arbitrary headers are not a codex config field).
-            McpTransport::Http { url, .. } | McpTransport::Sse { url, .. } => {
-                json!({ "url": url })
+            McpTransport::Http { url, .. } => json!({ "url": url }),
+            McpTransport::Sse { .. } => {
+                tracing::warn!(
+                    backend = "codex",
+                    server = %s.name,
+                    transport = "sse",
+                    "skipping unsupported MCP transport"
+                );
+                continue;
             }
         };
         map.insert(s.name.clone(), entry);
@@ -1303,8 +1352,8 @@ impl CodexSessionBackend {
             .spawner
             .as_ref()
             .ok_or_else(|| BackendError::Transport("codex wake: no spawner (suspension not enabled)".into()))?;
-        let mut args = vec!["app-server".to_string()];
-        args.extend(self.wake.config.extra_args.iter().cloned());
+        let args = codex_app_server_args(&self.wake.config.extra_args);
+        log_codex_runtime_policy(&self.wake.config.spawn_env);
         let cmd = aionui_common::CommandSpec {
             // Same bundled-CLI resolution + spawn env as the initial spawn
             // (R16 continuity).
@@ -7316,6 +7365,10 @@ mod tests {
     #[test]
     fn thread_start_injects_codex_mcp_map_and_preset() {
         use crate::backend::{McpServerSpec, McpTransport, SessionInit};
+        let descriptor = crate::backend::backend_capability_descriptor("codex").unwrap();
+        assert!(descriptor.mcp.stdio);
+        assert!(descriptor.mcp.streamable_http);
+        assert!(!descriptor.mcp.sse);
         let frame = thread_start_params(&SessionConfig {
             cwd: Some("/work".into()),
             init: SessionInit {
@@ -7335,6 +7388,13 @@ mod tests {
                             headers: vec![],
                         },
                     },
+                    McpServerSpec {
+                        name: "unsupported-sse".into(),
+                        transport: McpTransport::Sse {
+                            url: "https://mcp.example/sse".into(),
+                            headers: vec![],
+                        },
+                    },
                 ],
                 preset_context: Some("You are a helpful assistant.".into()),
                 ..Default::default()
@@ -7349,6 +7409,10 @@ mod tests {
         // codex env is a MAP {KEY:VAL}, NOT acp's array of {name,value}.
         assert_eq!(mcp["fs"]["env"]["TOKEN"], "x");
         assert_eq!(mcp["remote"]["url"], "https://mcp.example/api");
+        assert!(
+            mcp.get("unsupported-sse").is_none(),
+            "Codex does not declare an SSE MCP transport; the adapter must filter it instead of serializing it as HTTP"
+        );
         // preset → baseInstructions.
         assert_eq!(frame["params"]["baseInstructions"], "You are a helpful assistant.");
     }
@@ -7436,13 +7500,16 @@ mod tests {
         let spec = spawner.last_command().await.expect("a CommandSpec was recorded");
         assert_eq!(spec.command.to_str(), Some("codex"), "spawns the codex binary");
         assert_eq!(
-            spec.args.first().map(String::as_str),
-            Some("app-server"),
-            "first arg is app-server"
-        );
-        assert!(
-            spec.args.iter().any(|a| a == "--flag"),
-            "extra_args threaded into the spawn"
+            spec.args,
+            [
+                "app-server",
+                "--flag",
+                "-c",
+                "shell_environment_policy.inherit=all",
+                "-c",
+                "shell_environment_policy.include_only=[]",
+            ],
+            "every app-server spawn must explicitly propagate the parent environment to commandExecution shells"
         );
         assert_eq!(spec.cwd.as_deref(), Some("/tmp/work"), "cwd threaded (workspace)");
         // #103 parity with claude_conn: the orchestration-filled spawn env
@@ -8645,10 +8712,16 @@ mod tests {
         assert_eq!(spawner.call_count(), 1, "wake routed through the injected spawner once");
         let spec = spawner.last_command().await.expect("a spawn was recorded");
         assert_eq!(spec.command.to_str(), Some("codex"), "wake re-spawns the codex binary");
-        assert!(
-            spec.args.iter().any(|a| a == "app-server"),
-            "wake re-spawns `codex app-server`, got {:?}",
-            spec.args
+        assert_eq!(
+            spec.args,
+            [
+                "app-server",
+                "-c",
+                "shell_environment_policy.inherit=all",
+                "-c",
+                "shell_environment_policy.include_only=[]",
+            ],
+            "wake must restore the same explicit commandExecution environment policy as the initial spawn"
         );
         drop(backend);
     }

--- a/crates/aionui-session/src/backend/descriptor.rs
+++ b/crates/aionui-session/src/backend/descriptor.rs
@@ -1,0 +1,207 @@
+//! Static capability descriptors for non-ACP backends.
+//!
+//! Direct CLI adapters cannot obtain an ACP initialize snapshot, so their MCP
+//! capability comes from the adapter contract that performs the injection.
+
+use aionui_common::{CapabilityOrigin, McpTransportCapabilities, ResolvedBackendCapabilities};
+
+use super::cli_version::{VERIFIED_AGY_VERSION, VERIFIED_CLAUDE_VERSION, VERIFIED_CODEX_VERSION};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PromptCapabilities {
+    pub image: bool,
+    pub audio: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ForkCapabilities {
+    pub at_turn: bool,
+}
+
+/// Constructed capability data. Vendor serialization remains in each adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BackendCapabilityDescriptor {
+    pub backend_id: &'static str,
+    pub mcp: McpTransportCapabilities,
+    pub cli_fallback: bool,
+    pub verified_version: &'static str,
+    pub origin: CapabilityOrigin,
+    pub prompt: Option<PromptCapabilities>,
+    pub fork: Option<ForkCapabilities>,
+}
+
+impl BackendCapabilityDescriptor {
+    pub const fn resolved(self) -> ResolvedBackendCapabilities {
+        ResolvedBackendCapabilities {
+            mcp: self.mcp,
+            cli_fallback: self.cli_fallback,
+            origin: self.origin,
+        }
+    }
+}
+
+/// Return a descriptor only when the backend has constructed capability data.
+pub fn backend_capability_descriptor(backend: &str) -> Option<BackendCapabilityDescriptor> {
+    match backend {
+        // verified: ~/.npm/_npx/ca6c9a6e3c4cc822/node_modules/
+        // @agentclientprotocol/claude-agent-acp/dist/acp-agent.js:1872-1898
+        "claude" => Some(BackendCapabilityDescriptor {
+            backend_id: "claude",
+            mcp: McpTransportCapabilities {
+                stdio: true,
+                sse: true,
+                streamable_http: true,
+            },
+            cli_fallback: true,
+            verified_version: VERIFIED_CLAUDE_VERSION,
+            origin: CapabilityOrigin::DirectDescriptor,
+            prompt: Some(PromptCapabilities {
+                image: true,
+                audio: false,
+            }),
+            fork: Some(ForkCapabilities { at_turn: false }),
+        }),
+        // verified: `codex mcp add --help` declares command-based stdio and
+        // `--url` streamable HTTP, and does not declare SSE.
+        "codex" => Some(BackendCapabilityDescriptor {
+            backend_id: "codex",
+            mcp: McpTransportCapabilities {
+                stdio: true,
+                sse: false,
+                streamable_http: true,
+            },
+            cli_fallback: true,
+            verified_version: VERIFIED_CODEX_VERSION,
+            origin: CapabilityOrigin::DirectDescriptor,
+            prompt: Some(PromptCapabilities {
+                image: true,
+                audio: false,
+            }),
+            fork: Some(ForkCapabilities { at_turn: true }),
+        }),
+        // verified: ~/.gemini/antigravity-cli/builtin/skills/
+        // agy-customizations/docs/mcp_servers.md
+        "antigravity" => Some(BackendCapabilityDescriptor {
+            backend_id: "antigravity",
+            mcp: McpTransportCapabilities {
+                stdio: true,
+                sse: true,
+                streamable_http: false,
+            },
+            cli_fallback: true,
+            verified_version: VERIFIED_AGY_VERSION,
+            origin: CapabilityOrigin::DirectDescriptor,
+            prompt: None,
+            fork: None,
+        }),
+        "aionrs" => Some(BackendCapabilityDescriptor {
+            backend_id: "aionrs",
+            mcp: McpTransportCapabilities {
+                stdio: true,
+                sse: false,
+                streamable_http: false,
+            },
+            cli_fallback: false,
+            verified_version: env!("CARGO_PKG_VERSION"),
+            origin: CapabilityOrigin::InternalDescriptor,
+            prompt: None,
+            fork: Some(ForkCapabilities { at_turn: true }),
+        }),
+        _ => None,
+    }
+}
+
+/// Overlay constructed fields onto persisted discovery data. Constructed false
+/// values are authoritative, so stale ACP history cannot re-enable a transport.
+pub fn effective_agent_capabilities(backend: &str, persisted: Option<&serde_json::Value>) -> Option<serde_json::Value> {
+    let Some(descriptor) = backend_capability_descriptor(backend) else {
+        return persisted.cloned();
+    };
+    let mut effective = persisted.cloned().unwrap_or_else(|| serde_json::json!({}));
+    if !effective.is_object() {
+        effective = serde_json::json!({});
+    }
+    effective["mcp_capabilities"] = serde_json::json!({
+        "stdio": descriptor.mcp.stdio,
+        "sse": descriptor.mcp.sse,
+        "http": descriptor.mcp.streamable_http,
+        "streamable_http": descriptor.mcp.streamable_http,
+    });
+    match descriptor.prompt {
+        Some(prompt) => {
+            effective["prompt_capabilities"] = serde_json::json!({
+                "image": prompt.image,
+                "audio": prompt.audio,
+            });
+        }
+        None => {
+            effective
+                .as_object_mut()
+                .expect("effective capability projection is normalized to an object")
+                .remove("prompt_capabilities");
+        }
+    }
+    match descriptor.fork {
+        Some(fork) => {
+            let effective_object = effective
+                .as_object_mut()
+                .expect("effective capability projection is normalized to an object");
+            let session = effective_object
+                .entry("session_capabilities")
+                .or_insert_with(|| serde_json::json!({}));
+            if !session.is_object() {
+                *session = serde_json::json!({});
+            }
+            session["fork"] = serde_json::json!({
+                "at_turn": fork.at_turn,
+            });
+        }
+        None => {
+            if let Some(session) = effective
+                .get_mut("session_capabilities")
+                .and_then(serde_json::Value::as_object_mut)
+            {
+                session.remove("fork");
+            }
+        }
+    }
+    Some(effective)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direct_descriptor_matrix_matches_verified_adapter_contracts() {
+        let expected = [
+            ("claude", true, true, true, VERIFIED_CLAUDE_VERSION),
+            ("codex", true, false, true, VERIFIED_CODEX_VERSION),
+            ("antigravity", true, true, false, VERIFIED_AGY_VERSION),
+        ];
+        for (backend, stdio, sse, http, version) in expected {
+            let descriptor = backend_capability_descriptor(backend).expect("direct descriptor");
+            assert_eq!(descriptor.origin, CapabilityOrigin::DirectDescriptor);
+            assert_eq!(descriptor.mcp.stdio, stdio);
+            assert_eq!(descriptor.mcp.sse, sse);
+            assert_eq!(descriptor.mcp.streamable_http, http);
+            assert!(descriptor.cli_fallback);
+            assert_eq!(descriptor.verified_version, version);
+        }
+    }
+
+    #[test]
+    fn effective_projection_overrides_stale_direct_mcp_snapshot() {
+        let historical = serde_json::json!({
+            "mcp_capabilities": {"http": false, "sse": true},
+            "session_capabilities": false,
+            "unrelated": {"kept": true}
+        });
+        let effective = effective_agent_capabilities("codex", Some(&historical)).unwrap();
+        assert_eq!(effective["mcp_capabilities"]["stdio"], true);
+        assert_eq!(effective["mcp_capabilities"]["sse"], false);
+        assert_eq!(effective["mcp_capabilities"]["http"], true);
+        assert_eq!(effective["unrelated"]["kept"], true);
+        assert_eq!(effective["session_capabilities"]["fork"]["at_turn"], true);
+    }
+}

--- a/crates/aionui-session/src/backend/descriptor.rs
+++ b/crates/aionui-session/src/backend/descriptor.rs
@@ -40,75 +40,86 @@ impl BackendCapabilityDescriptor {
     }
 }
 
+const BACKEND_CAPABILITY_DESCRIPTORS: &[BackendCapabilityDescriptor] = &[
+    // verified: ~/.npm/_npx/ca6c9a6e3c4cc822/node_modules/
+    // @agentclientprotocol/claude-agent-acp/dist/acp-agent.js:1872-1898
+    BackendCapabilityDescriptor {
+        backend_id: "claude",
+        mcp: McpTransportCapabilities {
+            stdio: true,
+            sse: true,
+            streamable_http: true,
+        },
+        cli_fallback: true,
+        verified_version: VERIFIED_CLAUDE_VERSION,
+        origin: CapabilityOrigin::DirectDescriptor,
+        prompt: Some(PromptCapabilities {
+            image: true,
+            audio: false,
+        }),
+        fork: Some(ForkCapabilities { at_turn: false }),
+    },
+    // verified: `codex mcp add --help` declares command-based stdio and
+    // `--url` streamable HTTP, and does not declare SSE.
+    BackendCapabilityDescriptor {
+        backend_id: "codex",
+        mcp: McpTransportCapabilities {
+            stdio: true,
+            sse: false,
+            streamable_http: true,
+        },
+        cli_fallback: true,
+        verified_version: VERIFIED_CODEX_VERSION,
+        origin: CapabilityOrigin::DirectDescriptor,
+        prompt: Some(PromptCapabilities {
+            image: true,
+            audio: false,
+        }),
+        fork: Some(ForkCapabilities { at_turn: true }),
+    },
+    // verified: ~/.gemini/antigravity-cli/builtin/skills/
+    // agy-customizations/docs/mcp_servers.md
+    BackendCapabilityDescriptor {
+        backend_id: "antigravity",
+        mcp: McpTransportCapabilities {
+            stdio: true,
+            sse: true,
+            streamable_http: false,
+        },
+        cli_fallback: true,
+        verified_version: VERIFIED_AGY_VERSION,
+        origin: CapabilityOrigin::DirectDescriptor,
+        prompt: None,
+        fork: None,
+    },
+    BackendCapabilityDescriptor {
+        backend_id: "aionrs",
+        mcp: McpTransportCapabilities {
+            stdio: true,
+            sse: false,
+            streamable_http: false,
+        },
+        cli_fallback: false,
+        verified_version: env!("CARGO_PKG_VERSION"),
+        origin: CapabilityOrigin::InternalDescriptor,
+        prompt: None,
+        fork: Some(ForkCapabilities { at_turn: true }),
+    },
+];
+
+/// Enumerate every backend whose capabilities are constructed in-process.
+/// Contract tests consume this registry so a new entry automatically exercises
+/// lookup, projection, and Team resolver behavior.
+pub fn backend_capability_descriptors() -> &'static [BackendCapabilityDescriptor] {
+    BACKEND_CAPABILITY_DESCRIPTORS
+}
+
 /// Return a descriptor only when the backend has constructed capability data.
 pub fn backend_capability_descriptor(backend: &str) -> Option<BackendCapabilityDescriptor> {
-    match backend {
-        // verified: ~/.npm/_npx/ca6c9a6e3c4cc822/node_modules/
-        // @agentclientprotocol/claude-agent-acp/dist/acp-agent.js:1872-1898
-        "claude" => Some(BackendCapabilityDescriptor {
-            backend_id: "claude",
-            mcp: McpTransportCapabilities {
-                stdio: true,
-                sse: true,
-                streamable_http: true,
-            },
-            cli_fallback: true,
-            verified_version: VERIFIED_CLAUDE_VERSION,
-            origin: CapabilityOrigin::DirectDescriptor,
-            prompt: Some(PromptCapabilities {
-                image: true,
-                audio: false,
-            }),
-            fork: Some(ForkCapabilities { at_turn: false }),
-        }),
-        // verified: `codex mcp add --help` declares command-based stdio and
-        // `--url` streamable HTTP, and does not declare SSE.
-        "codex" => Some(BackendCapabilityDescriptor {
-            backend_id: "codex",
-            mcp: McpTransportCapabilities {
-                stdio: true,
-                sse: false,
-                streamable_http: true,
-            },
-            cli_fallback: true,
-            verified_version: VERIFIED_CODEX_VERSION,
-            origin: CapabilityOrigin::DirectDescriptor,
-            prompt: Some(PromptCapabilities {
-                image: true,
-                audio: false,
-            }),
-            fork: Some(ForkCapabilities { at_turn: true }),
-        }),
-        // verified: ~/.gemini/antigravity-cli/builtin/skills/
-        // agy-customizations/docs/mcp_servers.md
-        "antigravity" => Some(BackendCapabilityDescriptor {
-            backend_id: "antigravity",
-            mcp: McpTransportCapabilities {
-                stdio: true,
-                sse: true,
-                streamable_http: false,
-            },
-            cli_fallback: true,
-            verified_version: VERIFIED_AGY_VERSION,
-            origin: CapabilityOrigin::DirectDescriptor,
-            prompt: None,
-            fork: None,
-        }),
-        "aionrs" => Some(BackendCapabilityDescriptor {
-            backend_id: "aionrs",
-            mcp: McpTransportCapabilities {
-                stdio: true,
-                sse: false,
-                streamable_http: false,
-            },
-            cli_fallback: false,
-            verified_version: env!("CARGO_PKG_VERSION"),
-            origin: CapabilityOrigin::InternalDescriptor,
-            prompt: None,
-            fork: Some(ForkCapabilities { at_turn: true }),
-        }),
-        _ => None,
-    }
+    BACKEND_CAPABILITY_DESCRIPTORS
+        .iter()
+        .find(|descriptor| descriptor.backend_id == backend)
+        .copied()
 }
 
 /// Overlay constructed fields onto persisted discovery data. Constructed false
@@ -170,7 +181,55 @@ pub fn effective_agent_capabilities(backend: &str, persisted: Option<&serde_json
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
+
+    #[test]
+    fn constructed_descriptor_registry_is_unique_and_drives_lookup() {
+        let descriptors = backend_capability_descriptors();
+        assert!(
+            !descriptors.is_empty(),
+            "constructed backend descriptor registry must not be empty"
+        );
+
+        let mut ids = HashSet::new();
+        for descriptor in descriptors {
+            assert!(
+                !descriptor.backend_id.trim().is_empty(),
+                "constructed backend descriptors require a stable backend id"
+            );
+            assert!(
+                !descriptor.verified_version.trim().is_empty(),
+                "constructed backend {} must record the version its contract was verified against",
+                descriptor.backend_id
+            );
+            assert!(
+                ids.insert(descriptor.backend_id),
+                "duplicate constructed backend descriptor for {}; keep one registry entry per backend",
+                descriptor.backend_id
+            );
+            assert_eq!(
+                backend_capability_descriptor(descriptor.backend_id),
+                Some(*descriptor),
+                "registered backend {} is not discoverable through the capability lookup",
+                descriptor.backend_id
+            );
+
+            let projected = effective_agent_capabilities(descriptor.backend_id, None).unwrap_or_else(|| {
+                panic!(
+                    "registered backend {} has no effective projection",
+                    descriptor.backend_id
+                )
+            });
+            assert_eq!(projected["mcp_capabilities"]["stdio"], descriptor.mcp.stdio);
+            assert_eq!(projected["mcp_capabilities"]["sse"], descriptor.mcp.sse);
+            assert_eq!(
+                projected["mcp_capabilities"]["streamable_http"],
+                descriptor.mcp.streamable_http
+            );
+        }
+    }
 
     #[test]
     fn direct_descriptor_matrix_matches_verified_adapter_contracts() {

--- a/crates/aionui-session/src/backend/mod.rs
+++ b/crates/aionui-session/src/backend/mod.rs
@@ -14,6 +14,7 @@ mod claude_conn;
 mod cli_version;
 mod codex_conn;
 mod conversation_session;
+mod descriptor;
 mod orchestrator;
 mod rehydrate;
 mod suspend;
@@ -23,11 +24,14 @@ pub use acp_conn::{AcpConnection, AcpSessionBackend, acp_capabilities};
 pub use antigravity::{AntigravityConnection, AntigravitySessionBackend, antigravity_capabilities};
 pub use claude_conn::{ClaudeConnection, ClaudeSessionBackend};
 pub use cli_version::{
-    VERIFIED_CLAUDE_VERSION, VERIFIED_CODEX_VERSION, VersionDrift, VersionVerdict, classify as classify_cli_version,
-    parse_version as parse_cli_version, version_drift,
+    VERIFIED_AGY_VERSION, VERIFIED_CLAUDE_VERSION, VERIFIED_CODEX_VERSION, VersionDrift, VersionVerdict,
+    classify as classify_cli_version, parse_version as parse_cli_version, version_drift,
 };
-pub use codex_conn::{CodexConnection, CodexSessionBackend, codex_capabilities, slash_command_name};
+pub use codex_conn::{
+    CodexConnection, CodexSessionBackend, codex_capabilities, codex_shell_environment_policy_args, slash_command_name,
+};
 pub use conversation_session::{ConversationSession, MsgStatus, PendingMessage};
+pub use descriptor::{BackendCapabilityDescriptor, backend_capability_descriptor, effective_agent_capabilities};
 pub use orchestrator::Orchestrator;
 pub use rehydrate::rehydrate;
 // `suspend::{SuspendController, ProcHandle, spawn_idle_timer}` is the F-4 idle

--- a/crates/aionui-session/src/backend/mod.rs
+++ b/crates/aionui-session/src/backend/mod.rs
@@ -31,7 +31,10 @@ pub use codex_conn::{
     CodexConnection, CodexSessionBackend, codex_capabilities, codex_shell_environment_policy_args, slash_command_name,
 };
 pub use conversation_session::{ConversationSession, MsgStatus, PendingMessage};
-pub use descriptor::{BackendCapabilityDescriptor, backend_capability_descriptor, effective_agent_capabilities};
+pub use descriptor::{
+    BackendCapabilityDescriptor, backend_capability_descriptor, backend_capability_descriptors,
+    effective_agent_capabilities,
+};
 pub use orchestrator::Orchestrator;
 pub use rehydrate::rehydrate;
 // `suspend::{SuspendController, ProcHandle, spawn_idle_timer}` is the F-4 idle

--- a/crates/aionui-session/src/lib.rs
+++ b/crates/aionui-session/src/lib.rs
@@ -53,14 +53,15 @@ pub use adapter::{AgentIo, ManagedProcessIo, is_valid_claude_permission_mode};
 // `command`/`session` modules that forced the `BackendCommand`/`BackendSessionSpec`
 // aliases, so these are now exported under their plain names.
 pub use backend::{
-    AcpConnection, AcpSessionBackend, Admission, AntigravityConnection, AntigravitySessionBackend, BackendConnection,
-    BackendError, CancelTarget, ClaudeConnection, ClaudeSessionBackend, CodexConnection, CodexSessionBackend, Command,
-    CommandMeta, CommandReceipt, ContentBlock, ConversationSession, McpServerSpec, McpTransport, MsgStatus,
-    Orchestrator, PendingMessage, PendingPermissionView, PermissionDecision, QuestionAnswer, SessionBackend,
-    SessionConfig, SessionEnvelope, SessionInfoKind, SessionInit, SessionSpec, StateSnapshot, Tier2Checkpoint,
-    TransitionReason, VERIFIED_CLAUDE_VERSION, VERIFIED_CODEX_VERSION, VersionDrift, VersionVerdict, acp_capabilities,
-    antigravity_capabilities, classify_cli_version, codex_capabilities, command_name, parse_cli_version, rehydrate,
-    slash_command_name, version_drift,
+    AcpConnection, AcpSessionBackend, Admission, AntigravityConnection, AntigravitySessionBackend,
+    BackendCapabilityDescriptor, BackendConnection, BackendError, CancelTarget, ClaudeConnection, ClaudeSessionBackend,
+    CodexConnection, CodexSessionBackend, Command, CommandMeta, CommandReceipt, ContentBlock, ConversationSession,
+    McpServerSpec, McpTransport, MsgStatus, Orchestrator, PendingMessage, PendingPermissionView, PermissionDecision,
+    QuestionAnswer, SessionBackend, SessionConfig, SessionEnvelope, SessionInfoKind, SessionInit, SessionSpec,
+    StateSnapshot, Tier2Checkpoint, TransitionReason, VERIFIED_AGY_VERSION, VERIFIED_CLAUDE_VERSION,
+    VERIFIED_CODEX_VERSION, VersionDrift, VersionVerdict, acp_capabilities, antigravity_capabilities,
+    backend_capability_descriptor, classify_cli_version, codex_capabilities, codex_shell_environment_policy_args,
+    command_name, effective_agent_capabilities, parse_cli_version, rehydrate, slash_command_name, version_drift,
 };
 pub use capability::{
     BlockSet, Capabilities, CapabilityTier, CommandSet, ModeInfo, ModelInfo, PromptAcceptedSource, SignalSet,

--- a/crates/aionui-session/src/lib.rs
+++ b/crates/aionui-session/src/lib.rs
@@ -60,8 +60,9 @@ pub use backend::{
     QuestionAnswer, SessionBackend, SessionConfig, SessionEnvelope, SessionInfoKind, SessionInit, SessionSpec,
     StateSnapshot, Tier2Checkpoint, TransitionReason, VERIFIED_AGY_VERSION, VERIFIED_CLAUDE_VERSION,
     VERIFIED_CODEX_VERSION, VersionDrift, VersionVerdict, acp_capabilities, antigravity_capabilities,
-    backend_capability_descriptor, classify_cli_version, codex_capabilities, codex_shell_environment_policy_args,
-    command_name, effective_agent_capabilities, parse_cli_version, rehydrate, slash_command_name, version_drift,
+    backend_capability_descriptor, backend_capability_descriptors, classify_cli_version, codex_capabilities,
+    codex_shell_environment_policy_args, command_name, effective_agent_capabilities, parse_cli_version, rehydrate,
+    slash_command_name, version_drift,
 };
 pub use capability::{
     BlockSet, Capabilities, CapabilityTier, CommandSet, ModeInfo, ModelInfo, PromptAcceptedSource, SignalSet,

--- a/crates/aionui-team/src/lib.rs
+++ b/crates/aionui-team/src/lib.rs
@@ -44,7 +44,8 @@ pub use ports::{
     AgentTurnCancellationPort, AgentTurnExecutionError, AgentTurnExecutionPort, AgentTurnOutcome, AgentTurnRequest,
     AgentTurnSource, AgentTurnStarted, AgentTurnStartedCallback, AgentTurnStatus, NativeSlashCommandPort,
     NoopNativeSlashCommandPort, SlashCatalogSource, SlashCommandRecognition, TeamAssistantCatalogEntry,
-    TeamAssistantCatalogPort, TeamConversationBindingLookup, TeamConversationLookupPort,
+    TeamAssistantCatalogPort, TeamConversationBindingLookup, TeamConversationLookupPort, TeamToolCapabilityPort,
+    UnknownTeamToolCapabilityPort,
 };
 
 pub use prompt_dump::TeamPromptDumpConfig;

--- a/crates/aionui-team/src/ports.rs
+++ b/crates/aionui-team/src/ports.rs
@@ -4,9 +4,41 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use aionui_api_types::{ConversationRuntimeSummary, TeamRunTargetRole};
+use aionui_common::ResolvedBackendCapabilities;
 use async_trait::async_trait;
 
 use crate::error::TeamError;
+
+/// Resolves Team tool capability without exposing backend-specific descriptors
+/// or persisted handshake shapes to the Team domain.
+#[async_trait]
+pub trait TeamToolCapabilityPort: Send + Sync {
+    async fn resolve(
+        &self,
+        user_id: &str,
+        backend: &str,
+        agent_id: Option<&str>,
+    ) -> Result<ResolvedBackendCapabilities, TeamError>;
+}
+
+/// Safe default for test-only/service construction that does not inject the
+/// composition resolver: unknown backends retain the CLI fallback.
+pub struct UnknownTeamToolCapabilityPort;
+
+#[async_trait]
+impl TeamToolCapabilityPort for UnknownTeamToolCapabilityPort {
+    async fn resolve(
+        &self,
+        _user_id: &str,
+        _backend: &str,
+        _agent_id: Option<&str>,
+    ) -> Result<ResolvedBackendCapabilities, TeamError> {
+        Ok(ResolvedBackendCapabilities {
+            cli_fallback: true,
+            ..Default::default()
+        })
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TeamConversationBindingLookup {

--- a/crates/aionui-team/src/provisioning.rs
+++ b/crates/aionui-team/src/provisioning.rs
@@ -8,11 +8,10 @@ use aionui_db::{IAgentMetadataRepository, IProviderRepository, ITeamRepository, 
 use async_trait::async_trait;
 use tracing::{info, warn};
 
-use crate::capability::{supports_team_cli_fallback_backend, supports_team_mcp_backend};
 use crate::error::TeamError;
 use crate::mcp::TeamMcpStdioConfig;
-use crate::ports::TeamAssistantCatalogPort;
 use crate::ports::TeamConversationBindingLookup;
+use crate::ports::{TeamAssistantCatalogPort, TeamToolCapabilityPort};
 use crate::service::inherit_team_workspace;
 use crate::service::spawn_support::{agent_type_for_backend, cli_backend_metadata, session_mode_for_backend};
 use crate::types::{Team, TeamAgent, TeammateRole};
@@ -25,6 +24,7 @@ pub struct TeamAgentProvisioner {
     assistant_catalog: Arc<dyn TeamAssistantCatalogPort>,
     provider_repo: Arc<dyn IProviderRepository>,
     conversation_port: Arc<dyn TeamConversationProvisioningPort>,
+    capability_port: Arc<dyn TeamToolCapabilityPort>,
 }
 
 pub(crate) struct InitialProvisioningResult {
@@ -133,6 +133,7 @@ impl TeamAgentProvisioner {
         assistant_catalog: Arc<dyn TeamAssistantCatalogPort>,
         provider_repo: Arc<dyn IProviderRepository>,
         conversation_port: Arc<dyn TeamConversationProvisioningPort>,
+        capability_port: Arc<dyn TeamToolCapabilityPort>,
     ) -> Self {
         Self {
             repo,
@@ -140,6 +141,7 @@ impl TeamAgentProvisioner {
             assistant_catalog,
             provider_repo,
             conversation_port,
+            capability_port,
         }
     }
 
@@ -377,7 +379,20 @@ impl TeamAgentProvisioner {
         task_manager: &Arc<dyn IWorkerTaskManager>,
     ) -> Result<(), TeamError> {
         let team_id = mcp_stdio_cfg.team_id.clone();
-        let transport = self.team_tool_transport(user_id, agent).await?;
+        let (transport, capabilities) = self.resolve_team_tool_transport(user_id, agent).await?;
+        info!(
+            team_id = %team_id,
+            slot_id = %agent.slot_id,
+            conversation_id = %agent.conversation_id,
+            backend = %agent.backend,
+            capability_origin = capabilities.origin.as_str(),
+            mcp_stdio = capabilities.mcp.stdio,
+            mcp_sse = capabilities.mcp.sse,
+            mcp_streamable_http = capabilities.mcp.streamable_http,
+            cli_fallback = capabilities.cli_fallback,
+            selected_transport = ?transport,
+            "resolved Team tool transport"
+        );
         match transport {
             TeamToolTransport::Mcp => {
                 self.write_team_mcp_runtime_config(user_id, agent, mcp_stdio_cfg)
@@ -406,55 +421,35 @@ impl TeamAgentProvisioner {
         Ok(())
     }
 
-    /// Pick how team tools reach this agent. Deliberately a DIFFERENT question
-    /// from "may this agent join a team" (`AgentMetadata::team_capable`), and
-    /// deliberately judged from `agent_capabilities` ALONE:
-    ///
-    /// - The membership gate may say yes from `behavior_policy.supports_team` — a
-    ///   known-good whitelist that needs no probe evidence. That whitelist must
-    ///   NOT reach in here: which transport actually works is a property of the
-    ///   running agent, not of a policy row, and guessing MCP for an agent that
-    ///   silently ignores injected `mcpServers` loses every team tool with no
-    ///   error to show for it. CLI is the safe answer when unproven.
-    /// - `agent_capabilities` is only written by a live handshake (plus the seed
-    ///   backfills in migrations 003/033). So an agent that has never connected on
-    ///   this machine has NULL capabilities and lands on CLI even when it does
-    ///   support MCP — notably claude/codex/gemini on a fresh install. The next
-    ///   rebuild after its first handshake promotes it to MCP.
-    ///
-    /// Both transports coordinate a team; MCP exposes the tools natively, CLI
-    /// prompts the agent to shell out to `$AIONUI_HELPER_BIN team ...`.
+    /// Pick how team tools reach this agent from the unified capability port.
+    /// The Team domain deliberately does not know vendor ids or persistence
+    /// formats; constructed descriptors and ACP handshakes are resolved outside.
     pub(crate) async fn team_tool_transport(
         &self,
         user_id: &str,
         agent: &TeamAgent,
     ) -> Result<TeamToolTransport, TeamError> {
-        let capabilities = self.agent_capabilities(user_id, &agent.backend).await?;
-        if supports_team_mcp_backend(&agent.backend, capabilities.as_ref()) {
-            return Ok(TeamToolTransport::Mcp);
+        self.resolve_team_tool_transport(user_id, agent)
+            .await
+            .map(|(transport, _)| transport)
+    }
+
+    async fn resolve_team_tool_transport(
+        &self,
+        user_id: &str,
+        agent: &TeamAgent,
+    ) -> Result<(TeamToolTransport, aionui_common::ResolvedBackendCapabilities), TeamError> {
+        let capabilities = self.capability_port.resolve(user_id, &agent.backend, None).await?;
+        if capabilities.mcp.stdio {
+            return Ok((TeamToolTransport::Mcp, capabilities));
         }
-        if supports_team_cli_fallback_backend(capabilities.as_ref()) {
-            return Ok(TeamToolTransport::CliAssumed);
+        if capabilities.cli_fallback {
+            return Ok((TeamToolTransport::CliAssumed, capabilities));
         }
         Err(TeamError::InvalidRequest(format!(
             "agent backend is not eligible for Team transport: {}",
             agent.backend
         )))
-    }
-
-    async fn agent_capabilities(&self, user_id: &str, backend: &str) -> Result<Option<serde_json::Value>, TeamError> {
-        let Some(metadata) = cli_backend_metadata(&self.agent_metadata_repo, user_id, backend).await? else {
-            return Ok(None);
-        };
-        let Some(raw) = metadata
-            .agent_capabilities
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        else {
-            return Ok(None);
-        };
-        Ok(serde_json::from_str(raw).ok())
     }
 
     pub(crate) async fn write_team_mcp_runtime_config(
@@ -999,6 +994,35 @@ mod tests {
 
     struct EmptyProviderRepo;
 
+    struct TestCapabilityPort;
+
+    #[async_trait]
+    impl TeamToolCapabilityPort for TestCapabilityPort {
+        async fn resolve(
+            &self,
+            _user_id: &str,
+            backend: &str,
+            _agent_id: Option<&str>,
+        ) -> Result<aionui_common::ResolvedBackendCapabilities, TeamError> {
+            let direct = matches!(backend, "claude" | "codex" | "antigravity");
+            let internal = backend == "aionrs";
+            Ok(aionui_common::ResolvedBackendCapabilities {
+                mcp: aionui_common::McpTransportCapabilities {
+                    stdio: direct || internal,
+                    ..Default::default()
+                },
+                cli_fallback: !internal,
+                origin: if direct {
+                    aionui_common::CapabilityOrigin::DirectDescriptor
+                } else if internal {
+                    aionui_common::CapabilityOrigin::InternalDescriptor
+                } else {
+                    aionui_common::CapabilityOrigin::Unknown
+                },
+            })
+        }
+    }
+
     #[async_trait]
     impl IProviderRepository for EmptyProviderRepo {
         async fn list(&self, _user_id: &str) -> Result<Vec<Provider>, DbError> {
@@ -1037,6 +1061,7 @@ mod tests {
             Arc::new(EmptyTeamAssistantCatalog),
             Arc::new(EmptyProviderRepo),
             Arc::new(RecordingProvisioningPort { events, patches }),
+            Arc::new(TestCapabilityPort),
         )
     }
 
@@ -1074,6 +1099,24 @@ mod tests {
         let transport = provisioner.team_tool_transport("user-test", &agent).await.unwrap();
 
         assert_eq!(transport, TeamToolTransport::Mcp);
+    }
+
+    #[tokio::test]
+    async fn direct_cli_transport_uses_mcp_without_historical_acp_snapshot() {
+        let provisioner = test_provisioner(Arc::new(Mutex::new(Vec::new())));
+
+        for backend in ["claude", "codex", "antigravity"] {
+            let mut agent = test_agent();
+            agent.backend = backend.into();
+
+            let transport = provisioner.team_tool_transport("user-test", &agent).await.unwrap();
+
+            assert_eq!(
+                transport,
+                TeamToolTransport::Mcp,
+                "direct backend {backend} must use its adapter descriptor instead of an absent ACP snapshot"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/aionui-team/src/service.rs
+++ b/crates/aionui-team/src/service.rs
@@ -41,7 +41,7 @@ use crate::member_runtime::{
 use crate::message_projection::TeamProjectionMessageStore;
 use crate::ports::{
     AgentTurnCancellationPort, AgentTurnExecutionPort, NativeSlashCommandPort, NoopNativeSlashCommandPort,
-    TeamAssistantCatalogPort,
+    TeamAssistantCatalogPort, TeamToolCapabilityPort, UnknownTeamToolCapabilityPort,
 };
 use crate::prompt_dump::TeamPromptDumpConfig;
 use crate::provisioning::{TeamAgentProvisioner, TeamConversationProvisioningPort};
@@ -127,6 +127,7 @@ pub struct TeamSessionService {
     task_manager: Arc<dyn IWorkerTaskManager>,
     turn_port: Arc<dyn AgentTurnExecutionPort>,
     cancellation_port: Arc<dyn AgentTurnCancellationPort>,
+    capability_port: Arc<dyn TeamToolCapabilityPort>,
     /// Native slash-command recognizer injected into each `TeamSession`
     /// (ELECTRON-3RN). No-op by default (see `NoopNativeSlashCommandPort`).
     slash_command_port: Arc<dyn NativeSlashCommandPort>,
@@ -182,6 +183,46 @@ impl TeamSessionService {
             turn_port,
             cancellation_port,
             Arc::new(NoopNativeSlashCommandPort),
+            Arc::new(UnknownTeamToolCapabilityPort),
+            backend_binary_path,
+            TeamPromptDumpConfig::disabled(),
+        )
+    }
+
+    /// Construct with an explicit backend-capability resolver while keeping
+    /// the default no-op slash catalog and disabled prompt dump.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_capability_port(
+        repo: Arc<dyn ITeamRepository>,
+        agent_metadata_repo: Arc<dyn IAgentMetadataRepository>,
+        assistant_catalog: Arc<dyn TeamAssistantCatalogPort>,
+        assistant_definition_repo: Arc<dyn IAssistantDefinitionRepository>,
+        assistant_overlay_repo: Arc<dyn IAssistantOverlayRepository>,
+        provider_repo: Arc<dyn IProviderRepository>,
+        conversation_port: Arc<dyn TeamConversationProvisioningPort>,
+        projection_store: Arc<dyn TeamProjectionMessageStore>,
+        broadcaster: Arc<dyn EventBroadcaster>,
+        task_manager: Arc<dyn IWorkerTaskManager>,
+        turn_port: Arc<dyn AgentTurnExecutionPort>,
+        cancellation_port: Arc<dyn AgentTurnCancellationPort>,
+        capability_port: Arc<dyn TeamToolCapabilityPort>,
+        backend_binary_path: Arc<PathBuf>,
+    ) -> Arc<Self> {
+        Self::new_with_prompt_dump(
+            repo,
+            agent_metadata_repo,
+            assistant_catalog,
+            assistant_definition_repo,
+            assistant_overlay_repo,
+            provider_repo,
+            conversation_port,
+            projection_store,
+            broadcaster,
+            task_manager,
+            turn_port,
+            cancellation_port,
+            Arc::new(NoopNativeSlashCommandPort),
+            capability_port,
             backend_binary_path,
             TeamPromptDumpConfig::disabled(),
         )
@@ -202,6 +243,7 @@ impl TeamSessionService {
         turn_port: Arc<dyn AgentTurnExecutionPort>,
         cancellation_port: Arc<dyn AgentTurnCancellationPort>,
         slash_command_port: Arc<dyn NativeSlashCommandPort>,
+        capability_port: Arc<dyn TeamToolCapabilityPort>,
         backend_binary_path: Arc<PathBuf>,
         prompt_dump: TeamPromptDumpConfig,
     ) -> Arc<Self> {
@@ -219,6 +261,7 @@ impl TeamSessionService {
             turn_port,
             cancellation_port,
             slash_command_port,
+            capability_port,
             backend_binary_path,
             prompt_dump,
             sessions: Arc::new(DashMap::new()),
@@ -236,6 +279,7 @@ impl TeamSessionService {
             self.assistant_catalog.clone(),
             self.provider_repo.clone(),
             self.conversation_port.clone(),
+            self.capability_port.clone(),
         )
     }
 

--- a/crates/aionui-team/tests/session_service_integration.rs
+++ b/crates/aionui-team/tests/session_service_integration.rs
@@ -15,7 +15,10 @@ use aionui_api_types::{
     AcpBuildExtra, AcpConfigOptionDto, AcpConfigSelectOptionDto, AddAgentRequest, CreateTeamRequest,
     GetConfigOptionsResponse, TeamAgentInput, TeamRunSource, WebSocketMessage,
 };
-use aionui_common::{AgentKillReason, AgentType, PaginatedResult, ProviderWithModel};
+use aionui_common::{
+    AgentKillReason, AgentType, CapabilityOrigin, McpTransportCapabilities, PaginatedResult, ProviderWithModel,
+    ResolvedBackendCapabilities,
+};
 use aionui_db::models::{
     AgentMetadataRow, AssistantDefinitionRow, AssistantOverlayRow, ConversationRow, MessageRow,
     UpdateAgentAvailabilitySnapshotParams, UpdateAgentHandshakeParams, UpsertAgentMetadataParams,
@@ -32,7 +35,7 @@ use aionui_realtime::EventBroadcaster;
 use aionui_team::ports::{
     AgentTurnCancellationPort, AgentTurnExecutionError, AgentTurnExecutionPort, AgentTurnOutcome, AgentTurnRequest,
     AgentTurnStarted, AgentTurnStatus, TeamAssistantCatalogEntry, TeamAssistantCatalogPort,
-    TeamConversationBindingLookup, TeamConversationLookupPort,
+    TeamConversationBindingLookup, TeamConversationLookupPort, TeamToolCapabilityPort,
 };
 use aionui_team::session::SpawnAgentRequest;
 use aionui_team::{
@@ -41,6 +44,34 @@ use aionui_team::{
 };
 use aionui_team::{TeamError, TeamSessionService};
 use common::MockTeamRepo;
+
+struct TestTeamToolCapabilityPort;
+
+#[async_trait::async_trait]
+impl TeamToolCapabilityPort for TestTeamToolCapabilityPort {
+    async fn resolve(
+        &self,
+        _user_id: &str,
+        backend: &str,
+        _agent_id: Option<&str>,
+    ) -> Result<ResolvedBackendCapabilities, TeamError> {
+        let constructed = matches!(backend, "aionrs" | "claude" | "codex" | "antigravity");
+        Ok(ResolvedBackendCapabilities {
+            mcp: McpTransportCapabilities {
+                stdio: constructed,
+                ..Default::default()
+            },
+            cli_fallback: !matches!(backend, "aionrs"),
+            origin: if backend == "aionrs" {
+                CapabilityOrigin::InternalDescriptor
+            } else if constructed {
+                CapabilityOrigin::DirectDescriptor
+            } else {
+                CapabilityOrigin::Unknown
+            },
+        })
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Mock ConversationRepository — minimal impl for TeamSessionService tests
@@ -1841,7 +1872,7 @@ fn setup_with_factory_metadata_team_repo_and_conversation_repo(
     let task_manager_dyn: Arc<dyn IWorkerTaskManager> = task_manager.clone();
     let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aioncore-test"));
     let provider_repo: Arc<dyn IProviderRepository> = Arc::new(EmptyProviderRepo);
-    let svc = TeamSessionService::new(
+    let svc = TeamSessionService::new_with_capability_port(
         team_repo_dyn,
         agent_metadata_repo,
         Arc::new(EmptyTeamAssistantCatalog),
@@ -1854,6 +1885,7 @@ fn setup_with_factory_metadata_team_repo_and_conversation_repo(
         task_manager_dyn,
         noop_turn_port(),
         noop_cancellation_port(),
+        Arc::new(TestTeamToolCapabilityPort),
         backend_binary_path,
     );
     (svc, team_repo, task_manager, conv_repo)
@@ -1886,7 +1918,7 @@ fn setup_with_factory_metadata_assistants_and_conversation_repo(
         assistant_definition_repo: assistant_definition_repo.clone(),
         assistant_overlay_repo: assistant_overlay_repo.clone(),
     });
-    let svc = TeamSessionService::new(
+    let svc = TeamSessionService::new_with_capability_port(
         team_repo_dyn,
         agent_metadata_repo,
         assistant_catalog,
@@ -1899,6 +1931,7 @@ fn setup_with_factory_metadata_assistants_and_conversation_repo(
         task_manager_dyn,
         noop_turn_port(),
         noop_cancellation_port(),
+        Arc::new(TestTeamToolCapabilityPort),
         backend_binary_path,
     );
     (svc, team_repo, task_manager, conv_repo)
@@ -1947,7 +1980,7 @@ fn setup_with_ports_metadata_assistants_and_conversation_repo(
         assistant_definition_repo: assistant_definition_repo.clone(),
         assistant_overlay_repo: assistant_overlay_repo.clone(),
     });
-    let svc = TeamSessionService::new(
+    let svc = TeamSessionService::new_with_capability_port(
         team_repo_dyn,
         agent_metadata_repo,
         assistant_catalog,
@@ -1960,6 +1993,7 @@ fn setup_with_ports_metadata_assistants_and_conversation_repo(
         task_manager,
         noop_turn_port(),
         noop_cancellation_port(),
+        Arc::new(TestTeamToolCapabilityPort),
         backend_binary_path,
     );
     (svc, team_repo, conversation_ports, conv_repo)
@@ -1982,7 +2016,7 @@ fn setup_with_recording_turn_port() -> (
     let turn_port = Arc::new(RecordingTurnPort::default());
     let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aioncore-test"));
     let provider_repo: Arc<dyn IProviderRepository> = Arc::new(EmptyProviderRepo);
-    let svc = TeamSessionService::new(
+    let svc = TeamSessionService::new_with_capability_port(
         team_repo_dyn,
         Arc::new(StubAgentMetadataRepo::empty()),
         Arc::new(EmptyTeamAssistantCatalog),
@@ -1995,6 +2029,7 @@ fn setup_with_recording_turn_port() -> (
         task_manager,
         turn_port.clone(),
         noop_cancellation_port(),
+        Arc::new(TestTeamToolCapabilityPort),
         backend_binary_path,
     );
     (svc, team_repo, turn_port, conv_repo)
@@ -2187,7 +2222,7 @@ fn setup_with_recording_broadcaster() -> (Arc<TeamSessionService>, Arc<Recording
     let task_manager: Arc<dyn IWorkerTaskManager> = Arc::new(CountingTaskManager::new(success_factory()));
     let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aioncore-test"));
     let provider_repo: Arc<dyn IProviderRepository> = Arc::new(EmptyProviderRepo);
-    let svc = TeamSessionService::new(
+    let svc = TeamSessionService::new_with_capability_port(
         team_repo,
         agent_metadata_repo,
         Arc::new(EmptyTeamAssistantCatalog),
@@ -2200,6 +2235,7 @@ fn setup_with_recording_broadcaster() -> (Arc<TeamSessionService>, Arc<Recording
         task_manager,
         noop_turn_port(),
         noop_cancellation_port(),
+        Arc::new(TestTeamToolCapabilityPort),
         backend_binary_path,
     );
     (svc, recorder)
@@ -2240,7 +2276,7 @@ fn setup_with_factory_recording_broadcaster_and_conversation_repo(factory: Agent
     let task_manager_dyn: Arc<dyn IWorkerTaskManager> = task_manager.clone();
     let backend_binary_path = Arc::new(std::path::PathBuf::from("/tmp/aioncore-test"));
     let provider_repo: Arc<dyn IProviderRepository> = Arc::new(EmptyProviderRepo);
-    let svc = TeamSessionService::new(
+    let svc = TeamSessionService::new_with_capability_port(
         team_repo_dyn,
         agent_metadata_repo,
         Arc::new(EmptyTeamAssistantCatalog),
@@ -2253,6 +2289,7 @@ fn setup_with_factory_recording_broadcaster_and_conversation_repo(factory: Agent
         task_manager_dyn,
         noop_turn_port(),
         noop_cancellation_port(),
+        Arc::new(TestTeamToolCapabilityPort),
         backend_binary_path,
     );
     (svc, team_repo, task_manager, recorder, conv_repo)
@@ -6164,6 +6201,64 @@ async fn d9_ensure_session_persists_team_mcp_stdio_config() {
         .unwrap();
 
     svc.ensure_session("user1", &created.id).await.unwrap();
+}
+
+#[tokio::test]
+async fn direct_cli_ensure_session_persists_team_mcp_stdio_config_for_every_descriptor() {
+    use futures_util::FutureExt;
+
+    for backend in ["claude", "codex", "antigravity"] {
+        let expected_backend = backend.to_owned();
+        let factory: AgentFactory = Arc::new(move |opts: BuildTaskOptions| {
+            let expected_backend = expected_backend.clone();
+            async move {
+                let mcp = opts
+                    .context
+                    .team
+                    .as_ref()
+                    .and_then(|team| team.mcp.as_ref())
+                    .unwrap_or_else(|| panic!("{expected_backend} factory context has no Team MCP config"));
+                assert!(mcp.stdio.port > 0, "{expected_backend} Team MCP port");
+                assert!(!mcp.stdio.slot_id.is_empty(), "{expected_backend} Team MCP slot");
+                assert!(
+                    !mcp.stdio.binary_path.is_empty(),
+                    "{expected_backend} Team MCP binary path"
+                );
+                Ok(aionui_ai_agent::AgentInstance::Mock(Arc::new(
+                    mock_agent::MockAgent::new(opts.context.conversation.conversation_id, opts.context.workspace.path),
+                )))
+            }
+            .boxed()
+        });
+        let mut metadata = make_agent_metadata_row(&format!("{backend}-id"), backend, "");
+        if backend == "antigravity" {
+            metadata.agent_type = "antigravity".into();
+        }
+        let (svc, _tm) =
+            setup_with_factory_and_metadata(factory, Arc::new(StubAgentMetadataRepo::with_rows(vec![metadata])));
+        let created = svc
+            .create_team(
+                "user1",
+                CreateTeamRequest {
+                    name: format!("Direct {backend}"),
+                    agents: vec![TeamAgentInput {
+                        name: "Lead".into(),
+                        role: "lead".into(),
+                        backend: Some(backend.into()),
+                        model: backend.into(),
+                        assistant_id: None,
+                        conversation_id: None,
+                    }],
+                    workspace: None,
+                },
+            )
+            .await
+            .unwrap_or_else(|error| panic!("{backend} team creation failed: {error}"));
+
+        svc.ensure_session("user1", &created.id)
+            .await
+            .unwrap_or_else(|error| panic!("{backend} Team session ensure failed: {error}"));
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Restore constructed Team MCP capabilities for direct CLI backends.
- Propagate runtime environment context to direct CLI sessions while preserving CLI fallback support.
- Resolve Team tool transport through unified backend capability descriptors.
- Add contract tests that keep descriptors, factory routes, metadata projection, and Team resolution in sync.

## Verification

- `LC_ALL=C LANG=C just push -u origin fix/direct-cli-team-mcp-runtime-env`
- 8,516 workspace tests passed.
- Manually validated Team MCP calls with Codex and Claude in the development environment.