### PR TITLE
fix(claude): three follow-ups to the tool-step labels

### DIFF
--- a/crates/aionui-ai-agent/src/workflow_progress.rs
+++ b/crates/aionui-ai-agent/src/workflow_progress.rs
@@ -206,6 +206,15 @@ impl WorkflowCard {
     /// A rosterless background task (`local_bash` / `local_agent`). `desc` is the
     /// launching call's own description of the work; `task_id` rides in the
     /// headline so the user can name the task when asking to stop it.
+    ///
+    /// `desc` is DROPPED when it merely repeats `tool_name`. The step row draws
+    /// the name and the description side by side and dedupes only on exact
+    /// equality, so once a backend derives its step label from the same argument
+    /// the headline quotes — since #870 a claude Bash label IS that call's own
+    /// `description` — keeping both printed the text twice: "Wait for instance
+    /// readiness" + "Wait for instance readiness · bg task bdyspm202 · 00:09".
+    /// Where the label is still a bare tool name, `desc` is the only thing
+    /// saying what the task does, so it is kept.
     pub fn new_background(
         call_id: String,
         tool_name: String,
@@ -217,6 +226,7 @@ impl WorkflowCard {
         let mut card = Self::new(call_id, tool_name, args, now_ms);
         card.kind = CardKind::BackgroundTask;
         card.bg_headline = match desc {
+            Some(d) if d.trim() == card.tool_name.trim() => format!("bg task {task_id}"),
             Some(d) => format!("{} · bg task {task_id}", elide_middle(&d, SUMMARY_MAX)),
             None => format!("bg task {task_id}"),
         };
@@ -622,6 +632,57 @@ mod tests {
         assert_ne!(
             ea[0].call_id, eb[0].call_id,
             "two workflows must not claim the same messages.id"
+        );
+    }
+
+    #[test]
+    fn background_headline_does_not_repeat_the_step_label() {
+        // The step row draws `name` then `description`, deduping only on EXACT
+        // equality. Since #870 a claude Bash step's label IS that call's own
+        // `description`, so a headline that also quoted it printed the text
+        // twice: "Wait for instance readiness" + "Wait for instance readiness ·
+        // bg task bdyspm202 · 00:09".
+        let label = "Wait for instance readiness";
+        let mut c = WorkflowCard::new_background(
+            "toolu_bg".into(),
+            label.into(),
+            serde_json::json!({"command": "until grep -q READY log; do sleep 1; done", "description": label}),
+            "bdyspm202",
+            Some(label.to_string()),
+            0,
+        );
+        let (f, _) = c.take_emission(9_000, true).expect("background cards open immediately");
+        let description = f.description.as_deref().unwrap();
+
+        assert!(
+            !description.contains(label),
+            "headline must not repeat the label the row already shows: {description:?}"
+        );
+        // It still has to say WHICH task, so the user can ask to stop it.
+        assert!(
+            description.contains("bg task bdyspm202"),
+            "lost the task id: {description:?}"
+        );
+        assert!(description.ends_with("00:09"), "lost the clock: {description:?}");
+    }
+
+    /// The other direction: where the label is still a BARE tool name, the desc
+    /// is the only thing saying what the task does, so it must be kept.
+    #[test]
+    fn background_headline_keeps_a_desc_that_adds_information() {
+        let mut c = WorkflowCard::new_background(
+            "toolu_bg".into(),
+            "Bash".into(),
+            serde_json::Value::Null,
+            "b7",
+            Some("Sleep 15 seconds".into()),
+            0,
+        );
+        let (f, _) = c.take_emission(0, true).unwrap();
+        let description = f.description.as_deref().unwrap();
+        assert!(
+            description.contains("Sleep 15 seconds") && description.contains("bg task b7"),
+            "a desc distinct from the label carries the only description of the work: {description:?}"
         );
     }
 

--- a/crates/aionui-session/src/adapter/claude.rs
+++ b/crates/aionui-session/src/adapter/claude.rs
@@ -1413,21 +1413,23 @@ fn tool_call_display_name(name: &str, input: &Value) -> String {
         }
     }
 
-    let field = |key: &str| {
+    let raw = |key: &str| {
         input
             .get(key)
             .and_then(Value::as_str)
-            .map(bounded)
+            .map(str::trim)
             .filter(|s| !s.is_empty())
     };
-    // The trailing path segment; a path ending in a separator falls back to the
-    // whole (bounded) value rather than yielding an empty label.
+    let field = |key: &str| raw(key).map(bounded).filter(|s| !s.is_empty());
+    // The trailing path segment, taken from the RAW value and bounded only
+    // afterwards. Bounding first would cut a real project path (well over
+    // MAX_DETAIL_CHARS) mid-directory and leave that fragment as the "file
+    // name": `.../components/Markdown/CodeBlock.tsx` became "Markdown…".
+    // A path ending in a separator falls back to the whole value.
     let file_name = || {
-        field("file_path").map(|path| {
-            path.rsplit(['/', '\\'])
-                .find(|seg| !seg.is_empty())
-                .unwrap_or(&path)
-                .to_string()
+        raw("file_path").map(|path| {
+            let tail = path.rsplit(['/', '\\']).find(|seg| !seg.is_empty()).unwrap_or(path);
+            bounded(tail)
         })
     };
 
@@ -1448,6 +1450,16 @@ fn tool_call_display_name(name: &str, input: &Value) -> String {
         "WebSearch" | "ToolSearch" => labeled("Search", field("query")),
         "WebFetch" => labeled("Fetch", field("url")),
         "Skill" => labeled("Skill", field("skill")),
+        // A plan is a run of TaskCreate calls; without the subject they all read
+        // identically and the work is only visible after expanding each row.
+        "TaskCreate" => field("subject").unwrap_or_else(|| name.to_string()),
+        "TaskUpdate" => match (field("taskId"), field("status")) {
+            (Some(id), Some(status)) => format!("Task {id} → {status}"),
+            (Some(id), None) => format!("Task {id}"),
+            _ => name.to_string(),
+        },
+        "TaskStop" => labeled("Stop task", field("task_id")),
+        "SendMessage" => labeled("Message", field("to")),
         // Unverified shape (every mcp__* tool lands here): keep claude's name.
         _ => name.to_string(),
     }
@@ -2139,6 +2151,41 @@ mod tests {
         );
     }
 
+    /// A REAL project path is longer than the detail bound, and the bound must
+    /// not be applied before the file name is extracted — doing so truncates the
+    /// path mid-directory and leaves that directory fragment as the "file name":
+    /// `.../renderer/components/Markdown/CodeBlock.tsx` (116 chars) rendered as
+    /// "Read Ma…" because the cut landed inside "Markdown".
+    #[test]
+    fn long_paths_still_yield_the_file_name() {
+        for (path, expected) in [
+            (
+                "/Users/z/Documents/github/AionUi-worktrees/rtl/packages/desktop/src/renderer/components/Markdown/CodeBlock.tsx",
+                "Read CodeBlock.tsx",
+            ),
+            (
+                "/Users/z/Documents/github/AionUi-worktrees/rtl/packages/desktop/src/renderer/services/i18n/index.ts",
+                "Read index.ts",
+            ),
+        ] {
+            assert!(path.chars().count() > 96, "fixture must exceed the detail bound");
+            assert_eq!(
+                tool_call_display_name("Read", &serde_json::json!({"file_path": path})),
+                expected
+            );
+        }
+    }
+
+    /// A pathological file NAME (not path) still has to be bounded.
+    #[test]
+    fn an_absurdly_long_file_name_is_still_elided() {
+        let name = format!("{}.rs", "n".repeat(200));
+        let label = tool_call_display_name("Write", &serde_json::json!({"file_path": format!("/a/b/{name}")}));
+        assert!(label.starts_with("Write nnn"), "label: {label}");
+        assert!(label.ends_with('…'), "an over-long file name must be elided: {label}");
+        assert!(label.chars().count() <= 103, "label was not bounded: {label}");
+    }
+
     #[test]
     fn file_tool_labels_show_the_file_name_not_the_whole_path() {
         // A full path is mostly shared prefix; the tail (the part that matters)
@@ -2161,6 +2208,45 @@ mod tests {
         assert_eq!(
             tool_call_display_name("Grep", &serde_json::json!({"pattern": "tool_call_display_name"})),
             "Search tool_call_display_name"
+        );
+    }
+
+    /// The task/messaging tools were left on the bare name by #870, so a plan of
+    /// five `TaskCreate` steps read as five identical rows — the subject was only
+    /// visible after expanding each one. Shapes from real traffic:
+    /// `TaskCreate {activeForm, description, subject}` (26 rows),
+    /// `TaskUpdate {status, taskId}` (37), `TaskStop {task_id}` (14),
+    /// `SendMessage {to, message, …}` (12).
+    #[test]
+    fn task_and_messaging_tools_say_what_they_act_on() {
+        assert_eq!(
+            tool_call_display_name(
+                "TaskCreate",
+                &serde_json::json!({
+                    "subject": "P1: dir/lang sync + Arco rtl + LTR code islands",
+                    "description": "Add direction.ts helper …",
+                    "activeForm": "Implementing P1 direction plumbing"
+                })
+            ),
+            "P1: dir/lang sync + Arco rtl + LTR code islands"
+        );
+        assert_eq!(
+            tool_call_display_name("TaskUpdate", &serde_json::json!({"taskId": "3", "status": "completed"})),
+            "Task 3 → completed"
+        );
+        // A status-less update still names the task rather than falling back to
+        // the tool name.
+        assert_eq!(
+            tool_call_display_name("TaskUpdate", &serde_json::json!({"taskId": "3"})),
+            "Task 3"
+        );
+        assert_eq!(
+            tool_call_display_name("TaskStop", &serde_json::json!({"task_id": "b4p422pva"})),
+            "Stop task b4p422pva"
+        );
+        assert_eq!(
+            tool_call_display_name("SendMessage", &serde_json::json!({"to": "reviewer", "message": "ping"})),
+            "Message reviewer"
         );
     }
 


### PR DESCRIPTION
Three defects in the step labels #870 introduced, all visible in one screenshot.

## 1. Every long path rendered as a directory fragment

The detail bound was applied to `file_path` **before** the trailing segment was taken, so a real project path — comfortably over the 96-char bound — got cut mid-directory and that fragment became the "file name":

| stored label | should be |
| --- | --- |
| `Read Ma…` | Read CodeBlock.tsx |
| `Read i18n…` | Read index.ts |
| `Edit i18n…` | Edit index.ts |
| `Write i18n…` | Write direction.ts |
| `Write aionui-mobile-di…` | Write aionui-mobile-dir-out-of-scope.md |
| `Edit convers…` | Edit (the file under `pages/conversation/…`) |

`Edit main.tsx` and `Read MEMORY.md` only looked correct because those two paths happen to be short. Everything under a worktree path was broken.

Fix: take the segment from the raw value, bound it afterwards. An absurdly long file *name* is still elided — pinned by its own test so the bound is not simply dropped.

## 2. The task/messaging tools were still bare names

A plan of five `TaskCreate` calls rendered as five identical `TaskCreate` rows; the subjects were reachable only by expanding each one. Shapes taken from real traffic (26 `TaskCreate`, 37 `TaskUpdate`, 14 `TaskStop`, 12 `SendMessage` persisted rows):

| tool | label |
| --- | --- |
| `TaskCreate {subject}` | the subject |
| `TaskUpdate {taskId, status}` | `Task 3 → completed` (`Task 3` when status is absent) |
| `TaskStop {task_id}` | `Stop task b4p422pva` |
| `SendMessage {to}` | `Message reviewer` |

Unrecognized tools and every `mcp__*` tool still keep the name claude gave them — their shapes are not verified, so they are not guessed at.

## 3. The background-task card repeated its own label

The step row draws `name` then `description` side by side and dedupes only on **exact** equality (`MessageToolGroupSummary.tsx`):

```tsx
<span>{displayItem.name}</span>
{displayItem.description && displayItem.description !== displayItem.name && (
  <span className='m-l-4px'>{displayItem.description}</span>
)}
```

Since #870 a claude Bash step's label **is** that call's own `description`, and `new_background` quoted the same description in its headline. The two strings differ (the headline appends the task id and the clock), so the dedupe missed and both rendered:

```
Wait for instance readiness │ Wait for instance readiness · bg task bdyspm202 · 00:09
```

Fix: drop `desc` from the headline when it merely repeats `tool_name`, keeping the task id (the user needs it to name the task when asking to stop it).

The drop is **conditional** on purpose. Where the step label is still a bare tool name — any backend not deriving its label from the same argument — `desc` is the only thing describing the work. Removing it unconditionally regressed `background_bash_gets_a_live_card_and_settles_on_notification` (`name: "Bash"`, `desc: "Sleep 15 seconds"`); that failure is what made it conditional.

## Verification

Before/after on the real rows of the affected conversation:

```
Read Ma…                 ->  Read CodeBlock.tsx
Write aionui-mobile-di…  ->  Write aionui-mobile-dir-out-of-scope.md
TaskCreate               ->  P1: dir/lang sync + Arco rtl + LTR code islands
TaskCreate               ->  P2: codemod physical → logical CSS properties
TaskCreate               ->  Gates: tsc + lint + tests + prek
TaskUpdate               ->  Task 1 → in_progress
```

New tests: long-path file names, an over-long file name still elided, the four task/messaging labels, and both directions of the headline dedupe.

`cargo test -p aionui-session -p aionui-ai-agent` pass (960 + suites), `cargo clippy -p aionui-session -p aionui-ai-agent --all-targets -- -D warnings` clean, `cargo fmt --all -- --check` clean.
