### PR TITLE
fix(project): keep mounted targets when one fs/subscribe target fails (AIONUI-236)

### DIFF
--- a/crates/aionui-project/src/monitor/actor_test.rs
+++ b/crates/aionui-project/src/monitor/actor_test.rs
@@ -222,6 +222,80 @@ async fn subscribe_parent_escape_is_invalid_relative_path() {
     assert_eq!(reply["error"]["message"], "invalid_relative_path");
 }
 
+/// A target that resolves (phase 1) but cannot mount (phase 2) must not take the
+/// whole batch down. Mount = arm watch + read the baseline listing, so it can
+/// fail per-target for reasons that say nothing about the siblings — on a large
+/// tree, an exhausted OS watch-descriptor limit (AIONUI-236). A regular file
+/// stands in for that here: it passes lexical resolution, then fails the mount.
+#[tokio::test]
+async fn subscribe_keeps_mounted_targets_when_one_target_fails() {
+    let (mut actor, _rx, push, pe, dir, _db) = setup().await;
+    std::fs::create_dir(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src").join("main.ts"), b"x").unwrap();
+    // Resolves fine, but is not a directory → mount fails for this target only.
+    std::fs::write(dir.path().join("notadir"), b"x").unwrap();
+
+    // Failing target first, so a leading failure cannot short-circuit the batch.
+    actor
+        .dispatch_frame(
+            "1",
+            "system_default_user",
+            request(
+                4,
+                "fs/subscribe",
+                json!({"targets":[dir_ref(&pe, "notadir"), dir_ref(&pe, ""), dir_ref(&pe, "src")]}),
+            ),
+        )
+        .await;
+
+    let reply = push.last_for("1").unwrap();
+    assert!(
+        reply.get("error").is_none(),
+        "a partially mountable batch must not fail the request: {reply}"
+    );
+    let snaps = reply["result"]["snapshots"].as_array().unwrap();
+    assert_eq!(snaps.len(), 2, "both mountable targets keep their snapshot: {reply}");
+    assert_eq!(snaps[0]["target"], dir_ref(&pe, ""));
+    assert_eq!(snaps[1]["target"], dir_ref(&pe, "src"));
+    let src_names: Vec<&str> = snaps[1]["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(src_names, vec!["main.ts"]);
+}
+
+/// The degrade is only for partial success: when nothing mounts, the request
+/// still fails with the first target's error rather than replying with a
+/// silently empty snapshot list.
+#[tokio::test]
+async fn subscribe_all_targets_failing_to_mount_still_errors() {
+    let (mut actor, _rx, push, pe, dir, _db) = setup().await;
+    std::fs::write(dir.path().join("a.txt"), b"x").unwrap();
+    std::fs::write(dir.path().join("b.txt"), b"x").unwrap();
+
+    actor
+        .dispatch_frame(
+            "1",
+            "system_default_user",
+            request(
+                5,
+                "fs/subscribe",
+                json!({"targets":[dir_ref(&pe, "a.txt"), dir_ref(&pe, "b.txt")]}),
+            ),
+        )
+        .await;
+
+    let reply = push.last_for("1").unwrap();
+    assert!(reply.get("result").is_none(), "no snapshots mounted: {reply}");
+    assert_eq!(reply["error"]["code"], -32006);
+    assert_eq!(reply["error"]["message"], "provider_unavailable");
+    // The first failure identifies the batch, as it did before the degrade.
+    assert_eq!(reply["error"]["data"]["pe_id"], pe);
+    assert_eq!(reply["error"]["data"]["relative_path"], "a.txt");
+}
+
 #[tokio::test]
 async fn mkdir_then_remove_roundtrip() {
     let (mut actor, _rx, push, pe, dir, _db) = setup().await;

--- a/crates/aionui-project/src/monitor/dispatch.rs
+++ b/crates/aionui-project/src/monitor/dispatch.rs
@@ -142,8 +142,17 @@ impl FsMonitorActor {
         }
 
         // Phase 2: subscribe each; the subscribe reply carries every snapshot.
+        // Unlike phase 1 this is NOT atomic, on purpose: mounting arms an OS
+        // watch, so one target can fail for reasons that say nothing about the
+        // others (watch-descriptor limit exhausted on a large tree, a directory
+        // removed between resolve and mount). Failing the whole batch there left
+        // the client with an entirely blank explorer (AIONUI-236). Skip the
+        // failed target, keep every snapshot that did mount, and fall back to the
+        // error reply only when nothing mounted at all.
         let now = self.now();
         let mut snapshots: Vec<Value> = Vec::new();
+        let mut failed: usize = 0;
+        let mut first_failure: Option<(i64, &'static str, Value)> = None;
         for (target, canonical) in plan {
             let sub = Subscriber {
                 session: session.to_owned(),
@@ -159,18 +168,38 @@ impl FsMonitorActor {
                     }
                 }
                 Err(err) => {
+                    failed += 1;
                     let (code, message) = wire::fs_error_to_rpc(&err);
-                    tracing::warn!(session, code = message, pe_id = %target.pe_id, "fs subscribe rejected");
-                    self.push(session, wire::error(id.clone(), code, message, ref_data(&target)));
-                    return;
+                    // Degraded target — safely handled, but an operator needs the
+                    // cause: `code` is the stable protocol name the wire carries,
+                    // `reason` the provider/watcher detail that name hides.
+                    tracing::warn!(
+                        session,
+                        code = message,
+                        pe_id = %target.pe_id,
+                        rel = %target.relative_path,
+                        reason = wire::fs_error_detail(&err),
+                        "fs subscribe: target mount failed"
+                    );
+                    first_failure.get_or_insert_with(|| (code, message, ref_data(&target)));
                 }
             }
         }
+        // Nothing mounted → keep the request-level error (the first failure, as
+        // before) instead of replying with a silently empty batch.
+        if snapshots.is_empty()
+            && let Some((code, message, data)) = first_failure
+        {
+            self.push(session, wire::error(id, code, message, data));
+            return;
+        }
         // Subscription registration succeeded — lifecycle boundary (low volume).
+        // `failed` > 0 marks a degraded reply: some targets are not watched.
         tracing::info!(
             session,
             targets = target_count,
             snapshots = snapshots.len(),
+            failed,
             "fs subscribe"
         );
         self.push(session, wire::success(id, json!({ "snapshots": snapshots })));

--- a/crates/aionui-project/src/monitor/wire.rs
+++ b/crates/aionui-project/src/monitor/wire.rs
@@ -355,6 +355,27 @@ pub fn fs_error_to_rpc(err: &FsError) -> (i64, &'static str) {
     }
 }
 
+/// The underlying provider failure detail behind an [`FsError`], for logs only.
+///
+/// [`fs_error_to_rpc`] deliberately collapses several variants onto one stable
+/// protocol name (`provider_unavailable`), which drops the real cause — notably
+/// the `notify` message behind [`FsError::Io`] (e.g. an exhausted inotify watch
+/// limit). Logging this next to the protocol code keeps the wire contract
+/// unchanged while making the failure diagnosable. The absolute `uri` is
+/// intentionally left out: callers log the pe-relative identity instead.
+pub fn fs_error_detail(err: &FsError) -> &str {
+    match err {
+        FsError::Io { message, .. } => message,
+        FsError::UnsupportedScheme { scheme } => scheme,
+        // The remaining variants carry nothing beyond their protocol code and
+        // the uri, so the static text is the whole detail.
+        FsError::NotFound { .. } => "resource not found",
+        FsError::AlreadyExists { .. } => "resource already exists",
+        FsError::PermissionDenied { .. } => "permission denied",
+        FsError::NotADirectory { .. } => "not a directory",
+    }
+}
+
 #[cfg(test)]
 #[path = "wire_test.rs"]
 mod wire_test;

--- a/crates/aionui-project/src/monitor/wire_test.rs
+++ b/crates/aionui-project/src/monitor/wire_test.rs
@@ -320,3 +320,33 @@ fn fs_error_maps_to_protocol_codes() {
         (CODE_PROVIDER_UNAVAILABLE, "provider_unavailable")
     );
 }
+
+#[test]
+fn fs_error_detail_surfaces_the_cause_the_protocol_code_hides() {
+    // `Io` is the variant the protocol code flattens to `provider_unavailable`:
+    // the real cause (e.g. an exhausted inotify watch limit) only survives here.
+    assert_eq!(
+        fs_error_detail(&FsError::Io {
+            uri: "file:///x".into(),
+            message: "No space left on device (os error 28)".into(),
+        }),
+        "No space left on device (os error 28)"
+    );
+    assert_eq!(
+        fs_error_detail(&FsError::NotADirectory {
+            uri: "file:///x".into()
+        }),
+        "not a directory"
+    );
+    assert_eq!(
+        fs_error_detail(&FsError::UnsupportedScheme { scheme: "ssh".into() }),
+        "ssh"
+    );
+    // The absolute uri is deliberately not part of the detail.
+    assert!(
+        !fs_error_detail(&FsError::NotFound {
+            uri: "file:///secret/path".into()
+        })
+        .contains("secret")
+    );
+}


### PR DESCRIPTION
## Problem

The Project Explorer file tree renders completely empty on large repositories
(reported against a monorepo with 800+ directories, reproduced on 4 Linux hosts;
the reporter had already ruled out an OS-level inotify limit as the *only*
symptom, i.e. individual watches were still available).

Root cause is in the `fs/subscribe` handler, not in the OS limit itself:

- `crates/aionui-project/src/monitor/dispatch.rs:147-179` (pre-fix) — phase 2
  mounts each already-resolved target in a loop. The `Err` arm pushed a
  request-level JSON-RPC error and `return`ed, throwing away every snapshot
  already collected for the preceding targets. One unmountable directory
  therefore turned the whole batch into an error reply, and the client rendered
  an empty tree.
- `crates/aionui-project/src/runtime/tree_model.rs:221-233` — mount arms the OS
  watch first (`runtime.watcher().watch(canonical)?`) and then reads the
  baseline listing, so mounting is exactly where a per-target, environment-
  dependent failure can occur.
- `crates/aionui-project/src/runtime/local_watcher.rs:127-136` — every `notify`
  error (including `inotify_add_watch` hitting `max_user_watches`) is mapped to
  `FsError::Io { uri, message }`.
- `crates/aionui-project/src/monitor/wire.rs:344-356` — `fs_error_to_rpc`
  collapses `Io` onto the static protocol name `provider_unavailable`, and the
  warn line logged that static name as `code`. The real errno text and the
  failing directory never reached the logs, which matches the report that even
  trace-level logging showed no cause.

## Change

**Phase 2 degrades instead of aborting.** A target whose mount fails is logged
and skipped; the targets that did mount still return their snapshot, so the tree
renders degraded-but-usable rather than blank.

**Boundary preserved.** If *no* target mounts, the request still fails with the
first failure's code and `data` — the previous behaviour — rather than replying
with a silently empty snapshot list.

**Phase 1 is untouched.** Resolution/containment rejection (unknown pe, `..`
escape, unsupported scheme) stays atomic: a bad reference still fails the whole
request before anything is mounted.

**Diagnostics.** The per-target warn now carries `code` (stable protocol name),
`pe_id`, `rel`, and `reason` — the underlying provider/watcher detail, extracted
by a new diagnostic-only `wire::fs_error_detail`. The success `info` line gained
a `failed` count so a degraded reply is visible in production logs at `info`.
The absolute uri is deliberately excluded from the detail, consistent with the
existing convention of keeping absolute paths at `debug`
(`crates/aionui-project/src/monitor/actor.rs:193-199`).

`fs_error_to_rpc` is **not** modified — its `(code, message)` contract is asserted
by `monitor/wire_test.rs::fs_error_maps_to_protocol_codes` and stays byte-for-byte
identical on the wire.

## Tests

- `subscribe_keeps_mounted_targets_when_one_target_fails` — a batch of
  `[failing, root, src]` returns a non-error reply with exactly the two
  snapshots that mounted, in order. The failing target is placed first so a
  leading failure cannot short-circuit the batch.
- `subscribe_all_targets_failing_to_mount_still_errors` — all targets failing
  still produces `-32006 provider_unavailable` with the first target's
  `pe_id`/`relative_path` in `error.data`, and no `result`.
- `fs_error_detail_surfaces_the_cause_the_protocol_code_hides` — the `Io`
  message survives, the absolute uri does not.
- Phase-1 rejection tests (`subscribe_unknown_pe_is_out_of_scope`,
  `subscribe_parent_escape_is_invalid_relative_path`) unchanged and passing.

The phase-2 failure is produced by pointing a target at a regular file: it
passes lexical resolution, then fails the mount. Verified on macOS that the
watch succeeds and `read_dir` returns `NotADirectory`; that mapping lives in our
own `local_provider::map_io`, so the resulting `provider_unavailable` code is
platform-independent. The exhausted-watch-limit variant (`FsError::Io`) cannot
be induced in-process — the actor builds its runtime internally and exposes no
watcher seam — so it is covered at the unit level by the `fs_error_detail` test.

```
cargo test -p aionui-project --lib monitor::     # 80 passed
cargo test -p aionui-project --lib subscribe     # 21 passed
cargo test -p aionui-project --lib fs_error      # 2 passed
cargo clippy -p aionui-project --all-targets -- -D warnings   # clean
cargo fmt --all -- --check                                     # clean
```

## Follow-up (not in this PR)

A directory that fails to mount is still absent from the tree. A read-only
listing fallback (serving the baseline via `search.rs::walk_names` when the
watch cannot be armed, so the subtree browses but does not live-update) would
close that gap, but it changes the client-facing contract and needs product
sign-off — tracked separately.

Fixes AIONUI-236 (Jira)
