### PR TITLE
chore(cli-version): verify codex against 0.149.0

### DIFF
--- a/crates/aionui-session/src/backend/cli_version.rs
+++ b/crates/aionui-session/src/backend/cli_version.rs
@@ -33,11 +33,11 @@ use crate::event::{LocalizedText, NoticeLevel};
 ///
 /// codex skips 0.147.0, which never completes a turn (its response stream
 /// disconnects with `httpStatusCode: null`, observed three times including a
-/// back-to-back control after three clean versions). 0.148.0 does complete
-/// turns and passes the suite, so the gate moves there and 0.147.0 stays
-/// unverified rather than becoming a floor anyone can install into.
+/// back-to-back control after three clean versions). Every release from 0.148.0
+/// on does complete turns and passes the suite, so the gate walks forward over
+/// 0.147.0 and leaves it unverified rather than a floor anyone can install into.
 pub const VERIFIED_CLAUDE_VERSION: &str = "2.1.235";
-pub const VERIFIED_CODEX_VERSION: &str = "0.148.0";
+pub const VERIFIED_CODEX_VERSION: &str = "0.149.0";
 pub const VERIFIED_AGY_VERSION: &str = "1.1.14";
 
 /// The verified release for a direct-CLI backend, keyed by the program name the
@@ -456,10 +456,10 @@ mod tests {
 
     #[test]
     fn components_compare_numerically_not_lexically() {
-        // The bug a string compare would introduce: "0.148.0" < "0.99.0"
-        // lexically, but 148 > 99.
+        // The bug a string compare would introduce: "0.149.0" < "0.99.0"
+        // lexically, but 149 > 99.
         assert_eq!(classify("0.99.0", VERIFIED_CODEX_VERSION), VersionVerdict::Older);
-        assert_eq!(classify("0.148.1", VERIFIED_CODEX_VERSION), VersionVerdict::Newer);
+        assert_eq!(classify("0.149.1", VERIFIED_CODEX_VERSION), VersionVerdict::Newer);
     }
 
     #[test]
@@ -554,9 +554,9 @@ mod tests {
     fn local_codex_output_is_classified_as_newer() {
         // Real `codex --version` output shape, one release above the verified
         // one so the newer path is what gets exercised.
-        assert_eq!(parse_version("codex-cli 0.149.0"), Some(vec![0, 149, 0]));
-        let (level, _, localized) = drift_notice("codex", "codex-cli 0.149.0", VERIFIED_CODEX_VERSION)
-            .expect("0.149.0 drifts from the verified release");
+        assert_eq!(parse_version("codex-cli 0.150.0"), Some(vec![0, 150, 0]));
+        let (level, _, localized) = drift_notice("codex", "codex-cli 0.150.0", VERIFIED_CODEX_VERSION)
+            .expect("0.150.0 drifts from the verified release");
         assert_eq!(level, NoticeLevel::Info);
         assert_eq!(localized.code, CODE_CLI_VERSION_NEWER);
 
@@ -564,10 +564,10 @@ mod tests {
         // verified release is told nothing, and this breaks if a bump lands
         // without re-verifying against that exact binary.
         assert_eq!(
-            classify("codex-cli 0.148.0", VERIFIED_CODEX_VERSION),
+            classify("codex-cli 0.149.0", VERIFIED_CODEX_VERSION),
             VersionVerdict::Verified
         );
-        assert!(drift_notice("codex", "codex-cli 0.148.0", VERIFIED_CODEX_VERSION).is_none());
+        assert!(drift_notice("codex", "codex-cli 0.149.0", VERIFIED_CODEX_VERSION).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Moves `VERIFIED_CODEX_VERSION` from 0.148.0 to 0.149.0. All three gates pass against the real binary.

| Gate | Result |
| --- | --- |
| A — contract | **PASS** — 380 → 401 schema files, `ServerNotification` 72 → 75, `ClientRequest` 141 → 150, nothing removed, no enum value dropped |
| B — live e2e | **PASS 11/11**, 264.78s |
| C — release notes | **CLEAR** — 255 notes over one release, 9 filtered as risk verbs touching none of our 33 dependency tokens, 0 REVIEW items |

## The candidate is proven from the suite's own log

A green run against the binary you meant to replace certifies the wrong version, so this is checked rather than assumed:

```
direct CLI version detected session_id=04fa4ad7 cli=codex version=codex-cli 0.149.0
direct CLI version drift    session_id=04fa4ad7 cli=codex version=codex-cli 0.149.0
```

The drift lines only appear because the candidate disagrees with the constant that had not been bumped yet. The run went through a PATH shim (`npm install @openai/codex@0.149.0` into a temp dir); the operator’s own CLIs were not modified.

## Tests

Three pinned fixtures in `cli_version` named versions the constant has now passed. Each was re-pointed above the new constant rather than loosened, and the literal verified-release assertion now names `codex-cli 0.149.0`, so a future bump that forgets to re-verify still breaks the test. `cargo test -p aionui-session --lib cli_version`: 13/13. Clippy clean, fmt clean.

## Note on 0.147.0

Still deliberately unverified — it never completes a turn (`httpStatusCode: null`, three observations). The gate walks over it rather than through it, so it never becomes an accepted floor.

Record: `~/aion/protocols/samples/codex-cli/0.149.0/`

Constants and record only — no source change.