### PR TITLE
fix(antigravity): collapse agy's U+FFFD runs at text_delta joins

### DIFF
--- a/crates/aionui-session/src/backend/antigravity/conn.rs
+++ b/crates/aionui-session/src/backend/antigravity/conn.rs
@@ -110,6 +110,32 @@ fn final_turn_text(is_error: bool, result_text: &str, buffered: &str) -> Option<
         .filter(|t| !t.is_empty())
 }
 
+/// Append one `text_delta` to the turn's buffered reply, collapsing the
+/// U+FFFD run agy leaves at the join.
+///
+/// A multi-byte character agy cuts across two deltas arrives as a U+FFFD run —
+/// a suffix on one delta plus a prefix on the next — that together stand for
+/// exactly ONE lost character (measured against agy 1.1.14:
+/// samples/antigravity-cli/1.1.14/print_stream-json_long_chinese_fffd.ndjson,
+/// 49 of 49 splits are a 1+2 or 2+1 suffix/prefix pair, never mid-delta).
+/// The bytes are gone before agy serializes the frame, so the character cannot
+/// be restored — but it can be shown as one U+FFFD instead of three. Only the
+/// join case is touched: a U+FFFD away from a boundary passes through, since
+/// only the buffered fallback of a failed or cancelled turn ever renders this
+/// text (a successful turn is replaced wholesale by `result.response`).
+fn append_delta(buffered: &mut String, delta: &str) {
+    const REPLACEMENT: char = '\u{FFFD}';
+    let mut delta = delta;
+    if buffered.ends_with(REPLACEMENT) && delta.starts_with(REPLACEMENT) {
+        while buffered.ends_with(REPLACEMENT) {
+            buffered.pop();
+        }
+        delta = delta.trim_start_matches(REPLACEMENT);
+        buffered.push(REPLACEMENT);
+    }
+    buffered.push_str(delta);
+}
+
 /// agy's declared capability surface.
 pub fn antigravity_capabilities() -> Capabilities {
     Capabilities {
@@ -708,7 +734,7 @@ impl AntigravitySessionBackend {
                                 if text_item_id.is_empty() {
                                     text_item_id = item_id;
                                 }
-                                buffered_text.push_str(&text);
+                                append_delta(&mut buffered_text, &text);
                             }
                             SessionEvent::TurnResult {
                                 ref is_error,
@@ -1948,6 +1974,43 @@ mod tests {
         // A tool-only turn must not produce an empty assistant bubble.
         assert_eq!(final_turn_text(false, "", ""), None);
         assert_eq!(final_turn_text(true, "", ""), None);
+    }
+
+    #[test]
+    fn a_split_character_collapses_to_one_replacement_at_the_join() {
+        // agy 1.1.14 splits a 3-byte character into a 2-U+FFFD suffix plus a
+        // 1-U+FFFD prefix, or the 1+2 mirror (samples/antigravity-cli/1.1.14/
+        // print_stream-json_long_chinese_fffd.ndjson). One lost character must
+        // render as ONE marker, not three.
+        let mut buf = String::from("报告概述与背\u{fffd}\u{fffd}");
+        append_delta(&mut buf, "\u{fffd}\n\n在现代");
+        assert_eq!(buf, "报告概述与背\u{fffd}\n\n在现代");
+
+        let mut buf = String::from("性能\u{fffd}");
+        append_delta(&mut buf, "\u{fffd}\u{fffd}优化");
+        assert_eq!(buf, "性能\u{fffd}优化");
+    }
+
+    #[test]
+    fn a_replacement_on_only_one_side_of_the_join_is_kept() {
+        // A marker without a counterpart across the join is not a split
+        // character — it must survive untouched.
+        let mut buf = String::from("结尾\u{fffd}");
+        append_delta(&mut buf, "继续");
+        assert_eq!(buf, "结尾\u{fffd}继续");
+
+        let mut buf = String::from("结尾");
+        append_delta(&mut buf, "\u{fffd}继续");
+        assert_eq!(buf, "结尾\u{fffd}继续");
+    }
+
+    #[test]
+    fn a_replacement_away_from_the_join_passes_through() {
+        // Only join runs are collapsed; anything mid-delta is the model's own
+        // text, and the capture shows agy never mangles mid-delta.
+        let mut buf = String::from("前文");
+        append_delta(&mut buf, "中间\u{fffd}\u{fffd}还在");
+        assert_eq!(buf, "前文中间\u{fffd}\u{fffd}还在");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

iOfficeAI/AionUi#4099 reports Chinese characters intermittently corrupted to U+FFFD in Antigravity replies and persisted to the database.

The issue attributes this to aioncore splitting UTF-8 sequences across stdout read chunks in `conn.rs`. That layer is not the cause: the reader is line-buffered (`BufReader::lines()` over NDJSON), and tokio's `next_line` errors on invalid UTF-8 rather than lossy-decoding — it cannot manufacture U+FFFD. The suggested `LinesCodec` change is equivalent to what is already there.

The corruption originates inside agy itself. Captured against agy 1.1.14 with AionUi's exact argv (archived as `samples/antigravity-cli/1.1.14/print_stream-json_long_chinese_fffd.ndjson`, a 12k-char Chinese reply):

- the `text_delta` frames contain 147 U+FFFD, every single one at a delta boundary — 49 splits, each a 2+1 or 1+2 suffix/prefix pair, i.e. one lost 3-byte character rendered as three markers (matching the `\uFFFD\uFFFD\uFFFD` pattern in the report);
- the terminal `result` frame carries the same reply intact: 0 U+FFFD.

A successful turn is already unaffected: deltas are buffered, never forwarded, and replaced wholesale by `result.response` (`final_turn_text`, shipped with the first agy integration). The mangled text only survives turns that end in ERROR/INTERRUPTED or lose the process before a result frame — there the buffered deltas are the only reply that exists.

## Fix

The bytes are gone before agy serializes the frame, so the character cannot be restored on our side. What can be fixed is the markup: collapse the U+FFFD run at each delta join to a single U+FFFD while buffering, so a lost character renders as one marker instead of three on failed/cancelled turns. Only join runs are collapsed (both sides must carry the marker); mid-delta U+FFFD passes through — the capture shows agy never mangles mid-delta.

The complete fix belongs upstream in agy (cut deltas on character boundaries, or use a streaming decoder).

## Testing

- New unit tests cover the 2+1 and 1+2 join collapse, one-sided markers (kept), and mid-delta markers (kept).
- `cargo test -p aionui-session -- antigravity::conn::tests` (43 passed), `cargo clippy -p aionui-session -- -D warnings`, `cargo fmt --check` all pass.