### PR TITLE
chore(cli): bump verified agy to 1.1.14

### DIFF
--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -37,7 +37,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// the verified release stops at 0.146.0 until upstream fixes it.
 pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.234";
 pub const VERIFIED_CODEX_VERSION: &str = "0.146.0";
-pub const VERIFIED_AGY_VERSION: &str = "1.1.12";
+pub const VERIFIED_AGY_VERSION: &str = "1.1.14";
 
 /// The verified release for a direct-CLI backend, keyed by the program name the
 /// backend spawns. `None` for anything not version-gated here.


### PR DESCRIPTION
`VERIFIED_AGY_VERSION` 1.1.12 → 1.1.14. One line; nothing else pins the value.

## Gates

| gate | verdict | evidence |
|---|---|---|
| A — contract | DEGRADED | agy publishes no protocol schema; only codex does |
| B — live e2e | **PASS 7/7, twice back-to-back** | 172.84s and 198.26s |
| C — release notes | CLEAR | read by hand across 1.1.13 and 1.1.14 |

## Why two consecutive runs are the headline

This suite spent **nine runs at 3 pass / 6 fail** on `live_antigravity_team_mcp_tools_call_and_runtime_env`, and **twice** produced 7/7 immediately followed by 6/1 on a byte-identical tree. Taking either green at face value would have promoted agy on a coin flip.

It was never flaky. **agy never received the Team MCP server**: it reads `mcp_config.json` only from `~/.gemini/config/` and `plugins/<name>/`, never the per-workspace file this repo writes. The teammate then followed the MCP prompt's own fallback clause and coordinated over the Team CLI — so nothing looked broken, and the test's substring assertion (`contains("team_members")`, over frame JSON that its own prompt's wording could satisfy) kept reporting green about a third of the time.

#881 routes agy's Team coordination over the CLI it was already using, and makes the test assert the transport each backend actually takes. With that in, the suite is green twice in a row — a pair it had never produced before.

## Gate C

Read by hand, since agy's changelog is a rendered page (`gate-c-manual.md` filed with the record for both 1.1.13 and 1.1.14). Nothing consumed here was removed, renamed or reshaped:

- the `/resume` items are the **interactive picker** — tab labels, a `ctrl+delete`→`f4` shortcut — not the `--conversation` flag we pass;
- *"accessing paths outside the workspace now grants read access only, with writes requiring authorization based on the active execution mode"* changes what a mode **permits**, not the `--mode` vocabulary;
- the MCP items are additive (OAuth client-ID metadata) or strictly helpful (a malformed server entry no longer takes the others down with it);
- no flag was removed or renamed.

## Record

`~/aion/protocols/samples/antigravity-cli/1.1.14/` — `qualification.json` (verdict PASS, zero blockers, 7/0), the live-suite log, `gate-c-manual.md`, and `team-mcp-root-cause.md` with the four hypotheses eliminated along the way.

Gate B ran against the installed 1.1.14 — agy self-updates, so the operator's binary was already the candidate and nothing was moved.

## The other two

- **claude** and **codex** are being qualified in this same run and move in their own PRs.

Constants only, no source change.