### PR TITLE
fix(runtime): log npm/npx probe stderr and missing-executable snapshot (AIONUI-62)

### DIFF
--- a/crates/aionui-runtime/src/node_runtime/managed.rs
+++ b/crates/aionui-runtime/src/node_runtime/managed.rs
@@ -35,6 +35,10 @@ const MANAGED_NODE_ACTIVATION_COPY_BACKOFFS: [Duration; 3] = [
     Duration::from_millis(500),
     Duration::from_millis(1000),
 ];
+// Cap on directory entry names sampled into the missing-executable diagnostic log.
+// A healthy managed Node bin/ holds only a handful of entries, so 20 is enough to show
+// whether the copy landed at all while keeping an unexpected directory out of the log.
+const MISSING_EXECUTABLE_SAMPLE_LIMIT: usize = 20;
 
 #[derive(Debug, Clone, Copy)]
 struct PlatformSpec {
@@ -301,6 +305,19 @@ fn runtime_from_root_for_layout(
 
     let node_path = managed_node_path_for_layout(root, layout);
     if !node_path.is_file() {
+        // AIONUI-62: "executable missing" alone cannot distinguish a copy source that
+        // never contained the Node binary from a binary removed right after a clean copy
+        // (e.g. by antivirus). Snapshot what IS on disk. Log-only: the returned error is
+        // unchanged, because `classify_error` matches on the stringified message.
+        let parent = node_path.parent().unwrap_or(root);
+        let listing = directory_listing_sample(parent, MISSING_EXECUTABLE_SAMPLE_LIMIT);
+        warn!(
+            node_path = %node_path.display(),
+            parent_dir = %parent.display(),
+            entry_count = ?listing.entry_count,
+            entries = %listing.sample,
+            "managed node executable missing; runtime directory snapshot"
+        );
         return Err(NodeRuntimeError::managed_invalid(format!(
             "managed node executable missing: {}",
             node_path.display()
@@ -321,6 +338,44 @@ fn runtime_from_root_for_layout(
         npx_args_prefix,
         env: managed_env(root)?,
     })
+}
+
+/// Bounded snapshot of a directory's contents, used only for diagnostics.
+struct DirectoryListingSample {
+    /// `None` when the directory could not be listed at all.
+    entry_count: Option<usize>,
+    /// Human-readable, bounded entry-name sample (or a marker when unreadable).
+    sample: String,
+}
+
+/// List `dir` for diagnostics: cheap and infallible by construction — a directory that
+/// cannot be read reports itself as unreadable instead of failing the caller. Names are
+/// sorted for stable, comparable log lines and capped at `limit`.
+fn directory_listing_sample(dir: &Path, limit: usize) -> DirectoryListingSample {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return DirectoryListingSample {
+            entry_count: None,
+            sample: "<unreadable>".to_owned(),
+        };
+    };
+
+    let mut names = entries
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    names.sort();
+
+    let total = names.len();
+    let sample = if total > limit {
+        format!("{}, ...({} more)", names[..limit].join(", "), total - limit)
+    } else {
+        names.join(", ")
+    };
+
+    DirectoryListingSample {
+        entry_count: Some(total),
+        sample,
+    }
 }
 
 fn resolve_managed_entrypoint(

--- a/crates/aionui-runtime/src/node_runtime/managed/tests.rs
+++ b/crates/aionui-runtime/src/node_runtime/managed/tests.rs
@@ -701,3 +701,69 @@ fn windows_managed_runtime_fails_when_entrypoints_are_missing() {
         "unexpected error: {error}"
     );
 }
+
+#[test]
+fn directory_listing_sample_reports_unreadable_directory_without_failing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing = tmp.path().join("never-created");
+
+    let listing = directory_listing_sample(&missing, MISSING_EXECUTABLE_SAMPLE_LIMIT);
+
+    assert_eq!(listing.entry_count, None);
+    assert_eq!(listing.sample, "<unreadable>");
+}
+
+#[test]
+fn directory_listing_sample_lists_entries_sorted() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_file(&tmp.path().join("npx"));
+    write_file(&tmp.path().join("npm"));
+
+    let listing = directory_listing_sample(tmp.path(), MISSING_EXECUTABLE_SAMPLE_LIMIT);
+
+    assert_eq!(listing.entry_count, Some(2));
+    assert_eq!(listing.sample, "npm, npx");
+}
+
+#[test]
+fn directory_listing_sample_caps_the_name_sample() {
+    let tmp = tempfile::tempdir().unwrap();
+    for index in 0..25 {
+        write_file(&tmp.path().join(format!("entry-{index:02}")));
+    }
+
+    let listing = directory_listing_sample(tmp.path(), MISSING_EXECUTABLE_SAMPLE_LIMIT);
+
+    assert_eq!(listing.entry_count, Some(25));
+    assert_eq!(listing.sample.split(", ").count(), MISSING_EXECUTABLE_SAMPLE_LIMIT + 1);
+    assert!(
+        listing.sample.ends_with("...(5 more)"),
+        "capped sample must report the remainder: {}",
+        listing.sample
+    );
+    assert!(
+        listing.sample.starts_with("entry-00, entry-01,"),
+        "capped sample must keep sorted order: {}",
+        listing.sample
+    );
+}
+
+#[test]
+fn missing_managed_node_executable_error_message_is_unchanged() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("node-v24.11.0-linux-x64");
+    std::fs::create_dir_all(root.join("bin")).unwrap();
+    write_file(&root.join("bin").join("npm"));
+
+    let error = runtime_from_root_for_layout(&root, ResolvedNodeSource::Managed, ManagedNodeArchiveLayout::Unix)
+        .expect_err("missing node executable should fail");
+
+    assert_eq!(
+        error.to_string(),
+        format!(
+            "managed node executable missing: {}",
+            root.join("bin").join("node").display()
+        ),
+        "the diagnostic snapshot must not alter the message classify_error matches on"
+    );
+}

--- a/crates/aionui-runtime/src/node_runtime/mod.rs
+++ b/crates/aionui-runtime/src/node_runtime/mod.rs
@@ -310,15 +310,72 @@ where
     unreachable!("version probe retry loop always returns on the final attempt")
 }
 
+/// Character cap applied to captured child stderr before it reaches the log.
+/// `npm --version` stderr is normally empty and at worst a few lines; the cap only
+/// keeps a pathological blob (e.g. a corrupt executable dumping bytes) out of the log.
+const PROBE_STDERR_LOG_LIMIT: usize = 512;
+
+/// Flatten raw child stderr into one bounded log field: lossy UTF-8 decode (a corrupt
+/// executable can emit arbitrary bytes), collapse every whitespace run so a multi-line
+/// npm error stays a single line, then truncate to `limit` characters with a marker.
+fn sanitize_probe_stderr(stderr: &[u8], limit: usize) -> String {
+    let decoded = String::from_utf8_lossy(stderr);
+    let collapsed = decoded.split_whitespace().collect::<Vec<_>>().join(" ");
+    truncate_for_log(&collapsed, limit)
+}
+
+/// Truncate on a char boundary and record the original length, so a truncated field is
+/// never mistaken for the whole story.
+fn truncate_for_log(text: &str, limit: usize) -> String {
+    let total = text.chars().count();
+    if total <= limit {
+        return text.to_owned();
+    }
+    let head: String = text.chars().take(limit).collect();
+    format!("{head}...[truncated, {total} chars total]")
+}
+
 async fn command_version_once(command: ResolvedCommand, label: &str) -> Result<semver::Version, NodeRuntimeError> {
     let mut builder = crate::Builder::from_resolved(&command);
     builder.arg("--version");
-    let output = builder
-        .output()
-        .await
-        .map_err(|error| NodeRuntimeError::managed_invalid(format!("{label} failed to start: {error}")))?;
+
+    // AIONUI-62: the failure detail below is logged as structured fields ONLY and is
+    // deliberately kept out of the returned error message. `classify_error` (managed.rs)
+    // derives the user-facing failure kind — and its Sentry tag — by lowercased substring
+    // matching on the stringified error, and this message is embedded verbatim into
+    // "bundled Node runtime failed validation under {}: {}" (managed.rs
+    // `activate_local_runtime_source`). Appending arbitrary npm stderr there could match
+    // "timed out" / "unsupported" / "http <status>" and silently reclassify the failure.
+    //
+    // This fires once per attempt (at most VERSION_PROBE_ATTEMPTS), including the final
+    // one. `probe_command_version_with_retry` intentionally does not log the
+    // budget-exhausted verdict because its caller already warns — which left the actual
+    // recurring production shape (every attempt failing) with no captured detail at all.
+    // Logging per attempt here is what makes that case diagnosable.
+    let output = match builder.output().await {
+        Ok(output) => output,
+        Err(error) => {
+            warn!(
+                label,
+                program = %command.program.display(),
+                io_kind = ?error.kind(),
+                os_error = ?error.raw_os_error(),
+                "node runtime --version probe failed to start"
+            );
+            return Err(NodeRuntimeError::managed_invalid(format!(
+                "{label} failed to start: {error}"
+            )));
+        }
+    };
 
     if !output.status.success() {
+        warn!(
+            label,
+            program = %command.program.display(),
+            exit_code = ?output.status.code(),
+            stderr = %sanitize_probe_stderr(&output.stderr, PROBE_STDERR_LOG_LIMIT),
+            "node runtime --version probe exited unsuccessfully"
+        );
         return Err(NodeRuntimeError::managed_invalid(format!(
             "{label} exited with {}",
             output.status
@@ -616,6 +673,162 @@ mod tests {
                 Duration::from_millis(500),
                 Duration::from_millis(1000),
             ]
+        );
+    }
+
+    #[test]
+    fn sanitize_probe_stderr_returns_empty_for_no_stderr() {
+        assert_eq!(sanitize_probe_stderr(b"", PROBE_STDERR_LOG_LIMIT), "");
+        assert_eq!(sanitize_probe_stderr(b"   \n\n ", PROBE_STDERR_LOG_LIMIT), "");
+    }
+
+    #[test]
+    fn sanitize_probe_stderr_collapses_multi_line_output_into_one_line() {
+        let stderr = b"npm ERR! code ENOENT\r\nnpm ERR! syscall spawn\n\nnpm ERR! path /opt/node\n";
+
+        let sanitized = sanitize_probe_stderr(stderr, PROBE_STDERR_LOG_LIMIT);
+
+        assert_eq!(
+            sanitized,
+            "npm ERR! code ENOENT npm ERR! syscall spawn npm ERR! path /opt/node"
+        );
+        assert!(
+            !sanitized.contains('\n'),
+            "log field must stay single-line: {sanitized}"
+        );
+        assert!(
+            !sanitized.contains('\r'),
+            "log field must stay single-line: {sanitized}"
+        );
+    }
+
+    #[test]
+    fn sanitize_probe_stderr_truncates_oversized_output_with_marker() {
+        let stderr = "x".repeat(600);
+
+        let sanitized = sanitize_probe_stderr(stderr.as_bytes(), PROBE_STDERR_LOG_LIMIT);
+
+        assert!(
+            sanitized.starts_with(&"x".repeat(PROBE_STDERR_LOG_LIMIT)),
+            "truncation must keep the head: {sanitized}"
+        );
+        assert!(
+            sanitized.contains("[truncated, 600 chars total]"),
+            "truncation marker must record the original length: {sanitized}"
+        );
+    }
+
+    #[test]
+    fn sanitize_probe_stderr_handles_non_utf8_bytes_without_panicking() {
+        let sanitized = sanitize_probe_stderr(&[0xff, 0xfe, b'n', b'p', b'm'], PROBE_STDERR_LOG_LIMIT);
+
+        assert_eq!(sanitized, "\u{fffd}\u{fffd}npm");
+    }
+
+    #[test]
+    fn truncate_for_log_keeps_char_boundaries() {
+        let text = "ünïcødé";
+
+        let truncated = truncate_for_log(text, 3);
+
+        assert!(truncated.starts_with("ünï"), "must cut on char boundaries: {truncated}");
+        assert!(
+            truncated.contains("[truncated, 7 chars total]"),
+            "must report the char length, not the byte length: {truncated}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn failed_version_probe_logs_stderr_but_keeps_error_message_clean() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let script = tmp.path().join("npm");
+        // "unsupported" here is the hazard `classify_error` (managed.rs) would match on if
+        // stderr were ever appended to the error message.
+        write_executable(
+            &script,
+            "#!/bin/sh\nprintf 'npm ERR! code ENOENT\\nnpm ERR! unsupported\\n' >&2\nexit 7\n",
+        );
+
+        let buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let subscriber = {
+            let buffer = Arc::clone(&buffer);
+            fmt::Subscriber::builder()
+                .with_max_level(Level::WARN)
+                .with_writer(move || SharedBuf(Arc::clone(&buffer)))
+                .with_ansi(false)
+                .finish()
+        };
+
+        let error = {
+            let _guard = tracing::subscriber::set_default(subscriber);
+            command_version_once(ResolvedCommand::plain(script), "npm")
+                .await
+                .expect_err("non-zero exit must fail the probe")
+        };
+        let captured = String::from_utf8(buffer.lock().expect("lock").clone()).expect("utf8");
+
+        let message = error.to_string();
+        assert!(
+            message.starts_with("npm exited with "),
+            "error message must keep its existing shape: {message}"
+        );
+        assert!(
+            !message.contains("ENOENT") && !message.contains("unsupported"),
+            "stderr must never leak into the error message classify_error matches on: {message}"
+        );
+        assert!(
+            captured.contains("node runtime --version probe exited unsuccessfully"),
+            "missing probe failure log: {captured}"
+        );
+        assert!(
+            captured.contains("npm ERR! code ENOENT npm ERR! unsupported"),
+            "stderr detail must be captured in the log: {captured}"
+        );
+        assert!(
+            captured.contains("exit_code=Some(7)"),
+            "exit code must be captured as its own field: {captured}"
+        );
+    }
+
+    #[tokio::test]
+    async fn version_probe_spawn_failure_logs_os_error_detail() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let missing = tmp.path().join("definitely-missing-node");
+
+        let buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let subscriber = {
+            let buffer = Arc::clone(&buffer);
+            fmt::Subscriber::builder()
+                .with_max_level(Level::WARN)
+                .with_writer(move || SharedBuf(Arc::clone(&buffer)))
+                .with_ansi(false)
+                .finish()
+        };
+
+        let error = {
+            let _guard = tracing::subscriber::set_default(subscriber);
+            command_version_once(ResolvedCommand::plain(missing), "node")
+                .await
+                .expect_err("missing program must fail to start")
+        };
+        let captured = String::from_utf8(buffer.lock().expect("lock").clone()).expect("utf8");
+
+        assert!(
+            error.to_string().starts_with("node failed to start: "),
+            "error message must keep its existing shape: {error}"
+        );
+        assert!(
+            captured.contains("node runtime --version probe failed to start"),
+            "missing spawn failure log: {captured}"
+        );
+        assert!(
+            captured.contains("io_kind=NotFound"),
+            "io error kind must be captured as its own field: {captured}"
+        );
+        assert!(
+            captured.contains("os_error=Some("),
+            "raw OS error code must be captured as its own field: {captured}"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes **AC2** of AIONUI-62 — "capture and log the actual stderr/OS error detail for the failed `npm`/`npx` invocation (not just the exit code) so future cases can distinguish transient exec failures from real missing/corrupt binaries."

Status of the other acceptance criteria (already closed, nothing in this PR touches them):
- **AC1** (retry on the version probe) — closed by #771, confirmed working in production logs.
- **AC3** (renderer-side dialog reconciler) — closed by AionUi #3828.
- **AC4** — observation window, not code.

## What changed

**Primary (AC2)** — `crates/aionui-runtime/src/node_runtime/mod.rs`
- `command_version_once` now emits a structured `warn!` on both failure branches:
  - non-zero exit → `label`, `program`, `exit_code` (`output.status.code()`), and `stderr`, which was previously never read at all;
  - spawn failure → `label`, `program`, `io_kind` (`error.kind()`), `os_error` (`error.raw_os_error()`), i.e. the OS-error half of AC2 that the old `{error}` string dropped.
- `sanitize_probe_stderr` / `truncate_for_log`: lossy UTF-8 decode, whitespace collapsed to a single line, truncated at 512 chars with a `...[truncated, N chars total]` marker.
- The log lives in `command_version_once`, so it fires once per attempt (at most `VERSION_PROBE_ATTEMPTS` = 3) **including the final one**. `probe_command_version_with_retry` deliberately does not log the budget-exhausted verdict (its caller `activate_local_runtime_source` already warns), which is exactly why the recurring production shape — every attempt failing — arrives with no detail today. This is called out in a comment at the log site.

**Secondary, separate hunk** — `crates/aionui-runtime/src/node_runtime/managed.rs`
- The `"managed node executable missing"` branch of `runtime_from_root_for_layout` now warns with a snapshot of what *is* on disk: `node_path`, `parent_dir`, `entry_count`, and up to 20 sorted entry names. This is what separates "the copy source never contained node" from "node was removed right after a clean copy" (AV) for the non-self-healing population (AIONUI-DESKTOP-6B/7K).
- `directory_listing_sample` is cheap and infallible: an unreadable directory reports `entry_count=None`, `entries=<unreadable>` rather than failing the caller.
- **Reviewer note:** this second change is an explicitly-scoped extension beyond AC2 as written. If it is unwanted, it is one self-contained hunk plus its helper and three tests and can be dropped without affecting AC2.

## Why stderr goes to log fields, never into the error message

`classify_error` (`crates/aionui-runtime/src/node_runtime/managed.rs:1005-1042`) derives `NodeRuntimeFailureKind` — which drives the user-facing dialog and the Sentry tag — by **lowercased substring matching on the stringified error message**. It tests `"timed out"` (line 1013), then `parse_http_status` / `"http <digits>"` (line 1016), then `"unsupported"` (line 1019) — all **before** it reaches the `"bundled node runtime failed validation"` branch (line 1027). The probe's message is embedded verbatim into that wrapper at `crates/aionui-runtime/src/node_runtime/managed.rs:535-541` (`activate_local_runtime_source`). So appending real npm stderr — which routinely contains phrases like `network request ... timed out`, `unsupported platform`, or an HTTP status — could silently reclassify a bundled-resource-invalid failure into `Timeout` / `HttpStatus` / `UnsupportedPlatform`.

Therefore **every returned `Err(...)` message is byte-identical to before**. This is a log-only PR with zero behavior change. Two tests pin that directly:
- `failed_version_probe_logs_stderr_but_keeps_error_message_clean` runs a real child that exits 7 and writes `npm ERR! code ENOENT` / `npm ERR! unsupported` to stderr, then asserts the log contains both while the error message contains neither.
- `missing_managed_node_executable_error_message_is_unchanged` asserts the exact missing-executable message string.

The pre-existing end-to-end classification tests `transient_npm_version_failure_is_absorbed_without_failed_report` and `persistent_npm_version_failure_still_reports_bundled_resource_invalid` (real subprocesses, real npm-exit-7 fixture) still pass untouched.

## Logging discipline

Both sites are `warn` — unexpected but safely handled — and therefore visible at production's `info` level, which is required: this is precisely the data missing from production reports today. `npm --version` stderr and a directory listing are process/filesystem diagnostics, not prompts, tool IO, file contents, or secrets. The 512-char cap and the 20-name cap keep an arbitrary blob out of the log.

## Tests

New unit tests in the existing `#[cfg(test)]` modules; no existing assertion was weakened or rewritten.
- `mod.rs`: `sanitize_probe_stderr_returns_empty_for_no_stderr`, `sanitize_probe_stderr_collapses_multi_line_output_into_one_line`, `sanitize_probe_stderr_truncates_oversized_output_with_marker`, `sanitize_probe_stderr_handles_non_utf8_bytes_without_panicking`, `truncate_for_log_keeps_char_boundaries`, `failed_version_probe_logs_stderr_but_keeps_error_message_clean` (unix), `version_probe_spawn_failure_logs_os_error_detail`.
- `managed/tests.rs`: `directory_listing_sample_reports_unreadable_directory_without_failing`, `directory_listing_sample_lists_entries_sorted`, `directory_listing_sample_caps_the_name_sample`, `missing_managed_node_executable_error_message_is_unchanged`.

## Verification

Targeted runs only (no full-suite run):

```
env -u AIONUI_LOG_DIR cargo test -p aionui-runtime --lib node_runtime::
  -> ok. 57 passed; 0 failed; 45 filtered out

env -u AIONUI_LOG_DIR cargo test -p aionui-runtime --lib npm_version_failure
  -> ok. 2 passed; 0 failed  (classification path, real subprocesses)

env -u AIONUI_LOG_DIR cargo test -p aionui-runtime --lib managed_runtime
  -> ok. 14 passed; 0 failed

cargo clippy -p aionui-runtime --all-targets -- -D warnings
  -> exit 0, no warnings

cargo fmt --all -- --check
  -> exit 0
```
