### PR TITLE
test(live): make the restart test actually restart

### DIFF
--- a/crates/aionui-app/tests/live_ws_http_parity_e2e.rs
+++ b/crates/aionui-app/tests/live_ws_http_parity_e2e.rs
@@ -32,6 +32,28 @@ struct LiveApp {
     router: axum::Router,
     token: String,
     csrf: String,
+    /// Kept so a test can END this app the way a process exit would, instead of
+    /// letting the binding fall out of scope and hoping. Background tasks hold
+    /// their own Arcs into the services, so dropping `LiveApp` does NOT stop the
+    /// CLI subprocesses — the restart test proved it, by resuming while the
+    /// first app's codex was still running.
+    task_manager: std::sync::Arc<dyn aionui_ai_agent::IWorkerTaskManager>,
+}
+
+impl LiveApp {
+    /// Stop every agent this app started, and wait for the processes to go.
+    ///
+    /// The restart test needs this to mean anything: codex 0.148.0 refuses
+    /// `thread/resume` while another writer holds the thread, so resuming
+    /// against a still-live predecessor is not a restart — it is two apps
+    /// fighting over one conversation.
+    async fn shutdown(&self, conversation_ids: &[&str]) {
+        for id in conversation_ids {
+            self.task_manager
+                .kill_and_wait(id, Some(aionui_common::AgentKillReason::UserCancelTimeout))
+                .await;
+        }
+    }
 }
 
 async fn start_live_app() -> LiveApp {
@@ -75,6 +97,7 @@ async fn start_live_app_on(db: aionui_db::Database, create_user: bool) -> LiveAp
         router,
         token,
         csrf,
+        task_manager: services.worker_task_manager.clone(),
     }
 }
 
@@ -830,7 +853,7 @@ async fn run_backend_resume(backend: &str) {
     std::fs::create_dir_all(&ws_dir).unwrap();
 
     // ---- first app: tell the agent something only this conversation knows ----
-    let conv_id = {
+    let (conv_id, first_app) = {
         let app = start_live_app_on(db.clone(), true).await;
         let created = http_json(
             &app,
@@ -864,10 +887,15 @@ async fn run_backend_resume(backend: &str) {
             }
         }
         assert!(finished, "[{backend}] the first turn never finished");
-        conv_id
+        (conv_id, app)
     };
 
-    // The first app (and the CLI process it owned) is dropped here.
+    // End the first app the way a process exit would. Dropping the binding is
+    // NOT enough — background tasks hold their own Arcs into the services, so
+    // the CLI keeps running. Proven by codex 0.148.0, which refuses
+    // `thread/resume` while another writer holds the thread: the "restart" was
+    // resuming against a predecessor that had never stopped.
+    first_app.shutdown(&[&conv_id]).await;
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     // ---- second app, same database: the conversation must carry on ----


### PR DESCRIPTION
The live `resumes_after_restart` test dropped the first app’s binding and called that a restart. It is not one: background tasks hold their own `Arc`s into the services, so the CLI subprocess keeps running. The second app then resumed a conversation its predecessor still had open.

codex 0.148.0 is what exposed this. It enforces single-writer access to a thread and refuses the resume — `thread <id> already has an active writer` — where 0.146.0 tolerated two writers and the test passed by accident. Probe ordering proved the sequence: the refusal arrives *before* the first backend is dropped.

`LiveApp` now carries the task manager and offers `shutdown()`, which kills the agents and waits, the way a process exit would.

## This retracts a verdict

0.148.0 was recorded yesterday as losing conversation history on resume, which blocked the version bump. It does not. Our test was starting a second writer against a live one. The sample record under `codex-cli/0.148.0/` is corrected accordingly, and the bump can proceed once this lands.

## Verification

- `resumes_after_restart` passes 3/3 across claude, codex and agy against the real CLIs.
- With the fix, codex 0.148.0 resumes cleanly: `asked for AION-61995, got AION-61995`.
- A graceful-shutdown change to the process layer was written and tested first; once the test stopped racing itself it proved unnecessary, so it is not included here.

Test-only change.