### PR TITLE
chore(acp): bump dimcode, grok and nova registry pins to probed versions

### DIFF
--- a/crates/aionui-runtime/resources/acp-registry-npx-lock.json
+++ b/crates/aionui-runtime/resources/acp-registry-npx-lock.json
@@ -19,7 +19,7 @@
     "dimcode": {
       "registry_json_id": "dimcode",
       "package": "dimcode",
-      "version": "0.3.17"
+      "version": "0.3.18"
     },
     "dirac": {
       "registry_json_id": "dirac",
@@ -34,7 +34,7 @@
     "grok": {
       "registry_json_id": "grok-build",
       "package": "@xai-official/grok",
-      "version": "1.0.7"
+      "version": "1.0.8"
     },
     "kilo": {
       "registry_json_id": "kilo",
@@ -48,7 +48,7 @@
     "nova": {
       "registry_json_id": "nova",
       "package": "@compass-ai/nova",
-      "version": "1.1.35"
+      "version": "1.1.37"
     },
     "pi": {
       "registry_json_id": "pi-acp",


### PR DESCRIPTION
## Summary

Scheduled ACP Registry version sync. Three npx pins drifted since #909, each backed by a fresh serial ACP probe of the exact pinned version. Lock-only change — three lines; no metadata, migration, or entrypoint edits, and no lock-derived test assertion embeds any of these versions.

| backend | package | old → new | initialize | session/new |
|---|---|---|---|---|
| dimcode | `dimcode` | 0.3.17 → **0.3.18** | ok (agentInfo version 0.3.18) | auth required (`-32000`, "Provider credentials are required") |
| grok | `@xai-official/grok` | 1.0.7 → **1.0.8** | ok (protocolVersion 1) | auth required (`-32000`, "no auth method id provided") |
| nova | `@compass-ai/nova` | 1.1.35 → **1.1.37** | ok (protocolVersion 1) | config required (`-32000`, "Click Nova Setup to configure your API keys", advertising `kore-terminal-auth`) |

All three meet the release-lock criterion: `initialize` succeeds and `session/new` returns a clearly classified authentication/configuration requirement. Probes ran serially with no inherited HOME or credentials. Nova skips 1.1.36 — the Registry advertises 1.1.37 directly, and that is the version probed and pinned.

Derived-assertion check: each outgoing version (`0.3.17`, `1.0.7`, `1.1.35`) was grepped directly across `crates/**/*.rs` — none appears, so this is a pure lock change. That per-version scan replaces the package-name regex used before #909, where a `--package`-form literal split across lines slipped through and broke CI.

The other 8 Registry-pinned packages (autohand, codebuddy, deepagents, dirac, glm-acp-agent, kilo, pi, sigit) match the snapshot exactly. Package names and entrypoint args are unchanged for all 11. Drifted but not upgraded: none. `mimo-code` remains the one non-Registry builtin (no `registry_json_id`), excluded from drift reconciliation.

dimcode continues to self-report `agentInfo.title` as "DimAgent" and nova as `kore-cli` `1.0.0`; both public listings are unchanged, so no metadata follows — the standing observations from #837/#848.

## Registry snapshot

- Audit pinned to release tag [`v2026.08.22-07e9ed7`](https://cdn.agentclientprotocol.com/registry/v1/v2026.08.22-07e9ed7/registry.json) of `agentclientprotocol/registry`, fetched via the versioned CDN path for reproducibility.
- No newly listed and no delisted agents versus the 39-id baseline (which includes `antigravity-acp`, listed 2026-08-21 and deferred as binary-only).

## Validation

- `just migration-check` — pass
- `just lint-fix` (`cargo fix` + `clippy --fix --workspace -D warnings`) — clean
- `just fmt` — clean
- **Local `cargo nextest` intentionally skipped, by standing policy for lock-only bumps** (established 2026-08-11). The Test check on this PR is the authority for this change: the merge decision depends on CI rather than the local run, and this host's load only manufactures timeout-shaped test failures, which nothing in the local steps above is subject to.

## Logging

No logging changes: lock-only version bumps; existing startup/session error paths already identify a failing agent by backend.
