### PR TITLE
chore(cli): bump verified claude to 2.1.233

### DIFF
--- a/crates/aionui-ai-agent/src/claude_flags.rs
+++ b/crates/aionui-ai-agent/src/claude_flags.rs
@@ -126,7 +126,7 @@ mod tests {
         assert!(!supported("2.1.0"), "2.1.0 hard-errors on --thinking-display");
         assert!(!supported("2.1.190"), "below the verified floor stays off");
         assert!(supported("2.1.191"), "lowest live-probed OK version");
-        assert!(supported("2.1.232"), "the release this integration is verified against");
+        assert!(supported("2.1.233"), "the release this integration is verified against");
         assert!(supported("2.1.220"));
         assert!(supported("3.0.0"), "a future major must not regress the gate");
     }

--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -35,7 +35,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// turn (its response stream disconnects with `httpStatusCode: null`, observed
 /// three times including a back-to-back control after three clean versions), so
 /// the verified release stops at 0.146.0 until upstream fixes it.
-pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.232";
+pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.233";
 pub const VERIFIED_CODEX_VERSION: &str = "0.146.0";
 pub const VERIFIED_AGY_VERSION: &str = "1.1.12";
 
@@ -449,8 +449,8 @@ mod tests {
     fn the_verified_release_says_nothing() {
         // Literal on purpose: this is the exact string a user on the verified
         // release reports, so the test breaks if a bump forgets to re-verify.
-        assert_eq!(classify("2.1.232", VERIFIED_CLAUDE_VERSION), VersionVerdict::Verified);
-        assert!(drift_notice("claude", "2.1.232", VERIFIED_CLAUDE_VERSION).is_none());
+        assert_eq!(classify("2.1.233", VERIFIED_CLAUDE_VERSION), VersionVerdict::Verified);
+        assert!(drift_notice("claude", "2.1.233", VERIFIED_CLAUDE_VERSION).is_none());
     }
 
     #[test]


### PR DESCRIPTION
`VERIFIED_CLAUDE_VERSION` 2.1.232 → 2.1.233, plus the three assertions pinned to it.

## Gates

| gate | verdict | evidence |
|---|---|---|
| A — contract | DEGRADED | claude publishes no protocol schema |
| B — live e2e | **PASS 14/14** | 312.99s |
| C — release notes | CLEAR | 20 notes in range; 4 carried a risk verb, none touched the 31 dependency tokens |

The candidate was not installed here, so it was fetched with `npm @anthropic-ai/claude-code@2.1.233` into a temp dir and reached through a PATH shim. `~/.local/bin/claude` pointed at `2.1.232` before the run and still does; the record's `machine` block states it independently. The suite's own logs report `direct CLI version detected version=2.1.233`, so the candidate really ran.

## Record

`~/aion/protocols/samples/claude-cli/2.1.233/` — `qualification.json` (PASS, zero blockers, 14/0) and the live-suite log.

## The other two

- **codex** — latest is still 0.147.0, which never completes a turn. Stays at 0.146.0.
- **agy** — 1.1.13's changelog entry **appeared a day late**, so gate C ran this time and is CLEAR: nothing this repo consumes was removed, renamed or reshaped (the `/resume` items are the interactive picker, not the `--conversation` flag). Gate B is still not reliably green, so the constant does not move. Two separate things came out of that investigation, both in their own PRs: #860 (every agy tool call answered 403 CSRF_INVALID) and the tool-card test fix below.

Constants only, no source change.