### PR TITLE
fix(auth): stop CSRF rejecting agy's PreToolUse callback

### DIFF
--- a/crates/aionui-auth/src/csrf.rs
+++ b/crates/aionui-auth/src/csrf.rs
@@ -41,10 +41,27 @@ pub async fn csrf_middleware(
     // cannot attach cross-site without a CORS preflight. The token itself is
     // still fully validated by the auth middleware behind this layer.
     let is_runtime_token_request = request.headers().contains_key(crate::middleware::RUNTIME_TOKEN_HEADER);
+    // agy's PreToolUse callback. A local `aioncore antigravity-hook` process
+    // posts here for every tool the agent wants to run; it has no user session
+    // and no CSRF token to present. The route is already deliberately outside
+    // `auth_middleware` for that reason, and the handler authenticates it with a
+    // per-conversation token instead (`x-aionui-hook-token`) — but the CSRF
+    // layer is global, so it rejected what auth had been told to let through.
+    //
+    // Exempting it is safe on CSRF's own terms: this layer stops a browser
+    // attaching AMBIENT COOKIES to a cross-site request, and the endpoint reads
+    // no cookie. A forged call still has to carry a token minted per
+    // conversation and held in memory.
+    //
+    // Without this, every agy tool call is answered 403 CSRF_INVALID and the
+    // hook reads that as "no answer" and denies (measured 2026-08-14: 9/9 then
+    // 12/12 calls rejected across two live runs).
+    let is_antigravity_hook = path.starts_with("/internal/antigravity-hook/");
     let is_exempt = path == "/login"
         || path == "/api/auth/qr-login"
         || path.starts_with("/api/auth/internal/external-users/")
         || path.starts_with("/api/auth/internal/external-sessions")
+        || is_antigravity_hook
         || is_runtime_token_request;
 
     if needs_validation && !is_exempt {

--- a/crates/aionui-auth/tests/middleware_tests.rs
+++ b/crates/aionui-auth/tests/middleware_tests.rs
@@ -60,6 +60,10 @@ fn csrf_app() -> Router {
         .route("/login", post(|| async { "logged in" }))
         .route("/api/auth/qr-login", post(|| async { "qr ok" }))
         .route("/get-test", get(|| async { "get ok" }))
+        .route(
+            "/internal/antigravity-hook/{conversation_id}",
+            post(|| async { "hook ok" }),
+        )
         .layer(middleware::from_fn_with_state(config, csrf_middleware))
 }
 
@@ -71,6 +75,32 @@ async fn t12_2_get_requests_bypass_csrf() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
+}
+
+/// agy's PreToolUse callback must reach its handler without a CSRF token.
+///
+/// The hook is a local `aioncore antigravity-hook` process: no user session, no
+/// cookie, no token to present. It authenticates with a per-conversation
+/// `x-aionui-hook-token` that the handler checks. When CSRF rejected it, every
+/// call came back 403, the hook read that as "no answer" and denied, and agy
+/// turns produced no tool frames at all — measured 2026-08-14, 6/6 calls
+/// rejected.
+#[tokio::test]
+async fn the_antigravity_hook_is_not_blocked_by_csrf() {
+    let app = csrf_app();
+    let resp = app
+        .oneshot(
+            Request::post("/internal/antigravity-hook/conv-1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "a hook callback with no CSRF token must still reach the handler"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
> **This ships to AionPro users.** AionPro launches Core with `--identity-mode aionpro` (its own `README-multiaccount-core-bridge.md`: *启动方式 `--identity-mode aionpro`（替代 `--local`）*), and `is_local()` is true only for `Local` — so the CSRF layer is mounted and **every agy tool call in AionPro is denied**. AionPro ships the agy backend, onboarding icon included.
>
> **Correction (2026-08-17).** An earlier version of this description said every agy tool call is answered 403 without qualifying where. That is wrong for the AionUi desktop, which runs `--local` and mounts no CSRF layer at all — the operator's own logs show 71/71 callbacks at status=200. The scope is stated correctly below.

In **WebUi identity mode**, every agy tool call is answered **403 CSRF_INVALID**. The hook reads that as "no answer" and denies, so nothing the agent tries to run gets through.

```
POST /internal/antigravity-hook/<conv>  status=403  error_code="CSRF_INVALID"
```

## Which deployments this hits

`routes.rs` mounts the CSRF layer **only when identity mode is not local**:

```rust
let router = if services.identity_mode.is_local() {
    router                                   // desktop: no CSRF layer at all
} else {
    router.layer(csrf_middleware)            // WebUi / multi-account: CSRF applies
};
```

| mode | CSRF layer | hook | who runs it |
|---|---|---|---|
| `Local` | not mounted | **works** — operator's logs 2026-08-01 → 08-14: **71 calls, 71× 200, zero 403** | AionUi desktop (`--local`) |
| `WebUi` | mounted | **every call 403** — live suite, 9/9 then 12/12 rejected | `AppConfig::default()`, i.e. the test harness and server deployments |
| `AionPro` | mounted | **every call 403** | **the shipping AionPro app** |

`is_local()` returns true only for `Local`, so both other modes take the CSRF layer. That is why the desktop never saw this and AionPro does.

Worth noting what the exemption list already contains: `/api/auth/internal/external-users/` and `/api/auth/internal/external-sessions` — the AionPro identity-bridge endpoints from that same README. Whoever built the bridge exempted their own callbacks; the antigravity hook, which has exactly the same shape (a local process, no session, its own token), was missed.

## Reproduced by hand in a running app, 2026-08-17

Not inferred from the code and not only seen in the harness. A non-local
instance, default permission mode, one prompt asking for a directory listing:

```
02:24:07  antigravity: routing conversation through the direct-CLI SessionAgentTask
02:24:21  POST /internal/antigravity-hook/89758ebe  403  CSRF_INVALID
02:24:30  POST /internal/antigravity-hook/89758ebe  403  CSRF_INVALID
02:24:33  POST /internal/antigravity-hook/89758ebe  403  CSRF_INVALID
02:24:36  turn_terminal
```

Three approval requests, three rejections, **zero `permission answered` lines** —
the requests never reached the handler. The turn then ended.

### What the user saw

No permission card and no tool card, but the turn was not silent. The reply
carried the hook's own error text, and our `ANTIGRAVITY_STEPS_FAILED` tip fired:

> 本轮有 3 个步骤失败且未生效。agy 仍会把这类轮次标记为成功，请核对实际结果而非回复内容。

> 在尝试读取当前工作目录（`/Users/zhoukai/Desktop`）时，客户端工具权限拦截系统返回了错误：
> `aionui returned an unreadable decision: error decoding response body`

**Then the agent invented the answer.** Denied the listing, it produced a
directory tree "根据当前加载的环境配置与 Skill 上下文" — `.agents/skills/{aionui-config,
cron, officecli, skill-creator}` — none of it read from `/Users/zhoukai/Desktop`.
A user skimming past the warning banner gets a fabricated listing presented as
fact. That is the actual harm, and it is worse than a visible failure.

### A second, smaller defect in the same path

The error text is misleading, and the code shows why —
`cmd_antigravity_hook.rs` never looks at the status:

```rust
Ok(resp) => match resp.json::<AntigravityHookOutput>().await {
    Ok(out) => out,
    Err(e) => AntigravityHookOutput::deny(format!("aionui returned an unreadable decision: {e}")),
},
```

A 403 arrives with an `ApiError` body, which is not an `AntigravityHookOutput`,
so it lands in the decode-failure arm. The user is told the decision was
*unreadable* when the request was *rejected*. Checking `resp.status()` first and
denying with the status and code would have named this bug on sight instead of
sending it through a parser. Not fixed here — the exemption removes the 403
entirely — but worth its own change so the next transport failure on this path
says what actually happened.

The same log directory had **zero** hook calls before the test, so these three
are that prompt and nothing else. For contrast, the desktop's `--local` instance
logged **71 calls at status=200** over 2026-08-01 → 08-14.

**Reproduction steps**, if you want to see it yourself — the mode matters, since
full auto does not install the hook at all:

1. a non-local instance (AionPro, or Core started without `--local`);
2. a new Antigravity conversation, **default** permission mode;
3. ask for anything needing a tool, e.g. "list the files in the current directory";
4. watch for a permission card. It never comes.

## Cause

The route is already deliberately outside `auth_middleware`, and `routes.rs` says why:

> Antigravity permission hook callback. Deliberately NOT behind auth_middleware: the hook is a local process with no user session, and presents a per-conversation token instead (checked in the handler).

The CSRF layer is applied globally within that mode, so it rejected exactly what auth had been told to let through. The exemption list has an escape hatch — `is_runtime_token_request`, keyed on `x-aionui-runtime-token` — and the hook client sends a different header, `x-aionui-hook-token`, so it never matched. Validation then requires a cookie/header pair the hook has neither half of.

## Why exempting it is safe

On CSRF's own terms: this layer stops a browser attaching **ambient cookies** to a cross-site request, and the endpoint reads no cookie. A forged call still has to present a token minted per conversation and held in memory, which the handler checks — the same protection the route was designed around.

## Verification

| | before | after |
|---|---|---|
| hook callbacks 403 | 9/9, then 12/12 | **0** |
| hook callbacks 200 | 0 | **2/2** |

Unit test added; it returns 403 instead of 200 without the exemption, confirmed by removing it. `cargo test -p aionui-auth`: 114 + 3 + 34 passed. `clippy --all-targets -D warnings` and `cargo fmt --check` clean.

## What this does NOT fix

`live_antigravity_team_mcp_tools_call_and_runtime_env` still fails with the exemption in place — the model reaches for shell tools instead of the MCP tool, 1 pass / 4 fail across five runs. Undiagnosed, tracked in `~/aion/protocols/samples/antigravity-cli/1.1.13/gate-b-blocked.md`, and the remaining reason agy stays at 1.1.12.

Found by the nightly direct-CLI version sync while qualifying agy 1.1.13.



