### PR TITLE
fix(antigravity): route Team over the CLI, which is what agy was already using

### DIFF
--- a/crates/aionui-app/tests/live_ws_http_parity_e2e.rs
+++ b/crates/aionui-app/tests/live_ws_http_parity_e2e.rs
@@ -1116,7 +1116,6 @@ async fn run_direct_backend_team_mcp_and_runtime_env(backend: &str, agent_id: &s
         .chain(shell_tool_frames.iter())
         .copied()
         .collect::<Vec<_>>();
-    let mcp_tool_evidence = serde_json::to_string(&mcp_tool_frames).unwrap();
     let shell_tool_evidence = serde_json::to_string(&shell_tool_frames).unwrap();
     let tool_names = tool_frames
         .iter()
@@ -1126,10 +1125,36 @@ async fn run_direct_backend_team_mcp_and_runtime_env(backend: &str, agent_id: &s
                 .or_else(|| frame["data"]["data"]["update"]["name"].as_str())
         })
         .collect::<BTreeSet<_>>();
-    assert!(
-        mcp_tool_evidence.contains("team_members"),
-        "[{backend}] no streamed Team MCP tools/call evidence; tool names={tool_names:?}"
-    );
+    // agy is routed CliAssumed on purpose: we have no way to hand it an MCP
+    // server, because it reads `mcp_config.json` only from `~/.gemini/config/`
+    // and `plugins/<name>/`, never the per-workspace file this repo writes
+    // (measured 2026-08-19). Asserting an MCP tools/call for it would pin
+    // behaviour the product deliberately does not have.
+    //
+    // The old assertion was also weaker than it looked for the backends that DO
+    // take the MCP route: it searched every tool frame's JSON for the substring
+    // `team_members`, and this test's own prompt contains that string, so a
+    // shell command echoing the name satisfied it.
+    //
+    // The name field alone is not enough either: the two MCP backends shape it
+    // differently. claude names the frame after the tool (`team_members`);
+    // codex names every MCP call `mcpToolCall` and carries the tool name
+    // inside. Requiring one OR the other keeps a plain shell frame out — its
+    // name is the command line, which is neither.
+    let mcp_tool_frames_json = serde_json::to_string(&mcp_tool_frames).unwrap();
+    let called_team_members_over_mcp = tool_names.iter().any(|name| name.contains("team_members"))
+        || (tool_names.contains("mcpToolCall") && mcp_tool_frames_json.contains("team_members"));
+    if backend == "antigravity" {
+        assert!(
+            !called_team_members_over_mcp,
+            "[{backend}] routed CliAssumed, so no team_members MCP call should appear; tool names={tool_names:?}"
+        );
+    } else {
+        assert!(
+            called_team_members_over_mcp,
+            "[{backend}] no streamed Team MCP tools/call evidence; tool names={tool_names:?}"
+        );
+    }
     assert!(
         shell_tool_evidence.contains("AIONUI_HELPER_BIN")
             && (shell_tool_evidence.contains("AIONUI_E2E_SENTINEL") || shell_tool_evidence.contains("AIONUI_ENV_OK")),
@@ -1145,9 +1170,14 @@ async fn run_direct_backend_team_mcp_and_runtime_env(backend: &str, agent_id: &s
                 .or_else(|| frame["data"]["data"]["update"]["tool_call_id"].as_str())
         })
         .collect::<BTreeSet<_>>();
+    // Two calls are only expected where the two phases use different tools. A
+    // CliAssumed backend runs both over the shell, and the model may well do it
+    // in one command, so requiring two ids there asserts a shape the transport
+    // does not have.
+    let expected_distinct_calls = if backend == "antigravity" { 1 } else { 2 };
     assert!(
-        tool_call_ids.len() >= 2,
-        "[{backend}] expected distinct Team MCP and shell tool calls, got {tool_call_ids:?}; \
+        tool_call_ids.len() >= expected_distinct_calls,
+        "[{backend}] expected at least {expected_distinct_calls} tool call(s), got {tool_call_ids:?}; \
          tool names={tool_names:?}"
     );
     let mcp_reply = mcp_frames

--- a/crates/aionui-session/src/backend/antigravity/mcp_config.rs
+++ b/crates/aionui-session/src/backend/antigravity/mcp_config.rs
@@ -1,11 +1,25 @@
 //! Writes the session's MCP servers into `<workspace>/.agents/mcp_config.json`.
 //!
-//! agy has no per-run flag for MCP configuration — it only reads files — and
-//! the workspace-level file is what gives each conversation its own set of
-//! servers (verified: `crates/aionui-app/tests/live_ws_http_parity_e2e.rs`,
-//! `live_antigravity_team_mcp_tools_call_and_runtime_env`, against agy 1.1.13).
-//! This is also how the team coordination server reaches an Antigravity
-//! teammate.
+//! **agy does not read that file.** Measured 2026-08-19 with a purpose-built
+//! stdio MCP server that records when its tool runs, under
+//! `--dangerously-skip-permissions` (which `argv.rs` always passes): the same
+//! server is called when configured in `~/.gemini/config/mcp_config.json` and
+//! is NOT called from the workspace file, where agy logs
+//! `empty component: prompt section "mcp_servers"`. Its own documentation
+//! agrees — `~/.gemini/antigravity-cli/builtin/skills/agy-customizations/docs/
+//! mcp_servers.md` §Location lists only the global path and
+//! `plugins/<name>/mcp_config.json`.
+//!
+//! An earlier version of this comment cited
+//! `live_antigravity_team_mcp_tools_call_and_runtime_env` as having verified
+//! the workspace path. That was circular: the test asserts by searching every
+//! tool frame's JSON for the substring `team_members`, and its own prompt
+//! contains that string, so it can pass with no MCP binding at all.
+//!
+//! The mapping below is kept — it is correct, and is what a global or plugin
+//! writer would need — but nothing consumes the file it produces today.
+//! `descriptor.rs` therefore declares agy with no MCP transport, which routes
+//! Team coordination down the CLI it was already silently using.
 //!
 //! agy supports exactly two transports, Stdio and SSE (verified:
 //! `~/.gemini/antigravity-cli/builtin/skills/agy-customizations/docs/mcp_servers.md`),
@@ -85,8 +99,12 @@ mod tests {
 
     #[test]
     fn stdio_spec_maps_to_agys_command_shape() {
+        // Deliberately inverted 2026-08-19: agy speaks STDIO, but we have no
+        // way to hand it a server (see the module docs), so the descriptor
+        // declares none. The mapping below is still asserted — it stays correct
+        // and is what a global or plugin writer would reuse.
         assert!(
-            crate::backend::backend_capability_descriptor("antigravity")
+            !crate::backend::backend_capability_descriptor("antigravity")
                 .unwrap()
                 .mcp
                 .stdio
@@ -115,8 +133,12 @@ mod tests {
 
     #[test]
     fn sse_spec_maps_to_server_url_and_headers() {
+        // Deliberately inverted 2026-08-19: agy speaks SSE, but we have no
+        // way to hand it a server (see the module docs), so the descriptor
+        // declares none. The mapping below is still asserted — it stays correct
+        // and is what a global or plugin writer would reuse.
         assert!(
-            crate::backend::backend_capability_descriptor("antigravity")
+            !crate::backend::backend_capability_descriptor("antigravity")
                 .unwrap()
                 .mcp
                 .sse

--- a/crates/aionui-session/src/backend/descriptor.rs
+++ b/crates/aionui-session/src/backend/descriptor.rs
@@ -77,13 +77,37 @@ const BACKEND_CAPABILITY_DESCRIPTORS: &[BackendCapabilityDescriptor] = &[
         }),
         fork: Some(ForkCapabilities { at_turn: true }),
     },
-    // verified: ~/.gemini/antigravity-cli/builtin/skills/
-    // agy-customizations/docs/mcp_servers.md
+    // agy speaks Stdio and SSE (verified: ~/.gemini/antigravity-cli/builtin/
+    // skills/agy-customizations/docs/mcp_servers.md), but WE CANNOT HAND IT A
+    // SERVER, so from this integration's side it has no usable MCP transport.
+    //
+    // agy reads `mcp_config.json` from exactly two places — that same doc,
+    // §Location: `~/.gemini/config/` (global) and `plugins/<name>/`. It does
+    // NOT read the per-workspace `.agents/mcp_config.json` this repo writes, so
+    // a server configured for one conversation never reaches it.
+    //
+    // Measured 2026-08-19 with a purpose-built stdio MCP server that logs when
+    // its tool runs, under `--dangerously-skip-permissions` (which argv.rs
+    // always passes):
+    //
+    //   global config    → tool called
+    //   workspace config → not called, and agy logs
+    //                      `empty component: prompt section "mcp_servers"`
+    //
+    // Declaring stdio here sent every agy teammate down the Mcp branch of
+    // `resolve_transport`, whose config landed somewhere agy never looks. The
+    // teammate then followed the MCP prompt's own fallback clause and used the
+    // Team CLI — so coordination worked, but through a path nobody had chosen
+    // and nothing reported. `CliAssumed` makes that the declared route instead
+    // of the accidental one, and swaps in the CLI prompt that matches it.
+    //
+    // Flip these back the moment agy gains a per-conversation MCP config, or
+    // this repo starts writing the global one.
     BackendCapabilityDescriptor {
         backend_id: "antigravity",
         mcp: McpTransportCapabilities {
-            stdio: true,
-            sse: true,
+            stdio: false,
+            sse: false,
             streamable_http: false,
         },
         cli_fallback: true,
@@ -231,12 +255,39 @@ mod tests {
         }
     }
 
+    /// agy must route Team coordination down the CLI branch.
+    ///
+    /// `resolve_transport` takes the Mcp branch whenever `mcp.stdio` is true and
+    /// never reconsiders, so declaring stdio sent every agy teammate to a
+    /// transport whose config file agy does not read. Coordination still worked
+    /// — the MCP prompt tells a teammate to fall back to the Team CLI when the
+    /// tools are missing — but through a path nobody selected and nothing
+    /// reported.
+    #[test]
+    fn agy_declares_no_mcp_so_team_routing_picks_the_cli_it_actually_uses() {
+        let agy = backend_capability_descriptor("antigravity").expect("direct descriptor");
+        assert!(
+            !agy.mcp.stdio && !agy.mcp.sse && !agy.mcp.streamable_http,
+            "we have no way to hand agy an MCP server; declaring one routes Team to a dead transport"
+        );
+        assert!(
+            agy.cli_fallback,
+            "the CLI is the only route left, so it must stay declared or Team has none"
+        );
+    }
+
     #[test]
     fn direct_descriptor_matrix_matches_verified_adapter_contracts() {
         let expected = [
             ("claude", true, true, true, VERIFIED_CLAUDE_VERSION),
             ("codex", true, false, true, VERIFIED_CODEX_VERSION),
-            ("antigravity", true, true, false, VERIFIED_AGY_VERSION),
+            // agy is all-false on purpose: it speaks Stdio and SSE, but reads
+            // mcp_config.json only from `~/.gemini/config/` and
+            // `plugins/<name>/` — never the per-workspace file this repo
+            // writes. Measured 2026-08-19; see the descriptor's comment. What
+            // this row asserts is "can WE give it a server", and the answer is
+            // no.
+            ("antigravity", false, false, false, VERIFIED_AGY_VERSION),
         ];
         for (backend, stdio, sse, http, version) in expected {
             let descriptor = backend_capability_descriptor(backend).expect("direct descriptor");


### PR DESCRIPTION
agy was declared as having stdio and SSE MCP transports, so `resolve_transport` took the `Mcp` branch for every Antigravity teammate and never considered the CLI. **The config that branch writes lands in a file agy does not read.**

## Evidence

A purpose-built stdio MCP server exposing one uniquely-named tool, which records when that tool actually runs. Run under `--dangerously-skip-permissions` (which `argv.rs` always passes), 2026-08-19:

| config location | tool called? |
|---|---|
| `~/.gemini/config/mcp_config.json` | **yes** |
| `<workspace>/.agents/mcp_config.json` — *what this repo writes* | **no**, and agy logs `empty component: prompt section "mcp_servers"` |

agy's own documentation agrees. `agy-customizations/docs/mcp_servers.md` §Location lists exactly two places — the global path and `plugins/<name>/mcp_config.json`. There is no per-workspace file.

## Why nothing looked broken

The MCP prompt ends with its own fallback clause:

> If the `team_*` MCP tools are unavailable, missing, disconnected, or continue to fail after correction, use the Team CLI fallback through `"$AIONUI_HELPER_BIN" team ...` commands to continue Team coordination.

So teammates coordinated over the CLI and everything worked. What looked for weeks like a flaky test — "the model reaches for shell tools instead of the MCP tool" — was **the model following its instructions**, down a route nobody had selected and nothing reported.

## Fix

Declare no MCP transport for agy, which makes `CliAssumed` the chosen route and swaps in the CLI prompt that matches what actually happens. The mapping in `mcp_config.rs` is kept — it is correct, and is what a global or plugin writer would reuse — but its module doc no longer claims the workspace path works.

That doc previously cited this very live test as verification. It was circular, for the reason below.

**Flip this back** the day agy gains a per-conversation MCP config, or this repo starts writing the global one.

## The test was weaker than it looked

It asserted `mcp_tool_evidence.contains("team_members")` — a substring search over the serialised JSON of every tool frame. **The test's own prompt contains that string**, so a shell command echoing the name satisfied it. That is how it kept reporting green for a binding that never existed.

Now:

- **transport-aware** — agy asserts no MCP call appears; claude and codex assert one does;
- **tightened** — requires the tool NAME, or codex's `mcpToolCall` marker together with the name inside the frame. A plain shell frame is neither, because its name is the command line.

The two MCP backends genuinely shape this differently, which the first attempt got wrong: tightening to the name alone passed claude and agy and **broke codex**, whose every MCP call is named `mcpToolCall`. Caught by running all three.

## Verification

- `team_mcp_tools_call` passes **3/3** across claude, codex and agy;
- the full agy set passes **7/7 twice back-to-back** — a pair this test had never produced. Its history is 7/7 then 6/1 on byte-identical trees, twice (3 pass / 6 fail across nine runs);
- `cargo test -p aionui-session` 589, `-p aionui-team` 489/30/13, clippy `--all-targets -D warnings` and `cargo fmt --check` clean.

Full investigation, including the four eliminated hypotheses, at `~/aion/protocols/samples/antigravity-cli/1.1.14/team-mcp-root-cause.md`.

## Not fixed here

`write_mcp_config` still writes the workspace file on every turn, for conversation-level MCP servers as well as Team. Nothing reads it. Removing it is a larger call — it is the code a reachable writer would start from — so it is documented rather than deleted.