### PR TITLE
test(live): give agy's tool-card gate full auto so a denied tool is not read as a missing frame

### DIFF
--- a/crates/aionui-app/tests/live_ws_http_parity_e2e.rs
+++ b/crates/aionui-app/tests/live_ws_http_parity_e2e.rs
@@ -1526,6 +1526,51 @@ async fn run_backend_tool_card(backend: &str) {
     let conv_id = conversation_for(&app, backend, "toolcard").await;
     let ws_dir = std::env::temp_dir();
 
+    // agy only: run this one without approval prompts.
+    //
+    // The test is about whether a tool card RENDERS. In its default mode agy
+    // routes every tool through the PreToolUse hook and waits for a human, which
+    // no test provides; the backend then denies at its 20s deadline ("denied a
+    // tool because agy was about to stop waiting for approval"), no tool runs,
+    // and the assertion below reports "no tool frame at all" as though the
+    // translation were broken. Observed 2026-08-15 against agy 1.1.13: three
+    // `acp_permission` frames raised, three auto-denials, zero `tool_call`.
+    //
+    // claude and codex reach a tool here without this, so they are left alone —
+    // and the mode VOCABULARY is per-backend anyway: agy's full-auto sentinel is
+    // `yolo`, codex's is `agent-full-access`. A first attempt sent
+    // `agent-full-access` for every backend and turned claude's passing test red
+    // with `mode 'agent-full-access' is not one of the available modes`.
+    //
+    // Selected before the first turn: agy resolves its mode at spawn, so
+    // switching later would exercise a different path.
+    if backend == "antigravity" {
+        let ensured = http_json(
+            &app,
+            "POST",
+            &format!("/api/conversations/{conv_id}/runtime/ensure"),
+            json!({}),
+        )
+        .await;
+        assert_eq!(
+            ensured["success"],
+            json!(true),
+            "[{backend}] runtime must come up before selecting a mode: {ensured}"
+        );
+        let mode_resp = http_json(
+            &app,
+            "PUT",
+            &format!("/api/conversations/{conv_id}/config-options/mode"),
+            json!({"value": "yolo"}),
+        )
+        .await;
+        assert_eq!(
+            mode_resp["success"],
+            json!(true),
+            "[{backend}] full auto must actually apply, or a denied tool looks like a missing frame: {mode_resp}"
+        );
+    }
+
     let frames = drive_and_collect(
         &app,
         &conv_id,


### PR DESCRIPTION
`live_antigravity_tool_card_is_renderable` failed with **"no tool frame at all"**. The translation was fine — the test simply had nobody to approve the tools.

In its default mode agy routes every tool through the PreToolUse hook and waits for a human. No test provides one, so the backend denies each at its 20s deadline and nothing ever runs. Measured 2026-08-15 against agy 1.1.13:

```
denied a tool because agy was about to stop waiting for approval
antigravity hook: permission answered  tool=list_dir     approved=false
antigravity hook: permission answered  tool=run_command  approved=false
```

Frames seen: `start`, `tips`, **three `acp_permission`**, a stream of `acp_context_usage`, `content`, `finish` — and zero `tool_call`. The permission bridge was working correctly; the assertion just reported its success as a missing frame.

## Fix

The test asks whether a tool card *renders*, so it should not be gated on someone answering a prompt. agy now runs it in full auto, selected before the first turn because agy resolves its mode at spawn.

## Scoped to agy on purpose

claude and codex reach a tool here without any mode change, and the mode **vocabulary is per-backend**: agy's full-auto sentinel is `yolo`, codex's is `agent-full-access`.

A first attempt sent `agent-full-access` for every backend and turned claude's *passing* test red:

```
mode 'agent-full-access' is not one of the available modes
```

That is why all three backends are verified below rather than only the one being fixed — a shared helper makes it easy to fix one backend and break another silently.

## Verification

`tool_card_is_renderable` passes **3/3** across claude, codex and agy (65.7s). The agy run's frame types now include `tool_call`:

```
acp_context_usage acp_permission content finish start text tips tool_call
```

Found by the nightly direct-CLI version sync while qualifying agy 1.1.13. It is one of two things blocking that bump; the other is #860.