### PR TITLE
[codex] fix(auth): preserve local identity mode

### DIFF
--- a/crates/aionui-auth/src/routes.rs
+++ b/crates/aionui-auth/src/routes.rs
@@ -249,11 +249,7 @@ pub fn auth_routes(state: AuthRouterState) -> Router {
     let auth_state = AuthState {
         jwt_service: state.jwt_service.clone(),
         user_repo: state.user_repo.clone(),
-        identity_mode: if state.aionpro_mode {
-            AuthIdentityMode::AionPro
-        } else {
-            AuthIdentityMode::UserSession
-        },
+        identity_mode: state.identity_mode,
         // Auth endpoints manage sessions themselves; the helper CLI never
         // calls them, so the runtime-token channel stays disabled here.
         runtime_token_verifier: None,

--- a/crates/aionui-auth/tests/route_tests.rs
+++ b/crates/aionui-auth/tests/route_tests.rs
@@ -498,6 +498,20 @@ async fn t7_3_get_user_no_token() {
     assert_eq!(json["code"], "UNAUTHORIZED");
 }
 
+#[tokio::test]
+async fn t7_4_get_user_local_mode_without_token() {
+    let (app, _ctx) = test_app_with_local(true).await;
+
+    let req = get_anonymous("/api/auth/user");
+    let resp = app.oneshot(req).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp).await;
+    assert_eq!(json["success"], true);
+    assert_eq!(json["user"]["id"], "system_default_user");
+    assert_eq!(json["user"]["username"], "system_default_user");
+}
+
 // ===========================================================================
 // T8. Change Password (POST /api/auth/change-password)
 // ===========================================================================


### PR DESCRIPTION
## Summary

- preserve the configured identity mode when building auth middleware state
- add a route-level regression test for anonymous `GET /api/auth/user` requests in local mode

## Why

`auth_routes` rebuilt the middleware identity mode from `aionpro_mode` and mapped every non-AionPro configuration to `AuthIdentityMode::UserSession`. As a result, an explicitly configured local-mode router required a JWT or session cookie and returned `401 Unauthorized` instead of using the existing `system_default_user` identity.

Passing `AuthRouterState.identity_mode` through unchanged keeps the router and middleware configuration consistent. Anonymous requests in `UserSession` mode remain unauthorized; only explicitly configured `Local` mode uses the fixed local identity.

Fixes #912

## Validation

- `cargo test -p aionui-auth` (217 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p aionui-auth -- -D warnings`
- `just push -u fork codex/preserve-local-auth-identity-mode`
  - migration immutability check passed
  - workspace Clippy and formatting gates passed
  - nextest: 8,915 passed, 50 skipped by repository configuration
