### PR TITLE
chore(acp): bump dimcode, dirac, grok and kilo registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -19,12 +19,12 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.12"
+      "version": "0.3.13"
     },
     "dirac": {
       "registry_json_id": "dirac",
       "package": "dirac-cli",
-      "version": "0.4.35"
+      "version": "0.4.36"
     },
     "glm-acp-agent": {
       "registry_json_id": "glm-acp-agent",
@@ -34,12 +34,12 @@
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "1.0.3"
+      "version": "1.0.4"
     },
     "kilo": {
       "registry_json_id": "kilo",
       "package": "@kilocode/cli",
-      "version": "7.4.21"
+      "version": "7.4.22"
     },
     "mimo-code": {
       "package": "@mimo-ai/cli",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Four npx pins drifted since #848, each backed by a fresh serial ACP probe of the exact pinned version. Lock-only change — four lines; no metadata, migration, or entrypoint edits, and no lock-derived test assertion embeds any of these versions.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| dimcode | `dimcode` | 0.3.12 → **0.3.13** | ok (agentInfo version 0.3.13) | auth required (`-32000`, "Provider credentials are required") |
| dirac | `dirac-cli` | 0.4.35 → **0.4.36** | ok (agentInfo dirac 0.4.36) | success (modes plan/act) |
| grok | `@xai-official/grok` | 1.0.3 → **1.0.4** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |
| kilo | `@kilocode/cli` | 7.4.21 → **7.4.22** | ok (agentInfo Kilo 7.4.22) | success |

All four meet the release-lock criterion: `initialize` succeeds and `session/new` either succeeds or returns a clearly classified authentication requirement. Probes ran serially with no inherited HOME or credentials.

The other 7 Registry-pinned packages (autohand, codebuddy, deepagents, glm-acp-agent, nova, pi, sigit) match the snapshot exactly. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none.

**Note on the manifest's shape, unrelated to this bump:** the lock now holds 12 entries rather than 13 — #855 moved `omp` off the npx bridge to its local CLI, so it no longer needs a pin. What remains is 11 Registry-pinned packages plus `mimo-code`, the one non-Registry builtin (no `registry_json_id`), which stays excluded from drift reconciliation.

dimcode continues to self-report `agentInfo.title` as "DimAgent" while the public Registry card and CDN entry still say "DimCode" (`dimcode.dev` unchanged), so the seeded display name is untouched — same standing observation as #837/#848.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.14-ec4f9f7`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.14-ec4f9f7/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the previous baseline (38 ids).

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11; #810, #814, #822, #837 and #848 all merged green under it). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock-only version bumps; existing startup/session error paths already identify a failing agent by backend.