### PR TITLE
fix(runtime): find agent CLIs installed by bun and by vendor installers

### DIFF
--- a/crates/aionui-runtime/src/shell_env.rs
+++ b/crates/aionui-runtime/src/shell_env.rs
@@ -99,11 +99,16 @@ fn platform_extra_bins_at(home: Option<&Path>) -> Vec<PathBuf> {
     };
 
     if let Some(h) = home {
+        // Package-manager global bins.
         push_if_dir(h.join(".cargo").join("bin"));
         push_if_dir(h.join("go").join("bin"));
         push_if_dir(h.join(".deno").join("bin"));
+        push_if_dir(h.join(".bun").join("bin"));
         push_if_dir(h.join(".local").join("bin"));
         push_if_dir(h.join(".volta").join("bin"));
+        // Agent CLIs whose vendor installer uses a private directory rather
+        // than one of the above (MiMo Code: `INSTALL_DIR=$HOME/.mimocode/bin`).
+        push_if_dir(h.join(".mimocode").join("bin"));
         for nvm_bin in nvm_version_bins(h) {
             push_if_dir(nvm_bin);
         }
@@ -121,6 +126,12 @@ fn platform_extra_bins_at(home: Option<&Path>) -> Vec<PathBuf> {
             push_if_dir(PathBuf::from(&local).join("Microsoft").join("WinGet").join("Links"));
             // Yarn classic global bin.
             push_if_dir(PathBuf::from(&local).join("Yarn").join("bin"));
+            // omp's Windows installer writes `omp.exe` straight into this
+            // directory (`install.ps1`: `$InstallDir = "$env:LOCALAPPDATA\omp"`).
+            // It matters more here than the Unix vendor dirs do, because there
+            // is no login-shell probe on Windows — this list plus the inherited
+            // PATH is the whole search space.
+            push_if_dir(PathBuf::from(&local).join("omp"));
         }
         if let Ok(pf) = std::env::var("ProgramFiles") {
             push_if_dir(PathBuf::from(&pf).join("Git").join("cmd"));
@@ -323,6 +334,44 @@ mod tests {
         // 没创建的目录不应出现
         assert!(!bins.iter().any(|p| p.ends_with("go/bin")));
         assert!(!bins.iter().any(|p| p.ends_with(".deno/bin")));
+    }
+
+    /// bun sits alongside cargo/deno/volta as a package manager whose global
+    /// installs land in a home-relative bin, and `.mimocode/bin` is where the
+    /// MiMo Code installer puts its CLI. Both were missing from the fallback
+    /// list, so an agent installed either way was only findable when the
+    /// login-shell probe happened to succeed.
+    #[test]
+    fn platform_extra_bins_at_includes_bun_and_vendor_install_dirs() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+
+        std::fs::create_dir_all(home.join(".bun/bin")).unwrap();
+        std::fs::create_dir_all(home.join(".mimocode/bin")).unwrap();
+
+        let bins = platform_extra_bins_at(Some(home));
+
+        assert!(
+            bins.iter().any(|p| p.ends_with(".bun/bin")),
+            "expected ~/.bun/bin in result: {bins:?}"
+        );
+        assert!(
+            bins.iter().any(|p| p.ends_with(".mimocode/bin")),
+            "expected ~/.mimocode/bin in result: {bins:?}"
+        );
+    }
+
+    /// The list is a fallback, not a guess: a directory that does not exist
+    /// must not be pushed onto PATH just because a vendor might use it.
+    #[test]
+    fn platform_extra_bins_at_omits_bun_and_vendor_dirs_that_do_not_exist() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+
+        let bins = platform_extra_bins_at(Some(home));
+
+        assert!(!bins.iter().any(|p| p.ends_with(".bun/bin")), "{bins:?}");
+        assert!(!bins.iter().any(|p| p.ends_with(".mimocode/bin")), "{bins:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`platform_extra_bins` is the fallback list searched when neither the inherited PATH nor the login-shell probe already names a directory. Three locations that agent CLIs actually land in were absent from it, so an agent installed those ways was findable only when the login-shell probe happened to succeed.

| location | evidence | why it was missed |
|---|---|---|
| `~/.bun/bin` | omp's installer uses `bun install -g` in `--source` mode (`install.sh:164-208`) | an inconsistency — `.cargo/bin`, `go/bin`, `.deno/bin`, `.volta/bin` are all listed; the peer package manager was not |
| `~/.mimocode/bin` | MiMo Code installer: `INSTALL_DIR=$HOME/.mimocode/bin` | a private vendor directory matching none of the existing entries |
| `%LOCALAPPDATA%\omp` (Windows) | omp `install.ps1:21,265` — `$InstallDir = "$env:LOCALAPPDATA\omp"`, writing `omp.exe` directly there | see below |

The Windows entry carries more weight than its Unix counterparts: `login_shell_path` is `None` on non-Unix, so on Windows this list plus the inherited PATH is the *entire* search space. On Unix a vendor installer that patches the user's shell rc is usually recovered by the probe; on Windows there is no probe to recover it.

## Safety

These stay fallbacks. `merge_paths` orders login → current → extras with first occurrence winning, so nothing here can shadow a version the user's own PATH already selects. A directory that does not exist is still filtered out rather than pushed onto PATH speculatively — asserted by a test rather than left implicit.

## Verification

### The additions actually flip agent availability

Two `doctor` runs against the same build, each with a fake `HOME`, a minimal `PATH`, and `SHELL=/bin/sh` so the login-shell probe cannot smuggle the real PATH back in. The only difference is whether the vendor directories exist:

```
== bare ==
   Agents in catalog: 43  available: 2  unavailable: 41
   mimo-code  Builtin  missing    CLI `mimo` not on $PATH
   omp        Builtin  missing    CLI `omp` not on $PATH

== vendor ==      (adds ~/.mimocode/bin/mimo and ~/.bun/bin/omp)
   Agents in catalog: 43  available: 4  unavailable: 39
   mimo-code  Builtin  available  npx
   omp        Builtin  available  npx
```

The `SHELL=/bin/sh` pinning is not incidental: an earlier attempt at this check produced a false negative because the login-shell probe re-imported the real PATH and hid the difference.

### The Windows branch is compile-verified, not eyeballed

`#[cfg(windows)]` code does not compile on this host, and `ci.yml` is `runs-on: ubuntu-latest` throughout — so nothing in the PR pipeline builds that branch either; only the release workflow would. Cross-compiling to `x86_64-pc-windows-gnu` fails on a C dependency needing mingw.

So the block was type-checked by temporarily flipping `#[cfg(windows)]` to `#[cfg(all())]` and building on macOS — it uses only `std::env::var` and `PathBuf`, both cross-platform — then restored, with a byte-for-byte `diff` confirming the file matched its pre-flip state.

### Static

- `cargo test -p aionui-runtime` — 91 passed, 0 failed
- `cargo clippy -p aionui-runtime --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Written test-first: the inclusion test was watched failing with `expected ~/.bun/bin in result: []` before the entries existed.
- Local workspace `nextest` not run (work-hours policy); CI's Test check is the authority.

## Scope

- **Not a per-agent registry.** Two vendor directories are cheaper to list than a metadata field would be. If a third and fourth arrive, this should become agent-declared rather than a growing global list — noting it here so the next person does not simply append.
- **User-configured npm prefixes are still invisible.** Several CLIs on the author's machine live in `~/.npm-global/bin`, which cannot be guessed — reading it needs `npm config get prefix`, a subprocess this list deliberately does not run.
- **No PATH re-probing.** A vendor installer that updates PATH at the user or machine level still needs the app restarted before an inherited-PATH-only platform sees it; nothing here tries to detect that mid-session.

Refs iOfficeAI/AionUi#4009
