### PR TITLE
chore(cli): bump verified claude to 2.1.234

### DIFF
--- a/crates/aionui-ai-agent/src/claude_flags.rs
+++ b/crates/aionui-ai-agent/src/claude_flags.rs
@@ -126,7 +126,7 @@ mod tests {
         assert!(!supported("2.1.0"), "2.1.0 hard-errors on --thinking-display");
         assert!(!supported("2.1.190"), "below the verified floor stays off");
         assert!(supported("2.1.191"), "lowest live-probed OK version");
-        assert!(supported("2.1.233"), "the release this integration is verified against");
+        assert!(supported("2.1.234"), "the release this integration is verified against");
         assert!(supported("2.1.220"));
         assert!(supported("3.0.0"), "a future major must not regress the gate");
     }

--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -35,7 +35,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// turn (its response stream disconnects with `httpStatusCode: null`, observed
 /// three times including a back-to-back control after three clean versions), so
 /// the verified release stops at 0.146.0 until upstream fixes it.
-pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.233";
+pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.234";
 pub const VERIFIED_CODEX_VERSION: &str = "0.146.0";
 pub const VERIFIED_AGY_VERSION: &str = "1.1.12";
 
@@ -449,8 +449,8 @@ mod tests {
     fn the_verified_release_says_nothing() {
         // Literal on purpose: this is the exact string a user on the verified
         // release reports, so the test breaks if a bump forgets to re-verify.
-        assert_eq!(classify("2.1.233", VERIFIED_CLAUDE_VERSION), VersionVerdict::Verified);
-        assert!(drift_notice("claude", "2.1.233", VERIFIED_CLAUDE_VERSION).is_none());
+        assert_eq!(classify("2.1.234", VERIFIED_CLAUDE_VERSION), VersionVerdict::Verified);
+        assert!(drift_notice("claude", "2.1.234", VERIFIED_CLAUDE_VERSION).is_none());
     }
 
     #[test]


### PR DESCRIPTION
`VERIFIED_CLAUDE_VERSION` 2.1.233 → 2.1.234, plus the three assertions pinned to it.

## Gates

| gate | verdict | evidence |
|---|---|---|
| A — contract | DEGRADED | claude publishes no protocol schema |
| B — live e2e | **PASS 14/14** | 303.65s, 9 distinct WS frame types |
| C — release notes | REVIEW → **resolved in writing** | 51 notes in range, 9 filtered, 1 flagged |

## The gate C item, and why it does not block

The flagged note:

> Fixed Claude Desktop inter-session messages being silently dropped by the recipient session when cross-session messaging read as disabled, which left the sender's query "thinking" for many minutes

It matched the `thinking` token, but only because the note uses that word for the **symptom** — the sender's query kept spinning. Claude Desktop's cross-session messaging is not a surface this integration touches: `manifest/claude.toml` carries 21 entries and **zero** mention of cross-session, inter-session or desktop. The two `thinking` entries we do have are `claude.flag.thinking_display` and `claude.frame.assistant.thinking`, neither of which this note goes near.

The reasoning above is stored **next to the item** in `qualification.json`, not just here.

## Tooling gap closed on the way

`qualify.py` blocked this bump and had no way to unblock it. The rubric has always said *"every REVIEW item must be resolved in writing before promotion"*, but the script offered no way to record such a resolution — so a legitimately dismissed item left the report `BLOCKED` for ever and the reasoning lived only in a terminal. A policy with no executable path is not a policy.

It now takes `--resolve-review "<key>=<why>"`, one flag per item, and writes the reason into the record beside the note. Deliberately not a rubber stamp:

- no flag → still `BLOCKED` (verified);
- a key with an empty reason → exits 2 with `--resolve-review needs a reason` (verified);
- the key is `<version>:<first 40 chars of the note>`, so a resolution cannot silently drift onto a different note.

## Record

`~/aion/protocols/samples/claude-cli/2.1.234/` — `qualification.json` (verdict PASS, zero blockers, 14/0, and the REVIEW item with its written resolution) and the live-suite log.

The candidate was already the installed CLI — claude had self-updated to 2.1.234 — so no shim was needed and `~/.local/bin/claude` was not moved. The suite's own logs report `direct CLI version detected version=2.1.234`.

## The other two

- **codex** — latest is still 0.147.0, which never completes a turn. Stays at 0.146.0.
- **agy** — not bumped. Its gate B is flaky (`team_mcp`: 2 pass / 5 fail, including 7/7 then 6/1 on a byte-identical tree), and upstream has moved to 1.1.14, which is not installed here.

Constants only, no source change.