### PR TITLE
fix(agent): pair native media blocks with a link to the same file

### DIFF
--- a/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
+++ b/crates/aionui-ai-agent/src/manager/acp/agent_session_flow.rs
@@ -494,6 +494,15 @@ impl AcpAgentManager {
 /// accept. Attachments the agent cannot take (or that fail to read) stay in
 /// the text block's `[[AION_FILES]]` path list, byte-identical to the
 /// pre-multimodal wire form.
+///
+/// The text keeps EVERY attachment path, media included. This path emits no
+/// resource links — a non-media attachment rides solely as a marker line — so
+/// the marker is its only path channel, and a native media block carries bytes
+/// with no path. The `uri` set on the image block below is not enough: observed
+/// live, one ACP agent asked the user for a path it had already been handed as
+/// `uri`, and another silently reported an invented file size. Dropping the
+/// media path from the text leaves such an agent able to see the image but
+/// unable to open the file.
 async fn build_prompt_blocks(data: &SendMessageData, caps: crate::types::PromptMediaCaps) -> Vec<ContentBlock> {
     use base64::Engine as _;
 
@@ -536,7 +545,10 @@ async fn build_prompt_blocks(data: &SendMessageData, caps: crate::types::PromptM
     );
 
     let mut blocks = Vec::with_capacity(media_blocks.len() + 1);
-    blocks.push(ContentBlock::from(partition.content));
+    blocks.push(ContentBlock::from(crate::media::content_with_all_paths(
+        &data.content,
+        &data.files,
+    )));
     blocks.extend(media_blocks);
     blocks
 }
@@ -1585,10 +1597,15 @@ mod tests {
         assert_eq!(blocks.len(), 2);
         match &blocks[0] {
             ContentBlock::Text(text) => {
-                // Image path left the marker list; the pdf stays.
+                // BOTH paths stay in the marker list: the image rides as a native
+                // block AND keeps its path, since this path has no other way to
+                // hand the agent a file to open.
                 assert_eq!(
                     text.text,
-                    format!("look\n\n{}\n{pdf}", aionui_common::constants::AIONUI_FILES_MARKER)
+                    format!(
+                        "look\n\n{}\n{img}\n{pdf}",
+                        aionui_common::constants::AIONUI_FILES_MARKER
+                    )
                 );
             }
             other => panic!("expected text block, got {other:?}"),
@@ -1601,6 +1618,44 @@ mod tests {
             }
             other => panic!("expected image block, got {other:?}"),
         }
+    }
+
+    // Regression guard: this path emits NO resource links — a non-media
+    // attachment rides solely as an `[[AION_FILES]]` marker line — so the marker
+    // is the only path channel it has. A native image block carries bytes, not a
+    // path, and the `uri` field on it is not surfaced to the agents' file tools
+    // (observed live: one ACP agent asked for a path it had already been sent as
+    // `uri`, another invented a file size). Keep every media path in the text.
+    #[tokio::test]
+    async fn prompt_blocks_keep_media_paths_in_text() {
+        let dir = std::env::temp_dir().join("aionui-acp-prompt-tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let img = dir.join("keep-path.png");
+        std::fs::write(&img, b"fakepng").unwrap();
+        let img = img.to_string_lossy().into_owned();
+        let content = format!("read this\n\n{}\n{img}", aionui_common::constants::AIONUI_FILES_MARKER);
+        let data = SendMessageData {
+            content: content.clone(),
+            msg_id: "m4".into(),
+            turn_id: None,
+            files: vec![img.clone()],
+            inject_skills: vec![],
+        };
+        let caps = crate::types::PromptMediaCaps {
+            image: true,
+            audio: false,
+        };
+        let blocks = super::build_prompt_blocks(&data, caps).await;
+        assert_eq!(blocks.len(), 2, "text + native image block: {blocks:?}");
+        match &blocks[0] {
+            // Byte-identical to the pre-multimodal text: the path never left.
+            ContentBlock::Text(text) => assert_eq!(text.text, content),
+            other => panic!("expected text block, got {other:?}"),
+        }
+        assert!(
+            matches!(&blocks[1], ContentBlock::Image(_)),
+            "still sends the native image block: {blocks:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/aionui-ai-agent/src/media.rs
+++ b/crates/aionui-ai-agent/src/media.rs
@@ -142,6 +142,25 @@ fn append_files_marker(content: &str, paths: &[String]) -> String {
     }
 }
 
+/// The agent-bound text with the `[[AION_FILES]]` block listing EVERY
+/// attachment — media included — regardless of what [`partition_media`] moved
+/// to a native block.
+///
+/// For callers whose only path-delivery channel is the text itself (the ACP
+/// `session/prompt` path emits no resource links: a non-media attachment rides
+/// solely as a marker line). A native media block carries bytes, not a path, so
+/// dropping the media path from the marker leaves such an agent able to see the
+/// image but unable to open the file.
+///
+/// Not the same as returning `content` untouched: when `content` carries no
+/// marker at all, this appends one for the full list, so a caller can never
+/// lose the non-media paths [`partition_media`] would have re-appended. When
+/// `content` does carry the exact marker for `files`, the result is
+/// byte-identical to `content`.
+pub fn content_with_all_paths(content: &str, files: &[String]) -> String {
+    append_files_marker(strip_files_marker(content, files), files)
+}
+
 /// Read a media attachment's bytes, degrading to `None` (caller falls back to
 /// the path form) when the file vanished or grew past the limit between
 /// classification and read.
@@ -242,6 +261,35 @@ mod tests {
         assert!(part.media.is_empty());
         assert_eq!(part.path_files, files);
         assert_eq!(part.content, content);
+    }
+
+    #[test]
+    fn all_paths_content_keeps_media_paths_in_the_marker() {
+        let img = temp_file("h.png", b"png");
+        let doc = temp_file("h.pdf", b"pdf");
+        let files = vec![img.clone(), doc.clone()];
+        let content = inline("mix", &[&img, &doc]);
+        // partition drops the image path from the marker...
+        let part = partition_media(&content, &files, CAPS_IMAGE);
+        assert_eq!(part.content, inline("mix", &[&doc]));
+        // ...while the all-paths form keeps both, byte-identical to the input.
+        assert_eq!(content_with_all_paths(&content, &files), content);
+    }
+
+    #[test]
+    fn all_paths_content_appends_a_marker_when_none_present() {
+        // The trap this helper exists for: with no marker in `content`, falling
+        // back to the raw text would lose EVERY path, and partition would have
+        // appended a marker for the non-media ones. Rebuild the full list.
+        let img = temp_file("i.png", b"png");
+        let doc = temp_file("i.pdf", b"pdf");
+        let files = vec![img.clone(), doc.clone()];
+        assert_eq!(content_with_all_paths("bare", &files), inline("bare", &[&img, &doc]));
+    }
+
+    #[test]
+    fn all_paths_content_is_a_noop_without_files() {
+        assert_eq!(content_with_all_paths("just text", &[]), "just text");
     }
 
     #[test]

--- a/crates/aionui-ai-agent/src/session_agent.rs
+++ b/crates/aionui-ai-agent/src/session_agent.rs
@@ -529,12 +529,27 @@ impl SessionAgentTask {
     /// attachments by the backend's declared prompt blocks — capable media
     /// becomes native Image/Audio blocks; everything else keeps the
     /// pre-multimodal form (path in the [[AION_FILES]] text + resource link).
-    /// A read failure degrades that attachment back to a resource link — the
-    /// path also remains in the original text because partition already ran,
+    ///
+    /// A native media block carries ONLY bytes: `ContentBlock::Image` is
+    /// `{data, media_type}` with no path field, and `partition_media` has
+    /// already stripped that path out of the [[AION_FILES]] text. So each
+    /// natively-delivered attachment is PAIRED with a resource link to the very
+    /// same file — the adapters render a link as an `[Attached file: <uri>]`
+    /// text element (see `adapter/claude.rs` / `backend/codex_conn.rs`), which
+    /// is how every non-media attachment already travels and how images
+    /// travelled before the multimodal split. Without the pair, an agent that
+    /// can both see and read files gets pixels it cannot open (Sentry
+    /// 7677917218). The pair is gated on the backend advertising `resource`:
+    /// an un-advertised block is rejected at dispatch and would kill the whole
+    /// Send (`BlockSet::allows`).
+    ///
+    /// A read failure degrades that attachment back to a resource link alone —
+    /// the path also remains in the original text because partition already ran,
     /// which the adapters tolerate (they resolve links independently of the
     /// text). Shared by `send_message` and `deliver_midturn`.
     async fn build_prompt_blocks(&self, data: &SendMessageData) -> Vec<ContentBlock> {
         let partition = crate::media::partition_media(&data.content, &data.files, self.prompt_media_caps());
+        let link_media_paths = self.backend.capabilities().prompt_blocks.resource;
         let mut content: Vec<ContentBlock> = Vec::new();
         if !partition.content.is_empty() {
             content.push(ContentBlock::Text(partition.content));
@@ -547,18 +562,30 @@ impl SessionAgentTask {
                 mime_type: None,
             });
         }
+        let mut media_links = 0usize;
         for attachment in &partition.media {
             match crate::media::read_media_bytes(attachment).await {
-                Some(bytes) => content.push(match attachment.kind {
-                    crate::media::MediaKind::Image => ContentBlock::Image {
-                        data: bytes,
-                        media_type: attachment.mime.clone(),
-                    },
-                    crate::media::MediaKind::Audio => ContentBlock::Audio {
-                        data: bytes,
-                        media_type: attachment.mime.clone(),
-                    },
-                }),
+                Some(bytes) => {
+                    content.push(match attachment.kind {
+                        crate::media::MediaKind::Image => ContentBlock::Image {
+                            data: bytes,
+                            media_type: attachment.mime.clone(),
+                        },
+                        crate::media::MediaKind::Audio => ContentBlock::Audio {
+                            data: bytes,
+                            media_type: attachment.mime.clone(),
+                        },
+                    });
+                    // Pair the bytes with the path (see the fn doc): the block
+                    // itself has no uri field and the text no longer lists it.
+                    if link_media_paths {
+                        content.push(ContentBlock::ResourceLink {
+                            uri: attachment.path.clone(),
+                            mime_type: Some(attachment.mime.clone()),
+                        });
+                        media_links += 1;
+                    }
+                }
                 None => content.push(ContentBlock::ResourceLink {
                     uri: attachment.path.clone(),
                     mime_type: Some(attachment.mime.clone()),
@@ -576,6 +603,7 @@ impl SessionAgentTask {
                 msg_id = %data.msg_id,
                 images,
                 audios,
+                media_links,
                 "session prompt carries native media content blocks"
             );
         }
@@ -6681,8 +6709,8 @@ mod pump_tests {
     }
 
     // Image-capable backend: an image attachment leaves the [[AION_FILES]]
-    // text and rides as a native Image block; non-media files keep the
-    // path-text + resource-link form.
+    // text and rides as a native Image block PAIRED with a link to the same
+    // file; non-media files keep the path-text + resource-link form.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn send_message_partitions_image_into_native_block() {
         let dir = std::env::temp_dir().join("aionui-session-media-tests");
@@ -6730,7 +6758,11 @@ mod pump_tests {
         let Some(Command::Send { content, .. }) = commands.iter().find(|c| matches!(c, Command::Send { .. })) else {
             panic!("expected a Send command");
         };
-        assert_eq!(content.len(), 3, "text + pdf link + image block: {content:?}");
+        assert_eq!(
+            content.len(),
+            4,
+            "text + pdf link + image block + the image's own link: {content:?}"
+        );
         let ContentBlock::Text(text) = &content[0] else {
             panic!("expected text first: {content:?}");
         };
@@ -6744,6 +6776,132 @@ mod pump_tests {
         };
         assert_eq!(data, b"catbytes");
         assert_eq!(media_type, "image/png");
+        let ContentBlock::ResourceLink { uri, mime_type } = &content[3] else {
+            panic!("expected the image's paired resource link fourth: {content:?}");
+        };
+        assert_eq!(uri, &img);
+        assert_eq!(mime_type.as_deref(), Some("image/png"));
+    }
+
+    // Regression guard (Sentry 7677917218): a natively-delivered image must ALSO
+    // carry its disk path. Without the paired link the agent sees pixels but has
+    // no path for its Read tool — it can look at the image but not open the file.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn send_message_pairs_image_block_with_resource_link() {
+        let dir = std::env::temp_dir().join("aionui-session-media-link-tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let img = dir.join("qr.png");
+        std::fs::write(&img, b"qrbytes").unwrap();
+        let img = img.to_string_lossy().into_owned();
+
+        let backend = Arc::new(RecordingBackend {
+            commands: std::sync::Mutex::new(Vec::new()),
+            blocks: aionui_session::BlockSet {
+                text: true,
+                image: true,
+                audio: false,
+                resource: true,
+                at_mention: false,
+            },
+        });
+        let task = SessionAgentTask::new(
+            AgentType::Acp,
+            "conv-link".into(),
+            "user-1".into(),
+            "/w".into(),
+            backend.clone() as Arc<dyn SessionBackend>,
+            None,
+        );
+        let marker = aionui_common::constants::AIONUI_FILES_MARKER;
+        crate::agent_task::IAgentTask::send_message(
+            task.as_ref(),
+            SendMessageData {
+                content: format!("replace the qr code\n\n{marker}\n{img}"),
+                msg_id: "m-link".into(),
+                turn_id: None,
+                files: vec![img.clone()],
+                inject_skills: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let commands = backend.commands.lock().unwrap();
+        let Some(Command::Send { content, .. }) = commands.iter().find(|c| matches!(c, Command::Send { .. })) else {
+            panic!("expected a Send command");
+        };
+        assert!(
+            content.iter().any(|b| matches!(b, ContentBlock::Image { .. })),
+            "image block missing: {content:?}"
+        );
+        let linked: Vec<&str> = content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::ResourceLink { uri, .. } => Some(uri.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            linked,
+            vec![img.as_str()],
+            "the image's path must ride along as a resource link: {content:?}"
+        );
+    }
+
+    // Capability gate: a backend that takes images but NOT resource links must not
+    // receive the paired link — `BlockSet::allows` rejects an un-advertised block
+    // and that rejection kills the WHOLE Send.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn send_message_omits_media_link_when_resource_block_unsupported() {
+        let dir = std::env::temp_dir().join("aionui-session-media-link-tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let img = dir.join("no-link.png");
+        std::fs::write(&img, b"pngbytes").unwrap();
+        let img = img.to_string_lossy().into_owned();
+
+        let backend = Arc::new(RecordingBackend {
+            commands: std::sync::Mutex::new(Vec::new()),
+            blocks: aionui_session::BlockSet {
+                text: true,
+                image: true,
+                audio: false,
+                resource: false,
+                at_mention: false,
+            },
+        });
+        let task = SessionAgentTask::new(
+            AgentType::Acp,
+            "conv-nolink".into(),
+            "user-1".into(),
+            "/w".into(),
+            backend.clone() as Arc<dyn SessionBackend>,
+            None,
+        );
+        crate::agent_task::IAgentTask::send_message(
+            task.as_ref(),
+            SendMessageData {
+                content: "look".into(),
+                msg_id: "m-nolink".into(),
+                turn_id: None,
+                files: vec![img.clone()],
+                inject_skills: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let commands = backend.commands.lock().unwrap();
+        let Some(Command::Send { content, .. }) = commands.iter().find(|c| matches!(c, Command::Send { .. })) else {
+            panic!("expected a Send command");
+        };
+        assert!(
+            content.iter().any(|b| matches!(b, ContentBlock::Image { .. })),
+            "image block missing: {content:?}"
+        );
+        assert!(
+            !content.iter().any(|b| matches!(b, ContentBlock::ResourceLink { .. })),
+            "must not emit a resource link to a backend that does not advertise it: {content:?}"
+        );
     }
 
     /// A codex detached exec (`source: unifiedExecStartup`) is still RUNNING when


### PR DESCRIPTION
## Summary

An image attachment delivered as a native multimodal block reached the agent as pixels with **no disk path**, so an agent that can both see images and read files could look at the image but never open the file. Users hit this as "the agent never knows the path" and worked around it by retyping the path as plain text in a follow-up message.

Two things combined to drop the path:

- A native image block carries bytes only — the variant has no path field.
- `partition_media` strips a media attachment's path out of the `[[AION_FILES]]` text block when it promotes that attachment to a native block.

So the path was in neither the text nor the content blocks. This is a regression from the multimodal prompt work (#774, in since v0.1.59); before that change every attachment — images included — carried its path.

Both prompt-building paths were affected, and each needs a different fix because each has a different path channel.

## Changes

**Direct-CLI path (claude, codex).** `SessionAgentTask::build_prompt_blocks` now pairs each successfully-read media block with a `ResourceLink` to the same file. The adapters already render a link as an `[Attached file: <uri>]` text element — that is how every non-media attachment travels and how images travelled before the multimodal split. The pair is gated on the backend advertising the `resource` prompt block, since an un-advertised block is rejected at dispatch and would kill the whole `Send`. A `media_links` count was added to the already-present dispatch log so the behavior is observable at `info`.

**ACP path.** This path emits no resource links at all — a non-media attachment rides solely as an `[[AION_FILES]]` marker line — so the marker is its only path channel. It now builds the text block from the full attachment list instead of the post-partition one, keeping every media path in the marker while still sending the native block. Reconstructing the list (rather than reusing the raw text) matters when the content carries no marker at all, where partition would have appended one for the non-media paths; a new `media::content_with_all_paths` helper does that and is unit-tested for both cases.

The `uri` already set on the ACP image block is left in place, but it is not sufficient on its own — see the verification below.

Deliberately out of scope: `partition_media`'s partitioning is unchanged, so the persisted/broadcast message still carries the full `[[AION_FILES]]` form and UI chips and history render exactly as before. The read-failure degradation branches are unchanged.

## Testing

- `crates/aionui-ai-agent`: 977 lib tests pass (6 new).
- Direct-CLI: new tests assert an image attachment yields both a native `Image` block and a `ResourceLink` to the same path, and that a backend advertising images but not resource links gets no paired link.
- ACP: a new test asserts the media path stays in the text block while the native block is still sent. The helper is covered for three cases: marker present (byte-identical round-trip), no marker (full list appended), and no files (no-op).
- Two pre-existing tests pinned the old shapes and were updated to the new contracts, keeping their exact per-block assertions.
- `crates/aionui-session`: the existing adapter regression test already covers the downstream half of the direct-CLI fix — a `Text` + `Image` + `ResourceLink` slice collapses into exactly one claude user frame carrying the source-wrapped base64 image plus the `[Attached file: <uri>]` text reference.
- `cargo clippy -p aionui-ai-agent --all-targets -- -D warnings` and `cargo fmt --all --check` clean; full workspace suite green in the pre-push gate.

## Dev-environment verification

Verified in a local dev build by pasting an image into a fresh conversation and asking for information that can only come from the file itself (pixel dimensions and byte size), across both code paths:

**Direct-CLI — claude and codex.** For each run the dispatch log reported one native image block and one paired media link. The dumped final input carried the user text, the native base64 image block, and a `resource_link` pointing at the attachment's own path. Both agents then ran a single shell step against that path and reported the file's real on-disk byte size and pixel dimensions. Neither asked for the path.

**ACP — before/after on the same agent.** Before the change, one ACP agent answered that no original file was provided and asked for a path; a second silently reported a fabricated file size, off by roughly 4x from the real file. After the change, that second agent read the file at the supplied path and reported the exact byte size, pixel dimensions and format. The dumped prompt text confirms the marker line is present.

The reported byte sizes match the attachment on disk, so they came from the filesystem rather than from the inline block.

Two things this also settles:

- Attachments live in a managed temporary directory outside the conversation workspace, and the agents were still able to operate on them, so no extra directory-allowlist plumbing is needed for this flow. Note the direct-CLI agents reached the file via their shell tool; whether a read-file tool specifically accepts paths outside the workspace was not exercised.
- The persisted user message still contains the full `[[AION_FILES]]` path list, confirming only the agent-bound copy is rewritten.

### Unrelated observation

One ACP agent still returned wrong numbers after the fix, but not for want of a path: its tool call shows it received our exact path and passed it along — it then selected an image *generation* MCP tool to *analyze* the image, and reported values that tool cannot produce. Its own reasoning trace shows it looking for an "image metadata tool". That is an agent-side tool-selection problem (possibly a misleading tool description on our side) and is unrelated to this change; worth a separate look.
