### PR TITLE
fix(app): reuse the app-level ConversationService in build_cron_state

### DIFF
--- a/crates/aionui-app/src/router/state.rs
+++ b/crates/aionui-app/src/router/state.rs
@@ -12,16 +12,16 @@ use aionui_assistant::{
 };
 use aionui_auth::extract_token_from_ws_headers;
 use aionui_channel::ChannelRouterState;
-use aionui_conversation::{ConversationRouterState, ConversationService};
+use aionui_conversation::ConversationRouterState;
 use aionui_cron::{CronEventEmitter, CronRouterState, service::CronServiceDeps};
 use aionui_db::{
-    IAcpSessionRepository, IAgentMetadataRepository, IAssistantDefinitionRepository, IAssistantOverlayRepository,
+    IAgentMetadataRepository, IAssistantDefinitionRepository, IAssistantOverlayRepository,
     IAssistantOverrideRepository, IAssistantPreferenceRepository, IAssistantRepository, IConversationRepository,
-    IProviderRepository, SqliteAcpSessionRepository, SqliteAgentMetadataRepository,
-    SqliteAssistantDefinitionRepository, SqliteAssistantOverlayRepository, SqliteAssistantOverrideRepository,
-    SqliteAssistantPreferenceRepository, SqliteAssistantRepository, SqliteClientPreferenceRepository,
-    SqliteConversationRepository, SqliteFeedbackDiagnosticsRepository, SqliteProviderRepository,
-    SqliteRemoteAgentRepository, SqliteSettingsRepository,
+    IProviderRepository, SqliteAgentMetadataRepository, SqliteAssistantDefinitionRepository,
+    SqliteAssistantOverlayRepository, SqliteAssistantOverrideRepository, SqliteAssistantPreferenceRepository,
+    SqliteAssistantRepository, SqliteClientPreferenceRepository, SqliteConversationRepository,
+    SqliteFeedbackDiagnosticsRepository, SqliteProviderRepository, SqliteRemoteAgentRepository,
+    SqliteSettingsRepository,
 };
 use aionui_extension::{
     AssistantRuleDispatcher, ExtensionRegistry, ExtensionRouterState, ExtensionStateStore, ExternalPathsManager,
@@ -845,44 +845,19 @@ pub fn build_team_state(
 pub fn build_cron_state(services: &AppServices) -> CronRouterState {
     let pool = services.database.pool().clone();
     let cron_repo: Arc<dyn aionui_db::ICronRepository> = Arc::new(aionui_db::SqliteCronRepository::new(pool.clone()));
+    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> = Arc::new(SqliteAgentMetadataRepository::new(pool));
 
-    let conv_repo: Arc<dyn aionui_db::IConversationRepository> =
-        Arc::new(SqliteConversationRepository::new(pool.clone()));
-    let agent_metadata_repo: Arc<dyn IAgentMetadataRepository> =
-        Arc::new(SqliteAgentMetadataRepository::new(pool.clone()));
-    let acp_session_repo: Arc<dyn IAcpSessionRepository> = Arc::new(SqliteAcpSessionRepository::new(pool));
-    let skill_resolver = Arc::new(aionui_conversation::skill_resolver::ExtensionSkillResolver::new(
-        services.skill_paths.clone(),
-        services.skill_repo.clone(),
-    ));
-    let conv_service = ConversationService::new(
-        services.work_dir.clone(),
-        services.event_bus.clone(),
-        skill_resolver,
-        services.worker_task_manager.clone(),
-        conv_repo.clone(),
-        agent_metadata_repo.clone(),
-        acp_session_repo,
-    )
-    .with_runtime_state(services.conversation_runtime_state.clone())
-    .with_runtime_helper_context(services.runtime_helper_bin(), services.runtime_base_url());
-    conv_service.with_mcp_server_repo(Arc::new(aionui_db::SqliteMcpServerRepository::new(
-        services.database.pool().clone(),
-    )));
-    conv_service.with_assistant_definition_repo(Arc::new(SqliteAssistantDefinitionRepository::new(
-        services.database.pool().clone(),
-    )));
-    conv_service.with_assistant_state_repo(Arc::new(SqliteAssistantOverlayRepository::new(
-        services.database.pool().clone(),
-    )));
-    conv_service.with_assistant_preference_repo(Arc::new(SqliteAssistantPreferenceRepository::new(
-        services.database.pool().clone(),
-    )));
-    conv_service.with_project_service(Arc::new(services.project_service.clone()));
+    // Reuse the app-level ConversationService (AppServices is the sole service
+    // construction center). A separate instance carries its own
+    // background-watcher registry — `ensure_background_watcher` is idempotent
+    // only within one instance — so a cron-triggered conversation would get a
+    // second BackgroundStreamWatcher on the same agent broadcast channel and
+    // every CLI-initiated (orphan) turn would be persisted twice.
+    let conv_service = services.conversation_service.clone();
 
     let executor = Arc::new(aionui_cron::executor::JobExecutor::new(
         services.worker_task_manager.clone(),
-        conv_repo,
+        conv_service.conversation_repo().clone(),
         Arc::new(conv_service.clone()),
         services.work_dir.clone(),
         services.data_dir.clone(),
@@ -1390,6 +1365,39 @@ mod tests {
         assert!(
             env.contains(&(AIONUI_BASE_URL_ENV.to_owned(), config.local_base_url())),
             "cron conversation runtime env should include AIONUI_BASE_URL"
+        );
+
+        services.database.close().await;
+    }
+
+    /// The cron path must share the app-level `ConversationService` (a clone,
+    /// so all `Arc` internals — including the background-watcher registry —
+    /// are shared) rather than construct its own instance. A second instance
+    /// carries its own watcher registry: `ensure_background_watcher` is
+    /// idempotent only within one instance, so a cron-triggered conversation
+    /// got a SECOND `BackgroundStreamWatcher` subscribed to the same agent
+    /// broadcast channel and every CLI-initiated (orphan) turn's text and
+    /// thinking rows were persisted twice.
+    #[tokio::test]
+    async fn build_cron_state_reuses_app_conversation_service() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = AppConfig {
+            data_dir: tmp.path().join("data"),
+            work_dir: tmp.path().join("work"),
+            ..Default::default()
+        };
+        let db = aionui_db::init_database_memory().await.unwrap();
+        let services = AppServices::from_config(db, &config).await.unwrap();
+
+        let cron = build_cron_state(&services);
+
+        assert!(
+            Arc::ptr_eq(
+                cron.conversation_service.conversation_repo(),
+                services.conversation_service.conversation_repo(),
+            ),
+            "cron's ConversationService must be a clone of AppServices' instance, \
+             not an independently constructed one"
         );
 
         services.database.close().await;

--- a/crates/aionui-app/src/services.rs
+++ b/crates/aionui-app/src/services.rs
@@ -68,14 +68,6 @@ pub struct AppServices {
 }
 
 impl AppServices {
-    pub(crate) fn runtime_helper_bin(&self) -> String {
-        self.runtime_helper_bin.clone()
-    }
-
-    pub(crate) fn runtime_base_url(&self) -> String {
-        self.runtime_base_url.clone()
-    }
-
     pub(crate) fn backend_binary_path(&self) -> Arc<PathBuf> {
         self.backend_binary_path.clone()
     }


### PR DESCRIPTION
## Problem

Every conversation bound to a cron job persists CLI-initiated (orphan) turn content **twice**: each text/thinking block is stored as two independent rows written 1–105 ms apart. Tool-call messages appear once only because they upsert by `call_id`.

## Root cause

`build_cron_state` (crates/aionui-app/src/router/state.rs) constructed a **second** `ConversationService` for the cron `JobExecutor` instead of reusing `AppServices.conversation_service`.

`ensure_background_watcher` is idempotent only within one instance: its registry is the instance's own `background_watchers` map. The worker task manager — and therefore the agent instances and their broadcast channels — is shared between both service instances. So:

1. The user's first message spawns watcher #1 via the app-level service.
2. The cron trigger spawns watcher #2 via the cron-only service, subscribed to the **same** agent broadcast channel.
3. While a user turn is active the per-turn relay owns delivery (no duplication). The moment CLI-initiated content arrives between turns (a background task report, a resumed Task subagent), **both** watchers open an orphan turn and both persist every frame.

Verified against production logs (debug level): the affected conversation shows exactly two `background stream watcher started` entries — one at the first user message, one at the cron trigger — and two `CLI-initiated turn started` entries in the same millisecond, with distinct turn ids.

## Fix

Reuse `services.conversation_service.clone()` (AppServices is the sole service construction center per AGENTS.md; `Clone` shares all `Arc` internals including the watcher registry, so the idempotence guard holds). This also removes the cron-only config drift: the duplicate instance lacked `runtime_token_service`, delete hooks, and the assistant dispatcher.

Dropped the now-unused `AppServices::runtime_helper_bin`/`runtime_base_url` accessors (their only caller was the deleted construction) and stale imports.

## Tests

- New regression test `build_cron_state_reuses_app_conversation_service`: asserts the cron state's service shares the app-level instance's internals (`Arc::ptr_eq` on the conversation repo). Red before the fix, green after.
- Existing `build_cron_state_conversation_service_injects_runtime_helper_context` still passes — the cron path keeps injecting `AIONUI_HELPER_BIN`/`AIONUI_BASE_URL` through the reused instance.
- `cargo test -p aionui-app --lib build_cron_state` (2 passed), `cargo clippy -p aionui-app -- -D warnings` clean, `cargo fmt --all -- --check` clean.