### PR TITLE
fix(lark): allow null user_id in group message mentions

### DIFF
--- a/crates/aionui-channel/src/plugins/lark/types.rs
+++ b/crates/aionui-channel/src/plugins/lark/types.rs
@@ -164,11 +164,11 @@ pub(crate) struct Mention {
 #[derive(Debug, Clone, Deserialize)]
 #[allow(dead_code)]
 pub(crate) struct MentionId {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
     pub open_id: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
     pub user_id: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
     pub union_id: String,
 }
 
@@ -555,6 +555,37 @@ mod tests {
         let mentions = evt.message.mentions.unwrap();
         assert_eq!(mentions.len(), 1);
         assert_eq!(mentions[0].key, "@_user_1");
+        assert_eq!(mentions[0].name, "MyBot");
+    }
+
+    #[test]
+    fn message_event_with_null_mention_user_id_parses() {
+        let raw = json!({
+            "sender": {
+                "sender_id": { "open_id": "ou_user2", "user_id": "", "union_id": "" },
+                "sender_type": "user",
+                "tenant_key": "tk_1"
+            },
+            "message": {
+                "message_id": "om_msg3",
+                "chat_id": "oc_chat3",
+                "chat_type": "group",
+                "message_type": "text",
+                "content": "{\"text\":\"@_user_1 Hello\"}",
+                "mentions": [
+                    {
+                        "key": "@_user_1",
+                        "id": { "open_id": "ou_bot", "user_id": null, "union_id": "" },
+                        "name": "MyBot"
+                    }
+                ]
+            }
+        });
+        let evt: MessageEvent = serde_json::from_value(raw).unwrap();
+        let mentions = evt.message.mentions.unwrap();
+        assert_eq!(mentions.len(), 1);
+        assert_eq!(mentions[0].key, "@_user_1");
+        assert_eq!(mentions[0].id.user_id, ""); // null 被归一化为空字符串
         assert_eq!(mentions[0].name, "MyBot");
     }
 


### PR DESCRIPTION
Feishu group messages set mentions[].id.user_id to null when the bot is mentioned, which made serde fail to deserialize the whole MessageEvent (invalid type: null, expected a string) and silently dropped the message. Reuse the existing deserialize_nullable_string helper (already used by SenderIdContainer) for MentionId fields, and add a regression test.