### PR TITLE
fix(acp): give a first-run npx agent room to install before initialize times out

### DIFF
--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -249,6 +249,7 @@ async fn spawn_and_connect_acp_once(
         notification_tx,
         &params.conversation_id,
         Some(std::path::PathBuf::from(&params.workspace.path)),
+        crate::protocol::acp_init_budget::init_budget(&params.command_spec),
     );
     tokio::pin!(connect_fut);
     let protocol = tokio::select! {

--- a/crates/aionui-ai-agent/src/protocol/acp.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp.rs
@@ -47,6 +47,7 @@ use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec};
 use tracing::{debug, info, warn};
 
 use crate::protocol::acp_dialect;
+use crate::protocol::acp_init_budget::InitBudget;
 use crate::protocol::error::AcpError;
 use crate::protocol::events::{self as stream_event, AgentStreamEvent};
 
@@ -68,11 +69,9 @@ fn build_legacy_set_model_params(session_id: &str, model_id: &str) -> serde_json
     serde_json::json!({ "sessionId": session_id, "modelId": model_id })
 }
 
-/// Timeout for the ACP initialize handshake (seconds).
-const INIT_TIMEOUT_SECS: u64 = 30;
-
 /// Timeout for the short config/mode/model RPCs (seconds). Intentionally
-/// shorter than INIT_TIMEOUT_SECS; a dropped/absent response self-heals via retry.
+/// shorter than every `initialize` budget in [`acp_init_budget`]; a
+/// dropped/absent response self-heals via retry.
 const CONFIG_RPC_TIMEOUT_SECS: u64 = 10;
 
 /// Client identity reported in the ACP `initialize` handshake (`clientInfo`).
@@ -170,6 +169,11 @@ impl AcpProtocol {
     /// Takes ownership of the child's stdin/stdout (from [`CliAgentProcess::take_stdio`]).
     /// Spawns the SDK background task for JSON-RPC message routing.
     /// Returns after the initialize handshake completes successfully.
+    ///
+    /// `init_budget` bounds the handshake. It is passed in rather than read
+    /// here because only the caller knows whether this launch still has to
+    /// install its package — see [`crate::protocol::acp_init_budget`].
+    #[allow(clippy::too_many_arguments)]
     pub async fn connect(
         stdin: ChildStdin,
         stdout: ChildStdout,
@@ -178,12 +182,13 @@ impl AcpProtocol {
         notification_tx: mpsc::Sender<SessionNotification>,
         terminal_label: &str,
         terminal_cwd: Option<std::path::PathBuf>,
+        init_budget: InitBudget,
     ) -> Result<Self, AcpError> {
         let alive = Arc::new(AtomicBool::new(true));
         let replay_suppression = Arc::new(AtomicBool::new(false));
         let terminal_registry = Arc::new(crate::terminal::TerminalRegistry::new(terminal_label, terminal_cwd));
         let started_at = std::time::Instant::now();
-        log_acp_initialize_start();
+        log_acp_initialize_start(init_budget);
 
         // Signals from the background task:
         // - `init_tx`: initialize handshake result (with possible SDK error)
@@ -211,8 +216,7 @@ impl AcpProtocol {
         ));
 
         // Wait for init to complete with timeout.
-        let init_response = match tokio::time::timeout(std::time::Duration::from_secs(INIT_TIMEOUT_SECS), init_rx).await
-        {
+        let init_response = match tokio::time::timeout(init_budget.timeout, init_rx).await {
             Ok(Ok(Ok(response))) => {
                 log_acp_initialize_success(started_at.elapsed().as_millis() as u64);
                 response
@@ -232,7 +236,7 @@ impl AcpProtocol {
             Err(_) => {
                 log_acp_initialize_failed("timeout", started_at.elapsed().as_millis() as u64);
                 return Err(AcpError::InitTimeout {
-                    timeout_secs: INIT_TIMEOUT_SECS,
+                    timeout_secs: init_budget.timeout.as_secs(),
                 });
             }
         };
@@ -1067,11 +1071,12 @@ fn string_pointer(value: &serde_json::Value, pointers: &[&str]) -> Option<String
         .map(str::to_owned)
 }
 
-fn log_acp_initialize_start() {
+fn log_acp_initialize_start(init_budget: InitBudget) {
     info!(
         target: "aionui_feedback_diagnostics",
         diagnostic_event = "feedback.runtime.acp_initialize_start",
-        timeout_secs = INIT_TIMEOUT_SECS,
+        timeout_secs = init_budget.timeout.as_secs(),
+        cold_start = init_budget.cold_start,
         "feedback.runtime.acp_initialize_start"
     );
 }
@@ -1415,7 +1420,7 @@ mod tests {
         use tracing::Level;
 
         let captured = capture_logs(Level::INFO, || {
-            super::log_acp_initialize_start();
+            super::log_acp_initialize_start(steady_state_budget());
             super::log_acp_initialize_success(123);
             super::log_acp_initialize_failed("timeout", 456);
         });
@@ -1431,8 +1436,34 @@ mod tests {
             "{captured}"
         );
         assert!(captured.contains("timeout_secs=30"), "{captured}");
+        assert!(captured.contains("cold_start=false"), "{captured}");
         assert!(captured.contains("failure_class=timeout"), "{captured}");
         assert!(captured.contains("elapsed_ms=456"), "{captured}");
+    }
+
+    fn steady_state_budget() -> crate::protocol::acp_init_budget::InitBudget {
+        crate::protocol::acp_init_budget::InitBudget {
+            timeout: std::time::Duration::from_secs(30),
+            cold_start: false,
+        }
+    }
+
+    /// A cold start must be visible in the diagnostic log: a 300s wait that
+    /// reads as an ordinary 30s one leaves "the agent hung" indistinguishable
+    /// from "the package is still downloading".
+    #[test]
+    fn acp_initialize_start_log_reports_the_cold_start_budget_it_actually_used() {
+        use tracing::Level;
+
+        let captured = capture_logs(Level::INFO, || {
+            super::log_acp_initialize_start(crate::protocol::acp_init_budget::InitBudget {
+                timeout: std::time::Duration::from_secs(300),
+                cold_start: true,
+            });
+        });
+
+        assert!(captured.contains("timeout_secs=300"), "{captured}");
+        assert!(captured.contains("cold_start=true"), "{captured}");
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/protocol/acp_init_budget.rs
+++ b/crates/aionui-ai-agent/src/protocol/acp_init_budget.rs
@@ -1,0 +1,179 @@
+//! Budget for the ACP `initialize` handshake.
+//!
+//! A bridge-launched row (`npx -y <package> …`) pays a package install on its
+//! FIRST spawn, and that install happens inside the handshake window: npx
+//! downloads before the agent process can answer `initialize`. Measured cold
+//! runs on a fast link already exceed the steady-state budget by a wide margin
+//! (`@oh-my-pi/pi-coding-agent`: 81s cold vs 10s warm), so a single flat budget
+//! either fails every first run or lets a genuinely hung agent idle for minutes.
+//!
+//! So the budget is picked per spawn: a launch whose npx package is not yet in
+//! the cache gets the cold-start budget, everything else keeps the steady-state
+//! one. "Not yet in the cache" is decided by the same `_npx/<hash>` entry
+//! `npx_cache_repair` computes, so both features agree on which directory npm
+//! would use for this exact package set.
+
+use std::time::Duration;
+
+use aionui_common::CommandSpec;
+
+use super::npx_cache_repair::computed_npx_cache_entry;
+
+/// Steady-state `initialize` budget (seconds), used once the launch has
+/// everything it needs on disk.
+pub(crate) const INIT_TIMEOUT_SECS: u64 = 30;
+
+/// `initialize` budget (seconds) for a launch that still has to install its
+/// package. Sized off the slowest measured cold run (81s on a fast link) with
+/// headroom for connections several times slower.
+pub(crate) const COLD_START_INIT_TIMEOUT_SECS: u64 = 300;
+
+/// Overrides [`COLD_START_INIT_TIMEOUT_SECS`] for environments whose first-run
+/// install is slower still. Mirrors `AIONUI_HANDSHAKE_TIMEOUT_SECS`.
+const COLD_START_TIMEOUT_ENV: &str = "AIONUI_ACP_INIT_TIMEOUT_SECS";
+
+/// The chosen budget plus the reason, so the caller can log which one applied
+/// instead of leaving a 300s wait unexplained.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct InitBudget {
+    pub(crate) timeout: Duration,
+    pub(crate) cold_start: bool,
+}
+
+/// Pick the `initialize` budget for `command_spec`.
+pub(crate) fn init_budget(command_spec: &CommandSpec) -> InitBudget {
+    init_budget_with(command_spec, cold_start_timeout_secs())
+}
+
+/// Budget selection without the environment read, so tests stay deterministic
+/// (`std::env` is process-global and would race across parallel tests).
+fn init_budget_with(command_spec: &CommandSpec, cold_start_secs: u64) -> InitBudget {
+    if awaiting_first_install(command_spec) {
+        return InitBudget {
+            timeout: Duration::from_secs(cold_start_secs),
+            cold_start: true,
+        };
+    }
+    InitBudget {
+        timeout: Duration::from_secs(INIT_TIMEOUT_SECS),
+        cold_start: false,
+    }
+}
+
+/// Whether this launch still has to install its npx package.
+///
+/// False for a direct-CLI launch (nothing to install) and false when the cache
+/// location cannot be computed — an unknown cache state is not evidence of a
+/// first run, and guessing "cold" there would hand every unresolvable launch
+/// the long budget.
+fn awaiting_first_install(command_spec: &CommandSpec) -> bool {
+    computed_npx_cache_entry(command_spec).is_some_and(|entry| !entry.exists())
+}
+
+fn cold_start_timeout_secs() -> u64 {
+    parse_cold_start_secs(std::env::var(COLD_START_TIMEOUT_ENV).ok().as_deref())
+}
+
+/// Parse the override, ignoring absent, unparsable, and zero values.
+fn parse_cold_start_secs(raw: Option<&str>) -> u64 {
+    raw.and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .unwrap_or(COLD_START_INIT_TIMEOUT_SECS)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use aionui_common::{CommandSpec, EnvVar};
+
+    use super::{COLD_START_INIT_TIMEOUT_SECS, INIT_TIMEOUT_SECS, init_budget_with, parse_cold_start_secs};
+
+    /// Package set and cache hash are the pair `npx_cache_repair` already pins
+    /// in `computes_npx_cache_entry_from_direct_package_argument`, so these
+    /// tests anchor on an independently verified hash rather than on the
+    /// function under test.
+    const PINNED_ARGS: &[&str] = &["-y", "@xai-official/grok@0.2.102", "agent", "stdio"];
+    const PINNED_CACHE_HASH: &str = "c16927192d2e8dc3";
+
+    fn npx_spec(cache: &Path) -> CommandSpec {
+        CommandSpec {
+            command: PathBuf::from("npx"),
+            args: PINNED_ARGS.iter().map(|arg| (*arg).to_owned()).collect(),
+            env: vec![EnvVar {
+                name: "npm_config_cache".to_owned(),
+                value: cache.display().to_string(),
+            }],
+            cwd: None,
+        }
+    }
+
+    #[test]
+    fn npx_launch_whose_package_is_not_installed_yet_gets_the_cold_start_budget() {
+        let temp = tempfile::tempdir().unwrap();
+        let spec = npx_spec(temp.path());
+
+        let budget = init_budget_with(&spec, 300);
+
+        assert!(budget.cold_start, "a missing npx cache entry is a first run");
+        assert_eq!(budget.timeout.as_secs(), 300);
+    }
+
+    #[test]
+    fn npx_launch_whose_package_is_already_installed_keeps_the_steady_state_budget() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("_npx").join(PINNED_CACHE_HASH)).unwrap();
+        let spec = npx_spec(temp.path());
+
+        let budget = init_budget_with(&spec, 300);
+
+        assert!(!budget.cold_start, "a populated cache entry is not a first run");
+        assert_eq!(budget.timeout.as_secs(), INIT_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn direct_cli_launch_keeps_the_steady_state_budget() {
+        let spec = CommandSpec {
+            command: PathBuf::from("omp"),
+            args: vec!["acp".to_owned()],
+            env: vec![],
+            cwd: None,
+        };
+
+        let budget = init_budget_with(&spec, 300);
+
+        assert!(!budget.cold_start, "a direct CLI has no package to install");
+        assert_eq!(budget.timeout.as_secs(), INIT_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn npx_launch_without_a_cache_location_keeps_the_steady_state_budget() {
+        let spec = CommandSpec {
+            command: PathBuf::from("npx"),
+            args: PINNED_ARGS.iter().map(|arg| (*arg).to_owned()).collect(),
+            env: vec![],
+            cwd: None,
+        };
+
+        let budget = init_budget_with(&spec, 300);
+
+        assert!(
+            !budget.cold_start,
+            "an uncomputable cache location is not evidence of a first run"
+        );
+        assert_eq!(budget.timeout.as_secs(), INIT_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn cold_start_override_is_read_from_the_environment_value() {
+        assert_eq!(parse_cold_start_secs(Some("900")), 900);
+        assert_eq!(parse_cold_start_secs(Some(" 900 ")), 900);
+    }
+
+    #[test]
+    fn absent_unparsable_and_zero_overrides_fall_back_to_the_default() {
+        assert_eq!(parse_cold_start_secs(None), COLD_START_INIT_TIMEOUT_SECS);
+        assert_eq!(parse_cold_start_secs(Some("soon")), COLD_START_INIT_TIMEOUT_SECS);
+        assert_eq!(parse_cold_start_secs(Some("0")), COLD_START_INIT_TIMEOUT_SECS);
+    }
+}

--- a/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
+++ b/crates/aionui-ai-agent/src/protocol/custom_agent_probe.rs
@@ -17,6 +17,8 @@ use std::time::Duration;
 
 use aionui_api_types::{AgentHandshake, TryConnectCustomAgentResponse};
 use aionui_common::{CommandSpec, EnvVar};
+
+use crate::protocol::acp_init_budget::{INIT_TIMEOUT_SECS, InitBudget};
 use aionui_runtime::{NodeRuntimeProgressReporter, ResolvedCommand, ensure_runtime_command_with_reporter};
 use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, warn};
@@ -194,8 +196,14 @@ async fn run_handshake(proc: &CliAgentProcess) -> ProbeOutcome {
     // Race the ACP initialize handshake against the child process exiting.
     // A misconfigured CLI (e.g. an invalid package launcher command) exits
     // almost immediately with a non-zero status; without this race the
-    // `AcpProtocol::connect` call would block on its internal 30 s
-    // timeout waiting for an `initialize` reply that will never arrive.
+    // `AcpProtocol::connect` call would block on its whole initialize budget
+    // waiting for an `initialize` reply that will never arrive.
+    //
+    // The probe passes the steady-state budget rather than deriving a
+    // cold-start one: the caller already caps this handshake at
+    // `STEP2_TIMEOUT`, so a longer inner budget could never elapse. Keeping
+    // the inner budget strictly below that cap also preserves which timeout
+    // reports the failure — the inner one, as `InitTimeout`.
     let connect = AcpProtocol::connect(
         stdin,
         stdout,
@@ -204,6 +212,10 @@ async fn run_handshake(proc: &CliAgentProcess) -> ProbeOutcome {
         notification_tx,
         "custom-agent-probe",
         None,
+        InitBudget {
+            timeout: Duration::from_secs(INIT_TIMEOUT_SECS),
+            cold_start: false,
+        },
     );
     let protocol = tokio::select! {
         biased;

--- a/crates/aionui-ai-agent/src/protocol/mod.rs
+++ b/crates/aionui-ai-agent/src/protocol/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod acp;
 pub(crate) mod acp_dialect;
+pub(crate) mod acp_init_budget;
 
 pub(crate) mod custom_agent_probe;
 pub(crate) mod error;

--- a/crates/aionui-ai-agent/src/protocol/npx_cache_repair.rs
+++ b/crates/aionui-ai-agent/src/protocol/npx_cache_repair.rs
@@ -41,7 +41,7 @@ fn computed_existing_npx_cache_entry(command_spec: &CommandSpec) -> Option<PathB
     Some(npx_cache_entry)
 }
 
-fn computed_npx_cache_entry(command_spec: &CommandSpec) -> Option<PathBuf> {
+pub(crate) fn computed_npx_cache_entry(command_spec: &CommandSpec) -> Option<PathBuf> {
     let npm_cache = command_spec_env(command_spec, "npm_config_cache")?;
     let packages = npx_package_specs(command_spec)?;
     let hash = npm_npx_cache_hash(&packages);


### PR DESCRIPTION
## Problem

A builtin ACP row launched through `npx -y <package>` pays its package install *inside* the initialize window — npx downloads before the agent process can answer `initialize`. The budget was a flat 30s (`protocol/acp.rs`), and for at least one shipped agent that is not enough on any link.

Measured locally against the pinned packages, timing from process start to the `initialize` response:

| package | cold cache | warm cache | local CLI |
|---|---|---|---|
| `@oh-my-pi/pi-coding-agent` (omp) | **81.0s** | 10.0s | 0.7s |
| `@mimo-ai/cli` (mimo-code) | 16.0s | 3.6s | 1.5s |

So omp exceeded the budget by 2.7x on a fast link and failed every first start with `acp_init_failed` / `Incoming transport closed`, staying offline until the user retried often enough to warm the cache. The two packages differ by 5x despite mimo downloading *more* bytes (a 95 MB platform binary vs a 37.5 MB tarball) — omp resolves 26 runtime dependencies where mimo has none — so this is not a property of npx that a single tuned constant can absorb.

## What changed

**The budget is picked per spawn.** New `protocol/acp_init_budget`: a launch whose npx cache entry does not exist yet gets a 300s cold-start budget; everything else keeps the unchanged 30s. A genuinely hung agent therefore still fails in 30s rather than idling for minutes — which is what a flat raise would have cost.

**First-run detection reuses existing, already-tested machinery.** `npx_cache_repair::computed_npx_cache_entry` becomes `pub(crate)` rather than growing a second implementation: both features must agree on the `_npx/<hash>` directory npm would use for this exact package set, including the `--package` form and the node-wrapped `npx-cli.js` form it already covers.

**`AcpProtocol::connect` takes the budget** instead of reading a constant — only the caller knows whether this launch still has to install. `manager::acp::agent` derives it from the spawn's command spec.

**The custom-agent probe passes the steady-state budget explicitly.** Its caller already caps the handshake at `STEP2_TIMEOUT` (35s), so a longer inner budget could never elapse; keeping the inner one strictly below that cap also preserves which timeout reports the failure (the inner one, as `InitTimeout`).

**300s is overridable** via `AIONUI_ACP_INIT_TIMEOUT_SECS`, mirroring the existing `AIONUI_HANDSHAKE_TIMEOUT_SECS` precedent, for links slower still than the one these numbers came from.

## Why the detection is not dead code

`computed_npx_cache_entry` needs `npm_config_cache` in the command spec, so the fix only fires if production specs actually carry it. Traced end to end before writing it:

`managed_env()` sets `npm_config_cache` (`node_runtime/managed.rs:782`) → attached at the runtime built in `managed.rs:322` → carried by `npx_command()` (`node_runtime/types.rs:70`) → copied into the `CommandSpec` env by `factory::acp::resolve_agent_command_spec`. The one construction site that produces an env-less runtime (`probe_runtime_root`, `managed.rs:393`) is reached only by `doctor_snapshot`.

Where the location genuinely cannot be computed, the budget stays at 30s: an unknown cache state is not evidence of a first run, and guessing "cold" there would hand every unresolvable launch the long budget.

## Logging

`acp_initialize_start` now carries the budget actually used plus a `cold_start` flag. Without it a 300s wait is indistinguishable in logs from a hang, which is the one question this change makes harder to answer. Existing `info` level, no payloads.

## Verification

### End-to-end, against a genuinely cold cache

A fresh `--data-dir` moves the runtime root to `{data_dir}/runtime` (`cache.rs:44-52`), so the npm cache is empty and this is a real first run rather than a simulated one. Backend started with `--local`, an omp conversation created over the REST API, then `POST /api/conversations/{id}/runtime/ensure` — the path that spawns the agent and runs the handshake.

**With the fix:**

```
acp_initialize_start    timeout_secs=300  cold_start=true
acp_initialize_success  elapsed_ms=47372
→ HTTP 200, real config catalog returned (omp's default/plan modes)
```

**Negative control** — same script, same cold environment, only `AIONUI_ACP_INIT_TIMEOUT_SECS=30` to reproduce the old budget:

```
acp_initialize_start    timeout_secs=30   cold_start=true
acp_initialize_failed   failure_class=timeout  elapsed_ms=30002
→ HTTP 502 BAD_GATEWAY
```

The handshake took **47.4s**, so this run would have failed before this change and does not now; the A/B shows the budget is what makes the difference rather than a lucky environment. The 502 is the failure shape reported in AionUi#4009.

### Static

- `cargo test -p aionui-ai-agent` — 946 + 38 passed, 0 failed
- `cargo clippy -p aionui-ai-agent --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Written test-first. All six budget tests were watched failing against an `unimplemented!()` stub before the logic existed, so each is known to reach the code under test rather than passing on setup. The two cache-state tests anchor on the package/hash pair `npx_cache_repair` already pins independently, not on the function under test.
- Local `nextest` across the workspace not run (work-hours policy); CI's Test check is the authority.

## The frontend does not cut the request short

Checked rather than assumed, since a 300s handshake now holds `ensure_runtime` open that long. `ensureRuntime` goes through `httpPost` (`ipcBridge.ts:259`), whose `fetch` carries no `signal`, no `AbortController` and no timeout (`httpBridge.ts:197`); the only `setTimeout` in that module drives WebSocket reconnection. Backend-side there is no tower `TimeoutLayer` in `aionui-app` and nothing shorter in the ACP startup chain. The 94.8s `ensure_runtime` in the run above completed normally over HTTP.

## Scope this does NOT cover

- **Progress reporting.** The user still sees a silent spinner during the install; the `runtime.statusChanged` channel that already reports managed-Node downloads is not extended to agent packages. Deliberate — chosen for a minimal fix over a prepare-with-progress step.
- **`STEP2_TIMEOUT`.** A custom npx agent's first "Test Connection" is still capped at 35s and can still fail cold. Untouched on purpose: that budget is the probe's own contract.

Refs iOfficeAI/AionUi#4009
