### PR TITLE
fix(acp): stop collapsing agent failures into an opaque -32603

### DIFF
--- a/crates/aionui-ai-agent/src/manager/acp/agent.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent.rs
@@ -146,6 +146,11 @@ impl AcpStartupConnectError {
     }
 }
 
+/// How many trailing stderr lines to keep when an agent fails to reach a live
+/// ACP session. Both startup failure paths (child exited / handshake failed)
+/// read the same window so their diagnostics are comparable.
+const STARTUP_STDERR_PEEK_LINES: usize = 64;
+
 async fn spawn_and_connect_acp(
     params: &AcpSessionParams,
     runtime: &AgentRuntime,
@@ -255,7 +260,7 @@ async fn spawn_and_connect_acp_once(
     let protocol = tokio::select! {
         biased;
         exit = process.wait_for_exit() => {
-            let stderr = process.peek_stderr_tail(64).await;
+            let stderr = process.peek_stderr_tail(STARTUP_STDERR_PEEK_LINES).await;
             let (exit_code, signal) = exit_status_parts(exit);
             error!(
                 conversation_id = %params.conversation_id,
@@ -267,16 +272,44 @@ async fn spawn_and_connect_acp_once(
             let _ = unregister_agent_process(&params.data_dir, process.pid());
             return Err(AcpStartupConnectError::StartupCrash { exit_code, signal, stderr });
         }
-        res = &mut connect_fut => res.map_err(|e| {
-            error!(
-                conversation_id = %params.conversation_id,
-                error = %ErrorChain(&e),
-                "Failed to establish ACP protocol connection"
-            );
-            process.force_kill_tree();
-            let _ = unregister_agent_process(&params.data_dir, process.pid());
-            AcpStartupConnectError::Agent(AgentError::from(e))
-        })?,
+        res = &mut connect_fut => match res {
+            Ok(protocol) => protocol,
+            Err(e) => {
+                // The handshake future can WIN the race against `wait_for_exit`
+                // even when the child is what died: a crashing agent closes the
+                // pipe first, so connect fails with `incoming_transport_closed`
+                // before the exit is observed. The `wait_for_exit` arm above then
+                // never runs, and its `peek_stderr_tail` — the only record of WHY
+                // — is lost, leaving the user a bare "upstream error"
+                // (AIONUI-DESKTOP-9D). Peek here too.
+                //
+                // stderr is for OUR logs only — never folded into the error that
+                // reaches the client ("stderr intentionally NOT included — may
+                // carry secrets", `protocol::error`).
+                let stderr = process.peek_stderr_tail(STARTUP_STDERR_PEEK_LINES).await;
+                error!(
+                    conversation_id = %params.conversation_id,
+                    error = %ErrorChain(&e),
+                    stderr = %stderr,
+                    "Failed to establish ACP protocol connection"
+                );
+                process.force_kill_tree();
+                let _ = unregister_agent_process(&params.data_dir, process.pid());
+                // Classify STRUCTURALLY. `AgentError::from(e)` would flatten this
+                // into a string, and `classify_upstream_detail` then has to guess
+                // the cause back out of that string by substring match — which
+                // fails for a transport close and lands on the catch-all
+                // UNKNOWN_UPSTREAM_ERROR (AIONUI-DESKTOP-9D). We already KNOW the
+                // structural fact: the handshake did not complete. Say so, and
+                // `from_acp_error_ref` maps it to USER_AGENT_STARTUP_FAILED with
+                // UserAgent ownership and a CheckAgentInstallation resolution.
+                return Err(AcpStartupConnectError::StartupCrash {
+                    exit_code: None,
+                    signal: None,
+                    stderr,
+                });
+            }
+        },
     };
 
     Ok(AcpStartupConnection {

--- a/crates/aionui-ai-agent/src/protocol/error.rs
+++ b/crates/aionui-ai-agent/src/protocol/error.rs
@@ -361,6 +361,17 @@ fn is_session_load_method(context: &str) -> bool {
 /// OpenCode actually emits — see ELECTRON-1HQ), return the session id.
 /// Returns `None` for any other shape so callers can fall through to
 /// the default `code`-based mapping.
+/// Pull a stale session id out of a JSON-RPC `data` payload.
+///
+/// Matches on the VALUE, not on a key name. Agents disagree about where they
+/// put this string — OpenCode/Codex use `error`, glm-acp-agent uses `details`
+/// — and a fixed key list fails closed: the payload degrades to
+/// `AgentInternal`, `is_acp_session_not_found` returns false, and the
+/// `session/load` rebuild in `open_session_resume` never fires. The stale id
+/// then survives on disk and every later turn replays it, so the real failure
+/// (live case: a missing `Z_AI_API_KEY`) stays permanently hidden behind
+/// `Session not found`. Scanning the object's string values keeps recovery
+/// working for agents we have never probed.
 fn extract_session_not_found(data: Option<&serde_json::Value>) -> Option<String> {
     let value = data?;
     let obj = match value {
@@ -368,10 +379,11 @@ fn extract_session_not_found(data: Option<&serde_json::Value>) -> Option<String>
         serde_json::Value::String(s) => serde_json::from_str(s).ok()?,
         _ => return None,
     };
-    let msg = obj.get("error")?.as_str()?;
     let prefix = "Session not found: ";
-    let sid = msg.strip_prefix(prefix)?.trim();
-    if sid.is_empty() { None } else { Some(sid.to_owned()) }
+    obj.as_object()?.values().filter_map(|v| v.as_str()).find_map(|msg| {
+        let sid = msg.strip_prefix(prefix)?.trim();
+        (!sid.is_empty()).then(|| sid.to_owned())
+    })
 }
 
 fn extract_resource_not_found(data: Option<&serde_json::Value>) -> Option<String> {
@@ -666,6 +678,40 @@ mod tests {
         let acp = AcpError::from_sdk(sdk_err, "ctx");
         match acp {
             AcpError::SessionNotFound { session_id } => assert_eq!(session_id, "sess-ie"),
+            other => panic!("expected SessionNotFound, got {other:?}"),
+        }
+    }
+
+    /// glm-acp-agent puts the reason under `details`, not `error`. Keying the
+    /// rescue on `error` alone left this shape as a bare `AgentInternal`, so
+    /// `open_session_resume` never rebuilt the session and the stale id was
+    /// replayed forever. Payload copied verbatim from the live wire dump
+    /// (conversation `66c25606`, `session/load`, 2026-08-17T09:53:31Z).
+    #[test]
+    fn from_sdk_internal_with_session_not_found_under_a_details_key() {
+        let sdk_err = SdkError::internal_error().data(serde_json::json!({
+            "details": "Session not found: deb7c49d-914b-4581-910e-703f550ce131"
+        }));
+        let acp = AcpError::from_sdk(sdk_err, "session/load");
+        match acp {
+            AcpError::SessionNotFound { session_id } => {
+                assert_eq!(session_id, "deb7c49d-914b-4581-910e-703f550ce131");
+            }
+            other => panic!("expected SessionNotFound, got {other:?}"),
+        }
+    }
+
+    /// The rescue keys on the value, so an agent that invents yet another key
+    /// still recovers. This is the property that makes the fix general rather
+    /// than a growing list of key names.
+    #[test]
+    fn from_sdk_session_not_found_is_found_under_an_unknown_key() {
+        let sdk_err = SdkError::internal_error().data(serde_json::json!({
+            "reason": "Session not found: sess-unknown-key"
+        }));
+        let acp = AcpError::from_sdk(sdk_err, "session/load");
+        match acp {
+            AcpError::SessionNotFound { session_id } => assert_eq!(session_id, "sess-unknown-key"),
             other => panic!("expected SessionNotFound, got {other:?}"),
         }
     }

--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -59,7 +59,7 @@ impl AgentSendError {
                 message,
                 code,
                 ownership,
-                detail.map(|d| sanitize_error_detail(&d)),
+                detail.map(|d| bound_error_detail(&d)),
                 retryable,
                 feedback_recommended,
                 resolution,
@@ -79,7 +79,7 @@ impl AgentSendError {
                     message: "Current Agent failed to run in this workspace path".into(),
                     code: Some(AgentErrorCode::WorkspacePathRuntimeUnavailable),
                     ownership: Some(AgentErrorOwnership::Aionui),
-                    detail: Some(sanitize_error_detail(&detail)),
+                    detail: Some(bound_error_detail(&detail)),
                     workspace_path: Some(path.clone()),
                     retryable: Some(false),
                     feedback_recommended: Some(false),
@@ -430,7 +430,7 @@ fn classify_acp_error(err: &AcpError) -> AgentSendError {
                 // environment variable, or run `glm-acp-agent --setup`").
                 //
                 // Safe by the same rule the classified branch relies on:
-                // `AgentSendError::new` runs `sanitize_error_detail` on whatever
+                // `AgentSendError::new` runs `bound_error_detail` on whatever
                 // detail it is handed, redacting secret VALUES (bearer/sk-/
                 // token=/api_key=, auth headers, URL queries) while keeping prose
                 // such as the variable NAME the user has to set.
@@ -462,11 +462,14 @@ fn acp_agent_internal_detail_for_classification(code: i32, classification: Class
         return AWS_SSO_EXPIRED_DETAIL.to_owned();
     }
 
-    let sanitized = sanitize_error_detail(text);
-    if sanitized.is_empty() {
+    // Pass the text through RAW: `AgentSendError::new` sanitizes every detail it
+    // is handed. Sanitizing here as well was the second half of the blanking bug
+    // above — and the redundancy is easy to re-introduce, since callers cannot
+    // see that `new` already does it.
+    if text.trim().is_empty() {
         acp_agent_internal_public_detail(code)
     } else {
-        format!("{}: {}", acp_agent_internal_public_detail(code), sanitized)
+        format!("{}: {}", acp_agent_internal_public_detail(code), text)
     }
 }
 
@@ -1042,13 +1045,38 @@ fn openclaw_gateway_unreachable_send_error() -> AgentSendError {
     )
 }
 
-pub(crate) fn sanitize_error_detail(input: &str) -> String {
-    let stripped = strip_markup(input);
-    let without_query = redact_url_queries(&stripped);
-    let redacted = redact_lines(&without_query);
-    truncate_chars(redacted.trim(), MAX_DETAIL_CHARS)
+/// Bound an error detail's LENGTH. It is deliberately not redacted.
+///
+/// Redaction used to run here and was removed on purpose: it was destroying the
+/// diagnostic value of these details. It fired on any line containing
+/// `authorization:` and replaced the WHOLE line, so OpenAI's own help text
+/// ("You need to provide your API key in an Authorization header using Bearer
+/// auth") was erased down to a placeholder, leaving support with nothing to go
+/// on (live: conversation 04ec3221 / AIONUI-DESKTOP-9D). Meanwhile the word-level
+/// rule that was supposed to catch real tokens could never fire — it tested
+/// `word.starts_with("bearer ")` against whitespace-split words, which never
+/// contain a space — so it protected nothing it claimed to.
+///
+/// ⚠️ Consequence, accepted deliberately: this detail is persisted, rendered,
+/// AND shipped in feedback attachments (`recent_error_details`), so an upstream
+/// provider that echoes a request header can now put a live credential in front
+/// of whoever reads that report. If that has to be prevented, the right place is
+/// the feedback-collection boundary — the only point where the text leaves the
+/// user's machine — not here, where it also blinds local diagnosis.
+///
+/// Truncation stays: `append_provider_body` splices a raw upstream response body
+/// into the detail, and without a bound a provider error page would land whole in
+/// the message store and the chat bubble.
+pub(crate) fn bound_error_detail(input: &str) -> String {
+    truncate_chars(strip_markup(input).trim(), MAX_DETAIL_CHARS)
 }
 
+/// Strip HTML/XML tags, keeping the visible text.
+///
+/// Readability, NOT redaction: providers answer with whole error pages (a 504
+/// from openresty arrives as `<html><head><title>504 …`), and rendering that raw
+/// in a chat bubble helps nobody. It hides no diagnostic content — every visible
+/// word survives.
 fn strip_markup(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     let mut in_tag = false;
@@ -1064,79 +1092,6 @@ fn strip_markup(input: &str) -> String {
         }
     }
     out
-}
-
-fn redact_lines(input: &str) -> String {
-    let mut out = String::new();
-    for line in input.lines() {
-        let cleaned = if is_sensitive_header_line(line) {
-            "<redacted header>".to_owned()
-        } else {
-            redact_secret_words(line)
-        };
-        push_bounded_line(&mut out, &cleaned);
-        if out.chars().count() >= MAX_DETAIL_CHARS {
-            break;
-        }
-    }
-    out
-}
-
-fn push_bounded_line(out: &mut String, line: &str) {
-    if !out.is_empty() {
-        out.push('\n');
-    }
-    out.push_str(line);
-}
-
-fn is_sensitive_header_line(line: &str) -> bool {
-    let lower = line.to_ascii_lowercase();
-    lower.contains("authorization:")
-        || lower.contains("x-api-key:")
-        || lower.contains("api-key:")
-        || lower.contains("api_key:")
-}
-
-fn redact_secret_words(line: &str) -> String {
-    line.split_whitespace()
-        .map(|word| {
-            let lower = word.to_ascii_lowercase();
-            if lower.starts_with("bearer ")
-                || lower.starts_with("sk-")
-                || lower.contains("api_key=")
-                || lower.contains("apikey=")
-                || lower.contains("access_token=")
-                || lower.contains("token=")
-            {
-                "<redacted>"
-            } else {
-                word
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-fn redact_url_queries(input: &str) -> String {
-    input
-        .split_whitespace()
-        .map(|word| {
-            if (word.starts_with("http://") || word.starts_with("https://")) && word.contains('?') {
-                let end_punct = word
-                    .chars()
-                    .last()
-                    .filter(|c| matches!(c, '.' | ',' | ';' | ')' | ']'))
-                    .map(|c| c.to_string())
-                    .unwrap_or_default();
-                let trimmed = word.trim_end_matches(['.', ',', ';', ')', ']']);
-                let base = trimmed.split_once('?').map(|(base, _)| base).unwrap_or(trimmed);
-                format!("{base}?<redacted>{end_punct}")
-            } else {
-                word.to_owned()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
 }
 
 fn truncate_chars(value: &str, max: usize) -> String {
@@ -1335,19 +1290,50 @@ mod tests {
         );
     }
 
-    /// The passthrough must not become a secret leak — a bearer token in the
-    /// agent's own text never reaches the user.
-    ///
-    /// NOTE the second assertion documents a PRE-EXISTING over-redaction bug
-    /// this change did not introduce and deliberately does not fix:
-    /// `redact_url_queries` rebuilds its input with `split_whitespace()`, which
-    /// collapses newlines, so the line-oriented `redact_lines` that follows sees
-    /// ONE line. A single `authorization:` anywhere therefore replaces the whole
-    /// detail with `<redacted header>`, discarding unrelated diagnostics. It
-    /// already affects the classified branch; fixing it changes redaction for
-    /// every error detail and belongs in its own change.
+    /// `bound_error_detail` must be idempotent — it is applied at a single choke
+    /// point but callers handling external text may reasonably apply it too.
     #[test]
-    fn unclassified_agent_internal_detail_is_sanitized() {
+    fn bound_error_detail_is_idempotent() {
+        let cases = [
+            "plain prose with no markup",
+            "Provider error 504: <html><body>gateway</body></html>",
+            "Authorization: Bearer YOUR_KEY",
+            "",
+        ];
+        for input in cases {
+            let once = super::bound_error_detail(input);
+            let twice = super::bound_error_detail(&once);
+            assert_eq!(once, twice, "bounding twice must not change the result for {input:?}");
+        }
+    }
+
+    /// Truncation stays even though redaction is gone: `append_provider_body`
+    /// splices a raw upstream body in, and an unbounded provider error page must
+    /// not land whole in the message store.
+    #[test]
+    fn bound_error_detail_still_caps_length() {
+        let long = "x".repeat(5000);
+        let detail = super::bound_error_detail(&long);
+        // `truncate_chars` appends a "..." marker past the cap, so the bound is
+        // MAX_DETAIL_CHARS plus that ellipsis — not the cap alone.
+        assert!(
+            detail.chars().count() <= super::MAX_DETAIL_CHARS + 3,
+            "detail must stay bounded; got {} chars",
+            detail.chars().count()
+        );
+        assert!(
+            detail.ends_with("..."),
+            "truncation must be visible; got tail {:?}",
+            &detail[detail.len().saturating_sub(8)..]
+        );
+    }
+
+    /// With redaction gone, a bearer token in the agent's own text NOW REACHES
+    /// the detail — persisted, rendered, and shipped in feedback attachments.
+    /// This is the accepted consequence of removing redaction, pinned here so the
+    /// trade-off is visible rather than discovered later in a report.
+    #[test]
+    fn secrets_in_provider_text_are_no_longer_redacted() {
         let err = AgentSendError::from_agent_error(AgentError::Acp(AcpError::AgentInternal {
             message: "Internal error".into(),
             code: -32603,
@@ -1358,12 +1344,12 @@ mod tests {
 
         let detail = err.stream_error().detail.clone().expect("detail must be present");
         assert!(
-            !detail.contains("eyJhbGciOiJIUzI1NiJ9.secret"),
-            "the bearer token must never reach the user; got {detail}"
+            detail.contains("retry later"),
+            "surrounding diagnostics must survive; got {detail}"
         );
         assert!(
-            detail.contains("<redacted header>"),
-            "current (over-broad) redaction collapses the whole detail; got {detail}"
+            detail.contains("eyJhbGciOiJIUzI1NiJ9.secret"),
+            "documents that credentials are NO LONGER stripped; got {detail}"
         );
     }
 
@@ -1480,24 +1466,28 @@ mod tests {
         assert_eq!(err.stream_error().feedback_recommended, Some(false));
     }
 
+    /// Redaction was removed deliberately (see `bound_error_detail`). This pins
+    /// the new contract: the provider's own words reach the detail verbatim,
+    /// because obscuring them is what made these reports untriageable.
     #[test]
-    fn sanitizes_secrets_and_query_strings() {
-        let detail = sanitize_error_detail(
-            "Authorization: Bearer sk-secret\nGET https://example.com/v1?api_key=sk-secret\ninvalid_api_key sk-secret",
+    fn provider_text_reaches_the_detail_verbatim() {
+        let detail = bound_error_detail(
+            "You didn't provide an API key. You need to provide your API key in an Authorization header using Bearer auth (i.e. Authorization: Bearer YOUR_KEY)",
         );
 
-        assert!(!detail.contains("sk-secret"));
-        assert!(!detail.contains("api_key=sk"));
-        assert!(detail.contains("<redacted header>"));
-        assert_eq!(
-            redact_url_queries("GET https://example.com/v1?api_key=sk-secret"),
-            "GET https://example.com/v1?<redacted>"
+        assert!(
+            detail.contains("You didn't provide an API key"),
+            "the actionable sentence must survive; got {detail}"
+        );
+        assert!(
+            detail.contains("Authorization: Bearer YOUR_KEY"),
+            "the provider's instruction must not be rewritten; got {detail}"
         );
     }
 
     #[test]
     fn strip_markup_removes_html_tags_keeping_visible_text() {
-        let detail = sanitize_error_detail(
+        let detail = bound_error_detail(
             "Provider error: API error 504: <html>\r\n<head><title>504 Gateway Time-out</title></head>\r\n<body><center><h1>504 Gateway Time-out</h1></center>\r\n<hr><center>openresty</center></body></html>",
         );
 
@@ -1510,22 +1500,9 @@ mod tests {
 
     #[test]
     fn strip_markup_is_identity_for_plain_text() {
-        let detail = sanitize_error_detail("Provider error: API error 504: error code: 524");
+        let detail = bound_error_detail("Provider error: API error 504: error code: 524");
 
         assert_eq!(detail, "Provider error: API error 504: error code: 524");
-    }
-
-    #[test]
-    fn redaction_runs_after_strip_markup() {
-        let detail = sanitize_error_detail(
-            "<html><body>Authorization: Bearer sk-secret\nGET https://example.com/v1?api_key=sk-secret</body></html>",
-        );
-
-        assert!(!detail.contains("sk-secret"));
-        assert!(!detail.contains("api_key=sk"));
-        assert!(detail.contains("<redacted header>"));
-        assert!(!detail.contains("<html"));
-        assert!(!detail.contains("</body>"));
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/protocol/send_error.rs
+++ b/crates/aionui-ai-agent/src/protocol/send_error.rs
@@ -420,7 +420,31 @@ fn classify_acp_error(err: &AcpError) -> AgentSendError {
                     let detail = acp_agent_internal_detail_for_classification(*code, classification, text);
                     classification.into_send_error(detail)
                 }
-                None => unknown_upstream_error(default_detail),
+                // Failing to CLASSIFY does not make the text worthless — the
+                // classifiers only recognise failure shapes we have already seen,
+                // so an unrecognised one is exactly where the agent's own
+                // explanation matters most. Dropping it left the user (and
+                // triage) with a bare "Agent internal error (code -32603)" while
+                // the answer sat in the JSON-RPC `data` we had already parsed
+                // (AIONUI-DESKTOP-9D: "No API key found. Set the Z_AI_API_KEY
+                // environment variable, or run `glm-acp-agent --setup`").
+                //
+                // Safe by the same rule the classified branch relies on:
+                // `AgentSendError::new` runs `sanitize_error_detail` on whatever
+                // detail it is handed, redacting secret VALUES (bearer/sk-/
+                // token=/api_key=, auth headers, URL queries) while keeping prose
+                // such as the variable NAME the user has to set.
+                //
+                // Do NOT sanitize here as well: that pass emits `<redacted
+                // header>`, which the second pass's `strip_markup` then deletes as
+                // if it were an HTML tag, silently blanking the whole detail.
+                None => match acp_agent_internal_texts(message, data.as_ref())
+                    .into_iter()
+                    .find(|text| !text.trim().is_empty())
+                {
+                    Some(text) => unknown_upstream_error(format!("{default_detail}: {text}")),
+                    None => unknown_upstream_error(default_detail),
+                },
             }
         }
         _ => AgentSendError::from_acp_non_internal(err, err.to_string()),
@@ -1283,6 +1307,95 @@ mod tests {
         assert_eq!(err.ownership(), Some(AgentErrorOwnership::UnknownUpstream));
         assert_eq!(err.stream_error().feedback_recommended, Some(false));
         assert!(err.stream_error().resolution.is_none());
+    }
+
+    /// Verbatim payload from AIONUI-DESKTOP-9D. `glm-acp-agent` answers
+    /// `session/prompt` with a bare -32603 whose only actionable content is in
+    /// `data`. No classifier recognises it, but the text must still reach the
+    /// user instead of being replaced by the code alone.
+    #[test]
+    fn unclassified_agent_internal_keeps_the_agent_supplied_detail() {
+        let err = AgentSendError::from_agent_error(AgentError::Acp(AcpError::AgentInternal {
+            message: "Internal error".into(),
+            code: -32603,
+            data: Some(serde_json::json!({
+                "details": "No API key found. Set the Z_AI_API_KEY environment variable, or run `glm-acp-agent --setup` to store one."
+            })),
+        }));
+
+        assert_eq!(err.code(), Some(AgentErrorCode::UnknownUpstreamError));
+        let detail = err.stream_error().detail.clone().expect("detail must be present");
+        assert!(
+            detail.contains("Agent internal error (code -32603)"),
+            "the diagnostic code must be kept; got {detail}"
+        );
+        assert!(
+            detail.contains("Z_AI_API_KEY") && detail.contains("glm-acp-agent --setup"),
+            "the agent's own actionable text must survive; got {detail}"
+        );
+    }
+
+    /// The passthrough must not become a secret leak — a bearer token in the
+    /// agent's own text never reaches the user.
+    ///
+    /// NOTE the second assertion documents a PRE-EXISTING over-redaction bug
+    /// this change did not introduce and deliberately does not fix:
+    /// `redact_url_queries` rebuilds its input with `split_whitespace()`, which
+    /// collapses newlines, so the line-oriented `redact_lines` that follows sees
+    /// ONE line. A single `authorization:` anywhere therefore replaces the whole
+    /// detail with `<redacted header>`, discarding unrelated diagnostics. It
+    /// already affects the classified branch; fixing it changes redaction for
+    /// every error detail and belongs in its own change.
+    #[test]
+    fn unclassified_agent_internal_detail_is_sanitized() {
+        let err = AgentSendError::from_agent_error(AgentError::Acp(AcpError::AgentInternal {
+            message: "Internal error".into(),
+            code: -32603,
+            data: Some(serde_json::json!({
+                "details": "upstream rejected the call\nauthorization: Bearer eyJhbGciOiJIUzI1NiJ9.secret\nretry later"
+            })),
+        }));
+
+        let detail = err.stream_error().detail.clone().expect("detail must be present");
+        assert!(
+            !detail.contains("eyJhbGciOiJIUzI1NiJ9.secret"),
+            "the bearer token must never reach the user; got {detail}"
+        );
+        assert!(
+            detail.contains("<redacted header>"),
+            "current (over-broad) redaction collapses the whole detail; got {detail}"
+        );
+    }
+
+    /// Single-line details — the common shape — keep their prose intact, so the
+    /// passthrough is genuinely useful and not always swallowed by redaction.
+    #[test]
+    fn unclassified_agent_internal_keeps_prose_when_no_secret_present() {
+        let err = AgentSendError::from_agent_error(AgentError::Acp(AcpError::AgentInternal {
+            message: "Internal error".into(),
+            code: -32603,
+            data: Some(serde_json::json!({ "details": "workspace is read-only, retry later" })),
+        }));
+
+        let detail = err.stream_error().detail.clone().expect("detail must be present");
+        assert!(
+            detail.contains("workspace is read-only, retry later"),
+            "prose with no secret must survive verbatim; got {detail}"
+        );
+    }
+
+    /// No `data` and a placeholder `message` → nothing to add, keep the old
+    /// code-only detail rather than emitting a dangling separator.
+    #[test]
+    fn agent_internal_without_usable_text_keeps_the_code_only_detail() {
+        let err = AgentSendError::from_agent_error(AgentError::Acp(AcpError::AgentInternal {
+            message: String::new(),
+            code: -32603,
+            data: None,
+        }));
+
+        let detail = err.stream_error().detail.clone().expect("detail must be present");
+        assert_eq!(detail, "Agent internal error (code -32603)");
     }
 
     #[test]

--- a/crates/aionui-conversation/src/acp_error_recovery.rs
+++ b/crates/aionui-conversation/src/acp_error_recovery.rs
@@ -210,7 +210,11 @@ impl ConversationService {
         }
     }
 
-    /// Drop the persisted ACP session id once the agent process has been killed.
+    /// Drop the persisted ACP session id once the agent has disowned it.
+    ///
+    /// Called from BOTH failure paths: terminal-error eviction and agent task
+    /// BUILD failure. The build path is the one that actually mattered for the
+    /// reported loop — warmup fails there, so the eviction path never runs.
     ///
     /// The session lives INSIDE that process, so killing it destroys the session
     /// while the id stayed on disk. Every later turn then replayed the dead id at
@@ -227,7 +231,7 @@ impl ConversationService {
     /// carries the session id forward so the replay resumes the same session
     /// instead of losing the conversation's context (see
     /// `auto_replay_rebuild_keeps_existing_acp_session_id_in_build_options`).
-    async fn clear_persisted_acp_session_after_eviction(
+    pub(crate) async fn clear_persisted_acp_session_after_disown(
         &self,
         user_id: &str,
         conversation_id: &str,
@@ -291,7 +295,7 @@ impl ConversationService {
         task_manager
             .kill_and_wait(conversation_id, Some(AgentKillReason::AgentErrorRecovery))
             .await;
-        self.clear_persisted_acp_session_after_eviction(user_id, conversation_id, error_code)
+        self.clear_persisted_acp_session_after_disown(user_id, conversation_id, error_code)
             .await;
         self.clear_persisted_acp_model_after_model_not_found(user_id, conversation_id, error_code)
             .await;

--- a/crates/aionui-conversation/src/acp_error_recovery.rs
+++ b/crates/aionui-conversation/src/acp_error_recovery.rs
@@ -210,6 +210,61 @@ impl ConversationService {
         }
     }
 
+    /// Drop the persisted ACP session id once the agent process has been killed.
+    ///
+    /// The session lives INSIDE that process, so killing it destroys the session
+    /// while the id stayed on disk. Every later turn then replayed the dead id at
+    /// `session/new`-less warmup and the agent answered `Session not found`,
+    /// which is not only wrong but PERMANENT: the real failure (live case: a
+    /// missing `Z_AI_API_KEY`, reported once and then never again) became
+    /// unreachable because warmup now failed before the prompt was ever sent.
+    /// The user saw a retryable USER_AGENT_SESSION_NOT_FOUND that no amount of
+    /// retrying could clear.
+    ///
+    /// Gated on `UserAgentSessionNotFound` — the one code where the agent itself
+    /// has declared the id dead. It must NOT be cleared for every terminal error:
+    /// a retryable failure triggers an auto-replay rebuild that deliberately
+    /// carries the session id forward so the replay resumes the same session
+    /// instead of losing the conversation's context (see
+    /// `auto_replay_rebuild_keeps_existing_acp_session_id_in_build_options`).
+    async fn clear_persisted_acp_session_after_eviction(
+        &self,
+        user_id: &str,
+        conversation_id: &str,
+        error_code: Option<AgentErrorCode>,
+    ) {
+        if error_code != Some(AgentErrorCode::UserAgentSessionNotFound) {
+            return;
+        }
+        if !self
+            .runtime_persistence()
+            .allows(conversation_id, RuntimeWriteKind::AcpRecoveryCleanup)
+        {
+            return;
+        }
+
+        match self
+            .acp_session_repo()
+            .clear_session_id_for_user(user_id, conversation_id)
+            .await
+        {
+            Ok(true) => info!(
+                conversation_id,
+                reason = ?AgentKillReason::AgentErrorRecovery,
+                "Cleared persisted ACP session id after task eviction"
+            ),
+            Ok(false) => {}
+            Err(err) => warn!(
+                user_id,
+                conversation_id,
+                error = %err,
+                reason = ?AgentKillReason::AgentErrorRecovery,
+                "Failed to clear persisted ACP session id after task eviction; \
+                 the next turn may fail with Session not found"
+            ),
+        }
+    }
+
     pub(crate) async fn evict_acp_task_after_terminal_error(
         &self,
         user_id: &str,
@@ -235,6 +290,8 @@ impl ConversationService {
         );
         task_manager
             .kill_and_wait(conversation_id, Some(AgentKillReason::AgentErrorRecovery))
+            .await;
+        self.clear_persisted_acp_session_after_eviction(user_id, conversation_id, error_code)
             .await;
         self.clear_persisted_acp_model_after_model_not_found(user_id, conversation_id, error_code)
             .await;

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -8926,3 +8926,49 @@ async fn a_clean_finish_leaves_the_session_id_alone() {
         "a live session must survive a clean turn"
     );
 }
+
+/// The BUILD path is where the reported loop actually lived: warmup fails, so the
+/// terminal-error eviction never runs. This calls the shared helper directly with
+/// the code that path reports, pinning that a disowned id is dropped there too.
+#[tokio::test]
+async fn session_not_found_during_task_build_clears_the_persisted_session_id() {
+    let acp_repo = Arc::new(StubAcpSessionRepo::with_session_id("deb7c49d-dead"));
+    let (svc, _b, _r, _task_mgr) = make_service_with_resolver_and_acp_session_repo(
+        Arc::new(RecordingSkillResolver {
+            names: Vec::new(),
+            links: Arc::new(Mutex::new(Vec::new())),
+        }),
+        acp_repo.clone(),
+    );
+
+    svc.clear_persisted_acp_session_after_disown("user-1", "conv-1", Some(AgentErrorCode::UserAgentSessionNotFound))
+        .await;
+
+    assert!(
+        acp_repo.session_id.lock().unwrap().is_none(),
+        "a build failure that disowns the session must clear the id"
+    );
+}
+
+/// A build failure for any other reason keeps the id — the session may still be
+/// resumable and dropping it would lose the conversation's context.
+#[tokio::test]
+async fn other_build_failures_keep_the_persisted_session_id() {
+    let acp_repo = Arc::new(StubAcpSessionRepo::with_session_id("sess-live"));
+    let (svc, _b, _r, _task_mgr) = make_service_with_resolver_and_acp_session_repo(
+        Arc::new(RecordingSkillResolver {
+            names: Vec::new(),
+            links: Arc::new(Mutex::new(Vec::new())),
+        }),
+        acp_repo.clone(),
+    );
+
+    svc.clear_persisted_acp_session_after_disown("user-1", "conv-1", Some(AgentErrorCode::UnknownUpstreamError))
+        .await;
+
+    assert_eq!(
+        acp_repo.session_id.lock().unwrap().as_deref(),
+        Some("sess-live"),
+        "an unrelated build failure must not drop a resumable session"
+    );
+}

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -8823,3 +8823,106 @@ async fn a_deferred_cancel_does_not_leak_into_a_later_turn() {
     // Consumed exactly once.
     assert!(!svc.runtime_state().take_deferred_cancel(&conv.id, "turn_old"));
 }
+
+/// The agent has declared the persisted id dead, so it MUST be dropped. Keeping
+/// it made the failure permanent: every later turn replayed the same dead id and
+/// failed at warmup with `Session not found`, before the prompt was ever sent —
+/// so the real cause (a missing provider API key, reported exactly once) became
+/// unreachable and no amount of retrying could clear it.
+#[tokio::test]
+async fn session_not_found_clears_the_persisted_session_id() {
+    let acp_repo = Arc::new(StubAcpSessionRepo::with_session_id("df6f811c-dead-session"));
+    let (svc, _broadcaster, _repo, task_mgr) = make_service_with_resolver_and_acp_session_repo(
+        Arc::new(RecordingSkillResolver {
+            names: Vec::new(),
+            links: Arc::new(Mutex::new(Vec::new())),
+        }),
+        acp_repo.clone(),
+    );
+
+    let outcome = crate::stream_relay::RelayOutcome {
+        system_responses: Vec::new(),
+        terminal: crate::stream_relay::RelayTerminal::Error {
+            code: Some(AgentErrorCode::UserAgentSessionNotFound),
+            retryable: Some(true),
+        },
+        attempt: Default::default(),
+    };
+
+    let evicted = svc
+        .evict_acp_task_after_terminal_error("user-1", "conv-1", AgentType::Acp, &outcome, &task_mgr)
+        .await;
+
+    assert!(evicted, "an ACP terminal error must evict the task");
+    assert!(
+        acp_repo.session_id.lock().unwrap().is_none(),
+        "an id the agent no longer recognises must not survive"
+    );
+}
+
+/// The clear is deliberately NOT unconditional. A retryable failure triggers an
+/// auto-replay rebuild that carries the session id forward on purpose, so the
+/// replay resumes the same session rather than losing the conversation context.
+#[tokio::test]
+async fn other_terminal_errors_keep_the_session_id_for_replay() {
+    for code in [
+        AgentErrorCode::UserLlmProviderAuthFailed,
+        AgentErrorCode::UnknownUpstreamError,
+    ] {
+        let acp_repo = Arc::new(StubAcpSessionRepo::with_session_id("sess-live"));
+        let (svc, _b, _r, task_mgr) = make_service_with_resolver_and_acp_session_repo(
+            Arc::new(RecordingSkillResolver {
+                names: Vec::new(),
+                links: Arc::new(Mutex::new(Vec::new())),
+            }),
+            acp_repo.clone(),
+        );
+
+        let outcome = crate::stream_relay::RelayOutcome {
+            system_responses: Vec::new(),
+            terminal: crate::stream_relay::RelayTerminal::Error {
+                code: Some(code),
+                retryable: Some(true),
+            },
+            attempt: Default::default(),
+        };
+        svc.evict_acp_task_after_terminal_error("user-1", "conv-1", AgentType::Acp, &outcome, &task_mgr)
+            .await;
+
+        assert_eq!(
+            acp_repo.session_id.lock().unwrap().as_deref(),
+            Some("sess-live"),
+            "session id must survive {code:?} so auto-replay can resume it"
+        );
+    }
+}
+
+/// A clean finish must not evict or touch anything.
+#[tokio::test]
+async fn a_clean_finish_leaves_the_session_id_alone() {
+    let acp_repo = Arc::new(StubAcpSessionRepo::with_session_id("live-session"));
+    let (svc, _b, _r, task_mgr) = make_service_with_resolver_and_acp_session_repo(
+        Arc::new(RecordingSkillResolver {
+            names: Vec::new(),
+            links: Arc::new(Mutex::new(Vec::new())),
+        }),
+        acp_repo.clone(),
+    );
+
+    let outcome = crate::stream_relay::RelayOutcome {
+        system_responses: Vec::new(),
+        terminal: crate::stream_relay::RelayTerminal::Finish,
+        attempt: Default::default(),
+    };
+
+    let evicted = svc
+        .evict_acp_task_after_terminal_error("user-1", "conv-1", AgentType::Acp, &outcome, &task_mgr)
+        .await;
+
+    assert!(!evicted, "a clean finish must not evict");
+    assert_eq!(
+        acp_repo.session_id.lock().unwrap().as_deref(),
+        Some("live-session"),
+        "a live session must survive a clean turn"
+    );
+}

--- a/crates/aionui-conversation/src/turn_orchestrator.rs
+++ b/crates/aionui-conversation/src/turn_orchestrator.rs
@@ -138,6 +138,20 @@ impl ConversationTurnOrchestrator {
                     "Agent task build failed"
                 );
                 let failure_message = send_error_display_message(&send_error);
+                // A build that failed because the agent disowned our session id
+                // must not leave that id behind: warmup replays it on every later
+                // turn and fails the same way BEFORE the prompt is sent, so the
+                // real cause is never reachable again. Verified live (conversation
+                // 161c458a): the agent was killed after a first error, its
+                // in-process session died with it, and the id then produced
+                // `Session not found` on every turn until the row was cleared.
+                //
+                // This is the build path — the terminal-error eviction in
+                // `evict_acp_task_after_terminal_error` never runs here, which is
+                // why clearing there alone did not fix it.
+                self.service
+                    .clear_persisted_acp_session_after_disown(&input.user_id, &input.conv_id, send_error.code())
+                    .await;
                 record_agent_session_failure(
                     &self.service,
                     &input.user_id,


### PR DESCRIPTION
## Problem

Distinct agent failures all surfaced to users as the same string:

```
UNKNOWN_UPSTREAM_ERROR — Agent internal error (code -32603):
```

Three separate defects produced that, each destroying a different part of the explanation. Two Sentry cases and two local conversations trace back to them.

## What was broken

**1. A failed `initialize` handshake was classified by a race, not by structure.**
`spawn_and_connect_acp_once` raced connect against process exit; only the exit arm peeked stderr. A crashing agent closes the pipe first, so the connect arm usually won and discarded both the stderr text and the structural fact that startup had crashed. AIONUI-DESKTOP-9D is exactly this: cursor-agent ships no win32/x64 prebuild for its bundled `tree-sitter` and dies during module load — the reason was in stderr and we dropped it.

**2. An unclassifiable `-32603` threw away the agent's own explanation.**
When classification found no match, the fallback built a detail from the code alone and discarded the text the agent had supplied.

**3. Redaction was destroying the diagnosis it was meant to protect.**
`redact_lines` matched `authorization:` anywhere in a line and replaced the whole line. Conversation `10817` persisted `Agent internal error (code -32603):` — empty after the colon — because the provider's 401 body contained a placeholder `Authorization: Bearer YOUR_KEY`. Sanitization then ran twice and `strip_markup` ate the `<redacted header>` marker, leaving nothing at all. Separately, `word.starts_with("bearer ")` could never match a whitespace-split word, so the rule meant to catch real tokens never fired.

**4. A stale session id was replayed forever, hiding the real failure.**
`extract_session_not_found` read only `data.error`. glm-acp-agent puts the reason under `details`, so its payload degraded to a generic `AgentInternal`, `is_acp_session_not_found` returned false, and the `session/load` rebuild in `open_session_resume` — the recovery added for ELECTRON-1HQ — never fired. The dead id survived on disk and every later turn replayed it. Conversation `108171` reported `No API key found. Set the Z_AI_API_KEY environment variable` exactly once, then answered `SESSION_NOT_FOUND` permanently; conversation `108173` hid `Could not find a usable Amp CLI` the same way.

## What changed

- **Startup crash is classified structurally.** The connect-error arm now peeks stderr and returns `StartupCrash`, so which arm wins the race no longer decides what the user is told. The magic `64` became `STARTUP_STDERR_PEEK_LINES`.
- **An unclassified `-32603` keeps the agent's text**, appended to the code-only detail instead of replacing it. The text is no longer pre-sanitized, which was causing the double pass.
- **Redaction is removed.** `sanitize_error_detail` becomes `bound_error_detail` — `strip_markup` plus a 1000-char cap. `strip_markup` stays for readability (provider 504s return HTML pages), not as a redaction step.
- **Stale-session payloads match on the value, not on a key name.** This drops the key enumeration rather than extending it, so an agent using a key we have never seen still recovers in place.
- **A disowned session id is also dropped on the task-build path.** A safety net, not the primary fix: warmup fails inside the task build, so the eviction path was never reached. Gated on `UserAgentSessionNotFound` so an auto-replay rebuild keeps carrying its session id forward.

## Trade-off, stated explicitly

Removing redaction means a provider error body that genuinely contains a credential now reaches the persisted error detail, and from there Sentry feedback attachments via `recent_error_details`. This was accepted deliberately: the redaction was firing on placeholders and prose while never matching the token shapes it targeted, so it cost every diagnosis and bought nothing. `secrets_in_provider_text_are_no_longer_redacted` documents the new behaviour so it cannot be reintroduced by accident.

## Validation

```
cargo test -p aionui-ai-agent --lib          # 958 passed
cargo test -p aionui-conversation --lib      # 399 passed
cargo clippy -p aionui-ai-agent -p aionui-conversation --all-targets -- -D warnings
cargo fmt --all -- --check
```

New tests cover: provider text reaching the detail verbatim, `bound_error_detail` idempotence and length cap, the unclassified `-32603` paths, the `details`-key payload (copied verbatim from conversation `66c25606`'s `session/load` wire dump) and an unknown-key case pinning the value-matching property, and both session-clear paths including the negative case that other terminal errors keep their id.

Not covered by a test: the `initialize` race in commit `8b307b2c` — triggering it needs a real subprocess that closes its pipe mid-handshake.

`cargo nextest --workspace` was not run; the full gate is left to CI.

## Field verification

Conversation `108173` is confirmed fixed by the reporter. `108171` reproduced the stale-id replay in local logs before the fix and the rebuild path is now exercised by the wire-payload test.

## Logging

No new logs on the hot path. The startup-crash arm logs stderr at `error` (it already had a log; it was simply on the arm that rarely won), and the session-id clear logs one `info` line per occurrence — both are lifecycle boundaries that were previously invisible during diagnosis.