### PR TITLE
fix(app): fall back to default log dir when custom log dir is unusable (AIONUI-231)

### DIFF
--- a/crates/aionui-app/src/bootstrap/environment.rs
+++ b/crates/aionui-app/src/bootstrap/environment.rs
@@ -26,8 +26,10 @@ pub struct ServerEnvironment {
 /// Cheap, synchronous, no IO beyond creating the log directory.
 /// All subcommands that need logging and config should call this first.
 pub fn init_environment(cli: &Cli, merged_path: &str) -> Result<ServerEnvironment, BootstrapError> {
-    let log_dir = cli.log_dir.clone().unwrap_or_else(|| cli.data_dir.join("logs"));
-    let log_guard = init_tracing(&log_dir, cli.log_level.as_deref())?;
+    // A custom --log-dir that cannot be created must not permanently brick
+    // bootstrap (AIONUI-231): init_tracing falls back to the default dir.
+    let default_log_dir = cli.data_dir.join("logs");
+    let log_guard = init_tracing(cli.log_dir.as_deref(), &default_log_dir, cli.log_level.as_deref())?;
 
     info!(
         path_segments = merged_path.split(if cfg!(windows) { ';' } else { ':' }).count(),

--- a/crates/aionui-app/src/bootstrap/tracing_init.rs
+++ b/crates/aionui-app/src/bootstrap/tracing_init.rs
@@ -86,18 +86,95 @@ pub struct LogGuards {
 
 const LOGGING_INIT_MESSAGE: &str = "failed to initialize logging";
 
-pub fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> Result<LogGuards, BootstrapError> {
-    let active_log_dir = dated_log_dir(log_dir);
+/// Outcome of picking the log root: which root is active plus, when the
+/// requested custom directory was unusable, the details needed to report the
+/// degradation once the tracing subscriber is ready.
+#[derive(Debug)]
+struct LogDirSelection {
+    root: PathBuf,
+    active_dir: PathBuf,
+    fallback: Option<LogDirFallback>,
+}
 
-    std::fs::create_dir_all(&active_log_dir).map_err(|e| {
-        BootstrapError::new(
-            BootstrapErrorCode::LoggingInitFailed,
-            "logging.dir",
-            LOGGING_INIT_MESSAGE,
-        )
-        .with_source(e)
-        .with_field("logDir", active_log_dir.display().to_string())
-    })?;
+/// Custom log-dir failure that triggered the default-dir fallback. Held until
+/// the subscriber is initialized, then emitted as a structured warn.
+#[derive(Debug)]
+struct LogDirFallback {
+    requested_dir: PathBuf,
+    error_kind: io::ErrorKind,
+}
+
+fn logging_dir_error(active_log_dir: &Path, error: io::Error) -> BootstrapError {
+    // ErrorKind is the enum name only (no path, no OS message), so it can ride
+    // the stable stderr boundary line while the raw source stays private.
+    let error_kind = format!("{:?}", error.kind());
+    BootstrapError::new(
+        BootstrapErrorCode::LoggingInitFailed,
+        "logging.dir",
+        LOGGING_INIT_MESSAGE,
+    )
+    .with_source(error)
+    .with_field("logDir", active_log_dir.display().to_string())
+    .with_field("errorKind", error_kind)
+}
+
+/// Pick the log root directory, creating today's dated partition.
+///
+/// A custom directory that cannot be created (permissions, AV interference,
+/// path occupied by a file — Jira AIONUI-231) must not permanently brick
+/// bootstrap: fall back to the default directory instead. Failure to create
+/// the default directory itself remains fatal.
+fn select_log_root(custom_log_dir: Option<&Path>, default_log_dir: &Path) -> Result<LogDirSelection, BootstrapError> {
+    if let Some(custom) = custom_log_dir
+        && custom != default_log_dir
+    {
+        let custom_active = dated_log_dir(custom);
+        match std::fs::create_dir_all(&custom_active) {
+            Ok(()) => {
+                return Ok(LogDirSelection {
+                    root: custom.to_path_buf(),
+                    active_dir: custom_active,
+                    fallback: None,
+                });
+            }
+            Err(custom_error) => {
+                let custom_kind = custom_error.kind();
+                let default_active = dated_log_dir(default_log_dir);
+                std::fs::create_dir_all(&default_active).map_err(|default_error| {
+                    logging_dir_error(&default_active, default_error)
+                        .with_field("requestedLogDir", custom.display().to_string())
+                        .with_field("requestedErrorKind", format!("{custom_kind:?}"))
+                })?;
+                return Ok(LogDirSelection {
+                    root: default_log_dir.to_path_buf(),
+                    active_dir: default_active,
+                    fallback: Some(LogDirFallback {
+                        requested_dir: custom.to_path_buf(),
+                        error_kind: custom_kind,
+                    }),
+                });
+            }
+        }
+    }
+
+    let root = custom_log_dir.unwrap_or(default_log_dir);
+    let active_dir = dated_log_dir(root);
+    std::fs::create_dir_all(&active_dir).map_err(|e| logging_dir_error(&active_dir, e))?;
+    Ok(LogDirSelection {
+        root: root.to_path_buf(),
+        active_dir,
+        fallback: None,
+    })
+}
+
+pub fn init_tracing(
+    custom_log_dir: Option<&Path>,
+    default_log_dir: &Path,
+    log_level: Option<&str>,
+) -> Result<LogGuards, BootstrapError> {
+    let selection = select_log_root(custom_log_dir, default_log_dir)?;
+    let log_dir = selection.root.as_path();
+    let active_log_dir = selection.active_dir.as_path();
 
     let console_layer = fmt::layer().with_target(true).with_filter(build_env_filter(log_level));
 
@@ -147,6 +224,19 @@ pub fn init_tracing(log_dir: &Path, log_level: Option<&str>) -> Result<LogGuards
             .with_source(e)
             .with_field("logDir", active_log_dir.display().to_string())
         })?;
+
+    if let Some(fallback) = &selection.fallback {
+        // Production-visible degradation marker (AIONUI-231): the requested
+        // custom log dir was unusable and logging continues in the default dir.
+        tracing::warn!(
+            code = "BOOTSTRAP_DEGRADED_LOG_DIR",
+            stage = "logging.dir.fallback",
+            requested_log_dir = %fallback.requested_dir.display(),
+            active_log_dir = %active_log_dir.display(),
+            error_kind = ?fallback.error_kind,
+            "custom log directory is unusable; falling back to default log directory"
+        );
+    }
 
     Ok(LogGuards {
         _backend: backend_guard,
@@ -365,5 +455,86 @@ mod tests {
             "july 3\n"
         );
         assert!(!tmp.path().join("2026/07/02/2026-07-03.aioncore.log").exists());
+    }
+
+    #[test]
+    fn select_log_root_uses_creatable_custom_dir_without_fallback() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let custom = tmp.path().join("custom-logs");
+        let default = tmp.path().join("default-logs");
+
+        let selection = select_log_root(Some(&custom), &default).expect("creatable custom dir should be selected");
+
+        assert_eq!(selection.root, custom);
+        assert!(selection.fallback.is_none());
+        assert!(selection.active_dir.starts_with(&custom));
+        assert!(selection.active_dir.is_dir());
+    }
+
+    #[test]
+    fn select_log_root_falls_back_to_default_when_custom_dir_is_unusable() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        // A file occupying the custom path makes create_dir_all fail the same
+        // way an unwritable path does (AIONUI-231 repro without root).
+        let custom = tmp.path().join("occupied");
+        std::fs::write(&custom, b"not a directory").expect("occupy custom path");
+        let default = tmp.path().join("default-logs");
+
+        let selection = select_log_root(Some(&custom), &default).expect("unusable custom dir must degrade, not fail");
+
+        assert_eq!(selection.root, default);
+        assert!(selection.active_dir.starts_with(&default));
+        assert!(selection.active_dir.is_dir());
+        let fallback = selection
+            .fallback
+            .expect("fallback details must be recorded for the warn log");
+        assert_eq!(fallback.requested_dir, custom);
+    }
+
+    #[test]
+    fn select_log_root_stays_fatal_with_error_kind_when_default_dir_is_unusable() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let default = tmp.path().join("occupied");
+        std::fs::write(&default, b"not a directory").expect("occupy default path");
+
+        let err = select_log_root(None, &default).expect_err("default dir failure must stay fatal");
+
+        assert_eq!(err.code(), BootstrapErrorCode::LoggingInitFailed);
+        assert_eq!(err.stage(), "logging.dir");
+        let stderr = err.stderr_line();
+        assert!(stderr.contains("BOOTSTRAP_LOGGING_INIT_FAILED"), "{stderr}");
+        assert!(stderr.contains("errorKind="), "{stderr}");
+    }
+
+    #[test]
+    fn select_log_root_stays_fatal_when_both_custom_and_default_dirs_are_unusable() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let custom = tmp.path().join("custom-occupied");
+        let default = tmp.path().join("default-occupied");
+        std::fs::write(&custom, b"not a directory").expect("occupy custom path");
+        std::fs::write(&default, b"not a directory").expect("occupy default path");
+
+        let err = select_log_root(Some(&custom), &default).expect_err("both dirs failing must stay fatal");
+
+        assert_eq!(err.code(), BootstrapErrorCode::LoggingInitFailed);
+        assert_eq!(err.stage(), "logging.dir");
+        let stderr = err.stderr_line();
+        assert!(stderr.contains("errorKind="), "{stderr}");
+        assert!(stderr.contains("requestedErrorKind="), "{stderr}");
+    }
+
+    /// The only test allowed to call `init_tracing`: it registers the
+    /// process-global subscriber, and a second registration would fail.
+    #[test]
+    fn init_tracing_survives_unusable_custom_dir_by_falling_back_to_default() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let custom = tmp.path().join("occupied");
+        std::fs::write(&custom, b"not a directory").expect("occupy custom path");
+        let default = tmp.path().join("default-logs");
+
+        let _guards = init_tracing(Some(&custom), &default, Some("info"))
+            .expect("bootstrap must survive an unusable custom log dir");
+
+        assert!(dated_log_dir(&default).is_dir());
     }
 }


### PR DESCRIPTION
## Problem

When the user configures a custom log directory in settings and that directory cannot be created (permissions, antivirus interference, or the path being occupied by a file), the backend fails bootstrap at its earliest stage with `BOOTSTRAP_LOGGING_INIT_FAILED stage=logging.dir` on **every subsequent startup** — the app is permanently bricked until the setting is manually cleared. On top of that, the underlying OS error is intentionally kept off the stderr boundary line (`log_source()` suppression for `LoggingInitFailed`, since no tracing subscriber exists yet), so the generic failure dialog carries nothing actionable.

Root cause: `crates/aionui-app/src/bootstrap/tracing_init.rs` (`init_tracing`) treated any `create_dir_all` failure on the resolved log dir as fatal, with no fallback. The dir is resolved in `crates/aionui-app/src/bootstrap/environment.rs` as `cli.log_dir` (custom, from `--log-dir`) or `{data_dir}/logs` (default).

Real-world instance (Sentry): user set the log dir to `E:\soft\AionUi\Logs`; the next startup and all following ones failed.

## Fix

- `init_tracing` now receives the custom dir and the default dir separately. If creating the custom dir fails, it falls back to the default dir and continues initialization; once the subscriber is ready it emits a production-visible structured warn: `code=BOOTSTRAP_DEGRADED_LOG_DIR stage=logging.dir.fallback` with the requested/active directories and the `io::ErrorKind`.
- Failure to create the **default** dir remains fatal (unchanged behavior), but the bootstrap error now carries an `errorKind` field — the `ErrorKind` enum name only, no path and no raw OS message — which rides the stable stderr boundary line. When the custom dir also failed first, the line additionally carries `requestedLogDir` / `requestedErrorKind`.
- The intentional `log_source()` suppression for `LoggingInitFailed` (raw source stays private pre-subscriber) is untouched.

## Tests

New tests in `tracing_init.rs`:
- custom dir occupied by a file → falls back to default, unit-level and end-to-end through `init_tracing` (tracing initialization succeeds)
- default dir unusable → still `LoggingInitFailed stage=logging.dir` with `errorKind=` on the boundary line
- both dirs unusable → fatal with `errorKind=` and `requestedErrorKind=`
- creatable custom dir → selected without fallback (no regression)

Verified: `cargo test -p aionui-app --bin aioncore bootstrap` (38 passed), `cargo clippy -p aionui-app -- -D warnings`, `cargo fmt --all -- --check`.

## Follow-up (out of scope)

AionUi's `classifyBackendStartupFailure` can add a dedicated classification branch for `BOOTSTRAP_LOGGING_INIT_FAILED` / the new `errorKind` field to surface actionable guidance in the failure dialog. That is a cross-repo change and intentionally not part of this PR.

Fixes AIONUI-231 (Jira)