### PR TITLE
fix(app): keep backend_binary_path cmd.exe-launchable on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "dunce",
  "futures-util",
  "git2",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ dirs = "6"
 regex = "1"
 
 # File system
+dunce = "1"
 include_dir = "0.7"
 notify = "8"
 walkdir = "2"

--- a/crates/aionui-app/Cargo.toml
+++ b/crates/aionui-app/Cargo.toml
@@ -45,6 +45,7 @@ aion-config.workspace = true
 axum.workspace = true
 chrono.workspace = true
 dirs.workspace = true
+dunce.workspace = true
 tokio.workspace = true
 uuid.workspace = true
 tower.workspace = true

--- a/crates/aionui-app/src/services.rs
+++ b/crates/aionui-app/src/services.rs
@@ -110,7 +110,14 @@ impl AppServices {
         config: &AppConfig,
         backend_binary_path: PathBuf,
     ) -> anyhow::Result<Self> {
-        let backend_binary_path = backend_binary_path.canonicalize().unwrap_or(backend_binary_path);
+        // `dunce`, not `std::fs`: this path is embedded into agent-facing config
+        // files (e.g. antigravity's `.agents/hooks.json` command line, executed
+        // through cmd.exe on Windows), and `std::fs::canonicalize` on Windows
+        // returns a `\\?\`-prefixed verbatim path that cmd.exe cannot launch.
+        // `dunce::canonicalize` resolves symlinks the same way but keeps the
+        // plain drive-letter form whenever the path is representable without
+        // the prefix.
+        let backend_binary_path = dunce::canonicalize(&backend_binary_path).unwrap_or(backend_binary_path);
         let data_dir = config.data_dir.clone();
         let work_dir = config.work_dir.clone();
         let identity_mode = config.effective_identity_mode();
@@ -418,6 +425,34 @@ mod tests {
         let services = AppServices::from_config(db, &config).await.unwrap();
 
         assert_eq!(services.app_version, "9.9.9");
+
+        services.database.close().await;
+    }
+
+    #[tokio::test]
+    async fn backend_binary_path_never_carries_a_windows_verbatim_prefix() {
+        // The resolved path is embedded into agent-facing config files —
+        // antigravity's `.agents/hooks.json` command line is executed through
+        // cmd.exe on Windows, which cannot launch `\\?\`-prefixed programs
+        // (iOfficeAI/AionUi#4095). `std::fs::canonicalize` returns exactly
+        // that form on Windows, so the constructor must keep the plain
+        // drive-letter form while still resolving symlinks.
+        let db = aionui_db::init_database_memory().await.unwrap();
+        let exe = std::env::current_exe().unwrap();
+        let services = AppServices::from_config_with_backend_binary_path(db, &AppConfig::default(), exe)
+            .await
+            .unwrap();
+
+        let resolved = services.backend_binary_path();
+        assert!(
+            resolved.is_absolute(),
+            "canonicalization must still yield an absolute path"
+        );
+        assert!(
+            !resolved.to_string_lossy().starts_with(r"\\?\"),
+            "backend binary path must stay cmd.exe-launchable, got {}",
+            resolved.display()
+        );
 
         services.database.close().await;
     }


### PR DESCRIPTION
## Problem

On Windows, any tool call in an Antigravity conversation fails with `UNKNOWN_UPSTREAM_ERROR`. Reported in iOfficeAI/AionUi#4095, and the same failure mode was independently observed for the team MCP command line in an iOfficeAI/AionUi#4062 comment.

`AppServices::from_config_with_backend_binary_path` resolves the backend binary with `std::fs::canonicalize`, which on Windows returns a `\\?\`-prefixed verbatim path. That path is embedded into agent-facing command lines:

- the Antigravity PreToolUse permission hook: `.agents/hooks.json` gets `command: "\\?\C:\...\aioncore.exe" antigravity-hook` (`antigravity_hook.rs::hooks_json_body`). The stderr in the report shows the hook command being executed through cmd.exe, which cannot launch `\\?\`-prefixed programs — so the hook fails on every tool call and the turn surfaces `UNKNOWN_UPSTREAM_ERROR`.
- the team MCP stdio server spec: `<backend_binary_path> mcp-team-stdio` (`session.rs::mcp_stdio_config` → `session_agent.rs::team_mcp_server_spec` / `acp_assembler.rs::team_mcp_server`), spawned the same way by agent CLIs — the #4062 comment shows the identical `is not recognized` failure there.

## Fix

Resolve the backend binary with `dunce::canonicalize` instead: identical symlink resolution, but it keeps the plain drive-letter form whenever the path is representable without the verbatim prefix (falling back to verbatim only where genuinely required, e.g. over-long paths). Fixing the single construction site covers every downstream consumer of `backend_binary_path`.

## Testing

- New regression test `backend_binary_path_never_carries_a_windows_verbatim_prefix` goes through the real constructor and asserts the resolved path stays absolute and free of `\\?\`. CI runs on ubuntu, where the assertion is trivially true; on Windows machines it exercises the actual regression.
- `cargo test -p aionui-app` (targeted), `cargo clippy -p aionui-app -- -D warnings`, `cargo fmt --check` all pass.