### PR TITLE
chore(cli): bump verified claude to 2.1.232

### DIFF
--- a/crates/aionui-ai-agent/src/claude_flags.rs
+++ b/crates/aionui-ai-agent/src/claude_flags.rs
@@ -126,7 +126,7 @@ mod tests {
         assert!(!supported("2.1.0"), "2.1.0 hard-errors on --thinking-display");
         assert!(!supported("2.1.190"), "below the verified floor stays off");
         assert!(supported("2.1.191"), "lowest live-probed OK version");
-        assert!(supported("2.1.231"), "the release this integration is verified against");
+        assert!(supported("2.1.232"), "the release this integration is verified against");
         assert!(supported("2.1.220"));
         assert!(supported("3.0.0"), "a future major must not regress the gate");
     }

--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -35,7 +35,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// turn (its response stream disconnects with `httpStatusCode: null`, observed
 /// three times including a back-to-back control after three clean versions), so
 /// the verified release stops at 0.146.0 until upstream fixes it.
-pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.231";
+pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.232";
 pub const VERIFIED_CODEX_VERSION: &str = "0.146.0";
 pub const VERIFIED_AGY_VERSION: &str = "1.1.12";
 
@@ -449,8 +449,8 @@ mod tests {
     fn the_verified_release_says_nothing() {
         // Literal on purpose: this is the exact string a user on the verified
         // release reports, so the test breaks if a bump forgets to re-verify.
-        assert_eq!(classify("2.1.231", VERIFIED_CLAUDE_VERSION), VersionVerdict::Verified);
-        assert!(drift_notice("claude", "2.1.231", VERIFIED_CLAUDE_VERSION).is_none());
+        assert_eq!(classify("2.1.232", VERIFIED_CLAUDE_VERSION), VersionVerdict::Verified);
+        assert!(drift_notice("claude", "2.1.232", VERIFIED_CLAUDE_VERSION).is_none());
     }
 
     #[test]


### PR DESCRIPTION
`VERIFIED_CLAUDE_VERSION` 2.1.231 → 2.1.232, plus the three assertions pinned to it.

## Gates

| gate | verdict | evidence |
|---|---|---|
| A — contract | DEGRADED | claude publishes no protocol schema |
| B — live e2e | **PASS 14/14** | 282.93s |
| C — release notes | CLEAR | 49 notes in range; 7 carried a risk verb, none touched the 31 dependency tokens |

## A red that was the harness, not the candidate

The suite has grown an env-gated test per backend — `live_*_team_mcp_tools_call_and_runtime_env` — which asserts on `AIONUI_E2E_SENTINEL`. The first gate B run did not set it, so that test failed in a way that reads exactly like a candidate regression. Its own panic message is the instruction:

```
run this ignored release gate with AIONUI_E2E_SENTINEL=AIONUI_DIRECT_CLI_E2E_42
```

`qualify.py` recorded `verdict: BLOCKED` for that log, which is correct — a record that says BLOCKED cannot back a bump. So the **whole suite was re-run with the variable set**, and the record here is from that clean 14/14 run, rather than from a log with a failure explained away in prose.

The candidate was already the installed CLI, so no shim was needed and no symlink moved. That the suite ran 2.1.232 was confirmed from its own logs (`direct CLI version detected version=2.1.232`), not assumed.

## Record

`~/aion/protocols/samples/claude-cli/2.1.232/` — `qualification.json` (verdict PASS, zero blockers, 14 passed / 0 failed) and the live-suite log.

## The other two

- **codex** — latest is still 0.147.0, which never completes a turn. Stays at 0.146.0.
- **agy** — 1.1.13 is available but **not qualified**, for two independent reasons: its changelog has no 1.1.13 entry at all (the CLI section still ends at 1.1.12, so gate C could not run), and gate B is red on two tests that remain undiagnosed. A real defect found on the way — every agy tool call answered 403 CSRF_INVALID — is fixed separately in #860, which is **not** the cause of those two failures and does not clear them.

Constants only, no source change.