### PR TITLE
feat(project): add fs/remount to rebuild stale mounts

### DIFF
--- a/crates/aionui-project/src/monitor/actor.rs
+++ b/crates/aionui-project/src/monitor/actor.rs
@@ -283,10 +283,11 @@ impl FsMonitorActor {
                             pe_id: sub.pe_id.clone(),
                             relative_path: sub.rel.clone(),
                         };
-                        // Only overflow reaches this fan-out: the subscribe reply is
-                        // returned to its caller by `shard_handle`, and no other
-                        // command yields a snapshot. So this push is always a rescan
-                        // and is tagged as one.
+                        // Only overflow reaches this fan-out: the subscribe and
+                        // remount replies are returned to their caller by
+                        // `shard_handle`, and no other command drives a snapshot
+                        // through here. So this push is always a rescan and is
+                        // tagged as one.
                         let params = wire::overflow_snapshot_params(&snapshot, &target);
                         self.push.push(&sub.session, wire::notification("fs/snapshot", params));
                     }

--- a/crates/aionui-project/src/monitor/actor_test.rs
+++ b/crates/aionui-project/src/monitor/actor_test.rs
@@ -1358,3 +1358,118 @@ async fn completion_signals_done_actor_clears_and_later_cancel_is_noop() {
         "a completed search must not be treated as in-flight by fs/searchCancel"
     );
 }
+
+// ══ remount (force-refresh a stale backend mount) ════════════════════════════
+
+/// Entry names on a wire snapshot object (`{ target, entries }`).
+fn entry_names(snapshot: &Value) -> Vec<String> {
+    snapshot["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["name"].as_str().unwrap().to_owned())
+        .collect()
+}
+
+/// The behavioral contract that motivates the feature: a re-subscribe of a
+/// still-live root serves the cached listing (so a change the watcher never
+/// delivered stays invisible), whereas `fs/remount` tears the node down and
+/// re-reads the baseline from disk.
+#[tokio::test]
+async fn remount_rereads_baseline_where_resubscribe_serves_stale_cache() {
+    let (mut actor, _rx, push, pe, dir, _db) = setup().await;
+    std::fs::write(dir.path().join("a.txt"), b"x").unwrap();
+
+    // Subscribe → mounts, baseline = [a.txt].
+    actor
+        .dispatch_frame(
+            "1",
+            "system_default_user",
+            request(1, "fs/subscribe", json!({"targets":[dir_ref(&pe, "")]})),
+        )
+        .await;
+
+    // Change the directory without letting the watcher event reach the shard
+    // (raw_rx is never drained in these dispatch-level tests) → the backend's
+    // cached listing now lags the disk, the "mount went stale" the refresh fixes.
+    std::fs::write(dir.path().join("b.txt"), b"y").unwrap();
+
+    // A re-subscribe (AlreadyLive) serves the stale cached listing → no b.txt.
+    actor
+        .dispatch_frame(
+            "1",
+            "system_default_user",
+            request(2, "fs/subscribe", json!({"targets":[dir_ref(&pe, "")]})),
+        )
+        .await;
+    let resub = push.last_for("1").unwrap();
+    assert_eq!(
+        entry_names(&resub["result"]["snapshots"][0]),
+        vec!["a.txt"],
+        "re-subscribe serves the stale cached listing: {resub}"
+    );
+
+    // Remount re-reads the baseline → b.txt now present in a normal snapshot.
+    actor
+        .dispatch_frame(
+            "1",
+            "system_default_user",
+            request(3, "fs/remount", json!({"targets":[dir_ref(&pe, "")]})),
+        )
+        .await;
+    let reply = push.last_for("1").unwrap();
+    assert_eq!(reply["id"], 3);
+    let snaps = reply["result"]["snapshots"].as_array().unwrap();
+    assert_eq!(snaps.len(), 1);
+    assert_eq!(snaps[0]["target"], dir_ref(&pe, ""));
+    let mut names = entry_names(&snaps[0]);
+    names.sort();
+    assert_eq!(
+        names,
+        vec!["a.txt", "b.txt"],
+        "remount re-read the baseline from disk: {reply}"
+    );
+    // canonical / absolute path must never leak on the wire.
+    assert!(reply.to_string().find("file://").is_none(), "no canonical uri: {reply}");
+}
+
+/// A remount of a root that is not currently watched (never subscribed, or a
+/// collapsed root) is a no-op: an empty—but successful—snapshot batch, never an
+/// error, and it must not mount the cold canonical.
+#[tokio::test]
+async fn remount_unwatched_root_returns_empty_success() {
+    let (mut actor, _rx, push, pe, dir, _db) = setup().await;
+    std::fs::write(dir.path().join("a.txt"), b"x").unwrap();
+
+    // No prior subscribe → the root is cold.
+    actor
+        .dispatch_frame(
+            "1",
+            "system_default_user",
+            request(1, "fs/remount", json!({"targets":[dir_ref(&pe, "")]})),
+        )
+        .await;
+
+    let reply = push.last_for("1").unwrap();
+    assert!(reply.get("error").is_none(), "a no-op remount is not an error: {reply}");
+    let snaps = reply["result"]["snapshots"].as_array().unwrap();
+    assert!(snaps.is_empty(), "an unwatched target contributes no snapshot: {reply}");
+}
+
+/// Phase 1 resolves atomically (like subscribe): an unresolvable pe fails the
+/// whole request rather than silently dropping the target.
+#[tokio::test]
+async fn remount_unknown_pe_is_out_of_scope() {
+    let (mut actor, _rx, push, _pe, _dir, _db) = setup().await;
+    actor
+        .dispatch_frame(
+            "1",
+            "system_default_user",
+            request(2, "fs/remount", json!({"targets":[dir_ref("pe-nope", "")]})),
+        )
+        .await;
+    let reply = push.last_for("1").unwrap();
+    assert_eq!(reply["error"]["code"], -32000);
+    assert_eq!(reply["error"]["message"], "out_of_scope");
+    assert_eq!(reply["error"]["data"]["pe_id"], "pe-nope");
+}

--- a/crates/aionui-project/src/monitor/dispatch.rs
+++ b/crates/aionui-project/src/monitor/dispatch.rs
@@ -1,8 +1,9 @@
 //! Inbound JSON-RPC dispatch for the monitor actor.
 //!
 //! Parses one inner frame, routes by `method`, and drives the runtime:
-//! `initialize` handshakes; `fs/subscribe`/`fs/unsubscribe` go through the shard
-//! (identity resolved via [`ProjectService::resolve_reference`]); the file
+//! `initialize` handshakes; `fs/subscribe`/`fs/remount`/`fs/unsubscribe` go
+//! through the shard (identity resolved via [`ProjectService::resolve_reference`]);
+//! the file
 //! commands (`fs/mkdir|createFile|remove|rename`) resolve + realpath-guard, then
 //! hit the provider directly. Responses/notifications go out via the actor's
 //! push port. Errors map to protocol codes ([`wire`]) with `pe_id`/`relative_path`
@@ -21,8 +22,8 @@ use crate::types::{FileOp, ReferenceInput, ResolvedResource};
 use super::actor::FsMonitorActor;
 use super::search::{self, ActiveSearch, SearchRoot};
 use super::wire::{
-    self, CreateFileParams, InitializeParams, MkdirParams, RemoveParams, RenameParams, ResourceRef, SearchCancelParams,
-    SearchParams, SubscribeParams, TransferParams, UnsubscribeParams,
+    self, CreateFileParams, InitializeParams, MkdirParams, RemountParams, RemoveParams, RenameParams, ResourceRef,
+    SearchCancelParams, SearchParams, SubscribeParams, TransferParams, UnsubscribeParams,
 };
 
 /// Whether a transfer keeps the source (`Copy`) or removes it after it lands
@@ -55,6 +56,7 @@ impl FsMonitorActor {
         match incoming.method.as_str() {
             "initialize" => self.handle_initialize(session, id, params),
             "fs/subscribe" => self.handle_subscribe(session, user_id, id, params).await,
+            "fs/remount" => self.handle_remount(session, user_id, id, params).await,
             "fs/unsubscribe" => self.handle_unsubscribe(session, user_id, params).await,
             "fs/mkdir" => self.handle_mkdir(session, user_id, id, params).await,
             "fs/createFile" => self.handle_create_file(session, user_id, id, params).await,
@@ -201,6 +203,106 @@ impl FsMonitorActor {
             snapshots = snapshots.len(),
             failed,
             "fs subscribe"
+        );
+        self.push(session, wire::success(id, json!({ "snapshots": snapshots })));
+    }
+
+    /// `fs/remount` (request): force a fresh mount of directories the client is
+    /// already watching, recovering from a stale backend mount (a dead watch, a
+    /// path that was removed then recreated). Unlike `fs/subscribe` this registers
+    /// no subscription — it re-arms the watch and re-reads the baseline of nodes
+    /// that are already watched, then replies with the fresh snapshots (same
+    /// `{ snapshots }` shape as subscribe, so the client applies them identically).
+    /// A target that is not currently watched is a silent no-op (it contributes no
+    /// snapshot), so a remount of a collapsed root simply returns an empty batch.
+    async fn handle_remount(&mut self, session: &str, user_id: &str, id: Option<Value>, params: Value) {
+        let Ok(parsed) = serde_json::from_value::<RemountParams>(params) else {
+            self.push(session, invalid_params(id));
+            return;
+        };
+
+        let target_count = parsed.targets.len();
+
+        // Phase 1: resolve + canonicalize every target before mutating the shard,
+        // so a bad target fails the whole request atomically (mirrors subscribe).
+        let mut plan: Vec<(ResourceRef, String)> = Vec::new();
+        for target in parsed.targets {
+            let resolved = match self.resolve(user_id, &target, FileOp::Browse).await {
+                Ok(r) => r,
+                Err((code, message)) => {
+                    tracing::warn!(session, code = message, pe_id = %target.pe_id, "fs remount rejected");
+                    self.push(session, wire::error(id.clone(), code, message, ref_data(&target)));
+                    return;
+                }
+            };
+            let canonical = match canonical::canonicalize(&resolved.resource_uri) {
+                Ok(c) => c.as_str().to_owned(),
+                Err(_) => {
+                    tracing::warn!(session, code = "provider_unavailable", pe_id = %target.pe_id, "fs remount rejected");
+                    self.push(
+                        session,
+                        wire::error(
+                            id.clone(),
+                            wire::CODE_PROVIDER_UNAVAILABLE,
+                            "provider_unavailable",
+                            ref_data(&target),
+                        ),
+                    );
+                    return;
+                }
+            };
+            plan.push((target, canonical));
+        }
+
+        // Phase 2: remount each. Like subscribe's phase 2 this is NOT atomic — one
+        // target can fail to re-read (its path was removed) while others recover
+        // fine, so skip the failed target and keep every fresh snapshot. A target
+        // that is not currently watched yields no output (a legitimate no-op, not a
+        // failure). Fall back to the error reply only when a real failure occurred
+        // and nothing was remounted.
+        let mut snapshots: Vec<Value> = Vec::new();
+        let mut failed: usize = 0;
+        let mut first_failure: Option<(i64, &'static str, Value)> = None;
+        for (target, canonical) in plan {
+            match self.shard_handle(Command::Remount { canonical }).await {
+                Ok(outputs) => {
+                    for output in outputs {
+                        if let ShardOutput::Snapshot { snapshot, .. } = output {
+                            snapshots.push(wire::snapshot_params(&snapshot, &target));
+                        }
+                    }
+                }
+                Err(err) => {
+                    failed += 1;
+                    let (code, message) = wire::fs_error_to_rpc(&err);
+                    tracing::warn!(
+                        session,
+                        code = message,
+                        pe_id = %target.pe_id,
+                        rel = %target.relative_path,
+                        reason = wire::fs_error_detail(&err),
+                        "fs remount: target re-mount failed"
+                    );
+                    first_failure.get_or_insert_with(|| (code, message, ref_data(&target)));
+                }
+            }
+        }
+        // Nothing remounted *and* something failed → surface the failure rather
+        // than a misleadingly empty success. (Empty with no failure is valid: the
+        // targets were collapsed / not watched.)
+        if snapshots.is_empty()
+            && let Some((code, message, data)) = first_failure
+        {
+            self.push(session, wire::error(id, code, message, data));
+            return;
+        }
+        // Lifecycle boundary (low volume). `failed` > 0 marks a degraded reply.
+        tracing::info!(
+            session,
+            targets = target_count,
+            snapshots = snapshots.len(),
+            failed,
+            "fs remount"
         );
         self.push(session, wire::success(id, json!({ "snapshots": snapshots })));
     }

--- a/crates/aionui-project/src/monitor/wire.rs
+++ b/crates/aionui-project/src/monitor/wire.rs
@@ -70,6 +70,15 @@ pub struct SubscribeParams {
     pub targets: Vec<ResourceRef>,
 }
 
+/// `fs/remount` params. Same shape as subscribe (`targets` are the pe-relative
+/// directories to force-remount), but it does not register subscriptions — it
+/// re-arms the watch + re-reads the baseline of directories already being
+/// watched, for recovery from a stale backend mount.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RemountParams {
+    pub targets: Vec<ResourceRef>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct UnsubscribeParams {
     pub targets: Vec<ResourceRef>,

--- a/crates/aionui-project/src/runtime/actor.rs
+++ b/crates/aionui-project/src/runtime/actor.rs
@@ -25,7 +25,11 @@ use super::tree_model::{DeltaBatch, Hint, Snapshot, TreeModel};
 use super::watcher::RawEvent;
 
 /// A command processed serially by a shard worker. `Mount`/`Unmount` are not
-/// external commands — they are internal effects of subscribe/reap.
+/// external commands — they are internal effects of subscribe/reap. `Remount` is
+/// the one exception: an explicit "the backend mount may be stale" refresh that
+/// composes unmount + mount to re-arm a possibly-dead watch and re-read the
+/// baseline (a plain re-subscribe cannot, because mount is idempotent on a live
+/// node).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Command {
     Subscribe {
@@ -37,6 +41,14 @@ pub enum Command {
         sub: Subscriber,
         canonical: String,
         now: Millis,
+    },
+    /// Force a fresh mount of an already-watched canonical: tear the node down
+    /// (drop watch + facts) and mount it again (re-arm watch, re-read baseline).
+    /// Subscriptions are untouched, so subscribers and their pe identities are
+    /// preserved. A user-driven recovery for when the backend watcher/listing has
+    /// gone stale; a no-op for a canonical that is not currently watched.
+    Remount {
+        canonical: String,
     },
     Apply {
         canonical: String,
@@ -211,6 +223,28 @@ impl Shard {
                 // TTL; the reaper unmounts later. No immediate output.
                 let _ = self.subs.unsubscribe(&sub, &canonical, now);
                 Ok(Vec::new())
+            }
+
+            Command::Remount { canonical } => {
+                // Only meaningful for a canonical we are supposed to be watching
+                // (live or warm-in-grace). Mounting a cold canonical would orphan
+                // a tree node the reaper never reclaims (reap keys off the subs
+                // registry, which has no entry for it) → skip, no output.
+                if !self.subs.is_watched(&canonical) {
+                    return Ok(Vec::new());
+                }
+                // Tear down then mount fresh: re-arm the OS watch and re-read the
+                // baseline from disk. This is what a re-subscribe cannot do —
+                // mount is idempotent on a live node, so it would serve the cached
+                // (possibly stale) listing without touching the watch. `unmount`
+                // touches only the tree, never the subscription registry, so the
+                // subscribers here are exactly those before the remount.
+                self.tree.unmount(&canonical);
+                let snapshot = self.tree.mount(&canonical).await?;
+                Ok(vec![ShardOutput::Snapshot {
+                    subscribers: self.recipients(&canonical),
+                    snapshot,
+                }])
             }
 
             Command::Apply { canonical, hint } => {

--- a/crates/aionui-project/src/runtime/actor_test.rs
+++ b/crates/aionui-project/src/runtime/actor_test.rs
@@ -445,3 +445,114 @@ async fn end_to_end_watch_change_produces_delta() {
 
     assert_eq!(delta.canonical, c);
 }
+
+// ── remount (force fresh mount of a watched canonical) ──────────────────────
+
+#[tokio::test]
+async fn remount_rereads_baseline_that_resubscribe_would_miss() {
+    // The load-bearing distinction: a re-subscribe of a live node serves the
+    // cached listing (mount is idempotent), so a change the watcher never
+    // delivered stays invisible; a remount tears the node down and re-reads it.
+    let (mut shard, dir) = real_shard(100);
+    std::fs::write(dir.path().join("a.txt"), b"x").unwrap();
+    let c = canon(dir.path()).as_str().to_owned();
+
+    shard
+        .handle(Command::Subscribe {
+            sub: sub("s1"),
+            canonical: c.clone(),
+            now: 0,
+        })
+        .await
+        .unwrap();
+
+    // Change the directory WITHOUT feeding the watcher event through the shard
+    // (the raw event lands in the dropped receiver): the tree's cached facts now
+    // lag the disk, exactly the "backend mount went stale" the refresh recovers.
+    std::fs::write(dir.path().join("b.txt"), b"y").unwrap();
+
+    // A re-subscribe (AlreadyLive) serves the cached listing → b.txt is missing.
+    let resub = shard
+        .handle(Command::Subscribe {
+            sub: sub("s1"),
+            canonical: c.clone(),
+            now: 0,
+        })
+        .await
+        .unwrap();
+    match resub.as_slice() {
+        [ShardOutput::Snapshot { snapshot, .. }] => {
+            let names: Vec<&str> = snapshot.entries.iter().map(|(n, _)| n.as_str()).collect();
+            assert_eq!(names, vec!["a.txt"], "re-subscribe serves the stale cached listing");
+        }
+        other => panic!("expected one Snapshot, got {other:?}"),
+    }
+
+    // Remount re-reads the baseline → b.txt appears; subscribers are preserved.
+    let out = shard.handle(Command::Remount { canonical: c.clone() }).await.unwrap();
+    match out.as_slice() {
+        [ShardOutput::Snapshot { subscribers, snapshot }] => {
+            assert_eq!(
+                subscribers,
+                &vec![sub("s1")],
+                "remount snapshot carries current subscribers"
+            );
+            let mut names: Vec<&str> = snapshot.entries.iter().map(|(n, _)| n.as_str()).collect();
+            names.sort();
+            assert_eq!(names, vec!["a.txt", "b.txt"], "remount re-reads the baseline from disk");
+        }
+        other => panic!("expected one Snapshot, got {other:?}"),
+    }
+    assert!(shard.is_watched(&c), "still watched after remount");
+}
+
+#[tokio::test]
+async fn remount_unwatched_canonical_is_noop() {
+    // Never subscribed → not watched. Remounting must NOT mount it (that would
+    // orphan a tree node the reaper never reclaims); it produces no output.
+    let (mut shard, dir) = real_shard(100);
+    let c = canon(dir.path()).as_str().to_owned();
+    let out = shard.handle(Command::Remount { canonical: c.clone() }).await.unwrap();
+    assert!(out.is_empty(), "remount of an unwatched canonical is a no-op");
+    assert!(!shard.is_watched(&c), "remount did not mount the cold canonical");
+}
+
+#[tokio::test]
+async fn remount_preserves_subscription_so_later_deltas_still_fan_out() {
+    // A remount must not disturb the subscription registry: after it, a change to
+    // the directory still fans a delta to the original subscriber.
+    let (mut shard, dir) = real_shard(100);
+    let c = canon(dir.path()).as_str().to_owned();
+    shard
+        .handle(Command::Subscribe {
+            sub: sub("s1"),
+            canonical: c.clone(),
+            now: 0,
+        })
+        .await
+        .unwrap();
+
+    shard.handle(Command::Remount { canonical: c.clone() }).await.unwrap();
+
+    std::fs::write(dir.path().join("new.txt"), b"x").unwrap();
+    let out = shard
+        .handle(Command::Apply {
+            canonical: c.clone(),
+            hint: Hint::ChildNames(vec!["new.txt".to_owned()]),
+        })
+        .await
+        .unwrap();
+    match out.as_slice() {
+        [ShardOutput::Delta { subscribers, delta }] => {
+            assert_eq!(subscribers, &vec![sub("s1")], "subscription survived the remount");
+            assert_eq!(
+                delta.changes,
+                vec![Change::Added {
+                    name: "new.txt".to_owned(),
+                    kind: crate::runtime::provider::Kind::File
+                }]
+            );
+        }
+        other => panic!("expected one Delta to s1, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## What

Add an `fs/remount` WebSocket request (and its `Command::Remount` runtime primitive) so a client can force the backend to **tear down and re-mount an already-watched directory** — re-arm the OS watch and re-read the baseline from disk.

## Why

The explorer's manual "refresh a root" action needs to recover a pe root whose backend mount has gone **stale**: a dead/lost watcher, or a path that was unreachable and then came back. A plain `fs/subscribe` cannot do this — `TreeModel::mount` is idempotent on a live node, so it just replays the cached (possibly stale) listing without ever touching the watch.

## How

- **`Command::Remount { canonical }`** (`runtime/actor.rs`): `unmount` then `mount` the canonical. Guarded on `is_watched` — remounting a *cold* canonical would orphan a tree node the reaper never reclaims, so an unwatched target is a silent no-op. `unmount` touches only the tree, never the subscription registry, so subscribers and their pe identities survive the remount.
- **`fs/remount` dispatch** (`monitor/dispatch.rs`): mirrors `fs/subscribe` — atomic resolve + canonicalize of every target (a bad ref fails the whole request), then a non-atomic per-target remount. Replies with the same `{ snapshots }` shape as subscribe, so the client applies the fresh snapshots identically. Errors only when nothing was remounted *and* a real failure occurred; an all-unwatched request is a valid empty success.
- Snapshots are returned in the reply via `shard_handle` (not fanned out), preserving the invariant that only an overflow rescan pushes an `fs/snapshot` notification.

## Tests

- `runtime/actor_test.rs` (3): remount re-reads a baseline a re-subscribe would miss; no-op on an unwatched canonical; subscription preserved so later deltas still fan out.
- `monitor/actor_test.rs` (3): end-to-end stale-resubscribe vs fresh-remount; unwatched → empty success; unknown pe → `out_of_scope`.
- Full crate green: `cargo test -p aionui-project` (365 unit + 15 + 27 integration), `clippy -p aionui-project --all-targets -D warnings`, `fmt --all --check`.

## Logging

- `info` — one lifecycle line per remount (targets / snapshots / failed counts, no payloads).
- `warn` — on a rejected or failed target (pe identity + protocol code + provider detail, no payloads).
- No sensitive payloads (paths kept to pe-relative identities).

## Companion PR

Frontend consumer that drives this method (root context-menu "Refresh"): https://github.com/iOfficeAI/AionUi/pull/4121

## Notes

- No live / e2e verification yet.
