### PR TITLE
fix(app): bound the graceful-shutdown tail so the data-dir instance lock is released

### DIFF
--- a/crates/aionui-app/src/bootstrap/mod.rs
+++ b/crates/aionui-app/src/bootstrap/mod.rs
@@ -9,6 +9,7 @@ mod environment;
 mod error;
 mod instance_guard;
 mod parent_exit;
+mod shutdown_watchdog;
 mod tracing_init;
 mod work_dir;
 
@@ -16,3 +17,4 @@ pub use environment::{ServerEnvironment, init_data_layer, init_environment};
 pub(crate) use error::{BootstrapError, BootstrapErrorCode};
 pub(crate) use instance_guard::wait_for_instance_guard;
 pub(crate) use parent_exit::{ParentExitSignal, parent_exit_signal};
+pub(crate) use shutdown_watchdog::ShutdownWatchdog;

--- a/crates/aionui-app/src/bootstrap/shutdown_watchdog.rs
+++ b/crates/aionui-app/src/bootstrap/shutdown_watchdog.rs
@@ -1,0 +1,209 @@
+//! Hard shutdown watchdog (AIONUI-16).
+//!
+//! The data-dir instance `flock` is only released by the kernel when this
+//! process exits (`aionui-db/src/instance_lock.rs`). Sentry evidence shows the
+//! lock being held for 20–53 minutes across "clean quits", i.e. a shutdown
+//! that began but never finished: the graceful tail contains awaits that are
+//! unbounded by design (axum's connection drain waits for every connection
+//! task with no timeout; `sqlx::Pool::close()` waits for all checked-out
+//! connections; detached WebSocket tasks are never cancelled and can hold
+//! pool connections forever).
+//!
+//! The individual stages are bounded with `tokio::time::timeout` in
+//! `cmd_server`, but those bounds live inside the tokio runtime. If the
+//! runtime itself is wedged (or a stage outside the bounds hangs), nothing
+//! guarantees process exit. This watchdog is the last-resort bound: a plain
+//! OS thread, armed when the shutdown signal fires and disarmed once the
+//! graceful tail completes. If the timeout elapses while armed, it logs the
+//! failure, emits the bootstrap boundary stderr line, and force-exits so the
+//! instance lock is released in bounded time.
+
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use crate::bootstrap::{BootstrapError, BootstrapErrorCode};
+
+/// Exit code used on forced exit; matches `ExitKind::Internal` (exit 1), the
+/// same class `BOOTSTRAP_SHUTDOWN_FAILED` maps to via `BootstrapError`.
+const WATCHDOG_EXIT_CODE: i32 = 1;
+
+enum WatchdogMsg {
+    Arm,
+    Disarm,
+}
+
+/// Cloneable handle controlling the watchdog thread. Dropping every handle
+/// without arming (or after disarming) lets the thread exit without firing.
+#[derive(Clone)]
+pub(crate) struct ShutdownWatchdog {
+    tx: mpsc::Sender<WatchdogMsg>,
+}
+
+impl ShutdownWatchdog {
+    /// Spawn the production watchdog: on timeout it logs, prints the bootstrap
+    /// stderr boundary line, and calls `std::process::exit`.
+    pub(crate) fn spawn(timeout: Duration) -> Self {
+        Self::spawn_with_action(timeout, move || {
+            let timeout_secs = timeout.as_secs();
+            tracing::error!(
+                code = "BOOTSTRAP_SHUTDOWN_FAILED",
+                stage = "shutdown.watchdog",
+                timeout_secs,
+                "graceful shutdown did not complete in time; forcing exit to release the instance lock"
+            );
+            let error = BootstrapError::new(
+                BootstrapErrorCode::ShutdownFailed,
+                "shutdown.watchdog",
+                "graceful shutdown did not complete in time; forced exit",
+            )
+            .with_field("timeout_secs", timeout_secs.to_string());
+            // `std::process::exit` skips destructors, so the buffered tracing
+            // writer may not flush. The stderr boundary line below is written
+            // directly and survives the forced exit.
+            eprintln!("{}", error.stderr_line());
+            std::process::exit(WATCHDOG_EXIT_CODE);
+        })
+    }
+
+    /// Spawn a watchdog with an injectable timeout action (used by tests; the
+    /// production action force-exits the process).
+    pub(crate) fn spawn_with_action(timeout: Duration, on_timeout: impl FnOnce() + Send + 'static) -> Self {
+        let (tx, rx) = mpsc::channel::<WatchdogMsg>();
+        std::thread::Builder::new()
+            .name("shutdown-watchdog".into())
+            .spawn(move || watchdog_thread(rx, timeout, on_timeout))
+            // Thread spawn failure leaves shutdown unbounded, exactly as
+            // before this watchdog existed; the stage timeouts in cmd_server
+            // still bound the common paths.
+            .ok();
+        Self { tx }
+    }
+
+    /// Start the countdown. Called when the shutdown signal fires.
+    pub(crate) fn arm(&self) {
+        let _ = self.tx.send(WatchdogMsg::Arm);
+    }
+
+    /// Cancel the countdown. Called once the graceful tail has completed.
+    pub(crate) fn disarm(&self) {
+        let _ = self.tx.send(WatchdogMsg::Disarm);
+    }
+}
+
+fn watchdog_thread(rx: mpsc::Receiver<WatchdogMsg>, timeout: Duration, on_timeout: impl FnOnce() + Send + 'static) {
+    // Unarmed: wait indefinitely for the first arm. Sender drop (process
+    // exiting without a shutdown signal, e.g. bootstrap failure) ends the
+    // thread without firing.
+    loop {
+        match rx.recv() {
+            Ok(WatchdogMsg::Arm) => break,
+            Ok(WatchdogMsg::Disarm) => continue,
+            Err(mpsc::RecvError) => return,
+        }
+    }
+
+    // Armed: fire unless disarmed before the deadline. The deadline is fixed
+    // at first arm; duplicate arms do not extend it.
+    let deadline = Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            on_timeout();
+            return;
+        }
+        match rx.recv_timeout(remaining) {
+            Ok(WatchdogMsg::Disarm) => return,
+            Ok(WatchdogMsg::Arm) => continue,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                on_timeout();
+                return;
+            }
+            // All handles dropped while armed without an explicit disarm:
+            // the graceful tail owns a handle for its whole duration, so this
+            // means the process is already tearing down normally.
+            Err(mpsc::RecvTimeoutError::Disconnected) => return,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    use super::ShutdownWatchdog;
+
+    fn flag_action(flag: &Arc<AtomicBool>) -> impl FnOnce() + Send + 'static {
+        let flag = Arc::clone(flag);
+        move || flag.store(true, Ordering::SeqCst)
+    }
+
+    fn wait_for(flag: &AtomicBool, deadline: Duration) -> bool {
+        let start = std::time::Instant::now();
+        while start.elapsed() < deadline {
+            if flag.load(Ordering::SeqCst) {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        flag.load(Ordering::SeqCst)
+    }
+
+    #[test]
+    fn fires_when_armed_and_not_disarmed() {
+        let fired = Arc::new(AtomicBool::new(false));
+        let watchdog = ShutdownWatchdog::spawn_with_action(Duration::from_millis(50), flag_action(&fired));
+
+        watchdog.arm();
+
+        assert!(
+            wait_for(&fired, Duration::from_secs(5)),
+            "watchdog must fire after the timeout when never disarmed"
+        );
+    }
+
+    #[test]
+    fn does_not_fire_when_disarmed_in_time() {
+        let fired = Arc::new(AtomicBool::new(false));
+        let watchdog = ShutdownWatchdog::spawn_with_action(Duration::from_millis(200), flag_action(&fired));
+
+        watchdog.arm();
+        watchdog.disarm();
+
+        std::thread::sleep(Duration::from_millis(400));
+        assert!(
+            !fired.load(Ordering::SeqCst),
+            "watchdog must not fire after an in-time disarm"
+        );
+    }
+
+    #[test]
+    fn does_not_fire_when_never_armed() {
+        let fired = Arc::new(AtomicBool::new(false));
+        let watchdog = ShutdownWatchdog::spawn_with_action(Duration::from_millis(50), flag_action(&fired));
+
+        drop(watchdog);
+
+        std::thread::sleep(Duration::from_millis(200));
+        assert!(
+            !fired.load(Ordering::SeqCst),
+            "watchdog must not fire when the shutdown signal never arrived"
+        );
+    }
+
+    #[test]
+    fn duplicate_arm_does_not_extend_the_deadline() {
+        let fired = Arc::new(AtomicBool::new(false));
+        let watchdog = ShutdownWatchdog::spawn_with_action(Duration::from_millis(100), flag_action(&fired));
+
+        watchdog.arm();
+        std::thread::sleep(Duration::from_millis(60));
+        watchdog.arm();
+
+        assert!(
+            wait_for(&fired, Duration::from_secs(5)),
+            "watchdog deadline is fixed at first arm; a duplicate arm must not reset it"
+        );
+    }
+}

--- a/crates/aionui-app/src/commands/cmd_server.rs
+++ b/crates/aionui-app/src/commands/cmd_server.rs
@@ -5,7 +5,10 @@ use std::net::SocketAddr;
 use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use std::{future::Future, pin::Pin};
+use std::{
+    future::{Future, IntoFuture},
+    pin::Pin,
+};
 
 use tokio::net::TcpListener;
 use tracing::{info, warn};
@@ -15,7 +18,7 @@ use aionui_app::{AppConfig, AppServices, RouterBuildError, create_router_with_ru
 use aionui_system::RuntimePrepareService;
 use aionui_team::TeamIdleCleanupCoordinator;
 
-use crate::bootstrap::{BootstrapError, BootstrapErrorCode, ParentExitSignal, ServerEnvironment};
+use crate::bootstrap::{BootstrapError, BootstrapErrorCode, ParentExitSignal, ServerEnvironment, ShutdownWatchdog};
 
 const LISTENING_EVENT_PREFIX: &str = "AIONCORE_LISTENING";
 // Bare, payload-less readiness marker emitted once `axum::serve` actually begins
@@ -26,6 +29,26 @@ const LISTENING_EVENT_PREFIX: &str = "AIONCORE_LISTENING";
 const READY_EVENT_MARKER: &str = "AIONCORE_READY";
 const DYNAMIC_BACKEND_BIND_MAX_ATTEMPTS: usize = 50;
 const WORKER_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+// Bounded graceful-shutdown tail (AIONUI-16). The data-dir instance flock is
+// only released when this process exits, so every await between the shutdown
+// signal and process exit must be bounded — otherwise a restarting AionUi
+// keeps hitting BOOTSTRAP_PEER_ALREADY_RUNNING against a zombie backend.
+//
+// Stage bounds below cover the awaits that are unbounded by design:
+// - axum's drain waits for every connection task with no timeout
+//   (axum-0.8.9 serve/mod.rs: `close_tx.closed().await`), and an in-flight
+//   HTTP/1 response keeps its connection task alive indefinitely.
+// - `sqlx::Pool::close()` waits for all checked-out connections to be
+//   returned; detached tasks (e.g. WebSocket handlers, which axum spawns
+//   detached and nothing cancels at shutdown) can hold one forever.
+// The watchdog is the last-resort bound covering everything else (including a
+// wedged runtime); it must exceed the sum of all stage bounds
+// (WORKER_TASK_SHUTDOWN_TIMEOUT + drain + scanner join + db close = 20s).
+const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+const SHUTDOWN_IDLE_SCANNER_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
+const SHUTDOWN_DB_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
+const SHUTDOWN_WATCHDOG_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ShutdownReason {
@@ -310,9 +333,28 @@ pub(crate) async fn run_server(
     emit_ready_event();
     info!("startup: server ready, emitted AIONCORE_READY");
 
-    axum::serve(listener, router)
+    // Last-resort bound on the whole shutdown tail (AIONUI-16): armed when the
+    // shutdown signal fires, disarmed once the tail below completes. See
+    // `bootstrap::shutdown_watchdog` for rationale.
+    let shutdown_watchdog = ShutdownWatchdog::spawn(SHUTDOWN_WATCHDOG_TIMEOUT);
+    let watchdog_for_signal = shutdown_watchdog.clone();
+    // Observes `shutdown_tx.send(true)` at the end of the graceful-shutdown
+    // callback, i.e. the moment axum's connection drain becomes the only thing
+    // between us and process exit.
+    let drain_started = shutdown_tx.subscribe();
+
+    let serve_future = axum::serve(listener, router)
         .with_graceful_shutdown(async move {
-            match shutdown_signal(parent_exit).await {
+            let signal_result = shutdown_signal(parent_exit).await;
+            // From here on the process must exit in bounded time so the
+            // data-dir instance flock is released for the next backend.
+            watchdog_for_signal.arm();
+            info!(
+                stage = "shutdown.watchdog",
+                timeout_secs = SHUTDOWN_WATCHDOG_TIMEOUT.as_secs(),
+                "shutdown watchdog armed"
+            );
+            match signal_result {
                 Err(error) => {
                     error.log_source();
                     tracing::error!(error = %error.stderr_line(), "shutdown signal handler failed");
@@ -347,30 +389,62 @@ pub(crate) async fn run_server(
             }
             let _ = shutdown_tx.send(true);
         })
-        .await
-        .map_err(|error| {
-            BootstrapError::new(
-                BootstrapErrorCode::ServerFailed,
-                "server.serve",
-                "server runtime failed",
-            )
-            .with_source(error)
-        })?;
+        .into_future();
+
+    match await_serve_with_bounded_drain(serve_future, drain_started, SHUTDOWN_DRAIN_TIMEOUT).await {
+        ServeOutcome::Completed(result) => {
+            result.map_err(|error| {
+                BootstrapError::new(
+                    BootstrapErrorCode::ServerFailed,
+                    "server.serve",
+                    "server runtime failed",
+                )
+                .with_source(error)
+            })?;
+            info!(stage = "shutdown.drain", "shutdown: http connections drained");
+        }
+        ServeOutcome::DrainAbandoned => warn!(
+            code = "BOOTSTRAP_SHUTDOWN_STAGE_TIMEOUT",
+            stage = "shutdown.drain",
+            timeout_secs = SHUTDOWN_DRAIN_TIMEOUT.as_secs(),
+            "http connection drain timed out; abandoning open connections"
+        ),
+    }
 
     let shutdown_error = shutdown_error_rx.await.ok();
 
-    // Wait for the scanner to observe the shutdown watch value and
-    // return; at worst this blocks for the current 60 s tick.
-    if let Err(e) = idle_scanner_handle.await {
-        warn!(
+    // The scanner breaks out of its select loop as soon as it observes the
+    // shutdown watch value; the bound covers an in-progress scan_and_cleanup
+    // (which awaits agent kill operations) wedging the join.
+    match tokio::time::timeout(SHUTDOWN_IDLE_SCANNER_JOIN_TIMEOUT, idle_scanner_handle).await {
+        Ok(Ok(())) => info!(stage = "shutdown.idle_scanner", "shutdown: idle scanner joined"),
+        Ok(Err(e)) => warn!(
             code = "BOOTSTRAP_DEGRADED_IDLE_SCANNER",
             stage = "idle_scanner.join",
             error = %e,
             "idle scanner join failed"
-        );
+        ),
+        Err(_) => warn!(
+            code = "BOOTSTRAP_SHUTDOWN_STAGE_TIMEOUT",
+            stage = "shutdown.idle_scanner_join",
+            timeout_secs = SHUTDOWN_IDLE_SCANNER_JOIN_TIMEOUT.as_secs(),
+            "idle scanner join timed out; abandoning scanner task"
+        ),
     }
 
-    services.database.close().await;
+    // `sqlx::Pool::close()` waits for all checked-out connections to be
+    // returned, which is unbounded if a detached task still holds one.
+    match tokio::time::timeout(SHUTDOWN_DB_CLOSE_TIMEOUT, services.database.close()).await {
+        Ok(()) => info!(stage = "shutdown.database_close", "shutdown: database closed"),
+        Err(_) => warn!(
+            code = "BOOTSTRAP_SHUTDOWN_STAGE_TIMEOUT",
+            stage = "shutdown.database_close",
+            timeout_secs = SHUTDOWN_DB_CLOSE_TIMEOUT.as_secs(),
+            "database close timed out; abandoning checked-out connections"
+        ),
+    }
+
+    shutdown_watchdog.disarm();
     info!("Server shut down gracefully");
 
     // Prevent the log guard from being dropped before final log flush.
@@ -391,6 +465,49 @@ fn finish_server_shutdown(shutdown_error: Option<BootstrapError>) -> Result<Exit
     }
 
     Ok(ExitCode::SUCCESS)
+}
+
+#[derive(Debug)]
+enum ServeOutcome {
+    /// The serve future completed on its own (drain finished, or a runtime
+    /// error surfaced).
+    Completed(std::io::Result<()>),
+    /// The graceful-shutdown callback completed but the connection drain did
+    /// not finish within the bound; the serve future was dropped so shutdown
+    /// can proceed and the process can exit.
+    DrainAbandoned,
+}
+
+/// Await the serve future, bounding the post-signal connection drain.
+///
+/// axum's `with_graceful_shutdown` waits for every connection task with no
+/// upper bound (axum-0.8.9 serve/mod.rs: `close_tx.closed().await`); a hung
+/// in-flight response would otherwise block process exit — and therefore the
+/// data-dir instance flock release — forever (AIONUI-16). Once `drain_started`
+/// observes the graceful-shutdown callback completing, the remaining drain
+/// gets `drain_timeout` before being abandoned.
+async fn await_serve_with_bounded_drain<F>(
+    serve: F,
+    mut drain_started: tokio::sync::watch::Receiver<bool>,
+    drain_timeout: Duration,
+) -> ServeOutcome
+where
+    F: Future<Output = std::io::Result<()>>,
+{
+    tokio::pin!(serve);
+
+    tokio::select! {
+        result = serve.as_mut() => return ServeOutcome::Completed(result),
+        // Resolves when the graceful-shutdown callback sends the drain marker
+        // (or drops the sender); either way the drain phase is now the only
+        // remaining work inside `serve` and must be bounded.
+        _ = drain_started.changed() => {}
+    }
+
+    match tokio::time::timeout(drain_timeout, serve.as_mut()).await {
+        Ok(result) => ServeOutcome::Completed(result),
+        Err(_) => ServeOutcome::DrainAbandoned,
+    }
 }
 
 type ShutdownFuture = Pin<Box<dyn Future<Output = Result<ShutdownReason, BootstrapError>> + Send>>;
@@ -494,6 +611,69 @@ mod tests {
 
         assert!(config.port > 0);
         assert_eq!(config.port, bound.addr.port());
+    }
+
+    #[tokio::test]
+    async fn serve_completing_without_drain_signal_returns_its_result() {
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+
+        let outcome = await_serve_with_bounded_drain(
+            std::future::ready(Ok::<(), std::io::Error>(())),
+            rx,
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert!(matches!(outcome, ServeOutcome::Completed(Ok(()))));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn hung_drain_is_abandoned_after_the_bound() {
+        let (tx, rx) = tokio::sync::watch::channel(false);
+        tx.send(true).expect("drain marker should be delivered");
+
+        // A serve future that never completes models axum waiting forever on a
+        // connection task that will not exit (the AIONUI-16 hang).
+        let outcome = await_serve_with_bounded_drain(
+            std::future::pending::<std::io::Result<()>>(),
+            rx,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(matches!(outcome, ServeOutcome::DrainAbandoned));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_completing_within_the_bound_returns_its_result() {
+        let (tx, rx) = tokio::sync::watch::channel(false);
+        tx.send(true).expect("drain marker should be delivered");
+
+        let serve = async {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            Ok::<(), std::io::Error>(())
+        };
+
+        let outcome = await_serve_with_bounded_drain(serve, rx, Duration::from_secs(5)).await;
+
+        assert!(matches!(outcome, ServeOutcome::Completed(Ok(()))));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_marker_sender_drop_still_bounds_the_drain() {
+        // If the graceful-shutdown callback is torn down without sending the
+        // marker, the drain bound must still engage rather than wait forever.
+        let (tx, rx) = tokio::sync::watch::channel(false);
+        drop(tx);
+
+        let outcome = await_serve_with_bounded_drain(
+            std::future::pending::<std::io::Result<()>>(),
+            rx,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(matches!(outcome, ServeOutcome::DrainAbandoned));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Fixes AIONUI-16 (Jira).

Six independent Sentry sources (Windows/Linux/macOS, AionUi v2.1.44–v2.1.57 / AionCore v0.1.55–v0.1.68) show the same failure: after AionUi restarts, the new `aioncore` cannot acquire the data-dir instance `flock` (`BOOTSTRAP_PEER_ALREADY_RUNNING`), with log evidence of the lock being held by the same owner for 20–53 minutes across "clean quits". Since the lock is a pure kernel `flock` released only on process death (`crates/aionui-db/src/instance_lock.rs:8-11`), the previous backend must have started shutting down but never exited.

## Root cause

The graceful-shutdown tail in `run_server` contained awaits that are unbounded by design, so a single wedged connection or task kept the process (and therefore the flock) alive forever:

- **axum connection drain has no timeout.** `axum::serve(...).with_graceful_shutdown(...)` ends with `close_tx.closed().await`, waiting for every connection task with no upper bound (axum-0.8.9 `src/serve/mod.rs`, `WithGracefulShutdown::run`). For HTTP/1, `graceful_shutdown()` only disables keep-alive; an in-flight response (e.g. a hung streaming body) keeps its connection task alive indefinitely.
- **`Database::close()` → `sqlx::Pool::close()` waits for all checked-out connections to be returned** (sqlx-core-0.8.6 `src/pool/mod.rs:425-441`). WebSocket handler tasks are spawned detached by axum (`axum-0.8.9 src/extract/ws.rs:359`) and nothing in `aionui-realtime` observes the shutdown signal, so a detached task holding a pool connection blocks close forever (`crates/aionui-db/src/database.rs:101-103`, previously awaited with no bound at `cmd_server.rs`).
- The idle-scanner join was also unbounded if a `scan_and_cleanup` pass was in flight, and the comment above it ("at worst blocks for the current 60 s tick") was wrong — the scanner exits on the shutdown watch signal (`crates/aionui-ai-agent/src/idle_scanner.rs:79-95`).

Notably, upgraded WebSocket connections do **not** block the axum drain (hyper-1.9.0 `src/server/conn/http1.rs`: the connection future resolves at upgrade), so the WS risk is via the detached-task/DB-pool path, not the drain.

## Fix

`crates/aionui-app/src/commands/cmd_server.rs`:
- Bound the post-signal connection drain with a 5 s timeout (`await_serve_with_bounded_drain`): a watch receiver observes the graceful-shutdown callback completing, then the remaining drain gets `SHUTDOWN_DRAIN_TIMEOUT` before being abandoned.
- Bound the idle-scanner join and `database.close()` with 5 s timeouts each. Every expired stage logs a structured `warn` with `code = "BOOTSTRAP_SHUTDOWN_STAGE_TIMEOUT"` and a `stage` field (`shutdown.drain` / `shutdown.idle_scanner_join` / `shutdown.database_close`) so future Sentry reports pinpoint the wedged stage; completed stages log at `info`.

`crates/aionui-app/src/bootstrap/shutdown_watchdog.rs` (new):
- Last-resort hard bound: a plain OS thread (immune to a wedged tokio runtime), armed the moment the shutdown signal fires and disarmed once the tail completes. If 30 s elapse while armed, it logs at `error`, emits the `BOOTSTRAP_SHUTDOWN_FAILED stage=shutdown.watchdog` stderr boundary line (written directly so it survives the forced exit), and `std::process::exit(1)`s so the kernel releases the instance lock in bounded time. 30 s exceeds the sum of all stage bounds (5 s worker-task clear + 5 s drain + 5 s scanner join + 5 s db close), so it can only fire when something outside those bounds is wedged.

The normal fast-exit path is unchanged: all timeouts are upper bounds, and the watchdog is disarmed on completion. Active turns keep the existing semantics — `worker_task_manager.clear()` already bounded them at 5 s before this change.

## Test plan

- `cargo test -p aionui-app` — all suites pass, including new tests:
  - `shutdown_watchdog`: fires when armed and not disarmed; does not fire when disarmed in time; does not fire when never armed; duplicate arm does not extend the deadline.
  - `cmd_server`: serve completing without a drain signal returns its result; a hung drain is abandoned after the bound; a drain completing within the bound returns its result; sender drop still bounds the drain.
- `cargo clippy -p aionui-app -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
