### PR TITLE
fix(app): harden the shutdown watchdog force-exit path

### DIFF
--- a/crates/aionui-app/src/bootstrap/shutdown_watchdog.rs
+++ b/crates/aionui-app/src/bootstrap/shutdown_watchdog.rs
@@ -11,21 +11,31 @@
 //!
 //! The individual stages are bounded with `tokio::time::timeout` in
 //! `cmd_server`, but those bounds live inside the tokio runtime. If the
-//! runtime itself is wedged (or a stage outside the bounds hangs), nothing
-//! guarantees process exit. This watchdog is the last-resort bound: a plain
-//! OS thread, armed when the shutdown signal fires and disarmed once the
-//! graceful tail completes. If the timeout elapses while armed, it logs the
-//! failure, emits the bootstrap boundary stderr line, and force-exits so the
-//! instance lock is released in bounded time.
+//! runtime wedges after the shutdown signal was observed (or a stage outside
+//! the bounds hangs), nothing else guarantees process exit. This watchdog is
+//! the last-resort bound for that window: a plain OS thread, armed when the
+//! shutdown signal fires and disarmed once the graceful tail completes. If
+//! the timeout elapses while armed, it logs the failure, emits the bootstrap
+//! boundary stderr line, and force-exits so the instance lock is released in
+//! bounded time.
+//!
+//! Coverage limit: arming happens inside the runtime (the graceful-shutdown
+//! callback), and every shutdown-signal source is driven by the runtime too.
+//! A runtime that wedges *before* the signal is observed therefore never arms
+//! the watchdog, and that hang is not bounded by it.
 
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use crate::bootstrap::{BootstrapError, BootstrapErrorCode};
+use crate::process_report::ExitKind;
 
-/// Exit code used on forced exit; matches `ExitKind::Internal` (exit 1), the
-/// same class `BOOTSTRAP_SHUTDOWN_FAILED` maps to via `BootstrapError`.
-const WATCHDOG_EXIT_CODE: i32 = 1;
+/// Stage label shared by every watchdog log/error event.
+const WATCHDOG_STAGE: &str = "shutdown.watchdog";
+
+/// Exit code used on forced exit; `ExitKind::Internal` is the class
+/// `BOOTSTRAP_SHUTDOWN_FAILED` maps to via `BootstrapError`.
+const WATCHDOG_EXIT_CODE: i32 = ExitKind::Internal.raw_code() as i32;
 
 enum WatchdogMsg {
     Arm,
@@ -44,23 +54,32 @@ impl ShutdownWatchdog {
     /// stderr boundary line, and calls `std::process::exit`.
     pub(crate) fn spawn(timeout: Duration) -> Self {
         Self::spawn_with_action(timeout, move || {
-            let timeout_secs = timeout.as_secs();
-            tracing::error!(
-                code = "BOOTSTRAP_SHUTDOWN_FAILED",
-                stage = "shutdown.watchdog",
-                timeout_secs,
-                "graceful shutdown did not complete in time; forcing exit to release the instance lock"
-            );
-            let error = BootstrapError::new(
-                BootstrapErrorCode::ShutdownFailed,
-                "shutdown.watchdog",
-                "graceful shutdown did not complete in time; forced exit",
-            )
-            .with_field("timeout_secs", timeout_secs.to_string());
-            // `std::process::exit` skips destructors, so the buffered tracing
-            // writer may not flush. The stderr boundary line below is written
-            // directly and survives the forced exit.
-            eprintln!("{}", error.stderr_line());
+            // Nothing before `std::process::exit` may be allowed to panic or
+            // block the exit: on the ParentExit path the desktop parent is
+            // already gone and its stdio pipes are closed, so `eprintln!`
+            // would panic on EPIPE, unwind this thread, and the forced exit —
+            // the entire point of the watchdog — would never run.
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let timeout_secs = timeout.as_secs();
+                tracing::error!(
+                    code = BootstrapErrorCode::ShutdownFailed.as_str(),
+                    stage = WATCHDOG_STAGE,
+                    timeout_secs,
+                    "graceful shutdown did not complete in time; forcing exit to release the instance lock"
+                );
+                let error = BootstrapError::new(
+                    BootstrapErrorCode::ShutdownFailed,
+                    WATCHDOG_STAGE,
+                    "graceful shutdown did not complete in time; forced exit",
+                )
+                .with_field("timeout_secs", timeout_secs.to_string());
+                // `std::process::exit` skips destructors, so the buffered
+                // tracing writer may not flush. The stderr boundary line is
+                // written directly (best-effort: a closed pipe returns an
+                // error instead of panicking) and survives the forced exit.
+                use std::io::Write;
+                let _ = writeln!(std::io::stderr(), "{}", error.stderr_line());
+            }));
             std::process::exit(WATCHDOG_EXIT_CODE);
         })
     }
@@ -69,19 +88,30 @@ impl ShutdownWatchdog {
     /// production action force-exits the process).
     pub(crate) fn spawn_with_action(timeout: Duration, on_timeout: impl FnOnce() + Send + 'static) -> Self {
         let (tx, rx) = mpsc::channel::<WatchdogMsg>();
-        std::thread::Builder::new()
+        if let Err(error) = std::thread::Builder::new()
             .name("shutdown-watchdog".into())
             .spawn(move || watchdog_thread(rx, timeout, on_timeout))
+        {
             // Thread spawn failure leaves shutdown unbounded, exactly as
             // before this watchdog existed; the stage timeouts in cmd_server
-            // still bound the common paths.
-            .ok();
+            // still bound the common paths. Log it so a later unbounded hang
+            // is attributable to the missing watchdog instead of looking like
+            // an armed watchdog that mysteriously never fired.
+            tracing::warn!(
+                code = "BOOTSTRAP_DEGRADED_SHUTDOWN_WATCHDOG",
+                stage = WATCHDOG_STAGE,
+                error = %error,
+                "failed to spawn shutdown watchdog thread; shutdown tail has stage bounds only"
+            );
+        }
         Self { tx }
     }
 
-    /// Start the countdown. Called when the shutdown signal fires.
-    pub(crate) fn arm(&self) {
-        let _ = self.tx.send(WatchdogMsg::Arm);
+    /// Start the countdown. Called when the shutdown signal fires. Returns
+    /// `false` when the watchdog thread is not running (spawn failed), so the
+    /// caller can log the degraded state instead of claiming an armed bound.
+    pub(crate) fn arm(&self) -> bool {
+        self.tx.send(WatchdogMsg::Arm).is_ok()
     }
 
     /// Cancel the countdown. Called once the graceful tail has completed.
@@ -195,15 +225,38 @@ mod tests {
     #[test]
     fn duplicate_arm_does_not_extend_the_deadline() {
         let fired = Arc::new(AtomicBool::new(false));
-        let watchdog = ShutdownWatchdog::spawn_with_action(Duration::from_millis(100), flag_action(&fired));
+        let watchdog = ShutdownWatchdog::spawn_with_action(Duration::from_millis(1000), flag_action(&fired));
 
+        let start = std::time::Instant::now();
         watchdog.arm();
-        std::thread::sleep(Duration::from_millis(60));
+        std::thread::sleep(Duration::from_millis(500));
         watchdog.arm();
 
         assert!(
             wait_for(&fired, Duration::from_secs(5)),
-            "watchdog deadline is fixed at first arm; a duplicate arm must not reset it"
+            "watchdog must fire despite a duplicate arm"
         );
+        // A deadline-resetting regression would fire at ~1500ms from the first
+        // arm; the fixed deadline fires at ~1000ms. The 1400ms bound separates
+        // the two with scheduling slack on both sides.
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(1400),
+            "watchdog deadline is fixed at first arm; a duplicate arm must not reset it (fired after {elapsed:?})"
+        );
+    }
+
+    #[test]
+    fn arm_reports_whether_the_watchdog_thread_is_alive() {
+        let fired = Arc::new(AtomicBool::new(false));
+        let watchdog = ShutdownWatchdog::spawn_with_action(Duration::from_millis(50), flag_action(&fired));
+        assert!(watchdog.arm(), "arm must report success while the thread is alive");
+
+        // Simulate a dead watchdog thread (e.g. spawn failure dropped the
+        // receiver): arm must report the degradation instead of no-opping.
+        let (tx, rx) = std::sync::mpsc::channel();
+        drop(rx);
+        let dead = ShutdownWatchdog { tx };
+        assert!(!dead.arm(), "arm must report failure when the watchdog thread is gone");
     }
 }

--- a/crates/aionui-app/src/commands/cmd_server.rs
+++ b/crates/aionui-app/src/commands/cmd_server.rs
@@ -42,13 +42,28 @@ const WORKER_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 // - `sqlx::Pool::close()` waits for all checked-out connections to be
 //   returned; detached tasks (e.g. WebSocket handlers, which axum spawns
 //   detached and nothing cancels at shutdown) can hold one forever.
-// The watchdog is the last-resort bound covering everything else (including a
-// wedged runtime); it must exceed the sum of all stage bounds
-// (WORKER_TASK_SHUTDOWN_TIMEOUT + drain + scanner join + db close = 20s).
+// The watchdog is the last-resort bound for everything after it is armed,
+// including a runtime that wedges mid-tail. (It cannot cover a runtime that
+// wedges before the shutdown signal is observed — arming itself runs inside
+// the runtime; see `bootstrap::shutdown_watchdog`.)
+const SHUTDOWN_KEEP_AWAKE_TIMEOUT: Duration = Duration::from_secs(5);
 const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 const SHUTDOWN_IDLE_SCANNER_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
 const SHUTDOWN_DB_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
 const SHUTDOWN_WATCHDOG_TIMEOUT: Duration = Duration::from_secs(30);
+
+// The watchdog must outlast the sum of every bounded stage, otherwise it can
+// force-exit a shutdown that is still making progress within its per-stage
+// bounds. Checked by the compiler so a bumped stage bound cannot silently
+// invalidate it.
+const _: () = assert!(
+    SHUTDOWN_WATCHDOG_TIMEOUT.as_secs()
+        > WORKER_TASK_SHUTDOWN_TIMEOUT.as_secs()
+            + SHUTDOWN_KEEP_AWAKE_TIMEOUT.as_secs()
+            + SHUTDOWN_DRAIN_TIMEOUT.as_secs()
+            + SHUTDOWN_IDLE_SCANNER_JOIN_TIMEOUT.as_secs()
+            + SHUTDOWN_DB_CLOSE_TIMEOUT.as_secs()
+);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ShutdownReason {
@@ -348,12 +363,21 @@ pub(crate) async fn run_server(
             let signal_result = shutdown_signal(parent_exit).await;
             // From here on the process must exit in bounded time so the
             // data-dir instance flock is released for the next backend.
-            watchdog_for_signal.arm();
-            info!(
-                stage = "shutdown.watchdog",
-                timeout_secs = SHUTDOWN_WATCHDOG_TIMEOUT.as_secs(),
-                "shutdown watchdog armed"
-            );
+            if watchdog_for_signal.arm() {
+                info!(
+                    stage = "shutdown.watchdog",
+                    timeout_secs = SHUTDOWN_WATCHDOG_TIMEOUT.as_secs(),
+                    "shutdown watchdog armed"
+                );
+            } else {
+                // Watchdog thread never spawned (logged at spawn time): the
+                // tail still has its per-stage bounds but no last-resort exit.
+                warn!(
+                    code = "BOOTSTRAP_DEGRADED_SHUTDOWN_WATCHDOG",
+                    stage = "shutdown.watchdog",
+                    "shutdown watchdog unavailable; shutdown tail has stage bounds only"
+                );
+            }
             match signal_result {
                 Err(error) => {
                     error.log_source();
@@ -374,18 +398,41 @@ pub(crate) async fn run_server(
                     );
                     let active_task_count = worker_task_manager.active_count();
                     match tokio::time::timeout(WORKER_TASK_SHUTDOWN_TIMEOUT, worker_task_manager.clear()).await {
-                        Ok(()) => info!(active_task_count, "worker task manager shutdown completed"),
-                        Err(_) => warn!(active_task_count, "worker task manager shutdown timed out"),
+                        Ok(()) => info!(
+                            stage = "shutdown.worker_tasks",
+                            active_task_count, "worker task manager shutdown completed"
+                        ),
+                        Err(_) => warn!(
+                            code = "BOOTSTRAP_SHUTDOWN_STAGE_TIMEOUT",
+                            stage = "shutdown.worker_tasks",
+                            timeout_secs = WORKER_TASK_SHUTDOWN_TIMEOUT.as_secs(),
+                            active_task_count,
+                            "worker task manager shutdown timed out"
+                        ),
                     }
                 }
             }
-            if let Err(error) = client_pref_service.release_keep_awake_for_shutdown().await {
-                warn!(
+            // Bounded: this await sits before the drain marker below, so if it
+            // wedged unbounded no stage bound could ever start and the only
+            // escape would be the watchdog force-exit.
+            match tokio::time::timeout(
+                SHUTDOWN_KEEP_AWAKE_TIMEOUT,
+                client_pref_service.release_keep_awake_for_shutdown(),
+            )
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => warn!(
                     code = "BOOTSTRAP_DEGRADED_KEEP_AWAKE_RELEASE",
                     stage = "shutdown.keep_awake.release",
                     error = %error,
                     "keep-awake shutdown release failed"
-                );
+                ),
+                Err(_) => warn_stage_timeout(
+                    "shutdown.keep_awake.release",
+                    SHUTDOWN_KEEP_AWAKE_TIMEOUT,
+                    "keep-awake release timed out; abandoning keep-awake child reap",
+                ),
             }
             let _ = shutdown_tx.send(true);
         })
@@ -403,11 +450,10 @@ pub(crate) async fn run_server(
             })?;
             info!(stage = "shutdown.drain", "shutdown: http connections drained");
         }
-        ServeOutcome::DrainAbandoned => warn!(
-            code = "BOOTSTRAP_SHUTDOWN_STAGE_TIMEOUT",
-            stage = "shutdown.drain",
-            timeout_secs = SHUTDOWN_DRAIN_TIMEOUT.as_secs(),
-            "http connection drain timed out; abandoning open connections"
+        ServeOutcome::DrainAbandoned => warn_stage_timeout(
+            "shutdown.drain",
+            SHUTDOWN_DRAIN_TIMEOUT,
+            "http connection drain timed out; abandoning open connections",
         ),
     }
 
@@ -416,19 +462,20 @@ pub(crate) async fn run_server(
     // The scanner breaks out of its select loop as soon as it observes the
     // shutdown watch value; the bound covers an in-progress scan_and_cleanup
     // (which awaits agent kill operations) wedging the join.
+    // All three arms share one stage label so success/failure/timeout of the
+    // same stage correlate under a single stage= key in log queries.
     match tokio::time::timeout(SHUTDOWN_IDLE_SCANNER_JOIN_TIMEOUT, idle_scanner_handle).await {
         Ok(Ok(())) => info!(stage = "shutdown.idle_scanner", "shutdown: idle scanner joined"),
         Ok(Err(e)) => warn!(
             code = "BOOTSTRAP_DEGRADED_IDLE_SCANNER",
-            stage = "idle_scanner.join",
+            stage = "shutdown.idle_scanner",
             error = %e,
             "idle scanner join failed"
         ),
-        Err(_) => warn!(
-            code = "BOOTSTRAP_SHUTDOWN_STAGE_TIMEOUT",
-            stage = "shutdown.idle_scanner_join",
-            timeout_secs = SHUTDOWN_IDLE_SCANNER_JOIN_TIMEOUT.as_secs(),
-            "idle scanner join timed out; abandoning scanner task"
+        Err(_) => warn_stage_timeout(
+            "shutdown.idle_scanner",
+            SHUTDOWN_IDLE_SCANNER_JOIN_TIMEOUT,
+            "idle scanner join timed out; abandoning scanner task",
         ),
     }
 
@@ -436,11 +483,10 @@ pub(crate) async fn run_server(
     // returned, which is unbounded if a detached task still holds one.
     match tokio::time::timeout(SHUTDOWN_DB_CLOSE_TIMEOUT, services.database.close()).await {
         Ok(()) => info!(stage = "shutdown.database_close", "shutdown: database closed"),
-        Err(_) => warn!(
-            code = "BOOTSTRAP_SHUTDOWN_STAGE_TIMEOUT",
-            stage = "shutdown.database_close",
-            timeout_secs = SHUTDOWN_DB_CLOSE_TIMEOUT.as_secs(),
-            "database close timed out; abandoning checked-out connections"
+        Err(_) => warn_stage_timeout(
+            "shutdown.database_close",
+            SHUTDOWN_DB_CLOSE_TIMEOUT,
+            "database close timed out; abandoning checked-out connections",
         ),
     }
 
@@ -457,6 +503,18 @@ fn router_build_error_to_bootstrap(error: RouterBuildError) -> BootstrapError {
     let stage = error.stage();
     let message = error.message();
     BootstrapError::new(BootstrapErrorCode::ServerFailed, stage, message).with_source(error)
+}
+
+/// One shared emitter for every bounded-shutdown-stage timeout so the
+/// code/stage/timeout_secs field set stays queryable across all stages.
+fn warn_stage_timeout(stage: &'static str, timeout: Duration, detail: &'static str) {
+    warn!(
+        code = "BOOTSTRAP_SHUTDOWN_STAGE_TIMEOUT",
+        stage,
+        timeout_secs = timeout.as_secs(),
+        "{}",
+        detail
+    );
 }
 
 fn finish_server_shutdown(shutdown_error: Option<BootstrapError>) -> Result<ExitCode, BootstrapError> {

--- a/crates/aionui-app/src/process_report.rs
+++ b/crates/aionui-app/src/process_report.rs
@@ -11,12 +11,20 @@ pub(crate) enum ExitKind {
 }
 
 impl ExitKind {
-    pub(crate) fn exit_code(self) -> ExitCode {
+    /// Numeric exit code for this kind. The single source of truth for the
+    /// process-exit contract; `const` so exit paths that bypass `ExitCode`
+    /// (e.g. the shutdown watchdog's `std::process::exit`) reuse the same
+    /// table instead of hardcoding a copy.
+    pub(crate) const fn raw_code(self) -> u8 {
         match self {
-            Self::Internal => ExitCode::from(1),
-            Self::Config => ExitCode::from(2),
-            Self::Unavailable => ExitCode::from(3),
+            Self::Internal => 1,
+            Self::Config => 2,
+            Self::Unavailable => 3,
         }
+    }
+
+    pub(crate) fn exit_code(self) -> ExitCode {
+        ExitCode::from(self.raw_code())
     }
 }
 
@@ -59,6 +67,11 @@ mod tests {
         assert_eq!(ExitKind::Internal.exit_code(), ExitCode::from(1));
         assert_eq!(ExitKind::Config.exit_code(), ExitCode::from(2));
         assert_eq!(ExitKind::Unavailable.exit_code(), ExitCode::from(3));
+        // raw_code is the same table exposed as a number; the values are an
+        // external supervisor contract and must not drift.
+        assert_eq!(ExitKind::Internal.raw_code(), 1);
+        assert_eq!(ExitKind::Config.raw_code(), 2);
+        assert_eq!(ExitKind::Unavailable.raw_code(), 3);
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #884, from an adversarial review of the merged change (10 finder angles, 13 candidate defects individually verified against the merged code and vendored deps; 5 were refuted, the confirmed ones are fixed here).

## Fixes

1. **Panic-proof force-exit** (`shutdown_watchdog.rs`) — the forced-exit action wrote the stderr boundary line via `eprintln!` *before* `std::process::exit(1)`. On the ParentExit path the desktop parent is already gone and its stdio pipes are closed, so `eprintln!` panics on EPIPE (verified against rustc 1.95 std source), the unwind kills only the watchdog thread, and the forced exit never runs — the last-resort bound failed in exactly the scenario with no external SIGKILL rescue (parent-alive hangs are separately covered by the launcher's SIGTERM→SIGKILL escalation). The boundary line is now written best-effort (`let _ = writeln!`), and the whole logging block is wrapped in `catch_unwind` so `exit(1)` is unconditionally reachable.
2. **Bound the keep-awake release** (`cmd_server.rs`, 5s) — `release_keep_awake_for_shutdown().await` was the only unbounded await inside the armed window, and it sits *before* the drain marker: a wedge there (tokio Mutex held across `kill().await`/`wait().await`, shared with preference-update paths) prevented every stage bound from even starting, leaving only the 30s watchdog to turn a clean quit into exit 1.
3. **Observable watchdog degradation** — thread-spawn failure was discarded with `.ok()` while cmd_server unconditionally logged "shutdown watchdog armed"; a post-mortem would conclude an armed watchdog mysteriously never fired. Spawn failure now logs `BOOTSTRAP_DEGRADED_SHUTDOWN_WATCHDOG`, and `arm()` returns liveness so the armed/degraded log matches reality.
4. **Exit-code reuse** — `WATCHDOG_EXIT_CODE` hardcoded a copy of the `ExitKind` table; it now derives from a new `const ExitKind::raw_code()` (also reused by `exit_code()`), and the tracing `code` field reuses `BootstrapErrorCode::as_str()` instead of a string literal.
5. **Doc correction** — module and cmd_server docs claimed the watchdog covers "a wedged runtime"; arming runs inside the runtime and every signal source is runtime-driven, so a runtime wedged *before* the signal is observed is explicitly out of coverage now.
6. **Log-field consistency** — the idle-scanner stage emitted three different `stage=` values across its three arms (success/join-error/timeout), breaking stage-keyed correlation; all arms now share `shutdown.idle_scanner`. The worker-task timeout warn gains the `code`/`stage`/`timeout_secs` trio it was missing, and all stage-timeout warns go through one helper.
7. **Compile-checked budget** — the "watchdog must exceed the sum of stage bounds" invariant moves from comment arithmetic (which was already stale: it omitted the keep-awake stage) to a `const _: () = assert!(...)`.
8. **Non-vacuous regression test** — `duplicate_arm_does_not_extend_the_deadline` only asserted firing within a 5s window, which a deadline-resetting regression would also satisfy; it now asserts the fire time separates the fixed-deadline (~1.0s) from the extended (~1.5s) behavior, plus a new test pinning `arm()`'s liveness reporting.

## Out of scope

Wiring `run_startup_reap` so a force-exit's orphaned agent process groups are reaped on next boot (pre-existing systemic gap that any crash/kill -9 also hits) — separate change.

## Verification

- `cargo test -p aionui-app` filtered: `shutdown_watchdog` (5 pass, incl. the two new/tightened tests), `process_report` (3 pass), `cmd_server` (11 pass).
- `cargo clippy -p aionui-app -- -D warnings` clean; `cargo fmt -p aionui-app -- --check` clean.
- The const assert compiles with the new 25s stage sum vs 30s watchdog.