### PR TITLE
fix(auth): extend JWT TTL to 30d to match cookie

### DIFF
--- a/crates/aionui-auth/src/jwt.rs
+++ b/crates/aionui-auth/src/jwt.rs
@@ -10,8 +10,14 @@ use sha2::{Digest, Sha256};
 
 use crate::error::AuthError;
 
-/// JWT token lifetime: 24 hours.
-const TOKEN_EXPIRY: Duration = Duration::from_secs(24 * 60 * 60);
+/// JWT token lifetime: 30 days.
+///
+/// Stop-gap value aligned with the session cookie's `Max-Age`
+/// (`COOKIE_MAX_AGE_DAYS`). The cookie shell used to outlive this JWT, so after
+/// the previous 24h expiry every request carried a dead token, producing the
+/// 401/reconnect loop seen on remote WebUI. This stays long until token refresh
+/// lands, after which it returns to a short access-token lifetime.
+const TOKEN_EXPIRY: Duration = Duration::from_secs(30 * 24 * 60 * 60);
 
 /// JWT issuer claim value.
 const JWT_ISSUER: &str = "aionui";
@@ -60,7 +66,7 @@ impl JwtService {
         }
     }
 
-    /// Sign a new JWT for the given user. The token expires after 24 hours.
+    /// Sign a new JWT for the given user. The token expires after 30 days.
     pub fn sign(&self, user_id: &str, username: &str) -> Result<String, AuthError> {
         self.sign_with_session_generation(user_id, username, 0)
     }
@@ -249,6 +255,19 @@ mod tests {
     }
 
     #[test]
+    fn token_lifetime_is_30_days() {
+        // Stop-gap: the JWT lifetime is aligned with the session cookie's
+        // 30-day Max-Age so the cookie no longer outlives the token. Returns to
+        // a short lifetime once token refresh lands; updating it then is an
+        // intentional contract change, not a regression.
+        let service = test_service();
+        let token = service.sign("user_1", "admin").unwrap();
+        let payload = service.verify(&token).unwrap();
+        assert_eq!(TOKEN_EXPIRY.as_secs(), 30 * 24 * 60 * 60);
+        assert_eq!(payload.exp - payload.iat, 30 * 24 * 60 * 60);
+    }
+
+    #[test]
     fn sign_with_session_generation_roundtrip() {
         let service = test_service();
         let token = service.sign_with_session_generation("user_1", "admin", 7).unwrap();
@@ -392,7 +411,7 @@ mod tests {
         assert_eq!(service.blacklist_size(), 1);
 
         service.cleanup_blacklist();
-        // Token just signed with 24h expiry should still be in blacklist
+        // Token just signed with 30d expiry should still be in blacklist
         assert_eq!(service.blacklist_size(), 1);
     }
 

--- a/crates/aionui-common/src/constants.rs
+++ b/crates/aionui-common/src/constants.rs
@@ -26,7 +26,9 @@ pub const WS_CLOSE_POLICY_VIOLATION: u16 = 1008;
 
 // --- Authentication ---
 
-pub const SESSION_EXPIRY: &str = "24h";
+/// Human-readable session lifetime label. Currently unused; kept consistent
+/// with the real JWT/cookie lifetime (30 days).
+pub const SESSION_EXPIRY: &str = "30d";
 pub const COOKIE_NAME: &str = "aionui-session";
 pub const COOKIE_MAX_AGE_DAYS: u32 = 30;
 pub const CSRF_COOKIE_NAME: &str = "aionui-csrf-token";


### PR DESCRIPTION
## Summary

Stop-gap for iOfficeAI/AionUi#4124. On the remote WebUI (phone), once the desktop had been up for roughly a day the Core JWT expired and was never refreshed, so every request carried a dead token and the client fell into an unrecoverable 401 / WebSocket reconnect loop.

The session cookie has a 30-day `Max-Age` (`COOKIE_MAX_AGE_DAYS`), but the JWT inside it expired after 24h. That mismatch — a live cookie wrapping a dead token — is what triggered the loop. This bumps `TOKEN_EXPIRY` from 24h to 30d so the token lifetime matches the cookie, closing the window.

**This is a stop-gap, not the fix.** The real solution is a refresh-token flow (tracked separately). Once that lands, `TOKEN_EXPIRY` returns to a short access-token lifetime; the doc comment and the `token_lifetime_is_30_days` test record this so the later change is a deliberate contract update, not a silent regression.

## Changes

- **`aionui-auth/src/jwt.rs`**: `TOKEN_EXPIRY` 24h → 30d with a stop-gap doc comment; `sign()` doc updated; new `token_lifetime_is_30_days` test asserting both the constant and `exp - iat`; blacklist-test comment synced to 30d.
- **`aionui-common/src/constants.rs`**: `SESSION_EXPIRY` label `"24h"` → `"30d"` (currently unused; kept consistent, documented).

## Testing

- `just push` pre-push gate (migration check, lint, format, tests) passed — that is how this branch reached origin.
- New test `token_lifetime_is_30_days` locks the 30-day value.

## Scope / blast radius

Open-source AionUi runs the backend in **Local** identity mode (loopback), which skips JWT and WebSocket auth entirely — this change is inert there. It only affects deployments using the `UserSession` / `AionPro` identity modes, i.e. the remote-WebUI path in the linked issue.

Relates to iOfficeAI/AionUi#4124
