### PR TITLE
fix(extension): bound the builtin-skills materialize lock acquisition (AIONUI-168)

### DIFF
--- a/crates/aionui-extension/src/error.rs
+++ b/crates/aionui-extension/src/error.rs
@@ -71,6 +71,14 @@ pub enum ExtensionError {
     #[error("Cannot delete built-in skill: {0}")]
     BuiltinSkillDeletion(String),
 
+    /// The startup builtin-skills materialization lock was still held by
+    /// another process when the acquisition budget ran out. Distinct from a
+    /// plain IO failure so the caller (and the operator reading the boundary
+    /// line on stderr) can tell "a peer is materializing" apart from "the
+    /// filesystem rejected us".
+    #[error("Timed out after {waited_ms}ms waiting for the builtin skills materialize lock at {lock_path}")]
+    BuiltinSkillsLockTimeout { lock_path: String, waited_ms: u64 },
+
     #[error("Skill not found: {0}")]
     SkillNotFound(String),
 

--- a/crates/aionui-extension/src/routes.rs
+++ b/crates/aionui-extension/src/routes.rs
@@ -51,6 +51,15 @@ impl From<ExtensionError> for ApiError {
             ExtensionError::BuiltinSkillDeletion(name) => {
                 ApiError::BadRequest(format!("Cannot delete built-in skill: {name}"))
             }
+            // Transient: a peer process owns the materialize lock. The lock
+            // path stays out of the response body — it is already logged and
+            // reported on the startup boundary line.
+            ExtensionError::BuiltinSkillsLockTimeout { .. } => ApiError::coded(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "BUILTIN_SKILLS_LOCK_TIMEOUT",
+                "Builtin skills are being updated by another process. Try again shortly.",
+                None,
+            ),
             ExtensionError::SkillNotFound(name) => ApiError::NotFound(format!("Skill not found: {name}")),
             ExtensionError::InvalidSkillPath(path) => ApiError::BadRequest(format!("Invalid skill path: {path}")),
             ExtensionError::SkillInvalidFrontmatter(_) => ApiError::coded(

--- a/crates/aionui-extension/src/startup_materialize.rs
+++ b/crates/aionui-extension/src/startup_materialize.rs
@@ -16,11 +16,11 @@
 use std::fs::OpenOptions;
 use std::future::Future;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use fs2::FileExt;
 use include_dir::Dir;
-use tracing::{info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::error::ExtensionError;
 
@@ -28,6 +28,28 @@ const VERSION_FILE: &str = ".version";
 const LOCK_FILE_NAME: &str = ".builtin-skills.lock";
 const STAGING_DIR_NAME: &str = ".builtin-skills.tmp";
 const OLD_DIR_NAME: &str = ".builtin-skills.old";
+
+/// Total budget for acquiring the builtin-skills materialization lock.
+///
+/// Why 15s: this lock is taken *after* the HTTP listener is bound and the
+/// `AIONCORE_LISTENING <port>` line has already been printed (aionui-app
+/// `async_main` binds the listener, then calls `init_data_layer`). So the
+/// parent process is no longer in its port-report window (60s) — it is in its
+/// `/health` polling window, which AionUi caps at 30s
+/// (`waitForHealth(port, timeoutMs = 30_000)` in
+/// `packages/web-host/src/backend-launcher.ts`) before it SIGKILLs the
+/// backend. A 15s budget sits at half of the parent's patience: long enough to
+/// ride out a peer that is legitimately mid-materialization, and short enough
+/// that a timeout still leaves ~15s for the error to surface on stderr as a
+/// parseable `BOOTSTRAP_DATA_INIT_FAILED stage=data.builtin_skills` boundary
+/// line, instead of the user getting an unexplained SIGKILL (AIONUI-168).
+const MATERIALIZE_LOCK_BUDGET: Duration = Duration::from_secs(15);
+
+/// Poll interval while a peer holds the materialize lock. 150ms makes the
+/// hand-off latency negligible against the budget while keeping the retry
+/// count around 100 for a full 15s wait.
+const MATERIALIZE_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(150);
+
 const STARTUP_FILE_RETRY_DELAYS: [Duration; 5] = [
     Duration::from_millis(50),
     Duration::from_millis(100),
@@ -265,23 +287,92 @@ struct MaterializeLockGuard {
 }
 
 impl MaterializeLockGuard {
-    async fn acquire(data_dir: &Path) -> std::io::Result<Self> {
+    async fn acquire(data_dir: &Path) -> Result<Self, ExtensionError> {
+        Self::acquire_within(data_dir, MATERIALIZE_LOCK_BUDGET).await
+    }
+
+    /// Bounded acquisition: poll `try_lock_exclusive` until `budget` elapses,
+    /// then fail with a classifiable timeout instead of blocking forever.
+    ///
+    /// A blocking `lock_exclusive` here made a contended startup look like a
+    /// hang: the process printed one line and went silent until the parent
+    /// killed it, leaving nothing to diagnose (AIONUI-168).
+    ///
+    /// `budget` is a parameter so tests can drive the timeout path in
+    /// milliseconds rather than waiting out the production budget.
+    async fn acquire_within(data_dir: &Path, budget: Duration) -> Result<Self, ExtensionError> {
         let data_dir = data_dir.to_path_buf();
-        tokio::task::spawn_blocking(move || {
+        let lock_path = data_dir.join(LOCK_FILE_NAME);
+        let open_path = lock_path.clone();
+        // Directory creation and open() are blocking syscalls; keep them off
+        // the reactor. The lock polling below is non-blocking by construction.
+        let file = tokio::task::spawn_blocking(move || {
             std::fs::create_dir_all(&data_dir)?;
-            let lock_path = data_dir.join(LOCK_FILE_NAME);
-            let file = OpenOptions::new()
+            OpenOptions::new()
                 .create(true)
                 .truncate(false)
                 .read(true)
                 .write(true)
-                .open(lock_path)?;
-            FileExt::lock_exclusive(&file)?;
-            Ok(Self { file })
+                .open(&open_path)
         })
         .await
-        .map_err(|e| std::io::Error::other(format!("builtin skills lock task failed: {e}")))?
+        .map_err(|e| std::io::Error::other(format!("builtin skills lock task failed: {e}")))??;
+
+        let started = Instant::now();
+        let mut attempts: u32 = 0;
+        loop {
+            attempts += 1;
+            match FileExt::try_lock_exclusive(&file) {
+                Ok(()) => {
+                    if attempts > 1 {
+                        info!(
+                            lock_path = %lock_path.display(),
+                            waited_ms = started.elapsed().as_millis() as u64,
+                            attempts,
+                            "acquired builtin skills materialize lock after contention"
+                        );
+                    }
+                    return Ok(Self { file });
+                }
+                // Held by a peer — keep polling until the budget runs out.
+                Err(e) if is_lock_contended(&e) => {}
+                // Anything else (EPERM, ENOLCK, unsupported filesystem, …) is
+                // not going to resolve by waiting.
+                Err(e) => return Err(ExtensionError::Io(e)),
+            }
+
+            let waited = started.elapsed();
+            if waited >= budget {
+                error!(
+                    lock_path = %lock_path.display(),
+                    waited_ms = waited.as_millis() as u64,
+                    budget_ms = budget.as_millis() as u64,
+                    attempts,
+                    "builtin skills materialize lock is still held by another process; giving up"
+                );
+                return Err(ExtensionError::BuiltinSkillsLockTimeout {
+                    lock_path: lock_path.display().to_string(),
+                    waited_ms: waited.as_millis() as u64,
+                });
+            }
+
+            debug!(
+                lock_path = %lock_path.display(),
+                waited_ms = waited.as_millis() as u64,
+                budget_ms = budget.as_millis() as u64,
+                attempts,
+                "builtin skills materialize lock is busy; retrying"
+            );
+            tokio::time::sleep(MATERIALIZE_LOCK_POLL_INTERVAL.min(budget - waited)).await;
+        }
     }
+}
+
+/// True when `error` is the platform's "already locked by someone else"
+/// signal as produced by `fs2::try_lock_exclusive` (`EWOULDBLOCK` on Unix,
+/// `ERROR_LOCK_VIOLATION` on Windows).
+fn is_lock_contended(error: &std::io::Error) -> bool {
+    error.raw_os_error() == fs2::lock_contended_error().raw_os_error()
 }
 
 impl Drop for MaterializeLockGuard {
@@ -314,4 +405,114 @@ async fn write_dir_recursive(dir: &Dir<'static>, dest: &Path) -> Result<(), Exte
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod materialize_lock_tests {
+    use super::*;
+
+    /// Uncontended acquisition must not pay any of the retry budget.
+    #[tokio::test]
+    async fn acquire_within_succeeds_immediately_when_uncontended() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let started = Instant::now();
+
+        let guard = MaterializeLockGuard::acquire_within(dir.path(), MATERIALIZE_LOCK_BUDGET)
+            .await
+            .expect("uncontended acquire must succeed");
+
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "uncontended acquire took {:?}",
+            started.elapsed()
+        );
+        assert!(dir.path().join(LOCK_FILE_NAME).exists(), "lock file must be created");
+        drop(guard);
+    }
+
+    /// Regression for AIONUI-168: with the lock held by a peer, acquisition
+    /// must give up inside its budget with a classifiable timeout instead of
+    /// blocking until the parent process kills us.
+    ///
+    /// Unix-only: this relies on `flock` locks being owned by the open file
+    /// description, so two `open()`s in the same process genuinely contend
+    /// (verified by fs2's own tests, fs2-0.4.3/src/unix.rs `lock_replace`).
+    /// The equivalent Windows guarantee is not verified here, so the test is
+    /// gated rather than left to pass vacuously.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn acquire_within_times_out_while_a_peer_holds_the_lock() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let budget = Duration::from_millis(300);
+
+        // Peer: a second open file description holding the exclusive flock.
+        let peer = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(dir.path().join(LOCK_FILE_NAME))
+            .expect("open peer lock file");
+        FileExt::lock_exclusive(&peer).expect("peer must take the lock");
+
+        let started = Instant::now();
+        let result = MaterializeLockGuard::acquire_within(dir.path(), budget).await;
+        let elapsed = started.elapsed();
+
+        match result {
+            Err(ExtensionError::BuiltinSkillsLockTimeout { lock_path, waited_ms }) => {
+                assert_eq!(lock_path, dir.path().join(LOCK_FILE_NAME).display().to_string());
+                assert!(
+                    waited_ms >= budget.as_millis() as u64,
+                    "reported wait {waited_ms}ms is shorter than the {budget:?} budget"
+                );
+            }
+            Err(other) => panic!("expected BuiltinSkillsLockTimeout, got {other:?}"),
+            Ok(_) => panic!("acquire must not succeed while a peer holds the lock"),
+        }
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "acquire blocked for {elapsed:?} instead of honouring its {budget:?} budget"
+        );
+
+        FileExt::unlock(&peer).expect("release peer lock");
+    }
+
+    /// The budget is a ceiling, not a fixed wait: once the peer releases, the
+    /// poll loop must pick the lock up rather than run out the clock.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn acquire_within_succeeds_once_the_peer_releases() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let peer = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(dir.path().join(LOCK_FILE_NAME))
+            .expect("open peer lock file");
+        FileExt::lock_exclusive(&peer).expect("peer must take the lock");
+
+        let releaser = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            FileExt::unlock(&peer).expect("release peer lock");
+        });
+
+        let started = Instant::now();
+        let guard = MaterializeLockGuard::acquire_within(dir.path(), Duration::from_secs(5))
+            .await
+            .expect("acquire must succeed after the peer releases");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed >= Duration::from_millis(200),
+            "acquire returned in {elapsed:?}, before the peer could have released"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "acquire took {elapsed:?}, i.e. it ran out the whole budget"
+        );
+        drop(guard);
+        releaser.await.expect("releaser task");
+    }
 }


### PR DESCRIPTION
## Problem

On a contended data directory, aioncore's startup went silent instead of failing.
`MaterializeLockGuard::acquire` took the builtin-skills materialization lock with the
**blocking** `fs2::FileExt::lock_exclusive` and had no timeout, retry or watchdog:

- `crates/aionui-extension/src/startup_materialize.rs:268-284` (origin/main), `lock_exclusive(&file)` at `:279`

So when a peer process held `{data_dir}/.builtin-skills.lock`, the backend printed
`materializing embedded builtin skills` and then produced nothing at all until AionUi's
health window expired and SIGKILLed it. The user got the generic "AionCore failed to
start" dialog with nothing diagnosable in the report.

**Reproduced on the origin/main binary** (`2f5edd41`): with an external process holding the
lock, aioncore was still alive 40s later, had emitted **0 bytes on stderr**, and its last
line was `materializing embedded builtin skills`.

## Fix

Poll `try_lock_exclusive` every 150ms against a bounded budget instead of blocking. On
expiry, return the new `ExtensionError::BuiltinSkillsLockTimeout { lock_path, waited_ms }`
so "a peer is materializing" is distinguishable from "the filesystem rejected us".
Non-contention lock errors (EPERM, ENOLCK, unsupported filesystem) still fail fast rather
than being retried pointlessly.

Logging follows AGENTS.md: retries at `debug`, the final give-up at `error` with
`lock_path`, `waited_ms`, `budget_ms` and `attempts`; a late but successful acquisition
logs once at `info` (production runs at `info`, so the diagnosis survives).

### Why 15s

The lock is taken **after** the HTTP listener is bound and `AIONCORE_LISTENING` has been
printed (`crates/aionui-app/src/main.rs:141-142` binds, then calls `init_data_layer`;
`crates/aionui-app/src/commands/cmd_server.rs:133` emits the line). So the applicable
parent-side window is **not** the 60s port-report timeout
(`BACKEND_PORT_REPORT_TIMEOUT_MS` in AionUi `packages/web-host/src/backend-launcher.ts:254`)
— it is the `/health` poll, capped at **30s**
(`waitForHealth(port, timeoutMs = 30_000)`, `backend-launcher.ts:926`), after which the
launcher SIGKILLs the backend (`backend-launcher.ts:882`). This also explains the "~32s of
silence" in the report: 30s of polling plus the ~1s TCP probe at `backend-launcher.ts:469`.

15s sits at half the parent's patience: long enough to ride out a peer that is legitimately
mid-materialization, short enough that the failure still reaches stderr with ~15s to spare.
Measured end to end, the contended run now fails at 18s wall clock.

## Diagnosability: already parseable, no boundary-framework change needed

Traced and then observed live — the existing chain already produces an AionUi-parseable
boundary line, so no change to the bootstrap error framework was made:

`materialize_if_needed` -> `materialize_builtin_skills`
(`crates/aionui-app/src/bootstrap/builtin_skills.rs:22`) ->
`init_data_layer` maps it to `BOOTSTRAP_DATA_INIT_FAILED` / `stage=data.builtin_skills`
(`crates/aionui-app/src/bootstrap/environment.rs:107-115`) -> `MainError::report()`
`eprintln!`s the boundary line (`crates/aionui-app/src/error.rs:17`).

Observed stderr from the fixed binary under real contention:

```
BOOTSTRAP_DATA_INIT_FAILED stage=data.builtin_skills dataDir=/tmp/aionui168-e2e: failed to initialize application data
```

Fed through AionUi's `parseBackendBoundaryError` regex (`backend-launcher.ts:360`) this
yields `{code: "BOOTSTRAP_DATA_INIT_FAILED", stage: "data.builtin_skills"}`, which the
launcher already attaches as `backendBoundaryCode` / `backendBoundaryStage`
(`backend-launcher.ts:652-653`).

## Verification

Live, on the built binary with an external process holding the flock:

- origin/main: still running at 40s, 0 bytes stderr (the reported hang)
- this branch: gives up at `waited_ms=15002` after 100 attempts, exits rc=1 in 18s with the boundary line above

Targeted gates:

```
cargo test -p aionui-extension --lib materialize_lock_tests   # 3 passed
cargo clippy -p aionui-extension --all-targets -- -D warnings # clean
cargo fmt --all -- --check                                    # clean
```

Tests: uncontended fast path (all platforms), plus two Unix-gated tests driving real flock
contention with an injected short budget — one asserting the timeout lands inside budget
with the right error shape, one asserting the budget is a ceiling (a peer releasing
mid-wait is picked up rather than running out the clock). The contention tests are
`#[cfg(unix)]` because they rely on flock locks being owned by the open file description,
which is verified for Unix by fs2's own tests (`fs2-0.4.3/src/unix.rs` `lock_replace`);
the equivalent Windows guarantee was not verified, so the tests are gated rather than left
to pass vacuously.

## Out of scope / follow-ups

- Carrying `exitCode` / `signal` / `stderrTail` into the AionUi feedback report is a
  cross-repo change and is deliberately not in this PR.
- The AIONUI-117 staging -> target rename retry path is untouched.
- Possible future refinement: on lock timeout, degrade to the existing on-disk tree when it
  looks usable (as the post-materialize failure path already does) instead of failing
  startup. Left out here to keep this change to "make the hang bounded and diagnosable".

Fixes AIONUI-168 (Jira)
