### PR TITLE
fix(conversation): apply agent session titles at the relay level

### DIFF
--- a/crates/aionui-conversation/src/background_stream.rs
+++ b/crates/aionui-conversation/src/background_stream.rs
@@ -127,17 +127,20 @@ impl BackgroundStreamWatcher {
                 // Instance torn down (conversation deleted / process replaced).
                 Err(broadcast::error::RecvError::Closed) => break,
             };
-            // Agent session titles are consumed HERE, unconditionally — the
-            // watcher is the SINGLE consumer for both backend families, and the
+            // Agent session titles are consumed HERE unconditionally — the
             // active-turn gate below must NOT apply:
             // - claude: the generate_session_title reply lands seconds AFTER the
             //   first turn's Finish (live 2026-08-04: TurnResult 07:21:33 →
             //   title frame 07:21:36) — the per-turn relay is already gone.
             // - ACP agents (pi/omp, live 2026-08-04): session_info_update fires
             //   at session-open (no turn yet) and ~1ms BEFORE the turn's Finish
-            //   — racing the relay's exit. Only a gate-free persistent consumer
-            //   catches both. apply_agent_title is guarded (name_source) and
-            //   idempotent (same-title no-op), so timing is never harmful.
+            //   — racing the relay's exit.
+            // The StreamRelay ALSO applies titles (live 2026-08-19, conv
+            // a7f2838a: a reply landing 0.6s into an orphan turn — while this
+            // watcher's receiver was lent to `run_orphan_turn` — was otherwise
+            // lost with the latch already completed). apply_agent_title is
+            // guarded (name_source) and idempotent (same-title no-op), so the
+            // watcher/relay overlap is never harmful.
             if let AgentStreamEvent::AcpSessionInfo(payload) = &ev {
                 if let Some(title) = payload
                     .get("title")
@@ -1154,6 +1157,47 @@ mod tests {
             }
         }
         assert!(saw_name_updated, "nameUpdated must be broadcast");
+    }
+
+    /// Live 2026-08-19 (conv a7f2838a): the title reply landed 0.6s AFTER the
+    /// watcher had lent its receiver to a CLI-initiated orphan turn
+    /// (`run_orphan_turn`), so the watcher's own gate-free title arm never saw
+    /// the frame — the nested relay was the only consumer, dropped it, and the
+    /// one-shot claude latch was already completed (no retry). A title frame
+    /// arriving MID-orphan-turn must still rename the conversation.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn title_arriving_mid_orphan_turn_still_renames() {
+        let rig = rig().await;
+        // Orphan-turn content first: the watcher claims the turn and hands its
+        // receiver to the nested relay before the title frame arrives.
+        rig.tx
+            .send(AgentStreamEvent::Text(TextEventData {
+                content: "background continuation".into(),
+            }))
+            .unwrap();
+        rig.tx
+            .send(AgentStreamEvent::AcpSessionInfo(serde_json::json!({
+                "title": "Fix login bug"
+            })))
+            .unwrap();
+        rig.tx
+            .send(AgentStreamEvent::Finish(FinishEventData::default()))
+            .unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        loop {
+            let row = rig.repo.get(&rig.user_id, "conv-1").await.unwrap().unwrap();
+            if row.name == "Fix login bug" {
+                assert_eq!(row.name_source.as_deref(), Some("agent"));
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "a title arriving mid-orphan-turn must still be applied, name still {:?}",
+                row.name
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
     }
 
     /// A config-options snapshot arriving BETWEEN turns must still reach the frontend.

--- a/crates/aionui-conversation/src/background_stream.rs
+++ b/crates/aionui-conversation/src/background_stream.rs
@@ -154,6 +154,7 @@ impl BackgroundStreamWatcher {
                         &self.user_id,
                         &self.conversation_id,
                         title,
+                        "watcher",
                     )
                     .await
                     {

--- a/crates/aionui-conversation/src/service.rs
+++ b/crates/aionui-conversation/src/service.rs
@@ -5844,13 +5844,18 @@ pub(crate) async fn apply_agent_title(
     user_id: &str,
     conversation_id: &str,
     title: &str,
+    // Which consumer won the frame — "watcher" (between turns) or "relay"
+    // (inside a turn, incl. the orphan-turn window). Both are valid; logging it
+    // is what makes a lost title diagnosable: the two paths were previously
+    // indistinguishable in production logs, which is why this bug hid so long.
+    consumer: &str,
 ) -> Result<bool, ConversationError> {
     let Some(existing) = repo.get(user_id, conversation_id).await? else {
-        debug!(conversation_id, "agent title dropped: conversation not found");
+        debug!(conversation_id, consumer, "agent title dropped: conversation not found");
         return Ok(false);
     };
     if existing.name_source.as_deref() == Some("user") {
-        debug!(conversation_id, "agent title dropped: name is user-owned");
+        debug!(conversation_id, consumer, "agent title dropped: name is user-owned");
         return Ok(false);
     }
     if existing.name == title {
@@ -5896,6 +5901,7 @@ pub(crate) async fn apply_agent_title(
     info!(
         conversation_id,
         title_len = title.chars().count(),
+        consumer,
         "agent session title applied"
     );
     Ok(true)

--- a/crates/aionui-conversation/src/service_test.rs
+++ b/crates/aionui-conversation/src/service_test.rs
@@ -1693,9 +1693,10 @@ async fn agent_title_applies_to_default_named_conversation() {
 
     let repo_dyn: Arc<dyn IConversationRepository> = repo.clone();
     let broadcaster_dyn: Arc<dyn EventBroadcaster> = broadcaster.clone();
-    let applied = crate::service::apply_agent_title(&repo_dyn, &broadcaster_dyn, "user_1", &id, "Fix login bug")
-        .await
-        .unwrap();
+    let applied =
+        crate::service::apply_agent_title(&repo_dyn, &broadcaster_dyn, "user_1", &id, "Fix login bug", "test")
+            .await
+            .unwrap();
 
     assert!(applied);
     let row = get_row(&repo, "user_1", &id).await;
@@ -1720,9 +1721,10 @@ async fn agent_title_overwrites_previous_agent_title() {
 
     let repo_dyn: Arc<dyn IConversationRepository> = repo.clone();
     let broadcaster_dyn: Arc<dyn EventBroadcaster> = broadcaster.clone();
-    let applied = crate::service::apply_agent_title(&repo_dyn, &broadcaster_dyn, "user_1", &id, "Newer agent title")
-        .await
-        .unwrap();
+    let applied =
+        crate::service::apply_agent_title(&repo_dyn, &broadcaster_dyn, "user_1", &id, "Newer agent title", "test")
+            .await
+            .unwrap();
 
     assert!(applied);
     assert_eq!(get_row(&repo, "user_1", &id).await.name, "Newer agent title");
@@ -1736,7 +1738,7 @@ async fn agent_title_never_overwrites_user_rename() {
 
     let repo_dyn: Arc<dyn IConversationRepository> = repo.clone();
     let broadcaster_dyn: Arc<dyn EventBroadcaster> = broadcaster.clone();
-    let applied = crate::service::apply_agent_title(&repo_dyn, &broadcaster_dyn, "user_1", &id, "Agent title")
+    let applied = crate::service::apply_agent_title(&repo_dyn, &broadcaster_dyn, "user_1", &id, "Agent title", "test")
         .await
         .unwrap();
 
@@ -1761,7 +1763,7 @@ async fn agent_title_unchanged_is_noop() {
 
     let repo_dyn: Arc<dyn IConversationRepository> = repo.clone();
     let broadcaster_dyn: Arc<dyn EventBroadcaster> = broadcaster.clone();
-    let applied = crate::service::apply_agent_title(&repo_dyn, &broadcaster_dyn, "user_1", &id, "Same title")
+    let applied = crate::service::apply_agent_title(&repo_dyn, &broadcaster_dyn, "user_1", &id, "Same title", "test")
         .await
         .unwrap();
 
@@ -1781,7 +1783,7 @@ async fn agent_title_ignores_unknown_conversation() {
 
     let repo_dyn: Arc<dyn IConversationRepository> = repo.clone();
     let broadcaster_dyn: Arc<dyn EventBroadcaster> = broadcaster.clone();
-    let applied = crate::service::apply_agent_title(&repo_dyn, &broadcaster_dyn, "user_1", "missing", "Title")
+    let applied = crate::service::apply_agent_title(&repo_dyn, &broadcaster_dyn, "user_1", "missing", "Title", "test")
         .await
         .unwrap();
 

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -163,6 +163,7 @@ pub struct StreamRelay {
     msg_id: String,
     turn_id: String,
     user_id: String,
+    repo: Arc<dyn IConversationRepository>,
     broadcaster: Arc<dyn EventBroadcaster>,
     skill_resolver: Option<Arc<dyn SkillResolver>>,
     allowed_skill_names: Vec<String>,
@@ -183,13 +184,19 @@ impl StreamRelay {
         repo: Arc<dyn IConversationRepository>,
         broadcaster: Arc<dyn EventBroadcaster>,
     ) -> Self {
-        let adapter =
-            StreamPersistenceAdapter::new(user_id.clone(), conversation_id.clone(), msg_id.clone(), repo, None);
+        let adapter = StreamPersistenceAdapter::new(
+            user_id.clone(),
+            conversation_id.clone(),
+            msg_id.clone(),
+            repo.clone(),
+            None,
+        );
         Self {
             conversation_id,
             msg_id,
             turn_id,
             user_id,
+            repo,
             broadcaster,
             skill_resolver: None,
             allowed_skill_names: Vec::new(),
@@ -663,12 +670,39 @@ impl StreamRelay {
                             // turns; inside a turn it is pure bookkeeping. Never
                             // forwarded to the WebSocket.
                         }
-                        // NOTE: AcpSessionInfo (agent session titles) is deliberately
-                        // NOT consumed here. Titles arrive at session-open and at the
-                        // turn's final instant (pi/omp race the relay's exit by ~1ms;
-                        // claude replies seconds after Finish), so the per-instance
-                        // BackgroundStreamWatcher is the single gate-free consumer.
-                        // The frame still reaches the frontend via the catch-all.
+                        // Agent session titles. The BackgroundStreamWatcher is the
+                        // between-turns consumer, but while it lends its receiver to
+                        // an orphan-turn relay THIS relay is the only consumer — live
+                        // 2026-08-19 (conv a7f2838a): claude's generate_session_title
+                        // reply landed 0.6s after a CLI-initiated turn opened, the
+                        // frame was dropped here, and the one-shot latch was already
+                        // completed (no retry) — the placeholder name stuck forever.
+                        // apply_agent_title is idempotent (same-title no-op) and
+                        // name_source-guarded, so watcher+relay double-apply is safe.
+                        AgentStreamEvent::AcpSessionInfo(payload) => {
+                            if let Some(title) = payload
+                                .get("title")
+                                .and_then(serde_json::Value::as_str)
+                                .map(str::trim)
+                                .filter(|t| !t.is_empty())
+                                && let Err(e) = crate::service::apply_agent_title(
+                                    &self.repo,
+                                    &self.broadcaster,
+                                    &self.user_id,
+                                    &self.conversation_id,
+                                    title,
+                                )
+                                .await
+                            {
+                                warn!(
+                                    conversation_id = %self.conversation_id,
+                                    error = %e,
+                                    "agent session title apply failed (relay)"
+                                );
+                            }
+                            // The raw frame still reaches the frontend via message.stream.
+                            self.forward_to_websocket(&event);
+                        }
                         _ => {
                             self.forward_to_websocket(&event);
                         }
@@ -1197,8 +1231,15 @@ mod tests {
         }
     }
 
+    /// Live 2026-08-19 (conv a7f2838a): claude's `generate_session_title` reply
+    /// landed 0.6s after the BackgroundStreamWatcher lent its receiver to a
+    /// CLI-initiated orphan turn — the relay was the ONLY consumer of the title
+    /// frame and dropped it, and the one-shot latch was already completed, so
+    /// the conversation kept its placeholder name forever. The relay must apply
+    /// titles itself (apply_agent_title is idempotent and name_source-guarded,
+    /// so watcher+relay double-apply is a harmless no-op).
     #[tokio::test]
-    async fn acp_session_info_is_forwarded_but_never_renames_at_relay_level() {
+    async fn acp_session_info_applies_agent_title_at_relay_level() {
         let repo = Arc::new(RecordingRepo::new());
         *repo.conversation.lock().unwrap() = Some(agent_title_test_row("first message placeholder", None));
         let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
@@ -1222,15 +1263,12 @@ mod tests {
         let outcome = relay.consume(rx).await;
         assert_eq!(outcome.terminal, RelayTerminal::Finish);
 
-        // The relay must NOT rename (the BackgroundStreamWatcher is the single
-        // title consumer — relay-side apply raced its own exit and double-applied).
+        let renamed = repo.conversation_updates.lock().unwrap().iter().any(|(id, u)| {
+            id == "conv-1" && u.name.as_deref() == Some("Fix login bug") && u.name_source.as_deref() == Some("agent")
+        });
         assert!(
-            repo.conversation_updates
-                .lock()
-                .unwrap()
-                .iter()
-                .all(|(_, u)| u.name.is_none()),
-            "relay must not rename"
+            renamed,
+            "relay must apply the agent title (rename + name_source='agent')"
         );
         // The raw frame still reaches the frontend via message.stream.
         let mut saw_forward = false;
@@ -1240,6 +1278,39 @@ mod tests {
             }
         }
         assert!(saw_forward, "AcpSessionInfo frame must still be forwarded");
+    }
+
+    #[tokio::test]
+    async fn acp_session_info_never_renames_user_owned_name() {
+        let repo = Arc::new(RecordingRepo::new());
+        *repo.conversation.lock().unwrap() = Some(agent_title_test_row("my name", Some("user")));
+        let bus = Arc::new(aionui_realtime::BroadcastEventBus::new(64));
+        let (tx, _) = broadcast::channel(64);
+
+        let relay = StreamRelay::new(
+            "conv-1".into(),
+            "asst-1".into(),
+            "turn-1".into(),
+            "user-1".into(),
+            repo.clone(),
+            bus.clone(),
+        );
+        let rx = tx.subscribe();
+        tx.send(AgentStreamEvent::AcpSessionInfo(serde_json::json!({
+            "title": "Fix login bug"
+        })))
+        .unwrap();
+        tx.send(AgentStreamEvent::Finish(FinishEventData::default())).unwrap();
+        relay.consume(rx).await;
+
+        assert!(
+            repo.conversation_updates
+                .lock()
+                .unwrap()
+                .iter()
+                .all(|(_, u)| u.name.is_none()),
+            "a user-owned name must never be overwritten by an agent title"
+        );
     }
 
     #[tokio::test]

--- a/crates/aionui-conversation/src/stream_relay.rs
+++ b/crates/aionui-conversation/src/stream_relay.rs
@@ -691,6 +691,7 @@ impl StreamRelay {
                                     &self.user_id,
                                     &self.conversation_id,
                                     title,
+                                    "relay",
                                 )
                                 .await
                             {


### PR DESCRIPTION
Closes #894

## Problem

Agent session titles had a single consumer — the BackgroundStreamWatcher's gate-free arm. But when the watcher claims a CLI-initiated orphan turn (`run_orphan_turn`), it lends its broadcast receiver to a nested StreamRelay until that turn finishes, and the relay deliberately dropped `AcpSessionInfo` (only forwarding it to the WebSocket).

Live 2026-08-19 (conv `a7f2838a`): claude's `generate_session_title` reply landed 0.6s after an orphan turn opened. The title frame was consumed by the relay and dropped; the one-shot latch was already completed by the successful reply, so the #843 retry machinery (which covers lost/timeout/empty replies) never fired. The conversation kept its placeholder name forever. Conversations with background subagents almost always stream past the turn's Finish, which is exactly what opens that window during the title reply's 1–3s arrival span.

## Fix

The relay now applies titles too, through the same `apply_agent_title` free function — already idempotent (same-title no-op) and `name_source`-guarded, so the watcher/relay overlap is harmless whichever consumer sees the frame. The raw frame is still forwarded to the frontend unchanged, and user-owned names remain untouchable.

## Tests

- `stream_relay::tests::acp_session_info_applies_agent_title_at_relay_level` (new; replaces the old must-not-rename assertion, which encoded the buggy contract)
- `stream_relay::tests::acp_session_info_never_renames_user_owned_name` (new)
- `background_stream::tests::title_arriving_mid_orphan_turn_still_renames` (new; reproduces the live race — failed before the fix, passes after)
- Full `aionui-conversation` suite: 421 + integration tests all green; `cargo clippy -p aionui-conversation -- -D warnings` and `cargo fmt --check` clean.