### PR TITLE
fix(agents): launch omp through its local CLI instead of the npx bridge

### DIFF
--- a/crates/aionui-ai-agent/src/registry.rs
+++ b/crates/aionui-ai-agent/src/registry.rs
@@ -1681,7 +1681,7 @@ mod tests {
                 .unwrap_or_else(|error| panic!("missing release lock for {backend}: {error}"));
             locked += 1;
         }
-        assert_eq!(locked, 13);
+        assert_eq!(locked, 12);
     }
 
     /// On a host that has *none* of the seeded CLIs installed, the

--- a/crates/aionui-db/migrations/039_omp_direct_cli_launch.sql
+++ b/crates/aionui-db/migrations/039_omp_direct_cli_launch.sql
@@ -1,0 +1,40 @@
+-- omp launches its local CLI directly instead of bridging through npx.
+--
+-- 031 seeded omp as `npx -y @oh-my-pi/pi-coding-agent acp` with
+-- `binary_name: "omp"`, following the shape used by the Registry-listed npx
+-- rows. That shape does not fit omp:
+--
+--   * The Registry rows bridge because the ACP Registry declares an npx
+--     distribution for them (verified against the public catalogue: 11 of the
+--     13 npx rows match their Registry entry's package and args exactly). omp
+--     is NOT listed on the Registry, so there is no declared distribution to
+--     conform to — the bridge was chosen by analogy, not by evidence.
+--   * `@oh-my-pi/pi-coding-agent` is not an ACP adapter wrapping some other
+--     CLI; it ships bin `omp` (package.json `bin: {omp: dist/cli.js}`) and
+--     `omp acp` is the vendor's own entrypoint. The package IS the product.
+--   * `binary_name: "omp"` already made a local `omp` on $PATH mandatory:
+--     `probe_resolved_command` fails the row with `PrimaryMissing` without it,
+--     and `cli_probe::validate_with_budget` already runs the local
+--     `omp --version`. So the bridge re-downloaded a CLI the user had to have
+--     installed before the row was even offered.
+--
+-- The cost of that was measured, spawn to `initialize` response: 81.0s on a
+-- cold npx cache and 10.0s warm, against 0.7s for the local binary. The cold
+-- figure is from a fast link and exceeded the 30s handshake budget outright,
+-- which is the failure reported in iOfficeAI/AionUi#4009.
+--
+-- Written as an UPDATE rather than a re-seed on purpose: `agent_capabilities`
+-- and `auth_methods` hold what a live handshake learned on THIS install, and
+-- an `ON CONFLICT DO UPDATE` that lists them resets that to an integration-time
+-- snapshot. An UPDATE of the launch columns cannot reach them at all.
+--
+-- Version pinning moves with the launch path: the `acp-registry-npx-lock.json`
+-- entry is dropped in the same change, so omp now tracks whatever the user has
+-- installed, exactly as the other direct-CLI builtins (qwen, agy) do.
+UPDATE agent_metadata
+SET command = 'omp',
+    args = '["acp"]',
+    agent_source_info = '{"binary_name":"omp"}',
+    updated_at = unixepoch('now','subsec')*1000
+WHERE agent_source = 'builtin'
+  AND backend = 'omp';

--- a/crates/aionui-db/tests/omp_direct_cli_migration.rs
+++ b/crates/aionui-db/tests/omp_direct_cli_migration.rs
@@ -1,0 +1,79 @@
+//! omp launches its local CLI directly rather than through the npx bridge.
+//!
+//! omp is a non-Registry builtin, so there is no Registry-declared npx
+//! distribution to conform to: `@oh-my-pi/pi-coding-agent` ships bin `omp`,
+//! and `omp acp` is the vendor's own ACP entrypoint. The row already gated
+//! availability on a local `omp` through `binary_name`, so bridging the spawn
+//! through npx re-downloaded a CLI the user was required to have installed
+//! before the row was even offered.
+
+use aionui_db::{IAgentMetadataRepository, SqliteAgentMetadataRepository, init_database_memory};
+
+#[tokio::test]
+async fn omp_spawns_its_local_cli_instead_of_bridging_through_npx() {
+    let db = init_database_memory().await.unwrap();
+    let repo = SqliteAgentMetadataRepository::new(db.pool().clone());
+
+    let row = repo
+        .find_builtin_by_backend("omp")
+        .await
+        .unwrap()
+        .expect("omp is seeded");
+
+    assert_eq!(row.command.as_deref(), Some("omp"), "omp command");
+    assert_eq!(row.args.as_deref(), Some(r#"["acp"]"#), "omp args");
+
+    let source: serde_json::Value =
+        serde_json::from_str(row.agent_source_info.as_deref().expect("omp agent_source_info")).unwrap();
+    assert_eq!(source["binary_name"], "omp", "omp binary_name");
+    assert!(
+        source.get("bridge_binary").is_none(),
+        "a direct-CLI row must not declare a bridge: {source}"
+    );
+}
+
+/// The re-seed must not reset what a live handshake taught this install. A
+/// migration that lists `agent_capabilities` / `auth_methods` in its
+/// `ON CONFLICT DO UPDATE` set is dead code on a fresh row and silent data
+/// loss on an existing one, so the columns are asserted here rather than
+/// trusted to review.
+#[tokio::test]
+async fn omp_keeps_its_probed_handshake_columns_and_skills_dirs() {
+    let db = init_database_memory().await.unwrap();
+    let repo = SqliteAgentMetadataRepository::new(db.pool().clone());
+
+    let row = repo
+        .find_builtin_by_backend("omp")
+        .await
+        .unwrap()
+        .expect("omp is seeded");
+
+    assert_eq!(
+        row.native_skills_dirs.as_deref(),
+        Some(r#"[".omp/skills",".claude/skills"]"#),
+        "omp skills dirs"
+    );
+    assert!(
+        row.agent_capabilities.is_some(),
+        "omp keeps the agent_capabilities its probe seeded"
+    );
+    assert!(
+        row.auth_methods.is_some(),
+        "omp keeps the auth_methods its probe seeded"
+    );
+    assert_eq!(row.yolo_id.as_deref(), None, "omp advertises no yolo mode");
+}
+
+/// The lock manifest pins npx packages. A direct-CLI row has no package to
+/// pin, so leaving the entry behind would keep asserting a version nothing
+/// launches.
+#[test]
+fn omp_is_no_longer_pinned_in_the_npx_release_lock() {
+    let lock = include_str!("../../aionui-runtime/resources/acp-registry-npx-lock.json");
+    let parsed: serde_json::Value = serde_json::from_str(lock).unwrap();
+
+    assert!(
+        parsed["agents"].get("omp").is_none(),
+        "omp must not remain in the npx release lock once it launches directly"
+    );
+}

--- a/crates/aionui-db/tests/registry_npx_agents_migration.rs
+++ b/crates/aionui-db/tests/registry_npx_agents_migration.rs
@@ -57,13 +57,9 @@ async fn verified_registry_npx_agents_use_stable_packages_and_conservative_team_
             Some(r#"[".compass/skills"]"#),
             None,
         ),
-        (
-            "omp",
-            "omp",
-            r#"["-y","@oh-my-pi/pi-coding-agent","acp"]"#,
-            Some(r#"[".omp/skills",".claude/skills"]"#),
-            None,
-        ),
+        // omp is deliberately absent: 039 moved it off the npx bridge to a
+        // direct `omp acp` launch. Its shape is asserted in
+        // `omp_direct_cli_migration.rs`.
         ("sigit", "sigit", r#"["-y","@smbcloud/sigit"]"#, None, None),
     ];
 

--- a/crates/aionui-db/tests/team_capability_criteria_migration.rs
+++ b/crates/aionui-db/tests/team_capability_criteria_migration.rs
@@ -148,8 +148,9 @@ async fn probed_registry_agents_carry_seeded_mcp_capabilities() {
         ("kilo", Some((true, true))),
         ("mimo-code", Some((true, true))),
         ("nova", Some((true, true))),
-        ("omp", Some((true, true))),
         ("sigit", Some((false, false))),
+        // direct CLI launch (031 seeded it on npx; 039 moved it off the bridge)
+        ("omp", Some((true, true))),
         // binary distributions (025)
         ("amp-acp", Some((true, true))),
         ("cortex-code", None),

--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -50,10 +50,6 @@
       "package": "@compass-ai/nova",
       "version": "1.1.34"
     },
-    "omp": {
-      "package": "@oh-my-pi/pi-coding-agent",
-      "version": "17.1.8"
-    },
     "pi": {
       "registry_json_id": "pi-acp",
       "package": "pi-acp",

--- a/crates/aionui-runtime/src/registry_npx_lock.rs
+++ b/crates/aionui-runtime/src/registry_npx_lock.rs
@@ -130,7 +130,7 @@ mod tests {
     #[test]
     fn every_lock_entry_has_an_exact_version() {
         let lock = registry_npx_lock().unwrap();
-        assert_eq!(lock.agents.len(), 13);
+        assert_eq!(lock.agents.len(), 12);
         for package in lock.agents.values() {
             assert!(semver::Version::parse(&package.version).is_ok());
         }


### PR DESCRIPTION
## Problem

Migration 031 seeded omp as `npx -y @oh-my-pi/pi-coding-agent acp` with `binary_name: "omp"`, copying the shape the Registry-listed npx rows use. That shape does not fit omp, and the row ended up paying both launch paths' costs while getting neither's benefit.

**There is no Registry entry to conform to.** Audited against the public ACP Registry catalogue: 11 of the 13 `command='npx'` builtin rows match their Registry entry's package and args *exactly*.

| backend | Registry-declared distribution | our args | match |
|---|---|---|---|
| autohand | npx `@autohandai/autohand-acp` | `-y @autohandai/autohand-acp` | ✅ |
| codebuddy | npx `@tencent-ai/codebuddy-code` `--acp` | `-y --package … codebuddy --acp` | ✅ |
| deepagents | npx `deepagents-acp` | same | ✅ |
| dimcode | npx `dimcode acp` | same | ✅ |
| dirac | npx `dirac-cli --acp` | same | ✅ |
| glm-acp-agent | npx `glm-acp-agent` | same | ✅ |
| grok | npx `@xai-official/grok agent stdio` | same | ✅ |
| kilo | npx `@kilocode/cli acp` | same | ✅ |
| nova | npx `@compass-ai/nova acp` | same | ✅ |
| pi | npx `pi-acp` | same | ✅ |
| sigit | npx `@smbcloud/sigit` | same | ✅ |
| **mimo-code** | *not listed* | — | non-Registry builtin |
| **omp** | *not listed* | — | non-Registry builtin |

For the 11, npx **is** the vendor's declared ACP distribution and bridging is correct — this PR does not touch them. omp is one of the two non-Registry builtins, so its bridge was chosen by analogy rather than from a declared distribution.

**And the package is not an adapter.** `@oh-my-pi/pi-coding-agent` ships `bin: {omp: dist/cli.js}`; `omp acp` is the vendor's own entrypoint (`packages/coding-agent/src/commands/acp.ts`, built on `@agentclientprotocol/sdk`), and the vendor publishes standalone binaries per release. Contrast `pi-acp` ("ACP adapter for pi coding agent") or `@autohandai/autohand-acp` ("ACP adapter for the Autohand CLI"), where `binary_name` names a *different* CLI the package wraps and the PATH gate is genuinely required.

**The local binary was already mandatory.** `binary_name: "omp"` makes `probe_resolved_command` fail the row with `PrimaryMissing` when `omp` is absent, and `cli_probe::validate_with_budget` already runs the local `omp --version`. Confirmed on a simulated clean machine (`HOME` pointed at an empty dir, minimal `PATH`):

```
c9e8a2f4   omp   Builtin   missing   CLI `omp` not on $PATH
```

So the row required a local install, probed it, executed it — and then spawned a *different* copy through npx.

**What that cost**, spawn to `initialize` response:

| | cold npx cache | warm | local CLI |
|---|---|---|---|
| omp | **81.0s** | 10.0s | **0.7s** |

81s on a fast link, against a 30s handshake budget — the failure reported in iOfficeAI/AionUi#4009.

## What changed

`039_omp_direct_cli_launch.sql` sets `command='omp'`, `args=["acp"]`, `agent_source_info={"binary_name":"omp"}` (bridge dropped). The release-lock entry goes with it, and the two lock-count assertions fall to 12.

**Written as an UPDATE, not a re-seed.** `agent_capabilities` and `auth_methods` hold what a live handshake learned on the user's own install; an `ON CONFLICT DO UPDATE` that lists them resets that to an integration-time snapshot (dead code on a fresh row, silent data loss on an existing one — the migration-023 shape). An UPDATE of the launch columns cannot reach those columns at all, so the guarantee is structural rather than review-dependent.

## Verification

Real-path check, doctor run from this branch's build against a freshly migrated DB:

```
before:  c9e8a2f4  omp  Builtin  available  npx
after:   c9e8a2f4  omp  Builtin  available  /Users/zhoukai/.bun/bin/omp
```

Catalogue still 43 rows, availability unchanged at 41/2, and `pi` / `mimo-code` still resolve to `npx` — the change is scoped to omp. Seeded row after 039:

```
omp|omp|["acp"]|{"binary_name":"omp"}|[".omp/skills",".claude/skills"]
```

- `cargo test -p aionui-db -p aionui-runtime -p aionui-ai-agent` — all green (331 / 12 suites / 939 + 38)
- `cargo clippy` on those three with `-D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `just migration-check` — passed
- Written test-first: both row assertions were watched failing for the right reason (`command` was `Some("npx")`; the lock still carried omp). The third test is a guard that passes before and after — its job is to catch a re-seed clobbering the probed handshake columns.
- Local workspace `nextest` not run (work-hours policy); CI's Test check is the authority.

## Trade-off

omp's version is no longer pinned by `acp-registry-npx-lock.json` — it now tracks whatever the user has installed, exactly as the other direct-CLI builtins (qwen, agy) do. Version upkeep moves to the `VERIFIED_*` path.

## Not in scope

- **The other 12 npx rows stay.** For the 11 Registry-listed ones, npx is the declared distribution and bridging is correct as-is. `glm-acp-agent` is a different shape again — a pure ACP package with no separate product CLI, whose `binary_name` gate looks questionable but which should *drop the gate*, not go direct; left for its own change with its own evidence.
- **mimo-code stays on npx.** Same non-Registry status, but its cold start is 16.0s (warm 3.6s) — inside the budget, so there is no failure to fix. Its npm package is a launcher that resolves a 95 MB platform binary, and the vendor's postinstall recommends a native install over npm; that is worth revisiting, but not under a bug fix.
- **Install-path detection.** `platform_extra_bins()` covers `.cargo/bin`, `go/bin`, `.deno/bin`, `.local/bin`, `.volta/bin` and nvm — but not `~/.bun/bin` (where omp lands via bun) or `~/.mimocode/bin` (where mimo's own installer puts it). A user who follows the vendor's install and lacks that directory in their login-shell PATH still gets a hidden row. That is the broader half of AionUi#4009 proposal 1 and affects every agent, so it belongs in its own change.

## Migration number 039 is contested

`039` is currently claimed by three open PRs — this one, #644 (`039_project_knowledge.sql`) and #815 (`039_user_scope_assistant_ids.sql`) — and `038` is likewise claimed by #815, #644 and the sidebar stack. Whichever lands first takes the number; the others must rebase and rename.

This is caught, not silent: `scripts/migration/check-immutability.sh` rejects duplicate numeric prefixes. Verified by putting both 039 files in a scratch checkout of `main`:

```
Duplicate database migration versions are not allowed.
Duplicate versions:
39: 039_project_knowledge.sql, 039_omp_direct_cli_launch.sql
```

(exit 1). So if another 039 merges first, this PR's CI turns red on rebase and the fix is a one-file rename — no risk of two different `039`s reaching a release. Renumbering pre-emptively would not help: #644 also claims `040` and `041`.

Closes iOfficeAI/AionUi#4009

Scope note on that link: the issue's timeout and npm-cache halves are covered (the first by iOfficeAI/AionCore#854, the second already shipped), and its primary ask — use the installed omp instead of forcing npx — is what this PR does. What it does NOT add is a scan of extra install locations such as `%LOCALAPPDATA%\omp`: detection still goes through the app's resolved PATH, so an omp that is installed but not on PATH stays hidden. That gap is agent-agnostic and tracked separately.


