### PR TITLE
chore(acp): bump dimcode registry pin to probed 0.3.15

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -19,7 +19,7 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.13"
+      "version": "0.3.15"
     },
     "dirac": {
       "registry_json_id": "dirac",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. One npx pin drifted since #865, backed by a fresh ACP probe of the exact pinned version. Lock-only change — one line; no metadata, migration, or entrypoint edits, and no lock-derived test assertion embeds this version.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| dimcode | `dimcode` | 0.3.13 → **0.3.15** | ok (protocolVersion 1, agentInfo version 0.3.15) | auth required (`-32000`, "Provider credentials are required") |

Meets the release-lock criterion: `initialize` succeeds and `session/new` returns a clearly classified authentication requirement. The probe ran with no inherited HOME or credentials. The Registry advertises 0.3.15 directly (0.3.14 is skipped), and 0.3.15 is what was probed and pinned.

The other 10 Registry-pinned packages match the snapshot exactly — no drift. In particular glm-acp-agent 1.5.0, grok 1.0.5 and nova 1.1.35, all bumped last night in #865, are still current. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. `mimo-code` remains the one non-Registry builtin (no `registry_json_id`), excluded from drift reconciliation.

dimcode continues to self-report `agentInfo.title` as "DimAgent" while the public Registry card and CDN entry still say "DimCode" (`dimcode.dev` unchanged), so the seeded display name is untouched — the same standing observation carried since #814.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.17-168e146`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.17-168e146/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the previous baseline (38 ids).

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11; #810, #814, #822, #837, #848, #859 and #865 all merged green under it). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock-only version bump; existing startup/session error paths already identify a failing agent by backend.
