### PR TITLE
chore(cli-version): verify codex against 0.148.0

### DIFF
--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -31,12 +31,13 @@ use crate::event::{LocalizedText, NoticeLevel};
 /// is the evidence; a schema diff or a clean changelog is not, because neither
 /// can see a behavioural regression.
 ///
-/// codex is deliberately NOT on the latest release: 0.147.0 never completes a
-/// turn (its response stream disconnects with `httpStatusCode: null`, observed
-/// three times including a back-to-back control after three clean versions), so
-/// the verified release stops at 0.146.0 until upstream fixes it.
+/// codex skips 0.147.0, which never completes a turn (its response stream
+/// disconnects with `httpStatusCode: null`, observed three times including a
+/// back-to-back control after three clean versions). 0.148.0 does complete
+/// turns and passes the suite, so the gate moves there and 0.147.0 stays
+/// unverified rather than becoming a floor anyone can install into.
 pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.235";
-pub const VERIFIED_CODEX_VERSION: &str = "0.146.0";
+pub const VERIFIED_CODEX_VERSION: &str = "0.148.0";
 pub const VERIFIED_AGY_VERSION: &str = "1.1.14";
 
 /// The verified release for a direct-CLI backend, keyed by the program name the
@@ -455,10 +456,10 @@ mod tests {
 
     #[test]
     fn components_compare_numerically_not_lexically() {
-        // The bug a string compare would introduce: "0.144.6" < "0.99.0"
-        // lexically, but 144 > 99.
+        // The bug a string compare would introduce: "0.148.0" < "0.99.0"
+        // lexically, but 148 > 99.
         assert_eq!(classify("0.99.0", VERIFIED_CODEX_VERSION), VersionVerdict::Older);
-        assert_eq!(classify("0.146.1", VERIFIED_CODEX_VERSION), VersionVerdict::Newer);
+        assert_eq!(classify("0.148.1", VERIFIED_CODEX_VERSION), VersionVerdict::Newer);
     }
 
     #[test]
@@ -551,12 +552,22 @@ mod tests {
 
     #[test]
     fn local_codex_output_is_classified_as_newer() {
-        // Real `codex --version` output on this machine (2026-08-07).
-        assert_eq!(parse_version("codex-cli 0.147.0"), Some(vec![0, 147, 0]));
-        let (level, _, localized) =
-            drift_notice("codex", "codex-cli 0.147.0", VERIFIED_CODEX_VERSION).expect("0.147.0 drifts from 0.144.6");
+        // Real `codex --version` output shape, one release above the verified
+        // one so the newer path is what gets exercised.
+        assert_eq!(parse_version("codex-cli 0.149.0"), Some(vec![0, 149, 0]));
+        let (level, _, localized) = drift_notice("codex", "codex-cli 0.149.0", VERIFIED_CODEX_VERSION)
+            .expect("0.149.0 drifts from the verified release");
         assert_eq!(level, NoticeLevel::Info);
         assert_eq!(localized.code, CODE_CLI_VERSION_NEWER);
+
+        // Literal on purpose, same as the claude case: a user actually on the
+        // verified release is told nothing, and this breaks if a bump lands
+        // without re-verifying against that exact binary.
+        assert_eq!(
+            classify("codex-cli 0.148.0", VERIFIED_CODEX_VERSION),
+            VersionVerdict::Verified
+        );
+        assert!(drift_notice("codex", "codex-cli 0.148.0", VERIFIED_CODEX_VERSION).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Moves `VERIFIED_CODEX_VERSION` from 0.146.0 to 0.148.0.

## Gates

| Gate | Result |
| --- | --- |
| A — contract | **PASS** — 349 → 380 schema files, `ServerNotification` 70 → 72, `ClientRequest` 127 → 141, nothing removed, no enum value dropped |
| B — live e2e | **PASS 11/11** against the real 0.148.0 binary |
| C — release notes | CLEAR — the only flagged item was `codex exec --full-auto`’s removal in 0.147.0, and this repo spawns `codex app-server`, never `codex exec` |

## The resume failure was ours, not codex’s

Gate B previously reported that 0.148.0 loses conversation history on resume, and that blocked this bump. It does not.

Our live restart test only dropped the first app’s binding; background tasks kept their own `Arc`s, so the CLI subprocess stayed alive. The second app then resumed a thread its predecessor still held open — which 0.148.0 refuses by design (`thread <id> already has an active writer`), and which 0.146.0 tolerated. Probe ordering confirmed the refusal arrives *before* the first backend is dropped. Once the test actually stops the first app (#905), codex 0.148.0 resumes cleanly.

A real restart is a process exit, so no user was ever affected.

## Why not 0.147.0

0.147.0 never completes a turn — its response stream disconnects with `httpStatusCode: null`, observed three times including a back-to-back control after three clean versions. Jumping to 0.148.0 keeps it from becoming an accepted floor.

## Tests

Two fixtures in `cli_version` pinned versions the constant has now passed. They were re-pointed above the new constant rather than loosened, and the newer-path test gains the literal verified-release assertion the claude test already had. `cargo test -p aionui-session --lib cli_version`: 13/13.

Depends on #905 for the live suite to reproduce this result.