### PR TITLE
fix(conversation): extend turn auto-replay whitelist to Aionrs

### DIFF
--- a/crates/aionui-conversation/src/turn_recovery_policy.rs
+++ b/crates/aionui-conversation/src/turn_recovery_policy.rs
@@ -36,8 +36,13 @@ impl TurnRecoveryPolicy {
         let safe_to_auto_replay = outcome.attempt.safe_to_auto_replay();
         let session_recovery_signal = classify_session_recovery_signal(outcome);
 
+        // Auto-replay is limited to agent types whose replay path is verified
+        // safe: ACP (task evicted + resume anchor refreshed before replay) and
+        // Aionrs (in-process engine kept alive — replay re-sends the prompt on
+        // the same session, exactly what a manual retry does today; see
+        // AIONUI-65). Other agent types stay manual-retry only.
         let decision = if lifecycle == RuntimeLifecycleState::Active
-            && agent_type == AgentType::Acp
+            && matches!(agent_type, AgentType::Acp | AgentType::Aionrs)
             && outcome.terminal.is_error()
             && retryable == Some(true)
             && error_code != Some(AgentErrorCode::UserLlmProviderModelNotFound)
@@ -364,8 +369,65 @@ mod tests {
     }
 
     #[test]
-    fn non_acp_agent_does_not_auto_replay() {
+    fn non_replayable_agent_types_do_not_auto_replay() {
         let outcome = retryable_clean_error();
+
+        for agent_type in [AgentType::Antigravity, AgentType::OpenclawGateway, AgentType::Nanobot] {
+            let decision = TurnRecoveryPolicy::decide(agent_type, None, &outcome, RuntimeLifecycleState::Active, false);
+
+            assert_eq!(
+                decision,
+                TurnRecoveryDecision::None,
+                "agent_type {agent_type:?} must not auto-replay"
+            );
+        }
+    }
+
+    #[test]
+    fn retryable_clean_aionrs_error_auto_replays_once() {
+        let outcome = retryable_clean_error();
+
+        let decision =
+            TurnRecoveryPolicy::decide(AgentType::Aionrs, None, &outcome, RuntimeLifecycleState::Active, false);
+
+        assert_eq!(
+            decision,
+            TurnRecoveryDecision::AutoReplayOnce {
+                reason: AgentKillReason::AgentErrorRecovery,
+                safe_to_auto_replay: true,
+                session_recovery_signal: None,
+            }
+        );
+    }
+
+    #[test]
+    fn aionrs_visible_output_blocks_auto_replay() {
+        let mut outcome = retryable_clean_error();
+        outcome.attempt.saw_visible_output = true;
+
+        let decision =
+            TurnRecoveryPolicy::decide(AgentType::Aionrs, None, &outcome, RuntimeLifecycleState::Active, false);
+
+        assert_eq!(decision, TurnRecoveryDecision::None);
+    }
+
+    #[test]
+    fn aionrs_already_replayed_error_does_not_replay_again() {
+        let outcome = retryable_clean_error();
+
+        let decision =
+            TurnRecoveryPolicy::decide(AgentType::Aionrs, None, &outcome, RuntimeLifecycleState::Active, true);
+
+        assert_eq!(decision, TurnRecoveryDecision::None);
+    }
+
+    #[test]
+    fn aionrs_non_retryable_error_does_not_auto_replay() {
+        let mut outcome = retryable_clean_error();
+        outcome.terminal = RelayTerminal::Error {
+            code: Some(AgentErrorCode::UnknownUpstreamError),
+            retryable: None,
+        };
 
         let decision =
             TurnRecoveryPolicy::decide(AgentType::Aionrs, None, &outcome, RuntimeLifecycleState::Active, false);


### PR DESCRIPTION
## Summary

Aionrs (built-in Aion CLI) turns that fail mid-turn on transient upstream errors (gateway overload, 429/502/504, dropped connections) are normalized to `UNKNOWN_UPSTREAM_ERROR` with `retryable=Some(true)`, but `TurnRecoveryPolicy::decide` restricted auto-replay to `AgentType::Acp`, so every such turn ended with `decision=None` and forced the user to click Retry manually. Production logs confirm the exact pattern (`agent_type=Aionrs ... retryable=Some(true) safe_to_auto_replay=true ... decision=None`, Sentry AIONUI-DESKTOP-9S), with 12 distinct report sources and 10 recurrences across 9+ provider/gateway combinations.

This is an **intentional behavior change explicitly authorized by the Jira AIONUI-65 acceptance criteria** ("evaluate extending TurnRecoveryPolicy::decide's auto-replay condition from 'AgentType::Acp only' to AgentType::Aionrs under the existing safety gates"). The previous `non_acp_agent_does_not_auto_replay` test encoded the old conservative design and is rewritten accordingly.

## Change

- `turn_recovery_policy.rs`: agent-type gate extended from `agent_type == AgentType::Acp` to `matches!(agent_type, AgentType::Acp | AgentType::Aionrs)`.
- **All other safety gates are unchanged**: `retryable == Some(true)`, `safe_to_auto_replay` (no visible output / no tool side effects / no persisted assistant output), `!already_replayed` (replay at most once), `Active` lifecycle, model-not-found exclusion, and the provider-turn-error exclusion. All other agent types (Antigravity, OpenclawGateway, Nanobot, Remote, legacy Gemini/Codex) still never auto-replay.

## Replay-path safety for Aionrs (verified in code)

- `evict_acp_task_after_terminal_error` early-returns for non-ACP and `AgentHealthPolicy` keeps the Aionrs task alive on error, so the replay re-sends the same prompt on the same live in-process engine session — exactly what a manual Retry produces today; auto-replay only automates the click.
- `SessionContextBuilder::refresh_resume_anchor` is a documented no-op for non-ACP session kinds ("Non-ACP kinds carry no anchor").
- `TurnAttemptSummary` flags are set by the shared stream relay on normalized `AgentStreamEvent`s (Text/Thinking/ToolCall/ToolGroup), which the Aionrs agent feeds through the same broadcast channel, so the `safe_to_auto_replay` guard protects Aionrs turns identically.

## Tests

- Rewrote `non_acp_agent_does_not_auto_replay` → `non_replayable_agent_types_do_not_auto_replay` (asserts Antigravity, OpenclawGateway, Nanobot stay `None`).
- Added `retryable_clean_aionrs_error_auto_replays_once` (happy path).
- Added Aionrs negatives: visible output blocks replay, already-replayed blocks replay, non-retryable blocks replay.
- Verified: `cargo test -p aionui-conversation --lib turn_recovery` (15 passed), `cargo test -p aionui-conversation --lib auto_replay` (17 passed, includes the orchestrator-level ScriptedAgent replay tests), `cargo clippy -p aionui-conversation -- -D warnings`, `cargo fmt --all -- --check`.

## Follow-up (out of scope)

The error-classification collapse layer — where distinct upstream failures (429/502/504/connection reset) all flatten into `UNKNOWN_UPSTREAM_ERROR` — is left as a follow-up (the abandoned aionrs #140 + AionCore #496 PR pair). This PR only widens the recovery whitelist; finer-grained classification can later tighten which codes replay.

Fixes AIONUI-65 (Jira)