### PR TITLE
chore(acp): bump dimcode, dirac, glm-acp-agent and grok registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -19,22 +19,22 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.15"
+      "version": "0.3.16"
     },
     "dirac": {
       "registry_json_id": "dirac",
       "package": "dirac-cli",
-      "version": "0.4.36"
+      "version": "0.4.37"
     },
     "glm-acp-agent": {
       "registry_json_id": "glm-acp-agent",
       "package": "glm-acp-agent",
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "1.0.5"
+      "version": "1.0.6"
     },
     "kilo": {
       "registry_json_id": "kilo",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Four npx pins drifted since #873, each backed by a fresh serial ACP probe of the exact pinned version. Lock-only change — four lines; no metadata, migration, or entrypoint edits, and no lock-derived test assertion embeds any of these versions.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| dimcode | `dimcode` | 0.3.15 → **0.3.16** | ok (agentInfo version 0.3.16) | auth required (`-32000`, "Provider credentials are required") |
| dirac | `dirac-cli` | 0.4.36 → **0.4.37** | ok (agentInfo dirac 0.4.37) | success (modes plan/act) |
| glm-acp-agent | `glm-acp-agent` | 1.5.0 → **1.6.0** | ok (protocolVersion 1) | success, unauthenticated — modes `default` / `accept_edits` / `bypass_permissions` |
| grok | `@xai-official/grok` | 1.0.5 → **1.0.6** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |

All four meet the release-lock criterion: `initialize` succeeds and `session/new` either succeeds or returns a clearly classified authentication requirement. Probes ran serially with no inherited HOME or credentials.

**glm-acp-agent crosses another minor version, so its stored `yolo_id` was re-verified rather than assumed** — the same check #865 applied at 1.5.0. The 1.6.0 session catalog still advertises `bypass_permissions`, exactly the value migration 025 seeded, so the existing metadata stays correct and this remains a lock-only change. Had that mode disappeared, the `yolo_id` would need its own migration and would not belong in this PR.

The other 7 Registry-pinned packages (autohand, codebuddy, deepagents, kilo, nova, pi, sigit) match the snapshot exactly. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. `mimo-code` remains the one non-Registry builtin (no `registry_json_id`), excluded from drift reconciliation.

Two long-running vendor self-report quirks persist, neither actionable: dimcode reports `agentInfo.title` as "DimAgent" against a public listing that says "DimCode" (`dimcode.dev` unchanged), and glm-acp-agent 1.6.0 reports `agentInfo.version` as `1.0.0`. The Registry card, package identity and entrypoint remain the authorities, and `initialize` succeeded in both cases.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.19-28cd4e9`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.19-28cd4e9/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the previous baseline (38 ids).

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11; #810, #814, #822, #837, #848, #859, #865 and #873 all merged green under it). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock-only version bumps; existing startup/session error paths already identify a failing agent by backend.
