### PR TITLE
chore(acp): bump glm-acp-agent, grok and nova registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -29,12 +29,12 @@
     "glm-acp-agent": {
       "registry_json_id": "glm-acp-agent",
       "package": "glm-acp-agent",
-      "version": "1.3.0"
+      "version": "1.5.0"
     },
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "1.0.4"
+      "version": "1.0.5"
     },
     "kilo": {
       "registry_json_id": "kilo",
@@ -48,7 +48,7 @@
     "nova": {
       "registry_json_id": "nova",
       "package": "@compass-ai/nova",
-      "version": "1.1.34"
+      "version": "1.1.35"
     },
     "pi": {
       "registry_json_id": "pi-acp",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Three npx pins drifted since #859, each backed by a fresh serial ACP probe of the exact pinned version. Lock-only change — three lines; no metadata, migration, or entrypoint edits, and no lock-derived test assertion embeds any of these versions.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| glm-acp-agent | `glm-acp-agent` | 1.3.0 → **1.5.0** | ok (authMethods `z-ai-api-key`) | success, unauthenticated — modes `default` / `accept_edits` / `bypass_permissions` |
| grok | `@xai-official/grok` | 1.0.4 → **1.0.5** | ok (authMethods `grok.com`) | auth required (`-32000`, "no auth method id provided") |
| nova | `@compass-ai/nova` | 1.1.34 → **1.1.35** | ok (authMethods `kore-terminal-auth`) | config required (`-32000`, "Click Nova Setup to configure your API keys") |

All three meet the release-lock criterion: `initialize` succeeds and `session/new` either succeeds or returns a clearly classified authentication/configuration requirement. Probes ran serially with no inherited HOME or credentials.

**glm-acp-agent crosses two minor versions (1.3.0 → 1.5.0), so its stored `yolo_id` was re-checked rather than assumed.** The 1.5.0 session catalog still advertises `bypass_permissions`, which is exactly the value migration 025 seeded, so the existing metadata remains correct and this stays a lock-only change. Had that mode disappeared, the `yolo_id` would need its own migration and would not belong in this PR.

The other 8 Registry-pinned packages (autohand, codebuddy, deepagents, dimcode, dirac, kilo, pi, sigit) match the snapshot exactly. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. `mimo-code` remains the one non-Registry builtin (no `registry_json_id`), excluded from drift reconciliation.

**Vendor self-reported version mismatches — three of them now, none blocking:** glm-acp-agent 1.5.0 reports `agentInfo.version` as `1.0.0`; nova 1.1.35 reports `kore-cli` `1.0.0`; dimcode reports `agentInfo.title` "DimAgent" against a public listing that says "DimCode". In every case the Registry card, the package identity and the entrypoint are the authorities, and `initialize` succeeded — the pins are evidenced regardless of what the handshake calls itself.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.16-e3c983d`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.16-e3c983d/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the previous baseline (38 ids).

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11; #810, #814, #822, #837, #848 and #859 all merged green under it). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock-only version bumps; existing startup/session error paths already identify a failing agent by backend.
