### PR TITLE
chore(cli): bump verified claude to 2.1.235

### DIFF
--- a/crates/aionui-ai-agent/src/claude_flags.rs
+++ b/crates/aionui-ai-agent/src/claude_flags.rs
@@ -126,7 +126,7 @@ mod tests {
         assert!(!supported("2.1.0"), "2.1.0 hard-errors on --thinking-display");
         assert!(!supported("2.1.190"), "below the verified floor stays off");
         assert!(supported("2.1.191"), "lowest live-probed OK version");
-        assert!(supported("2.1.234"), "the release this integration is verified against");
+        assert!(supported("2.1.235"), "the release this integration is verified against");
         assert!(supported("2.1.220"));
         assert!(supported("3.0.0"), "a future major must not regress the gate");
     }

--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -35,7 +35,7 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// turn (its response stream disconnects with `httpStatusCode: null`, observed
 /// three times including a back-to-back control after three clean versions), so
 /// the verified release stops at 0.146.0 until upstream fixes it.
-pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.234";
+pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.235";
 pub const VERIFIED_CODEX_VERSION: &str = "0.146.0";
 pub const VERIFIED_AGY_VERSION: &str = "1.1.12";
 
@@ -449,8 +449,8 @@ mod tests {
     fn the_verified_release_says_nothing() {
         // Literal on purpose: this is the exact string a user on the verified
         // release reports, so the test breaks if a bump forgets to re-verify.
-        assert_eq!(classify("2.1.234", VERIFIED_CLAUDE_VERSION), VersionVerdict::Verified);
-        assert!(drift_notice("claude", "2.1.234", VERIFIED_CLAUDE_VERSION).is_none());
+        assert_eq!(classify("2.1.235", VERIFIED_CLAUDE_VERSION), VersionVerdict::Verified);
+        assert!(drift_notice("claude", "2.1.235", VERIFIED_CLAUDE_VERSION).is_none());
     }
 
     #[test]


### PR DESCRIPTION
`VERIFIED_CLAUDE_VERSION` 2.1.234 → 2.1.235, plus the three assertions pinned to it.

## Gates

| gate | verdict | evidence |
|---|---|---|
| A — contract | DEGRADED | claude publishes no protocol schema |
| B — live e2e | **PASS 14/14** | 269.87s |
| C — release notes | REVIEW → **resolved in writing** | 19 notes in range, 1 flagged |

## The gate C item

> Improved memory and CPU usage while cloud sessions such as `/ultrareview` or `/autofix-pr` run in the background — their event streams are no longer re-scanned and re-rendered on every update

A rendering optimisation inside claude's own TUI. It matched the `usage` token, which in `manifest/claude.toml` means `claude.result.usage` — the token accounting we read off the wire. **Different surface**: the note never touches what claude reports, only how its terminal redraws.

The reasoning is stored beside the item in `qualification.json`, not only here.

## Candidate handling

2.1.235 was not installed, so it came from `npm @anthropic-ai/claude-code@2.1.235` into a temp dir, reached through a PATH shim. `~/.local/bin/claude` pointed at `2.1.234` before the run and still does; the record's `machine` block states it independently. The suite's own logs report `direct CLI version detected version=2.1.235`.

## Record

`~/aion/protocols/samples/claude-cli/2.1.235/` — `qualification.json` (PASS, zero blockers, 14/0, and the REVIEW item with its written resolution) and the live-suite log.

## The other two

- **agy** — bumped separately in #882: gate B finally green **twice back-to-back** after #881 stopped routing its Team coordination through an MCP transport it could never reach.
- **codex** — stays at 0.146.0. **0.148.0 fixes the stall that blocked 0.147.0** — turns complete, 10 of 11 tests pass, and the `httpStatusCode: null` signature is gone — but it **loses conversation history on resume**. Verified A/B, since codex is on npm: the same single test passes on 0.146.0 (`asked for "AION-69531", got "AION-69531"`) and fails 2/2 on 0.148.0 (`got "Unknown"`). Gate A passed for that hop with 31 new schema files and nothing removed, which is once again the reason gate B is the only gate that may approve. Written up at `~/aion/protocols/samples/codex-cli/0.148.0/gate-b-blocked.md`.

Constants only, no source change.