### PR TITLE
fix(db): repair missing messages.hidden before migration 002 (AIONUI-230)

### DIFF
--- a/crates/aionui-db/src/legacy_handoff.rs
+++ b/crates/aionui-db/src/legacy_handoff.rs
@@ -41,6 +41,16 @@ pub(crate) const LEGACY_HANDOFF_COLUMNS: &[LegacyHandoffColumn] = &[
         column: "agents_version",
         definition: "TEXT NOT NULL DEFAULT '1.0.0'",
     },
+    // AIONUI-230 (Sentry): legacy databases that never ran AionUi JS-side v22
+    // lack `messages.hidden`, and migration 002 Part D.1 reads it from the old
+    // table (`COALESCE(hidden, 0)` fails at SQL prepare time when the source
+    // column is absent), leaving startup permanently broken. Definition matches
+    // the JS v22 migration and migration 002's rebuilt-table target.
+    LegacyHandoffColumn {
+        table: "messages",
+        column: "hidden",
+        definition: "INTEGER NOT NULL DEFAULT 0",
+    },
 ];
 
 pub(crate) async fn ensure_legacy_handoff_schema(pool: &SqlitePool) -> Result<(), DbError> {
@@ -106,6 +116,7 @@ mod tests {
                 ("conversations", "pinned_at", "INTEGER"),
                 ("teams", "session_mode", "TEXT"),
                 ("teams", "agents_version", "TEXT NOT NULL DEFAULT '1.0.0'"),
+                ("messages", "hidden", "INTEGER NOT NULL DEFAULT 0"),
             ]
         );
     }
@@ -119,6 +130,11 @@ mod tests {
             ("conversations", "pinned_at"),
             ("teams", "session_mode"),
             ("teams", "agents_version"),
+            // Moved out of the documented non-contract reads below: AIONUI-230
+            // (Sentry) proved legacy databases exist that never ran the JS-side
+            // v22 migration, so migration 002's read of `messages.hidden` does
+            // hit compatible drift and must be repaired before the migrator.
+            ("messages", "hidden"),
         ];
 
         for (table, column) in repaired_by_handoff_contract {
@@ -136,7 +152,6 @@ mod tests {
         // of future migration-002 edits has an explicit contract decision
         // point instead of a hidden assumption.
         let documented_non_contract_reads = [
-            ("messages", "hidden", "AionUi v22 adds it before v23-v26 issue path"),
             (
                 "conversations",
                 "source",

--- a/crates/aionui-db/tests/legacy_handoff.rs
+++ b/crates/aionui-db/tests/legacy_handoff.rs
@@ -7,11 +7,28 @@ use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
 use sqlx::{Row, SqlitePool};
 
 async fn create_raw_legacy_backend_missing_team_session_mode(path: &Path, user_id: &str) {
+    create_raw_legacy_backend(path, user_id, true).await;
+}
+
+/// Legacy database whose `messages` table predates AionUi JS-side v22, i.e. it
+/// has no `hidden` column at all (AIONUI-230). Migration 002 Part D.1 selects
+/// `hidden` from the old table, which fails at SQL prepare time unless the
+/// legacy handoff repair adds the column first.
+async fn create_raw_legacy_backend_missing_message_hidden(path: &Path, user_id: &str) {
+    create_raw_legacy_backend(path, user_id, false).await;
+}
+
+async fn create_raw_legacy_backend(path: &Path, user_id: &str, messages_have_hidden: bool) {
     let pool = open_raw_create(path).await;
+    let messages_ddl = if messages_have_hidden {
+        "CREATE TABLE messages (id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, msg_id TEXT, type TEXT NOT NULL, content TEXT NOT NULL DEFAULT '{}', position TEXT, status TEXT, hidden INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL)"
+    } else {
+        "CREATE TABLE messages (id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, msg_id TEXT, type TEXT NOT NULL, content TEXT NOT NULL DEFAULT '{}', position TEXT, status TEXT, created_at INTEGER NOT NULL)"
+    };
     let statements = [
         "CREATE TABLE users (id TEXT PRIMARY KEY NOT NULL, username TEXT NOT NULL UNIQUE, email TEXT UNIQUE, password_hash TEXT NOT NULL, avatar_path TEXT, jwt_secret TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, last_login INTEGER)",
         "CREATE TABLE conversations (id TEXT PRIMARY KEY, user_id TEXT NOT NULL, name TEXT NOT NULL, type TEXT NOT NULL, extra TEXT NOT NULL DEFAULT '{}', model TEXT, status TEXT NOT NULL DEFAULT 'pending', source TEXT, channel_chat_id TEXT, pinned INTEGER NOT NULL DEFAULT 0, pinned_at INTEGER, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)",
-        "CREATE TABLE messages (id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, msg_id TEXT, type TEXT NOT NULL, content TEXT NOT NULL DEFAULT '{}', position TEXT, status TEXT, hidden INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL)",
+        messages_ddl,
         "CREATE TABLE assistant_sessions (id TEXT PRIMARY KEY, user_id TEXT NOT NULL, agent_type TEXT NOT NULL, conversation_id TEXT, workspace TEXT, chat_id TEXT, created_at INTEGER NOT NULL, last_activity INTEGER NOT NULL)",
         "CREATE TABLE teams (id TEXT PRIMARY KEY NOT NULL, user_id TEXT NOT NULL DEFAULT 'system_default_user', name TEXT NOT NULL, workspace TEXT NOT NULL DEFAULT '', workspace_mode TEXT NOT NULL DEFAULT 'shared', agents TEXT NOT NULL DEFAULT '[]', lead_agent_id TEXT, agents_version TEXT NOT NULL DEFAULT '1.0.0', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)",
         "CREATE TABLE mailbox (id TEXT PRIMARY KEY NOT NULL, team_id TEXT NOT NULL, to_agent_id TEXT NOT NULL, from_agent_id TEXT NOT NULL, type TEXT NOT NULL, content TEXT NOT NULL, summary TEXT, files TEXT, read INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL)",
@@ -78,6 +95,49 @@ async fn advanced_legacy_db_missing_team_session_mode_still_initializes() {
         .unwrap();
     assert_eq!(row.get::<String, _>("name"), "Legacy Team");
     assert!(row.get::<Option<String>, _>("session_mode").is_none());
+    repaired.close().await;
+}
+
+#[tokio::test]
+async fn legacy_db_missing_message_hidden_column_still_initializes() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("aionui-backend.db");
+
+    create_raw_legacy_backend_missing_message_hidden(&path, "system_default_user").await;
+
+    // Seed rows so migration 002's rebuild actually copies data through the
+    // repaired `hidden` column instead of running against empty tables.
+    let raw = open_raw_create(&path).await;
+    sqlx::query(
+        "INSERT INTO conversations (id, user_id, name, type, created_at, updated_at) VALUES ('conv_1', 'system_default_user', 'Legacy Conversation', 'gemini', 1, 1)",
+    )
+    .execute(&raw)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO messages (id, conversation_id, type, content, created_at) VALUES ('msg_1', 'conv_1', 'text', '{}', 1), ('msg_2', 'conv_1', 'text', '{}', 2)",
+    )
+    .execute(&raw)
+    .await
+    .unwrap();
+    raw.close().await;
+
+    let repaired = init_database_staged(&path).await.unwrap();
+    assert!(has_column(repaired.pool(), "messages", "hidden").await);
+
+    let rows = sqlx::query("SELECT id, hidden FROM messages ORDER BY id")
+        .fetch_all(repaired.pool())
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2, "legacy messages must survive the migration 002 rebuild");
+    for row in rows {
+        assert_eq!(
+            row.get::<i64, _>("hidden"),
+            0,
+            "repaired hidden column must default to 0 for message {}",
+            row.get::<String, _>("id")
+        );
+    }
     repaired.close().await;
 }
 


### PR DESCRIPTION
## Root Cause

Legacy databases that never ran AionUi JS-side v22 have a `messages` table without the `hidden` column. Migration 002 Part D.1 (`crates/aionui-db/migrations/002_legacy_data_normalize.sql:176-184`) rebuilds `messages` via `INSERT ... SELECT ... COALESCE(hidden, 0) ... FROM messages` — the `SELECT` references `hidden` on the old table, so when the source column is absent SQLite fails at statement prepare time with `no such column: hidden` (`COALESCE` only handles NULL values, not missing columns). The migration aborts, and startup fails permanently on every retry — Sentry shows a macOS user with all startup attempts failing and no self-recovery even after reinstalling the app bundle.

The legacy handoff repair layer (`crates/aionui-db/src/legacy_handoff.rs`, invoked from `ensure_schema_columns()` at `crates/aionui-db/src/database.rs:381` / `:519` before the sqlx migrator runs) already exists for exactly this class of drift, but its column whitelist did not include `messages.hidden` — the audit test had documented it as a non-contract read on the assumption that JS v22 always ran first, an assumption the Sentry event disproves.

## Fix

- Add `messages.hidden` (`INTEGER NOT NULL DEFAULT 0`) to `LEGACY_HANDOFF_COLUMNS` so `ensure_legacy_handoff_schema()` adds the column before migrations run. The definition matches both the JS-side v22 migration and migration 002's rebuilt-table target (`002_legacy_data_normalize.sql:171`).
- Update the audit test `migration_002_direct_legacy_reads_are_audited`: move `messages.hidden` from the documented non-contract reads into the repaired-by-contract list, with the AIONUI-230 evidence recorded in a comment.
- Add regression test `legacy_db_missing_message_hidden_column_still_initializes` (`crates/aionui-db/tests/legacy_handoff.rs`): builds a raw legacy DB whose `messages` table lacks `hidden`, seeds rows, runs full `init_database_staged`, and asserts initialization succeeds with all rows preserved and `hidden = 0`.

The migration file itself is untouched (sqlx checksum immutability).

## Test Plan

- Red/green verification: with the whitelist entry temporarily reverted, the new regression test reproduces the exact production failure — `DatabaseInitError { stage: "database.migration", source: Migration(ExecuteMigration(SqliteError "no such column: hidden", 2)) }`; with the fix it passes.
- `cargo test -p aionui-db --lib legacy_handoff` — 2 passed
- `cargo test -p aionui-db --lib migration` — 10 passed
- `cargo test -p aionui-db --test legacy_handoff` — 4 passed (3 pre-existing + new regression)
- `cargo clippy -p aionui-db -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Fixes AIONUI-230 (Jira)